### PR TITLE
fix(#1059): replace size-based floor with Content-Type + magic-byte validation

### DIFF
--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -64,17 +64,24 @@ DEFAULT_TIMEOUT_S: Final[float] = 600.0  # multi-GB transfers can take many minu
 
 @dataclass(frozen=True)
 class BulkArchive:
-    """One archive to download.
+    """One archive to download. ``url`` is fully qualified.
 
-    ``url`` is fully qualified. ``expected_min_bytes`` is the floor
-    used to reject a corrupted / truncated transfer — set ~20% below
-    the observed Content-Length so SEC's normal week-on-week archive
-    growth does not trip it.
+    Content validation is performed at three points downstream — none
+    of which depend on a hard-coded size floor:
+
+      1. ``Content-Type`` HEAD check (must be application/zip-ish);
+         catches SEC redirects to HTML error pages without any
+         download.
+      2. HEAD-Content-Length-vs-streamed-bytes match; catches
+         network truncation mid-stream. This is the streaming
+         protocol's correctness check, NOT content validation.
+      3. Magic-byte check (PK\\x03\\x04 prefix) + ``zipfile.ZipFile``
+         round-trip after the bytes land; catches non-ZIP content
+         and corruption that survived 1+2.
     """
 
     name: str
     url: str
-    expected_min_bytes: int
 
 
 @dataclass
@@ -215,14 +222,12 @@ def build_bulk_archive_inventory(
         BulkArchive(
             name="submissions.zip",
             url=f"{SEC_BASE_URL}/Archives/edgar/daily-index/bulkdata/submissions.zip",
-            # 1.2 GB floor; observed 1.54 GB on 2026-05-08.
-            expected_min_bytes=int(1.2 * 1024**3),
+            # 1.2 GB floor; observed 1.54 GB on 2026-05-08.),
         ),
         BulkArchive(
             name="companyfacts.zip",
             url=f"{SEC_BASE_URL}/Archives/edgar/daily-index/xbrl/companyfacts.zip",
-            # 1.0 GB floor; observed 1.38 GB on 2026-05-08.
-            expected_min_bytes=int(1.0 * 1024**3),
+            # 1.0 GB floor; observed 1.38 GB on 2026-05-08.),
         ),
     ]
     for label in last_n_13f_periods(n_quarters_13f, today=today):
@@ -230,7 +235,6 @@ def build_bulk_archive_inventory(
             BulkArchive(
                 name=f"form13f_{label}.zip",
                 url=f"{SEC_BASE_URL}/files/structureddata/data/form-13f-data-sets/{label}_form13f.zip",
-                expected_min_bytes=50 * 1024**2,
             )
         )
     for q in last_n_quarters(n_quarters_insider, today=today):
@@ -238,7 +242,6 @@ def build_bulk_archive_inventory(
             BulkArchive(
                 name=f"insider_{q}.zip",
                 url=f"{SEC_BASE_URL}/files/structureddata/data/insider-transactions-data-sets/{q}_form345.zip",
-                expected_min_bytes=8 * 1024**2,
             )
         )
     for q in last_n_quarters(n_quarters_nport, today=today):
@@ -246,7 +249,6 @@ def build_bulk_archive_inventory(
             BulkArchive(
                 name=f"nport_{q}.zip",
                 url=f"{SEC_BASE_URL}/files/dera/data/form-n-port-data-sets/{q}_nport.zip",
-                expected_min_bytes=300 * 1024**2,
             )
         )
     return archives
@@ -361,16 +363,23 @@ def _zip_round_trip(path: Path) -> bool:
         return False
 
 
-async def _head_size(
+async def _head_size_and_type(
     client: httpx.AsyncClient,
     url: str,
     *,
     rate_limiter: Any | None = None,
-) -> int:
-    """Return Content-Length of ``url`` via HEAD.
+) -> tuple[int, str]:
+    """Return (Content-Length, Content-Type) for ``url`` via HEAD.
 
     ``rate_limiter`` acquires the shared SEC rate clock before the
     HEAD so it counts against the per-IP budget (#1042).
+
+    Content-Type is the real integrity signal — SEC serves bulk
+    archives as ``application/zip`` (or ``application/x-zip-compressed``);
+    an HTML error page would be ``text/html``. Returning the type
+    lets the caller reject non-archive responses BEFORE downloading
+    bytes, replacing the brittle ``expected_min_bytes`` floor that
+    conflated "small file" with "corrupted file" (#1059).
     """
     if rate_limiter is not None:
         await rate_limiter.acquire()
@@ -380,7 +389,66 @@ async def _head_size(
     length = response.headers.get("content-length")
     if length is None:
         raise RuntimeError(f"HEAD missing Content-Length: url={url}")
-    return int(length)
+    content_type = (response.headers.get("content-type") or "").lower()
+    return int(length), content_type
+
+
+# Acceptable Content-Type values for SEC bulk archives. Real-world
+# observation 2026-05-08 against www.sec.gov: archives served as
+# ``application/zip``. SEC's API docs don't contractually pin the
+# MIME header so we also accept common ZIP variants. An obvious-bad
+# CT (e.g. ``text/html`` for an error page) is rejected pre-flight;
+# anything else falls through to the post-download magic-byte +
+# ZipFile round-trip checks. Codex pre-push for #1059.
+_KNOWN_ARCHIVE_CONTENT_TYPES: tuple[str, ...] = (
+    "application/zip",
+    "application/x-zip",
+    "application/x-zip-compressed",
+    "application/octet-stream",
+)
+_OBVIOUS_BAD_CONTENT_TYPES: tuple[str, ...] = (
+    "text/html",
+    "text/plain",
+    "application/json",
+    "application/xml",
+)
+
+
+def _classify_content_type(content_type: str) -> Literal["known", "unknown", "bad"]:
+    """Classify HEAD Content-Type for archive pre-flight.
+
+    - 'known': matches a documented ZIP MIME → proceed.
+    - 'bad':   matches a known error-page MIME → reject pre-flight.
+    - 'unknown': anything else → proceed and let magic-byte +
+      ZipFile post-checks decide.
+    """
+    if not content_type:
+        return "unknown"
+    head = content_type.split(";", 1)[0].strip().lower()
+    if head in _KNOWN_ARCHIVE_CONTENT_TYPES:
+        return "known"
+    if head in _OBVIOUS_BAD_CONTENT_TYPES:
+        return "bad"
+    return "unknown"
+
+
+# ZIP magic bytes for non-split single-volume archives — the only
+# kind SEC publishes today. Multi-disk / spanned archives (signature
+# PK\\x07\\x08) are intentionally NOT accepted here because Python's
+# zipfile module rejects multi-disk archives anyway, so accepting
+# their magic at pre-check would mislead the operator. Codex pre-push
+# for #1059.
+_ZIP_MAGIC_BYTES: tuple[bytes, ...] = (b"PK\x03\x04", b"PK\x05\x06")
+
+
+def _has_zip_magic(path: Path) -> bool:
+    """Return True when the first 4 bytes of ``path`` match a ZIP signature."""
+    try:
+        with open(path, "rb") as fh:
+            header = fh.read(4)
+    except OSError:
+        return False
+    return any(header.startswith(magic) for magic in _ZIP_MAGIC_BYTES)
 
 
 _TRANSIENT_HTTPX_ERRORS = (
@@ -490,7 +558,7 @@ async def _download_one(
         )
 
     try:
-        expected_total = await _head_size(client, archive.url, rate_limiter=rate_limiter)
+        expected_total, content_type = await _head_size_and_type(client, archive.url, rate_limiter=rate_limiter)
     except Exception as exc:  # noqa: BLE001 — operator-visible message
         return ArchiveDownloadResult(
             name=archive.name,
@@ -499,14 +567,18 @@ async def _download_one(
             error=f"HEAD failed: {exc}",
         )
 
-    if expected_total < archive.expected_min_bytes:
+    # Pre-flight integrity check on the HEAD response. Three cases:
+    # known-archive MIME → proceed; obvious-bad MIME (text/html etc)
+    # → reject before downloading; anything else → proceed and let
+    # the post-download magic-byte + ZipFile round-trip catch it.
+    # #1059.
+    ct_class = _classify_content_type(content_type)
+    if ct_class == "bad":
         return ArchiveDownloadResult(
             name=archive.name,
             path=None,
             bytes_downloaded=0,
-            error=(
-                f"Content-Length {expected_total} below floor {archive.expected_min_bytes} — archive likely truncated"
-            ),
+            error=(f"Content-Type {content_type!r} is not an archive — SEC may have served an error page"),
         )
 
     # Resume from partial if present and shorter than expected.
@@ -566,6 +638,18 @@ async def _download_one(
             path=None,
             bytes_downloaded=final_size,
             error=f"size mismatch: got {final_size} bytes, expected {expected_total}",
+        )
+
+    # Magic-byte check before the more expensive ZIP round-trip.
+    # ZIP files start with PK\\x03\\x04 (or one of the central-
+    # directory variants); an HTML error page or random text would
+    # fail this faster than zipfile.ZipFile(). #1059.
+    if not _has_zip_magic(partial_path):
+        return ArchiveDownloadResult(
+            name=archive.name,
+            path=None,
+            bytes_downloaded=final_size,
+            error="missing ZIP magic bytes — content is not a ZIP archive",
         )
 
     if not _zip_round_trip(partial_path):

--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -222,12 +222,10 @@ def build_bulk_archive_inventory(
         BulkArchive(
             name="submissions.zip",
             url=f"{SEC_BASE_URL}/Archives/edgar/daily-index/bulkdata/submissions.zip",
-            # 1.2 GB floor; observed 1.54 GB on 2026-05-08.),
         ),
         BulkArchive(
             name="companyfacts.zip",
             url=f"{SEC_BASE_URL}/Archives/edgar/daily-index/xbrl/companyfacts.zip",
-            # 1.0 GB floor; observed 1.38 GB on 2026-05-08.),
         ),
     ]
     for label in last_n_13f_periods(n_quarters_13f, today=today):
@@ -432,12 +430,18 @@ def _classify_content_type(content_type: str) -> Literal["known", "unknown", "ba
     return "unknown"
 
 
-# ZIP magic bytes for non-split single-volume archives — the only
-# kind SEC publishes today. Multi-disk / spanned archives (signature
-# PK\\x07\\x08) are intentionally NOT accepted here because Python's
-# zipfile module rejects multi-disk archives anyway, so accepting
-# their magic at pre-check would mislead the operator. Codex pre-push
-# for #1059.
+# ZIP magic bytes for single-volume archives — the only kind SEC
+# publishes today.
+#   PK\\x03\\x04 = local-file-header signature (start of any
+#                 non-empty single-volume archive).
+#   PK\\x05\\x06 = end-of-central-directory signature (only header
+#                 in an empty archive).
+# Multi-disk / spanned archives (PK\\x06\\x06 / PK\\x06\\x07) are
+# intentionally rejected — Python's ``zipfile`` would reject them
+# downstream anyway, so accepting their magic at pre-check would
+# mislead the operator. ``PK\\x07\\x08`` is the data-descriptor
+# signature inside a stream-zip body, not a file header — also not
+# a valid first-bytes signature.
 _ZIP_MAGIC_BYTES: tuple[bytes, ...] = (b"PK\x03\x04", b"PK\x05\x06")
 
 

--- a/tests/test_sec_bulk_download.py
+++ b/tests/test_sec_bulk_download.py
@@ -51,7 +51,12 @@ def _make_handler(
         if request.method == "HEAD":
             return httpx.Response(
                 200,
-                headers={"Content-Length": str(len(archive_body))},
+                headers={
+                    "Content-Length": str(len(archive_body)),
+                    # Mock SEC's real response so the new
+                    # Content-Type integrity check passes (#1059).
+                    "Content-Type": "application/zip",
+                },
             )
         if request.method == "GET":
             range_header = request.headers.get("Range")
@@ -235,14 +240,20 @@ class TestRateClockOrdering:
         def handler(request: httpx.Request) -> httpx.Response:
             events.append(request.method)
             if request.method == "HEAD":
-                return httpx.Response(200, headers={"content-length": str(len(body))})
+                return httpx.Response(
+                    200,
+                    headers={
+                        "content-length": str(len(body)),
+                        "content-type": "application/zip",
+                    },
+                )
             return httpx.Response(200, content=body)
 
         class _SpyLimiter:
             async def acquire(self) -> None:
                 events.append("ACQUIRE")
 
-        archive = BulkArchive(name="archive.zip", url=url, expected_min_bytes=1)
+        archive = BulkArchive(name="archive.zip", url=url)
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             result = await _download_one(client, archive, tmp_path, rate_limiter=_SpyLimiter())
         assert result.error is None
@@ -265,7 +276,7 @@ class TestDownloadOne:
     async def test_atomic_rename_on_success(self, tmp_path: Path) -> None:
         body = _build_zip_bytes()
         url = "https://example.test/archive.zip"
-        archive = BulkArchive(name="archive.zip", url=url, expected_min_bytes=1)
+        archive = BulkArchive(name="archive.zip", url=url)
         transport = httpx.MockTransport(_make_handler(url, body))
         async with httpx.AsyncClient(transport=transport) as client:
             result = await _download_one(client, archive, tmp_path)
@@ -281,7 +292,7 @@ class TestDownloadOne:
     async def test_resume_from_partial(self, tmp_path: Path) -> None:
         body = _build_zip_bytes(filenames=("CIK1.json", "CIK2.json", "CIK3.json"))
         url = "https://example.test/archive.zip"
-        archive = BulkArchive(name="archive.zip", url=url, expected_min_bytes=1)
+        archive = BulkArchive(name="archive.zip", url=url)
 
         # Pre-seed half the file as ``.partial``.
         partial_path = tmp_path / "archive.zip.partial"
@@ -301,7 +312,7 @@ class TestDownloadOne:
     async def test_skip_when_final_file_already_present_and_valid(self, tmp_path: Path) -> None:
         body = _build_zip_bytes()
         url = "https://example.test/archive.zip"
-        archive = BulkArchive(name="archive.zip", url=url, expected_min_bytes=1)
+        archive = BulkArchive(name="archive.zip", url=url)
         # Final file exists already and is a valid ZIP.
         final = tmp_path / "archive.zip"
         final.write_bytes(body)
@@ -313,28 +324,73 @@ class TestDownloadOne:
         assert result.bytes_downloaded == 0
 
     @pytest.mark.asyncio
-    async def test_rejects_truncated_archive(self, tmp_path: Path) -> None:
-        body = _build_zip_bytes()
+    async def test_rejects_non_zip_content_type(self, tmp_path: Path) -> None:
+        # SEC redirected to an HTML error page — Content-Type='text/html'
+        # must reject before downloading any bytes (#1059).
         url = "https://example.test/archive.zip"
-        archive = BulkArchive(
-            name="archive.zip",
-            url=url,
-            expected_min_bytes=10 * len(body),  # impossibly large floor
-        )
-        transport = httpx.MockTransport(_make_handler(url, body))
+        archive = BulkArchive(name="archive.zip", url=url)
+
+        def html_handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "HEAD":
+                return httpx.Response(
+                    200,
+                    headers={"Content-Length": "1024", "Content-Type": "text/html"},
+                )
+            return httpx.Response(200, content=b"<html>error</html>")
+
+        transport = httpx.MockTransport(html_handler)
         async with httpx.AsyncClient(transport=transport) as client:
             result = await _download_one(client, archive, tmp_path)
         assert result.error is not None
-        assert "below floor" in result.error
-        # No final file written.
+        assert "Content-Type" in result.error
+        assert not (tmp_path / "archive.zip").exists()
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_zip_magic_bytes(self, tmp_path: Path) -> None:
+        # SEC served Content-Type='application/zip' but the body is
+        # not a real ZIP — magic-byte check rejects (#1059).
+        body = b"NOTAZIP" * 100_000  # >>>700KB of non-zip bytes
+        url = "https://example.test/archive.zip"
+        archive = BulkArchive(name="archive.zip", url=url)
+
+        def lying_handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "HEAD":
+                return httpx.Response(
+                    200,
+                    headers={
+                        "Content-Length": str(len(body)),
+                        "Content-Type": "application/zip",
+                    },
+                )
+            return httpx.Response(200, content=body)
+
+        transport = httpx.MockTransport(lying_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await _download_one(client, archive, tmp_path)
+        assert result.error is not None
+        assert "magic bytes" in result.error
         assert not (tmp_path / "archive.zip").exists()
 
     @pytest.mark.asyncio
     async def test_corrupted_zip_keeps_partial_clean(self, tmp_path: Path) -> None:
-        body = b"NOTAZIP" * 100_000  # >>> 700KB of non-zip bytes
+        # ZIP magic present but the rest of the bytes don't form a
+        # valid ZIP — round-trip catches it.
+        body = b"PK\x03\x04" + b"BROKEN" * 100_000  # has magic, not valid zip
         url = "https://example.test/archive.zip"
-        archive = BulkArchive(name="archive.zip", url=url, expected_min_bytes=1)
-        transport = httpx.MockTransport(_make_handler(url, body))
+        archive = BulkArchive(name="archive.zip", url=url)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "HEAD":
+                return httpx.Response(
+                    200,
+                    headers={
+                        "Content-Length": str(len(body)),
+                        "Content-Type": "application/zip",
+                    },
+                )
+            return httpx.Response(200, content=body)
+
+        transport = httpx.MockTransport(handler)
         async with httpx.AsyncClient(transport=transport) as client:
             result = await _download_one(client, archive, tmp_path)
         assert result.error is not None
@@ -381,7 +437,7 @@ class TestDownloadBulkArchives:
 
         # Threshold of 10000 Mbps is impossible to clear over a
         # MockTransport (no network), so probe always returns "below".
-        archives = [BulkArchive(name="archive.zip", url=url, expected_min_bytes=1)]
+        archives = [BulkArchive(name="archive.zip", url=url)]
         transport = httpx.MockTransport(_make_handler(url, body))
 
         # Patch the client factory to inject the mock transport.
@@ -420,8 +476,8 @@ class TestDownloadBulkArchives:
         url_a = "https://example.test/archive_a.zip"
         url_b = "https://example.test/archive_b.zip"
         archives = [
-            BulkArchive(name="archive_a.zip", url=url_a, expected_min_bytes=1),
-            BulkArchive(name="archive_b.zip", url=url_b, expected_min_bytes=1),
+            BulkArchive(name="archive_a.zip", url=url_a),
+            BulkArchive(name="archive_b.zip", url=url_b),
         ]
 
         bodies = {url_a: body_a, url_b: body_b}
@@ -432,7 +488,13 @@ class TestDownloadBulkArchives:
             if body is None:
                 return httpx.Response(404)
             if request.method == "HEAD":
-                return httpx.Response(200, headers={"Content-Length": str(len(body))})
+                return httpx.Response(
+                    200,
+                    headers={
+                        "Content-Length": str(len(body)),
+                        "Content-Type": "application/zip",
+                    },
+                )
             return httpx.Response(200, content=body, headers={"Content-Length": str(len(body))})
 
         transport = httpx.MockTransport(handler)


### PR DESCRIPTION
Closes #1059

## What

Live bootstrap failed with \`BootstrapPartialDownloadError: 15/18 archives; below floor\`. 3 insider quarters (2024Q3, 2025Q3, 2025Q4) legitimately ship at 7.9-8.3 MB which fell below the hard-coded 8 MB \`expected_min_bytes\` floor.

Initial 'fix' lowered floor to 4 MB. Operator pushed back: **size is not metadata-based validation**.

This PR replaces the size floor entirely with three real integrity checks:

1. **Content-Type HEAD pre-flight** — known archive MIME (\`application/zip\` etc) → proceed; obvious-bad MIME (\`text/html\`, \`application/json\`) → reject before download; unknown → proceed and let post-checks decide.
2. **HEAD-Content-Length-vs-streamed-bytes match** (existing). Catches network truncation. Mechanical streaming check, NOT content validation.
3. **ZIP magic-byte check** (\`PK\\x03\\x04\` / \`PK\\x05\\x06\`) before zipfile round-trip. Catches non-ZIP responses that lied about Content-Type.
4. **\`zipfile.ZipFile.namelist()\` round-trip** (existing). Catches corruption that survived 1-3.

\`expected_min_bytes\` field removed from \`BulkArchive\`.

## Why

Hard-coded size floors conflate "small file" with "corrupted file". 3 of 8 quarterly insider archives are legitimately small. Real validation comes from MIME headers + binary signatures + structural decode.

## Test plan

- [x] \`test_rejects_non_zip_content_type\` — HEAD with \`text/html\` rejects before download.
- [x] \`test_rejects_missing_zip_magic_bytes\` — Content-Type lied; magic-byte check rejects.
- [x] \`test_corrupted_zip_keeps_partial_clean\` — magic present but ZIP malformed; round-trip rejects.
- [x] All 22 sec_bulk_download tests pass.
- [x] Codex pre-push: APPROVE after addressing 3 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)