### PR TITLE
docs(#1064): expose data-engineer + metrics-analyst as discoverable skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -244,8 +244,8 @@ Read and apply these before pushing:
 
 - `.claude/skills/data-sources/sec-edgar.md` — source-of-truth: endpoints, formats, identifiers, gotchas (DD-MMM-YYYY dates, 13F PRN/SH, VALUE-cutover 2023-01-03, 13D/G XML mandate, etc.), rate-limit discipline, reference impls.
 - `.claude/skills/data-sources/edgartools.md` — library reference: coverage matrix, API cheat-sheet, Pydantic validation cliff (#932), version pinning, decision tree for use-vs-roll-our-own.
-- `.claude/skills/ebull/data-engineer.md` — what we own: schema invariants, two-layer ownership model, write-through pattern, settled-decisions cross-reference, "where does X come from?" FAQ.
-- `.claude/skills/ebull/metrics-analyst.md` — every operator-visible metric: source → transform → table → endpoint → chart, with caveats and validation steps.
+- `.claude/skills/data-engineer/SKILL.md` — what we own: schema invariants, two-layer ownership model, write-through pattern, settled-decisions cross-reference, "where does X come from?" FAQ, admin-page operator UX FAQ. Discoverable as the `data-engineer` skill.
+- `.claude/skills/metrics-analyst/SKILL.md` — every operator-visible metric: source → transform → table → endpoint → chart, with caveats and validation steps. Discoverable as the `metrics-analyst` skill.
 
 ## Settled decisions
 

--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -594,3 +594,76 @@ Every job in `SCHEDULED_JOBS` declares a `prerequisite: PrerequisiteFn | None`. 
 - **CI pytest job dropped (#928)**: pre-push hook is sole test gate.
 - **AS-OF semantics**: `as_of_date` everywhere = period end, never fetch time. `ingested_at` is system-time watermark for repair sweep. `known_from`/`known_to` are valid-time. Don't mix.
 - **N-PORT validation cliff (#932)**: EdgarTools' Pydantic `FundReport.parse_fund_xml` rejects synthetic test fixtures the bespoke parser tolerates. Bespoke stdlib-ElementTree parser remains shipped; rewrite parked.
+
+## 7. Admin / ETL page — operator UX FAQ
+
+This section is the answer key for "the admin processes page should behave like X — does it?" questions. Operator design intent (locked 2026-05-10):
+
+### 7.1 Bootstrap-incomplete state — visibility
+
+**Question:** "Bootstrap is in `partial_error` / `running` / not `complete`. Why am I seeing every other category disabled? They shouldn't even be on screen yet."
+
+**Answer:** Operator decision — when `bootstrap_state.status != 'complete'`, the ProcessesTable hides every non-bootstrap category. Bootstrap is the only row visible, expanded to show its child stages. Other lanes (universe / candles / sec / ownership / fundamentals / ops / ai) are not just disabled — they are filtered out of the list entirely so the operator's only path forward is the bootstrap row.
+
+Implementation surface: FE filter at `frontend/src/pages/AdminPage.tsx` or `useProcesses` consumer; BE `list_processes` continues returning all rows (BE stays mechanism-agnostic). The gate lives in the FE so bootstrap-as-overlay behaviour can change later without a schema migration.
+
+### 7.2 Bootstrap stages — schedules
+
+**Question:** "Why do bootstrap stages show a cadence? They're not scheduled."
+
+**Answer:** They aren't. Bootstrap stages are a fixed sequence (init → etoro → sec_rate → sec_bulk_download → db lanes) declared in `_BOOTSTRAP_STAGE_SPECS`. They run when the orchestrator runs, period. Any cadence rendered next to a stage row is a FE bug. Stages render with a status indicator only ("pending" / "running" / "complete" / "failed" / "cancelled"); `cadence_human` / `cadence_cron` / `next_fire_at` must be omitted at render-time for `mechanism === 'bootstrap'`.
+
+### 7.3 Bootstrap row — action verbs
+
+**Question:** "The action buttons say 'Iterate' and 'Full-wash'. What do those mean for bootstrap?"
+
+**Answer:** Wrong labels for bootstrap. Operator-locked verbs:
+
+| Mechanism | Iterate label | Full-wash label |
+|---|---|---|
+| `scheduled_job` | "Iterate" (catch up since watermark) | "Full-wash" (reset watermark + re-fetch) |
+| `bootstrap` | **"Re-run failed"** (resume incomplete + failed stages from where they stopped) | **"Re-run all"** (reset every stage to pending; full first-install replay) |
+| `ingest_sweep` | (read-only — no buttons) | (read-only — no buttons) |
+
+The underlying mechanics map: bootstrap "Re-run failed" = current `iterate` mode (`reset_failed_stages_for_retry` path); "Re-run all" = current `full_wash` mode (`start_run` flips bootstrap_state + every stage to pending). Only the labels change, not the fence-row + advisory-lock plumbing.
+
+### 7.4 Cancel — bootstrap level wraps the running stages
+
+**Question:** "Cancel today seems to be per-job. Bootstrap is N stages — I want one cancel that takes down whatever's running underneath."
+
+**Answer:** Operator-locked: the bootstrap row's Cancel button is the canonical cancel for the entire run. Clicking it sets `bootstrap_runs.cancel_requested_at` (today already does this for the bootstrap process_id). The cancel signal must propagate to whichever stage's job is actively running — that propagation is the work in PR7 (#1064 follow-up sequence). Today the orchestrator checks `cancel_requested_at` between stages but does NOT signal a stage that's mid-flight. PR7 plumbs the signal through `_invoker_request_context` so the stage's checkpoint loop sees it and exits cooperatively.
+
+UX expectation: when the bootstrap row says "running" and a stage is mid-flight, clicking Cancel on the bootstrap row should:
+1. Mark `bootstrap_runs.cancel_requested_at`.
+2. Signal the running stage (cooperative — no SIGKILL).
+3. Stage exits at next checkpoint, marks itself `cancelled` (NOT `error` — see #1093).
+4. Orchestrator sees the cancel between iterations, marks the run `cancelled`, every pending stage rolls forward as not-attempted.
+
+`terminate` (SIGKILL) mode is hidden behind the More disclosure on the bootstrap row — same as scheduled jobs (#1092 fix wires the modal selection through to `cancel_mode`; today hardcoded `cooperative` at `bootstrap_state.py:742`).
+
+### 7.5 Cancelled vs errored stages
+
+**Question:** "After cancel, all the stages went red. They didn't error — I cancelled them. The Timeline doesn't tell me which is which."
+
+**Answer:** Today `mark_run_cancelled` sweeps incomplete stages to `status='error'`. Wrong — they were never attempted (or were cooperatively interrupted). Operator-locked: cancelled stages need their own status value. Two paths considered:
+
+1. **Tone-only synthesis (FE):** keep `status='error'` in DB but tone the row gray when the parent run is `cancelled`. Cheap. Loses the distinction in any direct DB query.
+2. **New `status='cancelled'` on `bootstrap_stages`:** schema migration. Surfaces the distinction everywhere — FE, audit queries, runbook tooling. Costlier today.
+
+Path 2 is the correct one. Filed as #1093. Tone synthesis is a stopgap if #1093 takes more than a sprint.
+
+### 7.6 Why is everything on the page disabled when I just want to fix the bootstrap?
+
+**Answer:** Two paths are conflated:
+
+1. **Bootstrap-state gate** (`PR1b` / `PR1b-2`): when bootstrap != `complete`, scheduled jobs are gated — both scheduled fires AND manual triggers are rejected with `bootstrap_not_complete` reason. This is correct: you don't want `daily_candle_refresh` running while bootstrap is partway through `init`. Manual override exists (`?override_bootstrap_gate=true` + `decision_audit` audit row) for triage.
+
+2. **FE rendering of disabled rows** (current bug): the page shows every category, all greyed out, with the "rejected" tooltip. Operator-correct UX hides them entirely (§7.1) — operator's sole path forward when bootstrap is broken should be the bootstrap row's "Re-run failed" / "Re-run all" buttons.
+
+Today's UI shows you the locked door with a "no entry" sign on every category. The fix shows you only the bootstrap door. The gate logic doesn't change — only the rendering.
+
+### 7.7 First-install bootstrap drains slowly — what's happening?
+
+**Answer:** SEC bulk-download stages (12-15 in the sequence) fetch ~12,000 SEC per-CIK pages at a 10-req/s rate-limit. The bootstrap's `sec_first_install_drain` stage (#909 / PR1c) is the long pole — bounded by SEC's published rate limit, not eBull. Re-run all on a fresh DB is roughly 20+ minutes of bandwidth.
+
+Operator-helpful surface (deferred, NOT scheduled): a pre-flight estimate "this will issue ~12,000 SEC requests over ~20 minutes" before kick-off. Tracked as a future operator-UX ticket; not blocking PR7.

--- a/.claude/skills/metrics-analyst/SKILL.md
+++ b/.claude/skills/metrics-analyst/SKILL.md
@@ -514,4 +514,4 @@ After backfill, hit the relevant rollup endpoint and confirm the figure renders 
 
 - `.claude/skills/data-sources/sec-edgar.md` — where the source data comes from.
 - `.claude/skills/data-sources/edgartools.md` — the parsing library.
-- `.claude/skills/ebull/data-engineer.md` — schema invariants + write/read patterns.
+- `.claude/skills/data-engineer/SKILL.md` — schema invariants + write/read patterns.

--- a/docs/wiki/job-registry-audit.md
+++ b/docs/wiki/job-registry-audit.md
@@ -402,7 +402,7 @@ Notes:
 - Bootstrap orchestration spec: [`docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md`](../superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md)
 - First-install bootstrap spec: [`docs/superpowers/specs/2026-05-07-first-install-bootstrap.md`](../superpowers/specs/2026-05-07-first-install-bootstrap.md)
 - Settled-decisions (process topology #719, cancel UX): [`docs/settled-decisions.md`](../settled-decisions.md)
-- Data-engineer skill (PR0 §10 update target): [`.claude/skills/ebull/data-engineer.md`](../../.claude/skills/ebull/data-engineer.md)
+- Data-engineer skill (PR0 §10 update target): [`.claude/skills/data-engineer/SKILL.md`](../../.claude/skills/data-engineer/SKILL.md)
 - ScheduledJob declarations: [`app/workers/scheduler.py:453`](../../app/workers/scheduler.py#L453)
 - Bootstrap stage declarations: [`app/services/bootstrap_orchestrator.py:202`](../../app/services/bootstrap_orchestrator.py#L202)
 - Bespoke wrappers: [`app/services/bootstrap_orchestrator.py:751,847,897`](../../app/services/bootstrap_orchestrator.py#L751)


### PR DESCRIPTION
## Summary
- Move `.claude/skills/ebull/{data-engineer,metrics-analyst}.md` → `.claude/skills/{name}/SKILL.md` so the Claude Code harness loads them via the Skill registry. Confirmed in-session — both now show up in the available-skills list.
- Add §7 to data-engineer SKILL.md — admin / ETL page operator UX FAQ capturing 7 design-intent questions locked with operator on 2026-05-10 (bootstrap-only visibility, no stage cadence, "Re-run failed" / "Re-run all" verbs, bootstrap-level cancel propagation, cancelled-vs-errored stage tone, gate-vs-render distinction, first-install drain time).
- Update CLAUDE.md + metrics-analyst self-ref + `docs/wiki/job-registry-audit.md` backlinks.

## Why
Operator couldn't invoke the skill (`/data-engineer` not discoverable) because it lived as a bare markdown under `.claude/skills/ebull/`, not the `{name}/SKILL.md` shape the harness loads. Same fix lifts metrics-analyst. The new §7 turns the skill into the answer key for "the admin processes page should behave like X — does it?" so future agents stop relitigating the bootstrap UX from scratch.

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] In-session confirmation: both skills now appear in the system-reminder skill list with their H1 descriptions.

Refs #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)