### PR TITLE
feat(#980): Settings switches to PUT /broker-credentials/replace

### DIFF
--- a/frontend/src/api/brokerCredentials.ts
+++ b/frontend/src/api/brokerCredentials.ts
@@ -69,6 +69,35 @@ export function revokeBrokerCredential(id: string): Promise<void> {
   return apiFetch<void>(`/broker-credentials/${id}`, { method: "DELETE" });
 }
 
+/**
+ * #980 / #974/F: atomic revoke + insert in one transaction.
+ *
+ * Used by Settings + Setup wizard when an existing credential row
+ * for the same (provider, label, environment) is being replaced.
+ * Subscribers (orchestrator pre-flight gate, WS subscriber, admin
+ * banner) never observe a transient MISSING state during the swap.
+ *
+ * The backend short-circuits on identical secret (decrypts the
+ * existing row inside the transaction and compares); in that case
+ * the response carries `changed: false` and no NOTIFY fires.
+ */
+export interface ReplaceBrokerCredentialResponse {
+  changed: boolean;
+  credential: BrokerCredentialView;
+}
+
+export function replaceBrokerCredential(input: {
+  provider: BrokerProvider;
+  label: string;
+  environment: string;
+  secret: string;
+}): Promise<ReplaceBrokerCredentialResponse> {
+  return apiFetch<ReplaceBrokerCredentialResponse>("/broker-credentials/replace", {
+    method: "PUT",
+    body: JSON.stringify(input),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Validate (transient probe — nothing is persisted)
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -25,6 +25,7 @@ import {
   type CreateBrokerCredentialResponse,
   createBrokerCredential,
   listBrokerCredentials,
+  replaceBrokerCredential,
   revokeBrokerCredential,
   validateBrokerCredential,
   validateStoredCredentials,
@@ -34,6 +35,7 @@ import { ApiError } from "@/api/client";
 vi.mock("@/api/brokerCredentials", () => ({
   listBrokerCredentials: vi.fn(),
   createBrokerCredential: vi.fn(),
+  replaceBrokerCredential: vi.fn(),
   revokeBrokerCredential: vi.fn(),
   validateBrokerCredential: vi.fn(),
   validateStoredCredentials: vi.fn(),
@@ -57,6 +59,7 @@ vi.mock("@/api/budget", () => ({
 
 const mockedList = vi.mocked(listBrokerCredentials);
 const mockedCreate = vi.mocked(createBrokerCredential);
+const mockedReplace = vi.mocked(replaceBrokerCredential);
 const mockedRevoke = vi.mocked(revokeBrokerCredential);
 const mockedValidate = vi.mocked(validateBrokerCredential);
 const mockedValidateStored = vi.mocked(validateStoredCredentials);
@@ -552,23 +555,24 @@ describe("SettingsPage — edit single key", () => {
     mockedList.mockResolvedValue([apiKeyRow(), userKeyRow()]);
     mockedRevoke.mockResolvedValue(undefined);
     mockedCreate.mockResolvedValue(withoutPhrase());
+    mockedReplace.mockResolvedValue({
+      changed: true,
+      credential: makeRow({ id: "new-api-id", label: "api_key" }),
+    });
   });
 
-  it("opens edit form for API key and saves (revoke + create)", async () => {
+  it("opens edit form for API key and saves via PUT /replace (#980)", async () => {
     const user = userEvent.setup();
     render(<SettingsPage />);
     await screen.findByText("api_key");
 
-    // Click Edit on the first credential row
     const editButtons = screen.getAllByRole("button", { name: "Edit" });
     await user.click(editButtons[0]!);
 
-    // Edit form should appear
     expect(screen.getByText("Edit API key")).toBeInTheDocument();
     const input = screen.getByLabelText("New API key");
     await user.type(input, "new-secret-value");
 
-    // After save, list refreshes — set up the mock for refresh
     mockedList.mockResolvedValueOnce([
       makeRow({ id: "new-id", label: "api_key", last_four: "alue" }),
       userKeyRow(),
@@ -577,16 +581,16 @@ describe("SettingsPage — edit single key", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
-      // Revoke was called for the old api_key
-      expect(mockedRevoke).toHaveBeenCalledWith("aaaa-1111");
+      expect(mockedReplace).toHaveBeenCalledWith({
+        provider: "etoro",
+        label: "api_key",
+        environment: "demo",
+        secret: "new-secret-value",
+      });
     });
-    // Create was called with the new secret
-    expect(mockedCreate).toHaveBeenCalledWith({
-      provider: "etoro",
-      label: "api_key",
-      environment: "demo",
-      secret: "new-secret-value",
-    });
+    // The atomic replace endpoint replaces the legacy revoke+create.
+    expect(mockedRevoke).not.toHaveBeenCalled();
+    expect(mockedCreate).not.toHaveBeenCalled();
   });
 
   it("cancel returns to idle management panel", async () => {
@@ -604,12 +608,11 @@ describe("SettingsPage — edit single key", () => {
     expect(screen.getByRole("button", { name: /test connection/i })).toBeInTheDocument();
   });
 
-  it("surfaces partial failure when revoke succeeds but create fails", async () => {
-    mockedRevoke.mockResolvedValue(undefined);
-    mockedCreate.mockRejectedValueOnce(new Error("network"));
-    // After refresh, the revoked key is gone → repair mode
-    mockedList.mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
-    mockedList.mockResolvedValueOnce([userKeyRow()]);
+  it("surfaces an error when PUT /replace fails (#980)", async () => {
+    // Replace endpoint failure no longer leaves a partial state —
+    // the server does revoke+insert in one tx, so atomicity means
+    // either both happen or neither. The UI just reports the error.
+    mockedReplace.mockRejectedValueOnce(new Error("network"));
 
     const user = userEvent.setup();
     render(<SettingsPage />);
@@ -622,8 +625,10 @@ describe("SettingsPage — edit single key", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("alert")).toHaveTextContent(/old api_key was revoked/i);
+      expect(screen.getByRole("alert")).toHaveTextContent(/could not update credential/i);
     });
+    // No revoke happened — atomic replace either succeeds or fails.
+    expect(mockedRevoke).not.toHaveBeenCalled();
   });
 });
 
@@ -636,9 +641,13 @@ describe("SettingsPage — replace both keys", () => {
     mockedList.mockResolvedValue([apiKeyRow(), userKeyRow()]);
     mockedRevoke.mockResolvedValue(undefined);
     mockedCreate.mockResolvedValue(withoutPhrase());
+    mockedReplace.mockResolvedValue({
+      changed: true,
+      credential: makeRow({ id: "new-id", label: "api_key" }),
+    });
   });
 
-  it("opens replace form and saves (revoke both + create both)", async () => {
+  it("opens replace form and saves (PUT /replace per label) (#980)", async () => {
     const user = userEvent.setup();
     render(<SettingsPage />);
     await screen.findByText(/Credentials configured/i);
@@ -657,22 +666,21 @@ describe("SettingsPage — replace both keys", () => {
     await user.click(screen.getByRole("button", { name: /^replace both$/i }));
 
     await waitFor(() => {
-      // Both old credentials revoked
-      expect(mockedRevoke).toHaveBeenCalledTimes(2);
+      expect(mockedReplace).toHaveBeenCalledTimes(2);
     });
-    // Both new credentials created
-    expect(mockedCreate).toHaveBeenCalledTimes(2);
+    // Atomic replace per label; no DELETE+POST sequence.
+    expect(mockedRevoke).not.toHaveBeenCalled();
+    expect(mockedCreate).not.toHaveBeenCalled();
   });
 
-  it("surfaces partial failure when api_key created but user_key fails", async () => {
-    mockedRevoke.mockResolvedValue(undefined);
-    // api_key create succeeds, user_key create fails
-    mockedCreate
-      .mockResolvedValueOnce(withoutPhrase())
+  it("surfaces partial failure when api_key replaced but user_key fails (#980)", async () => {
+    // First label succeeds (api_key), second fails (user_key).
+    mockedReplace
+      .mockResolvedValueOnce({
+        changed: true,
+        credential: makeRow({ id: "new-api-id", label: "api_key" }),
+      })
       .mockRejectedValueOnce(new Error("network"));
-    // After refresh, only api_key exists → repair mode
-    mockedList.mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
-    mockedList.mockResolvedValueOnce([makeRow({ label: "api_key" })]);
 
     const user = userEvent.setup();
     render(<SettingsPage />);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -22,6 +22,7 @@ import {
   type BrokerCredentialView,
   type ValidateCredentialResponse,
   createBrokerCredential,
+  replaceBrokerCredential,
   listBrokerCredentials,
   revokeBrokerCredential,
   validateBrokerCredential,
@@ -298,21 +299,14 @@ function BrokerCredentialsSection(): JSX.Element {
     const label = manageAction === "edit-api_key" ? "api_key" : "user_key";
     setEditError(null);
     setEditing(true);
-    let revoked = false;
     try {
-      // Find the existing active credential for this label to revoke it.
-      const existing = rows?.find(
-        (r) =>
-          r.label === label &&
-          r.provider === "etoro" &&
-          r.environment === ENVIRONMENT &&
-          r.revoked_at === null,
-      );
-      if (existing) {
-        await revokeBrokerCredential(existing.id);
-        revoked = true;
-      }
-      await createBrokerCredential({
+      // #980 / #974/F: atomic revoke + insert in one server-side
+      // transaction. Pre-#980 this path issued DELETE + POST sequentially,
+      // letting subscribers (orchestrator gate, WS subscriber, admin
+      // banner) observe a transient MISSING state between the two calls.
+      // The PUT /replace endpoint does both inside one tx so no
+      // intermediate state is ever visible.
+      await replaceBrokerCredential({
         provider: "etoro",
         label,
         environment: ENVIRONMENT,
@@ -321,15 +315,25 @@ function BrokerCredentialsSection(): JSX.Element {
       setEditSecret("");
       setManageAction("idle");
     } catch (err: unknown) {
-      // If the old key was already revoked but the new save failed, the
-      // credential set is now incomplete.  After refresh() the mode will
-      // transition to "repair", hiding the edit form — so surface the
-      // error via actionError (rendered outside mode-specific sections).
-      if (revoked) {
-        const msg = `The old ${label} was revoked but the replacement failed — re-enter it below.`;
-        setActionError(msg);
-      } else if (err instanceof ApiError && err.status === 409) {
-        setEditError("A credential with that label already exists.");
+      if (err instanceof ApiError && err.status === 404) {
+        // Replace requires an existing active row. Falling here means
+        // the row was revoked between mount and submit; create instead.
+        try {
+          await createBrokerCredential({
+            provider: "etoro",
+            label,
+            environment: ENVIRONMENT,
+            secret: editSecret,
+          });
+          setEditSecret("");
+          setManageAction("idle");
+        } catch (createErr: unknown) {
+          if (createErr instanceof ApiError && createErr.status === 400) {
+            setEditError("Invalid key value.");
+          } else {
+            setEditError("Could not update credential.");
+          }
+        }
       } else if (err instanceof ApiError && err.status === 400) {
         setEditError("Invalid key value.");
       } else {
@@ -345,31 +349,22 @@ function BrokerCredentialsSection(): JSX.Element {
     e.preventDefault();
     setEditError(null);
     setEditing(true);
-    // Track progress so the error message reflects what actually happened.
-    let revokedCount = 0;
-    let createdApiKey = false;
+    // #980 / #974/F: each label is replaced via PUT /broker-credentials/replace
+    // (atomic revoke + insert in one server-side tx). Pre-#980 this
+    // path issued DELETE-DELETE-POST-POST sequentially and observers
+    // saw a transient MISSING + half-saved state; now each label is
+    // its own atomic replace, so worst case one label is replaced
+    // and the other isn't (operator-visible).
+    let savedApiKey = false;
     try {
-      // Revoke both existing active credentials.
-      const activeRows = rows?.filter(
-        (r) =>
-          r.provider === "etoro" &&
-          r.environment === ENVIRONMENT &&
-          r.revoked_at === null,
-      ) ?? [];
-      for (const row of activeRows) {
-        await revokeBrokerCredential(row.id);
-        revokedCount += 1;
-      }
-
-      // Create both new credentials.
-      await createBrokerCredential({
+      await replaceBrokerCredential({
         provider: "etoro",
         label: "api_key",
         environment: ENVIRONMENT,
         secret: apiKey,
       });
-      createdApiKey = true;
-      await createBrokerCredential({
+      savedApiKey = true;
+      await replaceBrokerCredential({
         provider: "etoro",
         label: "user_key",
         environment: ENVIRONMENT,
@@ -380,25 +375,21 @@ function BrokerCredentialsSection(): JSX.Element {
       setUserKey("");
       setManageAction("idle");
     } catch (err: unknown) {
-      // Determine the user-facing error message.  Specific API errors
-      // (409/400) take priority over generic partial-failure messaging
-      // so the operator sees the actionable detail.
       let message: string;
-      if (err instanceof ApiError && err.status === 409) {
-        message = "A credential with that label already exists.";
+      if (err instanceof ApiError && err.status === 404) {
+        // Replace endpoint requires an existing active row. If we
+        // hit this, it means the credential pair isn't actually
+        // present despite the UI being in 'replace' mode — race
+        // with another tab. Refresh will recover into the right mode.
+        message = "Credentials no longer exist — refreshing.";
       } else if (err instanceof ApiError && err.status === 400) {
         message = "Invalid key value.";
       } else {
         message = "Could not replace credentials.";
       }
 
-      // If revokes already happened, the mode will transition after
-      // refresh — surface via actionError (rendered outside mode-
-      // conditional sections) and prepend context about what was lost.
-      if (createdApiKey) {
+      if (savedApiKey) {
         setActionError(`api_key was saved but user_key failed — re-enter user_key below. ${message}`);
-      } else if (revokedCount > 0) {
-        setActionError(`Old credentials were revoked but neither replacement was saved — re-enter both below. ${message}`);
       } else {
         setEditError(message);
       }


### PR DESCRIPTION
Refs #974. Closes #980. Final child PR — frontend Settings flow now uses the atomic PUT /replace endpoint instead of DELETE+POST.

## What

- New \`replaceBrokerCredential\` API helper (PUT /broker-credentials/replace).
- \`SettingsPage.handleEditSave\` (single-label edit) → PUT replace. 404 fallback creates instead (race with concurrent revoke).
- \`SettingsPage.handleReplaceSave\` (both-label replace) → PUT replace per label. No more DELETE-DELETE-POST-POST sequence.

## Why

The legacy DELETE+POST sequence let subscribers (orchestrator gate, WS subscriber, admin banner) observe a transient MISSING state between the revoke and create. The atomic PUT /replace endpoint (#975) does both in one server-side transaction so no intermediate state is ever visible.

## Out of scope

SetupPage's first-run wizard stays on POST /broker-credentials — it's the genuine first-create case (no existing row to replace). The repair-mode path stays on POST since by definition only one label exists in repair mode.

## Test plan

- [x] SettingsPage.test.tsx updated for the PUT /replace contract: 4 tests rewritten, 0 broken.
- [x] All 28 SettingsPage tests pass.
- [x] Frontend typecheck + Backend ruff + format + pyright clean.
- [x] 45 cross-PR credential-health tests pass + smoke clean.

## Spec

\`docs/superpowers/specs/2026-05-06-credential-health-precondition-design.md\` section "Atomic credential replacement" + "Frontend integration".