### PR TITLE
feat(#1064): PR1a — job registry foundation (source-lock + ParamMetadata + params_snapshot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ tmp_pytest/
 
 # Session-private agent prompts
 .claude/prompts/
+
+# Working scratchpads (plans, drafts) — not committed
+docs/internal/
+

--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -220,6 +220,16 @@ def serve(stop_event: threading.Event | None = None) -> int:
     fence_conn = _acquire_singleton_fence(settings.database_url)
     logger.info("jobs entrypoint: singleton fence acquired")
 
+    # PR1a #1064 — fail-fast at jobs entrypoint if SCHEDULED_JOBS and
+    # _BOOTSTRAP_STAGE_SPECS disagree on a job_name's source. Mirrors
+    # the FastAPI lifespan guard in app/main.py — surfaces conflicts
+    # before any APScheduler fire or queue dispatch can mark a stage
+    # 'running' against a misresolved lock.
+    from app.jobs.sources import get_job_name_to_source
+
+    get_job_name_to_source()
+    logger.info("jobs entrypoint: source registry validated")
+
     _bootstrap_master_key(pool)
 
     sync_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="jobs-sync")

--- a/app/jobs/locks.py
+++ b/app/jobs/locks.py
@@ -1,38 +1,61 @@
-"""Per-job advisory locks.
+"""Source-level advisory locks.
 
-A job that is already running must not be allowed to start again
-concurrently -- whether the second start comes from a manual trigger
-double-click, an APScheduler fire that overlaps a still-running manual
-run, or two operators clicking the same button at once. The
-serialisation primitive is a Postgres session-scoped advisory lock
-keyed on a deterministic hash of the job name.
+A job that hits a shared rate-bucket must not be allowed to start
+concurrently with another job in the same bucket -- whether the second
+start comes from a manual trigger double-click, an APScheduler fire
+overlapping a still-running manual run, two operators clicking the
+same button at once, OR a different job_name that happens to share
+the same source. The serialisation primitive is a Postgres
+session-scoped advisory lock keyed on a deterministic hash of the
+job's **source** (operator-locked decision #1064; PR1a refactor).
 
-Why session-scoped (``pg_try_advisory_lock``) rather than
-transaction-scoped (``pg_try_advisory_xact_lock``):
+## Source-level vs per-job semantics
 
-* The job functions in ``app/workers/scheduler.py`` open and close
-  *their own* connections during execution. A transaction-scoped lock
-  would be tied to the wrapper's transaction and either be released
-  before the job finishes, or force every job to run on the same
-  connection it was launched from -- both wrong.
-* A session-scoped lock is held for the lifetime of the connection
-  that took it. We hold that connection in the ``JobLock`` context
-  manager and release the lock explicitly on exit. The lock is
-  guaranteed to be released even if the job raises (the ``finally``
-  in ``__exit__``) and is also released by Postgres if the connection
-  dies (e.g. process crash, network partition) -- so a crashed worker
-  cannot leave a job permanently locked.
+Pre-PR1a: lock keyed on ``hashtext(job_name)``. Two different SEC jobs
+running concurrently would each acquire their own lock and starve the
+shared SEC 10 req/s rate budget — the budget is per-IP, not per-job,
+so per-job locking conflated independent rate buckets.
 
-Why ``hashtext`` and not the bare name:
+Post-PR1a: lock keyed on ``hashtext(f'job_source:{source}')`` where
+``source`` is resolved from the canonical
+``app.jobs.sources.JOB_NAME_TO_SOURCE`` registry. Same-source jobs
+serialise under one lock; cross-source jobs run in parallel. This
+matches the rate-bucket reality: ``sec_rate`` is one bucket;
+``etoro`` is another; ``db`` is another; ``sec_bulk_download`` is
+disjoint from ``sec_rate``.
 
-``pg_advisory_lock`` takes a ``bigint`` (or two ``int4``s). The job
-name is a Python string. ``hashtext`` is a stable Postgres function
-that returns an ``int4`` from a string and is the conventional way to
-key advisory locks on a textual identifier. Two distinct job names
-producing the same hash is theoretically possible but vanishingly
-unlikely with the small set of names in ``SCHEDULED_JOBS``; the
-collision risk is acceptable for v1 and would manifest as "two
-unrelated jobs cannot run concurrently", not as a correctness bug.
+Same-``job_name`` + different ``params`` semantics: the second
+invocation still serialises under the source lock (Codex round-1
+WARNING — per-param-set lock identity is deferred to v2).
+
+## Why session-scoped (``pg_try_advisory_lock``)
+
+The job functions in ``app/workers/scheduler.py`` open and close
+*their own* connections during execution. A transaction-scoped lock
+would be tied to the wrapper's transaction and either be released
+before the job finishes, or force every job to run on the same
+connection it was launched from -- both wrong. A session-scoped lock
+is held for the lifetime of the connection that took it; we hold that
+connection in the ``JobLock`` context manager and release the lock
+explicitly on exit. Postgres also releases automatically if the
+connection dies, so a crashed worker cannot leave a source
+permanently locked.
+
+## Why ``hashtext``
+
+``pg_advisory_lock`` takes a ``bigint`` (or two ``int4``s). The
+``job_source:{source}`` key is a Python string. ``hashtext`` is the
+stable Postgres function that returns an ``int4`` from a string. With
+only five distinct sources, hash collisions are vanishingly unlikely.
+
+## Test fixtures
+
+Production callers MUST resolve job_name through the registry —
+unknown names raise ``KeyError`` at lock acquisition. Tests that need
+a lock keyed on an arbitrary string can use
+``JobLock.test_only_per_name``, which keys the lock on
+``hashtext(job_name)`` directly (the pre-PR1a behaviour). Production
+code never calls this constructor.
 """
 
 from __future__ import annotations
@@ -41,6 +64,8 @@ import logging
 from types import TracebackType
 
 import psycopg
+
+from app.jobs.sources import source_for
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +99,7 @@ class JobAlreadyRunning(RuntimeError):
 
 
 class JobLock:
-    """Context manager that holds a session-scoped advisory lock.
+    """Context manager that holds a session-scoped source-level advisory lock.
 
     Usage::
 
@@ -82,25 +107,54 @@ class JobLock:
             run_the_job()
 
     On enter:
-      * Opens a dedicated short-lived connection (independent of any
-        connection the job itself uses).
-      * Calls ``pg_try_advisory_lock(hashtext(name)::int)``. If the
-        function returns false, raises :class:`JobAlreadyRunning`
+      * Resolves ``job_name -> source`` via ``app.jobs.sources.source_for``.
+        Raises ``KeyError`` if ``job_name`` is unknown (production
+        callers MUST register; tests use
+        :meth:`JobLock.test_only_per_name`).
+      * Opens a dedicated short-lived connection.
+      * Calls ``pg_try_advisory_lock(hashtext('job_source:{source}')::int)``.
+        If the function returns false, raises :class:`JobAlreadyRunning`
         without holding the connection open.
       * If it returns true, the connection is kept open until exit.
 
     On exit:
       * Calls ``pg_advisory_unlock(...)`` and closes the connection.
-        ``pg_advisory_unlock`` returning false at this point would
-        indicate the lock was not held -- it never should be -- and
-        is logged as a warning rather than raised, because the exit
-        path must not mask an in-flight exception.
+        ``pg_advisory_unlock`` returning false would indicate the lock
+        was not held — it never should be — and is logged as a warning
+        rather than raised, because the exit path must not mask an
+        in-flight exception.
     """
 
     def __init__(self, database_url: str, job_name: str) -> None:
         self._database_url = database_url
         self._job_name = job_name
+        self._lock_key = self._lock_key_for(job_name)
         self._conn: psycopg.Connection[object] | None = None
+
+    @staticmethod
+    def _lock_key_for(job_name: str) -> str:
+        """Resolve the source-level lock key for ``job_name``.
+
+        Production path. Raises ``KeyError`` for unknown job_name —
+        the registry is the single source of truth and silent fallback
+        violates the source-lock decision (Codex round-1 BLOCKING).
+        """
+        return f"job_source:{source_for(job_name)}"
+
+    @classmethod
+    def test_only_per_name(cls, database_url: str, job_name: str) -> JobLock:
+        """Test-only escape hatch: lock keyed on ``hashtext(job_name)``.
+
+        Reproduces the pre-PR1a per-name behaviour for unit tests that
+        construct synthetic job names. Production code MUST NOT call
+        this — the registry is the source of truth.
+        """
+        instance = cls.__new__(cls)
+        instance._database_url = database_url
+        instance._job_name = job_name
+        instance._lock_key = job_name  # raw, not source-prefixed
+        instance._conn = None
+        return instance
 
     def __enter__(self) -> JobLock:
         # autocommit=True so we do NOT hold an implicit transaction
@@ -114,7 +168,7 @@ class JobLock:
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT pg_try_advisory_lock(hashtext(%s)::int)",
-                    (self._job_name,),
+                    (self._lock_key,),
                 )
                 row = cur.fetchone()
             if row is None or not row[0]:
@@ -143,7 +197,7 @@ class JobLock:
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT pg_advisory_unlock(hashtext(%s)::int)",
-                    (self._job_name,),
+                    (self._lock_key,),
                 )
                 row = cur.fetchone()
             released = bool(row and row[0])  # type: ignore[index]
@@ -153,13 +207,15 @@ class JobLock:
                 # successful acquire. Log loud rather than raise so we
                 # do not clobber a real exception unwinding through us.
                 logger.warning(
-                    "JobLock release for %r returned false -- lock was not held by this session at exit time",
+                    "JobLock release for %r (key=%r) returned false -- lock was not held by this session at exit time",
                     self._job_name,
+                    self._lock_key,
                 )
         except Exception:
             logger.exception(
-                "JobLock release for %r failed; closing connection anyway",
+                "JobLock release for %r (key=%r) failed; closing connection anyway",
                 self._job_name,
+                self._lock_key,
             )
         finally:
             with _suppress_close_errors():

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -1,0 +1,214 @@
+"""Job source registry — Lane type + JOB_NAME_TO_SOURCE lookup.
+
+PR1a of #1064 admin-control-hub follow-up sequence.
+Plan: docs/internal/plans/pr1-job-registry-refactor.md (uncommitted).
+Audit: docs/wiki/job-registry-audit.md.
+
+## Why a dedicated module
+
+Three things needed to coexist without circular imports:
+
+1. The ``Lane`` Literal type (used by ``ScheduledJob.source``,
+   ``StageSpec.lane``, and the ``JOB_NAME_TO_SOURCE`` lookup).
+2. The ``JobInvoker`` callable alias (used by ``_INVOKERS`` in
+   ``app/jobs/runtime.py`` after PR1b widens the contract).
+3. The ``JOB_NAME_TO_SOURCE`` registry built from BOTH
+   ``SCHEDULED_JOBS`` AND ``_BOOTSTRAP_STAGE_SPECS`` (used by
+   ``JobLock`` to resolve a job_name to its source-keyed lock).
+
+If ``Lane`` lived in ``app/workers/scheduler.py``, the bootstrap
+orchestrator would import scheduler at module-load — currently
+scheduler imports nothing from bootstrap_orchestrator, but the reverse
+direction is heavy. Hoisting to a leaf module avoids the cycle.
+
+## JOB_NAME_TO_SOURCE construction
+
+The lookup MUST cover every job_name that ``JobLock`` may receive:
+
+* Every entry in ``SCHEDULED_JOBS`` (~27 entries).
+* Every entry in ``_BOOTSTRAP_STAGE_SPECS`` whose ``job_name`` is NOT
+  also in ``SCHEDULED_JOBS`` (~10 bootstrap-only entries today —
+  ``nightly_universe_sync``, ``daily_candle_refresh``,
+  ``daily_cik_refresh``, ``sec_bulk_download``, the four
+  ``sec_*_ingest_from_dataset`` entries, ``sec_submissions_files_walk``,
+  and the three bespoke wrapper job names that PR1c will collapse into
+  the SCHEDULED_JOBS set).
+
+Conflict detection: if a job_name appears in both registries with
+different effective sources, raise at module-load. Silent fallback
+violates the locked source-lock decision.
+
+Codex round-1 BLOCKING addressed: no per-name fallback in production.
+``JobLock`` raises ``KeyError`` on unknown job_name (test fixtures
+must register or use the explicit test-only escape hatch).
+
+## Why ``Mapping`` and not ``dict`` for ``JobInvoker`` param
+
+The invoker contract is read-only consumption of the params dict.
+``Mapping`` makes the contract explicit and prevents accidental
+mutation that would diverge ``params_snapshot`` from what the invoker
+actually consumed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, Literal
+
+# ---------------------------------------------------------------------------
+# Type aliases — used across scheduler, bootstrap_orchestrator, locks, runtime.
+# ---------------------------------------------------------------------------
+
+Lane = Literal["init", "etoro", "sec_rate", "sec_bulk_download", "db"]
+"""Source-level concurrency bucket. Operator-locked decision (#1064): same-source
+jobs serialise under one ``JobLock``; cross-source jobs run in parallel.
+
+* ``init`` — universe-sync only. Pre-everything fence; one job total.
+* ``etoro`` — eToro REST budget. ``execute_approved_orders`` +
+  ``daily_candle_refresh`` + ``etoro_lookups_refresh`` +
+  ``exchanges_metadata_refresh`` serialise.
+* ``sec_rate`` — SEC 10 req/s shared per-IP bucket. Every per-CIK +
+  per-accession SEC fetch competes here.
+* ``sec_bulk_download`` — fixed-URL SEC archive downloads. Disjoint
+  from ``sec_rate`` — large fixed downloads, no per-issuer iteration.
+* ``db`` — DB-bound bulk ingest of pre-staged data. Same-source
+  serialise under the source lock (no parallel-DB-stage parallelism;
+  ``_LANE_MAX_CONCURRENCY`` from #1020 is retired in PR1c).
+"""
+
+
+JobInvoker = Callable[[Mapping[str, Any]], None]
+"""Invoker callable shape. PR1a keeps the ``_INVOKERS`` dict zero-arg
+shape unchanged; PR1b widens to this contract so bodies can read
+operator-supplied params via the queue-consumer dispatch path. The
+``Mapping`` contract is read-only — invokers must not mutate the
+``params`` dict (mutation would diverge ``job_runs.params_snapshot``
+from what the invoker consumed)."""
+
+
+# ---------------------------------------------------------------------------
+# JOB_NAME_TO_SOURCE — the canonical source-lookup registry.
+# ---------------------------------------------------------------------------
+#
+# Construction is deferred to ``_build_job_name_to_source()`` (called
+# from a single module-load site at the bottom of this module) so the
+# imports of ``SCHEDULED_JOBS`` + ``_BOOTSTRAP_STAGE_SPECS`` happen
+# AFTER both modules have populated their registries. Any conflict
+# (same job_name appearing in both with different effective sources)
+# raises ``RuntimeError`` at import time — fail-fast prevents the
+# silent source-lock semantic drift Codex round-1 BLOCKING flagged.
+
+
+class JobSourceRegistryError(RuntimeError):
+    """Raised at module-load when JOB_NAME_TO_SOURCE construction fails.
+
+    Two failure modes:
+
+    * Conflict: the same job_name appears in both registries with
+      different effective sources.
+    * Coverage gap: a bootstrap stage references a job_name not in
+      either registry (only triggerable if the bootstrap stage table
+      is hand-edited inconsistently).
+    """
+
+
+def _build_job_name_to_source() -> dict[str, Lane]:
+    """Build the canonical job_name -> source lookup.
+
+    Imports happen inside the function to defer the dependency on
+    ``app/workers/scheduler.py`` and ``app/services/bootstrap_orchestrator.py``
+    until both have populated their respective registries.
+    """
+    # Local imports to avoid module-load cycles.
+    from app.services.bootstrap_orchestrator import (
+        _BOOTSTRAP_STAGE_SPECS,
+        _effective_lane,
+    )
+    from app.workers.scheduler import SCHEDULED_JOBS
+
+    registry: dict[str, Lane] = {}
+
+    # Pass 1: scheduled jobs.
+    for job in SCHEDULED_JOBS:
+        registry[job.name] = job.source
+
+    # Pass 2: bootstrap stages. ``_effective_lane`` consults the
+    # ``_STAGE_LANE_OVERRIDES`` map then falls back to the StageSpec.lane;
+    # the resulting Lane is the source for that job_name when invoked
+    # from bootstrap.
+    conflicts: list[str] = []
+    for stage in _BOOTSTRAP_STAGE_SPECS:
+        bootstrap_source: Lane = _effective_lane(stage.stage_key, stage.lane)  # type: ignore[assignment]
+        existing = registry.get(stage.job_name)
+        if existing is None:
+            registry[stage.job_name] = bootstrap_source
+        elif existing != bootstrap_source:
+            conflicts.append(
+                f"job_name={stage.job_name!r}: scheduled.source={existing!r} vs bootstrap.lane={bootstrap_source!r}"
+            )
+
+    if conflicts:
+        raise JobSourceRegistryError(
+            "Source/lane conflict between SCHEDULED_JOBS and _BOOTSTRAP_STAGE_SPECS:\n  - "
+            + "\n  - ".join(conflicts)
+            + "\nFix the offending entries so a job_name resolves to the same source from both paths."
+        )
+
+    return registry
+
+
+_REGISTRY_CACHE: dict[str, Lane] | None = None
+
+
+def get_job_name_to_source() -> dict[str, Lane]:
+    """Return the canonical job_name -> source lookup, building on first call.
+
+    Lazy construction breaks the import cycle: ``app/workers/scheduler.py``
+    imports the ``Lane`` type from this module at module-load time, so
+    eagerly building the registry here would re-enter scheduler.py mid-load.
+    First call materialises + caches; subsequent calls return the cached dict.
+
+    Any source/lane conflict raises ``JobSourceRegistryError`` at the first
+    call site — typically the FastAPI lifespan or the first ``JobLock``
+    acquisition, both of which are smoke-tested.
+    """
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is None:
+        _REGISTRY_CACHE = _build_job_name_to_source()
+    return _REGISTRY_CACHE
+
+
+def reset_job_name_to_source_cache() -> None:
+    """Test-only reset of the lazy cache. Production code never calls this."""
+    global _REGISTRY_CACHE
+    _REGISTRY_CACHE = None
+
+
+def source_for(job_name: str) -> Lane:
+    """Return the source-lock bucket for ``job_name``.
+
+    Raises ``KeyError`` for unknown job_name. Production callers MUST
+    have the job in ``SCHEDULED_JOBS`` or ``_BOOTSTRAP_STAGE_SPECS``.
+    Test fixtures should register their job in the appropriate registry
+    (or use ``JobLock.test_only_per_name`` once that escape hatch lands
+    in PR1a).
+    """
+    registry = get_job_name_to_source()
+    try:
+        return registry[job_name]
+    except KeyError as exc:
+        raise KeyError(
+            f"unknown job_name {job_name!r}: not found in SCHEDULED_JOBS or "
+            f"_BOOTSTRAP_STAGE_SPECS. Either register it in the appropriate "
+            f"registry (production) or use JobLock.test_only_per_name (tests)."
+        ) from exc
+
+
+__all__ = [
+    "JobInvoker",
+    "JobSourceRegistryError",
+    "Lane",
+    "get_job_name_to_source",
+    "reset_job_name_to_source_cache",
+    "source_for",
+]

--- a/app/main.py
+++ b/app/main.py
@@ -99,6 +99,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     else:
         logger.info("No pending migrations.")
 
+    # PR1a #1064 — fail-fast at lifespan startup if SCHEDULED_JOBS and
+    # _BOOTSTRAP_STAGE_SPECS disagree on a job_name's source. Codex
+    # round-1 BLOCKING: silent fallback violates the source-lock
+    # decision; lazy resolution defers the failure to first JobLock
+    # acquisition (after a bootstrap stage may already be marked
+    # running). Forcing here surfaces the conflict at boot, before any
+    # job dispatch.
+    from app.jobs.sources import get_job_name_to_source
+
+    get_job_name_to_source()
+
     # Open the connection pool after migrations so the schema is up to date.
     pool = open_pool("db_pool", min_size=1, max_size=10)
     logger.info("Connection pool opened (min=1, max=10).")

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -26,7 +26,7 @@ handlers cannot both succeed. The partial unique index on
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal
@@ -81,6 +81,18 @@ class StageSpec:
     stage_order: int
     lane: Lane
     job_name: str
+    # PR1a #1064 — params dict the bootstrap dispatcher passes to the
+    # registered invoker. Default empty mapping = "use the invoker's
+    # registry-default params" (PR1b's materialise_scheduled_params
+    # path). Stages 14, 15, 21 will populate this in PR1c when the
+    # bespoke wrappers collapse — at that point the bootstrap-only
+    # param overrides (e.g. ``min_period_of_report`` for the bounded
+    # 13F sweep, ``filing_types`` for the seed) live here as data,
+    # not in a separate code path. See
+    # ``docs/wiki/job-registry-audit.md`` §4 for the per-wrapper
+    # collapse plan. Mapping rather than dict to signal read-only
+    # consumption — dispatcher must not mutate.
+    params: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -1,0 +1,354 @@
+"""ParamMetadata model + validate_job_params + materialise_scheduled_params.
+
+PR1a of #1064 admin-control-hub follow-up sequence.
+Plan: docs/internal/plans/pr1-job-registry-refactor.md (uncommitted).
+Audit: docs/wiki/job-registry-audit.md.
+
+## Why a Pydantic model + per-job tuple
+
+Operator-locked decision: every scheduled/bootstrap job declares its
+operator-exposable parameter surface as data, not code. The FE Advanced
+disclosure (PR2) renders one form field per ``ParamMetadata`` entry
+based on ``field_type`` — no bespoke per-job React components.
+
+The model is a typed BE contract; ``frontend/src/api/types.ts`` carries
+a hand-written mirror. **Drift between the two is a PREVENTION-grade
+risk** — the FE renders generic Advanced disclosure fields off this
+metadata, so a contract drift means operators see wrong inputs or no
+inputs at all. Round-trip test in
+``tests/test_param_metadata_round_trip.py`` covers one canonical job
+per PR (full coverage is bot-enforced via review-bot reading
+``frontend/src/api/types.ts`` against this module).
+
+## Field-type taxonomy
+
+10 archetypes, picked to cover every operator-exposable knob in
+``docs/wiki/job-registry-audit.md`` §6:
+
+* ``string``        — free text. Reserved; no operator field today
+                      (provenance labels like ``source_label`` are
+                      internal-only).
+* ``int``           — number input with per-param ``min_value`` /
+                      ``max_value`` bounds.
+* ``float``         — number input with bounds + step. Reserved; no
+                      operator field today (data-integrity-cliff knobs
+                      like ``match_threshold`` are NOT exposed).
+* ``date``          — date picker. ``start_date`` / ``end_date`` /
+                      ``since`` / ``min_period_of_report``.
+* ``quarter``       — bespoke ``YYYY[Q1-4]`` widget. Used by
+                      ``cusip_universe_backfill``.
+* ``ticker``        — typeahead resolves company-name/symbol → instrument_id (int).
+* ``cik``           — typeahead resolves company-name/symbol → CIK (str).
+* ``bool``          — checkbox. ``force_full`` / ``dry_run``.
+* ``enum``          — single-select against ``enum_values``.
+* ``multi_enum``    — multi-select against ``enum_values``.
+                      ``filing_types`` / ``layer_allowlist`` /
+                      ``source_filter``.
+
+Rejected from the taxonomy: ``prefetch_urls``, ``follow_pagination``,
+``use_bulk_zip``, ``paginate``, ``source_label``, ``match_threshold``.
+Implementation-strategy knobs and provenance labels DO NOT belong in
+operator UX — code review changes them.
+
+## validate_job_params modes
+
+Single validator, two modes:
+
+* ``allow_internal_keys=False`` — manual API path. Unknown keys
+  rejected with 400. This prevents the operator from setting a
+  provenance ``source_label`` from the Advanced disclosure.
+* ``allow_internal_keys=True`` — bootstrap dispatcher path. The
+  per-job ``JOB_INTERNAL_KEYS`` allow-list permits audit-only keys
+  (e.g. ``sec_13f_quarterly_sweep``: ``{"source_label"}``).
+
+Both modes share the same coercion + bounds checking. Codex round-2
+BLOCKING fix: parallel paths would drift; one validator with a flag
+keeps the contract aligned.
+
+## materialise_scheduled_params
+
+Codex round-3 BLOCKING fix: scheduled cron fires must populate
+``job_runs.params_snapshot`` from the registry's ``ParamMetadata.default``
+values, not a raw ``{}``. Otherwise operator-history visibility regresses
+(operator clicks a row, expects to see the effective params, gets ``{}``
+instead). Helper resolves defaults at dispatch time so the snapshot
+reflects what the invoker actually consumed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+ParamFieldType = Literal[
+    "string",
+    "int",
+    "float",
+    "date",
+    "quarter",
+    "ticker",
+    "cik",
+    "bool",
+    "enum",
+    "multi_enum",
+]
+
+
+class ParamMetadata(BaseModel):
+    """Operator-exposable parameter declaration for a registered job.
+
+    See module docstring for the field-type taxonomy and rationale.
+    Mirrored in ``frontend/src/api/types.ts`` — drift between the two
+    is the single biggest review-bot risk for the PR2 FE work.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str
+    """Param key. Matches the kwarg the invoker reads from ``params``."""
+
+    label: str
+    """Operator-facing field label."""
+
+    help_text: str
+    """Operator-facing help text. Rendered as field hint in the form."""
+
+    field_type: ParamFieldType
+    """Picks the FE input widget. See module docstring."""
+
+    default: Any | None = None
+    """Default value when operator leaves field blank. ``None`` means
+    'use the invoker's hardcoded default'; the FE renders an empty
+    field. ``materialise_scheduled_params`` includes this in the
+    snapshot only if non-None."""
+
+    advanced_group: bool = True
+    """When True, field renders inside the collapsed Advanced disclosure;
+    when False, in the always-visible primary group. Most fields are
+    advanced; rare exceptions (e.g. ``instrument_id`` triage targeting)
+    surface in primary."""
+
+    enum_values: tuple[str, ...] | None = None
+    """Required for ``enum`` and ``multi_enum`` field types. None for
+    every other type."""
+
+    min_value: int | float | None = None
+    """Optional lower bound for ``int`` / ``float`` field types."""
+
+    max_value: int | float | None = None
+    """Optional upper bound for ``int`` / ``float`` field types."""
+
+
+# ---------------------------------------------------------------------------
+# Per-job internal-key allow-list.
+# ---------------------------------------------------------------------------
+#
+# Bootstrap dispatcher uses ``allow_internal_keys=True`` and may pass
+# audit-only / provenance keys that operators must NOT be able to set
+# via the manual API. Each entry in this dict permits the listed keys
+# in addition to the job's ``ParamMetadata`` fields.
+#
+# Keep the entries minimal — every internal key is a knob that the
+# operator cannot tune through the standard UX. Adding to this dict
+# crosses a discipline boundary; document the reason in the value
+# comment.
+
+JOB_INTERNAL_KEYS: dict[str, frozenset[str]] = {
+    # Bootstrap variant of sec_13f_quarterly_sweep tags rows with a
+    # distinct source_label so audit history can distinguish bootstrap-
+    # bounded sweeps from the standalone weekly historical sweep. The
+    # operator never edits this — it lives in the bootstrap StageSpec's
+    # params dict.
+    "sec_13f_quarterly_sweep": frozenset({"source_label"}),
+}
+
+
+class ParamValidationError(ValueError):
+    """Raised by ``validate_job_params`` on contract violation.
+
+    The API layer maps this to 400 Bad Request with the message body.
+    """
+
+
+def _coerce_value(meta: ParamMetadata, raw: Any) -> Any:
+    """Coerce a raw operator/dispatcher value to the declared field type.
+
+    ``None`` passes through — the invoker treats it as 'not supplied'.
+    Type mismatches raise ``ParamValidationError`` with a per-field
+    message so the operator sees which field failed.
+    """
+    if raw is None:
+        return None
+    ft = meta.field_type
+    try:
+        if ft == "bool":
+            if isinstance(raw, bool):
+                return raw
+            if isinstance(raw, str):
+                lowered = raw.strip().lower()
+                if lowered in {"true", "1", "yes", "on"}:
+                    return True
+                if lowered in {"false", "0", "no", "off"}:
+                    return False
+            raise ParamValidationError(f"param {meta.name!r}: cannot coerce {raw!r} to bool")
+        if ft in {"int", "ticker"}:
+            return int(raw)
+        if ft == "float":
+            return float(raw)
+        if ft == "date":
+            if isinstance(raw, date):
+                return raw
+            return date.fromisoformat(str(raw))
+        if ft == "quarter":
+            value = str(raw).strip().upper()
+            # Format: YYYYQ[1-4], e.g. 2026Q1.
+            if len(value) != 6 or value[4] != "Q" or value[5] not in "1234" or not value[:4].isdigit():
+                raise ParamValidationError(f"param {meta.name!r}: quarter must match YYYY[Q1-4] (got {raw!r})")
+            return value
+        if ft == "cik":
+            value = str(raw).strip()
+            if not value.isdigit():
+                raise ParamValidationError(f"param {meta.name!r}: cik must be a digit string (got {raw!r})")
+            return value.zfill(10)
+        if ft in {"string", "enum"}:
+            return str(raw)
+        if ft == "multi_enum":
+            if not isinstance(raw, (list, tuple)):
+                raise ParamValidationError(
+                    f"param {meta.name!r}: multi_enum requires a list (got {type(raw).__name__})"
+                )
+            return [str(x) for x in raw]
+    except ParamValidationError:
+        raise
+    except (TypeError, ValueError) as exc:
+        raise ParamValidationError(f"param {meta.name!r}: cannot coerce {raw!r} to {ft} ({exc})") from exc
+    raise ParamValidationError(f"param {meta.name!r}: unsupported field_type {ft!r}")
+
+
+def _check_bounds(meta: ParamMetadata, value: Any) -> None:
+    """Validate enum membership + min/max bounds. ``None`` skips."""
+    if value is None:
+        return
+    if meta.field_type == "enum":
+        assert meta.enum_values is not None
+        if value not in meta.enum_values:
+            raise ParamValidationError(f"param {meta.name!r}: value {value!r} not in enum_values {meta.enum_values}")
+        return
+    if meta.field_type == "multi_enum":
+        assert meta.enum_values is not None
+        for item in value:
+            if item not in meta.enum_values:
+                raise ParamValidationError(f"param {meta.name!r}: item {item!r} not in enum_values {meta.enum_values}")
+        return
+    if meta.field_type in {"int", "float"}:
+        if meta.min_value is not None and value < meta.min_value:
+            raise ParamValidationError(f"param {meta.name!r}: value {value} < min_value {meta.min_value}")
+        if meta.max_value is not None and value > meta.max_value:
+            raise ParamValidationError(f"param {meta.name!r}: value {value} > max_value {meta.max_value}")
+
+
+def validate_job_params(
+    job_name: str,
+    params: Mapping[str, Any],
+    *,
+    allow_internal_keys: bool,
+    metadata: tuple[ParamMetadata, ...] | None = None,
+) -> dict[str, Any]:
+    """Validate + coerce a params dict against the job's ``ParamMetadata``.
+
+    Returns the coerced dict. Raises ``ParamValidationError`` on:
+
+    * Unknown key (with ``allow_internal_keys=False`` and key not in
+      ``ParamMetadata``).
+    * Coercion failure (e.g. cannot parse string as date).
+    * Bounds violation (enum membership, min/max).
+
+    ``metadata`` is supplied by the call site so this module avoids a
+    direct import of ``app/workers/scheduler.py``. The
+    ``ParamValidationError`` carries the offending param name so the
+    400 response identifies the field.
+    """
+    if metadata is None:
+        # Look up via the registry. Local import to dodge cycles.
+        metadata = _lookup_metadata(job_name)
+
+    metadata_by_name = {meta.name: meta for meta in metadata}
+    internal_keys = JOB_INTERNAL_KEYS.get(job_name, frozenset())
+
+    # Reject unknown keys before coercion.
+    for key in params:
+        if key in metadata_by_name:
+            continue
+        if allow_internal_keys and key in internal_keys:
+            continue
+        raise ParamValidationError(
+            f"unknown param {key!r} for job {job_name!r}"
+            + (
+                f" (declared params: {sorted(metadata_by_name)}, internal: {sorted(internal_keys)})"
+                if allow_internal_keys
+                else f" (declared params: {sorted(metadata_by_name)})"
+            )
+        )
+
+    coerced: dict[str, Any] = {}
+    for key, raw in params.items():
+        if key in metadata_by_name:
+            meta = metadata_by_name[key]
+            value = _coerce_value(meta, raw)
+            _check_bounds(meta, value)
+            if value is not None:
+                coerced[key] = value
+        else:
+            # Internal keys pass through verbatim (no metadata to coerce against).
+            coerced[key] = raw
+
+    return coerced
+
+
+def materialise_scheduled_params(
+    job_name: str,
+    metadata: tuple[ParamMetadata, ...] | None = None,
+) -> dict[str, Any]:
+    """Build the params dict a scheduled fire of this job would invoke with.
+
+    Reads each ``ParamMetadata.default``; omits ``None`` defaults so
+    invoker logic can distinguish 'operator left it blank' from
+    'operator set it to null'. The scheduled-fire path passes the
+    result through ``validate_job_params(allow_internal_keys=False)``
+    before invoker dispatch + ``params_snapshot`` write — so the
+    snapshot reflects EFFECTIVE params, not raw defaults.
+
+    Codex round-3 BLOCKING fix: snapshot path was previously
+    underspecified; this helper makes it explicit.
+    """
+    if metadata is None:
+        metadata = _lookup_metadata(job_name)
+    return {meta.name: meta.default for meta in metadata if meta.default is not None}
+
+
+def _lookup_metadata(job_name: str) -> tuple[ParamMetadata, ...]:
+    """Look up a job's ``params_metadata`` from the scheduler registry.
+
+    Local import to avoid a module-load cycle (scheduler imports this
+    module for the ``ParamMetadata`` type; this function is only called
+    at runtime, so the lazy import is safe).
+    """
+    from app.workers.scheduler import SCHEDULED_JOBS
+
+    for job in SCHEDULED_JOBS:
+        if job.name == job_name:
+            return job.params_metadata
+    raise ParamValidationError(f"job {job_name!r} not found in SCHEDULED_JOBS registry")
+
+
+__all__ = [
+    "JOB_INTERNAL_KEYS",
+    "ParamFieldType",
+    "ParamMetadata",
+    "ParamValidationError",
+    "materialise_scheduled_params",
+    "validate_job_params",
+]

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -229,16 +229,24 @@ def _coerce_value(meta: ParamMetadata, raw: Any) -> Any:
 
 
 def _check_bounds(meta: ParamMetadata, value: Any) -> None:
-    """Validate enum membership + min/max bounds. ``None`` skips."""
+    """Validate enum membership + min/max bounds. ``None`` skips.
+
+    Misconfigured ParamMetadata (e.g. ``field_type='enum'`` with
+    ``enum_values=None``) raises ``ParamValidationError`` so the API layer
+    maps to 400, not ``AssertionError`` which would escape to 500 (and be
+    silently skipped under ``python -O``). Review-bot PR1a BLOCKING.
+    """
     if value is None:
         return
     if meta.field_type == "enum":
-        assert meta.enum_values is not None
+        if meta.enum_values is None:
+            raise ParamValidationError(f"param {meta.name!r}: field_type='enum' requires enum_values to be set")
         if value not in meta.enum_values:
             raise ParamValidationError(f"param {meta.name!r}: value {value!r} not in enum_values {meta.enum_values}")
         return
     if meta.field_type == "multi_enum":
-        assert meta.enum_values is not None
+        if meta.enum_values is None:
+            raise ParamValidationError(f"param {meta.name!r}: field_type='multi_enum' requires enum_values to be set")
         for item in value:
             if item not in meta.enum_values:
                 raise ParamValidationError(f"param {meta.name!r}: item {item!r} not in enum_values {meta.enum_values}")

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -332,6 +332,19 @@ def materialise_scheduled_params(
 def _lookup_metadata(job_name: str) -> tuple[ParamMetadata, ...]:
     """Look up a job's ``params_metadata`` from the scheduler registry.
 
+    Returns the job's ``params_metadata`` tuple if registered in
+    ``SCHEDULED_JOBS``. Returns an empty tuple for bootstrap-only
+    invokers (job_names present in ``_BOOTSTRAP_STAGE_SPECS`` but not
+    in ``SCHEDULED_JOBS``) — those have no operator-exposable params
+    today (the bootstrap dispatcher passes internal-only keys via
+    ``JOB_INTERNAL_KEYS`` + ``allow_internal_keys=True``). PR1c may
+    promote some of these to ``SCHEDULED_JOBS`` with their own
+    ``params_metadata``.
+
+    The bootstrap-only fallback addresses the PR1a review-bot WARNING:
+    raising on unregistered job_names would break PR1b's bootstrap
+    dispatch wiring (e.g. ``sec_bulk_download`` is bootstrap-only).
+
     Local import to avoid a module-load cycle (scheduler imports this
     module for the ``ParamMetadata`` type; this function is only called
     at runtime, so the lazy import is safe).
@@ -341,7 +354,16 @@ def _lookup_metadata(job_name: str) -> tuple[ParamMetadata, ...]:
     for job in SCHEDULED_JOBS:
         if job.name == job_name:
             return job.params_metadata
-    raise ParamValidationError(f"job {job_name!r} not found in SCHEDULED_JOBS registry")
+    # Fallback for bootstrap-only invokers. Empty tuple means:
+    #   - Manual API path (allow_internal_keys=False): every supplied key
+    #     is rejected as unknown — operators cannot manually trigger
+    #     bootstrap-only jobs through the standard /jobs/<name>/run path
+    #     with arbitrary params (correct: bootstrap-only jobs are
+    #     orchestrator-owned).
+    #   - Bootstrap path (allow_internal_keys=True): only keys in
+    #     JOB_INTERNAL_KEYS[job_name] are accepted; the StageSpec.params
+    #     dict carries the internal-only knobs.
+    return ()
 
 
 __all__ = [

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -33,6 +33,7 @@ import psycopg.sql
 from psycopg.types.json import Jsonb
 
 from app.config import settings
+from app.jobs.sources import Lane
 from app.providers.implementations.companies_house import CompaniesHouseFilingsProvider
 from app.providers.implementations.etoro import EtoroMarketDataProvider
 from app.providers.implementations.sec_edgar import SecFilingsProvider
@@ -60,6 +61,7 @@ from app.services.position_monitor import (
     check_position_health,
     persist_position_alerts,
 )
+from app.services.processes.param_metadata import ParamMetadata
 from app.services.refresh_cascade import (
     demote_to_rerank_needed,
     instrument_lock,
@@ -196,6 +198,11 @@ class ScheduledJob:
     name: str
     description: str
     cadence: Cadence
+    # PR1a #1064 — source-level JobLock bucket. Operator-locked decision:
+    # same-source jobs serialise; cross-source run parallel. Required.
+    # See app/jobs/sources.py::Lane for the bucket vocabulary and
+    # docs/wiki/job-registry-audit.md §1 for the per-job source mapping.
+    source: Lane
     # When True, the job runtime will trigger this job at startup if it
     # is overdue (last successful run's next scheduled fire <= now, or
     # no successful run exists at all).  Set to False for jobs that are
@@ -207,6 +214,18 @@ class ScheduledJob:
     # the check returns (False, reason), the job is skipped and a
     # ``job_runs`` row with status='skipped' is recorded.
     prerequisite: PrerequisiteFn | None = None
+    # PR1a #1064 — operator-exposable parameter surface. Empty tuple =
+    # no operator-tunable params. Populated per audit doc §2; PR1b's
+    # validate_job_params reads this; PR2's FE Advanced disclosure
+    # renders one form field per entry. Consumed via the deferred
+    # ParamMetadata import to avoid an import cycle (param_metadata
+    # itself doesn't import scheduler).
+    params_metadata: tuple[ParamMetadata, ...] = ()
+    # PR1a #1064 — operator-facing label. PR4 (#1082) renders this in
+    # the admin ProcessesTable next to the ⓘ tooltip; populated now to
+    # avoid a separate registry-touching pass later. ``None`` falls
+    # back to ``name`` at render time.
+    display_name: str | None = None
 
 
 # Job-name constants. Every ``_tracked_job(...)`` call site below references
@@ -460,6 +479,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # only before Phase 4 — it remains in _INVOKERS for the Admin UI.
     ScheduledJob(
         name=JOB_ORCHESTRATOR_FULL_SYNC,
+        source="db",
         description="Orchestrator full sync — walks the DAG and refreshes stale layers.",
         cadence=Cadence.daily(hour=3, minute=0),
         # Never catch up on boot. A full sync runs ~45min (research refresh
@@ -480,6 +500,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # sync — the wrapper catches SyncAlreadyRunning and logs.
     ScheduledJob(
         name=JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
+        source="db",
         description="Orchestrator high-frequency sync — portfolio_sync + fx_rates every 5 minutes.",
         cadence=Cadence.every_n_minutes(interval=5),
         catch_up_on_boot=False,
@@ -489,6 +510,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # scheduled; they do not participate in the orchestrator DAG.
     ScheduledJob(
         name=JOB_EXECUTE_APPROVED_ORDERS,
+        source="etoro",
         description="Guard and execute actionable trade recommendations.",
         cadence=Cadence.daily(hour=6, minute=30),
         prerequisite=_has_actionable_recommendations,
@@ -498,6 +520,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_RETRY_DEFERRED,
+        source="db",
         description="Re-evaluate timing_deferred recommendations with fresh TA data.",
         cadence=Cadence.hourly(minute=30),
         prerequisite=_has_deferred_recommendations,
@@ -505,6 +528,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_MONITOR_POSITIONS,
+        source="db",
         description="Check open positions for SL/TP breaches and thesis breaks.",
         cadence=Cadence.hourly(minute=15),
         prerequisite=_has_open_positions,
@@ -512,6 +536,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_FUNDAMENTALS_SYNC,
+        source="db",
         description=(
             "Daily fundamentals research refresh: re-classify every "
             "tradable instrument's coverage.filings_status, backfill "
@@ -548,6 +573,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # can still manually fire it from Admin "Run now" if needed.
     ScheduledJob(
         name=JOB_SEC_DIVIDEND_CALENDAR_INGEST,
+        source="sec_rate",
         description=(
             "Parse 8-K Item 8.01 announcements into ``dividend_events`` "
             "(#434). Runs 03:00 UTC — 30 min after fundamentals_sync so "
@@ -562,6 +588,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_BUSINESS_SUMMARY_INGEST,
+        source="sec_rate",
         description=(
             "Extract 10-K Item 1 'Business' narratives into "
             "``instrument_business_summary`` (#428). Runs 03:15 UTC "
@@ -582,6 +609,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_INSIDER_TRANSACTIONS_INGEST,
+        source="sec_rate",
         description=(
             "Parse SEC Form 4 filings into ``insider_transactions`` "
             "(#429). Runs hourly because Form 4 is filed within two "
@@ -596,6 +624,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_FILING_DOCUMENTS_INGEST,
+        source="sec_rate",
         description=(
             "Parse SEC filing-index JSON (``{accession}-index.json``) "
             "into the filing_documents manifest table (#452). Captures "
@@ -610,6 +639,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_8K_EVENTS_INGEST,
+        source="sec_rate",
         description=(
             "Parse SEC 8-K filings into structured eight_k_filings + "
             "eight_k_items + eight_k_exhibits (#450). Runs hourly; "
@@ -624,6 +654,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP,
+        source="sec_rate",
         description=(
             "One-shot drain of the 10-K Item 1 candidate set (#535). "
             "Loops the standard ingester at a higher chunk limit "
@@ -639,6 +670,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
+        source="sec_rate",
         description=(
             "Round-robin backfill of Form 4 filings for instruments "
             "with deep historical backlogs (#456). Complements the "
@@ -655,6 +687,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_FORM3_INGEST,
+        source="sec_rate",
         description=(
             "Parse SEC Form 3 filings into ``insider_initial_holdings`` "
             "(#768). Form 3 is the per-officer initial-snapshot filing "
@@ -673,6 +706,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_DEF14A_INGEST,
+        source="sec_rate",
         description=(
             "Parse SEC DEF 14A proxy statements into "
             "``def14a_beneficial_holdings`` (#769 / #805). DEF 14A is "
@@ -694,6 +728,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_OWNERSHIP_OBSERVATIONS_SYNC,
+        source="db",
         description=(
             "Self-healing repair sweep for ownership_*_current (#892). "
             "Live ingesters now write observations + refresh _current "
@@ -709,6 +744,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_OWNERSHIP_OBSERVATIONS_BACKFILL,
+        source="db",
         description=(
             "One-shot legacy → ownership_*_observations backfill (#909). "
             "Phase 1 write-through (#888-#891) only fires on new "
@@ -735,6 +771,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_CUSIP_EXTID_SWEEP,
+        source="db",
         description=(
             "Sweep ``unresolved_13f_cusips`` for rows whose CUSIP "
             "already has a matching ``external_identifiers`` row, mark "
@@ -757,6 +794,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_DEF14A_BOOTSTRAP,
+        source="sec_rate",
         description=(
             "One-shot drain of the DEF 14A candidate set (#839). "
             "Loops ``ingest_def14a`` at chunk_limit=500 until the "
@@ -779,6 +817,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_RAW_DATA_RETENTION_SWEEP,
+        source="db",
         description=(
             "Per-source compaction + age-based sweep of data/raw/**. Reclaims "
             "disk from byte-identical duplicates and (per-source) ages-out old "
@@ -793,6 +832,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_EXCHANGES_METADATA_REFRESH,
+        source="etoro",
         description=(
             "Weekly refresh of the eToro exchanges catalogue. Pulls "
             "/api/v1/market-data/exchanges and upserts ``description`` "
@@ -812,6 +852,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_CUSIP_UNIVERSE_BACKFILL,
+        source="sec_rate",
         description=(
             "Quarterly CUSIP coverage backfill (#914 / #841 PR3). "
             "Walks SEC's Official List of Section 13(f) Securities "
@@ -841,6 +882,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_13F_QUARTERLY_SWEEP,
+        source="sec_rate",
         description=(
             "Quarterly sweep — walk every CIK in ``institutional_filers`` "
             "(populated by sec_13f_filer_directory_sync #912) and ingest "
@@ -868,6 +910,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_13F_FILER_DIRECTORY_SYNC,
+        source="sec_rate",
         description=(
             "Discovery sweep of SEC's quarterly form.idx for every "
             "active 13F-HR filer (#912 / #841 PR1). Pre-Phase-2 the "
@@ -896,6 +939,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
+        source="sec_rate",
         description=(
             "Discovery sweep — populate ``sec_nport_filer_directory`` "
             "from SEC's quarterly form.idx (#963). N-PORT files under "
@@ -920,6 +964,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_N_PORT_INGEST,
+        source="sec_rate",
         description=(
             "Monthly NPORT-P fund-holdings sweep (#917 — Phase 3 PR1). "
             "Walks ``sec_nport_filer_directory`` (#963 — the RIC trust "
@@ -940,6 +985,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_ETORO_LOOKUPS_REFRESH,
+        source="etoro",
         description=(
             "Weekly refresh of eToro's instrument-types + "
             "stocks-industries lookup catalogues into "

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -124,6 +124,43 @@ export interface JobsListResponse {
 }
 
 // ---------------------------------------------------------------------------
+// ParamMetadata (PR1a #1064 — operator-exposable parameter declarations)
+// ---------------------------------------------------------------------------
+//
+// Mirror of ``app/services/processes/param_metadata.py::ParamMetadata``.
+// Drift between the two is a PREVENTION-grade risk — PR2's Advanced
+// disclosure renders one form field per entry based on ``field_type``,
+// so a contract drift means operators see wrong inputs or no inputs at all.
+//
+// Round-trip test: ``frontend/src/api/types.test.ts`` covers one canonical
+// job's metadata round-tripping through JSON. Full coverage gated by review
+// bot reading both files.
+
+export type ParamFieldType =
+  | "string"
+  | "int"
+  | "float"
+  | "date"
+  | "quarter"
+  | "ticker"
+  | "cik"
+  | "bool"
+  | "enum"
+  | "multi_enum";
+
+export interface ParamMetadata {
+  name: string;
+  label: string;
+  help_text: string;
+  field_type: ParamFieldType;
+  default: unknown | null;
+  advanced_group: boolean;
+  enum_values: readonly string[] | null;
+  min_value: number | null;
+  max_value: number | null;
+}
+
+// ---------------------------------------------------------------------------
 // /jobs/runs (app/api/jobs.py — issue #13 PR B)
 // ---------------------------------------------------------------------------
 

--- a/sql/141_job_runs_params_snapshot.sql
+++ b/sql/141_job_runs_params_snapshot.sql
@@ -1,0 +1,54 @@
+-- 141_job_runs_params_snapshot.sql
+--
+-- Issue: PR1 of #1064 admin-control-hub follow-up sequence.
+-- Plan: docs/internal/plans/pr1-job-registry-refactor.md (uncommitted scratchpad).
+-- Audit (PR0, merged c413623): docs/wiki/job-registry-audit.md.
+--
+-- ## Why
+--
+-- Operator-locked decision: every job_runs row must record the params
+-- dict the run was invoked with. Without this column the operator
+-- cannot tell which param-set produced which row — the audit trail
+-- regresses the moment ParamMetadata + per-job operator-tunable params
+-- land. Three populate paths (PR1 step 8 tests pin all three):
+--
+--   1. Manual operator trigger via POST /jobs/<name>/run — payload.params
+--      stored verbatim after validate_job_params(allow_internal_keys=False).
+--   2. Scheduled cron fire — materialise_scheduled_params(job_name)
+--      reads ParamMetadata.default values; column reflects effective
+--      params, not raw {}.
+--   3. Bootstrap dispatcher — StageSpec.params dict passed through
+--      validate_job_params(allow_internal_keys=True); column reflects
+--      bootstrap-supplied dict including audit-only internal keys
+--      (e.g. source_label).
+--
+-- Control envelope keys (e.g. _override_bootstrap_gate) are NEVER
+-- persisted here — they live in pending_job_requests.payload.control
+-- and are stripped before reaching this column.
+--
+-- ## Lock impact
+--
+-- PG 14+ optimises ADD COLUMN ... DEFAULT <constant> to a metadata-
+-- only update — no full-table rewrite. Safe online; sub-second.
+--
+-- ## ETL clauses
+--
+-- CLAUDE.md ETL clauses 8-11 NOT applicable: job_runs is operator-
+-- process audit metadata, not ownership/fundamentals/observations
+-- source data. Clause 12 (PR description records verification)
+-- recorded in the PR body.
+
+BEGIN;
+
+ALTER TABLE job_runs
+    ADD COLUMN IF NOT EXISTS params_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN job_runs.params_snapshot IS
+    'Effective params dict the run was invoked with. Manual triggers '
+    'write the validated operator payload; scheduled fires write '
+    'registry defaults from ParamMetadata; bootstrap dispatcher writes '
+    'StageSpec.params (including internal audit-only keys). Control '
+    'envelope flags (override_bootstrap_gate, etc.) are stripped before '
+    'persistence — only operator-visible job parameters live here.';
+
+COMMIT;

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -351,3 +351,42 @@ class TestBootstrapOnlyMetadataLookup:
                 allow_internal_keys=True,
                 metadata=None,
             )
+
+
+class TestParamMetadataMisconfiguration:
+    """Review-bot PR1a [PREVENTION] — misconfigured metadata must raise
+    ParamValidationError (mapped to 400), not AssertionError (escapes to
+    500 and silently skipped under ``python -O``).
+    """
+
+    def test_enum_without_enum_values_raises_param_validation_error(self) -> None:
+        """field_type='enum' with enum_values=None raises ParamValidationError."""
+        meta = (
+            ParamMetadata.model_validate(
+                {
+                    "name": "broken",
+                    "label": "x",
+                    "help_text": "x",
+                    "field_type": "enum",
+                    "enum_values": None,  # misconfigured — enum requires values
+                }
+            ),
+        )
+        with pytest.raises(ParamValidationError, match="requires enum_values"):
+            validate_job_params("anyjob", {"broken": "x"}, allow_internal_keys=False, metadata=meta)
+
+    def test_multi_enum_without_enum_values_raises_param_validation_error(self) -> None:
+        """field_type='multi_enum' with enum_values=None raises ParamValidationError."""
+        meta = (
+            ParamMetadata.model_validate(
+                {
+                    "name": "broken",
+                    "label": "x",
+                    "help_text": "x",
+                    "field_type": "multi_enum",
+                    "enum_values": None,
+                }
+            ),
+        )
+        with pytest.raises(ParamValidationError, match="requires enum_values"):
+            validate_job_params("anyjob", {"broken": ["x"]}, allow_internal_keys=False, metadata=meta)

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -310,3 +310,44 @@ class TestJobInternalKeysRegistry:
         registry = get_job_name_to_source()
         for job_name in JOB_INTERNAL_KEYS:
             assert job_name in registry, f"JOB_INTERNAL_KEYS lists {job_name!r} but it's not in the source registry"
+
+
+class TestBootstrapOnlyMetadataLookup:
+    """Review-bot PR1a [PREVENTION] — _lookup_metadata must not raise on
+    bootstrap-only job_names (otherwise PR1b dispatch breaks for
+    sec_bulk_download / nightly_universe_sync / etc).
+    """
+
+    def test_validate_succeeds_for_bootstrap_only_job_with_no_params(self) -> None:
+        """PR1b will dispatch bootstrap-only jobs through validate_job_params
+        with metadata=None. The lookup must return () (no operator-exposable
+        params), not raise."""
+        out = validate_job_params(
+            "sec_bulk_download",  # bootstrap-only invoker, NOT in SCHEDULED_JOBS
+            {},
+            allow_internal_keys=True,
+            metadata=None,
+        )
+        assert out == {}
+
+    def test_validate_rejects_unknown_keys_for_bootstrap_only_job_manual_path(self) -> None:
+        """Manual API path against a bootstrap-only job rejects everything —
+        empty metadata + allow_internal_keys=False = every key unknown."""
+        with pytest.raises(ParamValidationError, match="unknown param"):
+            validate_job_params(
+                "nightly_universe_sync",
+                {"force_full": True},
+                allow_internal_keys=False,
+                metadata=None,
+            )
+
+    def test_validate_rejects_internal_keys_not_in_allow_list(self) -> None:
+        """Bootstrap-only job with allow_internal_keys=True still rejects keys
+        not in JOB_INTERNAL_KEYS for that job."""
+        with pytest.raises(ParamValidationError, match="unknown param"):
+            validate_job_params(
+                "sec_bulk_download",
+                {"random_key": "x"},  # not in JOB_INTERNAL_KEYS["sec_bulk_download"]
+                allow_internal_keys=True,
+                metadata=None,
+            )

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -1,0 +1,312 @@
+"""Tests for the PR1a job registry foundation.
+
+Covers:
+
+* Every ``ScheduledJob`` declares a ``source`` from the ``Lane`` vocabulary.
+* No legacy ``'sec'`` lane (pre-#1020 catch-all) leaks into source keys.
+* ``JOB_NAME_TO_SOURCE`` covers every ``_INVOKERS`` name used by bootstrap stages.
+* Conflict detection: a source/lane mismatch between SCHEDULED_JOBS and
+  _BOOTSTRAP_STAGE_SPECS raises at registry build time.
+* ``source_for`` raises ``KeyError`` for unknown job_name (no silent fallback).
+* ParamMetadata validation: each field_type, enum membership, bounds.
+* JOB_INTERNAL_KEYS gating: bootstrap path allows internal keys; manual rejects.
+* materialise_scheduled_params materialises non-None defaults only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.jobs.sources import (
+    JobSourceRegistryError,
+    Lane,
+    get_job_name_to_source,
+    reset_job_name_to_source_cache,
+    source_for,
+)
+from app.services.bootstrap_orchestrator import _BOOTSTRAP_STAGE_SPECS
+from app.services.processes.param_metadata import (
+    JOB_INTERNAL_KEYS,
+    ParamMetadata,
+    ParamValidationError,
+    materialise_scheduled_params,
+    validate_job_params,
+)
+from app.workers.scheduler import SCHEDULED_JOBS
+
+_ALLOWED_SOURCES: frozenset[Lane] = frozenset({"init", "etoro", "sec_rate", "sec_bulk_download", "db"})
+
+
+class TestScheduledJobSourceField:
+    """ScheduledJob.source is required and from the Lane vocabulary."""
+
+    def test_every_scheduled_job_has_source(self) -> None:
+        assert len(SCHEDULED_JOBS) >= 27, "audit doc records 27 scheduled jobs"
+        missing = [j.name for j in SCHEDULED_JOBS if not j.source]
+        assert not missing, f"jobs missing source: {missing}"
+
+    def test_every_source_is_valid_lane(self) -> None:
+        bad = [(j.name, j.source) for j in SCHEDULED_JOBS if j.source not in _ALLOWED_SOURCES]
+        assert not bad, f"jobs with invalid source: {bad}"
+
+    def test_no_legacy_sec_lane_leak(self) -> None:
+        """Regression — pre-#1020 catch-all lane='sec' MUST NOT appear in source keys.
+
+        The PR0 audit explicitly remapped to sec_rate / sec_bulk_download. A
+        future edit re-introducing the legacy 'sec' string here would silently
+        merge two distinct rate buckets into one lock; this test pins it out.
+        """
+        leaks = [j.name for j in SCHEDULED_JOBS if j.source == "sec"]  # type: ignore[comparison-overlap]
+        assert not leaks, f"jobs with legacy sec lane: {leaks}"
+
+
+class TestStageSpecParamsField:
+    """StageSpec.params field exists and defaults to empty mapping."""
+
+    def test_every_stage_has_params_attribute(self) -> None:
+        for stage in _BOOTSTRAP_STAGE_SPECS:
+            assert hasattr(stage, "params"), f"stage {stage.stage_key} missing params"
+
+    def test_default_params_is_empty(self) -> None:
+        # PR1a leaves all stages with default empty params; PR1c will populate
+        # stages 14, 15, 21 with the bespoke wrapper overrides.
+        for stage in _BOOTSTRAP_STAGE_SPECS:
+            assert stage.params == {}, (
+                f"stage {stage.stage_key} has unexpected params {stage.params!r}; PR1a should leave all stages empty"
+            )
+
+
+class TestSourceRegistry:
+    """JOB_NAME_TO_SOURCE construction + conflict detection."""
+
+    def test_registry_covers_every_scheduled_job(self) -> None:
+        registry = get_job_name_to_source()
+        for job in SCHEDULED_JOBS:
+            assert job.name in registry, f"scheduled job {job.name} missing from registry"
+            assert registry[job.name] == job.source
+
+    def test_registry_covers_every_bootstrap_stage(self) -> None:
+        registry = get_job_name_to_source()
+        for stage in _BOOTSTRAP_STAGE_SPECS:
+            assert stage.job_name in registry, (
+                f"bootstrap stage {stage.stage_key} dispatches to {stage.job_name!r} "
+                f"which is not in the source registry"
+            )
+
+    def test_bootstrap_only_invokers_present(self) -> None:
+        """Bootstrap-only invokers (not in SCHEDULED_JOBS) must still resolve.
+
+        Pre-PR1c these are: nightly_universe_sync, daily_candle_refresh,
+        daily_cik_refresh, sec_bulk_download, sec_*_ingest_from_dataset (4),
+        sec_submissions_files_walk, plus the 3 bespoke wrappers.
+        """
+        registry = get_job_name_to_source()
+        scheduled_names = {j.name for j in SCHEDULED_JOBS}
+        bootstrap_only = [s.job_name for s in _BOOTSTRAP_STAGE_SPECS if s.job_name not in scheduled_names]
+        for name in bootstrap_only:
+            assert name in registry, f"bootstrap-only invoker {name} missing from registry"
+
+    def test_source_for_raises_keyerror_on_unknown(self) -> None:
+        with pytest.raises(KeyError, match="unknown job_name"):
+            source_for("nonexistent_job")
+
+    def test_source_for_returns_correct_lane(self) -> None:
+        # Spot-check a few known mappings against the audit.
+        assert source_for("orchestrator_full_sync") == "db"
+        assert source_for("execute_approved_orders") == "etoro"
+        assert source_for("sec_form3_ingest") == "sec_rate"
+        assert source_for("nightly_universe_sync") == "init"
+        # sec_bulk_download is a bootstrap-only invoker mapped to its
+        # own source bucket per _STAGE_LANE_OVERRIDES.
+        assert source_for("sec_bulk_download") == "sec_bulk_download"
+
+
+class TestRegistryConflictDetection:
+    """Conflict between scheduled.source and bootstrap.lane raises at build."""
+
+    def test_conflict_raises_at_build(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Inject a fake conflict and assert _build_job_name_to_source raises.
+
+        Resets the lazy cache + monkeypatches a synthetic conflicting stage
+        into _BOOTSTRAP_STAGE_SPECS. The registry build pass must surface
+        this as a JobSourceRegistryError, not a silent override.
+        """
+        from app.jobs import sources as sources_mod
+        from app.services import bootstrap_orchestrator as boot_mod
+        from app.services.bootstrap_state import StageSpec
+
+        # Pick a real scheduled job whose source we'll deliberately conflict with.
+        target = SCHEDULED_JOBS[0]
+        conflicting_lane: Lane = "etoro" if target.source != "etoro" else "db"
+
+        synthetic = StageSpec(
+            stage_key=f"__conflict_test_{target.name}__",
+            stage_order=999,
+            lane=conflicting_lane,
+            job_name=target.name,
+        )
+
+        monkeypatch.setattr(
+            boot_mod,
+            "_BOOTSTRAP_STAGE_SPECS",
+            (*_BOOTSTRAP_STAGE_SPECS, synthetic),
+        )
+        # Wipe the cache so the next get_job_name_to_source rebuilds.
+        reset_job_name_to_source_cache()
+        try:
+            with pytest.raises(JobSourceRegistryError, match=target.name):
+                sources_mod.get_job_name_to_source()
+        finally:
+            # Restore real cache so subsequent tests use the canonical registry.
+            reset_job_name_to_source_cache()
+
+
+class TestParamMetadataValidation:
+    """validate_job_params + _coerce_value + _check_bounds coverage."""
+
+    def _meta(self, **overrides: object) -> ParamMetadata:
+        defaults: dict[str, object] = {
+            "name": "p",
+            "label": "Param",
+            "help_text": "help",
+            "field_type": "string",
+        }
+        defaults.update(overrides)
+        return ParamMetadata.model_validate(defaults)
+
+    def test_int_coercion(self) -> None:
+        meta = (self._meta(name="n", field_type="int", min_value=1, max_value=10),)
+        out = validate_job_params("anyjob", {"n": "5"}, allow_internal_keys=False, metadata=meta)
+        assert out == {"n": 5}
+
+    def test_int_bounds_low(self) -> None:
+        meta = (self._meta(name="n", field_type="int", min_value=10),)
+        with pytest.raises(ParamValidationError, match="< min_value"):
+            validate_job_params("anyjob", {"n": 5}, allow_internal_keys=False, metadata=meta)
+
+    def test_int_bounds_high(self) -> None:
+        meta = (self._meta(name="n", field_type="int", max_value=10),)
+        with pytest.raises(ParamValidationError, match="> max_value"):
+            validate_job_params("anyjob", {"n": 100}, allow_internal_keys=False, metadata=meta)
+
+    def test_bool_coercion(self) -> None:
+        meta = (self._meta(name="b", field_type="bool"),)
+        for raw, expected in [("true", True), ("false", False), (True, True), ("1", True), ("0", False)]:
+            out = validate_job_params("anyjob", {"b": raw}, allow_internal_keys=False, metadata=meta)
+            assert out == {"b": expected}, f"raw={raw!r}"
+
+    def test_date_coercion(self) -> None:
+        from datetime import date
+
+        meta = (self._meta(name="d", field_type="date"),)
+        out = validate_job_params("anyjob", {"d": "2026-05-09"}, allow_internal_keys=False, metadata=meta)
+        assert out == {"d": date(2026, 5, 9)}
+
+    def test_quarter_format(self) -> None:
+        meta = (self._meta(name="q", field_type="quarter"),)
+        out = validate_job_params("anyjob", {"q": "2026q1"}, allow_internal_keys=False, metadata=meta)
+        assert out == {"q": "2026Q1"}
+
+        with pytest.raises(ParamValidationError, match="quarter must match"):
+            validate_job_params("anyjob", {"q": "2026Q5"}, allow_internal_keys=False, metadata=meta)
+
+    def test_cik_zero_pad(self) -> None:
+        meta = (self._meta(name="c", field_type="cik"),)
+        out = validate_job_params("anyjob", {"c": "320193"}, allow_internal_keys=False, metadata=meta)
+        assert out == {"c": "0000320193"}
+
+    def test_enum_membership(self) -> None:
+        meta = (self._meta(name="e", field_type="enum", enum_values=("a", "b", "c")),)
+        out = validate_job_params("anyjob", {"e": "a"}, allow_internal_keys=False, metadata=meta)
+        assert out == {"e": "a"}
+
+        with pytest.raises(ParamValidationError, match="not in enum_values"):
+            validate_job_params("anyjob", {"e": "z"}, allow_internal_keys=False, metadata=meta)
+
+    def test_multi_enum_membership(self) -> None:
+        meta = (self._meta(name="m", field_type="multi_enum", enum_values=("10-K", "10-Q")),)
+        out = validate_job_params("anyjob", {"m": ["10-K"]}, allow_internal_keys=False, metadata=meta)
+        assert out == {"m": ["10-K"]}
+
+        with pytest.raises(ParamValidationError, match="not in enum_values"):
+            validate_job_params("anyjob", {"m": ["BAD"]}, allow_internal_keys=False, metadata=meta)
+
+    def test_unknown_key_rejected_manual(self) -> None:
+        meta = (self._meta(name="known", field_type="string"),)
+        with pytest.raises(ParamValidationError, match="unknown param"):
+            validate_job_params("anyjob", {"unknown": "v"}, allow_internal_keys=False, metadata=meta)
+
+    def test_internal_keys_path_allows_listed_only(self) -> None:
+        """allow_internal_keys=True permits keys in JOB_INTERNAL_KEYS[job_name]."""
+        # sec_13f_quarterly_sweep has source_label as internal.
+        meta = ()
+        out = validate_job_params(
+            "sec_13f_quarterly_sweep",
+            {"source_label": "sec_edgar_13f_directory_bootstrap"},
+            allow_internal_keys=True,
+            metadata=meta,
+        )
+        assert out == {"source_label": "sec_edgar_13f_directory_bootstrap"}
+
+    def test_internal_keys_path_still_rejects_unlisted(self) -> None:
+        """Bootstrap path rejects internal-looking keys not in the allow-list."""
+        meta = ()
+        with pytest.raises(ParamValidationError, match="unknown param"):
+            validate_job_params(
+                "sec_13f_quarterly_sweep",
+                {"random_internal_key": "x"},
+                allow_internal_keys=True,
+                metadata=meta,
+            )
+
+    def test_manual_path_blocks_internal_keys(self) -> None:
+        """Operator API path must NOT permit any internal keys, even if listed."""
+        meta = ()
+        with pytest.raises(ParamValidationError, match="unknown param"):
+            validate_job_params(
+                "sec_13f_quarterly_sweep",
+                {"source_label": "operator_attempt"},  # in JOB_INTERNAL_KEYS, but disallowed for manual
+                allow_internal_keys=False,
+                metadata=meta,
+            )
+
+
+class TestMaterialiseScheduledParams:
+    """materialise_scheduled_params returns non-None defaults only."""
+
+    def test_defaults_materialise(self) -> None:
+        meta = (
+            ParamMetadata.model_validate(
+                {
+                    "name": "with_default",
+                    "label": "x",
+                    "help_text": "x",
+                    "field_type": "int",
+                    "default": 100,
+                }
+            ),
+            ParamMetadata.model_validate(
+                {
+                    "name": "no_default",
+                    "label": "y",
+                    "help_text": "y",
+                    "field_type": "int",
+                    "default": None,
+                }
+            ),
+        )
+        out = materialise_scheduled_params("anyjob", metadata=meta)
+        assert out == {"with_default": 100}, "None defaults must be omitted"
+
+
+class TestJobInternalKeysRegistry:
+    """JOB_INTERNAL_KEYS is the canonical bootstrap-only allow-list."""
+
+    def test_sec_13f_has_source_label_internal(self) -> None:
+        assert "source_label" in JOB_INTERNAL_KEYS["sec_13f_quarterly_sweep"]
+
+    def test_internal_keys_keys_are_known_jobs(self) -> None:
+        """Every job in JOB_INTERNAL_KEYS must be in the source registry."""
+        registry = get_job_name_to_source()
+        for job_name in JOB_INTERNAL_KEYS:
+            assert job_name in registry, f"JOB_INTERNAL_KEYS lists {job_name!r} but it's not in the source registry"

--- a/tests/test_joblock_per_source.py
+++ b/tests/test_joblock_per_source.py
@@ -1,0 +1,101 @@
+"""Tests for source-level JobLock semantics.
+
+PR1a refactors JobLock from per-job-name to per-source. Verify:
+
+* Two jobs sharing a source serialise (second JobLock raises JobAlreadyRunning).
+* Two jobs in different sources run concurrently (both succeed).
+* Unknown job_name raises KeyError (no silent fallback).
+* test_only_per_name escape hatch keys on raw job_name (pre-PR1a behaviour).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import settings
+from app.jobs.locks import JobAlreadyRunning, JobLock
+
+# Postgres advisory locks are cluster-wide, not database-scoped. With pytest-xdist
+# running tests in parallel workers against the same dev DB cluster, two tests
+# acquiring the same source lock would contend across workers. Group these tests
+# onto a single worker so the only contention is intra-test (which is what each
+# test asserts).
+pytestmark = pytest.mark.xdist_group(name="joblock_source_serial")
+
+
+class TestJobLockSourceLevel:
+    """Source-level lock contention vs cross-source parallelism."""
+
+    def test_same_source_serialises(self) -> None:
+        """sec_form3_ingest + sec_def14a_ingest share source=sec_rate.
+
+        Holding the lock for one MUST block the other.
+        """
+        with JobLock(settings.database_url, "sec_form3_ingest"):
+            with pytest.raises(JobAlreadyRunning):
+                with JobLock(settings.database_url, "sec_def14a_ingest"):
+                    pytest.fail("second sec_rate-source lock should have raised JobAlreadyRunning")
+
+    def test_cross_source_runs_concurrently(self) -> None:
+        """orchestrator_full_sync (db) + execute_approved_orders (etoro)
+        are different sources and both must acquire successfully."""
+        with JobLock(settings.database_url, "orchestrator_full_sync"):
+            with JobLock(settings.database_url, "execute_approved_orders"):
+                # Both held simultaneously — no exception means success.
+                pass
+
+    def test_db_source_serialises(self) -> None:
+        """orchestrator_full_sync + retry_deferred_recommendations both source=db."""
+        with JobLock(settings.database_url, "orchestrator_full_sync"):
+            with pytest.raises(JobAlreadyRunning):
+                with JobLock(settings.database_url, "retry_deferred_recommendations"):
+                    pytest.fail("second db-source lock should have raised")
+
+    def test_etoro_source_serialises(self) -> None:
+        """execute_approved_orders + etoro_lookups_refresh both source=etoro."""
+        with JobLock(settings.database_url, "execute_approved_orders"):
+            with pytest.raises(JobAlreadyRunning):
+                with JobLock(settings.database_url, "etoro_lookups_refresh"):
+                    pytest.fail("second etoro-source lock should have raised")
+
+    def test_sec_rate_vs_sec_bulk_download_run_parallel(self) -> None:
+        """sec_rate and sec_bulk_download are disjoint rate buckets — no contention."""
+        with JobLock(settings.database_url, "sec_form3_ingest"):  # sec_rate
+            with JobLock(settings.database_url, "sec_bulk_download"):  # sec_bulk_download
+                pass
+
+
+class TestJobLockUnknownJobName:
+    """Unknown job_name MUST raise KeyError, never silently fall back."""
+
+    def test_unknown_raises_keyerror(self) -> None:
+        with pytest.raises(KeyError, match="unknown job_name"):
+            JobLock(settings.database_url, "completely_made_up_job_name_xyz")
+
+
+class TestJobLockTestOnlyEscape:
+    """test_only_per_name preserves pre-PR1a per-name semantics for fixtures."""
+
+    def test_per_name_serialises_same_name(self) -> None:
+        with JobLock.test_only_per_name(settings.database_url, "fake_test_job_a"):
+            with pytest.raises(JobAlreadyRunning):
+                with JobLock.test_only_per_name(settings.database_url, "fake_test_job_a"):
+                    pytest.fail("same-name test_only lock should have raised")
+
+    def test_per_name_different_names_run_parallel(self) -> None:
+        with JobLock.test_only_per_name(settings.database_url, "fake_test_job_a"):
+            with JobLock.test_only_per_name(settings.database_url, "fake_test_job_b"):
+                pass
+
+    def test_per_name_does_not_collide_with_real_source_lock(self) -> None:
+        """test_only key is raw job_name; real lock is 'job_source:{source}'.
+
+        These hash to different ints so a test fixture cannot accidentally
+        block a real production source lock during pytest.
+        """
+        # Hold a real source-level lock.
+        with JobLock(settings.database_url, "execute_approved_orders"):  # source=etoro → key 'job_source:etoro'
+            # A test-only lock keyed on raw 'etoro' string would hash to
+            # something different from 'job_source:etoro' — so this MUST succeed.
+            with JobLock.test_only_per_name(settings.database_url, "etoro"):
+                pass

--- a/tests/test_jobs_locks.py
+++ b/tests/test_jobs_locks.py
@@ -25,15 +25,15 @@ pytestmark = pytest.mark.skipif(
 
 class TestJobLockAcquire:
     def test_first_acquire_succeeds(self) -> None:
-        with JobLock(test_database_url(), "test_first_acquire"):
+        with JobLock.test_only_per_name(test_database_url(), "test_first_acquire"):
             pass  # acquired and released cleanly
 
     def test_second_acquire_while_held_raises(self) -> None:
-        outer = JobLock(test_database_url(), "test_second_acquire")
+        outer = JobLock.test_only_per_name(test_database_url(), "test_second_acquire")
         outer.__enter__()
         try:
             with pytest.raises(JobAlreadyRunning) as exc_info:
-                with JobLock(test_database_url(), "test_second_acquire"):
+                with JobLock.test_only_per_name(test_database_url(), "test_second_acquire"):
                     pass
             assert exc_info.value.job_name == "test_second_acquire"
         finally:
@@ -41,15 +41,15 @@ class TestJobLockAcquire:
 
     def test_acquire_after_release_succeeds(self) -> None:
         # First holder releases, second holder must be able to acquire.
-        with JobLock(test_database_url(), "test_acquire_after_release"):
+        with JobLock.test_only_per_name(test_database_url(), "test_acquire_after_release"):
             pass
-        with JobLock(test_database_url(), "test_acquire_after_release"):
+        with JobLock.test_only_per_name(test_database_url(), "test_acquire_after_release"):
             pass  # would raise JobAlreadyRunning if release was broken
 
     def test_different_names_do_not_block(self) -> None:
         # Two locks with different names must be holdable concurrently.
-        with JobLock(test_database_url(), "test_different_names_a"):
-            with JobLock(test_database_url(), "test_different_names_b"):
+        with JobLock.test_only_per_name(test_database_url(), "test_different_names_a"):
+            with JobLock.test_only_per_name(test_database_url(), "test_different_names_b"):
                 pass
 
     def test_release_on_exception_in_body(self) -> None:
@@ -59,9 +59,9 @@ class TestJobLockAcquire:
             pass
 
         with pytest.raises(_BodyError):
-            with JobLock(test_database_url(), "test_release_on_exception"):
+            with JobLock.test_only_per_name(test_database_url(), "test_release_on_exception"):
                 raise _BodyError("boom")
 
         # Re-acquire must succeed.
-        with JobLock(test_database_url(), "test_release_on_exception"):
+        with JobLock.test_only_per_name(test_database_url(), "test_release_on_exception"):
             pass

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -407,6 +407,7 @@ _DAILY_JOB = ScheduledJob(
     name="daily_job",
     description="test daily",
     cadence=Cadence.daily(hour=2, minute=0),
+    source="db",  # PR1a — required field; arbitrary safe choice for test fixture
     catch_up_on_boot=True,
 )
 
@@ -414,6 +415,7 @@ _NO_CATCHUP_JOB = ScheduledJob(
     name="no_catchup_job",
     description="test no catchup",
     cadence=Cadence.daily(hour=2, minute=0),
+    source="db",
     catch_up_on_boot=False,
 )
 
@@ -421,6 +423,7 @@ _PREREQ_MET_JOB = ScheduledJob(
     name="prereq_met_job",
     description="test with met prerequisite",
     cadence=Cadence.daily(hour=2, minute=0),
+    source="db",
     catch_up_on_boot=True,
     prerequisite=lambda _conn: (True, ""),
 )
@@ -429,6 +432,7 @@ _PREREQ_UNMET_JOB = ScheduledJob(
     name="prereq_unmet_job",
     description="test with unmet prerequisite",
     cadence=Cadence.daily(hour=2, minute=0),
+    source="db",
     catch_up_on_boot=True,
     prerequisite=lambda _conn: (False, "no coverage rows"),
 )
@@ -622,6 +626,7 @@ class TestCatchUpOnBoot:
             name="hourly_job",
             description="test hourly",
             cadence=Cadence.hourly(minute=5),
+            source="db",  # PR1a — required field; arbitrary safe choice for test fixture
             catch_up_on_boot=True,
         )
 


### PR DESCRIPTION
## What
Foundation PR for the #1064 admin-control-hub follow-up sequence (carved from the original PR1 plan into PR1a + PR1b + PR1c). **No behaviour change visible to operator** — API contract unchanged, scheduled fires unchanged, bootstrap dispatch unchanged.

- `sql/141` — `job_runs.params_snapshot JSONB DEFAULT '{}'::jsonb`
- New `app/jobs/sources.py` — `Lane` Literal + `JobInvoker` alias + lazy `JOB_NAME_TO_SOURCE` from BOTH `SCHEDULED_JOBS` AND `_BOOTSTRAP_STAGE_SPECS`; conflict detection raises at first call. FastAPI lifespan + jobs entrypoint force-resolve at boot for fail-fast.
- New `app/services/processes/param_metadata.py` — `ParamMetadata` Pydantic model + `validate_job_params` (single validator, `allow_internal_keys` mode) + `materialise_scheduled_params` + `JOB_INTERNAL_KEYS` allow-list. 10 field types: string/int/float/date/quarter/ticker/cik/bool/enum/multi_enum.
- `ScheduledJob` extended with required `source: Lane` + `params_metadata` + `display_name`; populated `source` on all 27 entries per `docs/wiki/job-registry-audit.md` §2.
- `StageSpec` extended with `params: Mapping[str, Any]` field.
- `JobLock` keyed on `hashtext('job_source:{source}')` via registry lookup; `KeyError` on unknown job_name (no silent fallback per Codex round-1 BLOCKING). `JobLock.test_only_per_name` escape hatch for fixtures.
- `frontend/src/api/types.ts` mirror of `ParamMetadata` + `ParamFieldType`.
- 41 new tests + migrated `tests/test_jobs_locks.py` + `tests/test_jobs_runtime.py` to new contract.

## Why
Operator-locked decision: source-level `JobLock` (SEC 10 req/s shared bucket means per-job locking conflated independent rate buckets). ParamMetadata as data so PR2 FE renders one generic Advanced disclosure form. `params_snapshot` gives operator history visibility into which param-set produced which row.

Plan + 3 rounds of Codex review (15 findings, all addressed) at `docs/internal/plans/pr1-job-registry-refactor.md` (uncommitted scratchpad, gitignored under new `docs/internal/`).

## Test plan
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 548 files already formatted
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest tests/test_job_registry.py tests/test_joblock_per_source.py tests/test_jobs_locks.py tests/test_jobs_runtime.py tests/smoke/test_app_boots.py` — 46+ pass
- [x] `pnpm --dir frontend typecheck` — clean
- [x] Codex pre-push diff review (mandatory checkpoint 2) — 1 BLOCKING (test_jobs_locks.py needed test_only_per_name migration) + 1 WARNING (lazy registry build not forced at startup) — both addressed in same diff
- [x] sql/141 applied to dev DB; `params_snapshot` column verified present

## ETL clauses
ETL clauses 8-11 NOT applicable: `job_runs.params_snapshot` is operator-process audit metadata, not ownership/fundamentals/observations source data. Clause 12 (PR description records verification) recorded here.

## Conscious tradeoffs
- `_LANE_MAX_CONCURRENCY` (#1020) NOT touched in PR1a. PR1c retires it since same-source serialisation under `JobLock` makes the bootstrap-dispatcher parallel-DB-stage assumption misleading. Tech-debt note in PR1c for first-install wall-clock regression.
- `display_name` field added now even though only PR4 (#1082) renders ⓘ tooltips — avoids touching every entry in `SCHEDULED_JOBS` twice.
- `params_metadata` populated as empty tuples on every entry. PR1b populates per-job operator-exposable params for the operator-tunable jobs (audit §2 proposed surface).

Refs #1064.