### PR TITLE
docs(#1062): foundation skills — SEC + EdgarTools + data engineer + metrics analyst

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -240,6 +240,13 @@ Read and apply these before pushing:
 - `.claude/skills/frontend/api-shape-and-types.md`
 - `.claude/skills/frontend/operator-ui-conventions.md`
 
+### Data foundation skills (read before SEC ingest / schema / parser / metric work)
+
+- `.claude/skills/data-sources/sec-edgar.md` — source-of-truth: endpoints, formats, identifiers, gotchas (DD-MMM-YYYY dates, 13F PRN/SH, VALUE-cutover 2023-01-03, 13D/G XML mandate, etc.), rate-limit discipline, reference impls.
+- `.claude/skills/data-sources/edgartools.md` — library reference: coverage matrix, API cheat-sheet, Pydantic validation cliff (#932), version pinning, decision tree for use-vs-roll-our-own.
+- `.claude/skills/ebull/data-engineer.md` — what we own: schema invariants, two-layer ownership model, write-through pattern, settled-decisions cross-reference, "where does X come from?" FAQ.
+- `.claude/skills/ebull/metrics-analyst.md` — every operator-visible metric: source → transform → table → endpoint → chart, with caveats and validation steps.
+
 ## Settled decisions
 
 → Covered in the Working order above (steps 2 and 4).

--- a/.claude/skills/data-sources/edgartools.md
+++ b/.claude/skills/data-sources/edgartools.md
@@ -1,0 +1,256 @@
+# EdgarTools — library reference
+
+> Read this before adding any new SEC parser. EdgarTools (`edgartools` on PyPI, `dgunning/edgartools` on GitHub) is the most active SEC-data library in the Python ecosystem (~2-3 patch releases / week). eBull pins **`edgartools==5.30.2`** (exact pin, no ceiling) at [pyproject.toml:21](../../../pyproject.toml#L21). Internal module paths are not part of the library's public stability contract — pin tight, keep golden-file replays, audit on every minor bump.
+
+## Coverage matrix
+
+Static parsers (no network, no Pydantic strict) — the **safe drop-in path**:
+
+| Form | Entry point | Returns |
+|---|---|---|
+| 13F-HR primary doc | `edgar.thirteenf.parsers.primary_xml.parse_primary_document_xml(xml)` | `PrimaryDocument13F` dataclass |
+| 13F-HR INFOTABLE | `edgar.thirteenf.parsers.infotable_xml.parse_infotable_xml(xml)` | `pd.DataFrame` (cols: `Issuer, Class, Cusip, Value, PutCall, InvestmentDiscretion, OtherManager, SharesPrnAmount, Type, SoleVoting, SharedVoting, NonVoting, Ticker`) |
+| Form 3 / 4 / 5 | `Ownership.parse_xml(xml)` (BeautifulSoup) | dict → `Form3/Form4/Form5(**dict)` |
+| Schedule 13D / 13G (post-2024-12-19) | `Schedule13D.parse_xml(xml)` / `Schedule13G.parse_xml(xml)` | dict → `Schedule13D(**dict)` |
+| Form 144 | `Form144.from_filing(filing)` | `Form144` |
+| Form D, EFFECT, MA-I, ATS-N | `FormD.from_xml(xml)` / `XmlFiling.from_filing(...)` | structured object |
+
+Network-required (live filing fetch + identity required):
+
+| Form | Entry point | Notes |
+|---|---|---|
+| 10-K / 10-Q / 8-K / 6-K / 20-F / 40-F | `Company("AAPL").latest_tenk` or `filing.obj()` | XBRL-backed reports |
+| N-PORT (P / EX / /A) | `FundReport.parse_fund_xml(xml)` | **Pydantic strict — see Gotcha G3** |
+| N-CSR | `FundShareholderReport.from_filing(filing)` | iXBRL OEF taxonomy. **No CUSIP at holding level** (#918 closeout). |
+| N-CEN | `FundCensus.from_filing(filing)` | structured census |
+| N-MFP2/3 | `MoneyMarketFund.from_filing(filing)` | money-market holdings |
+| N-PX | `NPX.from_filing(filing)` | proxy voting record |
+| DEF 14A family | `ProxyStatement.from_filing(filing)`; `Company.proxy_season(0)` | HTML extraction; quality variable |
+| S-1 / F-1 / S-3 / 424B / 497K / CORRESP | `RegistrationS1.from_filing(filing)` etc. | added in 5.23-5.27 |
+| Filings index walk | `get_filings(year, quarter, form=..., index=...)` | calendar year, NOT fiscal |
+| Submissions API per CIK | `get_entity_submissions(cik)` → `EntityData` | wraps `data.sec.gov` |
+| companyfacts | `Company("AAPL").facts` → `EntityFacts` | `time_series, get_concept, latest_periods, shares_outstanding, public_float` |
+| XBRL statements | `XBRL.from_filing(filing)` / `XBRL.from_directory(path)` | full statement engine |
+| Multi-filing stitching | `XBRLS.from_filings(c.latest("10-K", 5))` | 5y income statement stitched |
+
+**Not covered**: pre-2024-12-19 HTML 13D/G; non-CMBS Form 10-D; MSRB / FINRA filings; real-time push feeds.
+
+## API cheat-sheet
+
+```python
+# --- one-time setup -------------------------------------------------------
+from edgar import set_identity
+set_identity("Your Name your.email@example.com")  # required by SEC fair-use
+
+# --- universal find ------------------------------------------------------
+from edgar import find
+find("AAPL")                  # -> Entity
+find(320193)                  # -> Entity by CIK int
+find("0000320193-26-000042")  # -> Filing by accession
+find("S000012345")            # -> FundSeries
+
+# --- companies / entities ------------------------------------------------
+from edgar import Company
+c = Company("AAPL")
+c.cik; c.tickers; c.sic; c.is_foreign; c.fiscal_year_end
+c.latest_tenk; c.latest_tenq                  # one round-trip each
+c.get_filings(form="4", trigger_full_load=False).latest(10)
+c.facts                                        # EntityFacts (cached)
+c.shares_outstanding; c.public_float           # via facts
+
+# --- 13F-HR (the static, network-free path eBull uses) -------------------
+from edgar.thirteenf.parsers.primary_xml   import parse_primary_document_xml
+from edgar.thirteenf.parsers.infotable_xml import parse_infotable_xml
+primary  = parse_primary_document_xml(open("primary_doc.xml").read())
+holdings = parse_infotable_xml(open("infotable.xml").read())  # pd.DataFrame
+
+# --- Form 3/4/5 ---------------------------------------------------------
+from edgar.ownership import Ownership, Form4
+form4 = Form4(**Ownership.parse_xml(xml_string))
+form4.issuer.cik; form4.reporting_owners
+form4.non_derivative_table.transactions
+
+# --- N-PORT (validation cliff!) ------------------------------------------
+from edgar.funds.reports import FundReport
+report_dict = FundReport.parse_fund_xml(xml_string)  # dict (safe)
+fr = FundReport(**report_dict)                       # Pydantic — may raise
+
+# --- companyfacts / XBRL -------------------------------------------------
+facts = c.facts
+facts.get_concept("us-gaap:Revenues")
+facts.time_series("us-gaap:Revenues", periods=20)
+from edgar.xbrl import XBRLS
+XBRLS.from_filings(c.latest("10-K", 5)).statements.income_statement()
+
+# --- bulk download for offline / containers -----------------------------
+from edgar import download_edgar_data, use_local_storage
+use_local_storage("/data/edgar")
+download_edgar_data(submissions=True, facts=True, reference=True)  # ~7GB
+
+# --- HTTP configuration --------------------------------------------------
+from edgar import configure_http
+configure_http(use_system_certs=True)            # corp networks
+configure_http(timeout=30.0, proxy="http://...")
+```
+
+## Cache directories
+
+| Root | Default | Env var | Created when |
+|---|---|---|---|
+| Edgar data dir | `~/.edgar/` | `EDGAR_LOCAL_DATA_DIR` | **mkdir at module import** (`edgar/httpclient.py:103-108, 323`) |
+| Edgar cache dir | `~/.edgar_cache/` | `EDGAR_CACHE_DIR` | lazily on first search query |
+
+`~/.edgar/_tcache` is hishel-File HTTP cache, no automatic TTL. Manual invalidation: `edgar.storage.clear_cache()`.
+
+`download_edgar_data()` pulls submissions + facts + reference (~7 GB total). Does NOT pull SEC Data Sets archives or per-filing XBRL — for those use `download_filings('YYYY-MM-DD')` per day.
+
+## Identity / authentication
+
+- `set_identity("Name email@domain.com")` writes `EDGAR_IDENTITY` env var. Resets httpx client.
+- `get_identity()` **prompts interactively** if missing — in non-TTY contexts blocks 60s then raises `TimeoutError`. **Always set `EDGAR_IDENTITY` before any edgar import in batch / cron.**
+- Static parsers (`thirteenf.parsers.*`) never call `get_identity()` — fixture-safe.
+- eBull does NOT call `set_identity()` — only static parsers used today. Our HTTP fetch goes through `app/providers/implementations/sec_edgar.py` with `settings.sec_user_agent` directly.
+
+## Gotchas
+
+### G1 — Filesystem mkdir at module import
+`HOME=/nonexistent python -c "import edgar"` → `PermissionError`. Workaround: lazy-import inside a factory. Pattern at [app/providers/implementations/sec_13f.py:69-80](../../../app/providers/implementations/sec_13f.py#L69-L80):
+
+```python
+def _edgar_parsers() -> tuple[Any, Any]:
+    from edgar.thirteenf.parsers.infotable_xml import parse_infotable_xml
+    from edgar.thirteenf.parsers.primary_xml import parse_primary_document_xml
+    return parse_primary_document_xml, parse_infotable_xml
+```
+
+### G2 — Interactive identity prompt in batch contexts
+`unset EDGAR_IDENTITY; python -c "from edgar import get_filings; get_filings(2026,1)"` blocks 60s. Always export `EDGAR_IDENTITY` before HTTP-touching call.
+
+### G3 — N-PORT Pydantic validation cliff
+`FundReport(**parse_fund_xml(xml))` raises `pydantic.ValidationError` on synthetic fixtures missing required fields (`<regCik>`, `<regStreet1>`). Required fields are non-`Optional`. Punted #932.
+
+Workaround options:
+- **A** — use full real-world XML in fixtures (25KB+ each).
+- **B** — use the dict path: `report_dict = FundReport.parse_fund_xml(xml)` then walk `report_dict["investments"]` directly. Skip the model layer.
+- **C** — direct lxml parsing (`~150 LoC`, 10-20× faster, no validation cliff). Recommended for #932 if revisited.
+
+**Rule of thumb**: if the form's module imports `from pydantic import BaseModel`, expect a validation cliff for synthetic fixtures. Spike fixture compatibility BEFORE committing to a drop-in.
+
+### G4 — Type-label rewrite (`SH` → `Shares`, `PRN` → `Principal`)
+`parse_infotable_xml` output's `Type` column has values `"Shares"` / `"Principal"`, NOT the SEC two-letter codes. eBull maps back at [app/providers/implementations/sec_13f.py:210-213](../../../app/providers/implementations/sec_13f.py#L210-L213) (`_TYPE_CODE_FROM_LABEL`).
+
+### G5–G6 — Empty `<value>` and empty `<cusip>` rows tolerated
+Empty value/sshPrnamt rows land as `0`/`0` (not dropped). Empty CUSIP row lands as `Cusip=""`. Filter both at the boundary ([app/providers/implementations/sec_13f.py:316-328](../../../app/providers/implementations/sec_13f.py#L316-L328)).
+
+### G7 — `Decimal(float)` vulnerability
+EdgarTools constructs `total_value = Decimal(child_text(summary_page_el, "tableValueTotal"))` at `edgar/thirteenf/parsers/primary_xml.py:80` — the input is already a string (XML text from `child_text`). A future regression to `Decimal(<float-or-non-str>)` would silently introduce IEEE-754 rounding. Defense-in-depth: re-wrap with `Decimal(str(...))` at the boundary. See [app/providers/implementations/sec_13f.py:251-263](../../../app/providers/implementations/sec_13f.py#L251-L263).
+
+### G8 — Signature date timezone naivety
+`parsed.signature.date` is a string `"MM-DD-YYYY"`. Attach UTC explicitly:
+```python
+return datetime(parsed.year, parsed.month, parsed.day, tzinfo=UTC)
+```
+
+### G9 — Calendar-year vs fiscal-year in `get_filings(year, quarter)`
+Returns 10-Ks **filed** in that calendar year, NOT covering that fiscal year. Use `period_of_report` for fiscal queries.
+
+### G10 — `get_filings()` triggers full submissions load
+Default pages every historical filing. For Berkshire / BlackRock that's dozens of round-trips. Use `trigger_full_load=False` to limit to first ~1000.
+
+### G11 — Pre-2024-12-19 13D/G is HTML, not XML
+`Schedule13D.from_filing(old_filing)` returns `None` because `parse_xml` requires `<edgarSubmission>` root which only exists in post-rule structured XML. Filter ingest by filing date `>= 2024-12-19`.
+
+### G12 — N-CSR has no CUSIP
+OEF iXBRL N-CSR taxonomy publishes only fund-level identifiers — no holding-level CUSIPs. #918 closed for this reason. Don't use N-CSR for security-level rollups.
+
+### G13 — Internal module path is the only stability contract
+13F static parsers live under `edgar.thirteenf.parsers` — internal-looking. Library may reorganise. Mitigation: pin tight, keep golden-replay tests, audit on every minor bump.
+
+### G14 — Process-local rate limiter
+Default `requests_per_second=9` (`edgar/httpclient.py:142`). Spawning N processes each calling `get_filings(...)` collectively hits SEC at N×9 r/s. SEC threshold is ~10 r/s per IP. Lower `EDGAR_RATE_LIMIT_PER_SEC=9/N` per process or centralise SEC fetches.
+
+## Decision tree — when to use edgartools vs roll-our-own
+
+```
+Need to parse SEC data?
+├─ Existing eBull parser/provider for it?  → use that, do not casually add edgartools
+│
+├─ Static parser exists in edgartools (no Pydantic strict)?
+│   ├─ 13F-HR primary/infotable          → edgartools
+│   ├─ Form 3/4/5                        → edgartools (BeautifulSoup, fixture-safe)
+│   ├─ Schedule 13D/G post-2024-12-19    → edgartools
+│   ├─ Form 144                          → edgartools
+│   ├─ N-PORT                            → roll our own (Pydantic cliff)
+│   └─ Anything else                     → investigate first
+│
+├─ Need live HTTP fetch + auth?
+│   ├─ We have a wrapper (sec_edgar.py)  → use ours
+│   └─ We don't                          → edgartools (lazy-import + set_identity at startup)
+│
+├─ Need complex domain object (TenK / XBRL.statements)?
+│   └─ → edgartools (no realistic roll-our-own)
+│
+└─ Need bulk download / first-install drain?
+    └─ download_edgar_data() covers submissions + companyfacts. NOT data-sets.
+       For wider bulk: datamule. For narrow: write a date-range walker.
+```
+
+**Hard-stop criteria for adopting edgartools in a new path:**
+1. Confirm offline behaviour (set `EDGAR_LOCAL_DATA_DIR` first if sandboxed).
+2. Grep the form's module for `BaseModel` — if present, write fixture-compat spike before committing.
+3. Confirm internal module paths exist at the pinned version.
+4. Pin tight: `edgartools==X.Y.Z, <X.(Y+1).0`.
+5. `set_identity()` at process startup if any HTTP path will fire.
+
+**Roll-our-own when:**
+- Endpoint is well-known and stable (`data.sec.gov/submissions/...`, `companyfacts/...`, archive `index.json`). 20-50 LoC.
+- Need control over UA / retry / cache TTL / psycopg-friendly types.
+- Pydantic validation cliff (N-PORT).
+- Throughput must be coordinated across processes (eBull's shared throttle is at [app/providers/concurrent_fetch.py:74](../../../app/providers/concurrent_fetch.py#L74)).
+
+## Comparison
+
+| Need | edgartools | datamule | secedgar | direct httpx |
+|---|---|---|---|---|
+| 13F INFOTABLE → typed | **best** | partial (download only) | no | ~50 LoC |
+| Form 3/4/5 transactions | **best** (full insider model) | partial | no | hard |
+| 13D/13G structured XML | **best** (post-2024-12-19) | partial | no | possible |
+| N-PORT XML | yes (Pydantic strict) | no | no | ~150 LoC viable |
+| 10-K/10-Q XBRL | **best** (full statements engine) | no | no | painful |
+| companyfacts JSON | wraps cleanly | no | no | ~20 LoC |
+| Bulk archive download | yes (`download_edgar_data()`) | yes (faster on AWS path) | no | manual |
+| Rate-limit aware HTTP | yes | yes | partial | DIY |
+| Maintenance signal | very active | active | last release 2025-05 | n/a |
+
+## Existing eBull usage map
+
+Confirmed via `grep -rn "from edgar\b\|import edgar\b" app/ tests/`:
+
+| Where | What |
+|---|---|
+| [app/providers/implementations/sec_13f.py:77-80](../../../app/providers/implementations/sec_13f.py#L77-L80) | lazy `_edgar_parsers()` factory imports both static parsers |
+| [app/providers/implementations/sec_13f.py:237](../../../app/providers/implementations/sec_13f.py#L237) | `parse_primary_doc()` calls `edgar_parse_primary(xml)` |
+| [app/providers/implementations/sec_13f.py:308-309](../../../app/providers/implementations/sec_13f.py#L308-L309) | `parse_infotable()` calls `edgar_parse_infotable(xml)` |
+
+**No other code in eBull imports `edgar`.** All other SEC paths (`sec_edgar.py`, `sec_submissions.py`, `sec_daily_index.py`, `sec_13dg.py`, `sec_fundamentals.py`, `sec_getcurrent.py`) are direct httpx/lxml.
+
+## Upgrade procedure
+
+1. Read CHANGELOG between current pin and target.
+2. Re-run `tests/test_sec_13f_*` and any other golden-replay tests.
+3. Confirm `edgar.thirteenf.parsers.{primary,infotable}_xml.parse_*` exist at same paths with same signature.
+4. Confirm DataFrame columns unchanged (`Issuer, Class, Cusip, Value, ...`).
+5. Confirm `PrimaryDocument13F.summary_page.total_value` is still `Decimal | int` (not `float`).
+6. Run `pre-push` gate (lint/typecheck/test/format).
+7. Bump pin in `pyproject.toml` + `uv.lock` (exact pin, e.g. `edgartools==X.Y.Z`).
+
+**Do not auto-upgrade from Renovate/Dependabot.** Pin tight, upgrade manually after smoke run.
+
+## References
+
+- PyPI: <https://pypi.org/project/edgartools/>
+- GitHub: <https://github.com/dgunning/edgartools>
+- Source files (installed venv): `.venv/lib/python*/site-packages/edgar/` (relative to repo root)
+- `pyproject.toml:21` — pin
+- Specs: `docs/superpowers/specs/2026-05-08-bulk-datasets-first-bootstrap.md` (edgartools dependency boundary)
+- Memory: `feedback_pydantic_validation_cliff.md`

--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -1,0 +1,530 @@
+# SEC EDGAR — source-of-truth reference
+
+> Read this before adding any SEC ingest job, parser, or identifier resolver. eBull's data integrity depends on treating SEC formats as the source-of-truth, not guessing them. Every operator-visible figure traces back to a specific endpoint + format documented here.
+
+## Executive cheat sheet
+
+- **Two hostnames.** `data.sec.gov` serves JSON APIs (submissions, companyfacts, companyconcept, frames). `www.sec.gov` serves bulk archives, full-text indexes, primary documents under `/Archives/edgar/...`, JSON ticker reference files under `/files/...`, cgi-bin Atom feeds, daily/full-index `.idx` files. Don't confuse them.
+- **Rate limit: 10 req/s per IP, regardless of machine count.** Source: <https://www.sec.gov/about/developer-resources>.
+- **User-Agent required.** Format `<Name> <email>`. Missing or generic UA = immediate 403.
+- **Bulk over per-filing whenever possible.** `submissions.zip` (~1.54 GB) and `companyfacts.zip` (~1.38 GB) rebuild nightly ~03:00 ET.
+- **Conditional fetch supported.** Many endpoints emit `Last-Modified` / `ETag`. Always send `If-Modified-Since`.
+- **Three-tier polling.** Hot (Atom getcurrent) / Warm (daily-index) / Cold (per-CIK submissions JSON).
+- **Identifiers, never names.** TSLA = `TESLA INC` in SEC, `Tesla, Inc.` in broker. Fuzzy-name match is forbidden — use CIK / CUSIP bridges.
+
+## 1. Endpoints
+
+### Reference / canonical bridges
+
+| Endpoint | URL | Refresh | Use For |
+|---|---|---|---|
+| Company tickers | `https://www.sec.gov/files/company_tickers.json` | Daily nightly | Ticker → CIK bridge (~10k operating-co rows) |
+| Company tickers (exchange) | `https://www.sec.gov/files/company_tickers_exchange.json` | Daily nightly | + exchange (Nasdaq / NYSE / Cboe / OTC) |
+| Mutual-fund tickers | `https://www.sec.gov/files/company_tickers_mf.json` | Daily nightly | ~28k rows; carries `seriesId` + `classId` |
+| 13F Official List | `https://www.sec.gov/files/investment/13flist{year}q{quarter}.txt` | Quarterly ~2 weeks post-quarter | CUSIP → issuer-name (~24k rows). Authoritative CUSIP/CIK bridge for institutional ownership. |
+
+`company_tickers.json` shape:
+```json
+{"0": {"cik_str": 1045810, "ticker": "NVDA", "title": "NVIDIA CORP"}}
+```
+`cik_str` is **integer** in JSON, **not zero-padded**. Always pad to 10 digits with `f"CIK{cik:010d}"` before constructing API URLs.
+
+**Coverage gap**: `company_tickers.json` excludes pink-sheet/OTC, foreign-without-ADR, warrant-only, preferred-only. Layer `company_tickers_exchange.json` and `company_tickers_mf.json` to close gaps. eBull pattern at [app/services/cik_discovery.py:74-241](../../../app/services/cik_discovery.py#L74-L241).
+
+### JSON APIs (`data.sec.gov`)
+
+| Endpoint | URL | Refresh | Use For |
+|---|---|---|---|
+| Submissions per CIK | `https://data.sec.gov/submissions/CIK{padded}.json` | Real-time, <1s | Per-CIK 1000-most-recent filings + history pointers |
+| Submissions overflow | `https://data.sec.gov/submissions/CIK{padded}-submissions-{NNN}.json` | Real-time | Older filings, paginated |
+| Companyfacts | `https://data.sec.gov/api/xbrl/companyfacts/CIK{padded}.json` | Real-time, <1min | All XBRL concepts for a CIK |
+| Companyconcept | `https://data.sec.gov/api/xbrl/companyconcept/CIK{padded}/{taxonomy}/{tag}.json` | Real-time | One XBRL tag (smaller payload) |
+| Frames | `https://data.sec.gov/api/xbrl/frames/{taxonomy}/{tag}/{unit}/{period}.json` | Real-time | Cross-sectional one-fact-per-filer |
+
+**Submissions JSON top-level**: `cik, entityType, sic, name, tickers, exchanges, ein, lei, fiscalYearEnd, formerNames, addresses, filings`.
+
+`filings.recent` is **columnar** — parallel arrays each capped at **1000 most-recent OR ≥ 1 year** (whichever yields more). Older history lives in `filings.files[]` pointer array. Always check `files` and recurse:
+
+```python
+def fetch_all_filings(cik_padded: str):
+    primary = http_get(f"https://data.sec.gov/submissions/CIK{cik_padded}.json")
+    yield from _rows(primary["filings"]["recent"])
+    for ptr in primary["filings"].get("files", []):
+        page = http_get(f"https://data.sec.gov/submissions/{ptr['name']}")
+        yield from _rows(page)
+```
+
+Pattern at [app/services/institutional_holdings.py:189-220](../../../app/services/institutional_holdings.py#L189-L220), rebuild at [app/jobs/sec_rebuild.py:335](../../../app/jobs/sec_rebuild.py#L335).
+
+`recent` columnar keys: `accessionNumber, filingDate, reportDate, acceptanceDateTime, act, form, fileNumber, filmNumber, items, core_type, size, isXBRL, isInlineXBRL, isXBRLNumeric, primaryDocument, primaryDocDescription`. **All arrays must be same length, aligned by index** — pull row `i` by reading `recent[k][i]` for every `k`.
+
+### Bulk archives
+
+| Endpoint | Refresh | Use For |
+|---|---|---|
+| Submissions bulk ZIP | `https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip` | Nightly ~03:00 ET | Initial-install drain (~1.54 GB) |
+| Companyfacts bulk ZIP | `https://www.sec.gov/Archives/edgar/daily-index/xbrl/companyfacts.zip` | Nightly ~03:00 ET | Initial fundamentals drain (~1.38 GB) |
+| Form 13F dataset | `https://www.sec.gov/data-research/sec-markets-data/form-13f-data-sets` | Quarterly | All 13F holdings per quarter |
+| N-PORT dataset | `https://www.sec.gov/data-research/sec-markets-data/form-n-port-data-sets` | Quarterly | Mutual-fund/ETF holdings |
+| Insider dataset | `https://www.sec.gov/data-research/sec-markets-data/insider-transactions-data-sets` | Quarterly | All Form 3/4/5 |
+| Financial-statement dataset | `https://www.sec.gov/dera/data/financial-statement-data-sets.html` | Quarterly | XBRL extract (10-K / 10-Q) |
+
+### Indexes + Atom feeds
+
+| Endpoint | URL | Refresh | Use For |
+|---|---|---|---|
+| Full-index quarterly | `https://www.sec.gov/Archives/edgar/full-index/{YYYY}/QTR{n}/master.idx` | Weekly Sat (PAC rebuild) | Cross-quarter discovery |
+| Daily-index | `https://www.sec.gov/Archives/edgar/daily-index/{YYYY}/QTR{n}/master.{YYYYMMDD}.idx` | Nightly ~22:00 ET | Yesterday's filings |
+| Atom getcurrent | `https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type={form}&output=atom` | Live | Hot polling for current-day filings |
+| Atom getcompany | `https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK={cik}&type={form}&output=atom` | Live | Per-CIK Atom alternative |
+| Filing-folder manifest | `https://www.sec.gov/Archives/edgar/data/{cik_int}/{acc_no_dashes}/index.json` | Once at filing | Enumerate filing exhibits |
+
+**Atom `getcurrent` is `ISO-8859-1`-encoded**, not UTF-8. Decode accordingly.
+
+`master.idx` is pipe-delimited:
+```
+CIK|Company Name|Form Type|Date Filed|Filename
+1000045|OLD MARKET CAPITAL Corp|15-12G/A|2026-01-02|edgar/data/1000045/0001437749-26-000015.txt
+```
+
+`form.idx` is fixed-width at offsets 0,12,74,86,98.
+
+## 2. File formats
+
+### 2.1 Form 13F-HR INFOTABLE schema
+
+Source: <https://www.sec.gov/files/form_13f.pdf> §5.7.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ACCESSION_NUMBER` | VARCHAR2(25) | filer CIK + yy + seq |
+| `INFOTABLE_SK` | NUMBER | row surrogate |
+| `NAMEOFISSUER` | VARCHAR2(200) | |
+| `TITLEOFCLASS` | VARCHAR2(150) | |
+| `CUSIP` | CHAR(9) | |
+| `VALUE` | NUMBER | **Unit-cutover gotcha — see §3.1** |
+| `SSHPRNAMT` | NUMBER | shares OR principal |
+| `SSHPRNAMTTYPE` | VARCHAR2(10) | `SH` or `PRN` (uppercase) |
+| `PUTCALL` | VARCHAR2(10) | `Put` / `Call` (capitalised) or empty |
+| `INVESTMENTDISCRETION` | VARCHAR2(10) | `SOLE` / `DFND` / `OTR` |
+| `OTHERMANAGER` | VARCHAR2(100) | comma-sep seq numbers |
+| `VOTING_AUTH_SOLE` / `_SHARED` / `_NONE` | NUMBER | voting authority |
+
+**SSHPRNAMTTYPE = PRN** rows hold bond principal **in dollars**, not share counts. Filter `WHERE SSHPRNAMTTYPE = 'SH'` before any share aggregation. PRN belongs to a separate fixed-income rollup if surfaced at all. Pattern at [app/services/sec_13f_dataset_ingest.py:307-315](../../../app/services/sec_13f_dataset_ingest.py#L307-L315).
+
+13F filed within **45 days after each calendar quarter end**.
+
+### 2.2 N-PORT-P XML schema
+
+Source: <https://www.sec.gov/info/edgar/specifications/form-n-port-xml-tech-specs.htm>.
+
+```xml
+<edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+  <headerData><submissionType>NPORT-P</submissionType></headerData>
+  <formData>
+    <genInfo>
+      <regCik>...</regCik><regLei>...</regLei>
+      <seriesId>S000001234</seriesId><seriesName>...</seriesName>
+      <repPdEnd>2026-03-31</repPdEnd><repPdDate>2026-03-31</repPdDate>
+    </genInfo>
+    <invstOrSecs>
+      <invstOrSec>
+        <name>APPLE INC</name><lei>HWUPKR0MPOU8FGXBT394</lei>
+        <cusip>037833100</cusip>
+        <balance>123456.000000</balance>
+        <units>NS</units>          <!-- NS=shares; PA=principal; OU=other -->
+        <curCd>USD</curCd>
+        <valUSD>34567890.12</valUSD>
+        <pctVal>2.345</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>     <!-- equity-common, debt, etc. -->
+        <issuerCat>CORP</issuerCat>
+      </invstOrSec>
+    </invstOrSecs>
+  </formData>
+</edgarSubmission>
+```
+
+Critical fields: `cusip` (9 char), `lei` (20 char), `valUSD` (USD-converted regardless of `curCd`), `pctVal` (decimal — `2.345` = 2.345%), `balance` + `units` (same SH-vs-PRN trap as 13F: branch on `units='NS'`).
+
+**Fund hierarchy**: filings are at the **trust** CIK level; each holding belongs to a **series** (`S000123456`); each series has multiple **share classes** (`C000234567`). For ownership rollup at operating-issuer level, aggregate `valUSD` across funds without double-counting fund-of-funds. Aggregate by `(seriesId, issuerCusip)`, NOT by classId — share classes share the same portfolio.
+
+`<invstOrSec>` repeatability raised from 1000 → 500,000 — long lists are valid. eBull's parser is at [app/services/n_port_ingest.py](../../../app/services/n_port_ingest.py) (stdlib `xml.etree.ElementTree`, #917 closeout).
+
+### 2.3 Form 3/4/5 — Section 16 insider transactions
+
+XML root: `<ownershipDocument>`. **Element-wrapping idiom**: every leaf value lives inside a `<value>` child so SEC can attach a peer `<footnoteId>`. `findtext("transactionShares")` returns `None` — must descend to `transactionShares/value`.
+
+```xml
+<ownershipDocument>
+  <documentType>4</documentType>
+  <periodOfReport>2026-04-15</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId><rptOwnerCik>...</rptOwnerCik><rptOwnerName>...</rptOwnerName></reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isOfficer>true</isOfficer><officerTitle>...</officerTitle>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <transactionCoding>
+        <transactionCode>M</transactionCode>
+      </transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>1717</value></transactionShares>
+        <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+</ownershipDocument>
+```
+
+**Transaction code reference** (Form 4 General Instructions):
+
+| Code | Meaning |
+|---|---|
+| P | Open-market or private purchase |
+| S | Open-market or private sale |
+| A | Grant / award / RSU vest |
+| D | Sale or transfer back to company |
+| F | Net-settlement (tax / exercise withhold) |
+| M | Exercise / conversion of derivative |
+| C | Conversion of derivative |
+| G | Bona fide gift |
+| K | Equity swaps / hedging |
+| X | Exercise of in/at-the-money derivative |
+| O | Exercise of out-of-the-money derivative |
+| J | Other (footnote required) |
+| U | Disposition pursuant to tender offer |
+
+`directOrIndirectOwnership`: `D` = Direct, `I` = Indirect. **Both surface separately** — Section 16 ownership totals must aggregate D + I separately because the FILER label "owns" both. They are NOT double-counts. This is what made JPM insider rollup go 1.29% → 6.16% post-#905 (`project_905_rollup_cutover_done.md`).
+
+### 2.4 Schedule 13D / 13G — beneficial ownership
+
+XML mandate **since 2024-12-18**. Current EDGAR XML technical spec revision is **2.2** (2026-03-16) — verify against `https://www.sec.gov/edgar/filer-information/current-edgar-technical-specifications` before relying on the schema. Pre-mandate filings are HTML/text — no `primary_doc.xml` exists; legacy coverage is lower-fidelity unless you write a parallel HTML extractor.
+
+Sample reporting-person block:
+```xml
+<reportingPersonInfo>
+  <reportingPersonCIK>0001161286</reportingPersonCIK>
+  <reportingPersonName>...</reportingPersonName>
+  <memberOfGroup>a</memberOfGroup>
+  <citizenshipOrOrganization>FL</citizenshipOrOrganization>
+  <soleVotingPower>2121212.00</soleVotingPower>
+  <sharedVotingPower>2121212.00</sharedVotingPower>
+  <soleDispositivePower>212121.00</soleDispositivePower>
+  <sharedDispositivePower>212121.00</sharedDispositivePower>
+  <aggregateAmountOwned>21222121.00</aggregateAmountOwned>
+  <isAggregateExcludeShares>N</isAggregateExcludeShares>
+  <percentOfClass>2.7</percentOfClass>
+  <typeOfReportingPerson>BD</typeOfReportingPerson>
+</reportingPersonInfo>
+```
+
+A single accession can carry up to 100 reporting persons (joint filings). 13G uses `classPercent` instead of `percentOfClass` and includes `classOwnership5PercentOrLess` flag (signals when filer dropped under 5%).
+
+### 2.5 Date formats
+
+| Format | Example | Where used |
+|---|---|---|
+| ISO 8601 `YYYY-MM-DD` | `2026-04-15` | submissions JSON (`filingDate`, `reportDate`), companyfacts (`start`, `end`, `filed`), Form 4 XML, 13D/G XML, Atom feed `<filing-date>`, full-index `master.idx` |
+| ISO 8601 with timestamp | `2026-04-15T20:03:51.000Z` (UTC) | submissions JSON `acceptanceDateTime` |
+| ISO 8601 with TZ offset | `2026-05-08T15:26:04-04:00` (ET) | Atom feed `<updated>` |
+| `DD-MON-YYYY` (uppercase) | `14-NOV-2025` | **All bulk dataset TSV files** — 13F, NPORT, Insider, financial-statement |
+| `DD-MMM-YYYY` (mixed case) | `14-Nov-2025` | Some bulk archives with locale-aware writers |
+| `MM/DD/YYYY` | `06/07/2023` | 13D/G XML `<dateOfEvent>` |
+| `YYYYMMDD` | `20061207` | Daily `Feed/` filenames |
+| `MMDD` | `0926` | submissions JSON `fiscalYearEnd` (no year) |
+
+**Always parse with try/except across formats relevant to the source.** Never "ISO 8601 only" — that is the #1 cause of silent ingest gaps. Pattern:
+
+```python
+def _parse_sec_date(s: str) -> date:
+    for fmt in ("%Y-%m-%d", "%d-%b-%Y", "%d-%b-%y"):
+        try:
+            return datetime.strptime(s.strip(), fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"unrecognised SEC date: {s!r}")
+```
+
+## 3. Identifiers
+
+### 3.1 CIK (Central Index Key)
+
+- 10-digit zero-padded number assigned by EDGAR when a filer registers.
+- Identifies the **filer** (issuer / fund family / individual insider / institutional manager). **Not the security.**
+- **Never recycled.** Renames preserve the CIK (AAPL = `APPLE COMPUTER INC`/`/ FA`/`APPLE INC`, all 0000320193).
+- Padding: API + archive paths require 10-digit pad. JSON payloads carry it as integer (no padding) in some endpoints (`cik_str` in `company_tickers.json`) and as string in others. Normalise to int internally; pad to string at URL boundary.
+
+### 3.2 CUSIP
+
+- 9-character alphanumeric (8 + check digit). Identifies a **security**, not an issuer.
+- Foreign issuers often have a **CINS** (CUSIP International Numbering System) — same shape, starts with letter (e.g. `G0R21F121` for Cayman Islands).
+- Changes on corporate actions: stock splits, ticker changes, M&A, redomiciles. Issuer keeps CIK; security CUSIP moves.
+- **Class disambiguation**: GOOGL = `02079K305` (Class A), GOOG = `02079K107` (Class C). Both CIK 1652044 (Alphabet). Aggregating without share-class CUSIP collapses two distinct holdings.
+- Source of authoritative CUSIP→CIK mapping: 13F Official List (per-quarter): `https://www.sec.gov/files/investment/13flist{year}q{quarter}.txt`. Format: fixed-width, columns `CUSIP NO.` (9 char) | `ISSUER NAME` | `ISSUER DESCRIPTION` (`SHS`, `CALL`, `PUT`, `UNIT`, `*W EXP`) | `STATUS`. Each issuer has multiple rows (common, warrant, unit, options-call, options-put). Filter for shares means matching description like `SHS`, `COMMON`, `COM`.
+
+### 3.3 Accession number
+
+Two interchangeable shapes:
+- **With dashes**: `0001193125-26-214458` (20 chars). Used in submissions JSON, Atom, dataset ZIPs.
+- **Without dashes**: `000119312526214458` (18 chars). Used in `/Archives/edgar/data/{cik_int}/{acc_no_dashes}/...` paths.
+
+Conversion: `str.replace("-", "")`. **The first 10 digits of an accession number are the FILER CIK that submitted, NOT the issuer CIK.**
+
+Archive-URL CIK varies by form type:
+- **Form 4 / Form 3 / Form 5** — `/Archives/edgar/data/{ISSUER_CIK}/{acc_no_dashes}/...`. Insider Form 4 filings for AAPL are submitted by various filer-agent CIKs but stored under Apple's CIK 0000320193.
+- **13F-HR / 13G/D / N-PORT-P** — `/Archives/edgar/data/{FILER_CIK}/{acc_no_dashes}/...`. The filing-manager / blockholder / fund-trust IS the filer; there is no separate "issuer" in those forms. eBull's 13F builder uses the filer CIK at [app/services/sec_13f_dataset_ingest.py:334](../../../app/services/sec_13f_dataset_ingest.py#L334).
+
+### 3.4 LEI (Legal Entity Identifier)
+
+20-character alphanumeric ISO 17442 code. Required on N-PORT, N-CSR, N-MFP, certain swap reports, and (since 2023-01-03) on Form 13F. Resolve via GLEIF API: `https://api.gleif.org/api/v1/lei-records/{lei}`.
+
+### 3.5 Series ID / Class ID — fund hierarchy
+
+- `seriesId`: `S` + 9 digits (e.g. `S000123456`) — one per fund within a trust.
+- `classId`: `C` + 9 digits — share classes per series (Investor / Institutional / Retirement).
+- Mutual-fund tickers map to **classId**, not seriesId. Two share classes share the same holdings → aggregate by seriesId, not classId.
+- Source: `company_tickers_mf.json` carries ticker → seriesId → classId chain.
+
+## 4. Rate limits + access discipline
+
+### Official limit (verbatim from SEC)
+
+> Current max request rate: **10 requests/second**. To ensure everyone has equitable access to SEC EDGAR content, please use efficient scripting. Download only what you need and please moderate requests to minimize server load.
+>
+> Current guidelines limit each user to a total of **no more than 10 requests per second, regardless of the number of machines used to submit requests**.
+
+The "regardless of the number of machines" phrasing means horizontal scaling does not buy headroom — the budget is per-User-Agent identity. eBull treats 10 r/s as a global semaphore across every ingest job (#728). Empirical sustained ceiling is **5–7 r/s** to avoid transient 429/503; pattern at [app/services/sec_pipelined_fetcher.py:43](../../../app/services/sec_pipelined_fetcher.py#L43).
+
+### User-Agent header
+
+Required format: `<Name> <email>`. Email must be syntactically valid and routable. eBull config at [app/config.py:29](../../../app/config.py#L29) (`sec_user_agent`). **Default `eBull dev@example.com` is unacceptable for production** — every operator install must override.
+
+### What gets you blocked
+
+- Sustained > 10 r/s for any rolling 1-second window — soft block (403, recovers).
+- > 10 r/s for several minutes — IP rate-limit page for 10–30 min.
+- Repeated soft-blocks — IP ban until manual review.
+- Missing/generic UA (`python-requests/2.x`, `curl/8.x`) — **immediate 403**.
+- Crawling same URL hundreds of times — flagged as botnet even under 10 r/s.
+
+### Strategies
+
+1. **Bulk archives over per-filing scrapes.** `submissions.zip` + `companyfacts.zip` replace ~10k requests with 1.
+2. **`If-Modified-Since` against `Last-Modified`** for any per-CIK or per-filing endpoint. Server returns 304 (no body) for unchanged. Pattern at [app/providers/implementations/sec_edgar.py:497-529](../../../app/providers/implementations/sec_edgar.py#L497-L529).
+3. **`If-None-Match` against `ETag`** for archive files. Frankfurter pattern at [app/providers/implementations/frankfurter.py:98-144](../../../app/providers/implementations/frankfurter.py#L98-L144) is the cleanest in-repo template.
+4. **Three-tier polling**:
+   - **Hot**: Atom `getcurrent` for 8-K. Poll every 5–10 min during business hours.
+   - **Warm**: `daily-index/master.{YYYYMMDD}.idx` early-morning batch.
+   - **Cold**: per-CIK submissions JSON re-pull weekly or per-event.
+5. **Cache fetched bytes** in `raw_filings` table so re-wash is local. [app/services/raw_filings.py:11](../../../app/services/raw_filings.py#L11).
+6. **Backoff on 429 / 503**. Exponential, max 8 attempts. Many transient blocks clear within 60s.
+
+## 5. Identity resolution + canonical mapping
+
+### CIK → ticker bridge
+
+**Source**: `company_tickers.json` primary, `company_tickers_exchange.json` for exchange context. Refresh daily.
+
+Pattern at [app/services/cik_discovery.py](../../../app/services/cik_discovery.py):
+1. Pull both JSONs.
+2. Build CIK-keyed dict; canonical wins on collision.
+3. For each ticker store CIK + exchange + corporate name.
+4. Persist with watermark.
+
+**Edge cases**:
+- Multi-class issuers (GOOGL/GOOG): both share-class tickers map to same CIK. Store all rows.
+- Renames: `formerNames` in submissions JSON gives historical timeline. For back-filling 13F holdings, resolve name-as-of-filing-date.
+- Delisted: no longer in `company_tickers.json` but CIK persists. Use submissions JSON directly to detect "no current ticker".
+- Foreign without ADR: CIK exists but `tickers` array empty. Look up by name in 13F Official List (CUSIP-keyed).
+
+### CUSIP → CIK bridge
+
+**Source**: SEC Official 13(f) List (quarterly).
+
+Authoritative because:
+- Enumerates every CUSIP that institutional managers may hold.
+- Issuer-name column matches EDGAR-canonical name → derivable to CIK via `company_tickers.json`.
+- Includes warrants / units / preferred / depositary receipts as separate CUSIPs under the same issuer name.
+
+eBull imports into `sec_reference_documents` (sql/121); fuzzy threshold 0.92 on issuer name (PR #927). Coverage gate: 7.4% on dev as of #914 vs 80% target.
+
+**Limitations**: pink-sheet/OTC absent. ADRs sometimes appear under both local-share CUSIP and depositary CUSIP. Quarterly cadence means new IPOs miss bridge for up to 90 days.
+
+### Why fuzzy match is wrong
+
+TSLA: broker = `Tesla, Inc.`; SEC = `TESLA INC`; historical = `Tesla Motors, Inc.`. Trigram fuzzy match might pull `TESLA SECURITIES TRUST` (totally separate filer). **Fuzzy match is a code-smell — replace with explicit CIK/CUSIP bridge.** When unavoidable, bound threshold ≥ 0.92 and gate on coverage.
+
+### Tombstones / superseded filers
+
+Mark CIK tombstoned when:
+1. No longer in any current canonical list AND no filings ≥ 18 months.
+2. Form 15 (notice of termination of registration) filed.
+3. `company_tickers.json` drop after merger/acquisition overlap window.
+
+**Do NOT delete historical observations** — they remain valid for as-of queries. Per-CIK refresh stops; observations stay.
+
+## 6. Reference implementations
+
+| Library | Use For | License | Maintenance |
+|---|---|---|---|
+| `edgartools` | Structured parsers (13F, 3/4/5, 13D/G, N-PORT, XBRL) | MIT | Very active (~2-3 patches/week) |
+| `datamule` | Bulk-download throughput, AWS-mirrored archives | MIT | Active |
+| `secedgar` | Light filing crawler, mostly superseded | Apache-2.0 | Last release 2025-05 |
+| Direct `httpx` | Stable endpoints (companyfacts, master.idx, submissions JSON) | n/a | Always works |
+
+See `.claude/skills/data-sources/edgartools.md` for full edgartools reference.
+
+## 7. Gotchas
+
+### 7.1 13F VALUE unit cutover (2023-01-03)
+
+EDGAR Release 22.4.1 amended Form 13F to "the value to the nearest dollar" (was thousands). **The dataset PDF still says "(x$1000)" because SEC has not amended the codebook — trust the rule, not the codebook.**
+
+Branch on **filing date** (not period end — some pre-cutover-period filings were re-filed after cutover and use dollars):
+
+```python
+_VALUE_DOLLARS_CUTOVER = date(2023, 1, 3)
+if filed_at.date() >= _VALUE_DOLLARS_CUTOVER:
+    value_dollars = value_raw  # already dollars
+else:
+    value_dollars = value_raw * 1000
+```
+
+Pattern at [app/services/sec_13f_dataset_ingest.py:316-326](../../../app/services/sec_13f_dataset_ingest.py#L316-L326). SUMMARYPAGE.TABLEVALUETOTAL **also** flips on this date.
+
+### 7.2 13F PRN rows are bond principals
+
+Filter `WHERE SSHPRNAMTTYPE = 'SH'` before any share aggregation. PRN rows hold dollar principal of bonds — issuer name might still be familiar (e.g. `APPLE INC` for AAPL bonds). PR #1054 found 20k PRN rows in 2026Q1 alone.
+
+### 7.3 DD-MON-YYYY dates in bulk archives
+
+`datetime.fromisoformat("15-JAN-2026")` raises `ValueError`. Pipeline silently drops 100% of rows. Workaround: `_parse_sec_date` pattern in §2.5.
+
+### 7.4 Submissions JSON `recent` cap
+
+Max 1000 entries OR ≥ 1 year. Always check `filings.files[]` and recurse. Pattern in §1 above.
+
+### 7.5 Companyfacts can have null/empty units
+
+`units["USD"][0]` may KeyError or IndexError on small/recently-listed issuers. Defensive iteration:
+
+```python
+for tag, concept in facts.get("us-gaap", {}).items():
+    units = concept.get("units") or {}
+    for unit_name, rows in units.items():
+        for row in rows or []:
+            ...
+```
+
+### 7.6 ZIP archive entry ordering not guaranteed
+
+`for entry in zf.namelist()` may give wrong order. Always look up by name:
+```python
+with zipfile.ZipFile(path) as zf:
+    submission = zf.read("SUBMISSION.tsv")
+    infotable = zf.read("INFOTABLE.tsv")
+```
+
+### 7.7 13D/G coverage cliff at 2024-12-18
+
+Pre-mandate filings are HTML/text — no `primary_doc.xml`. Filter ingest by filing date or accept lower-fidelity historical coverage.
+
+### 7.8 `acceptanceDateTime` is UTC despite ET filing windows
+
+SEC's "5:30 p.m. ET" cutoff = **22:30 UTC (EST, UTC-5)** or **21:30 UTC (EDT, UTC-4)**. Convert to ET via `zoneinfo.ZoneInfo("America/New_York")` before applying SEC's day boundary.
+
+### 7.9 `getcurrent` Atom feed is `ISO-8859-1`
+
+Aggressive UTF-8 decoding mojibakes filers with accented names. Use the encoding declared in the XML prolog or feed lxml the raw bytes.
+
+### 7.10 `<value>`-wrapping in Form 4 / 13D/G
+
+`findtext("transactionShares")` returns None — descend to `transactionShares/value` (the `<value>` child wrapper exists so SEC can attach a sibling `<footnoteId>`).
+
+### 7.11 `data.sec.gov` does not support CORS
+
+Front-end JavaScript cannot directly call `data.sec.gov` — must proxy through eBull's backend. Affects any "fetch SEC live in the browser" idea.
+
+### 7.12 Tickers are uppercase but broker may return mixed case
+
+Submissions JSON returns `["AAPL"]`. eToro historically surfaced `"Aapl"`. Always uppercase before equality-match.
+
+### 7.13 Submissions JSON `tickers` array can be empty
+
+For delisted / foreign-only / fund-family filers, `tickers: []`. Check length before indexing.
+
+### 7.14 Mutual fund share classes share CUSIP at series level
+
+Vanguard 500 Index has VFINX (Investor) + VFIAX (Admiral). Both share classes hold the same portfolio. Aggregating by classId double-counts. Aggregate by `(seriesId, issuerCusip)`.
+
+### 7.15 Multiple INFOTABLE rows for same `(NAMEOFISSUER, CUSIP)` per accession
+
+A manager can submit multiple rows per security (per share class / per discretion bucket / per managed sub-fund). Aggregating "manager X's AAPL position" requires summing across rows. PR #1054 caught this.
+
+## 8. Operator checklist for new SEC integrations
+
+Before writing code that hits SEC EDGAR:
+
+1. ✅ Identify canonical endpoint (smallest payload, right refresh cadence).
+2. ✅ Pin User-Agent to `{operator name} {operator email}`. Verify config flows through every HTTP call site.
+3. ✅ Determine refresh tier (hot / warm / cold) and map to cron cadence.
+4. ✅ Decide if bulk archive can replace per-filing fetches for initial backfill.
+5. ✅ Implement conditional fetch (`If-Modified-Since` / `If-None-Match`) where headers are published.
+6. ✅ Implement tolerant date parsing (ISO 8601 + `DD-MON-YYYY`) for any field touching a bulk archive.
+7. ✅ Implement branch-on-type (INFOTABLE SH vs PRN, NPORT NS vs PA, Form 4 D vs I).
+8. ✅ Implement VALUE unit cutover (date(2023,1,3) by filing date) for any 13F-derived figure.
+9. ✅ Use explicit identifier bridges (`company_tickers.json`, 13F Official List, GLEIF). Never fuzzy-name match without bound + coverage gate.
+10. ✅ Cache fetched bytes in `raw_filings` so re-wash is local.
+11. ✅ Smoke-test against canonical 5-instrument panel: AAPL, GME, MSFT, JPM, HD. Verify operator-visible figure on live endpoint after backfill (CLAUDE.md ETL clauses 8-12).
+
+## 9. eBull-internal entry points
+
+Where this knowledge already lives in code:
+
+| Concern | File |
+|---|---|
+| CIK / ticker discovery | [app/services/cik_discovery.py](../../../app/services/cik_discovery.py) |
+| 13F XML per-filing parse | [app/providers/implementations/sec_13f.py](../../../app/providers/implementations/sec_13f.py) (EdgarTools, #925) |
+| 13F dataset bulk TSV | [app/services/sec_13f_dataset_ingest.py](../../../app/services/sec_13f_dataset_ingest.py) |
+| 13F filer directory walk | [app/services/sec_13f_quarterly_sweep.py](../../../app/services/sec_13f_quarterly_sweep.py) |
+| 13F Official List | [app/services/sec_13f_securities_list.py](../../../app/services/sec_13f_securities_list.py) |
+| Submissions JSON walker | [app/providers/implementations/sec_submissions.py](../../../app/providers/implementations/sec_submissions.py) |
+| Submissions overflow paging | [app/jobs/sec_rebuild.py:335](../../../app/jobs/sec_rebuild.py#L335) |
+| Companyfacts ingest | [app/providers/implementations/sec_fundamentals.py](../../../app/providers/implementations/sec_fundamentals.py), [app/services/fundamentals.py](../../../app/services/fundamentals.py) |
+| Conditional fetch | [app/providers/implementations/sec_edgar.py:497-529](../../../app/providers/implementations/sec_edgar.py#L497-L529) |
+| Daily-index walker | [app/providers/implementations/sec_daily_index.py](../../../app/providers/implementations/sec_daily_index.py) |
+| Atom getcurrent | [app/providers/implementations/sec_getcurrent.py](../../../app/providers/implementations/sec_getcurrent.py) |
+| N-PORT XML parse + ingest | [app/services/n_port_ingest.py](../../../app/services/n_port_ingest.py) (stdlib `xml.etree.ElementTree`, #917) |
+| N-PORT dataset bulk | [app/services/sec_nport_dataset_ingest.py](../../../app/services/sec_nport_dataset_ingest.py) |
+| N-CEN classifier | [app/services/ncen_classifier.py](../../../app/services/ncen_classifier.py) |
+| Form 4 insider | [app/services/insider_transactions.py](../../../app/services/insider_transactions.py), [app/services/sec_insider_dataset_ingest.py](../../../app/services/sec_insider_dataset_ingest.py) |
+| 13D/G blockholders | [app/services/blockholders.py](../../../app/services/blockholders.py), [app/providers/implementations/sec_13dg.py](../../../app/providers/implementations/sec_13dg.py) |
+| Filing-folder manifest | [app/services/filing_documents.py](../../../app/services/filing_documents.py) |
+| Bulk download orchestrator | [app/services/sec_bulk_download.py](../../../app/services/sec_bulk_download.py) |
+| Raw-filing cache | [app/services/raw_filings.py](../../../app/services/raw_filings.py) |
+| Schedulers (conditional fetch) | [app/workers/scheduler.py:1460-1574](../../../app/workers/scheduler.py#L1460-L1574) |
+
+## 10. Sources
+
+- SEC accessing-edgar-data: <https://www.sec.gov/search-filings/edgar-search-assistance/accessing-edgar-data>
+- SEC EDGAR APIs: <https://www.sec.gov/search-filings/edgar-application-programming-interfaces>
+- SEC developer resources: <https://www.sec.gov/about/developer-resources>
+- Form 13F dataset PDF: <https://www.sec.gov/files/form_13f.pdf>
+- Form 13F XML information-table guide: <https://www.sec.gov/files/13f-xml-information-table.pdf>
+- Form 13F FAQ (rounding/units): <https://www.sec.gov/rules-regulations/staff-guidance/division-investment-management-frequently-asked-questions/frequently-asked-questions-about-form-13f>
+- Form N-PORT XML tech specs (v1.7): <https://www.sec.gov/info/edgar/specifications/form-n-port-xml-tech-specs.htm>
+- N-PORT dataset readme: <https://www.sec.gov/files/nport_readme.pdf>
+- Schedule 13D/G XML tech specs (latest): <https://www.sec.gov/edgar/filer-information/current-edgar-technical-specifications> (current revision 2.2 as of 2026-03-16; pinned URL pattern is `https://www.sec.gov/file/schedule-13d-13g-tech-specs-{NN}`)
+- Insider Forms 3/4/5 bulletin: <https://www.sec.gov/files/forms-3-4-5.pdf>
+- EDGAR ownership XML spec: <https://www.sec.gov/info/edgar/ownershipxmlspec-v1-r1.doc>
+- 2023-01-03 13F amendment context: <https://www.toppanmerrill.com/blog/sec-updates-edgar-on-jan-3-2023-for-form-13f-changes/>

--- a/.claude/skills/ebull/data-engineer.md
+++ b/.claude/skills/ebull/data-engineer.md
@@ -1,0 +1,511 @@
+# eBull data engineer — what we own, how we store it, how we read it
+
+> Read this when adding a new ingest path, schema migration, or operator-visible read endpoint. The non-negotiable directive from the operator: future agents must use this file to answer "where does X come from?" without guessing. Cross-reference: `docs/settled-decisions.md` for the decisions; `docs/review-prevention-log.md` for the recurring traps; `.claude/skills/data-sources/sec-edgar.md` for the source-of-truth knowledge.
+
+## 0. Top-of-mind invariants — the don't-break list
+
+| # | Rule | Enforced by |
+|---|---|---|
+| I1 | API authn ≠ authz; instrument-scoped endpoints must validate operator/instrument scope | per-endpoint code; e.g. `app/api/instruments.py:34-47` (`require_session_or_service_token`) |
+| I2 | All SQL is parameterised — `%(name)s` / positional, never f-strings for values | `docs/review-prevention-log.md:334` |
+| I3 | Every parsed filing carries `parser_version` | `sec_filing_manifest.parser_version` (`sql/118:97-102`); keyed on accession not row |
+| I4 | Every rollup slice carries `denominator_basis ∈ {pie_wedge, institution_subset}` | `OwnershipSlice.denominator_basis` (`app/services/ownership_rollup.py:68, 125`) |
+| I5 | Funds slice excluded from residual + concentration math (memo overlay) | `_compute_residual` + `_compute_concentration` filters (`app/services/ownership_rollup.py:923-955`) |
+| I6 | Soft-delete via tombstones, never hard-delete observations | `ownership_*_observations.known_to`, `*_ingest_log` rows, manifest `tombstoned` state |
+| I7 | Atomic versioning for `_current` writes: `pg_advisory_xact_lock` per instrument; PK is second-line guard | `refresh_*_current()` functions in `app/services/ownership_observations.py` |
+| I8 | Every observation write triggers `_current` refresh (write-through). Plus weekly backfill catches legacy gaps | call-site pattern in ingesters; backfill `JOB_OWNERSHIP_OBSERVATIONS_BACKFILL` (`app/workers/scheduler.py:710-735`) |
+| I9 | `sec_filing_manifest` is source of truth for "is filing X on file?". Bumping `parser_version` flips rows back to `pending` for rewash | manifest state machine + `sec_rebuild` job |
+| I10 | Identity resolution: instruments are `BIGINT instrument_id`; filers are `TEXT cik` (10-digit zero-padded). They never collapse | manifest `subject_type` CHECK; observations split by category |
+| I11 | Coverage is telemetry, not a gate: red/amber/green banner state never blocks an endpoint | `_compute_coverage` / `_banner_for_state` (`app/services/ownership_rollup.py:966-1093`); `OwnershipRollup.no_data` returns 200 with empty payload |
+| I12 | eToro broker is sole execution boundary; all order writes go via `app/services/order_client.py` and audit `decision_audit` | settled-decisions Provider strategy; `app/api/orders.py` |
+
+Hard-rule corollaries:
+- `INSERT INTO instruments` fixtures must supply `is_tradable` (prev-log L615).
+- `_PLANNER_TABLES` in `tests/fixtures/ebull_test_db.py` must list every new FK-child table.
+- Never close positions without explicit user action — `close_position()` only via UI or EXIT recommendation.
+- Never `ON DELETE CASCADE` on `*_audit` / `*_log` (prev-log L350).
+
+## 1. Schema layer — by domain
+
+### 1.1 Identity & instrument core
+
+| Table | Sql | Purpose |
+|---|---|---|
+| `instruments` | sql/001 | Canonical entity row. `instrument_id BIGINT`, symbol, company_name, exchange, currency, sector, `is_tradable` |
+| `external_identifiers` | sql/003 | `(provider, identifier_type, identifier_value) → instrument_id`. Globally unique. SEC: `provider='sec', identifier_type='cik' / 'cusip'` |
+| `exchanges` | sql/067 | eToro `exchangeId` → semantic class. CHECK on `asset_class IN (us_equity, crypto, eu_equity, uk_equity, asia_equity, commodity, fx, index, unknown)` |
+| `instrument_sec_profile` | sql/051 | 1:1 SEC submissions metadata (cik, sic, former_names, has_insider_issuer). ON DELETE CASCADE from instruments |
+| `instrument_cik_history` | sql/102 | CIK chain per instrument with date ranges. `btree_gist` exclusion forbids overlapping ranges; partial UNIQUE WHERE `effective_to IS NULL` |
+| `instrument_symbol_history` | sql/103 | Symbol chain (FB→META, BBBY→BBBYQ). Same temporal-overlap GiST exclude |
+| `unresolved_13f_cusips` | sql/099 | Buffer for 13F-supplied CUSIPs not yet resolved to instruments |
+
+**No dedicated `cusip_map` table.** CUSIP→instrument lives in `external_identifiers WHERE provider='sec' AND identifier_type='cusip'`. Promotion path: 13F-HR ingest → unresolved → CUSIP backfill (#914 weekly) writes `external_identifiers` → `cusip_resolver.sweep_resolvable_unresolved_cusips` rewashes the source 13F (`app/services/cusip_resolver.py:425+`).
+
+**Identity-graph cheat sheet**:
+- Instrument = `BIGINT instrument_id` (eToro-derived).
+- CIK = 10-digit zero-padded TEXT (SEC).
+- Mapping: `external_identifiers.provider='sec', identifier_type='cik', is_primary=TRUE` is canonical resolver. Historical CIKs in `instrument_cik_history`.
+- 13F filer CIKs ≠ issuer CIKs. Live in `institutional_filers.cik` (sql/090).
+- N-PORT trust CIKs ≠ 13F manager CIKs. Live in `sec_nport_filer_directory.cik` (sql/126). Disjoint from `institutional_filers`. Codex finding on #919: walking `institutional_filers` for N-PORT was the root cause of empty fund holdings.
+- 13D/G primary filers in `blockholder_filers.cik` (sql/095). Per-row `reporter_cik` nullable (natural persons / family trusts).
+
+### 1.2 Ownership observations + current (sql/113 → sql/127)
+
+**Two-layer model** (#840 Phase 1):
+- **Layer 1 — observations**: immutable append-only fact log, partitioned `RANGE(period_end)` quarterly 2010-2030 + `_default` partition.
+- **Layer 2 — `_current`**: mutable materialised dedup snapshot, rebuilt by `refresh_<category>_current(instrument_id)`.
+
+**Five-axis category split** (six tables of each shape):
+
+| Category | Subject | observations | _current | Source(s) | Identity (_current) |
+|---|---|---|---|---|---|
+| insiders | issuer | `ownership_insiders_observations` (sql/113) | `ownership_insiders_current` | form4, form3 | `(instrument_id, holder_identity_key, ownership_nature)` |
+| institutions | issuer | `ownership_institutions_observations` (sql/114) | `ownership_institutions_current` | 13f | `(instrument_id, filer_cik, ownership_nature, exposure_kind)` |
+| blockholders | issuer | `ownership_blockholders_observations` (sql/115) | `ownership_blockholders_current` | 13d, 13g | `(instrument_id, reporter_cik, ownership_nature)` |
+| treasury | issuer | `ownership_treasury_observations` (sql/116) | `ownership_treasury_current` | xbrl_dei | `(instrument_id)` |
+| def14a | issuer | `ownership_def14a_observations` (sql/116) | `ownership_def14a_current` | def14a | `(instrument_id, holder_name_key, ownership_nature)` |
+| funds | issuer (via fund_series) | `ownership_funds_observations` (sql/123) | `ownership_funds_current` | nport (CHECK pinned) | `(instrument_id, fund_series_id)` |
+| esop | issuer | `ownership_esop_observations` (sql/127) | `ownership_esop_current` | def14a (CHECK pinned) | `(instrument_id, plan_name)` |
+
+**Provenance block** (uniform across every `ownership_*_observations`):
+
+| Column | Type | Meaning |
+|---|---|---|
+| source | TEXT | CHECK list: `form4, form3, 13d, 13g, def14a, 13f, nport, ncsr, xbrl_dei, 10k_note, finra_si, derived` |
+| source_document_id | TEXT | Per-row identifier inside accession (e.g. `accession#row_num`) |
+| source_accession | TEXT | SEC accession |
+| source_field | TEXT | Free-form provenance (XPath, JSON pointer) |
+| source_url | TEXT | Direct link |
+| filed_at | TIMESTAMPTZ | When SEC stamped acceptance |
+| period_start / period_end | DATE | Period coverage; period_end is partition key |
+| known_from / known_to | TIMESTAMPTZ | Valid-time. NULL `known_to` = currently valid; non-NULL = soft-delete |
+| ingest_run_id | UUID | Correlation id |
+| ingested_at | TIMESTAMPTZ | System-time. DEFAULT `clock_timestamp()` so each row in batch gets distinct stamp |
+
+**Generated identity keys handle NULL CIKs**:
+- `holder_identity_key` (sql/113:49-53) = `'CIK:'||trim(cik)` if non-NULL, else `'NAME:'||lower(trim(holder_name))`. Stops legacy NULL-CIK rows from collapsing.
+- `holder_name_key` (sql/116:110) = `lower(trim(holder_name))` for DEF 14A.
+
+**Cross-column CHECK invariants**:
+- Blockholders: submission_type ↔ status_flag (`13D|13D/A → active`, `13G|13G/A → passive`).
+- Funds: `payoff_profile='Long'`, `asset_category='EC'`, `shares > 0`.
+- ESOP: `source='def14a'`, `ownership_nature='beneficial'`, `shares > 0`.
+- Treasury: `ownership_nature` defaults `'economic'`.
+- Funds & N-PORT: `fund_series_id ~ '^S[0-9]{9}$'` regex CHECK.
+
+**Partitioning**:
+- All parents `PARTITION BY RANGE (period_end)` quarterly 2010-2030 + `_default`.
+- `_default` MUST stay empty post-backfill — pinned by `tests/test_ownership_observations.py::TestProvenanceBlockUniformity::test_default_partition_is_empty_post_backfill`.
+- `ALTER TABLE` on parent propagates to existing partitions on Postgres 14+.
+
+**Residual-exclusion semantics** (`denominator_basis`):
+- `pie_wedge` slices (insiders, blockholders, institutions, etfs, def14a_unmatched) sum to ≤ `shares_outstanding` and contribute to residual + concentration.
+- `institution_subset` slices (today: funds; future: ESOP / DRS / short-interest) render as memo overlays. Their shares are NOT subtracted from residual nor counted toward concentration. N-PORT rows are fund-level detail INSIDE the 13F-HR institutional aggregate — additive accounting would double-count.
+
+### 1.3 SEC reference / discovery / coverage tables
+
+| Table | Sql | Purpose |
+|---|---|---|
+| `sec_filing_manifest` | sql/118 | Single source of truth for "is accession X on file?" PK `accession_number`. State machine `pending/fetched/parsed/tombstoned/failed`. `parser_version` rewash trigger. Self-FK `amends_accession`. CHECK enforces `subject_type='issuer' ⇔ instrument_id IS NOT NULL` |
+| `data_freshness_index` | sql/120 | "Should I poll subject Y for source Z?" Subject-polymorphic. PK `(subject_type, subject_id, source)`. State `unknown/current/expected_filing_overdue/never_filed/error`. Cadence map at `app/services/data_freshness.py:69-100` |
+| `sec_reference_documents` | sql/121 | Per-quarterly raw SEC ref docs (e.g. 13F Securities List). PK `(document_kind, period_year, period_quarter)` |
+| `sec_fund_series` | sql/124 | series_id → name + filer_cik. PK `fund_series_id` with `~ '^S[0-9]{9}$'` |
+| `n_port_ingest_log` | sql/125 | Per-accession N-PORT ingest tombstone. PK `accession_number`. Re-record overwrites prior attempt |
+| `sec_nport_filer_directory` | sql/126 | RIC trust CIKs. PK `cik`. Populated by `sec_nport_filer_directory_sync`. Sibling of `institutional_filers` (#912). Disjoint universes |
+| `institutional_filers` | sql/090 | 13F-HR filer CIKs (managers). UNIQUE `cik`. CHECK `filer_type ∈ ETF/INV/INS/BD/OTHER` |
+| `institutional_holdings` | sql/090 | Legacy per-(accession, instrument, is_put_call) 13F holdings. Partial UNIQUE on `(accession_number, instrument_id, COALESCE(is_put_call,'EQUITY'))` |
+| `blockholder_filers` / `blockholder_filings` | sql/095 | 13D/G filer registry + per-reporter rows |
+| `def14a_beneficial_holdings` / `def14a_ingest_log` | sql/097 | DEF 14A bene-table holdings + per-accession tombstone. UNIQUE `(accession_number, holder_name)` |
+| `insider_transactions` | sql/056 | Form 4 per-transaction rows. UNIQUE `(accession_number, txn_row_num)` |
+| `insider_initial_holdings` | sql/093 | Form 3 initial-holdings snapshots. UNIQUE `(accession_number, row_num)` |
+| `filing_raw_documents` | sql/107 | Per-accession raw body store |
+| `cik_raw_documents` | sql/109 | Per-CIK raw documents (e.g. submissions.json snapshots) |
+| `financial_facts_raw` | sql/032 | Individual XBRL facts from companyfacts. UNIQUE `(instrument_id, concept, unit, COALESCE(period_start,'0001-01-01'), period_end, accession_number)` |
+| `financial_periods_raw` / `financial_periods` | sql/032 | Wide period rows + canonical one-per-period. Canonical PK `(instrument_id, period_end_date, period_type)`. `superseded_at` for restatement chain |
+| `data_ingestion_runs` | sql/032 | Audit trail per provider batch |
+
+**Read-side views**:
+- `instrument_share_count_latest` — DEI > us-gaap precedence over `financial_facts_raw` (sql/052). Drives ownership rollup denominator.
+- `share_count_history`, `instrument_dilution_summary`, `dividend_history`, `instrument_dividend_summary` (sql/050 / sql/052).
+- `financial_periods_ttm` (sql/032) — TTM = SUM last 4 quarters of flow + latest-quarter stock. Powers `instrument_valuation`.
+- `instrument_valuation` (sql/032) — P/E, P/B, EV/EBITDA, dividend yield, FCF yield, debt/equity. `priced` CTE picks best price from `quotes`.
+
+### 1.4 Market data / quotes / candles
+
+| Table | Sql | Purpose |
+|---|---|---|
+| `price_daily` | sql/001 | OHLCV per `(instrument_id, price_date)` + TA columns |
+| `quotes` | sql/002 | 1:1 current snapshot per instrument; overwritten each refresh; LEFT JOIN safe |
+| `intraday_candles` | (not persisted) | Provider pass-through (eToro REST + TTL cache) |
+
+### 1.5 Operator auth / broker secrets / runtime
+
+| Table | Sql | Purpose |
+|---|---|---|
+| `operators` | sql/016 | One row in v1; identity anchor. UUID `operator_id` |
+| `operator_sessions` | sql/016 | Cookie sessions for operator UI |
+| `broker_credentials` | sql/018 | Encrypted broker secrets per operator+provider+label+environment. Partial UNIQUE `(operator_id, provider, label) WHERE NOT revoked`. Health-state added in sql/128 |
+| `broker_credentials_audit` | sql/018 | Append-only audit. ON DELETE SET NULL on credential_id (forensic preservation) |
+| `runtime_config` | sql/015 | DB-backed feature flags + kill_switch. Distinct from deployment config |
+| `pending_job_requests` | sql/084 | Durable trigger queue. State `pending → claimed → dispatched → completed`. pg_notify is wakeup hint |
+| `job_runs` | sql/014 | Per-run audit. Status `running/success/failure/skipped` |
+| `bootstrap_state` | sql/129 | Singleton (id=1) — first-install gate. `pending/running/complete/partial_error` |
+| `bootstrap_runs` | sql/129 | Per "Run bootstrap" click. Unique partial index forbids two concurrent `running` rows |
+| `bootstrap_stages` | sql/129 | Per-stage detail; lane ∈ init/etoro/sec; status ∈ pending/running/success/error/skipped |
+| `bootstrap_archive_results` | sql/130 | Per-(run, stage_key, archive_name) audit |
+| `decision_audit` | sql/001 | One row per guard invocation; per-rule results in `evidence_json` |
+| `tax_lots` | sql/001 | Tax lot ledger; matched fills via `reference_fill_id` |
+| `cash_ledger` | sql/001 | `amount` sign: positive=inflow, negative=outflow |
+
+### 1.6 Tombstone / soft-delete inventory
+
+- `ownership_*_observations.known_to` — sets to NOW() on retraction.
+- `ownership_*_observations` `_default` partition — itself a tombstone for unexpected `period_end`.
+- `sec_filing_manifest.ingest_status='tombstoned'` (terminal under normal flow).
+- `def14a_ingest_log`, `n_port_ingest_log`, `institutional_holdings_ingest_log`, `blockholder_filings_ingest_log` — per-accession attempted tombstones.
+- `unresolved_13f_cusips.resolution_status` ∈ unresolvable/ambiguous/conflict/manual_review/resolved_via_extid.
+- `broker_credentials.revoked_at`.
+- `financial_periods.superseded_at` (restatement chain).
+
+ON DELETE CASCADE used on: `instruments → instrument_sec_profile / sec_filing_manifest / data_freshness_index / instrument_*_history / ownership_esop_observations`. ON DELETE SET NULL used on `broker_credentials_audit.credential_id`.
+
+## 2. Service layer
+
+Service modules under `app/services/` (~96 modules). Canonical entry points by domain:
+
+### 2.1 Ownership domain
+
+| Module | Role | Entry points |
+|---|---|---|
+| [app/services/ownership_observations.py](../../../app/services/ownership_observations.py) | Two-layer write side: `record_*_observation()` + `refresh_*_current()` | record_insider:110, record_institution:292, record_blockholder:483, record_treasury:631, record_def14a:747, record_fund:913, record_esop:1104; refresh_*_current at 181/390/568/689/843/1040/1194 |
+| [app/services/ownership_observations_sync.py](../../../app/services/ownership_observations_sync.py) | Legacy → observations backfill (`sync_all`); `JOB_OWNERSHIP_OBSERVATIONS_BACKFILL` weekly Sun 03:00 UTC | |
+| [app/services/ownership_rollup.py](../../../app/services/ownership_rollup.py) | **Canonical Tier 0 read service**: `get_ownership_rollup(conn, symbol, instrument_id) -> OwnershipRollup` | line 1222 |
+| [app/services/ownership_history.py](../../../app/services/ownership_history.py) | Time-series payload for chart | |
+| [app/services/ownership_drillthrough.py](../../../app/services/ownership_drillthrough.py) | Per-slice drill detail | |
+| [app/services/holder_name_resolver.py](../../../app/services/holder_name_resolver.py) | DEF 14A holder_name → filer_cik via `external_identifiers` | called from rollup `_enrich_and_union_def14a` |
+| [app/services/cusip_resolver.py](../../../app/services/cusip_resolver.py) | Sweep `unresolved_13f_cusips` → promote to `external_identifiers` | `MATCH_THRESHOLD=0.92` |
+| [app/services/rewash_filings.py](../../../app/services/rewash_filings.py) | Re-parse a previously-parsed filing under updated parser | called by manifest rebuild |
+| [app/services/sec_manifest.py](../../../app/services/sec_manifest.py) | Manifest record + state-machine helpers | `record_manifest_entry`, `transition_status`, `iter_pending`, `iter_retryable` |
+| [app/services/data_freshness.py](../../../app/services/data_freshness.py) | Scheduler API: `seed_scheduler_from_manifest`, `record_poll_outcome`, `subjects_due_for_poll` | |
+
+### 2.2 Identity / discovery
+
+`app/services/cik_discovery.py`, `sec_13f_filer_directory.py`, `sec_nport_filer_directory.py`, `sec_13f_securities_list.py`, `sec_entity_profile.py`, `cusip_resolver.py`, `holder_name_resolver.py`, `instrument_history.py`, `cik_raw_filings.py`, `filer_seed_verification.py`.
+
+### 2.3 SEC / filings ingest
+
+`sec_companyfacts_ingest.py`, `sec_insider_dataset_ingest.py`, `sec_13f_dataset_ingest.py`, `sec_nport_dataset_ingest.py`, `sec_submissions_ingest.py`, `sec_submissions_files_walk.py`, `sec_pipelined_fetcher.py`, `sec_bulk_download.py`, `sec_bulk_orchestrator_jobs.py`, `sec_filing_items.py`, `raw_filings.py`, `raw_persistence.py`, `filing_documents.py`, `eight_k_events.py`, `business_summary.py`, `dilution.py`.
+
+### 2.4 Market data / etoro
+
+`market_data.py`, `intraday_candles.py`, `quote_stream.py`, `etoro_lookups.py`, `etoro_websocket.py`, `exchanges.py`, `fx.py`.
+
+### 2.5 Portfolio / execution / reporting
+
+`portfolio.py`, `portfolio_sync.py`, `position_monitor.py`, `order_client.py`, `execution_guard.py`, `return_attribution.py`, `reporting.py`, `budget.py`, `transaction_cost.py`, `tax_ledger.py`.
+
+### 2.6 Coverage / fundamentals
+
+`coverage.py`, `fundamentals.py`, `fundamentals_observability.py`, `dividends.py`, `dividend_calendar.py`, `scoring.py`, `technical_analysis.py`, `entry_timing.py`, `thesis.py`, `news.py`, `sentiment.py`, `xbrl_derived_stats.py`.
+
+### 2.7 Operator + auth + ops
+
+`operators.py`, `operator_setup.py`, `broker_credentials.py`, `credential_health.py`, `credential_health_cache.py`, `runtime_config.py`, `ops_monitor.py`, `bootstrap_orchestrator.py`, `bootstrap_preconditions.py`, `bootstrap_state.py`.
+
+### 2.8 Sync orchestrator
+
+`sync_orchestrator/{adapters,cascade,content_predicates,dispatcher,exception_classifier,executor,freshness,layer_failure_history,layer_state,layer_types,planner,progress,reaper,registry,row_count_spikes,types}.py` — DAG-driven sync replacing 12 legacy crons (#260; merged 2026-04-16/17). `dispatcher.publish_manual_job_request` is the API → jobs-process boundary.
+
+### 2.9 Read paths — canonical example
+
+Ownership rollup read flow:
+```
+GET /instruments/{symbol}/ownership-rollup
+  └─ app/api/instruments.py:4069
+       resolve symbol → instrument_id (instruments + is_primary_listing tiebreaker)
+       with snapshot_read(conn):                    # REPEATABLE READ snapshot
+         get_ownership_rollup(conn, symbol, instrument_id)
+            ├─ _read_shares_outstanding             # instrument_share_count_latest VIEW
+            ├─ historical_symbols_for(conn, instrument_id)
+            ├─ _read_treasury_from_current
+            ├─ _collect_canonical_holders_from_current
+            │      ├─ ownership_insiders_current  (form4/form3)
+            │      ├─ ownership_blockholders_current  (13d/13g)
+            │      └─ ownership_institutions_current  (13f, exposure_kind='EQUITY')
+            ├─ _read_def14a_unmatched_from_current
+            ├─ _enrich_and_union_def14a (resolve_holder_to_filer)
+            ├─ _collect_funds_from_current → ownership_funds_current
+            ├─ partition into block-only vs other (separate-pool dedup, #837)
+            ├─ _dedup_by_priority(other_candidates) (form4>form3>13d/g>def14a>13f>nport)
+            ├─ _dedup_within_source(block_candidates) (latest amendment per CIK)
+            ├─ _bucket_into_slices                  # insiders, blockholders, institutions, etfs, def14a_unmatched, funds(memo)
+            ├─ _compute_residual                    # pie_wedge slices only
+            ├─ _compute_concentration               # pie_wedge slices only
+            ├─ _read_universe_estimates             # Tier 0: all NULL → banner=unknown_universe
+            ├─ _compute_coverage / _banner_for_state
+            └─ return OwnershipRollup
+       _rollup_to_response(rollup) → Pydantic OwnershipRollupResponse
+```
+
+**No-data path returns 200 with empty slices + red banner — never 503** (`OwnershipRollup.no_data` at line 207).
+
+### 2.10 Write paths — canonical examples
+
+**13F-HR ingest (institutions)**:
+```
+sec_13f_quarterly_sweep job (Sat 02:00 UTC)
+  → sec_13f_dataset_ingest.ingest_filer_13f
+      → for each accession:
+           parse XML
+           upsert institutional_filers
+           per holding:
+             resolve CUSIP → instrument_id (external_identifiers)
+                ├─ resolved → INSERT institutional_holdings (legacy)
+                │             record_institution_observation (write-through)
+                │             refresh_institutions_current(instrument_id)
+                └─ unresolved → unresolved_13f_cusips upsert
+           record manifest row (sec_filing_manifest, ingest_status=parsed)
+```
+
+**DEF 14A ingest**:
+```
+sec_def14a_ingest job (daily 04:35 UTC) | sec_def14a_bootstrap (weekly Sun 02:30)
+  → def14a_ingest._record_def14a_observations_for_filing
+      → record_def14a_observation (also routes ESOP names via record_esop_observation)
+      → refresh_def14a_current(instrument_id) + refresh_esop_current(instrument_id)
+      → def14a_ingest_log row
+```
+
+**N-PORT ingest**:
+```
+sec_n_port_ingest (monthly day 22 03:00 UTC)
+  → n_port_ingest.ingest_n_port_for_filer
+      → walk sec_nport_filer_directory CIKs
+      → for each accession not in n_port_ingest_log:
+           parse NPORT-P (stdlib ElementTree)
+           equity-common-Long filter
+           upsert sec_fund_series
+           record_fund_observation (write-through)
+           refresh_funds_current(instrument_id)
+           n_port_ingest_log row
+```
+
+**Write-through is wired in ingester service modules. There is no trigger-based write-through** — Postgres TRIGGERs only touch `updated_at` on manifest + freshness. Any new ingest path **must explicitly call** both `record_<cat>_observation` AND `refresh_<cat>_current(instrument_id)` plus update manifest. Forgetting either leaves `_current` empty (prev-log L1162).
+
+**What write-through does NOT update**:
+- Legacy typed tables (`institutional_holdings`, `def14a_beneficial_holdings`, `insider_transactions`, `insider_initial_holdings`, `blockholder_filings`) — still written by ingesters, NOT read by rollup post-#905. Survive for chart history + drift detection.
+- `data_freshness_index` — separate write-side via `record_poll_outcome`.
+- `sec_filing_manifest.parser_version` and `raw_status` — bumped by manifest worker / parser, not by `record_*_observation`.
+
+### 2.11 Worker / job entry points
+
+[app/workers/scheduler.py:453](../../../app/workers/scheduler.py#L453) — `SCHEDULED_JOBS` declaration. [app/jobs/](../../../app/jobs/) package owns runtime side:
+- `__main__.py` boots singleton-fenced jobs process (advisory lock, `JOBS_PROCESS_LOCK_KEY`).
+- `runtime.py` invokes.
+- `listener.py` consumes `pending_job_requests` + pg_notify.
+
+SEC-specific jobs:
+- `sec_atom_fast_lane.py` — Atom feed (5 min cadence — fastest discovery layer).
+- `sec_daily_index_reconcile.py` — daily-index reconciliation.
+- `sec_per_cik_poll.py` — per-CIK submissions.json poller (cadence-driven from `data_freshness_index`).
+- `sec_first_install_drain.py` — first-install drain (#871).
+- `sec_manifest_worker.py` — pulls `pending` + `failed AND next_retry_at<=NOW()` from manifest, dispatches to parsers.
+- `sec_rebuild.py` — `POST /jobs/sec_rebuild/run` (operator-triggered targeted re-ingest).
+- `ownership_observations_repair.py` — daily 03:30 UTC drift sweep.
+
+**Process topology** (settled-decisions §"Process topology #719"):
+- FastAPI process (`app.main`): HTTP only.
+- Jobs process (`python -m app.jobs`): APScheduler + manual-trigger executor + reaper + queue dispatcher + heartbeat.
+- IPC: Postgres only — `pending_job_requests` rows + `pg_notify('ebull_job_request', ...)`. No HTTP/Redis/shared memory.
+- Both processes use `app/db/pool.open_pool` (`sql_pool` config). Never instantiate raw `ConnectionPool(...)`.
+
+## 3. Operator-visible API surface
+
+### 3.1 `/instruments/...` endpoints ([app/api/instruments.py](../../../app/api/instruments.py))
+
+| Endpoint | Tables / services |
+|---|---|
+| `GET /instruments` | instruments + quotes + coverage + external_identifiers |
+| `GET /instruments/{symbol}/financials` | financial_periods + financial_periods_ttm + instrument_valuation |
+| `GET /instruments/{symbol}/candles` | price_daily |
+| `GET /instruments/{symbol}/intraday-candles` | provider pass-through (eToro REST + TTL cache) |
+| `GET /instruments/{symbol}/sec_profile` | instrument_sec_profile |
+| `GET /instruments/{symbol}/employees` | financial_facts_raw (`dei:EntityNumberOfEmployees`) |
+| `GET /instruments/{symbol}/eight_k_filings` | eight_k_filings + eight_k_items + eight_k_exhibits |
+| `GET /instruments/{symbol}/business_sections` | instrument_business_summary_sections |
+| `GET /instruments/{symbol}/filings/10-k/history` | filing_events + instrument_business_summary |
+| `GET /instruments/{symbol}/dilution` | instrument_dilution_summary view |
+| `GET /instruments/{symbol}/dividends` | dividend_history view + dividend_events |
+| `GET /instruments/{symbol}/insider_summary` | insider_transactions aggregated |
+| `GET /instruments/{symbol}/insider_transactions` | insider_transactions |
+| `GET /instruments/{symbol}/insider_baseline` | insider_initial_holdings + insider_transactions cumulative |
+| `GET /instruments/{symbol}/def14a_holdings/drill` | def14a_beneficial_holdings + drift detection |
+| `GET /instruments/{symbol}/summary` | composite summary panel |
+| `GET /instruments/{symbol}/institutional-holdings` | institutional_holdings + institutional_filers |
+| `GET /instruments/{symbol}/blockholders` | blockholder_filings + chain aggregator |
+| `GET /instruments/{symbol}/ownership-history` | ownership_history service (time series) |
+| `GET /instruments/{symbol}/ownership-rollup` | **Tier 0 canonical read** — `ownership_rollup.get_ownership_rollup` |
+| `GET /instruments/{symbol}/ownership-rollup/export.csv` | `build_rollup_csv` |
+
+### 3.2 `/system/...` ([app/api/system.py](../../../app/api/system.py))
+
+- `GET /system/status` — operator dashboard. Layer freshness via `check_all_layers`, job health via `check_job_health`, kill-switch via `get_kill_switch_status`. Returns `overall_status ∈ ok/degraded/down`. **503 on infra failure** (never 200).
+- `GET /system/jobs` — declared schedule + computed `next_run_time` + most recent `job_runs` row.
+
+Auth: router-level `require_session_or_service_token`. Reveals data-pipeline gaps so must not be public.
+
+### 3.3 `/jobs/...` ([app/api/jobs.py](../../../app/api/jobs.py))
+
+- `POST /jobs/{job_name}/run` — durable-queue manual trigger. INSERTs `pending_job_requests` + `pg_notify`. 202 on accept; 404 on unknown job_name.
+- `GET /jobs/runs` — recent `job_runs`.
+- `GET /jobs/requests` — recent `pending_job_requests`.
+
+Notable triggers: `POST /jobs/sec_rebuild/run`, `POST /jobs/ownership_observations_backfill/run`, `POST /jobs/sec_def14a_bootstrap/run`, `POST /jobs/sec_business_summary_bootstrap/run`, `POST /jobs/cusip_universe_backfill/run`.
+
+### 3.4 Other operator routers
+
+`/sync` (sync_orchestrator), `/system/bootstrap`, `/auth/*`, `/broker-credentials/*`, `/operators/*`, `/coverage/*`, `/recommendations/*`, `/orders/*`, `/portfolio/*`, `/scores/*`, `/theses/*`, `/audit/*`, `/news/*`, `/filings/*`, `/watchlist/*`, `/budget/*`, `/copy_trading/*`, `/alerts/*`, `/reports/*`, `/attribution/*`, `/config/*`. Operator ingest ops: `/operator/ingest-status`, `/ingest-failures`, `/ingest-backfill-queue`, `/ingest-backfill`.
+
+### 3.5 Pattern for adding a new operator-visible figure
+
+1. **Schema**: migration (next `sql/NNN`) creating table or VIEW. If observation-shaped, mirror provenance block + `record_*_observation` + `refresh_*_current` + partition strategy. Add `_PLANNER_TABLES` entry. Add CHECK constraints + Literal types on app side.
+2. **Write side**: ingester in `app/services/<source>_ingest.py`. Persist raw payload first (rule L1168). Write to typed table + write-through to observations + refresh `_current`. Manifest state-transition. `data_freshness_index` poll outcome.
+3. **Read side**: dedicated service in `app/services/<feature>.py` exposing `get_<thing>(conn, ...)` reading from `_current` snapshot inside `snapshot_read(conn)`. Return frozen dataclasses. Tag every slice with `denominator_basis` if it touches the rollup.
+4. **API**: endpoint in `app/api/instruments.py` or sibling. Call inside `with snapshot_read(conn):`. Return Pydantic mirror. Empty/no-data paths return 200 with empty payload + state flag, never 503.
+5. **Frontend**: shape in `frontend/src/api/<feature>.ts` + page component. Match denominator_basis logic on FE so charts agree with rollup CSV invariants.
+6. **Cron / job**: `ScheduledJob` entry in `app/workers/scheduler.py`. Gate behind `_bootstrap_complete`.
+7. **Tests**: shape uniformity + ingest path + read path + frontend snapshot.
+8. **Operator runbook**: backfill via `/jobs/sec_rebuild/run` for parser-version bumps.
+
+## 4. "Where does X come from?" — common-questions FAQ
+
+### Q1. AAPL institutional ownership %
+- Subject: issuer.
+- Tables: `ownership_institutions_current WHERE instrument_id=AAPL.id AND exposure_kind='EQUITY'` SUM(shares) / `instrument_share_count_latest.latest_shares`.
+- Service: `get_ownership_rollup` → slice `category='institutions'`.
+- Endpoint: `GET /instruments/AAPL/ownership-rollup`.
+- Caveat: AAPL real institutional % ~62%; pre-#841 universe expansion the dev DB number is much lower because `institutional_filers` only contains the 11k-row form.idx universe and CUSIP coverage is still being expanded (#914 weekly job).
+
+### Q2. Who holds the most TSLA?
+- Same rollup endpoint. Holders sorted by shares within each slice.
+- Per-filer drill: `GET /instruments/TSLA/institutional-holdings` (reads `institutional_holdings` directly with filer joins).
+- 13D/G activists: `GET /instruments/TSLA/blockholders`.
+
+### Q3. When was the last 10-K for MSFT?
+- `sec_filing_manifest WHERE instrument_id=MSFT AND form='10-K' ORDER BY filed_at DESC LIMIT 1`. Or `filing_events` (legacy) joined to `instrument_business_summary`.
+- Service: `app/services/filings.py`.
+- Endpoint: `GET /filings/{instrument_id}` and `GET /instruments/MSFT/filings/10-k/history`.
+
+### Q4. Why does GME insider % look low?
+- Cohen Form 4 reports DIRECT shares ~38M (`ownership_nature='direct'`).
+- Cohen 13D/A reports BENEFICIAL shares ~75M (`ownership_nature='beneficial'`).
+- Pre-#840 / pre-#788: priority chain `form4 > 13d/g` collapsed into single 38M, losing beneficial. Two-axis model + parallel 13D/G dedup pool is what makes both render today (`app/services/ownership_rollup.py:1260-1283`).
+- If only ~38M shows: legacy table read path still in effect (shouldn't be post-#905) OR `ownership_blockholders_current` empty. Rebuild: `POST /jobs/sec_rebuild/run` with `{"instrument_id": <id>, "source": "sec_13d"}`.
+- denominator_basis: insiders + blockholders both `pie_wedge`, so chart shows them as separate wedges, not merged.
+
+### Q5. How fresh is the filings data?
+- "Is filing X on file?" → `sec_filing_manifest WHERE accession_number=X`.
+- "Should we have polled subject Y?" → `data_freshness_index WHERE subject_type=... AND subject_id=... AND source=...`. State + `expected_next_at` show cadence health.
+- Last bootstrap: `bootstrap_state` (singleton) or `GET /system/bootstrap/status`.
+- Per-job freshness: `GET /system/status` aggregates `check_all_layers`.
+- Per-job last run: `job_runs WHERE job_name=...` or `GET /system/jobs` / `GET /jobs/runs?job_name=...`.
+- SEC ingest backlog: `sec_filing_manifest WHERE ingest_status IN ('pending','failed') AND (next_retry_at IS NULL OR next_retry_at <= NOW())`.
+
+### Q6. Which CIK does ticker X map to?
+- Current: `external_identifiers WHERE provider='sec' AND identifier_type='cik' AND is_primary=TRUE AND instrument_id=X.id` OR `instrument_sec_profile.cik`.
+- Historical: `instrument_cik_history WHERE instrument_id=X.id ORDER BY effective_from`.
+- Symbol history (FB → META): `instrument_symbol_history` analogous.
+- Reverse "this CIK is whose?": `external_identifiers WHERE provider='sec' AND identifier_type='cik' AND identifier_value='0000xxxxxxx'`.
+- For 13F/13D/N-PORT FILERS (not issuers): `institutional_filers.cik`, `blockholder_filers.cik`, `sec_nport_filer_directory.cik` — those are filer CIKs, NOT issuer CIKs.
+- Unresolved: `unresolved_13f_cusips`. Promotion runs weekly via `cusip_universe_backfill` + `cusip_extid_sweep`.
+
+### Q7. Does AAPL have an N-PORT mutual-fund slice?
+- `ownership_funds_current WHERE instrument_id=AAPL.id`. Source always `nport`. denominator_basis always `institution_subset` (memo overlay). Series identity = `fund_series_id` matched against `sec_fund_series`.
+- Fund manager (RIC trust) CIK in `fund_filer_cik`. To find which manager: `sec_nport_filer_directory WHERE cik=fund_filer_cik`. NOT in `institutional_filers` (that's 13F managers, disjoint).
+- Slice does NOT contribute to residual or concentration; visualises fund-level detail of holdings already counted via 13F-HR.
+
+### Q8. Why is this DEF 14A holder showing in `def14a_unmatched`?
+- DEF 14A bene-table holders carry `holder_name` only — no CIK on proxy itself. Match-to-CIK happens at rollup-read time via `holder_name_resolver.resolve_holder_to_filer`. If resolver returns `matched=False`, candidate lands in `def14a_unmatched`.
+- Common causes: name normalisation gap (try cleaning the holder_name spelling), or holder genuinely has no Form 4 / Form 3 / 13F filing in the DB (typical for non-officer 5%+ holders).
+
+### Q9. Where do I look at raw SEC payloads?
+- Per-accession bodies: `filing_raw_documents` (sql/107). `raw_status` on manifest tracks whether body is stored.
+- Per-CIK documents (e.g. submissions.json snapshot): `cik_raw_documents` (sql/109).
+- Per-quarter SEC reference docs (13F Securities List): `sec_reference_documents` (sql/121).
+- Filesystem `data/raw/**` retention: `raw_data_retention_sweep` (daily 02:00 UTC). Compaction state in `raw_persistence_state` (sql/038).
+
+### Q10. How are observations dedup'd into _current?
+- `refresh_<category>_current(conn, instrument_id=X)` — DELETE rows for instrument X then INSERT one row per `(holder_identity_key, ownership_nature, ...)` group.
+- Winner ordering: source priority (`form4 > form3 > 13d > 13g > def14a > 13f > nport > ncsr`) → `period_end DESC` → `filed_at DESC` (amendments win) → `source_document_id ASC`.
+- Wrapped in `pg_advisory_xact_lock(<hash of instrument_id>)` so concurrent refreshes serialise; PK on `_current` is second-line guard.
+- Cross-source dedup ONLY within compatible natures — Cohen direct + Cohen beneficial both survive.
+
+### Q11. Why might a chart show non-zero figure but CSV export sum 0?
+- CSV emits two memo rows: `__treasury__` and `__residual__` for additive reconciliation `treasury + residual + Σ pie_wedge = shares_outstanding`.
+- Memo-overlay slices (today: funds) emitted with `__memo:funds__` category prefix AFTER residual row. A spreadsheet `SUM(shares)` over the whole file is inflated. Filter to non-`__memo:` categories before summing. See `build_rollup_csv` (`app/services/ownership_rollup.py:1326-1444`).
+
+### Q12. How do I trigger a re-ingest after a parser bump?
+- Bump `parser_version` constant in parser code → manifest queries detect rows on older version → operator runs `POST /jobs/sec_rebuild/run` with `{"source": "sec_form4"}` (or scoped `{"instrument_id": N, "source": "sec_13f_hr"}`).
+- Job flips manifest rows back to `pending`, manifest worker drains at 10 r/s shared. Monitor via `GET /jobs/sec_manifest_worker/status` (or count of `manifest WHERE ingest_status='pending' AND source='...'`).
+
+### Q13. Where does shares_outstanding come from?
+- `instrument_share_count_latest` view (sql/052) → DEI > us-gaap precedence on `financial_facts_raw`.
+- Producing accession + form_type enriched via re-query in `_read_shares_outstanding` (`app/services/ownership_rollup.py:1138-1200`).
+- EDGAR archive URL computed backend-side (not frontend) to prevent the wrong endpoint shape (Claude-PR-800 caught a `filenum=`-using FE URL bug).
+
+### Q14. Where is the kill switch?
+- `runtime_config` row keyed by name. Read by `get_kill_switch_status` (`app/services/ops_monitor.py`).
+- Toggle: `POST /system/config/kill-switch` (`app/api/config.py:233`).
+
+## 5. Quick reference — file/line index
+
+**Schema**:
+- Two-layer ownership: `sql/113` insiders, `sql/114` institutions, `sql/115` blockholders, `sql/116` treasury+def14a, `sql/119` ingested_at, `sql/123` funds, `sql/127` esop.
+- SEC manifest + freshness: `sql/118`, `sql/120`, `sql/121`.
+- Fund directory: `sql/124`, `sql/125`, `sql/126`.
+- Identity: `sql/001`, `sql/003`, `sql/051`, `sql/067`, `sql/099`, `sql/102`, `sql/103`.
+- Filings legacy: `sql/056`, `sql/090`, `sql/093`, `sql/095`, `sql/097`.
+- Fundamentals: `sql/032`, `sql/050`, `sql/052`.
+- Bootstrap: `sql/129`, `sql/130`, `sql/131`, `sql/132`.
+- Ops + auth: `sql/014`, `sql/015`, `sql/016`, `sql/018`, `sql/084`, `sql/087`, `sql/128`.
+
+**Services (canonical entry points)**:
+- Read: `app/services/ownership_rollup.py:1222` (`get_ownership_rollup`).
+- Write/refresh: `app/services/ownership_observations.py`.
+- Manifest: `app/services/sec_manifest.py`.
+- Freshness: `app/services/data_freshness.py`.
+- CUSIP: `app/services/cusip_resolver.py`.
+- Holder name: `app/services/holder_name_resolver.py`.
+
+**Workers**:
+- Schedule: `app/workers/scheduler.py:453` (`SCHEDULED_JOBS`).
+- Jobs runtime: `app/jobs/__main__.py`, `app/jobs/runtime.py`, `app/jobs/listener.py`.
+- Singleton fence: `app/jobs/locks.py` (`JOBS_PROCESS_LOCK_KEY`).
+- DB pool: `app/db/pool.py:open_pool`.
+- Snapshot read: `app/db/snapshot.py:snapshot_read`.
+
+**API**:
+- `app/api/instruments.py` — `/instruments`.
+- `app/api/system.py` — `/system/status`, `/system/jobs`.
+- `app/api/jobs.py` — `/jobs/{name}/run`, `/jobs/runs`, `/jobs/requests`.
+- `app/api/bootstrap.py` — `/system/bootstrap/status`, `/system/bootstrap/run`, `/system/bootstrap/mark-complete` (router prefix `/system/bootstrap`).
+
+**Specs**:
+- `docs/superpowers/specs/2026-05-03-ownership-tier0-and-cik-history-design.md`
+- `docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md` (Phase 1 + 3)
+- `docs/superpowers/specs/2026-05-04-etl-coverage-model.md` (manifest + freshness + 3-tier polling)
+- `docs/superpowers/specs/2026-05-06-def14a-bene-table-extension-design.md` (#843 ESOP)
+- `docs/superpowers/specs/2026-05-07-first-install-bootstrap.md` (#993)
+- `docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md`
+
+**Settled decisions**: `docs/settled-decisions.md`.
+**Review prevention log**: `docs/review-prevention-log.md`.
+
+## 6. Known live caveats / tech debt
+
+- **Coverage = telemetry not gate**: per-category universe estimates still NULL for Tier 0 (`_read_universe_estimates` returns all-None). Banner reports `unknown_universe` on most instruments. Real estimates seeded in #790 / Batch 2.
+- **AAPL institutional %**: under-reported on dev DB until universe-expansion sweep finishes. Operator audit 2026-05-04.
+- **Funds slice coverage**: only 2020-CIK panel harvested before #963 directory walker. Sweep 2026-05-05 finished filling trust universe but per-CIK drain gated on monthly N-PORT job. For panel verification today, use `POST /jobs/sec_n_port_ingest/run`. **Workaround scripts at `.claude/*.py` are a tell that the standing job is broken — fix the job, don't extend the workaround.**
+- **CI pytest job dropped (#928)**: pre-push hook is sole test gate.
+- **AS-OF semantics**: `as_of_date` everywhere = period end, never fetch time. `ingested_at` is system-time watermark for repair sweep. `known_from`/`known_to` are valid-time. Don't mix.
+- **N-PORT validation cliff (#932)**: EdgarTools' Pydantic `FundReport.parse_fund_xml` rejects synthetic test fixtures the bespoke parser tolerates. Bespoke stdlib-ElementTree parser remains shipped; rewrite parked.

--- a/.claude/skills/ebull/metrics-analyst.md
+++ b/.claude/skills/ebull/metrics-analyst.md
@@ -1,0 +1,517 @@
+# eBull metrics analyst — what we measure, where it comes from, where it renders
+
+> Read this when answering "what is X?", "where does Y come from?", "where does Z render?", or when choosing what to expose on a new operator panel. Every metric below is anchored `path:line` so an agent can verify before quoting. All paths are repo-relative.
+>
+> **Naming**: numbers labelled "TTM" come from `financial_periods_ttm` and require `is_complete_ttm = TRUE`. Numbers labelled "as-filed" come from a single `financial_periods` row.
+>
+> **Scope discipline**: catalog is descriptive. Metrics marked `(planned: #N)` are filed but not rendered. Metrics marked `(deferred)` are not yet specced. Don't invent values.
+>
+> Per-metric template:
+> ```
+> Definition / Formula / Source data / Storage / Service / Endpoint / Chart / Cadence / Caveats / Validation
+> ```
+
+## Master index
+
+| Metric | Category | Storage | Endpoint |
+|---|---|---|---|
+| 13F holdings change (last quarter) | Filings + events | `ownership_institutions_observations` | `/instruments/{symbol}/institutional-holdings` |
+| 52-week range | Market data | (deferred) | `/instruments/{symbol}/summary` returns NULL |
+| 8-K event categorisation | Filings + events | `eight_k_structured_events.items[].severity` | `/instruments/{symbol}/eight_k_filings` |
+| ATR-14 | Market data | `price_daily.atr_14` | (TA scoring) |
+| AUM | Risk + portfolio | positions × quotes × cash_ledger | `/portfolio` |
+| Available for deployment | Risk + portfolio | `budget_config` + computed | `/budget` |
+| Backfill / SEC manifest pending count | Pipeline | `sec_filing_manifest`, `data_freshness_index` | `/system/jobs`, `/system/bootstrap/status` |
+| Beta vs SPY | Market data | (deferred) | — |
+| Blockholder ownership % | Ownership | `ownership_blockholders_current` | `/instruments/{symbol}/ownership-rollup` |
+| Bollinger bands (20, 2σ) | Market data | `price_daily.bb_upper / bb_lower` | (TA scoring) |
+| Bootstrap state + stage status | Pipeline | `bootstrap_state`, `bootstrap_stages`, `bootstrap_archive_results` | `/system/bootstrap/status` |
+| Buyback authorisation | Capital returns | (deferred) | — |
+| Capital event (deposit / withdraw) | Risk + portfolio | `capital_events` | `/budget/events` |
+| Cash + equivalents | Fundamentals | `financial_periods.cash` | `/instruments/{symbol}/financials?statement=balance` |
+| Cash balance (operator) | Risk + portfolio | `cash_ledger` SUM | `/portfolio` |
+| Cash buffer reserve | Risk + portfolio | `budget_config.cash_buffer_pct` | `/budget`, `/budget/config` |
+| Coverage tier | Pipeline | `coverage.coverage_tier` (1/2/3) | `/instruments`, `/instruments/{symbol}/summary` |
+| Coverage % per source | Pipeline | `coverage_audit`, ownership rollup `coverage` block | `/coverage/summary`, `/coverage/insufficient` |
+| Credential health (eToro) | Pipeline | `broker_credentials_health_state` | `/system/status.credential_health` |
+| CGT / estimated tax | Risk + portfolio | `tax_disposals` + `budget_config.cgt_scenario` | `/budget` |
+| Daily candle (OHLCV) | Market data | `price_daily` | `/instruments/{symbol}/candles?range=...` |
+| DEF 14A beneficial holdings | Ownership | `def14a_beneficial_holdings` → rollup `def14a_unmatched` | `/instruments/{symbol}/ownership-rollup` |
+| DEF 14A vote summary | Filings + events | (planned) | — |
+| Dividend per share (latest) | Capital returns | `instrument_dividend_summary.latest_dps` | `/instruments/{symbol}/dividends` |
+| Dividend streak (Q) | Capital returns | `instrument_dividend_summary.dividend_streak_q` | `/instruments/{symbol}/dividends` |
+| Dividend yield (TTM) | Capital returns | `instrument_dividend_summary.ttm_yield_pct` | `/instruments/{symbol}/summary`, `/instruments/{symbol}/dividends` |
+| EBITDA TTM | Fundamentals | `instrument_valuation.ebitda_ttm` | (scoring) |
+| EPS basic / diluted | Fundamentals | `financial_periods.eps_basic / eps_diluted` | `/instruments/{symbol}/financials?statement=income` |
+| ETL freshness per source | Pipeline | `data_freshness_index` | (admin via DB) |
+| Exit recommendation | Portfolio | `trade_recommendations.action='EXIT'` | `/recommendations` |
+| FCF (period) | Fundamentals | derived `operating_cf - capex` | `/instruments/{symbol}/financials?statement=cashflow` (FE-derived) |
+| FCF TTM | Fundamentals | `instrument_valuation.fcf_ttm` | (scoring) |
+| FCF yield | Fundamentals | `instrument_valuation.fcf_yield` | (scoring; planned operator surface #671) |
+| Float concentration info chip | Ownership | rollup `concentration.pct_outstanding_known` | `/instruments/{symbol}/ownership-rollup` |
+| Fund ownership % (memo overlay) | Ownership | `ownership_funds_current`, `denominator_basis="institution_subset"` | `/instruments/{symbol}/ownership-rollup` |
+| Gross margin | Fundamentals | derived FE; `instrument_valuation.gross_margin` | `/instruments/{symbol}/financials?statement=income` |
+| Insider 90d net / counts | Filings + events | `insider_transactions` rollup | `/instruments/{symbol}/insider_summary` |
+| Insider baseline (Form 3) | Ownership | `insider_initial_holdings` | `/instruments/{symbol}/insider_baseline` |
+| Insider ownership % | Ownership | `ownership_insiders_current` | `/instruments/{symbol}/ownership-rollup` |
+| Institutional ownership % | Ownership | `ownership_institutions_current` | `/instruments/{symbol}/ownership-rollup` |
+| Job runs success rate | Pipeline | `job_runs` | `/system/status`, `/system/jobs` |
+| Kill switch state | Pipeline | `runtime_config` | `/system/status.kill_switch` |
+| Last close | Market data | `quotes.last`, fallback `price_daily.close` | `/portfolio`, `/instruments/{symbol}/summary` |
+| Last 10-K / 10-Q / 8-K date | Filings + events | `filing_events.filing_date` | `/filings`, `/instruments/{symbol}/ten_k_history`, `/instruments/{symbol}/eight_k_filings` |
+| Live volume V2 | Market data | (planned: #608) | — |
+| MACD line / signal / histogram | Market data | `price_daily.macd_*` | (TA scoring) |
+| Market cap (live) | Fundamentals / Market | `instrument_share_count_latest` × quote midpoint | `/instruments/{symbol}/summary.identity.market_cap` |
+| Net buyback rate | Capital returns | `instrument_dilution_summary` derived | `/instruments/{symbol}/dilution` |
+| Net debt | Fundamentals | `fundamentals_snapshot.net_debt` (legacy) | `/instruments/{symbol}/summary` |
+| Net dilution % YoY | Capital returns | `instrument_dilution_summary.net_dilution_pct_yoy` | `/instruments/{symbol}/dilution` |
+| Net income | Fundamentals | `financial_periods.net_income` | `/instruments/{symbol}/financials?statement=income` |
+| News sentiment score | News | `news_events.sentiment_score` | `/news/{instrument_id}` |
+| News volume (last N days) | News | COUNT(*) `news_events` | `/news/{instrument_id}` |
+| Operating income | Fundamentals | `financial_periods.operating_income` | `/instruments/{symbol}/financials?statement=income` |
+| Operating margin | Fundamentals | derived | `instrument_valuation.operating_margin` |
+| Ownership freshness chips | Ownership | `data_freshness_index` per source | `/instruments/{symbol}/ownership-rollup` |
+| P/E (TTM) | Fundamentals | `key_stats.pe_ratio`, `instrument_valuation.pe_ratio` | `/instruments/{symbol}/summary.key_stats` |
+| P/B | Fundamentals | `key_stats.pb_ratio` | `/instruments/{symbol}/summary.key_stats` |
+| Payout ratio (Div/FCF) | Capital returns | derived FE | `/instrument/{symbol}/dividends` page |
+| Position cost basis | Risk + portfolio | `positions.cost_basis` | `/portfolio` |
+| Position market value | Risk + portfolio | derived | `/portfolio` |
+| Public float (residual) | Ownership | rollup `residual.shares` | `/instruments/{symbol}/ownership-rollup` |
+| Recommendation history | Portfolio | `trade_recommendations` | `/recommendations`, `/recommendations/{id}` |
+| Residual % | Ownership | rollup `residual.pct_outstanding` | `/instruments/{symbol}/ownership-rollup` |
+| Return windows (1d/1w/1m) | Risk + portfolio | derived from `price_daily.close` | `/portfolio/rolling-pnl` |
+| Revenue (period / TTM / FY) | Fundamentals | `financial_periods.revenue` / `financial_periods_ttm.revenue_ttm` | `/instruments/{symbol}/financials?statement=income` |
+| ROA | Fundamentals | `instrument_valuation.roa`, `key_stats.roa` | `/instruments/{symbol}/summary.key_stats` |
+| ROE | Fundamentals | `instrument_valuation.roe`, `key_stats.roe` | `/instruments/{symbol}/summary.key_stats` |
+| ROIC | Fundamentals | derived FE `buildRoic()` | `/instrument/{symbol}/fundamentals` page only |
+| Rolling P&L (1d/1w/1m) | Risk + portfolio | computed `price_daily` deltas vs anchor | `/portfolio/rolling-pnl` |
+| RSI-14 | Market data | `price_daily.rsi_14` | (TA scoring) |
+| Sentiment score (per ranking) | Scoring | `scores.sentiment_score` | `/rankings` |
+| SMA-20/50/200 | Market data | `price_daily.sma_20/50/200` | (TA scoring) |
+| Total assets / liabilities / equity | Fundamentals | `financial_periods.{total_assets, total_liabilities, shareholders_equity}` | `/instruments/{symbol}/financials?statement=balance` |
+| Total debt | Fundamentals | derived `LTD + STD` | `/instruments/{symbol}/financials?statement=balance` |
+| Treasury shares | Ownership / Fundamentals | `financial_periods.treasury_shares` → rollup top wedge | `/instruments/{symbol}/ownership-rollup`, balance |
+| TTM dividends paid | Capital returns | `instrument_dividend_summary.ttm_dividends_paid` | `/instruments/{symbol}/dividends` |
+| TTM DPS | Capital returns | `instrument_dividend_summary.ttm_dps` | `/instruments/{symbol}/dividends` |
+| Universe coverage banner | Ownership | rollup `coverage.state` | `/instruments/{symbol}/ownership-rollup` |
+| Unrealised P&L (per position) | Risk + portfolio | derived from `quotes.last` | `/portfolio` |
+| Volume (daily) | Market data | `price_daily.volume` | `/instruments/{symbol}/candles` |
+| VWAP | Market data | (deferred) | — |
+| Yield-on-cost | Capital returns | derived FE | dividends drilldown |
+
+## 1. Ownership metrics (Phase 1–3 of #788)
+
+The ownership card is the cleanest example of "one fetch, one snapshot, one denominator". Every slice comes from `app/services/ownership_rollup.py:get_ownership_rollup` and renders as one wedge in `frontend/src/components/instrument/OwnershipPanel.tsx`. The only denominator is XBRL-DEI `shares_outstanding`; treasury renders as additive top wedge and is **not** in the denominator.
+
+### Insider ownership %
+- **Definition**: percentage of `shares_outstanding` held by SEC Form 3/4 filers (officers, directors, 10% owners) after cross-channel dedup.
+- **Formula**: `Σ slice.holders.shares / shares_outstanding × 100`. Each holder's `shares` is highest-priority surviving row across `(form4 > form3)` per `(filer_cik, ownership_nature)`.
+- **Source data**: SEC Form 3 + Form 4 → [app/services/insider_transactions.py](../../../app/services/insider_transactions.py), [app/services/insider_form3_ingest.py](../../../app/services/insider_form3_ingest.py).
+- **Storage**: `ownership_insiders_observations` (write-through, partitioned quarterly) → `ownership_insiders_current`.
+- **Service**: [app/services/ownership_rollup.py:347](../../../app/services/ownership_rollup.py#L347) (insiders block) + dedup priority at `:326` (`_PRIORITY_RANK`).
+- **Endpoint**: `GET /instruments/{symbol}/ownership-rollup` slice `category="insiders"`.
+- **Chart**: `OwnershipPanel.tsx:38` + `OwnershipSunburst.tsx:133` (ring 2 wedge, blue).
+- **Cadence**: write-through on every Form 3/4 ingest; backfill `POST /jobs/ownership_observations_backfill/run` (Sun 03:00 UTC).
+- **Caveats**: dedup identity key `(filer_cik | NAME-fallback, ownership_nature)`. Direct + indirect surface as separate rows on per-officer ring 3 — JPM moved 1.29% → 6.16% when this landed. Form 3 baseline-only filers (no Form 4 history) surface via `/insider_baseline` and merge into per-officer ring on FE.
+- **Validation**: cross-source against gurufocus / openinsider; smoke `AAPL`, `GME`, `MSFT`, `JPM`, `HD` per CLAUDE.md panel.
+- **denominator_basis**: `pie_wedge`.
+
+### Institutional ownership %
+- **Definition**: percentage held by 13F-HR filers (≥ $100M AUM) after cross-channel dedup.
+- **Formula**: `Σ surviving 13F holdings / shares_outstanding × 100`, equity-only (PUT/CALL exposures dropped).
+- **Source**: SEC 13F-HR XML + quarterly 13F Securities List. Parse: [app/services/sec_13f_dataset_ingest.py](../../../app/services/sec_13f_dataset_ingest.py), filer directory: [app/services/sec_13f_filer_directory.py](../../../app/services/sec_13f_filer_directory.py), CUSIP resolution: [app/services/cusip_resolver.py](../../../app/services/cusip_resolver.py). EdgarTools 13F drop-in via #925.
+- **Storage**: `ownership_institutions_observations` (partitioned, `is_put_call IS NULL` filter at read time) → `ownership_institutions_current` with `exposure_kind = 'EQUITY'` filter.
+- **Service**: [app/services/ownership_rollup.py:434-460](../../../app/services/ownership_rollup.py#L434-L460).
+- **Endpoint**: `GET /instruments/{symbol}/ownership-rollup` slices `category="institutions"` and `category="etfs"`; flat list at `GET /instruments/{symbol}/institutional-holdings` ([app/api/instruments.py:3262](../../../app/api/instruments.py#L3262)).
+- **Chart**: `OwnershipPanel.tsx` ring 2 (institutions+etfs).
+- **Cadence**: `sec_13f_quarterly_sweep` Sat 02:00 UTC, 6h deadline. Filer directory walks last 4 closed quarters.
+- **Caveats**: AAPL was historically under-counted ~10× until #840-A through #840-F landed full decomposition. Universe expansion via #841 still pending — institutional totals can lag reality. CUSIP coverage gates the join: 7.4% on dev as of #914 vs 80% target.
+- **Validation**: cross-check vs WhaleWisdom / SEC EDGAR direct; track `unresolved_13f_cusips` count.
+- **denominator_basis**: `pie_wedge`. ETF filer-type holdings come from same 13F data but render as separate slice for legibility.
+
+### Fund ownership % (memo overlay, NOT in residual)
+- **Definition**: per-fund-series equity positions from N-PORT-P. Renders as memo wedge alongside institutional pie, NOT inside it (parent advisor's 13F-HR aggregate already counts the same shares).
+- **Formula**: `Σ fund_series_holdings.shares / shares_outstanding × 100`, with `denominator_basis="institution_subset"`.
+- **Source**: SEC Form N-PORT-P parsed via [app/services/n_port_ingest.py](../../../app/services/n_port_ingest.py) (stdlib ElementTree; EdgarTools rewrite punted #932).
+- **Storage**: `ownership_funds_observations` (partitioned) → `ownership_funds_current` keyed `(instrument_id, fund_series_id)`.
+- **Service**: [app/services/ownership_rollup.py:465](../../../app/services/ownership_rollup.py#L465) (`_collect_funds_from_current`). Slice constructed at `:850-870` with `denominator_basis="institution_subset"`.
+- **Endpoint**: same `/ownership-rollup`, slice `category="funds"`.
+- **Chart**: `OwnershipPanel.tsx` renders memo overlay separately (filtered out of pie math at `:1366-1367`).
+- **Cadence**: `sec_n_port_ingest` monthly day 22 03:00 UTC. Filer directory walker `sec_nport_filer_directory_sync` seeds CIK-trust set (#963).
+- **Caveats**: per `docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md`, funds are strict subset of institutional pie wedge and must NEVER add to it. Enforced via `denominator_basis` checks in residual/concentration sums (`:927`, `:948`, `:1366-1367`). PR #962 cutover specifically.
+- **Validation**: cross-check Vanguard 500's AAPL position separately against Vanguard 13F-HR aggregate — should NOT sum.
+- **denominator_basis**: `institution_subset`.
+
+### Blockholder ownership %
+- **Definition**: percentage held by Schedule 13D (active >5%) / 13G (passive >5%) filers.
+- **Formula**: `Σ blockholder.aggregate_amount_owned / shares_outstanding × 100`. Latest amendment per filer wins.
+- **Source**: SEC 13D/G/D-A/G-A. Parser: [app/services/blockholders.py](../../../app/services/blockholders.py).
+- **Storage**: `ownership_blockholders_observations` → `ownership_blockholders_current`.
+- **Service**: [app/services/ownership_rollup.py:401](../../../app/services/ownership_rollup.py#L401) (sources `'13d'` / `'13g'`).
+- **Endpoint**: `/ownership-rollup` slice `category="blockholders"`; flat list at `/instruments/{symbol}/blockholders` ([app/api/instruments.py:3512](../../../app/api/instruments.py#L3512)).
+- **Chart**: `OwnershipPanel.tsx` ring 2.
+- **Cadence**: write-through on each 13D/G ingest; daily filings sync.
+- **Caveats**: 13D and 13G compete with Form 4 / Form 3 in dedup; Form 4 wins (`_PRIORITY_RANK`). Cohen-on-GME bug fix (audit example at `app/services/ownership_rollup.py:18-23`): without dedup, Form 4 + 13D/A double-counted same holder.
+- **denominator_basis**: `pie_wedge`.
+
+### Treasury %
+- **Definition**: shares the issuer holds itself — additive on top of `shares_outstanding` for chart, NOT a holders slice.
+- **Formula**: `treasury_shares / shares_outstanding × 100` (rendered separately as top wedge).
+- **Source**: SEC XBRL `us-gaap:TreasuryStockCommonShares` + tag variants.
+- **Storage**: `financial_periods.treasury_shares` (sql/088); mirrored to `ownership_treasury_observations` and `ownership_treasury_current` (sql/116).
+- **Service**: [app/services/ownership_rollup.py](../../../app/services/ownership_rollup.py) `_read_treasury_from_current`.
+- **Endpoint**: `/ownership-rollup.treasury_shares` + `treasury_as_of` (top-level fields, NOT inside `slices`); also balance sheet endpoint.
+- **Chart**: `OwnershipPanel.tsx` renders treasury wedge above the ring; legend has treasury swatch.
+- **Cadence**: companyfacts daily sync.
+- **Caveats**: excluded from numerator of `concentration.pct_outstanding_known` — issuer doesn't "invest" in itself (`:158-164`). Treasury IS allowed to push chart "oversubscribed" if `Σ pie_wedges + treasury > shares_outstanding` (stale-13F + fresh Form 4 mix); residual clamps to zero, banner flags it.
+- **Validation**: check `shares_authorized ≥ shares_issued ≥ treasury_shares` invariant.
+
+### Public float / residual
+- **Definition**: shares not attributable to any known SEC filing or treasury — by construction includes retail, undeclared institutional below 13F threshold, and any filer outside coverage cohort.
+- **Formula**: `residual = shares_outstanding − Σ (slices where denominator_basis="pie_wedge") − treasury_shares`. Clamped ≥ 0; `oversubscribed` flag fires when negative (`:128-140`).
+- **Storage**: not stored — computed at read time.
+- **Service**: [app/services/ownership_rollup.py:850-948](../../../app/services/ownership_rollup.py#L850-L948).
+- **Endpoint**: `/ownership-rollup.residual.{shares, pct_outstanding, oversubscribed}`.
+- **Chart**: `OwnershipPanel.tsx ResidualLine` (`:380`); always rendered as grey "Public / unattributed" wedge.
+- **Caveats**: residual is NOT a free signal — 90% residual on a small-cap usually means coverage is incomplete, not that retail owns 90%. Coverage banner is the right cue.
+- **Validation**: `Σ all wedges + residual + treasury ≈ shares_outstanding` exactly when `oversubscribed=false`.
+
+### denominator_basis explained per kind
+
+`DenominatorBasis = Literal["pie_wedge", "institution_subset"]` ([ownership_rollup.py:68](../../../app/services/ownership_rollup.py#L68)).
+
+| Slice | denominator_basis | Why |
+|---|---|---|
+| insiders | pie_wedge | Beneficial ownership; sums into pie |
+| blockholders | pie_wedge | 13D/G; sums into pie |
+| institutions | pie_wedge | 13F-HR equity; sums into pie |
+| etfs | pie_wedge | 13F-HR by filer-type ETF; sums into pie |
+| def14a_unmatched | pie_wedge | DEF 14A holders unresolved to Form 4 / 13F; conservative addition |
+| funds | institution_subset | N-PORT positions are strict subset of parent advisor's 13F-HR aggregate; memo overlay only |
+| treasury | (special) | Top-level field; rendered above pie; excluded from concentration numerator |
+
+Future overlays (ESOP #843 / DRS / short-interest #961) will land as additional `institution_subset` rows.
+
+### Share-class collapse (GOOGL+GOOG)
+- GOOGL and GOOG share CIK 1652044 (Alphabet) but separate CUSIPs and separate `instrument_id`. Each class has its own card.
+- Each class's `shares_outstanding` fetched per-class from `instrument_share_count_latest`; insider/13F filings whose CUSIP matches one class are routed to that class only.
+- **No merged view today.** If you need combined Alphabet ownership, sum the two endpoints client-side.
+
+## 2. Fundamentals
+
+All US fundamentals come from SEC XBRL via Company Facts API (settled in `docs/settled-decisions.md` Provider strategy). `app/providers/implementations/sec_fundamentals.py` has the XBRL tag → column map; `app/services/fundamentals.py` is storage layer.
+
+### Revenue
+- **Formula**: rolling sum of last four quarterly rows for TTM (gated `is_complete_ttm = TRUE`); single row for quarter / FY.
+- **Source**: XBRL `us-gaap:Revenues` + tag-set fallbacks.
+- **Storage**: `financial_periods.revenue` per-period; `financial_periods_ttm.revenue_ttm`.
+- **Endpoint**: `GET /instruments/{symbol}/financials?statement=income&period=quarterly|annual`.
+- **Chart**: `FundamentalsPane.tsx` 8-quarter AreaChart top-left; `fundamentalsCharts.tsx:212` YoY growth.
+- **Cadence**: daily via `daily_financial_facts`.
+- **Caveats**: superseded rows filtered via `superseded_at IS NULL`. Some MLPs/partnerships file `IncomeLossFromContinuingOperations` not `Revenues` — TTM may be NULL; per-cell null filter on FE keeps chart rendering.
+
+### Operating income / Net income
+- Same pattern. Tags: `us-gaap:OperatingIncomeLoss` (MLP variant `IncomeLossFromContinuingOperations`); `us-gaap:NetIncomeLoss`.
+- Storage: `financial_periods.{operating_income, net_income}` + TTM views.
+- Charts: `FundamentalsPane.tsx` cells 2 + 3; YoY growth bars.
+
+### EBITDA
+- **Formula**: `operating_income_ttm + depreciation_amort_ttm` (`sql/080:99-106` `instrument_valuation`).
+- **Storage**: `instrument_valuation.ebitda_ttm` VIEW.
+- **Endpoint**: not directly exposed; visible to scoring engine only.
+- **Caveats**: depreciation/amort can be sparse on small issuers — falls back to operating income only.
+
+### FCF (period) / FCF TTM / FCF yield
+- **FCF formula**: `operating_cf - capex` where capex = `PaymentsToAcquirePropertyPlantAndEquipment` (positive outflow in XBRL; subtracting is correct, see [fundamentalsMetrics.ts:246-251](../../../frontend/src/lib/fundamentalsMetrics.ts#L246-L251)).
+- **TTM**: `instrument_valuation.fcf_ttm`.
+- **FCF yield**: `(operating_cf_ttm - |capex_ttm|) / (current_price × shares_outstanding)` (sql/080:83-87) → `instrument_valuation.fcf_yield`.
+- **Endpoint**: per-period FCF computed FE from `/instruments/{symbol}/financials?statement=cashflow`. TTM via `instrument_valuation` (scoring only). FCF yield NOT operator-visible today — **planned operator surface: #671** (needs price-join exposure on L2 fundamentals).
+- **Chart**: `fundamentalsCharts.tsx:507` (FCF line chart).
+- **Caveats**: `capex` null on issuers without explicit PPE filing → empty-state hint. Negative FCF returns 0 from `_value_score`. Quote-derived; stale quote = stale yield.
+
+### Margins
+- **Definitions**: each = `(line / revenue) × 100`.
+- **Source**: SEC XBRL.
+- **Storage**: `instrument_valuation.{gross_margin, operating_margin, net_margin}` (sql/080:107-116) + per-period derivation.
+- **Service**: VIEW + [fundamentalsMetrics.ts:210](../../../frontend/src/lib/fundamentalsMetrics.ts#L210) (`buildMargins`).
+- **Caveats**: gross margin requires `cost_of_revenue` which is sparse on financial firms — chart drops gross line.
+
+### Total debt / Net debt / Debt-to-equity / Cash + equivalents
+- Total debt = `long_term_debt + short_term_debt`.
+- Net debt = `total_debt − cash`.
+- Debt-to-equity = `total_debt / shareholders_equity` (NULL when equity ≤ 0).
+- Cash = `us-gaap:CashAndCashEquivalentsAtCarryingValue` + tag fallbacks.
+- Storage: `financial_periods.{long_term_debt, short_term_debt, cash}`; legacy `fundamentals_snapshot.{net_debt, debt}` for `key_stats`.
+- Endpoint: `/instruments/{symbol}/financials?statement=balance` + `/summary.key_stats.debt_to_equity`.
+- Chart: `FundamentalsPane.tsx` cell 4 (Total Debt); `fundamentalsCharts.tsx buildDebtStructure` (LTD + STD + interest coverage).
+
+### Total assets / liabilities / equity
+- Tags: `us-gaap:Assets`, `us-gaap:Liabilities`, `us-gaap:StockholdersEquity`.
+- Storage: `financial_periods.{total_assets, total_liabilities, shareholders_equity}`.
+- Chart: `latestBalanceStructure` ([fundamentalsMetrics.ts:326](../../../frontend/src/lib/fundamentalsMetrics.ts#L326)) — two horizontal stacked bars to verify `assets ≈ liab + equity`.
+
+### ROE / ROA / ROIC
+- ROE = `net_income / shareholders_equity`. ROA = `net_income / total_assets`.
+- ROIC = `NOPAT / invested_capital` where NOPAT ≈ `operating_income × (1 − effective_tax_rate)`; invested capital = `LTD + STD + equity`.
+- ROE/ROA per period: [app/api/instruments.py:2863-2864](../../../app/api/instruments.py#L2863-L2864) for `key_stats`; TTM at `instrument_valuation.{roe,roa}`.
+- ROIC: [fundamentalsMetrics.ts:415-441](../../../frontend/src/lib/fundamentalsMetrics.ts#L415-L441) (FE derivation; uses 21% US-statutory placeholder when effective tax rate undefined; skips lease liabilities + minority interest — "good enough for trend-watching, not absolute valuation").
+- Endpoint: `/summary.key_stats.{roe,roa}`. ROIC: not on API; FE-only on L2 fundamentals.
+- Chart: `KeyStatsPane.tsx` ROE/ROA cells; `fundamentalsCharts.tsx` ROIC + DuPont.
+- Caveats: when `current_price` unavailable but EPS/book_value present, source label flips `sec_xbrl_price_missing` so FE renders "price missing".
+
+### EPS / P/E / P/B
+- EPS: `us-gaap:EarningsPerShareBasic / Diluted` → `financial_periods.{eps_basic, eps_diluted}`; TTM `eps_diluted_ttm`.
+- P/E: `current_price / eps_diluted_ttm` (sql/080:69-71); per-period fallback `current_price / eps`. NULL for negative EPS.
+- P/B: `current_price / (shareholders_equity / shares_outstanding)`.
+- Endpoint: `/summary.key_stats.{pe_ratio, pb_ratio}`.
+
+### Dilution / share-count metrics
+- Fields: `latest_shares`, `yoy_shares`, `net_dilution_pct_yoy`, `ttm_shares_issued`, `ttm_buyback_shares`, `ttm_net_share_change`, `dilution_posture` ∈ `{stable, dilutive, buyback_heavy}`.
+- Source: XBRL `StockIssuedDuringPeriodSharesNewIssues`, `StockRepurchasedDuringPeriodShares`, `CommonStockSharesOutstanding`, `dei:EntityCommonStockSharesOutstanding`.
+- Storage: `instrument_share_count_history`, `instrument_dilution_summary` (sql/052).
+- Service: `app/services/dilution.py:get_dilution_summary`.
+- Endpoint: `/instruments/{symbol}/dilution`.
+
+## 3. Market data
+
+### Last close / current price
+- Source: eToro WebSocket → `quotes.last`; fallback `(bid+ask)/2` (`app/services/xbrl_derived_stats.py:73-76`).
+- Storage: `quotes` (1:1 by `instrument_id`, current snapshot, overwritten).
+- Endpoint: `/instruments/{symbol}/summary.price`, `/portfolio` positions.
+- Chart: hero ticker every L2 page; `PriceChart.tsx`.
+- Cadence: live (WS); 60s candle-window backstop poll.
+
+### Day range / 52-week range
+- (Deferred.) Would derive from `price_daily.high / low`. `/summary.price.{week_52_high, week_52_low, day_change, day_change_pct}` returns NULL today; FE renders "—". Operator-visible follow-up exists in CLAUDE-md task list.
+
+### Daily candles (OHLCV)
+- Source: eToro candles refresh job → `price_daily`.
+- Storage: `price_daily` per-day per-instrument.
+- Endpoint: `/instruments/{symbol}/candles?range=1w|1m|3m|6m|ytd|1y|5y|max` ([app/api/instruments.py:700](../../../app/api/instruments.py#L700)).
+- Chart: `PriceChart.tsx`. Range mapping at `:672-680`.
+- Cadence: daily after market close.
+
+### Volume (live volume V2 — planned: #608)
+- Today: `price_daily.volume` per day; live-tick volume not aggregated.
+- Planned: rolling intraday volume against running average.
+
+### VWAP / Realised volatility / Beta vs SPY
+- All **deferred**. eToro candles do not include intraday VWAP. ATR-14 stored at `price_daily.atr_14` (sql/025) consumed by scoring as proxy.
+
+### Total return windows
+- 1d / 1w / 1m: dashboard via `/portfolio/rolling-pnl` ([app/api/portfolio.py:710](../../../app/api/portfolio.py#L710)). Anchor uses each position's `latest_close` `price_date` — never wall-clock — so stale candle doesn't collapse the bucket (Codex #387 phase 2 finding).
+- 3m / 6m / 1y: consumed internally by scoring (`return_3m`, `return_6m`); not surfaced as own panel today.
+- 5y / since-IPO: not surfaced.
+
+### Technical indicators (TA scoring layer)
+- Stored on latest `price_daily` row only:
+  - `sma_20`, `sma_50`, `sma_200`.
+  - `ema_12`, `ema_26`, `macd_line`, `macd_signal`, `macd_histogram`.
+  - `rsi_14`, `stoch_k`, `stoch_d`.
+  - `bb_upper`, `bb_lower`, `atr_14`.
+- Formulas: sql/025:7-14. Implementations: `app/services/technical_analysis.py`.
+- Used by `_momentum_score` ([scoring.py:322](../../../app/services/scoring.py#L322)) for v1.1-balanced.
+- Operator-visible: NOT in v1.
+
+### Market cap (live)
+- Formula: SEC XBRL share count × current price ([xbrl_derived_stats.py:43-95](../../../app/services/xbrl_derived_stats.py#L43-L95)). Share count from `instrument_share_count_latest` (DEI > us-gaap; newest restated).
+- Endpoint: `/summary.identity.market_cap`.
+- Caveats: NULL for non-SEC instruments — no third-party fallback per #498/#499 settled decision.
+
+## 4. Capital returns (dividends + buybacks)
+
+### Dividend per share (latest announced)
+- Source: XBRL `us-gaap:CommonStockDividendsPerShareDeclared` per period; 8-K parser for forward calendar (`app/services/dividends.py:177-237`).
+- Storage: historical `financial_periods.dps_declared` → `dividend_history` view (sql/050). Forward `dividend_events` (sql/054) populated by 8-K parser.
+- Service: `dividends.py` `get_dividend_summary:84`, `get_dividend_history:125`, `get_upcoming_dividends:177`.
+- Endpoint: `/instruments/{symbol}/dividends`.
+- Chart: `DividendsPanel.tsx`; full L2 `DividendsPage.tsx`.
+- Caveats: latest = newest QUARTER WITH POSITIVE DPS (zero/null rows excluded). Tie-break Q4 > FY same period_end.
+
+### Dividend yield (TTM)
+- Formula: `(ttm_dps / price) × 100`.
+- Storage: `instrument_dividend_summary.ttm_yield_pct`.
+- Endpoint: `/summary.key_stats.dividend_yield` and `/dividends.summary.ttm_yield_pct`.
+- Caveats: NULL when `ttm_dps` null/zero or price null/zero. `dividend_streak_q` counts consecutive positive-DPS quarters.
+
+### TTM DPS / TTM dividends paid
+- `instrument_dividend_summary.ttm_dps`, `ttm_dividends_paid`.
+
+### Payout ratio (Dividends/FCF)
+- Formula: `dividends_paid / FCF × 100`. Computed FE on **annual** data only (quarterly too noisy). FCF-negative years → NULL clamped.
+- Service: [dividendsMetrics.ts:174](../../../frontend/src/lib/dividendsMetrics.ts#L174) (`buildPayoutRatio`).
+- Caveats: SEC XBRL `PaymentsOfDividends` is positive outflow; helper `Math.abs()` to normalise issuers under-reporting negative.
+
+### Buyback authorisation outstanding
+- **Deferred** — `dividend_events` parses dividend calendars from 8-K but no buyback-authorisation parser exists. Operator must consult 8-K Item 8.01 / 1.01 directly via `/instruments/{symbol}/eight_k_filings`.
+
+### Net buyback rate
+- Derives from `instrument_dilution_summary.{ttm_buyback_shares, ttm_shares_issued}`. Surfaces `dilution_posture` ∈ `{stable, dilutive, buyback_heavy}`.
+- Endpoint: `GET /instruments/{symbol}/dilution` ([app/api/instruments.py:1577](../../../app/api/instruments.py#L1577)).
+
+### Yield-on-cost
+- An income investor's "what's the yield on what I originally paid?". Derived FE only.
+- Service: [dividendsMetrics.ts:200+](../../../frontend/src/lib/dividendsMetrics.ts#L200) (`buildYieldOnCost`); requires `/portfolio/instruments/{id}` for entry price.
+- Chart: dividends drilldown.
+
+## 5. Filings + events
+
+### Last 10-K / 10-Q / 8-K date
+- Storage: `filing_events.filing_date` (per filing per provider), typed by `filing_events.form_type`.
+- Service: `app/services/filings.py`; api `app/api/filings.py:27`.
+- Endpoint: `GET /filings?instrument_id=...&form_types=...`.
+- Chart: `FilingsPane.tsx` on L1 instrument page.
+- Caveats: settled — `filing_events` stores metadata + summary + risk score + provider payload + canonical document link. Full raw filing text out of scope. Raw documents land in `filing_raw_documents`.
+
+### 10-K Item 1 subsections
+- Source: SEC 10-K HTML body parser (`app/services/business_summary.py`, `app/services/filing_documents.py`).
+- Storage: `instrument_business_summary` + `instrument_business_summary_sections` (sql/059).
+- Endpoint: `/instruments/{symbol}/business_sections` ([app/api/instruments.py:1358](../../../app/api/instruments.py#L1358)).
+- Parse states: `not_attempted` / `parse_failed` / `no_item_1` / `sections_pending`.
+
+### 8-K filings (structured items + exhibits)
+- Source: SEC 8-K parser (`app/services/eight_k_events.py`).
+- Storage: `eight_k_structured_events` (sql/061), `filing_documents` (sql/062 exhibit pointers).
+- Endpoint: `/instruments/{symbol}/eight_k_filings?limit=...` ([app/api/instruments.py:1195](../../../app/api/instruments.py#L1195)).
+- Per-item severity: `frontend/src/components/instrument/eightKSeverity.ts`.
+- Chart: `EightKEventsPanel.tsx`, `EightKDetailPanel.tsx`, `EightKListPage.tsx`.
+
+### 8-K event severity
+- FE-only mapping (not regulatory). Item 1.01 (material agreement), 4.02 (non-reliance / restatement), 5.02 (departure of officer) typically high severity.
+
+### Insider 90-day net / counts
+- Two lenses:
+  - **Open-market**: only discretionary purchases/sales (codes P/S).
+  - **Total-activity**: every non-derivative txn classified by `acquired_disposed_code`.
+- Fields: `open_market_net_shares_90d`, `open_market_buy_count_90d`, `open_market_sell_count_90d`, `total_acquired_shares_90d`, `total_disposed_shares_90d`, `acquisition_count_90d`, `disposition_count_90d`, `unique_filers_90d`, `latest_txn_date`.
+- Service: [insider_transactions.py:get_insider_summary](../../../app/services/insider_transactions.py).
+- Storage: `insider_transactions` + `insider_initial_holdings` (Form 3) + tombstones via sql/058.
+- Endpoint: `/instruments/{symbol}/insider_summary`; detail `/insider_transactions?limit=...`; baseline `/insider_baseline`.
+- Chart: compact `InsiderActivitySummary.tsx`; L2 `InsiderPage.tsx` → `InsiderNetByMonth`, `InsiderByOfficer`, `InsiderTransactionsTable`, `InsiderPriceMarkers`.
+- Caveats: derivative grants and option exercises EXCLUDED from `open_market_*`. Tombstones excluded.
+- Validation: cross-reference openinsider.com.
+
+### 13F holdings change (last quarter)
+- Storage: `ownership_institutions_observations` (immutable per-quarter rows, sql/114).
+- Endpoint: `/institutional-holdings` (flat list); rollup at `/ownership-rollup`.
+- Today the L2 ownership page shows per-filer current holdings without explicit "delta last quarter" panel.
+
+### DEF 14A vote summary
+- **Planned.** DEF 14A parser exists for beneficial holdings (`def14a_ingest.py`, `def14a_drift.py`) and surfaces `def14a_unmatched` slice on rollup, but vote tabulation (board elections / shareholder proposals) is not parsed.
+
+## 6. News + sentiment
+
+### News volume (last N days)
+- COUNT of `news_events` rows in lookback for an instrument.
+- Storage: `news_events` (sql/005). Unique key `(instrument_id, url_hash)` per settled-decisions.
+- Service: `app/services/news.py`.
+- Endpoint: `GET /news/{instrument_id}?since=...&limit=...`. Default 30-day window.
+- Chart: `RecentNewsPane.tsx`.
+
+### News sentiment score
+- `[-1, +1]` signed numeric (no labels — settled).
+- Storage: `news_events.sentiment_score` FLOAT.
+- Aggregated into ranking `sentiment_score` (`scores.sentiment_score`).
+- Caveats: settled — persist as signed numeric only (no label columns in v1). Out-of-range logged as warning and clipped on aggregation.
+
+## 7. Risk + portfolio
+
+### AUM
+- Definition: total operator capital marked-to-market.
+- Source: `positions × quotes` + `cash_ledger` SUM + mirrors.
+- Endpoint: `/portfolio`.
+- Settled: AUM uses mark-to-market first; cost-basis fallback; never unrealised P&L.
+
+### Cash balance / Cash buffer / Available for deployment / Capital event
+- Cash balance: `cash_ledger` SUM. Sign: + inflow / − outflow.
+- Cash buffer: `budget_config.cash_buffer_pct`.
+- Capital events: `capital_events` table.
+- Endpoints: `/portfolio`, `/budget`, `/budget/events`.
+- Settled: unknown cash tolerated in PM, hard-blocked in execution guard.
+
+### Position market value / cost basis / unrealised P&L
+- `positions.cost_basis`; market value derived from `quotes.last`; unrealised P&L = `(quotes.last − cost_basis) × shares`.
+- Endpoint: `/portfolio`.
+
+### Position alerts
+- `position_alerts` table → `/alerts/position-alerts`.
+
+### Rolling P&L (1d / 1w / 1m)
+- Computed from `price_daily` deltas vs anchor (each position's own `latest_close.price_date`, not wall-clock).
+- Endpoint: `/portfolio/rolling-pnl`.
+
+### CGT / estimated tax
+- `tax_disposals` table + `budget_config.cgt_scenario`. Computed via `tax_ledger`.
+- Endpoint: `/budget` (`estimated_tax_gbp` / `_usd`).
+
+### Recommendation history / Exit / HOLD
+- `trade_recommendations` table.
+- Endpoint: `/recommendations`, `/recommendations/{id}`.
+- Settled: append-oriented persistence, no spam HOLDs. Default HOLD unless EXIT fires.
+
+## 8. Pipeline / system metrics (operator-visible)
+
+### Bootstrap state + stage status
+- `bootstrap_state` (singleton, `pending/running/complete/partial_error`).
+- `bootstrap_runs` (per-click); `bootstrap_stages` (per-stage detail; lane ∈ init/etoro/sec; status ∈ pending/running/success/error/skipped).
+- `bootstrap_archive_results` (per-archive audit).
+- Endpoint: `GET /system/bootstrap/status`.
+
+### Backfill / SEC manifest pending count
+- `sec_filing_manifest WHERE ingest_status IN ('pending','failed')`.
+- `data_freshness_index` for cadence-due subjects.
+- Endpoints: `/system/jobs`, `/system/bootstrap/status`.
+
+### ETL freshness per source
+- `data_freshness_index`. State `unknown/current/expected_filing_overdue/never_filed/error`. Cadence map at [data_freshness.py:69-100](../../../app/services/data_freshness.py#L69-L100).
+- No public read endpoint — admin via DB.
+
+### Coverage tier / Coverage % per source
+- `coverage.coverage_tier` (1/2/3) per instrument.
+- `coverage_audit` history; ownership rollup `coverage` block.
+- Endpoints: `/instruments`, `/coverage/summary`, `/coverage/insufficient`, `/instruments/{symbol}/ownership-rollup`.
+- Settled: coverage = telemetry, not a gate.
+
+### Credential health (eToro)
+- `broker_credentials_health_state` (sql/128).
+- Endpoint: `/system/status.credential_health`.
+
+### Job runs success rate
+- `job_runs` history; aggregated by `app/services/ops_monitor.py:check_job_health`.
+- Endpoint: `/system/status`, `/system/jobs`.
+
+### Kill switch state
+- `runtime_config` row keyed by name. Read by `get_kill_switch_status` ([ops_monitor.py](../../../app/services/ops_monitor.py)).
+- Toggle: `POST /system/config/kill-switch` ([app/api/config.py:233](../../../app/api/config.py#L233)).
+- Endpoint: `/system/status.kill_switch`.
+
+## 9. Validation + golden panel
+
+CLAUDE.md ETL clauses 8-12 mandate verification on the canonical 5-instrument panel for any change touching ownership / fundamentals / observations:
+
+- **AAPL** — large-cap, dense 13F filer set, multi-decade history.
+- **GME** — high retail residual, Cohen direct + beneficial split, activist 13D/A history.
+- **MSFT** — broad institutional coverage, dividend issuer, frequent buybacks.
+- **JPM** — financial sector (no gross margin), large insider direct + indirect totals.
+- **HD** — REIT-style cash-flow profile, dilution-stable.
+
+Cross-source for at least one fixture against an independent reputable source (gurufocus, marketbeat, EdgarTools golden file, SEC EDGAR direct). Record the source + figure in the PR description.
+
+After backfill, hit the relevant rollup endpoint and confirm the figure renders correctly on the live chart. PR description records the verification step + commit SHA for each clause.
+
+## 10. Specs to consult
+
+- `docs/superpowers/specs/2026-05-03-ownership-tier0-and-cik-history-design.md`
+- `docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md` (Phase 1 + Phase 3)
+- `docs/superpowers/specs/2026-05-04-etl-coverage-model.md`
+- `docs/superpowers/specs/2026-05-06-def14a-bene-table-extension-design.md` (#843 ESOP)
+- `docs/superpowers/specs/2026-05-07-first-install-bootstrap.md` (#993)
+- `docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md`
+
+`docs/settled-decisions.md` — every numbered decision constraining a metric.
+
+## 11. Cross-link
+
+- `.claude/skills/data-sources/sec-edgar.md` — where the source data comes from.
+- `.claude/skills/data-sources/edgartools.md` — the parsing library.
+- `.claude/skills/ebull/data-engineer.md` — schema invariants + write/read patterns.


### PR DESCRIPTION
## Summary

- Four new skill files so future agents have source-of-truth references for SEC EDGAR data + the eBull data layer, instead of reinventing parsers and identifier resolvers.
- CLAUDE.md required-skills list updated; MEMORY.md gains pointer entries.
- All four skills passed a Codex factual-accuracy review (10 findings applied before push).

## Why

Recurring failure mode caught the operator's eye: implementation kept jumping to bespoke parsers and sweeping rewrites without grounding in source-of-truth knowledge. Concrete examples:

- 13F dataset parsing reinvented date / PRN / VALUE-cutover logic that EdgarTools handles natively.
- N-PORT bespoke parser kept after EdgarTools rejection (#932) without documenting the validation cliff.
- CIK→canonical-name resolution drifted to fuzzy-match instead of the SEC `company_tickers.json` bridge.
- Coverage gates invented out of thin air; reference impls (datamule / edgartools / secedgar) don't gate.
- Bootstrap stages kept failing in operator validation because edge cases (DD-MMM dates, share-class collisions, content-type validation) were discovered late.

Closes #1062.

## What

New skills:

- `.claude/skills/data-sources/sec-edgar.md` — endpoints, formats, identifiers, 18 named gotchas (including DD-MMM-YYYY dates, 13F PRN/SH, VALUE-cutover 2023-01-03, 13D/G XML mandate post-2024-12-19), rate-limit discipline, reference impls.
- `.claude/skills/data-sources/edgartools.md` — coverage matrix per form, API cheat-sheet, Pydantic validation cliff (#932), cache-dir gotchas, decision tree for use-vs-roll-our-own, comparison vs alternatives.
- `.claude/skills/ebull/data-engineer.md` — 12 don't-break invariants, schema layer by domain, two-layer ownership model, write-through pattern, settled-decisions cross-reference, 14-question "where does X come from?" FAQ.
- `.claude/skills/ebull/metrics-analyst.md` — alphabetical master index of every operator-visible metric, per-metric template (definition / formula / source / storage / service / endpoint / chart / cadence / caveats / validation).

Updates:

- `.claude/CLAUDE.md` required-skills list gains a "Data foundation skills" block.
- `MEMORY.md` gains four pointer entries.

## Test plan

- [x] All four skill files render as valid markdown.
- [x] Cross-links between skills and to in-repo paths are valid.
- [x] Codex factual-accuracy review applied (10 findings, all addressed).
- [x] No code changes — docs only. Does not block the in-flight bootstrap run.
- [ ] Reviewer skim: every `path:line` reference resolves; every settled-decision claim cited; no fabricated SEC URLs or APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)