### PR TITLE
feat: filing_raw_documents store + helper for ownership-side re-wash

### DIFF
--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -46,6 +46,7 @@ amended).
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime
@@ -61,9 +62,12 @@ DocumentKind = Literal[
     "form4_xml",
     "form3_xml",
     "def14a_body",
-    "submissions_json",
-    "companyfacts_json",
 ]
+# submissions.json / companyfacts.json are keyed by CIK, not by SEC
+# accession number — they belong in their own per-CIK store, not in
+# this per-filing table. Claude PR 808 review (BLOCKING) caught the
+# prior overload that smuggled CIKs into the accession_number column.
+# Future PR adds a sibling ``cik_raw_documents`` table for those.
 
 
 @dataclass(frozen=True)
@@ -179,7 +183,12 @@ def iter_raw(
         WHERE {where_sql}
         ORDER BY fetched_at DESC, accession_number
     """  # noqa: S608 — where_sql built from hardcoded enum + placeholders
-    with conn.cursor(row_factory=psycopg.rows.dict_row, name="iter_raw") as cur:
+    # Server-side cursor names are session-scoped in psycopg v3, so
+    # a hardcoded name would collide between concurrent ``iter_raw``
+    # calls on the same connection. Generate a unique name per call.
+    # Claude PR 808 review (BLOCKING) caught the prior literal name.
+    cursor_name = f"iter_raw_{uuid.uuid4().hex}"
+    with conn.cursor(row_factory=psycopg.rows.dict_row, name=cursor_name) as cur:
         cur.itersize = batch_size
         cur.execute(sql, params)  # type: ignore[arg-type]  # f-string composed from closed enum
         for row in cur:

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -1,0 +1,229 @@
+"""Raw-filings document store.
+
+Single-source-of-truth helper for the ``filing_raw_documents`` table
+(migration 107). Every ownership-side ingester (13F, 13D/G, Form 4,
+Form 3, DEF 14A) writes the source XML / HTML body here at fetch
+time so re-wash workflows can run against stored bodies instead of
+re-fetching from SEC.
+
+Operator audit 2026-05-03 found the prior pattern dropped raw bodies
+after parsing — meaning a parser bug discovered later forced a full
+re-fetch from SEC at 10 req/sec. This module is the foundation for
+the audit-and-rewash workflow.
+
+The helper is deliberately small (UPSERT + read by accession +
+size-aggregate) so per-ingester wiring is a 2-line change at each
+fetch site:
+
+    from app.services.raw_filings import store_raw
+
+    body = provider.fetch_xml(accession)
+    store_raw(
+        conn,
+        accession_number=accession,
+        document_kind="form4_xml",
+        payload=body,
+        parser_version="form4-v1",
+        source_url=primary_doc_url,
+    )
+    parsed = parse_form4(body)
+    # ... rest of ingester writes parsed rows ...
+
+Re-wash flow (separate module, future PR):
+
+    for row in iter_raw(conn, document_kind="form4_xml"):
+        if row.parser_version == CURRENT_PARSER_VERSION:
+            continue  # already on latest parser
+        re_parse_and_upsert(conn, row.accession_number, row.payload)
+
+The contract is: ``store_raw`` is idempotent; calling it twice for
+the same ``(accession, document_kind)`` overwrites the body and
+refreshes ``fetched_at`` + ``parser_version``. The new body is
+authoritative — re-fetches from SEC are exactly the case where
+overwriting is the right behaviour (the document may have been
+amended).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+DocumentKind = Literal[
+    "primary_doc",
+    "infotable_13f",
+    "primary_doc_13dg",
+    "form4_xml",
+    "form3_xml",
+    "def14a_body",
+    "submissions_json",
+    "companyfacts_json",
+]
+
+
+@dataclass(frozen=True)
+class RawFilingDocument:
+    accession_number: str
+    document_kind: DocumentKind
+    payload: str
+    byte_count: int
+    parser_version: str | None
+    fetched_at: datetime
+    source_url: str | None
+
+
+def store_raw(
+    conn: psycopg.Connection[Any],
+    *,
+    accession_number: str,
+    document_kind: DocumentKind,
+    payload: str,
+    parser_version: str | None = None,
+    source_url: str | None = None,
+) -> None:
+    """Idempotent UPSERT into ``filing_raw_documents``.
+
+    Re-calling for the same ``(accession_number, document_kind)``
+    overwrites the body and refreshes ``fetched_at`` +
+    ``parser_version`` + ``source_url``. The new body is treated as
+    authoritative — re-fetches from SEC are exactly when
+    overwriting is correct (the document may have been amended).
+    """
+    if not accession_number:
+        raise ValueError("accession_number is required")
+    if not payload:
+        raise ValueError("payload is required (empty payload would defeat re-wash)")
+    conn.execute(
+        """
+        INSERT INTO filing_raw_documents (
+            accession_number, document_kind, payload, parser_version,
+            source_url, fetched_at
+        ) VALUES (%s, %s, %s, %s, %s, NOW())
+        ON CONFLICT (accession_number, document_kind) DO UPDATE SET
+            payload = EXCLUDED.payload,
+            parser_version = EXCLUDED.parser_version,
+            source_url = EXCLUDED.source_url,
+            fetched_at = NOW()
+        """,
+        (accession_number, document_kind, payload, parser_version, source_url),
+    )
+
+
+def read_raw(
+    conn: psycopg.Connection[Any],
+    *,
+    accession_number: str,
+    document_kind: DocumentKind,
+) -> RawFilingDocument | None:
+    """Fetch the raw body for one (accession, kind) pair, or
+    ``None`` when the row is missing. Read-only; safe to call
+    inside a snapshot_read."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT accession_number, document_kind, payload, byte_count,
+                   parser_version, fetched_at, source_url
+            FROM filing_raw_documents
+            WHERE accession_number = %s AND document_kind = %s
+            """,
+            (accession_number, document_kind),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return RawFilingDocument(
+        accession_number=str(row["accession_number"]),  # type: ignore[arg-type]
+        document_kind=row["document_kind"],  # type: ignore[arg-type]
+        payload=str(row["payload"]),  # type: ignore[arg-type]
+        byte_count=int(row["byte_count"]),  # type: ignore[arg-type]
+        parser_version=(str(row["parser_version"]) if row.get("parser_version") is not None else None),
+        fetched_at=row["fetched_at"],  # type: ignore[arg-type]
+        source_url=(str(row["source_url"]) if row.get("source_url") is not None else None),
+    )
+
+
+def iter_raw(
+    conn: psycopg.Connection[Any],
+    *,
+    document_kind: DocumentKind,
+    parser_version_not_in: tuple[str, ...] = (),
+    batch_size: int = 100,
+) -> Iterator[RawFilingDocument]:
+    """Yield raw documents of a kind, optionally filtered to those
+    NOT already on a current parser version. Used by re-wash
+    workflows to walk only the rows that need re-parsing.
+
+    Server-side cursor avoids loading the full set into Python — the
+    body column compresses but uncompressed sizes can be hundreds of
+    KB per row.
+    """
+    where = ["document_kind = %s"]
+    params: list[Any] = [document_kind]
+    if parser_version_not_in:
+        # Cover both NULL parser_version and any other value not in
+        # the list. Using NOT IN doesn't catch NULLs, so explicit OR.
+        placeholders = ",".join(["%s"] * len(parser_version_not_in))
+        where.append(f"(parser_version IS NULL OR parser_version NOT IN ({placeholders}))")
+        params.extend(parser_version_not_in)
+    where_sql = " AND ".join(where)
+
+    sql = f"""
+        SELECT accession_number, document_kind, payload, byte_count,
+               parser_version, fetched_at, source_url
+        FROM filing_raw_documents
+        WHERE {where_sql}
+        ORDER BY fetched_at DESC, accession_number
+    """  # noqa: S608 — where_sql built from hardcoded enum + placeholders
+    with conn.cursor(row_factory=psycopg.rows.dict_row, name="iter_raw") as cur:
+        cur.itersize = batch_size
+        cur.execute(sql, params)  # type: ignore[arg-type]  # f-string composed from closed enum
+        for row in cur:
+            yield RawFilingDocument(
+                accession_number=str(row["accession_number"]),  # type: ignore[arg-type]
+                document_kind=row["document_kind"],  # type: ignore[arg-type]
+                payload=str(row["payload"]),  # type: ignore[arg-type]
+                byte_count=int(row["byte_count"]),  # type: ignore[arg-type]
+                parser_version=(str(row["parser_version"]) if row.get("parser_version") is not None else None),
+                fetched_at=row["fetched_at"],  # type: ignore[arg-type]
+                source_url=(str(row["source_url"]) if row.get("source_url") is not None else None),
+            )
+
+
+@dataclass(frozen=True)
+class StorageSummary:
+    document_kind: DocumentKind
+    row_count: int
+    total_bytes: int
+    avg_bytes: int
+
+
+def storage_summary(conn: psycopg.Connection[Any]) -> list[StorageSummary]:
+    """Per-kind row + byte summary. Drives the operator-visible
+    storage chip on the ingest-health page."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT document_kind,
+                   COUNT(*) AS row_count,
+                   COALESCE(SUM(byte_count), 0) AS total_bytes,
+                   COALESCE(AVG(byte_count)::int, 0) AS avg_bytes
+            FROM filing_raw_documents
+            GROUP BY document_kind
+            ORDER BY total_bytes DESC
+            """,
+        )
+        rows = cur.fetchall()
+    return [
+        StorageSummary(
+            document_kind=row["document_kind"],  # type: ignore[arg-type]
+            row_count=int(row["row_count"]),  # type: ignore[arg-type]
+            total_bytes=int(row["total_bytes"]),  # type: ignore[arg-type]
+            avg_bytes=int(row["avg_bytes"]),  # type: ignore[arg-type]
+        )
+        for row in rows
+    ]

--- a/sql/107_filing_raw_documents.sql
+++ b/sql/107_filing_raw_documents.sql
@@ -56,10 +56,14 @@ CREATE TABLE IF NOT EXISTS filing_raw_documents (
             'primary_doc_13dg',     -- 13D/G primary_doc.xml
             'form4_xml',            -- Form 4 ownership XML
             'form3_xml',            -- Form 3 initial-holdings XML
-            'def14a_body',          -- DEF 14A proxy statement body (HTML / text)
-            'submissions_json',     -- SEC submissions.json (per CIK)
-            'companyfacts_json'     -- SEC companyfacts.json (per CIK)
+            'def14a_body'           -- DEF 14A proxy statement body (HTML / text)
         )),
+    -- Note: SEC submissions.json + companyfacts.json are keyed by
+    -- CIK, not by accession number. They belong in their own
+    -- per-CIK store, not this per-filing table. Claude PR 808 review
+    -- (BLOCKING) caught the prior overload that smuggled CIKs into
+    -- this column. A future PR adds a sibling ``cik_raw_documents``
+    -- table.
     payload            TEXT NOT NULL,
     byte_count         INTEGER GENERATED ALWAYS AS (octet_length(payload)) STORED,
     parser_version     TEXT,

--- a/sql/107_filing_raw_documents.sql
+++ b/sql/107_filing_raw_documents.sql
@@ -1,0 +1,106 @@
+-- 107_filing_raw_documents.sql
+--
+-- Single-source-of-truth store for the raw XML / HTML body of every
+-- ownership filing the app ingests (operator audit 2026-05-03).
+--
+-- Pre-migration state: ownership-side filings (13F infotable, 13D/G
+-- primary_doc, Form 4 / Form 3 XML, DEF 14A body) were fetched,
+-- parsed into typed tables (``institutional_holdings``,
+-- ``blockholder_filings``, ``insider_transactions``,
+-- ``insider_initial_holdings``, ``def14a_beneficial_holdings``),
+-- and the original document was dropped. Re-washing after a parser
+-- bug discovery required re-fetching from SEC — slow, rate-limited,
+-- and risky if the original document has been amended in the
+-- interim.
+--
+-- ``filing_events.raw_payload_json`` (3.8M rows) was misleadingly
+-- named — it stores only filing METADATA (URL, date, type), not the
+-- document body. This migration closes that gap by adding the
+-- canonical body store.
+--
+-- Schema decisions:
+--
+--   * Single table keyed on ``(accession_number, document_kind)``
+--     rather than per-typed-table ``raw_payload`` columns. The 13F
+--     case is decisive: one infotable.xml produces dozens to
+--     thousands of ``institutional_holdings`` rows; storing the XML
+--     on each row would 100x the storage. One row per accession
+--     per document_kind keeps the body deduplicated.
+--   * ``payload TEXT`` not ``BYTEA``. SEC documents are XML / HTML,
+--     inherently text. Postgres TOAST compresses TEXT > 2KB
+--     automatically (~5x compression ratio on XML), so storage
+--     overhead vs BYTEA is negligible. SQL queries (grep for a
+--     CIK across raw bodies) work directly on TEXT.
+--   * ``document_kind`` is a CHECK-constrained set, NOT a free-text
+--     column. The constrained set ensures every ingester registers
+--     its kind explicitly; a typo gets caught at write time rather
+--     than producing a quietly mis-classified row.
+--   * ``parser_version`` records which parser the typed-table rows
+--     were derived from. Re-wash decisions can compare against the
+--     current parser version and skip rows that are already on the
+--     latest parser.
+--   * ``byte_count`` is a generated column on ``octet_length(payload)``
+--     — useful for retention sweeps and operator-visible storage
+--     accounting without re-computing on every read.
+--
+-- The table is the FOUNDATION. Per-ingester wiring lands in follow-
+-- on PRs; this PR ships the table + helper + tests so the contract
+-- is locked in before the rewrites.
+
+CREATE TABLE IF NOT EXISTS filing_raw_documents (
+    accession_number   TEXT NOT NULL,
+    document_kind      TEXT NOT NULL
+        CHECK (document_kind IN (
+            'primary_doc',          -- generic SEC primary_doc.xml (any source)
+            'infotable_13f',        -- 13F-HR infotable.xml (per accession)
+            'primary_doc_13dg',     -- 13D/G primary_doc.xml
+            'form4_xml',            -- Form 4 ownership XML
+            'form3_xml',            -- Form 3 initial-holdings XML
+            'def14a_body',          -- DEF 14A proxy statement body (HTML / text)
+            'submissions_json',     -- SEC submissions.json (per CIK)
+            'companyfacts_json'     -- SEC companyfacts.json (per CIK)
+        )),
+    payload            TEXT NOT NULL,
+    byte_count         INTEGER GENERATED ALWAYS AS (octet_length(payload)) STORED,
+    parser_version     TEXT,
+    fetched_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Free-form provenance hints. Useful when the same accession
+    -- appears under multiple document_kinds (e.g. a 13F has both
+    -- ``primary_doc`` and ``infotable_13f``) and the operator wants
+    -- to know which CIK owned which body.
+    source_url         TEXT,
+    PRIMARY KEY (accession_number, document_kind)
+);
+
+-- Hot path for re-wash: walk every doc of a given kind in
+-- fetched_at order. Partial index because most reads target one
+-- kind at a time.
+CREATE INDEX IF NOT EXISTS idx_filing_raw_documents_kind_fetched
+    ON filing_raw_documents (document_kind, fetched_at DESC);
+
+-- Hot path for ingester upserts and per-accession joins back to
+-- the typed parse tables.
+CREATE INDEX IF NOT EXISTS idx_filing_raw_documents_accession
+    ON filing_raw_documents (accession_number);
+
+-- Storage accounting: the operator-facing ingest-health page
+-- aggregates ``byte_count`` per kind so a sweep can flag retention
+-- bloat early. No index — the sweep is rare and a SeqScan is fine.
+
+COMMENT ON TABLE filing_raw_documents IS
+    'Canonical store for raw XML / HTML / JSON document bodies of '
+    'every SEC filing ingested. One row per (accession_number, '
+    'document_kind). Lets re-wash run against stored bodies instead '
+    'of re-fetching from SEC. Closes the gap that ``filing_events.'
+    'raw_payload_json`` left — that column stored only metadata '
+    '(URL / date), not the document body.';
+
+COMMENT ON COLUMN filing_raw_documents.parser_version IS
+    'Parser version that wrote the typed-table rows derived from '
+    'this body. Used by re-wash workflows to skip rows already on '
+    'the latest parser. NULL is acceptable for retroactive seeds.';
+
+COMMENT ON COLUMN filing_raw_documents.byte_count IS
+    'Generated from octet_length(payload). Useful for the retention '
+    'sweep and the operator-visible storage chip on the ingest-'
+    'health page. STORED so the materialised value is indexed-friendly.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -146,6 +146,11 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # teardown deterministic when a test populates a queue row
     # without touching the instruments row.
     "ingest_backfill_queue",
+    # Raw filing-document store (issue follow-up after PR #804 audit).
+    # No FK to other planner tables — accession_number is the natural
+    # key and the typed-table rows JOIN back via that column rather
+    # than a row-id FK. Listed for deterministic per-test cleanup.
+    "filing_raw_documents",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)
     "operators",  # #315 Phase 3 alerts (cursor column)

--- a/tests/test_raw_filings.py
+++ b/tests/test_raw_filings.py
@@ -212,6 +212,37 @@ def test_storage_summary_groups_by_kind(
     assert by_kind["def14a_body"].total_bytes == 5000
 
 
+def test_iter_raw_concurrent_calls_use_unique_cursor_names(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Server-side cursor names are session-scoped in psycopg v3.
+    Two concurrent ``iter_raw`` calls on the same connection must
+    not collide. Claude PR 808 review (BLOCKING) caught the prior
+    literal cursor name. Pin the dynamic-name behaviour by opening
+    two iterators side-by-side and walking both."""
+    conn = ebull_test_conn
+    for i in range(3):
+        raw_filings.store_raw(
+            conn,
+            accession_number=f"0000000999-26-{i:06d}",
+            document_kind="form4_xml",
+            payload=f"<doc-{i}/>",
+        )
+    conn.commit()
+    iter_a = raw_filings.iter_raw(conn, document_kind="form4_xml", batch_size=1)
+    iter_b = raw_filings.iter_raw(conn, document_kind="form4_xml", batch_size=1)
+    # Side-by-side advance — would have raised
+    # ``ProgrammingError: cursor "iter_raw" already exists`` under
+    # the prior static-name implementation.
+    a1 = next(iter_a)
+    b1 = next(iter_b)
+    assert a1.payload.startswith("<doc-")
+    assert b1.payload.startswith("<doc-")
+    # Drain both so the server-side cursors close cleanly.
+    list(iter_a)
+    list(iter_b)
+
+
 def test_byte_count_generated_from_octet_length(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
 ) -> None:

--- a/tests/test_raw_filings.py
+++ b/tests/test_raw_filings.py
@@ -1,0 +1,235 @@
+"""Tests for the raw-filings document store (migration 107).
+
+Pins the contract: idempotent UPSERT, body fidelity round-trip,
+iter filter on parser_version, byte-count generated column, kind
+CHECK constraint.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services import raw_filings
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+_SAMPLE_FORM4 = (
+    "<?xml version='1.0' encoding='UTF-8'?>\n"
+    "<ownershipDocument>"
+    "<periodOfReport>2026-04-15</periodOfReport>"
+    "<reportingOwner><reportingOwnerId>"
+    "<rptOwnerCik>0001767470</rptOwnerCik>"
+    "<rptOwnerName>Cohen Ryan</rptOwnerName>"
+    "</reportingOwnerId></reportingOwner>"
+    "</ownershipDocument>"
+)
+
+
+def test_store_and_read_roundtrips_payload(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    raw_filings.store_raw(
+        conn,
+        accession_number="0001767470-26-000003",
+        document_kind="form4_xml",
+        payload=_SAMPLE_FORM4,
+        parser_version="form4-v1",
+        source_url="https://www.sec.gov/Archives/edgar/data/1767470/000176747026000003/",
+    )
+    conn.commit()
+    doc = raw_filings.read_raw(
+        conn,
+        accession_number="0001767470-26-000003",
+        document_kind="form4_xml",
+    )
+    assert doc is not None
+    assert doc.payload == _SAMPLE_FORM4
+    assert doc.byte_count == len(_SAMPLE_FORM4.encode("utf-8"))
+    assert doc.parser_version == "form4-v1"
+    assert doc.source_url is not None and doc.source_url.startswith("https://")
+
+
+def test_store_is_idempotent_and_overwrites(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Re-fetching an amended document must overwrite the prior body
+    + refresh fetched_at. Re-runs of the ingester on the same
+    accession should not produce duplicate rows."""
+    conn = ebull_test_conn
+    accession = "0001767470-26-000004"
+    raw_filings.store_raw(
+        conn,
+        accession_number=accession,
+        document_kind="form4_xml",
+        payload="<original/>",
+        parser_version="form4-v1",
+    )
+    conn.commit()
+    raw_filings.store_raw(
+        conn,
+        accession_number=accession,
+        document_kind="form4_xml",
+        payload="<amended>now with more data</amended>",
+        parser_version="form4-v2",
+    )
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*), payload, parser_version FROM filing_raw_documents "
+            "WHERE accession_number = %s GROUP BY payload, parser_version",
+            (accession,),
+        )
+        rows = cur.fetchall()
+    # Exactly one row — UPSERT replaced.
+    assert len(rows) == 1
+    assert rows[0][0] == 1
+    assert rows[0][1] == "<amended>now with more data</amended>"
+    assert rows[0][2] == "form4-v2"
+
+
+def test_read_missing_returns_none(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    doc = raw_filings.read_raw(
+        conn,
+        accession_number="does-not-exist-26-000000",
+        document_kind="form4_xml",
+    )
+    assert doc is None
+
+
+def test_unknown_document_kind_rejected_at_check_constraint(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """The CHECK constraint on ``document_kind`` blocks typos at
+    write time. Codex pre-push prevention pattern: a parser typo
+    cannot smuggle a quietly-mis-classified row into the store."""
+    conn = ebull_test_conn
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with conn.transaction():
+            conn.execute(
+                """
+                INSERT INTO filing_raw_documents (
+                    accession_number, document_kind, payload
+                ) VALUES (%s, %s, %s)
+                """,
+                ("0000000000-26-000001", "form4_typo", "<x/>"),
+            )
+
+
+def test_empty_payload_rejected_at_helper(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Empty payload defeats the purpose (no body to re-wash from);
+    helper rejects rather than silently writing a useless row."""
+    conn = ebull_test_conn
+    with pytest.raises(ValueError):
+        raw_filings.store_raw(
+            conn,
+            accession_number="0001767470-26-000005",
+            document_kind="form4_xml",
+            payload="",
+        )
+
+
+def test_iter_raw_filters_by_kind_and_parser_version(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """``iter_raw`` returns only rows for the requested kind, and
+    optionally only those NOT on the current parser version."""
+    conn = ebull_test_conn
+    raw_filings.store_raw(
+        conn,
+        accession_number="0000000001-26-000001",
+        document_kind="form4_xml",
+        payload="<old/>",
+        parser_version="form4-v1",
+    )
+    raw_filings.store_raw(
+        conn,
+        accession_number="0000000001-26-000002",
+        document_kind="form4_xml",
+        payload="<new/>",
+        parser_version="form4-v2",
+    )
+    raw_filings.store_raw(
+        conn,
+        accession_number="0000000001-26-000003",
+        document_kind="form3_xml",
+        payload="<f3/>",
+        parser_version="form3-v1",
+    )
+    conn.commit()
+
+    form4_all = list(raw_filings.iter_raw(conn, document_kind="form4_xml"))
+    assert len(form4_all) == 2
+
+    # Filter to "needs re-parse" — anything NOT on form4-v2.
+    needs_reparse = list(
+        raw_filings.iter_raw(
+            conn,
+            document_kind="form4_xml",
+            parser_version_not_in=("form4-v2",),
+        )
+    )
+    assert len(needs_reparse) == 1
+    assert needs_reparse[0].parser_version == "form4-v1"
+
+
+def test_storage_summary_groups_by_kind(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    raw_filings.store_raw(
+        conn,
+        accession_number="0000000002-26-000001",
+        document_kind="form4_xml",
+        payload="x" * 100,
+    )
+    raw_filings.store_raw(
+        conn,
+        accession_number="0000000002-26-000002",
+        document_kind="form4_xml",
+        payload="y" * 200,
+    )
+    raw_filings.store_raw(
+        conn,
+        accession_number="0000000002-26-000003",
+        document_kind="def14a_body",
+        payload="z" * 5000,
+    )
+    conn.commit()
+    summary = raw_filings.storage_summary(conn)
+    by_kind = {s.document_kind: s for s in summary}
+    assert by_kind["form4_xml"].row_count == 2
+    assert by_kind["form4_xml"].total_bytes == 300
+    assert by_kind["def14a_body"].row_count == 1
+    assert by_kind["def14a_body"].total_bytes == 5000
+
+
+def test_byte_count_generated_from_octet_length(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """``byte_count`` is GENERATED ALWAYS so a manual UPDATE on
+    payload also refreshes it. Pin the invariant so a future schema
+    change can't silently drop the GENERATED clause."""
+    conn = ebull_test_conn
+    raw_filings.store_raw(
+        conn,
+        accession_number="0000000003-26-000001",
+        document_kind="form4_xml",
+        payload="<short/>",
+    )
+    conn.commit()
+    doc = raw_filings.read_raw(
+        conn,
+        accession_number="0000000003-26-000001",
+        document_kind="form4_xml",
+    )
+    assert doc is not None
+    assert doc.byte_count == len(b"<short/>")


### PR DESCRIPTION
## Summary

Operator audit 2026-05-03: ownership-side filings (13F, 13D/G, Form 4, Form 3, DEF 14A) parse the source XML/HTML and drop the body. \`filing_events.raw_payload_json\` (3.8M rows) only stores filing METADATA (URL, date, type), confirmed by inspection. So a parser-bug discovery forces re-fetch from SEC at 10 req/sec and risks the document being amended in-flight.

This PR ships the FOUNDATION — canonical body store + helper + tests. Per-ingester wiring lands in follow-up PRs (one per ingester) so each diff stays reviewable.

## Migration 107

\`filing_raw_documents\` keyed on \`(accession_number, document_kind)\`:
- TEXT payload (Postgres TOAST compresses XML automatically; ~5x ratio)
- CHECK on \`document_kind\` enumerates 8 valid values
- \`byte_count\` GENERATED ALWAYS from \`octet_length(payload)\`
- \`parser_version\` records which parser produced the typed-table rows so re-wash can skip already-current rows
- Indexed on \`(document_kind, fetched_at DESC)\` for re-wash walks + on accession_number for typed-table joins

## Helper

\`app/services/raw_filings.py\`:
- \`store_raw\` — idempotent UPSERT
- \`read_raw\` — fetch one (accession, kind)
- \`iter_raw\` — server-side cursor, optional filter on \`parser_version_not_in\`
- \`storage_summary\` — per-kind row + byte rollup

## Test plan

- [x] 8 cases: round-trip / idempotent overwrite / missing returns None / CHECK on kind / empty payload rejected / iter filter / storage summary / byte_count generated.
- [x] All 4 local gates pass.

## Follow-ups

Five focused PRs — one per ingester — wire \`store_raw\` at the fetch site:
- \`app/services/institutional_holdings.py\` → \`infotable_13f\` + \`primary_doc\`
- \`app/services/blockholders.py\` → \`primary_doc_13dg\`
- \`app/services/insider_transactions.py\` → \`form4_xml\`
- \`app/services/insider_form3_ingest.py\` → \`form3_xml\`
- \`app/services/def14a_ingest.py\` → \`def14a_body\`

Plus a re-wash workflow PR that walks \`iter_raw\` and re-parses against the latest parser_version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)