### PR TITLE
feat(#1064): PR1c — bespoke wrapper deletion + StageSpec.params lift

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -239,7 +239,10 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     JOB_OWNERSHIP_OBSERVATIONS_SYNC: _adapt_zero_arg(ownership_observations_sync),
     JOB_OWNERSHIP_OBSERVATIONS_BACKFILL: _adapt_zero_arg(ownership_observations_backfill),
     JOB_SEC_13F_FILER_DIRECTORY_SYNC: _adapt_zero_arg(sec_13f_filer_directory_sync),
-    JOB_SEC_13F_QUARTERLY_SWEEP: _adapt_zero_arg(sec_13f_quarterly_sweep),
+    # PR1c #1064 — sec_13f_quarterly_sweep migrated to native JobInvoker
+    # (params-aware). No _adapt_zero_arg wrap; bootstrap stage 21 passes
+    # ``min_period_of_report`` + ``source_label`` via StageSpec.params.
+    JOB_SEC_13F_QUARTERLY_SWEEP: sec_13f_quarterly_sweep,
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC: _adapt_zero_arg(sec_nport_filer_directory_sync),
     JOB_SEC_N_PORT_INGEST: _adapt_zero_arg(sec_n_port_ingest),
     # Registered for #994 (first-install bootstrap orchestrator) — these
@@ -270,16 +273,23 @@ _INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _adapt_zero_arg(_sec_bulk_
 _INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_ORCHESTRATOR] = _adapt_zero_arg(
     _bootstrap_orchestrator.run_bootstrap_orchestrator
 )
-_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_FILINGS_HISTORY_SEED] = _adapt_zero_arg(
-    _bootstrap_orchestrator.bootstrap_filings_history_seed
-)
-_INVOKERS[_bootstrap_orchestrator.JOB_SEC_FIRST_INSTALL_DRAIN] = _adapt_zero_arg(
-    _bootstrap_orchestrator.sec_first_install_drain_job
-)
-# #1008 — recency-bounded 13F sweep for first-install bootstrap.
-_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP] = _adapt_zero_arg(
-    _bootstrap_orchestrator.bootstrap_sec_13f_recent_sweep_job
-)
+# PR1c #1064 — promoted bodies (params-aware natively, no
+# ``_adapt_zero_arg``). Replace the three deleted bespoke wrappers:
+#
+#   * ``bootstrap_filings_history_seed`` → ``filings_history_seed``
+#   * ``sec_first_install_drain_job``    → ``sec_first_install_drain``
+#   * ``bootstrap_sec_13f_recent_sweep_job`` → existing
+#     ``sec_13f_quarterly_sweep`` (params-aware, honours
+#     ``min_period_of_report`` + ``source_label``)
+#
+# The third no longer needs a separate registry entry — bootstrap
+# stage 21 dispatches ``sec_13f_quarterly_sweep`` with a bootstrap-
+# scoped params dict, the same body the weekly cron fires with no
+# params.
+from app.workers import scheduler as _scheduler  # noqa: E402
+
+_INVOKERS[_scheduler.JOB_FILINGS_HISTORY_SEED] = _scheduler.filings_history_seed
+_INVOKERS[_scheduler.JOB_SEC_FIRST_INSTALL_DRAIN] = _scheduler.sec_first_install_drain
 
 # ---------------------------------------------------------------------------
 # Bulk-archive Phase C ingester invokers (#1027 — #1020)
@@ -566,8 +576,13 @@ def _run_prelude(
                 # branches (running + skipped). Passing ``None`` falls back
                 # to the column default ``'{}'`` so the legacy paths stay
                 # forward-compatible. Jsonb wraps the dict for psycopg's
-                # JSONB adapter.
-                snapshot_json = Jsonb(dict(params_snapshot)) if params_snapshot is not None else None
+                # JSONB adapter; ``_jsonable_params`` materialises ``date``
+                # values as ISO strings (PR1c #1064 — stage 21 + manual
+                # ``sec_13f_quarterly_sweep`` carry a ``min_period_of_report``
+                # ``date`` that ``json.dumps`` cannot serialize natively).
+                from app.services.ops_monitor import _jsonable_params
+
+                snapshot_json = Jsonb(_jsonable_params(dict(params_snapshot))) if params_snapshot is not None else None
                 if fence_held:
                     # When a sibling holds the fence, surface the holder
                     # in the audit row so the operator can see WHY this

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Any, Final
 
@@ -59,6 +59,10 @@ from app.services.bootstrap_state import (
 from app.services.process_stop import is_stop_requested
 from app.services.process_stop import mark_completed as mark_stop_completed
 from app.services.process_stop import mark_observed as mark_stop_observed
+from app.services.processes.param_metadata import (
+    ParamValidationError,
+    validate_job_params,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,12 +73,22 @@ logger = logging.getLogger(__name__)
 
 # Job names registered in app/jobs/runtime.py:_INVOKERS that PR2 adds:
 JOB_BOOTSTRAP_ORCHESTRATOR = "bootstrap_orchestrator"
-JOB_BOOTSTRAP_FILINGS_HISTORY_SEED = "bootstrap_filings_history_seed"
-JOB_SEC_FIRST_INSTALL_DRAIN = "sec_first_install_drain"
-# #1008 — first-install-bounded 13F sweep that limits to recent quarters.
-# Distinct from JOB_SEC_13F_QUARTERLY_SWEEP (full historical sweep) so
-# the standalone weekly cron keeps full coverage.
-JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP = "bootstrap_sec_13f_recent_sweep"
+
+# PR1c #1064 — three bespoke wrappers (``bootstrap_filings_history_seed``,
+# ``sec_first_install_drain_job``, ``bootstrap_sec_13f_recent_sweep_job``)
+# were lifted into params-aware ``JobInvoker`` bodies in
+# ``app/workers/scheduler.py``. The hardcoded values that lived inside
+# the wrapper bodies (``days_back=730``, ``min_period_of_report=today-380d``,
+# ``source_label="sec_edgar_13f_directory_bootstrap"``, etc.) now live
+# in ``StageSpec.params`` for stages 14, 15, 21 below.
+#
+# Constants imported from the scheduler so the bootstrap-stage entries
+# below carry the canonical names and a future rename is single-site.
+from app.workers.scheduler import (  # noqa: E402  (after dataclass to avoid cycle)
+    JOB_FILINGS_HISTORY_SEED,
+    JOB_SEC_13F_QUARTERLY_SWEEP,
+    JOB_SEC_FIRST_INSTALL_DRAIN,
+)
 
 # These already exist as scheduled jobs but were not registered in
 # _INVOKERS until PR2; we re-use the existing job-name constants so
@@ -83,8 +97,68 @@ JOB_DAILY_CIK_REFRESH = "daily_cik_refresh"
 JOB_DAILY_FINANCIAL_FACTS = "daily_financial_facts"
 
 
-def _spec(stage_key: str, stage_order: int, lane: str, job_name: str) -> StageSpec:
-    return StageSpec(stage_key=stage_key, stage_order=stage_order, lane=lane, job_name=job_name)  # type: ignore[arg-type]
+# PR1c #1064 — bootstrap-bounded 13F sweep recency cut-off. Used to
+# live as a constant inside the deleted ``bootstrap_sec_13f_recent_sweep_job``
+# wrapper. 4 quarters (~380 days) = current + 3 prior periods, matches
+# the rolling ownership-card window. Older 13Fs add no value to
+# current-quarter ranking and pre-2013 ones don't have machine-readable
+# holdings (#1008).
+_BOOTSTRAP_13F_QUARTERS_BACK = 4
+_BOOTSTRAP_13F_RECENCY_DAYS = _BOOTSTRAP_13F_QUARTERS_BACK * 95
+
+# PR1c #1064 — filings_history_seed bootstrap default form-type
+# allow-list. Imported once at module load so the StageSpec.params
+# dict is plain data; the underlying constant lives in the canonical
+# owner (``app.services.filings``) so the three-tier allow-list stays
+# single-sourced. Tuple (not list) for hashable, frozen-stage-spec
+# compat.
+from app.services.filings import SEC_INGEST_KEEP_FORMS  # noqa: E402
+
+_FILINGS_HISTORY_KEEP_FORMS_TUPLE: tuple[str, ...] = tuple(sorted(SEC_INGEST_KEEP_FORMS))
+
+
+# Sentinel for params values that depend on dispatch-time state
+# (e.g. ``date.today()``). Module-load evaluation would freeze the
+# value into ``_BOOTSTRAP_STAGE_SPECS`` for the lifetime of the jobs
+# process; a long-lived process would dispatch stage 21 with a stale
+# cutoff. ``_resolve_dynamic_params`` materialises the absolute value
+# at dispatch time. The sentinel string is namespaced so it never
+# collides with a legitimate operator value.
+_PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF = "<dynamic:bootstrap_13f_cutoff>"
+
+
+def _resolve_dynamic_params(params: Mapping[str, Any]) -> dict[str, Any]:
+    """Materialise dispatch-time dynamic values in a stage params dict.
+
+    Today the only dynamic value is the bootstrap-13F recency cutoff;
+    the helper is structured for forward extensibility (additional
+    sentinels can be added without touching call sites).
+
+    The dispatcher calls this immediately before invoking the
+    underlying ``JobInvoker`` so the absolute value is what flows
+    into ``job_runs.params_snapshot`` and the invoker body.
+    """
+    resolved: dict[str, Any] = dict(params)
+    if resolved.get("min_period_of_report") == _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF:
+        resolved["min_period_of_report"] = date.today() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS)
+    return resolved
+
+
+def _spec(
+    stage_key: str,
+    stage_order: int,
+    lane: str,
+    job_name: str,
+    *,
+    params: Mapping[str, Any] | None = None,
+) -> StageSpec:
+    return StageSpec(
+        stage_key=stage_key,
+        stage_order=stage_order,
+        lane=lane,  # type: ignore[arg-type]
+        job_name=job_name,
+        params=params if params is not None else {},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +175,20 @@ _LANE_MAX_CONCURRENCY: Final[dict[str, int]] = {
     "sec": 1,  # legacy catch-all; preserved for migration compat
     "sec_rate": 1,  # SEC per-IP rate clock
     "sec_bulk_download": 1,
-    "db": 5,  # DB-bound, parallel-able
+    # PR1c #1064: every lane serialises now that JobLock is source-keyed
+    # (one ``JobLock(source)`` covers all jobs in the same lane). The
+    # operator-locked source-lock decision is unambiguous: same-source =
+    # serialised. Setting ``db`` to 1 retires the parallel-DB-stage claim
+    # from #1020 — a misleading dispatcher shape (5 db stages submitted,
+    # 4 immediately blocked on the source lock). The map structure is
+    # kept (rather than deleted) for one cycle so the
+    # ``_phase_batched_dispatch`` shape stays stable; a follow-up PR
+    # removes the map entirely.
+    #
+    # Tech-debt: first-install bootstrap wall-clock regresses from "5 db
+    # stages parallel" → "1 db stage at a time". Measure on dev and file
+    # follow-up if operator-visible — tracked in PR description.
+    "db": 1,
 }
 
 
@@ -226,8 +313,28 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # bulk pass these are largely idempotent DB no-ops on populated
     # observation tables; on the slow-connection bypass path they are
     # the primary write path.
-    _spec("filings_history_seed", 14, "sec_rate", JOB_BOOTSTRAP_FILINGS_HISTORY_SEED),
-    _spec("sec_first_install_drain", 15, "sec_rate", JOB_SEC_FIRST_INSTALL_DRAIN),
+    # PR1c #1064 — three bespoke wrappers in this module collapsed into
+    # the SCHEDULED_JOBS-side ``filings_history_seed`` /
+    # ``sec_first_install_drain`` / ``sec_13f_quarterly_sweep`` bodies.
+    # Bootstrap-only knobs ride here as ``StageSpec.params``; the bodies
+    # consume the same dict shape that the manual API publishes.
+    _spec(
+        "filings_history_seed",
+        14,
+        "sec_rate",
+        JOB_FILINGS_HISTORY_SEED,
+        params={
+            "days_back": 730,
+            "filing_types": tuple(_FILINGS_HISTORY_KEEP_FORMS_TUPLE),
+        },
+    ),
+    _spec(
+        "sec_first_install_drain",
+        15,
+        "sec_rate",
+        JOB_SEC_FIRST_INSTALL_DRAIN,
+        params={"max_subjects": None},
+    ),
     _spec("sec_def14a_bootstrap", 16, "sec_rate", "sec_def14a_bootstrap"),
     _spec("sec_business_summary_bootstrap", 17, "sec_rate", "sec_business_summary_bootstrap"),
     _spec("sec_insider_transactions_backfill", 18, "sec_rate", "sec_insider_transactions_backfill"),
@@ -237,11 +344,30 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # (last 4 quarters, ~12 months) instead of the full historical
     # sweep. Walking decades of pre-2013 filings yields zero rows
     # (no machine-readable primary_doc/infotable) and turns the
-    # bootstrap into an 11+ hour wait. Standalone weekly cron
-    # keeps the full historical sweep via JOB_SEC_13F_QUARTERLY_SWEEP.
-    # On the bulk path (#1020) C3 has already populated
+    # bootstrap into an 11+ hour wait. Standalone weekly cron keeps
+    # the full historical sweep — same job, no min_period_of_report
+    # bound. On the bulk path (#1020) C3 has already populated
     # ownership_institutions_observations; this stage tops up.
-    _spec("sec_13f_recent_sweep", 21, "sec_rate", JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP),
+    #
+    # PR1c #1064: bootstrap-only ``source_label`` overrides the default
+    # so audit history distinguishes this bounded sweep from the
+    # standalone weekly run. The validator allows ``source_label`` here
+    # via ``JOB_INTERNAL_KEYS`` (PR1a) — manual API rejects it.
+    _spec(
+        "sec_13f_recent_sweep",
+        21,
+        "sec_rate",
+        JOB_SEC_13F_QUARTERLY_SWEEP,
+        # ``min_period_of_report`` resolves to ``today() - 380d`` at
+        # dispatch time (see ``_resolve_dynamic_params``). Hardcoding
+        # ``date.today()`` here would freeze the cutoff at module-load,
+        # so a long-lived jobs process would dispatch stage 21 with a
+        # stale floor. The sentinel keeps the StageSpec data-only.
+        params={
+            "min_period_of_report": _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF,
+            "source_label": "sec_edgar_13f_directory_bootstrap",
+        },
+    ),
     _spec("sec_n_port_ingest", 22, "sec_rate", "sec_n_port_ingest"),
     _spec("ownership_observations_backfill", 23, "db", "ownership_observations_backfill"),
     _spec("fundamentals_sync", 24, "db", "fundamentals_sync"),
@@ -279,6 +405,7 @@ def _run_one_stage(
     job_name: str,
     invoker: Callable[[Mapping[str, Any]], None],
     database_url: str,
+    params: Mapping[str, Any] | None = None,
 ) -> _StageOutcome:
     """Execute one stage end-to-end with `JobLock` + bookkeeping.
 
@@ -288,19 +415,38 @@ def _run_one_stage(
     (e.g. the bookkeeping query fails) — those propagate so the
     orchestrator surfaces them, but the lane runner catches a broad
     ``Exception`` to keep going.
+
+    PR1c #1064: ``params`` carries the dispatcher-supplied stage
+    params dict (from ``StageSpec.params`` after dynamic-value
+    resolution + validation). The invoker consumes them through the
+    widened ``JobInvoker`` contract; bootstrap-only knobs like
+    ``min_period_of_report`` and ``source_label`` flow through here
+    instead of living inside bespoke wrapper bodies. Default
+    ``None`` = empty dict for backwards compat with any direct
+    test caller that hasn't migrated.
     """
+    effective_params: Mapping[str, Any] = params if params is not None else {}
     with psycopg.connect(database_url) as conn:
         mark_stage_running(conn, run_id=run_id, stage_key=stage_key)
         conn.commit()
 
+    # PR1c #1064 (Codex pre-push WARNING): the promoted scheduler-side
+    # invokers call ``_tracked_job`` which reads ``_params_snapshot_var``
+    # via ``consume_params_snapshot()`` to populate
+    # ``job_runs.params_snapshot``. Bootstrap dispatch bypasses
+    # ``run_with_prelude``'s contextvar set, so we plumb the snapshot
+    # here. Without this, stage 21's audit row would persist ``{}``
+    # even though the body executed with a real ``min_period_of_report``
+    # cutoff + ``source_label`` override.
+    from app.jobs.runtime import _params_snapshot_var
+
     try:
         with JobLock(database_url, job_name):
-            # PR1b-2 (#1064): invoker contract widened to JobInvoker
-            # (``Callable[[Mapping[str, Any]], None]``). Bootstrap stages
-            # pass ``{}`` here today; PR1c lifts the bespoke wrappers
-            # and populates ``StageSpec.params`` with the per-stage
-            # hardcoded values currently buried in the wrapper bodies.
-            invoker({})
+            snap_token = _params_snapshot_var.set(effective_params)
+            try:
+                invoker(effective_params)
+            finally:
+                _params_snapshot_var.reset(snap_token)
     except JobAlreadyRunning:
         message = (
             f"another instance of {job_name!r} holds the advisory lock; "
@@ -417,6 +563,10 @@ class _RunnableStage:
     lane: str
     invoker: Callable[[Mapping[str, Any]], None]
     requires: tuple[str, ...]
+    # PR1c #1064: per-stage params dict from ``StageSpec.params``.
+    # Default empty so existing test fixtures that build
+    # ``_RunnableStage`` directly without params keep working.
+    params: Mapping[str, Any] = field(default_factory=dict)
 
 
 def _phase_batched_dispatch(
@@ -612,6 +762,38 @@ def _phase_batched_dispatch(
                 )
                 lane_executors.append(ex)
                 for stage in stages:
+                    # PR1c #1064: resolve dispatch-time dynamic values
+                    # (e.g. _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF →
+                    # ``today() - 380d``) and validate via the canonical
+                    # registry validator with allow_internal_keys=True
+                    # so audit-only keys (``source_label``) pass through.
+                    # Validation failure is a programmer error in the
+                    # stage spec — fail-fast, dispatch surfaces it as a
+                    # stage error.
+                    resolved = _resolve_dynamic_params(stage.params)
+                    try:
+                        validated_params = validate_job_params(
+                            stage.job_name,
+                            resolved,
+                            allow_internal_keys=True,
+                        )
+                    except ParamValidationError as exc:
+                        logger.error(
+                            "bootstrap dispatcher: stage %s params invalid: %s",
+                            stage.stage_key,
+                            exc,
+                        )
+                        with psycopg.connect(database_url) as conn:
+                            mark_stage_error(
+                                conn,
+                                run_id=run_id,
+                                stage_key=stage.stage_key,
+                                error_message=f"stage params invalid: {exc}",
+                            )
+                            conn.commit()
+                        statuses[stage.stage_key] = "error"
+                        continue
+
                     fut = ex.submit(
                         _run_one_stage,
                         run_id=run_id,
@@ -619,6 +801,7 @@ def _phase_batched_dispatch(
                         job_name=stage.job_name,
                         invoker=stage.invoker,
                         database_url=database_url,
+                        params=validated_params,
                     )
                     all_futures.append((stage.stage_key, fut))
             wait([f for _, f in all_futures])
@@ -671,6 +854,13 @@ def run_bootstrap_orchestrator() -> None:
         )
         return
 
+    # PR1c #1064 — build a stage_key → params lookup from the static
+    # ``_BOOTSTRAP_STAGE_SPECS`` so the per-stage params dict can be
+    # plumbed into ``_RunnableStage`` below. ``bootstrap_stages`` in
+    # DB doesn't store params (immutable across runs; lives in code),
+    # so the dispatch path consults the spec table at run time.
+    stage_params_by_key: dict[str, Mapping[str, Any]] = {spec.stage_key: spec.params for spec in _BOOTSTRAP_STAGE_SPECS}
+
     # Pre-populate statuses with stages already in a terminal state
     # so the dependency graph sees them when a downstream pending
     # stage's `requires` references them. Without this, a retry pass
@@ -710,6 +900,7 @@ def run_bootstrap_orchestrator() -> None:
                 lane=_effective_lane(stage.stage_key, stage.lane),
                 invoker=invoker,
                 requires=_STAGE_REQUIRES.get(stage.stage_key, ()),
+                params=stage_params_by_key.get(stage.stage_key, {}),
             )
         )
 
@@ -739,229 +930,23 @@ def run_bootstrap_orchestrator() -> None:
     logger.info("bootstrap dispatcher: run_id=%d finalised as %s", run_id, terminal)
 
 
-# ---------------------------------------------------------------------------
-# New invoker: bootstrap_filings_history_seed
-# ---------------------------------------------------------------------------
-
-
-# Historical depth window for the broad filings sweep. Two years
-# matches what most operators want for first-install ranking; the
-# practical depth is bounded by SEC submissions.json's inline
-# ``recent`` block (typically ~12 months) since
-# ``SecFilingsProvider.list_filings`` does not currently walk
-# secondary submissions pages.
-_FILINGS_HISTORY_DAYS = 730
-
-
-def bootstrap_filings_history_seed() -> None:
-    """``_INVOKERS['bootstrap_filings_history_seed']`` — broad filings sweep.
-
-    Walks each CIK-mapped tradable instrument's submissions.json via
-    ``refresh_filings`` with a 2-year window and no ``filing_types``
-    filter, populating ``filing_events`` for every form type. The
-    typed-form parsers later in the SEC lane (``sec_def14a_bootstrap``,
-    ``sec_business_summary_bootstrap``,
-    ``sec_insider_transactions_backfill``, etc.) read from
-    ``filing_events`` and would otherwise no-op on a fresh DB.
-
-    Bookkeeping: reuses ``_tracked_job`` from ``app.workers.scheduler``
-    (the same context manager every scheduled job uses) so
-    ``job_runs`` rows have a uniform shape regardless of whether the
-    invoker was triggered by bootstrap dispatch or manual operator
-    Run-now.
-    """
-    from app.providers.implementations.sec_edgar import SecFilingsProvider
-    from app.services.filings import SEC_INGEST_KEEP_FORMS, refresh_filings
-    from app.workers.scheduler import _tracked_job  # type: ignore[attr-defined]
-
-    with _tracked_job(JOB_BOOTSTRAP_FILINGS_HISTORY_SEED) as tracker:
-        with psycopg.connect(settings.database_url) as conn:
-            cik_rows = conn.execute(
-                """
-                SELECT i.symbol, i.instrument_id::text
-                  FROM external_identifiers ei
-                  JOIN instruments i ON i.instrument_id = ei.instrument_id
-                 WHERE ei.provider = 'sec'
-                   AND ei.identifier_type = 'cik'
-                   AND ei.is_primary = TRUE
-                   AND i.is_tradable = TRUE
-                """
-            ).fetchall()
-
-        if not cik_rows:
-            logger.info("bootstrap_filings_history_seed: no CIK-mapped instruments; ensure daily_cik_refresh ran first")
-            tracker.row_count = 0
-            return
-
-        instrument_ids = [row[1] for row in cik_rows]
-        from_date = date.today() - timedelta(days=_FILINGS_HISTORY_DAYS)
-        to_date = date.today()
-
-        with (
-            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
-            psycopg.connect(settings.database_url) as conn,
-        ):
-            summary = refresh_filings(
-                provider=sec,
-                provider_name="sec",
-                identifier_type="cik",
-                conn=conn,
-                instrument_ids=instrument_ids,
-                start_date=from_date,
-                end_date=to_date,
-                # #1011 — three-tier form-type allow-list. Pre-fix
-                # this was ``None`` (all forms); first-install audit
-                # 2026-05-07 measured ~32% of resulting filing_events
-                # rows were forms no parser ever consumes.
-                filing_types=sorted(SEC_INGEST_KEEP_FORMS),
-            )
-        tracker.row_count = summary.filings_upserted
-        logger.info(
-            "bootstrap_filings_history_seed: instruments=%d filings_upserted=%d skipped=%d",
-            summary.instruments_attempted,
-            summary.filings_upserted,
-            summary.instruments_skipped,
-        )
-
-
-# ---------------------------------------------------------------------------
-# New invoker: sec_first_install_drain (zero-arg wrapper)
-# ---------------------------------------------------------------------------
-
-
-def _make_sec_http_get(sec_provider: object) -> Callable[[str, dict[str, str]], tuple[int, bytes]]:
-    """Adapt ``SecFilingsProvider._http`` (a ``ResilientClient``) into
-    an ``HttpGet = Callable[[str, dict[str, str]], tuple[int, bytes]]``.
-
-    The drain / poll / rebuild call sites all consume this narrowed
-    callable shape (see ``app/providers/implementations/sec_submissions.py``);
-    the closure routes through the rate-limited shared client so SEC's
-    10 req/s bucket is honoured.
-    """
-
-    def _impl(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
-        # ``_http`` is the ResilientClient wrapping the SEC httpx.Client
-        # with the shared process-wide token bucket. ``.get(...)`` returns
-        # a httpx.Response; the HttpGet contract is (status, body bytes).
-        response = sec_provider._http.get(url, headers=headers)  # type: ignore[attr-defined]
-        return response.status_code, response.content
-
-    return _impl
-
-
-def sec_first_install_drain_job() -> None:
-    """``_INVOKERS['sec_first_install_drain']`` — zero-arg drain wrapper.
-
-    The underlying ``run_first_install_drain`` takes an ``http_get``
-    callable, ``follow_pagination``, etc. so it cannot be registered
-    directly. This wrapper picks the bootstrap-default arguments
-    (full universe scope, paginate enabled) and adapts the
-    ``SecFilingsProvider._http`` ResilientClient into the
-    ``HttpGet = Callable[[str, dict[str, str]], tuple[int, bytes]]``
-    contract via ``_make_sec_http_get``.
-    """
-    from app.jobs.sec_first_install_drain import run_first_install_drain
-    from app.providers.implementations.sec_edgar import SecFilingsProvider
-    from app.workers.scheduler import _tracked_job  # type: ignore[attr-defined]
-
-    with _tracked_job(JOB_SEC_FIRST_INSTALL_DRAIN) as tracker:
-        with (
-            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
-            psycopg.connect(settings.database_url) as conn,
-        ):
-            stats = run_first_install_drain(
-                conn,
-                http_get=_make_sec_http_get(sec),  # type: ignore[arg-type]
-                follow_pagination=True,
-                use_bulk_zip=False,
-                max_subjects=None,
-            )
-        tracker.row_count = stats.manifest_rows_upserted
-        logger.info(
-            "sec_first_install_drain: ciks_processed=%d skipped=%d manifest_rows=%d errors=%d",
-            stats.ciks_processed,
-            stats.ciks_skipped,
-            stats.manifest_rows_upserted,
-            stats.errors,
-        )
-
-
-# ---------------------------------------------------------------------------
-# New invoker: bootstrap_sec_13f_recent_sweep
-# ---------------------------------------------------------------------------
-
-
-# Recency cut-off for the bootstrap-bounded 13F sweep. 13F-HRs file
-# ~quarterly so 4 quarters = current + 3 prior periods, matches the
-# rolling ownership-card window operators use today. Older 13Fs
-# add no value to current-quarter ranking and pre-2013 ones don't
-# have machine-readable holdings (#1008).
-_BOOTSTRAP_13F_QUARTERS_BACK = 4
-
-
-def bootstrap_sec_13f_recent_sweep_job() -> None:
-    """``_INVOKERS['bootstrap_sec_13f_recent_sweep']`` — recency-bounded
-    13F sweep for first-install bootstrap (#1008).
-
-    Walks the same ``institutional_filers`` directory as
-    ``sec_13f_quarterly_sweep`` but passes ``min_period_of_report``
-    so the parser skips accessions whose ``period_of_report`` is
-    older than the cut-off. On a fresh install with ~11k filers and
-    no prior tombstones this cuts the sweep from 11+ hours
-    (operator-killed in the 2026-05-07 smoke run) to ~30-45 min.
-
-    Standalone scheduled ``sec_13f_quarterly_sweep`` retains the
-    full historical sweep so an operator who wants deeper coverage
-    later can trigger it manually.
-    """
-    from datetime import timedelta
-
-    from app.providers.implementations.sec_edgar import SecFilingsProvider
-    from app.services.institutional_holdings import (
-        ingest_all_active_filers,
-        list_directory_filer_ciks,
-    )
-    from app.workers.scheduler import _tracked_job  # type: ignore[attr-defined]
-
-    cutoff = date.today() - timedelta(days=_BOOTSTRAP_13F_QUARTERS_BACK * 95)
-
-    with _tracked_job(JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP) as tracker:
-        with (
-            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
-            psycopg.connect(settings.database_url) as conn,
-        ):
-            ciks = list_directory_filer_ciks(conn)
-            summaries = ingest_all_active_filers(
-                conn,
-                sec,
-                ciks=ciks,
-                deadline_seconds=settings.sec_13f_sweep_deadline_seconds,
-                source_label="sec_edgar_13f_directory_bootstrap",
-                min_period_of_report=cutoff,
-            )
-        rows_upserted = sum(s.holdings_inserted for s in summaries)
-        tracker.row_count = rows_upserted
-        logger.info(
-            "bootstrap_sec_13f_recent_sweep: filers_total=%d processed=%d holdings_upserted=%d cutoff=%s",
-            len(ciks),
-            len(summaries),
-            rows_upserted,
-            cutoff,
-        )
+# PR1c #1064 — three bespoke wrappers
+# (``bootstrap_filings_history_seed``, ``sec_first_install_drain_job``,
+# ``bootstrap_sec_13f_recent_sweep_job``) deleted. Their bodies were
+# lifted into params-aware ``JobInvoker`` bodies in
+# ``app/workers/scheduler.py`` (``filings_history_seed``,
+# ``sec_first_install_drain``, extended ``sec_13f_quarterly_sweep``).
+# Bootstrap stages 14, 15, 21 dispatch the promoted bodies via
+# ``StageSpec.params``; the deleted JOB_* constants are gone too,
+# so any straggling reference fails fast on import.
 
 
 __all__ = [
-    "JOB_BOOTSTRAP_FILINGS_HISTORY_SEED",
     "JOB_BOOTSTRAP_ORCHESTRATOR",
-    "JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP",
     "JOB_DAILY_CIK_REFRESH",
     "JOB_DAILY_FINANCIAL_FACTS",
-    "JOB_SEC_FIRST_INSTALL_DRAIN",
-    "bootstrap_filings_history_seed",
-    "bootstrap_sec_13f_recent_sweep_job",
     "get_bootstrap_stage_specs",
     "run_bootstrap_orchestrator",
-    "sec_first_install_drain_job",
 ]
 
 

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -36,6 +36,38 @@ from psycopg.types.json import Jsonb
 
 from app.services.runtime_config import write_kill_switch_audit
 
+
+def _jsonable_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Convert non-JSON-native values in a params dict to JSON-safe scalars.
+
+    Codex pre-push round 2 BLOCKING (#1064 PR1c): ``date`` values
+    cannot pass through ``json.dumps`` without a default coercer, so
+    a ``date`` in ``params_snapshot`` would raise ``TypeError`` inside
+    ``psycopg.types.json.Jsonb``. The promoted
+    ``sec_13f_quarterly_sweep`` body and bootstrap stage 21 both pass
+    a ``min_period_of_report`` date; this helper materialises dates +
+    datetimes as ISO-8601 strings so the JSONB column sees a stable
+    text representation. Operator queries that read
+    ``params_snapshot->>'min_period_of_report'`` get the same string
+    shape regardless of who triggered the run.
+    """
+    from datetime import date as _date
+    from datetime import datetime as _datetime
+
+    result: dict[str, Any] = {}
+    for key, value in params.items():
+        if isinstance(value, _datetime):
+            result[key] = value.isoformat()
+        elif isinstance(value, _date):
+            result[key] = value.isoformat()
+        elif isinstance(value, (list, tuple)):
+            # Preserve list/tuple semantics for multi_enum (filing_types, etc).
+            result[key] = list(value)
+        else:
+            result[key] = value
+    return result
+
+
 if TYPE_CHECKING:
     # layer_types sits at the bottom of the orchestrator import graph, but
     # the sync_orchestrator package __init__ re-exports executor/planner/
@@ -296,7 +328,11 @@ def record_job_start(
                 VALUES (%(name)s, %(started)s, 'running', %(params)s)
                 RETURNING run_id
                 """,
-                {"name": job_name, "started": now, "params": Jsonb(params_snapshot)},
+                {
+                    "name": job_name,
+                    "started": now,
+                    "params": Jsonb(_jsonable_params(params_snapshot)),
+                },
             )
         row = cur.fetchone()
     conn.commit()
@@ -395,7 +431,7 @@ def record_job_skip(
                     "name": job_name,
                     "ts": now,
                     "reason": reason,
-                    "params": Jsonb(params_snapshot),
+                    "params": Jsonb(_jsonable_params(params_snapshot)),
                 },
             ).fetchone()
         if row is None:

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -163,6 +163,18 @@ JOB_INTERNAL_KEYS: dict[str, frozenset[str]] = {
     # operator never edits this — it lives in the bootstrap StageSpec's
     # params dict.
     "sec_13f_quarterly_sweep": frozenset({"source_label"}),
+    # PR1c #1064 — bootstrap-only invokers promoted from bespoke
+    # wrappers. These jobs are NOT in SCHEDULED_JOBS today (no cron
+    # cadence), so they have no operator-facing ``ParamMetadata``;
+    # the bootstrap dispatcher passes the wrapper's former hardcoded
+    # values via ``StageSpec.params`` and the validator permits the
+    # keys here under ``allow_internal_keys=True``. The manual API
+    # path uses ``allow_internal_keys=False`` and would therefore
+    # reject these keys — operator-tunability is deferred to a
+    # future PR that promotes the jobs into SCHEDULED_JOBS with
+    # proper ``ParamMetadata`` declarations.
+    "filings_history_seed": frozenset({"days_back", "filing_types", "instrument_id"}),
+    "sec_first_install_drain": frozenset({"max_subjects"}),
 }
 
 

--- a/app/services/sec_submissions_ingest.py
+++ b/app/services/sec_submissions_ingest.py
@@ -10,8 +10,9 @@ universe:
    ownerOrg, addresses, exchanges, etc) flow through the existing
    ``parse_entity_profile()`` + ``upsert_entity_profile()`` helpers.
 
-This replaces the per-CIK HTTP walk that S5 (`bootstrap_filings_history_seed`)
-issues at 7 req/s on a fresh install. Per-CIK ``filings.files[]``
+This replaces the per-CIK HTTP walk that S5 (``filings_history_seed``;
+formerly the bespoke ``bootstrap_filings_history_seed`` wrapper, lifted
+in PR1c #1064) issues at 7 req/s on a fresh install. Per-CIK ``filings.files[]``
 secondary-page coverage is the responsibility of C1.b, a separate
 stage.
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from typing import Any, Literal
@@ -275,6 +275,14 @@ JOB_SEC_N_PORT_INGEST = "sec_n_port_ingest"
 JOB_CUSIP_UNIVERSE_BACKFILL = "cusip_universe_backfill"
 JOB_EXCHANGES_METADATA_REFRESH = "exchanges_metadata_refresh"
 JOB_ETORO_LOOKUPS_REFRESH = "etoro_lookups_refresh"
+
+# PR1c #1064 — promoted from bespoke wrappers in
+# ``app/services/bootstrap_orchestrator.py``. Each is now a registered
+# ``JobInvoker`` (params-aware) so bootstrap dispatch and operator
+# manual-trigger share a single body. The bootstrap stage spec
+# carries the per-stage hardcoded values via ``StageSpec.params``.
+JOB_FILINGS_HISTORY_SEED = "filings_history_seed"
+JOB_SEC_FIRST_INSTALL_DRAIN = "sec_first_install_drain"
 
 
 # ---------------------------------------------------------------------------
@@ -907,6 +915,28 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # on every dev restart would burn SEC bandwidth + DB I/O.
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
+        # PR1c #1064: ``min_period_of_report`` is operator-exposable so a
+        # triage operator can sweep "everything since 2024-01-01" without
+        # editing the bootstrap StageSpec. ``source_label`` is internal-
+        # only (declared in ``JOB_INTERNAL_KEYS`` per PR1a) so the
+        # bootstrap dispatch can override the audit tag while the
+        # operator API rejects it.
+        params_metadata=(
+            ParamMetadata(
+                name="min_period_of_report",
+                label="Recency floor",
+                help_text=(
+                    "Skip 13F accessions whose period_of_report is older "
+                    "than this date. Leave blank to sweep the full filer "
+                    "history. Bootstrap stage 21 sets this to today minus "
+                    "~380 days so the first-install sweep finishes in "
+                    "minutes rather than hours."
+                ),
+                field_type="date",
+                default=None,
+                advanced_group=True,
+            ),
+        ),
     ),
     ScheduledJob(
         name=JOB_SEC_13F_FILER_DIRECTORY_SYNC,
@@ -3994,7 +4024,7 @@ def cusip_universe_backfill() -> None:
         )
 
 
-def sec_13f_quarterly_sweep() -> None:
+def sec_13f_quarterly_sweep(params: Mapping[str, Any]) -> None:
     """Quarterly sweep — walk every CIK in ``institutional_filers``
     (populated by ``sec_13f_filer_directory_sync`` #912) and ingest
     each filer's pending 13F-HR / 13F-HR/A accessions through the
@@ -4003,6 +4033,21 @@ def sec_13f_quarterly_sweep() -> None:
     Soft 6h deadline budget — already-ingested accessions are
     tombstoned in ``institutional_holdings_ingest_log`` so a
     deadline-interrupted sweep resumes the tail on the next fire.
+
+    Honoured params (PR1c #1064):
+
+    * ``min_period_of_report`` (date) — recency floor; accessions whose
+      ``period_of_report`` is older are skipped. Default ``None`` = no
+      floor (full historical sweep). Bootstrap stage 21 dispatches with
+      ``today() - 380d`` so first-install completes in ~30-45 min
+      instead of 11+h.
+    * ``source_label`` (str, audit-only) — provenance tag on each
+      ingested holding row. Default ``"sec_edgar_13f_directory"``;
+      bootstrap stage 21 overrides with
+      ``"sec_edgar_13f_directory_bootstrap"`` so audit history
+      distinguishes bootstrap-bounded sweeps from the standalone
+      weekly historical sweep. Operator-API path REJECTS this key
+      via ``JOB_INTERNAL_KEYS`` allow-list (#1064 PR1a).
     """
     from app.providers.implementations.sec_edgar import SecFilingsProvider
     from app.services.institutional_holdings import (
@@ -4011,6 +4056,16 @@ def sec_13f_quarterly_sweep() -> None:
     )
 
     deadline_seconds = settings.sec_13f_sweep_deadline_seconds
+    min_period_of_report_param = params.get("min_period_of_report")
+    min_period_of_report: date | None
+    if min_period_of_report_param is None:
+        min_period_of_report = None
+    elif isinstance(min_period_of_report_param, date):
+        min_period_of_report = min_period_of_report_param
+    else:
+        # Validator should have coerced; defensive against direct invocation.
+        min_period_of_report = date.fromisoformat(str(min_period_of_report_param))
+    source_label = str(params.get("source_label") or "sec_edgar_13f_directory")
 
     with _tracked_job(JOB_SEC_13F_QUARTERLY_SWEEP) as tracker:
         with (
@@ -4023,7 +4078,8 @@ def sec_13f_quarterly_sweep() -> None:
                 sec,
                 ciks=ciks,
                 deadline_seconds=deadline_seconds,
-                source_label="sec_edgar_13f_directory",
+                source_label=source_label,
+                min_period_of_report=min_period_of_report,
             )
 
         total_filers = len(ciks)
@@ -4035,13 +4091,198 @@ def sec_13f_quarterly_sweep() -> None:
         logger.info(
             "sec_13f_quarterly_sweep: filers=%d processed=%d "
             "accessions_ingested=%d holdings_inserted=%d "
-            "holdings_skipped_no_cusip=%d",
+            "holdings_skipped_no_cusip=%d "
+            "source_label=%s min_period_of_report=%s",
             total_filers,
             processed,
             accessions_ingested,
             rows_upserted,
             rows_skipped,
+            source_label,
+            min_period_of_report,
         )
+
+
+# ---------------------------------------------------------------------------
+# PR1c #1064 — promoted bodies (formerly bespoke wrappers in
+# app/services/bootstrap_orchestrator.py).
+# ---------------------------------------------------------------------------
+#
+# Each function below is registered in ``_INVOKERS`` directly under the
+# new (PR1c) job name and dispatched by the bootstrap orchestrator via
+# ``StageSpec.params``. The hardcoded values that used to live inside
+# the deleted wrapper bodies now live in the bootstrap stage spec as
+# data, so a single body serves both the bootstrap stage and the
+# operator manual-trigger path.
+
+# Default historical depth window for the broad filings sweep. Two
+# years matches what most operators want for first-install ranking;
+# the practical depth is bounded by SEC submissions.json's inline
+# ``recent`` block (typically ~12 months) since
+# ``SecFilingsProvider.list_filings`` does not currently walk
+# secondary submissions pages.
+_FILINGS_HISTORY_DAYS_DEFAULT = 730
+
+
+def filings_history_seed(params: Mapping[str, Any]) -> None:
+    """``_INVOKERS['filings_history_seed']`` — broad filings sweep.
+
+    Promoted from the deleted ``bootstrap_filings_history_seed``
+    bespoke wrapper (PR1c #1064). Walks each CIK-mapped tradable
+    instrument's submissions.json via ``refresh_filings`` with the
+    configured window and form-type allow-list, populating
+    ``filing_events`` for every form type. The typed-form parsers
+    later in the SEC lane (``sec_def14a_bootstrap``,
+    ``sec_business_summary_bootstrap``,
+    ``sec_insider_transactions_backfill``, etc.) read from
+    ``filing_events`` and would otherwise no-op on a fresh DB.
+
+    Honoured params:
+
+    * ``days_back`` (int) — historical window. Default 730.
+    * ``filing_types`` (multi_enum) — form-type allow-list. Default
+      ``sorted(SEC_INGEST_KEEP_FORMS)`` (the curated three-tier set).
+    * ``instrument_id`` (int) — narrow scope to a single instrument
+      (operator triage path). Default ``None`` = full
+      CIK-mapped-tradable universe.
+    """
+    from app.services.filings import SEC_INGEST_KEEP_FORMS
+
+    days_back = int(params.get("days_back", _FILINGS_HISTORY_DAYS_DEFAULT))
+    filing_types_param = params.get("filing_types") or sorted(SEC_INGEST_KEEP_FORMS)
+    filing_types = list(filing_types_param)
+    instrument_id_param = params.get("instrument_id")
+
+    with _tracked_job(JOB_FILINGS_HISTORY_SEED) as tracker:
+        with psycopg.connect(settings.database_url) as conn:
+            if instrument_id_param is not None:
+                # Operator-triage path: single instrument, validated
+                # CIK-mapped tradable. We resolve through the same
+                # filter as the bulk path so an instrument without an
+                # SEC primary CIK row is rejected rather than silently
+                # producing zero filings.
+                cik_rows = conn.execute(
+                    """
+                    SELECT i.symbol, i.instrument_id::text
+                      FROM external_identifiers ei
+                      JOIN instruments i ON i.instrument_id = ei.instrument_id
+                     WHERE ei.provider = 'sec'
+                       AND ei.identifier_type = 'cik'
+                       AND ei.is_primary = TRUE
+                       AND i.is_tradable = TRUE
+                       AND i.instrument_id = %(iid)s
+                    """,
+                    {"iid": int(instrument_id_param)},
+                ).fetchall()
+            else:
+                cik_rows = conn.execute(
+                    """
+                    SELECT i.symbol, i.instrument_id::text
+                      FROM external_identifiers ei
+                      JOIN instruments i ON i.instrument_id = ei.instrument_id
+                     WHERE ei.provider = 'sec'
+                       AND ei.identifier_type = 'cik'
+                       AND ei.is_primary = TRUE
+                       AND i.is_tradable = TRUE
+                    """
+                ).fetchall()
+
+        if not cik_rows:
+            logger.info("filings_history_seed: no CIK-mapped instruments; ensure daily_cik_refresh ran first")
+            tracker.row_count = 0
+            return
+
+        instrument_ids = [row[1] for row in cik_rows]
+        from_date = date.today() - timedelta(days=days_back)
+        to_date = date.today()
+
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            summary = refresh_filings(
+                provider=sec,
+                provider_name="sec",
+                identifier_type="cik",
+                conn=conn,
+                instrument_ids=instrument_ids,
+                start_date=from_date,
+                end_date=to_date,
+                filing_types=filing_types,
+            )
+        tracker.row_count = summary.filings_upserted
+        logger.info(
+            "filings_history_seed: instruments=%d filings_upserted=%d skipped=%d days_back=%d",
+            summary.instruments_attempted,
+            summary.filings_upserted,
+            summary.instruments_skipped,
+            days_back,
+        )
+
+
+def sec_first_install_drain(params: Mapping[str, Any]) -> None:
+    """``_INVOKERS['sec_first_install_drain']`` — drain the SEC
+    submissions.json manifest backlog for first-install bootstrap.
+
+    Promoted from the deleted ``sec_first_install_drain_job`` bespoke
+    wrapper (PR1c #1064). The underlying ``run_first_install_drain``
+    takes an ``http_get`` callable that the wrapper adapts from the
+    SecFilingsProvider's ResilientClient (``HttpGet = Callable[[str,
+    dict[str, str]], tuple[int, bytes]]``).
+
+    Honoured params:
+
+    * ``max_subjects`` (int) — cap the number of CIKs processed.
+      Default ``None`` = full universe. Operator-triage path for
+      "iterate just N more CIKs from the queue head".
+
+    Internal-only invariants (NOT operator-exposed per audit §6):
+    ``follow_pagination=True`` (we want all pages), ``use_bulk_zip=False``
+    (slow-connection fallback bypassed Phase A3).
+    """
+    from app.jobs.sec_first_install_drain import run_first_install_drain
+
+    max_subjects_param = params.get("max_subjects")
+    max_subjects = int(max_subjects_param) if max_subjects_param is not None else None
+
+    with _tracked_job(JOB_SEC_FIRST_INSTALL_DRAIN) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            stats = run_first_install_drain(
+                conn,
+                http_get=_make_sec_http_get(sec),  # type: ignore[arg-type]
+                follow_pagination=True,
+                use_bulk_zip=False,
+                max_subjects=max_subjects,
+            )
+        tracker.row_count = stats.manifest_rows_upserted
+        logger.info(
+            "sec_first_install_drain: ciks_processed=%d skipped=%d manifest_rows=%d errors=%d max_subjects=%s",
+            stats.ciks_processed,
+            stats.ciks_skipped,
+            stats.manifest_rows_upserted,
+            stats.errors,
+            max_subjects,
+        )
+
+
+def _make_sec_http_get(sec_provider: object) -> Callable[[str, dict[str, str]], tuple[int, bytes]]:
+    """Adapt ``SecFilingsProvider._http`` (a ``ResilientClient``) into
+    the ``HttpGet`` callable shape the drain / poll / rebuild call
+    sites consume (see ``app/providers/implementations/sec_submissions.py``).
+
+    Lifted from the deleted ``sec_first_install_drain_job`` wrapper
+    (PR1c #1064). The closure routes through the rate-limited shared
+    client so SEC's 10 req/s bucket is honoured.
+    """
+
+    def _impl(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+        response = sec_provider._http.get(url, headers=headers)  # type: ignore[attr-defined]
+        return response.status_code, response.content
+
+    return _impl
 
 
 def sec_13f_filer_directory_sync() -> None:

--- a/docs/wiki/job-registry-audit.md
+++ b/docs/wiki/job-registry-audit.md
@@ -275,14 +275,14 @@ These follow the same archetype: zero-arg body → calls `ingest_<thing>(conn, p
 | 11 | `sec_insider_ingest_from_dataset` | db | `sec_insider_ingest_from_dataset` | (sec_bulk_download, cik_refresh) | ✗ (bootstrap only) |
 | 12 | `sec_nport_ingest_from_dataset` | db | `sec_nport_ingest_from_dataset` | (sec_bulk_download, cusip_universe_backfill) | ✗ (bootstrap only) |
 | 13 | `sec_submissions_files_walk` | sec_rate | `sec_submissions_files_walk` | (sec_submissions_ingest) | ✗ (bootstrap only) |
-| 14 | `filings_history_seed` | sec_rate | `bootstrap_filings_history_seed` ← **bespoke wrapper** | (cik_refresh) | ✗ |
-| 15 | `sec_first_install_drain` | sec_rate | `sec_first_install_drain` ← **bespoke wrapper** | (cik_refresh) | ✗ |
+| 14 | `filings_history_seed` | sec_rate | `filings_history_seed` (PR1c #1064 — promoted from `bootstrap_filings_history_seed`) | (cik_refresh) | ✗ |
+| 15 | `sec_first_install_drain` | sec_rate | `sec_first_install_drain` (PR1c #1064 — promoted from `sec_first_install_drain_job`) | (cik_refresh) | ✗ |
 | 16 | `sec_def14a_bootstrap` | sec_rate | `sec_def14a_bootstrap` | (sec_submissions_ingest, sec_submissions_files_walk) | ✓ |
 | 17 | `sec_business_summary_bootstrap` | sec_rate | `sec_business_summary_bootstrap` | (sec_submissions_ingest, sec_submissions_files_walk) | ✓ |
 | 18 | `sec_insider_transactions_backfill` | sec_rate | `sec_insider_transactions_backfill` | (cik_refresh) | ✓ |
 | 19 | `sec_form3_ingest` | sec_rate | `sec_form3_ingest` | (cik_refresh) | ✓ |
 | 20 | `sec_8k_events_ingest` | sec_rate | `sec_8k_events_ingest` | (sec_submissions_ingest, sec_submissions_files_walk) | ✓ |
-| 21 | `sec_13f_recent_sweep` | sec_rate | `bootstrap_sec_13f_recent_sweep` ← **bespoke wrapper** | (cik_refresh) | ✗ |
+| 21 | `sec_13f_recent_sweep` | sec_rate | `sec_13f_quarterly_sweep` (PR1c #1064 — folded `bootstrap_sec_13f_recent_sweep` into the existing scheduled body via `min_period_of_report` + `source_label` params) | (cik_refresh) | ✓ |
 | 22 | `sec_n_port_ingest` | sec_rate | `sec_n_port_ingest` | (cik_refresh) | ✓ |
 | 23 | `ownership_observations_backfill` | db | `ownership_observations_backfill` | (5 bulk + legacy chain stages) | ✓ |
 | 24 | `fundamentals_sync` | db | `fundamentals_sync` | (sec_companyfacts_ingest) | ✓ |

--- a/docs/wiki/runbooks/runbook-first-install-bootstrap.md
+++ b/docs/wiki/runbooks/runbook-first-install-bootstrap.md
@@ -41,9 +41,12 @@ Phases in order; spec §"Stages and lanes" is the source of truth:
    - ``sec_13f_filer_directory_sync``
    - ``sec_nport_filer_directory_sync``
    - ``cik_refresh`` (``daily_cik_refresh``)
-   - ``filings_history_seed`` (``bootstrap_filings_history_seed`` —
-     2-year window, all form types)
-   - ``sec_first_install_drain`` (~60min for ~12k filers)
+   - ``filings_history_seed`` (PR1c #1064 — promoted from the bespoke
+     ``bootstrap_filings_history_seed`` wrapper; bootstrap stage 14
+     dispatches with ``params={days_back: 730, filing_types: <three-tier
+     allow-list>}``)
+   - ``sec_first_install_drain`` (~60min for ~12k filers; bootstrap
+     stage 15 dispatches with ``params={max_subjects: None}``)
    - ``sec_def14a_bootstrap`` / ``sec_business_summary_bootstrap`` /
      insider/Form 3/8-K typed parsers
    - ``sec_13f_quarterly_sweep`` / ``sec_n_port_ingest``

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -24,11 +24,9 @@ import psycopg
 import pytest
 
 from app.services.bootstrap_orchestrator import (
-    JOB_BOOTSTRAP_FILINGS_HISTORY_SEED,
     JOB_BOOTSTRAP_ORCHESTRATOR,
     JOB_DAILY_CIK_REFRESH,
     JOB_DAILY_FINANCIAL_FACTS,
-    JOB_SEC_FIRST_INSTALL_DRAIN,
     _run_one_stage,
     _should_run,
     get_bootstrap_stage_specs,
@@ -38,6 +36,10 @@ from app.services.bootstrap_state import (
     read_latest_run_with_stages,
     read_state,
     start_run,
+)
+from app.workers.scheduler import (
+    JOB_FILINGS_HISTORY_SEED,
+    JOB_SEC_FIRST_INSTALL_DRAIN,
 )
 
 
@@ -112,7 +114,9 @@ def test_stage_orders_are_unique_and_contiguous() -> None:
 def test_critical_constants_exposed() -> None:
     # Tests + frontend will import these; keep them stable.
     assert JOB_BOOTSTRAP_ORCHESTRATOR == "bootstrap_orchestrator"
-    assert JOB_BOOTSTRAP_FILINGS_HISTORY_SEED == "bootstrap_filings_history_seed"
+    # PR1c #1064 — bespoke wrapper job names retired; the promoted
+    # scheduler-side constants now own these strings.
+    assert JOB_FILINGS_HISTORY_SEED == "filings_history_seed"
     assert JOB_SEC_FIRST_INSTALL_DRAIN == "sec_first_install_drain"
     assert JOB_DAILY_CIK_REFRESH == "daily_cik_refresh"
     assert JOB_DAILY_FINANCIAL_FACTS == "daily_financial_facts"

--- a/tests/test_filings_form_allowlist.py
+++ b/tests/test_filings_form_allowlist.py
@@ -5,8 +5,9 @@ Spec: docs/superpowers/specs/2026-05-08-filing-allow-list-and-raw-retention.md.
 Pins the three-tier model: every form an active parser consumes
 must be in ``SEC_PARSE_AND_RAW``; future-signal forms in
 ``SEC_METADATA_ONLY``; the union ``SEC_INGEST_KEEP_FORMS`` is what
-``bootstrap_filings_history_seed`` and ``daily_research_refresh``
-pass to ``refresh_filings``.
+``filings_history_seed`` (PR1c #1064 — formerly the bespoke
+``bootstrap_filings_history_seed`` wrapper) and
+``daily_research_refresh`` pass to ``refresh_filings``.
 """
 
 from __future__ import annotations

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -67,13 +67,29 @@ class TestStageSpecParamsField:
         for stage in _BOOTSTRAP_STAGE_SPECS:
             assert hasattr(stage, "params"), f"stage {stage.stage_key} missing params"
 
-    def test_default_params_is_empty(self) -> None:
-        # PR1a leaves all stages with default empty params; PR1c will populate
-        # stages 14, 15, 21 with the bespoke wrapper overrides.
+    def test_only_bootstrap_lifted_stages_have_params(self) -> None:
+        """PR1c populated stages 14, 15, 21 (the bespoke-wrapper lift targets);
+        every other stage stays with the empty default until a future
+        ParamMetadata expansion lands."""
+        # PR1c #1064 — lifted bespoke wrappers. The job registry audit
+        # §4 enumerates these three; any addition must update the audit
+        # and this assertion in lockstep.
+        lifted_stage_keys = {
+            "filings_history_seed",
+            "sec_first_install_drain",
+            "sec_13f_recent_sweep",
+        }
         for stage in _BOOTSTRAP_STAGE_SPECS:
-            assert stage.params == {}, (
-                f"stage {stage.stage_key} has unexpected params {stage.params!r}; PR1a should leave all stages empty"
-            )
+            if stage.stage_key in lifted_stage_keys:
+                assert stage.params, (
+                    f"stage {stage.stage_key} should carry the bespoke-wrapper params dict; "
+                    "PR1c populated this stage to retire the duplicate wrapper body"
+                )
+            else:
+                assert stage.params == {}, (
+                    f"stage {stage.stage_key} has unexpected params {stage.params!r}; "
+                    "only PR1c-lifted stages should carry non-empty params"
+                )
 
 
 class TestSourceRegistry:

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -416,8 +416,11 @@ class TestProductionInvokerRegistry:
             # but registered in _INVOKERS so the orchestrator can call
             # them via JobLock + so admin Run-now still works:
             "bootstrap_orchestrator",
-            "bootstrap_filings_history_seed",
-            "bootstrap_sec_13f_recent_sweep",
+            # PR1c #1064 — promoted from bespoke wrappers:
+            #   bootstrap_filings_history_seed   → filings_history_seed
+            #   sec_first_install_drain_job      → sec_first_install_drain (same name)
+            #   bootstrap_sec_13f_recent_sweep   → folded into sec_13f_quarterly_sweep
+            "filings_history_seed",
             "sec_first_install_drain",
             # #994 also un-retired these for bootstrap dispatch. They
             # are NOT in SCHEDULED_JOBS — daily_cik_refresh and

--- a/tests/test_pr1c_wrapper_lift.py
+++ b/tests/test_pr1c_wrapper_lift.py
@@ -1,0 +1,214 @@
+"""PR1c (#1064) — bespoke wrapper deletion + StageSpec.params extraction-equivalence.
+
+Three behaviour groups:
+
+1. **Deletion** — the three deleted symbols are gone from
+   ``app.services.bootstrap_orchestrator``.
+2. **StageSpec.params** — bootstrap stages 14, 15, 21 carry the
+   exact params dict the deleted wrappers used to hardcode in their
+   bodies. ``_resolve_dynamic_params`` materialises the dispatch-time
+   13F cutoff sentinel.
+3. **Promoted invoker contract** — ``filings_history_seed``,
+   ``sec_first_install_drain``, ``sec_13f_quarterly_sweep`` accept the
+   widened ``Mapping[str, Any]`` and honour the operator-tunable
+   keys.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+import pytest
+
+from app.services.bootstrap_orchestrator import (
+    _BOOTSTRAP_13F_RECENCY_DAYS,
+    _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF,
+    _resolve_dynamic_params,
+    get_bootstrap_stage_specs,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Deletion regression — wrappers + JOB_BOOTSTRAP_* constants gone.
+# ---------------------------------------------------------------------------
+
+
+class TestWrapperDeletion:
+    """Three wrappers + their JOB_* constants must not be importable."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "bootstrap_filings_history_seed",
+            "sec_first_install_drain_job",
+            "bootstrap_sec_13f_recent_sweep_job",
+            "JOB_BOOTSTRAP_FILINGS_HISTORY_SEED",
+            "JOB_BOOTSTRAP_SEC_13F_RECENT_SWEEP",
+        ],
+    )
+    def test_deleted_symbol_is_gone(self, name: str) -> None:
+        import app.services.bootstrap_orchestrator as orch
+
+        assert not hasattr(orch, name), (
+            f"PR1c (#1064) deleted {name!r}; reintroducing it would silently "
+            "re-create the bespoke-wrapper duplication path."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. StageSpec.params — bootstrap stage 14 / 15 / 21 carry the right dicts.
+# ---------------------------------------------------------------------------
+
+
+class TestStageSpecParams:
+    """Stages 14, 15, 21 populate the params dict the deleted wrappers hardcoded."""
+
+    def _spec_by_key(self, key: str) -> Any:
+        for spec in get_bootstrap_stage_specs():
+            if spec.stage_key == key:
+                return spec
+        raise AssertionError(f"unknown stage_key {key!r}")
+
+    def test_filings_history_seed_params_match_deleted_wrapper(self) -> None:
+        from app.services.filings import SEC_INGEST_KEEP_FORMS
+
+        spec = self._spec_by_key("filings_history_seed")
+        assert spec.job_name == "filings_history_seed"
+        assert spec.params["days_back"] == 730
+        # Bootstrap stage carries the canonical three-tier allow-list as
+        # an immutable tuple (frozen StageSpec compat).
+        assert tuple(spec.params["filing_types"]) == tuple(sorted(SEC_INGEST_KEEP_FORMS))
+
+    def test_sec_first_install_drain_params_match_deleted_wrapper(self) -> None:
+        spec = self._spec_by_key("sec_first_install_drain")
+        assert spec.job_name == "sec_first_install_drain"
+        # Wrapper hardcoded ``max_subjects=None`` (full universe).
+        assert spec.params == {"max_subjects": None}
+
+    def test_sec_13f_recent_sweep_params_match_deleted_wrapper(self) -> None:
+        spec = self._spec_by_key("sec_13f_recent_sweep")
+        # Stage 21 now dispatches the SCHEDULED ``sec_13f_quarterly_sweep`` body
+        # with bootstrap-only overrides; the previous bespoke job name is gone.
+        assert spec.job_name == "sec_13f_quarterly_sweep"
+        # ``source_label`` rides as audit-only via JOB_INTERNAL_KEYS (PR1a).
+        assert spec.params["source_label"] == "sec_edgar_13f_directory_bootstrap"
+        # ``min_period_of_report`` is the dispatch-time sentinel — module-load
+        # ``date.today()`` would freeze the cutoff in a long-lived process.
+        assert spec.params["min_period_of_report"] == _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF
+
+
+class TestResolveDynamicParams:
+    """``_resolve_dynamic_params`` materialises the dispatch-time 13F cutoff."""
+
+    def test_sentinel_resolves_to_today_minus_recency_days(self) -> None:
+        out = _resolve_dynamic_params(
+            {"min_period_of_report": _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF, "source_label": "x"}
+        )
+        assert out["min_period_of_report"] == date.today() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS)
+        # Pass-through of non-sentinel keys.
+        assert out["source_label"] == "x"
+
+    def test_concrete_date_passes_through(self) -> None:
+        fixed = date(2024, 1, 1)
+        out = _resolve_dynamic_params({"min_period_of_report": fixed})
+        assert out["min_period_of_report"] == fixed
+
+    def test_no_min_period_pass_through(self) -> None:
+        out = _resolve_dynamic_params({"days_back": 365})
+        assert out == {"days_back": 365}
+
+
+# ---------------------------------------------------------------------------
+# 3. Promoted invoker contract — params-aware bodies registered in _INVOKERS.
+# ---------------------------------------------------------------------------
+
+
+class TestPromotedInvokerRegistry:
+    """Registered invokers are the new params-aware bodies, not adapters."""
+
+    def test_filings_history_seed_registered_native(self) -> None:
+        from app.jobs.runtime import _INVOKERS
+        from app.workers import scheduler
+
+        assert _INVOKERS["filings_history_seed"] is scheduler.filings_history_seed
+
+    def test_sec_first_install_drain_registered_native(self) -> None:
+        from app.jobs.runtime import _INVOKERS
+        from app.workers import scheduler
+
+        assert _INVOKERS["sec_first_install_drain"] is scheduler.sec_first_install_drain
+
+    def test_sec_13f_quarterly_sweep_registered_native(self) -> None:
+        """Migrated to native JobInvoker; no ``_adapt_zero_arg`` wrap."""
+        from app.jobs.runtime import _INVOKERS
+        from app.workers import scheduler
+
+        assert _INVOKERS["sec_13f_quarterly_sweep"] is scheduler.sec_13f_quarterly_sweep
+
+
+class TestSec13fSweepHonoursParams:
+    """``sec_13f_quarterly_sweep`` body honours params dict — extraction equivalence."""
+
+    def test_default_params_use_canonical_source_label_and_no_cutoff(self) -> None:
+        """Empty params → standalone weekly sweep behaviour."""
+        from unittest.mock import MagicMock, patch
+
+        with (
+            patch("app.workers.scheduler._tracked_job") as mock_tracker,
+            patch("app.providers.implementations.sec_edgar.SecFilingsProvider"),
+            patch("app.workers.scheduler.psycopg.connect"),
+            patch("app.workers.scheduler.settings") as mock_settings,
+            patch("app.services.institutional_holdings.list_directory_filer_ciks", return_value=[]),
+            patch(
+                "app.services.institutional_holdings.ingest_all_active_filers",
+                return_value=[],
+            ) as mock_ingest,
+        ):
+            mock_tracker.return_value.__enter__.return_value = MagicMock()
+            mock_tracker.return_value.__exit__.return_value = False
+            mock_settings.sec_user_agent = "test-agent"
+            mock_settings.sec_13f_sweep_deadline_seconds = 3600
+            mock_settings.database_url = "postgresql://stub/stub"
+
+            from app.workers.scheduler import sec_13f_quarterly_sweep
+
+            sec_13f_quarterly_sweep({})
+
+        kwargs = mock_ingest.call_args.kwargs
+        assert kwargs["source_label"] == "sec_edgar_13f_directory"
+        assert kwargs["min_period_of_report"] is None
+
+    def test_bootstrap_params_override_source_label_and_set_cutoff(self) -> None:
+        """Bootstrap stage 21 dispatches with overrides → body honours both."""
+        from unittest.mock import MagicMock, patch
+
+        with (
+            patch("app.workers.scheduler._tracked_job") as mock_tracker,
+            patch("app.providers.implementations.sec_edgar.SecFilingsProvider"),
+            patch("app.workers.scheduler.psycopg.connect"),
+            patch("app.workers.scheduler.settings") as mock_settings,
+            patch("app.services.institutional_holdings.list_directory_filer_ciks", return_value=[]),
+            patch(
+                "app.services.institutional_holdings.ingest_all_active_filers",
+                return_value=[],
+            ) as mock_ingest,
+        ):
+            mock_tracker.return_value.__enter__.return_value = MagicMock()
+            mock_tracker.return_value.__exit__.return_value = False
+            mock_settings.sec_user_agent = "test-agent"
+            mock_settings.sec_13f_sweep_deadline_seconds = 3600
+            mock_settings.database_url = "postgresql://stub/stub"
+
+            cutoff = date(2025, 1, 1)
+            from app.workers.scheduler import sec_13f_quarterly_sweep
+
+            sec_13f_quarterly_sweep(
+                {
+                    "min_period_of_report": cutoff,
+                    "source_label": "sec_edgar_13f_directory_bootstrap",
+                }
+            )
+
+        kwargs = mock_ingest.call_args.kwargs
+        assert kwargs["source_label"] == "sec_edgar_13f_directory_bootstrap"
+        assert kwargs["min_period_of_report"] == cutoff


### PR DESCRIPTION
## What
- Deleted 3 bespoke wrappers from [bootstrap_orchestrator.py](app/services/bootstrap_orchestrator.py): `bootstrap_filings_history_seed`, `sec_first_install_drain_job`, `bootstrap_sec_13f_recent_sweep_job` + `JOB_BOOTSTRAP_*` constants.
- Promoted bodies into [scheduler.py](app/workers/scheduler.py) as native params-aware `JobInvoker`: `filings_history_seed` (`days_back`/`filing_types`/`instrument_id`), `sec_first_install_drain` (`max_subjects`), extended `sec_13f_quarterly_sweep` (`min_period_of_report` operator-exposed; `source_label` internal-only).
- Bootstrap stages 14/15/21 dispatch via `StageSpec.params` — wrapper hardcoded values now ride as data. Stage 21 uses `_PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF` sentinel resolved at dispatch time so a long-lived jobs process never freezes the cutoff.
- Bootstrap dispatcher validates each stage's params via `validate_job_params(allow_internal_keys=True)` then plumbs the validated dict into `_params_snapshot_var` so `job_runs.params_snapshot` reflects real overrides.
- `_jsonable_params` helper (`ops_monitor.py`) materialises `date`/`datetime` as ISO strings before `Jsonb(...)` — fixes the `json.dumps` `TypeError` Codex pre-push round 2 caught.
- `_LANE_MAX_CONCURRENCY[db]=1` retired the parallel-DB-stage claim from #1020; source-keyed `JobLock` (PR1a) already serialises within a lane.

## Why
Three bespoke wrappers each duplicated the parameter-overrides pattern at the named-callable layer. The widened `JobInvoker` contract from PR1b-2 made it possible to lift them into a single body each that bootstrap dispatch + operator manual-trigger share.

## Test plan
- [x] `tests/test_pr1c_wrapper_lift.py` — wrapper deletion regression, StageSpec.params extraction-equivalence (14/15/21 vs deleted wrapper hardcodes), `_resolve_dynamic_params` semantics, promoted invoker registry (no `_adapt_zero_arg`), `sec_13f_quarterly_sweep` body honours params.
- [x] `tests/test_job_registry.py::TestStageSpecParamsField` — only the 3 lifted stages carry non-empty params.
- [x] `tests/test_bootstrap_orchestrator.py` — JOB_* import rewires.
- [x] `tests/test_jobs_runtime.py` — _INVOKERS coverage updated.
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright` — clean.
- [x] Codex pre-push (checkpoint 2) — 3 rounds, final clean.
  - Round 1: BLOCKING — `validate_job_params` would reject bootstrap-only keys; fixed via `JOB_INTERNAL_KEYS` extension. WARNING — `_params_snapshot_var` not set in bootstrap dispatch; fixed.
  - Round 2: BLOCKING — `date` in `params_snapshot` breaks Jsonb; fixed via `_jsonable_params`.
  - Round 3: clean.

## Tech debt
- First-install bootstrap wall-clock regresses from "5 db stages parallel" → "1 db stage at a time" (the `_LANE_MAX_CONCURRENCY[db]=1` retirement). Measure on dev DB and file follow-up if operator-visible.
- `filings_history_seed` + `sec_first_install_drain` operator-tunability is bypassed for now (jobs in `_INVOKERS` only, manual-trigger uses `JOB_INTERNAL_KEYS` allow-list). Future PR promotes them to `SCHEDULED_JOBS` with proper `ParamMetadata`.

Refs #1064.

🤖 Generated with [Claude Code](https://claude.com/claude-code)