### PR TITLE
feat(#1102): share-class CIK uniqueness — partial-index relaxation (PR-A)

### DIFF
--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -344,16 +344,22 @@ def upsert_cik_mapping(
             if not cik:
                 logger.debug("CIK mapping: no CIK found for symbol %s", symbol)
                 continue
-            # external_identifiers has TWO uniqueness constraints:
-            #   (a) uq_external_identifiers_provider_value — UNIQUE(provider,
-            #       identifier_type, identifier_value)
-            #   (b) uq_external_identifiers_primary — partial UNIQUE
-            #       (instrument_id, provider, identifier_type) WHERE is_primary=TRUE
-            # ON CONFLICT can only target one. If an instrument already has a
-            # primary sec/cik row with a DIFFERENT value (e.g. the SEC ticker
-            # map changed), the INSERT below would violate (b) before (a)
-            # ever matched. Demote any mismatching primary row first so the
-            # upsert's own conflict target handles the rest.
+            # external_identifiers uniqueness invariants for sec/cik rows
+            # (post-#1102):
+            #   (a) uq_external_identifiers_cik_per_instrument — partial
+            #       UNIQUE(provider, identifier_type, identifier_value,
+            #       instrument_id) WHERE (provider='sec' AND
+            #       identifier_type='cik'). Allows N rows for the same CIK
+            #       across N siblings (GOOG + GOOGL, BRK.A + BRK.B).
+            #   (b) uq_external_identifiers_primary — partial
+            #       UNIQUE(instrument_id, provider, identifier_type) WHERE
+            #       is_primary=TRUE. Demote any mismatching primary row on
+            #       this instrument first so this insert's own conflict
+            #       target handles the same-CIK-already-mapped case.
+            # The instrument_id column is part of the conflict target so a
+            # hit means the same (CIK, instrument) row already exists; we
+            # only refresh the primary flag + last_verified_at and don't
+            # rewrite instrument_id.
             conn.execute(
                 """
                 UPDATE external_identifiers
@@ -376,8 +382,9 @@ def upsert_cik_mapping(
                     %(instrument_id)s, 'sec', 'cik', %(cik)s,
                     TRUE, NOW()
                 )
-                ON CONFLICT (provider, identifier_type, identifier_value) DO UPDATE SET
-                    instrument_id    = EXCLUDED.instrument_id,
+                ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+                    WHERE provider = 'sec' AND identifier_type = 'cik'
+                DO UPDATE SET
                     is_primary       = TRUE,
                     last_verified_at = NOW()
                 """,

--- a/app/services/sec_13f_securities_list.py
+++ b/app/services/sec_13f_securities_list.py
@@ -396,11 +396,15 @@ def _insert_external_identifier(
          violation on the INSERT rolls back this row only, not the
          entire backfill batch.
       3. ``ON CONFLICT (provider, identifier_type, identifier_value)
-         DO NOTHING RETURNING xmax`` — distinguishes fresh INSERT
-         from same-CUSIP-already-mapped without a second probe.
+         WHERE NOT (provider='sec' AND identifier_type='cik')
+         DO NOTHING RETURNING instrument_id`` — distinguishes fresh
+         INSERT from same-CUSIP-already-mapped without a second probe.
          Re-probe on no-row-returned tells us whether the conflict
          is same-instrument (already_mapped) or different
-         (conflict).
+         (conflict). The partial-index predicate is required by
+         Postgres ON CONFLICT inference post-#1102 (the global
+         unique-on-value constraint was replaced with two partial
+         indexes; CUSIP rows live under the non-CIK partial index).
     """
     cusip_norm = cusip.strip().upper()
 
@@ -427,7 +431,9 @@ def _insert_external_identifier(
                 INSERT INTO external_identifiers (
                     instrument_id, provider, identifier_type, identifier_value, is_primary
                 ) VALUES (%(iid)s, 'sec', 'cusip', %(cusip)s, FALSE)
-                ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+                ON CONFLICT (provider, identifier_type, identifier_value)
+                    WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+                DO NOTHING
                 RETURNING instrument_id
                 """,
                 {"iid": instrument_id, "cusip": cusip_norm},

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -381,6 +381,61 @@ pool with raw `ConnectionPool(...)` — use `open_pool`.
   §"Cancel semantics — cooperative" + Codex round 1 amendment B4 +
   round 2 R2-W2.
 
+## CIK = entity, CUSIP = security (#1102, settled 2026-05-10)
+
+Share-class siblings (GOOG/GOOGL, BRK.A/BRK.B, …) legitimately share an SEC
+CIK — the CIK identifies the issuer (legal entity), not the security. The
+CUSIP identifies the security (per-share-class). Every reputable feed (CRSP,
+Bloomberg, Yahoo, IEX, OpenFIGI, SEC EDGAR itself) encodes this shape.
+
+`external_identifiers` enforces this in two partial unique indexes
+(migration `sql/143`):
+
+- `uq_external_identifiers_provider_value_non_cik` — global UNIQUE on
+  `(provider, identifier_type, identifier_value)` for every NON-CIK
+  identifier. CUSIP / symbol / accession_no remain globally unique.
+- `uq_external_identifiers_cik_per_instrument` — UNIQUE on `(provider,
+  identifier_type, identifier_value, instrument_id)` for `(sec, cik)` rows.
+  Multiple instruments may share a CIK; each (CIK, instrument) pair is
+  unique.
+
+`upsert_cik_mapping` (`app/services/filings.py`) claims the CIK
+independently per instrument — there is no flap. Pre-#1102 the global
+constraint forced ON CONFLICT to rewrite the row's `instrument_id` to
+the last writer, so `daily_cik_refresh` ping-ponged the binding between
+siblings on every run, leaving one without 10-K / fundamentals.
+
+Postgres ON CONFLICT inference against partial unique indexes requires
+the predicate be supplied on the upsert. Empirically verified against
+Postgres 17 — without the predicate, the insert fails with
+"no unique or exclusion constraint matching the ON CONFLICT specification".
+All `INSERT ... ON CONFLICT (provider, identifier_type, identifier_value) DO ...`
+sites must attach the matching predicate (CIK target gets the 4-tuple
++ `WHERE provider='sec' AND identifier_type='cik'`; non-CIK gets the
+3-tuple + `WHERE NOT (provider='sec' AND identifier_type='cik')`).
+
+Entity-level data (10-K text, business summary, financial facts) is
+denormalised across siblings — acceptable for the small share-class
+population (~10 known instruments). If the population grows to 50+, file
+a follow-up to introduce a proper `entities` layer (Option B from the
+#1094 design discussion).
+
+`canonical_instrument_id` (#819) is a **different** mechanism for `.RTH`
+operational duplicates — same security, two ticker variants. Don't
+conflate.
+
+- **PR-A:** sql/143 migration + filings.py upsert + ON CONFLICT predicate
+  sweep across ~25 production + test sites + `tests/test_upsert_cik_mapping.py`
+  flips.
+- **PR-B (deferred):** fan-out CIK→instrument multimap in
+  `sec_companyfacts_ingest.py`, `sec_submissions_ingest.py`,
+  `sec_insider_dataset_ingest.py` so share-class siblings BOTH receive
+  bulk-ingest data. Until PR-B lands, only one of two siblings has
+  fundamentals / submissions / insider data — but the binding is stable
+  rather than flapping (strict improvement).
+
+**Spec:** `docs/superpowers/specs/2026-05-10-share-class-cik-uniqueness.md`.
+
 ## Maintenance rule
 
 When a new repo-level decision is agreed and is likely to affect future implementation:

--- a/docs/superpowers/specs/2026-05-10-share-class-cik-uniqueness.md
+++ b/docs/superpowers/specs/2026-05-10-share-class-cik-uniqueness.md
@@ -1,0 +1,209 @@
+# Share-class CIK uniqueness — implementation plan (#1102)
+
+Date: 2026-05-10
+Status: Spec drafted, Codex round 1+2 applied; ships as two PRs.
+
+## Split
+
+**PR1102a (this PR)** — schema migration + ON CONFLICT predicate sweep + filings.py upsert + tests/test_upsert_cik_mapping flips + settled-decisions. Stops the CIK flap. Bulk ingesters still write to one instrument per CIK (dict-collapse), but the binding is stable.
+
+**PR1102b (follow-up)** — fan-out fix in `sec_companyfacts_ingest.py`, `sec_submissions_ingest.py`, `sec_insider_dataset_ingest.py` so share-class siblings BOTH receive bulk-ingest data. Full operator-visible win.
+
+The split is deliberate: PR1102a is mechanical (predicate adds across ~25 sites). PR1102b changes per-callsite logic and adds tests proving fundamentals/insider/submissions land for both siblings.
+
+## Problem
+
+`external_identifiers` enforces a global UNIQUE on `(provider, identifier_type, identifier_value)`. When two share-class siblings (GOOG + GOOGL, BRK.A + BRK.B) legitimately share a CIK, `upsert_cik_mapping`'s ON CONFLICT clause rewrites the row's `instrument_id` to the last writer. `daily_cik_refresh` flaps the binding between siblings on every run, leaving one of them without a CIK and therefore without 10-K, fundamentals, or filings.
+
+Research at #1094 comment (CRSP / Bloomberg / Yahoo / IEX / OpenFIGI / SEC EDGAR all encode CIK = entity, CUSIP = security; siblings co-bind the parent CIK).
+
+## Decision (operator-locked 2026-05-10)
+
+Option A. Allow N `(provider='sec', identifier_type='cik', identifier_value=X)` rows pointing at different `instrument_id`s. CIK becomes a many-to-one relationship from instruments to issuer.
+
+## Schema migration — `sql/143_share_class_cik_uniqueness.sql`
+
+```sql
+-- Drop the global table-constraint UNIQUE on (provider, identifier_type, identifier_value).
+ALTER TABLE external_identifiers
+    DROP CONSTRAINT uq_external_identifiers_provider_value;
+
+-- Replace with a partial UNIQUE INDEX that excludes (sec, cik). Every other
+-- provider/type triple stays globally unique (CUSIP, symbol, etc.).
+CREATE UNIQUE INDEX uq_external_identifiers_provider_value_non_cik
+    ON external_identifiers (provider, identifier_type, identifier_value)
+    WHERE NOT (provider = 'sec' AND identifier_type = 'cik');
+
+-- For (sec, cik) rows, uniqueness is per-instrument so siblings co-bind.
+-- Per-(provider, type, value, instrument_id) — one row per (CIK, instrument)
+-- pair, but multiple instruments may share a CIK.
+CREATE UNIQUE INDEX uq_external_identifiers_cik_per_instrument
+    ON external_identifiers (provider, identifier_type, identifier_value, instrument_id)
+    WHERE provider = 'sec' AND identifier_type = 'cik';
+```
+
+Rationale for partial-index split:
+- Postgres CHECK / CONSTRAINT UNIQUE can't have a predicate. UNIQUE INDEX can.
+- The two new indexes together preserve every old guarantee on non-CIK rows AND add the per-instrument shape we want for CIK rows.
+- ON CONFLICT inference works against partial indexes when the INSERT row matches the predicate — Postgres docs confirm.
+
+## Code change 1 — `app/services/filings.py::upsert_cik_mapping`
+
+Codex spec round 1 BLOCKING: ON CONFLICT inference against a partial unique index requires the predicate be supplied, otherwise Postgres 17 reports "no unique or exclusion constraint matching the ON CONFLICT specification".
+
+```python
+INSERT INTO external_identifiers (
+    instrument_id, provider, identifier_type, identifier_value,
+    is_primary, last_verified_at
+)
+VALUES (
+    %(instrument_id)s, 'sec', 'cik', %(cik)s,
+    TRUE, NOW()
+)
+ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+    WHERE provider = 'sec' AND identifier_type = 'cik'
+DO UPDATE SET
+    is_primary       = TRUE,
+    last_verified_at = NOW()
+```
+
+Notes:
+- Drop `instrument_id = EXCLUDED.instrument_id` from the SET clause — the conflict target now includes `instrument_id` so a hit means it's already correct.
+- Comment block updated to name both partial indexes.
+- The is_primary demote UPDATE stays so a single instrument changing its CIK still demotes the prior row.
+
+## Code change 2 — non-CIK ON CONFLICT call site
+
+Codex spec round 1 BLOCKING: dropping the global constraint also breaks `app/services/sec_13f_securities_list.py:430`'s CUSIP upsert (`ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING`). With the global constraint gone the inference must match the new non-CIK partial index by supplying its predicate.
+
+```python
+INSERT INTO external_identifiers (
+    instrument_id, provider, identifier_type, identifier_value, is_primary
+) VALUES (%(iid)s, 'sec', 'cusip', %(cusip)s, FALSE)
+ON CONFLICT (provider, identifier_type, identifier_value)
+    WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+DO NOTHING
+RETURNING instrument_id
+```
+
+## Code change 3 — predicate sweep across ALL non-CIK ON CONFLICT sites (PR1102a)
+
+Codex round 2 BLOCKING + MEDIUM: dropping the global constraint breaks every `ON CONFLICT (provider, identifier_type, identifier_value)` site that doesn't supply the new partial-index predicate. Audited via grep:
+
+Production:
+
+- `app/services/filings.py:379` (CIK upsert — already in code change 1)
+- `app/services/sec_13f_securities_list.py:430` (CUSIP upsert — code change 2)
+- `scripts/seed_holder_coverage.py:385` (CUSIP upsert — Codex round 2)
+
+Test fixtures (~22 sites): `tests/test_insider_baseline_drill.py`, `tests/test_capabilities_resolver.py`, `tests/test_backfill_company_facts.py`, `tests/test_force_refresh_fundamentals.py`, `tests/test_filings_bulk_resolve.py`, `tests/test_def14a_drill.py`, `tests/test_ownership_drillthrough.py`, `tests/test_refresh_financial_facts_parallel.py`, `tests/test_filings_cancel_signal.py`, `tests/test_agent_cik_defense.py`, `tests/test_rewash_filings.py` (5 sites), `tests/test_blockholders_ingester.py`, `tests/test_n_port_ingest.py`, `tests/test_migration_066_purge_orphan_sec.py`, `tests/test_reconciliation.py`, `tests/test_institutional_holdings_ingester.py`.
+
+Each gets the same mechanical change: append `WHERE NOT (provider = 'sec' AND identifier_type = 'cik')` to the `ON CONFLICT` clause. All these test fixtures insert non-CIK rows (CUSIP / symbol) so the predicate matches the new non-CIK partial index.
+
+Empirically verified against Postgres 17 (T1/T2/T3/T4 in spec-review session): without the predicate, INSERT fails with `there is no unique or exclusion constraint matching the ON CONFLICT specification`.
+
+## Code change 4 — fan-out CIK→instrument lookup in three bulk ingesters (PR1102b — DEFERRED)
+
+Codex spec round 1 BLOCKING: three ingesters store `{cik: instrument_id}` as a dict, so a CIK that now legitimately binds to N siblings collapses to one. Each must change shape to a multimap and iterate the per-CIK list.
+
+| File | Current return | New return |
+|---|---|---|
+| `app/services/sec_companyfacts_ingest.py:96` | `dict[str, int]` | `dict[str, list[int]]` |
+| `app/services/sec_submissions_ingest.py:66` | `dict[str, tuple[int, str]]` | `dict[str, list[tuple[int, str]]]` |
+| `app/services/sec_insider_dataset_ingest.py:65` | `dict[str, int]` | `dict[str, list[int]]` |
+
+Per-callsite refactor: replace `instrument_id = cik_to_instrument.get(cik)` with `for instrument_id in cik_to_instrument.get(cik, []):` over the per-instrument write block. The persistence layer is per-instrument already — fan-out is a loop wrap, no new schema or write contract.
+
+Without these: GOOG and GOOGL both have CIK rows but only one of them receives companyfacts / submissions / insider data on the next bulk ingest. The operator would correctly call this a half-shipped feature.
+
+Performance: in the common case (no siblings) each list has one element; the loop iterates once and the cost matches today. Share-class CIKs (~10 instruments today) loop twice. SEC fetch deduplication is a follow-up if benchmarks demand it; nothing here makes the per-CIK fetch cost worse than today.
+
+## Read-path audit
+
+Five existing CIK-keyed read paths JOIN `external_identifiers`:
+
+- `app/services/sec_submissions_files_walk.py:73` — JOIN-driven; per-row processing handles fan-out implicitly.
+- `app/services/sec_companyfacts_ingest.py:104` — **collapses to dict[str,int]** → fixed in code change 3.
+- `app/services/sec_insider_dataset_ingest.py:73` — **collapses to dict[str,int]** → fixed in code change 3.
+- `app/services/sec_submissions_ingest.py:84` — **collapses to dict[str,tuple]** → fixed in code change 3.
+- `app/services/capabilities.py:237` — JOIN-driven; per-row already.
+
+Codex spec round 1 caught the three dict-collapse cases. The two JOIN-driven sites (sec_submissions_files_walk + capabilities) are confirmed safe.
+
+## Test updates — `tests/test_upsert_cik_mapping.py`
+
+| Existing test | Change |
+|---|---|
+| `test_first_insert_creates_primary_row` | unchanged |
+| `test_idempotent_rerun_same_mapping` | unchanged |
+| `test_cik_change_demotes_prior_primary` | unchanged (single-instrument path) |
+| `test_cik_reassigned_to_different_instrument` | **flip behaviour**: after both calls, BOTH instruments hold the CIK as primary. Old assertion that instrument 1 has zero rows is now wrong — under #1102 the row stays. |
+| `test_cik_reassigned_to_instrument_with_existing_different_cik` | **flip behaviour**: instrument 1 keeps its primary CIK 0000555555; instrument 2 holds both 0000555555 (primary) and 0000999999 (demoted) |
+
+New tests:
+
+- `test_share_class_siblings_co_bind_cik` — call upsert with GOOG + GOOGL on the same CIK; both rows are primary, neither flaps.
+- `test_share_class_repeat_run_is_idempotent` — second call against same panel adds zero rows, both still primary, last_verified_at advanced.
+
+## Verification matrix (dev DB, after migration runs)
+
+Per CLAUDE.md definition-of-done clauses 8-12 (ETL/schema migration affecting identity resolution).
+
+| Instrument | Class | Expected after `daily_cik_refresh` |
+|---|---|---|
+| AAPL | single | row primary on AAPL with CIK `0000320193`; control case ensures non-share-class regression |
+| GOOG | share-class | row primary on GOOG with CIK `0001652044` |
+| GOOGL | share-class | row primary on GOOGL with CIK `0001652044` |
+| BRK.A | share-class | row primary on BRK.A with CIK `0001067983` |
+| BRK.B | share-class | row primary on BRK.B with CIK `0001067983` |
+
+Each row read via:
+```sql
+SELECT instrument_id, identifier_value, is_primary
+  FROM external_identifiers
+ WHERE provider='sec' AND identifier_type='cik' AND instrument_id IN (
+   SELECT instrument_id FROM instruments WHERE symbol IN
+     ('AAPL', 'GOOG', 'GOOGL', 'BRK.A', 'BRK.B')
+ )
+ ORDER BY instrument_id;
+```
+
+Operator-visible verification:
+- `/instruments/GOOG/ownership-rollup` and `/instruments/GOOGL/ownership-rollup` both render with non-NULL totals.
+- 10-K / fundamentals tab on both renders.
+
+## Settled-decisions entry
+
+Append to `docs/settled-decisions.md`:
+
+```markdown
+## CIK = entity; CUSIP = security (#1102, settled 2026-05-10)
+
+Share-class siblings (GOOG/GOOGL, BRK.A/BRK.B) legitimately share a CIK
+(SEC's per-issuer registration identifier) but have distinct CUSIPs (per-
+security). Every reputable feed (CRSP, Bloomberg, Yahoo, IEX, OpenFIGI)
+encodes this. eBull's `external_identifiers` table now allows N
+`(sec, cik, value)` rows pointing at different `instrument_id`s, while
+keeping uniqueness on every other (provider, type, value) triple.
+
+`upsert_cik_mapping` claims the CIK independently per instrument. There
+is no flap. Entity-level data (10-K text, business summary, facts) is
+denormalised across siblings — acceptable for the small share-class
+population today (~10 instruments). If that grows to 50+, file a
+follow-up to introduce a proper `entities` layer (Option B from the
+#1094 design discussion).
+
+`canonical_instrument_id` (#819) is a different mechanism for `.RTH`
+operational duplicates — same security, two ticker variants.
+```
+
+## Out of scope
+
+- Option B entity layer (parked per design discussion).
+- `.RTH` mechanism — covered by #819 separately.
+- Universe expansion to seed share-class siblings — they already exist on the instruments table.
+- SEC fetch deduplication for shared CIKs — file follow-up only if benchmarks show it.
+
+## Codex spec review prompt
+
+Review correctness of: (a) migration partial-index design + ON CONFLICT inference; (b) test behaviour flips; (c) is_primary demote interaction with the new conflict target. Reply terse with severity-tagged findings.

--- a/scripts/seed_holder_coverage.py
+++ b/scripts/seed_holder_coverage.py
@@ -382,7 +382,9 @@ def _seed_all(conn: psycopg.Connection[tuple]) -> None:
             INSERT INTO external_identifiers (
                 instrument_id, provider, identifier_type, identifier_value, is_primary
             ) VALUES (%s, 'sec', 'cusip', %s, TRUE)
-            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            ON CONFLICT (provider, identifier_type, identifier_value)
+                WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+            DO NOTHING
             """,
             (instrument_id, cusip),
         )

--- a/sql/143_share_class_cik_uniqueness.sql
+++ b/sql/143_share_class_cik_uniqueness.sql
@@ -1,0 +1,57 @@
+-- Migration 143: relax external_identifiers (sec, cik) uniqueness for share-class siblings (#1102)
+--
+-- Background. The original `uq_external_identifiers_provider_value` table
+-- constraint enforced a single global UNIQUE on
+-- `(provider, identifier_type, identifier_value)`. This is correct for CUSIP /
+-- symbol / accession_no — those are per-security identifiers — but wrong for
+-- SEC CIK, which identifies an issuer (legal entity) not a security. Two
+-- share-class siblings (GOOG + GOOGL, BRK.A + BRK.B, etc.) legitimately share
+-- a CIK and have distinct CUSIPs. Under the old constraint
+-- `upsert_cik_mapping`'s ON CONFLICT clause rewrote the row's `instrument_id`
+-- to whichever sibling SEC's ticker map iterated last, so `daily_cik_refresh`
+-- flapped the binding on every run. One sibling always lost its 10-K /
+-- fundamentals / filings drill-in.
+--
+-- Decision (operator-locked 2026-05-10, settled-decisions §"CIK = entity;
+-- CUSIP = security"): allow N rows for the same `(provider='sec',
+-- identifier_type='cik', identifier_value=X)` triple as long as their
+-- `instrument_id` differs. Every reputable feed (CRSP, Bloomberg, Yahoo, IEX,
+-- OpenFIGI) encodes the same shape. Research detail at #1094 comment.
+--
+-- Implementation. Drop the global table-constraint UNIQUE and replace with
+-- two partial UNIQUE INDEXes:
+--
+--   1. `uq_external_identifiers_provider_value_non_cik` — global UNIQUE on
+--      `(provider, identifier_type, identifier_value)` for every NON-CIK
+--      identifier. CUSIP / symbol / accession_no remain globally unique as
+--      they were under the old constraint.
+--
+--   2. `uq_external_identifiers_cik_per_instrument` — UNIQUE on
+--      `(provider, identifier_type, identifier_value, instrument_id)` for
+--      `(provider='sec', identifier_type='cik')` rows. One row per (CIK,
+--      instrument) pair, but multiple instruments may share a CIK.
+--
+-- Postgres ON CONFLICT inference against partial indexes requires the
+-- predicate be supplied on the upsert. Every existing
+-- `ON CONFLICT (provider, identifier_type, identifier_value) DO ...` site is
+-- updated in the same PR (#1102 PR-A) to attach the matching predicate. CIK
+-- upserts move to the 4-tuple target with the CIK predicate; non-CIK upserts
+-- keep the 3-tuple target with the NON-CIK predicate. Empirically verified
+-- against Postgres 17 — without the predicate, the insert fails with
+-- "no unique or exclusion constraint matching the ON CONFLICT specification".
+--
+-- The `uq_external_identifiers_primary` partial index on
+-- `(instrument_id, provider, identifier_type) WHERE is_primary=TRUE` is
+-- unaffected — it operates on a different shape (per-instrument primacy)
+-- and was always orthogonal to the global value-uniqueness rule.
+
+ALTER TABLE external_identifiers
+    DROP CONSTRAINT uq_external_identifiers_provider_value;
+
+CREATE UNIQUE INDEX uq_external_identifiers_provider_value_non_cik
+    ON external_identifiers (provider, identifier_type, identifier_value)
+    WHERE NOT (provider = 'sec' AND identifier_type = 'cik');
+
+CREATE UNIQUE INDEX uq_external_identifiers_cik_per_instrument
+    ON external_identifiers (provider, identifier_type, identifier_value, instrument_id)
+    WHERE provider = 'sec' AND identifier_type = 'cik';

--- a/tests/test_agent_cik_defense.py
+++ b/tests/test_agent_cik_defense.py
@@ -165,7 +165,9 @@ def _seed(
         INSERT INTO external_identifiers
             (instrument_id, provider, identifier_type, identifier_value, is_primary)
         VALUES (%s, 'sec', 'cik', %s, %s)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+        DO NOTHING
         """,
         (instrument_id, cik, is_primary),
     )
@@ -195,10 +197,10 @@ def test_audit_excludes_secondary_by_default(
     #
     # Use a *different* agent CIK from the sibling test
     # ``test_audit_finds_primary_agent_cik_contamination`` so the
-    # ``ON CONFLICT (provider, identifier_type, identifier_value) DO
-    # NOTHING`` partial unique index doesn't silently skip this seed
-    # if test ordering leaves the prior test's row alive (PR #765
-    # review BLOCKING).
+    # ``ON CONFLICT ... DO NOTHING`` partial unique index
+    # ``uq_external_identifiers_cik_per_instrument`` doesn't silently
+    # skip this seed if test ordering leaves the prior test's row alive
+    # for the same (CIK, instrument) pair (PR #765 review BLOCKING).
     _seed(ebull_test_conn, 992_001, "ACD_SEC", "0001213900", is_primary=False)
     rows = find_contaminated(ebull_test_conn, include_secondary=False)
     assert 992_001 not in {r[0] for r in rows}

--- a/tests/test_backfill_company_facts.py
+++ b/tests/test_backfill_company_facts.py
@@ -53,7 +53,9 @@ def _seed(
             INSERT INTO external_identifiers
                 (instrument_id, provider, identifier_type, identifier_value, is_primary)
             VALUES (%s, 'sec', 'cik', %s, %s)
-            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+                WHERE provider = 'sec' AND identifier_type = 'cik'
+            DO NOTHING
             """,
             (instrument_id, cik, is_primary_cik),
         )

--- a/tests/test_blockholders_ingester.py
+++ b/tests/test_blockholders_ingester.py
@@ -289,7 +289,9 @@ def _seed_cusip_mapping(conn: psycopg.Connection[tuple], *, instrument_id: int, 
         """
         INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
         VALUES (%s, 'sec', 'cusip', %s, TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (instrument_id, cusip.upper()),
     )

--- a/tests/test_capabilities_resolver.py
+++ b/tests/test_capabilities_resolver.py
@@ -80,7 +80,9 @@ def _seed_sec_cik(
             INSERT INTO external_identifiers
                 (instrument_id, provider, identifier_type, identifier_value, is_primary)
             VALUES (%s, 'sec', 'cik', %s, %s)
-            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+                WHERE provider = 'sec' AND identifier_type = 'cik'
+            DO NOTHING
             """,
             (instrument_id, cik, is_primary),
         )
@@ -346,7 +348,9 @@ def test_non_cik_sec_identifier_does_not_augment(
             INSERT INTO external_identifiers
                 (instrument_id, provider, identifier_type, identifier_value, is_primary)
             VALUES (%s, 'sec', 'accession_no', '0001234567-26-000001', TRUE)
-            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            ON CONFLICT (provider, identifier_type, identifier_value)
+                WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+            DO NOTHING
             """,
             (960006,),
         )

--- a/tests/test_def14a_drill.py
+++ b/tests/test_def14a_drill.py
@@ -42,7 +42,9 @@ def _seed_instrument_with_cik(
         INSERT INTO external_identifiers (
             instrument_id, provider, identifier_type, identifier_value, is_primary
         ) VALUES (%s, 'sec', 'cik', %s, TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+        DO NOTHING
         """,
         (iid, cik),
     )

--- a/tests/test_filings_bulk_resolve.py
+++ b/tests/test_filings_bulk_resolve.py
@@ -83,7 +83,9 @@ def _seed_instrument(
             INSERT INTO external_identifiers
                 (instrument_id, provider, identifier_type, identifier_value, is_primary)
             VALUES (%s, 'sec', 'cik', %s, TRUE)
-            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+                WHERE provider = 'sec' AND identifier_type = 'cik'
+            DO NOTHING
             """,
             (instrument_id, cik),
         )

--- a/tests/test_filings_cancel_signal.py
+++ b/tests/test_filings_cancel_signal.py
@@ -80,7 +80,9 @@ def _seed_instrument_with_cik(
         INSERT INTO external_identifiers
             (instrument_id, provider, identifier_type, identifier_value, is_primary)
         VALUES (%s, 'sec', 'cik', %s, TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+        DO NOTHING
         """,
         (instrument_id, cik),
     )

--- a/tests/test_force_refresh_fundamentals.py
+++ b/tests/test_force_refresh_fundamentals.py
@@ -52,7 +52,9 @@ def _seed(
             INSERT INTO external_identifiers
                 (instrument_id, provider, identifier_type, identifier_value, is_primary)
             VALUES (%s, 'sec', 'cik', %s, TRUE)
-            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+                WHERE provider = 'sec' AND identifier_type = 'cik'
+            DO NOTHING
             """,
             (instrument_id, cik),
         )

--- a/tests/test_insider_baseline_drill.py
+++ b/tests/test_insider_baseline_drill.py
@@ -43,7 +43,9 @@ def _seed_instrument_with_cik(
         INSERT INTO external_identifiers (
             instrument_id, provider, identifier_type, identifier_value, is_primary
         ) VALUES (%s, 'sec', 'cik', %s, TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+        DO NOTHING
         """,
         (iid, cik),
     )

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -166,7 +166,9 @@ def _seed_cusip_mapping(conn: psycopg.Connection[tuple], *, instrument_id: int, 
         """
         INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
         VALUES (%s, 'sec', 'cusip', %s, TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (instrument_id, cusip.upper()),
     )

--- a/tests/test_migration_066_purge_orphan_sec.py
+++ b/tests/test_migration_066_purge_orphan_sec.py
@@ -75,7 +75,9 @@ def _link_sec_cik(conn: object, instrument_id: int, cik: str) -> None:
         INSERT INTO external_identifiers
             (instrument_id, provider, identifier_type, identifier_value, is_primary)
         VALUES (%s, 'sec', 'cik', %s, TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+        DO NOTHING
         """,
         (instrument_id, cik),
     )

--- a/tests/test_n_port_ingest.py
+++ b/tests/test_n_port_ingest.py
@@ -76,7 +76,9 @@ def _seed_cusip_mapping(conn: psycopg.Connection[tuple], *, instrument_id: int, 
             instrument_id, provider, identifier_type, identifier_value, is_primary
         )
         VALUES (%s, 'sec', 'cusip', %s, TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (instrument_id, cusip.upper()),
     )

--- a/tests/test_ownership_drillthrough.py
+++ b/tests/test_ownership_drillthrough.py
@@ -189,7 +189,9 @@ def test_blockholder_state_counts_partials_with_null_instrument(
         INSERT INTO external_identifiers (
             instrument_id, provider, identifier_type, identifier_value, is_primary
         ) VALUES (%s, 'sec', 'cusip', 'BHCUSIP1', FALSE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (970_007,),
     )

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -67,7 +67,9 @@ def _seed_instrument(
             INSERT INTO external_identifiers (
                 instrument_id, provider, identifier_type, identifier_value, is_primary
             ) VALUES (%s, 'sec', 'cik', %s, TRUE)
-            ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+            ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+                WHERE provider = 'sec' AND identifier_type = 'cik'
+            DO NOTHING
             """,
             (iid, cik),
         )

--- a/tests/test_refresh_financial_facts_parallel.py
+++ b/tests/test_refresh_financial_facts_parallel.py
@@ -126,7 +126,9 @@ def _seed_instrument(conn: psycopg.Connection[tuple], instrument_id: int, symbol
         INSERT INTO external_identifiers
             (instrument_id, provider, identifier_type, identifier_value, is_primary)
         VALUES (%s, 'sec', 'cik', %s, TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+        DO NOTHING
         """,
         (instrument_id, cik),
     )

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -999,7 +999,9 @@ def test_blockholders_apply_re_resolves_instrument_from_fresh_cusip(
         ) VALUES
             (%s, 'sec', 'cusip', 'OLDCUSIP', FALSE),
             (%s, 'sec', 'cusip', 'NEWCUSIP', FALSE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (old_iid, new_iid),
     )
@@ -1263,7 +1265,9 @@ def test_13f_infotable_apply_replaces_holdings_with_re_resolved_instrument(
         ) VALUES
             (%s, 'sec', 'cusip', 'OLD13FCSP', FALSE),
             (%s, 'sec', 'cusip', 'NEW13FCSP', FALSE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (old_iid, new_iid),
     )
@@ -1359,7 +1363,9 @@ def test_13f_infotable_apply_returns_false_when_cusip_unresolved(
         INSERT INTO external_identifiers (
             instrument_id, provider, identifier_type, identifier_value, is_primary
         ) VALUES (%s, 'sec', 'cusip', 'KNOWNCSP', FALSE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (iid,),
     )
@@ -1474,7 +1480,9 @@ def test_13f_infotable_apply_rescues_tombstoned_accession(
         INSERT INTO external_identifiers (
             instrument_id, provider, identifier_type, identifier_value, is_primary
         ) VALUES (%s, 'sec', 'cusip', 'RESCUECSP', FALSE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (iid,),
     )
@@ -1779,7 +1787,9 @@ def test_13f_infotable_apply_preserves_existing_when_some_cusips_unresolved(
         INSERT INTO external_identifiers (
             instrument_id, provider, identifier_type, identifier_value, is_primary
         ) VALUES (%s, 'sec', 'cusip', 'RESOLVED1', TRUE)
-        ON CONFLICT (provider, identifier_type, identifier_value) DO NOTHING
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
         """,
         (iid_existing_a,),
     )

--- a/tests/test_upsert_cik_mapping.py
+++ b/tests/test_upsert_cik_mapping.py
@@ -1,16 +1,24 @@
-"""Regression tests for upsert_cik_mapping — pins #257 / #267 fix.
+"""Regression tests for upsert_cik_mapping.
 
-external_identifiers has two uniqueness constraints:
+Pins #257 / #267 (original constraint design) and #1102 (share-class
+CIK relaxation). Post-#1102 ``external_identifiers`` enforces:
 
-- uq_external_identifiers_provider_value — UNIQUE(provider, identifier_type,
-  identifier_value)
-- uq_external_identifiers_primary — partial UNIQUE(instrument_id, provider,
-  identifier_type) WHERE is_primary=TRUE
+- uq_external_identifiers_provider_value_non_cik — partial UNIQUE
+  (provider, identifier_type, identifier_value) WHERE NOT (sec/cik).
+  CUSIP / symbol / accession_no remain globally unique.
+- uq_external_identifiers_cik_per_instrument — partial UNIQUE
+  (provider, identifier_type, identifier_value, instrument_id) WHERE
+  (sec/cik). Multiple instruments may share a CIK (share-class
+  siblings: GOOG/GOOGL, BRK.A/BRK.B); each (CIK, instrument) pair is
+  unique.
+- uq_external_identifiers_primary — partial UNIQUE
+  (instrument_id, provider, identifier_type) WHERE is_primary=TRUE.
 
-ON CONFLICT in upsert_cik_mapping targets the first. The partial UNIQUE is
-handled by demoting any mismatching primary row first. These tests lock that
-behaviour so a future refactor cannot reintroduce the UniqueViolation that
-crashed daily_cik_refresh on every repeat run (#257).
+upsert_cik_mapping's ON CONFLICT targets the per-instrument CIK index;
+the partial primary UNIQUE is handled by demoting any mismatching
+primary row first. Tests lock the new behaviour so a future refactor
+cannot reintroduce the flap (#1102) that left one share-class sibling
+without 10-K / fundamentals / filings.
 """
 
 from __future__ import annotations
@@ -113,11 +121,77 @@ def test_cik_change_demotes_prior_primary(ebull_test_conn: psycopg.Connection[tu
     ]
 
 
-def test_cik_reassigned_to_different_instrument(ebull_test_conn: psycopg.Connection[tuple]) -> None:
-    """Same CIK moves from instrument A to instrument B.
+def test_same_cik_co_binds_to_two_instruments(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """#1102: share-class siblings legitimately share a CIK.
 
-    Exercises the (provider, identifier_type, identifier_value) conflict path:
-    ON CONFLICT updates instrument_id to the new owner.
+    Pre-#1102 the global UNIQUE on (provider, type, value) flapped the
+    binding between siblings on every ``daily_cik_refresh`` — one
+    sibling always lost its 10-K / fundamentals.
+
+    Post-#1102 the per-instrument partial unique index allows two
+    rows for the same CIK as long as ``instrument_id`` differs. Both
+    instruments hold the CIK as primary; neither flaps.
+    """
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="GOOG")
+    _seed_instrument(conn, instrument_id=2, symbol="GOOGL")
+
+    upsert_cik_mapping(conn, {"GOOG": "0001652044"}, [("GOOG", "1")])
+    upsert_cik_mapping(conn, {"GOOGL": "0001652044"}, [("GOOGL", "2")])
+
+    # BOTH instruments hold the CIK as primary. Pre-#1102 the second
+    # call would have rewritten instrument 1's row to instrument 2.
+    assert _all_rows(conn, 1) == [("0001652044", True)]
+    assert _all_rows(conn, 2) == [("0001652044", True)]
+    assert _primary_cik(conn, 1) == "0001652044"
+    assert _primary_cik(conn, 2) == "0001652044"
+
+
+def test_share_class_repeat_run_is_idempotent(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """A second pass over the same panel adds zero rows; both
+    instruments still hold the CIK as primary and ``last_verified_at``
+    advances on the in-place UPDATE (asserted explicitly).
+    """
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="GOOG")
+    _seed_instrument(conn, instrument_id=2, symbol="GOOGL")
+
+    upsert_cik_mapping(conn, {"GOOG": "0001652044"}, [("GOOG", "1")])
+    upsert_cik_mapping(conn, {"GOOGL": "0001652044"}, [("GOOGL", "2")])
+
+    last_verified_before = conn.execute(
+        "SELECT instrument_id, last_verified_at FROM external_identifiers "
+        "WHERE provider='sec' AND identifier_type='cik' "
+        "AND identifier_value='0001652044' ORDER BY instrument_id"
+    ).fetchall()
+
+    # Second pass — no new rows, just refreshes.
+    upsert_cik_mapping(conn, {"GOOG": "0001652044"}, [("GOOG", "1")])
+    upsert_cik_mapping(conn, {"GOOGL": "0001652044"}, [("GOOGL", "2")])
+
+    assert _all_rows(conn, 1) == [("0001652044", True)]
+    assert _all_rows(conn, 2) == [("0001652044", True)]
+
+    last_verified_after = conn.execute(
+        "SELECT instrument_id, last_verified_at FROM external_identifiers "
+        "WHERE provider='sec' AND identifier_type='cik' "
+        "AND identifier_value='0001652044' ORDER BY instrument_id"
+    ).fetchall()
+    assert len(last_verified_before) == 2
+    assert len(last_verified_after) == 2
+    for (iid_b, ts_b), (iid_a, ts_a) in zip(last_verified_before, last_verified_after, strict=True):
+        assert iid_b == iid_a
+        assert ts_a >= ts_b, f"last_verified_at did not advance for iid={iid_a}: {ts_b} → {ts_a}"
+
+
+def test_cik_reassignment_does_not_remove_prior_instrument_binding(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Post-#1102 the rename / reassignment scenario no longer rewrites
+    the prior instrument's row. Instrument 1 keeps its CIK; instrument
+    2 also acquires the CIK as primary. If the rename intent is
+    genuine the prior row must be cleaned up by an explicit operator
+    action (not a side effect of upsert_cik_mapping).
     """
     conn = ebull_test_conn
     _seed_instrument(conn, instrument_id=1, symbol="OLD")
@@ -126,22 +200,19 @@ def test_cik_reassigned_to_different_instrument(ebull_test_conn: psycopg.Connect
     upsert_cik_mapping(conn, {"OLD": "0000555555"}, [("OLD", "1")])
     upsert_cik_mapping(conn, {"NEW": "0000555555"}, [("NEW", "2")])
 
-    # Instrument 1 must have no rows at all — the ON CONFLICT path rewrites
-    # the single (sec, cik, 0000555555) row in place from instrument 1 to 2.
-    assert _all_rows(conn, 1) == []
+    assert _all_rows(conn, 1) == [("0000555555", True)]
     assert _all_rows(conn, 2) == [("0000555555", True)]
 
 
-def test_cik_reassigned_to_instrument_with_existing_different_cik(
+def test_cik_change_demotes_prior_primary_when_target_already_holds_different_cik(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
-    """Combined conflict: target instrument already holds a different primary CIK,
-    and the incoming CIK is currently primary on a different instrument.
-
-    Exercises both conflict paths in one call: the demote UPDATE must fire for
-    the target instrument's stale primary row, and the ON CONFLICT must fire on
-    the (provider, identifier_type, identifier_value) triple to move the
-    existing row to the target.
+    """Combined: instrument 2 already holds CIK 0000999999 as primary;
+    incoming map says it should hold CIK 0000555555 instead. The
+    demote UPDATE fires (0000999999 → is_primary=FALSE) and the
+    incoming CIK is inserted as primary. Instrument 1's row is
+    untouched (it still holds 0000555555 from a prior pass —
+    share-class co-binding).
     """
     conn = ebull_test_conn
     _seed_instrument(conn, instrument_id=1, symbol="OLD")
@@ -151,7 +222,7 @@ def test_cik_reassigned_to_instrument_with_existing_different_cik(
     upsert_cik_mapping(conn, {"NEW": "0000999999"}, [("NEW", "2")])
     upsert_cik_mapping(conn, {"NEW": "0000555555"}, [("NEW", "2")])
 
-    assert _primary_cik(conn, 1) is None
+    assert _all_rows(conn, 1) == [("0000555555", True)]
     assert _primary_cik(conn, 2) == "0000555555"
     assert _all_rows(conn, 2) == [
         ("0000555555", True),


### PR DESCRIPTION
## What

Migration `sql/143` drops the global `uq_external_identifiers_provider_value` constraint and replaces with two partial UNIQUE INDEXes:

- `uq_external_identifiers_provider_value_non_cik` — global UNIQUE on `(provider, identifier_type, identifier_value)` for every NON-CIK identifier (CUSIP / symbol / accession_no remain globally unique).
- `uq_external_identifiers_cik_per_instrument` — UNIQUE on `(provider, identifier_type, identifier_value, instrument_id)` for `(sec, cik)` rows. Multiple instruments may share a CIK; each (CIK, instrument) pair is unique.

`upsert_cik_mapping` claims the CIK independently per instrument — no flap. All `INSERT ... ON CONFLICT (provider, identifier_type, identifier_value) DO ...` sites attach the matching partial-index predicate (Postgres ON CONFLICT inference against partial indexes requires the predicate; empirically verified on Postgres 17).

## Why

Pre-#1102 the global constraint forced ON CONFLICT to rewrite `instrument_id` to the last writer; `daily_cik_refresh` flapped the binding between share-class siblings (GOOG/GOOGL, BRK.A/BRK.B) on every run, leaving one of them without 10-K / fundamentals / filings until the next flap.

Decision: CIK = entity, CUSIP = security (research at #1094 comment).

Spec: `docs/superpowers/specs/2026-05-10-share-class-cik-uniqueness.md` (3 Codex spec rounds folded). Settled-decisions entry added.

## Sites changed

- `app/services/filings.py::upsert_cik_mapping` → 4-tuple/CIK predicate
- `app/services/sec_13f_securities_list.py:430` → 3-tuple/non-CIK predicate (CUSIP)
- `scripts/seed_holder_coverage.py:385` → same (CUSIP)
- 18 test fixtures across 16 files split by identifier type

## Test plan

- [x] `uv run pytest tests/test_upsert_cik_mapping.py` — 8/8 (4 new tests pin share-class semantics + idempotency + reassignment + combined demote)
- [x] `uv run pytest <all 17 touched test files> -n0` — 202 passed (4 pre-existing rewash failures unrelated to #1102, verified by reverting on main)
- [x] Lint / format / pyright clean
- [x] Codex pre-push: round 1 LOW-only (docstring + test assertion strengthening), all addressed
- [x] Empirical verification on dev DB (clauses 8-12): AAPL primary `0000320193`; GOOG + GOOGL BOTH primary on `0001652044`; BRK.B primary `0001067983`. Idempotent on 3x rerun.

## PR-B (deferred)

Fan-out CIK→instrument multimap in `sec_companyfacts_ingest`, `sec_submissions_ingest`, `sec_insider_dataset_ingest` so share-class siblings BOTH receive bulk-ingest data. Until PR-B lands, only one sibling has fundamentals / submissions / insider data — but the binding is stable rather than flapping (strict improvement).

Closes part of #1102 (PR-A scope only).
Refs #1094.