### PR TITLE
feat(#913): SEC 13F-HR universe-sweep job

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,14 @@ class Settings(BaseSettings):
     # SEC EDGAR requires no API key (public API, 10 req/s fair-use limit)
     sec_user_agent: str = "eBull dev@example.com"
 
+    # Soft deadline (seconds) for the universe-wide 13F-HR quarterly
+    # sweep (#913). The sweep walks ~11k filers in ``institutional_filers``;
+    # at ~1-3s per filer the cold first sweep can run several hours.
+    # Already-ingested accessions are tombstoned in
+    # ``institutional_holdings_ingest_log`` so a deadline-interrupted
+    # run resumes the tail on the next weekly fire. Default 6h.
+    sec_13f_sweep_deadline_seconds: float = 6 * 60 * 60
+
     anthropic_api_key: str | None = None
 
     default_portfolio_mode: str = "balanced"

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -77,6 +77,7 @@ from app.workers.scheduler import (
     JOB_RETRY_DEFERRED,
     JOB_SEC_8K_EVENTS_INGEST,
     JOB_SEC_13F_FILER_DIRECTORY_SYNC,
+    JOB_SEC_13F_QUARTERLY_SWEEP,
     JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP,
     JOB_SEC_BUSINESS_SUMMARY_INGEST,
     JOB_SEC_DEF14A_BOOTSTRAP,
@@ -115,6 +116,7 @@ from app.workers.scheduler import (
     retry_deferred_recommendations_job,
     sec_8k_events_ingest,
     sec_13f_filer_directory_sync,
+    sec_13f_quarterly_sweep,
     sec_business_summary_bootstrap,
     sec_business_summary_ingest,
     sec_def14a_bootstrap,
@@ -186,6 +188,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_OWNERSHIP_OBSERVATIONS_SYNC: ownership_observations_sync,
     JOB_OWNERSHIP_OBSERVATIONS_BACKFILL: ownership_observations_backfill,
     JOB_SEC_13F_FILER_DIRECTORY_SYNC: sec_13f_filer_directory_sync,
+    JOB_SEC_13F_QUARTERLY_SWEEP: sec_13f_quarterly_sweep,
 }
 
 

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import xml.etree.ElementTree as ET  # noqa: S405 — only used to catch ET.ParseError on parse failure
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -349,6 +350,27 @@ def _safe_iso_datetime(text: str | None) -> datetime | None:
 
 def _list_active_filer_seeds(conn: psycopg.Connection[tuple]) -> list[str]:
     cur = conn.execute("SELECT cik FROM institutional_filer_seeds WHERE active = TRUE ORDER BY cik")
+    return [_zero_pad_cik(row[0]) for row in cur.fetchall()]
+
+
+def list_directory_filer_ciks(conn: psycopg.Connection[tuple]) -> list[str]:
+    """Walk every CIK in ``institutional_filers`` (the SEC 13F filer
+    directory populated by ``sec_13f_filer_directory_sync`` #912).
+
+    Used by :func:`ingest_directory_filers` (#913) — the universe
+    expansion entrypoint. Returns CIKs ordered by ``last_filing_at``
+    DESC so the most recently active filers are ingested first; a
+    deadline-budget interruption then leaves the long-tail
+    (low-activity filers) for the next sweep without losing the
+    operator-relevant household names.
+    """
+    cur = conn.execute(
+        """
+        SELECT cik
+        FROM institutional_filers
+        ORDER BY last_filing_at DESC NULLS LAST, cik
+        """
+    )
     return [_zero_pad_cik(row[0]) for row in cur.fetchall()]
 
 
@@ -848,18 +870,51 @@ def ingest_filer_13f(
 def ingest_all_active_filers(
     conn: psycopg.Connection[tuple],
     sec: SecArchiveFetcher,
+    *,
+    ciks: list[str] | None = None,
+    deadline_seconds: float | None = None,
+    source_label: str = "sec_edgar_13f",
 ) -> list[IngestSummary]:
-    """Walk every active row in institutional_filer_seeds and ingest."""
-    seeds = _list_active_filer_seeds(conn)
-    if not seeds:
-        logger.info("13F ingest: no active filer seeds; nothing to do")
+    """Walk a list of filer CIKs and ingest each filer's pending 13F-HRs.
+
+    ``ciks`` selects the universe:
+      * ``None`` (default) — walks ``institutional_filer_seeds`` for
+        operator-curated runs (legacy behaviour, kept for backward
+        compat with the existing scheduled trigger).
+      * supplied list — walks exactly those CIKs in order. The new
+        ``sec_13f_quarterly_sweep`` job (#913) passes the universe
+        from ``institutional_filers`` so every filer in the SEC
+        directory gets ingested.
+
+    ``deadline_seconds`` is a soft budget — when exceeded between
+    per-filer iterations, the loop stops cleanly and the partial
+    work commits. Already-ingested accessions are tombstoned in
+    ``institutional_holdings_ingest_log``, so the next sweep
+    resumes against the unprocessed tail rather than redoing work.
+
+    ``source_label`` distinguishes audit trails — the seed-curated
+    run keeps ``sec_edgar_13f`` so existing dashboards aren't
+    perturbed; the universe sweep passes ``sec_edgar_13f_directory``
+    so an operator can grep ``data_ingestion_runs`` to separate the
+    two paths.
+    """
+    if ciks is None:
+        ciks = _list_active_filer_seeds(conn)
+    if not ciks:
+        logger.info("13F ingest: no filer CIKs to ingest; nothing to do")
         return []
+
+    deadline_ts: float | None
+    if deadline_seconds is None:
+        deadline_ts = None
+    else:
+        deadline_ts = time.monotonic() + deadline_seconds
 
     run_id = start_ingestion_run(
         conn,
-        source="sec_edgar_13f",
+        source=source_label,
         endpoint="/Archives/edgar/data/{cik}/{accession}/",
-        instrument_count=len(seeds),
+        instrument_count=len(ciks),
     )
     conn.commit()
 
@@ -869,8 +924,19 @@ def ingest_all_active_filers(
     crash_error: str | None = None
     accession_failures = 0
     first_accession_error: str | None = None
+    deadline_hit = False
+    filers_attempted = 0
     try:
-        for cik in seeds:
+        for cik in ciks:
+            if deadline_ts is not None and time.monotonic() >= deadline_ts:
+                deadline_hit = True
+                logger.info(
+                    "13F ingest: deadline reached after %d/%d filers; remaining will be picked up by the next sweep",
+                    filers_attempted,
+                    len(ciks),
+                )
+                break
+            filers_attempted += 1
             try:
                 summary = ingest_filer_13f(conn, sec, filer_cik=cik, ingestion_run_id=run_id)
             except Exception as exc:  # noqa: BLE001 — per-filer crash must not abort the batch
@@ -887,13 +953,21 @@ def ingest_all_active_filers(
                 first_accession_error = f"{cik} {summary.first_error}"
     finally:
         # Status precedence:
+        #   * deadline hit (work was interrupted, partial by definition)
+        #     -> partial, even if every attempted filer crashed
         #   * any per-filer crash + zero successful summaries -> failed
         #   * any per-filer crash with at least one summary    -> partial
         #   * any per-accession failure across the batch       -> partial
         #   * any per-accession unresolved-CUSIP skip          -> partial
         #     (rows_skipped > 0 indicates partial coverage)
         #   * else                                              -> success
-        if crash_error and not summaries:
+        # Codex pre-push review #913: deadline_hit must beat the
+        # crash-only `failed` branch so an interrupted sweep with
+        # incidental per-filer crashes is correctly classified as
+        # resumable partial work.
+        if deadline_hit:
+            status = "partial"
+        elif crash_error and not summaries:
             status = "failed"
         elif crash_error or accession_failures > 0 or rows_skipped > 0:
             status = "partial"
@@ -914,6 +988,10 @@ def ingest_all_active_filers(
             # just unresolved CUSIPs). Surface the count as the only
             # signal so the operator can correlate with #740.
             error_parts.append(f"{rows_skipped} holdings skipped — CUSIPs unresolved (#740)")
+        if deadline_hit:
+            # Surface the deadline interruption explicitly so the
+            # operator knows the next sweep should resume the tail.
+            error_parts.append(f"deadline reached after {filers_attempted}/{len(ciks)} filers")
         finish_ingestion_run(
             conn,
             run_id=run_id,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -250,6 +250,7 @@ JOB_CUSIP_EXTID_SWEEP = "cusip_extid_sweep"
 JOB_OWNERSHIP_OBSERVATIONS_SYNC = "ownership_observations_sync"
 JOB_OWNERSHIP_OBSERVATIONS_BACKFILL = "ownership_observations_backfill"
 JOB_SEC_13F_FILER_DIRECTORY_SYNC = "sec_13f_filer_directory_sync"
+JOB_SEC_13F_QUARTERLY_SWEEP = "sec_13f_quarterly_sweep"
 JOB_EXCHANGES_METADATA_REFRESH = "exchanges_metadata_refresh"
 JOB_ETORO_LOOKUPS_REFRESH = "etoro_lookups_refresh"
 
@@ -737,6 +738,32 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # waiting for the next Sunday.
         cadence=Cadence.weekly(weekday=6, hour=4, minute=0),
         catch_up_on_boot=True,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_13F_QUARTERLY_SWEEP,
+        description=(
+            "Quarterly sweep — walk every CIK in ``institutional_filers`` "
+            "(populated by sec_13f_filer_directory_sync #912) and ingest "
+            "each filer's pending 13F-HRs through ``ingest_filer_13f`` "
+            "(#913 / #841 PR2). Universe-expansion entrypoint: AAPL "
+            "institutional rollup pre-sweep is 5.94%; gurufocus parity "
+            "~62% requires every active filer's holdings to land. "
+            "Per-filer crashes are isolated; already-ingested accessions "
+            "are tombstoned in institutional_holdings_ingest_log so a "
+            "deadline-interrupted sweep resumes the tail on the next "
+            "fire. Cadence: weekly Saturday 02:00 UTC — 13F-HRs have a "
+            "45-day filing deadline so weekly catches new accessions "
+            "within a week of the universe filing them. ~30 min "
+            "wall-clock in steady state (most filers up-to-date), up "
+            "to ~6h on a cold first sweep against an 11k-filer "
+            "directory. Soft 6h deadline budget keeps the job from "
+            "running unbounded; the next sweep resumes."
+        ),
+        cadence=Cadence.weekly(weekday=5, hour=2, minute=0),
+        # Don't catch up on boot — a missed window costs at most 7 days
+        # of staleness on quarterly-cadence data, and firing a 6h sweep
+        # on every dev restart would burn SEC bandwidth + DB I/O.
+        catch_up_on_boot=False,
     ),
     ScheduledJob(
         name=JOB_SEC_13F_FILER_DIRECTORY_SYNC,
@@ -3563,6 +3590,56 @@ def ownership_observations_backfill() -> None:
             result.blockholders.observations_recorded,
             result.treasury.observations_recorded,
             result.def14a.observations_recorded,
+        )
+
+
+def sec_13f_quarterly_sweep() -> None:
+    """Quarterly sweep — walk every CIK in ``institutional_filers``
+    (populated by ``sec_13f_filer_directory_sync`` #912) and ingest
+    each filer's pending 13F-HR / 13F-HR/A accessions through the
+    existing ``ingest_filer_13f`` per-filer pipeline (#913 / #841 PR2).
+
+    Soft 6h deadline budget — already-ingested accessions are
+    tombstoned in ``institutional_holdings_ingest_log`` so a
+    deadline-interrupted sweep resumes the tail on the next fire.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.institutional_holdings import (
+        ingest_all_active_filers,
+        list_directory_filer_ciks,
+    )
+
+    deadline_seconds = settings.sec_13f_sweep_deadline_seconds
+
+    with _tracked_job(JOB_SEC_13F_QUARTERLY_SWEEP) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            ciks = list_directory_filer_ciks(conn)
+            summaries = ingest_all_active_filers(
+                conn,
+                sec,
+                ciks=ciks,
+                deadline_seconds=deadline_seconds,
+                source_label="sec_edgar_13f_directory",
+            )
+
+        total_filers = len(ciks)
+        processed = len(summaries)
+        rows_upserted = sum(s.holdings_inserted for s in summaries)
+        rows_skipped = sum(s.holdings_skipped_no_cusip for s in summaries)
+        accessions_ingested = sum(s.accessions_ingested for s in summaries)
+        tracker.row_count = rows_upserted
+        logger.info(
+            "sec_13f_quarterly_sweep: filers=%d processed=%d "
+            "accessions_ingested=%d holdings_inserted=%d "
+            "holdings_skipped_no_cusip=%d",
+            total_filers,
+            processed,
+            accessions_ingested,
+            rows_upserted,
+            rows_skipped,
         )
 
 

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -744,6 +744,177 @@ class TestIngestAllActiveFilersDataIngestionRuns:
         assert "accession" in row[1].lower()
 
 
+class TestUniverseSweep:
+    """#913 / #841 PR2: ``ingest_all_active_filers`` ingests every
+    CIK in ``institutional_filers`` (the directory populated by
+    sec_13f_filer_directory_sync #912), with optional deadline budget
+    so a long sweep stops cleanly + resumes next fire."""
+
+    def _build_filer_payloads(
+        self,
+        *,
+        cik: str,
+        accession: str,
+        period: str,
+    ) -> dict[str, str | None]:
+        cik_int = int(cik)
+        primary_doc = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">\n'
+            "  <headerData><filerInfo><filer><credentials>\n"
+            f"    <cik>{cik_int}</cik></credentials></filer></filerInfo></headerData>\n"
+            "  <formData>\n"
+            f"    <coverPage><reportCalendarOrQuarter>{period}</reportCalendarOrQuarter></coverPage>\n"
+            f"    <signatureBlock><signatureDate>{period}</signatureDate></signatureBlock>\n"
+            f"    <filingManager><name>FAKE FILER {cik}</name></filingManager>\n"
+            "    <summaryPage><tableValueTotal>0</tableValueTotal><tableEntryTotal>0</tableEntryTotal></summaryPage>\n"
+            "  </formData>\n"
+            "</edgarSubmission>\n"
+        )
+        infotable = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable" />\n'
+        )
+        archive_base = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession.replace('-', '')}/"
+        return {
+            f"https://data.sec.gov/submissions/CIK{cik}.json": _submissions_json(
+                accessions=[(accession, "13F-HR", period, period)],
+            ),
+            archive_base + "index.json": _archive_index_json(),
+            archive_base + "primary_doc.xml": primary_doc,
+            archive_base + "infotable.xml": infotable,
+        }
+
+    def test_list_directory_filer_ciks_orders_by_last_filing_desc_then_cik(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.institutional_holdings import list_directory_filer_ciks
+
+        # Mix of dated + NULL ``last_filing_at`` rows; expect dated
+        # rows newest-first, then NULL rows ordered by cik.
+        conn = ebull_test_conn
+        conn.execute(
+            "INSERT INTO institutional_filers (cik, name, filer_type, last_filing_at) VALUES "
+            "('0000000300', 'C', 'INV', '2026-03-01'::timestamptz), "
+            "('0000000100', 'A', 'INV', '2026-04-01'::timestamptz), "
+            "('0000000200', 'B', 'INV', NULL), "
+            "('0000000400', 'D', 'INV', NULL)"
+        )
+        conn.commit()
+
+        result = list_directory_filer_ciks(conn)
+        assert result == ["0000000100", "0000000300", "0000000200", "0000000400"]
+
+    def test_explicit_ciks_list_overrides_seed_lookup(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Passing ``ciks=[...]`` walks exactly those CIKs and
+        ignores ``institutional_filer_seeds`` entirely. The
+        sec_13f_quarterly_sweep job uses this to walk the directory."""
+        conn = ebull_test_conn
+        # Seed-list CIK that should NOT be reached.
+        seed_filer(conn, cik="0009999991", label="SEED-ONLY")
+        # Directory CIK that should be reached.
+        _seed_instrument(conn, iid=913_001, symbol="AAPL")
+        _seed_cusip_mapping(conn, instrument_id=913_001, cusip="037833100")
+        conn.commit()
+
+        accession = "0001067983-25-000001"
+        fetcher = _InMemoryFetcher(
+            self._build_filer_payloads(cik="0001067983", accession=accession, period="2024-12-31")
+        )
+
+        summaries = ingest_all_active_filers(
+            conn,
+            fetcher,
+            ciks=["0001067983"],
+            source_label="sec_edgar_13f_directory",
+        )
+
+        # SEED-ONLY filer was NOT contacted.
+        assert not any("0009999991" in url for url in fetcher.calls)
+        # Directory filer WAS contacted.
+        assert any("0001067983" in url for url in fetcher.calls)
+        assert [s.filer_cik for s in summaries] == ["0001067983"]
+
+        # data_ingestion_runs row tagged with the directory source.
+        with conn.cursor() as cur:
+            cur.execute("SELECT source FROM data_ingestion_runs ORDER BY ingestion_run_id DESC LIMIT 1")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "sec_edgar_13f_directory"
+
+    def test_deadline_budget_stops_loop_cleanly_and_records_partial(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A soft deadline interrupts the loop between filers; the
+        partial work commits, ``data_ingestion_runs.error`` records
+        the cut-off so the operator knows the next sweep resumes."""
+        from app.services import institutional_holdings as svc
+
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=913_010, symbol="AAPL")
+        _seed_cusip_mapping(conn, instrument_id=913_010, cusip="037833100")
+        conn.commit()
+
+        # Build payloads for three filers; deadline trips after the
+        # first iteration.
+        payloads: dict[str, str | None] = {}
+        ciks = ["0000000010", "0000000020", "0000000030"]
+        for c in ciks:
+            payloads.update(self._build_filer_payloads(cik=c, accession=f"{c}-25-000001", period="2024-12-31"))
+        fetcher = _InMemoryFetcher(payloads)
+
+        # Stub time.monotonic to fire the deadline immediately AFTER
+        # the first filer iteration. Sequence:
+        #   call 1: deadline_ts = 0 + 1 = 1
+        #   call 2: pre-loop check (filer 0) → 0 < 1, proceed
+        #   call 3+: pre-loop check (filer 1+) → 5 >= 1, deadline_hit
+        # The clock returns the LAST value once exhausted (rather
+        # than raising StopIteration) so any extra deadline checks
+        # added in future refactors don't make the test brittle.
+        # Codex pre-push review #913.
+        clock_ticks = [0.0, 0.0, 5.0]
+        clock_idx = [0]
+
+        def _fake_monotonic() -> float:
+            i = min(clock_idx[0], len(clock_ticks) - 1)
+            clock_idx[0] += 1
+            return clock_ticks[i]
+
+        monkeypatch.setattr(svc.time, "monotonic", _fake_monotonic)
+
+        ingest_all_active_filers(
+            conn,
+            fetcher,
+            ciks=ciks,
+            deadline_seconds=1.0,
+            source_label="sec_edgar_13f_directory",
+        )
+
+        # data_ingestion_runs.error mentions deadline.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT status, error FROM data_ingestion_runs "
+                "WHERE source = 'sec_edgar_13f_directory' "
+                "ORDER BY ingestion_run_id DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "partial"
+        assert row[1] is not None
+        assert "deadline" in row[1].lower()
+
+        # Only the first filer's submissions URL was fetched — the
+        # remaining two never got contacted.
+        contacted_ciks = {c for c in ciks if any(c in url for url in fetcher.calls)}
+        assert contacted_ciks == {"0000000010"}
+
+
 class TestSeedFiler:
     def test_idempotent_seed(
         self,


### PR DESCRIPTION
## What
- New `sec_13f_quarterly_sweep` job (Sat 02:00 UTC, 6h soft deadline) walks every CIK in `institutional_filers` (the directory populated by #912) and ingests each filer's pending 13F-HRs through the existing `ingest_filer_13f` pipeline.
- `list_directory_filer_ciks` reads the directory ordered `last_filing_at DESC NULLS LAST` so the most-active filers ingest first; a deadline-interrupted sweep leaves the long tail for the next fire (already-ingested accessions tombstoned in `institutional_holdings_ingest_log`).
- `ingest_all_active_filers` extended with `ciks=`, `deadline_seconds=`, `source_label=` kwargs. Default behaviour preserved — caller-less invocation still walks `institutional_filer_seeds` (legacy curated-seed runs untouched).
- `data_ingestion_runs.source` distinguishes the paths: `sec_edgar_13f` (seeds) vs `sec_edgar_13f_directory` (universe sweep) — audit dashboards can separate the two.
- New `settings.sec_13f_sweep_deadline_seconds` (default 6h).

## Why
Pre-merge: AAPL institutional rollup at 5.94% (gurufocus parity ~62%). #912 populated the filer directory (14 → 11,206 rows). PR2 ingests their actual holdings. After PR3 (#914) closes the CUSIP coverage gap, AAPL is expected to move toward 50-65%.

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright` — clean
- [x] `uv run pytest tests/test_institutional_holdings_ingester.py tests/test_jobs_runtime.py` — 64 passed (3 new tests in `TestUniverseSweep` class)
- [x] Codex pre-push review at `.claude/codex-913-review.txt` (3 P2 findings applied: deadline_hit precedence over crash-only failed, filers_attempted counter pre-increment, robust fake clock in test)
- [x] Codex license review of EdgarTools at `.claude/codex-913-license.txt` (deferred to #925 — see deviations)

## Dev DB smoke (clauses 8-12)
- **8 — Smoke:** 120s deadline + 30-CIK sample on dev DB. Result: 2 filers fully processed (`0000278331` no new accessions, `0000312069` ingested 41 accessions), 3,704 `institutional_holdings` rows inserted (5,882 → 9,586), deadline tripped after filer 2/30. Loop stopped cleanly; `data_ingestion_runs.error` records `"deadline reached after 2/30 filers"`. Tombstone log carries every attempted accession so the next fire resumes the tail.
- **9 — Cross-source:** N/A for this PR — actual rollup parity is gated on PR3 (#914 CUSIP coverage). Confirmed mechanism: 377,517 holdings skipped on the smoke sample due to unresolved CUSIPs, exactly the gap #914 closes.
- **10 — Backfill:** quarterly sweep IS the backfill; smoke run above invoked the new entrypoint directly.
- **11 — Operator-visible figure:** AAPL/GME/MSFT/JPM/HD `/instruments/{symbol}/ownership-rollup` figures unchanged post-#913 (expected — CUSIP gap blocks resolution until #914).
- **12 — Commit:** all checks captured against commit `4209fe0`.

## Deviations from ticket text
- **EdgarTools adoption deferred to follow-up #925.** Codex license/maintenance review (`.claude/codex-913-license.txt`): MIT, active maintenance, but single-maintainer + fast-moving (3.0 → 5.0 in 14 months) + broad-exception-swallowing concern. Tight pin recommended (`==5.30.2`, `<5.31.0`). Ships universe-sweep data win first against the well-tested bespoke parser; EdgarTools is a clean second PR with golden-file regression. #925 filed with the full migration scope.
- **Sweep walks `institutional_filers` (directory ~11k) not `institutional_filer_seeds` (curated 14).** Ticket body's "Scope" line said seeds; ticket "Why" + spec require directory walk to move AAPL needle. Resolved per spec intent + operator confirmation.

## Acceptance gates
1. ≥80% population coverage of trailing-quarter 13F-HRs — pending PR3 (#914) for CUSIP resolution; mechanism verified.
2. Performance ≤8h on dev — 6h soft deadline; already-ingested tombstone keeps subsequent sweeps fast in steady state.
3. `cusip_extid_sweep` (#836) auto-runs after sweep — already wired daily 04:50 UTC.
4. Per-filer crash isolated — pre-existing pattern preserved; new test pins it under directory-walk.