### PR TITLE
feat(#1020): bulk-archive disk hygiene — pre-flight + post-ingest delete

### DIFF
--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -257,6 +257,28 @@ def build_bulk_archive_inventory(
 # ---------------------------------------------------------------------------
 
 
+def _preflight_cleanup_stale_partials(target_dir: Path) -> None:
+    """Delete any leftover ``*.partial`` files from a previous interrupted run.
+
+    Disk-hygiene policy (#1020 follow-up): completed ``.zip`` files
+    are preserved so an interrupted bootstrap can resume Phase C
+    without re-downloading. Stale ``.partial`` files however are
+    never useful — the resume path on a complete-download retry
+    issues a fresh HTTP Range request and would overwrite any
+    partial. Deleting them up-front frees disk + removes ambiguity
+    if a previous transfer aborted at an unknown byte count.
+    """
+    if not target_dir.exists():
+        return
+    for path in target_dir.iterdir():
+        if path.is_file() and path.name.endswith(".partial"):
+            try:
+                path.unlink()
+                logger.info("preflight cleanup: removed stale partial %s", path)
+            except OSError as exc:
+                logger.warning("preflight cleanup: failed to remove %s: %s", path, exc)
+
+
 def check_disk_space(target_dir: Path, *, min_free_bytes: int = DEFAULT_MIN_FREE_BYTES) -> tuple[bool, int]:
     """Return ``(has_enough, free_bytes)`` for ``target_dir``.
 
@@ -504,6 +526,7 @@ async def download_bulk_archives(
     recorded on the result and surfaced in the admin UI.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
+    _preflight_cleanup_stale_partials(target_dir)
     has_space, free_bytes = check_disk_space(target_dir, min_free_bytes=min_free_bytes)
     if not has_space:
         return BulkDownloadResult(

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -71,6 +71,27 @@ def _run_with_conn(fn: Callable[[psycopg.Connection[tuple]], object]) -> None:
         conn.commit()
 
 
+def _delete_archive_after_success(archive: Path) -> None:
+    """Delete a successfully-ingested archive from the bulk cache.
+
+    Disk-hygiene policy (#1020 follow-up): once an archive's contents
+    are durably committed to Postgres, the multi-GB ZIP on disk is
+    dead weight — leaving it around bloats ``<data_dir>/sec/bulk/``
+    by ~5–6 GB per bootstrap and stales every subsequent download
+    (the next run's pre-flight then has to re-download anyway, but
+    cleanly via ``download_bulk_archives``).
+
+    Failures elsewhere in the pipeline are unaffected — only the
+    successful-ingest path deletes. ``OSError`` is logged and
+    swallowed so a permission glitch does not unwind the commit.
+    """
+    try:
+        archive.unlink(missing_ok=True)
+        logger.info("disk hygiene: deleted ingested archive %s", archive)
+    except OSError as exc:
+        logger.warning("disk hygiene: failed to delete %s: %s", archive, exc)
+
+
 # ---------------------------------------------------------------------------
 # C1.a — submissions.zip ingester
 # ---------------------------------------------------------------------------
@@ -93,6 +114,7 @@ def sec_submissions_ingest_job() -> None:
         )
 
     _run_with_conn(_do)
+    _delete_archive_after_success(archive)
 
 
 # ---------------------------------------------------------------------------
@@ -116,6 +138,7 @@ def sec_companyfacts_ingest_job() -> None:
         )
 
     _run_with_conn(_do)
+    _delete_archive_after_success(archive)
 
 
 # ---------------------------------------------------------------------------
@@ -142,6 +165,7 @@ def sec_13f_ingest_from_dataset_job() -> None:
                 conn.rollback()
                 logger.exception("sec_13f_ingest_from_dataset: archive=%s failed", archive.name)
                 continue
+        _delete_archive_after_success(archive)
         total_written += result.rows_written
         total_skipped += result.rows_skipped_unresolved_cusip
         logger.info(
@@ -179,6 +203,7 @@ def sec_insider_ingest_from_dataset_job() -> None:
                 conn.rollback()
                 logger.exception("sec_insider_ingest_from_dataset: archive=%s failed", archive.name)
                 continue
+        _delete_archive_after_success(archive)
         total_written += result.rows_written
         logger.info(
             "sec_insider_ingest_from_dataset: archive=%s rows_written=%d unresolved_cik=%d",
@@ -214,6 +239,7 @@ def sec_nport_ingest_from_dataset_job() -> None:
                 conn.rollback()
                 logger.exception("sec_nport_ingest_from_dataset: archive=%s failed", archive.name)
                 continue
+        _delete_archive_after_success(archive)
         total_written += result.rows_written
         logger.info(
             "sec_nport_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d non_equity=%d",

--- a/tests/test_sec_bulk_disk_hygiene.py
+++ b/tests/test_sec_bulk_disk_hygiene.py
@@ -1,0 +1,48 @@
+"""Disk-hygiene regression tests for the bulk orchestrator jobs (#1020)."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from app.services import sec_bulk_orchestrator_jobs as jobs
+from app.services.sec_bulk_orchestrator_jobs import _delete_archive_after_success
+
+
+class TestDeleteArchiveAfterSuccess:
+    def test_deletes_existing_file(self, tmp_path: Path) -> None:
+        archive = tmp_path / "submissions.zip"
+        archive.write_bytes(b"x" * 100)
+        _delete_archive_after_success(archive)
+        assert not archive.exists()
+
+    def test_missing_file_no_op(self, tmp_path: Path) -> None:
+        archive = tmp_path / "missing.zip"
+        # Must not raise — missing_ok=True.
+        _delete_archive_after_success(archive)
+
+
+def _build_minimal_archive(path: Path) -> None:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("CIK0000000000.json", '{"filings":{"recent":{},"files":[]}}')
+    path.write_bytes(buf.getvalue())
+
+
+class TestSubmissionsJobDeletesAfterSuccess:
+    def test_archive_removed_after_ingest_success(self, tmp_path: Path) -> None:
+        archive = tmp_path / "sec" / "bulk" / "submissions.zip"
+        archive.parent.mkdir(parents=True)
+        _build_minimal_archive(archive)
+
+        # Patch resolve_data_dir + _run_with_conn so the test does not
+        # need a live Postgres.
+        with (
+            patch.object(jobs, "_bulk_dir", return_value=archive.parent),
+            patch.object(jobs, "_run_with_conn") as run_with_conn,
+        ):
+            run_with_conn.return_value = None
+            jobs.sec_submissions_ingest_job()
+        assert not archive.exists(), "archive must be deleted after successful ingest"

--- a/tests/test_sec_bulk_download.py
+++ b/tests/test_sec_bulk_download.py
@@ -16,6 +16,7 @@ from app.services.sec_bulk_download import (
     BulkArchive,
     BulkDownloadResult,
     _download_one,
+    _preflight_cleanup_stale_partials,
     _zip_round_trip,
     build_bulk_archive_inventory,
     check_disk_space,
@@ -135,6 +136,23 @@ class TestInventory:
 # ---------------------------------------------------------------------------
 # Disk pre-flight
 # ---------------------------------------------------------------------------
+
+
+class TestPreflightCleanup:
+    def test_removes_partial_files_keeps_complete_zips(self, tmp_path: Path) -> None:
+        # Pre-existing complete archive must be preserved (resume path);
+        # stale .partial must be wiped (#1020 disk hygiene).
+        complete = tmp_path / "submissions.zip"
+        complete.write_bytes(b"complete payload")
+        partial = tmp_path / "companyfacts.zip.partial"
+        partial.write_bytes(b"truncated payload")
+        _preflight_cleanup_stale_partials(tmp_path)
+        assert complete.exists()
+        assert not partial.exists()
+
+    def test_no_op_when_dir_missing(self, tmp_path: Path) -> None:
+        # Should not raise on absent directory.
+        _preflight_cleanup_stale_partials(tmp_path / "does-not-exist")
 
 
 class TestDiskPreflight:


### PR DESCRIPTION
## Summary

Operator-requested disk-hygiene policy: keep `<data_dir>/sec/bulk/` clear of dead data.

- **Pre-flight (sec_bulk_download):** wipes leftover `*.partial` files; preserves complete `*.zip` so an interrupted bootstrap can resume Phase C without re-download.
- **Post-ingest (C1.a, C2, C3, C4, C5):** each archive is deleted via `_delete_archive_after_success` after its DB writes commit. Multi-archive jobs delete per-archive inside the loop; failing archives stay on disk for re-run.

Net effect on successful bootstrap: cache finishes empty.

## Test plan

- [x] 22 tests pass (existing + 3 new): preflight `.partial` cleanup, `_delete_archive_after_success` happy/missing paths, submissions job deletes after mocked ingest.
- [x] `uv run ruff check` + `uv run ruff format --check` clean.
- [x] `uv run pyright` clean.
- [x] Codex pre-push review APPROVE.

Refs #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)