### PR TITLE
feat(#788 Chain 2.6): Form 3 baseline drillthrough + CSV export

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -30,6 +30,7 @@ import httpx
 import psycopg
 import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 
 from app.api.auth import require_session_or_service_token
@@ -2114,6 +2115,247 @@ def get_instrument_insider_baseline(
             )
             for h in holdings
         ],
+    )
+
+
+# ---------------------------------------------------------------------
+# Form 3 baseline drillthrough + CSV export (#788 Chain 2.6)
+# ---------------------------------------------------------------------
+
+
+class InsiderBaselineDrillModel(BaseModel):
+    """Drillthrough payload pairing the baseline holdings list with
+    the Form 3 pipeline state from ownership_drillthrough.
+
+    Lets the operator distinguish "no baseline rows because the
+    issuer has no Form 3 filings" from "no baseline rows because
+    the parser missed / tombstoned them" without flipping between
+    pages.
+    """
+
+    symbol: str
+    instrument_id: int
+    rows: list[InsiderBaselineHoldingModel]
+    pipeline_typed_row_count: int
+    pipeline_raw_body_count: int
+    pipeline_tombstone_count: int
+    pipeline_notes: list[str]
+
+
+@router.get(
+    "/{symbol}/insider_baseline/drill",
+    response_model=InsiderBaselineDrillModel,
+)
+def get_insider_baseline_drill(
+    symbol: str,
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_form3'.",
+    ),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InsiderBaselineDrillModel:
+    """Form 3 baseline list + per-instrument pipeline state.
+
+    Empty-state contract matches ``/insider_baseline``: unknown
+    symbol → 404, no SEC coverage → 404, ingest-not-yet-run →
+    200 with empty rows + pipeline notes saying "no Form 3
+    baseline filings"."""
+    from app.services.insider_form3_ingest import list_baseline_only_insider_holdings
+
+    _validate_provider(provider, _INSIDER_BASELINE_PROVIDERS)
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
+
+    holdings = list_baseline_only_insider_holdings(conn, instrument_id=instrument_id)
+
+    # Inline Form 3 pipeline state — typed-row count, raw bodies,
+    # tombstones, informational notes. Same shape as the
+    # ownership_drillthrough service (Chain 2.5, PR #830);
+    # inlined here so this PR is independent of #830's merge order.
+    notes: list[str] = []
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) AS row_count
+            FROM insider_initial_holdings h
+            JOIN insider_filings f ON f.accession_number = h.accession_number
+            WHERE h.instrument_id = %s
+              AND f.document_type LIKE '3%%'
+              AND f.is_tombstone = FALSE
+            """,
+            (instrument_id,),
+        )
+        typed = cur.fetchone() or {"row_count": 0}
+        cur.execute(
+            """
+            SELECT COUNT(*) AS tombstone_count
+            FROM insider_filings
+            WHERE instrument_id = %s
+              AND document_type LIKE '3%%'
+              AND is_tombstone = TRUE
+            """,
+            (instrument_id,),
+        )
+        tomb = cur.fetchone() or {"tombstone_count": 0}
+        cur.execute(
+            """
+            SELECT COUNT(DISTINCT r.accession_number) AS body_count
+            FROM filing_raw_documents r
+            JOIN insider_filings i ON i.accession_number = r.accession_number
+            WHERE r.document_kind = 'form3_xml' AND i.instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        body = cur.fetchone() or {"body_count": 0}
+
+    typed_row_count = int(typed["row_count"])
+    tombstone_count = int(tomb["tombstone_count"])
+    raw_body_count = int(body["body_count"])
+    # "No filings" is the LITERAL no-coverage case: zero typed
+    # rows, zero tombstones, zero raw bodies. The other zero-typed
+    # cases (rewash candidate / tombstoned-only) get more specific
+    # notes below — Codex pre-push review caught the prior
+    # mislabelling.
+    if typed_row_count == 0 and tombstone_count == 0 and raw_body_count == 0:
+        notes.append("no Form 3 baseline filings")
+    if tombstone_count:
+        notes.append(f"{tombstone_count} tombstoned filing(s)")
+    if raw_body_count and not typed_row_count:
+        notes.append("raw bodies on file but zero typed rows — rewash candidate")
+
+    return InsiderBaselineDrillModel(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        instrument_id=instrument_id,
+        rows=[
+            InsiderBaselineHoldingModel(
+                filer_cik=h.filer_cik,
+                filer_name=h.filer_name,
+                filer_role=h.filer_role,
+                security_title=h.security_title,
+                is_derivative=h.is_derivative,
+                direct_indirect=h.direct_indirect,
+                shares=h.shares,
+                value_owned=h.value_owned,
+                as_of_date=h.as_of_date,
+            )
+            for h in holdings
+        ],
+        pipeline_typed_row_count=typed_row_count,
+        pipeline_raw_body_count=raw_body_count,
+        pipeline_tombstone_count=tombstone_count,
+        pipeline_notes=notes,
+    )
+
+
+@router.get(
+    "/{symbol}/insider_baseline/export.csv",
+    response_class=PlainTextResponse,
+)
+def get_insider_baseline_csv(
+    symbol: str,
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_form3'.",
+    ),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> PlainTextResponse:
+    """Operator-friendly CSV export of the same baseline list.
+
+    Always 200 (with a single header row when no data) so an
+    automation script can pipe this into a spreadsheet without
+    branch-on-status. Intentionally streams as text/csv with
+    ``Content-Disposition: attachment`` so the browser saves the
+    file rather than rendering the raw text."""
+    from app.services.insider_form3_ingest import list_baseline_only_insider_holdings
+
+    _validate_provider(provider, _INSIDER_BASELINE_PROVIDERS)
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
+
+    holdings = list_baseline_only_insider_holdings(conn, instrument_id=instrument_id)
+
+    # Build CSV via csv.writer to a StringIO so we get the
+    # canonical quoting + line terminator. Plain str-join would
+    # mishandle commas / quotes inside filer names.
+    import csv
+    import io
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerow(
+        [
+            "filer_cik",
+            "filer_name",
+            "filer_role",
+            "security_title",
+            "is_derivative",
+            "direct_indirect",
+            "shares",
+            "value_owned",
+            "as_of_date",
+        ]
+    )
+    for h in holdings:
+        writer.writerow(
+            [
+                h.filer_cik,
+                h.filer_name,
+                h.filer_role or "",
+                h.security_title or "",
+                "true" if h.is_derivative else "false",
+                h.direct_indirect or "",
+                str(h.shares) if h.shares is not None else "",
+                str(h.value_owned) if h.value_owned is not None else "",
+                h.as_of_date.isoformat(),
+            ]
+        )
+    return PlainTextResponse(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": f'attachment; filename="{symbol_clean}_insider_baseline.csv"',
+        },
     )
 
 

--- a/tests/test_insider_baseline_drill.py
+++ b/tests/test_insider_baseline_drill.py
@@ -1,0 +1,219 @@
+"""Tests for the Form 3 baseline drillthrough + CSV export
+(#788 Chain 2.6).
+
+Pins: drill endpoint composites baseline list + pipeline state,
+CSV export emits header even on empty data, unknown / no-SEC
+instruments 404.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Iterator
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument_with_cik(
+    conn: psycopg.Connection[tuple],
+    *,
+    iid: int,
+    symbol: str,
+    cik: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (
+            instrument_id, provider, identifier_type, identifier_value, is_primary
+        ) VALUES (%s, 'sec', 'cik', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        """,
+        (iid, cik),
+    )
+
+
+@pytest.fixture
+def client(
+    monkeypatch: pytest.MonkeyPatch,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> Iterator[TestClient]:
+    """Route the FastAPI app's get_conn dep at the test DB so the
+    drill endpoint reads what we seed."""
+    from app.api import auth
+    from app.db import get_conn
+
+    def _override_conn() -> Iterator[psycopg.Connection[tuple]]:
+        yield ebull_test_conn
+
+    def _override_auth() -> object:
+        return object()  # any non-None marker
+
+    app.dependency_overrides[get_conn] = _override_conn
+    app.dependency_overrides[auth.require_session_or_service_token] = _override_auth
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+        app.dependency_overrides.pop(auth.require_session_or_service_token, None)
+
+
+def test_drill_returns_pipeline_state_alongside_baseline_rows(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """An instrument with no Form 3 filings still resolves — drill
+    returns rows=[] plus a pipeline state with the 'no Form 3
+    baseline filings' note so the operator sees the gap explicitly."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=971_001, symbol="ABCD", cik="0000111000")
+    conn.commit()
+
+    resp = client.get("/instruments/ABCD/insider_baseline/drill")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["symbol"] == "ABCD"
+    assert body["instrument_id"] == 971_001
+    assert body["rows"] == []
+    assert body["pipeline_typed_row_count"] == 0
+    assert body["pipeline_raw_body_count"] == 0
+    assert body["pipeline_tombstone_count"] == 0
+    assert any("Form 3" in n or "no Form 3" in n.lower() for n in body["pipeline_notes"])
+
+
+def test_drill_404s_unknown_symbol(client: TestClient) -> None:
+    resp = client.get("/instruments/NONEXISTENT/insider_baseline/drill")
+    assert resp.status_code == 404
+
+
+def test_drill_404s_when_no_sec_cik(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Instrument exists but has no SEC CIK → 404. Same gate as
+    /insider_baseline."""
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (971_002, 'NOCIK', 'No CIK Inc', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+    )
+    conn.commit()
+
+    resp = client.get("/instruments/NOCIK/insider_baseline/drill")
+    assert resp.status_code == 404
+
+
+def test_csv_export_emits_header_even_on_empty(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Empty data still produces a valid CSV with header so
+    automation scripts don't have to branch on the empty case."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=971_003, symbol="EXPT", cik="0000111002")
+    conn.commit()
+
+    resp = client.get("/instruments/EXPT/insider_baseline/export.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert "attachment" in resp.headers["content-disposition"]
+    rows = list(csv.reader(io.StringIO(resp.text)))
+    assert rows[0] == [
+        "filer_cik",
+        "filer_name",
+        "filer_role",
+        "security_title",
+        "is_derivative",
+        "direct_indirect",
+        "shares",
+        "value_owned",
+        "as_of_date",
+    ]
+    assert len(rows) == 1  # header only
+
+
+def test_csv_export_404s_unknown_symbol(client: TestClient) -> None:
+    resp = client.get("/instruments/NONEXISTENT/insider_baseline/export.csv")
+    assert resp.status_code == 404
+
+
+def test_drill_rejects_wrong_provider(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """``?provider=sec_form4`` is invalid for the Form 3 baseline
+    drill. Same gate as /insider_baseline. Codex pre-push review
+    caught the missing validator."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=971_010, symbol="PROVDR", cik="0000111005")
+    conn.commit()
+
+    resp = client.get("/instruments/PROVDR/insider_baseline/drill?provider=sec_form4")
+    assert resp.status_code == 400
+
+
+def test_csv_rejects_wrong_provider(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Same provider gate on the CSV export."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=971_011, symbol="PROVCS", cik="0000111006")
+    conn.commit()
+
+    resp = client.get("/instruments/PROVCS/insider_baseline/export.csv?provider=sec_form4")
+    assert resp.status_code == 400
+
+
+def test_drill_no_filings_note_only_when_no_evidence_at_all(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """When tombstones or raw bodies exist, the 'no Form 3 baseline
+    filings' note must NOT fire — the more specific notes
+    (tombstoned / rewash candidate) carry the truth. Codex pre-push
+    review caught the prior mislabelling."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=971_012, symbol="TOMB3", cik="0000111007")
+    # Tombstoned filing only — no typed rows, no raw body.
+    conn.execute(
+        """
+        INSERT INTO insider_filings (
+            accession_number, instrument_id, document_type,
+            primary_document_url, parser_version, is_tombstone,
+            period_of_report
+        ) VALUES ('t-26-1', 971_012, '3', 'u', 1, TRUE, '2025-01-15')
+        """,
+    )
+    conn.commit()
+
+    resp = client.get("/instruments/TOMB3/insider_baseline/drill")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["pipeline_tombstone_count"] == 1
+    notes = body["pipeline_notes"]
+    # 'no Form 3 baseline filings' must NOT be in notes — there IS a
+    # filing, it's tombstoned. The specific tombstone note carries
+    # the actual state.
+    assert not any("no Form 3 baseline filings" in n for n in notes)
+    assert any("tombstoned" in n.lower() for n in notes)


### PR DESCRIPTION
## What
Two operator endpoints alongside the existing \`/insider_baseline\`:

- \`GET /instruments/{symbol}/insider_baseline/drill\` — baseline holdings list + Form 3 pipeline state (typed_row_count, raw_body_count, tombstone_count, notes).
- \`GET /instruments/{symbol}/insider_baseline/export.csv\` — text/csv with \`Content-Disposition: attachment\`. Header always emitted.

Both share existing /insider_baseline gates (404 unknown / no-SEC-CIK, 400 wrong provider).

## Why
Lets the operator distinguish "no Form 3 filings" from "parser missed / tombstoned" in one read instead of joining typed + raw + log tables by hand.

## Test plan
- [x] \`pytest tests/test_insider_baseline_drill.py\` 8/8
- [x] \`ruff\` / \`pyright\` clean
- [x] Codex pre-push review (2 rounds) — provider-validation gap + mislabelled "no filings" note both fixed; final pass clean

## Notes
Pipeline-state SQL inlined rather than calling \`ownership_drillthrough.get_instrument_drillthrough\` (Chain 2.5 / PR #830) so this PR is independent of #830's merge order. Once both land, follow-up can deduplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)