### PR TITLE
feat(#1064): PR3d — bootstrap stage cancel-signal propagation

### DIFF
--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -44,7 +44,9 @@ from app.providers.implementations.sec_submissions import (
     check_freshness,
     parse_submissions_page,
 )
+from app.services.bootstrap_state import BootstrapStageCancelled
 from app.services.data_freshness import seed_scheduler_from_manifest
+from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
 from app.services.sec_manifest import is_amendment_form, map_form_to_source, record_manifest_entry
 
 logger = logging.getLogger(__name__)
@@ -283,7 +285,19 @@ def run_first_install_drain(
         )
 
     skip_issuer_http = rows_seeded_from_filing_events > 0
-    for subject, cik in _iter_in_universe_subjects(conn):  # type: ignore[misc]
+    # PR3d #1064 — cancel-poll cadence. The drain iterates ~12k CIKs
+    # at 10 req/s, ~21 minutes wall-clock. Polling for the bootstrap
+    # cancel signal every 50 CIKs keeps observation latency under
+    # ~5 seconds without flooding the DB. Outside a bootstrap dispatch
+    # the helper short-circuits to False (contextvar unset), so
+    # scheduled / manual triggers of this job are unaffected.
+    _CANCEL_POLL_EVERY_N = 50
+    for n, (subject, cik) in enumerate(_iter_in_universe_subjects(conn)):  # type: ignore[misc]
+        if n % _CANCEL_POLL_EVERY_N == 0 and bootstrap_cancel_requested():
+            raise BootstrapStageCancelled(
+                f"first-install drain cancelled by operator after {ciks_processed} CIKs",
+                stage_key="sec_first_install_drain",
+            )
         if max_subjects is not None and ciks_processed >= max_subjects:
             break
         # #1044 fast-path: when filing_events seeded the issuer manifest

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -396,6 +396,12 @@ class _StageOutcome:
     success: bool
     error: str | None
     skipped: bool = False
+    # PR3d #1064 — operator-cancel observed mid-stage. The dispatcher
+    # maps this onto stage status='cancelled' (not 'error') so the
+    # Timeline tones gray instead of red. The next dispatcher
+    # iteration's run-level cancel checkpoint then sweeps remaining
+    # stages and terminalises the run.
+    cancelled: bool = False
 
 
 def _run_one_stage(
@@ -440,8 +446,17 @@ def _run_one_stage(
     # cutoff + ``source_label`` override.
     from app.jobs.runtime import _params_snapshot_var
 
+    # PR3d #1064 — expose the cancel signal to long-running invokers.
+    # Stages with multi-minute loops poll
+    # ``bootstrap_cancel_requested()`` and raise
+    # ``BootstrapStageCancelled`` to bail out cooperatively. The
+    # context manager scopes the contextvar so scheduled / manual
+    # triggers of the same job (outside bootstrap) see no signal.
+    from app.services.bootstrap_state import BootstrapStageCancelled, mark_stage_cancelled
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
     try:
-        with JobLock(database_url, job_name):
+        with JobLock(database_url, job_name), active_bootstrap_run(run_id):
             snap_token = _params_snapshot_var.set(effective_params)
             try:
                 invoker(effective_params)
@@ -456,6 +471,22 @@ def _run_one_stage(
             mark_stage_error(conn, run_id=run_id, stage_key=stage_key, error_message=message)
             conn.commit()
         return _StageOutcome(stage_key=stage_key, success=False, error=message)
+    except BootstrapStageCancelled as exc:
+        # PR3d #1064 — operator clicked Cancel mid-stage; the invoker
+        # observed the signal at one of its checkpoints and bailed
+        # out. Mark the stage ``cancelled`` (not ``error``) so the
+        # Timeline tones gray. The next dispatcher iteration's
+        # run-level cancel checkpoint terminalises remaining stages.
+        message = str(exc) or "stage cancelled by operator"
+        logger.info(
+            "bootstrap stage %s observed cancel signal; marking cancelled (%s)",
+            stage_key,
+            message,
+        )
+        with psycopg.connect(database_url) as conn:
+            mark_stage_cancelled(conn, run_id=run_id, stage_key=stage_key, reason=message)
+            conn.commit()
+        return _StageOutcome(stage_key=stage_key, success=False, error=message, cancelled=True)
     except BootstrapPhaseSkipped as exc:
         # Operator-policy skip: A3 wrote a fallback manifest because
         # bandwidth was below threshold, and the legacy chain handles
@@ -814,6 +845,15 @@ def _phase_batched_dispatch(
             if outcome.skipped:
                 statuses[stage_key] = "skipped"
                 logger.info("bootstrap dispatcher: %s SKIPPED", stage_key)
+            elif outcome.cancelled:
+                # PR3d #1064 — stage observed operator cancel
+                # mid-loop and exited cooperatively. Status maps to
+                # 'cancelled' so the Timeline tones gray; the
+                # outer cancel checkpoint at the next loop iteration
+                # picks up the run-level cancel signal and sweeps
+                # remaining stages.
+                statuses[stage_key] = "cancelled"
+                logger.info("bootstrap dispatcher: %s CANCELLED (%s)", stage_key, outcome.error)
             elif outcome.success:
                 statuses[stage_key] = "success"
                 logger.info("bootstrap dispatcher: %s OK", stage_key)

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -68,6 +68,28 @@ class BootstrapNotRunning(RuntimeError):
     """
 
 
+class BootstrapStageCancelled(RuntimeError):
+    """Raised by a long-running stage invoker when it observes the
+    bootstrap-run cancel signal at one of its checkpoints.
+
+    Issue #1064 PR3d. Stages with multi-minute loops (the SEC drain,
+    the 13F sweep) poll ``bootstrap_cancel_requested()`` periodically;
+    when the operator clicks Cancel the helper returns True and the
+    invoker raises this exception to bail out cooperatively. The
+    bootstrap orchestrator's ``_run_one_stage`` catches it, marks the
+    stage as ``cancelled`` (PR3c #1093), and the next dispatcher
+    iteration's run-level checkpoint terminalises the entire run.
+
+    The exception carries the stage_key (when known) so the operator
+    audit log can name the stage that observed the cancel; default
+    empty string for stages that don't thread the key through.
+    """
+
+    def __init__(self, message: str = "stage cancelled by operator", stage_key: str = "") -> None:
+        super().__init__(message)
+        self.stage_key = stage_key
+
+
 @dataclass(frozen=True)
 class StageSpec:
     """Static definition of a stage. Lives in code, not DB.
@@ -413,6 +435,43 @@ def mark_stage_skipped(
         """
         UPDATE bootstrap_stages
            SET status       = 'skipped',
+               completed_at = now(),
+               last_error   = %(reason)s
+         WHERE bootstrap_run_id = %(run_id)s
+           AND stage_key        = %(stage_key)s
+           AND status           IN ('running', 'pending')
+        """,
+        {
+            "run_id": run_id,
+            "stage_key": stage_key,
+            "reason": reason[:1000],
+        },
+    )
+
+
+def mark_stage_cancelled(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    stage_key: str,
+    reason: str,
+) -> None:
+    """Mark a stage as ``cancelled`` — operator clicked Cancel mid-stage.
+
+    Issue #1064 PR3d (#1093 schema migration). Distinct from ``error``
+    (genuine failure) and ``skipped`` (operator-policy bypass) — this
+    fires when the stage's invoker observes ``cancel_requested_at``
+    at one of its long-loop checkpoints and raises
+    ``BootstrapStageCancelled``. The orchestrator's
+    ``_run_one_stage`` catches the exception and calls this helper.
+
+    Refuses to overwrite terminal states; allows the same
+    ``running``/``pending`` transition window as ``mark_stage_skipped``.
+    """
+    conn.execute(
+        """
+        UPDATE bootstrap_stages
+           SET status       = 'cancelled',
                completed_at = now(),
                last_error   = %(reason)s
          WHERE bootstrap_run_id = %(run_id)s
@@ -1021,6 +1080,7 @@ def reap_orphaned_running(
 __all__ = [
     "BootstrapAlreadyRunning",
     "BootstrapNotRunning",
+    "BootstrapStageCancelled",
     "BootstrapState",
     "BootstrapStatus",
     "Lane",
@@ -1035,6 +1095,7 @@ __all__ = [
     "force_mark_complete",
     "mark_run_cancelled",
     "mark_stage_blocked",
+    "mark_stage_cancelled",
     "mark_stage_error",
     "mark_stage_running",
     "mark_stage_skipped",

--- a/app/services/processes/bootstrap_cancel_signal.py
+++ b/app/services/processes/bootstrap_cancel_signal.py
@@ -1,0 +1,135 @@
+"""Bootstrap cancel-signal plumbing for long-running stage invokers.
+
+Issue #1064 PR3d (`#1093` schema is the prerequisite). Operator clicks
+Cancel on the bootstrap row → ``cancel_run`` writes
+``bootstrap_runs.cancel_requested_at`` and the
+``process_stop_requests`` row. The orchestrator's main dispatcher
+loop checks ``is_stop_requested`` between stage batches but the
+checkpoint cadence is "between stages, not within". A 20-minute SEC
+drain or 30-minute 13F sweep observes the cancel only at completion.
+
+This module exposes the signal to long-running stages so they can
+poll periodically and bail out cooperatively. The pattern:
+
+    from app.services.processes.bootstrap_cancel_signal import (
+        bootstrap_cancel_requested,
+    )
+    from app.services.bootstrap_state import BootstrapStageCancelled
+
+    for n, item in enumerate(big_iterable):
+        if n % 50 == 0 and bootstrap_cancel_requested():
+            raise BootstrapStageCancelled(stage_key="sec_first_install_drain")
+        ...
+
+The bootstrap orchestrator's ``_run_one_stage`` sets the run id on
+this module's ContextVar around the invoker call; outside of a
+bootstrap dispatch the helper returns False (the contextvar is unset)
+so scheduled / manual triggers of the same job are unaffected.
+
+Polling cost: one SQL probe per call. Stage invokers should batch the
+polling (e.g. every 50 iterations) rather than calling on every loop
+body — the cancel-observation latency target is "seconds, not 20+
+minutes", not "instant".
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.services.process_stop import is_stop_requested
+
+logger = logging.getLogger(__name__)
+
+
+# When set, identifies the in-flight bootstrap run that the calling
+# stage invoker is part of. Outside of bootstrap dispatch the value is
+# ``None`` and ``bootstrap_cancel_requested`` short-circuits to False.
+_active_bootstrap_run_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "_active_bootstrap_run_id", default=None
+)
+
+
+@contextlib.contextmanager
+def active_bootstrap_run(run_id: int) -> Iterator[None]:
+    """Context manager that exposes ``run_id`` to stage invokers.
+
+    The bootstrap orchestrator's ``_run_one_stage`` wraps the invoker
+    call in ``with active_bootstrap_run(run_id): invoker(...)`` so any
+    long-running loop inside the invoker can poll
+    ``bootstrap_cancel_requested()`` to check whether the operator
+    has cancelled the run.
+    """
+    token = _active_bootstrap_run_id.set(run_id)
+    try:
+        yield
+    finally:
+        _active_bootstrap_run_id.reset(token)
+
+
+def bootstrap_cancel_requested(
+    *,
+    conn: psycopg.Connection[Any] | None = None,
+) -> bool:
+    """Return True iff the active bootstrap run has been cancelled.
+
+    Reads the ``_active_bootstrap_run_id`` contextvar; if unset (the
+    invoker is being called from a scheduled trigger, manual API
+    POST, or test fixture rather than the bootstrap dispatcher),
+    returns False without touching the DB. When set, opens a
+    short-lived autocommit connection (or uses ``conn`` when
+    supplied) and probes ``process_stop_requests`` for an unobserved
+    stop row targeting this run.
+
+    Polling cost: one SQL probe. Callers should batch (every 50
+    iterations of a CIK-loop, every 100 archive entries, etc.) so the
+    DB doesn't bear the cost of a probe per row.
+
+    Errors are logged and treated as "not cancelled" — a transient
+    DB hiccup must not stall a stage's loop. Worst case: cancel
+    observation falls back to the orchestrator's between-stage
+    checkpoint at the next stage boundary.
+    """
+    run_id = _active_bootstrap_run_id.get()
+    if run_id is None:
+        return False
+
+    try:
+        if conn is not None:
+            stop = is_stop_requested(
+                conn,
+                target_run_kind="bootstrap_run",
+                target_run_id=run_id,
+            )
+        else:
+            with psycopg.connect(settings.database_url, autocommit=True) as probe_conn:
+                stop = is_stop_requested(
+                    probe_conn,
+                    target_run_kind="bootstrap_run",
+                    target_run_id=run_id,
+                )
+    except Exception as exc:
+        # Defensive: fall back to "not cancelled" on transient DB
+        # error so the stage doesn't stall on a probe failure. The
+        # orchestrator's between-stage checkpoint still observes the
+        # cancel at the next boundary.
+        logger.warning(
+            "bootstrap_cancel_requested: probe failed for run_id=%d (%s); treating as not cancelled",
+            run_id,
+            exc,
+        )
+        return False
+
+    return stop is not None
+
+
+__all__ = [
+    "active_bootstrap_run",
+    "bootstrap_cancel_requested",
+]

--- a/tests/test_bootstrap_cancel_signal.py
+++ b/tests/test_bootstrap_cancel_signal.py
@@ -1,0 +1,180 @@
+"""Tests for the bootstrap cancel-signal helper.
+
+Issue #1064 PR3d. The helper exposes ``bootstrap_cancel_requested()``
+to long-running stage invokers (the SEC drain, the 13F sweep) so they
+can poll periodically and raise ``BootstrapStageCancelled`` to bail
+out cooperatively. Without this plumbing, cancel observation falls
+back to the orchestrator's between-stage checkpoint at the next
+boundary — which can be 20+ minutes for a SEC drain.
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from app.services.bootstrap_state import (
+    StageSpec,
+    cancel_run,
+    start_run,
+)
+from app.services.processes.bootstrap_cancel_signal import (
+    active_bootstrap_run,
+    bootstrap_cancel_requested,
+)
+
+# Use real registered job names so JobLock's source_for() resolves.
+# ``daily_cik_refresh`` is in SCHEDULED_JOBS (sec_rate source);
+# ``daily_financial_facts`` is also sec_rate.
+_SPECS = (
+    StageSpec(stage_key="alpha", stage_order=1, lane="sec_rate", job_name="daily_cik_refresh"),
+    StageSpec(stage_key="bravo", stage_order=2, lane="sec_rate", job_name="daily_financial_facts"),
+)
+
+
+def _reset_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        UPDATE bootstrap_state
+           SET status            = 'pending',
+               last_run_id       = NULL,
+               last_completed_at = NULL
+         WHERE id = 1
+        """
+    )
+    conn.commit()
+
+
+def test_returns_false_when_contextvar_unset() -> None:
+    """Outside ``active_bootstrap_run`` the helper short-circuits to
+    False without touching the DB. Scheduled / manual triggers of the
+    same job are unaffected by the bootstrap-cancel surface.
+    """
+    assert bootstrap_cancel_requested() is False
+
+
+def test_returns_false_when_no_cancel_pending(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """ContextVar set, no cancel pending → False."""
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    with active_bootstrap_run(run_id):
+        assert bootstrap_cancel_requested(conn=ebull_test_conn) is False
+
+
+def test_returns_true_after_cancel_run(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """ContextVar set, cancel_run wrote the stop row → True."""
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+
+    with active_bootstrap_run(run_id):
+        assert bootstrap_cancel_requested(conn=ebull_test_conn) is True
+
+
+def test_contextvar_resets_on_exit(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """``active_bootstrap_run`` must clear the contextvar on exit so
+    a subsequent call (different stage, different run, or the
+    scheduled fire of an unrelated job) doesn't see stale state.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    cancel_run(ebull_test_conn, requested_by_operator_id=None)
+    ebull_test_conn.commit()
+
+    with active_bootstrap_run(run_id):
+        assert bootstrap_cancel_requested(conn=ebull_test_conn) is True
+    # Outside the with-block: contextvar reset, helper returns False.
+    assert bootstrap_cancel_requested(conn=ebull_test_conn) is False
+
+
+def test_run_one_stage_maps_cancelled_invoker_to_cancelled_outcome(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR3d #1064 — when a stage invoker raises BootstrapStageCancelled,
+    ``_run_one_stage`` catches it, marks the stage as ``cancelled``
+    (not ``error``), and returns ``_StageOutcome(cancelled=True)``.
+
+    Pins both the exception priority (BootstrapStageCancelled before
+    generic Exception) and the schema-migration plumbing — without
+    PR3c's sql/142 the UPDATE would CheckViolation.
+    """
+    from app.services.bootstrap_orchestrator import _run_one_stage
+    from app.services.bootstrap_state import (
+        BootstrapStageCancelled,
+        mark_stage_running,
+    )
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    ebull_test_conn.commit()
+
+    def _cancelling_invoker(_params: object) -> None:
+        raise BootstrapStageCancelled("operator cancelled mid-stage", stage_key="alpha")
+
+    outcome = _run_one_stage(
+        run_id=run_id,
+        stage_key="alpha",
+        job_name="daily_cik_refresh",
+        invoker=_cancelling_invoker,
+        database_url=test_database_url(),
+    )
+    assert outcome.cancelled is True
+    assert outcome.success is False
+    assert outcome.skipped is False
+    # Stage row carries the new status + reason.
+    row = ebull_test_conn.execute(
+        "SELECT status, last_error FROM bootstrap_stages WHERE bootstrap_run_id = %s AND stage_key = %s",
+        (run_id, "alpha"),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "cancelled"
+    assert row[1] is not None
+    assert "operator" in row[1]
+
+
+def test_run_one_stage_generic_exception_still_maps_to_error(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Regression guard: a non-cancel exception still terminates the
+    stage as ``error`` so the ``BootstrapStageCancelled`` catch block
+    doesn't swallow real failures.
+    """
+    from app.services.bootstrap_orchestrator import _run_one_stage
+    from app.services.bootstrap_state import mark_stage_running
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="alpha")
+    ebull_test_conn.commit()
+
+    def _broken_invoker(_params: object) -> None:
+        raise RuntimeError("network kaput")
+
+    outcome = _run_one_stage(
+        run_id=run_id,
+        stage_key="alpha",
+        job_name="daily_cik_refresh",
+        invoker=_broken_invoker,
+        database_url=test_database_url(),
+    )
+    assert outcome.cancelled is False
+    assert outcome.success is False
+    assert outcome.error is not None and "network kaput" in outcome.error
+    row = ebull_test_conn.execute(
+        "SELECT status FROM bootstrap_stages WHERE bootstrap_run_id = %s AND stage_key = %s",
+        (run_id, "alpha"),
+    ).fetchone()
+    assert row is not None and row[0] == "error"


### PR DESCRIPTION
## Summary
- New ``app/services/processes/bootstrap_cancel_signal.py``: ContextVar + ``active_bootstrap_run(run_id)`` context manager + ``bootstrap_cancel_requested()`` helper. Short-circuits to False when the contextvar is unset (scheduled/manual triggers unaffected); fail-open on probe error.
- New ``BootstrapStageCancelled`` exception + ``mark_stage_cancelled`` helper in bootstrap_state.py.
- ``_run_one_stage`` wraps invoker call in ``active_bootstrap_run`` and catches ``BootstrapStageCancelled`` BEFORE generic ``Exception`` so cancel maps to ``status='cancelled'`` (not ``error``).
- ``_StageOutcome`` gains ``cancelled`` field; phase dispatcher maps onto status='cancelled'.
- First adopter: ``sec_first_install_drain`` polls every 50 CIKs in its 12k-CIK loop. Cuts cancel-observation latency from ~20 minutes (full drain wall-clock) to ~5 seconds.
- Other long-running invokers (13F sweep, filings_history_seed, archive ingesters) can adopt the same pattern in follow-ups — helper short-circuits when contextvar isn't set so they're unchanged today.

## Why
Operator clicks Cancel mid-drain → today the orchestrator's between-stage checkpoint can't observe a mid-flight stage; cancel only fires after the drain finishes. PR3d gives stages a sub-second polling path.

## Test plan
- [x] ``uv run ruff check . && uv run ruff format --check . && uv run pyright``
- [x] ``uv run pytest tests/test_bootstrap_cancel_signal.py tests/test_bootstrap_cancel.py tests/test_bootstrap_state.py -n 0`` — 32/33 (1 pre-existing fixture failure unrelated, confirmed on main)
- [x] New tests cover: contextvar-unset → False; cancel pending → True; contextvar reset on exit; _run_one_stage cancelled-path → stage 'cancelled' + outcome.cancelled=True; generic Exception still → 'error' (exception priority regression guard)
- [x] Codex pre-push (checkpoint 2): 2 BLOCKING findings (schema CHECK + Pydantic Literal) already addressed by rebased PR3c base; test gap on _run_one_stage cancelled-path addressed pre-push
- [ ] Smoke on dev: trigger bootstrap → click Cancel during sec_first_install_drain stage → stage marks cancelled within ~5s instead of waiting for full drain wall-clock

Refs #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)