### PR TITLE
feat(#788 Chain 2.8): canonical ownership rollup CSV export

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -3639,3 +3639,57 @@ def get_instrument_ownership_rollup(
             instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
         )
     return _rollup_to_response(rollup)
+
+
+@router.get(
+    "/{symbol}/ownership-rollup/export.csv",
+    response_class=PlainTextResponse,
+)
+def get_instrument_ownership_rollup_csv(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> PlainTextResponse:
+    """CSV export of the canonical deduped ownership rollup
+    (Chain 2.8 of #788).
+
+    Same data shape the operator sees in the L2 ownership card,
+    flattened to one row per surviving holder + treasury memo +
+    residual memo. ``Content-Disposition: attachment`` so the
+    browser saves rather than rendering. Header always emitted so
+    an automation pipe is branchless on empty rollups.
+
+    Reads run inside ``snapshot_read`` so the per-slice totals,
+    treasury, and residual all reconcile against one REPEATABLE
+    READ snapshot. Same isolation contract as the JSON rollup
+    endpoint."""
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with snapshot_read(conn):
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT instrument_id, symbol FROM instruments
+                WHERE UPPER(symbol) = %(s)s
+                ORDER BY is_primary_listing DESC, instrument_id ASC
+                LIMIT 1
+                """,
+                {"s": symbol_clean},
+            )
+            inst_row = cur.fetchone()
+        if inst_row is None:
+            raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+        rollup = ownership_rollup.get_ownership_rollup(
+            conn,
+            symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+            instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
+        )
+
+    return PlainTextResponse(
+        content=ownership_rollup.build_rollup_csv(rollup),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": f'attachment; filename="{symbol_clean}_ownership_rollup.csv"',
+        },
+    )

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -952,6 +952,124 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
 
 
 # ---------------------------------------------------------------------------
+# CSV export of the canonical rollup (Chain 2.8 of #788)
+# ---------------------------------------------------------------------------
+
+
+_CSV_HEADER: tuple[str, ...] = (
+    "filer_cik",
+    "filer_name",
+    "category",
+    "shares",
+    "pct_outstanding",
+    "winning_source",
+    "winning_accession",
+    "as_of_date",
+    "filer_type",
+    "edgar_url",
+)
+
+
+def build_rollup_csv(rollup: OwnershipRollup) -> str:
+    """Flatten a deduped :class:`OwnershipRollup` into a CSV string.
+
+    One row per surviving holder across all slices, plus two memo
+    rows at the end:
+
+      * ``__treasury__`` — issuer treasury share count (additive
+        wedge on the chart, not a deduped holder).
+      * ``__residual__`` — ``Public / unattributed`` block (clamped
+        to 0 when oversubscribed).
+
+    The two memo rows let an operator sum the ``shares`` column and
+    verify it equals ``shares_outstanding`` without round-tripping
+    to a separate endpoint.
+
+    Header always emitted so an automation pipe can be branchless on
+    empty rollups (no_data state, pre-ingest instruments).
+
+    Formula-injection guard: any cell value beginning with
+    ``=``, ``+``, ``-``, ``@``, ``\\t``, or ``\\r`` is prefixed with a
+    single quote. Mirrors the FE ``csvEscape`` rule and the existing
+    insider-baseline CSV export.
+    """
+    import csv
+    import io
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerow(_CSV_HEADER)
+
+    for slc in rollup.slices:
+        for holder in slc.holders:
+            writer.writerow(
+                [
+                    _csv_safe(holder.filer_cik or ""),
+                    _csv_safe(holder.filer_name),
+                    slc.category,
+                    str(holder.shares),
+                    f"{holder.pct_outstanding}",
+                    holder.winning_source,
+                    _csv_safe(holder.winning_accession),
+                    holder.as_of_date.isoformat() if holder.as_of_date is not None else "",
+                    _csv_safe(holder.filer_type or ""),
+                    _csv_safe(holder.winning_edgar_url or ""),
+                ]
+            )
+
+    if rollup.treasury_shares is not None and rollup.treasury_shares > 0:
+        treasury_pct = (
+            f"{rollup.treasury_shares / rollup.shares_outstanding}"
+            if rollup.shares_outstanding is not None and rollup.shares_outstanding > 0
+            else ""
+        )
+        writer.writerow(
+            [
+                "",
+                "Treasury (memo)",
+                "__treasury__",
+                str(rollup.treasury_shares),
+                treasury_pct,
+                "",
+                "",
+                rollup.treasury_as_of.isoformat() if rollup.treasury_as_of is not None else "",
+                "",
+                "",
+            ]
+        )
+
+    writer.writerow(
+        [
+            "",
+            "Public / unattributed",
+            "__residual__",
+            str(rollup.residual.shares),
+            f"{rollup.residual.pct_outstanding}",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+    )
+    return buf.getvalue()
+
+
+def _csv_safe(value: str) -> str:
+    """Formula-injection guard. ``csv.writer`` already handles RFC
+    4180 quoting; this function only guards against spreadsheet
+    formula triggers.
+
+    Mirrors the frontend ``csvEscape`` rule + the existing
+    insider-baseline CSV. Codex pre-push review caught the prior
+    implementation which forgot ``\\t`` / ``\\r`` (Excel treats both
+    as formula triggers in addition to ``=+-@``)."""
+    if value and value[0] in ("=", "+", "-", "@", "\t", "\r"):
+        return "'" + value
+    return value
+
+
+# ---------------------------------------------------------------------------
 # SQL: canonical-holder union (Form 4 + Form 3 + 13D/G + 13F)
 # ---------------------------------------------------------------------------
 #

--- a/tests/test_ownership_rollup_csv.py
+++ b/tests/test_ownership_rollup_csv.py
@@ -1,0 +1,373 @@
+"""Tests for :func:`build_rollup_csv` and the
+``GET /instruments/{symbol}/ownership-rollup/export.csv`` endpoint
+(Chain 2.8 of #788).
+
+The CSV export is the operator-facing export face of the canonical
+deduped rollup. The endpoint itself is a thin wrapper around
+:func:`build_rollup_csv`; the bulk of the testing exercises the
+helper directly with hand-built :class:`OwnershipRollup` payloads
+so the assertions stay fast and isolated from DB seeding.
+
+One integration test through the FastAPI ``TestClient`` pins the
+end-to-end contract: header always emitted, ``Content-Disposition:
+attachment``, 404 on unknown symbol.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.main import app
+from app.services.ownership_rollup import (
+    BannerCopy,
+    CategoryCoverage,
+    ConcentrationInfo,
+    CoverageReport,
+    DroppedSource,
+    Holder,
+    OwnershipRollup,
+    OwnershipSlice,
+    ResidualBlock,
+    SharesOutstandingSource,
+    build_rollup_csv,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+
+# The TestClient case below seeds against ``ebull_test``. Pytest
+# ``integration`` mark gates DB-touching tests so the unit-only run
+# can skip them. Codex pre-push review (Chain 2.8) flagged the
+# missing mark — without it this file leaks DB-dependent coverage
+# into the unit bucket.
+pytestmark = pytest.mark.integration
+
+
+def _holder(
+    *,
+    cik: str | None,
+    name: str,
+    shares: str,
+    pct: str,
+    source: str,
+    accession: str,
+    as_of: date | None = None,
+    filer_type: str | None = None,
+    edgar_url: str | None = None,
+    dropped: tuple[DroppedSource, ...] = (),
+) -> Holder:
+    return Holder(
+        filer_cik=cik,
+        filer_name=name,
+        shares=Decimal(shares),
+        pct_outstanding=Decimal(pct),
+        winning_source=source,  # type: ignore[arg-type]
+        winning_accession=accession,
+        winning_edgar_url=edgar_url,
+        as_of_date=as_of,
+        filer_type=filer_type,
+        dropped_sources=dropped,
+    )
+
+
+def _slice(category: str, holders: tuple[Holder, ...]) -> OwnershipSlice:
+    total = sum((h.shares for h in holders), Decimal(0))
+    return OwnershipSlice(
+        category=category,  # type: ignore[arg-type]
+        label=category.title(),
+        total_shares=total,
+        pct_outstanding=Decimal("0.10"),
+        filer_count=len(holders),
+        dominant_source=holders[0].winning_source if holders else None,
+        holders=holders,
+    )
+
+
+def _rollup(
+    *,
+    symbol: str = "TEST",
+    outstanding: str = "10000000",
+    treasury: str | None = "500000",
+    treasury_as_of: date | None = date(2026, 3, 31),
+    slices: tuple[OwnershipSlice, ...] = (),
+    residual_shares: str = "0",
+    residual_pct: str = "0",
+    oversubscribed: bool = False,
+) -> OwnershipRollup:
+    return OwnershipRollup(
+        symbol=symbol,
+        instrument_id=789_001,
+        shares_outstanding=Decimal(outstanding),
+        shares_outstanding_as_of=date(2026, 3, 31),
+        shares_outstanding_source=SharesOutstandingSource(
+            accession_number="0000000789-26-000001",
+            concept="EntityCommonStockSharesOutstanding",
+            form_type="10-Q",
+            edgar_url="https://www.sec.gov/x",
+        ),
+        treasury_shares=Decimal(treasury) if treasury is not None else None,
+        treasury_as_of=treasury_as_of,
+        slices=slices,
+        residual=ResidualBlock(
+            shares=Decimal(residual_shares),
+            pct_outstanding=Decimal(residual_pct),
+            label="Public / unattributed",
+            tooltip="",
+            oversubscribed=oversubscribed,
+        ),
+        concentration=ConcentrationInfo(
+            pct_outstanding_known=Decimal("0.10"),
+            info_chip="",
+        ),
+        coverage=CoverageReport(
+            state="green",
+            categories={"insiders": CategoryCoverage(0, 0, None, "green")},
+        ),
+        banner=BannerCopy(state="green", variant="success", headline="", body=""),
+        historical_symbols=(),
+        computed_at=datetime(2026, 5, 3, tzinfo=UTC),
+    )
+
+
+def test_build_csv_header_always_emitted_on_empty_rollup() -> None:
+    """no_data path / empty cohort still emits the header so an
+    automation pipe can treat the response as a uniform table."""
+    csv = build_rollup_csv(_rollup(slices=(), treasury=None, residual_shares="10000000"))
+    lines = csv.splitlines()
+    # Header + residual memo. No treasury (treasury=None).
+    expected_header = (
+        "filer_cik,filer_name,category,shares,pct_outstanding,"
+        "winning_source,winning_accession,as_of_date,filer_type,edgar_url"
+    )
+    assert lines[0] == expected_header
+    assert any(line.startswith(",Public / unattributed,__residual__,10000000,") for line in lines[1:])
+
+
+def test_build_csv_row_per_holder_across_slices() -> None:
+    """Two slices, three holders total → header + 3 holder rows + 1
+    residual + 1 treasury memo (treasury > 0)."""
+    insiders = _slice(
+        "insiders",
+        (
+            _holder(
+                cik="0000111111",
+                name="Alice CEO",
+                shares="500000",
+                pct="0.05",
+                source="form4",
+                accession="0000111111-26-000001",
+                as_of=date(2026, 3, 1),
+            ),
+        ),
+    )
+    institutions = _slice(
+        "institutions",
+        (
+            _holder(
+                cik="0000222222",
+                name="BigFund",
+                shares="2000000",
+                pct="0.20",
+                source="13f",
+                accession="0000222222-26-000010",
+                as_of=date(2026, 3, 31),
+                filer_type="OTHER",
+            ),
+            _holder(
+                cik="0000333333",
+                name="ETF Issuer",
+                shares="1000000",
+                pct="0.10",
+                source="13f",
+                accession="0000333333-26-000020",
+                as_of=date(2026, 3, 31),
+                filer_type="ETF",
+            ),
+        ),
+    )
+    csv = build_rollup_csv(_rollup(slices=(insiders, institutions), residual_shares="6500000"))
+    lines = csv.splitlines()
+    # Header + 3 holders + 1 treasury memo + 1 residual = 6 lines.
+    assert len(lines) == 6
+    assert lines[1].startswith("0000111111,Alice CEO,insiders,500000,")
+    assert "form4" in lines[1]
+    assert lines[2].startswith("0000222222,BigFund,institutions,2000000,")
+    assert "13f" in lines[2] and ",OTHER," in lines[2]
+    assert ",ETF," in lines[3]  # filer_type column
+    assert lines[4].startswith(",Treasury (memo),__treasury__,500000,")
+    assert lines[5].startswith(",Public / unattributed,__residual__,6500000,")
+
+
+def test_build_csv_omits_treasury_row_when_treasury_zero_or_none() -> None:
+    """Treasury memo only appears when treasury_shares > 0; matches
+    the FE convention where treasury=0 issuers don't get the wedge."""
+    csv_zero = build_rollup_csv(_rollup(treasury="0", residual_shares="10000000"))
+    csv_none = build_rollup_csv(_rollup(treasury=None, residual_shares="10000000"))
+    assert "Treasury (memo)" not in csv_zero
+    assert "Treasury (memo)" not in csv_none
+
+
+def test_build_csv_residual_oversubscribed_clamps_to_zero() -> None:
+    """Oversubscribed residual writes 0 (clamped value), not the
+    negative raw. Matches the in-memory ResidualBlock semantics."""
+    csv = build_rollup_csv(
+        _rollup(slices=(), treasury="0", residual_shares="0", oversubscribed=True),
+    )
+    residual_line = next(line for line in csv.splitlines() if "__residual__" in line)
+    parts = residual_line.split(",")
+    assert parts[3] == "0"  # shares column
+
+
+def test_build_csv_formula_injection_guards_filer_name() -> None:
+    """A holder name that begins with ``=`` would be interpreted by
+    Excel as a formula. The CSV builder must prefix a single quote
+    so the cell renders literally. Mirrors the FE ``csvEscape`` rule
+    + the existing insider-baseline export."""
+    csv = build_rollup_csv(
+        _rollup(
+            slices=(
+                _slice(
+                    "insiders",
+                    (
+                        _holder(
+                            cik="0000111111",
+                            name="=SUM(A1)",
+                            shares="100",
+                            pct="0.0001",
+                            source="form4",
+                            accession="0000111111-26-000099",
+                        ),
+                    ),
+                ),
+            ),
+            residual_shares="9499900",
+        ),
+    )
+    # ``=`` prefixed with single quote so Excel renders literally.
+    assert "'=SUM(A1)" in csv
+    assert ",=SUM" not in csv  # not the bare formula
+
+
+def test_build_csv_formula_injection_guards_filer_type_and_edgar_url() -> None:
+    """``filer_type`` and ``edgar_url`` are written to the CSV from the
+    same canonical rollup; both can carry operator-controlled or
+    upstream-mutated text. The injection guard must apply to every
+    cell, not just filer_cik / filer_name / accession. Codex pre-push
+    review (Chain 2.8) caught the prior version that left these two
+    fields raw."""
+    csv = build_rollup_csv(
+        _rollup(
+            slices=(
+                _slice(
+                    "institutions",
+                    (
+                        _holder(
+                            cik="0000444444",
+                            name="Safe Filer",
+                            shares="1000",
+                            pct="0.0001",
+                            source="13f",
+                            accession="0000444444-26-000001",
+                            filer_type="=BAD",
+                            edgar_url="@xrouter",
+                        ),
+                    ),
+                ),
+            ),
+            residual_shares="9499000",
+        ),
+    )
+    assert "'=BAD" in csv
+    assert "'@xrouter" in csv
+    # Bare values must NOT appear (the leading-tick prefix is the
+    # only acceptable shape).
+    for line in csv.splitlines():
+        assert not line.endswith(",=BAD,@xrouter")
+        assert not line.endswith(",=BAD,") and not line.endswith(",@xrouter")
+
+
+def test_build_csv_handles_null_cik_and_no_as_of() -> None:
+    """A NULL-CIK holder + a holder with no as_of_date both round
+    through the export cleanly (empty cells, not the literal
+    ``None``). Matches the contract the operator scripts depend on."""
+    csv = build_rollup_csv(
+        _rollup(
+            slices=(
+                _slice(
+                    "insiders",
+                    (
+                        _holder(
+                            cik=None,
+                            name="Legacy Filer",
+                            shares="1000",
+                            pct="0.0001",
+                            source="form4",
+                            accession="LEGACY-26-1",
+                            as_of=None,
+                        ),
+                    ),
+                ),
+            ),
+            residual_shares="9499000",
+            treasury="500000",
+        ),
+    )
+    legacy = next(line for line in csv.splitlines() if "Legacy Filer" in line)
+    parts = legacy.split(",")
+    assert parts[0] == ""  # filer_cik empty (was NULL)
+    assert parts[7] == ""  # as_of_date empty (was None)
+
+
+def test_csv_endpoint_returns_attachment_header_and_404_unknown_symbol(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """End-to-end smoke through TestClient. Pins the endpoint shape
+    the FE rewire (Chain 2.8 follow-up) will consume:
+
+      * ``Content-Type: text/csv``
+      * ``Content-Disposition: attachment`` with the symbol-derived filename
+      * 404 on unknown symbol with the standard error envelope
+      * 200 + header row on a known symbol with no ownership data
+        (no_data state still emits the header)
+    """
+    conn = ebull_test_conn
+    # Seed an instrument with no XBRL outstanding so the rollup goes
+    # down the no_data path. The endpoint should still 200 with a
+    # header-only-ish CSV.
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, %s, 'Test', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (789_700, "ROLLUPCSV"),
+    )
+    conn.commit()
+
+    def _override_conn():  # type: ignore[no-untyped-def]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _override_conn
+    app.dependency_overrides[require_session_or_service_token] = lambda: object()
+    try:
+        client = TestClient(app)
+
+        unknown = client.get("/instruments/NOPE12345/ownership-rollup/export.csv")
+        assert unknown.status_code == 404
+
+        resp = client.get("/instruments/ROLLUPCSV/ownership-rollup/export.csv")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/csv")
+        assert "ROLLUPCSV_ownership_rollup.csv" in resp.headers.get("content-disposition", "")
+        body = resp.text
+        # Header always emitted.
+        assert body.startswith("filer_cik,filer_name,category,")
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+        app.dependency_overrides.pop(require_session_or_service_token, None)

--- a/tests/test_ownership_rollup_csv.py
+++ b/tests/test_ownership_rollup_csv.py
@@ -40,12 +40,12 @@ from app.services.ownership_rollup import (
 )
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
 
-# The TestClient case below seeds against ``ebull_test``. Pytest
-# ``integration`` mark gates DB-touching tests so the unit-only run
-# can skip them. Codex pre-push review (Chain 2.8) flagged the
-# missing mark — without it this file leaks DB-dependent coverage
-# into the unit bucket.
-pytestmark = pytest.mark.integration
+# Only the TestClient case below touches the DB — it seeds against
+# ``ebull_test`` and exercises the FastAPI app. The ``build_rollup_csv``
+# unit tests are pure and must NOT carry the integration mark, so
+# the unit-only run still picks them up. Claude PR #834 round 1
+# review caught the prior module-level mark that silently gated all
+# 7 unit tests behind the integration bucket.
 
 
 def _holder(
@@ -323,6 +323,7 @@ def test_build_csv_handles_null_cik_and_no_as_of() -> None:
     assert parts[7] == ""  # as_of_date empty (was None)
 
 
+@pytest.mark.integration
 def test_csv_endpoint_returns_attachment_header_and_404_unknown_symbol(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
 ) -> None:


### PR DESCRIPTION
## Summary
- New endpoint `GET /instruments/{symbol}/ownership-rollup/export.csv` flattens the canonical deduped rollup into a flat CSV.
- One row per surviving holder + treasury memo (when treasury > 0) + residual memo. Header always emitted.
- Backend half of Chain 2.8: the L2 OwnershipPage frontend will rewire to consume this in a follow-up PR (currently 5-fetch client-side assembly).

## Why
The L2 OwnershipPage currently rebuilds the deduped rollup client-side from 5 separate fetches (financials, institutional, insiders, baseline, blockholders) and serialises a `?view=raw` CSV from the assembled state. The server-side `app.services.ownership_rollup.get_ownership_rollup` already produces the canonical, deduped view consumed by `/ownership-rollup` — this PR adds the matching CSV face so the frontend rewire (next PR) collapses to a single fetch.

## Test plan
- [x] `uv run pytest tests/test_ownership_rollup_csv.py` — 8/8 passing
- [x] `uv run pytest tests/test_ownership_rollup.py` — 23/23 (no regression)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright`
- [x] Codex pre-push review (CLAUDE.md checkpoint 2) — clean after one round (caught missing formula-injection guard on `filer_type` and `edgar_url`; fixed)