### PR TITLE
feat(#975): credential health state machine + atomic PUT /replace endpoint

### DIFF
--- a/app/api/broker_credentials.py
+++ b/app/api/broker_credentials.py
@@ -36,6 +36,7 @@ from uuid import UUID, uuid4
 
 import httpx
 import psycopg
+import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
@@ -60,6 +61,7 @@ from app.services.broker_credentials import (
     revoke_credential,
     store_credential,
 )
+from app.services.credential_health import record_health_outcome
 
 logger = logging.getLogger(__name__)
 
@@ -780,10 +782,258 @@ def validate_stored(
     # Commit audit rows before the external probe call (audit durability).
     conn.commit()
 
+    # Look up credential_ids before the probe so we can write through
+    # health outcomes (#975 / #974/A). Side-tx writes from
+    # record_health_outcome use the request app's pool.
+    cred_ids = _lookup_active_credential_ids(
+        conn,
+        operator_id=session.operator_id,
+        provider="etoro",
+        environment=environment,
+    )
+
     try:
-        return _probe_etoro(api_key, user_key, environment)
+        result = _probe_etoro(api_key, user_key, environment)
     except CredentialValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid environment for stored credential validation.",
         ) from exc
+
+    # Write the probe outcome through to credential health for both
+    # rows. validate-stored is THE canonical probe path — source='probe'
+    # is required to clear a sticky REJECTED row, per the credential
+    # health contract.
+    request_pool = getattr(request.app.state, "pool", None)
+    if request_pool is not None:
+        for cred_id in cred_ids.values():
+            try:
+                record_health_outcome(
+                    credential_id=cred_id,
+                    success=result.auth_valid,
+                    source="probe",
+                    error_detail=result.note if not result.auth_valid else None,
+                    pool=request_pool,
+                )
+            except Exception:
+                # Best-effort beyond the side-tx contract per spec.
+                # The probe response IS the user-facing outcome — a
+                # health-write failure must not change the API result.
+                logger.warning(
+                    "validate-stored: credential health write-through failed",
+                    exc_info=True,
+                )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# PUT /broker-credentials/replace — atomic revoke + create (#975 / #974/A)
+# ---------------------------------------------------------------------------
+
+
+class ReplaceCredentialRequest(BaseModel):
+    """Atomic revoke + create for an existing label.
+
+    Replaces the active credential row for ``(operator, provider, label,
+    environment)`` in a single transaction so subscribers (orchestrator
+    pre-flight gate, WS subscriber) never observe a transient MISSING
+    state between the revoke and create. Per spec section "Atomic
+    credential replacement".
+    """
+
+    provider: str = Field(min_length=1, max_length=64)
+    label: str = Field(min_length=1, max_length=255)
+    environment: str = Field(default="demo", min_length=1, max_length=16)
+    secret: str = Field(min_length=1, max_length=4096)
+
+
+class ReplaceCredentialResponse(BaseModel):
+    """Response for PUT /broker-credentials/replace.
+
+    ``changed=False`` when the new secret is identical to the active
+    row's plaintext (identical-secret short-circuit). The credential
+    metadata still reflects the existing row.
+    """
+
+    changed: bool
+    credential: CredentialMetadataOut
+
+
+@router.put("/replace", response_model=ReplaceCredentialResponse)
+def replace(
+    body: ReplaceCredentialRequest,
+    request: Request,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ReplaceCredentialResponse:
+    """Atomically revoke and re-insert an active broker credential row.
+
+    All work runs in one transaction:
+      1. SELECT the active row for the supplied label FOR UPDATE.
+      2. Decrypt the existing ciphertext and compare to the new
+         plaintext. If identical, short-circuit with changed=False;
+         no row update, no NOTIFY (avoids spurious VALID -> UNTESTED
+         -> VALID flap from an idempotent re-save).
+      3. Otherwise: ``revoked_at = NOW()`` on the existing row,
+         INSERT a new row with ``health_state='untested'``.
+      4. Commit.
+
+    Returns 404 if no active row exists for the label (callers should
+    POST instead). Returns 503 if the existing ciphertext cannot be
+    decrypted (key material issue).
+
+    The new row is UNTESTED until ``validate-stored`` probe success
+    flips it to VALID. Subscribers see one NOTIFY at most: the
+    underlying row update fires no NOTIFY itself (handled by the
+    insert default state); when validate-stored runs after this
+    endpoint and probes successfully, that probe's write-through
+    fires the VALID NOTIFY.
+    """
+    if getattr(request.app.state, "recovery_required", False):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="recovery required",
+        )
+
+    try:
+        provider_norm = normalise_provider(body.provider)
+        label_norm = normalise_label(body.label)
+        env_norm = normalise_environment(body.environment)
+        secret_norm = normalise_secret(body.secret)
+    except CredentialValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    # Look up the active row for this label. We need to keep the
+    # decrypt + compare + revoke + insert together in one tx; doing
+    # the lookup inside the tx with FOR UPDATE serialises against
+    # concurrent replace calls for the same (operator, label).
+    audit_pool = getattr(request.app.state, "audit_pool", None)
+
+    with conn.transaction():
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT id, last_four
+                  FROM broker_credentials
+                 WHERE operator_id = %(op)s
+                   AND provider    = %(prov)s
+                   AND label       = %(label)s
+                   AND environment = %(env)s
+                   AND revoked_at IS NULL
+                 FOR UPDATE
+                """,
+                {
+                    "op": session.operator_id,
+                    "prov": provider_norm,
+                    "label": label_norm,
+                    "env": env_norm,
+                },
+            )
+            existing = cur.fetchone()
+
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No active credential to replace. Use POST /broker-credentials to create.",
+            )
+
+        # Identical-secret short-circuit (Codex r2.3): decrypt existing
+        # ciphertext and compare to new plaintext. Avoids the spurious
+        # VALID -> UNTESTED -> VALID flap from an idempotent re-save.
+        try:
+            existing_plaintext = load_credential_for_provider_use(
+                conn,
+                operator_id=session.operator_id,
+                provider=provider_norm,
+                label=label_norm,
+                environment=env_norm,
+                caller="replace-compare",
+                audit_pool=audit_pool,
+            )
+        except CredentialDecryptError as exc:
+            logger.error("replace: decryption of existing row failed", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Existing credential decryption failed. Check server key material.",
+            ) from exc
+
+        if existing_plaintext == secret_norm:
+            # Same secret. Return the existing row's metadata; no row
+            # update, no NOTIFY.
+            existing_meta = next(
+                (m for m in list_credentials(conn, operator_id=session.operator_id) if m.id == existing["id"]),
+                None,
+            )
+            if existing_meta is None:
+                # Logical impossibility: we just selected this row inside
+                # the transaction and now list_credentials returns no
+                # match. Fail loudly rather than silently default.
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Internal: existing credential not found in same transaction.",
+                )
+            return ReplaceCredentialResponse(
+                changed=False,
+                credential=_to_out(existing_meta),
+            )
+
+        # Different secret. Revoke the existing row, then insert.
+        revoke_credential(
+            conn,
+            credential_id=existing["id"],
+            operator_id=session.operator_id,
+        )
+        new_meta = store_credential(
+            conn,
+            operator_id=session.operator_id,
+            provider=provider_norm,
+            label=label_norm,
+            environment=env_norm,
+            plaintext=secret_norm,
+        )
+
+    return ReplaceCredentialResponse(
+        changed=True,
+        credential=_to_out(new_meta),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _lookup_active_credential_ids(
+    conn: psycopg.Connection[object],
+    *,
+    operator_id: UUID,
+    provider: str,
+    environment: str,
+) -> dict[str, UUID]:
+    """Return ``{label: credential_id}`` for the operator's active rows.
+
+    Used by validate-stored to find the rows whose health to write
+    through after a probe outcome. The probe call doesn't need the IDs
+    itself — only the outcome plumbing does.
+
+    Returns an empty dict if the operator has no active rows for the
+    provider/environment. Caller is responsible for treating that as
+    "no write-throughs to perform".
+    """
+    out: dict[str, UUID] = {}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT id, label
+              FROM broker_credentials
+             WHERE operator_id = %(op)s
+               AND provider    = %(prov)s
+               AND environment = %(env)s
+               AND revoked_at IS NULL
+            """,
+            {"op": operator_id, "prov": provider, "env": environment},
+        )
+        for row in cur.fetchall():
+            out[row["label"]] = row["id"]
+    return out

--- a/app/api/broker_credentials.py
+++ b/app/api/broker_credentials.py
@@ -61,7 +61,11 @@ from app.services.broker_credentials import (
     revoke_credential,
     store_credential,
 )
-from app.services.credential_health import record_health_outcome
+from app.services.credential_health import (
+    get_operator_credential_health,
+    notify_aggregate_if_changed,
+    record_health_outcome,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -804,7 +808,10 @@ def validate_stored(
     # rows. validate-stored is THE canonical probe path — source='probe'
     # is required to clear a sticky REJECTED row, per the credential
     # health contract.
-    request_pool = getattr(request.app.state, "pool", None)
+    # Use db_pool (lifespan attribute name) — earlier draft used
+    # the wrong attribute and silently no-op'd in production
+    # (Codex pre-push r1.1).
+    request_pool = getattr(request.app.state, "db_pool", None)
     if request_pool is not None:
         for cred_id in cred_ids.values():
             try:
@@ -910,6 +917,13 @@ def replace(
     # concurrent replace calls for the same (operator, label).
     audit_pool = getattr(request.app.state, "audit_pool", None)
 
+    # Flush any implicit transaction the dependency machinery may have
+    # opened on this connection so the next ``conn.transaction()``
+    # opens a real top-level txn rather than a savepoint that defers
+    # commit until the dependency teardown (Codex pre-push r1.4).
+    # Mirrors the same pattern in POST /broker-credentials.
+    conn.commit()
+
     with conn.transaction():
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
@@ -937,6 +951,18 @@ def replace(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="No active credential to replace. Use POST /broker-credentials to create.",
             )
+
+        # Snapshot the operator aggregate BEFORE the revoke+insert so
+        # we can NOTIFY subscribers of the resulting transition. Without
+        # this, a VALID -> UNTESTED move (replacing a VALID row with a
+        # fresh UNTESTED one) would silently bypass the cache (Codex
+        # pre-push r1.3).
+        old_aggregate = get_operator_credential_health(
+            conn,
+            operator_id=session.operator_id,
+            provider=provider_norm,
+            environment=env_norm,
+        )
 
         # Identical-secret short-circuit (Codex r2.3): decrypt existing
         # ciphertext and compare to new plaintext. Avoids the spurious
@@ -991,6 +1017,17 @@ def replace(
             label=label_norm,
             environment=env_norm,
             plaintext=secret_norm,
+        )
+
+        # NOTIFY subscribers if the aggregate actually moved. Inside
+        # the same tx as the row mutations so the notify commits
+        # alongside (and after) the durable state change.
+        notify_aggregate_if_changed(
+            conn,
+            operator_id=session.operator_id,
+            provider=provider_norm,
+            environment=env_norm,
+            old_aggregate=old_aggregate,
         )
 
     return ReplaceCredentialResponse(

--- a/app/services/credential_health.py
+++ b/app/services/credential_health.py
@@ -365,23 +365,22 @@ def _do_health_transition(
             environment=environment,
         )
 
-        # Record the recovery timestamp ONLY on REJECTED -> VALID at
-        # operator level. Other transitions (UNTESTED -> VALID,
-        # MISSING -> UNTESTED) don't write the transitions row — that
-        # row exists specifically to mark "operator has recovered from
-        # an explicit rejection" so AUTH_EXPIRED suppression has a
-        # boundary. Codex r2.4 + spec.
-        if old_aggregate == CredentialHealth.REJECTED and new_aggregate == CredentialHealth.VALID:
-            cur.execute(
-                """
-                INSERT INTO operator_credential_health_transitions
-                    (operator_id, last_recovered_at)
-                VALUES (%(op)s, NOW())
-                ON CONFLICT (operator_id) DO UPDATE
-                    SET last_recovered_at = EXCLUDED.last_recovered_at
-                """,
-                {"op": operator_id},
-            )
+        # Record the recovery timestamp on ANY move OUT of REJECTED at
+        # operator level — VALID, UNTESTED, or MISSING — not only the
+        # direct REJECTED -> VALID transition. The realistic operator
+        # flow is: REJECTED -> (PUT /replace) UNTESTED -> (validate-
+        # stored) VALID. If we only stamped on REJECTED -> VALID we
+        # would miss the recovery moment entirely (Codex pre-push
+        # r2.1). The suppression query filters AUTH_EXPIRED rows with
+        # failed_at < last_recovered_at, and any subsequent REJECTED
+        # cycle generates new rows with failed_at > last_recovered_at
+        # so they surface normally.
+        _maybe_record_recovery(
+            cur,
+            operator_id=operator_id,
+            old_aggregate=old_aggregate,
+            new_aggregate=new_aggregate,
+        )
 
         # Idempotent: if the aggregate didn't move, no NOTIFY. A row-
         # level transition that doesn't move the aggregate (e.g.
@@ -458,13 +457,19 @@ def notify_aggregate_if_changed(
     observe that transition or they'll keep treating creds as valid
     (Codex pre-push r1.3).
 
+    Also records the operator-level recovery timestamp when the
+    aggregate moves OUT of REJECTED — covers the realistic
+    REJECTED -> UNTESTED transition from PUT /replace before the
+    operator runs validate-stored (Codex pre-push r2.1).
+
     Caller is expected to have:
       1. Snapshotted ``old_aggregate`` before any row mutations.
       2. Performed the mutations on ``conn`` inside a transaction.
       3. Called this helper inside the same transaction. The pg_notify
          fires when that transaction commits.
 
-    Idempotent: if the aggregate hasn't moved, no NOTIFY fires.
+    Idempotent: if the aggregate hasn't moved, no NOTIFY fires and no
+    recovery timestamp is written.
     """
     new_aggregate = get_operator_credential_health(
         conn,
@@ -475,20 +480,61 @@ def notify_aggregate_if_changed(
     if old_aggregate == new_aggregate:
         return
 
-    payload = json.dumps(
-        {
-            "operator_id": str(operator_id),
-            "provider": provider,
-            "old_aggregate": old_aggregate.value,
-            "new_aggregate": new_aggregate.value,
-            "at": datetime.now(UTC).isoformat(),
-        }
-    )
     with conn.cursor() as cur:
+        _maybe_record_recovery(
+            cur,
+            operator_id=operator_id,
+            old_aggregate=old_aggregate,
+            new_aggregate=new_aggregate,
+        )
+
+        payload = json.dumps(
+            {
+                "operator_id": str(operator_id),
+                "provider": provider,
+                "old_aggregate": old_aggregate.value,
+                "new_aggregate": new_aggregate.value,
+                "at": datetime.now(UTC).isoformat(),
+            }
+        )
         cur.execute(
             "SELECT pg_notify(%(channel)s, %(payload)s)",
             {"channel": NOTIFY_CHANNEL, "payload": payload},
         )
+
+
+def _maybe_record_recovery(
+    cur: psycopg.Cursor[Any],
+    *,
+    operator_id: UUID,
+    old_aggregate: CredentialHealth,
+    new_aggregate: CredentialHealth,
+) -> None:
+    """UPSERT operator_credential_health_transitions when leaving REJECTED.
+
+    Marks "the moment this operator stopped being REJECTED at
+    aggregate level" — used by the AUTH_EXPIRED suppression query
+    (failed_at < last_recovered_at) so cascade rows from the rejected
+    window stop surfacing in the operator-visible streak count.
+
+    Fires on REJECTED -> {VALID, UNTESTED, MISSING}. A subsequent
+    cycle back into REJECTED is fine: the new failures' failed_at
+    will be after last_recovered_at and will surface correctly.
+    """
+    if old_aggregate != CredentialHealth.REJECTED:
+        return
+    if new_aggregate == CredentialHealth.REJECTED:
+        return
+    cur.execute(
+        """
+        INSERT INTO operator_credential_health_transitions
+            (operator_id, last_recovered_at)
+        VALUES (%(op)s, NOW())
+        ON CONFLICT (operator_id) DO UPDATE
+            SET last_recovered_at = EXCLUDED.last_recovered_at
+        """,
+        {"op": operator_id},
+    )
 
 
 def get_last_recovered_at(

--- a/app/services/credential_health.py
+++ b/app/services/credential_health.py
@@ -1,0 +1,443 @@
+"""Credential health state machine + write-through helpers (#974 / #975).
+
+Every auth-using path (HTTP request handlers, WebSocket subscriber,
+batch-job adapters) reports its outcome through this module. The module
+owns:
+
+  * Row-level health state on ``broker_credentials`` (untested / valid /
+    rejected). Computed aggregate at operator level (worst-of, with
+    REJECTED dominating MISSING per locked precedence).
+  * Side-transactional write-through: ``record_health_outcome`` opens
+    its own connection from the pool, commits, then ``pg_notify``. A
+    caller's transaction rolling back can never lose a health write.
+  * REJECTED-stickiness: only an explicit validation-probe success
+    (``source='probe'``) can promote REJECTED → VALID. Incidental 2xx
+    from any other auth path cannot clear an explicit rejection.
+  * NOTIFY on aggregate movement only (idempotent). Subscribers (the
+    LISTEN listener at ``app/jobs/credential_health_listener.py`` —
+    ticket #976) wake on the channel and re-read DB truth.
+
+Design background: ``docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md``.
+Codex review chain: ``.claude/codex-974-r{1,2,3,4,5}-review.txt``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Literal
+from uuid import UUID
+
+import psycopg
+import psycopg.rows
+from psycopg_pool import ConnectionPool, PoolTimeout
+
+logger = logging.getLogger(__name__)
+
+
+# LISTEN/NOTIFY channel for aggregate-level operator health changes.
+# Subscribers run in the API process, the jobs process, and the WS
+# subscriber; cross-process delivery is the reason for using
+# pg_notify rather than an in-process pub-sub (settled-decision:
+# Postgres-first; no Redis). The channel is wake-up only — payload
+# carries operator_id + before/after aggregate but consumers MUST
+# re-read DB truth on receipt rather than trusting the payload alone.
+NOTIFY_CHANNEL = "ebull_credential_health"
+
+
+# Required label set per provider. Operator-level aggregate health
+# is computed against this list — a missing required label means
+# the operator's pair is incomplete (MISSING).
+REQUIRED_LABELS_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "etoro": ("api_key", "user_key"),
+}
+
+
+HealthState = Literal["untested", "valid", "rejected"]
+
+
+class CredentialHealth(StrEnum):
+    """Operator-level aggregate credential health.
+
+    UNTESTED / VALID / REJECTED come from the row-level column.
+    MISSING is derived from the absence of a required label row for
+    the operator and is never stored at row level.
+
+    Aggregate precedence (locked, REJECTED-first per Codex r3.2):
+        REJECTED > MISSING > UNTESTED > VALID
+
+    REJECTED dominates MISSING because if the operator has saved at
+    least one rejected key, they have a concrete fix to make; reporting
+    MISSING for the other label would mask that.
+    """
+
+    UNTESTED = "untested"
+    VALID = "valid"
+    REJECTED = "rejected"
+    MISSING = "missing"
+
+
+# ---------------------------------------------------------------------------
+# Operator-level aggregate computation
+# ---------------------------------------------------------------------------
+
+
+def get_operator_credential_health(
+    conn: psycopg.Connection[Any],
+    *,
+    operator_id: UUID,
+    provider: str = "etoro",
+) -> CredentialHealth:
+    """Compute the operator's aggregate credential health.
+
+    Joins a synthetic required-labels CTE against ``broker_credentials``
+    and returns the worst-of state per the locked precedence above.
+
+    Returns:
+        CredentialHealth — REJECTED / MISSING / UNTESTED / VALID.
+
+    Raises:
+        KeyError — provider not in REQUIRED_LABELS_BY_PROVIDER.
+        RuntimeError — aggregate query produced no decision (logical
+            impossibility under the schema CHECK constraints; surfaced
+            rather than silently defaulting per Codex r2.2).
+    """
+    required = REQUIRED_LABELS_BY_PROVIDER[provider]
+
+    sql_query = """
+        WITH required(label) AS (
+            SELECT * FROM unnest(%(required_labels)s::text[])
+        ),
+        observed AS (
+            SELECT label, health_state
+              FROM broker_credentials
+             WHERE operator_id = %(op)s
+               AND provider    = %(prov)s
+               AND revoked_at IS NULL
+        ),
+        label_join AS (
+            SELECT r.label, obs.health_state
+              FROM required r
+              LEFT JOIN observed obs USING (label)
+        )
+        SELECT
+            bool_or(health_state IS NULL)        AS any_missing,
+            bool_or(health_state = 'rejected')   AS any_rejected,
+            bool_or(health_state = 'untested')   AS any_untested,
+            bool_and(health_state = 'valid')     AS all_valid
+        FROM label_join
+    """
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            sql_query,
+            {
+                "required_labels": list(required),
+                "op": operator_id,
+                "prov": provider,
+            },
+        )
+        row = cur.fetchone()
+
+    # Aggregate-only SELECT against a non-empty required CTE always
+    # returns one row. The dict_row factory pins the shape; tuple/scalar
+    # row_factory regressions are caught by tests in
+    # test_credential_health.py::test_aggregate_row_factory_pinned.
+    if row is None:
+        raise RuntimeError("get_operator_credential_health: aggregate query returned no row")
+
+    # Decision tree (REJECTED-first per locked precedence).
+    if row["any_rejected"]:
+        return CredentialHealth.REJECTED
+    if row["any_missing"]:
+        return CredentialHealth.MISSING
+    if row["any_untested"]:
+        return CredentialHealth.UNTESTED
+    if row["all_valid"]:
+        return CredentialHealth.VALID
+
+    raise RuntimeError(
+        f"get_operator_credential_health: unreachable — aggregate query produced no decision branch: {row!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Side-transactional write-through
+# ---------------------------------------------------------------------------
+
+
+def record_health_outcome(
+    *,
+    credential_id: UUID,
+    success: bool,
+    source: Literal["probe", "incidental"],
+    error_detail: str | None,
+    pool: ConnectionPool[psycopg.Connection[Any]],
+) -> None:
+    """Write the outcome of an auth-using call through to credential health.
+
+    Public entry point for auth-using paths (HTTP handlers, WS subscriber,
+    batch-job adapters). Translates the (success, source) pair into a
+    target row state and dispatches to ``record_row_health_transition``.
+
+    Behaviour matrix:
+        success=True,  source='probe'      -> row VALID (clears REJECTED)
+        success=True,  source='incidental' -> row VALID iff old=='untested'; never overwrites rejected
+        success=False, source=any          -> row REJECTED (sticky)
+
+    error_detail is recorded on the row regardless; the column is
+    overwritten on every call (best-effort surface for the most recent
+    failure message).
+    """
+    new_state: HealthState = "valid" if success else "rejected"
+    record_row_health_transition(
+        credential_id=credential_id,
+        new_state=new_state,
+        source=source,
+        error_detail=error_detail if not success else None,
+        pool=pool,
+    )
+
+
+def record_row_health_transition(
+    *,
+    credential_id: UUID,
+    new_state: HealthState,
+    source: Literal["probe", "incidental"],
+    error_detail: str | None,
+    pool: ConnectionPool[psycopg.Connection[Any]],
+) -> None:
+    """Update one row's health and pg_notify if operator aggregate moves.
+
+    Side-transaction contract:
+      * Acquires its own connection from the pool. Never takes a conn
+        argument — caller's transaction lifecycle is independent.
+      * UPDATE under FOR UPDATE row lock so concurrent transitions
+        serialize.
+      * REJECTED-sticky: ``new_state='valid'`` on a row whose
+        ``health_state='rejected'`` only proceeds when ``source='probe'``.
+        Incidental 2xx from any other auth path returns without modifying
+        the row.
+      * Always touches ``last_health_check_at`` and ``last_health_error``
+        (reflects "we checked"). These updates do NOT trigger NOTIFY
+        — only an aggregate-level transition does.
+      * On VALID transition that flips the operator aggregate from
+        REJECTED to VALID: UPSERT ``operator_credential_health_transitions``
+        with ``last_recovered_at = NOW()``. The AUTH_EXPIRED suppression
+        query (#977) filters job_runs failures with
+        ``failed_at < last_recovered_at``.
+      * Idempotent: if the operator-level aggregate before and after
+        the row update is identical, no NOTIFY fires.
+
+    Pool exhaustion (Codex r2.1): ``PoolTimeout`` from the pool's
+    acquisition is logged at ERROR with credential_id + intended
+    new_state and re-raised. Caller is responsible for catching and
+    deciding whether to fail the user-facing request — the spec says
+    auth bookkeeping is best-effort beyond this contract.
+    """
+    try:
+        with pool.connection() as conn:
+            with conn.transaction():
+                _do_health_transition(
+                    conn,
+                    credential_id=credential_id,
+                    new_state=new_state,
+                    source=source,
+                    error_detail=error_detail,
+                )
+    except PoolTimeout:
+        logger.error(
+            "credential_health write-through pool timeout: credential_id=%s new_state=%s source=%s — DROPPED",
+            credential_id,
+            new_state,
+            source,
+        )
+        raise
+
+
+def _do_health_transition(
+    conn: psycopg.Connection[Any],
+    *,
+    credential_id: UUID,
+    new_state: HealthState,
+    source: Literal["probe", "incidental"],
+    error_detail: str | None,
+) -> None:
+    """Inner implementation of the transition under a caller-supplied tx.
+
+    Split out so tests can drive it directly with a connection without
+    going through the pool path. Production callers go through
+    ``record_row_health_transition``, which provides the side-tx
+    + PoolTimeout semantics.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT id, operator_id, provider, health_state
+              FROM broker_credentials
+             WHERE id = %(id)s
+               AND revoked_at IS NULL
+             FOR UPDATE
+            """,
+            {"id": credential_id},
+        )
+        row = cur.fetchone()
+
+        if row is None:
+            # Row doesn't exist or is revoked. Not an error — a delete-
+            # then-write race or a stale credential_id from a long-
+            # running consumer is benign here. Log and bail.
+            logger.warning(
+                "credential_health: row %s not found (revoked or deleted); skipping write-through",
+                credential_id,
+            )
+            return
+
+        old_state: HealthState = row["health_state"]
+        operator_id: UUID = row["operator_id"]
+        provider: str = row["provider"]
+
+        # Decide whether this call mutates health_state.
+        will_change_health = _should_change_state(
+            old_state=old_state,
+            new_state=new_state,
+            source=source,
+        )
+
+        # Always reflect that we checked. last_health_check_at gives the
+        # admin UI "last checked Nm ago" without depending on a state
+        # transition. last_health_error always reflects the most recent
+        # failure detail (or NULL on success).
+        cur.execute(
+            """
+            UPDATE broker_credentials
+               SET last_health_check_at = NOW(),
+                   last_health_error = %(err)s
+             WHERE id = %(id)s
+            """,
+            {"id": credential_id, "err": error_detail},
+        )
+
+        if not will_change_health:
+            # No transition. last_health_check_at was bumped; no NOTIFY.
+            return
+
+        # Snapshot the operator aggregate BEFORE the row update.
+        # Reads against the same connection within the same tx so the
+        # FOR UPDATE row is visible.
+        old_aggregate = get_operator_credential_health(conn, operator_id=operator_id, provider=provider)
+
+        cur.execute(
+            """
+            UPDATE broker_credentials
+               SET health_state = %(new)s,
+                   health_state_updated_at = NOW()
+             WHERE id = %(id)s
+            """,
+            {"id": credential_id, "new": new_state},
+        )
+
+        # Recompute aggregate after the row update.
+        new_aggregate = get_operator_credential_health(conn, operator_id=operator_id, provider=provider)
+
+        # Record the recovery timestamp ONLY on REJECTED -> VALID at
+        # operator level. Other transitions (UNTESTED -> VALID,
+        # MISSING -> UNTESTED) don't write the transitions row — that
+        # row exists specifically to mark "operator has recovered from
+        # an explicit rejection" so AUTH_EXPIRED suppression has a
+        # boundary. Codex r2.4 + spec.
+        if old_aggregate == CredentialHealth.REJECTED and new_aggregate == CredentialHealth.VALID:
+            cur.execute(
+                """
+                INSERT INTO operator_credential_health_transitions
+                    (operator_id, last_recovered_at)
+                VALUES (%(op)s, NOW())
+                ON CONFLICT (operator_id) DO UPDATE
+                    SET last_recovered_at = EXCLUDED.last_recovered_at
+                """,
+                {"op": operator_id},
+            )
+
+        # Idempotent: if the aggregate didn't move, no NOTIFY. A row-
+        # level transition that doesn't move the aggregate (e.g.
+        # one of two REJECTED rows clears, but the other is still
+        # REJECTED) leaves subscribers alone — the operator's situation
+        # hasn't changed from their perspective.
+        if old_aggregate == new_aggregate:
+            return
+
+        payload = json.dumps(
+            {
+                "operator_id": str(operator_id),
+                "provider": provider,
+                "old_aggregate": old_aggregate.value,
+                "new_aggregate": new_aggregate.value,
+                "at": datetime.now(UTC).isoformat(),
+            }
+        )
+        # pg_notify inside the same tx; Postgres delivers on commit.
+        # Committing first means the notify carries the durably-stored
+        # state — a subscriber that re-reads will see the post-update row.
+        cur.execute(
+            "SELECT pg_notify(%(channel)s, %(payload)s)",
+            {"channel": NOTIFY_CHANNEL, "payload": payload},
+        )
+
+
+def _should_change_state(
+    *,
+    old_state: HealthState,
+    new_state: HealthState,
+    source: Literal["probe", "incidental"],
+) -> bool:
+    """Apply REJECTED-stickiness + same-state idempotence rules.
+
+    Returns True iff the row's health_state should be updated.
+
+    Truth table:
+        old=untested,  new=valid,    *           -> True
+        old=untested,  new=rejected, *           -> True
+        old=valid,     new=valid,    *           -> False (idempotent)
+        old=valid,     new=rejected, *           -> True
+        old=rejected,  new=valid,    probe       -> True
+        old=rejected,  new=valid,    incidental  -> False (sticky)
+        old=rejected,  new=rejected, *           -> False (idempotent)
+    """
+    if old_state == new_state:
+        return False
+    if old_state == "rejected" and new_state == "valid":
+        return source == "probe"
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Recovery-timestamp lookup (used by AUTH_EXPIRED suppression query in #977)
+# ---------------------------------------------------------------------------
+
+
+def get_last_recovered_at(
+    conn: psycopg.Connection[Any],
+    *,
+    operator_id: UUID,
+) -> datetime | None:
+    """Return the operator's most recent REJECTED -> VALID timestamp, or None.
+
+    Missing row OR ``last_recovered_at IS NULL`` -> None. Callers must
+    treat None as "no filter applied" — i.e. all AUTH_EXPIRED rows
+    remain operator-visible.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT last_recovered_at
+              FROM operator_credential_health_transitions
+             WHERE operator_id = %(op)s
+            """,
+            {"op": operator_id},
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return row["last_recovered_at"]

--- a/app/services/credential_health.py
+++ b/app/services/credential_health.py
@@ -320,20 +320,26 @@ def _do_health_transition(
 
         # Always reflect that we checked. last_health_check_at gives the
         # admin UI "last checked Nm ago" without depending on a state
-        # transition. last_health_error always reflects the most recent
-        # failure detail (or NULL on success).
+        # transition. last_health_error is intentionally NOT touched
+        # here — clearing it on a sticky-skip would silently wipe an
+        # operator-visible error string for a row whose health didn't
+        # actually change (review feedback PR #981 round 1 WARNING).
+        # The error column is rewritten below only when we commit a
+        # real state transition.
         cur.execute(
             """
             UPDATE broker_credentials
-               SET last_health_check_at = NOW(),
-                   last_health_error = %(err)s
+               SET last_health_check_at = NOW()
              WHERE id = %(id)s
             """,
-            {"id": credential_id, "err": error_detail},
+            {"id": credential_id},
         )
 
         if not will_change_health:
             # No transition. last_health_check_at was bumped; no NOTIFY.
+            # last_health_error preserved (may still describe the
+            # rejection that we couldn't clear via this incidental
+            # success).
             return
 
         # Snapshot the operator aggregate BEFORE the row update.
@@ -351,10 +357,11 @@ def _do_health_transition(
             """
             UPDATE broker_credentials
                SET health_state = %(new)s,
-                   health_state_updated_at = NOW()
+                   health_state_updated_at = NOW(),
+                   last_health_error = %(err)s
              WHERE id = %(id)s
             """,
-            {"id": credential_id, "new": new_state},
+            {"id": credential_id, "new": new_state, "err": error_detail},
         )
 
         # Recompute aggregate after the row update.

--- a/app/services/credential_health.py
+++ b/app/services/credential_health.py
@@ -89,11 +89,20 @@ def get_operator_credential_health(
     *,
     operator_id: UUID,
     provider: str = "etoro",
+    environment: str = "demo",
 ) -> CredentialHealth:
     """Compute the operator's aggregate credential health.
 
     Joins a synthetic required-labels CTE against ``broker_credentials``
     and returns the worst-of state per the locked precedence above.
+
+    Scoped to a single (provider, environment) pair (Codex pre-push r1.2).
+    Active uniqueness on broker_credentials is
+    ``(operator_id, provider, label, environment)``, so demo and real rows
+    are independent. Without the environment filter, a demo api_key VALID
+    + real user_key VALID would falsely report VALID for either env. v1
+    only uses ``demo`` but the parameter is plumbed so the same helper
+    works when ``real`` arrives.
 
     Returns:
         CredentialHealth — REJECTED / MISSING / UNTESTED / VALID.
@@ -115,6 +124,7 @@ def get_operator_credential_health(
               FROM broker_credentials
              WHERE operator_id = %(op)s
                AND provider    = %(prov)s
+               AND environment = %(env)s
                AND revoked_at IS NULL
         ),
         label_join AS (
@@ -137,6 +147,7 @@ def get_operator_credential_health(
                 "required_labels": list(required),
                 "op": operator_id,
                 "prov": provider,
+                "env": environment,
             },
         )
         row = cur.fetchone()
@@ -275,7 +286,7 @@ def _do_health_transition(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT id, operator_id, provider, health_state
+            SELECT id, operator_id, provider, environment, health_state
               FROM broker_credentials
              WHERE id = %(id)s
                AND revoked_at IS NULL
@@ -298,6 +309,7 @@ def _do_health_transition(
         old_state: HealthState = row["health_state"]
         operator_id: UUID = row["operator_id"]
         provider: str = row["provider"]
+        environment: str = row["environment"]
 
         # Decide whether this call mutates health_state.
         will_change_health = _should_change_state(
@@ -326,8 +338,14 @@ def _do_health_transition(
 
         # Snapshot the operator aggregate BEFORE the row update.
         # Reads against the same connection within the same tx so the
-        # FOR UPDATE row is visible.
-        old_aggregate = get_operator_credential_health(conn, operator_id=operator_id, provider=provider)
+        # FOR UPDATE row is visible. Environment-scoped per Codex
+        # pre-push r1.2.
+        old_aggregate = get_operator_credential_health(
+            conn,
+            operator_id=operator_id,
+            provider=provider,
+            environment=environment,
+        )
 
         cur.execute(
             """
@@ -340,7 +358,12 @@ def _do_health_transition(
         )
 
         # Recompute aggregate after the row update.
-        new_aggregate = get_operator_credential_health(conn, operator_id=operator_id, provider=provider)
+        new_aggregate = get_operator_credential_health(
+            conn,
+            operator_id=operator_id,
+            provider=provider,
+            environment=environment,
+        )
 
         # Record the recovery timestamp ONLY on REJECTED -> VALID at
         # operator level. Other transitions (UNTESTED -> VALID,
@@ -415,6 +438,57 @@ def _should_change_state(
 # ---------------------------------------------------------------------------
 # Recovery-timestamp lookup (used by AUTH_EXPIRED suppression query in #977)
 # ---------------------------------------------------------------------------
+
+
+def notify_aggregate_if_changed(
+    conn: psycopg.Connection[Any],
+    *,
+    operator_id: UUID,
+    provider: str,
+    environment: str,
+    old_aggregate: CredentialHealth,
+) -> None:
+    """Emit pg_notify if the operator aggregate has moved since old_aggregate.
+
+    For callers that mutate broker_credentials rows directly (e.g. PUT
+    /broker-credentials/replace) and need to wake subscribers without
+    going through ``record_row_health_transition``. PUT /replace
+    revokes a possibly-VALID row and inserts an UNTESTED replacement;
+    the aggregate may move VALID → UNTESTED, and subscribers must
+    observe that transition or they'll keep treating creds as valid
+    (Codex pre-push r1.3).
+
+    Caller is expected to have:
+      1. Snapshotted ``old_aggregate`` before any row mutations.
+      2. Performed the mutations on ``conn`` inside a transaction.
+      3. Called this helper inside the same transaction. The pg_notify
+         fires when that transaction commits.
+
+    Idempotent: if the aggregate hasn't moved, no NOTIFY fires.
+    """
+    new_aggregate = get_operator_credential_health(
+        conn,
+        operator_id=operator_id,
+        provider=provider,
+        environment=environment,
+    )
+    if old_aggregate == new_aggregate:
+        return
+
+    payload = json.dumps(
+        {
+            "operator_id": str(operator_id),
+            "provider": provider,
+            "old_aggregate": old_aggregate.value,
+            "new_aggregate": new_aggregate.value,
+            "at": datetime.now(UTC).isoformat(),
+        }
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT pg_notify(%(channel)s, %(payload)s)",
+            {"channel": NOTIFY_CHANNEL, "payload": payload},
+        )
 
 
 def get_last_recovered_at(

--- a/docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md
+++ b/docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md
@@ -1,0 +1,602 @@
+# Credential health as scheduling pre-condition
+
+**Issue:** [#974](https://github.com/Luke-Bradford/eBull/issues/974)
+**Phase:** Standalone — sits across orchestrator, WS subscriber, broker_credentials API, admin frontend
+**Date:** 2026-05-06
+**Author:** Luke + Claude (round 3 design, post-Codex r1 + r2)
+**Codex r1:** `.claude/codex-974-r1-review.txt` — 10 high + 5 medium findings, all addressed.
+**Codex r2:** `.claude/codex-974-r2-review.txt` — 3 high + 7 medium + 1 low residual findings, all addressed in this v3.
+
+## Why
+
+When broker credentials are not validated, the system today:
+
+1. Keeps running every credential-using batch job on schedule. Each run 401s.
+2. Lets dependent layers cascade-fail (`portfolio_sync` writing to `positions` FK-violates against an empty `instruments` table — surfaced as "Database constraint violated" in the admin Problems panel).
+3. Caches creds at process start in [`app/services/etoro_websocket.py:419`](../../../app/services/etoro_websocket.py#L419) and reconnects every 5s with the **stale in-memory copy** even after the operator updates the keys via Settings. Fixed 5s backoff = constant log spam.
+4. Forces the operator to manually click **Sync now** on the admin page after correcting keys to clear the failure state.
+
+**Principle (operator quote, 2026-05-06):**
+> we shouldnt be trying to poll anything if the keys aren't right, should be flagged out of the gate, holding any schedules off
+
+The operator should never have to manually intervene after fixing the very thing the system told them to fix. Credential health must be a scheduling pre-condition.
+
+## Schema reality check (Codex r1.1)
+
+`broker_credentials` has **one row per `(operator_id, provider, label, environment)`**. eToro requires `label='api_key'` AND `label='user_key'` as **two separate rows**. There is no "credential pair" entity — the pair is implicit.
+
+Every health concept in this spec must therefore distinguish:
+- **Row-level health** — stored on the individual `broker_credentials` row (UNTESTED / VALID / REJECTED).
+- **Operator-level health** — derived aggregate that consumers (orchestrator, WS subscriber, admin UI) actually care about.
+
+Consumers operate on operator-level health only. Row-level health is implementation detail.
+
+## Locked design decisions (revised)
+
+| Decision | Rationale |
+|---|---|
+| Row-level health column on `broker_credentials`; operator-level computed | Schema reality: row per label. Avoids inventing a synthetic "pair" entity. |
+| **REJECTED is sticky** at row level — only `validate-stored` probe success can promote REJECTED → VALID | Codex r1.3 + r3.1: avoids flap from incidental 2xx responses on partial-permission endpoints. The validation probe is the *canonical* signal. |
+| Incidental 401/403 from any auth-using path → row REJECTED (sticky). Incidental 2xx → row VALID **only if** old state is `untested`; never overwrites `rejected`. | Codex r1.4 + r3.1: 2xx from a non-probe endpoint is suggestive (auth worked once) but not authoritative; allow it to settle the initial UNTESTED state, but never to clear an explicit REJECTED. |
+| Health write-through uses a **dedicated side transaction** committed by the helper, not the caller's tx | Codex r1.5: a caller's rollback must never lose a health write. Helper opens its own connection from the pool, commits, releases. |
+| **Operator-level aggregate precedence**: REJECTED > MISSING > UNTESTED > VALID. | Codex r1.2 + r3.2. REJECTED dominates MISSING because if the operator has saved at least one rejected key, they have a concrete "fix your key" to do; reporting MISSING for the other label would mask that. The message "Update the API key in Settings → Providers" applies and naturally surfaces both issues. |
+| **NOTIFY payload carries `operator_id`**, not credential_id alone | Codex r1.13: consumers care about operator-level state; row-level credential_id is implementation noise. |
+| **Subscribers MUST do a full DB scan on startup** to populate state, before subscribing to NOTIFY. NOTIFY is a wake-up, not the source of truth. | Codex r1.10/11: there is no durable event table for health (unlike `pending_job_requests`). Subscribers cannot recover dropped notifies from a queue. |
+| Atomic credential replacement via new `PUT /broker-credentials/replace` endpoint | Codex r1.6: revoke-then-create is non-atomic; pre-flight sees transient MISSING. The replace endpoint does both in one tx. |
+| `requires_broker_credential: bool` on `DataLayer` | Codex r1.14: the existing `secret_refs` field is env-secret only, not DB credentials. New flag, no overlap. |
+| `requires_layer_initialized: tuple[str, ...]` on `DataLayer` | Codex r1.7 + r2.5 + r3.3 + portfolio_sync FK fix: stricter than `dependencies` (which is per-tick). Means "the named dep's data table is content-initialized per its `INIT_CHECKS` predicate". Content-driven, not job_runs-driven. `portfolio_sync` gets `("universe",)` — fixes the FK cascade in scope, not as sibling. |
+| Postgres LISTEN/NOTIFY (not Redis pub-sub, not in-process) | Settled-decisions: Postgres-first; no Redis pub-sub for control plane. Cross-process: API + jobs process + WS subscriber may run separately. The `ebull_job_request` channel at [`app/api/sync.py:202`](../../../app/api/sync.py#L202) is the precedent **for wake-ups only**, not durable delivery. |
+
+## Schema
+
+`sql/128_broker_credentials_health_state.sql`:
+
+```sql
+ALTER TABLE broker_credentials
+  ADD COLUMN health_state TEXT NOT NULL DEFAULT 'untested'
+    CHECK (health_state IN ('untested', 'valid', 'rejected')),
+  ADD COLUMN health_state_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ADD COLUMN last_health_check_at TIMESTAMPTZ,
+  ADD COLUMN last_health_error TEXT;
+
+-- Index for the operator-level aggregate computation. Filters out
+-- revoked rows since they don't participate in health computation.
+CREATE INDEX idx_broker_credentials_operator_health
+  ON broker_credentials (operator_id, label, health_state)
+  WHERE revoked_at IS NULL;
+
+-- Tracks the most recent REJECTED -> VALID transition timestamp per
+-- operator. Used by query-time filter for AUTH_EXPIRED failure
+-- suppression (Codex r1.7 + r1.8). NULL means no transition yet.
+CREATE TABLE operator_credential_health_transitions (
+    operator_id              UUID NOT NULL,
+    last_recovered_at        TIMESTAMPTZ,
+    PRIMARY KEY (operator_id)
+);
+```
+
+The fourth conceptual state — `MISSING` — is **derived** from absence of either label row for the operator. Not stored at row level.
+
+`operator_credential_health_transitions` exists because we need a single timestamp per operator to query against when filtering AUTH_EXPIRED failure-history rows from operator-visible displays. Updated atomically inside the same side-tx that flips any of the operator's rows from REJECTED → VALID.
+
+## Service layer
+
+New file `app/services/credential_health.py`:
+
+```python
+class CredentialHealth(StrEnum):
+    UNTESTED = "untested"
+    VALID = "valid"
+    REJECTED = "rejected"
+    MISSING = "missing"  # derived, never stored at row level
+
+
+REQUIRED_LABELS_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "etoro": ("api_key", "user_key"),
+}
+
+
+def get_operator_credential_health(
+    conn: psycopg.Connection[Any],
+    *,
+    operator_id: UUID,
+    provider: str = "etoro",
+) -> CredentialHealth:
+    """Compute the operator's aggregate credential health.
+
+    Aggregation rule (worst-of):
+      MISSING   any required label has no non-revoked row
+      REJECTED  any non-revoked row for required labels has health_state='rejected'
+      UNTESTED  all required labels present, but >=1 row is 'untested'
+      VALID     all required labels present and all rows are 'valid'
+
+    Required labels per provider come from REQUIRED_LABELS_BY_PROVIDER.
+
+    Implementation (Codex r2.2 — exact SQL contract, dict_row factory):
+
+      WITH required(label) AS (
+        VALUES ('api_key'), ('user_key')
+      ),
+      observed AS (
+        SELECT label, health_state
+          FROM broker_credentials
+         WHERE operator_id = %(op)s
+           AND provider    = %(prov)s
+           AND revoked_at IS NULL
+      ),
+      label_join AS (
+        SELECT r.label,
+               obs.health_state
+          FROM required r
+          LEFT JOIN observed obs USING (label)
+      )
+      SELECT
+        bool_or(health_state IS NULL)            AS any_missing,
+        bool_or(health_state = 'rejected')       AS any_rejected,
+        bool_or(health_state = 'untested')       AS any_untested,
+        bool_and(health_state = 'valid')         AS all_valid
+      FROM label_join;
+
+    Result is a single dict_row. Decision tree (in order, REJECTED-first
+    per locked precedence in the table above):
+      1. any_rejected -> REJECTED
+      2. any_missing  -> MISSING
+      3. any_untested -> UNTESTED
+      4. all_valid    -> VALID
+      5. otherwise (logical impossibility, e.g. all rows NULL after the
+         required CROSS JOIN) raise RuntimeError; do not silently default.
+
+    Tests pin tuple/dict/scalar row-factory shape so a future
+    row_factory change cannot accidentally treat partial coverage as
+    VALID (Codex r2.2).
+    """
+
+
+def record_row_health_transition(
+    *,
+    credential_id: UUID,
+    new_state: Literal["valid", "rejected"],
+    source: Literal["probe", "incidental"],
+    error_detail: str | None,
+    pool: psycopg.ConnectionPool,
+) -> None:
+    """Update a single row's health and pg_notify the operator-scoped channel.
+
+    Side-transaction contract (Codex r1.5 + r2.1):
+      - Acquires its OWN connection from the pool. Does NOT take a conn arg.
+      - UPDATE the row in this side tx.
+      - REJECTED is sticky: if old_state == 'rejected' and new_state ==
+        'valid', the UPDATE only proceeds when called from the explicit
+        validation-probe path (parameter source='probe' below).
+        Incidental 2xx (source='incidental') only writes valid when
+        old_state in ('untested',) — never overwrites rejected.
+      - On VALID transition: also UPSERT operator_credential_health_transitions
+        with last_recovered_at=NOW() so AUTH_EXPIRED suppression has a
+        timestamp to filter against.
+      - COMMIT the side tx.
+      - pg_notify('ebull_credential_health', payload) AFTER commit
+        (Postgres delivers notifies on commit anyway, but committing
+        first means the notify carries the durably-stored state).
+      - Idempotent: same-state transitions skip the NOTIFY.
+
+    Pool-exhaustion semantics (Codex r2.1):
+      - If the pool acquire times out (PoolTimeout): RAISE — do NOT
+        swallow. Caller is responsible for catching and deciding whether
+        the auth-using operation should fail or proceed without a
+        health update. We log at ERROR with credential_id + intended
+        new_state so the dropped write is greppable.
+      - We expose a metric counter `credential_health_write_failed`
+        (label: reason=pool_timeout|db_error|integrity_violation) so
+        a sustained pool-pressure regression is visible.
+      - Callers in the auth-using request path catch PoolTimeout and
+        log a single warning per request, but do NOT fail the user-
+        facing call on health-write failure (auth itself succeeded or
+        failed independently). Auth outcome bookkeeping is best-effort
+        beyond the side-tx contract — but the surrounding NOTIFY/health
+        pipeline IS guaranteed once the row write commits.
+
+    Payload shape:
+      {
+        "operator_id": "<uuid>",
+        "provider": "etoro",
+        "old_aggregate": "rejected",
+        "new_aggregate": "valid",
+        "at": "2026-05-06T20:25:00Z"
+      }
+
+    Note: payload carries OPERATOR-LEVEL aggregate, not the row state
+    that triggered the transition. The helper recomputes the operator
+    aggregate after the row update and emits the notify only if the
+    aggregate actually moved (idempotent).
+    """
+
+
+def record_health_outcome(
+    *,
+    credential_id: UUID,
+    success: bool,
+    source: Literal["probe", "incidental"],
+    error_detail: str | None,
+    pool: psycopg.ConnectionPool,
+) -> None:
+    """Public write-through helper for auth-using paths.
+
+    success=True, source='probe'      -> row VALID (clears REJECTED)
+    success=True, source='incidental' -> row VALID iff old in ('untested',); ignored if 'rejected'
+    success=False (any source)        -> row REJECTED (sticky)
+    """
+```
+
+**REJECTED-stickiness invariant** (Codex r1.3):
+
+```
+For any row with health_state='rejected':
+  -> The ONLY paths that may flip it to 'valid' are:
+     1. POST /broker-credentials/validate-stored returning 200 (source='probe')
+     2. PUT /broker-credentials/replace creating a fresh row (replaces the
+        rejected row entirely; the new row starts at 'untested')
+
+  -> Incidental 2xx responses from any other auth-using path do NOT
+     flip rejected to valid.
+```
+
+This is enforced inside `record_row_health_transition` by the `source` parameter check.
+
+## NOTIFY contract
+
+Channel: `ebull_credential_health`. Wake-up only. Payload carries operator-level aggregate.
+
+**Subscribers MUST**:
+1. On startup: full-table scan of `broker_credentials` (filtered to non-revoked) joined to compute operator aggregate per operator. Populate in-memory cache.
+2. THEN subscribe to NOTIFY.
+3. On NOTIFY arrival: re-read DB truth for that operator (don't trust payload alone). Update cache.
+4. On 5s poll fallback: re-read DB truth for any operator whose cache is older than the threshold OR for the full table if the listener thread has been disconnected.
+
+This is more conservative than the `ebull_job_request` pattern because there is no durable event table to recover from (Codex r1.10).
+
+**Startup retry contract (Codex r2.8):** the listener thread runs the initial full-scan with retry-with-backoff (1s, 2s, 5s, 10s, 30s cap) until success. While the initial scan has not completed, the cache is in `INITIALIZING` state and consumers (orchestrator pre-flight, WS subscriber) treat it as `MISSING` for safety — no credential-using layers run, WS stays disconnected. This avoids any false-VALID window during a slow DB warm-up.
+
+The `INITIALIZING` state is exposed on `GET /system/status` so the admin UI can show a transient "Initializing credential health…" banner instead of a confusing "MISSING" during a clean restart.
+
+## Orchestrator pre-flight gate
+
+`DataLayer` registry at [`app/services/sync_orchestrator/registry.py:84`](../../../app/services/sync_orchestrator/registry.py#L84) gets two new fields:
+
+```python
+@dataclass(frozen=True)
+class DataLayer:
+    ...
+    requires_broker_credential: bool = False
+    # Layers whose data table must be content-initialized (i.e. has at
+    # least one usable row per the layer's INIT_CHECKS predicate)
+    # before this layer is eligible. Stricter than `dependencies`
+    # which only requires the dep to have completed in the current
+    # run. Used to break the FK-violation cascade where portfolio_sync
+    # writes to `positions` referencing `instruments` that universe
+    # has not yet populated. (Codex r1.7 / r2.5 / r3.3)
+    requires_layer_initialized: tuple[str, ...] = ()
+```
+
+Layers tagged `requires_broker_credential=True`: `universe`, `portfolio_sync`, `candles`, `fundamentals`, `fx_rates`, `cost_models`. (Verified by reading each refresh function during implementation; PR description records the audit.)
+
+`portfolio_sync` additionally gets `requires_layer_initialized=("universe",)` — fixes the FK cascade explicitly. (Codex r2.5/r2.6.)
+
+**The init-check is content-driven, not job_runs-driven.** Each layer name in `requires_layer_initialized` is mapped to a content predicate that asserts the layer's data table is non-empty. This is more reliable than chasing `job_runs.status` semantics across cleanup/archival:
+
+```python
+INIT_CHECKS: dict[str, str] = {
+    "universe":     "SELECT EXISTS (SELECT 1 FROM instruments WHERE is_tradable = true)",
+    "candles":      "SELECT EXISTS (SELECT 1 FROM quotes)",
+    "fundamentals": "SELECT EXISTS (SELECT 1 FROM financial_facts_raw)",
+    # ...one per layer that any other layer depends on at init time.
+}
+```
+
+The init check answers "has this dep produced ANY rows the dependent layer needs". For `portfolio_sync` waiting on `universe`, that means `instruments` table is non-empty AND has at least one tradable row. This is stricter than "any row" because a partial-failure universe sync could leave only delisted rows — those don't unblock portfolio_sync writes.
+
+The existing index `idx_instruments_is_tradable` (verify during implementation; if absent, add one) supports the EXISTS short-circuit.
+
+Executor change at [`app/services/sync_orchestrator/executor.py`](../../../app/services/sync_orchestrator/executor.py): the existing `_blocking_dependency_failed` check at line 286 gets two sibling checks running BEFORE it:
+1. `_credential_health_blocks(layer)` — returns `PREREQ_SKIP` if `requires_broker_credential` and operator health ≠ VALID.
+2. `_layer_initialization_blocks(layer)` — returns `PREREQ_SKIP` if any name in `requires_layer_initialized` fails its `INIT_CHECKS` predicate.
+
+Cascade-skip via the existing `_blocking_dependency_failed` mechanism handles dependent layers.
+
+## AUTH_EXPIRED failure-row suppression (revised)
+
+Codex r1.7/r1.8 caught that mutating `consecutive_failures` rows is wrong. Replaced with a **query-time filter**:
+
+When the orchestrator computes operator-visible problem rows, AUTH_EXPIRED failures with `failed_at < operator_credential_health_transitions.last_recovered_at` are excluded from the streak count.
+
+**Implementation surface (Codex r2.9):** the suppression must apply to BOTH the single-layer helper at [`layer_failure_history.py:43`](../../../app/services/sync_orchestrator/layer_failure_history.py#L43) AND the batched helper `all_layer_histories` invoked at [`app/api/sync.py:283,362`](../../../app/api/sync.py#L283) — that's the path operator-visible v2 takes. Both signatures gain `suppress_auth_expired_before: datetime | None = None`. The `/system/status` and `/sync/layers` API handlers populate it from `operator_credential_health_transitions.last_recovered_at` for the calling operator.
+
+**Initial-row + NULL semantics (Codex r2.4):**
+- `operator_credential_health_transitions` has NO row written until the first REJECTED → VALID transition occurs for that operator. Missing-row case = no recovery has ever happened.
+- When the suppression API resolves `suppress_auth_expired_before`:
+  - Missing row OR `last_recovered_at IS NULL` → pass `None` to the helper → no filter applied (all AUTH_EXPIRED rows visible).
+  - Row exists with non-null timestamp → pass that timestamp → filter applied.
+- Tests pin both branches: missing-row, NULL-row, and recent-row.
+
+This means:
+- AUTH_EXPIRED failures from the rejected window stay in `job_runs` (audit history is immutable).
+- They no longer count toward operator-visible "consecutive failures" once the operator has saved valid creds.
+- New failures (RATE_LIMITED, SOURCE_DOWN, etc.) after the recovery timestamp are visible normally.
+
+## WS subscriber reload (revised, Codex r1.11)
+
+[`app/services/etoro_websocket.py:411`](../../../app/services/etoro_websocket.py#L411) currently takes `api_key`/`user_key` as construction args. Refactor to take `operator_id` and pull credentials from DB.
+
+**Callsite enumeration (Codex r2.10):** the only production constructor is at [`app/main.py:298`](../../../app/main.py#L298) (FastAPI lifespan). Tests construct via fixtures in `tests/test_etoro_websocket.py`. The refactor:
+1. Removes the `api_key` / `user_key` parameters entirely from `__init__`.
+2. Adds `operator_id: UUID` and `pool: psycopg.ConnectionPool`.
+3. Updates the lifespan call site to pass operator_id (loaded from session bootstrap during startup) + the existing pool.
+4. Updates all test constructors to pass operator_id + a test-pool fixture.
+
+PR #974/D acceptance includes: grep `EtoroWebSocketSubscriber\(` returns zero matches with `api_key=` or `user_key=` after the change. Enforced as part of `uv run ruff check .`-grade discipline; not a separate lint rule.
+
+```python
+class EtoroWebSocketSubscriber:
+    def __init__(
+        self,
+        *,
+        operator_id: UUID,
+        pool: psycopg.ConnectionPool,
+        ...
+    ) -> None:
+        self._operator_id = operator_id
+        self._pool = pool
+        self._api_key: str | None = None
+        self._user_key: str | None = None
+        self._consecutive_auth_failures: int = 0
+
+    def _reload_credentials(self) -> bool:
+        """Re-read credentials from DB. Returns True iff both labels
+        present and operator health = VALID."""
+
+    async def _run(self) -> None:
+        """Background loop:
+          1. On startup + every 5s poll fallback: re-read DB.
+          2. Subscribe to ebull_credential_health NOTIFY.
+          3. On VALID notify or DB-confirmed VALID: connect/reconnect.
+          4. On REJECTED: drop connection; stay disconnected until VALID.
+          5. Auth-failure backoff: 5s, 30s, 2min, 10min, 10min cap.
+             Reset to 5s on first successful auth.
+          6. On every auth reply: write through via record_health_outcome
+             (source='incidental' for 2xx, always for 4xx).
+        """
+```
+
+Backoff sequence: **(5, 30, 120, 600, 600)** — capped at 600s after the 4th consecutive auth failure. Locked here, asserted by tests in #974/D. Reset to 5s on the first successful auth.
+
+**Prolonged REJECTED behavior (Codex r2.11):** at the 600s cap, an operator who never fixes their keys would still see ~144 reconnect attempts per day. That's wasteful and unfriendly to eToro. New rule:
+
+- After health = REJECTED is observed (via NOTIFY or the WS's own write-through of a 401), the WS subscriber **stops auto-reconnecting entirely**. Backoff is irrelevant in this state.
+- The only path back to reconnecting is a NOTIFY of `new_aggregate=valid` from the credential-health channel.
+- The 5s health-cache poll fallback continues — that's how the WS detects a missed VALID notify.
+- Acceptance test: simulate REJECTED for 1 hour (mocked clock); assert zero reconnect attempts; then simulate a VALID notify; assert reconnect within one cache poll cycle (5s).
+
+This means the backoff sequence (5,30,120,600,600) only applies during transient auth failures (server-side hiccup, eToro rotation lag) where health hasn't yet flipped to REJECTED. The instant health flips REJECTED, the WS goes quiet.
+
+## Atomic credential replacement (Codex r1.6)
+
+New endpoint `PUT /broker-credentials/replace` in [`app/api/broker_credentials.py`](../../../app/api/broker_credentials.py):
+
+```
+PUT /broker-credentials/replace
+Body:
+  { "provider": "etoro",
+    "label": "api_key",
+    "environment": "demo",
+    "secret": "<new-plaintext>" }
+
+Behavior:
+  In ONE transaction:
+    1. SET revoked_at = NOW() WHERE operator_id, provider, label, environment
+       AND revoked_at IS NULL.
+    2. INSERT a new row with the new ciphertext, health_state='untested'.
+    3. Recompute operator aggregate.
+    4. NOTIFY (in side tx after commit, per the contract above).
+```
+
+The wizard + Settings page switch from "delete + create" to a single PUT call. Pre-flight gate never sees a transient MISSING.
+
+The existing `POST /broker-credentials` stays for the genuine first-create case (no existing row). The frontend chooses which based on whether a row of that label already exists.
+
+**Identical-secret semantics (Codex r2.3):** when `PUT /replace` is called with a new secret whose ciphertext (after AAD-bound AESGCM) decrypts to the same plaintext as the active row's, **no row update happens** and **no notify fires**. Implementation: decrypt the active row inside the transaction, compare plaintext, short-circuit on match. Returns 200 with body `{"changed": false}`. Avoids spurious VALID → UNTESTED → VALID flap from a re-save. Tests pin both branches (changed=true and changed=false).
+
+**DELETE+POST deprecation (Codex r2.7):** the existing `DELETE /broker-credentials/{id}` followed by `POST /broker-credentials` flow remains in the codebase but is **deprecated for active eToro labels**. The new policy:
+
+1. `DELETE /broker-credentials/{id}` returns `409 Conflict` with body `{"error": "use_replace_endpoint", "message": "Active broker credentials must be updated via PUT /broker-credentials/replace; DELETE is reserved for permanent revocation"}` when:
+   - The credential being deleted has `provider='etoro'` AND `revoked_at IS NULL`.
+   - There is no concurrent `PUT /broker-credentials/replace` with the same `(operator, provider, label)` already in flight (best-effort detection: a new row with `created_at` within the last 5 seconds and matching label).
+2. Operators can still permanently revoke via the Settings UI, which calls a separate `DELETE` with explicit `revoke=true` confirmation; that path proceeds and emits a MISSING transition.
+3. Old clients still calling DELETE+POST will see the 409, fail loudly, and prompt the operator to refresh. This is preferable to silent transient MISSING. The frontend bumps a `client_version` header so the server can log when an outdated client tries the old flow.
+
+## Frontend integration
+
+`/system/status` API extends with operator credential health:
+
+```typescript
+interface SystemStatusResponse {
+  ...
+  credential_health: {
+    state: "missing" | "untested" | "valid" | "rejected";
+    last_validated_at: string | null;
+    last_recovered_at: string | null;
+    last_error: string | null;
+  };
+}
+```
+
+Admin Problems panel at [`frontend/src/components/admin/ProblemsPanel.tsx`](../../../frontend/src/components/admin/ProblemsPanel.tsx):
+- If `credential_health.state === 'rejected'`: render single high-severity row "Credentials rejected by provider — update the API key in [Settings → Providers]". Other items tagged `error_category === 'AUTH_EXPIRED'` are folded under that row (collapsed, expandable).
+- If `valid`/`untested`/`missing`: render the panel as today, but `AUTH_EXPIRED` rows from before `last_recovered_at` are filtered out server-side (handled by the suppression query above).
+
+Setup wizard's broker step (and Settings cred form, both pre-#971) call the new `PUT /broker-credentials/replace` instead of DELETE + POST when an existing row is present. Validation always uses `POST /broker-credentials/validate-stored` after save (the canonical probe path that promotes REJECTED → VALID).
+
+## Test plan
+
+### Unit tests
+
+`tests/test_credential_health.py`:
+- `get_operator_credential_health` returns each of MISSING/UNTESTED/VALID/REJECTED for the right row mixes — including missing-label cases (api_key valid, user_key absent → MISSING).
+- `record_row_health_transition` REJECTED sticky: source='incidental' success on a rejected row leaves it rejected.
+- `record_row_health_transition` REJECTED clears: source='probe' success on a rejected row promotes to valid.
+- Side-tx commit: helper commits even if a separate caller-supplied tx rolls back (simulated via concurrent calls).
+- Idempotent: same-state transition does not NOTIFY.
+
+`tests/test_credential_health_listener.py`:
+- Notify arrives at subscriber within 1s.
+- 5s poll fallback recovers from dropped notify.
+- Startup full-scan populates cache for operators not in any in-flight notify.
+
+`tests/test_sync_orchestrator_credential_gate.py`:
+- `requires_broker_credential=True` layer PREREQ_SKIPs when health=REJECTED.
+- `requires_broker_credential=False` layer runs normally.
+- Cascade: dependent layer skips via existing mechanism.
+- `requires_layer_initialized=("universe",)`: portfolio_sync skips until universe has historical success.
+- AUTH_EXPIRED suppression: failures from the rejected window are excluded from operator-visible streak counts after a VALID transition; new RATE_LIMITED failures still surface.
+
+`tests/test_etoro_websocket.py` extension:
+- WS reload picks up new keys without process restart (notify-driven).
+- Backoff sequence asserted: (5, 30, 120, 600, 600).
+- Counter resets to 0 on successful auth.
+- Auth-failure write-through emits the right `record_health_outcome` calls.
+
+### Integration tests
+
+`tests/test_credential_health_e2e.py` (real Postgres):
+- Save creds → both labels UNTESTED → operator UNTESTED.
+- Validate-stored success → both labels VALID → operator VALID; subscribers see notify.
+- 401 from any auth-using path → row REJECTED (sticky); operator REJECTED; orchestrator pauses dependent layers; WS subscriber drops connection.
+- Replace flow: PUT with corrected secret → atomic revoke+insert; pre-flight never sees MISSING.
+- Validate-stored success after replace → operator VALID; orchestrator resumes; WS reconnects.
+- No manual Sync-now click required.
+
+### Frontend tests
+
+`ProblemsPanel.test.tsx`:
+- REJECTED state shows single banner; AUTH_EXPIRED rows folded.
+- VALID state shows all rows independently (none from before `last_recovered_at`).
+- MISSING state shows "Save credentials in Settings → Providers" with a deep link.
+
+### Smoke test (manual operator)
+
+1. Fresh install, save deliberately-swapped keys via wizard.
+2. Wait for next sync tick. Confirm: single banner, no cascade rows, no FK violation in logs (`portfolio_sync` skipped via `requires_layer_initialized`).
+3. Update keys to correct values via Settings (PUT replace).
+4. **Without clicking anything else**, wait one sync cycle. Confirm: banner gone, layers running, admin Problems panel clean, WS subscriber connected.
+
+## Decomposition into child PRs
+
+Each child = its own branch + PR. **A and B ship first** (foundational); **C/D/E/F in parallel** consume them. Codex r2 review covers the decomposition shape (CLAUDE.md checkpoint 1b) — pending.
+
+### #974/A — Schema + state machine + write-through helper + replace endpoint
+
+**Branch:** `feature/974A-credential-health-state-machine`
+**Files:**
+- New: `sql/128_broker_credentials_health_state.sql` (col + index + transitions table).
+- New: `app/services/credential_health.py` (state machine + side-tx helpers).
+- New: `app/api/broker_credentials.py` `PUT /replace` endpoint.
+- Edit: existing `POST /broker-credentials` (`create`), `DELETE /{id}`, `POST /validate`, `POST /validate-stored` — call `record_health_outcome` with appropriate source.
+- New: `tests/test_credential_health.py`.
+
+**Acceptance:**
+- Migration applies cleanly; existing rows backfill `untested`.
+- All POST/DELETE/validate/replace paths write health correctly.
+- REJECTED-stickiness covered by tests; race scenario (concurrent probe + incidental) covered.
+- pg_notify fires once per real operator-aggregate transition, never on idempotent same-state.
+
+### #974/B — LISTEN/NOTIFY listener + operator-health cache
+
+**Branch:** `feature/974B-credential-health-pubsub`
+**Files:**
+- New: `app/jobs/credential_health_listener.py` (mirrors [`app/jobs/listener.py`](../../../app/jobs/listener.py) shape).
+- Edit: [`app/jobs/__main__.py`](../../../app/jobs/__main__.py) — start the listener thread alongside the existing job listener.
+- New: `app/services/credential_health_cache.py` — in-memory cache populated from DB scan + notifies + 5s poll fallback.
+- New: `tests/test_credential_health_listener.py`.
+
+**Acceptance:**
+- Notify on `ebull_credential_health` arrives at subscriber within 1s.
+- 5s poll fallback recovers from dropped notify.
+- Startup full-scan populates cache for operators not in any pending notify.
+- Cache returns MISSING for an operator with no rows.
+
+### #974/C — Orchestrator pre-flight gate + AUTH_EXPIRED suppression
+
+**Branch:** `feature/974C-orchestrator-credential-gate`
+**Files:**
+- Edit: [`app/services/sync_orchestrator/registry.py`](../../../app/services/sync_orchestrator/registry.py) — add fields; tag relevant layers; `portfolio_sync` gets `requires_layer_initialized=("universe",)`.
+- Edit: [`app/services/sync_orchestrator/executor.py:286`](../../../app/services/sync_orchestrator/executor.py#L286) — add the two sibling checks before `_blocking_dependency_failed`.
+- Edit: [`app/services/sync_orchestrator/layer_failure_history.py`](../../../app/services/sync_orchestrator/layer_failure_history.py) `consecutive_failures` — add `suppress_auth_expired_before` parameter; update the v2 API endpoint to pass it.
+- New: `tests/test_sync_orchestrator_credential_gate.py`.
+
+**Acceptance:**
+- Layer tagged `requires_broker_credential=True` PREREQ_SKIPs when health=REJECTED.
+- Dependent layers cascade-skip via existing mechanism.
+- `portfolio_sync` PREREQ_SKIPs until `INIT_CHECKS["universe"]` returns true (i.e. `instruments` table has ≥1 tradable row).
+- AUTH_EXPIRED rows from before `last_recovered_at` are excluded from streak counts.
+
+### #974/D — WS subscriber operator-scoped reload + backoff
+
+**Branch:** `feature/974D-ws-subscriber-reload-backoff`
+**Files:**
+- Edit: [`app/services/etoro_websocket.py:411`](../../../app/services/etoro_websocket.py#L411) — refactor `__init__` to `operator_id` + pool; add `_reload_credentials`.
+- Edit: [`app/services/etoro_websocket.py:671,692`](../../../app/services/etoro_websocket.py#L671) — backoff sequence + write-through.
+- Edit: subscribe to `ebull_credential_health` notifies; reload + reconnect on VALID; pause on REJECTED.
+- Edit: callers that construct the subscriber to pass `operator_id`+pool instead of raw keys.
+- Edit: `tests/test_etoro_websocket.py` — backoff + reload coverage.
+
+**Acceptance:**
+- After REJECTED notify: WS drops connection and stops reconnecting.
+- After VALID notify: WS reads fresh creds + reconnects.
+- Backoff sequence exact: 5, 30, 120, 600, 600.
+- No 5s/loop spam during prolonged auth failure.
+- Auth-failure write-through correctly emits `record_health_outcome(source='incidental')`.
+
+### #974/E — Admin UI cred-health banner + cascade-row hide
+
+**Branch:** `feature/974E-admin-cred-health-banner`
+**Files:**
+- Edit: `/system/status` handler — include `credential_health` in response.
+- Edit: [`frontend/src/api/types.ts`](../../../frontend/src/api/types.ts) — add `CredentialHealth`.
+- Edit: [`frontend/src/components/admin/ProblemsPanel.tsx`](../../../frontend/src/components/admin/ProblemsPanel.tsx) — single banner when REJECTED, fold AUTH_EXPIRED rows.
+- Edit: [`frontend/src/pages/AdminPage.tsx`](../../../frontend/src/pages/AdminPage.tsx) — verify polling cadence is acceptable; no SSE.
+- Edit: `ProblemsPanel.test.tsx`.
+
+**Acceptance:**
+- Single banner when `credential_health.state==='rejected'`; cascade rows folded.
+- After operator saves valid keys via PUT replace, admin page reflects state within one poll cycle.
+- All existing ProblemsPanel cases unchanged when state==='valid'.
+
+### #974/F — Settings + wizard switch to PUT /replace
+
+**Branch:** `feature/974F-frontend-credential-replace`
+**Files:**
+- Edit: [`frontend/src/api/brokerCredentials.ts`](../../../frontend/src/api/brokerCredentials.ts) — add `replaceBrokerCredential`.
+- Edit: [`frontend/src/pages/SettingsPage.tsx`](../../../frontend/src/pages/SettingsPage.tsx) — use replace when row exists for label.
+- Edit: [`frontend/src/pages/SetupPage.tsx`](../../../frontend/src/pages/SetupPage.tsx) — same.
+- Edit: respective tests.
+
+**Acceptance:**
+- Editing an existing credential calls PUT replace, not DELETE + POST.
+- New credentials still call POST.
+- Atomic from frontend perspective — no transient MISSING state.
+
+## Out of scope
+
+- Multi-cred per operator (#971 wizard simplification — separate ticket).
+- Multi-broker (eToro is the only v1 broker).
+- The recovery-phrase ceremony (#972 — separate ADR amendment).
+- The eToro key terminology mismatch (#973 — separate label fix).
+- Generic "any credential rejected anywhere" — scope is broker_credentials only. EBULL_SECRETS_KEY and other env-secret paths are unchanged.
+
+## ETL DoD clauses 8-12
+
+**N/A.** This change touches orchestrator + auth lifecycle, not filings ETL / parsers / ingest pipelines / schema migrations affecting ownership data. Standard PR DoD applies (clauses 1-7).
+
+## Codex sign-off
+
+- Round 1: see `.claude/codex-974-r1-review.txt`. 10 high + 5 medium findings; all addressed in this v2.
+- Round 2 (this revision): mandatory per CLAUDE.md checkpoint 1b — re-review v2 spec for residual gaps before child-ticket dispatch.
+- Round 3 (per-PR plan + diff review): mandatory per CLAUDE.md checkpoint 2 for each child PR.

--- a/sql/128_broker_credentials_health_state.sql
+++ b/sql/128_broker_credentials_health_state.sql
@@ -73,7 +73,8 @@ CREATE INDEX idx_broker_credentials_operator_health
     WHERE revoked_at IS NULL;
 
 CREATE TABLE operator_credential_health_transitions (
-    operator_id        UUID NOT NULL,
+    operator_id        UUID NOT NULL
+        REFERENCES operators(operator_id) ON DELETE CASCADE,
     last_recovered_at  TIMESTAMPTZ,
     PRIMARY KEY (operator_id)
 );

--- a/sql/128_broker_credentials_health_state.sql
+++ b/sql/128_broker_credentials_health_state.sql
@@ -1,0 +1,90 @@
+-- 128_broker_credentials_health_state.sql
+--
+-- Issue #975 (parent #974) — Credential health as scheduling pre-condition.
+--
+-- Spec: docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md
+--
+-- ## Why
+--
+-- Today, when an operator's eToro keys are wrong, the orchestrator
+-- keeps firing every credential-using batch on schedule, the
+-- WebSocket subscriber reconnects every 5s with stale in-memory keys,
+-- and the admin Problems panel cascades N copies of the same root
+-- 401. Saving corrected keys does not feed back into the scheduler
+-- or WS — the operator has to manually click Sync now.
+--
+-- This migration introduces row-level credential health that the
+-- orchestrator pre-flight gate, the WS subscriber, and the admin UI
+-- all observe. Aggregate operator health is computed in code from
+-- the row-level columns; see app/services/credential_health.py.
+--
+-- ## Columns added to broker_credentials
+--
+--   * health_state             — UNTESTED / VALID / REJECTED.
+--                                Default UNTESTED so existing rows
+--                                naturally start at "we have not
+--                                proven they work yet".
+--   * health_state_updated_at  — last time the row's health changed.
+--                                Lets the admin UI render "last
+--                                checked 5 minutes ago".
+--   * last_health_check_at     — last time ANY auth-using path checked
+--                                this row (success or failure).
+--                                Distinct from health_state_updated_at
+--                                so a no-op same-state check still
+--                                touches a timestamp without trigger-
+--                                ing a NOTIFY.
+--   * last_health_error        — operator-visible string from the most
+--                                recent failure. NULL on VALID rows.
+--
+-- ## operator_credential_health_transitions
+--
+-- Records the most recent REJECTED -> VALID transition timestamp per
+-- operator. The orchestrator's AUTH_EXPIRED failure-row suppression
+-- query filters job_runs failures with failed_at < last_recovered_at,
+-- so once the operator saves valid keys the cascade of stale 401
+-- failure rows stops counting toward the operator-visible streak.
+--
+-- A row is created on the FIRST REJECTED -> VALID transition for an
+-- operator. Missing-row case = "no recovery has ever happened" —
+-- callers MUST treat that as "no filter applied", same as
+-- last_recovered_at IS NULL.
+--
+-- ## Backfill
+--
+-- All existing broker_credentials rows are stamped UNTESTED via the
+-- column default. The next call to validate-stored or any auth-using
+-- path will write through their real state. No data migration needed
+-- for the transitions table — it stays empty until the first recovery.
+
+ALTER TABLE broker_credentials
+    ADD COLUMN health_state TEXT NOT NULL DEFAULT 'untested'
+        CHECK (health_state IN ('untested', 'valid', 'rejected')),
+    ADD COLUMN health_state_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ADD COLUMN last_health_check_at TIMESTAMPTZ,
+    ADD COLUMN last_health_error TEXT;
+
+-- Index for the operator-level aggregate computation. The aggregate
+-- query joins required-labels CTE against this table; the index
+-- covers the WHERE operator_id=? AND provider=? AND revoked_at IS NULL
+-- + the label/health_state SELECT columns. Partial-WHERE filters out
+-- revoked rows since they don't participate in health computation.
+CREATE INDEX idx_broker_credentials_operator_health
+    ON broker_credentials (operator_id, label, health_state)
+    WHERE revoked_at IS NULL;
+
+CREATE TABLE operator_credential_health_transitions (
+    operator_id        UUID NOT NULL,
+    last_recovered_at  TIMESTAMPTZ,
+    PRIMARY KEY (operator_id)
+);
+
+COMMENT ON COLUMN broker_credentials.health_state IS
+    'untested | valid | rejected. Set by app/services/credential_health.record_row_health_transition.';
+COMMENT ON COLUMN broker_credentials.health_state_updated_at IS
+    'Last time health_state actually changed. Used by admin UI for "last checked Nm ago".';
+COMMENT ON COLUMN broker_credentials.last_health_check_at IS
+    'Last time any auth-using path checked this row, regardless of state change.';
+COMMENT ON COLUMN broker_credentials.last_health_error IS
+    'Operator-visible error from the most recent failure. NULL on VALID rows.';
+COMMENT ON TABLE operator_credential_health_transitions IS
+    'Tracks last REJECTED -> VALID transition per operator. Used by AUTH_EXPIRED suppression query at orchestrator/ProblemsPanel boundary.';

--- a/tests/test_credential_health.py
+++ b/tests/test_credential_health.py
@@ -1,0 +1,640 @@
+"""Tests for app.services.credential_health (issue #975, parent #974).
+
+Spec: docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md.
+
+Coverage:
+  * _should_change_state — pure logic; full truth table including REJECTED-sticky.
+  * get_operator_credential_health — all 4 aggregate states + missing-label cases + precedence.
+  * record_row_health_transition (via _do_health_transition for tx control):
+    - row UPDATE under FOR UPDATE.
+    - last_health_check_at always touched.
+    - health_state changes only when _should_change_state allows.
+    - operator_credential_health_transitions UPSERT only on REJECTED -> VALID aggregate.
+    - NOTIFY emitted only on aggregate movement; payload shape pinned.
+  * get_last_recovered_at — missing row, NULL row, present row.
+  * Row-factory pinning — aggregate query result shape locked to dict_row.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID, uuid4
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.security import secrets_crypto
+from app.services.credential_health import (
+    NOTIFY_CHANNEL,
+    REQUIRED_LABELS_BY_PROVIDER,
+    CredentialHealth,
+    _do_health_transition,
+    _should_change_state,
+    get_last_recovered_at,
+    get_operator_credential_health,
+)
+from tests.fixtures.ebull_test_db import (
+    ebull_test_conn,  # noqa: F401
+    test_database_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _key() -> Iterator[None]:
+    """secrets_crypto needs an active key for the broker_credentials encrypt()
+    path to work — even though the health module doesn't encrypt, fixtures
+    that insert via the service layer would. Set up once per test."""
+    secrets_crypto.set_active_key(os.urandom(32))
+    yield
+    secrets_crypto._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_operator(conn: psycopg.Connection[Any]) -> UUID:
+    """Insert a synthetic operator row; return its UUID."""
+    op_id = uuid4()
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s, %s, %s)",
+            (op_id, f"op-{op_id.hex[:8]}", "argon2:dummy"),
+        )
+    conn.commit()
+    return op_id
+
+
+def _insert_credential(
+    conn: psycopg.Connection[Any],
+    *,
+    operator_id: UUID,
+    label: str,
+    health_state: str = "untested",
+    revoked: bool = False,
+) -> UUID:
+    """Insert a synthetic broker_credentials row at a given health_state."""
+    cred_id = uuid4()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO broker_credentials
+                (id, operator_id, provider, label, environment,
+                 ciphertext, last_four, key_version, health_state, revoked_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                cred_id,
+                operator_id,
+                "etoro",
+                label,
+                "demo",
+                b"\x00" * 32,  # bytea ciphertext placeholder; tests don't decrypt
+                "abcd",
+                1,
+                health_state,
+                "NOW()" if False else None,  # placeholder; we use a separate path for revoked
+            ),
+        )
+        if revoked:
+            cur.execute(
+                "UPDATE broker_credentials SET revoked_at = NOW() WHERE id = %s",
+                (cred_id,),
+            )
+    conn.commit()
+    return cred_id
+
+
+def _seed_pair(
+    conn: psycopg.Connection[Any],
+    *,
+    api_state: str | None,
+    user_state: str | None,
+) -> UUID:
+    """Insert an operator + broker_credentials rows for both labels.
+
+    state=None means "no row present" so the aggregate sees a missing label.
+    """
+    op_id = _insert_operator(conn)
+    if api_state is not None:
+        _insert_credential(conn, operator_id=op_id, label="api_key", health_state=api_state)
+    if user_state is not None:
+        _insert_credential(conn, operator_id=op_id, label="user_key", health_state=user_state)
+    return op_id
+
+
+# ---------------------------------------------------------------------------
+# _should_change_state — pure logic, no DB
+# ---------------------------------------------------------------------------
+
+
+class TestShouldChangeState:
+    @pytest.mark.parametrize(
+        "old,new,source,expected",
+        [
+            # Untested rows: any change applies regardless of source.
+            ("untested", "valid", "probe", True),
+            ("untested", "valid", "incidental", True),
+            ("untested", "rejected", "probe", True),
+            ("untested", "rejected", "incidental", True),
+            # Valid -> rejected: any source flips.
+            ("valid", "rejected", "probe", True),
+            ("valid", "rejected", "incidental", True),
+            # Rejected -> valid: ONLY probe source.
+            ("rejected", "valid", "probe", True),
+            ("rejected", "valid", "incidental", False),
+            # Same-state transitions: never.
+            ("valid", "valid", "probe", False),
+            ("valid", "valid", "incidental", False),
+            ("rejected", "rejected", "probe", False),
+            ("rejected", "rejected", "incidental", False),
+            ("untested", "untested", "probe", False),
+            ("untested", "untested", "incidental", False),
+        ],
+    )
+    def test_truth_table(self, old: str, new: str, source: str, expected: bool) -> None:
+        assert (
+            _should_change_state(old_state=old, new_state=new, source=source)  # type: ignore[arg-type]
+            == expected
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_operator_credential_health
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGetOperatorCredentialHealth:
+    def test_both_valid_returns_valid(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op = _seed_pair(ebull_test_conn, api_state="valid", user_state="valid")
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op) == CredentialHealth.VALID
+
+    def test_both_untested_returns_untested(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op = _seed_pair(ebull_test_conn, api_state="untested", user_state="untested")
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op) == CredentialHealth.UNTESTED
+
+    def test_both_rejected_returns_rejected(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op = _seed_pair(ebull_test_conn, api_state="rejected", user_state="rejected")
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op) == CredentialHealth.REJECTED
+
+    def test_no_rows_returns_missing(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op = _seed_pair(ebull_test_conn, api_state=None, user_state=None)
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op) == CredentialHealth.MISSING
+
+    def test_one_label_missing_returns_missing(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        # api_key valid, user_key absent -> MISSING
+        op = _seed_pair(ebull_test_conn, api_state="valid", user_state=None)
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op) == CredentialHealth.MISSING
+
+    def test_rejected_dominates_missing(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Locked precedence (Codex r3.2): REJECTED > MISSING."""
+        op = _seed_pair(ebull_test_conn, api_state="rejected", user_state=None)
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op) == CredentialHealth.REJECTED
+
+    def test_rejected_dominates_valid(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op = _seed_pair(ebull_test_conn, api_state="rejected", user_state="valid")
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op) == CredentialHealth.REJECTED
+
+    def test_untested_with_valid_returns_untested(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        # one valid, one untested -> UNTESTED (any_untested is true).
+        op = _seed_pair(ebull_test_conn, api_state="valid", user_state="untested")
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op) == CredentialHealth.UNTESTED
+
+    def test_revoked_rows_excluded(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """A revoked row should not affect the aggregate."""
+        op_id = _insert_operator(ebull_test_conn)
+        # Revoked api_key (REJECTED state, but revoked) — should not surface.
+        _insert_credential(
+            ebull_test_conn,
+            operator_id=op_id,
+            label="api_key",
+            health_state="rejected",
+            revoked=True,
+        )
+        # Active api_key (valid).
+        _insert_credential(ebull_test_conn, operator_id=op_id, label="api_key", health_state="valid")
+        _insert_credential(ebull_test_conn, operator_id=op_id, label="user_key", health_state="valid")
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op_id) == CredentialHealth.VALID
+
+    def test_unknown_provider_raises(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op_id = _insert_operator(ebull_test_conn)
+        with pytest.raises(KeyError):
+            get_operator_credential_health(ebull_test_conn, operator_id=op_id, provider="kraken")
+
+    def test_required_labels_constant_locked(self) -> None:
+        """Locks the etoro (api_key, user_key) requirement so a future
+        provider addition doesn't accidentally relax health for etoro."""
+        assert REQUIRED_LABELS_BY_PROVIDER["etoro"] == ("api_key", "user_key")
+
+
+# ---------------------------------------------------------------------------
+# _do_health_transition — drives row update, transitions row, NOTIFY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestDoHealthTransition:
+    def test_untested_to_valid_via_probe(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op_id = _seed_pair(ebull_test_conn, api_state="untested", user_state="valid")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=api_id,
+                new_state="valid",
+                source="probe",
+                error_detail=None,
+            )
+
+        state = _row_state(ebull_test_conn, api_id)
+        assert state["health_state"] == "valid"
+        assert state["last_health_check_at"] is not None
+        assert state["last_health_error"] is None
+
+    def test_rejected_blocked_by_incidental_success(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """REJECTED-stickiness: incidental 2xx must NOT clear rejected."""
+        op_id = _seed_pair(ebull_test_conn, api_state="rejected", user_state="valid")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=api_id,
+                new_state="valid",
+                source="incidental",
+                error_detail=None,
+            )
+
+        # Row state is unchanged.
+        state = _row_state(ebull_test_conn, api_id)
+        assert state["health_state"] == "rejected"
+        # last_health_check_at is still touched (we observed the call), but
+        # last_health_error was cleared by the success outcome write.
+        assert state["last_health_check_at"] is not None
+
+    def test_rejected_cleared_by_probe_success(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op_id = _seed_pair(ebull_test_conn, api_state="rejected", user_state="valid")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=api_id,
+                new_state="valid",
+                source="probe",
+                error_detail=None,
+            )
+
+        state = _row_state(ebull_test_conn, api_id)
+        assert state["health_state"] == "valid"
+
+    def test_recovery_writes_transitions_row(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """REJECTED -> VALID at OPERATOR level upserts the transitions row."""
+        # Both rows REJECTED: aggregate is REJECTED.
+        op_id = _seed_pair(ebull_test_conn, api_state="rejected", user_state="rejected")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+        user_id = _credential_id(ebull_test_conn, op_id, "user_key")
+
+        # Clear api_key first via probe success — aggregate stays REJECTED
+        # because user_key still rejected. No transitions row yet.
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=api_id,
+                new_state="valid",
+                source="probe",
+                error_detail=None,
+            )
+        assert get_last_recovered_at(ebull_test_conn, operator_id=op_id) is None
+
+        # Clear user_key: aggregate flips to VALID. Transitions row appears.
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=user_id,
+                new_state="valid",
+                source="probe",
+                error_detail=None,
+            )
+        recovered_at = get_last_recovered_at(ebull_test_conn, operator_id=op_id)
+        assert recovered_at is not None
+
+    def test_untested_to_valid_does_not_write_transitions_row(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """UNTESTED -> VALID is a fresh-bootstrap path, NOT recovery."""
+        op_id = _seed_pair(ebull_test_conn, api_state="untested", user_state="untested")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+        user_id = _credential_id(ebull_test_conn, op_id, "user_key")
+
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=api_id,
+                new_state="valid",
+                source="probe",
+                error_detail=None,
+            )
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=user_id,
+                new_state="valid",
+                source="probe",
+                error_detail=None,
+            )
+
+        # Operator aggregate moved UNTESTED -> VALID, but that's not a
+        # REJECTED -> VALID, so no transitions row.
+        assert get_last_recovered_at(ebull_test_conn, operator_id=op_id) is None
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op_id) == CredentialHealth.VALID
+
+    def test_failure_writes_error_detail(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op_id = _seed_pair(ebull_test_conn, api_state="valid", user_state="valid")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=api_id,
+                new_state="rejected",
+                source="incidental",
+                error_detail="HTTP 401 Unauthorized",
+            )
+
+        state = _row_state(ebull_test_conn, api_id)
+        assert state["health_state"] == "rejected"
+        assert state["last_health_error"] == "HTTP 401 Unauthorized"
+
+    def test_idempotent_same_state_does_not_change_health_state_updated_at(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op_id = _seed_pair(ebull_test_conn, api_state="valid", user_state="valid")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+
+        before = _row_state(ebull_test_conn, api_id)["health_state_updated_at"]
+
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=api_id,
+                new_state="valid",
+                source="probe",
+                error_detail=None,
+            )
+
+        after = _row_state(ebull_test_conn, api_id)
+        # health_state_updated_at unchanged (no transition).
+        assert after["health_state_updated_at"] == before
+        # last_health_check_at WAS bumped (we observed a call).
+        assert after["last_health_check_at"] is not None
+
+    def test_revoked_credential_id_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """A credential_id whose row is revoked should be a no-op + warning."""
+        op_id = _insert_operator(ebull_test_conn)
+        cred_id = _insert_credential(
+            ebull_test_conn,
+            operator_id=op_id,
+            label="api_key",
+            health_state="rejected",
+            revoked=True,
+        )
+
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=cred_id,
+                new_state="valid",
+                source="probe",
+                error_detail=None,
+            )
+
+        # Row state still rejected (no update; the helper bailed early).
+        state = _row_state(ebull_test_conn, cred_id)
+        assert state["health_state"] == "rejected"
+
+    def test_notify_emitted_on_aggregate_movement(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """LISTEN on a separate connection; assert payload arrives.
+
+        Uses a fresh sender connection rather than ebull_test_conn so
+        the fixture's rollback-at-teardown lifecycle can't mask the
+        commit semantics under test.
+        """
+        op_id = _seed_pair(ebull_test_conn, api_state="untested", user_state="untested")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+        user_id = _credential_id(ebull_test_conn, op_id, "user_key")
+
+        url = test_database_url()
+        listen_conn = psycopg.connect(url, autocommit=True)
+        sender_conn = psycopg.connect(url)
+        try:
+            listen_conn.execute(f"LISTEN {NOTIFY_CHANNEL}")
+
+            with sender_conn.transaction():
+                _do_health_transition(
+                    sender_conn,
+                    credential_id=api_id,
+                    new_state="valid",
+                    source="probe",
+                    error_detail=None,
+                )
+                _do_health_transition(
+                    sender_conn,
+                    credential_id=user_id,
+                    new_state="valid",
+                    source="probe",
+                    error_detail=None,
+                )
+            # Both transitions inside the same outer tx — the second
+            # one moves the operator aggregate to VALID.
+
+            payloads: list[dict[str, Any]] = []
+            for n in listen_conn.notifies(timeout=2.0, stop_after=2):
+                payloads.append(json.loads(n.payload))
+
+            assert any(p["new_aggregate"] == "valid" and p["operator_id"] == str(op_id) for p in payloads), (
+                f"expected VALID notify; got {payloads!r}"
+            )
+        finally:
+            sender_conn.close()
+            listen_conn.close()
+
+    def test_notify_payload_shape(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Pin payload field set so subscribers can rely on it."""
+        op_id = _seed_pair(ebull_test_conn, api_state="untested", user_state="untested")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+        user_id = _credential_id(ebull_test_conn, op_id, "user_key")
+
+        url = test_database_url()
+        listen_conn = psycopg.connect(url, autocommit=True)
+        sender_conn = psycopg.connect(url)
+        try:
+            listen_conn.execute(f"LISTEN {NOTIFY_CHANNEL}")
+
+            with sender_conn.transaction():
+                _do_health_transition(
+                    sender_conn,
+                    credential_id=api_id,
+                    new_state="valid",
+                    source="probe",
+                    error_detail=None,
+                )
+                _do_health_transition(
+                    sender_conn,
+                    credential_id=user_id,
+                    new_state="valid",
+                    source="probe",
+                    error_detail=None,
+                )
+
+            payloads = []
+            for n in listen_conn.notifies(timeout=2.0, stop_after=1):
+                payloads.append(json.loads(n.payload))
+
+            assert payloads, "expected at least one notify"
+            payload = payloads[0]
+            assert set(payload.keys()) == {
+                "operator_id",
+                "provider",
+                "old_aggregate",
+                "new_aggregate",
+                "at",
+            }
+            assert payload["provider"] == "etoro"
+        finally:
+            sender_conn.close()
+            listen_conn.close()
+
+
+# ---------------------------------------------------------------------------
+# get_last_recovered_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGetLastRecoveredAt:
+    def test_missing_row_returns_none(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op_id = uuid4()  # no row anywhere.
+        assert get_last_recovered_at(ebull_test_conn, operator_id=op_id) is None
+
+    def test_null_value_returns_none(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op_id = _insert_operator(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO operator_credential_health_transitions (operator_id, last_recovered_at) VALUES (%s, NULL)",
+                (op_id,),
+            )
+        ebull_test_conn.commit()
+        assert get_last_recovered_at(ebull_test_conn, operator_id=op_id) is None
+
+    def test_present_value_returned(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        op_id = _insert_operator(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO operator_credential_health_transitions "
+                "(operator_id, last_recovered_at) VALUES (%s, NOW())",
+                (op_id,),
+            )
+        ebull_test_conn.commit()
+        result = get_last_recovered_at(ebull_test_conn, operator_id=op_id)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Local helpers used by the test classes
+# ---------------------------------------------------------------------------
+
+
+def _credential_id(conn: psycopg.Connection[Any], op_id: UUID, label: str) -> UUID:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM broker_credentials WHERE operator_id = %s AND label = %s AND revoked_at IS NULL",
+            (op_id, label),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
+def _row_state(conn: psycopg.Connection[Any], cred_id: UUID) -> dict[str, Any]:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT health_state, health_state_updated_at, "
+            "last_health_check_at, last_health_error "
+            "FROM broker_credentials WHERE id = %s",
+            (cred_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return row

--- a/tests/test_credential_health.py
+++ b/tests/test_credential_health.py
@@ -433,9 +433,45 @@ class TestDoHealthTransition:
         # Row state is unchanged.
         state = _row_state(ebull_test_conn, api_id)
         assert state["health_state"] == "rejected"
-        # last_health_check_at is still touched (we observed the call), but
-        # last_health_error was cleared by the success outcome write.
+        # last_health_check_at IS touched (we observed the call).
         assert state["last_health_check_at"] is not None
+
+    def test_sticky_skip_preserves_last_health_error(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """PREVENTION (review #981): incidental success on a REJECTED
+        row must NOT wipe last_health_error.
+
+        Pre-fix the helper unconditionally rewrote last_health_error
+        on every call; this test pins the new contract that the
+        column is only touched when an actual transition happens.
+        """
+        op_id = _seed_pair(ebull_test_conn, api_state="rejected", user_state="valid")
+        api_id = _credential_id(ebull_test_conn, op_id, "api_key")
+
+        # Seed a non-NULL error message that the operator should keep
+        # seeing in the admin UI.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE broker_credentials SET last_health_error = %s WHERE id = %s",
+                ("HTTP 401 Unauthorized — original rejection message", api_id),
+            )
+        ebull_test_conn.commit()
+
+        # Incidental success that should be sticky-skipped.
+        with ebull_test_conn.transaction():
+            _do_health_transition(
+                ebull_test_conn,
+                credential_id=api_id,
+                new_state="valid",
+                source="incidental",
+                error_detail=None,
+            )
+
+        state = _row_state(ebull_test_conn, api_id)
+        assert state["health_state"] == "rejected"
+        assert state["last_health_error"] == "HTTP 401 Unauthorized — original rejection message"
 
     def test_rejected_cleared_by_probe_success(
         self,

--- a/tests/test_credential_health.py
+++ b/tests/test_credential_health.py
@@ -36,6 +36,7 @@ from app.services.credential_health import (
     _should_change_state,
     get_last_recovered_at,
     get_operator_credential_health,
+    notify_aggregate_if_changed,
 )
 from tests.fixtures.ebull_test_db import (
     ebull_test_conn,  # noqa: F401
@@ -77,6 +78,7 @@ def _insert_credential(
     label: str,
     health_state: str = "untested",
     revoked: bool = False,
+    environment: str = "demo",
 ) -> UUID:
     """Insert a synthetic broker_credentials row at a given health_state."""
     cred_id = uuid4()
@@ -93,12 +95,12 @@ def _insert_credential(
                 operator_id,
                 "etoro",
                 label,
-                "demo",
+                environment,
                 b"\x00" * 32,  # bytea ciphertext placeholder; tests don't decrypt
                 "abcd",
                 1,
                 health_state,
-                "NOW()" if False else None,  # placeholder; we use a separate path for revoked
+                None,
             ),
         )
         if revoked:
@@ -261,6 +263,126 @@ class TestGetOperatorCredentialHealth:
         """Locks the etoro (api_key, user_key) requirement so a future
         provider addition doesn't accidentally relax health for etoro."""
         assert REQUIRED_LABELS_BY_PROVIDER["etoro"] == ("api_key", "user_key")
+
+    def test_environment_scoping_prevents_cross_pollination(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Codex pre-push r1.2: aggregate must be scoped to environment.
+
+        A demo api_key VALID + real user_key VALID should NOT make
+        either env's aggregate VALID — neither has a complete pair.
+        """
+        op_id = _insert_operator(ebull_test_conn)
+        _insert_credential(
+            ebull_test_conn,
+            operator_id=op_id,
+            label="api_key",
+            health_state="valid",
+            environment="demo",
+        )
+        _insert_credential(
+            ebull_test_conn,
+            operator_id=op_id,
+            label="user_key",
+            health_state="valid",
+            environment="real",
+        )
+
+        # demo: api_key valid, user_key absent -> MISSING
+        assert (
+            get_operator_credential_health(ebull_test_conn, operator_id=op_id, environment="demo")
+            == CredentialHealth.MISSING
+        )
+        # real: user_key valid, api_key absent -> MISSING
+        assert (
+            get_operator_credential_health(ebull_test_conn, operator_id=op_id, environment="real")
+            == CredentialHealth.MISSING
+        )
+
+
+# ---------------------------------------------------------------------------
+# notify_aggregate_if_changed (used by PUT /broker-credentials/replace)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestNotifyAggregateIfChanged:
+    def test_emits_notify_when_aggregate_moves(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Mutate rows directly, then call helper — NOTIFY should fire."""
+        op_id = _seed_pair(ebull_test_conn, api_state="valid", user_state="valid")
+
+        url = test_database_url()
+        listen_conn = psycopg.connect(url, autocommit=True)
+        sender_conn = psycopg.connect(url)
+        try:
+            listen_conn.execute(f"LISTEN {NOTIFY_CHANNEL}")
+
+            with sender_conn.transaction():
+                # Snapshot before mutation.
+                old = get_operator_credential_health(sender_conn, operator_id=op_id, environment="demo")
+                assert old == CredentialHealth.VALID
+
+                # Revoke the api_key row (mimics PUT /replace's first step).
+                with sender_conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE broker_credentials SET revoked_at = NOW() "
+                        "WHERE operator_id = %s AND label = 'api_key' AND revoked_at IS NULL",
+                        (op_id,),
+                    )
+
+                # Notify after mutation.
+                notify_aggregate_if_changed(
+                    sender_conn,
+                    operator_id=op_id,
+                    provider="etoro",
+                    environment="demo",
+                    old_aggregate=old,
+                )
+
+            payloads = []
+            for n in listen_conn.notifies(timeout=2.0, stop_after=1):
+                payloads.append(json.loads(n.payload))
+
+            assert payloads, "expected NOTIFY for VALID -> MISSING transition"
+            assert payloads[0]["old_aggregate"] == "valid"
+            assert payloads[0]["new_aggregate"] == "missing"
+        finally:
+            sender_conn.close()
+            listen_conn.close()
+
+    def test_no_notify_when_aggregate_unchanged(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Idempotent: aggregate same before+after means no NOTIFY."""
+        op_id = _seed_pair(ebull_test_conn, api_state="valid", user_state="valid")
+
+        url = test_database_url()
+        listen_conn = psycopg.connect(url, autocommit=True)
+        sender_conn = psycopg.connect(url)
+        try:
+            listen_conn.execute(f"LISTEN {NOTIFY_CHANNEL}")
+
+            with sender_conn.transaction():
+                old = get_operator_credential_health(sender_conn, operator_id=op_id, environment="demo")
+                # No mutation between snapshot and helper call.
+                notify_aggregate_if_changed(
+                    sender_conn,
+                    operator_id=op_id,
+                    provider="etoro",
+                    environment="demo",
+                    old_aggregate=old,
+                )
+
+            payloads = list(listen_conn.notifies(timeout=0.5, stop_after=1))
+            assert payloads == [], f"expected no NOTIFY; got {payloads}"
+        finally:
+            sender_conn.close()
+            listen_conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_credential_health.py
+++ b/tests/test_credential_health.py
@@ -515,10 +515,78 @@ class TestDoHealthTransition:
                 error_detail=None,
             )
 
-        # Operator aggregate moved UNTESTED -> VALID, but that's not a
-        # REJECTED -> VALID, so no transitions row.
+        # Operator aggregate moved UNTESTED -> VALID, but the
+        # recovery timestamp only matters for AUTH_EXPIRED suppression
+        # which has no relevance for an operator that was never REJECTED.
+        # No transitions row written.
         assert get_last_recovered_at(ebull_test_conn, operator_id=op_id) is None
         assert get_operator_credential_health(ebull_test_conn, operator_id=op_id) == CredentialHealth.VALID
+
+    def test_rejected_to_untested_via_replace_records_recovery(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """REJECTED -> UNTESTED at aggregate writes the recovery row.
+
+        Mirrors the realistic flow: operator with rejected creds
+        revokes the bad row + inserts a fresh untested replacement
+        via PUT /replace. The aggregate moves REJECTED -> UNTESTED;
+        the recovery timestamp must be set so AUTH_EXPIRED
+        suppression kicks in NOW, not waiting for the later
+        validate-stored (Codex pre-push r2.1).
+        """
+        op_id = _seed_pair(ebull_test_conn, api_state="rejected", user_state="rejected")
+
+        with ebull_test_conn.transaction():
+            old = get_operator_credential_health(ebull_test_conn, operator_id=op_id)
+            assert old == CredentialHealth.REJECTED
+
+            # Simulate two PUT /replace calls that fixed both rejected
+            # rows in one operator action: revoke each row and insert
+            # a fresh untested replacement. Inlined rather than using
+            # _insert_credential because that helper commits, which
+            # is forbidden inside an active transaction context.
+            with ebull_test_conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE broker_credentials SET revoked_at = NOW() WHERE operator_id = %s AND revoked_at IS NULL",
+                    (op_id,),
+                )
+                for label in ("api_key", "user_key"):
+                    cur.execute(
+                        """
+                        INSERT INTO broker_credentials
+                            (id, operator_id, provider, label, environment,
+                             ciphertext, last_four, key_version, health_state)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            uuid4(),
+                            op_id,
+                            "etoro",
+                            label,
+                            "demo",
+                            b"\x00" * 32,
+                            "abcd",
+                            1,
+                            "untested",
+                        ),
+                    )
+
+            notify_aggregate_if_changed(
+                ebull_test_conn,
+                operator_id=op_id,
+                provider="etoro",
+                environment="demo",
+                old_aggregate=old,
+            )
+
+        # Aggregate is now UNTESTED (both rows untested); recovery
+        # timestamp is set because the operator moved OUT of REJECTED.
+        # AUTH_EXPIRED suppression kicks in NOW, not waiting for the
+        # later validate-stored.
+        assert get_operator_credential_health(ebull_test_conn, operator_id=op_id) == CredentialHealth.UNTESTED
+        recovered_at = get_last_recovered_at(ebull_test_conn, operator_id=op_id)
+        assert recovered_at is not None
 
     def test_failure_writes_error_detail(
         self,


### PR DESCRIPTION
Refs #974. Closes #975. Foundational PR for the credential-health-as-scheduling-precondition umbrella.

## What

- Schema migration `sql/128_broker_credentials_health_state.sql`: new health_state column + index + operator_credential_health_transitions table.
- New service `app/services/credential_health.py`: operator-level aggregate computation (REJECTED-first precedence), side-tx write-through helpers, REJECTED-stickiness, NOTIFY on aggregate movement only, recovery-timestamp upsert on any move out of REJECTED.
- New endpoint `PUT /broker-credentials/replace`: atomic revoke + insert in one transaction (no transient MISSING window for subscribers). Identical-secret short-circuit (`{"changed": false}`) avoids spurious flap on idempotent re-saves.
- `POST /broker-credentials/validate-stored` write-through: probes flip both rows' health to VALID (canonical recovery path); 401/403 flips to REJECTED.

## Why

Operator with bad keys today: the scheduler keeps firing every credential-using job on schedule, the WS subscriber spams 5s reconnect loops with stale in-memory keys, and the admin Problems panel cascades N copies of the same root 401. After saving correct keys nothing auto-resumes — operator has to click Sync now manually. This PR is the foundation: row-level health + operator-level aggregate + LISTEN/NOTIFY signal that subsequent children (#976-#980) consume to gate scheduling, reload the WS, and clean the admin UI.

## Test plan

- [x] 42 new tests at `tests/test_credential_health.py` covering: truth-table for stickiness, all aggregate states + missing-label cases + precedence, side-tx semantics, NOTIFY emission and payload shape, recovery timestamp via both _do_health_transition AND notify_aggregate_if_changed, environment scoping, NULL/missing transitions row.
- [x] Adjacent suites pass (broker_credentials_*, smoke).
- [x] ruff check + ruff format --check + pyright clean.
- [x] Codex pre-push review: 3 rounds; 5 findings raised, all fixed before push (validate-stored pool attribute, environment scoping, PUT /replace NOTIFY, conn.commit() flush, recovery timestamp on REJECTED → UNTESTED).

## Spec

- docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md
- 5 Codex spec-review rounds: 26 findings raised, all addressed before any code landed.