### PR TITLE
feat(#813): consume SEC company_tickers_exchange.json supplement

### DIFF
--- a/app/services/cik_discovery.py
+++ b/app/services/cik_discovery.py
@@ -1,4 +1,4 @@
-"""CIK discovery from SEC's curated ticker→CIK map.
+"""CIK discovery from SEC's curated ticker→CIK maps.
 
 Operator audit 2026-05-03 found 7,281 of 12,379 instruments (59%)
 have no SEC CIK row in ``external_identifiers``. Without a CIK
@@ -7,21 +7,43 @@ they're invisible to every SEC ingester (13F, 13D/G, Form 4, Form
 those instruments.
 
 This module's contract: walk every no-CIK instrument, look up the
-ticker in SEC's ``company_tickers.json`` (a curated map maintained
-by SEC, ~10k entries), write the ``external_identifiers`` row when a
-match is found.
+ticker in SEC's published ticker→CIK maps, write the
+``external_identifiers`` row when a match is found.
 
-Source: ``https://www.sec.gov/files/company_tickers.json``. Updated
-roughly daily by SEC. Single fetch is sufficient — a periodic
-re-fetch (weekly) catches new IPOs and issuer renames.
+Sources (SEC-published bulk exports — no inventive crawlers; the
+operator audit framing is "data in forms and exports"):
+
+  * ``https://www.sec.gov/files/company_tickers.json`` — ~10k
+    entries, common stocks. **CANONICAL** — required for any
+    sweep to proceed. If this fetch fails the sweep aborts (a
+    healthy partial mapping is preferable to a divergent
+    persisted-bad-mapping that the next sweep can't repair).
+  * ``https://www.sec.gov/files/company_tickers_exchange.json`` —
+    ~10k entries with ``cik / name / ticker / exchange``. ETFs
+    and NYSE Arca listings live here that don't appear in the
+    bare ``company_tickers.json``. Best-effort supplement; a
+    fetch failure here only reduces coverage on subsequent runs.
+
+Merge priority on collision: common-stocks > exchange. First
+source wins.
+
+``company_tickers_mf.json`` (~28k mutual-fund share-class rows) is
+DELIBERATELY NOT consumed in this module today: SEC publishes one
+TRUST CIK across many share-class symbols (LACAX / LIACX / ACRNX
+all share CIK 2110), but ``external_identifiers`` enforces a
+one-instrument-per-CIK unique constraint, so binding the trust
+CIK to a single share class would silently no-op every other
+sibling. The fund map needs the canonical-instrument-redirect
+mechanism tracked in #819 before it can land cleanly.
 
 Misses (no SEC ticker entry for the instrument's symbol) are
 expected for:
 
-  * Foreign issuers without ADRs.
+  * Foreign issuers without ADRs (covered by a future ADR resolver).
   * Defunct / delisted tickers.
   * Synthetic / duplicate listings (e.g. ``.RTH`` suffixes used as
-    operational duplicates of an underlying ticker).
+    operational duplicates of an underlying ticker — handled via
+    suffix-stripping fallback).
   * Bonds / preferreds / warrants (separate ticker from common
     stock).
 
@@ -30,11 +52,7 @@ best-effort and operators triage the long tail manually.
 
 Idempotent: ``ON CONFLICT DO NOTHING`` on the
 ``external_identifiers`` upsert means re-running won't duplicate
-rows or stomp on operator-curated overrides. A re-fetch after a
-ticker change would not over-write the prior CIK row — it just
-no-ops because the prior row is still on file. Removing the prior
-CIK after a ticker reassignment is operator territory (manual
-DELETE + audit trail).
+rows or stomp on operator-curated overrides.
 """
 
 from __future__ import annotations
@@ -54,6 +72,7 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 _TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
+_TICKERS_EXCHANGE_URL = "https://www.sec.gov/files/company_tickers_exchange.json"
 
 
 @dataclass(frozen=True)
@@ -61,6 +80,10 @@ class TickerMapEntry:
     cik_padded: str  # 10-digit zero-padded
     ticker: str  # uppercase
     title: str  # SEC entity name
+    # Which SEC export this entry came from. Useful for operator
+    # triage when a ticker resolves to an unexpected entity ("why
+    # did MFGAX map to a Vanguard CIK? — because mf.json").
+    source: str = "company_tickers"
 
 
 @dataclass(frozen=True)
@@ -71,24 +94,23 @@ class DiscoveryResult:
     misses: int
 
 
-def fetch_ticker_map() -> dict[str, TickerMapEntry]:
-    """Fetch SEC's curated ticker→CIK map. Returns dict keyed on
-    UPPERCASE ticker so callers can ``.get(symbol.upper())``.
-
-    Raises ``urllib.error.URLError`` on network failure — caller
-    decides whether that's transient (retry) or terminal (skip
-    this run).
-    """
+def _fetch_sec_json(url: str) -> Any:
+    """Fetch + decode a SEC bulk export. Raises on network /
+    decode failure — callers wrap or let it bubble."""
     req = urllib.request.Request(
-        _TICKERS_URL,
+        url,
         headers={"User-Agent": settings.sec_user_agent},
     )
     with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 — fixed SEC URL
-        payload = json.load(resp)
+        return json.load(resp)
 
-    out: dict[str, TickerMapEntry] = {}
+
+def _parse_company_tickers(payload: Any) -> Iterator[TickerMapEntry]:
+    """Parse ``company_tickers.json``. Shape: dict keyed by
+    arbitrary numeric string with each value carrying
+    ``{cik_str, ticker, title}``."""
     if not isinstance(payload, dict):
-        return out
+        return
     for entry in payload.values():
         if not isinstance(entry, dict):
             continue
@@ -101,19 +123,124 @@ def fetch_ticker_map() -> dict[str, TickerMapEntry]:
             cik_int = int(cik_raw)
         except TypeError, ValueError:
             continue
-        cik_padded = f"{cik_int:010d}"
         ticker_upper = str(ticker).upper().strip()
         if not ticker_upper:
             continue
-        # SEC's map can have multiple entries for the same ticker
-        # (rare; share class amendments). Keep the first match —
-        # callers can override manually if needed.
-        if ticker_upper not in out:
-            out[ticker_upper] = TickerMapEntry(
-                cik_padded=cik_padded,
-                ticker=ticker_upper,
-                title=str(title),
-            )
+        yield TickerMapEntry(
+            cik_padded=f"{cik_int:010d}",
+            ticker=ticker_upper,
+            title=str(title),
+            source="company_tickers",
+        )
+
+
+def _parse_fields_data(
+    payload: Any,
+    *,
+    cik_field: str,
+    ticker_field: str,
+    title_field: str | None,
+    source: str,
+) -> Iterator[TickerMapEntry]:
+    """Parse the ``{fields: [...], data: [[...], ...]}`` shape used
+    by ``company_tickers_exchange.json`` and
+    ``company_tickers_mf.json``. Generic over which column holds
+    the ticker / CIK / title because the two files use different
+    column names."""
+    if not isinstance(payload, dict):
+        return
+    fields = payload.get("fields")
+    data = payload.get("data")
+    if not isinstance(fields, list) or not isinstance(data, list):
+        return
+    try:
+        cik_idx = fields.index(cik_field)
+        ticker_idx = fields.index(ticker_field)
+    except ValueError:
+        return
+    title_idx = fields.index(title_field) if title_field and title_field in fields else None
+    for row in data:
+        if not isinstance(row, list) or len(row) <= max(cik_idx, ticker_idx):
+            continue
+        cik_raw = row[cik_idx]
+        ticker = row[ticker_idx]
+        try:
+            cik_int = int(cik_raw)
+        except TypeError, ValueError:
+            continue
+        if not ticker:
+            continue
+        ticker_upper = str(ticker).upper().strip()
+        if not ticker_upper:
+            continue
+        title = ""
+        if title_idx is not None and len(row) > title_idx:
+            title = str(row[title_idx] or "")
+        yield TickerMapEntry(
+            cik_padded=f"{cik_int:010d}",
+            ticker=ticker_upper,
+            title=title,
+            source=source,
+        )
+
+
+def _parse_company_tickers_exchange(payload: Any) -> Iterator[TickerMapEntry]:
+    """Parse ``company_tickers_exchange.json``. Fields:
+    ``cik / name / ticker / exchange``. ETFs and NYSE Arca-listed
+    securities live here that don't appear in the bare
+    ``company_tickers.json``."""
+    yield from _parse_fields_data(
+        payload,
+        cik_field="cik",
+        ticker_field="ticker",
+        title_field="name",
+        source="company_tickers_exchange",
+    )
+
+
+def fetch_ticker_map() -> dict[str, TickerMapEntry]:
+    """Fetch + merge SEC's published ticker→CIK exports into a
+    single dict keyed on UPPERCASE ticker.
+
+    Priority on collision: ``company_tickers.json`` >
+    ``company_tickers_exchange.json``. The first source seen for a
+    given ticker wins; later sources skip the existing key.
+
+    Failure semantics — fail-CLOSED on the canonical source:
+
+      * If ``company_tickers.json`` (canonical) fetch fails, the
+        ENTIRE sweep aborts (raises). Rationale: a partial sweep
+        with only ``exchange.json`` data could persist a wrong
+        CIK for a ticker whose canonical entry exists but is
+        currently unfetchable; later healthy sweeps can't repair
+        the row because ``upsert_cik`` no-ops on existing primary.
+        Better to skip the run than to lock in bad data.
+      * If ``company_tickers_exchange.json`` (supplement) fetch
+        fails, the sweep proceeds with canonical-only coverage —
+        a missed ETF resolution today is recoverable; a wrong
+        persisted CIK is not.
+    """
+    out: dict[str, TickerMapEntry] = {}
+
+    # Canonical — required.
+    canonical_payload = _fetch_sec_json(_TICKERS_URL)
+    for entry in _parse_company_tickers(canonical_payload):
+        if entry.ticker not in out:
+            out[entry.ticker] = entry
+
+    # Supplement — best-effort. A failure here only reduces
+    # coverage on the current sweep; the next sweep retries.
+    try:
+        exchange_payload = _fetch_sec_json(_TICKERS_EXCHANGE_URL)
+    except Exception:  # noqa: BLE001 — supplement failure is non-fatal
+        logger.exception(
+            "cik_discovery: failed to fetch %s; proceeding with canonical-only",
+            _TICKERS_EXCHANGE_URL,
+        )
+        return out
+    for entry in _parse_company_tickers_exchange(exchange_payload):
+        if entry.ticker not in out:
+            out[entry.ticker] = entry
     return out
 
 

--- a/tests/test_cik_discovery.py
+++ b/tests/test_cik_discovery.py
@@ -6,6 +6,8 @@ no-CIK instruments only, miss-counter accurate.
 
 from __future__ import annotations
 
+from typing import Any
+
 import psycopg
 import pytest
 
@@ -276,6 +278,161 @@ def test_discover_does_not_fold_warrant_suffixes(
 
     assert result.matches_found == 0
     assert result.rows_inserted == 0
+
+
+def test_parse_company_tickers_exchange_yields_etf_entries() -> None:
+    """The exchange.json export carries the full set including
+    ETFs / NYSE Arca listings that company_tickers.json misses.
+    Parser yields TickerMapEntry per row."""
+    from app.services.cik_discovery import _parse_company_tickers_exchange
+
+    payload = {
+        "fields": ["cik", "name", "ticker", "exchange"],
+        "data": [
+            [1100663, "ISHARES TR", "IVV", "NYSE Arca"],
+            [884394, "INVESCO QQQ TRUST", "QQQ", "Nasdaq"],
+        ],
+    }
+
+    entries = list(_parse_company_tickers_exchange(payload))
+    assert len(entries) == 2
+    by_ticker = {e.ticker: e for e in entries}
+    assert by_ticker["IVV"].cik_padded == "0001100663"
+    assert by_ticker["IVV"].title == "ISHARES TR"
+    assert by_ticker["IVV"].source == "company_tickers_exchange"
+    assert by_ticker["QQQ"].cik_padded == "0000884394"
+
+
+def test_parse_company_tickers_exchange_skips_malformed_rows() -> None:
+    """Defensive parser: missing fields, non-list rows, non-int
+    CIKs, empty tickers all skipped without raising."""
+    from app.services.cik_discovery import _parse_company_tickers_exchange
+
+    payload = {
+        "fields": ["cik", "name", "ticker", "exchange"],
+        "data": [
+            [320193, "Apple Inc.", "AAPL", "Nasdaq"],
+            "not a row",
+            [None, "X Corp", "XCORP", "NYSE"],
+            [123, "Y Corp", "", "NYSE"],
+            [123, "Z Corp", "ZCORP", "NYSE"],
+        ],
+    }
+
+    entries = list(_parse_company_tickers_exchange(payload))
+    tickers = {e.ticker for e in entries}
+    assert tickers == {"AAPL", "ZCORP"}
+
+
+def test_fetch_ticker_map_merges_canonical_and_exchange_with_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fetch_ticker_map merges the canonical company_tickers.json
+    with the company_tickers_exchange.json supplement. On ticker
+    collision, canonical wins; otherwise exchange.json fills gaps
+    (ETFs, NYSE Arca listings)."""
+    from app.services import cik_discovery
+
+    payloads: dict[str, Any] = {
+        cik_discovery._TICKERS_URL: {
+            "0": {"cik_str": 320193, "ticker": "AAPL", "title": "Apple Inc."},
+        },
+        cik_discovery._TICKERS_EXCHANGE_URL: {
+            "fields": ["cik", "name", "ticker", "exchange"],
+            "data": [
+                # Collision — canonical wins, this row should NOT overwrite.
+                [9999999, "Spoof", "AAPL", "NYSE"],
+                # New entry — should win on the exchange-only path.
+                [1100663, "ISHARES TR", "IVV", "NYSE Arca"],
+            ],
+        },
+    }
+
+    monkeypatch.setattr(cik_discovery, "_fetch_sec_json", lambda url: payloads[url])
+
+    out = cik_discovery.fetch_ticker_map()
+
+    assert out["AAPL"].cik_padded == "0000320193"
+    assert out["AAPL"].source == "company_tickers"
+    assert out["IVV"].cik_padded == "0001100663"
+    assert out["IVV"].source == "company_tickers_exchange"
+
+
+def test_fetch_ticker_map_aborts_when_canonical_source_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail-closed on canonical: if company_tickers.json is
+    unfetchable, the sweep MUST raise rather than proceeding with
+    only the supplement. Otherwise a ticker whose canonical entry
+    is currently unreachable could get a wrong CIK persisted from
+    the supplement that later healthy sweeps can't repair (the
+    one-instrument-per-CIK constraint plus upsert_cik's no-op on
+    existing primary)."""
+    from app.services import cik_discovery
+
+    def _fetch(url: str) -> Any:
+        if url == cik_discovery._TICKERS_URL:
+            raise RuntimeError("simulated canonical outage")
+        return {
+            "fields": ["cik", "name", "ticker", "exchange"],
+            "data": [[1100663, "ISHARES TR", "IVV", "NYSE Arca"]],
+        }
+
+    monkeypatch.setattr(cik_discovery, "_fetch_sec_json", _fetch)
+
+    with pytest.raises(RuntimeError, match="simulated canonical outage"):
+        cik_discovery.fetch_ticker_map()
+
+
+def test_fetch_ticker_map_continues_on_supplement_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Best-effort on supplement: if exchange.json fails, sweep
+    proceeds with canonical-only coverage. Missed ETF resolution
+    today is recoverable; aborting on a supplement failure would
+    block all common-stock discovery."""
+    from app.services import cik_discovery
+
+    def _fetch(url: str) -> Any:
+        if url == cik_discovery._TICKERS_URL:
+            return {"0": {"cik_str": 320193, "ticker": "AAPL", "title": "Apple Inc."}}
+        raise RuntimeError("simulated supplement outage")
+
+    monkeypatch.setattr(cik_discovery, "_fetch_sec_json", _fetch)
+
+    out = cik_discovery.fetch_ticker_map()
+    assert "AAPL" in out
+
+
+def test_discover_resolves_etf_ticker_via_exchange_export(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """End-to-end: an instrument with an ETF ticker that's NOT in
+    company_tickers.json gets resolved via the exchange supplement."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, iid=900_030, symbol="IVV")
+    conn.commit()
+    fake_map = {
+        "IVV": TickerMapEntry(
+            cik_padded="0001100663",
+            ticker="IVV",
+            title="ISHARES TR",
+            source="company_tickers_exchange",
+        ),
+    }
+
+    result = discover_ciks(conn, ticker_map=fake_map)
+
+    assert result.matches_found == 1
+    assert result.rows_inserted == 1
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT identifier_value FROM external_identifiers WHERE instrument_id = %s",
+            (900_030,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "0001100663"
 
 
 def test_discover_handles_case_insensitive_ticker_lookup(


### PR DESCRIPTION
## What
Extends \`fetch_ticker_map\` to merge SEC's canonical \`company_tickers.json\` with the \`company_tickers_exchange.json\` supplement so ETF / NYSE Arca tickers absent from the bare common-stocks map can resolve.

- Canonical \`company_tickers.json\` is REQUIRED — fetch failure aborts the sweep (fail-closed).
- Supplement \`company_tickers_exchange.json\` is best-effort — fetch failure logs + proceeds.
- \`company_tickers_mf.json\` deliberately deferred (one-trust-CIK / many-share-class semantics conflict with one-instrument-per-CIK schema; needs #819 redirect).
- \`TickerMapEntry.source\` carries which export the entry came from for operator triage.

## Why
Operator audit framing: "data in forms and exports". SEC publishes the bulk maps; we consume them. No inventive crawlers.

## Test plan
- [x] \`uv run pytest tests/test_cik_discovery.py\` — 16/16 pass
- [x] \`uv run ruff check .\` clean
- [x] \`uv run pyright\` clean
- [x] Codex pre-push review (2 rounds) — fail-open and mf.json semantics fixes; final pass clean
- [x] Live sweep on dev: 9 net new tickers from supplement, 10,368 total merged-map entries

## Follow-ups
- mf.json fund-trust mapping → tracked in #819 (canonical-instrument redirect prerequisite).
- Codex flagged residual concurrent-sweep race in upsert_cik (pre-existing, not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)