### PR TITLE
fix(#840 P1.D.1): def14a observations PK missing ownership_nature

### DIFF
--- a/app/services/ownership_observations.py
+++ b/app/services/ownership_observations.py
@@ -770,11 +770,10 @@ def record_def14a_observation(
                 %(filed_at)s, %(period_start)s, %(period_end)s, %(run_id)s,
                 %(shares)s, %(pct)s
             )
-            ON CONFLICT (instrument_id, holder_name_key, period_end, source_document_id)
+            ON CONFLICT (instrument_id, holder_name_key, ownership_nature, period_end, source_document_id)
             DO UPDATE SET
                 holder_name = EXCLUDED.holder_name,
                 holder_role = EXCLUDED.holder_role,
-                ownership_nature = EXCLUDED.ownership_nature,
                 source_accession = EXCLUDED.source_accession,
                 source_field = EXCLUDED.source_field,
                 source_url = EXCLUDED.source_url,

--- a/sql/117_ownership_def14a_obs_pk_nature.sql
+++ b/sql/117_ownership_def14a_obs_pk_nature.sql
@@ -1,0 +1,25 @@
+-- 117_ownership_def14a_obs_pk_nature.sql
+--
+-- Issue #840 P1.D follow-up — review caught observation-table PK gap
+-- on PR #854. The _current PK was correctly updated to include
+-- ``ownership_nature`` so dual-nature rows (beneficial + voting on
+-- same proxy) coexist; the observations PK was NOT mirrored, so the
+-- ON CONFLICT DO UPDATE in record_def14a_observation silently
+-- overwrites the first nature with the second whenever both share
+-- the same accession (which a real single-proxy filing does).
+--
+-- Fix: drop the prior PK + recreate including ownership_nature.
+-- The table is empty in production today (no backfill yet) so this
+-- is a clean DDL change with no data migration step.
+
+BEGIN;
+
+-- Drop the parent's PK; partition tables inherit the parent's PK
+-- definition, so the change cascades to every partition.
+ALTER TABLE ownership_def14a_observations
+    DROP CONSTRAINT IF EXISTS ownership_def14a_observations_pkey;
+
+ALTER TABLE ownership_def14a_observations
+    ADD PRIMARY KEY (instrument_id, holder_name_key, ownership_nature, period_end, source_document_id);
+
+COMMIT;

--- a/tests/test_ownership_observations.py
+++ b/tests/test_ownership_observations.py
@@ -1073,13 +1073,78 @@ class TestDef14aObservations:
         assert len(rows) == 1
         assert rows[0]["shares"] == Decimal("3300000")
 
+    def test_dual_nature_for_same_holder_same_accession(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Bot review for #840.D PR #854: a real proxy filing carries
+        BOTH beneficial and voting rows for the same holder under the
+        SAME accession. The observations PK must include
+        ``ownership_nature`` so the two rows coexist; otherwise the
+        second INSERT collapses the first via ON CONFLICT before
+        refresh ever runs. Migration 117 fixes this."""
+        conn = _setup
+        run_id = uuid4()
+        accession = "ACC-PROXY-2026"  # SAME accession for both natures
+        for nature, shares in [
+            ("beneficial", Decimal("3300000")),
+            ("voting", Decimal("3000000")),
+        ]:
+            record_def14a_observation(
+                conn,
+                instrument_id=840_400,
+                holder_name="Tim Cook",
+                holder_role="CEO",
+                ownership_nature=nature,  # type: ignore[arg-type]
+                source="def14a",
+                source_document_id=accession,
+                source_accession=accession,
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 1, 15, tzinfo=UTC),
+                period_start=None,
+                period_end=date(2025, 12, 31),
+                ingest_run_id=run_id,
+                shares=shares,
+                percent_of_class=None,
+            )
+        conn.commit()
+
+        # Both observations preserved (no PK collision).
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM ownership_def14a_observations
+                WHERE instrument_id = %s AND source_document_id = %s
+                """,
+                (840_400, accession),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 2
+
+        refresh_def14a_current(conn, instrument_id=840_400)
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT ownership_nature, shares FROM ownership_def14a_current
+                WHERE instrument_id = %s ORDER BY ownership_nature
+                """,
+                (840_400,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 2
+        natures = {r["ownership_nature"]: r["shares"] for r in rows}
+        assert natures == {"beneficial": Decimal("3300000"), "voting": Decimal("3000000")}
+
     def test_dual_nature_for_same_holder(
         self,
         _setup: psycopg.Connection[tuple],
     ) -> None:
-        """Codex review for #840.D: a DEF 14A holder reporting BOTH
-        beneficial and voting splits must retain BOTH rows in
-        _current. Earlier shape collapsed on holder_name_key."""
+        """Earlier dual-nature test using DIFFERENT accessions per
+        nature. Kept for coverage of the cross-proxy case."""
         conn = _setup
         run_id = uuid4()
         for nature, accession, shares in [


### PR DESCRIPTION
## What

Follow-up to #854 (#840.D) — fix bot-caught review finding post-merge.

## Bug

DEF 14A ``_current`` PK was updated to include ``ownership_nature`` so dual-nature rows (beneficial + voting on same proxy) coexist. The OBSERVATIONS PK was NOT mirrored. ``record_def14a_observation``'s ON CONFLICT DO UPDATE silently overwrites the first nature with the second whenever both rows share the same accession — which a real single-proxy filing always does. The earlier dual-nature test passed only because it used distinct ``source_document_id`` values per nature, masking the production-path gap.

## Fix

- Migration 117: drop + recreate the parent table PK with ``ownership_nature`` included. Table is empty in production today so this is a clean DDL change.
- record helper ON CONFLICT clause uses the new PK.
- New test ``test_dual_nature_for_same_holder_same_accession`` uses the same accession for both natures (mirrors real proxies) and asserts both observations + both _current rows survive.

## Test plan

- [x] 25 tests passing.
- [x] ``ruff check``, ``ruff format`` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)