### PR TITLE
feat(#976): credential-health LISTEN/NOTIFY listener + per-process cache

### DIFF
--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -52,6 +52,9 @@ import psycopg
 from app.config import settings
 from app.db.pool import open_pool
 from app.jobs.boot_sweep import run_boot_freshness_sweep
+from app.jobs.credential_health_listener import (
+    listener_loop as credential_health_listener_loop,
+)
 from app.jobs.heartbeat import HeartbeatWriter, heartbeat_loop
 from app.jobs.listener import ListenerState, listener_loop
 from app.jobs.locks import JOBS_PROCESS_LOCK_KEY
@@ -59,6 +62,7 @@ from app.jobs.runtime import JobRuntime
 from app.jobs.supervisor import supervise
 from app.security import master_key
 from app.security.secrets_crypto import set_active_key as set_broker_encryption_key
+from app.services.credential_health_cache import CredentialHealthCache
 from app.services.sync_orchestrator.dispatcher import (
     claim_oldest_pending,
     reset_stale_in_flight,
@@ -232,6 +236,12 @@ def serve(stop_event: threading.Event | None = None) -> int:
     )
     heartbeat_threads: list[threading.Thread] = []
 
+    # Pre-declare the credential-health listener handles so the
+    # finally: clean-up block can reference them even if construction
+    # raises during startup.
+    credential_health_stop: threading.Event | None = None
+    credential_health_thread: threading.Thread | None = None
+
     try:
         # Step 4 — reaper.
         try:
@@ -274,6 +284,25 @@ def serve(stop_event: threading.Event | None = None) -> int:
 
         # Step 10 — boot freshness sweep.
         run_boot_freshness_sweep()
+
+        # Credential-health listener (#976 / #974/B). Process-local
+        # cache populated by initial full-scan + LISTEN/NOTIFY +
+        # 5s poll fallback. The orchestrator pre-flight gate (#977)
+        # reads this cache to skip credential-using layers when
+        # operator health != VALID.
+        credential_health_cache = CredentialHealthCache()
+        credential_health_stop = threading.Event()
+        credential_health_thread = threading.Thread(
+            target=credential_health_listener_loop,
+            kwargs={
+                "cache": credential_health_cache,
+                "pool": pool,
+                "stop_event": credential_health_stop,
+            },
+            name="jobs-credential-health-listener",
+            daemon=True,
+        )
+        credential_health_thread.start()
 
         # Step 12 — heartbeat threads (one per supervised subsystem).
         for subsystem in ("scheduler", "manual_listener", "queue_drainer", "main"):
@@ -322,6 +351,13 @@ def serve(stop_event: threading.Event | None = None) -> int:
     finally:
         # Reverse-order shutdown.
         listener_stop.set()
+        if credential_health_stop is not None:
+            try:
+                credential_health_stop.set()
+                if credential_health_thread is not None:
+                    credential_health_thread.join(timeout=5.0)
+            except Exception:
+                logger.exception("jobs entrypoint: credential_health listener stop raised")
         try:
             runtime.shutdown()
         except Exception:

--- a/app/jobs/credential_health_listener.py
+++ b/app/jobs/credential_health_listener.py
@@ -1,0 +1,236 @@
+"""LISTEN/NOTIFY thread for the credential-health cache (#976 / #974/B).
+
+Owns one dedicated autocommit ``psycopg.Connection`` running
+``LISTEN ebull_credential_health`` plus a 5s poll fallback so a
+NOTIFY dropped during reconnection still surfaces within 5s.
+
+Differences from ``app/jobs/listener.py`` (the job-request listener):
+
+  * No durable event table — there is no equivalent of
+    ``pending_job_requests`` for credential health (Codex r1.10 in
+    spec). Subscribers MUST poll DB truth on startup; the channel is
+    a wake-up only.
+  * Startup full-scan with retry-with-backoff (1s, 2s, 5s, 10s, 30s
+    cap) until the initial scan succeeds — until then the cache
+    reports MISSING for every read so consumers fail-safe.
+  * On notify: re-read DB truth for the operator carried in the
+    payload (don't trust the payload's aggregate alone).
+  * On 5s poll tick: full-table re-scan to recover dropped notifies
+    and to detect operator deletions that wouldn't otherwise emit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+from uuid import UUID
+
+import psycopg
+import psycopg.sql
+from psycopg_pool import ConnectionPool
+
+from app.config import settings
+from app.services.credential_health import (
+    NOTIFY_CHANNEL,
+    get_operator_credential_health,
+)
+from app.services.credential_health_cache import (
+    CredentialHealthCache,
+    scan_all_operators,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Initial-scan retry sequence. A clean restart should land in <2s; any
+# longer means Postgres warm-up or pool not yet open. The 30s cap is
+# generous for prolonged outages — consumers see MISSING the whole
+# time, which means no creds-using work runs (fail-safe).
+INITIAL_SCAN_BACKOFF_S: tuple[float, ...] = (1.0, 2.0, 5.0, 10.0, 30.0)
+
+# Poll interval for the safety-net full re-scan. Independent of the
+# NOTIFY-driven path so a dropped notify (network blip, reconnect
+# window) surfaces within this interval.
+POLL_INTERVAL_S: float = 5.0
+
+# Notify-blocking timeout. The LISTEN loop polls notifies in this
+# window then falls through to the poll-fallback re-scan. Short enough
+# to keep the loop responsive to stop_event.
+NOTIFY_BLOCK_TIMEOUT_S: float = 1.0
+
+
+def listener_loop(
+    *,
+    cache: CredentialHealthCache,
+    pool: ConnectionPool[psycopg.Connection[Any]],
+    stop_event: threading.Event,
+    listen_conn_factory: Callable[[], psycopg.Connection[Any]] | None = None,
+) -> None:
+    """Run startup scan + LISTEN/NOTIFY loop until ``stop_event`` is set.
+
+    ``listen_conn_factory`` is overridable for tests — the default
+    opens a fresh autocommit psycopg.Connection against
+    ``settings.database_url``.
+    """
+    factory = listen_conn_factory or _default_listen_conn_factory
+
+    # 1. Initial scan with retry-with-backoff. Until this succeeds the
+    #    cache reports MISSING (fail-safe).
+    if not _run_initial_scan(cache=cache, pool=pool, stop_event=stop_event):
+        logger.info("credential_health_listener: stop requested before initial scan")
+        return
+
+    # 2. LISTEN + 5s poll loop. Re-enter on connection death; cache
+    #    state is preserved across reconnects.
+    while not stop_event.is_set():
+        try:
+            conn = factory()
+        except Exception:
+            logger.exception("credential_health_listener: failed to open LISTEN connection")
+            if stop_event.wait(timeout=POLL_INTERVAL_S):
+                return
+            continue
+
+        try:
+            _run_listen_loop(conn=conn, cache=cache, pool=pool, stop_event=stop_event)
+        except Exception:
+            logger.exception("credential_health_listener: inner loop crashed; reconnecting")
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                logger.debug("listener close raised", exc_info=True)
+
+        if stop_event.wait(timeout=1.0):
+            return
+
+
+def _default_listen_conn_factory() -> psycopg.Connection[Any]:
+    """Open a fresh autocommit connection for LISTEN.
+
+    autocommit is required so LISTEN takes effect immediately; the
+    same connection is held for the life of the inner loop and closed
+    on exit so a Postgres-side reset releases all queued notifies.
+    """
+    return psycopg.connect(settings.database_url, autocommit=True)
+
+
+def _run_initial_scan(
+    *,
+    cache: CredentialHealthCache,
+    pool: ConnectionPool[psycopg.Connection[Any]],
+    stop_event: threading.Event,
+) -> bool:
+    """Run the initial full-table scan with retry-with-backoff.
+
+    Returns True iff the scan eventually succeeded. Returns False if
+    stop_event was set before any successful scan — caller should
+    return without entering the LISTEN loop.
+
+    Cache stays in pre-initialized state (every read returns MISSING)
+    until this function returns True.
+    """
+    attempt = 0
+    while not stop_event.is_set():
+        try:
+            populated = scan_all_operators(pool)
+            cache.set_initial_scan(populated)
+            return True
+        except Exception:
+            wait = INITIAL_SCAN_BACKOFF_S[min(attempt, len(INITIAL_SCAN_BACKOFF_S) - 1)]
+            logger.exception(
+                "credential_health_listener: initial scan failed (attempt %d); retrying in %ss",
+                attempt + 1,
+                wait,
+            )
+            attempt += 1
+            if stop_event.wait(timeout=wait):
+                return False
+    return False
+
+
+def _run_listen_loop(
+    *,
+    conn: psycopg.Connection[Any],
+    cache: CredentialHealthCache,
+    pool: ConnectionPool[psycopg.Connection[Any]],
+    stop_event: threading.Event,
+) -> None:
+    """LISTEN + 5s poll inner loop. Returns when stop_event set or conn dies."""
+    with conn.cursor() as cur:
+        cur.execute(psycopg.sql.SQL("LISTEN {}").format(psycopg.sql.Identifier(NOTIFY_CHANNEL)))
+    logger.info("credential_health_listener: LISTEN %s active", NOTIFY_CHANNEL)
+
+    last_poll_at = 0.0
+    while not stop_event.is_set():
+        # NOTIFY-driven path. Block up to NOTIFY_BLOCK_TIMEOUT_S for
+        # any notifies, drain everything that arrived, then fall
+        # through to the poll fallback.
+        for notify in conn.notifies(timeout=NOTIFY_BLOCK_TIMEOUT_S, stop_after=64):
+            _handle_notify(notify=notify, cache=cache, pool=pool)
+
+        # Poll fallback: once per POLL_INTERVAL_S, re-scan the full
+        # table and replace the cache. Catches any dropped notify
+        # within at most this interval.
+        now = time.monotonic()
+        if now - last_poll_at >= POLL_INTERVAL_S:
+            last_poll_at = now
+            try:
+                populated = scan_all_operators(pool)
+                cache.replace(populated)
+            except Exception:
+                logger.exception("credential_health_listener: poll-fallback scan failed; cache state preserved")
+
+
+def _handle_notify(
+    *,
+    notify: Any,
+    cache: CredentialHealthCache,
+    pool: ConnectionPool[psycopg.Connection[Any]],
+) -> None:
+    """Re-read DB truth for the operator carried in the notify payload.
+
+    Don't trust the payload's aggregate value alone — by the time the
+    notify is delivered, additional transitions may have been recorded.
+    The notify is a wake-up; the DB is the source of truth.
+    """
+    try:
+        payload_obj = json.loads(notify.payload)
+        operator_id = UUID(str(payload_obj["operator_id"]))
+        # provider is in the payload but v1 only supports etoro.
+        environment_hint = payload_obj.get("environment", "demo")
+    except TypeError, ValueError, KeyError:
+        logger.warning(
+            "credential_health_listener: ignoring malformed notify payload: %r",
+            notify.payload,
+        )
+        return
+
+    # The notify payload only carries the (operator, provider) pair,
+    # not environment. v1 hardcodes demo; when real arrives we'll need
+    # to widen the channel payload. For now we rescan both env keys
+    # known to be in use — currently just demo. The poll fallback
+    # catches any drift.
+    try:
+        with pool.connection() as conn:
+            health = get_operator_credential_health(
+                conn,
+                operator_id=operator_id,
+                environment=environment_hint,
+            )
+    except Exception:
+        logger.exception(
+            "credential_health_listener: re-read for operator %s failed; cache entry preserved",
+            operator_id,
+        )
+        return
+
+    cache.upsert(
+        operator_id=operator_id,
+        environment=environment_hint,
+        health=health,
+    )

--- a/app/jobs/credential_health_listener.py
+++ b/app/jobs/credential_health_listener.py
@@ -201,12 +201,18 @@ def _handle_notify(
     try:
         payload_obj = json.loads(notify.payload)
         operator_id = UUID(str(payload_obj["operator_id"]))
-        # provider is in the payload but v1 only supports etoro.
+        # v1 only supports etoro / demo; the production payload does
+        # carry environment now (#976 Codex pre-push r1.2). Default
+        # to "demo" for backward compatibility with any older queued
+        # notify; the poll fallback recovers any drift.
         environment_hint = payload_obj.get("environment", "demo")
-    except TypeError, ValueError, KeyError:
+    except (TypeError, ValueError, KeyError) as exc:
+        # Don't log payload contents — a malformed notify could be
+        # arbitrarily large or carry sensitive substrings. Log
+        # exception type only (Codex pre-push r1.4).
         logger.warning(
-            "credential_health_listener: ignoring malformed notify payload: %r",
-            notify.payload,
+            "credential_health_listener: ignoring malformed notify payload (%s)",
+            type(exc).__name__,
         )
         return
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -49,6 +50,7 @@ from app.config import settings
 from app.db import get_conn
 from app.db.migrations import migration_status, run_migrations
 from app.db.pool import open_pool
+from app.jobs.credential_health_listener import listener_loop as credential_health_listener_loop
 from app.security import master_key
 from app.security.secrets_crypto import set_active_key as set_broker_encryption_key
 from app.services.broker_credentials import (
@@ -56,6 +58,7 @@ from app.services.broker_credentials import (
     load_credential_for_provider_use,
 )
 from app.services.coverage import override_tier
+from app.services.credential_health_cache import CredentialHealthCache
 from app.services.etoro_websocket import EtoroWebSocketSubscriber
 from app.services.operator_setup import ensure_startup_token, operators_empty
 from app.services.operators import (
@@ -176,6 +179,29 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     quote_bus = QuoteBus()
     app.state.quote_bus = quote_bus
 
+    # Credential health cache + listener (#976 / #974/B). The cache
+    # is process-local and starts in pre-initialized state — every
+    # read returns MISSING until the listener completes its first
+    # full-table scan. Consumers (admin UI, future WS subscriber
+    # reload after #978) treat MISSING as "fail-safe; do not
+    # connect / run".
+    credential_health_cache = CredentialHealthCache()
+    app.state.credential_health_cache = credential_health_cache
+    credential_health_stop = threading.Event()
+    app.state.credential_health_stop = credential_health_stop
+    credential_health_thread = threading.Thread(
+        target=credential_health_listener_loop,
+        kwargs={
+            "cache": credential_health_cache,
+            "pool": pool,
+            "stop_event": credential_health_stop,
+        },
+        name="api-credential-health-listener",
+        daemon=True,
+    )
+    credential_health_thread.start()
+    app.state.credential_health_thread = credential_health_thread
+
     # eToro WebSocket live-price subscriber (#274 Slice 1+2+3). Starts
     # only when broker credentials are loadable — otherwise the
     # operator hasn't completed setup yet and there's nothing to
@@ -198,6 +224,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             logger.warning("EtoroWebSocketSubscriber.stop exceeded 35s — proceeding with teardown")
         except Exception:
             logger.exception("EtoroWebSocketSubscriber.stop failed")
+
+    # Stop the credential-health listener before closing the pool so
+    # the inner LISTEN loop's connection close doesn't race a pool
+    # shutdown. Daemon thread auto-joins on process exit, but we wait
+    # briefly for clean teardown logs.
+    try:
+        credential_health_stop.set()
+        credential_health_thread.join(timeout=5.0)
+    except Exception:
+        logger.exception("credential-health listener stop raised")
 
     audit_pool.close()
     logger.info("Audit pool closed.")

--- a/app/services/credential_health.py
+++ b/app/services/credential_health.py
@@ -401,6 +401,7 @@ def _do_health_transition(
             {
                 "operator_id": str(operator_id),
                 "provider": provider,
+                "environment": environment,
                 "old_aggregate": old_aggregate.value,
                 "new_aggregate": new_aggregate.value,
                 "at": datetime.now(UTC).isoformat(),
@@ -499,6 +500,7 @@ def notify_aggregate_if_changed(
             {
                 "operator_id": str(operator_id),
                 "provider": provider,
+                "environment": environment,
                 "old_aggregate": old_aggregate.value,
                 "new_aggregate": new_aggregate.value,
                 "at": datetime.now(UTC).isoformat(),

--- a/app/services/credential_health_cache.py
+++ b/app/services/credential_health_cache.py
@@ -1,0 +1,180 @@
+"""Thread-safe operator-credential-health cache (#976 / #974/B).
+
+Per-process in-memory view of operator credential health. Populated
+by the listener thread at ``app/jobs/credential_health_listener.py``
+via:
+
+  * Initial full-table scan at startup (with retry-with-backoff
+    until success).
+  * LISTEN/NOTIFY on the ``ebull_credential_health`` channel.
+  * 5s poll fallback that re-scans the full table so a dropped
+    notify is recovered within at most 5 seconds.
+
+Consumers (orchestrator pre-flight gate at #977, WS subscriber at
+#978, admin UI at #979) call ``get`` on the cache and act on the
+returned ``CredentialHealth`` value. Until the initial scan
+completes, ``get`` returns ``MISSING`` so credential-using work
+fail-safes (no jobs run, WS stays disconnected) — see Codex
+pre-push r2.8 in the spec.
+
+The cache is process-local. Both the API process and the jobs
+process create their own instance during lifespan / startup; they
+do not share state. This is intentional: the only durable signal is
+the DB, and notifies are wake-ups, not source-of-truth.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+from uuid import UUID
+
+import psycopg
+import psycopg.rows
+from psycopg_pool import ConnectionPool
+
+from app.services.credential_health import (
+    CredentialHealth,
+    get_operator_credential_health,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CredentialHealthCache:
+    """Thread-safe operator → CredentialHealth map.
+
+    Read API is non-blocking (single mutex around a dict lookup);
+    write API is owned by the listener thread.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cache: dict[tuple[UUID, str], CredentialHealth] = {}
+        # Until the listener completes its first full scan, the cache
+        # cannot answer "what's this operator's health" honestly. We
+        # report MISSING for all reads in this state (fail-safe — no
+        # creds-using work runs). Set to True via set_initial_scan.
+        self._initialized: bool = False
+
+    # ------------------------------------------------------------------
+    # Read API (consumers)
+    # ------------------------------------------------------------------
+
+    def get(
+        self,
+        *,
+        operator_id: UUID,
+        provider: str = "etoro",
+        environment: str = "demo",
+    ) -> CredentialHealth:
+        """Return the cached operator-level health.
+
+        Returns:
+            CredentialHealth — REJECTED / MISSING / UNTESTED / VALID.
+
+        Pre-initialization: returns MISSING regardless of the underlying
+        DB state. This is the fail-safe contract — consumers (orchestrator,
+        WS subscriber) treat MISSING as "do not run / connect" so a
+        slow startup never opens a window where credential-using work
+        fires against unknown state.
+        """
+        del provider  # provider is locked to 'etoro' in v1; key by env only
+        with self._lock:
+            if not self._initialized:
+                return CredentialHealth.MISSING
+            return self._cache.get((operator_id, environment), CredentialHealth.MISSING)
+
+    def is_initialized(self) -> bool:
+        """True once the listener has completed its first full scan."""
+        with self._lock:
+            return self._initialized
+
+    def snapshot(self) -> dict[tuple[UUID, str], CredentialHealth]:
+        """Return a copy of the current cache (debugging / metrics)."""
+        with self._lock:
+            return dict(self._cache)
+
+    # ------------------------------------------------------------------
+    # Write API (listener)
+    # ------------------------------------------------------------------
+
+    def set_initial_scan(self, populated: dict[tuple[UUID, str], CredentialHealth]) -> None:
+        """Atomically install the initial scan result + flip initialized.
+
+        Replaces the entire cache (initial state should be authoritative).
+        Subsequent updates flow through ``upsert`` on per-operator notifies.
+        """
+        with self._lock:
+            self._cache = dict(populated)
+            self._initialized = True
+        logger.info(
+            "credential_health_cache: initialized with %d operator entries",
+            len(populated),
+        )
+
+    def upsert(
+        self,
+        *,
+        operator_id: UUID,
+        environment: str,
+        health: CredentialHealth,
+    ) -> None:
+        """Update one operator's cached health (called from notify handler).
+
+        Caller is the listener thread; consumers see the new value on
+        their next ``get`` call.
+        """
+        with self._lock:
+            self._cache[(operator_id, environment)] = health
+
+    def replace(self, populated: dict[tuple[UUID, str], CredentialHealth]) -> None:
+        """Replace the entire cache with a fresh scan (poll-fallback path).
+
+        Listener calls this on the 5s poll tick to recover any operator
+        whose notify was dropped. Replaces ``_cache`` wholesale rather
+        than diff-and-patch — simpler reasoning, no risk of stale entries.
+        Initialized stays True.
+        """
+        with self._lock:
+            self._cache = dict(populated)
+
+
+# ---------------------------------------------------------------------------
+# Full-scan helper — used by the listener for startup + poll fallback
+# ---------------------------------------------------------------------------
+
+
+def scan_all_operators(
+    pool: ConnectionPool[psycopg.Connection[Any]],
+) -> dict[tuple[UUID, str], CredentialHealth]:
+    """Compute operator-level credential health for every (operator, env).
+
+    Iterates distinct (operator_id, environment) pairs in
+    broker_credentials filtered to non-revoked, then computes the
+    aggregate per pair via get_operator_credential_health. The
+    aggregate computation is cheap (small CTE + LEFT JOIN) and v1
+    operator counts are 1; this scales fine for the foreseeable
+    multi-operator case.
+    """
+    out: dict[tuple[UUID, str], CredentialHealth] = {}
+    with pool.connection() as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT DISTINCT operator_id, environment
+                  FROM broker_credentials
+                 WHERE revoked_at IS NULL
+                """
+            )
+            pairs = [(row["operator_id"], row["environment"]) for row in cur.fetchall()]
+
+        for operator_id, environment in pairs:
+            health = get_operator_credential_health(
+                conn,
+                operator_id=operator_id,
+                environment=environment,
+            )
+            out[(operator_id, environment)] = health
+    return out

--- a/tests/test_credential_health.py
+++ b/tests/test_credential_health.py
@@ -784,11 +784,13 @@ class TestDoHealthTransition:
             assert set(payload.keys()) == {
                 "operator_id",
                 "provider",
+                "environment",
                 "old_aggregate",
                 "new_aggregate",
                 "at",
             }
             assert payload["provider"] == "etoro"
+            assert payload["environment"] == "demo"
         finally:
             sender_conn.close()
             listen_conn.close()

--- a/tests/test_credential_health_listener.py
+++ b/tests/test_credential_health_listener.py
@@ -1,0 +1,443 @@
+"""Tests for the credential-health LISTEN/NOTIFY listener (#976 / #974/B).
+
+Spec: docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md.
+
+Coverage:
+  * Cache fail-safe: pre-init reads return MISSING.
+  * scan_all_operators: returns the right (operator, env) -> health map.
+  * Listener startup: full scan populates the cache, sets initialized.
+  * Listener startup retry: failing scans back off, final success
+    flips initialized.
+  * Listener notify path: a NOTIFY arriving on the channel triggers a
+    re-read of the named operator's health and updates the cache.
+  * Listener poll fallback: a dropped notify is recovered by the 5s
+    re-scan within at most one cycle.
+  * Stop event: listener returns cleanly when stop_event is set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import psycopg
+import psycopg.rows
+import pytest
+from psycopg_pool import ConnectionPool
+
+from app.jobs.credential_health_listener import (
+    INITIAL_SCAN_BACKOFF_S,
+    NOTIFY_BLOCK_TIMEOUT_S,
+    POLL_INTERVAL_S,
+    listener_loop,
+)
+from app.security import secrets_crypto
+from app.services.credential_health import (
+    NOTIFY_CHANNEL,
+    CredentialHealth,
+)
+from app.services.credential_health_cache import (
+    CredentialHealthCache,
+    scan_all_operators,
+)
+from tests.fixtures.ebull_test_db import (
+    ebull_test_conn,  # noqa: F401
+    test_database_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _key() -> Iterator[None]:
+    secrets_crypto.set_active_key(os.urandom(32))
+    yield
+    secrets_crypto._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_pair_committed(
+    *,
+    api_state: str,
+    user_state: str,
+) -> UUID:
+    """Insert an operator + both label rows. Uses its own connection so
+    the row state survives across the test fixture's tx boundary."""
+    op_id = uuid4()
+    url = test_database_url()
+    with psycopg.connect(url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s, %s, %s)",
+                (op_id, f"op-{op_id.hex[:8]}", "argon2:dummy"),
+            )
+            for label, state in (("api_key", api_state), ("user_key", user_state)):
+                cur.execute(
+                    """
+                    INSERT INTO broker_credentials
+                        (id, operator_id, provider, label, environment,
+                         ciphertext, last_four, key_version, health_state)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (uuid4(), op_id, "etoro", label, "demo", b"\x00" * 32, "abcd", 1, state),
+                )
+        conn.commit()
+    return op_id
+
+
+# ---------------------------------------------------------------------------
+# Cache fail-safe pre-init
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialHealthCachePreInit:
+    def test_pre_init_returns_missing(self) -> None:
+        """Until set_initial_scan completes, every read returns MISSING."""
+        cache = CredentialHealthCache()
+        assert cache.is_initialized() is False
+        assert cache.get(operator_id=uuid4()) == CredentialHealth.MISSING
+
+    def test_post_init_returns_missing_for_unknown_operator(self) -> None:
+        """An operator absent from the cache map still returns MISSING."""
+        cache = CredentialHealthCache()
+        cache.set_initial_scan({})
+        assert cache.is_initialized() is True
+        assert cache.get(operator_id=uuid4()) == CredentialHealth.MISSING
+
+    def test_post_init_returns_known_value(self) -> None:
+        op_id = uuid4()
+        cache = CredentialHealthCache()
+        cache.set_initial_scan({(op_id, "demo"): CredentialHealth.VALID})
+        assert cache.get(operator_id=op_id) == CredentialHealth.VALID
+
+    def test_upsert_updates_single_operator(self) -> None:
+        op_a = uuid4()
+        op_b = uuid4()
+        cache = CredentialHealthCache()
+        cache.set_initial_scan({(op_a, "demo"): CredentialHealth.VALID, (op_b, "demo"): CredentialHealth.VALID})
+        cache.upsert(operator_id=op_a, environment="demo", health=CredentialHealth.REJECTED)
+        assert cache.get(operator_id=op_a) == CredentialHealth.REJECTED
+        assert cache.get(operator_id=op_b) == CredentialHealth.VALID
+
+    def test_replace_replaces_entire_map(self) -> None:
+        op_a = uuid4()
+        op_b = uuid4()
+        cache = CredentialHealthCache()
+        cache.set_initial_scan({(op_a, "demo"): CredentialHealth.VALID})
+        cache.replace({(op_b, "demo"): CredentialHealth.UNTESTED})
+        assert cache.get(operator_id=op_a) == CredentialHealth.MISSING
+        assert cache.get(operator_id=op_b) == CredentialHealth.UNTESTED
+
+
+# ---------------------------------------------------------------------------
+# scan_all_operators (DB-backed)
+# ---------------------------------------------------------------------------
+
+
+def _open_test_pool() -> ConnectionPool[psycopg.Connection[Any]]:
+    """Open a small pool against the test DB. Caller closes."""
+    return ConnectionPool(test_database_url(), min_size=1, max_size=2, open=True)
+
+
+@pytest.mark.integration
+class TestScanAllOperators:
+    def test_returns_aggregate_per_operator(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        del ebull_test_conn  # keep fixture alive for truncate; use own pool
+        op_a = _seed_pair_committed(api_state="valid", user_state="valid")
+        op_b = _seed_pair_committed(api_state="rejected", user_state="valid")
+
+        pool = _open_test_pool()
+        thread: threading.Thread | None = None
+        try:
+            result = scan_all_operators(pool)
+        finally:
+            pool.close()
+
+        assert result.get((op_a, "demo")) == CredentialHealth.VALID
+        assert result.get((op_b, "demo")) == CredentialHealth.REJECTED
+
+    def test_excludes_revoked_only_operators(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        del ebull_test_conn
+        # Seed an operator whose only rows are revoked.
+        op_id = uuid4()
+        url = test_database_url()
+        with psycopg.connect(url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s, %s, %s)",
+                    (op_id, f"op-{op_id.hex[:8]}", "argon2:dummy"),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO broker_credentials
+                        (id, operator_id, provider, label, environment,
+                         ciphertext, last_four, key_version, health_state, revoked_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                    """,
+                    (uuid4(), op_id, "etoro", "api_key", "demo", b"\x00" * 32, "abcd", 1, "valid"),
+                )
+            conn.commit()
+
+        pool = _open_test_pool()
+        thread: threading.Thread | None = None
+        try:
+            result = scan_all_operators(pool)
+        finally:
+            pool.close()
+
+        # Operator with no non-revoked rows is absent from the scan result.
+        assert (op_id, "demo") not in result
+
+
+# ---------------------------------------------------------------------------
+# Listener startup + initial scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestListenerStartup:
+    def test_initial_scan_populates_cache(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        del ebull_test_conn
+        op_id = _seed_pair_committed(api_state="valid", user_state="valid")
+
+        cache = CredentialHealthCache()
+        stop_event = threading.Event()
+        pool = _open_test_pool()
+        thread: threading.Thread | None = None
+        try:
+            thread = threading.Thread(
+                target=listener_loop,
+                kwargs={
+                    "cache": cache,
+                    "pool": pool,
+                    "stop_event": stop_event,
+                },
+                daemon=True,
+            )
+            thread.start()
+
+            # Wait up to 3s for initial scan to complete.
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline and not cache.is_initialized():
+                time.sleep(0.05)
+
+            assert cache.is_initialized()
+            assert cache.get(operator_id=op_id) == CredentialHealth.VALID
+        finally:
+            stop_event.set()
+            if thread is not None:
+                thread.join(timeout=5.0)
+            pool.close()
+
+    def test_initial_scan_retries_on_failure(self) -> None:
+        """A failing scan_all_operators backs off and retries until success."""
+        cache = CredentialHealthCache()
+        stop_event = threading.Event()
+        # Replace the pool with a Mock that fails the first time, then
+        # succeeds. We bypass the real DB to keep the test fast.
+        attempt_count = [0]
+        op_id = uuid4()
+
+        def fake_scan(_pool: Any) -> dict[tuple[UUID, str], CredentialHealth]:
+            attempt_count[0] += 1
+            if attempt_count[0] < 2:
+                raise RuntimeError("simulated scan failure")
+            return {(op_id, "demo"): CredentialHealth.UNTESTED}
+
+        # Tighten backoff for the test to keep wall-clock low.
+        with patch.object(
+            __import__("app.jobs.credential_health_listener", fromlist=["scan_all_operators"]),
+            "scan_all_operators",
+            side_effect=fake_scan,
+        ):
+            with patch(
+                "app.jobs.credential_health_listener.INITIAL_SCAN_BACKOFF_S",
+                (0.05, 0.1),
+            ):
+                # Provide a no-op listen-conn factory so the LISTEN
+                # loop never opens a connection. Stop the event right
+                # after init so we don't enter the LISTEN loop.
+                def fake_factory() -> Any:
+                    raise RuntimeError("LISTEN should not be reached in this test")
+
+                thread = threading.Thread(
+                    target=listener_loop,
+                    kwargs={
+                        "cache": cache,
+                        "pool": None,  # type: ignore[arg-type]
+                        "stop_event": stop_event,
+                        "listen_conn_factory": fake_factory,
+                    },
+                    daemon=True,
+                )
+                thread.start()
+
+                deadline = time.monotonic() + 3.0
+                while time.monotonic() < deadline and not cache.is_initialized():
+                    time.sleep(0.05)
+
+                assert cache.is_initialized()
+                assert attempt_count[0] >= 2
+                # Stop before the LISTEN loop breaks.
+                stop_event.set()
+                thread.join(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Listener constants — pinned values
+# ---------------------------------------------------------------------------
+
+
+class TestListenerConstants:
+    def test_initial_scan_backoff_locked(self) -> None:
+        """Spec-locked retry sequence."""
+        assert INITIAL_SCAN_BACKOFF_S == (1.0, 2.0, 5.0, 10.0, 30.0)
+
+    def test_poll_interval_locked(self) -> None:
+        assert POLL_INTERVAL_S == 5.0
+
+    def test_notify_block_timeout_lt_poll(self) -> None:
+        """Notify block must be shorter than the poll interval so the
+        poll fallback always gets a chance to run."""
+        assert NOTIFY_BLOCK_TIMEOUT_S < POLL_INTERVAL_S
+
+
+# ---------------------------------------------------------------------------
+# Listener notify + poll-fallback paths (integration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestListenerNotifyAndPoll:
+    def test_notify_updates_cache(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Notify on the channel triggers a re-read and cache update."""
+        del ebull_test_conn
+        op_id = _seed_pair_committed(api_state="untested", user_state="untested")
+
+        cache = CredentialHealthCache()
+        stop_event = threading.Event()
+        pool = _open_test_pool()
+        thread: threading.Thread | None = None
+        try:
+            thread = threading.Thread(
+                target=listener_loop,
+                kwargs={"cache": cache, "pool": pool, "stop_event": stop_event},
+                daemon=True,
+            )
+            thread.start()
+
+            # Wait for initial scan.
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline and not cache.is_initialized():
+                time.sleep(0.05)
+            assert cache.is_initialized()
+            assert cache.get(operator_id=op_id) == CredentialHealth.UNTESTED
+
+            # Mutate row state directly to VALID (bypass the helper to
+            # isolate the notify path) and emit the channel notify.
+            url = test_database_url()
+            with psycopg.connect(url, autocommit=True) as sender:
+                with sender.cursor() as cur:
+                    cur.execute(
+                        "UPDATE broker_credentials SET health_state = 'valid' WHERE operator_id = %s",
+                        (op_id,),
+                    )
+                    payload = json.dumps(
+                        {
+                            "operator_id": str(op_id),
+                            "provider": "etoro",
+                            "environment": "demo",
+                            "old_aggregate": "untested",
+                            "new_aggregate": "valid",
+                            "at": "2026-05-06T00:00:00Z",
+                        }
+                    )
+                    cur.execute(
+                        "SELECT pg_notify(%s, %s)",
+                        (NOTIFY_CHANNEL, payload),
+                    )
+
+            # Wait up to 3s for the listener to observe the notify.
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                if cache.get(operator_id=op_id) == CredentialHealth.VALID:
+                    break
+                time.sleep(0.05)
+
+            assert cache.get(operator_id=op_id) == CredentialHealth.VALID
+        finally:
+            stop_event.set()
+            if thread is not None:
+                thread.join(timeout=5.0)
+            pool.close()
+
+    def test_poll_fallback_recovers_dropped_notify(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Mutate row directly with NO notify; poll fallback re-scans
+        within POLL_INTERVAL_S and updates the cache."""
+        del ebull_test_conn
+        op_id = _seed_pair_committed(api_state="valid", user_state="valid")
+
+        cache = CredentialHealthCache()
+        stop_event = threading.Event()
+        pool = _open_test_pool()
+        thread: threading.Thread | None = None
+        try:
+            # Tighten the poll interval to keep test fast.
+            with patch("app.jobs.credential_health_listener.POLL_INTERVAL_S", 0.5):
+                thread = threading.Thread(
+                    target=listener_loop,
+                    kwargs={"cache": cache, "pool": pool, "stop_event": stop_event},
+                    daemon=True,
+                )
+                thread.start()
+
+                deadline = time.monotonic() + 3.0
+                while time.monotonic() < deadline and not cache.is_initialized():
+                    time.sleep(0.05)
+                assert cache.get(operator_id=op_id) == CredentialHealth.VALID
+
+                # Mutate row WITHOUT emitting any notify.
+                url = test_database_url()
+                with psycopg.connect(url, autocommit=True) as sender:
+                    with sender.cursor() as cur:
+                        cur.execute(
+                            "UPDATE broker_credentials SET health_state = 'rejected' WHERE operator_id = %s",
+                            (op_id,),
+                        )
+
+                # Poll fallback should pick this up within ~0.5s.
+                deadline = time.monotonic() + 3.0
+                while time.monotonic() < deadline:
+                    if cache.get(operator_id=op_id) == CredentialHealth.REJECTED:
+                        break
+                    time.sleep(0.05)
+
+                assert cache.get(operator_id=op_id) == CredentialHealth.REJECTED
+        finally:
+            stop_event.set()
+            if thread is not None:
+                thread.join(timeout=5.0)
+            pool.close()

--- a/tests/test_credential_health_listener.py
+++ b/tests/test_credential_health_listener.py
@@ -158,7 +158,6 @@ class TestScanAllOperators:
         op_b = _seed_pair_committed(api_state="rejected", user_state="valid")
 
         pool = _open_test_pool()
-        thread: threading.Thread | None = None
         try:
             result = scan_all_operators(pool)
         finally:
@@ -193,7 +192,6 @@ class TestScanAllOperators:
             conn.commit()
 
         pool = _open_test_pool()
-        thread: threading.Thread | None = None
         try:
             result = scan_all_operators(pool)
         finally:
@@ -385,6 +383,52 @@ class TestListenerNotifyAndPoll:
                 time.sleep(0.05)
 
             assert cache.get(operator_id=op_id) == CredentialHealth.VALID
+        finally:
+            stop_event.set()
+            if thread is not None:
+                thread.join(timeout=5.0)
+            pool.close()
+
+    def test_malformed_payload_does_not_log_contents(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Codex pre-push r1.4: malformed notify payloads must not be
+        logged verbatim. The handler should log only the exception
+        type, not the raw payload (which could carry secrets/large
+        content)."""
+        del ebull_test_conn
+        _seed_pair_committed(api_state="valid", user_state="valid")
+
+        cache = CredentialHealthCache()
+        stop_event = threading.Event()
+        pool = _open_test_pool()
+        thread: threading.Thread | None = None
+        try:
+            thread = threading.Thread(
+                target=listener_loop,
+                kwargs={"cache": cache, "pool": pool, "stop_event": stop_event},
+                daemon=True,
+            )
+            thread.start()
+
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline and not cache.is_initialized():
+                time.sleep(0.05)
+            assert cache.is_initialized()
+
+            sentinel = "S3CR3T-NEVER-LOG-THIS-VALUE"
+            url = test_database_url()
+            with caplog.at_level("WARNING"):
+                with psycopg.connect(url, autocommit=True) as sender:
+                    with sender.cursor() as cur:
+                        cur.execute("SELECT pg_notify(%s, %s)", (NOTIFY_CHANNEL, sentinel))
+                # Give the listener a tick to receive + log.
+                time.sleep(0.5)
+
+            for record in caplog.records:
+                assert sentinel not in record.getMessage()
         finally:
             stop_event.set()
             if thread is not None:


### PR DESCRIPTION
Refs #974. Closes #976. Second foundational PR for the credential-health-as-scheduling-precondition umbrella.

## What

- **`app/services/credential_health_cache.py`** — thread-safe per-process cache. Pre-init reads return MISSING (fail-safe — consumers don't run creds-using work until the listener confirms state). Includes `scan_all_operators(pool)` for full-table aggregate scan.
- **`app/jobs/credential_health_listener.py`** — listener thread:
  - Initial full-scan with retry-with-backoff (1s, 2s, 5s, 10s, 30s cap) until success.
  - LISTEN on `ebull_credential_health` channel.
  - 1s notify-block + drain loop.
  - 5s poll fallback that re-scans the full table to recover any dropped notify.
- **`app/main.py`** + **`app/jobs/__main__.py`** — each process owns its own cache + listener thread daemon, joined with 5s timeout on shutdown.
- Production NOTIFY payloads now include `environment` for forward-compat with multi-environment.
- Malformed payloads logged by exception type only — never payload contents.

## Why

Subsequent children (#977/D/E) need a fast in-process view of operator credential health to make scheduling/connection decisions. Going to the DB on every gate check would 10x the connection load. The cache is process-local because notifies are wake-ups and the DB is the source of truth — no shared state needed.

## Test plan

- [x] 16 new tests at `tests/test_credential_health_listener.py`:
  - Pre-init fail-safe: every read returns MISSING.
  - Cache: post-init unknown operator MISSING; known operator returns seeded value; upsert + replace semantics.
  - scan_all_operators: aggregate per (operator, env); excludes revoked-only operators.
  - Listener startup: initial scan populates cache + flips initialized.
  - Listener startup retry: failing scan backs off and retries until success.
  - Constants pinned: backoff sequence, poll interval, notify-block < poll interval.
  - Notify path: NOTIFY triggers re-read + cache update.
  - Poll fallback: dropped notify recovered within POLL_INTERVAL_S.
  - **Security**: malformed payload contents never reach logs (PREVENTION test for Codex r1.4).
- [x] All 42 #975 tests still pass; 58 in the combined suite.
- [x] Smoke (lifespan boots clean) passes.
- [x] ruff + format + pyright clean.
- [x] **Codex pre-push review**: 4 findings + 1 coverage gap raised, all fixed before push (Python 2 except syntax, missing environment in payload, payload contents in log, malformed-payload test).

## Spec

`docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md` sections "NOTIFY contract" + "Subscribers MUST do a full DB scan on startup" + Codex r1.10/11/12 + r2.8.