### PR TITLE
docs(skills): parser registration rule + per-source retention horizon

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -909,3 +909,35 @@ Winner-priority order across categories: `source` priority (`form4 > form3 > 13d
 - `ON DELETE CASCADE` on `*_audit` / `*_log` (prev-log L350).
 - `SELECT DISTINCT` over a multi-column row when the dedup target is one column — use `DISTINCT ON (col)`.
 - `dict[cik, instrument_id]` for any CIK→instrument lookup post-#1102 — must be `dict[cik, list[instrument_id]]` (the multimap pattern from #1117). Single-result collapse drops share-class siblings silently.
+
+## 13. Per-source retention horizon
+
+eBull doesn't keep every historical filing forever. Each source has a backfill horizon (what bootstrap drains) and a steady-state cadence (how the scheduled job refreshes). Steady-state only fetches NEW accessions discovered via atom / daily-index / per-CIK poll — no re-fetch of in-horizon data unless explicit rewash.
+
+| Source | Backfill | Steady-state cadence | Storage budget per instrument |
+|---|---|---|---|
+| Form 4 / 3 / 5 | last 2 years | atom + daily-index | ~50-200 rows |
+| 13F-HR | last 4 quarters | quarterly bulk sweep | ~4 quarterly rollups |
+| N-PORT | last 4 quarters | monthly bulk + atom | ~4 quarterly rollups |
+| 13D / 13G | last 2 years | atom + daily-index | ~5-20 rows |
+| DEF 14A | last 2 years | atom + daily-index | ~1-2 proxy seasons |
+| 8-K | last 2 years | atom | ~30-100 events |
+| 10-K | last 3 annual | atom + daily-index | 3 filings |
+| 10-Q | last 8 quarterly | atom + daily-index | 8 filings |
+| FINRA short interest | last 2 years | bi-monthly per FINRA cadence | ~48 bi-monthly rows |
+| Form 144 | rolling 90 days (effective ≤ 90d post-filing) | atom | ephemeral |
+| SC 13E | last 2 years | atom + daily-index | rare event filings |
+
+### 13.A Backfill horizon enforcement
+
+The horizon is enforced at the **discovery layer**, not at the parser layer. Discovery sites (`check_freshness`, daily-index walker, per-CIK poll) filter by `filed_at >= cutoff` so older accessions never make it into the manifest. Once bootstrap completes, the steady-state poll's `last_known_filing_id` watermark naturally restricts to new accessions.
+
+**Rule:** when adding a new source, the discovery layer MUST apply the cutoff before writing to `sec_filing_manifest`. Filtering at the parser layer (i.e. discovery writes everything; parser drops old) is forbidden because it leaves dead manifest rows that the `/coverage/manifest-parsers` audit counts as `pending`.
+
+### 13.B Rewash retention exception
+
+A parser-version bump triggers re-parse of in-horizon raw bodies (`filing_raw_documents`). Out-of-horizon bodies are NOT retained; if a rewash needs older accessions, the operator runs targeted `sec_rebuild` with `discover=True` to re-fetch from SEC. This pattern is documented in [docs/settled-decisions.md](../../../docs/settled-decisions.md).
+
+### 13.C Adding a new source — derivable from this rule
+
+`(filing size per instrument) × (rows per instrument over the horizon)` must fit the storage budget for the universe (~12k tradable instruments). A source with 100k filings per instrument over 2 years would blow the budget — pick a shorter horizon or a coarser steady-state cadence. The horizon values in the table above are derived from this constraint; do not change them without re-computing the budget for that source.

--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -516,6 +516,46 @@ Where this knowledge already lives in code:
 | Raw-filing cache | [app/services/raw_filings.py](../../../app/services/raw_filings.py) |
 | Schedulers (conditional fetch) | [app/workers/scheduler.py:1460-1574](../../../app/workers/scheduler.py#L1460-L1574) |
 
+## 11. Manifest-worker parser onboarding
+
+### 11.1 Architecture rule
+
+Every SEC source has a registered parser in `app/services/manifest_parsers/<source>.py`. The package's `register_all_parsers()` runs at module-import time from both `app/main.py` and `app/jobs/__main__.py` so API + worker share the same registry view. If a source has no parser, the worker debug-skips its manifest rows and `GET /coverage/manifest-parsers` reports `has_registered_parser=False` for that source.
+
+Adding a new source is a five-step contract — anything beyond these is over-engineering:
+
+1. Add a `register()` call to `app/services/manifest_parsers/<source>.py`. The parser receives `(conn, ManifestRow)` and returns `ParseOutcome`.
+2. Add `from . import <source> as _<source>` to `app/services/manifest_parsers/__init__.py` and a `_<source>.register()` line in `register_all_parsers()`.
+3. Use `requires_raw_payload=True` for any payload-backed source (Form 4 XML, 13F infotable, 13D/G primary doc, DEF 14A HTML, NPORT-P XML, 10-K/Q/8-K HTML). The worker rejects parsed outcomes with `raw_status='absent'` for these.
+4. Wrap every DB write (`store_raw`, observation upsert, tombstone insert) in `conn.transaction()` so a partial failure doesn't leave the worker's outer tx aborted before `transition_status` fires.
+5. Failed outcomes from fetch/store/upsert errors set `next_retry_at = now + _backoff_for(0)` explicitly (the worker only computes backoff for parser-raised exceptions; returned `failed` outcomes pass through as-is).
+
+The legacy ingest job for the same source can run in parallel during cutover — parent UPSERTs are idempotent. The legacy job retires once the manifest path catches up.
+
+### 11.2 Per-source backfill horizon
+
+Bootstrap drains the horizon. Steady-state refresh fetches only new accessions discovered via atom / daily-index / per-CIK poll — no re-fetch of in-horizon data unless explicit rewash (§3.7).
+
+| Source | Backfill | Steady-state cadence |
+|---|---|---|
+| Form 4 / 3 / 5 | last 2 years | atom + daily-index |
+| 13F-HR | last 4 quarters | quarterly bulk sweep |
+| N-PORT | last 4 quarters | monthly bulk + atom |
+| 13D / 13G | last 2 years | atom + daily-index |
+| DEF 14A | last 2 years | atom + daily-index |
+| 8-K | last 2 years | atom |
+| 10-K | last 3 annual | atom + daily-index |
+| 10-Q | last 8 quarterly | atom + daily-index |
+| FINRA short interest | last 2 years | bi-monthly per FINRA cadence |
+| Form 144 | rolling 90 days (filing → effective ≤ 90d) | atom |
+| SC 13E | last 2 years | atom + daily-index |
+
+**Why per-source rather than uniform:** Form 4 has tens of millions of accessions in a 2-year window but is small per filing (~10 KB XML); the cost is well within bounds. 13F has fewer but heavier filings — limiting to 4 quarters keeps disk + parse cost bounded. Per-filing-size × per-source-cadence determines retention; arbitrary cutoffs cost storage without informing decisions.
+
+**Bootstrap drain implementation:** scheduler stages with `min_period_of_report` / `start_date` params per source. The horizon is enforced at the discovery layer (`check_freshness` + daily-index walker filter by `filed_at >= cutoff`) so older accessions never make it into the manifest. Once bootstrap completes, the steady-state poll's `last_known_filing_id` watermark naturally restricts to new accessions.
+
+**Rewash retention exception:** a parser-version bump triggers re-parse of in-horizon raw bodies. Out-of-horizon bodies are NOT retained; if the rewash needs older accessions, the operator runs a targeted `sec_rebuild` with `discover=True` to re-fetch.
+
 ## 10. Sources
 
 - SEC accessing-edgar-data: <https://www.sec.gov/search-filings/edgar-search-assistance/accessing-edgar-data>


### PR DESCRIPTION
## What

Two new skill sections derived from the #873 / #1117 work so future parser PRs template off documented rules, not the 8-K reference implementation.

- ``sec-edgar §11`` — manifest-worker parser onboarding (5-step contract + per-source backfill horizon table).
- ``data-engineer §13`` — per-source retention horizon enforcement at the discovery layer, with rewash exception + derivation rule.

## Why

Without the rule documented, each new parser PR re-derives the same five contract decisions (when to set ``requires_raw_payload``, when to wrap in ``conn.transaction()``, how failed outcomes get backoff, where the horizon is enforced). Codex pre-push round 1+2 on #873/#1126 caught four findings that follow from these rules; documenting them once means subsequent parser PRs ship clean.

"Rules not recipes" per the b5939ba operator directive — each new source's horizon + registration are derivable.

## Test plan

- [x] Docs-only PR; no code paths touched.
- [x] References ``app/services/manifest_parsers/`` package and the worker registry contract that ships in #1126.