### PR TITLE
feat(#1023): C3 bulk 13F dataset ingester

### DIFF
--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -265,41 +265,46 @@ def ingest_13f_dataset_archive(
             voting_authority = _map_voting_authority(row)
             exposure_kind = _map_putcall(row.get("PUTCALL"))
 
+            accession_no_dashes = accession.replace("-", "")
+            source_url = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession_no_dashes}/"
+            # Per-row savepoint: a CHECK-constraint violation on one
+            # malformed dataset row would otherwise put psycopg into
+            # ``InFailedSqlTransaction`` for every subsequent
+            # ``_resolve_cusip`` / ``record_institution_observation``
+            # call. Wrapping each write in ``conn.transaction()``
+            # rolls back the bad row cleanly so the loop can keep
+            # processing. Codex review BLOCKING for PR #1031.
             try:
-                accession_no_dashes = accession.replace("-", "")
-                source_url = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession_no_dashes}/"
-                record_institution_observation(
-                    conn,
-                    instrument_id=instrument_id,
-                    filer_cik=filer_cik,
-                    filer_name=filer_name,
-                    # Spec maps 13F filers to ``filer_type='INV'``
-                    # (investment manager) by default. The schema
-                    # CHECK accepts ETF/INV/INS/BD/OTHER. INV is the
-                    # right default for typical 13F-HR filers.
-                    filer_type="INV",
-                    ownership_nature="economic",
-                    source="13f",
-                    source_document_id=accession,
-                    source_accession=accession,
-                    source_field=None,
-                    source_url=source_url,
-                    filed_at=filed_at,
-                    period_start=None,
-                    period_end=period_end,
-                    ingest_run_id=ingest_run_id,
-                    shares=shares,
-                    market_value_usd=market_value_usd,
-                    voting_authority=voting_authority,
-                    exposure_kind=exposure_kind,
-                )
+                with conn.transaction():
+                    record_institution_observation(
+                        conn,
+                        instrument_id=instrument_id,
+                        filer_cik=filer_cik,
+                        filer_name=filer_name,
+                        # Spec maps 13F filers to ``filer_type='INV'``
+                        # (investment manager) by default. The schema
+                        # CHECK accepts ETF/INV/INS/BD/OTHER. INV is
+                        # the right default for typical 13F-HR filers.
+                        filer_type="INV",
+                        ownership_nature="economic",
+                        source="13f",
+                        source_document_id=accession,
+                        source_accession=accession,
+                        source_field=None,
+                        source_url=source_url,
+                        filed_at=filed_at,
+                        period_start=None,
+                        period_end=period_end,
+                        ingest_run_id=ingest_run_id,
+                        shares=shares,
+                        market_value_usd=market_value_usd,
+                        voting_authority=voting_authority,
+                        exposure_kind=exposure_kind,
+                    )
                 result.rows_written += 1
             except Exception as exc:  # noqa: BLE001
-                # Record-level write failure (e.g. CHECK constraint
-                # violation on a malformed dataset row) — count and
-                # continue. The caller is responsible for opening a
-                # transaction so partial writes are atomic per
-                # archive batch.
+                # Record-level write failure rolled back via the
+                # savepoint; loop continues with a clean transaction.
                 logger.debug(
                     "13F ingest: record_institution_observation failed for %s/%s: %s",
                     accession,

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -1,0 +1,310 @@
+"""C3 — bulk Form 13F Data Sets ingester (#1023).
+
+Reads cached Form 13F Data Sets ZIPs (downloaded by Phase A3, #1021)
+and writes ``ownership_institutions_observations`` rows for every
+holding whose CUSIP resolves to a universe instrument.
+
+Each ZIP contains TSVs:
+
+  - ``SUBMISSION.tsv`` — one row per filing
+    (CIK, accession, filing date, period of report).
+  - ``COVERPAGE.tsv`` — one row per filing
+    (filer name, total holdings value, etc).
+  - ``INFOTABLE.tsv`` — one row per holding
+    (CUSIP, value, shares, type, voting authority, PUT/CALL).
+
+Replaces S13 (`sec_13f_quarterly_sweep`) entirely on a fresh install.
+The bulk archive covers 100% of 13F filers — no top-N cohort cuts.
+
+Spec: docs/superpowers/specs/2026-05-08-bulk-datasets-first-bootstrap.md
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import zipfile
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+import psycopg
+
+from app.services.ownership_observations import record_institution_observation
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Form13FIngestResult:
+    """Per-archive ingest outcome."""
+
+    submissions_seen: int = 0
+    coverpage_seen: int = 0
+    infotable_seen: int = 0
+    rows_written: int = 0
+    rows_skipped_unresolved_cusip: int = 0
+    rows_skipped_orphan_accession: int = 0
+    rows_skipped_bad_data: int = 0
+    parse_errors: int = 0
+
+
+def _resolve_cusip(conn: psycopg.Connection[Any], cusip: str) -> int | None:
+    """Look up ``instrument_id`` for a CUSIP via ``external_identifiers``.
+
+    Same query shape as the existing per-filing 13F ingester.
+    """
+    cur = conn.execute(
+        """
+        SELECT instrument_id
+        FROM external_identifiers
+        WHERE provider = 'sec'
+          AND identifier_type = 'cusip'
+          AND identifier_value = %(cusip)s
+        ORDER BY is_primary DESC, external_identifier_id ASC
+        LIMIT 1
+        """,
+        {"cusip": cusip.strip().upper()},
+    )
+    row = cur.fetchone()
+    return int(row[0]) if row is not None else None
+
+
+def _parse_filing_date(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).replace(tzinfo=UTC)
+    except ValueError:
+        try:
+            return datetime.fromisoformat(value[:10]).replace(tzinfo=UTC)
+        except ValueError:
+            return None
+
+
+def _parse_period_end(value: str | None) -> date | None:
+    if not value:
+        return None
+    # Dataset uses ``DD-MMM-YYYY`` for some columns and ISO for others;
+    # try ISO first then fall back.
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        for fmt in ("%d-%b-%Y", "%d-%b-%y"):
+            try:
+                return datetime.strptime(value, fmt).date()
+            except ValueError:
+                continue
+        return None
+
+
+def _parse_decimal(value: str | None) -> Decimal | None:
+    if value is None or not value.strip():
+        return None
+    try:
+        return Decimal(str(value).strip())
+    # Bind ``as _`` so ruff format on Python 3.14 keeps the tuple
+    # parens (PEP 758 unparenthesised except handlers strip them
+    # otherwise — Codex / older parsers reject the bare form).
+    except (InvalidOperation, ValueError) as _exc:
+        del _exc
+        return None
+
+
+def _map_putcall(raw: str | None) -> Literal["EQUITY", "PUT", "CALL"]:
+    """Map dataset's PUTCALL column to the schema's exposure_kind enum."""
+    if not raw:
+        return "EQUITY"
+    upper = raw.strip().upper()
+    if upper == "PUT":
+        return "PUT"
+    if upper == "CALL":
+        return "CALL"
+    return "EQUITY"
+
+
+def _map_voting_authority(row: dict[str, str]) -> str | None:
+    """Pick the highest-priority non-zero voting authority column.
+
+    Dataset publishes three parallel columns (SOLE / SHARED / NONE);
+    the row's "primary" voting flavour is the first that's non-zero.
+
+    Column-name resilience: the SEC dataset has historically used
+    both ``VOTING_AUTH_<KIND>`` and ``VOTING_AUTHORITY_<KIND>`` in
+    different publication runs; this helper accepts either spelling.
+    """
+
+    def _read(*candidates: str) -> Decimal | None:
+        for key in candidates:
+            value = _parse_decimal(row.get(key))
+            if value is not None:
+                return value
+        return None
+
+    sole = _read("VOTING_AUTH_SOLE", "VOTING_AUTHORITY_SOLE")
+    shared = _read("VOTING_AUTH_SHARED", "VOTING_AUTHORITY_SHARED")
+    none_v = _read("VOTING_AUTH_NONE", "VOTING_AUTHORITY_NONE")
+    if sole and sole > 0:
+        return "SOLE"
+    if shared and shared > 0:
+        return "SHARED"
+    if none_v and none_v > 0:
+        return "NONE"
+    return None
+
+
+def _open_tsv(zf: zipfile.ZipFile, name: str) -> list[dict[str, str]]:
+    """Read a TSV from the archive into a list of dicts.
+
+    The 13F datasets are typically <100 MB so loading SUBMISSION.tsv
+    + COVERPAGE.tsv into memory is acceptable. INFOTABLE can be 30M+
+    rows so the caller iterates that one streamingly.
+    """
+    if name not in zf.namelist():
+        # Some archives bundle CSVs at top-level and others nest under
+        # a directory. Try to fall back.
+        candidates = [n for n in zf.namelist() if n.endswith("/" + name) or n == name]
+        if not candidates:
+            return []
+        name = candidates[0]
+    with zf.open(name) as fh:
+        text = io.TextIOWrapper(fh, encoding="utf-8", newline="")
+        return list(csv.DictReader(text, delimiter="\t"))
+
+
+def _iter_tsv(zf: zipfile.ZipFile, name: str):
+    """Yield rows of a TSV one at a time (used for INFOTABLE)."""
+    if name not in zf.namelist():
+        candidates = [n for n in zf.namelist() if n.endswith("/" + name) or n == name]
+        if not candidates:
+            return
+        name = candidates[0]
+    with zf.open(name) as fh:
+        text = io.TextIOWrapper(fh, encoding="utf-8", newline="")
+        yield from csv.DictReader(text, delimiter="\t")
+
+
+def ingest_13f_dataset_archive(
+    *,
+    conn: psycopg.Connection[Any],
+    archive_path: Path,
+    ingest_run_id: UUID | None = None,
+) -> Form13FIngestResult:
+    """Walk one Form 13F Data Set ZIP and append observations.
+
+    The 13F dataset's three TSVs join on ``ACCESSION_NUMBER``. The
+    primary loop iterates ``INFOTABLE.tsv`` (one row per holding) and
+    looks up the matching SUBMISSION + COVERPAGE row by accession.
+
+    Returns telemetry suitable for stage reporting. Per-row failures
+    (unresolved CUSIP, bad period_end, etc) are counted on the result
+    rather than raised.
+    """
+    if ingest_run_id is None:
+        ingest_run_id = uuid4()
+
+    result = Form13FIngestResult()
+
+    with zipfile.ZipFile(archive_path) as zf:
+        submissions = _open_tsv(zf, "SUBMISSION.tsv")
+        coverpages = _open_tsv(zf, "COVERPAGE.tsv")
+        result.submissions_seen = len(submissions)
+        result.coverpage_seen = len(coverpages)
+
+        sub_by_accession = {row["ACCESSION_NUMBER"]: row for row in submissions if "ACCESSION_NUMBER" in row}
+        cover_by_accession = {row["ACCESSION_NUMBER"]: row for row in coverpages if "ACCESSION_NUMBER" in row}
+
+        for row in _iter_tsv(zf, "INFOTABLE.tsv"):
+            result.infotable_seen += 1
+            accession = row.get("ACCESSION_NUMBER", "").strip()
+            if not accession:
+                result.rows_skipped_orphan_accession += 1
+                continue
+            sub = sub_by_accession.get(accession)
+            cover = cover_by_accession.get(accession)
+            if sub is None or cover is None:
+                result.rows_skipped_orphan_accession += 1
+                continue
+
+            cusip = (row.get("CUSIP") or "").strip().upper()
+            if not cusip:
+                result.rows_skipped_bad_data += 1
+                continue
+
+            instrument_id = _resolve_cusip(conn, cusip)
+            if instrument_id is None:
+                result.rows_skipped_unresolved_cusip += 1
+                continue
+
+            filer_cik = str(sub.get("CIK") or "").strip()
+            if not filer_cik:
+                result.rows_skipped_bad_data += 1
+                continue
+            filer_cik = filer_cik.zfill(10)
+            filer_name = (cover.get("FILINGMANAGER_NAME") or "").strip()
+            if not filer_name:
+                # Schema requires NOT NULL filer_name; fall back to
+                # the CIK to keep the row instead of dropping it.
+                filer_name = f"CIK{filer_cik}"
+
+            filed_at = _parse_filing_date(sub.get("FILING_DATE") or sub.get("DATE_FILED"))
+            period_end = _parse_period_end(cover.get("REPORTCALENDARORQUARTER"))
+            if filed_at is None or period_end is None:
+                result.rows_skipped_bad_data += 1
+                continue
+
+            shares = _parse_decimal(row.get("SSHPRNAMT"))
+            value_thousands = _parse_decimal(row.get("VALUE"))
+            # SEC reports VALUE in $thousands. Multiply for canonical USD.
+            market_value_usd = (value_thousands * Decimal("1000")) if value_thousands is not None else None
+
+            voting_authority = _map_voting_authority(row)
+            exposure_kind = _map_putcall(row.get("PUTCALL"))
+
+            try:
+                accession_no_dashes = accession.replace("-", "")
+                source_url = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession_no_dashes}/"
+                record_institution_observation(
+                    conn,
+                    instrument_id=instrument_id,
+                    filer_cik=filer_cik,
+                    filer_name=filer_name,
+                    # Spec maps 13F filers to ``filer_type='INV'``
+                    # (investment manager) by default. The schema
+                    # CHECK accepts ETF/INV/INS/BD/OTHER. INV is the
+                    # right default for typical 13F-HR filers.
+                    filer_type="INV",
+                    ownership_nature="economic",
+                    source="13f",
+                    source_document_id=accession,
+                    source_accession=accession,
+                    source_field=None,
+                    source_url=source_url,
+                    filed_at=filed_at,
+                    period_start=None,
+                    period_end=period_end,
+                    ingest_run_id=ingest_run_id,
+                    shares=shares,
+                    market_value_usd=market_value_usd,
+                    voting_authority=voting_authority,
+                    exposure_kind=exposure_kind,
+                )
+                result.rows_written += 1
+            except Exception as exc:  # noqa: BLE001
+                # Record-level write failure (e.g. CHECK constraint
+                # violation on a malformed dataset row) — count and
+                # continue. The caller is responsible for opening a
+                # transaction so partial writes are atomic per
+                # archive batch.
+                logger.debug(
+                    "13F ingest: record_institution_observation failed for %s/%s: %s",
+                    accession,
+                    cusip,
+                    exc,
+                )
+                result.parse_errors += 1
+    return result

--- a/tests/test_sec_13f_dataset_ingest.py
+++ b/tests/test_sec_13f_dataset_ingest.py
@@ -1,0 +1,303 @@
+"""Tests for the bulk Form 13F dataset ingester (#1023)."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from app.services.sec_13f_dataset_ingest import (
+    Form13FIngestResult,
+    _map_putcall,
+    _map_voting_authority,
+    _parse_decimal,
+    _parse_filing_date,
+    _parse_period_end,
+    ingest_13f_dataset_archive,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPureHelpers:
+    def test_map_putcall_default_equity(self) -> None:
+        assert _map_putcall(None) == "EQUITY"
+        assert _map_putcall("") == "EQUITY"
+        assert _map_putcall("PUT") == "PUT"
+        assert _map_putcall("Put") == "PUT"
+        assert _map_putcall("CALL") == "CALL"
+
+    def test_map_voting_authority_priority_chain(self) -> None:
+        assert _map_voting_authority({"VOTING_AUTH_SOLE": "100", "VOTING_AUTH_SHARED": "0"}) == "SOLE"
+        assert _map_voting_authority({"VOTING_AUTH_SOLE": "0", "VOTING_AUTH_SHARED": "50"}) == "SHARED"
+        assert _map_voting_authority({"VOTING_AUTH_NONE": "10"}) == "NONE"
+        assert _map_voting_authority({}) is None
+
+    def test_parse_decimal_handles_empty_strings(self) -> None:
+        assert _parse_decimal(None) is None
+        assert _parse_decimal("") is None
+        assert _parse_decimal("   ") is None
+        assert _parse_decimal("123.45") == Decimal("123.45")
+        assert _parse_decimal("not a number") is None
+
+    def test_parse_filing_date_iso_and_short(self) -> None:
+        assert _parse_filing_date("2025-11-01") is not None
+        assert _parse_filing_date("2025-11-01T00:00:00") is not None
+        assert _parse_filing_date(None) is None
+
+    def test_parse_period_end_iso_and_dmmy(self) -> None:
+        assert _parse_period_end("2025-09-30") is not None
+        assert _parse_period_end("30-Sep-2025") is not None
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _build_dataset_zip(
+    *,
+    submissions: list[dict[str, str]],
+    coverpages: list[dict[str, str]],
+    infotable: list[dict[str, str]],
+) -> bytes:
+    """Build a tiny in-memory 13F dataset ZIP."""
+    import csv
+
+    def _to_tsv(rows: list[dict[str, str]]) -> str:
+        if not rows:
+            return ""
+        fieldnames = sorted({k for row in rows for k in row.keys()})
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+        return buf.getvalue()
+
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w") as zf:
+        zf.writestr("SUBMISSION.tsv", _to_tsv(submissions))
+        zf.writestr("COVERPAGE.tsv", _to_tsv(coverpages))
+        zf.writestr("INFOTABLE.tsv", _to_tsv(infotable))
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# DB integration
+# ---------------------------------------------------------------------------
+
+
+_NEXT_IID: list[int] = [12000]
+
+
+def _seed_universe_with_cusip(
+    conn: psycopg.Connection[tuple],
+    *,
+    symbol: str,
+    cusip: str,
+) -> int:
+    _NEXT_IID[0] += 1
+    iid = _NEXT_IID[0]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+        cur.execute(
+            "INSERT INTO external_identifiers "
+            "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (%s, 'sec', 'cusip', %s, TRUE)",
+            (iid, cusip.upper()),
+        )
+    conn.commit()
+    return iid
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestIngest13FDatasetArchive:
+    def test_resolved_cusip_writes_observation_with_correct_fields(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # AAPL CUSIP — 037833100.
+        iid = _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CIK": "1234567",
+                    "FILING_DATE": "2025-11-14",
+                },
+            ],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILINGMANAGER_NAME": "Big Fund LLC",
+                    "REPORTCALENDARORQUARTER": "2025-09-30",
+                },
+            ],
+            infotable=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CUSIP": "037833100",
+                    "VALUE": "5000000",  # $thousands
+                    "SSHPRNAMT": "100000",
+                    "VOTING_AUTH_SOLE": "100000",
+                    "VOTING_AUTH_SHARED": "0",
+                    "VOTING_AUTH_NONE": "0",
+                    "PUTCALL": "",
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert isinstance(result, Form13FIngestResult)
+        assert result.infotable_seen == 1
+        assert result.rows_written == 1
+        assert result.rows_skipped_unresolved_cusip == 0
+
+        # Verify the observation row.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT filer_cik, filer_name, ownership_nature, source,
+                       shares, market_value_usd, voting_authority, exposure_kind, period_end
+                FROM ownership_institutions_observations
+                WHERE instrument_id = %s
+                """,
+                (iid,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            (filer_cik, filer_name, nature, source, shares, mv, voting, exposure, period) = row
+            assert filer_cik == "0001234567"
+            assert filer_name == "Big Fund LLC"
+            assert nature == "economic"
+            assert source == "13f"
+            assert shares == Decimal("100000.0000")
+            # 5_000_000 thousands = 5_000_000_000 USD.
+            assert mv == Decimal("5000000000.00")
+            assert voting == "SOLE"
+            assert exposure == "EQUITY"
+            assert period.isoformat() == "2025-09-30"
+
+    def test_unresolved_cusip_skipped_not_written(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # Seed AAPL but the dataset references a different CUSIP.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+
+        archive_bytes = _build_dataset_zip(
+            submissions=[{"ACCESSION_NUMBER": "ACCN1", "CIK": "1", "FILING_DATE": "2025-11-14"}],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "ACCN1",
+                    "FILINGMANAGER_NAME": "Some Fund",
+                    "REPORTCALENDARORQUARTER": "2025-09-30",
+                }
+            ],
+            infotable=[
+                {"ACCESSION_NUMBER": "ACCN1", "CUSIP": "999999999", "VALUE": "1", "SSHPRNAMT": "1"},
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_written == 0
+        assert result.rows_skipped_unresolved_cusip == 1
+
+    def test_putcall_split_writes_three_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # The 13F schema allows up to 3 rows per (accession, instrument):
+        # equity + PUT + CALL via exposure_kind.
+        iid = _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+
+        archive_bytes = _build_dataset_zip(
+            submissions=[{"ACCESSION_NUMBER": "ACCN1", "CIK": "1", "FILING_DATE": "2025-11-14"}],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "ACCN1",
+                    "FILINGMANAGER_NAME": "Some Fund",
+                    "REPORTCALENDARORQUARTER": "2025-09-30",
+                }
+            ],
+            infotable=[
+                {
+                    "ACCESSION_NUMBER": "ACCN1",
+                    "CUSIP": "037833100",
+                    "VALUE": "100",
+                    "SSHPRNAMT": "10",
+                    "PUTCALL": "",
+                },
+                {
+                    "ACCESSION_NUMBER": "ACCN1",
+                    "CUSIP": "037833100",
+                    "VALUE": "50",
+                    "SSHPRNAMT": "5",
+                    "PUTCALL": "PUT",
+                },
+                {
+                    "ACCESSION_NUMBER": "ACCN1",
+                    "CUSIP": "037833100",
+                    "VALUE": "75",
+                    "SSHPRNAMT": "7",
+                    "PUTCALL": "CALL",
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_written == 3
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT exposure_kind FROM ownership_institutions_observations "
+                "WHERE instrument_id = %s ORDER BY exposure_kind",
+                (iid,),
+            )
+            kinds = [r[0] for r in cur.fetchall()]
+            assert kinds == ["CALL", "EQUITY", "PUT"]


### PR DESCRIPTION
## Summary

- New `app/services/sec_13f_dataset_ingest.py` — Phase C3 of #1020.
- Reads cached Form 13F Data Sets ZIPs (SUBMISSION + COVERPAGE + INFOTABLE TSVs) and writes `ownership_institutions_observations` via the existing `record_institution_observation` helper.
- CUSIP-resolved holdings only; universe gaps tracked in `rows_skipped_unresolved_cusip`.
- PUT/CALL/EQUITY 3-row coexistence preserved via `exposure_kind`.
- Decimal(str(...)) for shares + value; `market_value_usd = VALUE × 1000`.
- `filer_type='INV'` per spec.
- Voting-authority column-name resilience for both `VOTING_AUTH_<KIND>` and `VOTING_AUTHORITY_<KIND>`.

## Test plan

- [x] 8 unit + integration tests cover pure helpers, happy path, unresolved-CUSIP path, PUT/CALL 3-row split.
- [x] `uv run ruff check` + `uv run ruff format --check` clean.
- [x] `uv run pyright` clean.
- [x] `uv run pytest tests/test_sec_13f_dataset_ingest.py` 8/8 pass.
- [x] Codex pre-push review APPROVE (2 rounds).

Stacks on top of #1029 (bulk download).

Closes #1023. Refs #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)