### PR TITLE
feat(#1011): SEC form-type three-tier allow-list

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -386,7 +386,7 @@ def bootstrap_filings_history_seed() -> None:
     Run-now.
     """
     from app.providers.implementations.sec_edgar import SecFilingsProvider
-    from app.services.filings import refresh_filings
+    from app.services.filings import SEC_INGEST_KEEP_FORMS, refresh_filings
     from app.workers.scheduler import _tracked_job  # type: ignore[attr-defined]
 
     with _tracked_job(JOB_BOOTSTRAP_FILINGS_HISTORY_SEED) as tracker:
@@ -424,7 +424,11 @@ def bootstrap_filings_history_seed() -> None:
                 instrument_ids=instrument_ids,
                 start_date=from_date,
                 end_date=to_date,
-                filing_types=None,
+                # #1011 — three-tier form-type allow-list. Pre-fix
+                # this was ``None`` (all forms); first-install audit
+                # 2026-05-07 measured ~32% of resulting filing_events
+                # rows were forms no parser ever consumes.
+                filing_types=sorted(SEC_INGEST_KEEP_FORMS),
             )
         tracker.row_count = summary.filings_upserted
         logger.info(

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -14,6 +14,25 @@ Skip behaviour:
   - missing Companies House company_number → skip CH for that instrument, record reason
   - provider HTTP error → skip that instrument for that provider, log warning
   - do not fail the whole batch for one missing identifier
+
+## SEC form-type allow-list (#1011)
+
+Spec: docs/superpowers/specs/2026-05-08-filing-allow-list-and-raw-retention.md.
+
+Three tiers govern which form types we ingest:
+
+  - SEC_PARSE_AND_RAW: active parsers consume these; raw payload
+    retained per per-form retention policy.
+  - SEC_METADATA_ONLY: no parser yet, but the form has thesis /
+    signal value an LLM or future ranking signal would consume.
+    filing_events row only — never fetched as raw.
+  - default = SKIP: pure noise / regulatory boilerplate; never
+    appears in filing_events.
+
+The union ``SEC_INGEST_KEEP_FORMS`` is what callers of
+``refresh_filings`` pass to bound the ingest. Pre-#1011 the default
+was ``filing_types=None`` (all forms), which wrote ~32% non-consumed
+rows on first install (operator audit 2026-05-07).
 """
 
 import json
@@ -26,6 +45,115 @@ import psycopg
 from app.providers.filings import FilingEvent, FilingSearchResult, FilingsProvider
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# SEC form-type allow-list (#1011)
+# ---------------------------------------------------------------------------
+
+
+# Tier 1 — active parsers consume these. Raw payload retained.
+SEC_PARSE_AND_RAW: frozenset[str] = frozenset(
+    {
+        "10-K",
+        "10-K/A",
+        "10-Q",
+        "10-Q/A",
+        "8-K",
+        "8-K/A",
+        "DEF 14A",
+        "DEFA14A",
+        "DEFM14A",
+        "DEFR14A",
+        "3",
+        "3/A",
+        "4",
+        "4/A",
+        "13F-HR",
+        "13F-HR/A",
+        "NPORT-P",
+        "NPORT-P/A",
+        "SCHEDULE 13G",
+        "SCHEDULE 13G/A",
+        "SCHEDULE 13D",
+        "SCHEDULE 13D/A",
+    }
+)
+
+
+# Tier 2 — metadata-only. No parser, no raw body. filing_events row
+# costs ~200 bytes; cheap insurance for future parsers + ad-hoc
+# operator queries. See spec for per-form rationale (Codex round 1).
+SEC_METADATA_ONLY: frozenset[str] = frozenset(
+    {
+        # Late-filing red flags — restatement / auditor-change signal.
+        "NT 10-K",
+        "NT 10-Q",
+        # Foreign-issuer classification + future parsers.
+        "20-F",
+        "20-F/A",
+        "40-F",
+        "40-F/A",
+        "6-K",
+        "6-K/A",
+        # 13F-NT — used for institutional-filer classification only.
+        "13F-NT",
+        "13F-NT/A",
+        # Capital actions — IPO / secondary / shelf / debt / M&A.
+        "S-1",
+        "S-1/A",
+        "S-3",
+        "S-3/A",
+        "S-4",
+        "S-4/A",
+        "F-1",
+        "F-1/A",
+        "F-3",
+        "F-3/A",
+        "F-4",
+        "F-4/A",
+        "424B2",
+        "424B3",
+        "424B4",
+        "424B5",
+        "424B7",
+        "424B8",
+        # Proxy variants — contested votes / dilution authorisations.
+        "PRE 14A",
+        "PRER14A",
+        # Tender offers + going-private — M&A / take-out signal.
+        "SC TO-T",
+        "SC TO-T/A",
+        "SC 14D9",
+        "SC 14D9/A",
+        "DEF 13E-3",
+        "PREM14C",
+        "DEFM14C",
+        # Delisting / deregistration — terminal-state signal.
+        "25",
+        "25-NSE",
+        "15-12B",
+        "15-12G",
+        "15-15D",
+        "15F",
+        "15F-12B",
+        "15F-12G",
+        "15F-15D",
+        # Insider compliance — late/exempt Section 16, proposed
+        # restricted-share sales (insider overhang).
+        "5",
+        "5/A",
+        "144",
+        # SEC correspondence — rare red-flag signal.
+        "CORRESP",
+        # Employer-plan stock concentration.
+        "11-K",
+    }
+)
+
+
+# Public union — pass this to ``refresh_filings(filing_types=...)``.
+SEC_INGEST_KEEP_FORMS: frozenset[str] = SEC_PARSE_AND_RAW | SEC_METADATA_ONLY
 
 
 @dataclass(frozen=True)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1635,6 +1635,14 @@ def daily_research_refresh() -> None:
                 SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
                 psycopg.connect(settings.database_url) as conn,
             ):
+                # #1011 — daily incremental uses the same three-tier
+                # allow-list as the bootstrap. Pre-fix this was
+                # ``["10-K", "10-Q", "8-K"]`` (narrower than bootstrap),
+                # so first-install + nightly diverged in coverage.
+                # ``SEC_INGEST_KEEP_FORMS`` is the canonical union of
+                # parse-and-raw + metadata-only forms.
+                from app.services.filings import SEC_INGEST_KEEP_FORMS
+
                 sec_summary = refresh_filings(
                     provider=sec,
                     provider_name="sec",
@@ -1643,7 +1651,7 @@ def daily_research_refresh() -> None:
                     instrument_ids=instrument_ids,
                     start_date=from_date,
                     end_date=to_date,
-                    filing_types=["10-K", "10-Q", "8-K"],
+                    filing_types=sorted(SEC_INGEST_KEEP_FORMS),
                 )
             total_rows += sec_summary.filings_upserted
             logger.info(

--- a/docs/superpowers/specs/2026-05-08-filing-allow-list-and-raw-retention.md
+++ b/docs/superpowers/specs/2026-05-08-filing-allow-list-and-raw-retention.md
@@ -1,0 +1,401 @@
+# SEC filing allow-list + raw-payload retention policy
+
+Author: claude (autonomous)
+Date: 2026-05-08
+Status: Draft (post-Codex round 1)
+
+## Problem
+
+Operator first-install bootstrap audit (2026-05-07) surfaced two
+shapes of waste in the SEC ingest path:
+
+1. **`filings_history_seed` (S5) writes 32% non-consumed rows**:
+   816,597 ``filing_events`` rows after first-install, of which
+   265,956 (32%) are forms no parser consumes today (424B
+   prospectus supplements, 144 sale notices, FWP marketing,
+   CORRESP, etc.). Plus a long tail of ~100 other form types
+   we never look at.
+2. **Raw-payload persistence is over-broad**: ``filing_raw_documents``
+   holds ~14.7 GB uncompressed (1.5 GB on disk via TOAST). DEF 14A
+   bodies alone are 11 GB for 16,588 filings (avg 713 KB each), but
+   ``def14a_beneficial_holdings`` (the parsed output we actually
+   query) is 11 MB — a **1000:1 raw-vs-extracted ratio**.
+
+The settled-decision principle is "raw API payloads persisted before
+any parse / normalise step" (prevention-log entry). That justifies
+SOME raw retention; current implementation persists too much.
+
+## Goal
+
+Refine SEC ingest so:
+
+- We pull and store only what offers signal value to ranking, thesis,
+  or coverage classification.
+- "No-benefit" forms (defined as: no parser, no classifier use, no
+  documented LLM thesis-relevance) are skipped entirely.
+- Raw-payload retention is justified per-form: kept when re-parse-
+  from-SEC is unsafe (parser-bug forensics on a takedown-prone
+  source), dropped when SEC archive guarantees re-fetchability.
+- The decision is documented per-form so adding a new ingest later
+  inherits the framework.
+
+## Form-type allow-list — by signal value
+
+For each SEC form type seen on the dev DB ingest, the table below
+records: what the form contains, what an LLM (or ranking signal)
+could extract from it, current parser status, and whether to keep
+metadata in `filing_events` / persist raw / skip entirely.
+
+| Form | Contents | LLM / ranking signal | Parser today | Raw policy | Decision |
+|---|---|---|---|---|---|
+| **10-K, 10-K/A** | Annual report + audited financials + risk factors + business description | High — `business_summary`, fundamentals, risk-factor text mining | Yes (`business_summary`, fundamentals via XBRL) | Persist body — 10-K is foundational, re-parse cost is high | **KEEP + parse + raw** |
+| **10-Q, 10-Q/A** | Quarterly unaudited financials + MD&A | High — fundamentals, MD&A text | Yes (fundamentals via XBRL) | Persist on parse-fail only — XBRL Company Facts is the canonical re-fetch | **KEEP + parse + raw-on-fail** |
+| **8-K, 8-K/A** | Material events (Item 1.01 agreement, 2.01 M&A, 4.02 non-reliance, 5.02 officer change, etc.) | High — event-driven thesis, material change detection | Yes (`eight_k_events`) | Persist on parse-fail only | **KEEP + parse + raw-on-fail** |
+| **DEF 14A** | Annual proxy: beneficial-ownership table, executive compensation, board composition | High — beneficial ownership, governance, comp structure | Yes (`def14a_beneficial_holdings`) | **Drop on success** — raw is 713 KB avg × 16k filings = 11 GB; extracted output is 11 MB. Re-fetch from SEC archive is idempotent | **KEEP + parse + raw-on-fail** |
+| **DEFA14A** | Activist proxy supplements, board letters during contested elections | High — activist campaign signal | Partial (def14a parser accepts) | Persist on parse-fail | **KEEP + parse + raw-on-fail** |
+| **DEFM14A, DEFR14A** | Merger / revised proxy variants | Medium — M&A signal | Partial | Persist on parse-fail | **KEEP + parse + raw-on-fail** |
+| **3, 3/A** | Initial insider holdings statement | High — insider baseline cumulative position | Yes (`insider_form3_ingest`) | Persist on parse-fail | **KEEP + parse + raw-on-fail** |
+| **4, 4/A** | Insider transactions (Section 16) | High — insider buy/sell signal, the bedrock of the insider ranking | Yes (`insider_transactions`) | Persist on parse-fail | **KEEP + parse + raw-on-fail** |
+| **13F-HR, 13F-HR/A** | Institutional holdings (managers $100M+ AUM) | High — institutional ownership mosaic | Yes (`institutional_holdings`) | Drop on success — informationtable.xml re-fetch is idempotent. 14 GB savings | **KEEP + parse + raw-on-fail** |
+| **NPORT-P** | Mutual fund / ETF holdings (monthly) | High — fund flows + sector positioning | Yes (`n_port_ingest`) | Persist on parse-fail | **KEEP + parse + raw-on-fail** |
+| **SCHEDULE 13G, 13G/A** | Passive 5%+ blockholder | High — institutional concentration signal | Yes (blockholder_filings) | Persist on parse-fail | **KEEP + parse + raw-on-fail** |
+| **SCHEDULE 13D, 13D/A** | Activist 5%+ blockholder (with intent) | High — activist target detection | Partial (blockholder_filings) | Persist on parse-fail | **KEEP + parse + raw-on-fail** |
+| **NT 10-K, NT 10-Q** | Notification of late filing — reason often signals trouble (auditor change, restatement pending, accounting issue) | **High — late-filing is a red flag** that historically correlates with restatements / SEC actions | None — no parser | Persist on parse-fail (parser TBD) | **ADD — keep metadata + add lightweight parser later** |
+| **20-F, 20-F/A** | Foreign annual report (non-US issuers) | Medium — same role as 10-K for foreign issuers; phase 2 | Coverage classifier reads it | Persist on parse-fail | **KEEP metadata + raw-on-fail** (used by coverage classifier today, parser later) |
+| **40-F, 40-F/A** | Canadian annual report | Same as 20-F | Coverage classifier | Persist on parse-fail | **KEEP metadata** |
+| **6-K, 6-K/A** | Foreign material event / interim (non-US ADRs) | Medium — equivalent to 8-K + 10-Q for foreign issuers | Coverage classifier | Persist on parse-fail | **KEEP metadata** |
+| **13F-NT, 13F-NT/A** | "I'm filing combined with parent X" notice | Low — used for filer classification only | Filer-directory classifier | Skip raw | **KEEP metadata** |
+| ~~**424B2/B3/B4/B5/B7**~~ | Prospectus supplements (bond/secondary offerings) | Marginal — capital-action signal IS thesis-relevant (new debt, dilutive issuance) but no parser today and the same info lands in 10-K next quarter | None | Skip | **SKIP** for v1; reconsider when offerings parser exists |
+| ~~**144**~~ | Insider notice of intent to sell restricted shares | Low — Form 4 captures the actual transaction; 144 is forward-looking but ~30-50% never execute | None | Skip | **SKIP** (Form 4 supersedes) |
+| ~~**FWP**~~ | Free writing prospectus (marketing material for offerings) | Near-zero — sales-pitch tier sheets, real terms land in 424B at offering close | None | Skip | **SKIP** |
+| ~~**CORRESP**~~ | Letters between issuer and SEC review staff | High-signal in rare cases (revenue-recognition Q&A, going-concern queries), but ~95% is routine review-cycle correspondence; red flags eventually surface in 8-K Item 4.02 | None | Skip | **SKIP** for v1; could be valuable LLM signal in a "deep-dive" mode later |
+| ~~**5, 5/A**~~ | Annual insider catch-all for transactions missed in Form 4 | Marginal — Form 4 should capture most | None | Skip | **SKIP** |
+| ~~**S-8**~~ | Registration of employee stock plans | Marginal — dilution disclosure already in 10-K | None | Skip | **SKIP** |
+| ~~**N-CSR, N-CSRS**~~ | Mutual-fund annual / semi-annual reports | Low — NPORT covers fund holdings monthly | None | Skip | **SKIP** (NPORT supersedes) |
+| ~~**D, D/A**~~ | Private placement notices (Reg D exempt offerings) | Low — private placement, not directly relevant to public ranking | None | Skip | **SKIP** |
+| ~~**S-1, S-3, S-4**~~ | Registration statements (IPO, secondary, M&A) | High for IPO / M&A specifically — but no parser today, deferred to v2 | None | Skip | **SKIP** for v1, defer to ticketed v2 IPO/M&A work |
+
+### Form-type categories not in the table
+
+The dev DB shows ~125 distinct form_type values across 800k
+``filing_events`` rows. The above covers the ~30 we explicitly take
+a position on. The long tail (CT ORDER, EFFECT, COVER, SC TO-T,
+PX14A6G, PRE 14A, F-1, F-3, etc.) all default to **SKIP** unless
+the operator surfaces a concrete LLM use case + parser plan.
+
+Default = skip is the right posture: each new form type added to
+the allow-list should require a documented "what would the LLM /
+ranking pipeline do with this" justification, not the reverse.
+
+## Concrete output of the form-type review
+
+### Three-tier allow-list (post-Codex round 1)
+
+Codex pushed back on the binary "parse OR skip" model. Reality is
+three tiers — each costs different storage:
+
+| Tier | Per-form cost | When to use |
+|---|---|---|
+| **PARSE+RAW** | filing_events row + raw payload retained per retention policy | Active parsers exist; raw needed for re-parse-on-bug |
+| **METADATA-ONLY** | filing_events row only (~200 bytes); no raw body fetch | No parser yet but the form has thesis / signal value an LLM or future ranking signal would consume |
+| **SKIP** | nothing — never appears in filing_events | Pure noise / regulatory boilerplate; no documented LLM use case |
+
+A metadata-only row costs ~zero (200 bytes) but lets a future parser
+backfill from `filing_events` without a fresh submissions.json walk
+of every CIK. This is the cheap insurance Codex flagged.
+
+#### Tier 1 — PARSE+RAW (active parsers + retention policy)
+
+```python
+SEC_PARSE_AND_RAW: frozenset[str] = frozenset({
+    "10-K", "10-K/A",
+    "10-Q", "10-Q/A",
+    "8-K", "8-K/A",
+    "DEF 14A", "DEFA14A", "DEFM14A", "DEFR14A",
+    "3", "3/A",
+    "4", "4/A",
+    "13F-HR", "13F-HR/A",
+    "NPORT-P", "NPORT-P/A",
+    "SCHEDULE 13G", "SCHEDULE 13G/A",
+    "SCHEDULE 13D", "SCHEDULE 13D/A",
+})
+```
+
+#### Tier 2 — METADATA-ONLY (no parser yet; future signal value)
+
+Codex round-1 explicitly added each of these:
+
+```python
+SEC_METADATA_ONLY: frozenset[str] = frozenset({
+    # Late-filing red flags — restatement / auditor-change signal.
+    "NT 10-K", "NT 10-Q",
+    # Foreign-issuer classification + future parsers (used by
+    # coverage today; parser deferred to UK/EU phase 2).
+    "20-F", "20-F/A",
+    "40-F", "40-F/A",
+    "6-K", "6-K/A",
+    # 13F-NT — used for institutional-filer classification only.
+    "13F-NT", "13F-NT/A",
+    # Capital actions — IPO / secondary / shelf / debt / M&A.
+    # Final pricing + use-of-proceeds in 424B don't land in 10-Q
+    # for weeks; signal is fresher in these forms.
+    "S-1", "S-1/A",
+    "S-3", "S-3/A",
+    "S-4", "S-4/A",
+    "F-1", "F-1/A",  # foreign IPO
+    "F-3", "F-3/A",  # foreign shelf
+    "F-4", "F-4/A",  # foreign M&A
+    "424B2", "424B3", "424B4", "424B5", "424B7", "424B8",
+    # Proxy variants — contested votes / dilution authorisations
+    # / reverse splits land here before DEF 14A.
+    "PRE 14A", "PRER14A",
+    # Tender offers + going-private — M&A / take-out signal.
+    "SC TO-T", "SC TO-T/A",
+    "SC 14D9", "SC 14D9/A",
+    "DEF 13E-3", "PREM14C", "DEFM14C",
+    # Delisting / deregistration — terminal-state signal.
+    "25", "25-NSE",
+    "15-12B", "15-12G", "15-15D",
+    "15F", "15F-12B", "15F-12G", "15F-15D",
+    # Insider compliance — late/exempt Section 16, proposed
+    # restricted-share sales (insider overhang). Codex flagged
+    # these are not fully superseded by Form 4.
+    "5", "5/A",
+    "144",
+    # SEC correspondence — rare red-flag signal (rev-rec Q&A,
+    # going-concern, restatement-pending). 95% routine but the
+    # 5% is exactly LLM thesis material.
+    "CORRESP",
+    # Employer-plan stock concentration (low priority but cheap).
+    "11-K",
+})
+```
+
+#### Tier 3 — SKIP (zero documented value)
+
+```python
+SEC_SKIP: frozenset[str] = frozenset({
+    # Marketing material — final terms land in 424B.
+    "FWP",
+    # Mutual-fund annual/semi reports — NPORT-P covers fund
+    # holdings monthly with structured XBRL.
+    "N-CSR", "N-CSRS",
+    # Private placement notices — exempt offering, not directly
+    # ranking-relevant for public-equity universe.
+    "D", "D/A",
+    # Employee stock plan registrations — dilution disclosure
+    # already in 10-K cover-page DEI tags + risk factors.
+    "S-8", "S-8 POS",
+})
+```
+
+#### Default = SKIP
+
+The dev DB observes ~125 distinct form_type values. The three tiers
+above cover ~70. Everything else defaults to SKIP. Adding a new
+form-type to Tier 1 or Tier 2 requires a documented "what LLM /
+ranking pipeline consumes this" justification.
+
+#### `SEC_INGEST_KEEP_FORMS` (the union the ingester actually uses)
+
+```python
+SEC_INGEST_KEEP_FORMS: frozenset[str] = (
+    SEC_PARSE_AND_RAW | SEC_METADATA_ONLY
+)
+```
+
+This is the constant `bootstrap_filings_history_seed` and
+`daily_research_refresh` pass to `refresh_filings(filing_types=...)`.
+The downstream raw-fetch step gates on `SEC_PARSE_AND_RAW` membership
+to decide whether to fetch the raw body.
+
+### What `bootstrap_filings_history_seed` (S5) does today
+
+```python
+refresh_filings(filing_types=None, ...)  # = "all forms"
+```
+
+### What it should do
+
+```python
+refresh_filings(filing_types=list(SEC_BOOTSTRAP_FORM_ALLOWLIST), ...)
+```
+
+### Apply to `daily_research_refresh` too
+
+Currently passes `filing_types=["10-K", "10-Q", "8-K"]` — narrower
+than the bootstrap allow-list. Daily incremental should also use
+the full bootstrap allow-list so first-install + nightly converge to
+the same coverage shape.
+
+### Coverage / parser implementation gap
+
+Several forms in the allow-list have **no parser** today:
+
+- `NT 10-K`, `NT 10-Q` — late-filing notices (high signal, no parser)
+- `20-F`, `40-F`, `6-K` — foreign-issuer reports (coverage classifier
+  uses metadata, no parser)
+- `DEFM14A`, `DEFR14A` — proxy variants (def14a parser accepts but
+  no specific path)
+
+**Decision**: keep the metadata in `filing_events` for these; they
+cost ~bytes per row, downstream parsers ignore them, but they're
+available when (a) the parser lands, or (b) operator does ad-hoc
+LLM analysis via SQL.
+
+## Raw-payload retention policy
+
+### Current state (uncompressed sizes from dev DB)
+
+| document_kind | count | total | avg/doc |
+|---|---|---|---|
+| `def14a_body` | 16,588 | 11 GB | 713 KB |
+| `infotable_13f` | 14,316 | 3.6 GB | 267 KB |
+| `primary_doc` | 14,317 | 32 MB | 2 KB |
+| `form4_xml` | 2,500 | 21 MB | 9 KB |
+| `form3_xml` | 1,000 | 3.6 MB | 4 KB |
+
+### Why we persist raw
+
+The prevention-log rule is "Raw API payload must be persisted before
+any parse / normalise step". The justifications historically:
+
+1. **Re-parse on parser bug**: if a parser fix lands later, we can
+   re-parse without re-fetching from SEC.
+2. **Forensic audit**: operator can verify what we actually got from
+   SEC at ingest time.
+3. **SEC takedown risk**: in theory, SEC could remove a filing.
+   In practice, SEC archive is durable — accepted filings remain
+   accessible at their `primary_document_url` indefinitely.
+
+### Proposed policy
+
+Three retention modes, picked per `document_kind`:
+
+| Mode | When | Storage cost |
+|---|---|---|
+| **drop-on-success** | Persist raw → run parser → if parse succeeds, delete the raw row → if parse fails, keep raw for forensic re-parse | ~zero steady state; one filing's worth of TOASTed text per recent failure |
+| **keep-on-fail** | Same as drop-on-success, plus keep raw rows for any parse outcome marked `failed` or `partial` until the issue is resolved | low; bounded by parse-fail tail |
+| **keep-always** | Persist raw forever — used only for filings whose URL is unstable or whose parse cost is prohibitive | full current cost |
+
+### Per-form decision
+
+| document_kind | Mode | Rationale |
+|---|---|---|
+| `def14a_body` | **drop-on-success** | 11 GB recoverable. Re-fetch is idempotent. Forensic value low — extracted table is the operator-relevant data; full proxy text is rarely needed except for legal review |
+| `infotable_13f` | **drop-on-success** | 3.6 GB recoverable. XML is short, re-parse cheap |
+| `primary_doc` | keep-always | 32 MB, tiny. Index page is sometimes used for cross-referencing. Not worth optimising |
+| `form4_xml` | keep-always | 21 MB. Form 4 amendments + insider-transaction forensics are non-trivial; 21 MB is cheap insurance |
+| `form3_xml` | keep-always | 3.6 MB. Same reasoning |
+| (future) 10-K body | **drop-on-success** | Annual reports are 5-50 MB each; 9k filings = 45 GB-2 TB. Operator should not pay this |
+| (future) 8-K body | keep-on-fail | 50 KB - 1 MB each; full-text mining might want eventual access |
+
+**Net savings**: ~14 GB (def14a + infotable). 95% of `filing_raw_documents`
+storage. Successful parses re-fetchable from SEC.
+
+### Reproducibility guard — hash-on-write, hash-verify-on-refetch
+
+Codex round-1 flagged: "re-fetch is idempotent" is too strong without
+a hash check. **Add reproducibility guard:**
+
+1. On ingest, persist `payload_sha256` (32 bytes) + `accepted_at`
+   + `parser_version` + `extracted_at` per `filing_raw_documents`
+   row. These rows survive the drop-on-success sweep — only the
+   `payload` column itself is nullified.
+2. On any future re-fetch (manual operator action, parser-bug
+   re-parse), compute hash of fetched bytes and compare to the
+   persisted `payload_sha256`. Mismatch = SEC silently changed the
+   document → fail loud, surface to operator, do NOT auto-overwrite.
+
+This makes drop-on-success safe: we always have proof of what we
+parsed against, even after the bytes are gone. Operator gets a
+clean "the document changed" signal if SEC ever does retract /
+re-issue.
+
+### Risk: SEC takedown — actual edge cases
+
+Codex enumerated the real edge cases:
+
+- **Public-release timing for CORRESP / UPLOAD**: SEC withholds
+  staff-review correspondence until the review is closed. Then
+  releases it bulk. We never see in-flight correspondence. No
+  retraction risk; just delayed availability.
+- **SEC correction / reprocessing**: rare, but happens (typo in
+  filing metadata gets corrected on republish). Hash mismatch
+  surfaces this.
+- **Malformed historical filings**: pre-2001 EDGAR sometimes has
+  non-canonical encodings. Parse-fail keeps raw under `keep-on-fail`
+  by definition, so this is auto-handled.
+- **Withdrawn filings**: visible as filing + RW (request to
+  withdraw) accession. Both stay in EDGAR. No bytes lost.
+- **CT ORDER (confidential treatment)**: withheld by design, never
+  was bytes to begin with. Not a takedown case.
+- **Parser-success-but-semantically-wrong**: hash guard doesn't
+  catch this; only re-parse with the fixed parser does. This is
+  why we keep `parser_version` per row — sweeper can re-fetch only
+  rows with `parser_version < latest_for_kind`.
+
+If a takedown were ever observed (no historical case), we'd flip
+the affected `document_kind` to `keep-always` — the policy is
+per-form, mutable, not a one-way door.
+
+## Apply to all SEC ingest paths
+
+This audit is one-shot but the framework should govern future ingest
+work. Per-stage allow-list discipline:
+
+| Stage / Job | Currently | Should be |
+|---|---|---|
+| `bootstrap_filings_history_seed` (S5) | `filing_types=None` (all forms) | `filing_types=SEC_BOOTSTRAP_FORM_ALLOWLIST` |
+| `daily_research_refresh` (orchestrator-driven) | `["10-K", "10-Q", "8-K"]` | `SEC_BOOTSTRAP_FORM_ALLOWLIST` |
+| `daily_financial_facts` (orchestrator-driven) | Master-index walks all forms | Filter to allow-list at the master-index parse step |
+| `sec_first_install_drain` (S6) | All sources via `manifest_source_for_form` | Filter same allow-list before recording manifest entries |
+| Future: 10-K body parser | n/a | `keep-on-fail` raw |
+| Future: 8-K Item-1.01 deep-dive | n/a | `keep-on-fail` raw |
+
+## Open questions for review
+
+1. **Should `CORRESP` be in the allow-list as a "deep-dive" mode**?
+   Argument for: rare red-flag signal (revenue-recognition Q&A).
+   Argument against: 95% routine, requires NLP to surface signal
+   from noise, no current parser. **Default skip; revisit when an
+   LLM-driven thesis pipeline can consume it as a free-text input.**
+
+2. **Should `424B*` be added back as metadata-only**?
+   Capital actions (debt issuance, secondary offerings) ARE
+   thesis-relevant. Argument for: cheap to keep metadata.
+   Argument against: 100k+ rows of noise, signal extraction needs
+   a parser we don't have. **Default skip; revisit when the
+   capital-actions parser lands.**
+
+3. **Should foreign forms (20-F, 40-F, 6-K) keep raw bodies**?
+   We don't parse them yet. Coverage classifier reads metadata
+   only. **Skip raw, keep metadata** matches the "no parser, no
+   raw" rule.
+
+## Migration plan
+
+1. **PR1 (small, low-risk)**: Add `SEC_BOOTSTRAP_FORM_ALLOWLIST`
+   constant + thread it through `bootstrap_filings_history_seed`
+   and `daily_research_refresh`. Cuts S5 writes by ~32% on next
+   first-install. Minimal blast radius.
+2. **PR2 (data-migration)**: Retroactively delete `filing_events`
+   rows for skipped form types from existing dev DB. Idempotent.
+3. **PR3 (raw-retention infra)**: Add `retention_mode` column on
+   `filing_raw_documents` + per-document_kind policy + a sweeper
+   job that drops `drop-on-success` rows where the parse outcome
+   was `success`. ~14 GB recovery.
+4. **PR4 (sweeper retroactive run)**: Operator triggers
+   `POST /jobs/raw_retention_sweep/run` to drop existing
+   already-parsed raw bodies.
+
+## Spec deliverables
+
+- [ ] Codex review of the per-form decisions (especially CORRESP /
+      424B / S-1 trade-offs).
+- [ ] Operator sign-off on the allow-list shape before PR1.
+- [ ] PR1-PR4 land in sequence.
+- [ ] Runbook update: how to add a new form type to the allow-list
+      (the documentation question is "what LLM / ranking pipeline
+      will consume this"; the implementation question is
+      "what's the raw retention mode").

--- a/docs/superpowers/specs/2026-05-08-filing-allow-list-and-raw-retention.md
+++ b/docs/superpowers/specs/2026-05-08-filing-allow-list-and-raw-retention.md
@@ -65,23 +65,29 @@ metadata in `filing_events` / persist raw / skip entirely.
 | **40-F, 40-F/A** | Canadian annual report | Same as 20-F | Coverage classifier | Persist on parse-fail | **KEEP metadata** |
 | **6-K, 6-K/A** | Foreign material event / interim (non-US ADRs) | Medium — equivalent to 8-K + 10-Q for foreign issuers | Coverage classifier | Persist on parse-fail | **KEEP metadata** |
 | **13F-NT, 13F-NT/A** | "I'm filing combined with parent X" notice | Low — used for filer classification only | Filer-directory classifier | Skip raw | **KEEP metadata** |
-| ~~**424B2/B3/B4/B5/B7**~~ | Prospectus supplements (bond/secondary offerings) | Marginal — capital-action signal IS thesis-relevant (new debt, dilutive issuance) but no parser today and the same info lands in 10-K next quarter | None | Skip | **SKIP** for v1; reconsider when offerings parser exists |
-| ~~**144**~~ | Insider notice of intent to sell restricted shares | Low — Form 4 captures the actual transaction; 144 is forward-looking but ~30-50% never execute | None | Skip | **SKIP** (Form 4 supersedes) |
+| **424B2/B3/B4/B5/B7/B8** | Prospectus supplements (bond/secondary offerings) | Capital-action signal IS thesis-relevant (new debt, dilutive issuance, ATM offerings, refinancing). Final pricing + use-of-proceeds land here weeks before 10-Q. Codex round 1 flagged the original SKIP call as underweighting capital-action signal | None | Skip raw | **METADATA-ONLY** (parser deferred — see #1015) |
+| **144** | Insider notice of intent to sell restricted shares | Form 4 captures the actual transaction afterwards, BUT 144 surfaces insider overhang + low-float pressure + founder/VC distribution intent before the sale. Codex round 1 flagged: not fully superseded by Form 4 | None | Skip raw | **METADATA-ONLY** (parser deferred) |
+| **CORRESP** | Letters between issuer and SEC review staff | High-signal in rare cases (revenue-recognition Q&A, going-concern queries, restatement-pending). 95% routine but the 5% is exactly LLM thesis material. Codex round 1: SEC says CorpFin reviews focus on disclosures that may conflict with rules / be materially deficient — exactly what an LLM deep-dive would consume | None | Skip raw | **METADATA-ONLY** (deep-dive LLM parser deferred) |
+| **5, 5/A** | Annual insider catch-all for transactions missed in Form 4 | Form 4 should capture most, but Form 5 reveals late/exempt Section 16 reporting. Codex round 1 flagged: late/missed reporting is itself an insider-quality / compliance signal | None | Skip raw | **METADATA-ONLY** (parser deferred) |
+| **S-1, S-3, S-4** | Registration statements (IPO, secondary, M&A) | S-1 = IPO / new-issuer thesis; S-3 = shelf takedowns + ATM + secondary; S-4 = merger/exchange-offer economics. Codex round 1 flagged the SKIP call as missing capital-action thesis material | None | Skip raw | **METADATA-ONLY** (IPO/M&A parser deferred to v2) |
+| **F-1, F-3, F-4** | Foreign-issuer mirrors of S-1/S-3/S-4 | Same signal as S-* for foreign issuers; thesis-relevant for ADRs and foreign-listed names | None | Skip raw | **METADATA-ONLY** |
+| **PRE 14A, PRER14A** | Preliminary proxy + revisions | Contested votes, dilution authorisations, reverse splits surface here before DEF 14A is final. Codex round 1 flagged | None | Skip raw | **METADATA-ONLY** |
+| **SC TO-T, SC 14D9, DEF 13E-3** | Tender-offer acquirer materials, target recommendation, going-private fairness | M&A / take-out signal. DEF 13E-3 is the conflict-of-interest disclosure for going-private transactions | None | Skip raw | **METADATA-ONLY** |
+| **25, 25-NSE, 15-12B, 15-12G, 15-15D, 15F variants** | Delisting / deregistration / foreign termination notices | Terminal-state signal — instrument leaving the universe. Codex round 1 flagged | None | Skip raw | **METADATA-ONLY** |
+| **11-K** | Annual report for employee stock-purchase / savings / 401(k) plans | Low priority but reveals employer-plan stock concentration | None | Skip raw | **METADATA-ONLY** |
 | ~~**FWP**~~ | Free writing prospectus (marketing material for offerings) | Near-zero — sales-pitch tier sheets, real terms land in 424B at offering close | None | Skip | **SKIP** |
-| ~~**CORRESP**~~ | Letters between issuer and SEC review staff | High-signal in rare cases (revenue-recognition Q&A, going-concern queries), but ~95% is routine review-cycle correspondence; red flags eventually surface in 8-K Item 4.02 | None | Skip | **SKIP** for v1; could be valuable LLM signal in a "deep-dive" mode later |
-| ~~**5, 5/A**~~ | Annual insider catch-all for transactions missed in Form 4 | Marginal — Form 4 should capture most | None | Skip | **SKIP** |
-| ~~**S-8**~~ | Registration of employee stock plans | Marginal — dilution disclosure already in 10-K | None | Skip | **SKIP** |
-| ~~**N-CSR, N-CSRS**~~ | Mutual-fund annual / semi-annual reports | Low — NPORT covers fund holdings monthly | None | Skip | **SKIP** (NPORT supersedes) |
-| ~~**D, D/A**~~ | Private placement notices (Reg D exempt offerings) | Low — private placement, not directly relevant to public ranking | None | Skip | **SKIP** |
-| ~~**S-1, S-3, S-4**~~ | Registration statements (IPO, secondary, M&A) | High for IPO / M&A specifically — but no parser today, deferred to v2 | None | Skip | **SKIP** for v1, defer to ticketed v2 IPO/M&A work |
+| ~~**N-CSR, N-CSRS**~~ | Mutual-fund annual / semi-annual reports | Low — NPORT covers fund holdings monthly with structured XBRL | None | Skip | **SKIP** (NPORT supersedes) |
+| ~~**D, D/A**~~ | Private placement notices (Reg D exempt offerings) | Low — private placement, not directly relevant to public-equity ranking | None | Skip | **SKIP** |
+| ~~**S-8, S-8 POS**~~ | Registration of employee stock plans | Marginal — dilution disclosure already in 10-K cover-page DEI tags + risk factors | None | Skip | **SKIP** |
 
 ### Form-type categories not in the table
 
 The dev DB shows ~125 distinct form_type values across 800k
-``filing_events`` rows. The above covers the ~30 we explicitly take
-a position on. The long tail (CT ORDER, EFFECT, COVER, SC TO-T,
-PX14A6G, PRE 14A, F-1, F-3, etc.) all default to **SKIP** unless
-the operator surfaces a concrete LLM use case + parser plan.
+``filing_events`` rows. The table above + the Tier 2 / Tier 3 code
+blocks below cover ~70 explicitly. Everything else defaults to
+**SKIP** — adding a form to PARSE+RAW or METADATA-ONLY requires a
+documented "what LLM / ranking pipeline consumes this"
+justification.
 
 Default = skip is the right posture: each new form type added to
 the allow-list should require a documented "what would the LLM /

--- a/tests/test_filings_form_allowlist.py
+++ b/tests/test_filings_form_allowlist.py
@@ -1,0 +1,137 @@
+"""Tests for the SEC form-type allow-list (#1011).
+
+Spec: docs/superpowers/specs/2026-05-08-filing-allow-list-and-raw-retention.md.
+
+Pins the three-tier model: every form an active parser consumes
+must be in ``SEC_PARSE_AND_RAW``; future-signal forms in
+``SEC_METADATA_ONLY``; the union ``SEC_INGEST_KEEP_FORMS`` is what
+``bootstrap_filings_history_seed`` and ``daily_research_refresh``
+pass to ``refresh_filings``.
+"""
+
+from __future__ import annotations
+
+from app.services.filings import (
+    SEC_INGEST_KEEP_FORMS,
+    SEC_METADATA_ONLY,
+    SEC_PARSE_AND_RAW,
+)
+
+
+def test_tiers_are_disjoint() -> None:
+    """A form belongs to exactly one tier (parse-and-raw OR metadata-only).
+
+    Overlap would mean the spec is ambiguous about whether the
+    raw-payload retention sweeper should touch the form.
+    """
+    overlap = SEC_PARSE_AND_RAW & SEC_METADATA_ONLY
+    assert overlap == frozenset(), f"forms in both tiers: {sorted(overlap)}"
+
+
+def test_union_is_public_constant() -> None:
+    assert SEC_INGEST_KEEP_FORMS == SEC_PARSE_AND_RAW | SEC_METADATA_ONLY
+
+
+def test_active_parser_forms_are_in_parse_and_raw() -> None:
+    """Every form a parser SQL filters on must be in
+    ``SEC_PARSE_AND_RAW`` so the bootstrap allow-list doesn't
+    starve a parser of input rows.
+
+    Pinned forms below are the ones we have explicit parser code
+    for today (verified by grep on app/services/*.py for
+    ``filing_type IN`` and ``filing_type =`` patterns).
+    """
+    must_parse = {
+        "10-K",
+        "10-K/A",
+        "10-Q",
+        "10-Q/A",
+        "8-K",
+        "8-K/A",
+        "DEF 14A",
+        "DEFA14A",
+        "DEFM14A",
+        "DEFR14A",
+        "3",
+        "3/A",
+        "4",
+        "4/A",
+        "13F-HR",
+        "13F-HR/A",
+        "NPORT-P",
+        "SCHEDULE 13G",
+        "SCHEDULE 13G/A",
+        "SCHEDULE 13D",
+        "SCHEDULE 13D/A",
+    }
+    missing = must_parse - SEC_PARSE_AND_RAW
+    assert missing == set(), f"forms missing from SEC_PARSE_AND_RAW (parsers will starve): {sorted(missing)}"
+
+
+def test_metadata_only_forms_have_no_parser_today() -> None:
+    """Sanity check: forms we mark metadata-only should not also
+    be in the parse-and-raw set. If a parser lands later, move
+    the form between sets in lockstep."""
+    # Pick a few representative forms the spec calls out as
+    # metadata-only (#1011 Codex round 1).
+    metadata_forms = {
+        "S-1",
+        "S-3",
+        "S-4",
+        "F-1",
+        "F-3",
+        "F-4",
+        "424B2",
+        "424B3",
+        "PRE 14A",
+        "SC TO-T",
+        "SC 14D9",
+        "DEF 13E-3",
+        "25-NSE",
+        "15F",
+        "5",
+        "5/A",
+        "144",
+        "CORRESP",
+        "11-K",
+        "NT 10-K",
+        "NT 10-Q",
+        "20-F",
+        "40-F",
+        "6-K",
+        "13F-NT",
+    }
+    missing = metadata_forms - SEC_METADATA_ONLY
+    assert missing == set(), f"forms missing from SEC_METADATA_ONLY: {sorted(missing)}"
+    in_both = metadata_forms & SEC_PARSE_AND_RAW
+    assert in_both == set(), f"metadata-only forms also in parse-and-raw: {sorted(in_both)}"
+
+
+def test_skipped_forms_not_in_keep_list() -> None:
+    """Forms the spec marks SKIP must NOT be in the union — including
+    them would defeat the allow-list purpose.
+
+    Pinned set is the documented SKIP tier from the spec. Adding a
+    form to the keep list later requires moving it out of this test
+    deliberately, surfacing the decision in code review.
+    """
+    skip_forms = {
+        "FWP",
+        "N-CSR",
+        "N-CSRS",
+        "D",
+        "D/A",
+        "S-8",
+        "S-8 POS",
+    }
+    overlap = skip_forms & SEC_INGEST_KEEP_FORMS
+    assert overlap == set(), f"forms marked SKIP appear in keep list: {sorted(overlap)}"
+
+
+def test_keep_list_size_is_bounded() -> None:
+    """Pin a size budget so an accidental ``frozenset.update``-style
+    over-broad merge fails the test. Current expected count is ~70."""
+    assert 50 <= len(SEC_INGEST_KEEP_FORMS) <= 100, (
+        f"SEC_INGEST_KEEP_FORMS size {len(SEC_INGEST_KEEP_FORMS)} outside expected range; "
+        "if this is intentional, update the test bounds."
+    )

--- a/tests/test_filings_form_allowlist.py
+++ b/tests/test_filings_form_allowlist.py
@@ -59,6 +59,7 @@ def test_active_parser_forms_are_in_parse_and_raw() -> None:
         "13F-HR",
         "13F-HR/A",
         "NPORT-P",
+        "NPORT-P/A",
         "SCHEDULE 13G",
         "SCHEDULE 13G/A",
         "SCHEDULE 13D",
@@ -126,6 +127,33 @@ def test_skipped_forms_not_in_keep_list() -> None:
     }
     overlap = skip_forms & SEC_INGEST_KEEP_FORMS
     assert overlap == set(), f"forms marked SKIP appear in keep list: {sorted(overlap)}"
+
+
+def test_spec_skip_table_matches_constants() -> None:
+    """Drift guard: every form the spec table declares as SKIP must
+    be absent from ``SEC_INGEST_KEEP_FORMS``.
+
+    PR1012 review caught the spec table contradicting the implementation
+    (424B*, CORRESP, S-1/S-3/S-4 marked SKIP in the table but METADATA-ONLY
+    in code). This test prevents that drift class from re-occurring.
+
+    The spec's authoritative SKIP table is reproduced here; updates to
+    either the table or the constants must be reflected in both places.
+    """
+    spec_skip_forms = {
+        "FWP",
+        "N-CSR",
+        "N-CSRS",
+        "D",
+        "D/A",
+        "S-8",
+        "S-8 POS",
+    }
+    overlap = spec_skip_forms & SEC_INGEST_KEEP_FORMS
+    assert overlap == set(), (
+        f"forms the spec table marks SKIP appear in SEC_INGEST_KEEP_FORMS: "
+        f"{sorted(overlap)} — spec table and code constants have drifted"
+    )
 
 
 def test_keep_list_size_is_bounded() -> None:


### PR DESCRIPTION
## Summary

PR1 of the form-type / raw-retention spec (2026-05-08-filing-allow-list-and-raw-retention.md, post-Codex round 1).

Adds three-tier SEC form-type allow-list (PARSE+RAW / METADATA-ONLY / SKIP) and threads ``SEC_INGEST_KEEP_FORMS`` through ``bootstrap_filings_history_seed`` (was ``None`` = all forms) and ``daily_research_refresh`` (was narrower ``["10-K", "10-Q", "8-K"]``). Cuts S5 writes by ~32% on next first-install.

Codex round 1 pushed back on binary "parse OR skip" — surfaced metadata-only tier covering S-1/S-3/S-4 + 424B (capital actions), PRE 14A / SC TO-T / DEF 13E-3 (M&A signals), NT 10-K (late-filing red flag), CORRESP, Form 5/144 (insider compliance), 25/15/15F (delisting), 11-K. Metadata rows cost ~200 bytes each; cheap insurance for future parsers + ad-hoc LLM queries.

## Test plan

- [x] ``uv run ruff check . && uv run ruff format --check .``
- [x] ``uv run pyright`` (0 errors)
- [x] 71 tests pass.

## Out of scope

PR2 (retroactive cleanup), PR3 (raw-retention infra + SHA-256 hash guard), PR4 (parsers for metadata-only forms) tracked separately. Spec details each.

Closes #1011.