### PR TITLE
fix(#1016 obs 1+2): useAsync stale-while-revalidate

### DIFF
--- a/frontend/src/components/admin/BootstrapPanel.tsx
+++ b/frontend/src/components/admin/BootstrapPanel.tsx
@@ -98,7 +98,11 @@ function formatProgress(stage: BootstrapStageResponse): string {
 }
 
 export function BootstrapPanel() {
-  const state = useAsync(fetchBootstrapStatus, []);
+  // #1016 — preserveOnRefetch keeps the prior payload visible during the
+  // 5s poll tick so the operator's scroll position is preserved and the
+  // table doesn't flicker on every refresh. Skeleton still renders on
+  // the initial load (before the first successful fetch).
+  const state = useAsync(fetchBootstrapStatus, [], { preserveOnRefetch: true });
   const refetch = state.refetch;
 
   // Poll cadence: 5s while running, 60s otherwise. See AdminPage.tsx

--- a/frontend/src/lib/ConfigContext.tsx
+++ b/frontend/src/lib/ConfigContext.tsx
@@ -31,9 +31,10 @@ export function ConfigProvider({ children }: { children: ReactNode }): JSX.Eleme
       data: state.data,
       error: state.error,
       loading: state.loading,
+      isRevalidating: state.isRevalidating,
       refetch: state.refetch,
     }),
-    [state.data, state.error, state.loading, state.refetch],
+    [state.data, state.error, state.loading, state.isRevalidating, state.refetch],
   );
   return <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>;
 }
@@ -69,6 +70,7 @@ export function TestConfigProvider({
     data: value.data ?? null,
     error: value.error ?? null,
     loading: value.loading ?? false,
+    isRevalidating: value.isRevalidating ?? false,
     refetch: value.refetch ?? (() => {}),
   };
   return <ConfigContext.Provider value={merged}>{children}</ConfigContext.Provider>;

--- a/frontend/src/lib/useAsync.test.ts
+++ b/frontend/src/lib/useAsync.test.ts
@@ -36,3 +36,103 @@ describe("useAsync — refetch reference stability", () => {
     expect(result.current.refetch).toBe(first);
   });
 });
+
+describe("useAsync — preserveOnRefetch (#1016)", () => {
+  it("clears data on refetch by default (backward compat)", async () => {
+    let value = 1;
+    const { result } = renderHook(() => useAsync(async () => value, []));
+    // Wait for first resolve.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe(1);
+    expect(result.current.isRevalidating).toBe(false);
+
+    value = 2;
+    await act(async () => {
+      result.current.refetch();
+      // Synchronously after refetch but before resolve, data is cleared.
+    });
+    // After resolve.
+    expect(result.current.data).toBe(2);
+  });
+
+  it("preserves data during refetch when preserveOnRefetch=true", async () => {
+    // Controllable fetcher: each call returns a manually-resolved
+    // promise so the test can observe the mid-flight state where
+    // the new fetch is pending but the old data should still be
+    // visible.
+    let resolveCurrent: ((v: string) => void) | null = null;
+    const calls: number[] = [];
+    const fetcher = () =>
+      new Promise<string>((resolve) => {
+        const callIdx = calls.length;
+        calls.push(callIdx);
+        resolveCurrent = resolve;
+        if (callIdx === 0) {
+          // First call resolves immediately so we have data to
+          // preserve on the second call.
+          Promise.resolve().then(() => resolve("first"));
+        }
+      });
+
+    const { result } = renderHook(() =>
+      useAsync(fetcher, [], { preserveOnRefetch: true }),
+    );
+
+    // Let first call resolve.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe("first");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.isRevalidating).toBe(false);
+
+    // Trigger refetch but don't resolve yet — observe mid-flight.
+    await act(async () => {
+      result.current.refetch();
+      // Yield so the effect runs and the second fetcher call starts.
+      await Promise.resolve();
+    });
+    // Mid-flight: data preserved, isRevalidating flipped on, loading
+    // stays false (so consumer doesn't render skeleton).
+    expect(result.current.data).toBe("first");
+    expect(result.current.isRevalidating).toBe(true);
+    expect(result.current.loading).toBe(false);
+
+    // Now resolve the second fetch.
+    await act(async () => {
+      resolveCurrent?.("second");
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe("second");
+    expect(result.current.isRevalidating).toBe(false);
+  });
+
+  it("clears data on a refetch that errors, even with preserveOnRefetch=true", async () => {
+    let shouldError = false;
+    const fetcher = async () => {
+      if (shouldError) {
+        throw new Error("boom");
+      }
+      return 42;
+    };
+    const { result } = renderHook(() =>
+      useAsync(fetcher, [], { preserveOnRefetch: true }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe(42);
+
+    shouldError = true;
+    await act(async () => {
+      result.current.refetch();
+      await Promise.resolve();
+    });
+    // Error path: data cleared (stale-while-erroring is misleading),
+    // error surfaced.
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/frontend/src/lib/useAsync.test.ts
+++ b/frontend/src/lib/useAsync.test.ts
@@ -135,4 +135,48 @@ describe("useAsync — preserveOnRefetch (#1016)", () => {
     expect(result.current.data).toBeNull();
     expect(result.current.error).toBeInstanceOf(Error);
   });
+
+  it("clears stale error on successful revalidation after a failed one", async () => {
+    // PR1017 review BLOCKING: if a revalidation errors then the next
+    // one succeeds, ``error`` must be cleared. Pre-fix the success
+    // path never reset ``error`` and the preserve branch skipped the
+    // fetch-start ``setError(null)``, so a recovered fetch would
+    // render fresh data alongside a stale error banner.
+    let mode: "ok" | "fail" = "ok";
+    let counter = 0;
+    const fetcher = async () => {
+      counter += 1;
+      if (mode === "fail") {
+        throw new Error("revalidation failed");
+      }
+      return counter;
+    };
+    const { result } = renderHook(() =>
+      useAsync(fetcher, [], { preserveOnRefetch: true }),
+    );
+    // First load — success.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe(1);
+    expect(result.current.error).toBeNull();
+
+    // Second call — fail.
+    mode = "fail";
+    await act(async () => {
+      result.current.refetch();
+      await Promise.resolve();
+    });
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.data).toBeNull();
+
+    // Third call — success again. Error must clear.
+    mode = "ok";
+    await act(async () => {
+      result.current.refetch();
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe(3);
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/frontend/src/lib/useAsync.ts
+++ b/frontend/src/lib/useAsync.ts
@@ -103,6 +103,12 @@ export function useAsync<T>(
       .then((result) => {
         if (cancelled) return;
         setData(result);
+        // Always clear ``error`` on success — under
+        // ``preserveOnRefetch`` we don't reset it at fetch-start, so
+        // a prior failed revalidation leaves ``error`` set; without
+        // this clear, a recovered fetch would render fresh data
+        // alongside a stale error banner. PR1017 review BLOCKING.
+        setError(null);
         setLoading(false);
         setIsRevalidating(false);
         hasLoadedRef.current = true;

--- a/frontend/src/lib/useAsync.ts
+++ b/frontend/src/lib/useAsync.ts
@@ -16,6 +16,27 @@
  *   - `refetch()` re-runs the latest `fn` without changing `deps`.
  *   - Errors are surfaced as the raw `unknown` thrown — callers render a
  *     fixed phrase, never the message text (mirrors ErrorBoundary policy).
+ *
+ * Stale-while-revalidate (#1016 obs 1+2):
+ *
+ *   On a poll-driven refetch (cadence-triggered, not user-triggered), pass
+ *   `{ preserveOnRefetch: true }` to keep the prior `data` visible while
+ *   the new request is in flight. Without this, every poll tick clears
+ *   `data` to `null`, the consumer re-mounts its skeleton (different DOM
+ *   shape than the rendered table), the browser loses scroll position,
+ *   and the operator sees a flicker every 5s.
+ *
+ *   The default behaviour is unchanged (clear-on-refetch) — opt-in only,
+ *   for callers that genuinely poll. Filter-driven refetches (operator
+ *   clicks "filter by X") should NOT preserve stale data, because the
+ *   prior payload is now semantically wrong, not just stale-by-time.
+ *
+ *   Even with `preserveOnRefetch: true`, a refetch that LANDS in error
+ *   still clears `data` — a stale-but-correct payload is preferable to
+ *   blank, but a stale-while-erroring payload is misleading. The
+ *   `loading` flag stays `false` during preserved-data refetches; a
+ *   separate `isRevalidating` flag exposes the in-flight refetch state
+ *   for callers that want to surface a subtle indicator.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -24,13 +45,29 @@ export interface AsyncState<T> {
   data: T | null;
   error: unknown;
   loading: boolean;
+  isRevalidating: boolean;
   refetch: () => void;
 }
 
-export function useAsync<T>(fn: () => Promise<T>, deps: ReadonlyArray<unknown>): AsyncState<T> {
+export interface UseAsyncOptions {
+  /**
+   * Keep `data` visible during refetch (#1016). Defaults to `false` for
+   * backward compat. Set to `true` for poll-driven refetches where the
+   * prior payload is stale-by-time, not stale-by-intent.
+   */
+  preserveOnRefetch?: boolean;
+}
+
+export function useAsync<T>(
+  fn: () => Promise<T>,
+  deps: ReadonlyArray<unknown>,
+  options: UseAsyncOptions = {},
+): AsyncState<T> {
+  const { preserveOnRefetch = false } = options;
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<unknown>(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [isRevalidating, setIsRevalidating] = useState<boolean>(false);
   const [tick, setTick] = useState(0);
 
   // Capture the latest `fn` in a ref so refetch() always runs the freshest
@@ -38,27 +75,50 @@ export function useAsync<T>(fn: () => Promise<T>, deps: ReadonlyArray<unknown>):
   const fnRef = useRef(fn);
   fnRef.current = fn;
 
+  // Track whether we've ever resolved successfully — `preserveOnRefetch`
+  // only kicks in after the first successful load. Pre-load (initial
+  // mount) still shows the skeleton, otherwise the consumer sees an
+  // empty table on first paint instead of a clear loading state.
+  const hasLoadedRef = useRef(false);
+
   useEffect(() => {
     let cancelled = false;
-    // Clear `data` alongside `error` on every (re)fetch start. Without this,
-    // a successful fetch followed by a failing refetch would leave the stale
-    // previous payload visible while `loading=true` and `error=null`, which
-    // gives callers no way to distinguish "first load in progress" from
-    // "previous data is stale and the retry hasn't resolved yet".
-    setLoading(true);
-    setError(null);
-    setData(null);
+    const isRefetch = tick > 0;
+    const preserve = preserveOnRefetch && isRefetch && hasLoadedRef.current;
+
+    if (preserve) {
+      // Stale-while-revalidate: keep `data` visible, surface revalidation
+      // via the dedicated flag instead. `loading` stays false so the
+      // consumer's `loading ? <Skeleton/> : <Body/>` branch keeps showing
+      // the body — no flicker, no scroll-jump.
+      setIsRevalidating(true);
+    } else {
+      setLoading(true);
+      setError(null);
+      setData(null);
+    }
+
     fnRef
       .current()
       .then((result) => {
         if (cancelled) return;
         setData(result);
         setLoading(false);
+        setIsRevalidating(false);
+        hasLoadedRef.current = true;
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         setError(err);
         setLoading(false);
+        setIsRevalidating(false);
+        if (preserve) {
+          // Stale-while-erroring is misleading; clear data on the failed
+          // refetch even when preservation was requested. Operator sees
+          // the error rather than a stale payload alongside an error
+          // banner.
+          setData(null);
+        }
       });
     return () => {
       cancelled = true;
@@ -70,5 +130,5 @@ export function useAsync<T>(fn: () => Promise<T>, deps: ReadonlyArray<unknown>):
     setTick((t) => t + 1);
   }, []);
 
-  return { data, error, loading, refetch };
+  return { data, error, loading, isRevalidating, refetch };
 }


### PR DESCRIPTION
## Summary

Fix #1016 observations 1 + 2 (scroll-jump + flicker on poll tick). Adds opt-in ``preserveOnRefetch`` to ``useAsync`` so cadence-driven refetches keep prior ``data`` visible while revalidating. ``BootstrapPanel`` opts in; other ~40 call sites unchanged (default = clear-on-refetch preserved).

Stale-while-erroring path explicitly clears data — a stale-but-correct payload preferable to blank, but stale-while-erroring is misleading.

## Test plan

- [x] ``pnpm --dir frontend typecheck`` (clean)
- [x] ``pnpm --dir frontend exec vitest run src/lib/useAsync.test.ts`` (4 tests)
- [x] ``pnpm --dir frontend exec vitest run src/components/admin/`` (49 tests)
- [x] Dark-class hygiene gate clean.

Part of #1016. Other observations (live-progress motion, error-history view, full admin-page redesign) tracked in #1016 + #1005; spec for redesign in flight.