### PR TITLE
feat(#807): top-13F-filer discovery primitive + CLI

### DIFF
--- a/app/services/top_filer_discovery.py
+++ b/app/services/top_filer_discovery.py
@@ -1,0 +1,212 @@
+"""Top 13F-HR filer discovery from SEC's quarterly form indexes.
+
+Operator audit 2026-05-03 (issue #807) flagged the
+``institutional_filer_seeds`` table at 14 rows vs the ~5,400-row
+13F-HR universe. The pie chart on the ownership card silently
+omits institutional ownership for any issuer not held by one of
+those 14 filers.
+
+Approach: SEC publishes quarterly ``form.idx`` files at
+``https://www.sec.gov/Archives/edgar/full-index/{year}/QTR{n}/form.idx``.
+Each file is a fixed-width text index of every form filed in that
+quarter. Aggregating the 13F-HR rows by filer CIK over the last N
+quarters surfaces ACTIVE 13F filers without an inventive crawler.
+
+Limitations of the count-based ranking:
+
+  * **Filing count is not AUM.** A small filer who files many
+    13F-HR/A amendments per quarter outranks a large filer who
+    files one clean 13F-HR per quarter. The household-name top
+    managers (Vanguard, BlackRock, Fidelity, State Street) file
+    once per quarter and rank low on count.
+  * The truly AUM-based ranking requires fetching each filer's
+    primary_doc.xml (carries ``reportSummary/tableValueTotal``)
+    and ranking by that value. Tracked as the AUM-ranking
+    follow-up; this discovery primitive feeds into it.
+
+For now this module is useful as:
+
+  * A "is filer X actively filing right now?" check.
+  * A long-tail discovery surface — the operator can review the
+    top-200 by count, hand-pick names not yet in the curated 14
+    seeds, and apply through the verification gate.
+
+The expansion path:
+
+  1. ``aggregate_top_filers(quarters=N, top_n=200)`` walks the
+     last N quarterly form.idx files (default 4 = one full year).
+  2. Each entry yields ``(cik, latest_name, filing_count)``
+     sorted by ``filing_count`` desc.
+  3. The CLI in ``scripts/seed_top_13f_filers.py`` runs the
+     filer_seed_verification gate against each candidate before
+     persisting via ``seed_filer`` — same gate from PR #821.
+
+This module is the data-fetch + aggregation half. Persistence
+lives in the CLI so the operator can review candidates before
+applying.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import urllib.request
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import date
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+_FORM_IDX_URL = "https://www.sec.gov/Archives/edgar/full-index/{year}/QTR{q}/form.idx"
+
+# Form types we treat as 13F-HR for the count. ``13F-HR/A`` is an
+# amendment of a previously-filed 13F-HR; both signal active filer
+# status. ``13F-NT`` is a notice-only "another manager has all my
+# holdings" filing — counted because it's still operator-relevant
+# (a no-positions notice still indicates an active manager).
+_THIRTEEN_F_FORM_TYPES: frozenset[str] = frozenset({"13F-HR", "13F-HR/A", "13F-NT", "13F-NT/A"})
+
+
+@dataclass(frozen=True)
+class FormIndexEntry:
+    """One row from form.idx."""
+
+    form_type: str
+    company_name: str
+    cik: str  # 10-digit zero-padded
+    date_filed: date
+    file_name: str
+
+
+@dataclass(frozen=True)
+class TopFilerCandidate:
+    """One aggregated candidate. ``filing_count`` is the count of
+    13F-HR / 13F-HR/A / 13F-NT filings observed across the
+    aggregated quarters."""
+
+    cik: str  # 10-digit zero-padded
+    latest_name: str
+    filing_count: int
+
+
+def fetch_form_index(year: int, quarter: int) -> str:
+    """Fetch one quarterly form.idx as latin-1 text. Raises on
+    network / decode failure — caller decides whether to retry or
+    skip the quarter.
+
+    The file is ~50MB; SEC serves it cacheable, so a periodic
+    weekly refresh is the operator-intended cadence.
+    """
+    url = _FORM_IDX_URL.format(year=year, q=quarter)
+    req = urllib.request.Request(url, headers={"User-Agent": settings.sec_user_agent})
+    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 — fixed SEC URL
+        # form.idx historically uses latin-1 encoding for company
+        # names with non-ASCII characters; using utf-8 raises on
+        # certain rows. SEC's archive convention.
+        return resp.read().decode("latin-1")
+
+
+# Header marker that identifies the start of data rows. Everything
+# above it is preamble / column headers / dashes.
+_DATA_MARKER = re.compile(r"^-+\s*$")
+
+
+def parse_form_index(payload: str) -> Iterable[FormIndexEntry]:
+    """Yield :class:`FormIndexEntry` per data row.
+
+    Strategy: anchor on the predictable trailing fields (CIK =
+    digits, Date Filed = ``YYYY-MM-DD``, File Name =
+    ``edgar/...``). Everything before is "form_type + spaces +
+    company_name"; split on the LAST 2+-space gap to recover the
+    two parts. This is robust to:
+
+      * Form types that contain spaces (``1-A POS``, ``25-NSE``).
+      * Company names with internal spaces.
+      * Column-width drift across years (SEC widened the Company
+        Name column when issuers started exceeding 60 chars).
+    """
+    line_pattern = re.compile(
+        r"^(?P<head>.+?)\s+"
+        r"(?P<cik>\d+)\s+"
+        r"(?P<date>\d{4}-\d{2}-\d{2})\s+"
+        r"(?P<file>edgar/\S+)\s*$"
+    )
+    # Form type + Company name are separated by at least 2 spaces.
+    # rsplit guards against the possibility that a form type
+    # contains a single space ("1-A POS"); SEC keeps a 2+-space
+    # gap before the company name as the canonical boundary.
+    head_split = re.compile(r"^(?P<form>.+?)\s{2,}(?P<name>.+?)\s*$")
+
+    in_data = False
+    for line in payload.splitlines():
+        if not in_data:
+            if _DATA_MARKER.match(line):
+                in_data = True
+            continue
+        m = line_pattern.match(line)
+        if m is None:
+            continue
+        head_m = head_split.match(m.group("head"))
+        if head_m is None:
+            continue
+        try:
+            cik_padded = f"{int(m.group('cik')):010d}"
+            filed = date.fromisoformat(m.group("date"))
+        except ValueError:
+            continue
+        yield FormIndexEntry(
+            form_type=head_m.group("form").strip(),
+            company_name=head_m.group("name").strip(),
+            cik=cik_padded,
+            date_filed=filed,
+            file_name=m.group("file").strip(),
+        )
+
+
+def aggregate_top_filers(
+    quarters: list[tuple[int, int]],
+    *,
+    top_n: int = 150,
+    fetch: Callable[[int, int], str] = fetch_form_index,
+) -> list[TopFilerCandidate]:
+    """Fetch each quarter's form.idx, sum 13F-HR filing counts per
+    CIK, return the top ``top_n`` candidates sorted by count desc.
+
+    ``fetch`` is injectable for tests so the aggregator can be
+    exercised against a fake.
+
+    A per-quarter fetch failure is logged and skipped — partial
+    coverage is preferable to aborting the whole sweep.
+    """
+    counts: dict[str, int] = defaultdict(int)
+    # Track the date_filed of the name we've recorded so far, so
+    # we keep the name from the LATEST observed filing — robust
+    # against caller passing quarters in any order. Codex pre-push
+    # review caught a previous bug where iteration order determined
+    # the outcome.
+    latest_name: dict[str, str] = {}
+    latest_filed: dict[str, date] = {}
+
+    for year, q in quarters:
+        try:
+            payload = fetch(year, q)
+        except Exception:  # noqa: BLE001 — per-quarter failure isolation
+            logger.exception("top_filer_discovery: form.idx fetch failed for %sQ%s", year, q)
+            continue
+        for entry in parse_form_index(payload):
+            if entry.form_type not in _THIRTEEN_F_FORM_TYPES:
+                continue
+            counts[entry.cik] += 1
+            prior = latest_filed.get(entry.cik)
+            if prior is None or entry.date_filed > prior:
+                latest_name[entry.cik] = entry.company_name
+                latest_filed[entry.cik] = entry.date_filed
+
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [
+        TopFilerCandidate(cik=cik, latest_name=latest_name[cik], filing_count=count) for cik, count in ranked[:top_n]
+    ]

--- a/scripts/seed_top_13f_filers.py
+++ b/scripts/seed_top_13f_filers.py
@@ -1,0 +1,135 @@
+"""Operator CLI — discover and seed top active 13F-HR filers.
+
+Usage::
+
+    # Dry-run: print top-N candidates from the last 4 quarters
+    uv run python -m scripts.seed_top_13f_filers --top-n 200
+
+    # Apply via verification gate
+    uv run python -m scripts.seed_top_13f_filers --top-n 200 --apply
+
+Walks SEC's quarterly form.idx for the past N quarters, aggregates
+13F-HR filing counts per CIK, takes the top-N, runs each through
+the filer_seed_verification gate (PR #821), persists matches via
+seed_filer.
+
+Filing-count is a noisy proxy for AUM — the household-name top
+managers (Vanguard, BlackRock, Fidelity, State Street) file once
+per quarter and rank low. The output IS useful for surfacing
+active filers the operator can hand-pick from. AUM-based ranking
+needs primary_doc.xml fetches (tracked as a follow-up).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date
+
+import psycopg
+
+from app.config import settings
+from app.services import filer_seed_verification
+from app.services.institutional_holdings import seed_filer
+from app.services.top_filer_discovery import aggregate_top_filers
+
+
+def _last_n_quarters(today: date, n: int) -> list[tuple[int, int]]:
+    """Return the last ``n`` (year, quarter) tuples ending at the
+    quarter PRECEDING ``today`` — the current quarter's form.idx
+    is incomplete until the quarter ends."""
+    cur_q = (today.month - 1) // 3 + 1  # 1..4
+    cur_year = today.year
+    out: list[tuple[int, int]] = []
+    y, q = cur_year, cur_q - 1
+    if q == 0:
+        q = 4
+        y -= 1
+    for _ in range(n):
+        out.append((y, q))
+        q -= 1
+        if q == 0:
+            q = 4
+            y -= 1
+    return out
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Seed top 13F-HR filers from SEC form.idx.")
+    p.add_argument("--quarters", type=int, default=4, help="Number of quarters to aggregate.")
+    p.add_argument("--top-n", type=int, default=200, help="Take this many filers from the count ranking.")
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Persist verified filers via seed_filer. Default is dry-run.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    quarters = _last_n_quarters(date.today(), args.quarters)
+    print(f"Aggregating 13F-HR filings across quarters: {quarters}")
+
+    candidates = aggregate_top_filers(quarters, top_n=args.top_n)
+    print(f"Top {len(candidates)} candidates by filing count:")
+    for c in candidates:
+        print(f"  {c.cik}  {c.filing_count:4d}  {c.latest_name}")
+
+    if not args.apply:
+        print("\nDry run — pass --apply to verify + persist.")
+        return 0
+
+    matched = 0
+    drift = 0
+    fetch_errors = 0
+    inserted = 0
+    skipped_existing = 0
+    with psycopg.connect(settings.database_url) as conn:
+        # Pre-load existing curated CIKs so the CLI doesn't
+        # silently overwrite operator-curated display labels with
+        # raw SEC names. Existing rows are operator's choice;
+        # discovery only ADDS new rows. Codex pre-push review
+        # caught the prior label-clobber bug.
+        with conn.cursor() as cur:
+            cur.execute("SELECT cik FROM institutional_filer_seeds")
+            existing_ciks = {row[0] for row in cur.fetchall()}
+
+        for c in candidates:
+            if c.cik in existing_ciks:
+                skipped_existing += 1
+                continue
+            result = filer_seed_verification.verify_seed(
+                conn,
+                cik=c.cik,
+                expected_name=c.latest_name,
+            )
+            if result.status == "match":
+                matched += 1
+                seed_filer(
+                    conn,
+                    cik=c.cik,
+                    label=c.latest_name,
+                    expected_name=c.latest_name,
+                )
+                inserted += 1
+            elif result.status == "drift":
+                drift += 1
+                print(f"  DRIFT  {c.cik}  expected={c.latest_name!r} sec={result.sec_name!r}")
+            elif result.status == "fetch_error":
+                fetch_errors += 1
+                print(f"  FETCH_ERROR  {c.cik}  {result.detail}")
+        conn.commit()
+
+    print(
+        f"\nSummary: existing_preserved={skipped_existing} matched={matched} drift={drift} "
+        f"fetch_errors={fetch_errors} inserted={inserted}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_top_filer_discovery.py
+++ b/tests/test_top_filer_discovery.py
@@ -1,0 +1,260 @@
+"""Tests for the top-13F-filer discovery primitive.
+
+Pins the contract: form.idx parser handles the various
+form-type / company-name shapes in SEC's index, aggregator sums
+counts across quarters, per-quarter fetch failures don't abort
+the sweep.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.top_filer_discovery import (
+    aggregate_top_filers,
+    parse_form_index,
+)
+
+_HEADER = "Description: x\n\nForm Type   Company Name   CIK   Date Filed   File Name\n" + "-" * 100 + "\n"
+
+
+def _row(form_type: str, company: str, cik: int, filed: str, file: str) -> str:
+    """Build one form.idx row with canonical 2+-space gaps. SEC's
+    real layout uses fixed-width columns; the parser anchors on
+    the trailing CIK / date / file columns and only requires 2+
+    spaces between form_type and company_name + before each
+    trailing field."""
+    return f"{form_type}  {company}  {cik}  {filed}  {file}\n"
+
+
+def test_parse_form_index_handles_basic_13fhr_row() -> None:
+    payload = _HEADER + _row("13F-HR", "BlackRock Advisors LLC", 1086364, "2025-03-01", "edgar/data/1086364/a.txt")
+    entries = list(parse_form_index(payload))
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.form_type == "13F-HR"
+    assert e.company_name == "BlackRock Advisors LLC"
+    assert e.cik == "0001086364"
+    assert e.date_filed == date(2025, 3, 1)
+    assert e.file_name == "edgar/data/1086364/a.txt"
+
+
+def test_parse_form_index_pads_cik_to_ten_digits() -> None:
+    """SEC stores CIKs as plain integers in form.idx but every
+    other table in the codebase uses 10-digit zero-padded form."""
+    payload = _HEADER + _row("13F-HR", "Small Filer", 42, "2025-02-14", "edgar/data/42/x.txt")
+    entries = list(parse_form_index(payload))
+    assert entries[0].cik == "0000000042"
+
+
+def test_parse_form_index_handles_form_types_with_spaces() -> None:
+    """Form types like ``1-A POS`` contain a single space; SEC's
+    layout puts a 2+-space gap before the company name as the
+    canonical boundary."""
+    payload = _HEADER + _row("1-A POS", "Foo Bar LLC", 222222, "2025-02-14", "edgar/data/222222/w.txt")
+    entries = list(parse_form_index(payload))
+    assert entries[0].form_type == "1-A POS"
+    assert entries[0].company_name == "Foo Bar LLC"
+
+
+def test_parse_form_index_skips_preamble_and_malformed_lines() -> None:
+    payload = (
+        _HEADER
+        + "garbage line with no structure\n"
+        + _row("13F-HR", "ValidFiler", 100, "2025-01-15", "edgar/data/100/x.txt")
+        + "another garbage\n"
+    )
+    entries = list(parse_form_index(payload))
+    assert len(entries) == 1
+    assert entries[0].cik == "0000000100"
+
+
+def test_aggregate_top_filers_counts_13f_variants_only() -> None:
+    """13F-HR / 13F-HR/A / 13F-NT count toward the aggregation;
+    other forms (10-K, Form 4) do not."""
+    payload = (
+        _HEADER
+        + _row("13F-HR", "Filer A", 100, "2025-01-15", "edgar/data/100/a.txt")
+        + _row("13F-HR/A", "Filer A", 100, "2025-02-01", "edgar/data/100/b.txt")
+        + _row("10-K", "Filer A", 100, "2025-03-01", "edgar/data/100/k.txt")
+        + _row("13F-NT", "Filer B", 200, "2025-01-15", "edgar/data/200/x.txt")
+        + _row("4", "Apple", 320193, "2025-01-15", "edgar/data/320193/z.txt")
+    )
+    fetched: list[tuple[int, int]] = []
+
+    def _fake(year: int, q: int) -> str:
+        fetched.append((year, q))
+        return payload
+
+    top = aggregate_top_filers([(2025, 1)], top_n=10, fetch=_fake)
+    assert fetched == [(2025, 1)]
+    by_cik = {c.cik: c for c in top}
+    assert by_cik["0000000100"].filing_count == 2  # 13F-HR + 13F-HR/A
+    assert by_cik["0000000200"].filing_count == 1  # 13F-NT
+    assert "0000320193" not in by_cik  # Form 4 ignored
+
+
+def test_aggregate_top_filers_sums_across_quarters_and_truncates() -> None:
+    """Counts sum across quarters; result is truncated to top_n
+    sorted by count desc."""
+    by_quarter: dict[tuple[int, int], str] = {
+        (2024, 4): _HEADER
+        + _row("13F-HR", "Filer A", 100, "2024-11-15", "edgar/data/100/a.txt")
+        + _row("13F-HR", "Filer B", 200, "2024-11-15", "edgar/data/200/b.txt")
+        + _row("13F-HR", "Filer C", 300, "2024-11-15", "edgar/data/300/c.txt"),
+        (2025, 1): _HEADER
+        + _row("13F-HR", "Filer A", 100, "2025-02-15", "edgar/data/100/a2.txt")
+        + _row("13F-HR", "Filer A", 100, "2025-03-15", "edgar/data/100/a3.txt")
+        + _row("13F-HR/A", "Filer B", 200, "2025-02-15", "edgar/data/200/b2.txt"),
+    }
+
+    def _fake(year: int, q: int) -> str:
+        return by_quarter[(year, q)]
+
+    top = aggregate_top_filers([(2024, 4), (2025, 1)], top_n=2, fetch=_fake)
+    assert [(c.cik, c.filing_count) for c in top] == [
+        ("0000000100", 3),
+        ("0000000200", 2),
+    ]
+
+
+def test_aggregate_top_filers_per_quarter_failure_isolated() -> None:
+    """A fetch failure on one quarter must not abort the whole
+    sweep. Surviving quarters still aggregate."""
+
+    def _fake(year: int, q: int) -> str:
+        if (year, q) == (2025, 1):
+            raise RuntimeError("simulated SEC outage")
+        return _HEADER + _row("13F-HR", "Filer A", 100, "2024-11-15", "edgar/data/100/a.txt")
+
+    top = aggregate_top_filers([(2024, 4), (2025, 1)], top_n=10, fetch=_fake)
+    assert len(top) == 1
+    assert top[0].cik == "0000000100"
+    assert top[0].filing_count == 1
+
+
+def test_aggregate_top_filers_uses_latest_quarter_name() -> None:
+    """When a filer renames mid-year, the aggregated record uses
+    the most recent quarter's name."""
+    by_quarter: dict[tuple[int, int], str] = {
+        (2024, 4): _HEADER + _row("13F-HR", "OLD CORPORATE NAME LLC", 100, "2024-11-15", "edgar/data/100/a.txt"),
+        (2025, 1): _HEADER + _row("13F-HR", "NEW REBRANDED NAME LLC", 100, "2025-02-15", "edgar/data/100/b.txt"),
+    }
+
+    def _fake(year: int, q: int) -> str:
+        return by_quarter[(year, q)]
+
+    top = aggregate_top_filers([(2024, 4), (2025, 1)], top_n=10, fetch=_fake)
+    assert top[0].latest_name == "NEW REBRANDED NAME LLC"
+
+
+def test_aggregate_top_filers_picks_latest_name_independent_of_quarter_iteration_order() -> None:
+    """latest_name is keyed by date_filed, not iteration order, so
+    a caller passing quarters newest→oldest still gets the most
+    recent name. Regression for the high-severity Codex finding."""
+    by_quarter: dict[tuple[int, int], str] = {
+        (2024, 4): _HEADER + _row("13F-HR", "OLD CORPORATE NAME LLC", 100, "2024-11-15", "edgar/data/100/a.txt"),
+        (2025, 1): _HEADER + _row("13F-HR", "NEW REBRANDED NAME LLC", 100, "2025-02-15", "edgar/data/100/b.txt"),
+    }
+
+    def _fake(year: int, q: int) -> str:
+        return by_quarter[(year, q)]
+
+    # Pass quarters newest-first (the order _last_n_quarters returns).
+    top = aggregate_top_filers([(2025, 1), (2024, 4)], top_n=10, fetch=_fake)
+    assert top[0].latest_name == "NEW REBRANDED NAME LLC"
+
+
+def test_last_n_quarters_returns_newest_first_excluding_current() -> None:
+    """The CLI helper _last_n_quarters skips the in-progress
+    quarter and returns N closed quarters newest-first."""
+    from datetime import date as _d
+
+    from scripts.seed_top_13f_filers import _last_n_quarters
+
+    # March is in Q1; the most recent CLOSED quarter is Q4 of the
+    # prior year.
+    assert _last_n_quarters(_d(2025, 3, 15), 4) == [
+        (2024, 4),
+        (2024, 3),
+        (2024, 2),
+        (2024, 1),
+    ]
+    # July is in Q3; closed quarters are Q2 of same year going back.
+    assert _last_n_quarters(_d(2025, 7, 1), 3) == [
+        (2025, 2),
+        (2025, 1),
+        (2024, 4),
+    ]
+
+
+def test_cli_apply_skips_existing_seeded_ciks(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The --apply CLI must NOT overwrite operator-curated rows.
+    CIKs already present in institutional_filer_seeds are preserved
+    and reported in the summary as existing_preserved. Regression
+    for the medium-severity Codex finding (label clobber)."""
+    import psycopg as _psycopg
+
+    from app.services import filer_seed_verification, top_filer_discovery
+    from scripts import seed_top_13f_filers as cli
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    # Pull a connection fresh; we can't use the fixture here because
+    # this isn't a fixture-using test, so do it manually.
+    test_url = test_database_url()
+    setup_conn = _psycopg.connect(test_url)
+    try:
+        # Truncate first to start clean.
+        setup_conn.execute("TRUNCATE institutional_filer_seeds CASCADE")
+        # Seed an existing curated row.
+        setup_conn.execute(
+            """
+            INSERT INTO institutional_filer_seeds (cik, label, expected_name, active)
+            VALUES ('0000111000', 'Curated Display Label', 'CURATED EXPECTED', TRUE)
+            """,
+        )
+        setup_conn.commit()
+
+        # Stub aggregator to return a candidate matching the curated CIK.
+        monkeypatch.setattr(
+            top_filer_discovery,
+            "aggregate_top_filers",
+            lambda quarters, top_n=200, fetch=None: [
+                top_filer_discovery.TopFilerCandidate(
+                    cik="0000111000",
+                    latest_name="Raw SEC Name",
+                    filing_count=10,
+                ),
+            ],
+        )
+        # Patch the CLI's import too — resolves at module load.
+        monkeypatch.setattr(cli, "aggregate_top_filers", top_filer_discovery.aggregate_top_filers)
+        monkeypatch.setattr(
+            filer_seed_verification,
+            "_fetch_submissions",
+            lambda _conn, _cik: {"name": "Raw SEC Name"},
+        )
+        # Route the CLI's psycopg.connect to the test DB.
+        original_connect = _psycopg.connect
+        monkeypatch.setattr(cli.psycopg, "connect", lambda _url: original_connect(test_url))
+
+        cli.main(["--top-n", "10", "--apply"])
+        capsys.readouterr()  # drain
+
+        # Curated label MUST be preserved.
+        with setup_conn.cursor() as cur:
+            cur.execute(
+                "SELECT label FROM institutional_filer_seeds WHERE cik = '0000111000'",
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "Curated Display Label"  # NOT clobbered to 'Raw SEC Name'
+    finally:
+        setup_conn.execute("TRUNCATE institutional_filer_seeds CASCADE")
+        setup_conn.commit()
+        setup_conn.close()


### PR DESCRIPTION
## What
Pre-cursor for the 14→150 \`institutional_filer_seeds\` expansion. Consumes SEC's quarterly \`form.idx\` (~5,400 active 13F filers per quarter) to surface candidates, runs each through the verification gate (#821), persists matches.

- \`app/services/top_filer_discovery.py\` — \`parse_form_index\` + \`aggregate_top_filers\`. Handles form-types-with-spaces, malformed rows, per-quarter fetch failures.
- \`scripts/seed_top_13f_filers.py\` — operator CLI. \`--apply\` PRESERVES existing curated rows (does NOT overwrite labels) + verifies before persisting.
- 11 unit tests.

## Limitation
Filing-count is a noisy proxy for AUM. Vanguard / BlackRock / Fidelity / State Street file once per quarter and rank low. AUM-based ranking via \`primary_doc.xml\` fetches is a follow-up. Current output is useful for surfacing active filers the operator can hand-pick from + a "is filer X actively filing?" check.

## Test plan
- [x] \`pytest tests/test_top_filer_discovery.py\` 11/11
- [x] \`ruff\` / \`pyright\` clean
- [x] Codex pre-push review (2 rounds) — quarter-order bug + label-clobber bug both fixed; final pass clean
- [x] Live aggregation against Q1 2025 + last 3 quarters: 50MB form.idx parses cleanly, top-20 returned

## Follow-ups
- AUM-based ranking via primary_doc.xml fetches (separate PR — heavier).
- Bulk apply of confirmed top-150 list once AUM ranking lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)