### PR TITLE
fix(#1093): bootstrap stages — cancelled status distinct from error

### DIFF
--- a/app/api/bootstrap.py
+++ b/app/api/bootstrap.py
@@ -65,7 +65,7 @@ router = APIRouter(
 
 BootstrapApiStatus = Literal["pending", "running", "complete", "partial_error", "cancelled"]
 LaneApi = Literal["init", "etoro", "sec", "sec_rate", "sec_bulk_download", "db"]
-StageApiStatus = Literal["pending", "running", "success", "error", "skipped", "blocked"]
+StageApiStatus = Literal["pending", "running", "success", "error", "skipped", "blocked", "cancelled"]
 
 
 class BootstrapArchiveResultResponse(BaseModel):

--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -285,7 +285,7 @@ class BootstrapTimelineStageResponse(BaseModel):
     stage_order: int
     lane: str
     job_name: str
-    status: Literal["pending", "running", "success", "error", "skipped", "blocked"]
+    status: Literal["pending", "running", "success", "error", "skipped", "blocked", "cancelled"]
     started_at: datetime | None
     completed_at: datetime | None
     last_error: str | None

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 BootstrapStatus = Literal["pending", "running", "complete", "partial_error", "cancelled"]
 RunStatus = Literal["running", "complete", "partial_error", "cancelled"]
-StageStatus = Literal["pending", "running", "success", "error", "skipped", "blocked"]
+StageStatus = Literal["pending", "running", "success", "error", "skipped", "blocked", "cancelled"]
 Lane = Literal["init", "etoro", "sec", "sec_rate", "sec_bulk_download", "db"]
 
 
@@ -528,7 +528,7 @@ def finalize_run(
             """
             SELECT COUNT(*) FROM bootstrap_stages
              WHERE bootstrap_run_id = %(run_id)s
-               AND status IN ('error', 'blocked')
+               AND status IN ('error', 'blocked', 'cancelled')
             """,
             {"run_id": run_id},
         ).fetchone()
@@ -604,7 +604,7 @@ def reset_failed_stages_for_retry(
             SELECT lane, MIN(stage_order)
               FROM bootstrap_stages
              WHERE bootstrap_run_id = %(run_id)s
-               AND status IN ('error', 'blocked')
+               AND status IN ('error', 'blocked', 'cancelled')
              GROUP BY lane
             """,
             {"run_id": run_id},
@@ -821,10 +821,15 @@ def mark_run_cancelled(
                 f"state {current_status!r}; cannot cancel a finalised run"
             )
 
+        # PR3c #1093: operator cancel-mid-run sweeps running + pending
+        # stages to ``cancelled`` (not ``error``) so the Timeline can
+        # tone gray rather than red. Genuine error stages stay red. The
+        # ``cancelled by operator`` reason still lands in ``last_error``
+        # for audit clarity.
         conn.execute(
             """
             UPDATE bootstrap_stages
-               SET status       = 'error',
+               SET status       = 'cancelled',
                    completed_at = now(),
                    last_error   = COALESCE(last_error, %(reason)s)
              WHERE bootstrap_run_id = %(run_id)s
@@ -835,7 +840,7 @@ def mark_run_cancelled(
         conn.execute(
             """
             UPDATE bootstrap_stages
-               SET status       = 'error',
+               SET status       = 'cancelled',
                    completed_at = now(),
                    last_error   = %(reason)s
              WHERE bootstrap_run_id = %(run_id)s
@@ -891,6 +896,13 @@ def reap_orphaned_running(
 
     All in one transaction. Idempotent on a state that is not
     ``running``; returns True if a sweep occurred, False otherwise.
+
+    PR3c #1093: when the boot-recovery sweep observes
+    ``cancel_requested_at IS NOT NULL`` (operator clicked Cancel
+    before the jobs process died), running + pending stages are swept
+    to ``cancelled`` rather than ``error`` so the Timeline tones them
+    gray (operator-driven termination) instead of red (genuine
+    failure).
     """
     with conn.transaction():
         state = conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1 FOR UPDATE").fetchone()
@@ -912,27 +924,41 @@ def reap_orphaned_running(
         ).fetchone()
         cancel_requested = bool(run_meta[0]) if run_meta is not None else False
 
+        # PR3c #1093: cancel-driven boot recovery writes ``cancelled``;
+        # generic crash recovery still writes ``error`` (server died,
+        # not operator intent). Branch on cancel_requested up-front so
+        # both UPDATEs use the matching status value.
+        terminal_status = "cancelled" if cancel_requested else "error"
+        running_reason = (
+            "cancelled by operator before jobs restart" if cancel_requested else "jobs process restarted mid-run"
+        )
+        pending_reason = (
+            "cancelled by operator before jobs restart"
+            if cancel_requested
+            else "orchestrator did not dispatch before restart"
+        )
+
         conn.execute(
             """
             UPDATE bootstrap_stages
-               SET status       = 'error',
+               SET status       = %(status)s,
                    completed_at = now(),
-                   last_error   = 'jobs process restarted mid-run'
+                   last_error   = %(reason)s
              WHERE bootstrap_run_id = %(run_id)s
                AND status           = 'running'
             """,
-            {"run_id": last_run_id},
+            {"run_id": last_run_id, "status": terminal_status, "reason": running_reason},
         )
         conn.execute(
             """
             UPDATE bootstrap_stages
-               SET status       = 'error',
+               SET status       = %(status)s,
                    completed_at = now(),
-                   last_error   = 'orchestrator did not dispatch before restart'
+                   last_error   = %(reason)s
              WHERE bootstrap_run_id = %(run_id)s
                AND status           = 'pending'
             """,
-            {"run_id": last_run_id},
+            {"run_id": last_run_id, "status": terminal_status, "reason": pending_reason},
         )
 
         if cancel_requested:

--- a/frontend/src/api/bootstrap.ts
+++ b/frontend/src/api/bootstrap.ts
@@ -21,7 +21,11 @@ export type BootstrapStageStatus =
   | "skipped"
   // ``blocked`` (#1020): orchestrator never invoked the stage because
   // a `requires` upstream stage finished error/blocked.
-  | "blocked";
+  | "blocked"
+  // ``cancelled`` (PR3c #1093): operator-cancelled mid-run. Distinct
+  // from ``error`` so the Timeline can tone gray (operator-driven
+  // termination) instead of red (genuine failure).
+  | "cancelled";
 
 export type BootstrapLane =
   | "init"

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1386,7 +1386,12 @@ export type BootstrapStageStatus =
   | "success"
   | "error"
   | "skipped"
-  | "blocked";
+  | "blocked"
+  // PR3c #1093: operator-cancelled mid-run. Distinct from ``error`` so
+  // the Timeline can tone gray (operator-driven termination) instead
+  // of red (genuine failure). Mirrors ``app/services/bootstrap_state.py``
+  // sql/142 CHECK constraint extension.
+  | "cancelled";
 
 export interface BootstrapTimelineArchiveResponse {
   archive_name: string;

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -906,6 +906,14 @@ const STAGE_STATUS_TONE: Record<string, string> = {
     "border-slate-300 bg-slate-50 text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400",
   blocked:
     "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
+  // PR3c #1093: operator-cancelled stage. Gray tone — visually
+  // distinct from red (genuine failure) so the operator can tell at a
+  // glance which stages were stopped by their own cancel vs which
+  // failed on their own. Slightly darker than ``pending`` / ``skipped``
+  // gray so the cancelled stage doesn't look interchangeable with
+  // not-yet-attempted.
+  cancelled:
+    "border-slate-400 bg-slate-100 text-slate-700 dark:border-slate-600 dark:bg-slate-800/60 dark:text-slate-300 italic",
 };
 
 const ARCHIVE_TONE: Record<string, string> = {

--- a/sql/142_bootstrap_stages_status_cancelled.sql
+++ b/sql/142_bootstrap_stages_status_cancelled.sql
@@ -1,0 +1,36 @@
+-- Migration 142 — bootstrap_stages.status add 'cancelled'
+--
+-- Issue #1093 (PR3c #1064 follow-up sequence). Operator audit
+-- 2026-05-10: when a bootstrap run is cancelled, the running and
+-- pending stages today get swept to ``status='error'`` by
+-- ``mark_run_cancelled`` and ``reap_orphaned_running``. The Timeline
+-- can't tell those apart from genuine errors, so they all render red
+-- with the ``cancelled by operator`` message buried in ``last_error``.
+--
+-- Operator-correct shape: stages cancelled by operator action carry
+-- their own status value so the Timeline tones them gray (or amber)
+-- rather than red. Genuine errors (parse failures, SEC 5xx, schema
+-- regression) keep ``status='error'`` for the existing red-tone path.
+--
+-- This migration extends the CHECK constraint to allow ``cancelled``;
+-- the application code in ``bootstrap_state.py`` flips the UPDATE
+-- targets to write ``cancelled`` instead of ``error`` for the cancel
+-- path.
+--
+-- Idempotent. Existing rows untouched (the migration adds an allowed
+-- value; previously-committed ``error`` rows that were really cancels
+-- stay as-is — backfilling them risks rewriting genuine error rows
+-- and is not worth the ambiguity. Future cancels carry the new
+-- value).
+
+ALTER TABLE bootstrap_stages
+    DROP CONSTRAINT IF EXISTS bootstrap_stages_status_check;
+
+ALTER TABLE bootstrap_stages
+    ADD CONSTRAINT bootstrap_stages_status_check
+    CHECK (status IN ('pending', 'running', 'success', 'error', 'skipped', 'blocked', 'cancelled'));
+
+COMMENT ON COLUMN bootstrap_stages.status IS
+    'Stage lifecycle. pending → running → (success | error | skipped | cancelled). '
+    'blocked = upstream requires-stage failed. cancelled (#1093) = operator-cancelled '
+    'mid-run; distinct from error so the Timeline can tone gray instead of red.';

--- a/tests/test_bootstrap_cancel.py
+++ b/tests/test_bootstrap_cancel.py
@@ -183,10 +183,13 @@ def test_mark_run_cancelled_terminalises_run_and_state(
     assert snap.run_status == "cancelled"
     by_key = {s.stage_key: s for s in snap.stages}
     assert by_key["alpha"].status == "success"
-    # Running stage swept to error so re-Iterate retries it.
-    assert by_key["bravo"].status == "error"
-    # Pending stage swept to error too — retry-failed picks it up.
-    assert by_key["charlie"].status == "error"
+    # PR3c #1093: running + pending stages swept to ``cancelled``
+    # instead of ``error`` so the Timeline can tone gray (operator
+    # cancel) rather than red (genuine failure). Re-Iterate's
+    # ``reset_failed_stages_for_retry`` resets cancelled stages too,
+    # so retry semantics stay intact.
+    assert by_key["bravo"].status == "cancelled"
+    assert by_key["charlie"].status == "cancelled"
 
     state = read_state(ebull_test_conn)
     assert state.status == "cancelled"
@@ -306,6 +309,95 @@ def test_reap_orphaned_running_routes_cancel_requested_to_cancelled(
     assert notes is not None
     assert notes[1] == "cancelled"
     assert "terminated by operator before jobs restart" in (notes[0] or "")
+
+
+def test_reap_orphaned_running_cancel_path_writes_cancelled_stage_status(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR3c #1093 — when boot-recovery routes the cancel path, running
+    + pending stages get ``status='cancelled'`` not ``status='error'``.
+    The Timeline tones cancelled stages gray (operator-driven) instead
+    of red (genuine failure).
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+
+    reap_orphaned_running(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    rows = ebull_test_conn.execute(
+        "SELECT stage_key, status FROM bootstrap_stages WHERE bootstrap_run_id = %s",
+        (run_id,),
+    ).fetchall()
+    by_key = dict(rows)
+    # alpha was running → cancelled (operator-cancel branch)
+    assert by_key["alpha"] == "cancelled"
+    # bravo + charlie were pending → cancelled
+    assert by_key["bravo"] == "cancelled"
+    assert by_key["charlie"] == "cancelled"
+
+
+def test_reap_orphaned_running_no_cancel_path_keeps_error_stage_status(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Generic crash recovery (no operator cancel) still writes
+    ``status='error'`` on running + pending stages — these were
+    server-side failures, not operator-driven termination.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    ebull_test_conn.commit()
+
+    reap_orphaned_running(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    rows = ebull_test_conn.execute(
+        "SELECT stage_key, status FROM bootstrap_stages WHERE bootstrap_run_id = %s",
+        (run_id,),
+    ).fetchall()
+    by_key = dict(rows)
+    assert by_key["alpha"] == "error"
+    assert by_key["bravo"] == "error"
+    assert by_key["charlie"] == "error"
+
+
+def test_reset_failed_for_retry_picks_up_cancelled_stages(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR3c #1093 — re-Iterate after operator cancel resets cancelled
+    stages back to pending so the retry can pick them up. Without this,
+    a cancelled stage would stay terminal and the retry would never
+    reach it.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="bravo")
+    ebull_test_conn.commit()
+
+    mark_run_cancelled(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    # Bravo + charlie are now ``cancelled``; retry-failed should reset
+    # them to ``pending`` (cancelled is treated like error/blocked for
+    # the lane-min-order logic).
+    reset = reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    assert reset > 0
+
+    rows = ebull_test_conn.execute(
+        "SELECT stage_key, status FROM bootstrap_stages WHERE bootstrap_run_id = %s",
+        (run_id,),
+    ).fetchall()
+    by_key = dict(rows)
+    assert by_key["alpha"] == "success"  # untouched, prior success
+    assert by_key["bravo"] == "pending"
+    assert by_key["charlie"] == "pending"
 
 
 def test_reap_orphaned_running_partial_error_when_no_cancel(


### PR DESCRIPTION
## Summary
- ``sql/142`` extends ``bootstrap_stages.status`` CHECK constraint to allow ``cancelled``.
- ``mark_run_cancelled`` sweeps running + pending stages to ``cancelled`` (was ``error``); cancel reason still lands in ``last_error`` for audit.
- ``reap_orphaned_running`` branches: cancel-requested writes ``cancelled``, generic crash keeps ``error``.
- ``reset_failed_stages_for_retry`` picks up ``cancelled`` stages alongside ``error`` + ``blocked`` so re-Iterate after cancel resumes cleanly.
- Pydantic Literal drift addressed across ``StageStatus`` (bootstrap_state), ``StageApiStatus`` (api/bootstrap), ``BootstrapTimelineStageResponse`` (api/processes) — without these, cancelled stages would 500 ``/system/bootstrap/status`` + timeline endpoints (Codex pre-push BLOCKING).
- FE ``BootstrapStageStatus`` union extended; Timeline ``STAGE_STATUS_TONE`` adds gray-italic for ``cancelled``.

## Why
Operator audit: cancelled stages were indistinguishable from genuinely-errored stages. Both rendered red with the cancel reason buried in ``last_error``. Operator-correct shape is a separate ``cancelled`` value with its own gray tone, leaving red for actual failures.

## Test plan
- [x] ``uv run ruff check . && uv run ruff format --check .``
- [x] ``uv run pyright`` on touched files: 0 errors
- [x] ``pnpm --dir frontend typecheck``
- [x] ``uv run pytest tests/test_bootstrap_cancel.py tests/test_bootstrap_state.py tests/smoke/test_app_boots.py tests/test_processes_endpoints.py -n 0`` — 68/69 (1 pre-existing fixture unrelated, confirmed on main)
- [x] New tests pin the schema + sweep semantics for cancel-path, no-cancel-path, reset-after-cancel
- [x] Codex pre-push: 3 BLOCKING findings (2x Pydantic drift + untracked sql) all addressed pre-push
- [ ] Smoke on dev: trigger bootstrap → Cancel mid-run → Timeline shows gray-italic cancelled tone (not red error)
- [ ] Smoke: re-Iterate after cancel — cancelled stages reset to pending and re-run

Closes #1093
Refs #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)