### PR TITLE
feat(#1064): PR2 — FE Advanced disclosure renderer + JSON-safe params

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -49,6 +49,7 @@ from pydantic import BaseModel
 from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.jobs.runtime import VALID_JOB_NAMES
+from app.services.processes.json_safe import to_jsonsafe_params
 from app.services.processes.param_metadata import (
     ParamValidationError,
     validate_job_params,
@@ -237,8 +238,13 @@ async def run_job(
     if effective_override:
         canonical_control["override_bootstrap_gate"] = True
 
+    # ``validate_job_params`` returns native ``date`` / ``datetime`` for the
+    # corresponding ``field_type``; ``Jsonb`` will raise ``TypeError`` at
+    # adapt time without JSON-safe coercion. The listener re-validates after
+    # dequeue (``app/jobs/listener.py:157``) so writing ISO strings here
+    # round-trips back to native types for the invoker. PR2 #1064.
     payload: dict[str, Any] = {
-        "params": validated_params,
+        "params": to_jsonsafe_params(validated_params),
         "control": canonical_control,
     }
 

--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -30,7 +30,7 @@ import psycopg
 import psycopg.errors
 import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.api.auth import require_session_or_service_token
 from app.db import get_conn
@@ -74,6 +74,7 @@ from app.services.processes import (
     scheduled_adapter,
 )
 from app.services.processes.ingest_sweep_adapter import is_sweep
+from app.services.processes.param_metadata import ParamMetadata
 from app.services.processes.watermarks import (
     acquire_shared_source_locks,
     atom_etag_target_for,
@@ -163,6 +164,13 @@ class ProcessRowResponse(BaseModel):
     can_cancel: bool
     last_n_errors: list[ErrorClassSummaryResponse]
     stale_reasons: list[StaleReason]
+    # PR2 #1064 — operator-exposable params for the Advanced disclosure
+    # tab on /admin/processes/{id}. Empty list for bootstrap +
+    # ingest_sweep mechanisms; non-empty only for scheduled jobs that
+    # declare ``ScheduledJob.params_metadata``. The FE renders one
+    # form field per entry. ``Field(default_factory=list)`` keeps the
+    # default per-instance, not a shared mutable.
+    params_metadata: list[ParamMetadata] = Field(default_factory=list)
 
 
 class ProcessListResponse(BaseModel):
@@ -372,6 +380,7 @@ def _convert_row(row: ProcessRow) -> ProcessRowResponse:
         can_cancel=row.can_cancel,
         last_n_errors=[_convert_error(e) for e in row.last_n_errors],
         stale_reasons=list(row.stale_reasons),
+        params_metadata=list(row.params_metadata),
     )
 
 

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -576,13 +576,15 @@ def _run_prelude(
                 # branches (running + skipped). Passing ``None`` falls back
                 # to the column default ``'{}'`` so the legacy paths stay
                 # forward-compatible. Jsonb wraps the dict for psycopg's
-                # JSONB adapter; ``_jsonable_params`` materialises ``date``
+                # JSONB adapter; ``to_jsonsafe_params`` materialises ``date``
                 # values as ISO strings (PR1c #1064 — stage 21 + manual
                 # ``sec_13f_quarterly_sweep`` carry a ``min_period_of_report``
                 # ``date`` that ``json.dumps`` cannot serialize natively).
-                from app.services.ops_monitor import _jsonable_params
+                from app.services.processes.json_safe import to_jsonsafe_params
 
-                snapshot_json = Jsonb(_jsonable_params(dict(params_snapshot))) if params_snapshot is not None else None
+                snapshot_json = (
+                    Jsonb(to_jsonsafe_params(dict(params_snapshot))) if params_snapshot is not None else None
+                )
                 if fence_held:
                     # When a sibling holds the fence, surface the holder
                     # in the audit row so the operator can see WHY this

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -34,39 +34,14 @@ import psycopg
 import psycopg.rows
 from psycopg.types.json import Jsonb
 
+# Back-compat re-export. Canonical home is
+# ``app.services.processes.json_safe.to_jsonsafe_params`` (#1064 PR2).
+# ``_jsonable_params`` is the legacy name used by ``app/jobs/runtime.py``
+# and the two call sites in this module — kept as an alias so internal
+# rewires can land in PR2 without touching every caller. New code MUST
+# import ``to_jsonsafe_params`` directly.
+from app.services.processes.json_safe import to_jsonsafe_params as _jsonable_params
 from app.services.runtime_config import write_kill_switch_audit
-
-
-def _jsonable_params(params: dict[str, Any]) -> dict[str, Any]:
-    """Convert non-JSON-native values in a params dict to JSON-safe scalars.
-
-    Codex pre-push round 2 BLOCKING (#1064 PR1c): ``date`` values
-    cannot pass through ``json.dumps`` without a default coercer, so
-    a ``date`` in ``params_snapshot`` would raise ``TypeError`` inside
-    ``psycopg.types.json.Jsonb``. The promoted
-    ``sec_13f_quarterly_sweep`` body and bootstrap stage 21 both pass
-    a ``min_period_of_report`` date; this helper materialises dates +
-    datetimes as ISO-8601 strings so the JSONB column sees a stable
-    text representation. Operator queries that read
-    ``params_snapshot->>'min_period_of_report'`` get the same string
-    shape regardless of who triggered the run.
-    """
-    from datetime import date as _date
-    from datetime import datetime as _datetime
-
-    result: dict[str, Any] = {}
-    for key, value in params.items():
-        if isinstance(value, _datetime):
-            result[key] = value.isoformat()
-        elif isinstance(value, _date):
-            result[key] = value.isoformat()
-        elif isinstance(value, (list, tuple)):
-            # Preserve list/tuple semantics for multi_enum (filing_types, etc).
-            result[key] = list(value)
-        else:
-            result[key] = value
-    return result
-
 
 if TYPE_CHECKING:
     # layer_types sits at the bottom of the orchestrator import graph, but

--- a/app/services/processes/__init__.py
+++ b/app/services/processes/__init__.py
@@ -18,10 +18,12 @@ no async — because adapter callers serialise straight to JSON for the
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal
 from uuid import UUID
+
+from app.services.processes.param_metadata import ParamMetadata
 
 ProcessLane = Literal[
     "setup",
@@ -183,6 +185,12 @@ class ProcessRow:
     can_cancel: bool
     last_n_errors: tuple[ErrorClassSummary, ...]
     stale_reasons: tuple[StaleReason, ...]
+    # PR2 #1064 — operator-exposable params for the Advanced disclosure
+    # tab on the drill-in. Bootstrap + ingest_sweep adapters keep the
+    # default empty tuple; scheduled_adapter populates from the
+    # underlying ``ScheduledJob.params_metadata`` so the FE knows
+    # which form fields to render.
+    params_metadata: tuple[ParamMetadata, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/services/processes/json_safe.py
+++ b/app/services/processes/json_safe.py
@@ -1,0 +1,56 @@
+"""JSON-safe coercion for params dicts before ``Jsonb`` publish.
+
+Issue #1064 PR2 — admin control hub Advanced disclosure renderer.
+
+``validate_job_params`` returns native Python types: ``date`` for
+``field_type='date'``, ``datetime`` for ``field_type='datetime'``,
+``int``/``float``/``str`` for the scalar types, ``list``/``tuple``
+for ``multi_enum``. ``psycopg.types.json.Jsonb`` then serialises with
+the stdlib ``json.dumps`` which has no default coercer for ``date``
+and raises ``TypeError`` at adapt time.
+
+Two call sites need the coercion:
+
+* ``app/api/jobs.py::run_job`` — ``pending_job_requests.payload`` write.
+  Pre-PR2 this path latently crashed when an operator submitted a
+  ``date``-typed param; no test exercised it because no FE rendered
+  the field.
+* ``app/jobs/runtime.py::_run_prelude`` — ``job_runs.params_snapshot``
+  write. Already uses ``_jsonable_params`` from ``ops_monitor.py``
+  (PR1c). PR2 lifts it here for shared ownership.
+
+Listener re-validates after dequeue (``app/jobs/listener.py:157``),
+so ISO-string-on-publish round-trips back to native ``date`` for the
+invoker.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any
+
+
+def to_jsonsafe_params(params: Mapping[str, Any]) -> dict[str, Any]:
+    """Coerce native Python types in a params dict to JSON-safe scalars.
+
+    ``date`` / ``datetime`` → ISO-8601 string. ``list``/``tuple`` →
+    list (preserves multi_enum semantics). All other values pass
+    through unchanged — anything that survived ``validate_job_params``
+    is already JSON-native (``str``, ``int``, ``float``, ``bool``,
+    ``list[str]``).
+    """
+    result: dict[str, Any] = {}
+    for key, value in params.items():
+        if isinstance(value, datetime):
+            result[key] = value.isoformat()
+        elif isinstance(value, date):
+            result[key] = value.isoformat()
+        elif isinstance(value, (list, tuple)):
+            result[key] = list(value)
+        else:
+            result[key] = value
+    return result
+
+
+__all__ = ["to_jsonsafe_params"]

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -688,6 +688,11 @@ def _build_row(
         can_cancel=can_cancel,
         last_n_errors=last_n_errors,
         stale_reasons=stale_reasons,
+        # PR2 #1064 — surface ``ScheduledJob.params_metadata`` so the FE
+        # Advanced disclosure renders one form field per declared param.
+        # Empty tuple for jobs with no operator-exposable params (the
+        # default — every entry except ``sec_13f_quarterly_sweep`` today).
+        params_metadata=job.params_metadata,
     )
 
 

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,69 @@
+/**
+ * apiFetch — 202 body handling (#1064 PR2).
+ *
+ * Pre-PR2 the wrapper short-circuited every 202 to ``undefined``; the
+ * comment claimed empty body for all 202 callers. PR1b-2 made
+ * ``POST /jobs/{name}/run`` return ``{request_id: N}`` on 202 so the
+ * Advanced disclosure (PR2) can pivot the operator to the queue row.
+ * This test pins the new contract: read JSON when present, fall back
+ * to ``undefined`` on empty body / unparseable text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { apiFetch } from "@/api/client";
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function emptyResponse(status: number): Response {
+  return new Response(null, { status });
+}
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("apiFetch — 202 body handling", () => {
+  it("parses JSON body on 202 when present", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      jsonResponse(202, { request_id: 42 }),
+    );
+    const result = await apiFetch<{ request_id: number }>("/jobs/x/run", {
+      method: "POST",
+    });
+    expect(result).toEqual({ request_id: 42 });
+  });
+
+  it("returns undefined on 202 with empty body (legacy contract)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(emptyResponse(202));
+    const result = await apiFetch<undefined>("/legacy/202", { method: "POST" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined on 202 when body is non-JSON text", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response("plain text", { status: 202 }),
+    );
+    const result = await apiFetch<undefined>("/legacy/202", { method: "POST" });
+    expect(result).toBeUndefined();
+  });
+
+  it("204 still returns undefined unconditionally", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(emptyResponse(204));
+    const result = await apiFetch<undefined>("/auth/logout", {
+      method: "POST",
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -85,11 +85,26 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     }
     throw new ApiError(res.status, message, detailRaw);
   }
-  // 202 Accepted (e.g. POST /jobs/{name}/run) and 204 No Content
-  // (e.g. /auth/logout) both have empty bodies in this codebase.
-  // Calling res.json() on either would throw "Unexpected end of
-  // JSON input"; the contract for both endpoints is "no body, the
-  // status code is the response".
-  if (res.status === 202 || res.status === 204) return undefined as T;
+  // 204 No Content always has an empty body — auth logout, cancel
+  // dispatcher rows, etc. Calling res.json() on it throws "Unexpected
+  // end of JSON input".
+  if (res.status === 204) return undefined as T;
+  // 202 Accepted is split: PR1b-2 #1064 made POST /jobs/{name}/run
+  // return JobRunQueuedResponse ({"request_id": N}) on 202 so the FE
+  // Advanced disclosure (PR2) can pivot the operator to the queue
+  // row. Other 202 callers may still send an empty body. Read the
+  // response as text once, parse JSON only when non-empty, and fall
+  // back to undefined on either an empty body or invalid JSON. This
+  // preserves the pre-PR2 contract for callers that expected
+  // undefined while unlocking the body for new endpoints.
+  if (res.status === 202) {
+    const text = await res.text();
+    if (!text) return undefined as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return undefined as T;
+    }
+  }
   return (await res.json()) as T;
 }

--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -8,9 +8,12 @@
  *     imports from one module.
  *   - fetchJobRuns(jobName?, limit?) — recent rows from job_runs,
  *     newest-first; backs the admin page recent-runs panel.
- *   - runJob(jobName) — POST /jobs/{name}/run. Returns void on 202;
- *     ApiError on 404 (unknown job) or 409 (already running). Other
- *     statuses bubble up unchanged.
+ *   - runJob(jobName, body?) — POST /jobs/{name}/run. Returns
+ *     {request_id} on 202 (PR1b-2 #1064 added the body); ApiError on
+ *     404 (unknown job) or 400 (invalid params / control). Other
+ *     statuses bubble up unchanged. PR2 #1064 widens to accept the
+ *     {params, control} envelope so the Advanced disclosure form can
+ *     submit operator-supplied params.
  */
 
 import { apiFetch } from "@/api/client";
@@ -34,11 +37,32 @@ export function fetchJobRuns(
   return apiFetch<JobRunsListResponse>(`/jobs/runs?${params.toString()}`);
 }
 
-export function runJob(jobName: string): Promise<void> {
-  // The 202 path returns no body; apiFetch short-circuits at the
-  // status check (see client.ts). 404 / 409 surface as ApiError so
-  // the page can render a status-specific message.
-  return apiFetch<void>(`/jobs/${encodeURIComponent(jobName)}/run`, {
-    method: "POST",
-  });
+export interface RunJobBody {
+  params?: Record<string, unknown>;
+  control?: { override_bootstrap_gate?: boolean };
+}
+
+export interface RunJobQueuedResponse {
+  request_id: number;
+}
+
+export function runJob(
+  jobName: string,
+  body?: RunJobBody,
+): Promise<RunJobQueuedResponse | undefined> {
+  // PR1b-2 #1064 made the 202 body carry {request_id} so the operator
+  // can pivot to the queue row. apiFetch reads JSON when present and
+  // falls back to undefined on empty body — defensive on the
+  // never-supposed-to-fire case where BE drops the body.
+  //
+  // Zero-arg calls preserve the pre-PR2 shape: no body sent, BE
+  // _safe_read_json_body returns {} which legacy-flat-dict-normalises
+  // to {params: {}, control: {}}.
+  return apiFetch<RunJobQueuedResponse | undefined>(
+    `/jobs/${encodeURIComponent(jobName)}/run`,
+    {
+      method: "POST",
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    },
+  );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1245,6 +1245,11 @@ export interface ProcessRowResponse {
   can_cancel: boolean;
   last_n_errors: ErrorClassSummaryResponse[];
   stale_reasons: StaleReason[];
+  // PR2 #1064 — operator-exposable params for the drill-in Advanced
+  // disclosure. Empty list for bootstrap + ingest_sweep mechanisms.
+  // Non-empty only for scheduled jobs that declare
+  // ``ScheduledJob.params_metadata`` (e.g. sec_13f_quarterly_sweep).
+  params_metadata: ParamMetadata[];
 }
 
 export interface ProcessListResponse {

--- a/frontend/src/components/admin/AdvancedParamsForm.test.tsx
+++ b/frontend/src/components/admin/AdvancedParamsForm.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * AdvancedParamsForm — render + submit per ParamFieldType (#1064 PR2).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ParamMetadata } from "@/api/types";
+import { AdvancedParamsForm } from "@/components/admin/AdvancedParamsForm";
+
+function meta(overrides: Partial<ParamMetadata>): ParamMetadata {
+  return {
+    name: overrides.name ?? "f",
+    label: overrides.label ?? "Field",
+    help_text: overrides.help_text ?? "",
+    field_type: overrides.field_type ?? "string",
+    default: overrides.default ?? null,
+    advanced_group: overrides.advanced_group ?? true,
+    enum_values: overrides.enum_values ?? null,
+    min_value: overrides.min_value ?? null,
+    max_value: overrides.max_value ?? null,
+  };
+}
+
+function renderForm(metadata: ParamMetadata[]) {
+  const onSubmit = vi.fn().mockResolvedValue(undefined);
+  render(
+    <AdvancedParamsForm metadata={metadata} busy={false} onSubmit={onSubmit} />,
+  );
+  return { onSubmit };
+}
+
+describe("AdvancedParamsForm", () => {
+  it("renders empty-state when metadata is empty", () => {
+    render(
+      <AdvancedParamsForm metadata={[]} busy={false} onSubmit={vi.fn()} />,
+    );
+    expect(
+      screen.getByText(/declares no operator-exposable params/i),
+    ).toBeTruthy();
+  });
+
+  it("string: text input + submits string value", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "label", field_type: "string", label: "Label" }),
+    ]);
+    const input = screen.getByLabelText("Label") as HTMLInputElement;
+    expect(input.type).toBe("text");
+    fireEvent.change(input, { target: { value: "hello" } });
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ label: "hello" });
+  });
+
+  it("int: number input + submits Number value", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "n", field_type: "int", label: "N" }),
+    ]);
+    const input = screen.getByLabelText("N") as HTMLInputElement;
+    expect(input.type).toBe("number");
+    expect(input.step).toBe("1");
+    fireEvent.change(input, { target: { value: "42" } });
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ n: 42 });
+  });
+
+  it("float: step=any + submits float", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "x", field_type: "float", label: "X" }),
+    ]);
+    const input = screen.getByLabelText("X") as HTMLInputElement;
+    expect(input.step).toBe("any");
+    fireEvent.change(input, { target: { value: "3.14" } });
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ x: 3.14 });
+  });
+
+  it("date: date input + submits ISO string", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "d", field_type: "date", label: "D" }),
+    ]);
+    const input = screen.getByLabelText("D") as HTMLInputElement;
+    expect(input.type).toBe("date");
+    fireEvent.change(input, { target: { value: "2024-01-01" } });
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ d: "2024-01-01" });
+  });
+
+  it("quarter: text input with pattern + submits string", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "q", field_type: "quarter", label: "Q" }),
+    ]);
+    const input = screen.getByLabelText("Q") as HTMLInputElement;
+    expect(input.pattern).toBe("\\d{4}Q[1-4]");
+    fireEvent.change(input, { target: { value: "2026Q1" } });
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ q: "2026Q1" });
+  });
+
+  it("ticker: number input + submits Number (BE coerces to instrument_id)", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "t", field_type: "ticker", label: "T" }),
+    ]);
+    const input = screen.getByLabelText("T") as HTMLInputElement;
+    expect(input.type).toBe("number");
+    fireEvent.change(input, { target: { value: "12345" } });
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ t: 12345 });
+  });
+
+  it("cik: text input + lets BE pad", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "c", field_type: "cik", label: "C" }),
+    ]);
+    const input = screen.getByLabelText("C") as HTMLInputElement;
+    expect(input.type).toBe("text");
+    expect(input.inputMode).toBe("numeric");
+    fireEvent.change(input, { target: { value: "320193" } });
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    // FE submits raw digits; BE _coerce_value zfill(10) at validation.
+    expect(onSubmit).toHaveBeenCalledWith({ c: "320193" });
+  });
+
+  it("bool: checkbox always submits even when unchecked", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "b", field_type: "bool", label: "B", default: false }),
+    ]);
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ b: false });
+  });
+
+  it("bool: checked submits true", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "b", field_type: "bool", label: "B", default: false }),
+    ]);
+    fireEvent.click(screen.getByLabelText("B"));
+    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ b: true });
+  });
+
+  it("enum: select restricted to enum_values", async () => {
+    const { onSubmit } = renderForm([
+      meta({
+        name: "e",
+        field_type: "enum",
+        label: "E",
+        enum_values: ["a", "b", "c"],
+      }),
+    ]);
+    const select = screen.getByLabelText("E") as HTMLSelectElement;
+    expect(select.tagName).toBe("SELECT");
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      "",
+      "a",
+      "b",
+      "c",
+    ]);
+    fireEvent.change(select, { target: { value: "b" } });
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ e: "b" });
+  });
+
+  it("multi_enum: checkbox list submits string[]", async () => {
+    const { onSubmit } = renderForm([
+      meta({
+        name: "m",
+        field_type: "multi_enum",
+        label: "M",
+        enum_values: ["x", "y", "z"],
+      }),
+    ]);
+    fireEvent.click(screen.getByLabelText("x"));
+    fireEvent.click(screen.getByLabelText("z"));
+    fireEvent.click(screen.getByRole("button"));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ m: ["x", "z"] });
+  });
+
+  it("empty optional string fields are omitted from submit", async () => {
+    const { onSubmit } = renderForm([
+      meta({ name: "left_blank", field_type: "string", label: "Blank" }),
+      meta({ name: "filled", field_type: "string", label: "Filled" }),
+    ]);
+    fireEvent.change(screen.getByLabelText("Filled"), {
+      target: { value: "x" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({ filled: "x" });
+  });
+
+  it("empty number input is omitted from submit (HTML5 filters non-numeric)", async () => {
+    // HTML5 number inputs reject non-numeric keystrokes at the
+    // browser layer — the form state stays at the initial empty
+    // string. isLocalEmpty drops empty strings from the submit
+    // payload, so the BE never sees a NaN/Infinity for these fields.
+    // The defensive Number.isFinite guard inside coerceForSubmit is
+    // belt-and-braces for programmatic values that bypass the input.
+    const { onSubmit } = renderForm([
+      meta({ name: "n", field_type: "int", label: "N" }),
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith({});
+  });
+
+  it("enum with missing enum_values falls back to text input + warns", () => {
+    const warn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    render(
+      <AdvancedParamsForm
+        metadata={[
+          meta({
+            name: "broken",
+            field_type: "enum",
+            label: "Broken",
+            enum_values: null,
+          }),
+        ]}
+        busy={false}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const fallback = screen.getByLabelText("Broken") as HTMLInputElement;
+    expect(fallback.type).toBe("text");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("disables submit button when busy", () => {
+    render(
+      <AdvancedParamsForm
+        metadata={[meta({ name: "f", field_type: "string", label: "F" })]}
+        busy={true}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /run/i }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("seeds string input with default value when provided", () => {
+    render(
+      <AdvancedParamsForm
+        metadata={[
+          meta({
+            name: "f",
+            field_type: "string",
+            label: "F",
+            default: "seed",
+          }),
+        ]}
+        busy={false}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect((screen.getByLabelText("F") as HTMLInputElement).value).toBe(
+      "seed",
+    );
+  });
+});

--- a/frontend/src/components/admin/AdvancedParamsForm.test.tsx
+++ b/frontend/src/components/admin/AdvancedParamsForm.test.tsx
@@ -185,6 +185,31 @@ describe("AdvancedParamsForm", () => {
     expect(onSubmit).toHaveBeenCalledWith({ m: ["x", "z"] });
   });
 
+  it("multi_enum: group's aria-labelledby targets a real element id", () => {
+    // Review-bot WARNING from PR #1100 — the group div previously
+    // referenced ``id`` (the input id, never assigned to anything),
+    // breaking SR association. Pin: the referenced id resolves to a
+    // rendered <label> in the document.
+    render(
+      <AdvancedParamsForm
+        metadata={[
+          meta({
+            name: "m",
+            field_type: "multi_enum",
+            label: "M",
+            enum_values: ["a"],
+          }),
+        ]}
+        busy={false}
+        onSubmit={vi.fn()}
+      />,
+    );
+    const group = screen.getByRole("group");
+    const labelledBy = group.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toBe("M");
+  });
+
   it("empty optional string fields are omitted from submit", async () => {
     const { onSubmit } = renderForm([
       meta({ name: "left_blank", field_type: "string", label: "Blank" }),

--- a/frontend/src/components/admin/AdvancedParamsForm.tsx
+++ b/frontend/src/components/admin/AdvancedParamsForm.tsx
@@ -1,0 +1,400 @@
+/**
+ * AdvancedParamsForm — operator-tunable params form on the drill-in.
+ *
+ * Issue #1064 PR2 — admin control hub Advanced disclosure renderer.
+ *
+ * Renders one form field per ``ParamMetadata`` entry surfaced on
+ * ``ProcessRowResponse.params_metadata``. The drill-in's Advanced tab
+ * wires this component to ``runJob(jobName, {params})`` so an operator
+ * can re-fetch a scheduled job with custom params (e.g.
+ * ``min_period_of_report=2024-01-01`` for ``sec_13f_quarterly_sweep``)
+ * without raw API POSTs.
+ *
+ * Field rendering matrix matches ``_coerce_value`` in
+ * ``app/services/processes/param_metadata.py``:
+ *
+ *   string | ticker (int / instrument_id) | cik   → text/number input
+ *   int | float                                   → number input
+ *   date                                          → HTML5 date input
+ *   quarter                                       → text with regex hint
+ *   bool                                          → checkbox
+ *   enum                                          → select
+ *   multi_enum                                    → checkbox list
+ *
+ * BE-side ``validate_job_params`` is the authoritative validator;
+ * the FE produces JSON-safe values and surfaces the BE 400 detail
+ * string on rejection. Empty optional fields are omitted from the
+ * submit payload — manual ``/jobs/{name}/run`` does NOT materialise
+ * registry defaults (that helper is scheduled-fire only), so absent
+ * keys fall through to the invoker's own ``params.get(key, fallback)``
+ * default.
+ */
+
+import { useCallback, useState } from "react";
+
+import type { ParamFieldType, ParamMetadata } from "@/api/types";
+
+export interface AdvancedParamsFormProps {
+  readonly metadata: readonly ParamMetadata[];
+  readonly busy: boolean;
+  readonly onSubmit: (params: Record<string, unknown>) => Promise<void>;
+  readonly submitLabel?: string;
+}
+
+type FieldValue = string | boolean | string[];
+
+function defaultValueFor(meta: ParamMetadata): FieldValue {
+  if (meta.field_type === "bool") {
+    return meta.default === true;
+  }
+  if (meta.field_type === "multi_enum") {
+    return Array.isArray(meta.default) ? (meta.default as string[]) : [];
+  }
+  if (meta.default == null) return "";
+  // Coerce primitive defaults to a stable string for controlled inputs;
+  // submit-time coercion (Number(), array building) restores the right
+  // JSON shape from the form state.
+  return String(meta.default);
+}
+
+function isLocalEmpty(field_type: ParamFieldType, value: FieldValue): boolean {
+  if (field_type === "bool") return false; // bools always submit
+  if (field_type === "multi_enum")
+    return Array.isArray(value) && value.length === 0;
+  return value === "" || value === null || value === undefined;
+}
+
+function coerceForSubmit(
+  meta: ParamMetadata,
+  raw: FieldValue,
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  switch (meta.field_type) {
+    case "string":
+    case "cik":
+    case "date":
+    case "quarter":
+    case "enum":
+      return { ok: true, value: raw };
+    case "int":
+    case "float":
+    case "ticker": {
+      // ticker is wired as ``int(raw)`` in BE _coerce_value (PR1a:
+      // operator passes instrument_id, not symbol; symbol → id is a
+      // future PR). Same numeric coercion as int.
+      const n = Number(raw);
+      if (!Number.isFinite(n)) {
+        // Defense in depth: HTML5 number input blocks non-numeric
+        // chars at the keystroke layer, so this branch only fires if
+        // a programmatic value (Infinity, NaN) reaches the form
+        // state. JSON.stringify emits null for those, which 400s on
+        // BE with a confusing message — surface a field-specific
+        // error inline instead.
+        return {
+          ok: false,
+          error: `${meta.label}: must be a finite number`,
+        };
+      }
+      return { ok: true, value: n };
+    }
+    case "bool":
+      return { ok: true, value: raw === true };
+    case "multi_enum":
+      return { ok: true, value: Array.isArray(raw) ? raw : [] };
+  }
+}
+
+export function AdvancedParamsForm({
+  metadata,
+  busy,
+  onSubmit,
+  submitLabel = "Run with these params",
+}: AdvancedParamsFormProps) {
+  const [values, setValues] = useState<Record<string, FieldValue>>(() => {
+    const seed: Record<string, FieldValue> = {};
+    for (const meta of metadata) {
+      seed[meta.name] = defaultValueFor(meta);
+    }
+    return seed;
+  });
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const updateValue = useCallback((name: string, value: FieldValue) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setLocalError(null);
+      const payload: Record<string, unknown> = {};
+      for (const meta of metadata) {
+        const raw = values[meta.name];
+        if (raw === undefined) continue;
+        if (isLocalEmpty(meta.field_type, raw)) continue;
+        const coerced = coerceForSubmit(meta, raw);
+        if (!coerced.ok) {
+          setLocalError(coerced.error);
+          return;
+        }
+        payload[meta.name] = coerced.value;
+      }
+      await onSubmit(payload);
+    },
+    [metadata, values, onSubmit],
+  );
+
+  if (metadata.length === 0) {
+    return (
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        This job declares no operator-exposable params.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {metadata.map((meta) => (
+        <FieldRow
+          key={meta.name}
+          meta={meta}
+          value={values[meta.name] ?? defaultValueFor(meta)}
+          busy={busy}
+          onChange={(v) => updateValue(meta.name, v)}
+        />
+      ))}
+      {localError ? (
+        <p
+          role="alert"
+          className="text-xs text-red-700 dark:text-red-300"
+        >
+          {localError}
+        </p>
+      ) : null}
+      <div>
+        <button
+          type="submit"
+          disabled={busy}
+          className="rounded border border-slate-300 bg-white px-3 py-1 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800/40"
+        >
+          {submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function FieldRow({
+  meta,
+  value,
+  busy,
+  onChange,
+}: {
+  meta: ParamMetadata;
+  value: FieldValue;
+  busy: boolean;
+  onChange: (v: FieldValue) => void;
+}) {
+  const id = `advanced-param-${meta.name}`;
+  return (
+    <div className="space-y-1">
+      <label
+        htmlFor={id}
+        className="block text-sm font-medium text-slate-700 dark:text-slate-200"
+      >
+        {meta.label}
+      </label>
+      <FieldInput id={id} meta={meta} value={value} busy={busy} onChange={onChange} />
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        {meta.help_text}
+      </p>
+    </div>
+  );
+}
+
+function FieldInput({
+  id,
+  meta,
+  value,
+  busy,
+  onChange,
+}: {
+  id: string;
+  meta: ParamMetadata;
+  value: FieldValue;
+  busy: boolean;
+  onChange: (v: FieldValue) => void;
+}) {
+  const baseInputClass =
+    "block w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-800 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100";
+
+  switch (meta.field_type) {
+    case "bool":
+      return (
+        <input
+          id={id}
+          type="checkbox"
+          checked={value === true}
+          disabled={busy}
+          onChange={(e) => onChange(e.target.checked)}
+          className="h-4 w-4 rounded border-slate-300 text-blue-600 dark:border-slate-700"
+        />
+      );
+    case "enum": {
+      // Defensive: BE rejects field_type='enum' with enum_values=null at
+      // ParamMetadata construction (validate_job_params raises). If a
+      // misconfigured row slips through, fall back to a text input + a
+      // console warning rather than rendering an empty <select>.
+      if (meta.enum_values == null) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `AdvancedParamsForm: param ${meta.name} has field_type='enum' but no enum_values; falling back to text`,
+        );
+        return (
+          <input
+            id={id}
+            type="text"
+            value={String(value ?? "")}
+            disabled={busy}
+            onChange={(e) => onChange(e.target.value)}
+            className={baseInputClass}
+          />
+        );
+      }
+      return (
+        <select
+          id={id}
+          value={String(value ?? "")}
+          disabled={busy}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseInputClass}
+        >
+          <option value="">— unset —</option>
+          {meta.enum_values.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      );
+    }
+    case "multi_enum": {
+      if (meta.enum_values == null) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `AdvancedParamsForm: param ${meta.name} has field_type='multi_enum' but no enum_values; falling back to text`,
+        );
+        return (
+          <input
+            id={id}
+            type="text"
+            value={Array.isArray(value) ? value.join(",") : ""}
+            disabled={busy}
+            onChange={(e) => onChange(e.target.value.split(",").map((s) => s.trim()).filter(Boolean))}
+            className={baseInputClass}
+          />
+        );
+      }
+      const selected = new Set(Array.isArray(value) ? value : []);
+      return (
+        <div role="group" aria-labelledby={id} className="flex flex-wrap gap-3">
+          {meta.enum_values.map((opt) => {
+            const checkboxId = `${id}-${opt}`;
+            return (
+              <label
+                key={opt}
+                htmlFor={checkboxId}
+                className="flex items-center gap-1 text-sm text-slate-700 dark:text-slate-200"
+              >
+                <input
+                  id={checkboxId}
+                  type="checkbox"
+                  checked={selected.has(opt)}
+                  disabled={busy}
+                  onChange={(e) => {
+                    const next = new Set(selected);
+                    if (e.target.checked) next.add(opt);
+                    else next.delete(opt);
+                    onChange(Array.from(next));
+                  }}
+                  className="h-4 w-4 rounded border-slate-300 text-blue-600 dark:border-slate-700"
+                />
+                {opt}
+              </label>
+            );
+          })}
+        </div>
+      );
+    }
+    case "int":
+    case "float":
+    case "ticker": {
+      // ticker is wired as int(raw) in the BE coercer (instrument_id,
+      // not symbol resolution — symbol → id is a future PR). Same
+      // input shape as int.
+      const step = meta.field_type === "float" ? "any" : "1";
+      return (
+        <input
+          id={id}
+          type="number"
+          step={step}
+          min={meta.min_value ?? undefined}
+          max={meta.max_value ?? undefined}
+          value={String(value ?? "")}
+          disabled={busy}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseInputClass}
+        />
+      );
+    }
+    case "date":
+      return (
+        <input
+          id={id}
+          type="date"
+          value={String(value ?? "")}
+          disabled={busy}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseInputClass}
+        />
+      );
+    case "quarter":
+      return (
+        <input
+          id={id}
+          type="text"
+          inputMode="text"
+          pattern="\d{4}Q[1-4]"
+          placeholder="2026Q1"
+          value={String(value ?? "")}
+          disabled={busy}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseInputClass}
+        />
+      );
+    case "cik":
+      return (
+        <input
+          id={id}
+          type="text"
+          inputMode="numeric"
+          pattern="\d{1,10}"
+          placeholder="0000320193"
+          value={String(value ?? "")}
+          disabled={busy}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseInputClass}
+        />
+      );
+    case "string":
+      return (
+        <input
+          id={id}
+          type="text"
+          value={String(value ?? "")}
+          disabled={busy}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseInputClass}
+        />
+      );
+  }
+}

--- a/frontend/src/components/admin/AdvancedParamsForm.tsx
+++ b/frontend/src/components/admin/AdvancedParamsForm.tsx
@@ -195,15 +195,30 @@ function FieldRow({
   onChange: (v: FieldValue) => void;
 }) {
   const id = `advanced-param-${meta.name}`;
+  const labelId = `${id}-label`;
+  const isGroup = meta.field_type === "multi_enum";
+  // multi_enum has no single focusable input — assistive tech relies on
+  // ``aria-labelledby={labelId}`` on the wrapping group div pointing at
+  // the label's id. Drop ``htmlFor`` for that case so the label isn't
+  // pointing at a non-existent id (review-bot WARNING from PR #1100).
+  // For all other field types ``htmlFor`` keeps click-to-focus working.
   return (
     <div className="space-y-1">
       <label
-        htmlFor={id}
+        id={labelId}
+        htmlFor={isGroup ? undefined : id}
         className="block text-sm font-medium text-slate-700 dark:text-slate-200"
       >
         {meta.label}
       </label>
-      <FieldInput id={id} meta={meta} value={value} busy={busy} onChange={onChange} />
+      <FieldInput
+        id={id}
+        labelId={labelId}
+        meta={meta}
+        value={value}
+        busy={busy}
+        onChange={onChange}
+      />
       <p className="text-xs text-slate-500 dark:text-slate-400">
         {meta.help_text}
       </p>
@@ -213,12 +228,14 @@ function FieldRow({
 
 function FieldInput({
   id,
+  labelId,
   meta,
   value,
   busy,
   onChange,
 }: {
   id: string;
+  labelId: string;
   meta: ParamMetadata;
   value: FieldValue;
   busy: boolean;
@@ -296,7 +313,7 @@ function FieldInput({
       }
       const selected = new Set(Array.isArray(value) ? value : []);
       return (
-        <div role="group" aria-labelledby={id} className="flex flex-wrap gap-3">
+        <div role="group" aria-labelledby={labelId} className="flex flex-wrap gap-3">
           {meta.enum_values.map((opt) => {
             const checkboxId = `${id}-${opt}`;
             return (

--- a/frontend/src/components/admin/__fixtures__/processes.ts
+++ b/frontend/src/components/admin/__fixtures__/processes.ts
@@ -72,6 +72,7 @@ export function makeProcessRow(
     can_cancel: false,
     last_n_errors: [],
     stale_reasons: [],
+    params_metadata: [],
     ...overrides,
   };
 }

--- a/frontend/src/pages/ProcessDetailPage.test.tsx
+++ b/frontend/src/pages/ProcessDetailPage.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "@/api/client";
+import { runJob } from "@/api/jobs";
 import {
   cancelProcess,
   fetchBootstrapTimeline,
@@ -14,6 +15,7 @@ import {
 import type {
   BootstrapTimelineResponse,
   OrchestratorDagResponse,
+  ParamMetadata,
 } from "@/api/types";
 import {
   makeProcessRow,
@@ -35,12 +37,20 @@ vi.mock("@/api/processes", async () => {
   };
 });
 
+vi.mock("@/api/jobs", async () => {
+  const actual = await vi.importActual<typeof import("@/api/jobs")>(
+    "@/api/jobs",
+  );
+  return { ...actual, runJob: vi.fn() };
+});
+
 const mockedDetail = vi.mocked(fetchProcess);
 const mockedRuns = vi.mocked(fetchProcessRuns);
 const mockedTrigger = vi.mocked(triggerProcess);
 const mockedCancel = vi.mocked(cancelProcess);
 const mockedDag = vi.mocked(fetchOrchestratorDag);
 const mockedTimeline = vi.mocked(fetchBootstrapTimeline);
+const mockedRunJob = vi.mocked(runJob);
 
 beforeEach(() => {
   mockedDetail.mockReset();
@@ -49,6 +59,7 @@ beforeEach(() => {
   mockedCancel.mockReset();
   mockedDag.mockReset();
   mockedTimeline.mockReset();
+  mockedRunJob.mockReset();
 });
 
 function renderAt(path = "/admin/processes/sec_form4_ingest") {
@@ -485,5 +496,127 @@ describe("ProcessDetailPage — Timeline tab (bootstrap)", () => {
     const dialog = await screen.findByRole("dialog");
     expect(dialog.textContent).toContain("cik_index_2026Q2.zip");
     expect(dialog.textContent).toContain("unresolved_cik");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Advanced tab — params disclosure renderer (#1064 PR2)
+// ---------------------------------------------------------------------------
+
+const SAMPLE_DATE_METADATA: ParamMetadata = {
+  name: "min_period_of_report",
+  label: "Recency floor",
+  help_text: "Skip 13F accessions whose period_of_report is older than this date.",
+  field_type: "date",
+  default: null,
+  advanced_group: true,
+  enum_values: null,
+  min_value: null,
+  max_value: null,
+};
+
+describe("ProcessDetailPage — Advanced tab", () => {
+  function renderAtAdvanced(processId = "sec_13f_quarterly_sweep") {
+    return render(
+      <MemoryRouter initialEntries={[`/admin/processes/${processId}`]}>
+        <Routes>
+          <Route path="admin/processes/:id" element={<ProcessDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it("hidden when row is bootstrap mechanism (no operator-exposable params)", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        params_metadata: [],
+      }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    renderAtAdvanced("bootstrap");
+    await waitFor(() => expect(mockedDetail).toHaveBeenCalled());
+    expect(screen.queryByRole("tab", { name: "Advanced" })).toBeNull();
+  });
+
+  it("hidden when scheduled job has empty params_metadata", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({
+        process_id: "daily_cik_refresh",
+        mechanism: "scheduled_job",
+        params_metadata: [],
+      }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    renderAtAdvanced("daily_cik_refresh");
+    await waitFor(() => expect(mockedDetail).toHaveBeenCalled());
+    expect(screen.queryByRole("tab", { name: "Advanced" })).toBeNull();
+  });
+
+  it("visible when scheduled job has at least one param declaration", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({
+        process_id: "sec_13f_quarterly_sweep",
+        mechanism: "scheduled_job",
+        params_metadata: [SAMPLE_DATE_METADATA],
+      }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    renderAtAdvanced();
+    expect(
+      await screen.findByRole("tab", { name: "Advanced" }),
+    ).toBeTruthy();
+  });
+
+  it("submit calls runJob with {params} envelope and surfaces request_id", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({
+        process_id: "sec_13f_quarterly_sweep",
+        mechanism: "scheduled_job",
+        params_metadata: [SAMPLE_DATE_METADATA],
+      }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    mockedRunJob.mockResolvedValue({ request_id: 7 });
+    renderAtAdvanced();
+    fireEvent.click(await screen.findByRole("tab", { name: "Advanced" }));
+    fireEvent.change(screen.getByLabelText("Recency floor"), {
+      target: { value: "2024-01-01" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /run with these params/i }),
+    );
+    await waitFor(() =>
+      expect(mockedRunJob).toHaveBeenCalledWith("sec_13f_quarterly_sweep", {
+        params: { min_period_of_report: "2024-01-01" },
+      }),
+    );
+    await screen.findByText(/queued as request #7/i);
+  });
+
+  it("surfaces 400 ApiError detail inline", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({
+        process_id: "sec_13f_quarterly_sweep",
+        mechanism: "scheduled_job",
+        params_metadata: [SAMPLE_DATE_METADATA],
+      }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    mockedRunJob.mockRejectedValue(
+      new ApiError(400, "param 'min_period_of_report': cannot coerce ...", "param 'min_period_of_report': cannot coerce ..."),
+    );
+    renderAtAdvanced();
+    fireEvent.click(await screen.findByRole("tab", { name: "Advanced" }));
+    fireEvent.change(screen.getByLabelText("Recency floor"), {
+      target: { value: "2024-01-01" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /run with these params/i }),
+    );
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/trigger rejected/);
+    expect(alert.textContent).toMatch(/cannot coerce/);
   });
 });

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { ApiError } from "@/api/client";
+import { runJob } from "@/api/jobs";
 import {
   cancelProcess,
   fetchBootstrapTimeline,
@@ -40,6 +41,7 @@ import {
   SectionSkeleton,
 } from "@/components/dashboard/Section";
 import { Modal } from "@/components/ui/Modal";
+import { AdvancedParamsForm } from "@/components/admin/AdvancedParamsForm";
 import {
   REASON_TOOLTIP,
   STATUS_VISUAL,
@@ -48,7 +50,7 @@ import {
 import { useAsync } from "@/lib/useAsync";
 import { formatDateTime } from "@/lib/format";
 
-type TabKey = "overview" | "history" | "errors" | "dag" | "timeline";
+type TabKey = "overview" | "history" | "errors" | "dag" | "timeline" | "advanced";
 
 const ORCHESTRATOR_FULL_SYNC_ID = "orchestrator_full_sync";
 const BOOTSTRAP_PROCESS_ID = "bootstrap";
@@ -76,6 +78,8 @@ export function ProcessDetailPage() {
   const [cancelError, setCancelError] = useState<unknown>(null);
   const [showFullWash, setShowFullWash] = useState(false);
   const [showCancel, setShowCancel] = useState(false);
+  const [advancedError, setAdvancedError] = useState<unknown>(null);
+  const [advancedRequestId, setAdvancedRequestId] = useState<number | null>(null);
 
   // useAsync captures fn via a ref — fresh arrow per render is fine.
   const detail = useAsync(() => fetchProcess(id), [id]);
@@ -110,18 +114,29 @@ export function ProcessDetailPage() {
     { preserveOnRefetch: true },
   );
 
+  // PR2 #1064 — Advanced tab visibility. Only shown for scheduled
+  // jobs that declare params_metadata. Bootstrap + ingest_sweep
+  // mechanisms own no operator-exposable params; scheduled jobs with
+  // an empty metadata tuple (the majority today) also hide the tab.
+  const showAdvanced =
+    detail.data?.mechanism === "scheduled_job" &&
+    (detail.data?.params_metadata?.length ?? 0) > 0;
+
   // Reset tab to overview if currently on a process-specific tab and the
   // route param changes to an id that no longer owns that tab (operator
   // clicked a different process row from the table). Codex pre-impl
   // review M-r2-2 originally pinned the DAG variant; PR7 extends to
-  // timeline.
+  // timeline. PR2 extends to advanced — when the operator pivots from a
+  // scheduled job with metadata to a process that has none, fall back.
   useEffect(() => {
     if (tab === "dag" && !isOrchestrator) {
       setTab("overview");
     } else if (tab === "timeline" && !isBootstrap) {
       setTab("overview");
+    } else if (tab === "advanced" && !showAdvanced) {
+      setTab("overview");
     }
-  }, [tab, isOrchestrator, isBootstrap]);
+  }, [tab, isOrchestrator, isBootstrap, showAdvanced]);
 
   // Extract the refetch refs as local const bindings so ESLint can
   // see their identity and verify the dep array — `useAsync` wraps
@@ -179,6 +194,29 @@ export function ProcessDetailPage() {
       setBusy(false);
     }
   }, [id, refetchAll]);
+
+  const handleAdvancedSubmit = useCallback(
+    async (params: Record<string, unknown>) => {
+      setAdvancedError(null);
+      setAdvancedRequestId(null);
+      setBusy(true);
+      try {
+        // For scheduled_job mechanism, process_id is the job_name verbatim
+        // (see app/api/processes.py::trigger_process: target_job_name = process_id).
+        const result = await runJob(id, { params });
+        setAdvancedRequestId(result?.request_id ?? null);
+        refetchAll();
+      } catch (err) {
+        setAdvancedError(err);
+        if (!(err instanceof ApiError))
+          // eslint-disable-next-line no-console
+          console.error("runJob (advanced) failed", err);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [id, refetchAll],
+  );
 
   const handleCancelConfirmed = useCallback(
     async (mode: CancelMode) => {
@@ -240,6 +278,7 @@ export function ProcessDetailPage() {
         setTab={setTab}
         showDag={isOrchestrator}
         showTimeline={isBootstrap}
+        showAdvanced={showAdvanced}
       />
 
       <Section title={tabTitle(tab)}>
@@ -277,6 +316,14 @@ export function ProcessDetailPage() {
             loading={timeline.loading}
             error={timeline.error}
             onRetry={timeline.refetch}
+          />
+        ) : tab === "advanced" && showAdvanced && detail.data ? (
+          <AdvancedTab
+            row={detail.data}
+            busy={busy}
+            error={advancedError}
+            requestId={advancedRequestId}
+            onSubmit={handleAdvancedSubmit}
           />
         ) : null}
       </Section>
@@ -390,11 +437,13 @@ function TabBar({
   setTab,
   showDag,
   showTimeline,
+  showAdvanced,
 }: {
   tab: TabKey;
   setTab: (t: TabKey) => void;
   showDag: boolean;
   showTimeline: boolean;
+  showAdvanced: boolean;
 }) {
   const tabs: { key: TabKey; label: string }[] = [
     { key: "overview", label: "Overview" },
@@ -402,6 +451,9 @@ function TabBar({
     { key: "errors", label: "Errors" },
     ...(showDag ? [{ key: "dag" as TabKey, label: "DAG" }] : []),
     ...(showTimeline ? [{ key: "timeline" as TabKey, label: "Timeline" }] : []),
+    ...(showAdvanced
+      ? [{ key: "advanced" as TabKey, label: "Advanced" }]
+      : []),
   ];
   return (
     <div role="tablist" className="flex gap-1 border-b border-slate-200 dark:border-slate-800">
@@ -440,6 +492,8 @@ function tabTitle(tab: TabKey): string {
       return "DAG (latest sync run)";
     case "timeline":
       return "Bootstrap timeline (latest run)";
+    case "advanced":
+      return "Advanced — re-fetch with custom params";
   }
 }
 
@@ -627,6 +681,55 @@ const LAYER_STATUS_TONE: Record<string, string> = {
   partial: "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
   cancelled: "border-slate-300 bg-slate-50 text-slate-500 line-through dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400",
 };
+
+function AdvancedTab({
+  row,
+  busy,
+  error,
+  requestId,
+  onSubmit,
+}: {
+  row: ProcessRowResponse;
+  busy: boolean;
+  error: unknown;
+  requestId: number | null;
+  onSubmit: (params: Record<string, unknown>) => Promise<void>;
+}) {
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        Submits to <code>POST /jobs/{row.process_id}/run</code> with the
+        validated params envelope. The job is queued; track outcome on
+        the requests panel.
+      </p>
+      <AdvancedParamsForm
+        metadata={row.params_metadata}
+        busy={busy}
+        onSubmit={onSubmit}
+      />
+      {requestId !== null ? (
+        <p
+          role="status"
+          className="text-xs text-emerald-700 dark:text-emerald-300"
+        >
+          queued as request #{requestId}
+        </p>
+      ) : null}
+      {error ? (
+        <p
+          role="alert"
+          className="text-xs text-red-700 dark:text-red-300"
+          title={reasonTooltip(error)}
+        >
+          trigger rejected
+          {error instanceof ApiError && typeof error.detail === "string"
+            ? `: ${error.detail}`
+            : null}
+        </p>
+      ) : null}
+    </div>
+  );
+}
 
 function DagTab({
   payload,

--- a/tests/test_api_jobs.py
+++ b/tests/test_api_jobs.py
@@ -144,6 +144,25 @@ class TestRunJobEnvelope:
         assert "boolean" in resp.json()["detail"].lower()
         pub.assert_not_called()
 
+    def test_date_param_round_trips_as_iso_string_in_payload(self) -> None:
+        """PR2 #1064 — ``validate_job_params`` returns native ``date`` for
+        ``field_type='date'``; if the API path published the dict directly,
+        ``Jsonb`` would raise ``TypeError`` on adapt. ``to_jsonsafe_params``
+        coerces to ISO string before publish so the queue row's payload is
+        JSON-clean. The listener re-validates after dequeue, so the invoker
+        still receives a native ``date``.
+        """
+        with patch("app.api.jobs.publish_manual_job_request", return_value=99) as pub:
+            resp = client.post(
+                "/jobs/sec_13f_quarterly_sweep/run",
+                json={"params": {"min_period_of_report": "2024-01-01"}},
+            )
+        assert resp.status_code == 202
+        kwargs = pub.call_args.kwargs
+        # Pin: ISO string in payload, NOT a datetime.date instance.
+        assert kwargs["payload"]["params"]["min_period_of_report"] == "2024-01-01"
+        assert isinstance(kwargs["payload"]["params"]["min_period_of_report"], str)
+
 
 class TestListJobRequests:
     """Smoke for the new GET /jobs/requests endpoint (#719)."""

--- a/tests/test_processes_endpoints.py
+++ b/tests/test_processes_endpoints.py
@@ -86,11 +86,54 @@ def test_list_processes_returns_envelope_shape(conn_override: None, ebull_test_c
     for row in payload["rows"]:
         assert "stale_reasons" in row
         assert isinstance(row["stale_reasons"], list)
+        # PR2 #1064 — every row carries ``params_metadata``. Empty list
+        # for bootstrap + ingest_sweep + scheduled jobs without metadata.
+        assert "params_metadata" in row
+        assert isinstance(row["params_metadata"], list)
         if row["active_run"] is not None:
             active = row["active_run"]
             assert "is_stale" not in active
             assert "expected_p95_seconds" not in active
             assert "last_progress_at" in active
+
+
+def test_get_process_returns_params_metadata_for_declared_job(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """PR2 #1064 — a job with declared ``params_metadata`` surfaces it
+    on ``/system/processes/{id}`` so the FE Advanced disclosure
+    renders one form field per entry.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    resp = client.get("/system/processes/sec_13f_quarterly_sweep")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["mechanism"] == "scheduled_job"
+    metadata = payload["params_metadata"]
+    assert isinstance(metadata, list) and len(metadata) == 1
+    entry = metadata[0]
+    assert entry["name"] == "min_period_of_report"
+    assert entry["field_type"] == "date"
+    assert entry["advanced_group"] is True
+    assert entry["help_text"]
+
+
+def test_get_process_returns_empty_metadata_for_bootstrap(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """Bootstrap mechanism has no operator-exposable params (stages own
+    their hardcoded params dict via ``StageSpec.params``); the FE
+    keys off the empty list to hide the Advanced tab.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    _seed_bootstrap_state(ebull_test_conn, "pending")
+    ebull_test_conn.commit()
+
+    resp = client.get("/system/processes/bootstrap")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["params_metadata"] == []
 
 
 def test_get_process_unknown_returns_404(conn_override: None) -> None:

--- a/tests/test_processes_envelope.py
+++ b/tests/test_processes_envelope.py
@@ -76,6 +76,7 @@ def test_process_row_carries_all_envelope_fields() -> None:
         "can_cancel",
         "last_n_errors",
         "stale_reasons",
+        "params_metadata",
     }
     assert set(row.__slots__) == expected
 

--- a/tests/test_processes_json_safe.py
+++ b/tests/test_processes_json_safe.py
@@ -1,0 +1,62 @@
+"""Unit tests for ``app.services.processes.json_safe``.
+
+Issue #1064 PR2 — pins the JSON-safe coercion that ``app/api/jobs.py``
+calls before publishing the queue payload. The same helper is used by
+``app/jobs/runtime.py`` for ``params_snapshot`` writes; the back-compat
+re-export in ``ops_monitor`` keeps legacy callers wired.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from app.services.processes.json_safe import to_jsonsafe_params
+
+
+def test_date_coerces_to_iso_string() -> None:
+    assert to_jsonsafe_params({"d": date(2024, 1, 1)}) == {"d": "2024-01-01"}
+
+
+def test_datetime_coerces_to_iso_string() -> None:
+    dt = datetime(2024, 1, 1, 12, 30, 45, tzinfo=UTC)
+    out = to_jsonsafe_params({"ts": dt})
+    assert out["ts"] == dt.isoformat()
+
+
+def test_list_and_tuple_normalise_to_list() -> None:
+    out = to_jsonsafe_params({"l": [1, 2], "t": (3, 4)})
+    assert out["l"] == [1, 2]
+    assert out["t"] == [3, 4]
+
+
+def test_scalars_pass_through_unchanged() -> None:
+    out = to_jsonsafe_params({"s": "x", "i": 7, "f": 1.5, "b": True, "n": None})
+    assert out == {"s": "x", "i": 7, "f": 1.5, "b": True, "n": None}
+
+
+def test_back_compat_re_export_in_ops_monitor() -> None:
+    """``ops_monitor._jsonable_params`` is the legacy alias.
+
+    PR1c landed it inline; PR2 lifted the canonical helper to
+    ``app.services.processes.json_safe`` and the ops_monitor name is
+    now a thin re-export. Existing internal callers (runtime.py
+    fallback path, ops_monitor's two write sites) keep working
+    without a global rewire.
+    """
+    from app.services.ops_monitor import _jsonable_params
+
+    assert _jsonable_params is to_jsonsafe_params
+    assert _jsonable_params({"d": date(2024, 1, 1)}) == {"d": "2024-01-01"}
+
+
+def test_jsonb_roundtrip_does_not_raise_on_date() -> None:
+    """psycopg.Jsonb adapts at SQL-execution time; verify the helper's
+    output passes through ``json.dumps`` cleanly so the adapt step
+    never crashes. Pre-PR2 a raw ``date`` in the queue payload would
+    raise ``TypeError`` here.
+    """
+    import json
+
+    safe = to_jsonsafe_params({"d": date(2024, 1, 1)})
+    # No exception raised — round-trip the same JSON psycopg would emit.
+    assert json.dumps(safe) == '{"d": "2024-01-01"}'

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -630,3 +630,49 @@ def test_queue_stuck_does_not_fire_on_recently_claimed_dispatched(
     row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
     assert row is not None
     assert "queue_stuck" not in row.stale_reasons
+
+
+# ---------------------------------------------------------------------------
+# PR2 #1064 — params_metadata surfacing for the Advanced disclosure tab
+# ---------------------------------------------------------------------------
+
+
+def test_params_metadata_surfaces_for_sec_13f_quarterly_sweep(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """ScheduledJob.params_metadata flows verbatim onto ProcessRow.
+
+    Pins the foundation that the FE Advanced tab depends on: a job that
+    declares ``params_metadata`` surfaces its full tuple on the row,
+    enabling the drill-in to render one form field per entry. Drift
+    here silently breaks the renderer.
+    """
+    from app.workers.scheduler import JOB_SEC_13F_QUARTERLY_SWEEP, SCHEDULED_JOBS
+
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_SEC_13F_QUARTERLY_SWEEP)
+    assert row is not None
+    job = next(j for j in SCHEDULED_JOBS if j.name == JOB_SEC_13F_QUARTERLY_SWEEP)
+    assert row.params_metadata == job.params_metadata
+    assert len(row.params_metadata) == 1
+    assert row.params_metadata[0].name == "min_period_of_report"
+    assert row.params_metadata[0].field_type == "date"
+
+
+def test_params_metadata_default_empty_for_jobs_without_declarations(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Jobs that do not declare ``params_metadata`` surface ``()``.
+
+    Today every scheduled job except ``sec_13f_quarterly_sweep`` falls
+    in this bucket. The empty tuple is what the FE keys off to hide
+    the Advanced tab.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
+    assert row is not None
+    assert row.params_metadata == ()


### PR DESCRIPTION
## Summary
- BE: surface `ScheduledJob.params_metadata` on `ProcessRow` + `ProcessRowResponse`; new `app/services/processes/json_safe.py` wired into `/jobs/<name>/run` before `Jsonb` publish (fixes latent PR1b-2 `date` serialisation bug).
- FE: generic `<AdvancedParamsForm>` per `ParamFieldType` (string / int / float / date / quarter / ticker / cik / bool / enum / multi_enum); new "Advanced" tab in `ProcessDetailPage` gated on `mechanism === "scheduled_job"` AND `params_metadata.length > 0`; `runJob` widened to envelope `{params, control}`; `apiFetch` reads 202 body when present.

## Why
- PR1b-2 made `/jobs/<name>/run` accept the validated envelope but no FE rendered the disclosure — operators had to POST raw JSON.
- `validate_job_params` returns native `datetime.date` for `field_type='date'`; `Jsonb` cannot adapt without coercion. PR1b-2 had this latent — first operator who submits a date-typed param via the new form would have crashed publish. `to_jsonsafe_params` (extracted from `ops_monitor._jsonable_params`) coerces to ISO string before publish; listener re-validates after dequeue, so invokers still receive native `date`.

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright`
- [x] `uv run pytest tests/test_processes_json_safe.py tests/test_scheduled_adapter.py tests/test_api_jobs.py tests/test_pr1b2_envelope_and_gate.py tests/test_pr1c_wrapper_lift.py tests/test_processes_envelope.py tests/test_jobs_runtime.py` — 132 passed
- [x] `uv run pytest tests/test_processes_endpoints.py -n 0` — 34 passed (xdist+postgres lock OOM is pre-existing per `feedback_pre_push_xdist_postgres_locks.md`)
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend test:unit` — 831/842 (11 pre-existing theme/chart failures unrelated to PR; confirmed on clean main)
- [x] Codex spec review (3 rounds, clean) + Codex pre-push diff review (no blocking findings)
- [ ] Smoke on dev: open `/admin/processes/sec_13f_quarterly_sweep` → Advanced tab visible → submit `min_period_of_report=2024-01-01` → 202 with `request_id` → `pending_job_requests.payload.params.min_period_of_report == "2024-01-01"` (ISO string)
- [ ] Smoke: open `/admin/processes/bootstrap` → Advanced tab NOT visible
- [ ] Smoke: open `/admin/processes/daily_cik_refresh` (scheduled, empty metadata) → Advanced tab NOT visible

Refs #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)