### PR TITLE
feat(#1064): PR3a — bootstrap-only render mode + verb swap on bootstrap row

### DIFF
--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -296,4 +296,63 @@ describe("ProcessRow", () => {
     // full meaning rather than the bare phrase.
     expect(chip).toHaveAccessibleName(/^Stale reason: no progress\s+\d+m$/);
   });
+
+  // ---------------------------------------------------------------------
+  // PR3a #1064 — bootstrap mechanism action verbs + no cadence
+  // ---------------------------------------------------------------------
+
+  it("bootstrap row labels Iterate as 'Re-run failed' and Full-wash as 'Re-run all'", () => {
+    renderRow({
+      row: makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        display_name: "First-install bootstrap",
+        can_iterate: true,
+        can_full_wash: true,
+      }),
+    });
+    expect(
+      screen.getByRole("button", { name: "Re-run failed" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Re-run all" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Iterate" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Full-wash" })).toBeNull();
+  });
+
+  it("scheduled_job row keeps Iterate / Full-wash labels", () => {
+    renderRow({
+      row: makeProcessRow({
+        process_id: "daily_cik_refresh",
+        mechanism: "scheduled_job",
+      }),
+    });
+    expect(screen.getByRole("button", { name: "Iterate" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Full-wash" })).toBeTruthy();
+  });
+
+  it("bootstrap row omits cadence (stages are a fixed sequence, not scheduled)", () => {
+    const { container } = renderRow({
+      row: makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        cadence_human: "every 5m",
+        next_fire_at: "2026-05-10T14:00:00+00:00",
+      }),
+    });
+    expect(container.textContent).not.toContain("every 5m");
+    expect(container.textContent).not.toContain("next:");
+  });
+
+  it("scheduled_job row keeps cadence visible", () => {
+    const { container } = renderRow({
+      row: makeProcessRow({
+        process_id: "daily_cik_refresh",
+        mechanism: "scheduled_job",
+        cadence_human: "every 5m",
+      }),
+    });
+    expect(container.textContent).toContain("every 5m");
+  });
 });

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -68,15 +68,29 @@ export function ProcessRow({
 
   const watermarkTooltip = row.watermark?.human ?? "no resume cursor";
 
+  // Per data-engineer skill §7.3 — bootstrap mechanism uses different
+  // verbs because iterate / full_wash semantics map to "resume incomplete
+  // stages" vs "reset every stage to pending" rather than the
+  // watermark-aware fetch on scheduled jobs. Underlying mechanics
+  // (iterate / full_wash modes on the trigger endpoint) unchanged; only
+  // the operator-visible label changes per mechanism.
+  const isBootstrap = row.mechanism === "bootstrap";
+  const iterateLabel = isBootstrap ? "Re-run failed" : "Iterate";
+  const fullWashLabel = isBootstrap ? "Re-run all" : "Full-wash";
+
   const iterateDisabled = !row.can_iterate || busy;
   const iterateTooltip = row.can_iterate
-    ? watermarkTooltip
-    : "Iterate is not available right now — open the process detail page for the precondition that is blocking it.";
+    ? isBootstrap
+      ? "Resume incomplete + failed stages from where they stopped."
+      : watermarkTooltip
+    : `${iterateLabel} is not available right now — open the process detail page for the precondition that is blocking it.`;
 
   const fullWashDisabled = !row.can_full_wash || busy;
   const fullWashTooltip = row.can_full_wash
-    ? "Reset watermark and re-fetch from epoch (typed-name confirm required)."
-    : "Full-wash is not available right now.";
+    ? isBootstrap
+      ? "Reset every stage to pending; full first-install replay (typed-name confirm required)."
+      : "Reset watermark and re-fetch from epoch (typed-name confirm required)."
+    : `${fullWashLabel} is not available right now.`;
 
   const cancelDisabled = !row.can_cancel || busy;
   const cancelTooltip = row.can_cancel
@@ -120,23 +134,32 @@ export function ProcessRow({
         {lastRunLabel}
       </td>
       <td className="px-2 py-2 text-xs text-slate-600 dark:text-slate-400">
-        <div>{row.cadence_human}</div>
-        {row.next_fire_at ? (
-          <div className="text-slate-500 dark:text-slate-500">
-            next: {formatDateTime(row.next_fire_at)}
-          </div>
-        ) : null}
+        {isBootstrap ? (
+          // Bootstrap stages run as a fixed sequence, not on a cadence
+          // (data-engineer skill §7.2). Show a placeholder rather than
+          // a phantom schedule.
+          <span className="text-slate-400 dark:text-slate-500">—</span>
+        ) : (
+          <>
+            <div>{row.cadence_human}</div>
+            {row.next_fire_at ? (
+              <div className="text-slate-500 dark:text-slate-500">
+                next: {formatDateTime(row.next_fire_at)}
+              </div>
+            ) : null}
+          </>
+        )}
       </td>
       <td className="px-2 py-2 text-right">
         <div className="flex flex-wrap items-center justify-end gap-1">
           <ActionButton
-            label="Iterate"
+            label={iterateLabel}
             tooltip={iterateTooltip}
             disabled={iterateDisabled}
             onClick={() => onIterate(row)}
           />
           <ActionButton
-            label="Full-wash"
+            label={fullWashLabel}
             tooltip={fullWashTooltip}
             disabled={fullWashDisabled}
             onClick={() => onFullWash(row)}

--- a/frontend/src/components/admin/ProcessesTable.test.tsx
+++ b/frontend/src/components/admin/ProcessesTable.test.tsx
@@ -313,4 +313,157 @@ describe("ProcessesTable", () => {
       screen.getByRole("button", { name: "Cancel" }),
     );
   });
+
+  // ---------------------------------------------------------------------
+  // PR3a #1064 — bootstrap-only render mode
+  // ---------------------------------------------------------------------
+  // Per data-engineer skill §7.1, when bootstrap_state.status !=
+  // 'complete' the ProcessesTable hides every non-bootstrap row so the
+  // operator's only path forward is the bootstrap row. Lane filter
+  // hidden in this mode (one-row list).
+
+  function renderTableWithStatus(
+    rows: Parameters<typeof makeProcessList>[0],
+    bootstrapStatus:
+      | "pending"
+      | "running"
+      | "complete"
+      | "partial_error"
+      | null,
+  ) {
+    return render(
+      <MemoryRouter>
+        <ProcessesTable
+          snapshot={makeProcessList(rows, false)}
+          onMutationSuccess={vi.fn()}
+          bootstrapStatus={bootstrapStatus}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("hides non-bootstrap rows + lane filter when bootstrap is partial_error", () => {
+    renderTableWithStatus(
+      [
+        makeProcessRow({
+          process_id: "bootstrap",
+          mechanism: "bootstrap",
+          display_name: "First-install bootstrap",
+        }),
+        makeProcessRow({
+          process_id: "daily_cik_refresh",
+          mechanism: "scheduled_job",
+          display_name: "CIK refresh",
+        }),
+        makeProcessRow({
+          process_id: "form4_sweep",
+          mechanism: "ingest_sweep",
+          display_name: "Form 4 sweep",
+        }),
+      ],
+      "partial_error",
+    );
+    expect(
+      screen.getByRole("link", { name: "First-install bootstrap" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "CIK refresh" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Form 4 sweep" })).toBeNull();
+    expect(
+      screen.getByText(/Other categories are gated until bootstrap reaches/i),
+    ).toBeTruthy();
+    // Lane chip filter (LaneFilter, role="toolbar") is suppressed in this mode.
+    expect(
+      screen.queryByRole("toolbar", { name: /Filter processes by lane/i }),
+    ).toBeNull();
+  });
+
+  it("renders all rows when bootstrap status is complete", () => {
+    renderTableWithStatus(
+      [
+        makeProcessRow({
+          process_id: "bootstrap",
+          mechanism: "bootstrap",
+          display_name: "First-install bootstrap",
+        }),
+        makeProcessRow({
+          process_id: "daily_cik_refresh",
+          mechanism: "scheduled_job",
+          display_name: "CIK refresh",
+        }),
+      ],
+      "complete",
+    );
+    expect(
+      screen.getByRole("link", { name: "First-install bootstrap" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: "CIK refresh" })).toBeTruthy();
+    expect(
+      screen.queryByText(/Other categories are gated/i),
+    ).toBeNull();
+  });
+
+  it("bootstrap full-wash modal uses 'Re-run all' heading + replay copy", async () => {
+    renderTableWithStatus(
+      [
+        makeProcessRow({
+          process_id: "bootstrap",
+          mechanism: "bootstrap",
+          display_name: "First-install bootstrap",
+          can_iterate: true,
+          can_full_wash: true,
+        }),
+      ],
+      "partial_error",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Re-run all" }));
+    expect(
+      await screen.findByRole("heading", { name: /Confirm Re-run all/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/replays the full first-install bootstrap/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/resets the watermark/i)).toBeNull();
+  });
+
+  it("scheduled_job full-wash modal keeps original watermark copy", async () => {
+    renderTableWithStatus(
+      [
+        makeProcessRow({
+          process_id: "daily_cik_refresh",
+          mechanism: "scheduled_job",
+          display_name: "CIK refresh",
+          can_iterate: true,
+          can_full_wash: true,
+        }),
+      ],
+      "complete",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Full-wash" }));
+    expect(
+      await screen.findByRole("heading", { name: /Confirm full-wash/i }),
+    ).toBeTruthy();
+    expect(screen.getByText(/resets the watermark/i)).toBeTruthy();
+  });
+
+  it("fail-open: renders all rows when bootstrapStatus is null (fetch pending/errored)", () => {
+    renderTableWithStatus(
+      [
+        makeProcessRow({
+          process_id: "bootstrap",
+          mechanism: "bootstrap",
+          display_name: "First-install bootstrap",
+        }),
+        makeProcessRow({
+          process_id: "daily_cik_refresh",
+          mechanism: "scheduled_job",
+          display_name: "CIK refresh",
+        }),
+      ],
+      null,
+    );
+    expect(
+      screen.getByRole("link", { name: "First-install bootstrap" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: "CIK refresh" })).toBeTruthy();
+  });
 });

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -38,6 +38,20 @@ import {
 export interface ProcessesTableProps {
   readonly snapshot: ProcessListResponse;
   readonly onMutationSuccess: () => void;
+  // PR3a #1064 — bootstrap-incomplete render mode. When the
+  // operator's first-install bootstrap is not yet ``complete`` the
+  // table hides every non-bootstrap category so the only path
+  // forward is the bootstrap row's "Re-run failed" / "Re-run all"
+  // buttons. Pass ``null`` to render every row regardless (e.g. when
+  // the bootstrap-status fetch is pending or errored — fail-open).
+  // See ``.claude/skills/data-engineer/SKILL.md`` §7.1 for the
+  // operator design intent.
+  readonly bootstrapStatus?:
+    | "pending"
+    | "running"
+    | "complete"
+    | "partial_error"
+    | null;
 }
 
 interface RowErrorState {
@@ -48,6 +62,7 @@ interface RowErrorState {
 export function ProcessesTable({
   snapshot,
   onMutationSuccess,
+  bootstrapStatus = null,
 }: ProcessesTableProps) {
   const [selectedLane, setSelectedLane] = useState<ProcessLane | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -60,21 +75,39 @@ export function ProcessesTable({
     null,
   );
 
+  // PR3a #1064 — bootstrap-only mode. When bootstrap is not complete
+  // every other lane / mechanism is hidden so the operator sees only
+  // the bootstrap row and its child stages. The lane filter is also
+  // hidden in this mode (no point filtering a one-row list). The
+  // ``null`` fallback (status fetch pending or errored) is fail-open:
+  // render the full table so a bootstrap-status hiccup doesn't lock
+  // the operator out of every other category.
+  const bootstrapOnly =
+    bootstrapStatus !== null && bootstrapStatus !== "complete";
+
+  const baseRows = useMemo(
+    () =>
+      bootstrapOnly
+        ? snapshot.rows.filter((r) => r.mechanism === "bootstrap")
+        : snapshot.rows,
+    [snapshot.rows, bootstrapOnly],
+  );
+
   const counts = useMemo(() => {
     const out: Partial<Record<ProcessLane, number>> = {};
-    for (const r of snapshot.rows) {
+    for (const r of baseRows) {
       out[r.lane] = (out[r.lane] ?? 0) + 1;
     }
     return out;
-  }, [snapshot.rows]);
+  }, [baseRows]);
 
   const visibleRows = useMemo(() => {
     const rows =
       selectedLane === null
-        ? snapshot.rows
-        : snapshot.rows.filter((r) => r.lane === selectedLane);
+        ? baseRows
+        : baseRows.filter((r) => r.lane === selectedLane);
     return [...rows].sort(compareRows);
-  }, [snapshot.rows, selectedLane]);
+  }, [baseRows, selectedLane]);
 
   const setRowError = useCallback(
     (processId: string, patch: RowErrorState) => {
@@ -163,18 +196,35 @@ export function ProcessesTable({
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <LaneFilter
-          selected={selectedLane}
-          counts={counts}
-          onSelect={setSelectedLane}
-        />
-        <div className="text-xs text-slate-500 dark:text-slate-400">
-          {visibleRows.length} of {snapshot.rows.length} processes
+      {/* In bootstrap-only mode the lane chips would offer one option
+          (whichever lane the bootstrap row sits in) — hide them and use
+          the freed space for the explanatory banner. */}
+      {bootstrapOnly ? (
+        <div
+          role="status"
+          aria-label="Bootstrap incomplete — only the bootstrap row is shown"
+          className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-800 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-200"
+        >
+          First-install bootstrap is{" "}
+          <span className="font-semibold">{bootstrapStatus}</span>. Other
+          categories are gated until bootstrap reaches{" "}
+          <span className="font-semibold">complete</span> — re-run failed
+          stages or re-run all from the bootstrap row.
         </div>
-      </div>
+      ) : (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <LaneFilter
+            selected={selectedLane}
+            counts={counts}
+            onSelect={setSelectedLane}
+          />
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            {visibleRows.length} of {snapshot.rows.length} processes
+          </div>
+        </div>
+      )}
 
-      <StaleBanner rows={snapshot.rows} />
+      <StaleBanner rows={baseRows} />
 
       {snapshot.partial ? (
         <div
@@ -283,6 +333,15 @@ function FullWashConfirmDialog({
 }) {
   const [typed, setTyped] = useState("");
   const matches = typed === row.display_name;
+  // PR3a #1064 — bootstrap mechanism uses different verbs per
+  // data-engineer skill §7.3. Modal heading + body + confirm-button
+  // copy follow the same swap; the underlying POST stays mode='full_wash'.
+  const isBootstrap = row.mechanism === "bootstrap";
+  const heading = isBootstrap ? "Confirm Re-run all" : "Confirm full-wash";
+  const verb = isBootstrap ? "Re-run all" : "Full-wash";
+  const description = isBootstrap
+    ? `Re-run all resets every stage of ${row.display_name} to pending and replays the full first-install bootstrap. Stages re-run from scratch; ingested rows are deduped at the destination by ON CONFLICT.`
+    : `Full-wash resets the watermark for ${row.display_name} and re-fetches from epoch. ON CONFLICT idempotency prevents row duplication; the cost is bandwidth and rate-budget.`;
   return (
     <Modal
       isOpen={true}
@@ -293,13 +352,10 @@ function FullWashConfirmDialog({
         id="full-wash-confirm-title"
         className="text-sm font-semibold text-slate-800 dark:text-slate-100"
       >
-        Confirm full-wash
+        {heading}
       </h2>
       <p className="mt-2 text-sm text-slate-700 dark:text-slate-300">
-        Full-wash resets the watermark for{" "}
-        <span className="font-medium">{row.display_name}</span> and re-fetches
-        from epoch. ON CONFLICT idempotency prevents row duplication; the
-        cost is bandwidth and rate-budget.
+        {description}
       </p>
       <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
         Type the process name exactly to enable the confirm button.
@@ -330,7 +386,7 @@ function FullWashConfirmDialog({
           disabled={!matches || busy}
           className="rounded border border-red-400 bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700 dark:bg-red-700 dark:hover:bg-red-800"
         >
-          {busy ? "Triggering…" : "Full-wash"}
+          {busy ? "Triggering…" : verb}
         </button>
       </div>
     </Modal>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
+import { fetchBootstrapStatus } from "@/api/bootstrap";
 import { fetchCoverageSummary } from "@/api/coverage";
 import { fetchJobsOverview, runJob } from "@/api/jobs";
 import { fetchRecommendations } from "@/api/recommendations";
@@ -82,6 +83,11 @@ export function AdminPage() {
   // PR6 decommissioned the legacy SyncDashboard + LayerHealthList —
   // the orchestrator surfaces here as one row + DAG drill-in.
   const processes = useProcesses();
+  // PR3a #1064 — bootstrap-only render mode. When bootstrap_state.status
+  // is anything other than 'complete' the ProcessesTable hides every
+  // non-bootstrap category. Single read on mount; if a re-run flips
+  // status to 'complete' the operator's next refetchAll catches it.
+  const bootstrap = useAsync(fetchBootstrapStatus, []);
 
   // Extract the refetch refs as local const bindings so ESLint can
   // see their identity and verify the dep array without the suppression
@@ -93,6 +99,11 @@ export function AdminPage() {
   const refetchCoverage = coverage.refetch;
   const refetchJobs = jobs.refetch;
   const refetchRecs = recs.refetch;
+  // PR3a #1064 — re-poll bootstrap status on every refresh so a
+  // 'partial_error' → 'complete' transition surfaces without a page
+  // reload. Without this the operator stays in bootstrap-only render
+  // mode after a successful Re-run all (Codex pre-push round 1).
+  const refetchBootstrap = bootstrap.refetch;
 
   const refetchAll = useCallback(() => {
     refetchV2();
@@ -100,7 +111,15 @@ export function AdminPage() {
     refetchCoverage();
     refetchJobs();
     refetchRecs();
-  }, [refetchV2, refetchStatus, refetchCoverage, refetchJobs, refetchRecs]);
+    refetchBootstrap();
+  }, [
+    refetchV2,
+    refetchStatus,
+    refetchCoverage,
+    refetchJobs,
+    refetchRecs,
+    refetchBootstrap,
+  ]);
 
   const isRunning = status.data?.is_running ?? false;
   const refreshInterval = isRunning ? 10_000 : 60_000;
@@ -189,7 +208,18 @@ export function AdminPage() {
         ) : processes.data ? (
           <ProcessesTable
             snapshot={processes.data}
-            onMutationSuccess={processes.refetch}
+            onMutationSuccess={() => {
+              // After a trigger / cancel re-poll BOTH the processes
+              // snapshot AND bootstrap status — a successful Re-run
+              // all on the bootstrap row may flip status to
+              // 'complete', which lifts the bootstrap-only render
+              // gate. Refetching only `processes` would leave the
+              // table in bootstrap-only mode until the next cadence
+              // tick (Codex pre-push round 1).
+              processes.refetch();
+              refetchBootstrap();
+            }}
+            bootstrapStatus={bootstrap.data?.status ?? null}
           />
         ) : null}
       </CollapsibleSection>

--- a/frontend/src/pages/ProcessDetailPage.test.tsx
+++ b/frontend/src/pages/ProcessDetailPage.test.tsx
@@ -194,6 +194,35 @@ describe("ProcessDetailPage", () => {
       mode: "cooperative",
     });
   });
+
+  // PR3a #1064 — bootstrap mechanism uses different action verbs.
+  it("bootstrap mechanism labels Iterate as 'Re-run failed' and Full-wash as 'Re-run all'", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        display_name: "First-install bootstrap",
+        can_iterate: true,
+        can_full_wash: true,
+      }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    render(
+      <MemoryRouter initialEntries={["/admin/processes/bootstrap"]}>
+        <Routes>
+          <Route path="admin/processes/:id" element={<ProcessDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Re-run failed" }),
+      ).toBeTruthy(),
+    );
+    expect(screen.getByRole("button", { name: "Re-run all" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Iterate" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Full-wash" })).toBeNull();
+  });
 });
 
 

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -371,6 +371,21 @@ function ActionBar({
   onCancel: () => void;
 }) {
   const watermarkTooltip = row.watermark?.human ?? "no resume cursor";
+  // Mechanism-specific labels — bootstrap maps iterate/full_wash to
+  // "Re-run failed" / "Re-run all" per data-engineer skill §7.3.
+  const isBootstrap = row.mechanism === "bootstrap";
+  const iterateLabel = isBootstrap ? "Re-run failed" : "Iterate";
+  const fullWashLabel = isBootstrap ? "Re-run all" : "Full-wash";
+  const iterateTooltip = row.can_iterate
+    ? isBootstrap
+      ? "Resume incomplete + failed stages from where they stopped."
+      : watermarkTooltip
+    : `${iterateLabel} is not available right now.`;
+  const fullWashTooltip = row.can_full_wash
+    ? isBootstrap
+      ? "Reset every stage to pending; full first-install replay (typed-name confirm required)."
+      : "Reset watermark and re-fetch from epoch (typed-name confirm required)."
+    : `${fullWashLabel} is not available right now.`;
   return (
     <div className="flex flex-col items-end gap-1">
       <div className="flex items-center gap-2">
@@ -378,23 +393,19 @@ function ActionBar({
           type="button"
           onClick={onIterate}
           disabled={!row.can_iterate || busy}
-          title={row.can_iterate ? watermarkTooltip : "Iterate is not available right now."}
+          title={iterateTooltip}
           className="rounded border border-slate-300 bg-white px-3 py-1 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800/40"
         >
-          Iterate
+          {iterateLabel}
         </button>
         <button
           type="button"
           onClick={onFullWash}
           disabled={!row.can_full_wash || busy}
-          title={
-            row.can_full_wash
-              ? "Reset watermark and re-fetch from epoch (typed-name confirm required)."
-              : "Full-wash is not available right now."
-          }
+          title={fullWashTooltip}
           className="rounded border border-red-300 bg-white px-3 py-1 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-900 dark:bg-slate-900 dark:text-red-300 dark:hover:bg-red-950/40"
         >
-          Full-wash
+          {fullWashLabel}
         </button>
         <button
           type="button"
@@ -1203,18 +1214,34 @@ function FullWashConfirmDialog({
 }) {
   const [typed, setTyped] = useState("");
   const matches = typed === row.display_name;
+  // PR3a #1064 — bootstrap mechanism uses different verbs.
+  const isBootstrap = row.mechanism === "bootstrap";
+  const heading = isBootstrap ? "Confirm Re-run all" : "Confirm full-wash";
+  const verb = isBootstrap ? "Re-run all" : "Full-wash";
   return (
     <Modal isOpen={true} onRequestClose={onCancel} labelledBy="detail-fw-title">
       <h2
         id="detail-fw-title"
         className="text-sm font-semibold text-slate-800 dark:text-slate-100"
       >
-        Confirm full-wash
+        {heading}
       </h2>
       <p className="mt-2 text-sm text-slate-700 dark:text-slate-300">
-        Full-wash resets the watermark for{" "}
-        <span className="font-medium">{row.display_name}</span> and re-fetches
-        from epoch.
+        {isBootstrap ? (
+          <>
+            Re-run all resets every stage of{" "}
+            <span className="font-medium">{row.display_name}</span> to pending
+            and replays the full first-install bootstrap. Stages re-run from
+            scratch; ingested rows are deduped at the destination by ON
+            CONFLICT.
+          </>
+        ) : (
+          <>
+            Full-wash resets the watermark for{" "}
+            <span className="font-medium">{row.display_name}</span> and
+            re-fetches from epoch.
+          </>
+        )}
       </p>
       <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
         Type the process name exactly to enable the confirm button.
@@ -1245,7 +1272,7 @@ function FullWashConfirmDialog({
           disabled={!matches || busy}
           className="rounded border border-red-400 bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700 dark:bg-red-700 dark:hover:bg-red-800"
         >
-          {busy ? "Triggering…" : "Full-wash"}
+          {busy ? "Triggering…" : verb}
         </button>
       </div>
     </Modal>


### PR DESCRIPTION
## Summary
- ``ProcessesTable`` accepts ``bootstrapStatus`` prop; when non-null and not ``complete``, hide every non-bootstrap row + lane filter, render an explanatory banner.
- ``ProcessRow`` + ``ProcessDetailPage`` ActionBar swap "Iterate" / "Full-wash" labels to "Re-run failed" / "Re-run all" on bootstrap mechanism; underlying POST mode unchanged.
- ``FullWashConfirmDialog`` heading + body + confirm-button copy follow the swap (replay-all copy on bootstrap, watermark-reset copy on scheduled).
- Bootstrap row omits cadence column (stages run as a fixed sequence, not scheduled).
- ``AdminPage`` fetches ``/system/bootstrap/status``; threads status into the table; refetches bootstrap on every ``refetchAll`` tick AND on per-row mutation success so a successful "Re-run all" lifts the bootstrap-only gate immediately.

## Why
Operator audit 2026-05-10 — bootstrap was in ``partial_error`` and the admin page showed every category greyed-out instead of hiding them, masking that the only path forward is a bootstrap re-run. Captured in ``.claude/skills/data-engineer/SKILL.md`` §7.1–7.3 as locked operator design intent. Pre-push Codex flagged stale-status-after-mutation + modal copy regression — both fixed before push.

## Test plan
- [x] ``pnpm --dir frontend typecheck``
- [x] ``pnpm test:unit`` (touched files): 69/69 (5 new — bootstrap-only filter, fallback fail-open, label/copy swap, modal copy)
- [x] ``pnpm test:unit`` (full): 840/851 — 11 pre-existing theme failures unrelated (confirmed on main)
- [x] ``uv run ruff check . && uv run ruff format --check .``
- [x] Codex spec context already in data-engineer skill §7; Codex pre-push review (no remaining findings)
- [ ] Smoke on dev: ``bootstrap_state.status='partial_error'`` → ``/admin`` shows only the bootstrap row + banner + "Re-run failed" / "Re-run all" buttons; clicking "Re-run all" opens the verb-swapped modal with replay copy.
- [ ] Smoke on dev: ``status='complete'`` → all categories visible, lane filter present, "Iterate" / "Full-wash" labels intact on scheduled rows.

Refs #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)