### PR TITLE
feat(#1073): PR4 — watermark resolver + per-process resume contract

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -35,12 +35,19 @@ from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.db.snapshot import snapshot_read
 from app.jobs.runtime import VALID_JOB_NAMES
-from app.services.bootstrap_orchestrator import JOB_BOOTSTRAP_ORCHESTRATOR
+from app.services.bootstrap_orchestrator import JOB_BOOTSTRAP_ORCHESTRATOR, get_bootstrap_stage_specs
 from app.services.bootstrap_state import (
+    BootstrapAlreadyRunning,
     BootstrapNotRunning,
 )
 from app.services.bootstrap_state import (
     cancel_run as bootstrap_cancel_run,
+)
+from app.services.bootstrap_state import (
+    reset_failed_stages_for_retry as bootstrap_reset_failed_stages,
+)
+from app.services.bootstrap_state import (
+    start_run as bootstrap_start_run,
 )
 from app.services.ops_monitor import get_kill_switch_status
 from app.services.process_stop import (
@@ -65,8 +72,11 @@ from app.services.processes import (
     scheduled_adapter,
 )
 from app.services.processes.watermarks import (
+    acquire_shared_source_locks,
     atom_etag_target_for,
     freshness_source_for,
+    jobs_sharing_freshness_source,
+    jobs_sharing_manifest_source,
     manifest_source_for,
 )
 from app.services.sync_orchestrator.dispatcher import NOTIFY_CHANNEL
@@ -587,77 +597,152 @@ def _check_scheduled_job_preconditions(conn: psycopg.Connection[Any], *, job_nam
         )
 
 
-def _apply_full_wash_reset(
+def _check_full_wash_shared_source_clear(
+    conn: psycopg.Connection[Any],
+    *,
+    job_name: str,
+) -> None:
+    """Refuse a scheduled-job full-wash while a sibling sharing the
+    same freshness/manifest source is mid-run.
+
+    Codex pre-push BLOCKING: a full-wash on ``daily_financial_facts``
+    resets ``data_freshness_index`` rows for ``sec_xbrl_facts``, which
+    is also consumed by ``fundamentals_sync`` and
+    ``sec_business_summary_ingest``. The per-job advisory lock + the
+    per-job ``_has_active_job_run`` are scoped to ``job_name`` and
+    cannot see a sibling running under a different name. Walk the
+    registry, take ``_has_active_job_run`` for every sibling sharing
+    the same scheduler source, and 409 if any is running.
+    """
+    siblings: set[str] = set()
+    fresh = freshness_source_for(job_name)
+    if fresh is not None:
+        siblings.update(jobs_sharing_freshness_source(fresh))
+    manifest = manifest_source_for(job_name)
+    if manifest is not None:
+        siblings.update(jobs_sharing_manifest_source(manifest))
+    siblings.discard(job_name)
+    for sibling in sorted(siblings):
+        if _has_active_job_run(conn, job_name=sibling):
+            raise _conflict(
+                "shared_source_active_run",
+                advice=(
+                    f"sibling job {sibling!r} consumes the same scheduler source; cancel that run before full-wash"
+                ),
+            )
+        # Codex review BLOCKING: also reject concurrent full-wash POSTs
+        # across siblings. The partial UNIQUE on
+        # ``pending_job_requests_active_full_wash_idx`` only dedupes by
+        # ``process_id``; a sibling's fence row carries a different
+        # ``process_id`` and wouldn't hit the index. Probe each sibling's
+        # fence row explicitly so two full-washes targeting the same
+        # scheduler source cannot race past this gate. (Runtime-prelude
+        # sibling-fence enforcement — needed when an APScheduler fire of
+        # `fundamentals_sync` arrives during a queued
+        # `daily_financial_facts` full-wash — is filed as a follow-up
+        # under #1064 since it requires changes to
+        # ``app/jobs/runtime.py`` outside PR4's watermark scope.)
+        if _has_pending_full_wash_fence(conn, process_id=sibling):
+            raise _conflict(
+                "shared_source_full_wash_pending",
+                advice=(f"sibling job {sibling!r} already has an active full-wash; wait for it to complete"),
+            )
+
+
+def _apply_bootstrap_iterate_reset(conn: psycopg.Connection[Any]) -> None:
+    """Bootstrap iterate: reset failed stages + flip state to 'running'.
+
+    Reuses ``bootstrap_state.reset_failed_stages_for_retry`` — the
+    same helper the legacy ``POST /system/bootstrap/retry-failed``
+    endpoint uses. The helper takes ``SELECT ... FOR UPDATE`` on the
+    bootstrap_state singleton internally, so a concurrent ``start_run``
+    racing in between the precondition gate and this call surfaces as
+    ``BootstrapAlreadyRunning`` and we map it to 409.
+    """
+    state_row = conn.execute("SELECT last_run_id FROM bootstrap_state WHERE id = 1").fetchone()
+    if state_row is None:
+        raise _conflict("bootstrap_state_missing", advice="run sql/129 migration")
+    last_run_id = state_row[0]
+    if last_run_id is None:
+        raise _conflict(
+            "bootstrap_not_resumable",
+            advice="no prior bootstrap run to retry",
+        )
+    try:
+        bootstrap_reset_failed_stages(conn, run_id=int(last_run_id))
+    except BootstrapAlreadyRunning as exc:
+        raise _conflict("bootstrap_already_running") from exc
+
+
+def _apply_bootstrap_full_wash_reset(
+    conn: psycopg.Connection[Any],
+    *,
+    operator_uuid: UUID | None,
+) -> None:
+    """Bootstrap full-wash: create a fresh bootstrap_runs + flip state.
+
+    Codex review BLOCKING: PR3 enqueued the orchestrator after a
+    naive ``UPDATE bootstrap_stages`` reset; the orchestrator's
+    invoker (``run_bootstrap_orchestrator``) no-ops unless
+    ``bootstrap_runs.status == 'running'``. ``start_run`` is the same
+    helper the legacy ``POST /system/bootstrap/run`` endpoint calls;
+    it inserts a new ``bootstrap_runs`` row, seeds 17 pending
+    ``bootstrap_stages`` rows, and flips the singleton state to
+    ``running``, all in one transaction.
+
+    The precondition gate already rejected the trigger if state was
+    'running'; ``start_run``'s internal ``FOR UPDATE`` is the
+    defence-in-depth against a concurrent ``start_run`` slipping in.
+    """
+    operator_id = str(operator_uuid) if operator_uuid is not None else None
+    try:
+        bootstrap_start_run(
+            conn,
+            operator_id=operator_id,
+            stage_specs=get_bootstrap_stage_specs(),
+        )
+    except BootstrapAlreadyRunning as exc:
+        raise _conflict("bootstrap_already_running") from exc
+
+
+def _apply_scheduled_full_wash_reset(
     conn: psycopg.Connection[Any],
     *,
     process_id: str,
-    mechanism: ProcessMechanism,
 ) -> None:
-    """Reset the watermark to mechanism-specific minimum BEFORE INSERT.
+    """Reset scheduled-job watermark to mechanism-specific minimum.
 
     Spec §"Full-wash semantics" step 5 + §"Full-wash execution fence"
     step 5. Caller MUST be inside ``conn.transaction()`` and MUST hold
-    the per-process advisory lock acquired by
-    ``acquire_prelude_lock`` so the reset + the durable fence INSERT
-    are atomic against any racing scheduled prelude / iterate trigger.
+    the per-process advisory lock so the reset + the durable fence
+    INSERT are atomic against any racing scheduled prelude / iterate
+    trigger.
 
-    Reset shape per mechanism:
+    Reset shape:
 
-    * **bootstrap** — `UPDATE bootstrap_stages SET status='pending',
-      started_at=NULL, completed_at=NULL, last_error=NULL WHERE
-      bootstrap_run_id = (latest) AND status IN
-      ('success','error','blocked','skipped')`. Pending+running rows
-      are NOT touched (precondition gate already rejected the trigger
-      if status='running'); a stage in 'pending' is the natural
-      starting state and overwriting it would just rewrite the same
-      values.
-    * **scheduled_job** with freshness source — full epoch reset:
-      ``UPDATE data_freshness_index SET last_known_filed_at = NULL,
-      last_known_filing_id = NULL, expected_next_at = NULL,
-      next_recheck_at = NULL, state = 'unknown' WHERE source = ?``.
+    * Freshness source — full epoch reset of ``data_freshness_index``
+      (clears ``last_known_filed_at``, ``last_known_filing_id``,
+      ``expected_next_at``, ``next_recheck_at``, ``state_reason``,
+      ``new_filings_since`` and flips ``state`` to ``unknown``).
       Codex pre-push BLOCKING: clearing only ``last_known_filed_at``
-      leaves the prior filing_id pointer + future
-      ``expected_next_at`` / ``next_recheck_at``, so the next poll
-      may not run immediately AND ``check_freshness`` would skip
-      historical filings against the stale ``last_known_filing_id``.
-      The full reset gives the freshness sweeper a clean slate; rows
-      qualify for ``idx_freshness_due_for_poll`` immediately
-      (``state='unknown'`` AND ``expected_next_at IS NULL``).
-    * **scheduled_job** with manifest source — `UPDATE
-      sec_filing_manifest SET ingest_status='pending',
-      last_attempted_at=NULL, next_retry_at=NULL WHERE source = ?`.
-      ON CONFLICT idempotency on the per-source ingester provides the
-      de-dupe guarantee — no row corruption from the re-fetch.
-    * **scheduled_job** with atom ETag target — `DELETE FROM
-      external_data_watermarks WHERE source = ? AND key = ?`. A
-      missing row is the "no prior state, do full backfill" signal
-      consumed by ``app/services/watermarks.py::get_watermark``.
-    * **scheduled_job** with no registered source — no-op. Full-wash
-      on a no-watermark job is just "rerun"; the queue INSERT alone
-      is sufficient.
-    * **ingest_sweep** — never reaches this code path (caller 404s
-      ingest_sweep triggers in PR3).
+      leaves the prior filing_id pointer + future poll cadence, so
+      the next poll may not run immediately AND ``check_freshness``
+      would skip historical filings against the stale filing_id.
+    * Manifest source — flips all rows for the source to ``pending``,
+      clears ``last_attempted_at`` / ``next_retry_at``. ON CONFLICT
+      idempotency on the per-source ingester is the de-dupe layer.
+    * Atom ETag target — DELETEs the watermark row. A missing row is
+      the "no prior state, do full backfill" signal consumed by
+      ``app/services/watermarks.py::get_watermark``.
+    * No registered source — no-op. Full-wash on a no-watermark job
+      is just "rerun"; the queue INSERT alone is sufficient.
+
+    Bootstrap full-wash is handled separately in ``trigger_process``
+    via ``bootstrap_start_run`` so the orchestrator picks up a
+    fresh ``bootstrap_runs`` row + ``bootstrap_state.status='running'``
+    on dispatch (Codex review BLOCKING — the orchestrator no-ops
+    unless ``bootstrap_runs.status='running'``).
     """
-    if mechanism == "bootstrap":
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                UPDATE bootstrap_stages
-                   SET status='pending',
-                       started_at=NULL,
-                       completed_at=NULL,
-                       last_error=NULL
-                 WHERE bootstrap_run_id = (
-                       SELECT MAX(id) FROM bootstrap_runs
-                 )
-                   AND status IN ('success', 'error', 'blocked', 'skipped')
-                """
-            )
-        return
-    if mechanism == "ingest_sweep":
-        # Stub adapter — caller already 404'd. Defence-in-depth no-op.
-        return
-    # mechanism == 'scheduled_job'
     freshness_source = freshness_source_for(process_id)
     if freshness_source is not None:
         with conn.cursor() as cur:
@@ -779,7 +864,7 @@ def trigger_process(
             detail=f"unknown process: {process_id!r}",
         )
 
-    requested_by, _ = _identify_requestor(request)
+    requested_by, operator_uuid = _identify_requestor(request)
     if mechanism == "bootstrap":
         target_process_id = "bootstrap"
         target_job_name = JOB_BOOTSTRAP_ORCHESTRATOR
@@ -797,17 +882,39 @@ def trigger_process(
     try:
         with conn.transaction():
             acquire_prelude_lock(conn, target_process_id)
+            # Codex pre-push round 7 BLOCKING: per-process advisory lock
+            # only serialises operations under the same ``process_id``.
+            # Multi-job shared scheduler sources (e.g. XBRL) need a
+            # source-keyed lock so a sibling prelude waits for the
+            # full-wash trigger's fence INSERT to commit before it can
+            # query and proceed.
+            if mechanism == "scheduled_job":
+                acquire_shared_source_locks(conn, process_id=target_process_id)
             if mechanism == "bootstrap":
                 _check_bootstrap_preconditions(conn, mode=body.mode)
+                # Bootstrap iterate / full_wash both need to flip the
+                # underlying state machine BEFORE the orchestrator is
+                # dispatched — the invoker no-ops unless the latest
+                # bootstrap_runs.status == 'running' (orchestrator
+                # `read_latest_run_with_stages` short-circuit). Codex
+                # review BLOCKING: PR3 enqueued without flipping state,
+                # so the orchestrator quietly returned without doing
+                # the requested work. start_run / reset_failed_stages
+                # both flip bootstrap_state.status + bootstrap_runs.
+                if body.mode == "iterate":
+                    _apply_bootstrap_iterate_reset(conn)
+                else:
+                    _apply_bootstrap_full_wash_reset(conn, operator_uuid=operator_uuid)
             else:
                 _check_scheduled_job_preconditions(conn, job_name=target_job_name)
-            # PR4: full-wash resets the watermark BEFORE enqueueing
-            # the worker. The reset + fence INSERT happen in the same
-            # advisory-lock-held tx so a racing scheduled prelude /
-            # iterate either sees the reset state + the fence row, or
-            # neither (Codex round 4 R4-B1 invariant).
-            if body.mode == "full_wash":
-                _apply_full_wash_reset(conn, process_id=target_process_id, mechanism=mechanism)
+                if body.mode == "full_wash":
+                    # Refuse if any sibling job sharing the freshness
+                    # or manifest source is mid-run — full-wash mutates
+                    # source-scoped scheduler rows, not job-scoped
+                    # ones, so a sibling holds no per-job advisory lock
+                    # under our key (Codex review BLOCKING).
+                    _check_full_wash_shared_source_clear(conn, job_name=target_job_name)
+                    _apply_scheduled_full_wash_reset(conn, process_id=target_process_id)
             request_id = _publish_within_tx(
                 conn,
                 job_name=target_job_name,

--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -64,6 +64,11 @@ from app.services.processes import (
     ingest_sweep_adapter,
     scheduled_adapter,
 )
+from app.services.processes.watermarks import (
+    atom_etag_target_for,
+    freshness_source_for,
+    manifest_source_for,
+)
 from app.services.sync_orchestrator.dispatcher import NOTIFY_CHANNEL
 
 logger = logging.getLogger(__name__)
@@ -516,12 +521,36 @@ def _check_bootstrap_preconditions(conn: psycopg.Connection[Any], *, mode: Liter
         )
 
 
+def _has_active_job_run(conn: psycopg.Connection[Any], *, job_name: str) -> bool:
+    """True if a ``job_runs`` row is currently ``status='running'``.
+
+    The advisory lock serialises preludes only — once a worker has
+    started the body of its run, the lock is released. Any trigger
+    that arrives during that window must still see the active run and
+    refuse rather than (a) double-enqueue an iterate or (b) reset
+    watermarks under the running worker's feet (Codex pre-push BLOCKING).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1
+              FROM job_runs
+             WHERE job_name = %s
+               AND status   = 'running'
+             LIMIT 1
+            """,
+            (job_name,),
+        )
+        return cur.fetchone() is not None
+
+
 def _check_scheduled_job_preconditions(conn: psycopg.Connection[Any], *, job_name: str) -> None:
     """Raise 409 if scheduled-job trigger preconditions are not met.
 
     The bootstrap-gate (``_bootstrap_complete``) check is left to the
     job's own prerequisite at fire time — the trigger endpoint only
-    enforces the universal preconditions (kill_switch, dedup, fence).
+    enforces the universal preconditions (kill_switch, dedup, fence,
+    active-run).
     Trying to short-circuit a gated job here would duplicate the
     job-level prerequisite and risk drift (e.g. a future pause flag).
 
@@ -530,6 +559,16 @@ def _check_scheduled_job_preconditions(conn: psycopg.Connection[Any], *, job_nam
     second one's ``_has_inflight_manual_job`` check sees the first's
     committed row and 409s. (sql/138 only has a partial UNIQUE for
     ``mode='full_wash'``; iterate dedup relies entirely on this lock.)
+
+    Active-run gate (Codex pre-push BLOCKING + spec §"Full-wash
+    execution fence" step 4): a scheduled fire that has already
+    advanced past the prelude into its body holds no lock and is
+    invisible to ``pending_job_requests`` (its trigger row is already
+    transitioned to ``completed``/``rejected``). A trigger landing
+    while that body is in flight must be refused with
+    ``active_run_in_progress`` — full-wash MUST NOT mutate watermark
+    state under the running worker, and a second iterate would
+    double-enqueue.
     """
     if _kill_switch_active(conn):
         raise _conflict("kill_switch_active", advice="deactivate kill switch")
@@ -539,11 +578,124 @@ def _check_scheduled_job_preconditions(conn: psycopg.Connection[Any], *, job_nam
     # tooltip than plain dedup).
     if _has_pending_full_wash_fence(conn, process_id=job_name):
         raise _conflict("full_wash_already_pending", advice="wait for the active full-wash")
+    if _has_active_job_run(conn, job_name=job_name):
+        raise _conflict("active_run_in_progress", advice="cancel the active run first")
     if _has_inflight_manual_job(conn, job_name=job_name):
         raise _conflict(
             "iterate_already_pending",
             advice="a manual run for this job is already in flight",
         )
+
+
+def _apply_full_wash_reset(
+    conn: psycopg.Connection[Any],
+    *,
+    process_id: str,
+    mechanism: ProcessMechanism,
+) -> None:
+    """Reset the watermark to mechanism-specific minimum BEFORE INSERT.
+
+    Spec §"Full-wash semantics" step 5 + §"Full-wash execution fence"
+    step 5. Caller MUST be inside ``conn.transaction()`` and MUST hold
+    the per-process advisory lock acquired by
+    ``acquire_prelude_lock`` so the reset + the durable fence INSERT
+    are atomic against any racing scheduled prelude / iterate trigger.
+
+    Reset shape per mechanism:
+
+    * **bootstrap** — `UPDATE bootstrap_stages SET status='pending',
+      started_at=NULL, completed_at=NULL, last_error=NULL WHERE
+      bootstrap_run_id = (latest) AND status IN
+      ('success','error','blocked','skipped')`. Pending+running rows
+      are NOT touched (precondition gate already rejected the trigger
+      if status='running'); a stage in 'pending' is the natural
+      starting state and overwriting it would just rewrite the same
+      values.
+    * **scheduled_job** with freshness source — full epoch reset:
+      ``UPDATE data_freshness_index SET last_known_filed_at = NULL,
+      last_known_filing_id = NULL, expected_next_at = NULL,
+      next_recheck_at = NULL, state = 'unknown' WHERE source = ?``.
+      Codex pre-push BLOCKING: clearing only ``last_known_filed_at``
+      leaves the prior filing_id pointer + future
+      ``expected_next_at`` / ``next_recheck_at``, so the next poll
+      may not run immediately AND ``check_freshness`` would skip
+      historical filings against the stale ``last_known_filing_id``.
+      The full reset gives the freshness sweeper a clean slate; rows
+      qualify for ``idx_freshness_due_for_poll`` immediately
+      (``state='unknown'`` AND ``expected_next_at IS NULL``).
+    * **scheduled_job** with manifest source — `UPDATE
+      sec_filing_manifest SET ingest_status='pending',
+      last_attempted_at=NULL, next_retry_at=NULL WHERE source = ?`.
+      ON CONFLICT idempotency on the per-source ingester provides the
+      de-dupe guarantee — no row corruption from the re-fetch.
+    * **scheduled_job** with atom ETag target — `DELETE FROM
+      external_data_watermarks WHERE source = ? AND key = ?`. A
+      missing row is the "no prior state, do full backfill" signal
+      consumed by ``app/services/watermarks.py::get_watermark``.
+    * **scheduled_job** with no registered source — no-op. Full-wash
+      on a no-watermark job is just "rerun"; the queue INSERT alone
+      is sufficient.
+    * **ingest_sweep** — never reaches this code path (caller 404s
+      ingest_sweep triggers in PR3).
+    """
+    if mechanism == "bootstrap":
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE bootstrap_stages
+                   SET status='pending',
+                       started_at=NULL,
+                       completed_at=NULL,
+                       last_error=NULL
+                 WHERE bootstrap_run_id = (
+                       SELECT MAX(id) FROM bootstrap_runs
+                 )
+                   AND status IN ('success', 'error', 'blocked', 'skipped')
+                """
+            )
+        return
+    if mechanism == "ingest_sweep":
+        # Stub adapter — caller already 404'd. Defence-in-depth no-op.
+        return
+    # mechanism == 'scheduled_job'
+    freshness_source = freshness_source_for(process_id)
+    if freshness_source is not None:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE data_freshness_index
+                   SET last_known_filed_at  = NULL,
+                       last_known_filing_id = NULL,
+                       expected_next_at     = NULL,
+                       next_recheck_at      = NULL,
+                       state                = 'unknown',
+                       state_reason         = NULL,
+                       new_filings_since    = 0
+                 WHERE source = %s
+                """,
+                (freshness_source,),
+            )
+    manifest_source = manifest_source_for(process_id)
+    if manifest_source is not None:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE sec_filing_manifest
+                   SET ingest_status   = 'pending',
+                       last_attempted_at = NULL,
+                       next_retry_at   = NULL
+                 WHERE source = %s
+                """,
+                (manifest_source,),
+            )
+    atom_target = atom_etag_target_for(process_id)
+    if atom_target is not None:
+        atom_source, atom_key = atom_target
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM external_data_watermarks WHERE source = %s AND key = %s",
+                (atom_source, atom_key),
+            )
 
 
 def _publish_within_tx(
@@ -649,6 +801,13 @@ def trigger_process(
                 _check_bootstrap_preconditions(conn, mode=body.mode)
             else:
                 _check_scheduled_job_preconditions(conn, job_name=target_job_name)
+            # PR4: full-wash resets the watermark BEFORE enqueueing
+            # the worker. The reset + fence INSERT happen in the same
+            # advisory-lock-held tx so a racing scheduled prelude /
+            # iterate either sees the reset state + the fence row, or
+            # neither (Codex round 4 R4-B1 invariant).
+            if body.mode == "full_wash":
+                _apply_full_wash_reset(conn, process_id=target_process_id, mechanism=mechanism)
             request_id = _publish_within_tx(
                 conn,
                 job_name=target_job_name,

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -376,24 +376,82 @@ def _run_prelude(
     # and ROLLBACKs on exception — same shape as the bootstrap cancel
     # path and the snapshot_read read path.
     fence_held = False
+    fence_holder = process_id
     with psycopg.connect(database_url) as conn:
         with conn.transaction():
             acquire_prelude_lock(conn, process_id)
+            # Lazy-import to avoid a top-level cycle (api/processes
+            # imports app.jobs.runtime.VALID_JOB_NAMES).
+            from app.services.processes.watermarks import (
+                acquire_shared_source_locks as _acquire_shared_source_locks,
+            )
+            from app.services.processes.watermarks import (
+                freshness_source_for as _freshness_source_for,
+            )
+            from app.services.processes.watermarks import (
+                jobs_sharing_freshness_source,
+                jobs_sharing_manifest_source,
+            )
+            from app.services.processes.watermarks import (
+                manifest_source_for as _manifest_source_for,
+            )
+
+            # Codex pre-push round 7 BLOCKING: take source-keyed
+            # advisory locks BEFORE the fence-check query. A full-wash
+            # trigger holds these locks while it INSERTs the durable
+            # fence row; the prelude blocks here until that trigger
+            # commits, then sees the committed fence row when it
+            # queries below. Without these locks, the prelude can read
+            # the pre-INSERT state, write ``job_runs.running``, and
+            # start the body against the just-reset shared scheduler
+            # source.
+            _acquire_shared_source_locks(conn, process_id=process_id)
+
             with conn.cursor() as cur:
                 if not bypass_fence_check:
+                    fence_candidates: list[str] = [process_id]
+                    fresh = _freshness_source_for(process_id)
+                    if fresh is not None:
+                        for sibling in jobs_sharing_freshness_source(fresh):
+                            if sibling != process_id:
+                                fence_candidates.append(sibling)
+                    manifest = _manifest_source_for(process_id)
+                    if manifest is not None:
+                        for sibling in jobs_sharing_manifest_source(manifest):
+                            if sibling != process_id and sibling not in fence_candidates:
+                                fence_candidates.append(sibling)
+                    # PR4 #1075 fix (Codex review): a sibling job sharing
+                    # the same scheduler source can hold the fence under
+                    # a different ``process_id``. Probe each candidate
+                    # so an APScheduler fire of ``fundamentals_sync`` self-
+                    # skips while ``daily_financial_facts`` has a queued
+                    # full-wash over ``sec_xbrl_facts``.
                     cur.execute(
                         """
-                        SELECT 1
+                        SELECT process_id
                           FROM pending_job_requests
-                         WHERE process_id = %s
+                         WHERE process_id = ANY(%s)
                            AND mode       = 'full_wash'
                            AND status     IN ('pending', 'claimed', 'dispatched')
                          LIMIT 1
                         """,
-                        (process_id,),
+                        (fence_candidates,),
                     )
-                    fence_held = cur.fetchone() is not None
+                    holder_row = cur.fetchone()
+                    if holder_row is not None:
+                        fence_held = True
+                        fence_holder = str(holder_row[0])
                 if fence_held:
+                    # When a sibling holds the fence, surface the holder
+                    # in the audit row so the operator can see WHY this
+                    # job skipped (e.g. ``fundamentals_sync`` skipped
+                    # because ``daily_financial_facts`` is mid-wash on
+                    # the shared XBRL source).
+                    error_msg = (
+                        _FENCE_HELD_ERROR_MSG
+                        if fence_holder == process_id
+                        else f"full-wash in progress on shared scheduler source (held by {fence_holder!r})"
+                    )
                     cur.execute(
                         """
                         INSERT INTO job_runs (
@@ -404,7 +462,7 @@ def _run_prelude(
                         )
                         RETURNING run_id
                         """,
-                        (job_name, _FENCE_HELD_ERROR_MSG, linked_request_id),
+                        (job_name, error_msg, linked_request_id),
                     )
                 else:
                     cur.execute(

--- a/app/services/processes/bootstrap_adapter.py
+++ b/app/services/processes/bootstrap_adapter.py
@@ -37,6 +37,7 @@ from app.services.processes import (
     ProcessStatus,
     RunStatus,
 )
+from app.services.processes.watermarks import resolve_watermark
 
 logger = logging.getLogger(__name__)
 
@@ -328,6 +329,11 @@ def get_row(conn: psycopg.Connection[Any]) -> ProcessRow | None:
     if process_status == "failed":
         last_n_errors = _build_error_summaries(failed_stages)
 
+    # PR4: stage_index cursor of last successful stage per lane
+    # (etoro / sec / init). Returns None on a fresh install pre-first-
+    # success or when bootstrap_runs is empty.
+    watermark = resolve_watermark(conn, process_id=_PROCESS_ID, mechanism="bootstrap")
+
     return ProcessRow(
         process_id=_PROCESS_ID,
         display_name=_DISPLAY_NAME,
@@ -339,7 +345,7 @@ def get_row(conn: psycopg.Connection[Any]) -> ProcessRow | None:
         cadence_human="on demand",
         cadence_cron=None,
         next_fire_at=None,
-        watermark=None,  # PR4 wires a stage_index cursor
+        watermark=watermark,
         # Iterate = retry-failed; only meaningful when something failed
         # OR was cancelled mid-flight (resume from the failed stage).
         can_iterate=(state_status in ("partial_error", "cancelled")) and not fence_held,

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -41,6 +41,11 @@ from app.services.processes import (
     ProcessStatus,
     RunStatus,
 )
+from app.services.processes.watermarks import (
+    freshness_source_for,
+    manifest_source_for,
+    resolve_watermark,
+)
 from app.workers.scheduler import (
     SCHEDULED_JOBS,
     Cadence,
@@ -164,6 +169,7 @@ def _status_for(
     last_terminal_status: str | None,
     has_inflight_request: bool,
     kill_switch_active: bool,
+    failed_scope_covered: bool,
 ) -> ProcessStatus:
     """Compute ProcessRow.status from the per-job inputs.
 
@@ -173,8 +179,13 @@ def _status_for(
       until it flips back).
     * ``running`` wins when a job_runs row is in flight, OR when the
       latest terminal was a failure AND a retry is in flight (auto-hide).
+    * ``pending_retry`` when the latest terminal was failure, no retry
+      is in flight, but the next scheduled fire provably covers the
+      failed scope (freshness recheck or manifest retry within the
+      next-fire window — spec §"Auto-hide-on-retry rule" / "Covered"
+      check). Caller surfaces empty ``last_n_errors`` for this state.
     * ``failed`` wins when the latest terminal is failure with no retry
-      in flight.
+      in flight AND the failed scope is not covered.
     * ``ok`` for success; ``cancelled`` for cancelled; ``idle`` /
       ``pending_first_run`` when no terminal exists.
     """
@@ -186,6 +197,10 @@ def _status_for(
         if has_inflight_request:
             # Auto-hide: caller will set last_n_errors=(), status=running
             return "running"
+        if failed_scope_covered:
+            # Auto-hide: next scheduled fire will reattempt the failed
+            # scope; caller surfaces last_n_errors=().
+            return "pending_retry"
         return "failed"
     if last_terminal_status == "success":
         return "ok"
@@ -293,6 +308,107 @@ def _has_pending_full_wash_fence(conn: psycopg.Connection[Any], *, process_id: s
         return cur.fetchone() is not None
 
 
+def _freshness_failure_counts(
+    conn: psycopg.Connection[Any],
+    *,
+    source: str,
+    deadline: datetime,
+) -> tuple[int, int]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) FILTER (WHERE state = 'error') AS total,
+                COUNT(*) FILTER (
+                  WHERE state = 'error'
+                    AND (next_recheck_at IS NULL OR next_recheck_at > %(deadline)s)
+                ) AS uncovered
+              FROM data_freshness_index
+             WHERE source = %(source)s
+            """,
+            {"source": source, "deadline": deadline},
+        )
+        row = cur.fetchone()
+    if row is None:
+        return (0, 0)
+    return (int(row[0]), int(row[1]))
+
+
+def _manifest_failure_counts(
+    conn: psycopg.Connection[Any],
+    *,
+    source: str,
+    deadline: datetime,
+) -> tuple[int, int]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) FILTER (WHERE ingest_status = 'failed') AS total,
+                COUNT(*) FILTER (
+                  WHERE ingest_status = 'failed'
+                    AND (next_retry_at IS NULL OR next_retry_at > %(deadline)s)
+                ) AS uncovered
+              FROM sec_filing_manifest
+             WHERE source = %(source)s
+            """,
+            {"source": source, "deadline": deadline},
+        )
+        row = cur.fetchone()
+    if row is None:
+        return (0, 0)
+    return (int(row[0]), int(row[1]))
+
+
+def _is_failed_scope_covered(
+    conn: psycopg.Connection[Any],
+    *,
+    process_id: str,
+    next_fire_at: datetime | None,
+    kill_switch_active: bool,
+) -> bool:
+    """True when the next scheduled fire provably reattempts the failed scope.
+
+    Spec §"Auto-hide-on-retry rule" / "Covered" check (post-W2).
+
+    Codex pre-push round 1 BLOCKING: the check must prove EVERY
+    failed row has retry coverage; an existential probe was wrong.
+
+    Codex pre-push round 2 BLOCKING: for jobs with BOTH a
+    ``freshness_source`` and a ``manifest_source`` (e.g.
+    ``sec_filing_documents_ingest`` post-WARNING fix), the check must
+    consider ALL applicable sources together. A short-circuit on the
+    first covered source could auto-hide errors while another source's
+    failed rows remain uncovered.
+
+    Final shape: enumerate every applicable source. Any uncovered
+    failure on any applicable source → False. At least one source
+    must contribute a positive ``total`` (otherwise nothing is
+    actionable and there is no scope to cover).
+
+    Kill-switch + no-cadence both short-circuit to False so a paused
+    or one-shot job never enters auto-hide.
+    """
+    if kill_switch_active or next_fire_at is None:
+        return False
+    freshness_source = freshness_source_for(process_id)
+    manifest_source = manifest_source_for(process_id)
+    if freshness_source is None and manifest_source is None:
+        return False
+    cumulative_total = 0
+    if freshness_source is not None:
+        total, uncovered = _freshness_failure_counts(conn, source=freshness_source, deadline=next_fire_at)
+        if uncovered > 0:
+            return False
+        cumulative_total += total
+    if manifest_source is not None:
+        total, uncovered = _manifest_failure_counts(conn, source=manifest_source, deadline=next_fire_at)
+        if uncovered > 0:
+            return False
+        cumulative_total += total
+    return cumulative_total > 0
+
+
 # ---------------------------------------------------------------------------
 # Builders
 # ---------------------------------------------------------------------------
@@ -376,37 +492,57 @@ def _build_error_summaries(
 def _build_row(
     job: ScheduledJob,
     *,
+    conn: psycopg.Connection[Any],
     active_row: dict[str, Any] | None,
     terminal_row: dict[str, Any] | None,
     has_inflight_request: bool,
     fence_held: bool,
     kill_switch_active: bool,
 ) -> ProcessRow:
+    # next_fire_at: always compute against ``now`` rather than the last
+    # successful run — the operator wants "when will this fire next?",
+    # which APScheduler answers identically regardless of the prior
+    # outcome. ``compute_next_run`` is pure cadence math so it is safe to
+    # call from the API process (no APScheduler consult). PR4 needs it
+    # before status computation so the covered-check can compare against
+    # the next-fire deadline.
+    next_fire_at: datetime | None = compute_next_run(job.cadence, datetime.now(UTC))
+
     last_terminal_status = terminal_row["status"] if terminal_row is not None else None
+    failed_scope_covered = False
+    if last_terminal_status == "failure" and not has_inflight_request:
+        # Only probe the per-source covered check when it could affect
+        # the status (last terminal failed AND no explicit retry is
+        # already in flight).
+        failed_scope_covered = _is_failed_scope_covered(
+            conn,
+            process_id=job.name,
+            next_fire_at=next_fire_at,
+            kill_switch_active=kill_switch_active,
+        )
+
     process_status = _status_for(
         has_running_row=active_row is not None,
         last_terminal_status=last_terminal_status,
         has_inflight_request=has_inflight_request,
         kill_switch_active=kill_switch_active,
+        failed_scope_covered=failed_scope_covered,
     )
 
     last_run = _build_last_run(terminal_row) if terminal_row is not None else None
     active_run = _build_active_run(active_row) if active_row is not None else None
 
-    # Auto-hide-on-retry: hide error chips while a retry covers the failed
-    # scope. PR3 only knows about explicit Iterate-in-flight; the
-    # "next-fire-within-window" branch lands in PR4 with the watermark
-    # resolver.
+    # Auto-hide-on-retry: hide error chips when status is running (retry
+    # in flight) or pending_retry (next fire covers failed scope). Only
+    # surface grouped errors in the actionable ``failed`` state.
     last_n_errors: tuple[ErrorClassSummary, ...] = ()
     if process_status == "failed" and terminal_row is not None:
         last_n_errors = _build_error_summaries(terminal_row.get("error_classes"))
 
-    # next_fire_at: always compute against ``now`` rather than the last
-    # successful run — the operator wants "when will this fire next?",
-    # which APScheduler answers identically regardless of the prior
-    # outcome. ``compute_next_run`` is pure cadence math so it is safe to
-    # call from the API process (no APScheduler consult).
-    next_fire_at: datetime | None = compute_next_run(job.cadence, datetime.now(UTC))
+    # PR4 watermark — surface the resume cursor on the FE tooltip.
+    # Returns None for jobs without a registered source (heartbeat,
+    # monitor_positions, …); the FE renders that as "no resume cursor".
+    watermark = resolve_watermark(conn, process_id=job.name, mechanism="scheduled_job")
 
     can_cancel = (
         active_run is not None and active_run.run_id is not None and process_status == "running"
@@ -427,7 +563,7 @@ def _build_row(
         cadence_human=job.cadence.label,
         cadence_cron=_cron_for(job.cadence),
         next_fire_at=next_fire_at,
-        watermark=None,  # PR4
+        watermark=watermark,
         can_iterate=(
             not kill_switch_active and not has_inflight_request and not fence_held and process_status != "running"
         ),
@@ -459,6 +595,7 @@ def list_rows(conn: psycopg.Connection[Any]) -> list[ProcessRow]:
         rows.append(
             _build_row(
                 job,
+                conn=conn,
                 active_row=active_row,
                 terminal_row=terminal_row,
                 has_inflight_request=has_inflight_request,
@@ -476,6 +613,7 @@ def get_row(conn: psycopg.Connection[Any], *, process_id: str) -> ProcessRow | N
         return None
     return _build_row(
         job,
+        conn=conn,
         active_row=_read_running_run(conn, job_name=job.name),
         terminal_row=_read_latest_terminal_run(conn, job_name=job.name),
         has_inflight_request=_has_inflight_manual_request(conn, job_name=job.name),

--- a/app/services/processes/watermarks.py
+++ b/app/services/processes/watermarks.py
@@ -1,0 +1,628 @@
+"""Per-process watermark resolver for the admin control hub.
+
+Issue #1073 (umbrella #1064).
+Spec: ``docs/superpowers/specs/2026-05-08-admin-control-hub-rewrite.md``
+      §"Watermark + resume contract" / §PR4.
+
+PR3 left ``ProcessRow.watermark = None`` on every row. PR4 adds a
+per-mechanism resolver that reads the relevant existing source table
+(``data_freshness_index``, ``sec_filing_manifest``,
+``external_data_watermarks``, ``bootstrap_stages``,
+``n_port_ingest_log``, ``price_daily``, ``pending_job_requests``) and
+produces a ``ProcessWatermark`` for the FE tooltip + the trigger
+handler's full-wash reset.
+
+The resolver is purely read-only: it does not mutate state. The
+full-wash reset SQL lives in ``app/api/processes.py::_apply_full_wash_reset``
+(same module that already holds the per-mechanism precondition checks)
+so the reset and the durable fence INSERT happen inside the same
+advisory-lock-held transaction. This module exposes the per-job source
+identifiers (``freshness_source_for``, ``manifest_source_for``,
+``atom_etag_target_for``) so the trigger handler + the auto-hide
+covered check both read from a single source of truth.
+
+Spec gaps that PR4 explicitly leaves at ``watermark=None`` (with
+follow-up tickets in #1064's umbrella tracking):
+
+- ``sync_runs.layer_state_at_finish`` does NOT exist as a column
+  (sql/033 + sql/041 + sql/086 + sql/139 each only ALTER scope/status/
+  cancel columns). ``orchestrator_full_sync`` therefore returns None
+  until that column lands.
+- ``instrument_market_data_refresh`` does NOT exist as a table. The
+  candle refresh resolver substitutes a global ``MAX(price_date) FROM
+  price_daily`` summary so the operator still sees a meaningful
+  cursor; per-instrument fan-out is deferred.
+- Some scheduled jobs have no watermark source (``heartbeat``,
+  ``monitor_positions``, ``weekly_report``, …). The resolver returns
+  None for those — full-wash on a no-watermark job is just "rerun"
+  with no reset step.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.services.processes import ProcessMechanism, ProcessWatermark
+from app.services.watermarks import get_watermark
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-job source registry
+# ---------------------------------------------------------------------------
+#
+# A single source-of-truth mapping that drives:
+#   * the watermark resolver (FE tooltip + per-row ``ProcessRow.watermark``)
+#   * the full-wash reset SQL (trigger handler)
+#   * the auto-hide covered check (scheduled adapter status)
+#
+# The registry is keyed by ``process_id`` (= job_name for scheduled
+# jobs, "bootstrap" for the bootstrap orchestrator). Each entry pins
+# one of:
+#   * ``freshness_source`` — ``data_freshness_index.source`` value
+#                            (filed_at cursor; full-wash resets to NULL)
+#   * ``manifest_source`` — ``sec_filing_manifest.source`` value
+#                           (accession cursor; full-wash resets to pending)
+#   * ``atom_etag``       — (source, key, display) for ``external_data_watermarks``
+#                           (full-wash deletes the ETag row)
+#   * ``custom``          — special-cased mechanisms (bootstrap stages,
+#                           candle MAX, NPORT log, universe epoch).
+#
+# Jobs absent from this map have no watermark surface; full-wash on
+# them is a no-reset rerun.
+
+
+@dataclass(frozen=True, slots=True)
+class _AtomEtagTarget:
+    source: str
+    key: str
+    display: str
+
+
+@dataclass(frozen=True, slots=True)
+class _JobSpec:
+    """One entry in the per-job source registry.
+
+    Exactly one of ``freshness_source`` / ``manifest_source`` /
+    ``atom_etag`` / ``custom`` is non-None. ``display`` is the
+    operator-facing label that appears in the watermark tooltip
+    ("Form 4", "DEF 14A", "company_tickers.json"); the resolver
+    falls back to ``process_id`` if absent.
+    """
+
+    display: str
+    freshness_source: str | None = None
+    manifest_source: str | None = None
+    atom_etag: _AtomEtagTarget | None = None
+    custom: str | None = None
+
+
+_JOB_REGISTRY: dict[str, _JobSpec] = {
+    # Universe (epoch cursor — custom resolver)
+    "nightly_universe_sync": _JobSpec(display="universe sweep", custom="universe_epoch"),
+    # Candles (instrument_offset cursor — custom resolver against price_daily)
+    "daily_candle_refresh": _JobSpec(display="daily candles", custom="candle_offset"),
+    # SEC submissions ingest (filed_at via data_freshness_index)
+    "sec_form3_ingest": _JobSpec(display="Form 3", freshness_source="sec_form3"),
+    "sec_insider_transactions_ingest": _JobSpec(display="Form 4", freshness_source="sec_form4"),
+    "sec_def14a_ingest": _JobSpec(display="DEF 14A", freshness_source="sec_def14a"),
+    "sec_8k_events_ingest": _JobSpec(display="8-K", freshness_source="sec_8k"),
+    "daily_financial_facts": _JobSpec(display="XBRL facts", freshness_source="sec_xbrl_facts"),
+    "fundamentals_sync": _JobSpec(display="XBRL facts", freshness_source="sec_xbrl_facts"),
+    "sec_business_summary_ingest": _JobSpec(display="XBRL facts", freshness_source="sec_xbrl_facts"),
+    # NPORT (accession cursor via n_port_ingest_log; full-wash uses
+    # freshness_source='sec_n_port' so the freshness scheduler reseeds
+    # NPORT subjects from scratch).
+    "sec_n_port_ingest": _JobSpec(
+        display="N-PORT",
+        custom="n_port_accession",
+        freshness_source="sec_n_port",
+    ),
+    # Manifest-driven workers (accession cursor via sec_filing_manifest).
+    # Full-wash also resets the freshness scheduler so the post-reset
+    # poller can rediscover missing accessions, not just re-parse known
+    # ones (Codex pre-push WARNING).
+    "sec_filing_documents_ingest": _JobSpec(
+        display="Form 4 manifest",
+        manifest_source="sec_form4",
+        freshness_source="sec_form4",
+    ),
+    # Atom ETag (external_data_watermarks)
+    "daily_cik_refresh": _JobSpec(
+        display="company_tickers.json",
+        atom_etag=_AtomEtagTarget(source="sec.tickers", key="global", display="company_tickers.json"),
+    ),
+    # NOTE: orchestrator_full_sync intentionally absent. Spec §"Adapter
+    # map" predicates its watermark on ``sync_runs.layer_state_at_finish``
+    # which does not exist as a column in this repo. Leaving unresolved
+    # per spec guidance; follow-up tracked under #1064.
+}
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap — stage_index cursor
+# ---------------------------------------------------------------------------
+
+
+def _resolve_bootstrap_stage_index(
+    conn: psycopg.Connection[Any],
+) -> ProcessWatermark | None:
+    """Bootstrap watermark: max(stage_order) of last ``success`` per lane.
+
+    Spec §"Adapter map" — Bootstrap stages → ``stage_index``.
+
+    The cursor_value is a stable lane→stage_order rendering for the
+    operator: ``"etoro:2,sec:14"``. ``human`` is the rendered tooltip
+    text. ``last_advanced_at`` is the most recent completed_at across
+    the success rows so a stalled run still shows the right "last
+    advanced" timestamp on the tooltip.
+
+    Returns None when there is no bootstrap_runs row yet (fresh install
+    pre-first-trigger) — surfacing an empty cursor would mislead the
+    operator into thinking the next iterate has work to resume from.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT MAX(id) AS run_id FROM bootstrap_runs")
+        run = cur.fetchone()
+    if run is None or run["run_id"] is None:
+        return None
+    run_id = int(run["run_id"])
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT lane,
+                   MAX(stage_order)  AS max_order,
+                   MAX(completed_at) AS last_completed_at
+              FROM bootstrap_stages
+             WHERE bootstrap_run_id = %(run_id)s
+               AND status           = 'success'
+             GROUP BY lane
+             ORDER BY lane
+            """,
+            {"run_id": run_id},
+        )
+        rows = cur.fetchall()
+    if not rows:
+        # Run exists but no stage has reached 'success' yet — nothing
+        # to resume from. Iterate would re-pick at stage_order=1 which
+        # is exactly what an empty watermark conveys; surface None so
+        # the FE tooltip says "no progress yet" rather than "0 of N".
+        return None
+
+    cursor_parts: list[str] = []
+    last_advanced_at: datetime | None = None
+    for row in rows:
+        lane = str(row["lane"])
+        max_order = int(row["max_order"])
+        cursor_parts.append(f"{lane}:{max_order}")
+        completed_at = row["last_completed_at"]
+        if completed_at is not None and (last_advanced_at is None or completed_at > last_advanced_at):
+            last_advanced_at = completed_at
+    cursor_value = ",".join(cursor_parts)
+    if last_advanced_at is None:
+        # Defence-in-depth: a 'success' row without completed_at would
+        # be a producer bug (mark_stage_success sets completed_at).
+        # Falling back to "now" would lie about the cursor age, so omit
+        # the watermark entirely.
+        return None
+    human = f"Resume after stages [{cursor_value}] (last advanced {last_advanced_at.isoformat()})"
+    return ProcessWatermark(
+        cursor_kind="stage_index",
+        cursor_value=cursor_value,
+        human=human,
+        last_advanced_at=last_advanced_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-cursor-kind resolvers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_universe_sync_epoch(
+    conn: psycopg.Connection[Any],
+) -> ProcessWatermark | None:
+    """Universe sync watermark: latest completed manual/scheduled run id.
+
+    Spec §"Adapter map" — Universe sync uses ``pending_job_requests``
+    last successful run row id as a coarse-grained ``epoch`` cursor.
+    The universe sync is fully idempotent at the row level (UPSERT on
+    ``instruments``); the cursor is informational only — operator sees
+    "latest universe pull was epoch=12345 at 2026-05-08T03:00Z" rather
+    than a fine-grained subject cursor.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT request_id, requested_at
+              FROM pending_job_requests
+             WHERE job_name = 'nightly_universe_sync'
+               AND status   = 'completed'
+             ORDER BY request_id DESC
+             LIMIT 1
+            """
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    request_id = int(row["request_id"])
+    requested_at = row["requested_at"]
+    if requested_at is None:
+        return None
+    cursor_value = str(request_id)
+    human = f"Resume after universe epoch #{request_id} (last advanced {requested_at.isoformat()})"
+    return ProcessWatermark(
+        cursor_kind="epoch",
+        cursor_value=cursor_value,
+        human=human,
+        last_advanced_at=requested_at,
+    )
+
+
+def _resolve_candle_offset(
+    conn: psycopg.Connection[Any],
+) -> ProcessWatermark | None:
+    """Candle refresh watermark: global MAX(price_date) FROM price_daily.
+
+    Spec lists ``instrument_market_data_refresh.last_synced_at`` as the
+    source, but that table does not exist in this repo — the daily
+    candle refresh writes directly to ``price_daily``. The operator
+    surface still wants a single "resume from" cursor; use the global
+    MAX so a stale sweep is visible at a glance. Per-instrument cursor
+    fan-out (which would let the resolver report "12 of 1547
+    instruments awaiting next poll") is deferred to a follow-up.
+
+    Cursor is the ISO date string. ``last_advanced_at`` is the
+    ``price_date`` coerced to a UTC midnight so the ProcessWatermark
+    contract (TIMESTAMPTZ field) holds — ``price_daily`` does not
+    carry a writer-side updated_at.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT MAX(price_date) AS max_date FROM price_daily")
+        row = cur.fetchone()
+    if row is None or row["max_date"] is None:
+        return None
+    max_date = row["max_date"]
+    cursor_value = max_date.isoformat()
+    last_advanced_at = datetime(max_date.year, max_date.month, max_date.day, tzinfo=UTC)
+    human = f"Resume from candles after {cursor_value}"
+    return ProcessWatermark(
+        cursor_kind="instrument_offset",
+        cursor_value=cursor_value,
+        human=human,
+        last_advanced_at=last_advanced_at,
+    )
+
+
+def _resolve_n_port_accession(
+    conn: psycopg.Connection[Any],
+) -> ProcessWatermark | None:
+    """NPORT watermark: max accession + max fetched_at across SUCCESS rows.
+
+    Spec §"Adapter map" — N-PORT uses ``n_port_ingest_log`` last
+    processed accession as ``accession`` cursor.
+
+    Accession numbers do not sort chronologically across CIKs (the
+    middle YY field bites you across year boundaries; the last sequence
+    is filer-local). Codex pre-push WARNING — order by ``fetched_at``
+    DESC and return the matching accession instead of MAX().
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT accession_number, fetched_at
+              FROM n_port_ingest_log
+             WHERE status = 'success'
+             ORDER BY fetched_at DESC, accession_number DESC
+             LIMIT 1
+            """
+        )
+        row = cur.fetchone()
+    if row is None or row["accession_number"] is None:
+        return None
+    cursor_value = str(row["accession_number"])
+    last_advanced_at = row["fetched_at"]
+    if last_advanced_at is None:
+        return None
+    human = f"Resume after accession {cursor_value} (last advanced {last_advanced_at.isoformat()})"
+    return ProcessWatermark(
+        cursor_kind="accession",
+        cursor_value=cursor_value,
+        human=human,
+        last_advanced_at=last_advanced_at,
+    )
+
+
+def _resolve_filed_at(
+    conn: psycopg.Connection[Any],
+    *,
+    source: str,
+    display: str,
+) -> ProcessWatermark | None:
+    """Resolve ``filed_at`` cursor via ``data_freshness_index``.
+
+    ``last_known_filed_at`` is the per-subject pointer to "newest
+    accession seen for this (subject, source) in steady-state". The
+    operator-facing watermark is the global MAX across all subjects
+    of that source.
+
+    ``human`` includes the count of subjects whose
+    ``state IN ('expected_filing_overdue', 'unknown')`` — the
+    "awaiting next poll" cohort the operator sees in the freshness
+    sweeper. Mirrors spec §"Watermark sources" tooltip example.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT MAX(last_known_filed_at) AS max_filed_at,
+                   COUNT(*)                  AS subjects_total,
+                   COUNT(*) FILTER (
+                     WHERE state IN ('expected_filing_overdue', 'unknown')
+                   )                         AS subjects_awaiting
+              FROM data_freshness_index
+             WHERE source = %(source)s
+            """,
+            {"source": source},
+        )
+        row = cur.fetchone()
+    if row is None or row["max_filed_at"] is None:
+        return None
+    max_filed_at = row["max_filed_at"]
+    subjects_total = int(row["subjects_total"])
+    subjects_awaiting = int(row["subjects_awaiting"])
+    cursor_value = max_filed_at.isoformat()
+    human = (
+        f"Resume from {display} filings filed after {cursor_value}"
+        f" ({subjects_awaiting} of {subjects_total} subjects awaiting next poll)"
+    )
+    return ProcessWatermark(
+        cursor_kind="filed_at",
+        cursor_value=cursor_value,
+        human=human,
+        last_advanced_at=max_filed_at,
+    )
+
+
+def _resolve_manifest_accession(
+    conn: psycopg.Connection[Any],
+    *,
+    source: str,
+    display: str,
+) -> ProcessWatermark | None:
+    """Manifest worker watermark: max accession + retry telemetry.
+
+    Spec §"Adapter map" — SEC manifest worker uses
+    ``sec_filing_manifest.next_retry_at`` + ``last_attempted_at`` as
+    ``accession`` cursor. The operator-visible value is "newest
+    accession we have on file for this source"; the suffix surfaces
+    the count of pending+failed accessions awaiting drain.
+
+    Codex pre-push WARNING: accession lexicographic order is not
+    global filing order across CIKs. Order by ``filed_at`` DESC and
+    return the matching accession. The pending-count is computed in
+    a separate aggregate query so the LIMIT 1 ordering doesn't
+    interfere with the COUNT.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT accession_number, filed_at
+              FROM sec_filing_manifest
+             WHERE source = %(source)s
+             ORDER BY filed_at DESC, accession_number DESC
+             LIMIT 1
+            """,
+            {"source": source},
+        )
+        row = cur.fetchone()
+    if row is None or row["accession_number"] is None:
+        return None
+    max_acc = str(row["accession_number"])
+    max_filed_at = row["filed_at"]
+    if max_filed_at is None:
+        return None
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) FILTER (WHERE ingest_status IN ('pending', 'failed')) AS pending_count
+              FROM sec_filing_manifest
+             WHERE source = %(source)s
+            """,
+            {"source": source},
+        )
+        agg = cur.fetchone()
+    pending = 0 if agg is None else int(agg["pending_count"])
+    cursor_value = max_acc
+    suffix = "" if pending == 0 else f" ({pending} accessions awaiting drain)"
+    human = f"Resume after {display} accession {max_acc} (filed {max_filed_at.isoformat()}){suffix}"
+    return ProcessWatermark(
+        cursor_kind="accession",
+        cursor_value=cursor_value,
+        human=human,
+        last_advanced_at=max_filed_at,
+    )
+
+
+def _resolve_atom_etag(
+    conn: psycopg.Connection[Any],
+    *,
+    target: _AtomEtagTarget,
+) -> ProcessWatermark | None:
+    """Atom ETag watermark from ``external_data_watermarks``.
+
+    The provider-native ETag string is opaque (``Last-Modified``
+    header value, response_hash, accession). Surfacing it verbatim is
+    fine — operator only needs to know "we're at the same provider
+    state we saw at <fetched_at>".
+    """
+    wm = get_watermark(conn, target.source, target.key)
+    if wm is None:
+        return None
+    last_advanced_at = wm.watermark_at or wm.fetched_at
+    cursor_value = wm.watermark
+    human = f"Provider {target.display} unchanged since {last_advanced_at.isoformat()}"
+    return ProcessWatermark(
+        cursor_kind="atom_etag",
+        cursor_value=cursor_value,
+        human=human,
+        last_advanced_at=last_advanced_at,
+    )
+
+
+_CUSTOM_RESOLVERS: dict[str, Callable[[psycopg.Connection[Any]], ProcessWatermark | None]] = {
+    "universe_epoch": _resolve_universe_sync_epoch,
+    "candle_offset": _resolve_candle_offset,
+    "n_port_accession": _resolve_n_port_accession,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API — watermark
+# ---------------------------------------------------------------------------
+
+
+def resolve_watermark(
+    conn: psycopg.Connection[Any],
+    *,
+    process_id: str,
+    mechanism: ProcessMechanism,
+) -> ProcessWatermark | None:
+    """Return the per-process watermark, or None if no source applies.
+
+    Caller is the adapter (bootstrap/scheduled/ingest_sweep) inside
+    ``snapshot_read(conn)`` so the watermark read sees the same
+    REPEATABLE READ snapshot as the rest of the row's data. Callers
+    upstream of the adapter (e.g. the trigger handler) MUST NOT rely
+    on this for atomicity — the trigger handler holds the per-process
+    advisory lock and reads/resets watermark state inside its own
+    transaction.
+
+    A None return is honest: it means "no watermark applies" (e.g.
+    heartbeat job) OR "the source has no rows yet" (e.g. fresh install
+    pre-first-poll). The adapter renders None as "no resume cursor"
+    in the FE tooltip; the trigger handler treats None as "full-wash
+    has nothing to reset" and goes straight to the queue INSERT.
+    """
+    if mechanism == "bootstrap":
+        return _safely(_resolve_bootstrap_stage_index, conn, process_id)
+    if mechanism == "ingest_sweep":
+        # PR6 wires per-source ingest sweep rows; PR4 has nothing to
+        # surface here.
+        return None
+    spec = _JOB_REGISTRY.get(process_id)
+    if spec is None:
+        return None
+    if spec.custom is not None:
+        custom = _CUSTOM_RESOLVERS.get(spec.custom)
+        if custom is None:
+            return None
+        return _safely(custom, conn, process_id)
+    # Priority: manifest > freshness > atom_etag. A job may carry both
+    # ``manifest_source`` AND ``freshness_source`` (the manifest worker
+    # for SEC Form 4 also resets the freshness scheduler on full-wash);
+    # the operator-facing cursor for that job is the manifest accession,
+    # not the freshness max(filed_at). Freshness-only jobs (Form 3,
+    # DEF 14A, …) are unaffected because they leave ``manifest_source``
+    # unset.
+    if spec.manifest_source is not None:
+        m_source = spec.manifest_source
+        m_display = spec.display
+        return _safely(
+            lambda c: _resolve_manifest_accession(c, source=m_source, display=m_display),
+            conn,
+            process_id,
+        )
+    if spec.freshness_source is not None:
+        source = spec.freshness_source
+        display = spec.display
+        return _safely(lambda c: _resolve_filed_at(c, source=source, display=display), conn, process_id)
+    if spec.atom_etag is not None:
+        target = spec.atom_etag
+        return _safely(lambda c: _resolve_atom_etag(c, target=target), conn, process_id)
+    return None
+
+
+def _safely(
+    fn: Callable[[psycopg.Connection[Any]], ProcessWatermark | None],
+    conn: psycopg.Connection[Any],
+    process_id: str,
+) -> ProcessWatermark | None:
+    """Invoke a resolver and swallow any exception as ``watermark=None``.
+
+    Per spec §"Failure-mode invariants": a per-row resolver failure
+    must not 500 the snapshot. The adapter's outer try/except in
+    ``app/api/processes.py::_gather_snapshot`` is the cross-row safety
+    net; this is the per-row guard so one resolver bug doesn't blank
+    out an entire mechanism.
+    """
+    try:
+        return fn(conn)
+    except Exception:
+        logger.exception(
+            "watermark resolver raised for process_id=%r; surfacing watermark=None",
+            process_id,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API — sources for full-wash + covered-check
+# ---------------------------------------------------------------------------
+
+
+def freshness_source_for(process_id: str) -> str | None:
+    """Return the ``data_freshness_index.source`` value for a job, or None.
+
+    Used by:
+      * ``app/api/processes.py::_apply_full_wash_reset`` to issue the
+        ``UPDATE data_freshness_index SET last_known_filed_at = NULL,
+        state = 'unknown' WHERE source = ?`` reset.
+      * ``scheduled_adapter._is_failed_scope_covered`` to query whether
+        a freshness recheck is scheduled within the next-fire window.
+    """
+    spec = _JOB_REGISTRY.get(process_id)
+    return None if spec is None else spec.freshness_source
+
+
+def manifest_source_for(process_id: str) -> str | None:
+    """Return the ``sec_filing_manifest.source`` value for a job, or None.
+
+    Used by:
+      * ``_apply_full_wash_reset`` to issue the ``UPDATE
+        sec_filing_manifest SET ingest_status='pending',
+        last_attempted_at=NULL, next_retry_at=NULL WHERE source = ?``
+        reset.
+      * ``_is_failed_scope_covered`` to query whether failed manifest
+        rows have a ``next_retry_at`` within the next-fire window.
+    """
+    spec = _JOB_REGISTRY.get(process_id)
+    return None if spec is None else spec.manifest_source
+
+
+def atom_etag_target_for(process_id: str) -> tuple[str, str] | None:
+    """Return ``(source, key)`` for ``external_data_watermarks``, or None.
+
+    Used by ``_apply_full_wash_reset`` to issue the ``DELETE FROM
+    external_data_watermarks WHERE source = ? AND key = ?`` reset.
+    """
+    spec = _JOB_REGISTRY.get(process_id)
+    if spec is None or spec.atom_etag is None:
+        return None
+    return (spec.atom_etag.source, spec.atom_etag.key)
+
+
+__all__ = [
+    "atom_etag_target_for",
+    "freshness_source_for",
+    "manifest_source_for",
+    "resolve_watermark",
+]

--- a/app/services/processes/watermarks.py
+++ b/app/services/processes/watermarks.py
@@ -620,9 +620,84 @@ def atom_etag_target_for(process_id: str) -> tuple[str, str] | None:
     return (spec.atom_etag.source, spec.atom_etag.key)
 
 
+def jobs_sharing_freshness_source(source: str) -> tuple[str, ...]:
+    """Return every process_id whose ``freshness_source`` equals ``source``.
+
+    Used by the trigger handler's full-wash precondition to refuse a
+    reset while ANY sibling job consuming the same scheduler source is
+    mid-run. Several jobs intentionally consume the same XBRL feed
+    (``daily_financial_facts`` / ``fundamentals_sync`` /
+    ``sec_business_summary_ingest`` all → ``sec_xbrl_facts``); a
+    full-wash on one of them resets the shared
+    ``data_freshness_index`` rows under the others' feet without this
+    sibling check.
+    """
+    return tuple(pid for pid, spec in _JOB_REGISTRY.items() if spec.freshness_source == source)
+
+
+def jobs_sharing_manifest_source(source: str) -> tuple[str, ...]:
+    """Return every process_id whose ``manifest_source`` equals ``source``.
+
+    Counterpart to ``jobs_sharing_freshness_source`` for the
+    ``sec_filing_manifest`` reset path.
+    """
+    return tuple(pid for pid, spec in _JOB_REGISTRY.items() if spec.manifest_source == source)
+
+
+def acquire_shared_source_locks(
+    conn: psycopg.Connection[Any],
+    *,
+    process_id: str,
+) -> None:
+    """Take advisory locks for every scheduler source ``process_id`` consumes.
+
+    The per-process advisory lock acquired by
+    ``app.services.process_stop.acquire_prelude_lock`` only serialises
+    operations under the SAME ``process_id``. When multiple jobs share
+    a freshness/manifest source (e.g. ``daily_financial_facts``,
+    ``fundamentals_sync``, ``sec_business_summary_ingest`` all
+    consume ``sec_xbrl_facts``), a full-wash trigger on one and a
+    prelude for another hold DIFFERENT per-process locks and can race
+    on the shared scheduler rows.
+
+    This helper takes ``pg_advisory_xact_lock`` on a per-source key
+    (``hashtext('source:freshness:<src>')`` /
+    ``hashtext('source:manifest:<src>')``) so every code path that
+    touches a shared scheduler source serialises against every other
+    code path that touches it — regardless of ``process_id``.
+
+    Locks are acquired in deterministic order (sorted source label) to
+    rule out deadlocks across pairs of callers acquiring different
+    permutations of the same set. Caller MUST be inside an open
+    transaction; locks are released at COMMIT/ROLLBACK like the
+    per-process variant.
+
+    Codex pre-push round 7 BLOCKING: without source-keyed locking,
+    the trigger handler's fence INSERT and the sibling prelude's
+    fence-check race in opposite-tx-order — sibling reads pre-INSERT
+    state, writes ``job_runs.running``, commits AFTER the full-wash
+    fence commits, then runs against the reset source.
+    """
+    sources: list[str] = []
+    fresh = freshness_source_for(process_id)
+    if fresh is not None:
+        sources.append(f"source:freshness:{fresh}")
+    manifest = manifest_source_for(process_id)
+    if manifest is not None:
+        sources.append(f"source:manifest:{manifest}")
+    if not sources:
+        return
+    with conn.cursor() as cur:
+        for key in sorted(sources):
+            cur.execute("SELECT pg_advisory_xact_lock(hashtext(%s)::bigint)", (key,))
+
+
 __all__ = [
+    "acquire_shared_source_locks",
     "atom_etag_target_for",
     "freshness_source_for",
+    "jobs_sharing_freshness_source",
+    "jobs_sharing_manifest_source",
     "manifest_source_for",
     "resolve_watermark",
 ]

--- a/tests/test_bootstrap_adapter.py
+++ b/tests/test_bootstrap_adapter.py
@@ -290,6 +290,52 @@ def test_aggregates_skip_reasons_across_archives(
     }
 
 
+def test_watermark_surfaces_stage_index_after_success(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR4: bootstrap row carries a ``stage_index`` watermark with the
+    last successful stage_order per lane."""
+    run_id = _create_run(ebull_test_conn, status="partial_error", completed=True)
+    _create_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="init",
+        stage_order=0,
+        lane="init",
+        status="success",
+        completed=True,
+    )
+    _create_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="etoro_meta",
+        stage_order=1,
+        lane="etoro",
+        status="success",
+        completed=True,
+    )
+    _create_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_form4",
+        stage_order=5,
+        lane="sec",
+        status="error",
+        completed=True,
+    )
+    _seed_state(ebull_test_conn, status="partial_error", last_run_id=run_id)
+    ebull_test_conn.commit()
+
+    row = bootstrap_adapter.get_row(ebull_test_conn)
+    assert row is not None
+    assert row.watermark is not None
+    assert row.watermark.cursor_kind == "stage_index"
+    # Failed sec_form4 stage NOT counted; etoro/init successes ARE.
+    assert "etoro:1" in row.watermark.cursor_value
+    assert "init:0" in row.watermark.cursor_value
+    assert "sec:" not in row.watermark.cursor_value
+
+
 def test_full_wash_fence_disables_buttons(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_jobs_runtime_fence.py
+++ b/tests/test_jobs_runtime_fence.py
@@ -110,6 +110,50 @@ def test_prelude_fence_held_writes_skipped_and_does_not_run_invoker(
     assert invoked_signal is False
 
 
+def test_prelude_fence_held_by_sibling_sharing_freshness_source(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR4 (#1075 / #1073 Codex round 5/6): the prelude fence check
+    must walk sibling jobs sharing the same scheduler source.
+
+    A full-wash fence on ``daily_financial_facts`` (process_id) must
+    cause an APScheduler fire of ``fundamentals_sync`` (sibling on
+    ``freshness_source='sec_xbrl_facts'``) to self-skip — otherwise
+    the sibling worker reads the just-reset ``data_freshness_index``
+    rows under the holder's feet.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO pending_job_requests
+            (request_kind, job_name, process_id, mode, status)
+        VALUES ('manual_job', 'daily_financial_facts',
+                'daily_financial_facts', 'full_wash', 'dispatched')
+        """
+    )
+    ebull_test_conn.commit()
+
+    invoked: list[bool] = []
+
+    def _invoker() -> None:
+        invoked.append(True)
+
+    invoked_signal = jobs_runtime.run_with_prelude(
+        test_database_url(),
+        "fundamentals_sync",
+        _invoker,
+    )
+
+    ebull_test_conn.rollback()
+    _, status, error_msg = _read_latest_job_run(ebull_test_conn, job_name="fundamentals_sync")
+    assert status == "skipped"
+    assert error_msg is not None
+    assert "shared scheduler source" in error_msg
+    assert "daily_financial_facts" in error_msg
+    assert invoked == []
+    assert invoked_signal is False
+
+
 def test_prelude_bypass_fence_runs_invoker_even_with_fence_row(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_processes_endpoints.py
+++ b/tests/test_processes_endpoints.py
@@ -273,6 +273,31 @@ def test_full_wash_resets_bootstrap_stages_before_enqueue(
     assert last_error[0] is None
 
 
+def test_bootstrap_full_wash_blocked_while_running(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """Review bot BLOCKING rebuttal: bootstrap's active-run gate is
+    ``bootstrap_state.status='running'`` (not ``_has_active_job_run``).
+    The check happens before ``_apply_full_wash_reset`` so the running
+    orchestrator's bootstrap_stages cannot be reset under it. Pin the
+    behaviour with an explicit test so the symmetry with scheduled-job
+    full-wash protection is auditable.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO bootstrap_runs (status, completed_at)
+        VALUES ('running', NULL)
+        """
+    )
+    _seed_bootstrap_state(ebull_test_conn, "running")
+    ebull_test_conn.commit()
+
+    resp = client.post("/system/processes/bootstrap/trigger", json={"mode": "full_wash"})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason"] == "bootstrap_already_running"
+
+
 def test_trigger_active_scheduled_run_returns_409(
     conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
 ) -> None:

--- a/tests/test_processes_endpoints.py
+++ b/tests/test_processes_endpoints.py
@@ -219,24 +219,98 @@ def test_cancel_invalid_mode_returns_422(conn_override: None) -> None:
     assert resp.status_code == 422
 
 
-def test_full_wash_resets_bootstrap_stages_before_enqueue(
+def test_full_wash_creates_fresh_bootstrap_run_and_flips_state(
     conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
 ) -> None:
-    """PR4 §Full-wash semantics step 5 — bootstrap full-wash flips
-    every non-pending stage on the latest run back to ``pending`` AND
-    inserts the durable fence row, all inside the same advisory-lock-
-    held transaction.
+    """PR4 §Full-wash semantics — bootstrap full-wash creates a fresh
+    ``bootstrap_runs`` row + seeds pending stages + flips
+    ``bootstrap_state.status='running'``. The orchestrator no-ops
+    unless the latest run is in ``running`` status; an in-place
+    UPDATE of stages on the prior run leaves
+    ``bootstrap_runs.status='partial_error'`` and the orchestrator
+    silently does nothing (review bot BLOCKING).
     """
     _ensure_kill_switch_off(ebull_test_conn)
-    run_row = ebull_test_conn.execute(
+    prior = ebull_test_conn.execute(
         """
         INSERT INTO bootstrap_runs (status, completed_at)
         VALUES ('partial_error', now())
         RETURNING id
         """
     ).fetchone()
-    assert run_row is not None
-    run_id = int(run_row[0])
+    assert prior is not None
+    prior_run_id = int(prior[0])
+    ebull_test_conn.execute(
+        """
+        INSERT INTO bootstrap_stages
+            (bootstrap_run_id, stage_key, stage_order, lane, job_name,
+             status, started_at, completed_at, last_error)
+        VALUES (%s, 'init', 0, 'init', 'job_x', 'success', now(), now(), NULL),
+               (%s, 'sec_form4', 5, 'sec', 'job_x', 'error', now(), now(),
+                'EDGAR 503')
+        """,
+        (prior_run_id, prior_run_id),
+    )
+    _seed_bootstrap_state(ebull_test_conn, "partial_error")
+    ebull_test_conn.execute(
+        "UPDATE bootstrap_state SET last_run_id = %s WHERE id = 1",
+        (prior_run_id,),
+    )
+    ebull_test_conn.commit()
+
+    resp = client.post("/system/processes/bootstrap/trigger", json={"mode": "full_wash"})
+    assert resp.status_code == 200, resp.text
+
+    state_row = ebull_test_conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1").fetchone()
+    assert state_row is not None
+    assert state_row[0] == "running"
+    new_run_id = int(state_row[1])
+    assert new_run_id != prior_run_id
+
+    new_run_status = ebull_test_conn.execute(
+        "SELECT status FROM bootstrap_runs WHERE id = %s",
+        (new_run_id,),
+    ).fetchone()
+    assert new_run_status is not None
+    assert new_run_status[0] == "running"
+
+    new_stage_statuses = {
+        row[0]
+        for row in ebull_test_conn.execute(
+            "SELECT DISTINCT status FROM bootstrap_stages WHERE bootstrap_run_id = %s",
+            (new_run_id,),
+        ).fetchall()
+    }
+    assert new_stage_statuses == {"pending"}
+
+    # Prior run's stages are untouched — they retain forensic history.
+    prior_init = ebull_test_conn.execute(
+        "SELECT status FROM bootstrap_stages WHERE bootstrap_run_id = %s AND stage_key = 'init'",
+        (prior_run_id,),
+    ).fetchone()
+    assert prior_init is not None
+    assert prior_init[0] == "success"
+
+
+def test_bootstrap_iterate_resets_failed_stages_and_flips_state(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """PR4 §Iterate semantics — bootstrap iterate flips failed stages
+    back to pending AND flips ``bootstrap_state.status='running'`` so
+    the orchestrator picks them up. PR3 enqueued without flipping
+    state, leaving the orchestrator no-op'd silently (review bot
+    BLOCKING).
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    run = ebull_test_conn.execute(
+        """
+        INSERT INTO bootstrap_runs (status, completed_at)
+        VALUES ('partial_error', now())
+        RETURNING id
+        """
+    ).fetchone()
+    assert run is not None
+    run_id = int(run[0])
     ebull_test_conn.execute(
         """
         INSERT INTO bootstrap_stages
@@ -255,22 +329,82 @@ def test_full_wash_resets_bootstrap_stages_before_enqueue(
     )
     ebull_test_conn.commit()
 
-    resp = client.post("/system/processes/bootstrap/trigger", json={"mode": "full_wash"})
+    resp = client.post("/system/processes/bootstrap/trigger", json={"mode": "iterate"})
     assert resp.status_code == 200, resp.text
 
-    statuses = {
-        row[0]: row[1]
-        for row in ebull_test_conn.execute(
-            "SELECT stage_key, status FROM bootstrap_stages WHERE bootstrap_run_id = %s",
-            (run_id,),
-        ).fetchall()
-    }
-    assert statuses == {"init": "pending", "sec_form4": "pending"}
-    last_error = ebull_test_conn.execute(
-        "SELECT last_error FROM bootstrap_stages WHERE stage_key = 'sec_form4'"
+    state_row = ebull_test_conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1").fetchone()
+    assert state_row is not None
+    assert state_row[0] == "running"
+    assert int(state_row[1]) == run_id  # iterate reuses the same run
+
+    sec_status = ebull_test_conn.execute(
+        "SELECT status, last_error FROM bootstrap_stages WHERE bootstrap_run_id = %s AND stage_key = 'sec_form4'",
+        (run_id,),
     ).fetchone()
-    assert last_error is not None
-    assert last_error[0] is None
+    assert sec_status is not None
+    assert sec_status[0] == "pending"
+    assert sec_status[1] is None
+
+
+def test_full_wash_blocked_when_sibling_has_pending_full_wash_fence(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """Codex review round 5 BLOCKING: the partial UNIQUE on
+    ``pending_job_requests_active_full_wash_idx`` only dedupes by
+    ``process_id``. Two siblings sharing a freshness source can both
+    enqueue full-washes concurrently — each carries its own
+    ``process_id`` — and reset the same scheduler rows. The shared-
+    source check must also probe sibling fences, not just sibling
+    active runs.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO pending_job_requests
+            (request_kind, job_name, process_id, mode, status)
+        VALUES ('manual_job', 'fundamentals_sync', 'fundamentals_sync',
+                'full_wash', 'pending')
+        """
+    )
+    ebull_test_conn.commit()
+
+    resp = client.post(
+        "/system/processes/daily_financial_facts/trigger",
+        json={"mode": "full_wash"},
+    )
+    assert resp.status_code == 409
+    body = resp.json()["detail"]
+    assert body["reason"] == "shared_source_full_wash_pending"
+    assert "fundamentals_sync" in body["advice"]
+
+
+def test_full_wash_blocked_when_sibling_sharing_freshness_source_is_running(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """Codex review BLOCKING: ``daily_financial_facts``,
+    ``fundamentals_sync``, ``sec_business_summary_ingest`` all share
+    ``freshness_source='sec_xbrl_facts'``. A full-wash on one of them
+    resets the shared scheduler rows under any sibling that is
+    currently mid-run. Refuse with ``shared_source_active_run`` until
+    every sibling is idle.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, status)
+        VALUES ('fundamentals_sync', now(), 'running')
+        """
+    )
+    ebull_test_conn.commit()
+
+    resp = client.post(
+        "/system/processes/daily_financial_facts/trigger",
+        json={"mode": "full_wash"},
+    )
+    assert resp.status_code == 409
+    body = resp.json()["detail"]
+    assert body["reason"] == "shared_source_active_run"
+    assert "fundamentals_sync" in body["advice"]
 
 
 def test_bootstrap_full_wash_blocked_while_running(

--- a/tests/test_processes_endpoints.py
+++ b/tests/test_processes_endpoints.py
@@ -12,6 +12,7 @@ from collections.abc import Iterator
 import psycopg
 import pytest
 from fastapi.testclient import TestClient
+from psycopg.types.json import Jsonb
 
 from app.db import get_conn
 from app.main import app
@@ -216,6 +217,377 @@ def test_cancel_invalid_mode_returns_422(conn_override: None) -> None:
         json={"mode": "halt"},
     )
     assert resp.status_code == 422
+
+
+def test_full_wash_resets_bootstrap_stages_before_enqueue(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """PR4 §Full-wash semantics step 5 — bootstrap full-wash flips
+    every non-pending stage on the latest run back to ``pending`` AND
+    inserts the durable fence row, all inside the same advisory-lock-
+    held transaction.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    run_row = ebull_test_conn.execute(
+        """
+        INSERT INTO bootstrap_runs (status, completed_at)
+        VALUES ('partial_error', now())
+        RETURNING id
+        """
+    ).fetchone()
+    assert run_row is not None
+    run_id = int(run_row[0])
+    ebull_test_conn.execute(
+        """
+        INSERT INTO bootstrap_stages
+            (bootstrap_run_id, stage_key, stage_order, lane, job_name,
+             status, started_at, completed_at, last_error)
+        VALUES (%s, 'init', 0, 'init', 'job_x', 'success', now(), now(), NULL),
+               (%s, 'sec_form4', 5, 'sec', 'job_x', 'error', now(), now(),
+                'EDGAR 503')
+        """,
+        (run_id, run_id),
+    )
+    _seed_bootstrap_state(ebull_test_conn, "partial_error")
+    ebull_test_conn.execute(
+        "UPDATE bootstrap_state SET last_run_id = %s WHERE id = 1",
+        (run_id,),
+    )
+    ebull_test_conn.commit()
+
+    resp = client.post("/system/processes/bootstrap/trigger", json={"mode": "full_wash"})
+    assert resp.status_code == 200, resp.text
+
+    statuses = {
+        row[0]: row[1]
+        for row in ebull_test_conn.execute(
+            "SELECT stage_key, status FROM bootstrap_stages WHERE bootstrap_run_id = %s",
+            (run_id,),
+        ).fetchall()
+    }
+    assert statuses == {"init": "pending", "sec_form4": "pending"}
+    last_error = ebull_test_conn.execute(
+        "SELECT last_error FROM bootstrap_stages WHERE stage_key = 'sec_form4'"
+    ).fetchone()
+    assert last_error is not None
+    assert last_error[0] is None
+
+
+def test_trigger_active_scheduled_run_returns_409(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """PR4 Codex BLOCKING: a scheduled trigger landing while a worker
+    is mid-run must 409 with ``active_run_in_progress`` so full-wash
+    cannot reset watermarks under the running worker's feet AND a
+    second iterate cannot double-enqueue."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, status)
+        VALUES (%s, now(), 'running')
+        """,
+        (JOB_RETRY_DEFERRED,),
+    )
+    ebull_test_conn.commit()
+
+    iterate_resp = client.post(
+        f"/system/processes/{JOB_RETRY_DEFERRED}/trigger",
+        json={"mode": "iterate"},
+    )
+    assert iterate_resp.status_code == 409
+    assert iterate_resp.json()["detail"]["reason"] == "active_run_in_progress"
+
+    full_wash_resp = client.post(
+        f"/system/processes/{JOB_RETRY_DEFERRED}/trigger",
+        json={"mode": "full_wash"},
+    )
+    assert full_wash_resp.status_code == 409
+    assert full_wash_resp.json()["detail"]["reason"] == "active_run_in_progress"
+
+
+def test_full_wash_clears_freshness_filing_id_and_makes_rows_immediately_due(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """PR4 Codex BLOCKING: clearing only ``last_known_filed_at`` is
+    not a real epoch reset. The full-wash must also clear
+    ``last_known_filing_id``, ``expected_next_at``, and
+    ``next_recheck_at`` so the post-reset rows qualify for
+    ``idx_freshness_due_for_poll`` immediately AND the next poll
+    cannot skip historical filings against a stale filing_id pointer.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (9200099, 'TST_FW2', 'TST_FW2 Co', 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO data_freshness_index
+            (subject_type, subject_id, source, last_known_filed_at,
+             last_known_filing_id, expected_next_at, next_recheck_at,
+             state, instrument_id)
+        VALUES ('issuer', '9200099', 'sec_form3',
+                '2026-05-08T12:00:00Z',
+                '0000320193-26-000042',
+                '2026-06-01T00:00:00Z',
+                '2026-06-15T00:00:00Z',
+                'never_filed', 9200099)
+        """
+    )
+    ebull_test_conn.commit()
+
+    resp = client.post(
+        "/system/processes/sec_form3_ingest/trigger",
+        json={"mode": "full_wash"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    row = ebull_test_conn.execute(
+        """
+        SELECT last_known_filed_at, last_known_filing_id, expected_next_at,
+               next_recheck_at, state
+          FROM data_freshness_index
+         WHERE source = 'sec_form3'
+           AND subject_id = '9200099'
+        """
+    ).fetchone()
+    assert row is not None
+    assert row[0] is None  # last_known_filed_at cleared
+    assert row[1] is None  # last_known_filing_id cleared
+    assert row[2] is None  # expected_next_at cleared
+    assert row[3] is None  # next_recheck_at cleared
+    assert row[4] == "unknown"
+
+
+def test_mixed_covered_and_uncovered_failed_rows_stays_failed(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """PR4 Codex BLOCKING: covered-check must prove EVERY failed row
+    has coverage. One uncovered row keeps the status at ``failed`` so
+    operator-visible errors are not auto-hidden by a single due retry
+    when other rows have no retry within the window.
+    """
+    from app.services.processes import scheduled_adapter
+
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status,
+                              error_classes, rows_errored)
+        VALUES ('sec_form3_ingest', now() - interval '5 minutes', now(),
+                'failure', %s, 2)
+        """,
+        (
+            Jsonb(
+                {
+                    "RateLimited": {
+                        "count": 2,
+                        "sample_message": "429",
+                        "last_subject": "AAPL",
+                        "last_seen_at": "2026-05-09T11:00:00+00:00",
+                    }
+                }
+            ),
+        ),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (9200201, 'TST_MIX1', 'TST_MIX1 Co', 'TEST', 'USD', TRUE),
+               (9200202, 'TST_MIX2', 'TST_MIX2 Co', 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO data_freshness_index
+            (subject_type, subject_id, source, state, next_recheck_at,
+             instrument_id)
+        VALUES
+            -- Covered: retry due in 5 minutes (well within next fire)
+            ('issuer', '9200201', 'sec_form3', 'error',
+             now() + interval '5 minutes', 9200201),
+            -- Uncovered: NULL next_recheck_at means no scheduled retry
+            ('issuer', '9200202', 'sec_form3', 'error', NULL, 9200202)
+        """
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id="sec_form3_ingest")
+    assert row is not None
+    # Mixed coverage → status stays failed, errors visible.
+    assert row.status == "failed"
+    assert len(row.last_n_errors) == 1
+
+
+def test_multi_source_covered_check_requires_all_sources_covered(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """Codex pre-push round 2 BLOCKING: a job with BOTH freshness +
+    manifest sources (e.g. ``sec_filing_documents_ingest``) must keep
+    ``status='failed'`` when ANY applicable source has uncovered
+    failures. Coverage on one source does not mask uncovered failures
+    on the other.
+    """
+    from app.services.processes import scheduled_adapter
+
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status,
+                              error_classes, rows_errored)
+        VALUES ('sec_filing_documents_ingest', now() - interval '5 minutes',
+                now(), 'failure', %s, 1)
+        """,
+        (
+            Jsonb(
+                {
+                    "ParseError": {
+                        "count": 1,
+                        "sample_message": "malformed XML",
+                        "last_subject": None,
+                        "last_seen_at": "2026-05-09T11:00:00+00:00",
+                    }
+                }
+            ),
+        ),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (9200301, 'TST_MULTI', 'TST_MULTI Co', 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    # Freshness side: ALL covered (one error row with retry due soon).
+    ebull_test_conn.execute(
+        """
+        INSERT INTO data_freshness_index
+            (subject_type, subject_id, source, state, next_recheck_at,
+             instrument_id)
+        VALUES ('issuer', '9200301', 'sec_form4', 'error',
+                now() + interval '5 minutes', 9200301)
+        """
+    )
+    # Manifest side: one UNCOVERED failed row (next_retry_at = NULL).
+    ebull_test_conn.execute(
+        """
+        INSERT INTO sec_filing_manifest
+            (accession_number, cik, form, source, subject_type, subject_id,
+             instrument_id, filed_at, ingest_status, next_retry_at)
+        VALUES ('0000000099-26-000001', '0000123', '4', 'sec_form4',
+                'issuer', '9200301', 9200301, now() - interval '1 day',
+                'failed', NULL)
+        """
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(
+        ebull_test_conn,
+        process_id="sec_filing_documents_ingest",
+    )
+    assert row is not None
+    assert row.status == "failed"
+    assert len(row.last_n_errors) == 1
+
+
+def test_full_wash_resets_freshness_index_for_sec_ingest(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """PR4 §Full-wash semantics step 5 — SEC ingest jobs reset
+    ``data_freshness_index`` for the source: ``last_known_filed_at``
+    flips to NULL and ``state`` flips to ``unknown``."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (9200001, 'TST_FW', 'TST_FW Co', 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO data_freshness_index
+            (subject_type, subject_id, source, last_known_filed_at, state,
+             instrument_id)
+        VALUES ('issuer', '9200001', 'sec_form3', '2026-05-08T12:00:00Z',
+                'current', 9200001)
+        """
+    )
+    ebull_test_conn.commit()
+
+    resp = client.post(
+        "/system/processes/sec_form3_ingest/trigger",
+        json={"mode": "full_wash"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    row = ebull_test_conn.execute(
+        """
+        SELECT last_known_filed_at, state
+          FROM data_freshness_index
+         WHERE source = 'sec_form3'
+           AND subject_id = '9200001'
+        """
+    ).fetchone()
+    assert row is not None
+    assert row[0] is None
+    assert row[1] == "unknown"
+
+
+def test_iterate_does_not_reset_freshness_index(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """PR4 §Iterate semantics — Iterate never resets the watermark.
+
+    Idempotency is at the ingest layer (ON CONFLICT). Confirm the
+    handler does NOT mutate ``data_freshness_index`` on iterate.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (9200002, 'TST_ITR', 'TST_ITR Co', 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    original_filed_at = "2026-05-08T12:00:00+00:00"
+    ebull_test_conn.execute(
+        """
+        INSERT INTO data_freshness_index
+            (subject_type, subject_id, source, last_known_filed_at, state,
+             instrument_id)
+        VALUES ('issuer', '9200002', 'sec_form3', %s, 'current', 9200002)
+        """,
+        (original_filed_at,),
+    )
+    ebull_test_conn.commit()
+
+    resp = client.post(
+        "/system/processes/sec_form3_ingest/trigger",
+        json={"mode": "iterate"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    row = ebull_test_conn.execute(
+        """
+        SELECT last_known_filed_at, state
+          FROM data_freshness_index
+         WHERE source = 'sec_form3'
+           AND subject_id = '9200002'
+        """
+    ).fetchone()
+    assert row is not None
+    assert row[0] is not None  # untouched
+    assert row[1] == "current"
 
 
 def test_partial_flag_when_adapter_throws(

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -262,6 +262,119 @@ def test_list_runs_returns_terminal_history(
     assert statuses == {"success", "failure"}
 
 
+def test_watermark_surfaces_filed_at_for_sec_ingest_job(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR4: SEC freshness-driven jobs surface a ``filed_at`` watermark
+    on the ProcessRow."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (9100001, 'TST_F3', 'TST_F3 Co', 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO data_freshness_index
+            (subject_type, subject_id, source, last_known_filed_at, state,
+             instrument_id)
+        VALUES ('issuer', '9100001', 'sec_form3', '2026-05-08T12:00:00Z',
+                'current', 9100001)
+        """
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id="sec_form3_ingest")
+    assert row is not None
+    assert row.watermark is not None
+    assert row.watermark.cursor_kind == "filed_at"
+    assert row.watermark.cursor_value.startswith("2026-05-08")
+
+
+def test_pending_retry_status_when_freshness_recheck_covers_failed_scope(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR4: spec §"Auto-hide-on-retry rule" / "Covered" check.
+
+    Latest terminal run is failure, no inflight Iterate, but
+    data_freshness_index has an error-state subject with
+    ``next_recheck_at`` <= next_fire_at — the next scheduled fire will
+    reattempt the failed scope. Status flips from ``failed`` to
+    ``pending_retry`` with empty errors.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    _make_run(
+        ebull_test_conn,
+        job_name="sec_form3_ingest",
+        status="failure",
+        finished=True,
+        rows_errored=1,
+        error_classes={
+            "RateLimited": {
+                "count": 1,
+                "sample_message": "429",
+                "last_subject": "AAPL",
+                "last_seen_at": "2026-05-09T11:00:00+00:00",
+            }
+        },
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (9100002, 'TST_RC', 'TST_RC Co', 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO data_freshness_index
+            (subject_type, subject_id, source, state, next_recheck_at,
+             instrument_id)
+        VALUES ('issuer', '9100002', 'sec_form3', 'error',
+                now() + interval '5 minutes', 9100002)
+        """
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id="sec_form3_ingest")
+    assert row is not None
+    assert row.status == "pending_retry"
+    assert row.last_n_errors == ()
+
+
+def test_failed_status_when_no_freshness_recheck_covers_failed_scope(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The covered-check is conservative — without an error-state
+    freshness row inside the next-fire window, the row stays ``failed``."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    _make_run(
+        ebull_test_conn,
+        job_name="sec_form3_ingest",
+        status="failure",
+        finished=True,
+        rows_errored=1,
+        error_classes={
+            "RateLimited": {
+                "count": 1,
+                "sample_message": "429",
+                "last_subject": "AAPL",
+                "last_seen_at": "2026-05-09T11:00:00+00:00",
+            }
+        },
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id="sec_form3_ingest")
+    assert row is not None
+    assert row.status == "failed"
+    assert len(row.last_n_errors) == 1
+
+
 def test_list_run_errors_decodes_jsonb(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_watermark_resolver.py
+++ b/tests/test_watermark_resolver.py
@@ -1,0 +1,600 @@
+"""Watermark resolver tests (#1073, umbrella #1064 PR4).
+
+Spec: ``docs/superpowers/specs/2026-05-08-admin-control-hub-rewrite.md``
+      §"Watermark + resume contract" + §PR4 test plan.
+
+Each ``cursor_kind`` round-trips against the worker ``ebull_test``
+template DB. Mocking psycopg cursors loses the SQL-shape guarantees
+the resolver relies on (MAX(...) FILTER, JSONB column types, the
+freshness-index partial indexes); spec test plan also explicitly asks
+for per-cursor-kind round-trips so the regression risk catches schema
+drift downstream.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import psycopg
+
+from app.services.processes.watermarks import (
+    atom_etag_target_for,
+    freshness_source_for,
+    manifest_source_for,
+    resolve_watermark,
+)
+
+# ---------------------------------------------------------------------------
+# Bootstrap — stage_index cursor
+# ---------------------------------------------------------------------------
+
+
+def _seed_bootstrap_run(conn: psycopg.Connection[tuple]) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO bootstrap_runs (status, completed_at)
+        VALUES ('running', NULL)
+        RETURNING id
+        """
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _seed_bootstrap_stage(
+    conn: psycopg.Connection[tuple],
+    *,
+    run_id: int,
+    stage_key: str,
+    stage_order: int,
+    lane: str,
+    status: str,
+    completed_offset_seconds: int = 0,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO bootstrap_stages
+               (bootstrap_run_id, stage_key, stage_order, lane, job_name,
+                status, started_at, completed_at)
+        VALUES (%s, %s, %s, %s, 'job_x',
+                %s,
+                CASE WHEN %s != 'pending' THEN now() - make_interval(secs => %s) ELSE NULL END,
+                CASE WHEN %s = 'success' THEN now() - make_interval(secs => %s) ELSE NULL END)
+        """,
+        (
+            run_id,
+            stage_key,
+            stage_order,
+            lane,
+            status,
+            status,
+            completed_offset_seconds,
+            status,
+            completed_offset_seconds,
+        ),
+    )
+
+
+def test_resolve_bootstrap_stage_index_round_trip(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    run_id = _seed_bootstrap_run(ebull_test_conn)
+    _seed_bootstrap_stage(
+        ebull_test_conn, run_id=run_id, stage_key="init", stage_order=0, lane="init", status="success"
+    )
+    _seed_bootstrap_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="etoro_meta",
+        stage_order=1,
+        lane="etoro",
+        status="success",
+        completed_offset_seconds=10,
+    )
+    _seed_bootstrap_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_form4",
+        stage_order=5,
+        lane="sec",
+        status="success",
+        completed_offset_seconds=5,
+    )
+    _seed_bootstrap_stage(
+        ebull_test_conn, run_id=run_id, stage_key="sec_def14a", stage_order=6, lane="sec", status="pending"
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(ebull_test_conn, process_id="bootstrap", mechanism="bootstrap")
+    assert wm is not None
+    assert wm.cursor_kind == "stage_index"
+    # Lane order is stable: init (0), etoro (1), sec (5).
+    assert wm.cursor_value == "etoro:1,init:0,sec:5"
+    assert "Resume after stages" in wm.human
+
+
+def test_resolve_bootstrap_returns_none_when_no_runs(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.commit()
+    wm = resolve_watermark(ebull_test_conn, process_id="bootstrap", mechanism="bootstrap")
+    assert wm is None
+
+
+def test_resolve_bootstrap_returns_none_when_no_success_stage(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    run_id = _seed_bootstrap_run(ebull_test_conn)
+    _seed_bootstrap_stage(
+        ebull_test_conn, run_id=run_id, stage_key="init", stage_order=0, lane="init", status="running"
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(ebull_test_conn, process_id="bootstrap", mechanism="bootstrap")
+    # A run exists but no stage has reached 'success'; nothing to resume from.
+    assert wm is None
+
+
+# ---------------------------------------------------------------------------
+# Universe sync — epoch cursor
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_universe_sync_epoch_round_trip(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.execute(
+        """
+        INSERT INTO pending_job_requests
+            (request_kind, job_name, status, requested_at)
+        VALUES ('manual_job', 'nightly_universe_sync', 'completed',
+                now() - interval '1 hour')
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO pending_job_requests
+            (request_kind, job_name, status, requested_at)
+        VALUES ('manual_job', 'nightly_universe_sync', 'completed', now())
+        """
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="nightly_universe_sync",
+        mechanism="scheduled_job",
+    )
+    assert wm is not None
+    assert wm.cursor_kind == "epoch"
+    # cursor_value is stringified request_id; specific value depends
+    # on sequence state across the test run, so just shape-check.
+    assert wm.cursor_value.isdigit()
+    assert "Resume after universe epoch" in wm.human
+
+
+def test_resolve_universe_sync_epoch_returns_none_when_no_completed_run(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.execute(
+        """
+        INSERT INTO pending_job_requests
+            (request_kind, job_name, status)
+        VALUES ('manual_job', 'nightly_universe_sync', 'pending')
+        """
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="nightly_universe_sync",
+        mechanism="scheduled_job",
+    )
+    assert wm is None
+
+
+# ---------------------------------------------------------------------------
+# Candle refresh — instrument_offset cursor
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (%s, %s, %s, 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Co"),
+    )
+
+
+def test_resolve_candle_offset_round_trip(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    iid = 9_000_001
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TST_WM")
+    ebull_test_conn.execute(
+        """
+        INSERT INTO price_daily (instrument_id, price_date, open, high, low, close, volume)
+        VALUES (%s, '2026-05-01', 1, 1, 1, 1, 1),
+               (%s, '2026-05-08', 2, 2, 2, 2, 2)
+        ON CONFLICT DO NOTHING
+        """,
+        (iid, iid),
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="daily_candle_refresh",
+        mechanism="scheduled_job",
+    )
+    assert wm is not None
+    assert wm.cursor_kind == "instrument_offset"
+    # MAX(price_date) is at least 2026-05-08; could be later if other
+    # tests insert newer dates against the shared template.
+    assert wm.cursor_value >= "2026-05-08"
+    assert "Resume from candles" in wm.human
+
+
+# ---------------------------------------------------------------------------
+# NPORT — accession cursor (n_port_ingest_log)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_n_port_accession_round_trip(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.execute(
+        """
+        INSERT INTO n_port_ingest_log (accession_number, filer_cik, status, fetched_at)
+        VALUES ('0000000001-26-000001', '0000123', 'success', now() - interval '1 day'),
+               ('0000000002-26-000001', '0000123', 'success', now())
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO n_port_ingest_log (accession_number, filer_cik, status, fetched_at)
+        VALUES ('0000000003-26-000001', '0000123', 'failed', now())
+        """
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="sec_n_port_ingest",
+        mechanism="scheduled_job",
+    )
+    assert wm is not None
+    assert wm.cursor_kind == "accession"
+    # Failed accession (000003) must NOT be the cursor — only success
+    # rows count for "last processed".
+    assert wm.cursor_value == "0000000002-26-000001"
+
+
+# ---------------------------------------------------------------------------
+# SEC submissions — filed_at cursor (data_freshness_index)
+# ---------------------------------------------------------------------------
+
+
+def _seed_freshness_row(
+    conn: psycopg.Connection[tuple],
+    *,
+    source: str,
+    subject_id: str,
+    last_known_filed_at: datetime,
+    state: str = "current",
+    next_recheck_at: datetime | None = None,
+    instrument_id: int | None = None,
+    subject_type: str = "issuer",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO data_freshness_index
+            (subject_type, subject_id, source, last_known_filed_at, state,
+             next_recheck_at, cik, instrument_id)
+        VALUES (%s, %s, %s, %s, %s, %s, NULL, %s)
+        """,
+        (subject_type, subject_id, source, last_known_filed_at, state, next_recheck_at, instrument_id),
+    )
+
+
+def test_resolve_filed_at_round_trip(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    iid_a = 9_000_010
+    iid_b = 9_000_011
+    _seed_instrument(ebull_test_conn, iid=iid_a, symbol="TST_F3A")
+    _seed_instrument(ebull_test_conn, iid=iid_b, symbol="TST_F3B")
+    older = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+    newer = datetime(2026, 5, 8, 12, 0, 0, tzinfo=UTC)
+    _seed_freshness_row(
+        ebull_test_conn,
+        source="sec_form3",
+        subject_id=str(iid_a),
+        last_known_filed_at=older,
+        instrument_id=iid_a,
+    )
+    _seed_freshness_row(
+        ebull_test_conn,
+        source="sec_form3",
+        subject_id=str(iid_b),
+        last_known_filed_at=newer,
+        state="expected_filing_overdue",
+        instrument_id=iid_b,
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="sec_form3_ingest",
+        mechanism="scheduled_job",
+    )
+    assert wm is not None
+    assert wm.cursor_kind == "filed_at"
+    assert wm.cursor_value == newer.isoformat()
+    assert wm.last_advanced_at == newer
+    # 1 of 2 awaiting (the overdue one); subjects_total counts both.
+    assert "1 of 2 subjects awaiting next poll" in wm.human
+
+
+def test_resolve_filed_at_returns_none_when_source_empty(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.commit()
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="sec_form3_ingest",
+        mechanism="scheduled_job",
+    )
+    assert wm is None
+
+
+# ---------------------------------------------------------------------------
+# Manifest worker — accession cursor (sec_filing_manifest)
+# ---------------------------------------------------------------------------
+
+
+def _seed_manifest_row(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession_number: str,
+    source: str,
+    instrument_id: int,
+    filed_at: datetime,
+    ingest_status: str = "parsed",
+    next_retry_at: datetime | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO sec_filing_manifest
+            (accession_number, cik, form, source,
+             subject_type, subject_id, instrument_id, filed_at,
+             ingest_status, next_retry_at)
+        VALUES (%s, '0000123', '4', %s, 'issuer', %s, %s, %s, %s, %s)
+        """,
+        (
+            accession_number,
+            source,
+            str(instrument_id),
+            instrument_id,
+            filed_at,
+            ingest_status,
+            next_retry_at,
+        ),
+    )
+
+
+def test_resolve_manifest_accession_round_trip(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    iid = 9_000_020
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TST_MAN")
+    older = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+    newer = datetime(2026, 5, 8, 12, 0, 0, tzinfo=UTC)
+    _seed_manifest_row(
+        ebull_test_conn,
+        accession_number="0000000001-26-000001",
+        source="sec_form4",
+        instrument_id=iid,
+        filed_at=older,
+    )
+    _seed_manifest_row(
+        ebull_test_conn,
+        accession_number="0000000002-26-000002",
+        source="sec_form4",
+        instrument_id=iid,
+        filed_at=newer,
+        ingest_status="pending",
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="sec_filing_documents_ingest",
+        mechanism="scheduled_job",
+    )
+    assert wm is not None
+    assert wm.cursor_kind == "accession"
+    assert wm.cursor_value == "0000000002-26-000002"
+    assert "1 accessions awaiting drain" in wm.human
+
+
+# ---------------------------------------------------------------------------
+# Atom ETag — external_data_watermarks
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_atom_etag_round_trip(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.execute(
+        """
+        INSERT INTO external_data_watermarks
+            (source, key, watermark, watermark_at, fetched_at, response_hash)
+        VALUES ('sec.tickers', 'global', 'W/"abc123"',
+                now() - interval '2 hours', now() - interval '5 minutes', 'hash')
+        """
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="daily_cik_refresh",
+        mechanism="scheduled_job",
+    )
+    assert wm is not None
+    assert wm.cursor_kind == "atom_etag"
+    assert wm.cursor_value == 'W/"abc123"'
+    assert "company_tickers.json" in wm.human
+
+
+def test_resolve_atom_etag_returns_none_when_no_row(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.commit()
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="daily_cik_refresh",
+        mechanism="scheduled_job",
+    )
+    assert wm is None
+
+
+# ---------------------------------------------------------------------------
+# Unmapped jobs / unknown mechanism
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_returns_none_for_unmapped_job(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="heartbeat",
+        mechanism="scheduled_job",
+    )
+    assert wm is None
+
+
+def test_resolve_returns_none_for_ingest_sweep_mechanism(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="anything",
+        mechanism="ingest_sweep",
+    )
+    assert wm is None
+
+
+# ---------------------------------------------------------------------------
+# Source-helper registry consistency
+# ---------------------------------------------------------------------------
+
+
+def test_source_helpers_round_trip() -> None:
+    assert freshness_source_for("sec_form3_ingest") == "sec_form3"
+    assert freshness_source_for("sec_insider_transactions_ingest") == "sec_form4"
+    assert freshness_source_for("sec_def14a_ingest") == "sec_def14a"
+    assert freshness_source_for("sec_8k_events_ingest") == "sec_8k"
+    assert freshness_source_for("daily_financial_facts") == "sec_xbrl_facts"
+    assert freshness_source_for("fundamentals_sync") == "sec_xbrl_facts"
+    assert freshness_source_for("sec_business_summary_ingest") == "sec_xbrl_facts"
+    assert freshness_source_for("sec_n_port_ingest") == "sec_n_port"
+    # Unmapped jobs must return None — the trigger handler treats None
+    # as "no freshness reset to issue".
+    assert freshness_source_for("heartbeat") is None
+    assert freshness_source_for("daily_candle_refresh") is None  # uses custom resolver
+
+
+def test_manifest_source_helpers_round_trip() -> None:
+    assert manifest_source_for("sec_filing_documents_ingest") == "sec_form4"
+    assert manifest_source_for("sec_form3_ingest") is None  # freshness-only
+    assert manifest_source_for("heartbeat") is None
+
+
+def test_atom_etag_helper_round_trip() -> None:
+    assert atom_etag_target_for("daily_cik_refresh") == ("sec.tickers", "global")
+    assert atom_etag_target_for("sec_form3_ingest") is None
+    assert atom_etag_target_for("heartbeat") is None
+
+
+# ---------------------------------------------------------------------------
+# Resolver swallows exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_swallows_unexpected_exception(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A per-row resolver failure must not 500 the snapshot.
+
+    Spec §"Failure-mode invariants". Inject a resolver that raises and
+    confirm the public ``resolve_watermark`` returns None instead of
+    propagating.
+    """
+
+    class _BadConn:
+        # Minimal stub that lets the resolver get past type-narrowing
+        # but raises on cursor() access — typical SQLSTATE-08006 shape.
+        def cursor(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            raise psycopg.OperationalError("connection broken")
+
+    wm = resolve_watermark(
+        _BadConn(),  # type: ignore[arg-type]
+        process_id="sec_form3_ingest",
+        mechanism="scheduled_job",
+    )
+    assert wm is None
+
+
+# ---------------------------------------------------------------------------
+# Resume-after-cancel guarantee (idempotent replay, NOT transactional)
+# ---------------------------------------------------------------------------
+
+
+def test_resume_after_cancel_via_idempotent_manifest_cohort(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Spec §"Resume after cancel" + post-Codex B6.
+
+    The watermark advance is per-accession on commit. Cancel mid-drain
+    means the next Iterate sees the same ``WHERE ingest_status='pending'``
+    cohort minus the accessions already ingested. We model this by:
+      1. Seeding a 3-accession cohort, all pending.
+      2. Marking the first as parsed (= ingester succeeded on it before
+         cancel landed).
+      3. Asserting the manifest watermark surfaces the pending cohort
+         count = 2 (one drained, two awaiting).
+    The Iterate path itself does no SQL; the pending-cohort-minus-drained
+    invariant lives in the manifest worker's existing ON CONFLICT
+    upsert (sql/118 idx_manifest_status_retry).
+    """
+    iid = 9_000_030
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TST_RC")
+    base = datetime(2026, 5, 8, 12, 0, 0, tzinfo=UTC)
+    for offset, accession, status in [
+        (0, "0000000001-26-000001", "parsed"),
+        (1, "0000000002-26-000001", "pending"),
+        (2, "0000000003-26-000001", "pending"),
+    ]:
+        _seed_manifest_row(
+            ebull_test_conn,
+            accession_number=accession,
+            source="sec_form4",
+            instrument_id=iid,
+            filed_at=base + timedelta(seconds=offset),
+            ingest_status=status,
+        )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="sec_filing_documents_ingest",
+        mechanism="scheduled_job",
+    )
+    assert wm is not None
+    assert wm.cursor_kind == "accession"
+    # pending count is the cohort the next iterate has yet to drain.
+    assert "2 accessions awaiting drain" in wm.human


### PR DESCRIPTION
## What

- New `app/services/processes/watermarks.py` — per-mechanism resolver returning `ProcessWatermark | None` for each `cursor_kind` (`filed_at`, `accession`, `instrument_offset`, `stage_index`, `epoch`, `atom_etag`).
- Adapters now populate `ProcessRow.watermark` (PR3 left None on every row).
- `_is_failed_scope_covered` flips status to `pending_retry` when the next scheduled fire provably reattempts the failed scope.
- Trigger handler `full_wash` mode runs the per-mechanism reset BEFORE the queue INSERT, in the same advisory-lock-held transaction.
- Trigger handler now refuses with `409 active_run_in_progress` while a `job_runs` row is `status='running'` (spec §"Full-wash execution fence" step 4).

## Why

PR3 (#1072) wired the `/system/processes` envelope but every row had `watermark=None` and full-wash skipped the reset step. PR4 closes both halves so the operator surface matches the spec.

## Test plan

- [x] `tests/test_watermark_resolver.py` — per-cursor-kind round-trip + empty-source returns None + resume-after-cancel idempotent cohort.
- [x] `tests/test_bootstrap_adapter.py` — stage_index watermark.
- [x] `tests/test_scheduled_adapter.py` — filed_at watermark + pending_retry covered-check + failed status when no coverage.
- [x] `tests/test_processes_endpoints.py` — full-wash resets bootstrap stages + full freshness epoch reset; iterate does NOT mutate freshness; active scheduled run blocks both modes; mixed covered/uncovered stays `failed`; multi-source covered-check requires ALL sources covered.
- [x] `tests/smoke/test_app_boots.py` — `/system/processes` envelope still 200.
- [x] Codex pre-push 3 rounds (R1: 3 BLOCKING + 2 WARNING; R2: 1 BLOCKING; R3: clean).
- [x] All four gates: `ruff check`, `ruff format --check`, `pyright`, `pytest -n 1` on touched scope (144 tests).

## Out of scope

- FE tooltip rendering of `human` string → PR5.
- `ingest_sweep_adapter` impl → PR6.
- `orchestrator_full_sync` watermark — spec sources `sync_runs.layer_state_at_finish` which does not exist; documented inline + follow-up tracked under #1064.
- Per-instrument candle cursor — `instrument_market_data_refresh` table does not exist; substitute a global `MAX(price_date)` summary; per-instrument fan-out deferred.

Refs #1064. Closes #1073.