### PR TITLE
feat(#1082): admin processes ⓘ tooltip — operator-facing description

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -171,6 +171,11 @@ class ProcessRowResponse(BaseModel):
     # form field per entry. ``Field(default_factory=list)`` keeps the
     # default per-instance, not a shared mutable.
     params_metadata: list[ParamMetadata] = Field(default_factory=list)
+    # PR4 #1082 — operator-facing description for the ⓘ tooltip on the
+    # admin ProcessesTable. Empty string when the underlying registry
+    # entry has no description; the FE hides the icon on empty rather
+    # than showing a blank popover.
+    description: str = ""
 
 
 class ProcessListResponse(BaseModel):
@@ -381,6 +386,7 @@ def _convert_row(row: ProcessRow) -> ProcessRowResponse:
         last_n_errors=[_convert_error(e) for e in row.last_n_errors],
         stale_reasons=list(row.stale_reasons),
         params_metadata=list(row.params_metadata),
+        description=row.description,
     )
 
 

--- a/app/services/processes/__init__.py
+++ b/app/services/processes/__init__.py
@@ -185,6 +185,12 @@ class ProcessRow:
     can_cancel: bool
     last_n_errors: tuple[ErrorClassSummary, ...]
     stale_reasons: tuple[StaleReason, ...]
+    # PR4 #1082 — operator-facing description. Renders as the ⓘ
+    # tooltip on the admin ProcessesTable. Empty for processes that
+    # don't have one declared (e.g. legacy fallback paths) — the FE
+    # hides the tooltip when this is empty rather than showing a
+    # blank popover.
+    description: str = ""
     # PR2 #1064 — operator-exposable params for the Advanced disclosure
     # tab on the drill-in. Bootstrap + ingest_sweep adapters keep the
     # default empty tuple; scheduled_adapter populates from the

--- a/app/services/processes/bootstrap_adapter.py
+++ b/app/services/processes/bootstrap_adapter.py
@@ -419,6 +419,13 @@ def get_row(conn: psycopg.Connection[Any]) -> ProcessRow | None:
         can_cancel=(state_status == "running"),
         last_n_errors=last_n_errors,
         stale_reasons=stale_reasons,
+        # PR4 #1082 — bootstrap row description for the ⓘ tooltip.
+        description=(
+            "First-install bootstrap. Walks the 17-stage init → eToro → SEC "
+            "lane sequence to populate every dependent table. Re-run failed "
+            "resumes from the failed stage; Re-run all wipes + replays from "
+            "scratch."
+        ),
     )
 
 

--- a/app/services/processes/ingest_sweep_adapter.py
+++ b/app/services/processes/ingest_sweep_adapter.py
@@ -616,6 +616,15 @@ def _build_row(
         can_cancel=False,
         last_n_errors=last_n_errors,
         stale_reasons=stale_reasons,
+        # PR4 #1082 — describe the sweep + the underlying job that
+        # actually does the trigger work, so the operator's ⓘ tooltip
+        # answers "this is read-only — go trigger ``<underlying>``".
+        description=(
+            f"Read-only roll-up of {spec.display_name}. The underlying "
+            f"scheduled job ``{spec.underlying_job}`` is what actually runs; "
+            f"this row aggregates its progress over time. Iterate / "
+            f"full-wash from the {spec.underlying_job} row instead."
+        ),
     )
 
 

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -671,7 +671,11 @@ def _build_row(
 
     return ProcessRow(
         process_id=job.name,
-        display_name=job.name,
+        # PR4 #1082 — prefer the operator-facing label PR1a populated
+        # on every ScheduledJob; fall back to the raw name when an
+        # entry doesn't declare one (defensive — registry test pins
+        # display_name non-empty).
+        display_name=job.display_name or job.name,
         lane=_lane_for(job.name),
         mechanism="scheduled_job",
         status=process_status,
@@ -693,6 +697,8 @@ def _build_row(
         # Empty tuple for jobs with no operator-exposable params (the
         # default — every entry except ``sec_13f_quarterly_sweep`` today).
         params_metadata=job.params_metadata,
+        # PR4 #1082 — operator-visible description for the ⓘ tooltip.
+        description=job.description,
     )
 
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1250,6 +1250,10 @@ export interface ProcessRowResponse {
   // Non-empty only for scheduled jobs that declare
   // ``ScheduledJob.params_metadata`` (e.g. sec_13f_quarterly_sweep).
   params_metadata: ParamMetadata[];
+  // PR4 #1082 — operator-facing description for the ⓘ tooltip. Empty
+  // when the registry entry has no description; the FE hides the
+  // icon on empty rather than showing a blank popover.
+  description: string;
 }
 
 export interface ProcessListResponse {

--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -409,6 +409,24 @@ describe("ProcessRow", () => {
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 
+  it("popover's role='tooltip' is linked to the trigger via aria-describedby", () => {
+    // Round 3 review WARNING: ARIA spec requires explicit linkage
+    // between the trigger and the popover for AT to announce the
+    // expanded content. Pin: when the tooltip is visible, the
+    // trigger's aria-describedby points at the tooltip's id.
+    renderRow({
+      row: makeProcessRow({ description: "linkage content." }),
+    });
+    const tooltip = screen.getByTestId("process-description-tooltip");
+    expect(tooltip.getAttribute("aria-describedby")).toBeNull();
+
+    fireEvent.click(tooltip);
+    const describedBy = tooltip.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const popover = screen.getByRole("tooltip");
+    expect(popover.id).toBe(describedBy);
+  });
+
   it("hides ⓘ tooltip when description is empty", () => {
     renderRow({
       row: makeProcessRow({ description: "" }),

--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -355,4 +355,33 @@ describe("ProcessRow", () => {
     });
     expect(container.textContent).toContain("every 5m");
   });
+
+  // ---------------------------------------------------------------------
+  // PR4 #1082 — ⓘ tooltip rendering description
+  // ---------------------------------------------------------------------
+
+  it("renders ⓘ tooltip when description is non-empty", () => {
+    renderRow({
+      row: makeProcessRow({
+        description: "Refreshes SEC CIK mappings nightly.",
+      }),
+    });
+    const tooltip = screen.getByTestId("process-description-tooltip");
+    expect(tooltip).toBeTruthy();
+    expect(tooltip.getAttribute("title")).toBe(
+      "Refreshes SEC CIK mappings nightly.",
+    );
+    expect(tooltip).toHaveAccessibleName(
+      "Refreshes SEC CIK mappings nightly.",
+    );
+  });
+
+  it("hides ⓘ tooltip when description is empty", () => {
+    renderRow({
+      row: makeProcessRow({ description: "" }),
+    });
+    expect(
+      screen.queryByTestId("process-description-tooltip"),
+    ).toBeNull();
+  });
 });

--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
@@ -360,7 +360,7 @@ describe("ProcessRow", () => {
   // PR4 #1082 — ⓘ tooltip rendering description
   // ---------------------------------------------------------------------
 
-  it("renders ⓘ tooltip when description is non-empty", () => {
+  it("renders ⓘ tooltip button when description is non-empty", () => {
     renderRow({
       row: makeProcessRow({
         description: "Refreshes SEC CIK mappings nightly.",
@@ -368,12 +368,45 @@ describe("ProcessRow", () => {
     });
     const tooltip = screen.getByTestId("process-description-tooltip");
     expect(tooltip).toBeTruthy();
-    expect(tooltip.getAttribute("title")).toBe(
-      "Refreshes SEC CIK mappings nightly.",
-    );
+    // Accessible name carries the description for screen readers
+    // (replaces the prior native ``title`` after operator feedback
+    // that the native delay + click-to-hide were poor UX).
     expect(tooltip).toHaveAccessibleName(
       "Refreshes SEC CIK mappings nightly.",
     );
+    // Popover starts collapsed; aria-expanded reflects it.
+    expect(tooltip.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("clicking the ⓘ pins the tooltip open; second click collapses", () => {
+    renderRow({
+      row: makeProcessRow({ description: "pinned popover content." }),
+    });
+    const tooltip = screen.getByTestId("process-description-tooltip");
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    fireEvent.click(tooltip);
+    expect(tooltip.getAttribute("aria-expanded")).toBe("true");
+    const pop = screen.getByRole("tooltip");
+    expect(pop.textContent).toBe("pinned popover content.");
+
+    fireEvent.click(tooltip);
+    expect(tooltip.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("hovering the ⓘ surfaces the popover immediately (no native title delay)", () => {
+    renderRow({
+      row: makeProcessRow({ description: "hover content." }),
+    });
+    const tooltip = screen.getByTestId("process-description-tooltip");
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    fireEvent.pointerEnter(tooltip.parentElement!);
+    expect(screen.getByRole("tooltip").textContent).toBe("hover content.");
+
+    fireEvent.pointerLeave(tooltip.parentElement!);
+    expect(screen.queryByRole("tooltip")).toBeNull();
   });
 
   it("hides ⓘ tooltip when description is empty", () => {

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -12,6 +12,7 @@
  * `prefers-reduced-motion` setting.
  */
 
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 import type { ProcessRowResponse, StaleReason } from "@/api/types";
@@ -352,29 +353,66 @@ function formatElapsedSince(iso: string): string {
 /**
  * ⓘ tooltip showing operator-facing description (PR4 #1082).
  *
- * Native ``title`` attribute on a small inline-flex ⓘ glyph. Operating
- * systems render the title as a tooltip on hover/long-press; assistive
- * technology reads the same string via ``aria-label``. No JS modal,
- * no portal — just the browser's tooltip surface so the row stays
- * focus-stable + keyboard-traversable.
+ * Hover-or-click popover. Native ``title`` was the original
+ * implementation but operator feedback flagged two problems:
+ *   - ~1.5s browser-default delay before the title surfaces
+ *   - Clicking the icon (a natural expectation) hid the title
+ *     instead of pinning it
+ *
+ * The replacement is a small CSS-driven popover triggered by
+ * ``onPointerEnter`` / ``onPointerLeave`` (no delay) and a click
+ * toggle that pins it open until clicked again or focus leaves the
+ * row. ``aria-label`` still carries the description for screen
+ * readers; the popover is also reachable by Tab so keyboard-only
+ * operators can press Enter/Space to pin it.
  */
 function DescriptionTooltip({ description }: { description: string }) {
+  const [hovered, setHovered] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const containerRef = useRef<HTMLSpanElement>(null);
+
+  // Click outside closes the pinned popover. Idle when not pinned so
+  // the listener doesn't run for every row in the table.
+  useEffect(() => {
+    if (!pinned) return;
+    function handlePointerDown(e: PointerEvent) {
+      const target = e.target as Node | null;
+      if (target && containerRef.current && !containerRef.current.contains(target)) {
+        setPinned(false);
+      }
+    }
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () =>
+      document.removeEventListener("pointerdown", handlePointerDown);
+  }, [pinned]);
+
+  const visible = hovered || pinned;
   return (
-    // ``<button type="button">`` rather than a bare span so keyboard
-    // users can Tab to the icon and trigger the browser's native
-    // tooltip surface (and screen readers announce it via
-    // ``aria-label``). Codex pre-push PR4 a11y finding: a non-focusable
-    // span left keyboard-only operators with no way to reach the
-    // tooltip.
-    <button
-      type="button"
-      aria-label={description}
-      title={description}
-      data-testid="process-description-tooltip"
-      className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-slate-400 text-[10px] font-bold text-slate-500 hover:border-slate-600 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 dark:border-slate-500 dark:text-slate-400 dark:hover:border-slate-300 dark:hover:text-slate-200"
+    <span
+      ref={containerRef}
+      className="relative inline-flex"
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
     >
-      i
-    </button>
+      <button
+        type="button"
+        aria-label={description}
+        aria-expanded={visible}
+        data-testid="process-description-tooltip"
+        onClick={() => setPinned((p) => !p)}
+        className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-slate-400 text-[10px] font-bold text-slate-500 hover:border-slate-600 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 dark:border-slate-500 dark:text-slate-400 dark:hover:border-slate-300 dark:hover:text-slate-200"
+      >
+        i
+      </button>
+      {visible ? (
+        <span
+          role="tooltip"
+          className="absolute left-5 top-0 z-10 w-64 rounded-md border border-slate-300 bg-white px-2 py-1 text-xs font-normal normal-case tracking-normal text-slate-700 shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+        >
+          {description}
+        </span>
+      ) : null}
+    </span>
   );
 }
 

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -371,7 +371,6 @@ function DescriptionTooltip({ description }: { description: string }) {
       aria-label={description}
       title={description}
       data-testid="process-description-tooltip"
-      onClick={(e) => e.preventDefault()}
       className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-slate-400 text-[10px] font-bold text-slate-500 hover:border-slate-600 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 dark:border-slate-500 dark:text-slate-400 dark:hover:border-slate-300 dark:hover:text-slate-200"
     >
       i

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -104,12 +104,17 @@ export function ProcessRow({
       className={`align-top text-sm ${pulseBorder}`}
     >
       <td className="px-2 py-2">
-        <Link
-          to={`/admin/processes/${encodeURIComponent(row.process_id)}`}
-          className="font-medium text-blue-700 hover:underline dark:text-blue-300"
-        >
-          {row.display_name}
-        </Link>
+        <div className="flex items-center gap-1">
+          <Link
+            to={`/admin/processes/${encodeURIComponent(row.process_id)}`}
+            className="font-medium text-blue-700 hover:underline dark:text-blue-300"
+          >
+            {row.display_name}
+          </Link>
+          {row.description ? (
+            <DescriptionTooltip description={row.description} />
+          ) : null}
+        </div>
         <div className="text-xs text-slate-500 dark:text-slate-400">
           {row.process_id} · {row.mechanism}
         </div>
@@ -342,6 +347,36 @@ function formatElapsedSince(iso: string): string {
   const sec = Math.max(0, Math.round((Date.now() - t) / 1000));
   if (sec < 60) return `${sec}s`;
   return `${Math.round(sec / 60)}m`;
+}
+
+/**
+ * ⓘ tooltip showing operator-facing description (PR4 #1082).
+ *
+ * Native ``title`` attribute on a small inline-flex ⓘ glyph. Operating
+ * systems render the title as a tooltip on hover/long-press; assistive
+ * technology reads the same string via ``aria-label``. No JS modal,
+ * no portal — just the browser's tooltip surface so the row stays
+ * focus-stable + keyboard-traversable.
+ */
+function DescriptionTooltip({ description }: { description: string }) {
+  return (
+    // ``<button type="button">`` rather than a bare span so keyboard
+    // users can Tab to the icon and trigger the browser's native
+    // tooltip surface (and screen readers announce it via
+    // ``aria-label``). Codex pre-push PR4 a11y finding: a non-focusable
+    // span left keyboard-only operators with no way to reach the
+    // tooltip.
+    <button
+      type="button"
+      aria-label={description}
+      title={description}
+      data-testid="process-description-tooltip"
+      onClick={(e) => e.preventDefault()}
+      className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-slate-400 text-[10px] font-bold text-slate-500 hover:border-slate-600 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 dark:border-slate-500 dark:text-slate-400 dark:hover:border-slate-300 dark:hover:text-slate-200"
+    >
+      i
+    </button>
+  );
 }
 
 // Re-export so test files can assert on the canonical mapping rather

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -12,7 +12,7 @@
  * `prefers-reduced-motion` setting.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 import type { ProcessRowResponse, StaleReason } from "@/api/types";
@@ -370,6 +370,7 @@ function DescriptionTooltip({ description }: { description: string }) {
   const [hovered, setHovered] = useState(false);
   const [pinned, setPinned] = useState(false);
   const containerRef = useRef<HTMLSpanElement>(null);
+  const tooltipId = useId();
 
   // Click outside closes the pinned popover. Idle when not pinned so
   // the listener doesn't run for every row in the table.
@@ -398,6 +399,12 @@ function DescriptionTooltip({ description }: { description: string }) {
         type="button"
         aria-label={description}
         aria-expanded={visible}
+        // PR4 round 3 a11y fix — link the trigger to the rendered
+        // tooltip via aria-describedby so AT announces the popover
+        // when it surfaces. Always reference the id (tooltip span is
+        // rendered conditionally; AT just sees no descriptor while
+        // the span is unmounted, which is the correct quiet state).
+        aria-describedby={visible ? tooltipId : undefined}
         data-testid="process-description-tooltip"
         onClick={() => setPinned((p) => !p)}
         className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full border border-slate-400 text-[10px] font-bold text-slate-500 hover:border-slate-600 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 dark:border-slate-500 dark:text-slate-400 dark:hover:border-slate-300 dark:hover:text-slate-200"
@@ -406,6 +413,7 @@ function DescriptionTooltip({ description }: { description: string }) {
       </button>
       {visible ? (
         <span
+          id={tooltipId}
           role="tooltip"
           className="absolute left-5 top-0 z-10 w-64 rounded-md border border-slate-300 bg-white px-2 py-1 text-xs font-normal normal-case tracking-normal text-slate-700 shadow-lg dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
         >

--- a/frontend/src/components/admin/ProcessesTable.test.tsx
+++ b/frontend/src/components/admin/ProcessesTable.test.tsx
@@ -283,7 +283,11 @@ describe("ProcessesTable", () => {
   // row's own DOM order.
   // ---------------------------------------------------------------------
 
-  it("row keyboard order: link → Iterate → Full-wash → Cancel (all enabled)", async () => {
+  it("row keyboard order: link → ⓘ tooltip → Iterate → Full-wash → Cancel (all enabled)", async () => {
+    // PR4 #1082: the ⓘ description tooltip is a focusable button so
+    // keyboard-only operators can reach it; it slots in between the
+    // row link and the Iterate button. The order pin protects the
+    // operator's expected focus path through the row.
     const user = userEvent.setup();
     renderTable([
       makeProcessRow({
@@ -292,11 +296,17 @@ describe("ProcessesTable", () => {
         can_iterate: true,
         can_full_wash: true,
         can_cancel: true,
+        description: "kbd row description",
       }),
     ]);
     const link = screen.getByRole("link", { name: "Keyboard Row" });
     link.focus();
     expect(document.activeElement).toBe(link);
+
+    await user.tab();
+    expect(document.activeElement).toBe(
+      screen.getByTestId("process-description-tooltip"),
+    );
 
     await user.tab();
     expect(document.activeElement).toBe(

--- a/frontend/src/components/admin/__fixtures__/processes.ts
+++ b/frontend/src/components/admin/__fixtures__/processes.ts
@@ -73,6 +73,7 @@ export function makeProcessRow(
     last_n_errors: [],
     stale_reasons: [],
     params_metadata: [],
+    description: "Operator-facing description for the Insider Form 4 ingest.",
     ...overrides,
   };
 }

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -259,6 +259,15 @@ export function ProcessDetailPage() {
               {detail.data.lane}
             </p>
           ) : null}
+          {/* PR4 #1082 — operator-facing description rendered inline
+              on the drill-in (vs the ⓘ tooltip on the table row). The
+              drill-in has the screen real estate; the table row uses
+              the icon to keep the column compact. */}
+          {detail.data?.description ? (
+            <p className="mt-1 max-w-3xl text-xs text-slate-600 dark:text-slate-300">
+              {detail.data.description}
+            </p>
+          ) : null}
         </div>
         {detail.data ? (
           <ActionBar

--- a/tests/test_processes_envelope.py
+++ b/tests/test_processes_envelope.py
@@ -77,6 +77,7 @@ def test_process_row_carries_all_envelope_fields() -> None:
         "last_n_errors",
         "stale_reasons",
         "params_metadata",
+        "description",
     }
     assert set(row.__slots__) == expected
 

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -6,6 +6,7 @@ DB-backed against the worker ``ebull_test`` template.
 from __future__ import annotations
 
 import psycopg
+import pytest
 from psycopg.types.json import Jsonb
 
 from app.services.processes import scheduled_adapter
@@ -695,15 +696,17 @@ def test_display_name_prefers_scheduled_job_label_over_raw_name(
     _ensure_kill_switch_off(ebull_test_conn)
     ebull_test_conn.commit()
 
-    # Find any job that has a non-None display_name. If every entry's
-    # display_name is None today, the adapter still falls back to
-    # job.name (defensive); this test guards the propagation path.
+    # Find any job that has a non-None display_name. ``pytest.skip`` if
+    # none are populated yet so CI surfaces the gap (Codex review
+    # WARNING from PR #1108 round 2 — bare ``return`` silently passes
+    # with zero assertions).
     job_with_label = next(
         (j for j in SCHEDULED_JOBS if j.display_name is not None),
         None,
     )
     if job_with_label is None:
-        return  # nothing to assert until at least one entry populates display_name
+        pytest.skip("no ScheduledJob declares display_name yet")
+    assert job_with_label is not None  # narrow Optional for pyright
     row = scheduled_adapter.get_row(ebull_test_conn, process_id=job_with_label.name)
     assert row is not None
     assert row.display_name == job_with_label.display_name

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -661,6 +661,54 @@ def test_params_metadata_surfaces_for_sec_13f_quarterly_sweep(
     assert row.params_metadata[0].field_type == "date"
 
 
+def test_description_surfaces_from_scheduled_job(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR4 #1082 — ``ScheduledJob.description`` flows onto
+    ``ProcessRow.description`` so the FE ⓘ tooltip can render it.
+
+    Pins the foundation: every scheduled job declares a description
+    string; the adapter forwards verbatim. A regression that returns
+    empty would silently hide every ⓘ icon.
+    """
+    from app.workers.scheduler import SCHEDULED_JOBS
+
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    job = next(j for j in SCHEDULED_JOBS if j.name == JOB_RETRY_DEFERRED)
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
+    assert row is not None
+    assert row.description == job.description
+    assert len(row.description) > 0
+
+
+def test_display_name_prefers_scheduled_job_label_over_raw_name(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """PR4 #1082 — when ``ScheduledJob.display_name`` is populated
+    (PR1a populated every entry), the adapter surfaces it instead of
+    the raw ``job.name``.
+    """
+    from app.workers.scheduler import SCHEDULED_JOBS
+
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    # Find any job that has a non-None display_name. If every entry's
+    # display_name is None today, the adapter still falls back to
+    # job.name (defensive); this test guards the propagation path.
+    job_with_label = next(
+        (j for j in SCHEDULED_JOBS if j.display_name is not None),
+        None,
+    )
+    if job_with_label is None:
+        return  # nothing to assert until at least one entry populates display_name
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=job_with_label.name)
+    assert row is not None
+    assert row.display_name == job_with_label.display_name
+
+
 def test_params_metadata_default_empty_for_jobs_without_declarations(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:


### PR DESCRIPTION
## Summary
- ``ProcessRow`` + ``ProcessRowResponse`` gain a ``description`` field; scheduled_adapter forwards ``ScheduledJob.description``; bootstrap_adapter + ingest_sweep_adapter populate explanatory strings.
- ``scheduled_adapter`` switches to ``job.display_name or job.name`` (PR1a populated display_name on every entry; the adapter was still using the raw name).
- ``ProcessRow`` renders a focusable ⓘ ``<button>`` next to display_name with ``title`` + ``aria-label``; hidden when description is empty.
- ``ProcessDetailPage`` header gains an inline description paragraph below the process_id/mechanism/lane line.

## Why
Operator clicked through the table hunting the difference between, e.g., ``daily_cik_refresh`` vs ``cusip_universe_backfill``; the only distinguishing string was the cron stamp. Surfacing the registry's existing description string in a single ⓘ tooltip + drill-in paragraph closes the gap. PR1a populated every entry; PR4 is the rendering layer.

## Test plan
- [x] ``uv run ruff check . && uv run ruff format --check . && uv run pyright`` — 0 errors
- [x] ``pnpm --dir frontend typecheck``
- [x] BE: ``test_description_surfaces_from_scheduled_job`` + envelope-slots test (PR3 #1082 schema pin)
- [x] FE: ``ProcessRow`` tests for ⓘ visible iff description non-empty + accessible-name match
- [x] ``uv run pytest tests/test_scheduled_adapter.py tests/test_processes_envelope.py -n 0`` — 36/36
- [x] ``npx vitest run src/components/admin/ProcessRow.test.tsx`` — 26/26
- [x] Codex pre-push round 1: 2 findings (envelope-slots + a11y focus on icon) — both addressed pre-push
- [ ] Smoke on dev: hover ⓘ → tooltip; Tab to ⓘ → focus ring; bootstrap row + sweep row show their canonical descriptions

Closes #1082
Refs #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)