### PR TITLE
feat(#1064): PR1b — extend per-job prerequisite check to manual-queue dispatch

### DIFF
--- a/app/jobs/listener.py
+++ b/app/jobs/listener.py
@@ -50,6 +50,7 @@ from app.services.sync_orchestrator.dispatcher import (
 )
 from app.services.sync_orchestrator.executor import run_sync
 from app.services.sync_orchestrator.types import SyncTrigger
+from app.workers.scheduler import SCHEDULED_JOBS
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,59 @@ def _dispatch_manual_job(
                 error_msg=f"unknown job name: {job_name!r}",
             )
         return
+
+    # PR1b #1064 — extend per-job prerequisite check to the manual-queue
+    # path. The scheduled-fire path in app/jobs/runtime.py::_wrap_invoker
+    # has always honoured ScheduledJob.prerequisite (e.g.
+    # _bootstrap_complete on every SEC + fundamentals job). Pre-PR1b the
+    # manual-queue path bypassed this — operators could fire any SEC
+    # ingest from the admin panel during a half-installed dev DB,
+    # getting confusing "instruments=0" log lines + empty results.
+    #
+    # Bootstrap-internal jobs (bootstrap_orchestrator + its stage jobs)
+    # are NOT in SCHEDULED_JOBS, so the lookup returns no prerequisite
+    # and the manual queue path proceeds unchanged. Operator-tunable
+    # SEC/fundamentals jobs WITH the prerequisite get the same
+    # "first-install bootstrap not complete" rejection scheduled fires
+    # already produce. Manual queue uses mark_request_rejected (NOT
+    # mark_request_completed — PREVENTION-grade per data-engineer skill
+    # §6.5.7 step 8).
+    job = next((j for j in SCHEDULED_JOBS if j.name == job_name), None)
+    if job is not None and job.prerequisite is not None:
+        # Fail-open posture covers BOTH connection-open failures AND
+        # prerequisite-callable raises. Codex round-2 BLOCKING fix —
+        # the try MUST wrap psycopg.connect because if connection-open
+        # raises while inside the `with`, the exception escapes the
+        # listener's _dispatch_manual_job entirely and _route_claim's
+        # broad except marks the request rejected — silent divergence
+        # from the scheduled-fire posture (which fails-open on the
+        # same class of errors at app/jobs/runtime.py::_wrap_invoker).
+        try:
+            with psycopg.connect(settings.database_url, autocommit=True) as conn:
+                met, reason = job.prerequisite(conn)
+                if not met:
+                    logger.info(
+                        "listener: rejecting manual_job request_id=%d for %r — prerequisite not met: %s",
+                        request_id,
+                        job_name,
+                        reason,
+                    )
+                    mark_request_rejected(
+                        conn,
+                        request_id,
+                        error_msg=reason,
+                    )
+                    return
+        except Exception:
+            # Mirrors scheduled-fire posture — silently dropping a real
+            # run is worse than running against a partial DB where the
+            # body itself can detect + skip. Logged loud so ops_monitor
+            # surfaces a repeating failure pattern.
+            logger.warning(
+                "listener: prerequisite check for %r failed (connect or callable raised); running anyway",
+                job_name,
+                exc_info=True,
+            )
 
     # Submit to the runtime's manual executor. The runtime's own
     # wrapper handles the linked_request_id / dispatched / completed

--- a/app/jobs/listener.py
+++ b/app/jobs/listener.py
@@ -137,40 +137,52 @@ def _dispatch_manual_job(
     # §6.5.7 step 8).
     job = next((j for j in SCHEDULED_JOBS if j.name == job_name), None)
     if job is not None and job.prerequisite is not None:
-        # Fail-open posture covers BOTH connection-open failures AND
-        # prerequisite-callable raises. Codex round-2 BLOCKING fix —
-        # the try MUST wrap psycopg.connect because if connection-open
-        # raises while inside the `with`, the exception escapes the
-        # listener's _dispatch_manual_job entirely and _route_claim's
-        # broad except marks the request rejected — silent divergence
-        # from the scheduled-fire posture (which fails-open on the
-        # same class of errors at app/jobs/runtime.py::_wrap_invoker).
+        # Two-stage try/except (review-bot PR1b BLOCKING fix):
+        #   1. Inner try wraps ONLY the prereq evaluation (connect +
+        #      callable). Failures fail-open (mirrors scheduled-fire
+        #      posture at app/jobs/runtime.py::_wrap_invoker).
+        #   2. The rejection write (mark_request_rejected + return)
+        #      lives OUTSIDE the inner try — if it raises, the failure
+        #      escapes to _route_claim's broad except, which is correct
+        #      (rejecting a rejected job is the safe direction). It
+        #      MUST NOT fall through to submit_manual_with_request.
+        prereq_decision: tuple[bool, str] | None = None
         try:
             with psycopg.connect(settings.database_url, autocommit=True) as conn:
-                met, reason = job.prerequisite(conn)
-                if not met:
-                    logger.info(
-                        "listener: rejecting manual_job request_id=%d for %r — prerequisite not met: %s",
-                        request_id,
-                        job_name,
-                        reason,
-                    )
-                    mark_request_rejected(
-                        conn,
-                        request_id,
-                        error_msg=reason,
-                    )
-                    return
+                prereq_decision = job.prerequisite(conn)
         except Exception:
-            # Mirrors scheduled-fire posture — silently dropping a real
-            # run is worse than running against a partial DB where the
-            # body itself can detect + skip. Logged loud so ops_monitor
+            # Connection-open OR prerequisite-callable raised. Mirrors
+            # scheduled-fire posture — silently dropping a real run is
+            # worse than running against a partial DB where the body
+            # itself can detect + skip. Logged loud so ops_monitor
             # surfaces a repeating failure pattern.
             logger.warning(
                 "listener: prerequisite check for %r failed (connect or callable raised); running anyway",
                 job_name,
                 exc_info=True,
             )
+
+        if prereq_decision is not None:
+            met, reason = prereq_decision
+            if not met:
+                # Rejection write lives OUTSIDE the fail-open try so a
+                # transient mark_request_rejected failure cannot fall
+                # through to submit_manual_with_request — a job whose
+                # prerequisite explicitly returned (False, reason) MUST
+                # NOT dispatch even if the rejection write fails.
+                logger.info(
+                    "listener: rejecting manual_job request_id=%d for %r — prerequisite not met: %s",
+                    request_id,
+                    job_name,
+                    reason,
+                )
+                with psycopg.connect(settings.database_url, autocommit=True) as conn:
+                    mark_request_rejected(
+                        conn,
+                        request_id,
+                        error_msg=reason,
+                    )
+                return
 
     # Submit to the runtime's manual executor. The runtime's own
     # wrapper handles the linked_request_id / dispatched / completed

--- a/tests/test_bootstrap_state_gate.py
+++ b/tests/test_bootstrap_state_gate.py
@@ -136,6 +136,37 @@ class TestPrereqEnforcement:
         mock_reject.assert_not_called()
         runtime.submit_manual_with_request.assert_called_once()
 
+    def test_unmet_prereq_with_failing_rejection_write_does_not_dispatch(self) -> None:
+        """Review-bot PR1b BLOCKING regression — if mark_request_rejected
+        raises (transient write failure), the job MUST NOT fall through
+        to submit_manual_with_request. A prerequisite that explicitly
+        returned (False, reason) MUST NOT dispatch even if the rejection
+        write fails."""
+        runtime = _runtime_mock()
+        fake_job = _job_with_prereq("sec_form3_ingest", met=False, reason="bootstrap not complete")
+        with (
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_form3_ingest"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch(
+                "app.jobs.listener.mark_request_rejected",
+                side_effect=RuntimeError("write failed"),
+            ),
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            try:
+                _dispatch_manual_job(
+                    runtime=runtime,
+                    request_id=42,
+                    job_name="sec_form3_ingest",
+                )
+            except RuntimeError:
+                # Rejection write failure escapes — _route_claim's broad
+                # except will mark the request rejected. That's correct.
+                pass
+        # The critical invariant: dispatch MUST NOT have fired.
+        runtime.submit_manual_with_request.assert_not_called()
+
     def test_connect_failure_fails_open(self) -> None:
         """Codex round-2 BLOCKING regression — psycopg.connect raising MUST
         fail-open (not escape to _route_claim, which would silently

--- a/tests/test_bootstrap_state_gate.py
+++ b/tests/test_bootstrap_state_gate.py
@@ -1,0 +1,212 @@
+"""Tests for the PR1b manual-queue prerequisite check.
+
+Pre-PR1b: scheduled fires honoured ScheduledJob.prerequisite (e.g.
+_bootstrap_complete on every SEC + fundamentals job); manual triggers
+via the durable queue bypassed the prerequisite entirely. PR1b extends
+the per-job prerequisite enforcement to the manual-queue dispatch path
+in app/jobs/listener.py::_dispatch_manual_job.
+
+Bootstrap-internal jobs (bootstrap_orchestrator + its stage jobs) are
+NOT in SCHEDULED_JOBS, so the lookup returns no prerequisite and the
+manual-queue path proceeds unchanged. This test pins both behaviours.
+
+Codex pre-push BLOCKING #1 + #2 are addressed by this design — the gate
+fires per-job from the existing prerequisite registry, not as a global
+bootstrap_state check, so:
+  - bootstrap_orchestrator (no prereq) is never gated, even with
+    bootstrap_state.status='running'.
+  - jobs without _bootstrap_complete prereq (orchestrator_high_frequency_sync,
+    execute_approved_orders, monitor_positions, ...) keep pre-PR1b
+    semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.jobs.listener import _dispatch_manual_job
+from app.workers.scheduler import SCHEDULED_JOBS
+
+
+def _runtime_mock() -> MagicMock:
+    """Mock JobRuntime that records submit_manual_with_request calls."""
+    runtime = MagicMock()
+    runtime.submit_manual_with_request = MagicMock()
+    return runtime
+
+
+def _job_with_prereq(name: str, met: bool, reason: str) -> Any:
+    """Build a ScheduledJob-like fake whose prerequisite returns (met, reason)."""
+    job = MagicMock()
+    job.name = name
+    job.prerequisite = MagicMock(return_value=(met, reason))
+    return job
+
+
+class TestPrereqEnforcement:
+    """Manual-queue path runs ScheduledJob.prerequisite if declared."""
+
+    def test_unmet_prereq_rejects_with_reason(self) -> None:
+        """Job with prereq returning (False, reason) → mark_request_rejected."""
+        runtime = _runtime_mock()
+        fake_job = _job_with_prereq(
+            "sec_form3_ingest", met=False, reason="first-install bootstrap not complete; visit /admin to run"
+        )
+        with (
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_form3_ingest"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="sec_form3_ingest",
+            )
+        # Should have rejected with the prereq's reason string.
+        mock_reject.assert_called_once()
+        kwargs = mock_reject.call_args.kwargs
+        assert kwargs["error_msg"] == "first-install bootstrap not complete; visit /admin to run"
+        # Must NOT have submitted to the runtime executor.
+        runtime.submit_manual_with_request.assert_not_called()
+
+    def test_met_prereq_proceeds_to_runtime(self) -> None:
+        """Job with prereq returning (True, '') → runtime.submit_manual_with_request fires."""
+        runtime = _runtime_mock()
+        fake_job = _job_with_prereq("sec_form3_ingest", met=True, reason="")
+        with (
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_form3_ingest"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="sec_form3_ingest",
+            )
+        mock_reject.assert_not_called()
+        runtime.submit_manual_with_request.assert_called_once_with("sec_form3_ingest", request_id=42, mode=None)
+
+    def test_no_prereq_proceeds_to_runtime(self) -> None:
+        """Job with no prereq declared → runtime.submit_manual_with_request fires.
+
+        Critical for bootstrap-internal jobs (bootstrap_orchestrator + stage
+        jobs) which are NOT in SCHEDULED_JOBS and therefore have no prereq
+        lookup — must not be gated by PR1b's manual-queue extension.
+        """
+        runtime = _runtime_mock()
+        # Empty SCHEDULED_JOBS — bootstrap_orchestrator pattern.
+        with (
+            patch("app.jobs.listener.SCHEDULED_JOBS", []),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"bootstrap_orchestrator"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="bootstrap_orchestrator",
+            )
+        mock_reject.assert_not_called()
+        runtime.submit_manual_with_request.assert_called_once()
+
+    def test_prereq_check_failure_fails_open(self) -> None:
+        """If prereq function itself raises, the job runs anyway (fail-open)."""
+        runtime = _runtime_mock()
+        bad_job = MagicMock()
+        bad_job.name = "fundamentals_sync"
+        bad_job.prerequisite = MagicMock(side_effect=RuntimeError("DB unavailable"))
+        with (
+            patch("app.jobs.listener.SCHEDULED_JOBS", [bad_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"fundamentals_sync"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="fundamentals_sync",
+            )
+        mock_reject.assert_not_called()
+        runtime.submit_manual_with_request.assert_called_once()
+
+    def test_connect_failure_fails_open(self) -> None:
+        """Codex round-2 BLOCKING regression — psycopg.connect raising MUST
+        fail-open (not escape to _route_claim, which would silently
+        mark the queue row rejected — divergence from scheduled-fire posture)."""
+        runtime = _runtime_mock()
+        fake_job = _job_with_prereq("sec_form3_ingest", met=False, reason="should not be reached")
+        with (
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_form3_ingest"}),
+            patch("app.jobs.listener.psycopg.connect", side_effect=RuntimeError("connect failed")),
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="sec_form3_ingest",
+            )
+        mock_reject.assert_not_called()
+        runtime.submit_manual_with_request.assert_called_once()
+
+
+class TestUnknownJobName:
+    """Pre-existing behaviour: unknown job_name → mark_request_rejected, no dispatch."""
+
+    def test_unknown_rejects(self) -> None:
+        runtime = _runtime_mock()
+        with (
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="completely_made_up_xyz",
+            )
+        mock_reject.assert_called_once()
+        kwargs = mock_reject.call_args.kwargs
+        assert "unknown job name" in kwargs["error_msg"]
+        runtime.submit_manual_with_request.assert_not_called()
+
+
+class TestRealRegistryCoverage:
+    """Coverage: real SCHEDULED_JOBS registry has _bootstrap_complete prereq
+    on the SEC + fundamentals jobs (the ones that would have hit the gate
+    in the original PR1b design). Spot-check that those jobs would gate."""
+
+    def test_sec_form3_has_bootstrap_complete_prereq(self) -> None:
+        from app.workers.scheduler import _bootstrap_complete
+
+        job = next(j for j in SCHEDULED_JOBS if j.name == "sec_form3_ingest")
+        assert job.prerequisite is _bootstrap_complete
+
+    def test_fundamentals_sync_has_bootstrap_complete_in_compose(self) -> None:
+        """fundamentals_sync uses _all_of(_bootstrap_complete, _has_any_coverage).
+        The composed prereq fires the bootstrap check first; manual-queue path
+        gets the same rejection."""
+        job = next(j for j in SCHEDULED_JOBS if j.name == "fundamentals_sync")
+        assert job.prerequisite is not None  # composed; identity check infeasible
+
+    def test_orchestrator_high_frequency_sync_has_no_prereq(self) -> None:
+        """Pre-PR1b non-gated job stays non-gated in PR1b. Critical for the
+        BLOCKING #2 Codex caught — global gate would have broken this."""
+        job = next(j for j in SCHEDULED_JOBS if j.name == "orchestrator_high_frequency_sync")
+        assert job.prerequisite is None
+
+    def test_execute_approved_orders_has_no_bootstrap_prereq(self) -> None:
+        """execute_approved_orders has _has_actionable_recommendations prereq,
+        NOT _bootstrap_complete. Pre-PR1b semantics preserved."""
+        from app.workers.scheduler import _bootstrap_complete, _has_actionable_recommendations
+
+        job = next(j for j in SCHEDULED_JOBS if j.name == "execute_approved_orders")
+        assert job.prerequisite is _has_actionable_recommendations
+        assert job.prerequisite is not _bootstrap_complete


### PR DESCRIPTION
## What
Extends the existing per-job ScheduledJob.prerequisite check from the scheduled-fire path to the manual-queue dispatch path in `app/jobs/listener.py::_dispatch_manual_job`. If the prerequisite returns `(False, reason)`, the listener `mark_request_rejected`s the queue row with the prereq's reason string (NOT `mark_request_completed` — PREVENTION-grade per data-engineer skill §6.5.7 step 8).

Bootstrap-internal jobs (`bootstrap_orchestrator` + its stage jobs) are NOT in `SCHEDULED_JOBS`, so the lookup returns no prerequisite and the manual-queue path proceeds unchanged. Jobs without `_bootstrap_complete` prereq (`orchestrator_high_frequency_sync`, `execute_approved_orders`, `monitor_positions`, etc.) keep pre-PR1b semantics.

## Why
Pre-PR1b: scheduled fires honoured `ScheduledJob.prerequisite` (e.g. `_bootstrap_complete` on every SEC + fundamentals job); manual triggers via the durable queue bypassed the prerequisite entirely. Operators could fire any SEC ingest from the admin panel during a half-installed dev DB, getting confusing "instruments=0" log lines + empty results.

## Design history (Codex pre-push rounds)
- **Round 1** caught two BLOCKING flaws in the original global-bootstrap-gate design: (1) gate would deadlock `bootstrap_orchestrator` itself (status='running' during dispatch), (2) behavior expansion to jobs that never had `_bootstrap_complete` prereq.
- **Redesign**: drop the new `bootstrap_gate.py` module entirely; reuse the per-job prereq registry. Net diff is ~50 lines in `listener.py` + tests.
- **Round 2** caught one BLOCKING (incomplete fail-open — try inside `with` lets `psycopg.connect` failures escape) + one WARNING (`claims_dispatched` counter increments on rejected paths). BLOCKING fixed; WARNING tech-debt.

## Schema / migration impact
None.

## Test plan
- [x] `uv run pytest tests/test_bootstrap_state_gate.py` — 10/10 pass
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright` — all clean
- [x] `pnpm --dir frontend typecheck` — clean (no FE changes in this PR)
- [x] Codex pre-push round 1 + round 2 — all findings addressed

## Conscious tradeoffs
- Fail-open posture preserved at the listener (matches scheduled-fire). A bootstrap-state gate is arguably a safety policy that should fail-closed, but diverging from the scheduled-fire posture would be confusing. PR1b-2 may revisit.
- DEFERRED to PR1b-2: `{params, control}` envelope on `POST /jobs/<name>/run`; `params_snapshot` populate; `_INVOKERS` contract widen; FE `TriggerConflictReason` `bootstrap_not_complete` + tooltip; operator override (`?override_bootstrap_gate=true` + `decision_audit` row).
- DEFERRED to PR1c: bespoke wrapper deletion + 11-file ref rewire.

Refs #1064.