### PR TITLE
feat(#893): pytest perf redesign — xdist + per-worker DB + template

### DIFF
--- a/docs/superpowers/specs/2026-05-05-pytest-perf-redesign.md
+++ b/docs/superpowers/specs/2026-05-05-pytest-perf-redesign.md
@@ -1,0 +1,391 @@
+# Pytest perf redesign — concurrent isolation + xdist + template DB
+
+**Date:** 2026-05-05
+**Issue:** #893 — tech-debt: pytest infra slowness + integration test contention
+**Status:** brainstorm + 2x Codex-reviewed (8 findings folded); awaiting operator sign-off
+
+## Problem
+
+Operator-observed pain on `main` as of 2026-05-05:
+
+- Full pytest suite is the pre-push gate (`.githooks/pre-push:34-35`). Single
+  shared `ebull_test` Postgres database is consumed serially.
+- `tests/fixtures/ebull_test_db.py::ebull_test_conn` truncates **73 tables**
+  (`_PLANNER_TABLES`) before and after every test that opts into the fixture.
+  ~260 fixture invocations across ~130 test files.
+- 121 SQL migrations under `sql/`. Migrations are skipped per-process if
+  already recorded in `schema_migrations` (cheap path), but a fresh DB pays
+  the full 121-file replay cost.
+- Concurrent pytest invocations (developer running multiple shells, or
+  pre-push hook firing while another suite is mid-flight) **block on row
+  and table locks** in the shared DB. Operator has observed 10+ minute
+  hangs from a stuck process holding locks while siblings pile up.
+- No `pytest-xdist` configured. Sequential-only execution.
+- Some tests write directly to `settings.database_url` — i.e. the
+  **operator's dev DB** — bypassing the `ebull_test` fixture entirely.
+  Audit (grep `psycopg.connect(settings.database_url`) finds 6 writer
+  files: `tests/test_jobs_listener.py`,
+  `tests/test_jobs_heartbeat.py`,
+  `tests/test_jobs_queue_recovery.py`,
+  `tests/test_jobs_queue_boot_drain.py`,
+  `tests/test_sync_orchestrator_dispatcher.py`, and one read-only
+  reachability probe in `tests/test_jobs_locks.py` (the test itself
+  is read-only against the DB; the lock writes happen inside
+  `JobLock` which receives a URL parameter). These violate
+  `feedback_test_db_isolation.md` and would deadlock under concurrent
+  pytest invocations.
+
+Operator goal: full suite **≤ 5–10 min wall-clock** while preserving
+coverage. Concurrent pytest must not deadlock.
+
+## Out of scope
+
+- **Truncate-by-need / opt-in fixture API rewrite** — high blast radius
+  across ~130 files. Defer to follow-up after worker isolation lands.
+- **`pg_dump` / `pg_restore` snapshot-restore path** — Postgres native
+  `CREATE DATABASE … TEMPLATE` is faster (page-level copy) and removes
+  the round trip through a dump file.
+- **Pre-push hook scope reduction** — operator decision 2026-05-04 was
+  explicitly to keep full pytest at push time. This spec speeds it up,
+  not removes it.
+- **Pre-existing failures #875 + #876** — handled in their own tickets;
+  this spec must not touch them. Pre-push currently blocks on them and
+  developers bypass with `--no-verify` per pickup notes.
+- **Replacing `_PLANNER_TABLES` truncation order** — list stays as-is.
+_(Migrating dev-DB writers to test fixture is **in scope** — see §6.)_
+
+## Success criteria
+
+1. `time uv run pytest -q` on operator's dev box: full suite finishes in
+   **≤ 10 min** (target: 5–7 min).
+2. Two concurrent `uv run pytest -q` invocations both complete without
+   either deadlocking, hanging > 60 s on each other, or corrupting the
+   other's working DB.
+3. No regressions: every previously green test still green under
+   xdist (modulo #875 + #876 which were already failing).
+4. `pytest --durations=20` always-on so future regressions surface
+   loudly.
+5. `_assert_test_db` invariant remains intact: no test writes to a DB
+   other than its assigned `ebull_test_<run>_<worker>`.
+   **Documented exception:** `tests/smoke/test_app_boots.py` exists
+   specifically to drive FastAPI lifespan against the real dev DB
+   (CLAUDE.md "smoke gate" clause). It stays on `settings.database_url`
+   by design. To satisfy SC#2 (concurrent invocations must not corrupt
+   each other), it is wrapped in a Postgres **session-scoped advisory
+   lock** acquired on the maintenance `postgres` DB
+   (`EBULL_SMOKE_LIFESPAN_LOCK = 0x65427554534D4B`) before
+   `TestClient(app)` enters, released after exit. This lock serialises
+   the smoke test across **all pytest invocations** on the same
+   Postgres cluster — only one process can drive lifespan migrations
+   at a time. The lock acquisition wraps the test body in a
+   `try/finally` so a `TestClient` exit-or-raise still releases the
+   lock connection (Codex v5 implementation note). xdist_group is
+   also applied as a within-invocation pin (defence in depth, makes
+   wait-time deterministic). This is the only allowed exception.
+
+## Design
+
+### 1. Add `pytest-xdist` and configure default parallelism
+
+`pyproject.toml`:
+
+- Add `pytest-xdist>=3.5` to `[dependency-groups].dev`.
+- Add to `[tool.pytest.ini_options]`:
+  - `addopts = "-q --tb=short -n 4 --durations=20 --dist=loadgroup"`
+  - `--dist=loadgroup` is needed so the single `xdist_group("dev_db_smoke")`
+    marker on `tests/smoke/test_app_boots.py` (the documented
+    dev-DB exception, see SC #5) pins it to one worker.
+  - **Worker count is `4`, not `auto`.** Codex finding #7: `-n auto`
+    saturates Postgres on a high-core-count box and is slower than a
+    fixed cap. Empirically tune via the benchmark loop in §8 before
+    raising.
+- **Do not** use shell-style env interpolation in `addopts` (Codex
+  finding #4 — pytest does not expand `${VAR:-default}`). Configure
+  `--basetemp` programmatically in the controller-only hook (see §4).
+
+### 2. Per-worker, per-invocation private database
+
+Codex finding #1: two concurrent `pytest` invocations both have `gw0`,
+both compute the same DB name, run B's `DROP ... FORCE` evicts run A
+mid-flight. Need a **per-invocation run id** mixed into the name.
+
+`tests/fixtures/ebull_test_db.py` rework:
+
+```python
+import os, time
+from secrets import token_hex
+
+# Set once per pytest invocation in the controller. Workers inherit
+# via xdist's worker-spawn env propagation.
+_RUN_ID_ENV = "EBULL_PYTEST_RUN_ID"
+
+def _run_id() -> str:
+    rid = os.environ.get(_RUN_ID_ENV)
+    if rid is None:
+        # First call in the controller (before pytest_sessionstart fires).
+        # Use a short, filesystem-safe id.
+        rid = f"{int(time.time())}_{token_hex(3)}"
+        os.environ[_RUN_ID_ENV] = rid
+    return rid
+
+def _worker_id() -> str:
+    return os.environ.get("PYTEST_XDIST_WORKER", "main")
+
+def test_db_name() -> str:
+    return f"ebull_test_{_run_id()}_{_worker_id()}"
+```
+
+`test_database_url()` derives from `test_db_name()`. The
+~30 test modules calling `test_database_url()` directly pick this up
+automatically.
+
+**`TEST_DB_NAME` constant is removed.** All importers move to
+`test_db_name()`. Pyright + ruff fail any leftover.
+
+**Postgres database name limit is 63 bytes.** `ebull_test_<10 digits>_<6 hex>_gw15` ≈ 33 bytes — well under cap.
+
+### 3. Migrate `tests/test_operator_setup_race.py` onto the shared fixture
+
+Codex finding #2: this file inlines its own `_TEST_DB_NAME = "ebull_test"`
+at line 67 and rebuilds the connect/migrate/truncate path locally. Under
+xdist or concurrent invocations, every worker still hits the literal
+`ebull_test` and races every other test process.
+
+Action: replace the file's local helpers with imports from
+`tests.fixtures.ebull_test_db`. The file's per-test logic (the race-
+condition assertions themselves) is preserved; only the DB-bootstrap
+plumbing is shared. This was already flagged as a follow-up in the
+fixture's own docstring (lines 22-24) and is now the right time.
+
+### 4. Template database with migration-hash invalidation
+
+A new `ebull_test_template` is the master copy. **Build runs only in
+the xdist controller process**, never in workers (Codex finding #5).
+
+Controller-only detection in `tests/conftest.py`:
+
+```python
+def pytest_configure(config: pytest.Config) -> None:
+    is_worker = hasattr(config, "workerinput")
+    if not is_worker:
+        _build_template_if_stale()
+        _set_basetemp(config)
+```
+
+Bootstrap sequence inside `_build_template_if_stale()` (controller only):
+
+1. Acquire Postgres advisory lock on the **maintenance `postgres` DB**
+   (key `EBULL_TEMPLATE_LOCK = 0x65427554455354` ≈ "eBuTEST"; valid
+   Python int literal, Codex finding #8). This serialises template
+   build across pytest invocations on the same Postgres cluster.
+2. Compute migration hash. Codex finding #6: include filename + bytes,
+   sorted by filename, so renames or order changes invalidate the
+   template:
+   ```python
+   import hashlib
+   h = hashlib.sha256()
+   for path in sorted(SQL_DIR.glob("*.sql"), key=lambda p: p.name):
+       h.update(path.name.encode("utf-8"))
+       h.update(b"\0")
+       h.update(path.read_bytes())
+       h.update(b"\0")
+   migration_hash = h.hexdigest()
+   ```
+3. Read stored hash from a small file at
+   `~/.cache/ebull/test_template_hash` (cross-platform via
+   `platformdirs.user_cache_dir("ebull")`).
+4. If `ebull_test_template` does not exist OR stored hash ≠ current
+   hash: drop and recreate template, apply all migrations, store new
+   hash. Drop must use `WITH (FORCE)` to evict stale connections.
+5. Release advisory lock.
+
+Per-worker DB creation (each xdist worker, on first use of the
+fixture or on first call to `test_database_url()`):
+
+1. Acquire advisory lock on `postgres` DB (per-worker key derived
+   deterministically — `int.from_bytes(blake2b(f"{run_id}:{worker_id}"
+   .encode(), digest_size=8).digest(), "big", signed=True)`. Codex v2
+   finding #5: Python's built-in `hash()` is salted across processes,
+   so workers would compute different keys for the same string. blake2b
+   is stable.) Prevents a worker re-running itself from racing.
+2. If `ebull_test_<run>_<worker>` exists: `DROP DATABASE … WITH (FORCE)`
+   (defensive — should not exist, but cleanup of crashed prior runs).
+3. `CREATE DATABASE ebull_test_<run>_<worker> TEMPLATE ebull_test_template`.
+   Postgres copies pages directly. Sub-second on local SSD.
+4. Release lock.
+
+**Why advisory lock on `postgres` and not `ebull_test_template`:**
+PostgreSQL refuses `CREATE DATABASE ... TEMPLATE foo` if **any
+connection** is open on `foo`. The advisory lock must be held on a DB
+nobody else is connecting to — `postgres` is the natural choice and is
+already used by `_admin_database_url()` in the existing fixture.
+
+### 5. Per-worker `basetemp` outside the repo
+
+Codex finding #4: pytest ini does not expand `${VAR:-default}`.
+Configure programmatically:
+
+```python
+# tests/conftest.py — controller-only path inside pytest_configure
+def _set_basetemp(config: pytest.Config) -> None:
+    base = pathlib.Path(tempfile.gettempdir()) / "ebull_pytest" / _run_id()
+    base.mkdir(parents=True, exist_ok=True)
+    config.option.basetemp = str(base)
+```
+
+xdist creates per-worker subdirs `gw0/`, `gw1/`, … under `basetemp`.
+At session end, Python's `tempfile.gettempdir()` cleans up nothing —
+add a session-finish hook that prunes the `_run_id()` subtree.
+
+Old `tmp_pytest/` in repo root: leave gitignored entry, one-shot
+`rm -rf tmp_pytest/` cleanup commit.
+
+### 6. Migrate dev-DB-writing tests onto the per-worker test DB
+
+Codex finding #3 (v2): success criterion #2 ("two concurrent pytest
+invocations must not corrupt each other") cannot be satisfied while
+6 test files still write to `settings.database_url`. xdist groups
+only serialise within a single invocation, not across invocations.
+
+Migration is straightforward because the test-DB schema is identical
+to the dev-DB schema (the template applies every `sql/*.sql` file).
+Two patterns:
+
+**Pattern A — direct connection in the test file.** Replace each
+`psycopg.connect(settings.database_url, ...)` with
+`psycopg.connect(test_database_url(), ...)` and pass
+`test_database_url()` instead of `settings.database_url` into any
+class under test that takes a URL string (`HeartbeatWriter`,
+`JobLock`).
+
+**Pattern B — connection inside a tested helper.** Codex v3
+finding #1: `publish_manual_job_request()` and `publish_sync_request()`
+at `app/services/sync_orchestrator/dispatcher.py:83,117` hard-code
+`psycopg.connect(settings.database_url, ...)`. They read
+`settings.database_url` at call time (verified — module-level
+`from app.config import settings`), so tests can `monkeypatch.setattr(
+"app.config.settings.database_url", test_database_url())` for the
+duration of the test. Apply this monkeypatch via a per-file
+autouse fixture in the affected test files. Pattern is the standard
+pytest monkeypatch idiom; no production code change needed.
+
+In-scope file list (verified by grep):
+
+- `tests/test_jobs_listener.py`
+- `tests/test_jobs_heartbeat.py`
+- `tests/test_jobs_queue_recovery.py`
+- `tests/test_jobs_queue_boot_drain.py`
+- `tests/test_sync_orchestrator_dispatcher.py`
+- `tests/test_jobs_locks.py` (read-only probe + URL pass-through into
+  `JobLock`; same substitution).
+
+Cleanup blocks (e.g. `DELETE FROM job_runtime_heartbeat WHERE …`) move
+to the test DB too, so no rows persist into the operator's dev DB.
+
+Add to `_PLANNER_TABLES` if any of these files write to tables not
+yet in the truncate set (audit at implementation time:
+`job_runtime_heartbeat`, `pending_job_requests`, anything else
+touched by these files).
+
+Extend the existing structural guard at
+`tests/smoke/test_no_settings_url_in_destructive_paths.py` to fail if
+any test file under `tests/` (excluding smoke tests, the fixture
+module itself, and explicit reachability-probe blocks marked with a
+recognised comment) calls `psycopg.connect(settings.database_url`.
+Re-greppable canary so future contributors don't reintroduce the
+violation.
+
+After this PR, **no test writes to the operator's dev DB** except
+the documented `test_app_boots.py` lifespan smoke gate, which is
+pinned to a single worker.
+
+### 7. Always-on durations + perf gate (deferred)
+
+`addopts` includes `--durations=20`. This prints the 20 slowest
+tests every run. Enables the operator to spot regressions visually.
+
+A **soft** perf gate (custom plugin recording per-test wall-clock to
+JSON, compared against baseline) is **out of scope here**; tracked as
+a follow-up tech-debt ticket.
+
+### 8. Audit pass for serial-order assumptions
+
+Before merging:
+
+- **Global advisory locks** — `app/jobs/locks.py::JOBS_PROCESS_LOCK_KEY`
+  is session-scoped on `settings.database_url`. After §6 migration,
+  `tests/test_jobs_locks.py` exercises this against the per-worker
+  test DB. Per-worker isolation eliminates cross-worker contention
+  automatically.
+- **Module-globals mutation** — xdist runs each worker as a separate
+  process; module globals are per-worker. No action required.
+- **`PYTEST_XDIST_WORKER` not set in controller** — `_worker_id()`
+  returns `"main"` in the controller; no test should call
+  `test_db_name()` from controller-only code (controller has no
+  `ebull_test_main_*` DB).
+- **Empirical xdist worker count tune** — start with `-n 4`, run the
+  full suite, record wall-clock. Step 6 → 8 → auto and pick the knee.
+  Numbers go in PR description.
+
+Audit report goes in PR description, not the spec.
+
+### 9. Cleanup of leaked databases and basetemp dirs
+
+Add session-finish teardown that:
+- Drops `ebull_test_<run>_<worker>` for the workers this invocation
+  owned. The template stays.
+- Removes `${TEMP}/ebull_pytest/<run>/` subtree.
+
+Do **not** drop the template at session end — the next invocation
+re-uses it for free if the migration hash matches.
+
+A manual cleanup helper (`python -m tests.fixtures.cleanup_test_dbs`)
+drops every database matching `ebull_test_*` except the template, for
+operator-driven recovery from a crashed run.
+
+## Rollout
+
+1. Feature branch `fix/893-pytest-perf-redesign`.
+2. Single PR. Squash-merge OK; this branch has no stacked dependencies.
+3. After merge: operator runs `time uv run pytest -q` on dev box and
+   records new wall-clock in PR description (Definition of Done clause
+   8 from CLAUDE.md).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `CREATE DATABASE … TEMPLATE` fails because a connection on `ebull_test_template` is still open | Use `WITH (FORCE)` on DROP; controller closes its admin connection before workers fire. |
+| Postgres on operator's box doesn't support `WITH (FORCE)` (PG13+) | Operator confirmed cluster is PG15+. If a teammate has older, fall back to `pg_terminate_backend()` loop. |
+| `pg_advisory_lock` numeric key collision with application code | Use a documented constant range; constants live in `tests/fixtures/ebull_test_db.py` and are off-limits to app code. |
+| xdist workers race on `schema_migrations` insert | Workers don't migrate — only the controller does. Workers receive a fully-migrated template. |
+| New migrations during a long-lived dev session | Hash check at session start triggers template rebuild. Cost is one full migration apply on first run after a new file lands; subsequent runs hit the cache. |
+| Tests that used `TEST_DB_NAME` as a string constant | Replaced with `test_db_name()` function. Imports auto-fail at pyright/ruff stage. Audit pass before push. |
+| Pre-existing failures #875 + #876 still flake under xdist | Out of scope. Document in PR. |
+| Cross-worker schema drift if a test mutates schema (DDL inside a test) | TRUNCATE is not DDL. Audit confirms no test issues `CREATE TABLE` against `ebull_test_*`. |
+| Concurrent invocations collide on per-worker DB names | `_run_id()` mixes seconds + 6 hex chars; collision probability ≈ 1 / 16M per second. Acceptable. |
+| §6 file migration breaks tests that depend on dev-DB-only state (e.g. existing rows) | Audit each file: every observed pattern is "set up your own row, write, assert, clean up". No file reads pre-existing dev-DB state, so swapping URLs is safe. Verified by reading the 6 files at implementation time. |
+
+## Open questions
+
+None — both Codex passes folded.
+
+## References
+
+- Issue #893: tech-debt ticket.
+- `tests/fixtures/ebull_test_db.py:1-363` — current fixture.
+- `tests/test_operator_setup_race.py:67` — inlined `_TEST_DB_NAME` to be
+  migrated onto shared fixture.
+- 6 dev-DB writer files migrated to `test_database_url()` in §6:
+  `tests/test_jobs_listener.py`, `tests/test_jobs_heartbeat.py`,
+  `tests/test_jobs_queue_recovery.py`,
+  `tests/test_jobs_queue_boot_drain.py`,
+  `tests/test_sync_orchestrator_dispatcher.py`,
+  `tests/test_jobs_locks.py`.
+- `.githooks/pre-push:23-46` — current pre-push gate.
+- `pyproject.toml:50-54` — current pytest config.
+- Codex review session 019df563 (2026-05-04 23:46 UTC) — initial 5
+  findings folded.
+- Codex review session 019df567 (2026-05-04 23:51 UTC) — 8 findings on
+  spec v1, all folded into v2 (this version).
+- CLAUDE.md "Codex second-opinion — mandatory checkpoints" section.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
   "pyright>=1.1.0",
   "pytest>=8.0.0",
   "pytest-asyncio>=0.23.0",
+  "pytest-xdist>=3.5",
   "httpx>=0.27.0",
 ]
 
@@ -49,6 +50,7 @@ strict = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+addopts = "-q --tb=short -n 4 --durations=20 --dist=loadgroup"
 markers = [
   "integration: marks tests that require a live Postgres connection (deselect with -m 'not integration')",
 ]

--- a/scripts/bench_fundamentals_upsert.py
+++ b/scripts/bench_fundamentals_upsert.py
@@ -61,8 +61,8 @@ import psycopg
 from app.providers.fundamentals import XbrlFact
 from app.services.fundamentals import upsert_facts_for_instrument
 from tests.fixtures.ebull_test_db import (
-    apply_migrations_to_test_db,
-    ensure_test_db_exists,
+    build_template_if_stale,
+    ensure_worker_database,
     test_database_url,
 )
 
@@ -364,8 +364,8 @@ def _time(fn: Callable[[], None]) -> float:
 
 
 def bench(facts_count: int) -> list[BenchResult]:
-    ensure_test_db_exists()
-    apply_migrations_to_test_db()
+    build_template_if_stale()
+    ensure_worker_database()
     results: list[BenchResult] = []
     facts = _generate_facts(facts_count)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,23 @@
-"""Shared pytest configuration for eBull API tests.
+"""Shared pytest configuration for eBull tests.
 
-The protected routes use ``require_session_or_service_token`` (issue #98).
-We install a no-op override on it so the broad set of pre-existing API
-tests can hit protected endpoints without managing bearer tokens or
-session cookies. The dedicated auth tests
-(``test_api_auth_session.py``) clear this override per-test to exercise
-the real dependency.
+Two responsibilities:
+
+1. Auth bypass for the broad set of pre-existing API tests
+   (``require_session_or_service_token`` no-op override). The
+   dedicated auth tests in ``test_api_auth_session.py`` clear this
+   override per-test to exercise the real dependency.
+2. Per-invocation pytest infra (#893): build the
+   ``ebull_test_template`` once in the controller, give every xdist
+   worker a private DB derived from it, and route ``--basetemp``
+   outside the repo so concurrent runs don't share locked tmp dirs.
 """
 
 from __future__ import annotations
 
 import os
+import pathlib
+import shutil
+import tempfile
 
 # Skip lifespan catch-up in every TestClient(app) enter/exit cycle.
 # Without this, each test that enters the FastAPI lifespan fires real
@@ -33,7 +40,14 @@ import pytest  # noqa: E402
 
 from app.api.auth import require_session_or_service_token  # noqa: E402
 from app.main import app  # noqa: E402
-from tests.fixtures.ebull_test_db import ebull_test_conn as ebull_test_conn  # noqa: F401, E402
+from tests.fixtures.ebull_test_db import (  # noqa: E402, F401
+    _run_id,  # noqa: E402
+    build_template_if_stale,
+    drop_worker_database,
+)
+from tests.fixtures.ebull_test_db import (
+    ebull_test_conn as ebull_test_conn,
+)
 
 
 def _noop_auth() -> None:  # pragma: no cover - trivial override
@@ -54,3 +68,74 @@ app.dependency_overrides[require_session_or_service_token] = _noop_auth
 @pytest.fixture(autouse=True)
 def _reassert_auth_bypass() -> None:
     app.dependency_overrides[require_session_or_service_token] = _noop_auth
+
+
+def _is_xdist_worker(config: pytest.Config) -> bool:
+    return hasattr(config, "workerinput")
+
+
+def _set_basetemp(config: pytest.Config) -> pathlib.Path:
+    """Route pytest tmp dirs outside the repo, partitioned by run id.
+
+    Avoids the Windows-specific lock-leak smell from the legacy
+    ``tmp_pytest/`` directory in repo root and lets concurrent
+    invocations have non-overlapping tmp trees.
+    """
+    base = pathlib.Path(tempfile.gettempdir()) / "ebull_pytest" / _run_id()
+    base.mkdir(parents=True, exist_ok=True)
+    config.option.basetemp = str(base)
+    return base
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Build the test-DB template + set basetemp.
+
+    Runs only in the xdist controller process. Workers inherit the
+    template (fully migrated) and the run id (env propagation), so
+    they never repeat this work.
+
+    Errors building the template are not fatal: the per-test
+    ``ebull_test_conn`` fixture skips cleanly if the DB stack is
+    unavailable. We still log a warning via ``test_db_available``
+    when a worker actually tries to use it.
+    """
+    if _is_xdist_worker(config):
+        return
+
+    try:
+        build_template_if_stale()
+    except Exception as exc:  # pragma: no cover - best-effort
+        # Don't crash the whole pytest invocation just because
+        # Postgres is unreachable; tests that need the real DB will
+        # skip individually via ``test_db_available``.
+        import warnings
+
+        warnings.warn(
+            f"Could not build ebull_test_template: {type(exc).__name__}: {exc}",
+            stacklevel=2,
+        )
+
+    _set_basetemp(config)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Drop this worker's private DB and prune its basetemp dir.
+
+    Runs in every process — controller and workers. The controller
+    has no private DB (worker_id == "main" only if no workers ran);
+    the drop is a no-op when the DB doesn't exist.
+
+    The template stays so the next invocation reuses it for free.
+    """
+    drop_worker_database()
+
+    if _is_xdist_worker(session.config):
+        return
+
+    # Controller-only: best-effort cleanup of the run's basetemp tree.
+    try:
+        base = pathlib.Path(tempfile.gettempdir()) / "ebull_pytest" / _run_id()
+        if base.exists():
+            shutil.rmtree(base, ignore_errors=True)
+    except Exception:  # pragma: no cover - best-effort
+        pass

--- a/tests/fixtures/cleanup_test_dbs.py
+++ b/tests/fixtures/cleanup_test_dbs.py
@@ -1,0 +1,57 @@
+"""Operator-driven cleanup helper for leaked test databases.
+
+Drops every ``ebull_test_*`` database **except** ``ebull_test_template``
+on the configured Postgres cluster. Used after a crashed pytest run
+leaves a worker DB orphaned (the session-finish hook would normally
+clean up, but a SIGKILL'd worker skips it).
+
+Usage:
+
+    uv run python -m tests.fixtures.cleanup_test_dbs
+
+The template stays so the next pytest invocation re-uses it for free.
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from tests.fixtures.ebull_test_db import (
+    TEMPLATE_DB_NAME,
+    _admin_database_url,
+    _drop_database_force,
+)
+
+
+def main() -> int:
+    dropped: list[str] = []
+    skipped: list[str] = []
+    with psycopg.connect(_admin_database_url(), autocommit=True) as admin:
+        with admin.cursor() as cur:
+            cur.execute("SELECT datname FROM pg_database WHERE datname LIKE 'ebull_test_%' ORDER BY datname")
+            names = [row[0] for row in cur.fetchall()]
+        for name in names:
+            if name == TEMPLATE_DB_NAME:
+                skipped.append(name)
+                continue
+            try:
+                _drop_database_force(admin, name)
+                dropped.append(name)
+            except Exception as exc:
+                print(f"  [warn] could not drop {name}: {type(exc).__name__}: {exc}")
+
+    if dropped:
+        print("Dropped:")
+        for name in dropped:
+            print(f"  - {name}")
+    else:
+        print("No leaked test databases found.")
+    if skipped:
+        print("Preserved (template):")
+        for name in skipped:
+            print(f"  - {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -346,7 +346,20 @@ def build_template_if_stale() -> None:
     template exists, this is a no-op (one cheap SELECT). Called from
     the controller-only branch of ``pytest_configure`` in the project
     conftest.
+
+    **Must never be called from an xdist worker.** A worker that
+    rebuilds the template would invalidate the per-worker DBs that
+    sibling workers have already materialised via ``CREATE DATABASE
+    ... TEMPLATE``. Enforced at runtime so the contract is impossible
+    to misread (review-bot prevention follow-up).
     """
+    if "PYTEST_XDIST_WORKER" in os.environ:
+        raise RuntimeError(
+            "build_template_if_stale() must run only in the xdist "
+            "controller. A worker rebuilding the template would corrupt "
+            "sibling workers that have already CREATE-FROM-TEMPLATE'd."
+        )
+
     current = _migration_hash()
     cached = _read_stored_hash()
 
@@ -423,11 +436,25 @@ def ensure_worker_database() -> None:
             try:
                 _create_database_from_template(admin, db_name, TEMPLATE_DB_NAME)
             finally:
-                with admin.cursor() as cur:
-                    cur.execute("SELECT pg_advisory_unlock(%s)", (EBULL_TEMPLATE_LOCK,))
+                # Unlock on a connection that may be in an error
+                # state after a failed DDL; swallow secondary failures
+                # so the primary error reaches the caller. Same
+                # rationale for the outer lock_key release below.
+                # (review-bot 2026-05-05 WARN).
+                try:
+                    with admin.cursor() as cur:
+                        cur.execute(
+                            "SELECT pg_advisory_unlock(%s)",
+                            (EBULL_TEMPLATE_LOCK,),
+                        )
+                except Exception:
+                    pass
         finally:
-            with admin.cursor() as cur:
-                cur.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
+            try:
+                with admin.cursor() as cur:
+                    cur.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
+            except Exception:
+                pass
 
 
 def drop_worker_database() -> None:
@@ -449,9 +476,12 @@ def drop_worker_database() -> None:
 def test_db_available() -> bool:  # noqa: D401 — `test_*` here is the legacy public name, not a pytest test
     """Probe the test DB stack.
 
-    Triggers the controller-side template build if it hasn't run yet
-    (e.g. when used outside a pytest_configure-aware test runner) and
-    materialises the per-worker DB.
+    Materialises the per-worker private DB on first call and verifies
+    the connection works. **Does not touch the template** — the
+    controller's ``pytest_configure`` is the sole template builder
+    (review-bot 2026-05-05 BLOCKING: a worker rebuilding the template
+    after sibling workers have already CREATE-FROM-TEMPLATE'd
+    invalidates their schema).
 
     Returns False on any failure so the test skips cleanly in
     environments without a Postgres at all. Logs a warning so
@@ -459,7 +489,6 @@ def test_db_available() -> bool:  # noqa: D401 — `test_*` here is the legacy p
     hide under the same skip path as "no Postgres".
     """
     try:
-        build_template_if_stale()
         ensure_worker_database()
         with psycopg.connect(test_database_url(), connect_timeout=2) as conn:
             with conn.cursor() as cur:

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -1,34 +1,46 @@
 """Reusable helpers for tests that need a real ``ebull_test`` Postgres.
 
-Extracted from ``tests/test_operator_setup_race.py`` so future tasks
-(SEC incremental planner + executor, integration tests) can import a
-single canonical implementation rather than re-inlining the connect /
-create / migrate / guard dance.
+Originally extracted from ``tests/test_operator_setup_race.py``. As of
+issue #893, this module owns:
 
-The strategy mirrors ``test_operator_setup_race.py`` exactly:
+* per-worker, per-invocation private databases
+  (``ebull_test_<run_id>_<worker_id>``)
+* a session-shared template database (``ebull_test_template``) built
+  once per migration-set hash and reused across runs
+* a session-end teardown that drops the worker's private DB
 
-1. Derive an isolated ``ebull_test`` URL from ``settings.database_url``
-   (same host, same credentials, different database name).
-2. Create the database on demand (admin connection against the
-   maintenance ``postgres`` DB, autocommit — ``CREATE DATABASE`` cannot
-   run inside a transaction).
-3. Apply every ``sql/NNN_*.sql`` migration file to the test DB.
-4. Expose a pytest fixture ``ebull_test_conn`` that yields a fresh
-   ``psycopg.Connection[tuple]`` and TRUNCATEs the planner/executor
-   tables after each test.
-5. Guard every destructive op with ``_assert_test_db`` so a future
-   refactor cannot regress the TRUNCATE onto the dev DB.
+The strategy:
 
-``tests/test_operator_setup_race.py`` deliberately keeps its own
-inlined copies; the migration of that file to this module is a
-follow-up PR, not part of this task's scope.
+1. **Controller process** (the pytest top-level / ``main`` worker)
+   builds ``ebull_test_template`` if its migration hash is stale,
+   under a Postgres advisory lock so concurrent pytest invocations
+   serialise on template construction.
+2. **Each xdist worker** (gw0, gw1, ...) creates its own private DB
+   from the template via ``CREATE DATABASE ... TEMPLATE
+   ebull_test_template``. Postgres copies pages directly so this is
+   sub-second on local SSD.
+3. The fixture's per-test ``TRUNCATE`` runs against the worker's
+   private DB. Cross-worker contention is impossible because each
+   worker owns its DB.
+4. ``settings.database_url`` (the operator's dev DB) is never written
+   to by the test suite, with the documented exception of
+   ``tests/smoke/test_app_boots.py`` (the lifespan smoke gate).
+
+Critically: the dev DB at ``settings.database_url`` is never touched
+by anything in this module. ``_assert_test_db`` enforces that any
+destructive op runs against an ``ebull_test_*`` database, never
+``ebull``.
 """
 
 from __future__ import annotations
 
+import hashlib
+import os
+import time
 import warnings
 from collections.abc import Iterator
 from pathlib import Path
+from secrets import token_hex
 from urllib.parse import urlparse, urlunparse
 
 import psycopg
@@ -38,142 +50,101 @@ from psycopg import sql
 
 from app.config import settings
 
-TEST_DB_NAME = "ebull_test"
+TEMPLATE_DB_NAME = "ebull_test_template"
 _SQL_DIR = Path(__file__).resolve().parents[2] / "sql"
 
-# Tables touched by the SEC incremental planner + executor tests.
-# TRUNCATE in dependency order with CASCADE to handle FKs cleanly.
+# Advisory lock keys. Cross-pytest-invocation locks live on the
+# maintenance ``postgres`` DB so they don't collide with application
+# advisory locks. Constants are documented for the audit trail —
+# application code must not pick keys in this range.
+EBULL_TEMPLATE_LOCK = 0x65427554455354  # ASCII "eBuTEST"
+EBULL_SMOKE_LIFESPAN_LOCK = 0x65427554534D4B  # ASCII "eBuTSMK"
+
+# Run-id env var. Set once in the controller; xdist propagates env to
+# spawned workers automatically.
+_RUN_ID_ENV = "EBULL_PYTEST_RUN_ID"
+
+
+# Path to the migration-hash cache file. Lives under the user's cache
+# dir so the value survives across pytest invocations.
+def _hash_cache_path() -> Path:
+    try:
+        from platformdirs import user_cache_dir
+    except ImportError:  # pragma: no cover
+        cache_root = Path.home() / ".cache" / "ebull"
+    else:
+        cache_root = Path(user_cache_dir("ebull"))
+    cache_root.mkdir(parents=True, exist_ok=True)
+    return cache_root / "test_template_hash"
+
+
+# Tables the per-test fixture truncates between tests. Keep child-to-
+# parent so CASCADE handles any FK we missed. New tables added by a
+# migration that introduces FKs MUST be appended here in the same PR
+# (review-prevention-log entry "Test-teardown list missing new FK-child
+# tables").
 _PLANNER_TABLES: tuple[str, ...] = (
     "cascade_retry_queue",
-    "cik_upsert_timing",  # #418 per-CIK timing audit (FK → data_ingestion_runs)
+    "cik_upsert_timing",
     "financial_facts_raw",
-    "sec_facts_concept_catalog",  # #451 — per-concept metadata
-    "sec_entity_change_log",  # #463 — entity-field change events
+    "sec_facts_concept_catalog",
+    "sec_entity_change_log",
     "data_ingestion_runs",
-    # layer_enabled is the home of the #414 fundamentals_ingest pause
-    # flag and is written by several observability/planner tests. Keep
-    # it in the planner truncation set so a failed test cannot leak
-    # a disabled state across the next function-scoped run and
-    # silently make subsequent "not paused" assertions trip.
-    # layer_enabled_audit is the #346 append-only history table — also
-    # truncated so audit-row leakage between cases doesn't make a
-    # later assertion observe a phantom prior toggle.
     "layer_enabled_audit",
     "layer_enabled",
     "external_identifiers",
     "external_data_watermarks",
-    "coverage_status_events",  # #397 transition log (child of coverage)
-    "coverage",  # #397 truncate needed to reset trigger-driven state cleanly
-    "position_alerts",  # #396 position-alert episodes
-    "watchlist",  # #042 — FK → instruments
-    "broker_positions",  # #024 — FK → instruments
-    "positions",  # #186 — FK → instruments; truncated so the upsert
-    # reset-on-reopen integration tests don't see stale state from
-    # earlier in the test run.
-    "quotes",  # #002 — FK → instruments (live-tick target #471)
+    "coverage_status_events",
+    "coverage",
+    "position_alerts",
+    "watchlist",
+    "broker_positions",
+    "positions",
+    "quotes",
     "instruments",
     "job_runs",
     "financial_periods_raw",
     "financial_periods",
-    "dividend_events",  # #434 — 8-K 8.01 calendar, FK → instruments
-    # #450 8-K structured-event tables. Children → parent:
-    # items + exhibits FK into eight_k_filings; eight_k_filings FKs
-    # into instruments (so the instrument truncation below would
-    # cascade, but listing them explicitly keeps teardown deterministic
-    # when a test populates a filings-only row without touching
-    # instruments).
+    "dividend_events",
     "eight_k_exhibits",
     "eight_k_items",
     "eight_k_filings",
-    "filing_documents",  # #452 — child of filing_events
-    "instrument_business_summary_sections",  # #449 — FK → instruments
-    "instrument_business_summary",  # #428 — 10-K Item 1 body, FK → instruments
-    "instrument_sec_profile",  # #427 — SEC entity profile, FK → instruments
-    # #429 Form 4 tables. Child-to-parent truncation order: transactions
-    # and footnotes FK into filings; filers also FK into filings;
-    # filings FKs into instruments (so instrument truncation further
-    # down would already cascade, but listing them explicitly keeps
-    # teardown deterministic when a test populates filings-only rows
-    # without touching instruments).
+    "filing_documents",
+    "instrument_business_summary_sections",
+    "instrument_business_summary",
+    "instrument_sec_profile",
     "insider_transaction_footnotes",
     "insider_transactions",
-    "insider_initial_holdings",  # #768 — Form 3 baseline, FK → instruments
+    "insider_initial_holdings",
     "insider_filers",
     "insider_filings",
-    # #730 — 13F-HR institutional holdings. Child-to-parent:
-    # institutional_holdings FKs into institutional_filers AND
-    # instruments (so the instrument truncation further down would
-    # cascade), but listing them explicitly keeps teardown
-    # deterministic when a test populates filer / holding rows
-    # without touching the instruments row in the same case.
-    # #781 — unresolved 13F CUSIPs tracking. No FK to instruments
-    # (PK is the CUSIP) so it's safe in any order, but listed
-    # alongside the institutional set for cohesion.
     "unresolved_13f_cusips",
     "institutional_holdings_ingest_log",
     "institutional_holdings",
     "institutional_filers",
     "institutional_filer_seeds",
     "etf_filer_cik_seeds",
-    # #782 — N-CEN-derived filer-type classifications. No FK to
-    # other planner tables; PK is CIK. Listed here so each test
-    # starts with a clean classification state.
     "ncen_filer_classifications",
-    # #766 — 13D/G blockholders. Child-to-parent: blockholder_filings
-    # FKs into blockholder_filers AND instruments. The instrument row
-    # truncation further down would cascade, but listing them
-    # explicitly keeps teardown deterministic when a test populates
-    # filer / filing rows without touching the instruments row in the
-    # same case.
     "blockholder_filings_ingest_log",
     "blockholder_filings",
     "blockholder_filers",
     "blockholder_filer_seeds",
-    # #769 — DEF 14A beneficial ownership cross-check. FK → instruments
-    # (nullable). Listing explicitly keeps teardown deterministic when
-    # a test populates DEF 14A rows without touching instruments.
     "def14a_drift_alerts",
     "def14a_ingest_log",
     "def14a_beneficial_holdings",
     "filing_events",
-    # #794 — instrument CIK and symbol history (Batch 1 of #788). FK →
-    # instruments (cascade on delete). Listed before the instruments
-    # row truncation further down so a test that populates a history
-    # row without touching the instruments row clears deterministically.
     "instrument_cik_history",
     "instrument_symbol_history",
-    # #793 + #790 P4 (Batch 4 of #788). FK → instruments. Keeps
-    # teardown deterministic when a test populates a queue row
-    # without touching the instruments row.
     "ingest_backfill_queue",
-    # Raw filing-document store (issue follow-up after PR #804 audit).
-    # No FK to other planner tables — accession_number is the natural
-    # key and the typed-table rows JOIN back via that column rather
-    # than a row-id FK. Listed for deterministic per-test cleanup.
     "filing_raw_documents",
-    # Reconciliation framework (operator audit follow-up). Findings FK
-    # into runs which FK into instruments — listed child-to-parent
-    # so the truncation order respects the FK tree.
     "data_reconciliation_findings",
     "data_reconciliation_runs",
-    # Per-CIK raw-document store (sibling of filing_raw_documents).
-    # No FK to other planner tables — keyed on (cik, document_kind).
-    # Listed for deterministic per-test cleanup.
     "cik_raw_documents",
-    # #864 — accession-level manifest. Self-referential FK on
-    # ``amends_accession`` is ON DELETE SET NULL so CASCADE truncation
-    # handles the chain cleanly.
     "sec_filing_manifest",
-    # #865 — poll scheduler. No FK to other planner tables (PK is
-    # composite). Listed for deterministic per-test cleanup.
     "data_freshness_index",
-    "decision_audit",  # #315 Phase 3 alerts
-    "trade_recommendations",  # #315 Phase 3 alerts (FK parent of decision_audit)
-    "operators",  # #315 Phase 3 alerts (cursor column)
-    # #840 P1 Phase 1 schema unification — observations + _current per
-    # category. Truncate before each test so observation/refresh data
-    # doesn't leak across cases. _current must come before _observations
-    # in the truncate list (no FK either way; ordered for clarity).
+    "decision_audit",
+    "trade_recommendations",
+    "operators",
     "ownership_insiders_current",
     "ownership_insiders_observations",
     "ownership_institutions_current",
@@ -184,6 +155,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "ownership_treasury_observations",
     "ownership_def14a_current",
     "ownership_def14a_observations",
+    # #893 — dev-DB writers migrated onto worker test DB; tables they
+    # touched now need per-test cleanup.
+    "job_runtime_heartbeat",
+    "pending_job_requests",
 )
 
 
@@ -192,50 +167,147 @@ def _swap_database(url: str, new_db: str) -> str:
     return urlunparse(parsed._replace(path=f"/{new_db}"))
 
 
-def test_database_url() -> str:
-    return _swap_database(settings.database_url, TEST_DB_NAME)
-
-
 def _admin_database_url() -> str:
-    # Admin connection used only to ``CREATE DATABASE``. Connect to
-    # the built-in ``postgres`` maintenance DB so we never hold a
-    # session on the database we are about to create.
+    """URL for the maintenance ``postgres`` DB.
+
+    Used for ``CREATE DATABASE``, ``DROP DATABASE``, and the
+    cross-invocation advisory lock. Must never be confused with the
+    operator's dev DB.
+    """
     return _swap_database(settings.database_url, "postgres")
 
 
-def ensure_test_db_exists() -> None:
-    """Create ``ebull_test`` if it does not yet exist.
+def _run_id() -> str:
+    """Return the per-pytest-invocation run id.
 
-    ``CREATE DATABASE`` cannot run inside a transaction, so the admin
-    connection is opened in autocommit mode. Idempotent: if the
-    database already exists we return without touching it.
+    Set once on first call (in the controller, before workers spawn)
+    and stored in the environment so xdist's worker-spawn propagation
+    delivers the same id to every worker. ``int(time.time())`` is
+    seconds resolution; the 6 hex chars from ``token_hex(3)`` add 24
+    bits of entropy → collision probability across two invocations
+    starting in the same second is ~1 / 16M.
     """
-    with psycopg.connect(_admin_database_url(), autocommit=True) as admin:
-        with admin.cursor() as cur:
-            cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (TEST_DB_NAME,))
-            if cur.fetchone() is None:
-                # ``TEST_DB_NAME`` is a hard-coded constant, never user
-                # input, so SQL injection is not a concern. The
-                # double-quoting guards against a future rename that
-                # introduces an unusual character.
-                cur.execute(f'CREATE DATABASE "{TEST_DB_NAME}"')
+    rid = os.environ.get(_RUN_ID_ENV)
+    if rid is None:
+        rid = f"{int(time.time())}_{token_hex(3)}"
+        os.environ[_RUN_ID_ENV] = rid
+    return rid
 
 
-def apply_migrations_to_test_db() -> None:
-    """Apply every ``sql/NNN_*.sql`` file to the test DB.
+def _worker_id() -> str:
+    """Return the xdist worker id, or ``"main"`` in single-process pytest."""
+    return os.environ.get("PYTEST_XDIST_WORKER", "main")
 
-    Mirrors ``app/db/migrations.run_migrations`` but targets the test
-    DB URL directly. Uses a per-file connection so a single
-    transaction-hostile migration cannot poison the tracking state of
-    earlier migrations.
+
+def test_db_name() -> str:
+    """Compute the per-worker, per-invocation private DB name."""
+    return f"ebull_test_{_run_id()}_{_worker_id()}"
+
+
+# Opt-out of pytest's test-collection. The function names are
+# ``test_*`` because that's the public API the rest of the suite has
+# always called them by, but they are helpers — not tests — and
+# pytest would otherwise auto-collect them when imported into a test
+# module. ``__test__ = False`` is the documented escape hatch.
+test_db_name.__test__ = False  # type: ignore[attr-defined]
+
+
+def test_database_url() -> str:
+    return _swap_database(settings.database_url, test_db_name())
+
+
+test_database_url.__test__ = False  # type: ignore[attr-defined]
+
+
+def template_database_url() -> str:
+    return _swap_database(settings.database_url, TEMPLATE_DB_NAME)
+
+
+def _migration_hash() -> str:
+    """Hash of the (filename, bytes) sequence of every migration file.
+
+    Including the filename catches renames that would otherwise leave
+    a stale template after migrations were re-numbered. Sorted by
+    filename so the order is deterministic across platforms.
+    """
+    h = hashlib.sha256()
+    for path in sorted(_SQL_DIR.glob("*.sql"), key=lambda p: p.name):
+        h.update(path.name.encode("utf-8"))
+        h.update(b"\0")
+        h.update(path.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def _read_stored_hash() -> str | None:
+    cache_path = _hash_cache_path()
+    try:
+        return cache_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+
+
+def _write_stored_hash(value: str) -> None:
+    _hash_cache_path().write_text(value, encoding="utf-8")
+
+
+def _ensure_database(admin: psycopg.Connection[object], db_name: str) -> bool:
+    """Return True if the database already existed."""
+    with admin.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (db_name,))
+        return cur.fetchone() is not None
+
+
+def _drop_database_force(admin: psycopg.Connection[object], db_name: str) -> None:
+    """Drop a database, forcibly evicting any open connections.
+
+    PG13+ supports ``DROP DATABASE ... WITH (FORCE)`` which terminates
+    backends connected to the target. Older clusters need a manual
+    ``pg_terminate_backend`` loop, but operator confirmed PG15+ on the
+    dev box (spec risk-mitigations row).
+    """
+    # ``db_name`` is composed in this module from constants and a
+    # run id we compute. Never user input. ``sql.SQL`` composition
+    # via ``Identifier`` is the standard psycopg-typed idiom.
+    query = sql.SQL("DROP DATABASE IF EXISTS {name} WITH (FORCE)").format(
+        name=sql.Identifier(db_name),
+    )
+    with admin.cursor() as cur:
+        cur.execute(query)
+
+
+def _create_database_from_template(
+    admin: psycopg.Connection[object],
+    db_name: str,
+    template_name: str,
+) -> None:
+    query = sql.SQL("CREATE DATABASE {name} TEMPLATE {tpl}").format(
+        name=sql.Identifier(db_name),
+        tpl=sql.Identifier(template_name),
+    )
+    with admin.cursor() as cur:
+        cur.execute(query)
+
+
+def _create_empty_database(admin: psycopg.Connection[object], db_name: str) -> None:
+    query = sql.SQL("CREATE DATABASE {name}").format(name=sql.Identifier(db_name))
+    with admin.cursor() as cur:
+        cur.execute(query)
+
+
+def _apply_migrations(target_url: str) -> None:
+    """Apply every ``sql/NNN_*.sql`` file to the target DB.
+
+    Uses a per-file connection so a single transaction-hostile
+    migration cannot poison the tracking state of earlier ones. Mirror
+    of ``app/db/migrations.run_migrations`` but targeted at an
+    arbitrary URL (the test template, not the dev DB).
     """
     files = sorted(_SQL_DIR.glob("*.sql"))
     if not files:
         return
 
-    # Bootstrap: schema_migrations exists and is committed before any
-    # migration file runs.
-    with psycopg.connect(test_database_url()) as bootstrap:
+    with psycopg.connect(target_url) as bootstrap:
         with psycopg.ClientCursor(bootstrap) as cur:
             cur.execute(
                 "CREATE TABLE IF NOT EXISTS schema_migrations ("
@@ -244,9 +316,7 @@ def apply_migrations_to_test_db() -> None:
             )
         bootstrap.commit()
 
-    # Reader: fetch the applied set on its own connection so the
-    # per-file connections below see a consistent committed view.
-    with psycopg.connect(test_database_url()) as reader:
+    with psycopg.connect(target_url) as reader:
         with reader.cursor(row_factory=psycopg.rows.tuple_row) as cur:
             cur.execute("SELECT filename FROM schema_migrations")
             done = {row[0] for row in cur.fetchall()}
@@ -255,7 +325,7 @@ def apply_migrations_to_test_db() -> None:
         if path.name in done:
             continue
         sql_text = path.read_text(encoding="utf-8")
-        with psycopg.connect(test_database_url()) as conn:
+        with psycopg.connect(target_url) as conn:
             try:
                 with psycopg.ClientCursor(conn) as cur:
                     cur.execute(sql_text)  # type: ignore[call-overload]
@@ -269,18 +339,128 @@ def apply_migrations_to_test_db() -> None:
                 raise
 
 
-def test_db_available() -> bool:
-    """Probe (and lazily create + migrate) the test DB.
+def build_template_if_stale() -> None:
+    """Build or rebuild ``ebull_test_template`` under a cluster-wide lock.
+
+    Idempotent: if the migration hash matches the cached value and the
+    template exists, this is a no-op (one cheap SELECT). Called from
+    the controller-only branch of ``pytest_configure`` in the project
+    conftest.
+    """
+    current = _migration_hash()
+    cached = _read_stored_hash()
+
+    with psycopg.connect(_admin_database_url(), autocommit=True) as admin:
+        with admin.cursor() as cur:
+            cur.execute("SELECT pg_advisory_lock(%s)", (EBULL_TEMPLATE_LOCK,))
+        try:
+            template_exists = _ensure_database(admin, TEMPLATE_DB_NAME)
+            if template_exists and cached == current:
+                return
+
+            if template_exists:
+                _drop_database_force(admin, TEMPLATE_DB_NAME)
+
+            _create_empty_database(admin, TEMPLATE_DB_NAME)
+            # Apply migrations on a separate connection (we still hold
+            # the advisory lock on the postgres DB).
+            _apply_migrations(template_database_url())
+            _write_stored_hash(current)
+        finally:
+            with admin.cursor() as cur:
+                cur.execute("SELECT pg_advisory_unlock(%s)", (EBULL_TEMPLATE_LOCK,))
+
+
+def _worker_lock_key() -> int:
+    """Deterministic per-worker advisory lock key.
+
+    ``hash()`` is salted across Python processes, so we can't use it.
+    blake2b is stable; first 8 bytes give us a signed bigint that fits
+    Postgres' advisory-lock parameter type.
+    """
+    payload = f"{_run_id()}:{_worker_id()}".encode()
+    digest = hashlib.blake2b(payload, digest_size=8).digest()
+    return int.from_bytes(digest, "big", signed=True)
+
+
+def ensure_worker_database() -> None:
+    """Ensure the per-worker private DB exists.
+
+    Idempotent: if the DB already exists for this run + worker, this
+    is a no-op. The first worker call inside a run materialises the
+    DB from ``ebull_test_template``; subsequent calls (e.g. when
+    multiple test files invoke ``test_db_available`` for skipif) do
+    nothing.
+
+    Held under three locks while creating from the template:
+
+    * the per-worker advisory lock so a worker re-running itself
+      (CI retry) can't race itself, and
+    * the cluster-wide ``EBULL_TEMPLATE_LOCK`` while ``CREATE
+      DATABASE ... TEMPLATE`` reads the template, so a concurrent
+      pytest invocation cannot drop + rebuild the template mid-copy
+      (Codex pre-push #2).
+    """
+    db_name = test_db_name()
+    lock_key = _worker_lock_key()
+
+    with psycopg.connect(_admin_database_url(), autocommit=True) as admin:
+        with admin.cursor() as cur:
+            cur.execute("SELECT pg_advisory_lock(%s)", (lock_key,))
+        try:
+            if _ensure_database(admin, db_name):
+                # Already materialised earlier in this invocation.
+                # Subsequent test_db_available probes must NOT drop
+                # this DB — that would wipe state mid-run (Codex
+                # pre-push #1).
+                return
+            # Hold EBULL_TEMPLATE_LOCK while reading the template so
+            # a concurrent invocation cannot rebuild the template
+            # mid-copy. The lock is brief (page-level COPY); it will
+            # not throttle template builds materially.
+            with admin.cursor() as cur:
+                cur.execute("SELECT pg_advisory_lock(%s)", (EBULL_TEMPLATE_LOCK,))
+            try:
+                _create_database_from_template(admin, db_name, TEMPLATE_DB_NAME)
+            finally:
+                with admin.cursor() as cur:
+                    cur.execute("SELECT pg_advisory_unlock(%s)", (EBULL_TEMPLATE_LOCK,))
+        finally:
+            with admin.cursor() as cur:
+                cur.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
+
+
+def drop_worker_database() -> None:
+    """Drop the worker's private DB at session end."""
+    db_name = test_db_name()
+    try:
+        with psycopg.connect(_admin_database_url(), autocommit=True) as admin:
+            _drop_database_force(admin, db_name)
+    except Exception as exc:  # pragma: no cover - best-effort cleanup
+        warnings.warn(
+            f"Failed to drop test database {db_name!r}: "
+            f"{type(exc).__name__}: {exc}. "
+            f"Run `uv run python -m tests.fixtures.cleanup_test_dbs` to "
+            f"reclaim leaked databases.",
+            stacklevel=2,
+        )
+
+
+def test_db_available() -> bool:  # noqa: D401 — `test_*` here is the legacy public name, not a pytest test
+    """Probe the test DB stack.
+
+    Triggers the controller-side template build if it hasn't run yet
+    (e.g. when used outside a pytest_configure-aware test runner) and
+    materialises the per-worker DB.
 
     Returns False on any failure so the test skips cleanly in
-    environments without a Postgres at all. Logs a warning with the
-    underlying exception — a bare ``except Exception: return False``
-    hides configuration bugs (e.g. the configured role lacks
-    CREATEDB privilege) under the same log message as "no Postgres".
+    environments without a Postgres at all. Logs a warning so
+    configuration bugs (role lacks CREATEDB privilege, etc.) don't
+    hide under the same skip path as "no Postgres".
     """
     try:
-        ensure_test_db_exists()
-        apply_migrations_to_test_db()
+        build_template_if_stale()
+        ensure_worker_database()
         with psycopg.connect(test_database_url(), connect_timeout=2) as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT 1")
@@ -297,49 +477,70 @@ def test_db_available() -> bool:
         return False
 
 
-def _assert_test_db(conn: psycopg.Connection[object]) -> None:
-    """Refuse to run a destructive op against anything but ``ebull_test``.
+test_db_available.__test__ = False  # type: ignore[attr-defined]
 
-    Paranoid backstop: if a future refactor accidentally passes a
-    connection to ``settings.database_url`` (the dev DB) into a
-    cleanup fixture, this guard fails the test loudly instead of
-    silently TRUNCATing the user's working state.
+
+def assert_test_db(conn: psycopg.Connection[object]) -> None:
+    """Refuse to run a destructive op against anything but the worker's test DB.
+
+    Paranoid backstop: a future refactor could accidentally pass a
+    connection to ``settings.database_url`` (the dev DB) or to the
+    shared template into a cleanup fixture. This guard fails the test
+    loudly instead of silently TRUNCATing the operator's working
+    state or corrupting the reusable template (Codex pre-push #3).
     """
     with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
         cur.execute("SELECT current_database()")
         row = cur.fetchone()
         assert row is not None
         db_name = row[0]
-    if db_name != TEST_DB_NAME:
+    expected = test_db_name()
+    if db_name != expected:
         raise RuntimeError(
-            f"Refusing to TRUNCATE: connected to database {db_name!r}, "
-            f"expected {TEST_DB_NAME!r}. The dev DB must never be wiped by tests."
+            f"Refusing to TRUNCATE: connected to database {db_name!r}; "
+            f"expected this worker's private DB {expected!r}. "
+            f"Neither the dev DB nor the {TEMPLATE_DB_NAME!r} template "
+            f"may be wiped by tests."
         )
 
 
+# Back-compat alias — older test modules imported the underscore-prefixed
+# private form. Both names point at the same callable.
+_assert_test_db = assert_test_db
+
+
 def _truncate_planner_tables(conn: psycopg.Connection[tuple]) -> None:
-    _assert_test_db(conn)
-    # TRUNCATE cannot parameterise table names, so compose via
-    # ``psycopg.sql.Identifier`` which quotes each name safely. The
-    # table list is a module-level constant — never user input — but
-    # composition is still the right habit.
-    query = sql.SQL("TRUNCATE {tables} RESTART IDENTITY CASCADE").format(
-        tables=sql.SQL(", ").join(sql.Identifier(t) for t in _PLANNER_TABLES),
-    )
+    """Truncate the planner table set in chunks.
+
+    A single ``TRUNCATE ... CASCADE`` over 70+ tables on a worker
+    running concurrently with other workers exhausts Postgres'
+    ``max_locks_per_transaction`` (default 64). Splitting into
+    bounded chunks keeps the per-transaction lock count safe even
+    when CASCADE pulls in extra child tables.
+    """
+    assert_test_db(conn)
+    chunk_size = 20
+    chunks = [_PLANNER_TABLES[i : i + chunk_size] for i in range(0, len(_PLANNER_TABLES), chunk_size)]
     with conn.cursor() as cur:
-        cur.execute(query)
-    conn.commit()
+        for chunk in chunks:
+            query = sql.SQL("TRUNCATE {tables} RESTART IDENTITY CASCADE").format(
+                tables=sql.SQL(", ").join(sql.Identifier(t) for t in chunk),
+            )
+            cur.execute(query)
+            conn.commit()
 
 
 @pytest.fixture
 def ebull_test_conn() -> Iterator[psycopg.Connection[tuple]]:
-    """Yield a fresh ``ebull_test`` connection, TRUNCATE before + after.
+    """Yield a fresh connection to the worker's private test DB.
 
-    Function-scoped so each test starts with a clean slate and no test
-    leaks state into the next. Both the pre-yield and post-yield
-    TRUNCATE go through ``_assert_test_db`` so the dev DB can never be
-    wiped by a misconfigured connection.
+    TRUNCATE before and after each test. Both passes go through
+    ``_assert_test_db`` so the dev DB can never be wiped by a
+    misconfigured connection.
     """
+    if not test_db_available():
+        pytest.skip("ebull_test DB unavailable")
+
     url = test_database_url()
     with psycopg.connect(url) as setup_conn:
         _truncate_planner_tables(setup_conn)
@@ -348,10 +549,6 @@ def ebull_test_conn() -> Iterator[psycopg.Connection[tuple]]:
     try:
         yield conn
     finally:
-        # Roll back any in-flight transaction before we hand the
-        # connection to the TRUNCATE path — TRUNCATE on an aborted
-        # transaction would itself fail with ``current transaction is
-        # aborted``.
         try:
             conn.rollback()
         except Exception:
@@ -360,3 +557,19 @@ def ebull_test_conn() -> Iterator[psycopg.Connection[tuple]]:
             _truncate_planner_tables(conn)
         finally:
             conn.close()
+
+
+__all__ = [
+    "EBULL_SMOKE_LIFESPAN_LOCK",
+    "EBULL_TEMPLATE_LOCK",
+    "TEMPLATE_DB_NAME",
+    "assert_test_db",
+    "build_template_if_stale",
+    "drop_worker_database",
+    "ebull_test_conn",
+    "ensure_worker_database",
+    "test_database_url",
+    "test_db_available",
+    "test_db_name",
+    "template_database_url",
+]

--- a/tests/smoke/test_app_boots.py
+++ b/tests/smoke/test_app_boots.py
@@ -40,8 +40,30 @@ populated) also fails this test.
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import Iterator
+
+import psycopg
 import pytest
 from fastapi.testclient import TestClient
+
+# This file is the documented exception (#893) to the "no test writes
+# the dev DB" rule (SC #5 of the pytest-perf-redesign spec). Two
+# protections in place:
+#
+#   1. ``xdist_group("dev_db_smoke")`` — every test in this module
+#      runs on the same xdist worker, so within a single pytest
+#      invocation the lifespan migrations are not driven from two
+#      processes at once.
+#   2. ``_dev_db_lifespan_lock`` — a Postgres session-scoped advisory
+#      lock on the maintenance ``postgres`` DB serialises the smoke
+#      test across **all** concurrent pytest invocations on the same
+#      Postgres cluster. Without this, two operators running ``uv run
+#      pytest`` simultaneously would race the lifespan migrations.
+#
+# Note: the full ``pytestmark`` value is set further down once
+# ``_db_reachable()`` is defined; it combines the xdist_group pin with
+# a skipif so the test cleanly skips on Postgres-less environments.
 
 # State flags the lifespan in ``app/main.py`` is contracted to write.
 # Imported here as a module-level constant so the per-test cleanup
@@ -89,10 +111,44 @@ def _db_reachable() -> bool:
         return False
 
 
-pytestmark = pytest.mark.skipif(
-    not _db_reachable(),
-    reason="dev Postgres not reachable; smoke test requires the real DB",
-)
+pytestmark = [
+    pytest.mark.xdist_group("dev_db_smoke"),
+    pytest.mark.skipif(
+        not _db_reachable(),
+        reason="dev Postgres not reachable; smoke test requires the real DB",
+    ),
+]
+
+
+@contextlib.contextmanager
+def _dev_db_lifespan_lock() -> Iterator[None]:
+    """Serialise lifespan migrations across concurrent pytest invocations.
+
+    Holds ``EBULL_SMOKE_LIFESPAN_LOCK`` on the maintenance ``postgres``
+    DB for the duration of the smoke body. The advisory lock is
+    cluster-wide, so a second pytest invocation running the same smoke
+    test will block here rather than racing the lifespan's
+    ``run_migrations()`` call.
+    """
+    from urllib.parse import urlparse, urlunparse
+
+    from app.config import settings
+    from tests.fixtures.ebull_test_db import EBULL_SMOKE_LIFESPAN_LOCK
+
+    parsed = urlparse(settings.database_url)
+    admin_url = urlunparse(parsed._replace(path="/postgres"))
+
+    admin = psycopg.connect(admin_url, autocommit=True)
+    try:
+        with admin.cursor() as cur:
+            cur.execute("SELECT pg_advisory_lock(%s)", (EBULL_SMOKE_LIFESPAN_LOCK,))
+        try:
+            yield
+        finally:
+            with admin.cursor() as cur:
+                cur.execute("SELECT pg_advisory_unlock(%s)", (EBULL_SMOKE_LIFESPAN_LOCK,))
+    finally:
+        admin.close()
 
 
 def test_app_lifespan_boots_and_state_is_coherent() -> None:
@@ -149,7 +205,7 @@ def test_app_lifespan_boots_and_state_is_coherent() -> None:
     saved_get_conn = app.dependency_overrides.pop(get_conn, None)
 
     try:
-        with TestClient(app) as client:
+        with _dev_db_lifespan_lock(), TestClient(app) as client:
             # Lifespan must have populated every flag the rest of the
             # app reads off ``app.state``. Missing attributes here
             # mean the lifespan returned early or skipped its writes

--- a/tests/smoke/test_app_boots.py
+++ b/tests/smoke/test_app_boots.py
@@ -138,15 +138,34 @@ def _dev_db_lifespan_lock() -> Iterator[None]:
     parsed = urlparse(settings.database_url)
     admin_url = urlunparse(parsed._replace(path="/postgres"))
 
-    admin = psycopg.connect(admin_url, autocommit=True)
+    try:
+        admin = psycopg.connect(admin_url, autocommit=True)
+    except Exception:
+        # postgres maintenance DB unreachable — fall back to running
+        # without cross-invocation serialisation. The within-invocation
+        # ``xdist_group("dev_db_smoke")`` pin still prevents two
+        # workers in this run racing the lifespan; only concurrent
+        # pytest invocations on the same cluster lose protection,
+        # which is no worse than pre-#893 behaviour.
+        # (review-bot 2026-05-05 WARN: avoid ERROR-instead-of-SKIP
+        # when the maintenance DB is the unreachable target.)
+        yield
+        return
+
     try:
         with admin.cursor() as cur:
             cur.execute("SELECT pg_advisory_lock(%s)", (EBULL_SMOKE_LIFESPAN_LOCK,))
         try:
             yield
         finally:
-            with admin.cursor() as cur:
-                cur.execute("SELECT pg_advisory_unlock(%s)", (EBULL_SMOKE_LIFESPAN_LOCK,))
+            try:
+                with admin.cursor() as cur:
+                    cur.execute(
+                        "SELECT pg_advisory_unlock(%s)",
+                        (EBULL_SMOKE_LIFESPAN_LOCK,),
+                    )
+            except Exception:
+                pass
     finally:
         admin.close()
 

--- a/tests/smoke/test_no_settings_url_in_destructive_paths.py
+++ b/tests/smoke/test_no_settings_url_in_destructive_paths.py
@@ -13,6 +13,16 @@ inside a fixture and adding a TRUNCATE next to it.
 
 This test is the structural guard.
 
+Per #893, the test fixture now provisions a per-worker private
+database (``ebull_test_<run_id>_<worker_id>``) so concurrent pytest
+invocations cannot collide. The guard's role is unchanged — it ensures
+no test reaches around the fixture and connects to the operator's
+dev DB directly. The single documented exception is
+``tests/smoke/test_app_boots.py``, which drives the FastAPI lifespan
+against the real dev DB by contract; that file is wrapped in a
+cluster-wide Postgres advisory lock so concurrent invocations
+serialise on the lifespan migrations rather than racing them.
+
 What it catches
 ---------------
 The guard greps every test file for any of the patterns in
@@ -41,10 +51,14 @@ to proceed against anything but ``ebull_test``.
 If you are a future test author hitting this guard
 ---------------------------------------------------
 * Do NOT add yourself to ``_ALLOWED`` to make the test pass.
-* Use the isolated ``ebull_test`` pattern from
-  ``tests/test_operator_setup_race.py`` instead -- copy
-  ``_swap_database`` / ``_ensure_test_db_exists`` /
-  ``_apply_migrations_to_test_db`` / ``_assert_test_db``.
+* Use the per-worker isolated DB by importing
+  ``test_database_url`` from ``tests.fixtures.ebull_test_db``.
+  If the code under test opens its own connection internally
+  via ``settings.database_url`` (e.g. dispatcher helpers), use a
+  ``monkeypatch.setattr("app.config.settings.database_url",
+  test_database_url())`` autouse fixture in the test file —
+  that points the helper at the per-worker test DB without
+  any production-code change.
 * The PREVENTION note on PR #129 round 1 explicitly asked for
   this guard. Removing or weakening it requires a written
   rebuttal in a follow-up PR.
@@ -98,40 +112,15 @@ _ALLOWED: dict[str, str] = {
     # connection. The smoke gate's *job* is "did the lifespan come
     # up against the same DB the running app uses", which is
     # unanswerable without using ``settings.database_url``.
-    "smoke/test_app_boots.py": "read-only lifespan + reachability probe",
+    "smoke/test_app_boots.py": (
+        "documented dev-DB exception (#893 SC#5): smoke gate drives "
+        "FastAPI lifespan against the real dev DB by design, wrapped in "
+        "a cross-invocation Postgres advisory lock"
+    ),
     # The guard itself contains the forbidden patterns as data
     # (the ``_FORBIDDEN_PATTERNS`` literals above). Exclude it to
     # avoid a self-match.
     "smoke/test_no_settings_url_in_destructive_paths.py": "the guard itself",
-    # Read-only reachability probe + advisory-lock semantics test for
-    # the JobLock primitive (#13 PR A). The probe runs ``SELECT 1`` to
-    # decide whether to skip (no Postgres -> clean skip) and the test
-    # bodies exercise ``pg_try_advisory_lock`` / ``pg_advisory_unlock``,
-    # both of which are session-scoped state -- they write no rows and
-    # cannot CASCADE into broker_credentials. Cannot use the
-    # ``ebull_test`` pattern here because the JobLock implementation
-    # opens its own connection internally; the test must connect to
-    # the same DB the JobLock will resolve to via ``settings.database_url``.
-    "test_jobs_locks.py": "read-only reachability probe + advisory-lock semantics; no row writes",
-    # #719 dispatcher tests open a connection against settings.database_url
-    # to exercise the durable-queue helpers against the real DB. Writes
-    # are scoped to the ``pending_job_requests`` table and a per-test
-    # cleanup fixture deletes the request_ids it created in teardown,
-    # so the dev DB's other tables are never touched. Cannot use
-    # ``ebull_test`` because the dispatcher's helpers themselves resolve
-    # the URL from ``settings.database_url`` internally.
-    "test_sync_orchestrator_dispatcher.py": "scoped writes to pending_job_requests with per-test cleanup",
-    # #719 listener / heartbeat / queue-recovery tests open connections
-    # against the dev DB to exercise queue claim + heartbeat upsert +
-    # boot-recovery branches. Writes are scoped to pending_job_requests,
-    # job_runtime_heartbeat, job_runs.linked_request_id, and
-    # sync_runs.linked_request_id, with per-test cleanup deleting only
-    # the rows the test created. Cannot use ``ebull_test`` because the
-    # helpers resolve ``settings.database_url`` internally.
-    "test_jobs_listener.py": "scoped writes via dispatcher helpers with per-test cleanup",
-    "test_jobs_heartbeat.py": "scoped writes to job_runtime_heartbeat with per-test cleanup",
-    "test_jobs_queue_recovery.py": "scoped writes to pending_job_requests + linked-run rows with per-test cleanup",
-    "test_jobs_queue_boot_drain.py": "scoped writes to pending_job_requests with per-test cleanup",
     # Read-only schema introspection. ``test_schema_drift.py`` (B5
     # of #797 pulled forward into Batch 1 of #788) parses
     # ``CREATE TABLE`` blocks from sql/*.sql and compares declared

--- a/tests/test_api_portfolio_mirror_equity.py
+++ b/tests/test_api_portfolio_mirror_equity.py
@@ -25,10 +25,14 @@ from tests.fixtures.copy_mirrors import (
     _NOW,
     mirror_aum_fixture,
 )
-from tests.test_operator_setup_race import (
-    _assert_test_db,
-    _test_database_url,
-    _test_db_available,
+from tests.fixtures.ebull_test_db import (
+    assert_test_db as _assert_test_db,
+)
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
 )
 
 pytestmark = pytest.mark.skipif(

--- a/tests/test_execution_guard_mirror_aum.py
+++ b/tests/test_execution_guard_mirror_aum.py
@@ -21,10 +21,14 @@ from tests.fixtures.copy_mirrors import (
     _NOW,
     mirror_aum_fixture,
 )
-from tests.test_operator_setup_race import (
-    _assert_test_db,
-    _test_database_url,
-    _test_db_available,
+from tests.fixtures.ebull_test_db import (
+    assert_test_db as _assert_test_db,
+)
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
 )
 
 pytestmark = pytest.mark.skipif(

--- a/tests/test_jobs_heartbeat.py
+++ b/tests/test_jobs_heartbeat.py
@@ -1,10 +1,12 @@
 """HeartbeatWriter unit coverage (#719).
 
-Drives ``HeartbeatWriter.beat`` against the real dev DB so the SQL
-upsert (ON CONFLICT (subsystem) DO UPDATE) is exercised. The
+Drives ``HeartbeatWriter.beat`` against the per-worker test DB so the
+SQL upsert (ON CONFLICT (subsystem) DO UPDATE) is exercised. The
 ``heartbeat_loop`` driver is exercised structurally via a stop_event
 that fires after one tick — a longer integration runs lives in the
 smoke gate against the running jobs process.
+
+Per #893, points at the worker's ``ebull_test_<run>_<worker>`` DB.
 """
 
 from __future__ import annotations
@@ -17,24 +19,12 @@ from typing import Any
 import psycopg
 import pytest
 
-from app.config import settings
 from app.jobs.heartbeat import HeartbeatWriter, heartbeat_loop
-
-
-def _db_reachable() -> bool:
-    try:
-        with psycopg.connect(settings.database_url, connect_timeout=2) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-                cur.fetchone()
-        return True
-    except Exception:
-        return False
-
+from tests.fixtures.ebull_test_db import test_database_url, test_db_available
 
 pytestmark = pytest.mark.skipif(
-    not _db_reachable(),
-    reason="dev Postgres not reachable; heartbeat tests require the real DB",
+    not test_db_available(),
+    reason="ebull_test DB unavailable; heartbeat tests require a real DB",
 )
 
 
@@ -44,7 +34,7 @@ def _cleanup_subsystems() -> Generator[list[str]]:
     written: list[str] = []
     yield written
     if written:
-        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+        with psycopg.connect(test_database_url(), autocommit=True) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     "DELETE FROM job_runtime_heartbeat WHERE subsystem = ANY(%s)",
@@ -55,12 +45,12 @@ def _cleanup_subsystems() -> Generator[list[str]]:
 def test_beat_inserts_then_updates_row(_cleanup_subsystems: list[str]) -> None:
     subsystem = "test_beat_subsystem"
     _cleanup_subsystems.append(subsystem)
-    writer = HeartbeatWriter(settings.database_url, pid=99999, process_started_at=datetime.now(UTC))
+    writer = HeartbeatWriter(test_database_url(), pid=99999, process_started_at=datetime.now(UTC))
 
     writer.beat(subsystem, notes={"first": True})
     writer.beat(subsystem, notes={"first": False, "second": True})
 
-    with psycopg.connect(settings.database_url, autocommit=True) as conn:
+    with psycopg.connect(test_database_url(), autocommit=True) as conn:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT pid, notes FROM job_runtime_heartbeat WHERE subsystem=%s",
@@ -88,7 +78,7 @@ def test_heartbeat_loop_stops_on_event(_cleanup_subsystems: list[str]) -> None:
     """The loop honours stop_event and exits cleanly."""
     subsystem = "test_loop_stop"
     _cleanup_subsystems.append(subsystem)
-    writer = HeartbeatWriter(settings.database_url, pid=99999, process_started_at=datetime.now(UTC))
+    writer = HeartbeatWriter(test_database_url(), pid=99999, process_started_at=datetime.now(UTC))
     stop_event = threading.Event()
 
     def _provider() -> dict[str, Any]:
@@ -106,7 +96,7 @@ def test_heartbeat_loop_stops_on_event(_cleanup_subsystems: list[str]) -> None:
 
     # The first beat ran (notes_provider was called); after that the
     # stop_event interrupted the wait.
-    with psycopg.connect(settings.database_url, autocommit=True) as conn:
+    with psycopg.connect(test_database_url(), autocommit=True) as conn:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT notes FROM job_runtime_heartbeat WHERE subsystem=%s",

--- a/tests/test_jobs_listener.py
+++ b/tests/test_jobs_listener.py
@@ -7,6 +7,12 @@ by ``test_sync_orchestrator_dispatcher.py``) but the dispatch routing
 needs a real psycopg connection and is out of scope for this unit
 test; integration coverage runs through the smoke gate in dev when
 the jobs process is up.
+
+Per #893, the test exercises the per-worker private test DB rather
+than ``settings.database_url``; helpers like
+``publish_manual_job_request`` read ``settings.database_url`` at call
+time, so an autouse monkeypatch points it at the test DB for the
+test's lifetime.
 """
 
 from __future__ import annotations
@@ -18,7 +24,6 @@ from unittest.mock import MagicMock
 import psycopg
 import pytest
 
-from app.config import settings
 from app.jobs.listener import (
     ListenerState,
     _dispatch_manual_job,
@@ -26,23 +31,23 @@ from app.jobs.listener import (
     _route_claim,
 )
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request
-
-
-def _db_reachable() -> bool:
-    try:
-        with psycopg.connect(settings.database_url, connect_timeout=2) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-                cur.fetchone()
-        return True
-    except Exception:
-        return False
-
+from tests.fixtures.ebull_test_db import test_database_url, test_db_available
 
 pytestmark = pytest.mark.skipif(
-    not _db_reachable(),
-    reason="dev Postgres not reachable; listener tests require the real DB for queue claims",
+    not test_db_available(),
+    reason="ebull_test DB unavailable; listener tests require a real DB for queue claims",
 )
+
+
+@pytest.fixture(autouse=True)
+def _route_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point app.config.settings.database_url at the worker's test DB.
+
+    ``publish_manual_job_request`` and friends read
+    ``settings.database_url`` at call time, so a per-test monkeypatch
+    is sufficient — no production code change needed.
+    """
+    monkeypatch.setattr("app.config.settings.database_url", test_database_url())
 
 
 @pytest.fixture()
@@ -50,7 +55,7 @@ def _cleanup_requests() -> Generator[list[int]]:
     created: list[int] = []
     yield created
     if created:
-        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+        with psycopg.connect(test_database_url(), autocommit=True) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     "DELETE FROM pending_job_requests WHERE request_id = ANY(%s)",
@@ -67,7 +72,7 @@ def test_dispatch_manual_job_with_unknown_name_marks_rejected(_cleanup_requests:
     _dispatch_manual_job(runtime=runtime, request_id=request_id, job_name="definitely_not_a_real_job")
 
     runtime.submit_manual_with_request.assert_not_called()
-    with psycopg.connect(settings.database_url, autocommit=True) as conn:
+    with psycopg.connect(test_database_url(), autocommit=True) as conn:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT status, error_msg FROM pending_job_requests WHERE request_id=%s",
@@ -91,7 +96,7 @@ def test_dispatch_sync_with_invalid_payload_marks_rejected(
 ) -> None:
     """A sync request with no scope dict must be rejected without submitting."""
     # publish a valid sync row first so the dispatcher has something to update
-    with psycopg.connect(settings.database_url, autocommit=True) as conn:
+    with psycopg.connect(test_database_url(), autocommit=True) as conn:
         cur = conn.execute(
             "INSERT INTO pending_job_requests (request_kind, payload) VALUES ('sync', '{}'::jsonb) RETURNING request_id"
         )

--- a/tests/test_jobs_locks.py
+++ b/tests/test_jobs_locks.py
@@ -4,52 +4,36 @@ These exercise ``pg_try_advisory_lock`` for real -- mocks would prove
 nothing about the lock semantics. Skipped automatically if Postgres
 is unreachable, so a CI run with no DB at all still passes cleanly.
 
-Critically: the lock is read-only on the database (it does not write
-any rows), so this test does NOT need the ``ebull_test`` isolation
-pattern from ``test_operator_setup_race.py``. It runs against
-``settings.database_url`` directly. Verified by the structural guard
-``tests/smoke/test_no_settings_url_in_destructive_paths.py`` which
-greps for ``connect(settings.database_url`` in destructive contexts;
-this file does not match because the connection is opened *inside*
-the JobLock implementation, not directly here.
+Per #893, ``JobLock`` is constructed against the per-worker test DB
+URL rather than the operator's dev DB. Advisory locks are scoped to
+the connection's database, so two workers exercising the same lock
+name in their own private DBs cannot interfere with each other.
 """
 
 from __future__ import annotations
 
-import psycopg
 import pytest
 
-from app.config import settings
 from app.jobs.locks import JobAlreadyRunning, JobLock
-
-
-def _db_available() -> bool:
-    try:
-        with psycopg.connect(settings.database_url, connect_timeout=2) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-        return True
-    except Exception:
-        return False
-
+from tests.fixtures.ebull_test_db import test_database_url, test_db_available
 
 pytestmark = pytest.mark.skipif(
-    not _db_available(),
-    reason="Postgres unreachable -- skipping JobLock real-DB tests",
+    not test_db_available(),
+    reason="ebull_test DB unavailable -- skipping JobLock real-DB tests",
 )
 
 
 class TestJobLockAcquire:
     def test_first_acquire_succeeds(self) -> None:
-        with JobLock(settings.database_url, "test_first_acquire"):
+        with JobLock(test_database_url(), "test_first_acquire"):
             pass  # acquired and released cleanly
 
     def test_second_acquire_while_held_raises(self) -> None:
-        outer = JobLock(settings.database_url, "test_second_acquire")
+        outer = JobLock(test_database_url(), "test_second_acquire")
         outer.__enter__()
         try:
             with pytest.raises(JobAlreadyRunning) as exc_info:
-                with JobLock(settings.database_url, "test_second_acquire"):
+                with JobLock(test_database_url(), "test_second_acquire"):
                     pass
             assert exc_info.value.job_name == "test_second_acquire"
         finally:
@@ -57,15 +41,15 @@ class TestJobLockAcquire:
 
     def test_acquire_after_release_succeeds(self) -> None:
         # First holder releases, second holder must be able to acquire.
-        with JobLock(settings.database_url, "test_acquire_after_release"):
+        with JobLock(test_database_url(), "test_acquire_after_release"):
             pass
-        with JobLock(settings.database_url, "test_acquire_after_release"):
+        with JobLock(test_database_url(), "test_acquire_after_release"):
             pass  # would raise JobAlreadyRunning if release was broken
 
     def test_different_names_do_not_block(self) -> None:
         # Two locks with different names must be holdable concurrently.
-        with JobLock(settings.database_url, "test_different_names_a"):
-            with JobLock(settings.database_url, "test_different_names_b"):
+        with JobLock(test_database_url(), "test_different_names_a"):
+            with JobLock(test_database_url(), "test_different_names_b"):
                 pass
 
     def test_release_on_exception_in_body(self) -> None:
@@ -75,9 +59,9 @@ class TestJobLockAcquire:
             pass
 
         with pytest.raises(_BodyError):
-            with JobLock(settings.database_url, "test_release_on_exception"):
+            with JobLock(test_database_url(), "test_release_on_exception"):
                 raise _BodyError("boom")
 
         # Re-acquire must succeed.
-        with JobLock(settings.database_url, "test_release_on_exception"):
+        with JobLock(test_database_url(), "test_release_on_exception"):
             pass

--- a/tests/test_jobs_queue_boot_drain.py
+++ b/tests/test_jobs_queue_boot_drain.py
@@ -5,6 +5,9 @@ queue row at boot — same atomic claim path the listener uses on its
 poll fallback. This test seeds two pending rows, drives the boot-drain
 helper from ``app.jobs.__main__``, and asserts both rows are claimed
 and dispatched.
+
+Per #893, ``settings.database_url`` is monkeypatched to the worker's
+test DB so the drain helper writes to per-worker isolation.
 """
 
 from __future__ import annotations
@@ -17,27 +20,21 @@ from unittest.mock import MagicMock
 import psycopg
 import pytest
 
-from app.config import settings
 from app.jobs.__main__ import _drain_pending_at_boot
 from app.jobs.listener import ListenerState
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request
-
-
-def _db_reachable() -> bool:
-    try:
-        with psycopg.connect(settings.database_url, connect_timeout=2) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-                cur.fetchone()
-        return True
-    except Exception:
-        return False
-
+from tests.fixtures.ebull_test_db import test_database_url, test_db_available
 
 pytestmark = pytest.mark.skipif(
-    not _db_reachable(),
-    reason="dev Postgres not reachable; boot-drain test requires the real DB",
+    not test_db_available(),
+    reason="ebull_test DB unavailable; boot-drain test requires a real DB",
 )
+
+
+@pytest.fixture(autouse=True)
+def _route_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the drain helper + dispatcher at the worker's test DB."""
+    monkeypatch.setattr("app.config.settings.database_url", test_database_url())
 
 
 @pytest.fixture()
@@ -45,7 +42,7 @@ def _cleanup_requests() -> Generator[list[int]]:
     created: list[int] = []
     yield created
     if created:
-        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+        with psycopg.connect(test_database_url(), autocommit=True) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     "DELETE FROM pending_job_requests WHERE request_id = ANY(%s)",
@@ -78,7 +75,7 @@ def test_drain_pending_at_boot_claims_each_row(
     # Both rows should now be `claimed` (the dispatch path will only
     # transition to `dispatched` inside the executor wrapper, which
     # we mocked out via runtime.submit_manual_with_request).
-    with psycopg.connect(settings.database_url, autocommit=True) as conn:
+    with psycopg.connect(test_database_url(), autocommit=True) as conn:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT request_id, status FROM pending_job_requests WHERE request_id = ANY(%s) ORDER BY request_id",
@@ -92,8 +89,10 @@ def test_drain_pending_at_boot_claims_each_row(
 
 def test_drain_pending_at_boot_returns_zero_when_empty() -> None:
     """No pending rows: the helper returns 0 without calling the runtime."""
-    # Best-effort — there may be other pending rows in the dev DB.
-    # Drain those into the mock first, then re-call to confirm 0.
+    # Per-worker test DB starts clean of pending_job_requests at fixture
+    # truncation time, but other tests in the same worker may have
+    # written rows. Drain those into the mock first, reset, drain again
+    # to confirm idempotence.
     runtime = MagicMock()
     state = ListenerState()
     sync_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-sync")
@@ -101,7 +100,7 @@ def test_drain_pending_at_boot_returns_zero_when_empty() -> None:
     try:
         first = _drain_pending_at_boot(runtime=runtime, sync_executor=sync_executor, boot_id="t", state=state)
         # Reset the rows we just claimed so another suite doesn't see them stuck.
-        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+        with psycopg.connect(test_database_url(), autocommit=True) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     "UPDATE pending_job_requests SET status='pending', claimed_at=NULL, claimed_by=NULL "
@@ -111,6 +110,14 @@ def test_drain_pending_at_boot_returns_zero_when_empty() -> None:
         second = _drain_pending_at_boot(runtime=runtime, sync_executor=sync_executor, boot_id="t2", state=state)
     finally:
         sync_executor.shutdown(wait=False, cancel_futures=True)
+        # Cleanup: the per-worker fixture's _PLANNER_TABLES truncation
+        # only fires for tests that opt into ``ebull_test_conn``; this
+        # test does not, so any rows the drain claimed under boot_ids
+        # ``t`` / ``t2`` would leak into later tests in this worker.
+        # Delete them explicitly so the per-worker DB stays clean.
+        with psycopg.connect(test_database_url(), autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM pending_job_requests WHERE claimed_by IN ('t', 't2')")
 
     assert first >= 0
     assert second >= 0

--- a/tests/test_jobs_queue_recovery.py
+++ b/tests/test_jobs_queue_recovery.py
@@ -11,6 +11,10 @@ locked in:
   (c) `sync` row whose linked sync_runs is still 'running' (mid-flight
       crash) IS replayed.
   (d) Any row whose `requested_at` is older than 24h is NOT replayed.
+
+Per #893, ``settings.database_url`` is monkeypatched to the worker's
+test DB so dispatcher helpers (``publish_manual_job_request`` etc.)
+write to per-worker isolation rather than the operator's dev DB.
 """
 
 from __future__ import annotations
@@ -21,35 +25,35 @@ from typing import Any
 import psycopg
 import pytest
 
-from app.config import settings
 from app.services.sync_orchestrator.dispatcher import (
     publish_manual_job_request,
     publish_sync_request,
     reset_stale_in_flight,
 )
 from app.services.sync_orchestrator.types import SyncScope
-
-
-def _db_reachable() -> bool:
-    try:
-        with psycopg.connect(settings.database_url, connect_timeout=2) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-                cur.fetchone()
-        return True
-    except Exception:
-        return False
-
+from tests.fixtures.ebull_test_db import test_database_url, test_db_available
 
 pytestmark = pytest.mark.skipif(
-    not _db_reachable(),
-    reason="dev Postgres not reachable; queue recovery tests require the real DB",
+    not test_db_available(),
+    reason="ebull_test DB unavailable; queue recovery tests require a real DB",
 )
+
+
+@pytest.fixture(autouse=True)
+def _route_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point dispatcher helpers at the worker's test DB."""
+    monkeypatch.setattr("app.config.settings.database_url", test_database_url())
 
 
 @pytest.fixture()
 def _dev_conn() -> Generator[psycopg.Connection[Any]]:
-    conn = psycopg.connect(settings.database_url, autocommit=True)
+    """Connection to the worker's test DB.
+
+    Name retained for diff-locality with the original file; pre-#893
+    this opened ``settings.database_url`` directly. After migration
+    it points at ``test_database_url()``.
+    """
+    conn = psycopg.connect(test_database_url(), autocommit=True)
     try:
         yield conn
     finally:
@@ -148,9 +152,10 @@ def test_sync_with_running_sync_run_is_replayed(
     the queue request is replayed (NOT EXISTS clause requires terminal
     status; 'running' is non-terminal).
     """
-    # Clear any stale running sync_runs left by other tests so the
-    # partial unique index doesn't reject our INSERT below. The dev DB
-    # is not test-isolated; we have to cooperate with siblings.
+    # Clear any stale running sync_runs left by earlier tests in this
+    # worker so the partial unique index doesn't reject our INSERT
+    # below. Even on the per-worker test DB, sibling tests in the same
+    # worker share state until the next TRUNCATE.
     with _dev_conn.cursor() as cur:
         cur.execute("UPDATE sync_runs SET status='cancelled' WHERE status='running'")
 

--- a/tests/test_mirror_equity.py
+++ b/tests/test_mirror_equity.py
@@ -19,10 +19,14 @@ from tests.fixtures.copy_mirrors import (
     mtm_delta_mirror_fixture,
     no_quote_mirror_fixture,
 )
-from tests.test_operator_setup_race import (
-    _assert_test_db,
-    _test_database_url,
-    _test_db_available,
+from tests.fixtures.ebull_test_db import (
+    assert_test_db as _assert_test_db,
+)
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
 )
 
 pytestmark = pytest.mark.skipif(

--- a/tests/test_operator_setup_race.py
+++ b/tests/test_operator_setup_race.py
@@ -16,9 +16,11 @@ Strategy:
      assert it returns ALREADY_SETUP.
 
 Skipped automatically if no Postgres URL is configured or the DB is
-unreachable -- we never want this test to fail in a CI run that has no
-Postgres at all, but we do want it to fail loudly if the lock is
-removed.
+unreachable.
+
+Per #893, this file delegates DB bootstrap, migration, and assertion
+to ``tests.fixtures.ebull_test_db`` so concurrent pytest invocations
+each operate on their own per-worker private DB.
 """
 
 from __future__ import annotations
@@ -26,213 +28,26 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Iterator
-from pathlib import Path
-from urllib.parse import urlparse, urlunparse
 
 import psycopg
-import psycopg.rows
 import pytest
 
-from app.config import settings  # used by _swap_database to derive test URL
 from app.services.operator_setup import (
     _BOOTSTRAP_LOCK_KEY,
     SetupOutcome,
     perform_setup,
     reset_token_slot_for_tests,
 )
-
-# ---------------------------------------------------------------------------
-# Isolated test database
-# ---------------------------------------------------------------------------
-#
-# This test runs ``TRUNCATE operators, sessions, operator_audit RESTART
-# IDENTITY CASCADE`` and the CASCADE follows the FK from
-# ``broker_credentials.operator_id`` -- so a TRUNCATE here also wipes
-# every saved broker credential. The dev database (typically ``ebull``)
-# holds the user's real operator account and live broker keys, and a
-# pytest run that points at that database destroys their working state
-# without warning. This was discovered the hard way on 2026-04-08 when
-# multiple pytest runs during a PR cycle silently wiped the user's
-# operator + demo eToro key, locking them out of the running app.
-#
-# Fix: derive an isolated ``ebull_test`` database URL from
-# ``settings.database_url`` (same host, same credentials, different
-# database name), create the database if it does not yet exist, apply
-# the project's SQL migrations to it, and run every connection in this
-# test against ``_TEST_DATABASE_URL`` instead of ``settings.database_url``.
-# A paranoid ``_assert_test_db`` guard runs before every TRUNCATE so a
-# future refactor that accidentally re-introduces ``settings.database_url``
-# fails loud instead of silently destroying user data.
-
-_TEST_DB_NAME = "ebull_test"
-_SQL_DIR = Path(__file__).resolve().parents[1] / "sql"
-
-
-def _swap_database(url: str, new_db: str) -> str:
-    """Return *url* with the path component replaced by ``/{new_db}``."""
-    parsed = urlparse(url)
-    return urlunparse(parsed._replace(path=f"/{new_db}"))
-
-
-def _test_database_url() -> str:
-    return _swap_database(settings.database_url, _TEST_DB_NAME)
-
-
-def _admin_database_url() -> str:
-    # Admin connection used only to ``CREATE DATABASE``. Connecting to
-    # the built-in ``postgres`` maintenance DB avoids any chance of
-    # holding a session on the database we are about to create.
-    return _swap_database(settings.database_url, "postgres")
-
-
-def _ensure_test_db_exists() -> None:
-    """Create ``ebull_test`` if it does not yet exist.
-
-    ``CREATE DATABASE`` cannot run inside a transaction, so the admin
-    connection is opened in autocommit mode. Idempotent: if the
-    database already exists we return without touching it.
-    """
-    with psycopg.connect(_admin_database_url(), autocommit=True) as admin:
-        with admin.cursor() as cur:
-            cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (_TEST_DB_NAME,))
-            if cur.fetchone() is None:
-                # Identifier interpolation: _TEST_DB_NAME is a hard-coded
-                # constant, never user input, so SQL injection is not a
-                # concern. The double-quoting still defends against a
-                # future change to the constant.
-                cur.execute(f'CREATE DATABASE "{_TEST_DB_NAME}"')
-
-
-def _apply_migrations_to_test_db() -> None:
-    """Apply every ``sql/NNN_*.sql`` file to the test DB.
-
-    Mirrors ``app/db/migrations.run_migrations`` but targets the test
-    DB URL directly instead of reading ``settings.database_url``. We
-    deliberately do not call ``run_migrations()`` itself because it
-    hard-codes ``settings.database_url`` and re-pointing it would
-    require monkeypatching settings before any other test imports
-    them, which is too fragile to rely on.
-
-    Connection lifecycle mirrors production exactly:
-      1. A dedicated bootstrap connection creates ``schema_migrations``
-         and commits + closes before any migration file runs. This
-         is critical -- if a future migration uses transaction-hostile
-         DDL (e.g. ``CREATE INDEX CONCURRENTLY``), a single shared
-         connection would roll back the entire batch *including the
-         tracking table itself*, leaving the test DB in a half-
-         migrated state with no record and the next run would
-         re-apply every migration and likely error on duplicate
-         objects (BLOCKING comment, PR #129 round 1).
-      2. A reader connection fetches the applied set, then closes.
-      3. Each pending migration file runs in its **own** connection,
-         committing on success and rolling back on failure -- so a
-         single broken migration cannot corrupt the tracking state
-         of the migrations that ran before it. This matches
-         ``app/db/migrations.run_migrations`` line-for-line.
-    """
-    files = sorted(_SQL_DIR.glob("*.sql"))
-    if not files:
-        return
-
-    # 1. Bootstrap: schema_migrations exists and is committed before
-    #    we even look at the migration files.
-    with psycopg.connect(_test_database_url()) as bootstrap:
-        with psycopg.ClientCursor(bootstrap) as cur:
-            cur.execute(
-                "CREATE TABLE IF NOT EXISTS schema_migrations ("
-                "filename TEXT PRIMARY KEY, "
-                "applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW())"
-            )
-        bootstrap.commit()
-
-    # 2. Reader: fetch the applied set on its own connection so the
-    #    per-file connections below see a consistent committed view.
-    with psycopg.connect(_test_database_url()) as reader:
-        with reader.cursor(row_factory=psycopg.rows.tuple_row) as cur:
-            cur.execute("SELECT filename FROM schema_migrations")
-            done = {row[0] for row in cur.fetchall()}
-
-    # 3. Per-file: a fresh connection per migration so a transaction-
-    #    hostile statement in one file cannot poison the tracking
-    #    state of the others.
-    for path in files:
-        if path.name in done:
-            continue
-        sql = path.read_text(encoding="utf-8")
-        with psycopg.connect(_test_database_url()) as conn:
-            try:
-                with psycopg.ClientCursor(conn) as cur:
-                    cur.execute(sql)  # type: ignore[call-overload]
-                    cur.execute(  # type: ignore[call-overload]
-                        "INSERT INTO schema_migrations (filename) VALUES (%s)",
-                        (path.name,),
-                    )
-                conn.commit()
-            except Exception:
-                conn.rollback()
-                raise
-
-
-def _test_db_available() -> bool:
-    """Probe (and lazily create + migrate) the test DB.
-
-    Returns False on any failure -- DNS, refused, auth, permission to
-    CREATE DATABASE, migration error -- so the test skips cleanly in
-    environments without a Postgres at all (and so the user's dev DB
-    is *never* fallen back to as a side effect of an unreachable test
-    DB).
-
-    The exception is logged via ``warnings.warn`` rather than
-    swallowed silently. A bare ``except Exception: return False``
-    looks identical in CI logs whether the cause is "no Postgres at
-    all" (an expected skip) or "configured role lacks CREATEDB"
-    (a real configuration bug masquerading as a clean skip). The
-    warning gives the operator something actionable.
-    """
-    import warnings
-
-    try:
-        _ensure_test_db_exists()
-        _apply_migrations_to_test_db()
-        with psycopg.connect(_test_database_url(), connect_timeout=2) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-        return True
-    except Exception as exc:
-        warnings.warn(
-            f"ebull_test DB unavailable -- {type(exc).__name__}: {exc}. "
-            f"Race test will be skipped. If this is unexpected, check "
-            f"that the configured Postgres role has CREATEDB privilege "
-            f"and that the host/port in EBULL_DATABASE_URL is reachable.",
-            stacklevel=2,
-        )
-        return False
-
-
-pytestmark = pytest.mark.skipif(
-    not _test_db_available(),
-    reason="ebull_test DB unavailable -- skipping real-DB race test",
+from tests.fixtures.ebull_test_db import (
+    assert_test_db,
+    test_database_url,
+    test_db_available,
 )
 
-
-def _assert_test_db(conn: psycopg.Connection[object]) -> None:
-    """Refuse to run a destructive op against anything but ``ebull_test``.
-
-    Paranoid backstop: if a future refactor accidentally passes a
-    connection to ``settings.database_url`` (the dev DB) into the
-    ``clean_operators`` fixture, this guard fails the test loudly
-    instead of silently TRUNCATing the user's working state.
-    """
-    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
-        cur.execute("SELECT current_database()")
-        row = cur.fetchone()
-        assert row is not None
-        db_name = row[0]
-    if db_name != _TEST_DB_NAME:
-        raise RuntimeError(
-            f"Refusing to TRUNCATE: connected to database {db_name!r}, "
-            f"expected {_TEST_DB_NAME!r}. The dev DB must never be wiped by tests."
-        )
+pytestmark = pytest.mark.skipif(
+    not test_db_available(),
+    reason="ebull_test DB unavailable -- skipping real-DB race test",
+)
 
 
 @pytest.fixture
@@ -240,20 +55,19 @@ def clean_operators() -> Iterator[None]:
     """Wipe operators + sessions + audit on the isolated test DB.
 
     Uses TRUNCATE ... CASCADE so any FK-referenced rows are also
-    cleared. Every connection here points at ``ebull_test`` and the
-    ``_assert_test_db`` guard runs before every TRUNCATE so a future
-    refactor cannot regress this back onto the dev DB.
+    cleared. ``_assert_test_db`` runs before every TRUNCATE so a
+    future refactor cannot regress this back onto the dev DB.
     """
-    test_url = _test_database_url()
+    test_url = test_database_url()
     with psycopg.connect(test_url) as conn:
-        _assert_test_db(conn)
+        assert_test_db(conn)
         with conn.cursor() as cur:
             cur.execute("TRUNCATE operators, sessions, operator_audit RESTART IDENTITY CASCADE")
         conn.commit()
     reset_token_slot_for_tests()
     yield
     with psycopg.connect(test_url) as conn:
-        _assert_test_db(conn)
+        assert_test_db(conn)
         with conn.cursor() as cur:
             cur.execute("TRUNCATE operators, sessions, operator_audit RESTART IDENTITY CASCADE")
         conn.commit()
@@ -262,7 +76,7 @@ def clean_operators() -> Iterator[None]:
 
 def test_advisory_lock_serialises_concurrent_setup(clean_operators: None) -> None:
     """A held advisory lock must block perform_setup until released."""
-    test_url = _test_database_url()
+    test_url = test_database_url()
     blocker = psycopg.connect(test_url)
     blocker.autocommit = False
     with blocker.cursor() as cur:

--- a/tests/test_portfolio_review_mirror_equity.py
+++ b/tests/test_portfolio_review_mirror_equity.py
@@ -28,10 +28,14 @@ import pytest
 
 from app.services.portfolio import _load_mirror_equity, run_portfolio_review
 from tests.fixtures.copy_mirrors import mirror_aum_fixture
-from tests.test_operator_setup_race import (
-    _assert_test_db,
-    _test_database_url,
-    _test_db_available,
+from tests.fixtures.ebull_test_db import (
+    assert_test_db as _assert_test_db,
+)
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
 )
 
 pytestmark = pytest.mark.skipif(

--- a/tests/test_portfolio_sync_mirrors.py
+++ b/tests/test_portfolio_sync_mirrors.py
@@ -27,10 +27,14 @@ from tests.fixtures.copy_mirrors import (
     two_mirror_payload,
     two_mirror_seed_rows,
 )
-from tests.test_operator_setup_race import (
-    _assert_test_db,
-    _test_database_url,
-    _test_db_available,
+from tests.fixtures.ebull_test_db import (
+    assert_test_db as _assert_test_db,
+)
+from tests.fixtures.ebull_test_db import (
+    test_database_url as _test_database_url,
+)
+from tests.fixtures.ebull_test_db import (
+    test_db_available as _test_db_available,
 )
 
 pytestmark = pytest.mark.skipif(

--- a/tests/test_sync_orchestrator_dispatcher.py
+++ b/tests/test_sync_orchestrator_dispatcher.py
@@ -1,10 +1,13 @@
 """Unit coverage for ``app.services.sync_orchestrator.dispatcher`` (#719).
 
-Drives every helper against the real dev DB so the SQL itself is
+Drives every helper against a real Postgres so the SQL itself is
 exercised: schema-mismatch bugs (column renamed, status enum drift)
 fail loudly here rather than at first operator click. The helpers are
-pure SQL with no provider I/O, so they're safe to run against the
-shared test DB.
+pure SQL with no provider I/O.
+
+Per #893, ``settings.database_url`` is monkeypatched to the worker's
+test DB so dispatcher helpers (which read the URL at call time) write
+to per-worker isolation rather than the operator's dev DB.
 """
 
 from __future__ import annotations
@@ -16,7 +19,6 @@ import psycopg
 import pytest
 from psycopg.types.json import Jsonb
 
-from app.config import settings
 from app.services.sync_orchestrator.dispatcher import (
     NOTIFY_CHANNEL,
     claim_oldest_pending,
@@ -30,30 +32,29 @@ from app.services.sync_orchestrator.dispatcher import (
     scope_from_json,
 )
 from app.services.sync_orchestrator.types import SyncScope
-
-
-def _db_reachable() -> bool:
-    """Skip the suite cleanly when the dev Postgres isn't running."""
-    try:
-        with psycopg.connect(settings.database_url, connect_timeout=2) as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-                cur.fetchone()
-        return True
-    except Exception:
-        return False
-
+from tests.fixtures.ebull_test_db import test_database_url, test_db_available
 
 pytestmark = pytest.mark.skipif(
-    not _db_reachable(),
-    reason="dev Postgres not reachable; dispatcher tests require the real DB",
+    not test_db_available(),
+    reason="ebull_test DB unavailable; dispatcher tests require a real DB",
 )
+
+
+@pytest.fixture(autouse=True)
+def _route_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point dispatcher helpers at the worker's test DB."""
+    monkeypatch.setattr("app.config.settings.database_url", test_database_url())
 
 
 @pytest.fixture()
 def _dev_conn() -> Generator[psycopg.Connection[Any]]:
-    """A short-lived autocommit connection scoped to one test."""
-    conn = psycopg.connect(settings.database_url, autocommit=True)
+    """A short-lived autocommit connection scoped to one test.
+
+    Name retained for diff-locality; pre-#893 this opened
+    ``test_database_url()``. After migration it points at the
+    worker's test DB.
+    """
+    conn = psycopg.connect(test_database_url(), autocommit=True)
     try:
         yield conn
     finally:
@@ -88,7 +89,7 @@ def test_publish_sync_request_inserts_row_and_notifies(
     """
     # Open a side connection BEFORE publishing so its LISTEN catches
     # the NOTIFY. autocommit ensures the LISTEN takes effect immediately.
-    listener = psycopg.connect(settings.database_url, autocommit=True)
+    listener = psycopg.connect(test_database_url(), autocommit=True)
     try:
         with listener.cursor() as cur:
             cur.execute(f"LISTEN {NOTIFY_CHANNEL}")
@@ -190,7 +191,7 @@ def test_claim_oldest_pending_skips_locked_rows(
     _cleanup_requests.append(int(max_row[0]))
 
     # Hold rid_a in a transaction on conn A.
-    conn_a = psycopg.connect(settings.database_url)
+    conn_a = psycopg.connect(test_database_url())
     try:
         conn_a.execute(
             "SELECT request_id FROM pending_job_requests WHERE request_id=%s FOR UPDATE",

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -297,7 +298,17 @@ dev = [
     { name = "pyright", specifier = ">=1.1.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "ruff", specifier = ">=0.4.0" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -661,6 +672,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Reworks pytest to satisfy issue #893: full suite ≤ 10 min wall-clock,
no concurrent-pytest deadlock, no test writes to operator dev DB.

## Why

Operator pain on `main`: shared `ebull_test` DB, no parallelism, 73-table
TRUNCATE per test, 6 dev-DB writers bypassing the fixture entirely.
Concurrent pytest invocations could deadlock for 10+ min.

## How

- pytest-xdist `-n 4` + per-worker private DB
  `ebull_test_<run_id>_<worker_id>` so concurrent invocations no longer
  share state. Per-invocation `run_id` (epoch-seconds + 6 hex) prevents
  cross-invocation collisions.
- Postgres `CREATE DATABASE … TEMPLATE ebull_test_template` for
  sub-second cold start. Migration-hash invalidation triggers rebuild
  when `sql/*.sql` changes. Controller-only build under
  `EBULL_TEMPLATE_LOCK`. Workers acquire the same lock briefly during
  `CREATE FROM TEMPLATE` so a concurrent rebuild can't mid-copy.
- 6 dev-DB-writer tests migrated off `settings.database_url` onto the
  per-worker test DB (Pattern A direct + Pattern B `monkeypatch`
  for helpers like `publish_manual_job_request`).
- `tests/smoke/test_app_boots.py` keeps its dev-DB lifespan contract
  (CLAUDE.md smoke gate) but is now wrapped in a cluster-wide Postgres
  advisory lock (`EBULL_SMOKE_LIFESPAN_LOCK`) so concurrent invocations
  serialise on lifespan migrations instead of racing them.
- `--basetemp` routed to `${TEMP}/ebull_pytest/<run_id>` outside the
  repo (kills the `tmp_pytest/` Windows lock smell).
- TRUNCATE chunked at 20 tables to stay under
  `max_locks_per_transaction` when 4 workers run simultaneously.
- New helper `tests.fixtures.cleanup_test_dbs` for operator-driven
  recovery after a crashed run.
- Smoke guard at `tests/smoke/test_no_settings_url_in_destructive_paths`
  tightened — allowlist now contains only the documented smoke
  exception + the guard itself.

## Test plan

- [x] `time uv run pytest`: **6m48s, 3786 passed, 1 skipped**.
  Down from baseline >10 min. Within the 5-10 min target.
- [x] `uv run ruff check`, `uv run ruff format --check`,
  `uv run pyright` all green.
- [x] Pre-push gate (lint + format + pyright + pytest + dark-mode
  hygiene) green.
- [x] Codex reviewed across spec v1→v5 (8 + 4 + 1 + 0 BLOCKING)
  plus pre-push review of branch diff (4 findings: ensure_worker_database
  drop+recreate, missing template lock on CREATE FROM TEMPLATE,
  loose assert_test_db prefix match, missing boot-drain cleanup —
  all folded into this commit).
- [x] Concurrent-invocation deadlock test passed: two `uv run pytest`
  shells finish independently, neither hangs.
- [x] Operator dev DB inspected after run — only the documented
  smoke gate writes ever land there (and only its own rows, cleaned
  up by lifespan).

## Out of scope

- Truncate-by-need / opt-in fixture API — high blast radius across
  ~130 files. Follow-up.
- Soft perf-regression gate (durations baseline + 2x slowdown fail) —
  measurement is in (`--durations=20`); enforcement is a follow-up.
- Pre-existing failures #875 + #876 — unrelated to this PR.

Closes #893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)