### PR TITLE
feat(#1069): bootstrap cooperative cancel + cancelled state + sql/140

### DIFF
--- a/app/api/bootstrap.py
+++ b/app/api/bootstrap.py
@@ -36,12 +36,15 @@ from app.services.bootstrap_orchestrator import (
 )
 from app.services.bootstrap_state import (
     BootstrapAlreadyRunning,
+    BootstrapNotRunning,
+    cancel_run,
     force_mark_complete,
     read_latest_run_with_stages,
     read_state,
     reset_failed_stages_for_retry,
     start_run,
 )
+from app.services.process_stop import StopAlreadyPendingError
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request
 
 logger = logging.getLogger(__name__)
@@ -59,7 +62,7 @@ router = APIRouter(
 # ---------------------------------------------------------------------------
 
 
-BootstrapApiStatus = Literal["pending", "running", "complete", "partial_error"]
+BootstrapApiStatus = Literal["pending", "running", "complete", "partial_error", "cancelled"]
 LaneApi = Literal["init", "etoro", "sec", "sec_rate", "sec_bulk_download", "db"]
 StageApiStatus = Literal["pending", "running", "success", "error", "skipped", "blocked"]
 
@@ -444,6 +447,86 @@ def retry_failed(
 
 class BootstrapMarkCompleteResponse(BaseModel):
     status: BootstrapApiStatus
+
+
+class BootstrapCancelResponse(BaseModel):
+    """Response for ``POST /system/bootstrap/cancel``.
+
+    Operator-visible payload: which run got the stop signal so the FE
+    can pin the cancel-pending UI to that run id (rather than the
+    eventual ``last_run_id`` from a future re-run).
+    """
+
+    run_id: int
+    status: Literal["cancel_requested"]
+
+
+@router.post(
+    "/cancel",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=BootstrapCancelResponse,
+)
+def cancel_bootstrap(
+    request: Request,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> BootstrapCancelResponse:
+    """Cooperatively cancel the in-flight bootstrap run.
+
+    Spec §Cancel semantics — cooperative + §PR2.
+
+    Atomic flow inside ``cancel_run`` (one tx):
+      1. ``SELECT ... FOR UPDATE`` on ``bootstrap_state`` singleton
+         (TOCTOU-safe per prevention-log).
+      2. Verify status='running' + last_run_id IS NOT NULL — else 409.
+      3. ``SELECT ... FOR UPDATE`` on the active ``bootstrap_runs``
+         row to pin the target id.
+      4. INSERT ``process_stop_requests`` row (target_run_kind=
+         'bootstrap_run', mode='cooperative'). Partial-unique violation
+         (operator double-clicked) raises ``StopAlreadyPendingError``
+         → 409.
+      5. UPDATE ``bootstrap_runs.cancel_requested_at = now()`` for
+         worker fast-path observation.
+
+    The orchestrator's per-batch checkpoint observes the stop row,
+    transitions the run + state to ``cancelled``, and exits cleanly.
+    Worst-case observation latency = duration of the longest
+    in-flight stage (~30 min for 13F sweep, ~30s for CIK refresh).
+
+    Returns 202 with the run id. The FE polls ``/status`` and shows
+    ``cancelling…`` until the worker observes the stop, then
+    ``cancelled``.
+    """
+    requested_by = _identify_requestor(request)
+    try:
+        run_id = cancel_run(conn, requested_by_operator_id=None)
+    except BootstrapNotRunning as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "no_active_run",
+                "message": str(exc),
+            },
+        ) from exc
+    except StopAlreadyPendingError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "stop_already_pending",
+                "message": str(exc),
+            },
+        ) from exc
+
+    logger.warning(
+        "bootstrap: cancel requested run_id=%d requested_by=%s",
+        run_id,
+        requested_by,
+    )
+    return BootstrapCancelResponse(run_id=run_id, status="cancel_requested")
+
+
+# ---------------------------------------------------------------------------
+# POST /mark-complete
+# ---------------------------------------------------------------------------
 
 
 @router.post("/mark-complete", response_model=BootstrapMarkCompleteResponse)

--- a/app/api/bootstrap.py
+++ b/app/api/bootstrap.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from typing import Literal
+from uuid import UUID
 
 import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -145,6 +146,31 @@ def _identify_requestor(request: Request) -> str:
     if op:
         return f"operator:{op}"
     return "operator:anonymous"
+
+
+def _operator_uuid(request: Request) -> UUID | None:
+    """Extract the request's authenticated operator UUID, if any.
+
+    Returns ``None`` when middleware has not populated
+    ``request.state.operator_id`` (service-token paths or unauth'd
+    callers — the audit field is nullable, so a NULL row is the
+    correct shape, not a 500).
+
+    Codex pre-push round 1 WARNING W5: cancel_run takes
+    ``requested_by_operator_id``; the API previously hard-coded None.
+    Wire it through honestly so the FK populates the moment the
+    middleware lands the operator id on request state.
+    """
+    op = getattr(request.state, "operator_id", None)
+    if op is None:
+        return None
+    if isinstance(op, UUID):
+        return op
+    try:
+        return UUID(str(op))
+    except ValueError, TypeError:
+        logger.warning("bootstrap: request.state.operator_id %r is not a UUID; auditing as NULL", op)
+        return None
 
 
 def _build_status_response(conn: psycopg.Connection[object]) -> BootstrapStatusResponse:
@@ -474,21 +500,26 @@ def cancel_bootstrap(
 
     Spec §Cancel semantics — cooperative + §PR2.
 
-    Atomic flow inside ``cancel_run`` (one tx):
-      1. ``SELECT ... FOR UPDATE`` on ``bootstrap_state`` singleton
-         (TOCTOU-safe per prevention-log).
-      2. Verify status='running' + last_run_id IS NOT NULL — else 409.
-      3. ``SELECT ... FOR UPDATE`` on the active ``bootstrap_runs``
-         row to pin the target id.
-      4. INSERT ``process_stop_requests`` row (target_run_kind=
+    Atomic flow inside ``cancel_run`` (one tx, runs-row-only locking
+    to avoid lock-order inversion against ``finalize_run`` — Codex
+    pre-push round 1 BLOCKING B1):
+      1. ``SELECT id FROM bootstrap_runs WHERE status='running'
+         FOR UPDATE`` — pins the active run via the partial-unique
+         index ``bootstrap_runs_one_running_idx``. No row → 409
+         ``no_active_run``.
+      2. INSERT ``process_stop_requests`` row (target_run_kind=
          'bootstrap_run', mode='cooperative'). Partial-unique violation
          (operator double-clicked) raises ``StopAlreadyPendingError``
-         → 409.
-      5. UPDATE ``bootstrap_runs.cancel_requested_at = now()`` for
+         → 409 ``stop_already_pending``.
+      3. UPDATE ``bootstrap_runs.cancel_requested_at = now()`` for
          worker fast-path observation.
 
     The orchestrator's per-batch checkpoint observes the stop row,
     transitions the run + state to ``cancelled``, and exits cleanly.
+    If the dispatcher loop already exited before the cancel arrived,
+    ``finalize_run`` reads ``cancel_requested_at`` under the same row
+    lock and routes the terminal state to ``cancelled`` instead of
+    ``complete`` (Codex pre-push round 1 BLOCKING B2).
     Worst-case observation latency = duration of the longest
     in-flight stage (~30 min for 13F sweep, ~30s for CIK refresh).
 
@@ -497,8 +528,9 @@ def cancel_bootstrap(
     ``cancelled``.
     """
     requested_by = _identify_requestor(request)
+    operator_uuid = _operator_uuid(request)
     try:
-        run_id = cancel_run(conn, requested_by_operator_id=None)
+        run_id = cancel_run(conn, requested_by_operator_id=operator_uuid)
     except BootstrapNotRunning as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -48,6 +48,7 @@ from app.services.bootstrap_preconditions import BootstrapPhaseSkipped
 from app.services.bootstrap_state import (
     StageSpec,
     finalize_run,
+    mark_run_cancelled,
     mark_stage_blocked,
     mark_stage_error,
     mark_stage_running,
@@ -55,6 +56,9 @@ from app.services.bootstrap_state import (
     mark_stage_success,
     read_latest_run_with_stages,
 )
+from app.services.process_stop import is_stop_requested
+from app.services.process_stop import mark_completed as mark_stop_completed
+from app.services.process_stop import mark_observed as mark_stop_observed
 
 logger = logging.getLogger(__name__)
 
@@ -416,27 +420,45 @@ def _phase_batched_dispatch(
     runnable: list[_RunnableStage],
     database_url: str,
     preexisting_statuses: dict[str, str] | None = None,
-) -> dict[str, str]:
+) -> tuple[dict[str, str], bool]:
     """Dispatch ``runnable`` stages in phase-batched fashion with lane concurrency.
 
-    Returns ``{stage_key: terminal_status}`` (success / error / blocked /
-    skipped) for every input stage.
+    Returns a tuple ``(statuses, cancelled)``:
+
+    * ``statuses`` — ``{stage_key: terminal_status}`` (success / error /
+      blocked / skipped) for every input stage.
+    * ``cancelled`` — True if the dispatcher exited early due to an
+      observed cooperative-cancel signal at a checkpoint. The caller
+      uses this to skip ``finalize_run`` (the run is already in the
+      terminal ``cancelled`` state).
 
     Algorithm:
 
       1. Build per-stage status map (initially ``pending``).
-      2. While any stage is pending: collect every pending stage whose
+      2. **Cancel checkpoint** — at the top of each iteration check
+         ``is_stop_requested`` against ``(target_run_kind='bootstrap_run',
+         target_run_id=run_id)``. On observed cancel: mark stop
+         request observed, call ``mark_run_cancelled`` (terminalises
+         run + state + sweeps remaining stages), mark stop request
+         completed, and return early. This is the operator-cancel
+         observation point per spec §Cancel semantics — cooperative.
+      3. While any stage is pending: collect every pending stage whose
          ``requires`` are all ``success`` → "ready batch". Stages
          whose any required dep is ``error``/``blocked`` →
          immediately propagate to ``blocked`` (no invocation).
-      3. Group the ready batch by lane. For each lane, run up to
+      4. Group the ready batch by lane. For each lane, run up to
          ``_LANE_MAX_CONCURRENCY[lane]`` stages concurrently via a
          per-lane ``ThreadPoolExecutor``.
-      4. Join all lane workers; refresh status from the DB; loop.
-      5. Stop when no stage is pending.
+      5. Join all lane workers; refresh status from the DB; loop.
+      6. Stop when no stage is pending.
 
     Stages with no `requires` start in the first batch. The dispatcher
     is fully data-driven by ``_STAGE_REQUIRES`` + ``_STAGE_LANE_OVERRIDES``.
+
+    Cancel observation latency: at most the duration of the longest
+    in-flight batch (a 13F sweep is ~30 min; CIK refresh ~30s).
+    Mid-stage work runs to completion — the watermark advances on
+    commit and the next Iterate resumes from there.
     """
     from concurrent.futures import ThreadPoolExecutor, wait
 
@@ -450,6 +472,38 @@ def _phase_batched_dispatch(
                 statuses[key] = status
 
     while True:
+        # Cancel checkpoint — covers (W1) "before submitting Phase A's
+        # first batch", "between any two ready batches", "before
+        # kicking off Phase B lanes", and "between stages within a
+        # lane" (the loop body re-enters here after every wait()).
+        # Each check uses its own short tx so a cancel arriving while
+        # we're between iterations is observed before the next batch
+        # spawns.
+        with psycopg.connect(database_url) as cancel_conn:
+            stop = is_stop_requested(
+                cancel_conn,
+                target_run_kind="bootstrap_run",
+                target_run_id=run_id,
+            )
+            if stop is not None:
+                logger.info(
+                    "bootstrap dispatcher: cancel observed at checkpoint (run_id=%d, stop_id=%d, mode=%s)",
+                    run_id,
+                    stop.id,
+                    stop.mode,
+                )
+                mark_stop_observed(cancel_conn, stop.id)
+                cancel_conn.commit()
+                mark_run_cancelled(
+                    cancel_conn,
+                    run_id=run_id,
+                    notes_line="cancelled by operator at dispatcher checkpoint",
+                )
+                cancel_conn.commit()
+                mark_stop_completed(cancel_conn, stop.id)
+                cancel_conn.commit()
+                return statuses, True
+
         pending_keys = [k for k, s in statuses.items() if s == "pending"]
         if not pending_keys:
             break
@@ -576,7 +630,7 @@ def _phase_batched_dispatch(
                 statuses[stage_key] = "error"
                 logger.warning("bootstrap dispatcher: %s ERROR (%s)", stage_key, outcome.error)
 
-    return statuses
+    return statuses, False
 
 
 def run_bootstrap_orchestrator() -> None:
@@ -658,12 +712,19 @@ def run_bootstrap_orchestrator() -> None:
         {lane: sum(1 for r in runnable if r.lane == lane) for lane in _LANE_MAX_CONCURRENCY},
     )
 
-    _phase_batched_dispatch(
+    _statuses, cancelled = _phase_batched_dispatch(
         run_id=run_id,
         runnable=runnable,
         database_url=database_url,
         preexisting_statuses=preexisting_statuses,
     )
+
+    if cancelled:
+        # The cancel checkpoint already terminalised the run via
+        # mark_run_cancelled; finalize_run would no-op against the
+        # status='running' guard, but skipping it is clearer.
+        logger.info("bootstrap dispatcher: run_id=%d cancelled by operator", run_id)
+        return
 
     with psycopg.connect(database_url) as conn:
         terminal = finalize_run(conn, run_id=run_id)

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -476,9 +476,14 @@ def _phase_batched_dispatch(
         # first batch", "between any two ready batches", "before
         # kicking off Phase B lanes", and "between stages within a
         # lane" (the loop body re-enters here after every wait()).
-        # Each check uses its own short tx so a cancel arriving while
-        # we're between iterations is observed before the next batch
-        # spawns.
+        #
+        # Single-tx atomicity (Codex pre-push round 1 WARNING W4):
+        # observation, cancellation, and stop-completion all commit
+        # together. A worker crash between two of three separate
+        # commits would otherwise leave the stop row observed-but-
+        # unfinished with the run still ``running``. Boot-recovery
+        # would still clean up after the next jobs restart, but
+        # collapsing into one tx makes the happy path clean.
         with psycopg.connect(database_url) as cancel_conn:
             stop = is_stop_requested(
                 cancel_conn,
@@ -492,16 +497,14 @@ def _phase_batched_dispatch(
                     stop.id,
                     stop.mode,
                 )
-                mark_stop_observed(cancel_conn, stop.id)
-                cancel_conn.commit()
-                mark_run_cancelled(
-                    cancel_conn,
-                    run_id=run_id,
-                    notes_line="cancelled by operator at dispatcher checkpoint",
-                )
-                cancel_conn.commit()
-                mark_stop_completed(cancel_conn, stop.id)
-                cancel_conn.commit()
+                with cancel_conn.transaction():
+                    mark_stop_observed(cancel_conn, stop.id)
+                    mark_run_cancelled(
+                        cancel_conn,
+                        run_id=run_id,
+                        notes_line="cancelled by operator at dispatcher checkpoint",
+                    )
+                    mark_stop_completed(cancel_conn, stop.id)
                 return statuses, True
 
         pending_keys = [k for k, s in statuses.items() if s == "pending"]

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -30,14 +30,20 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal
+from uuid import UUID
 
 import psycopg
+
+from app.services.process_stop import (
+    StopAlreadyPendingError,
+    request_stop,
+)
 
 logger = logging.getLogger(__name__)
 
 
-BootstrapStatus = Literal["pending", "running", "complete", "partial_error"]
-RunStatus = Literal["running", "complete", "partial_error"]
+BootstrapStatus = Literal["pending", "running", "complete", "partial_error", "cancelled"]
+RunStatus = Literal["running", "complete", "partial_error", "cancelled"]
 StageStatus = Literal["pending", "running", "success", "error", "skipped", "blocked"]
 Lane = Literal["init", "etoro", "sec", "sec_rate", "sec_bulk_download", "db"]
 
@@ -53,6 +59,13 @@ class BootstrapAlreadyRunning(RuntimeError):
     def __init__(self, run_id: int) -> None:
         super().__init__(f"bootstrap run {run_id} is already running")
         self.run_id = run_id
+
+
+class BootstrapNotRunning(RuntimeError):
+    """Raised by ``cancel_run`` when no bootstrap run is currently in flight.
+
+    The API layer maps this to 409 Conflict — there is nothing to cancel.
+    """
 
 
 @dataclass(frozen=True)
@@ -423,7 +436,12 @@ def finalize_run(
     Updates the run row, the bootstrap_state singleton, and
     ``last_completed_at`` in one transaction.
 
-    Returns the chosen terminal status.
+    Cooperative-cancel guard: if the run row is already in a terminal
+    state (e.g. ``cancelled``, written by the orchestrator's cancel
+    checkpoint via ``mark_run_cancelled``), the UPDATEs no-op via the
+    ``status='running'`` predicate and the existing terminal state is
+    preserved. We then return whatever the run row's current status is
+    so callers see the truth.
     """
     with conn.transaction():
         # Count both `error` and `blocked` — both are unsuccessful
@@ -438,16 +456,17 @@ def finalize_run(
             {"run_id": run_id},
         ).fetchone()
         error_count = error_count_row[0] if error_count_row is not None else 0
-        terminal: RunStatus = "partial_error" if error_count > 0 else "complete"
+        candidate: RunStatus = "partial_error" if error_count > 0 else "complete"
 
         conn.execute(
             """
             UPDATE bootstrap_runs
                SET status       = %(status)s,
                    completed_at = now()
-             WHERE id = %(run_id)s
+             WHERE id     = %(run_id)s
+               AND status = 'running'
             """,
-            {"status": terminal, "run_id": run_id},
+            {"status": candidate, "run_id": run_id},
         )
         conn.execute(
             """
@@ -455,10 +474,23 @@ def finalize_run(
                SET status            = %(status)s,
                    last_run_id       = %(run_id)s,
                    last_completed_at = now()
-             WHERE id = 1
+             WHERE id     = 1
+               AND status = 'running'
             """,
-            {"status": terminal, "run_id": run_id},
+            {"status": candidate, "run_id": run_id},
         )
+
+        # Re-read the post-UPDATE truth. If the orchestrator's cancel
+        # checkpoint already terminalised the run as ``cancelled``, the
+        # status='running' guards above no-op'd and we return the
+        # actual terminal state, not the candidate we computed.
+        terminal_row = conn.execute(
+            "SELECT status FROM bootstrap_runs WHERE id = %(run_id)s",
+            {"run_id": run_id},
+        ).fetchone()
+        if terminal_row is None:
+            raise RuntimeError(f"finalize_run: bootstrap_runs row {run_id} disappeared")
+        terminal: RunStatus = terminal_row[0]
 
     return terminal
 
@@ -590,6 +622,174 @@ def force_mark_complete(
         )
 
 
+def cancel_run(
+    conn: psycopg.Connection[Any],
+    *,
+    requested_by_operator_id: UUID | None,
+) -> int:
+    """Cooperatively cancel the in-flight bootstrap run.
+
+    Spec §Cancel semantics — cooperative + §PR2.
+
+    One-transaction flow that mirrors ``start_run``'s singleton-locking
+    contract (prevention-log: "TOCTOU on singleton state — read-then-
+    mutate without `FOR UPDATE`"):
+
+    1. ``SELECT ... FOR UPDATE`` on ``bootstrap_state`` — pins the
+       singleton; concurrent ``start_run`` / ``mark_complete`` cannot
+       race past us.
+    2. Verify ``status='running'`` and ``last_run_id IS NOT NULL``;
+       raise ``BootstrapNotRunning`` otherwise (API → 409).
+    3. ``SELECT ... FOR UPDATE`` on the active ``bootstrap_runs`` row
+       (also ``status='running'``) — pins the run id we're targeting,
+       so the worker cannot finish + start a new run between our read
+       and insert.
+    4. ``request_stop`` writes the ``process_stop_requests`` row with
+       ``target_run_kind='bootstrap_run'`` and the locked run id.
+       Internally wraps the INSERT in a SAVEPOINT so a
+       ``UniqueViolation`` (active stop already pending) rolls back
+       cleanly without poisoning the outer transaction.
+    5. UPDATE ``bootstrap_runs.cancel_requested_at = now()`` for the
+       worker's fast-path observation.
+
+    Returns the cancelled run id.
+
+    Raises:
+        BootstrapNotRunning: nothing to cancel.
+        StopAlreadyPendingError: an active stop is already pending
+            for this run (operator double-clicked).
+    """
+    with conn.transaction():
+        state_row = conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1 FOR UPDATE").fetchone()
+        if state_row is None:
+            raise RuntimeError("bootstrap_state singleton row missing")
+        current_status, last_run_id = state_row
+        if current_status != "running" or last_run_id is None:
+            raise BootstrapNotRunning(
+                f"bootstrap is not running (status={current_status!r}, last_run_id={last_run_id!r})"
+            )
+
+        run_row = conn.execute(
+            """
+            SELECT id FROM bootstrap_runs
+             WHERE id = %(run_id)s AND status = 'running'
+             FOR UPDATE
+            """,
+            {"run_id": last_run_id},
+        ).fetchone()
+        if run_row is None:
+            # State says running but the run row already terminated —
+            # singleton is out of sync. Treat as not-running per the
+            # prevention-log "Post-step DB re-read must fail closed"
+            # rule: a race-window read that disagrees with the gate is
+            # the failure case, not the optimistic one.
+            raise BootstrapNotRunning(
+                f"bootstrap_state.status='running' but bootstrap_runs row {last_run_id} is not running"
+            )
+        run_id: int = run_row[0]
+
+        # Insert the stop signal. ``request_stop`` raises
+        # StopAlreadyPendingError on partial-unique violation; the
+        # exception escapes the inner SAVEPOINT cleanly so the outer
+        # tx stays usable.
+        request_stop(
+            conn,
+            process_id="bootstrap",
+            mechanism="bootstrap",
+            target_run_kind="bootstrap_run",
+            target_run_id=run_id,
+            mode="cooperative",
+            requested_by_operator_id=requested_by_operator_id,
+        )
+
+        update_cur = conn.execute(
+            """
+            UPDATE bootstrap_runs
+               SET cancel_requested_at = now()
+             WHERE id = %(run_id)s
+            """,
+            {"run_id": run_id},
+        )
+        # Single-row UPDATE: if rowcount is 0 the run row vanished
+        # between our FOR UPDATE and now (impossible — we hold the
+        # lock — but guard against silent no-ops per prevention-log
+        # "UPDATE-by-PK helpers must assert rowcount").
+        if update_cur.rowcount != 1:
+            raise RuntimeError(
+                f"cancel_run: expected 1 bootstrap_runs row for run_id={run_id}, got rowcount={update_cur.rowcount}"
+            )
+
+    return run_id
+
+
+def mark_run_cancelled(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    notes_line: str = "cancelled by operator",
+) -> None:
+    """Transition the bootstrap run to the terminal ``cancelled`` state.
+
+    Called from the orchestrator after observing the stop signal at a
+    cancel checkpoint, AND from boot recovery on a jobs restart.
+
+    Idempotent: if the run row is already ``cancelled``, the UPDATEs
+    no-op (status guard in WHERE clause).
+
+    Sweeps stages still in ``running`` or ``pending`` to ``error`` —
+    the run is cancelled, the in-flight stage didn't finish cleanly.
+    Subsequent Iterate / Re-run uses the existing
+    ``reset_failed_stages_for_retry`` path (treats ``error`` as
+    retryable).
+    """
+    with conn.transaction():
+        conn.execute(
+            """
+            UPDATE bootstrap_stages
+               SET status       = 'error',
+                   completed_at = now(),
+                   last_error   = COALESCE(last_error, %(reason)s)
+             WHERE bootstrap_run_id = %(run_id)s
+               AND status           = 'running'
+            """,
+            {"run_id": run_id, "reason": notes_line},
+        )
+        conn.execute(
+            """
+            UPDATE bootstrap_stages
+               SET status       = 'error',
+                   completed_at = now(),
+                   last_error   = %(reason)s
+             WHERE bootstrap_run_id = %(run_id)s
+               AND status           = 'pending'
+            """,
+            {"run_id": run_id, "reason": notes_line},
+        )
+        conn.execute(
+            """
+            UPDATE bootstrap_runs
+               SET status       = 'cancelled',
+                   completed_at = now(),
+                   notes        = TRIM(BOTH E'\n' FROM
+                                       COALESCE(notes, '') || E'\n' || %(reason)s)
+             WHERE id     = %(run_id)s
+               AND status = 'running'
+            """,
+            {"run_id": run_id, "reason": notes_line},
+        )
+        conn.execute(
+            """
+            UPDATE bootstrap_state
+               SET status            = 'cancelled',
+                   last_completed_at = now()
+             WHERE id          = 1
+               AND last_run_id = %(run_id)s
+               AND status      = 'running'
+            """,
+            {"run_id": run_id},
+        )
+
+
 def reap_orphaned_running(
     conn: psycopg.Connection[Any],
 ) -> bool:
@@ -603,8 +803,13 @@ def reap_orphaned_running(
         last_error='jobs process restarted mid-run'.
       - Latest run's stages with ``status='pending'`` → ``error``,
         last_error='orchestrator did not dispatch before restart'.
-      - Latest ``bootstrap_runs`` row → ``partial_error``.
-      - ``bootstrap_state`` → ``partial_error``.
+      - Latest ``bootstrap_runs`` row →
+          * ``cancelled`` if ``cancel_requested_at IS NOT NULL`` (an
+            operator cancel that the worker never observed before
+            jobs restarted — Codex round 2 R2-B3 + spec §sql/136
+            "boot recovery handles cancelled");
+          * ``partial_error`` otherwise.
+      - ``bootstrap_state`` → matching terminal status.
 
     All in one transaction. Idempotent on a state that is not
     ``running``; returns True if a sweep occurred, False otherwise.
@@ -617,6 +822,17 @@ def reap_orphaned_running(
         if last_run_id is None:
             conn.execute("UPDATE bootstrap_state SET status = 'partial_error' WHERE id = 1")
             return True
+
+        # Distinguish operator-cancel-then-restart from generic crash.
+        run_meta = conn.execute(
+            """
+            SELECT cancel_requested_at IS NOT NULL
+              FROM bootstrap_runs
+             WHERE id = %(run_id)s
+            """,
+            {"run_id": last_run_id},
+        ).fetchone()
+        cancel_requested = bool(run_meta[0]) if run_meta is not None else False
 
         conn.execute(
             """
@@ -640,29 +856,56 @@ def reap_orphaned_running(
             """,
             {"run_id": last_run_id},
         )
-        conn.execute(
-            """
-            UPDATE bootstrap_runs
-               SET status       = 'partial_error',
-                   completed_at = now()
-             WHERE id = %(run_id)s
-            """,
-            {"run_id": last_run_id},
-        )
-        conn.execute(
-            """
-            UPDATE bootstrap_state
-               SET status            = 'partial_error',
-                   last_completed_at = now()
-             WHERE id = 1
-            """
-        )
+
+        if cancel_requested:
+            # Operator clicked Cancel; jobs restarted before the
+            # worker observed. Honour the cancel intent rather than
+            # masking it as partial_error.
+            conn.execute(
+                """
+                UPDATE bootstrap_runs
+                   SET status       = 'cancelled',
+                       completed_at = now(),
+                       notes        = TRIM(BOTH E'\n' FROM
+                                           COALESCE(notes, '') || E'\n' ||
+                                           'terminated by operator before jobs restart')
+                 WHERE id = %(run_id)s
+                """,
+                {"run_id": last_run_id},
+            )
+            conn.execute(
+                """
+                UPDATE bootstrap_state
+                   SET status            = 'cancelled',
+                       last_completed_at = now()
+                 WHERE id = 1
+                """
+            )
+        else:
+            conn.execute(
+                """
+                UPDATE bootstrap_runs
+                   SET status       = 'partial_error',
+                       completed_at = now()
+                 WHERE id = %(run_id)s
+                """,
+                {"run_id": last_run_id},
+            )
+            conn.execute(
+                """
+                UPDATE bootstrap_state
+                   SET status            = 'partial_error',
+                       last_completed_at = now()
+                 WHERE id = 1
+                """
+            )
 
     return True
 
 
 __all__ = [
     "BootstrapAlreadyRunning",
+    "BootstrapNotRunning",
     "BootstrapState",
     "BootstrapStatus",
     "Lane",
@@ -671,8 +914,11 @@ __all__ = [
     "StageRow",
     "StageSpec",
     "StageStatus",
+    "StopAlreadyPendingError",
+    "cancel_run",
     "finalize_run",
     "force_mark_complete",
+    "mark_run_cancelled",
     "mark_stage_blocked",
     "mark_stage_error",
     "mark_stage_running",

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -311,7 +311,15 @@ def mark_stage_success(
     stage_key: str,
     rows_processed: int | None = None,
 ) -> None:
-    """Transition a stage to success on invoker exit."""
+    """Transition a stage to success on invoker exit.
+
+    ``status='running'`` predicate (Codex pre-push round 1 WARNING
+    W3): defense in depth against a late stage update racing with
+    ``mark_run_cancelled`` having already swept the stage to
+    ``error``. The dispatcher's wait()/checkpoint ordering already
+    avoids the race in the normal flow, but pinning the helper to
+    "only advance from running" keeps the invariant local.
+    """
     conn.execute(
         """
         UPDATE bootstrap_stages
@@ -321,6 +329,7 @@ def mark_stage_success(
                last_error     = NULL
          WHERE bootstrap_run_id = %(run_id)s
            AND stage_key        = %(stage_key)s
+           AND status           = 'running'
         """,
         {
             "run_id": run_id,
@@ -342,6 +351,11 @@ def mark_stage_error(
     ``error_message`` is truncated to 1000 chars to keep DB rows
     bounded; full forensic detail lives in the underlying
     ``job_runs`` row that the invoker's own ``_tracked_job`` writes.
+
+    ``status='running'`` predicate (Codex pre-push round 1 W3):
+    avoids overwriting a cancellation sweep with a late error
+    transition (defense in depth — dispatcher wait() ordering
+    already prevents the race in the normal flow).
     """
     conn.execute(
         """
@@ -351,6 +365,7 @@ def mark_stage_error(
                last_error   = %(error_message)s
          WHERE bootstrap_run_id = %(run_id)s
            AND stage_key        = %(stage_key)s
+           AND status           = 'running'
         """,
         {
             "run_id": run_id,
@@ -375,6 +390,12 @@ def mark_stage_skipped(
     is bypassed in favour of the legacy chain. ``finalize_run`` does
     NOT count ``skipped`` as a failure, so the run still reaches
     ``complete`` when only skips remain.
+
+    ``status IN ('running', 'pending')`` predicate (Codex pre-push
+    round 1 W3): allow the existing two callsites — the bypass path
+    skips a still-pending stage; the lane runner skips a stage it
+    just transitioned to running. Refuses to overwrite terminal
+    states (success / error / cancelled-via-sweep).
     """
     conn.execute(
         """
@@ -384,6 +405,7 @@ def mark_stage_skipped(
                last_error   = %(reason)s
          WHERE bootstrap_run_id = %(run_id)s
            AND stage_key        = %(stage_key)s
+           AND status           IN ('running', 'pending')
         """,
         {
             "run_id": run_id,
@@ -436,14 +458,57 @@ def finalize_run(
     Updates the run row, the bootstrap_state singleton, and
     ``last_completed_at`` in one transaction.
 
-    Cooperative-cancel guard: if the run row is already in a terminal
-    state (e.g. ``cancelled``, written by the orchestrator's cancel
-    checkpoint via ``mark_run_cancelled``), the UPDATEs no-op via the
-    ``status='running'`` predicate and the existing terminal state is
-    preserved. We then return whatever the run row's current status is
-    so callers see the truth.
+    Cooperative-cancel handling (Codex pre-push round 1 BLOCKING B2 —
+    closes the "no checkpoint between dispatcher loop-exit and
+    finalize_run" race): we lock the run row ``FOR UPDATE`` at the
+    start of the tx and then check ``cancel_requested_at``. If set,
+    the operator clicked Cancel any time before this commit — even
+    after the dispatcher's last checkpoint observed nothing — and we
+    terminalise as ``cancelled`` here, sweeping any remaining running/
+    pending stages to ``error`` so a follow-up Iterate retries them.
+
+    Lock-order discipline: this function locks ``bootstrap_runs``
+    BEFORE writing to ``bootstrap_state`` — the same order
+    ``cancel_run`` uses — so the two paths cannot deadlock.
+
+    The ``status='running'`` guard on the UPDATEs preserves any prior
+    terminal state set by ``mark_run_cancelled`` from a dispatcher
+    checkpoint that landed slightly earlier.
     """
     with conn.transaction():
+        # Lock the run row first. cancel_run also locks runs first;
+        # finalize_run holding state-then-runs would deadlock against
+        # a concurrent cancel.
+        run_meta = conn.execute(
+            """
+            SELECT status, cancel_requested_at IS NOT NULL
+              FROM bootstrap_runs
+             WHERE id = %(run_id)s
+             FOR UPDATE
+            """,
+            {"run_id": run_id},
+        ).fetchone()
+        if run_meta is None:
+            raise RuntimeError(f"finalize_run: bootstrap_runs row {run_id} disappeared")
+        current_status, cancel_pending = run_meta
+
+        # Already terminal (e.g. mark_run_cancelled fired from a
+        # dispatcher checkpoint). Return what the row says.
+        if current_status != "running":
+            return current_status
+
+        # Cancel was requested but never observed by a checkpoint —
+        # honour it here. Sweep stages so retry-failed has work to
+        # reset. mark_run_cancelled idempotently transitions the run
+        # + state under our held row lock.
+        if cancel_pending:
+            mark_run_cancelled(
+                conn,
+                run_id=run_id,
+                notes_line="cancelled by operator before finalize",
+            )
+            return "cancelled"
+
         # Count both `error` and `blocked` — both are unsuccessful
         # outcomes. `blocked` = upstream failure propagation; the
         # operator must still see the run as `partial_error`.
@@ -456,7 +521,7 @@ def finalize_run(
             {"run_id": run_id},
         ).fetchone()
         error_count = error_count_row[0] if error_count_row is not None else 0
-        candidate: RunStatus = "partial_error" if error_count > 0 else "complete"
+        terminal: RunStatus = "partial_error" if error_count > 0 else "complete"
 
         conn.execute(
             """
@@ -466,7 +531,7 @@ def finalize_run(
              WHERE id     = %(run_id)s
                AND status = 'running'
             """,
-            {"status": candidate, "run_id": run_id},
+            {"status": terminal, "run_id": run_id},
         )
         conn.execute(
             """
@@ -477,20 +542,8 @@ def finalize_run(
              WHERE id     = 1
                AND status = 'running'
             """,
-            {"status": candidate, "run_id": run_id},
+            {"status": terminal, "run_id": run_id},
         )
-
-        # Re-read the post-UPDATE truth. If the orchestrator's cancel
-        # checkpoint already terminalised the run as ``cancelled``, the
-        # status='running' guards above no-op'd and we return the
-        # actual terminal state, not the candidate we computed.
-        terminal_row = conn.execute(
-            "SELECT status FROM bootstrap_runs WHERE id = %(run_id)s",
-            {"run_id": run_id},
-        ).fetchone()
-        if terminal_row is None:
-            raise RuntimeError(f"finalize_run: bootstrap_runs row {run_id} disappeared")
-        terminal: RunStatus = terminal_row[0]
 
     return terminal
 
@@ -631,25 +684,30 @@ def cancel_run(
 
     Spec §Cancel semantics — cooperative + §PR2.
 
-    One-transaction flow that mirrors ``start_run``'s singleton-locking
-    contract (prevention-log: "TOCTOU on singleton state — read-then-
-    mutate without `FOR UPDATE`"):
+    One-transaction flow. Lock-order discipline (Codex pre-push round
+    1 BLOCKING B1): we acquire the bootstrap_runs row lock FIRST and
+    do NOT touch the bootstrap_state singleton lock — same order the
+    finalize_run UPDATEs use (runs first, then state). Locking state
+    first here would deadlock against a finalize_run racing in
+    parallel.
 
-    1. ``SELECT ... FOR UPDATE`` on ``bootstrap_state`` — pins the
-       singleton; concurrent ``start_run`` / ``mark_complete`` cannot
-       race past us.
-    2. Verify ``status='running'`` and ``last_run_id IS NOT NULL``;
-       raise ``BootstrapNotRunning`` otherwise (API → 409).
-    3. ``SELECT ... FOR UPDATE`` on the active ``bootstrap_runs`` row
-       (also ``status='running'``) — pins the run id we're targeting,
-       so the worker cannot finish + start a new run between our read
-       and insert.
-    4. ``request_stop`` writes the ``process_stop_requests`` row with
+    Identifying the active run without the singleton: the partial
+    unique index ``bootstrap_runs_one_running_idx`` guarantees at most
+    one row with ``status='running'``. We resolve via that predicate
+    rather than dereferencing ``bootstrap_state.last_run_id`` so the
+    cancel path never depends on the singleton being in sync.
+
+    Steps:
+
+    1. ``SELECT id FROM bootstrap_runs WHERE status='running'
+       FOR UPDATE`` — pins the active run; the partial-unique index
+       guarantees ≤1 row. No row → BootstrapNotRunning (API → 409).
+    2. ``request_stop`` writes the ``process_stop_requests`` row with
        ``target_run_kind='bootstrap_run'`` and the locked run id.
        Internally wraps the INSERT in a SAVEPOINT so a
        ``UniqueViolation`` (active stop already pending) rolls back
        cleanly without poisoning the outer transaction.
-    5. UPDATE ``bootstrap_runs.cancel_requested_at = now()`` for the
+    3. UPDATE ``bootstrap_runs.cancel_requested_at = now()`` for the
        worker's fast-path observation.
 
     Returns the cancelled run id.
@@ -660,32 +718,15 @@ def cancel_run(
             for this run (operator double-clicked).
     """
     with conn.transaction():
-        state_row = conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1 FOR UPDATE").fetchone()
-        if state_row is None:
-            raise RuntimeError("bootstrap_state singleton row missing")
-        current_status, last_run_id = state_row
-        if current_status != "running" or last_run_id is None:
-            raise BootstrapNotRunning(
-                f"bootstrap is not running (status={current_status!r}, last_run_id={last_run_id!r})"
-            )
-
         run_row = conn.execute(
             """
             SELECT id FROM bootstrap_runs
-             WHERE id = %(run_id)s AND status = 'running'
+             WHERE status = 'running'
              FOR UPDATE
             """,
-            {"run_id": last_run_id},
         ).fetchone()
         if run_row is None:
-            # State says running but the run row already terminated —
-            # singleton is out of sync. Treat as not-running per the
-            # prevention-log "Post-step DB re-read must fail closed"
-            # rule: a race-window read that disagrees with the gate is
-            # the failure case, not the optimistic one.
-            raise BootstrapNotRunning(
-                f"bootstrap_state.status='running' but bootstrap_runs row {last_run_id} is not running"
-            )
+            raise BootstrapNotRunning("no running bootstrap_runs row to cancel")
         run_id: int = run_row[0]
 
         # Insert the stop signal. ``request_stop`` raises
@@ -731,18 +772,43 @@ def mark_run_cancelled(
     """Transition the bootstrap run to the terminal ``cancelled`` state.
 
     Called from the orchestrator after observing the stop signal at a
-    cancel checkpoint, AND from boot recovery on a jobs restart.
+    cancel checkpoint, AND from boot recovery on a jobs restart, AND
+    from finalize_run when cancel_requested_at is non-null.
 
-    Idempotent: if the run row is already ``cancelled``, the UPDATEs
-    no-op (status guard in WHERE clause).
+    Pre-state contract (Codex pre-push round 1 WARNING W2 —
+    UPDATE-by-PK rowcount): we read the current status under
+    ``FOR UPDATE`` first.
 
-    Sweeps stages still in ``running`` or ``pending`` to ``error`` —
-    the run is cancelled, the in-flight stage didn't finish cleanly.
-    Subsequent Iterate / Re-run uses the existing
-    ``reset_failed_stages_for_retry`` path (treats ``error`` as
-    retryable).
+    * ``running``           → transition to ``cancelled`` (the work).
+    * ``cancelled``         → no-op (true idempotency for the
+                              dispatcher → finalize_run double-call).
+    * ``complete`` /
+      ``partial_error``     → raise; cancelling a finalised run is a
+                              programming error, not a benign no-op,
+                              and silently masking it would let the
+                              singleton state drift from the run row.
+    * row missing           → raise.
     """
     with conn.transaction():
+        run_meta = conn.execute(
+            """
+            SELECT status FROM bootstrap_runs
+             WHERE id = %(run_id)s
+             FOR UPDATE
+            """,
+            {"run_id": run_id},
+        ).fetchone()
+        if run_meta is None:
+            raise RuntimeError(f"mark_run_cancelled: bootstrap_runs row {run_id} not found")
+        current_status = run_meta[0]
+        if current_status == "cancelled":
+            return
+        if current_status != "running":
+            raise RuntimeError(
+                f"mark_run_cancelled: bootstrap_runs row {run_id} is in terminal "
+                f"state {current_status!r}; cannot cancel a finalised run"
+            )
+
         conn.execute(
             """
             UPDATE bootstrap_stages

--- a/sql/140_per_run_progress_telemetry.sql
+++ b/sql/140_per_run_progress_telemetry.sql
@@ -1,0 +1,75 @@
+-- 140_per_run_progress_telemetry.sql
+--
+-- Issue #1069 (umbrella #1064) — admin control hub rewrite, PR2 of 10.
+--
+-- Spec: docs/superpowers/specs/2026-05-08-admin-control-hub-rewrite.md
+--       §Operator-amendment round 1 / A3 — per-process progress reporting.
+--
+-- ## Why
+--
+-- Operator A3 amendment: per-running-row "Processed: X" ticker, with
+-- optional "Rows: N · Processed: X (Y%)" when target is known, plus
+-- warning chips. The columns added here are schema-only; producer
+-- (`JobTelemetryAggregator.record_processed` / `record_warning` /
+-- `maybe_flush`) and consumer (Processes envelope adapters) wiring
+-- arrive in PR3.
+--
+-- Mirror columns onto `job_runs`, `bootstrap_stages`, `sync_runs` so
+-- the Processes table envelope can render parity progress UX across
+-- mechanisms.
+--
+-- ## Bounded vs unbounded
+--
+-- `target_count` is nullable — NULL means unbounded (e.g. SEC drain
+-- "anything since T?"). FE renders `Processed: 312` only. When set
+-- (e.g. bootstrap_filings_history_seed over a CIK list), FE renders
+-- `Rows: 1547 · Processed: 312 (20%)`.
+--
+-- ## Mid-flight stuck (4th stale case)
+--
+-- `last_progress_at` is the heartbeat: producer's `record_processed`
+-- bumps it. Stale-detection (PR8) flags any `status='running'` row
+-- whose `last_progress_at < now() - STALE_PROGRESS_THRESHOLD` (default
+-- 5 min, per-job override).
+--
+-- ## warning_classes shape
+--
+-- Mirrors `job_runs.error_classes` (sql/137):
+--   `{"RateLimited": {"count": 12, "sample_message": "...",
+--                      "last_subject": "CIK 320193",
+--                      "last_seen_at": "..."}}`
+--
+-- Producer-side: `record_warning(error_class, message, subject)`
+-- (PR3) aggregates onto the JSONB at flush time.
+--
+-- ## Lock impact
+--
+-- PG 14+ `ADD COLUMN ... DEFAULT <constant>` is metadata-only, no
+-- table rewrite. NULL-defaulted columns (`target_count`,
+-- `last_progress_at`) are also metadata-only. All ALTERs run in one
+-- transaction with the migration runner.
+
+BEGIN;
+
+ALTER TABLE job_runs
+    ADD COLUMN IF NOT EXISTS processed_count   INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS target_count      INTEGER,
+    ADD COLUMN IF NOT EXISTS last_progress_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS warnings_count    INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS warning_classes   JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE bootstrap_stages
+    ADD COLUMN IF NOT EXISTS processed_count   INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS target_count      INTEGER,
+    ADD COLUMN IF NOT EXISTS last_progress_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS warnings_count    INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS warning_classes   JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE sync_runs
+    ADD COLUMN IF NOT EXISTS processed_count   INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS target_count      INTEGER,
+    ADD COLUMN IF NOT EXISTS last_progress_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS warnings_count    INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS warning_classes   JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMIT;

--- a/tests/smoke/test_app_boots.py
+++ b/tests/smoke/test_app_boots.py
@@ -443,3 +443,32 @@ def test_admin_control_hub_schema_present() -> None:
         assert "cancelled" in row[0], (
             f"sync_runs_status_check does not include 'cancelled': {row[0]!r}; sql/139 did not widen the constraint."
         )
+
+
+def test_per_run_progress_telemetry_schema_present() -> None:
+    """Recovery gate for sql/140 (#1069 PR2 of #1064).
+
+    Operator amendment A3 adds parity progress columns onto job_runs,
+    bootstrap_stages, sync_runs so the Processes table envelope (PR3)
+    can render the same UX across mechanisms. Schema-only here;
+    producer + consumer wiring lands in PR3.
+    """
+    import psycopg
+
+    from app.config import settings
+
+    progress_columns = (
+        "processed_count",
+        "target_count",
+        "last_progress_at",
+        "warnings_count",
+        "warning_classes",
+    )
+    with psycopg.connect(settings.database_url) as conn:
+        for table in ("job_runs", "bootstrap_stages", "sync_runs"):
+            for col in progress_columns:
+                row = conn.execute(
+                    "SELECT 1 FROM information_schema.columns WHERE table_name=%s AND column_name=%s",
+                    (table, col),
+                ).fetchone()
+                assert row is not None, f"{table}.{col} missing — sql/140 did not apply."

--- a/tests/test_api_bootstrap.py
+++ b/tests/test_api_bootstrap.py
@@ -290,6 +290,49 @@ def test_mark_complete_returns_409_while_running(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# POST /system/bootstrap/cancel
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_returns_202_when_running(client: TestClient) -> None:
+    _install_conn()
+    with patch("app.api.bootstrap.cancel_run", return_value=42) as cancel_mock:
+        resp = client.post("/system/bootstrap/cancel")
+
+    assert resp.status_code == 202
+    assert resp.json() == {"run_id": 42, "status": "cancel_requested"}
+    cancel_mock.assert_called_once()
+
+
+def test_cancel_returns_409_when_not_running(client: TestClient) -> None:
+    from app.services.bootstrap_state import BootstrapNotRunning
+
+    _install_conn()
+    with patch(
+        "app.api.bootstrap.cancel_run",
+        side_effect=BootstrapNotRunning("nothing running"),
+    ):
+        resp = client.post("/system/bootstrap/cancel")
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error"] == "no_active_run"
+
+
+def test_cancel_returns_409_when_double_clicked(client: TestClient) -> None:
+    from app.services.process_stop import StopAlreadyPendingError
+
+    _install_conn()
+    with patch(
+        "app.api.bootstrap.cancel_run",
+        side_effect=StopAlreadyPendingError("already pending"),
+    ):
+        resp = client.post("/system/bootstrap/cancel")
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error"] == "stop_already_pending"
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bootstrap_cancel.py
+++ b/tests/test_bootstrap_cancel.py
@@ -223,6 +223,36 @@ def test_mark_run_cancelled_idempotent(
 # ---------------------------------------------------------------------------
 
 
+def test_finalize_run_terminalises_late_cancel(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Codex pre-push round 1 BLOCKING B2 regression: dispatcher
+    finished its loop without observing the stop signal, then operator
+    clicks Cancel in the gap before finalize_run runs. Without the
+    cancel_requested_at branch in finalize_run, the run terminalises
+    as 'complete' and the stop row is orphaned. With the fix, finalize
+    routes the run to 'cancelled'.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    for spec in _SPECS:
+        mark_stage_running(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+        mark_stage_success(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+    ebull_test_conn.commit()
+
+    # Operator cancels AFTER all stages finished — dispatcher loop
+    # already exited; checkpoint never observed the stop row.
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+
+    terminal = finalize_run(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    assert terminal == "cancelled"
+    state = read_state(ebull_test_conn)
+    assert state.status == "cancelled"
+
+
 def test_finalize_run_preserves_cancelled(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_bootstrap_cancel.py
+++ b/tests/test_bootstrap_cancel.py
@@ -1,0 +1,506 @@
+"""Tests for cooperative cancel of the bootstrap orchestrator (#1069).
+
+Spec: docs/superpowers/specs/2026-05-08-admin-control-hub-rewrite.md
+      §Cancel semantics — cooperative + §PR2.
+
+Real-DB tests against the worker ``ebull_test`` database. Mocking the
+process_stop_requests partial-unique index would defeat half the
+correctness contract under test, so these all go through psycopg
+against the truncated test DB.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.bootstrap_orchestrator import (
+    _phase_batched_dispatch,
+    _RunnableStage,
+    run_bootstrap_orchestrator,
+)
+from app.services.bootstrap_state import (
+    BootstrapNotRunning,
+    StageSpec,
+    cancel_run,
+    finalize_run,
+    force_mark_complete,
+    mark_run_cancelled,
+    mark_stage_error,
+    mark_stage_running,
+    mark_stage_success,
+    read_latest_run_with_stages,
+    read_state,
+    reap_orphaned_running,
+    reset_failed_stages_for_retry,
+    start_run,
+)
+from app.services.process_stop import (
+    StopAlreadyPendingError,
+    is_stop_requested,
+)
+
+
+# Singleton reset — same pattern as test_bootstrap_state.py.
+def _reset_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        UPDATE bootstrap_state
+           SET status            = 'pending',
+               last_run_id       = NULL,
+               last_completed_at = NULL
+         WHERE id = 1
+        """
+    )
+    conn.commit()
+
+
+def _bind_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> str:
+    from app.config import settings as app_settings
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    url = test_database_url()
+    monkeypatch.setattr(app_settings, "database_url", url)
+    return url
+
+
+_SPECS = (
+    StageSpec(stage_key="alpha", stage_order=1, lane="init", job_name="alpha_job"),
+    StageSpec(stage_key="bravo", stage_order=2, lane="sec", job_name="bravo_job"),
+    StageSpec(stage_key="charlie", stage_order=3, lane="sec", job_name="charlie_job"),
+)
+
+
+# ---------------------------------------------------------------------------
+# cancel_run
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_run_inserts_stop_row_and_marks_run(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    cancelled_run_id = cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+
+    assert cancelled_run_id == run_id
+
+    # Stop request exists, unobserved, uncompleted.
+    stop = is_stop_requested(
+        ebull_test_conn,
+        target_run_kind="bootstrap_run",
+        target_run_id=run_id,
+    )
+    assert stop is not None
+    assert stop.process_id == "bootstrap"
+    assert stop.mechanism == "bootstrap"
+    assert stop.mode == "cooperative"
+    assert stop.observed_at is None
+    assert stop.completed_at is None
+
+    # Fast-path observation column populated.
+    row = ebull_test_conn.execute(
+        "SELECT cancel_requested_at, status FROM bootstrap_runs WHERE id = %s",
+        (run_id,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] is not None
+    # Run row is still 'running' — the cancel signal is just a flag;
+    # the orchestrator transitions to 'cancelled' on observation.
+    assert row[1] == "running"
+
+
+def test_cancel_run_raises_when_not_running(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    # state='pending'
+    with pytest.raises(BootstrapNotRunning):
+        cancel_run(ebull_test_conn, requested_by_operator_id=None)
+
+
+def test_cancel_run_raises_when_complete(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    for spec in _SPECS:
+        mark_stage_running(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+        mark_stage_success(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+    finalize_run(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    assert read_state(ebull_test_conn).status == "complete"
+
+    with pytest.raises(BootstrapNotRunning):
+        cancel_run(ebull_test_conn, requested_by_operator_id=None)
+
+
+def test_cancel_run_double_click_raises_already_pending(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+
+    with pytest.raises(StopAlreadyPendingError):
+        cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    # Outer connection still usable after the SAVEPOINT-wrapped insert
+    # rejected — verify with a follow-up read.
+    state = read_state(ebull_test_conn)
+    assert state.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# mark_run_cancelled
+# ---------------------------------------------------------------------------
+
+
+def test_mark_run_cancelled_terminalises_run_and_state(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="bravo")
+    ebull_test_conn.commit()
+
+    mark_run_cancelled(
+        ebull_test_conn,
+        run_id=run_id,
+        notes_line="cancelled by operator at dispatcher checkpoint",
+    )
+    ebull_test_conn.commit()
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    assert snap.run_status == "cancelled"
+    by_key = {s.stage_key: s for s in snap.stages}
+    assert by_key["alpha"].status == "success"
+    # Running stage swept to error so re-Iterate retries it.
+    assert by_key["bravo"].status == "error"
+    # Pending stage swept to error too — retry-failed picks it up.
+    assert by_key["charlie"].status == "error"
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "cancelled"
+
+    # Notes audit line written.
+    notes = ebull_test_conn.execute("SELECT notes FROM bootstrap_runs WHERE id = %s", (run_id,)).fetchone()
+    assert notes is not None and notes[0] is not None
+    assert "cancelled by operator" in notes[0]
+
+
+def test_mark_run_cancelled_idempotent(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    mark_run_cancelled(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    first_state = read_state(ebull_test_conn)
+
+    mark_run_cancelled(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    second_state = read_state(ebull_test_conn)
+
+    # Both reads see cancelled; second call's status='running' guard
+    # made the UPDATEs no-op.
+    assert first_state.status == "cancelled"
+    assert second_state.status == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# finalize_run interaction with cancelled
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_run_preserves_cancelled(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Race: orchestrator completed Phase A successfully, cancel
+    observed before Phase B kicks off. mark_run_cancelled fires; if the
+    dispatcher's caller still calls finalize_run, the status='running'
+    guard on the UPDATE preserves 'cancelled'.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    ebull_test_conn.commit()
+
+    mark_run_cancelled(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    terminal = finalize_run(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    assert terminal == "cancelled"
+    assert read_state(ebull_test_conn).status == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# reap_orphaned_running with cancel_requested_at
+# ---------------------------------------------------------------------------
+
+
+def test_reap_orphaned_running_routes_cancel_requested_to_cancelled(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Operator clicked cancel; jobs process restarted before the
+    worker observed. Boot-recovery must terminalise as 'cancelled', not
+    mask it as 'partial_error'.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+
+    swept = reap_orphaned_running(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    assert swept is True
+    state = read_state(ebull_test_conn)
+    assert state.status == "cancelled"
+
+    notes = ebull_test_conn.execute("SELECT notes, status FROM bootstrap_runs WHERE id = %s", (run_id,)).fetchone()
+    assert notes is not None
+    assert notes[1] == "cancelled"
+    assert "terminated by operator before jobs restart" in (notes[0] or "")
+
+
+def test_reap_orphaned_running_partial_error_when_no_cancel(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Generic crash without operator cancel still terminalises as
+    partial_error per the existing contract.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    ebull_test_conn.commit()
+
+    reap_orphaned_running(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    assert read_state(ebull_test_conn).status == "partial_error"
+    row = ebull_test_conn.execute("SELECT status FROM bootstrap_runs WHERE id = %s", (run_id,)).fetchone()
+    assert row is not None and row[0] == "partial_error"
+
+
+# ---------------------------------------------------------------------------
+# orchestrator end-to-end with cancel checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_observes_cancel_at_top_of_loop_and_returns_cancelled(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-stage cancel: insert a stop row before invoking the
+    dispatcher; the very first iteration's checkpoint observes it,
+    transitions the run to cancelled, and returns ``cancelled=True``
+    without dispatching any stage. None of the test invokers are
+    called.
+    """
+    _reset_state(ebull_test_conn)
+    test_db_url = _bind_settings_to_test_db(monkeypatch)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+
+    calls: list[str] = []
+    runnable = [
+        _RunnableStage(
+            stage_key="alpha",
+            job_name="alpha_job",
+            lane="init",
+            invoker=lambda: calls.append("alpha"),
+            requires=(),
+        ),
+        _RunnableStage(
+            stage_key="bravo",
+            job_name="bravo_job",
+            lane="sec",
+            invoker=lambda: calls.append("bravo"),
+            requires=("alpha",),
+        ),
+    ]
+
+    statuses, cancelled = _phase_batched_dispatch(
+        run_id=run_id,
+        runnable=runnable,
+        database_url=test_db_url,
+    )
+
+    assert cancelled is True
+    # No stage was dispatched — checkpoint fired before the first batch.
+    assert calls == []
+    # Statuses dict is the initial pending map (no stages advanced).
+    assert statuses == {"alpha": "pending", "bravo": "pending"}
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "cancelled"
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    assert snap.run_status == "cancelled"
+
+
+def test_dispatcher_observes_cancel_between_batches(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mid-flight cancel: alpha's invoker requests the cancel as a
+    side effect; the dispatcher's next-iteration checkpoint observes
+    it before bravo dispatches.
+    """
+    _reset_state(ebull_test_conn)
+    test_db_url = _bind_settings_to_test_db(monkeypatch)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    calls: list[str] = []
+
+    def alpha_invoker() -> None:
+        calls.append("alpha")
+        # Simulate operator clicking Cancel during alpha's run.
+        with psycopg.connect(test_db_url) as conn:
+            cancel_run(conn, requested_by_operator_id=None)
+            conn.commit()
+
+    def bravo_invoker() -> None:  # pragma: no cover — must NOT run
+        calls.append("bravo")
+
+    runnable = [
+        _RunnableStage(
+            stage_key="alpha",
+            job_name="alpha_job",
+            lane="init",
+            invoker=alpha_invoker,
+            requires=(),
+        ),
+        _RunnableStage(
+            stage_key="bravo",
+            job_name="bravo_job",
+            lane="sec",
+            invoker=bravo_invoker,
+            requires=("alpha",),
+        ),
+    ]
+
+    _statuses, cancelled = _phase_batched_dispatch(
+        run_id=run_id,
+        runnable=runnable,
+        database_url=test_db_url,
+    )
+
+    assert cancelled is True
+    # Alpha completed; bravo never dispatched.
+    assert calls == ["alpha"]
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    by_key = {s.stage_key: s for s in snap.stages}
+    assert by_key["alpha"].status == "success"
+    # bravo: was 'pending' when cancel observed; mark_run_cancelled
+    # sweeps pending → error so retry-failed picks it up.
+    assert by_key["bravo"].status == "error"
+    assert read_state(ebull_test_conn).status == "cancelled"
+
+
+def test_cancel_then_iterate_resumes_via_reset_failed(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After cancellation, the existing reset_failed_stages_for_retry
+    path resets pending/error stages on the same run and flips state
+    back to running — Iterate is just a re-publish of the orchestrator
+    job. This test exercises the resume contract without re-running
+    the orchestrator.
+    """
+    _reset_state(ebull_test_conn)
+    _bind_settings_to_test_db(monkeypatch)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    ebull_test_conn.commit()
+
+    # Operator cancels.
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+    mark_run_cancelled(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    assert read_state(ebull_test_conn).status == "cancelled"
+
+    # Operator clicks Iterate (= reset failed/pending + republish).
+    reset_count = reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    # alpha success preserved; bravo + charlie were swept to error
+    # and reset back to pending.
+    assert reset_count == 2
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    by_key = {s.stage_key: s for s in snap.stages}
+    assert by_key["alpha"].status == "success"
+    assert by_key["bravo"].status == "pending"
+    assert by_key["charlie"].status == "pending"
+    assert read_state(ebull_test_conn).status == "running"
+
+
+# ---------------------------------------------------------------------------
+# scheduler-gate verification — _bootstrap_complete rejects 'cancelled'
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_complete_returns_false_on_cancelled(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The cancelled state must keep dependent SEC / fundamentals
+    jobs gated. Operator must Iterate or force-mark-complete.
+    """
+    from app.workers.scheduler import _bootstrap_complete
+
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_run_cancelled(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    ok, msg = _bootstrap_complete(ebull_test_conn)
+    assert ok is False
+    assert "bootstrap" in msg.lower()
+
+
+def test_force_mark_complete_releases_gate_after_cancel(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """After cancel, the operator escape hatch (force_mark_complete)
+    still works — it requires status != 'running', and 'cancelled' is
+    a non-running terminal state.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    mark_run_cancelled(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    assert read_state(ebull_test_conn).status == "cancelled"
+
+    force_mark_complete(ebull_test_conn)
+    ebull_test_conn.commit()
+    assert read_state(ebull_test_conn).status == "complete"
+
+
+# Avoid unused-import lint warnings on helpers used only by the
+# integration test above.
+_ = mark_stage_error
+_ = run_bootstrap_orchestrator


### PR DESCRIPTION
## What

PR2 of #1064 admin control hub rewrite. Spec §PR2 at `docs/superpowers/specs/2026-05-08-admin-control-hub-rewrite.md`.

- **sql/140** per-run progress telemetry on `job_runs` / `bootstrap_stages` / `sync_runs` (operator A3 amendment, schema-only; producer + consumer wiring lands in PR3).
- **bootstrap_state**: widen `BootstrapStatus` + `RunStatus` literals to include `'cancelled'`. Add `cancel_run()` (locks running run row FOR UPDATE → `request_stop` → set `cancel_requested_at`, all one tx) and `mark_run_cancelled()` (idempotent terminaliser; raises on terminal-but-not-cancelled). `finalize_run()` reads `cancel_requested_at` under FOR UPDATE and routes to `cancelled` if set — closes the dispatcher-loop-exit-to-finalize race.
- **reap_orphaned_running**: routes runs with `cancel_requested_at IS NOT NULL` to `cancelled` with audit note in `bootstrap_runs.notes`; rest stay `partial_error`.
- **bootstrap_orchestrator**: cancel checkpoint at top of `_phase_batched_dispatch` loop covers (W1) before Phase A first batch, between batches, before Phase B, between stages within a lane. Single-tx `mark_stop_observed + mark_run_cancelled + mark_stop_completed`. Returns `(statuses, cancelled)` so `run_bootstrap_orchestrator` skips redundant `finalize_run` on observed cancel.
- **POST /system/bootstrap/cancel**: 202 with `{"run_id": N, "status": "cancel_requested"}`; 409 `no_active_run` / `stop_already_pending`. Audit field receives operator UUID where middleware has populated `request.state.operator_id`, NULL otherwise.
- **Defense-in-depth**: `mark_stage_success` / `mark_stage_error` now require `status='running'`; `mark_stage_skipped` requires `status IN ('running','pending')`. Prevents late stage UPDATEs from overwriting a cancellation sweep.

## Why

Operator wants a cancel button (#1064 quote 4 — "There's no cancel button on the page either"). Spec models cancel as cooperative + watermark-resume-safe (vs. fake hard-kill that creates ghost runs). PR2 scope is bootstrap; later PRs extend the same shape to scheduled jobs (PR3) and the orchestrator full-sync (PR6).

## Test plan

- [x] `tests/test_bootstrap_cancel.py` — cancel happy path, BootstrapNotRunning on idle/complete, double-click → StopAlreadyPending, mark_run_cancelled idempotency, finalize_run preserves cancelled, finalize_run terminalises late cancel (B2 regression), reap_orphaned_running routing, dispatcher checkpoints (pre-stage + between-batches), cancel-then-Iterate resume, scheduler-gate keeps `cancelled` rejected, force_mark_complete still releases gate after cancel.
- [x] `tests/test_api_bootstrap.py` — 202 + 409 mappings.
- [x] `tests/smoke/test_app_boots.py` — sql/140 column gate.
- [x] All four pre-push gates green: `uv run ruff check`, `uv run ruff format --check`, `uv run pyright`, `uv run pytest tests/test_bootstrap_cancel.py tests/test_bootstrap_state.py tests/test_api_bootstrap.py tests/test_bootstrap_orchestrator.py tests/test_bootstrap_state_prerequisite.py tests/test_bootstrap_flow_integration.py tests/smoke/test_app_boots.py tests/test_process_stop.py tests/test_bootstrap_fallback_skip.py -n 0` → 89 passed.
- [x] Codex pre-push review: round 1 surfaced 2 BLOCKING + 5 WARNING, all addressed (lock-order inversion, final-checkpoint race, mark_run_cancelled rowcount semantics, stage update guards, single-tx checkpoint, operator UUID wiring); round 2 confirmed all fixes sound, only NIT was a docstring drift now corrected.

Closes #1069
Refs #1064