### PR TITLE
fix(#973): relabel UI to eToro's public/private terminology

### DIFF
--- a/app/services/sync_orchestrator/layer_types.py
+++ b/app/services/sync_orchestrator/layer_types.py
@@ -60,7 +60,7 @@ class Remedy:
 REMEDIES: dict[FailureCategory, Remedy] = {
     FailureCategory.AUTH_EXPIRED: Remedy(
         message="Credential rejected by provider",
-        operator_fix="Update the API key in Settings → Providers",
+        operator_fix="Update the public key in Settings → Providers",
         self_heal=False,
     ),
     FailureCategory.RATE_LIMITED: Remedy(

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -195,14 +195,14 @@ describe("ProblemsPanel", () => {
         display_name: "Layer X",
         category: "auth_expired",
         operator_message: "Credential expired",
-        operator_fix: "Update the API key in Settings → Providers",
+        operator_fix: "Update the public key in Settings → Providers",
         self_heal: false,
         consecutive_failures: 1,
         affected_downstream: [],
       },
     ];
     renderPanel({ v2 });
-    const link = screen.getByRole("link", { name: /Update the API key/i });
+    const link = screen.getByRole("link", { name: /Update the public key/i });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/settings#providers");
   });
@@ -495,7 +495,7 @@ describe("ProblemsPanel", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders a Settings link when operator_fix says 'Update the API key in Settings'", () => {
+  it("renders a Settings link when operator_fix says 'Update the public key in Settings'", () => {
     const v2 = emptyV2();
     v2.system_state = "needs_attention";
     v2.action_needed = [
@@ -504,14 +504,14 @@ describe("ProblemsPanel", () => {
         display_name: "Layer X",
         category: "auth_expired",
         operator_message: "Credential expired",
-        operator_fix: "Update the API key in Settings",
+        operator_fix: "Update the public key in Settings",
         self_heal: false,
         consecutive_failures: 1,
         affected_downstream: [],
       },
     ];
     renderPanel({ v2 });
-    const link = screen.getByRole("link", { name: /Update the API key in Settings/i });
+    const link = screen.getByRole("link", { name: /Update the public key in Settings/i });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/settings#providers");
   });

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -62,7 +62,7 @@ const CREDENTIAL_REJECTED_BANNER: ActionNeededItem = {
   category: "auth_expired",
   operator_message:
     "eToro rejected your credentials. The orchestrator has paused all credential-using layers until you save valid keys.",
-  operator_fix: "Update the API key in Settings → Providers",
+  operator_fix: "Update the public key in Settings → Providers",
   self_heal: false,
   consecutive_failures: 0,
   affected_downstream: [],
@@ -79,7 +79,7 @@ interface SourceCache {
 
 function mentionsSettings(text: string): boolean {
   // Match the canonical remedy phrasings emitted by the backend REMEDIES
-  // table — e.g. "Set X in Settings → Providers", "Update the API key in
+  // table — e.g. "Set X in Settings → Providers", "Update the public key in
   // Settings". Narrow enough that a remedy mentioning settings/providers
   // in passing (e.g. "nothing to do with Settings — inspect the row
   // manually") stays plain text rather than becoming a misleading link.

--- a/frontend/src/components/broker/ValidationResultDisplay.tsx
+++ b/frontend/src/components/broker/ValidationResultDisplay.tsx
@@ -19,7 +19,7 @@ export function ValidationResultDisplay({
   if (!result.auth_valid) {
     return (
       <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
-        Authentication failed — check your API key and user key.
+        Authentication failed — check your eToro public key and private key.
       </div>
     );
   }

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -92,8 +92,8 @@ function withoutPhrase(): CreateBrokerCredentialResponse {
 
 async function fillAndSubmit(apiKey: string, userKey: string): Promise<void> {
   const user = userEvent.setup();
-  await user.type(screen.getByLabelText("API key"), apiKey);
-  await user.type(screen.getByLabelText("User key"), userKey);
+  await user.type(screen.getByLabelText("Public key"), apiKey);
+  await user.type(screen.getByLabelText("Private key"), userKey);
   await user.click(screen.getByRole("button", { name: /save credential/i }));
 }
 
@@ -118,27 +118,27 @@ describe("SettingsPage — credential-set modes", () => {
   it("shows both key fields when no credentials exist (Create mode)", async () => {
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    expect(screen.getByLabelText("API key")).toBeInTheDocument();
-    expect(screen.getByLabelText("User key")).toBeInTheDocument();
+    expect(screen.getByLabelText("Public key")).toBeInTheDocument();
+    expect(screen.getByLabelText("Private key")).toBeInTheDocument();
   });
 
   it("shows only the missing field when one key exists (Repair mode)", async () => {
     mockedList.mockResolvedValueOnce([apiKeyRow()]);
     render(<SettingsPage />);
-    await screen.findByText("api_key");
+    await screen.findByText("Public key");
     // api_key exists, so only user_key field should be shown.
-    expect(screen.queryByLabelText("API key")).toBeNull();
-    expect(screen.getByLabelText("User key")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Public key")).toBeNull();
+    expect(screen.getByLabelText("Private key")).toBeInTheDocument();
     expect(screen.getByText(/One key was already saved/i)).toBeInTheDocument();
   });
 
   it("hides the create form when both keys exist (Complete mode)", async () => {
     mockedList.mockResolvedValueOnce([apiKeyRow(), userKeyRow()]);
     render(<SettingsPage />);
-    await screen.findByText("api_key");
+    await screen.findByText("Public key");
     expect(screen.getByText(/Credentials configured/i)).toBeInTheDocument();
-    expect(screen.queryByLabelText("API key")).toBeNull();
-    expect(screen.queryByLabelText("User key")).toBeNull();
+    expect(screen.queryByLabelText("Public key")).toBeNull();
+    expect(screen.queryByLabelText("Private key")).toBeNull();
   });
 
   it("shows environment in the credential list", async () => {
@@ -166,8 +166,8 @@ describe("SettingsPage — test connection", () => {
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await userEvent.setup().type(screen.getByLabelText("API key"), "test-api-key");
-    await user.type(screen.getByLabelText("User key"), "test-user-key");
+    await userEvent.setup().type(screen.getByLabelText("Public key"), "test-api-key");
+    await user.type(screen.getByLabelText("Private key"), "test-user-key");
     await user.click(screen.getByRole("button", { name: /test connection/i }));
 
     expect(await screen.findByText(/Connection verified/i)).toBeInTheDocument();
@@ -189,8 +189,8 @@ describe("SettingsPage — test connection", () => {
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await user.type(screen.getByLabelText("API key"), "bad-api-key");
-    await user.type(screen.getByLabelText("User key"), "bad-user-key");
+    await user.type(screen.getByLabelText("Public key"), "bad-api-key");
+    await user.type(screen.getByLabelText("Private key"), "bad-user-key");
     await user.click(screen.getByRole("button", { name: /test connection/i }));
 
     expect(
@@ -213,8 +213,8 @@ describe("SettingsPage — test connection", () => {
 
     render(<SettingsPage />);
     await screen.findByText(/No broker credentials saved yet/i);
-    await user.type(screen.getByLabelText("API key"), "test-api-key");
-    await user.type(screen.getByLabelText("User key"), "test-user-key");
+    await user.type(screen.getByLabelText("Public key"), "test-api-key");
+    await user.type(screen.getByLabelText("Private key"), "test-user-key");
     await user.click(screen.getByRole("button", { name: /test connection/i }));
 
     expect(
@@ -226,7 +226,7 @@ describe("SettingsPage — test connection", () => {
   it("disables Test connection in Repair mode", async () => {
     mockedList.mockResolvedValueOnce([apiKeyRow()]);
     render(<SettingsPage />);
-    await screen.findByText("api_key");
+    await screen.findByText("Public key");
 
     const btn = screen.getByRole("button", { name: /test connection/i });
     expect(btn).toBeDisabled();
@@ -275,10 +275,10 @@ describe("SettingsPage — two-key save", () => {
     mockedCreate.mockResolvedValueOnce(withoutPhrase());
 
     render(<SettingsPage />);
-    await screen.findByText("api_key");
+    await screen.findByText("Public key");
 
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText("User key"), "test-user-key");
+    await user.type(screen.getByLabelText("Private key"), "test-user-key");
     await user.click(screen.getByRole("button", { name: /save credential/i }));
 
     await waitFor(() => {
@@ -309,9 +309,9 @@ describe("SettingsPage — two-key save", () => {
     expect(await screen.findByText(/Could not save credential/i)).toBeInTheDocument();
     // Re-derived to Repair mode: only user_key field visible.
     await waitFor(() => {
-      expect(screen.queryByLabelText("API key")).toBeNull();
+      expect(screen.queryByLabelText("Public key")).toBeNull();
     });
-    expect(screen.getByLabelText("User key")).toBeInTheDocument();
+    expect(screen.getByLabelText("Private key")).toBeInTheDocument();
   });
 });
 
@@ -370,7 +370,7 @@ describe("SettingsPage — complete mode management", () => {
 
   it("shows Edit button on each active credential row", async () => {
     render(<SettingsPage />);
-    await screen.findByText("api_key");
+    await screen.findByText("Public key");
     const editButtons = screen.getAllByRole("button", { name: "Edit" });
     expect(editButtons).toHaveLength(2);
   });
@@ -428,13 +428,13 @@ describe("SettingsPage — edit single key", () => {
   it("opens edit form for API key and saves via PUT /replace (#980)", async () => {
     const user = userEvent.setup();
     render(<SettingsPage />);
-    await screen.findByText("api_key");
+    await screen.findByText("Public key");
 
     const editButtons = screen.getAllByRole("button", { name: "Edit" });
     await user.click(editButtons[0]!);
 
-    expect(screen.getByText("Edit API key")).toBeInTheDocument();
-    const input = screen.getByLabelText("New API key");
+    expect(screen.getByText("Edit public key")).toBeInTheDocument();
+    const input = screen.getByLabelText("New public key");
     await user.type(input, "new-secret-value");
 
     mockedList.mockResolvedValueOnce([
@@ -460,12 +460,12 @@ describe("SettingsPage — edit single key", () => {
   it("cancel returns to idle management panel", async () => {
     const user = userEvent.setup();
     render(<SettingsPage />);
-    await screen.findByText("api_key");
+    await screen.findByText("Public key");
 
     const editButtons = screen.getAllByRole("button", { name: "Edit" });
     await user.click(editButtons[0]!);
 
-    expect(screen.getByText("Edit API key")).toBeInTheDocument();
+    expect(screen.getByText("Edit public key")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     // Should be back to idle — management buttons visible
@@ -480,12 +480,12 @@ describe("SettingsPage — edit single key", () => {
 
     const user = userEvent.setup();
     render(<SettingsPage />);
-    await screen.findByText("api_key");
+    await screen.findByText("Public key");
 
     const editButtons = screen.getAllByRole("button", { name: "Edit" });
     await user.click(editButtons[0]!);
 
-    await user.type(screen.getByLabelText("New API key"), "new-val");
+    await user.type(screen.getByLabelText("New public key"), "new-val");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
@@ -519,8 +519,8 @@ describe("SettingsPage — replace both keys", () => {
     await user.click(screen.getByRole("button", { name: /replace both/i }));
 
     expect(screen.getByText("Replace both keys")).toBeInTheDocument();
-    await user.type(screen.getByLabelText("New API key"), "new-api");
-    await user.type(screen.getByLabelText("New user key"), "new-user");
+    await user.type(screen.getByLabelText("New public key"), "new-api");
+    await user.type(screen.getByLabelText("New private key"), "new-user");
 
     mockedList.mockResolvedValueOnce([
       makeRow({ id: "new-api-id", label: "api_key" }),
@@ -551,8 +551,8 @@ describe("SettingsPage — replace both keys", () => {
     await screen.findByText(/Credentials configured/i);
 
     await user.click(screen.getByRole("button", { name: /replace both/i }));
-    await user.type(screen.getByLabelText("New API key"), "new-api");
-    await user.type(screen.getByLabelText("New user key"), "new-user");
+    await user.type(screen.getByLabelText("New public key"), "new-api");
+    await user.type(screen.getByLabelText("New private key"), "new-user");
     await user.click(screen.getByRole("button", { name: /^replace both$/i }));
 
     await waitFor(() => {
@@ -574,8 +574,8 @@ describe("SettingsPage — replace both keys", () => {
     await screen.findByText(/Credentials configured/i);
 
     await user.click(screen.getByRole("button", { name: /replace both/i }));
-    await user.type(screen.getByLabelText("New API key"), "test-api");
-    await user.type(screen.getByLabelText("New user key"), "test-user");
+    await user.type(screen.getByLabelText("New public key"), "test-api");
+    await user.type(screen.getByLabelText("New private key"), "test-user");
 
     await user.click(screen.getByRole("button", { name: /test connection/i }));
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -197,7 +197,7 @@ function BrokerCredentialsSection(): JSX.Element {
       if (err instanceof ApiError && err.status === 409) {
         setCreateError("A credential with that label already exists. Revoke it first to replace.");
       } else if (err instanceof ApiError && err.status === 400) {
-        setCreateError("Invalid API key or user key value.");
+        setCreateError("Invalid public key or private key value.");
       } else {
         setCreateError("Could not save credential.");
       }
@@ -415,7 +415,13 @@ function BrokerCredentialsSection(): JSX.Element {
                 className="flex items-center justify-between px-3 py-2 text-sm"
               >
                 <div>
-                  <span className="font-medium text-slate-800 dark:text-slate-100">{row.label}</span>
+                  <span className="font-medium text-slate-800 dark:text-slate-100">
+                    {row.label === "api_key"
+                      ? "Public key"
+                      : row.label === "user_key"
+                        ? "Private key"
+                        : row.label}
+                  </span>
                   <span className="ml-2 text-xs text-slate-500">
                     {row.provider} · {row.environment} · ••••{row.last_four}
                   </span>
@@ -493,14 +499,14 @@ function BrokerCredentialsSection(): JSX.Element {
           className="max-w-sm space-y-3 rounded border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900"
         >
           <h3 className="text-sm font-medium text-slate-700">
-            Edit {manageAction === "edit-api_key" ? "API key" : "user key"}
+            Edit {manageAction === "edit-api_key" ? "public key" : "private key"}
           </h3>
           <p className="text-xs text-slate-500">
             Enter the new value. The existing key will be revoked and replaced.
           </p>
           <label className="block text-sm">
             <span className="mb-1 block text-slate-600">
-              {manageAction === "edit-api_key" ? "New API key" : "New user key"}
+              {manageAction === "edit-api_key" ? "New public key" : "New private key"}
             </span>
             <input
               type="password"
@@ -549,7 +555,7 @@ function BrokerCredentialsSection(): JSX.Element {
             You can test the new credentials before saving.
           </p>
           <label className="block text-sm">
-            <span className="mb-1 block text-slate-600">New API key</span>
+            <span className="mb-1 block text-slate-600">New public key</span>
             <input
               type="password"
               name="broker-credential-api-key"
@@ -562,7 +568,7 @@ function BrokerCredentialsSection(): JSX.Element {
             />
           </label>
           <label className="block text-sm">
-            <span className="mb-1 block text-slate-600">New user key</span>
+            <span className="mb-1 block text-slate-600">New private key</span>
             <input
               type="password"
               name="broker-credential-user-key"
@@ -635,14 +641,14 @@ function BrokerCredentialsSection(): JSX.Element {
           </h3>
           {mode === "repair" && (
             <p className="text-xs text-slate-500">
-              One key was already saved. Enter the missing {missingLabel === "api_key" ? "API key" : "user key"} to
+              One key was already saved. Enter the missing {missingLabel === "api_key" ? "public key" : "private key"} to
               complete the credential pair.
             </p>
           )}
 
           {showApiKeyField && (
             <label className="block text-sm">
-              <span className="mb-1 block text-slate-600">API key</span>
+              <span className="mb-1 block text-slate-600">Public key</span>
               <input
                 type="password"
                 name="broker-credential-api-key"
@@ -658,7 +664,7 @@ function BrokerCredentialsSection(): JSX.Element {
 
           {showUserKeyField && (
             <label className="block text-sm">
-              <span className="mb-1 block text-slate-600">User key</span>
+              <span className="mb-1 block text-slate-600">Private key</span>
               <input
                 type="password"
                 name="broker-credential-user-key"


### PR DESCRIPTION
## What

Operator-facing labels switch from eBull's \"API key\" / \"User key\" to eToro's \"Public key\" / \"Private key\" so a fresh-install operator can match the eToro dashboard's wording without a swap-test cycle.

Backend label enum (`api_key` / `user_key`) is unchanged — Option B from the ticket. No schema churn, no migration.

## Why

Reported during 2026-05-06 fresh-install audit — operator entered the keys swapped, hit a 401, then had to re-test with the orientation flipped.

## Surfaces

- `frontend/src/pages/SettingsPage.tsx` — form labels (create + repair + edit + replace flows), helper copy, error message, credential-row label rendering.
- `frontend/src/components/broker/ValidationResultDisplay.tsx` — auth-failed copy.
- `frontend/src/components/admin/ProblemsPanel.tsx` — AUTH_EXPIRED operator_fix + comment.
- `app/services/sync_orchestrator/layer_types.py` — AUTH_EXPIRED `operator_fix` REMEDIES table copy (frontend mirrors).
- Tests updated: `SettingsPage.test.tsx`, `ProblemsPanel.test.tsx`.

## Test plan

- [x] `pnpm typecheck`: clean.
- [x] `node frontend/scripts/check-dark-classes.mjs`: 173 files, no violations.
- [x] `pnpm test:unit`: 766 pass, 11 pre-existing failures (theme/useChartTheme `localStorage.clear is not a function`) unaffected.
- [x] `uv run ruff check .` + `format --check` + `pyright`: clean.
- [x] Codex pre-push: no HIGH severity findings.

Closes #973