### PR TITLE
feat(#1064): adopt bootstrap cancel-poll in C-stage bulk ingesters

### DIFF
--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -294,12 +294,29 @@ def sec_13f_ingest_from_dataset_job() -> None:
     # the WHOLE stage has succeeded — if a later archive fails,
     # retry needs all manifest archives on disk (Codex sweep
     # BLOCKING).
+    # PR3d #1064 follow-up — poll the bootstrap cancel signal between
+    # archives. Each archive ingests in 5-20 min; without a poll the
+    # operator's cancel is observed only at the next bootstrap-stage
+    # boundary, well after the C-stage commits a long-running archive.
+    # Outside ``active_bootstrap_run`` (manual trigger / no-run path)
+    # the helper short-circuits to False, so non-bootstrap callers are
+    # unaffected. Per-archive commits already drop a clean rollback
+    # boundary; raising on observed cancel preserves whatever ran
+    # before the signal landed.
+    from app.services.bootstrap_state import BootstrapStageCancelled
+    from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+
     failed_archives: list[str] = []
     total_written = 0
     total_skipped = 0
     succeeded: list[Path] = []
     touched_ids: set[int] = set()
     for archive in archives:
+        if bootstrap_cancel_requested():
+            raise BootstrapStageCancelled(
+                f"sec_13f_ingest_from_dataset cancelled by operator after {len(succeeded)}/{len(archives)} archives",
+                stage_key="sec_13f_ingest_from_dataset",
+            )
         with psycopg.connect(settings.database_url) as conn:
             try:
                 result = ingest_13f_dataset_archive(conn=conn, archive_path=archive)
@@ -351,11 +368,28 @@ def sec_13f_ingest_from_dataset_job() -> None:
     # observations land but _current is stale AND archives are deleted,
     # leaving no retry input. Codex pre-push BLOCKING for #1020.
     if touched_ids:
+        # Codex pre-push round 1: cancel must outrank the post-loop
+        # refresh too, otherwise a signal that lands between the last
+        # archive's poll and the refresh loop entry would let the
+        # stage finish + delete archives + return success while the
+        # dispatcher waits for the next stage boundary.
+        if bootstrap_cancel_requested():
+            raise BootstrapStageCancelled(
+                f"sec_13f_ingest_from_dataset cancelled by operator before refresh of {len(touched_ids)} instruments",
+                stage_key="sec_13f_ingest_from_dataset",
+            )
+
         from app.services.ownership_observations import refresh_institutions_current
 
         refresh_failures: list[str] = []
         with psycopg.connect(settings.database_url) as conn:
-            for instrument_id in sorted(touched_ids):
+            for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
+                if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
+                    raise BootstrapStageCancelled(
+                        f"sec_13f_ingest_from_dataset cancelled by operator after "
+                        f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
+                        stage_key="sec_13f_ingest_from_dataset",
+                    )
                 # Per-iteration savepoint — refresh_institutions_current
                 # owns its own ``with conn.transaction()`` (sql/.py:404),
                 # so this is defence-in-depth against a future refactor
@@ -426,11 +460,22 @@ def sec_insider_ingest_from_dataset_job() -> None:
         logger.info("sec_insider_ingest_from_dataset: no insider_*.zip cached, skipping (no run)")
         return
 
+    # PR3d #1064 follow-up — see sec_13f_ingest_from_dataset_job for
+    # the cancel-poll rationale; same pattern applies per-archive.
+    from app.services.bootstrap_state import BootstrapStageCancelled
+    from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+
     failed_archives: list[str] = []
     total_written = 0
     succeeded: list[Path] = []
     touched_ids: set[int] = set()
     for archive in archives:
+        if bootstrap_cancel_requested():
+            raise BootstrapStageCancelled(
+                f"sec_insider_ingest_from_dataset cancelled by operator after "
+                f"{len(succeeded)}/{len(archives)} archives",
+                stage_key="sec_insider_ingest_from_dataset",
+            )
         with psycopg.connect(settings.database_url) as conn:
             try:
                 result = ingest_insider_dataset_archive(conn=conn, archive_path=archive)
@@ -475,11 +520,25 @@ def sec_insider_ingest_from_dataset_job() -> None:
     # — refresh failures propagate before disk cleanup so the archives
     # remain available for retry. Codex pre-push BLOCKING for #1020.
     if touched_ids:
+        # Codex round 1 — cancel poll before + during refresh loop.
+        if bootstrap_cancel_requested():
+            raise BootstrapStageCancelled(
+                f"sec_insider_ingest_from_dataset cancelled by operator before "
+                f"refresh of {len(touched_ids)} instruments",
+                stage_key="sec_insider_ingest_from_dataset",
+            )
+
         from app.services.ownership_observations import refresh_insiders_current
 
         refresh_failures: list[str] = []
         with psycopg.connect(settings.database_url) as conn:
-            for instrument_id in sorted(touched_ids):
+            for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
+                if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
+                    raise BootstrapStageCancelled(
+                        f"sec_insider_ingest_from_dataset cancelled by operator after "
+                        f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
+                        stage_key="sec_insider_ingest_from_dataset",
+                    )
                 try:
                     with conn.transaction():
                         refresh_insiders_current(conn, instrument_id=instrument_id)
@@ -544,11 +603,21 @@ def sec_nport_ingest_from_dataset_job() -> None:
         logger.info("sec_nport_ingest_from_dataset: no nport_*.zip cached, skipping (no run)")
         return
 
+    # PR3d #1064 follow-up — see sec_13f_ingest_from_dataset_job for
+    # the cancel-poll rationale; same pattern applies per-archive.
+    from app.services.bootstrap_state import BootstrapStageCancelled
+    from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+
     failed_archives: list[str] = []
     total_written = 0
     succeeded: list[Path] = []
     touched_ids: set[int] = set()
     for archive in archives:
+        if bootstrap_cancel_requested():
+            raise BootstrapStageCancelled(
+                f"sec_nport_ingest_from_dataset cancelled by operator after {len(succeeded)}/{len(archives)} archives",
+                stage_key="sec_nport_ingest_from_dataset",
+            )
         with psycopg.connect(settings.database_url) as conn:
             try:
                 result = ingest_nport_dataset_archive(conn=conn, archive_path=archive)
@@ -597,11 +666,24 @@ def sec_nport_ingest_from_dataset_job() -> None:
     # failures propagate before disk cleanup so archives stay
     # retryable. Codex pre-push BLOCKING for #1020.
     if touched_ids:
+        # Codex round 1 — cancel poll before + during refresh loop.
+        if bootstrap_cancel_requested():
+            raise BootstrapStageCancelled(
+                f"sec_nport_ingest_from_dataset cancelled by operator before refresh of {len(touched_ids)} instruments",
+                stage_key="sec_nport_ingest_from_dataset",
+            )
+
         from app.services.ownership_observations import refresh_funds_current
 
         refresh_failures: list[str] = []
         with psycopg.connect(settings.database_url) as conn:
-            for instrument_id in sorted(touched_ids):
+            for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
+                if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
+                    raise BootstrapStageCancelled(
+                        f"sec_nport_ingest_from_dataset cancelled by operator after "
+                        f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
+                        stage_key="sec_nport_ingest_from_dataset",
+                    )
                 try:
                     with conn.transaction():
                         refresh_funds_current(conn, instrument_id=instrument_id)

--- a/tests/test_sec_bulk_cancel_signal.py
+++ b/tests/test_sec_bulk_cancel_signal.py
@@ -1,0 +1,234 @@
+"""Cancel-signal adoption tests for the bulk-archive C-stage ingesters.
+
+Issue #1064 PR3d follow-up. The C3/C4/C5 ingesters
+(``sec_13f_ingest_from_dataset_job``, ``sec_insider_ingest_from_dataset_job``,
+``sec_nport_ingest_from_dataset_job``) walk per-archive loops where each
+archive ingest takes 5-20 minutes. Polling between archives lets the
+operator's cancel signal land at an archive boundary instead of waiting
+for the next bootstrap-stage checkpoint.
+
+Outside ``active_bootstrap_run`` the contextvar is unset and
+``bootstrap_cancel_requested`` short-circuits to False, so the
+no-run / standalone-trigger paths are unaffected. These tests stub the
+helper directly with ``monkeypatch`` so the per-job loop runs without a
+live bootstrap_runs row.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.services import sec_bulk_orchestrator_jobs as jobs
+from app.services.bootstrap_state import BootstrapStageCancelled
+
+
+def _make_form13f_archive(path: Path) -> None:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("README.txt", "stub")
+    path.write_bytes(buf.getvalue())
+
+
+@pytest.mark.parametrize(
+    ("job_name", "archive_prefix", "stage_key"),
+    [
+        ("sec_13f_ingest_from_dataset_job", "form13f_", "sec_13f_ingest_from_dataset"),
+        ("sec_insider_ingest_from_dataset_job", "insider_", "sec_insider_ingest_from_dataset"),
+        ("sec_nport_ingest_from_dataset_job", "nport_", "sec_nport_ingest_from_dataset"),
+    ],
+)
+def test_cancel_signal_aborts_before_first_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    job_name: str,
+    archive_prefix: str,
+    stage_key: str,
+) -> None:
+    """When ``bootstrap_cancel_requested`` returns True on the first
+    iteration, the per-archive loop raises ``BootstrapStageCancelled``
+    with the matching ``stage_key`` and the per-archive ingester is
+    never invoked.
+
+    The no-run path skips the precondition + manifest checks; the
+    cancel poll fires for any caller that runs the loop body, so the
+    standalone path is the cleanest test surface.
+    """
+    bulk_dir = tmp_path / "sec" / "bulk"
+    bulk_dir.mkdir(parents=True)
+    # Two archives so the loop has work — the cancel must block both.
+    for i in range(2):
+        _make_form13f_archive(bulk_dir / f"{archive_prefix}2024q{i + 1}.zip")
+
+    monkeypatch.setattr(
+        "app.services.processes.bootstrap_cancel_signal.bootstrap_cancel_requested",
+        lambda: True,
+    )
+
+    # Track whether the per-archive ingester was invoked. Patching the
+    # symbol on the module means a False positive on cancel-aborts
+    # (i.e. cancel poll didn't fire) would call the patched ingester
+    # and the test would observe the call.
+    ingest_calls: list[Path] = []
+
+    def _record(*args, **kwargs):
+        ingest_calls.append(kwargs.get("archive_path") or args[1])
+        return None
+
+    job = getattr(jobs, job_name)
+
+    with (
+        patch.object(jobs, "_bulk_dir", return_value=bulk_dir),
+        patch.object(jobs, "_current_running_bootstrap_run_id", return_value=None),
+        patch.object(jobs, "ingest_13f_dataset_archive", side_effect=_record),
+        patch.object(jobs, "ingest_insider_dataset_archive", side_effect=_record),
+        patch.object(jobs, "ingest_nport_dataset_archive", side_effect=_record),
+    ):
+        with pytest.raises(BootstrapStageCancelled) as exc_info:
+            job()
+
+    # Pin the stage_key attribute, not just substring-in-message —
+    # message-substring would pass even on a wrong-stage_key bug.
+    # Codex pre-push round 1.
+    assert exc_info.value.stage_key == stage_key
+    assert "cancelled by operator" in str(exc_info.value)
+    # Critical: the per-archive ingester was NEVER called.
+    assert ingest_calls == [], f"ingest helper called despite cancel: {ingest_calls}"
+
+
+@pytest.mark.parametrize(
+    ("job_name", "archive_prefix", "expected_ingester", "other_ingesters"),
+    [
+        (
+            "sec_13f_ingest_from_dataset_job",
+            "form13f_",
+            "ingest_13f_dataset_archive",
+            ("ingest_insider_dataset_archive", "ingest_nport_dataset_archive"),
+        ),
+        (
+            "sec_insider_ingest_from_dataset_job",
+            "insider_",
+            "ingest_insider_dataset_archive",
+            ("ingest_13f_dataset_archive", "ingest_nport_dataset_archive"),
+        ),
+        (
+            "sec_nport_ingest_from_dataset_job",
+            "nport_",
+            "ingest_nport_dataset_archive",
+            ("ingest_13f_dataset_archive", "ingest_insider_dataset_archive"),
+        ),
+    ],
+)
+def test_each_job_calls_only_its_own_ingester(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    job_name: str,
+    archive_prefix: str,
+    expected_ingester: str,
+    other_ingesters: tuple[str, ...],
+) -> None:
+    """Without a cancel signal, the no-run path runs the loop once and
+    the EXPECTED per-job ingester is called. The two non-matching
+    ingesters must NOT be invoked — guards against a copy-paste regression
+    binding the wrong helper. Codex pre-push round 1.
+    """
+    bulk_dir = tmp_path / "sec" / "bulk"
+    bulk_dir.mkdir(parents=True)
+    _make_form13f_archive(bulk_dir / f"{archive_prefix}2024q1.zip")
+
+    monkeypatch.setattr(
+        "app.services.processes.bootstrap_cancel_signal.bootstrap_cancel_requested",
+        lambda: False,
+    )
+
+    expected_calls: list[Path] = []
+    foreign_calls: dict[str, list[Path]] = {name: [] for name in other_ingesters}
+
+    def _make_recorder(sink: list[Path]):
+        def _record(*args, **kwargs):
+            sink.append(kwargs.get("archive_path") or args[1])
+            from types import SimpleNamespace
+
+            return SimpleNamespace(
+                rows_written=1,
+                rows_skipped_unresolved_cusip=0,
+                rows_skipped_unresolved_cik=0,
+                rows_skipped_non_equity=0,
+                touched_instrument_ids=set(),
+            )
+
+        return _record
+
+    job = getattr(jobs, job_name)
+
+    patches = [
+        patch.object(jobs, "_bulk_dir", return_value=bulk_dir),
+        patch.object(jobs, "_current_running_bootstrap_run_id", return_value=None),
+        patch.object(jobs, expected_ingester, side_effect=_make_recorder(expected_calls)),
+    ]
+    for name in other_ingesters:
+        patches.append(patch.object(jobs, name, side_effect=_make_recorder(foreign_calls[name])))
+
+    # Apply patches in a stack.
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        # _delete_archive_after_success is benign on the temp file but
+        # patch it to a no-op so a slow filesystem doesn't matter.
+        stack.enter_context(patch.object(jobs, "_delete_archive_after_success"))
+        job()
+
+    assert len(expected_calls) == 1
+    for name, calls in foreign_calls.items():
+        assert calls == [], f"{job_name} called {name} but should only call {expected_ingester}"
+
+
+@pytest.mark.parametrize(
+    "job_name",
+    [
+        "sec_13f_ingest_from_dataset_job",
+        "sec_insider_ingest_from_dataset_job",
+        "sec_nport_ingest_from_dataset_job",
+    ],
+)
+def test_no_archives_skips_loop_without_cancel_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    job_name: str,
+) -> None:
+    """When there are no archives on disk and no bootstrap run is
+    active, the early-return path runs and the cancel poll is never
+    reached. Pinned to guard against regression where a misplaced poll
+    would raise on standalone triggers with empty disk state.
+    """
+    bulk_dir = tmp_path / "sec" / "bulk"
+    bulk_dir.mkdir(parents=True)
+
+    poll_calls = [0]
+
+    def _poll() -> bool:
+        poll_calls[0] += 1
+        return True
+
+    monkeypatch.setattr(
+        "app.services.processes.bootstrap_cancel_signal.bootstrap_cancel_requested",
+        _poll,
+    )
+
+    job = getattr(jobs, job_name)
+
+    with (
+        patch.object(jobs, "_bulk_dir", return_value=bulk_dir),
+        patch.object(jobs, "_current_running_bootstrap_run_id", return_value=None),
+    ):
+        # Returns cleanly with no archives present, no exception.
+        job()
+
+    # Cancel poll never fired because the loop had nothing to iterate.
+    assert poll_calls == [0]


### PR DESCRIPTION
## What

Fourth wave of the PR3d bootstrap cancel-signal helper. Three Phase C dataset ingesters in `sec_bulk_orchestrator_jobs.py` adopt the per-archive cancel poll:

- `sec_13f_ingest_from_dataset_job`
- `sec_insider_ingest_from_dataset_job`
- `sec_nport_ingest_from_dataset_job`

Each polls before opening the archive-ingest connection, then again before + every 50 instruments inside the post-loop `refresh_*_current` sweep. Codex pre-push round 1 caught the refresh-window gap (signal between last archive poll and refresh entry would let stage finish + delete archives + return success).

## Why

Each archive ingest takes 5-20 minutes; without a poll the operator's cancel signal is observed only at the next bootstrap-stage boundary. Polling between archives (and inside the refresh loop) cuts observation latency to one archive boundary or 50 refreshes, whichever fires first.

Outside `active_bootstrap_run` the contextvar is unset → poll short-circuits to False. Standalone manual triggers and the no-run path are unaffected.

## Test plan

`tests/test_sec_bulk_cancel_signal.py` — 12 tests, parametrized over all three jobs:

- [x] cancel-on-iter-0 raises `BootstrapStageCancelled` with the matching `stage_key` attribute (not just message substring) and the per-archive ingester is never invoked
- [x] each job binds to its own ingester (guards copy-paste regression where e.g. `sec_insider` calls the 13F ingester)
- [x] no archives + cancel-on → loop never enters, no exception
- [x] Lint / format / pyright clean
- [x] Codex pre-push: round 1 (3 findings) → round 2 no blocking findings

Refs #1064.