### PR TITLE
docs: rewrite README for general audience + add GitHub Wiki publish guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,135 @@
 # eBull
 
-Long-horizon AI-assisted investment engine for eToro.
+A self-hosted, AI-assisted long-horizon investment engine for eToro.
 
-- Python 3.14 backend on FastAPI; jobs run in a separate APScheduler process.
-- PostgreSQL 17 as the system of record (125+ migrations, partitioned ownership tables).
-- React + Vite + TypeScript operator dashboard with Tailwind.
-- Claude Code skills / agents / hooks drive research, review, and execution discipline.
-- SQL-first schema for auditability — every recommendation, decision, and order ties back to a structured row.
-- Demo-first; small-capital live later. Long-only v1, no leverage, no shorting.
+eBull aggregates regulatory filings, market data, news, and ownership
+disclosures across thousands of US and UK issuers, runs them through
+an explicit scoring model and an Anthropic-backed thesis writer, and
+surfaces the result as a structured operator dashboard. Every
+recommendation, ranking, and order ties back to a row you can audit.
 
-## Process topology
+> **Status — actively developed pre-release.** The data plane and
+> operator dashboard are functional on a single-instance demo. Live
+> trading is gated behind a kill switch and explicit operator opt-in.
+> Schemas, endpoints, and frontend surfaces are subject to change
+> without notice.
 
-The runtime is split (#719):
+## What it does
 
-- **API process** (`uvicorn app.main:app`) — HTTP only. No scheduler, no orchestrator, no reaper.
-- **Jobs process** (`python -m app.jobs`) — APScheduler, manual-trigger executor, sync orchestrator, queue dispatcher, reaper, heartbeat. Singleton via Postgres advisory lock.
-- **Frontend** — Vite dev server (`pnpm --dir frontend dev`).
+- Ingests filings from **SEC EDGAR** (10-K / 10-Q / 8-K / 13F-HR /
+  13D / 13G / NPORT-P / N-CSR / DEF 14A / Form 3-4-5) and
+  **Companies House** (UK).
+- Pulls market data and execution from **eToro**.
+- Adds **FINRA short-interest** + RegSHO daily volume and
+  **Anthropic-classified** news sentiment.
+- Resolves identifiers (CIK, CUSIP, ISIN, LEI) into a single
+  instrument graph.
+- Materialises an "ownership card" per instrument: institutional /
+  insider / blockholder / mutual-fund / treasury / ESOP slices, each
+  with a freshness state and a click-through to the underlying
+  filings.
+- Generates per-instrument theses and a critic pass via the
+  Anthropic API; scores and ranks under an explicit, audit-friendly
+  v1 model (no ML, no cohort normalisation, no hidden weights).
+- Drives a portfolio-manager + execution-guard pipeline that turns
+  recommendations into eToro orders — under hard rule constraints
+  (long-only, no leverage, no shorting, kill-switch enforced).
 
-IPC is Postgres-only: durable `pending_job_requests` rows + `pg_notify` wakeups. No HTTP between processes.
+## Design philosophy
 
-## Repo structure
+- **Free regulated-source-only.** SEC, FINRA, Companies House,
+  eToro. No paid fundamentals (S&P, FactSet, Bloomberg). No scraped
+  feeds. No unofficial API wrappers.
+- **Audit before automation.** Every trade path is reviewable.
+  Every recommendation cites its inputs. Raw payloads are persisted
+  before parsing so a parser bug can be re-washed without re-fetching
+  the upstream.
+- **Deterministic execution, AI-heavy research.** Thesis writer and
+  critic are LLM-driven. The scoring model, portfolio manager, and
+  execution guard are explicit code with hard rules.
+- **Operator in the loop.** Long-only v1. Kill switch is a runtime
+  flag separate from deployment config. Live trading requires
+  explicit opt-in and small-capital posture before scaling.
+- **Postgres-first.** No Redis pub-sub for control plane, no shared
+  memory between processes, no message queues. The system of record
+  is one Postgres instance with structured rows you can query
+  directly.
 
-- `app/` — FastAPI services, providers, jobs runtime, security, CLI.
-  - `app/api/` — HTTP route handlers.
-  - `app/services/` — domain logic (filings, ownership, fundamentals, news, ranking, portfolio, execution guard, ledger).
-  - `app/providers/` — thin adapters over SEC EDGAR, FINRA, eToro, Companies House, Anthropic.
-  - `app/workers/scheduler.py` — declared `ScheduledJob` registry (~26 jobs).
-  - `app/jobs/` — runtime, locks, listener, supervisor, manifest worker, ingest workers.
-- `sql/` — Postgres migrations (`001` … `125+`). Numeric prefix; never edited in place.
-- `frontend/` — React + Vite operator dashboard (pnpm).
-- `tests/` — pytest suite (integration tests against `ebull_test` DB).
-- `.claude/` — project guidance, skills, agents, hooks, commands.
-- `.githooks/pre-push` — runs ruff + format + pyright on every push.
-- `docs/` — architecture, scoring model, trading policy, tax engine, settled-decisions, review-prevention log, ADRs, super-power specs.
-- `docker-compose.yml` — local Postgres 17.
-- `THIRD_PARTY_NOTICES.md` — open-source dependency licenses.
+## Direction of travel
 
-## Current state
+eBull is being built out in phases:
 
-Backend services implemented:
+1. **Tradable universe** — eToro instrument sync, exchange + sector
+   metadata, identifier reconciliation. ✓
+2. **Market data** — quotes, candles, FX, intraday + EOD. ✓
+3. **Filings + news ingestion** — SEC + Companies House + Anthropic
+   sentiment. ✓
+4. **Ownership card** — multi-source decomposition with freshness
+   gates. (Active.)
+5. **Thesis + critic engine** — LLM-driven research with structured
+   citations. ✓
+6. **Ranking engine** — heuristic v1 scoring with audit columns. ✓
+7. **Portfolio manager + execution guard** — recommendation →
+   guarded order pipeline. ✓
+8. **Tax + reconciliation ledger** — basis tracking + reporting. (In flight.)
 
-- Universe sync (eToro instruments, exchange + sector lookups).
-- Market data (OHLCV, intraday candles, FX rates).
-- Filings ingestion: SEC EDGAR (Form 3/4/5, 13D/G, 13F-HR, DEF 14A, 8-K, NPORT-P, 10-K/10-Q, XBRL company-facts) and Companies House.
-- News + sentiment with Anthropic-classified scores.
-- Fundamentals + business-summary ingest from SEC XBRL.
-- **Ownership card** (#788 redesign) — two-layer observations + materialised current snapshots, partitioned by `period_end`. Categories: insiders, institutions (13F-HR), blockholders (13D/G), DEF 14A bene, treasury, **funds (NPORT-P, #917)**.
-- Thesis engine + critic, scoring + ranking, portfolio manager, execution guard, eToro order client.
-- Tax ledger + reconciliation.
-- Coverage tier management, ops monitoring, runtime config, broker-credential audit.
-- Operator dashboard with chart drilldowns, ownership card, thesis drawer, settings.
+Active focus areas: closing out ownership decomposition (mutual
+funds via N-PORT / N-CSR; short-interest overlay via FINRA),
+chart polish on the operator dashboard, and full coverage banner
+state machine.
 
-In flight:
+## Stack
 
-- Phase 3 of #788 — N-CSR (#918), rollup funds slice + ESOP (#919).
-- Short-interest overlay (#915 FINRA bimonthly + #916 RegSHO daily).
-- DEF 14A consolidated (#843), DRS / restricted disclosure (#844).
-- Chart UI polish: hatching, click-through, coverage-banner v2, history pane (#920–#923).
-- EdgarTools as 13F drop-in parser (#925) — **shipped 2026-05-05**.
-- N-PORT EdgarTools rewrite (#932) — operator decision pending (Pydantic-validation-cliff trade-off).
+- **Backend** — Python 3.14, FastAPI, APScheduler, psycopg 3, uv.
+- **Database** — PostgreSQL 17 with partitioned ownership tables and
+  125+ migrations.
+- **Frontend** — React + Vite + TypeScript + Tailwind.
+- **AI** — Anthropic Claude (research + critic + narrative).
+- **Process model** — split API ↔ jobs processes, both on the same
+  Postgres. Singleton enforced via advisory lock. (#719 settled.)
 
-## Prerequisites
+Full third-party inventory: [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
 
-| Tool | Minimum version | Notes |
-|------|----------------|-------|
-| Python | 3.14 | |
-| uv | 0.5.21 | Python package manager — `pip install uv==0.5.21`. Pinned to match CI. |
-| Node.js | 22 LTS | |
-| pnpm | 10 | `npm install -g pnpm` |
-| Docker | 28 | Local Postgres 17 via `docker-compose.yml`. |
-| Git | 2.40+ | |
+## Documentation
+
+| Audience | Start here |
+|---|---|
+| Operator running eBull | [`docs/wiki/`](docs/wiki/) |
+| Contributor — workflow | [`.claude/CLAUDE.md`](.claude/CLAUDE.md) |
+| Contributor — design decisions | [`docs/settled-decisions.md`](docs/settled-decisions.md) |
+| Contributor — recurring mistakes | [`docs/review-prevention-log.md`](docs/review-prevention-log.md) |
+| Contributor — epic specs | [`docs/superpowers/specs/README.md`](docs/superpowers/specs/README.md) |
+
+The `docs/wiki/` directory is the source of truth for the operator
+wiki. The GitHub Wiki tab can be populated from this directory once
+the operator creates the first wiki page via the web UI (GitHub does
+not provision the wiki repo until then). See
+[`docs/wiki/HOW-TO-PUBLISH.md`](docs/wiki/HOW-TO-PUBLISH.md).
 
 ## Local setup
 
+Prerequisites:
+
+| Tool | Minimum |
+|---|---|
+| Python | 3.14 |
+| uv | 0.5.21 |
+| Node.js | 22 LTS |
+| pnpm | 10 |
+| Docker | 28 (for Postgres 17 via `docker-compose.yml`) |
+| Git | 2.40+ |
+
+Bootstrap:
+
 ```bash
-cp .env.example .env
+cp .env.example .env       # fill in DATABASE_URL + SEC_USER_AGENT
 docker compose up -d
 uv sync --group dev
 pnpm --dir frontend install
-
-# Wire the pre-push hook (one-time per clone).
-git config core.hooksPath .githooks
+git config core.hooksPath .githooks   # one-time per clone
 ```
 
-Then run the three processes side by side (a VS Code task pre-bakes
-this):
+Three processes side by side (a VS Code task pre-bakes this):
 
 ```bash
 uv run uvicorn app.main:app --reload --reload-dir app
@@ -94,8 +139,7 @@ pnpm --dir frontend dev
 
 Open <http://localhost:5173>. On a fresh database the app drops into
 **first-run setup**: pick a username and a password (≥ 12 characters)
-on the `/setup` form and you are signed in. After that the standard
-`/login` flow takes over.
+on `/setup` and you are signed in.
 
 ### Non-loopback bind
 
@@ -104,17 +148,15 @@ form needs no token. If you change `EBULL_HOST` to a non-loopback
 address, the setup form refuses the request unless one of the
 following is true:
 
-- you set `EBULL_BOOTSTRAP_TOKEN` in `.env` to a high-entropy string
-  and paste that value into the **Setup token** field, **or**
-- you let the server generate one on first start: with no env token,
-  an empty `operators` table, and a non-loopback bind, the server
-  prints a one-shot token to its log on the first request and accepts
-  it exactly once on `/setup`.
+- `EBULL_BOOTSTRAP_TOKEN` is set to a high-entropy string in `.env`
+  and pasted into the **Setup token** field, **or**
+- the server generates one on first start (no env token + empty
+  `operators` table + non-loopback bind) and prints a one-shot token
+  to its log on the first request.
 
-This is the only path that lets a brand-new instance be set up over
-the LAN. There is no IP allow-list — anything reachable on the bind
-address can hit the form, so the token is the trust boundary. See
-[`docs/adr/0002-first-run-setup.md`](docs/adr/0002-first-run-setup.md).
+The login surface is open to anyone reachable on the bind address —
+there is no IP allow-list, the token is the trust boundary. See
+[`docs/adr/0002-local-browser-bootstrap-and-multi-operator.md`](docs/adr/0002-local-browser-bootstrap-and-multi-operator.md).
 
 ### Recovery / break-glass CLI
 
@@ -123,21 +165,18 @@ Normal onboarding is the browser flow above. The CLI in
 unavailable:
 
 ```bash
-# Forgot your password
-uv run python -m app.cli set-password    alice
-
-# Operators table got wiped and the browser flow refuses to help
-uv run python -m app.cli create-operator alice
+uv run python -m app.cli set-password    alice    # forgot password
+uv run python -m app.cli create-operator alice    # operators table wiped
 ```
 
-Both prompt for the password interactively (via `getpass`) so the
-password never appears in shell history. `create-operator` refuses to
-overwrite an existing row without `--force`.
+Both prompt interactively via `getpass`; passwords never appear in
+shell history. `create-operator` refuses to overwrite an existing
+row without `--force`.
 
 ## Pre-push checklist
 
 The committed pre-push hook at [`.githooks/pre-push`](.githooks/pre-push)
-runs these on every push:
+runs on every push:
 
 ```bash
 uv run ruff check .
@@ -145,55 +184,40 @@ uv run ruff format --check .
 uv run pyright
 ```
 
-Pytest is the developer's responsibility before push (CI runs lint +
-supply-chain only). Run locally:
+Pytest is the developer's responsibility before push — CI runs lint +
+supply-chain only. Run locally:
 
 ```bash
 uv run pytest
-# Frontend
 pnpm --dir frontend typecheck && pnpm --dir frontend test:unit
 ```
 
 `uv run pytest` includes `tests/smoke/test_app_boots.py`, which drives
-the FastAPI lifespan through `TestClient` against the real dev DB. If
-that test fails, the running server is broken — fix the root cause,
-do not skip it.
+the FastAPI lifespan against the real dev DB — that test failing
+means the running server is broken, not that the test is flaky.
 
 ## CI
 
-`.github/workflows/ci.yml` runs on every pull request:
+`.github/workflows/ci.yml` on every pull request:
 
-- **lint** — ruff check + ruff format + pyright + pre-push hook mode (100755 enforced).
-- **supply-chain** — pnpm audit (frontend) + pip-audit (backend lockfile).
-
-Pytest is no longer a CI gate (operator decision 2026-05-05; pre-push
-hook is the test gate).
+- **lint** — ruff check + format + pyright + pre-push hook mode-bit check.
+- **supply-chain** — pnpm audit (frontend) + pip-audit (backend).
 
 `.github/workflows/claude-review.yml` posts an automated review on
-every PR push using Claude.
+every PR push.
 
-## Documentation
+## Contributing
 
-| Audience | Read this first |
-|---|---|
-| Operator running eBull | [`docs/wiki/`](docs/wiki/) |
-| Contributor (workflow rules) | [`.claude/CLAUDE.md`](.claude/CLAUDE.md) |
-| Contributor (design decisions) | [`docs/settled-decisions.md`](docs/settled-decisions.md) |
-| Contributor (recurring mistakes) | [`docs/review-prevention-log.md`](docs/review-prevention-log.md) |
-| Contributor (epic-level designs) | [`docs/superpowers/specs/README.md`](docs/superpowers/specs/README.md) |
-
-## Third-party software
-
-eBull bundles open-source dependencies under permissive licenses (MIT,
-BSD, Apache-2.0) plus LGPL'd psycopg as a runtime link. Full inventory
-and per-package notices in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
-
-Public data sources (SEC EDGAR, FINRA, Companies House, eToro API) are
-listed there with their terms.
+eBull is currently developed by a single operator. Contributions are
+accepted under the project's source license (currently proprietary).
+Read [`.claude/CLAUDE.md`](.claude/CLAUDE.md) end-to-end before
+opening a PR — the workflow rules (branch + PR sequence, Codex
+checkpoints, review resolution contract, ETL definition-of-done
+clauses) are non-negotiable.
 
 ## License
 
-eBull's own source is currently unlicensed (proprietary). Distribution
-or modification of eBull source requires explicit operator consent.
-The bundled open-source dependencies retain their own licenses
+eBull's own source is currently unlicensed (proprietary).
+Distribution or modification of eBull source requires explicit
+operator consent. Open-source dependencies retain their own licenses
 irrespective of eBull's status.

--- a/docs/wiki/HOW-TO-PUBLISH.md
+++ b/docs/wiki/HOW-TO-PUBLISH.md
@@ -1,0 +1,69 @@
+# How to publish this wiki to the GitHub Wiki tab
+
+## TL;DR
+
+The `docs/wiki/` directory in this repo is the source of truth for
+the eBull operator wiki. To publish it under the **Wiki** tab on
+GitHub:
+
+1. Visit https://github.com/Luke-Bradford/eBull/wiki and click
+   "Create the first page". Title it `Home`, paste any placeholder
+   content, save. (GitHub does not provision the wiki Git
+   repository until the first page is created via the web UI.)
+2. Run the publish script (below) to mirror `docs/wiki/` into the
+   wiki repo.
+
+## Why this is necessary
+
+GitHub Wiki content lives in a sibling Git repository at
+`https://github.com/<owner>/<repo>.wiki.git`. That repo is
+auto-created the first time a page is saved through the web UI;
+before that, push attempts return `Repository not found`.
+
+eBull keeps the canonical wiki content in-repo (under `docs/wiki/`)
+so it ships with the rest of the source — wiki changes go through
+the same PR review process as code. The GitHub Wiki tab is a
+mirror, not the source.
+
+## Publish script
+
+After the one-time web bootstrap, run:
+
+```bash
+git clone https://github.com/Luke-Bradford/eBull.wiki.git /tmp/ebull-wiki
+cd /tmp/ebull-wiki
+
+# Mirror docs/wiki/ contents. GitHub Wiki uses Home.md not README.md.
+cp /path/to/eBull/docs/wiki/README.md       Home.md
+cp /path/to/eBull/docs/wiki/getting-started.md ./
+cp /path/to/eBull/docs/wiki/architecture.md  ./
+cp /path/to/eBull/docs/wiki/data-sources.md  ./
+cp /path/to/eBull/docs/wiki/ownership-card.md ./
+cp /path/to/eBull/docs/wiki/glossary.md      ./
+mkdir -p runbooks
+cp /path/to/eBull/docs/wiki/runbooks/*.md    runbooks/
+
+git add .
+git commit -m "sync from docs/wiki/"
+git push
+```
+
+GitHub Wiki flattens the directory tree by default. Subdirectories
+under the wiki repo render as path segments in URLs. Internal
+markdown links in `docs/wiki/` use relative `[label](path/file.md)`
+syntax that works both in-repo and on the wiki — no rewrite needed.
+
+## Keeping the mirror in sync
+
+Re-run the publish script after any merged PR that touches
+`docs/wiki/`. Or wire it into a GitHub Action triggered on push to
+`main`.
+
+## Why not use the wiki repo directly
+
+- Wiki edits would not go through PR review.
+- Wiki content would not version alongside the code it documents.
+- Diffs against schema / API changes would be impossible to track.
+
+The in-repo + mirror pattern keeps the wiki as a derived artefact of
+reviewed source.


### PR DESCRIPTION
## What
- Rewrite README.md from ticket-focused to general-audience: what eBull is, sources, design philosophy, direction of travel by phase. Status block at top flags pre-release / active development.
- Drop ticket numbers from public-facing README (they belong in changelog/PR bodies).
- Fix stale ADR link: README pointed at \`docs/adr/0002-first-run-setup.md\` which does not exist; actual ADR is \`0002-local-browser-bootstrap-and-multi-operator.md\`.
- Verify EBULL_BOOTSTRAP_TOKEN is real (it is — \`app/config.py:114\` + \`app/services/operator_setup.py\`); .env.example still documents it.
- Add \`docs/wiki/HOW-TO-PUBLISH.md\` — operator-action guide explaining why the GitHub Wiki tab at https://github.com/Luke-Bradford/eBull/wiki is empty (GitHub does not provision \`<repo>.wiki.git\` until the first page is saved via web UI) and the publish script for mirroring \`docs/wiki/\` once bootstrapped.

## Operator action
After this lands: visit https://github.com/Luke-Bradford/eBull/wiki and click "Create the first page". Save with title \`Home\` and any placeholder content. After that, run the publish script in \`docs/wiki/HOW-TO-PUBLISH.md\` to mirror the in-repo wiki.

## Test plan
- [x] \`uv run ruff check . && uv run ruff format --check .\` — clean (no .py touched).
- [x] No code paths affected; README + new doc only.
- [x] Verified \`EBULL_BOOTSTRAP_TOKEN\` references in \`.env.example\` + \`app/config.py:114\` + \`app/services/operator_setup.py\` — README claim is accurate.
- [x] Verified ADR target file exists at \`docs/adr/0002-local-browser-bootstrap-and-multi-operator.md\`.