### PR TITLE
feat(#788/#809): register DEF 14A rewash spec

### DIFF
--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -405,3 +405,126 @@ register_parser(
         apply_fn=_apply_form3,
     )
 )
+
+
+# ---------------------------------------------------------------------------
+# DEF 14A proxy beneficial-ownership table wiring
+# ---------------------------------------------------------------------------
+
+
+def _apply_def14a(
+    conn: psycopg.Connection[Any],
+    raw_doc: RawFilingDocument,
+) -> bool:
+    """Re-parse the DEF 14A HTML body and re-apply the beneficial-
+    ownership-holdings upsert.
+
+    Replace-then-insert: clear all rows for the accession, then
+    INSERT each parsed holder. The unique key on the typed table
+    is ``(accession_number, holder_name)`` — without a clear, a
+    new parser version that DROPS a stale holder would leave the
+    old row pinned forever.
+
+    Returns ``False`` when no existing typed row is found (re-wash
+    isn't a first-time ingester). Raises ``RewashParseError`` on
+    parser regression so the failure surfaces in ``rows_failed``.
+    Note: a no-table-found (parsed.rows empty) is also a regression
+    here — under the existing ingester it would tombstone status=
+    partial, but in re-wash context it means the new parser is
+    weaker than the prior one against the same body."""
+    from app.providers.implementations.sec_def14a import parse_beneficial_ownership_table
+    from app.services.def14a_ingest import _upsert_holding
+
+    # Resolution priority:
+    #   1. Existing typed rows in def14a_beneficial_holdings —
+    #      happy path (first ingest produced rows, parser bump
+    #      now updating them).
+    #   2. Fallback to def14a_ingest_log + filing_events when no
+    #      typed rows exist. Covers the rescue cohort: original
+    #      ingest tombstoned status='failed' or 'partial' with
+    #      zero typed rows; the new parser now wants to fill them
+    #      in. Codex pre-push review caught this gap — without
+    #      the fallback, the cohort rewash should rescue stays on
+    #      the old parser_version forever.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT issuer_cik, instrument_id
+            FROM def14a_beneficial_holdings
+            WHERE accession_number = %s
+            LIMIT 1
+            """,
+            (raw_doc.accession_number,),
+        )
+        row = cur.fetchone()
+    had_existing_rows = row is not None
+    if row is None:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT log.issuer_cik, fe.instrument_id
+                FROM def14a_ingest_log log
+                JOIN filing_events fe
+                  ON fe.provider_filing_id = log.accession_number
+                 AND fe.provider = 'sec'
+                WHERE log.accession_number = %s
+                LIMIT 1
+                """,
+                (raw_doc.accession_number,),
+            )
+            row = cur.fetchone()
+    if row is None:
+        return False
+    issuer_cik, instrument_id = row
+
+    try:
+        parsed = parse_beneficial_ownership_table(raw_doc.payload)
+    except Exception as exc:
+        raise RewashParseError(
+            f"parse_beneficial_ownership_table failed for accession={raw_doc.accession_number}: {exc}"
+        ) from exc
+
+    if not parsed.rows:
+        if had_existing_rows:
+            # Parser regression on a populated accession — raise
+            # so the operator sees the gap in rows_failed rather
+            # than silently zeroing out typed rows.
+            raise RewashParseError(
+                f"DEF 14A re-parse produced zero holders for accession="
+                f"{raw_doc.accession_number} (best_score={parsed.raw_table_score}); "
+                f"previous parser found rows"
+            )
+        # Rescue cohort with still-empty parse. Don't raise —
+        # parser hasn't improved enough yet. Skip without bumping
+        # parser_version so a future sweep with a better parser
+        # re-tries.
+        return False
+
+    # Replace-then-insert: clear all existing holders for the
+    # accession so a holder dropped by the new parser cannot
+    # linger.
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM def14a_beneficial_holdings WHERE accession_number = %s",
+            (raw_doc.accession_number,),
+        )
+
+    for holder in parsed.rows:
+        _upsert_holding(
+            conn,
+            accession_number=raw_doc.accession_number,
+            issuer_cik=str(issuer_cik),
+            instrument_id=int(instrument_id),
+            as_of_date=parsed.as_of_date,
+            holder=holder,
+        )
+    return True
+
+
+register_parser(
+    ParserSpec(
+        document_kind="def14a_body",
+        current_version="def14a-v1",
+        apply_fn=_apply_def14a,
+    )
+)

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import psycopg
 import pytest
@@ -641,3 +642,226 @@ def test_form3_rewash_preserves_original_fetched_at(
         row = cur.fetchone()
     assert row is not None
     assert row[0] == backdate
+
+
+def test_def14a_apply_raises_on_parse_failure(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """DEF 14A parser failure on a body with an existing typed row
+    must raise so the failure surfaces in rows_failed."""
+    conn = ebull_test_conn
+    accession = "0001234567-26-def14a-regress"
+    instrument_id = 950_050
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'D14', 'DEF 14A Regression', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO def14a_beneficial_holdings (
+            instrument_id, accession_number, issuer_cik,
+            holder_name, holder_role, shares, percent_of_class, as_of_date
+        ) VALUES (%s, %s, '0000999000', 'Test Holder', 'officer', 100, 5.0, '2025-01-01')
+        """,
+        (instrument_id, accession),
+    )
+    _seed_raw(conn, accession=accession, kind="def14a_body", parser_version="def14a-v0")
+    conn.commit()
+
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_def14a.parse_beneficial_ownership_table",
+        lambda _html: (_ for _ in ()).throw(ValueError("synthetic parse error")),
+    )
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="def14a_body",
+            current_version="def14a-v1",
+            apply_fn=rewash_filings._apply_def14a,
+        )
+    )
+
+    result = rewash_filings.run_rewash(conn, document_kind="def14a_body")
+
+    assert result.rows_scanned == 1
+    assert result.rows_failed == 1
+    assert result.rows_skipped == 0
+
+
+def test_def14a_apply_replaces_holders_on_rewash(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """DEF 14A rewash replaces all holders for the accession. A
+    holder dropped by the new parser must not linger from the
+    previous parse."""
+    from app.providers.implementations.sec_def14a import (
+        Def14ABeneficialHolder,
+        Def14ABeneficialOwnershipTable,
+    )
+
+    conn = ebull_test_conn
+    instrument_id = 950_051
+    accession = "0001234567-26-def14a-replace"
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'D14R', 'DEF 14A Replace', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    # Two pre-existing holders.
+    for holder in ("Holder A", "Holder B"):
+        conn.execute(
+            """
+            INSERT INTO def14a_beneficial_holdings (
+                instrument_id, accession_number, issuer_cik,
+                holder_name, holder_role, shares, percent_of_class, as_of_date
+            ) VALUES (%s, %s, '0000999000', %s, 'officer', 100, 5.0, '2025-01-01')
+            """,
+            (instrument_id, accession, holder),
+        )
+    _seed_raw(conn, accession=accession, kind="def14a_body", parser_version="def14a-v0")
+    conn.commit()
+
+    # New parse drops Holder B and adds Holder C.
+    fake_table = Def14ABeneficialOwnershipTable(
+        as_of_date=None,
+        rows=[
+            Def14ABeneficialHolder(
+                holder_name="Holder A",
+                holder_role="officer",
+                shares=Decimal("100"),
+                percent_of_class=Decimal("5.0"),
+            ),
+            Def14ABeneficialHolder(
+                holder_name="Holder C",
+                holder_role="director",
+                shares=Decimal("200"),
+                percent_of_class=Decimal("8.0"),
+            ),
+        ],
+        raw_table_score=10,
+    )
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_def14a.parse_beneficial_ownership_table",
+        lambda _html: fake_table,
+    )
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="def14a_body",
+            current_version="def14a-v1",
+            apply_fn=rewash_filings._apply_def14a,
+        )
+    )
+
+    result = rewash_filings.run_rewash(conn, document_kind="def14a_body")
+    assert result.rows_reparsed == 1
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT holder_name FROM def14a_beneficial_holdings WHERE accession_number = %s ORDER BY holder_name",
+            (accession,),
+        )
+        rows = cur.fetchall()
+    holders = [r[0] for r in rows]
+    assert holders == ["Holder A", "Holder C"]
+
+
+def test_def14a_apply_rescues_tombstoned_accession(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """Rescue cohort: original ingest tombstoned with zero typed
+    rows (parser couldn't find table). New parser DOES find a
+    table. Re-wash must populate the typed rows — not skip
+    forever. Regression for the medium-severity Codex finding."""
+    from app.providers.implementations.sec_def14a import (
+        Def14ABeneficialHolder,
+        Def14ABeneficialOwnershipTable,
+    )
+
+    conn = ebull_test_conn
+    instrument_id = 950_060
+    accession = "0001234567-26-def14a-rescue"
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'D14X', 'DEF 14A Rescue', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    # Tombstoned ingest_log row, zero typed rows.
+    conn.execute(
+        """
+        INSERT INTO def14a_ingest_log (accession_number, issuer_cik, status)
+        VALUES (%s, '0000999000', 'partial')
+        """,
+        (accession,),
+    )
+    # filing_events row carries instrument_id resolution.
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type, source_url,
+            provider, provider_filing_id, primary_document_url
+        ) VALUES (%s, '2025-03-01', 'DEF 14A', 'https://example.com/x',
+                  'sec', %s, 'https://example.com/x')
+        """,
+        (instrument_id, accession),
+    )
+    _seed_raw(conn, accession=accession, kind="def14a_body", parser_version="def14a-v0")
+    conn.commit()
+
+    fake_table = Def14ABeneficialOwnershipTable(
+        as_of_date=None,
+        rows=[
+            Def14ABeneficialHolder(
+                holder_name="Rescued Holder",
+                holder_role="director",
+                shares=Decimal("500"),
+                percent_of_class=Decimal("3.0"),
+            ),
+        ],
+        raw_table_score=15,
+    )
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_def14a.parse_beneficial_ownership_table",
+        lambda _html: fake_table,
+    )
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="def14a_body",
+            current_version="def14a-v1",
+            apply_fn=rewash_filings._apply_def14a,
+        )
+    )
+
+    result = rewash_filings.run_rewash(conn, document_kind="def14a_body")
+    assert result.rows_reparsed == 1  # rescued, not skipped
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT holder_name FROM def14a_beneficial_holdings WHERE accession_number = %s",
+            (accession,),
+        )
+        rows = cur.fetchall()
+    assert [r[0] for r in rows] == ["Rescued Holder"]


### PR DESCRIPTION
## What
Fourth ownership kind in rewash registry (Form 4 = #818, Form 3 = #824, 13D/G = #825 in flight, DEF 14A here).

\`_apply_def14a\` uses replace-then-insert with two-tier resolution: existing typed rows for happy path, JOIN \`def14a_ingest_log\` + \`filing_events\` fallback for the rescue cohort whose original ingest tombstoned with zero typed rows.

3 new tests including the rescue cohort regression.

## Test plan
- [x] \`pytest tests/test_rewash_filings.py\` 16/16
- [x] \`ruff\` / \`pyright\` clean
- [x] Codex pre-push review (2 rounds) — rescue-cohort fallback added; final pass clean

## Follow-ups
- 13F infotable rewash spec (separate PR — last ownership kind).
- Historical CIK writer routing (separate PR — Codex's lane H second half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)