### PR TITLE
feat(#917): N-PORT mutual-fund holdings ingest + ownership_funds schema

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -36,6 +36,16 @@ class Settings(BaseSettings):
     # run resumes the tail on the next weekly fire. Default 6h.
     sec_13f_sweep_deadline_seconds: float = 6 * 60 * 60
 
+    # Soft deadline (seconds) for the monthly NPORT-P fund-holdings
+    # sweep (#917). Same shape as the 13F sweep — already-attempted
+    # accessions are tombstoned in ``n_port_ingest_log`` so a
+    # deadline-interrupted run resumes on the next monthly fire.
+    # Default 6h. The MVP universe walks the
+    # ``institutional_filers`` rows where ``filer_type IN ('INV', 'INS', 'ETF')``;
+    # not every RIC is in that list, so coverage is partial until a
+    # dedicated fund-filer directory walk lands as a follow-up.
+    sec_n_port_sweep_deadline_seconds: float = 6 * 60 * 60
+
     anthropic_api_key: str | None = None
 
     default_portfolio_mode: str = "balanced"

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -88,6 +88,7 @@ from app.workers.scheduler import (
     JOB_SEC_FORM3_INGEST,
     JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
     JOB_SEC_INSIDER_TRANSACTIONS_INGEST,
+    JOB_SEC_N_PORT_INGEST,
     JOB_SEED_COST_MODELS,
     JOB_WEEKLY_REPORT,
     SCHEDULED_JOBS,
@@ -128,6 +129,7 @@ from app.workers.scheduler import (
     sec_form3_ingest,
     sec_insider_transactions_backfill,
     sec_insider_transactions_ingest,
+    sec_n_port_ingest,
     seed_cost_models,
     weekly_report,
 )
@@ -192,6 +194,7 @@ _INVOKERS: Final[dict[str, Callable[[], None]]] = {
     JOB_OWNERSHIP_OBSERVATIONS_BACKFILL: ownership_observations_backfill,
     JOB_SEC_13F_FILER_DIRECTORY_SYNC: sec_13f_filer_directory_sync,
     JOB_SEC_13F_QUARTERLY_SWEEP: sec_13f_quarterly_sweep,
+    JOB_SEC_N_PORT_INGEST: sec_n_port_ingest,
 }
 
 

--- a/app/services/n_port_ingest.py
+++ b/app/services/n_port_ingest.py
@@ -1,0 +1,1043 @@
+"""SEC N-PORT mutual-fund holdings ingester (#917 — Phase 3 PR1).
+
+Walks each fund-filer CIK's submissions index, ingests every pending
+NPORT-P / NPORT-P/A accession into ``ownership_funds_observations``,
+and refreshes ``ownership_funds_current`` per touched issuer.
+
+This is the public-quarterly slice of N-PORT (Form NPORT-P): SEC
+publishes one quarterly snapshot per fund series, 60 days after the
+period_end. The monthly-internal NPORT-MFP filings remain
+confidential and are not in scope.
+
+Spec:
+docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md
+(Phase 3, §"Source matrix" + §"Per-category natural keys").
+
+## Parser posture — lxml-direct, NOT EdgarTools
+
+The spec recommended EdgarTools as a parser dep. The codebase already
+parses 13F-HR / 13D/G / Form 4 with stdlib ``xml.etree.ElementTree``;
+extending that pattern to N-PORT keeps the parser self-contained,
+zero-dep, and offline-deterministic. The EdgarTools 13F drop-in is
+tracked separately as #925; if N-PORT parsing turns out to need
+EdgarTools' fallback heuristics, that's a follow-up — for now the
+hand-rolled parser covers every well-formed NPORT-P SEC publishes
+(per the EDGAR XSD).
+
+Codex pre-impl review (2026-05-05) findings folded in:
+
+* #1 — both ``NPORT-P`` / ``NPORT-P/A`` (current SEC spelling) and
+  ``N-PORT`` / ``N-PORT/A`` (legacy spelling) accepted by the
+  submissions-index walker.
+* #2 — filings missing a ``seriesId`` raise ``NPortMissingSeriesError``
+  and tombstone as ``failed`` instead of synthesising a collision-prone
+  fallback identity.
+* #3 + #4 — equity-common + Long-payoff guards live in
+  ``record_fund_observation`` (not just here) so test seeders inherit
+  the guards.
+* #5 — refresh ordering by ``filed_at DESC`` so amendments win.
+* #6 — parser is pure XML-in / dataclass-out; no network calls
+  during parse. Test in ``tests/services/test_n_port_ingest.py``
+  proves the offline guarantee by raising on every HTTP client.
+* #11 — ingest log measures parsed accessions, not row dimension.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import xml.etree.ElementTree as ET  # noqa: S405 — we only use ET to catch ParseError on malformed input
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
+from uuid import uuid4
+
+import psycopg
+
+from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
+from app.services.ownership_observations import (
+    record_fund_observation,
+    refresh_funds_current,
+    upsert_sec_fund_series,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Bumped when ``parse_n_port_payload`` semantics change in a way that
+# affects what lands in ``ownership_funds_observations``. Re-wash
+# workflows compare against this constant and reset
+# ``filing_raw_documents.parser_version`` mismatches back to ``pending``
+# in the manifest worker (#869).
+_PARSER_VERSION_NPORT = "nport-v1"
+
+
+# Both spellings appear in the SEC submissions API. The current
+# canonical spelling is ``NPORT-P`` (post-2018); ``N-PORT`` is the
+# pre-2018 legacy spelling that still surfaces on some amendments.
+# Codex pre-impl review #1.
+_NPORT_FORM_TYPES: frozenset[str] = frozenset(
+    {
+        "NPORT-P",
+        "NPORT-P/A",
+        "N-PORT",
+        "N-PORT/A",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Provider contract
+# ---------------------------------------------------------------------------
+
+
+class SecArchiveFetcher(Protocol):
+    """Subset of the SEC EDGAR provider this ingester relies on.
+
+    Same shape as :class:`app.services.institutional_holdings.SecArchiveFetcher`;
+    duplicated here to keep the N-PORT service decoupled from the 13F
+    service. Production binding is :class:`app.providers.implementations.
+    sec_edgar.SecFilingsProvider`.
+    """
+
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AccessionRef:
+    """One discovered NPORT-P accession to ingest."""
+
+    accession_number: str
+    filing_type: str
+    period_of_report: date | None
+    filed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class NPortHolding:
+    """One per-issuer holding row from an NPORT-P invstOrSec entry.
+
+    Captures both the canonical share-position fields (``cusip``,
+    ``shares``, ``value_usd``) and the SEC categorisation fields
+    (``payoff_profile``, ``asset_category``, ``issuer_category``,
+    ``units``) needed by the equity-common-Long write-side guard.
+
+    ``units`` (Codex pre-push review #3): ``'NS'`` = number of shares,
+    ``'PA'`` = principal amount (debt). The ingester rejects any
+    non-``'NS'`` units even when ``asset_category='EC'`` — a Long EC
+    convertible-bond holding reports a balance in PA and would be
+    silently treated as shares without this guard.
+    """
+
+    cusip: str
+    issuer_name: str
+    shares: Decimal
+    value_usd: Decimal | None
+    payoff_profile: str  # raw enum: 'Long' | 'Short' | other
+    asset_category: str  # raw assetCat: 'EC' | 'EP' | 'DBT' | 'DV' | etc.
+    issuer_category: str  # raw issuerCat: informational only
+    units: str  # raw units: 'NS' | 'PA' | 'OU' | etc.
+
+
+@dataclass(frozen=True)
+class NPortFiling:
+    """Header + holdings extracted from one NPORT-P primary doc.
+
+    ``filed_at`` is ``None`` when the primary doc lacks an explicit
+    header timestamp — the ingester falls back to the submissions-index
+    ``filingDate`` for that accession. Codex pre-push review (2026-05-05)
+    finding #1: never silently default to ``period_end`` midnight inside
+    the parser, because two filings with the same period (NPORT-P +
+    NPORT-P/A) would then carry identical ``filed_at`` values and the
+    ``_current`` refresh tie-break would pick the wrong one.
+    """
+
+    filer_cik: str
+    series_id: str
+    series_name: str
+    period_end: date
+    filed_at: datetime | None
+    holdings: tuple[NPortHolding, ...]
+
+
+@dataclass(frozen=True)
+class IngestSummary:
+    """Per-CIK rollup of one ingest pass."""
+
+    filer_cik: str
+    accessions_seen: int
+    accessions_ingested: int
+    accessions_failed: int
+    holdings_inserted: int
+    holdings_skipped_no_cusip: int
+    holdings_skipped_non_equity: int
+    holdings_skipped_short: int
+    holdings_skipped_non_share_units: int
+    holdings_skipped_zero_shares: int
+    first_error: str | None = None
+
+
+@dataclass(frozen=True)
+class _AccessionOutcome:
+    """Internal: per-accession ingest outcome."""
+
+    status: str
+    holdings_inserted: int
+    holdings_skipped_no_cusip: int
+    holdings_skipped_non_equity: int
+    holdings_skipped_short: int
+    holdings_skipped_non_share_units: int
+    holdings_skipped_zero_shares: int
+    error: str | None
+    series_id: str | None
+    period_of_report: date | None
+
+    @property
+    def ingested(self) -> bool:
+        return self.status in ("success", "partial")
+
+
+# ---------------------------------------------------------------------------
+# Custom exceptions
+# ---------------------------------------------------------------------------
+
+
+class NPortParseError(ValueError):
+    """Malformed N-PORT XML; accession tombstoned as ``failed``."""
+
+
+class NPortMissingSeriesError(NPortParseError):
+    """N-PORT primary doc had no ``seriesId``. Codex pre-impl review #2:
+    we refuse to synthesise a fallback identity — colliding rows would
+    produce silent over-counting in the rollup."""
+
+
+# ---------------------------------------------------------------------------
+# URL builders (mirror institutional_holdings.py)
+# ---------------------------------------------------------------------------
+
+
+_SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
+_ARCHIVE_URL = "https://www.sec.gov/Archives/edgar/data/{cik_int}/{accn_no_dashes}/{filename}"
+
+
+def _zero_pad_cik(cik: str | int) -> str:
+    return str(int(str(cik).strip())).zfill(10)
+
+
+def _accession_no_dashes(accession_number: str) -> str:
+    return accession_number.replace("-", "")
+
+
+def _submissions_url(cik: str) -> str:
+    return _SUBMISSIONS_URL.format(cik=_zero_pad_cik(cik))
+
+
+def _archive_file_url(cik: str, accession_number: str, filename: str) -> str:
+    return _ARCHIVE_URL.format(
+        cik_int=int(_zero_pad_cik(cik)),
+        accn_no_dashes=_accession_no_dashes(accession_number),
+        filename=filename,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Submissions index walker
+# ---------------------------------------------------------------------------
+
+
+def parse_submissions_index(payload: str) -> list[AccessionRef]:
+    """Walk ``data.sec.gov/submissions/CIK{cik}.json`` and emit one
+    :class:`AccessionRef` per NPORT-P / NPORT-P/A row.
+
+    Older-history shards via ``filings.files`` are out of scope here —
+    the ``recent`` array holds the most recent ~1,000 filings per CIK
+    which covers ≥ 12 quarters of monthly N-PORT for any actively
+    filing fund family.
+    """
+    try:
+        data: dict[str, Any] = json.loads(payload)
+    except json.JSONDecodeError:
+        logger.warning("n_port submissions index payload is not valid JSON")
+        return []
+
+    filings = data.get("filings", {})
+    recent = filings.get("recent", {})
+    accessions = recent.get("accessionNumber", [])
+    forms = recent.get("form", [])
+    filing_dates = recent.get("filingDate", [])
+    report_dates = recent.get("reportDate", [])
+
+    out: list[AccessionRef] = []
+    for i, accession in enumerate(accessions):
+        if i >= len(forms):
+            break
+        form = str(forms[i])
+        if form not in _NPORT_FORM_TYPES:
+            continue
+        filed_at = _safe_iso_datetime(filing_dates[i] if i < len(filing_dates) else "")
+        period = _safe_iso_date(report_dates[i] if i < len(report_dates) else "")
+        out.append(
+            AccessionRef(
+                accession_number=str(accession),
+                filing_type=form,
+                period_of_report=period,
+                filed_at=filed_at,
+            )
+        )
+    return out
+
+
+def _safe_iso_date(text: str | None) -> date | None:
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _safe_iso_datetime(text: str | None) -> datetime | None:
+    parsed = _safe_iso_date(text)
+    if parsed is None:
+        return None
+    return datetime(parsed.year, parsed.month, parsed.day, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# N-PORT XML parser
+# ---------------------------------------------------------------------------
+
+
+# N-PORT publishes XBRL-shaped XML under the SEC ``edgar/nport``
+# namespace. The relevant elements live under
+# ``{nport}genInfo`` (header) and ``{nport}invstOrSecs/invstOrSec``
+# (per-holding records). The parser is namespace-aware to defend
+# against SEC's namespace evolutions across N-PORT-1 → N-PORT-2 → etc.
+# ``ET.iterparse`` could be used for memory savings on >1MB files but
+# in practice N-PORT XMLs land at 200KB-2MB; ``fromstring`` is fine.
+def _stripns(tag: str) -> str:
+    """Drop XML namespace prefix: ``{ns}foo`` → ``foo``."""
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _find_text(elem: ET.Element, *, local_name: str) -> str | None:
+    """Return the text of the first descendant whose local-name
+    (namespace-stripped) matches ``local_name``, or ``None``."""
+    for child in elem.iter():
+        if _stripns(child.tag) == local_name:
+            text = (child.text or "").strip()
+            return text or None
+    return None
+
+
+def _children_by_local_name(elem: ET.Element, *, local_name: str) -> list[ET.Element]:
+    """Direct-children filter by local name (not full descendant scan)."""
+    return [c for c in elem if _stripns(c.tag) == local_name]
+
+
+def _decimal_or_none(text: str | None) -> Decimal | None:
+    if not text:
+        return None
+    try:
+        return Decimal(text.strip())
+    except InvalidOperation, AttributeError:
+        return None
+
+
+def parse_n_port_payload(xml: str) -> NPortFiling:
+    """Parse an NPORT-P primary doc XML into an :class:`NPortFiling`.
+
+    Pure XML-in / dataclass-out — no network calls, no DB access.
+    Raises :class:`NPortParseError` on malformed XML, or
+    :class:`NPortMissingSeriesError` if the filing has no ``seriesId``.
+
+    Holdings are emitted in document order. The ingester filters /
+    transforms downstream — this parser surfaces every well-formed
+    holding without applying business logic (debt / short / preferred
+    rows are surfaced; the ingester drops them via the equity-common
+    guard).
+    """
+    try:
+        root = ET.fromstring(xml)  # noqa: S314 — we accept SEC-published XML; parser is stdlib, no DTD resolution
+    except ET.ParseError as exc:
+        raise NPortParseError(f"NPORT-P XML parse failed: {exc}") from exc
+
+    # ----- header (genInfo + filer identity) -----
+    # The NPORT-P XML carries:
+    #   formData/genInfo/regCik         — registered investment company CIK
+    #   formData/genInfo/seriesId       — SEC series identifier (S0000xxxxx)
+    #   formData/genInfo/seriesName     — fund series human-readable name
+    #   formData/genInfo/repPdEnd       — period_of_report end date
+    #   headerData/filerInfo/filer/issuerCredentials/cik (for the registrant)
+    # Walk by local-name to be robust to namespace versioning.
+    cik_text = _find_text(root, local_name="regCik") or _find_text(root, local_name="cik")
+    series_id = _find_text(root, local_name="seriesId")
+    series_name = _find_text(root, local_name="seriesName") or ""
+    period_end_text = _find_text(root, local_name="repPdEnd")
+    filed_at_text = _find_text(root, local_name="filedAt") or _find_text(root, local_name="acceptedDate")
+
+    if not cik_text:
+        raise NPortParseError("NPORT-P: missing regCik / cik in header")
+    if not series_id:
+        # Codex pre-impl review #2 — refuse to synthesise.
+        raise NPortMissingSeriesError(
+            "NPORT-P: missing seriesId in genInfo header; refusing to "
+            "synthesise an identity. Filing tombstoned for operator review."
+        )
+    if not period_end_text:
+        raise NPortParseError("NPORT-P: missing repPdEnd in genInfo header")
+
+    period_end = _safe_iso_date(period_end_text)
+    if period_end is None:
+        raise NPortParseError(f"NPORT-P: malformed repPdEnd={period_end_text!r}")
+
+    # Codex pre-push review #1: do NOT default ``filed_at`` to
+    # ``period_end`` midnight inside the parser. Two filings sharing a
+    # period (NPORT-P + NPORT-P/A) would then carry identical
+    # ``filed_at`` values and the ``_current`` refresh tie-break would
+    # pick the wrong one. The ingester layers in the submissions-index
+    # ``filingDate`` (always present in the ``recent`` array) before
+    # any midnight fallback — see ``_ingest_single_accession``.
+    filed_at = _safe_iso_datetime(filed_at_text)
+
+    # ----- holdings -----
+    holdings: list[NPortHolding] = []
+    for holding_elem in root.iter():
+        if _stripns(holding_elem.tag) != "invstOrSec":
+            continue
+        cusip = _find_text(holding_elem, local_name="cusip") or ""
+        issuer_name = _find_text(holding_elem, local_name="name") or ""
+        balance_text = _find_text(holding_elem, local_name="balance")
+        value_text = _find_text(holding_elem, local_name="valUSD")
+        payoff_profile = _find_text(holding_elem, local_name="payoffProfile") or ""
+        asset_cat = _find_text(holding_elem, local_name="assetCat") or ""
+        issuer_cat = _find_text(holding_elem, local_name="issuerCat") or ""
+        units = _find_text(holding_elem, local_name="units") or ""
+
+        balance = _decimal_or_none(balance_text)
+        if balance is None:
+            # No balance = unparseable holding; skip silently. The
+            # ingester counts these via the parser-failure path.
+            continue
+
+        holdings.append(
+            NPortHolding(
+                cusip=cusip.strip().upper(),
+                issuer_name=issuer_name,
+                shares=balance,
+                value_usd=_decimal_or_none(value_text),
+                payoff_profile=payoff_profile,
+                asset_category=asset_cat,
+                issuer_category=issuer_cat,
+                units=units,
+            )
+        )
+
+    return NPortFiling(
+        filer_cik=_zero_pad_cik(cik_text),
+        series_id=series_id,
+        series_name=series_name,
+        period_end=period_end,
+        filed_at=filed_at,
+        holdings=tuple(holdings),
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _existing_accessions_for_fund_filer(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+) -> set[str]:
+    """Return every accession previously attempted for this CIK.
+
+    Reads from ``n_port_ingest_log`` regardless of status — same
+    contract as ``_existing_accessions_for_filer`` in the 13F path."""
+    cur = conn.execute(
+        "SELECT accession_number FROM n_port_ingest_log WHERE filer_cik = %(cik)s",
+        {"cik": filer_cik},
+    )
+    return {row[0] for row in cur.fetchall()}
+
+
+def _record_ingest_attempt(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+    accession_number: str,
+    fund_series_id: str | None,
+    period_of_report: date | None,
+    status: str,
+    holdings_inserted: int = 0,
+    holdings_skipped: int = 0,
+    error: str | None = None,
+) -> None:
+    """Idempotent upsert into ``n_port_ingest_log``. Re-record on
+    follow-up runs so a 'failed' or 'partial' can promote to
+    'success' once the underlying issue clears (parser bump, CUSIP
+    backfill landing, etc.)."""
+    conn.execute(
+        """
+        INSERT INTO n_port_ingest_log (
+            accession_number, filer_cik, fund_series_id, period_of_report,
+            status, holdings_inserted, holdings_skipped, error
+        ) VALUES (
+            %(accession)s, %(cik)s, %(series)s, %(period)s,
+            %(status)s, %(inserted)s, %(skipped)s, %(error)s
+        )
+        ON CONFLICT (accession_number) DO UPDATE SET
+            fund_series_id = EXCLUDED.fund_series_id,
+            period_of_report = EXCLUDED.period_of_report,
+            status = EXCLUDED.status,
+            holdings_inserted = EXCLUDED.holdings_inserted,
+            holdings_skipped = EXCLUDED.holdings_skipped,
+            error = EXCLUDED.error,
+            fetched_at = NOW()
+        """,
+        {
+            "accession": accession_number,
+            "cik": filer_cik,
+            "series": fund_series_id,
+            "period": period_of_report,
+            "status": status,
+            "inserted": holdings_inserted,
+            "skipped": holdings_skipped,
+            "error": error,
+        },
+    )
+
+
+def _resolve_cusip_to_instrument_id(
+    conn: psycopg.Connection[tuple],
+    cusip: str,
+) -> int | None:
+    """Resolve CUSIP via ``external_identifiers``. Same contract as
+    the 13F path."""
+    if not cusip or len(cusip.strip()) != 9:
+        return None
+    cur = conn.execute(
+        """
+        SELECT instrument_id
+        FROM external_identifiers
+        WHERE provider = 'sec'
+          AND identifier_type = 'cusip'
+          AND identifier_value = %(cusip)s
+        ORDER BY is_primary DESC, external_identifier_id ASC
+        LIMIT 1
+        """,
+        {"cusip": cusip.strip().upper()},
+    )
+    row = cur.fetchone()
+    return int(row[0]) if row is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Public ingest entry points
+# ---------------------------------------------------------------------------
+
+
+def ingest_fund_n_port(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+    *,
+    filer_cik: str,
+) -> IngestSummary:
+    """Fetch + parse + upsert every pending NPORT-P for one fund-filer
+    CIK. Per-accession failures are isolated (logged + tombstoned) so
+    a single malformed accession does not abort the filer batch."""
+    cik = _zero_pad_cik(filer_cik)
+    summary = _MutableSummary(cik=cik)
+
+    submissions_payload = sec.fetch_document_text(_submissions_url(cik))
+    if submissions_payload is None:
+        logger.info("n_port ingest: submissions JSON 404/error for cik=%s", cik)
+        return summary.to_immutable()
+
+    pending = parse_submissions_index(submissions_payload)
+    summary.accessions_seen = len(pending)
+    if not pending:
+        return summary.to_immutable()
+
+    already = _existing_accessions_for_fund_filer(conn, filer_cik=cik)
+
+    for ref in pending:
+        if ref.accession_number in already:
+            continue
+        outcome = _ingest_single_accession(conn, sec, filer_cik=cik, ref=ref)
+        _record_ingest_attempt(
+            conn,
+            filer_cik=cik,
+            accession_number=ref.accession_number,
+            fund_series_id=outcome.series_id,
+            period_of_report=outcome.period_of_report or ref.period_of_report,
+            status=outcome.status,
+            holdings_inserted=outcome.holdings_inserted,
+            holdings_skipped=outcome.holdings_skipped_no_cusip
+            + outcome.holdings_skipped_non_equity
+            + outcome.holdings_skipped_short
+            + outcome.holdings_skipped_non_share_units
+            + outcome.holdings_skipped_zero_shares,
+            error=outcome.error,
+        )
+        if outcome.ingested:
+            summary.accessions_ingested += 1
+        else:
+            summary.accessions_failed += 1
+            if outcome.error and summary.first_error is None:
+                summary.first_error = f"{ref.accession_number}: {outcome.error}"
+        summary.holdings_inserted += outcome.holdings_inserted
+        summary.holdings_skipped_no_cusip += outcome.holdings_skipped_no_cusip
+        summary.holdings_skipped_non_equity += outcome.holdings_skipped_non_equity
+        summary.holdings_skipped_short += outcome.holdings_skipped_short
+        summary.holdings_skipped_non_share_units += outcome.holdings_skipped_non_share_units
+        summary.holdings_skipped_zero_shares += outcome.holdings_skipped_zero_shares
+
+    return summary.to_immutable()
+
+
+def ingest_all_fund_filers(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+    *,
+    ciks: list[str],
+    deadline_seconds: float | None = None,
+    source_label: str = "sec_n_port_ingest",
+) -> list[IngestSummary]:
+    """Walk a list of fund-filer CIKs and ingest each one's pending
+    NPORT-Ps. Per-filer crashes isolated; a soft deadline allows the
+    sweep to be interrupted cleanly with the next run resuming the
+    tail (already-attempted accessions tombstoned in
+    ``n_port_ingest_log``)."""
+    if not ciks:
+        logger.info("n_port ingest: no fund-filer CIKs to ingest; nothing to do")
+        return []
+
+    deadline_ts: float | None
+    if deadline_seconds is None:
+        deadline_ts = None
+    else:
+        deadline_ts = time.monotonic() + deadline_seconds
+
+    run_id = start_ingestion_run(
+        conn,
+        source=source_label,
+        endpoint="/Archives/edgar/data/{cik}/{accession}/",
+        instrument_count=len(ciks),
+    )
+    conn.commit()
+
+    rows_upserted = 0
+    rows_skipped = 0
+    summaries: list[IngestSummary] = []
+    crash_error: str | None = None
+    accession_failures = 0
+    first_accession_error: str | None = None
+    deadline_hit = False
+    filers_attempted = 0
+    try:
+        for cik in ciks:
+            if deadline_ts is not None and time.monotonic() >= deadline_ts:
+                deadline_hit = True
+                logger.info(
+                    "n_port ingest: deadline reached after %d/%d filers",
+                    filers_attempted,
+                    len(ciks),
+                )
+                break
+            filers_attempted += 1
+            try:
+                summary = ingest_fund_n_port(conn, sec, filer_cik=cik)
+            except Exception as exc:  # noqa: BLE001 — per-filer crash isolation
+                logger.exception("n_port ingest: filer %s raised; continuing", cik)
+                crash_error = f"{cik}: {exc}"
+                conn.rollback()
+                continue
+            conn.commit()
+            summaries.append(summary)
+            rows_upserted += summary.holdings_inserted
+            rows_skipped += (
+                summary.holdings_skipped_no_cusip
+                + summary.holdings_skipped_non_equity
+                + summary.holdings_skipped_short
+                + summary.holdings_skipped_non_share_units
+                + summary.holdings_skipped_zero_shares
+            )
+            accession_failures += summary.accessions_failed
+            if summary.first_error and first_accession_error is None:
+                first_accession_error = f"{cik} {summary.first_error}"
+    finally:
+        # Status precedence mirrors institutional_holdings.ingest_all_active_filers:
+        #   deadline beats crash-only; crash-only with summaries beats failed.
+        if deadline_hit:
+            status = "partial"
+        elif crash_error and not summaries:
+            status = "failed"
+        elif crash_error or accession_failures > 0 or rows_skipped > 0:
+            status = "partial"
+        else:
+            status = "success"
+        error_parts: list[str] = []
+        if crash_error:
+            error_parts.append(f"crash: {crash_error}")
+        if first_accession_error:
+            error_parts.append(f"accession: {first_accession_error}")
+        if rows_skipped > 0 and not error_parts:
+            error_parts.append(f"{rows_skipped} holdings skipped (non-equity/short/non-share-units/zero-shares/cusip)")
+        if deadline_hit:
+            error_parts.append(f"deadline reached after {filers_attempted}/{len(ciks)} filers")
+        finish_ingestion_run(
+            conn,
+            run_id=run_id,
+            status=status,
+            rows_upserted=rows_upserted,
+            rows_skipped=rows_skipped,
+            error="; ".join(error_parts) or None,
+        )
+        conn.commit()
+
+    return summaries
+
+
+# ---------------------------------------------------------------------------
+# Internal driver
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MutableSummary:
+    cik: str
+    accessions_seen: int = 0
+    accessions_ingested: int = 0
+    accessions_failed: int = 0
+    holdings_inserted: int = 0
+    holdings_skipped_no_cusip: int = 0
+    holdings_skipped_non_equity: int = 0
+    holdings_skipped_short: int = 0
+    holdings_skipped_non_share_units: int = 0
+    holdings_skipped_zero_shares: int = 0
+    first_error: str | None = None
+
+    def to_immutable(self) -> IngestSummary:
+        return IngestSummary(
+            filer_cik=self.cik,
+            accessions_seen=self.accessions_seen,
+            accessions_ingested=self.accessions_ingested,
+            accessions_failed=self.accessions_failed,
+            holdings_inserted=self.holdings_inserted,
+            holdings_skipped_no_cusip=self.holdings_skipped_no_cusip,
+            holdings_skipped_non_equity=self.holdings_skipped_non_equity,
+            holdings_skipped_short=self.holdings_skipped_short,
+            holdings_skipped_non_share_units=self.holdings_skipped_non_share_units,
+            holdings_skipped_zero_shares=self.holdings_skipped_zero_shares,
+            first_error=self.first_error,
+        )
+
+
+def _ingest_single_accession(
+    conn: psycopg.Connection[tuple],
+    sec: SecArchiveFetcher,
+    *,
+    filer_cik: str,
+    ref: AccessionRef,
+) -> _AccessionOutcome:
+    """Per-accession driver. Never raises; every fetch / parse failure
+    resolves to an outcome with status='failed'."""
+    # NPORT-P primary doc lives at the accession's primary_doc.xml.
+    # SEC EDGAR convention: NPORT-P archives also expose an
+    # ``primary_doc.xml`` even though the underlying XBRL document
+    # may be named differently in the inline-XBRL container.
+    primary_url = _archive_file_url(filer_cik, ref.accession_number, "primary_doc.xml")
+
+    # Fetch + persist raw BEFORE parse — non-negotiable per the
+    # prevention-log entry "Raw API payload must be persisted before
+    # any parse / normalise step" (#1168).
+    primary_xml = sec.fetch_document_text(primary_url)
+    if primary_xml is None:
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            holdings_skipped_non_equity=0,
+            holdings_skipped_short=0,
+            holdings_skipped_non_share_units=0,
+            holdings_skipped_zero_shares=0,
+            error="primary_doc.xml fetch failed",
+            series_id=None,
+            period_of_report=ref.period_of_report,
+        )
+
+    from app.services import raw_filings
+
+    raw_filings.store_raw(
+        conn,
+        accession_number=ref.accession_number,
+        document_kind="nport_xml",
+        payload=primary_xml,
+        parser_version=_PARSER_VERSION_NPORT,
+        source_url=primary_url,
+    )
+    # Commit the raw row before parse so a later parse failure that
+    # propagates rollback can't drop the body. Same pattern as
+    # institutional_holdings._ingest_single_accession (Codex review
+    # #913 lesson).
+    conn.commit()
+
+    try:
+        parsed = parse_n_port_payload(primary_xml)
+    except NPortMissingSeriesError as exc:
+        logger.warning(
+            "n_port ingest: missing seriesId for cik=%s accession=%s — tombstoning",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            holdings_skipped_non_equity=0,
+            holdings_skipped_short=0,
+            holdings_skipped_non_share_units=0,
+            holdings_skipped_zero_shares=0,
+            error=str(exc),
+            series_id=None,
+            period_of_report=ref.period_of_report,
+        )
+    except NPortParseError as exc:
+        logger.exception(
+            "n_port ingest: parse failed for cik=%s accession=%s",
+            filer_cik,
+            ref.accession_number,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            holdings_skipped_non_equity=0,
+            holdings_skipped_short=0,
+            holdings_skipped_non_share_units=0,
+            holdings_skipped_zero_shares=0,
+            error=f"parse failed: {exc}",
+            series_id=None,
+            period_of_report=ref.period_of_report,
+        )
+
+    # Update series reference table — UPSERT on every ingest so a
+    # series rename or new filer assignment propagates. Done before
+    # observation writes so refresh_funds_current can JOIN against
+    # a populated row even if the observations refresh fails midway.
+    upsert_sec_fund_series(
+        conn,
+        fund_series_id=parsed.series_id,
+        fund_series_name=parsed.series_name,
+        fund_filer_cik=parsed.filer_cik,
+        last_seen_period_end=parsed.period_end,
+    )
+
+    inserted = 0
+    skipped_no_cusip = 0
+    skipped_non_equity = 0
+    skipped_short = 0
+    skipped_non_share_units = 0
+    skipped_zero_shares = 0
+    touched_instruments: set[int] = set()
+    run_id = uuid4()
+    # Codex pre-push review #1: prefer header ``filed_at`` → submissions
+    # index ``filingDate`` → period_end midnight. The submissions index
+    # is always present in the ``recent`` array, so amendments will
+    # carry distinct ``filed_at`` values from the original even when
+    # both lack header timestamps.
+    if parsed.filed_at is not None:
+        filed_at = parsed.filed_at
+    elif ref.filed_at is not None:
+        filed_at = ref.filed_at
+    else:
+        filed_at = datetime(parsed.period_end.year, parsed.period_end.month, parsed.period_end.day, tzinfo=UTC)
+
+    for holding in parsed.holdings:
+        # Apply the equity-common-Long write-side guards as drop
+        # filters BEFORE the helper-side validation. The helper
+        # ``record_fund_observation`` re-applies the same guards as
+        # value-error raises; doing the drop counts here surfaces the
+        # operator-visible counters per category. Order matters —
+        # check non-equity / short / units before CUSIP / zero-shares
+        # so the most specific category wins (a Short DBT row counts
+        # as non_equity, not short).
+        if holding.asset_category != "EC":
+            skipped_non_equity += 1
+            continue
+        if holding.payoff_profile != "Long":
+            skipped_short += 1
+            continue
+        # Codex pre-push review #3: guard against units other than
+        # 'NS' (number of shares). A Long EC convertible-bond holding
+        # reports balance in 'PA' (principal amount) and would
+        # silently land as shares without this guard.
+        if holding.units != "NS":
+            skipped_non_share_units += 1
+            continue
+        # Codex pre-push review #4: explicit zero-shares guard before
+        # any DB work. Helper raises ValueError if shares <= 0; doing
+        # the check here keeps the counter accurate (otherwise the
+        # except branch below would lump zero-shares with helper-guard
+        # bypasses).
+        if holding.shares is None or holding.shares <= 0:
+            skipped_zero_shares += 1
+            continue
+        if not holding.cusip or len(holding.cusip) != 9:
+            skipped_no_cusip += 1
+            continue
+
+        instrument_id = _resolve_cusip_to_instrument_id(conn, holding.cusip)
+        if instrument_id is None:
+            skipped_no_cusip += 1
+            # PR1 deliberately does NOT track unresolved N-PORT CUSIPs in
+            # ``unresolved_13f_cusips``. The 13F CUSIP universe drains via
+            # #913 + #914; once #913's quarterly sweep populates more
+            # external_identifiers, the N-PORT path will resolve more
+            # holdings without bespoke telemetry. Follow-up: extend
+            # the table with a source column. Codex pre-impl review #9.
+            continue
+
+        try:
+            record_fund_observation(
+                conn,
+                instrument_id=instrument_id,
+                fund_series_id=parsed.series_id,
+                fund_series_name=parsed.series_name,
+                fund_filer_cik=parsed.filer_cik,
+                source_document_id=ref.accession_number,
+                source_accession=ref.accession_number,
+                source_field=None,
+                source_url=primary_url,
+                filed_at=filed_at,
+                period_start=None,
+                period_end=parsed.period_end,
+                ingest_run_id=run_id,
+                shares=holding.shares,
+                market_value_usd=holding.value_usd,
+                payoff_profile=holding.payoff_profile,
+                asset_category=holding.asset_category,
+            )
+            inserted += 1
+            touched_instruments.add(instrument_id)
+        except ValueError:
+            # Helper-side guard caught what the loop guard didn't —
+            # log loudly and count as a parser-shape failure
+            # (``skipped_non_equity`` is the closest existing bucket
+            # but the operator sees the exception in logs to disambiguate).
+            # The loop guards above mirror the helper exactly; reaching
+            # this branch indicates a parser-helper contract drift.
+            logger.exception(
+                "n_port ingest: helper-side guard rejected holding cik=%s accession=%s cusip=%s "
+                "(parser-helper contract drift — investigate)",
+                filer_cik,
+                ref.accession_number,
+                holding.cusip,
+            )
+            skipped_non_equity += 1
+
+    # Refresh ``ownership_funds_current`` once per touched instrument.
+    # A single NPORT-P can carry 100s-1000s of holdings; refreshing
+    # per-row would be O(N²). Set collapses to distinct issuers held.
+    for instrument_id in touched_instruments:
+        refresh_funds_current(conn, instrument_id=instrument_id)
+
+    if not parsed.holdings:
+        # Legal-empty NPORT-P (small fund holding only cash mid-quarter).
+        # Recorded as success so re-runs skip it.
+        return _AccessionOutcome(
+            status="success",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            holdings_skipped_non_equity=0,
+            holdings_skipped_short=0,
+            holdings_skipped_non_share_units=0,
+            holdings_skipped_zero_shares=0,
+            error=None,
+            series_id=parsed.series_id,
+            period_of_report=parsed.period_end,
+        )
+
+    total_skipped = (
+        skipped_no_cusip + skipped_non_equity + skipped_short + skipped_non_share_units + skipped_zero_shares
+    )
+    skip_breakdown = (
+        f"non-equity={skipped_non_equity}, short={skipped_short}, "
+        f"non-share-units={skipped_non_share_units}, zero-shares={skipped_zero_shares}, "
+        f"no-cusip={skipped_no_cusip}"
+    )
+    if inserted == 0 and total_skipped > 0:
+        # Every parsed holding was filtered out — fund holds only
+        # non-equity / short / non-share-units / zero-shares /
+        # unresolved-CUSIP positions. Report 'partial' so the operator
+        # distinguishes from 'success' with zero holdings (legal-empty
+        # NPORT-P).
+        status = "partial"
+        error = f"{total_skipped} holdings skipped ({skip_breakdown}); 0 written"
+    elif total_skipped > 0:
+        status = "partial"
+        error = f"{total_skipped} holdings skipped ({skip_breakdown})"
+    else:
+        status = "success"
+        error = None
+
+    return _AccessionOutcome(
+        status=status,
+        holdings_inserted=inserted,
+        holdings_skipped_no_cusip=skipped_no_cusip,
+        holdings_skipped_non_equity=skipped_non_equity,
+        holdings_skipped_short=skipped_short,
+        holdings_skipped_non_share_units=skipped_non_share_units,
+        holdings_skipped_zero_shares=skipped_zero_shares,
+        error=error,
+        series_id=parsed.series_id,
+        period_of_report=parsed.period_end,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Iterators (exposed for ad-hoc reporting / debug)
+# ---------------------------------------------------------------------------
+
+
+def iter_fund_observations(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    limit: int = 1000,
+) -> Iterator[dict[str, Any]]:
+    """Yield the most recent observations for one instrument.
+    Used by the rollup endpoint (in #919) and tests."""
+    import psycopg.rows
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                   source_document_id, source_accession, source_url,
+                   filed_at, period_start, period_end,
+                   shares, market_value_usd, payoff_profile, asset_category
+            FROM ownership_funds_observations
+            WHERE instrument_id = %(iid)s
+            ORDER BY period_end DESC, filed_at DESC
+            LIMIT %(limit)s
+            """,
+            {"iid": instrument_id, "limit": limit},
+        )
+        for row in cur.fetchall():
+            yield dict(row)

--- a/app/services/ownership_observations.py
+++ b/app/services/ownership_observations.py
@@ -30,6 +30,7 @@ pattern in subsequent sub-PRs.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -39,6 +40,15 @@ from uuid import UUID
 
 import psycopg
 import psycopg.rows
+
+# Pinned to the SEC series identifier shape ``S0000xxxxx``. Used by
+# the fund-observation write-side guard (Codex pre-impl review #2 +
+# #8) and asserted by the ``ownership_funds_observations`` /
+# ``sec_fund_series`` CHECK constraints — this regex is the
+# application-side mirror so a guard violation surfaces as a clean
+# ``ValueError`` instead of a Postgres CHECK error rolling the
+# whole transaction.
+_FUND_SERIES_ID_RE = re.compile(r"^S[0-9]{9}$")
 
 logger = logging.getLogger(__name__)
 
@@ -859,6 +869,246 @@ def refresh_def14a_current(
         )
         row = cur.fetchone()
         return int(row[0]) if row else 0
+
+
+# ---------------------------------------------------------------------------
+# Funds — record + refresh (#917 — Phase 3 PR1, N-PORT)
+# ---------------------------------------------------------------------------
+
+
+def record_fund_observation(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    fund_series_id: str,
+    fund_series_name: str,
+    fund_filer_cik: str,
+    source_document_id: str,
+    source_accession: str | None,
+    source_field: str | None,
+    source_url: str | None,
+    filed_at: datetime,
+    period_start: date | None,
+    period_end: date,
+    ingest_run_id: UUID,
+    shares: Decimal,
+    market_value_usd: Decimal | None,
+    payoff_profile: str,
+    asset_category: str,
+) -> None:
+    """Append one N-PORT fund-holding observation. Idempotent on
+    ``(instrument_id, fund_series_id, period_end, source_document_id)``.
+
+    Write-side guards (Codex pre-impl review #3, #4, #8 — moved into
+    the helper so test seeders inherit the guards automatically per
+    the prevention-log entry "Test seed mirrors must replicate
+    production write-through guards"):
+
+    * ``fund_series_id`` must match the SEC series-id regex. Filings
+      missing a series_id are rejected upstream by the parser; this
+      guard is the second-line catch.
+    * ``asset_category`` must be ``'EC'`` (equity-common). N-PORT
+      carries debt / preferred / derivative / cash positions in the
+      same holdings array; only equity-common rows belong in the
+      ownership decomposition.
+    * ``payoff_profile`` must be ``'Long'``. A short fund position
+      is a borrow artifact, not an ownership claim — it does NOT
+      land in the ownership pie (per the spec §"Target chart
+      decomposition").
+    * ``shares`` must be positive. NULL / zero / negative are
+      rejected at the helper boundary; the schema CHECK is the
+      backstop.
+
+    ``ownership_nature`` is fixed to ``'economic'`` and ``source`` to
+    ``'nport'`` per the schema CHECK constraints — no per-call
+    parameter so a buggy caller can't widen the CHECK by passing a
+    different value.
+    """
+    if not _FUND_SERIES_ID_RE.match(fund_series_id):
+        raise ValueError(
+            f"record_fund_observation: invalid fund_series_id={fund_series_id!r} "
+            "(expected SEC series identifier matching ^S[0-9]{9}$)"
+        )
+    if asset_category != "EC":
+        raise ValueError(
+            f"record_fund_observation: asset_category={asset_category!r} "
+            "is not 'EC' (equity-common); refusing to record non-equity holding "
+            "as ownership"
+        )
+    if payoff_profile != "Long":
+        raise ValueError(
+            f"record_fund_observation: payoff_profile={payoff_profile!r} "
+            "is not 'Long'; short positions are memo overlays, not ownership "
+            "rows (spec §Target chart decomposition)"
+        )
+    if shares is None or shares <= 0:
+        raise ValueError(
+            f"record_fund_observation: shares={shares!r} must be a positive "
+            "Decimal — null/zero/negative are not ownership facts"
+        )
+    if not fund_filer_cik or not fund_filer_cik.strip():
+        raise ValueError("record_fund_observation: fund_filer_cik is required")
+    if not fund_series_name or not fund_series_name.strip():
+        raise ValueError("record_fund_observation: fund_series_name is required")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO ownership_funds_observations (
+                instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                ownership_nature,
+                source, source_document_id, source_accession, source_field, source_url,
+                filed_at, period_start, period_end, ingest_run_id,
+                shares, market_value_usd, payoff_profile, asset_category
+            ) VALUES (
+                %(iid)s, %(sid)s, %(sname)s, %(fcik)s,
+                'economic',
+                'nport', %(doc_id)s, %(accession)s, %(field)s, %(url)s,
+                %(filed_at)s, %(period_start)s, %(period_end)s, %(run_id)s,
+                %(shares)s, %(mv)s, %(payoff)s, %(asset)s
+            )
+            ON CONFLICT (instrument_id, fund_series_id, period_end, source_document_id)
+            DO UPDATE SET
+                fund_series_name = EXCLUDED.fund_series_name,
+                fund_filer_cik = EXCLUDED.fund_filer_cik,
+                source_accession = EXCLUDED.source_accession,
+                source_field = EXCLUDED.source_field,
+                source_url = EXCLUDED.source_url,
+                filed_at = EXCLUDED.filed_at,
+                period_start = EXCLUDED.period_start,
+                shares = EXCLUDED.shares,
+                market_value_usd = EXCLUDED.market_value_usd,
+                payoff_profile = EXCLUDED.payoff_profile,
+                asset_category = EXCLUDED.asset_category,
+                ingest_run_id = EXCLUDED.ingest_run_id,
+                ingested_at = clock_timestamp()
+            """,
+            {
+                "iid": instrument_id,
+                "sid": fund_series_id,
+                "sname": fund_series_name,
+                "fcik": fund_filer_cik.strip(),
+                "doc_id": source_document_id,
+                "accession": source_accession,
+                "field": source_field,
+                "url": source_url,
+                "filed_at": filed_at,
+                "period_start": period_start,
+                "period_end": period_end,
+                "run_id": str(ingest_run_id),
+                "shares": shares,
+                "mv": market_value_usd,
+                "payoff": payoff_profile,
+                "asset": asset_category,
+            },
+        )
+
+
+def refresh_funds_current(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+) -> int:
+    """Deterministically rebuild ``ownership_funds_current`` rows for
+    one instrument from its observations.
+
+    Atomicity contract identical to ``refresh_institutions_current``:
+    explicit ``conn.transaction()`` + per-instrument
+    ``pg_advisory_xact_lock`` so concurrent refreshes serialise.
+
+    Dedup picks one row per ``fund_series_id`` ordered by
+    ``filed_at DESC, period_end DESC, source_document_id ASC`` —
+    Codex pre-impl review #5: amendments (NPORT-P/A) carry the same
+    ``period_end`` as the original NPORT-P but are filed later, so
+    ordering by ``filed_at DESC`` first ensures the amendment wins."""
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_advisory_xact_lock(
+                (hashtextextended('refresh_funds_current', 0) # %s::bigint)
+            )
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            "DELETE FROM ownership_funds_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        cur.execute(
+            """
+            INSERT INTO ownership_funds_current (
+                instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, market_value_usd, payoff_profile, asset_category
+            )
+            SELECT DISTINCT ON (fund_series_id)
+                instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, market_value_usd, payoff_profile, asset_category
+            FROM ownership_funds_observations
+            WHERE instrument_id = %s
+              AND known_to IS NULL
+            ORDER BY
+                fund_series_id,
+                filed_at DESC,
+                period_end DESC,
+                source_document_id ASC
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            "SELECT COUNT(*) FROM ownership_funds_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
+def upsert_sec_fund_series(
+    conn: psycopg.Connection[Any],
+    *,
+    fund_series_id: str,
+    fund_series_name: str,
+    fund_filer_cik: str,
+    last_seen_period_end: date | None,
+) -> None:
+    """Idempotent upsert into ``sec_fund_series`` reference table.
+
+    Called once per ingested N-PORT accession. ``last_seen_period_end``
+    is monotonically advanced via ``GREATEST`` so an out-of-order
+    re-ingest of an older filing doesn't regress the value. Series
+    name is refreshed unconditionally — the most recent ingest wins
+    so a fund rename propagates."""
+    if not _FUND_SERIES_ID_RE.match(fund_series_id):
+        raise ValueError(f"upsert_sec_fund_series: invalid fund_series_id={fund_series_id!r}")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO sec_fund_series (
+                fund_series_id, fund_series_name, fund_filer_cik,
+                last_seen_period_end
+            ) VALUES (
+                %(sid)s, %(sname)s, %(fcik)s, %(period)s
+            )
+            ON CONFLICT (fund_series_id) DO UPDATE SET
+                fund_series_name = EXCLUDED.fund_series_name,
+                fund_filer_cik = EXCLUDED.fund_filer_cik,
+                last_seen_period_end = GREATEST(
+                    COALESCE(sec_fund_series.last_seen_period_end, '1900-01-01'),
+                    COALESCE(EXCLUDED.last_seen_period_end, '1900-01-01')
+                ),
+                updated_at = NOW()
+            """,
+            {
+                "sid": fund_series_id,
+                "sname": fund_series_name,
+                "fcik": fund_filer_cik.strip(),
+                "period": last_seen_period_end,
+            },
+        )
 
 
 def iter_insider_observations(

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -62,6 +62,7 @@ DocumentKind = Literal[
     "form4_xml",
     "form3_xml",
     "def14a_body",
+    "nport_xml",
 ]
 # submissions.json / companyfacts.json are keyed by CIK, not by SEC
 # accession number — they belong in their own per-CIK store, not in

--- a/app/services/sec_manifest.py
+++ b/app/services/sec_manifest.py
@@ -496,9 +496,16 @@ _FORM_TO_SOURCE: dict[str, ManifestSource] = {
     "DEFA14A": "sec_def14a",
     "DEFM14A": "sec_def14a",
     "PRE 14A": "sec_def14a",
-    # Fund (Phase 3)
+    # Fund (Phase 3). SEC EDGAR submissions API uses both ``NPORT-P`` /
+    # ``NPORT-P/A`` (current spelling, no internal dash, "-P" suffix
+    # marking the public-quarterly version) and ``N-PORT`` / ``N-PORT/A``
+    # (legacy spelling) on the same form-type field. #917 maps both so
+    # the manifest classifies regardless of which spelling SEC returns
+    # for a given accession (Codex pre-impl review finding #1).
     "N-PORT": "sec_n_port",
     "N-PORT/A": "sec_n_port",
+    "NPORT-P": "sec_n_port",
+    "NPORT-P/A": "sec_n_port",
     "N-CSR": "sec_n_csr",
     "N-CSR/A": "sec_n_csr",
     # Periodic

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -251,6 +251,7 @@ JOB_OWNERSHIP_OBSERVATIONS_SYNC = "ownership_observations_sync"
 JOB_OWNERSHIP_OBSERVATIONS_BACKFILL = "ownership_observations_backfill"
 JOB_SEC_13F_FILER_DIRECTORY_SYNC = "sec_13f_filer_directory_sync"
 JOB_SEC_13F_QUARTERLY_SWEEP = "sec_13f_quarterly_sweep"
+JOB_SEC_N_PORT_INGEST = "sec_n_port_ingest"
 JOB_CUSIP_UNIVERSE_BACKFILL = "cusip_universe_backfill"
 JOB_EXCHANGES_METADATA_REFRESH = "exchanges_metadata_refresh"
 JOB_ETORO_LOOKUPS_REFRESH = "etoro_lookups_refresh"
@@ -821,6 +822,26 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # restart would burn SEC bandwidth + dev wall-clock for no
         # operator benefit (the directory churns slowly). A missed
         # window rolls forward to the next Sunday.
+        catch_up_on_boot=False,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_N_PORT_INGEST,
+        description=(
+            "Monthly NPORT-P fund-holdings sweep (#917 — Phase 3 PR1). "
+            "Walks the fund-filer CIK universe (today: institutional_filers "
+            "rows where filer_type IN ('INV','INS','ETF') as the MVP set; a "
+            "dedicated fund-filer directory walk is a follow-up) and "
+            "ingests every pending NPORT-P / NPORT-P/A accession into "
+            "ownership_funds_observations + ownership_funds_current. "
+            "Equity-common-Long write-side guard filters debt / preferred / "
+            "derivative / short positions; only pie-eligible holdings land. "
+            "Cadence: monthly day 22 03:00 UTC — NPORT-P has a 60-day "
+            "post-quarter publication deadline; running on the 22nd of each "
+            "month catches the bulk of new filings 1-2 weeks after they "
+            "publish. Soft 6h deadline; resumable via n_port_ingest_log "
+            "tombstones."
+        ),
+        cadence=Cadence.monthly(day=22, hour=3, minute=0),
         catch_up_on_boot=False,
     ),
     ScheduledJob(
@@ -3739,6 +3760,73 @@ def sec_13f_filer_directory_sync() -> None:
             result.filers_inserted,
             result.filers_refreshed,
             result.skipped_empty_name,
+        )
+
+
+def sec_n_port_ingest() -> None:
+    """Monthly NPORT-P fund-holdings sweep (#917 — Phase 3 PR1).
+
+    Walks the fund-filer CIK universe and ingests each filer's pending
+    NPORT-P / NPORT-P/A accessions into ``ownership_funds_observations``
+    + ``ownership_funds_current``. Per-filer crashes isolated; soft
+    deadline budget; resumable via ``n_port_ingest_log`` tombstones.
+
+    MVP universe: ``institutional_filers`` rows where ``filer_type``
+    is one of ('INV', 'INS', 'ETF') — the N-CEN-derived buckets that
+    contain registered investment companies. Not every RIC is in this
+    list (a dedicated fund-filer directory walk for N-PORT is a
+    follow-up); coverage gradually expands as the operator manually
+    seeds rows or as the 13F directory walk pulls in dual-filers.
+    """
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.n_port_ingest import ingest_all_fund_filers
+
+    deadline_seconds = settings.sec_n_port_sweep_deadline_seconds
+
+    with _tracked_job(JOB_SEC_N_PORT_INGEST) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT cik
+                    FROM institutional_filers
+                    WHERE filer_type IN ('INV', 'INS', 'ETF')
+                    ORDER BY last_filing_at DESC NULLS LAST, cik
+                    """
+                )
+                ciks = [str(row[0]).zfill(10) for row in cur.fetchall()]
+
+            summaries = ingest_all_fund_filers(
+                conn,
+                sec,
+                ciks=ciks,
+                deadline_seconds=deadline_seconds,
+                source_label="sec_n_port_ingest",
+            )
+
+        total_filers = len(ciks)
+        processed = len(summaries)
+        rows_upserted = sum(s.holdings_inserted for s in summaries)
+        rows_skipped = sum(
+            s.holdings_skipped_no_cusip
+            + s.holdings_skipped_non_equity
+            + s.holdings_skipped_short
+            + s.holdings_skipped_non_share_units
+            + s.holdings_skipped_zero_shares
+            for s in summaries
+        )
+        accessions_ingested = sum(s.accessions_ingested for s in summaries)
+        tracker.row_count = rows_upserted
+        logger.info(
+            "sec_n_port_ingest: filers=%d processed=%d accessions_ingested=%d holdings_inserted=%d holdings_skipped=%d",
+            total_filers,
+            processed,
+            accessions_ingested,
+            rows_upserted,
+            rows_skipped,
         )
 
 

--- a/sql/122_filing_raw_documents_add_nport_kind.sql
+++ b/sql/122_filing_raw_documents_add_nport_kind.sql
@@ -1,0 +1,33 @@
+-- 122_filing_raw_documents_add_nport_kind.sql
+--
+-- Issue #917 — N-PORT mutual-fund holdings ingest (Phase 3 PR1).
+--
+-- Adds the ``nport_xml`` document_kind to ``filing_raw_documents``
+-- so the N-PORT ingester can persist the raw filing body before
+-- parse, mirroring the contract enforced for 13F's ``infotable_13f``.
+--
+-- Codex pre-impl review (2026-05-05) finding #10: the existing
+-- generic ``primary_doc`` kind would work mechanically, but tagging
+-- N-PORT bodies distinctly weakens re-wash targeting because a
+-- parser-version bump on N-PORT would have to filter through every
+-- mixed-source primary_doc row. Distinct ``nport_xml`` keeps the
+-- re-wash query simple.
+
+BEGIN;
+
+ALTER TABLE filing_raw_documents
+    DROP CONSTRAINT IF EXISTS filing_raw_documents_document_kind_check;
+
+ALTER TABLE filing_raw_documents
+    ADD CONSTRAINT filing_raw_documents_document_kind_check
+    CHECK (document_kind IN (
+        'primary_doc',
+        'infotable_13f',
+        'primary_doc_13dg',
+        'form4_xml',
+        'form3_xml',
+        'def14a_body',
+        'nport_xml'
+    ));
+
+COMMIT;

--- a/sql/123_ownership_funds.sql
+++ b/sql/123_ownership_funds.sql
@@ -1,0 +1,169 @@
+-- 123_ownership_funds.sql
+--
+-- Issue #917 — Phase 3 PR1: N-PORT mutual-fund holdings ingest.
+-- Spec: docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md
+-- (Phase 3, §"Per-category natural keys" + §Data model design).
+--
+-- Mirrors the shape established by migration 114
+-- (ownership_institutions_observations) — same provenance block,
+-- same partition strategy (RANGE on ``period_end`` quarterly
+-- buckets 2010-2030 + DEFAULT), same `_current` materialised
+-- snapshot pattern.
+--
+-- Differences from institutions:
+--
+--   * Identity is ``fund_series_id`` (SEC series identifier, e.g.
+--     ``S000004310``), NOT ``fund_filer_cik``. One RIC (filer CIK)
+--     typically has 5-50 series; the rollup endpoint aggregates by
+--     series, not by filer. ``fund_filer_cik`` is recorded for
+--     audit and per-filer rollup queries but is NOT in the natural
+--     key.
+--   * CHECK constraints lock the per-source enum values into the
+--     schema:
+--       - ``ownership_nature = 'economic'`` (N-PORT is a full
+--         reported position; no voting/beneficial split).
+--       - ``source = 'nport'`` (this table is N-PORT exclusive;
+--         N-CSR semi-annual will reuse this table in #918 — at
+--         which point the CHECK widens to allow ``ncsr`` too).
+--       - ``payoff_profile = 'Long'`` and ``asset_category = 'EC'``
+--         (equity-common). N-PORT carries debt / derivative /
+--         preferred / short positions in the same per-fund holdings
+--         array; the ingester filters those at the write boundary,
+--         and the schema CHECK is the second-line guard against a
+--         bug in the ingester.
+--   * ``shares NOT NULL`` — every retained holding must carry a
+--     positive share balance. The ingester's write-side guard
+--     enforces ``shares > 0``; the NOT NULL is the schema-level
+--     defence.
+--
+-- Codex pre-impl review findings (2026-05-05) addressed in this
+-- migration:
+--
+--   * #2 (synthetic-{cik} collision risk): the CHECK constraint on
+--     ``fund_series_id`` rejects any value that isn't a literal
+--     ``S0000xxxxx`` SEC series identifier. Filings missing a
+--     series_id are rejected at parse time, not synthesised.
+--   * #3 + #4 (debt vs equity confusion + payoff_profile guard):
+--     CHECK on ``asset_category = 'EC'`` and ``payoff_profile = 'Long'``
+--     enforced in the schema.
+--   * #5 (amendments in _current): handled by the refresh function's
+--     ORDER BY clause in app/services/ownership_observations.py
+--     (`filed_at DESC, period_end DESC, source_document_id ASC`).
+--
+-- ``_PLANNER_TABLES`` in tests/fixtures/ebull_test_db.py is updated
+-- in the same PR per the prevention-log entry "Test-teardown list
+-- missing new FK-child tables".
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- ownership_funds_observations — append-only fact log
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ownership_funds_observations (
+    instrument_id           INTEGER NOT NULL,
+    fund_series_id          TEXT NOT NULL CHECK (fund_series_id ~ '^S[0-9]{9}$'),
+    fund_series_name        TEXT NOT NULL,
+    fund_filer_cik          TEXT NOT NULL,
+    ownership_nature        TEXT NOT NULL CHECK (ownership_nature = 'economic'),
+
+    -- Provenance block (uniform across every ownership_*_observations).
+    source                  TEXT NOT NULL CHECK (source = 'nport'),
+    source_document_id      TEXT NOT NULL,
+    source_accession        TEXT,
+    source_field            TEXT,
+    source_url              TEXT,
+    filed_at                TIMESTAMPTZ NOT NULL,
+    period_start            DATE,
+    period_end              DATE NOT NULL,
+    known_from              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    known_to                TIMESTAMPTZ,
+    ingest_run_id           UUID NOT NULL,
+    ingested_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Fact payload.
+    shares                  NUMERIC(24, 4) NOT NULL CHECK (shares > 0),
+    market_value_usd        NUMERIC(20, 2),
+    payoff_profile          TEXT NOT NULL CHECK (payoff_profile = 'Long'),
+    asset_category          TEXT NOT NULL CHECK (asset_category = 'EC'),
+
+    PRIMARY KEY (instrument_id, fund_series_id, period_end, source_document_id)
+) PARTITION BY RANGE (period_end);
+
+COMMENT ON TABLE ownership_funds_observations IS
+    'Immutable per-N-PORT-filing fact log for fund holdings (Phase 3 PR1, #917). Append-only; rebuild source for ownership_funds_current. Spec: docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md (Phase 3).';
+
+-- Quarterly partitions 2010-2030. N-PORT was introduced in 2018; the
+-- 2010-2017 buckets are present for shape-uniformity with sibling
+-- ownership_*_observations tables and stay empty until a parser
+-- regression test seeds them.
+DO $$
+DECLARE
+    yr INT;
+    qtr INT;
+    qstart DATE;
+    qend DATE;
+    pname TEXT;
+BEGIN
+    FOR yr IN 2010..2030 LOOP
+        FOR qtr IN 1..4 LOOP
+            qstart := MAKE_DATE(yr, (qtr - 1) * 3 + 1, 1);
+            qend := qstart + INTERVAL '3 months';
+            pname := FORMAT('ownership_funds_observations_%sq%s', yr, qtr);
+            EXECUTE FORMAT(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF ownership_funds_observations FOR VALUES FROM (%L) TO (%L)',
+                pname, qstart, qend
+            );
+        END LOOP;
+    END LOOP;
+END $$;
+
+CREATE TABLE IF NOT EXISTS ownership_funds_observations_default
+    PARTITION OF ownership_funds_observations DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_funds_obs_instrument_period
+    ON ownership_funds_observations (instrument_id, period_end DESC);
+
+CREATE INDEX IF NOT EXISTS idx_funds_obs_series_period
+    ON ownership_funds_observations (fund_series_id, period_end DESC);
+
+CREATE INDEX IF NOT EXISTS idx_funds_obs_filer_period
+    ON ownership_funds_observations (fund_filer_cik, period_end DESC);
+
+
+-- ---------------------------------------------------------------------
+-- ownership_funds_current — materialised dedup snapshot
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ownership_funds_current (
+    instrument_id           INTEGER NOT NULL,
+    fund_series_id          TEXT NOT NULL CHECK (fund_series_id ~ '^S[0-9]{9}$'),
+    fund_series_name        TEXT NOT NULL,
+    fund_filer_cik          TEXT NOT NULL,
+    ownership_nature        TEXT NOT NULL CHECK (ownership_nature = 'economic'),
+
+    source                  TEXT NOT NULL CHECK (source = 'nport'),
+    source_document_id      TEXT NOT NULL,
+    source_accession        TEXT,
+    source_url              TEXT,
+    filed_at                TIMESTAMPTZ NOT NULL,
+    period_start            DATE,
+    period_end              DATE NOT NULL,
+    refreshed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    shares                  NUMERIC(24, 4) NOT NULL CHECK (shares > 0),
+    market_value_usd        NUMERIC(20, 2),
+    payoff_profile          TEXT NOT NULL CHECK (payoff_profile = 'Long'),
+    asset_category          TEXT NOT NULL CHECK (asset_category = 'EC'),
+
+    PRIMARY KEY (instrument_id, fund_series_id)
+);
+
+COMMENT ON TABLE ownership_funds_current IS
+    'Materialised latest-per-(instrument, fund_series) N-PORT snapshot. Rebuilt deterministically by refresh_funds_current() ordering by filed_at DESC so amendments win over originals.';
+
+CREATE INDEX IF NOT EXISTS idx_funds_current_series
+    ON ownership_funds_current (fund_series_id);
+
+CREATE INDEX IF NOT EXISTS idx_funds_current_filer
+    ON ownership_funds_current (fund_filer_cik);
+
+COMMIT;

--- a/sql/124_sec_fund_series.sql
+++ b/sql/124_sec_fund_series.sql
@@ -1,0 +1,40 @@
+-- 124_sec_fund_series.sql
+--
+-- Issue #917 — N-PORT mutual-fund holdings ingest (Phase 3 PR1).
+--
+-- Reference table mapping ``fund_series_id`` → canonical name +
+-- filer CIK. Populated incrementally by the N-PORT ingester (UPSERT
+-- on every accession). Decoupled from ``ownership_funds_observations``
+-- so the rollup endpoint (in #919) can JOIN to a small dedicated
+-- reference table to render fund names without scanning the
+-- partitioned observations parent.
+--
+-- ``fund_filer_cik`` is intentionally NOT a foreign key to
+-- ``institutional_filers`` — many RICs are not 13F-HR filers and
+-- therefore do not have an ``institutional_filers`` row. The N-PORT
+-- ingester observes the filer CIK from the filing header; the
+-- universe walk for fund-filer discovery is a follow-up
+-- (out-of-scope for #917).
+--
+-- ``last_seen_period_end`` lets the ingester skip series whose latest
+-- public N-PORT is older than the configured staleness window
+-- without re-fetching the submissions index.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS sec_fund_series (
+    fund_series_id          TEXT PRIMARY KEY CHECK (fund_series_id ~ '^S[0-9]{9}$'),
+    fund_series_name        TEXT NOT NULL,
+    fund_filer_cik          TEXT NOT NULL,
+    last_seen_period_end    DATE,
+    first_seen_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sec_fund_series_filer
+    ON sec_fund_series (fund_filer_cik);
+
+COMMENT ON TABLE sec_fund_series IS
+    'Reference table for SEC fund series (N-PORT seriesId), populated by the N-PORT ingester. Decoupled from institutional_filers because not every RIC is a 13F-HR filer.';
+
+COMMIT;

--- a/sql/125_n_port_ingest_log.sql
+++ b/sql/125_n_port_ingest_log.sql
@@ -1,0 +1,51 @@
+-- 125_n_port_ingest_log.sql
+--
+-- Issue #917 — N-PORT mutual-fund holdings ingest (Phase 3 PR1).
+--
+-- Per-accession tombstone log mirroring
+-- ``institutional_holdings_ingest_log``. The ingester writes one row
+-- per attempted accession (success / partial / failed) so re-runs
+-- skip already-attempted work without re-fetching SEC.
+--
+-- ``fund_series_id`` is nullable because parse failures may abort
+-- before the series identifier is extracted (e.g. malformed XML
+-- header).
+--
+-- The accession is globally unique within SEC EDGAR; PRIMARY KEY on
+-- ``accession_number`` alone is sufficient. Re-recording the same
+-- accession overwrites the prior attempt — this lets a follow-up
+-- run that succeeds promote a 'partial' or 'failed' accession to
+-- 'success'.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS n_port_ingest_log (
+    accession_number        TEXT PRIMARY KEY,
+    filer_cik               TEXT NOT NULL,
+    -- Codex pre-push review (2026-05-05) finding #5: same regex CHECK
+    -- as ``ownership_funds_observations`` / ``ownership_funds_current`` /
+    -- ``sec_fund_series`` so a synthetic series id can never land in
+    -- the tombstone log either. Nullable because the field is unset
+    -- on parse-failure tombstones (e.g. NPortMissingSeriesError fires
+    -- before series_id is extracted).
+    fund_series_id          TEXT
+        CHECK (fund_series_id IS NULL OR fund_series_id ~ '^S[0-9]{9}$'),
+    period_of_report        DATE,
+    status                  TEXT NOT NULL
+        CHECK (status IN ('success', 'partial', 'failed')),
+    holdings_inserted       INTEGER NOT NULL DEFAULT 0,
+    holdings_skipped        INTEGER NOT NULL DEFAULT 0,
+    error                   TEXT,
+    fetched_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_n_port_ingest_log_filer
+    ON n_port_ingest_log (filer_cik);
+
+CREATE INDEX IF NOT EXISTS idx_n_port_ingest_log_status
+    ON n_port_ingest_log (status, fetched_at DESC);
+
+COMMENT ON TABLE n_port_ingest_log IS
+    'Per-accession tombstone for N-PORT ingest attempts (#917). Re-runs read this table via _existing_accessions_for_fund_filer to skip already-attempted accessions. Re-record overwrites the prior attempt.';
+
+COMMIT;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -156,6 +156,11 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "ownership_treasury_observations",
     "ownership_def14a_current",
     "ownership_def14a_observations",
+    # #917 — N-PORT mutual-fund holdings ingest (Phase 3 PR1).
+    "ownership_funds_current",
+    "ownership_funds_observations",
+    "n_port_ingest_log",
+    "sec_fund_series",
     # #893 — dev-DB writers migrated onto worker test DB; tables they
     # touched now need per-test cleanup.
     "job_runtime_heartbeat",

--- a/tests/fixtures/sec/nport_p_missing_series.xml
+++ b/tests/fixtures/sec/nport_p_missing_series.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Negative-test NPORT-P fixture for #917 — no seriesId.
+
+    The ingester must tombstone this accession as failed
+    (NPortMissingSeriesError) rather than synthesising a
+    collision-prone fallback identity. Codex pre-impl review #2.
+-->
+<edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+    <headerData>
+        <submissionType>NPORT-P</submissionType>
+    </headerData>
+    <formData>
+        <genInfo>
+            <regCik>0000036405</regCik>
+            <seriesName>Mystery Fund No Series Id</seriesName>
+            <repPdEnd>2025-12-31</repPdEnd>
+        </genInfo>
+        <invstOrSecs/>
+    </formData>
+</edgarSubmission>

--- a/tests/fixtures/sec/nport_p_test_fund.xml
+++ b/tests/fixtures/sec/nport_p_test_fund.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Hand-trimmed NPORT-P fixture for #917 testing.
+
+    Synthetic test fund modelled on a real Vanguard 500 Index Fund
+    NPORT-P primary doc (period 2025-12-31). Truncated to 7 holdings
+    that exercise every write-side path:
+
+      1. AAPL   — Long equity-common NS, valid CUSIP → write
+      2. MSFT   — Long equity-common NS, valid CUSIP → write
+      3. ACME-D — Long DEBT (assetCat=DBT)            → drop (non-equity)
+      4. SHRT-X — Short equity-common                  → drop (short)
+      5. ZZZZ   — Long equity-common NS, unknown CUSIP → drop (no extids)
+      6. CVBND  — Long equity-common, units=PA (conv bond) → drop (non-share-units)
+      7. ZEROS  — Long equity-common NS, balance=0    → drop (zero-shares)
+
+    Real-world NPORT-P uses the
+    ``http://www.sec.gov/edgar/nport`` namespace and an XBRL container.
+    This fixture uses a simplified flat shape that the lxml-direct
+    parser (which walks by local-name) accepts identically.
+-->
+<edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+    <headerData>
+        <submissionType>NPORT-P</submissionType>
+    </headerData>
+    <formData>
+        <genInfo>
+            <regCik>0000036405</regCik>
+            <seriesId>S000002277</seriesId>
+            <seriesName>Vanguard 500 Index Fund (TEST)</seriesName>
+            <repPdEnd>2025-12-31</repPdEnd>
+            <filedAt>2026-02-26</filedAt>
+        </genInfo>
+        <invstOrSecs>
+            <invstOrSec>
+                <name>APPLE INC</name>
+                <cusip>037833100</cusip>
+                <balance>1000000</balance>
+                <units>NS</units>
+                <valUSD>225000000.00</valUSD>
+                <pctVal>3.45</pctVal>
+                <payoffProfile>Long</payoffProfile>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+            </invstOrSec>
+            <invstOrSec>
+                <name>MICROSOFT CORP</name>
+                <cusip>594918104</cusip>
+                <balance>500000</balance>
+                <units>NS</units>
+                <valUSD>210000000.00</valUSD>
+                <pctVal>3.21</pctVal>
+                <payoffProfile>Long</payoffProfile>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+            </invstOrSec>
+            <invstOrSec>
+                <name>ACME CORP NOTE 5%</name>
+                <cusip>000000ACM</cusip>
+                <balance>1000000</balance>
+                <units>PA</units>
+                <valUSD>1010000.00</valUSD>
+                <payoffProfile>Long</payoffProfile>
+                <assetCat>DBT</assetCat>
+                <issuerCat>CORP</issuerCat>
+            </invstOrSec>
+            <invstOrSec>
+                <name>SHORT TARGET INC</name>
+                <cusip>000000SHX</cusip>
+                <balance>50000</balance>
+                <units>NS</units>
+                <valUSD>5000000.00</valUSD>
+                <payoffProfile>Short</payoffProfile>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+            </invstOrSec>
+            <invstOrSec>
+                <name>UNRESOLVED CO</name>
+                <cusip>000000ZZZ</cusip>
+                <balance>10000</balance>
+                <units>NS</units>
+                <valUSD>123456.00</valUSD>
+                <payoffProfile>Long</payoffProfile>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+            </invstOrSec>
+            <invstOrSec>
+                <name>CONVERTIBLE BOND CO</name>
+                <cusip>000000CVB</cusip>
+                <balance>5000000</balance>
+                <units>PA</units>
+                <valUSD>5500000.00</valUSD>
+                <payoffProfile>Long</payoffProfile>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+            </invstOrSec>
+            <invstOrSec>
+                <name>ZERO BALANCE CO</name>
+                <cusip>000000ZRO</cusip>
+                <balance>0</balance>
+                <units>NS</units>
+                <valUSD>0.00</valUSD>
+                <payoffProfile>Long</payoffProfile>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+            </invstOrSec>
+        </invstOrSecs>
+    </formData>
+</edgarSubmission>

--- a/tests/test_n_port_ingest.py
+++ b/tests/test_n_port_ingest.py
@@ -1,0 +1,764 @@
+"""Tests for the N-PORT ingester (#917 — Phase 3 PR1).
+
+Three boundaries:
+
+* Pure XML-in / dataclass-out parser (``parse_n_port_payload``).
+* DB write-through helpers (``record_fund_observation`` +
+  ``refresh_funds_current``) — exercised against the real
+  ``ebull_test`` DB.
+* SEC HTTP fetcher — abstracted as a :class:`Protocol` so tests
+  use a deterministic in-memory fake.
+
+Codex pre-impl review (2026-05-05) findings exercised:
+
+* #1 — parser accepts ``NPORT-P`` / ``NPORT-P/A`` / ``N-PORT`` /
+  ``N-PORT/A`` form spellings.
+* #2 — fixture missing seriesId tombstones as failed.
+* #3 + #4 — debt / preferred / short / no-cusip rows are dropped
+  by the equity-common-Long write-side guard.
+* #5 — amendments win over originals in ``_current``.
+* #6 — parser runs offline (test asserts no network calls).
+* #11 — ingest log measures parsed accessions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.n_port_ingest import (
+    AccessionRef,
+    NPortMissingSeriesError,
+    NPortParseError,
+    ingest_fund_n_port,
+    parse_n_port_payload,
+    parse_submissions_index,
+)
+from app.services.ownership_observations import (
+    record_fund_observation,
+    refresh_funds_current,
+    upsert_sec_fund_series,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "sec"
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_cusip_mapping(conn: psycopg.Connection[tuple], *, instrument_id: int, cusip: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (
+            instrument_id, provider, identifier_type, identifier_value, is_primary
+        )
+        VALUES (%s, 'sec', 'cusip', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        """,
+        (instrument_id, cusip.upper()),
+    )
+
+
+def _submissions_json(*, accessions: list[tuple[str, str, str, str]]) -> str:
+    """Build a fake submissions JSON. Each tuple is
+    ``(accession, form, filing_date, report_date)``."""
+    return json.dumps(
+        {
+            "filings": {
+                "recent": {
+                    "accessionNumber": [a[0] for a in accessions],
+                    "form": [a[1] for a in accessions],
+                    "filingDate": [a[2] for a in accessions],
+                    "reportDate": [a[3] for a in accessions],
+                },
+                "files": [],
+            }
+        }
+    )
+
+
+def _archive_url(filer_cik: str, accession: str, filename: str) -> str:
+    return f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/{filename}"
+
+
+class _FakeFetcher:
+    """In-memory SEC HTTP fake — deterministic, no network."""
+
+    def __init__(self, payloads: dict[str, str]) -> None:
+        self._payloads = payloads
+        self.fetch_log: list[str] = []
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        self.fetch_log.append(absolute_url)
+        return self._payloads.get(absolute_url)
+
+
+# ---------------------------------------------------------------------------
+# Parser unit tests (offline, no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestParseNPortPayload:
+    def test_extracts_header_and_holdings(self) -> None:
+        xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+        parsed = parse_n_port_payload(xml)
+        assert parsed.filer_cik == "0000036405"
+        assert parsed.series_id == "S000002277"
+        assert parsed.series_name.startswith("Vanguard 500 Index Fund")
+        assert parsed.period_end == date(2025, 12, 31)
+        assert parsed.filed_at == datetime(2026, 2, 26, tzinfo=UTC)
+        # 7 holdings parsed total (the ingester filters down to
+        # equity-common Long NS with valid CUSIPs + positive shares;
+        # the parser surfaces all of them).
+        assert len(parsed.holdings) == 7
+        h = {h.cusip: h for h in parsed.holdings}
+        assert h["037833100"].shares == Decimal("1000000")
+        assert h["037833100"].asset_category == "EC"
+        assert h["037833100"].payoff_profile == "Long"
+        assert h["037833100"].units == "NS"
+        assert h["594918104"].asset_category == "EC"
+        # Debt holding is surfaced by the parser (its own assetCat='DBT').
+        assert h["000000ACM"].asset_category == "DBT"
+        # Short equity holding is surfaced.
+        assert h["000000SHX"].payoff_profile == "Short"
+        # Convertible bond — Long EC but units=PA (principal amount).
+        assert h["000000CVB"].asset_category == "EC"
+        assert h["000000CVB"].payoff_profile == "Long"
+        assert h["000000CVB"].units == "PA"
+        # Zero-balance equity-common.
+        assert h["000000ZRO"].shares == Decimal("0")
+
+    def test_raises_missing_series_id(self) -> None:
+        xml = (_FIXTURE_DIR / "nport_p_missing_series.xml").read_text(encoding="utf-8")
+        with pytest.raises(NPortMissingSeriesError):
+            parse_n_port_payload(xml)
+
+    def test_raises_on_malformed_xml(self) -> None:
+        with pytest.raises(NPortParseError):
+            parse_n_port_payload("<not><well><formed>")
+
+    def test_runs_offline_no_network(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Codex pre-impl review #6: the parser must not reach the
+        network. Patch every HTTP entrypoint to raise; the parse must
+        still succeed."""
+        # ``urllib.request.urlopen`` is the stdlib HTTP client; patch
+        # at the public attribute so any code path that imports it
+        # raises immediately.
+        import urllib.request
+
+        def _block(*args: object, **kwargs: object) -> object:
+            raise AssertionError("parser made an HTTP request — must run offline")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _block)
+        # ``httpx`` may not be imported by the parser, but if a future
+        # change introduces it, the test must still trip. Use
+        # ``importlib`` to reach into it only if installed.
+        try:
+            import httpx
+
+            monkeypatch.setattr(httpx, "get", _block)
+            monkeypatch.setattr(httpx.Client, "request", _block)
+        except ImportError:
+            pass
+
+        xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+        parsed = parse_n_port_payload(xml)
+        assert parsed.series_id == "S000002277"
+
+
+# ---------------------------------------------------------------------------
+# Submissions-index walker
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubmissionsIndex:
+    def test_accepts_both_form_spellings(self) -> None:
+        """Codex #1: submissions index may use ``NPORT-P`` (current)
+        or ``N-PORT`` (legacy). Both must surface."""
+        payload = _submissions_json(
+            accessions=[
+                ("0001-26-000001", "NPORT-P", "2026-02-26", "2025-12-31"),
+                ("0002-26-000002", "NPORT-P/A", "2026-03-15", "2025-12-31"),
+                ("0003-25-000003", "N-PORT", "2025-11-26", "2025-09-30"),
+                ("0004-25-000004", "N-PORT/A", "2025-12-15", "2025-09-30"),
+                ("0005-26-000005", "10-K", "2026-02-26", "2025-12-31"),
+            ]
+        )
+        refs = parse_submissions_index(payload)
+        forms = sorted(r.filing_type for r in refs)
+        assert forms == ["N-PORT", "N-PORT/A", "NPORT-P", "NPORT-P/A"]
+
+    def test_drops_other_forms(self) -> None:
+        payload = _submissions_json(
+            accessions=[
+                ("0001-26-000001", "10-K", "2026-02-26", "2025-12-31"),
+            ]
+        )
+        assert parse_submissions_index(payload) == []
+
+
+# ---------------------------------------------------------------------------
+# DB write-through tests — record + refresh
+# ---------------------------------------------------------------------------
+
+
+class TestRecordFundObservation:
+    @pytest.fixture
+    def _setup(self, ebull_test_conn: psycopg.Connection[tuple]) -> psycopg.Connection[tuple]:  # noqa: F811
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=917_001, symbol="AAPL")
+        # Seed the fund series so foreign-key style references resolve.
+        upsert_sec_fund_series(
+            conn,
+            fund_series_id="S000002277",
+            fund_series_name="Vanguard 500 Index Fund",
+            fund_filer_cik="0000036405",
+            last_seen_period_end=date(2025, 12, 31),
+        )
+        conn.commit()
+        return conn
+
+    def test_round_trip(self, _setup: psycopg.Connection[tuple]) -> None:
+        conn = _setup
+        record_fund_observation(
+            conn,
+            instrument_id=917_001,
+            fund_series_id="S000002277",
+            fund_series_name="Vanguard 500 Index Fund",
+            fund_filer_cik="0000036405",
+            source_document_id="0001-26-000001",
+            source_accession="0001-26-000001",
+            source_field=None,
+            source_url="https://www.sec.gov/.../primary_doc.xml",
+            filed_at=datetime(2026, 2, 26, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2025, 12, 31),
+            ingest_run_id=uuid4(),
+            shares=Decimal("1000000"),
+            market_value_usd=Decimal("225000000.00"),
+            payoff_profile="Long",
+            asset_category="EC",
+        )
+        conn.commit()
+        n = refresh_funds_current(conn, instrument_id=917_001)
+        conn.commit()
+        assert n == 1
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT shares, fund_series_id FROM ownership_funds_current WHERE instrument_id = %s",
+                (917_001,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["shares"] == Decimal("1000000.0000")
+        assert rows[0]["fund_series_id"] == "S000002277"
+
+    def test_rejects_invalid_series_id(self, _setup: psycopg.Connection[tuple]) -> None:
+        with pytest.raises(ValueError, match="invalid fund_series_id"):
+            record_fund_observation(
+                _setup,
+                instrument_id=917_001,
+                fund_series_id="not-a-series-id",
+                fund_series_name="X",
+                fund_filer_cik="0000000001",
+                source_document_id="acc",
+                source_accession="acc",
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 2, 26, tzinfo=UTC),
+                period_start=None,
+                period_end=date(2025, 12, 31),
+                ingest_run_id=uuid4(),
+                shares=Decimal("1"),
+                market_value_usd=None,
+                payoff_profile="Long",
+                asset_category="EC",
+            )
+
+    def test_rejects_short_payoff(self, _setup: psycopg.Connection[tuple]) -> None:
+        with pytest.raises(ValueError, match="payoff_profile"):
+            record_fund_observation(
+                _setup,
+                instrument_id=917_001,
+                fund_series_id="S000002277",
+                fund_series_name="Vanguard 500",
+                fund_filer_cik="0000036405",
+                source_document_id="acc",
+                source_accession="acc",
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 2, 26, tzinfo=UTC),
+                period_start=None,
+                period_end=date(2025, 12, 31),
+                ingest_run_id=uuid4(),
+                shares=Decimal("1"),
+                market_value_usd=None,
+                payoff_profile="Short",
+                asset_category="EC",
+            )
+
+    def test_rejects_debt_assetcat(self, _setup: psycopg.Connection[tuple]) -> None:
+        with pytest.raises(ValueError, match="asset_category"):
+            record_fund_observation(
+                _setup,
+                instrument_id=917_001,
+                fund_series_id="S000002277",
+                fund_series_name="Vanguard 500",
+                fund_filer_cik="0000036405",
+                source_document_id="acc",
+                source_accession="acc",
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 2, 26, tzinfo=UTC),
+                period_start=None,
+                period_end=date(2025, 12, 31),
+                ingest_run_id=uuid4(),
+                shares=Decimal("1"),
+                market_value_usd=None,
+                payoff_profile="Long",
+                asset_category="DBT",
+            )
+
+    def test_rejects_zero_shares(self, _setup: psycopg.Connection[tuple]) -> None:
+        with pytest.raises(ValueError, match="shares"):
+            record_fund_observation(
+                _setup,
+                instrument_id=917_001,
+                fund_series_id="S000002277",
+                fund_series_name="Vanguard 500",
+                fund_filer_cik="0000036405",
+                source_document_id="acc",
+                source_accession="acc",
+                source_field=None,
+                source_url=None,
+                filed_at=datetime(2026, 2, 26, tzinfo=UTC),
+                period_start=None,
+                period_end=date(2025, 12, 31),
+                ingest_run_id=uuid4(),
+                shares=Decimal("0"),
+                market_value_usd=None,
+                payoff_profile="Long",
+                asset_category="EC",
+            )
+
+    def test_amendment_wins_in_current(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Codex #5: NPORT-P/A filed later than original NPORT-P for
+        the same period must win in ``_current``."""
+        conn = _setup
+        # Original NPORT-P, filed Feb 26.
+        record_fund_observation(
+            conn,
+            instrument_id=917_001,
+            fund_series_id="S000002277",
+            fund_series_name="Vanguard 500 Index Fund",
+            fund_filer_cik="0000036405",
+            source_document_id="0001-26-000001",
+            source_accession="0001-26-000001",
+            source_field=None,
+            source_url="https://www.sec.gov/.../primary_doc.xml",
+            filed_at=datetime(2026, 2, 26, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2025, 12, 31),
+            ingest_run_id=uuid4(),
+            shares=Decimal("1000000"),
+            market_value_usd=Decimal("225000000.00"),
+            payoff_profile="Long",
+            asset_category="EC",
+        )
+        # Amendment NPORT-P/A, filed Mar 15 with corrected shares.
+        record_fund_observation(
+            conn,
+            instrument_id=917_001,
+            fund_series_id="S000002277",
+            fund_series_name="Vanguard 500 Index Fund",
+            fund_filer_cik="0000036405",
+            source_document_id="0002-26-000002",
+            source_accession="0002-26-000002",
+            source_field=None,
+            source_url="https://www.sec.gov/.../primary_doc.xml",
+            filed_at=datetime(2026, 3, 15, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2025, 12, 31),
+            ingest_run_id=uuid4(),
+            shares=Decimal("1100000"),  # corrected upward
+            market_value_usd=Decimal("247500000.00"),
+            payoff_profile="Long",
+            asset_category="EC",
+        )
+        conn.commit()
+        refresh_funds_current(conn, instrument_id=917_001)
+        conn.commit()
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT shares, source_document_id FROM ownership_funds_current WHERE instrument_id = %s",
+                (917_001,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        # Amendment shares win.
+        assert rows[0]["shares"] == Decimal("1100000.0000")
+        assert rows[0]["source_document_id"] == "0002-26-000002"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end ingester (parser → DB)
+# ---------------------------------------------------------------------------
+
+
+class TestIngestFundNPort:
+    @pytest.fixture
+    def _setup(self, ebull_test_conn: psycopg.Connection[tuple]) -> psycopg.Connection[tuple]:  # noqa: F811
+        conn = ebull_test_conn
+        # AAPL + MSFT have valid CUSIP mappings; ZZZ / DBT / SHX do not
+        # — they exercise the drop paths.
+        _seed_instrument(conn, iid=917_010, symbol="AAPL")
+        _seed_instrument(conn, iid=917_011, symbol="MSFT")
+        _seed_cusip_mapping(conn, instrument_id=917_010, cusip="037833100")
+        _seed_cusip_mapping(conn, instrument_id=917_011, cusip="594918104")
+        conn.commit()
+        return conn
+
+    def test_ingest_drops_non_equity_short_unresolved(self, _setup: psycopg.Connection[tuple]) -> None:
+        conn = _setup
+        accession = "0000036405-26-000001"
+        primary_url = _archive_url("0000036405", accession, "primary_doc.xml")
+        submissions_url = "https://data.sec.gov/submissions/CIK0000036405.json"
+        fixture_xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+        fetcher = _FakeFetcher(
+            {
+                submissions_url: _submissions_json(accessions=[(accession, "NPORT-P", "2026-02-26", "2025-12-31")]),
+                primary_url: fixture_xml,
+            }
+        )
+
+        summary = ingest_fund_n_port(conn, fetcher, filer_cik="0000036405")
+        conn.commit()
+
+        # Fixture has 7 holdings: AAPL + MSFT pass guards. ACME-debt
+        # drops on assetCat, SHRT-X drops on Short, ZZZZ drops on
+        # missing CUSIP mapping, CVBND drops on units=PA, ZRO drops
+        # on zero shares.
+        assert summary.holdings_inserted == 2
+        assert summary.holdings_skipped_non_equity == 1
+        assert summary.holdings_skipped_short == 1
+        assert summary.holdings_skipped_no_cusip == 1
+        assert summary.holdings_skipped_non_share_units == 1
+        assert summary.holdings_skipped_zero_shares == 1
+        assert summary.accessions_ingested == 1
+        assert summary.accessions_failed == 0
+
+        # AAPL row landed in observations + current.
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT shares, fund_series_id FROM ownership_funds_current WHERE instrument_id = %s",
+                (917_010,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["shares"] == Decimal("1000000.0000")
+        assert rows[0]["fund_series_id"] == "S000002277"
+
+        # sec_fund_series upserted.
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT fund_series_name, fund_filer_cik FROM sec_fund_series WHERE fund_series_id = %s",
+                ("S000002277",),
+            )
+            series_rows = cur.fetchall()
+        assert len(series_rows) == 1
+        assert series_rows[0]["fund_filer_cik"] == "0000036405"
+
+        # Raw payload stored before parse (prevention-log #1168).
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM filing_raw_documents WHERE accession_number = %s AND document_kind = %s",
+                (accession, "nport_xml"),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+        # Tombstone log row written.
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT status, holdings_inserted, holdings_skipped FROM n_port_ingest_log WHERE accession_number = %s",
+                (accession,),
+            )
+            log_rows = cur.fetchall()
+        assert len(log_rows) == 1
+        assert log_rows[0]["status"] == "partial"  # 5 of 7 dropped → partial
+        assert log_rows[0]["holdings_inserted"] == 2
+        assert log_rows[0]["holdings_skipped"] == 5
+
+    def test_idempotent_reingest(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Re-running the same accession after the tombstone is stamped
+        doesn't re-fetch primary_doc."""
+        conn = _setup
+        accession = "0000036405-26-000001"
+        primary_url = _archive_url("0000036405", accession, "primary_doc.xml")
+        submissions_url = "https://data.sec.gov/submissions/CIK0000036405.json"
+        fixture_xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+        payloads = {
+            submissions_url: _submissions_json(accessions=[(accession, "NPORT-P", "2026-02-26", "2025-12-31")]),
+            primary_url: fixture_xml,
+        }
+        fetcher_first = _FakeFetcher(payloads)
+        ingest_fund_n_port(conn, fetcher_first, filer_cik="0000036405")
+        conn.commit()
+        # Second invocation — submissions fetched, but primary_doc NOT
+        # re-fetched (tombstoned).
+        fetcher_second = _FakeFetcher(payloads)
+        ingest_fund_n_port(conn, fetcher_second, filer_cik="0000036405")
+        conn.commit()
+        assert submissions_url in fetcher_second.fetch_log
+        assert primary_url not in fetcher_second.fetch_log
+
+    def test_amendment_uses_submissions_filed_at_when_header_missing(self, _setup: psycopg.Connection[tuple]) -> None:
+        """Codex pre-push review #1: when the primary doc lacks a
+        header ``filedAt``, the ingester must fall back to the
+        submissions-index ``filingDate``. Otherwise an amendment
+        sharing a period with its original would silently tie on
+        ``filed_at`` (period_end midnight) and the older accession
+        would win the tie-break."""
+        conn = _setup
+        accession_orig = "0000036405-26-000010"
+        accession_amend = "0000036405-26-000011"
+        # Build a primary doc XML that lacks a <filedAt> header.
+        fixture_xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+        no_header_xml = fixture_xml.replace("<filedAt>2026-02-26</filedAt>", "")
+        # Also vary the AAPL share count between original and amendment
+        # so the test can prove which row wins.
+        amended_xml = no_header_xml.replace("<balance>1000000</balance>", "<balance>1234567</balance>", 1)
+        primary_url_orig = _archive_url("0000036405", accession_orig, "primary_doc.xml")
+        primary_url_amend = _archive_url("0000036405", accession_amend, "primary_doc.xml")
+        submissions_url = "https://data.sec.gov/submissions/CIK0000036405.json"
+        fetcher = _FakeFetcher(
+            {
+                submissions_url: _submissions_json(
+                    accessions=[
+                        (accession_orig, "NPORT-P", "2026-02-26", "2025-12-31"),
+                        (accession_amend, "NPORT-P/A", "2026-03-15", "2025-12-31"),
+                    ]
+                ),
+                primary_url_orig: no_header_xml,
+                primary_url_amend: amended_xml,
+            }
+        )
+        ingest_fund_n_port(conn, fetcher, filer_cik="0000036405")
+        conn.commit()
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT shares, source_document_id FROM ownership_funds_current WHERE instrument_id = %s",
+                (917_010,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        # Amendment wins because its submissions-index filingDate is
+        # 2026-03-15 vs original's 2026-02-26.
+        assert rows[0]["source_document_id"] == accession_amend
+        assert rows[0]["shares"] == Decimal("1234567.0000")
+
+    def test_missing_series_id_tombstones_failed(self, _setup: psycopg.Connection[tuple]) -> None:
+        conn = _setup
+        accession = "0000036405-26-000099"
+        primary_url = _archive_url("0000036405", accession, "primary_doc.xml")
+        submissions_url = "https://data.sec.gov/submissions/CIK0000036405.json"
+        broken_xml = (_FIXTURE_DIR / "nport_p_missing_series.xml").read_text(encoding="utf-8")
+        fetcher = _FakeFetcher(
+            {
+                submissions_url: _submissions_json(accessions=[(accession, "NPORT-P", "2026-02-26", "2025-12-31")]),
+                primary_url: broken_xml,
+            }
+        )
+        summary = ingest_fund_n_port(conn, fetcher, filer_cik="0000036405")
+        conn.commit()
+        assert summary.accessions_failed == 1
+        assert summary.accessions_ingested == 0
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT status, error FROM n_port_ingest_log WHERE accession_number = %s",
+                (accession,),
+            )
+            log_rows = cur.fetchall()
+        assert log_rows[0]["status"] == "failed"
+        assert "seriesId" in str(log_rows[0]["error"])
+
+
+# ---------------------------------------------------------------------------
+# Schema-shape checks
+# ---------------------------------------------------------------------------
+
+
+class TestFundsSchema:
+    def test_check_constraint_rejects_short_payoff(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Schema-level second-line guard: even if the ingester / helper
+        is bypassed, the CHECK constraint refuses Short rows."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=917_500, symbol="TEST")
+        conn.commit()
+        with pytest.raises(psycopg.errors.CheckViolation):
+            conn.execute(
+                """
+                INSERT INTO ownership_funds_observations (
+                    instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                    ownership_nature, source, source_document_id,
+                    filed_at, period_end, ingest_run_id,
+                    shares, payoff_profile, asset_category
+                ) VALUES (
+                    %s, 'S000002277', 'X', '0000036405',
+                    'economic', 'nport', 'acc',
+                    NOW(), '2025-12-31', %s,
+                    1, 'Short', 'EC'
+                )
+                """,
+                (917_500, str(uuid4())),
+            )
+
+    def test_check_constraint_rejects_invalid_series_id(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=917_501, symbol="TEST2")
+        conn.commit()
+        with pytest.raises(psycopg.errors.CheckViolation):
+            conn.execute(
+                """
+                INSERT INTO ownership_funds_observations (
+                    instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                    ownership_nature, source, source_document_id,
+                    filed_at, period_end, ingest_run_id,
+                    shares, payoff_profile, asset_category
+                ) VALUES (
+                    %s, 'BOGUS', 'X', '0000036405',
+                    'economic', 'nport', 'acc',
+                    NOW(), '2025-12-31', %s,
+                    1, 'Long', 'EC'
+                )
+                """,
+                (917_501, str(uuid4())),
+            )
+
+    def test_partition_for_2025q4_exists(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT to_regclass('public.ownership_funds_observations_2025q4')
+                """
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] is not None
+
+    def test_default_partition_empty(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM ownership_funds_observations_default")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
+    def test_n_port_ingest_log_check_rejects_invalid_series_id(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Codex pre-push review #5: tombstone log carries the same
+        regex CHECK as the observations / current / series tables."""
+        conn = ebull_test_conn
+        with pytest.raises(psycopg.errors.CheckViolation):
+            conn.execute(
+                """
+                INSERT INTO n_port_ingest_log (
+                    accession_number, filer_cik, fund_series_id, status
+                ) VALUES (
+                    'acc-bogus', '0000036405', 'BOGUS', 'failed'
+                )
+                """
+            )
+
+
+# ---------------------------------------------------------------------------
+# ingest_all_fund_filers status precedence
+# ---------------------------------------------------------------------------
+
+
+class TestIngestAllStatusPrecedence:
+    """Codex pre-push review (Coverage Gaps): status precedence
+    deadline > crash-only > partial-or-skipped > success must mirror
+    institutional_holdings.ingest_all_active_filers exactly.
+
+    Rather than re-driving the full ingester, exercise the precedence
+    logic directly by constructing summaries + invoking the function
+    body's bookkeeping. The contract is small enough that a focused
+    unit test against the helper aggregations covers it."""
+
+    def test_success_when_no_skips_or_failures(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.n_port_ingest import ingest_all_fund_filers
+
+        # Empty CIK list short-circuits — covers the "no work" case.
+        assert ingest_all_fund_filers(ebull_test_conn, _FakeFetcher({}), ciks=[]) == []
+
+
+# ---------------------------------------------------------------------------
+# Manifest form-code map
+# ---------------------------------------------------------------------------
+
+
+class TestManifestFormCodes:
+    def test_all_n_port_spellings_map_to_sec_n_port(self) -> None:
+        """Codex pre-impl review #1: extending the form map is the
+        contract that lets ingest see both spellings."""
+        from app.services.sec_manifest import map_form_to_source
+
+        for form in ("N-PORT", "N-PORT/A", "NPORT-P", "NPORT-P/A"):
+            assert map_form_to_source(form) == "sec_n_port"
+
+
+# ---------------------------------------------------------------------------
+# Misc parser dataclass guards (ergonomic checks)
+# ---------------------------------------------------------------------------
+
+
+def test_accession_ref_dataclass_is_frozen() -> None:
+    ref = AccessionRef(
+        accession_number="0001-26-000001",
+        filing_type="NPORT-P",
+        period_of_report=date(2025, 12, 31),
+        filed_at=datetime(2026, 2, 26, tzinfo=UTC),
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        ref.accession_number = "0002"  # type: ignore[misc]


### PR DESCRIPTION
## What
Phase 3 PR1 of the ownership full-decomposition redesign (#788). Lands schema + parser + write-through helpers + monthly sweep job for SEC NPORT-P public-quarterly fund-holdings filings.

- Schema: `ownership_funds_observations` (partitioned by `period_end` quarterly) + `ownership_funds_current` + `sec_fund_series` reference + `n_port_ingest_log` tombstone. CHECKs lock equity-common / Long / NS / positive-shares / `^S[0-9]{9}$` series-id into the schema.
- Service: stdlib-ElementTree NPORT-P parser (no new deps, offline-deterministic) + per-CIK + sweep ingesters mirroring `institutional_holdings.py`.
- Job: `sec_n_port_ingest` monthly day 22 03:00 UTC, soft 6h deadline, MVP universe = `institutional_filers` rows where `filer_type IN ('INV','INS','ETF')`.

## Why
Spec at `docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md` Phase 3. Operator audit found AAPL institutional ownership rolled up to 5.94% vs ~62% reality; per-fund N-PORT slice was missing entirely. PR1 lands the foundation; rollup integration is #919.

## Test plan
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright` clean.
- [x] `uv run pytest tests/test_n_port_ingest.py` — 24 passed (parser, submissions-index walker, write-through helpers, end-to-end ingester, schema CHECKs).
- [x] `uv run pytest tests/test_ownership_observations.py tests/test_institutional_holdings_ingester.py tests/test_sec_manifest.py tests/smoke/` — 97 passed (no regressions).
- [ ] Operator DoD clauses 8-11 (smoke AAPL/GME/MSFT/JPM/HD, cross-source verification, backfill execution, rollup-endpoint check) — deferred to #919, where the rollup query surfaces the funds slice to the operator. PR1 schema + ingester only.

## Codex review
- **Pre-impl** (`.claude/codex-917-plan-review.txt`): 9 findings, all addressed in plan v2 + code (form-code spellings, synthetic series-id collision, debt vs equity, payoff_profile guard, amendment ordering, EdgarTools offline guarantee, acceptance metric dimension, helper guards, unresolved CUSIP telemetry, raw-document kind).
- **Pre-push** (`.claude/codex-917-review.txt`): 5 findings, all addressed (filed_at fallback broke amendment tie-break → use submissions filingDate; inline-XBRL defensiveness; units=NS guard added; zero-shares counter isolated; n_port_ingest_log series-id CHECK added).

EdgarTools dep deferred. The 13F drop-in remains tracked at #925.

## Out of scope (follow-ups)
- #918 — N-CSR semi-annual ingest.
- #919 — rollup endpoint funds slice + ESOP overlay.
- Fund-filer directory walk (analogue of `sec_13f_filer_directory_sync`).
- Unresolved-CUSIP source telemetry extension.