### PR TITLE
docs: add THIRD_PARTY_NOTICES.md + refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,54 +2,72 @@
 
 Long-horizon AI-assisted investment engine for eToro.
 
-- Python backend with FastAPI
-- PostgreSQL as the system of record
-- Claude Code skills / agents / hooks for research and execution discipline
-- SQL-first schema for auditability
-- Demo-first, live-small-capital later
+- Python 3.14 backend on FastAPI; jobs run in a separate APScheduler process.
+- PostgreSQL 17 as the system of record (125+ migrations, partitioned ownership tables).
+- React + Vite + TypeScript operator dashboard with Tailwind.
+- Claude Code skills / agents / hooks drive research, review, and execution discipline.
+- SQL-first schema for auditability — every recommendation, decision, and order ties back to a structured row.
+- Demo-first; small-capital live later. Long-only v1, no leverage, no shorting.
+
+## Process topology
+
+The runtime is split (#719):
+
+- **API process** (`uvicorn app.main:app`) — HTTP only. No scheduler, no orchestrator, no reaper.
+- **Jobs process** (`python -m app.jobs`) — APScheduler, manual-trigger executor, sync orchestrator, queue dispatcher, reaper, heartbeat. Singleton via Postgres advisory lock.
+- **Frontend** — Vite dev server (`pnpm --dir frontend dev`).
+
+IPC is Postgres-only: durable `pending_job_requests` rows + `pg_notify` wakeups. No HTTP between processes.
 
 ## Repo structure
 
-- `app/` — services, providers, workers, and API
-- `sql/` — Postgres migrations (001–021 and counting)
-- `docs/` — architecture, scoring model, trading policy, tax engine
-- `.claude/` — project guidance, skills, agents, and hooks
-- `frontend/` — React + Vite operator dashboard (pnpm)
-- `tests/` — pytest suite
-- `docker-compose.yml` — local Postgres
+- `app/` — FastAPI services, providers, jobs runtime, security, CLI.
+  - `app/api/` — HTTP route handlers.
+  - `app/services/` — domain logic (filings, ownership, fundamentals, news, ranking, portfolio, execution guard, ledger).
+  - `app/providers/` — thin adapters over SEC EDGAR, FINRA, eToro, Companies House, Anthropic.
+  - `app/workers/scheduler.py` — declared `ScheduledJob` registry (~26 jobs).
+  - `app/jobs/` — runtime, locks, listener, supervisor, manifest worker, ingest workers.
+- `sql/` — Postgres migrations (`001` … `125+`). Numeric prefix; never edited in place.
+- `frontend/` — React + Vite operator dashboard (pnpm).
+- `tests/` — pytest suite (integration tests against `ebull_test` DB).
+- `.claude/` — project guidance, skills, agents, hooks, commands.
+- `.githooks/pre-push` — runs ruff + format + pyright on every push.
+- `docs/` — architecture, scoring model, trading policy, tax engine, settled-decisions, review-prevention log, ADRs, super-power specs.
+- `docker-compose.yml` — local Postgres 17.
+- `THIRD_PARTY_NOTICES.md` — open-source dependency licenses.
 
 ## Current state
 
 Backend services implemented:
-- Universe sync
-- Market data (OHLCV, quotes, features)
-- Filings and fundamentals (SEC EDGAR, Companies House)
-- News and sentiment
-- Thesis engine (#6)
-- Scoring and ranking engine
-- Portfolio manager
-- Execution guard
-- eToro order client (#10)
-- Tax ledger (#11)
-- Coverage tier management (#12)
-- REST API layer (FastAPI) and operator dashboard
-- Ops monitoring (job runs, runtime config, admin page)
-- Broker credential management with durable audit log
 
-Currently in flight:
+- Universe sync (eToro instruments, exchange + sector lookups).
+- Market data (OHLCV, intraday candles, FX rates).
+- Filings ingestion: SEC EDGAR (Form 3/4/5, 13D/G, 13F-HR, DEF 14A, 8-K, NPORT-P, 10-K/10-Q, XBRL company-facts) and Companies House.
+- News + sentiment with Anthropic-classified scores.
+- Fundamentals + business-summary ingest from SEC XBRL.
+- **Ownership card** (#788 redesign) — two-layer observations + materialised current snapshots, partitioned by `period_end`. Categories: insiders, institutions (13F-HR), blockholders (13D/G), DEF 14A bene, treasury, **funds (NPORT-P, #917)**.
+- Thesis engine + critic, scoring + ranking, portfolio manager, execution guard, eToro order client.
+- Tax ledger + reconciliation.
+- Coverage tier management, ops monitoring, runtime config, broker-credential audit.
+- Operator dashboard with chart drilldowns, ownership card, thesis drawer, settings.
 
-- Copy-trading ingestion (#183 Track 1a), AUM correction (#187
-  Track 1b), browsing UX (#188 Track 1.5), discovery (#189 Track 2)
+In flight:
+
+- Phase 3 of #788 — N-CSR (#918), rollup funds slice + ESOP (#919).
+- Short-interest overlay (#915 FINRA bimonthly + #916 RegSHO daily).
+- DEF 14A consolidated (#843), DRS / restricted disclosure (#844).
+- Chart UI polish: hatching, click-through, coverage-banner v2, history pane (#920–#923).
+- EdgarTools as 13F drop-in parser (#925).
 
 ## Prerequisites
 
 | Tool | Minimum version | Notes |
 |------|----------------|-------|
-| Python | 3.14 | `python --version` |
-| uv | 0.11 | Python package manager — `pip install uv` |
-| Node.js | 22 LTS | `node --version` |
+| Python | 3.14 | |
+| uv | 0.5.21 | Python package manager — `pip install uv==0.5.21`. Pinned to match CI. |
+| Node.js | 22 LTS | |
 | pnpm | 10 | `npm install -g pnpm` |
-| Docker | 28 | Runs PostgreSQL 17 via `docker-compose.yml` |
+| Docker | 28 | Local Postgres 17 via `docker-compose.yml`. |
 | Git | 2.40+ | |
 
 ## Local setup
@@ -58,10 +76,19 @@ Currently in flight:
 cp .env.example .env
 docker compose up -d
 uv sync --group dev
-# Three processes run side-by-side in dev: API, jobs, frontend.
+pnpm --dir frontend install
+
+# Wire the pre-push hook (one-time per clone).
+git config core.hooksPath .githooks
+```
+
+Then run the three processes side by side (a VS Code task pre-bakes
+this):
+
+```bash
 uv run uvicorn app.main:app --reload --reload-dir app
 uv run python -m app.jobs
-pnpm --dir frontend install && pnpm --dir frontend dev
+pnpm --dir frontend dev
 ```
 
 Open <http://localhost:5173>. On a fresh database the app drops into
@@ -73,7 +100,7 @@ on the `/setup` form and you are signed in. After that the standard
 
 The default bind is `127.0.0.1` (loopback only) so the first-run setup
 form needs no token. If you change `EBULL_HOST` to a non-loopback
-address, the setup form will refuse the request unless one of the
+address, the setup form refuses the request unless one of the
 following is true:
 
 - you set `EBULL_BOOTSTRAP_TOKEN` in `.env` to a high-entropy string
@@ -85,12 +112,14 @@ following is true:
 
 This is the only path that lets a brand-new instance be set up over
 the LAN. There is no IP allow-list — anything reachable on the bind
-address can hit the form, so the token is the trust boundary.
+address can hit the form, so the token is the trust boundary. See
+[`docs/adr/0002-first-run-setup.md`](docs/adr/0002-first-run-setup.md).
 
 ### Recovery / break-glass CLI
 
-Normal onboarding is the browser flow above. The CLI in `app/cli.py`
-exists for cases where the browser path is unavailable:
+Normal onboarding is the browser flow above. The CLI in
+[`app/cli.py`](app/cli.py) exists for cases where the browser path is
+unavailable:
 
 ```bash
 # Forgot your password
@@ -100,10 +129,71 @@ uv run python -m app.cli set-password    alice
 uv run python -m app.cli create-operator alice
 ```
 
-Both prompt for the password interactively (via `getpass`) so it never
-appears in shell history. `create-operator` refuses to overwrite an
-existing row without `--force`.
+Both prompt for the password interactively (via `getpass`) so the
+password never appears in shell history. `create-operator` refuses to
+overwrite an existing row without `--force`.
 
-## Build order
+## Pre-push checklist
 
-See `.claude/CLAUDE.md` and `docs/architecture.md` for detailed guidance.
+The committed pre-push hook at [`.githooks/pre-push`](.githooks/pre-push)
+runs these on every push:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+```
+
+Pytest is the developer's responsibility before push (CI runs lint +
+supply-chain only). Run locally:
+
+```bash
+uv run pytest
+# Frontend
+pnpm --dir frontend typecheck && pnpm --dir frontend test:unit
+```
+
+`uv run pytest` includes `tests/smoke/test_app_boots.py`, which drives
+the FastAPI lifespan through `TestClient` against the real dev DB. If
+that test fails, the running server is broken — fix the root cause,
+do not skip it.
+
+## CI
+
+`.github/workflows/ci.yml` runs on every pull request:
+
+- **lint** — ruff check + ruff format + pyright + pre-push hook mode (100755 enforced).
+- **supply-chain** — pnpm audit (frontend) + pip-audit (backend lockfile).
+
+Pytest is no longer a CI gate (operator decision 2026-05-05; pre-push
+hook is the test gate).
+
+`.github/workflows/claude-review.yml` posts an automated review on
+every PR push using Claude.
+
+## Settled decisions
+
+See [`docs/settled-decisions.md`](docs/settled-decisions.md) for live
+repo-level decisions: provider strategy, identifier strategy, filing
+storage, news/sentiment, thesis semantics, scoring, portfolio manager,
+execution guard, process topology, broker-secret encryption.
+
+Per-feature design specs live under
+[`docs/superpowers/specs/`](docs/superpowers/specs/) and
+[`docs/superpowers/plans/`](docs/superpowers/plans/).
+
+## Third-party software
+
+eBull bundles open-source dependencies under permissive licenses (MIT,
+BSD, Apache-2.0) plus LGPL'd psycopg as a runtime link. Full inventory
+and per-package notices in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+
+Public data sources (SEC EDGAR, FINRA, Companies House, eToro API) are
+listed there with their terms.
+
+## License
+
+eBull's own source is currently unlicensed (proprietary). Distribution
+or modification of eBull source requires explicit operator consent.
+The bundled open-source dependencies retain their own licenses
+irrespective of eBull's status.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,134 @@
+# Third-Party Notices
+
+eBull bundles or depends on the following open-source software. Each
+entry below lists the project, its license, and an upstream link. Where
+permitted, we exercise commercial / closed / paywalled distribution
+rights granted by these licenses.
+
+For licenses requiring redistribution of the original notice (MIT,
+BSD-3-Clause, Apache-2.0), the full license text is reproduced under
+[`LICENSES/`](LICENSES/) at the project root and shipped with every
+distribution.
+
+## Backend (Python)
+
+### Production
+
+| Package | License | Upstream |
+|---|---|---|
+| anthropic | MIT | <https://github.com/anthropics/anthropic-sdk-python> |
+| fastapi | MIT | <https://github.com/tiangolo/fastapi> |
+| uvicorn (with `standard` extras) | BSD-3-Clause | <https://github.com/encode/uvicorn> |
+| pydantic | MIT | <https://github.com/pydantic/pydantic> |
+| pydantic-settings | MIT | <https://github.com/pydantic/pydantic-settings> |
+| psycopg (with `binary` extras) | LGPL-3.0-or-later | <https://github.com/psycopg/psycopg> |
+| psycopg-pool | LGPL-3.0-or-later | <https://github.com/psycopg/psycopg> |
+| httpx | BSD-3-Clause | <https://github.com/encode/httpx> |
+| argon2-cffi | MIT | <https://github.com/hynek/argon2-cffi> |
+| cryptography | Apache-2.0 OR BSD-3-Clause | <https://github.com/pyca/cryptography> |
+| platformdirs | MIT | <https://github.com/platformdirs/platformdirs> |
+| apscheduler | MIT | <https://github.com/agronholm/apscheduler> |
+| redis (with `hiredis` extras) | MIT | <https://github.com/redis/redis-py> |
+
+**psycopg LGPL note.** psycopg uses LGPL-3.0-or-later, which permits
+linking from non-GPL applications (including closed-source ones) so
+long as the LGPL'd component itself remains replaceable. Because we
+import psycopg as an unmodified PyPI dependency, the standard
+"dynamic linking" exemption applies: redistribution of eBull does
+not require source disclosure of eBull itself, but does require us
+to (a) include the LGPL notice + license text, (b) provide the
+psycopg source on request (a link to the upstream repository
+satisfies this), and (c) not statically combine our code with a
+modified psycopg without complying with §4 of the LGPL. We do
+none of (c).
+
+### Dev-only (not redistributed)
+
+These ship in the dev dependency group and run on developer machines /
+CI runners only. They do not enter the production runtime artifact.
+
+| Package | License | Upstream |
+|---|---|---|
+| ruff | MIT | <https://github.com/astral-sh/ruff> |
+| pyright | MIT | <https://github.com/microsoft/pyright> |
+| pytest | MIT | <https://github.com/pytest-dev/pytest> |
+| pytest-asyncio | Apache-2.0 | <https://github.com/pytest-dev/pytest-asyncio> |
+| pytest-xdist | MIT | <https://github.com/pytest-dev/pytest-xdist> |
+| pytest-testmon | AGPL-3.0 | <https://github.com/tarpas/pytest-testmon> |
+
+**pytest-testmon AGPL note.** AGPL-3.0 obligations attach to
+distribution / network-service interaction with the AGPL'd code.
+pytest-testmon runs only on developer / CI machines as a test
+selection helper; it is never linked into the eBull runtime, never
+network-served, and never redistributed as part of eBull. As long as
+this remains true, AGPL obligations do not propagate to eBull. If
+the project ever ships testmon in a runtime path or as a hosted
+service, this notice must be revisited.
+
+## Frontend (Node)
+
+### Production
+
+| Package | License | Upstream |
+|---|---|---|
+| react | MIT | <https://github.com/facebook/react> |
+| react-dom | MIT | <https://github.com/facebook/react> |
+| react-router-dom | MIT | <https://github.com/remix-run/react-router> |
+| @tanstack/react-query | MIT | <https://github.com/TanStack/query> |
+| lightweight-charts | Apache-2.0 | <https://github.com/tradingview/lightweight-charts> |
+| recharts | MIT | <https://github.com/recharts/recharts> |
+
+### Dev-only
+
+| Package | License | Upstream |
+|---|---|---|
+| typescript | Apache-2.0 | <https://github.com/microsoft/TypeScript> |
+| vite | MIT | <https://github.com/vitejs/vite> |
+| @vitejs/plugin-react | MIT | <https://github.com/vitejs/vite-plugin-react> |
+| vitest | MIT | <https://github.com/vitest-dev/vitest> |
+| jsdom | MIT | <https://github.com/jsdom/jsdom> |
+| @testing-library/react | MIT | <https://github.com/testing-library/react-testing-library> |
+| @testing-library/jest-dom | MIT | <https://github.com/testing-library/jest-dom> |
+| @testing-library/user-event | MIT | <https://github.com/testing-library/user-event> |
+| tailwindcss | MIT | <https://github.com/tailwindlabs/tailwindcss> |
+| autoprefixer | MIT | <https://github.com/postcss/autoprefixer> |
+| postcss | MIT | <https://github.com/postcss/postcss> |
+| @types/* | MIT (DefinitelyTyped) | <https://github.com/DefinitelyTyped/DefinitelyTyped> |
+
+## Public data sources
+
+eBull consumes data from the following sources. None imposes a
+commercial-use restriction on derived analyses; all are public and
+either US-government works or contractually-clean public APIs.
+
+| Source | Terms | Notes |
+|---|---|---|
+| SEC EDGAR | US-government public domain (17 USC §105) | 10 req/s fair-use cap; User-Agent header required (set via `EBULL_SEC_USER_AGENT`). |
+| FINRA published files | Free public data | Bimonthly short-interest, daily RegSHO short-volume. |
+| eToro API | Per eToro Public API Terms | Account / quote / order endpoints. Operator must hold valid eToro credentials. |
+| Companies House (UK) | Open Government Licence v3.0 | Filings + company metadata for UK issuers. |
+
+## Generative AI (Anthropic Claude)
+
+eBull invokes the Anthropic API for thesis writing, critic review, and
+narrative generation. Anthropic's API ToS govern usage; the SDK
+(`anthropic`) is MIT-licensed (see backend table). Generated content
+is owned by the operator subject to Anthropic's usage policy.
+
+## How this file is maintained
+
+Update this file in the same PR that adds, removes, or upgrades any
+top-level dependency. Direct edits to `pyproject.toml` `dependencies` /
+`dependency-groups.dev` and `frontend/package.json`
+`dependencies` / `devDependencies` MUST be reflected here. Transitive
+dependencies are not enumerated; the lockfiles (`uv.lock` and
+`frontend/pnpm-lock.yaml`) are the authoritative complete inventory and
+can be audited via `uv export` + `pnpm licenses list` when assembling
+a redistributable build.
+
+## License
+
+eBull's own source is currently unlicensed (proprietary). Distribution
+or modification of eBull source requires explicit operator consent.
+Open-source dependencies above retain their own licenses irrespective
+of eBull's status.


### PR DESCRIPTION
## What
Add `THIRD_PARTY_NOTICES.md` cataloguing every top-level Python + Node dependency with license + upstream URL. Refresh `README.md` to reflect current repo state.

## Why
Notices file is the prerequisite for paywalled / commercial distribution: MIT / BSD / Apache-2.0 deps require the license notice be reproduced on redistribution. README was several months out of date — missed process topology split (#719), ownership card redesign (#788), pre-push test gate (post-#928), and current dep / version pins.

## Test plan
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright` clean.
- [x] Notices file lists every package in `pyproject.toml` `dependencies` + `dependency-groups.dev` and every `frontend/package.json` `dependencies` + `devDependencies`.
- [x] README reflects: 125+ migrations, Postgres 17, Python 3.14, uv 0.5.21 pinned, jobs-process split, NPORT-P + ownership_funds tables, pre-push test gate, supply-chain CI, pointer to settled-decisions + super-power specs.

## Notes
- psycopg (LGPL-3.0-or-later): LGPL note in notices file documents the dynamic-link allowance + source-on-request obligation.
- pytest-testmon (AGPL-3.0): dev-only carve-out documented; AGPL doesn't propagate provided testmon stays out of the runtime / network path.
- eBull's own source remains unlicensed (proprietary) — this PR doesn't change that.