### PR TITLE
feat(#813): .RTH suffix stripping in CIK discovery

### DIFF
--- a/app/services/cik_discovery.py
+++ b/app/services/cik_discovery.py
@@ -211,6 +211,44 @@ def upsert_cik(
     return affected > 0
 
 
+# eToro-side operational suffixes that wrap the underlying common
+# stock ticker (no separate SEC entry — the RTH listing is the same
+# issuer as the underlying). Stripping the suffix and re-trying the
+# lookup catches ~560 no-CIK instruments on the dev cohort without
+# any false positives, because each suffix maps deterministically to
+# a single underlying.
+#
+# Add new suffixes ONLY when:
+#   1. The suffix is a deterministic operational duplicate of the
+#      underlying (not a separate security like a warrant or pref).
+#   2. The match rate is non-trivial against the operator audit
+#      cohort.
+#
+# Warrants (``-W``, ``-WT``) and preferreds (``-PA``, ``-PB``) are
+# DELIBERATELY not in this list — they are separate securities with
+# their own filings, and folding them onto the common-stock CIK
+# would mis-attribute filings on the pie chart.
+_OPERATIONAL_SUFFIXES: tuple[str, ...] = (
+    ".RTH",  # eToro "regular trading hours" duplicate
+)
+
+
+def _normalise_for_lookup(symbol: str) -> tuple[str, ...]:
+    """Return candidate forms of ``symbol`` to try against the SEC
+    map, in priority order. The original form always comes first so
+    a genuine ``.RTH``-like SEC ticker (none known today, but the
+    map is operator-curated and could change) wins over the
+    stripped fallback."""
+    upper = symbol.upper().strip()
+    candidates: list[str] = [upper]
+    for suffix in _OPERATIONAL_SUFFIXES:
+        if upper.endswith(suffix):
+            stripped = upper[: -len(suffix)]
+            if stripped and stripped not in candidates:
+                candidates.append(stripped)
+    return tuple(candidates)
+
+
 def discover_ciks(
     conn: psycopg.Connection[Any],
     *,
@@ -219,18 +257,64 @@ def discover_ciks(
     """Walk every no-CIK instrument and attempt SEC ticker→CIK
     resolution. Idempotent.
 
+    Two-pass strategy:
+
+      1. **Direct match** — try the original symbol against the SEC
+         map. The canonical underlying (e.g. ``AAPL``) gets the CIK
+         row.
+      2. **Suffix-stripped fallback** — try the suffix-stripped form
+         (e.g. ``AAPL.RTH`` → ``AAPL``) only after pass 1 has
+         finished. ``upsert_cik``'s ON CONFLICT means the underlying
+         mapping (already inserted in pass 1) wins; the
+         operational duplicate's row no-ops.
+
+    Pass-ordering matters: a single-pass loop ordered by
+    ``instrument_id`` would let an early-sorting ``.RTH`` row claim
+    the only SEC CIK row, leaving the underlying unmapped. Two
+    passes guarantee the underlying always wins. Codex pre-push
+    review caught the single-pass version of this bug.
+
     ``ticker_map`` is injectable for tests; production callers pass
     ``None`` and the function fetches from SEC.
     """
     if ticker_map is None:
         ticker_map = fetch_ticker_map()
-    scanned = 0
+
+    cohort = list(iter_no_cik_instruments(conn))
+    scanned = len(cohort)
     matches = 0
     inserts = 0
+
+    # Pass 1: direct symbol match. Underlying tickers get first crack
+    # at any shared CIK row.
+    deferred: list[tuple[int, str]] = []
+    for instrument_id, symbol in cohort:
+        entry = ticker_map.get(symbol.upper().strip())
+        if entry is not None:
+            matches += 1
+            if upsert_cik(
+                conn,
+                instrument_id=instrument_id,
+                cik_padded=entry.cik_padded,
+                ticker=entry.ticker,
+            ):
+                inserts += 1
+            conn.commit()
+        else:
+            deferred.append((instrument_id, symbol))
+
+    # Pass 2: suffix-stripped fallback. Pass-1 inserts already
+    # committed, so ON CONFLICT here correctly leaves the underlying
+    # as the canonical owner of the CIK.
     misses = 0
-    for instrument_id, symbol in iter_no_cik_instruments(conn):
-        scanned += 1
-        entry = ticker_map.get(symbol.upper())
+    for instrument_id, symbol in deferred:
+        entry = None
+        for candidate in _normalise_for_lookup(symbol):
+            if candidate == symbol.upper().strip():
+                continue  # already tried in pass 1
+            entry = ticker_map.get(candidate)
+            if entry is not None:
+                break
         if entry is None:
             misses += 1
             continue
@@ -242,9 +326,8 @@ def discover_ciks(
             ticker=entry.ticker,
         ):
             inserts += 1
-        # Commit per-instrument so a downstream failure doesn't
-        # discard the entire batch's discoveries.
         conn.commit()
+
     return DiscoveryResult(
         instruments_scanned=scanned,
         matches_found=matches,

--- a/tests/test_cik_discovery.py
+++ b/tests/test_cik_discovery.py
@@ -166,6 +166,118 @@ def test_upsert_cik_does_not_clobber_existing_row(
     assert [r[0] for r in rows] == ["0000111111"]
 
 
+def test_discover_strips_rth_suffix_and_matches_underlying(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """eToro's ``.RTH`` (regular trading hours) listing is an
+    operational duplicate of the underlying common stock — same
+    issuer, same SEC CIK. Strip the suffix and re-try the lookup so
+    the no-CIK cohort folds these in without a separate seed."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_010, symbol="AAPL.RTH")
+    conn.commit()
+    fake_map = {
+        "AAPL": TickerMapEntry(cik_padded="0000320193", ticker="AAPL", title="Apple Inc."),
+    }
+
+    result = discover_ciks(conn, ticker_map=fake_map)
+
+    assert result.matches_found == 1
+    assert result.rows_inserted == 1
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT identifier_value FROM external_identifiers
+            WHERE instrument_id = %s AND provider = 'sec' AND identifier_type = 'cik'
+            """,
+            (900_010,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "0000320193"
+
+
+def test_discover_prefers_original_symbol_over_stripped(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """When the original symbol IS in the SEC map (rare hypothetical
+    where SEC adds a ``.RTH`` ticker), the original must win over
+    the stripped fallback. Order is original-first."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_011, symbol="X.RTH")
+    conn.commit()
+    fake_map = {
+        "X.RTH": TickerMapEntry(cik_padded="9999999999", ticker="X.RTH", title="Hypothetical"),
+        "X": TickerMapEntry(cik_padded="0000000001", ticker="X", title="X Corp"),
+    }
+
+    result = discover_ciks(conn, ticker_map=fake_map)
+
+    assert result.rows_inserted == 1
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT identifier_value FROM external_identifiers WHERE instrument_id = %s",
+            (900_011,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "9999999999"  # original ticker won, not the stripped fallback
+
+
+def test_discover_underlying_wins_over_suffix_duplicate_in_same_cohort(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """When BOTH the operational-duplicate (``.RTH``) and the
+    underlying are in the no-CIK cohort, the underlying must claim
+    the SEC CIK row — not the suffix-stripped fallback. Two-pass
+    ordering: direct matches first, suffix fallbacks second.
+    Regression for the high-severity Codex finding."""
+    conn = ebull_test_conn
+    # Seed the .RTH duplicate FIRST (lower instrument_id) so a
+    # naive single-pass loop ordered by instrument_id would let it
+    # win. The underlying must still claim the CIK.
+    _seed_instrument(conn, iid=900_020, symbol="AAPL.RTH")
+    _seed_instrument(conn, iid=900_021, symbol="AAPL")
+    conn.commit()
+    fake_map = {
+        "AAPL": TickerMapEntry(cik_padded="0000320193", ticker="AAPL", title="Apple Inc."),
+    }
+
+    result = discover_ciks(conn, ticker_map=fake_map)
+
+    assert result.rows_inserted == 1
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id FROM external_identifiers
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+              AND identifier_value = '0000320193'
+            """,
+        )
+        rows = cur.fetchall()
+    assert [r[0] for r in rows] == [900_021]  # underlying won, not the .RTH duplicate
+
+
+def test_discover_does_not_fold_warrant_suffixes(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Warrants (``-W``, ``-WT``) and preferreds (``-PA`` etc.) are
+    SEPARATE securities — folding them onto the common-stock CIK
+    would mis-attribute filings on the ownership pie chart. The
+    suffix list deliberately excludes them; they should miss."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_012, symbol="WARRANT-W")
+    conn.commit()
+    fake_map = {
+        "WARRANT": TickerMapEntry(cik_padded="0000111111", ticker="WARRANT", title="Should not fold"),
+    }
+
+    result = discover_ciks(conn, ticker_map=fake_map)
+
+    assert result.matches_found == 0
+    assert result.rows_inserted == 0
+
+
 def test_discover_handles_case_insensitive_ticker_lookup(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
 ) -> None:


### PR DESCRIPTION
## What
First sub-task of #813. Adds \`.RTH\` suffix stripping to \`cik_discovery\` so eToro's regular-trading-hours operational duplicates fold onto the underlying SEC CIK during the discovery sweep.

- \`_OPERATIONAL_SUFFIXES\` closed tuple (\`.RTH\` only — warrants/preferreds deliberately excluded).
- Two-pass strategy in \`discover_ciks\`: direct matches first (underlying wins shared CIK), suffix-stripped fallback second.
- 3 new tests including the regression for the underlying-loses bug Codex caught.

## Why
Operator audit 2026-05-03 found 7,281 of 12,379 instruments with no CIK row. \`.RTH\` instruments are 559 of that cohort. Live sweep: 14 net new inserts (underlyings discovered through their \`.RTH\` counterparts where both were no-CIK).

The remaining ~545 \`.RTH\` instruments still have no CIK row of their own because the underlying already owns it — that's the right behaviour for filing attribution. UI redirect for \`.RTH\` rendering tracked as follow-up #819.

## Test plan
- [x] \`uv run pytest tests/test_cik_discovery.py\` — 10/10 pass
- [x] \`uv run ruff check .\` clean
- [x] \`uv run pyright\` clean
- [x] Codex pre-push review (2 rounds) — high-severity underlying-loses bug fixed; final pass clean
- [x] Live sweep: \`scanned=7239 matches=592 inserted=14 misses=6647\`

## Follow-ups
- #819 — operational-duplicate redirect for .RTH instruments without separate CIK rows.
- #813 remaining sub-tasks: ETF map (\`company_tickers_exchange.json\`, \`company_tickers_mf.json\`), ADR resolver, manual override surface, scheduler entry, discovery report UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)