### PR TITLE
fix(#1008): recency-bounded 13F sweep for first-install bootstrap

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -228,6 +228,10 @@ _INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_FILINGS_HISTORY_SEED] = (
     _bootstrap_orchestrator.bootstrap_filings_history_seed
 )
 _INVOKERS[_bootstrap_orchestrator.JOB_SEC_FIRST_INSTALL_DRAIN] = _bootstrap_orchestrator.sec_first_install_drain_job
+# #1008 — recency-bounded 13F sweep for first-install bootstrap.
+_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP] = (
+    _bootstrap_orchestrator.bootstrap_sec_13f_recent_sweep_job
+)
 
 
 # Public registry of valid job names. The API layer (#719) imports this

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -64,6 +64,10 @@ logger = logging.getLogger(__name__)
 JOB_BOOTSTRAP_ORCHESTRATOR = "bootstrap_orchestrator"
 JOB_BOOTSTRAP_FILINGS_HISTORY_SEED = "bootstrap_filings_history_seed"
 JOB_SEC_FIRST_INSTALL_DRAIN = "sec_first_install_drain"
+# #1008 — first-install-bounded 13F sweep that limits to recent quarters.
+# Distinct from JOB_SEC_13F_QUARTERLY_SWEEP (full historical sweep) so
+# the standalone weekly cron keeps full coverage.
+JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP = "bootstrap_sec_13f_recent_sweep"
 
 # These already exist as scheduled jobs but were not registered in
 # _INVOKERS until PR2; we re-use the existing job-name constants so
@@ -93,7 +97,13 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     _spec("sec_insider_transactions_backfill", 11, "sec", "sec_insider_transactions_backfill"),
     _spec("sec_form3_ingest", 12, "sec", "sec_form3_ingest"),
     _spec("sec_8k_events_ingest", 13, "sec", "sec_8k_events_ingest"),
-    _spec("sec_13f_quarterly_sweep", 14, "sec", "sec_13f_quarterly_sweep"),
+    # #1008 — first-install bootstrap uses a recency-bounded sweep
+    # (last 4 quarters, ~12 months) instead of the full historical
+    # sweep. Walking decades of pre-2013 filings yields zero rows
+    # (no machine-readable primary_doc/infotable) and turns the
+    # bootstrap into an 11+ hour wait. Standalone weekly cron
+    # keeps the full historical sweep via JOB_SEC_13F_QUARTERLY_SWEEP.
+    _spec("sec_13f_recent_sweep", 14, "sec", JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP),
     _spec("sec_n_port_ingest", 15, "sec", "sec_n_port_ingest"),
     _spec("ownership_observations_backfill", 16, "sec", "ownership_observations_backfill"),
     _spec("fundamentals_sync", 17, "sec", "fundamentals_sync"),
@@ -487,13 +497,79 @@ def sec_first_install_drain_job() -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# New invoker: bootstrap_sec_13f_recent_sweep
+# ---------------------------------------------------------------------------
+
+
+# Recency cut-off for the bootstrap-bounded 13F sweep. 13F-HRs file
+# ~quarterly so 4 quarters = current + 3 prior periods, matches the
+# rolling ownership-card window operators use today. Older 13Fs
+# add no value to current-quarter ranking and pre-2013 ones don't
+# have machine-readable holdings (#1008).
+_BOOTSTRAP_13F_QUARTERS_BACK = 4
+
+
+def bootstrap_sec_13f_recent_sweep_job() -> None:
+    """``_INVOKERS['bootstrap_sec_13f_recent_sweep']`` — recency-bounded
+    13F sweep for first-install bootstrap (#1008).
+
+    Walks the same ``institutional_filers`` directory as
+    ``sec_13f_quarterly_sweep`` but passes ``min_period_of_report``
+    so the parser skips accessions whose ``period_of_report`` is
+    older than the cut-off. On a fresh install with ~11k filers and
+    no prior tombstones this cuts the sweep from 11+ hours
+    (operator-killed in the 2026-05-07 smoke run) to ~30-45 min.
+
+    Standalone scheduled ``sec_13f_quarterly_sweep`` retains the
+    full historical sweep so an operator who wants deeper coverage
+    later can trigger it manually.
+    """
+    from datetime import timedelta
+
+    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    from app.services.institutional_holdings import (
+        ingest_all_active_filers,
+        list_directory_filer_ciks,
+    )
+    from app.workers.scheduler import _tracked_job  # type: ignore[attr-defined]
+
+    cutoff = date.today() - timedelta(days=_BOOTSTRAP_13F_QUARTERS_BACK * 95)
+
+    with _tracked_job(JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            ciks = list_directory_filer_ciks(conn)
+            summaries = ingest_all_active_filers(
+                conn,
+                sec,
+                ciks=ciks,
+                deadline_seconds=settings.sec_13f_sweep_deadline_seconds,
+                source_label="sec_edgar_13f_directory_bootstrap",
+                min_period_of_report=cutoff,
+            )
+        rows_upserted = sum(s.holdings_inserted for s in summaries)
+        tracker.row_count = rows_upserted
+        logger.info(
+            "bootstrap_sec_13f_recent_sweep: filers_total=%d processed=%d holdings_upserted=%d cutoff=%s",
+            len(ciks),
+            len(summaries),
+            rows_upserted,
+            cutoff,
+        )
+
+
 __all__ = [
     "JOB_BOOTSTRAP_FILINGS_HISTORY_SEED",
     "JOB_BOOTSTRAP_ORCHESTRATOR",
+    "JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP",
     "JOB_DAILY_CIK_REFRESH",
     "JOB_DAILY_FINANCIAL_FACTS",
     "JOB_SEC_FIRST_INSTALL_DRAIN",
     "bootstrap_filings_history_seed",
+    "bootstrap_sec_13f_recent_sweep_job",
     "get_bootstrap_stage_specs",
     "run_bootstrap_orchestrator",
     "sec_first_install_drain_job",

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -181,7 +181,11 @@ def _archive_file_url(cik: str, accession_number: str, filename: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def parse_submissions_index(payload: str) -> list[AccessionRef]:
+def parse_submissions_index(
+    payload: str,
+    *,
+    min_period_of_report: date | None = None,
+) -> list[AccessionRef]:
     """Walk ``data.sec.gov/submissions/CIK{cik}.json`` and emit one
     :class:`AccessionRef` per 13F-HR / 13F-HR/A row.
 
@@ -205,8 +209,18 @@ def parse_submissions_index(payload: str) -> list[AccessionRef]:
     Older-history shards are referenced by ``files`` and need a
     second fetch. Out of scope here — the ingester walks the
     ``recent`` array, which holds the most recent ~1,000 filings
-    per filer (12+ quarters of 13F coverage at one filing per
-    quarter, more than enough for the rolling ownership-card view).
+    per filer.
+
+    For active filers (banks, asset managers) the recent array can
+    cover 60+ years of filings since most issuers file far fewer
+    than 1,000 reports per decade. ``min_period_of_report`` (#1008)
+    bounds historical depth: when set, accessions whose
+    ``period_of_report`` is older than the cut-off are skipped.
+    Pre-2013 13F filings additionally have no machine-readable
+    primary_doc / infotable structure, so iterating them costs an
+    SEC fetch + parse and yields zero rows. First-install bootstrap
+    passes a recent cut-off (last 4 quarters); the standalone
+    weekly cron leaves it ``None`` for full historical coverage.
     """
     try:
         data: dict[str, Any] = json.loads(payload)
@@ -230,6 +244,11 @@ def parse_submissions_index(payload: str) -> list[AccessionRef]:
             continue
         filed_at = _safe_iso_datetime(filing_dates[i] if i < len(filing_dates) else "")
         period = _safe_iso_date(report_dates[i] if i < len(report_dates) else "")
+        if min_period_of_report is not None and period is not None and period < min_period_of_report:
+            # #1008 — first-install bootstrap caller passes a recent
+            # cut-off so we don't iterate pre-2013 filings whose
+            # primary_doc/infotable XML structure didn't exist yet.
+            continue
         out.append(
             AccessionRef(
                 accession_number=str(accession),
@@ -813,6 +832,7 @@ def ingest_filer_13f(
     *,
     filer_cik: str,
     ingestion_run_id: int | None = None,
+    min_period_of_report: date | None = None,
 ) -> IngestSummary:
     """Fetch + parse + upsert every pending 13F-HR for one filer.
 
@@ -821,6 +841,8 @@ def ingest_filer_13f(
     flow into the existing data_ingestion_runs row owned by the
     caller; when absent, no audit row is touched. The batch-mode
     entry point :func:`ingest_all_active_filers` always supplies one.
+    ``min_period_of_report`` (#1008) bounds historical depth — see
+    :func:`parse_submissions_index`.
     """
     cik = _zero_pad_cik(filer_cik)
     summary = _MutableSummary(cik=cik)
@@ -830,7 +852,10 @@ def ingest_filer_13f(
         logger.warning("13F ingest: submissions JSON 404/error for cik=%s", cik)
         return summary.to_immutable()
 
-    pending_accessions = parse_submissions_index(submissions_payload)
+    pending_accessions = parse_submissions_index(
+        submissions_payload,
+        min_period_of_report=min_period_of_report,
+    )
     summary.accessions_seen = len(pending_accessions)
 
     already_ingested = _existing_accessions_for_filer(conn, filer_cik=cik)
@@ -874,6 +899,7 @@ def ingest_all_active_filers(
     ciks: list[str] | None = None,
     deadline_seconds: float | None = None,
     source_label: str = "sec_edgar_13f",
+    min_period_of_report: date | None = None,
 ) -> list[IngestSummary]:
     """Walk a list of filer CIKs and ingest each filer's pending 13F-HRs.
 
@@ -897,6 +923,12 @@ def ingest_all_active_filers(
     perturbed; the universe sweep passes ``sec_edgar_13f_directory``
     so an operator can grep ``data_ingestion_runs`` to separate the
     two paths.
+
+    ``min_period_of_report`` (#1008) bounds historical depth so
+    first-install bootstrap doesn't iterate decades of pre-2013
+    13F filings whose primary_doc/infotable XML structure didn't
+    exist yet. ``None`` keeps the previous full-history behaviour
+    for the standalone weekly cron.
     """
     if ciks is None:
         ciks = _list_active_filer_seeds(conn)
@@ -938,7 +970,13 @@ def ingest_all_active_filers(
                 break
             filers_attempted += 1
             try:
-                summary = ingest_filer_13f(conn, sec, filer_cik=cik, ingestion_run_id=run_id)
+                summary = ingest_filer_13f(
+                    conn,
+                    sec,
+                    filer_cik=cik,
+                    ingestion_run_id=run_id,
+                    min_period_of_report=min_period_of_report,
+                )
             except Exception as exc:  # noqa: BLE001 — per-filer crash must not abort the batch
                 logger.exception("13F ingest: filer %s raised; continuing batch", cik)
                 crash_error = f"{cik}: {exc}"

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -353,6 +353,7 @@ class TestProductionInvokerRegistry:
             # them via JobLock + so admin Run-now still works:
             "bootstrap_orchestrator",
             "bootstrap_filings_history_seed",
+            "bootstrap_sec_13f_recent_sweep",
             "sec_first_install_drain",
             # #994 also un-retired these for bootstrap dispatch. They
             # are NOT in SCHEDULED_JOBS — daily_cik_refresh and


### PR DESCRIPTION
## Summary

Operator smoke run on dev DB caught it: ``sec_13f_quarterly_sweep`` ran 174 minutes walking decades of pre-2013 13F filings whose primary_doc / infotable XML didn't exist — each costing an SEC fetch with zero rows yielded. Operator killed the sweep before completion. Original ETA estimate of 30-45 min for that stage assumed quarterly cadence; reality is the parser walks ~1000-row ``recent`` arrays which span 60+ years for active filers.

Fixes by adding ``min_period_of_report`` parameter to ``parse_submissions_index`` / ``ingest_filer_13f`` / ``ingest_all_active_filers``. Bootstrap orchestrator gets a new bounded invoker (``bootstrap_sec_13f_recent_sweep``) that passes a 4-quarter cut-off; standalone weekly cron keeps full historical sweep.

## Test plan

- [x] ``uv run ruff check . && uv run ruff format --check .``
- [x] ``uv run pyright`` (0 errors)
- [x] 55 tests pass across orchestrator / prerequisite / integration / runtime suites.

Closes #1008. Part of #992 follow-up.