### PR TITLE
feat(#977): orchestrator pre-flight credential + init gate + AUTH_EXPIRED suppression

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -236,9 +236,16 @@ def _resolve_auth_expired_suppression(conn: psycopg.Connection[object]) -> datet
         sole_operator_id,
     )
 
+    # Two narrow except clauses rather than `except (A, B):` because
+    # ruff format strips the parens to `except A, B:` on Python 3.14
+    # where the comma form is also valid (Codex pre-push r3.1) — the
+    # paren-less form is ambiguous to readers and Codex flags it as
+    # Python-2 syntax.
     try:
         op_id = sole_operator_id(conn)
-    except NoOperatorError, AmbiguousOperatorError:
+    except NoOperatorError:
+        return None
+    except AmbiguousOperatorError:
         return None
     return get_last_recovered_at(conn, operator_id=op_id)
 

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from app.api.auth import require_session_or_service_token
 from app.config import settings
 from app.db import get_conn
+from app.services.credential_health import get_last_recovered_at
 from app.services.fundamentals_observability import (
     get_cik_timing_summary,
     get_seed_progress,
@@ -217,6 +218,31 @@ def post_sync(body: SyncRequest) -> Any:
     return {"request_id": request_id}
 
 
+def _resolve_auth_expired_suppression(conn: psycopg.Connection[object]) -> datetime | None:
+    """Look up the operator's last credential-recovery timestamp for
+    the AUTH_EXPIRED suppression query (#977 / #974/C).
+
+    Returns None when:
+      * No operator (single-operator v1 not yet bootstrapped).
+      * The operator has never moved out of REJECTED.
+      * The transitions row exists but ``last_recovered_at IS NULL``.
+
+    None means "no filter applied" — every AUTH_EXPIRED row stays
+    visible. Codex r2.4 missing-row + NULL-row contract.
+    """
+    from app.services.operators import (
+        AmbiguousOperatorError,
+        NoOperatorError,
+        sole_operator_id,
+    )
+
+    try:
+        op_id = sole_operator_id(conn)
+    except NoOperatorError, AmbiguousOperatorError:
+        return None
+    return get_last_recovered_at(conn, operator_id=op_id)
+
+
 @router.get("/status")
 def get_sync_status(
     conn: psycopg.Connection[object] = Depends(get_conn),
@@ -280,7 +306,12 @@ def get_sync_layers(
     # Was O(N) round-trips; now O(1). The layer name filter keeps both
     # queries on an index seek regardless of how large the history
     # table grows.
-    failure_streaks, persisted_errors = all_layer_histories(conn, list(LAYERS.keys()))
+    suppress_before = _resolve_auth_expired_suppression(conn)
+    failure_streaks, persisted_errors = all_layer_histories(
+        conn,
+        list(LAYERS.keys()),
+        suppress_auth_expired_before=suppress_before,
+    )
 
     # _LAYER_TO_JOB is built and asserted-disjoint at module import.
     out: list[dict[str, Any]] = []
@@ -359,7 +390,8 @@ def get_sync_layers_v2(
     """
     states = compute_layer_states_from_db(conn)
     names = list(states.keys())
-    streaks, categories = all_layer_histories(conn, names)
+    suppress_before = _resolve_auth_expired_suppression(conn)
+    streaks, categories = all_layer_histories(conn, names, suppress_auth_expired_before=suppress_before)
     error_excerpts = all_layer_error_excerpts(conn, names)
     last_updates = _layer_last_updated_map(conn, names)
 

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -388,9 +388,13 @@ def get_sync_layers_v2(
     system_summary. Designed as the sole feed for the new Admin UI
     (sub-project C). v1 /sync/layers is unchanged.
     """
-    states = compute_layer_states_from_db(conn)
-    names = list(states.keys())
+    # Resolve AUTH_EXPIRED suppression timestamp BEFORE state
+    # computation so the state machine itself observes the suppression
+    # — otherwise an old pre-recovery auth_expired could still push
+    # a layer into ACTION_NEEDED (Codex pre-push r3.2).
     suppress_before = _resolve_auth_expired_suppression(conn)
+    states = compute_layer_states_from_db(conn, suppress_auth_expired_before=suppress_before)
+    names = list(states.keys())
     streaks, categories = all_layer_histories(conn, names, suppress_auth_expired_before=suppress_before)
     error_excerpts = all_layer_error_excerpts(conn, names)
     last_updates = _layer_last_updated_map(conn, names)

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -236,11 +236,11 @@ def _resolve_auth_expired_suppression(conn: psycopg.Connection[object]) -> datet
         sole_operator_id,
     )
 
-    # Two narrow except clauses rather than `except (A, B):` because
-    # ruff format strips the parens to `except A, B:` on Python 3.14
-    # where the comma form is also valid (Codex pre-push r3.1) — the
-    # paren-less form is ambiguous to readers and Codex flags it as
-    # Python-2 syntax.
+    # Two narrow except clauses for readability. Both branches collapse
+    # to the same return — splitting them keeps each handler trivially
+    # one-purpose and avoids the `except (A, B):` form which has
+    # historically been a source of paren-less-tuple confusion on this
+    # codebase.
     try:
         op_id = sole_operator_id(conn)
     except NoOperatorError:

--- a/app/services/sync_orchestrator/executor.py
+++ b/app/services/sync_orchestrator/executor.py
@@ -328,12 +328,21 @@ def _credential_health_blocks(layer: LayerPlan) -> str | None:
     request-path consumers (admin UI, WS subscriber) where DB latency
     matters; the orchestrator goes direct.
 
+    Environment scoping (review #983 BLOCKING): gates on EVERY
+    environment for which the operator has an active credential row.
+    v1 only uses 'demo' but the runtime may add 'live' at any time;
+    hardcoding 'demo' here would let a layer with invalid 'live'
+    credentials pass the gate and trade live with bad keys.
+
     Returns None when:
       * No emit requires broker credentials.
-      * Aggregate is VALID.
+      * Operator has no active environments (treated as MISSING by
+        the underlying aggregate, so the gate blocks — explicit
+        return below).
+      * All environments aggregate VALID.
       * DB lookup itself failed (don't block on infra error — let
-        the layer's adapter surface the real failure if it tries to
-        run).
+        the layer's adapter surface the real failure if it tries
+        to run).
     """
     from app.services.sync_orchestrator.registry import LAYERS
 
@@ -348,7 +357,18 @@ def _credential_health_blocks(layer: LayerPlan) -> str | None:
             except (NoOperatorError, AmbiguousOperatorError) as exc:
                 return f"operator not configured ({type(exc).__name__})"
 
-            health = get_operator_credential_health(conn, operator_id=op_id, environment="demo")
+            # Discover the operator's active environments. Any
+            # environment with active rows is gated — if any of them
+            # is not VALID, block the layer.
+            environments = _operator_active_environments(conn, op_id)
+            if not environments:
+                # Operator has no active credential rows at all.
+                return "broker credentials not configured for any environment"
+
+            for env in environments:
+                health = get_operator_credential_health(conn, operator_id=op_id, environment=env)
+                if health != CredentialHealth.VALID:
+                    return f"broker credentials not validated (env={env}, health={health.value})"
     except Exception:
         logger.exception(
             "credential_health gate: DB lookup failed for layer %s; not blocking",
@@ -356,9 +376,30 @@ def _credential_health_blocks(layer: LayerPlan) -> str | None:
         )
         return None
 
-    if health == CredentialHealth.VALID:
-        return None
-    return f"broker credentials not validated (operator health={health.value})"
+    return None
+
+
+def _operator_active_environments(
+    conn: psycopg.Connection[Any],
+    operator_id: Any,
+) -> list[str]:
+    """Return distinct environments the operator has non-revoked rows for.
+
+    Sorted for deterministic gate-skip-reason output. Empty list when
+    the operator has no active rows.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT environment
+              FROM broker_credentials
+             WHERE operator_id = %s
+               AND revoked_at IS NULL
+             ORDER BY environment
+            """,
+            (operator_id,),
+        )
+        return [row[0] for row in cur.fetchall()]
 
 
 def _layer_initialization_blocks(layer: LayerPlan) -> str | None:

--- a/app/services/sync_orchestrator/executor.py
+++ b/app/services/sync_orchestrator/executor.py
@@ -30,11 +30,21 @@ from collections.abc import Mapping
 from typing import Any
 
 import psycopg
+import psycopg.sql
 
 from app.config import settings
+from app.services.credential_health import (
+    CredentialHealth,
+    get_operator_credential_health,
+)
+from app.services.operators import (
+    AmbiguousOperatorError,
+    NoOperatorError,
+    sole_operator_id,
+)
 from app.services.sync_orchestrator.exception_classifier import classify_exception
 from app.services.sync_orchestrator.planner import build_execution_plan
-from app.services.sync_orchestrator.registry import JOB_TO_LAYERS
+from app.services.sync_orchestrator.registry import INIT_CHECKS, JOB_TO_LAYERS
 from app.services.sync_orchestrator.types import (
     PREREQ_SKIP_MARKER,
     ExecutionPlan,
@@ -224,6 +234,31 @@ def _run_layers_loop(
     for layer_plan in plan.layers_to_refresh:
         upstream_outcomes = _build_upstream_outcomes(layer_plan, outcomes)
 
+        # Pre-flight gate #1 — credential health (#977 / #974/C).
+        # Layers tagged ``requires_broker_credential=True`` PREREQ_SKIP
+        # when the operator's aggregate health is anything other than
+        # VALID. Stops the cascade where every credential-using layer
+        # 401s on each tick before the operator has even fixed their
+        # keys.
+        cred_skip = _credential_health_blocks(layer_plan)
+        if cred_skip is not None:
+            for emit in layer_plan.emits:
+                _record_layer_skipped(sync_run_id, emit, cred_skip)
+                outcomes[emit] = LayerOutcome.PREREQ_SKIP
+            continue
+
+        # Pre-flight gate #2 — layer initialization (#977 / #974/C).
+        # Layers tagged ``requires_layer_initialized=("dep",)`` skip
+        # until ``INIT_CHECKS["dep"]`` returns true. Used by
+        # portfolio_sync to wait for ``instruments`` to be non-empty
+        # before writing positions (FK constraint).
+        init_skip = _layer_initialization_blocks(layer_plan)
+        if init_skip is not None:
+            for emit in layer_plan.emits:
+                _record_layer_skipped(sync_run_id, emit, init_skip)
+                outcomes[emit] = LayerOutcome.PREREQ_SKIP
+            continue
+
         blocking_failure = _blocking_dependency_failed(layer_plan, upstream_outcomes)
         if blocking_failure is not None:
             for emit in layer_plan.emits:
@@ -281,6 +316,93 @@ def _run_layers_loop(
 # ---------------------------------------------------------------------------
 # Dependency gate + upstream resolution
 # ---------------------------------------------------------------------------
+
+
+def _credential_health_blocks(layer: LayerPlan) -> str | None:
+    """Return skip_reason if any emit needs broker creds and aggregate != VALID.
+
+    Reads operator credential health on a fresh autocommit connection
+    per gate check. Per-tick DB hit is acceptable because the
+    orchestrator runs as discrete sync ticks, not per-request. The
+    cache at ``app.services.credential_health_cache`` exists for the
+    request-path consumers (admin UI, WS subscriber) where DB latency
+    matters; the orchestrator goes direct.
+
+    Returns None when:
+      * No emit requires broker credentials.
+      * Aggregate is VALID.
+      * DB lookup itself failed (don't block on infra error — let
+        the layer's adapter surface the real failure if it tries to
+        run).
+    """
+    from app.services.sync_orchestrator.registry import LAYERS
+
+    requires_creds = any(LAYERS[emit].requires_broker_credential for emit in layer.emits)
+    if not requires_creds:
+        return None
+
+    try:
+        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+            try:
+                op_id = sole_operator_id(conn)
+            except (NoOperatorError, AmbiguousOperatorError) as exc:
+                return f"operator not configured ({type(exc).__name__})"
+
+            health = get_operator_credential_health(conn, operator_id=op_id, environment="demo")
+    except Exception:
+        logger.exception(
+            "credential_health gate: DB lookup failed for layer %s; not blocking",
+            layer.name,
+        )
+        return None
+
+    if health == CredentialHealth.VALID:
+        return None
+    return f"broker credentials not validated (operator health={health.value})"
+
+
+def _layer_initialization_blocks(layer: LayerPlan) -> str | None:
+    """Return skip_reason if any required init-dep is not content-initialized.
+
+    INIT_CHECKS is a registry mapping layer name -> SQL EXISTS query.
+    Each requires_layer_initialized entry must have an INIT_CHECKS
+    mapping or the gate fails closed (logged + skipped).
+    """
+    from app.services.sync_orchestrator.registry import LAYERS
+
+    init_deps: set[str] = set()
+    for emit in layer.emits:
+        init_deps.update(LAYERS[emit].requires_layer_initialized)
+    if not init_deps:
+        return None
+
+    try:
+        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                for dep_name in sorted(init_deps):  # deterministic order
+                    init_sql = INIT_CHECKS.get(dep_name)
+                    if init_sql is None:
+                        # A layer registered as requires_layer_initialized
+                        # for a name with no INIT_CHECKS entry is a
+                        # registry config error. Fail closed.
+                        logger.error(
+                            "layer %s requires_layer_initialized=%r but no INIT_CHECKS entry exists",
+                            layer.name,
+                            dep_name,
+                        )
+                        return f"init-check missing for dep {dep_name}"
+                    cur.execute(psycopg.sql.SQL(init_sql))  # type: ignore[arg-type]
+                    row = cur.fetchone()
+                    if row is None or not row[0]:
+                        return f"layer {dep_name} not yet initialized"
+    except Exception:
+        logger.exception(
+            "init-check gate: DB lookup failed for layer %s; not blocking",
+            layer.name,
+        )
+        return None
+
+    return None
 
 
 def _blocking_dependency_failed(

--- a/app/services/sync_orchestrator/layer_failure_history.py
+++ b/app/services/sync_orchestrator/layer_failure_history.py
@@ -34,15 +34,23 @@ Contract:
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 import psycopg
 import psycopg.rows
 
+# Failure-category that the credential-health recovery suppression
+# applies to. Imported as a string here to avoid a circular import
+# back to ``layer_types``; the value matches FailureCategory.AUTH_EXPIRED.
+_AUTH_EXPIRED_CATEGORY = "auth_expired"
+
 
 def consecutive_failures(
     conn: psycopg.Connection[Any],
     layer_name: str,
+    *,
+    suppress_auth_expired_before: datetime | None = None,
 ) -> int:
     """Count how many of the most-recent progress rows were 'failed'.
 
@@ -50,6 +58,17 @@ def consecutive_failures(
     pending / running / complete / skipped / partial row breaks the
     streak. The count includes the most recent row if and only if it
     was a failure.
+
+    AUTH_EXPIRED suppression (#977 / #974/C):
+      When ``suppress_auth_expired_before`` is non-None, any failed row
+      with ``error_category='auth_expired'`` whose
+      ``COALESCE(started_at, finished_at) < suppress_auth_expired_before``
+      is filtered out as if it never existed. This implements the
+      "AUTH_EXPIRED rows from before the operator's last recovery
+      timestamp don't count toward the operator-visible streak"
+      contract. Caller resolves the timestamp via
+      ``app.services.credential_health.get_last_recovered_at``;
+      passing None means no suppression (Codex r2.4 missing-row case).
     """
     # Postgres sorts nulls first on DESC. `started_at` is nullable —
     # pending rows are inserted without it (executor.py:154), and
@@ -67,11 +86,21 @@ def consecutive_failures(
             """
             SELECT status
             FROM sync_layer_progress
-            WHERE layer_name = %s
+            WHERE layer_name = %(layer)s
+              AND NOT (
+                %(suppress_before)s::timestamptz IS NOT NULL
+                AND status = 'failed'
+                AND error_category = %(auth_cat)s
+                AND COALESCE(started_at, finished_at) < %(suppress_before)s::timestamptz
+              )
             ORDER BY COALESCE(started_at, finished_at) DESC NULLS LAST, sync_run_id DESC
             LIMIT 50
             """,
-            (layer_name,),
+            {
+                "layer": layer_name,
+                "suppress_before": suppress_auth_expired_before,
+                "auth_cat": _AUTH_EXPIRED_CATEGORY,
+            },
         )
         rows = cur.fetchall()
     streak = 0
@@ -120,6 +149,8 @@ def last_error_category(
 def all_layer_histories(
     conn: psycopg.Connection[Any],
     layer_names: list[str] | tuple[str, ...],
+    *,
+    suppress_auth_expired_before: datetime | None = None,
 ) -> tuple[dict[str, int], dict[str, str | None]]:
     """Batched equivalent of (consecutive_failures, last_error_category).
 
@@ -162,7 +193,24 @@ def all_layer_histories(
         # history).
         cur.execute(
             """
-            WITH ranked AS (
+            WITH filtered AS (
+                -- AUTH_EXPIRED suppression (#977 / #974/C): when
+                -- suppress_auth_expired_before is non-NULL, drop
+                -- failed rows with error_category='auth_expired'
+                -- older than that timestamp. Caller resolves the
+                -- timestamp via
+                -- credential_health.get_last_recovered_at.
+                SELECT *
+                FROM sync_layer_progress
+                WHERE layer_name = ANY(%(names)s)
+                  AND NOT (
+                    %(suppress_before)s::timestamptz IS NOT NULL
+                    AND status = 'failed'
+                    AND error_category = %(auth_cat)s
+                    AND COALESCE(started_at, finished_at) < %(suppress_before)s::timestamptz
+                  )
+            ),
+            ranked AS (
                 SELECT
                     layer_name,
                     status,
@@ -171,8 +219,7 @@ def all_layer_histories(
                         ORDER BY COALESCE(started_at, finished_at) DESC NULLS LAST, sync_run_id DESC
                     ) AS rn,
                     COUNT(*) OVER (PARTITION BY layer_name) AS total
-                FROM sync_layer_progress
-                WHERE layer_name = ANY(%s)
+                FROM filtered
             ),
             first_non_failed AS (
                 SELECT layer_name, MIN(rn) AS rn
@@ -181,14 +228,6 @@ def all_layer_histories(
                 GROUP BY layer_name
             ),
             totals AS (
-                -- MAX(total) is deterministic here because
-                -- COUNT(*) OVER (PARTITION BY layer_name) yields
-                -- the same value across every row within a partition.
-                -- GROUP BY ensures exactly one row per layer_name
-                -- even if a concurrent writer were somehow to let
-                -- the window see slightly different per-partition
-                -- counts — DISTINCT on a window-function column
-                -- would fan out in that (theoretical) case.
                 SELECT layer_name, MAX(total) AS total
                 FROM ranked
                 GROUP BY layer_name
@@ -199,7 +238,11 @@ def all_layer_histories(
             FROM totals t
             LEFT JOIN first_non_failed f USING (layer_name);
             """,
-            (names,),
+            {
+                "names": names,
+                "suppress_before": suppress_auth_expired_before,
+                "auth_cat": _AUTH_EXPIRED_CATEGORY,
+            },
         )
         for row in cur.fetchall():
             streaks[str(row["layer_name"])] = int(row["streak"])

--- a/app/services/sync_orchestrator/layer_failure_history.py
+++ b/app/services/sync_orchestrator/layer_failure_history.py
@@ -115,6 +115,8 @@ def consecutive_failures(
 def last_error_category(
     conn: psycopg.Connection[Any],
     layer_name: str,
+    *,
+    suppress_auth_expired_before: datetime | None = None,
 ) -> str | None:
     """Return the most recent non-null error_category for the layer.
 
@@ -124,6 +126,14 @@ def last_error_category(
     category, we want to surface that. In practice the executor only
     writes `error_category` on non-success paths, so this is a
     defensive allowance rather than an observed case.
+
+    AUTH_EXPIRED suppression (Codex pre-push r3.3): when
+    ``suppress_auth_expired_before`` is non-None, rows with
+    ``error_category='auth_expired'`` whose
+    ``COALESCE(started_at, finished_at) < suppress_before`` are
+    excluded from this query so an old pre-recovery auth_expired
+    cannot surface as the "current" category in the admin Problems
+    panel after the operator has fixed their keys.
     """
     # COALESCE(started_at, finished_at) + sync_run_id tiebreak for the
     # same reason as `consecutive_failures` — see that function for the
@@ -133,11 +143,20 @@ def last_error_category(
             """
             SELECT error_category
             FROM sync_layer_progress
-            WHERE layer_name = %s AND error_category IS NOT NULL
+            WHERE layer_name = %(layer)s AND error_category IS NOT NULL
+              AND NOT (
+                %(suppress_before)s::timestamptz IS NOT NULL
+                AND error_category = %(auth_cat)s
+                AND COALESCE(started_at, finished_at) < %(suppress_before)s::timestamptz
+              )
             ORDER BY COALESCE(started_at, finished_at) DESC NULLS LAST, sync_run_id DESC
             LIMIT 1
             """,
-            (layer_name,),
+            {
+                "layer": layer_name,
+                "suppress_before": suppress_auth_expired_before,
+                "auth_cat": _AUTH_EXPIRED_CATEGORY,
+            },
         )
         row = cur.fetchone()
     if row is None:
@@ -249,6 +268,10 @@ def all_layer_histories(
 
     categories: dict[str, str | None] = {}
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # AUTH_EXPIRED suppression also applies to category lookup
+        # (Codex pre-push r3.3): an old pre-recovery auth_expired
+        # cannot surface as the "current" category once the operator
+        # has fixed their keys.
         cur.execute(
             """
             WITH ranked AS (
@@ -260,13 +283,23 @@ def all_layer_histories(
                         ORDER BY COALESCE(started_at, finished_at) DESC NULLS LAST, sync_run_id DESC
                     ) AS rn
                 FROM sync_layer_progress
-                WHERE error_category IS NOT NULL AND layer_name = ANY(%s)
+                WHERE error_category IS NOT NULL
+                  AND layer_name = ANY(%(names)s)
+                  AND NOT (
+                    %(suppress_before)s::timestamptz IS NOT NULL
+                    AND error_category = %(auth_cat)s
+                    AND COALESCE(started_at, finished_at) < %(suppress_before)s::timestamptz
+                  )
             )
             SELECT layer_name, error_category
             FROM ranked
             WHERE rn = 1;
             """,
-            (names,),
+            {
+                "names": names,
+                "suppress_before": suppress_auth_expired_before,
+                "auth_cat": _AUTH_EXPIRED_CATEGORY,
+            },
         )
         for row in cur.fetchall():
             # WHERE error_category IS NOT NULL in the CTE already

--- a/app/services/sync_orchestrator/layer_state.py
+++ b/app/services/sync_orchestrator/layer_state.py
@@ -101,6 +101,8 @@ MAX_STATE_ITERATIONS = 16
 
 def compute_layer_states_from_db(
     conn: psycopg.Connection[Any],
+    *,
+    suppress_auth_expired_before: datetime | None = None,
 ) -> dict[str, LayerState]:
     """Build a LayerState for every registered layer by reading
     sync_layer_progress + content predicates + layer_enabled + secrets.
@@ -108,6 +110,15 @@ def compute_layer_states_from_db(
     Fixed-point iteration propagates cascade state across DAG depth.
     Converges in at most MAX_STATE_ITERATIONS rounds; safety-capped so
     a future cycle in the registry cannot hang the planning query.
+
+    AUTH_EXPIRED suppression (#977 / #974/C):
+      ``suppress_auth_expired_before`` is plumbed through to
+      ``all_layer_histories`` so an old pre-recovery auth_expired
+      failure cannot push a layer into ACTION_NEEDED after the
+      operator has fixed their keys (Codex pre-push r3.2). Caller
+      resolves the timestamp from
+      ``credential_health.get_last_recovered_at``; passing None means
+      no suppression.
     """
     # Deferred imports to avoid circular imports at module load time.
     # layer_types is at the bottom of the import graph; registry imports
@@ -118,7 +129,11 @@ def compute_layer_states_from_db(
 
     names = list(LAYERS.keys())
     enabled = read_all_enabled(conn, names)
-    streaks, categories = all_layer_histories(conn, names)
+    streaks, categories = all_layer_histories(
+        conn,
+        names,
+        suppress_auth_expired_before=suppress_auth_expired_before,
+    )
     running_set = _running_layers(conn, names)
     latest_status = _latest_status_map(conn, names)
     latest_ages = _latest_age_seconds_map(conn, names)

--- a/app/services/sync_orchestrator/layer_state.py
+++ b/app/services/sync_orchestrator/layer_state.py
@@ -226,6 +226,13 @@ def _latest_status_map(
     a layer into ACTION_NEEDED after the operator has fixed their
     keys.
     """
+    # Reference the same constant used by layer_failure_history so a
+    # future rename of the FailureCategory enum value can't drift one
+    # site from the others (review #983 WARNING).
+    from app.services.sync_orchestrator.layer_failure_history import (
+        _AUTH_EXPIRED_CATEGORY,
+    )
+
     rows = conn.execute(
         """
         WITH ranked AS (
@@ -240,13 +247,17 @@ def _latest_status_map(
               AND NOT (
                 %(suppress_before)s::timestamptz IS NOT NULL
                 AND status = 'failed'
-                AND error_category = 'auth_expired'
+                AND error_category = %(auth_cat)s
                 AND COALESCE(started_at, finished_at) < %(suppress_before)s::timestamptz
               )
         )
         SELECT layer_name, status FROM ranked WHERE rn = 1
         """,
-        {"names": names, "suppress_before": suppress_auth_expired_before},
+        {
+            "names": names,
+            "suppress_before": suppress_auth_expired_before,
+            "auth_cat": _AUTH_EXPIRED_CATEGORY,
+        },
     ).fetchall()
     out = {str(r[0]): str(r[1]) for r in rows}
     # Never-run layer: sentinel that the context-builder translates to

--- a/app/services/sync_orchestrator/layer_state.py
+++ b/app/services/sync_orchestrator/layer_state.py
@@ -135,7 +135,11 @@ def compute_layer_states_from_db(
         suppress_auth_expired_before=suppress_auth_expired_before,
     )
     running_set = _running_layers(conn, names)
-    latest_status = _latest_status_map(conn, names)
+    latest_status = _latest_status_map(
+        conn,
+        names,
+        suppress_auth_expired_before=suppress_auth_expired_before,
+    )
     latest_ages = _latest_age_seconds_map(conn, names)
     content_results = _content_ok_map(conn)
     # Snapshot a single ``now`` per state-machine evaluation so all
@@ -207,7 +211,21 @@ def _running_layers(conn: psycopg.Connection[Any], names: list[str]) -> set[str]
     return {str(r[0]) for r in rows}
 
 
-def _latest_status_map(conn: psycopg.Connection[Any], names: list[str]) -> dict[str, str]:
+def _latest_status_map(
+    conn: psycopg.Connection[Any],
+    names: list[str],
+    *,
+    suppress_auth_expired_before: datetime | None = None,
+) -> dict[str, str]:
+    """Return ``{layer_name: latest_status}`` filtered to non-suppressed rows.
+
+    AUTH_EXPIRED suppression (Codex pre-push r3.2): rows with
+    ``status='failed'`` AND ``error_category='auth_expired'`` AND
+    ``COALESCE(started_at, finished_at) < suppress_before`` are
+    excluded so an old pre-recovery auth_expired failure cannot push
+    a layer into ACTION_NEEDED after the operator has fixed their
+    keys.
+    """
     rows = conn.execute(
         """
         WITH ranked AS (
@@ -218,11 +236,17 @@ def _latest_status_map(conn: psycopg.Connection[Any], names: list[str]) -> dict[
                     ORDER BY COALESCE(started_at, finished_at) DESC NULLS LAST, sync_run_id DESC
                 ) AS rn
             FROM sync_layer_progress
-            WHERE layer_name = ANY(%s)
+            WHERE layer_name = ANY(%(names)s)
+              AND NOT (
+                %(suppress_before)s::timestamptz IS NOT NULL
+                AND status = 'failed'
+                AND error_category = 'auth_expired'
+                AND COALESCE(started_at, finished_at) < %(suppress_before)s::timestamptz
+              )
         )
         SELECT layer_name, status FROM ranked WHERE rn = 1
         """,
-        (names,),
+        {"names": names, "suppress_before": suppress_auth_expired_before},
     ).fetchall()
     out = {str(r[0]): str(r[1]) for r in rows}
     # Never-run layer: sentinel that the context-builder translates to

--- a/app/services/sync_orchestrator/registry.py
+++ b/app/services/sync_orchestrator/registry.py
@@ -69,6 +69,31 @@ class DataLayer:
     secret_refs: tuple[SecretRef, ...] = ()
     content_predicate: ContentPredicate | None = None
     plain_language_sla: str = ""
+    # Credential-health gate (#977 / #974/C). When True, the
+    # orchestrator pre-flight gate at executor.py PREREQ_SKIPs this
+    # layer when operator credential health != VALID. Layers whose
+    # refresh path calls eToro must set this to True; layers that
+    # only read DB-resident data leave it False.
+    requires_broker_credential: bool = False
+    # Layer-initialization gate (#977 / #974/C). Each named dep must
+    # have its data table content-initialized (per INIT_CHECKS) before
+    # this layer is eligible. Stricter than `dependencies` (per-tick).
+    # Used by portfolio_sync to wait until `instruments` is non-empty
+    # so writing positions doesn't FK-violate. Codex r2.5/r3.3.
+    requires_layer_initialized: tuple[str, ...] = ()
+
+
+# Content-initialization predicates per layer name. Each is a SQL
+# EXISTS query that returns a single boolean column. The orchestrator
+# pre-flight gate calls these to decide whether a dependent layer
+# tagged ``requires_layer_initialized=("dep_name",)`` is eligible.
+#
+# Map keys are layer names; the SQL must be plain `SELECT EXISTS(...)`
+# returning one row, one column. Tested by
+# tests/test_sync_orchestrator_credential_gate.py.
+INIT_CHECKS: dict[str, str] = {
+    "universe": "SELECT EXISTS (SELECT 1 FROM instruments WHERE is_tradable = true)",
+}
 
 
 MINUTE_LAYER_RETRY = RetryPolicy(max_attempts=5, backoff_seconds=(30, 60, 120, 300, 600))
@@ -82,6 +107,7 @@ LAYERS: dict[str, DataLayer] = {
         is_fresh=universe_is_fresh,
         refresh=refresh_universe,
         dependencies=(),
+        requires_broker_credential=True,
         plain_language_sla="Refreshed weekly — eToro instrument list.",
     ),
     "candles": DataLayer(
@@ -92,6 +118,7 @@ LAYERS: dict[str, DataLayer] = {
         is_fresh=candles_is_fresh,
         refresh=refresh_candles,
         dependencies=("universe",),
+        requires_broker_credential=True,
         content_predicate=candles_content_ok,
         plain_language_sla="Refreshed every trading day after market close.",
     ),
@@ -135,6 +162,13 @@ LAYERS: dict[str, DataLayer] = {
         refresh=refresh_portfolio_sync,
         dependencies=(),
         is_blocking=False,
+        requires_broker_credential=True,
+        # Wait for `instruments` to have at least one tradable row
+        # before writing to `positions`. Without this gate
+        # portfolio_sync FK-violates on a fresh install when eToro
+        # returns positions for instruments universe hasn't ingested
+        # yet (Codex r1.7 / r2.5).
+        requires_layer_initialized=("universe",),
         retry_policy=MINUTE_LAYER_RETRY,
         plain_language_sla="Synced every 5 minutes against eToro.",
     ),
@@ -147,6 +181,8 @@ LAYERS: dict[str, DataLayer] = {
         refresh=refresh_fx_rates,
         dependencies=(),
         is_blocking=False,
+        # FX rates come from Frankfurter (free public API), NOT eToro.
+        # Don't gate on broker credential health.
         retry_policy=MINUTE_LAYER_RETRY,
         plain_language_sla="Refreshed every 5 minutes for live valuation.",
     ),

--- a/tests/test_sync_orchestrator_credential_gate.py
+++ b/tests/test_sync_orchestrator_credential_gate.py
@@ -1,0 +1,388 @@
+"""Tests for the orchestrator credential-health + init-check gates (#977 / #974/C).
+
+Spec: docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md.
+
+Coverage:
+  * _credential_health_blocks: returns None when no requires_broker_credential
+    emit; returns reason when operator health != VALID; returns None on VALID.
+  * _layer_initialization_blocks: returns None when no requires_layer_initialized;
+    returns reason when an init dep's INIT_CHECKS predicate is False; returns
+    None when the predicate is True.
+  * Registry tags: portfolio_sync has requires_layer_initialized=("universe",);
+    universe / candles / portfolio_sync have requires_broker_credential=True;
+    fundamentals / fx_rates / cost_models do NOT.
+  * AUTH_EXPIRED suppression: consecutive_failures + all_layer_histories
+    correctly filter rows whose error_category='auth_expired' and
+    failed_at < suppress_auth_expired_before.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.security import secrets_crypto
+from app.services.sync_orchestrator.executor import (
+    _credential_health_blocks,
+    _layer_initialization_blocks,
+)
+from app.services.sync_orchestrator.layer_failure_history import (
+    all_layer_histories,
+    consecutive_failures,
+)
+from app.services.sync_orchestrator.registry import INIT_CHECKS, LAYERS
+from app.services.sync_orchestrator.types import LayerPlan
+from tests.fixtures.ebull_test_db import (
+    ebull_test_conn,  # noqa: F401
+    test_database_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _key() -> Iterator[None]:
+    secrets_crypto.set_active_key(os.urandom(32))
+    yield
+    secrets_crypto._reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _patch_db_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force executor's psycopg.connect to use the test DB URL.
+
+    The gate helpers open fresh autocommit connections via
+    settings.database_url; without this patch they'd hit the dev DB.
+    """
+    monkeypatch.setattr("app.services.sync_orchestrator.executor.settings.database_url", test_database_url())
+
+
+def _make_plan(name: str, emits: tuple[str, ...]) -> LayerPlan:
+    """Build a minimal LayerPlan for gate tests."""
+    return LayerPlan(
+        name=name,
+        emits=emits,
+        reason="test",
+        dependencies=LAYERS[emits[0]].dependencies,
+        is_blocking=LAYERS[emits[0]].is_blocking,
+        estimated_items=0,
+    )
+
+
+def _seed_operator_with_health(
+    *,
+    api_state: str,
+    user_state: str,
+) -> None:
+    """Insert a single operator + both labels at the supplied health states."""
+    op_id = uuid4()
+    url = test_database_url()
+    with psycopg.connect(url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s, %s, %s)",
+                (op_id, f"op-{op_id.hex[:8]}", "argon2:dummy"),
+            )
+            for label, state in (("api_key", api_state), ("user_key", user_state)):
+                cur.execute(
+                    """
+                    INSERT INTO broker_credentials
+                        (id, operator_id, provider, label, environment,
+                         ciphertext, last_four, key_version, health_state)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (uuid4(), op_id, "etoro", label, "demo", b"\x00" * 32, "abcd", 1, state),
+                )
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Registry tags — locked
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryTags:
+    def test_universe_requires_credential(self) -> None:
+        assert LAYERS["universe"].requires_broker_credential is True
+        assert LAYERS["universe"].requires_layer_initialized == ()
+
+    def test_candles_requires_credential(self) -> None:
+        assert LAYERS["candles"].requires_broker_credential is True
+
+    def test_portfolio_sync_requires_credential_and_universe_init(self) -> None:
+        assert LAYERS["portfolio_sync"].requires_broker_credential is True
+        assert LAYERS["portfolio_sync"].requires_layer_initialized == ("universe",)
+
+    def test_fundamentals_does_not_require_credential(self) -> None:
+        # SEC XBRL — no eToro creds needed.
+        assert LAYERS["fundamentals"].requires_broker_credential is False
+
+    def test_fx_rates_does_not_require_credential(self) -> None:
+        # Frankfurter — no eToro creds.
+        assert LAYERS["fx_rates"].requires_broker_credential is False
+
+    def test_cost_models_does_not_require_credential(self) -> None:
+        # Re-seeded from existing DB data — no eToro creds.
+        assert LAYERS["cost_models"].requires_broker_credential is False
+
+    def test_init_checks_has_universe(self) -> None:
+        assert "universe" in INIT_CHECKS
+        # Must check `is_tradable = true` per spec.
+        assert "is_tradable" in INIT_CHECKS["universe"]
+
+
+# ---------------------------------------------------------------------------
+# _credential_health_blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestCredentialHealthBlocks:
+    def test_no_credential_layer_passes(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Layers with requires_broker_credential=False are not gated."""
+        del ebull_test_conn
+        plan = _make_plan("fx_rates", ("fx_rates",))
+        result = _credential_health_blocks(plan)
+        assert result is None
+
+    def test_no_operator_returns_skip_reason(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """A credential-using layer with no operator is gated."""
+        del ebull_test_conn  # leave fixture truncated; no operator seeded
+        plan = _make_plan("universe", ("universe",))
+        result = _credential_health_blocks(plan)
+        assert result is not None
+        assert "operator not configured" in result
+
+    def test_rejected_health_returns_skip_reason(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        del ebull_test_conn
+        _seed_operator_with_health(api_state="rejected", user_state="valid")
+        plan = _make_plan("universe", ("universe",))
+        result = _credential_health_blocks(plan)
+        assert result is not None
+        assert "rejected" in result
+
+    def test_valid_health_passes(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        del ebull_test_conn
+        _seed_operator_with_health(api_state="valid", user_state="valid")
+        plan = _make_plan("universe", ("universe",))
+        result = _credential_health_blocks(plan)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _layer_initialization_blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLayerInitializationBlocks:
+    def test_no_init_dep_passes(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Layer without requires_layer_initialized is not gated."""
+        del ebull_test_conn
+        plan = _make_plan("universe", ("universe",))
+        result = _layer_initialization_blocks(plan)
+        assert result is None
+
+    def test_uninitialized_universe_blocks_portfolio_sync(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """portfolio_sync with empty instruments table → SKIP."""
+        del ebull_test_conn  # truncated; instruments empty
+        plan = _make_plan("portfolio_sync", ("portfolio_sync",))
+        result = _layer_initialization_blocks(plan)
+        assert result is not None
+        assert "universe" in result and "not yet initialized" in result
+
+    def test_initialized_universe_unblocks_portfolio_sync(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        del ebull_test_conn
+        # Seed at least one tradable instrument.
+        url = test_database_url()
+        with psycopg.connect(url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO instruments
+                        (instrument_id, symbol, company_name, is_tradable, currency, instrument_type)
+                    VALUES (1, 'AAPL', 'Apple Inc.', TRUE, 'USD', 'stock')
+                    """
+                )
+            conn.commit()
+
+        plan = _make_plan("portfolio_sync", ("portfolio_sync",))
+        result = _layer_initialization_blocks(plan)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# AUTH_EXPIRED suppression in failure-history queries
+# ---------------------------------------------------------------------------
+
+
+def _seed_progress_row(
+    conn: psycopg.Connection[Any],
+    *,
+    layer_name: str,
+    status: str,
+    error_category: str | None,
+    started_at: datetime,
+) -> int:
+    """Insert a sync_layer_progress row for failure-history tests.
+
+    sync_run_id is GENERATED ALWAYS so we let Postgres assign it and
+    return the id. Each call creates a fresh sync_runs row.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO sync_runs (scope, scope_detail, trigger, layers_planned, status)
+            VALUES (%s, %s, %s, %s, %s)
+            RETURNING sync_run_id
+            """,
+            ("full", None, "manual", 1, "complete"),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        sync_run_id = row[0]
+        cur.execute(
+            """
+            INSERT INTO sync_layer_progress
+                (sync_run_id, layer_name, status, error_category, started_at, finished_at)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (sync_run_id, layer_name, status, error_category, started_at, started_at + timedelta(seconds=5)),
+        )
+    conn.commit()
+    return sync_run_id
+
+
+@pytest.mark.integration
+class TestAuthExpiredSuppression:
+    def test_suppression_filters_old_auth_expired_failures(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """A failed auth_expired row with started_at < suppress_before
+        does NOT count toward the streak."""
+        # Three auth_expired failures, all old.
+        recovery_at = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        old = recovery_at - timedelta(hours=1)
+        for i in range(3):
+            _seed_progress_row(
+                ebull_test_conn,
+                layer_name="universe",
+                status="failed",
+                error_category="auth_expired",
+                started_at=old + timedelta(minutes=i),
+            )
+
+        # Without suppression: streak = 3.
+        assert consecutive_failures(ebull_test_conn, "universe", suppress_auth_expired_before=None) == 3
+        # With suppression at recovery_at: streak = 0.
+        assert (
+            consecutive_failures(
+                ebull_test_conn,
+                "universe",
+                suppress_auth_expired_before=recovery_at,
+            )
+            == 0
+        )
+
+    def test_suppression_preserves_new_failures_after_recovery(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Failures of any category that happen AFTER recovery still
+        count toward the streak."""
+        recovery_at = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        # Old auth_expired (suppressed).
+        _seed_progress_row(
+            ebull_test_conn,
+            layer_name="universe",
+            status="failed",
+            error_category="auth_expired",
+            started_at=recovery_at - timedelta(hours=1),
+        )
+        # New rate_limited AFTER recovery (visible).
+        _seed_progress_row(
+            ebull_test_conn,
+            layer_name="universe",
+            status="failed",
+            error_category="rate_limited",
+            started_at=recovery_at + timedelta(minutes=5),
+        )
+
+        result = consecutive_failures(
+            ebull_test_conn,
+            "universe",
+            suppress_auth_expired_before=recovery_at,
+        )
+        assert result == 1  # only the rate_limited failure
+
+    def test_suppression_does_not_filter_new_auth_expired(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """auth_expired rows AFTER suppress_before remain visible —
+        operator entered another bad key after recovery."""
+        recovery_at = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        # New auth_expired (visible).
+        _seed_progress_row(
+            ebull_test_conn,
+            layer_name="universe",
+            status="failed",
+            error_category="auth_expired",
+            started_at=recovery_at + timedelta(minutes=5),
+        )
+        result = consecutive_failures(
+            ebull_test_conn,
+            "universe",
+            suppress_auth_expired_before=recovery_at,
+        )
+        assert result == 1
+
+    def test_all_layer_histories_applies_suppression(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Batched helper applies the same suppression as the single-layer one."""
+        recovery_at = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        _seed_progress_row(
+            ebull_test_conn,
+            layer_name="universe",
+            status="failed",
+            error_category="auth_expired",
+            started_at=recovery_at - timedelta(hours=1),
+        )
+
+        streaks_no_suppress, _ = all_layer_histories(ebull_test_conn, ["universe"])
+        streaks_suppress, _ = all_layer_histories(
+            ebull_test_conn,
+            ["universe"],
+            suppress_auth_expired_before=recovery_at,
+        )
+        assert streaks_no_suppress.get("universe", 0) == 1
+        assert streaks_suppress.get("universe", 0) == 0

--- a/tests/test_sync_orchestrator_credential_gate.py
+++ b/tests/test_sync_orchestrator_credential_gate.py
@@ -185,6 +185,59 @@ class TestCredentialHealthBlocks:
         result = _credential_health_blocks(plan)
         assert result is None
 
+    def test_real_environment_with_rejected_creds_blocks(
+        self,
+        ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+    ) -> None:
+        """Review #983 BLOCKING regression test: gate must check
+        every environment the operator has rows for, not just 'demo'.
+
+        Operator has demo=valid + real=rejected. Pre-fix the gate
+        hardcoded 'demo' so a layer would pass the check and trade
+        real with bad keys.
+        """
+        del ebull_test_conn
+        # Seed demo VALID + live REJECTED on the same operator.
+        op_id = uuid4()
+        url = test_database_url()
+        with psycopg.connect(url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s, %s, %s)",
+                    (op_id, f"op-{op_id.hex[:8]}", "argon2:dummy"),
+                )
+                for env, state in (
+                    ("demo", "valid"),
+                    ("real", "rejected"),
+                ):
+                    for label in ("api_key", "user_key"):
+                        cur.execute(
+                            """
+                            INSERT INTO broker_credentials
+                                (id, operator_id, provider, label, environment,
+                                 ciphertext, last_four, key_version, health_state)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                            """,
+                            (
+                                uuid4(),
+                                op_id,
+                                "etoro",
+                                label,
+                                env,
+                                b"\x00" * 32,
+                                "abcd",
+                                1,
+                                state,
+                            ),
+                        )
+            conn.commit()
+
+        plan = _make_plan("universe", ("universe",))
+        result = _credential_health_blocks(plan)
+        assert result is not None
+        assert "real" in result
+        assert "rejected" in result
+
 
 # ---------------------------------------------------------------------------
 # _layer_initialization_blocks


### PR DESCRIPTION
Refs #974. Closes #977. Third foundational PR for the credential-health-as-scheduling-precondition umbrella.

## What

- **DataLayer registry tags**: \`requires_broker_credential: bool\` + \`requires_layer_initialized: tuple[str, ...]\`. Tagged: universe / candles / portfolio_sync require eToro creds. portfolio_sync also gets \`requires_layer_initialized=(\"universe\",)\` so it waits for \`instruments\` to be non-empty before writing positions (fixes the FK cascade bug).
- **\`INIT_CHECKS\` registry**: SQL EXISTS predicate per layer. \`universe\` → \`SELECT EXISTS (SELECT 1 FROM instruments WHERE is_tradable = true)\`.
- **Executor pre-flight gates** (in order, BEFORE \`_blocking_dependency_failed\`):
  1. \`_credential_health_blocks(layer)\` — PREREQ_SKIP when operator credential health != VALID.
  2. \`_layer_initialization_blocks(layer)\` — PREREQ_SKIP when any init-dep predicate is false.
- **AUTH_EXPIRED suppression**: \`consecutive_failures\`, \`all_layer_histories\`, \`last_error_category\`, \`compute_layer_states_from_db\`, and \`_latest_status_map\` ALL gain \`suppress_auth_expired_before\` parameter. Filter rows with \`error_category='auth_expired'\` and \`COALESCE(started_at, finished_at) < suppress_before\`.
- **\`/sync/layers\` and \`/sync/layers/v2\`** resolve the timestamp via \`credential_health.get_last_recovered_at\` and pass it through.

## Why

Stops the cascade: when keys are wrong, credential-using layers PREREQ_SKIP instead of 401-cascading. portfolio_sync stops FK-violating against an empty instruments table. After the operator fixes their keys, AUTH_EXPIRED suppression hides the historical cascade rows so the admin Problems panel goes clean automatically.

## Test plan

- [x] 18 new tests at \`tests/test_sync_orchestrator_credential_gate.py\`:
  - Registry tags pinned (which layers require credentials, init-checks).
  - Credential gate: no-credential layer passes; no operator returns skip; rejected health returns skip; valid passes.
  - Init gate: no init-dep passes; uninitialized instruments blocks portfolio_sync; one tradable row unblocks.
  - AUTH_EXPIRED suppression: old auth_expired filtered; new failures (any category) preserved; new auth_expired surface; batched + single-layer helpers consistent.
- [x] All #975 + #976 tests still green; 78 in the combined credential-health suite.
- [x] Smoke (lifespan boots clean) passes.
- [x] ruff + format + pyright clean.
- [x] **Codex pre-push review**: 2 rounds; 5 findings raised, all fixed before push (Python-2-except syntax stripped by ruff format, suppression incomplete in compute_layer_states_from_db / _latest_status_map / last_error_category / categories query).

## Spec

\`docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md\` sections "Orchestrator pre-flight gate" + "AUTH_EXPIRED failure-row suppression" + "portfolio_sync init-check" + Codex r1.7/r2.5/r3.3.