### PR TITLE
feat(#788 Chain 2.7): DEF 14A drillthrough + CSV export

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -21,6 +21,8 @@ DB-only.
 
 from __future__ import annotations
 
+import csv
+import io
 import logging
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
@@ -1170,6 +1172,7 @@ _INSIDER_PROVIDERS: tuple[str, ...] = ("sec_form4",)
 # rather than silently passing through to a reader that doesn't
 # consume it. PR #774 review caught the cross-contamination risk.
 _INSIDER_BASELINE_PROVIDERS: tuple[str, ...] = ("sec_form3",)
+_DEF14A_PROVIDERS: tuple[str, ...] = ("sec_def14a",)
 
 
 def _validate_provider(provider: str | None, allowed: tuple[str, ...]) -> None:
@@ -2318,9 +2321,6 @@ def get_insider_baseline_csv(
     # Build CSV via csv.writer to a StringIO so we get the
     # canonical quoting + line terminator. Plain str-join would
     # mishandle commas / quotes inside filer names.
-    import csv
-    import io
-
     buf = io.StringIO()
     writer = csv.writer(buf, lineterminator="\n")
     writer.writerow(
@@ -2355,6 +2355,361 @@ def get_insider_baseline_csv(
         media_type="text/csv",
         headers={
             "Content-Disposition": f'attachment; filename="{symbol_clean}_insider_baseline.csv"',
+        },
+    )
+
+
+# ---------------------------------------------------------------------
+# DEF 14A beneficial-ownership drillthrough + CSV export (#788 Chain 2.7)
+# ---------------------------------------------------------------------
+
+
+class Def14AHolderModel(BaseModel):
+    holder_name: str
+    holder_role: str | None
+    shares: Decimal | None
+    percent_of_class: Decimal | None
+    as_of_date: date | None
+    accession_number: str
+    issuer_cik: str
+
+
+class Def14ADrillModel(BaseModel):
+    """Holders + Form 14A pipeline state.
+
+    ``holders`` are from the latest TYPED-ROW filing
+    (def14a_beneficial_holdings → latest as_of_date). When a
+    newer filing exists in filing_events but didn't produce
+    typed rows (parser failed / not yet ingested),
+    ``pipeline_notes`` surfaces the gap so the operator doesn't
+    silently see stale holders. Codex pre-push review caught
+    the prior version which served stale holders without
+    surfacing the newer filing's existence.
+    """
+
+    symbol: str
+    instrument_id: int
+    holders: list[Def14AHolderModel]
+    pipeline_typed_row_count: int
+    pipeline_raw_body_count: int
+    pipeline_tombstone_count: int
+    pipeline_notes: list[str]
+    # Newest DEF 14A filing date observed in filing_events, regardless
+    # of whether typed rows exist for it. Lets the operator see at a
+    # glance whether the holders shown are from the latest known
+    # filing or an older one.
+    latest_known_filing_date: date | None
+    # Date of the filing the holders are from (the typed-row
+    # filing). NULL when no typed rows exist.
+    holders_as_of_date: date | None
+
+
+@router.get(
+    "/{symbol}/def14a_holdings/drill",
+    response_model=Def14ADrillModel,
+)
+def get_def14a_drill(
+    symbol: str,
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_def14a'.",
+    ),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> Def14ADrillModel:
+    """Latest-filing DEF 14A beneficial-ownership holders + Form
+    14A pipeline state (typed row count, raw body count,
+    tombstones, notes). Same gates as /insider_baseline."""
+    _validate_provider(provider, _DEF14A_PROVIDERS)
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
+
+    # Latest filing's holders. ``ORDER BY as_of_date DESC NULLS
+    # LAST, accession_number DESC`` so a tie-breaks on accession
+    # rather than picking arbitrarily; NULLS LAST so a non-null
+    # ``as_of_date`` always beats a null one.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH latest AS (
+                SELECT accession_number, as_of_date AS holders_as_of
+                FROM def14a_beneficial_holdings
+                WHERE instrument_id = %s
+                ORDER BY as_of_date DESC NULLS LAST, accession_number DESC
+                LIMIT 1
+            )
+            SELECT holder_name, holder_role, shares, percent_of_class,
+                   h.as_of_date, h.accession_number, issuer_cik,
+                   latest.holders_as_of
+            FROM def14a_beneficial_holdings h
+            JOIN latest USING (accession_number)
+            WHERE instrument_id = %s
+            ORDER BY shares DESC NULLS LAST, holder_name
+            """,
+            (instrument_id, instrument_id),
+        )
+        holder_rows = cur.fetchall()
+        holders_as_of_date = holder_rows[0].get("holders_as_of") if holder_rows else None
+
+        # Newest DEF 14A filing observed in filing_events
+        # (regardless of whether typed rows exist for it). Track
+        # ``provider_filing_id`` (= accession_number) so the
+        # stale check below can compare like-for-like against the
+        # holders' accession. ``filing_date`` and the holders'
+        # ``as_of_date`` are different business dates for the same
+        # filing — Codex pre-push review caught a prior version
+        # that compared them and false-positived.
+        cur.execute(
+            """
+            SELECT provider_filing_id AS accession, filing_date
+            FROM filing_events
+            WHERE provider = 'sec'
+              AND filing_type = 'DEF 14A'
+              AND instrument_id = %s
+            -- Tie-break on accession (provider_filing_id), not
+            -- filing_event_id, so the choice is deterministic
+            -- regardless of insert order. Codex pre-push review
+            -- caught a same-day false-stale where event-id tie-
+            -- break picked acc-2 over acc-1.
+            ORDER BY filing_date DESC, provider_filing_id DESC
+            LIMIT 1
+            """,
+            (instrument_id,),
+        )
+        latest_event_row = cur.fetchone()
+        latest_known_filing_date = latest_event_row.get("filing_date") if latest_event_row else None
+        latest_known_accession = latest_event_row.get("accession") if latest_event_row else None
+        holders_accession = holder_rows[0].get("accession_number") if holder_rows else None
+
+        # Pipeline state (mirrors ownership_drillthrough's def14a
+        # query — inlined to keep this PR independent of #830's
+        # merge order).
+        cur.execute(
+            "SELECT COUNT(*) AS row_count FROM def14a_beneficial_holdings WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        typed = cur.fetchone() or {"row_count": 0}
+        # COUNT(DISTINCT log.accession_number): a single filing
+        # retried multiple times produces multiple log rows, so a
+        # bare COUNT(*) inflates tombstone_count and misleads
+        # operator triage. Claude PR #833 review caught this as
+        # WARNING — filing-level counts are the canonical operator
+        # signal, not row-level.
+        cur.execute(
+            """
+            SELECT COUNT(DISTINCT log.accession_number) AS tombstone_count
+            FROM def14a_ingest_log log
+            WHERE log.status IN ('partial', 'failed')
+              AND log.accession_number IN (
+                  SELECT accession_number FROM def14a_beneficial_holdings
+                  WHERE instrument_id = %s
+                  UNION
+                  SELECT fe.provider_filing_id FROM filing_events fe
+                  WHERE fe.provider = 'sec' AND fe.instrument_id = %s
+                    AND fe.filing_type = 'DEF 14A'
+              )
+            """,
+            (instrument_id, instrument_id),
+        )
+        tomb = cur.fetchone() or {"tombstone_count": 0}
+        cur.execute(
+            """
+            SELECT COUNT(DISTINCT r.accession_number) AS body_count
+            FROM filing_raw_documents r
+            JOIN filing_events fe ON fe.provider_filing_id = r.accession_number
+            WHERE r.document_kind = 'def14a_body'
+              AND fe.provider = 'sec'
+              AND fe.filing_type = 'DEF 14A'
+              AND fe.instrument_id = %s
+            """,
+            (instrument_id,),
+        )
+        body = cur.fetchone() or {"body_count": 0}
+
+    typed_count = int(typed["row_count"])
+    tombstone_count = int(tomb["tombstone_count"])
+    raw_body_count = int(body["body_count"])
+
+    # Discovered-but-unparsed: filings exist in filing_events but
+    # haven't produced typed rows / raw bodies / tombstones. The
+    # ingest queue should pick them up; surface as info so the
+    # operator knows the gap is queue-side, not pipeline-side.
+    discovered_unparsed_count = 0
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) AS c
+            FROM filing_events fe
+            WHERE fe.provider = 'sec'
+              AND fe.filing_type = 'DEF 14A'
+              AND fe.instrument_id = %s
+              AND NOT EXISTS (
+                  SELECT 1 FROM def14a_ingest_log log
+                  WHERE log.accession_number = fe.provider_filing_id
+              )
+            """,
+            (instrument_id,),
+        )
+        d_row = cur.fetchone()
+        if d_row is not None:
+            discovered_unparsed_count = int(d_row["c"])
+
+    notes: list[str] = []
+    if typed_count == 0 and tombstone_count == 0 and raw_body_count == 0 and discovered_unparsed_count == 0:
+        notes.append("no DEF 14A holders")
+    if tombstone_count:
+        notes.append(f"{tombstone_count} tombstoned proxy filing(s)")
+    if raw_body_count and not typed_count:
+        notes.append("raw bodies on file but zero typed rows — rewash candidate")
+    if discovered_unparsed_count:
+        notes.append(f"{discovered_unparsed_count} filing(s) discovered but not yet ingested")
+    # Stale-holders surface: the latest filing in filing_events is
+    # a DIFFERENT accession than the one the holders came from.
+    # Compare by accession (not date) — filing_date and as_of_date
+    # are different business dates of the same filing, so a date
+    # comparison would false-positive on a healthy single-filing
+    # case. Codex pre-push review caught.
+    if (
+        latest_known_accession is not None
+        and holders_accession is not None
+        and latest_known_accession != holders_accession
+    ):
+        date_str = latest_known_filing_date.isoformat() if latest_known_filing_date is not None else "unknown"
+        notes.append(
+            f"holders shown are from accession {holders_accession}; "
+            f"newer DEF 14A {latest_known_accession} (filed {date_str}) "
+            f"is missing typed rows"
+        )
+
+    return Def14ADrillModel(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        instrument_id=instrument_id,
+        holders=[
+            Def14AHolderModel(
+                holder_name=str(r["holder_name"]),  # type: ignore[arg-type]
+                holder_role=(str(r["holder_role"]) if r.get("holder_role") else None),
+                shares=r.get("shares"),  # type: ignore[arg-type]
+                percent_of_class=r.get("percent_of_class"),  # type: ignore[arg-type]
+                as_of_date=r.get("as_of_date"),  # type: ignore[arg-type]
+                accession_number=str(r["accession_number"]),  # type: ignore[arg-type]
+                issuer_cik=str(r["issuer_cik"]),  # type: ignore[arg-type]
+            )
+            for r in holder_rows
+        ],
+        pipeline_typed_row_count=typed_count,
+        pipeline_raw_body_count=raw_body_count,
+        pipeline_tombstone_count=tombstone_count,
+        pipeline_notes=notes,
+        latest_known_filing_date=latest_known_filing_date,
+        holders_as_of_date=holders_as_of_date,
+    )
+
+
+@router.get(
+    "/{symbol}/def14a_holdings/export.csv",
+    response_class=PlainTextResponse,
+)
+def get_def14a_csv(
+    symbol: str,
+    provider: str | None = Query(
+        default=None,
+        description="Capability provider tag. Today only 'sec_def14a'.",
+    ),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> PlainTextResponse:
+    """CSV export of all DEF 14A holders across all on-file
+    accessions for the instrument. Operator-friendly: header
+    always emitted; downloaded file uses
+    ``Content-Disposition: attachment``."""
+    _validate_provider(provider, _DEF14A_PROVIDERS)
+
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    if not _has_sec_cik(conn, instrument_id):
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} has no SEC coverage")
+
+    # Export ALL holdings (every accession) — the CSV is for
+    # historical analysis, not the latest snapshot. Ordered so a
+    # spreadsheet groups by filing year naturally.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT accession_number, issuer_cik, holder_name, holder_role,
+                   shares, percent_of_class, as_of_date
+            FROM def14a_beneficial_holdings
+            WHERE instrument_id = %s
+            ORDER BY as_of_date DESC NULLS LAST, accession_number DESC,
+                     shares DESC NULLS LAST, holder_name
+            """,
+            (instrument_id,),
+        )
+        rows = cur.fetchall()
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerow(
+        [
+            "accession_number",
+            "issuer_cik",
+            "holder_name",
+            "holder_role",
+            "shares",
+            "percent_of_class",
+            "as_of_date",
+        ]
+    )
+    for r in rows:
+        writer.writerow(
+            [
+                str(r["accession_number"]),
+                str(r["issuer_cik"]),
+                str(r["holder_name"]),
+                str(r["holder_role"] or ""),
+                str(r["shares"]) if r.get("shares") is not None else "",
+                str(r["percent_of_class"]) if r.get("percent_of_class") is not None else "",
+                r["as_of_date"].isoformat() if r.get("as_of_date") else "",
+            ]
+        )
+    return PlainTextResponse(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": f'attachment; filename="{symbol_clean}_def14a_holdings.csv"',
         },
     )
 

--- a/tests/test_def14a_drill.py
+++ b/tests/test_def14a_drill.py
@@ -1,0 +1,428 @@
+"""Tests for the DEF 14A drillthrough + CSV export
+(#788 Chain 2.7).
+
+Pins: latest-filing holders only on the drill, header always
+on the CSV, gates (404 unknown / no-SEC-CIK, 400 wrong provider).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Iterator
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument_with_cik(
+    conn: psycopg.Connection[tuple],
+    *,
+    iid: int,
+    symbol: str,
+    cik: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (
+            instrument_id, provider, identifier_type, identifier_value, is_primary
+        ) VALUES (%s, 'sec', 'cik', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        """,
+        (iid, cik),
+    )
+
+
+@pytest.fixture
+def client(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> Iterator[TestClient]:
+    from app.api import auth
+    from app.db import get_conn
+
+    def _override_conn() -> Iterator[psycopg.Connection[tuple]]:
+        yield ebull_test_conn
+
+    def _override_auth() -> object:
+        return object()
+
+    app.dependency_overrides[get_conn] = _override_conn
+    app.dependency_overrides[auth.require_session_or_service_token] = _override_auth
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+        app.dependency_overrides.pop(auth.require_session_or_service_token, None)
+
+
+def test_drill_returns_latest_filing_holders_only(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """When two DEF 14A filings exist, the drill returns ONLY the
+    holders from the most recent (by as_of_date)."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_001, symbol="DRILL", cik="0000111100")
+    # Older filing — should NOT appear in the response.
+    conn.execute(
+        """
+        INSERT INTO def14a_beneficial_holdings (
+            instrument_id, accession_number, issuer_cik,
+            holder_name, holder_role, shares, percent_of_class, as_of_date
+        ) VALUES (%s, 'old-26-1', '0000111100',
+                  'Old Holder', 'officer', 100, 5.0, '2024-03-01')
+        """,
+        (972_001,),
+    )
+    # Newer filing — these should appear.
+    for name, shares in [("Latest A", 200), ("Latest B", 150)]:
+        conn.execute(
+            """
+            INSERT INTO def14a_beneficial_holdings (
+                instrument_id, accession_number, issuer_cik,
+                holder_name, holder_role, shares, percent_of_class, as_of_date
+            ) VALUES (%s, 'new-26-1', '0000111100',
+                      %s, 'director', %s, 8.0, '2025-03-01')
+            """,
+            (972_001, name, shares),
+        )
+    conn.commit()
+
+    resp = client.get("/instruments/DRILL/def14a_holdings/drill")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["symbol"] == "DRILL"
+    holder_names = {h["holder_name"] for h in body["holders"]}
+    # Old Holder (older as_of_date) must NOT be in the latest snapshot.
+    assert holder_names == {"Latest A", "Latest B"}
+    # Sorted by shares desc — Latest A (200) before Latest B (150).
+    assert body["holders"][0]["holder_name"] == "Latest A"
+    # Pipeline state counts ALL rows (3 across two filings).
+    assert body["pipeline_typed_row_count"] == 3
+
+
+def test_drill_404s_unknown_symbol(client: TestClient) -> None:
+    resp = client.get("/instruments/NONEXISTENT/def14a_holdings/drill")
+    assert resp.status_code == 404
+
+
+def test_drill_404s_when_no_sec_cik(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (972_002, 'NOCIK14A', 'No CIK', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+    )
+    conn.commit()
+    resp = client.get("/instruments/NOCIK14A/def14a_holdings/drill")
+    assert resp.status_code == 404
+
+
+def test_drill_rejects_wrong_provider(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_003, symbol="WRONGP", cik="0000111101")
+    conn.commit()
+    resp = client.get("/instruments/WRONGP/def14a_holdings/drill?provider=sec_form4")
+    assert resp.status_code == 400
+
+
+def test_drill_no_holders_note_only_when_no_evidence(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """With zero typed rows + zero tombstones + zero raw bodies,
+    'no DEF 14A holders' note fires. With evidence, the more
+    specific notes carry the truth."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_004, symbol="EMPTY14A", cik="0000111102")
+    conn.commit()
+    resp = client.get("/instruments/EMPTY14A/def14a_holdings/drill")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["holders"] == []
+    assert any("no DEF 14A holders" in n for n in body["pipeline_notes"])
+
+
+def test_csv_export_emits_header_even_on_empty(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_005, symbol="CSVD14", cik="0000111103")
+    conn.commit()
+    resp = client.get("/instruments/CSVD14/def14a_holdings/export.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    rows = list(csv.reader(io.StringIO(resp.text)))
+    assert rows[0] == [
+        "accession_number",
+        "issuer_cik",
+        "holder_name",
+        "holder_role",
+        "shares",
+        "percent_of_class",
+        "as_of_date",
+    ]
+    assert len(rows) == 1
+
+
+def test_csv_export_includes_all_filings(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """CSV is for historical analysis — includes EVERY filing,
+    not just the latest. Distinguishes from the drill view which
+    is latest-only."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_006, symbol="HIST14", cik="0000111104")
+    for accn, name, year in [("h-24", "Past Holder", "2024"), ("h-25", "Now Holder", "2025")]:
+        conn.execute(
+            """
+            INSERT INTO def14a_beneficial_holdings (
+                instrument_id, accession_number, issuer_cik,
+                holder_name, holder_role, shares, percent_of_class, as_of_date
+            ) VALUES (%s, %s, '0000111104',
+                      %s, 'officer', 100, 5.0, %s)
+            """,
+            (972_006, accn, name, f"{year}-03-01"),
+        )
+    conn.commit()
+    resp = client.get("/instruments/HIST14/def14a_holdings/export.csv")
+    assert resp.status_code == 200
+    rows = list(csv.reader(io.StringIO(resp.text)))
+    holder_names = {row[2] for row in rows[1:]}
+    assert holder_names == {"Past Holder", "Now Holder"}
+
+
+def test_drill_surfaces_newer_unparsed_filing_via_filing_events(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A 2026 DEF 14A failed to parse (only filing_events row +
+    def14a_ingest_log status='failed'); 2025 holders exist in the
+    typed table. Drill MUST surface the gap so the operator
+    doesn't silently see stale 2025 holders. Regression for the
+    high-severity Codex finding."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_010, symbol="STALE", cik="0000111110")
+    # 2025 typed holders.
+    conn.execute(
+        """
+        INSERT INTO def14a_beneficial_holdings (
+            instrument_id, accession_number, issuer_cik,
+            holder_name, holder_role, shares, percent_of_class, as_of_date
+        ) VALUES (%s, '2025-1', '0000111110', 'A', 'officer', 100, 5.0, '2025-03-01')
+        """,
+        (972_010,),
+    )
+    # 2026 filing in filing_events with no typed rows.
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type, source_url,
+            provider, provider_filing_id, primary_document_url
+        ) VALUES (%s, '2026-03-15', 'DEF 14A', 'https://example.com/x',
+                  'sec', '2026-1', 'https://example.com/x')
+        """,
+        (972_010,),
+    )
+    conn.commit()
+
+    resp = client.get("/instruments/STALE/def14a_holdings/drill")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["latest_known_filing_date"] == "2026-03-15"
+    assert body["holders_as_of_date"] == "2025-03-01"
+    notes = body["pipeline_notes"]
+    assert any("newer DEF 14A 2026-1" in n and "2026-03-15" in n for n in notes), (
+        f"expected stale-holders surface; got notes={notes}"
+    )
+
+
+def test_drill_no_stale_warning_on_healthy_single_filing(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A single DEF 14A with both filing_events row AND typed
+    holders must NOT trip the stale-holders warning. The
+    accession-comparison guards against false positives where
+    filing_date differs from as_of_date for the SAME filing.
+    Regression for the high-severity Codex finding."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_012, symbol="HEALTH", cik="0000111112")
+    accession = "h-26-1"
+    conn.execute(
+        """
+        INSERT INTO def14a_beneficial_holdings (
+            instrument_id, accession_number, issuer_cik,
+            holder_name, holder_role, shares, percent_of_class, as_of_date
+        ) VALUES (%s, %s, '0000111112', 'A', 'officer', 100, 5.0, '2026-03-01')
+        """,
+        (972_012, accession),
+    )
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type, source_url,
+            provider, provider_filing_id, primary_document_url
+        ) VALUES (%s, '2026-03-15', 'DEF 14A', 'https://example.com/h',
+                  'sec', %s, 'https://example.com/h')
+        """,
+        (972_012, accession),
+    )
+    conn.commit()
+
+    resp = client.get("/instruments/HEALTH/def14a_holdings/drill")
+    assert resp.status_code == 200
+    notes = resp.json()["pipeline_notes"]
+    assert not any("missing typed rows" in n for n in notes), (
+        f"unexpected stale warning on healthy filing; notes={notes}"
+    )
+
+
+def test_drill_no_holders_note_suppressed_when_filing_events_has_pending(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Discovered-but-unparsed: filing_events row exists but no
+    typed rows / no ingest_log entry. 'no DEF 14A holders' note
+    must NOT fire — the gap is queue-side, surface that explicitly.
+    Regression for the medium-severity Codex finding."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_011, symbol="PEND", cik="0000111111")
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type, source_url,
+            provider, provider_filing_id, primary_document_url
+        ) VALUES (%s, '2025-03-01', 'DEF 14A', 'https://example.com/y',
+                  'sec', 'pending-1', 'https://example.com/y')
+        """,
+        (972_011,),
+    )
+    conn.commit()
+
+    resp = client.get("/instruments/PEND/def14a_holdings/drill")
+    assert resp.status_code == 200
+    body = resp.json()
+    notes = body["pipeline_notes"]
+    assert not any("no DEF 14A holders" in n for n in notes)
+    assert any("not yet ingested" in n for n in notes)
+
+
+def test_drill_same_day_filings_tie_break_on_accession_not_insert_order(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """When two DEF 14A filings share the same filing_date, the
+    'latest' must tie-break on accession (provider_filing_id),
+    not on filing_event_id. Otherwise insertion order decides
+    which accession wins, which can flip a healthy state into a
+    false stale-holders warning. Regression for the medium
+    severity Codex finding."""
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_013, symbol="TIE14", cik="0000111113")
+    # Holders are on acc-2 (the lexicographically later
+    # accession). Insert acc-2 to filing_events FIRST, so a
+    # naive ``ORDER BY filing_event_id DESC`` picks acc-1
+    # (inserted later, larger event_id).
+    conn.execute(
+        """
+        INSERT INTO def14a_beneficial_holdings (
+            instrument_id, accession_number, issuer_cik,
+            holder_name, holder_role, shares, percent_of_class, as_of_date
+        ) VALUES (%s, 'acc-2', '0000111113', 'A', 'officer', 100, 5.0, '2026-03-01')
+        """,
+        (972_013,),
+    )
+    for accn in ("acc-2", "acc-1"):
+        conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, filing_date, filing_type, source_url,
+                provider, provider_filing_id, primary_document_url
+            ) VALUES (%s, '2026-03-15', 'DEF 14A', 'https://example.com/x',
+                      'sec', %s, 'https://example.com/x')
+            """,
+            (972_013, accn),
+        )
+    conn.commit()
+
+    resp = client.get("/instruments/TIE14/def14a_holdings/drill")
+    assert resp.status_code == 200
+    notes = resp.json()["pipeline_notes"]
+    # acc-2 > acc-1 lexicographically; latest should be acc-2 =
+    # holders' accession ⇒ NO stale warning.
+    assert not any("missing typed rows" in n for n in notes), (
+        f"unexpected stale warning when latest accession matches holders; notes={notes}"
+    )
+
+
+def test_drill_tombstone_query_is_filing_distinct(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """The tombstone query uses ``COUNT(DISTINCT log.accession_number)``
+    so the count is filing-level even if the schema later drops the
+    PK on accession_number (e.g. moves to a retry-attempt model).
+
+    Today ``def14a_ingest_log`` has a PK on accession_number, so
+    retries update in place via ON CONFLICT — bare COUNT(*) is
+    equivalent here. The DISTINCT is defense-in-depth; this test
+    pins the contract by seeding two accessions in different
+    tombstone-states and asserting the count is 2 (not double-
+    counted, not collapsed). Codex PR #833 review.
+    """
+    conn = ebull_test_conn
+    _seed_instrument_with_cik(conn, iid=972_020, symbol="TOMB14", cik="0000111110")
+    # Two distinct tombstoned filings.
+    for accn, status in [("tomb-26-1", "failed"), ("tomb-26-2", "partial")]:
+        conn.execute(
+            """
+            INSERT INTO def14a_ingest_log (
+                accession_number, issuer_cik, status, error, fetched_at
+            ) VALUES (%s, '0000111110', %s, 'simulated', NOW())
+            """,
+            (accn, status),
+        )
+        conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, provider, provider_filing_id, filing_type,
+                filing_date, primary_document_url, source_url
+            ) VALUES (%s, 'sec', %s, 'DEF 14A', '2025-04-01',
+                      'http://x', 'http://y')
+            ON CONFLICT (provider, provider_filing_id) DO NOTHING
+            """,
+            (972_020, accn),
+        )
+    conn.commit()
+
+    resp = client.get("/instruments/TOMB14/def14a_holdings/drill")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["pipeline_tombstone_count"] == 2

--- a/tests/test_def14a_drill.py
+++ b/tests/test_def14a_drill.py
@@ -398,14 +398,18 @@ def test_drill_tombstone_query_is_filing_distinct(
     counted, not collapsed). Codex PR #833 review.
     """
     conn = ebull_test_conn
-    _seed_instrument_with_cik(conn, iid=972_020, symbol="TOMB14", cik="0000111110")
+    # Unique CIK (0000111120) — distinct from STALE's 0000111110
+    # so the external_identifiers row actually inserts. Claude PR
+    # #833 round 3 review caught the prior collision (silent DO
+    # NOTHING + 404 on _has_sec_cik).
+    _seed_instrument_with_cik(conn, iid=972_020, symbol="TOMB14", cik="0000111120")
     # Two distinct tombstoned filings.
     for accn, status in [("tomb-26-1", "failed"), ("tomb-26-2", "partial")]:
         conn.execute(
             """
             INSERT INTO def14a_ingest_log (
                 accession_number, issuer_cik, status, error, fetched_at
-            ) VALUES (%s, '0000111110', %s, 'simulated', NOW())
+            ) VALUES (%s, '0000111120', %s, 'simulated', NOW())
             """,
             (accn, status),
         )


### PR DESCRIPTION
## What
Two operator endpoints for DEF 14A beneficial-ownership state:

- \`GET /instruments/{symbol}/def14a_holdings/drill\` — latest-filing holders + pipeline state with stale-holders surface when newer filing exists but didn't produce typed rows.
- \`GET /instruments/{symbol}/def14a_holdings/export.csv\` — historical CSV across all on-file accessions.

Provider gate (\`?provider=sec_def14a\`), 404 on unknown / no-SEC-CIK.

## Test plan
- [x] \`pytest tests/test_def14a_drill.py\` 11/11
- [x] \`ruff\` / \`pyright\` clean
- [x] Codex pre-push review (4 rounds) — stale-holders date-vs-date bug, "no holders" note suppression, accession tie-break all fixed; final pass clean

## Notes
Pipeline-state SQL inlined rather than calling \`ownership_drillthrough.get_instrument_drillthrough\` so this PR is independent of #830 merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)