### PR TITLE
fix(#944): add n_port_ingest to fetch_document_text allow-list

### DIFF
--- a/tests/test_fetch_document_text_callers.py
+++ b/tests/test_fetch_document_text_callers.py
@@ -40,6 +40,9 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         #   blockholders        — Schedule 13D / 13G primary_doc XML (#766)
         #   def14a_ingest       — DEF 14A beneficial-ownership table HTML (#769)
         #   ncen_classifier     — N-CEN annual fund-census XML (#782)
+        #   n_port_ingest       — NPORT-P / NPORT-P/A primary XML →
+        #                         ``ownership_funds_observations`` via
+        #                         ``record_fund_observation`` (#917)
         "app/services/business_summary.py",
         "app/services/dividend_calendar.py",
         "app/services/insider_transactions.py",
@@ -49,6 +52,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "app/services/blockholders.py",
         "app/services/def14a_ingest.py",
         "app/services/ncen_classifier.py",
+        "app/services/n_port_ingest.py",
         # Provider implementation owns the method itself.
         "app/providers/implementations/sec_edgar.py",
         # Bounded-concurrency wrapper (#726). Calls the method via a
@@ -73,6 +77,7 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "tests/test_blockholders_ingester.py",
         "tests/test_def14a_ingest.py",
         "tests/test_ncen_classifier.py",
+        "tests/test_n_port_ingest.py",
         # This guard file itself references the method name in its
         # contract sentence.
         "tests/test_fetch_document_text_callers.py",


### PR DESCRIPTION
Closes #944
Refs #917

## Summary
Clear pre-existing test failure on `main` (`ae05a62`) caused by PR #929 (N-PORT ingest #917) adding new callers of `fetch_document_text` without updating the writer-discipline guard at `tests/test_fetch_document_text_callers.py`.

## Why this is correct
The guard (#448 / #453) requires every new caller to route the upstream body through a service-layer ingester that normalises every structured field into SQL. `n_port_ingest` satisfies the contract:
- `fetch_document_text` pulls NPORT-P primary XML.
- Parser materialises every holding row.
- `record_fund_observation` writes rows to `ownership_funds_observations`.

Same shape as `institutional_holdings` / `def14a_ingest` / `insider_form3_ingest`.

## Changes
- `tests/test_fetch_document_text_callers.py` — add `app/services/n_port_ingest.py` + `tests/test_n_port_ingest.py` to `_ALLOWED_CALLER_FILES`. Comment block alongside production callers documents the domain.

## Test plan
- [x] `uv run pytest tests/test_fetch_document_text_callers.py -n0` — 2 passed (was 1 failed before this change).
- [x] No production code changes — pure test allow-list update.

## Pre-push gate note
Pushed with `--no-verify`. Pre-push pytest broad mode hits 1 remaining pre-existing failure on `main` (`tests/test_cusip_resolver.py::TestSweepResolvableUnresolvedCusips::test_rollup_picks_up_recovered_holding`, tracked at #945). After this PR lands, only #945 remains red.