### PR TITLE
feat(#1117): share-class CIK multimap fan-out + filing_events bridge (PR-B)

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -2,6 +2,34 @@
 
 > Read this when adding a new ingest path, schema migration, or operator-visible read endpoint. The non-negotiable directive from the operator: future agents must use this file to answer "where does X come from?" without guessing. Cross-reference: `docs/settled-decisions.md` for the decisions; `docs/review-prevention-log.md` for the recurring traps; `.claude/skills/data-sources/sec-edgar.md` for the source-of-truth knowledge.
 
+## 0.0 Before-spec gate — for any ETL / schema / parser / identity work
+
+If you are about to write a spec or implementation that touches schema, parsers, ingest paths, or identity resolution, complete this gate FIRST. Codex catching what this skill should have owned is a skill defect (operator-locked 2026-05-10).
+
+1. **Grep the actual shape, never paraphrase.** For every table you touch in writes:
+   - PK columns (column order matters for ON CONFLICT inference).
+   - Every UNIQUE / UNIQUE INDEX (full column list, in order).
+   - Every FK in (children pointing AT this table) and FK out.
+   - Every CHECK constraint on enum-shaped columns (allowed values).
+   - Generated columns / triggers.
+   The reference matrix in §11 is the in-skill shortcut for the load-bearing tables. If your table is not listed, run `psql \d <table>` or grep `sql/*.sql` and add it before writing the spec.
+2. **Identify the canonical-pick pattern for any "single canonical row" lookup.** CIK→canonical ext-identifier row, observation-priority winner, manifest source mapping, etc. Reference matrix §12. Re-using existing patterns verbatim avoids drift.
+3. **Identify FK cascade impact for any PK / UNIQUE relaxation.** A child FK keyed on the parent's old shape blocks the relaxation. The reference matrix §11.B lists every accession-keyed parent + its children. Check before proposing PK changes.
+4. **Identify the migration shape-check pattern.** `pg_constraint.contype + conkey` and `pg_index.indisunique + indkey` introspection are the canonical idempotency primitives — name-only checks miss partial-applies. Reference §12.D.
+5. **Confirm the actual writer ON CONFLICT syntax.** Never propose changing a conflict target without grepping every site that writes the table. The grep command:
+
+   ```bash
+   grep -rn "ON CONFLICT.*<table_or_constraint_name>" --include="*.py" --include="*.sql"
+   ```
+
+6. **Confirm the actual reader filter pattern per site.** A read site that filters on a column that becomes per-instrument fan-out will silently multiply rows. The grep command:
+
+   ```bash
+   grep -rn "FROM <table>\|JOIN <table>" --include="*.py" -A3 | grep "instrument_id"
+   ```
+
+If any step's answer disagrees with what your spec assumed, **fix the spec first, then run Codex**. The spec author owns this gate. Codex is the second opinion, not the first.
+
 ## 0. Top-of-mind invariants — the don't-break list
 
 | # | Rule | Enforced by |
@@ -667,3 +695,217 @@ Today's UI shows you the locked door with a "no entry" sign on every category. T
 **Answer:** SEC bulk-download stages (12-15 in the sequence) fetch ~12,000 SEC per-CIK pages at a 10-req/s rate-limit. The bootstrap's `sec_first_install_drain` stage (#909 / PR1c) is the long pole — bounded by SEC's published rate limit, not eBull. Re-run all on a fresh DB is roughly 20+ minutes of bandwidth.
 
 Operator-helpful surface (deferred, NOT scheduled): a pre-flight estimate "this will issue ~12,000 SEC requests over ~20 minutes" before kick-off. Tracked as a future operator-UX ticket; not blocking PR7.
+
+## 11. Integrity reference matrix — actual shapes per table
+
+> When in doubt, this section is the source of truth, not memory. Source: grep of `sql/*.sql` 2026-05-10. If a table's actual shape diverges from this matrix, the matrix is stale — fix it before continuing.
+
+### 11.A SEC filing-object tables — accession-keyed entity-level
+
+| Table | PK | UNIQUE / UNIQUE INDEX | Children with FK pointing here | CHECK enum cols |
+|---|---|---|---|---|
+| `eight_k_filings` (sql/061) | `(accession_number)` | n/a | `eight_k_items.accession_number → eight_k_filings.accession_number ON DELETE CASCADE` (UNIQUE on `(accession_number, item_code)`); `eight_k_exhibits.accession_number → eight_k_filings.accession_number ON DELETE CASCADE` (UNIQUE on `(accession_number, exhibit_number)`) | n/a |
+| `insider_filings` (sql/057) | `(accession_number)` | n/a | `insider_filers.accession_number → insider_filings.accession_number ON DELETE CASCADE` (UNIQUE on `(accession_number, filer_cik)`); `insider_transaction_footnotes.accession_number → insider_filings.accession_number ON DELETE CASCADE` (UNIQUE on `(accession_number, footnote_id)`); `insider_transactions.accession_number → insider_filings.accession_number` (PK on `(accession_number, txn_row_num)`); `insider_initial_holdings.accession_number → insider_filings.accession_number` (PK on `(accession_number, row_num)`) | n/a |
+| `def14a_ingest_log` (sql/097) | `(accession_number)` | n/a | n/a | `status IN ('success','partial','failed')` |
+| `n_port_ingest_log` (sql/125) | `(accession_number)` | n/a | n/a | (status enum — verify before write) |
+| `sec_filing_manifest` (sql/118) | `(accession_number)` | n/a | self-FK `amends_accession → sec_filing_manifest.accession_number ON DELETE SET NULL` | `source IN ('sec_form3','sec_form4','sec_form5','sec_13d','sec_13g','sec_13f_hr','sec_def14a','sec_n_port','sec_n_csr','sec_10k','sec_10q','sec_8k','sec_xbrl_facts','finra_short_interest')`; `subject_type IN ('issuer','institutional_filer','blockholder_filer','fund_series','finra_universe')`; `ingest_status IN ('pending','fetched','parsed','tombstoned','failed')`; `raw_status IN ('absent','stored','compacted')`; CHECK `(subject_type='issuer' AND instrument_id IS NOT NULL) OR (subject_type<>'issuer' AND instrument_id IS NULL)` |
+| `filing_raw_documents` (sql/107) | `(accession_number, document_kind)` | n/a | n/a | `document_kind` enum (extended in sql/122 to add `nport_xml` etc.) |
+| `cik_raw_documents` (sql/109) | (verify before write) | (verify) | (verify) | (verify) |
+| `sec_reference_documents` (sql/121) | `(document_kind, period_year, period_quarter)` | n/a | n/a | (verify) |
+
+**Implication:** `eight_k_filings` and `insider_filings` PK relaxation to `(accession, instrument_id)` is BLOCKED by their child tables' accession-only FKs. If you need per-sibling visibility, route reads through `filing_events` (the per-instrument bridge — see §11.C). Do NOT propose PK changes here without rewriting every child FK.
+
+### 11.B SEC bridge / per-instrument tables
+
+| Table | PK | UNIQUE / UNIQUE INDEX | Children with FK | CHECK enum cols |
+|---|---|---|---|---|
+| `filing_events` (sql/001 + sql/004) | `(filing_event_id)` BIGSERIAL | `uq_filing_events_provider_unique` UNIQUE on `(provider, provider_filing_id)` | n/a | n/a |
+| `external_identifiers` (sql/003) | `(external_identifier_id)` BIGSERIAL | (post-sql/143) partial UNIQUE INDEX `uq_external_identifiers_provider_value_non_cik` on `(provider, identifier_type, identifier_value) WHERE NOT (provider='sec' AND identifier_type='cik')` + partial UNIQUE INDEX `uq_external_identifiers_cik_per_instrument` on `(provider, identifier_type, identifier_value, instrument_id) WHERE provider='sec' AND identifier_type='cik'` | n/a | (verify identifier_type enum) |
+| `def14a_beneficial_holdings` (sql/097) | `(holding_id)` BIGSERIAL | `uq_def14a_holdings_accession_holder` UNIQUE INDEX on `(accession_number, holder_name)` | n/a | n/a |
+| `insider_transactions` (sql/056 + sql/057) | `(accession_number, txn_row_num)` | n/a | (FK to `insider_filings`) | n/a |
+| `insider_initial_holdings` (sql/093) | `(accession_number, row_num)` | n/a | (FK to `insider_filings`) | n/a |
+| `institutional_holdings` (sql/090) | `(holding_id)` BIGSERIAL | partial UNIQUE INDEX on `(accession_number, instrument_id, COALESCE(is_put_call,'EQUITY'))` | n/a | (verify) |
+| `institutional_filers` (sql/090) | `(institutional_filer_id)` BIGSERIAL | UNIQUE `(cik)` | n/a | `filer_type IN ('ETF','INV','INS','BD','OTHER')` |
+| `blockholder_filers` (sql/095) | `(blockholder_filer_id)` BIGSERIAL | UNIQUE `(cik)` | n/a | (verify) |
+| `blockholder_filings` (sql/095) | (verify) | (verify) | (verify) | (verify status_flag enum) |
+| `unresolved_13f_cusips` (sql/099) | (verify) | (verify) | n/a | `resolution_status IN ('unresolvable','ambiguous','conflict','manual_review','resolved_via_extid')` |
+| `data_freshness_index` (sql/120) | `(subject_type, subject_id, source)` | n/a | n/a | (state enum: `unknown,current,expected_filing_overdue,never_filed,error`) |
+| `instrument_cik_history` (sql/102) | (BIGSERIAL) | `btree_gist` exclusion forbids overlapping `(instrument_id, daterange(effective_from, effective_to))` ranges; partial UNIQUE INDEX on `(instrument_id) WHERE effective_to IS NULL` | n/a | n/a |
+| `instrument_symbol_history` (sql/103) | same shape as above | same | n/a | n/a |
+| `sec_fund_series` (sql/124) | `(fund_series_id)` | n/a | n/a | regex CHECK `fund_series_id ~ '^S[0-9]{9}$'` |
+| `sec_nport_filer_directory` (sql/126) | `(cik)` | n/a | n/a | (verify) |
+
+**Implication:** `def14a_beneficial_holdings` UNIQUE is `(accession_number, holder_name)`, NOT `(instrument_id, accession, holder_name)` as the spec author might assume. Per-instrument fan-out requires a UNIQUE shape change.
+
+### 11.C Two-layer ownership tables
+
+All `ownership_*_observations` partitioned `RANGE(period_end)` quarterly 2010-2030 + `_default` (must stay empty post-backfill).
+
+| Table | Per-instrument | Identity (`_current`) | source CHECK |
+|---|---|---|---|
+| `ownership_insiders_observations` / `_current` (sql/113) | yes | `(instrument_id, holder_identity_key, ownership_nature)` | source ∈ canonical list |
+| `ownership_institutions_observations` / `_current` (sql/114) | yes | `(instrument_id, filer_cik, ownership_nature, exposure_kind)` | `source='13f'` |
+| `ownership_blockholders_observations` / `_current` (sql/115) | yes | `(instrument_id, reporter_cik, ownership_nature)` | `source IN ('13d','13g')` |
+| `ownership_treasury_observations` / `_current` (sql/116) | yes | `(instrument_id)` | `source='xbrl_dei'` |
+| `ownership_def14a_observations` / `_current` (sql/116) | yes | `(instrument_id, holder_name_key, ownership_nature)` | `source='def14a'` |
+| `ownership_funds_observations` / `_current` (sql/123) | yes | `(instrument_id, fund_series_id)` | `source IN ('nport','ncsr')` |
+| `ownership_esop_observations` / `_current` (sql/127) | yes | `(instrument_id, plan_name)` | `source='def14a'`, `ownership_nature='beneficial'`, `shares > 0` |
+
+Canonical observations source enum (used in `record_*_observation` writers): `form4, form3, 13d, 13g, def14a, 13f, nport, ncsr, xbrl_dei, 10k_note, finra_si, derived`. Do not write a value not in this list — the per-table CHECK rejects.
+
+### 11.D What "matrix is stale" looks like
+
+Examples of integrity drift the matrix MUST catch before spec writing:
+
+- "I'll change `ON CONFLICT (accession_number, holder_name)` to `(instrument_id, accession_number, holder_name)`." — Cross-check matrix §11.B before writing the spec; you'll see the actual current UNIQUE shape, not paraphrased.
+- "I'll promote `eight_k_filings` PK to `(accession, instrument_id)`." — §11.A surfaces every accession-only child FK; you immediately see the cascade. Pivot to `filing_events`-bridge read pattern (§11.B) instead.
+- "I'll write `source='sec_submissions'` on a manifest seeder INSERT." — §11.A enum list rejects `'sec_submissions'`; canonical mapping is `sec_form4`, `sec_def14a`, `sec_8k`, etc. via `app/services/sec_manifest.py::map_form_to_source(form)`.
+
+If your spec proposal touches a table not yet in this matrix, ADD the row before writing the spec. The matrix grows; it does not shrink.
+
+## 12. Canonical patterns — name, code, callers
+
+### 12.A Canonical CIK pick (from external_identifiers)
+
+When you need a single canonical `external_identifier_value` for an instrument:
+
+```sql
+SELECT identifier_value
+  FROM external_identifiers
+ WHERE provider = 'sec' AND identifier_type = 'cik'
+   AND instrument_id = %s
+ ORDER BY is_primary DESC, external_identifier_id ASC
+ LIMIT 1
+```
+
+`is_primary DESC` prefers the primary mapping. `external_identifier_id ASC` is the deterministic tie-breaker — handles legacy multi-primary edge AND non-primary-only mappings. Used by [app/services/filings.py::upsert_cik_mapping](../../../app/services/filings.py) (and post-#1091 every site that needs a canonical CIK). Never `LIMIT 1` without the explicit ORDER BY.
+
+### 12.B Canonical sibling-fan-out lookup (post-#1102)
+
+When you need EVERY instrument sharing an issuer CIK (for per-instrument fan-out writes):
+
+```python
+def siblings_for_issuer_cik(conn, cik: str) -> list[int]:
+    cik_padded = str(cik).strip().zfill(10)
+    if not cik_padded.isdigit():
+        raise ValueError(f"non-numeric CIK: {cik!r}")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id
+            FROM external_identifiers
+            WHERE provider = 'sec'
+              AND identifier_type = 'cik'
+              AND identifier_value = %s
+            ORDER BY instrument_id
+            """,
+            (cik_padded,),
+        )
+        return [int(r[0]) for r in cur.fetchall()]
+```
+
+Lives in `app/services/sec_identity.py` (post-#1117). Ordering is deterministic, NOT semantically primary — caller fans out across the full list. For "single canonical sibling" use §12.A on instrument_id ASC.
+
+### 12.C Manifest source mapping (form → source enum)
+
+Lives in [`app/services/sec_manifest.py::map_form_to_source`](../../../app/services/sec_manifest.py). Returns one of the §11.A enum values OR `None` for unsupported forms (`S-1`, `424B5`, etc. — discovery paths must skip).
+
+```python
+from app.services.sec_manifest import map_form_to_source
+
+source = map_form_to_source(filing_type)
+if source is None:
+    continue  # unsupported form — skip
+```
+
+NEVER hardcode `'sec_submissions'` or any other string not in the §11.A enum. The CHECK rejects.
+
+### 12.D Migration shape-check (idempotent re-runnability)
+
+Name-only constraint checks miss partial-applies. Use shape introspection:
+
+```sql
+-- For UNIQUE / PK constraints (pg_constraint):
+DO $$
+DECLARE
+    has_correct_shape BOOLEAN;
+BEGIN
+    SELECT EXISTS(
+        SELECT 1 FROM pg_constraint c
+        WHERE c.conname = '<name>'
+          AND c.contype = 'u'  -- 'u' UNIQUE, 'p' PRIMARY KEY, 'c' CHECK, 'f' FK
+          AND c.conrelid = '<table>'::regclass
+          AND (
+              SELECT array_agg(a.attname ORDER BY array_position(c.conkey, a.attnum))
+                FROM pg_attribute a
+               WHERE a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+          ) = ARRAY['<col1>','<col2>',...]::name[]
+    ) INTO has_correct_shape;
+
+    IF NOT has_correct_shape THEN
+        ALTER TABLE <table> DROP CONSTRAINT IF EXISTS <name>;
+        ALTER TABLE <table> ADD CONSTRAINT <name> UNIQUE (<col1>, <col2>, ...);
+    END IF;
+END$$;
+
+-- For CREATE UNIQUE INDEX (pg_index + pg_class):
+DO $$
+DECLARE
+    has_correct_shape BOOLEAN;
+BEGIN
+    SELECT EXISTS(
+        SELECT 1
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+         WHERE c.relname = '<index_name>'
+           AND i.indrelid = '<table>'::regclass
+           AND i.indisunique
+           AND (
+               SELECT array_agg(a.attname ORDER BY array_position(i.indkey::int[], a.attnum::int))
+                 FROM pg_attribute a
+                WHERE a.attrelid = i.indrelid
+                  AND a.attnum = ANY(i.indkey::int[])
+           ) = ARRAY['<col1>','<col2>',...]::name[]
+    ) INTO has_correct_shape;
+
+    IF NOT has_correct_shape THEN
+        DROP INDEX IF EXISTS <wrong_name>;
+        DROP INDEX IF EXISTS <index_name>;
+        CREATE UNIQUE INDEX <index_name> ON <table> (<col1>, <col2>, ...);
+    END IF;
+END$$;
+```
+
+Why: a partial-apply leaves the constraint name pointing at a WRONG-shape constraint. Name-only checks falsely skip. Shape-introspection re-runs cleanly.
+
+### 12.E Atomic _current refresh
+
+```python
+with conn.cursor() as cur:
+    cur.execute(
+        "SELECT pg_advisory_xact_lock(hashtext('<category>:%s' % instrument_id))"
+    )
+    cur.execute("DELETE FROM ownership_<cat>_current WHERE instrument_id = %s", (iid,))
+    cur.execute(
+        """
+        INSERT INTO ownership_<cat>_current (...)
+        SELECT DISTINCT ON (<identity-tuple>) ...
+        FROM ownership_<cat>_observations
+        WHERE instrument_id = %s AND known_to IS NULL
+        ORDER BY <identity-tuple>, <winner-priority-clause>
+        """,
+        (iid,),
+    )
+```
+
+Winner-priority order across categories: `source` priority (`form4 > form3 > 13d > 13g > def14a > 13f > nport > ncsr`) → `period_end DESC` → `filed_at DESC` (amendments win) → `source_document_id ASC`. Wrapped in `pg_advisory_xact_lock(<hash of instrument_id>)` so concurrent refreshes serialise; PK on `_current` is second-line guard.
+
+### 12.F Forbidden patterns — these are PR review BLOCKING
+
+- `ON CONFLICT (...) DO UPDATE SET <pk_col> = EXCLUDED.<pk_col>` — overwriting a column that's now in the conflict target is a smell. Hit means already correct; the SET drives nothing useful.
+- `LIMIT 1` without `ORDER BY` — leaks nondeterminism; #1117 caught one in `rewash_filings`. Always pair LIMIT with explicit ORDER BY.
+- `f-string interpolation into SQL` — parameterise. See §I2.
+- `record_*_observation()` without paired `refresh_*_current(instrument_id)` — leaves `_current` empty (prev-log L1162). Both are mandatory.
+- `ON DELETE CASCADE` on `*_audit` / `*_log` (prev-log L350).
+- `SELECT DISTINCT` over a multi-column row when the dedup target is one column — use `DISTINCT ON (col)`.
+- `dict[cik, instrument_id]` for any CIK→instrument lookup post-#1102 — must be `dict[cik, list[instrument_id]]` (the multimap pattern from #1117). Single-result collapse drops share-class siblings silently.

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -2198,14 +2198,26 @@ def get_insider_baseline_drill(
     # inlined here so this PR is independent of #830's merge order.
     notes: list[str] = []
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Per-#1117 PR-B: insider_initial_holdings + insider_filings are
+        # entity-level (PK accession or accession+row_num); the
+        # per-instrument denormalised instrument_id column points at
+        # the canonical sibling, NOT every share-class sibling. Reads
+        # for share-class siblings (GOOG/GOOGL) route through
+        # filing_events bridge so both render the same Form 3
+        # baseline.
         cur.execute(
             """
             SELECT COUNT(*) AS row_count
             FROM insider_initial_holdings h
             JOIN insider_filings f ON f.accession_number = h.accession_number
-            WHERE h.instrument_id = %s
-              AND f.document_type LIKE '3%%'
+            WHERE f.document_type LIKE '3%%'
               AND f.is_tombstone = FALSE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = h.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )
@@ -2213,10 +2225,15 @@ def get_insider_baseline_drill(
         cur.execute(
             """
             SELECT COUNT(*) AS tombstone_count
-            FROM insider_filings
-            WHERE instrument_id = %s
-              AND document_type LIKE '3%%'
-              AND is_tombstone = TRUE
+            FROM insider_filings i
+            WHERE i.document_type LIKE '3%%'
+              AND i.is_tombstone = TRUE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = i.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )
@@ -2226,7 +2243,13 @@ def get_insider_baseline_drill(
             SELECT COUNT(DISTINCT r.accession_number) AS body_count
             FROM filing_raw_documents r
             JOIN insider_filings i ON i.accession_number = r.accession_number
-            WHERE r.document_kind = 'form3_xml' AND i.instrument_id = %s
+            WHERE r.document_kind = 'form3_xml'
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = i.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )

--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -99,9 +99,16 @@ def seed_manifest_from_filing_events(
         # Codex pre-push MED for #1044 — naive `is_primary = TRUE`
         # would drop valid rows whose only SEC CIK mapping isn't
         # flagged primary.
+        # Per-#1117 PR-B: filing_events fans out per share-class
+        # sibling under sql/144, so two rows can carry the same
+        # accession. sec_filing_manifest.accession_number is PK
+        # (entity-level), so the seeder dedups by accession picking
+        # the canonical (lowest instrument_id) sibling. Parser
+        # fan-out at parse time covers per-sibling observations;
+        # the manifest itself is one row per accession.
         cur.execute(
             """
-            SELECT
+            SELECT DISTINCT ON (fe.provider_filing_id)
                 fe.instrument_id,
                 fe.filing_date,
                 fe.filing_type,
@@ -119,6 +126,7 @@ def seed_manifest_from_filing_events(
                 LIMIT 1
             ) cik_map ON TRUE
             WHERE fe.provider = 'sec'
+            ORDER BY fe.provider_filing_id, fe.instrument_id
             """
         )
         rows = cur.fetchall()

--- a/app/services/capabilities.py
+++ b/app/services/capabilities.py
@@ -174,13 +174,19 @@ _PRESENCE_QUERIES: dict[tuple[str, str], str] = {
     ("corporate_events", "sec_8k_events"): (
         # Per-#1117 PR-B: eight_k_filings is entity-level (PK
         # accession, denormalised instrument_id is the discovery
-        # sibling). Route through filing_events bridge so share-
-        # class siblings (GOOG/GOOGL) BOTH show the capability when
-        # an 8-K exists for the issuer.
-        "SELECT EXISTS(SELECT 1 FROM filing_events fe "
-        "WHERE fe.provider = 'sec' "
+        # sibling). Capability requires a PARSED row in
+        # eight_k_filings (so list_8k_filings has data to return);
+        # route through filing_events bridge so share-class
+        # siblings (GOOG/GOOGL) BOTH show the capability when an
+        # 8-K is parsed for the issuer. Codex pre-push P2 caught
+        # the prior over-claim where filing_events alone implied
+        # availability before parsing landed.
+        "SELECT EXISTS(SELECT 1 FROM eight_k_filings ekf "
+        "WHERE EXISTS (SELECT 1 FROM filing_events fe "
+        "WHERE fe.provider_filing_id = ekf.accession_number "
+        "AND fe.provider = 'sec' "
         "AND fe.filing_type IN ('8-K', '8-K/A') "
-        "AND fe.instrument_id = %s)"
+        "AND fe.instrument_id = %s))"
     ),
     ("business_summary", "sec_10k_item1"): (
         "SELECT EXISTS(SELECT 1 FROM instrument_business_summary b WHERE b.instrument_id = %s)"

--- a/app/services/capabilities.py
+++ b/app/services/capabilities.py
@@ -172,12 +172,29 @@ _PRESENCE_QUERIES: dict[tuple[str, str], str] = {
         "SELECT EXISTS(SELECT 1 FROM instrument_dividend_summary d WHERE d.instrument_id = %s)"
     ),
     ("corporate_events", "sec_8k_events"): (
-        "SELECT EXISTS(SELECT 1 FROM eight_k_filings e WHERE e.instrument_id = %s)"
+        # Per-#1117 PR-B: eight_k_filings is entity-level (PK
+        # accession, denormalised instrument_id is the discovery
+        # sibling). Route through filing_events bridge so share-
+        # class siblings (GOOG/GOOGL) BOTH show the capability when
+        # an 8-K exists for the issuer.
+        "SELECT EXISTS(SELECT 1 FROM filing_events fe "
+        "WHERE fe.provider = 'sec' "
+        "AND fe.filing_type IN ('8-K', '8-K/A') "
+        "AND fe.instrument_id = %s)"
     ),
     ("business_summary", "sec_10k_item1"): (
         "SELECT EXISTS(SELECT 1 FROM instrument_business_summary b WHERE b.instrument_id = %s)"
     ),
-    ("insider", "sec_form4"): ("SELECT EXISTS(SELECT 1 FROM insider_transactions t WHERE t.instrument_id = %s)"),
+    ("insider", "sec_form4"): (
+        # Per-#1117 PR-B: insider_transactions is entity-level
+        # (PK accession+txn_row_num); the per-instrument signal lives
+        # in ownership_insiders_observations (which IS fanned out
+        # across siblings). Use the observation table for the
+        # capability check.
+        "SELECT EXISTS(SELECT 1 FROM ownership_insiders_current oc "
+        "WHERE oc.instrument_id = %s "
+        "AND oc.source IN ('form4', 'form3'))"
+    ),
     # ``ownership`` panel — wired via the post-#788 ``ownership_*_current``
     # tables (#905 read-path cutover). Without these entries, the
     # ownership panel stayed permanently hidden even when the

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -55,6 +55,7 @@ from app.services.ownership_observations import (
     refresh_def14a_current,
     refresh_esop_current,
 )
+from app.services.sec_identity import siblings_for_issuer_cik
 
 _PARSER_VERSION_DEF14A = "def14a-v1"
 
@@ -442,49 +443,64 @@ def _ingest_single_accession(
     inserted = 0
     updated = 0
 
-    for holder in parsed.rows:
-        outcome = _upsert_holding(
-            conn,
-            accession_number=ref.accession_number,
-            issuer_cik=issuer_cik,
-            instrument_id=ref.instrument_id,
-            as_of_date=parsed.as_of_date,
-            holder=holder,
-        )
-        if outcome == "inserted":
-            inserted += 1
-        else:
-            updated += 1
+    # Per-share-class fan-out (#1117 PR-B). Same DEF 14A document
+    # describes the same issuer; each share-class sibling renders
+    # its own copy of the per-instrument tables. Bulk path covered
+    # by sec_submissions_ingest multimap; per-filing parser path
+    # covered here.
+    if issuer_cik != _CIK_MISSING_SENTINEL:
+        siblings = siblings_for_issuer_cik(conn, issuer_cik)
+        if not siblings:
+            siblings = [ref.instrument_id]
+    else:
+        siblings = [ref.instrument_id]
+
+    for sibling_iid in siblings:
+        for holder in parsed.rows:
+            outcome = _upsert_holding(
+                conn,
+                accession_number=ref.accession_number,
+                issuer_cik=issuer_cik,
+                instrument_id=sibling_iid,
+                as_of_date=parsed.as_of_date,
+                holder=holder,
+            )
+            if outcome == "inserted":
+                inserted += 1
+            else:
+                updated += 1
 
     # Write-through observations + refresh _current (#891 / spec
     # §"Eliminate periodic re-scan jobs"). Replaces nightly
     # ownership_observations_sync.sync_def14a read-from-typed-tables
     # path. record_def14a_observation is itself UPSERT so re-ingest
     # of the same accession (parser bump) refreshes existing rows
-    # in place.
+    # in place. Fan out across share-class siblings post-#1117.
     if parsed.rows:
-        _record_def14a_observations_for_filing(
-            conn,
-            instrument_id=ref.instrument_id,
-            accession_number=ref.accession_number,
-            as_of_date=parsed.as_of_date,
-            holders=parsed.rows,
-        )
-        refresh_def14a_current(conn, instrument_id=ref.instrument_id)
-        # ESOP write-through (#843). Mirrors the def14a write-through
-        # above but lands rows in ``ownership_esop_observations`` for
-        # the dedicated funds-slice overlay path (#961). Same accession
-        # / as_of semantics so the two slices reconcile against one
-        # provenance.
-        esop_rows_written = _record_esop_observations_for_filing(
-            conn,
-            instrument_id=ref.instrument_id,
-            accession_number=ref.accession_number,
-            as_of_date=parsed.as_of_date,
-            holders=parsed.rows,
-        )
-        if esop_rows_written > 0:
-            refresh_esop_current(conn, instrument_id=ref.instrument_id)
+        for sibling_iid in siblings:
+            _record_def14a_observations_for_filing(
+                conn,
+                instrument_id=sibling_iid,
+                accession_number=ref.accession_number,
+                as_of_date=parsed.as_of_date,
+                holders=parsed.rows,
+            )
+            refresh_def14a_current(conn, instrument_id=sibling_iid)
+            # ESOP write-through (#843). Mirrors the def14a
+            # write-through above but lands rows in
+            # ``ownership_esop_observations`` for the dedicated
+            # funds-slice overlay path (#961). Same accession /
+            # as_of semantics so the two slices reconcile against
+            # one provenance.
+            esop_rows_written = _record_esop_observations_for_filing(
+                conn,
+                instrument_id=sibling_iid,
+                accession_number=ref.accession_number,
+                as_of_date=parsed.as_of_date,
+                holders=parsed.rows,
+            )
+            if esop_rows_written > 0:
+                refresh_esop_current(conn, instrument_id=sibling_iid)
 
     return _AccessionOutcome(
         status="success",

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -186,29 +186,61 @@ def discover_pending_def14a(
     issuer (used by ad-hoc re-ingest scripts and the per-instrument
     backfill in PR 3); ``None`` returns the full pending set.
     """
+    # Per-#1117 PR-B: targeted selectors (`fe.instrument_id = %s`)
+    # only match one sibling's rows in filing_events — no fan-out
+    # multiplies, dedup unnecessary. Universe-wide selectors require
+    # the inner-CTE DISTINCT ON pattern so N siblings sharing a CIK
+    # do not consume N slots of the LIMIT budget for one accession.
     where_iid = "AND fe.instrument_id = %(iid)s" if instrument_id is not None else ""
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            f"""
-            SELECT fe.provider_filing_id, fe.instrument_id, fe.filing_date,
-                   fe.primary_document_url
-            FROM filing_events fe
-            LEFT JOIN def14a_ingest_log log
-                ON log.accession_number = fe.provider_filing_id
-            WHERE fe.provider = 'sec'
-              AND fe.filing_type = ANY(%(forms)s)
-              AND fe.primary_document_url IS NOT NULL
-              AND log.accession_number IS NULL
-              {where_iid}
-            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
-            LIMIT %(limit)s
-            """,
-            {
-                "forms": list(_DEF14A_FORM_TYPES),
-                "iid": instrument_id,
-                "limit": limit,
-            },
-        )
+        if instrument_id is not None:
+            cur.execute(
+                f"""
+                SELECT fe.provider_filing_id, fe.instrument_id, fe.filing_date,
+                       fe.primary_document_url
+                FROM filing_events fe
+                LEFT JOIN def14a_ingest_log log
+                    ON log.accession_number = fe.provider_filing_id
+                WHERE fe.provider = 'sec'
+                  AND fe.filing_type = ANY(%(forms)s)
+                  AND fe.primary_document_url IS NOT NULL
+                  AND log.accession_number IS NULL
+                  {where_iid}
+                ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+                LIMIT %(limit)s
+                """,
+                {
+                    "forms": list(_DEF14A_FORM_TYPES),
+                    "iid": instrument_id,
+                    "limit": limit,
+                },
+            )
+        else:
+            cur.execute(
+                """
+                WITH per_accession AS (
+                    SELECT DISTINCT ON (fe.provider_filing_id)
+                        fe.provider_filing_id, fe.instrument_id, fe.filing_date,
+                        fe.primary_document_url, fe.filing_event_id
+                    FROM filing_events fe
+                    LEFT JOIN def14a_ingest_log log
+                        ON log.accession_number = fe.provider_filing_id
+                    WHERE fe.provider = 'sec'
+                      AND fe.filing_type = ANY(%(forms)s)
+                      AND fe.primary_document_url IS NOT NULL
+                      AND log.accession_number IS NULL
+                    ORDER BY fe.provider_filing_id, fe.instrument_id
+                )
+                SELECT provider_filing_id, instrument_id, filing_date, primary_document_url
+                FROM per_accession
+                ORDER BY filing_date DESC, filing_event_id DESC
+                LIMIT %(limit)s
+                """,
+                {
+                    "forms": list(_DEF14A_FORM_TYPES),
+                    "limit": limit,
+                },
+            )
         rows = cur.fetchall()
 
     return [

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -312,8 +312,7 @@ def _upsert_holding(
                 %(name)s, %(role)s, %(shares)s, %(pct)s,
                 %(as_of)s
             )
-            ON CONFLICT (accession_number, holder_name) DO UPDATE SET
-                instrument_id = EXCLUDED.instrument_id,
+            ON CONFLICT (instrument_id, accession_number, holder_name) DO UPDATE SET
                 issuer_cik = EXCLUDED.issuer_cik,
                 holder_role = EXCLUDED.holder_role,
                 shares = EXCLUDED.shares,

--- a/app/services/eight_k_events.py
+++ b/app/services/eight_k_events.py
@@ -719,20 +719,33 @@ def ingest_8k_events(
 
     candidates: list[tuple[int, str, str, tuple[str, ...]]] = []
     with conn.cursor() as cur:
+        # Per-#1117 PR-B: filing_events fans out per share-class
+        # sibling under sql/144. Universe-wide candidate selectors
+        # must dedup by accession (inner CTE) before applying the
+        # priority LIMIT, otherwise N siblings consume N slots of
+        # the LIMIT budget for the same accession AND the parser
+        # runs twice with different canonical instrument_ids
+        # (entity-level rows flap on each second pass).
         cur.execute(
             """
-            SELECT fe.instrument_id,
-                   fe.provider_filing_id,
-                   fe.primary_document_url,
-                   COALESCE(fe.items, ARRAY[]::TEXT[])
-            FROM filing_events fe
-            LEFT JOIN eight_k_filings ekf
-                ON ekf.accession_number = fe.provider_filing_id
-            WHERE fe.provider = 'sec'
-              AND fe.filing_type IN ('8-K', '8-K/A')
-              AND fe.primary_document_url IS NOT NULL
-              AND ekf.accession_number IS NULL
-            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            WITH per_accession AS (
+                SELECT DISTINCT ON (fe.provider_filing_id)
+                    fe.instrument_id, fe.provider_filing_id,
+                    fe.primary_document_url, fe.items, fe.filing_date,
+                    fe.filing_event_id
+                FROM filing_events fe
+                LEFT JOIN eight_k_filings ekf
+                    ON ekf.accession_number = fe.provider_filing_id
+                WHERE fe.provider = 'sec'
+                  AND fe.filing_type IN ('8-K', '8-K/A')
+                  AND fe.primary_document_url IS NOT NULL
+                  AND ekf.accession_number IS NULL
+                ORDER BY fe.provider_filing_id, fe.instrument_id
+            )
+            SELECT instrument_id, provider_filing_id, primary_document_url,
+                   COALESCE(items, ARRAY[]::TEXT[])
+            FROM per_accession
+            ORDER BY filing_date DESC, filing_event_id DESC
             LIMIT %s
             """,
             (limit,),

--- a/app/services/eight_k_events.py
+++ b/app/services/eight_k_events.py
@@ -568,6 +568,11 @@ def list_8k_filings(
     """Return recent 8-K filings for an instrument with items +
     exhibits attached. Tombstoned filings excluded."""
     with conn.cursor() as cur:
+        # Per-share-class read bridge (#1117 PR-B): eight_k_filings is
+        # entity-level (PK accession, child FKs anchor on it). Reads
+        # for share-class siblings route through filing_events as the
+        # per-instrument bridge so both GOOG and GOOGL render the
+        # same 8-K event without duplicating eight_k_filings rows.
         cur.execute(
             """
             SELECT
@@ -576,8 +581,14 @@ def list_8k_filings(
                 f.signature_name, f.signature_title, f.signature_date,
                 f.primary_document_url
             FROM eight_k_filings f
-            WHERE f.instrument_id = %s
-              AND f.is_tombstone = FALSE
+            WHERE f.is_tombstone = FALSE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = f.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+                    AND fe.filing_type IN ('8-K', '8-K/A')
+              )
             ORDER BY f.date_of_report DESC NULLS LAST, f.fetched_at DESC
             LIMIT %s
             """,

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -446,7 +446,7 @@ def _upsert_filing_event(
             %(provider)s, %(provider_filing_id)s, %(source_url)s, %(primary_document_url)s,
             %(raw_payload_json)s
         )
-        ON CONFLICT (provider, provider_filing_id) DO UPDATE SET
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO UPDATE SET
             filing_date          = EXCLUDED.filing_date,
             filing_type          = EXCLUDED.filing_type,
             source_url           = EXCLUDED.source_url,
@@ -496,7 +496,7 @@ def _upsert_filing(
             %(provider)s, %(provider_filing_id)s, %(source_url)s, %(primary_document_url)s,
             %(raw_payload_json)s
         )
-        ON CONFLICT (provider, provider_filing_id) DO UPDATE SET
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO UPDATE SET
             filing_date          = EXCLUDED.filing_date,
             filing_type          = EXCLUDED.filing_type,
             source_url           = EXCLUDED.source_url,

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -2252,7 +2252,7 @@ def _upsert_filing_from_master_index(
             %(provider)s, %(provider_filing_id)s, %(source_url)s, %(primary_document_url)s,
             %(raw_payload_json)s
         )
-        ON CONFLICT (provider, provider_filing_id) DO UPDATE SET
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO UPDATE SET
             filing_date          = EXCLUDED.filing_date,
             filing_type          = EXCLUDED.filing_type,
             source_url           = COALESCE(filing_events.source_url, EXCLUDED.source_url),

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -576,20 +576,29 @@ def ingest_form_3_filings(
     """
     conn.commit()
 
+    # Per-#1117 PR-B: dedup by accession before LIMIT so siblings
+    # don't consume budget for the same filing. Targeted variant
+    # above (`fe.instrument_id = %s`) skips dedup since only one
+    # sibling matches.
     candidates: list[tuple[int, str, str]] = []
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT fe.instrument_id,
-                   fe.provider_filing_id,
-                   fe.primary_document_url
-            FROM filing_events fe
-            LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
-            WHERE fe.provider = 'sec'
-              AND fe.filing_type IN ('3', '3/A')
-              AND fe.primary_document_url IS NOT NULL
-              AND (fil.accession_number IS NULL OR fil.parser_version < %s)
-            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            WITH per_accession AS (
+                SELECT DISTINCT ON (fe.provider_filing_id)
+                    fe.instrument_id, fe.provider_filing_id,
+                    fe.primary_document_url, fe.filing_date, fe.filing_event_id
+                FROM filing_events fe
+                LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
+                WHERE fe.provider = 'sec'
+                  AND fe.filing_type IN ('3', '3/A')
+                  AND fe.primary_document_url IS NOT NULL
+                  AND (fil.accession_number IS NULL OR fil.parser_version < %s)
+                ORDER BY fe.provider_filing_id, fe.instrument_id
+            )
+            SELECT instrument_id, provider_filing_id, primary_document_url
+            FROM per_accession
+            ORDER BY filing_date DESC, filing_event_id DESC
             LIMIT %s
             """,
             (_FORM3_PARSER_VERSION, limit),

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -53,6 +53,7 @@ from app.services.ownership_observations import (
     record_insider_observation,
     refresh_insiders_current,
 )
+from app.services.sec_identity import siblings_for_issuer_cik
 
 logger = logging.getLogger(__name__)
 
@@ -318,14 +319,30 @@ def upsert_form_3_filing(
     # periodic re-scan jobs"). Mirrors the Form 4 path —
     # one observation per (filer_cik, direct_indirect), shares = the
     # holding's reported share count, period_end = period_of_report.
-    _record_form3_observations_for_filing(
-        conn,
-        instrument_id=instrument_id,
-        accession_number=accession_number,
-        primary_document_url=primary_document_url,
-        parsed=parsed,
-    )
-    refresh_insiders_current(conn, instrument_id=instrument_id)
+    #
+    # Per-share-class fan-out (#1117 PR-B): same Form 3 describes the
+    # same issuer; each share-class sibling carries its own
+    # ownership_insiders_observations rows. Entity-level tables
+    # (insider_filings, insider_initial_holdings) stay PK=accession.
+    issuer_cik = parsed.issuer_cik or ""
+    if issuer_cik:
+        try:
+            siblings = siblings_for_issuer_cik(conn, issuer_cik)
+        except ValueError:
+            siblings = [instrument_id]
+        if not siblings:
+            siblings = [instrument_id]
+    else:
+        siblings = [instrument_id]
+    for sibling_iid in siblings:
+        _record_form3_observations_for_filing(
+            conn,
+            instrument_id=sibling_iid,
+            accession_number=accession_number,
+            primary_document_url=primary_document_url,
+            parsed=parsed,
+        )
+        refresh_insiders_current(conn, instrument_id=sibling_iid)
 
 
 def _record_form3_observations_for_filing(

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -55,6 +55,7 @@ from app.services.ownership_observations import (
     record_insider_observation,
     refresh_insiders_current,
 )
+from app.services.sec_identity import siblings_for_issuer_cik
 
 _PARSER_VERSION_FORM4 = "form4-v1"
 
@@ -1139,14 +1140,32 @@ def upsert_filing(
     # ownership_observations_sync read-from-typed-tables path with an
     # inline call so the operator-visible rollup reflects the new filing
     # without waiting for the next sync cycle.
-    _record_form4_observations_for_filing(
-        conn,
-        instrument_id=instrument_id,
-        accession_number=accession_number,
-        primary_document_url=primary_document_url,
-        parsed=parsed,
-    )
-    refresh_insiders_current(conn, instrument_id=instrument_id)
+    #
+    # Per-share-class fan-out (#1117 PR-B): same Form 4 describes the
+    # same issuer; each share-class sibling carries its own
+    # ownership_insiders_observations rows. Entity-level tables
+    # (insider_filings, insider_transactions, insider_filers,
+    # insider_transaction_footnotes) stay PK=accession — siblings see
+    # them via filing_events bridge in read paths.
+    issuer_cik = parsed.issuer_cik or ""
+    if issuer_cik:
+        try:
+            siblings = siblings_for_issuer_cik(conn, issuer_cik)
+        except ValueError:
+            siblings = [instrument_id]
+        if not siblings:
+            siblings = [instrument_id]
+    else:
+        siblings = [instrument_id]
+    for sibling_iid in siblings:
+        _record_form4_observations_for_filing(
+            conn,
+            instrument_id=sibling_iid,
+            accession_number=accession_number,
+            primary_document_url=primary_document_url,
+            parsed=parsed,
+        )
+        refresh_insiders_current(conn, instrument_id=sibling_iid)
 
 
 def _record_form4_observations_for_filing(

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -1468,21 +1468,29 @@ def ingest_insider_transactions(
     """
     conn.commit()
 
+    # Per-#1117 PR-B: universe-wide selector requires inner-CTE
+    # DISTINCT ON dedup so N siblings sharing a CIK do not consume N
+    # slots of the LIMIT budget for the same accession.
     candidates: list[tuple[int, str, str]] = []
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT fe.instrument_id,
-                   fe.provider_filing_id,
-                   fe.primary_document_url
-            FROM filing_events fe
-            LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
-            WHERE fe.provider = 'sec'
-              AND fe.filing_type IN ('4', '4/A')
-              AND fe.primary_document_url IS NOT NULL
-              AND fil.accession_number IS NULL
-              AND fe.filing_date >= NOW() - make_interval(years => %(floor_years)s)
-            ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+            WITH per_accession AS (
+                SELECT DISTINCT ON (fe.provider_filing_id)
+                    fe.instrument_id, fe.provider_filing_id,
+                    fe.primary_document_url, fe.filing_date, fe.filing_event_id
+                FROM filing_events fe
+                LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
+                WHERE fe.provider = 'sec'
+                  AND fe.filing_type IN ('4', '4/A')
+                  AND fe.primary_document_url IS NOT NULL
+                  AND fil.accession_number IS NULL
+                  AND fe.filing_date >= NOW() - make_interval(years => %(floor_years)s)
+                ORDER BY fe.provider_filing_id, fe.instrument_id
+            )
+            SELECT instrument_id, provider_filing_id, primary_document_url
+            FROM per_accession
+            ORDER BY filing_date DESC, filing_event_id DESC
             LIMIT %(limit)s
             """,
             {"limit": limit, "floor_years": INSIDER_FORM4_BACKFILL_FLOOR_YEARS},
@@ -1626,18 +1634,31 @@ def ingest_insider_transactions_backfill(
     """
     conn.commit()
 
+    # Per-#1117 PR-B: dedup by accession before GROUP BY so a single
+    # share-class accession is not double-counted across siblings.
+    # The canonical-sibling parser fan-out (see upsert_filing) covers
+    # all siblings on parse, so picking the canonical sibling for the
+    # backfill drain is sufficient — the per-instrument fan-out
+    # reaches the others without scheduling them as separate
+    # candidates.
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT fe.instrument_id, COUNT(*) AS unfetched
-            FROM filing_events fe
-            LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
-            WHERE fe.provider = 'sec'
-              AND fe.filing_type IN ('4', '4/A')
-              AND fe.primary_document_url IS NOT NULL
-              AND fil.accession_number IS NULL
-              AND fe.filing_date >= NOW() - make_interval(years => %(floor_years)s)
-            GROUP BY fe.instrument_id
+            WITH per_accession AS (
+                SELECT DISTINCT ON (fe.provider_filing_id)
+                    fe.instrument_id, fe.provider_filing_id
+                FROM filing_events fe
+                LEFT JOIN insider_filings fil ON fil.accession_number = fe.provider_filing_id
+                WHERE fe.provider = 'sec'
+                  AND fe.filing_type IN ('4', '4/A')
+                  AND fe.primary_document_url IS NOT NULL
+                  AND fil.accession_number IS NULL
+                  AND fe.filing_date >= NOW() - make_interval(years => %(floor_years)s)
+                ORDER BY fe.provider_filing_id, fe.instrument_id
+            )
+            SELECT instrument_id, COUNT(*) AS unfetched
+            FROM per_accession
+            GROUP BY instrument_id
             ORDER BY unfetched DESC
             LIMIT %(limit)s
             """,

--- a/app/services/ownership_drillthrough.py
+++ b/app/services/ownership_drillthrough.py
@@ -284,14 +284,24 @@ def _form4_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
     insiders."""
     notes: list[str] = []
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Per-#1117 PR-B: insider_transactions + insider_filings are
+        # entity-level (PK accession or accession+txn_row_num); the
+        # per-instrument denormalised instrument_id points at the
+        # canonical sibling. Bridge via filing_events for per-sibling
+        # reads.
         cur.execute(
             """
             SELECT COUNT(*) AS row_count, MAX(f.period_of_report) AS latest_period
             FROM insider_transactions t
             JOIN insider_filings f ON f.accession_number = t.accession_number
-            WHERE t.instrument_id = %s
-              AND f.document_type = '4'
+            WHERE f.document_type = '4'
               AND f.is_tombstone = FALSE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = t.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )
@@ -300,10 +310,15 @@ def _form4_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
         cur.execute(
             """
             SELECT COUNT(*) AS tombstone_count
-            FROM insider_filings
-            WHERE instrument_id = %s
-              AND document_type = '4'
-              AND is_tombstone = TRUE
+            FROM insider_filings i
+            WHERE i.document_type = '4'
+              AND i.is_tombstone = TRUE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = i.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )
@@ -315,8 +330,13 @@ def _form4_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
             FROM filing_raw_documents r
             JOIN insider_filings i ON i.accession_number = r.accession_number
             WHERE r.document_kind = 'form4_xml'
-              AND i.instrument_id = %s
               AND i.is_tombstone = FALSE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = i.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )
@@ -345,14 +365,21 @@ def _form3_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
     the prior header-count bug here too."""
     notes: list[str] = []
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Per-#1117 PR-B: same bridge pattern as Form 4 — entity-level
+        # tables route via filing_events for sibling visibility.
         cur.execute(
             """
             SELECT COUNT(*) AS row_count, MAX(f.period_of_report) AS latest_period
             FROM insider_initial_holdings h
             JOIN insider_filings f ON f.accession_number = h.accession_number
-            WHERE h.instrument_id = %s
-              AND f.document_type LIKE '3%%'
+            WHERE f.document_type LIKE '3%%'
               AND f.is_tombstone = FALSE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = h.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )
@@ -361,10 +388,15 @@ def _form3_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
         cur.execute(
             """
             SELECT COUNT(*) AS tombstone_count
-            FROM insider_filings
-            WHERE instrument_id = %s
-              AND document_type LIKE '3%%'
-              AND is_tombstone = TRUE
+            FROM insider_filings i
+            WHERE i.document_type LIKE '3%%'
+              AND i.is_tombstone = TRUE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = i.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )
@@ -376,8 +408,13 @@ def _form3_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
             FROM filing_raw_documents r
             JOIN insider_filings i ON i.accession_number = r.accession_number
             WHERE r.document_kind = 'form3_xml'
-              AND i.instrument_id = %s
               AND i.is_tombstone = FALSE
+              AND EXISTS (
+                  SELECT 1 FROM filing_events fe
+                  WHERE fe.provider_filing_id = i.accession_number
+                    AND fe.provider = 'sec'
+                    AND fe.instrument_id = %s
+              )
             """,
             (instrument_id,),
         )

--- a/app/services/sec_companyfacts_ingest.py
+++ b/app/services/sec_companyfacts_ingest.py
@@ -93,9 +93,15 @@ def _cik_from_filename(name: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, int]:
-    """Return ``{cik_padded: instrument_id}`` for every CIK-mapped instrument."""
-    out: dict[str, int] = {}
+def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, list[int]]:
+    """Return ``{cik_padded: [instrument_id, ...]}`` for every CIK-mapped instrument.
+
+    Multimap shape — share-class siblings (GOOG/GOOGL, BRK.A/BRK.B) co-bind
+    a single SEC CIK per #1102. Collapsing to ``dict[str, int]`` would
+    silently drop one sibling on every bulk run, leaving it without
+    fundamentals.
+    """
+    out: dict[str, list[int]] = {}
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -107,7 +113,7 @@ def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, int]:
         for row in cur.fetchall():
             instrument_id, identifier = row
             cik = str(identifier).zfill(10)
-            out[cik] = int(instrument_id)
+            out.setdefault(cik, []).append(int(instrument_id))
     return out
 
 
@@ -115,7 +121,7 @@ def ingest_companyfacts_archive(
     *,
     conn: psycopg.Connection[Any],
     archive_path: Path,
-    cik_to_instrument: dict[str, int] | None = None,
+    cik_to_instrument: dict[str, list[int]] | None = None,
 ) -> CompanyFactsIngestResult:
     """Walk every ``CIK<10>.json`` entry in ``archive_path`` and upsert
     XBRL facts into ``financial_facts_raw`` for matching universe instruments.
@@ -157,17 +163,18 @@ def ingest_companyfacts_archive(
                 if cik is None:
                     continue
                 result.archive_entries_seen += 1
-                instrument_id = cik_to_instrument.get(cik)
-                if instrument_id is None:
+                matched_instruments = cik_to_instrument.get(cik, [])
+                if not matched_instruments:
                     result.archive_entries_skipped_universe_gap += 1
                     continue
-                result.instruments_matched += 1
 
                 # Per-CIK savepoint: a parse error or DB-write failure
                 # for one CIK must not abort the surrounding
                 # transaction. Without this, a single corrupted entry
                 # poisons the rest of the archive (Codex pre-push
-                # round 1, finding 3).
+                # round 1, finding 3). Share-class siblings on the
+                # same CIK share one savepoint — failure rolls back
+                # all sibling writes for that entry together (#1117).
                 try:
                     with conn.transaction():
                         try:
@@ -186,14 +193,16 @@ def ingest_companyfacts_archive(
                         if not facts:
                             raise _SkipEntry  # roll back savepoint cleanly
 
-                        upserted, skipped = upsert_facts_for_instrument(
-                            conn,
-                            instrument_id=instrument_id,
-                            facts=facts,
-                            ingestion_run_id=run_id,
-                        )
-                        result.facts_upserted += upserted
-                        result.facts_skipped += skipped
+                        for instrument_id in matched_instruments:
+                            result.instruments_matched += 1
+                            upserted, skipped = upsert_facts_for_instrument(
+                                conn,
+                                instrument_id=instrument_id,
+                                facts=facts,
+                                ingestion_run_id=run_id,
+                            )
+                            result.facts_upserted += upserted
+                            result.facts_skipped += skipped
                 except _SkipEntry:
                     # Savepoint already rolled back; advance to next entry.
                     continue

--- a/app/services/sec_identity.py
+++ b/app/services/sec_identity.py
@@ -23,9 +23,7 @@ from typing import Any
 import psycopg
 
 
-def siblings_for_issuer_cik(
-    conn: psycopg.Connection[Any], cik: str
-) -> list[int]:
+def siblings_for_issuer_cik(conn: psycopg.Connection[Any], cik: str) -> list[int]:
     """Return all instrument_ids sharing this issuer CIK.
 
     The CIK is normalised (strip + zero-pad to 10 digits) before

--- a/app/services/sec_identity.py
+++ b/app/services/sec_identity.py
@@ -1,0 +1,61 @@
+"""Shared helpers for resolving SEC issuer CIKs to instrument siblings.
+
+Per #1102, multiple instruments may share an SEC CIK — share-class
+siblings (GOOG/GOOGL, BRK.A/BRK.B) co-bind the issuer CIK because the
+CIK identifies the entity (issuer) and the CUSIP identifies the
+security (per-share-class).
+
+Per-filing parsers writing per-instrument observation rows must fan
+out across all siblings, not collapse to one. The bulk-ingester
+multimap pattern (`dict[str, list[int]]`) covers the bulk path; this
+module covers the per-filing path. See
+``docs/superpowers/specs/2026-05-10-1117-filings-fanout-complete.md``.
+
+Cross-reference: data-engineer skill §12.B (canonical sibling
+fan-out lookup pattern); §12.A documents the single-canonical-pick
+variant for entity-level row writes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+
+
+def siblings_for_issuer_cik(
+    conn: psycopg.Connection[Any], cik: str
+) -> list[int]:
+    """Return all instrument_ids sharing this issuer CIK.
+
+    The CIK is normalised (strip + zero-pad to 10 digits) before
+    lookup; callers may pass either form.
+
+    Ordering is deterministic (instrument_id ASC), NOT semantically
+    primary. Per-instrument fan-out callers iterate the full list.
+    Callers that need a single canonical sibling for entity-level
+    row writes should pick by explicit policy (e.g.
+    ``instruments.is_primary_listing``) rather than relying on this
+    ordering.
+
+    Raises ``ValueError`` if ``cik`` is not numeric after
+    normalisation. Empty string and obvious non-CIK input fail
+    fast — silent zero-pad of garbage would mask data-quality
+    issues upstream.
+    """
+    cik_padded = str(cik).strip().zfill(10)
+    if not cik_padded.isdigit() or len(cik_padded) != 10:
+        raise ValueError(f"non-numeric or wrong-length CIK: {cik!r}")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id
+            FROM external_identifiers
+            WHERE provider = 'sec'
+              AND identifier_type = 'cik'
+              AND identifier_value = %s
+            ORDER BY instrument_id
+            """,
+            (cik_padded,),
+        )
+        return [int(row[0]) for row in cur.fetchall()]

--- a/app/services/sec_insider_dataset_ingest.py
+++ b/app/services/sec_insider_dataset_ingest.py
@@ -62,9 +62,15 @@ class InsiderIngestResult:
 # ---------------------------------------------------------------------------
 
 
-def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, int]:
-    """Return ``{cik_padded: instrument_id}`` for every CIK-mapped instrument."""
-    out: dict[str, int] = {}
+def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, list[int]]:
+    """Return ``{cik_padded: [instrument_id, ...]}`` for every CIK-mapped instrument.
+
+    Multimap shape — share-class siblings (GOOG/GOOGL, BRK.A/BRK.B) co-bind
+    a single SEC CIK per #1102. Collapsing to ``dict[str, int]`` would
+    silently drop one sibling on every bulk run, leaving it without
+    insider observations.
+    """
+    out: dict[str, list[int]] = {}
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -76,7 +82,7 @@ def _load_cik_to_instrument(conn: psycopg.Connection[Any]) -> dict[str, int]:
         for row in cur.fetchall():
             instrument_id, identifier = row
             cik = str(identifier).zfill(10)
-            out[cik] = int(instrument_id)
+            out.setdefault(cik, []).append(int(instrument_id))
     return out
 
 
@@ -237,7 +243,7 @@ def ingest_insider_dataset_archive(
     *,
     conn: psycopg.Connection[Any],
     archive_path: Path,
-    cik_to_instrument: dict[str, int] | None = None,
+    cik_to_instrument: dict[str, list[int]] | None = None,
     ingest_run_id: UUID | None = None,
 ) -> InsiderIngestResult:
     """Walk one Insider Transactions Data Set ZIP and append observations.
@@ -297,8 +303,8 @@ def ingest_insider_dataset_archive(
 
             issuer_cik_raw = sub.get("ISSUERCIK") or sub.get("ISSUER_CIK") or ""
             issuer_cik = str(issuer_cik_raw).strip().zfill(10) if issuer_cik_raw.strip() else ""
-            instrument_id = cik_to_instrument.get(issuer_cik) if issuer_cik else None
-            if instrument_id is None:
+            matched_instruments = cik_to_instrument.get(issuer_cik, []) if issuer_cik else []
+            if not matched_instruments:
                 result.rows_skipped_unresolved_cik += 1
                 continue
 
@@ -320,21 +326,23 @@ def ingest_insider_dataset_archive(
             trans_sk = (trans.get("NONDERIV_TRANS_SK") or trans.get("NON_DERIV_TRANS_SK") or "").strip() or "0"
             source_document_id = f"{accn}:NDT:{trans_sk}"
 
-            _write_for_owners(
-                conn,
-                owner_list=owner_list,
-                instrument_id=instrument_id,
-                issuer_cik=issuer_cik,
-                accn=accn,
-                source=source,
-                source_document_id=source_document_id,
-                source_field=trans_sk if trans_sk != "0" else None,
-                filed_at=filed_at,
-                period_end=period_end,
-                ingest_run_id=ingest_run_id,
-                shares=shares,
-                result=result,
-            )
+            # Fan-out across share-class siblings on the same CIK (#1117).
+            for instrument_id in matched_instruments:
+                _write_for_owners(
+                    conn,
+                    owner_list=owner_list,
+                    instrument_id=instrument_id,
+                    issuer_cik=issuer_cik,
+                    accn=accn,
+                    source=source,
+                    source_document_id=source_document_id,
+                    source_field=trans_sk if trans_sk != "0" else None,
+                    filed_at=filed_at,
+                    period_end=period_end,
+                    ingest_run_id=ingest_run_id,
+                    shares=shares,
+                    result=result,
+                )
 
         # ─── Secondary write path: NONDERIV_HOLDING ─────────────
         # For accessions WITHOUT transactions (Form 3 initial-holdings
@@ -354,8 +362,8 @@ def ingest_insider_dataset_archive(
 
             issuer_cik_raw = sub.get("ISSUERCIK") or sub.get("ISSUER_CIK") or ""
             issuer_cik = str(issuer_cik_raw).strip().zfill(10) if issuer_cik_raw.strip() else ""
-            instrument_id = cik_to_instrument.get(issuer_cik) if issuer_cik else None
-            if instrument_id is None:
+            matched_instruments = cik_to_instrument.get(issuer_cik, []) if issuer_cik else []
+            if not matched_instruments:
                 result.rows_skipped_unresolved_cik += 1
                 continue
 
@@ -378,21 +386,23 @@ def ingest_insider_dataset_archive(
             ).strip() or "0"
             source_document_id = f"{accn}:NDH:{holding_sk}"
 
-            _write_for_owners(
-                conn,
-                owner_list=owner_list,
-                instrument_id=instrument_id,
-                issuer_cik=issuer_cik,
-                accn=accn,
-                source=source,
-                source_document_id=source_document_id,
-                source_field=holding_sk if holding_sk != "0" else None,
-                filed_at=filed_at,
-                period_end=period_end,
-                ingest_run_id=ingest_run_id,
-                shares=shares,
-                result=result,
-            )
+            # Fan-out across share-class siblings on the same CIK (#1117).
+            for instrument_id in matched_instruments:
+                _write_for_owners(
+                    conn,
+                    owner_list=owner_list,
+                    instrument_id=instrument_id,
+                    issuer_cik=issuer_cik,
+                    accn=accn,
+                    source=source,
+                    source_document_id=source_document_id,
+                    source_field=holding_sk if holding_sk != "0" else None,
+                    filed_at=filed_at,
+                    period_end=period_end,
+                    ingest_run_id=ingest_run_id,
+                    shares=shares,
+                    result=result,
+                )
     return result
 
 

--- a/app/services/sec_submissions_ingest.py
+++ b/app/services/sec_submissions_ingest.py
@@ -65,16 +65,21 @@ def _cik_from_filename(name: str) -> str | None:
 
 def _load_cik_to_instrument(
     conn: psycopg.Connection[Any],
-) -> dict[str, tuple[int, str]]:
-    """Return ``{cik_padded: (instrument_id, symbol)}`` for every CIK-mapped
-    instrument.
+) -> dict[str, list[tuple[int, str]]]:
+    """Return ``{cik_padded: [(instrument_id, symbol), ...]}`` for every
+    CIK-mapped instrument.
 
     Reads ``external_identifiers`` SEC CIK rows joined to ``instruments``
     so the writer below can pass the canonical ticker symbol — not a
     stringified instrument_id — to ``_normalise_submissions_block`` and
     ``_upsert_filing`` (Codex review BLOCKING for PR #1030).
+
+    Multimap shape — share-class siblings (GOOG/GOOGL, BRK.A/BRK.B)
+    co-bind a single SEC CIK per #1102. Collapsing to
+    ``dict[str, tuple[int, str]]`` would silently drop one sibling on
+    every bulk run, leaving it without filings or entity profile.
     """
-    out: dict[str, tuple[int, str]] = {}
+    out: dict[str, list[tuple[int, str]]] = {}
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -87,7 +92,7 @@ def _load_cik_to_instrument(
         for row in cur.fetchall():
             instrument_id, identifier, symbol = row
             cik = str(identifier).zfill(10)
-            out[cik] = (int(instrument_id), str(symbol or ""))
+            out.setdefault(cik, []).append((int(instrument_id), str(symbol or "")))
     return out
 
 
@@ -95,7 +100,7 @@ def ingest_submissions_archive(
     *,
     conn: psycopg.Connection[Any],
     archive_path: Path,
-    cik_to_instrument: dict[str, tuple[int, str]] | None = None,
+    cik_to_instrument: dict[str, list[tuple[int, str]]] | None = None,
 ) -> SubmissionsIngestResult:
     """Walk every ``CIK<10>.json`` entry in ``archive_path`` and upsert
     matching universe instruments into ``filing_events`` + ``instrument_sec_profile``.
@@ -124,20 +129,19 @@ def ingest_submissions_archive(
                 # noise we silently skip.
                 continue
             result.archive_entries_seen += 1
-            entry = cik_to_instrument.get(cik)
-            if entry is None:
+            matched_instruments = cik_to_instrument.get(cik, [])
+            if not matched_instruments:
                 # Universe gap — most CIKs in the archive are not in
                 # our universe. This is expected, not an error.
                 result.archive_entries_skipped += 1
                 continue
-            instrument_id, symbol = entry
-
-            result.instruments_matched += 1
 
             # Per-CIK savepoint: a parse error or DB-write failure for
             # one CIK must not abort the surrounding transaction or
             # block the rest of the archive (Codex pre-push round 1,
-            # finding 3).
+            # finding 3). Share-class siblings on the same CIK share
+            # one savepoint — failure rolls back all sibling writes
+            # for that entry together (#1117).
             try:
                 with conn.transaction():
                     try:
@@ -148,14 +152,16 @@ def ingest_submissions_archive(
                         result.parse_errors += 1
                         raise _SkipEntry from exc
 
-                    _ingest_one(
-                        conn,
-                        instrument_id=instrument_id,
-                        cik_padded=cik,
-                        symbol=symbol,
-                        payload=payload,
-                        result=result,
-                    )
+                    for instrument_id, symbol in matched_instruments:
+                        result.instruments_matched += 1
+                        _ingest_one(
+                            conn,
+                            instrument_id=instrument_id,
+                            cik_padded=cik,
+                            symbol=symbol,
+                            payload=payload,
+                            result=result,
+                        )
             except _SkipEntry:
                 continue
             except Exception as exc:  # noqa: BLE001

--- a/docs/superpowers/specs/2026-05-10-1117-filings-fanout-complete.md
+++ b/docs/superpowers/specs/2026-05-10-1117-filings-fanout-complete.md
@@ -1,0 +1,573 @@
+# #1117 PR-B fan-out — complete end-to-end design (v2 post-Codex)
+
+Date: 2026-05-10
+Status: spec drafted v2, addressing Codex round-1 findings.
+
+## Codex round-1 deltas applied (4 BLOCKING + 3 MEDIUM + 1 NIT)
+
+1. **BLOCKING — eight_k_filings/insider_filings child FKs.** PK relaxation
+   on those tables would cascade through eight_k_items / eight_k_exhibits
+   / insider_filers / insider_transaction_footnotes / insider_transactions
+   FK rewrites and force per-sibling duplication of entity-level
+   document detail. **Pivoting to Design B**: keep those PKs at accession
+   alone (entity-level), make `filing_events` the per-sibling bridge,
+   route `WHERE f.instrument_id = X` reads through filing_events.
+2. **BLOCKING — ON CONFLICT sweep.** Under Design B, eight_k_events.py
+   ON CONFLICTs at :428 + :516, insider_transactions.py at :942 + :1310,
+   insider_form3_ingest.py at :122 + :470 stay accession-keyed
+   unchanged. No sweep needed for those tables.
+3. **BLOCKING — def14a holdings UNIQUE shape.** Actual schema is
+   `(accession_number, holder_name)`, not the
+   `(instrument_id, accession, holder_name)` v1 spec assumed. Change
+   the UNIQUE shape in sql/144 + ON CONFLICT in def14a_ingest.py:315
+   so per-sibling fan-out creates distinct rows instead of
+   instrument_id flap.
+4. **BLOCKING — read-site audit.** Under Design B the JOINs Codex
+   flagged on insider_filings/eight_k_filings (no FK fan-out) collapse
+   1:1 again. New audit task: enumerate every `WHERE f.instrument_id`
+   on insider_filings + eight_k_filings and route through filing_events
+   bridge. Listed below.
+5. **MEDIUM — DISTINCT ON LIMIT semantics.** Use inner CTE for accession
+   dedup, outer ORDER BY filing_date DESC + LIMIT for priority.
+6. **MEDIUM — manifest seeder.** Inner DISTINCT ON accession only;
+   pick canonical sibling explicitly (lowest instrument_id) for
+   instrument_id/CIK columns.
+7. **MEDIUM — migration shape check.** Validate constraint shape via
+   pg_constraint.contype + conkey columns, not name alone.
+8. **NIT — sec_identity helper.** Normalise CIK input (strip + 10-pad);
+   document ordering as deterministic-only, not semantic-primary.
+
+## Context
+
+#1102 PR-A (sql/143, merged 2026-05-10) made `external_identifiers`
+allow N `(provider='sec', identifier_type='cik', identifier_value=X)`
+rows pointing at distinct `instrument_id`s. Share-class siblings
+(GOOG/GOOGL, BRK.A/BRK.B) co-bind a CIK without flap.
+
+#1117 is the follow-up: every code path that resolves CIK → instrument
+must fan out to ALL siblings. The bulk-ingester multimap shape change
+(`dict[str, list[X]]`) is in this PR's first commit — covers
+`sec_companyfacts_ingest` (financial_facts_raw), `sec_insider_dataset_ingest`
+(ownership_insiders_observations), `sec_submissions_ingest`
+(instrument_sec_profile + filing_events). The remaining work is
+schema relaxation for filing_events + def14a_beneficial_holdings,
+read-site routing through filing_events as bridge, candidate-selector
+DISTINCT ON dedup, per-filing-parser fan-out across siblings.
+
+## Synthesised design principle (data-engineer + sec-edgar skills)
+
+- **CIK identifies the issuer (entity).** Entity-level data —
+  document body, items, exhibits, manifest tombstones, ingest logs,
+  raw payloads — keyed at accession alone. One row per filing
+  regardless of how many share classes the issuer has.
+- **CUSIP identifies the security (per-share-class).** Per-instrument
+  data — observations, beneficial holdings, fund positions,
+  fundamentals — fans out per sibling.
+- **filing_events is the per-instrument bridge.** "This filing
+  applies to this instrument." Belongs at per-(accession, instrument).
+  Reads filter `WHERE fe.instrument_id = X`; entity-level tables JOIN
+  through it for sibling visibility.
+- **eight_k_filings + insider_filings stay entity-level.** PK on
+  accession; instrument_id column is "discovery sibling" denormalisation,
+  informational only — reads use filing_events bridge instead.
+
+## Schema migration — `sql/144_filings_fanout_per_instrument.sql`
+
+```sql
+-- 1. filing_events: relax UNIQUE to (provider, provider_filing_id, instrument_id).
+--    Bridge table for per-sibling routing.
+DO $$
+DECLARE
+    has_correct_shape BOOLEAN;
+BEGIN
+    SELECT EXISTS(
+        SELECT 1 FROM pg_constraint c
+        WHERE c.conname = 'uq_filing_events_provider_unique'
+          AND c.contype = 'u'
+          AND c.conrelid = 'filing_events'::regclass
+          AND (
+              SELECT array_agg(a.attname ORDER BY array_position(c.conkey, a.attnum))
+              FROM pg_attribute a
+              WHERE a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+          ) = ARRAY['provider', 'provider_filing_id', 'instrument_id']::name[]
+    ) INTO has_correct_shape;
+
+    IF NOT has_correct_shape THEN
+        ALTER TABLE filing_events
+            DROP CONSTRAINT IF EXISTS uq_filing_events_provider_unique;
+        ALTER TABLE filing_events
+            ADD CONSTRAINT uq_filing_events_provider_unique
+                UNIQUE (provider, provider_filing_id, instrument_id);
+    END IF;
+END$$;
+
+-- 2. def14a_beneficial_holdings: relax UNIQUE to per-(instrument, accession, holder).
+--    Allows share-class siblings to each carry their own holdings rows.
+DO $$
+DECLARE
+    has_correct_shape BOOLEAN;
+BEGIN
+    SELECT EXISTS(
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND tablename = 'def14a_beneficial_holdings'
+          AND indexname = 'uq_def14a_holdings_instrument_accession_holder'
+    ) INTO has_correct_shape;
+
+    IF NOT has_correct_shape THEN
+        DROP INDEX IF EXISTS uq_def14a_holdings_accession_holder;
+        CREATE UNIQUE INDEX uq_def14a_holdings_instrument_accession_holder
+            ON def14a_beneficial_holdings (instrument_id, accession_number, holder_name);
+    END IF;
+END$$;
+```
+
+eight_k_filings + insider_filings stay PK=accession. Their child
+tables (items, exhibits, filers, footnotes, transactions) keep their
+accession-keyed FKs — entity-level invariants preserved.
+
+## Code change 1 — filing_events ON CONFLICT (3 prod sites + 3 test sites)
+
+`app/services/filings.py:449` (`_upsert_filing_event`),
+`app/services/filings.py:499` (`_upsert_filing`),
+`app/services/fundamentals.py:2255`:
+
+Append `, instrument_id` to conflict target. DO UPDATE clauses
+unchanged (don't touch instrument_id; hit means already correct).
+
+```python
+ON CONFLICT (provider, provider_filing_id, instrument_id) DO UPDATE SET
+    filing_date          = EXCLUDED.filing_date,
+    filing_type          = EXCLUDED.filing_type,
+    source_url           = EXCLUDED.source_url,
+    primary_document_url = EXCLUDED.primary_document_url
+```
+
+Test fixtures sweep: `tests/test_def14a_drill.py:425`,
+`tests/test_rewash_filings.py:1514`, `tests/test_def14a_ingest.py:119`.
+Same mechanical change.
+
+## Code change 2 — def14a_beneficial_holdings ON CONFLICT
+
+`app/services/def14a_ingest.py:315`:
+
+Change conflict target from `(accession_number, holder_name)` to
+`(instrument_id, accession_number, holder_name)`. Drop
+`instrument_id = EXCLUDED.instrument_id` from DO UPDATE SET (now in
+conflict target — hit means already correct).
+
+```python
+ON CONFLICT (instrument_id, accession_number, holder_name) DO UPDATE SET
+    issuer_cik       = EXCLUDED.issuer_cik,
+    holder_role      = EXCLUDED.holder_role,
+    shares           = EXCLUDED.shares,
+    percent_of_class = EXCLUDED.percent_of_class,
+    as_of_date       = EXCLUDED.as_of_date,
+    fetched_at       = NOW()
+RETURNING (xmax = 0) AS inserted
+```
+
+## Code change 3 — siblings helper (new module)
+
+`app/services/sec_identity.py`:
+
+```python
+"""Shared helpers for resolving SEC issuer CIKs to instrument siblings.
+
+Per #1102, multiple instruments may share an SEC CIK (share-class
+siblings GOOG/GOOGL, BRK.A/BRK.B). Per-filing parsers must fan out
+their per-instrument writes across all siblings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+
+
+def siblings_for_issuer_cik(
+    conn: psycopg.Connection[Any], cik: str
+) -> list[int]:
+    """Return all instrument_ids sharing this issuer CIK.
+
+    Ordering is deterministic (instrument_id ASC), not semantic.
+    Callers that need to fan out per-instrument writes should iterate
+    the full list. Callers that must pick a single canonical sibling
+    for entity-level row writes should choose by explicit policy
+    (e.g. instruments.is_primary_listing) rather than relying on
+    this ordering.
+
+    The CIK is normalised (strip + zero-pad to 10 digits) before
+    lookup; callers may pass either form.
+    """
+    cik_padded = str(cik).strip().zfill(10)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id
+            FROM external_identifiers
+            WHERE provider = 'sec'
+              AND identifier_type = 'cik'
+              AND identifier_value = %s
+            ORDER BY instrument_id
+            """,
+            (cik_padded,),
+        )
+        return [int(r[0]) for r in cur.fetchall()]
+```
+
+## Code change 4 — eight_k_filings reads route through filing_events
+
+[app/services/eight_k_events.py:578](../../../app/services/eight_k_events.py#L578) — change `WHERE f.instrument_id = %s` to filing_events bridge:
+
+```sql
+SELECT
+    f.accession_number, f.document_type, f.is_amendment,
+    f.date_of_report, f.reporting_party,
+    f.signature_name, f.signature_title, f.signature_date,
+    f.primary_document_url
+FROM eight_k_filings f
+WHERE f.is_tombstone = FALSE
+  AND EXISTS (
+      SELECT 1 FROM filing_events fe
+      WHERE fe.provider_filing_id = f.accession_number
+        AND fe.provider = 'sec'
+        AND fe.instrument_id = %s
+        AND fe.filing_type IN ('8-K', '8-K/A')
+  )
+ORDER BY f.date_of_report DESC NULLS LAST, f.fetched_at DESC
+LIMIT %s
+```
+
+[app/services/capabilities.py:175](../../../app/services/capabilities.py#L175) — same pattern:
+
+```python
+("eight_k", "sec_edgar"): (
+    "SELECT EXISTS(SELECT 1 FROM filing_events fe "
+    "WHERE fe.provider = 'sec' "
+    "AND fe.filing_type IN ('8-K', '8-K/A') "
+    "AND fe.instrument_id = %s)"
+)
+```
+
+eight_k_filings.instrument_id column stays — repurposed as "discovery
+sibling, informational only". Document the deprecation in a comment.
+
+## Code change 5 — insider_filings reads route through filing_events
+
+Per Codex audit, the affected sites with direct
+`WHERE i.instrument_id = X` filter (NOT through observations) are:
+
+- [app/api/instruments.py:2205, 2216, 2228](../../../app/api/instruments.py) — insider summary panels.
+- [app/services/ownership_observations_sync.py:174, 232](../../../app/services/ownership_observations_sync.py) — backfill walk.
+- [app/services/rewash_filings.py:299, 370](../../../app/services/rewash_filings.py) — rewash queries.
+- [app/services/insider_form3_ingest.py:139, 768, 801](../../../app/services/insider_form3_ingest.py) — backfill.
+
+Most of these JOIN `insider_filings` then filter via downstream
+`WHERE instrument_id = X` on observations or transactions. Audit each
+to verify the per-sibling filter happens at the per-instrument table,
+NOT at insider_filings. Where it currently filters at insider_filings,
+re-route to filing_events:
+
+```sql
+JOIN insider_filings f ON f.accession_number = obs.accession_number
+WHERE EXISTS (
+    SELECT 1 FROM filing_events fe
+    WHERE fe.provider_filing_id = f.accession_number
+      AND fe.provider = 'sec'
+      AND fe.filing_type IN ('4', '4/A', '3', '3/A', '5', '5/A')
+      AND fe.instrument_id = %s
+)
+```
+
+Per-site audit table (filled in 2026-05-10):
+
+| Site | Current filter | Action |
+|---|---|---|
+| `app/api/instruments.py:2206` | `WHERE h.instrument_id` on `insider_initial_holdings` | safe — per-instrument table |
+| `app/api/instruments.py:2217` | `WHERE instrument_id` on `insider_filings` | **FIX** — bridge via filing_events |
+| `app/api/instruments.py:2229` | `i.instrument_id` on `insider_filings` JOIN | **FIX** — bridge via filing_events |
+| `app/services/ownership_drillthrough.py:292` | `WHERE t.instrument_id` on `insider_transactions` | safe — per-row table is observation-shaped |
+| `app/services/ownership_drillthrough.py:304` | `WHERE instrument_id` on `insider_filings` | **FIX** — bridge via filing_events |
+| `app/services/ownership_drillthrough.py:318` | `i.instrument_id` on `insider_filings` JOIN | **FIX** — bridge via filing_events |
+| `app/services/ownership_drillthrough.py:353` | `WHERE h.instrument_id` on `insider_initial_holdings` | safe |
+| `app/services/ownership_drillthrough.py:365` | `WHERE instrument_id` on `insider_filings` | **FIX** — bridge via filing_events |
+| `app/services/ownership_drillthrough.py:379` | `i.instrument_id` on `insider_filings` JOIN | **FIX** — bridge via filing_events |
+| `app/services/ownership_observations_sync.py:174, 232` | JOIN by accession; per-row processing | safe |
+| `app/services/rewash_filings.py:299, 370` | JOIN/SELECT for rewash; observation-keyed | safe (per-row processing handles fan-out implicitly) |
+| `app/services/insider_form3_ingest.py:139, 768, 801` | candidate selectors (covered by code change 8) + observation walk | candidate dedup; rewash queries safe |
+
+Six insider/eight_k bad sites total (3 + 2 in instruments.py/eight_k_events.py + 6 in ownership_drillthrough). All get the EXISTS bridge predicate. Observation-keyed and per-row paths stay unchanged.
+
+## Code change 6 — DEF 14A parser fan-out
+
+[app/services/def14a_ingest.py](../../../app/services/def14a_ingest.py)
+parses one DEF 14A at a time and writes
+`def14a_beneficial_holdings` rows + `def14a_ingest_log`.
+
+Post-fan-out:
+- `def14a_ingest_log` stays PK=accession (entity-level tombstone — one
+  parse attempt logged regardless of siblings).
+- `def14a_beneficial_holdings` writes wrap in
+  `for instrument_id in siblings_for_issuer_cik(conn, cik):` —
+  each sibling gets its own rows under the new
+  `(instrument_id, accession, holder_name)` UNIQUE.
+- `record_def14a_observation()` + `refresh_def14a_current(instrument_id)`
+  fan out across siblings.
+- `record_esop_observation()` + `refresh_esop_current(instrument_id)`
+  fan out across siblings (ESOP holdings live on def14a payloads).
+
+## Code change 7 — Form 4/3 per-filing parser fan-out
+
+[app/services/insider_transactions.py](../../../app/services/insider_transactions.py)
++ [app/services/insider_form3_ingest.py](../../../app/services/insider_form3_ingest.py).
+
+`insider_filings` row stays PK=accession (entity-level — one filing
+object). `insider_transactions` / `insider_initial_holdings` rows
+stay PK=(accession, txn_row_num) / (accession, row_num) — entity-level
+per-transaction details.
+
+Per-instrument fan-out happens at the observation layer:
+- `record_insider_observation()` + `refresh_insiders_current(instrument_id)`
+  fan out across siblings.
+
+The `insider_filings.instrument_id` column stays (informational —
+"discovery sibling"). Same pattern as eight_k_filings.
+
+## Code change 8 — candidate-selector DISTINCT ON dedup (inner CTE)
+
+Six per-filing candidate-selector sites that LEFT JOIN entity-level
+log/marker tables on accession alone — without dedup they batch the
+same accession N times post-fan-out, wasting LIMIT budget:
+
+| File:line | Pattern | Fix |
+|---|---|---|
+| `app/services/def14a_ingest.py:194` | LEFT JOIN def14a_ingest_log ON accession_number | Inner CTE dedup |
+| `app/services/eight_k_events.py:717` | LEFT JOIN eight_k_filings ON accession_number IS NULL | Inner CTE dedup |
+| `app/services/insider_transactions.py:1404, 1459, 1614, 1646` | LEFT JOIN insider_filings ON accession_number IS NULL | Inner CTE dedup |
+| `app/services/insider_form3_ingest.py:520, 569` | Same Form 3 variant | Inner CTE dedup |
+
+Pattern (preserves LIMIT-by-recency semantics):
+
+```sql
+WITH per_accession AS (
+    SELECT DISTINCT ON (fe.provider_filing_id)
+        fe.instrument_id, fe.provider_filing_id, fe.primary_document_url,
+        fe.filing_date, fe.filing_event_id
+    FROM filing_events fe
+    LEFT JOIN <log_or_marker> ekf
+        ON ekf.accession_number = fe.provider_filing_id
+    WHERE fe.provider = 'sec'
+      AND fe.filing_type IN (...)
+      AND ekf.accession_number IS NULL
+    ORDER BY fe.provider_filing_id, fe.instrument_id  -- inner: dedup
+)
+SELECT instrument_id, provider_filing_id, primary_document_url
+FROM per_accession
+ORDER BY filing_date DESC, filing_event_id DESC      -- outer: priority
+LIMIT %s
+```
+
+Inner ORDER BY locks dedup choice (`fe.instrument_id ASC` —
+deterministic, parser fans out anyway so the choice is academic).
+Outer ORDER BY preserves "newest first" for LIMIT priority.
+
+## Code change 9 — manifest seeder dedup (sec_first_install_drain)
+
+[app/jobs/sec_first_install_drain.py:104-130](../../../app/jobs/sec_first_install_drain.py).
+
+`sec_filing_manifest.accession_number` is PK. With per-instrument
+filing_events, the seeder's straight `SELECT FROM filing_events`
+emits one row per (accession, instrument_id) pair. The downstream
+INSERT collapses on PK, last-row-wins.
+
+Fix: dedup on accession in the SELECT, pick canonical sibling
+explicitly (lowest instrument_id) for the row's instrument_id /
+issuer_cik columns. Source must use `map_form_to_source(form)` —
+manifest's source CHECK rejects `'sec_submissions'`:
+
+```sql
+INSERT INTO sec_filing_manifest (
+    accession_number, cik, form, filed_at,
+    instrument_id, source, ingest_status, ...
+)
+SELECT DISTINCT ON (fe.provider_filing_id)
+    fe.provider_filing_id,
+    -- Resolve issuer CIK from external_identifiers. Existing code
+    -- pattern (preserve verbatim): ORDER BY is_primary DESC,
+    -- external_identifier_id ASC — handles non-primary-only mappings
+    -- AND multi-primary edge if a sibling has stale duplicates.
+    (SELECT identifier_value
+       FROM external_identifiers
+      WHERE provider = 'sec' AND identifier_type = 'cik'
+        AND instrument_id = fe.instrument_id
+      ORDER BY is_primary DESC, external_identifier_id ASC
+      LIMIT 1) AS cik,
+    fe.filing_type,
+    fe.filing_date,
+    fe.instrument_id,                  -- discovery sibling (canonical)
+    map_form_to_source(fe.filing_type) AS source,
+    'pending',
+    ...
+FROM filing_events fe
+WHERE fe.provider = 'sec'
+  AND map_form_to_source(fe.filing_type) IS NOT NULL  -- skip unsupported forms
+  AND NOT EXISTS (
+      SELECT 1 FROM sec_filing_manifest m
+      WHERE m.accession_number = fe.provider_filing_id
+  )
+ORDER BY fe.provider_filing_id, fe.instrument_id  -- canonical = lowest iid
+ON CONFLICT (accession_number) DO NOTHING;
+```
+
+If `map_form_to_source` is a Python helper not a SQL function, the
+seeder either (a) reads the rows in Python and partitions per-source
+before INSERT or (b) embeds an inline `CASE WHEN fe.filing_type IN
+('10-K', '10-K/A') THEN 'sec_10k' ...` map. (a) is the cleaner shape
+since the existing form→source map already lives in
+`app/services/sec_manifest.py`.
+
+DISTINCT ON carve-out for targeted selectors: when the candidate
+selector has `WHERE fe.instrument_id = %s`, only one sibling's rows
+match the WHERE — no fan-out can multiply, dedup is unnecessary. The
+inner-CTE pattern applies to **universe-wide** selectors only
+(`WHERE fe.filing_type IN (...) AND ekf.accession_number IS NULL`
+without instrument_id filter). Targeted backfill paths
+(`fe.instrument_id = %s AND ekf.accession_number IS NULL`) skip
+DISTINCT ON entirely.
+
+`sec_filing_manifest.instrument_id` becomes "canonical sibling for
+this filing"; the manifest worker / parsers fan out via
+`siblings_for_issuer_cik(cik)` at parse time.
+
+## Read-site audit (post-migration)
+
+### filing_events (per-instrument post-migration)
+
+All 28 read sites verified: filter by `WHERE fe.instrument_id = X`
+in WHERE clause OR thread instrument_id through per-row processor.
+Safe.
+
+One genuine pre-existing edge: `app/services/rewash_filings.py:467,
+777` — `JOIN filing_events ... LIMIT 1` without instrument filter
+picks an arbitrary sibling. Pre-existing arbitrary-pick that surfaced
+at #1102 PR-A. Add deterministic `ORDER BY fe.instrument_id ASC` so
+LIMIT 1 is reproducible; document in commit message.
+
+### eight_k_filings (entity-level, PK=accession unchanged)
+
+- Read site `:578` — fixed in code change 4 (filing_events bridge).
+- Read site `capabilities.py:175` — fixed in code change 4.
+- Candidate selector `:717` — fixed in code change 8.
+
+### insider_filings (entity-level, PK=accession unchanged)
+
+- Per-site audit listed in code change 5.
+
+### Other accession-keyed reads (cross-check)
+
+- `def14a_ingest_log` PK=accession — unchanged shape, all reads safe.
+- `n_port_ingest_log` PK=accession — unchanged.
+- `sec_filing_manifest` PK=accession — fixed in code change 9.
+- `filing_raw_documents` PK=(accession, kind) — unchanged.
+
+## Test plan
+
+### Existing fan-out tests (already in this PR's first commit)
+
+- `tests/test_sec_companyfacts_ingest.py::test_share_class_siblings_both_receive_facts`
+- `tests/test_sec_submissions_ingest.py::test_share_class_siblings_both_receive_filings_and_profile`
+- `tests/test_sec_insider_dataset_ingest.py::test_share_class_siblings_both_receive_observations`
+
+### New tests (this PR's second commit)
+
+- `tests/test_def14a_ingest.py::test_share_class_siblings_both_receive_holdings_and_observations` — parse one DEF 14A; both siblings get def14a_beneficial_holdings rows + def14a_observations + esop_observations.
+- `tests/test_eight_k_events.py::test_share_class_siblings_both_render_via_filing_events_bridge` — one 8-K parsed; eight_k_filings has one row (accession-keyed); both siblings see it via the read-side bridge query.
+- `tests/test_insider_transactions.py::test_share_class_siblings_both_receive_observations_via_per_filing_path` — one Form 4 per-filing parse; both siblings get observations + refresh_current.
+- `tests/test_filings.py::test_upsert_filing_per_instrument_idempotent` — call _upsert_filing twice with same (accession, instrument); one row. Twice with same accession + different instrument; two rows.
+- `tests/test_sec_identity.py::test_siblings_for_issuer_cik_returns_all_siblings_deterministic` — helper unit test.
+- Idempotency tests for each fan-out path (re-parse → no duplication).
+
+### Migration test
+
+- `tests/test_migration_144_filings_fanout.py` — apply migration cleanly + idempotently against post-#143 schema. Verify constraint shape via pg_constraint inspection.
+
+## Verification matrix (DOD clauses 8-12)
+
+Per CLAUDE.md ETL/parser/schema-migration clauses 8-12.
+
+| Instrument | Class | Expected after sec_rebuild |
+|---|---|---|
+| AAPL | single | unchanged baseline (regression sentinel) |
+| GOOG | share-class | filing_events ≥ N, def14a_beneficial_holdings ≥ J, ownership_insiders_observations ≥ L (per-instrument) |
+| GOOGL | share-class | same row counts as GOOG |
+| BRK.A | share-class | same |
+| BRK.B | share-class | same |
+
+SQL audit:
+
+```sql
+WITH siblings AS (
+    SELECT instrument_id, symbol FROM instruments
+    WHERE symbol IN ('AAPL', 'GOOG', 'GOOGL', 'BRK.A', 'BRK.B')
+)
+SELECT s.symbol,
+       (SELECT COUNT(*) FROM filing_events                  WHERE instrument_id = s.instrument_id) AS filings,
+       (SELECT COUNT(*) FROM def14a_beneficial_holdings     WHERE instrument_id = s.instrument_id) AS def14a,
+       (SELECT COUNT(*) FROM ownership_insiders_observations WHERE instrument_id = s.instrument_id) AS obs
+FROM siblings s ORDER BY s.symbol;
+```
+
+Both GOOG and GOOGL must return non-zero on every column.
+
+Operator-visible verification (DOD clause 11):
+- `/instruments/GOOG/ownership-rollup` AND `/instruments/GOOGL/ownership-rollup` both render with non-NULL totals + insider slice + def14a slice.
+- `/instruments/GOOG/eight_k_filings` AND `/instruments/GOOGL/eight_k_filings` both return rows (via filing_events bridge).
+- `/instruments/GOOG/insider_baseline` AND `/instruments/GOOGL/insider_baseline` both return rows.
+- `/instruments/GOOG/def14a_holdings/drill` AND `/instruments/GOOGL/def14a_holdings/drill` both return rows.
+
+Cross-source verify (DOD clause 9): GOOGL filing date or insider holder count against gurufocus / SEC EDGAR direct.
+
+## Operator runbook (post-merge)
+
+1. Apply migration sql/144.
+2. Trigger rebuild:
+   ```bash
+   curl -X POST http://localhost:8000/jobs/sec_rebuild/run -d '{"source": "sec_submissions"}'
+   curl -X POST http://localhost:8000/jobs/sec_rebuild/run -d '{"source": "sec_form4"}'
+   curl -X POST http://localhost:8000/jobs/sec_rebuild/run -d '{"source": "sec_def14a"}'
+   ```
+3. Wait for manifest worker drain.
+4. Run verification SQL above. Confirm GOOG + GOOGL parity.
+5. Hit operator-visible endpoints listed above for both siblings.
+6. Cross-source confirm one figure.
+
+## Out of scope
+
+- Per-sibling fan-out at eight_k_filings / insider_filings level — child
+  tables (items, exhibits, footnotes, transactions) are entity-level
+  by FK shape; per-sibling rows would force per-sibling duplication of
+  document detail.
+- `eight_k_filings.instrument_id` and `insider_filings.instrument_id`
+  column drop — kept as informational "discovery sibling" denormalisation.
+  Operator-visible behaviour reroutes via filing_events bridge.
+- Universe expansion / share-class sibling discovery — already covered
+  by #1102 PR-A.
+
+## Codex spec review v2 prompt
+
+Review correctness of v2 spec against round-1 findings:
+(a) Design B PK preservation on eight_k_filings + insider_filings —
+    are entity-level invariants intact?
+(b) Read-site routing through filing_events — any sites missed where
+    `WHERE f.instrument_id = X` on insider_filings/eight_k_filings
+    won't be re-routed?
+(c) def14a UNIQUE shape change idempotency — re-runnable index swap?
+(d) Inner-CTE DISTINCT ON pattern — preserves LIMIT-by-recency?
+(e) Manifest seeder canonical-sibling pick — leak any nondeterminism?
+(f) Migration shape-check via pg_constraint.contype + conkey —
+    handles partial-apply?
+(g) sec_identity helper — naming, normalisation, ordering policy
+    documentation?
+Reply terse with severity-tagged findings (BLOCKING / MEDIUM / NIT).

--- a/sql/144_filings_fanout_per_instrument.sql
+++ b/sql/144_filings_fanout_per_instrument.sql
@@ -1,0 +1,98 @@
+-- Migration 144: filings fan-out per instrument (#1117 PR-B)
+--
+-- Companion to sql/143 (#1102 PR-A). Once external_identifiers allows N
+-- (provider='sec', identifier_type='cik', identifier_value=X) rows
+-- pointing at distinct instrument_ids (sql/143), every code path that
+-- resolves CIK -> instrument must fan out to ALL siblings. The bulk
+-- ingester multimap shape change ships in the same PR's first commit.
+--
+-- This migration relaxes:
+--
+-- 1. ``filing_events`` UNIQUE (provider, provider_filing_id) ->
+--    UNIQUE (provider, provider_filing_id, instrument_id). filing_events
+--    is the per-instrument bridge: every read filters by
+--    ``WHERE fe.instrument_id = X`` already; the relaxation lets two
+--    siblings each carry their own (accession, instrument) row instead
+--    of one collapsing on top of the other.
+--
+-- 2. ``def14a_beneficial_holdings`` UNIQUE INDEX
+--    ``uq_def14a_holdings_accession_holder`` (accession_number,
+--    holder_name) -> ``uq_def14a_holdings_instrument_accession_holder``
+--    (instrument_id, accession_number, holder_name). Per-share-class
+--    proxies legitimately list the same holder name on the same
+--    accession for both siblings; pre-relaxation the second sibling's
+--    INSERT ON CONFLICT overwrote instrument_id instead of creating a
+--    distinct row.
+--
+-- Tables NOT relaxed (entity-level, child FKs anchor on accession alone):
+-- - ``eight_k_filings`` PK accession (eight_k_items / eight_k_exhibits FK)
+-- - ``insider_filings`` PK accession (insider_filers /
+--   insider_transaction_footnotes / insider_transactions /
+--   insider_initial_holdings FK)
+-- - ``def14a_ingest_log`` PK accession (entity-level tombstone)
+-- - ``sec_filing_manifest`` PK accession (entity-level)
+-- - ``filing_raw_documents`` PK (accession, document_kind)
+--
+-- Read-side fan-out for those tables routes through ``filing_events``
+-- as the per-instrument bridge -- application code change, not schema.
+-- See docs/superpowers/specs/2026-05-10-1117-filings-fanout-complete.md.
+--
+-- Idempotency: each constraint/index swap is gated on a shape check
+-- (pg_constraint.contype + conkey for table constraints; pg_index +
+-- pg_class.relname for indexes) so partial-applied dev DBs re-run
+-- cleanly. Name-only checks would falsely skip when the name points
+-- at a wrong-shape constraint.
+
+-- 1. filing_events: relax UNIQUE to (provider, provider_filing_id, instrument_id)
+DO $$
+DECLARE
+    has_correct_shape BOOLEAN;
+BEGIN
+    SELECT EXISTS(
+        SELECT 1 FROM pg_constraint c
+        WHERE c.conname = 'uq_filing_events_provider_unique'
+          AND c.contype = 'u'
+          AND c.conrelid = 'filing_events'::regclass
+          AND (
+              SELECT array_agg(a.attname ORDER BY array_position(c.conkey, a.attnum))
+              FROM pg_attribute a
+              WHERE a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+          ) = ARRAY['provider', 'provider_filing_id', 'instrument_id']::name[]
+    ) INTO has_correct_shape;
+
+    IF NOT has_correct_shape THEN
+        ALTER TABLE filing_events
+            DROP CONSTRAINT IF EXISTS uq_filing_events_provider_unique;
+        ALTER TABLE filing_events
+            ADD CONSTRAINT uq_filing_events_provider_unique
+                UNIQUE (provider, provider_filing_id, instrument_id);
+    END IF;
+END$$;
+
+-- 2. def14a_beneficial_holdings: relax UNIQUE INDEX to per-(instrument, accession, holder)
+DO $$
+DECLARE
+    has_correct_shape BOOLEAN;
+BEGIN
+    SELECT EXISTS(
+        SELECT 1
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+         WHERE c.relname = 'uq_def14a_holdings_instrument_accession_holder'
+           AND i.indrelid = 'def14a_beneficial_holdings'::regclass
+           AND i.indisunique
+           AND (
+               SELECT array_agg(a.attname ORDER BY array_position(i.indkey::int[], a.attnum::int))
+                 FROM pg_attribute a
+                WHERE a.attrelid = i.indrelid
+                  AND a.attnum = ANY(i.indkey::int[])
+           ) = ARRAY['instrument_id', 'accession_number', 'holder_name']::name[]
+    ) INTO has_correct_shape;
+
+    IF NOT has_correct_shape THEN
+        DROP INDEX IF EXISTS uq_def14a_holdings_accession_holder;
+        DROP INDEX IF EXISTS uq_def14a_holdings_instrument_accession_holder;
+        CREATE UNIQUE INDEX uq_def14a_holdings_instrument_accession_holder
+            ON def14a_beneficial_holdings (instrument_id, accession_number, holder_name);
+    END IF;
+END$$;

--- a/tests/test_def14a_drill.py
+++ b/tests/test_def14a_drill.py
@@ -422,7 +422,7 @@ def test_drill_tombstone_query_is_filing_distinct(
                 filing_date, primary_document_url, source_url
             ) VALUES (%s, 'sec', %s, 'DEF 14A', '2025-04-01',
                       'http://x', 'http://y')
-            ON CONFLICT (provider, provider_filing_id) DO NOTHING
+            ON CONFLICT (provider, provider_filing_id, instrument_id) DO NOTHING
             """,
             (972_020, accn),
         )

--- a/tests/test_def14a_ingest.py
+++ b/tests/test_def14a_ingest.py
@@ -116,7 +116,7 @@ def _seed_filing_event(
             instrument_id, filing_date, filing_type,
             provider, provider_filing_id, primary_document_url
         ) VALUES (%s, %s, %s, 'sec', %s, %s)
-        ON CONFLICT (provider, provider_filing_id) DO NOTHING
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO NOTHING
         """,
         (instrument_id, filing_date, filing_type, accession, primary_document_url),
     )

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -1511,7 +1511,7 @@ def test_13f_infotable_apply_rescues_tombstoned_accession(
             instrument_id, provider, provider_filing_id, filing_type,
             filing_date, primary_document_url, source_url
         ) VALUES (%s, 'sec', %s, '13F-HR', %s, 'http://x', 'http://y')
-        ON CONFLICT (provider, provider_filing_id) DO NOTHING
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO NOTHING
         """,
         (iid, accession, sec_filing_date),
     )

--- a/tests/test_sec_companyfacts_ingest.py
+++ b/tests/test_sec_companyfacts_ingest.py
@@ -211,3 +211,56 @@ class TestIngestCompanyFactsArchive:
 
         assert result.parse_errors == 1
         assert result.facts_upserted == 0
+
+    def test_share_class_siblings_both_receive_facts(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """#1117 — GOOG + GOOGL co-bind one CIK; both must receive facts.
+
+        Pre-#1117 the dict-collapse in ``_load_cik_to_instrument`` kept
+        only the last-seen sibling, leaving the other without
+        fundamentals on every bulk run. Multimap shape fans out one
+        archive entry to N siblings.
+        """
+        iid_goog = _seed_universe(ebull_test_conn, symbol="GOOG", cik_padded="0001652044")
+        iid_googl = _seed_universe(ebull_test_conn, symbol="GOOGL", cik_padded="0001652044")
+
+        # Reuse AAPL payload shape — XBRL semantics are independent of
+        # the issuer; the fan-out test cares about row presence per
+        # instrument, not the specific concept set.
+        archive_bytes = _build_archive({"0001652044": _aapl_companyfacts_payload()})
+        archive_path = tmp_path / "companyfacts.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_companyfacts_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+        )
+        ebull_test_conn.commit()
+
+        assert result.archive_entries_seen == 1
+        assert result.instruments_matched == 2  # GOOG + GOOGL
+        assert result.parse_errors == 0
+        assert result.facts_upserted >= 4  # 2 facts × 2 siblings
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM financial_facts_raw WHERE instrument_id = %s",
+                (iid_goog,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            goog_count = row[0]
+
+            cur.execute(
+                "SELECT COUNT(*) FROM financial_facts_raw WHERE instrument_id = %s",
+                (iid_googl,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            googl_count = row[0]
+
+        assert goog_count >= 2, f"GOOG expected >=2 facts, got {goog_count}"
+        assert googl_count >= 2, f"GOOGL expected >=2 facts, got {googl_count}"

--- a/tests/test_sec_insider_dataset_ingest.py
+++ b/tests/test_sec_insider_dataset_ingest.py
@@ -406,3 +406,74 @@ class TestIngestInsiderDatasetArchive:
 
         assert result.rows_written == 0
         assert result.rows_skipped_unresolved_cik == 1
+
+    def test_share_class_siblings_both_receive_observations(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """#1117 — GOOG + GOOGL co-bind one CIK; both must receive
+        insider observations. Pre-#1117 the dict-collapse kept only
+        the last-seen sibling.
+        """
+        iid_goog = _seed_universe(ebull_test_conn, symbol="GOOG", cik_padded="0001652044")
+        iid_googl = _seed_universe(ebull_test_conn, symbol="GOOGL", cik_padded="0001652044")
+
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000099",
+                    "ISSUERCIK": "1652044",
+                    "DOCUMENT_TYPE": "4",
+                    "FILING_DATE": "2025-11-14",
+                    "PERIOD_OF_REPORT": "2025-11-12",
+                },
+            ],
+            owners=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000099",
+                    "RPTOWNERCIK": "1234567",
+                    "RPTOWNERNAME": "Pichai Sundar",
+                    "RPTOWNER_RELATIONSHIP": "Officer",
+                },
+            ],
+            transactions=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000099",
+                    "NONDERIV_TRANS_SK": "1",
+                    "TRANS_DATE": "2025-11-12",
+                    "SHRS_OWND_FOLWNG_TRANS": "5000",
+                },
+            ],
+            holdings=[],
+        )
+        archive_path = tmp_path / "form345.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_insider_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        # 1 transaction × 1 owner × 2 siblings = 2 rows written.
+        assert result.rows_written == 2
+        assert result.rows_skipped_unresolved_cik == 0
+        assert {iid_goog, iid_googl} <= result.touched_instrument_ids
+
+        with ebull_test_conn.cursor() as cur:
+            for iid, label in ((iid_goog, "GOOG"), (iid_googl, "GOOGL")):
+                cur.execute(
+                    """
+                    SELECT holder_name, source, shares
+                    FROM ownership_insiders_observations
+                    WHERE instrument_id = %s
+                    """,
+                    (iid,),
+                )
+                row = cur.fetchone()
+                assert row is not None, f"{label} missing observation row"
+                assert row[0] == "Pichai Sundar"
+                assert row[1] == "form4"
+                assert row[2] == Decimal("5000.0000")

--- a/tests/test_sec_submissions_ingest.py
+++ b/tests/test_sec_submissions_ingest.py
@@ -233,3 +233,81 @@ class TestIngestSubmissionsArchive:
 
         assert result.parse_errors == 1
         assert result.filings_upserted == 0
+
+    def test_share_class_siblings_both_receive_filings_and_profile(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """#1117 — GOOG + GOOGL co-bind one CIK; both must receive
+        filings + entity profile.
+        """
+        iid_goog = _seed_universe(ebull_test_conn, symbol="GOOG", cik_padded="0001652044")
+        iid_googl = _seed_universe(ebull_test_conn, symbol="GOOGL", cik_padded="0001652044")
+
+        # Reuse AAPL submissions payload shape — _normalise_submissions_block
+        # is content-agnostic; we care that the same archive entry
+        # produces filings rows for both siblings.
+        archive_bytes = _build_archive({"0001652044": _aapl_payload()})
+        archive_path = tmp_path / "submissions.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_submissions_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+        )
+        ebull_test_conn.commit()
+
+        assert result.archive_entries_seen == 1
+        assert result.instruments_matched == 2
+        assert result.parse_errors == 0
+        # 2 filings × 2 siblings = 4 filings; 1 profile × 2 siblings = 2.
+        assert result.filings_upserted == 4
+        assert result.profiles_upserted == 2
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM filing_events WHERE instrument_id = %s AND provider = 'sec'",
+                (iid_goog,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 2, f"GOOG expected 2 filings, got {row[0]}"
+
+            cur.execute(
+                "SELECT COUNT(*) FROM filing_events WHERE instrument_id = %s AND provider = 'sec'",
+                (iid_googl,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 2, f"GOOGL expected 2 filings, got {row[0]}"
+
+            # Each sibling carries its own ticker on the filing_events
+            # row — Codex review BLOCKING for PR #1030 (the canonical
+            # symbol must NOT be a stringified instrument_id, and must
+            # NOT cross-contaminate between siblings).
+            cur.execute(
+                "SELECT raw_payload_json->>'symbol' FROM filing_events "
+                "WHERE instrument_id = %s LIMIT 1",
+                (iid_goog,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "GOOG", f"GOOG row carrying wrong symbol {row[0]!r}"
+
+            cur.execute(
+                "SELECT raw_payload_json->>'symbol' FROM filing_events "
+                "WHERE instrument_id = %s LIMIT 1",
+                (iid_googl,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "GOOGL", f"GOOGL row carrying wrong symbol {row[0]!r}"
+
+            cur.execute(
+                "SELECT COUNT(*) FROM instrument_sec_profile WHERE instrument_id IN (%s, %s)",
+                (iid_goog, iid_googl),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 2, f"expected 2 profiles, got {row[0]}"

--- a/tests/test_sec_submissions_ingest.py
+++ b/tests/test_sec_submissions_ingest.py
@@ -287,8 +287,7 @@ class TestIngestSubmissionsArchive:
             # symbol must NOT be a stringified instrument_id, and must
             # NOT cross-contaminate between siblings).
             cur.execute(
-                "SELECT raw_payload_json->>'symbol' FROM filing_events "
-                "WHERE instrument_id = %s LIMIT 1",
+                "SELECT raw_payload_json->>'symbol' FROM filing_events WHERE instrument_id = %s LIMIT 1",
                 (iid_goog,),
             )
             row = cur.fetchone()
@@ -296,8 +295,7 @@ class TestIngestSubmissionsArchive:
             assert row[0] == "GOOG", f"GOOG row carrying wrong symbol {row[0]!r}"
 
             cur.execute(
-                "SELECT raw_payload_json->>'symbol' FROM filing_events "
-                "WHERE instrument_id = %s LIMIT 1",
+                "SELECT raw_payload_json->>'symbol' FROM filing_events WHERE instrument_id = %s LIMIT 1",
                 (iid_googl,),
             )
             row = cur.fetchone()


### PR DESCRIPTION
## Summary
- PR-B for #1102. Bulk ingesters that resolved CIK→instrument_id collapsed share-class siblings; multimap shape + sql/144 schema relaxation + per-filing parser fan-out + read-side bridges close the loop.
- All three bulk ingesters fan out (companyfacts, insider dataset, submissions). filing_events relaxed to per-(provider, accession, instrument). DEF 14A + Form 4 + Form 3 per-filing parsers fan out at observation/holdings layer. eight_k_filings + insider_filings stay PK=accession (entity-level — child FKs anchor on accession alone); reads route via filing_events bridge.

## Why
Pre-#1102 only one share-class sibling held the CIK row, so dict-collapse never bit. Post-#1102 PR-A both siblings hold CIK rows but bulk ingesters dropped one silently. This PR closes the per-instrument visibility gap end-to-end so GOOG and GOOGL (and BRK.A/BRK.B) each render their own filings + insider observations + def14a holdings + 8-K events.

Spec: [docs/superpowers/specs/2026-05-10-1117-filings-fanout-complete.md](docs/superpowers/specs/2026-05-10-1117-filings-fanout-complete.md) (v2 post-Codex round 2).

Skill update: data-engineer skill §0.0 before-spec gate + §11 integrity reference matrix + §12 canonical patterns. Operator-locked: skills must own integrity (FK/UNIQUE/PK/CHECK shapes + canonical-pick patterns + migration shape-check), not just inventory.

## Test plan
- [x] Bulk fan-out tests pass: companyfacts, insider dataset, submissions all assert both GOOG + GOOGL receive rows
- [x] Lint + format + pyright all clean
- [x] Codex pre-push review: one P2 found and fixed (8-K capability anchors on `eight_k_filings`)
- [ ] DOD clauses 8-12: smoke against AAPL / GOOG / GOOGL / BRK.A / BRK.B on dev DB after `POST /jobs/sec_rebuild/run` for sec_submissions + sec_form4 + sec_def14a + sec_8k
- [ ] Cross-source verify GOOGL filing date or insider holder count against gurufocus / SEC EDGAR direct
- [ ] Operator-visible: `/instruments/GOOG/ownership-rollup` AND `/instruments/GOOGL/ownership-rollup` both render with non-NULL totals + insider slice + def14a slice
- [ ] Add fan-out tests for DEF 14A + Form 4 + Form 3 + 8-K read bridge (follow-up commits on this PR)

Closes #1117
Refs #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)