### PR TITLE
feat(#993): bootstrap_state schema + repo helpers + smoke

### DIFF
--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -1,0 +1,589 @@
+"""First-install bootstrap state — DB persistence layer.
+
+Source of truth for the bootstrap orchestrator's run history and the
+singleton scheduler-gate state. Spec:
+``docs/superpowers/specs/2026-05-07-first-install-bootstrap.md``.
+
+Three tables (sql/129_bootstrap_state.sql):
+
+  - ``bootstrap_runs``    — one row per "Run bootstrap" click.
+  - ``bootstrap_stages``  — one row per stage in a run (18 stages today).
+  - ``bootstrap_state``   — singleton row (id=1) with the canonical
+                            ``_bootstrap_complete`` gate status.
+
+This module owns all reads / writes against those tables. Callers
+(API endpoints, the orchestrator service, the scheduler prerequisite)
+must go through these helpers rather than touching the tables
+directly so the state machine stays consistent.
+
+Concurrency contract: ``start_run`` takes ``SELECT ... FOR UPDATE`` on
+the ``bootstrap_state`` singleton row before deciding whether to
+create a new run, so two concurrent ``POST /system/bootstrap/run``
+handlers cannot both succeed. The partial unique index on
+``bootstrap_runs(status='running')`` is defense-in-depth.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+BootstrapStatus = Literal["pending", "running", "complete", "partial_error"]
+RunStatus = Literal["running", "complete", "partial_error"]
+StageStatus = Literal["pending", "running", "success", "error", "skipped"]
+Lane = Literal["init", "etoro", "sec"]
+
+
+class BootstrapAlreadyRunning(RuntimeError):
+    """Raised by ``start_run`` when a run is already in flight.
+
+    The API layer maps this to 409 Conflict. The exception carries the
+    in-flight ``run_id`` so the API response can point the operator at
+    the existing run.
+    """
+
+    def __init__(self, run_id: int) -> None:
+        super().__init__(f"bootstrap run {run_id} is already running")
+        self.run_id = run_id
+
+
+@dataclass(frozen=True)
+class StageSpec:
+    """Static definition of a stage. Lives in code, not DB.
+
+    The orchestrator service builds the canonical ordered list of
+    18 specs (1 init + 1 eToro + 16 SEC) and passes it to ``start_run``,
+    which materialises one ``bootstrap_stages`` row per spec.
+    """
+
+    stage_key: str
+    stage_order: int
+    lane: Lane
+    job_name: str
+
+
+@dataclass(frozen=True)
+class StageRow:
+    """Snapshot of a single ``bootstrap_stages`` row."""
+
+    id: int
+    bootstrap_run_id: int
+    stage_key: str
+    stage_order: int
+    lane: Lane
+    job_name: str
+    status: StageStatus
+    started_at: datetime | None
+    completed_at: datetime | None
+    rows_processed: int | None
+    expected_units: int | None
+    units_done: int | None
+    last_error: str | None
+    attempt_count: int
+
+
+@dataclass(frozen=True)
+class RunSnapshot:
+    """Latest run + its stages, read in a single transaction."""
+
+    run_id: int
+    run_status: RunStatus
+    triggered_at: datetime
+    completed_at: datetime | None
+    stages: Sequence[StageRow] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class BootstrapState:
+    """Singleton bootstrap_state row."""
+
+    status: BootstrapStatus
+    last_run_id: int | None
+    last_completed_at: datetime | None
+
+
+def read_state(conn: psycopg.Connection[Any]) -> BootstrapState:
+    """Return the singleton bootstrap_state row.
+
+    Raises ``RuntimeError`` if the migration has not seeded the row.
+    The migration's ``INSERT ... ON CONFLICT DO NOTHING`` makes that
+    case represent migration corruption rather than first-time-run.
+    """
+    row = conn.execute("SELECT status, last_run_id, last_completed_at FROM bootstrap_state WHERE id = 1").fetchone()
+    if row is None:
+        raise RuntimeError("bootstrap_state singleton row missing; sql/129_bootstrap_state.sql may not have run")
+    return BootstrapState(
+        status=row[0],
+        last_run_id=row[1],
+        last_completed_at=row[2],
+    )
+
+
+def read_latest_run_with_stages(
+    conn: psycopg.Connection[Any],
+) -> RunSnapshot | None:
+    """Return the latest bootstrap_runs row + its stages, or None.
+
+    Reads happen inside a single transaction so a stage transition
+    landing mid-fetch cannot produce an inconsistent snapshot — the
+    contract this respects is the prevention-log entry "Multi-query
+    read handlers must use a single snapshot".
+    """
+    with conn.transaction():
+        run_row = conn.execute(
+            """
+            SELECT id, status, triggered_at, completed_at
+              FROM bootstrap_runs
+             ORDER BY id DESC
+             LIMIT 1
+            """
+        ).fetchone()
+        if run_row is None:
+            return None
+        run_id, run_status, triggered_at, completed_at = run_row
+
+        stage_rows = conn.execute(
+            """
+            SELECT id, bootstrap_run_id, stage_key, stage_order, lane, job_name,
+                   status, started_at, completed_at, rows_processed,
+                   expected_units, units_done, last_error, attempt_count
+              FROM bootstrap_stages
+             WHERE bootstrap_run_id = %(run_id)s
+             ORDER BY stage_order ASC, id ASC
+            """,
+            {"run_id": run_id},
+        ).fetchall()
+
+    stages = tuple(
+        StageRow(
+            id=row[0],
+            bootstrap_run_id=row[1],
+            stage_key=row[2],
+            stage_order=row[3],
+            lane=row[4],
+            job_name=row[5],
+            status=row[6],
+            started_at=row[7],
+            completed_at=row[8],
+            rows_processed=row[9],
+            expected_units=row[10],
+            units_done=row[11],
+            last_error=row[12],
+            attempt_count=row[13],
+        )
+        for row in stage_rows
+    )
+
+    return RunSnapshot(
+        run_id=run_id,
+        run_status=run_status,
+        triggered_at=triggered_at,
+        completed_at=completed_at,
+        stages=stages,
+    )
+
+
+def start_run(
+    conn: psycopg.Connection[Any],
+    *,
+    operator_id: str | None,
+    stage_specs: Sequence[StageSpec],
+) -> int:
+    """Create a new bootstrap run + seed pending stage rows.
+
+    Single-flight contract: takes ``SELECT ... FOR UPDATE`` on the
+    bootstrap_state singleton row, raises ``BootstrapAlreadyRunning``
+    if status is already ``running``, otherwise inserts a new
+    ``bootstrap_runs`` row and one ``bootstrap_stages`` row per spec,
+    then flips ``bootstrap_state.status`` to ``running``.
+
+    Returns the new ``bootstrap_runs.id``.
+
+    All work happens inside one transaction so a partial commit cannot
+    leave a half-seeded run.
+    """
+    if not stage_specs:
+        raise ValueError("stage_specs must be non-empty")
+
+    with conn.transaction():
+        state_row = conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1 FOR UPDATE").fetchone()
+        if state_row is None:
+            raise RuntimeError("bootstrap_state singleton row missing; sql/129_bootstrap_state.sql may not have run")
+        current_status, last_run_id = state_row
+        if current_status == "running":
+            raise BootstrapAlreadyRunning(run_id=last_run_id or 0)
+
+        run_row = conn.execute(
+            """
+            INSERT INTO bootstrap_runs (triggered_by_operator_id, status)
+            VALUES (%(operator_id)s, 'running')
+            RETURNING id
+            """,
+            {"operator_id": operator_id},
+        ).fetchone()
+        if run_row is None:
+            raise RuntimeError("INSERT INTO bootstrap_runs returned no row")
+        run_id = run_row[0]
+
+        for spec in stage_specs:
+            conn.execute(
+                """
+                INSERT INTO bootstrap_stages
+                       (bootstrap_run_id, stage_key, stage_order, lane, job_name, status)
+                VALUES (%(run_id)s, %(stage_key)s, %(stage_order)s, %(lane)s, %(job_name)s, 'pending')
+                """,
+                {
+                    "run_id": run_id,
+                    "stage_key": spec.stage_key,
+                    "stage_order": spec.stage_order,
+                    "lane": spec.lane,
+                    "job_name": spec.job_name,
+                },
+            )
+
+        conn.execute(
+            """
+            UPDATE bootstrap_state
+               SET status      = 'running',
+                   last_run_id = %(run_id)s
+             WHERE id = 1
+            """,
+            {"run_id": run_id},
+        )
+
+    return run_id
+
+
+def mark_stage_running(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    stage_key: str,
+) -> None:
+    """Transition a stage from pending to running.
+
+    Increments ``attempt_count``, clears stale ``last_error`` /
+    timestamps. Idempotency: re-running this on an already-running
+    stage row leaves attempt_count un-incremented (UPDATE matches
+    only ``status='pending'``).
+    """
+    conn.execute(
+        """
+        UPDATE bootstrap_stages
+           SET status        = 'running',
+               started_at    = now(),
+               completed_at  = NULL,
+               last_error    = NULL,
+               attempt_count = attempt_count + 1
+         WHERE bootstrap_run_id = %(run_id)s
+           AND stage_key        = %(stage_key)s
+           AND status           = 'pending'
+        """,
+        {"run_id": run_id, "stage_key": stage_key},
+    )
+
+
+def mark_stage_success(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    stage_key: str,
+    rows_processed: int | None = None,
+) -> None:
+    """Transition a stage to success on invoker exit."""
+    conn.execute(
+        """
+        UPDATE bootstrap_stages
+           SET status         = 'success',
+               completed_at   = now(),
+               rows_processed = %(rows_processed)s,
+               last_error     = NULL
+         WHERE bootstrap_run_id = %(run_id)s
+           AND stage_key        = %(stage_key)s
+        """,
+        {
+            "run_id": run_id,
+            "stage_key": stage_key,
+            "rows_processed": rows_processed,
+        },
+    )
+
+
+def mark_stage_error(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    stage_key: str,
+    error_message: str,
+) -> None:
+    """Record a stage error. Lane proceeds; orchestrator finalises later.
+
+    ``error_message`` is truncated to 1000 chars to keep DB rows
+    bounded; full forensic detail lives in the underlying
+    ``job_runs`` row that the invoker's own ``_tracked_job`` writes.
+    """
+    conn.execute(
+        """
+        UPDATE bootstrap_stages
+           SET status       = 'error',
+               completed_at = now(),
+               last_error   = %(error_message)s
+         WHERE bootstrap_run_id = %(run_id)s
+           AND stage_key        = %(stage_key)s
+        """,
+        {
+            "run_id": run_id,
+            "stage_key": stage_key,
+            "error_message": error_message[:1000],
+        },
+    )
+
+
+def finalize_run(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+) -> RunStatus:
+    """Compute terminal run status from per-stage outcomes.
+
+    Called by the orchestrator after both lane threads have joined.
+    All stages in error → ``partial_error``; otherwise ``complete``.
+    Updates the run row, the bootstrap_state singleton, and
+    ``last_completed_at`` in one transaction.
+
+    Returns the chosen terminal status.
+    """
+    with conn.transaction():
+        error_count_row = conn.execute(
+            """
+            SELECT COUNT(*) FROM bootstrap_stages
+             WHERE bootstrap_run_id = %(run_id)s
+               AND status = 'error'
+            """,
+            {"run_id": run_id},
+        ).fetchone()
+        error_count = error_count_row[0] if error_count_row is not None else 0
+        terminal: RunStatus = "partial_error" if error_count > 0 else "complete"
+
+        conn.execute(
+            """
+            UPDATE bootstrap_runs
+               SET status       = %(status)s,
+                   completed_at = now()
+             WHERE id = %(run_id)s
+            """,
+            {"status": terminal, "run_id": run_id},
+        )
+        conn.execute(
+            """
+            UPDATE bootstrap_state
+               SET status            = %(status)s,
+                   last_run_id       = %(run_id)s,
+                   last_completed_at = now()
+             WHERE id = 1
+            """,
+            {"status": terminal, "run_id": run_id},
+        )
+
+    return terminal
+
+
+def reset_failed_stages_for_retry(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+) -> int:
+    """Reset failed + later-numbered same-lane stages for retry.
+
+    Spec §"retry-failed dependency-aware reset". Returns the number
+    of rows reset to ``pending``.
+
+    Algorithm (one transaction):
+
+    1. Find all failed (error) stages on the latest run.
+    2. For each lane that has at least one failed stage, find the
+       smallest ``stage_order`` of a failed stage in that lane.
+    3. Reset every stage in that lane with ``stage_order >=`` the
+       smallest-failed-order to ``pending``, regardless of current
+       status. The orchestrator's per-stage pre-check skips stages
+       already in ``success``, so only re-running re-enqueued
+       pending stages happens.
+    4. Flip bootstrap_state.status back to ``running``.
+
+    If no failed stages exist, returns 0 and leaves state untouched.
+    """
+    with conn.transaction():
+        failed_rows = conn.execute(
+            """
+            SELECT lane, MIN(stage_order)
+              FROM bootstrap_stages
+             WHERE bootstrap_run_id = %(run_id)s
+               AND status           = 'error'
+             GROUP BY lane
+            """,
+            {"run_id": run_id},
+        ).fetchall()
+        if not failed_rows:
+            return 0
+
+        total_reset = 0
+        for lane, min_order in failed_rows:
+            cursor = conn.execute(
+                """
+                UPDATE bootstrap_stages
+                   SET status       = 'pending',
+                       started_at   = NULL,
+                       completed_at = NULL,
+                       last_error   = NULL
+                 WHERE bootstrap_run_id = %(run_id)s
+                   AND lane             = %(lane)s
+                   AND stage_order      >= %(min_order)s
+                """,
+                {"run_id": run_id, "lane": lane, "min_order": min_order},
+            )
+            if cursor.rowcount and cursor.rowcount > 0:
+                total_reset += cursor.rowcount
+
+        conn.execute(
+            """
+            UPDATE bootstrap_runs
+               SET status       = 'running',
+                   completed_at = NULL
+             WHERE id = %(run_id)s
+            """,
+            {"run_id": run_id},
+        )
+        conn.execute(
+            """
+            UPDATE bootstrap_state
+               SET status      = 'running',
+                   last_run_id = %(run_id)s
+             WHERE id = 1
+            """,
+            {"run_id": run_id},
+        )
+
+    return total_reset
+
+
+def force_mark_complete(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """Operator escape hatch: flip bootstrap_state.status to complete.
+
+    Used when the operator has manually fixed the cause of a stage
+    failure and wants to release the scheduler gate without re-running
+    heavy stages. Does not touch any run / stage row — those keep
+    their accurate forensic history. Audit-logging of the call is the
+    caller's responsibility.
+    """
+    conn.execute(
+        """
+        UPDATE bootstrap_state
+           SET status            = 'complete',
+               last_completed_at = now()
+         WHERE id = 1
+        """
+    )
+
+
+def reap_orphaned_running(
+    conn: psycopg.Connection[Any],
+) -> bool:
+    """Boot-recovery sweep for crash-orphaned runs.
+
+    Runs once at jobs-process startup. If
+    ``bootstrap_state.status='running'`` on cold start, no live thread
+    is executing this run. Sweep:
+
+      - Latest run's stages with ``status='running'`` → ``error``,
+        last_error='jobs process restarted mid-run'.
+      - Latest run's stages with ``status='pending'`` → ``error``,
+        last_error='orchestrator did not dispatch before restart'.
+      - Latest ``bootstrap_runs`` row → ``partial_error``.
+      - ``bootstrap_state`` → ``partial_error``.
+
+    All in one transaction. Idempotent on a state that is not
+    ``running``; returns True if a sweep occurred, False otherwise.
+    """
+    with conn.transaction():
+        state = conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1 FOR UPDATE").fetchone()
+        if state is None or state[0] != "running":
+            return False
+        last_run_id = state[1]
+        if last_run_id is None:
+            conn.execute("UPDATE bootstrap_state SET status = 'partial_error' WHERE id = 1")
+            return True
+
+        conn.execute(
+            """
+            UPDATE bootstrap_stages
+               SET status       = 'error',
+                   completed_at = now(),
+                   last_error   = 'jobs process restarted mid-run'
+             WHERE bootstrap_run_id = %(run_id)s
+               AND status           = 'running'
+            """,
+            {"run_id": last_run_id},
+        )
+        conn.execute(
+            """
+            UPDATE bootstrap_stages
+               SET status       = 'error',
+                   completed_at = now(),
+                   last_error   = 'orchestrator did not dispatch before restart'
+             WHERE bootstrap_run_id = %(run_id)s
+               AND status           = 'pending'
+            """,
+            {"run_id": last_run_id},
+        )
+        conn.execute(
+            """
+            UPDATE bootstrap_runs
+               SET status       = 'partial_error',
+                   completed_at = now()
+             WHERE id = %(run_id)s
+            """,
+            {"run_id": last_run_id},
+        )
+        conn.execute(
+            """
+            UPDATE bootstrap_state
+               SET status            = 'partial_error',
+                   last_completed_at = now()
+             WHERE id = 1
+            """
+        )
+
+    return True
+
+
+__all__ = [
+    "BootstrapAlreadyRunning",
+    "BootstrapState",
+    "BootstrapStatus",
+    "Lane",
+    "RunSnapshot",
+    "RunStatus",
+    "StageRow",
+    "StageSpec",
+    "StageStatus",
+    "finalize_run",
+    "force_mark_complete",
+    "mark_stage_error",
+    "mark_stage_running",
+    "mark_stage_success",
+    "read_latest_run_with_stages",
+    "read_state",
+    "reap_orphaned_running",
+    "reset_failed_stages_for_retry",
+    "start_run",
+]

--- a/docs/superpowers/specs/2026-05-07-first-install-bootstrap.md
+++ b/docs/superpowers/specs/2026-05-07-first-install-bootstrap.md
@@ -1,0 +1,841 @@
+# First-install bootstrap orchestrator + admin panel
+
+Author: claude (autonomous)
+Date: 2026-05-07
+Status: Draft (post-Codex round 4)
+
+## Problem
+
+Fresh eBull installs leave the database empty. Setup creates an
+operator + session, but no automation populates the universe, SEC
+filer directories, CUSIP cross-walks, filing events, or filing
+manifest. The scheduler immediately starts firing jobs that no-op
+against an empty universe — `sec_insider_transactions_backfill: instruments=0`
+is the visible symptom in the operator's logs.
+
+Two manual steps unblock today:
+
+- `POST /jobs/nightly_universe_sync/run` — populates `instruments` +
+  Tier 3 coverage.
+- `POST /jobs/sec_first_install_drain/run` — seeds
+  `sec_filing_manifest` + `data_freshness_index`.
+
+Plus 15+ other ingests must run before the system is fully populated
+end-to-end (see "Stages" below). None of this is surfaced in the
+admin UI as a single first-install backfill narrative; the operator
+has to know to invoke the right endpoints in the right order.
+
+## Goal
+
+After the operator clicks one button, the system reaches a
+fully-backfilled state suitable for normal scheduled-job operation,
+**without** requiring them to know the underlying job topology.
+
+Specifically:
+
+1. Universe + market data + SEC filer directories + CUSIP universe +
+   `filing_events` + filing manifest + freshness index + typed-form
+   parsers (DEF14A, 10-K business summary, Form 3/4, 8-K, dividend
+   calendar, 13F, NPORT) + ownership observations + fundamentals are
+   all populated end-to-end.
+2. Per-stage progress, ETA where computable, and per-stage error
+   visibility are surfaced in the admin UI.
+3. Scheduled jobs that depend on a populated DB stay quiet (skip with
+   a clear reason) until bootstrap is `complete`.
+4. Errors do not abort the run — the orchestrator iterates past
+   failures, logs them per stage, and offers a "retry failed" path.
+   Nightly schedules continue making further attempts on their own
+   cadence once `_bootstrap_complete` flips true.
+
+Non-goals:
+
+- Automatic kickoff at setup completion. Operator triggers explicitly
+  (Option B from the design discussion). Dashboard banner nudges; it
+  does not auto-fire — gated to comply with prevention-log entry
+  "Fire-and-forget job triggers missing first-time guard" (#145).
+- AI-driven jobs (thesis, ranking, recommendations). Out of scope —
+  these are not yet penciled in for the v1 demo and have no
+  first-install backfill semantics.
+- Cooperative cancel mid-run. Out of scope for v1 (see "Cancel" below).
+
+## Settled-decisions check
+
+- **#719 (process topology):** API process serves HTTP only. The
+  bootstrap orchestrator runs in the jobs process, dispatched via
+  the existing manual-job queue (`pending_job_requests` +
+  `pg_notify('ebull_job_request', ...)`). The HTTP endpoint writes a
+  `request_kind='manual_job'` row pointing at a new
+  `bootstrap_orchestrator` job we register in `_INVOKERS`. The
+  existing listener path (`app/jobs/listener.py:88`) dispatches it
+  unchanged. ✓
+- **Provider strategy (eToro = source of truth for universe; SEC =
+  US filings):** Stages reuse existing job invokers — no new provider
+  paths. ✓
+- **Free regulated-source-only fundamentals (#532):** Stage S16
+  (`fundamentals_sync`) uses the existing SEC XBRL Company Facts
+  path. ✓
+
+## Prevention-log applicable entries
+
+- **"Fire-and-forget job triggers missing first-time guard" (#145):**
+  Bootstrap is operator-explicit, never auto-fired. The status
+  endpoint must distinguish `pending` (never run) from `complete`
+  (done) so a returning operator does not re-fire by default — the UI
+  shows "Run bootstrap" only when status is `pending` or
+  `partial_error`.
+- **"Hint / warning state with no clear-on-next-transition" (#321):**
+  Per-stage `last_error` must clear when that stage transitions to
+  `running` on retry — leaving stale errors visible while the stage
+  is actively re-attempting is misleading.
+- **"Multiple ResilientClient instances sharing a rate limit must
+  share throttle state" (#168):** Stages in the SEC lane already go
+  through the shared process-wide token bucket
+  (`_PROCESS_RATE_LIMIT_CLOCK`). Lane design enforces strict serial
+  execution inside the SEC lane to avoid splitting the budget.
+- **"Naive datetime in TIMESTAMPTZ query params" (#278):** All
+  bootstrap timestamps stored as `timestamptz`; service code uses
+  timezone-aware UTC `datetime.now(timezone.utc)`.
+- **"Multi-query read handlers must use a single snapshot" (#1024):**
+  `GET /system/bootstrap/status` reads run + stages within one
+  `conn.transaction()` so a stage transitioning mid-fetch cannot
+  produce an internally-inconsistent payload.
+
+## Stages and lanes
+
+Bootstrap runs in three phases:
+
+- **Phase A — `init`:** sequential, single thread. Populates
+  `instruments` + tier 3 `coverage`. All later phases depend on this.
+- **Phase B — `lanes`:** two threads in parallel
+  (`etoro_lane`, `sec_lane`). Stages within each lane run strictly
+  serially.
+- **Phase C — `finalize`:** single-threaded state transition only;
+  no work units. Computes final run status from per-stage outcomes.
+
+### Phase A — init (1 stage)
+
+| # | Key | Job invoker | Purpose | ETA |
+|---|---|---|---|---|
+| A1 | `universe_sync` | `nightly_universe_sync` | Populates `instruments` + Tier 3 `coverage` rows | ~30s, ~1.5k rows |
+
+### Phase B — eToro lane (1 stage; runs parallel with SEC lane)
+
+| # | Key | Job invoker | Purpose | ETA |
+|---|---|---|---|---|
+| E1 | `candle_refresh` | `daily_candle_refresh` | Full-universe candles (eToro) | minutes; rolling rate |
+
+### Phase B — SEC lane (16 stages, sequential, shared 11 req/s bucket)
+
+| # | Key | Job invoker | Reads | Purpose | ETA |
+|---|---|---|---|---|---|
+| S1 | `cusip_universe_backfill` | `cusip_universe_backfill` | `instruments` | SEC official 13(f) list → `external_identifiers` | minutes |
+| S2 | `sec_13f_filer_directory_sync` | `sec_13f_filer_directory_sync` | — | quarterly form.idx → `institutional_filers` | minutes |
+| S3 | `sec_nport_filer_directory_sync` | `sec_nport_filer_directory_sync` | — | NPORT filer trust CIK harvest | minutes |
+| S4 | `cik_refresh` | `daily_cik_refresh` | `instruments` | SEC `company_tickers.json` → `external_identifiers` SEC CIK rows; **prereq for every SEC stage that resolves CIK by ticker** | seconds |
+| S5 | `filings_history_seed` | `bootstrap_filings_history_seed` (new) | CIK-mapped `instruments` | broad `refresh_filings` sweep — all form types, ~2y window — populates `filing_events` historically (the table every typed parser reads) | universe × ~3 req ÷ 11 req/s; ~minutes |
+| S6 | `sec_first_install_drain` | `sec_first_install_drain` | `instrument_sec_profile` + filer tables | submissions.json per CIK → `sec_filing_manifest` + `data_freshness_index` | filers × ~4 req ÷ 11 req/s ≈ ~60min |
+| S7 | `sec_def14a_bootstrap` | `sec_def14a_bootstrap` | `filing_events` (DEF 14A) | first DEF 14A parse pass | filings ÷ 11 req/s |
+| S8 | `sec_business_summary_bootstrap` | `sec_business_summary_bootstrap` | `filing_events` (10-K/A) | first business-section ingest | filings ÷ 11 req/s |
+| S9 | `sec_insider_transactions_backfill` | `sec_insider_transactions_backfill` | `filing_events` (Form 4) | first Form 4 backfill | filings ÷ 11 req/s |
+| S10 | `sec_form3_ingest` | `sec_form3_ingest` | `filing_events` (Form 3) | initial Form 3 parse | filings ÷ 11 req/s |
+| S11 | `sec_8k_events_ingest` | `sec_8k_events_ingest` | `filing_events` (8-K) | initial 8-K event extraction | filings ÷ 11 req/s |
+| ~~S12~~ | ~~`sec_dividend_calendar_ingest`~~ | ~~`sec_dividend_calendar_ingest`~~ | — | **dropped from v1 bootstrap** — reads `filing_events.items` (8-K parsed-items array) which neither `refresh_filings` nor `_upsert_filing_from_master_index` populates today; `sec_8k_events_ingest` (S11) writes a separate `eight_k_items` table. Bootstrap stage would always report `rows_processed=0`. Wire into bootstrap once `filing_events.items` is populated by an upstream parser (separate ticket). | — |
+| S13 | `sec_13f_quarterly_sweep` | `sec_13f_quarterly_sweep` | `institutional_filers` | first 13F holdings sweep | filings ÷ 11 req/s |
+| S14 | `sec_n_port_ingest` | `sec_n_port_ingest` | NPORT filers | first NPORT-P parse pass | filings ÷ 11 req/s |
+| S15 | `ownership_observations_backfill` | `ownership_observations_backfill` | `ownership_*_legacy` (filled by S7–S14) | walk legacy → `ownership_*_observations` (DB-only) | seconds-to-low-minutes |
+| S16 | `fundamentals_sync` | `fundamentals_sync` | CIK-mapped `instruments` | first XBRL Company Facts pass | universe ÷ 11 req/s |
+
+**Total: 17 stages (1 init + 1 eToro lane + 15 SEC lane).** S12 was
+dropped (see strikethrough above). Renumbering of S13–S16 in
+implementation: the spec's `stage_order` values are integers but
+non-contiguous gaps are fine; PR2's `_BOOTSTRAP_STAGE_SPECS` may
+either skip the gap or renumber.
+
+#### v1 historical-depth caveat
+
+The "fully backfilled end-to-end" goal is true for the *plumbing* —
+universe, CIK mapping, filing manifest, freshness index, ownership
+rollup tables — but **filing history depth is bounded by SEC
+submissions.json's inline `recent` block** (typically the last
+~12 months of filings). PR2's `bootstrap_filings_history_seed`
+requests a 2-year window, but `SecFilingsProvider.list_filings`
+processes only the inline `recent` block today
+(`app/providers/implementations/sec_edgar.py:766`). Walking
+secondary submissions pages for a deeper history is a separate
+follow-up. For v1 demo purposes, ~12 months of history is
+sufficient: the typed parsers (S7–S14) get real data, and nightly
+cron picks up new filings going forward.
+
+#### Stage invokers that need wrapping/registration in PR2
+
+Three stages call invokers that are not in the current `_INVOKERS`
+map (`app/jobs/runtime.py:162`); PR2 (#994) registers them:
+
+- `daily_cik_refresh` — already a free function in scheduler.py;
+  just needs `_INVOKERS[JOB_DAILY_CIK_REFRESH] = daily_cik_refresh`.
+- `daily_financial_facts` — same situation; not in the gated list
+  but reachable via the master-index path.
+- `sec_first_install_drain` — currently exposed as
+  `run_first_install_drain(*args)` taking parameters. PR2 adds a
+  zero-arg wrapper `sec_first_install_drain_job()` that picks
+  sensible defaults (full universe scope, no CIK filter) and
+  registers that wrapper in `_INVOKERS`.
+- `bootstrap_orchestrator` (the run-the-whole-thing entrypoint).
+- `bootstrap_filings_history_seed` (the new S5 invoker).
+
+#### S6 input note: `instrument_sec_profile`
+
+`sec_first_install_drain` reads issuer cohorts from
+`instrument_sec_profile`. That table is populated by
+`fundamentals_sync`'s SEC-profile bootstrap path. On a fresh DB
+where S6 runs before S16 (`fundamentals_sync`), the issuer cohort
+is empty and S6 would run only against the institutional + blockholder
+filer tables (S2 + S3 outputs). v1 acceptance: this is fine — the
+filer-driven cohort still seeds the manifest with quarterly 13F /
+NPORT filers. The instrument cohort gets manifest entries when the
+nightly per-CIK poll (`sec_per_cik_poll`) runs after `fundamentals_sync`
+populates `instrument_sec_profile`. Operator may also re-run
+bootstrap after the first nightly to widen coverage.
+
+#### S5 — `bootstrap_filings_history_seed` (new invoker)
+
+Existing scheduled jobs do not provide a clean fit for "walk every
+CIK-mapped instrument's submissions.json and seed `filing_events`
+for all form types over a multi-year window":
+
+- `daily_research_refresh` is hardcoded to `["10-K","10-Q","8-K"]`
+  with a 30-day window
+  (`app/workers/scheduler.py:1574-1577`). Insufficient — DEF 14A,
+  Form 3, Form 4 histories are out of scope for that job.
+- `daily_financial_facts` walks the SEC daily master-index, which
+  is "today's index" only; for historical depth it would need to
+  iterate hundreds of past days, hammering SEC for marginal value.
+
+`bootstrap_filings_history_seed` is therefore a thin new invoker
+that calls the existing `refresh_filings` service helper with a
+broader argument set:
+
+```python
+refresh_filings(
+    provider=sec,
+    provider_name="sec",
+    identifier_type="cik",
+    conn=conn,
+    instrument_ids=cik_mapped_instrument_ids,
+    start_date=date.today() - timedelta(days=730),
+    end_date=date.today(),
+    filing_types=None,  # all form types
+)
+```
+
+It is registered in `_INVOKERS` as `bootstrap_filings_history_seed`
+so it can also be triggered manually via the existing admin Run-now
+button if an operator ever needs to widen historical depth on
+demand. It is **not** added to `SCHEDULED_JOBS` — there is no
+nightly cadence for "broad historical sweep"; the daily incremental
+paths take over after bootstrap.
+
+#### Why this order in the SEC lane
+
+- S1 reads `instruments`, so it cannot precede A1. It runs first in
+  the SEC lane because it is independent of all later SEC writes.
+- S2, S3 populate filer-directory tables that S6 (drain) depends on.
+- **S4 (`daily_cik_refresh`) and S5
+  (`bootstrap_filings_history_seed`) are the critical bridge for
+  typed parsers.** S4 populates `external_identifiers` SEC CIK rows
+  for every CIK-mappable instrument
+  (`app/workers/scheduler.py:1387`); S5 then walks each CIK's
+  submissions.json via `refresh_filings` and populates
+  `filing_events` historically. The typed parsers (S7–S14) read
+  `filing_events`, verified by direct reads:
+  `app/services/def14a_ingest.py:194`,
+  `app/services/business_summary.py:1290`,
+  `app/services/insider_transactions.py:1614`, etc.
+- S6 (`sec_first_install_drain`) seeds `sec_filing_manifest` +
+  `data_freshness_index`. The future-state plan (post-#873) is for
+  the manifest worker to be the sole `filing_events` writer; until
+  then we keep S5 in the chain to populate `filing_events`
+  directly.
+- S7–S14 run after both `filing_events` (from S5) and the manifest
+  (from S6) are populated, so each parser has its required input.
+- S15 (DB-only ownership rollup) reads legacy ownership tables that
+  the S7–S14 parsers fill via write-through.
+- S16 (`fundamentals_sync`) reads CIK-mapped `instruments` (S4
+  output) and could in principle run earlier, but the SEC bucket is
+  fully utilised by S5–S14; running it last keeps the lane simple
+  and the rate budget predictable.
+
+### Phase C — finalize
+
+After both lane threads have joined, the orchestrator inspects all
+18 stage rows:
+
+- All `success` (or harmlessly `skipped`) → `bootstrap_state.status='complete'`.
+- One or more `error` → `bootstrap_state.status='partial_error'`.
+
+If A1 fails, lanes never start and the orchestrator sets
+`partial_error` immediately.
+
+### Lane parallelism rationale
+
+eToro stages hit only eToro APIs; SEC stages hit only SEC EDGAR. The
+two outbound rate limits are independent. Inside the SEC lane stages
+must run serially: shared process-wide token bucket means parallel
+SEC stages would multiplex into the same 11 req/s budget — total
+wall-clock is unchanged but each stage's ETA doubles, log noise
+doubles, and 503 retry pressure rises.
+
+S14 is DB-only and does not contend for the SEC bucket, but it is
+still scheduled inside the SEC lane after S13 because its input rows
+(`ownership_*_legacy`) are populated by S6–S13. Putting S14 in its
+own thread would just race the writes its read depends on.
+
+## Per-stage execution contract
+
+Each stage runs through this exact sequence inside its lane thread:
+
+1. **Pre-check:** read the stage row's status. If `success`, skip
+   (retry-failed paths set successful stages back to `success` rather
+   than `pending` — see retry-failed below).
+2. **Mark running:** UPDATE the stage row to `status='running'`,
+   set `started_at = now()`, increment `attempt_count`, clear
+   `last_error`.
+3. **Acquire `JobLock(database_url, job_name)`:** the same advisory
+   lock the scheduled + manual paths use
+   (`app/jobs/runtime.py:789`). If the lock is held (e.g. operator
+   manually triggered the same job concurrently), the stage records
+   `status='error'`, `last_error="another instance holds the job
+   advisory lock; retry from the bootstrap panel after it
+   completes"`, and the lane proceeds to the next stage. The
+   advisory lock guarantees we never run the same invoker twice
+   simultaneously across bootstrap, manual triggers, or scheduled
+   fires.
+4. **Invoke the underlying job function** via `_INVOKERS[job_name]()`.
+   The function's own `_tracked_job` writes a normal `job_runs` row,
+   which gives us the full per-job forensic trail in addition to the
+   `bootstrap_stages` summary.
+5. **Catch exceptions:** any exception is caught and recorded as
+   `status='error'`, `last_error=str(exc)[:1000]`, `completed_at=now()`.
+   The lane continues to the next stage.
+6. **On success:** UPDATE `status='success'`, `completed_at=now()`,
+   `rows_processed=<from job_runs>`.
+
+The `JobLock` wrapper means bootstrap dispatch is **not** equivalent
+to "calling `_INVOKERS[name]()` directly bypassing all wrappers" —
+prerequisites *are* bypassed (intentional: bootstrap is the operator
+forcing first-install work), but the advisory lock is acquired so
+overlapping manual / scheduled triggers cannot run twice
+simultaneously.
+
+## Database schema
+
+New migration (next sequence number) creates three tables.
+
+### `bootstrap_runs`
+
+```sql
+CREATE TABLE bootstrap_runs (
+    id              BIGSERIAL PRIMARY KEY,
+    triggered_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    triggered_by_operator_id BIGINT REFERENCES operators(id),
+    status          TEXT NOT NULL DEFAULT 'running'
+                    CHECK (status IN ('running','complete','partial_error')),
+    completed_at    TIMESTAMPTZ,
+    notes           TEXT
+);
+```
+
+History — every "Run bootstrap" or "Re-run bootstrap" click is one
+row. Latest row drives the UI. Retry-failed reuses the latest row.
+
+### `bootstrap_stages`
+
+```sql
+CREATE TABLE bootstrap_stages (
+    id              BIGSERIAL PRIMARY KEY,
+    bootstrap_run_id BIGINT NOT NULL REFERENCES bootstrap_runs(id) ON DELETE CASCADE,
+    stage_key       TEXT NOT NULL,
+    stage_order     SMALLINT NOT NULL,
+    lane            TEXT NOT NULL CHECK (lane IN ('init','etoro','sec')),
+    job_name        TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending','running','success','error','skipped')),
+    started_at      TIMESTAMPTZ,
+    completed_at    TIMESTAMPTZ,
+    rows_processed  INTEGER,
+    expected_units  INTEGER,
+    units_done      INTEGER,
+    last_error      TEXT,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (bootstrap_run_id, stage_key)
+);
+
+CREATE INDEX bootstrap_stages_run_status_idx
+    ON bootstrap_stages (bootstrap_run_id, status);
+
+-- Defense-in-depth: at most one bootstrap_runs row may have
+-- status='running'. The /run handler also takes a row-level lock on
+-- bootstrap_state to serialise concurrent POSTs; this index exists
+-- to make a second concurrent insert fail loudly rather than
+-- silently create a duplicate run if the row lock is ever bypassed.
+CREATE UNIQUE INDEX bootstrap_runs_one_running_idx
+    ON bootstrap_runs (status)
+    WHERE status = 'running';
+```
+
+`expected_units` + `units_done` drive ETA. Set lazily by the
+orchestrator when a stage starts (e.g. universe stage knows its
+target row count up front; ones that don't know just leave both
+`NULL` and the UI shows a spinner instead of a fake percentage).
+
+### `bootstrap_state`
+
+```sql
+CREATE TABLE bootstrap_state (
+    id                INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    status            TEXT NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending','running','complete','partial_error')),
+    last_run_id       BIGINT REFERENCES bootstrap_runs(id),
+    last_completed_at TIMESTAMPTZ
+);
+INSERT INTO bootstrap_state (id) VALUES (1) ON CONFLICT DO NOTHING;
+```
+
+Singleton row. The `_bootstrap_complete` prerequisite reads
+`SELECT status FROM bootstrap_state WHERE id = 1`.
+
+### `bootstrap_stage_errors` (deferred — out of scope for v1)
+
+Reserved for a follow-up if we want per-item error history below the
+stage level. Not in v1: `last_error` on the stage row is sufficient,
+and the underlying jobs already log per-item failures via their own
+`job_runs` rows.
+
+## State machine
+
+`bootstrap_state.status` transitions:
+
+```
+pending ─run─▶ running ──run finalises, no errors──▶ complete
+                  │
+                  └─run finalises, ≥1 stage error──▶ partial_error
+                                                       │
+                                                       └─retry-failed─▶ running ──no errors──▶ complete
+```
+
+Key invariant: `partial_error` is a **terminal run-completion
+state**, never set mid-run. While the run is in flight, status is
+`running` and individual stages may already have `status='error'`
+recorded. `bootstrap_state.status` does not flip to `partial_error`
+until both lane threads have joined. This keeps "continue past
+errors" (Goals §4) consistent with the state machine: errors during
+a run are visible per-stage but do not interrupt the run, and the UI
+keeps polling at the 5s `running` cadence until the final transition.
+
+`_bootstrap_complete` returns `(True, "")` only when status is
+`complete`. Both `pending` and `partial_error` return `(False, ...)`.
+`partial_error` does **not** unblock the prerequisite — scheduled
+jobs running against a half-populated DB produce tens of thousands
+of `instruments=0` no-op log lines plus partial data shapes that
+confuse downstream operators. The operator must either retry failed
+stages, fix underlying causes and re-run, or use `mark-complete`
+(audit-logged escape hatch).
+
+### Cancel — out of scope for v1
+
+The orchestrator does not expose `cancel`. A long bootstrap run is
+~60-90 minutes wall-clock and cannot be safely interrupted mid-stage
+without leaving partial state in `sec_filing_manifest` etc. that
+later writes would conflict with. If the operator needs to abort,
+they restart the jobs process; boot recovery (below) finalises
+`bootstrap_state.status='partial_error'`, then they choose
+retry-failed or mark-complete. v2 may add a cooperative cancel
+signal.
+
+### Boot recovery for orphaned runs
+
+The existing `JobRuntime` reaper handles orphaned `sync_runs`
+(`app/jobs/runtime.py:517`) — it does **not** know about bootstrap
+state. We add a dedicated bootstrap recovery step in the jobs
+process startup sequence (alongside the existing reaper):
+
+```python
+def reap_orphaned_bootstrap(conn) -> None:
+    # If bootstrap_state.status='running' on cold start, no live
+    # thread is executing this run. Sweep the latest run's stages:
+    #   - status='running'  → 'error', last_error='jobs process restarted mid-run'
+    #   - status='pending'  → 'error', last_error='orchestrator did not dispatch before restart'
+    # Then transition bootstrap_state to 'partial_error' so the
+    # operator gets an accurate picture and retry-failed has work.
+    # The partial-unique index on bootstrap_runs.status='running'
+    # also has to be released — UPDATE bootstrap_runs.status to
+    # 'partial_error' for the latest row.
+    ...
+```
+
+This runs once at jobs-process startup, in the same connection that
+runs the existing sync reaper. Idempotent: a `pending` /
+`complete` / `partial_error` state is left alone. Only a stuck
+`running` state triggers the sweep.
+
+Edge case (`status='running'` but zero stages were ever started):
+both the `running` and `pending` sweep clauses above ensure
+retry-failed has stages to act on. Without the `pending → error`
+sweep, retry-failed would 404 with "no failed stages" and leave the
+operator stuck — they'd have to use mark-complete or wait for
+dev-environment intervention.
+
+## Concurrency model
+
+The bootstrap orchestrator runs in the jobs process as a
+`manual_job` invoker (`bootstrap_orchestrator`). It is *not*
+re-entrant: a second `POST /system/bootstrap/run` while a run is
+already `running` returns 409 with the existing `run_id`.
+
+Lane parallelism uses two `threading.Thread` workers (one per Phase
+B lane) launched from the orchestrator function. Both threads share
+the same `psycopg.Connection` pool. Stages within a lane are awaited
+sequentially.
+
+Why threads not asyncio: the underlying job invokers are sync
+functions that wrap `psycopg` connections + `httpx.Client` calls
+through `ResilientClient`. Lifting them to async would be invasive
+and has no benefit when each lane is single-flight by construction.
+
+The shared SEC token bucket is `threading.Lock`-guarded
+(`_PROCESS_RATE_LIMIT_LOCK` at
+`app/providers/implementations/sec_edgar.py:80`), so parallel
+non-SEC work in the eToro lane is safe with the SEC lane.
+
+## API endpoints
+
+All under the existing `/system/...` namespace
+(`app/api/system_status.py` + new `app/api/bootstrap.py`).
+
+### `GET /system/bootstrap/status`
+
+Single multi-table snapshot.
+
+```json
+{
+  "status": "running",
+  "current_run_id": 7,
+  "last_completed_at": null,
+  "stages": [
+    {
+      "stage_key": "universe_sync",
+      "lane": "init",
+      "job_name": "nightly_universe_sync",
+      "stage_order": 1,
+      "status": "success",
+      "started_at": "2026-05-07T...",
+      "completed_at": "2026-05-07T...",
+      "rows_processed": 1547,
+      "expected_units": null,
+      "units_done": null,
+      "last_error": null,
+      "eta_seconds": null,
+      "attempt_count": 1
+    },
+    ...
+  ]
+}
+```
+
+Read with a single `conn.transaction()` snapshot.
+
+### `POST /system/bootstrap/run`
+
+Single-flight (one bootstrap run at a time).
+
+Concurrency contract: the handler opens a transaction, takes
+`SELECT ... FOR UPDATE` on the singleton `bootstrap_state` row, then
+inspects status. This serialises concurrent POSTs at the DB level
+even when two API workers race. If status is `running` after lock
+acquisition, return 409 `{ "current_run_id": N }`. Otherwise, INSERT
+into `bootstrap_runs` with `status='running'` — the partial unique
+index (see schema below) provides defense-in-depth: if the
+`FOR UPDATE` were ever bypassed by a pathological retry, a second
+insert would fail with a unique-violation rather than create two
+runs.
+
+- If status `running`: returns 409 `{ "current_run_id": N }`.
+- Otherwise (status `pending`, `complete`, or `partial_error`):
+  creates a fresh `bootstrap_runs` row, seeds **18 pending**
+  `bootstrap_stages` rows (1 init + 1 eToro lane + 16 SEC lane),
+  flips `bootstrap_state.status` to `running` with `last_run_id`
+  pointing at the new row, then writes a `pending_job_requests` row
+  with `request_kind='manual_job'`,
+  `job_name='bootstrap_orchestrator'` +
+  `pg_notify('ebull_job_request', ...)`. Returns 202 + `run_id`.
+
+This works under the existing #719 contract because we register
+`bootstrap_orchestrator` in `_INVOKERS` (`app/jobs/runtime.py:162`)
+as a normal manual job. The dispatcher's existing `manual_job`
+listener path (`app/jobs/listener.py:88`) picks it up unchanged. The
+orchestrator function reads the latest `bootstrap_runs` row + its
+pending stages and runs them.
+
+Re-running after `complete` or `partial_error` is allowed by design:
+operators may want to re-bootstrap after a long absence (universe
+churn, new SEC filer cohort). Each run is its own row in
+`bootstrap_runs`; previous runs' history is preserved.
+
+### `POST /system/bootstrap/retry-failed`
+
+For a `partial_error` state. Reuses the latest `bootstrap_runs.id`
+(does not create a new run).
+
+**Dependency-aware reset:** resets stages with `status='error'` to
+`pending` AND additionally resets every later-numbered stage in the
+**same lane** whose `status` is `success` or `skipped`. Reasoning:
+when an upstream stage failed, downstream stages may have run
+against partial / stale data and recorded a misleading success.
+Re-running the upstream stage and then the downstream chain in the
+same lane gives the correct final state. The eToro lane is one stage
+deep so this is moot; the SEC lane is where the dependency walk
+matters.
+
+The reset clears `last_error`, `started_at`, `completed_at` on the
+affected rows but preserves `attempt_count` so the lane runner
+increments it on the next run. Flips `bootstrap_state.status` back
+to `running` with the same `last_run_id`. Writes a fresh
+`manual_job` queue row + NOTIFY.
+
+UI shows a clear preview of which stages will be re-run (failed +
+downstream-in-same-lane) before the operator confirms.
+
+409 if state is `running`. 404 if no prior run exists or latest run
+has no failed stages.
+
+The orchestrator function checks each stage's `status` before
+dispatching it to the lane runner: stages still marked `success` are
+skipped this time, so retry-failed touches only the affected
+stages.
+
+### `POST /system/bootstrap/mark-complete`
+
+Operator escape hatch. Forces `bootstrap_state.status='complete'`.
+Used when the operator has manually fixed the cause of a stage
+failure and wants to release the scheduler gate without re-running
+heavy stages. Audit-logged via the existing operator-action audit
+trail; requires the existing operator session auth.
+
+**Running-state guard: returns 409 if `bootstrap_state.status='running'`.**
+Releasing the scheduler gate while the orchestrator threads are still
+mutating data would let nightly jobs run against half-populated
+tables — exactly the case the gate exists to prevent.
+
+## Scheduler prerequisite
+
+Add to `app/workers/scheduler.py`:
+
+```python
+def _bootstrap_complete(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    if _exists(
+        conn,
+        psycopg.sql.SQL(
+            "SELECT EXISTS(SELECT 1 FROM bootstrap_state WHERE id = 1 AND status = 'complete')"
+        ),
+    ):
+        return (True, "")
+    return (False, "first-install bootstrap not complete; visit /admin to run")
+```
+
+Wire as `prerequisite=_bootstrap_complete` on:
+
+- `JOB_ORCHESTRATOR_FULL_SYNC`
+- `JOB_FUNDAMENTALS_SYNC` (S16 in bootstrap)
+- `JOB_DAILY_FINANCIAL_FACTS`
+- `JOB_DAILY_RESEARCH_REFRESH`
+- `JOB_DAILY_CIK_REFRESH` (S4 in bootstrap; nightly is gated)
+- `JOB_SEC_INSIDER_TRANSACTIONS_INGEST`
+- `JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL` (S9 in bootstrap)
+- `JOB_SEC_FORM3_INGEST` (S10 in bootstrap)
+- `JOB_SEC_DEF14A_INGEST`
+- `JOB_SEC_DEF14A_BOOTSTRAP` (S7 in bootstrap)
+- `JOB_SEC_8K_EVENTS_INGEST` (S11 in bootstrap)
+- `JOB_SEC_FILING_DOCUMENTS_INGEST`
+- `JOB_SEC_BUSINESS_SUMMARY_INGEST`
+- `JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP` (S8 in bootstrap)
+- `JOB_SEC_DIVIDEND_CALENDAR_INGEST` (S12 in bootstrap)
+- `JOB_OWNERSHIP_OBSERVATIONS_SYNC`
+- `JOB_SEC_13F_QUARTERLY_SWEEP` (S13 in bootstrap)
+- `JOB_SEC_N_PORT_INGEST` (S14 in bootstrap)
+- `JOB_DAILY_CANDLE_REFRESH` (E1 in bootstrap; nightly is gated)
+
+Self-reference note: stages S4–S16 + E1 are also in the gated list,
+but gating their *scheduled* path is safe because:
+
+1. The `prerequisite=` gate only fires on the scheduled path
+   (`app/jobs/runtime.py:766` — `_wrap_scheduled_invoker` checks
+   prerequisite before lock acquisition).
+2. Manual invocations (`POST /jobs/{name}/run`) explicitly bypass
+   prereqs (`app/jobs/runtime.py:765` comment: "bypass prerequisites
+   so the operator can force a run").
+3. The bootstrap orchestrator dispatches stage jobs by calling the
+   invoker inside a `JobLock` context (no scheduler-side gate).
+
+So these jobs run during bootstrap (orchestrator-direct invocation)
+but stay silent in their nightly crons until
+`bootstrap_state.status='complete'`.
+
+Do **not** wire the gate on:
+
+- `JOB_NIGHTLY_UNIVERSE_SYNC` (A1 in bootstrap) — itself the gate
+  prerequisite read state. Gating would deadlock.
+- `JOB_DAILY_PORTFOLIO_SYNC` — eToro portfolio works pre-universe
+  (proven by the operator's logs showing `mirror_positions_up=361`
+  against empty `instruments`).
+- `JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC` — only fires
+  portfolio_sync + fx_rates; safe pre-bootstrap.
+- `JOB_FX_RATES_REFRESH`, `JOB_ETORO_LOOKUPS_REFRESH`,
+  `JOB_EXCHANGES_METADATA_REFRESH` — independent eToro metadata.
+- `JOB_RETRY_DEFERRED`, `JOB_MONITOR_POSITIONS`,
+  `JOB_EXECUTE_APPROVED_ORDERS` — already gated by their own
+  state-vacuous prerequisites.
+- `JOB_CUSIP_UNIVERSE_BACKFILL` (S1), `JOB_SEC_13F_FILER_DIRECTORY_SYNC`
+  (S2), `JOB_SEC_NPORT_FILER_DIRECTORY_SYNC` (S3),
+  `JOB_SEC_FIRST_INSTALL_DRAIN` (S6),
+  `JOB_OWNERSHIP_OBSERVATIONS_BACKFILL` (S15),
+  `bootstrap_filings_history_seed` (S5; new invoker, has no
+  scheduled cadence) — these read no state that depends on
+  bootstrap completion; safe pre-bootstrap and may be re-run
+  independently.
+
+## Frontend
+
+### `BootstrapPanel.tsx` (new)
+
+Replaces `SeedProgressPanel` placement at the top of the admin page
+for fresh installs. Renders:
+
+- Header row: status pill ("Pending" / "Running" / "Complete" /
+  "Partial — N errors") + action button. Button copy by status:
+  - `pending`: "Run bootstrap"
+  - `running`: disabled "Running…" (no cancel — see Cancel scope)
+  - `complete`: "Re-run bootstrap" (secondary tone)
+  - `partial_error`: primary "Retry failed (N)" + secondary "Re-run all" + secondary "Mark complete"
+- Per-stage list: **18 rows**, grouped by phase/lane (1 init, 1
+  eToro, 16 SEC). Each row:
+  - stage_key + job_name (caption)
+  - phase/lane badge (`init` / `eToro` / `SEC`)
+  - status (pending / running / success / error / skipped)
+  - progress (`units_done / expected_units` if known else spinner)
+  - elapsed + ETA where ETA is computable
+  - error message (truncated 80 chars; click expands)
+
+Polls `GET /system/bootstrap/status` every 5s while status is
+`running`, every 60s otherwise. Uses existing `useAsync` hook.
+
+### Dashboard banner
+
+When `bootstrap_state.status !== 'complete'` and a session exists,
+render a top-of-page banner on every authenticated route linking to
+`/admin#bootstrap`. Component: `BootstrapNudgeBanner.tsx`. Banner
+suppresses itself if dismissed for the current session
+(`sessionStorage.bootstrapBannerDismissed`); the next reload
+re-shows it as long as bootstrap remains incomplete — we do not want
+"dismiss forever" because the actual fix path is via the admin
+panel.
+
+### `BootstrapProgress.tsx` (existing, setup wizard)
+
+Unchanged — that lives on the setup wizard for the live universe
+sync after the operator saves credentials. The new
+`BootstrapPanel.tsx` lives on the admin page for explicit operator
+control.
+
+## Test plan
+
+### Unit (Python)
+
+- `tests/test_bootstrap_orchestrator.py`:
+  - Happy path: all 18 stages succeed → `bootstrap_state.status='complete'`.
+  - Single-stage failure mid-SEC-lane: subsequent SEC stages still
+    run; eToro lane runs to completion; final state is
+    `partial_error`; `last_error` recorded for the failed stage.
+  - A1 failure: SEC + eToro lanes never start; final state is
+    `partial_error` with all Phase B stages still `pending`.
+  - Retry-failed: reuses same `bootstrap_runs.id`, only re-runs
+    failed stages (skipped success stages stay `success`), marks
+    final state `complete` if all retried succeed.
+  - Idempotent run: second concurrent run rejected with current
+    `run_id` (409).
+  - Mark-complete: writes audit row, flips state without re-running
+    stages.
+  - JobLock contention: a stage whose `JobLock` is held by another
+    invoker records `error` with the contention reason.
+- `tests/test_bootstrap_state_prerequisite.py`:
+  - `_bootstrap_complete` returns `(False, ...)` while pending /
+    running / partial_error.
+  - `_bootstrap_complete` returns `(True, "")` after
+    `mark-complete`.
+  - Scheduler `prerequisite` gate logs `skipped` rows for each
+    gated job pre-bootstrap.
+- `tests/test_bootstrap_endpoints.py`:
+  - `GET /system/bootstrap/status` returns full payload.
+  - `POST /system/bootstrap/run` writes pending_job_requests +
+    NOTIFY.
+  - 409 conflict on second run.
+- `tests/test_bootstrap_boot_recovery.py`:
+  - `bootstrap_state.status='running'` on cold start →
+    `partial_error`; in-flight stages → `error`.
+- Smoke: `tests/smoke/test_app_boots.py` already runs lifespan;
+  add assertion that the `bootstrap_state` row exists post-migration.
+
+### Integration
+
+- `tests/integration/test_bootstrap_flow.py`:
+  - Stub `_INVOKERS[stage]` to deterministic test fakes that
+    insert sentinel rows.
+  - Run orchestrator end-to-end against `ebull_test`.
+  - Assert all sentinel rows present + final state.
+
+### Frontend
+
+- `BootstrapPanel.test.tsx` — render with each status shape, button
+  copy + disabled state, retry-failed action, error expand.
+- `BootstrapNudgeBanner.test.tsx` — visibility transitions on
+  status change + dismiss/reload.
+
+## Implementation order (PR plan)
+
+| PR | Scope | Branch | Depends |
+|---|---|---|---|
+| 1 | DB migration + `bootstrap_state` repo functions + smoke assertion | `feature/<umbrella>-1-schema` | — |
+| 2 | `BootstrapOrchestrator` service + lane runners + per-stage `JobLock` wrapper + register `bootstrap_orchestrator` in `_INVOKERS` + boot recovery sweep + tests | `feature/<umbrella>-2-orchestrator` | 1 |
+| 3 | API endpoints (`/system/bootstrap/{status,run,retry-failed,mark-complete}`) + jobs-process trigger via NOTIFY | `feature/<umbrella>-3-api` | 2 |
+| 4 | Scheduler prerequisite wiring on 19 gated jobs + tests | `feature/<umbrella>-4-prereq` | 1 |
+| 5 | `BootstrapPanel.tsx` + `useBootstrapStatus` hook + dashboard banner + frontend tests | `feature/<umbrella>-5-frontend` | 3 |
+| 6 | Smoke + integration test + admin-ops runbook update | `feature/<umbrella>-6-smoke` | 5 |
+
+PR4 can land in parallel with PR3 (only depends on PR1 schema). The
+others are linear.
+
+## Open scope calls (already decided per user clarification 2026-05-07)
+
+- **Trigger model:** Explicit operator click (Option B). Banner
+  nudges; setup wizard does not auto-fire.
+- **Candle refresh scope:** Full universe, not capped. User said
+  "even if bulky, it's needed".
+- **Failure mode:** Continue past errors; per-stage error log;
+  retry-failed-only button; nightly cadence picks up further
+  attempts after `mark-complete` or successful retry.
+- **Visibility surface:** Admin page is canonical. Replace
+  `SeedProgressPanel` placement — surface bootstrap-incomplete state
+  prominently when `status !== 'complete'`.
+
+## Out of scope
+
+- Per-CIK error drilldown (deferred — `last_error` on the stage row
+  is sufficient for v1; underlying jobs already log to their own
+  `job_runs` rows for forensics).
+- AI / ranking / thesis bootstrap — not yet penciled.
+- Multi-region universe (UK / EU). v1 covers eToro tradable +
+  US-SEC only, matching settled-decisions.
+- Phase 2 universe expansion (#841 — EdgarTools 13F adoption + 10x
+  filer count). Bootstrap design uses current `institutional_filers`
+  table; #841 expands that table without changing bootstrap shape.
+- Cooperative cancel mid-run. Operator restart + boot recovery is
+  the v1 abort path.

--- a/sql/129_bootstrap_state.sql
+++ b/sql/129_bootstrap_state.sql
@@ -1,0 +1,113 @@
+-- 129_bootstrap_state.sql
+--
+-- Issue #993 (umbrella #992) — First-install bootstrap orchestrator.
+--
+-- Spec: docs/superpowers/specs/2026-05-07-first-install-bootstrap.md
+--
+-- ## Why
+--
+-- Fresh eBull installs leave the database empty after operator setup.
+-- Scheduled jobs fire but no-op against an empty universe. There is
+-- no automation walking the operator from "credentials saved" to
+-- "system fully populated", and no admin surface that explains what
+-- is missing. This migration introduces the persistence layer for an
+-- explicit "Run bootstrap" admin button: a singleton state row that
+-- the scheduler reads as a prerequisite gate, plus per-run history
+-- and per-stage detail.
+--
+-- ## Tables
+--
+--   * bootstrap_runs   — one row per "Run bootstrap" click. Status
+--                        flips from running to terminal complete /
+--                        partial_error when both lane threads have
+--                        joined.
+--   * bootstrap_stages — one row per stage in a run. 18 stages per
+--                        run today (1 init + 1 eToro + 16 SEC).
+--   * bootstrap_state  — singleton row (id=1) carrying the canonical
+--                        scheduler-gate status. Read by
+--                        _bootstrap_complete in app/workers/scheduler.py.
+--
+-- ## Concurrency
+--
+-- A partial unique index on bootstrap_runs(status='running') gives
+-- defense-in-depth against two concurrent /run handlers both
+-- inserting a new run. The /run API also takes
+-- SELECT ... FOR UPDATE on the bootstrap_state singleton row to
+-- serialise at the application layer; the index exists to make a
+-- second insert fail loudly if that lock is ever bypassed.
+--
+-- ## Status semantics
+--
+--   bootstrap_state.status:
+--     pending       — never run on this install.
+--     running       — a bootstrap_runs row is in flight.
+--     complete      — most recent run finalised with zero stage errors.
+--     partial_error — most recent run finalised with one or more
+--                     stage errors. Scheduler gate stays closed.
+--
+--   bootstrap_runs.status:
+--     running       — orchestrator dispatched, lanes still working.
+--     complete      — all stages success or harmlessly skipped.
+--     partial_error — one or more stages ended in error.
+--
+--   bootstrap_stages.status:
+--     pending  — created with the run; not yet dispatched.
+--     running  — lane runner is currently executing this stage.
+--     success  — invoker returned without raising; rows_processed
+--                may be set.
+--     error    — invoker raised, JobLock contention, or boot recovery
+--                swept; last_error explains.
+--     skipped  — reserved for retry-failed paths that intentionally
+--                skip a stage (e.g. successor stages skipped because
+--                a predecessor failed terminally).
+
+CREATE TABLE IF NOT EXISTS bootstrap_runs (
+    id                       BIGSERIAL PRIMARY KEY,
+    triggered_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    triggered_by_operator_id UUID REFERENCES operators(operator_id),
+    status                   TEXT NOT NULL DEFAULT 'running'
+                             CHECK (status IN ('running', 'complete', 'partial_error')),
+    completed_at             TIMESTAMPTZ,
+    notes                    TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS bootstrap_runs_one_running_idx
+    ON bootstrap_runs (status)
+    WHERE status = 'running';
+
+CREATE TABLE IF NOT EXISTS bootstrap_stages (
+    id               BIGSERIAL PRIMARY KEY,
+    bootstrap_run_id BIGINT NOT NULL REFERENCES bootstrap_runs(id) ON DELETE CASCADE,
+    stage_key        TEXT NOT NULL,
+    stage_order      SMALLINT NOT NULL,
+    lane             TEXT NOT NULL CHECK (lane IN ('init', 'etoro', 'sec')),
+    job_name         TEXT NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'running', 'success', 'error', 'skipped')),
+    started_at       TIMESTAMPTZ,
+    completed_at     TIMESTAMPTZ,
+    rows_processed   INTEGER,
+    expected_units   INTEGER,
+    units_done       INTEGER,
+    last_error       TEXT,
+    attempt_count    INTEGER NOT NULL DEFAULT 0,
+    UNIQUE (bootstrap_run_id, stage_key)
+);
+
+CREATE INDEX IF NOT EXISTS bootstrap_stages_run_status_idx
+    ON bootstrap_stages (bootstrap_run_id, status);
+
+CREATE TABLE IF NOT EXISTS bootstrap_state (
+    id                INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    status            TEXT NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending', 'running', 'complete', 'partial_error')),
+    -- last_run_id is informational, not a FK. The truncate-cascade
+    -- semantics in the test fixture would otherwise wipe the
+    -- singleton row whenever bootstrap_runs is truncated. A dangling
+    -- last_run_id pointing at a deleted run is harmless — the API
+    -- just stops finding the run.
+    last_run_id       BIGINT,
+    last_completed_at TIMESTAMPTZ
+);
+
+INSERT INTO bootstrap_state (id) VALUES (1) ON CONFLICT DO NOTHING;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -170,6 +170,13 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # touched now need per-test cleanup.
     "job_runtime_heartbeat",
     "pending_job_requests",
+    # #993 — first-install bootstrap orchestrator. Truncating
+    # ``bootstrap_runs`` cascades to ``bootstrap_stages`` via FK.
+    # ``bootstrap_state`` is the singleton row and intentionally
+    # NOT FK-linked (see migration 129); test bodies that exercise
+    # state transitions are responsible for resetting the singleton
+    # back to ``status='pending'`` themselves.
+    "bootstrap_runs",
 )
 
 

--- a/tests/smoke/test_app_boots.py
+++ b/tests/smoke/test_app_boots.py
@@ -321,3 +321,31 @@ def test_insider_initial_holdings_value_owned_column_exists() -> None:
         "insider_initial_holdings.value_owned column missing — migration 101 did not apply or was no-op'd."
     )
     assert row[1] == "numeric", f"value_owned has unexpected type {row[1]!r}; expected NUMERIC."
+
+
+def test_bootstrap_state_singleton_seeded() -> None:
+    """Recovery gate for migration 129 — bootstrap_state singleton row.
+
+    Migration 129 (#993) creates the ``bootstrap_state`` table and
+    seeds the ``id=1`` row via ``INSERT ... ON CONFLICT DO NOTHING``.
+    The scheduler prerequisite ``_bootstrap_complete`` (PR4 #996)
+    reads this row to gate dependent jobs; if the migration runs
+    without seeding the row, every gated job would hard-fail with a
+    "singleton missing" error. Pin the seed here so a regression on
+    the migration path fails at boot rather than silently breaking
+    the gate.
+    """
+    import psycopg
+
+    from app.config import settings
+
+    with psycopg.connect(settings.database_url) as conn:
+        row = conn.execute("SELECT status FROM bootstrap_state WHERE id = 1").fetchone()
+    assert row is not None, (
+        "bootstrap_state singleton row missing — sql/129_bootstrap_state.sql "
+        "did not seed it; the _bootstrap_complete prerequisite would hard-fail."
+    )
+    assert row[0] in {"pending", "running", "complete", "partial_error"}, (
+        f"bootstrap_state.status has unexpected value {row[0]!r}; "
+        "expected one of pending / running / complete / partial_error."
+    )

--- a/tests/test_bootstrap_state.py
+++ b/tests/test_bootstrap_state.py
@@ -1,0 +1,292 @@
+"""Tests for app.services.bootstrap_state.
+
+Real-DB tests against the worker ``ebull_test`` database. The repo
+helpers wrap the singleton ``bootstrap_state`` row plus
+``bootstrap_runs`` and ``bootstrap_stages``; mocking psycopg cursors
+for these checks would lose the FK / partial-unique guarantees the
+tests are exercising.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.bootstrap_state import (
+    BootstrapAlreadyRunning,
+    StageSpec,
+    finalize_run,
+    force_mark_complete,
+    mark_stage_error,
+    mark_stage_running,
+    mark_stage_success,
+    read_latest_run_with_stages,
+    read_state,
+    reap_orphaned_running,
+    reset_failed_stages_for_retry,
+    start_run,
+)
+
+
+# Used by every test to leave the singleton row in a clean ``pending`` state.
+# The truncate fixture wipes ``bootstrap_runs`` (and its FK-cascading
+# ``bootstrap_stages``) but does not touch ``bootstrap_state``; tests are
+# responsible for resetting the singleton when they leave it non-pending.
+def _reset_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        UPDATE bootstrap_state
+           SET status            = 'pending',
+               last_run_id       = NULL,
+               last_completed_at = NULL
+         WHERE id = 1
+        """
+    )
+    conn.commit()
+
+
+_SPECS = (
+    StageSpec(stage_key="universe_sync", stage_order=1, lane="init", job_name="nightly_universe_sync"),
+    StageSpec(stage_key="candle_refresh", stage_order=2, lane="etoro", job_name="daily_candle_refresh"),
+    StageSpec(stage_key="cusip_universe_backfill", stage_order=3, lane="sec", job_name="cusip_universe_backfill"),
+)
+
+
+def test_read_state_returns_seeded_singleton(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _reset_state(ebull_test_conn)
+    state = read_state(ebull_test_conn)
+    assert state.status == "pending"
+    assert state.last_run_id is None
+    assert state.last_completed_at is None
+
+
+def test_start_run_creates_run_and_stages(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    assert run_id > 0
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "running"
+    assert state.last_run_id == run_id
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    assert snap.run_id == run_id
+    assert snap.run_status == "running"
+    assert len(snap.stages) == len(_SPECS)
+    assert {s.stage_key for s in snap.stages} == {spec.stage_key for spec in _SPECS}
+    for stage in snap.stages:
+        assert stage.status == "pending"
+        assert stage.attempt_count == 0
+
+
+def test_start_run_rejects_concurrent_run(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _reset_state(ebull_test_conn)
+    first_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    with pytest.raises(BootstrapAlreadyRunning) as exc:
+        start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    assert exc.value.run_id == first_id
+
+
+def test_start_run_after_complete_creates_new_run(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _reset_state(ebull_test_conn)
+    first_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    for spec in _SPECS:
+        mark_stage_running(ebull_test_conn, run_id=first_id, stage_key=spec.stage_key)
+        mark_stage_success(ebull_test_conn, run_id=first_id, stage_key=spec.stage_key, rows_processed=1)
+    ebull_test_conn.commit()
+
+    terminal = finalize_run(ebull_test_conn, run_id=first_id)
+    assert terminal == "complete"
+    assert read_state(ebull_test_conn).status == "complete"
+
+    second_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+    assert second_id != first_id
+    assert read_state(ebull_test_conn).status == "running"
+
+
+def test_partial_unique_index_blocks_two_running_runs(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _reset_state(ebull_test_conn)
+    start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    with pytest.raises(psycopg.errors.UniqueViolation):
+        ebull_test_conn.execute("INSERT INTO bootstrap_runs (status) VALUES ('running')")
+
+
+def test_mark_stage_running_then_error_then_finalize_partial(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="universe_sync")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="universe_sync", rows_processed=1500)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="candle_refresh")
+    mark_stage_error(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="candle_refresh",
+        error_message="eToro 503",
+    )
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="cusip_universe_backfill")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="cusip_universe_backfill")
+    ebull_test_conn.commit()
+
+    terminal = finalize_run(ebull_test_conn, run_id=run_id)
+    assert terminal == "partial_error"
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    by_key = {stage.stage_key: stage for stage in snap.stages}
+    assert by_key["universe_sync"].status == "success"
+    assert by_key["universe_sync"].rows_processed == 1500
+    assert by_key["candle_refresh"].status == "error"
+    assert by_key["candle_refresh"].last_error == "eToro 503"
+    assert by_key["cusip_universe_backfill"].status == "success"
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "partial_error"
+
+
+def test_reset_failed_stages_resets_failed_and_downstream_in_lane(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    specs = (
+        StageSpec(stage_key="a1", stage_order=1, lane="init", job_name="job_a"),
+        StageSpec(stage_key="s1", stage_order=2, lane="sec", job_name="job_s1"),
+        StageSpec(stage_key="s2", stage_order=3, lane="sec", job_name="job_s2"),
+        StageSpec(stage_key="s3", stage_order=4, lane="sec", job_name="job_s3"),
+        StageSpec(stage_key="e1", stage_order=5, lane="etoro", job_name="job_e1"),
+    )
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=specs)
+    ebull_test_conn.commit()
+
+    for key in ("a1", "s1"):
+        mark_stage_running(ebull_test_conn, run_id=run_id, stage_key=key)
+        mark_stage_success(ebull_test_conn, run_id=run_id, stage_key=key)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="s2")
+    mark_stage_error(ebull_test_conn, run_id=run_id, stage_key="s2", error_message="boom")
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="s3")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="s3")
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="e1")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="e1")
+    ebull_test_conn.commit()
+
+    finalize_run(ebull_test_conn, run_id=run_id)
+    assert read_state(ebull_test_conn).status == "partial_error"
+
+    reset_count = reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id)
+    # s2 (failed) + s3 (downstream same lane) = 2 stages reset.
+    assert reset_count == 2
+    ebull_test_conn.commit()
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    by_key = {stage.stage_key: stage for stage in snap.stages}
+    assert by_key["a1"].status == "success"
+    assert by_key["s1"].status == "success"
+    assert by_key["s2"].status == "pending"
+    assert by_key["s2"].last_error is None
+    assert by_key["s3"].status == "pending"
+    assert by_key["e1"].status == "success"  # other lane, untouched.
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "running"
+
+
+def test_reset_failed_stages_no_op_when_no_failures(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    for spec in _SPECS:
+        mark_stage_running(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+        mark_stage_success(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+    finalize_run(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    assert reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id) == 0
+    assert read_state(ebull_test_conn).status == "complete"
+
+
+def test_force_mark_complete_flips_state(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="universe_sync")
+    mark_stage_error(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="universe_sync",
+        error_message="forced fail",
+    )
+    finalize_run(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    assert read_state(ebull_test_conn).status == "partial_error"
+
+    force_mark_complete(ebull_test_conn)
+    ebull_test_conn.commit()
+    state = read_state(ebull_test_conn)
+    assert state.status == "complete"
+    assert state.last_completed_at is not None
+
+
+def test_reap_orphaned_running_sweeps_running_and_pending_stages(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="universe_sync")
+    # candle_refresh stays pending; cusip_universe_backfill stays pending.
+    ebull_test_conn.commit()
+
+    swept = reap_orphaned_running(ebull_test_conn)
+    assert swept is True
+    ebull_test_conn.commit()
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    by_key = {stage.stage_key: stage for stage in snap.stages}
+    assert by_key["universe_sync"].status == "error"
+    assert by_key["universe_sync"].last_error == "jobs process restarted mid-run"
+    assert by_key["candle_refresh"].status == "error"
+    assert by_key["candle_refresh"].last_error == "orchestrator did not dispatch before restart"
+    assert by_key["cusip_universe_backfill"].status == "error"
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "partial_error"
+
+
+def test_reap_orphaned_running_no_op_when_not_running(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    assert reap_orphaned_running(ebull_test_conn) is False
+
+
+def test_truncate_fixture_wipes_run_history(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """Sanity check that the truncate-cascade chain in the fixture
+    wipes ``bootstrap_runs`` and (via FK CASCADE) ``bootstrap_stages``
+    between tests, but leaves the singleton ``bootstrap_state`` row
+    alone — see the comment block in tests/fixtures/ebull_test_db.py.
+    """
+    cnt_runs = ebull_test_conn.execute("SELECT COUNT(*) FROM bootstrap_runs").fetchone()
+    cnt_stages = ebull_test_conn.execute("SELECT COUNT(*) FROM bootstrap_stages").fetchone()
+    cnt_state = ebull_test_conn.execute("SELECT COUNT(*) FROM bootstrap_state").fetchone()
+    assert cnt_runs is not None and cnt_runs[0] == 0
+    assert cnt_stages is not None and cnt_stages[0] == 0
+    assert cnt_state is not None and cnt_state[0] == 1


### PR DESCRIPTION
## Summary

PR1 of #992 (first-install bootstrap orchestrator). Adds the persistence layer + repo helpers + smoke gate.

- New schema: `bootstrap_runs` + `bootstrap_stages` + `bootstrap_state` singleton with a partial-unique single-flight gate index.
- `app/services/bootstrap_state.py` wraps every read/write with consistent state-machine semantics (SELECT FOR UPDATE on the singleton, dependency-aware retry reset, boot-recovery sweep).
- Smoke: assert the singleton row exists post-migration so a regression fails at boot.
- 12 real-DB unit tests against `ebull_test`, all passing.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pyright` (0 errors)
- [x] `uv run pytest tests/test_bootstrap_state.py` (12 passed)
- [x] `uv run pytest tests/smoke/test_app_boots.py` (3 passed, including new singleton-seed assertion)
- [x] Migration applies cleanly on dev DB; re-running migrations is a no-op (verified manually).

## Spec

\`docs/superpowers/specs/2026-05-07-first-install-bootstrap.md\` — included in this PR; post-Codex round 4.

Closes #993. Part of #992.