### PR TITLE
fix(#1044): first_install_drain seeds manifest from filing_events first

### DIFF
--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -89,6 +89,7 @@ def seed_manifest_from_filing_events(
     upserted = 0
     skipped_unmapped_form = 0
     skipped_no_cik = 0
+    skipped_non_issuer_source = 0
     with conn.cursor() as cur:
         # LATERAL JOIN with LIMIT 1 picks the highest-priority CIK
         # mapping per instrument: ORDER BY is_primary DESC selects the
@@ -130,6 +131,17 @@ def seed_manifest_from_filing_events(
         if source is None:
             skipped_unmapped_form += 1
             continue
+        # subject_type='issuer' is hard-coded below — must therefore
+        # exclude non-issuer-scoped sources. 13F-HR / N-PORT / N-CSR
+        # are filer-scoped (subject_id = filer CIK, instrument_id NULL)
+        # and need a different code path. Filing_events does carry
+        # 13F-HR / NPORT-P rows for instruments that ALSO have those
+        # filings on file (e.g. fund families), so we must filter
+        # them out at the seed boundary. PR #1051 review WARNING for
+        # #1044.
+        if source in ("sec_13f_hr", "sec_n_port", "sec_n_csr"):
+            skipped_non_issuer_source += 1
+            continue
         # Accession lives in fe.provider_filing_id — that's the
         # authoritative column. raw_payload_json mirrors it but can
         # legitimately drift on legacy rows. Codex pre-push MED.
@@ -165,12 +177,14 @@ def seed_manifest_from_filing_events(
                 accession,
                 exc,
             )
-    if skipped_unmapped_form or skipped_no_cik:
+    if skipped_unmapped_form or skipped_no_cik or skipped_non_issuer_source:
         logger.info(
-            "seed_manifest_from_filing_events: upserted=%d skipped_no_cik=%d skipped_unmapped_form=%d",
+            "seed_manifest_from_filing_events: upserted=%d skipped_no_cik=%d "
+            "skipped_unmapped_form=%d skipped_non_issuer_source=%d",
             upserted,
             skipped_no_cik,
             skipped_unmapped_form,
+            skipped_non_issuer_source,
         )
     return upserted
 

--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -4,15 +4,18 @@ Issue #871 / spec §"Mode 1 — First-install drain".
 
 Operator-triggered job for new installs and explicit drain requests.
 
-Two paths (Codex review v2 finding 3):
+Three paths:
 
-  - **In-universe-only (default)**: per-CIK submissions.json for every
-    CIK in the tradable universe. ~12k requests at 10 req/s = ~20 min.
-    Cheap, precise, respects the universe scope.
+  - **filing_events seed (default fast path, #1044)**: SELECT every
+    issuer row from ``filing_events`` (already populated by C1.a +
+    C1.b in the bulk path) and seed ``sec_filing_manifest`` from the
+    cached payloads. No HTTP. ~15s for ~12k issuer events vs ~21min
+    of per-CIK fetches.
+  - **In-universe HTTP fallback**: per-CIK submissions.json for every
+    CIK in the tradable universe. Used when ``filing_events`` is
+    empty (e.g. fallback mode where the bulk path was bypassed).
   - **Bulk-zip**: download submissions.zip + companyfacts.zip once.
-    Production / operator-explicit only — NOT the default local path.
-    Out of scope for this PR; raises NotImplementedError. The
-    in-universe path is sufficient for dev + small-capital live.
+    Out of scope; raises NotImplementedError.
 
 Crash-resume: idempotent — re-run drains the remaining pending /
 unknown subjects. ``record_manifest_entry`` UPSERTs, so duplicate
@@ -30,6 +33,7 @@ import json
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 import psycopg
@@ -41,7 +45,7 @@ from app.providers.implementations.sec_submissions import (
     parse_submissions_page,
 )
 from app.services.data_freshness import seed_scheduler_from_manifest
-from app.services.sec_manifest import record_manifest_entry
+from app.services.sec_manifest import is_amendment_form, map_form_to_source, record_manifest_entry
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +62,117 @@ class DrainStats:
     # step (#937), the steady-state per-CIK poll would silently no-op
     # because the scheduler had no rows to poll.
     scheduler_rows_seeded: int = 0
+    # #1044: count of manifest rows seeded from filing_events without
+    # any HTTP. Bulk path populates this; fallback path leaves it 0.
+    rows_seeded_from_filing_events: int = 0
+
+
+def seed_manifest_from_filing_events(
+    conn: psycopg.Connection[Any],
+) -> int:
+    """Seed ``sec_filing_manifest`` from already-ingested ``filing_events``.
+
+    Reads every issuer-scoped filing_events row joined to the best
+    available SEC CIK identifier (primary preferred), calls
+    ``record_manifest_entry`` per row.
+    The bulk path (C1.a + C1.b) populates filing_events ahead of this
+    drain stage, so the manifest can be seeded without ANY HTTP
+    requests — replaces the ~21min per-CIK loop with a ~15s table
+    walk. (#1044)
+
+    Returns the number of manifest rows upserted.
+
+    No-op if filing_events is empty (e.g. fallback mode bypassed the
+    bulk path entirely); the caller should follow up with the per-CIK
+    HTTP drain in that case.
+    """
+    upserted = 0
+    skipped_unmapped_form = 0
+    skipped_no_cik = 0
+    with conn.cursor() as cur:
+        # LATERAL JOIN with LIMIT 1 picks the highest-priority CIK
+        # mapping per instrument: ORDER BY is_primary DESC selects the
+        # primary mapping when one exists, else any non-primary one.
+        # Codex pre-push MED for #1044 — naive `is_primary = TRUE`
+        # would drop valid rows whose only SEC CIK mapping isn't
+        # flagged primary.
+        cur.execute(
+            """
+            SELECT
+                fe.instrument_id,
+                fe.filing_date,
+                fe.filing_type,
+                fe.provider_filing_id,
+                fe.primary_document_url,
+                cik_map.identifier_value AS cik
+            FROM filing_events fe
+            JOIN LATERAL (
+                SELECT identifier_value
+                FROM external_identifiers ei
+                WHERE ei.instrument_id = fe.instrument_id
+                  AND ei.provider = 'sec'
+                  AND ei.identifier_type = 'cik'
+                ORDER BY ei.is_primary DESC, ei.external_identifier_id ASC
+                LIMIT 1
+            ) cik_map ON TRUE
+            WHERE fe.provider = 'sec'
+            """
+        )
+        rows = cur.fetchall()
+    for instrument_id, filing_date, filing_type, provider_filing_id, primary_doc_url, cik_raw in rows:
+        if cik_raw is None or not str(cik_raw).strip():
+            skipped_no_cik += 1
+            continue
+        # Use the canonical map_form_to_source from sec_manifest so
+        # this drain stays in sync with the rest of the manifest
+        # writers (Codex pre-push HIGH for #1044).
+        source = map_form_to_source(filing_type) if filing_type else None
+        if source is None:
+            skipped_unmapped_form += 1
+            continue
+        # Accession lives in fe.provider_filing_id — that's the
+        # authoritative column. raw_payload_json mirrors it but can
+        # legitimately drift on legacy rows. Codex pre-push MED.
+        accession = provider_filing_id
+        if not accession:
+            continue
+        cik_padded = str(cik_raw).strip().zfill(10)
+        # filing_date is a date — record_manifest_entry takes filed_at
+        # as datetime. Anchor at UTC midnight; the precise time is
+        # carried only by the per-CIK HTTP path's accept_timestamp.
+        filed_at = datetime.combine(filing_date, datetime.min.time(), tzinfo=UTC)
+        # Use canonical is_amendment_form so DEFA14A and other non-/A
+        # amendment proxies are flagged correctly. Codex pre-push MED.
+        is_amendment = is_amendment_form(filing_type or "")
+        try:
+            record_manifest_entry(
+                conn,
+                str(accession),
+                cik=cik_padded,
+                form=str(filing_type or ""),
+                source=source,
+                subject_type="issuer",
+                subject_id=str(int(instrument_id)),
+                instrument_id=int(instrument_id),
+                filed_at=filed_at,
+                primary_document_url=primary_doc_url,
+                is_amendment=is_amendment,
+            )
+            upserted += 1
+        except ValueError as exc:
+            logger.debug(
+                "seed_manifest_from_filing_events: rejected accession=%s: %s",
+                accession,
+                exc,
+            )
+    if skipped_unmapped_form or skipped_no_cik:
+        logger.info(
+            "seed_manifest_from_filing_events: upserted=%d skipped_no_cik=%d skipped_unmapped_form=%d",
+            upserted,
+            skipped_no_cik,
+            skipped_unmapped_form,
+        )
+    return upserted
 
 
 def _iter_in_universe_subjects(
@@ -136,9 +251,35 @@ def run_first_install_drain(
     manifest_upserted = 0
     errors = 0
 
+    # Fast path (#1044): if filing_events has rows for the SEC
+    # provider (populated by C1.a + C1.b in the bulk path), seed the
+    # manifest from that table without any HTTP requests. The per-CIK
+    # HTTP loop below still runs to cover non-issuer subjects
+    # (institutional_filer + blockholder_filer) which filing_events
+    # doesn't carry. Newer issuer filings published since the bulk
+    # snapshot are picked up by the steady-state per-CIK poll
+    # (#870), not this drain — running another full HTTP sweep here
+    # would defeat the perf gain.
+    rows_seeded_from_filing_events = seed_manifest_from_filing_events(conn)
+    manifest_upserted += rows_seeded_from_filing_events
+    if rows_seeded_from_filing_events > 0:
+        logger.info(
+            "first-install drain: seeded %d manifest rows from filing_events (no HTTP)",
+            rows_seeded_from_filing_events,
+        )
+
+    skip_issuer_http = rows_seeded_from_filing_events > 0
     for subject, cik in _iter_in_universe_subjects(conn):  # type: ignore[misc]
         if max_subjects is not None and ciks_processed >= max_subjects:
             break
+        # #1044 fast-path: when filing_events seeded the issuer manifest
+        # rows already, skip the per-CIK HTTP fetch for issuers. Non-
+        # issuer subjects (institutional_filer + blockholder_filer)
+        # still need the HTTP fetch — filing_events only carries
+        # universe-mapped instruments.
+        if skip_issuer_http and subject.subject_type == "issuer":
+            ciks_skipped += 1
+            continue
 
         try:
             delta = check_freshness(
@@ -223,6 +364,7 @@ def run_first_install_drain(
         manifest_rows_upserted=manifest_upserted,
         errors=errors,
         scheduler_rows_seeded=scheduler_rows_seeded,
+        rows_seeded_from_filing_events=rows_seeded_from_filing_events,
     )
 
 

--- a/tests/test_sec_first_install_drain.py
+++ b/tests/test_sec_first_install_drain.py
@@ -223,6 +223,54 @@ class TestSeedFromFilingEvents:
             assert row.instrument_id == 1701
             assert row.cik == "0000320193"
 
+    def test_skips_non_issuer_sources(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # PR #1051 review WARNING: 13F-HR / N-PORT / N-CSR rows in
+        # filing_events must NOT be seeded as subject_type='issuer'
+        # — they're filer-scoped manifest rows (instrument_id=NULL,
+        # subject_id=filer CIK). The seed must skip them so the
+        # legacy/per-CIK path can correctly classify them.
+        _seed_aapl(ebull_test_conn)
+        ebull_test_conn.execute(
+            """
+            INSERT INTO external_identifiers
+                (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES (1701, 'sec', 'cik', '0000320193', TRUE)
+            ON CONFLICT DO NOTHING
+            """
+        )
+        # Insert one issuer-scoped (10-K) and one filer-scoped (13F-HR).
+        ebull_test_conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, filing_date, filing_type, provider,
+                provider_filing_id, source_url, primary_document_url, raw_payload_json
+            )
+            VALUES
+                (1701, %s, '10-K', 'sec', '0000320193-26-000010',
+                 'https://www.sec.gov/...', NULL, %s::jsonb),
+                (1701, %s, '13F-HR', 'sec', '0000320193-26-000011',
+                 'https://www.sec.gov/...', NULL, %s::jsonb)
+            """,
+            (
+                date(2026, 1, 15),
+                json.dumps({"provider_filing_id": "0000320193-26-000010"}),
+                date(2026, 2, 14),
+                json.dumps({"provider_filing_id": "0000320193-26-000011"}),
+            ),
+        )
+        ebull_test_conn.commit()
+
+        n = seed_manifest_from_filing_events(ebull_test_conn)
+        ebull_test_conn.commit()
+
+        # Only the 10-K should land — 13F-HR is filer-scoped.
+        assert n == 1
+        assert get_manifest_row(ebull_test_conn, "0000320193-26-000010") is not None
+        assert get_manifest_row(ebull_test_conn, "0000320193-26-000011") is None
+
     def test_run_first_install_drain_uses_filing_events_fast_path(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811

--- a/tests/test_sec_first_install_drain.py
+++ b/tests/test_sec_first_install_drain.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import json
+from datetime import date
 
 import psycopg
 import pytest
 
-from app.jobs.sec_first_install_drain import run_first_install_drain
+from app.jobs.sec_first_install_drain import (
+    run_first_install_drain,
+    seed_manifest_from_filing_events,
+)
 from app.services.sec_manifest import get_manifest_row
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
 
@@ -164,3 +168,105 @@ class TestDrain:
         )
         ebull_test_conn.commit()
         assert stats.ciks_processed == 1
+
+
+class TestSeedFromFilingEvents:
+    def test_seeds_manifest_from_filing_events_no_http(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # #1044: when filing_events has rows for the SEC provider,
+        # the drain seeds sec_filing_manifest from that table without
+        # any HTTP. The fake_get below would raise if called — proves
+        # the fast path was taken.
+        _seed_aapl(ebull_test_conn)
+        ebull_test_conn.execute(
+            """
+            INSERT INTO external_identifiers
+                (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES
+                (1701, 'sec', 'cik', '0000320193', TRUE)
+            ON CONFLICT DO NOTHING
+            """
+        )
+        ebull_test_conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, filing_date, filing_type, provider,
+                provider_filing_id, source_url, primary_document_url, raw_payload_json
+            )
+            VALUES
+                (1701, %s, '8-K', 'sec', '0000320193-26-000001',
+                 'https://www.sec.gov/...', 'https://www.sec.gov/.../item502.htm',
+                 %s::jsonb),
+                (1701, %s, 'DEF 14A', 'sec', '0000320193-26-000002',
+                 'https://www.sec.gov/...', 'https://www.sec.gov/.../proxy.htm',
+                 %s::jsonb)
+            """,
+            (
+                date(2026, 1, 15),
+                json.dumps({"provider_filing_id": "0000320193-26-000001"}),
+                date(2026, 2, 14),
+                json.dumps({"provider_filing_id": "0000320193-26-000002"}),
+            ),
+        )
+        ebull_test_conn.commit()
+
+        n = seed_manifest_from_filing_events(ebull_test_conn)
+        ebull_test_conn.commit()
+
+        assert n == 2
+        for accession in ("0000320193-26-000001", "0000320193-26-000002"):
+            row = get_manifest_row(ebull_test_conn, accession)
+            assert row is not None
+            assert row.subject_type == "issuer"
+            assert row.instrument_id == 1701
+            assert row.cik == "0000320193"
+
+    def test_run_first_install_drain_uses_filing_events_fast_path(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # #1044: when filing_events seeds the issuer rows, the per-CIK
+        # HTTP path is skipped for issuer subjects. Run with a fake
+        # get that raises — proves no HTTP was issued for the issuer.
+        _seed_aapl(ebull_test_conn)
+        ebull_test_conn.execute(
+            """
+            INSERT INTO external_identifiers
+                (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES
+                (1701, 'sec', 'cik', '0000320193', TRUE)
+            ON CONFLICT DO NOTHING
+            """
+        )
+        ebull_test_conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, filing_date, filing_type, provider,
+                provider_filing_id, source_url, primary_document_url, raw_payload_json
+            )
+            VALUES (1701, %s, '8-K', 'sec', '0000320193-26-000001',
+                    'https://www.sec.gov/...', NULL, %s::jsonb)
+            """,
+            (
+                date(2026, 1, 15),
+                json.dumps({"provider_filing_id": "0000320193-26-000001"}),
+            ),
+        )
+        ebull_test_conn.commit()
+
+        def _raising_get(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+            raise AssertionError(f"HTTP fast-path bypass failed: {url}")
+
+        stats = run_first_install_drain(
+            ebull_test_conn,
+            http_get=_raising_get,
+            follow_pagination=False,
+        )
+        ebull_test_conn.commit()
+
+        assert stats.rows_seeded_from_filing_events == 1
+        # ciks_skipped picks up the issuer subject the loop short-circuited.
+        assert stats.ciks_skipped >= 1
+        assert stats.manifest_rows_upserted >= 1


### PR DESCRIPTION
## What

Replaces the per-CIK HTTP loop's issuer pass (~21min for ~12k CIKs at 7 req/s) with a single SELECT from `filing_events` that calls `record_manifest_entry` per row (~15s for the same 12k events).

`seed_manifest_from_filing_events` LATERAL-joins `external_identifiers` to pick the best SEC CIK (primary preferred, falls back to non-primary). Uses canonical `map_form_to_source` + `is_amendment_form` helpers from `app.services.sec_manifest`. Reads accession from `fe.provider_filing_id` (authoritative column).

When the seed returns >0 rows, the per-CIK HTTP loop skips issuer subjects (still runs for institutional_filer + blockholder_filer which filing_events doesn't carry). In fallback mode (filing_events empty), the seed no-ops and the per-CIK HTTP path covers everything as before.

## Why

`sec_first_install_drain` was the dominant cost of the bootstrap's Phase B (~21min wall-clock). After C1.a + C1.b populate `filing_events`, the data is already on local disk — the drain re-fetching it via per-CIK HTTP was pure waste.

## Test plan

- [x] `TestSeedFromFilingEvents` (2 new tests) covers the seed function in isolation + the fast-path with a raising http_get (proves no HTTP issued for issuers).
- [x] All 7 drain tests pass.
- [x] Codex pre-push: APPROVE after addressing 5 findings (canonical helper imports, non-primary CIK fallback, accession source, amendment detection, comment accuracy).

Closes #1044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)