### PR TITLE
fix(#805): wire DEF 14A ingester to scheduler

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -75,6 +75,7 @@ from app.workers.scheduler import (
     JOB_SEC_8K_EVENTS_INGEST,
     JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP,
     JOB_SEC_BUSINESS_SUMMARY_INGEST,
+    JOB_SEC_DEF14A_INGEST,
     JOB_SEC_DIVIDEND_CALENDAR_INGEST,
     JOB_SEC_FILING_DOCUMENTS_INGEST,
     JOB_SEC_FORM3_INGEST,
@@ -107,6 +108,7 @@ from app.workers.scheduler import (
     sec_8k_events_ingest,
     sec_business_summary_bootstrap,
     sec_business_summary_ingest,
+    sec_def14a_ingest,
     sec_dividend_calendar_ingest,
     sec_filing_documents_ingest,
     sec_form3_ingest,
@@ -166,6 +168,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST: sec_insider_transactions_ingest,
     JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL: sec_insider_transactions_backfill,
     JOB_SEC_FORM3_INGEST: sec_form3_ingest,
+    JOB_SEC_DEF14A_INGEST: sec_def14a_ingest,
     JOB_SEC_8K_EVENTS_INGEST: sec_8k_events_ingest,
     JOB_SEC_FILING_DOCUMENTS_INGEST: sec_filing_documents_ingest,
 }

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -242,6 +242,7 @@ JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP = "sec_business_summary_bootstrap"
 JOB_SEC_INSIDER_TRANSACTIONS_INGEST = "sec_insider_transactions_ingest"
 JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL = "sec_insider_transactions_backfill"
 JOB_SEC_FORM3_INGEST = "sec_form3_ingest"
+JOB_SEC_DEF14A_INGEST = "sec_def14a_ingest"
 JOB_SEC_8K_EVENTS_INGEST = "sec_8k_events_ingest"
 JOB_SEC_FILING_DOCUMENTS_INGEST = "sec_filing_documents_ingest"
 JOB_EXCHANGES_METADATA_REFRESH = "exchanges_metadata_refresh"
@@ -594,6 +595,26 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "were invisible to the per-filer ring."
         ),
         cadence=Cadence.daily(hour=4, minute=20),
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_DEF14A_INGEST,
+        description=(
+            "Parse SEC DEF 14A proxy statements into "
+            "``def14a_beneficial_holdings`` (#769 / #805). DEF 14A is "
+            "the canonical annual reconciliation point for both insiders "
+            "(officers + directors with proxy-disclosed beneficial "
+            "ownership) and 5%+ blockholders. Without this ingest, the "
+            "ownership rollup's def14a_unmatched slice is always empty "
+            "and the DEF 14A drift detector has nothing to reconcile "
+            "against — surfacing 0 rows in dev DB on operator audit "
+            "2026-05-03. Cadence: daily — proxy filings appear "
+            "~quarterly per issuer so daily catches them within a day "
+            "of EDGAR availability without burning bandwidth. Idempotent "
+            "via the (accession, holder_name) UNIQUE on the holdings "
+            "table + the def14a_ingest_log tombstone."
+        ),
+        cadence=Cadence.daily(hour=4, minute=35),
         catch_up_on_boot=False,
     ),
     ScheduledJob(
@@ -3252,6 +3273,43 @@ def sec_form3_ingest() -> None:
             result.rows_inserted,
             result.fetch_errors,
             result.parse_misses,
+        )
+
+
+def sec_def14a_ingest() -> None:
+    """Parse SEC DEF 14A proxy statements into
+    ``def14a_beneficial_holdings`` (#769 / #805).
+
+    Operator audit 2026-05-03 found this ingester was authored under
+    #769 (PRs #771-#774) but never had a periodic invocation wired up,
+    leaving ``def14a_beneficial_holdings`` empty in dev DB. The DEF
+    14A drift detector and the ownership rollup's
+    ``def14a_unmatched`` slice both depend on this data.
+
+    Daily cadence is plenty — proxy filings are quarterly-ish per
+    issuer; daily catches new ones within a cycle. Idempotent via
+    the ``(accession, holder_name)`` UNIQUE key + the
+    ``def14a_ingest_log`` tombstone.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.def14a_ingest import ingest_def14a
+
+    with _tracked_job(JOB_SEC_DEF14A_INGEST) as tracker:
+        with (
+            psycopg.connect(settings.database_url) as conn,
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
+        ):
+            result = ingest_def14a(conn, provider)
+
+        tracker.row_count = result.rows_inserted
+        logger.info(
+            "sec_def14a_ingest: scanned=%d succeeded=%d partial=%d failed=%d rows_inserted=%d rows_updated=%d",
+            result.accessions_seen,
+            result.accessions_succeeded,
+            result.accessions_partial,
+            result.accessions_failed,
+            result.rows_inserted,
+            result.rows_updated,
         )
 
 


### PR DESCRIPTION
## Summary

Operator audit 2026-05-03 found the DEF 14A ingester (authored under #769 / PRs #771-#774) was never wired to the scheduler. \`def14a_beneficial_holdings\` is empty in dev DB despite 358k \`insider_filings\` rows being present — the DEF 14A drift detector has nothing to reconcile against and the ownership rollup's \`def14a_unmatched\` slice is always empty.

## Wiring

- \`JOB_SEC_DEF14A_INGEST\` constant + \`ScheduledJob\` entry — daily at 04:35 UTC. Daily cadence is plenty since proxy filings are quarterly-ish per issuer.
- \`sec_def14a_ingest\` invoker runs \`ingest_def14a\` inside \`_tracked_job\` so the run lands in \`data_ingestion_runs\` under source=\`sec_def14a_ingest\`. Surfaces on the operator's ingest-health page (PR #801) under the SEC ownership group automatically (provider taxonomy already maps the prefix).
- Registered in \`_INVOKERS\` in \`app/jobs/runtime.py\`.

## Test plan

- [x] Existing drift-guard tests in \`test_jobs_runtime.py\` (\`test_every_scheduled_job_has_an_invoker\`, \`test_every_invoker_is_scheduled_or_on_demand\`) cover the wiring contract — adding a job without an invoker would fail the guard.
- [x] All 47 tests in \`test_jobs_runtime.py\` + \`test_def14a_ingest.py\` pass.
- [x] All 4 local gates pass.
- [x] Manual verify: \`VALID_JOB_NAMES\` and \`SCHEDULED_JOBS\` both contain \`sec_def14a_ingest\`.

## Operator action after merge

The next 04:35 UTC tick fires the ingester for the first time. Expect rows landing in \`def14a_beneficial_holdings\` over the following day (subject to filing-event source URL availability per the ingester's eligibility query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)