### PR TITLE
feat(#996): _bootstrap_complete prerequisite + 14 gated jobs

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -336,6 +336,51 @@ def _has_scoreable_instruments(conn: psycopg.Connection[Any]) -> PrerequisiteRes
     return (False, "no scoreable instruments")
 
 
+def _all_of(*prereqs: PrerequisiteFn) -> PrerequisiteFn:
+    """Compose multiple prerequisite checks into a single one.
+
+    Returns ``(True, "")`` only if every wrapped check returns
+    ``(True, "")``. The first failing check's reason is returned
+    so the operator sees a deterministic explanation rather than a
+    concatenation that mutates with check order.
+    """
+
+    def composed(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+        for check in prereqs:
+            met, reason = check(conn)
+            if not met:
+                return (False, reason)
+        return (True, "")
+
+    return composed
+
+
+def _bootstrap_complete(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """True if first-install bootstrap has finalised in the ``complete`` state.
+
+    Spec: docs/superpowers/specs/2026-05-07-first-install-bootstrap.md.
+
+    Returns ``(False, ...)`` while bootstrap is ``pending``,
+    ``running``, or ``partial_error`` so dependent SEC / fundamentals
+    / orchestrator-DAG jobs stay quiet against an empty / half-populated
+    DB. Operator releases the gate by either:
+
+      1. Running the bootstrap from the admin panel until every stage
+         is ``success``, OR
+      2. Pressing "Mark complete" after manually fixing the cause of
+         a stage failure.
+
+    Per #719 the connection is opened by the caller (catch-up /
+    scheduled-fire path) and closed after the check.
+    """
+    if _exists(
+        conn,
+        psycopg.sql.SQL("SELECT EXISTS(SELECT 1 FROM bootstrap_state WHERE id = 1 AND status = 'complete')"),
+    ):
+        return (True, "")
+    return (False, "first-install bootstrap not complete; visit /admin to run")
+
+
 def _has_actionable_recommendations(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     """True if at least one proposed or approved recommendation exists."""
     if _exists(
@@ -423,6 +468,11 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # site until it finishes. If the 03:00 UTC slot is missed, the
         # operator can click "Sync now" in the admin UI.
         catch_up_on_boot=False,
+        # #996 — gated until first-install bootstrap is complete. The
+        # full-sync DAG walk fires every credential-using and
+        # filings-using layer; against an empty DB those layers
+        # produce a flood of misleading "instruments=0" log lines.
+        prerequisite=_bootstrap_complete,
     ),
     # Every-5-minutes refresh of independent high-frequency layers
     # (portfolio_sync + fx_rates). The orchestrator's partial unique
@@ -475,7 +525,14 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "later (#414)."
         ),
         cadence=Cadence.daily(hour=2, minute=30),
-        prerequisite=_has_any_coverage,
+        # #996 — compose with bootstrap gate. ``_bootstrap_complete``
+        # is strictly stronger than ``_has_any_coverage`` (bootstrap
+        # finalises only after universe sync + Tier 3 coverage seed),
+        # but keeping the original check as a defense-in-depth means
+        # an operator who forces ``mark-complete`` on an empty DB
+        # still doesn't get a fundamentals run that returns
+        # ``instruments_attempted=0``.
+        prerequisite=_all_of(_bootstrap_complete, _has_any_coverage),
         # Never catch up on boot. The job pulls SEC EDGAR data for every
         # covered CIK (tens of minutes, holds DB-pool workers and hits
         # SEC's 10 rps cap). Every dev-stack restart would otherwise
@@ -501,6 +558,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.daily(hour=3, minute=0),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_BUSINESS_SUMMARY_INGEST,
@@ -520,6 +578,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # per run (~22s at the SEC 9 req/s floor), so the worst case is
         # one 22s burst of requests per boot per 24h window.
         catch_up_on_boot=True,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_INSIDER_TRANSACTIONS_INGEST,
@@ -533,6 +592,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.hourly(minute=30),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_FILING_DOCUMENTS_INGEST,
@@ -546,6 +606,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.hourly(minute=35),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_8K_EVENTS_INGEST,
@@ -559,6 +620,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.hourly(minute=20),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP,
@@ -573,6 +635,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.weekly(weekday=6, hour=4, minute=0),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
@@ -588,6 +651,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.hourly(minute=45),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_FORM3_INGEST,
@@ -605,6 +669,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.daily(hour=4, minute=20),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_DEF14A_INGEST,
@@ -625,6 +690,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.daily(hour=4, minute=35),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_OWNERSHIP_OBSERVATIONS_SYNC,
@@ -639,6 +705,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.daily(hour=3, minute=30),
         catch_up_on_boot=True,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_OWNERSHIP_OBSERVATIONS_BACKFILL,
@@ -708,6 +775,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.weekly(weekday=6, hour=2, minute=30),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_RAW_DATA_RETENTION_SWEEP,
@@ -796,6 +864,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # of staleness on quarterly-cadence data, and firing a 6h sweep
         # on every dev restart would burn SEC bandwidth + DB I/O.
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_SEC_13F_FILER_DIRECTORY_SYNC,
@@ -867,6 +936,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         ),
         cadence=Cadence.monthly(day=22, hour=3, minute=0),
         catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
     ScheduledJob(
         name=JOB_ETORO_LOOKUPS_REFRESH,

--- a/tests/test_bootstrap_state_prerequisite.py
+++ b/tests/test_bootstrap_state_prerequisite.py
@@ -1,0 +1,180 @@
+"""Tests for the ``_bootstrap_complete`` scheduler prerequisite (#996).
+
+Spec: docs/superpowers/specs/2026-05-07-first-install-bootstrap.md.
+
+Pins:
+
+* ``_bootstrap_complete`` returns ``(False, ...)`` for every non-
+  ``complete`` status so dependent jobs stay quiet on a fresh /
+  half-populated install.
+* Every gated SCHEDULED_JOBS entry from the spec carries the gate
+  (or composes it via ``_all_of`` for jobs with a pre-existing
+  prereq).
+* The set of *non-gated* SCHEDULED_JOBS exactly matches the spec's
+  "Do not wire the gate on" list — adding a new job without a
+  conscious gating decision shows up in the test diff.
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from app.workers.scheduler import (
+    JOB_CUSIP_EXTID_SWEEP,
+    JOB_CUSIP_UNIVERSE_BACKFILL,
+    JOB_DAILY_PORTFOLIO_SYNC,
+    JOB_ETORO_LOOKUPS_REFRESH,
+    JOB_EXCHANGES_METADATA_REFRESH,
+    JOB_EXECUTE_APPROVED_ORDERS,
+    JOB_FX_RATES_REFRESH,
+    JOB_MONITOR_POSITIONS,
+    JOB_NIGHTLY_UNIVERSE_SYNC,
+    JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
+    JOB_OWNERSHIP_OBSERVATIONS_BACKFILL,
+    JOB_RAW_DATA_RETENTION_SWEEP,
+    JOB_RETRY_DEFERRED,
+    JOB_SEC_13F_FILER_DIRECTORY_SYNC,
+    JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
+    JOB_SEED_COST_MODELS,
+    JOB_WEEKLY_REPORT,
+    SCHEDULED_JOBS,
+    _bootstrap_complete,
+)
+
+
+def _set_bootstrap_state(
+    conn: psycopg.Connection[tuple],
+    *,
+    status: str,
+) -> None:
+    conn.execute("UPDATE bootstrap_state SET status = %s WHERE id = 1", (status,))
+    conn.commit()
+
+
+def test_bootstrap_complete_returns_false_on_pending(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _set_bootstrap_state(ebull_test_conn, status="pending")
+    met, reason = _bootstrap_complete(ebull_test_conn)
+    assert met is False
+    assert "first-install bootstrap not complete" in reason
+
+
+def test_bootstrap_complete_returns_false_on_running(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _set_bootstrap_state(ebull_test_conn, status="running")
+    met, _ = _bootstrap_complete(ebull_test_conn)
+    assert met is False
+
+
+def test_bootstrap_complete_returns_false_on_partial_error(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _set_bootstrap_state(ebull_test_conn, status="partial_error")
+    met, _ = _bootstrap_complete(ebull_test_conn)
+    assert met is False
+
+
+def test_bootstrap_complete_returns_true_on_complete(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _set_bootstrap_state(ebull_test_conn, status="complete")
+    met, reason = _bootstrap_complete(ebull_test_conn)
+    assert met is True
+    assert reason == ""
+
+
+# ---------------------------------------------------------------------------
+# Gate-coverage invariants
+# ---------------------------------------------------------------------------
+
+
+# Spec §"Do not wire the gate on". Every entry here must be in
+# SCHEDULED_JOBS without a ``_bootstrap_complete``-flavoured prereq.
+NON_GATED_SCHEDULED: frozenset[str] = frozenset(
+    {
+        JOB_NIGHTLY_UNIVERSE_SYNC,
+        JOB_DAILY_PORTFOLIO_SYNC,
+        JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
+        JOB_FX_RATES_REFRESH,
+        JOB_ETORO_LOOKUPS_REFRESH,
+        JOB_EXCHANGES_METADATA_REFRESH,
+        JOB_RETRY_DEFERRED,
+        JOB_MONITOR_POSITIONS,
+        JOB_EXECUTE_APPROVED_ORDERS,
+        # Bootstrap stage jobs that establish the gate's read state —
+        # gating these would prevent the bootstrap from ever running.
+        JOB_CUSIP_UNIVERSE_BACKFILL,
+        JOB_SEC_13F_FILER_DIRECTORY_SYNC,
+        JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
+        JOB_OWNERSHIP_OBSERVATIONS_BACKFILL,
+        # Maintenance jobs not bootstrap-dependent.
+        JOB_CUSIP_EXTID_SWEEP,
+        JOB_RAW_DATA_RETENTION_SWEEP,
+        JOB_SEED_COST_MODELS,
+        JOB_WEEKLY_REPORT,
+    }
+)
+
+
+def _references_bootstrap_complete(prereq: object) -> bool:
+    """True if the prerequisite callable references _bootstrap_complete.
+
+    Either by being _bootstrap_complete itself or being an _all_of
+    closure that wraps it. Inspects the closure cells for the
+    ``_all_of`` case.
+    """
+    from app.workers.scheduler import _bootstrap_complete as bc
+
+    if prereq is None:
+        return False
+    if prereq is bc:
+        return True
+    # _all_of returns a closure with a `prereqs` cell.
+    closure = getattr(prereq, "__closure__", None)
+    if closure is None:
+        return False
+    for cell in closure:
+        try:
+            value = cell.cell_contents
+        except ValueError:
+            continue
+        if value is bc:
+            return True
+        if isinstance(value, tuple):
+            if any(item is bc for item in value):
+                return True
+    return False
+
+
+def test_every_scheduled_job_either_gated_or_explicitly_excluded() -> None:
+    """Drift guard: every SCHEDULED_JOBS entry must be either:
+
+      1. Gated by ``_bootstrap_complete`` (directly or via ``_all_of``).
+      2. Listed in ``NON_GATED_SCHEDULED``.
+
+    Adding a new SCHEDULED_JOBS entry without choosing one of the
+    two paths fails this test, surfacing the decision in review.
+    """
+    by_name = {job.name: job for job in SCHEDULED_JOBS}
+    gated: set[str] = set()
+    ungated: set[str] = set()
+    for name, job in by_name.items():
+        if _references_bootstrap_complete(job.prerequisite):
+            gated.add(name)
+        else:
+            ungated.add(name)
+
+    unexpected_ungated = ungated - NON_GATED_SCHEDULED
+    assert not unexpected_ungated, (
+        f"Scheduled job(s) {sorted(unexpected_ungated)} are not gated by "
+        f"_bootstrap_complete and not in NON_GATED_SCHEDULED. Decide one "
+        f"of the two paths and update the test if intentional."
+    )
+    unexpected_gated = NON_GATED_SCHEDULED & gated
+    assert not unexpected_gated, (
+        f"Scheduled job(s) {sorted(unexpected_gated)} are listed as "
+        f"non-gated in NON_GATED_SCHEDULED but actually carry the "
+        f"_bootstrap_complete gate. Pick one."
+    )


### PR DESCRIPTION
## Summary

PR4 of #992. Adds the scheduler prerequisite ``_bootstrap_complete`` and wires it onto 14 dependent SCHEDULED_JOBS so they skip-and-log on a fresh / half-populated DB until the operator runs the bootstrap.

- ``_bootstrap_complete(conn)`` reads ``bootstrap_state.status`` and returns ``(True, "")`` only when ``complete``.
- ``_all_of(*prereqs)`` composes multiple checks; used to keep ``_has_any_coverage`` on ``JOB_FUNDAMENTALS_SYNC`` as defense-in-depth against ``mark-complete`` on an empty DB.
- Drift-guard test pins every ``SCHEDULED_JOBS`` entry as either gated or explicitly excluded via ``NON_GATED_SCHEDULED``; new scheduled jobs that skip the decision fail the test.

## Test plan

- [x] ``uv run ruff check . && uv run ruff format --check .``
- [x] ``uv run pyright`` (0 errors)
- [x] ``uv run pytest tests/test_bootstrap_state_prerequisite.py tests/test_jobs_runtime.py`` (40 passed)

Closes #996. Part of #992.