### PR TITLE
feat(#840 P1.B): institutions observations/current + exposure_kind

### DIFF
--- a/app/services/ownership_observations.py
+++ b/app/services/ownership_observations.py
@@ -273,6 +273,196 @@ def refresh_insiders_current(
         return int(row[0]) if row else 0
 
 
+# ---------------------------------------------------------------------------
+# Institutions — record + refresh (#840.B)
+# ---------------------------------------------------------------------------
+
+
+def record_institution_observation(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    filer_cik: str,
+    filer_name: str,
+    filer_type: str | None,
+    ownership_nature: OwnershipNature,
+    source: OwnershipSource,
+    source_document_id: str,
+    source_accession: str | None,
+    source_field: str | None,
+    source_url: str | None,
+    filed_at: datetime,
+    period_start: date | None,
+    period_end: date,
+    ingest_run_id: UUID,
+    shares: Decimal | None,
+    market_value_usd: Decimal | None,
+    voting_authority: str | None,
+    exposure_kind: Literal["EQUITY", "PUT", "CALL"] = "EQUITY",
+) -> None:
+    """Append one institution observation. Idempotent on
+    ``(instrument_id, filer_cik, ownership_nature, period_end, source_document_id, exposure_kind)``.
+
+    ``exposure_kind`` (Codex review for #840.B): 13F-HR can carry up
+    to three legal rows per ``(accession, instrument)`` — equity, PUT,
+    CALL. Pass ``'EQUITY'`` (default) for the standard equity position;
+    ``'PUT'`` / ``'CALL'`` for option exposure rows. Without this axis,
+    ON CONFLICT would collapse the three legal rows into one.
+
+    Identity contract (Codex plan-review finding #2): the legacy
+    ``institutional_holdings`` table joins to ``institutional_filers``
+    via ``filer_id``. Backfill (#840.E-prep) MUST resolve filer_id →
+    cik before calling this helper. ``filer_cik`` is the canonical
+    identity in the new model — orphans (filer_id with no
+    institutional_filers row) must be rejected at the call site, not
+    silently dropped here.
+
+    ``ownership_nature`` for 13F-HR: pass ``'economic'`` for the
+    full reported position. ``'voting'`` is reserved for an explicit
+    voting-authority overlay row that operator UI gains in a future
+    phase. Mapping pinned here so the per-source default is
+    consistent across the codebase."""
+    if filer_cik is None or not filer_cik.strip():
+        raise ValueError("record_institution_observation: filer_cik is required")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO ownership_institutions_observations (
+                instrument_id, filer_cik, filer_name, filer_type, ownership_nature,
+                source, source_document_id, source_accession, source_field, source_url,
+                filed_at, period_start, period_end, ingest_run_id,
+                shares, market_value_usd, voting_authority, exposure_kind
+            ) VALUES (
+                %(iid)s, %(cik)s, %(name)s, %(ftype)s, %(nature)s,
+                %(source)s, %(doc_id)s, %(accession)s, %(field)s, %(url)s,
+                %(filed_at)s, %(period_start)s, %(period_end)s, %(run_id)s,
+                %(shares)s, %(mv)s, %(voting)s, %(exp)s
+            )
+            ON CONFLICT (instrument_id, filer_cik, ownership_nature, period_end, source_document_id, exposure_kind)
+            DO UPDATE SET
+                filer_name = EXCLUDED.filer_name,
+                filer_type = EXCLUDED.filer_type,
+                source_accession = EXCLUDED.source_accession,
+                source_field = EXCLUDED.source_field,
+                source_url = EXCLUDED.source_url,
+                filed_at = EXCLUDED.filed_at,
+                period_start = EXCLUDED.period_start,
+                shares = EXCLUDED.shares,
+                market_value_usd = EXCLUDED.market_value_usd,
+                voting_authority = EXCLUDED.voting_authority,
+                ingest_run_id = EXCLUDED.ingest_run_id
+            """,
+            {
+                "iid": instrument_id,
+                "cik": filer_cik.strip(),
+                "name": filer_name,
+                "ftype": filer_type,
+                "nature": ownership_nature,
+                "source": source,
+                "doc_id": source_document_id,
+                "accession": source_accession,
+                "field": source_field,
+                "url": source_url,
+                "filed_at": filed_at,
+                "period_start": period_start,
+                "period_end": period_end,
+                "run_id": str(ingest_run_id),
+                "shares": shares,
+                "mv": market_value_usd,
+                "voting": voting_authority,
+                "exp": exposure_kind,
+            },
+        )
+
+
+def refresh_institutions_current(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> int:
+    """Deterministically rebuild ``ownership_institutions_current``
+    rows for one instrument.
+
+    Same atomicity contract as ``refresh_insiders_current``: explicit
+    transaction + per-instrument advisory lock. Dedup picks the latest
+    ``period_end`` per ``(filer_cik, ownership_nature)`` — within 13F
+    there's no cross-source priority chain to apply (13F is the only
+    source today; nport/ncsr in Phase 3 will need the chain). Final
+    deterministic tie-breakers: ``filed_at DESC, source_document_id ASC``."""
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_advisory_xact_lock(
+                (hashtextextended('refresh_institutions_current', 0) # %s::bigint)
+            )
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            "DELETE FROM ownership_institutions_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        cur.execute(
+            """
+            INSERT INTO ownership_institutions_current (
+                instrument_id, filer_cik, filer_name, filer_type, ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, market_value_usd, voting_authority, exposure_kind
+            )
+            SELECT DISTINCT ON (filer_cik, ownership_nature, exposure_kind)
+                instrument_id, filer_cik, filer_name, filer_type, ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, market_value_usd, voting_authority, exposure_kind
+            FROM ownership_institutions_observations
+            WHERE instrument_id = %s
+              AND known_to IS NULL
+            ORDER BY
+                filer_cik,
+                ownership_nature,
+                exposure_kind,
+                period_end DESC,
+                filed_at DESC,
+                source_document_id ASC
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            "SELECT COUNT(*) FROM ownership_institutions_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
+def resolve_filer_cik_or_raise(
+    conn: psycopg.Connection[Any],
+    *,
+    filer_id: int,
+) -> tuple[str, str, str | None]:
+    """Resolve a legacy ``institutional_holdings.filer_id`` to
+    ``(cik, name, filer_type)`` for the new observations API.
+
+    Codex plan-review finding #2: backfill MUST validate parent rows
+    exist before recording observations. Raises ``ValueError`` on an
+    orphan filer_id so the operator sees a loud failure rather than a
+    silent drop. Use this as the single resolution path so behaviour
+    is consistent across backfill + live ingester write-through."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT cik, name, filer_type FROM institutional_filers WHERE filer_id = %s",
+            (filer_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"institutional_filers row missing for filer_id={filer_id}; refusing to drop holding silently")
+    cik = str(row[0])
+    if not cik.strip():
+        raise ValueError(f"institutional_filers.cik is empty for filer_id={filer_id}")
+    return cik, str(row[1]), (str(row[2]) if row[2] is not None else None)
+
+
 def iter_insider_observations(
     conn: psycopg.Connection[Any],
     *,

--- a/sql/114_ownership_institutions_observations.sql
+++ b/sql/114_ownership_institutions_observations.sql
@@ -1,0 +1,143 @@
+-- 114_ownership_institutions_observations.sql
+--
+-- Issue #840 P1.B — institutions observations + _current per the
+-- Phase 1 schema unification. Mirrors the shape established in
+-- migration 113 (insiders).
+--
+-- Natural key per spec §"Per-category natural keys":
+--   - observations: (instrument_id, filer_cik, period_end, source_document_id)
+--   - _current:     (instrument_id, filer_cik)
+--
+-- Note: institutions don't use the cross-source priority chain the
+-- way insiders do (13F is the only source today; nport/ncsr land in
+-- Phase 3). Dedup is "latest period_end wins per (instrument, filer)".
+-- ``ownership_nature`` for 13F is ``voting`` or ``economic`` per the
+-- spec — current 13F-HR ingest tracks the holding-level voting figure
+-- in ``voting_authority`` already; this PR maps to ``economic`` as
+-- the default (full reported position) and the operator UI will gain
+-- a separate voting overlay later. Mapping pinned in
+-- ``record_institution_observation`` docstring.
+--
+-- Provenance block matches insiders byte-for-byte (Codex finding #4
+-- enforced by the schema-shape uniformity test).
+--
+-- ``filer_cik`` is the canonical identity here. The legacy
+-- ``institutional_holdings`` table joins to ``institutional_filers``
+-- via ``filer_id`` (BIGSERIAL FK); the backfill (#840.E-prep) has to
+-- resolve filer_id → cik before recording observations. Codex
+-- plan-review finding #2 documented the gap; the test suite below
+-- pins the contract.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS ownership_institutions_observations (
+    instrument_id           INTEGER NOT NULL,
+    filer_cik               TEXT NOT NULL,
+    filer_name              TEXT NOT NULL,
+    filer_type              TEXT
+        CHECK (filer_type IS NULL OR filer_type IN ('ETF', 'INV', 'INS', 'BD', 'OTHER')),
+    ownership_nature        TEXT NOT NULL
+        CHECK (ownership_nature IN ('direct', 'indirect', 'beneficial', 'voting', 'economic')),
+
+    source                  TEXT NOT NULL
+        CHECK (source IN ('form4', 'form3', '13d', '13g', 'def14a', '13f', 'nport', 'ncsr', 'xbrl_dei', '10k_note', 'finra_si', 'derived')),
+    source_document_id      TEXT NOT NULL,
+    source_accession        TEXT,
+    source_field            TEXT,
+    source_url              TEXT,
+    filed_at                TIMESTAMPTZ NOT NULL,
+    period_start            DATE,
+    period_end              DATE NOT NULL,
+    known_from              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    known_to                TIMESTAMPTZ,
+    ingest_run_id           UUID NOT NULL,
+
+    shares                  NUMERIC(24, 4),
+    market_value_usd        NUMERIC(20, 2),
+    voting_authority        TEXT
+        CHECK (voting_authority IS NULL OR voting_authority IN ('SOLE', 'SHARED', 'NONE')),
+    -- 13F-HR can carry up to three rows per (accession, instrument):
+    -- the equity position, PUT exposure, CALL exposure. Legacy
+    -- ``institutional_holdings`` keeps them distinct via
+    -- ``COALESCE(is_put_call, 'EQUITY')`` in a partial UNIQUE index.
+    -- The new model promotes that exposure kind to a first-class
+    -- column so all three coexist instead of collapsing on
+    -- ON CONFLICT (Codex review for #840.B caught the prior shape).
+    exposure_kind           TEXT NOT NULL DEFAULT 'EQUITY'
+        CHECK (exposure_kind IN ('EQUITY', 'PUT', 'CALL')),
+
+    PRIMARY KEY (instrument_id, filer_cik, ownership_nature, period_end, source_document_id, exposure_kind)
+) PARTITION BY RANGE (period_end);
+
+COMMENT ON TABLE ownership_institutions_observations IS
+    'Immutable per-quarter-per-filer 13F-HR fact log. Append-only; rebuild source for ownership_institutions_current. Spec: docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md (Phase 1).';
+
+DO $$
+DECLARE
+    yr INT;
+    qtr INT;
+    qstart DATE;
+    qend DATE;
+    pname TEXT;
+BEGIN
+    FOR yr IN 2010..2030 LOOP
+        FOR qtr IN 1..4 LOOP
+            qstart := MAKE_DATE(yr, (qtr - 1) * 3 + 1, 1);
+            qend := qstart + INTERVAL '3 months';
+            pname := FORMAT('ownership_institutions_observations_%sq%s', yr, qtr);
+            EXECUTE FORMAT(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF ownership_institutions_observations FOR VALUES FROM (%L) TO (%L)',
+                pname, qstart, qend
+            );
+        END LOOP;
+    END LOOP;
+END $$;
+
+CREATE TABLE IF NOT EXISTS ownership_institutions_observations_default
+    PARTITION OF ownership_institutions_observations DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_inst_obs_instrument_period
+    ON ownership_institutions_observations (instrument_id, period_end DESC);
+
+CREATE INDEX IF NOT EXISTS idx_inst_obs_filer_period
+    ON ownership_institutions_observations (filer_cik, period_end DESC);
+
+
+CREATE TABLE IF NOT EXISTS ownership_institutions_current (
+    instrument_id           INTEGER NOT NULL,
+    filer_cik               TEXT NOT NULL,
+    filer_name              TEXT NOT NULL,
+    filer_type              TEXT
+        CHECK (filer_type IS NULL OR filer_type IN ('ETF', 'INV', 'INS', 'BD', 'OTHER')),
+    ownership_nature        TEXT NOT NULL
+        CHECK (ownership_nature IN ('direct', 'indirect', 'beneficial', 'voting', 'economic')),
+
+    source                  TEXT NOT NULL
+        CHECK (source IN ('form4', 'form3', '13d', '13g', 'def14a', '13f', 'nport', 'ncsr', 'xbrl_dei', '10k_note', 'finra_si', 'derived')),
+    source_document_id      TEXT NOT NULL,
+    source_accession        TEXT,
+    source_url              TEXT,
+    filed_at                TIMESTAMPTZ NOT NULL,
+    period_start            DATE,
+    period_end              DATE NOT NULL,
+    refreshed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    shares                  NUMERIC(24, 4),
+    market_value_usd        NUMERIC(20, 2),
+    voting_authority        TEXT
+        CHECK (voting_authority IS NULL OR voting_authority IN ('SOLE', 'SHARED', 'NONE')),
+    -- Mirror the observations table: distinct equity / PUT / CALL
+    -- exposures coexist in _current (Codex review for #840.B).
+    exposure_kind           TEXT NOT NULL DEFAULT 'EQUITY'
+        CHECK (exposure_kind IN ('EQUITY', 'PUT', 'CALL')),
+
+    PRIMARY KEY (instrument_id, filer_cik, ownership_nature, exposure_kind)
+);
+
+COMMENT ON TABLE ownership_institutions_current IS
+    'Materialised latest-per-(instrument, filer, nature) 13F-HR snapshot. Rebuilt deterministically by refresh_institutions_current().';
+
+CREATE INDEX IF NOT EXISTS idx_inst_current_filer
+    ON ownership_institutions_current (filer_cik);
+
+COMMIT;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -169,6 +169,8 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # in the truncate list (no FK either way; ordered for clarity).
     "ownership_insiders_current",
     "ownership_insiders_observations",
+    "ownership_institutions_current",
+    "ownership_institutions_observations",
 )
 
 

--- a/tests/test_ownership_observations.py
+++ b/tests/test_ownership_observations.py
@@ -20,7 +20,10 @@ import pytest
 
 from app.services.ownership_observations import (
     record_insider_observation,
+    record_institution_observation,
     refresh_insiders_current,
+    refresh_institutions_current,
+    resolve_filer_cik_or_raise,
 )
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
 
@@ -404,3 +407,264 @@ class TestInsiderObservations:
             row = cur.fetchone()
         assert row is not None
         assert row[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# Institution observations + _current (#840.B)
+# ---------------------------------------------------------------------------
+
+
+def _seed_institutional_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str,
+    name: str,
+    filer_type: str | None = None,
+) -> int:
+    """Returns filer_id for the legacy join path."""
+    conn.execute(
+        """
+        INSERT INTO institutional_filers (cik, name, filer_type)
+        VALUES (%s, %s, %s)
+        ON CONFLICT (cik) DO UPDATE SET filer_type = EXCLUDED.filer_type
+        """,
+        (cik, name, filer_type),
+    )
+    with conn.cursor() as cur:
+        cur.execute("SELECT filer_id FROM institutional_filers WHERE cik = %s", (cik,))
+        row = cur.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+class TestInstitutionObservations:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=840_100, symbol="AAPL")
+        conn.commit()
+        return conn
+
+    def test_record_then_refresh_round_trip(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        record_institution_observation(
+            conn,
+            instrument_id=840_100,
+            filer_cik="0000102909",
+            filer_name="Vanguard Group Inc",
+            filer_type="ETF",
+            ownership_nature="economic",
+            source="13f",
+            source_document_id="0001234567-26-VG-Q1",
+            source_accession="0001234567-26-VG-Q1",
+            source_field=None,
+            source_url=None,
+            filed_at=datetime(2026, 4, 15, tzinfo=UTC),
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 3, 31),
+            ingest_run_id=uuid4(),
+            shares=Decimal("1500000000"),
+            market_value_usd=Decimal("250000000000"),
+            voting_authority="SOLE",
+        )
+        conn.commit()
+
+        n = refresh_institutions_current(conn, instrument_id=840_100)
+        conn.commit()
+        assert n == 1
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT filer_cik, shares, voting_authority
+                FROM ownership_institutions_current WHERE instrument_id = %s
+                """,
+                (840_100,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["filer_cik"] == "0000102909"
+        assert rows[0]["shares"] == Decimal("1500000000")
+        assert rows[0]["voting_authority"] == "SOLE"
+
+    def test_dedup_picks_latest_period_end(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Same filer, two consecutive quarters — _current carries the
+        Q1 2026 row; Q4 2025 stays in observations as history."""
+        conn = _setup
+        cik = "0000102909"
+        run_id = uuid4()
+        for q_end, accession, shares in [
+            (date(2025, 12, 31), "ACC-Q4", Decimal("1400000000")),
+            (date(2026, 3, 31), "ACC-Q1", Decimal("1500000000")),
+        ]:
+            record_institution_observation(
+                conn,
+                instrument_id=840_100,
+                filer_cik=cik,
+                filer_name="Vanguard Group Inc",
+                filer_type="ETF",
+                ownership_nature="economic",
+                source="13f",
+                source_document_id=accession,
+                source_accession=accession,
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(q_end.year, q_end.month, 28, tzinfo=UTC),
+                period_start=None,
+                period_end=q_end,
+                ingest_run_id=run_id,
+                shares=shares,
+                market_value_usd=None,
+                voting_authority=None,
+            )
+        conn.commit()
+
+        refresh_institutions_current(conn, instrument_id=840_100)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT period_end, shares FROM ownership_institutions_current WHERE filer_cik = %s",
+                (cik,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["period_end"] == date(2026, 3, 31)
+        assert rows[0]["shares"] == Decimal("1500000000")
+
+        # Both observations preserved (history).
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM ownership_institutions_observations WHERE filer_cik = %s",
+                (cik,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 2
+
+    def test_equity_put_call_coexist_per_accession(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Codex review for #840.B: 13F-HR can carry up to three legal
+        rows per (accession, instrument): equity, PUT, CALL. They MUST
+        coexist in observations and in _current — collapsing on
+        ON CONFLICT loses the option exposures."""
+        conn = _setup
+        cik = "0000102909"
+        run_id = uuid4()
+        accession = "ACC-3-EXPOSURE"
+        period_end = date(2026, 3, 31)
+        for kind, shares in [("EQUITY", Decimal("1000000")), ("PUT", Decimal("50000")), ("CALL", Decimal("75000"))]:
+            record_institution_observation(
+                conn,
+                instrument_id=840_100,
+                filer_cik=cik,
+                filer_name="Vanguard Group Inc",
+                filer_type="ETF",
+                ownership_nature="economic",
+                source="13f",
+                source_document_id=accession,
+                source_accession=accession,
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 4, 15, tzinfo=UTC),
+                period_start=None,
+                period_end=period_end,
+                ingest_run_id=run_id,
+                shares=shares,
+                market_value_usd=None,
+                voting_authority=None,
+                exposure_kind=kind,  # type: ignore[arg-type]
+            )
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM ownership_institutions_observations WHERE instrument_id = %s",
+                (840_100,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 3
+
+        refresh_institutions_current(conn, instrument_id=840_100)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT exposure_kind, shares FROM ownership_institutions_current
+                WHERE instrument_id = %s ORDER BY exposure_kind
+                """,
+                (840_100,),
+            )
+            rows = cur.fetchall()
+        kinds = {r["exposure_kind"]: r["shares"] for r in rows}
+        assert kinds == {
+            "CALL": Decimal("75000"),
+            "EQUITY": Decimal("1000000"),
+            "PUT": Decimal("50000"),
+        }
+
+    def test_record_rejects_blank_filer_cik(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Codex plan-review finding #2: orphan filer_cik must fail
+        loud, not silently drop. The new model's identity is filer_cik;
+        a blank value is unrecoverable."""
+        with pytest.raises(ValueError, match="filer_cik is required"):
+            record_institution_observation(
+                _setup,
+                instrument_id=840_100,
+                filer_cik="   ",
+                filer_name="Blank",
+                filer_type=None,
+                ownership_nature="economic",
+                source="13f",
+                source_document_id="ACC-X",
+                source_accession="ACC-X",
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 4, 15, tzinfo=UTC),
+                period_start=None,
+                period_end=date(2026, 3, 31),
+                ingest_run_id=uuid4(),
+                shares=Decimal("1"),
+                market_value_usd=None,
+                voting_authority=None,
+            )
+
+
+class TestResolveFilerCikOrRaise:
+    """Codex plan-review finding #2: backfill must resolve filer_id →
+    cik via institutional_filers and fail loud on orphans."""
+
+    def test_resolves_known_filer(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        filer_id = _seed_institutional_filer(conn, cik="0000102909", name="Vanguard", filer_type="ETF")
+        conn.commit()
+        cik, name, ftype = resolve_filer_cik_or_raise(conn, filer_id=filer_id)
+        assert cik == "0000102909"
+        assert name == "Vanguard"
+        assert ftype == "ETF"
+
+    def test_raises_on_orphan_filer_id(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        with pytest.raises(ValueError, match="filer_id=999999"):
+            resolve_filer_cik_or_raise(ebull_test_conn, filer_id=999_999)


### PR DESCRIPTION
## What

Sub-PR B of #840. Institutions (13F-HR) observations/current per the spec. Mirrors #840.A insiders shape with one extension: ``exposure_kind`` (EQUITY/PUT/CALL) as a first-class axis.

## Codex pre-push finding (fixed in this commit)

13F-HR can carry up to three legal rows per (accession, instrument) — equity, PUT, CALL. Legacy ``institutional_holdings`` keeps them distinct via ``COALESCE(is_put_call, 'EQUITY')`` in a partial UNIQUE index. The first draft of this sub-PR collapsed all three onto one PK; ON CONFLICT would have dropped two of three legal exposures. Fix: ``exposure_kind`` column + included in PK on both observations and current tables.

## Test plan

- [x] ``pytest tests/test_ownership_observations.py`` — 13 passing (12 + 1 new equity/PUT/CALL coexistence test).
- [x] Schema-shape uniformity test auto-enrolls the new institutions table via LIKE-pattern.
- [x] ``ruff check``, ``pyright`` clean.
- [x] Codex pre-push review — exposure-axis finding addressed.

## Out of scope

- Live institutional ingester write-through (#840.E-prep).
- Backfill of legacy rows (#840.E-prep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)