### PR TITLE
fix: pyright list/tuple mismatch in def14a write-through helper

### DIFF
--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -482,7 +482,7 @@ def _record_def14a_observations_for_filing(
     instrument_id: int,
     accession_number: str,
     as_of_date: date | None,
-    holders: tuple[Def14ABeneficialHolder, ...],
+    holders: list[Def14ABeneficialHolder],
 ) -> None:
     """Record one ``ownership_def14a_observations`` row per holder
     on this DEF 14A accession.


### PR DESCRIPTION
Hotfix for main. #897 merged with tuple type annotation but parsed.rows is list. Pyright strict catches invariance. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)