### PR TITLE
feat(#1020): Phase C concurrent dispatch + blocked status + lane model

### DIFF
--- a/app/api/bootstrap.py
+++ b/app/api/bootstrap.py
@@ -60,8 +60,8 @@ router = APIRouter(
 
 
 BootstrapApiStatus = Literal["pending", "running", "complete", "partial_error"]
-LaneApi = Literal["init", "etoro", "sec"]
-StageApiStatus = Literal["pending", "running", "success", "error", "skipped"]
+LaneApi = Literal["init", "etoro", "sec", "sec_rate", "sec_bulk_download", "db"]
+StageApiStatus = Literal["pending", "running", "success", "error", "skipped", "blocked"]
 
 
 class BootstrapStageResponse(BaseModel):

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -432,22 +432,29 @@ def _phase_batched_dispatch(
         ready: list[_RunnableStage] = []
         for key in pending_keys:
             stage = by_key[key]
+            # Stages whose required upstream is unknown to this run
+            # (not in `statuses`) are treated as a failed dependency
+            # too — without this guard, a typo in _STAGE_REQUIRES
+            # would let the stage dispatch as if the dep were
+            # satisfied. Codex review BLOCKING (PR #1039).
+            unknown_reqs = [req for req in stage.requires if req not in statuses]
             failed_reqs = [req for req in stage.requires if req in statuses and statuses[req] in ("error", "blocked")]
             unmet_reqs = [req for req in stage.requires if req in statuses and statuses[req] == "pending"]
-            if failed_reqs:
+            if unknown_reqs or failed_reqs:
+                reason_parts = list(failed_reqs) + [f"{r} (unknown to run)" for r in unknown_reqs]
                 with psycopg.connect(database_url) as conn:
                     mark_stage_blocked(
                         conn,
                         run_id=run_id,
                         stage_key=key,
-                        reason=f"upstream stage(s) failed/blocked: {', '.join(failed_reqs)}",
+                        reason=f"upstream stage(s) failed/blocked: {', '.join(reason_parts)}",
                     )
                     conn.commit()
                 statuses[key] = "blocked"
                 logger.warning(
                     "bootstrap dispatcher: %s BLOCKED (upstream %s)",
                     key,
-                    failed_reqs,
+                    reason_parts,
                 )
                 continue
             if unmet_reqs:
@@ -455,10 +462,27 @@ def _phase_batched_dispatch(
             ready.append(stage)
 
         if not ready:
-            # All remaining pending stages have unmet but in-progress
-            # requirements that are no longer pending themselves —
-            # which can't happen given our state machine. Defensive:
-            # break to avoid infinite loop.
+            # No stage advanced this iteration. Any stage still in
+            # `pending` means its requirements are stuck (e.g. all
+            # in unmet_reqs) — the dispatcher cannot make progress.
+            # Mark them blocked so finalize_run sees a terminal state
+            # and the operator panel doesn't show "pending forever".
+            # Codex review BLOCKING (PR #1039).
+            stuck_keys = [k for k, s in statuses.items() if s == "pending"]
+            for key in stuck_keys:
+                with psycopg.connect(database_url) as conn:
+                    mark_stage_blocked(
+                        conn,
+                        run_id=run_id,
+                        stage_key=key,
+                        reason="dispatcher could not resolve dependencies; stage abandoned",
+                    )
+                    conn.commit()
+                statuses[key] = "blocked"
+                logger.warning(
+                    "bootstrap dispatcher: %s ABANDONED (deadlock in dependency graph)",
+                    key,
+                )
             break
 
         # Group ready by lane; dispatch each lane's batch concurrently.

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -35,10 +35,10 @@ parallel manual / scheduled trigger cannot run twice simultaneously.
 from __future__ import annotations
 
 import logging
-import threading
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import date, timedelta
+from typing import Final
 
 import psycopg
 
@@ -47,6 +47,7 @@ from app.jobs.locks import JobAlreadyRunning, JobLock
 from app.services.bootstrap_state import (
     StageSpec,
     finalize_run,
+    mark_stage_blocked,
     mark_stage_error,
     mark_stage_running,
     mark_stage_success,
@@ -80,6 +81,91 @@ def _spec(stage_key: str, stage_order: int, lane: str, job_name: str) -> StageSp
     return StageSpec(stage_key=stage_key, stage_order=stage_order, lane=lane, job_name=job_name)  # type: ignore[arg-type]
 
 
+# ---------------------------------------------------------------------------
+# Lane concurrency model (#1020)
+# ---------------------------------------------------------------------------
+#
+# Each lane has a max-concurrency cap. Stages in the same lane share
+# a budget (rate-bound: SEC clock; or DB-bound: psycopg conn pool).
+# Stages in different lanes run in parallel.
+
+_LANE_MAX_CONCURRENCY: Final[dict[str, int]] = {
+    "init": 1,
+    "etoro": 1,
+    "sec": 1,  # legacy catch-all; preserved for migration compat
+    "sec_rate": 1,  # SEC per-IP rate clock
+    "sec_bulk_download": 1,
+    "db": 5,  # DB-bound, parallel-able
+}
+
+
+# Stage-key dependency graph: which `requires` keys must be `success`
+# before this stage can run. If any required stage is `error` or
+# `blocked`, this stage transitions to `blocked` (orchestrator
+# never invokes the underlying job).
+_STAGE_REQUIRES: Final[dict[str, tuple[str, ...]]] = {
+    # Phase A
+    "universe_sync": (),
+    "candle_refresh": ("universe_sync",),
+    "cusip_universe_backfill": ("universe_sync",),
+    "sec_13f_filer_directory_sync": ("universe_sync",),
+    "sec_nport_filer_directory_sync": ("universe_sync",),
+    "cik_refresh": ("universe_sync",),
+    "sec_bulk_download": ("universe_sync",),
+    # Phase C — DB-bound bulk ingesters (parallel-able in db lane)
+    "sec_submissions_ingest": ("sec_bulk_download", "cik_refresh"),
+    "sec_companyfacts_ingest": ("sec_bulk_download", "cik_refresh"),
+    "sec_13f_ingest_from_dataset": ("sec_bulk_download", "cusip_universe_backfill"),
+    "sec_insider_ingest_from_dataset": ("sec_bulk_download", "cik_refresh"),
+    "sec_nport_ingest_from_dataset": ("sec_bulk_download", "cusip_universe_backfill"),
+    # Phase C' — secondary-pages walker (rate-bound)
+    "sec_submissions_files_walk": ("sec_submissions_ingest",),
+    # Legacy chain — keeps fallback if any bulk path failed.
+    # Required upstream: universe_sync (B-stages handled by graph).
+    "filings_history_seed": ("universe_sync",),
+    "sec_first_install_drain": ("universe_sync",),
+    "sec_def14a_bootstrap": ("sec_submissions_ingest", "sec_submissions_files_walk"),
+    "sec_business_summary_bootstrap": ("sec_submissions_ingest", "sec_submissions_files_walk"),
+    "sec_insider_transactions_backfill": ("universe_sync",),
+    "sec_form3_ingest": ("universe_sync",),
+    "sec_8k_events_ingest": ("sec_submissions_ingest", "sec_submissions_files_walk"),
+    "sec_13f_recent_sweep": ("universe_sync",),
+    "sec_n_port_ingest": ("universe_sync",),
+    "ownership_observations_backfill": (
+        "sec_13f_ingest_from_dataset",
+        "sec_insider_ingest_from_dataset",
+        "sec_nport_ingest_from_dataset",
+    ),
+    "fundamentals_sync": ("sec_companyfacts_ingest",),
+}
+
+
+# Lane override map — stage_key → lane name, used by the new
+# concurrency dispatcher. Stages NOT in this map default to their
+# StageSpec.lane field (so existing 17-stage runs still work).
+_STAGE_LANE_OVERRIDES: Final[dict[str, str]] = {
+    "cusip_universe_backfill": "sec_rate",
+    "sec_13f_filer_directory_sync": "sec_rate",
+    "sec_nport_filer_directory_sync": "sec_rate",
+    "cik_refresh": "sec_rate",
+    "sec_bulk_download": "sec_bulk_download",
+    "sec_submissions_ingest": "db",
+    "sec_companyfacts_ingest": "db",
+    "sec_13f_ingest_from_dataset": "db",
+    "sec_insider_ingest_from_dataset": "db",
+    "sec_nport_ingest_from_dataset": "db",
+    "sec_submissions_files_walk": "sec_rate",
+    "sec_def14a_bootstrap": "sec_rate",
+    "sec_business_summary_bootstrap": "sec_rate",
+    "sec_8k_events_ingest": "sec_rate",
+    "sec_13f_recent_sweep": "sec_rate",
+}
+
+
+def _effective_lane(stage_key: str, default_lane: str) -> str:
+    return _STAGE_LANE_OVERRIDES.get(stage_key, default_lane)
+
+
 # Bulk-archive job names for the #1020 first-install bulk-datasets-first
 # pipeline. Re-exported from the canonical owners so duplicate-constant
 # drift is impossible (Codex review WARNING for PR #1035).
@@ -98,38 +184,37 @@ from app.services.sec_submissions_files_walk import (  # noqa: E402
 _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # Phase A (init, sequential)
     _spec("universe_sync", 1, "init", "nightly_universe_sync"),
-    # Phase B — eToro lane
+    # eToro lane (separate rate budget; runs concurrent with SEC).
     _spec("candle_refresh", 2, "etoro", "daily_candle_refresh"),
-    # Phase B — SEC lane (sequential, shared rate budget).
-    _spec("cusip_universe_backfill", 3, "sec", "cusip_universe_backfill"),
-    _spec("sec_13f_filer_directory_sync", 4, "sec", "sec_13f_filer_directory_sync"),
-    _spec("sec_nport_filer_directory_sync", 5, "sec", "sec_nport_filer_directory_sync"),
-    _spec("cik_refresh", 6, "sec", JOB_DAILY_CIK_REFRESH),
+    # SEC reference lane — share per-IP rate clock.
+    _spec("cusip_universe_backfill", 3, "sec_rate", "cusip_universe_backfill"),
+    _spec("sec_13f_filer_directory_sync", 4, "sec_rate", "sec_13f_filer_directory_sync"),
+    _spec("sec_nport_filer_directory_sync", 5, "sec_rate", "sec_nport_filer_directory_sync"),
+    _spec("cik_refresh", 6, "sec_rate", JOB_DAILY_CIK_REFRESH),
     # Phase A3 — bulk archive download (#1020). Ships the heavy data
     # in <10 min on a fast connection; the C-stages below ingest
     # locally with no rate-budget cost.
-    _spec("sec_bulk_download", 7, "sec", JOB_SEC_BULK_DOWNLOAD),
-    # Phase C — DB-bound bulk ingesters (#1020). Each skips silently
-    # if its archive is missing (slow-connection bypass).
-    _spec("sec_submissions_ingest", 8, "sec", JOB_SEC_SUBMISSIONS_INGEST),
-    _spec("sec_companyfacts_ingest", 9, "sec", JOB_SEC_COMPANYFACTS_INGEST),
-    _spec("sec_13f_ingest_from_dataset", 10, "sec", JOB_SEC_13F_INGEST_FROM_DATASET),
-    _spec("sec_insider_ingest_from_dataset", 11, "sec", JOB_SEC_INSIDER_INGEST_FROM_DATASET),
-    _spec("sec_nport_ingest_from_dataset", 12, "sec", JOB_SEC_NPORT_INGEST_FROM_DATASET),
-    # Phase C' — per-CIK secondary-pages walk for deep-history parity
-    # with the existing per-CIK drain (#1020).
-    _spec("sec_submissions_files_walk", 13, "sec", JOB_SEC_SUBMISSIONS_FILES_WALK),
+    _spec("sec_bulk_download", 7, "sec_bulk_download", JOB_SEC_BULK_DOWNLOAD),
+    # Phase C — DB-bound bulk ingesters (#1020). Parallel within db
+    # lane (max_concurrency=5).
+    _spec("sec_submissions_ingest", 8, "db", JOB_SEC_SUBMISSIONS_INGEST),
+    _spec("sec_companyfacts_ingest", 9, "db", JOB_SEC_COMPANYFACTS_INGEST),
+    _spec("sec_13f_ingest_from_dataset", 10, "db", JOB_SEC_13F_INGEST_FROM_DATASET),
+    _spec("sec_insider_ingest_from_dataset", 11, "db", JOB_SEC_INSIDER_INGEST_FROM_DATASET),
+    _spec("sec_nport_ingest_from_dataset", 12, "db", JOB_SEC_NPORT_INGEST_FROM_DATASET),
+    # Phase C' — per-CIK secondary-pages walk for deep-history parity.
+    _spec("sec_submissions_files_walk", 13, "sec_rate", JOB_SEC_SUBMISSIONS_FILES_WALK),
     # Legacy per-filing stages — kept as a fallback path. After the
     # bulk pass these are largely idempotent DB no-ops on populated
     # observation tables; on the slow-connection bypass path they are
     # the primary write path.
-    _spec("filings_history_seed", 14, "sec", JOB_BOOTSTRAP_FILINGS_HISTORY_SEED),
-    _spec("sec_first_install_drain", 15, "sec", JOB_SEC_FIRST_INSTALL_DRAIN),
-    _spec("sec_def14a_bootstrap", 16, "sec", "sec_def14a_bootstrap"),
-    _spec("sec_business_summary_bootstrap", 17, "sec", "sec_business_summary_bootstrap"),
-    _spec("sec_insider_transactions_backfill", 18, "sec", "sec_insider_transactions_backfill"),
-    _spec("sec_form3_ingest", 19, "sec", "sec_form3_ingest"),
-    _spec("sec_8k_events_ingest", 20, "sec", "sec_8k_events_ingest"),
+    _spec("filings_history_seed", 14, "sec_rate", JOB_BOOTSTRAP_FILINGS_HISTORY_SEED),
+    _spec("sec_first_install_drain", 15, "sec_rate", JOB_SEC_FIRST_INSTALL_DRAIN),
+    _spec("sec_def14a_bootstrap", 16, "sec_rate", "sec_def14a_bootstrap"),
+    _spec("sec_business_summary_bootstrap", 17, "sec_rate", "sec_business_summary_bootstrap"),
+    _spec("sec_insider_transactions_backfill", 18, "sec_rate", "sec_insider_transactions_backfill"),
+    _spec("sec_form3_ingest", 19, "sec_rate", "sec_form3_ingest"),
+    _spec("sec_8k_events_ingest", 20, "sec_rate", "sec_8k_events_ingest"),
     # #1008 — first-install bootstrap uses a recency-bounded sweep
     # (last 4 quarters, ~12 months) instead of the full historical
     # sweep. Walking decades of pre-2013 filings yields zero rows
@@ -138,10 +223,10 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # keeps the full historical sweep via JOB_SEC_13F_QUARTERLY_SWEEP.
     # On the bulk path (#1020) C3 has already populated
     # ownership_institutions_observations; this stage tops up.
-    _spec("sec_13f_recent_sweep", 21, "sec", JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP),
-    _spec("sec_n_port_ingest", 22, "sec", "sec_n_port_ingest"),
-    _spec("ownership_observations_backfill", 23, "sec", "ownership_observations_backfill"),
-    _spec("fundamentals_sync", 24, "sec", "fundamentals_sync"),
+    _spec("sec_13f_recent_sweep", 21, "sec_rate", JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP),
+    _spec("sec_n_port_ingest", 22, "sec_rate", "sec_n_port_ingest"),
+    _spec("ownership_observations_backfill", 23, "db", "ownership_observations_backfill"),
+    _spec("fundamentals_sync", 24, "db", "fundamentals_sync"),
 )
 
 
@@ -290,12 +375,149 @@ def _run_lane(
 # ---------------------------------------------------------------------------
 
 
-def run_bootstrap_orchestrator() -> None:
-    """``_INVOKERS['bootstrap_orchestrator']`` — drive a queued run.
+@dataclass
+class _RunnableStage:
+    stage_key: str
+    job_name: str
+    lane: str
+    invoker: Callable[[], None]
+    requires: tuple[str, ...]
 
-    Reads the latest ``bootstrap_runs`` row + its stages, runs Phase A
-    sequentially, spawns two lane threads for Phase B in parallel,
-    joins both, then finalises the run state.
+
+def _phase_batched_dispatch(
+    *,
+    run_id: int,
+    runnable: list[_RunnableStage],
+    database_url: str,
+    preexisting_statuses: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Dispatch ``runnable`` stages in phase-batched fashion with lane concurrency.
+
+    Returns ``{stage_key: terminal_status}`` (success / error / blocked /
+    skipped) for every input stage.
+
+    Algorithm:
+
+      1. Build per-stage status map (initially ``pending``).
+      2. While any stage is pending: collect every pending stage whose
+         ``requires`` are all ``success`` → "ready batch". Stages
+         whose any required dep is ``error``/``blocked`` →
+         immediately propagate to ``blocked`` (no invocation).
+      3. Group the ready batch by lane. For each lane, run up to
+         ``_LANE_MAX_CONCURRENCY[lane]`` stages concurrently via a
+         per-lane ``ThreadPoolExecutor``.
+      4. Join all lane workers; refresh status from the DB; loop.
+      5. Stop when no stage is pending.
+
+    Stages with no `requires` start in the first batch. The dispatcher
+    is fully data-driven by ``_STAGE_REQUIRES`` + ``_STAGE_LANE_OVERRIDES``.
+    """
+    from concurrent.futures import ThreadPoolExecutor, wait
+
+    by_key = {r.stage_key: r for r in runnable}
+    statuses: dict[str, str] = {r.stage_key: "pending" for r in runnable}
+    # Merge in upstream stages already in a terminal state so the
+    # dependency check sees them.
+    if preexisting_statuses:
+        for key, status in preexisting_statuses.items():
+            if key not in statuses:
+                statuses[key] = status
+
+    while True:
+        pending_keys = [k for k, s in statuses.items() if s == "pending"]
+        if not pending_keys:
+            break
+
+        # Propagate blocked status from upstream failure.
+        ready: list[_RunnableStage] = []
+        for key in pending_keys:
+            stage = by_key[key]
+            failed_reqs = [req for req in stage.requires if req in statuses and statuses[req] in ("error", "blocked")]
+            unmet_reqs = [req for req in stage.requires if req in statuses and statuses[req] == "pending"]
+            if failed_reqs:
+                with psycopg.connect(database_url) as conn:
+                    mark_stage_blocked(
+                        conn,
+                        run_id=run_id,
+                        stage_key=key,
+                        reason=f"upstream stage(s) failed/blocked: {', '.join(failed_reqs)}",
+                    )
+                    conn.commit()
+                statuses[key] = "blocked"
+                logger.warning(
+                    "bootstrap dispatcher: %s BLOCKED (upstream %s)",
+                    key,
+                    failed_reqs,
+                )
+                continue
+            if unmet_reqs:
+                continue  # wait for next iteration
+            ready.append(stage)
+
+        if not ready:
+            # All remaining pending stages have unmet but in-progress
+            # requirements that are no longer pending themselves —
+            # which can't happen given our state machine. Defensive:
+            # break to avoid infinite loop.
+            break
+
+        # Group ready by lane; dispatch each lane's batch concurrently.
+        by_lane_batch: dict[str, list[_RunnableStage]] = {}
+        for stage in ready:
+            by_lane_batch.setdefault(stage.lane, []).append(stage)
+
+        logger.info(
+            "bootstrap dispatcher: ready batch — %s",
+            {lane: [s.stage_key for s in stages] for lane, stages in by_lane_batch.items()},
+        )
+
+        # One ThreadPoolExecutor per lane, sized to lane's concurrency.
+        # Lanes run concurrently with each other; within a lane,
+        # max_concurrency bounds the in-flight count.
+        lane_executors: list[ThreadPoolExecutor] = []
+        all_futures = []
+        try:
+            for lane, stages in by_lane_batch.items():
+                max_concurrency = _LANE_MAX_CONCURRENCY.get(lane, 1)
+                ex = ThreadPoolExecutor(
+                    max_workers=max_concurrency,
+                    thread_name_prefix=f"bootstrap-{lane}",
+                )
+                lane_executors.append(ex)
+                for stage in stages:
+                    fut = ex.submit(
+                        _run_one_stage,
+                        run_id=run_id,
+                        stage_key=stage.stage_key,
+                        job_name=stage.job_name,
+                        invoker=stage.invoker,
+                        database_url=database_url,
+                    )
+                    all_futures.append((stage.stage_key, fut))
+            wait([f for _, f in all_futures])
+        finally:
+            for ex in lane_executors:
+                ex.shutdown(wait=True)
+
+        for stage_key, fut in all_futures:
+            outcome = fut.result()
+            statuses[stage_key] = "success" if outcome.success else "error"
+            if outcome.success:
+                logger.info("bootstrap dispatcher: %s OK", stage_key)
+            else:
+                logger.warning("bootstrap dispatcher: %s ERROR (%s)", stage_key, outcome.error)
+
+    return statuses
+
+
+def run_bootstrap_orchestrator() -> None:
+    """``_INVOKERS['bootstrap_orchestrator']`` — drive a queued run
+    via lane-aware phase-batched dispatch (#1020).
+
+    Replaces the prior "init thread + 2 lane threads" model with a
+    data-driven dependency-graph dispatcher: stages declare
+    ``requires`` in ``_STAGE_REQUIRES``; dispatcher fans out ready
+    batches respecting per-lane ``max_concurrency``.
     """
     # Lazy import: app.jobs.runtime imports app.services.bootstrap_orchestrator
     # via the orchestrator job invoker registration, and importing back the
@@ -318,16 +540,25 @@ def run_bootstrap_orchestrator() -> None:
         )
         return
 
-    by_lane: dict[str, list[tuple[str, str, str, str, Callable[[], None]]]] = {
-        "init": [],
-        "etoro": [],
-        "sec": [],
-    }
+    # Pre-populate statuses with stages already in a terminal state
+    # so the dependency graph sees them when a downstream pending
+    # stage's `requires` references them. Without this, a retry pass
+    # could treat an upstream `error`/`blocked` row as satisfied
+    # because that upstream was filtered out of `runnable`. Codex
+    # review BLOCKING for #1020 PR2.
+    preexisting_statuses: dict[str, str] = {}
+    runnable: list[_RunnableStage] = []
     for stage in sorted(snapshot.stages, key=lambda s: s.stage_order):
+        # Skip stages already in a terminal state (re-runs); record
+        # their status so dispatch dependency checks see them.
+        if stage.status in ("success", "error", "blocked", "skipped"):
+            preexisting_statuses[stage.stage_key] = stage.status
+            logger.info("bootstrap dispatcher: skipping %s (already %s)", stage.stage_key, stage.status)
+            continue
         invoker = _INVOKERS.get(stage.job_name)
         if invoker is None:
             logger.error(
-                "bootstrap_orchestrator: stage %s has unknown job_name %r; marking error",
+                "bootstrap dispatcher: stage %s has unknown job_name %r; marking error",
                 stage.stage_key,
                 stage.job_name,
             )
@@ -341,76 +572,33 @@ def run_bootstrap_orchestrator() -> None:
                 )
                 conn.commit()
             continue
-        by_lane[stage.lane].append((stage.stage_key, stage.job_name, stage.lane, stage.status, invoker))
+        runnable.append(
+            _RunnableStage(
+                stage_key=stage.stage_key,
+                job_name=stage.job_name,
+                lane=_effective_lane(stage.stage_key, stage.lane),
+                invoker=invoker,
+                requires=_STAGE_REQUIRES.get(stage.stage_key, ()),
+            )
+        )
 
     logger.info(
-        "bootstrap_orchestrator: run_id=%d phaseA=%d eToro=%d SEC=%d",
+        "bootstrap dispatcher: run_id=%d runnable=%d (lane breakdown: %s)",
         run_id,
-        len(by_lane["init"]),
-        len(by_lane["etoro"]),
-        len(by_lane["sec"]),
+        len(runnable),
+        {lane: sum(1 for r in runnable if r.lane == lane) for lane in _LANE_MAX_CONCURRENCY},
     )
 
-    # Phase A — sequential init.
-    _run_lane(
+    _phase_batched_dispatch(
         run_id=run_id,
-        lane_specs=by_lane["init"],
+        runnable=runnable,
         database_url=database_url,
-        log_label="init",
+        preexisting_statuses=preexisting_statuses,
     )
-
-    # If Phase A's only init stage errored, do not start Phase B.
-    # Treat a missing post-init snapshot (e.g. transient DB
-    # connectivity blip) as an init failure too — Phase B threads
-    # would otherwise spawn against a run whose state we cannot
-    # confirm, which would race the finalize step. Failing closed
-    # here is the right default for a one-shot operator-driven run.
-    init_failed = False
-    with psycopg.connect(database_url) as conn:
-        snap_after_init = read_latest_run_with_stages(conn)
-    if snap_after_init is None:
-        init_failed = True
-        logger.warning(
-            "bootstrap_orchestrator: post-init snapshot read returned None; "
-            "treating as init failure and skipping Phase B"
-        )
-    else:
-        for stage in snap_after_init.stages:
-            if stage.lane == "init" and stage.status == "error":
-                init_failed = True
-                break
-
-    if init_failed:
-        logger.warning("bootstrap_orchestrator: Phase A init failed; skipping Phase B and finalising")
-    else:
-        etoro_thread = threading.Thread(
-            target=_run_lane,
-            kwargs={
-                "run_id": run_id,
-                "lane_specs": by_lane["etoro"],
-                "database_url": database_url,
-                "log_label": "eToro",
-            },
-            name="bootstrap-etoro-lane",
-        )
-        sec_thread = threading.Thread(
-            target=_run_lane,
-            kwargs={
-                "run_id": run_id,
-                "lane_specs": by_lane["sec"],
-                "database_url": database_url,
-                "log_label": "SEC",
-            },
-            name="bootstrap-sec-lane",
-        )
-        etoro_thread.start()
-        sec_thread.start()
-        etoro_thread.join()
-        sec_thread.join()
 
     with psycopg.connect(database_url) as conn:
         terminal = finalize_run(conn, run_id=run_id)
-    logger.info("bootstrap_orchestrator: run_id=%d finalised as %s", run_id, terminal)
+    logger.info("bootstrap dispatcher: run_id=%d finalised as %s", run_id, terminal)
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -38,8 +38,8 @@ logger = logging.getLogger(__name__)
 
 BootstrapStatus = Literal["pending", "running", "complete", "partial_error"]
 RunStatus = Literal["running", "complete", "partial_error"]
-StageStatus = Literal["pending", "running", "success", "error", "skipped"]
-Lane = Literal["init", "etoro", "sec"]
+StageStatus = Literal["pending", "running", "success", "error", "skipped", "blocked"]
+Lane = Literal["init", "etoro", "sec", "sec_rate", "sec_bulk_download", "db"]
 
 
 class BootstrapAlreadyRunning(RuntimeError):
@@ -347,6 +347,37 @@ def mark_stage_error(
     )
 
 
+def mark_stage_blocked(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    stage_key: str,
+    reason: str,
+) -> None:
+    """Mark a stage as ``blocked`` — orchestrator never invoked it
+    because an upstream `requires` stage finished `error` or `blocked`.
+
+    Distinct from `error` (which means the invoker raised). The
+    operator panel renders both with red styling but a different
+    sublabel: blocked = "Skipped — upstream failure".
+    """
+    conn.execute(
+        """
+        UPDATE bootstrap_stages
+           SET status       = 'blocked',
+               completed_at = now(),
+               last_error   = %(reason)s
+         WHERE bootstrap_run_id = %(run_id)s
+           AND stage_key        = %(stage_key)s
+        """,
+        {
+            "run_id": run_id,
+            "stage_key": stage_key,
+            "reason": reason[:1000],
+        },
+    )
+
+
 def finalize_run(
     conn: psycopg.Connection[Any],
     *,
@@ -362,11 +393,14 @@ def finalize_run(
     Returns the chosen terminal status.
     """
     with conn.transaction():
+        # Count both `error` and `blocked` — both are unsuccessful
+        # outcomes. `blocked` = upstream failure propagation; the
+        # operator must still see the run as `partial_error`.
         error_count_row = conn.execute(
             """
             SELECT COUNT(*) FROM bootstrap_stages
              WHERE bootstrap_run_id = %(run_id)s
-               AND status = 'error'
+               AND status IN ('error', 'blocked')
             """,
             {"run_id": run_id},
         ).fetchone()
@@ -440,7 +474,7 @@ def reset_failed_stages_for_retry(
             SELECT lane, MIN(stage_order)
               FROM bootstrap_stages
              WHERE bootstrap_run_id = %(run_id)s
-               AND status           = 'error'
+               AND status IN ('error', 'blocked')
              GROUP BY lane
             """,
             {"run_id": run_id},

--- a/frontend/src/api/bootstrap.ts
+++ b/frontend/src/api/bootstrap.ts
@@ -18,9 +18,18 @@ export type BootstrapStageStatus =
   | "running"
   | "success"
   | "error"
-  | "skipped";
+  | "skipped"
+  // ``blocked`` (#1020): orchestrator never invoked the stage because
+  // a `requires` upstream stage finished error/blocked.
+  | "blocked";
 
-export type BootstrapLane = "init" | "etoro" | "sec";
+export type BootstrapLane =
+  | "init"
+  | "etoro"
+  | "sec"
+  | "sec_rate"
+  | "sec_bulk_download"
+  | "db";
 
 export interface BootstrapStageResponse {
   stage_key: string;

--- a/frontend/src/components/admin/BootstrapPanel.tsx
+++ b/frontend/src/components/admin/BootstrapPanel.tsx
@@ -58,18 +58,28 @@ const STATUS_LABEL: Record<BootstrapStatus, string> = {
   partial_error: "Partial — errors",
 };
 
-const LANE_BADGE: Record<BootstrapStageResponse["lane"], string> = {
+const LANE_BADGE: Record<string, string> = {
   init: "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200",
   etoro: "bg-sky-100 dark:bg-sky-900/40 text-sky-800 dark:text-sky-200",
   sec: "bg-violet-100 dark:bg-violet-900/40 text-violet-800 dark:text-violet-200",
+  sec_rate: "bg-violet-100 dark:bg-violet-900/40 text-violet-800 dark:text-violet-200",
+  sec_bulk_download: "bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-200",
+  db: "bg-teal-100 dark:bg-teal-900/40 text-teal-800 dark:text-teal-200",
 };
 
-const STAGE_STATUS_TONE: Record<BootstrapStageResponse["status"], string> = {
+const STAGE_STATUS_TONE: Record<string, string> = {
   pending: "text-slate-400",
   running: "text-amber-700",
   success: "text-emerald-700",
   error: "text-red-700",
   skipped: "text-slate-400",
+  // ``blocked`` = upstream-failure propagation (#1020). Same red tone
+  // as ``error`` but the sublabel below distinguishes it.
+  blocked: "text-red-700",
+};
+
+const STAGE_STATUS_SUBLABEL: Record<string, string> = {
+  blocked: "Skipped — upstream failure",
 };
 
 function formatElapsed(startedAt: string | null, completedAt: string | null): string {
@@ -149,7 +159,11 @@ export function BootstrapPanel() {
 
   const failedCount = useMemo(() => {
     if (state.data === null) return 0;
-    return state.data.stages.filter((s) => s.status === "error").length;
+    // Count both `error` and `blocked` — both are unsuccessful
+    // outcomes that retry-failed needs to reset (#1020).
+    return state.data.stages.filter(
+      (s) => s.status === "error" || s.status === "blocked",
+    ).length;
   }, [state.data]);
 
   return (
@@ -324,9 +338,16 @@ function StagesTable({
                     {stage.lane}
                   </span>
                 </td>
-                <td className={`py-2 pr-4 text-xs ${STAGE_STATUS_TONE[stage.status]}`}>
-                  {stage.status}
-                  {stage.attempt_count > 1 ? ` (×${stage.attempt_count})` : ""}
+                <td className={`py-2 pr-4 text-xs ${STAGE_STATUS_TONE[stage.status] ?? ""}`}>
+                  <div>
+                    {stage.status}
+                    {stage.attempt_count > 1 ? ` (×${stage.attempt_count})` : ""}
+                  </div>
+                  {STAGE_STATUS_SUBLABEL[stage.status] !== undefined ? (
+                    <div className="text-[10px] text-slate-500">
+                      {STAGE_STATUS_SUBLABEL[stage.status]}
+                    </div>
+                  ) : null}
                 </td>
                 <td className="py-2 pr-4 text-xs text-slate-600">
                   {formatProgress(stage)}

--- a/sql/131_bootstrap_stages_status_blocked.sql
+++ b/sql/131_bootstrap_stages_status_blocked.sql
@@ -1,0 +1,29 @@
+-- 131_bootstrap_stages_status_blocked.sql
+--
+-- Extend the bootstrap_stages.status CHECK to allow `blocked`
+-- (#1020 ETL orchestration design).
+--
+-- New semantics:
+--   pending  - not yet attempted
+--   running  - in progress
+--   success  - completed cleanly
+--   error    - invoker raised (runtime or precondition)
+--   skipped  - operator-policy skip (e.g. legacy fallback bypassed
+--              because bulk path succeeded). Already in the existing
+--              CHECK; preserved.
+--   blocked  - NEW: orchestrator never invoked the stage because a
+--              dependency stage finished error/blocked. Distinct
+--              from `error` because no run-attempt was made.
+--
+-- The migration must NOT drop `skipped` from the existing CHECK.
+
+BEGIN;
+
+ALTER TABLE bootstrap_stages
+    DROP CONSTRAINT IF EXISTS bootstrap_stages_status_check;
+
+ALTER TABLE bootstrap_stages
+    ADD CONSTRAINT bootstrap_stages_status_check
+    CHECK (status IN ('pending', 'running', 'success', 'error', 'skipped', 'blocked'));
+
+COMMIT;

--- a/sql/132_bootstrap_stages_lane_extension.sql
+++ b/sql/132_bootstrap_stages_lane_extension.sql
@@ -1,0 +1,27 @@
+-- 132_bootstrap_stages_lane_extension.sql
+--
+-- Extend the bootstrap_stages.lane CHECK with the finer-grained
+-- lane names introduced by the #1020 orchestration redesign:
+--
+--   init               - A1 universe_sync only.
+--   etoro              - A2 candle_refresh (separate eToro budget).
+--   sec                - LEGACY catch-all for prior schema; preserved
+--                        so existing rows from the 17-stage run history
+--                        stay valid.
+--   sec_rate           - SEC stages that share the per-IP rate clock
+--                        (B1, B2, B3, B4, C1.b, D1, D2, D3).
+--   sec_bulk_download  - A3 only — separate connection but shares
+--                        SEC clock for HEAD requests.
+--   db                 - DB-bound Phase C/E stages (separate
+--                        psycopg connections, parallel-able).
+
+BEGIN;
+
+ALTER TABLE bootstrap_stages
+    DROP CONSTRAINT IF EXISTS bootstrap_stages_lane_check;
+
+ALTER TABLE bootstrap_stages
+    ADD CONSTRAINT bootstrap_stages_lane_check
+    CHECK (lane IN ('init', 'etoro', 'sec', 'sec_rate', 'sec_bulk_download', 'db'));
+
+COMMIT;

--- a/tests/test_bootstrap_flow_integration.py
+++ b/tests/test_bootstrap_flow_integration.py
@@ -4,7 +4,7 @@ Drives every public surface of the first-install bootstrap stack
 together against ``ebull_test``:
 
   1. ``POST /system/bootstrap/run`` writes a ``manual_job`` queue row
-     and seeds 17 ``bootstrap_stages``.
+     and seeds 24 ``bootstrap_stages``.
   2. The orchestrator (with stubbed invokers) runs Phase A then
      Phase B in parallel and finalises the run.
   3. ``GET /system/bootstrap/status`` returns the final shape.
@@ -101,7 +101,7 @@ def test_bootstrap_end_to_end(
     assert met is False
     assert "first-install bootstrap not complete" in reason
 
-    # 2. start_run seeds 17 stages atomically.
+    # 2. start_run seeds 24 stages atomically.
     run_id = start_run(
         ebull_test_conn,
         operator_id=None,
@@ -112,7 +112,7 @@ def test_bootstrap_end_to_end(
     snap = read_latest_run_with_stages(ebull_test_conn)
     assert snap is not None
     assert snap.run_id == run_id
-    assert len(snap.stages) == 17
+    assert len(snap.stages) == 24
     assert all(s.status == "pending" for s in snap.stages)
 
     # 3. State is running, gate stays closed.
@@ -125,7 +125,7 @@ def test_bootstrap_end_to_end(
     run_bootstrap_orchestrator()
 
     # 5. Every fake invoker fired once.
-    assert len(calls["order"]) == 17
+    assert len(calls["order"]) == 24
 
     # 6. State is complete; gate releases.
     state = read_state(ebull_test_conn)

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -77,9 +77,15 @@ def _bind_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_stage_catalogue_has_seventeen_stages() -> None:
+def test_stage_catalogue_has_twenty_four_stages() -> None:
+    """Catalogue size pinned to surface adds/removes in code review.
+
+    24 = 1 init + 1 etoro + 4 sec_rate (B-stages) + 1 sec_bulk_download
+    + 5 db (Phase C ingesters) + 1 sec_rate (C1.b) + 7 sec_rate (legacy
+    chain) + 2 sec_rate (legacy 13F/N-PORT recent sweeps) + 2 db (E-stages).
+    """
     specs = get_bootstrap_stage_specs()
-    assert len(specs) == 17
+    assert len(specs) == 24
 
 
 def test_stage_catalogue_lane_composition() -> None:
@@ -87,7 +93,14 @@ def test_stage_catalogue_lane_composition() -> None:
     by_lane: dict[str, int] = {}
     for spec in specs:
         by_lane[spec.lane] = by_lane.get(spec.lane, 0) + 1
-    assert by_lane == {"init": 1, "etoro": 1, "sec": 15}
+    # 1 + 1 + (4 + 1 + 7 + 2) + 1 + (5 + 2) = 24
+    assert by_lane == {
+        "init": 1,
+        "etoro": 1,
+        "sec_rate": 14,
+        "sec_bulk_download": 1,
+        "db": 7,
+    }
 
 
 def test_stage_orders_are_unique_and_contiguous() -> None:
@@ -250,8 +263,8 @@ def test_orchestrator_happy_path_completes(
     state = read_state(ebull_test_conn)
     assert state.status == "complete"
 
-    # All 17 invokers called.
-    assert len(calls["order"]) == 17
+    # All 24 invokers called.
+    assert len(calls["order"]) == 24
     # Phase A's universe sync was first.
     assert calls["order"][0] == "nightly_universe_sync"
 
@@ -273,11 +286,14 @@ def test_orchestrator_init_failure_skips_phase_b(
     assert snap is not None
     statuses = {stage.stage_key: stage.status for stage in snap.stages}
     assert statuses["universe_sync"] == "error"
-    # Phase B never ran — every other stage stays pending.
+    # New dispatcher (#1020): downstream stages with `requires` on
+    # the failed stage propagate to `blocked` instead of staying
+    # pending. Distinguishes upstream-failure from "operator hasn't
+    # triggered yet".
     for key, status in statuses.items():
         if key == "universe_sync":
             continue
-        assert status == "pending", (key, status)
+        assert status == "blocked", (key, status)
 
     state = read_state(ebull_test_conn)
     assert state.status == "partial_error"


### PR DESCRIPTION
## Summary

PR2 of the ETL orchestration redesign (#1037 spec).

- Data-driven dependency graph (`_STAGE_REQUIRES`) replaces flat sequential lanes.
- Lane-based concurrency: `db`=5 (Phase C parallel), `sec_rate`=1 (shared SEC clock), etc.
- New `blocked` status — upstream-failure propagation distinct from `error`/`skipped`.
- `mark_stage_blocked` + `finalize_run` counts blocked alongside error.
- Retry-failed resets both error AND blocked rows.
- Frontend renders `blocked` with red tone + "Skipped — upstream failure" sublabel; failedCount includes blocked.
- 3 migrations: status CHECK, lane CHECK, [bootstrap_archive_results from PR1 already merged].

## Test plan

- [x] `uv run ruff check` + `uv run ruff format --check` clean.
- [x] `uv run pyright` clean.
- [x] `pnpm typecheck` clean.
- [x] `uv run pytest tests/test_bootstrap_orchestrator.py` 13/13.
- [x] Codex pre-push APPROVE (2 rounds; round 1 caught retry-doesn't-reset-blocked + dispatcher-loses-upstream-statuses + stale 17-stage test asserts).

Refs #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)