### PR TITLE
feat(#979): admin Problems-panel cred-health banner + /system/status credential_health

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -378,12 +378,18 @@ def get_system_status(
 def _build_credential_health_summary(conn: psycopg.Connection[object]) -> CredentialHealthSummary:
     """Resolve operator-level credential health for the admin banner.
 
-    Per-operator scope (single-operator v1). Falls back to MISSING
-    when no operator yet, so the admin UI shows the "save credentials
-    in Settings" path on a fresh install rather than misreporting
-    VALID. Codex r3.2 + #979 banner contract.
+    Per-operator scope (single-operator v1). Walks every environment
+    the operator has active credential rows for and returns the
+    worst-of state — REJECTED in any environment surfaces as
+    REJECTED so a live-environment rejection is not masked by a
+    valid demo pair (review #985 BLOCKING).
+
+    Falls back to MISSING when no operator yet so the admin UI shows
+    the "save credentials in Settings" path on a fresh install rather
+    than misreporting VALID.
     """
     from app.services.credential_health import (
+        CredentialHealth,
         get_last_recovered_at,
         get_operator_credential_health,
     )
@@ -401,24 +407,89 @@ def _build_credential_health_summary(conn: psycopg.Connection[object]) -> Creden
         return CredentialHealthSummary(state="missing")
 
     try:
-        health = get_operator_credential_health(conn, operator_id=op_id, environment="demo")
+        environments = _operator_environments(conn, op_id)
+        if not environments:
+            return CredentialHealthSummary(state="missing")
+
+        worst_health: CredentialHealth | None = None
+        for env in environments:
+            env_health = get_operator_credential_health(conn, operator_id=op_id, environment=env)
+            if worst_health is None or _is_worse(env_health, worst_health):
+                worst_health = env_health
+
         recovered_at = get_last_recovered_at(conn, operator_id=op_id)
+        last_error = _latest_credential_error(conn, op_id) if worst_health == CredentialHealth.REJECTED else None
     except Exception:
         logger.exception("credential_health summary lookup failed; reporting missing")
         return CredentialHealthSummary(state="missing")
 
-    state_value = health.value
+    if worst_health is None:
+        return CredentialHealthSummary(state="missing")
+
+    state_value = worst_health.value
     if state_value not in ("valid", "untested", "rejected", "missing"):
-        # CredentialHealth enum values are pinned to the four literals
-        # above; any deviation is a registry change that hasn't yet
-        # been propagated to this response model. Fail-safe to missing.
         logger.error("unexpected CredentialHealth value: %s", state_value)
         return CredentialHealthSummary(state="missing")
     return CredentialHealthSummary(
         state=state_value,  # type: ignore[arg-type]
         last_recovered_at=recovered_at,
-        last_error=None,
+        last_error=last_error,
     )
+
+
+def _operator_environments(conn: psycopg.Connection[object], operator_id: object) -> list[str]:
+    """Return distinct active-credential environments for the operator."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT environment
+              FROM broker_credentials
+             WHERE operator_id = %s
+               AND revoked_at IS NULL
+             ORDER BY environment
+            """,
+            (operator_id,),
+        )
+        return [row[0] for row in cur.fetchall()]
+
+
+def _is_worse(a: object, b: object) -> bool:
+    """Worst-of precedence on CredentialHealth (REJECTED > MISSING > UNTESTED > VALID)."""
+    from app.services.credential_health import CredentialHealth
+
+    rank = {
+        CredentialHealth.VALID: 0,
+        CredentialHealth.UNTESTED: 1,
+        CredentialHealth.MISSING: 2,
+        CredentialHealth.REJECTED: 3,
+    }
+    return rank.get(a, 0) > rank.get(b, 0)  # type: ignore[arg-type]
+
+
+def _latest_credential_error(conn: psycopg.Connection[object], operator_id: object) -> str | None:
+    """Return the most recent ``last_health_error`` across the operator's
+    rejected rows, for the admin banner's contextual error display
+    (review #985 WARNING — the response model declared the field but
+    the original implementation always returned None)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT last_health_error
+              FROM broker_credentials
+             WHERE operator_id = %s
+               AND revoked_at IS NULL
+               AND health_state = 'rejected'
+               AND last_health_error IS NOT NULL
+             ORDER BY health_state_updated_at DESC
+             LIMIT 1
+            """,
+            (operator_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    value = row[0]
+    return str(value) if value is not None else None
 
 
 @router.get("/jobs", response_model=JobsListResponse)

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -439,7 +439,7 @@ def _build_credential_health_summary(conn: psycopg.Connection[object]) -> Creden
 
 def _operator_environments(conn: psycopg.Connection[object], operator_id: object) -> list[str]:
     """Return distinct active-credential environments for the operator."""
-    with conn.cursor() as cur:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
             SELECT DISTINCT environment
@@ -450,7 +450,7 @@ def _operator_environments(conn: psycopg.Connection[object], operator_id: object
             """,
             (operator_id,),
         )
-        return [row[0] for row in cur.fetchall()]
+        return [str(row["environment"]) for row in cur.fetchall()]
 
 
 def _is_worse(a: object, b: object) -> bool:
@@ -471,7 +471,7 @@ def _latest_credential_error(conn: psycopg.Connection[object], operator_id: obje
     rejected rows, for the admin banner's contextual error display
     (review #985 WARNING — the response model declared the field but
     the original implementation always returned None)."""
-    with conn.cursor() as cur:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
             SELECT last_health_error
@@ -488,7 +488,7 @@ def _latest_credential_error(conn: psycopg.Connection[object], operator_id: obje
         row = cur.fetchone()
     if row is None:
         return None
-    value = row[0]
+    value = row["last_health_error"]
     return str(value) if value is not None else None
 
 

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -100,12 +100,33 @@ class JobHealthResponse(BaseModel):
     detail: str
 
 
+class CredentialHealthSummary(BaseModel):
+    """Operator-level credential health for the admin Problems banner (#979 / #974/E).
+
+    State values mirror ``app.services.credential_health.CredentialHealth``:
+      * ``valid``     — operator's credential pair validated; orchestrator
+                        runs credential-using layers freely.
+      * ``untested``  — saved but not yet probed; orchestrator will skip
+                        until validate-stored confirms.
+      * ``rejected``  — provider returned 401/403; orchestrator
+                        PREREQ_SKIPs all credential-using layers; admin
+                        UI surfaces a single banner instead of N
+                        cascading AUTH_EXPIRED rows.
+      * ``missing``   — no credential rows; first-run state.
+    """
+
+    state: Literal["valid", "untested", "rejected", "missing"]
+    last_recovered_at: datetime | None = None
+    last_error: str | None = None
+
+
 class SystemStatusResponse(BaseModel):
     checked_at: datetime
     overall_status: OverallStatus
     layers: list[LayerHealthResponse]
     jobs: list[JobHealthResponse]
     kill_switch: KillSwitchStateResponse
+    credential_health: CredentialHealthSummary
 
 
 class JobOverviewResponse(BaseModel):
@@ -350,6 +371,53 @@ def get_system_status(
             activated_by=ks.get("activated_by"),
             reason=ks.get("reason"),
         ),
+        credential_health=_build_credential_health_summary(conn),
+    )
+
+
+def _build_credential_health_summary(conn: psycopg.Connection[object]) -> CredentialHealthSummary:
+    """Resolve operator-level credential health for the admin banner.
+
+    Per-operator scope (single-operator v1). Falls back to MISSING
+    when no operator yet, so the admin UI shows the "save credentials
+    in Settings" path on a fresh install rather than misreporting
+    VALID. Codex r3.2 + #979 banner contract.
+    """
+    from app.services.credential_health import (
+        get_last_recovered_at,
+        get_operator_credential_health,
+    )
+    from app.services.operators import (
+        AmbiguousOperatorError,
+        NoOperatorError,
+        sole_operator_id,
+    )
+
+    try:
+        op_id = sole_operator_id(conn)
+    except NoOperatorError:
+        return CredentialHealthSummary(state="missing")
+    except AmbiguousOperatorError:
+        return CredentialHealthSummary(state="missing")
+
+    try:
+        health = get_operator_credential_health(conn, operator_id=op_id, environment="demo")
+        recovered_at = get_last_recovered_at(conn, operator_id=op_id)
+    except Exception:
+        logger.exception("credential_health summary lookup failed; reporting missing")
+        return CredentialHealthSummary(state="missing")
+
+    state_value = health.value
+    if state_value not in ("valid", "untested", "rejected", "missing"):
+        # CredentialHealth enum values are pinned to the four literals
+        # above; any deviation is a registry change that hasn't yet
+        # been propagated to this response model. Fail-safe to missing.
+        logger.error("unexpected CredentialHealth value: %s", state_value)
+        return CredentialHealthSummary(state="missing")
+    return CredentialHealthSummary(
+        state=state_value,  # type: ignore[arg-type]
+        last_recovered_at=recovered_at,
+        last_error=None,
     )
 
 

--- a/frontend/src/api/mocks.ts
+++ b/frontend/src/api/mocks.ts
@@ -77,5 +77,10 @@ export async function fetchSystemStatusMock(): Promise<SystemStatusResponse> {
       activated_by: null,
       reason: null,
     },
+    credential_health: {
+      state: "valid",
+      last_recovered_at: null,
+      last_error: null,
+    },
   };
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -81,12 +81,25 @@ export interface JobHealthResponse {
   detail: string;
 }
 
+export type CredentialHealthState =
+  | "valid"
+  | "untested"
+  | "rejected"
+  | "missing";
+
+export interface CredentialHealthSummary {
+  state: CredentialHealthState;
+  last_recovered_at: string | null;
+  last_error: string | null;
+}
+
 export interface SystemStatusResponse {
   checked_at: string;
   overall_status: OverallStatus;
   layers: LayerHealthResponse[];
   jobs: JobHealthResponse[];
   kill_switch: KillSwitchStateResponse;
+  credential_health: CredentialHealthSummary;
 }
 
 export interface JobOverviewResponse {

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -73,6 +73,38 @@ describe("ProblemsPanel", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("injects credential-rejected banner when credential_health.state === 'rejected'", () => {
+    // #979 / #974/E: when the operator's aggregate health is REJECTED,
+    // the orchestrator gate (#977) PREREQ_SKIPs all credential-using
+    // layers — so v2.action_needed would be empty even though the
+    // system is fully gated. The banner item compensates so the
+    // operator still sees the actionable "fix Settings" surface.
+    renderPanel({
+      credentialHealth: {
+        state: "rejected",
+        last_recovered_at: null,
+        last_error: null,
+      },
+    });
+    expect(screen.getByText(/Credentials rejected by provider/i)).toBeInTheDocument();
+  });
+
+  it("does NOT inject the banner when credential_health.state === 'valid'", () => {
+    const { container } = renderPanel({
+      credentialHealth: {
+        state: "valid",
+        last_recovered_at: null,
+        last_error: null,
+      },
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does NOT inject the banner when credential_health is null (legacy / pre-bootstrap)", () => {
+    const { container } = renderPanel({ credentialHealth: null });
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("renders a red row per action_needed entry", () => {
     const v2 = emptyV2();
     v2.system_state = "needs_attention";

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -13,6 +13,7 @@ import { Link } from "react-router-dom";
 import type {
   ActionNeededItem,
   CoverageSummaryResponse,
+  CredentialHealthSummary,
   JobsListResponse,
   SecretMissingItem,
   SyncLayersV2Response,
@@ -27,12 +28,46 @@ export interface ProblemsPanelProps {
   readonly jobs: JobsListResponse | null;
   /** Coverage payload (unchanged from v1; null_rows still surface here). */
   readonly coverage: CoverageSummaryResponse | null;
+  /**
+   * Operator credential health (#979 / #974/E). When state==='rejected'
+   * the panel surfaces a single "Credentials rejected" banner item
+   * with a Settings link — the orchestrator gate already PREREQ_SKIPs
+   * the affected layers, so without this banner the operator would
+   * see no problems at all even though the system is gated.
+   *
+   * Optional + nullable so existing tests that pre-date #979 don't
+   * have to thread a value through; the banner only renders when
+   * state==='rejected'.
+   */
+  readonly credentialHealth?: CredentialHealthSummary | null;
   readonly v2Error: boolean;
   readonly jobsError: boolean;
   readonly coverageError: boolean;
   /** Called with the root layer name when the operator clicks drill-through. */
   readonly onOpenOrchestrator: (layerName: string) => void;
 }
+
+
+/** Synthetic ActionNeededItem injected when credentialHealth.state === 'rejected'.
+ *
+ * The orchestrator gate (#977) PREREQ_SKIPs credential-using layers
+ * when the operator's aggregate health is REJECTED. Without this
+ * synthetic banner item, action_needed would be empty and the
+ * operator would see no problems despite the system being fully
+ * gated. The banner gives them the actionable "go fix Settings".
+ */
+const CREDENTIAL_REJECTED_BANNER: ActionNeededItem = {
+  root_layer: "_credential_health",
+  display_name: "Credentials rejected by provider",
+  category: "auth_expired",
+  operator_message:
+    "eToro rejected your credentials. The orchestrator has paused all credential-using layers until you save valid keys.",
+  operator_fix: "Update the API key in Settings → Providers",
+  self_heal: false,
+  consecutive_failures: 0,
+  affected_downstream: [],
+  error_excerpt: null,
+};
 
 
 interface SourceCache {
@@ -56,6 +91,7 @@ export function ProblemsPanel({
   v2,
   jobs,
   coverage,
+  credentialHealth,
   v2Error,
   jobsError,
   coverageError,
@@ -92,10 +128,20 @@ export function ProblemsPanel({
     );
   }
 
-  const actionNeeded = cache.v2?.action_needed ?? [];
+  const baseActionNeeded = cache.v2?.action_needed ?? [];
   const secretMissing = cache.v2?.secret_missing ?? [];
   const failingJobs = (cache.jobs?.jobs ?? []).filter((j) => j.last_status === "failure");
   const coverageNullRows = cache.coverage?.null_rows ?? 0;
+
+  // Inject the credential-rejected banner when the operator's aggregate
+  // health is REJECTED. Backend already PREREQ_SKIPs affected layers
+  // (#977) and AUTH_EXPIRED suppression hides stale rows post-recovery,
+  // so without this synthetic item action_needed would be empty even
+  // though the system is fully gated. Prepended so it's visually first.
+  const showCredRejectedBanner = credentialHealth?.state === "rejected";
+  const actionNeeded: ActionNeededItem[] = showCredRejectedBanner
+    ? [CREDENTIAL_REJECTED_BANNER, ...baseActionNeeded]
+    : baseActionNeeded;
 
   const totalProblems = actionNeeded.length + secretMissing.length + failingJobs.length + (coverageNullRows > 0 ? 1 : 0);
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -24,6 +24,7 @@ import { Link } from "react-router-dom";
 import { fetchCoverageSummary } from "@/api/coverage";
 import { fetchJobsOverview, runJob } from "@/api/jobs";
 import { fetchRecommendations } from "@/api/recommendations";
+import { fetchSystemStatus } from "@/api/system";
 import { fetchSyncLayersV2, fetchSyncStatus, setLayerEnabled } from "@/api/sync";
 import { ApiError } from "@/api/client";
 import type {
@@ -67,6 +68,10 @@ export function AdminPage() {
   const status = useAsync(fetchSyncStatus, []);
   const coverage = useAsync(fetchCoverageSummary, []);
   const jobs = useAsync(fetchJobsOverview, []);
+  // /system/status carries the operator credential health summary used
+  // by the Problems banner (#979 / #974/E). Fetched alongside the
+  // existing admin sources; the same auto-refresh loop polls it.
+  const systemStatus = useAsync(fetchSystemStatus, []);
   const recs = useAsync(
     () =>
       fetchRecommendations(
@@ -249,6 +254,7 @@ export function AdminPage() {
         v2={v2.data}
         jobs={jobs.data}
         coverage={coverage.data}
+        credentialHealth={systemStatus.data?.credential_health ?? null}
         v2Error={v2.error !== null}
         jobsError={jobs.error !== null}
         coverageError={coverage.error !== null}


### PR DESCRIPTION
Refs #974. Closes #979. Operator-facing loop for the credential-health umbrella.

## What

- **\`/system/status\` extension**: \`credential_health: { state, last_recovered_at, last_error }\` resolved per-operator via \`sole_operator_id\` + \`get_operator_credential_health\` + \`get_last_recovered_at\`. Falls back to \`missing\` when no operator yet.
- **Frontend types**: \`CredentialHealthSummary\` + \`SystemStatusResponse.credential_health\` added.
- **\`ProblemsPanel\`** accepts an optional \`credentialHealth\` prop. When \`state==='rejected'\` it prepends a synthetic ActionNeededItem (\`CREDENTIAL_REJECTED_BANNER\`) at the top of \`action_needed\` so the operator sees an actionable "Update the API key in Settings → Providers" link instead of an empty problems panel.
- **AdminPage** fetches \`/system/status\` via \`useAsync\` and passes \`credential_health\` to ProblemsPanel.

## Why

After #977 the orchestrator PREREQ_SKIPs all credential-using layers when health is rejected, and AUTH_EXPIRED suppression hides historical cascade rows. Without this banner the operator with bad keys would see no problems despite the system being fully gated. The banner is the actionable surface that closes the loop.

## Test plan

- [x] 3 new ProblemsPanel tests:
  - Banner renders when \`credential_health.state === 'rejected'\`
  - Banner doesn't render when state === 'valid'
  - Banner doesn't render when credentialHealth is null
- [x] All 24 ProblemsPanel tests pass.
- [x] Frontend typecheck clean.
- [x] Backend ruff + pyright clean.
- [x] 91 cross-PR credential-health tests pass.
- [x] Smoke (lifespan boots clean) passes.

## Spec

\`docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md\` section "Frontend integration".