### PR TITLE
fix(#1092): bootstrap cancel — thread modal mode selection through helper

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -1462,18 +1462,26 @@ def cancel_process(
 
     if mechanism == "bootstrap":
         try:
-            run_id = bootstrap_cancel_run(conn, requested_by_operator_id=operator_uuid)
+            # PR3b #1092 #1064 — thread the operator's modal selection
+            # through to ``cancel_run``. Pre-fix the helper hardcoded
+            # ``mode='cooperative'`` regardless of choice; the FE's
+            # terminate disclosure was honest copy ("worker treats as
+            # cooperative; restart jobs to kill") but the durable
+            # ``process_stop_requests.mode`` row recorded ``cooperative``
+            # so post-mortem audits couldn't tell what the operator
+            # actually asked for. Worker behaviour stays cooperative
+            # (genuine terminate requires a jobs-process restart per
+            # the cancel runbook); the durable mode signal records
+            # operator intent.
+            run_id = bootstrap_cancel_run(
+                conn,
+                requested_by_operator_id=operator_uuid,
+                mode=body.mode,
+            )
         except BootstrapNotRunning as exc:
             raise _conflict("no_active_run") from exc
         except StopAlreadyPendingError as exc:
             raise _conflict("stop_already_pending") from exc
-        # bootstrap_state.cancel_run wraps everything in conn.transaction()
-        # which auto-commits on clean exit; ``mode`` is currently always
-        # 'cooperative' in the helper. PR3's body validates 'terminate'
-        # input but the bootstrap cancel helper does not yet distinguish
-        # — PR2 only landed cooperative. The bootstrap cancel runbook
-        # (PR10) documents the operator path: cooperative cancel +
-        # restart jobs is the equivalent of terminate.
         return CancelResponse(target_run_kind="bootstrap_run", target_run_id=run_id)
 
     # mechanism == 'scheduled_job'

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -691,10 +691,21 @@ def cancel_run(
     conn: psycopg.Connection[Any],
     *,
     requested_by_operator_id: UUID | None,
+    mode: Literal["cooperative", "terminate"] = "cooperative",
 ) -> int:
-    """Cooperatively cancel the in-flight bootstrap run.
+    """Cancel the in-flight bootstrap run.
 
     Spec §Cancel semantics — cooperative + §PR2.
+
+    Issue #1092 (PR3b #1064): ``mode`` plumbed through from the FE
+    cancel modal selection. Pre-fix the helper hardcoded
+    ``mode='cooperative'`` regardless of operator choice. ``terminate``
+    in v1 still writes the same stop row — the worker observes it at
+    the next checkpoint and acts cooperatively. The operator-visible
+    distinction lives in ``process_stop_requests.mode`` so post-mortem
+    auditing can tell what the operator asked for vs what the worker
+    did. Genuine terminate (forcibly kill stuck worker) requires a
+    jobs-process restart per the cancel runbook.
 
     One-transaction flow. Lock-order discipline (Codex pre-push round
     1 BLOCKING B1): we acquire the bootstrap_runs row lock FIRST and
@@ -751,7 +762,7 @@ def cancel_run(
             mechanism="bootstrap",
             target_run_kind="bootstrap_run",
             target_run_id=run_id,
-            mode="cooperative",
+            mode=mode,
             requested_by_operator_id=requested_by_operator_id,
         )
 

--- a/tests/test_bootstrap_cancel.py
+++ b/tests/test_bootstrap_cancel.py
@@ -11,6 +11,8 @@ against the truncated test DB.
 
 from __future__ import annotations
 
+from typing import Any
+
 import psycopg
 import pytest
 
@@ -120,6 +122,85 @@ def test_cancel_run_raises_when_not_running(
     # state='pending'
     with pytest.raises(BootstrapNotRunning):
         cancel_run(ebull_test_conn, requested_by_operator_id=None)
+
+
+def test_cancel_run_records_terminate_mode_when_requested(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR3b #1092 — operator's modal selection (cooperative vs terminate)
+    flows through to ``process_stop_requests.mode``.
+
+    Pre-fix the helper hardcoded ``mode='cooperative'``, masking what
+    the operator actually asked for. Worker behaviour stays cooperative
+    in both cases (genuine terminate requires a jobs-process restart
+    per the cancel runbook); only the durable mode signal differs.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    cancelled_run_id = cancel_run(
+        ebull_test_conn,
+        requested_by_operator_id=None,
+        mode="terminate",
+    )
+    ebull_test_conn.commit()
+
+    assert cancelled_run_id == run_id
+    stop = is_stop_requested(
+        ebull_test_conn,
+        target_run_kind="bootstrap_run",
+        target_run_id=run_id,
+    )
+    assert stop is not None
+    assert stop.mode == "terminate"
+
+
+def test_processes_bootstrap_cancel_api_persists_terminate_mode(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR3b #1092 — POST /system/processes/bootstrap/cancel with
+    ``mode='terminate'`` reaches the helper which persists
+    ``terminate`` on the durable stop row.
+
+    Codex pre-push round 1 — the helper-level test alone would still
+    pass if the API path reverted to a hardcoded cooperative call;
+    this test pins the wiring at the request boundary.
+    """
+    from fastapi.testclient import TestClient
+
+    from app.db import get_conn
+    from app.main import app
+
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    def _yield_conn() -> Any:
+        yield ebull_test_conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    try:
+        client = TestClient(app)
+        resp = client.post(
+            "/system/processes/bootstrap/cancel",
+            json={"mode": "terminate"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["target_run_kind"] == "bootstrap_run"
+    assert body["target_run_id"] == run_id
+
+    stop = is_stop_requested(
+        ebull_test_conn,
+        target_run_kind="bootstrap_run",
+        target_run_id=run_id,
+    )
+    assert stop is not None
+    assert stop.mode == "terminate"
 
 
 def test_cancel_run_raises_when_complete(


### PR DESCRIPTION
## Summary
- ``app/services/bootstrap_state.py::cancel_run`` previously hardcoded ``mode='cooperative'``. Adds a ``mode: Literal["cooperative", "terminate"]`` parameter (cooperative default) and passes the value to ``request_stop`` so ``process_stop_requests.mode`` records what the operator asked for.
- ``app/api/processes.py`` cancel handler for bootstrap mechanism now passes ``body.mode`` through. Stale comment block removed.
- Tests pin both the helper round-trip AND the ``/system/processes/bootstrap/cancel`` API wiring (Codex pre-push round 1 finding).

## Why
Operator-visible mismatch: the FE cancel modal exposes a Terminate option behind a More disclosure with honest copy, but the durable mode signal in ``process_stop_requests`` always recorded ``cooperative`` regardless of selection. Post-mortem audits couldn't tell what the operator actually asked for.

Worker behaviour stays cooperative on both modes — genuine terminate requires a jobs-process restart per the cancel runbook. The change here is the operator-intent audit signal.

## Test plan
- [x] ``uv run ruff check . && uv run ruff format --check . && uv run pyright``
- [x] ``uv run pytest tests/test_bootstrap_cancel.py -n 0`` — 16/17 (1 pre-existing fixture failure unrelated, confirmed on clean main)
- [x] New test: ``cancel_run(mode="terminate")`` persists terminate on stop row
- [x] New test: POST ``/system/processes/bootstrap/cancel`` with ``{"mode":"terminate"}`` round-trips terminate (pins API wiring, not just helper)
- [x] Codex pre-push (checkpoint 2) — flagged missing API integration test, addressed pre-push

Closes #1092
Refs #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)