### PR TITLE
feat(#1026): Phase D pipelined SEC fetcher

### DIFF
--- a/app/services/sec_pipelined_fetcher.py
+++ b/app/services/sec_pipelined_fetcher.py
@@ -1,0 +1,215 @@
+"""Pipelined SEC EDGAR fetcher (#1026).
+
+Phase D of the bulk-datasets-first first-install bootstrap (#1020).
+Wraps an ``httpx.AsyncClient`` with a fixed-concurrency pool plus a
+shared async rate limiter so per-filing body fetches (DEF 14A,
+10-K, 8-K) can issue multiple requests in flight while honouring
+SEC's per-IP 10 req/s ceiling (real-world target ~7 req/s, see the
+spec's facts table).
+
+Pipelining a 4-way concurrent fetcher at 7 req/s vs sequential at
+7 req/s is ~30% faster wall-clock when fetch latency dominates the
+inter-request floor (typical for SEC HTML/PDF bodies at 200–500 ms
+RTT). Same total request count, same rate ceiling.
+
+Result yield order is COMPLETION ORDER, not request order. Each
+``FetchTask`` carries an opaque ``key`` that the caller uses to
+associate the result with the original request — caller code must
+not rely on positional ordering.
+
+Spec: docs/superpowers/specs/2026-05-08-bulk-datasets-first-bootstrap.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass
+from typing import Final
+
+import httpx
+
+from app.providers.implementations.sec_edgar import (
+    _PROCESS_RATE_LIMIT_CLOCK,
+    _PROCESS_RATE_LIMIT_LOCK,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Real-world ceiling per the datamule "hidden cumulative rate limit"
+# article + SEC's published 10 req/s fair-use policy. 7 leaves
+# headroom for retransmits.
+DEFAULT_TARGET_RPS: Final[float] = 7.0
+DEFAULT_CONCURRENCY: Final[int] = 4
+DEFAULT_TIMEOUT_S: Final[float] = 30.0
+
+
+@dataclass(frozen=True)
+class FetchTask:
+    """One pending fetch.
+
+    ``key`` is opaque to the fetcher — callers use it to associate
+    the result back to its originating context (filing accession,
+    instrument id, etc) since results yield in completion order.
+    """
+
+    key: object
+    url: str
+    headers: dict[str, str] | None = None
+
+
+@dataclass
+class FetchResult:
+    """Outcome of one fetch.
+
+    On success ``response`` is the ``httpx.Response``; on failure
+    ``error`` is a string and ``response`` is ``None``.
+    """
+
+    key: object
+    response: httpx.Response | None
+    error: str | None = None
+
+
+class _AsyncRateLimiter:
+    """Coordinates a shared inter-request floor across coroutines AND
+    across the existing synchronous ``ResilientClient`` SEC clients.
+
+    Mirrors the synchronous ``ResilientClient`` shared-clock pattern
+    used by the existing per-filing path (#168 / #537 / prevention
+    log "Multiple ResilientClient instances sharing a rate limit must
+    share throttle state").
+
+    The clock is a one-element ``list[float]`` (next-allowed-time)
+    shared with the synchronous SEC clients via
+    ``_PROCESS_RATE_LIMIT_CLOCK``; the companion ``threading.Lock``
+    ``_PROCESS_RATE_LIMIT_LOCK`` makes the read-modify-write atomic
+    across both async coroutines and sync threads. Pipelined fetcher
+    acquires the threading lock briefly inside the async context —
+    no coroutine sleeps while holding it, so concurrent coroutines
+    queue at the lock instead of bursting past the budget.
+
+    Codex pre-push round 1 (PR1026): without sharing the clock, two
+    pipelined fetchers can issue 14 req/s combined, and one fetcher
+    plus existing sync SEC traffic can exceed the per-IP budget.
+    """
+
+    def __init__(
+        self,
+        target_rps: float,
+        *,
+        shared_clock: list[float] | None = None,
+        shared_lock: threading.Lock | None = None,
+    ) -> None:
+        if target_rps <= 0:
+            raise ValueError("target_rps must be > 0")
+        self._min_interval = 1.0 / target_rps
+        self._clock = shared_clock if shared_clock is not None else [0.0]
+        self._lock = shared_lock if shared_lock is not None else threading.Lock()
+
+    async def acquire(self) -> None:
+        """Block until the rate limiter authorises one request.
+
+        Stores the same semantics as the synchronous
+        ``ResilientClient._throttle_and_stamp``
+        (``app/providers/resilient_client.py:135``):
+        ``self._clock[0]`` is the LAST-REQUEST TIMESTAMP, and the
+        floor is ``last + min_interval``. Mixed sync + async traffic
+        on the same shared clock therefore observes a single coherent
+        floor — Codex pre-push round 2.
+
+        Two-phase: (1) under the threading lock, compute the wait
+        duration and stamp the new last-request timestamp at
+        ``now + wait`` (i.e. when this request will actually fire);
+        (2) release the lock and ``await asyncio.sleep`` outside it
+        so other coroutines on the same event loop can still queue.
+        """
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._clock[0]
+            wait = max(0.0, self._min_interval - elapsed)
+            # Stamp the projected fire-time — both sync and async
+            # readers will observe this as the last-request timestamp.
+            self._clock[0] = now + wait
+        if wait > 0:
+            await asyncio.sleep(wait)
+
+
+class PipelinedSecFetcher:
+    """Fixed-concurrency rate-limited wrapper around ``httpx.AsyncClient``.
+
+    Concurrency cap (semaphore) and rate ceiling (async lock with
+    next-allowed-time stamp) are independent guarantees:
+    - Concurrency keeps at most N requests in flight simultaneously
+      (TCP socket budget + memory budget for buffered responses).
+    - Rate ceiling keeps the requests-per-second below SEC's fair-use
+      policy.
+
+    A 4-way pool at 7 req/s is the spec default. Both knobs can be
+    raised or lowered by the caller for testing.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        target_rps: float = DEFAULT_TARGET_RPS,
+        concurrency: int = DEFAULT_CONCURRENCY,
+        shared_clock: list[float] | None = None,
+        shared_lock: threading.Lock | None = None,
+    ) -> None:
+        """Initialise the fetcher.
+
+        Process-wide rate budget is shared with the synchronous SEC
+        ``ResilientClient`` instances by default
+        (``_PROCESS_RATE_LIMIT_CLOCK`` / ``_PROCESS_RATE_LIMIT_LOCK``).
+        Pass explicit ``shared_clock``/``shared_lock`` for tests that
+        need an isolated budget, or pass empty lists / ``None`` for
+        the default shared one.
+        """
+        if concurrency < 1:
+            raise ValueError("concurrency must be >= 1")
+        self._client = client
+        self._sem = asyncio.Semaphore(concurrency)
+        self._rate_limiter = _AsyncRateLimiter(
+            target_rps,
+            shared_clock=shared_clock if shared_clock is not None else _PROCESS_RATE_LIMIT_CLOCK,
+            shared_lock=shared_lock if shared_lock is not None else _PROCESS_RATE_LIMIT_LOCK,
+        )
+
+    async def fetch_one(self, task: FetchTask) -> FetchResult:
+        """Single bounded fetch — useful for callers that don't need
+        a generator interface."""
+        async with self._sem:
+            await self._rate_limiter.acquire()
+            try:
+                response = await self._client.get(task.url, headers=task.headers)
+                return FetchResult(key=task.key, response=response)
+            except (httpx.HTTPError, OSError) as exc:
+                return FetchResult(key=task.key, response=None, error=str(exc))
+
+    async def fetch_many(self, tasks: Iterable[FetchTask]) -> AsyncIterator[FetchResult]:
+        """Yield ``FetchResult`` instances in COMPLETION ORDER.
+
+        Caller iterates with ``async for result in fetcher.fetch_many(...)``
+        and uses ``result.key`` to associate to the originating
+        context. Each task acquires the semaphore + rate limiter
+        independently so completion-order can interleave arbitrarily.
+        """
+        # Materialise into a list so we can enumerate without
+        # exhausting a one-shot iterable.
+        task_list = list(tasks)
+        if not task_list:
+            return
+
+        # Spawn coroutines first, then drain via ``as_completed``.
+        # ``asyncio.as_completed`` returns an iterator of futures
+        # that resolve in completion order — which is the contract
+        # we promise.
+        coros = [self.fetch_one(t) for t in task_list]
+        for coro in asyncio.as_completed(coros):
+            yield await coro

--- a/tests/test_sec_pipelined_fetcher.py
+++ b/tests/test_sec_pipelined_fetcher.py
@@ -1,0 +1,252 @@
+"""Tests for the pipelined SEC EDGAR fetcher (#1026)."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import httpx
+import pytest
+
+from app.services.sec_pipelined_fetcher import (
+    DEFAULT_CONCURRENCY,
+    DEFAULT_TARGET_RPS,
+    FetchTask,
+    PipelinedSecFetcher,
+    _AsyncRateLimiter,
+)
+
+
+def _isolated_budget() -> tuple[list[float], threading.Lock]:
+    """Return a fresh (clock, lock) pair for tests that need predictable timing.
+
+    Without this the fetcher shares the process-wide SEC budget with
+    every other test in the suite, making timing-sensitive assertions
+    fragile under xdist.
+    """
+    return [0.0], threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# AsyncRateLimiter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRateLimiter:
+    @pytest.mark.asyncio
+    async def test_first_acquire_is_immediate(self) -> None:
+        rl = _AsyncRateLimiter(target_rps=10)
+        started = time.monotonic()
+        await rl.acquire()
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.05
+
+    @pytest.mark.asyncio
+    async def test_back_to_back_acquires_observe_min_interval(self) -> None:
+        rl = _AsyncRateLimiter(target_rps=10)  # 100 ms floor
+        started = time.monotonic()
+        await rl.acquire()
+        await rl.acquire()
+        await rl.acquire()
+        elapsed = time.monotonic() - started
+        # 3 acquires over a 100 ms floor must take at least ~200 ms.
+        assert elapsed >= 0.18
+
+    @pytest.mark.asyncio
+    async def test_zero_or_negative_rps_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            _AsyncRateLimiter(target_rps=0)
+        with pytest.raises(ValueError):
+            _AsyncRateLimiter(target_rps=-1)
+
+
+# ---------------------------------------------------------------------------
+# PipelinedSecFetcher integration tests
+# ---------------------------------------------------------------------------
+
+
+def _record_handler(latency_s: float = 0.05, in_flight: list[int] | None = None):
+    """Return a MockTransport handler that records concurrent in-flight counts."""
+    if in_flight is None:
+        in_flight = [0, 0]  # current, peak
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        in_flight[0] += 1
+        in_flight[1] = max(in_flight[1], in_flight[0])
+        time.sleep(latency_s)
+        in_flight[0] -= 1
+        path = request.url.path
+        return httpx.Response(200, content=path.encode("utf-8"))
+
+    return handler, in_flight
+
+
+class TestPipelinedSecFetcher:
+    @pytest.mark.asyncio
+    async def test_results_yield_in_completion_order_with_correct_keys(self) -> None:
+        # Each URL responds after a deterministic delay; with
+        # concurrency=3 all three start near-simultaneously and
+        # complete in increasing-delay order.
+        delays = {"a": 0.15, "b": 0.05, "c": 0.10}
+
+        async def async_handler(request: httpx.Request) -> httpx.Response:
+            await asyncio.sleep(delays.get(request.url.path.strip("/"), 0))
+            return httpx.Response(200)
+
+        transport = httpx.MockTransport(async_handler)
+        async with httpx.AsyncClient(transport=transport, base_url="https://test") as client:
+            clock, lock = _isolated_budget()
+            fetcher = PipelinedSecFetcher(
+                client=client,
+                target_rps=1000,
+                concurrency=3,
+                shared_clock=clock,
+                shared_lock=lock,
+            )
+            tasks = [FetchTask(key=k, url=f"https://test/{k}") for k in ("a", "b", "c")]
+            keys_in_order: list[object] = []
+            async for result in fetcher.fetch_many(tasks):
+                assert result.error is None
+                keys_in_order.append(result.key)
+        # Completion order: shortest delay first.
+        assert keys_in_order == ["b", "c", "a"]
+
+    @pytest.mark.asyncio
+    async def test_concurrency_cap_honoured(self) -> None:
+        in_flight = [0, 0]
+
+        async def async_handler(request: httpx.Request) -> httpx.Response:
+            in_flight[0] += 1
+            in_flight[1] = max(in_flight[1], in_flight[0])
+            await asyncio.sleep(0.05)
+            in_flight[0] -= 1
+            return httpx.Response(200)
+
+        transport = httpx.MockTransport(async_handler)
+        async with httpx.AsyncClient(transport=transport, base_url="https://test") as client:
+            clock, lock = _isolated_budget()
+            fetcher = PipelinedSecFetcher(
+                client=client,
+                target_rps=1000,
+                concurrency=2,
+                shared_clock=clock,
+                shared_lock=lock,
+            )
+            tasks = [FetchTask(key=i, url=f"https://test/{i}") for i in range(8)]
+            async for _ in fetcher.fetch_many(tasks):
+                pass
+        # With concurrency=2, peak in-flight must never exceed 2.
+        assert in_flight[1] <= 2
+
+    @pytest.mark.asyncio
+    async def test_rate_ceiling_honoured_under_load(self) -> None:
+        # 5 req/s ceiling = 200 ms floor; 6 requests over MockTransport
+        # with negligible latency must take ~1.0s (5 floors between
+        # 6 acquires).
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport, base_url="https://test") as client:
+            clock, lock = _isolated_budget()
+            fetcher = PipelinedSecFetcher(
+                client=client,
+                target_rps=5,
+                concurrency=4,
+                shared_clock=clock,
+                shared_lock=lock,
+            )
+            tasks = [FetchTask(key=i, url=f"https://test/{i}") for i in range(6)]
+            started = time.monotonic()
+            async for _ in fetcher.fetch_many(tasks):
+                pass
+            elapsed = time.monotonic() - started
+        assert elapsed >= 0.95  # 5 floors × 200 ms
+
+    @pytest.mark.asyncio
+    async def test_empty_task_list_yields_nothing(self) -> None:
+        transport = httpx.MockTransport(lambda r: httpx.Response(200))
+        async with httpx.AsyncClient(transport=transport) as client:
+            fetcher = PipelinedSecFetcher(client=client)
+            yielded = [r async for r in fetcher.fetch_many([])]
+        assert yielded == []
+
+    @pytest.mark.asyncio
+    async def test_http_error_surfaces_on_result_error_field(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("simulated")
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport, base_url="https://test") as client:
+            clock, lock = _isolated_budget()
+            fetcher = PipelinedSecFetcher(
+                client=client,
+                target_rps=1000,
+                concurrency=1,
+                shared_clock=clock,
+                shared_lock=lock,
+            )
+            results = [r async for r in fetcher.fetch_many([FetchTask(key="x", url="https://test/x")])]
+        assert len(results) == 1
+        assert results[0].response is None
+        assert results[0].error is not None
+
+    def test_concurrency_zero_rejected(self) -> None:
+        async def _make() -> None:
+            async with httpx.AsyncClient() as client:
+                with pytest.raises(ValueError):
+                    PipelinedSecFetcher(client=client, concurrency=0)
+
+        asyncio.run(_make())
+
+    def test_default_constants_match_spec(self) -> None:
+        assert DEFAULT_TARGET_RPS == 7.0
+        assert DEFAULT_CONCURRENCY == 4
+
+    @pytest.mark.asyncio
+    async def test_async_floor_observes_sync_stamp(self) -> None:
+        # Mixed sync+async sharing of the same clock: simulate a sync
+        # ResilientClient firing "right now" by stamping clock[0] =
+        # monotonic(); the async fetcher must wait min_interval before
+        # firing. Codex pre-push round 2: the prior implementation
+        # treated clock[0] as "next allowed time" and bypassed the
+        # floor when it was actually a last-request stamp.
+        clock, lock = _isolated_budget()
+        # Sync client just fired:
+        clock[0] = time.monotonic()
+        rl = _AsyncRateLimiter(target_rps=10, shared_clock=clock, shared_lock=lock)
+        started = time.monotonic()
+        await rl.acquire()
+        elapsed = time.monotonic() - started
+        # 10 req/s = 100 ms floor; the async caller should wait ~100 ms.
+        assert elapsed >= 0.08, f"expected ~100 ms wait, got {elapsed:.3f} s"
+
+    @pytest.mark.asyncio
+    async def test_two_fetchers_share_rate_budget_via_shared_clock(self) -> None:
+        # Two fetchers configured against the SAME (clock, lock)
+        # tuple must serialise their requests against the budget —
+        # combined throughput stays at target_rps, not 2 × target_rps.
+        # Codex pre-push round 1: this is the prevention-log
+        # "Multiple ResilientClient instances sharing a rate limit
+        # must share throttle state" case applied to async clients.
+        clock, lock = _isolated_budget()
+        transport = httpx.MockTransport(lambda r: httpx.Response(200))
+        async with httpx.AsyncClient(transport=transport, base_url="https://test") as client:
+            # 5 req/s shared budget; two fetchers each issuing 3 requests.
+            f1 = PipelinedSecFetcher(client=client, target_rps=5, concurrency=3, shared_clock=clock, shared_lock=lock)
+            f2 = PipelinedSecFetcher(client=client, target_rps=5, concurrency=3, shared_clock=clock, shared_lock=lock)
+            t1 = [FetchTask(key=f"a{i}", url=f"https://test/a{i}") for i in range(3)]
+            t2 = [FetchTask(key=f"b{i}", url=f"https://test/b{i}") for i in range(3)]
+
+            async def _drain(fetcher: PipelinedSecFetcher, tasks: list[FetchTask]) -> None:
+                async for _ in fetcher.fetch_many(tasks):
+                    pass
+
+            started = time.monotonic()
+            await asyncio.gather(_drain(f1, t1), _drain(f2, t2))
+            elapsed = time.monotonic() - started
+        # 6 requests at 5 req/s shared = 5 floors × 200 ms ≈ 1.0 s.
+        # If the budget were NOT shared, two fetchers at 3 req each
+        # would interleave at 10 req/s combined and finish in ~0.4 s.
+        assert elapsed >= 0.95


### PR DESCRIPTION
## Summary

- New `app/services/sec_pipelined_fetcher.py` — Phase D entrypoint of #1020.
- 4-way concurrency at 7 req/s (default per spec).
- `FetchTask(key, url)` + completion-order `FetchResult(key, response, error)` yield.
- Shares `_PROCESS_RATE_LIMIT_CLOCK` + `_PROCESS_RATE_LIMIT_LOCK` with the existing synchronous SEC clients so mixed sync+async traffic stays inside the per-IP budget.
- Last-request-timestamp semantics match `ResilientClient._throttle_and_stamp`.

## Test plan

- [x] 12 unit tests cover rate limiter floor, zero-rps rejection, concurrency cap, completion-order yield, rate ceiling, empty list, HTTP error path, two-fetcher budget sharing, sync-stamp → async-floor respect.
- [x] `uv run ruff check` + `uv run ruff format --check` clean.
- [x] `uv run pyright` clean.
- [x] 12/12 tests pass.
- [x] Codex pre-push review APPROVE (3 rounds; round 1 caught private-clock budget violation; round 2 caught last-request-time vs next-allowed-time semantic mismatch).

Closes #1026. Refs #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)