### PR TITLE
feat: reconciliation spot-check framework + first check

### DIFF
--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -1,0 +1,545 @@
+"""Reconciliation framework — spot-check stored values vs live SEC.
+
+Operator audit 2026-05-03 made the case for a self-healing layer:
+the system should be able to know when something isn't right and
+flag it without operator hand-curation. This module is the
+mechanism.
+
+Contract: ``run_spot_check(conn, sample_size=N)`` picks N random
+instruments, runs every registered check against them, logs
+findings to ``data_reconciliation_findings``. The check registry
+lives in this module — adding a new check is two lines (function +
+register call).
+
+This PR ships the framework + ONE check
+(``shares_outstanding_freshness``). More checks land as follow-ups
+once the framework + first check have shipped and proven the
+contract.
+
+The framework is operator-runnable today:
+
+    uv run python scripts/run_reconciliation.py --sample-size 25
+
+Surfaces on the ingest-health page in a follow-up PR.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import urllib.request
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Stored ``as_of_date`` older than this triggers a freshness finding
+# even when the value still matches SEC's latest. SEC issuers refresh
+# at least once per quarter via 10-Q; >180 days stale means we
+# missed at least one filing.
+_STALENESS_THRESHOLD = timedelta(days=180)
+
+
+Severity = Literal["info", "warning", "critical"]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One drift finding from a single check on a single instrument."""
+
+    check_name: str
+    severity: Severity
+    summary: str
+    expected: str | None = None
+    observed: str | None = None
+    source_url: str | None = None
+
+
+@dataclass(frozen=True)
+class InstrumentSubject:
+    """Per-instrument context passed to every check. Pre-resolved so
+    each check doesn't repeat the lookups."""
+
+    instrument_id: int
+    symbol: str
+    cik: str | None  # 10-digit padded; None when no SEC mapping
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Per-check, per-instrument result. ``findings`` is empty when
+    the check passed cleanly."""
+
+    instrument_id: int
+    check_name: str
+    findings: tuple[Finding, ...]
+
+
+@dataclass(frozen=True)
+class ReconciliationSummary:
+    run_id: int
+    instruments_checked: int
+    findings_emitted: int
+
+
+# A check function takes the per-instrument subject and returns a
+# tuple of findings. Empty tuple = clean pass. The framework wraps
+# every call in a try/except so a single misbehaving check doesn't
+# abort the whole sweep.
+CheckFn = Callable[[psycopg.Connection[Any], InstrumentSubject], tuple[Finding, ...]]
+
+
+_REGISTRY: dict[str, CheckFn] = {}
+
+
+def register_check(name: str, fn: CheckFn) -> None:
+    """Register a check function under ``name``. Idempotent — re-
+    registering with the same name overwrites the prior function.
+    """
+    _REGISTRY[name] = fn
+
+
+def registered_checks() -> dict[str, CheckFn]:
+    """Snapshot of the registry for tests + introspection."""
+    return dict(_REGISTRY)
+
+
+# ---------------------------------------------------------------------------
+# Check 1: shares_outstanding freshness vs SEC submissions.json
+# ---------------------------------------------------------------------------
+
+
+def check_shares_outstanding_freshness(
+    conn: psycopg.Connection[Any],
+    subject: InstrumentSubject,
+) -> tuple[Finding, ...]:
+    """Compare our stored ``instrument_share_count_latest.latest_shares``
+    against the latest XBRL DEI value SEC publishes for the same CIK.
+
+    Drift sources:
+
+      * Stale ingest — our value lags SEC's by > 1 quarter.
+      * Parse bug — our value differs by > 0.1% from SEC's.
+      * No CIK — instrument can't be reconciled at all
+        (info-severity).
+
+    Source: ``https://data.sec.gov/submissions/CIK{cik}.json`` is
+    free-form metadata; the share count itself comes from
+    ``https://data.sec.gov/api/xbrl/companyfacts/CIK{cik}.json`` →
+    ``facts.dei.EntityCommonStockSharesOutstanding`` (latest).
+    """
+    if subject.cik is None:
+        return (
+            Finding(
+                check_name="shares_outstanding_freshness",
+                severity="info",
+                summary="No SEC CIK — instrument cannot be reconciled.",
+                expected=None,
+                observed=None,
+            ),
+        )
+
+    # Stored value
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT latest_shares, as_of_date
+            FROM instrument_share_count_latest
+            WHERE instrument_id = %s
+            """,
+            (subject.instrument_id,),
+        )
+        stored = cur.fetchone()
+
+    if stored is None or stored.get("latest_shares") is None:
+        return (
+            Finding(
+                check_name="shares_outstanding_freshness",
+                severity="warning",
+                summary="No stored shares_outstanding for instrument with SEC CIK.",
+                expected="non-null XBRL DEI value at SEC",
+                observed="NULL in instrument_share_count_latest",
+                source_url=_companyfacts_url(subject.cik),
+            ),
+        )
+
+    # Live SEC value
+    try:
+        sec_latest = _fetch_latest_dei_shares_outstanding(subject.cik)
+    except Exception as exc:  # noqa: BLE001 — fetch errors must not abort the sweep
+        return (
+            Finding(
+                check_name="shares_outstanding_freshness",
+                severity="info",
+                summary=f"SEC fetch failed: {type(exc).__name__}: {exc}",
+                source_url=_companyfacts_url(subject.cik),
+            ),
+        )
+
+    if sec_latest is None:
+        return ()  # SEC has no DEI value either — clean
+
+    stored_val = Decimal(stored["latest_shares"])
+    sec_val = Decimal(sec_latest)
+    findings: list[Finding] = []
+
+    # Freshness check — surface stale ingest even when the value
+    # still matches. A multi-quarter-old ``as_of_date`` means the
+    # SEC fundamentals ingester hasn't reached this instrument
+    # recently, which is a separate failure mode from value drift.
+    as_of = stored.get("as_of_date")
+    if isinstance(as_of, date):
+        age = datetime.now(UTC).date() - as_of
+        if age > _STALENESS_THRESHOLD:
+            findings.append(
+                Finding(
+                    check_name="shares_outstanding_freshness",
+                    severity="warning",
+                    summary=(f"Stored shares_outstanding is stale (as_of_date {as_of.isoformat()}, age {age.days}d)."),
+                    expected=f"as_of_date within {_STALENESS_THRESHOLD.days}d",
+                    observed=as_of.isoformat(),
+                    source_url=_companyfacts_url(subject.cik),
+                )
+            )
+
+    if stored_val == sec_val:
+        return tuple(findings)  # value clean; freshness may still have fired
+
+    # Compute drift fraction — guard divide-by-zero on stored=0.
+    if stored_val == 0:
+        drift = Decimal("999")
+    else:
+        drift = abs(sec_val - stored_val) / stored_val
+
+    if drift < Decimal("0.001"):
+        # < 0.1% drift — likely rounding / share-class slicing; clean
+        return tuple(findings)
+
+    severity: Severity
+    if drift < Decimal("0.05"):
+        severity = "warning"
+    else:
+        severity = "critical"
+
+    findings.append(
+        Finding(
+            check_name="shares_outstanding_freshness",
+            severity=severity,
+            summary=(f"Drift {drift * 100:.2f}% between stored shares_outstanding and SEC DEI latest."),
+            # Share counts are integers; the source NUMERIC(30,6)
+            # column stores them with trailing fractional zeros that
+            # would otherwise read as ``100000000.000000`` in
+            # operator triage. Cast to int for the display.
+            expected=str(int(sec_val)),
+            observed=str(int(stored_val)),
+            source_url=_companyfacts_url(subject.cik),
+        )
+    )
+    return tuple(findings)
+
+
+def _companyfacts_url(cik_padded: str) -> str:
+    return f"https://data.sec.gov/api/xbrl/companyfacts/CIK{cik_padded}.json"
+
+
+def _fetch_latest_dei_shares_outstanding(cik_padded: str) -> int | None:
+    """Walk the SEC companyfacts payload and return the latest DEI
+    ``EntityCommonStockSharesOutstanding`` value, or ``None`` when
+    the concept is absent.
+
+    Picks the row with the highest ``end`` date, tie-broken by
+    ``filed`` desc so amended filings overwrite the original.
+    Companyfacts publishes the original 10-K row alongside any
+    10-K/A re-statement under the same ``end`` date — without the
+    ``filed`` tie-break, payload order decides which one wins,
+    creating spurious drift findings.
+
+    SEC publishes multiple unit-of-measure variants for a given
+    fact; we pick the ``shares`` unit only.
+    """
+    req = urllib.request.Request(
+        _companyfacts_url(cik_padded),
+        headers={"User-Agent": settings.sec_user_agent},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 — fixed SEC URL
+        payload = json.load(resp)
+    facts = payload.get("facts", {}).get("dei", {}).get("EntityCommonStockSharesOutstanding")
+    if not isinstance(facts, dict):
+        return None
+    units = facts.get("units", {}).get("shares", [])
+    if not isinstance(units, list) or not units:
+        return None
+    latest = max(units, key=lambda u: (u.get("end") or "", u.get("filed") or ""))
+    val = latest.get("val")
+    return int(val) if val is not None else None
+
+
+register_check("shares_outstanding_freshness", check_shares_outstanding_freshness)
+
+
+# ---------------------------------------------------------------------------
+# Run orchestration
+# ---------------------------------------------------------------------------
+
+
+def _pick_subjects(
+    conn: psycopg.Connection[Any],
+    sample_size: int,
+    seed: int,
+) -> list[InstrumentSubject]:
+    """Random sample of ``sample_size`` instruments for spot-checking.
+
+    Pre-joins ``external_identifiers`` so each check has the CIK
+    already resolved. The sample is biased towards instruments WITH
+    a CIK because they're the ones a check can meaningfully run
+    against — but a fraction without CIK is included so the
+    operator sees the no-CIK gap surfaced as info findings.
+    """
+    rng = random.Random(seed)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT i.instrument_id, i.symbol, ei.identifier_value AS cik
+            FROM instruments i
+            LEFT JOIN external_identifiers ei
+                ON ei.instrument_id = i.instrument_id
+               AND ei.provider = 'sec'
+               AND ei.identifier_type = 'cik'
+               AND ei.is_primary = TRUE
+            WHERE i.symbol IS NOT NULL
+            -- ORDER BY before sampling: Postgres returns rows in
+            -- whatever physical order the planner picks. ``random.sample``
+            -- is deterministic on its INPUT order, so without a
+            -- stable ORDER BY here the same seed picks different
+            -- cohorts across runs — defeating the reproducibility
+            -- contract of ``sample_seed``.
+            ORDER BY i.instrument_id
+            """,
+        )
+        rows = cur.fetchall()
+    if not rows:
+        return []
+    sample = rng.sample(rows, k=min(sample_size, len(rows)))
+    return [
+        InstrumentSubject(
+            instrument_id=int(r["instrument_id"]),
+            symbol=str(r["symbol"]),
+            cik=(str(r["cik"]) if r.get("cik") is not None else None),
+        )
+        for r in sample
+    ]
+
+
+def _start_run(
+    conn: psycopg.Connection[Any],
+    sample_seed: int,
+    triggered_by: Literal["system", "operator", "scheduler"],
+) -> int:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO data_reconciliation_runs (
+                sample_seed, triggered_by
+            ) VALUES (%s, %s)
+            RETURNING run_id
+            """,
+            (sample_seed, triggered_by),
+        )
+        row = cur.fetchone()
+    return int(row["run_id"])  # type: ignore[index]
+
+
+def _finalise_run(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    instruments_checked: int,
+    findings_emitted: int,
+    error: str | None,
+) -> None:
+    status: Literal["success", "failed"] = "failed" if error else "success"
+    conn.execute(
+        """
+        UPDATE data_reconciliation_runs
+        SET finished_at = NOW(),
+            status = %s,
+            instruments_checked = %s,
+            findings_emitted = %s,
+            error = %s
+        WHERE run_id = %s
+        """,
+        (status, instruments_checked, findings_emitted, error, run_id),
+    )
+
+
+def _persist_finding(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    instrument_id: int,
+    finding: Finding,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO data_reconciliation_findings (
+            run_id, instrument_id, check_name, severity, summary,
+            expected, observed, source_url
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            run_id,
+            instrument_id,
+            finding.check_name,
+            finding.severity,
+            finding.summary,
+            finding.expected,
+            finding.observed,
+            finding.source_url,
+        ),
+    )
+
+
+def run_spot_check(
+    conn: psycopg.Connection[Any],
+    *,
+    sample_size: int = 25,
+    sample_seed: int | None = None,
+    triggered_by: Literal["system", "operator", "scheduler"] = "operator",
+) -> ReconciliationSummary:
+    """Execute every registered check against ``sample_size`` random
+    instruments. Returns a summary; findings are persisted to
+    ``data_reconciliation_findings``.
+
+    ``sample_seed`` is injectable — passing the same seed on a
+    re-run reproduces the same instrument selection, useful for
+    "is this finding still there?" triage.
+    """
+    seed = sample_seed if sample_seed is not None else random.randrange(2**63 - 1)
+    run_id = _start_run(conn, seed, triggered_by)
+    conn.commit()
+
+    # Snapshot the registry once per run. A concurrent
+    # ``register_check`` call after this point cannot make later
+    # subjects in the same run execute a different check set than
+    # earlier ones — the reproducibility contract of ``sample_seed``
+    # extends to "same seed + same code revision = same set of
+    # checks run".
+    checks = list(registered_checks().items())
+
+    findings_count = 0
+    instruments_count = 0
+    error: str | None = None
+    try:
+        subjects = _pick_subjects(conn, sample_size, seed)
+        for subject in subjects:
+            instruments_count += 1
+            for check_name, check_fn in checks:
+                try:
+                    findings = check_fn(conn, subject)
+                except Exception as exc:  # noqa: BLE001 — per-check crash must not abort
+                    logger.exception(
+                        "reconciliation: check %s raised on instrument %s",
+                        check_name,
+                        subject.instrument_id,
+                    )
+                    findings = (
+                        Finding(
+                            check_name=check_name,
+                            severity="info",
+                            summary=f"Check raised: {type(exc).__name__}: {exc}",
+                        ),
+                    )
+                for finding in findings:
+                    # Commit per-finding so a later constraint
+                    # violation can't roll back earlier successful
+                    # inserts in the same subject. ``findings_count``
+                    # then matches what's actually persisted in
+                    # ``data_reconciliation_findings``.
+                    _persist_finding(
+                        conn,
+                        run_id=run_id,
+                        instrument_id=subject.instrument_id,
+                        finding=finding,
+                    )
+                    conn.commit()
+                    findings_count += 1
+    except Exception as exc:  # noqa: BLE001 — record the error then re-raise
+        error = f"{type(exc).__name__}: {exc}"
+        logger.exception("reconciliation: spot-check sweep raised")
+        raise
+    finally:
+        # Roll back any aborted transaction state before the UPDATE.
+        # If a prior _persist_finding raised (e.g., constraint
+        # violation, FK race when an instrument got deleted
+        # mid-sweep), the connection is in InFailedSqlTransaction
+        # state and the finalise UPDATE would itself raise — leaving
+        # the run row stuck in 'running' forever. Roll back to a
+        # clean transaction first; the original exception is already
+        # captured in ``error``.
+        try:
+            conn.rollback()
+        except Exception:  # noqa: BLE001 — defensive; rollback should not raise
+            logger.exception("reconciliation: rollback before finalise failed")
+        try:
+            _finalise_run(
+                conn,
+                run_id=run_id,
+                instruments_checked=instruments_count,
+                findings_emitted=findings_count,
+                error=error,
+            )
+            conn.commit()
+        except Exception:
+            logger.exception("reconciliation: finalise UPDATE failed")
+            # Suppress the finalise error only when there's already
+            # an exception in flight — otherwise re-raise so the
+            # caller sees a real signal that the run row is in an
+            # unfinalised state.
+            if error is None:
+                raise
+
+    return ReconciliationSummary(
+        run_id=run_id,
+        instruments_checked=instruments_count,
+        findings_emitted=findings_count,
+    )
+
+
+def iter_recent_findings(
+    conn: psycopg.Connection[Any],
+    *,
+    limit: int = 100,
+    severity_min: Severity | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield recent findings for the operator surface. ``severity_min``
+    filters to findings AT OR ABOVE the named severity (info →
+    warning → critical)."""
+    where = []
+    params: list[Any] = []
+    if severity_min == "warning":
+        where.append("severity IN ('warning', 'critical')")
+    elif severity_min == "critical":
+        where.append("severity = 'critical'")
+    where_sql = ("WHERE " + " AND ".join(where)) if where else ""
+    params.append(limit)
+    sql = f"""
+        SELECT finding_id, run_id, instrument_id, check_name, severity,
+               summary, expected, observed, source_url, fetched_at
+        FROM data_reconciliation_findings
+        {where_sql}
+        ORDER BY fetched_at DESC, finding_id DESC
+        LIMIT %s
+    """  # noqa: S608 — where built from closed enum
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, params)  # type: ignore[arg-type]
+        for row in cur.fetchall():
+            yield dict(row)

--- a/scripts/run_reconciliation.py
+++ b/scripts/run_reconciliation.py
@@ -1,0 +1,72 @@
+"""Operator CLI — run the reconciliation spot-check.
+
+Usage::
+
+    uv run python scripts/run_reconciliation.py --sample-size 25
+    uv run python scripts/run_reconciliation.py --sample-size 25 --seed 1234
+
+Picks N random instruments and runs every registered reconciliation
+check against them, comparing what we have in SQL against live SEC
+EDGAR. Drift findings land in ``data_reconciliation_findings`` for
+operator triage.
+
+``--seed`` reproduces the exact instrument cohort from a prior run —
+useful for "is that finding still there?" workflows after a fix.
+
+Operator audit 2026-05-03 made the case for a self-healing layer:
+the system should know when something isn't right and flag it
+without operator hand-curation. This is the mechanism. UI surface
+on the ingest-health page lands as a follow-up PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.services.reconciliation import run_spot_check
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run a reconciliation spot-check.")
+    p.add_argument(
+        "--sample-size",
+        type=int,
+        default=25,
+        help="Number of random instruments to spot-check (default 25).",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Reproducible seed for the instrument selection. Omit to pick a fresh random cohort.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    with psycopg.connect(settings.database_url) as conn:
+        summary = run_spot_check(
+            conn,
+            sample_size=args.sample_size,
+            sample_seed=args.seed,
+            triggered_by="operator",
+        )
+
+    print(
+        f"Reconciliation run {summary.run_id}: "
+        f"checked={summary.instruments_checked} "
+        f"findings={summary.findings_emitted}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sql/108_data_reconciliation.sql
+++ b/sql/108_data_reconciliation.sql
@@ -1,0 +1,95 @@
+-- 108_data_reconciliation.sql
+--
+-- Reconciliation framework — operator-driven spot-check of stored
+-- values vs live SEC EDGAR (operator audit 2026-05-03).
+--
+-- The framework runs N random instruments through a set of
+-- registered checks, comparing what we have in SQL against what SEC
+-- says right now. Drift findings land in
+-- ``data_reconciliation_findings`` so the operator can triage in
+-- one place rather than spot-checking by hand. Surfaces on the
+-- ingest-health page (follow-up PR).
+--
+-- Schema decisions:
+--
+--   * ``data_reconciliation_runs`` is the per-run audit. One row
+--     per ``run_spot_check`` invocation. Mirrors the
+--     ``data_ingestion_runs`` shape so operator tooling can JOIN
+--     them with familiar semantics.
+--   * ``data_reconciliation_findings`` is per-(run, instrument,
+--     check) drift finding. ``severity`` is a CHECK-constrained
+--     enum so a typo can't smuggle a quietly-mis-classified row.
+--   * ``check_name`` is free-text — a new check ships under its own
+--     name without a schema migration. The check registry lives in
+--     ``app.services.reconciliation``; if an operator sees a
+--     finding under an unfamiliar check_name they can grep the
+--     code.
+--   * Both tables include ``fetched_at`` provenance so the operator
+--     can answer "is this finding still current?" without
+--     re-running the check.
+--
+-- Out of scope: scheduler entry, operator UI surface. Both are
+-- separate PRs once the framework + first checks are shipped.
+
+CREATE TABLE IF NOT EXISTS data_reconciliation_runs (
+    run_id              BIGSERIAL PRIMARY KEY,
+    started_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at         TIMESTAMPTZ,
+    status              TEXT NOT NULL DEFAULT 'running'
+        CHECK (status IN ('running', 'success', 'failed')),
+    instruments_checked INTEGER NOT NULL DEFAULT 0,
+    findings_emitted    INTEGER NOT NULL DEFAULT 0,
+    -- ``sample_seed`` records the random seed used to pick the
+    -- instrument cohort so re-running the same seed reproduces the
+    -- same selection. Useful for "is this finding still there?"
+    -- triage workflows.
+    sample_seed         BIGINT,
+    error               TEXT,
+    triggered_by        TEXT NOT NULL DEFAULT 'system'
+        CHECK (triggered_by IN ('system', 'operator', 'scheduler'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_data_reconciliation_runs_started
+    ON data_reconciliation_runs (started_at DESC);
+
+
+CREATE TABLE IF NOT EXISTS data_reconciliation_findings (
+    finding_id      BIGSERIAL PRIMARY KEY,
+    run_id          BIGINT NOT NULL
+        REFERENCES data_reconciliation_runs(run_id) ON DELETE CASCADE,
+    instrument_id   BIGINT NOT NULL
+        REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    check_name      TEXT NOT NULL,
+    severity        TEXT NOT NULL
+        CHECK (severity IN ('info', 'warning', 'critical')),
+    summary         TEXT NOT NULL,
+    expected        TEXT,
+    observed        TEXT,
+    -- Optional URL to the SEC source so the operator can verify on
+    -- the regulator's site without re-running anything.
+    source_url      TEXT,
+    fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_data_reconciliation_findings_run
+    ON data_reconciliation_findings (run_id, severity);
+
+CREATE INDEX IF NOT EXISTS idx_data_reconciliation_findings_instrument
+    ON data_reconciliation_findings (instrument_id, fetched_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_data_reconciliation_findings_check
+    ON data_reconciliation_findings (check_name, fetched_at DESC);
+
+
+COMMENT ON TABLE data_reconciliation_runs IS
+    'Per-run audit for the reconciliation spot-check framework. '
+    'One row per run_spot_check invocation. Mirrors '
+    'data_ingestion_runs for familiar operator-tool joins. '
+    'sample_seed reproduces the instrument selection if needed.';
+
+COMMENT ON TABLE data_reconciliation_findings IS
+    'Per-(run, instrument, check) drift finding. severity is a '
+    'CHECK-constrained enum (info / warning / critical). check_name '
+    'is free-text; the registry lives in '
+    'app.services.reconciliation. Operator triage point — surfaces '
+    'on the ingest-health page in a follow-up PR.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -151,6 +151,11 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # key and the typed-table rows JOIN back via that column rather
     # than a row-id FK. Listed for deterministic per-test cleanup.
     "filing_raw_documents",
+    # Reconciliation framework (operator audit follow-up). Findings FK
+    # into runs which FK into instruments — listed child-to-parent
+    # so the truncation order respects the FK tree.
+    "data_reconciliation_findings",
+    "data_reconciliation_runs",
     "decision_audit",  # #315 Phase 3 alerts
     "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)
     "operators",  # #315 Phase 3 alerts (cursor column)

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,0 +1,733 @@
+"""Tests for the reconciliation spot-check framework.
+
+Pins the contract:
+
+  * Registry: ``register_check`` is idempotent / overwrite-on-name.
+  * Run lifecycle: ``run_spot_check`` opens + closes a row in
+    ``data_reconciliation_runs`` and persists findings into
+    ``data_reconciliation_findings``.
+  * Failure isolation: a single check raising must not abort the
+    sweep.
+  * Severity classification: ``shares_outstanding_freshness``
+    classifies drift at the documented thresholds (clean / info /
+    warning / critical).
+  * Operator surface: ``iter_recent_findings`` filters by severity.
+
+The shares-outstanding check fetches from SEC; tests inject a fake
+fetch via ``monkeypatch`` so they run without network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services import reconciliation
+from app.services.reconciliation import (
+    Finding,
+    InstrumentSubject,
+    check_shares_outstanding_freshness,
+    iter_recent_findings,
+    register_check,
+    registered_checks,
+    run_spot_check,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(
+    conn: psycopg.Connection[tuple],
+    *,
+    iid: int,
+    symbol: str,
+    cik: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+    if cik is not None:
+        conn.execute(
+            """
+            INSERT INTO external_identifiers (
+                instrument_id, provider, identifier_type, identifier_value, is_primary
+            ) VALUES (%s, 'sec', 'cik', %s, TRUE)
+            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            """,
+            (iid, cik),
+        )
+
+
+def _seed_share_count(
+    conn: psycopg.Connection[tuple],
+    *,
+    iid: int,
+    shares: int,
+    period_end: str = "2026-03-31",
+    accession: str = "0000000000-26-000001",
+) -> None:
+    """Seed an ``EntityCommonStockSharesOutstanding`` fact so that
+    ``instrument_share_count_latest`` (the view) returns ``shares``
+    for the instrument."""
+    conn.execute(
+        """
+        INSERT INTO financial_facts_raw (
+            instrument_id, taxonomy, concept, unit, period_end,
+            val, accession_number, form_type, filed_date
+        ) VALUES (%s, 'dei', 'EntityCommonStockSharesOutstanding',
+                  'shares', %s, %s, %s, '10-K', %s)
+        """,
+        (iid, period_end, shares, accession, period_end),
+    )
+
+
+@pytest.fixture
+def isolated_registry() -> Iterator[None]:
+    """Snapshot + restore the global check registry around each test
+    so a test that registers a custom check doesn't leak into the
+    sweep run by the next test."""
+    saved = registered_checks()
+    try:
+        yield
+    finally:
+        reconciliation._REGISTRY.clear()
+        for name, fn in saved.items():
+            register_check(name, fn)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_register_check_overwrites_on_same_name(isolated_registry: None) -> None:
+    def first(_conn: object, _subj: object) -> tuple[Finding, ...]:
+        return ()
+
+    def second(_conn: object, _subj: object) -> tuple[Finding, ...]:
+        return ()
+
+    register_check("dup_name", first)  # type: ignore[arg-type]
+    register_check("dup_name", second)  # type: ignore[arg-type]
+
+    assert registered_checks()["dup_name"] is second
+
+
+# ---------------------------------------------------------------------------
+# Shares-outstanding check
+# ---------------------------------------------------------------------------
+
+
+def test_check_no_cik_emits_info_finding(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    findings = check_shares_outstanding_freshness(
+        ebull_test_conn,
+        InstrumentSubject(instrument_id=1, symbol="X", cik=None),
+    )
+    assert len(findings) == 1
+    assert findings[0].severity == "info"
+    assert "No SEC CIK" in findings[0].summary
+
+
+def test_check_no_stored_value_emits_warning(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Instrument has CIK but no XBRL row → can't compare; warn the
+    operator that the SEC ingester didn't reach this instrument."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=910_001, symbol="NOFACTS", cik="0000111222")
+    conn.commit()
+
+    # Network must not be touched — early return path.
+    monkeypatch.setattr(
+        reconciliation,
+        "_fetch_latest_dei_shares_outstanding",
+        lambda _cik: pytest.fail("SEC fetch must not run when stored value is missing"),
+    )
+
+    findings = check_shares_outstanding_freshness(
+        conn,
+        InstrumentSubject(instrument_id=910_001, symbol="NOFACTS", cik="0000111222"),
+    )
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert "No stored shares_outstanding" in findings[0].summary
+
+
+def test_check_clean_when_stored_matches_sec(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=910_002, symbol="MATCH", cik="0000111223")
+    _seed_share_count(conn, iid=910_002, shares=100_000_000)
+    conn.commit()
+
+    monkeypatch.setattr(
+        reconciliation,
+        "_fetch_latest_dei_shares_outstanding",
+        lambda _cik: 100_000_000,
+    )
+
+    findings = check_shares_outstanding_freshness(
+        conn,
+        InstrumentSubject(instrument_id=910_002, symbol="MATCH", cik="0000111223"),
+    )
+    assert findings == ()
+
+
+def test_check_below_threshold_drift_treated_as_clean(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """< 0.1% drift is rounding / share-class slicing — clean."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=910_003, symbol="ROUND", cik="0000111224")
+    _seed_share_count(conn, iid=910_003, shares=100_000_000)
+    conn.commit()
+
+    # 0.05% drift
+    monkeypatch.setattr(
+        reconciliation,
+        "_fetch_latest_dei_shares_outstanding",
+        lambda _cik: 100_050_000,
+    )
+
+    findings = check_shares_outstanding_freshness(
+        conn,
+        InstrumentSubject(instrument_id=910_003, symbol="ROUND", cik="0000111224"),
+    )
+    assert findings == ()
+
+
+def test_check_classifies_warning_drift(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=910_004, symbol="WARN", cik="0000111225")
+    _seed_share_count(conn, iid=910_004, shares=100_000_000)
+    conn.commit()
+
+    # 1% drift
+    monkeypatch.setattr(
+        reconciliation,
+        "_fetch_latest_dei_shares_outstanding",
+        lambda _cik: 101_000_000,
+    )
+
+    findings = check_shares_outstanding_freshness(
+        conn,
+        InstrumentSubject(instrument_id=910_004, symbol="WARN", cik="0000111225"),
+    )
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert findings[0].expected == "101000000"
+    assert findings[0].observed == "100000000"
+
+
+def test_check_classifies_critical_drift(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=910_005, symbol="CRIT", cik="0000111226")
+    _seed_share_count(conn, iid=910_005, shares=100_000_000)
+    conn.commit()
+
+    # 10% drift
+    monkeypatch.setattr(
+        reconciliation,
+        "_fetch_latest_dei_shares_outstanding",
+        lambda _cik: 110_000_000,
+    )
+
+    findings = check_shares_outstanding_freshness(
+        conn,
+        InstrumentSubject(instrument_id=910_005, symbol="CRIT", cik="0000111226"),
+    )
+    assert len(findings) == 1
+    assert findings[0].severity == "critical"
+
+
+def test_check_fetch_failure_emits_info_finding(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transient SEC outage shouldn't cascade into critical alerts —
+    the framework downgrades to info so operator can re-run."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=910_006, symbol="FETCHFAIL", cik="0000111227")
+    _seed_share_count(conn, iid=910_006, shares=100_000_000)
+    conn.commit()
+
+    def _boom(_cik: str) -> int | None:
+        raise RuntimeError("SEC unreachable")
+
+    monkeypatch.setattr(reconciliation, "_fetch_latest_dei_shares_outstanding", _boom)
+
+    findings = check_shares_outstanding_freshness(
+        conn,
+        InstrumentSubject(instrument_id=910_006, symbol="FETCHFAIL", cik="0000111227"),
+    )
+    assert len(findings) == 1
+    assert findings[0].severity == "info"
+    assert "SEC fetch failed" in findings[0].summary
+
+
+def test_check_clean_when_sec_has_no_dei_value(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC concept absent → not a drift signal, just no upstream
+    data to compare against. Clean."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=910_007, symbol="NOSEC", cik="0000111228")
+    _seed_share_count(conn, iid=910_007, shares=100_000_000)
+    conn.commit()
+
+    monkeypatch.setattr(
+        reconciliation,
+        "_fetch_latest_dei_shares_outstanding",
+        lambda _cik: None,
+    )
+
+    findings = check_shares_outstanding_freshness(
+        conn,
+        InstrumentSubject(instrument_id=910_007, symbol="NOSEC", cik="0000111228"),
+    )
+    assert findings == ()
+
+
+def test_check_emits_freshness_warning_when_value_clean_but_stale(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """as_of_date older than the staleness threshold is itself a
+    finding even when the stored value still matches SEC. Catches
+    the failure mode where the SEC fundamentals ingester silently
+    stopped reaching this instrument but the share count happens
+    to be unchanged."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=910_008, symbol="STALE", cik="0000111229")
+    # period_end well past the 180-day staleness threshold.
+    _seed_share_count(
+        conn,
+        iid=910_008,
+        shares=100_000_000,
+        period_end="2024-01-31",
+        accession="0000000000-24-000001",
+    )
+    conn.commit()
+
+    monkeypatch.setattr(
+        reconciliation,
+        "_fetch_latest_dei_shares_outstanding",
+        lambda _cik: 100_000_000,  # value matches; only freshness should fire
+    )
+
+    findings = check_shares_outstanding_freshness(
+        conn,
+        InstrumentSubject(instrument_id=910_008, symbol="STALE", cik="0000111229"),
+    )
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert "stale" in findings[0].summary.lower()
+
+
+def test_fetch_latest_picks_amended_filing_for_same_period(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC's companyfacts payload publishes the original filing
+    alongside any 10-K/A amendment under the same ``end`` date.
+    Without a ``filed`` tie-break, payload order decides the winner —
+    creating spurious drift findings when the amendment restates
+    the share count. The tie-break must pick the latest ``filed``."""
+    fake_payload = {
+        "facts": {
+            "dei": {
+                "EntityCommonStockSharesOutstanding": {
+                    "units": {
+                        "shares": [
+                            {"end": "2026-03-31", "filed": "2026-04-15", "val": 100},
+                            {"end": "2026-03-31", "filed": "2026-05-20", "val": 200},
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    class _Resp:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self._payload = payload
+
+        def __enter__(self) -> _Resp:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            import json as _json
+
+            return _json.dumps(self._payload).encode()
+
+    def _fake_open(_req: object, timeout: int = 30) -> _Resp:  # noqa: ARG001
+        return _Resp(fake_payload)
+
+    monkeypatch.setattr(reconciliation.urllib.request, "urlopen", _fake_open)
+    # ``json.load`` reads from the response stream; route it through
+    # the same stub.
+    monkeypatch.setattr(reconciliation.json, "load", lambda r: fake_payload)
+
+    val = reconciliation._fetch_latest_dei_shares_outstanding("0000999999")
+
+    assert val == 200  # amendment wins on filed-desc tie-break
+
+
+def test_run_spot_check_findings_count_matches_persisted_rows(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """A check that emits a valid finding followed by an invalid one
+    must NOT roll back the valid finding. ``findings_emitted`` on the
+    run row must match the actual persisted row count — no orphaned
+    accounting where the run says N findings but the table has M < N."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=920_030, symbol="MIXED", cik=None)
+    conn.commit()
+
+    reconciliation._REGISTRY.clear()
+
+    def emit_one_good_one_bad(
+        _conn: psycopg.Connection[tuple],
+        _subj: InstrumentSubject,
+    ) -> tuple[Finding, ...]:
+        return (
+            Finding(check_name="mix", severity="info", summary="good"),
+            Finding(
+                check_name="mix",
+                severity="not_a_severity",  # type: ignore[arg-type]
+                summary="bad",
+            ),
+        )
+
+    register_check("emit_one_good_one_bad", emit_one_good_one_bad)  # type: ignore[arg-type]
+
+    with pytest.raises(psycopg.errors.CheckViolation):
+        run_spot_check(conn, sample_size=1, sample_seed=137)
+
+    conn.rollback()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT findings_emitted, status FROM data_reconciliation_runs WHERE sample_seed = %s",
+            (137,),
+        )
+        run_row = cur.fetchone()
+        cur.execute(
+            "SELECT count(*) FROM data_reconciliation_findings WHERE run_id = ("
+            "SELECT run_id FROM data_reconciliation_runs WHERE sample_seed = %s)",
+            (137,),
+        )
+        persisted = cur.fetchone()
+    assert run_row is not None
+    assert persisted is not None
+    findings_emitted, status = run_row
+    persisted_count = persisted[0]
+    assert status == "failed"
+    # The valid "good" finding must survive; the invalid one must not.
+    # findings_emitted on the run row must equal what's actually persisted.
+    assert findings_emitted == persisted_count == 1
+
+
+def test_run_spot_check_uses_consistent_check_set_across_subjects(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """A concurrent ``register_check`` call mid-run must not change
+    the set of checks executed for later subjects. The registry is
+    snapshotted once per run."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=920_040, symbol="A", cik=None)
+    _seed_instrument(conn, iid=920_041, symbol="B", cik=None)
+    conn.commit()
+
+    reconciliation._REGISTRY.clear()
+
+    call_log: list[int] = []
+
+    def first_check(
+        _conn: psycopg.Connection[tuple],
+        subj: InstrumentSubject,
+    ) -> tuple[Finding, ...]:
+        call_log.append(subj.instrument_id)
+        # Mid-run mutation of the registry — should NOT affect the
+        # check set executed against the next subject.
+        register_check("late_arrival", first_check)  # type: ignore[arg-type]
+        return ()
+
+    register_check("first_check", first_check)  # type: ignore[arg-type]
+
+    summary = run_spot_check(conn, sample_size=10, sample_seed=88)
+
+    assert summary.instruments_checked == 2
+    # Each subject runs only ``first_check`` (registered at start),
+    # not the late-arrival registered mid-loop. So the call log has
+    # exactly 2 entries (1 per subject), not 4 or 3.
+    assert len(call_log) == 2
+
+
+def test_run_spot_check_finalises_when_persist_fails(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """A check that emits an invalid finding (e.g., severity not
+    matching the CHECK constraint) puts the connection into
+    InFailedSqlTransaction. The framework must roll back before
+    finalising so the run row doesn't get stuck in 'running'
+    forever."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=920_020, symbol="BADFINDING", cik=None)
+    conn.commit()
+
+    reconciliation._REGISTRY.clear()
+
+    def emit_invalid(
+        _conn: psycopg.Connection[tuple],
+        _subj: InstrumentSubject,
+    ) -> tuple[Finding, ...]:
+        # Bypass dataclass validation by constructing a Finding with
+        # a severity outside the CHECK constraint enum. The runtime
+        # type is ``str``; the constraint fires on INSERT.
+        return (
+            Finding(
+                check_name="bad",
+                severity="not_a_severity",  # type: ignore[arg-type]
+                summary="intentional bad row",
+            ),
+        )
+
+    register_check("emit_invalid", emit_invalid)  # type: ignore[arg-type]
+
+    with pytest.raises(psycopg.errors.CheckViolation):
+        run_spot_check(conn, sample_size=1, sample_seed=99)
+
+    # Reset the connection state so the post-test check can read
+    # the run row that was finalised on its own clean transaction.
+    conn.rollback()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, error FROM data_reconciliation_runs WHERE sample_seed = %s",
+            (99,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    status, err = row
+    assert status == "failed"
+    assert err is not None and "CheckViolation" in err
+
+
+# ---------------------------------------------------------------------------
+# Run orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_run_spot_check_finalises_run_with_zero_subjects(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """Empty instruments table → sweep still produces a finalised run
+    row with status=success and zero counters."""
+    conn = ebull_test_conn
+    summary = run_spot_check(conn, sample_size=10, sample_seed=1, triggered_by="operator")
+
+    assert summary.instruments_checked == 0
+    assert summary.findings_emitted == 0
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, instruments_checked, findings_emitted, sample_seed,"
+            " triggered_by FROM data_reconciliation_runs WHERE run_id = %s",
+            (summary.run_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    status, checked, emitted, seed, triggered = row
+    assert status == "success"
+    assert checked == 0
+    assert emitted == 0
+    assert seed == 1
+    assert triggered == "operator"
+
+
+def test_run_spot_check_persists_findings(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """End-to-end happy path: register a deterministic check, run the
+    sweep, observe one finding row per instrument."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=920_001, symbol="A", cik=None)
+    _seed_instrument(conn, iid=920_002, symbol="B", cik=None)
+    conn.commit()
+
+    reconciliation._REGISTRY.clear()
+
+    def always_warn(
+        _conn: psycopg.Connection[tuple],
+        subj: InstrumentSubject,
+    ) -> tuple[Finding, ...]:
+        return (
+            Finding(
+                check_name="always_warn",
+                severity="warning",
+                summary=f"synthetic warning for {subj.symbol}",
+            ),
+        )
+
+    register_check("always_warn", always_warn)  # type: ignore[arg-type]
+
+    summary = run_spot_check(conn, sample_size=10, sample_seed=42)
+
+    assert summary.instruments_checked == 2
+    assert summary.findings_emitted == 2
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT instrument_id, severity, summary FROM data_reconciliation_findings "
+            "WHERE run_id = %s ORDER BY instrument_id",
+            (summary.run_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 2
+    assert {r[0] for r in rows} == {920_001, 920_002}
+    assert all(r[1] == "warning" for r in rows)
+    assert all("synthetic warning for" in r[2] for r in rows)
+
+
+def test_run_spot_check_isolates_per_check_failure(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """A check that raises must not abort the sweep — the framework
+    downgrades the crash to an info finding so the operator sees it
+    in triage and other checks still run."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=920_010, symbol="X", cik=None)
+    conn.commit()
+
+    reconciliation._REGISTRY.clear()
+
+    def crashy(_conn: object, _subj: object) -> tuple[Finding, ...]:
+        raise ValueError("boom")
+
+    register_check("crashy", crashy)  # type: ignore[arg-type]
+
+    summary = run_spot_check(conn, sample_size=10, sample_seed=7)
+
+    assert summary.instruments_checked == 1
+    assert summary.findings_emitted == 1
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT severity, summary FROM data_reconciliation_findings WHERE run_id = %s",
+            (summary.run_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    severity, summary_text = row
+    assert severity == "info"
+    assert "Check raised" in summary_text
+    assert "ValueError" in summary_text
+
+
+def test_run_spot_check_seed_is_reproducible(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """Same ``sample_seed`` must select the same instrument cohort —
+    operator triage workflow ("is this finding still there?")
+    depends on it."""
+    conn = ebull_test_conn
+    for i in range(20):
+        _seed_instrument(conn, iid=930_000 + i, symbol=f"SEED{i}", cik=None)
+    conn.commit()
+
+    reconciliation._REGISTRY.clear()
+
+    captured: list[set[int]] = []
+
+    def capture(
+        _conn: psycopg.Connection[tuple],
+        subj: InstrumentSubject,
+    ) -> tuple[Finding, ...]:
+        captured.append({subj.instrument_id})
+        return ()
+
+    register_check("capture", capture)  # type: ignore[arg-type]
+
+    run_spot_check(conn, sample_size=5, sample_seed=12345)
+    first = {iid for s in captured for iid in s}
+    captured.clear()
+    run_spot_check(conn, sample_size=5, sample_seed=12345)
+    second = {iid for s in captured for iid in s}
+
+    assert first == second
+    assert len(first) == 5
+
+
+# ---------------------------------------------------------------------------
+# Operator surface
+# ---------------------------------------------------------------------------
+
+
+def test_iter_recent_findings_severity_filter(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """``severity_min='warning'`` excludes info; ``'critical'``
+    excludes both info and warning."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=940_001, symbol="A", cik=None)
+    conn.commit()
+
+    reconciliation._REGISTRY.clear()
+
+    def mixed(
+        _conn: psycopg.Connection[tuple],
+        _subj: InstrumentSubject,
+    ) -> tuple[Finding, ...]:
+        return (
+            Finding(check_name="mixed", severity="info", summary="i"),
+            Finding(check_name="mixed", severity="warning", summary="w"),
+            Finding(check_name="mixed", severity="critical", summary="c"),
+        )
+
+    register_check("mixed", mixed)  # type: ignore[arg-type]
+    run_spot_check(conn, sample_size=1, sample_seed=1)
+
+    all_findings = list(iter_recent_findings(conn, limit=50))
+    warn_plus = list(iter_recent_findings(conn, limit=50, severity_min="warning"))
+    crit_only = list(iter_recent_findings(conn, limit=50, severity_min="critical"))
+
+    assert len(all_findings) == 3
+    assert {r["severity"] for r in warn_plus} == {"warning", "critical"}
+    assert {r["severity"] for r in crit_only} == {"critical"}


### PR DESCRIPTION
## What
Operator audit 2026-05-03 made the case for a self-healing layer: the system should know when something isn't right and flag it without operator hand-curation. This PR ships the mechanism.

- `sql/108_data_reconciliation.sql` — `data_reconciliation_runs` + `data_reconciliation_findings`, severity CHECK enum, `sample_seed` for reproducible cohorts.
- `app/services/reconciliation.py` — registry pattern (`register_check`) + `run_spot_check` orchestrator + first check `shares_outstanding_freshness` (drift comparison vs SEC DEI `EntityCommonStockSharesOutstanding` plus separate staleness check on `as_of_date`).
- `scripts/run_reconciliation.py` — operator CLI; `--seed` reproduces the exact cohort.
- 19 integration tests pinning the contract.

## Why
Closing the audit gap raised after PR #804 ("any of this is correctly updating as we expect it to"). Drift thresholds: <0.1% clean / <5% warning / ≥5% critical. Stale `as_of_date` (>180d) emits its own warning even when value matches — catches the case where the SEC fundamentals ingester silently stops reaching an instrument but the share count is unchanged.

## Test plan
- [x] `uv run pytest tests/test_reconciliation.py` — 19/19 pass
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] Codex pre-push review (3 rounds) — all findings addressed; final pass clean
- [ ] Operator CLI smoke against dev DB after merge: `uv run python scripts/run_reconciliation.py --sample-size 10 --seed 1`

## Follow-ups (separate PRs)
- More checks (13F filer count sanity, insider filing count, filing count sanity).
- Ingest-health page surface.
- Scheduler entry (cron-driven nightly sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)