### PR TITLE
feat(#788 Chain 2.8): rewire L2 ?view=raw CSV to canonical endpoint

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -3996,12 +3996,33 @@ def get_instrument_ownership_rollup(
     return _rollup_to_response(rollup)
 
 
+# Slice categories present on ``OwnershipSlice.category``. The
+# frontend's ``CATEGORY_LABELS`` set also includes ``treasury`` —
+# treasury is a memo row in the CSV (additive wedge on the chart),
+# not a holders slice. Treated as a valid filter value below: it
+# scopes the CSV to the treasury memo + residual rows only.
+_ROLLUP_CSV_SLICE_CATEGORIES: frozenset[str] = frozenset(
+    {"insiders", "blockholders", "institutions", "etfs", "def14a_unmatched"},
+)
+_ROLLUP_CSV_CATEGORIES: frozenset[str] = _ROLLUP_CSV_SLICE_CATEGORIES | {"treasury"}
+
+
 @router.get(
     "/{symbol}/ownership-rollup/export.csv",
     response_class=PlainTextResponse,
 )
 def get_instrument_ownership_rollup_csv(
     symbol: str,
+    category: str | None = Query(
+        default=None,
+        description=(
+            "Optional category filter: insiders | blockholders | institutions "
+            "| etfs | def14a_unmatched | treasury. Slice categories scope the "
+            "export to that slice's holders; ``treasury`` drops all slice "
+            "holders and emits only the treasury + residual memo rows. "
+            "Without ``category``, every slice is exported."
+        ),
+    ),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> PlainTextResponse:
     """CSV export of the canonical deduped ownership rollup
@@ -4013,6 +4034,10 @@ def get_instrument_ownership_rollup_csv(
     browser saves rather than rendering. Header always emitted so
     an automation pipe is branchless on empty rollups.
 
+    ``?category=`` scopes the export to one slice — drives the L2
+    page's "download CSV" button when the operator has drilled into
+    a single category. Without it, every slice is exported.
+
     Reads run inside ``snapshot_read`` so the per-slice totals,
     treasury, and residual all reconcile against one REPEATABLE
     READ snapshot. Same isolation contract as the JSON rollup
@@ -4020,6 +4045,11 @@ def get_instrument_ownership_rollup_csv(
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
         raise HTTPException(status_code=400, detail="symbol is required")
+    if category is not None and category not in _ROLLUP_CSV_CATEGORIES:
+        raise HTTPException(
+            status_code=400,
+            detail=(f"Unknown category {category!r}; expected one of {sorted(_ROLLUP_CSV_CATEGORIES)}"),
+        )
 
     with snapshot_read(conn):
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -4040,6 +4070,28 @@ def get_instrument_ownership_rollup_csv(
             symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
             instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
         )
+
+    if category is not None:
+        # Server-side slice filter so the FE's L2 ``?category=`` filter
+        # state can flow into the CSV without a client-side build.
+        # ``dataclasses.replace`` keeps every other field
+        # (residual, treasury, banner, computed_at) intact — the
+        # operator still sees the canonical residual + treasury memo
+        # rows even when the slice list is filtered.
+        #
+        # ``category=treasury`` is a valid filter even though treasury
+        # is a memo row (not a slice). Drop ALL slices and keep the
+        # treasury + residual memo rows — preserves the prior
+        # ``buildCsv(filteredRows)`` behavior where ``?category=treasury``
+        # only emitted the treasury row. Codex Chain 2.8 follow-up
+        # caught the prior version 400ing on ``treasury``.
+        from dataclasses import replace
+
+        if category == "treasury":
+            filtered_slices: tuple[ownership_rollup.OwnershipSlice, ...] = ()
+        else:
+            filtered_slices = tuple(s for s in rollup.slices if s.category == category)
+        rollup = replace(rollup, slices=filtered_slices)
 
     return PlainTextResponse(
         content=ownership_rollup.build_rollup_csv(rollup),

--- a/frontend/src/pages/OwnershipPage.test.ts
+++ b/frontend/src/pages/OwnershipPage.test.ts
@@ -1,84 +1,28 @@
+/**
+ * The CSV export contract used to live in this file as ``buildCsv``
+ * unit tests. As of Chain 2.8 of #788, the CSV is built server-side
+ * from the canonical deduped rollup at
+ * ``/instruments/{symbol}/ownership-rollup/export.csv`` and the
+ * client-side builder has been removed.
+ *
+ * The header / row-shape / formula-injection / RFC-4180 contracts
+ * are now pinned in ``tests/test_ownership_rollup_csv.py`` against
+ * the ``build_rollup_csv`` helper. The L2 ``?view=raw`` link is
+ * exercised at the page level by ``OwnershipPage`` integration
+ * tests where present.
+ *
+ * Vitest treats an empty file as a "no test" failure, so we keep
+ * one trivial smoke check here as a placeholder until a page-level
+ * integration test for the new download link lands.
+ */
+
 import { describe, expect, it } from "vitest";
 
-import { buildCsv } from "./OwnershipPage";
-import type { FilerRow } from "./OwnershipPage";
-
-function row(overrides: Partial<FilerRow> = {}): FilerRow {
-  return {
-    key: "0000102909",
-    label: "VANGUARD GROUP",
-    category: "etfs",
-    category_label: "ETFs",
-    shares: 1_234_567,
-    value_usd: 230_000_000,
-    voting: "SOLE",
-    is_put_call: null,
-    accession: "0000102909-25-000001",
-    period_of_report: "2024-12-31",
-    ...overrides,
-  };
-}
-
-describe("buildCsv", () => {
-  it("emits a header line matching the column order", () => {
-    const csv = buildCsv([]);
-    const [header] = csv.split("\n");
-    expect(header).toBe(
-      "filer_key,filer_label,category,shares,value_usd,voting_authority,put_call,accession,period_of_report",
-    );
-  });
-
-  it("renders typical rows without quoting safe values", () => {
-    const csv = buildCsv([row()]);
-    const [, dataLine] = csv.split("\n");
-    expect(dataLine).toContain("0000102909,VANGUARD GROUP,etfs,1234567,230000000,SOLE,,0000102909-25-000001,2024-12-31");
-  });
-
-  it("escapes commas, quotes, and newlines via RFC 4180 quoting", () => {
-    const csv = buildCsv([
-      row({ label: 'Vanguard "Group", LLC' }),
-      row({ label: "Two\nLine\nName" }),
-    ]);
-    expect(csv).toContain('"Vanguard ""Group"", LLC"');
-    expect(csv).toContain('"Two\nLine\nName"');
-  });
-
-  it("formula-injection guard prefixes leading =/+/-/@ with a single quote", () => {
-    // Excel / Sheets / Numbers interpret =CMD() as a formula on
-    // import, which is a known CSV smuggling vector. Mirrors the
-    // backend guard in app/api/instruments insider transactions.
-    const csv = buildCsv([
-      row({ label: "=cmd|' /C calc'!A0" }),
-      row({ label: "+SUM(A:A)" }),
-      row({ label: "-1234" }),
-      row({ label: "@user" }),
-    ]);
-    expect(csv).toContain("'=cmd");
-    expect(csv).toContain("'+SUM(A:A)");
-    expect(csv).toContain("'-1234");
-    expect(csv).toContain("'@user");
-  });
-
-  it("renders null value_usd as empty string, not 'null'", () => {
-    const csv = buildCsv([row({ value_usd: null })]);
-    expect(csv).not.toContain("null");
-    // Empty token between two commas in the value_usd position.
-    expect(csv).toMatch(/,1234567,,SOLE,/);
-  });
-
-  it("escapes voting + period_of_report through csvEscape (PR review pin)", () => {
-    // PR #749 review caught these two columns silently bypassing
-    // csvEscape. Pin the contract so a future schema change can't
-    // re-introduce the gap.
-    const csv = buildCsv([
-      row({
-        voting: "=cmd",
-        period_of_report: "2024,12,31",
-      }),
-    ]);
-    // voting prefixed with a single quote (formula-injection guard).
-    expect(csv).toContain("'=cmd");
-    // period_of_report with embedded commas wrapped in quotes.
-    expect(csv).toContain('"2024,12,31"');
+describe("OwnershipPage", () => {
+  it("module imports without throwing", async () => {
+    // A bare import smoke — picks up syntax errors / missing exports
+    // a stricter test would otherwise miss in this slim file.
+    const mod = await import("./OwnershipPage");
+    expect(typeof mod.OwnershipPage).toBe("function");
   });
 });

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -483,7 +483,13 @@ function OwnershipBody({
         </p>
         <a
           href={exportHref}
-          download
+          // Explicit filename — bare ``download`` collapses to the
+          // URL's last path segment (``export.csv``) for every symbol
+          // in browsers that don't honor the server's
+          // ``Content-Disposition`` header. Match the backend's
+          // ``${symbol}_ownership_rollup.csv`` pattern. Claude PR
+          // review (#835 round 1) flagged the regression.
+          download={`${symbol}_ownership_rollup.csv`}
           className="inline-block rounded border border-slate-300 px-3 py-1.5 text-xs hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
         >
           Download CSV

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -450,21 +450,40 @@ function OwnershipBody({
   const filerRowRef = useRef<HTMLTableRowElement | null>(null);
 
   if (viewMode === "raw") {
-    const csv = buildCsv(filteredRows);
+    // Server-side CSV export (Chain 2.8 of #788). The CSV is now
+    // built from the canonical deduped rollup at
+    // ``/instruments/{symbol}/ownership-rollup/export.csv`` so the
+    // operator's spreadsheet matches the L1/L2 chart 1:1 — the prior
+    // client-side ``buildCsv`` reconstructed shares from raw 13F /
+    // Form 4 / 13D fetches and could over-count joint filings or
+    // miss the cross-channel dedup that the backend rollup applies.
+    //
+    // ``categoryFilter`` flows through to the backend's ``?category=``
+    // filter so a drilled view (e.g. ``?category=institutions&view=raw``)
+    // exports only that slice — preserves the prior buildCsv behavior
+    // that scoped the CSV to ``filteredRows``. Codex pre-push review
+    // (Chain 2.8 follow-up) caught the regression when the filter
+    // wasn't forwarded.
+    const exportPath = `/api/instruments/${encodeURIComponent(symbol)}/ownership-rollup/export.csv`;
+    const exportHref =
+      categoryFilter !== null
+        ? `${exportPath}?category=${encodeURIComponent(categoryFilter)}`
+        : exportPath;
     return (
       <div className="space-y-3">
         <p className="text-xs text-slate-500 dark:text-slate-400">
-          Raw view: {filteredRows.length} rows
+          Canonical deduped CSV — one row per surviving holder across
+          insiders, blockholders, institutions, ETFs, plus treasury
+          memo + residual rows. Server-built from the same dedup
+          priority (form4 &gt; form3 &gt; 13D/G &gt; def14a &gt; 13f)
+          the L1/L2 chart uses.
           {categoryFilter !== null && (
-            <> · filtered to <strong>{labelFor(categoryFilter)}</strong></>
+            <> · scoped to <strong>{labelFor(categoryFilter)}</strong></>
           )}
         </p>
-        <pre className="overflow-x-auto rounded border border-slate-200 bg-slate-50 p-3 text-xs dark:border-slate-700 dark:bg-slate-950">
-{csv}
-        </pre>
         <a
-          href={`data:text/csv;charset=utf-8,${encodeURIComponent(csv)}`}
-          download={`${symbol}-ownership.csv`}
+          href={exportHref}
+          download
           className="inline-block rounded border border-slate-300 px-3 py-1.5 text-xs hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
         >
           Download CSV
@@ -916,41 +935,3 @@ function buildFilerRows(
   return rows;
 }
 
-export function buildCsv(rows: readonly FilerRow[]): string {
-  const header = [
-    "filer_key",
-    "filer_label",
-    "category",
-    "shares",
-    "value_usd",
-    "voting_authority",
-    "put_call",
-    "accession",
-    "period_of_report",
-  ].join(",");
-  const lines = rows.map((r) =>
-    [
-      csvEscape(r.key),
-      csvEscape(r.label),
-      csvEscape(r.category),
-      r.shares.toString(),
-      r.value_usd === null ? "" : r.value_usd.toString(),
-      csvEscape(r.voting ?? ""),
-      csvEscape(r.is_put_call ?? ""),
-      csvEscape(r.accession ?? ""),
-      csvEscape(r.period_of_report ?? ""),
-    ].join(","),
-  );
-  return [header, ...lines].join("\n");
-}
-
-function csvEscape(value: string): string {
-  // RFC 4180 escaping + formula-injection guard (mirrors
-  // app.api.instruments).
-  let v = value;
-  if (v !== "" && /^[=+\-@]/.test(v)) v = `'${v}`;
-  if (/[",\n]/.test(v)) {
-    return `"${v.replace(/"/g, '""')}"`;
-  }
-  return v;
-}

--- a/tests/test_ownership_rollup_csv.py
+++ b/tests/test_ownership_rollup_csv.py
@@ -323,6 +323,171 @@ def test_build_csv_handles_null_cik_and_no_as_of() -> None:
     assert parts[7] == ""  # as_of_date empty (was None)
 
 
+def test_build_csv_treasury_filter_drops_holders_keeps_memo() -> None:
+    """Pin: when the endpoint has filtered slices to () (the
+    ``?category=treasury`` path), the resulting rollup's CSV
+    contains the treasury memo row + residual + header — and NO
+    holder rows. Codex Chain 2.8 follow-up V3 caught the prior
+    integration test was too weak (no_data seed didn't pin the
+    'memo only' contract); this unit-level pin verifies it
+    deterministically against a populated input."""
+    from dataclasses import replace
+
+    insiders = _slice(
+        "insiders",
+        (
+            _holder(
+                cik="0000111111",
+                name="Holder X",
+                shares="500",
+                pct="0.05",
+                source="form4",
+                accession="0000111111-26-1",
+            ),
+        ),
+    )
+    full = _rollup(
+        slices=(insiders,),
+        treasury="500000",
+        residual_shares="9499500",
+    )
+    treasury_only = replace(full, slices=())
+    csv = build_rollup_csv(treasury_only)
+
+    assert "Holder X" not in csv  # no slice holders
+    assert "Treasury (memo)" in csv  # memo row present
+    assert "Public / unattributed" in csv  # residual present
+
+
+def test_build_csv_supports_post_filter_via_dataclass_replace() -> None:
+    """``?category=`` filter on the endpoint applies via
+    ``dataclasses.replace`` to scope the rollup before the helper
+    runs. This test pins the contract that ``build_rollup_csv`` is
+    deterministic on the slices tuple it sees — feeding it a
+    one-slice rollup must produce the same shape as the multi-slice
+    case minus the dropped slices' rows. Codex Chain 2.8 follow-up
+    caught the regression where the FE's category filter wasn't
+    forwarded; this pin guards the backend half of the fix."""
+    from dataclasses import replace
+
+    insiders = _slice(
+        "insiders",
+        (
+            _holder(
+                cik="0000111111",
+                name="A",
+                shares="100",
+                pct="0.0001",
+                source="form4",
+                accession="0000111111-26-1",
+            ),
+        ),
+    )
+    institutions = _slice(
+        "institutions",
+        (
+            _holder(
+                cik="0000222222",
+                name="B",
+                shares="200",
+                pct="0.0002",
+                source="13f",
+                accession="0000222222-26-2",
+                filer_type="OTHER",
+            ),
+        ),
+    )
+    full = _rollup(slices=(insiders, institutions), residual_shares="9700")
+    filtered = replace(full, slices=(institutions,))
+
+    csv_full = build_rollup_csv(full)
+    csv_filt = build_rollup_csv(filtered)
+
+    assert "A,insiders" in csv_full
+    assert "B,institutions" in csv_full
+    assert "A,insiders" not in csv_filt
+    assert "B,institutions" in csv_filt
+    # Treasury memo + residual still appear in the filtered CSV
+    # (they are not slice-scoped).
+    assert "Public / unattributed" in csv_filt
+
+
+@pytest.mark.integration
+def test_csv_endpoint_treasury_filter_returns_memo_only(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """``?category=treasury`` is a valid filter even though treasury
+    is a memo row, not a slice. Endpoint returns CSV with the
+    treasury memo + residual rows only — no holder slices. Pins the
+    contract Codex Chain 2.8 follow-up identified: the FE's
+    CATEGORY_LABELS set includes 'treasury' so this filter value
+    must round-trip cleanly. The actual treasury memo row only
+    emits when the rollup has treasury_shares > 0; a no_data
+    instrument is fine for asserting the ``?category=treasury`` path
+    doesn't 400."""
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (789702, 'TREASCSV', 'Test', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+    )
+    conn.commit()
+
+    def _override_conn():  # type: ignore[no-untyped-def]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _override_conn
+    app.dependency_overrides[require_session_or_service_token] = lambda: object()
+    try:
+        client = TestClient(app)
+        resp = client.get("/instruments/TREASCSV/ownership-rollup/export.csv?category=treasury")
+        assert resp.status_code == 200
+        body = resp.text
+        # Header always emitted.
+        assert body.startswith("filer_cik,filer_name,category,")
+        # Residual memo always emitted (no treasury data on the
+        # no_data path, but the path itself works).
+        assert "Public / unattributed" in body
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+        app.dependency_overrides.pop(require_session_or_service_token, None)
+
+
+@pytest.mark.integration
+def test_csv_endpoint_rejects_unknown_category(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Unknown ``?category=`` value → 400, not silent pass-through.
+    Closed-set validation prevents typos surfacing as empty CSVs."""
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (789701, 'CATBAD', 'Test', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+    )
+    conn.commit()
+
+    def _override_conn():  # type: ignore[no-untyped-def]
+        yield conn
+
+    app.dependency_overrides[get_conn] = _override_conn
+    app.dependency_overrides[require_session_or_service_token] = lambda: object()
+    try:
+        client = TestClient(app)
+        resp = client.get("/instruments/CATBAD/ownership-rollup/export.csv?category=nope")
+        assert resp.status_code == 400
+        assert "Unknown category" in resp.json()["detail"]
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+        app.dependency_overrides.pop(require_session_or_service_token, None)
+
+
 @pytest.mark.integration
 def test_csv_endpoint_returns_attachment_header_and_404_unknown_symbol(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811


### PR DESCRIPTION
## Summary
- L2 ``?view=raw`` now links to the server-side canonical CSV endpoint instead of building CSV client-side from 5 separate fetches.
- Backend endpoint extended with ``?category=`` filter (insiders | blockholders | institutions | etfs | def14a_unmatched | treasury) so a drilled FE view scopes the CSV correctly.
- Removes ``buildCsv()`` + ``csvEscape()`` helpers (now dead code); contract preserved in ``tests/test_ownership_rollup_csv.py``.

## Why
The L2 ``?view=raw`` CSV used to reconstruct shares client-side from raw 13F + Form 4 + 13D fetches — could over-count joint filings or miss the cross-channel dedup. The server endpoint produces the canonical deduped CSV (form4 > form3 > 13D/G > def14a > 13f priority). This PR rewires the FE to that endpoint, with the FE's category filter flowing through.

## Test plan
- [x] ``uv run pytest tests/test_ownership_rollup_csv.py`` — 12/12 passing
- [x] ``pnpm typecheck`` — green
- [x] ``pnpm test:unit`` — 831/831 passing
- [x] Codex pre-push review (3 rounds — caught FE filter regression, treasury 400 regression, weak treasury test; all addressed)