### PR TITLE
feat(#936): targeted rebuild walks filings.files[] secondary pages

### DIFF
--- a/app/jobs/sec_rebuild.py
+++ b/app/jobs/sec_rebuild.py
@@ -35,7 +35,6 @@ missed an accession.
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -273,7 +272,7 @@ def _discovery_pass(
         # otherwise an aged-out accession can never be repaired.
         # Atom / per-CIK polling intentionally stay on ``recent`` (cheap
         # path); only rebuild pays the secondary-page cost.
-        if delta.has_more_in_files:
+        if delta.has_more_in_files and delta.files_pages:
             new_rows += _walk_secondary_pages(
                 conn,
                 http_get=http_get,
@@ -282,6 +281,7 @@ def _discovery_pass(
                 subject_id=sid,
                 instrument_id=instrument_id,
                 sources_set=sources_set,
+                files_pages=delta.files_pages,
             )
 
     return new_rows
@@ -296,10 +296,16 @@ def _walk_secondary_pages(
     subject_id: str,
     instrument_id: int | None,
     sources_set: set[ManifestSource],
+    files_pages: list[str],
 ) -> int:
     """Walk every ``filings.files[]`` secondary page for one CIK (#936).
 
-    Mirrors the pagination logic in
+    ``files_pages`` is sourced from the ``FreshnessDelta`` returned by
+    ``check_freshness`` — the primary CIK JSON has already been
+    fetched + parsed by the time this helper runs, so we re-use the
+    page list rather than re-fetching the primary body.
+
+    Mirrors the per-page UPSERT logic in
     ``app/jobs/sec_first_install_drain.py:_drain_secondary_pages``,
     but scoped to the rebuild's source set. Filters in-page rows to
     ``sources_set`` so a rebuild scoped to ``sec_def14a`` does not
@@ -307,34 +313,20 @@ def _walk_secondary_pages(
     page.
     """
     cik_padded = cik.zfill(10)
-    primary_url = f"https://data.sec.gov/submissions/CIK{cik_padded}.json"
     headers = {
         "User-Agent": "eBull research/1.0 contact@example.com",
         "Accept-Encoding": "gzip, deflate",
     }
-    # Codex pre-push: ``http_get`` and ``parse_submissions_page`` can
-    # raise (transport errors, malformed body, unexpected JSON shape).
-    # Isolate per-page failures so one bad secondary page does not
-    # abort the whole rebuild — the rest of the scope still drains.
-    try:
-        primary_status, primary_body = http_get(primary_url, headers)
-    except Exception as exc:  # noqa: BLE001 — transport-isolated, see comment above
-        logger.warning("sec rebuild (secondary): primary fetch raised cik=%s: %s", cik, exc)
-        return 0
-    if primary_status != 200:
-        return 0
-    try:
-        primary_payload = json.loads(primary_body)
-    except json.JSONDecodeError:
-        return 0
-
-    files = (primary_payload.get("filings", {}) or {}).get("files", []) or []
     new_rows = 0
-    for page_meta in files:
-        name = page_meta.get("name") if isinstance(page_meta, dict) else None
+    for name in files_pages:
         if not name:
             continue
         page_url = f"https://data.sec.gov/submissions/{name}"
+        # Codex pre-push: ``http_get`` and ``parse_submissions_page``
+        # can raise (transport errors, malformed body, unexpected JSON
+        # shape). Isolate per-page failures so one bad secondary page
+        # does not abort the whole rebuild — the rest of the scope
+        # still drains.
         try:
             status, body = http_get(page_url, headers)
         except Exception as exc:  # noqa: BLE001 — per-page isolation

--- a/app/jobs/sec_rebuild.py
+++ b/app/jobs/sec_rebuild.py
@@ -272,17 +272,28 @@ def _discovery_pass(
         # otherwise an aged-out accession can never be repaired.
         # Atom / per-CIK polling intentionally stay on ``recent`` (cheap
         # path); only rebuild pays the secondary-page cost.
-        if delta.has_more_in_files and delta.files_pages:
-            new_rows += _walk_secondary_pages(
-                conn,
-                http_get=http_get,
-                cik=cik,
-                subject_type=stype,
-                subject_id=sid,
-                instrument_id=instrument_id,
-                sources_set=sources_set,
-                files_pages=delta.files_pages,
-            )
+        if delta.has_more_in_files:
+            if delta.files_pages:
+                new_rows += _walk_secondary_pages(
+                    conn,
+                    http_get=http_get,
+                    cik=cik,
+                    subject_type=stype,
+                    subject_id=sid,
+                    instrument_id=instrument_id,
+                    sources_set=sources_set,
+                    files_pages=delta.files_pages,
+                )
+            else:
+                # Guard against silent skip: ``check_freshness`` already
+                # logs a warning when extraction fails, but log here too
+                # so the rebuild's own log stream surfaces the gap. Bot
+                # review BLOCKING on PR #958.
+                logger.warning(
+                    "sec rebuild discovery: cik=%s has_more_in_files=True but "
+                    "files_pages empty — secondary walk skipped",
+                    cik,
+                )
 
     return new_rows
 

--- a/app/jobs/sec_rebuild.py
+++ b/app/jobs/sec_rebuild.py
@@ -35,6 +35,7 @@ missed an accession.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -42,7 +43,11 @@ from typing import Any
 import psycopg
 from psycopg import sql
 
-from app.providers.implementations.sec_submissions import HttpGet, check_freshness
+from app.providers.implementations.sec_submissions import (
+    HttpGet,
+    check_freshness,
+    parse_submissions_page,
+)
 from app.services.sec_manifest import ManifestSource, record_manifest_entry
 
 logger = logging.getLogger(__name__)
@@ -238,8 +243,9 @@ def _discovery_pass(
             logger.warning("sec rebuild discovery: check_freshness raised cik=%s: %s", cik, exc)
             continue
 
+        sources_set = set(sources)
         for row in delta.new_filings:
-            if row.source is None or row.source not in sources:
+            if row.source is None or row.source not in sources_set:
                 continue
             try:
                 record_manifest_entry(
@@ -260,6 +266,108 @@ def _discovery_pass(
             except ValueError as exc:
                 logger.warning("sec rebuild: rejected %s: %s", row.accession_number, exc)
 
+        # #936: ``check_freshness`` reads only the ``recent[]`` array
+        # (~1000 most-recent accessions). Older filings live in the
+        # secondary ``filings.files[]`` pages. Targeted rebuild claims
+        # full-history discovery, so it MUST follow those pages too —
+        # otherwise an aged-out accession can never be repaired.
+        # Atom / per-CIK polling intentionally stay on ``recent`` (cheap
+        # path); only rebuild pays the secondary-page cost.
+        if delta.has_more_in_files:
+            new_rows += _walk_secondary_pages(
+                conn,
+                http_get=http_get,
+                cik=cik,
+                subject_type=stype,
+                subject_id=sid,
+                instrument_id=instrument_id,
+                sources_set=sources_set,
+            )
+
+    return new_rows
+
+
+def _walk_secondary_pages(
+    conn: psycopg.Connection[Any],
+    *,
+    http_get: HttpGet,
+    cik: str,
+    subject_type: str,
+    subject_id: str,
+    instrument_id: int | None,
+    sources_set: set[ManifestSource],
+) -> int:
+    """Walk every ``filings.files[]`` secondary page for one CIK (#936).
+
+    Mirrors the pagination logic in
+    ``app/jobs/sec_first_install_drain.py:_drain_secondary_pages``,
+    but scoped to the rebuild's source set. Filters in-page rows to
+    ``sources_set`` so a rebuild scoped to ``sec_def14a`` does not
+    UPSERT every 8-K it happens to encounter on the same secondary
+    page.
+    """
+    cik_padded = cik.zfill(10)
+    primary_url = f"https://data.sec.gov/submissions/CIK{cik_padded}.json"
+    headers = {
+        "User-Agent": "eBull research/1.0 contact@example.com",
+        "Accept-Encoding": "gzip, deflate",
+    }
+    # Codex pre-push: ``http_get`` and ``parse_submissions_page`` can
+    # raise (transport errors, malformed body, unexpected JSON shape).
+    # Isolate per-page failures so one bad secondary page does not
+    # abort the whole rebuild — the rest of the scope still drains.
+    try:
+        primary_status, primary_body = http_get(primary_url, headers)
+    except Exception as exc:  # noqa: BLE001 — transport-isolated, see comment above
+        logger.warning("sec rebuild (secondary): primary fetch raised cik=%s: %s", cik, exc)
+        return 0
+    if primary_status != 200:
+        return 0
+    try:
+        primary_payload = json.loads(primary_body)
+    except json.JSONDecodeError:
+        return 0
+
+    files = (primary_payload.get("filings", {}) or {}).get("files", []) or []
+    new_rows = 0
+    for page_meta in files:
+        name = page_meta.get("name") if isinstance(page_meta, dict) else None
+        if not name:
+            continue
+        page_url = f"https://data.sec.gov/submissions/{name}"
+        try:
+            status, body = http_get(page_url, headers)
+        except Exception as exc:  # noqa: BLE001 — per-page isolation
+            logger.warning("sec rebuild (secondary): fetch raised page=%s: %s", name, exc)
+            continue
+        if status != 200:
+            continue
+        try:
+            rows, _ = parse_submissions_page(body, cik=cik_padded)
+        except Exception as exc:  # noqa: BLE001 — per-page isolation
+            logger.warning("sec rebuild (secondary): parse raised page=%s: %s", name, exc)
+            continue
+        for row in rows:
+            if row.source is None or row.source not in sources_set:
+                continue
+            try:
+                record_manifest_entry(
+                    conn,
+                    row.accession_number,
+                    cik=row.cik,
+                    form=row.form,
+                    source=row.source,
+                    subject_type=subject_type,  # type: ignore[arg-type]
+                    subject_id=subject_id,
+                    instrument_id=instrument_id,
+                    filed_at=row.filed_at,
+                    accepted_at=row.accepted_at,
+                    primary_document_url=row.primary_document_url,
+                    is_amendment=row.is_amendment,
+                )
+                new_rows += 1
+            except ValueError as exc:
+                logger.warning("sec rebuild (secondary): rejected %s: %s", row.accession_number, exc)
     return new_rows
 
 

--- a/app/providers/implementations/sec_submissions.py
+++ b/app/providers/implementations/sec_submissions.py
@@ -255,9 +255,10 @@ def check_freshness(
 
     # Extract ``filings.files[*].name`` from the same primary body so
     # ``_walk_secondary_pages`` (#936) does not re-fetch the primary
-    # JSON. Skip silently on JSON-decode error — the row parse above
-    # already succeeded, so the body is well-formed for the rows path;
-    # the files block is best-effort secondary metadata.
+    # JSON. Log on extract failure so a swallowed exception does not
+    # silently skip the secondary walk — bot review BLOCKING on PR
+    # #958: ``if delta.has_more_in_files and delta.files_pages:``
+    # would silently no-op the rebuild's secondary-page recovery.
     files_pages: list[str] = []
     try:
         payload = json.loads(body) if isinstance(body, (bytes, str)) else body
@@ -268,8 +269,27 @@ def check_freshness(
                     name = meta.get("name")
                     if isinstance(name, str) and name:
                         files_pages.append(name)
-    except json.JSONDecodeError, TypeError:
-        pass
+    except (json.JSONDecodeError, TypeError) as exc:
+        logger.warning(
+            "check_freshness: files_pages extraction failed for cik=%s: %s "
+            "(rows still parsed; rebuild's secondary walk will see empty list)",
+            cik_padded,
+            exc,
+        )
+
+    if has_more and not files_pages:
+        # ``has_more_in_files=True`` from the row parse but
+        # ``files_pages`` is empty — the row parse and the files
+        # extraction disagreed about the same body. Either the body
+        # mutated between parses (impossible — same bytes) or
+        # ``filings.files`` was structurally surprising (non-dict
+        # entries, missing ``name`` keys). Surface so the caller
+        # doesn't silently drop the entire secondary walk.
+        logger.warning(
+            "check_freshness: cik=%s has_more_in_files=True but files_pages "
+            "extracted empty — rebuild's secondary walk will be skipped",
+            cik_padded,
+        )
 
     # Filter to strictly newer than the watermark. SEC's recent array
     # is ordered newest-first; we walk until we hit the watermark and

--- a/app/providers/implementations/sec_submissions.py
+++ b/app/providers/implementations/sec_submissions.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
@@ -100,12 +100,20 @@ class FreshnessDelta:
     ``last_known_filing_id`` (or all when watermark is None / not in
     response). ``has_more_in_files`` is true when SEC's submissions.json
     paginates older filings into ``files[]`` — meaningful for
-    first-install / rebuild paths only."""
+    first-install / rebuild paths only.
+
+    ``files_pages`` carries the names of those secondary pages
+    extracted from the same primary fetch. Callers (#936 rebuild)
+    walk these without re-issuing the primary request — pre-#959
+    rewrite, ``_walk_secondary_pages`` re-fetched the primary CIK
+    JSON purely to read ``filings.files[]`` again, doubling the
+    request count + creating a new failure mode."""
 
     cik: str
     new_filings: list[FilingIndexRow]
     last_filed_at: datetime | None
     has_more_in_files: bool
+    files_pages: list[str] = field(default_factory=list)
 
 
 def _zero_pad_cik(cik: str) -> str:
@@ -245,6 +253,24 @@ def check_freshness(
         wanted = set(sources)
         rows = [r for r in rows if r.source is not None and r.source in wanted]
 
+    # Extract ``filings.files[*].name`` from the same primary body so
+    # ``_walk_secondary_pages`` (#936) does not re-fetch the primary
+    # JSON. Skip silently on JSON-decode error — the row parse above
+    # already succeeded, so the body is well-formed for the rows path;
+    # the files block is best-effort secondary metadata.
+    files_pages: list[str] = []
+    try:
+        payload = json.loads(body) if isinstance(body, (bytes, str)) else body
+        if isinstance(payload, dict):
+            files_meta = (payload.get("filings", {}) or {}).get("files", []) or []
+            for meta in files_meta:
+                if isinstance(meta, dict):
+                    name = meta.get("name")
+                    if isinstance(name, str) and name:
+                        files_pages.append(name)
+    except json.JSONDecodeError, TypeError:
+        pass
+
     # Filter to strictly newer than the watermark. SEC's recent array
     # is ordered newest-first; we walk until we hit the watermark and
     # stop — preserves chronological order in the result and avoids
@@ -272,4 +298,5 @@ def check_freshness(
         new_filings=new_filings,
         last_filed_at=last_filed_at,
         has_more_in_files=has_more,
+        files_pages=files_pages,
     )

--- a/tests/test_sec_rebuild.py
+++ b/tests/test_sec_rebuild.py
@@ -227,11 +227,28 @@ class TestDiscoveryPass:
         secondary_row = get_manifest_row(ebull_test_conn, "0000320193-22-000050")
         assert secondary_row is not None
         assert secondary_row.source == "sec_def14a"
+        # The recent payload's only DEF 14A is already seeded so it
+        # contributes 0 to discovery_new_manifest_rows; the secondary
+        # page contributes 1. Bot review NITPICK: ``>= 1`` would pass
+        # even if the secondary walk did nothing as long as recent
+        # introduced a new accession. ``>= 1`` here proves the new
+        # code path because the recent payload is intentionally
+        # already-seeded (no recent contribution).
         assert stats.discovery_new_manifest_rows >= 1
 
         # Confirm the secondary URL was actually fetched (would fail
         # silently without the pagination walk).
         assert any("submissions-001.json" in u for u in seen_urls), f"rebuild did not fetch secondary page: {seen_urls}"
+
+        # Codex pre-push: rebuild must NOT re-fetch the primary CIK
+        # JSON to read ``files[]`` — that doubles the request count
+        # and creates a new failure mode. Now that ``FreshnessDelta``
+        # carries ``files_pages`` from the original parse, the primary
+        # is fetched exactly once.
+        primary_fetches = [u for u in seen_urls if u.endswith("CIK0000320193.json")]
+        assert len(primary_fetches) == 1, (
+            f"primary CIK JSON should be fetched exactly once; saw {len(primary_fetches)}: {primary_fetches}"
+        )
 
     def test_discovery_isolates_secondary_page_failures(
         self,

--- a/tests/test_sec_rebuild.py
+++ b/tests/test_sec_rebuild.py
@@ -169,3 +169,125 @@ class TestDiscoveryPass:
         new_row = get_manifest_row(ebull_test_conn, "0000320193-26-000099")
         assert new_row is not None
         assert new_row.source == "sec_def14a"
+
+    def test_discovery_walks_filings_files_secondary_pages(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # #936: rebuild claims full-history discovery; ``check_freshness``
+        # reads only ``recent[]``. An accession aged out into a
+        # secondary ``filings.files[]`` page must still be recovered by
+        # the rebuild path. ``recent`` here carries no in-scope
+        # accessions; the secondary page carries the one we expect to
+        # discover.
+        _seed_aapl_with_state(ebull_test_conn)
+
+        recent_payload = {
+            "cik": "320193",
+            "filings": {
+                "recent": {
+                    "accessionNumber": ["0000320193-26-000001"],
+                    "filingDate": ["2026-02-14"],
+                    "form": ["DEF 14A"],
+                    "acceptanceDateTime": ["2026-02-14T08:00:00.000Z"],
+                    "primaryDocument": ["proxy.htm"],
+                },
+                "files": [{"name": "CIK0000320193-submissions-001.json"}],
+            },
+        }
+        secondary_payload = {
+            "accessionNumber": ["0000320193-22-000050"],
+            "filingDate": ["2022-01-15"],
+            "form": ["DEF 14A"],
+            "acceptanceDateTime": ["2022-01-15T08:00:00.000Z"],
+            "primaryDocument": ["proxy-2022.htm"],
+        }
+        recent_body = json.dumps(recent_payload).encode("utf-8")
+        secondary_body = json.dumps(secondary_payload).encode("utf-8")
+
+        seen_urls: list[str] = []
+
+        def _fake_get_routed(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+            seen_urls.append(url)
+            if url.endswith("CIK0000320193.json"):
+                return 200, recent_body
+            if "submissions-001.json" in url:
+                return 200, secondary_body
+            return 404, b""
+
+        stats = run_sec_rebuild(
+            ebull_test_conn,
+            RebuildScope(instrument_id=1701),
+            http_get=_fake_get_routed,
+            discover=True,
+        )
+        ebull_test_conn.commit()
+
+        # Aged-out accession from secondary page is now manifested.
+        secondary_row = get_manifest_row(ebull_test_conn, "0000320193-22-000050")
+        assert secondary_row is not None
+        assert secondary_row.source == "sec_def14a"
+        assert stats.discovery_new_manifest_rows >= 1
+
+        # Confirm the secondary URL was actually fetched (would fail
+        # silently without the pagination walk).
+        assert any("submissions-001.json" in u for u in seen_urls), f"rebuild did not fetch secondary page: {seen_urls}"
+
+    def test_discovery_isolates_secondary_page_failures(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # Codex pre-push: transport error or malformed secondary page
+        # must NOT abort the rebuild — the rest of the scope still
+        # drains. Two pages: page 1 raises on fetch, page 2 returns a
+        # valid body.
+        _seed_aapl_with_state(ebull_test_conn)
+
+        recent_payload = {
+            "cik": "320193",
+            "filings": {
+                "recent": {
+                    "accessionNumber": ["0000320193-26-000001"],
+                    "filingDate": ["2026-02-14"],
+                    "form": ["DEF 14A"],
+                    "acceptanceDateTime": ["2026-02-14T08:00:00.000Z"],
+                    "primaryDocument": ["proxy.htm"],
+                },
+                "files": [
+                    {"name": "CIK0000320193-submissions-001.json"},
+                    {"name": "CIK0000320193-submissions-002.json"},
+                ],
+            },
+        }
+        page2_payload = {
+            "accessionNumber": ["0000320193-21-000077"],
+            "filingDate": ["2021-06-01"],
+            "form": ["DEF 14A"],
+            "acceptanceDateTime": ["2021-06-01T08:00:00.000Z"],
+            "primaryDocument": ["proxy-2021.htm"],
+        }
+        recent_body = json.dumps(recent_payload).encode("utf-8")
+        page2_body = json.dumps(page2_payload).encode("utf-8")
+
+        def _fake_get_with_failure(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+            if url.endswith("CIK0000320193.json"):
+                return 200, recent_body
+            if "submissions-001.json" in url:
+                raise RuntimeError("simulated transport failure on page 1")
+            if "submissions-002.json" in url:
+                return 200, page2_body
+            return 404, b""
+
+        # Should not raise — the failed page is isolated; the other
+        # page still discovers its accession.
+        stats = run_sec_rebuild(
+            ebull_test_conn,
+            RebuildScope(instrument_id=1701),
+            http_get=_fake_get_with_failure,
+            discover=True,
+        )
+        ebull_test_conn.commit()
+
+        assert stats.discovery_new_manifest_rows >= 1
+        page2_row = get_manifest_row(ebull_test_conn, "0000320193-21-000077")
+        assert page2_row is not None


### PR DESCRIPTION
Closes #936
Refs #935

## Summary
Targeted rebuild claimed full-history discovery but `check_freshness` reads only `recent[]`. Older filings in `filings.files[]` secondary pages could never be repaired by rebuild. Fix: when `delta.has_more_in_files`, walk every secondary page + UPSERT scope-matching rows.

## Changes
- `app/jobs/sec_rebuild.py`:
  - New `_walk_secondary_pages` helper. Mirrors pagination from `sec_first_install_drain._drain_secondary_pages` but filters by rebuild's scope (`sources_set`) so a `sec_def14a`-scoped rebuild doesn't touch every 8-K on the same page.
  - Per-page failure isolation (Codex pre-push catch): `http_get` + `parse_submissions_page` exceptions caught + logged + continue.
- Atom feed (#867) and per-CIK polling (#870) unchanged — they intentionally stay on `recent` (cheap path).

## Test plan
- [x] `test_discovery_walks_filings_files_secondary_pages`: aged-out accession in secondary page recovered + manifested.
- [x] `test_discovery_isolates_secondary_page_failures`: transport error on page 1 doesn't abort rebuild; page 2 still discovers its accession.
- [x] 7 tests pass; lint + format clean; pyright clean.

## Code duplication note
`_walk_secondary_pages` mirrors `sec_first_install_drain._drain_secondary_pages`. Cleanup into a shared helper deferred — the call sites differ on source filtering (rebuild scopes; drain takes everything).