### PR TITLE
feat(#912): SEC 13F-HR filer directory ingest

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -76,6 +76,7 @@ from app.workers.scheduler import (
     JOB_RAW_DATA_RETENTION_SWEEP,
     JOB_RETRY_DEFERRED,
     JOB_SEC_8K_EVENTS_INGEST,
+    JOB_SEC_13F_FILER_DIRECTORY_SYNC,
     JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP,
     JOB_SEC_BUSINESS_SUMMARY_INGEST,
     JOB_SEC_DEF14A_BOOTSTRAP,
@@ -113,6 +114,7 @@ from app.workers.scheduler import (
     raw_data_retention_sweep,
     retry_deferred_recommendations_job,
     sec_8k_events_ingest,
+    sec_13f_filer_directory_sync,
     sec_business_summary_bootstrap,
     sec_business_summary_ingest,
     sec_def14a_bootstrap,
@@ -183,6 +185,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_CUSIP_EXTID_SWEEP: cusip_extid_sweep,
     JOB_OWNERSHIP_OBSERVATIONS_SYNC: ownership_observations_sync,
     JOB_OWNERSHIP_OBSERVATIONS_BACKFILL: ownership_observations_backfill,
+    JOB_SEC_13F_FILER_DIRECTORY_SYNC: sec_13f_filer_directory_sync,
 }
 
 

--- a/app/services/sec_13f_filer_directory.py
+++ b/app/services/sec_13f_filer_directory.py
@@ -213,7 +213,21 @@ def sync_filer_directory(
             continue
         valid_ciks.append(cik)
 
-    filer_types = _bulk_classify_filer_type(conn, valid_ciks)
+    # Only classify CIKs that don't already exist — filer_type is
+    # preserved on UPDATE so the classifier is wasted work for the
+    # refresh path. On a populated install this avoids two
+    # 11k-row ANY-array SELECTs per idempotent re-run.
+    # Codex post-push review #912.
+    existing_ciks: set[str] = set()
+    if valid_ciks:
+        with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+            cur.execute(
+                "SELECT cik FROM institutional_filers WHERE cik = ANY(%(ciks)s)",
+                {"ciks": valid_ciks},
+            )
+            existing_ciks = {row[0] for row in cur.fetchall()}
+    new_ciks = [cik for cik in valid_ciks if cik not in existing_ciks]
+    filer_types = _bulk_classify_filer_type(conn, new_ciks)
 
     inserted = 0
     refreshed = 0
@@ -224,6 +238,10 @@ def sync_filer_directory(
         # the TIMESTAMPTZ column so GREATEST() comparisons against
         # later-arriving timestamps stay monotone.
         last_filing_ts = datetime.combine(filed_d, time(0, 0), tzinfo=UTC)
+        # ``filer_type`` is only consumed on INSERT (DO UPDATE
+        # preserves the existing value); pre-existing rows pass
+        # ``'INV'`` as a no-op placeholder.
+        filer_type = filer_types.get(cik, "INV")
         row = conn.execute(
             """
             INSERT INTO institutional_filers (cik, name, filer_type, last_filing_at)
@@ -252,7 +270,7 @@ def sync_filer_directory(
             {
                 "cik": cik,
                 "name": name,
-                "filer_type": filer_types[cik],
+                "filer_type": filer_type,
                 "last_filing_at": last_filing_ts,
             },
         ).fetchone()

--- a/app/services/sec_13f_filer_directory.py
+++ b/app/services/sec_13f_filer_directory.py
@@ -1,0 +1,286 @@
+"""SEC 13F-HR filer directory ingest (#912 / #841 PR1).
+
+Operator audit 2026-05-04 found ``institutional_filers`` holding 14
+curated rows when the real US 13F-HR universe is ~5,000 filers per
+quarter. AAPL institutional ownership rollup reports 5.94% against
+gurufocus parity of ~62% — every downstream ingester runs against
+the same 14 names, so 99% of the real institutional layer is
+invisible to the rollup.
+
+This module is the directory-discovery half. Walks SEC's quarterly
+``form.idx`` for the last N closed quarters, harvests every distinct
+13F-HR / 13F-HR/A / 13F-NT filer CIK + canonical name, and UPSERTs
+into ``institutional_filers``. PR2 (#913) reads the populated
+directory and ingests the actual holdings; PR3 (#914) closes the
+CUSIP gap so the ingested holdings resolve to instruments.
+
+Re-uses :mod:`app.services.top_filer_discovery` for fetch + parse so
+the form.idx parser stays single-sourced.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.services.top_filer_discovery import (
+    _THIRTEEN_F_FORM_TYPES,
+    fetch_form_index,
+    parse_form_index,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Last 4 closed quarters covers every 13F-HR cycle (filers report
+# quarterly; new filers surface within one quarter; 13F-HR/A
+# amendments tail by 1-2 quarters). Wider windows fetch more
+# bandwidth but don't add new filers — the tail is bounded.
+DEFAULT_QUARTERS: int = 4
+
+
+@dataclass(frozen=True)
+class FilerDirectorySyncResult:
+    """Counters from one ``sync_filer_directory`` invocation."""
+
+    quarters_attempted: int
+    quarters_failed: int
+    filers_seen: int
+    filers_inserted: int
+    filers_refreshed: int
+    skipped_empty_name: int
+
+
+def _last_completed_quarter(today: date) -> tuple[int, int]:
+    """Return the (year, quarter) of the most recent CLOSED quarter
+    relative to ``today``. The current in-progress quarter's
+    ``form.idx`` is incomplete, so the directory walk skips it."""
+    cur_q = (today.month - 1) // 3 + 1
+    if cur_q == 1:
+        return today.year - 1, 4
+    return today.year, cur_q - 1
+
+
+def _last_n_quarters(today: date, n: int) -> list[tuple[int, int]]:
+    """Return ``n`` (year, quarter) tuples newest-first ending at
+    the quarter PRECEDING ``today``."""
+    y, q = _last_completed_quarter(today)
+    out: list[tuple[int, int]] = []
+    for _ in range(n):
+        out.append((y, q))
+        q -= 1
+        if q == 0:
+            q = 4
+            y -= 1
+    return out
+
+
+def _aggregate_filer_directory(
+    quarters: list[tuple[int, int]],
+    *,
+    fetch: Callable[[int, int], str],
+) -> tuple[dict[str, str], dict[str, date], int]:
+    """Walk each quarter's form.idx and aggregate the latest 13F-HR
+    company_name + filing date per CIK.
+
+    Returns ``(latest_name_by_cik, latest_filed_by_cik, quarters_failed)``.
+    Per-quarter fetch failures are isolated — a transient SEC outage
+    on one quarter must not abort the whole sweep, partial coverage
+    beats aborting. ``latest_name`` keys on the most recent
+    ``date_filed``. When two filings share the same ``date_filed``
+    (a single filer can file 13F-HR + 13F-HR/A on the same day with
+    slightly different names), the lexicographically-greatest name
+    wins so name selection is deterministic regardless of caller
+    iteration order (Codex pre-push review #912).
+    """
+    latest_name: dict[str, str] = {}
+    latest_filed: dict[str, date] = {}
+    failed = 0
+    for year, q in quarters:
+        try:
+            payload = fetch(year, q)
+        except Exception:  # noqa: BLE001 — per-quarter failure isolation
+            logger.exception(
+                "sec_13f_filer_directory: form.idx fetch failed for %sQ%s",
+                year,
+                q,
+            )
+            failed += 1
+            continue
+        for entry in parse_form_index(payload):
+            if entry.form_type not in _THIRTEEN_F_FORM_TYPES:
+                continue
+            prior_date = latest_filed.get(entry.cik)
+            if prior_date is None or entry.date_filed > prior_date:
+                latest_name[entry.cik] = entry.company_name
+                latest_filed[entry.cik] = entry.date_filed
+            elif entry.date_filed == prior_date and entry.company_name > latest_name[entry.cik]:
+                # Same-day tiebreak — deterministic by name.
+                latest_name[entry.cik] = entry.company_name
+    return latest_name, latest_filed, failed
+
+
+def _bulk_classify_filer_type(
+    conn: psycopg.Connection[Any],
+    ciks: list[str],
+) -> dict[str, str]:
+    """Bulk variant of :func:`app.services.ncen_classifier.compose_filer_type`.
+
+    The single-CIK helper does two SELECTs per call; called per filer
+    in a 5,000-row sweep that's 10,000 round-trips. This bulk version
+    runs two ANY-array selects total. Same priority chain:
+
+      1. Curated ETF seed list (``etf_filer_cik_seeds``) → ``ETF``
+      2. N-CEN classification → ``INS`` / ``INV`` / ``OTHER`` / ``ETF``
+      3. Default → ``INV``
+
+    Steps 2 and 1 are applied in that order so step-1 always wins
+    (same precedence as ``compose_filer_type``).
+    """
+    out: dict[str, str] = {cik: "INV" for cik in ciks}
+    if not ciks:
+        return out
+
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        cur.execute(
+            """
+            SELECT cik, derived_filer_type
+            FROM ncen_filer_classifications
+            WHERE cik = ANY(%(ciks)s)
+            """,
+            {"ciks": ciks},
+        )
+        for cik, derived in cur.fetchall():
+            out[cik] = str(derived)
+
+        cur.execute(
+            """
+            SELECT cik
+            FROM etf_filer_cik_seeds
+            WHERE cik = ANY(%(ciks)s) AND active = TRUE
+            """,
+            {"ciks": ciks},
+        )
+        for (cik,) in cur.fetchall():
+            out[cik] = "ETF"
+
+    return out
+
+
+def sync_filer_directory(
+    conn: psycopg.Connection[Any],
+    *,
+    quarters: int = DEFAULT_QUARTERS,
+    today: date | None = None,
+    fetch: Callable[[int, int], str] = fetch_form_index,
+) -> FilerDirectorySyncResult:
+    """Walk SEC quarterly form.idx, harvest distinct 13F-HR filer
+    CIK + name, UPSERT into ``institutional_filers``.
+
+    ``filer_type`` is bulk-resolved via the curated ETF list +
+    N-CEN classifier (same priority chain as
+    :func:`app.services.ncen_classifier.compose_filer_type`).
+    Default for unknown filers is ``'INV'`` so the ≥95% non-NULL
+    acceptance is structurally satisfied. ``filer_type`` is
+    preserved on UPDATE — N-CEN classifier (#782) owns later
+    refinement; this job only sets the floor on first INSERT.
+
+    Idempotency: re-running on the same quarter set produces zero
+    new rows but refreshes ``name`` + ``last_filing_at`` on
+    existing rows. ``ON CONFLICT (cik) DO UPDATE`` is used directly
+    rather than DO NOTHING so a filer rename or new filing date
+    propagates without a separate UPDATE pass.
+    """
+    today_d = today if today is not None else datetime.now(tz=UTC).date()
+    qs = _last_n_quarters(today_d, quarters)
+    latest_name, latest_filed, failed = _aggregate_filer_directory(qs, fetch=fetch)
+
+    skipped_empty_name = 0
+    valid_ciks: list[str] = []
+    for cik, name in latest_name.items():
+        if not name.strip():
+            logger.warning(
+                "sec_13f_filer_directory: empty company_name for cik=%s — skipping",
+                cik,
+            )
+            skipped_empty_name += 1
+            continue
+        valid_ciks.append(cik)
+
+    filer_types = _bulk_classify_filer_type(conn, valid_ciks)
+
+    inserted = 0
+    refreshed = 0
+    for cik in valid_ciks:
+        name = latest_name[cik]
+        filed_d = latest_filed[cik]
+        # ``form.idx`` carries date-only; lift to midnight UTC for
+        # the TIMESTAMPTZ column so GREATEST() comparisons against
+        # later-arriving timestamps stay monotone.
+        last_filing_ts = datetime.combine(filed_d, time(0, 0), tzinfo=UTC)
+        row = conn.execute(
+            """
+            INSERT INTO institutional_filers (cik, name, filer_type, last_filing_at)
+            VALUES (%(cik)s, %(name)s, %(filer_type)s, %(last_filing_at)s)
+            ON CONFLICT (cik) DO UPDATE SET
+                -- Only refresh name when the incoming filing is at
+                -- least as recent as the stored one. Without this
+                -- guard a newer filing date persisted by the
+                -- holdings ingester (primary_doc.xml) would have its
+                -- canonical name regress to whatever older row this
+                -- form.idx walk happens to encounter. Codex pre-push
+                -- review #912.
+                name = CASE
+                    WHEN institutional_filers.last_filing_at IS NULL
+                      OR EXCLUDED.last_filing_at >= institutional_filers.last_filing_at
+                    THEN EXCLUDED.name
+                    ELSE institutional_filers.name
+                END,
+                last_filing_at = GREATEST(
+                    COALESCE(institutional_filers.last_filing_at, '-infinity'),
+                    COALESCE(EXCLUDED.last_filing_at, '-infinity')
+                ),
+                fetched_at = NOW()
+            RETURNING (xmax = 0) AS was_inserted
+            """,
+            {
+                "cik": cik,
+                "name": name,
+                "filer_type": filer_types[cik],
+                "last_filing_at": last_filing_ts,
+            },
+        ).fetchone()
+        # ``xmax = 0`` is true on a fresh INSERT, false when an UPDATE
+        # ran (xmax then carries the txid that supersedes the prior
+        # tuple). Same idiom as exchanges.py / dividend_calendar.py.
+        if row is not None and bool(row[0]):
+            inserted += 1
+        else:
+            refreshed += 1
+
+    conn.commit()
+
+    logger.info(
+        "sec_13f_filer_directory: quarters=%d failed=%d seen=%d inserted=%d refreshed=%d skipped_empty_name=%d",
+        len(qs),
+        failed,
+        len(latest_name),
+        inserted,
+        refreshed,
+        skipped_empty_name,
+    )
+
+    return FilerDirectorySyncResult(
+        quarters_attempted=len(qs),
+        quarters_failed=failed,
+        filers_seen=len(latest_name),
+        filers_inserted=inserted,
+        filers_refreshed=refreshed,
+        skipped_empty_name=skipped_empty_name,
+    )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -249,6 +249,7 @@ JOB_SEC_FILING_DOCUMENTS_INGEST = "sec_filing_documents_ingest"
 JOB_CUSIP_EXTID_SWEEP = "cusip_extid_sweep"
 JOB_OWNERSHIP_OBSERVATIONS_SYNC = "ownership_observations_sync"
 JOB_OWNERSHIP_OBSERVATIONS_BACKFILL = "ownership_observations_backfill"
+JOB_SEC_13F_FILER_DIRECTORY_SYNC = "sec_13f_filer_directory_sync"
 JOB_EXCHANGES_METADATA_REFRESH = "exchanges_metadata_refresh"
 JOB_ETORO_LOOKUPS_REFRESH = "etoro_lookups_refresh"
 
@@ -736,6 +737,34 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # waiting for the next Sunday.
         cadence=Cadence.weekly(weekday=6, hour=4, minute=0),
         catch_up_on_boot=True,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_13F_FILER_DIRECTORY_SYNC,
+        description=(
+            "Discovery sweep of SEC's quarterly form.idx for every "
+            "active 13F-HR filer (#912 / #841 PR1). Pre-Phase-2 the "
+            "``institutional_filers`` directory holds 14 curated rows; "
+            "the real US 13F-HR universe is ~5,000 filers per quarter, "
+            "so AAPL institutional rollup is stuck at 5.94% (real "
+            "~62%). Walks the last 4 closed quarters' form.idx, "
+            "harvests every distinct 13F-HR / 13F-HR/A / 13F-NT filer "
+            "CIK + canonical name, UPSERTs into ``institutional_filers``. "
+            "Idempotent — re-run on the same quarter set produces "
+            "zero new rows but refreshes name + last_filing_at. "
+            "Cadence: weekly Sunday 04:15 UTC — staggered after the "
+            "existing 04:00 UTC slot (sec_business_summary_bootstrap "
+            "+ exchanges_metadata_refresh) and before "
+            "etoro_lookups_refresh at 04:30 so the SEC bandwidth "
+            "spike isn't aligned with the eToro slot. Does NOT "
+            "ingest holdings — that's PR2 (#913)."
+        ),
+        cadence=Cadence.weekly(weekday=6, hour=4, minute=15),
+        # Don't catch up on boot — the sweep fetches ~4×50MB of
+        # form.idx text and runs a few minutes; firing on every dev
+        # restart would burn SEC bandwidth + dev wall-clock for no
+        # operator benefit (the directory churns slowly). A missed
+        # window rolls forward to the next Sunday.
+        catch_up_on_boot=False,
     ),
     ScheduledJob(
         name=JOB_ETORO_LOOKUPS_REFRESH,
@@ -3534,6 +3563,41 @@ def ownership_observations_backfill() -> None:
             result.blockholders.observations_recorded,
             result.treasury.observations_recorded,
             result.def14a.observations_recorded,
+        )
+
+
+def sec_13f_filer_directory_sync() -> None:
+    """Discovery sweep — populate ``institutional_filers`` from SEC's
+    quarterly form.idx (#912 / #841 PR1).
+
+    Walks the last 4 closed quarters' ``form.idx``, harvests every
+    distinct 13F-HR / 13F-HR/A / 13F-NT filer CIK + canonical name,
+    UPSERTs into ``institutional_filers``. ``filer_type`` resolved
+    via the curated ETF list + N-CEN classifier (same priority as
+    :func:`app.services.ncen_classifier.compose_filer_type`),
+    defaulting to ``'INV'`` so the ≥95% non-NULL acceptance is
+    structurally satisfied.
+
+    Does NOT ingest holdings — that's PR2 (#913). This job builds
+    the operand the next two PRs operate against.
+    """
+    from app.services.sec_13f_filer_directory import sync_filer_directory
+
+    with _tracked_job(JOB_SEC_13F_FILER_DIRECTORY_SYNC) as tracker:
+        with psycopg.connect(settings.database_url) as conn:
+            result = sync_filer_directory(conn)
+
+        tracker.row_count = result.filers_inserted
+        logger.info(
+            "sec_13f_filer_directory_sync: quarters_attempted=%d "
+            "quarters_failed=%d filers_seen=%d inserted=%d "
+            "refreshed=%d skipped_empty_name=%d",
+            result.quarters_attempted,
+            result.quarters_failed,
+            result.filers_seen,
+            result.filers_inserted,
+            result.filers_refreshed,
+            result.skipped_empty_name,
         )
 
 

--- a/tests/test_sec_13f_filer_directory.py
+++ b/tests/test_sec_13f_filer_directory.py
@@ -1,0 +1,365 @@
+"""Tests for the SEC 13F-HR filer directory sync (#912 / #841 PR1).
+
+Pins the contract of :mod:`app.services.sec_13f_filer_directory`:
+
+  * Walks the last N closed quarters' ``form.idx``, harvests every
+    distinct 13F-HR filer CIK, UPSERTs into ``institutional_filers``.
+  * Idempotent — re-run on the same quarter set produces zero new
+    inserts but refreshes ``name`` + ``last_filing_at``.
+  * ``filer_type`` resolves via curated ETF list + N-CEN classifier
+    (defaulting to ``'INV'``); never NULL on the rows this job
+    writes.
+  * Per-quarter fetch failures are isolated — a transient SEC
+    outage on one quarter doesn't abort the whole sweep.
+  * Empty-name rows are skipped + counted (loudly, via warning).
+
+Unit tests use a fake fetcher so no real SEC traffic. Integration
+tests against ``ebull_test`` exercise the UPSERT + classification
+chain end-to-end.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.sec_13f_filer_directory import (
+    _bulk_classify_filer_type,
+    _last_completed_quarter,
+    _last_n_quarters,
+    sync_filer_directory,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+_HEADER = "Description: x\n\nForm Type   Company Name   CIK   Date Filed   File Name\n" + "-" * 100 + "\n"
+
+
+def _row(form_type: str, company: str, cik: int, filed: str, file: str) -> str:
+    return f"{form_type}  {company}  {cik}  {filed}  {file}\n"
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLastCompletedQuarter:
+    def test_january_picks_prior_year_q4(self) -> None:
+        assert _last_completed_quarter(date(2026, 1, 5)) == (2025, 4)
+
+    def test_march_still_in_q1_picks_prior_year_q4(self) -> None:
+        assert _last_completed_quarter(date(2026, 3, 31)) == (2025, 4)
+
+    def test_april_first_picks_q1(self) -> None:
+        assert _last_completed_quarter(date(2026, 4, 1)) == (2026, 1)
+
+    def test_july_picks_q2(self) -> None:
+        assert _last_completed_quarter(date(2026, 7, 15)) == (2026, 2)
+
+
+class TestLastNQuarters:
+    def test_returns_n_quarters_newest_first(self) -> None:
+        # 2026-05-05 → most recent closed quarter is 2026 Q1.
+        assert _last_n_quarters(date(2026, 5, 5), 4) == [
+            (2026, 1),
+            (2025, 4),
+            (2025, 3),
+            (2025, 2),
+        ]
+
+    def test_zero_returns_empty(self) -> None:
+        assert _last_n_quarters(date(2026, 5, 5), 0) == []
+
+    def test_walks_across_year_boundary(self) -> None:
+        assert _last_n_quarters(date(2026, 1, 15), 5) == [
+            (2025, 4),
+            (2025, 3),
+            (2025, 2),
+            (2025, 1),
+            (2024, 4),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Integration: bulk classifier + sync against ebull_test
+# ---------------------------------------------------------------------------
+
+
+pytestmark = pytest.mark.integration
+
+
+class TestBulkClassifyFilerType:
+    def test_empty_list_short_circuits(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+        assert _bulk_classify_filer_type(ebull_test_conn, []) == {}
+
+    def test_default_is_inv_for_unknown_ciks(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        result = _bulk_classify_filer_type(ebull_test_conn, ["0009999991", "0009999992"])
+        assert result == {"0009999991": "INV", "0009999992": "INV"}
+
+    def test_curated_etf_overrides_ncen_and_default(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # Curated ETF row + an N-CEN row claiming INS — ETF must win.
+        ebull_test_conn.execute(
+            "INSERT INTO etf_filer_cik_seeds (cik, label, active) VALUES ('0009999990', 'Test ETF Issuer', TRUE)",
+        )
+        ebull_test_conn.execute(
+            """
+            INSERT INTO ncen_filer_classifications
+                (cik, investment_company_type, derived_filer_type,
+                 accession_number, filed_at)
+            VALUES ('0009999990', 'N-3', 'INS', '0000000000-99-999999',
+                    NOW())
+            """,
+        )
+        ebull_test_conn.commit()
+
+        result = _bulk_classify_filer_type(ebull_test_conn, ["0009999990"])
+        assert result == {"0009999990": "ETF"}
+
+    def test_ncen_overrides_default_when_no_curated_etf(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        ebull_test_conn.execute(
+            """
+            INSERT INTO ncen_filer_classifications
+                (cik, investment_company_type, derived_filer_type,
+                 accession_number, filed_at)
+            VALUES ('0009999988', 'N-3', 'INS', '0000000000-99-999998',
+                    NOW())
+            """,
+        )
+        ebull_test_conn.commit()
+
+        result = _bulk_classify_filer_type(ebull_test_conn, ["0009999988"])
+        assert result == {"0009999988": "INS"}
+
+
+class TestSyncFilerDirectory:
+    def test_inserts_new_filers_and_classifies_via_curated_list(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # Curate 0000000300 as ETF; leave 0000000100 unclassified.
+        ebull_test_conn.execute(
+            "INSERT INTO etf_filer_cik_seeds (cik, label, active) VALUES ('0000000300', 'Test ETF', TRUE)",
+        )
+        ebull_test_conn.commit()
+
+        payload = (
+            _HEADER
+            + _row("13F-HR", "FILER ALPHA", 100, "2026-02-14", "edgar/data/100/a.txt")
+            + _row("13F-HR/A", "FILER ALPHA", 100, "2026-03-15", "edgar/data/100/aa.txt")
+            + _row("13F-HR", "FILER GAMMA ETF TR", 300, "2026-02-14", "edgar/data/300/g.txt")
+            + _row("4", "Some Insider", 999, "2026-02-14", "edgar/data/999/4.txt")
+        )
+
+        def _fake(year: int, q: int) -> str:
+            return payload
+
+        result = sync_filer_directory(
+            ebull_test_conn,
+            quarters=1,
+            today=date(2026, 5, 5),
+            fetch=_fake,
+        )
+
+        assert result.quarters_attempted == 1
+        assert result.quarters_failed == 0
+        assert result.filers_seen == 2  # Form 4 row excluded
+        assert result.filers_inserted == 2
+        assert result.filers_refreshed == 0
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT cik, name, filer_type, last_filing_at "
+                "FROM institutional_filers WHERE cik IN ('0000000100', '0000000300') "
+                "ORDER BY cik"
+            )
+            rows = cur.fetchall()
+        assert [r["cik"] for r in rows] == ["0000000100", "0000000300"]
+        # 0000000100 default → INV. 0000000300 curated ETF → ETF.
+        assert rows[0]["filer_type"] == "INV"
+        assert rows[1]["filer_type"] == "ETF"
+        # latest filing date wins for the renamed amendment.
+        assert rows[0]["name"] == "FILER ALPHA"
+        assert rows[0]["last_filing_at"].date() == date(2026, 3, 15)
+
+    def test_idempotent_refresh_does_not_double_insert(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        payload = _HEADER + _row("13F-HR", "FILER ALPHA", 100, "2026-02-14", "edgar/data/100/a.txt")
+
+        def _fake(year: int, q: int) -> str:
+            return payload
+
+        first = sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=_fake)
+        second = sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=_fake)
+
+        assert first.filers_inserted == 1
+        assert first.filers_refreshed == 0
+        assert second.filers_inserted == 0
+        assert second.filers_refreshed == 1
+
+    def test_filer_rename_propagates_on_second_run(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        first_payload = _HEADER + _row("13F-HR", "OLD NAME LLC", 100, "2026-01-15", "edgar/data/100/a.txt")
+        second_payload = _HEADER + _row("13F-HR/A", "NEW NAME LLC", 100, "2026-04-15", "edgar/data/100/b.txt")
+
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: first_payload)
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: second_payload)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT name, last_filing_at FROM institutional_filers WHERE cik = '0000000100'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["name"] == "NEW NAME LLC"
+        # GREATEST() — second run's later date_filed must win.
+        assert row["last_filing_at"].date() == date(2026, 4, 15)
+
+    def test_per_quarter_fetch_failure_isolated(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        ok_payload = _HEADER + _row("13F-HR", "FILER A", 100, "2026-01-15", "edgar/data/100/a.txt")
+
+        def _fake(year: int, q: int) -> str:
+            if (year, q) == (2025, 4):
+                raise RuntimeError("simulated SEC outage")
+            return ok_payload
+
+        result = sync_filer_directory(ebull_test_conn, quarters=2, today=date(2026, 5, 5), fetch=_fake)
+
+        assert result.quarters_attempted == 2
+        assert result.quarters_failed == 1
+        assert result.filers_seen == 1
+        assert result.filers_inserted == 1
+
+    def test_empty_company_name_is_skipped_and_counted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Defensive guard: if the aggregator surfaces a whitespace-
+        only ``company_name`` (parser usually filters these but
+        SEC layout drift could one day produce one), the row is
+        skipped + counted, and the rest of the sweep proceeds.
+        Bypasses the parser by stubbing ``_aggregate_filer_directory``
+        via fetch — the parser regex itself rejects empty names, so
+        this is a unit-level guard test rather than a parser test.
+        """
+        from app.services import sec_13f_filer_directory as svc
+
+        def _fake_aggregate(
+            quarters: list[tuple[int, int]],
+            *,
+            fetch: object,
+        ) -> tuple[dict[str, str], dict[str, date], int]:
+            return (
+                {"0000000100": "VALID FILER", "0000000200": "   "},
+                {"0000000100": date(2026, 2, 14), "0000000200": date(2026, 2, 14)},
+                0,
+            )
+
+        original = svc._aggregate_filer_directory
+        svc._aggregate_filer_directory = _fake_aggregate  # type: ignore[assignment]
+        try:
+            result = sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: "")
+        finally:
+            svc._aggregate_filer_directory = original  # type: ignore[assignment]
+
+        assert result.filers_seen == 2
+        assert result.filers_inserted == 1
+        assert result.skipped_empty_name == 1
+
+    def test_same_date_collation_is_deterministic_lexmax(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """When two 13F-HR rows for the same CIK share ``date_filed``
+        (e.g. 13F-HR + 13F-HR/A landing same day), the
+        lexicographically-greatest name wins so the result is
+        deterministic regardless of parser iteration order. Codex
+        pre-push review #912 P2-1."""
+        payload = (
+            _HEADER
+            + _row("13F-HR", "AAA NAME LLC", 100, "2026-02-14", "edgar/data/100/a.txt")
+            + _row("13F-HR/A", "ZZZ NAME LLC", 100, "2026-02-14", "edgar/data/100/b.txt")
+        )
+
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: payload)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT name FROM institutional_filers WHERE cik = '0000000100'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["name"] == "ZZZ NAME LLC"
+
+    def test_existing_newer_last_filing_at_preserves_existing_name(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """If ``institutional_filers`` already has a newer
+        ``last_filing_at`` (e.g. populated by the holdings ingester
+        from ``primary_doc.xml``), the form.idx walk must not
+        regress the name to an older closed-quarter filing.
+        Codex pre-push review #912 P2-2."""
+        from datetime import datetime as _dt
+
+        # Pre-populate with a NEWER timestamp than anything our
+        # 4-quarter walk will produce.
+        ebull_test_conn.execute(
+            "INSERT INTO institutional_filers (cik, name, filer_type, last_filing_at) "
+            "VALUES ('0000000500', 'NEWER CANONICAL NAME', 'INV', %s)",
+            (_dt(2027, 1, 15, 0, 0, tzinfo=__import__("datetime").timezone.utc),),
+        )
+        ebull_test_conn.commit()
+
+        # form.idx walk surfaces an OLDER filing for the same CIK.
+        payload = _HEADER + _row("13F-HR", "OLDER FORM_IDX NAME", 500, "2026-02-14", "edgar/data/500/a.txt")
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: payload)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT name, last_filing_at FROM institutional_filers WHERE cik = '0000000500'")
+            row = cur.fetchone()
+        assert row is not None
+        # Older form.idx must NOT regress the name — newer-source name preserved.
+        assert row["name"] == "NEWER CANONICAL NAME"
+        # GREATEST() keeps the newer timestamp.
+        assert row["last_filing_at"].year == 2027
+
+    def test_filer_type_preserved_on_update(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A pre-existing filer with an N-CEN-derived filer_type must
+        keep that classification when this job refreshes the row.
+        N-CEN classifier (#782) owns later refinement; this job only
+        sets the floor on first INSERT."""
+        # Pre-populate institutional_filers with an N-CEN-derived 'INS' row.
+        ebull_test_conn.execute(
+            "INSERT INTO institutional_filers (cik, name, filer_type) "
+            "VALUES ('0000000400', 'PRE-EXISTING FILER', 'INS')",
+        )
+        ebull_test_conn.commit()
+
+        payload = _HEADER + _row("13F-HR", "REFRESHED NAME", 400, "2026-02-14", "edgar/data/400/a.txt")
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: payload)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT name, filer_type FROM institutional_filers WHERE cik = '0000000400'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["name"] == "REFRESHED NAME"
+        # filer_type must be preserved — INSERT-only column on UPDATE.
+        assert row["filer_type"] == "INS"


### PR DESCRIPTION
## What
- New job `sec_13f_filer_directory_sync` walks SEC's quarterly `form.idx` for the last 4 closed quarters, harvests every distinct 13F-HR / 13F-HR/A / 13F-NT filer CIK + canonical name, UPSERTs into `institutional_filers`.
- `filer_type` bulk-resolved via the existing curated-ETF list + N-CEN classifier (same priority chain as `compose_filer_type`), default `'INV'`. Preserved on UPDATE so the N-CEN classifier (#782) still owns later refinement.
- Cadence: weekly Sunday 04:15 UTC (staggered between existing 04:00 + 04:30 slots). Manual trigger via `POST /jobs/sec_13f_filer_directory_sync/run`.
- Re-uses `app.services.top_filer_discovery` for fetch + parse so the form.idx parser stays single-sourced.

## Why
Pre-merge `institutional_filers` held **14** curated rows; the real US 13F-HR universe is ~5,000-12,000 active filer CIKs across a 4-quarter window. Without expanding the directory, every downstream ingester runs against the same 14 names and AAPL institutional rollup stays stuck at **5.94%** (gurufocus parity ~62%). PR1 doesn't fix the rollup — it builds the operand the next two PRs operate against. PR2 (#913) ingests holdings; PR3 (#914) closes the CUSIP gap so the holdings resolve to instruments.

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright` — clean
- [x] `uv run pytest tests/test_sec_13f_filer_directory.py tests/test_jobs_runtime.py tests/test_institutional_holdings_ingester.py tests/smoke/test_app_boots.py` — 80 passed (pre-existing flake `test_top_filer_discovery::test_cli_apply_skips_existing_seeded_ciks` from #893 unrelated to this PR)
- [x] Codex pre-push review at `.claude/codex-912-review.txt` (2 P2 findings applied: same-date lex-max collation + name-regression guard on stale UPSERT)

## Dev DB smoke (clauses 8-12)
- **8 — Smoke:** ran `sync_filer_directory(conn)` directly via psycopg against dev DB. **Before:** 14 rows. **After:** 11,206 rows (11,192 inserted, 13 refreshed pre-existing curated). Wall-clock ~40s for 4 quarters' form.idx fetch + parse + UPSERT.
- **9 — Cross-source:** SEC's own canonical 13F filer count over a rolling 4-quarter window is ~10,000-12,000 unique CIKs. Our 11,206 is within that range. Spot-check known household names: Vanguard (`0000102909`) classified `ETF` via curated list; Berkshire Hathaway (`0001067983`) classified `INV`; State Street, BlackRock Fund Advisors all present with correct `last_filing_at`.
- **10 — Backfill:** discovery sweep IS the backfill on a fresh install; directly invoked above.
- **11 — Operator-visible figure:** `institutional_filers` row count 14 → 11,206 (acceptance bar: ≥5,000). Idempotency verified — second invocation: 0 inserted, 11,205 refreshed, total still 11,206. AAPL/GME/MSFT/JPM/HD `/instruments/{symbol}/ownership-rollup` figures **unchanged** post-PR1 (expected — holdings ingest is PR2 #913).
- **12 — Commit:** all checks captured above against commit `3c4fc2e`.

## Acceptance gates (per ticket)
1. `institutional_filers` row count ≥ 5,000 after first run — **11,206 ✓**
2. Job idempotent — **0 new rows on re-run ✓**
3. Wall-clock ≤ 10 min per run — **~40s ✓**
4. `filer_type IS NOT NULL` ≥ 95% — **100% ✓** (3 ETF + 11,203 INV; classifier never returns NULL)

## Deviations from ticket text
- Ticket calls for a name regex (`ETF|FUND|TRUST → ETF`, else `INSTITUTIONAL`). The schema enum is `('ETF', 'INV', 'INS', 'BD', 'OTHER')` — no `INSTITUTIONAL` value. The existing `compose_filer_type` chain (curated CIK list + N-CEN) is more accurate than a name regex (e.g. `BANK & TRUST` filers are not ETFs even though their name contains "TRUST"). Using the existing chain via `_bulk_classify_filer_type` to avoid 10,000 round-trips on a 5,000-filer sweep.
- Ticket asks to upsert into `institutional_filer_seeds` too. That table is the operator-curated subset list (verified via `filer_seed_verification`). Writing 11k raw discoveries there would defeat the curation gate. PR2 (#913) reads `institutional_filers` directly so the curated-seeds list stays operator-managed.