### PR TITLE
feat(#1027): orchestrator integration + C1.b walker + bulk job invokers

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -237,6 +237,28 @@ _INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP] = (
     _bootstrap_orchestrator.bootstrap_sec_13f_recent_sweep_job
 )
 
+# ---------------------------------------------------------------------------
+# Bulk-archive Phase C ingester invokers (#1027 — #1020)
+# ---------------------------------------------------------------------------
+# Each ingester is a zero-arg wrapper that opens its own connection
+# and reads cached archives from ``resolve_data_dir() / "sec" / "bulk"``.
+# Skip silently if the archive is missing (slow-connection fallback
+# bypassed Phase A3).
+from app.services import sec_bulk_download as _sec_bulk_download  # noqa: E402
+from app.services import sec_bulk_orchestrator_jobs as _bulk_jobs  # noqa: E402
+from app.services import sec_submissions_files_walk as _files_walk  # noqa: E402
+
+# Phase A3 — bulk archive download (#1021 / #1020). Registered here
+# so PR7 is self-consistent if PR #1029 has not yet landed; the
+# duplicate dict-key assignment when both PRs are merged is a no-op.
+_INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _sec_bulk_download.sec_bulk_download_job
+_INVOKERS[_bulk_jobs.JOB_SEC_SUBMISSIONS_INGEST] = _bulk_jobs.sec_submissions_ingest_job
+_INVOKERS[_bulk_jobs.JOB_SEC_COMPANYFACTS_INGEST] = _bulk_jobs.sec_companyfacts_ingest_job
+_INVOKERS[_bulk_jobs.JOB_SEC_13F_INGEST_FROM_DATASET] = _bulk_jobs.sec_13f_ingest_from_dataset_job
+_INVOKERS[_bulk_jobs.JOB_SEC_INSIDER_INGEST_FROM_DATASET] = _bulk_jobs.sec_insider_ingest_from_dataset_job
+_INVOKERS[_bulk_jobs.JOB_SEC_NPORT_INGEST_FROM_DATASET] = _bulk_jobs.sec_nport_ingest_from_dataset_job
+_INVOKERS[_files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK] = _files_walk.sec_submissions_files_walk_job
+
 
 # Public registry of valid job names. The API layer (#719) imports this
 # to validate ``POST /jobs/{name}/run`` before writing a queue row, so

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -80,33 +80,66 @@ def _spec(stage_key: str, stage_order: int, lane: str, job_name: str) -> StageSp
     return StageSpec(stage_key=stage_key, stage_order=stage_order, lane=lane, job_name=job_name)  # type: ignore[arg-type]
 
 
+# Bulk-archive job names for the #1020 first-install bulk-datasets-first
+# pipeline. Each archive is downloaded by Phase A3 (sec_bulk_download)
+# and ingested locally by the matching DB-bound stage. Stages skip
+# silently if the archive is missing (slow-connection fallback bypass).
+JOB_SEC_BULK_DOWNLOAD = "sec_bulk_download"
+JOB_SEC_SUBMISSIONS_INGEST = "sec_submissions_ingest"
+JOB_SEC_COMPANYFACTS_INGEST = "sec_companyfacts_ingest"
+JOB_SEC_13F_INGEST_FROM_DATASET = "sec_13f_ingest_from_dataset"
+JOB_SEC_INSIDER_INGEST_FROM_DATASET = "sec_insider_ingest_from_dataset"
+JOB_SEC_NPORT_INGEST_FROM_DATASET = "sec_nport_ingest_from_dataset"
+JOB_SEC_SUBMISSIONS_FILES_WALK = "sec_submissions_files_walk"
+
+
 _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # Phase A (init, sequential)
     _spec("universe_sync", 1, "init", "nightly_universe_sync"),
     # Phase B — eToro lane
     _spec("candle_refresh", 2, "etoro", "daily_candle_refresh"),
-    # Phase B — SEC lane (15 stages, sequential)
+    # Phase B — SEC lane (sequential, shared rate budget).
     _spec("cusip_universe_backfill", 3, "sec", "cusip_universe_backfill"),
     _spec("sec_13f_filer_directory_sync", 4, "sec", "sec_13f_filer_directory_sync"),
     _spec("sec_nport_filer_directory_sync", 5, "sec", "sec_nport_filer_directory_sync"),
     _spec("cik_refresh", 6, "sec", JOB_DAILY_CIK_REFRESH),
-    _spec("filings_history_seed", 7, "sec", JOB_BOOTSTRAP_FILINGS_HISTORY_SEED),
-    _spec("sec_first_install_drain", 8, "sec", JOB_SEC_FIRST_INSTALL_DRAIN),
-    _spec("sec_def14a_bootstrap", 9, "sec", "sec_def14a_bootstrap"),
-    _spec("sec_business_summary_bootstrap", 10, "sec", "sec_business_summary_bootstrap"),
-    _spec("sec_insider_transactions_backfill", 11, "sec", "sec_insider_transactions_backfill"),
-    _spec("sec_form3_ingest", 12, "sec", "sec_form3_ingest"),
-    _spec("sec_8k_events_ingest", 13, "sec", "sec_8k_events_ingest"),
+    # Phase A3 — bulk archive download (#1020). Ships the heavy data
+    # in <10 min on a fast connection; the C-stages below ingest
+    # locally with no rate-budget cost.
+    _spec("sec_bulk_download", 7, "sec", JOB_SEC_BULK_DOWNLOAD),
+    # Phase C — DB-bound bulk ingesters (#1020). Each skips silently
+    # if its archive is missing (slow-connection bypass).
+    _spec("sec_submissions_ingest", 8, "sec", JOB_SEC_SUBMISSIONS_INGEST),
+    _spec("sec_companyfacts_ingest", 9, "sec", JOB_SEC_COMPANYFACTS_INGEST),
+    _spec("sec_13f_ingest_from_dataset", 10, "sec", JOB_SEC_13F_INGEST_FROM_DATASET),
+    _spec("sec_insider_ingest_from_dataset", 11, "sec", JOB_SEC_INSIDER_INGEST_FROM_DATASET),
+    _spec("sec_nport_ingest_from_dataset", 12, "sec", JOB_SEC_NPORT_INGEST_FROM_DATASET),
+    # Phase C' — per-CIK secondary-pages walk for deep-history parity
+    # with the existing per-CIK drain (#1020).
+    _spec("sec_submissions_files_walk", 13, "sec", JOB_SEC_SUBMISSIONS_FILES_WALK),
+    # Legacy per-filing stages — kept as a fallback path. After the
+    # bulk pass these are largely idempotent DB no-ops on populated
+    # observation tables; on the slow-connection bypass path they are
+    # the primary write path.
+    _spec("filings_history_seed", 14, "sec", JOB_BOOTSTRAP_FILINGS_HISTORY_SEED),
+    _spec("sec_first_install_drain", 15, "sec", JOB_SEC_FIRST_INSTALL_DRAIN),
+    _spec("sec_def14a_bootstrap", 16, "sec", "sec_def14a_bootstrap"),
+    _spec("sec_business_summary_bootstrap", 17, "sec", "sec_business_summary_bootstrap"),
+    _spec("sec_insider_transactions_backfill", 18, "sec", "sec_insider_transactions_backfill"),
+    _spec("sec_form3_ingest", 19, "sec", "sec_form3_ingest"),
+    _spec("sec_8k_events_ingest", 20, "sec", "sec_8k_events_ingest"),
     # #1008 — first-install bootstrap uses a recency-bounded sweep
     # (last 4 quarters, ~12 months) instead of the full historical
     # sweep. Walking decades of pre-2013 filings yields zero rows
     # (no machine-readable primary_doc/infotable) and turns the
     # bootstrap into an 11+ hour wait. Standalone weekly cron
     # keeps the full historical sweep via JOB_SEC_13F_QUARTERLY_SWEEP.
-    _spec("sec_13f_recent_sweep", 14, "sec", JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP),
-    _spec("sec_n_port_ingest", 15, "sec", "sec_n_port_ingest"),
-    _spec("ownership_observations_backfill", 16, "sec", "ownership_observations_backfill"),
-    _spec("fundamentals_sync", 17, "sec", "fundamentals_sync"),
+    # On the bulk path (#1020) C3 has already populated
+    # ownership_institutions_observations; this stage tops up.
+    _spec("sec_13f_recent_sweep", 21, "sec", JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP),
+    _spec("sec_n_port_ingest", 22, "sec", "sec_n_port_ingest"),
+    _spec("ownership_observations_backfill", 23, "sec", "ownership_observations_backfill"),
+    _spec("fundamentals_sync", 24, "sec", "fundamentals_sync"),
 )
 
 
@@ -583,7 +616,8 @@ __all__ = [
 # Stage count assertion — pin so a future refactor that adds /
 # removes a spec deliberately surfaces in code review and doesn't
 # silently break the tests + frontend that hardcode "17 stages".
-assert len(_BOOTSTRAP_STAGE_SPECS) == 17, (
-    f"_BOOTSTRAP_STAGE_SPECS expected 17 stages, got {len(_BOOTSTRAP_STAGE_SPECS)}; "
-    "update the spec, frontend, and stage_count tests in lockstep."
+assert len(_BOOTSTRAP_STAGE_SPECS) == 24, (
+    f"_BOOTSTRAP_STAGE_SPECS expected 24 stages, got {len(_BOOTSTRAP_STAGE_SPECS)}; "
+    "update the spec, frontend, and stage_count tests in lockstep. "
+    "#1027 added 7 bulk-archive stages (sec_bulk_download + C1.a/C2/C3/C4/C5 ingesters + C1.b walker)."
 )

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -81,17 +81,19 @@ def _spec(stage_key: str, stage_order: int, lane: str, job_name: str) -> StageSp
 
 
 # Bulk-archive job names for the #1020 first-install bulk-datasets-first
-# pipeline. Each archive is downloaded by Phase A3 (sec_bulk_download)
-# and ingested locally by the matching DB-bound stage. Stages skip
-# silently if the archive is missing (slow-connection fallback bypass).
-JOB_SEC_BULK_DOWNLOAD = "sec_bulk_download"
-JOB_SEC_SUBMISSIONS_INGEST = "sec_submissions_ingest"
-JOB_SEC_COMPANYFACTS_INGEST = "sec_companyfacts_ingest"
-JOB_SEC_13F_INGEST_FROM_DATASET = "sec_13f_ingest_from_dataset"
-JOB_SEC_INSIDER_INGEST_FROM_DATASET = "sec_insider_ingest_from_dataset"
-JOB_SEC_NPORT_INGEST_FROM_DATASET = "sec_nport_ingest_from_dataset"
-JOB_SEC_SUBMISSIONS_FILES_WALK = "sec_submissions_files_walk"
-
+# pipeline. Re-exported from the canonical owners so duplicate-constant
+# drift is impossible (Codex review WARNING for PR #1035).
+from app.services.sec_bulk_download import JOB_SEC_BULK_DOWNLOAD  # noqa: E402
+from app.services.sec_bulk_orchestrator_jobs import (  # noqa: E402
+    JOB_SEC_13F_INGEST_FROM_DATASET,
+    JOB_SEC_COMPANYFACTS_INGEST,
+    JOB_SEC_INSIDER_INGEST_FROM_DATASET,
+    JOB_SEC_NPORT_INGEST_FROM_DATASET,
+    JOB_SEC_SUBMISSIONS_INGEST,
+)
+from app.services.sec_submissions_files_walk import (  # noqa: E402
+    JOB_SEC_SUBMISSIONS_FILES_WALK,
+)
 
 _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # Phase A (init, sequential)

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -1,0 +1,212 @@
+"""Zero-arg job invokers for the bulk-archive Phase C ingesters (#1027).
+
+Each invoker is a thin wrapper the runtime registry can dispatch with
+no arguments. The wrappers:
+
+  * Open a fresh ``psycopg`` connection against ``settings.database_url``.
+  * Resolve the cached archive path under
+    ``resolve_data_dir() / "sec" / "bulk" / <name>``.
+  * Skip with a clear log line if the archive is missing (slow-connection
+    fallback path skipped Phase A3).
+  * Call the matching service-layer ingester.
+  * Commit + log.
+
+Each wrapper is registered in ``app/jobs/runtime.py:_INVOKERS`` so the
+orchestrator + admin UI can dispatch them.
+
+Spec: docs/superpowers/specs/2026-05-08-bulk-datasets-first-bootstrap.md
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Final
+
+import psycopg
+
+from app.config import settings
+from app.security.master_key import resolve_data_dir
+from app.services.sec_13f_dataset_ingest import ingest_13f_dataset_archive
+from app.services.sec_companyfacts_ingest import ingest_companyfacts_archive
+from app.services.sec_insider_dataset_ingest import ingest_insider_dataset_archive
+from app.services.sec_nport_dataset_ingest import ingest_nport_dataset_archive
+from app.services.sec_submissions_ingest import ingest_submissions_archive
+
+logger = logging.getLogger(__name__)
+
+
+JOB_SEC_SUBMISSIONS_INGEST: Final[str] = "sec_submissions_ingest"
+JOB_SEC_COMPANYFACTS_INGEST: Final[str] = "sec_companyfacts_ingest"
+JOB_SEC_13F_INGEST_FROM_DATASET: Final[str] = "sec_13f_ingest_from_dataset"
+JOB_SEC_INSIDER_INGEST_FROM_DATASET: Final[str] = "sec_insider_ingest_from_dataset"
+JOB_SEC_NPORT_INGEST_FROM_DATASET: Final[str] = "sec_nport_ingest_from_dataset"
+
+
+def _bulk_dir() -> Path:
+    return resolve_data_dir() / "sec" / "bulk"
+
+
+def _archive_path(name: str) -> Path:
+    return _bulk_dir() / name
+
+
+def _list_archives_matching(prefix: str) -> list[Path]:
+    """Return every archive in the cache whose filename starts with ``prefix``.
+
+    Used for the multi-quarter Phase C ingesters (13F, insider, N-PORT)
+    which iterate every quarterly ZIP in the cache.
+    """
+    base = _bulk_dir()
+    if not base.exists():
+        return []
+    return sorted(p for p in base.iterdir() if p.is_file() and p.name.startswith(prefix))
+
+
+def _run_with_conn(fn: Callable[[psycopg.Connection[tuple]], object]) -> None:
+    """Open a fresh psycopg connection, run ``fn``, commit."""
+    with psycopg.connect(settings.database_url) as conn:
+        fn(conn)
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# C1.a — submissions.zip ingester
+# ---------------------------------------------------------------------------
+
+
+def sec_submissions_ingest_job() -> None:
+    archive = _archive_path("submissions.zip")
+    if not archive.exists():
+        logger.info("sec_submissions_ingest: archive %s not present, skipping", archive)
+        return
+
+    def _do(conn: psycopg.Connection[tuple]) -> None:
+        result = ingest_submissions_archive(conn=conn, archive_path=archive)
+        logger.info(
+            "sec_submissions_ingest: matched=%d filings_upserted=%d profiles=%d parse_errors=%d",
+            result.instruments_matched,
+            result.filings_upserted,
+            result.profiles_upserted,
+            result.parse_errors,
+        )
+
+    _run_with_conn(_do)
+
+
+# ---------------------------------------------------------------------------
+# C2 — companyfacts.zip ingester
+# ---------------------------------------------------------------------------
+
+
+def sec_companyfacts_ingest_job() -> None:
+    archive = _archive_path("companyfacts.zip")
+    if not archive.exists():
+        logger.info("sec_companyfacts_ingest: archive %s not present, skipping", archive)
+        return
+
+    def _do(conn: psycopg.Connection[tuple]) -> None:
+        result = ingest_companyfacts_archive(conn=conn, archive_path=archive)
+        logger.info(
+            "sec_companyfacts_ingest: matched=%d facts_upserted=%d parse_errors=%d",
+            result.instruments_matched,
+            result.facts_upserted,
+            result.parse_errors,
+        )
+
+    _run_with_conn(_do)
+
+
+# ---------------------------------------------------------------------------
+# C3 — Form 13F dataset ingester (one job, walks all cached quarters)
+# ---------------------------------------------------------------------------
+
+
+def sec_13f_ingest_from_dataset_job() -> None:
+    archives = _list_archives_matching("form13f_")
+    if not archives:
+        logger.info("sec_13f_ingest_from_dataset: no form13f_*.zip cached, skipping")
+        return
+
+    def _do(conn: psycopg.Connection[tuple]) -> None:
+        total_written = 0
+        total_skipped = 0
+        for archive in archives:
+            result = ingest_13f_dataset_archive(conn=conn, archive_path=archive)
+            total_written += result.rows_written
+            total_skipped += result.rows_skipped_unresolved_cusip
+            logger.info(
+                "sec_13f_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d",
+                archive.name,
+                result.rows_written,
+                result.rows_skipped_unresolved_cusip,
+            )
+        logger.info(
+            "sec_13f_ingest_from_dataset: total_rows_written=%d total_unresolved=%d",
+            total_written,
+            total_skipped,
+        )
+
+    _run_with_conn(_do)
+
+
+# ---------------------------------------------------------------------------
+# C4 — Insider Transactions dataset ingester
+# ---------------------------------------------------------------------------
+
+
+def sec_insider_ingest_from_dataset_job() -> None:
+    archives = _list_archives_matching("insider_")
+    if not archives:
+        logger.info("sec_insider_ingest_from_dataset: no insider_*.zip cached, skipping")
+        return
+
+    def _do(conn: psycopg.Connection[tuple]) -> None:
+        total_written = 0
+        for archive in archives:
+            result = ingest_insider_dataset_archive(conn=conn, archive_path=archive)
+            total_written += result.rows_written
+            logger.info(
+                "sec_insider_ingest_from_dataset: archive=%s rows_written=%d unresolved_cik=%d",
+                archive.name,
+                result.rows_written,
+                result.rows_skipped_unresolved_cik,
+            )
+        logger.info(
+            "sec_insider_ingest_from_dataset: total_rows_written=%d",
+            total_written,
+        )
+
+    _run_with_conn(_do)
+
+
+# ---------------------------------------------------------------------------
+# C5 — Form N-PORT dataset ingester
+# ---------------------------------------------------------------------------
+
+
+def sec_nport_ingest_from_dataset_job() -> None:
+    archives = _list_archives_matching("nport_")
+    if not archives:
+        logger.info("sec_nport_ingest_from_dataset: no nport_*.zip cached, skipping")
+        return
+
+    def _do(conn: psycopg.Connection[tuple]) -> None:
+        total_written = 0
+        for archive in archives:
+            result = ingest_nport_dataset_archive(conn=conn, archive_path=archive)
+            total_written += result.rows_written
+            logger.info(
+                "sec_nport_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d non_equity=%d",
+                archive.name,
+                result.rows_written,
+                result.rows_skipped_unresolved_cusip,
+                result.rows_skipped_non_equity,
+            )
+        logger.info(
+            "sec_nport_ingest_from_dataset: total_rows_written=%d",
+            total_written,
+        )
+
+    _run_with_conn(_do)

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -129,26 +129,32 @@ def sec_13f_ingest_from_dataset_job() -> None:
         logger.info("sec_13f_ingest_from_dataset: no form13f_*.zip cached, skipping")
         return
 
-    def _do(conn: psycopg.Connection[tuple]) -> None:
-        total_written = 0
-        total_skipped = 0
-        for archive in archives:
-            result = ingest_13f_dataset_archive(conn=conn, archive_path=archive)
-            total_written += result.rows_written
-            total_skipped += result.rows_skipped_unresolved_cusip
-            logger.info(
-                "sec_13f_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d",
-                archive.name,
-                result.rows_written,
-                result.rows_skipped_unresolved_cusip,
-            )
+    # Per-archive commit so an exception on archive N does not roll
+    # back archives 1..N-1's writes (Codex review WARNING for PR #1035).
+    total_written = 0
+    total_skipped = 0
+    for archive in archives:
+        with psycopg.connect(settings.database_url) as conn:
+            try:
+                result = ingest_13f_dataset_archive(conn=conn, archive_path=archive)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                logger.exception("sec_13f_ingest_from_dataset: archive=%s failed", archive.name)
+                continue
+        total_written += result.rows_written
+        total_skipped += result.rows_skipped_unresolved_cusip
         logger.info(
-            "sec_13f_ingest_from_dataset: total_rows_written=%d total_unresolved=%d",
-            total_written,
-            total_skipped,
+            "sec_13f_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d",
+            archive.name,
+            result.rows_written,
+            result.rows_skipped_unresolved_cusip,
         )
-
-    _run_with_conn(_do)
+    logger.info(
+        "sec_13f_ingest_from_dataset: total_rows_written=%d total_unresolved=%d",
+        total_written,
+        total_skipped,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -162,23 +168,28 @@ def sec_insider_ingest_from_dataset_job() -> None:
         logger.info("sec_insider_ingest_from_dataset: no insider_*.zip cached, skipping")
         return
 
-    def _do(conn: psycopg.Connection[tuple]) -> None:
-        total_written = 0
-        for archive in archives:
-            result = ingest_insider_dataset_archive(conn=conn, archive_path=archive)
-            total_written += result.rows_written
-            logger.info(
-                "sec_insider_ingest_from_dataset: archive=%s rows_written=%d unresolved_cik=%d",
-                archive.name,
-                result.rows_written,
-                result.rows_skipped_unresolved_cik,
-            )
+    # Per-archive commit per Codex review WARNING for PR #1035.
+    total_written = 0
+    for archive in archives:
+        with psycopg.connect(settings.database_url) as conn:
+            try:
+                result = ingest_insider_dataset_archive(conn=conn, archive_path=archive)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                logger.exception("sec_insider_ingest_from_dataset: archive=%s failed", archive.name)
+                continue
+        total_written += result.rows_written
         logger.info(
-            "sec_insider_ingest_from_dataset: total_rows_written=%d",
-            total_written,
+            "sec_insider_ingest_from_dataset: archive=%s rows_written=%d unresolved_cik=%d",
+            archive.name,
+            result.rows_written,
+            result.rows_skipped_unresolved_cik,
         )
-
-    _run_with_conn(_do)
+    logger.info(
+        "sec_insider_ingest_from_dataset: total_rows_written=%d",
+        total_written,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -192,21 +203,26 @@ def sec_nport_ingest_from_dataset_job() -> None:
         logger.info("sec_nport_ingest_from_dataset: no nport_*.zip cached, skipping")
         return
 
-    def _do(conn: psycopg.Connection[tuple]) -> None:
-        total_written = 0
-        for archive in archives:
-            result = ingest_nport_dataset_archive(conn=conn, archive_path=archive)
-            total_written += result.rows_written
-            logger.info(
-                "sec_nport_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d non_equity=%d",
-                archive.name,
-                result.rows_written,
-                result.rows_skipped_unresolved_cusip,
-                result.rows_skipped_non_equity,
-            )
+    # Per-archive commit per Codex review WARNING for PR #1035.
+    total_written = 0
+    for archive in archives:
+        with psycopg.connect(settings.database_url) as conn:
+            try:
+                result = ingest_nport_dataset_archive(conn=conn, archive_path=archive)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                logger.exception("sec_nport_ingest_from_dataset: archive=%s failed", archive.name)
+                continue
+        total_written += result.rows_written
         logger.info(
-            "sec_nport_ingest_from_dataset: total_rows_written=%d",
-            total_written,
+            "sec_nport_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d non_equity=%d",
+            archive.name,
+            result.rows_written,
+            result.rows_skipped_unresolved_cusip,
+            result.rows_skipped_non_equity,
         )
-
-    _run_with_conn(_do)
+    logger.info(
+        "sec_nport_ingest_from_dataset: total_rows_written=%d",
+        total_written,
+    )

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -50,31 +50,33 @@ class FilesWalkResult:
     parse_errors: int = 0
 
 
-def _list_cik_secondary_pages(conn: psycopg.Connection[Any]) -> list[tuple[int, str, list[str]]]:
-    """Return ``[(instrument_id, cik_padded, secondary_filenames)]`` for
-    every universe instrument that recorded ``filings.files[]`` entries
-    during the C1.a bulk pass.
+def _list_cik_secondary_pages(
+    conn: psycopg.Connection[Any],
+) -> list[tuple[int, str, str]]:
+    """Return ``[(instrument_id, cik_padded, symbol)]`` for every
+    CIK-mapped universe instrument.
 
-    NOTE: this assumes the C1.a pass persisted secondary-page filenames.
-    For v1 we recompute on the fly: the bulk archive entry is small
-    enough to re-read. The callsite below performs the per-CIK
-    secondary-page expansion via the existing ``SecFilingsProvider``
-    pagination, which is the same code path the per-filing
-    ``sec_first_install_drain`` exercises.
+    Joins ``external_identifiers`` to ``instruments`` so the writer
+    below threads the canonical ticker through to
+    ``_normalise_submissions_block`` + ``_upsert_filing``. Passing
+    ``str(instrument_id)`` as the symbol corrupts every
+    ``filing_events.raw_payload_json`` row — Codex review BLOCKING
+    for PR #1035, parity with the same fix in PR #1030 (C1.a).
     """
-    out: list[tuple[int, str, list[str]]] = []
+    out: list[tuple[int, str, str]] = []
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT instrument_id, identifier_value
-            FROM external_identifiers
-            WHERE provider = 'sec' AND identifier_type = 'cik'
+            SELECT ei.instrument_id, ei.identifier_value, i.symbol
+            FROM external_identifiers ei
+            JOIN instruments i ON i.instrument_id = ei.instrument_id
+            WHERE ei.provider = 'sec' AND ei.identifier_type = 'cik'
             """,
         )
         for row in cur.fetchall():
-            instrument_id, identifier = row
+            instrument_id, identifier, symbol = row
             cik = str(identifier).zfill(10)
-            out.append((int(instrument_id), cik, []))
+            out.append((int(instrument_id), cik, str(symbol or "")))
     return out
 
 
@@ -95,7 +97,7 @@ def walk_files_pages(
     targets = _list_cik_secondary_pages(conn)
 
     with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-        for instrument_id, cik, _hint in targets:
+        for instrument_id, cik, symbol in targets:
             result.ciks_visited += 1
             try:
                 # Fetch primary submissions.json (rate-limited).
@@ -139,10 +141,15 @@ def walk_files_pages(
 
                 result.secondary_pages_fetched += 1
                 try:
+                    # ``symbol`` is the canonical ticker (e.g. "AAPL"),
+                    # NOT a stringified instrument_id. Threaded from
+                    # the universe lookup at the top of the walk so
+                    # ``filing_events.raw_payload_json`` carries the
+                    # right value. Codex review BLOCKING for PR #1035.
                     filings = _normalise_submissions_block(
                         page,
                         cik_padded=cik,
-                        symbol=str(instrument_id),
+                        symbol=symbol or cik,
                     )
                 except Exception as exc:  # noqa: BLE001
                     logger.debug("files walk: normalise failed for %s: %s", page_name, exc)

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -1,0 +1,183 @@
+"""C1.b — per-CIK ``filings.files[]`` secondary-pages walker (#1027).
+
+The bulk ``submissions.zip`` archive published by SEC contains every
+CIK's ``filings.recent`` block (last ~12 months / 1000 most-recent
+filings). For deeper history, SEC paginates older filings under
+``filings.files[]`` — secondary JSON URLs the bulk archive does NOT
+include.
+
+C1.a (bulk submissions ingester, #1022) reads the bulk archive's
+``recent`` block. C1.b walks each CIK's secondary pages — bounded
+by the per-CIK rate budget — to seed ``filing_events`` with the
+deeper history that the existing ``sec_first_install_drain`` would
+otherwise have walked one CIK at a time at 7 req/s.
+
+This is a ~150–300 secondary-page-fetch job for a typical 1.5 k
+universe (most CIKs have <12 months of history; only the
+deepest-history filers cross into the secondary-page region).
+Walked AFTER C1.a + Phase B so the CUSIP universe + filer
+directories are in place; rate-limited via the existing process-wide
+SEC clock.
+
+Spec: docs/superpowers/specs/2026-05-08-bulk-datasets-first-bootstrap.md
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_edgar import (
+    SecFilingsProvider,
+    _normalise_submissions_block,
+)
+from app.services.filings import _upsert_filing
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FilesWalkResult:
+    """Per-CIK walk telemetry."""
+
+    ciks_visited: int = 0
+    secondary_pages_fetched: int = 0
+    filings_upserted: int = 0
+    parse_errors: int = 0
+
+
+def _list_cik_secondary_pages(conn: psycopg.Connection[Any]) -> list[tuple[int, str, list[str]]]:
+    """Return ``[(instrument_id, cik_padded, secondary_filenames)]`` for
+    every universe instrument that recorded ``filings.files[]`` entries
+    during the C1.a bulk pass.
+
+    NOTE: this assumes the C1.a pass persisted secondary-page filenames.
+    For v1 we recompute on the fly: the bulk archive entry is small
+    enough to re-read. The callsite below performs the per-CIK
+    secondary-page expansion via the existing ``SecFilingsProvider``
+    pagination, which is the same code path the per-filing
+    ``sec_first_install_drain`` exercises.
+    """
+    out: list[tuple[int, str, list[str]]] = []
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, identifier_value
+            FROM external_identifiers
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+            """,
+        )
+        for row in cur.fetchall():
+            instrument_id, identifier = row
+            cik = str(identifier).zfill(10)
+            out.append((int(instrument_id), cik, []))
+    return out
+
+
+def walk_files_pages(
+    *,
+    conn: psycopg.Connection[Any],
+) -> FilesWalkResult:
+    """Walk ``filings.files[]`` secondary pages for every CIK-mapped
+    universe instrument and append discovered filings to
+    ``filing_events``.
+
+    The walker reuses the existing ``SecFilingsProvider`` HTTP client
+    (which already shares the process-wide rate-limit clock) so this
+    pass coexists with concurrent SEC ingest jobs without bursting
+    the per-IP budget.
+    """
+    result = FilesWalkResult()
+    targets = _list_cik_secondary_pages(conn)
+
+    with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+        for instrument_id, cik, _hint in targets:
+            result.ciks_visited += 1
+            try:
+                # Fetch primary submissions.json (rate-limited).
+                # The provider exposes ``fetch_submissions(cik)`` which
+                # returns the parsed dict for the given CIK; the dict's
+                # ``filings.files[]`` array names secondary pages.
+                primary = provider.fetch_submissions(cik)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("files walk: primary fetch failed for CIK %s: %s", cik, exc)
+                result.parse_errors += 1
+                continue
+
+            if not isinstance(primary, dict):
+                continue
+            filings_block = primary.get("filings")
+            files: list[Any] = []
+            if isinstance(filings_block, dict):
+                raw_files = filings_block.get("files")
+                if isinstance(raw_files, list):
+                    files = raw_files
+
+            for entry in files:
+                if not isinstance(entry, dict):
+                    continue
+                page_name = entry.get("name")
+                if not page_name:
+                    continue
+                try:
+                    page = provider.fetch_submissions_page(page_name)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "files walk: secondary fetch failed for CIK %s/%s: %s",
+                        cik,
+                        page_name,
+                        exc,
+                    )
+                    result.parse_errors += 1
+                    continue
+                if page is None:
+                    continue
+
+                result.secondary_pages_fetched += 1
+                try:
+                    filings = _normalise_submissions_block(
+                        page,
+                        cik_padded=cik,
+                        symbol=str(instrument_id),
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("files walk: normalise failed for %s: %s", page_name, exc)
+                    result.parse_errors += 1
+                    continue
+
+                for filing in filings:
+                    try:
+                        with conn.transaction():
+                            _upsert_filing(conn, str(instrument_id), "sec", filing)
+                            result.filings_upserted += 1
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug(
+                            "files walk: upsert failed for %s/%s: %s",
+                            cik,
+                            filing.provider_filing_id,
+                            exc,
+                        )
+                        result.parse_errors += 1
+    return result
+
+
+# Job invoker registered in app/jobs/runtime.py:_INVOKERS.
+JOB_SEC_SUBMISSIONS_FILES_WALK = "sec_submissions_files_walk"
+
+
+def sec_submissions_files_walk_job() -> None:
+    """Zero-arg job invoker for the runtime registry."""
+    with psycopg.connect(settings.database_url) as conn:
+        result = walk_files_pages(conn=conn)
+        conn.commit()
+    logger.info(
+        "sec_submissions_files_walk: ciks=%d pages=%d filings=%d parse_errors=%d",
+        result.ciks_visited,
+        result.secondary_pages_fetched,
+        result.filings_upserted,
+        result.parse_errors,
+    )


### PR DESCRIPTION
## Summary

Final integration of the bulk-datasets-first first-install bootstrap (#1020). Wires the Phase A3 downloader (#1029), Phase C ingesters (#1030/#1031/#1032/#1033), and pipelined fetcher (#1034) into the bootstrap orchestrator stage catalogue.

- New `app/services/sec_submissions_files_walk.py` (C1.b) — per-CIK `filings.files[]` secondary-page walker for deep-history parity.
- New `app/services/sec_bulk_orchestrator_jobs.py` — zero-arg wrappers for every Phase C ingester. Each skips silently if the cached archive is missing.
- `app/jobs/runtime.py` — registers all 6 new invokers.
- `_BOOTSTRAP_STAGE_SPECS` extended 17 → 24 stages; bulk stages slot in before the legacy per-CIK stages so the bulk path runs first.

## Dependencies

This PR stacks on top of and **must merge after**: #1029, #1030, #1031, #1032, #1033, #1034. CI will fail until the dependencies merge because the wrapper imports reference modules introduced by those PRs.

## Out of scope (follow-up issue)

- Frontend admin UI updates — bytes-downloaded telemetry + slow-connection banner. Filed as a separate issue once the service layer lands.
- Refactor of `sec_first_install_drain` to read from cached `submissions.zip` (currently still walks per-CIK; the new C1.a stage covers the same ground via the bulk path so the drain becomes an idempotent fast-path no-op).

## Test plan

- [x] `uv run ruff check` + `uv run ruff format --check` clean against PR7 files.
- [x] `uv run pyright` flags only the cross-PR import dependencies (resolved on merge).
- [x] Codex pre-push review APPROVE (2 rounds; round 1 caught the stale 17-stage length assertion + missing `sec_bulk_download` invoker registration).
- [ ] End-to-end smoke test deferred until PRs 1029-1034 merge — operator can run a fresh-install attempt then.

Closes #1027. Refs #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)