### PR TITLE
fix(#838 P0c): pin treasury XBRL concept aliases + audit findings

### DIFF
--- a/tests/test_xbrl_fact_extraction.py
+++ b/tests/test_xbrl_fact_extraction.py
@@ -566,3 +566,49 @@ class TestPartnershipDistributionAliasing:
 
         col, _ = _TAG_TO_COLUMN["DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaidPerUnit"]
         assert col == "dps_cash_paid"
+
+
+# ---------------------------------------------------------------------------
+# Treasury stock shares concept aliasing (#838 / #788 P0c)
+# ---------------------------------------------------------------------------
+
+
+class TestTreasuryStockSharesAliasing:
+    """Pin the ``treasury_shares`` concept aliases. Operator audit
+    2026-05-03 found ownership rollup banner reporting NULL for every
+    instrument — root cause traced to extraction + normalization being
+    correct but sparse SEC reporting (AAPL retires buybacks instead of
+    holding treasury). Tests guard against accidental removal of the
+    canonical concepts so issuers who DO report (JPM, HD, MCD, etc.)
+    keep flowing through to the chart."""
+
+    def test_treasury_stock_shares_in_tracked_concepts(self) -> None:
+        from app.providers.implementations.sec_fundamentals import TRACKED_CONCEPTS
+
+        assert "treasury_shares" in TRACKED_CONCEPTS
+        tags = TRACKED_CONCEPTS["treasury_shares"]
+        # Both the legacy ``TreasuryStockShares`` and the modern
+        # ``TreasuryStockCommonShares`` must be present. Removing
+        # either silently halves coverage (issuers vary by accounting
+        # vintage / standard).
+        assert "TreasuryStockShares" in tags
+        assert "TreasuryStockCommonShares" in tags
+
+    def test_treasury_stock_shares_aliased_to_canonical_column(self) -> None:
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        col_a, _ = _TAG_TO_COLUMN["TreasuryStockShares"]
+        col_b, _ = _TAG_TO_COLUMN["TreasuryStockCommonShares"]
+        assert col_a == "treasury_shares"
+        assert col_b == "treasury_shares"
+
+    def test_treasury_priority_legacy_outranks_common(self) -> None:
+        """``TreasuryStockShares`` (legacy) is priority 0;
+        ``TreasuryStockCommonShares`` (modern) is fallback. Pinning
+        order guards against an accidental swap that would silently
+        flip the value-source for filers that emit both."""
+        from app.services.fundamentals import _TAG_TO_COLUMN
+
+        _, prio_legacy = _TAG_TO_COLUMN["TreasuryStockShares"]
+        _, prio_modern = _TAG_TO_COLUMN["TreasuryStockCommonShares"]
+        assert prio_legacy < prio_modern


### PR DESCRIPTION
## What

Regression coverage for the ``treasury_shares`` XBRL concept aliases. Investigation finding: extraction + backfill path already shipped under #731; the operator audit claim was inaccurate.

## Audit findings

1. ``TreasuryStockShares`` (legacy) + ``TreasuryStockCommonShares`` (modern) already in TRACKED_CONCEPTS since #731.
2. Backfill ``scripts/backfill_xbrl_normalization.py`` already shipped for #731. Re-ran on dev DB; coverage stable.
3. **1,362 instruments** have non-null ``treasury_shares`` in ``financial_periods`` today.
4. Rollup endpoint correctly surfaces:
   - ``GET /instruments/JPM/ownership-rollup`` → ``treasury_shares=1425422477``, ``treasury_as_of=2026-03-31``.
   - ``GET /instruments/HD/ownership-rollup`` → ``treasury_shares=806000000``, ``treasury_as_of=2026-02-01``.
5. AAPL / MSFT / GME / TSLA: genuinely don't report standing ``TreasuryStockShares`` to SEC (verified via direct ``data.sec.gov/api/xbrl/companyfacts/CIK*.json`` call). These issuers retire buybacks instead of holding treasury — NULL is the correct SEC-convention value, not a bug. The operator's "NULL across 4,591" claim was inaccurate.

## Why pin via tests

Future TRACKED_CONCEPTS edits could silently drop one alias or flip priority. Both are real risks given the long tag list. Three regression tests guard against:

- Removal of either ``TreasuryStockShares`` or ``TreasuryStockCommonShares``.
- Misrouting to a non-``treasury_shares`` canonical column.
- Priority swap (legacy must outrank modern so issuers that emit both don't flip value source).

## Test plan

- [x] ``pytest tests/test_xbrl_fact_extraction.py::TestTreasuryStockSharesAliasing`` — 3 new tests pass.
- [x] ``pytest tests/test_financial_normalization.py`` — existing 4+ treasury alias tests still pass.
- [x] ``pytest tests/test_ownership_rollup.py`` — 27 passing.
- [x] Live dev rollup endpoint smoke verified (JPM/HD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)