### PR TITLE
feat(#891): inline write-through for treasury XBRL + DEF 14A

### DIFF
--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -463,7 +463,6 @@ def _ingest_single_accession(
             instrument_id=ref.instrument_id,
             accession_number=ref.accession_number,
             as_of_date=parsed.as_of_date,
-            filing_date=ref.filing_date,
             holders=parsed.rows,
         )
         refresh_def14a_current(conn, instrument_id=ref.instrument_id)
@@ -483,7 +482,6 @@ def _record_def14a_observations_for_filing(
     instrument_id: int,
     accession_number: str,
     as_of_date: date | None,
-    filing_date: date,
     holders: tuple[Def14ABeneficialHolder, ...],
 ) -> None:
     """Record one ``ownership_def14a_observations`` row per holder
@@ -497,21 +495,28 @@ def _record_def14a_observations_for_filing(
       - ``ownership_nature``: pinned to ``'beneficial'`` (DEF 14A's
         canonical table reports beneficial ownership per Rule 13d-3).
       - ``period_end``: ``as_of_date`` when present, else falls back
-        to ``filing_date`` (matches the legacy
-        ``as_of_date OR fetched_at.date()`` shape).
-      - ``filed_at``: ``filing_date`` anchored to UTC midnight; the
-        legacy batch path used ``fetched_at`` (when we wrote the
-        typed row), but the inline path doesn't have that yet — use
-        ``filing_date`` as the closest equivalent. The next steady-
-        state poll won't change this; the rollup endpoint's
-        period_end key advances the same way.
+        to ``fetched_at.date()`` — matches the legacy
+        ``sync_def14a`` rule (``as_of_date OR fetched_at.date()``).
+        Codex pre-push review flagged this divergence — period_end
+        is part of the DEF 14A observation conflict key, so any
+        difference between legacy + inline produces a different
+        observation identity.
+      - ``filed_at``: ``fetched_at`` from the row we just wrote (the
+        column default is ``NOW()`` so this is current-transaction
+        wall clock). Same value the legacy batch would have read.
       - Identity: ``holder_name`` (normalised by the observations
         layer via ``holder_name_key`` GENERATED column). DEF 14A
         rows don't carry holder CIK; CIK match happens at rollup-read
         time.
     """
-    period_end: date = as_of_date or filing_date
-    filed_at = datetime.combine(filing_date, datetime.min.time(), tzinfo=UTC)
+    fetched_at = datetime.now(tz=UTC)
+    # Match legacy sync_def14a:
+    #   filed_at = row.fetched_at OR (as_of midnight UTC fallback)
+    #   period_end = as_of_date OR row.fetched_at.date()
+    # Inline path: ``fetched_at`` is current wall-clock (the typed
+    # row we just wrote has the same value via column default).
+    period_end: date = as_of_date or fetched_at.date()
+    filed_at = fetched_at
     run_id = uuid4()
     for holder in holders:
         if holder.shares is None:

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -33,8 +33,10 @@ import logging
 import xml.etree.ElementTree as ET  # noqa: S405 — only used to catch ET.ParseError; no untrusted input parsed here.
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import date
+from datetime import UTC, date, datetime
+from decimal import Decimal
 from typing import Any, Protocol
+from uuid import uuid4
 
 import psycopg
 import psycopg.rows
@@ -46,6 +48,10 @@ from app.providers.implementations.sec_def14a import (
 )
 from app.services import raw_filings
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
+from app.services.ownership_observations import (
+    record_def14a_observation,
+    refresh_def14a_current,
+)
 
 _PARSER_VERSION_DEF14A = "def14a-v1"
 
@@ -445,6 +451,23 @@ def _ingest_single_accession(
         else:
             updated += 1
 
+    # Write-through observations + refresh _current (#891 / spec
+    # §"Eliminate periodic re-scan jobs"). Replaces nightly
+    # ownership_observations_sync.sync_def14a read-from-typed-tables
+    # path. record_def14a_observation is itself UPSERT so re-ingest
+    # of the same accession (parser bump) refreshes existing rows
+    # in place.
+    if parsed.rows:
+        _record_def14a_observations_for_filing(
+            conn,
+            instrument_id=ref.instrument_id,
+            accession_number=ref.accession_number,
+            as_of_date=parsed.as_of_date,
+            filing_date=ref.filing_date,
+            holders=parsed.rows,
+        )
+        refresh_def14a_current(conn, instrument_id=ref.instrument_id)
+
     return _AccessionOutcome(
         status="success",
         rows_inserted=inserted,
@@ -452,6 +475,67 @@ def _ingest_single_accession(
         error=None,
         issuer_cik=issuer_cik,
     )
+
+
+def _record_def14a_observations_for_filing(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    accession_number: str,
+    as_of_date: date | None,
+    filing_date: date,
+    holders: tuple[Def14ABeneficialHolder, ...],
+) -> None:
+    """Record one ``ownership_def14a_observations`` row per holder
+    on this DEF 14A accession.
+
+    Mirrors the legacy batch-sync rule in
+    ``ownership_observations_sync.sync_def14a``:
+
+      - Filter: ``shares IS NOT NULL`` (the typed table requires it
+        and the legacy batch query enforces).
+      - ``ownership_nature``: pinned to ``'beneficial'`` (DEF 14A's
+        canonical table reports beneficial ownership per Rule 13d-3).
+      - ``period_end``: ``as_of_date`` when present, else falls back
+        to ``filing_date`` (matches the legacy
+        ``as_of_date OR fetched_at.date()`` shape).
+      - ``filed_at``: ``filing_date`` anchored to UTC midnight; the
+        legacy batch path used ``fetched_at`` (when we wrote the
+        typed row), but the inline path doesn't have that yet — use
+        ``filing_date`` as the closest equivalent. The next steady-
+        state poll won't change this; the rollup endpoint's
+        period_end key advances the same way.
+      - Identity: ``holder_name`` (normalised by the observations
+        layer via ``holder_name_key`` GENERATED column). DEF 14A
+        rows don't carry holder CIK; CIK match happens at rollup-read
+        time.
+    """
+    period_end: date = as_of_date or filing_date
+    filed_at = datetime.combine(filing_date, datetime.min.time(), tzinfo=UTC)
+    run_id = uuid4()
+    for holder in holders:
+        if holder.shares is None:
+            continue
+        if not holder.holder_name or not holder.holder_name.strip():
+            continue
+        record_def14a_observation(
+            conn,
+            instrument_id=instrument_id,
+            holder_name=holder.holder_name,
+            holder_role=holder.holder_role,
+            ownership_nature="beneficial",
+            source="def14a",
+            source_document_id=accession_number,
+            source_accession=accession_number,
+            source_field=None,
+            source_url=None,
+            filed_at=filed_at,
+            period_start=None,
+            period_end=period_end,
+            ingest_run_id=run_id,
+            shares=Decimal(holder.shares),
+            percent_of_class=Decimal(holder.percent_of_class) if holder.percent_of_class is not None else None,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -38,6 +38,10 @@ from app.providers.implementations.sec_edgar import (
     parse_master_index,
 )
 from app.providers.implementations.sec_fundamentals import TRACKED_CONCEPTS
+from app.services.ownership_observations import (
+    record_treasury_observation,
+    refresh_treasury_current,
+)
 from app.services.sec_entity_profile import parse_entity_profile, upsert_entity_profile
 from app.services.sec_filing_items import (
     apply_8k_items_to_filing_events,
@@ -1559,6 +1563,75 @@ class NormalizationSummary:
     periods_canonical_upserted: int
 
 
+def _record_treasury_observations_for_instrument(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+) -> None:
+    """Record one ``ownership_treasury_observations`` row per quarterly
+    period_end with non-null treasury_shares for one instrument, then
+    refresh ``ownership_treasury_current`` once.
+
+    Mirrors the legacy batch-sync rule in
+    ``ownership_observations_sync.sync_treasury``:
+
+      - Filter: ``treasury_shares IS NOT NULL`` AND
+        ``period_type IN ('Q1','Q2','Q3','Q4')`` (spec line: only
+        Q1-Q4 periods carry the canonical treasury count; YTD / FY
+        rollups would double-count).
+      - Synthetic ``source_document_id``: ``f'{instrument_id}|{period_end}'``
+        — the canonical financial_periods row doesn't carry an
+        accession_number, and this id is stable across re-runs so
+        re-normalize is idempotent on the observation natural key.
+      - ``filed_at``: ``filed_date`` from financial_periods when known;
+        else period_end-anchored midnight UTC.
+      - ``ownership_nature``: pinned to ``'economic'`` (issuer-held
+        shares — not Rule 13d-3 beneficial).
+    """
+    from uuid import uuid4
+
+    run_id = uuid4()
+    rows_recorded = 0
+    cur = conn.execute(
+        """
+        SELECT period_end_date, treasury_shares, filed_date
+        FROM financial_periods
+        WHERE instrument_id = %(iid)s
+          AND treasury_shares IS NOT NULL
+          AND superseded_at IS NULL
+          AND period_type IN ('Q1','Q2','Q3','Q4')
+        ORDER BY period_end_date ASC
+        """,
+        {"iid": instrument_id},
+    )
+    for row in cur.fetchall():
+        period_end, treasury_shares, filed_date = row[0], row[1], row[2]
+        synthetic_doc_id = f"{instrument_id}|{period_end.isoformat()}"
+        filed_at = (
+            datetime.combine(filed_date, datetime.min.time(), tzinfo=UTC)
+            if filed_date is not None
+            else datetime.combine(period_end, datetime.min.time(), tzinfo=UTC)
+        )
+        record_treasury_observation(
+            conn,
+            instrument_id=instrument_id,
+            source="xbrl_dei",
+            source_document_id=synthetic_doc_id,
+            source_accession=None,
+            source_field="TreasuryStockShares",
+            source_url=None,
+            filed_at=filed_at,
+            period_start=None,
+            period_end=period_end,
+            ingest_run_id=run_id,
+            treasury_shares=Decimal(treasury_shares),
+        )
+        rows_recorded += 1
+
+    if rows_recorded > 0:
+        refresh_treasury_current(conn, instrument_id=instrument_id)
+
+
 def normalize_financial_periods(
     conn: psycopg.Connection[tuple],
     instrument_ids: Sequence[int] | None = None,
@@ -1629,6 +1702,14 @@ def normalize_financial_periods(
                 # Step 4: Canonical merge
                 canonical_count = _canonical_merge_instrument(conn, iid)
                 total_canonical += canonical_count
+
+                # Step 5: Treasury write-through (#891 / spec
+                # §"Eliminate periodic re-scan jobs"). Replaces nightly
+                # ownership_observations_sync.sync_treasury read-from-
+                # canonical-table path. Records one observation per
+                # quarterly period_end with non-null treasury_shares,
+                # then refreshes ownership_treasury_current once.
+                _record_treasury_observations_for_instrument(conn, instrument_id=iid)
 
                 logger.info(
                     "Normalized instrument %d: %d raw periods, %d canonical",


### PR DESCRIPTION
Sub-task 873.D. DEF 14A: per-holder observation + refresh at end of upsert loop. Treasury: per-period observation in normalize_financial_periods step 5. Codex pre-push fix: DEF 14A period_end fallback uses fetched_at not filing_date (legacy parity). Local integration tests skipped (#893); CI to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)