### PR TITLE
fix(#1041): slow-connection fallback manifest + Phase C skipped

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -44,12 +44,14 @@ import psycopg
 
 from app.config import settings
 from app.jobs.locks import JobAlreadyRunning, JobLock
+from app.services.bootstrap_preconditions import BootstrapPhaseSkipped
 from app.services.bootstrap_state import (
     StageSpec,
     finalize_run,
     mark_stage_blocked,
     mark_stage_error,
     mark_stage_running,
+    mark_stage_skipped,
     mark_stage_success,
     read_latest_run_with_stages,
 )
@@ -133,9 +135,20 @@ _STAGE_REQUIRES: Final[dict[str, tuple[str, ...]]] = {
     "sec_13f_recent_sweep": ("cik_refresh",),
     "sec_n_port_ingest": ("cik_refresh",),
     "ownership_observations_backfill": (
+        # Bulk path — direct writes to ownership_*_observations.
         "sec_13f_ingest_from_dataset",
         "sec_insider_ingest_from_dataset",
         "sec_nport_ingest_from_dataset",
+        # Legacy chain — populates the legacy typed tables
+        # (insider_transactions, institutional_holdings, n_port_*) that
+        # the backfill mirrors into observations. In fallback mode the
+        # bulk stages skip, so the legacy chain becomes the sole source;
+        # without these requires the backfill could fire BEFORE the
+        # legacy chain populates rows. Codex pre-push BLOCKING for #1041.
+        "sec_insider_transactions_backfill",
+        "sec_form3_ingest",
+        "sec_13f_recent_sweep",
+        "sec_n_port_ingest",
     ),
     "fundamentals_sync": ("sec_companyfacts_ingest",),
 }
@@ -252,6 +265,7 @@ class _StageOutcome:
     stage_key: str
     success: bool
     error: str | None
+    skipped: bool = False
 
 
 def _run_one_stage(
@@ -287,6 +301,17 @@ def _run_one_stage(
             mark_stage_error(conn, run_id=run_id, stage_key=stage_key, error_message=message)
             conn.commit()
         return _StageOutcome(stage_key=stage_key, success=False, error=message)
+    except BootstrapPhaseSkipped as exc:
+        # Operator-policy skip: A3 wrote a fallback manifest because
+        # bandwidth was below threshold, and the legacy chain handles
+        # ingest. Mark the stage `skipped` so finalize_run does NOT
+        # count it as a failure (#1041).
+        message = f"skipped: {exc}"
+        logger.info("bootstrap stage %s skipped: %s", stage_key, exc)
+        with psycopg.connect(database_url) as conn:
+            mark_stage_skipped(conn, run_id=run_id, stage_key=stage_key, reason=message)
+            conn.commit()
+        return _StageOutcome(stage_key=stage_key, success=True, error=None, skipped=True)
     except Exception as exc:
         message = f"{type(exc).__name__}: {exc}"
         logger.exception("bootstrap stage %s raised; lane continues", stage_key)
@@ -541,10 +566,14 @@ def _phase_batched_dispatch(
 
         for stage_key, fut in all_futures:
             outcome = fut.result()
-            statuses[stage_key] = "success" if outcome.success else "error"
-            if outcome.success:
+            if outcome.skipped:
+                statuses[stage_key] = "skipped"
+                logger.info("bootstrap dispatcher: %s SKIPPED", stage_key)
+            elif outcome.success:
+                statuses[stage_key] = "success"
                 logger.info("bootstrap dispatcher: %s OK", stage_key)
             else:
+                statuses[stage_key] = "error"
                 logger.warning("bootstrap dispatcher: %s ERROR (%s)", stage_key, outcome.error)
 
     return statuses

--- a/app/services/bootstrap_preconditions.py
+++ b/app/services/bootstrap_preconditions.py
@@ -48,6 +48,18 @@ class BootstrapPreconditionError(RuntimeError):
     """
 
 
+class BootstrapPhaseSkipped(Exception):
+    """Raised by Phase C preconditions when A3 wrote a fallback
+    manifest (slow-connection path bypasses the bulk archives, #1041).
+
+    The orchestrator catches this distinct type and marks the stage
+    ``skipped`` (not ``error``) so the run still finalises ``complete``
+    when the legacy chain handles ingest. Inheriting from ``Exception``
+    rather than ``RuntimeError`` keeps it out of the generic catch-all
+    in third-party code.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Provenance — bootstrap_archive_results row existence
 # ---------------------------------------------------------------------------
@@ -255,10 +267,56 @@ def assert_archives_in_manifest(
     Catches both stale-archive (prior run's leftover) and partial-set
     (some quarterly archives failed to land) failure modes.
     """
-    from app.services.sec_bulk_download import assert_archive_belongs_to_run
+    from app.services.sec_bulk_download import assert_archive_belongs_to_run, read_run_manifest
+
+    # Detect fallback-mode manifest: A3 measured bandwidth below
+    # threshold, wrote a stub manifest with mode=fallback + no
+    # archives, and the legacy chain handles ingest. Phase C should
+    # be marked `skipped` instead of forcing the whole run to
+    # partial_error. (#1041)
+    manifest = read_run_manifest(target_dir)
+    if manifest is not None and manifest.get("mode") == "fallback":
+        if int(manifest.get("bootstrap_run_id", -1)) != bootstrap_run_id:
+            # Stale fallback manifest from a prior run — treat as
+            # missing, the regular provenance check will raise.
+            pass
+        else:
+            raise BootstrapPhaseSkipped(
+                "sec_bulk_download landed in fallback mode (slow connection); "
+                "Phase C bypassed in favour of legacy per-CIK chain."
+            )
 
     for name in expected_names:
         assert_archive_belongs_to_run(target_dir, name, bootstrap_run_id=bootstrap_run_id)
+
+
+def assert_not_fallback_mode(
+    bulk_dir: Any,
+    *,
+    bootstrap_run_id: int,
+) -> None:
+    """Raise BootstrapPhaseSkipped if A3 wrote a fallback manifest.
+
+    Called at the top of every Phase C / C' precondition so the slow-
+    connection bypass cascades cleanly to ``skipped`` for the entire
+    bulk-ingest chain (#1041). Without this, downstream stages that
+    don't load archives directly (e.g. C1.b sec_submissions_files_walk)
+    would raise ``BootstrapPreconditionError`` because their upstream
+    C1.a is `skipped` not `success`, inflating the failed-stage count.
+    """
+    from app.services.sec_bulk_download import read_run_manifest
+
+    manifest = read_run_manifest(bulk_dir)
+    if manifest is None:
+        return
+    if manifest.get("mode") != "fallback":
+        return
+    if int(manifest.get("bootstrap_run_id", -1)) != bootstrap_run_id:
+        return
+    raise BootstrapPhaseSkipped(
+        "sec_bulk_download landed in fallback mode (slow connection); "
+        "bulk-ingest stage bypassed in favour of legacy per-CIK chain."
+    )
 
 
 def assert_c1a_preconditions(
@@ -268,6 +326,8 @@ def assert_c1a_preconditions(
     bulk_dir: Any | None = None,
 ) -> None:
     """C1.a (sec_submissions_ingest): B4 invocation + CIK coverage + manifest provenance."""
+    if bulk_dir is not None:
+        assert_not_fallback_mode(bulk_dir, bootstrap_run_id=bootstrap_run_id)
     assert_archive_result_exists(
         conn,
         bootstrap_run_id=bootstrap_run_id,
@@ -286,6 +346,8 @@ def assert_c2_preconditions(
     bulk_dir: Any | None = None,
 ) -> None:
     """C2 (sec_companyfacts_ingest): B4 invocation + CIK coverage + manifest provenance."""
+    if bulk_dir is not None:
+        assert_not_fallback_mode(bulk_dir, bootstrap_run_id=bootstrap_run_id)
     assert_archive_result_exists(
         conn,
         bootstrap_run_id=bootstrap_run_id,
@@ -305,6 +367,8 @@ def assert_c3_preconditions(
     expected_archive_names: list[str] | None = None,
 ) -> None:
     """C3 (13F): B1 invocation + CUSIP coverage + ALL 4 quarterly archives landed."""
+    if bulk_dir is not None:
+        assert_not_fallback_mode(bulk_dir, bootstrap_run_id=bootstrap_run_id)
     assert_archive_result_exists(
         conn,
         bootstrap_run_id=bootstrap_run_id,
@@ -324,6 +388,8 @@ def assert_c4_preconditions(
     expected_archive_names: list[str] | None = None,
 ) -> None:
     """C4 (insider): B4 invocation + CIK coverage + ALL 8 quarterly archives landed."""
+    if bulk_dir is not None:
+        assert_not_fallback_mode(bulk_dir, bootstrap_run_id=bootstrap_run_id)
     assert_archive_result_exists(
         conn,
         bootstrap_run_id=bootstrap_run_id,
@@ -343,6 +409,8 @@ def assert_c5_preconditions(
     expected_archive_names: list[str] | None = None,
 ) -> None:
     """C5 (N-PORT): B1 invocation + CUSIP coverage + ALL 4 quarterly archives landed."""
+    if bulk_dir is not None:
+        assert_not_fallback_mode(bulk_dir, bootstrap_run_id=bootstrap_run_id)
     assert_archive_result_exists(
         conn,
         bootstrap_run_id=bootstrap_run_id,
@@ -358,6 +426,7 @@ def assert_c1b_preconditions(
     conn: psycopg.Connection[Any],
     *,
     bootstrap_run_id: int,
+    bulk_dir: Any | None = None,
 ) -> None:
     """C1.b: C1.a succeeded in current run AND wrote ≥ 1 row.
 
@@ -366,6 +435,8 @@ def assert_c1b_preconditions(
     C1.b proceed to walk an empty CIK list. Codex review
     BLOCKING for #1020.
     """
+    if bulk_dir is not None:
+        assert_not_fallback_mode(bulk_dir, bootstrap_run_id=bootstrap_run_id)
     assert_stage_succeeded_in_run(
         conn,
         bootstrap_run_id=bootstrap_run_id,

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -347,6 +347,39 @@ def mark_stage_error(
     )
 
 
+def mark_stage_skipped(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    stage_key: str,
+    reason: str,
+) -> None:
+    """Mark a stage as ``skipped`` — operator-policy bypass.
+
+    Distinct from ``blocked`` (which means upstream failure forced
+    the skip). ``skipped`` is the right state for intentional bypass
+    paths like the slow-connection fallback (#1041) where Phase C
+    is bypassed in favour of the legacy chain. ``finalize_run`` does
+    NOT count ``skipped`` as a failure, so the run still reaches
+    ``complete`` when only skips remain.
+    """
+    conn.execute(
+        """
+        UPDATE bootstrap_stages
+           SET status       = 'skipped',
+               completed_at = now(),
+               last_error   = %(reason)s
+         WHERE bootstrap_run_id = %(run_id)s
+           AND stage_key        = %(stage_key)s
+        """,
+        {
+            "run_id": run_id,
+            "stage_key": stage_key,
+            "reason": reason[:1000],
+        },
+    )
+
+
 def mark_stage_blocked(
     conn: psycopg.Connection[Any],
     *,
@@ -640,8 +673,10 @@ __all__ = [
     "StageStatus",
     "finalize_run",
     "force_mark_complete",
+    "mark_stage_blocked",
     "mark_stage_error",
     "mark_stage_running",
+    "mark_stage_skipped",
     "mark_stage_success",
     "read_latest_run_with_stages",
     "read_state",

--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -44,7 +44,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Final
+from typing import Final, Literal
 
 import httpx
 
@@ -599,6 +599,7 @@ def write_run_manifest(
     *,
     bootstrap_run_id: int,
     archives: Sequence[ArchiveDownloadResult],
+    mode: Literal["bulk", "fallback"] = "bulk",
 ) -> None:
     """Persist a per-run archive manifest at ``<bulk>/.run_manifest.json``.
 
@@ -606,11 +607,17 @@ def write_run_manifest(
     the CURRENT bootstrap run, not a previous one. Stale archives left
     on disk from a prior run will have a different ``bootstrap_run_id``
     and fail the provenance check (Codex review BLOCKING for #1020).
+
+    ``mode='fallback'`` writes a stub manifest with no archives so
+    Phase C preconditions can detect intentional bypass and mark the
+    stage ``skipped`` instead of ``error``. See assert_archives_in_manifest
+    + BootstrapPhaseSkipped in app/services/bootstrap_preconditions.py.
     """
     import json
 
     manifest = {
         "bootstrap_run_id": bootstrap_run_id,
+        "mode": mode,
         "archives": [
             {
                 "name": r.name,
@@ -621,8 +628,15 @@ def write_run_manifest(
             if r.error is None and r.path is not None
         ],
     }
-    path = target_dir / RUN_MANIFEST_NAME
-    path.write_text(json.dumps(manifest))
+    # Atomic write: write to a sibling tempfile then rename. Without
+    # this, a crash mid-write leaves a partial JSON that read_run_manifest
+    # silently treats as "no manifest" → Phase C errors as "manifest
+    # missing" instead of detecting fallback. Codex pre-push LOW for
+    # #1041.
+    final_path = target_dir / RUN_MANIFEST_NAME
+    tmp_path = final_path.with_suffix(final_path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(manifest))
+    tmp_path.replace(final_path)
 
 
 def read_run_manifest(target_dir: Path) -> dict | None:
@@ -840,6 +854,17 @@ def sec_bulk_download_job() -> None:
             result.measured_mbps,
             result.error,
         )
+        # Fallback manifest is part of the success contract — without
+        # it Phase C cannot detect intentional bypass and would error
+        # as "manifest missing". Refuse to mark stage success without
+        # a writable run_id, matching the bulk-mode contract above.
+        # Codex pre-push MEDIUM for #1041.
+        if run_id is None:
+            raise BootstrapPartialDownloadError(
+                "sec_bulk_download: could not determine current bootstrap_run_id; "
+                "fallback manifest cannot be written. Refuse to mark stage success."
+            )
+        write_run_manifest(target_dir, bootstrap_run_id=run_id, archives=[], mode="fallback")
     elif result.mode == "skipped_disk":
         # Disk pre-flight refused — surface as error so operator
         # knows to free space; downstream Phase C will be `blocked`.

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -196,7 +196,10 @@ def sec_submissions_files_walk_job() -> None:
             row = cur.fetchone()
             run_id = int(row[0]) if row else None
         if run_id is not None:
-            assert_c1b_preconditions(conn, bootstrap_run_id=run_id)
+            from app.security.master_key import resolve_data_dir
+
+            bulk_dir = resolve_data_dir() / "sec" / "bulk"
+            assert_c1b_preconditions(conn, bootstrap_run_id=run_id, bulk_dir=bulk_dir)
 
     with psycopg.connect(settings.database_url) as conn:
         result = walk_files_pages(conn=conn)

--- a/tests/test_bootstrap_fallback_skip.py
+++ b/tests/test_bootstrap_fallback_skip.py
@@ -1,0 +1,123 @@
+"""Phase C fallback-mode skip tests (#1041).
+
+When ``sec_bulk_download`` measures bandwidth below threshold and
+returns ``mode='fallback'``, A3 writes a stub manifest with
+``mode='fallback'`` + empty archives. Every Phase C precondition
+detects this and raises ``BootstrapPhaseSkipped``; the orchestrator
+catches and marks each stage ``skipped`` (not ``error``).
+
+This test pins the contract: write fallback manifest → preconditions
+raise BootstrapPhaseSkipped → orchestrator marks stage skipped →
+finalize_run sees the run as ``complete`` (skipped is not a failure).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.bootstrap_preconditions import (
+    BootstrapPhaseSkipped,
+    assert_c1a_preconditions,
+    assert_c1b_preconditions,
+    assert_c2_preconditions,
+    assert_c3_preconditions,
+    assert_c4_preconditions,
+    assert_c5_preconditions,
+    assert_not_fallback_mode,
+)
+from app.services.sec_bulk_download import RUN_MANIFEST_NAME, write_run_manifest
+
+
+class TestAssertNotFallbackMode:
+    def test_no_manifest_does_not_raise(self, tmp_path: Path) -> None:
+        # Empty bulk dir = no manifest = no fallback signal. Should pass.
+        assert_not_fallback_mode(tmp_path, bootstrap_run_id=42)
+
+    def test_bulk_mode_manifest_does_not_raise(self, tmp_path: Path) -> None:
+        # Real bulk-mode manifest with archives = NOT fallback.
+        write_run_manifest(tmp_path, bootstrap_run_id=42, archives=[], mode="bulk")
+        assert_not_fallback_mode(tmp_path, bootstrap_run_id=42)
+
+    def test_fallback_manifest_raises_phase_skipped(self, tmp_path: Path) -> None:
+        write_run_manifest(tmp_path, bootstrap_run_id=42, archives=[], mode="fallback")
+        with pytest.raises(BootstrapPhaseSkipped, match="fallback mode"):
+            assert_not_fallback_mode(tmp_path, bootstrap_run_id=42)
+
+    def test_stale_fallback_manifest_does_not_raise(self, tmp_path: Path) -> None:
+        # Fallback manifest from a PRIOR run is not load-bearing for
+        # the current run — the regular manifest-mismatch check will
+        # raise. assert_not_fallback_mode silently passes through.
+        write_run_manifest(tmp_path, bootstrap_run_id=99, archives=[], mode="fallback")
+        assert_not_fallback_mode(tmp_path, bootstrap_run_id=42)
+
+
+class TestPhaseCPreconditionsCascadeFallback:
+    """Each Phase C precondition must short-circuit on fallback BEFORE
+    its DB checks. Without this, C1.b would raise BootstrapPreconditionError
+    because its upstream C1.a is `skipped` not `success`."""
+
+    @pytest.fixture()
+    def fallback_dir(self, tmp_path: Path) -> Path:
+        write_run_manifest(tmp_path, bootstrap_run_id=42, archives=[], mode="fallback")
+        return tmp_path
+
+    def test_c1a_short_circuits_on_fallback(self, fallback_dir: Path) -> None:
+        # No DB conn supplied — if precondition reached the DB checks
+        # it would crash. BootstrapPhaseSkipped raised before that.
+        with pytest.raises(BootstrapPhaseSkipped):
+            assert_c1a_preconditions(conn=None, bootstrap_run_id=42, bulk_dir=fallback_dir)  # type: ignore[arg-type]
+
+    def test_c2_short_circuits_on_fallback(self, fallback_dir: Path) -> None:
+        with pytest.raises(BootstrapPhaseSkipped):
+            assert_c2_preconditions(conn=None, bootstrap_run_id=42, bulk_dir=fallback_dir)  # type: ignore[arg-type]
+
+    def test_c3_short_circuits_on_fallback(self, fallback_dir: Path) -> None:
+        with pytest.raises(BootstrapPhaseSkipped):
+            assert_c3_preconditions(
+                conn=None,  # type: ignore[arg-type]
+                bootstrap_run_id=42,
+                bulk_dir=fallback_dir,
+                expected_archive_names=["form13f_2025q1.zip"],
+            )
+
+    def test_c4_short_circuits_on_fallback(self, fallback_dir: Path) -> None:
+        with pytest.raises(BootstrapPhaseSkipped):
+            assert_c4_preconditions(
+                conn=None,  # type: ignore[arg-type]
+                bootstrap_run_id=42,
+                bulk_dir=fallback_dir,
+                expected_archive_names=["insider_2025q1.zip"],
+            )
+
+    def test_c5_short_circuits_on_fallback(self, fallback_dir: Path) -> None:
+        with pytest.raises(BootstrapPhaseSkipped):
+            assert_c5_preconditions(
+                conn=None,  # type: ignore[arg-type]
+                bootstrap_run_id=42,
+                bulk_dir=fallback_dir,
+                expected_archive_names=["nport_2025q1.zip"],
+            )
+
+    def test_c1b_short_circuits_on_fallback(self, fallback_dir: Path) -> None:
+        with pytest.raises(BootstrapPhaseSkipped):
+            assert_c1b_preconditions(conn=None, bootstrap_run_id=42, bulk_dir=fallback_dir)  # type: ignore[arg-type]
+
+
+class TestFallbackManifestShape:
+    def test_fallback_manifest_records_mode_field(self, tmp_path: Path) -> None:
+        write_run_manifest(tmp_path, bootstrap_run_id=42, archives=[], mode="fallback")
+        manifest_path = tmp_path / RUN_MANIFEST_NAME
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["mode"] == "fallback"
+        assert manifest["bootstrap_run_id"] == 42
+        assert manifest["archives"] == []
+
+    def test_bulk_mode_manifest_records_mode_field(self, tmp_path: Path) -> None:
+        # Default mode='bulk' — back-compat with existing manifest readers.
+        write_run_manifest(tmp_path, bootstrap_run_id=42, archives=[])
+        manifest_path = tmp_path / RUN_MANIFEST_NAME
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["mode"] == "bulk"


### PR DESCRIPTION
## What

When A3 measures bandwidth below threshold and returns `mode=fallback`, it now writes a stub manifest (`mode='fallback'`, empty archives). Each Phase C precondition calls `assert_not_fallback_mode` first and raises `BootstrapPhaseSkipped`; orchestrator catches it via a new arm above the generic Exception handler and calls `mark_stage_skipped`. `finalize_run` does NOT count skipped as failure, so the run finalises `complete`.

## Why

Without this, fallback mode caused Phase C stages to fail manifest-provenance checks with confusing \"manifest missing\" errors, inflating the failed-stage count for an intentional bypass.

## Test plan

- [x] `tests/test_bootstrap_fallback_skip.py` covers manifest shape, `assert_not_fallback_mode` helper, and every Phase C precondition's short-circuit on fallback.
- [x] All gates green (ruff, format, pyright, 66 impacted tests).
- [x] Codex pre-push: APPROVE after addressing 3 findings (cascade gap on ownership_observations_backfill requires; fallback run_id contract; atomic manifest write).

Closes #1041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)