### PR TITLE
feat(#794): historical-symbols payload + frontend callout (Batch 7 of #788)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -3212,6 +3212,13 @@ class _BannerModel(BaseModel):
     body: str
 
 
+class _HistoricalSymbolModel(BaseModel):
+    symbol: str
+    effective_from: date
+    effective_to: date | None
+    source_event: str
+
+
 class _SharesOutstandingSourceModel(BaseModel):
     accession_number: str | None
     concept: str | None
@@ -3243,6 +3250,11 @@ class OwnershipRollupResponse(BaseModel):
     concentration: _ConcentrationModel
     coverage: _CoverageModel
     banner: _BannerModel
+    # Symbol chain from instrument_symbol_history (Batch 7 of #788).
+    # Empty for instruments without a backfilled chain. Frontend
+    # renders a "Filed as X" callout when the chain has any symbol
+    # other than the current one.
+    historical_symbols: list[_HistoricalSymbolModel]
     computed_at: datetime
 
 
@@ -3326,6 +3338,15 @@ def _rollup_to_response(
             headline=rollup.banner.headline,
             body=rollup.banner.body,
         ),
+        historical_symbols=[
+            _HistoricalSymbolModel(
+                symbol=h.symbol,
+                effective_from=h.effective_from,
+                effective_to=h.effective_to,
+                source_event=h.source_event,
+            )
+            for h in rollup.historical_symbols
+        ],
         computed_at=rollup.computed_at,
     )
 

--- a/app/services/instrument_history.py
+++ b/app/services/instrument_history.py
@@ -35,9 +35,56 @@ ingest fail loud rather than silently produce two current chains.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
 
 import psycopg
 import psycopg.rows
+
+
+@dataclass(frozen=True)
+class SymbolHistoryEntry:
+    """One row from ``instrument_symbol_history`` shaped for the
+    ownership-rollup payload (#794 frontend finish, Batch 7 of #788).
+
+    The frontend renders a "Filed as X" callout when the historical
+    chain includes a symbol other than the current one. Empty
+    ``effective_to`` marks the current row."""
+
+    symbol: str
+    effective_from: date
+    effective_to: date | None
+    source_event: str
+
+
+def historical_symbols_for(conn: psycopg.Connection[tuple], instrument_id: int) -> Sequence[SymbolHistoryEntry]:
+    """Every symbol ever associated with this instrument, oldest-first.
+
+    Returns ``[]`` for an instrument with no
+    ``instrument_symbol_history`` row (pre-backfill stub). Callers
+    can treat ``len(entries) > 1`` OR ``any(e.effective_to is not None)``
+    as the trigger for the historical-symbol callout — both conditions
+    imply the chain has more than just the imported current row.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT symbol, effective_from, effective_to, source_event
+            FROM instrument_symbol_history
+            WHERE instrument_id = %s
+            ORDER BY effective_from ASC
+            """,
+            (instrument_id,),
+        )
+        return [
+            SymbolHistoryEntry(
+                symbol=str(row[0]),
+                effective_from=row[1],
+                effective_to=row[2],
+                source_event=str(row[3]),
+            )
+            for row in cur.fetchall()
+        ]
 
 
 def historical_ciks_for(conn: psycopg.Connection[tuple], instrument_id: int) -> Sequence[str]:

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -42,6 +42,10 @@ import psycopg
 import psycopg.rows
 
 from app.services.holder_name_resolver import resolve_holder_to_filer
+from app.services.instrument_history import (
+    SymbolHistoryEntry,
+    historical_symbols_for,
+)
 
 # ---------------------------------------------------------------------------
 # Public dataclasses (mirrored to Pydantic models in the API layer)
@@ -171,14 +175,34 @@ class OwnershipRollup:
     concentration: ConcentrationInfo
     coverage: CoverageReport
     banner: BannerCopy
+    # Historical symbols from ``instrument_symbol_history`` (#794
+    # frontend finish, Batch 7 of #788). Empty for instruments
+    # without a backfilled chain. Frontend renders a "Filed as X"
+    # callout when the chain includes any symbol other than the
+    # current one — useful for BBBY → BBBYQ ticker-change cases
+    # where filings under the prior symbol still belong to this
+    # instrument.
+    historical_symbols: tuple[SymbolHistoryEntry, ...]
     computed_at: datetime
 
     @classmethod
-    def no_data(cls, symbol: str, instrument_id: int) -> OwnershipRollup:
+    def no_data(
+        cls,
+        symbol: str,
+        instrument_id: int,
+        historical_symbols: tuple[SymbolHistoryEntry, ...] = (),
+    ) -> OwnershipRollup:
         """Empty payload for the ``no_data`` state (no XBRL outstanding
         on file). 200 OK with the red banner, not 503 — that way the
         frontend renders a uniform empty state and a sync-trigger
-        CTA rather than crashing on a non-2xx response."""
+        CTA rather than crashing on a non-2xx response.
+
+        ``historical_symbols`` is threaded through so the BBBY-style
+        callout still renders on instruments missing
+        ``shares_outstanding`` — that case is exactly when the
+        operator wants the "filings before symbol change still belong
+        here" hint. Codex pre-push review (Batch 7 of #788) caught
+        the prior version dropping the chain on this path."""
         residual = ResidualBlock(
             shares=Decimal(0),
             pct_outstanding=Decimal(0),
@@ -204,6 +228,7 @@ class OwnershipRollup:
             ),
             coverage=coverage,
             banner=banner,
+            historical_symbols=historical_symbols,
             computed_at=datetime.now(tz=UTC),
         )
 
@@ -891,8 +916,13 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     anti-pattern.
     """
     outstanding, outstanding_as_of, outstanding_source = _read_shares_outstanding(conn, instrument_id)
+    historical_symbols = tuple(historical_symbols_for(conn, instrument_id))
     if outstanding is None or outstanding <= 0:
-        return OwnershipRollup.no_data(symbol=symbol, instrument_id=instrument_id)
+        return OwnershipRollup.no_data(
+            symbol=symbol,
+            instrument_id=instrument_id,
+            historical_symbols=historical_symbols,
+        )
     treasury, treasury_as_of = _read_treasury(conn, instrument_id)
     sql_candidates = _collect_canonical_holders_sql(conn, instrument_id)
     matched, unmatched_def14a = _enrich_and_union_def14a(conn, instrument_id, sql_candidates)
@@ -916,6 +946,7 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
         concentration=concentration,
         coverage=coverage,
         banner=banner,
+        historical_symbols=historical_symbols,
         computed_at=datetime.now(tz=UTC),
     )
 

--- a/frontend/src/api/ownership.ts
+++ b/frontend/src/api/ownership.ts
@@ -135,6 +135,22 @@ export interface OwnershipBanner {
   readonly body: string;
 }
 
+/** One row of ``instrument_symbol_history``, oldest-first. Frontend
+ *  renders a "Filed as X" callout when the chain includes any symbol
+ *  other than the current one (Batch 7 of #788). */
+export interface OwnershipHistoricalSymbol {
+  readonly symbol: string;
+  /** ISO ``YYYY-MM-DD`` — when this symbol started representing the
+   *  instrument. */
+  readonly effective_from: string;
+  /** ISO ``YYYY-MM-DD`` — when this symbol stopped representing the
+   *  instrument. ``null`` marks the current symbol row. */
+  readonly effective_to: string | null;
+  /** ``imported`` | ``rebrand`` | ``delisting`` | ``relisting`` |
+   *  ``manual`` — see migration 103. */
+  readonly source_event: string;
+}
+
 export interface OwnershipSharesOutstandingSource {
   readonly accession_number: string | null;
   readonly concept: string | null;
@@ -160,6 +176,7 @@ export interface OwnershipRollupResponse {
   readonly concentration: OwnershipConcentration;
   readonly coverage: OwnershipCoverage;
   readonly banner: OwnershipBanner;
+  readonly historical_symbols: readonly OwnershipHistoricalSymbol[];
   readonly computed_at: string;
 }
 

--- a/frontend/src/components/instrument/HistoricalSymbolCallout.test.tsx
+++ b/frontend/src/components/instrument/HistoricalSymbolCallout.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for HistoricalSymbolCallout (#794 frontend finish, Batch
+ * 7 of #788).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HistoricalSymbolCallout } from "./HistoricalSymbolCallout";
+
+describe("HistoricalSymbolCallout", () => {
+  it("renders nothing when there are no historical symbols", () => {
+    const { container } = render(
+      <HistoricalSymbolCallout currentSymbol="AAPL" historicalSymbols={[]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the only symbol matches the current one", () => {
+    const { container } = render(
+      <HistoricalSymbolCallout
+        currentSymbol="AAPL"
+        historicalSymbols={[
+          {
+            symbol: "AAPL",
+            effective_from: "2010-01-01",
+            effective_to: null,
+            source_event: "imported",
+          },
+        ]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the callout when a prior symbol is in the chain", () => {
+    render(
+      <HistoricalSymbolCallout
+        currentSymbol="BBBYQ"
+        historicalSymbols={[
+          {
+            symbol: "BBBY",
+            effective_from: "2000-06-01",
+            effective_to: "2023-04-01",
+            source_event: "delisting",
+          },
+          {
+            symbol: "BBBYQ",
+            effective_from: "2023-04-01",
+            effective_to: null,
+            source_event: "relisting",
+          },
+        ]}
+      />,
+    );
+    // The component uses ``data-test=`` (the repo's convention) +
+    // ``role="note"``; query by role since testing-library's
+    // ``getByTestId`` looks for ``data-testid`` and the repo
+    // doesn't standardise on that name.
+    const callout = screen.getByRole("note");
+    expect(callout).toBeInTheDocument();
+    expect(callout.textContent).toContain("BBBY");
+    expect(callout.textContent).toContain("BBBYQ");
+    expect(callout.textContent).toContain("2023-04-01");
+  });
+
+  it("treats the current symbol comparison case-insensitively", () => {
+    const { container } = render(
+      <HistoricalSymbolCallout
+        currentSymbol="aapl"
+        historicalSymbols={[
+          {
+            symbol: "AAPL",
+            effective_from: "2010-01-01",
+            effective_to: null,
+            source_event: "imported",
+          },
+        ]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/instrument/HistoricalSymbolCallout.tsx
+++ b/frontend/src/components/instrument/HistoricalSymbolCallout.tsx
@@ -1,0 +1,63 @@
+/**
+ * Historical-symbol callout (#794 frontend finish, Batch 7 of #788).
+ *
+ * The user's 2026-05-03 question:
+ *
+ *   "I see things like in BBBY, we don't have all the financial
+ *   information available, because they changed tickers, but assume
+ *   the cik was still the same, filings should still be represented
+ *   by the etoro id provided?"
+ *
+ * Renders a small inline callout when the instrument's symbol chain
+ * (from ``instrument_symbol_history``) includes any symbol other
+ * than the current one. Tells the operator "filings before YYYY-MM-DD
+ * appear on EDGAR under SYMBOL_X" so they can verify the historical
+ * coverage path on the source side.
+ *
+ * Hidden when the chain is just the current ``imported`` row (no
+ * historical context to surface).
+ */
+
+import type { OwnershipHistoricalSymbol } from "@/api/ownership";
+
+export interface HistoricalSymbolCalloutProps {
+  readonly currentSymbol: string;
+  readonly historicalSymbols: readonly OwnershipHistoricalSymbol[];
+}
+
+export function HistoricalSymbolCallout({
+  currentSymbol,
+  historicalSymbols,
+}: HistoricalSymbolCalloutProps): JSX.Element | null {
+  const priorSymbols = historicalSymbols.filter(
+    (h) => h.symbol.toUpperCase() !== currentSymbol.toUpperCase(),
+  );
+  if (priorSymbols.length === 0) return null;
+
+  // Render the most-recent prior symbol prominently (the typical
+  // BBBY → BBBYQ case has exactly one prior). When >1 prior, list
+  // all in chronological order so the operator can trace the
+  // chain.
+  return (
+    <p
+      className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900 dark:border-blue-900/60 dark:bg-blue-900/20 dark:text-blue-200"
+      data-test="historical-symbol-callout"
+      role="note"
+    >
+      <span className="font-medium">Symbol history:</span> filings before
+      {" "}
+      <span className="font-mono">
+        {priorSymbols.map((h, i) => (
+          <span key={h.symbol + h.effective_from}>
+            {i > 0 && ", "}
+            {h.symbol}
+            {h.effective_to !== null && ` (until ${h.effective_to})`}
+          </span>
+        ))}
+      </span>{" "}
+      are aggregated under the current{" "}
+      <span className="font-mono">{currentSymbol}</span> instrument via the
+      stable SEC CIK.
+    </p>
+  );
+}

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -63,6 +63,7 @@ function _baseRollup(
       headline: "Coverage estimate not available",
       body: "Treat as best-effort.",
     },
+    historical_symbols: [],
     computed_at: "2026-05-03T00:00:00Z",
     ...overrides,
   };

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -43,6 +43,7 @@ import type {
   OwnershipSliceCategory,
 } from "@/api/ownership";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { HistoricalSymbolCallout } from "@/components/instrument/HistoricalSymbolCallout";
 import {
   OwnershipLegend,
   OwnershipSunburst,
@@ -237,6 +238,10 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
     return (
       <div className="flex flex-col gap-3">
         <Banner banner={rollup.banner} />
+        <HistoricalSymbolCallout
+          currentSymbol={rollup.symbol}
+          historicalSymbols={rollup.historical_symbols}
+        />
         <EmptyState
           title="No ownership data"
           description="XBRL shares-outstanding not yet on file for this instrument. Trigger a fundamentals sync, or wait for the next scheduled run."
@@ -249,6 +254,10 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
     return (
       <div className="flex flex-col gap-3">
         <Banner banner={rollup.banner} />
+        <HistoricalSymbolCallout
+          currentSymbol={rollup.symbol}
+          historicalSymbols={rollup.historical_symbols}
+        />
         <EmptyState
           title="No ownership data"
           description="Sunburst rings could not be derived — shares outstanding resolved to zero or the input snapshot is malformed."
@@ -260,6 +269,10 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
   return (
     <div className="flex flex-col gap-3">
       <Banner banner={rollup.banner} />
+      <HistoricalSymbolCallout
+        currentSymbol={rollup.symbol}
+        historicalSymbols={rollup.historical_symbols}
+      />
       <ConcentrationChip rollup={rollup} />
       {rollup.residual.oversubscribed && <OversubscribedWarning />}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start">

--- a/tests/test_ownership_rollup.py
+++ b/tests/test_ownership_rollup.py
@@ -942,6 +942,101 @@ class TestProvenance:
         assert rollup.shares_outstanding_source.edgar_url is None
 
 
+class TestHistoricalSymbols:
+    """Symbol-history payload threading (#794 frontend finish, Batch 7
+    of #788)."""
+
+    def test_rollup_includes_historical_symbols_from_history_table(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794_001, symbol="BBBYQ")
+        _seed_outstanding(conn, instrument_id=794_001, shares="100000000")
+        # Seed a BBBY → BBBYQ chain manually (the real ticker-change
+        # ingester is a future epic; here we exercise the read path).
+        conn.execute(
+            """
+            INSERT INTO instrument_symbol_history (
+                instrument_id, symbol, effective_from, effective_to,
+                source_event
+            ) VALUES (%s, %s, %s, %s, %s)
+            """,
+            (794_001, "BBBY", date(2000, 6, 1), date(2023, 4, 1), "delisting"),
+        )
+        conn.execute(
+            """
+            INSERT INTO instrument_symbol_history (
+                instrument_id, symbol, effective_from, effective_to,
+                source_event
+            ) VALUES (%s, %s, %s, %s, %s)
+            """,
+            (794_001, "BBBYQ", date(2023, 4, 1), None, "relisting"),
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="BBBYQ", instrument_id=794_001)
+        symbols = [h.symbol for h in rollup.historical_symbols]
+        assert symbols == ["BBBY", "BBBYQ"]
+        # Effective ranges round-trip cleanly.
+        bbby_entry = next(h for h in rollup.historical_symbols if h.symbol == "BBBY")
+        assert bbby_entry.effective_to == date(2023, 4, 1)
+        assert bbby_entry.source_event == "delisting"
+
+    def test_rollup_historical_symbols_empty_when_no_history(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794_002, symbol="NOHIST")
+        _seed_outstanding(conn, instrument_id=794_002, shares="100000000")
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="NOHIST", instrument_id=794_002)
+        assert rollup.historical_symbols == ()
+
+    def test_historical_symbols_present_on_no_data_path(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Codex pre-push review (Batch 7 of #788) caught this: an
+        instrument missing ``shares_outstanding`` returns
+        ``OwnershipRollup.no_data(...)`` — but it must still carry
+        ``historical_symbols`` because the BBBY-style ticker-change
+        case is exactly when the operator wants the callout."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794_003, symbol="NODATA")
+        # Skip _seed_outstanding intentionally — exercise the no_data
+        # path.
+        conn.execute(
+            """
+            INSERT INTO instrument_symbol_history (
+                instrument_id, symbol, effective_from, effective_to,
+                source_event
+            ) VALUES (%s, %s, %s, %s, %s)
+            """,
+            (794_003, "OLDSYM", date(2010, 1, 1), date(2024, 1, 1), "rebrand"),
+        )
+        conn.execute(
+            """
+            INSERT INTO instrument_symbol_history (
+                instrument_id, symbol, effective_from, effective_to,
+                source_event
+            ) VALUES (%s, %s, %s, %s, %s)
+            """,
+            (794_003, "NODATA", date(2024, 1, 1), None, "imported"),
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="NODATA", instrument_id=794_003)
+        # no_data state — outstanding missing.
+        assert rollup.banner.state == "no_data"
+        assert rollup.shares_outstanding is None
+        # Historical symbols still surface so the callout renders.
+        symbols = [h.symbol for h in rollup.historical_symbols]
+        assert symbols == ["OLDSYM", "NODATA"]
+
+
 class TestEmptyStates:
     def test_empty_cohort_residual_equals_outstanding(
         self,


### PR DESCRIPTION
## Summary

Surfaces the BBBY → BBBYQ ticker-change hint the user asked for on 2026-05-03. Tight scope: thin payload extension + UI callout. Full ticker-change ingester deferred to a future epic.

- \`app/services/instrument_history.py\`: new \`historical_symbols_for\` helper.
- \`app/services/ownership_rollup.py\`: thread \`historical_symbols\` through both happy-path and \`no_data\` branches (Codex pre-push caught the prior version dropping it on no_data).
- \`frontend/src/components/instrument/HistoricalSymbolCallout.tsx\`: small inline callout. Rendered on every panel branch (happy, both empty paths).

## Test plan

- [x] \`tests/test_ownership_rollup.py::TestHistoricalSymbols\` — 3 cases (BBBY chain shape, empty state, no_data path threading).
- [x] \`HistoricalSymbolCallout.test.tsx\` — 4 cases (no history, only-current, BBBY chain renders, case-insensitive).
- [x] All 4 local gates + frontend typecheck pass.

## Out of scope (deferred to future epics)

- Real ticker-change ingester walking SEC submissions.json former_tickers / detecting exchange listing changes.
- \`instrument_id_for_cik_at_date\` historical-by-date resolver.
- #795 N-PORT mutual fund ingestion.
- #796 FINRA short interest + Reg SHO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)