### PR TITLE
fix(#937): first-install drain seeds data_freshness_index

### DIFF
--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -40,6 +40,7 @@ from app.providers.implementations.sec_submissions import (
     check_freshness,
     parse_submissions_page,
 )
+from app.services.data_freshness import seed_scheduler_from_manifest
 from app.services.sec_manifest import record_manifest_entry
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,11 @@ class DrainStats:
     secondary_pages_fetched: int
     manifest_rows_upserted: int
     errors: int
+    # Count of (subject_type, subject_id, source) triples written to
+    # ``data_freshness_index`` after the drain. Without this seeding
+    # step (#937), the steady-state per-CIK poll would silently no-op
+    # because the scheduler had no rows to poll.
+    scheduler_rows_seeded: int = 0
 
 
 def _iter_in_universe_subjects(
@@ -185,13 +191,30 @@ def run_first_install_drain(
                 subject=subject,
             )
 
+    # #937: seed the scheduler from manifest after the drain commits
+    # rows. Without this, the per-CIK poll (#870) silently no-ops
+    # post-drain because data_freshness_index is empty for the drained
+    # scope. ``seed_scheduler_from_manifest`` is idempotent + UPSERTs
+    # by (subject_type, subject_id, source) so re-runs are safe.
+    #
+    # Scope trade-off: ``seed_scheduler_from_manifest`` is full-table —
+    # ``SELECT DISTINCT ON ... FROM sec_filing_manifest``. With
+    # ``max_subjects=N`` (sample run) it still scans every prior
+    # manifest row, not just this drain's. Acceptable here because the
+    # drain runs rarely (first-install + explicit operator re-drain);
+    # the full-scan + ON CONFLICT UPSERT is bounded at ~12k subjects ×
+    # ~10 forms ≈ 120k rows, well under any pathological threshold. A
+    # scoped variant is filed as a follow-up if the scale ever grows.
+    scheduler_rows_seeded = seed_scheduler_from_manifest(conn)
+
     logger.info(
-        "first-install drain: ciks=%d skipped=%d errors=%d secondary_pages=%d upserted=%d",
+        "first-install drain: ciks=%d skipped=%d errors=%d secondary_pages=%d upserted=%d scheduler_seeded=%d",
         ciks_processed,
         ciks_skipped,
         errors,
         secondary_pages_fetched,
         manifest_upserted,
+        scheduler_rows_seeded,
     )
     return DrainStats(
         ciks_processed=ciks_processed,
@@ -199,6 +222,7 @@ def run_first_install_drain(
         secondary_pages_fetched=secondary_pages_fetched,
         manifest_rows_upserted=manifest_upserted,
         errors=errors,
+        scheduler_rows_seeded=scheduler_rows_seeded,
     )
 
 

--- a/tests/test_sec_first_install_drain.py
+++ b/tests/test_sec_first_install_drain.py
@@ -109,6 +109,38 @@ class TestDrain:
                 use_bulk_zip=True,
             )
 
+    def test_drain_seeds_data_freshness_index(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # #937: drain MUST leave both manifest AND scheduler queryable
+        # so the per-CIK poll (#870) finds work post-drain. Pre-fix
+        # the scheduler stayed empty for the drained scope.
+        _seed_aapl(ebull_test_conn)
+        stats = run_first_install_drain(
+            ebull_test_conn,
+            http_get=_fake_get(_AAPL_RECENT),
+            follow_pagination=False,
+        )
+        ebull_test_conn.commit()
+
+        assert stats.manifest_rows_upserted == 2
+        # AAPL recent has two distinct sources: sec_8k + sec_def14a.
+        # Each (issuer, instrument_id, source) triple gets one
+        # data_freshness_index row.
+        assert stats.scheduler_rows_seeded >= 2
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT source FROM data_freshness_index
+                WHERE subject_type = 'issuer' AND subject_id = '1701'
+                ORDER BY source
+                """
+            )
+            sources = [row[0] for row in cur.fetchall()]
+        assert sources == ["sec_8k", "sec_def14a"]
+
     def test_max_subjects_caps(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811


### PR DESCRIPTION
Closes #937
Refs #935 #956

## Summary
Drain wrote manifest rows but left `data_freshness_index` empty. Per-CIK poll (#870) reads from freshness index → silent no-op post-drain. Fix: invoke `seed_scheduler_from_manifest` after manifest commits.

## Changes
- `app/jobs/sec_first_install_drain.py`: call `seed_scheduler_from_manifest(conn)` at end of `run_first_install_drain`. Add `DrainStats.scheduler_rows_seeded`.
- `tests/test_sec_first_install_drain.py`: new test asserts `data_freshness_index` populated for both sources after AAPL drain.

## Test plan
- [x] 22 tests pass (`test_sec_first_install_drain.py` + `test_data_freshness.py`).
- [x] Fresh drain → freshness index has rows for every observed source.
- [x] `ruff check`, `ruff format --check`, `pyright` clean.

## Codex pre-push deferred findings
- **Perf scope** — `seed_scheduler_from_manifest` is full-table (`SELECT DISTINCT ON ... FROM sec_filing_manifest`). Acceptable here because drain runs rarely + bounded scale (~12k subjects × ~10 forms ≈ 120k rows). Comment documents the trade-off.
- **#956** filed as follow-up: atom fast-lane / daily-index reconcile / per-CIK poll / targeted rebuild all write manifest without seeding the freshness index. Same invariant gap — broader fix.