### PR TITLE
fix(#1055,#1056): wipe-then-bootstrap works clean — no hand-patching

### DIFF
--- a/app/services/exchanges.py
+++ b/app/services/exchanges.py
@@ -110,3 +110,198 @@ def refresh_exchanges_metadata(
         inserted=inserted,
         description_updated=description_updated,
     )
+
+
+@dataclass(frozen=True)
+class ExchangesReclassifySummary:
+    """Result of one ``reclassify_unknown_exchanges`` call."""
+
+    classified: int  # asset_class='unknown' rows promoted to a concrete class
+
+
+def _count_unknown_exchanges(conn: psycopg.Connection) -> int:  # type: ignore[type-arg]
+    """Return the count of exchanges with asset_class='unknown'."""
+    row = conn.execute("SELECT COUNT(*) FROM exchanges WHERE asset_class = 'unknown'").fetchone()
+    return int(row[0]) if row else 0
+
+
+def reclassify_unknown_exchanges(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+) -> ExchangesReclassifySummary:
+    """Auto-classify ``exchanges.asset_class='unknown'`` rows from
+    instrument-suffix patterns (#1055).
+
+    Why this exists: sql/068 ran the same classification CTE at
+    migration time when the ``instruments`` table was empty. The
+    dominance computation produced nothing and every exchange stayed
+    ``unknown``. After ``nightly_universe_sync`` populates instruments
+    the CTE has data to work with — but it never re-fires. Result:
+    fresh installs have AAPL/MSFT etc on exchanges classified as
+    'unknown', so every job that filters on
+    ``e.asset_class = 'us_equity'`` (cik_refresh, cusip backfill,
+    bootstrap_preconditions cohort queries) returns 0 rows.
+
+    Operator-curated rows are PRESERVED — the WHERE filter only
+    touches rows where ``asset_class='unknown'``. A row promoted to
+    a concrete class by a prior run STAYS at that class even if the
+    suffix pattern would now imply a different one.
+
+    The classification is the same as sql/068 — kept in lock-step;
+    extending the suffix → asset_class map requires updating both
+    sites (the migration runs once at install, this service runs
+    every nightly_universe_sync).
+
+    ``classified`` in the returned summary is the count of rows
+    PROMOTED THIS CALL (before-after delta on asset_class='unknown').
+    """
+    unknown_before = _count_unknown_exchanges(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH suffix_counts AS (
+                SELECT
+                    i.exchange AS exchange_id,
+                    CASE
+                        WHEN POSITION('.' IN i.symbol) > 0
+                            THEN UPPER(SPLIT_PART(REVERSE(i.symbol), '.', 1))
+                        ELSE NULL
+                    END AS suffix,
+                    COUNT(*) AS n
+                FROM instruments i
+                WHERE i.exchange IS NOT NULL
+                GROUP BY 1, 2
+            ),
+            ranked AS (
+                SELECT exchange_id, suffix, n,
+                       ROW_NUMBER() OVER (PARTITION BY exchange_id ORDER BY n DESC) AS rn,
+                       SUM(n) OVER (PARTITION BY exchange_id) AS total_n
+                FROM suffix_counts
+            ),
+            dominant AS (
+                SELECT
+                    r.exchange_id,
+                    REVERSE(r.suffix) AS suffix,
+                    r.n,
+                    r.total_n
+                FROM ranked r
+                WHERE r.rn = 1
+                  AND r.n::numeric / NULLIF(r.total_n, 0) > 0.80
+                  AND NOT EXISTS (
+                      SELECT 1 FROM ranked r2
+                      WHERE r2.exchange_id = r.exchange_id
+                        AND r2.rn = 2
+                        AND r2.n = r.n
+                  )
+            )
+            UPDATE exchanges e
+               SET asset_class = m.asset_class,
+                   country     = m.country,
+                   updated_at  = NOW()
+              FROM (
+                  SELECT d.exchange_id,
+                         CASE
+                             WHEN d.suffix IS NULL AND d.total_n > 30 THEN 'us_equity'
+                             WHEN d.suffix = 'L'    THEN 'uk_equity'
+                             WHEN d.suffix = 'DE'   THEN 'eu_equity'
+                             WHEN d.suffix = 'PA'   THEN 'eu_equity'
+                             WHEN d.suffix = 'ST'   THEN 'eu_equity'
+                             WHEN d.suffix = 'OL'   THEN 'eu_equity'
+                             WHEN d.suffix = 'IM'   THEN 'eu_equity'
+                             WHEN d.suffix = 'MI'   THEN 'eu_equity'
+                             WHEN d.suffix = 'HE'   THEN 'eu_equity'
+                             WHEN d.suffix = 'NV'   THEN 'eu_equity'
+                             WHEN d.suffix = 'AS'   THEN 'eu_equity'
+                             WHEN d.suffix = 'CO'   THEN 'eu_equity'
+                             WHEN d.suffix = 'BR'   THEN 'eu_equity'
+                             WHEN d.suffix = 'MC'   THEN 'eu_equity'
+                             WHEN d.suffix = 'ZU'   THEN 'eu_equity'
+                             WHEN d.suffix = 'LS'   THEN 'eu_equity'
+                             WHEN d.suffix = 'LSB'  THEN 'eu_equity'
+                             WHEN d.suffix = 'HK'   THEN 'asia_equity'
+                             WHEN d.suffix = 'T'    THEN 'asia_equity'
+                             WHEN d.suffix = 'ASX'  THEN 'asia_equity'
+                             WHEN d.suffix = 'DH'   THEN 'mena_equity'
+                             WHEN d.suffix = 'AE'   THEN 'mena_equity'
+                             WHEN d.suffix = 'RTH'  THEN 'us_equity'
+                             WHEN d.suffix = 'FUT'  THEN 'commodity'
+                             ELSE NULL
+                         END AS asset_class,
+                         CASE
+                             WHEN d.suffix = 'L'    THEN 'GB'
+                             WHEN d.suffix = 'DE'   THEN 'DE'
+                             WHEN d.suffix = 'PA'   THEN 'FR'
+                             WHEN d.suffix = 'ST'   THEN 'SE'
+                             WHEN d.suffix = 'OL'   THEN 'NO'
+                             WHEN d.suffix IN ('IM', 'MI') THEN 'IT'
+                             WHEN d.suffix = 'HE'   THEN 'FI'
+                             WHEN d.suffix IN ('NV', 'AS') THEN 'NL'
+                             WHEN d.suffix = 'CO'   THEN 'DK'
+                             WHEN d.suffix = 'BR'   THEN 'BE'
+                             WHEN d.suffix = 'MC'   THEN 'ES'
+                             WHEN d.suffix = 'ZU'   THEN 'CH'
+                             WHEN d.suffix IN ('LS', 'LSB') THEN 'PT'
+                             WHEN d.suffix = 'HK'   THEN 'HK'
+                             WHEN d.suffix = 'T'    THEN 'JP'
+                             WHEN d.suffix = 'ASX'  THEN 'AU'
+                             WHEN d.suffix = 'DH'   THEN 'AE'
+                             WHEN d.suffix = 'AE'   THEN 'AE'
+                             WHEN d.suffix IS NULL AND d.total_n > 30 THEN 'US'
+                             WHEN d.suffix = 'RTH'  THEN 'US'
+                             ELSE NULL
+                         END AS country
+                  FROM dominant d
+              ) AS m
+             WHERE e.exchange_id = m.exchange_id
+               AND e.asset_class = 'unknown'
+               AND m.asset_class IS NOT NULL
+            """
+        )
+        # Hard-coded overrides for known special exchange ids that
+        # the suffix heuristic can't disambiguate (FX/commodity/index/
+        # crypto exchanges with no consistent suffix). Mirrors
+        # sql/068 lines 193-203 plus exchange_id='8' (crypto, seeded
+        # in production via #503 PR 3 but historically left
+        # 'unknown' on dev installs).
+        cur.execute(
+            """
+            UPDATE exchanges SET asset_class = 'fx', country = NULL, updated_at = NOW()
+             WHERE exchange_id = '1' AND asset_class = 'unknown'
+            """
+        )
+        cur.execute(
+            """
+            UPDATE exchanges SET asset_class = 'commodity', country = NULL, updated_at = NOW()
+             WHERE exchange_id = '2' AND asset_class = 'unknown'
+            """
+        )
+        cur.execute(
+            """
+            UPDATE exchanges SET asset_class = 'index', country = NULL, updated_at = NOW()
+             WHERE exchange_id = '3' AND asset_class = 'unknown'
+            """
+        )
+        cur.execute(
+            """
+            UPDATE exchanges SET asset_class = 'crypto', country = NULL, updated_at = NOW()
+             WHERE exchange_id = '8' AND asset_class = 'unknown'
+            """
+        )
+        cur.execute(
+            """
+            UPDATE exchanges SET asset_class = 'us_equity', country = 'US', updated_at = NOW()
+             WHERE exchange_id IN ('19', '20') AND asset_class = 'unknown'
+            """
+        )
+        cur.execute("SELECT COUNT(*) FROM exchanges")
+        row = cur.fetchone()
+        total = int(row[0]) if row else 0
+    unknown_after = _count_unknown_exchanges(conn)
+    classified = max(0, unknown_before - unknown_after)
+    logger.info(
+        "reclassify_unknown_exchanges: classified=%d this call (unknown %d -> %d, total exchanges=%d)",
+        classified,
+        unknown_before,
+        unknown_after,
+        total,
+    )
+    return ExchangesReclassifySummary(classified=classified)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1216,6 +1216,23 @@ def nightly_universe_sync() -> None:
                     summary.deactivated,
                 )
 
+            # #1055: auto-classify exchanges.asset_class='unknown' rows
+            # from the now-populated instrument suffix patterns. The
+            # one-shot migration sql/068 ran at install when the
+            # instruments table was empty so its dominance computation
+            # produced nothing — every exchange stayed 'unknown' and
+            # downstream us_equity-cohort filters returned 0 rows.
+            # Operator-curated rows are preserved (filter scopes to
+            # asset_class='unknown' only).
+            from app.services.exchanges import reclassify_unknown_exchanges
+
+            with conn.transaction():
+                reclass = reclassify_unknown_exchanges(conn)
+                logger.info(
+                    "Universe sync: reclassified %d exchanges from 'unknown'",
+                    reclass.classified,
+                )
+
             # First-run bootstrap: if the coverage table is empty after a
             # successful universe sync, seed all tradable instruments at
             # Tier 3.  This is a no-op on subsequent runs (seed_coverage
@@ -1420,6 +1437,20 @@ def daily_candle_refresh() -> None:
     )
 
 
+def _cik_destination_is_empty(conn: psycopg.Connection) -> bool:  # type: ignore[type-arg]
+    """Return True when ``external_identifiers`` has zero SEC CIK rows.
+
+    Extracted for testability — daily_cik_refresh's force-full-upsert
+    decision pivots on this query result. Empty destination after a
+    data wipe must trigger an unconditional fetch + upsert regardless
+    of any surviving watermark / body-hash. (#1056)
+    """
+    row = conn.execute(
+        "SELECT COUNT(*) FROM external_identifiers WHERE provider = 'sec' AND identifier_type = 'cik'"
+    ).fetchone()
+    return row is not None and int(row[0]) == 0
+
+
 def daily_cik_refresh() -> None:
     """
     Refresh SEC ticker → CIK mapping and upsert into external_identifiers.
@@ -1448,17 +1479,38 @@ def daily_cik_refresh() -> None:
             SecFilingsProvider(user_agent=settings.sec_user_agent) as provider,
             psycopg.connect(settings.database_url) as conn,
         ):
+            # #1056: detect empty destination. If the operator wiped
+            # external_identifiers but the watermark survived (the
+            # admin-wipe doesn't currently clear watermarks), the
+            # 304/hash-skip branch below would silently no-op forever
+            # and AAPL/MSFT would never get CIKs. Force a full
+            # unconditional fetch + upsert when destination is empty.
+            dest_empty = _cik_destination_is_empty(conn)
+
             prior = get_watermark(conn, SOURCE, WATERMARK_KEY)
             # Explicit truthy check: an empty-string watermark from a
             # prior run where Last-Modified was absent must NOT be sent
             # as `If-Modified-Since: ` (invalid HTTP date).
-            if_modified_since = prior.watermark if (prior and prior.watermark) else None
+            # On dest_empty, send no conditional header so the SEC
+            # cannot return 304 against a stale validator.
+            if_modified_since = None if dest_empty else (prior.watermark if (prior and prior.watermark) else None)
 
             result = provider.build_cik_mapping_conditional(
                 if_modified_since=if_modified_since,
             )
 
             if result is None:
+                if dest_empty:
+                    # Should be unreachable — when dest is empty we
+                    # send no If-Modified-Since header so SEC cannot
+                    # legitimately return 304. Codex pre-push MEDIUM
+                    # for #1056: enforce the invariant explicitly so
+                    # a future provider/refactor that silently sends
+                    # IMS doesn't leave dest empty forever.
+                    raise RuntimeError(
+                        "daily_cik_refresh: provider returned 304 despite empty destination "
+                        "(no If-Modified-Since header sent). Refusing to skip upsert — investigate."
+                    )
                 # 304 — nothing changed.
                 logger.info("daily_cik_refresh: 304 Not Modified, skipping upsert")
                 tracker.row_count = 0
@@ -1466,8 +1518,11 @@ def daily_cik_refresh() -> None:
 
             mapping_size = len(result.mapping)
 
-            if prior and prior.response_hash == result.body_hash:
-                # 200 with identical bytes. Advance fetched_at only.
+            if not dest_empty and prior and prior.response_hash == result.body_hash:
+                # 200 with identical bytes AND destination already has
+                # rows — advance fetched_at only. When destination is
+                # empty we MUST upsert regardless of hash (the data
+                # was wiped; the hash-skip branch would leave it empty).
                 logger.info("daily_cik_refresh: 200 but body hash unchanged, skipping upsert")
                 with conn.transaction():
                     set_watermark(
@@ -1479,6 +1534,11 @@ def daily_cik_refresh() -> None:
                     )
                 tracker.row_count = 0
                 return
+            if dest_empty:
+                logger.warning(
+                    "daily_cik_refresh: destination external_identifiers (sec/cik) is empty — "
+                    "forcing full upsert regardless of watermark / body hash."
+                )
 
             # #475: Scope to US-listed exchanges only. SEC's
             # company_tickers.json only covers US-registered companies;

--- a/tests/test_daily_cik_refresh_scope.py
+++ b/tests/test_daily_cik_refresh_scope.py
@@ -227,9 +227,9 @@ class TestDailyCikRefreshEmptyDest:
         monkeypatch.setattr(settings, "database_url", test_database_url())
 
     def test_empty_dest_omits_if_modified_since(self, ebull_test_conn, monkeypatch) -> None:
-        self._patch_db_url(monkeypatch)
         """Stale watermark + empty dest → refresh sends no IMS so
         SEC can't return 304 against the stale validator."""
+        self._patch_db_url(monkeypatch)
         from app.services.watermarks import set_watermark
         from app.workers.scheduler import daily_cik_refresh
 
@@ -271,9 +271,9 @@ class TestDailyCikRefreshEmptyDest:
         assert row[0] == "0000320193"
 
     def test_empty_dest_with_matching_hash_still_upserts(self, ebull_test_conn, monkeypatch) -> None:
-        self._patch_db_url(monkeypatch)
         """Empty dest + 200-with-same-body-hash must still upsert.
         Pre-fix: the hash-skip branch fired and dest stayed empty."""
+        self._patch_db_url(monkeypatch)
         from app.services.watermarks import set_watermark
         from app.workers.scheduler import daily_cik_refresh
 
@@ -309,10 +309,10 @@ class TestDailyCikRefreshEmptyDest:
         assert row[0] == "0000320193"
 
     def test_empty_dest_with_none_result_raises(self, ebull_test_conn, monkeypatch) -> None:
-        self._patch_db_url(monkeypatch)
         """Defence-in-depth: if the provider returns None despite no
         IMS being sent (impossible but guarded), raise loudly so the
         bug isn't masked. Codex pre-push MEDIUM for #1056."""
+        self._patch_db_url(monkeypatch)
         from app.workers.scheduler import daily_cik_refresh
 
         self._seed_aapl_us_equity(ebull_test_conn)

--- a/tests/test_daily_cik_refresh_scope.py
+++ b/tests/test_daily_cik_refresh_scope.py
@@ -137,3 +137,194 @@ class TestCikCandidateQueryScope:
 
         symbols = sorted(s for s, _ in self._run_scoped_query(ebull_test_conn))
         assert "UNK" not in symbols
+
+
+# ---------------------------------------------------------------------------
+# Empty-destination forces full upsert (#1056)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestCikDestinationIsEmpty:
+    """Pin #1056: when the operator wipes external_identifiers but
+    the watermark survives, daily_cik_refresh's empty-dest helper
+    detects the empty state so the upsert is forced regardless of
+    304 / hash-skip optimisations."""
+
+    def test_returns_true_when_no_sec_cik_rows(self, ebull_test_conn) -> None:
+        from app.workers.scheduler import _cik_destination_is_empty
+
+        ebull_test_conn.execute("DELETE FROM external_identifiers WHERE provider='sec' AND identifier_type='cik'")
+        ebull_test_conn.commit()
+        assert _cik_destination_is_empty(ebull_test_conn) is True
+
+    def test_returns_false_when_at_least_one_sec_cik_row(self, ebull_test_conn) -> None:
+        from app.workers.scheduler import _cik_destination_is_empty
+
+        # Seed a single SEC CIK row.
+        _seed_instrument(ebull_test_conn, instrument_id=4801, symbol="AAPL", exchange="4")
+        ebull_test_conn.execute(
+            "INSERT INTO external_identifiers "
+            "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (4801, 'sec', 'cik', '0000320193', TRUE) "
+            "ON CONFLICT DO NOTHING"
+        )
+        ebull_test_conn.commit()
+        assert _cik_destination_is_empty(ebull_test_conn) is False
+
+    def test_ignores_non_sec_cik_rows(self, ebull_test_conn) -> None:
+        # A row with provider='etoro' or identifier_type='isin' must
+        # NOT count toward dest-non-empty.
+        from app.workers.scheduler import _cik_destination_is_empty
+
+        ebull_test_conn.execute("DELETE FROM external_identifiers WHERE provider='sec' AND identifier_type='cik'")
+        _seed_instrument(ebull_test_conn, instrument_id=4802, symbol="HD", exchange="4")
+        ebull_test_conn.execute(
+            "INSERT INTO external_identifiers "
+            "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (4802, 'sec', 'cusip', '437076102', TRUE) "
+            "ON CONFLICT DO NOTHING"
+        )
+        ebull_test_conn.commit()
+        assert _cik_destination_is_empty(ebull_test_conn) is True
+
+
+# ---------------------------------------------------------------------------
+# daily_cik_refresh empty-dest regression branches (#1056)
+# ---------------------------------------------------------------------------
+
+
+from unittest.mock import patch  # noqa: E402
+
+from app.providers.implementations.sec_edgar import CikMappingResult  # noqa: E402
+
+
+@pytest.mark.integration
+class TestDailyCikRefreshEmptyDest:
+    """End-to-end coverage of the empty-dest regression branches.
+
+    Mocks the SEC HTTP boundary (build_cik_mapping_conditional) to
+    return controlled results; runs the real daily_cik_refresh path
+    against ebull_test DB and asserts external_identifiers is
+    populated post-run."""
+
+    @staticmethod
+    def _seed_aapl_us_equity(conn) -> None:
+        # Ensure exchange '4' is us_equity (default in test DB) +
+        # AAPL instrument exists.
+        conn.execute("UPDATE exchanges SET asset_class='us_equity' WHERE exchange_id='4'")
+        _seed_instrument(conn, instrument_id=4901, symbol="AAPL", exchange="4")
+        conn.execute("DELETE FROM external_identifiers WHERE provider='sec' AND identifier_type='cik'")
+        conn.commit()
+
+    @staticmethod
+    def _patch_db_url(monkeypatch):
+        # daily_cik_refresh hardcodes settings.database_url; redirect
+        # to the ebull_test DB for the duration of the test.
+        from app.config import settings
+        from tests.fixtures.ebull_test_db import test_database_url
+
+        monkeypatch.setattr(settings, "database_url", test_database_url())
+
+    def test_empty_dest_omits_if_modified_since(self, ebull_test_conn, monkeypatch) -> None:
+        self._patch_db_url(monkeypatch)
+        """Stale watermark + empty dest → refresh sends no IMS so
+        SEC can't return 304 against the stale validator."""
+        from app.services.watermarks import set_watermark
+        from app.workers.scheduler import daily_cik_refresh
+
+        self._seed_aapl_us_equity(ebull_test_conn)
+        with ebull_test_conn.transaction():
+            set_watermark(
+                ebull_test_conn,
+                source="sec.tickers",
+                key="global",
+                watermark="Wed, 01 Jan 2025 00:00:00 GMT",  # stale
+                response_hash="STALE_HASH",
+            )
+        ebull_test_conn.commit()
+
+        captured: dict = {}
+
+        def fake_conditional(self, *, if_modified_since=None):
+            captured["if_modified_since"] = if_modified_since
+            return CikMappingResult(
+                mapping={"AAPL": "0000320193"},
+                last_modified="Wed, 06 May 2026 20:52:27 GMT",
+                body_hash="NEW_HASH",
+            )
+
+        with patch(
+            "app.providers.implementations.sec_edgar.SecFilingsProvider.build_cik_mapping_conditional",
+            new=fake_conditional,
+        ):
+            daily_cik_refresh()
+
+        # Empty-dest branch must omit IMS.
+        assert captured["if_modified_since"] is None
+        # AAPL CIK must be present after the run.
+        row = ebull_test_conn.execute(
+            "SELECT identifier_value FROM external_identifiers "
+            "WHERE provider='sec' AND identifier_type='cik' AND instrument_id=4901"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "0000320193"
+
+    def test_empty_dest_with_matching_hash_still_upserts(self, ebull_test_conn, monkeypatch) -> None:
+        self._patch_db_url(monkeypatch)
+        """Empty dest + 200-with-same-body-hash must still upsert.
+        Pre-fix: the hash-skip branch fired and dest stayed empty."""
+        from app.services.watermarks import set_watermark
+        from app.workers.scheduler import daily_cik_refresh
+
+        self._seed_aapl_us_equity(ebull_test_conn)
+        with ebull_test_conn.transaction():
+            set_watermark(
+                ebull_test_conn,
+                source="sec.tickers",
+                key="global",
+                watermark="",
+                response_hash="MATCHING_HASH",
+            )
+        ebull_test_conn.commit()
+
+        def fake_conditional(self, *, if_modified_since=None):
+            return CikMappingResult(
+                mapping={"AAPL": "0000320193"},
+                last_modified="Wed, 06 May 2026 20:52:27 GMT",
+                body_hash="MATCHING_HASH",  # SAME as prior watermark
+            )
+
+        with patch(
+            "app.providers.implementations.sec_edgar.SecFilingsProvider.build_cik_mapping_conditional",
+            new=fake_conditional,
+        ):
+            daily_cik_refresh()
+
+        row = ebull_test_conn.execute(
+            "SELECT identifier_value FROM external_identifiers "
+            "WHERE provider='sec' AND identifier_type='cik' AND instrument_id=4901"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "0000320193"
+
+    def test_empty_dest_with_none_result_raises(self, ebull_test_conn, monkeypatch) -> None:
+        self._patch_db_url(monkeypatch)
+        """Defence-in-depth: if the provider returns None despite no
+        IMS being sent (impossible but guarded), raise loudly so the
+        bug isn't masked. Codex pre-push MEDIUM for #1056."""
+        from app.workers.scheduler import daily_cik_refresh
+
+        self._seed_aapl_us_equity(ebull_test_conn)
+
+        def fake_conditional(self, *, if_modified_since=None):
+            return None
+
+        with patch(
+            "app.providers.implementations.sec_edgar.SecFilingsProvider.build_cik_mapping_conditional",
+            new=fake_conditional,
+        ):
+            # _tracked_job catches and re-raises after recording a
+            # job_runs failure row; the RuntimeError bubbles out.
+            with pytest.raises(RuntimeError, match="304 despite empty destination"):
+                daily_cik_refresh()

--- a/tests/test_exchanges_service.py
+++ b/tests/test_exchanges_service.py
@@ -310,3 +310,107 @@ class TestRefreshExchangesMetadata:
             assert row == ("Operator data", "GB", "uk_equity")
         finally:
             _cleanup(ebull_test_conn, [_TEST_ID_EXISTING])
+
+
+# ---------------------------------------------------------------------------
+# Auto-reclassify post-universe-sync (#1055)
+# ---------------------------------------------------------------------------
+
+
+import pytest as _pytest_for_reclassify  # noqa: E402
+
+from tests.fixtures.ebull_test_db import ebull_test_conn as _ebull_test_conn_for_reclassify  # noqa: E402, F401
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available_for_reclassify  # noqa: E402
+
+
+@_pytest_for_reclassify.mark.integration
+@_pytest_for_reclassify.mark.skipif(not _test_db_available_for_reclassify(), reason="ebull_test DB unavailable")
+class TestReclassifyUnknownExchanges:
+    @staticmethod
+    def _seed_us_exchange(conn, exchange_id: str, instrument_count: int) -> None:
+        # ON CONFLICT DO NOTHING — preserves any existing asset_class
+        # the test pre-seeded (e.g. operator-curated 'crypto').
+        conn.execute(
+            """
+            INSERT INTO exchanges (exchange_id, description, asset_class)
+            VALUES (%s, 'Test', 'unknown')
+            ON CONFLICT (exchange_id) DO NOTHING
+            """,
+            (exchange_id,),
+        )
+        # Seed instrument_count tradable instruments WITHOUT a suffix
+        # (US-style symbols).
+        for i in range(instrument_count):
+            iid = 900_000_000 + int(exchange_id) * 1000 + i
+            conn.execute(
+                """
+                INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+                VALUES (%s, %s, 'X', %s, 'USD', TRUE)
+                ON CONFLICT (instrument_id) DO NOTHING
+                """,
+                (iid, f"X{exchange_id}{i}", exchange_id),
+            )
+        conn.commit()
+
+    def test_us_exchange_reclassified_when_unknown(
+        self,
+        ebull_test_conn,
+    ) -> None:
+        from app.services.exchanges import reclassify_unknown_exchanges
+
+        # Use a fresh exchange_id that won't collide with seed data.
+        TEST_ID = "97"
+        ebull_test_conn.execute("DELETE FROM exchanges WHERE exchange_id = %s", (TEST_ID,))
+        ebull_test_conn.commit()
+        self._seed_us_exchange(ebull_test_conn, TEST_ID, 50)
+        ebull_test_conn.commit()
+        reclassify_unknown_exchanges(ebull_test_conn)
+        ebull_test_conn.commit()
+        row = ebull_test_conn.execute(
+            "SELECT asset_class, country FROM exchanges WHERE exchange_id = %s",
+            (TEST_ID,),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "us_equity"
+        assert row[1] == "US"
+
+    def test_operator_curated_rows_preserved(
+        self,
+        ebull_test_conn,
+    ) -> None:
+        # Pre-set asset_class to 'crypto' (non-unknown). Reclassify
+        # MUST NOT overwrite it even if the suffix heuristic would
+        # imply 'us_equity'.
+        from app.services.exchanges import reclassify_unknown_exchanges
+
+        TEST_ID = "98"
+        ebull_test_conn.execute("DELETE FROM exchanges WHERE exchange_id = %s", (TEST_ID,))
+        ebull_test_conn.execute(
+            "INSERT INTO exchanges (exchange_id, description, asset_class) VALUES (%s, 'Test', 'crypto')",
+            (TEST_ID,),
+        )
+        ebull_test_conn.commit()
+        self._seed_us_exchange(ebull_test_conn, TEST_ID, 50)
+        ebull_test_conn.commit()
+        reclassify_unknown_exchanges(ebull_test_conn)
+        ebull_test_conn.commit()
+        row = ebull_test_conn.execute("SELECT asset_class FROM exchanges WHERE exchange_id = %s", (TEST_ID,)).fetchone()
+        assert row is not None
+        assert row[0] == "crypto"  # operator-curated value preserved
+
+    def test_idempotent_rerun_classified_count_drops_to_zero(self, ebull_test_conn) -> None:
+        from app.services.exchanges import reclassify_unknown_exchanges
+
+        TEST_ID = "99"
+        ebull_test_conn.execute("DELETE FROM exchanges WHERE exchange_id = %s", (TEST_ID,))
+        ebull_test_conn.commit()
+        self._seed_us_exchange(ebull_test_conn, TEST_ID, 40)
+        ebull_test_conn.commit()
+        first = reclassify_unknown_exchanges(ebull_test_conn)
+        ebull_test_conn.commit()
+        second = reclassify_unknown_exchanges(ebull_test_conn)
+        ebull_test_conn.commit()
+        # First call promotes the unknown row; second call has no
+        # unknown rows left to promote (this run's delta = 0).
+        assert first.classified >= 1
+        assert second.classified == 0


### PR DESCRIPTION
## What

Root-cause fixes for the two upstream blockers found while testing the bulk-archive ingesters end-to-end. Operator can now wipe DB and rerun bootstrap with no hand-patching.

### #1055 — Exchange `asset_class` auto-reclassify

`sql/068` ran the classification CTE at migration time when the instruments table was empty, so the dominance computation produced nothing and every exchange stayed `unknown`. Cik_refresh + cusip_universe_backfill returned 0 rows — AAPL/MSFT never got CIK/CUSIP mappings.

New service `reclassify_unknown_exchanges` runs the same CTE on current data + applies hard-coded overrides (FX/commodity/index/crypto). Wired into `nightly_universe_sync`. WHERE-clause scopes to `asset_class='unknown'` so operator-curated rows are preserved.

### #1056 — daily_cik_refresh empty-destination detection

Watermark + body-hash skip-path fired forever after a wipe. New helper `_cik_destination_is_empty` triggers a forced full upsert when dest is empty:
- Skips `If-Modified-Since` (no stale 304).
- Bypasses hash-skip.
- Raises `RuntimeError` if SEC still returns 304 (fail-closed invariant).

## Test plan

- [x] `TestReclassifyUnknownExchanges` — us_equity classification / operator-curated preserved / per-call promotion count.
- [x] `TestCikDestinationIsEmpty` — empty / non-empty / non-sec-cik distinct.
- [x] `TestDailyCikRefreshEmptyDest` — empty-dest omits IMS, empty-dest with matching hash still upserts, empty-dest + None raises.
- [x] All 78 impacted tests pass; smoke green.
- [x] Codex pre-push: APPROVE after addressing 3 findings.

Closes #1055.
Closes #1056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)