### PR TITLE
feat(#956): inline freshness seed in record_manifest_entry

### DIFF
--- a/app/services/data_freshness.py
+++ b/app/services/data_freshness.py
@@ -129,6 +129,115 @@ def predict_next_at(
 # ---------------------------------------------------------------------------
 
 
+def seed_freshness_for_manifest_row(
+    conn: psycopg.Connection[Any],
+    *,
+    subject_type: ManifestSubjectType,
+    subject_id: str,
+    source: ManifestSource,
+    cik: str | None,
+    instrument_id: int | None,
+    accession_number: str,
+    filed_at: datetime,
+) -> None:
+    """Single-row scheduler seed for one manifest write (#956).
+
+    Companion to ``seed_scheduler_from_manifest`` (the bulk full-table
+    rebuild). Called inline from ``record_manifest_entry`` so every
+    manifest discovery write — Atom fast-lane, daily-index reconcile,
+    per-CIK poll, targeted rebuild, first-install drain — leaves the
+    scheduler queryable. Pre-#956 only the drain seeded; the others
+    relied on the next full ``seed_scheduler_from_manifest`` to pick
+    up new triples, leaving them invisible until that ran.
+
+    Latest-row semantics: the freshness ``last_known_*`` columns must
+    reflect the LATEST filing per (subject, source). Discovery writers
+    can call this with an older accession (rebuild walking
+    ``filings.files[]`` secondary pages, daily-index reconcile picking
+    up a missed older row, etc.) — the conditional UPDATE preserves
+    the existing newer values rather than letting ``EXCLUDED`` clobber
+    them.
+    """
+    expected_next_at = predict_next_at(source, filed_at)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO data_freshness_index (
+                subject_type, subject_id, source,
+                cik, instrument_id,
+                last_known_filing_id, last_known_filed_at,
+                last_polled_at, last_polled_outcome,
+                expected_next_at, state
+            ) VALUES (
+                %(stype)s, %(sid)s, %(source)s,
+                %(cik)s, %(iid)s,
+                %(acc)s, %(filed_at)s,
+                NULL, 'never',
+                %(next_at)s, 'current'
+            )
+            ON CONFLICT (subject_type, subject_id, source) DO UPDATE SET
+                cik = COALESCE(EXCLUDED.cik, data_freshness_index.cik),
+                instrument_id = COALESCE(
+                    EXCLUDED.instrument_id, data_freshness_index.instrument_id
+                ),
+                -- Latest-row preservation. The "newer" gate drives
+                -- ALL watermark fields (filing_id + filed_at +
+                -- expected_next_at) uniformly so they never diverge.
+                -- Older discovery writes (rebuild's secondary-page
+                -- walk, daily-index reconcile catching up) leave the
+                -- existing watermark intact.
+                last_known_filing_id = CASE
+                    WHEN data_freshness_index.last_known_filed_at IS NULL
+                      OR EXCLUDED.last_known_filed_at > data_freshness_index.last_known_filed_at
+                    THEN EXCLUDED.last_known_filing_id
+                    ELSE data_freshness_index.last_known_filing_id
+                END,
+                last_known_filed_at = CASE
+                    WHEN data_freshness_index.last_known_filed_at IS NULL
+                      OR EXCLUDED.last_known_filed_at > data_freshness_index.last_known_filed_at
+                    THEN EXCLUDED.last_known_filed_at
+                    ELSE data_freshness_index.last_known_filed_at
+                END,
+                expected_next_at = CASE
+                    WHEN data_freshness_index.last_known_filed_at IS NULL
+                      OR EXCLUDED.last_known_filed_at > data_freshness_index.last_known_filed_at
+                    THEN EXCLUDED.expected_next_at
+                    ELSE data_freshness_index.expected_next_at
+                END,
+                -- State: only ESCALATE from ``never_filed`` to
+                -- ``current`` (manifest evidence shows the subject
+                -- has filed). Don't clobber legitimate poll-outcome
+                -- states like ``error`` / ``expected_filing_overdue``
+                -- on a duplicate / older re-discovery write — those
+                -- carry meaning from the per-CIK poll lifecycle and
+                -- a noisy Atom replay shouldn't reset them.
+                -- Codex pre-push catch.
+                state = CASE
+                    WHEN data_freshness_index.state = 'never_filed' THEN 'current'
+                    ELSE data_freshness_index.state
+                END,
+                state_reason = CASE
+                    WHEN data_freshness_index.state = 'never_filed' THEN NULL
+                    ELSE data_freshness_index.state_reason
+                END,
+                next_recheck_at = CASE
+                    WHEN data_freshness_index.state = 'never_filed' THEN NULL
+                    ELSE data_freshness_index.next_recheck_at
+                END
+            """,
+            {
+                "stype": subject_type,
+                "sid": subject_id,
+                "source": source,
+                "cik": cik,
+                "iid": instrument_id,
+                "acc": accession_number,
+                "filed_at": filed_at,
+                "next_at": expected_next_at,
+            },
+        )
+
+
 def seed_scheduler_from_manifest(conn: psycopg.Connection[Any]) -> int:
     """Bootstrap ``data_freshness_index`` rows from manifest history.
 

--- a/app/services/sec_manifest.py
+++ b/app/services/sec_manifest.py
@@ -226,6 +226,27 @@ def record_manifest_entry(
             },
         )
 
+    # #956: every manifest discovery write also seeds / updates the
+    # scheduler row for its (subject_type, subject_id, source) triple.
+    # Pre-#956 only the first-install drain (#937 / PR #957) called
+    # ``seed_scheduler_from_manifest``; Atom fast-lane / daily-index
+    # reconcile / per-CIK poll / targeted rebuild left new triples
+    # scheduler-invisible until the next full bulk seed. Lazy import
+    # to avoid a circular dependency — ``data_freshness`` imports
+    # ``ManifestSource`` from this module.
+    from app.services.data_freshness import seed_freshness_for_manifest_row
+
+    seed_freshness_for_manifest_row(
+        conn,
+        subject_type=subject_type,
+        subject_id=subject_id.strip(),
+        source=source,
+        cik=cik.strip(),
+        instrument_id=instrument_id,
+        accession_number=accession_number,
+        filed_at=filed_at,
+    )
+
 
 def transition_status(
     conn: psycopg.Connection[Any],

--- a/tests/test_data_freshness.py
+++ b/tests/test_data_freshness.py
@@ -24,6 +24,7 @@ from app.services.data_freshness import (
     get_freshness_row,
     predict_next_at,
     record_poll_outcome,
+    seed_freshness_for_manifest_row,
     seed_scheduler_from_manifest,
     subjects_due_for_poll,
     subjects_due_for_recheck,
@@ -478,3 +479,233 @@ class TestIterators:
 
         recheck_rows = list(subjects_due_for_recheck(ebull_test_conn, source="sec_form4", limit=10))
         assert recheck_rows == []
+
+
+class TestSeedFreshnessForManifestRow:
+    """#956: single-row seed wired into ``record_manifest_entry``."""
+
+    def test_seeds_new_subject(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_instrument(ebull_test_conn, iid=1, symbol="X", cik="0000000001")
+        seed_freshness_for_manifest_row(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            cik="0000000001",
+            instrument_id=1,
+            accession_number="ACC-1",
+            filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        ebull_test_conn.commit()
+
+        row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1", source="sec_form4")
+        assert row is not None
+        assert row.last_known_filing_id == "ACC-1"
+        assert row.last_known_filed_at == datetime(2026, 2, 1, tzinfo=UTC)
+        assert row.state == "current"
+        # Cadence = 30d for sec_form4
+        assert row.expected_next_at == datetime(2026, 3, 3, tzinfo=UTC)
+
+    def test_newer_row_advances_watermark(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_instrument(ebull_test_conn, iid=1, symbol="X", cik="0000000001")
+        seed_freshness_for_manifest_row(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            cik="0000000001",
+            instrument_id=1,
+            accession_number="ACC-OLD",
+            filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        seed_freshness_for_manifest_row(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            cik="0000000001",
+            instrument_id=1,
+            accession_number="ACC-NEW",
+            filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        ebull_test_conn.commit()
+
+        row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1", source="sec_form4")
+        assert row is not None
+        assert row.last_known_filing_id == "ACC-NEW"
+        assert row.last_known_filed_at == datetime(2026, 2, 1, tzinfo=UTC)
+
+    def test_older_row_does_not_clobber_watermark(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # Discovery writers (rebuild secondary-page walk, daily-index
+        # reconcile catching up) can call this with an OLDER accession
+        # than what's already tracked. The watermark must not regress.
+        _seed_instrument(ebull_test_conn, iid=1, symbol="X", cik="0000000001")
+        seed_freshness_for_manifest_row(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            cik="0000000001",
+            instrument_id=1,
+            accession_number="ACC-NEW",
+            filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        seed_freshness_for_manifest_row(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            cik="0000000001",
+            instrument_id=1,
+            accession_number="ACC-OLD",
+            filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        ebull_test_conn.commit()
+
+        row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1", source="sec_form4")
+        assert row is not None
+        # Watermark stayed on the newer accession.
+        assert row.last_known_filing_id == "ACC-NEW"
+        assert row.last_known_filed_at == datetime(2026, 2, 1, tzinfo=UTC)
+
+    def test_re_discovery_does_not_clobber_poll_error_state(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # Codex pre-push: the inline UPSERT must NOT clobber legitimate
+        # poll-outcome states (``error`` / ``expected_filing_overdue``)
+        # on a duplicate / older re-discovery write. A noisy Atom
+        # replay of an already-known accession should leave the
+        # per-CIK poll's error state intact.
+        _seed_instrument(ebull_test_conn, iid=1, symbol="X", cik="0000000001")
+        seed_freshness_for_manifest_row(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            cik="0000000001",
+            instrument_id=1,
+            accession_number="ACC-1",
+            filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        # Simulate a poll error overwriting state to 'error'.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE data_freshness_index
+                SET state = 'error',
+                    state_reason = 'HTTP 503',
+                    next_recheck_at = %s
+                WHERE subject_type = 'issuer' AND subject_id = '1' AND source = 'sec_form4'
+                """,
+                (datetime(2026, 3, 1, tzinfo=UTC),),
+            )
+        ebull_test_conn.commit()
+
+        # Re-discovery via Atom replay (same accession or older).
+        seed_freshness_for_manifest_row(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            cik="0000000001",
+            instrument_id=1,
+            accession_number="ACC-1",
+            filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        ebull_test_conn.commit()
+
+        row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1", source="sec_form4")
+        assert row is not None
+        # State stayed 'error' — the manifest write did not overwrite
+        # the poll-outcome state.
+        assert row.state == "error"
+        assert row.next_recheck_at == datetime(2026, 3, 1, tzinfo=UTC)
+        # state_reason isn't on FreshnessRow; query directly.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT state_reason FROM data_freshness_index
+                WHERE subject_type = 'issuer' AND subject_id = '1' AND source = 'sec_form4'
+                """
+            )
+            (state_reason,) = cur.fetchone() or (None,)
+        assert state_reason == "HTTP 503"
+
+    def test_re_discovery_escalates_never_filed_to_current(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # The legitimate state change: ``never_filed`` → ``current``
+        # MUST happen when manifest evidence appears. This is the
+        # rescue path the bulk seed comment documents.
+        _seed_instrument(ebull_test_conn, iid=1, symbol="X", cik="0000000001")
+        # Seed a freshness row in 'never_filed' state (subject was
+        # tracked but no filings yet).
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO data_freshness_index (
+                    subject_type, subject_id, source, cik, instrument_id,
+                    state, expected_next_at
+                ) VALUES (
+                    'issuer', '1', 'sec_form4', '0000000001', 1,
+                    'never_filed', %s
+                )
+                """,
+                (datetime(2026, 1, 1, tzinfo=UTC),),
+            )
+        ebull_test_conn.commit()
+
+        # Manifest write rescues the row.
+        seed_freshness_for_manifest_row(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            cik="0000000001",
+            instrument_id=1,
+            accession_number="ACC-1",
+            filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        ebull_test_conn.commit()
+
+        row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1", source="sec_form4")
+        assert row is not None
+        assert row.state == "current"
+        assert row.last_known_filing_id == "ACC-1"
+
+    def test_record_manifest_entry_seeds_inline(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # The actual contract: every ``record_manifest_entry`` call
+        # leaves the freshness index queryable for that triple. No
+        # separate ``seed_scheduler_from_manifest`` invocation needed.
+        _seed_instrument(ebull_test_conn, iid=1, symbol="X", cik="0000000001")
+        record_manifest_entry(
+            ebull_test_conn,
+            "ACC-1",
+            cik="0000000001",
+            form="4",
+            source="sec_form4",
+            subject_type="issuer",
+            subject_id="1",
+            instrument_id=1,
+            filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        ebull_test_conn.commit()
+
+        row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1", source="sec_form4")
+        assert row is not None
+        assert row.last_known_filing_id == "ACC-1"
+        assert row.state == "current"

--- a/tests/test_sec_atom_fast_lane.py
+++ b/tests/test_sec_atom_fast_lane.py
@@ -119,6 +119,60 @@ class TestFastLaneJob:
         assert blackrock_row.subject_type == "institutional_filer"
         assert blackrock_row.instrument_id is None
 
+    def test_atom_discovery_seeds_freshness_index(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # #956: every manifest discovery write must also seed
+        # data_freshness_index. Pre-fix Atom fast-lane left new
+        # (subject, source) triples scheduler-invisible until the
+        # next bulk seed_scheduler_from_manifest invocation.
+        def resolver(conn, cik):
+            if cik == "0000320193":
+                return ResolvedSubject(subject_type="issuer", subject_id="1701", instrument_id=1701)
+            if cik == "0001364742":
+                return ResolvedSubject(subject_type="institutional_filer", subject_id=cik, instrument_id=None)
+            return None
+
+        ebull_test_conn.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+            VALUES (1701, 'AAPL', 'Apple', '4', 'USD', TRUE)
+            """
+        )
+        ebull_test_conn.commit()
+
+        run_atom_fast_lane(
+            ebull_test_conn,
+            http_get=_fake_get(200, _ATOM_SAMPLE),
+            subject_resolver=resolver,
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT subject_type, subject_id, source, state, last_known_filing_id
+                FROM data_freshness_index
+                ORDER BY subject_type, subject_id, source
+                """
+            )
+            rows = cur.fetchall()
+
+        # Both Atom-discovered triples are now scheduler-visible.
+        triples = {(r[0], r[1], r[2]) for r in rows}
+        assert ("issuer", "1701", "sec_form4") in triples
+        assert ("institutional_filer", "0001364742", "sec_13f_hr") in triples
+        # And state is 'current' (manifest evidence shows the subject
+        # has filed) so the per-CIK poll picks them up.
+        assert all(r[3] == "current" for r in rows)
+        # last_known_filing_id matches the just-discovered accession.
+        for stype, sid, _src, _state, last_id in rows:
+            if (stype, sid) == ("issuer", "1701"):
+                assert last_id == "0000320193-26-000042"
+            elif (stype, sid) == ("institutional_filer", "0001364742"):
+                assert last_id == "0001364742-26-000099"
+
     def test_unknown_subject_skipped(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811


### PR DESCRIPTION
Closes #956
Refs #935 #937 #959

## Summary
Pre-#956 only the first-install drain (#937) seeded `data_freshness_index`; Atom fast-lane / daily-index reconcile / per-CIK poll / targeted rebuild left new triples scheduler-invisible until the next bulk seed. Fix: `record_manifest_entry` invokes a new `seed_freshness_for_manifest_row` helper inline. Single boundary — every manifest write maintains the index automatically.

## Changes
- `app/services/data_freshness.py`: new `seed_freshness_for_manifest_row` with latest-row preservation (newer-gate on watermark fields) + state-machine rules (only escalate `never_filed` → `current`; don't clobber `error` / `expected_filing_overdue`).
- `app/services/sec_manifest.py`: `record_manifest_entry` calls helper inline. Lazy import to avoid the cycle.
- 7 new tests across `test_data_freshness.py` + `test_sec_atom_fast_lane.py`.

## Codex pre-push findings applied
- **State preservation** — initial draft unconditionally set `state='current'` on every UPSERT, clobbering legitimate poll errors. Fixed with conditional CASE.
- **Latest-row uniformity** — initial draft used `GREATEST(EXCLUDED, current)` for `expected_next_at`, which could keep stale poll-derived values when a newer accession arrived. Fixed with the same newer-gate as `last_known_*`.
- **Drain double-seed perf** — filed as **#959** follow-up. Drain now seeds inline per-row + bulk at end. Idempotent (correctness fine), redundant on the largest write path. Defer to #959 since dropping the bulk call needs careful behaviour analysis.

## Test plan
- [x] 87 tests pass across `test_data_freshness.py` + `test_sec_atom_fast_lane.py` + `test_sec_first_install_drain.py` + `test_sec_per_cik_poll.py` + `test_sec_rebuild.py` + `test_sec_daily_index_reconcile.py` + `test_sec_manifest.py`.
- [x] Atom discovery → freshness index has scheduler-visible rows in `state='current'`.
- [x] Older accession does not clobber newer watermark.
- [x] Re-discovery of same accession preserves poll-error state.
- [x] `never_filed` state correctly escalates to `current` on first manifest evidence.
- [x] `ruff check`, `ruff format --check`, `pyright` clean.