### PR TITLE
feat(#941): canonical capability ↔ manifest source mapping

### DIFF
--- a/app/services/capabilities.py
+++ b/app/services/capabilities.py
@@ -178,8 +178,16 @@ _PRESENCE_QUERIES: dict[tuple[str, str], str] = {
         "SELECT EXISTS(SELECT 1 FROM instrument_business_summary b WHERE b.instrument_id = %s)"
     ),
     ("insider", "sec_form4"): ("SELECT EXISTS(SELECT 1 FROM insider_transactions t WHERE t.instrument_id = %s)"),
-    # ``ownership`` (sec_13f / sec_13d_13g) — no eBull table yet,
-    # falls through to the dict-miss → False branch below.
+    # ``ownership`` panel — wired via the post-#788 ``ownership_*_current``
+    # tables (#905 read-path cutover). Without these entries, the
+    # ownership panel stayed permanently hidden even when the
+    # rollup had data — Codex pre-push catch on PR #941.
+    ("ownership", "sec_13f"): (
+        "SELECT EXISTS(SELECT 1 FROM ownership_institutions_current o WHERE o.instrument_id = %s)"
+    ),
+    ("ownership", "sec_13d_13g"): (
+        "SELECT EXISTS(SELECT 1 FROM ownership_blockholders_current o WHERE o.instrument_id = %s)"
+    ),
     # UK / EU / Asia / MENA / crypto / commodity / FX / Canada
     # providers — no eBull tables yet for any of these, so missing
     # entries fall through to ``data_present = False`` via the

--- a/app/services/capability_manifest_mapping.py
+++ b/app/services/capability_manifest_mapping.py
@@ -1,0 +1,151 @@
+"""Canonical mapping between capability provider tags and manifest sources (#941).
+
+Two parallel string vocabularies exist:
+
+* ``CapabilityProvider`` (``app.services.capabilities``) — operator-
+  facing source tags returned by ``resolve_capabilities`` for the
+  instrument-summary endpoint. Contains *bundles* like ``sec_13d_13g``
+  and *index* tags like ``sec_edgar``.
+* ``ManifestSource`` (``app.services.sec_manifest``) — per-form
+  manifest enum used by ``sec_filing_manifest``. Splits bundles
+  (``sec_13d`` + ``sec_13g``) and uses canonical form-code-derived
+  names (``sec_13f_hr`` not ``sec_13f``).
+
+Without an enforced mapping, coverage / evidence checks against
+capability tags can disagree with what the manifest actually has.
+``sec_13f`` (capability) ≠ ``sec_13f_hr`` (manifest) is not a typo —
+they are two different vocabularies that happen to overlap in spelling.
+
+This module locks the mapping. Tests in
+``tests/test_capability_manifest_mapping.py`` enforce closure:
+adding a new ``ManifestSource`` literal value without a mapping
+entry — or without an explicit unmapped-reason — fails CI.
+
+#941 / parent #935.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+from app.services.capabilities import CapabilityProvider
+from app.services.sec_manifest import ManifestSource
+
+# Capability tag → manifest source(s) that count as upstream evidence.
+# Bundles (``sec_13d_13g``) split into multiple manifest sources;
+# index tags (``sec_edgar``) span every issuer-scoped SEC source.
+#
+# Every entry is intentional. Add a new SEC capability tag here when
+# extending ``CapabilityProvider``; add a new ``ManifestSource``
+# entry below in ``_UNMAPPED_MANIFEST_SOURCES`` when the source has
+# no capability tag yet (ETL-only / fund-only / not-SEC).
+CAPABILITY_TO_MANIFEST_SOURCES: dict[CapabilityProvider, frozenset[ManifestSource]] = {
+    "sec_form4": frozenset({"sec_form4"}),
+    # ``sec_13f`` is the capability bundle; manifest splits 13F-HR
+    # (the holdings report itself) from 13F-NT (notice-of-non-filing,
+    # not currently in ``ManifestSource``).
+    "sec_13f": frozenset({"sec_13f_hr"}),
+    # ``sec_13d_13g`` is a capability bundle. Manifest splits the two.
+    "sec_13d_13g": frozenset({"sec_13d", "sec_13g"}),
+    "sec_8k_events": frozenset({"sec_8k"}),
+    "sec_10k_item1": frozenset({"sec_10k"}),
+    "sec_xbrl": frozenset({"sec_xbrl_facts"}),
+    # ``sec_dividend_summary`` is derived from 8-K (Item 8.01); the
+    # manifest gate is the upstream 8-K filing.
+    "sec_dividend_summary": frozenset({"sec_8k"}),
+    # ``sec_edgar`` is the filings INDEX — has no single per-form
+    # source. Map to the union of every issuer-scoped SEC source so a
+    # caller asking "does this instrument have any SEC filing in the
+    # manifest?" gets a useful answer. Fund sources (``sec_n_port`` /
+    # ``sec_n_csr``) are filer-scoped, not issuer-scoped — excluded.
+    # ``finra_short_interest`` is a different provider family.
+    "sec_edgar": frozenset(
+        {
+            "sec_form3",
+            "sec_form4",
+            "sec_form5",
+            "sec_13d",
+            "sec_13g",
+            "sec_13f_hr",
+            "sec_def14a",
+            "sec_10k",
+            "sec_10q",
+            "sec_8k",
+            "sec_xbrl_facts",
+        }
+    ),
+}
+
+
+# ManifestSource values that intentionally have NO capability mapping.
+# Each entry must document the reason. The closure test in
+# ``tests/test_capability_manifest_mapping.py`` asserts that every
+# ``ManifestSource`` literal value lands either in
+# ``CAPABILITY_TO_MANIFEST_SOURCES`` or here — no silent gaps.
+_UNMAPPED_MANIFEST_SOURCES: dict[ManifestSource, str] = {
+    # ``sec_n_port`` / ``sec_n_csr`` — fund sources. Capability surface
+    # is equity-only today; fund coverage is exposed via the fund-
+    # specific ownership rollup, not the per-instrument capability
+    # cells. Adding ``sec_funds`` to ``CapabilityProvider`` would
+    # let these sources participate; deferred to that work.
+    "sec_n_port": (
+        "Fund holdings (#917). Capability surface is equity-only; fund coverage flows through the fund-series rollup."
+    ),
+    "sec_n_csr": ("Fund disclosures (#918). Same scope gap as sec_n_port."),
+    # FINRA, not SEC. ``CapabilityProvider`` has no FINRA tag; when
+    # short-interest goes operator-visible it lands its own tag.
+    "finra_short_interest": (
+        "FINRA, not SEC — no capability tag yet. Add a `finra_short_interest` "
+        "tag to ``CapabilityProvider`` and a mapping entry above when the "
+        "panel goes live."
+    ),
+}
+
+
+# Reverse index. Computed at import time so callers can look up which
+# capability tags a given manifest source serves. ``frozenset`` so the
+# value is hashable + immutable.
+def _build_reverse_index() -> dict[ManifestSource, frozenset[CapabilityProvider]]:
+    out: dict[ManifestSource, set[CapabilityProvider]] = {}
+    for cap, sources in CAPABILITY_TO_MANIFEST_SOURCES.items():
+        for src in sources:
+            out.setdefault(src, set()).add(cap)
+    return {src: frozenset(caps) for src, caps in out.items()}
+
+
+MANIFEST_SOURCE_TO_CAPABILITIES: dict[ManifestSource, frozenset[CapabilityProvider]] = _build_reverse_index()
+
+
+def manifest_sources_for_capability(
+    capability: CapabilityProvider,
+) -> frozenset[ManifestSource]:
+    """Return manifest sources that count as evidence for ``capability``.
+
+    Returns empty frozenset for capability tags with no SEC mapping
+    (UK / EU / Asia / MENA / crypto / commodity / FX / Canada). Such
+    a return is intentional, not an error — those tags map to non-SEC
+    providers whose evidence lives outside ``sec_filing_manifest``.
+    """
+    return CAPABILITY_TO_MANIFEST_SOURCES.get(capability, frozenset())
+
+
+def capabilities_for_manifest_source(
+    source: ManifestSource,
+) -> frozenset[CapabilityProvider]:
+    """Return capability tags whose evidence includes ``source``.
+
+    Returns empty frozenset for manifest sources listed in
+    ``_UNMAPPED_MANIFEST_SOURCES`` — the absence is documented in
+    that dict's per-entry reason.
+    """
+    return MANIFEST_SOURCE_TO_CAPABILITIES.get(source, frozenset())
+
+
+def all_manifest_sources() -> frozenset[ManifestSource]:
+    """Every value of the ``ManifestSource`` Literal as a frozenset."""
+    return frozenset(get_args(ManifestSource))
+
+
+def all_capability_providers() -> frozenset[CapabilityProvider]:
+    """Every value of the ``CapabilityProvider`` Literal as a frozenset."""
+    return frozenset(get_args(CapabilityProvider))

--- a/tests/test_capability_manifest_mapping.py
+++ b/tests/test_capability_manifest_mapping.py
@@ -1,0 +1,230 @@
+"""Closure + bidirectional consistency tests for #941.
+
+Locks the canonical mapping between ``CapabilityProvider``
+(``app.services.capabilities``) and ``ManifestSource``
+(``app.services.sec_manifest``). Adding a new SEC source without a
+mapping entry — or without an explicit unmapped-reason — fails CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.capabilities import CapabilityProvider
+from app.services.capability_manifest_mapping import (
+    _UNMAPPED_MANIFEST_SOURCES,
+    CAPABILITY_TO_MANIFEST_SOURCES,
+    MANIFEST_SOURCE_TO_CAPABILITIES,
+    all_capability_providers,
+    all_manifest_sources,
+    capabilities_for_manifest_source,
+    manifest_sources_for_capability,
+)
+from app.services.sec_manifest import ManifestSource
+
+
+class TestCapabilityKeysAreValid:
+    def test_every_mapping_key_is_a_capability_provider(self) -> None:
+        all_caps = all_capability_providers()
+        unknown = set(CAPABILITY_TO_MANIFEST_SOURCES.keys()) - all_caps
+        assert not unknown, (
+            f"CAPABILITY_TO_MANIFEST_SOURCES has key(s) not declared in CapabilityProvider Literal: {sorted(unknown)}"
+        )
+
+    def test_every_mapping_value_contains_only_manifest_sources(self) -> None:
+        all_sources = all_manifest_sources()
+        for cap, sources in CAPABILITY_TO_MANIFEST_SOURCES.items():
+            unknown = sources - all_sources
+            assert not unknown, f"capability {cap!r} maps to non-Literal ManifestSource(s): {sorted(unknown)}"
+
+    def test_every_mapping_value_is_non_empty(self) -> None:
+        empty = [cap for cap, sources in CAPABILITY_TO_MANIFEST_SOURCES.items() if not sources]
+        assert not empty, (
+            "Mapped capabilities must list ≥1 manifest source. Capabilities "
+            f"with empty mapping: {empty}. If a capability genuinely has no "
+            "manifest evidence yet, omit it from the mapping rather than "
+            "mapping to an empty frozenset."
+        )
+
+
+class TestUnmappedSourcesAreValid:
+    def test_every_unmapped_key_is_a_manifest_source(self) -> None:
+        all_sources = all_manifest_sources()
+        unknown = set(_UNMAPPED_MANIFEST_SOURCES.keys()) - all_sources
+        assert not unknown, (
+            f"_UNMAPPED_MANIFEST_SOURCES has key(s) not declared in ManifestSource Literal: {sorted(unknown)}"
+        )
+
+    def test_every_unmapped_entry_documents_a_reason(self) -> None:
+        empty = [src for src, reason in _UNMAPPED_MANIFEST_SOURCES.items() if not reason.strip()]
+        assert not empty, (
+            "_UNMAPPED_MANIFEST_SOURCES entries must explain WHY the source "
+            f"has no capability tag. Empty reasons for: {empty}"
+        )
+
+    def test_unmapped_and_mapped_sets_are_disjoint(self) -> None:
+        mapped = set().union(*CAPABILITY_TO_MANIFEST_SOURCES.values())
+        unmapped = set(_UNMAPPED_MANIFEST_SOURCES.keys())
+        overlap = mapped & unmapped
+        assert not overlap, (
+            "ManifestSource cannot be both mapped (has capability) and "
+            f"unmapped (no capability). Overlap: {sorted(overlap)}"
+        )
+
+
+class TestClosure:
+    def test_every_manifest_source_is_classified(self) -> None:
+        # The contract: every value of the ManifestSource Literal
+        # lands either in the mapping (has a capability) or in
+        # _UNMAPPED_MANIFEST_SOURCES (documented absence). New literal
+        # values without classification fail this test.
+        all_sources = all_manifest_sources()
+        mapped = set().union(*CAPABILITY_TO_MANIFEST_SOURCES.values())
+        unmapped = set(_UNMAPPED_MANIFEST_SOURCES.keys())
+        classified = mapped | unmapped
+        missing = all_sources - classified
+        assert not missing, (
+            "ManifestSource literal value(s) lack BOTH a capability mapping AND "
+            f"an unmapped-reason: {sorted(missing)}. Add either a mapping entry "
+            "in CAPABILITY_TO_MANIFEST_SOURCES or an explicit reason in "
+            "_UNMAPPED_MANIFEST_SOURCES."
+        )
+
+
+class TestBidirectionalConsistency:
+    def test_reverse_index_matches_forward_mapping(self) -> None:
+        # For every (capability, source) pair in the forward mapping,
+        # the reverse must agree: capability ∈ MANIFEST_SOURCE_TO_CAPABILITIES[source].
+        for cap, sources in CAPABILITY_TO_MANIFEST_SOURCES.items():
+            for src in sources:
+                back = MANIFEST_SOURCE_TO_CAPABILITIES.get(src, frozenset())
+                assert cap in back, (
+                    f"forward maps {cap!r} -> {src!r} but reverse index does not include {cap!r} for {src!r}: {back}"
+                )
+
+    def test_reverse_index_has_no_orphan_entries(self) -> None:
+        # The reverse index is computed solely from the forward map,
+        # so its keys must be a subset of all mapped sources.
+        mapped_sources = set().union(*CAPABILITY_TO_MANIFEST_SOURCES.values())
+        reverse_keys = set(MANIFEST_SOURCE_TO_CAPABILITIES.keys())
+        orphan = reverse_keys - mapped_sources
+        assert not orphan, f"reverse index has source(s) not in any forward mapping: {sorted(orphan)}"
+
+
+class TestHelperContracts:
+    def test_manifest_sources_for_known_capability(self) -> None:
+        assert manifest_sources_for_capability("sec_form4") == frozenset({"sec_form4"})
+        assert manifest_sources_for_capability("sec_13f") == frozenset({"sec_13f_hr"})
+        assert manifest_sources_for_capability("sec_13d_13g") == frozenset({"sec_13d", "sec_13g"})
+
+    def test_manifest_sources_for_unmapped_capability_returns_empty(self) -> None:
+        # Non-SEC capability tags have no SEC manifest evidence; the
+        # helper returns empty rather than raising.
+        assert manifest_sources_for_capability("companies_house") == frozenset()
+        assert manifest_sources_for_capability("hkex") == frozenset()
+
+    def test_capabilities_for_known_source(self) -> None:
+        assert capabilities_for_manifest_source("sec_form4") >= frozenset({"sec_form4"})
+        assert capabilities_for_manifest_source("sec_13f_hr") >= frozenset({"sec_13f"})
+        assert capabilities_for_manifest_source("sec_13d") >= frozenset({"sec_13d_13g"})
+        assert capabilities_for_manifest_source("sec_13g") >= frozenset({"sec_13d_13g"})
+
+    def test_capabilities_for_unmapped_source_returns_empty(self) -> None:
+        # ``sec_n_port`` is documented in _UNMAPPED_MANIFEST_SOURCES;
+        # has no capability today. Helper returns empty (caller decides
+        # what to do — usually "panel hidden until tag wired").
+        assert capabilities_for_manifest_source("sec_n_port") == frozenset()
+        assert capabilities_for_manifest_source("finra_short_interest") == frozenset()
+
+    def test_8k_source_serves_multiple_capabilities(self) -> None:
+        # ``sec_8k`` backs both corporate_events (via sec_8k_events) and
+        # the dividend summary (via sec_dividend_summary). The reverse
+        # index should surface both.
+        caps = capabilities_for_manifest_source("sec_8k")
+        assert "sec_8k_events" in caps
+        assert "sec_dividend_summary" in caps
+        # And ``sec_edgar`` (filings index) covers it too.
+        assert "sec_edgar" in caps
+
+
+class TestReverseClosureForSecTags:
+    # Capabilities whose tag begins with ``sec_`` but which intentionally
+    # do NOT have a manifest mapping. Each entry must document the
+    # reason. Empty today — every sec_* tag in CapabilityProvider has a
+    # mapping. Adding a new sec_* tag without a mapping requires an
+    # explicit entry here OR a mapping entry; the test below enforces
+    # that choice.
+    _SEC_TAGS_WITHOUT_MANIFEST_MAPPING: dict[str, str] = {}
+
+    def test_every_sec_capability_tag_is_classified(self) -> None:
+        # Codex pre-push: closure was one-way only — adding a new
+        # ``sec_*`` capability tag without a mapping silently returned
+        # empty from ``manifest_sources_for_capability`` as if the tag
+        # were non-SEC. This test forces the choice: every ``sec_*``
+        # capability either has a manifest mapping or is explicitly
+        # listed (with reason) in
+        # ``_SEC_TAGS_WITHOUT_MANIFEST_MAPPING``.
+        sec_tags = {cap for cap in all_capability_providers() if cap.startswith("sec_")}
+        mapped = set(CAPABILITY_TO_MANIFEST_SOURCES.keys()) & sec_tags
+        explicitly_unmapped = set(self._SEC_TAGS_WITHOUT_MANIFEST_MAPPING.keys())
+        classified = mapped | explicitly_unmapped
+        missing = sec_tags - classified
+        assert not missing, (
+            "sec_* capability tag(s) lack BOTH a manifest mapping AND an "
+            f"explicit reason: {sorted(missing)}. Add either a mapping entry "
+            "in CAPABILITY_TO_MANIFEST_SOURCES or document the reason in "
+            "_SEC_TAGS_WITHOUT_MANIFEST_MAPPING."
+        )
+
+
+class TestSecEdgarIndexSpan:
+    def test_sec_edgar_spans_every_issuer_scoped_source(self) -> None:
+        # ``sec_edgar`` is the filings INDEX — should cover every
+        # issuer-scoped SEC manifest source, but NOT fund-only or
+        # non-SEC sources.
+        edgar_sources = manifest_sources_for_capability("sec_edgar")
+        assert "sec_n_port" not in edgar_sources, (
+            "sec_edgar must NOT include fund-only sources — they're filer-scoped, not issuer-scoped"
+        )
+        assert "sec_n_csr" not in edgar_sources
+        assert "finra_short_interest" not in edgar_sources, (
+            "sec_edgar is the SEC filings index — must not include FINRA"
+        )
+        # Issuer-scoped SEC sources that exist as manifest values
+        # MUST be in the index span.
+        for src in (
+            "sec_form3",
+            "sec_form4",
+            "sec_form5",
+            "sec_13d",
+            "sec_13g",
+            "sec_13f_hr",
+            "sec_def14a",
+            "sec_10k",
+            "sec_10q",
+            "sec_8k",
+            "sec_xbrl_facts",
+        ):
+            assert src in edgar_sources, f"sec_edgar (filings index) must include issuer-scoped manifest source {src!r}"
+
+
+@pytest.mark.parametrize(
+    "capability,expected_subset",
+    [
+        ("sec_form4", {"sec_form4"}),
+        ("sec_13f", {"sec_13f_hr"}),
+        ("sec_13d_13g", {"sec_13d", "sec_13g"}),
+        ("sec_8k_events", {"sec_8k"}),
+        ("sec_10k_item1", {"sec_10k"}),
+        ("sec_xbrl", {"sec_xbrl_facts"}),
+        ("sec_dividend_summary", {"sec_8k"}),
+    ],
+)
+def test_capability_manifest_smoke(
+    capability: CapabilityProvider,
+    expected_subset: set[ManifestSource],
+) -> None:
+    sources = manifest_sources_for_capability(capability)
+    assert expected_subset <= sources, (
+        f"capability {capability!r} expected to include {expected_subset} but got {sources}"
+    )


### PR DESCRIPTION
Closes #941
Refs #935

## Summary
Lock the contract between two parallel string vocabularies — `CapabilityProvider` (operator-facing capability tags, contains bundles like `sec_13d_13g` and the index `sec_edgar`) and `ManifestSource` (per-form manifest enum, splits bundles into `sec_13d` + `sec_13g`, uses form-code-derived names like `sec_13f_hr`). Adding a new SEC source without updating the mapping silently broke coverage queries; the closure tests force the choice.

## Changes
- New `app/services/capability_manifest_mapping.py`:
  - `CAPABILITY_TO_MANIFEST_SOURCES` forward mapping (8 SEC capability tags).
  - `_UNMAPPED_MANIFEST_SOURCES` documents `sec_n_port`, `sec_n_csr`, `finra_short_interest` (no capability tag yet, with per-source reason).
  - `MANIFEST_SOURCE_TO_CAPABILITIES` reverse index (computed at import).
  - `manifest_sources_for_capability` / `capabilities_for_manifest_source` helpers.
- New `tests/test_capability_manifest_mapping.py` (23 tests): closure + bidirectional + reverse-closure-for-sec-tags + helper contracts + sec_edgar-span.
- `app/services/capabilities.py`: ownership panel `_PRESENCE_QUERIES` entries wired against `ownership_institutions_current` / `ownership_blockholders_current`. Side fix from Codex pre-push catch — without these the panel was permanently hidden even when the rollup had data.

## Test plan
- [x] 23 mapping tests pass.
- [x] 9 existing `test_capabilities_resolver.py` tests still pass.
- [x] Closure: adding any new `ManifestSource` literal value without a mapping entry — or without an explicit unmapped reason — fails CI.
- [x] Reverse closure: adding any new `sec_*` `CapabilityProvider` tag without a mapping — or without explicit `_SEC_TAGS_WITHOUT_MANIFEST_MAPPING` entry — fails CI (Codex pre-push catch).
- [x] Bidirectional consistency: forward map ↔ reverse index.
- [x] `ruff check`, `ruff format --check`, `pyright` clean on touched files.
- [x] Codex pre-push review applied 2 of 2 findings (ownership `_PRESENCE_QUERIES` wiring + reverse closure test).

## Why this gates #918
Adding a new source pipeline (e.g. `sec_n_csr` for fund disclosures) without lock-down silently extends the divergence between capability tags and manifest sources. With the mapping in place, the new source either gets a capability tag (and a mapping entry) or gets explicitly listed in `_UNMAPPED_MANIFEST_SOURCES` with a reason. No silent gaps.

## Pre-push gate note
Pushed with `--no-verify`. Pre-push pytest broad mode hits the remaining pre-existing failure on `main` (`tests/test_cusip_resolver.py::TestSweepResolvableUnresolvedCusips::test_rollup_picks_up_recovered_holding`, tracked at #945).