### PR TITLE
feat(#1022): C1.a + C2 bulk archive ingesters

### DIFF
--- a/app/services/sec_companyfacts_ingest.py
+++ b/app/services/sec_companyfacts_ingest.py
@@ -1,0 +1,235 @@
+"""C2 — bulk companyfacts.zip ingester (#1022).
+
+Reads the cached ``companyfacts.zip`` archive (downloaded by Phase A3,
+#1021) and writes XBRL facts into ``financial_facts_raw`` for every
+CIK-mapped instrument in the universe.
+
+Replaces the per-CIK ``/api/xbrl/companyfacts/CIK<10>.json`` HTTP walk
+that S16 (`fundamentals_sync`) issues at 7 req/s on a fresh install.
+The archive payload shape is identical to the per-CIK API response,
+so the existing parser chain is reused unchanged:
+
+  per-CIK JSON
+    -> _extract_facts_from_section(gaap_section, taxonomy="us-gaap")
+    -> _extract_facts_from_section(dei_section, taxonomy="dei")
+    -> upsert_facts_for_instrument(conn, instrument_id, facts, ingestion_run_id)
+
+Spec: docs/superpowers/specs/2026-05-08-bulk-datasets-first-bootstrap.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from app.providers.fundamentals import XbrlFact
+from app.providers.implementations.sec_fundamentals import _extract_facts_from_section
+from app.services.fundamentals import (
+    finish_ingestion_run,
+    start_ingestion_run,
+    upsert_facts_for_instrument,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_CIK_FILENAME_RE = re.compile(r"^CIK(\d{10})\.json$")
+
+
+class _SkipEntry(Exception):
+    """Sentinel raised inside a per-entry savepoint to roll it back."""
+
+
+@dataclass
+class CompanyFactsIngestResult:
+    """Per-archive ingest outcome."""
+
+    archive_entries_seen: int
+    instruments_matched: int
+    facts_upserted: int
+    facts_skipped: int
+    archive_entries_skipped_universe_gap: int = 0
+    parse_errors: int = 0
+    ingestion_run_id: int | None = None
+
+
+def extract_facts_from_companyfacts_payload(
+    payload: dict[str, Any],
+) -> list[XbrlFact]:
+    """Public wrapper around the existing per-section extractor.
+
+    Routes the ``us-gaap`` + ``dei`` sections through
+    ``_extract_facts_from_section`` (the canonical extractor used by
+    the per-CIK API path) and returns one flat ``list[XbrlFact]``.
+
+    Wrapping the private helper here means C2 reuses the per-CIK
+    parser unchanged — same field semantics, same Decimal handling,
+    same NaN/Infinity guards. The wrapper exists because the existing
+    public ``extract_facts(symbol, cik)`` method on the provider
+    self-fetches over HTTP; for bulk ingest we have the payload
+    already.
+    """
+    raw_facts: dict[str, Any] = payload.get("facts", {})
+    gaap_section = raw_facts.get("us-gaap", {})
+    dei_section = raw_facts.get("dei", {})
+    facts: list[XbrlFact] = []
+    if gaap_section:
+        facts.extend(_extract_facts_from_section(gaap_section, taxonomy="us-gaap"))
+    if dei_section:
+        facts.extend(_extract_facts_from_section(dei_section, taxonomy="dei"))
+    return facts
+
+
+def _cik_from_filename(name: str) -> str | None:
+    """Parse the 10-digit CIK out of a ``CIK<10>.json`` archive entry name."""
+    m = _CIK_FILENAME_RE.match(name)
+    return m.group(1) if m else None
+
+
+def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, int]:
+    """Return ``{cik_padded: instrument_id}`` for every CIK-mapped instrument."""
+    out: dict[str, int] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, identifier_value
+            FROM external_identifiers
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+            """,
+        )
+        for row in cur.fetchall():
+            instrument_id, identifier = row
+            cik = str(identifier).zfill(10)
+            out[cik] = int(instrument_id)
+    return out
+
+
+def ingest_companyfacts_archive(
+    *,
+    conn: psycopg.Connection[Any],
+    archive_path: Path,
+    cik_to_instrument: dict[str, int] | None = None,
+) -> CompanyFactsIngestResult:
+    """Walk every ``CIK<10>.json`` entry in ``archive_path`` and upsert
+    XBRL facts into ``financial_facts_raw`` for matching universe instruments.
+
+    Returns a summary suitable for stage telemetry. Per-entry parse
+    errors are counted, not raised. The caller (orchestrator) commits
+    the surrounding transaction so all facts ingested in this archive
+    are atomically visible.
+    """
+    if cik_to_instrument is None:
+        cik_to_instrument = _load_cik_to_instrument(conn)
+
+    # Commit the start row IMMEDIATELY so a later fatal error +
+    # rollback does not erase it. Without this, the terminal-status
+    # update in the except branch would target a row that no longer
+    # exists (Codex pre-push round 1, finding 2). The provenance
+    # contract on data_ingestion_runs requires every run to land —
+    # success, partial, or failed — so callers can audit retries.
+    run_id = start_ingestion_run(
+        conn,
+        source="sec_companyfacts_bulk",
+        endpoint=str(archive_path.name),
+        instrument_count=len(cik_to_instrument),
+    )
+    conn.commit()
+
+    result = CompanyFactsIngestResult(
+        archive_entries_seen=0,
+        instruments_matched=0,
+        facts_upserted=0,
+        facts_skipped=0,
+        ingestion_run_id=run_id,
+    )
+
+    try:
+        with zipfile.ZipFile(archive_path) as zf:
+            for entry_name in zf.namelist():
+                cik = _cik_from_filename(entry_name)
+                if cik is None:
+                    continue
+                result.archive_entries_seen += 1
+                instrument_id = cik_to_instrument.get(cik)
+                if instrument_id is None:
+                    result.archive_entries_skipped_universe_gap += 1
+                    continue
+                result.instruments_matched += 1
+
+                # Per-CIK savepoint: a parse error or DB-write failure
+                # for one CIK must not abort the surrounding
+                # transaction. Without this, a single corrupted entry
+                # poisons the rest of the archive (Codex pre-push
+                # round 1, finding 3).
+                try:
+                    with conn.transaction():
+                        try:
+                            with zf.open(entry_name) as fh:
+                                payload: dict[str, Any] = json.load(fh)
+                        except (json.JSONDecodeError, KeyError) as exc:
+                            logger.debug(
+                                "companyfacts ingest: bad payload for %s: %s",
+                                entry_name,
+                                exc,
+                            )
+                            result.parse_errors += 1
+                            raise _SkipEntry from exc
+
+                        facts = extract_facts_from_companyfacts_payload(payload)
+                        if not facts:
+                            raise _SkipEntry  # roll back savepoint cleanly
+
+                        upserted, skipped = upsert_facts_for_instrument(
+                            conn,
+                            instrument_id=instrument_id,
+                            facts=facts,
+                            ingestion_run_id=run_id,
+                        )
+                        result.facts_upserted += upserted
+                        result.facts_skipped += skipped
+                except _SkipEntry:
+                    # Savepoint already rolled back; advance to next entry.
+                    continue
+                except Exception as exc:  # noqa: BLE001
+                    # Per-CIK DB error or unexpected fault — savepoint
+                    # rolled back; record + continue. Do NOT promote to
+                    # archive-fatal: one bad CIK must not kill the run.
+                    logger.warning(
+                        "companyfacts ingest: per-CIK failure for %s: %s",
+                        entry_name,
+                        exc,
+                    )
+                    result.parse_errors += 1
+    except Exception as exc:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        finish_ingestion_run(
+            conn,
+            run_id=run_id,
+            status="failed",
+            rows_upserted=result.facts_upserted,
+            rows_skipped=result.facts_skipped,
+            error=str(exc),
+        )
+        conn.commit()
+        raise
+
+    terminal_status = "partial" if result.parse_errors else "success"
+    finish_ingestion_run(
+        conn,
+        run_id=run_id,
+        status=terminal_status,
+        rows_upserted=result.facts_upserted,
+        rows_skipped=result.facts_skipped,
+    )
+    conn.commit()
+    return result

--- a/app/services/sec_submissions_ingest.py
+++ b/app/services/sec_submissions_ingest.py
@@ -1,0 +1,192 @@
+"""C1.a — bulk submissions.zip ingester (#1022).
+
+Reads the cached ``submissions.zip`` archive (downloaded by Phase A3,
+#1021) and seeds two tables for every CIK-mapped instrument in the
+universe:
+
+1. ``filing_events`` — the recent block (`filings.recent`) becomes
+   ``provider='sec'`` rows keyed on the SEC accession number.
+2. ``instrument_sec_profile`` — the JSON top-level fields (sic,
+   ownerOrg, addresses, exchanges, etc) flow through the existing
+   ``parse_entity_profile()`` + ``upsert_entity_profile()`` helpers.
+
+This replaces the per-CIK HTTP walk that S5 (`bootstrap_filings_history_seed`)
+issues at 7 req/s on a fresh install. Per-CIK ``filings.files[]``
+secondary-page coverage is the responsibility of C1.b, a separate
+stage.
+
+Spec: docs/superpowers/specs/2026-05-08-bulk-datasets-first-bootstrap.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from app.providers.implementations.sec_edgar import _normalise_submissions_block
+from app.services.filings import _upsert_filing
+from app.services.sec_entity_profile import parse_entity_profile, upsert_entity_profile
+
+logger = logging.getLogger(__name__)
+
+
+_CIK_FILENAME_RE = re.compile(r"^CIK(\d{10})\.json$")
+
+
+class _SkipEntry(Exception):
+    """Sentinel raised inside a per-entry savepoint to roll it back."""
+
+
+@dataclass
+class SubmissionsIngestResult:
+    """Per-archive ingest outcome."""
+
+    archive_entries_seen: int
+    instruments_matched: int
+    filings_upserted: int
+    profiles_upserted: int
+    archive_entries_skipped: int = 0
+    parse_errors: int = 0
+
+
+def _cik_from_filename(name: str) -> str | None:
+    """Parse the 10-digit CIK out of a ``CIK<10>.json`` archive entry name."""
+    m = _CIK_FILENAME_RE.match(name)
+    return m.group(1) if m else None
+
+
+def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, int]:
+    """Return ``{cik_padded: instrument_id}`` for every CIK-mapped instrument.
+
+    Reads ``external_identifiers`` SEC CIK rows (the table B4
+    ``cik_refresh`` populates). The CIK column is stored zero-padded
+    to 10 characters to match SEC's ``CIK<10>.json`` filename format.
+    """
+    out: dict[str, int] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, identifier_value
+            FROM external_identifiers
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+            """,
+        )
+        for row in cur.fetchall():
+            instrument_id, identifier = row
+            cik = str(identifier).zfill(10)
+            out[cik] = int(instrument_id)
+    return out
+
+
+def ingest_submissions_archive(
+    *,
+    conn: psycopg.Connection[Any],
+    archive_path: Path,
+    cik_to_instrument: dict[str, int] | None = None,
+) -> SubmissionsIngestResult:
+    """Walk every ``CIK<10>.json`` entry in ``archive_path`` and upsert
+    matching universe instruments into ``filing_events`` + ``instrument_sec_profile``.
+
+    Returns a summary suitable for stage telemetry. Per-entry parse
+    errors are counted, not raised — one bad CIK file in a 5-million-row
+    archive must not block the rest. The bulk archive is treated as
+    a soft source: corrupted entries are logged at DEBUG and counted.
+    """
+    if cik_to_instrument is None:
+        cik_to_instrument = _load_cik_to_instrument(conn)
+
+    result = SubmissionsIngestResult(
+        archive_entries_seen=0,
+        instruments_matched=0,
+        filings_upserted=0,
+        profiles_upserted=0,
+    )
+
+    with zipfile.ZipFile(archive_path) as zf:
+        for entry_name in zf.namelist():
+            cik = _cik_from_filename(entry_name)
+            if cik is None:
+                # Sub-CIK secondary pages are not in this archive; the
+                # only valid entries are CIK<10>.json. Anything else is
+                # noise we silently skip.
+                continue
+            result.archive_entries_seen += 1
+            instrument_id = cik_to_instrument.get(cik)
+            if instrument_id is None:
+                # Universe gap — most CIKs in the archive are not in
+                # our universe. This is expected, not an error.
+                result.archive_entries_skipped += 1
+                continue
+
+            result.instruments_matched += 1
+
+            # Per-CIK savepoint: a parse error or DB-write failure for
+            # one CIK must not abort the surrounding transaction or
+            # block the rest of the archive (Codex pre-push round 1,
+            # finding 3).
+            try:
+                with conn.transaction():
+                    try:
+                        with zf.open(entry_name) as fh:
+                            payload: dict[str, Any] = json.load(fh)
+                    except (json.JSONDecodeError, KeyError) as exc:
+                        logger.debug("submissions ingest: bad payload for %s: %s", entry_name, exc)
+                        result.parse_errors += 1
+                        raise _SkipEntry from exc
+
+                    _ingest_one(
+                        conn,
+                        instrument_id=instrument_id,
+                        cik_padded=cik,
+                        payload=payload,
+                        result=result,
+                    )
+            except _SkipEntry:
+                continue
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "submissions ingest: per-CIK failure for %s: %s",
+                    entry_name,
+                    exc,
+                )
+                result.parse_errors += 1
+    return result
+
+
+def _ingest_one(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    cik_padded: str,
+    payload: dict[str, Any],
+    result: SubmissionsIngestResult,
+) -> None:
+    """Upsert one CIK's submissions payload — filings + profile."""
+    profile = parse_entity_profile(payload, instrument_id=instrument_id, cik=cik_padded)
+    upsert_entity_profile(conn, profile)
+    result.profiles_upserted += 1
+
+    filings_block = payload.get("filings")
+    if not isinstance(filings_block, dict):
+        return
+    recent = filings_block.get("recent")
+    if not isinstance(recent, dict):
+        return
+
+    # Reuse the existing per-CIK normaliser. It returns a list of
+    # ``FilingSearchResult`` ordered oldest-first.
+    filings = _normalise_submissions_block(
+        recent,
+        cik_padded=cik_padded,
+        symbol=str(instrument_id),
+    )
+    for filing in filings:
+        _upsert_filing(conn, str(instrument_id), "sec", filing)
+        result.filings_upserted += 1

--- a/app/services/sec_submissions_ingest.py
+++ b/app/services/sec_submissions_ingest.py
@@ -62,26 +62,31 @@ def _cik_from_filename(name: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, int]:
-    """Return ``{cik_padded: instrument_id}`` for every CIK-mapped instrument.
+def _load_cik_to_instrument(
+    conn: psycopg.Connection[Any],
+) -> dict[str, tuple[int, str]]:
+    """Return ``{cik_padded: (instrument_id, symbol)}`` for every CIK-mapped
+    instrument.
 
-    Reads ``external_identifiers`` SEC CIK rows (the table B4
-    ``cik_refresh`` populates). The CIK column is stored zero-padded
-    to 10 characters to match SEC's ``CIK<10>.json`` filename format.
+    Reads ``external_identifiers`` SEC CIK rows joined to ``instruments``
+    so the writer below can pass the canonical ticker symbol — not a
+    stringified instrument_id — to ``_normalise_submissions_block`` and
+    ``_upsert_filing`` (Codex review BLOCKING for PR #1030).
     """
-    out: dict[str, int] = {}
+    out: dict[str, tuple[int, str]] = {}
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT instrument_id, identifier_value
-            FROM external_identifiers
-            WHERE provider = 'sec' AND identifier_type = 'cik'
+            SELECT ei.instrument_id, ei.identifier_value, i.symbol
+            FROM external_identifiers ei
+            JOIN instruments i ON i.instrument_id = ei.instrument_id
+            WHERE ei.provider = 'sec' AND ei.identifier_type = 'cik'
             """,
         )
         for row in cur.fetchall():
-            instrument_id, identifier = row
+            instrument_id, identifier, symbol = row
             cik = str(identifier).zfill(10)
-            out[cik] = int(instrument_id)
+            out[cik] = (int(instrument_id), str(symbol or ""))
     return out
 
 
@@ -89,7 +94,7 @@ def ingest_submissions_archive(
     *,
     conn: psycopg.Connection[Any],
     archive_path: Path,
-    cik_to_instrument: dict[str, int] | None = None,
+    cik_to_instrument: dict[str, tuple[int, str]] | None = None,
 ) -> SubmissionsIngestResult:
     """Walk every ``CIK<10>.json`` entry in ``archive_path`` and upsert
     matching universe instruments into ``filing_events`` + ``instrument_sec_profile``.
@@ -118,12 +123,13 @@ def ingest_submissions_archive(
                 # noise we silently skip.
                 continue
             result.archive_entries_seen += 1
-            instrument_id = cik_to_instrument.get(cik)
-            if instrument_id is None:
+            entry = cik_to_instrument.get(cik)
+            if entry is None:
                 # Universe gap — most CIKs in the archive are not in
                 # our universe. This is expected, not an error.
                 result.archive_entries_skipped += 1
                 continue
+            instrument_id, symbol = entry
 
             result.instruments_matched += 1
 
@@ -145,6 +151,7 @@ def ingest_submissions_archive(
                         conn,
                         instrument_id=instrument_id,
                         cik_padded=cik,
+                        symbol=symbol,
                         payload=payload,
                         result=result,
                     )
@@ -165,10 +172,17 @@ def _ingest_one(
     *,
     instrument_id: int,
     cik_padded: str,
+    symbol: str,
     payload: dict[str, Any],
     result: SubmissionsIngestResult,
 ) -> None:
-    """Upsert one CIK's submissions payload — filings + profile."""
+    """Upsert one CIK's submissions payload — filings + profile.
+
+    ``symbol`` is the ticker for ``instrument_id``, threaded through
+    so ``_normalise_submissions_block`` and ``_upsert_filing`` write
+    the canonical symbol on every ``filing_events`` row instead of a
+    stringified instrument id (Codex review BLOCKING for PR #1030).
+    """
     profile = parse_entity_profile(payload, instrument_id=instrument_id, cik=cik_padded)
     upsert_entity_profile(conn, profile)
     result.profiles_upserted += 1
@@ -181,11 +195,14 @@ def _ingest_one(
         return
 
     # Reuse the existing per-CIK normaliser. It returns a list of
-    # ``FilingSearchResult`` ordered oldest-first.
+    # ``FilingSearchResult`` ordered oldest-first. The ``symbol``
+    # parameter is the ticker (e.g. "AAPL") — passing the
+    # stringified instrument_id here would corrupt every
+    # ``filing_events`` row. Codex review BLOCKING for PR #1030.
     filings = _normalise_submissions_block(
         recent,
         cik_padded=cik_padded,
-        symbol=str(instrument_id),
+        symbol=symbol or cik_padded,
     )
     for filing in filings:
         _upsert_filing(conn, str(instrument_id), "sec", filing)

--- a/tests/test_sec_companyfacts_ingest.py
+++ b/tests/test_sec_companyfacts_ingest.py
@@ -1,0 +1,213 @@
+"""Tests for the bulk companyfacts.zip ingester (#1022)."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from app.services.sec_companyfacts_ingest import (
+    CompanyFactsIngestResult,
+    extract_facts_from_companyfacts_payload,
+    ingest_companyfacts_archive,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+
+# ---------------------------------------------------------------------------
+# Payload fixtures
+# ---------------------------------------------------------------------------
+
+
+def _aapl_companyfacts_payload() -> dict:
+    return {
+        "cik": 320193,
+        "entityName": "Apple Inc.",
+        "facts": {
+            "us-gaap": {
+                "Revenues": {
+                    "label": "Revenues",
+                    "description": "Total revenue.",
+                    "units": {
+                        "USD": [
+                            {
+                                "start": "2024-10-01",
+                                "end": "2025-09-30",
+                                "val": 391_000_000_000,
+                                "accn": "0000320193-25-000001",
+                                "fy": 2025,
+                                "fp": "FY",
+                                "form": "10-K",
+                                "filed": "2025-11-01",
+                                "frame": "CY2025",
+                            },
+                        ]
+                    },
+                },
+            },
+            "dei": {
+                "EntityCommonStockSharesOutstanding": {
+                    "label": "Shares outstanding",
+                    "units": {
+                        "shares": [
+                            {
+                                "end": "2025-09-30",
+                                "val": 15_000_000_000,
+                                "accn": "0000320193-25-000001",
+                                "fy": 2025,
+                                "fp": "FY",
+                                "form": "10-K",
+                                "filed": "2025-11-01",
+                            },
+                        ]
+                    },
+                },
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pure-payload extractor
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFactsFromCompanyFactsPayload:
+    def test_extracts_both_taxonomies(self) -> None:
+        payload = _aapl_companyfacts_payload()
+        facts = extract_facts_from_companyfacts_payload(payload)
+        assert len(facts) == 2
+        taxonomies = {f.taxonomy for f in facts}
+        assert taxonomies == {"us-gaap", "dei"}
+        assert any(f.concept == "Revenues" for f in facts)
+        assert any(f.concept == "EntityCommonStockSharesOutstanding" for f in facts)
+
+    def test_empty_payload_returns_empty_list(self) -> None:
+        assert extract_facts_from_companyfacts_payload({}) == []
+        assert extract_facts_from_companyfacts_payload({"facts": {}}) == []
+
+
+# ---------------------------------------------------------------------------
+# DB integration
+# ---------------------------------------------------------------------------
+
+
+_NEXT_IID: list[int] = [11000]
+
+
+def _seed_universe(
+    conn: psycopg.Connection[tuple],
+    *,
+    symbol: str,
+    cik_padded: str,
+) -> int:
+    _NEXT_IID[0] += 1
+    iid = _NEXT_IID[0]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+        cur.execute(
+            "INSERT INTO external_identifiers "
+            "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (%s, 'sec', 'cik', %s, TRUE)",
+            (iid, cik_padded),
+        )
+    conn.commit()
+    return iid
+
+
+def _build_archive(entries: dict[str, dict]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for cik, payload in entries.items():
+            zf.writestr(f"CIK{cik}.json", json.dumps(payload))
+    return buf.getvalue()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestIngestCompanyFactsArchive:
+    def test_universe_match_writes_facts(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        iid_aapl = _seed_universe(ebull_test_conn, symbol="AAPL", cik_padded="0000320193")
+
+        archive_bytes = _build_archive(
+            {
+                "0000320193": _aapl_companyfacts_payload(),
+                "9999999999": {  # out-of-universe
+                    "cik": 9999999999,
+                    "entityName": "Out of Universe",
+                    "facts": {"us-gaap": {}, "dei": {}},
+                },
+            }
+        )
+        archive_path = tmp_path / "companyfacts.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_companyfacts_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+        )
+        ebull_test_conn.commit()
+
+        assert isinstance(result, CompanyFactsIngestResult)
+        assert result.archive_entries_seen == 2
+        assert result.instruments_matched == 1
+        assert result.archive_entries_skipped_universe_gap == 1
+        assert result.parse_errors == 0
+        assert result.facts_upserted >= 2  # at least Revenues + Shares.
+        assert result.ingestion_run_id is not None
+
+        # Verify rows landed in financial_facts_raw.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM financial_facts_raw WHERE instrument_id = %s",
+                (iid_aapl,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] >= 2
+
+            # Verify the ingestion run row is marked ok.
+            cur.execute(
+                "SELECT status, rows_upserted FROM data_ingestion_runs WHERE ingestion_run_id = %s",
+                (result.ingestion_run_id,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "success"
+            assert row[1] == result.facts_upserted
+
+    def test_corrupted_entry_increments_parse_errors_not_raise(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        _seed_universe(ebull_test_conn, symbol="AAPL", cik_padded="0000320193")
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("CIK0000320193.json", "not valid json {")
+        archive_path = tmp_path / "companyfacts.zip"
+        archive_path.write_bytes(buf.getvalue())
+
+        result = ingest_companyfacts_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+        )
+        ebull_test_conn.commit()
+
+        assert result.parse_errors == 1
+        assert result.facts_upserted == 0

--- a/tests/test_sec_submissions_ingest.py
+++ b/tests/test_sec_submissions_ingest.py
@@ -1,0 +1,223 @@
+"""Tests for the bulk submissions.zip ingester (#1022)."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from app.services.sec_submissions_ingest import (
+    SubmissionsIngestResult,
+    _cik_from_filename,
+    ingest_submissions_archive,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+
+# ---------------------------------------------------------------------------
+# CIK filename parser — unit
+# ---------------------------------------------------------------------------
+
+
+class TestCikFromFilename:
+    def test_valid_cik_filename(self) -> None:
+        assert _cik_from_filename("CIK0000320193.json") == "0000320193"
+
+    def test_unpadded_cik_rejected(self) -> None:
+        assert _cik_from_filename("CIK320193.json") is None
+
+    def test_non_cik_filename_rejected(self) -> None:
+        assert _cik_from_filename("README.txt") is None
+        assert _cik_from_filename("CIK0000320193-submissions-001.json") is None
+
+
+# ---------------------------------------------------------------------------
+# Archive fixture builder
+# ---------------------------------------------------------------------------
+
+
+def _build_archive(entries: dict[str, dict]) -> bytes:
+    """Build an in-memory submissions.zip with the given CIK->payload map."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for cik, payload in entries.items():
+            zf.writestr(f"CIK{cik}.json", json.dumps(payload))
+    return buf.getvalue()
+
+
+def _aapl_payload() -> dict:
+    return {
+        "cik": "320193",
+        "name": "Apple Inc.",
+        "sic": "3571",
+        "sicDescription": "Electronic Computers",
+        "exchanges": ["Nasdaq"],
+        "category": "Large accelerated filer",
+        "fiscalYearEnd": "0930",
+        "stateOfIncorporation": "CA",
+        "stateOfIncorporationDescription": "California",
+        "filings": {
+            "recent": {
+                "accessionNumber": ["0000320193-25-000001", "0000320193-25-000002"],
+                "filingDate": ["2025-11-01", "2025-08-01"],
+                "form": ["10-K", "10-Q"],
+                "primaryDocument": ["aapl-10-k.htm", "aapl-10-q.htm"],
+                "reportDate": ["2025-09-30", "2025-06-30"],
+            },
+            "files": [],
+        },
+    }
+
+
+def _msft_payload() -> dict:
+    return {
+        "cik": "789019",
+        "name": "Microsoft Corp",
+        "sic": "7372",
+        "sicDescription": "Prepackaged Software",
+        "exchanges": ["Nasdaq"],
+        "category": "Large accelerated filer",
+        "filings": {
+            "recent": {
+                "accessionNumber": ["0000789019-25-000010"],
+                "filingDate": ["2025-07-30"],
+                "form": ["10-K"],
+                "primaryDocument": ["msft-10-k.htm"],
+                "reportDate": ["2025-06-30"],
+            },
+            "files": [],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# DB integration
+# ---------------------------------------------------------------------------
+
+
+_NEXT_IID: list[int] = [10000]
+
+
+def _seed_universe(
+    conn: psycopg.Connection[tuple],
+    *,
+    symbol: str,
+    cik_padded: str,
+) -> int:
+    _NEXT_IID[0] += 1
+    iid = _NEXT_IID[0]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+        cur.execute(
+            "INSERT INTO external_identifiers "
+            "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (%s, 'sec', 'cik', %s, TRUE)",
+            (iid, cik_padded),
+        )
+    conn.commit()
+    return iid
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestIngestSubmissionsArchive:
+    def test_universe_match_writes_filings_and_profile(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # Seed two universe instruments + one out-of-universe CIK.
+        iid_aapl = _seed_universe(ebull_test_conn, symbol="AAPL", cik_padded="0000320193")
+        iid_msft = _seed_universe(ebull_test_conn, symbol="MSFT", cik_padded="0000789019")
+
+        archive_bytes = _build_archive(
+            {
+                "0000320193": _aapl_payload(),
+                "0000789019": _msft_payload(),
+                "9999999999": {
+                    "cik": "9999999999",
+                    "name": "Out of Universe",
+                    "filings": {"recent": {}, "files": []},
+                },
+            }
+        )
+        archive_path = tmp_path / "submissions.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_submissions_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+        )
+        ebull_test_conn.commit()
+
+        assert isinstance(result, SubmissionsIngestResult)
+        assert result.archive_entries_seen == 3
+        assert result.instruments_matched == 2
+        assert result.archive_entries_skipped == 1  # the out-of-universe CIK
+        assert result.parse_errors == 0
+        # 2 AAPL filings + 1 MSFT filing = 3 upserted.
+        assert result.filings_upserted == 3
+        assert result.profiles_upserted == 2
+
+        # Verify the rows actually landed.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM filing_events WHERE instrument_id = %s AND provider = 'sec'",
+                (iid_aapl,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 2
+
+            cur.execute(
+                "SELECT sic, sic_description FROM instrument_sec_profile WHERE instrument_id = %s",
+                (iid_aapl,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "3571"
+            assert row[1] == "Electronic Computers"
+
+            # MSFT also landed.
+            cur.execute(
+                "SELECT COUNT(*) FROM filing_events WHERE instrument_id = %s AND provider = 'sec'",
+                (iid_msft,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 1
+
+    def test_corrupted_entry_increments_parse_errors_not_raise(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        iid = _seed_universe(ebull_test_conn, symbol="AAPL", cik_padded="0000320193")
+        del iid
+
+        # One bad JSON entry plus one good one.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("CIK0000320193.json", "not valid json {")
+        archive_path = tmp_path / "submissions.zip"
+        archive_path.write_bytes(buf.getvalue())
+
+        result = ingest_submissions_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+        )
+        ebull_test_conn.commit()
+
+        assert result.parse_errors == 1
+        assert result.filings_upserted == 0

--- a/tests/test_sec_submissions_ingest.py
+++ b/tests/test_sec_submissions_ingest.py
@@ -189,6 +189,18 @@ class TestIngestSubmissionsArchive:
             assert row[0] == "3571"
             assert row[1] == "Electronic Computers"
 
+            # Codex review BLOCKING for PR #1030: ``raw_payload_json``
+            # must carry the canonical ticker symbol (e.g. "AAPL"),
+            # NOT a stringified instrument_id.
+            cur.execute(
+                "SELECT raw_payload_json->>'symbol' FROM filing_events "
+                "WHERE instrument_id = %s ORDER BY filing_date DESC LIMIT 1",
+                (iid_aapl,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "AAPL", f"expected ticker AAPL, got {row[0]!r}"
+
             # MSFT also landed.
             cur.execute(
                 "SELECT COUNT(*) FROM filing_events WHERE instrument_id = %s AND provider = 'sec'",


### PR DESCRIPTION
## Summary

- New `app/services/sec_submissions_ingest.py` (C1.a) — reads cached `submissions.zip` → `filing_events` recent block + `instrument_sec_profile`.
- New `app/services/sec_companyfacts_ingest.py` (C2) — reads cached `companyfacts.zip` → `financial_facts_raw` via existing `upsert_facts_for_instrument`. Public wrapper `extract_facts_from_companyfacts_payload` reuses the per-section extractor unchanged.
- Per-CIK savepoints so a malformed entry doesn't poison the rest of the archive.
- `data_ingestion_runs` start row committed immediately so fatal rollback can't erase audit trail.

## Test plan

- [x] 9 unit + integration tests cover universe-match, universe-gap, corrupted-entry, taxonomy split.
- [x] `uv run ruff check` + `uv run ruff format --check` clean.
- [x] `uv run pyright` clean.
- [x] `uv run pytest tests/test_sec_submissions_ingest.py tests/test_sec_companyfacts_ingest.py` 9/9 pass.
- [x] Codex pre-push review APPROVE (2 rounds).

Stacks on top of #1029 (bulk download).

Closes #1022. Refs #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)