### PR TITLE
feat(#888): inline write-through for Form 3 + Form 4 insider ingest

### DIFF
--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -364,9 +364,15 @@ def _record_form3_observations_for_filing(
             continue
         if holding.shares is None:
             continue
+        # Defensive: bot review flagged a None-comparison crash risk
+        # on row_num. Schema declares row_num NOT NULL but parser
+        # paths can in principle emit a None on malformed XML — guard
+        # explicitly rather than relying on the schema.
+        if holding.row_num is None:
+            continue
         key = (holding.filer_cik, holding.direct_indirect)
         prior = latest.get(key)
-        if prior is None or holding.row_num > prior.row_num:
+        if prior is None or (prior.row_num is not None and holding.row_num > prior.row_num):
             latest[key] = holding
 
     if not latest:

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -358,14 +358,13 @@ def _record_form3_observations_for_filing(
     if as_of is None:
         return
 
-    LatestKey = tuple[str | None, str | None]
-    latest: dict[LatestKey, ParsedHolding] = {}
+    latest: dict[tuple[str | None, str | None], ParsedHolding] = {}
     for holding in parsed.holdings:
         if holding.is_derivative:
             continue
         if holding.shares is None:
             continue
-        key: LatestKey = (holding.filer_cik, holding.direct_indirect)
+        key = (holding.filer_cik, holding.direct_indirect)
         prior = latest.get(key)
         if prior is None or holding.row_num > prior.row_num:
             latest[key] = holding

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -34,9 +34,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any, Protocol
+from uuid import uuid4
 
 import psycopg
 
@@ -46,6 +47,10 @@ from app.services.insider_transactions import (
     ParsedForm3,
     _canonical_form_4_url,
     parse_form_3_xml,
+)
+from app.services.ownership_observations import (
+    record_insider_observation,
+    refresh_insiders_current,
 )
 
 logger = logging.getLogger(__name__)
@@ -307,6 +312,82 @@ def upsert_form_3_filing(
                     holding.underlying_value,
                 ),
             )
+
+    # Write-through observations + refresh _current (#888 / spec §"Eliminate
+    # periodic re-scan jobs"). Mirrors the Form 4 path —
+    # one observation per (filer_cik, direct_indirect), shares = the
+    # holding's reported share count, period_end = period_of_report.
+    _record_form3_observations_for_filing(
+        conn,
+        instrument_id=instrument_id,
+        accession_number=accession_number,
+        primary_document_url=primary_document_url,
+        parsed=parsed,
+    )
+    refresh_insiders_current(conn, instrument_id=instrument_id)
+
+
+def _record_form3_observations_for_filing(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    accession_number: str,
+    primary_document_url: str,
+    parsed: ParsedForm3,
+) -> None:
+    """Derive one ``ownership_insiders_observations`` row per
+    ``(filer_cik, direct_indirect)`` from the parsed Form 3 holdings.
+
+    Mirrors the legacy batch-sync rule in
+    ``ownership_observations_sync.sync_insiders``:
+
+      - Filter: ``shares IS NOT NULL`` AND ``is_derivative = FALSE``.
+      - Group key: ``(filer_cik, direct_indirect)``. Sum shares per
+        group when joint filers list the same security under the same
+        nature (rare; the legacy batch path also folds these).
+      - ``ownership_nature``: ``'indirect'`` when direct_indirect='I',
+        else ``'direct'``.
+    """
+    as_of: date | None = parsed.period_of_report or parsed.signature_date
+    if as_of is None:
+        return
+
+    LatestKey = tuple[str | None, str | None]
+    grouped_shares: dict[LatestKey, Decimal] = {}
+    for holding in parsed.holdings:
+        if holding.is_derivative:
+            continue
+        if holding.shares is None:
+            continue
+        key: LatestKey = (holding.filer_cik, holding.direct_indirect)
+        grouped_shares[key] = grouped_shares.get(key, Decimal(0)) + Decimal(holding.shares)
+
+    if not grouped_shares:
+        return
+
+    run_id = uuid4()
+    for (filer_cik, direct_indirect), shares in grouped_shares.items():
+        holder_name = _filer_name_for(parsed, filer_cik)
+        if not holder_name and not filer_cik:
+            continue
+        nature = "indirect" if direct_indirect == "I" else "direct"
+        record_insider_observation(
+            conn,
+            instrument_id=instrument_id,
+            holder_cik=filer_cik,
+            holder_name=holder_name or (filer_cik or "UNKNOWN"),
+            ownership_nature=nature,  # type: ignore[arg-type]
+            source="form3",
+            source_document_id=accession_number,
+            source_accession=accession_number,
+            source_field=None,
+            source_url=primary_document_url or None,
+            filed_at=datetime.combine(as_of, datetime.min.time(), tzinfo=UTC),
+            period_start=None,
+            period_end=as_of,
+            ingest_run_id=run_id,
+            shares=shares,
+        )
 
 
 def _filer_name_for(parsed: ParsedForm3, filer_cik: str | None) -> str:

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -45,6 +45,7 @@ from app.providers.concurrent_fetch import fetch_document_texts
 from app.services import raw_filings
 from app.services.insider_transactions import (
     ParsedForm3,
+    ParsedHolding,
     _canonical_form_4_url,
     parse_form_3_xml,
 )
@@ -342,9 +343,14 @@ def _record_form3_observations_for_filing(
     ``ownership_observations_sync.sync_insiders``:
 
       - Filter: ``shares IS NOT NULL`` AND ``is_derivative = FALSE``.
-      - Group key: ``(filer_cik, direct_indirect)``. Sum shares per
-        group when joint filers list the same security under the same
-        nature (rare; the legacy batch path also folds these).
+      - Group key: ``(filer_cik, direct_indirect)``. Last row per group
+        wins by ``row_num`` ordering — matches the legacy batch sync
+        in ownership_observations_sync.sync_insiders, where iterating
+        every insider_initial_holdings row sequentially with the same
+        observation natural key produced a "last write wins" effect.
+        Codex review: summing instead would change observed-shares
+        semantics for filings with multi-class common stock listed
+        under one filer/nature.
       - ``ownership_nature``: ``'indirect'`` when direct_indirect='I',
         else ``'direct'``.
     """
@@ -353,20 +359,25 @@ def _record_form3_observations_for_filing(
         return
 
     LatestKey = tuple[str | None, str | None]
-    grouped_shares: dict[LatestKey, Decimal] = {}
+    latest: dict[LatestKey, ParsedHolding] = {}
     for holding in parsed.holdings:
         if holding.is_derivative:
             continue
         if holding.shares is None:
             continue
         key: LatestKey = (holding.filer_cik, holding.direct_indirect)
-        grouped_shares[key] = grouped_shares.get(key, Decimal(0)) + Decimal(holding.shares)
+        prior = latest.get(key)
+        if prior is None or holding.row_num > prior.row_num:
+            latest[key] = holding
 
-    if not grouped_shares:
+    if not latest:
         return
 
     run_id = uuid4()
-    for (filer_cik, direct_indirect), shares in grouped_shares.items():
+    for (filer_cik, direct_indirect), holding in latest.items():
+        shares = holding.shares
+        if shares is None:
+            continue
         holder_name = _filer_name_for(parsed, filer_cik)
         if not holder_name and not filer_cik:
             continue

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -1,4 +1,4 @@
-"""Form 4 insider-transactions parser + ingester (#429).
+"""Form 4 insider-transactions parser + ingester (#429, #888).
 
 SEC Form 4 is filed by directors, officers, and ≥10% holders within
 two business days of any trade in their company's stock. Free,
@@ -41,15 +41,20 @@ import logging
 import re
 import xml.etree.ElementTree as ET  # noqa: S405 — Form 4 source is SEC EDGAR, trusted.
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any, Protocol
+from uuid import uuid4
 
 import psycopg
 from psycopg.types.json import Jsonb
 
 from app.providers.concurrent_fetch import fetch_document_texts
 from app.services import raw_filings
+from app.services.ownership_observations import (
+    record_insider_observation,
+    refresh_insiders_current,
+)
 
 _PARSER_VERSION_FORM4 = "form4-v1"
 
@@ -1128,6 +1133,98 @@ def upsert_filing(
                     footnote_refs_json,
                 ),
             )
+
+    # Write-through observations + refresh _current (#888 / spec §"Eliminate
+    # periodic re-scan jobs"). Replaces the legacy nightly
+    # ownership_observations_sync read-from-typed-tables path with an
+    # inline call so the operator-visible rollup reflects the new filing
+    # without waiting for the next sync cycle.
+    _record_form4_observations_for_filing(
+        conn,
+        instrument_id=instrument_id,
+        accession_number=accession_number,
+        primary_document_url=primary_document_url,
+        parsed=parsed,
+    )
+    refresh_insiders_current(conn, instrument_id=instrument_id)
+
+
+def _record_form4_observations_for_filing(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    accession_number: str,
+    primary_document_url: str,
+    parsed: ParsedFiling,
+) -> None:
+    """Derive one ``ownership_insiders_observations`` row per
+    ``(filer_cik, direct_indirect)`` from the parsed transactions and
+    record it.
+
+    Mirrors the existing batch-sync rule in
+    ``ownership_observations_sync.sync_insiders``:
+
+      - Filter: ``post_transaction_shares IS NOT NULL`` AND
+        ``is_derivative = FALSE`` (derivative-side rows aren't a
+        share-balance signal).
+      - Group key: ``(filer_cik, direct_indirect)``. Latest txn per
+        group wins (``txn_date DESC, txn_row_num DESC``).
+      - ``ownership_nature``: ``'indirect'`` when direct_indirect='I',
+        else ``'direct'``.
+
+    The two-axis identity is preserved at the observations table — a
+    filer's direct + indirect splits produce SEPARATE observation
+    rows.
+    """
+    # Build the latest-per-group map
+    LatestKey = tuple[str | None, str | None]  # (filer_cik, direct_indirect)
+    latest: dict[LatestKey, ParsedTransaction] = {}
+    for txn in parsed.transactions:
+        if txn.is_derivative:
+            continue
+        if txn.post_transaction_shares is None:
+            continue
+        if txn.txn_date is None:
+            continue
+        key: LatestKey = (txn.filer_cik, txn.direct_indirect)
+        prior = latest.get(key)
+        if prior is None:
+            latest[key] = txn
+            continue
+        # Pick later txn_date; tie-break on txn_row_num
+        if (txn.txn_date, txn.txn_row_num) > ((prior.txn_date or date.min), prior.txn_row_num):
+            latest[key] = txn
+
+    if not latest:
+        return
+
+    run_id = uuid4()
+    for (filer_cik, direct_indirect), txn in latest.items():
+        if txn.txn_date is None or txn.post_transaction_shares is None:
+            # Belt-and-braces — the filter above already excludes these.
+            continue
+        holder_name = _primary_filer_name(parsed, filer_cik)
+        if not holder_name and not filer_cik:
+            # Skip rows with no identity at all.
+            continue
+        nature = "indirect" if direct_indirect == "I" else "direct"
+        record_insider_observation(
+            conn,
+            instrument_id=instrument_id,
+            holder_cik=filer_cik,
+            holder_name=holder_name or (filer_cik or "UNKNOWN"),
+            ownership_nature=nature,  # type: ignore[arg-type]
+            source="form4",
+            source_document_id=accession_number,
+            source_accession=accession_number,
+            source_field=None,
+            source_url=primary_document_url or None,
+            filed_at=datetime.combine(txn.txn_date, datetime.min.time(), tzinfo=UTC),
+            period_start=None,
+            period_end=txn.txn_date,
+            ingest_run_id=run_id,
+            shares=Decimal(txn.post_transaction_shares),
+        )
 
 
 def filer_role_string(filer: ParsedFiler) -> str | None:

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -1176,9 +1176,8 @@ def _record_form4_observations_for_filing(
     filer's direct + indirect splits produce SEPARATE observation
     rows.
     """
-    # Build the latest-per-group map
-    LatestKey = tuple[str | None, str | None]  # (filer_cik, direct_indirect)
-    latest: dict[LatestKey, ParsedTransaction] = {}
+    # Build the latest-per-group map. Key: (filer_cik, direct_indirect).
+    latest: dict[tuple[str | None, str | None], ParsedTransaction] = {}
     for txn in parsed.transactions:
         if txn.is_derivative:
             continue
@@ -1186,7 +1185,7 @@ def _record_form4_observations_for_filing(
             continue
         if txn.txn_date is None:
             continue
-        key: LatestKey = (txn.filer_cik, txn.direct_indirect)
+        key = (txn.filer_cik, txn.direct_indirect)
         prior = latest.get(key)
         if prior is None:
             latest[key] = txn


### PR DESCRIPTION
## What

Sub-task 873.A. Adds inline observation+refresh calls at end of `upsert_filing` (Form 4) and `upsert_form_3_filing` (Form 3). Replaces nightly `ownership_observations_sync` for the insider category — rollup endpoint sees new Form 3/4 data immediately on parse, not after the cron cycle.

- `_record_form4_observations_for_filing` — group by (filer_cik, direct_indirect); latest txn per group by (txn_date, txn_row_num); filter post_transaction_shares NOT NULL + is_derivative=FALSE.
- `_record_form3_observations_for_filing` — same shape against parsed.holdings; last-row-per-group by row_num (Codex review fix: matches legacy UPSERT-collapse semantics, not sum).

## Why

#873 spec §"Eliminate periodic re-scan jobs". One of 5 sub-tasks (#888-#892).

## Test plan

- [x] ruff/format clean
- [ ] Local integration tests skipped this push due to test-infra hang (#893). CI will run full suite.
- [x] Codex review applied (Form 3 last-write-wins fix)
- [ ] After CI green + bot APPROVE: operator smoke against AAPL/GME insider rollup endpoint pre-merge

## Setting (#893 follow-up)

Test infra hang during this development was painful. Filed #893 for fixing pytest contention/migration-replay overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)