### PR TITLE
chore(#1064): populate ScheduledJob.display_name + surface in legacy paths

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -131,6 +131,13 @@ class SystemStatusResponse(BaseModel):
 
 class JobOverviewResponse(BaseModel):
     name: str
+    # Operator-facing label populated from
+    # ``ScheduledJob.display_name`` (registry single-source-of-truth at
+    # ``app/workers/scheduler.py::SCHEDULED_JOBS``). FE renders this in
+    # the legacy "Background tasks" JobsTable + ProblemsPanel failure
+    # copy in place of the raw ``name`` slug. ``None`` falls back to
+    # ``name`` at render time, matching the scheduled_adapter contract.
+    display_name: str | None
     description: str
     cadence: str
     cadence_kind: Literal["every_n_minutes", "hourly", "daily", "weekly", "monthly"]
@@ -261,6 +268,7 @@ def _build_jobs_overview(
         overviews.append(
             JobOverviewResponse(
                 name=job.name,
+                display_name=job.display_name,
                 description=job.description,
                 cadence=job.cadence.label,
                 cadence_kind=job.cadence.kind,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -487,6 +487,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # only before Phase 4 — it remains in _INVOKERS for the Admin UI.
     ScheduledJob(
         name=JOB_ORCHESTRATOR_FULL_SYNC,
+        display_name="Orchestrator full sync",
         source="db",
         description="Orchestrator full sync — walks the DAG and refreshes stale layers.",
         cadence=Cadence.daily(hour=3, minute=0),
@@ -508,6 +509,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # sync — the wrapper catches SyncAlreadyRunning and logs.
     ScheduledJob(
         name=JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
+        display_name="Orchestrator high-frequency sync",
         source="db",
         description="Orchestrator high-frequency sync — portfolio_sync + fx_rates every 5 minutes.",
         cadence=Cadence.every_n_minutes(interval=5),
@@ -518,6 +520,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # scheduled; they do not participate in the orchestrator DAG.
     ScheduledJob(
         name=JOB_EXECUTE_APPROVED_ORDERS,
+        display_name="Execute approved orders",
         source="etoro",
         description="Guard and execute actionable trade recommendations.",
         cadence=Cadence.daily(hour=6, minute=30),
@@ -528,6 +531,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_RETRY_DEFERRED,
+        display_name="Retry deferred recommendations",
         source="db",
         description="Re-evaluate timing_deferred recommendations with fresh TA data.",
         cadence=Cadence.hourly(minute=30),
@@ -536,6 +540,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_MONITOR_POSITIONS,
+        display_name="Monitor open positions",
         source="db",
         description="Check open positions for SL/TP breaches and thesis breaks.",
         cadence=Cadence.hourly(minute=15),
@@ -544,6 +549,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_FUNDAMENTALS_SYNC,
+        display_name="Fundamentals research refresh",
         source="db",
         description=(
             "Daily fundamentals research refresh: re-classify every "
@@ -581,6 +587,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # can still manually fire it from Admin "Run now" if needed.
     ScheduledJob(
         name=JOB_SEC_DIVIDEND_CALENDAR_INGEST,
+        display_name="SEC dividend calendar ingest",
         source="sec_rate",
         description=(
             "Parse 8-K Item 8.01 announcements into ``dividend_events`` "
@@ -596,6 +603,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_BUSINESS_SUMMARY_INGEST,
+        display_name="SEC 10-K business-summary ingest",
         source="sec_rate",
         description=(
             "Extract 10-K Item 1 'Business' narratives into "
@@ -617,6 +625,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_INSIDER_TRANSACTIONS_INGEST,
+        display_name="SEC Form 4 ingest",
         source="sec_rate",
         description=(
             "Parse SEC Form 4 filings into ``insider_transactions`` "
@@ -632,6 +641,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_FILING_DOCUMENTS_INGEST,
+        display_name="SEC filing-documents manifest ingest",
         source="sec_rate",
         description=(
             "Parse SEC filing-index JSON (``{accession}-index.json``) "
@@ -647,6 +657,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_8K_EVENTS_INGEST,
+        display_name="SEC 8-K events ingest",
         source="sec_rate",
         description=(
             "Parse SEC 8-K filings into structured eight_k_filings + "
@@ -662,6 +673,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_BUSINESS_SUMMARY_BOOTSTRAP,
+        display_name="SEC business-summary bootstrap drain",
         source="sec_rate",
         description=(
             "One-shot drain of the 10-K Item 1 candidate set (#535). "
@@ -678,6 +690,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL,
+        display_name="SEC Form 4 round-robin backfill",
         source="sec_rate",
         description=(
             "Round-robin backfill of Form 4 filings for instruments "
@@ -695,6 +708,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_FORM3_INGEST,
+        display_name="SEC Form 3 ingest",
         source="sec_rate",
         description=(
             "Parse SEC Form 3 filings into ``insider_initial_holdings`` "
@@ -714,6 +728,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_DEF14A_INGEST,
+        display_name="SEC DEF 14A ingest",
         source="sec_rate",
         description=(
             "Parse SEC DEF 14A proxy statements into "
@@ -736,6 +751,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_OWNERSHIP_OBSERVATIONS_SYNC,
+        display_name="Ownership repair sweep",
         source="db",
         description=(
             "Self-healing repair sweep for ownership_*_current (#892). "
@@ -752,6 +768,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_OWNERSHIP_OBSERVATIONS_BACKFILL,
+        display_name="Legacy → observations backfill",
         source="db",
         description=(
             "One-shot legacy → ownership_*_observations backfill (#909). "
@@ -779,6 +796,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_CUSIP_EXTID_SWEEP,
+        display_name="CUSIP rewash sweep",
         source="db",
         description=(
             "Sweep ``unresolved_13f_cusips`` for rows whose CUSIP "
@@ -802,6 +820,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_DEF14A_BOOTSTRAP,
+        display_name="SEC DEF 14A bootstrap drain",
         source="sec_rate",
         description=(
             "One-shot drain of the DEF 14A candidate set (#839). "
@@ -825,6 +844,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_RAW_DATA_RETENTION_SWEEP,
+        display_name="Raw data retention sweep",
         source="db",
         description=(
             "Per-source compaction + age-based sweep of data/raw/**. Reclaims "
@@ -840,6 +860,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_EXCHANGES_METADATA_REFRESH,
+        display_name="eToro exchanges metadata refresh",
         source="etoro",
         description=(
             "Weekly refresh of the eToro exchanges catalogue. Pulls "
@@ -860,6 +881,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_CUSIP_UNIVERSE_BACKFILL,
+        display_name="CUSIP universe backfill",
         source="sec_rate",
         description=(
             "Quarterly CUSIP coverage backfill (#914 / #841 PR3). "
@@ -890,6 +912,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_13F_QUARTERLY_SWEEP,
+        display_name="13F quarterly holdings sweep",
         source="sec_rate",
         description=(
             "Quarterly sweep — walk every CIK in ``institutional_filers`` "
@@ -940,6 +963,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_13F_FILER_DIRECTORY_SYNC,
+        display_name="13F filer-directory sync",
         source="sec_rate",
         description=(
             "Discovery sweep of SEC's quarterly form.idx for every "
@@ -969,6 +993,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
+        display_name="N-PORT filer-directory sync",
         source="sec_rate",
         description=(
             "Discovery sweep — populate ``sec_nport_filer_directory`` "
@@ -994,6 +1019,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_SEC_N_PORT_INGEST,
+        display_name="N-PORT monthly fund-holdings sweep",
         source="sec_rate",
         description=(
             "Monthly NPORT-P fund-holdings sweep (#917 — Phase 3 PR1). "
@@ -1015,6 +1041,7 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ),
     ScheduledJob(
         name=JOB_ETORO_LOOKUPS_REFRESH,
+        display_name="eToro lookup catalogues refresh",
         source="etoro",
         description=(
             "Weekly refresh of eToro's instrument-types + "

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -104,6 +104,10 @@ export interface SystemStatusResponse {
 
 export interface JobOverviewResponse {
   name: string;
+  // Operator-facing label populated from `ScheduledJob.display_name`.
+  // Render `display_name ?? name` — `null` means the job has no
+  // dedicated label and falls back to the raw slug.
+  display_name: string | null;
   description: string;
   cadence: string;
   cadence_kind: CadenceKind;

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -326,6 +326,7 @@ describe("ProblemsPanel", () => {
       jobs: [
         {
           name: "test_job",
+          display_name: null,
           description: "test job",
           cadence: "daily",
           cadence_kind: "daily",
@@ -351,6 +352,7 @@ describe("ProblemsPanel", () => {
       jobs: [
         {
           name: "fundamentals_sync",
+          display_name: null,
           description: "",
           cadence: "weekly",
           cadence_kind: "weekly",
@@ -379,6 +381,7 @@ describe("ProblemsPanel", () => {
       jobs: [
         {
           name: "etl/fundamentals_sync",
+          display_name: null,
           description: "",
           cadence: "weekly",
           cadence_kind: "weekly",
@@ -429,6 +432,7 @@ describe("ProblemsPanel", () => {
       jobs: [
         {
           name: "fundamentals_sync",
+          display_name: null,
           description: "",
           cadence: "weekly",
           cadence_kind: "weekly",

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -198,29 +198,32 @@ export function ProblemsPanel({
         {secretMissing.map((item) => (
           <SecretMissingRow key={item.layer} item={item} />
         ))}
-        {failingJobs.map((job) => (
-          <li key={`job-${job.name}`} className="px-4 py-2 text-sm">
-            <div className="flex items-start gap-2">
-              <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-red-500" />
-              <div className="flex-1">
-                <div className="font-medium text-red-800">{job.name} — last run failed</div>
-                {job.last_finished_at !== null ? (
-                  <div className="text-xs text-slate-600">Failed at {formatDateTime(job.last_finished_at)}</div>
-                ) : null}
-                <div className="text-xs text-slate-600">
-                  Clears when the next run of {job.name} succeeds.
+        {failingJobs.map((job) => {
+          const label = job.display_name ?? job.name;
+          return (
+            <li key={`job-${job.name}`} className="px-4 py-2 text-sm">
+              <div className="flex items-start gap-2">
+                <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-red-500" />
+                <div className="flex-1">
+                  <div className="font-medium text-red-800">{label} — last run failed</div>
+                  {job.last_finished_at !== null ? (
+                    <div className="text-xs text-slate-600">Failed at {formatDateTime(job.last_finished_at)}</div>
+                  ) : null}
+                  <div className="text-xs text-slate-600">
+                    Clears when the next run of {label} succeeds.
+                  </div>
                 </div>
+                <Link
+                  to={`/admin/jobs/${encodeURIComponent(job.name)}`}
+                  className="shrink-0 text-xs font-medium text-blue-700 hover:underline"
+                  aria-label={`View runs for ${label}`}
+                >
+                  View runs →
+                </Link>
               </div>
-              <Link
-                to={`/admin/jobs/${encodeURIComponent(job.name)}`}
-                className="shrink-0 text-xs font-medium text-blue-700 hover:underline"
-                aria-label={`View runs for ${job.name}`}
-              >
-                View runs →
-              </Link>
-            </div>
-          </li>
-        ))}
+            </li>
+          );
+        })}
         {coverageNullRows > 0 ? (
           <li className="px-4 py-2 text-sm">
             <div className="flex items-start gap-2">

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -109,6 +109,7 @@ function jobsResponse(): JobsListResponse {
     jobs: [
       {
         name: "orchestrator_full_sync",
+        display_name: "Orchestrator full sync",
         description: "orchestrator sweep",
         cadence: "daily",
         cadence_kind: "daily",
@@ -121,6 +122,7 @@ function jobsResponse(): JobsListResponse {
       },
       {
         name: "execute_approved_orders",
+        display_name: "Execute approved orders",
         description: "execute orders",
         cadence: "every 1 minutes",
         cadence_kind: "every_n_minutes",
@@ -133,6 +135,7 @@ function jobsResponse(): JobsListResponse {
       },
       {
         name: "attribution_summary",
+        display_name: null,
         description: "attribution",
         cadence: "daily",
         cadence_kind: "daily",
@@ -226,6 +229,7 @@ describe("AdminPage — top-level composition", () => {
       jobs: [
         {
           name: "execute_approved_orders",
+          display_name: "Execute approved orders",
           description: "execute orders",
           cadence: "every 1 minutes",
           cadence_kind: "every_n_minutes",
@@ -291,10 +295,10 @@ describe("AdminPage — Background tasks collapsible", () => {
     );
 
     await screen.findByRole("button", {
-      name: "Run execute_approved_orders now",
+      name: "Run Execute approved orders now",
     });
     expect(
-      screen.queryByRole("button", { name: "Run orchestrator_full_sync now" }),
+      screen.queryByRole("button", { name: "Run Orchestrator full sync now" }),
     ).toBeNull();
   });
 
@@ -306,7 +310,7 @@ describe("AdminPage — Background tasks collapsible", () => {
       await screen.findByRole("button", { name: /Background tasks/ }),
     );
     const btn = await screen.findByRole("button", {
-      name: "Run execute_approved_orders now",
+      name: "Run Execute approved orders now",
     });
 
     const callsBefore = mockedJobs.mock.calls.length;
@@ -328,7 +332,7 @@ describe("AdminPage — Background tasks collapsible", () => {
       await screen.findByRole("button", { name: /Background tasks/ }),
     );
     const btn = await screen.findByRole("button", {
-      name: "Run execute_approved_orders now",
+      name: "Run Execute approved orders now",
     });
     await user.click(btn);
     expect(btn).toHaveTextContent("Already running");
@@ -342,7 +346,7 @@ describe("AdminPage — Background tasks collapsible", () => {
       await screen.findByRole("button", { name: /Background tasks/ }),
     );
     const btn = await screen.findByRole("button", {
-      name: "Run execute_approved_orders now",
+      name: "Run Execute approved orders now",
     });
     await user.click(btn);
     expect(btn).toHaveTextContent("Unknown job");

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -359,10 +359,11 @@ function JobsTable({
         <tbody className="divide-y divide-slate-100">
           {items.map((job) => {
             const state = rowState[job.name] ?? { kind: "idle" };
+            const label = job.display_name ?? job.name;
             return (
               <tr key={job.name} className="align-top">
                 <td className="py-2 pr-4">
-                  <div className="font-medium text-slate-700">{job.name}</div>
+                  <div className="font-medium text-slate-700">{label}</div>
                   <div className="text-xs text-slate-500">{job.description}</div>
                 </td>
                 <td className="py-2 pr-4 text-xs text-slate-600">{job.cadence}</td>
@@ -384,6 +385,7 @@ function JobsTable({
                 <td className="py-2 pr-0 text-right">
                   <RunButton
                     name={job.name}
+                    label={label}
                     state={state}
                     onClick={() => onRun(job.name)}
                   />
@@ -399,15 +401,17 @@ function JobsTable({
 
 function RunButton({
   name,
+  label,
   state,
   onClick,
 }: {
   name: string;
+  label: string;
   state: RowState;
   onClick: () => void;
 }) {
   const disabled = state.kind === "running";
-  const label =
+  const buttonLabel =
     state.kind === "running"
       ? "Triggering…"
       : state.kind === "queued"
@@ -426,10 +430,11 @@ function RunButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      aria-label={`Run ${name} now`}
+      aria-label={`Run ${label} now`}
+      data-job-name={name}
       className={`rounded border px-2 py-1 text-xs font-medium disabled:opacity-50 ${tone}`}
     >
-      {label}
+      {buttonLabel}
     </button>
   );
 }

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -6,7 +6,6 @@ DB-backed against the worker ``ebull_test`` template.
 from __future__ import annotations
 
 import psycopg
-import pytest
 from psycopg.types.json import Jsonb
 
 from app.services.processes import scheduled_adapter
@@ -687,29 +686,32 @@ def test_description_surfaces_from_scheduled_job(
 def test_display_name_prefers_scheduled_job_label_over_raw_name(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    """PR4 #1082 — when ``ScheduledJob.display_name`` is populated
-    (PR1a populated every entry), the adapter surfaces it instead of
-    the raw ``job.name``.
+    """PR4 #1082 — every ``ScheduledJob`` declares a non-empty
+    ``display_name`` distinct from the raw ``name`` slug, and the
+    adapter forwards it verbatim.
+
+    Iterates every registered entry rather than spot-checking the first
+    one — without this the test passes on a partial population.
     """
     from app.workers.scheduler import SCHEDULED_JOBS
 
     _ensure_kill_switch_off(ebull_test_conn)
     ebull_test_conn.commit()
 
-    # Find any job that has a non-None display_name. ``pytest.skip`` if
-    # none are populated yet so CI surfaces the gap (Codex review
-    # WARNING from PR #1108 round 2 — bare ``return`` silently passes
-    # with zero assertions).
-    job_with_label = next(
-        (j for j in SCHEDULED_JOBS if j.display_name is not None),
-        None,
-    )
-    if job_with_label is None:
-        pytest.skip("no ScheduledJob declares display_name yet")
-    assert job_with_label is not None  # narrow Optional for pyright
-    row = scheduled_adapter.get_row(ebull_test_conn, process_id=job_with_label.name)
-    assert row is not None
-    assert row.display_name == job_with_label.display_name
+    missing = [j.name for j in SCHEDULED_JOBS if j.display_name is None]
+    assert missing == [], f"jobs missing display_name: {missing}"
+
+    for job in SCHEDULED_JOBS:
+        assert job.display_name is not None  # narrow Optional for pyright
+        assert job.display_name.strip() != "", f"{job.name}: display_name is blank"
+        assert job.display_name != job.name, (
+            f"{job.name}: display_name equals raw slug — supply a distinct operator-facing label"
+        )
+        row = scheduled_adapter.get_row(ebull_test_conn, process_id=job.name)
+        assert row is not None, f"{job.name}: adapter returned no row"
+        assert row.display_name == job.display_name, (
+            f"{job.name}: adapter surfaced {row.display_name!r} but registry declares {job.display_name!r}"
+        )
 
 
 def test_params_metadata_default_empty_for_jobs_without_declarations(


### PR DESCRIPTION
## What

- Populate `display_name` on all 27 `SCHEDULED_JOBS` entries verbatim from `docs/wiki/job-registry-audit.md`.
- Surface `display_name` (with `name` fallback) in the legacy `/system/jobs` paths: `JobOverviewResponse` BE schema + `frontend/src/api/types.ts` mirror + `AdminPage` JobsTable + `ProblemsPanel` failing-jobs alert + `RunButton` aria-label.
- Unskip + strengthen `test_display_name_prefers_scheduled_job_label_over_raw_name` — iterates every entry, asserts non-None / non-blank / distinct-from-slug / adapter-forwards-verbatim.

## Why

`PR1a #1096` added `ScheduledJob.display_name` but no entry set it, so the test pytest.skipped on every run and the audit doc's operator-facing labels never reached operators. Without iteration the test passes on partial population — Codex round-1 W3 caught that.

Codex round-1 also flagged two adjacent surfaces still rendering raw slugs (legacy JobsTable + ProblemsPanel) and round-2 flagged the RunButton aria-label. All addressed in-PR per "fix-in-scope by default" — small, coupled, unblocked. Round 3: no findings.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest tests/test_scheduled_adapter.py tests/test_api_system.py` — 57 passed (unskipped test now iterates 27 entries)
- [x] `pnpm --dir frontend typecheck` — clean
- [x] `pnpm exec vitest run src/pages/AdminPage.test.tsx src/components/admin/ProblemsPanel.test.tsx` — 39 passed
- [x] Codex 3 rounds: round 1 (3 findings: audit drift / legacy paths / spot-check test) → round 2 (1 finding: RunButton aria-label) → round 3 no findings

Closes #1082 follow-up (display_name populate gap noted in PR #1108 round 2).

Refs #1064.