### PR TITLE
feat(#1064): PR1b-2 — envelope + params_snapshot + universal bootstrap gate

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -49,6 +49,10 @@ from pydantic import BaseModel
 from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.jobs.runtime import VALID_JOB_NAMES
+from app.services.processes.param_metadata import (
+    ParamValidationError,
+    validate_job_params,
+)
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request
 
 logger = logging.getLogger(__name__)
@@ -128,13 +132,32 @@ class JobRunQueuedResponse(BaseModel):
     request_id: int
 
 
+# #1064 PR1b-2 — control allow-list. Any other key on ``body.control``
+# is a 400. Keep this tight: every entry is an operator-control flag the
+# dispatcher knows how to interpret. Adding a key requires a matching
+# dispatcher branch, otherwise the flag silently no-ops and the
+# operator's intent is lost.
+_ALLOWED_CONTROL_KEYS: frozenset[str] = frozenset({"override_bootstrap_gate"})
+
+
 @router.post(
     "/{job_name}/run",
     status_code=status.HTTP_202_ACCEPTED,
     response_model=JobRunQueuedResponse,
     dependencies=[Depends(require_session_or_service_token)],
 )
-def run_job(job_name: str, request: Request) -> Response:
+async def run_job(
+    job_name: str,
+    request: Request,
+    override_bootstrap_gate: bool = Query(
+        default=False,
+        description=(
+            "Operator escape hatch — when true, the bootstrap_state "
+            "gate is bypassed for this run and a decision_audit row "
+            "is written. Equivalent to body.control.override_bootstrap_gate."
+        ),
+    ),
+) -> Response:
     """Publish a manual run of *job_name* to the durable queue.
 
     The jobs process picks the request up via NOTIFY (or its 5s poll
@@ -145,6 +168,32 @@ def run_job(job_name: str, request: Request) -> Response:
     Validates ``job_name`` against the imported invoker registry
     BEFORE the INSERT — unknown names return 404 and never write a
     queue row.
+
+    Body envelope (#1064 PR1b-2):
+
+    ::
+
+        {
+          "params":  { ... validated job params ... },
+          "control": { "override_bootstrap_gate": true }   // optional
+        }
+
+    Legacy callers POSTing a flat dict (e.g. ``{"start_date": "..."}``)
+    are normalised to ``{"params": <body>, "control": {}}`` BEFORE
+    validation so existing operator scripts keep working without code
+    changes. ``params`` flows to the invoker AND
+    ``job_runs.params_snapshot``; ``control`` is consumed by the
+    dispatcher only and never reaches the invoker.
+
+    Validation:
+
+    * ``params`` is run through ``validate_job_params(allow_internal_keys=False)``.
+      Failures raise 400 with the offending field name.
+    * ``control`` keys are validated against
+      ``_ALLOWED_CONTROL_KEYS``. Unknown keys raise 400.
+    * The ``?override_bootstrap_gate=true`` query param is the
+      ergonomic shortcut for body.control.override_bootstrap_gate; both
+      ORed together drive the dispatcher's gate decision.
     """
     if job_name not in VALID_JOB_NAMES:
         raise HTTPException(
@@ -152,13 +201,127 @@ def run_job(job_name: str, request: Request) -> Response:
             detail=f"unknown job: {job_name}",
         )
 
+    raw_body = await _safe_read_json_body(request)
+    params, control = _normalise_envelope(raw_body)
+
+    try:
+        validated_params = validate_job_params(
+            job_name,
+            params,
+            allow_internal_keys=False,
+        )
+    except ParamValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    unknown_control = set(control) - _ALLOWED_CONTROL_KEYS
+    if unknown_control:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown control key(s): {sorted(unknown_control)}",
+        )
+
+    # Strict-bool check (Codex pre-push round 2 BLOCKING): truthy
+    # strings ("false", "0", "no") would otherwise grant the override.
+    # Require the JSON value to be exactly the boolean ``true``.
+    body_override_raw = control.get("override_bootstrap_gate", False)
+    if body_override_raw is not False and body_override_raw is not True:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="control.override_bootstrap_gate must be a boolean",
+        )
+    body_override = body_override_raw is True
+    # Query-param shortcut + body flag OR together — either path the
+    # operator chose surfaces in the durable payload.
+    effective_override = override_bootstrap_gate or body_override
+    canonical_control: dict[str, Any] = dict(control)
+    if effective_override:
+        canonical_control["override_bootstrap_gate"] = True
+
+    payload: dict[str, Any] = {
+        "params": validated_params,
+        "control": canonical_control,
+    }
+
     requested_by = _identify_requestor(request)
-    request_id = publish_manual_job_request(job_name, requested_by=requested_by)
+    request_id = publish_manual_job_request(
+        job_name,
+        requested_by=requested_by,
+        payload=payload,
+    )
     return Response(
         content=JobRunQueuedResponse(request_id=request_id).model_dump_json(),
         media_type="application/json",
         status_code=status.HTTP_202_ACCEPTED,
     )
+
+
+async def _safe_read_json_body(request: Request) -> Any:
+    """Read the request body as JSON, returning ``{}`` on empty body.
+
+    A POST with no body is the legitimate "no params" path — every
+    job that does not declare ``ParamMetadata`` accepts an empty
+    dict. We do not want to require operators to send ``{}`` to
+    trigger such jobs.
+    """
+    raw = await request.body()
+    if not raw:
+        return {}
+    try:
+        import json
+
+        return json.loads(raw)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"request body must be valid JSON: {exc}",
+        ) from exc
+
+
+def _normalise_envelope(raw_body: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Normalise the request body into ``(params, control)``.
+
+    Two accepted shapes:
+
+    1. Canonical envelope: ``{"params": {...}, "control": {...}}``.
+       Either key may be omitted (treated as ``{}``).
+    2. Legacy flat dict: ``{"start_date": "..."}`` etc. — the entire
+       body is treated as ``params`` with empty ``control``. This
+       keeps operator scripts that predate the envelope working.
+
+    Disambiguation: a body containing ``"params"`` OR ``"control"``
+    keys is interpreted as the canonical envelope; otherwise the
+    legacy flat-dict path is taken. A flat dict that legitimately
+    has a ``params`` field collides with the envelope shape — that
+    collision is acceptable for PR1b-2 because no current job's
+    ``ParamMetadata`` declares a param named ``params`` or
+    ``control``.
+
+    Raises 400 on any non-dict body (lists, strings, numbers).
+    """
+    if not isinstance(raw_body, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"request body must be a JSON object (got {type(raw_body).__name__})",
+        )
+
+    has_envelope_keys = "params" in raw_body or "control" in raw_body
+    if has_envelope_keys:
+        params = raw_body.get("params", {})
+        control = raw_body.get("control", {})
+        if not isinstance(params, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="body.params must be a JSON object",
+            )
+        if not isinstance(control, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="body.control must be a JSON object",
+            )
+        return dict(params), dict(control)
+
+    # Legacy flat-dict — entire body is params.
+    return dict(raw_body), {}
 
 
 def _identify_requestor(request: Request) -> str:

--- a/app/jobs/listener.py
+++ b/app/jobs/listener.py
@@ -40,6 +40,11 @@ import psycopg.sql
 
 from app.config import settings
 from app.jobs.runtime import VALID_JOB_NAMES, JobRuntime
+from app.services.processes.bootstrap_gate import check_bootstrap_state_gate
+from app.services.processes.param_metadata import (
+    ParamValidationError,
+    validate_job_params,
+)
 from app.services.sync_orchestrator.dispatcher import (
     NOTIFY_CHANNEL,
     claim_oldest_pending,
@@ -91,6 +96,7 @@ def _dispatch_manual_job(
     runtime: JobRuntime,
     request_id: int,
     job_name: str | None,
+    payload: Any = None,
     mode: str | None = None,
 ) -> None:
     """Inner-loop dispatch for ``request_kind='manual_job'``.
@@ -118,6 +124,98 @@ def _dispatch_manual_job(
                 error_msg=f"unknown job name: {job_name!r}",
             )
         return
+
+    # PR1b-2 #1064 — extract canonical envelope from durable payload.
+    # ``payload`` is the JSONB blob from ``pending_job_requests.payload``;
+    # ``None`` covers legacy queue rows written before PR1b-2 (and the
+    # synthetic "no body" path that publishes payload=NULL). Keys missing
+    # from the envelope default to empty dicts so downstream code can
+    # consume them uniformly. A structurally malformed envelope
+    # (params/control present but not a JSON object) is rejected with
+    # the contract message — silent coercion would mask the violation
+    # for direct queue inserts.
+    try:
+        raw_params, control = _extract_envelope(payload)
+    except _MalformedEnvelopeError as exc:
+        logger.info(
+            "listener: rejecting manual_job request_id=%d for %r — malformed envelope: %s",
+            request_id,
+            job_name,
+            exc,
+        )
+        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+            mark_request_rejected(conn, request_id, error_msg=f"malformed payload: {exc}")
+        return
+
+    # Validate the durable payload's params dict against the registry.
+    # The API path (run_job) already validated when the queue row was
+    # written, but the listener must be defensive: a direct INSERT into
+    # the queue (operator script, batch tool) bypasses the API. Reject
+    # such rows BEFORE invoker dispatch so the operator sees the
+    # contract violation in the queue row's error_msg.
+    try:
+        validated_params = validate_job_params(
+            job_name,
+            raw_params,
+            allow_internal_keys=False,
+        )
+    except ParamValidationError as exc:
+        logger.info(
+            "listener: rejecting manual_job request_id=%d for %r — params invalid: %s",
+            request_id,
+            job_name,
+            exc,
+        )
+        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+            mark_request_rejected(conn, request_id, error_msg=f"invalid params: {exc}")
+        return
+
+    # ``_extract_envelope`` already enforced strict-bool typing; we can
+    # safely read the value as-is without a coercion that would treat
+    # truthy strings as override.
+    override_present = control.get("override_bootstrap_gate", False) is True
+
+    # PR1b-2 #1064 — bootstrap_state gate at manual-queue dispatch.
+    # Mirrors the scheduled-fire path in app/jobs/runtime.py::_wrap_invoker.
+    # Bootstrap-internal jobs (orchestrator + its stage jobs) are NOT in
+    # SCHEDULED_JOBS, so the registry lookup returns no entry and the
+    # gate is skipped — the orchestrator MUST be able to run while
+    # bootstrap_state.status='running' or it would deadlock itself.
+    job_in_registry = any(j.name == job_name for j in SCHEDULED_JOBS)
+    if job_in_registry:
+        try:
+            with psycopg.connect(settings.database_url, autocommit=True) as conn:
+                allowed, reason = check_bootstrap_state_gate(
+                    conn,
+                    job_name=job_name,
+                    invocation_path="manual_queue",
+                    override_present=override_present,
+                )
+        except Exception:
+            # Fail-open mirrors the prereq check below — a transient
+            # bootstrap_state read failure should not silently drop a
+            # real run; the body-side guards still apply.
+            logger.warning(
+                "listener: bootstrap_state gate for %r failed; running anyway",
+                job_name,
+                exc_info=True,
+            )
+            allowed, reason = True, ""
+
+        if not allowed:
+            logger.info(
+                "listener: rejecting manual_job request_id=%d for %r — %s",
+                request_id,
+                job_name,
+                reason,
+            )
+            with psycopg.connect(settings.database_url, autocommit=True) as conn:
+                # PREVENTION-grade: data-engineer skill §6.5.7 step 8
+                # mandates mark_request_rejected (NOT _completed) for
+                # any prelude-skip path. A 'completed' row would falsely
+                # claim the job ran.
+                mark_request_rejected(conn, request_id, error_msg=reason)
+            return
 
     # PR1b #1064 — extend per-job prerequisite check to the manual-queue
     # path. The scheduled-fire path in app/jobs/runtime.py::_wrap_invoker
@@ -187,7 +285,87 @@ def _dispatch_manual_job(
     # Submit to the runtime's manual executor. The runtime's own
     # wrapper handles the linked_request_id / dispatched / completed
     # transitions inside the executor task.
-    runtime.submit_manual_with_request(job_name, request_id=request_id, mode=mode)
+    runtime.submit_manual_with_request(
+        job_name,
+        request_id=request_id,
+        mode=mode,
+        params=validated_params,
+    )
+
+
+class _MalformedEnvelopeError(ValueError):
+    """``pending_job_requests.payload`` is structurally invalid.
+
+    Raised by ``_extract_envelope`` when the payload has the canonical
+    envelope shape but ``body.params`` or ``body.control`` is not a
+    JSON object. The listener maps this to ``mark_request_rejected``
+    with the message body so the operator sees the contract violation
+    on ``GET /jobs/requests``. Codex pre-push round 1 WARNING.
+    """
+
+
+# Codex pre-push round 2 WARNING: control allow-list at the listener.
+# Mirrors ``_ALLOWED_CONTROL_KEYS`` in app/api/jobs.py so a direct
+# queue insert with a typo'd flag (``override_bootstrap_gates``) is
+# rejected at dispatch instead of silently no-opping the operator's
+# intent.
+_LISTENER_ALLOWED_CONTROL_KEYS: frozenset[str] = frozenset({"override_bootstrap_gate"})
+
+
+def _extract_envelope(payload: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Decode the durable payload into ``(params, control)``.
+
+    PR1b-2 (#1064): ``pending_job_requests.payload`` carries the
+    canonical envelope ``{"params": {...}, "control": {...}}``. This
+    helper tolerates three input shapes so the listener stays robust
+    against direct queue inserts and pre-PR1b-2 rows:
+
+    1. ``None`` — legacy row or empty body. Returns ``({}, {})``.
+    2. Canonical envelope dict — extract ``params`` and ``control``,
+       defaulting either to ``{}`` when absent. Raises
+       ``_MalformedEnvelopeError`` when the inner ``params`` /
+       ``control`` exists but is not a JSON object, when an unknown
+       control key is set, or when ``override_bootstrap_gate`` is not
+       a boolean — silent coercion would mask a real contract violation.
+    3. Flat dict (legacy ergonomic shape) — entire payload becomes
+       ``params`` with empty ``control``. Mirrors the API
+       ``_normalise_envelope`` helper so a directly-inserted row goes
+       through the same disambiguation rule.
+
+    Top-level non-dict payloads (lists, strings, numbers) raise
+    ``_MalformedEnvelopeError`` — the API rejects them at the boundary,
+    and a direct queue insert with the same shape is just as broken.
+    Codex pre-push round 2 WARNING.
+    """
+    if payload is None:
+        return ({}, {})
+    if not isinstance(payload, dict):
+        raise _MalformedEnvelopeError(f"payload must be a JSON object (got {type(payload).__name__})")
+
+    has_envelope_keys = "params" in payload or "control" in payload
+    if not has_envelope_keys:
+        return (dict(payload), {})
+
+    params = payload.get("params", {})
+    control = payload.get("control", {})
+    if params is None:
+        params = {}
+    if control is None:
+        control = {}
+    if not isinstance(params, dict):
+        raise _MalformedEnvelopeError(f"payload.params must be a JSON object (got {type(params).__name__})")
+    if not isinstance(control, dict):
+        raise _MalformedEnvelopeError(f"payload.control must be a JSON object (got {type(control).__name__})")
+
+    unknown = set(control) - _LISTENER_ALLOWED_CONTROL_KEYS
+    if unknown:
+        raise _MalformedEnvelopeError(f"unknown control key(s): {sorted(unknown)}")
+    # Strict-bool check (Codex pre-push round 2 BLOCKING): truthy strings
+    # like ``"false"`` would otherwise grant the override via ``bool(...)``.
+    raw_override = control.get("override_bootstrap_gate", False)
+    if raw_override is not False and raw_override is not True:
+        raise _MalformedEnvelopeError("control.override_bootstrap_gate must be a boolean")
+    return (dict(params), dict(control))
 
 
 def _dispatch_sync_request(
@@ -435,6 +613,7 @@ def _route_claim(
                 runtime=runtime,
                 request_id=request_id,
                 job_name=claim["job_name"],
+                payload=claim.get("payload"),
                 mode=claim.get("mode"),
             )
             state.claims_dispatched += 1

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -42,19 +42,27 @@ import contextvars
 import logging
 import os
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
-from typing import Final
+from typing import Any, Final
 
 import psycopg
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+from psycopg.types.json import Jsonb
 
 from app.config import settings
 from app.jobs.locks import JobAlreadyRunning, JobLock
+from app.jobs.sources import JobInvoker
 from app.services.ops_monitor import fetch_latest_successful_runs, record_job_skip
 from app.services.process_stop import acquire_prelude_lock
+from app.services.processes.bootstrap_gate import check_bootstrap_state_gate
+from app.services.processes.param_metadata import (
+    ParamValidationError,
+    materialise_scheduled_params,
+    validate_job_params,
+)
 from app.services.sync_orchestrator.types import OrchestratorFenceHeld
 from app.workers.scheduler import (
     JOB_ATTRIBUTION_SUMMARY,
@@ -165,54 +173,83 @@ logger = logging.getLogger(__name__)
 # this map with ``SCHEDULED_JOBS``, and ``test_jobs_runtime.py`` asserts
 # the two are equal so a job declared in the registry without an invoker
 # (or vice versa) fails the test rather than silently no-opping.
+#
+# Contract widening (#1064 PR1b-2): the registry stores ``JobInvoker``
+# (``Callable[[Mapping[str, Any]], None]``). Existing zero-arg bodies
+# are adapted at registration via ``_adapt_zero_arg`` — the body still
+# ignores params; PR1c lifts the bespoke bootstrap wrappers and
+# migrates the three affected bodies (``filings_history_seed``,
+# ``sec_first_install_drain``, ``sec_13f_quarterly_sweep``) to consume
+# the params dict directly. Adapting at the registration boundary keeps
+# the body diff zero for the ~35 jobs that PR1c will not touch.
 
-_INVOKERS: Final[dict[str, Callable[[], None]]] = {
-    JOB_NIGHTLY_UNIVERSE_SYNC: nightly_universe_sync,
-    JOB_DAILY_CANDLE_REFRESH: daily_candle_refresh,
-    JOB_ETORO_LOOKUPS_REFRESH: etoro_lookups_refresh,
-    JOB_EXCHANGES_METADATA_REFRESH: exchanges_metadata_refresh,
-    JOB_FX_RATES_REFRESH: fx_rates_refresh,
-    JOB_DAILY_RESEARCH_REFRESH: daily_research_refresh,
-    JOB_DAILY_PORTFOLIO_SYNC: daily_portfolio_sync,
-    JOB_EXECUTE_APPROVED_ORDERS: execute_approved_orders,
-    JOB_MORNING_CANDIDATE_REVIEW: morning_candidate_review,
-    JOB_FUNDAMENTALS_SYNC: fundamentals_sync,
-    JOB_DAILY_TAX_RECONCILIATION: daily_tax_reconciliation,
-    JOB_RETRY_DEFERRED: retry_deferred_recommendations_job,
-    JOB_MONITOR_POSITIONS: monitor_positions_job,
-    JOB_ATTRIBUTION_SUMMARY: attribution_summary_job,
-    JOB_SEED_COST_MODELS: seed_cost_models,
-    JOB_WEEKLY_REPORT: weekly_report,
-    JOB_MONTHLY_REPORT: monthly_report,
-    JOB_ORCHESTRATOR_FULL_SYNC: orchestrator_full_sync,
-    JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC: orchestrator_high_frequency_sync,
-    JOB_RAW_DATA_RETENTION_SWEEP: raw_data_retention_sweep,
-    JOB_SEC_BUSINESS_SUMMARY_INGEST: sec_business_summary_ingest,
-    JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP: sec_business_summary_bootstrap,
-    JOB_SEC_DIVIDEND_CALENDAR_INGEST: sec_dividend_calendar_ingest,
-    JOB_SEC_INSIDER_TRANSACTIONS_INGEST: sec_insider_transactions_ingest,
-    JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL: sec_insider_transactions_backfill,
-    JOB_SEC_FORM3_INGEST: sec_form3_ingest,
-    JOB_SEC_DEF14A_INGEST: sec_def14a_ingest,
-    JOB_SEC_DEF14A_BOOTSTRAP: sec_def14a_bootstrap,
-    JOB_SEC_8K_EVENTS_INGEST: sec_8k_events_ingest,
-    JOB_SEC_FILING_DOCUMENTS_INGEST: sec_filing_documents_ingest,
-    JOB_CUSIP_EXTID_SWEEP: cusip_extid_sweep,
-    JOB_CUSIP_UNIVERSE_BACKFILL: cusip_universe_backfill,
-    JOB_OWNERSHIP_OBSERVATIONS_SYNC: ownership_observations_sync,
-    JOB_OWNERSHIP_OBSERVATIONS_BACKFILL: ownership_observations_backfill,
-    JOB_SEC_13F_FILER_DIRECTORY_SYNC: sec_13f_filer_directory_sync,
-    JOB_SEC_13F_QUARTERLY_SWEEP: sec_13f_quarterly_sweep,
-    JOB_SEC_NPORT_FILER_DIRECTORY_SYNC: sec_nport_filer_directory_sync,
-    JOB_SEC_N_PORT_INGEST: sec_n_port_ingest,
+
+def _adapt_zero_arg(fn: Callable[[], None]) -> JobInvoker:
+    """Wrap a zero-arg invoker into the ``JobInvoker`` contract.
+
+    Discards the params dict and calls the underlying function. Used
+    only at the registration boundary so ``_INVOKERS`` keeps its
+    uniform ``JobInvoker`` shape without forcing a body-level rewrite
+    on every scheduled-job function. PR1c's bespoke-wrapper lift will
+    drop the adapter on the three jobs whose bodies start consuming
+    params; everything else keeps its zero-arg body indefinitely.
+    """
+
+    def _adapted(params: Mapping[str, Any]) -> None:
+        del params  # PR1b-2 widening; PR1c lifts adapter on consuming jobs.
+        fn()
+
+    _adapted.__wrapped__ = fn  # type: ignore[attr-defined]
+    return _adapted
+
+
+_INVOKERS: Final[dict[str, JobInvoker]] = {
+    JOB_NIGHTLY_UNIVERSE_SYNC: _adapt_zero_arg(nightly_universe_sync),
+    JOB_DAILY_CANDLE_REFRESH: _adapt_zero_arg(daily_candle_refresh),
+    JOB_ETORO_LOOKUPS_REFRESH: _adapt_zero_arg(etoro_lookups_refresh),
+    JOB_EXCHANGES_METADATA_REFRESH: _adapt_zero_arg(exchanges_metadata_refresh),
+    JOB_FX_RATES_REFRESH: _adapt_zero_arg(fx_rates_refresh),
+    JOB_DAILY_RESEARCH_REFRESH: _adapt_zero_arg(daily_research_refresh),
+    JOB_DAILY_PORTFOLIO_SYNC: _adapt_zero_arg(daily_portfolio_sync),
+    JOB_EXECUTE_APPROVED_ORDERS: _adapt_zero_arg(execute_approved_orders),
+    JOB_MORNING_CANDIDATE_REVIEW: _adapt_zero_arg(morning_candidate_review),
+    JOB_FUNDAMENTALS_SYNC: _adapt_zero_arg(fundamentals_sync),
+    JOB_DAILY_TAX_RECONCILIATION: _adapt_zero_arg(daily_tax_reconciliation),
+    JOB_RETRY_DEFERRED: _adapt_zero_arg(retry_deferred_recommendations_job),
+    JOB_MONITOR_POSITIONS: _adapt_zero_arg(monitor_positions_job),
+    JOB_ATTRIBUTION_SUMMARY: _adapt_zero_arg(attribution_summary_job),
+    JOB_SEED_COST_MODELS: _adapt_zero_arg(seed_cost_models),
+    JOB_WEEKLY_REPORT: _adapt_zero_arg(weekly_report),
+    JOB_MONTHLY_REPORT: _adapt_zero_arg(monthly_report),
+    JOB_ORCHESTRATOR_FULL_SYNC: _adapt_zero_arg(orchestrator_full_sync),
+    JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC: _adapt_zero_arg(orchestrator_high_frequency_sync),
+    JOB_RAW_DATA_RETENTION_SWEEP: _adapt_zero_arg(raw_data_retention_sweep),
+    JOB_SEC_BUSINESS_SUMMARY_INGEST: _adapt_zero_arg(sec_business_summary_ingest),
+    JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP: _adapt_zero_arg(sec_business_summary_bootstrap),
+    JOB_SEC_DIVIDEND_CALENDAR_INGEST: _adapt_zero_arg(sec_dividend_calendar_ingest),
+    JOB_SEC_INSIDER_TRANSACTIONS_INGEST: _adapt_zero_arg(sec_insider_transactions_ingest),
+    JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL: _adapt_zero_arg(sec_insider_transactions_backfill),
+    JOB_SEC_FORM3_INGEST: _adapt_zero_arg(sec_form3_ingest),
+    JOB_SEC_DEF14A_INGEST: _adapt_zero_arg(sec_def14a_ingest),
+    JOB_SEC_DEF14A_BOOTSTRAP: _adapt_zero_arg(sec_def14a_bootstrap),
+    JOB_SEC_8K_EVENTS_INGEST: _adapt_zero_arg(sec_8k_events_ingest),
+    JOB_SEC_FILING_DOCUMENTS_INGEST: _adapt_zero_arg(sec_filing_documents_ingest),
+    JOB_CUSIP_EXTID_SWEEP: _adapt_zero_arg(cusip_extid_sweep),
+    JOB_CUSIP_UNIVERSE_BACKFILL: _adapt_zero_arg(cusip_universe_backfill),
+    JOB_OWNERSHIP_OBSERVATIONS_SYNC: _adapt_zero_arg(ownership_observations_sync),
+    JOB_OWNERSHIP_OBSERVATIONS_BACKFILL: _adapt_zero_arg(ownership_observations_backfill),
+    JOB_SEC_13F_FILER_DIRECTORY_SYNC: _adapt_zero_arg(sec_13f_filer_directory_sync),
+    JOB_SEC_13F_QUARTERLY_SWEEP: _adapt_zero_arg(sec_13f_quarterly_sweep),
+    JOB_SEC_NPORT_FILER_DIRECTORY_SYNC: _adapt_zero_arg(sec_nport_filer_directory_sync),
+    JOB_SEC_N_PORT_INGEST: _adapt_zero_arg(sec_n_port_ingest),
     # Registered for #994 (first-install bootstrap orchestrator) — these
     # were callable as scheduled-only paths before but the orchestrator
     # needs them in _INVOKERS so it can dispatch them via JobLock.
     # ``daily_cik_refresh`` seeds external_identifiers SEC CIK rows;
     # ``daily_financial_facts`` walks the SEC daily master-index.
     # Both are also wired into SCHEDULED_JOBS unchanged.
-    JOB_DAILY_CIK_REFRESH: daily_cik_refresh,
-    JOB_DAILY_FINANCIAL_FACTS: daily_financial_facts,
+    JOB_DAILY_CIK_REFRESH: _adapt_zero_arg(daily_cik_refresh),
+    JOB_DAILY_FINANCIAL_FACTS: _adapt_zero_arg(daily_financial_facts),
 }
 
 
@@ -229,14 +266,18 @@ from app.services import sec_bulk_download as _sec_bulk_download  # noqa: E402
 
 # #1021 — bulk-archive download stage A3 of the bulk-datasets-first
 # bootstrap (#1020). Registered so the orchestrator can dispatch it.
-_INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _sec_bulk_download.sec_bulk_download_job
-_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_ORCHESTRATOR] = _bootstrap_orchestrator.run_bootstrap_orchestrator
-_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_FILINGS_HISTORY_SEED] = (
+_INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _adapt_zero_arg(_sec_bulk_download.sec_bulk_download_job)
+_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_ORCHESTRATOR] = _adapt_zero_arg(
+    _bootstrap_orchestrator.run_bootstrap_orchestrator
+)
+_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_FILINGS_HISTORY_SEED] = _adapt_zero_arg(
     _bootstrap_orchestrator.bootstrap_filings_history_seed
 )
-_INVOKERS[_bootstrap_orchestrator.JOB_SEC_FIRST_INSTALL_DRAIN] = _bootstrap_orchestrator.sec_first_install_drain_job
+_INVOKERS[_bootstrap_orchestrator.JOB_SEC_FIRST_INSTALL_DRAIN] = _adapt_zero_arg(
+    _bootstrap_orchestrator.sec_first_install_drain_job
+)
 # #1008 — recency-bounded 13F sweep for first-install bootstrap.
-_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP] = (
+_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP] = _adapt_zero_arg(
     _bootstrap_orchestrator.bootstrap_sec_13f_recent_sweep_job
 )
 
@@ -254,13 +295,15 @@ from app.services import sec_submissions_files_walk as _files_walk  # noqa: E402
 # Phase A3 — bulk archive download (#1021 / #1020). Registered here
 # so PR7 is self-consistent if PR #1029 has not yet landed; the
 # duplicate dict-key assignment when both PRs are merged is a no-op.
-_INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _sec_bulk_download.sec_bulk_download_job
-_INVOKERS[_bulk_jobs.JOB_SEC_SUBMISSIONS_INGEST] = _bulk_jobs.sec_submissions_ingest_job
-_INVOKERS[_bulk_jobs.JOB_SEC_COMPANYFACTS_INGEST] = _bulk_jobs.sec_companyfacts_ingest_job
-_INVOKERS[_bulk_jobs.JOB_SEC_13F_INGEST_FROM_DATASET] = _bulk_jobs.sec_13f_ingest_from_dataset_job
-_INVOKERS[_bulk_jobs.JOB_SEC_INSIDER_INGEST_FROM_DATASET] = _bulk_jobs.sec_insider_ingest_from_dataset_job
-_INVOKERS[_bulk_jobs.JOB_SEC_NPORT_INGEST_FROM_DATASET] = _bulk_jobs.sec_nport_ingest_from_dataset_job
-_INVOKERS[_files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK] = _files_walk.sec_submissions_files_walk_job
+_INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _adapt_zero_arg(_sec_bulk_download.sec_bulk_download_job)
+_INVOKERS[_bulk_jobs.JOB_SEC_SUBMISSIONS_INGEST] = _adapt_zero_arg(_bulk_jobs.sec_submissions_ingest_job)
+_INVOKERS[_bulk_jobs.JOB_SEC_COMPANYFACTS_INGEST] = _adapt_zero_arg(_bulk_jobs.sec_companyfacts_ingest_job)
+_INVOKERS[_bulk_jobs.JOB_SEC_13F_INGEST_FROM_DATASET] = _adapt_zero_arg(_bulk_jobs.sec_13f_ingest_from_dataset_job)
+_INVOKERS[_bulk_jobs.JOB_SEC_INSIDER_INGEST_FROM_DATASET] = _adapt_zero_arg(
+    _bulk_jobs.sec_insider_ingest_from_dataset_job
+)
+_INVOKERS[_bulk_jobs.JOB_SEC_NPORT_INGEST_FROM_DATASET] = _adapt_zero_arg(_bulk_jobs.sec_nport_ingest_from_dataset_job)
+_INVOKERS[_files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK] = _adapt_zero_arg(_files_walk.sec_submissions_files_walk_job)
 
 
 # Public registry of valid job names. The API layer (#719) imports this
@@ -344,6 +387,17 @@ _PRELUDE_OPT_OUT_JOBS: frozenset[str] = frozenset(
 _prelude_run_id: contextvars.ContextVar[int | None] = contextvars.ContextVar("_prelude_run_id", default=None)
 
 
+# #1064 PR1b-2 — carries the validated params snapshot into ``_tracked_job``
+# for the prelude-fallback path (``record_job_start``). The prelude itself
+# writes the snapshot inline in its ``INSERT INTO job_runs``; this var
+# covers invokers that bypass the prelude (bootstrap stage invokers,
+# direct test invocations) so their ``record_job_start`` call can persist
+# the same snapshot.
+_params_snapshot_var: contextvars.ContextVar[Mapping[str, Any] | None] = contextvars.ContextVar(
+    "_params_snapshot_var", default=None
+)
+
+
 # #1078 — admin control hub PR6. Plumbs the listener-decoded
 # ``(linked_request_id, mode)`` into prelude-opt-out invokers. The
 # orchestrator's wrapper (``orchestrator_full_sync()``) consumes this
@@ -369,6 +423,26 @@ def consume_prelude_run_id() -> int | None:
     if run_id is not None:
         _prelude_run_id.set(None)
     return run_id
+
+
+def consume_params_snapshot() -> Mapping[str, Any] | None:
+    """Pop the validated params snapshot for the current invoker call.
+
+    Issue #1064 PR1b-2 — admin control hub job-registry refactor.
+
+    ``_tracked_job`` calls this on entry from the prelude-fallback
+    path so ``record_job_start`` can persist the snapshot alongside
+    the new ``job_runs`` row. Returns ``None`` when the invoker was
+    started outside the runtime wrappers (direct test invocation)
+    — the column default ``'{}'`` then applies.
+
+    Idempotent: clears the contextvar after read so a nested
+    ``_tracked_job`` cannot reuse the same snapshot.
+    """
+    snapshot = _params_snapshot_var.get()
+    if snapshot is not None:
+        _params_snapshot_var.set(None)
+    return snapshot
 
 
 def consume_invoker_request_context() -> tuple[int | None, str | None]:
@@ -397,6 +471,7 @@ def _run_prelude(
     *,
     bypass_fence_check: bool = False,
     linked_request_id: int | None = None,
+    params_snapshot: Mapping[str, Any] | None = None,
 ) -> int | None:
     """One-tx prelude: acquire lock, check fence, write job_runs INSERT.
 
@@ -487,6 +562,12 @@ def _run_prelude(
                     if holder_row is not None:
                         fence_held = True
                         fence_holder = str(holder_row[0])
+                # PR1b-2 (#1064): write ``params_snapshot`` inline on both
+                # branches (running + skipped). Passing ``None`` falls back
+                # to the column default ``'{}'`` so the legacy paths stay
+                # forward-compatible. Jsonb wraps the dict for psycopg's
+                # JSONB adapter.
+                snapshot_json = Jsonb(dict(params_snapshot)) if params_snapshot is not None else None
                 if fence_held:
                     # When a sibling holds the fence, surface the holder
                     # in the audit row so the operator can see WHY this
@@ -498,28 +579,53 @@ def _run_prelude(
                         if fence_holder == process_id
                         else f"full-wash in progress on shared scheduler source (held by {fence_holder!r})"
                     )
-                    cur.execute(
-                        """
-                        INSERT INTO job_runs (
-                            job_name, started_at, finished_at, status, row_count,
-                            error_msg, linked_request_id
-                        ) VALUES (
-                            %s, now(), now(), 'skipped', 0, %s, %s
+                    if snapshot_json is None:
+                        cur.execute(
+                            """
+                            INSERT INTO job_runs (
+                                job_name, started_at, finished_at, status, row_count,
+                                error_msg, linked_request_id
+                            ) VALUES (
+                                %s, now(), now(), 'skipped', 0, %s, %s
+                            )
+                            RETURNING run_id
+                            """,
+                            (job_name, error_msg, linked_request_id),
                         )
-                        RETURNING run_id
-                        """,
-                        (job_name, error_msg, linked_request_id),
-                    )
+                    else:
+                        cur.execute(
+                            """
+                            INSERT INTO job_runs (
+                                job_name, started_at, finished_at, status, row_count,
+                                error_msg, linked_request_id, params_snapshot
+                            ) VALUES (
+                                %s, now(), now(), 'skipped', 0, %s, %s, %s
+                            )
+                            RETURNING run_id
+                            """,
+                            (job_name, error_msg, linked_request_id, snapshot_json),
+                        )
                 else:
-                    cur.execute(
-                        """
-                        INSERT INTO job_runs (
-                            job_name, started_at, status, linked_request_id
-                        ) VALUES (%s, now(), 'running', %s)
-                        RETURNING run_id
-                        """,
-                        (job_name, linked_request_id),
-                    )
+                    if snapshot_json is None:
+                        cur.execute(
+                            """
+                            INSERT INTO job_runs (
+                                job_name, started_at, status, linked_request_id
+                            ) VALUES (%s, now(), 'running', %s)
+                            RETURNING run_id
+                            """,
+                            (job_name, linked_request_id),
+                        )
+                    else:
+                        cur.execute(
+                            """
+                            INSERT INTO job_runs (
+                                job_name, started_at, status, linked_request_id, params_snapshot
+                            ) VALUES (%s, now(), 'running', %s, %s)
+                            RETURNING run_id
+                            """,
+                            (job_name, linked_request_id, snapshot_json),
+                        )
                 row = cur.fetchone()
                 if row is None:
                     raise RuntimeError("prelude: job_runs INSERT returned no row")
@@ -538,10 +644,11 @@ def _run_prelude(
 def run_with_prelude(
     database_url: str,
     job_name: str,
-    invoker: Callable[[], None],
+    invoker: JobInvoker,
     *,
     bypass_fence_check: bool = False,
     linked_request_id: int | None = None,
+    params: Mapping[str, Any] | None = None,
 ) -> bool:
     """Run ``invoker`` after the lock+fence prelude.
 
@@ -577,19 +684,23 @@ def run_with_prelude(
     suppress double-replay of completed runs. Scheduled fires pass
     ``None``.
     """
+    effective_params: Mapping[str, Any] = params if params is not None else {}
     run_id = _run_prelude(
         database_url,
         job_name,
         bypass_fence_check=bypass_fence_check,
         linked_request_id=linked_request_id,
+        params_snapshot=effective_params,
     )
     if run_id is None:
         return False  # fence held; skipped row already committed
     token = _prelude_run_id.set(run_id)
+    snapshot_token = _params_snapshot_var.set(effective_params)
     try:
-        invoker()
+        invoker(effective_params)
     finally:
         _prelude_run_id.reset(token)
+        _params_snapshot_var.reset(snapshot_token)
     return True
 
 
@@ -659,11 +770,11 @@ class JobRuntime:
         self,
         *,
         database_url: str | None = None,
-        invokers: dict[str, Callable[[], None]] | None = None,
+        invokers: dict[str, JobInvoker] | None = None,
     ) -> None:
         self._database_url = database_url or settings.database_url
         # Copy so callers cannot mutate after construction.
-        self._invokers: dict[str, Callable[[], None]] = dict(invokers if invokers is not None else _INVOKERS)
+        self._invokers: dict[str, JobInvoker] = dict(invokers if invokers is not None else _INVOKERS)
         # Per-job in-process lock for synchronous 409 detection on
         # manual triggers. The advisory ``JobLock`` (Postgres) is the
         # cross-process source of truth and is acquired on the worker
@@ -838,11 +949,55 @@ class JobRuntime:
             with psycopg.connect(self._database_url, autocommit=True) as conn:
                 for name in overdue:
                     job = catch_up_jobs[name]
+                    # PR1b-2 (#1064): materialise + validate registry-default
+                    # params so any pre-skip path persists the same snapshot
+                    # the eventual run would have. Validation failure here is
+                    # treated as a skip with the validation message — same
+                    # posture as ``_wrap_invoker``.
+                    raw_defaults = materialise_scheduled_params(name)
+                    try:
+                        params_dict = validate_job_params(
+                            name,
+                            raw_defaults,
+                            allow_internal_keys=False,
+                        )
+                    except ParamValidationError as exc:
+                        processed.add(name)
+                        # Snapshot raw materialised defaults so the audit row
+                        # preserves the same shape as successful catch-up
+                        # fires (Codex pre-push round 2 NIT).
+                        record_job_skip(
+                            conn,
+                            name,
+                            f"registry default params invalid: {exc}",
+                            params_snapshot=dict(raw_defaults),
+                        )
+                        skipped.append((name, f"registry default params invalid: {exc}"))
+                        continue
+
+                    # PR1b-2 (#1064): universal bootstrap_state gate runs
+                    # BEFORE the per-job prereq so the actionable reason
+                    # ``bootstrap_not_complete`` wins when both would block.
+                    # Catch-up is the boot-time scheduled fire equivalent
+                    # — never an operator-driven path, so override is
+                    # never present.
+                    gate_allowed, gate_reason = check_bootstrap_state_gate(
+                        conn,
+                        job_name=name,
+                        invocation_path="scheduled",
+                        override_present=False,
+                    )
+                    if not gate_allowed:
+                        processed.add(name)
+                        record_job_skip(conn, name, gate_reason, params_snapshot=dict(params_dict))
+                        skipped.append((name, gate_reason))
+                        continue
+
                     if job.prerequisite is not None:
                         met, reason = job.prerequisite(conn)
                         if not met:
                             processed.add(name)
-                            record_job_skip(conn, name, reason)
+                            record_job_skip(conn, name, reason, params_snapshot=dict(params_dict))
                             skipped.append((name, reason))
                             continue
                     firing.append(name)
@@ -1046,7 +1201,7 @@ class JobRuntime:
         if not inflight.acquire(blocking=False):
             raise JobAlreadyRunning(job_name)
         try:
-            fut = self._manual_executor.submit(self._run_manual, job_name, invoker, None)
+            fut = self._manual_executor.submit(self._run_manual, job_name, invoker, None, None, {})
             fut.add_done_callback(self._log_future_exception)
         except Exception:
             # Submission failed before the worker took ownership --
@@ -1060,6 +1215,7 @@ class JobRuntime:
         *,
         request_id: int,
         mode: str | None = None,
+        params: Mapping[str, Any] | None = None,
     ) -> None:
         """Submit a manual run associated with a queue request_id (#719).
 
@@ -1112,7 +1268,14 @@ class JobRuntime:
             return
 
         try:
-            fut = self._manual_executor.submit(self._run_manual, job_name, invoker, request_id, mode)
+            fut = self._manual_executor.submit(
+                self._run_manual,
+                job_name,
+                invoker,
+                request_id,
+                mode,
+                params if params is not None else {},
+            )
             fut.add_done_callback(self._log_future_exception)
         except Exception:
             inflight.release()
@@ -1142,7 +1305,7 @@ class JobRuntime:
         if exc is not None:
             logger.error("executor future raised unexpectedly: %s", exc, exc_info=exc)
 
-    def _wrap_invoker(self, job_name: str, invoker: Callable[[], None]) -> Callable[[], None]:
+    def _wrap_invoker(self, job_name: str, invoker: JobInvoker) -> Callable[[], None]:
         """Wrap a scheduled invoker with prerequisite check + advisory lock.
 
         The scheduled fire path checks the prerequisite (if any) before
@@ -1154,11 +1317,92 @@ class JobRuntime:
         overlaps a still-running manual trigger -- and is logged at INFO
         and skipped, not raised, because APScheduler would otherwise log
         a noisy traceback for an expected race.
+
+        PR1b-2 (#1064) additions:
+
+        * ``check_bootstrap_state_gate`` runs BEFORE the per-job
+          prerequisite. Both write a ``status='skipped'`` ``job_runs``
+          row OUTSIDE ``_tracked_job`` (prevention-log L791). On gate
+          block the operator-actionable reason ``bootstrap_not_complete``
+          wins over any downstream prereq message.
+        * Validated registry-default params are materialised via
+          ``materialise_scheduled_params`` + ``validate_job_params``
+          and persisted as ``job_runs.params_snapshot`` on every entry
+          (running, prereq-skip, gate-skip).
         """
         database_url = self._database_url
         job = self._job_registry.get(job_name)
 
         def wrapped() -> None:
+            # Materialise + validate the registry-default params for this
+            # scheduled fire. ParamValidationError here means the
+            # registry itself is misconfigured (a default that violates
+            # its own bounds) — fail-closed by skipping with the error
+            # in the audit row, since running a misconfigured job risks
+            # incorrect downstream rows.
+            params: Mapping[str, Any]
+            raw_defaults = materialise_scheduled_params(job_name)
+            try:
+                params = validate_job_params(
+                    job_name,
+                    raw_defaults,
+                    allow_internal_keys=False,
+                )
+            except ParamValidationError as exc:
+                logger.error(
+                    "scheduled fire of %r aborted — registry default params failed validation: %s",
+                    job_name,
+                    exc,
+                )
+                try:
+                    with psycopg.connect(database_url, autocommit=True) as conn:
+                        # Snapshot the RAW materialised defaults so the
+                        # operator audit row preserves the same shape as
+                        # successful scheduled fires (Codex pre-push NIT).
+                        record_job_skip(
+                            conn,
+                            job_name,
+                            f"registry default params invalid: {exc}",
+                            params_snapshot=dict(raw_defaults),
+                        )
+                except Exception:
+                    logger.exception(
+                        "failed to record scheduled-fire skip for %r after param-validation error",
+                        job_name,
+                    )
+                return
+
+            # Bootstrap-state gate (#1064 PR1b-2). Runs BEFORE the per-job
+            # prereq so the operator-visible reason
+            # ``bootstrap_not_complete`` is the actionable signal when
+            # both would block. Scheduled fires never override.
+            try:
+                with psycopg.connect(database_url, autocommit=True) as conn:
+                    allowed, reason = check_bootstrap_state_gate(
+                        conn,
+                        job_name=job_name,
+                        invocation_path="scheduled",
+                        override_present=False,
+                    )
+                    if not allowed:
+                        record_job_skip(conn, job_name, reason, params_snapshot=dict(params))
+                        logger.info(
+                            "scheduled fire of %r skipped — %s",
+                            job_name,
+                            reason,
+                        )
+                        return
+            except Exception:
+                # Fail-open mirrors the prereq path below — silently
+                # dropping a real run is worse than running against a
+                # half-installed DB; the body's own checks then surface
+                # the issue.
+                logger.warning(
+                    "bootstrap_state gate for %r failed; running anyway",
+                    job_name,
+                    exc_info=True,
+                )
+
             # Prerequisite gate (scheduled fires only — manual triggers
             # bypass prerequisites so the operator can force a run).
             if job is not None and job.prerequisite is not None:
@@ -1166,7 +1410,12 @@ class JobRuntime:
                     with psycopg.connect(database_url, autocommit=True) as conn:
                         met, reason = job.prerequisite(conn)
                         if not met:
-                            record_job_skip(conn, job_name, reason)
+                            record_job_skip(
+                                conn,
+                                job_name,
+                                reason,
+                                params_snapshot=dict(params),
+                            )
                             logger.info(
                                 "scheduled fire of %r skipped — prerequisite not met: %s",
                                 job_name,
@@ -1191,9 +1440,15 @@ class JobRuntime:
                     # default ``bypass_fence_check=False`` applies.
                     # Self-tracked invokers opt out of the prelude.
                     if job_name in _PRELUDE_OPT_OUT_JOBS:
-                        invoker()
+                        # Set both contextvars so the opt-out invoker's
+                        # ``_tracked_job`` (if any) reuses the snapshot.
+                        snap_token = _params_snapshot_var.set(params)
+                        try:
+                            invoker(params)
+                        finally:
+                            _params_snapshot_var.reset(snap_token)
                     else:
-                        run_with_prelude(database_url, job_name, invoker)
+                        run_with_prelude(database_url, job_name, invoker, params=params)
             except JobAlreadyRunning:
                 logger.info(
                     "scheduled fire of %r skipped: another instance is "
@@ -1223,9 +1478,10 @@ class JobRuntime:
     def _run_manual(
         self,
         job_name: str,
-        invoker: Callable[[], None],
+        invoker: JobInvoker,
         request_id: int | None,
         mode: str | None = None,
+        params: Mapping[str, Any] | None = None,
     ) -> None:
         """Worker-thread entry point for manual triggers.
 
@@ -1271,6 +1527,7 @@ class JobRuntime:
         # this worker IS the fence holder, so bypass the fence check
         # (otherwise the worker would self-skip on its own queue row).
         bypass_fence_check = mode == "full_wash"
+        effective_params: Mapping[str, Any] = params if params is not None else {}
         try:
             try:
                 with JobLock(self._database_url, job_name):
@@ -1284,10 +1541,12 @@ class JobRuntime:
                         # invoker can pass through to its own fence
                         # handling.
                         token = _invoker_request_context.set((request_id, mode))
+                        snap_token = _params_snapshot_var.set(effective_params)
                         try:
-                            invoker()
+                            invoker(effective_params)
                         finally:
                             _invoker_request_context.reset(token)
+                            _params_snapshot_var.reset(snap_token)
                         invoked = True
                     else:
                         invoked = run_with_prelude(
@@ -1296,6 +1555,7 @@ class JobRuntime:
                             invoker,
                             bypass_fence_check=bypass_fence_check,
                             linked_request_id=request_id,
+                            params=effective_params,
                         )
                     if request_id is not None and not invoked:
                         # Prelude wrote a 'skipped' job_runs row +

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -35,10 +35,10 @@ parallel manual / scheduled trigger cannot run twice simultaneously.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, timedelta
-from typing import Final
+from typing import Any, Final
 
 import psycopg
 
@@ -277,7 +277,7 @@ def _run_one_stage(
     run_id: int,
     stage_key: str,
     job_name: str,
-    invoker: Callable[[], None],
+    invoker: Callable[[Mapping[str, Any]], None],
     database_url: str,
 ) -> _StageOutcome:
     """Execute one stage end-to-end with `JobLock` + bookkeeping.
@@ -295,7 +295,12 @@ def _run_one_stage(
 
     try:
         with JobLock(database_url, job_name):
-            invoker()
+            # PR1b-2 (#1064): invoker contract widened to JobInvoker
+            # (``Callable[[Mapping[str, Any]], None]``). Bootstrap stages
+            # pass ``{}`` here today; PR1c lifts the bespoke wrappers
+            # and populates ``StageSpec.params`` with the per-stage
+            # hardcoded values currently buried in the wrapper bodies.
+            invoker({})
     except JobAlreadyRunning:
         message = (
             f"another instance of {job_name!r} holds the advisory lock; "
@@ -372,7 +377,7 @@ def _should_run(stage_status: str) -> bool:
 def _run_lane(
     *,
     run_id: int,
-    lane_specs: Sequence[tuple[str, str, str, str, Callable[[], None]]],
+    lane_specs: Sequence[tuple[str, str, str, str, Callable[[Mapping[str, Any]], None]]],
     database_url: str,
     log_label: str,
 ) -> None:
@@ -410,7 +415,7 @@ class _RunnableStage:
     stage_key: str
     job_name: str
     lane: str
-    invoker: Callable[[], None]
+    invoker: Callable[[Mapping[str, Any]], None]
     requires: tuple[str, ...]
 
 

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import psycopg
 import psycopg.rows
+from psycopg.types.json import Jsonb
 
 from app.services.runtime_config import write_kill_switch_audit
 
@@ -255,22 +256,48 @@ def record_job_start(
     job_name: str,
     *,
     now: datetime | None = None,
+    params_snapshot: dict[str, Any] | None = None,
 ) -> int:
     """
     Record the start of a scheduled job.  Returns the run_id.
 
     The caller should later call record_job_finish() with this run_id.
+
+    ``params_snapshot`` (#1064 PR1b-2) populates ``job_runs.params_snapshot``
+    with the validated effective params dict. Three populate paths:
+
+    * Manual queue: validated ``payload['params']`` from
+      ``pending_job_requests``.
+    * Scheduled fire: ``materialise_scheduled_params(job_name)`` after
+      validation.
+    * Bootstrap stage: the StageSpec params dict (PR1c lifts the
+      bespoke wrappers; PR1b-2 still carries ``{}`` for those).
+
+    ``None`` means the caller is on the legacy direct-invocation path
+    (tests, prelude-fallback) where the column's column-default
+    ``'{}'::jsonb`` is the right value — we omit the column from the
+    INSERT and let Postgres apply the default.
     """
     now = now or _utcnow()
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            INSERT INTO job_runs (job_name, started_at, status)
-            VALUES (%(name)s, %(started)s, 'running')
-            RETURNING run_id
-            """,
-            {"name": job_name, "started": now},
-        )
+        if params_snapshot is None:
+            cur.execute(
+                """
+                INSERT INTO job_runs (job_name, started_at, status)
+                VALUES (%(name)s, %(started)s, 'running')
+                RETURNING run_id
+                """,
+                {"name": job_name, "started": now},
+            )
+        else:
+            cur.execute(
+                """
+                INSERT INTO job_runs (job_name, started_at, status, params_snapshot)
+                VALUES (%(name)s, %(started)s, 'running', %(params)s)
+                RETURNING run_id
+                """,
+                {"name": job_name, "started": now, "params": Jsonb(params_snapshot)},
+            )
         row = cur.fetchone()
     conn.commit()
 
@@ -319,6 +346,7 @@ def record_job_skip(
     reason: str,
     *,
     now: datetime | None = None,
+    params_snapshot: dict[str, Any] | None = None,
 ) -> int:
     """Record a skipped job run (prerequisite not met).
 
@@ -334,20 +362,42 @@ def record_job_skip(
     This is intentionally separate from the start/finish pair used by
     ``_tracked_job`` — a skipped job has no execution phase, so a
     single insert is the honest representation.
+
+    ``params_snapshot`` (#1064 PR1b-2) — when supplied, the validated
+    params dict is committed alongside the skip row so the operator
+    audit trail reflects the effective inputs even when the run never
+    executed. ``None`` lets the column default to ``'{}'``.
     """
     assert conn.autocommit, (
         "record_job_skip requires autocommit=True so conn.transaction() issues a real BEGIN/COMMIT, not a savepoint"
     )
     now = now or _utcnow()
     with conn.transaction():
-        row = conn.execute(
-            """
-            INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
-            VALUES (%(name)s, %(ts)s, %(ts)s, 'skipped', 0, %(reason)s)
-            RETURNING run_id
-            """,
-            {"name": job_name, "ts": now, "reason": reason},
-        ).fetchone()
+        if params_snapshot is None:
+            row = conn.execute(
+                """
+                INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
+                VALUES (%(name)s, %(ts)s, %(ts)s, 'skipped', 0, %(reason)s)
+                RETURNING run_id
+                """,
+                {"name": job_name, "ts": now, "reason": reason},
+            ).fetchone()
+        else:
+            row = conn.execute(
+                """
+                INSERT INTO job_runs (
+                    job_name, started_at, finished_at, status, row_count, error_msg, params_snapshot
+                )
+                VALUES (%(name)s, %(ts)s, %(ts)s, 'skipped', 0, %(reason)s, %(params)s)
+                RETURNING run_id
+                """,
+                {
+                    "name": job_name,
+                    "ts": now,
+                    "reason": reason,
+                    "params": Jsonb(params_snapshot),
+                },
+            ).fetchone()
         if row is None:
             raise RuntimeError("job_runs INSERT returned no row")
         run_id = int(row[0])

--- a/app/services/processes/bootstrap_gate.py
+++ b/app/services/processes/bootstrap_gate.py
@@ -1,0 +1,221 @@
+"""Universal ``bootstrap_state.status='complete'`` gate.
+
+PR1b-2 of #1064 admin-control-hub follow-up sequence.
+Plan: docs/internal/plans/pr1-job-registry-refactor.md (Step 7).
+
+## Why this exists
+
+Pre-PR1b-2 the bootstrap-completion gate was implicit: each
+SEC/fundamentals job declared a ``ScheduledJob.prerequisite``
+(``_bootstrap_complete``) that returned ``(False, reason)`` while
+``bootstrap_state.status`` was anything other than ``'complete'``.
+The scheduled-fire path honoured the prereq; PR1b extended that to
+the manual-queue path.
+
+The gate is ORTHOGONAL to per-job prerequisites:
+
+* **Per-job prereq** (e.g. ``_bootstrap_complete``, ``_has_filings``)
+  is the data-availability check — "do we have the upstream rows
+  this job needs?" Each job declares its own.
+* **Bootstrap gate** (this module) is the install-state check —
+  "is the first-install bootstrap complete, partial-error, or
+  cancelled?" Identical for every gated job.
+
+Order: gate first, then prereq. If both fail, gate wins — the
+operator's actionable signal is "bootstrap not complete", not "no
+coverage rows". The gate is what the operator can fix
+(retry/iterate the bootstrap); a downstream prereq failure during a
+half-installed bootstrap is noise.
+
+## Override semantics
+
+Manual triggers may override the gate via the ``{control:
+{override_bootstrap_gate: true}}`` envelope. When the override
+fires:
+
+1. A ``decision_audit`` row is written with ``stage='bootstrap_gate_override'``,
+   ``pass_fail='OVERRIDE'``, and an explanation including the
+   ``invocation_path`` + ``operator_id``.
+2. The gate returns ``(True, '')`` — the run proceeds.
+
+Codex round-2 WARNING addressed: the audit row fires ONLY when the
+override actually bypasses the gate. A happy-path ``status='complete'``
+run never writes an audit row (otherwise every successful run
+generates noise that drowns the actual override events).
+
+Scheduled fires CANNOT override — there is no operator at the
+keyboard for a cron tick. ``invocation_path='scheduled'`` ignores
+``override_present`` entirely.
+
+## Why a dedicated module
+
+The gate has three distinct callers (scheduled-fire wrapper,
+queue-dispatch wrapper, catch-up loop) and one decision_audit
+write. Keeping the logic in one place prevents drift between paths
+— each caller passes its own ``invocation_path`` literal, and the
+gate handles the rest identically.
+
+The module reads ``bootstrap_state``; it does NOT mutate. The
+read-only contract means callers can supply any psycopg connection
+(autocommit or transactional) without changing semantics.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+from uuid import UUID
+
+import psycopg
+
+from app.services.bootstrap_state import read_state
+
+logger = logging.getLogger(__name__)
+
+
+GateInvocationPath = Literal["scheduled", "manual_queue"]
+"""Which dispatch path is consulting the gate.
+
+* ``scheduled`` — APScheduler fire or boot-time catch-up. Override
+  is meaningless here; ``override_present`` is ignored.
+* ``manual_queue`` — durable queue-consumer dispatch
+  (``app.jobs.listener``). Override-aware.
+"""
+
+
+_GATE_REASON_BOOTSTRAP_NOT_COMPLETE: Literal["bootstrap_not_complete"] = "bootstrap_not_complete"
+"""Reason key surfaced to operator UI via ``processStatus.ts::REASON_TOOLTIP``."""
+
+
+def check_bootstrap_state_gate(
+    conn: psycopg.Connection[Any],
+    *,
+    job_name: str,
+    invocation_path: GateInvocationPath,
+    override_present: bool,
+    operator_id: UUID | str | None = None,
+) -> tuple[bool, str]:
+    """Decide whether ``job_name`` may run given ``bootstrap_state.status``.
+
+    Returns ``(allowed, reason)``:
+
+    * ``(True, "")`` — bootstrap is complete OR a manual override
+      bypassed the gate. On override, a ``decision_audit`` row is
+      written before returning.
+    * ``(False, "bootstrap_not_complete")`` — gate blocks the run.
+      Caller's responsibility to surface this through the
+      appropriate skip path:
+
+      - scheduled fire / catch-up → ``record_job_skip(conn, job_name, reason)``
+        BEFORE entering ``_tracked_job`` (prevention-log L791).
+      - manual queue dispatch → ``mark_request_rejected(conn,
+        request_id, error_msg=reason)`` (prevention-log L1202;
+        data-engineer skill §6.5.7 step 8 — NEVER
+        ``mark_request_completed`` for skipped runs).
+
+    The connection is consulted in two ways:
+
+    1. ``read_state(conn)`` — single SELECT on the singleton.
+    2. ``INSERT INTO decision_audit`` (only when the override
+       actually bypasses).
+
+    Connections passed by scheduled-fire callers run in autocommit
+    mode (matching ``record_job_skip``'s contract); the override
+    INSERT relies on autocommit semantics so the audit row is
+    visible immediately. Manual-queue callers should also use
+    autocommit so a rejection-write race cannot strand the audit
+    row inside an uncommitted transaction.
+    """
+    state = read_state(conn)
+    if state.status == "complete":
+        return (True, "")
+
+    # status is one of {'pending', 'running', 'partial_error', 'cancelled'}
+    # — every non-complete value blocks scheduled fires unconditionally
+    # and blocks manual-queue dispatches unless the override flag is set.
+    if invocation_path == "manual_queue" and override_present:
+        _write_override_audit(
+            conn,
+            job_name=job_name,
+            current_status=state.status,
+            operator_id=operator_id,
+        )
+        logger.info(
+            "bootstrap_gate: manual override granted for %r (status=%s, operator=%s)",
+            job_name,
+            state.status,
+            operator_id,
+        )
+        return (True, "")
+
+    return (False, _GATE_REASON_BOOTSTRAP_NOT_COMPLETE)
+
+
+def _write_override_audit(
+    conn: psycopg.Connection[Any],
+    *,
+    job_name: str,
+    current_status: str,
+    operator_id: UUID | str | None,
+) -> None:
+    """Record the bypass in ``decision_audit`` for the operator audit trail.
+
+    Single INSERT, no return value. The connection's commit posture
+    (autocommit vs. transactional) is the caller's choice; the
+    contract is "row is visible by the time the gate returns
+    ``(True, '')``" — autocommit satisfies that automatically.
+
+    A failure here does NOT raise: operator-action audit is desired
+    but not load-bearing for the run itself, and we have already
+    decided to allow the run. The log line surfaces the failure for
+    ops_monitor.
+    """
+    explanation = (
+        f"manual override of bootstrap_state gate for job {job_name!r}: "
+        f"bootstrap_state.status was {current_status!r}; "
+        f"operator override bypassed the gate"
+    )
+    operator_label = str(operator_id) if operator_id is not None else "<unknown>"
+    try:
+        conn.execute(
+            """
+            INSERT INTO decision_audit
+                (decision_time, stage, pass_fail, explanation, evidence_json)
+            VALUES
+                (NOW(), 'bootstrap_gate_override', 'OVERRIDE', %(expl)s, %(evidence)s::jsonb)
+            """,
+            {
+                "expl": explanation,
+                "evidence": _encode_evidence(
+                    {
+                        "job_name": job_name,
+                        "bootstrap_status": current_status,
+                        "operator_id": operator_label,
+                    }
+                ),
+            },
+        )
+    except Exception:
+        logger.exception(
+            "bootstrap_gate: failed to write override audit row for %r — proceeding anyway",
+            job_name,
+        )
+
+
+def _encode_evidence(payload: dict[str, str]) -> str:
+    """Hand-roll the JSON payload for the evidence_json column.
+
+    ``json.dumps`` is enough — the dict is shallow and the values
+    are all strings. Avoiding ``Jsonb()`` keeps this module's
+    psycopg dependency minimal (helpful for unit tests that mock
+    the connection).
+    """
+    import json
+
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+__all__ = [
+    "GateInvocationPath",
+    "check_bootstrap_state_gate",
+]

--- a/app/services/sync_orchestrator/dispatcher.py
+++ b/app/services/sync_orchestrator/dispatcher.py
@@ -108,6 +108,7 @@ def publish_manual_job_request(
     requested_by: str | None = None,
     process_id: str | None = None,
     mode: Literal["iterate", "full_wash"] | None = None,
+    payload: dict[str, Any] | None = None,
 ) -> int:
     """Publish a manual job request through the durable queue.
 
@@ -122,6 +123,14 @@ def publish_manual_job_request(
     not migrated leave them ``None`` so the columns stay nullable for
     pre-existing rows.
 
+    ``payload`` (#1064 PR1b-2) carries the canonical
+    ``{params, control}`` envelope into ``pending_job_requests.payload``.
+    The listener extracts ``payload['params']`` for invoker dispatch and
+    ``payload['control']['override_bootstrap_gate']`` for gate control.
+    Legacy callers leave it ``None`` and the column writes ``NULL`` (no
+    params, no control flags). Callers MUST validate the params dict
+    before calling this helper — the listener trusts the envelope.
+
     UNIQUE partial index ``pending_job_requests_active_full_wash_idx``
     catches a concurrent INSERT racing past the trigger handler's
     fence-check as ``UniqueViolation`` — handler maps to 409.
@@ -131,13 +140,14 @@ def publish_manual_job_request(
             cur.execute(
                 """
                 INSERT INTO pending_job_requests
-                    (request_kind, job_name, requested_by, process_id, mode)
-                VALUES ('manual_job', %(job_name)s, %(requested_by)s,
+                    (request_kind, job_name, payload, requested_by, process_id, mode)
+                VALUES ('manual_job', %(job_name)s, %(payload)s, %(requested_by)s,
                         %(process_id)s, %(mode)s)
                 RETURNING request_id
                 """,
                 {
                     "job_name": job_name,
+                    "payload": Jsonb(payload) if payload is not None else None,
                     "requested_by": requested_by,
                     "process_id": process_id,
                     "mode": mode,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1103,9 +1103,14 @@ def _tracked_job(job_name: str) -> Generator[_JobTracker]:
     tracker = _JobTracker(job_name)
     # Function-local import: app.jobs.runtime imports this module's
     # invokers at top level, so the reverse import has to be lazy.
-    from app.jobs.runtime import consume_prelude_run_id
+    from app.jobs.runtime import consume_params_snapshot, consume_prelude_run_id
 
     pre_allocated_run_id = consume_prelude_run_id()
+    # Always consume the snapshot context so a nested ``_tracked_job``
+    # cannot reuse a stale value. Only used on the prelude-fallback path
+    # below (``record_job_start``); the prelude branch already wrote the
+    # snapshot in its own INSERT.
+    fallback_params_snapshot = consume_params_snapshot()
     if pre_allocated_run_id is not None:
         tracker.run_id = pre_allocated_run_id
         # Advance straight to the body — the prelude already wrote the
@@ -1153,7 +1158,11 @@ def _tracked_job(job_name: str) -> Generator[_JobTracker]:
 
     try:
         with psycopg.connect(settings.database_url) as conn:
-            tracker.run_id = record_job_start(conn, job_name)
+            tracker.run_id = record_job_start(
+                conn,
+                job_name,
+                params_snapshot=dict(fallback_params_snapshot) if fallback_params_snapshot is not None else None,
+            )
     except Exception:
         logger.error("Failed to record job start for %s", job_name, exc_info=True)
         # Still run the job even if tracking fails.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1291,7 +1291,13 @@ export type TriggerConflictReason =
   // surface these reasons to point the operator at the underlying
   // scheduled job.
   | "trigger_not_supported"
-  | "cancel_not_supported";
+  | "cancel_not_supported"
+  // PR1b-2 (#1064) — universal bootstrap-state gate. Emitted by the
+  // jobs-process listener (NOT a synchronous API 409) when a manual
+  // job request is rejected because bootstrap_state.status !=
+  // 'complete' and no override flag was set. Surfaces to the operator
+  // via the rejected pending_job_requests row's error_msg.
+  | "bootstrap_not_complete";
 
 // ---------------------------------------------------------------------------
 // Orchestrator DAG drill-in (#1078, umbrella #1064 — PR6)

--- a/frontend/src/components/admin/processStatus.ts
+++ b/frontend/src/components/admin/processStatus.ts
@@ -110,6 +110,8 @@ export const REASON_TOOLTIP: Record<TriggerConflictReason, string> = {
     "Sweeps are read-only — trigger via the underlying scheduled job.",
   cancel_not_supported:
     "Sweeps have no in-flight state — cancel the underlying scheduled job.",
+  bootstrap_not_complete:
+    "First-install bootstrap is not complete — finish or override before triggering this job.",
 };
 
 const KNOWN_REASONS = new Set<string>(Object.keys(REASON_TOOLTIP));

--- a/tests/test_api_jobs.py
+++ b/tests/test_api_jobs.py
@@ -46,6 +46,105 @@ class TestRunJob:
         assert pub.call_count == 0
 
 
+class TestRunJobEnvelope:
+    """PR1b-2 (#1064) — envelope + control + override on POST /jobs/<name>/run."""
+
+    def test_canonical_envelope_publishes_canonical_payload(self) -> None:
+        with patch("app.api.jobs.publish_manual_job_request", return_value=11) as pub:
+            resp = client.post(
+                "/jobs/nightly_universe_sync/run",
+                json={"params": {}, "control": {}},
+            )
+        assert resp.status_code == 202
+        kwargs = pub.call_args.kwargs
+        assert kwargs["payload"] == {"params": {}, "control": {}}
+
+    def test_legacy_flat_dict_normalised_to_params(self) -> None:
+        """Pre-PR1b-2 ergonomic shape — entire body becomes params."""
+        # nightly_universe_sync has no declared ParamMetadata, so the only
+        # legitimate flat-dict body is empty. Use an empty body to verify
+        # the legacy → envelope normalisation produces ``{params: {}}``.
+        with patch("app.api.jobs.publish_manual_job_request", return_value=12) as pub:
+            resp = client.post("/jobs/nightly_universe_sync/run", json={})
+        assert resp.status_code == 202
+        kwargs = pub.call_args.kwargs
+        assert kwargs["payload"] == {"params": {}, "control": {}}
+
+    def test_no_body_treated_as_empty_params(self) -> None:
+        with patch("app.api.jobs.publish_manual_job_request", return_value=13) as pub:
+            resp = client.post("/jobs/nightly_universe_sync/run")
+        assert resp.status_code == 202
+        kwargs = pub.call_args.kwargs
+        assert kwargs["payload"] == {"params": {}, "control": {}}
+
+    def test_unknown_control_key_400(self) -> None:
+        with patch("app.api.jobs.publish_manual_job_request") as pub:
+            resp = client.post(
+                "/jobs/nightly_universe_sync/run",
+                json={"params": {}, "control": {"force_kill": True}},
+            )
+        assert resp.status_code == 400
+        assert "force_kill" in resp.json()["detail"]
+        pub.assert_not_called()
+
+    def test_invalid_param_400(self) -> None:
+        """ParamValidationError → 400 (not 500)."""
+        with patch("app.api.jobs.publish_manual_job_request") as pub:
+            resp = client.post(
+                "/jobs/nightly_universe_sync/run",
+                json={"params": {"unknown_field": "x"}},
+            )
+        assert resp.status_code == 400
+        assert "unknown" in resp.json()["detail"].lower()
+        pub.assert_not_called()
+
+    def test_query_param_override_propagates_to_payload(self) -> None:
+        with patch("app.api.jobs.publish_manual_job_request", return_value=14) as pub:
+            resp = client.post(
+                "/jobs/nightly_universe_sync/run?override_bootstrap_gate=true",
+                json={"params": {}},
+            )
+        assert resp.status_code == 202
+        kwargs = pub.call_args.kwargs
+        assert kwargs["payload"]["control"]["override_bootstrap_gate"] is True
+
+    def test_body_override_propagates_to_payload(self) -> None:
+        with patch("app.api.jobs.publish_manual_job_request", return_value=15) as pub:
+            resp = client.post(
+                "/jobs/nightly_universe_sync/run",
+                json={"params": {}, "control": {"override_bootstrap_gate": True}},
+            )
+        assert resp.status_code == 202
+        kwargs = pub.call_args.kwargs
+        assert kwargs["payload"]["control"]["override_bootstrap_gate"] is True
+
+    def test_non_dict_body_400(self) -> None:
+        with patch("app.api.jobs.publish_manual_job_request") as pub:
+            resp = client.post("/jobs/nightly_universe_sync/run", json=[1, 2, 3])
+        assert resp.status_code == 400
+        pub.assert_not_called()
+
+    def test_envelope_params_non_dict_400(self) -> None:
+        with patch("app.api.jobs.publish_manual_job_request") as pub:
+            resp = client.post(
+                "/jobs/nightly_universe_sync/run",
+                json={"params": "not an object", "control": {}},
+            )
+        assert resp.status_code == 400
+        pub.assert_not_called()
+
+    def test_override_must_be_strict_bool_400(self) -> None:
+        """Codex pre-push round 2 BLOCKING — truthy strings cannot grant override."""
+        with patch("app.api.jobs.publish_manual_job_request") as pub:
+            resp = client.post(
+                "/jobs/nightly_universe_sync/run",
+                json={"params": {}, "control": {"override_bootstrap_gate": "true"}},
+            )
+        assert resp.status_code == 400
+        assert "boolean" in resp.json()["detail"].lower()
+        pub.assert_not_called()
+
+
 class TestListJobRequests:
     """Smoke for the new GET /jobs/requests endpoint (#719)."""
 

--- a/tests/test_bootstrap_cancel.py
+++ b/tests/test_bootstrap_cancel.py
@@ -354,14 +354,14 @@ def test_dispatcher_observes_cancel_at_top_of_loop_and_returns_cancelled(
             stage_key="alpha",
             job_name="alpha_job",
             lane="init",
-            invoker=lambda: calls.append("alpha"),
+            invoker=lambda _params: calls.append("alpha"),
             requires=(),
         ),
         _RunnableStage(
             stage_key="bravo",
             job_name="bravo_job",
             lane="sec",
-            invoker=lambda: calls.append("bravo"),
+            invoker=lambda _params: calls.append("bravo"),
             requires=("alpha",),
         ),
     ]
@@ -401,14 +401,14 @@ def test_dispatcher_observes_cancel_between_batches(
 
     calls: list[str] = []
 
-    def alpha_invoker() -> None:
+    def alpha_invoker(_params: object = None) -> None:
         calls.append("alpha")
         # Simulate operator clicking Cancel during alpha's run.
         with psycopg.connect(test_db_url) as conn:
             cancel_run(conn, requested_by_operator_id=None)
             conn.commit()
 
-    def bravo_invoker() -> None:  # pragma: no cover — must NOT run
+    def bravo_invoker(_params: object = None) -> None:  # pragma: no cover — must NOT run
         calls.append("bravo")
 
     runnable = [

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -150,7 +150,7 @@ def test_run_one_stage_records_success(
 
     calls: list[str] = []
 
-    def alpha_invoker() -> None:
+    def alpha_invoker(_params: object = None) -> None:
         calls.append("alpha")
 
     outcome = _run_one_stage(
@@ -180,7 +180,7 @@ def test_run_one_stage_records_error_on_invoker_exception(
     run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=specs)
     ebull_test_conn.commit()
 
-    def bravo_invoker() -> None:
+    def bravo_invoker(_params: object = None) -> None:
         raise RuntimeError("kaboom")
 
     outcome = _run_one_stage(
@@ -222,8 +222,12 @@ def _patch_invokers_with_fakes(
     calls: dict[str, list[str]] = {"order": []}
     failing = failing_jobs or set()
 
-    def _make_fake(name: str) -> Callable[[], None]:
-        def _fake() -> None:
+    def _make_fake(name: str) -> Callable[..., None]:
+        # PR1b-2 (#1064) widened JobInvoker to ``(Mapping) -> None``;
+        # bootstrap dispatch now calls invoker({}). Accept-and-ignore
+        # the params kwarg so this fake satisfies both the legacy
+        # zero-arg and the post-PR1b-2 signature without test churn.
+        def _fake(_params: object = None) -> None:
             calls["order"].append(name)
             if name in failing:
                 raise RuntimeError(f"forced {name} failure")

--- a/tests/test_bootstrap_state_gate.py
+++ b/tests/test_bootstrap_state_gate.py
@@ -18,6 +18,12 @@ bootstrap_state check, so:
   - jobs without _bootstrap_complete prereq (orchestrator_high_frequency_sync,
     execute_approved_orders, monitor_positions, ...) keep pre-PR1b
     semantics.
+
+PR1b-2 (#1064) layered the universal bootstrap_state gate ON TOP of
+the per-job prereq. Tests in this file pre-date PR1b-2 and exercise
+the prereq path in isolation — the bootstrap_state gate is patched to
+always allow so the original assertions still hold. PR1b-2's gate
+behaviour is covered in tests/test_bootstrap_gate_universal.py.
 """
 
 from __future__ import annotations
@@ -27,6 +33,17 @@ from unittest.mock import MagicMock, patch
 
 from app.jobs.listener import _dispatch_manual_job
 from app.workers.scheduler import SCHEDULED_JOBS
+
+
+def _allow_gate() -> Any:
+    """Patch ``check_bootstrap_state_gate`` to always allow (True, '').
+
+    Tests in TestPrereqEnforcement exercise the per-job prereq path,
+    not the universal bootstrap_state gate added in PR1b-2. With the
+    gate patched to allow, dispatch reaches the per-job prereq check
+    and the original assertions hold.
+    """
+    return patch("app.jobs.listener.check_bootstrap_state_gate", return_value=(True, ""))
 
 
 def _runtime_mock() -> MagicMock:
@@ -54,6 +71,7 @@ class TestPrereqEnforcement:
             "sec_form3_ingest", met=False, reason="first-install bootstrap not complete; visit /admin to run"
         )
         with (
+            _allow_gate(),
             patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
             patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_form3_ingest"}),
             patch("app.jobs.listener.psycopg.connect") as mock_connect,
@@ -77,6 +95,7 @@ class TestPrereqEnforcement:
         runtime = _runtime_mock()
         fake_job = _job_with_prereq("sec_form3_ingest", met=True, reason="")
         with (
+            _allow_gate(),
             patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
             patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_form3_ingest"}),
             patch("app.jobs.listener.psycopg.connect") as mock_connect,
@@ -89,7 +108,9 @@ class TestPrereqEnforcement:
                 job_name="sec_form3_ingest",
             )
         mock_reject.assert_not_called()
-        runtime.submit_manual_with_request.assert_called_once_with("sec_form3_ingest", request_id=42, mode=None)
+        runtime.submit_manual_with_request.assert_called_once_with(
+            "sec_form3_ingest", request_id=42, mode=None, params={}
+        )
 
     def test_no_prereq_proceeds_to_runtime(self) -> None:
         """Job with no prereq declared → runtime.submit_manual_with_request fires.
@@ -100,6 +121,7 @@ class TestPrereqEnforcement:
         """
         runtime = _runtime_mock()
         # Empty SCHEDULED_JOBS — bootstrap_orchestrator pattern.
+        # Gate is bypassed by job_in_registry=False; no _allow_gate() needed.
         with (
             patch("app.jobs.listener.SCHEDULED_JOBS", []),
             patch("app.jobs.listener.VALID_JOB_NAMES", {"bootstrap_orchestrator"}),
@@ -122,6 +144,7 @@ class TestPrereqEnforcement:
         bad_job.name = "fundamentals_sync"
         bad_job.prerequisite = MagicMock(side_effect=RuntimeError("DB unavailable"))
         with (
+            _allow_gate(),
             patch("app.jobs.listener.SCHEDULED_JOBS", [bad_job]),
             patch("app.jobs.listener.VALID_JOB_NAMES", {"fundamentals_sync"}),
             patch("app.jobs.listener.psycopg.connect") as mock_connect,
@@ -145,6 +168,7 @@ class TestPrereqEnforcement:
         runtime = _runtime_mock()
         fake_job = _job_with_prereq("sec_form3_ingest", met=False, reason="bootstrap not complete")
         with (
+            _allow_gate(),
             patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
             patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_form3_ingest"}),
             patch("app.jobs.listener.psycopg.connect") as mock_connect,
@@ -174,6 +198,7 @@ class TestPrereqEnforcement:
         runtime = _runtime_mock()
         fake_job = _job_with_prereq("sec_form3_ingest", met=False, reason="should not be reached")
         with (
+            _allow_gate(),
             patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
             patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_form3_ingest"}),
             patch("app.jobs.listener.psycopg.connect", side_effect=RuntimeError("connect failed")),

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -80,19 +80,67 @@ def patched_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     # Tests in this module pass a stub URL ("postgresql://stub/stub")
     # and exercise the JobRuntime shape without staging a real DB —
     # bypass the prelude entirely so the invoker still runs.
+    # PR1b-2 (#1064) widened the JobInvoker contract to accept a params
+    # Mapping; the fake forwards an empty dict so tests remain agnostic.
     monkeypatch.setattr(
         "app.jobs.runtime.run_with_prelude",
-        lambda _url, _name, invoker, **_kw: invoker(),
+        lambda _url, _name, invoker, **_kw: invoker(_kw.get("params") or {}) or True,
+    )
+    # _wrap_invoker also runs check_bootstrap_state_gate before the
+    # prereq check; tests with a stub URL never seed the bootstrap_state
+    # singleton, so allow by default. PR1b-2.
+    monkeypatch.setattr(
+        "app.jobs.runtime.check_bootstrap_state_gate",
+        lambda _conn, **_kw: (True, ""),
+    )
+    # _wrap_invoker materialises + validates registry-default params
+    # before the gate. Stub both so tests can use lambda invokers
+    # registered under arbitrary names not in SCHEDULED_JOBS.
+    monkeypatch.setattr(
+        "app.jobs.runtime.materialise_scheduled_params",
+        lambda _name: {},
+    )
+    monkeypatch.setattr(
+        "app.jobs.runtime.validate_job_params",
+        lambda _name, params, **_kw: dict(params),
     )
 
 
 def _make_runtime(invokers: dict[str, object]) -> JobRuntime:
     # The mypy/pyright complaint about object vs Callable is silenced
     # by the cast at construction; the test invokers are all callables.
+    # PR1b-2 (#1064) widened the JobInvoker contract to accept a params
+    # Mapping; tests pass zero-arg callables so we adapt them here so
+    # individual cases stay focused on the runtime shape under test.
+    from app.jobs.runtime import _adapt_zero_arg
+
+    adapted: dict[str, object] = {
+        name: _adapt_zero_arg(fn)  # type: ignore[arg-type]
+        if callable(fn) and _is_zero_arg(fn)
+        else fn
+        for name, fn in invokers.items()
+    }
     return JobRuntime(
         database_url="postgresql://stub/stub",
-        invokers=invokers,  # type: ignore[arg-type]
+        invokers=adapted,  # type: ignore[arg-type]
     )
+
+
+def _is_zero_arg(fn: object) -> bool:
+    """Return True when the callable's positional arity is zero.
+
+    Used to distinguish legacy zero-arg test invokers (which we adapt)
+    from PR1b-2-shaped invokers (``Callable[[Mapping], None]``) that
+    would double-wrap if adapted again.
+    """
+    import inspect
+
+    try:
+        sig = inspect.signature(fn)  # type: ignore[arg-type]
+    except TypeError, ValueError:
+        return False
+    positional = [p for p in sig.parameters.values() if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)]
+    return len(positional) == 0
 
 
 class TestUnknownJob:
@@ -184,20 +232,25 @@ class TestScheduledFireWrapper:
             invocations.append(1)
 
         rt = _make_runtime({"j": invoker})
+        # PR1b-2 widened JobInvoker; _wrap_invoker calls invoker(params).
+        # Adapt for direct invocation through the wrapper.
+        from app.jobs.runtime import _adapt_zero_arg
+
+        adapted = _adapt_zero_arg(invoker)
 
         # Hold the fake lock externally to simulate a manual run in
         # flight.
         held = _FakeLock("ignored", "j")
         held.__enter__()
         try:
-            wrapped = rt._wrap_invoker("j", invoker)
+            wrapped = rt._wrap_invoker("j", adapted)
             wrapped()  # must not raise
             assert invocations == []  # invoker did not run
         finally:
             held.__exit__()
 
         # After release, the wrapper should run the invoker normally.
-        wrapped = rt._wrap_invoker("j", invoker)
+        wrapped = rt._wrap_invoker("j", adapted)
         wrapped()
         assert invocations == [1]
 
@@ -209,7 +262,9 @@ class TestScheduledFireWrapper:
             raise RuntimeError("boom")
 
         rt = _make_runtime({"boom_job": boom})
-        wrapped = rt._wrap_invoker("boom_job", boom)
+        from app.jobs.runtime import _adapt_zero_arg
+
+        wrapped = rt._wrap_invoker("boom_job", _adapt_zero_arg(boom))
         wrapped()  # must not raise
 
 
@@ -460,9 +515,29 @@ def _make_catchup_runtime(
     )
 
     # Stub record_job_skip so catch-up can record skips without a real DB.
+    # PR1b-2 (#1064): widened to accept ``params_snapshot`` kwarg.
     monkeypatch.setattr(
         "app.jobs.runtime.record_job_skip",
-        lambda _conn, _name, _reason: 0,
+        lambda _conn, _name, _reason, **_kw: 0,
+    )
+
+    # PR1b-2 (#1064): stub the universal bootstrap_state gate to allow
+    # so the per-job prereq path under test still executes. Tests for
+    # the gate path itself live in tests/test_pr1b2_envelope_and_gate.py.
+    monkeypatch.setattr(
+        "app.jobs.runtime.check_bootstrap_state_gate",
+        lambda _conn, **_kw: (True, ""),
+    )
+    # PR1b-2 (#1064): stub registry-default params materialiser +
+    # validator so the catch-up loop's pre-skip path doesn't choke on
+    # synthetic test job names not registered in SCHEDULED_JOBS.
+    monkeypatch.setattr(
+        "app.jobs.runtime.materialise_scheduled_params",
+        lambda _name: {},
+    )
+    monkeypatch.setattr(
+        "app.jobs.runtime.validate_job_params",
+        lambda _name, params, **_kw: dict(params),
     )
 
     # Stub psycopg.connect so _catch_up gets a no-op connection.
@@ -474,9 +549,11 @@ def _make_catchup_runtime(
     # fixture's mocked psycopg.connect would otherwise return a
     # MagicMock whose ``cur.fetchone()`` reads as truthy and triggers
     # a false "fence held" branch, skipping every catch-up invoker.
+    # PR1b-2 widened the JobInvoker contract; forward an empty params
+    # dict to the test invoker.
     monkeypatch.setattr(
         "app.jobs.runtime.run_with_prelude",
-        lambda _url, _name, invoker, **_kw: invoker(),
+        lambda _url, _name, invoker, **_kw: invoker(_kw.get("params") or {}) or True,
     )
 
     # Pin the clock.
@@ -485,9 +562,20 @@ def _make_catchup_runtime(
         type("_FakeDT", (), {"now": staticmethod(lambda tz: _NOW)}),
     )
 
+    # PR1b-2 (#1064): adapt zero-arg test invokers to the widened
+    # JobInvoker contract. The catch-up loop calls invoker(params).
+    from app.jobs.runtime import _adapt_zero_arg
+
+    adapted = {
+        name: _adapt_zero_arg(fn)  # type: ignore[arg-type]
+        if callable(fn) and _is_zero_arg(fn)
+        else fn
+        for name, fn in invokers.items()
+    }
+
     rt = JobRuntime(
         database_url="postgresql://stub/stub",
-        invokers=invokers,  # type: ignore[arg-type]
+        invokers=adapted,  # type: ignore[arg-type]
     )
 
     # The caller tracks invocations via side-effects in the invoker
@@ -759,7 +847,7 @@ class TestCatchUpPrerequisites:
         )
         monkeypatch.setattr(
             "app.jobs.runtime.record_job_skip",
-            lambda _conn, name, reason: skip_calls.append((name, reason)) or 0,
+            lambda _conn, name, reason, **_kw: skip_calls.append((name, reason)) or 0,
         )
 
         mock_conn = MagicMock()
@@ -771,9 +859,11 @@ class TestCatchUpPrerequisites:
             type("_FakeDT", (), {"now": staticmethod(lambda tz: _NOW)}),
         )
 
+        from app.jobs.runtime import _adapt_zero_arg
+
         rt = JobRuntime(
             database_url="postgresql://stub/stub",
-            invokers={"prereq_unmet_job": lambda: None},  # type: ignore[dict-item]
+            invokers={"prereq_unmet_job": _adapt_zero_arg(lambda: None)},  # type: ignore[dict-item]
         )
         rt._catch_up()
         rt._manual_executor.shutdown(wait=True)
@@ -802,7 +892,7 @@ class TestScheduledFirePrerequisite:
         # Stub record_job_skip.
         monkeypatch.setattr(
             "app.jobs.runtime.record_job_skip",
-            lambda _conn, _name, _reason: 0,
+            lambda _conn, _name, _reason, **_kw: 0,
         )
 
         # Stub psycopg.connect for the prerequisite check.
@@ -813,7 +903,9 @@ class TestScheduledFirePrerequisite:
         monkeypatch.setattr("app.jobs.runtime.SCHEDULED_JOBS", [_PREREQ_UNMET_JOB])
 
         rt = _make_runtime({"prereq_unmet_job": invoker})
-        wrapped = rt._wrap_invoker("prereq_unmet_job", invoker)
+        from app.jobs.runtime import _adapt_zero_arg
+
+        wrapped = rt._wrap_invoker("prereq_unmet_job", _adapt_zero_arg(invoker))
         wrapped()
         assert invocations == []  # invoker was NOT called
 
@@ -834,7 +926,10 @@ class TestScheduledFirePrerequisite:
         monkeypatch.setattr("app.jobs.runtime.SCHEDULED_JOBS", [_PREREQ_MET_JOB])
 
         rt = _make_runtime({"prereq_met_job": invoker})
-        wrapped = rt._wrap_invoker("prereq_met_job", invoker)
+        # PR1b-2 widened JobInvoker; adapt for direct _wrap_invoker call.
+        from app.jobs.runtime import _adapt_zero_arg
+
+        wrapped = rt._wrap_invoker("prereq_met_job", _adapt_zero_arg(invoker))
         wrapped()
         assert invocations == [1]
 

--- a/tests/test_jobs_runtime_fence.py
+++ b/tests/test_jobs_runtime_fence.py
@@ -61,7 +61,7 @@ def test_prelude_no_fence_writes_running_row_and_runs_invoker(
 
     captured_run_id: list[int | None] = []
 
-    def _invoker() -> None:
+    def _invoker(_p=None) -> None:
         captured_run_id.append(jobs_runtime.consume_prelude_run_id())
 
     invoked_signal = jobs_runtime.run_with_prelude(test_database_url(), "fence_test_no_fence", _invoker)
@@ -94,7 +94,7 @@ def test_prelude_fence_held_writes_skipped_and_does_not_run_invoker(
 
     invoked = []
 
-    def _invoker() -> None:
+    def _invoker(_p=None) -> None:
         invoked.append(True)
 
     invoked_signal = jobs_runtime.run_with_prelude(test_database_url(), "fence_test_held", _invoker)
@@ -135,7 +135,7 @@ def test_prelude_fence_held_by_sibling_sharing_freshness_source(
 
     invoked: list[bool] = []
 
-    def _invoker() -> None:
+    def _invoker(_p=None) -> None:
         invoked.append(True)
 
     invoked_signal = jobs_runtime.run_with_prelude(
@@ -173,7 +173,7 @@ def test_prelude_bypass_fence_runs_invoker_even_with_fence_row(
 
     invoked = []
 
-    def _invoker() -> None:
+    def _invoker(_p=None) -> None:
         invoked.append(True)
 
     jobs_runtime.run_with_prelude(
@@ -233,7 +233,7 @@ def test_prelude_propagates_linked_request_id_to_job_runs(
 
     invoked = []
 
-    def _invoker() -> None:
+    def _invoker(_p=None) -> None:
         invoked.append(True)
 
     jobs_runtime.run_with_prelude(
@@ -267,7 +267,7 @@ def test_prelude_failure_propagates_does_not_run_invoker(
     active full-wash."""
     invoked = []
 
-    def _invoker() -> None:
+    def _invoker(_p=None) -> None:
         invoked.append(True)
 
     def _explode(*_args: object, **_kw: object) -> int | None:
@@ -288,7 +288,7 @@ def test_invoker_can_use_telemetry_aggregator_against_pre_allocated_run(
     _ensure_kill_switch_off(ebull_test_conn)
     ebull_test_conn.commit()
 
-    def _invoker() -> None:
+    def _invoker(_p=None) -> None:
         run_id = jobs_runtime.consume_prelude_run_id()
         assert run_id is not None
         agg = JobTelemetryAggregator()

--- a/tests/test_pr1b2_envelope_and_gate.py
+++ b/tests/test_pr1b2_envelope_and_gate.py
@@ -1,0 +1,381 @@
+"""PR1b-2 (#1064) — envelope, params_snapshot, and universal bootstrap_state gate.
+
+Three behaviour groups:
+
+1. **Envelope normalisation** — ``app/api/jobs.py`` accepts canonical
+   ``{"params": ..., "control": ...}`` AND legacy flat-dict bodies.
+   Both produce the same ``pending_job_requests.payload`` shape.
+2. **Listener gate** — ``app/jobs/listener.py::_dispatch_manual_job``
+   consults ``check_bootstrap_state_gate`` BEFORE the per-job prereq.
+   Override flag bypasses + writes ``decision_audit``.
+3. **Bootstrap gate helper** — ``check_bootstrap_state_gate`` returns
+   the right tuple for each ``(invocation_path, status, override)``
+   combination and writes the audit row only on actual override.
+
+The PR1b prereq tests in ``test_bootstrap_state_gate.py`` cover the
+per-job branch; this file is dedicated to the universal gate + envelope
+plumbing PR1b-2 added.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+from uuid import uuid4
+
+import pytest
+
+from app.jobs.listener import _dispatch_manual_job, _extract_envelope, _MalformedEnvelopeError
+from app.services.processes.bootstrap_gate import check_bootstrap_state_gate
+
+# ---------------------------------------------------------------------------
+# 1. Envelope normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEnvelope:
+    """``_extract_envelope`` decodes durable payloads into (params, control)."""
+
+    def test_canonical_envelope(self) -> None:
+        params, control = _extract_envelope(
+            {"params": {"start_date": "2026-01-01"}, "control": {"override_bootstrap_gate": True}}
+        )
+        assert params == {"start_date": "2026-01-01"}
+        assert control == {"override_bootstrap_gate": True}
+
+    def test_legacy_flat_dict(self) -> None:
+        """Pre-PR1b-2 callers passed a flat dict — entire body becomes params."""
+        params, control = _extract_envelope({"start_date": "2026-01-01"})
+        assert params == {"start_date": "2026-01-01"}
+        assert control == {}
+
+    def test_none_payload(self) -> None:
+        """Legacy queue rows have NULL payload — both sides empty."""
+        params, control = _extract_envelope(None)
+        assert params == {}
+        assert control == {}
+
+    def test_partial_envelope_params_only(self) -> None:
+        params, control = _extract_envelope({"params": {"x": 1}})
+        assert params == {"x": 1}
+        assert control == {}
+
+    def test_partial_envelope_control_only(self) -> None:
+        params, control = _extract_envelope({"control": {"override_bootstrap_gate": True}})
+        assert params == {}
+        assert control == {"override_bootstrap_gate": True}
+
+    def test_non_dict_payload_raises(self) -> None:
+        """Codex pre-push round 2 — direct queue insert with list payload rejects."""
+        with pytest.raises(_MalformedEnvelopeError):
+            _extract_envelope([1, 2, 3])
+
+    def test_envelope_params_non_dict_raises(self) -> None:
+        """Codex pre-push round 1 — malformed inner params now rejects."""
+        with pytest.raises(_MalformedEnvelopeError):
+            _extract_envelope({"params": "not a dict", "control": {}})
+
+    def test_envelope_control_non_dict_raises(self) -> None:
+        with pytest.raises(_MalformedEnvelopeError):
+            _extract_envelope({"params": {}, "control": [1, 2]})
+
+    def test_unknown_control_key_raises(self) -> None:
+        """Codex pre-push round 2 — direct insert with typo'd flag rejects."""
+        with pytest.raises(_MalformedEnvelopeError) as exc:
+            _extract_envelope({"params": {}, "control": {"override_bootstrap_gates": True}})
+        assert "override_bootstrap_gates" in str(exc.value)
+
+    def test_override_must_be_strict_bool(self) -> None:
+        """Codex pre-push round 2 BLOCKING — truthy strings cannot grant override."""
+        with pytest.raises(_MalformedEnvelopeError) as exc:
+            _extract_envelope({"params": {}, "control": {"override_bootstrap_gate": "true"}})
+        assert "boolean" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# 2. Listener gate (universal bootstrap_state)
+# ---------------------------------------------------------------------------
+
+
+def _runtime_mock() -> MagicMock:
+    runtime = MagicMock()
+    runtime.submit_manual_with_request = MagicMock()
+    return runtime
+
+
+def _job_no_prereq(name: str) -> Any:
+    job = MagicMock()
+    job.name = name
+    job.prerequisite = None
+    return job
+
+
+class TestListenerGate:
+    """Universal bootstrap_state gate fires for jobs in SCHEDULED_JOBS."""
+
+    def test_gate_blocks_without_override_marks_rejected(self) -> None:
+        """status != 'complete', no override → mark_request_rejected with reason."""
+        runtime = _runtime_mock()
+        fake_job = _job_no_prereq("daily_cik_refresh")
+        with (
+            patch(
+                "app.jobs.listener.check_bootstrap_state_gate",
+                return_value=(False, "bootstrap_not_complete"),
+            ),
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"daily_cik_refresh"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="daily_cik_refresh",
+                payload={"params": {}, "control": {}},
+            )
+        # Reject (NOT complete — PREVENTION-grade per data-engineer §6.5.7 step 8).
+        mock_reject.assert_called_once()
+        kwargs = mock_reject.call_args.kwargs
+        assert kwargs["error_msg"] == "bootstrap_not_complete"
+        runtime.submit_manual_with_request.assert_not_called()
+
+    def test_gate_allows_with_override(self) -> None:
+        """override_present=True + gate returns allowed → dispatch fires."""
+        runtime = _runtime_mock()
+        fake_job = _job_no_prereq("daily_cik_refresh")
+        gate_mock = MagicMock(return_value=(True, ""))
+        with (
+            patch("app.jobs.listener.check_bootstrap_state_gate", gate_mock),
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"daily_cik_refresh"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="daily_cik_refresh",
+                payload={"params": {}, "control": {"override_bootstrap_gate": True}},
+            )
+        # Gate consulted with override_present=True.
+        assert gate_mock.call_args.kwargs["override_present"] is True
+        mock_reject.assert_not_called()
+        runtime.submit_manual_with_request.assert_called_once()
+
+    def test_gate_skipped_for_bootstrap_internal_jobs(self) -> None:
+        """job not in SCHEDULED_JOBS → gate is NOT consulted (orchestrator self-deadlock guard)."""
+        runtime = _runtime_mock()
+        gate_mock = MagicMock()
+        with (
+            patch("app.jobs.listener.check_bootstrap_state_gate", gate_mock),
+            patch("app.jobs.listener.SCHEDULED_JOBS", []),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"bootstrap_orchestrator"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=99,
+                job_name="bootstrap_orchestrator",
+                payload=None,
+            )
+        gate_mock.assert_not_called()
+        mock_reject.assert_not_called()
+        runtime.submit_manual_with_request.assert_called_once()
+
+    def test_invalid_params_rejected_with_400_message(self) -> None:
+        """Direct queue insert with invalid params → mark_request_rejected before gate."""
+        runtime = _runtime_mock()
+        fake_job = _job_no_prereq("sec_13f_quarterly_sweep")
+        # job_name=sec_13f_quarterly_sweep allows internal key 'source_label'
+        # ONLY when allow_internal_keys=True; the listener uses False, so an
+        # operator-supplied source_label is rejected.
+        with (
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"sec_13f_quarterly_sweep"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=7,
+                job_name="sec_13f_quarterly_sweep",
+                payload={"params": {"source_label": "operator_attempt"}, "control": {}},
+            )
+        mock_reject.assert_called_once()
+        kwargs = mock_reject.call_args.kwargs
+        assert "invalid params" in kwargs["error_msg"]
+        runtime.submit_manual_with_request.assert_not_called()
+
+    def test_malformed_envelope_rejects_with_contract_message(self) -> None:
+        """Direct queue insert with malformed envelope → mark_request_rejected."""
+        runtime = _runtime_mock()
+        fake_job = _job_no_prereq("daily_cik_refresh")
+        with (
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"daily_cik_refresh"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected") as mock_reject,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="daily_cik_refresh",
+                payload={"params": "not a dict", "control": {}},
+            )
+        mock_reject.assert_called_once()
+        kwargs = mock_reject.call_args.kwargs
+        assert "malformed payload" in kwargs["error_msg"]
+        runtime.submit_manual_with_request.assert_not_called()
+
+    def test_validated_params_passed_to_runtime(self) -> None:
+        """Valid params on the envelope flow to runtime.submit_manual_with_request."""
+        runtime = _runtime_mock()
+        fake_job = _job_no_prereq("daily_cik_refresh")
+        # The job has no declared ParamMetadata, so the only valid params
+        # dict is empty. The validator passes ``{}`` through unchanged.
+        with (
+            patch("app.jobs.listener.check_bootstrap_state_gate", return_value=(True, "")),
+            patch("app.jobs.listener.SCHEDULED_JOBS", [fake_job]),
+            patch("app.jobs.listener.VALID_JOB_NAMES", {"daily_cik_refresh"}),
+            patch("app.jobs.listener.psycopg.connect") as mock_connect,
+            patch("app.jobs.listener.mark_request_rejected"),
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            _dispatch_manual_job(
+                runtime=runtime,
+                request_id=42,
+                job_name="daily_cik_refresh",
+                payload={"params": {}, "control": {}},
+            )
+        runtime.submit_manual_with_request.assert_called_once_with(
+            "daily_cik_refresh", request_id=42, mode=None, params={}
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. check_bootstrap_state_gate helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeBootstrapState:
+    """Stand-in for app.services.bootstrap_state.BootstrapState."""
+
+    def __init__(self, status: str) -> None:
+        self.status = status
+
+
+class TestBootstrapStateGate:
+    """Unit-level coverage of the gate decision matrix + audit-write path."""
+
+    def _patched_state(self, status: str) -> Any:
+        return patch(
+            "app.services.processes.bootstrap_gate.read_state",
+            return_value=_FakeBootstrapState(status),
+        )
+
+    def test_complete_status_allows_no_audit(self) -> None:
+        """Happy path: complete bootstrap → (True, '') with NO audit row."""
+        conn = MagicMock()
+        with self._patched_state("complete"):
+            allowed, reason = check_bootstrap_state_gate(
+                conn,
+                job_name="daily_cik_refresh",
+                invocation_path="manual_queue",
+                override_present=False,
+            )
+        assert allowed is True
+        assert reason == ""
+        conn.execute.assert_not_called()
+
+    def test_partial_error_blocks_scheduled(self) -> None:
+        conn = MagicMock()
+        with self._patched_state("partial_error"):
+            allowed, reason = check_bootstrap_state_gate(
+                conn,
+                job_name="fundamentals_sync",
+                invocation_path="scheduled",
+                override_present=False,
+            )
+        assert allowed is False
+        assert reason == "bootstrap_not_complete"
+        conn.execute.assert_not_called()
+
+    def test_running_blocks_manual_no_override(self) -> None:
+        conn = MagicMock()
+        with self._patched_state("running"):
+            allowed, reason = check_bootstrap_state_gate(
+                conn,
+                job_name="daily_cik_refresh",
+                invocation_path="manual_queue",
+                override_present=False,
+            )
+        assert allowed is False
+        assert reason == "bootstrap_not_complete"
+        conn.execute.assert_not_called()
+
+    def test_manual_override_allows_and_audits(self) -> None:
+        conn = MagicMock()
+        operator_id = uuid4()
+        with self._patched_state("partial_error"):
+            allowed, reason = check_bootstrap_state_gate(
+                conn,
+                job_name="daily_cik_refresh",
+                invocation_path="manual_queue",
+                override_present=True,
+                operator_id=operator_id,
+            )
+        assert allowed is True
+        assert reason == ""
+        # Single decision_audit INSERT.
+        assert conn.execute.call_count == 1
+        sql = conn.execute.call_args.args[0]
+        assert "INSERT INTO decision_audit" in sql
+        assert "bootstrap_gate_override" in sql
+        params = conn.execute.call_args.args[1]
+        assert "manual override" in params["expl"]
+        assert "partial_error" in params["expl"]
+        # operator_id rides on evidence_json, not expl.
+        assert str(operator_id) in params["evidence"]
+
+    def test_scheduled_path_ignores_override(self) -> None:
+        """Scheduled fires cannot override — override_present is meaningless there."""
+        conn = MagicMock()
+        with self._patched_state("partial_error"):
+            allowed, reason = check_bootstrap_state_gate(
+                conn,
+                job_name="daily_cik_refresh",
+                invocation_path="scheduled",
+                override_present=True,  # ignored
+            )
+        assert allowed is False
+        assert reason == "bootstrap_not_complete"
+        conn.execute.assert_not_called()
+
+    def test_audit_write_failure_does_not_block_run(self) -> None:
+        """If decision_audit INSERT raises, the gate STILL returns allowed.
+
+        Audit is desired but not load-bearing: we have already decided to
+        allow the run on operator's explicit override; failing closed
+        because the audit row failed to write would punish the operator
+        for an unrelated DB hiccup.
+        """
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("audit insert failed")
+        with self._patched_state("partial_error"):
+            allowed, reason = check_bootstrap_state_gate(
+                conn,
+                job_name="daily_cik_refresh",
+                invocation_path="manual_queue",
+                override_present=True,
+                operator_id="svc-token",
+            )
+        assert allowed is True
+        assert reason == ""
+        # We tried once.
+        assert conn.execute.call_args_list == [call(conn.execute.call_args.args[0], conn.execute.call_args.args[1])]


### PR DESCRIPTION
## What
- POST `/jobs/<name>/run` accepts canonical `{params, control}` envelope (+ legacy flat-dict normalisation); validates params + control allow-list; strict-bool override.
- `_INVOKERS` widened to `JobInvoker` (`Callable[[Mapping[str, Any]], None]`). Zero-arg bodies adapted at registration via `_adapt_zero_arg` — body diff zero for jobs PR1c won't lift.
- New `app/services/processes/bootstrap_gate.py::check_bootstrap_state_gate` wired into scheduled-fire (`_wrap_invoker`), boot catch-up (`_catch_up`), and listener manual-queue path (`_dispatch_manual_job`). Override bypass writes `decision_audit` only when actually overriding.
- `job_runs.params_snapshot` populated on all three paths (manual / scheduled / bootstrap) via `materialise_scheduled_params` + validate + `_params_snapshot_var` contextvar (consumed by `_tracked_job`'s prelude-fallback `record_job_start` branch).
- FE `TriggerConflictReason` + `REASON_TOOLTIP` add `bootstrap_not_complete`.

## Why
Pre-PR1b-2: manual `/jobs/<name>/run` ignored body params; scheduled fires gated only via per-job `_bootstrap_complete` prereq; queue-row `payload` unused. Operators had no way to pass `start_date` / `filing_types` / etc through the queue, and no override path for the bootstrap gate. Widened invoker contract is the precondition for PR1c lifting the bespoke wrappers.

## Test plan
- [x] `tests/test_pr1b2_envelope_and_gate.py` — envelope normalisation (canonical / flat / null / malformed / strict-bool / unknown control), listener gate (block / override / bootstrap-internal-bypass / malformed payload / invalid params), `check_bootstrap_state_gate` decision matrix + audit-write semantics.
- [x] `tests/test_api_jobs.py` — envelope happy + 4× 400 paths (unknown control, invalid param, non-dict body, non-bool override).
- [x] `tests/test_bootstrap_state_gate.py` — PR1b prereq tests preserved; gate stubbed to allow so prereq path isolates.
- [x] `tests/test_jobs_runtime.py` + `tests/test_jobs_runtime_fence.py` — fixture extended for widened invoker contract; all 35 + 9 pass.
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright` clean.
- [x] `pnpm --dir frontend typecheck` clean.
- [x] Codex pre-push checkpoint 2 — 3 rounds, final clean. Caught + fixed: catch-up gate ordering + skip snapshots, malformed-envelope silent coercion, truthy-string override, non-dict payload coercion, listener control allow-list.

## Out of scope (deferred to PR1c per plan-doc carve-out)
- Bespoke wrapper deletion + `StageSpec.params` + 11-file ref rewire. Bootstrap path currently invokes `invoker({})`; PR1c populates `StageSpec.params` with the wrappers' hardcoded values and deletes the wrappers.

Refs #1064.

🤖 Generated with [Claude Code](https://claude.com/claude-code)