### PR TITLE
feat: CIK discovery sweep from SEC company_tickers.json

### DIFF
--- a/app/services/cik_discovery.py
+++ b/app/services/cik_discovery.py
@@ -1,0 +1,253 @@
+"""CIK discovery from SEC's curated ticker→CIK map.
+
+Operator audit 2026-05-03 found 7,281 of 12,379 instruments (59%)
+have no SEC CIK row in ``external_identifiers``. Without a CIK
+they're invisible to every SEC ingester (13F, 13D/G, Form 4, Form
+3, DEF 14A, fundamentals). The pie chart can never populate for
+those instruments.
+
+This module's contract: walk every no-CIK instrument, look up the
+ticker in SEC's ``company_tickers.json`` (a curated map maintained
+by SEC, ~10k entries), write the ``external_identifiers`` row when a
+match is found.
+
+Source: ``https://www.sec.gov/files/company_tickers.json``. Updated
+roughly daily by SEC. Single fetch is sufficient — a periodic
+re-fetch (weekly) catches new IPOs and issuer renames.
+
+Misses (no SEC ticker entry for the instrument's symbol) are
+expected for:
+
+  * Foreign issuers without ADRs.
+  * Defunct / delisted tickers.
+  * Synthetic / duplicate listings (e.g. ``.RTH`` suffixes used as
+    operational duplicates of an underlying ticker).
+  * Bonds / preferreds / warrants (separate ticker from common
+    stock).
+
+Misses are logged but never raise — the discovery sweep is
+best-effort and operators triage the long tail manually.
+
+Idempotent: ``ON CONFLICT DO NOTHING`` on the
+``external_identifiers`` upsert means re-running won't duplicate
+rows or stomp on operator-curated overrides. A re-fetch after a
+ticker change would not over-write the prior CIK row — it just
+no-ops because the prior row is still on file. Removing the prior
+CIK after a ticker reassignment is operator territory (manual
+DELETE + audit trail).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
+
+
+@dataclass(frozen=True)
+class TickerMapEntry:
+    cik_padded: str  # 10-digit zero-padded
+    ticker: str  # uppercase
+    title: str  # SEC entity name
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    instruments_scanned: int
+    matches_found: int
+    rows_inserted: int
+    misses: int
+
+
+def fetch_ticker_map() -> dict[str, TickerMapEntry]:
+    """Fetch SEC's curated ticker→CIK map. Returns dict keyed on
+    UPPERCASE ticker so callers can ``.get(symbol.upper())``.
+
+    Raises ``urllib.error.URLError`` on network failure — caller
+    decides whether that's transient (retry) or terminal (skip
+    this run).
+    """
+    req = urllib.request.Request(
+        _TICKERS_URL,
+        headers={"User-Agent": settings.sec_user_agent},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 — fixed SEC URL
+        payload = json.load(resp)
+
+    out: dict[str, TickerMapEntry] = {}
+    if not isinstance(payload, dict):
+        return out
+    for entry in payload.values():
+        if not isinstance(entry, dict):
+            continue
+        cik_raw = entry.get("cik_str")
+        ticker = entry.get("ticker")
+        title = entry.get("title", "")
+        if cik_raw is None or not ticker:
+            continue
+        try:
+            cik_int = int(cik_raw)
+        except TypeError, ValueError:
+            continue
+        cik_padded = f"{cik_int:010d}"
+        ticker_upper = str(ticker).upper().strip()
+        if not ticker_upper:
+            continue
+        # SEC's map can have multiple entries for the same ticker
+        # (rare; share class amendments). Keep the first match —
+        # callers can override manually if needed.
+        if ticker_upper not in out:
+            out[ticker_upper] = TickerMapEntry(
+                cik_padded=cik_padded,
+                ticker=ticker_upper,
+                title=str(title),
+            )
+    return out
+
+
+def iter_no_cik_instruments(
+    conn: psycopg.Connection[Any],
+) -> Iterator[tuple[int, str]]:
+    """Yield ``(instrument_id, symbol)`` for every instrument with no
+    primary SEC CIK.
+
+    Eager-fetched — the cohort is bounded (~7k rows × ~50 bytes each
+    = ~350 KB) and a server-side cursor would close on every
+    per-instrument ``conn.commit()`` in the discovery loop. Loading
+    once up front avoids cursor-lifetime headaches.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT i.instrument_id, i.symbol
+            FROM instruments i
+            LEFT JOIN external_identifiers ei
+                ON ei.instrument_id = i.instrument_id
+               AND ei.provider = 'sec'
+               AND ei.identifier_type = 'cik'
+               AND ei.is_primary = TRUE
+            WHERE ei.identifier_value IS NULL
+              AND i.symbol IS NOT NULL
+            ORDER BY i.instrument_id
+            """,
+        )
+        rows = cur.fetchall()
+    for row in rows:
+        yield int(row["instrument_id"]), str(row["symbol"])
+
+
+def upsert_cik(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    cik_padded: str,
+    ticker: str,
+) -> bool:
+    """Idempotent insert of one ``external_identifiers`` row. Returns
+    ``True`` when a new row was inserted, ``False`` on no-op /
+    conflict.
+
+    Two unique constraints can fire here:
+
+      1. ``uq_external_identifiers_primary`` partial unique on
+         ``(instrument_id, provider, identifier_type) WHERE
+         is_primary`` — same instrument already has a primary CIK
+         row (with any value). Operator-curated CIK takes precedence
+         over the discovery match; we no-op.
+      2. ``uq_external_identifiers_provider_value`` on
+         ``(provider, identifier_type, identifier_value)`` — same
+         CIK already mapped to another instrument. Discovery match
+         conflicts with an existing CIK→instrument mapping; we
+         no-op (the prior mapping wins).
+
+    Pre-check on (1) keeps the SQL straightforward; ON CONFLICT on
+    (2) handles the cross-instrument case at insert time.
+    """
+    with conn.cursor() as cur:
+        # Pre-check: does this instrument already have a primary CIK?
+        cur.execute(
+            """
+            SELECT 1 FROM external_identifiers
+            WHERE instrument_id = %s
+              AND provider = 'sec'
+              AND identifier_type = 'cik'
+              AND is_primary = TRUE
+            """,
+            (instrument_id,),
+        )
+        if cur.fetchone() is not None:
+            return False  # operator-curated row wins
+
+        cur.execute(
+            """
+            INSERT INTO external_identifiers (
+                instrument_id, provider, identifier_type, identifier_value,
+                is_primary
+            ) VALUES (%s, 'sec', 'cik', %s, TRUE)
+            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            """,
+            (instrument_id, cik_padded),
+        )
+        affected = cur.rowcount or 0
+    if affected > 0:
+        logger.info(
+            "cik_discovery: matched %s -> CIK %s (instrument_id=%s)",
+            ticker,
+            cik_padded,
+            instrument_id,
+        )
+    return affected > 0
+
+
+def discover_ciks(
+    conn: psycopg.Connection[Any],
+    *,
+    ticker_map: dict[str, TickerMapEntry] | None = None,
+) -> DiscoveryResult:
+    """Walk every no-CIK instrument and attempt SEC ticker→CIK
+    resolution. Idempotent.
+
+    ``ticker_map`` is injectable for tests; production callers pass
+    ``None`` and the function fetches from SEC.
+    """
+    if ticker_map is None:
+        ticker_map = fetch_ticker_map()
+    scanned = 0
+    matches = 0
+    inserts = 0
+    misses = 0
+    for instrument_id, symbol in iter_no_cik_instruments(conn):
+        scanned += 1
+        entry = ticker_map.get(symbol.upper())
+        if entry is None:
+            misses += 1
+            continue
+        matches += 1
+        if upsert_cik(
+            conn,
+            instrument_id=instrument_id,
+            cik_padded=entry.cik_padded,
+            ticker=entry.ticker,
+        ):
+            inserts += 1
+        # Commit per-instrument so a downstream failure doesn't
+        # discard the entire batch's discoveries.
+        conn.commit()
+    return DiscoveryResult(
+        instruments_scanned=scanned,
+        matches_found=matches,
+        rows_inserted=inserts,
+        misses=misses,
+    )

--- a/scripts/discover_ciks.py
+++ b/scripts/discover_ciks.py
@@ -1,0 +1,42 @@
+"""Run the CIK discovery sweep against SEC's company_tickers.json.
+
+Usage::
+
+    uv run python scripts/discover_ciks.py
+
+Walks every no-CIK instrument, looks up the ticker in SEC's curated
+map, writes ``external_identifiers`` rows for matches. Idempotent —
+re-running produces the same set of inserts (zero on the second
+pass).
+
+Operator audit 2026-05-03 found 7,281 of 12,379 instruments had no
+SEC CIK row. This script is the cleanup. After it lands, the SEC
+ingesters (13F, Form 4, fundamentals etc.) reach a wider universe
+on every subsequent run.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.services.cik_discovery import discover_ciks
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    with psycopg.connect(settings.database_url) as conn:
+        result = discover_ciks(conn)
+    print(
+        f"CIK discovery complete: scanned={result.instruments_scanned} "
+        f"matches={result.matches_found} inserted={result.rows_inserted} "
+        f"misses={result.misses}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cik_discovery.py
+++ b/tests/test_cik_discovery.py
@@ -1,0 +1,184 @@
+"""Tests for the CIK discovery sweep (#794-derived follow-up).
+
+Pins the contract: idempotent, no-clobber-on-conflict, fold over
+no-CIK instruments only, miss-counter accurate.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.cik_discovery import (
+    TickerMapEntry,
+    discover_ciks,
+    upsert_cik,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_existing_cik(conn: psycopg.Connection[tuple], *, iid: int, cik_padded: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (
+            instrument_id, provider, identifier_type, identifier_value, is_primary
+        ) VALUES (%s, 'sec', 'cik', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        """,
+        (iid, cik_padded),
+    )
+
+
+def test_discover_inserts_cik_for_no_cik_instrument(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_001, symbol="AAPL")
+    conn.commit()
+    fake_map = {
+        "AAPL": TickerMapEntry(cik_padded="0000320193", ticker="AAPL", title="Apple Inc."),
+    }
+
+    result = discover_ciks(conn, ticker_map=fake_map)
+
+    assert result.instruments_scanned == 1
+    assert result.matches_found == 1
+    assert result.rows_inserted == 1
+    assert result.misses == 0
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT identifier_value FROM external_identifiers
+            WHERE instrument_id = %s AND provider = 'sec' AND identifier_type = 'cik'
+            """,
+            (900_001,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "0000320193"
+
+
+def test_discover_skips_instruments_with_existing_cik(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Instruments that already have a CIK row are not in the
+    discovery cohort. The sweep walks only ``no_cik`` instruments
+    via the LEFT JOIN filter."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_002, symbol="MSFT")
+    _seed_existing_cik(conn, iid=900_002, cik_padded="0000789019")
+    conn.commit()
+    fake_map = {
+        "MSFT": TickerMapEntry(cik_padded="9999999999", ticker="MSFT", title="Spoof"),
+    }
+
+    result = discover_ciks(conn, ticker_map=fake_map)
+
+    # MSFT already has a CIK → not in the no-CIK cohort → not scanned.
+    assert result.instruments_scanned == 0
+
+    # Existing CIK preserved.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT identifier_value FROM external_identifiers WHERE instrument_id = %s",
+            (900_002,),
+        )
+        rows = cur.fetchall()
+    assert [r[0] for r in rows] == ["0000789019"]
+
+
+def test_discover_records_misses_when_ticker_not_in_map(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_003, symbol="NOTREAL")
+    conn.commit()
+
+    result = discover_ciks(conn, ticker_map={})
+
+    assert result.instruments_scanned == 1
+    assert result.matches_found == 0
+    assert result.misses == 1
+    assert result.rows_inserted == 0
+
+
+def test_discover_is_idempotent(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A second pass with the same map produces zero new inserts —
+    the inserted CIK from the first pass means the instrument is no
+    longer in the no-CIK cohort."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_004, symbol="GME")
+    conn.commit()
+    fake_map = {
+        "GME": TickerMapEntry(cik_padded="0001326380", ticker="GME", title="GameStop Corp."),
+    }
+
+    first = discover_ciks(conn, ticker_map=fake_map)
+    second = discover_ciks(conn, ticker_map=fake_map)
+
+    assert first.rows_inserted == 1
+    assert second.instruments_scanned == 0
+    assert second.rows_inserted == 0
+
+
+def test_upsert_cik_does_not_clobber_existing_row(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Operator-curated CIK takes precedence over discovery match —
+    ON CONFLICT DO NOTHING preserves the prior row."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_005, symbol="OVERRIDE")
+    _seed_existing_cik(conn, iid=900_005, cik_padded="0000111111")
+    conn.commit()
+
+    inserted = upsert_cik(
+        conn,
+        instrument_id=900_005,
+        cik_padded="0000999999",
+        ticker="OVERRIDE",
+    )
+    conn.commit()
+
+    assert inserted is False
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT identifier_value FROM external_identifiers WHERE instrument_id = %s AND identifier_type = 'cik'",
+            (900_005,),
+        )
+        rows = cur.fetchall()
+    assert [r[0] for r in rows] == ["0000111111"]
+
+
+def test_discover_handles_case_insensitive_ticker_lookup(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Instrument ``symbol`` may be stored mixed-case; the SEC map
+    is uppercase. Lookup must normalise."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_006, symbol="Goog")
+    conn.commit()
+    fake_map = {
+        "GOOG": TickerMapEntry(cik_padded="0001652044", ticker="GOOG", title="Alphabet Inc."),
+    }
+
+    result = discover_ciks(conn, ticker_map=fake_map)
+
+    assert result.matches_found == 1
+    assert result.rows_inserted == 1


### PR DESCRIPTION
## Summary

Operator audit 2026-05-03: **7,281 of 12,379 instruments (59%) have no SEC CIK** in \`external_identifiers\`. Without a CIK they're invisible to every SEC ingester. This PR ships the first-pass discovery against SEC's curated \`company_tickers.json\` (~10k entries).

Live sweep on dev DB:
- Scanned: 7,285
- Matches in SEC map: 84
- New CIK rows inserted: 46
- Misses: 7,201

## Why misses dominate

\`company_tickers.json\` only covers operating issuers' common-stock tickers. The misses are:
- ETFs (file with SEC under different CIKs; appear in \`company_tickers_exchange.json\` not the canonical map)
- Foreign issuers without ADRs
- Preferreds / warrants (separate ticker from common stock)
- Delisted / synthetic listings

Future PRs add: ETF map ingestion, ADR resolver, manual operator override surface.

## Test plan

- [x] 6 cases pinning the contract: match-and-insert, skip-existing-CIK, miss counter, idempotency, no-clobber-on-conflict, case-insensitive lookup.
- [x] Live sweep against dev DB succeeded — 46 new instruments now have SEC ingest paths.
- [x] All 4 local gates pass.

## Conflict handling

Two unique constraints on \`external_identifiers\`:
- \`uq_external_identifiers_primary\` (partial on \`(instrument_id, provider, type) WHERE is_primary\`) — pre-checked before INSERT
- \`uq_external_identifiers_provider_value\` — caught with \`ON CONFLICT DO NOTHING\`

Both no-op rather than override. Operator-curated rows take precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)