### PR TITLE
feat(#840 P1.D): treasury + DEF 14A observations/current

### DIFF
--- a/app/services/ownership_observations.py
+++ b/app/services/ownership_observations.py
@@ -610,6 +610,253 @@ def refresh_blockholders_current(
         return int(row[0]) if row else 0
 
 
+# ---------------------------------------------------------------------------
+# Treasury — record + refresh (#840.D)
+# ---------------------------------------------------------------------------
+
+
+def record_treasury_observation(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    source: OwnershipSource,
+    source_document_id: str,
+    source_accession: str | None,
+    source_field: str | None,
+    source_url: str | None,
+    filed_at: datetime,
+    period_start: date | None,
+    period_end: date,
+    ingest_run_id: UUID,
+    treasury_shares: Decimal | None,
+) -> None:
+    """Append one treasury observation. ``ownership_nature`` is fixed
+    to ``'economic'`` (issuer-held shares — not Rule 13d-3 beneficial).
+    Source is typically ``'xbrl_dei'`` (TreasuryStockShares /
+    TreasuryStockCommonShares); ``'10k_note'`` for narrative
+    fallbacks."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO ownership_treasury_observations (
+                instrument_id, source, source_document_id, source_accession, source_field, source_url,
+                filed_at, period_start, period_end, ingest_run_id, treasury_shares
+            ) VALUES (
+                %(iid)s, %(source)s, %(doc_id)s, %(accession)s, %(field)s, %(url)s,
+                %(filed_at)s, %(period_start)s, %(period_end)s, %(run_id)s, %(shares)s
+            )
+            ON CONFLICT (instrument_id, period_end, source_document_id)
+            DO UPDATE SET
+                source = EXCLUDED.source,
+                source_accession = EXCLUDED.source_accession,
+                source_field = EXCLUDED.source_field,
+                source_url = EXCLUDED.source_url,
+                filed_at = EXCLUDED.filed_at,
+                period_start = EXCLUDED.period_start,
+                treasury_shares = EXCLUDED.treasury_shares,
+                ingest_run_id = EXCLUDED.ingest_run_id
+            """,
+            {
+                "iid": instrument_id,
+                "source": source,
+                "doc_id": source_document_id,
+                "accession": source_accession,
+                "field": source_field,
+                "url": source_url,
+                "filed_at": filed_at,
+                "period_start": period_start,
+                "period_end": period_end,
+                "run_id": str(ingest_run_id),
+                "shares": treasury_shares,
+            },
+        )
+
+
+def refresh_treasury_current(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> int:
+    """Latest non-null ``treasury_shares`` per instrument wins.
+    ``WHERE treasury_shares IS NOT NULL`` so a NULL observation
+    doesn't displace an earlier non-null value (e.g. a re-parse
+    that lost the concept shouldn't blank out the column)."""
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_advisory_xact_lock(
+                (hashtextextended('refresh_treasury_current', 0) # %s::bigint)
+            )
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            "DELETE FROM ownership_treasury_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        cur.execute(
+            """
+            INSERT INTO ownership_treasury_current (
+                instrument_id, ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end, treasury_shares
+            )
+            SELECT DISTINCT ON (instrument_id)
+                instrument_id, ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end, treasury_shares
+            FROM ownership_treasury_observations
+            WHERE instrument_id = %s
+              AND known_to IS NULL
+              AND treasury_shares IS NOT NULL
+            ORDER BY
+                instrument_id,
+                period_end DESC,
+                filed_at DESC,
+                source_document_id ASC
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            "SELECT COUNT(*) FROM ownership_treasury_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
+# ---------------------------------------------------------------------------
+# DEF 14A — record + refresh (#840.D)
+# ---------------------------------------------------------------------------
+
+
+def record_def14a_observation(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    holder_name: str,
+    holder_role: str | None,
+    ownership_nature: OwnershipNature,
+    source: OwnershipSource,
+    source_document_id: str,
+    source_accession: str | None,
+    source_field: str | None,
+    source_url: str | None,
+    filed_at: datetime,
+    period_start: date | None,
+    period_end: date,
+    ingest_run_id: UUID,
+    shares: Decimal | None,
+    percent_of_class: Decimal | None,
+) -> None:
+    """Append one DEF 14A bene-table observation. Identity is the
+    normalised holder name (generated column ``holder_name_key`` =
+    lower(trim(holder_name))) — DEF 14A doesn't carry CIK on the
+    proxy so the resolver-to-CIK match happens at rollup-read time
+    instead of here."""
+    if not holder_name or not holder_name.strip():
+        raise ValueError("record_def14a_observation: holder_name is required")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO ownership_def14a_observations (
+                instrument_id, holder_name, holder_role, ownership_nature,
+                source, source_document_id, source_accession, source_field, source_url,
+                filed_at, period_start, period_end, ingest_run_id,
+                shares, percent_of_class
+            ) VALUES (
+                %(iid)s, %(name)s, %(role)s, %(nature)s,
+                %(source)s, %(doc_id)s, %(accession)s, %(field)s, %(url)s,
+                %(filed_at)s, %(period_start)s, %(period_end)s, %(run_id)s,
+                %(shares)s, %(pct)s
+            )
+            ON CONFLICT (instrument_id, holder_name_key, period_end, source_document_id)
+            DO UPDATE SET
+                holder_name = EXCLUDED.holder_name,
+                holder_role = EXCLUDED.holder_role,
+                ownership_nature = EXCLUDED.ownership_nature,
+                source_accession = EXCLUDED.source_accession,
+                source_field = EXCLUDED.source_field,
+                source_url = EXCLUDED.source_url,
+                filed_at = EXCLUDED.filed_at,
+                period_start = EXCLUDED.period_start,
+                shares = EXCLUDED.shares,
+                percent_of_class = EXCLUDED.percent_of_class,
+                ingest_run_id = EXCLUDED.ingest_run_id
+            """,
+            {
+                "iid": instrument_id,
+                "name": holder_name,
+                "role": holder_role,
+                "nature": ownership_nature,
+                "source": source,
+                "doc_id": source_document_id,
+                "accession": source_accession,
+                "field": source_field,
+                "url": source_url,
+                "filed_at": filed_at,
+                "period_start": period_start,
+                "period_end": period_end,
+                "run_id": str(ingest_run_id),
+                "shares": shares,
+                "pct": percent_of_class,
+            },
+        )
+
+
+def refresh_def14a_current(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> int:
+    """Latest proxy per (instrument, normalised holder name) wins."""
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_advisory_xact_lock(
+                (hashtextextended('refresh_def14a_current', 0) # %s::bigint)
+            )
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            "DELETE FROM ownership_def14a_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        cur.execute(
+            """
+            INSERT INTO ownership_def14a_current (
+                instrument_id, holder_name, holder_name_key, holder_role, ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, percent_of_class
+            )
+            SELECT DISTINCT ON (holder_name_key, ownership_nature)
+                instrument_id, holder_name, holder_name_key, holder_role, ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, percent_of_class
+            FROM ownership_def14a_observations
+            WHERE instrument_id = %s
+              AND known_to IS NULL
+              AND shares IS NOT NULL  -- prevent NULL re-parse displacing prior good value
+            ORDER BY
+                holder_name_key,
+                ownership_nature,
+                period_end DESC,
+                filed_at DESC,
+                source_document_id ASC
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            "SELECT COUNT(*) FROM ownership_def14a_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
 def iter_insider_observations(
     conn: psycopg.Connection[Any],
     *,

--- a/sql/116_ownership_treasury_def14a_observations.sql
+++ b/sql/116_ownership_treasury_def14a_observations.sql
@@ -1,0 +1,202 @@
+-- 116_ownership_treasury_def14a_observations.sql
+--
+-- Issue #840 P1.D — treasury (XBRL DEI/us-gaap) + DEF 14A bene-table
+-- observations + _current. Final per-category sub-PR for Phase 1.
+--
+-- Treasury natural keys per spec:
+--   - observations: (instrument_id, period_end, source_document_id)
+--   - _current:     (instrument_id)
+-- Treasury is issuer-level — no holder dimension. ``ownership_nature``
+-- pinned to ``'economic'`` (issuer-held shares are an economic
+-- position; not Rule-13d-3 beneficial). Source = 'xbrl_dei'.
+--
+-- DEF 14A natural keys:
+--   - observations: (instrument_id, holder_name, period_end, source_document_id)
+--   - _current:     (instrument_id, holder_name)
+-- DEF 14A's bene table holders are typically named officers /
+-- directors / 5%+ owners; not all of them have a CIK on the proxy
+-- itself. Identity is the canonical lower(trim(holder_name)) so
+-- DEF 14A doesn't depend on the holder-name resolver running first.
+-- Match-to-CIK happens at rollup-read time (#840.E).
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- Treasury observations
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ownership_treasury_observations (
+    instrument_id           INTEGER NOT NULL,
+    ownership_nature        TEXT NOT NULL DEFAULT 'economic'
+        CHECK (ownership_nature IN ('direct', 'indirect', 'beneficial', 'voting', 'economic')),
+
+    source                  TEXT NOT NULL
+        CHECK (source IN ('form4', 'form3', '13d', '13g', 'def14a', '13f', 'nport', 'ncsr', 'xbrl_dei', '10k_note', 'finra_si', 'derived')),
+    source_document_id      TEXT NOT NULL,
+    source_accession        TEXT,
+    source_field            TEXT,
+    source_url              TEXT,
+    filed_at                TIMESTAMPTZ NOT NULL,
+    period_start            DATE,
+    period_end              DATE NOT NULL,
+    known_from              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    known_to                TIMESTAMPTZ,
+    ingest_run_id           UUID NOT NULL,
+
+    treasury_shares         NUMERIC(24, 4),
+
+    PRIMARY KEY (instrument_id, period_end, source_document_id)
+) PARTITION BY RANGE (period_end);
+
+COMMENT ON TABLE ownership_treasury_observations IS
+    'Immutable per-period treasury-stock fact log from XBRL DEI / us-gaap. Source for ownership_treasury_current.';
+
+DO $$
+DECLARE
+    yr INT;
+    qtr INT;
+    qstart DATE;
+    qend DATE;
+    pname TEXT;
+BEGIN
+    FOR yr IN 2010..2030 LOOP
+        FOR qtr IN 1..4 LOOP
+            qstart := MAKE_DATE(yr, (qtr - 1) * 3 + 1, 1);
+            qend := qstart + INTERVAL '3 months';
+            pname := FORMAT('ownership_treasury_observations_%sq%s', yr, qtr);
+            EXECUTE FORMAT(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF ownership_treasury_observations FOR VALUES FROM (%L) TO (%L)',
+                pname, qstart, qend
+            );
+        END LOOP;
+    END LOOP;
+END $$;
+
+CREATE TABLE IF NOT EXISTS ownership_treasury_observations_default
+    PARTITION OF ownership_treasury_observations DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_treasury_obs_instrument_period
+    ON ownership_treasury_observations (instrument_id, period_end DESC);
+
+CREATE TABLE IF NOT EXISTS ownership_treasury_current (
+    instrument_id           INTEGER NOT NULL,
+    ownership_nature        TEXT NOT NULL DEFAULT 'economic'
+        CHECK (ownership_nature IN ('direct', 'indirect', 'beneficial', 'voting', 'economic')),
+
+    source                  TEXT NOT NULL
+        CHECK (source IN ('form4', 'form3', '13d', '13g', 'def14a', '13f', 'nport', 'ncsr', 'xbrl_dei', '10k_note', 'finra_si', 'derived')),
+    source_document_id      TEXT NOT NULL,
+    source_accession        TEXT,
+    source_url              TEXT,
+    filed_at                TIMESTAMPTZ NOT NULL,
+    period_start            DATE,
+    period_end              DATE NOT NULL,
+    refreshed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    treasury_shares         NUMERIC(24, 4),
+
+    PRIMARY KEY (instrument_id)
+);
+
+COMMENT ON TABLE ownership_treasury_current IS
+    'Materialised latest-treasury snapshot per instrument. Rebuilt by refresh_treasury_current().';
+
+
+-- ---------------------------------------------------------------------
+-- DEF 14A observations
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ownership_def14a_observations (
+    instrument_id           INTEGER NOT NULL,
+    holder_name             TEXT NOT NULL,
+    holder_name_key         TEXT NOT NULL GENERATED ALWAYS AS (lower(trim(holder_name))) STORED,
+    holder_role             TEXT,
+    ownership_nature        TEXT NOT NULL DEFAULT 'beneficial'
+        CHECK (ownership_nature IN ('direct', 'indirect', 'beneficial', 'voting', 'economic')),
+
+    source                  TEXT NOT NULL
+        CHECK (source IN ('form4', 'form3', '13d', '13g', 'def14a', '13f', 'nport', 'ncsr', 'xbrl_dei', '10k_note', 'finra_si', 'derived')),
+    source_document_id      TEXT NOT NULL,
+    source_accession        TEXT,
+    source_field            TEXT,
+    source_url              TEXT,
+    filed_at                TIMESTAMPTZ NOT NULL,
+    period_start            DATE,
+    period_end              DATE NOT NULL,
+    known_from              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    known_to                TIMESTAMPTZ,
+    ingest_run_id           UUID NOT NULL,
+
+    shares                  NUMERIC(24, 4),
+    percent_of_class        NUMERIC(8, 4),
+
+    PRIMARY KEY (instrument_id, holder_name_key, period_end, source_document_id)
+) PARTITION BY RANGE (period_end);
+
+COMMENT ON TABLE ownership_def14a_observations IS
+    'Immutable per-proxy bene-table fact log. Holder identity is normalized name (no CIK on proxy). CIK match happens at rollup-read time.';
+
+DO $$
+DECLARE
+    yr INT;
+    qtr INT;
+    qstart DATE;
+    qend DATE;
+    pname TEXT;
+BEGIN
+    FOR yr IN 2010..2030 LOOP
+        FOR qtr IN 1..4 LOOP
+            qstart := MAKE_DATE(yr, (qtr - 1) * 3 + 1, 1);
+            qend := qstart + INTERVAL '3 months';
+            pname := FORMAT('ownership_def14a_observations_%sq%s', yr, qtr);
+            EXECUTE FORMAT(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF ownership_def14a_observations FOR VALUES FROM (%L) TO (%L)',
+                pname, qstart, qend
+            );
+        END LOOP;
+    END LOOP;
+END $$;
+
+CREATE TABLE IF NOT EXISTS ownership_def14a_observations_default
+    PARTITION OF ownership_def14a_observations DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_def14a_obs_instrument_period
+    ON ownership_def14a_observations (instrument_id, period_end DESC);
+
+CREATE INDEX IF NOT EXISTS idx_def14a_obs_holder_period
+    ON ownership_def14a_observations (holder_name_key, period_end DESC);
+
+
+CREATE TABLE IF NOT EXISTS ownership_def14a_current (
+    instrument_id           INTEGER NOT NULL,
+    holder_name             TEXT NOT NULL,
+    holder_name_key         TEXT NOT NULL,
+    holder_role             TEXT,
+    ownership_nature        TEXT NOT NULL DEFAULT 'beneficial'
+        CHECK (ownership_nature IN ('direct', 'indirect', 'beneficial', 'voting', 'economic')),
+
+    source                  TEXT NOT NULL
+        CHECK (source IN ('form4', 'form3', '13d', '13g', 'def14a', '13f', 'nport', 'ncsr', 'xbrl_dei', '10k_note', 'finra_si', 'derived')),
+    source_document_id      TEXT NOT NULL,
+    source_accession        TEXT,
+    source_url              TEXT,
+    filed_at                TIMESTAMPTZ NOT NULL,
+    period_start            DATE,
+    period_end              DATE NOT NULL,
+    refreshed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    shares                  NUMERIC(24, 4),
+    percent_of_class        NUMERIC(8, 4),
+
+    -- Codex review for #840.D: include ``ownership_nature`` in the
+    -- PK so a holder reporting both beneficial + voting splits on
+    -- the same proxy retains both rows. Without it, the second
+    -- INSERT collapses the first via UPSERT.
+    PRIMARY KEY (instrument_id, holder_name_key, ownership_nature)
+);
+
+COMMENT ON TABLE ownership_def14a_current IS
+    'Materialised latest-proxy-per-holder DEF 14A bene snapshot. Rebuilt by refresh_def14a_current().';
+
+CREATE INDEX IF NOT EXISTS idx_def14a_current_holder_key
+    ON ownership_def14a_current (holder_name_key);
+
+COMMIT;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -173,6 +173,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "ownership_institutions_observations",
     "ownership_blockholders_current",
     "ownership_blockholders_observations",
+    "ownership_treasury_current",
+    "ownership_treasury_observations",
+    "ownership_def14a_current",
+    "ownership_def14a_observations",
 )
 
 

--- a/tests/test_ownership_observations.py
+++ b/tests/test_ownership_observations.py
@@ -20,11 +20,15 @@ import pytest
 
 from app.services.ownership_observations import (
     record_blockholder_observation,
+    record_def14a_observation,
     record_insider_observation,
     record_institution_observation,
+    record_treasury_observation,
     refresh_blockholders_current,
+    refresh_def14a_current,
     refresh_insiders_current,
     refresh_institutions_current,
+    refresh_treasury_current,
     resolve_filer_cik_or_raise,
 )
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
@@ -854,5 +858,349 @@ class TestBlockholderObservations:
                 period_end=date(2026, 1, 1),
                 ingest_run_id=uuid4(),
                 aggregate_amount_owned=Decimal("1"),
+                percent_of_class=None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Treasury observations + _current (#840.D)
+# ---------------------------------------------------------------------------
+
+
+class TestTreasuryObservations:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=840_300, symbol="JPM")
+        conn.commit()
+        return conn
+
+    def test_round_trip_picks_latest_period(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        run_id = uuid4()
+        for q_end, accession, shares in [
+            (date(2025, 12, 31), "ACC-Q4", Decimal("1408661319")),
+            (date(2026, 3, 31), "ACC-Q1", Decimal("1425422477")),
+        ]:
+            record_treasury_observation(
+                conn,
+                instrument_id=840_300,
+                source="xbrl_dei",
+                source_document_id=accession,
+                source_accession=accession,
+                source_field="TreasuryStockShares",
+                source_url=None,
+                filed_at=datetime(q_end.year, q_end.month, 28, tzinfo=UTC),
+                period_start=None,
+                period_end=q_end,
+                ingest_run_id=run_id,
+                treasury_shares=shares,
+            )
+        conn.commit()
+
+        n = refresh_treasury_current(conn, instrument_id=840_300)
+        conn.commit()
+        assert n == 1
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT period_end, treasury_shares FROM ownership_treasury_current WHERE instrument_id = %s",
+                (840_300,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["period_end"] == date(2026, 3, 31)
+        assert rows[0]["treasury_shares"] == Decimal("1425422477")
+
+    def test_null_observation_does_not_displace_non_null(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """A re-parse that lost the concept (NULL value) must NOT
+        blank out the prior good value in _current."""
+        conn = _setup
+        run_id = uuid4()
+        record_treasury_observation(
+            conn,
+            instrument_id=840_300,
+            source="xbrl_dei",
+            source_document_id="ACC-OLD",
+            source_accession="ACC-OLD",
+            source_field=None,
+            source_url=None,
+            filed_at=datetime(2025, 6, 30, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2025, 6, 30),
+            ingest_run_id=run_id,
+            treasury_shares=Decimal("1300000000"),
+        )
+        record_treasury_observation(
+            conn,
+            instrument_id=840_300,
+            source="xbrl_dei",
+            source_document_id="ACC-NEW",
+            source_accession="ACC-NEW",
+            source_field=None,
+            source_url=None,
+            filed_at=datetime(2026, 3, 31, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2026, 3, 31),
+            ingest_run_id=run_id,
+            treasury_shares=None,
+        )
+        conn.commit()
+
+        refresh_treasury_current(conn, instrument_id=840_300)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT treasury_shares FROM ownership_treasury_current WHERE instrument_id = %s",
+                (840_300,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["treasury_shares"] == Decimal("1300000000")
+
+
+# ---------------------------------------------------------------------------
+# DEF 14A observations + _current (#840.D)
+# ---------------------------------------------------------------------------
+
+
+class TestDef14aObservations:
+    @pytest.fixture
+    def _setup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> psycopg.Connection[tuple]:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=840_400, symbol="AAPL")
+        conn.commit()
+        return conn
+
+    def test_round_trip(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        conn = _setup
+        record_def14a_observation(
+            conn,
+            instrument_id=840_400,
+            holder_name="Tim Cook",
+            holder_role="CEO",
+            ownership_nature="beneficial",
+            source="def14a",
+            source_document_id="ACC-PROXY-2026",
+            source_accession="ACC-PROXY-2026",
+            source_field=None,
+            source_url=None,
+            filed_at=datetime(2026, 1, 15, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2025, 12, 31),
+            ingest_run_id=uuid4(),
+            shares=Decimal("3300000"),
+            percent_of_class=Decimal("0.02"),
+        )
+        conn.commit()
+
+        n = refresh_def14a_current(conn, instrument_id=840_400)
+        conn.commit()
+        assert n == 1
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT holder_name, holder_name_key, shares
+                FROM ownership_def14a_current WHERE instrument_id = %s
+                """,
+                (840_400,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["holder_name"] == "Tim Cook"
+        assert rows[0]["holder_name_key"] == "tim cook"
+        assert rows[0]["shares"] == Decimal("3300000")
+
+    def test_holder_name_normalised_to_key(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Two proxies, same officer with whitespace / case variation
+        in the name: dedup collapses to one ``_current`` row keyed on
+        the normalised name."""
+        conn = _setup
+        run_id = uuid4()
+        for q_end, accession, name, shares in [
+            (date(2024, 12, 31), "ACC-2024", "  Tim Cook  ", Decimal("3000000")),
+            (date(2025, 12, 31), "ACC-2025", "TIM COOK", Decimal("3300000")),
+        ]:
+            record_def14a_observation(
+                conn,
+                instrument_id=840_400,
+                holder_name=name,
+                holder_role=None,
+                ownership_nature="beneficial",
+                source="def14a",
+                source_document_id=accession,
+                source_accession=accession,
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(q_end.year, q_end.month, 31, tzinfo=UTC),
+                period_start=None,
+                period_end=q_end,
+                ingest_run_id=run_id,
+                shares=shares,
+                percent_of_class=None,
+            )
+        conn.commit()
+
+        refresh_def14a_current(conn, instrument_id=840_400)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT shares FROM ownership_def14a_current WHERE instrument_id = %s",
+                (840_400,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["shares"] == Decimal("3300000")
+
+    def test_dual_nature_for_same_holder(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Codex review for #840.D: a DEF 14A holder reporting BOTH
+        beneficial and voting splits must retain BOTH rows in
+        _current. Earlier shape collapsed on holder_name_key."""
+        conn = _setup
+        run_id = uuid4()
+        for nature, accession, shares in [
+            ("beneficial", "ACC-BEN", Decimal("3300000")),
+            ("voting", "ACC-VOTE", Decimal("3000000")),
+        ]:
+            record_def14a_observation(
+                conn,
+                instrument_id=840_400,
+                holder_name="Tim Cook",
+                holder_role="CEO",
+                ownership_nature=nature,  # type: ignore[arg-type]
+                source="def14a",
+                source_document_id=accession,
+                source_accession=accession,
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 1, 15, tzinfo=UTC),
+                period_start=None,
+                period_end=date(2025, 12, 31),
+                ingest_run_id=run_id,
+                shares=shares,
+                percent_of_class=None,
+            )
+        conn.commit()
+
+        refresh_def14a_current(conn, instrument_id=840_400)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT ownership_nature, shares FROM ownership_def14a_current
+                WHERE instrument_id = %s ORDER BY ownership_nature
+                """,
+                (840_400,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 2
+        natures = {r["ownership_nature"]: r["shares"] for r in rows}
+        assert natures == {"beneficial": Decimal("3300000"), "voting": Decimal("3000000")}
+
+    def test_null_shares_does_not_displace_prior_good_value(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Codex review for #840.D: a re-parse of a later proxy that
+        loses the shares concept must NOT blank out the prior good
+        value in _current. Refresh filters NULL shares."""
+        conn = _setup
+        run_id = uuid4()
+        record_def14a_observation(
+            conn,
+            instrument_id=840_400,
+            holder_name="Tim Cook",
+            holder_role=None,
+            ownership_nature="beneficial",
+            source="def14a",
+            source_document_id="ACC-OLD",
+            source_accession="ACC-OLD",
+            source_field=None,
+            source_url=None,
+            filed_at=datetime(2024, 1, 15, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2023, 12, 31),
+            ingest_run_id=run_id,
+            shares=Decimal("3000000"),
+            percent_of_class=None,
+        )
+        record_def14a_observation(
+            conn,
+            instrument_id=840_400,
+            holder_name="Tim Cook",
+            holder_role=None,
+            ownership_nature="beneficial",
+            source="def14a",
+            source_document_id="ACC-NEW",
+            source_accession="ACC-NEW",
+            source_field=None,
+            source_url=None,
+            filed_at=datetime(2026, 1, 15, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2025, 12, 31),
+            ingest_run_id=run_id,
+            shares=None,
+            percent_of_class=None,
+        )
+        conn.commit()
+
+        refresh_def14a_current(conn, instrument_id=840_400)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT shares FROM ownership_def14a_current WHERE instrument_id = %s",
+                (840_400,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["shares"] == Decimal("3000000")
+
+    def test_record_rejects_blank_holder_name(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        with pytest.raises(ValueError, match="holder_name is required"):
+            record_def14a_observation(
+                _setup,
+                instrument_id=840_400,
+                holder_name="   ",
+                holder_role=None,
+                ownership_nature="beneficial",
+                source="def14a",
+                source_document_id="ACC-X",
+                source_accession="ACC-X",
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+                period_start=None,
+                period_end=date(2026, 1, 1),
+                ingest_run_id=uuid4(),
+                shares=Decimal("1"),
                 percent_of_class=None,
             )


### PR DESCRIPTION
## What

Final per-category sub-PR for Phase 1 schema unification. Treasury (XBRL DEI / us-gaap) + DEF 14A bene-table observations/current. Mirrors #840.A/B/C shape.

## Codex pre-push findings (both fixed)

1. DEF 14A current PK collapsed dual-nature rows (beneficial + voting on same proxy). Fix: include ``ownership_nature`` in PK + DISTINCT ON.
2. DEF 14A refresh didn't filter NULL ``shares``. A re-parse losing the concept would blank prior good value. Fix: ``WHERE shares IS NOT NULL`` in refresh.

## Test plan

- [x] 24 tests passing (was 17 in #840.C).
- [x] Schema-shape uniformity auto-enrolls treasury + def14a tables.
- [x] Codex pre-push (2 findings fixed).

## Phase 1 status after this merge

- ✅ A — insiders observations/current (PR #851).
- ✅ B — institutions (PR #852).
- ✅ C — blockholders (PR #853).
- ✅ D — treasury + def14a (this PR).
- 🟡 E-prep — live ingester write-through + backfill (next sub-PR).
- 🟡 E — rewire rollup with feature flag + dual-read parity.
- 🟡 F — history endpoint with time-bucket dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)