### PR TITLE
chore(#1064): in-memory localStorage polyfill in vitest setup

### DIFF
--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -61,6 +61,50 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   globalThis.ResizeObserver = NoopObserver as unknown as typeof ResizeObserver;
 }
 
+// jsdom 25 + vitest 2 + pool='forks' returns a plain object for
+// `window.localStorage` whose Storage prototype methods are missing
+// (`getItem` / `setItem` / `clear` / `removeItem` / `length` all
+// undefined). The theme tests at `src/lib/theme.test.tsx` and
+// `src/lib/useChartTheme.test.tsx` call `window.localStorage.clear()`
+// in `beforeEach` and crash on
+// `TypeError: window.localStorage.clear is not a function`.
+//
+// Install a minimal in-memory Storage polyfill on window so the
+// production code path (`window.localStorage.getItem(STORAGE_KEY)`
+// in `lib/theme.tsx`) works under tests without per-test mocks.
+// The polyfill resets between tests because the wrapping `Map`
+// instance lives on the per-file module scope and `cleanup()` plus
+// the test-file's own `beforeEach(() => window.localStorage.clear())`
+// keeps state from leaking.
+if (typeof window !== "undefined") {
+  const memory = new Map<string, string>();
+  const polyfill: Storage = {
+    get length(): number {
+      return memory.size;
+    },
+    clear(): void {
+      memory.clear();
+    },
+    getItem(key: string): string | null {
+      return memory.get(key) ?? null;
+    },
+    key(index: number): string | null {
+      return Array.from(memory.keys())[index] ?? null;
+    },
+    removeItem(key: string): void {
+      memory.delete(key);
+    },
+    setItem(key: string, value: string): void {
+      memory.set(key, String(value));
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    writable: false,
+    value: polyfill,
+  });
+}
+
 if (typeof window !== "undefined" && typeof window.matchMedia === "undefined") {
   Object.defineProperty(window, "matchMedia", {
     writable: true,


### PR DESCRIPTION
## What

Install a minimal in-memory Storage shim on `window.localStorage` in `frontend/src/test/setup.ts` covering `clear` / `getItem` / `setItem` / `removeItem` / `length` / `key`.

## Why

jsdom 25 + vitest 2 + `pool='forks'` returns a plain object for `window.localStorage` with no Storage prototype methods. Both `lib/theme.test.tsx` (8 tests) and `lib/useChartTheme.test.tsx` (3 tests) crash in `beforeEach` on `TypeError: window.localStorage.clear is not a function` — 11 failures on every CI run.

Production code path (`window.localStorage.getItem('ebull.theme')` in `lib/theme.tsx`) is the only consumer in the repo; the shim covers everything app + tests actually call.

## Test plan

- [x] `pnpm exec vitest run src/lib/theme.test.tsx src/lib/useChartTheme.test.tsx` — 11/11 pass (was 11/11 fail)
- [x] `pnpm --dir frontend test:unit` — 858 passed (no regressions)
- [x] `pnpm --dir frontend typecheck` — clean
- [x] Codex pre-push: no findings

Refs #1064.