### PR TITLE
feat(#1020): pre-write validation contract + bulk-download error-on-partial

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -209,6 +209,30 @@ def _run_one_stage(
             conn.commit()
         return _StageOutcome(stage_key=stage_key, success=False, error=message)
 
+    # Auto-record the __job__ row in bootstrap_archive_results so
+    # downstream stages can verify provenance via the precondition
+    # checker. C-stages write their own per-archive rows; this catches
+    # the B-stages and any other invoker that doesn't self-record.
+    # Idempotent ON CONFLICT — no-op if the C-stage already wrote.
+    from app.services.bootstrap_preconditions import record_archive_result
+
+    with psycopg.connect(database_url) as conn:
+        try:
+            record_archive_result(
+                conn,
+                bootstrap_run_id=run_id,
+                stage_key=stage_key,
+                archive_name="__job__",
+                rows_written=0,
+            )
+            conn.commit()
+        except Exception as exc:  # noqa: BLE001 — auditing must not fail the stage
+            logger.warning(
+                "bootstrap stage %s: failed to record __job__ result: %s",
+                stage_key,
+                exc,
+            )
+
     with psycopg.connect(database_url) as conn:
         mark_stage_success(conn, run_id=run_id, stage_key=stage_key)
         conn.commit()

--- a/app/services/bootstrap_preconditions.py
+++ b/app/services/bootstrap_preconditions.py
@@ -1,0 +1,453 @@
+"""Pre-write validation for first-install bootstrap stages (#1020).
+
+Every Phase C / D / E invoker calls into this module BEFORE any DB
+write to verify that:
+
+  1. **Provenance** — required upstream B-stage / C-stage rows exist
+     in ``bootstrap_archive_results`` for the current
+     ``bootstrap_run_id``. The row's existence proves the upstream
+     stage ran in THIS bootstrap run, not a prior one.
+
+  2. **Coverage adequacy** (Phase C only) — the producer reference
+     table has populated enough rows in the current A1 universe
+     cohort. Stale partial mappings are caught here before downstream
+     ingest writes nothing.
+
+A precondition failure raises ``BootstrapPreconditionError`` so the
+orchestrator marks the stage ``error`` with a clear operator-visible
+message. Without this guard, the older path silently no-op'd
+(empty lookup table → 100 % rows_skipped_unresolved → stage marked
+``success`` with zero writes).
+
+Spec: docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+# Default coverage ratios. Operator overrides via env vars.
+DEFAULT_MIN_CIK_COVERAGE_RATIO = float(os.environ.get("BOOTSTRAP_MIN_CIK_COVERAGE_RATIO", "0.50"))
+DEFAULT_MIN_CUSIP_COVERAGE_RATIO = float(os.environ.get("BOOTSTRAP_MIN_CUSIP_COVERAGE_RATIO", "0.50"))
+
+
+class BootstrapPreconditionError(RuntimeError):
+    """Raised when a Phase C / D / E precondition fails.
+
+    Distinct exception type so the orchestrator's error message reads
+    "PRECONDITION: {detail}" instead of being mistaken for a
+    runtime ingester failure.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Provenance — bootstrap_archive_results row existence
+# ---------------------------------------------------------------------------
+
+
+def assert_archive_result_exists(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    stage_key: str,
+    archive_name: str,
+) -> None:
+    """Raise unless ``bootstrap_archive_results`` has a row for this triple.
+
+    Used by C-stages to verify the matching B-stage (archive_name='__job__')
+    or upstream C-stage (archive_name=<zip>) ran in the current run.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1 FROM bootstrap_archive_results
+            WHERE bootstrap_run_id = %s
+              AND stage_key = %s
+              AND archive_name = %s
+            """,
+            (bootstrap_run_id, stage_key, archive_name),
+        )
+        if cur.fetchone() is None:
+            raise BootstrapPreconditionError(
+                f"PRECONDITION: bootstrap_archive_results row missing for "
+                f"run_id={bootstrap_run_id}, stage_key={stage_key!r}, "
+                f"archive_name={archive_name!r}; upstream stage did not "
+                f"complete in the current bootstrap run."
+            )
+
+
+def assert_stage_succeeded_in_run(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    stage_key: str,
+) -> None:
+    """Raise unless ``bootstrap_stages`` shows ``status='success'`` for
+    the given (run_id, stage_key)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT status FROM bootstrap_stages
+            WHERE bootstrap_run_id = %s AND stage_key = %s
+            """,
+            (bootstrap_run_id, stage_key),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise BootstrapPreconditionError(
+                f"PRECONDITION: bootstrap_stages row missing for run_id={bootstrap_run_id}, stage_key={stage_key!r}."
+            )
+        if row[0] != "success":
+            raise BootstrapPreconditionError(
+                f"PRECONDITION: stage {stage_key!r} status={row[0]!r} in run_id={bootstrap_run_id}; required 'success'."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Coverage adequacy — mapped/cohort ratio
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CoverageRatio:
+    mapped: int
+    cohort: int
+
+    @property
+    def ratio(self) -> float:
+        if self.cohort == 0:
+            return 0.0
+        return self.mapped / self.cohort
+
+
+def compute_cik_coverage(conn: psycopg.Connection[Any]) -> CoverageRatio:
+    """Compute CIK coverage ratio against the producer cohort.
+
+    Producer cohort matches ``daily_cik_refresh`` (verified at
+    ``app/workers/scheduler.py:1501``):
+    ``is_tradable = TRUE AND exchanges.asset_class = 'us_equity'``.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM instruments i
+              JOIN exchanges e ON e.exchange_id = i.exchange
+             WHERE i.is_tradable = TRUE
+               AND e.asset_class = 'us_equity'
+            """,
+        )
+        row = cur.fetchone()
+        cohort = int(row[0]) if row else 0
+
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM instruments i
+              JOIN exchanges e ON e.exchange_id = i.exchange
+              JOIN external_identifiers ei
+                ON ei.instrument_id = i.instrument_id
+               AND ei.provider = 'sec'
+               AND ei.identifier_type = 'cik'
+             WHERE i.is_tradable = TRUE
+               AND e.asset_class = 'us_equity'
+            """,
+        )
+        row = cur.fetchone()
+        mapped = int(row[0]) if row else 0
+    return CoverageRatio(mapped=mapped, cohort=cohort)
+
+
+def compute_cusip_coverage(conn: psycopg.Connection[Any]) -> CoverageRatio:
+    """Compute CUSIP coverage ratio against the producer cohort.
+
+    Producer cohort matches ``backfill_cusip_coverage`` (verified at
+    ``app/services/sec_13f_securities_list.py``):
+    ``is_tradable = TRUE AND company_name IS NOT NULL AND company_name <> ''``.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM instruments
+             WHERE is_tradable = TRUE
+               AND company_name IS NOT NULL
+               AND company_name <> ''
+            """,
+        )
+        row = cur.fetchone()
+        cohort = int(row[0]) if row else 0
+
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM instruments i
+              JOIN external_identifiers ei
+                ON ei.instrument_id = i.instrument_id
+               AND ei.provider = 'sec'
+               AND ei.identifier_type = 'cusip'
+             WHERE i.is_tradable = TRUE
+               AND i.company_name IS NOT NULL
+               AND i.company_name <> ''
+            """,
+        )
+        row = cur.fetchone()
+        mapped = int(row[0]) if row else 0
+    return CoverageRatio(mapped=mapped, cohort=cohort)
+
+
+def assert_cik_coverage(
+    conn: psycopg.Connection[Any],
+    *,
+    min_ratio: float = DEFAULT_MIN_CIK_COVERAGE_RATIO,
+) -> None:
+    """Raise unless CIK coverage in the US-equity cohort meets the floor."""
+    coverage = compute_cik_coverage(conn)
+    if coverage.cohort == 0:
+        raise BootstrapPreconditionError(
+            "PRECONDITION: CIK cohort is empty (no tradable us_equity instruments); A1 universe_sync may have not run."
+        )
+    if coverage.ratio < min_ratio:
+        raise BootstrapPreconditionError(
+            f"PRECONDITION: CIK coverage {coverage.mapped}/{coverage.cohort} "
+            f"= {coverage.ratio:.2%} below floor {min_ratio:.0%}; "
+            f"daily_cik_refresh has not adequately mapped the current universe."
+        )
+
+
+def assert_cusip_coverage(
+    conn: psycopg.Connection[Any],
+    *,
+    min_ratio: float = DEFAULT_MIN_CUSIP_COVERAGE_RATIO,
+) -> None:
+    """Raise unless CUSIP coverage in the named-tradable cohort meets the floor."""
+    coverage = compute_cusip_coverage(conn)
+    if coverage.cohort == 0:
+        raise BootstrapPreconditionError(
+            "PRECONDITION: CUSIP cohort is empty (no tradable named instruments); A1 universe_sync may have not run."
+        )
+    if coverage.ratio < min_ratio:
+        raise BootstrapPreconditionError(
+            f"PRECONDITION: CUSIP coverage {coverage.mapped}/{coverage.cohort} "
+            f"= {coverage.ratio:.2%} below floor {min_ratio:.0%}; "
+            f"cusip_universe_backfill has not adequately mapped the current universe."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-stage precondition bundles
+# ---------------------------------------------------------------------------
+
+
+def assert_archives_in_manifest(
+    target_dir: Any,
+    expected_names: list[str],
+    *,
+    bootstrap_run_id: int,
+) -> None:
+    """Raise unless every name in ``expected_names`` is in the current
+    run's manifest.
+
+    Catches both stale-archive (prior run's leftover) and partial-set
+    (some quarterly archives failed to land) failure modes.
+    """
+    from app.services.sec_bulk_download import assert_archive_belongs_to_run
+
+    for name in expected_names:
+        assert_archive_belongs_to_run(target_dir, name, bootstrap_run_id=bootstrap_run_id)
+
+
+def assert_c1a_preconditions(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    bulk_dir: Any | None = None,
+) -> None:
+    """C1.a (sec_submissions_ingest): B4 invocation + CIK coverage + manifest provenance."""
+    assert_archive_result_exists(
+        conn,
+        bootstrap_run_id=bootstrap_run_id,
+        stage_key="cik_refresh",
+        archive_name="__job__",
+    )
+    assert_cik_coverage(conn)
+    if bulk_dir is not None:
+        assert_archives_in_manifest(bulk_dir, ["submissions.zip"], bootstrap_run_id=bootstrap_run_id)
+
+
+def assert_c2_preconditions(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    bulk_dir: Any | None = None,
+) -> None:
+    """C2 (sec_companyfacts_ingest): B4 invocation + CIK coverage + manifest provenance."""
+    assert_archive_result_exists(
+        conn,
+        bootstrap_run_id=bootstrap_run_id,
+        stage_key="cik_refresh",
+        archive_name="__job__",
+    )
+    assert_cik_coverage(conn)
+    if bulk_dir is not None:
+        assert_archives_in_manifest(bulk_dir, ["companyfacts.zip"], bootstrap_run_id=bootstrap_run_id)
+
+
+def assert_c3_preconditions(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    bulk_dir: Any | None = None,
+    expected_archive_names: list[str] | None = None,
+) -> None:
+    """C3 (13F): B1 invocation + CUSIP coverage + ALL 4 quarterly archives landed."""
+    assert_archive_result_exists(
+        conn,
+        bootstrap_run_id=bootstrap_run_id,
+        stage_key="cusip_universe_backfill",
+        archive_name="__job__",
+    )
+    assert_cusip_coverage(conn)
+    if bulk_dir is not None and expected_archive_names is not None:
+        assert_archives_in_manifest(bulk_dir, expected_archive_names, bootstrap_run_id=bootstrap_run_id)
+
+
+def assert_c4_preconditions(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    bulk_dir: Any | None = None,
+    expected_archive_names: list[str] | None = None,
+) -> None:
+    """C4 (insider): B4 invocation + CIK coverage + ALL 8 quarterly archives landed."""
+    assert_archive_result_exists(
+        conn,
+        bootstrap_run_id=bootstrap_run_id,
+        stage_key="cik_refresh",
+        archive_name="__job__",
+    )
+    assert_cik_coverage(conn)
+    if bulk_dir is not None and expected_archive_names is not None:
+        assert_archives_in_manifest(bulk_dir, expected_archive_names, bootstrap_run_id=bootstrap_run_id)
+
+
+def assert_c5_preconditions(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    bulk_dir: Any | None = None,
+    expected_archive_names: list[str] | None = None,
+) -> None:
+    """C5 (N-PORT): B1 invocation + CUSIP coverage + ALL 4 quarterly archives landed."""
+    assert_archive_result_exists(
+        conn,
+        bootstrap_run_id=bootstrap_run_id,
+        stage_key="cusip_universe_backfill",
+        archive_name="__job__",
+    )
+    assert_cusip_coverage(conn)
+    if bulk_dir is not None and expected_archive_names is not None:
+        assert_archives_in_manifest(bulk_dir, expected_archive_names, bootstrap_run_id=bootstrap_run_id)
+
+
+def assert_c1b_preconditions(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+) -> None:
+    """C1.b: C1.a succeeded in current run AND wrote ≥ 1 row.
+
+    Without the rows-written check, a zero-row C1.a (e.g. universe
+    had no SEC-mapped instruments) would pass this gate and let
+    C1.b proceed to walk an empty CIK list. Codex review
+    BLOCKING for #1020.
+    """
+    assert_stage_succeeded_in_run(
+        conn,
+        bootstrap_run_id=bootstrap_run_id,
+        stage_key="sec_submissions_ingest",
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT rows_written FROM bootstrap_archive_results
+            WHERE bootstrap_run_id = %s
+              AND stage_key = 'sec_submissions_ingest'
+              AND archive_name = 'submissions.zip'
+            """,
+            (bootstrap_run_id,),
+        )
+        row = cur.fetchone()
+        if row is None or int(row[0]) <= 0:
+            raise BootstrapPreconditionError(
+                f"PRECONDITION: sec_submissions_ingest wrote 0 rows in run_id={bootstrap_run_id}; C1.b cannot proceed."
+            )
+
+
+def assert_d_preconditions(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+) -> None:
+    """D1/D2/D3: C1.a + C1.b both succeeded in current run."""
+    assert_stage_succeeded_in_run(
+        conn,
+        bootstrap_run_id=bootstrap_run_id,
+        stage_key="sec_submissions_ingest",
+    )
+    assert_stage_succeeded_in_run(
+        conn,
+        bootstrap_run_id=bootstrap_run_id,
+        stage_key="sec_submissions_files_walk",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit-trail writer for B-stage / C-stage invokers
+# ---------------------------------------------------------------------------
+
+
+def record_archive_result(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    stage_key: str,
+    archive_name: str,
+    rows_written: int,
+    rows_skipped: dict[str, int] | None = None,
+) -> None:
+    """Insert/upsert one row in ``bootstrap_archive_results``.
+
+    Each Phase C ingester calls this AFTER each archive's writes
+    commit. Each B-stage wrapper calls it with ``archive_name='__job__'``
+    after the underlying scheduler job completes.
+
+    Idempotent on ``(bootstrap_run_id, stage_key, archive_name)`` so a
+    re-run within the same orchestrator re-records cleanly.
+    """
+    import json
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO bootstrap_archive_results
+                (bootstrap_run_id, stage_key, archive_name, rows_written, rows_skipped, completed_at)
+            VALUES
+                (%(run_id)s, %(stage)s, %(archive)s, %(rows_written)s, %(rows_skipped)s::jsonb, NOW())
+            ON CONFLICT (bootstrap_run_id, stage_key, archive_name) DO UPDATE SET
+                rows_written = EXCLUDED.rows_written,
+                rows_skipped = EXCLUDED.rows_skipped,
+                completed_at = EXCLUDED.completed_at
+            """,
+            {
+                "run_id": bootstrap_run_id,
+                "stage": stage_key,
+                "archive": archive_name,
+                "rows_written": rows_written,
+                "rows_skipped": json.dumps(rows_skipped or {}),
+            },
+        )

--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -258,23 +258,31 @@ def build_bulk_archive_inventory(
 
 
 def _preflight_cleanup_stale_partials(target_dir: Path) -> None:
-    """Delete any leftover ``*.partial`` files from a previous interrupted run.
+    """Delete leftover ``*.partial`` AND complete ``*.zip`` files
+    from previous runs.
 
-    Disk-hygiene policy (#1020 follow-up): completed ``.zip`` files
-    are preserved so an interrupted bootstrap can resume Phase C
-    without re-downloading. Stale ``.partial`` files however are
-    never useful — the resume path on a complete-download retry
-    issues a fresh HTTP Range request and would overwrite any
-    partial. Deleting them up-front frees disk + removes ambiguity
-    if a previous transfer aborted at an unknown byte count.
+    Originally only cleaned partials — but the run-manifest provenance
+    contract (#1020) requires every archive in the current run's
+    manifest to have been physically downloaded in THIS run. Promoting
+    a prior-run complete ``.zip`` into the current manifest would let
+    stale data pass provenance. Solution: nuke everything, every run
+    re-downloads. Resume-from-partial (within the same run) still
+    works because the per-run download itself can interrupt and
+    leave a ``.partial`` that the next-attempt pre-flight wipes
+    before retrying.
+
+    The run-manifest itself is also wiped so a stale manifest cannot
+    leak into the next run.
     """
     if not target_dir.exists():
         return
     for path in target_dir.iterdir():
-        if path.is_file() and path.name.endswith(".partial"):
+        if not path.is_file():
+            continue
+        if path.name.endswith(".partial") or path.name.endswith(".zip") or path.name == RUN_MANIFEST_NAME:
             try:
                 path.unlink()
-                logger.info("preflight cleanup: removed stale partial %s", path)
+                logger.info("preflight cleanup: removed %s", path)
             except OSError as exc:
                 logger.warning("preflight cleanup: failed to remove %s: %s", path, exc)
 
@@ -504,6 +512,80 @@ async def _make_client(user_agent: str) -> AsyncIterator[httpx.AsyncClient]:
         yield client
 
 
+RUN_MANIFEST_NAME: Final[str] = ".run_manifest.json"
+
+
+def write_run_manifest(
+    target_dir: Path,
+    *,
+    bootstrap_run_id: int,
+    archives: Sequence[ArchiveDownloadResult],
+) -> None:
+    """Persist a per-run archive manifest at ``<bulk>/.run_manifest.json``.
+
+    Phase C preconditions read this to verify each archive landed in
+    the CURRENT bootstrap run, not a previous one. Stale archives left
+    on disk from a prior run will have a different ``bootstrap_run_id``
+    and fail the provenance check (Codex review BLOCKING for #1020).
+    """
+    import json
+
+    manifest = {
+        "bootstrap_run_id": bootstrap_run_id,
+        "archives": [
+            {
+                "name": r.name,
+                "bytes_downloaded": r.bytes_downloaded,
+                "error": r.error,
+            }
+            for r in archives
+            if r.error is None and r.path is not None
+        ],
+    }
+    path = target_dir / RUN_MANIFEST_NAME
+    path.write_text(json.dumps(manifest))
+
+
+def read_run_manifest(target_dir: Path) -> dict | None:
+    """Return the manifest dict at ``<bulk>/.run_manifest.json`` or None."""
+    import json
+
+    path = target_dir / RUN_MANIFEST_NAME
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("read_run_manifest failed: %s", exc)
+        return None
+
+
+def assert_archive_belongs_to_run(
+    target_dir: Path,
+    archive_name: str,
+    *,
+    bootstrap_run_id: int,
+) -> None:
+    """Raise if the archive at ``<bulk>/<archive_name>`` is not in the
+    current run's manifest."""
+    manifest = read_run_manifest(target_dir)
+    if manifest is None:
+        raise RuntimeError(
+            f"PRECONDITION: bulk run manifest missing at {target_dir / RUN_MANIFEST_NAME}; "
+            f"sec_bulk_download did not complete in the current run."
+        )
+    if int(manifest.get("bootstrap_run_id", -1)) != bootstrap_run_id:
+        raise RuntimeError(
+            f"PRECONDITION: bulk manifest run_id={manifest.get('bootstrap_run_id')!r} "
+            f"!= current bootstrap_run_id={bootstrap_run_id}; archive is stale."
+        )
+    archive_names = {a["name"] for a in manifest.get("archives", [])}
+    if archive_name not in archive_names:
+        raise RuntimeError(
+            f"PRECONDITION: archive {archive_name!r} not in current-run manifest; sec_bulk_download did not land it."
+        )
+
+
 async def download_bulk_archives(
     *,
     target_dir: Path,
@@ -591,8 +673,34 @@ async def download_bulk_archives(
 JOB_SEC_BULK_DOWNLOAD: Final[str] = "sec_bulk_download"
 
 
+class BootstrapPartialDownloadError(RuntimeError):
+    """Raised when ``sec_bulk_download`` lands fewer than the full
+    archive inventory.
+
+    The orchestrator catches this and marks the A3 stage ``error``
+    with the failed-archive list, so downstream Phase C stages see
+    the failure (= status `blocked`) rather than no-op'ing on
+    missing files. Closes the silent-success bug observed in the
+    first live attempt: 2 of 14 archives errored mid-transfer,
+    stage marked `success`, C1.a + C2 skipped silently.
+
+    Spec: docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md
+    """
+
+
 def sec_bulk_download_job() -> None:
-    """Zero-arg job invoker for the runtime registry."""
+    """Zero-arg job invoker for the runtime registry.
+
+    Raises ``BootstrapPartialDownloadError`` if the bulk-mode run
+    finished with any archive in error state. Slow-connection
+    fallback (mode=fallback) is NOT treated as an error — it
+    intentionally bypasses Phase C and falls through to the legacy
+    per-CIK chain.
+
+    Writes ``<bulk>/.run_manifest.json`` after a complete success
+    so Phase C preconditions can verify each archive belongs to
+    the current bootstrap run (not a stale prior run's leftover).
+    """
     from app.config import settings
     from app.security.master_key import resolve_data_dir
 
@@ -603,20 +711,58 @@ def sec_bulk_download_job() -> None:
             user_agent=settings.sec_user_agent,
         )
     )
+
+    # Read the current bootstrap_run_id for the manifest stamp.
+    import psycopg
+
+    run_id: int | None = None
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT id FROM bootstrap_runs WHERE status='running' ORDER BY id DESC LIMIT 1")
+                row = cur.fetchone()
+                run_id = int(row[0]) if row else None
+    except Exception:  # noqa: BLE001
+        pass
+
     if result.mode == "bulk":
         ok = sum(1 for r in result.archives if r.error is None)
-        failed = sum(1 for r in result.archives if r.error is not None)
+        failed_archives = [r for r in result.archives if r.error is not None]
         logger.info(
             "sec_bulk_download: mode=bulk mbps=%.1f archives_ok=%d archives_failed=%d",
             result.measured_mbps or 0.0,
             ok,
-            failed,
+            len(failed_archives),
         )
+        if failed_archives:
+            # Surface partial-failure as a stage error so downstream
+            # Phase C stages don't silently no-op on missing archives.
+            details = "; ".join(f"{r.name}: {r.error}" for r in failed_archives)
+            raise BootstrapPartialDownloadError(
+                f"sec_bulk_download landed {ok}/{len(result.archives)} archives; failed: {details}"
+            )
+        # All archives landed; write the run manifest so Phase C
+        # preconditions can verify provenance. The manifest is part
+        # of the A3 success contract — without it Phase C cannot
+        # validate archive run-id, so refusing to mark success when
+        # we couldn't determine the run id keeps the contract honest.
+        if run_id is None:
+            raise BootstrapPartialDownloadError(
+                "sec_bulk_download: could not determine current bootstrap_run_id; "
+                "manifest cannot be written. Refuse to mark stage success without "
+                "manifest provenance."
+            )
+        write_run_manifest(target_dir, bootstrap_run_id=run_id, archives=result.archives)
     elif result.mode == "fallback":
         logger.warning(
             "sec_bulk_download: mode=fallback mbps=%s reason=%s",
             result.measured_mbps,
             result.error,
         )
+    elif result.mode == "skipped_disk":
+        # Disk pre-flight refused — surface as error so operator
+        # knows to free space; downstream Phase C will be `blocked`.
+        raise BootstrapPartialDownloadError(f"sec_bulk_download refused: {result.error}")
     else:
         logger.error("sec_bulk_download: mode=%s error=%s", result.mode, result.error)
+        raise BootstrapPartialDownloadError(f"sec_bulk_download unexpected mode={result.mode!r}: {result.error}")

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -29,6 +29,7 @@ import psycopg
 from app.config import settings
 from app.security.master_key import resolve_data_dir
 from app.services.sec_13f_dataset_ingest import ingest_13f_dataset_archive
+from app.services.sec_bulk_download import build_bulk_archive_inventory
 from app.services.sec_companyfacts_ingest import ingest_companyfacts_archive
 from app.services.sec_insider_dataset_ingest import ingest_insider_dataset_archive
 from app.services.sec_nport_dataset_ingest import ingest_nport_dataset_archive
@@ -71,6 +72,54 @@ def _run_with_conn(fn: Callable[[psycopg.Connection[tuple]], object]) -> None:
         conn.commit()
 
 
+def _current_running_bootstrap_run_id() -> int | None:
+    """Read the currently-running bootstrap_run id, if any.
+
+    Returns ``None`` when no run is in progress — operator may be
+    invoking a Phase C job standalone (without an orchestrator
+    wrapper). In that case preconditions are skipped and the
+    invoker falls back to "if archive exists, ingest it" — same
+    pre-#1020 behaviour.
+    """
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id FROM bootstrap_runs
+                    WHERE status = 'running'
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                )
+                row = cur.fetchone()
+                return int(row[0]) if row else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _record_archive_result(
+    *,
+    bootstrap_run_id: int,
+    stage_key: str,
+    archive_name: str,
+    rows_written: int,
+    rows_skipped: dict[str, int] | None = None,
+) -> None:
+    """Write an audit-trail row in ``bootstrap_archive_results``."""
+    from app.services.bootstrap_preconditions import record_archive_result
+
+    with psycopg.connect(settings.database_url) as conn:
+        record_archive_result(
+            conn,
+            bootstrap_run_id=bootstrap_run_id,
+            stage_key=stage_key,
+            archive_name=archive_name,
+            rows_written=rows_written,
+            rows_skipped=rows_skipped,
+        )
+        conn.commit()
+
+
 def _delete_archive_after_success(archive: Path) -> None:
     """Delete a successfully-ingested archive from the bulk cache.
 
@@ -98,13 +147,35 @@ def _delete_archive_after_success(archive: Path) -> None:
 
 
 def sec_submissions_ingest_job() -> None:
+    from app.services.bootstrap_preconditions import assert_c1a_preconditions
+
+    run_id = _current_running_bootstrap_run_id()
     archive = _archive_path("submissions.zip")
-    if not archive.exists():
-        logger.info("sec_submissions_ingest: archive %s not present, skipping", archive)
+
+    # Within an orchestrated run: preconditions must pass before any
+    # write. Standalone manual invocation (no run): fall back to the
+    # legacy "ingest if archive exists" path.
+    if run_id is not None:
+        with psycopg.connect(settings.database_url) as conn:
+            assert_c1a_preconditions(conn, bootstrap_run_id=run_id, bulk_dir=_bulk_dir())
+        if not archive.exists():
+            from app.services.sec_bulk_download import BootstrapPartialDownloadError
+
+            raise BootstrapPartialDownloadError(
+                f"sec_submissions_ingest: archive {archive} not present; "
+                f"upstream sec_bulk_download did not land submissions.zip."
+            )
+    elif not archive.exists():
+        logger.info("sec_submissions_ingest: archive %s not present, skipping (no run)", archive)
         return
+
+    captured: dict[str, int] = {}
 
     def _do(conn: psycopg.Connection[tuple]) -> None:
         result = ingest_submissions_archive(conn=conn, archive_path=archive)
+        captured["filings_upserted"] = result.filings_upserted
+        captured["profiles_upserted"] = result.profiles_upserted
+        captured["parse_errors"] = result.parse_errors
         logger.info(
             "sec_submissions_ingest: matched=%d filings_upserted=%d profiles=%d parse_errors=%d",
             result.instruments_matched,
@@ -114,6 +185,14 @@ def sec_submissions_ingest_job() -> None:
         )
 
     _run_with_conn(_do)
+    if run_id is not None:
+        _record_archive_result(
+            bootstrap_run_id=run_id,
+            stage_key="sec_submissions_ingest",
+            archive_name="submissions.zip",
+            rows_written=captured.get("filings_upserted", 0),
+            rows_skipped={"parse_errors": captured.get("parse_errors", 0)},
+        )
     _delete_archive_after_success(archive)
 
 
@@ -123,13 +202,31 @@ def sec_submissions_ingest_job() -> None:
 
 
 def sec_companyfacts_ingest_job() -> None:
+    from app.services.bootstrap_preconditions import assert_c2_preconditions
+
+    run_id = _current_running_bootstrap_run_id()
     archive = _archive_path("companyfacts.zip")
-    if not archive.exists():
-        logger.info("sec_companyfacts_ingest: archive %s not present, skipping", archive)
+
+    if run_id is not None:
+        with psycopg.connect(settings.database_url) as conn:
+            assert_c2_preconditions(conn, bootstrap_run_id=run_id, bulk_dir=_bulk_dir())
+        if not archive.exists():
+            from app.services.sec_bulk_download import BootstrapPartialDownloadError
+
+            raise BootstrapPartialDownloadError(
+                f"sec_companyfacts_ingest: archive {archive} not present; "
+                f"upstream sec_bulk_download did not land companyfacts.zip."
+            )
+    elif not archive.exists():
+        logger.info("sec_companyfacts_ingest: archive %s not present, skipping (no run)", archive)
         return
+
+    captured: dict[str, int] = {}
 
     def _do(conn: psycopg.Connection[tuple]) -> None:
         result = ingest_companyfacts_archive(conn=conn, archive_path=archive)
+        captured["facts_upserted"] = result.facts_upserted
+        captured["parse_errors"] = result.parse_errors
         logger.info(
             "sec_companyfacts_ingest: matched=%d facts_upserted=%d parse_errors=%d",
             result.instruments_matched,
@@ -138,6 +235,14 @@ def sec_companyfacts_ingest_job() -> None:
         )
 
     _run_with_conn(_do)
+    if run_id is not None:
+        _record_archive_result(
+            bootstrap_run_id=run_id,
+            stage_key="sec_companyfacts_ingest",
+            archive_name="companyfacts.zip",
+            rows_written=captured.get("facts_upserted", 0),
+            rows_skipped={"parse_errors": captured.get("parse_errors", 0)},
+        )
     _delete_archive_after_success(archive)
 
 
@@ -147,13 +252,48 @@ def sec_companyfacts_ingest_job() -> None:
 
 
 def sec_13f_ingest_from_dataset_job() -> None:
+    from app.services.bootstrap_preconditions import assert_c3_preconditions
+    from app.services.sec_bulk_download import BootstrapPartialDownloadError
+
+    run_id = _current_running_bootstrap_run_id()
     archives = _list_archives_matching("form13f_")
-    if not archives:
-        logger.info("sec_13f_ingest_from_dataset: no form13f_*.zip cached, skipping")
+
+    expected: list[str] | None = None
+    if run_id is not None:
+        expected = [a.name for a in build_bulk_archive_inventory() if a.name.startswith("form13f_")]
+        with psycopg.connect(settings.database_url) as conn:
+            assert_c3_preconditions(
+                conn,
+                bootstrap_run_id=run_id,
+                bulk_dir=_bulk_dir(),
+                expected_archive_names=expected,
+            )
+        # Restrict loop to the expected manifest-backed names so
+        # stale archives left on disk from a prior run are NOT
+        # ingested under the current run.
+        archives = [a for a in archives if a.name in set(expected)]
+        # All expected files MUST be on disk after manifest provenance
+        # passes; missing physical file is a partial-download failure.
+        present_names = {a.name for a in archives}
+        missing = [n for n in expected if n not in present_names]
+        if missing:
+            from app.services.sec_bulk_download import BootstrapPartialDownloadError
+
+            raise BootstrapPartialDownloadError(
+                f"expected archives missing on disk after preconditions passed: {missing}"
+            )
+        if not archives:
+            raise BootstrapPartialDownloadError(
+                "sec_13f_ingest_from_dataset: no form13f_*.zip cached; "
+                "upstream sec_bulk_download did not land 13F archives."
+            )
+    elif not archives:
+        logger.info("sec_13f_ingest_from_dataset: no form13f_*.zip cached, skipping (no run)")
         return
 
     # Per-archive commit so an exception on archive N does not roll
-    # back archives 1..N-1's writes (Codex review WARNING for PR #1035).
+    # back archives 1..N-1's writes.
+    failed_archives: list[str] = []
     total_written = 0
     total_skipped = 0
     for archive in archives:
@@ -161,13 +301,22 @@ def sec_13f_ingest_from_dataset_job() -> None:
             try:
                 result = ingest_13f_dataset_archive(conn=conn, archive_path=archive)
                 conn.commit()
-            except Exception:
+            except Exception as exc:  # noqa: BLE001
                 conn.rollback()
                 logger.exception("sec_13f_ingest_from_dataset: archive=%s failed", archive.name)
+                failed_archives.append(f"{archive.name}: {exc}")
                 continue
         _delete_archive_after_success(archive)
         total_written += result.rows_written
         total_skipped += result.rows_skipped_unresolved_cusip
+        if run_id is not None:
+            _record_archive_result(
+                bootstrap_run_id=run_id,
+                stage_key="sec_13f_ingest_from_dataset",
+                archive_name=archive.name,
+                rows_written=result.rows_written,
+                rows_skipped={"unresolved_cusip": result.rows_skipped_unresolved_cusip},
+            )
         logger.info(
             "sec_13f_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d",
             archive.name,
@@ -179,6 +328,15 @@ def sec_13f_ingest_from_dataset_job() -> None:
         total_written,
         total_skipped,
     )
+    if failed_archives:
+        raise RuntimeError(
+            f"sec_13f_ingest_from_dataset: {len(failed_archives)} archives failed: " + "; ".join(failed_archives)
+        )
+    if run_id is not None and total_written == 0:
+        raise RuntimeError(
+            f"sec_13f_ingest_from_dataset: aggregate rows_written=0 across {len(archives)} archives; "
+            f"unresolved_cusip={total_skipped}. Check CUSIP coverage."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -187,24 +345,64 @@ def sec_13f_ingest_from_dataset_job() -> None:
 
 
 def sec_insider_ingest_from_dataset_job() -> None:
+    from app.services.bootstrap_preconditions import assert_c4_preconditions
+    from app.services.sec_bulk_download import BootstrapPartialDownloadError
+
+    run_id = _current_running_bootstrap_run_id()
     archives = _list_archives_matching("insider_")
-    if not archives:
-        logger.info("sec_insider_ingest_from_dataset: no insider_*.zip cached, skipping")
+
+    expected: list[str] | None = None
+    if run_id is not None:
+        expected = [a.name for a in build_bulk_archive_inventory() if a.name.startswith("insider_")]
+        with psycopg.connect(settings.database_url) as conn:
+            assert_c4_preconditions(
+                conn,
+                bootstrap_run_id=run_id,
+                bulk_dir=_bulk_dir(),
+                expected_archive_names=expected,
+            )
+        archives = [a for a in archives if a.name in set(expected)]
+        # All expected files MUST be on disk after manifest provenance
+        # passes; missing physical file is a partial-download failure.
+        present_names = {a.name for a in archives}
+        missing = [n for n in expected if n not in present_names]
+        if missing:
+            from app.services.sec_bulk_download import BootstrapPartialDownloadError
+
+            raise BootstrapPartialDownloadError(
+                f"expected archives missing on disk after preconditions passed: {missing}"
+            )
+        if not archives:
+            raise BootstrapPartialDownloadError(
+                "sec_insider_ingest_from_dataset: no insider_*.zip cached; "
+                "upstream sec_bulk_download did not land insider archives."
+            )
+    elif not archives:
+        logger.info("sec_insider_ingest_from_dataset: no insider_*.zip cached, skipping (no run)")
         return
 
-    # Per-archive commit per Codex review WARNING for PR #1035.
+    failed_archives: list[str] = []
     total_written = 0
     for archive in archives:
         with psycopg.connect(settings.database_url) as conn:
             try:
                 result = ingest_insider_dataset_archive(conn=conn, archive_path=archive)
                 conn.commit()
-            except Exception:
+            except Exception as exc:  # noqa: BLE001
                 conn.rollback()
                 logger.exception("sec_insider_ingest_from_dataset: archive=%s failed", archive.name)
+                failed_archives.append(f"{archive.name}: {exc}")
                 continue
         _delete_archive_after_success(archive)
         total_written += result.rows_written
+        if run_id is not None:
+            _record_archive_result(
+                bootstrap_run_id=run_id,
+                stage_key="sec_insider_ingest_from_dataset",
+                archive_name=archive.name,
+                rows_written=result.rows_written,
+                rows_skipped={"unresolved_cik": result.rows_skipped_unresolved_cik},
+            )
         logger.info(
             "sec_insider_ingest_from_dataset: archive=%s rows_written=%d unresolved_cik=%d",
             archive.name,
@@ -215,6 +413,15 @@ def sec_insider_ingest_from_dataset_job() -> None:
         "sec_insider_ingest_from_dataset: total_rows_written=%d",
         total_written,
     )
+    if failed_archives:
+        raise RuntimeError(
+            f"sec_insider_ingest_from_dataset: {len(failed_archives)} archives failed: " + "; ".join(failed_archives)
+        )
+    if run_id is not None and total_written == 0:
+        raise RuntimeError(
+            f"sec_insider_ingest_from_dataset: aggregate rows_written=0 across {len(archives)} archives. "
+            "Check CIK coverage."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -223,24 +430,67 @@ def sec_insider_ingest_from_dataset_job() -> None:
 
 
 def sec_nport_ingest_from_dataset_job() -> None:
+    from app.services.bootstrap_preconditions import assert_c5_preconditions
+    from app.services.sec_bulk_download import BootstrapPartialDownloadError
+
+    run_id = _current_running_bootstrap_run_id()
     archives = _list_archives_matching("nport_")
-    if not archives:
-        logger.info("sec_nport_ingest_from_dataset: no nport_*.zip cached, skipping")
+
+    expected: list[str] | None = None
+    if run_id is not None:
+        expected = [a.name for a in build_bulk_archive_inventory() if a.name.startswith("nport_")]
+        with psycopg.connect(settings.database_url) as conn:
+            assert_c5_preconditions(
+                conn,
+                bootstrap_run_id=run_id,
+                bulk_dir=_bulk_dir(),
+                expected_archive_names=expected,
+            )
+        archives = [a for a in archives if a.name in set(expected)]
+        # All expected files MUST be on disk after manifest provenance
+        # passes; missing physical file is a partial-download failure.
+        present_names = {a.name for a in archives}
+        missing = [n for n in expected if n not in present_names]
+        if missing:
+            from app.services.sec_bulk_download import BootstrapPartialDownloadError
+
+            raise BootstrapPartialDownloadError(
+                f"expected archives missing on disk after preconditions passed: {missing}"
+            )
+        if not archives:
+            raise BootstrapPartialDownloadError(
+                "sec_nport_ingest_from_dataset: no nport_*.zip cached; "
+                "upstream sec_bulk_download did not land NPORT archives."
+            )
+    elif not archives:
+        logger.info("sec_nport_ingest_from_dataset: no nport_*.zip cached, skipping (no run)")
         return
 
-    # Per-archive commit per Codex review WARNING for PR #1035.
+    failed_archives: list[str] = []
     total_written = 0
     for archive in archives:
         with psycopg.connect(settings.database_url) as conn:
             try:
                 result = ingest_nport_dataset_archive(conn=conn, archive_path=archive)
                 conn.commit()
-            except Exception:
+            except Exception as exc:  # noqa: BLE001
                 conn.rollback()
                 logger.exception("sec_nport_ingest_from_dataset: archive=%s failed", archive.name)
+                failed_archives.append(f"{archive.name}: {exc}")
                 continue
         _delete_archive_after_success(archive)
         total_written += result.rows_written
+        if run_id is not None:
+            _record_archive_result(
+                bootstrap_run_id=run_id,
+                stage_key="sec_nport_ingest_from_dataset",
+                archive_name=archive.name,
+                rows_written=result.rows_written,
+                rows_skipped={
+                    "unresolved_cusip": result.rows_skipped_unresolved_cusip,
+                    "non_equity": result.rows_skipped_non_equity,
+                },
+            )
         logger.info(
             "sec_nport_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d non_equity=%d",
             archive.name,
@@ -252,3 +502,12 @@ def sec_nport_ingest_from_dataset_job() -> None:
         "sec_nport_ingest_from_dataset: total_rows_written=%d",
         total_written,
     )
+    if failed_archives:
+        raise RuntimeError(
+            f"sec_nport_ingest_from_dataset: {len(failed_archives)} archives failed: " + "; ".join(failed_archives)
+        )
+    if run_id is not None and total_written == 0:
+        raise RuntimeError(
+            f"sec_nport_ingest_from_dataset: aggregate rows_written=0 across {len(archives)} archives. "
+            "Check CUSIP coverage."
+        )

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -75,26 +75,24 @@ def _run_with_conn(fn: Callable[[psycopg.Connection[tuple]], object]) -> None:
 def _current_running_bootstrap_run_id() -> int | None:
     """Read the currently-running bootstrap_run id, if any.
 
-    Returns ``None`` when no run is in progress — operator may be
-    invoking a Phase C job standalone (without an orchestrator
-    wrapper). In that case preconditions are skipped and the
-    invoker falls back to "if archive exists, ingest it" — same
-    pre-#1020 behaviour.
+    Returns ``None`` only when there is genuinely no running run —
+    the operator may be invoking a Phase C job standalone. A DB
+    error here is RAISED, not swallowed, because returning None on
+    a connection hiccup would make C-stages skip every precondition
+    and silently no-op (the very failure mode #1020 fixes).
+    PR review WARNING (bot, PR #1038).
     """
-    try:
-        with psycopg.connect(settings.database_url) as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT id FROM bootstrap_runs
-                    WHERE status = 'running'
-                    ORDER BY id DESC LIMIT 1
-                    """,
-                )
-                row = cur.fetchone()
-                return int(row[0]) if row else None
-    except Exception:  # noqa: BLE001
-        return None
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id FROM bootstrap_runs
+                WHERE status = 'running'
+                ORDER BY id DESC LIMIT 1
+                """,
+            )
+            row = cur.fetchone()
+            return int(row[0]) if row else None
 
 
 def _record_archive_result(

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -177,7 +177,27 @@ JOB_SEC_SUBMISSIONS_FILES_WALK = "sec_submissions_files_walk"
 
 
 def sec_submissions_files_walk_job() -> None:
-    """Zero-arg job invoker for the runtime registry."""
+    """Zero-arg job invoker for the runtime registry.
+
+    Within an orchestrated bootstrap run, validates C1.a's
+    rows_written > 0 before walking. Records its own per-run
+    archive_result row so D-stages can verify provenance.
+    """
+    from app.services.bootstrap_preconditions import (
+        assert_c1b_preconditions,
+        record_archive_result,
+    )
+
+    # Find current bootstrap_run.
+    run_id: int | None = None
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM bootstrap_runs WHERE status='running' ORDER BY id DESC LIMIT 1")
+            row = cur.fetchone()
+            run_id = int(row[0]) if row else None
+        if run_id is not None:
+            assert_c1b_preconditions(conn, bootstrap_run_id=run_id)
+
     with psycopg.connect(settings.database_url) as conn:
         result = walk_files_pages(conn=conn)
         conn.commit()
@@ -188,3 +208,14 @@ def sec_submissions_files_walk_job() -> None:
         result.filings_upserted,
         result.parse_errors,
     )
+    if run_id is not None:
+        with psycopg.connect(settings.database_url) as conn:
+            record_archive_result(
+                conn,
+                bootstrap_run_id=run_id,
+                stage_key="sec_submissions_files_walk",
+                archive_name="__job__",
+                rows_written=result.filings_upserted,
+                rows_skipped={"parse_errors": result.parse_errors},
+            )
+            conn.commit()

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -209,13 +209,26 @@ def sec_submissions_files_walk_job() -> None:
         result.parse_errors,
     )
     if run_id is not None:
-        with psycopg.connect(settings.database_url) as conn:
-            record_archive_result(
-                conn,
-                bootstrap_run_id=run_id,
-                stage_key="sec_submissions_files_walk",
-                archive_name="__job__",
-                rows_written=result.filings_upserted,
-                rows_skipped={"parse_errors": result.parse_errors},
+        # The walker has already committed its writes; a failure of
+        # the post-commit audit row must NOT propagate to the
+        # orchestrator (which would mark the stage `error` and a
+        # later retry would re-run the walker AND fail
+        # ``assert_c1b_preconditions`` because the audit row is
+        # missing — permanently blocking C1.b on a transient DB
+        # hiccup). PR review WARNING (bot, PR #1038).
+        try:
+            with psycopg.connect(settings.database_url) as conn:
+                record_archive_result(
+                    conn,
+                    bootstrap_run_id=run_id,
+                    stage_key="sec_submissions_files_walk",
+                    archive_name="__job__",
+                    rows_written=result.filings_upserted,
+                    rows_skipped={"parse_errors": result.parse_errors},
+                )
+                conn.commit()
+        except Exception as exc:  # noqa: BLE001 — audit must not block stage
+            logger.warning(
+                "sec_submissions_files_walk: failed to record __job__ audit row (walker already committed): %s",
+                exc,
             )
-            conn.commit()

--- a/sql/130_bootstrap_archive_results.sql
+++ b/sql/130_bootstrap_archive_results.sql
@@ -1,0 +1,35 @@
+-- 130_bootstrap_archive_results.sql
+--
+-- Per-bootstrap-run audit trail for B-stage and C-stage archive
+-- writes (#1020 ETL orchestration design).
+--
+-- Each Phase C ingester writes one row per processed archive
+-- (e.g. ('sec_submissions_ingest', 'submissions.zip')). Each B-stage
+-- writes one row per scheduler-job invocation
+-- (archive_name = '__job__').
+--
+-- The row's existence proves "the stage ran in the current bootstrap
+-- run" — the freshness invariant downstream stages query before
+-- writing. ``rows_written`` is operator telemetry only; an idempotent
+-- re-run against a populated reference table legitimately reports 0
+-- upserts and that does NOT defeat the freshness proof.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS bootstrap_archive_results (
+    bootstrap_run_id  BIGINT NOT NULL REFERENCES bootstrap_runs(id) ON DELETE CASCADE,
+    stage_key         TEXT NOT NULL,
+    archive_name      TEXT NOT NULL,
+    rows_written      BIGINT NOT NULL DEFAULT 0,
+    rows_skipped      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    completed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (bootstrap_run_id, stage_key, archive_name)
+);
+
+COMMENT ON TABLE bootstrap_archive_results IS
+    'Per-bootstrap-run per-archive write audit. Existence of a row proves the stage ran in this run; rows_written is telemetry only. Spec: docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md.';
+
+CREATE INDEX IF NOT EXISTS idx_bootstrap_archive_results_run
+    ON bootstrap_archive_results (bootstrap_run_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes the silent-success bug the first live attempt revealed: `sec_bulk_download` marked stage success when 2 of 14 archives errored; Phase C no-op'd silently.

- New `bootstrap_archive_results` table (sql/130) — per-run per-archive write provenance.
- New `app/services/bootstrap_preconditions.py` — provenance + coverage-ratio gates.
- `sec_bulk_download` writes `.run_manifest.json` only on full success; raises `BootstrapPartialDownloadError` on any per-archive failure.
- Pre-flight wipes complete .zip + .partial + manifest each run (stale archives can never poison the current-run manifest).
- Phase C invokers require all 4/8/4 expected archives in manifest, restrict ingest loop to manifest-backed names, raise on aggregate `rows_written == 0`.
- C1.b precondition checks C1.a wrote ≥ 1 row.
- `_run_one_stage` auto-records `__job__` row on stage success so B-stage scheduler jobs participate without code change.

## Test plan

- [x] `uv run ruff check` + `uv run ruff format --check` clean.
- [x] `uv run pyright` clean.
- [x] Smoke check: coverage queries return CoverageRatio against fresh wiped DB (cohort=0).
- [x] Codex pre-push APPROVE (4 rounds).

Refs #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)