### PR TITLE
fix(#945): rewash sweep must write through to ownership_*_current

### DIFF
--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -518,6 +518,23 @@ def _apply_def14a(
             as_of_date=parsed.as_of_date,
             holder=holder,
         )
+
+    # Write-through to ownership_def14a_observations + refresh
+    # ownership_def14a_current. Mirrors the first-ingest path at
+    # app/services/def14a_ingest.py:463-471. Without this, the rewash
+    # writes typed rows but leaves the rollup (#905 read-path) stale
+    # against the new parser output (#945 same-pattern as 13F).
+    from app.services.def14a_ingest import _record_def14a_observations_for_filing
+    from app.services.ownership_observations import refresh_def14a_current
+
+    _record_def14a_observations_for_filing(
+        conn,
+        instrument_id=int(instrument_id),
+        accession_number=raw_doc.accession_number,
+        as_of_date=parsed.as_of_date,
+        holders=parsed.rows,
+    )
+    refresh_def14a_current(conn, instrument_id=int(instrument_id))
     return True
 
 
@@ -640,6 +657,40 @@ def _apply_blockholders(
             filed_at=filing.filed_at or filed_at,
             person=person,
         )
+
+    # Write-through to ownership_blockholders_observations + refresh
+    # ownership_blockholders_current. Mirrors first-ingest path at
+    # app/services/blockholders.py:707-724. Same #945 pattern as 13F:
+    # rewash writes typed rows but leaves the rollup stale without
+    # this hook. ``_record_13dg_observation_for_filing`` requires an
+    # ``AccessionRef`` for the ``filed_at`` fallback — synthesise one
+    # from the rewash's known values (the filing's own ``filed_at``
+    # takes priority when present).
+    if instrument_id is not None:
+        from uuid import uuid4
+
+        from app.services.blockholders import (
+            AccessionRef,
+            _record_13dg_observation_for_filing,
+        )
+        from app.services.ownership_observations import refresh_blockholders_current
+
+        ref = AccessionRef(
+            accession_number=raw_doc.accession_number,
+            filing_type=filing.submission_type,
+            filed_at=filed_at,
+        )
+        _record_13dg_observation_for_filing(
+            conn,
+            instrument_id=int(instrument_id),
+            accession_number=raw_doc.accession_number,
+            primary_document_url="",
+            filing=filing,
+            filer_name=filer_name,
+            ref=ref,
+            run_id=uuid4(),
+        )
+        refresh_blockholders_current(conn, instrument_id=int(instrument_id))
     return True
 
 
@@ -860,6 +911,33 @@ def _apply_13f_infotable(
             holding=holding,
         )
         inserted += 1
+
+    # Write-through to observations + refresh ownership_institutions_current
+    # so the rollup (#905 read-path cutover) reflects the recovered
+    # holdings on the same transaction. Mirrors the first-ingest path
+    # in app/services/institutional_holdings.py:1260-1274. Without this,
+    # ``cusip_resolver.sweep_resolvable_unresolved_cusips`` would happily
+    # log "rewashed accession=..." while leaving every ownership rollup
+    # query showing zero institutional shares (#945).
+    if resolved:
+        from app.services.institutional_holdings import _record_13f_observations_for_filing
+        from app.services.ownership_observations import refresh_institutions_current
+
+        # ``filed_at`` from the SELECT above is a tuple-row Decimal/None
+        # type (psycopg returned timestamptz) — record_institution_observation
+        # expects a datetime. The first-ingest path threads the same
+        # value through the same helper, so the type is already what
+        # the helper accepts.
+        _record_13f_observations_for_filing(
+            conn,
+            filer_id=int(filer_id),
+            accession_number=raw_doc.accession_number,
+            period_of_report=period_of_report,
+            filed_at=filed_at,
+            resolved_holdings=resolved,
+        )
+        for unique_instrument_id in {iid for iid, _ in resolved}:
+            refresh_institutions_current(conn, instrument_id=unique_instrument_id)
 
     # Log full success.
     with conn.cursor() as cur:


### PR DESCRIPTION
Closes #945
Refs #935 #953 #954

## Summary
Rewash code path (13F / DEF 14A / 13D-G) wrote only to legacy typed tables. Post-#788/#905 the rollup reads from `ownership_*_current` populated by write-through (#888-#891). Rewash skipped both observation record + `_current` refresh, so `cusip_resolver.sweep_resolvable_unresolved_cusips` logged "rewashed" while rollup showed zero recovered shares.

## Changes
Mirror first-ingest write-through across the 3 rewash kinds:
- **13F** `_rewash_13f_accession`: `_record_13f_observations_for_filing` + `refresh_institutions_current`. Mirrors `institutional_holdings.py:1260-1274`.
- **DEF 14A** `_apply_def14a`: `_record_def14a_observations_for_filing` + `refresh_def14a_current`. Mirrors `def14a_ingest.py:463-471`.
- **13D/G** `_apply_blockholders`: `_record_13dg_observation_for_filing` + `refresh_blockholders_current`. Mirrors `blockholders.py:707-724`. Synthesises `AccessionRef` from rewash's known values for the `filed_at` fallback.

## Test plan
- [x] `test_rollup_picks_up_recovered_holding` (the original #945 reproducer): passes.
- [x] 94 tests across `test_rewash_filings.py` + `test_cusip_resolver.py` + `test_blockholders_ingester.py` + `test_def14a_ingest.py` all pass.
- [x] `ruff check`, `ruff format --check`, `pyright` clean.

## Codex pre-push deferred findings
- **#953** — 13F rewash leaves stale observations on parser-fix CUSIP changes (refresh covers new instruments only, not old). Latent today; the CUSIP sweep recovers tombstones with identical CUSIPs.
- **#954** — 13F rewash dedup mismatch (typed-table keeps first, observations keep last). Latent today; current sweep cohort lacks duplicate XML rows.

## Pre-push gate note
Pre-existing failure on `main` (#945) is what this PR fixes. After this lands, pre-push pytest broad mode is clean.