### PR TITLE
feat(#809): re-wash workflow + Form 4 wiring

### DIFF
--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -897,6 +897,7 @@ def upsert_filing(
     accession_number: str,
     primary_document_url: str,
     parsed: ParsedFiling,
+    is_rewash: bool = False,
 ) -> None:
     """Insert/refresh the filing header + filer dim + footnote bodies +
     transaction rows for one accession.
@@ -906,7 +907,13 @@ def upsert_filing(
     accession (e.g. after a parser bump) refreshes every field in
     place. The prior 056-era ``ON CONFLICT DO NOTHING`` policy would
     have frozen pre-expansion rows forever; the new parser version
-    deliberately overwrites them."""
+    deliberately overwrites them.
+
+    ``is_rewash``: when True, the conflict branch preserves the
+    original ``fetched_at`` (re-parsing a stored body isn't a fresh
+    SEC fetch and shouldn't claim to be — operator audit / recency
+    logic using ``fetched_at`` would otherwise read every re-walked
+    filing as "fetched today")."""
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -943,7 +950,9 @@ def upsert_filing(
                 primary_document_url         = EXCLUDED.primary_document_url,
                 parser_version               = EXCLUDED.parser_version,
                 is_tombstone                 = FALSE,
-                fetched_at                   = NOW()
+                fetched_at                   = CASE WHEN %s
+                                                    THEN insider_filings.fetched_at
+                                                    ELSE NOW() END
             """,
             (
                 accession_number,
@@ -962,6 +971,7 @@ def upsert_filing(
                 parsed.signature_date,
                 primary_document_url,
                 _PARSER_VERSION,
+                is_rewash,
             ),
         )
 

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -1,0 +1,329 @@
+"""Re-wash workflow — re-parse stored raw bodies under the current
+parser version.
+
+The contract: ``filing_raw_documents`` retains the source XML / HTML
+body of every ownership filing the app ingests (PR #808 + #810 +
+#811 wired this for all five kinds). When a parser bug ships, the
+fix is to re-walk every row whose ``parser_version`` is below the
+current one and re-apply the typed-table upsert against the stored
+body — no SEC re-fetch required.
+
+Operator audit 2026-05-03 motivated this: a parser bug discovery
+under the prior architecture forced a full re-fetch from SEC at
+10 req/s. With the raw store in place, re-wash is local I/O.
+
+Architecture: a per-kind ``ParserSpec`` registry binds each
+``DocumentKind`` to the parse + apply pair already shipped in the
+ingester. Re-wash dispatches by kind. ``run_rewash(conn, kind=...)``
+walks every row whose ``parser_version`` doesn't match the spec's
+``current_version`` and re-applies the parser. The raw row's
+``parser_version`` is bumped on success so a second pass is a
+no-op.
+
+Scope of this PR: framework + Form 4 wiring (the most common
+ownership filing kind, ~440k rows). Other kinds (13F, 13D/G, Form
+3, DEF 14A) wire in follow-up PRs once the framework + first kind
+have shipped and proven the contract — same rollout shape as the
+reconciliation framework.
+
+Operator runs:
+
+    uv run python scripts/rewash.py --kind form4_xml
+    uv run python scripts/rewash.py --kind form4_xml --since 2024-01-01
+    uv run python scripts/rewash.py --kind form4_xml --dry-run
+
+Re-wash is idempotent. Re-running after a successful pass is a
+no-op because every row's ``parser_version`` already matches the
+current spec.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.services import raw_filings
+from app.services.raw_filings import DocumentKind, RawFilingDocument
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ParserSpec:
+    """Per-kind parser binding for re-wash.
+
+    ``apply_fn`` does the typed-table upsert. It receives the
+    connection and the raw document; the rest of the context
+    (instrument_id, accession_number, etc.) is its responsibility
+    to derive — typically by reading the existing typed-table row
+    keyed on ``raw_doc.accession_number``.
+
+    ``apply_fn`` returns ``True`` when the upsert ran (a typed
+    row existed and was refreshed under the current parser),
+    ``False`` when the row should be skipped (e.g., no typed
+    row exists yet — re-wash is not a first-time ingester).
+    """
+
+    document_kind: DocumentKind
+    current_version: str
+    apply_fn: Callable[[psycopg.Connection[Any], RawFilingDocument], bool]
+
+
+@dataclass(frozen=True)
+class RewashResult:
+    document_kind: DocumentKind
+    rows_scanned: int
+    rows_reparsed: int
+    rows_skipped: int
+    rows_failed: int
+
+
+_REGISTRY: dict[DocumentKind, ParserSpec] = {}
+
+
+def register_parser(spec: ParserSpec) -> None:
+    """Register a parser binding. Idempotent — re-registering the
+    same kind overwrites the prior spec. Used by the per-ingester
+    modules at import time."""
+    _REGISTRY[spec.document_kind] = spec
+
+
+def registered_specs() -> dict[DocumentKind, ParserSpec]:
+    """Snapshot for tests + introspection."""
+    return dict(_REGISTRY)
+
+
+def run_rewash(
+    conn: psycopg.Connection[Any],
+    *,
+    document_kind: DocumentKind,
+    since: date | None = None,
+    dry_run: bool = False,
+    batch_size: int = 100,
+) -> RewashResult:
+    """Walk every raw row of ``document_kind`` whose parser_version
+    is not the registered spec's current_version and re-apply the
+    parser.
+
+    ``since`` filters by ``fetched_at`` to scope sweeps to recent
+    filings — useful when an operator only wants to re-wash the
+    cohort affected by a recent bug.
+
+    ``dry_run=True`` walks the rows and counts what WOULD be
+    re-parsed but writes nothing — the typed-table upsert and the
+    raw-row parser_version bump are both skipped.
+
+    Returns counts for operator triage.
+    """
+    spec = _REGISTRY.get(document_kind)
+    if spec is None:
+        raise ValueError(f"No parser registered for document_kind={document_kind!r}. Available: {sorted(_REGISTRY)}")
+
+    scanned = 0
+    reparsed = 0
+    skipped = 0
+    failed = 0
+
+    # Eager-fetch the cohort: accession_number + fetched_at only,
+    # NOT the body. The bodies can be hundreds of KB each — loading
+    # all of them up front would balloon memory. Per-accession
+    # ``read_raw`` later in the loop fetches the body for one row
+    # at a time.
+    #
+    # A server-side cursor + commit/rollback in the loop is NOT an
+    # option: PostgreSQL closes the cursor on every commit, so once
+    # the first buffered batch is exhausted the next fetch raises
+    # ``InvalidCursorName``. Eager-fetching the small identifier set
+    # sidesteps the issue entirely.
+    cohort = _fetch_cohort(
+        conn,
+        document_kind=document_kind,
+        current_version=spec.current_version,
+        batch_size=batch_size,
+    )
+
+    for accession, fetched_at in cohort:
+        scanned += 1
+        if since is not None and fetched_at.date() < since:
+            skipped += 1
+            continue
+
+        if dry_run:
+            reparsed += 1
+            continue
+
+        # Read the body NOW — separate per-accession round-trip but
+        # avoids the cursor-commit interaction.
+        raw_doc = raw_filings.read_raw(
+            conn,
+            accession_number=accession,
+            document_kind=document_kind,
+        )
+        if raw_doc is None:
+            # Row vanished between cohort scan and read (rare but
+            # possible if a parallel process truncated). Treat as
+            # skipped; the next sweep will see the new state.
+            skipped += 1
+            continue
+
+        try:
+            applied = spec.apply_fn(conn, raw_doc)
+        except Exception:  # noqa: BLE001 — single-row failure must not abort
+            logger.exception(
+                "rewash: apply_fn raised on accession=%s kind=%s",
+                accession,
+                document_kind,
+            )
+            conn.rollback()
+            failed += 1
+            continue
+
+        if not applied:
+            skipped += 1
+            conn.commit()
+            continue
+
+        # Bump the raw row's parser_version so a re-run is a no-op.
+        # Done in the same transaction as the typed-table upsert
+        # so a crash between the two leaves both unchanged — the
+        # row will be picked up again on the next sweep.
+        try:
+            _bump_parser_version(
+                conn,
+                accession_number=accession,
+                document_kind=document_kind,
+                new_version=spec.current_version,
+            )
+            conn.commit()
+        except Exception:
+            logger.exception(
+                "rewash: parser_version bump failed for accession=%s",
+                accession,
+            )
+            conn.rollback()
+            failed += 1
+            continue
+
+        reparsed += 1
+
+    return RewashResult(
+        document_kind=document_kind,
+        rows_scanned=scanned,
+        rows_reparsed=reparsed,
+        rows_skipped=skipped,
+        rows_failed=failed,
+    )
+
+
+def _fetch_cohort(
+    conn: psycopg.Connection[Any],
+    *,
+    document_kind: DocumentKind,
+    current_version: str,
+    batch_size: int,  # noqa: ARG001 — kept for API symmetry with iter_raw; eager fetch ignores
+) -> list[tuple[str, datetime]]:
+    """Return ``(accession_number, fetched_at)`` for every row of
+    ``document_kind`` whose parser_version is NOT ``current_version``.
+    Body intentionally not fetched here — keeps the cohort scan
+    cheap (~25 bytes per row × ~440k Form 4 rows = ~11 MB)."""
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        cur.execute(
+            """
+            SELECT accession_number, fetched_at
+            FROM filing_raw_documents
+            WHERE document_kind = %s
+              AND (parser_version IS NULL OR parser_version <> %s)
+            ORDER BY accession_number
+            """,
+            (document_kind, current_version),
+        )
+        return list(cur.fetchall())
+
+
+def _bump_parser_version(
+    conn: psycopg.Connection[Any],
+    *,
+    accession_number: str,
+    document_kind: DocumentKind,
+    new_version: str,
+) -> None:
+    """Update the ``parser_version`` on a single raw row WITHOUT
+    rewriting the body. Avoid ``store_raw`` (which would refresh
+    ``fetched_at``) so the operator-visible "when did SEC last
+    publish this?" timestamp is preserved."""
+    conn.execute(
+        """
+        UPDATE filing_raw_documents
+        SET parser_version = %s
+        WHERE accession_number = %s AND document_kind = %s
+        """,
+        (new_version, accession_number, document_kind),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Form 4 wiring — first kind to land
+# ---------------------------------------------------------------------------
+
+
+def _apply_form4(
+    conn: psycopg.Connection[Any],
+    raw_doc: RawFilingDocument,
+) -> bool:
+    """Re-parse the Form 4 XML body and re-apply the typed-table
+    upsert. Returns ``False`` when no existing ``insider_filings``
+    row is found (re-wash is not a first-time ingester — the
+    instrument resolution / filer seeding has to have happened on
+    the original ingest pass)."""
+    from app.services.insider_transactions import parse_form_4_xml, upsert_filing
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, primary_document_url
+            FROM insider_filings
+            WHERE accession_number = %s
+            """,
+            (raw_doc.accession_number,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return False
+    instrument_id, primary_document_url = row
+
+    parsed = parse_form_4_xml(raw_doc.payload)
+    if parsed is None:
+        # Parser miss on a body that the previous parser version
+        # presumably handled. Don't crash the sweep; treat as a
+        # skipped row so the operator can spot the regression in
+        # the result counters.
+        return False
+
+    upsert_filing(
+        conn,
+        instrument_id=int(instrument_id),
+        accession_number=raw_doc.accession_number,
+        primary_document_url=str(primary_document_url) if primary_document_url else "",
+        parsed=parsed,
+        is_rewash=True,  # preserve original fetched_at — re-wash isn't a fresh SEC fetch
+    )
+    return True
+
+
+# Registered eagerly so the registry is populated at import time —
+# matches the pattern in app.services.reconciliation. The version
+# string mirrors the constant in insider_transactions; if either
+# changes, both must change so re-wash actually re-walks.
+register_parser(
+    ParserSpec(
+        document_kind="form4_xml",
+        current_version="form4-v1",
+        apply_fn=_apply_form4,
+    )
+)

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -54,6 +54,15 @@ from app.services.raw_filings import DocumentKind, RawFilingDocument
 logger = logging.getLogger(__name__)
 
 
+class RewashParseError(Exception):
+    """A parser returned ``None`` (or otherwise rejected) a body
+    that a prior parser version produced typed-table output for.
+
+    Distinguishes a parser REGRESSION (must surface in
+    ``rows_failed``) from a legitimate "no typed row to update"
+    skip (``apply_fn`` returns ``False`` → ``rows_skipped``)."""
+
+
 @dataclass(frozen=True)
 class ParserSpec:
     """Per-kind parser binding for re-wash.
@@ -299,11 +308,16 @@ def _apply_form4(
 
     parsed = parse_form_4_xml(raw_doc.payload)
     if parsed is None:
-        # Parser miss on a body that the previous parser version
-        # presumably handled. Don't crash the sweep; treat as a
-        # skipped row so the operator can spot the regression in
-        # the result counters.
-        return False
+        # Parser regression — the previous parser presumably
+        # produced a typed-table row for this body, but the current
+        # parser returns None. RAISE rather than return False:
+        # ``apply_fn`` returning False means "no typed row to
+        # update, legitimately skip", which is operator-invisible
+        # in the failure counter. A parser regression is a real
+        # failure that must surface in ``rows_failed``.
+        raise RewashParseError(
+            f"parse_form_4_xml returned None for accession={raw_doc.accession_number} body_size={len(raw_doc.payload)}"
+        )
 
     upsert_filing(
         conn,

--- a/scripts/rewash.py
+++ b/scripts/rewash.py
@@ -1,0 +1,79 @@
+"""Operator CLI — re-wash stored raw filing bodies under the current
+parser version.
+
+Usage::
+
+    uv run python scripts/rewash.py --kind form4_xml
+    uv run python scripts/rewash.py --kind form4_xml --since 2024-01-01
+    uv run python scripts/rewash.py --kind form4_xml --dry-run
+
+Walks every ``filing_raw_documents`` row of the given kind whose
+``parser_version`` is below the current version and re-applies the
+parser against the stored body. No SEC re-fetch.
+
+Operator audit 2026-05-03 motivated this. The raw store (#808) +
+per-ingester wiring (#810/#811) make local re-wash possible — this
+CLI is the operator-visible surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date
+
+import psycopg
+
+from app.config import settings
+from app.services.raw_filings import DocumentKind
+from app.services.rewash_filings import registered_specs, run_rewash
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Re-wash stored raw filings under the current parser.")
+    p.add_argument(
+        "--kind",
+        required=True,
+        choices=sorted(registered_specs().keys()),
+        help="Document kind to re-wash (only registered kinds available).",
+    )
+    p.add_argument(
+        "--since",
+        type=date.fromisoformat,
+        default=None,
+        help="Only re-wash rows fetched on/after this date (YYYY-MM-DD).",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Walk and count without writing anything.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    kind: DocumentKind = args.kind  # argparse validated against registered keys
+
+    with psycopg.connect(settings.database_url) as conn:
+        result = run_rewash(
+            conn,
+            document_kind=kind,
+            since=args.since,
+            dry_run=args.dry_run,
+        )
+
+    print(
+        f"Rewash {kind} (dry_run={args.dry_run}): "
+        f"scanned={result.rows_scanned} "
+        f"reparsed={result.rows_reparsed} "
+        f"skipped={result.rows_skipped} "
+        f"failed={result.rows_failed}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -338,6 +338,63 @@ def test_run_rewash_since_filters_by_fetched_at(
     assert result.rows_skipped == 1
 
 
+def test_form4_apply_raises_on_parse_regression(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """``_apply_form4`` must RAISE (not return False) when the
+    parser returns None on a body that has an existing typed-row.
+    A returned False means "no typed row to update, legitimately
+    skip", which is invisible in the operator's failure counter.
+    Parser regressions must surface as rows_failed.
+
+    Regression for the WARNING from PR #818 review."""
+    conn = ebull_test_conn
+    accession = "0001234567-26-parse-regress"
+    instrument_id = 950_010
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'PR', 'Parse Regression', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO insider_filings (
+            accession_number, instrument_id, document_type,
+            primary_document_url, parser_version, is_tombstone
+        ) VALUES (%s, %s, '4', 'https://example.com/x', 1, FALSE)
+        """,
+        (accession, instrument_id),
+    )
+    _seed_raw(conn, accession=accession, kind="form4_xml", parser_version="v1")
+
+    monkeypatch.setattr(
+        "app.services.insider_transactions.parse_form_4_xml",
+        lambda _xml: None,
+    )
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="form4_xml",
+            current_version="form4-v1",
+            apply_fn=rewash_filings._apply_form4,
+        )
+    )
+
+    result = rewash_filings.run_rewash(conn, document_kind="form4_xml")
+
+    assert result.rows_scanned == 1
+    assert result.rows_failed == 1
+    assert result.rows_skipped == 0
+    assert result.rows_reparsed == 0
+
+
 def test_form4_rewash_preserves_original_fetched_at(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     isolated_registry: None,

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -1,0 +1,439 @@
+"""Tests for the re-wash workflow.
+
+Pins the contract:
+
+  * Registry: ``register_parser`` is idempotent / overwrite-on-kind.
+  * Iter filter: rows already on the spec's ``current_version``
+    are skipped — re-running after success is a no-op.
+  * Apply contract: ``apply_fn`` returning ``False`` (typed row
+    missing) skips without bumping parser_version.
+  * Failure isolation: a single accession's apply_fn raising must
+    not abort the sweep.
+  * parser_version bump happens on success → second pass scans 0
+    rows for that accession.
+  * ``since`` filter scopes the cohort.
+  * ``dry_run`` walks but writes nothing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import psycopg
+import pytest
+
+from app.services import raw_filings, rewash_filings
+from app.services.raw_filings import RawFilingDocument
+from app.services.rewash_filings import (
+    ParserSpec,
+    register_parser,
+    registered_specs,
+    run_rewash,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def isolated_registry() -> Iterator[None]:
+    """Snapshot + restore the parser registry around each test."""
+    saved = registered_specs()
+    try:
+        yield
+    finally:
+        rewash_filings._REGISTRY.clear()
+        for spec in saved.values():
+            register_parser(spec)
+
+
+def _seed_raw(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    kind: str,
+    payload: str = "<x/>",
+    parser_version: str | None = None,
+) -> None:
+    raw_filings.store_raw(
+        conn,
+        accession_number=accession,
+        document_kind=kind,  # type: ignore[arg-type]
+        payload=payload,
+        parser_version=parser_version,
+    )
+    conn.commit()
+
+
+def test_register_parser_overwrites_on_same_kind(isolated_registry: None) -> None:
+    def _apply_a(_conn: object, _doc: object) -> bool:
+        return True
+
+    def _apply_b(_conn: object, _doc: object) -> bool:
+        return True
+
+    register_parser(
+        ParserSpec(document_kind="form4_xml", current_version="v1", apply_fn=_apply_a)  # type: ignore[arg-type]
+    )
+    register_parser(
+        ParserSpec(document_kind="form4_xml", current_version="v2", apply_fn=_apply_b)  # type: ignore[arg-type]
+    )
+
+    spec = registered_specs()["form4_xml"]
+    assert spec.current_version == "v2"
+    assert spec.apply_fn is _apply_b
+
+
+def test_run_rewash_unknown_kind_raises(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    rewash_filings._REGISTRY.clear()
+    with pytest.raises(ValueError, match="No parser registered"):
+        run_rewash(ebull_test_conn, document_kind="form4_xml")
+
+
+def test_run_rewash_skips_rows_on_current_version(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """Idempotent: a row already on the spec's current_version must
+    not be re-parsed. iter_raw filters them out."""
+    conn = ebull_test_conn
+    _seed_raw(conn, accession="0000-26-1", kind="form4_xml", parser_version="v1")
+    _seed_raw(conn, accession="0000-26-2", kind="form4_xml", parser_version="v1")
+
+    rewash_filings._REGISTRY.clear()
+    apply_calls: list[str] = []
+
+    def _apply(_conn: psycopg.Connection[tuple], doc: RawFilingDocument) -> bool:
+        apply_calls.append(doc.accession_number)
+        return True
+
+    register_parser(
+        ParserSpec(document_kind="form4_xml", current_version="v1", apply_fn=_apply)  # type: ignore[arg-type]
+    )
+
+    result = run_rewash(conn, document_kind="form4_xml")
+
+    assert apply_calls == []
+    assert result.rows_scanned == 0
+    assert result.rows_reparsed == 0
+
+
+def test_run_rewash_reparses_old_versions_and_bumps(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """Rows on older parser_version (or NULL) get re-parsed and
+    their parser_version is bumped to the current spec — second
+    pass is a no-op."""
+    conn = ebull_test_conn
+    _seed_raw(conn, accession="0000-26-3", kind="form4_xml", parser_version="v1")
+    _seed_raw(conn, accession="0000-26-4", kind="form4_xml", parser_version=None)
+
+    rewash_filings._REGISTRY.clear()
+    apply_calls: list[str] = []
+
+    def _apply(_conn: psycopg.Connection[tuple], doc: RawFilingDocument) -> bool:
+        apply_calls.append(doc.accession_number)
+        return True
+
+    register_parser(
+        ParserSpec(document_kind="form4_xml", current_version="v2", apply_fn=_apply)  # type: ignore[arg-type]
+    )
+
+    first = run_rewash(conn, document_kind="form4_xml")
+    assert sorted(apply_calls) == ["0000-26-3", "0000-26-4"]
+    assert first.rows_reparsed == 2
+    assert first.rows_failed == 0
+
+    # Second pass: parser_version was bumped → iter_raw filters both rows out.
+    apply_calls.clear()
+    second = run_rewash(conn, document_kind="form4_xml")
+    assert apply_calls == []
+    assert second.rows_scanned == 0
+
+
+def test_run_rewash_apply_returning_false_is_skipped_not_bumped(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """apply_fn returning False (typed row missing) must NOT bump
+    the parser_version — the row stays eligible for the next sweep
+    so that fixing the typed-row gap and re-running picks it up."""
+    conn = ebull_test_conn
+    _seed_raw(conn, accession="0000-26-5", kind="form4_xml", parser_version="v1")
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="form4_xml",
+            current_version="v2",
+            apply_fn=lambda _c, _d: False,  # type: ignore[arg-type]
+        )
+    )
+
+    result = run_rewash(conn, document_kind="form4_xml")
+
+    assert result.rows_scanned == 1
+    assert result.rows_skipped == 1
+    assert result.rows_reparsed == 0
+
+    # parser_version untouched
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT parser_version FROM filing_raw_documents WHERE accession_number = %s",
+            ("0000-26-5",),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "v1"
+
+
+def test_run_rewash_isolates_per_row_failure(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """One accession's apply_fn raising must not abort the sweep —
+    later rows still get processed and the failure is counted."""
+    conn = ebull_test_conn
+    _seed_raw(conn, accession="0000-26-6", kind="form4_xml", parser_version="v1")
+    _seed_raw(conn, accession="0000-26-7", kind="form4_xml", parser_version="v1")
+    _seed_raw(conn, accession="0000-26-8", kind="form4_xml", parser_version="v1")
+
+    rewash_filings._REGISTRY.clear()
+
+    def _apply(_conn: psycopg.Connection[tuple], doc: RawFilingDocument) -> bool:
+        if doc.accession_number == "0000-26-7":
+            raise RuntimeError("simulated parse failure")
+        return True
+
+    register_parser(
+        ParserSpec(document_kind="form4_xml", current_version="v2", apply_fn=_apply)  # type: ignore[arg-type]
+    )
+
+    result = run_rewash(conn, document_kind="form4_xml")
+
+    assert result.rows_scanned == 3
+    assert result.rows_reparsed == 2
+    assert result.rows_failed == 1
+
+
+def test_run_rewash_dry_run_writes_nothing(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """dry_run walks the rows and counts but neither calls apply_fn
+    nor bumps parser_version — useful for sizing the cohort before
+    a real sweep."""
+    conn = ebull_test_conn
+    _seed_raw(conn, accession="0000-26-9", kind="form4_xml", parser_version="v1")
+
+    rewash_filings._REGISTRY.clear()
+    apply_calls: list[str] = []
+
+    def _apply(_conn: psycopg.Connection[tuple], doc: RawFilingDocument) -> bool:
+        apply_calls.append(doc.accession_number)
+        return True
+
+    register_parser(
+        ParserSpec(document_kind="form4_xml", current_version="v2", apply_fn=_apply)  # type: ignore[arg-type]
+    )
+
+    result = run_rewash(conn, document_kind="form4_xml", dry_run=True)
+
+    assert apply_calls == []  # apply_fn not invoked
+    assert result.rows_scanned == 1
+    assert result.rows_reparsed == 1  # counts what WOULD be re-parsed
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT parser_version FROM filing_raw_documents WHERE accession_number = %s",
+            ("0000-26-9",),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "v1"  # not bumped
+
+
+def test_run_rewash_handles_cohort_larger_than_batch_size(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """Cohort > batch_size must NOT trip the server-side-cursor +
+    per-row-commit interaction (PostgreSQL closes cursors on
+    commit). Eager-fetch of the cohort identifiers sidesteps it.
+    Regression test for the high-severity Codex finding before
+    push."""
+    conn = ebull_test_conn
+    cohort_size = 105  # > default batch_size=100
+    for i in range(cohort_size):
+        _seed_raw(
+            conn,
+            accession=f"0000-26-cohort-{i:03d}",
+            kind="form4_xml",
+            parser_version="v1",
+        )
+
+    rewash_filings._REGISTRY.clear()
+    seen: list[str] = []
+
+    def _apply(_conn: psycopg.Connection[tuple], doc: RawFilingDocument) -> bool:
+        seen.append(doc.accession_number)
+        return True
+
+    register_parser(
+        ParserSpec(document_kind="form4_xml", current_version="v2", apply_fn=_apply)  # type: ignore[arg-type]
+    )
+
+    result = run_rewash(conn, document_kind="form4_xml", batch_size=10)
+
+    assert result.rows_scanned == cohort_size
+    assert result.rows_reparsed == cohort_size
+    assert result.rows_failed == 0
+    assert len(seen) == cohort_size  # every accession reached apply_fn
+
+
+def test_run_rewash_since_filters_by_fetched_at(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """``since`` scopes the sweep to rows fetched on/after the
+    cutoff date — operator only re-washes the cohort that a recent
+    bug touched."""
+    conn = ebull_test_conn
+    _seed_raw(conn, accession="0000-26-10", kind="form4_xml", parser_version="v1")
+    _seed_raw(conn, accession="0000-26-11", kind="form4_xml", parser_version="v1")
+
+    # Backdate one row well before the cutoff.
+    conn.execute(
+        """
+        UPDATE filing_raw_documents
+        SET fetched_at = %s
+        WHERE accession_number = %s
+        """,
+        (datetime.now(UTC) - timedelta(days=400), "0000-26-10"),
+    )
+    conn.commit()
+
+    rewash_filings._REGISTRY.clear()
+    apply_calls: list[str] = []
+
+    def _apply(_conn: psycopg.Connection[tuple], doc: RawFilingDocument) -> bool:
+        apply_calls.append(doc.accession_number)
+        return True
+
+    register_parser(
+        ParserSpec(document_kind="form4_xml", current_version="v2", apply_fn=_apply)  # type: ignore[arg-type]
+    )
+
+    cutoff = (datetime.now(UTC) - timedelta(days=30)).date()
+    result = run_rewash(conn, document_kind="form4_xml", since=cutoff)
+
+    assert apply_calls == ["0000-26-11"]  # backdated row skipped
+    assert result.rows_scanned == 2
+    assert result.rows_reparsed == 1
+    assert result.rows_skipped == 1
+
+
+def test_form4_rewash_preserves_original_fetched_at(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """Form 4 re-wash must NOT bump ``insider_filings.fetched_at``
+    (it isn't a fresh SEC fetch; the body comes from the local raw
+    store). Audit / recency logic depends on fetched_at meaning
+    "when SEC last published this", not "when we last re-parsed
+    it". Regression test for the medium-severity Codex finding."""
+    from app.services.insider_transactions import (
+        ParsedFiler,
+        ParsedFiling,
+        upsert_filing,
+    )
+
+    conn = ebull_test_conn
+    accession = "0001234567-26-rewash-test"
+    instrument_id = 950_001
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'RW', 'Rewash Inc', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.commit()
+
+    parsed = ParsedFiling(
+        document_type="4",
+        period_of_report=None,
+        date_of_original_submission=None,
+        not_subject_to_section_16=None,
+        form3_holdings_reported=None,
+        form4_transactions_reported=None,
+        issuer_cik="0000111000",
+        issuer_name="Rewash Inc",
+        issuer_trading_symbol="RW",
+        remarks=None,
+        signature_name=None,
+        signature_date=None,
+        filers=(
+            ParsedFiler(
+                filer_cik="0000222000",
+                filer_name="Test Filer",
+                street1=None,
+                street2=None,
+                city=None,
+                state=None,
+                zip_code=None,
+                state_description=None,
+                is_director=False,
+                is_officer=False,
+                officer_title=None,
+                is_ten_percent_owner=False,
+                is_other=False,
+                other_text=None,
+            ),
+        ),
+        footnotes=(),
+        transactions=(),
+    )
+    upsert_filing(
+        conn,
+        instrument_id=instrument_id,
+        accession_number=accession,
+        primary_document_url="https://example.com/x",
+        parsed=parsed,
+    )
+    conn.commit()
+
+    # Backdate the row to a known prior timestamp, then call the
+    # rewash variant and confirm fetched_at was preserved.
+    backdate = datetime(2024, 6, 1, tzinfo=UTC)
+    conn.execute(
+        "UPDATE insider_filings SET fetched_at = %s WHERE accession_number = %s",
+        (backdate, accession),
+    )
+    conn.commit()
+
+    upsert_filing(
+        conn,
+        instrument_id=instrument_id,
+        accession_number=accession,
+        primary_document_url="https://example.com/x",
+        parsed=parsed,
+        is_rewash=True,
+    )
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT fetched_at FROM insider_filings WHERE accession_number = %s",
+            (accession,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == backdate  # preserved across rewash upsert


### PR DESCRIPTION
## What
Re-wash framework that re-parses stored \`filing_raw_documents\` bodies under the current parser version. No SEC re-fetch when a parser bug ships.

- \`app/services/rewash_filings.py\` — ParserSpec registry + \`run_rewash\` orchestrator. Eager-fetches (accession, fetched_at) cohort identifiers; iterates per-row reading body + applying parser; bumps \`parser_version\` on success.
- \`app/services/insider_transactions.py\` — \`is_rewash\` flag on \`upsert_filing\` preserves original \`fetched_at\` on the conflict branch.
- \`scripts/rewash.py\` — operator CLI (\`--kind\`, \`--since\`, \`--dry-run\`).
- 10 integration tests.

## Why
Closes the second half of #809. PR #808 + #810/#811 retained raw bodies. This PR makes them re-parsable in place. Form 4 wired first (most common ownership kind, ~440k rows). Other kinds follow in separate PRs.

## Test plan
- [x] \`uv run pytest tests/test_rewash_filings.py tests/test_insider_transactions.py tests/test_insider_form3_ingest.py\` — 64/64 pass
- [x] \`uv run ruff check .\` clean
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run pyright\` clean
- [x] Codex pre-push review (2 rounds) — both findings (cursor+commit interaction, fetched_at mutation) addressed; final pass clean

## Follow-ups
- Concurrent re-wash + live-ingest duplicate-work race → tech-debt #817 (no corruption; idempotent upserts).
- Wire 13F / 13D/G / Form 3 / DEF 14A — separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)