### PR TITLE
feat: wire all 5 ownership ingesters to filing_raw_documents

### DIFF
--- a/app/services/blockholders.py
+++ b/app/services/blockholders.py
@@ -64,7 +64,10 @@ from app.providers.implementations.sec_13dg import (
     BlockholderReportingPerson,
     parse_primary_doc,
 )
+from app.services import raw_filings
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
+
+_PARSER_VERSION_13DG = "13dg-primary-v1"
 
 logger = logging.getLogger(__name__)
 
@@ -600,6 +603,20 @@ def _ingest_single_accession(
             error="primary_doc.xml fetch failed",
             submission_type=None,
         )
+    # Persist raw body BEFORE parsing — re-wash workflows depend on
+    # this row even if parsing fails. Operator audit 2026-05-03 +
+    # PR #808 contract. Commit immediately so a later per-filer
+    # exception that triggers ``conn.rollback()`` upstream cannot
+    # take this row down with it (Codex pre-push review).
+    raw_filings.store_raw(
+        conn,
+        accession_number=ref.accession_number,
+        document_kind="primary_doc_13dg",
+        payload=primary_xml,
+        parser_version=_PARSER_VERSION_13DG,
+        source_url=primary_url,
+    )
+    conn.commit()
 
     try:
         filing: BlockholderFiling = parse_primary_doc(primary_xml)

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -44,7 +44,10 @@ from app.providers.implementations.sec_def14a import (
     Def14ABeneficialOwnershipTable,
     parse_beneficial_ownership_table,
 )
+from app.services import raw_filings
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
+
+_PARSER_VERSION_DEF14A = "def14a-v1"
 
 logger = logging.getLogger(__name__)
 
@@ -381,6 +384,20 @@ def _ingest_single_accession(
             error="primary doc fetch failed",
             issuer_cik=issuer_cik,
         )
+    # Persist raw body BEFORE parsing — re-wash workflows depend on
+    # this row even if parsing fails. Operator audit 2026-05-03 +
+    # PR #808 contract. Commit immediately so a later per-accession
+    # exception that triggers the outer ``conn.rollback()`` cannot
+    # take this row down with it (Codex pre-push review).
+    raw_filings.store_raw(
+        conn,
+        accession_number=ref.accession_number,
+        document_kind="def14a_body",
+        payload=body,
+        parser_version=_PARSER_VERSION_DEF14A,
+        source_url=ref.primary_document_url,
+    )
+    conn.commit()
 
     try:
         parsed: Def14ABeneficialOwnershipTable = parse_beneficial_ownership_table(body)

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -41,6 +41,7 @@ from typing import Any, Protocol
 import psycopg
 
 from app.providers.concurrent_fetch import fetch_document_texts
+from app.services import raw_filings
 from app.services.insider_transactions import (
     ParsedForm3,
     _canonical_form_4_url,
@@ -515,6 +516,19 @@ def _process_form_3_candidates(
             )
             conn.commit()
             continue
+
+        # Persist raw body BEFORE parsing — re-wash workflows depend
+        # on this row even if parsing fails. Operator audit
+        # 2026-05-03 + PR #808 contract.
+        raw_filings.store_raw(
+            conn,
+            accession_number=accession,
+            document_kind="form3_xml",
+            payload=xml,
+            parser_version=f"form3-v{_FORM3_PARSER_VERSION}",
+            source_url=url,
+        )
+        conn.commit()
 
         parsed = parse_form_3_xml(xml)
         if parsed is None:

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -49,6 +49,9 @@ import psycopg
 from psycopg.types.json import Jsonb
 
 from app.providers.concurrent_fetch import fetch_document_texts
+from app.services import raw_filings
+
+_PARSER_VERSION_FORM4 = "form4-v1"
 
 logger = logging.getLogger(__name__)
 
@@ -1419,6 +1422,19 @@ def _process_candidates(
             )
             conn.commit()
             continue
+
+        # Persist raw body BEFORE parsing — re-wash workflows depend
+        # on this row even if parsing fails. Operator audit
+        # 2026-05-03 + PR #808 contract.
+        raw_filings.store_raw(
+            conn,
+            accession_number=accession,
+            document_kind="form4_xml",
+            payload=xml,
+            parser_version=_PARSER_VERSION_FORM4,
+            source_url=url,
+        )
+        conn.commit()
 
         parsed = parse_form_4_xml(xml)
         if parsed is None:

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import logging
+import xml.etree.ElementTree as ET  # noqa: S405 — only used to catch ET.ParseError on parse failure
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
@@ -48,7 +49,16 @@ from app.providers.implementations.sec_13f import (
     parse_infotable,
     parse_primary_doc,
 )
+from app.services import raw_filings
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
+
+# Parser-version tags written alongside the raw bodies. Re-wash
+# workflows compare against these constants and skip rows already
+# on the latest parser. Bump when ``parse_primary_doc`` /
+# ``parse_infotable`` semantics change in a way that affects what
+# lands in the typed tables.
+_PARSER_VERSION_13F_PRIMARY = "13f-primary-v1"
+_PARSER_VERSION_13F_INFOTABLE = "13f-infotable-v1"
 
 logger = logging.getLogger(__name__)
 
@@ -906,17 +916,19 @@ def _ingest_single_accession(
     primary_url = _archive_file_url(filer_cik, ref.accession_number, primary_name)
     infotable_url = _archive_file_url(filer_cik, ref.accession_number, infotable_name)
 
-    # Raw-payload-persistence contract (#448 / #453):
-    # the fetched body is consumed directly by parse_primary_doc
-    # and parse_infotable below; every structured field they emit
-    # lands in SQL via _upsert_filer / _upsert_holding. Matches the
-    # pattern in app/services/insider_transactions.py,
-    # app/services/business_summary.py, app/services/eight_k_events.py
-    # — none of which persist the fetched body to a separate raw
-    # column before parsing. SEC EDGAR's fetch_document_text owns
-    # the host-side audit; the service-layer contract is "every
-    # structured field from the upstream document lands in SQL",
-    # which the upserts below satisfy.
+    # Raw-payload retention (operator audit 2026-05-03 + PR #808):
+    # both fetched bodies are persisted to ``filing_raw_documents``
+    # IMMEDIATELY after successful fetch, BEFORE parsing. That way:
+    #
+    #   * A parser bug discovered later can re-wash from the stored
+    #     body without re-fetching SEC at 10 req/sec.
+    #   * If parsing raises, we still have the body for diagnostic.
+    #   * Re-fetches (amended filings) overwrite via ON CONFLICT —
+    #     the new body is always authoritative.
+    #
+    # Prior contract was "every structured field from the upstream
+    # document lands in SQL" via the upserts below — that holds, but
+    # is no longer the only re-wash path.
     primary_xml = sec.fetch_document_text(primary_url)
     if primary_xml is None:
         logger.warning(
@@ -930,10 +942,25 @@ def _ingest_single_accession(
             holdings_skipped_no_cusip=0,
             error="primary_doc.xml fetch failed",
         )
+    raw_filings.store_raw(
+        conn,
+        accession_number=ref.accession_number,
+        document_kind="primary_doc",
+        payload=primary_xml,
+        parser_version=_PARSER_VERSION_13F_PRIMARY,
+        source_url=primary_url,
+    )
+    # Commit the raw row immediately so a later parse failure that
+    # propagates up to the outer filer loop's rollback can't take
+    # the just-stored body down with it. Codex pre-push review caught
+    # this — without the commit, the rollback at the per-filer
+    # exception handler discards the raw row exactly when we need it
+    # most (parse failed → re-wash needs the body).
+    conn.commit()
 
     try:
         info = parse_primary_doc(primary_xml)
-    except ValueError as exc:
+    except (ValueError, ET.ParseError) as exc:
         logger.exception(
             "13F ingest: primary_doc.xml parse failed for cik=%s accession=%s",
             filer_cik,
@@ -959,8 +986,30 @@ def _ingest_single_accession(
             holdings_skipped_no_cusip=0,
             error="infotable.xml fetch failed",
         )
+    raw_filings.store_raw(
+        conn,
+        accession_number=ref.accession_number,
+        document_kind="infotable_13f",
+        payload=infotable_xml,
+        parser_version=_PARSER_VERSION_13F_INFOTABLE,
+        source_url=infotable_url,
+    )
+    conn.commit()
 
-    holdings = parse_infotable(infotable_xml)
+    try:
+        holdings = parse_infotable(infotable_xml)
+    except (ValueError, ET.ParseError) as exc:
+        logger.exception(
+            "13F ingest: infotable.xml parse failed for cik=%s accession=%s",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            error=f"infotable.xml parse failed: {exc}",
+        )
     filer_id = _upsert_filer(conn, info)
 
     if not holdings:

--- a/tests/test_blockholders_ingester.py
+++ b/tests/test_blockholders_ingester.py
@@ -437,6 +437,33 @@ class TestIngestFilerBlockholders:
         assert row["symbol"] == "AAPL"
         assert row["filer_name"] == "Test Activist Fund LP"
 
+    def test_raw_payload_persisted_for_primary_doc_13dg(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """13D/G ingester must persist primary_doc.xml body to
+        ``filing_raw_documents`` before parsing — operator audit
+        2026-05-03 + PR #808 contract."""
+        from app.services import raw_filings
+
+        conn = _setup
+        accession = "0001234567-25-000099"
+        fetcher = self._build_fetcher(
+            accessions=[(accession, "SC 13D", "2025-11-06")],
+            xml_by_accession={accession: _13d_xml()},
+        )
+        ingest_filer_blockholders(conn, fetcher, filer_cik="0001234567")
+        conn.commit()
+
+        doc = raw_filings.read_raw(
+            conn,
+            accession_number=accession,
+            document_kind="primary_doc_13dg",
+        )
+        assert doc is not None
+        assert "<edgarSubmission" in doc.payload or "<schedule13D" in doc.payload.lower()
+        assert doc.parser_version == "13dg-primary-v1"
+
     def test_multi_reporter_writes_n_rows(
         self,
         _setup: psycopg.Connection[tuple],

--- a/tests/test_def14a_ingest.py
+++ b/tests/test_def14a_ingest.py
@@ -326,6 +326,40 @@ class TestIngestDef14a:
         assert log["status"] == "success"
         assert log["rows_inserted"] == 3
 
+    def test_raw_payload_persisted_for_def14a_body(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """DEF 14A ingester must persist the proxy body to
+        ``filing_raw_documents`` before parsing — operator audit
+        2026-05-03 + PR #808 contract."""
+        from app.services import raw_filings
+
+        conn = _setup
+        url = "https://www.sec.gov/test/proxy_raw.htm"
+        accession = "0001234567-25-RAW001"
+        _seed_filing_event(
+            conn,
+            instrument_id=769_100,
+            accession=accession,
+            filing_date=date(2026, 3, 15),
+            primary_document_url=url,
+        )
+        conn.commit()
+        fetcher = _InMemoryFetcher({url: _proxy_html_with_table()})
+        ingest_def14a(conn, fetcher)
+        conn.commit()
+
+        doc = raw_filings.read_raw(
+            conn,
+            accession_number=accession,
+            document_kind="def14a_body",
+        )
+        assert doc is not None
+        assert doc.parser_version == "def14a-v1"
+        assert doc.source_url == url
+        assert len(doc.payload) > 0
+
     def test_re_ingest_promotes_via_upsert_not_insert(
         self,
         _setup: psycopg.Connection[tuple],

--- a/tests/test_insider_form3_ingest.py
+++ b/tests/test_insider_form3_ingest.py
@@ -156,6 +156,33 @@ _FORM_3_RICH = """<?xml version="1.0"?>
 
 
 class TestRichHappyPath:
+    def test_raw_payload_persisted_for_form3_xml(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Form 3 ingester must persist the XML body to
+        ``filing_raw_documents`` before parsing — operator audit
+        2026-05-03 + PR #808 contract."""
+        from app.services import raw_filings
+
+        iid = _seed_instrument(ebull_test_conn)
+        url = "https://www.sec.gov/Archives/edgar/data/320193/000119312526RAW001/form3.xml"
+        _seed_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="RAW-FORM3-26-000001",
+            url=url,
+        )
+        fetcher = _StubFetcher({url: _FORM_3_RICH})
+        ingest_form_3_filings(ebull_test_conn, fetcher)
+
+        doc = raw_filings.read_raw(
+            ebull_test_conn,
+            accession_number="RAW-FORM3-26-000001",
+            document_kind="form3_xml",
+        )
+        assert doc is not None
+        assert "<ownershipDocument>" in doc.payload
+        assert doc.parser_version == "form3-v1"
+        assert doc.source_url == url
+
     def test_full_filing_lands_across_four_tables(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         iid = _seed_instrument(ebull_test_conn)
         url = "https://www.sec.gov/Archives/edgar/data/320193/000119312526001000/form3.xml"

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -297,6 +297,39 @@ _FORM_4A_AMENDMENT = """<?xml version="1.0"?>
 
 
 class TestIngestInsiderTransactions:
+    def test_raw_payload_persisted_for_form4_xml(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Form 4 ingester must persist the XML body to
+        ``filing_raw_documents`` before parsing — operator audit
+        2026-05-03 + PR #808 contract."""
+        from app.services import raw_filings
+
+        iid = _seed_instrument(ebull_test_conn)
+        _seed_form_4(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession="RAW-FORM4-26-000001",
+            url="https://www.sec.gov/Archives/form4-raw.xml",
+            filing_date=date.today().isoformat(),
+        )
+        fetcher = _StubFetcher(
+            {
+                "https://www.sec.gov/Archives/form4-raw.xml": _FORM_4_RICH_BUY.replace(
+                    "2024-06-15", date.today().isoformat()
+                )
+            }
+        )
+        ingest_insider_transactions(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+
+        doc = raw_filings.read_raw(
+            ebull_test_conn,
+            accession_number="RAW-FORM4-26-000001",
+            document_kind="form4_xml",
+        )
+        assert doc is not None
+        assert "<ownershipDocument>" in doc.payload
+        assert doc.parser_version == "form4-v1"
+        assert doc.source_url == "https://www.sec.gov/Archives/form4-raw.xml"
+
     def test_rich_happy_path_populates_every_field(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         iid = _seed_instrument(ebull_test_conn)
         _seed_form_4(

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -350,6 +350,93 @@ class TestIngestFiler13F:
         assert rows[0]["market_value_usd"] == Decimal("69900000")
         assert rows[0]["voting_authority"] == "SOLE"
 
+    def test_raw_payload_persisted_for_primary_doc_and_infotable(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """13F ingester must persist BOTH the primary_doc.xml and
+        the infotable.xml bodies to ``filing_raw_documents`` before
+        parsing — operator audit 2026-05-03 + PR #808 contract.
+        Re-wash workflows depend on these rows."""
+        from app.services import raw_filings
+
+        conn = _setup
+        fetcher = self._build_fetcher(
+            holdings=[
+                {"cusip": "037833100", "name": "APPLE INC", "value": "1", "shares": "1"},
+            ]
+        )
+        ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+
+        primary = raw_filings.read_raw(
+            conn,
+            accession_number="0001067983-25-000001",
+            document_kind="primary_doc",
+        )
+        assert primary is not None
+        assert "BERKSHIRE" in primary.payload.upper() or "<edgarSubmission" in primary.payload
+        assert primary.parser_version == "13f-primary-v1"
+        assert primary.source_url is not None
+        assert primary.source_url.endswith("primary_doc.xml")
+
+        infotable = raw_filings.read_raw(
+            conn,
+            accession_number="0001067983-25-000001",
+            document_kind="infotable_13f",
+        )
+        assert infotable is not None
+        assert "037833100" in infotable.payload  # the seeded CUSIP
+        assert infotable.parser_version == "13f-infotable-v1"
+        assert infotable.source_url is not None
+        assert infotable.source_url.endswith("infotable.xml")
+
+    def test_raw_payload_survives_parse_failure(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Codex pre-push review (PR follow-up to #808): if
+        primary_doc.xml or infotable.xml is malformed and the parser
+        raises ET.ParseError, the previously-stored raw body must
+        survive — the whole point of raw retention is debugging
+        parser failures without re-fetching SEC."""
+        from app.services import raw_filings
+
+        conn = _setup
+        # Corrupt the infotable so parse_infotable raises ParseError
+        # while primary_doc.xml is still valid.
+        cik_int = 1067983
+        accession = "0001067983-25-000099"
+        accn_no_dashes = accession.replace("-", "")
+        archive_base = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accn_no_dashes}/"
+        payloads: dict[str, str | None] = {
+            "https://data.sec.gov/submissions/CIK0001067983.json": _submissions_json(
+                accessions=[(accession, "13F-HR", "2025-02-14", "2024-12-31")]
+            ),
+            archive_base + "index.json": _archive_index_json(),
+            archive_base + "primary_doc.xml": _PRIMARY_DOC_XML,
+            archive_base + "infotable.xml": "<not-valid-xml<<<",  # malformed
+        }
+        fetcher = _InMemoryFetcher(payloads)
+
+        ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+
+        # Both raw rows persisted despite the parse failure.
+        primary = raw_filings.read_raw(
+            conn,
+            accession_number=accession,
+            document_kind="primary_doc",
+        )
+        assert primary is not None
+        infotable = raw_filings.read_raw(
+            conn,
+            accession_number=accession,
+            document_kind="infotable_13f",
+        )
+        assert infotable is not None
+        assert infotable.payload == "<not-valid-xml<<<"
+
     def test_unknown_cusip_is_skipped_with_counter(
         self,
         _setup: psycopg.Connection[tuple],


### PR DESCRIPTION
## Summary

Operator audit 2026-05-03 + PR #808 contract: every ownership-side ingester (13F, 13D/G, Form 4, Form 3, DEF 14A) now persists the source XML/HTML body to \`filing_raw_documents\` BEFORE parsing, with \`conn.commit()\` immediately after \`store_raw\` so a downstream parse failure cannot rollback the raw row.

## Per ingester

- **13F** — \`infotable_13f\` + \`primary_doc\` (parser_versions \`13f-infotable-v1\` / \`13f-primary-v1\`)
- **13D/G** — \`primary_doc_13dg\` (\`13dg-primary-v1\`)
- **Form 4** — \`form4_xml\` (\`form4-v1\`)
- **Form 3** — \`form3_xml\` (uses existing \`_FORM3_PARSER_VERSION\` constant)
- **DEF 14A** — \`def14a_body\` (\`def14a-v1\`)

## Codex pre-push review caught (both fixed)

1. **13F lost raw bodies on malformed XML**. \`_ingest_single_accession\` had no try/except on \`parse_infotable\` and only \`ValueError\` on \`parse_primary_doc\`. SEC parsers use \`ET.fromstring\` which raises \`ET.ParseError\` on malformed XML — that bubbled to the per-filer exception handler and triggered a rollback that discarded the raw rows. Fixed: catch \`(ValueError, ET.ParseError)\` on both parse calls + \`conn.commit()\` immediately after each \`store_raw\`. Function now honors its "Never raises" docstring.
2. **Same rollback risk in blockholders + def14a_ingest** (both have outer per-accession/per-filer rollback paths). Both now \`conn.commit()\` immediately after \`store_raw\` so the raw row is durable regardless of subsequent parse/upsert outcome.

## Test plan

- [x] 5 raw-payload regression tests (one per ingester) asserting the row is persisted on a happy-path ingest with the expected parser_version + source_url.
- [x] Malformed-XML survival test on 13F: corrupt the infotable, run ingest, assert BOTH raw rows persist despite the parse failure.
- [x] 103 tests pass across the 5 ingester suites + raw_filings foundation.
- [x] All 4 local gates pass.

## Follow-ups (from #809)

- Re-wash workflow CLI walking \`iter_raw\` with \`parser_version_not_in\`.
- \`cik_raw_documents\` sibling table for submissions.json / companyfacts.json (CIK-keyed, distinct from this per-accession store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)