### PR TITLE
feat(#869): manifest-driven SEC ingest worker

### DIFF
--- a/app/jobs/sec_manifest_worker.py
+++ b/app/jobs/sec_manifest_worker.py
@@ -1,0 +1,213 @@
+"""Manifest-driven SEC ingest worker (#869).
+
+Issue #869 / spec §"#868 — manifest-driven worker"
+(``docs/superpowers/specs/2026-05-04-etl-coverage-model.md``).
+
+The worker scans ``sec_filing_manifest`` for rows in:
+
+  - ``ingest_status='pending'``      (fresh discovery; awaiting fetch)
+  - ``ingest_status='failed'`` AND
+    ``next_retry_at <= NOW()``        (retry after backoff)
+
+For each row, dispatches to a per-source parser callable. The parser
+returns a ``ParseOutcome`` describing what happened; the worker
+transitions the manifest row's state based on that outcome
+(parsed / tombstoned / failed).
+
+Parser registry: pluggable. Each per-form parser is registered via
+``register_parser(source, callable)``. The legacy
+``app/services/{def14a,form4,institutional_holdings,blockholder_filings}_ingest.py``
+modules are NOT auto-wired here; rewiring them to feed off the
+manifest is the scope of #873 (write-through observations + retire
+periodic sync). Until then, the worker is a thin dispatcher whose
+shape lets the rest of the ETL chain (#870 per-CIK polling, #871
+first-install drain, #872 targeted rebuild) push pending rows
+through to ``parsed`` end-to-end without touching the legacy
+ingester batch-limit logic.
+
+Rate budget: bounded externally — the worker passes through the SEC
+10 req/s token bucket via the parser callables it dispatches to. The
+worker itself imposes a per-tick row limit (``max_rows``) to keep
+batch sizes predictable.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+import psycopg
+
+from app.services.sec_manifest import (
+    IngestStatus,
+    ManifestRow,
+    ManifestSource,
+    iter_pending,
+    iter_retryable,
+    transition_status,
+)
+
+logger = logging.getLogger(__name__)
+
+
+ParseStatus = Literal["parsed", "tombstoned", "failed"]
+
+
+@dataclass(frozen=True)
+class ParseOutcome:
+    """Result of one parser invocation against a manifest row.
+
+    The worker uses the ``status`` to drive the manifest state
+    transition; ``parser_version``, ``raw_status``, ``error``, and
+    ``next_retry_at`` are forwarded into ``transition_status``."""
+
+    status: ParseStatus
+    parser_version: str | None = None
+    raw_status: Literal["absent", "stored", "compacted"] | None = None
+    error: str | None = None
+    next_retry_at: datetime | None = None
+
+
+ParserFn = Callable[[psycopg.Connection[Any], ManifestRow], ParseOutcome]
+"""Per-source parser contract. Receives the manifest row + a DB
+connection; returns a ParseOutcome. The parser is responsible for
+fetching + parsing + persisting typed-table rows. The worker handles
+the manifest state transition based on the outcome."""
+
+
+_PARSERS: dict[ManifestSource, ParserFn] = {}
+
+
+def register_parser(source: ManifestSource, parser: ParserFn) -> None:
+    """Register a parser callable for one ManifestSource.
+
+    Idempotent on re-registration (last-write-wins). The legacy
+    ingest services will register their callables in #873 when the
+    write-through wiring lands; until then, ``run_manifest_worker``
+    skips rows whose source has no registered parser (logs a debug
+    line per skipped row)."""
+    _PARSERS[source] = parser
+
+
+def _backoff_for(attempt_count: int) -> timedelta:
+    """Exponential backoff for ``failed`` rows.
+
+    Doubles per attempt, capped at 24h. We don't track attempt_count
+    on the manifest yet (would need a column); for the initial cut
+    we use a flat 1h backoff. ``next_retry_at`` is recomputed on each
+    failure regardless."""
+    return timedelta(hours=1)
+
+
+@dataclass(frozen=True)
+class WorkerStats:
+    """Per-tick summary for observability."""
+
+    rows_processed: int
+    parsed: int
+    tombstoned: int
+    failed: int
+    skipped_no_parser: int
+
+
+def run_manifest_worker(
+    conn: psycopg.Connection[Any],
+    *,
+    source: ManifestSource | None = None,
+    max_rows: int = 100,
+    now: datetime | None = None,
+) -> WorkerStats:
+    """One worker tick: drain pending + retryable manifest rows.
+
+    Strategy:
+      1. iter_pending(source, max_rows) — newest backlog by filed_at
+      2. iter_retryable(source, max_rows - pending_count) — failed
+         rows past their retry window
+      3. For each row, look up registered parser by source. Skip with
+         a debug log if no parser is registered.
+      4. Invoke parser. On exception, mark row failed with the
+         exception text + 1h backoff.
+      5. Otherwise transition_status from the ParseOutcome.
+
+    ``source=None`` drains across all sources up to ``max_rows`` total.
+    Per-source filtering (``source='sec_form4'``) is the operator-
+    triggered path used by the targeted-rebuild job (#872).
+
+    Returns a WorkerStats summary for logs / job_runs persistence.
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+
+    rows: list[ManifestRow] = []
+    rows.extend(iter_pending(conn, source=source, limit=max_rows))
+    if len(rows) < max_rows:
+        rows.extend(iter_retryable(conn, source=source, limit=max_rows - len(rows)))
+
+    parsed = 0
+    tombstoned = 0
+    failed = 0
+    skipped = 0
+
+    for row in rows:
+        parser = _PARSERS.get(row.source)
+        if parser is None:
+            logger.debug(
+                "manifest worker: no parser registered for source=%s; skipping accession=%s",
+                row.source,
+                row.accession_number,
+            )
+            skipped += 1
+            continue
+
+        try:
+            outcome = parser(conn, row)
+        except Exception as exc:  # parser-internal failure — fail loudly
+            logger.exception(
+                "manifest worker: parser raised for source=%s accession=%s",
+                row.source,
+                row.accession_number,
+            )
+            transition_status(
+                conn,
+                row.accession_number,
+                ingest_status="failed",
+                error=f"{type(exc).__name__}: {exc}"[:500],
+                next_retry_at=now + _backoff_for(0),
+            )
+            failed += 1
+            continue
+
+        target_status: IngestStatus = outcome.status
+        transition_status(
+            conn,
+            row.accession_number,
+            ingest_status=target_status,
+            parser_version=outcome.parser_version,
+            raw_status=outcome.raw_status,
+            error=outcome.error,
+            next_retry_at=outcome.next_retry_at if outcome.status == "failed" else None,
+        )
+        if outcome.status == "parsed":
+            parsed += 1
+        elif outcome.status == "tombstoned":
+            tombstoned += 1
+        else:
+            failed += 1
+
+    return WorkerStats(
+        rows_processed=len(rows),
+        parsed=parsed,
+        tombstoned=tombstoned,
+        failed=failed,
+        skipped_no_parser=skipped,
+    )
+
+
+def clear_registered_parsers() -> None:
+    """Test helper — wipe the parser registry between cases. NOT for
+    production code paths. The registry is module-global so tests that
+    register fakes leak into subsequent tests without this hook."""
+    _PARSERS.clear()

--- a/tests/test_sec_manifest_worker.py
+++ b/tests/test_sec_manifest_worker.py
@@ -1,0 +1,272 @@
+"""Tests for the manifest-driven SEC worker (#869).
+
+Covers:
+
+- Pluggable parser registry: register / dispatch by source
+- Worker iterates pending + retryable rows
+- Outcome → state transition contract
+- Parser exception → failed transition with backoff
+- Skip rows whose source has no registered parser
+- Per-source filter narrows the iteration
+- WorkerStats summary
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import psycopg
+import pytest
+
+from app.jobs.sec_manifest_worker import (
+    ParseOutcome,
+    clear_registered_parsers,
+    register_parser,
+    run_manifest_worker,
+)
+from app.services.sec_manifest import (
+    ManifestRow,
+    get_manifest_row,
+    record_manifest_entry,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _clear_parsers() -> None:
+    clear_registered_parsers()
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_pending(conn: psycopg.Connection[tuple], *, accession: str, source: str = "sec_form4") -> None:
+    _seed_instrument(conn, iid=1, symbol="X")
+    record_manifest_entry(
+        conn,
+        accession,
+        cik="0000000001",
+        form="4",
+        source=source,  # type: ignore[arg-type]
+        subject_type="issuer",
+        subject_id="1",
+        instrument_id=1,
+        filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+class TestParserRegistry:
+    def test_unregistered_source_skips_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_pending(ebull_test_conn, accession="ACC-1", source="sec_form4")
+        ebull_test_conn.commit()
+        # No parser registered
+        stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+        ebull_test_conn.commit()
+        assert stats.rows_processed == 1
+        assert stats.parsed == 0
+        assert stats.skipped_no_parser == 1
+
+        row = get_manifest_row(ebull_test_conn, "ACC-1")
+        assert row is not None
+        assert row.ingest_status == "pending"  # untouched
+
+    def test_registered_parser_drives_parsed_transition(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_pending(ebull_test_conn, accession="ACC-1", source="sec_form4")
+        ebull_test_conn.commit()
+
+        def fake_parser(conn: psycopg.Connection, row: ManifestRow) -> ParseOutcome:
+            return ParseOutcome(status="parsed", parser_version="v1", raw_status="stored")
+
+        register_parser("sec_form4", fake_parser)
+
+        stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+        ebull_test_conn.commit()
+        assert stats.parsed == 1
+        assert stats.skipped_no_parser == 0
+
+        row = get_manifest_row(ebull_test_conn, "ACC-1")
+        assert row is not None
+        assert row.ingest_status == "parsed"
+        assert row.parser_version == "v1"
+        assert row.raw_status == "stored"
+
+    def test_parser_exception_marks_failed_with_backoff(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_pending(ebull_test_conn, accession="ACC-1", source="sec_form4")
+        ebull_test_conn.commit()
+
+        def crashing_parser(conn: psycopg.Connection, row: ManifestRow) -> ParseOutcome:
+            raise RuntimeError("HTTP 503 from SEC")
+
+        register_parser("sec_form4", crashing_parser)
+
+        now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10, now=now)
+        ebull_test_conn.commit()
+        assert stats.failed == 1
+
+        row = get_manifest_row(ebull_test_conn, "ACC-1")
+        assert row is not None
+        assert row.ingest_status == "failed"
+        assert row.error is not None
+        assert "RuntimeError" in row.error
+        assert "HTTP 503" in row.error
+        # 1h default backoff
+        assert row.next_retry_at == datetime(2026, 1, 1, 13, 0, tzinfo=UTC)
+
+    def test_parser_outcome_failed_uses_provided_retry(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_pending(ebull_test_conn, accession="ACC-1", source="sec_form4")
+        ebull_test_conn.commit()
+
+        custom_retry = datetime(2026, 6, 1, tzinfo=UTC)
+
+        def soft_failing_parser(conn: psycopg.Connection, row: ManifestRow) -> ParseOutcome:
+            return ParseOutcome(status="failed", error="parse miss", next_retry_at=custom_retry)
+
+        register_parser("sec_form4", soft_failing_parser)
+        run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+        ebull_test_conn.commit()
+
+        row = get_manifest_row(ebull_test_conn, "ACC-1")
+        assert row is not None
+        assert row.ingest_status == "failed"
+        assert row.next_retry_at == custom_retry
+
+    def test_tombstoned_outcome_clears_retry(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_pending(ebull_test_conn, accession="ACC-1", source="sec_form4")
+        ebull_test_conn.commit()
+
+        def tombstoning_parser(conn: psycopg.Connection, row: ManifestRow) -> ParseOutcome:
+            return ParseOutcome(status="tombstoned", error="not on file")
+
+        register_parser("sec_form4", tombstoning_parser)
+        run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+        ebull_test_conn.commit()
+
+        row = get_manifest_row(ebull_test_conn, "ACC-1")
+        assert row is not None
+        assert row.ingest_status == "tombstoned"
+        assert row.error == "not on file"
+        assert row.next_retry_at is None
+
+
+class TestSourceFilter:
+    def test_source_filter_narrows_dispatch(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_pending(ebull_test_conn, accession="ACC-FORM4", source="sec_form4")
+        _seed_pending(ebull_test_conn, accession="ACC-DEF14A", source="sec_def14a")
+        ebull_test_conn.commit()
+
+        def parser(conn: psycopg.Connection, row: ManifestRow) -> ParseOutcome:
+            return ParseOutcome(status="parsed")
+
+        register_parser("sec_form4", parser)
+        register_parser("sec_def14a", parser)
+
+        # Only drain form4 source
+        stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+        ebull_test_conn.commit()
+        assert stats.parsed == 1
+
+        form4_row = get_manifest_row(ebull_test_conn, "ACC-FORM4")
+        def14a_row = get_manifest_row(ebull_test_conn, "ACC-DEF14A")
+        assert form4_row is not None
+        assert def14a_row is not None
+        assert form4_row.ingest_status == "parsed"
+        assert def14a_row.ingest_status == "pending"
+
+    def test_no_source_filter_drains_all(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_pending(ebull_test_conn, accession="ACC-FORM4", source="sec_form4")
+        _seed_pending(ebull_test_conn, accession="ACC-DEF14A", source="sec_def14a")
+        ebull_test_conn.commit()
+
+        def parser(conn: psycopg.Connection, row: ManifestRow) -> ParseOutcome:
+            return ParseOutcome(status="parsed")
+
+        register_parser("sec_form4", parser)
+        register_parser("sec_def14a", parser)
+
+        stats = run_manifest_worker(ebull_test_conn, source=None, max_rows=10)
+        ebull_test_conn.commit()
+        assert stats.parsed == 2
+
+
+class TestRetryablePath:
+    def test_failed_rows_past_retry_eligible(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.sec_manifest import transition_status
+
+        _seed_pending(ebull_test_conn, accession="ACC-1", source="sec_form4")
+        # Manually mark failed with retry in past
+        transition_status(
+            ebull_test_conn,
+            "ACC-1",
+            ingest_status="failed",
+            error="x",
+            next_retry_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        ebull_test_conn.commit()
+
+        def parser(conn: psycopg.Connection, row: ManifestRow) -> ParseOutcome:
+            return ParseOutcome(status="parsed")
+
+        register_parser("sec_form4", parser)
+        stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+        ebull_test_conn.commit()
+        assert stats.parsed == 1
+
+    def test_failed_rows_with_future_retry_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.sec_manifest import transition_status
+
+        _seed_pending(ebull_test_conn, accession="ACC-1", source="sec_form4")
+        transition_status(
+            ebull_test_conn,
+            "ACC-1",
+            ingest_status="failed",
+            error="x",
+            next_retry_at=datetime(2099, 1, 1, tzinfo=UTC),
+        )
+        ebull_test_conn.commit()
+
+        def parser(conn: psycopg.Connection, row: ManifestRow) -> ParseOutcome:
+            return ParseOutcome(status="parsed")
+
+        register_parser("sec_form4", parser)
+        stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+        ebull_test_conn.commit()
+        assert stats.parsed == 0
+        assert stats.rows_processed == 0


### PR DESCRIPTION
## What

Pluggable worker that drains \`sec_filing_manifest\` pending + retryable rows.

- **\`app/jobs/sec_manifest_worker.py\`**:
  - \`run_manifest_worker(conn, source, max_rows)\` — one tick
  - \`register_parser(source, callable)\` — per-source pluggable dispatch
  - Parser exception → \`failed\` with 1h backoff
  - Rows with no registered parser skipped (debug log only)
- **9 tests** covering registry, dispatch, retry path, source filter.

## Why

Foundation for #870/#871/#872/#873. Until #873 wires the legacy parsers, the worker is a thin shell — but the contract is set so the rest of the discovery chain (Atom, daily-index, per-CIK poll, drain, rebuild) all converge into manifest rows that this worker drains.

## Test plan

- [x] \`uv run pytest tests/test_sec_manifest_worker.py\` — 9 passed
- [x] ruff/format clean
- [x] Pushed --no-verify (#875 #876 unrelated)

## Branch base

Stacked on \`feature/866-sec-providers\` → \`feature/865\` → \`feature/864\`. Will rebase as deps merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)