### PR TITLE
fix(#1054): real-archive edge cases — DD-MMM-YYYY dates, PRN, VALUE cutover, COM-preference

### DIFF
--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -39,6 +39,14 @@ from app.services.ownership_observations import record_institution_observation
 logger = logging.getLogger(__name__)
 
 
+# SEC FORM13F_metadata.json column description: "Starting on
+# January 3, 2023, market value is reported rounded to the nearest
+# dollar.  Previously, market value was reported in thousands."
+# Hoisted to module level so the cutover constant isn't re-built
+# on every INFOTABLE row. Codex pre-push NITPICK for #1054.
+_VALUE_DOLLARS_CUTOVER = date(2023, 1, 3)
+
+
 @dataclass
 class Form13FIngestResult:
     """Per-archive ingest outcome."""
@@ -306,16 +314,11 @@ def ingest_13f_dataset_archive(
                 continue
             shares = _parse_decimal(row.get("SSHPRNAMT"))
             # VALUE column unit changed 2023-01-03 — pre-cutover it
-            # was reported in $thousands, post-cutover in $dollars
-            # (SEC metadata FORM13F_metadata.json:
-            # "Starting on January 3, 2023, market value is reported
-            # rounded to the nearest dollar.  Previously, market value
-            # was reported in thousands."). Discriminate on FILED_AT
-            # (when the filer reported), NOT period_end — a 2022Q4
-            # restatement filed in March 2023 reports in dollars even
-            # though period_end is pre-cutover. Codex pre-push MEDIUM
-            # for #1054.
-            _VALUE_DOLLARS_CUTOVER = date(2023, 1, 3)
+            # was reported in $thousands, post-cutover in $dollars.
+            # See _VALUE_DOLLARS_CUTOVER constant at module top.
+            # Discriminate on FILED_AT (when the filer reported), NOT
+            # period_end — a 2022Q4 restatement filed in March 2023
+            # reports in dollars even though period_end is pre-cutover.
             value_raw = _parse_decimal(row.get("VALUE"))
             if value_raw is None:
                 market_value_usd = None

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -88,15 +88,37 @@ def _load_cusip_map(conn: psycopg.Connection[Any]) -> dict[str, int]:
 
 
 def _parse_filing_date(value: str | None) -> datetime | None:
+    """Parse a filing-date that may be ISO or SEC's ``DD-MMM-YYYY``.
+
+    Real-world 13F dataset (verified 2026-05-08 against
+    form13f_01dec2025-28feb2026.zip) emits ``FILING_DATE`` as
+    ``31-DEC-2025``, NOT ISO. Without the fallback every 13F holding
+    is rejected as bad_data — verified with a probe ingest that
+    produced 0 rows_written.
+    """
     if not value:
         return None
+    text = value.strip()
     try:
-        return datetime.fromisoformat(value).replace(tzinfo=UTC)
+        return datetime.fromisoformat(text).replace(tzinfo=UTC)
     except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(text[:10]).replace(tzinfo=UTC)
+    except ValueError:
+        pass
+    for fmt in ("%d-%b-%Y", "%d-%b-%y"):
         try:
-            return datetime.fromisoformat(value[:10]).replace(tzinfo=UTC)
+            return datetime.strptime(text, fmt).replace(tzinfo=UTC)
         except ValueError:
-            return None
+            continue
+    titled = text.title()
+    for fmt in ("%d-%b-%Y", "%d-%b-%y"):
+        try:
+            return datetime.strptime(titled, fmt).replace(tzinfo=UTC)
+        except ValueError:
+            continue
+    return None
 
 
 def _parse_period_end(value: str | None) -> date | None:
@@ -274,10 +296,33 @@ def ingest_13f_dataset_archive(
                 result.rows_skipped_bad_data += 1
                 continue
 
+            # SSHPRNAMT carries shares OR principal-amount depending on
+            # SSHPRNAMTTYPE (SH | PRN). PRN rows hold bond principal in
+            # dollars, NOT shares — must skip to avoid silent
+            # corruption (PR #1054 finding: 20k PRN rows in 2026Q1).
+            shprn_type = (row.get("SSHPRNAMTTYPE") or "").strip().upper()
+            if shprn_type and shprn_type != "SH":
+                result.rows_skipped_bad_data += 1
+                continue
             shares = _parse_decimal(row.get("SSHPRNAMT"))
-            value_thousands = _parse_decimal(row.get("VALUE"))
-            # SEC reports VALUE in $thousands. Multiply for canonical USD.
-            market_value_usd = (value_thousands * Decimal("1000")) if value_thousands is not None else None
+            # VALUE column unit changed 2023-01-03 — pre-cutover it
+            # was reported in $thousands, post-cutover in $dollars
+            # (SEC metadata FORM13F_metadata.json:
+            # "Starting on January 3, 2023, market value is reported
+            # rounded to the nearest dollar.  Previously, market value
+            # was reported in thousands."). Discriminate on FILED_AT
+            # (when the filer reported), NOT period_end — a 2022Q4
+            # restatement filed in March 2023 reports in dollars even
+            # though period_end is pre-cutover. Codex pre-push MEDIUM
+            # for #1054.
+            _VALUE_DOLLARS_CUTOVER = date(2023, 1, 3)
+            value_raw = _parse_decimal(row.get("VALUE"))
+            if value_raw is None:
+                market_value_usd = None
+            elif filed_at.date() >= _VALUE_DOLLARS_CUTOVER:
+                market_value_usd = value_raw
+            else:
+                market_value_usd = value_raw * Decimal("1000")
 
             voting_authority = _map_voting_authority(row)
             exposure_kind = _map_putcall(row.get("PUTCALL"))

--- a/app/services/sec_13f_securities_list.py
+++ b/app/services/sec_13f_securities_list.py
@@ -267,6 +267,54 @@ def _bucket_by_first_token(
     return out
 
 
+# Description tokens that mark equity/common-share rows on the SEC
+# 13F Official List. Every issuer's COM line is paired with CALL +
+# PUT (and sometimes WT/UNIT/RIGHTS) sharing the SAME issuer_name —
+# without preference filtering, every matched issuer trips the
+# ambiguity rejection (real-world bug surfaced 2026-05-08:
+# backfill returned inserted=0 because every issuer had >1 same-
+# score row across COM/CALL/PUT). Selecting the COM row over the
+# option row is unambiguous: CALL/PUT have distinct CUSIPs from the
+# underlying common but represent options on the same issuer; the
+# 13F holdings ingester filters PUTCALL separately so picking the
+# COM CUSIP is the correct identity for ownership joins.
+# UNIT is intentionally OMITTED — SPAC unit CUSIPs (which often
+# include warrants attached) are NOT the same security as the
+# common stock and would map a stock instrument to the wrong CUSIP.
+# Codex pre-push MEDIUM for #1054.
+_COMMON_SHARE_DESC_TOKENS: frozenset[str] = frozenset(
+    {
+        "COM",
+        "COMMON",
+        "SHS",
+        "SHARES",
+        "CL",  # CL A / CL B common-share class designators
+        "CLASS",
+        "ORD",  # ordinary shares
+        "ADS",  # American Depositary Shares
+        "ADR",  # American Depositary Receipts
+        "REIT",
+    }
+)
+_OPTION_DESC_TOKENS: frozenset[str] = frozenset({"CALL", "PUT", "WTS", "WARRANT", "WT", "RIGHT", "RIGHTS"})
+
+
+def _is_common_share(sec: ThirteenFSecurity) -> bool:
+    desc = (sec.description or "").upper().strip()
+    if not desc:
+        return False
+    tokens = set(desc.split())
+    if tokens & _OPTION_DESC_TOKENS:
+        return False
+    return bool(tokens & _COMMON_SHARE_DESC_TOKENS)
+
+
+def _is_option(sec: ThirteenFSecurity) -> bool:
+    desc = (sec.description or "").upper().strip()
+    tokens = set(desc.split())
+    return bool(tokens & _OPTION_DESC_TOKENS)
+
+
 def _best_match(
     target: str,
     bucket: list[tuple[str, ThirteenFSecurity]],
@@ -277,8 +325,13 @@ def _best_match(
 
     Mirrors the resolver's same-named helper: we walk the bucket,
     pick the highest similarity, return a flag when two distinct
-    CUSIPs tie at the top score (typical SPAC / share-class
-    collision — operator must disambiguate via curated mapping).
+    CUSIPs tie at the top score.
+
+    Tie-break for SEC 13F triplets (#1054): when the top-score set
+    contains both common-share and option (CALL/PUT) rows under the
+    same issuer name, prefer the common-share row. Ambiguity only
+    fires when distinct ISSUERS tie at the top (true SPAC /
+    share-class collision that needs operator disambiguation).
     """
     if not target or not bucket:
         return (None, False)
@@ -295,9 +348,25 @@ def _best_match(
             top_securities.append(sec)
     if not top_securities:
         return (None, False)
-    distinct_cusips = {s.cusip for s in top_securities}
+    # Prefer common-share rows over option rows when both share the
+    # top score (the SEC list always emits COM + CALL + PUT triplets
+    # for each underlying issuer).
+    common = [s for s in top_securities if _is_common_share(s)]
+    options = [s for s in top_securities if _is_option(s)]
+    preferred: list[ThirteenFSecurity]
+    if common and options and len(common) + len(options) == len(top_securities):
+        # Every top row is either common or option; restrict to common.
+        preferred = common
+    elif common and len(common) < len(top_securities):
+        # Mixed: prefer common, but keep ambiguity check honest by
+        # only collapsing if every non-common is an option.
+        non_common_non_option = [s for s in top_securities if not _is_common_share(s) and not _is_option(s)]
+        preferred = common if not non_common_non_option else top_securities
+    else:
+        preferred = top_securities
+    distinct_cusips = {s.cusip for s in preferred}
     is_ambiguous = len(distinct_cusips) > 1
-    return (top_securities[0], is_ambiguous)
+    return (preferred[0], is_ambiguous)
 
 
 def _insert_external_identifier(

--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -73,26 +73,66 @@ class NPortIngestResult:
 
 
 def _parse_filing_date(value: str | None) -> datetime | None:
+    """Parse a filing-date that may be ISO or SEC's ``DD-MMM-YYYY``.
+
+    Real-world N-PORT dataset (verified 2026-05-08 against
+    nport_2026q1.zip) emits ``FILING_DATE`` as ``25-FEB-2026``.
+    """
     if not value:
         return None
     text = value.strip()
     try:
         return datetime.fromisoformat(text).replace(tzinfo=UTC)
     except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(text[:10]).replace(tzinfo=UTC)
+    except ValueError:
+        pass
+    for fmt in ("%d-%b-%Y", "%d-%b-%y"):
         try:
-            return datetime.fromisoformat(text[:10]).replace(tzinfo=UTC)
+            return datetime.strptime(text, fmt).replace(tzinfo=UTC)
         except ValueError:
-            return None
+            continue
+    titled = text.title()
+    for fmt in ("%d-%b-%Y", "%d-%b-%y"):
+        try:
+            return datetime.strptime(titled, fmt).replace(tzinfo=UTC)
+        except ValueError:
+            continue
+    return None
 
 
 def _parse_iso_date(value: str | None) -> date | None:
+    """Parse a date that may be ISO or SEC's ``DD-MMM-YYYY`` format.
+
+    Real-world SEC N-PORT dataset (verified 2026-05-08 against
+    nport_2026q1.zip) emits ``REPORT_DATE`` and ``REPORT_ENDING_PERIOD``
+    as ``31-DEC-2025``, NOT ISO. Without the fallback every N-PORT
+    holding gets skipped as bad_data — verified with a probe ingest
+    that produced 0 rows_written.
+    """
     if not value:
         return None
     text = value.strip()
     try:
         return date.fromisoformat(text[:10])
     except ValueError:
-        return None
+        pass
+    for fmt in ("%d-%b-%Y", "%d-%b-%y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    # `%b` is locale-aware; SEC uses uppercase MMM (DEC, JAN, …).
+    # Many locales accept it but title-case as fallback.
+    titled = text.title()
+    for fmt in ("%d-%b-%Y", "%d-%b-%y"):
+        try:
+            return datetime.strptime(titled, fmt).date()
+        except ValueError:
+            continue
+    return None
 
 
 def _parse_decimal(value: str | None) -> Decimal | None:

--- a/tests/test_sec_13f_dataset_ingest.py
+++ b/tests/test_sec_13f_dataset_ingest.py
@@ -200,8 +200,12 @@ class TestIngest13FDatasetArchive:
             assert nature == "economic"
             assert source == "13f"
             assert shares == Decimal("100000.0000")
-            # 5_000_000 thousands = 5_000_000_000 USD.
-            assert mv == Decimal("5000000000.00")
+            # Post-2023-01-03 SEC reports VALUE in dollars (not
+            # thousands) — period_end here is 2025-09-30 so no
+            # multiplier applied. SEC FORM13F_metadata.json column
+            # description: "Starting on January 3, 2023, market value
+            # is reported rounded to the nearest dollar."
+            assert mv == Decimal("5000000.00")
             assert voting == "SOLE"
             assert exposure == "EQUITY"
             assert period.isoformat() == "2025-09-30"
@@ -301,3 +305,146 @@ class TestIngest13FDatasetArchive:
             )
             kinds = [r[0] for r in cur.fetchall()]
             assert kinds == ["CALL", "EQUITY", "PUT"]
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestRealArchiveEdgeCases:
+    """Pin behaviour against real-archive edge cases discovered
+    2026-05-08 by ingesting form13f_01dec2025-28feb2026.zip
+    end-to-end (#1054)."""
+
+    def test_dd_mmm_yyyy_filing_date_format_parses(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # Real SEC 13F dataset emits FILING_DATE as DD-MMM-YYYY
+        # ('31-DEC-2025'), NOT ISO. Pre-fix every row was rejected
+        # as bad_data — verified end-to-end produced 0 rows_written.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CIK": "1234567",
+                    "FILING_DATE": "31-DEC-2025",  # SEC dataset format
+                },
+            ],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILINGMANAGER_NAME": "Big Fund LLC",
+                    "REPORTCALENDARORQUARTER": "30-SEP-2025",
+                },
+            ],
+            infotable=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CUSIP": "037833100",
+                    "VALUE": "1000",
+                    "SSHPRNAMT": "100",
+                    "SSHPRNAMTTYPE": "SH",
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+        assert result.rows_written == 1, f"expected 1, got {result}"
+
+    def test_prn_rows_skipped_as_bad_data(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # SSHPRNAMT carries shares (SH) OR principal-amount (PRN)
+        # depending on SSHPRNAMTTYPE. Real archive 2026Q1 had 20k
+        # PRN rows. Without filter they'd get stored as shares —
+        # silent data corruption.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {"ACCESSION_NUMBER": "0001234567-25-000001", "CIK": "1", "FILING_DATE": "2025-11-14"},
+            ],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILINGMANAGER_NAME": "Bond Fund",
+                    "REPORTCALENDARORQUARTER": "2025-09-30",
+                },
+            ],
+            infotable=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CUSIP": "037833100",
+                    "VALUE": "1000",
+                    "SSHPRNAMT": "1000000",
+                    "SSHPRNAMTTYPE": "PRN",  # bond principal — must skip
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+        assert result.rows_written == 0
+        assert result.rows_skipped_bad_data == 1
+
+    def test_value_pre_2023_cutover_multiplied_by_thousands(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # Pre-2023-01-03 SEC reported VALUE in $thousands.
+        # Post-cutover in dollars. SEC FORM13F_metadata.json:
+        # "Starting on January 3, 2023, market value is reported
+        # rounded to the nearest dollar."
+        iid = _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {"ACCESSION_NUMBER": "0001234567-22-000001", "CIK": "1", "FILING_DATE": "2022-12-15"},
+            ],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-22-000001",
+                    "FILINGMANAGER_NAME": "Old Fund",
+                    "REPORTCALENDARORQUARTER": "2022-09-30",  # pre-cutover
+                },
+            ],
+            infotable=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-22-000001",
+                    "CUSIP": "037833100",
+                    "VALUE": "5000000",  # $thousands → 5B dollars
+                    "SSHPRNAMT": "100000",
+                    "SSHPRNAMTTYPE": "SH",
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+        assert result.rows_written == 1
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT market_value_usd FROM ownership_institutions_observations WHERE instrument_id=%s",
+                (iid,),
+            )
+            mv = cur.fetchone()[0]
+        # 5,000,000 thousands = 5B USD (pre-2023 multiplier applied).
+        assert mv == Decimal("5000000000.00")

--- a/tests/test_sec_13f_dataset_ingest.py
+++ b/tests/test_sec_13f_dataset_ingest.py
@@ -445,6 +445,8 @@ class TestRealArchiveEdgeCases:
                 "SELECT market_value_usd FROM ownership_institutions_observations WHERE instrument_id=%s",
                 (iid,),
             )
-            mv = cur.fetchone()[0]
+            row = cur.fetchone()
+            assert row is not None
+            mv = row[0]
         # 5,000,000 thousands = 5B USD (pre-2023 multiplier applied).
         assert mv == Decimal("5000000000.00")

--- a/tests/test_sec_13f_securities_list.py
+++ b/tests/test_sec_13f_securities_list.py
@@ -456,3 +456,113 @@ class TestBackfillCusipCoverage:
         backfill_cusip_coverage(conn, today=date(2026, 5, 5), fetch=_fake)
         # 2026-05-05 → most recent closed quarter is 2026 Q1.
         assert captured["q"] == (2026, 1)
+
+
+# ---------------------------------------------------------------------------
+# CUSIP matcher COM/CALL/PUT triplet handling (#1054)
+# ---------------------------------------------------------------------------
+
+
+class TestBestMatchCommonSharePreference:
+    """Pin the matcher's behaviour against the real-archive collision
+    pattern: SEC 13F Official List ALWAYS lists each issuer 3 times
+    (COM + CALL + PUT) sharing the same issuer name. Naive ambiguity
+    detection collapses every equity issuer."""
+
+    @staticmethod
+    def _bucket(rows: list[tuple[str, str, str]]) -> list:
+        from app.services.sec_13f_securities_list import ThirteenFSecurity
+
+        return [
+            (
+                "APPLE",
+                ThirteenFSecurity(
+                    cusip=cusip, issuer_name=name, description=desc, is_added_since_last=False, status="E"
+                ),
+            )
+            for cusip, name, desc in rows
+        ]
+
+    def test_com_call_put_collapses_to_com(self) -> None:
+        from app.services.cusip_resolver import MATCH_THRESHOLD
+        from app.services.sec_13f_securities_list import _best_match
+
+        bucket = self._bucket(
+            [
+                ("037833100", "APPLE INC", "COM"),
+                ("037833900", "APPLE INC", "CALL"),
+                ("037833950", "APPLE INC", "PUT"),
+            ]
+        )
+        best, ambig = _best_match("APPLE", bucket, threshold=MATCH_THRESHOLD)
+        assert best is not None
+        assert best.cusip == "037833100"
+        assert ambig is False
+
+    def test_unit_call_put_does_not_collapse_to_unit(self) -> None:
+        # SPAC unit CUSIPs are distinct from common-stock CUSIPs;
+        # without a COM row the matcher must NOT pick the UNIT row
+        # silently. Codex pre-push MEDIUM for #1054.
+        from app.services.cusip_resolver import MATCH_THRESHOLD
+        from app.services.sec_13f_securities_list import _best_match
+
+        bucket = self._bucket(
+            [
+                ("UNIT12345", "APPLE INC", "UNIT"),
+                ("OPTC12345", "APPLE INC", "CALL"),
+                ("OPTP12345", "APPLE INC", "PUT"),
+            ]
+        )
+        best, ambig = _best_match("APPLE", bucket, threshold=MATCH_THRESHOLD)
+        # No common-share row → no collapse; ambig stays True since
+        # UNIT vs CALL/PUT remain distinct CUSIPs.
+        assert ambig is True
+
+    def test_distinct_issuers_at_top_score_stay_ambiguous(self) -> None:
+        # True share-class collision: distinct issuers normalising to
+        # same first-token name. Must remain ambiguous.
+        from app.services.cusip_resolver import MATCH_THRESHOLD
+        from app.services.sec_13f_securities_list import ThirteenFSecurity, _best_match
+
+        bucket = [
+            (
+                "APPLE",
+                ThirteenFSecurity(
+                    cusip="037833100",
+                    issuer_name="APPLE INC",
+                    description="COM",
+                    is_added_since_last=False,
+                    status="E",
+                ),
+            ),
+            (
+                "APPLE",
+                ThirteenFSecurity(
+                    cusip="03784Y200",
+                    issuer_name="APPLE HOSPITALITY REIT INC",
+                    description="COM NEW",
+                    is_added_since_last=False,
+                    status="E",
+                ),
+            ),
+        ]
+        # With score-1.0 to "APPLE" the COM/COM-NEW tie is real.
+        best, ambig = _best_match("APPLE", bucket, threshold=MATCH_THRESHOLD)
+        assert ambig is True
+
+
+class TestParseDateNPORT:
+    def test_dd_mmm_yyyy_format_parses(self) -> None:
+        # Regression for #1054: real N-PORT archive emits
+        # `25-FEB-2026` for FILING_DATE and `31-DEC-2025` for
+        # REPORT_ENDING_PERIOD. ISO-only parser silently dropped
+        # every row.
+        from app.services.sec_nport_dataset_ingest import _parse_filing_date, _parse_iso_date
+
+        d = _parse_iso_date("31-DEC-2025")
+        assert d is not None
+        assert d.isoformat() == "2025-12-31"
+
+        ts = _parse_filing_date("25-FEB-2026")
+        assert ts is not None
+        assert ts.date().isoformat() == "2026-02-25"


### PR DESCRIPTION
Refs #1054 (this PR's edge-case sweep filed three follow-up issues #1054 #1055 #1056; all three are filed-as-followup, not closed by this PR; this PR's title cites #1054 because that's the parent issue # for the bulk-archive ingester sweep work).

## What

End-to-end test of each bulk-archive ingester against actual SEC archives surfaced 6 BLOCKING bugs producing 0 rows_written from real data despite test suite passing. Fixes:

1. **DD-MMM-YYYY date parsers** — 13F + N-PORT had ISO-only `_parse_filing_date` / `_parse_iso_date`; rejected real archive's `'31-DEC-2025'` format.
2. **13F PRN filter** — `SSHPRNAMT` is shares OR bond principal per `SSHPRNAMTTYPE`. 20k PRN rows in 2026Q1 were silently stored as shares.
3. **13F VALUE 2023-01-03 cutover** — pre-cutover \$thousands, post-cutover dollars. Pre-fix Vanguard AAPL = \$347T (1000x reality). Conditional on `filed_at`.
4. **CUSIP matcher COM-preference** — SEC 13F list emits each issuer 3 times (COM/CALL/PUT). Naive ambiguity check rejected EVERY equity. Pre-fix `inserted=0`. Post-fix `inserted=2,933` (AAPL CUSIP `037833100` mapped).

## Why

Operator triggered bootstrap; despite all stages running successfully, AAPL/MSFT showed 0 ownership. Root cause: real archives violated multiple format assumptions baked into the existing tests.

## End-to-end verification (dev DB, 2026Q1)

- 13F: 1,464,721 rows; AAPL Vanguard = 1.28B shares × ~\$272 = **\$347.7B** (matches gurufocus/bloomberg).
- Insider: 111,247 rows.
- N-PORT: 556,758 rows.

## Test plan

- [x] `TestRealArchiveEdgeCases` — DD-MMM-YYYY / PRN / pre-2023 VALUE multiplier.
- [x] `TestBestMatchCommonSharePreference` — COM/CALL/PUT collapse, UNIT/CALL/PUT non-collapse, distinct-issuer ambiguity.
- [x] `TestParseDateNPORT` — real-format DD-MMM-YYYY.
- [x] Codex pre-push: APPROVE after addressing 4 findings (UNIT collapse, cutover discriminator, matcher tests, parity check).

## Upstream issues filed (separate scope, NOT closed by this PR)

- Refs #1054 PRN parity in legacy per-filing XML ingester
- Refs #1055 Exchange `asset_class` classification missing post-universe-sync
- Refs #1056 cik_refresh hash-skip breaks after data wipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)