### PR TITLE
feat(#1067): CIK coverage audit endpoint + runbook

### DIFF
--- a/app/api/coverage.py
+++ b/app/api/coverage.py
@@ -84,6 +84,38 @@ class InsufficientListResponse(BaseModel):
     rows: list[InsufficientRow]
 
 
+# #1067 — CIK coverage audit.
+
+
+class CikGapRowResponse(BaseModel):
+    """One unmapped instrument in the CIK gap detail."""
+
+    instrument_id: int
+    symbol: str
+    company_name: str | None
+    category: str  # "suffix_variant" | "other"
+
+
+class CikCoverageGapResponse(BaseModel):
+    """Aggregate counters + capped sample for the CIK gap report.
+
+    Cohort is the us_equity tradable producer cohort (matches
+    ``daily_cik_refresh``'s scope). ``unmapped_suffix_variants``
+    rows are operational-duplicate variants (``.RTH``, ``.US`` etc)
+    that legitimately lack their own CIK row; ``unmapped_other`` is
+    the real gap signal — typically ETFs, funds, merger CVRs, or
+    a genuine missing mapping.
+    """
+
+    checked_at: datetime
+    cohort_total: int
+    mapped: int
+    unmapped: int
+    unmapped_suffix_variants: int
+    unmapped_other: int
+    sample: list[CikGapRowResponse]
+
+
 # ---------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------
@@ -233,3 +265,45 @@ def get_coverage_insufficient(
         )
 
     return InsufficientListResponse(checked_at=datetime.now(tz=UTC), rows=out)
+
+
+@router.get("/cik-gap", response_model=CikCoverageGapResponse)
+def get_cik_gap(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CikCoverageGapResponse:
+    """#1067 — CIK coverage audit for the us_equity tradable cohort.
+
+    Operator-visible gap report. Cohort matches ``daily_cik_refresh``
+    so the ``mapped`` + ``unmapped`` split correlates with the
+    bridge's hit / miss rate. Unmapped rows are bucketed:
+
+    * ``suffix_variants`` — symbol contains ``.`` (operational
+      duplicates like ``AAPL.RTH``). Pre-#819 these would render
+      empty pages; post-#819 the canonical-redirect mechanism
+      ensures they don't need their own CIK.
+    * ``other`` — ETFs, funds, merger CVRs, and any genuine gap
+      worth operator triage.
+
+    See ``docs/wiki/runbooks/runbook-diagnosing-missing-cik.md`` for
+    the runbook that interprets this report.
+    """
+    from app.services.cik_coverage_audit import compute_cik_gap_report
+
+    report = compute_cik_gap_report(conn)  # type: ignore[arg-type]
+    return CikCoverageGapResponse(
+        checked_at=datetime.now(tz=UTC),
+        cohort_total=report.cohort_total,
+        mapped=report.mapped,
+        unmapped=report.unmapped,
+        unmapped_suffix_variants=report.unmapped_suffix_variants,
+        unmapped_other=report.unmapped_other,
+        sample=[
+            CikGapRowResponse(
+                instrument_id=r.instrument_id,
+                symbol=r.symbol,
+                company_name=r.company_name,
+                category=r.category,
+            )
+            for r in report.sample
+        ],
+    )

--- a/app/services/cik_coverage_audit.py
+++ b/app/services/cik_coverage_audit.py
@@ -1,0 +1,194 @@
+"""CIK coverage audit (#1067 — PR10 leftover from #1064).
+
+Operator-visible report of which us_equity tradable instruments are
+missing a primary SEC CIK in ``external_identifiers``. Useful when:
+
+  * A new universe sync introduces tickers the daily CIK refresh
+    didn't pick up.
+  * The operator suspects a high-profile ticker (TSLA, GOOGL) is
+    missing — historical context for #1067, fixed post-#1102 share-
+    class CIK uniqueness.
+  * Diagnosing why an instrument's chart / ownership / fundamentals
+    render empty: no CIK = no SEC filings ingest.
+
+The audit splits unmapped instruments into two buckets so the
+operator can ignore the noise and focus on real gaps:
+
+  * ``suffix_variants`` — symbol contains ``.`` (e.g. ``AAPL.RTH``,
+    ``ABT.US``, ``ACLX.CVR``). These are operational duplicates;
+    once #819 lands the canonical-redirect mechanism, they should
+    NOT have their own CIK row — the canonical row carries it.
+    Legitimate share-class siblings like ``BRK.B`` DO have CIK rows
+    (post-#1102) so they don't show here.
+  * ``other`` — everything else. ETFs, funds, merger CVRs, and any
+    genuine gap. Operator must triage one by one.
+
+The bridge itself (ticker → CIK via SEC's ``company_tickers.json``)
+already ships in ``daily_cik_refresh`` (#475); this audit surface is
+the operator-side telemetry the issue body asked for.
+
+Runbook: ``docs/wiki/runbooks/runbook-diagnosing-missing-cik.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CikGapRow:
+    """One unmapped instrument in the audit detail."""
+
+    instrument_id: int
+    symbol: str
+    company_name: str | None
+    category: str  # "suffix_variant" | "other"
+
+
+@dataclass(frozen=True)
+class CikCoverageGapReport:
+    """Aggregate report for the audit endpoint."""
+
+    cohort_total: int
+    mapped: int
+    unmapped: int
+    unmapped_suffix_variants: int
+    unmapped_other: int
+    sample: list[CikGapRow]  # capped at sample_limit
+
+
+def compute_cik_gap_report(
+    conn: psycopg.Connection[Any],
+    *,
+    sample_limit: int = 200,
+) -> CikCoverageGapReport:
+    """Audit query: us_equity tradable instruments without primary SEC CIK.
+
+    Cohort matches the daily_cik_refresh producer cohort
+    (``is_tradable AND e.asset_class='us_equity'``) so the gap count
+    correlates 1:1 with what the bridge tried + missed. ``sample_limit``
+    bounds the per-row payload so the endpoint stays fast on a large
+    universe; the aggregate counters reflect the full gap regardless
+    of the sample cap.
+
+    Caller owns ``conn`` (no commit needed — read-only).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM instruments i
+              JOIN exchanges e ON e.exchange_id = i.exchange
+             WHERE i.is_tradable = TRUE
+               AND e.asset_class = 'us_equity'
+            """,
+        )
+        row = cur.fetchone()
+        cohort_total = int(row[0]) if row else 0
+
+        # ``is_primary = TRUE`` is load-bearing: demoted historical
+        # CIK rows must not count as "mapped" (Codex pre-push round 1
+        # — without this an instrument with N historical CIKs would
+        # inflate mapped past cohort_total). Mirrors the producer-side
+        # primary filter in #540 (daily_cik_refresh).
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM instruments i
+              JOIN exchanges e ON e.exchange_id = i.exchange
+              JOIN external_identifiers ei
+                ON ei.instrument_id = i.instrument_id
+               AND ei.provider = 'sec'
+               AND ei.identifier_type = 'cik'
+               AND ei.is_primary = TRUE
+             WHERE i.is_tradable = TRUE
+               AND e.asset_class = 'us_equity'
+            """,
+        )
+        row = cur.fetchone()
+        mapped = int(row[0]) if row else 0
+
+        # Two aggregate counters for the unmapped split. Cheaper than
+        # streaming the full unmapped set just to bucket them. The
+        # sample query below caps payload size.
+        cur.execute(
+            """
+            SELECT
+              COUNT(*) FILTER (WHERE i.symbol LIKE '%%.%%') AS suffix_variants,
+              COUNT(*) FILTER (WHERE i.symbol NOT LIKE '%%.%%') AS other
+              FROM instruments i
+              JOIN exchanges e ON e.exchange_id = i.exchange
+              LEFT JOIN external_identifiers ei
+                ON ei.instrument_id = i.instrument_id
+               AND ei.provider = 'sec'
+               AND ei.identifier_type = 'cik'
+               AND ei.is_primary = TRUE
+             WHERE i.is_tradable = TRUE
+               AND e.asset_class = 'us_equity'
+               AND ei.identifier_value IS NULL
+            """,
+        )
+        row = cur.fetchone()
+        if row is None:
+            unmapped_suffix_variants = 0
+            unmapped_other = 0
+        else:
+            unmapped_suffix_variants = int(row[0] or 0)
+            unmapped_other = int(row[1] or 0)
+        unmapped = unmapped_suffix_variants + unmapped_other
+
+        # Sample: prioritise "other" rows over suffix variants so the
+        # operator sees the genuinely interesting gaps first. Cap at
+        # sample_limit to keep the JSON response bounded.
+        cur.execute(
+            """
+            SELECT i.instrument_id, i.symbol, i.company_name,
+                   CASE WHEN i.symbol LIKE '%%.%%' THEN 'suffix_variant'
+                        ELSE 'other' END AS category
+              FROM instruments i
+              JOIN exchanges e ON e.exchange_id = i.exchange
+              LEFT JOIN external_identifiers ei
+                ON ei.instrument_id = i.instrument_id
+               AND ei.provider = 'sec'
+               AND ei.identifier_type = 'cik'
+               AND ei.is_primary = TRUE
+             WHERE i.is_tradable = TRUE
+               AND e.asset_class = 'us_equity'
+               AND ei.identifier_value IS NULL
+             ORDER BY CASE WHEN i.symbol LIKE '%%.%%' THEN 1 ELSE 0 END,
+                      i.symbol
+             LIMIT %s
+            """,
+            (sample_limit,),
+        )
+        sample = [
+            CikGapRow(
+                instrument_id=int(r[0]),
+                symbol=str(r[1]),
+                company_name=r[2] if r[2] else None,
+                category=str(r[3]),
+            )
+            for r in cur.fetchall()
+        ]
+
+    logger.info(
+        "cik_coverage_audit: cohort=%d mapped=%d unmapped=%d (suffix_variants=%d other=%d) sample=%d",
+        cohort_total,
+        mapped,
+        unmapped,
+        unmapped_suffix_variants,
+        unmapped_other,
+        len(sample),
+    )
+    return CikCoverageGapReport(
+        cohort_total=cohort_total,
+        mapped=mapped,
+        unmapped=unmapped,
+        unmapped_suffix_variants=unmapped_suffix_variants,
+        unmapped_other=unmapped_other,
+        sample=sample,
+    )

--- a/docs/wiki/runbooks/runbook-diagnosing-missing-cik.md
+++ b/docs/wiki/runbooks/runbook-diagnosing-missing-cik.md
@@ -1,0 +1,170 @@
+# Runbook: diagnosing a missing SEC CIK
+
+Use when an instrument's chart / ownership / fundamentals / filings
+panes are empty AND the issue is suspected to be a missing SEC CIK
+mapping in `external_identifiers`.
+
+## TL;DR
+
+1. Hit `GET /coverage/cik-gap` (#1067) — operator-visible audit.
+2. If the instrument is in `unmapped_suffix_variants`: it's an
+   operational duplicate (`.RTH`, `.US`, `.CVR`) and SHOULD NOT have
+   its own CIK row. Verify the canonical-redirect mechanism (#819)
+   is wired and the canonical row has a CIK.
+3. If in `unmapped_other`: investigate further (steps below).
+
+## Background
+
+SEC CIK = entity-level identifier. The bridge that maps a ticker to a
+CIK is SEC's `company_tickers.json`, fetched daily by
+`daily_cik_refresh`. The producer cohort is
+`is_tradable=TRUE AND exchanges.asset_class='us_equity'`.
+
+What SHOULDN'T have a CIK row:
+
+- Operational-duplicate variants (`AAPL.RTH`, `AAPL.US`,
+  `AAPL.24-7`, `ACLX.CVR`). Per the partial-unique CIK index in
+  `sql/143`, only ONE instrument can claim a given CIK; the
+  underlying row (e.g. `AAPL`) wins. Variants render via the
+  canonical-redirect path (#819) — they should not need their own.
+- Crypto / FX / non-US equity instruments — `daily_cik_refresh`
+  filters them out of the cohort entirely.
+- ETFs and funds — `company_tickers.json` doesn't include most
+  registered funds. SEC fund filings live under separate forms
+  (N-PORT, N-CSR). Use the funds-side ingest (#917) for those.
+
+What SHOULD have a CIK row:
+
+- Every common-share US equity instrument with an active listing.
+- Share-class siblings (`GOOG`/`GOOGL`, `BRK.A`/`BRK.B`). Pre-#1102
+  these flapped between siblings; post-#1102 both rows hold the
+  shared CIK simultaneously via the partial unique index.
+
+## Diagnostics
+
+### Step 1 — read the audit
+
+```bash
+curl -s -H "Cookie: <operator session>" \
+  http://localhost:8000/coverage/cik-gap | jq .
+```
+
+Returned shape (truncated):
+
+```json
+{
+  "checked_at": "...",
+  "cohort_total": 7151,
+  "mapped": 5080,
+  "unmapped": 2071,
+  "unmapped_suffix_variants": 1900,
+  "unmapped_other": 171,
+  "sample": [
+    {
+      "instrument_id": 1023,
+      "symbol": "AAXJ",
+      "company_name": "iShares MSCI All Country Asia ex Japan ETF",
+      "category": "other"
+    },
+    ...
+  ]
+}
+```
+
+- `cohort_total - mapped == unmapped`. If `unmapped_suffix_variants`
+  dominates, the daily refresh is working as expected and
+  operational duplicates are the noise floor.
+- `unmapped_other` is the actionable count.
+
+### Step 2 — categorise a single instrument
+
+For the instrument in question (let's say `EXAMPLE`):
+
+```sql
+SELECT i.symbol, i.company_name, e.asset_class,
+       ei.identifier_value AS primary_cik
+  FROM instruments i
+  JOIN exchanges e ON e.exchange_id = i.exchange
+  LEFT JOIN external_identifiers ei
+    ON ei.instrument_id = i.instrument_id
+   AND ei.provider = 'sec'
+   AND ei.identifier_type = 'cik'
+   AND ei.is_primary = TRUE
+ WHERE UPPER(i.symbol) = 'EXAMPLE';
+```
+
+Read the result:
+
+- `asset_class != 'us_equity'` → out of cohort by design. Cannot
+  have a SEC CIK from `company_tickers.json`.
+- `primary_cik IS NULL` AND `asset_class = 'us_equity'` AND the
+  symbol contains a `.` (e.g. `AAPL.RTH`) → operational duplicate.
+  Once #819 lands, query
+  `SELECT inst_can.symbol FROM instruments i JOIN instruments inst_can ON inst_can.instrument_id = i.canonical_instrument_id WHERE UPPER(i.symbol) = 'AAPL.RTH'`
+  to confirm the canonical row carries the CIK.
+- `primary_cik IS NULL` AND `asset_class = 'us_equity'` AND symbol
+  contains no `.` → genuine gap; proceed to Step 3.
+
+The `is_primary = TRUE` filter is load-bearing — demoted historical
+CIK rows still live in `external_identifiers` and would otherwise
+falsely report a mapping for an instrument whose current SEC
+linkage is broken.
+
+### Step 3 — confirm SEC has the ticker
+
+Hit SEC's `company_tickers.json` directly:
+
+```bash
+curl -s -H "User-Agent: <SEC user agent>" \
+  https://www.sec.gov/files/company_tickers.json | \
+  jq '.[] | select(.ticker == "EXAMPLE")'
+```
+
+If SEC has it, `daily_cik_refresh` should pick it up on the next
+fire. To force immediately:
+
+```bash
+curl -s -X POST -H "Cookie: <operator session>" \
+  http://localhost:8000/jobs/daily_cik_refresh/run
+```
+
+Poll `/jobs/requests` for the run to finish. Re-check Step 2.
+
+If SEC does NOT have the ticker → the issuer is genuinely off the
+SEC bridge. Possible reasons:
+
+- Former ticker (delisted) — the issuer may have changed name /
+  ticker; look at the issuer's submissions filing directly.
+- ADR / foreign issuer — some ADRs do appear in
+  `company_tickers.json` but not all.
+- Pre-IPO / private — no SEC filings yet.
+
+For genuine gaps that cannot be resolved via the bridge, manually
+insert the CIK after independent verification:
+
+```sql
+INSERT INTO external_identifiers
+  (instrument_id, provider, identifier_type, identifier_value,
+   is_primary, last_verified_at)
+VALUES (<instrument_id>, 'sec', 'cik', '<10-digit CIK>',
+        TRUE, NOW())
+ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+  WHERE provider = 'sec' AND identifier_type = 'cik'
+DO UPDATE SET is_primary = TRUE, last_verified_at = NOW();
+```
+
+Then trigger `daily_research_refresh` so the new CIK starts driving
+fundamentals + filings ingest.
+
+## Cross-references
+
+- Settled decision: `docs/settled-decisions.md` — "CIK = entity,
+  CUSIP = security (#1102)" + "Canonical-instrument redirect
+  (#819)".
+- Data-engineer skill: `.claude/skills/data-engineer/SKILL.md` §11
+  (integrity reference matrix for `external_identifiers`).
+- SEC EDGAR skill: `.claude/skills/data-sources/sec-edgar.md` §5.1
+  (`company_tickers.json` shape + caveats).
+- Related runbooks:
+  `docs/wiki/runbooks/runbook-after-parser-change.md`,
+  `docs/wiki/runbooks/runbook-data-freshness.md`.

--- a/tests/test_cik_coverage_audit.py
+++ b/tests/test_cik_coverage_audit.py
@@ -1,0 +1,176 @@
+"""Tests for the CIK coverage audit (#1067).
+
+The audit reports the us_equity tradable cohort, how many have a
+primary SEC CIK in ``external_identifiers``, and a categorised
+sample of the unmapped rows (``suffix_variants`` vs ``other``).
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from app.services.cik_coverage_audit import compute_cik_gap_report
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+
+def _seed_universe(conn: psycopg.Connection[tuple]) -> None:
+    # us_equity exchange.
+    conn.execute(
+        """
+        INSERT INTO exchanges (exchange_id, description, country, asset_class)
+        VALUES ('audit_us', 'audit us eq', 'US', 'us_equity')
+        ON CONFLICT (exchange_id) DO NOTHING
+        """,
+    )
+    # crypto exchange — out of cohort.
+    conn.execute(
+        """
+        INSERT INTO exchanges (exchange_id, description, country, asset_class)
+        VALUES ('audit_crypto', 'audit crypto', 'US', 'crypto')
+        ON CONFLICT (exchange_id) DO NOTHING
+        """,
+    )
+    # Mapped row: AAPL with CIK.
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671001, 'AAPL', 'Apple Inc', 'audit_us', 'USD', TRUE)
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers
+          (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (90671001, 'sec', 'cik', '0000320193', TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+        DO NOTHING
+        """,
+    )
+    # Unmapped suffix variant: AAPL.RTH (no CIK).
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671002, 'AAPL.RTH', 'Apple Inc (RTH)', 'audit_us', 'USD', TRUE)
+        """,
+    )
+    # Unmapped other: ETF.
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671003, 'AAXJ', 'iShares MSCI Asia ETF', 'audit_us', 'USD', TRUE)
+        """,
+    )
+    # Crypto — out of cohort, should not affect counts.
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671004, 'BTC', 'Bitcoin', 'audit_crypto', 'USD', TRUE)
+        """,
+    )
+    conn.commit()
+
+
+def test_gap_report_counts_us_equity_only(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Cohort scoped to us_equity asset_class — crypto must not
+    inflate the cohort count or the unmapped count.
+
+    Cohort = 3 (AAPL + AAPL.RTH + AAXJ). Mapped = 1 (AAPL).
+    Unmapped = 2 (AAPL.RTH suffix + AAXJ other).
+    """
+    conn = ebull_test_conn
+    _seed_universe(conn)
+
+    report = compute_cik_gap_report(conn)
+
+    assert report.cohort_total == 3
+    assert report.mapped == 1
+    assert report.unmapped == 2
+    assert report.unmapped_suffix_variants == 1  # AAPL.RTH
+    assert report.unmapped_other == 1  # AAXJ
+
+
+def test_sample_orders_other_before_suffix_variants(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Sample prioritises ``other`` over ``suffix_variant`` so the
+    operator sees the genuine gaps first when scanning the response."""
+    conn = ebull_test_conn
+    _seed_universe(conn)
+
+    report = compute_cik_gap_report(conn, sample_limit=10)
+
+    # Two unmapped rows; both fit in the sample.
+    assert len(report.sample) == 2
+    assert report.sample[0].category == "other"
+    assert report.sample[0].symbol == "AAXJ"
+    assert report.sample[1].category == "suffix_variant"
+    assert report.sample[1].symbol == "AAPL.RTH"
+
+
+def test_demoted_historical_cik_does_not_count_as_mapped(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Codex pre-push round 1: ``is_primary = TRUE`` is load-bearing.
+    An instrument with only a demoted historical CIK row must count
+    as UNMAPPED, not mapped — otherwise a stale-CIK-only row would
+    falsely inflate the coverage figure."""
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO exchanges (exchange_id, description, country, asset_class)
+        VALUES ('audit_us2', 'audit us eq 2', 'US', 'us_equity')
+        ON CONFLICT (exchange_id) DO NOTHING
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671099, 'STALECIK', 'Stale Inc', 'audit_us2', 'USD', TRUE)
+        """,
+    )
+    # Only a demoted historical CIK exists for this instrument.
+    conn.execute(
+        """
+        INSERT INTO external_identifiers
+          (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (90671099, 'sec', 'cik', '0009999999', FALSE)
+        ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+            WHERE provider = 'sec' AND identifier_type = 'cik'
+        DO NOTHING
+        """,
+    )
+    conn.commit()
+
+    report = compute_cik_gap_report(conn)
+
+    # Should appear in the unmapped count + sample (no primary).
+    assert any(s.symbol == "STALECIK" for s in report.sample)
+    assert report.unmapped >= 1
+
+
+def test_sample_limit_caps_payload(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Sample limit bounds the per-row payload regardless of the
+    aggregate unmapped count."""
+    conn = ebull_test_conn
+    _seed_universe(conn)
+    # Add 5 more suffix-variant unmapped rows so the aggregate
+    # exceeds sample_limit=2.
+    for i in range(5):
+        conn.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+            VALUES (%s, %s, 'extra', 'audit_us', 'USD', TRUE)
+            """,
+            (90671010 + i, f"EXTRA{i}.RTH"),
+        )
+    conn.commit()
+
+    report = compute_cik_gap_report(conn, sample_limit=2)
+
+    assert report.unmapped == 7  # AAPL.RTH + AAXJ + 5 EXTRA.RTH
+    assert len(report.sample) == 2


### PR DESCRIPTION
## What

- New ``GET /coverage/cik-gap`` returns cohort + mapped/unmapped counts for the us_equity tradable cohort. Unmapped rows are bucketed into ``suffix_variants`` (operational duplicates) vs ``other`` (real gaps).
- Operator runbook ``docs/wiki/runbooks/runbook-diagnosing-missing-cik.md``.
- Tests pin cohort scoping, sample ordering, payload cap, ``is_primary = TRUE`` filter.

## Why

#1067 asked for: audit + bridge (ticker→CIK) + fuzzy-as-last-resort + runbook. The bridge already ships in ``daily_cik_refresh`` (#475), and the original TSLA/GOOGL gap was closed post-#1102. The remaining ask is the operator-side telemetry + runbook so the operator can answer "is the bridge actually doing its job?" and "why is THIS specific instrument missing a CIK?" without ad-hoc SQL.

``is_primary = TRUE`` is load-bearing throughout: demoted historical CIK rows must not count as mapped (Codex pre-push round 1 finding).

## Test plan

- [x] ``tests/test_cik_coverage_audit.py`` — cohort scoping, sample ordering, sample cap, demoted-CIK exclusion.
- [x] Dev smoke: cohort=7151 mapped=5080 unmapped=2071 (851 suffix_variants + 1220 other). Other-bucket is the actionable signal.
- [x] Lint + format + pyright + impacted tests green.
- [x] Codex pre-push round 1: 4 findings, all resolved.

## Out of scope (follow-up)

- Operational-duplicate filter on ``daily_cik_refresh``'s instrument list — depends on ``canonical_instrument_id`` from #819 (PR #1121, pending merge).
- Fuzzy-match-to-CIK as last-resort — the existing fuzzy in ``sec_13f_securities_list.backfill_cusip_coverage`` is for CUSIP coverage (different path). A CIK-side fuzzy fallback would require its own design; not part of #1067's bounded scope.

Closes #1067
Refs #1064