### PR TITLE
feat(#788/#809): register Form 3 rewash spec

### DIFF
--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -78,6 +78,7 @@ def upsert_form_3_filing(
     accession_number: str,
     primary_document_url: str,
     parsed: ParsedForm3,
+    is_rewash: bool = False,
 ) -> None:
     """Insert / refresh the Form 3 filing header + filer dim + footnote
     bodies + holding rows for one accession.
@@ -87,6 +88,10 @@ def upsert_form_3_filing(
     after a parser bump) refreshes every field in place. Tombstones
     are flipped back to live via the ``is_tombstone = FALSE`` reset on
     the filings UPDATE branch.
+
+    ``is_rewash``: when True, the conflict branch preserves the
+    original ``fetched_at`` (re-parsing a stored body isn't a fresh
+    SEC fetch). Same flag pattern as Form 4 (PR #818).
     """
     with conn.cursor() as cur:
         cur.execute(
@@ -124,7 +129,9 @@ def upsert_form_3_filing(
                 primary_document_url         = EXCLUDED.primary_document_url,
                 parser_version               = EXCLUDED.parser_version,
                 is_tombstone                 = FALSE,
-                fetched_at                   = NOW()
+                fetched_at                   = CASE WHEN %s
+                                                    THEN insider_filings.fetched_at
+                                                    ELSE NOW() END
             """,
             (
                 accession_number,
@@ -147,6 +154,7 @@ def upsert_form_3_filing(
                 parsed.signature_date,
                 primary_document_url,
                 _FORM3_PARSER_VERSION,
+                is_rewash,
             ),
         )
 

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -332,12 +332,76 @@ def _apply_form4(
 
 # Registered eagerly so the registry is populated at import time —
 # matches the pattern in app.services.reconciliation. The version
-# string mirrors the constant in insider_transactions; if either
-# changes, both must change so re-wash actually re-walks.
+# strings mirror the constants in each ingester; if either changes,
+# both must change so re-wash actually re-walks.
 register_parser(
     ParserSpec(
         document_kind="form4_xml",
         current_version="form4-v1",
         apply_fn=_apply_form4,
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Form 3 wiring
+# ---------------------------------------------------------------------------
+
+
+def _apply_form3(
+    conn: psycopg.Connection[Any],
+    raw_doc: RawFilingDocument,
+) -> bool:
+    """Re-parse the Form 3 XML body and re-apply the typed-table
+    upsert. Same shape as Form 4 — Form 3 is the
+    initial-holdings-baseline cousin of Form 4's transactions.
+
+    Returns ``False`` when no existing ``insider_filings`` row is
+    found (re-wash is not a first-time ingester). Raises
+    ``RewashParseError`` on parser regression so the failure
+    surfaces in ``rows_failed``, not silently in ``rows_skipped``."""
+    from app.services.insider_form3_ingest import upsert_form_3_filing
+    from app.services.insider_transactions import parse_form_3_xml
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, primary_document_url
+            FROM insider_filings
+            WHERE accession_number = %s
+            """,
+            (raw_doc.accession_number,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return False
+    instrument_id, primary_document_url = row
+
+    parsed = parse_form_3_xml(raw_doc.payload)
+    if parsed is None:
+        raise RewashParseError(
+            f"parse_form_3_xml returned None for accession={raw_doc.accession_number} body_size={len(raw_doc.payload)}"
+        )
+
+    upsert_form_3_filing(
+        conn,
+        instrument_id=int(instrument_id),
+        accession_number=raw_doc.accession_number,
+        primary_document_url=str(primary_document_url) if primary_document_url else "",
+        parsed=parsed,
+        is_rewash=True,
+    )
+    return True
+
+
+# Form 3 parser version is "form3-v{N}" — see _FORM3_PARSER_VERSION
+# in insider_form3_ingest.py. Bump both constants in lockstep when
+# the parser semantics change in a way that affects what lands in
+# typed tables.
+register_parser(
+    ParserSpec(
+        document_kind="form3_xml",
+        current_version="form3-v1",
+        apply_fn=_apply_form3,
     )
 )

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -494,3 +494,150 @@ def test_form4_rewash_preserves_original_fetched_at(
         row = cur.fetchone()
     assert row is not None
     assert row[0] == backdate  # preserved across rewash upsert
+
+
+def test_form3_apply_raises_on_parse_regression(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """Form 3 rewash spec uses the same parse-regression contract
+    as Form 4: parser returning None on a body that has an existing
+    typed row must RAISE so the failure surfaces in rows_failed,
+    not silently in rows_skipped."""
+    conn = ebull_test_conn
+    accession = "0001234567-26-form3-regress"
+    instrument_id = 950_020
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'F3', 'Form 3 Regression', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO insider_filings (
+            accession_number, instrument_id, document_type,
+            primary_document_url, parser_version, is_tombstone
+        ) VALUES (%s, %s, '3', 'https://example.com/x', 1, FALSE)
+        """,
+        (accession, instrument_id),
+    )
+    _seed_raw(conn, accession=accession, kind="form3_xml", parser_version="form3-v0")
+
+    monkeypatch.setattr(
+        "app.services.insider_transactions.parse_form_3_xml",
+        lambda _xml: None,
+    )
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="form3_xml",
+            current_version="form3-v1",
+            apply_fn=rewash_filings._apply_form3,
+        )
+    )
+
+    result = rewash_filings.run_rewash(conn, document_kind="form3_xml")
+
+    assert result.rows_scanned == 1
+    assert result.rows_failed == 1
+    assert result.rows_skipped == 0
+
+
+def test_form3_rewash_preserves_original_fetched_at(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    isolated_registry: None,
+) -> None:
+    """Form 3 rewash must NOT bump insider_filings.fetched_at —
+    same audit contract as Form 4 (PR #818)."""
+    from app.services.insider_form3_ingest import upsert_form_3_filing
+    from app.services.insider_transactions import ParsedFiler
+    from app.services.insider_transactions import (
+        ParsedForm3 as ParsedForm3Data,
+    )
+
+    conn = ebull_test_conn
+    accession = "0001234567-26-form3-rewash"
+    instrument_id = 950_021
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'F3R', 'Form 3 Rewash', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.commit()
+
+    parsed = ParsedForm3Data(
+        document_type="3",
+        period_of_report=None,
+        date_of_original_submission=None,
+        issuer_cik="0000111000",
+        issuer_name="Form 3 Rewash Inc",
+        issuer_trading_symbol="F3R",
+        remarks=None,
+        signature_name=None,
+        signature_date=None,
+        filers=(
+            ParsedFiler(
+                filer_cik="0000222000",
+                filer_name="Test Filer",
+                street1=None,
+                street2=None,
+                city=None,
+                state=None,
+                zip_code=None,
+                state_description=None,
+                is_director=False,
+                is_officer=False,
+                officer_title=None,
+                is_ten_percent_owner=False,
+                is_other=False,
+                other_text=None,
+            ),
+        ),
+        holdings=(),
+        footnotes=(),
+        no_securities_owned=False,
+    )
+    upsert_form_3_filing(
+        conn,
+        instrument_id=instrument_id,
+        accession_number=accession,
+        primary_document_url="https://example.com/x",
+        parsed=parsed,
+    )
+    conn.commit()
+
+    backdate = datetime(2024, 6, 1, tzinfo=UTC)
+    conn.execute(
+        "UPDATE insider_filings SET fetched_at = %s WHERE accession_number = %s",
+        (backdate, accession),
+    )
+    conn.commit()
+
+    upsert_form_3_filing(
+        conn,
+        instrument_id=instrument_id,
+        accession_number=accession,
+        primary_document_url="https://example.com/x",
+        parsed=parsed,
+        is_rewash=True,
+    )
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT fetched_at FROM insider_filings WHERE accession_number = %s",
+            (accession,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == backdate


### PR DESCRIPTION
## What
Extends the rewash framework (PR #818) with Form 3 — second ownership kind to land in the registry.

- \`upsert_form_3_filing\` gets \`is_rewash\` flag (CASE WHEN preserves original \`fetched_at\` on conflict).
- \`rewash_filings\` registers \`form3_xml\` ParserSpec via \`_apply_form3\` (same shape as \`_apply_form4\`).
- 2 new tests pin parse-regression-counts-as-failed + fetched_at-preservation contracts.

## Why
Codex's recommended chain: A Form 4 → B Form 3 → C 13D/G → D DEF 14A → E 13F. Form 3 is the natural next step because it shares Form 4's \`upsert_form_3_filing\` shape; the canonical rewash pattern (selector → raw body → parser → typed table → bump version) just needs the registry hookup.

## Test plan
- [x] \`pytest tests/test_rewash_filings.py\` 13/13 + \`tests/test_insider_form3_ingest.py\` 17/17
- [x] \`ruff check\` / \`format\` / \`pyright\` clean
- [x] Codex pre-push review — no findings

## Follow-ups
- 13D/G / 13F / DEF 14A rewash specs require extracting inline upsert helpers from each ingester (per-PR).
- Historical CIK writer routing (other half of Codex's lane H) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)