### PR TITLE
feat(#998): bootstrap end-to-end integration test + admin runbook

### DIFF
--- a/docs/wiki/runbooks/runbook-first-install-bootstrap.md
+++ b/docs/wiki/runbooks/runbook-first-install-bootstrap.md
@@ -1,0 +1,165 @@
+# Runbook — First-install bootstrap
+
+When an operator stands up a fresh eBull install, the database is
+empty after the setup wizard completes. Scheduled jobs that depend
+on a populated universe + filings + filer directories stay quiet
+behind the ``_bootstrap_complete`` prerequisite gate until the
+operator explicitly runs the first-install bootstrap.
+
+This runbook covers when to run it, what to expect, and how to
+recover from per-stage failures.
+
+Spec: ``docs/superpowers/specs/2026-05-07-first-install-bootstrap.md``.
+
+## 1. When to run
+
+Click "Run bootstrap" on the admin page when:
+
+- The operator has just saved their eToro broker credentials on a
+  fresh install. The dashboard banner ("First-install bootstrap has
+  not been run yet…") nudges to ``/admin``.
+- The ``bootstrap_state.status`` is ``pending`` or ``partial_error``
+  (the panel surfaces both prominently).
+- An operator wants to widen historical depth on demand after a long
+  gap (re-running on ``complete`` is allowed and creates a fresh
+  run).
+
+Do **not** run it as part of routine ops: scheduled jobs handle
+incremental refresh once bootstrap is complete.
+
+## 2. What runs (17 stages)
+
+Phases in order; spec §"Stages and lanes" is the source of truth:
+
+1. **Phase A — init** (sequential, single thread): ``universe_sync``
+   (~30s, ~1.5k rows).
+2. **Phase B — eToro lane** (parallel with SEC lane):
+   ``candle_refresh`` (full universe; minutes).
+3. **Phase B — SEC lane** (sequential, shared 11 req/s bucket; 15
+   stages):
+   - ``cusip_universe_backfill``
+   - ``sec_13f_filer_directory_sync``
+   - ``sec_nport_filer_directory_sync``
+   - ``cik_refresh`` (``daily_cik_refresh``)
+   - ``filings_history_seed`` (``bootstrap_filings_history_seed`` —
+     2-year window, all form types)
+   - ``sec_first_install_drain`` (~60min for ~12k filers)
+   - ``sec_def14a_bootstrap`` / ``sec_business_summary_bootstrap`` /
+     insider/Form 3/8-K typed parsers
+   - ``sec_13f_quarterly_sweep`` / ``sec_n_port_ingest``
+   - ``ownership_observations_backfill``
+   - ``fundamentals_sync``
+
+Total wall-clock: typically **60–90 minutes**, dominated by the SEC
+manifest drain (``sec_first_install_drain``).
+
+## 3. Watching it
+
+The admin panel polls ``GET /system/bootstrap/status`` every 5
+seconds while a run is in flight. Each stage row shows:
+
+- Current status (``pending`` / ``running`` / ``success`` /
+  ``error`` / ``skipped``).
+- Progress where the underlying job exposes ``expected_units`` /
+  ``units_done``; ``rows_processed`` otherwise.
+- Elapsed wall-clock and a truncated ``last_error`` (click to
+  expand).
+
+For deeper forensics on a failing stage, jump to the underlying
+``job_runs`` row from the admin Background-tasks panel — the
+orchestrator's per-stage dispatch routes through the same
+``_tracked_job`` shape every scheduled fire writes.
+
+## 4. Per-stage failure paths
+
+Errors do not abort the run. The lane runner catches the exception,
+records ``status='error'`` + ``last_error``, and continues to the
+next stage. Phase B's two lane threads are independent — a SEC-lane
+error does not stop the eToro lane and vice versa.
+
+After the run finalises with at least one error,
+``bootstrap_state.status='partial_error'``. Three operator actions:
+
+- **Retry failed (N)** — reuses the same ``bootstrap_runs.id``.
+  Resets failed stages **plus all later-numbered stages in the same
+  lane** to ``pending`` (dependency walk: a downstream stage that
+  ran on stale upstream data must be re-run with fresh data).
+  Re-publishes the orchestrator queue row. Successful prior stages
+  stay ``success`` and are skipped.
+- **Re-run all** — creates a brand-new ``bootstrap_runs`` row +
+  freshly seeds 17 ``bootstrap_stages`` rows. Use when an operator
+  wants to widen historical depth or after a config change that
+  affects upstream ingest (e.g. CIK universe expansion).
+- **Mark complete** — operator escape hatch. Forces
+  ``bootstrap_state.status='complete'`` so the scheduler gate
+  releases. Use only when the operator has manually verified that
+  every still-error stage's underlying problem is resolved (the
+  panel itself does not enforce this — auditing is on the operator).
+
+## 5. Boot-recovery for a crashed jobs process
+
+If the jobs process crashes mid-bootstrap, ``bootstrap_state.status``
+stays at ``running`` until the next jobs-process boot. On startup
+the bootstrap reaper (``app/services/bootstrap_state.py::reap_orphaned_running``,
+called at ``app/jobs/__main__.py`` Step 4b) sweeps:
+
+- ``bootstrap_stages`` rows with ``status='running'`` →
+  ``error`` with ``last_error='jobs process restarted mid-run'``.
+- ``bootstrap_stages`` rows with ``status='pending'`` on the latest
+  run → ``error`` with ``last_error='orchestrator did not dispatch
+  before restart'``.
+- ``bootstrap_runs.status`` → ``partial_error``.
+- ``bootstrap_state.status`` → ``partial_error``.
+
+The operator can then click "Retry failed" to drive everything
+again. There is no cooperative-cancel button in v1; restarting the
+jobs process is the abort path.
+
+## 6. Common stage failures
+
+### `cik_refresh` — 304 Not Modified loop
+
+If the watermark is corrupted, the SEC ``company_tickers.json``
+endpoint may return 304 indefinitely. Clear the watermark from
+``external_data_watermarks`` and re-run.
+
+### `filings_history_seed` — `no CIK-mapped instruments`
+
+The previous stage (``cik_refresh``) failed to populate
+``external_identifiers``. Retry from the failed stage; the
+dependency walk re-runs everything from there.
+
+### `sec_first_install_drain` — partial drain
+
+The drain is bounded by the SEC 10 req/s shared bucket. A 60-minute
+drain over 12k filers can hit transient SEC 503s that record per-CIK
+errors but keep the stage running. ``last_error`` on the stage row
+will summarise; per-CIK detail is in the underlying
+``sec_first_install_drain`` ``job_runs`` row's log + the
+``sec_filing_manifest`` ``last_fetch_error`` column.
+
+### Typed parsers — `instruments=0` after the drain
+
+If S6/S7/S8/etc parsers report 0 instruments processed, check that
+``filings_history_seed`` (S5) actually populated ``filing_events`` —
+without ``filing_events`` rows for the relevant form type, the
+parser candidate selectors find nothing.
+
+## 7. Scheduler gate behaviour
+
+While ``bootstrap_state.status`` is anything other than ``complete``,
+14 scheduled jobs skip-and-log instead of firing:
+
+- ``orchestrator_full_sync`` (entire DAG-walk path)
+- ``fundamentals_sync`` (also gated by ``_has_any_coverage``)
+- 12 SEC ingest / bootstrap / backfill jobs
+
+A skip writes a ``job_runs`` row with ``status='skipped'`` and the
+reason ``"first-install bootstrap not complete; visit /admin to
+run"``. Manual triggers (``POST /jobs/{name}/run``) bypass the gate
+deliberately so an operator override stays available pre-bootstrap.
+
+The bootstrap orchestrator itself dispatches stage jobs by direct
+invocation (``_INVOKERS[name]()``), bypassing the scheduler-side
+gate but acquiring the per-job ``JobLock`` so manual / scheduled
+triggers cannot run twice simultaneously.

--- a/tests/test_bootstrap_flow_integration.py
+++ b/tests/test_bootstrap_flow_integration.py
@@ -1,0 +1,221 @@
+"""End-to-end bootstrap flow integration test.
+
+Drives every public surface of the first-install bootstrap stack
+together against ``ebull_test``:
+
+  1. ``POST /system/bootstrap/run`` writes a ``manual_job`` queue row
+     and seeds 17 ``bootstrap_stages``.
+  2. The orchestrator (with stubbed invokers) runs Phase A then
+     Phase B in parallel and finalises the run.
+  3. ``GET /system/bootstrap/status`` returns the final shape.
+  4. ``_bootstrap_complete`` returns ``(True, "")`` after success.
+
+Spec: docs/superpowers/specs/2026-05-07-first-install-bootstrap.md.
+
+Stubs every invoker the orchestrator dispatches with a deterministic
+in-process fake — no real provider HTTP, no real DB writes beyond
+``bootstrap_*`` tables. The test confirms the wiring of API + queue
++ orchestrator + scheduler gate end-to-end.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.bootstrap_orchestrator import (
+    get_bootstrap_stage_specs,
+    run_bootstrap_orchestrator,
+)
+from app.services.bootstrap_state import (
+    read_latest_run_with_stages,
+    read_state,
+)
+from app.workers.scheduler import _bootstrap_complete
+
+
+def _reset_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute("UPDATE bootstrap_state SET status='pending', last_run_id=NULL, last_completed_at=NULL WHERE id = 1")
+    conn.commit()
+
+
+def _bind_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.config import settings as app_settings
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    monkeypatch.setattr(app_settings, "database_url", test_database_url())
+
+
+def _override_get_conn(conn: psycopg.Connection[tuple]) -> None:
+    from app.db import get_conn
+
+    def _dep() -> Iterator[psycopg.Connection[tuple]]:
+        yield conn
+
+    app.dependency_overrides[get_conn] = _dep
+
+
+def _patch_orchestrator_invokers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, list[str]]:
+    """Replace every _INVOKERS entry the orchestrator might dispatch
+    with a deterministic in-process fake. Returns a calls dict.
+    """
+    from app.jobs import runtime as runtime_module
+
+    calls: dict[str, list[str]] = {"order": []}
+
+    def _make_fake(name: str) -> Callable[[], None]:
+        def _fake() -> None:
+            calls["order"].append(name)
+
+        return _fake
+
+    fake_invokers = {spec.job_name: _make_fake(spec.job_name) for spec in get_bootstrap_stage_specs()}
+    monkeypatch.setattr(runtime_module, "_INVOKERS", fake_invokers)
+    return calls
+
+
+def test_bootstrap_end_to_end(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drive the service-layer integration end-to-end against the
+    test DB. The HTTP-layer integration is covered separately in
+    ``test_api_bootstrap.py``; this test focuses on the
+    service-layer + orchestrator + scheduler-gate wiring.
+    """
+    from app.services.bootstrap_state import start_run
+
+    _reset_state(ebull_test_conn)
+    _bind_settings_to_test_db(monkeypatch)
+    calls = _patch_orchestrator_invokers(monkeypatch)
+
+    # 1. _bootstrap_complete returns False before the run.
+    met, reason = _bootstrap_complete(ebull_test_conn)
+    assert met is False
+    assert "first-install bootstrap not complete" in reason
+
+    # 2. start_run seeds 17 stages atomically.
+    run_id = start_run(
+        ebull_test_conn,
+        operator_id=None,
+        stage_specs=get_bootstrap_stage_specs(),
+    )
+    ebull_test_conn.commit()
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    assert snap.run_id == run_id
+    assert len(snap.stages) == 17
+    assert all(s.status == "pending" for s in snap.stages)
+
+    # 3. State is running, gate stays closed.
+    state = read_state(ebull_test_conn)
+    assert state.status == "running"
+    met, _ = _bootstrap_complete(ebull_test_conn)
+    assert met is False
+
+    # 4. Orchestrator drives Phase A → B → C with the stubbed invokers.
+    run_bootstrap_orchestrator()
+
+    # 5. Every fake invoker fired once.
+    assert len(calls["order"]) == 17
+
+    # 6. State is complete; gate releases.
+    state = read_state(ebull_test_conn)
+    assert state.status == "complete"
+    met, reason = _bootstrap_complete(ebull_test_conn)
+    assert met is True
+    assert reason == ""
+
+    # 7. GET /status reflects the terminal shape (HTTP-layer smoke).
+    _override_get_conn(ebull_test_conn)
+    try:
+        with TestClient(app) as client:
+            resp = client.get("/system/bootstrap/status")
+            assert resp.status_code == 200
+            status_body: dict[str, Any] = resp.json()
+            assert status_body["status"] == "complete"
+            assert status_body["current_run_id"] == run_id
+            assert all(stage["status"] == "success" for stage in status_body["stages"])
+    finally:
+        from app.db import get_conn
+
+        app.dependency_overrides.pop(get_conn, None)
+
+
+def test_bootstrap_partial_error_then_retry_failed(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mid-lane stage fails; retry-failed re-runs failed + downstream."""
+    from app.jobs import runtime as runtime_module
+    from app.services.bootstrap_state import (
+        reset_failed_stages_for_retry,
+        start_run,
+    )
+
+    _reset_state(ebull_test_conn)
+    _bind_settings_to_test_db(monkeypatch)
+
+    # First pass: one SEC-lane stage fails. Track which invokers fired.
+    calls_pass1: dict[str, list[str]] = {"order": []}
+    failing = {"sec_def14a_bootstrap"}
+
+    def _make_pass1(name: str) -> Callable[[], None]:
+        def _fake() -> None:
+            calls_pass1["order"].append(name)
+            if name in failing:
+                raise RuntimeError(f"forced {name} failure")
+
+        return _fake
+
+    pass1_invokers = {spec.job_name: _make_pass1(spec.job_name) for spec in get_bootstrap_stage_specs()}
+    monkeypatch.setattr(runtime_module, "_INVOKERS", pass1_invokers)
+
+    run_id = start_run(
+        ebull_test_conn,
+        operator_id=None,
+        stage_specs=get_bootstrap_stage_specs(),
+    )
+    ebull_test_conn.commit()
+
+    run_bootstrap_orchestrator()
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "partial_error"
+
+    # Second pass: replace invokers with a successful set + reset failed stages.
+    calls_pass2: dict[str, list[str]] = {"order": []}
+
+    def _make_pass2(name: str) -> Callable[[], None]:
+        def _fake() -> None:
+            calls_pass2["order"].append(name)
+
+        return _fake
+
+    pass2_invokers = {spec.job_name: _make_pass2(spec.job_name) for spec in get_bootstrap_stage_specs()}
+    monkeypatch.setattr(runtime_module, "_INVOKERS", pass2_invokers)
+
+    reset_count = reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id)
+    assert reset_count > 0
+    ebull_test_conn.commit()
+
+    run_bootstrap_orchestrator()
+
+    # Pass 2 should have called only the failed stage + later-numbered SEC-lane peers.
+    # The init + eToro stages stay 'success' from pass 1 and are skipped.
+    assert "nightly_universe_sync" not in calls_pass2["order"]
+    assert "daily_candle_refresh" not in calls_pass2["order"]
+    # Failed stage and downstream peers re-fired.
+    assert "sec_def14a_bootstrap" in calls_pass2["order"]
+    assert "fundamentals_sync" in calls_pass2["order"]
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "complete"


### PR DESCRIPTION
## Summary

PR6 of #992. Closes the umbrella with end-to-end coverage and operator documentation.

- ``tests/test_bootstrap_flow_integration.py`` — two real-DB tests against ``ebull_test`` covering the happy path (gate closed → run → 17 stages succeed → gate releases → ``GET /status`` reflects terminal shape) and the partial-error → retry-failed path (mid-lane fail → reset failed + downstream → re-run succeeds).
- ``docs/wiki/runbooks/runbook-first-install-bootstrap.md`` — operator-facing runbook covering when to run, what runs, watching, per-stage failure paths, retry / re-run / mark-complete, boot recovery, and the scheduler-gate behaviour.

## Test plan

- [x] ``uv run ruff check . && uv run ruff format --check .``
- [x] ``uv run pyright`` (0 errors)
- [x] ``uv run pytest tests/test_bootstrap_flow_integration.py`` (2 passed)

Closes #998. Closes #992.