### PR TITLE
fix(#1114): bootstrap-cancel contextvar carries run_id+stage_key

### DIFF
--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -46,7 +46,10 @@ from app.providers.implementations.sec_submissions import (
 )
 from app.services.bootstrap_state import BootstrapStageCancelled
 from app.services.data_freshness import seed_scheduler_from_manifest
-from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+from app.services.processes.bootstrap_cancel_signal import (
+    active_bootstrap_stage_key,
+    bootstrap_cancel_requested,
+)
 from app.services.sec_manifest import is_amendment_form, map_form_to_source, record_manifest_entry
 
 logger = logging.getLogger(__name__)
@@ -302,9 +305,10 @@ def run_first_install_drain(
     _CANCEL_POLL_EVERY_N = 50
     for n, (subject, cik) in enumerate(_iter_in_universe_subjects(conn)):  # type: ignore[misc]
         if n % _CANCEL_POLL_EVERY_N == 0 and bootstrap_cancel_requested():
+            # #1114: stage_key sourced from contextvar.
             raise BootstrapStageCancelled(
                 f"first-install drain cancelled by operator after {ciks_processed} CIKs",
-                stage_key="sec_first_install_drain",
+                stage_key=active_bootstrap_stage_key() or "",
             )
         if max_subjects is not None and ciks_processed >= max_subjects:
             break

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -456,7 +456,7 @@ def _run_one_stage(
     from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
 
     try:
-        with JobLock(database_url, job_name), active_bootstrap_run(run_id):
+        with JobLock(database_url, job_name), active_bootstrap_run(run_id, stage_key):
             snap_token = _params_snapshot_var.set(effective_params)
             try:
                 invoker(effective_params)

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -271,18 +271,27 @@ def refresh_filings(
     # operator manual-trigger path is unaffected — this same
     # ``refresh_filings`` body powers many non-bootstrap flows.
     from app.services.bootstrap_state import BootstrapStageCancelled
-    from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+    from app.services.processes.bootstrap_cancel_signal import (
+        active_bootstrap_stage_key,
+        bootstrap_cancel_requested,
+    )
 
     _cancel_poll_every_n = 50
     iter_index = 0
 
     for instrument_id, identifier_value in resolved.items():
         if iter_index % _cancel_poll_every_n == 0 and bootstrap_cancel_requested():
+            # #1114: read stage_key from contextvar so a future stage
+            # that invokes refresh_filings doesn't misattribute the
+            # cancel to filings_history_seed. The orchestrator's
+            # _run_one_stage uses its OWN local stage_key when writing
+            # the cancelled row, but the exception's stage_key is the
+            # audit-log breadcrumb that names which stage observed it.
             raise BootstrapStageCancelled(
                 f"refresh_filings cancelled by operator after "
                 f"{iter_index}/{len(resolved)} instruments "
                 f"(provider={provider_name}, identifier={identifier_type})",
-                stage_key="filings_history_seed",
+                stage_key=active_bootstrap_stage_key() or "",
             )
         iter_index += 1
         try:

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -966,7 +966,10 @@ def ingest_all_active_filers(
     # Outside a bootstrap dispatch the contextvar is unset and the
     # helper short-circuits to False, so the standalone weekly sweep
     # and operator manual-trigger paths are unaffected.
-    from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+    from app.services.processes.bootstrap_cancel_signal import (
+        active_bootstrap_stage_key,
+        bootstrap_cancel_requested,
+    )
 
     try:
         for cik in ciks:
@@ -1082,9 +1085,10 @@ def ingest_all_active_filers(
         # contextvar guard means we never enter this branch.
         from app.services.bootstrap_state import BootstrapStageCancelled
 
+        # #1114: stage_key sourced from contextvar.
         raise BootstrapStageCancelled(
             f"13F quarterly sweep cancelled by operator after {filers_attempted}/{len(ciks)} filers",
-            stage_key="sec_13f_quarterly_sweep",
+            stage_key=active_bootstrap_stage_key() or "",
         )
 
     return summaries

--- a/app/services/processes/bootstrap_cancel_signal.py
+++ b/app/services/processes/bootstrap_cancel_signal.py
@@ -12,19 +12,29 @@ This module exposes the signal to long-running stages so they can
 poll periodically and bail out cooperatively. The pattern:
 
     from app.services.processes.bootstrap_cancel_signal import (
+        active_bootstrap_stage_key,
         bootstrap_cancel_requested,
     )
     from app.services.bootstrap_state import BootstrapStageCancelled
 
     for n, item in enumerate(big_iterable):
         if n % 50 == 0 and bootstrap_cancel_requested():
-            raise BootstrapStageCancelled(stage_key="sec_first_install_drain")
+            raise BootstrapStageCancelled(
+                stage_key=active_bootstrap_stage_key() or "",
+            )
         ...
 
-The bootstrap orchestrator's ``_run_one_stage`` sets the run id on
-this module's ContextVar around the invoker call; outside of a
-bootstrap dispatch the helper returns False (the contextvar is unset)
-so scheduled / manual triggers of the same job are unaffected.
+The bootstrap orchestrator's ``_run_one_stage`` sets the run id and
+the dispatching stage_key on this module's ContextVar around the
+invoker call; outside of a bootstrap dispatch the helpers return
+``False`` / ``None`` so scheduled / manual triggers of the same job
+are unaffected.
+
+Issue #1114: the contextvar carries both ``run_id`` AND ``stage_key``
+so adopters never hardcode the stage_key. If a future bootstrap
+stage invokes a helper that previously hardcoded its stage_key, the
+exception's ``stage_key`` attribute would otherwise misattribute the
+cancel to the wrong stage in the audit log.
 
 Polling cost: one SQL probe per call. Stage invokers should batch the
 polling (e.g. every 50 iterations) rather than calling on every loop
@@ -38,6 +48,7 @@ import contextlib
 import contextvars
 import logging
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Any
 
 import psycopg
@@ -48,29 +59,68 @@ from app.services.process_stop import is_stop_requested
 logger = logging.getLogger(__name__)
 
 
-# When set, identifies the in-flight bootstrap run that the calling
-# stage invoker is part of. Outside of bootstrap dispatch the value is
-# ``None`` and ``bootstrap_cancel_requested`` short-circuits to False.
-_active_bootstrap_run_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
-    "_active_bootstrap_run_id", default=None
+@dataclass(frozen=True)
+class _BootstrapContext:
+    """Identifies the in-flight bootstrap run + dispatching stage.
+
+    Set by the orchestrator's ``_run_one_stage`` boundary so any
+    long-running invoker called from that stage can read both the
+    run_id (to probe for a cancel signal) and the stage_key (to
+    label the ``BootstrapStageCancelled`` exception with the
+    dispatching stage's name).
+    """
+
+    run_id: int
+    stage_key: str
+
+
+# When set, identifies the in-flight bootstrap run + dispatching
+# stage_key. Outside of bootstrap dispatch the value is ``None`` and
+# ``bootstrap_cancel_requested`` short-circuits to False.
+_active_bootstrap_context: contextvars.ContextVar[_BootstrapContext | None] = contextvars.ContextVar(
+    "_active_bootstrap_context", default=None
 )
 
 
 @contextlib.contextmanager
-def active_bootstrap_run(run_id: int) -> Iterator[None]:
-    """Context manager that exposes ``run_id`` to stage invokers.
+def active_bootstrap_run(run_id: int, stage_key: str) -> Iterator[None]:
+    """Context manager that exposes ``(run_id, stage_key)`` to stage invokers.
 
     The bootstrap orchestrator's ``_run_one_stage`` wraps the invoker
-    call in ``with active_bootstrap_run(run_id): invoker(...)`` so any
-    long-running loop inside the invoker can poll
-    ``bootstrap_cancel_requested()`` to check whether the operator
-    has cancelled the run.
+    call in ``with active_bootstrap_run(run_id, stage_key): invoker(...)``
+    so any long-running loop inside the invoker can poll
+    ``bootstrap_cancel_requested()`` to check whether the operator has
+    cancelled the run AND read ``active_bootstrap_stage_key()`` to
+    label the cancel exception with the dispatching stage.
+
+    Issue #1114: stage_key is now required (was implicit in caller
+    hardcoding). The orchestrator always knows its own stage_key at
+    the dispatch boundary; helpers should never hardcode it because
+    the same helper may be invoked from multiple stages in future.
     """
-    token = _active_bootstrap_run_id.set(run_id)
+    token = _active_bootstrap_context.set(_BootstrapContext(run_id=run_id, stage_key=stage_key))
     try:
         yield
     finally:
-        _active_bootstrap_run_id.reset(token)
+        _active_bootstrap_context.reset(token)
+
+
+def active_bootstrap_stage_key() -> str | None:
+    """Return the stage_key of the in-flight bootstrap stage, or None.
+
+    Issue #1114. Long-running helpers that raise
+    ``BootstrapStageCancelled`` read this to label the exception
+    with the dispatching stage's name instead of hardcoding their
+    own. Outside ``active_bootstrap_run`` the contextvar is unset
+    and this returns ``None``; callers should treat ``None`` as
+    "stage_key unknown" and pass an empty string to the exception
+    so audit log readers see a clear sentinel rather than a wrong
+    value.
+    """
+    ctx = _active_bootstrap_context.get()
+    if ctx is None:
+        return None
+    return ctx.stage_key
 
 
 def bootstrap_cancel_requested(
@@ -79,7 +129,7 @@ def bootstrap_cancel_requested(
 ) -> bool:
     """Return True iff the active bootstrap run has been cancelled.
 
-    Reads the ``_active_bootstrap_run_id`` contextvar; if unset (the
+    Reads the ``_active_bootstrap_context`` contextvar; if unset (the
     invoker is being called from a scheduled trigger, manual API
     POST, or test fixture rather than the bootstrap dispatcher),
     returns False without touching the DB. When set, opens a
@@ -96,9 +146,10 @@ def bootstrap_cancel_requested(
     observation falls back to the orchestrator's between-stage
     checkpoint at the next stage boundary.
     """
-    run_id = _active_bootstrap_run_id.get()
-    if run_id is None:
+    ctx = _active_bootstrap_context.get()
+    if ctx is None:
         return False
+    run_id = ctx.run_id
 
     try:
         if conn is not None:
@@ -131,5 +182,6 @@ def bootstrap_cancel_requested(
 
 __all__ = [
     "active_bootstrap_run",
+    "active_bootstrap_stage_key",
     "bootstrap_cancel_requested",
 ]

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -304,7 +304,10 @@ def sec_13f_ingest_from_dataset_job() -> None:
     # boundary; raising on observed cancel preserves whatever ran
     # before the signal landed.
     from app.services.bootstrap_state import BootstrapStageCancelled
-    from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+    from app.services.processes.bootstrap_cancel_signal import (
+        active_bootstrap_stage_key,
+        bootstrap_cancel_requested,
+    )
 
     failed_archives: list[str] = []
     total_written = 0
@@ -313,9 +316,10 @@ def sec_13f_ingest_from_dataset_job() -> None:
     touched_ids: set[int] = set()
     for archive in archives:
         if bootstrap_cancel_requested():
+            # #1114: stage_key sourced from contextvar.
             raise BootstrapStageCancelled(
                 f"sec_13f_ingest_from_dataset cancelled by operator after {len(succeeded)}/{len(archives)} archives",
-                stage_key="sec_13f_ingest_from_dataset",
+                stage_key=active_bootstrap_stage_key() or "",
             )
         with psycopg.connect(settings.database_url) as conn:
             try:
@@ -374,9 +378,10 @@ def sec_13f_ingest_from_dataset_job() -> None:
         # stage finish + delete archives + return success while the
         # dispatcher waits for the next stage boundary.
         if bootstrap_cancel_requested():
+            # #1114: stage_key sourced from contextvar.
             raise BootstrapStageCancelled(
                 f"sec_13f_ingest_from_dataset cancelled by operator before refresh of {len(touched_ids)} instruments",
-                stage_key="sec_13f_ingest_from_dataset",
+                stage_key=active_bootstrap_stage_key() or "",
             )
 
         from app.services.ownership_observations import refresh_institutions_current
@@ -385,10 +390,11 @@ def sec_13f_ingest_from_dataset_job() -> None:
         with psycopg.connect(settings.database_url) as conn:
             for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
                 if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
+                    # #1114: stage_key sourced from contextvar.
                     raise BootstrapStageCancelled(
                         f"sec_13f_ingest_from_dataset cancelled by operator after "
                         f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
-                        stage_key="sec_13f_ingest_from_dataset",
+                        stage_key=active_bootstrap_stage_key() or "",
                     )
                 # Per-iteration savepoint — refresh_institutions_current
                 # owns its own ``with conn.transaction()`` (sql/.py:404),
@@ -463,7 +469,10 @@ def sec_insider_ingest_from_dataset_job() -> None:
     # PR3d #1064 follow-up — see sec_13f_ingest_from_dataset_job for
     # the cancel-poll rationale; same pattern applies per-archive.
     from app.services.bootstrap_state import BootstrapStageCancelled
-    from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+    from app.services.processes.bootstrap_cancel_signal import (
+        active_bootstrap_stage_key,
+        bootstrap_cancel_requested,
+    )
 
     failed_archives: list[str] = []
     total_written = 0
@@ -471,10 +480,11 @@ def sec_insider_ingest_from_dataset_job() -> None:
     touched_ids: set[int] = set()
     for archive in archives:
         if bootstrap_cancel_requested():
+            # #1114: stage_key sourced from contextvar.
             raise BootstrapStageCancelled(
                 f"sec_insider_ingest_from_dataset cancelled by operator after "
                 f"{len(succeeded)}/{len(archives)} archives",
-                stage_key="sec_insider_ingest_from_dataset",
+                stage_key=active_bootstrap_stage_key() or "",
             )
         with psycopg.connect(settings.database_url) as conn:
             try:
@@ -522,10 +532,11 @@ def sec_insider_ingest_from_dataset_job() -> None:
     if touched_ids:
         # Codex round 1 — cancel poll before + during refresh loop.
         if bootstrap_cancel_requested():
+            # #1114: stage_key sourced from contextvar.
             raise BootstrapStageCancelled(
                 f"sec_insider_ingest_from_dataset cancelled by operator before "
                 f"refresh of {len(touched_ids)} instruments",
-                stage_key="sec_insider_ingest_from_dataset",
+                stage_key=active_bootstrap_stage_key() or "",
             )
 
         from app.services.ownership_observations import refresh_insiders_current
@@ -534,10 +545,11 @@ def sec_insider_ingest_from_dataset_job() -> None:
         with psycopg.connect(settings.database_url) as conn:
             for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
                 if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
+                    # #1114: stage_key sourced from contextvar.
                     raise BootstrapStageCancelled(
                         f"sec_insider_ingest_from_dataset cancelled by operator after "
                         f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
-                        stage_key="sec_insider_ingest_from_dataset",
+                        stage_key=active_bootstrap_stage_key() or "",
                     )
                 try:
                     with conn.transaction():
@@ -606,7 +618,10 @@ def sec_nport_ingest_from_dataset_job() -> None:
     # PR3d #1064 follow-up — see sec_13f_ingest_from_dataset_job for
     # the cancel-poll rationale; same pattern applies per-archive.
     from app.services.bootstrap_state import BootstrapStageCancelled
-    from app.services.processes.bootstrap_cancel_signal import bootstrap_cancel_requested
+    from app.services.processes.bootstrap_cancel_signal import (
+        active_bootstrap_stage_key,
+        bootstrap_cancel_requested,
+    )
 
     failed_archives: list[str] = []
     total_written = 0
@@ -614,9 +629,10 @@ def sec_nport_ingest_from_dataset_job() -> None:
     touched_ids: set[int] = set()
     for archive in archives:
         if bootstrap_cancel_requested():
+            # #1114: stage_key sourced from contextvar.
             raise BootstrapStageCancelled(
                 f"sec_nport_ingest_from_dataset cancelled by operator after {len(succeeded)}/{len(archives)} archives",
-                stage_key="sec_nport_ingest_from_dataset",
+                stage_key=active_bootstrap_stage_key() or "",
             )
         with psycopg.connect(settings.database_url) as conn:
             try:
@@ -668,9 +684,10 @@ def sec_nport_ingest_from_dataset_job() -> None:
     if touched_ids:
         # Codex round 1 — cancel poll before + during refresh loop.
         if bootstrap_cancel_requested():
+            # #1114: stage_key sourced from contextvar.
             raise BootstrapStageCancelled(
                 f"sec_nport_ingest_from_dataset cancelled by operator before refresh of {len(touched_ids)} instruments",
-                stage_key="sec_nport_ingest_from_dataset",
+                stage_key=active_bootstrap_stage_key() or "",
             )
 
         from app.services.ownership_observations import refresh_funds_current
@@ -679,10 +696,11 @@ def sec_nport_ingest_from_dataset_job() -> None:
         with psycopg.connect(settings.database_url) as conn:
             for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
                 if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
+                    # #1114: stage_key sourced from contextvar.
                     raise BootstrapStageCancelled(
                         f"sec_nport_ingest_from_dataset cancelled by operator after "
                         f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
-                        stage_key="sec_nport_ingest_from_dataset",
+                        stage_key=active_bootstrap_stage_key() or "",
                     )
                 try:
                     with conn.transaction():

--- a/tests/test_bootstrap_cancel_signal.py
+++ b/tests/test_bootstrap_cancel_signal.py
@@ -19,6 +19,7 @@ from app.services.bootstrap_state import (
 )
 from app.services.processes.bootstrap_cancel_signal import (
     active_bootstrap_run,
+    active_bootstrap_stage_key,
     bootstrap_cancel_requested,
 )
 
@@ -52,6 +53,21 @@ def test_returns_false_when_contextvar_unset() -> None:
     assert bootstrap_cancel_requested() is False
 
 
+def test_active_bootstrap_stage_key_returns_none_when_unset() -> None:
+    """#1114: outside ``active_bootstrap_run`` the reader returns None."""
+    assert active_bootstrap_stage_key() is None
+
+
+def test_active_bootstrap_stage_key_returns_stage_key_when_set() -> None:
+    """#1114: under ``active_bootstrap_run(run_id, stage_key)`` the
+    reader returns the stage_key so adopters can label their
+    ``BootstrapStageCancelled`` exceptions without hardcoding."""
+    with active_bootstrap_run(99, "filings_history_seed"):
+        assert active_bootstrap_stage_key() == "filings_history_seed"
+    # Reset on exit.
+    assert active_bootstrap_stage_key() is None
+
+
 def test_returns_false_when_no_cancel_pending(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
@@ -60,7 +76,7 @@ def test_returns_false_when_no_cancel_pending(
     run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
     ebull_test_conn.commit()
 
-    with active_bootstrap_run(run_id):
+    with active_bootstrap_run(run_id, "alpha"):
         assert bootstrap_cancel_requested(conn=ebull_test_conn) is False
 
 
@@ -75,7 +91,7 @@ def test_returns_true_after_cancel_run(
     cancel_run(ebull_test_conn, requested_by_operator_id=None)
     ebull_test_conn.commit()
 
-    with active_bootstrap_run(run_id):
+    with active_bootstrap_run(run_id, "alpha"):
         assert bootstrap_cancel_requested(conn=ebull_test_conn) is True
 
 
@@ -91,7 +107,7 @@ def test_contextvar_resets_on_exit(
     cancel_run(ebull_test_conn, requested_by_operator_id=None)
     ebull_test_conn.commit()
 
-    with active_bootstrap_run(run_id):
+    with active_bootstrap_run(run_id, "alpha"):
         assert bootstrap_cancel_requested(conn=ebull_test_conn) is True
     # Outside the with-block: contextvar reset, helper returns False.
     assert bootstrap_cancel_requested(conn=ebull_test_conn) is False

--- a/tests/test_filings_cancel_signal.py
+++ b/tests/test_filings_cancel_signal.py
@@ -139,7 +139,7 @@ def test_refresh_filings_observes_bootstrap_cancel_signal(
 
     provider = _StubFilingsProvider({"0001064201": [], "0001064202": []})
 
-    with active_bootstrap_run(run_id):
+    with active_bootstrap_run(run_id, "filings_history_seed"):
         with pytest.raises(BootstrapStageCancelled) as exc_info:
             refresh_filings(
                 provider=provider,  # type: ignore[arg-type]
@@ -150,6 +150,9 @@ def test_refresh_filings_observes_bootstrap_cancel_signal(
             )
 
     assert "cancelled by operator" in str(exc_info.value)
+    # #1114: stage_key on the exception is read from the contextvar,
+    # not hardcoded inside refresh_filings.
+    assert exc_info.value.stage_key == "filings_history_seed"
     # Cancel observed on iteration 0 — provider untouched.
     assert provider.calls == []
 

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -927,7 +927,7 @@ class TestUniverseSweep:
             payloads.update(self._build_filer_payloads(cik=c, accession=f"{c}-25-000001", period="2024-12-31"))
         fetcher = _InMemoryFetcher(payloads)
 
-        with active_bootstrap_run(run_id):
+        with active_bootstrap_run(run_id, "sec_13f_quarterly_sweep"):
             with pytest.raises(BootstrapStageCancelled) as exc_info:
                 ingest_all_active_filers(
                     conn,
@@ -937,6 +937,8 @@ class TestUniverseSweep:
                 )
 
         assert "cancelled by operator" in str(exc_info.value)
+        # #1114: stage_key on exception read from contextvar, not hardcoded.
+        assert exc_info.value.stage_key == "sec_13f_quarterly_sweep"
 
         # Bookkeeping path ran before the raise: data_ingestion_runs
         # carries the partial state + cancel reason.
@@ -1027,7 +1029,7 @@ class TestUniverseSweep:
             payloads.update(self._build_filer_payloads(cik=c, accession=f"{c}-25-000001", period="2024-12-31"))
         fetcher = _InMemoryFetcher(payloads)
 
-        with active_bootstrap_run(run_id):
+        with active_bootstrap_run(run_id, "sec_13f_quarterly_sweep"):
             with pytest.raises(BootstrapStageCancelled):
                 ingest_all_active_filers(
                     conn,

--- a/tests/test_sec_bulk_cancel_signal.py
+++ b/tests/test_sec_bulk_cancel_signal.py
@@ -81,12 +81,18 @@ def test_cancel_signal_aborts_before_first_archive(
 
     job = getattr(jobs, job_name)
 
+    # #1114: under bootstrap dispatch the contextvar carries (run_id,
+    # stage_key) so adopters read stage_key from it. Mirror that here so
+    # the asserted exc.stage_key reflects the new contract.
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
     with (
         patch.object(jobs, "_bulk_dir", return_value=bulk_dir),
         patch.object(jobs, "_current_running_bootstrap_run_id", return_value=None),
         patch.object(jobs, "ingest_13f_dataset_archive", side_effect=_record),
         patch.object(jobs, "ingest_insider_dataset_archive", side_effect=_record),
         patch.object(jobs, "ingest_nport_dataset_archive", side_effect=_record),
+        active_bootstrap_run(99, stage_key),
     ):
         with pytest.raises(BootstrapStageCancelled) as exc_info:
             job()


### PR DESCRIPTION
## What

ContextVar in `bootstrap_cancel_signal.py` now carries a frozen `_BootstrapContext(run_id, stage_key)` instead of just `run_id`. The orchestrator's `_run_one_stage` sets both at the dispatch boundary; long-running invokers read the stage_key via the new `active_bootstrap_stage_key()` helper instead of hardcoding it on every `BootstrapStageCancelled` raise.

## Why

PR #1113 hardcoded `stage_key=\"filings_history_seed\"` inside `refresh_filings`. If a future bootstrap stage ever invokes `refresh_filings` under `active_bootstrap_run`, the cancel exception would misattribute the cancel to the wrong stage in the audit log. Issue #1114 chose Option 1 (extend the contextvar) over Option 2 (kwarg per call site) because the helper signature stays clean.

## Test plan

- [x] `tests/test_bootstrap_cancel_signal.py` — new `active_bootstrap_stage_key()` reader tests.
- [x] `tests/test_filings_cancel_signal.py` — pins `exc.stage_key == \"filings_history_seed\"`.
- [x] `tests/test_sec_bulk_cancel_signal.py` — wraps job invocations in `active_bootstrap_run(99, stage_key)` so contextvar is set under the monkeypatched cancel-true path.
- [x] `tests/test_institutional_holdings_ingester.py` — pins `exc.stage_key == \"sec_13f_quarterly_sweep\"`.
- [x] Codex pre-push review: no findings.
- [x] Lint + format + pyright + impacted-tests all green.

Closes #1114
Refs #1064