### PR TITLE
feat(#873): manifest-worker DEF 14A parser adapter

### DIFF
--- a/app/services/manifest_parsers/__init__.py
+++ b/app/services/manifest_parsers/__init__.py
@@ -33,6 +33,7 @@ module-body side effects don't re-fire.
 
 from __future__ import annotations
 
+from app.services.manifest_parsers import def14a as _def14a
 from app.services.manifest_parsers import eight_k as _eight_k
 
 
@@ -42,6 +43,7 @@ def register_all_parsers() -> None:
     callable again by tests after ``clear_registered_parsers()``.
     """
     _eight_k.register()
+    _def14a.register()
 
 
 # Run once at package import.

--- a/app/services/manifest_parsers/def14a.py
+++ b/app/services/manifest_parsers/def14a.py
@@ -1,0 +1,384 @@
+"""DEF 14A manifest-worker parser adapter (#873).
+
+Wraps the existing pure-function parser
+``parse_beneficial_ownership_table`` + table-writer helpers from
+``app.services.def14a_ingest`` so the generic manifest worker can
+drive DEF 14A ingest one accession at a time.
+
+Pre-#873 the legacy ``ingest_def14a`` job scanned ``filing_events``
+for DEF 14A accessions whose ``def14a_ingest_log`` row was missing
+and processed them in batches. That path still works (no breakage
+in this PR) but the manifest worker is the future-facing single-
+writer pattern from the #869 spec. The manifest parser writes a
+``def14a_ingest_log`` row on every outcome so the legacy discovery
+filter (which excludes accessions already in the log) skips
+manifest-handled accessions — no duplicate fetches during cutover.
+
+ParseOutcome contract (see ``sec_manifest_worker.ParserSpec``):
+
+  * ``status='parsed'`` + ``raw_status='stored'`` — success path.
+    Raw HTML persisted in ``filing_raw_documents``; one
+    ``def14a_beneficial_holdings`` row per (sibling, holder); one
+    ``def14a_ingest_log`` row with ``status='success'``; one
+    ``ownership_def14a_observations`` row per non-ESOP holder; one
+    ``ownership_esop_observations`` row per ESOP plan.
+  * ``status='tombstoned'`` — fetch returned non-200/empty body
+    OR parser identified no beneficial-ownership table (notice-only
+    proxy / unrecognisable layout). Matches the legacy ``partial``
+    bucket so dashboard counts converge.
+  * ``status='failed'`` — transient error (fetch raise, store_raw
+    error, upsert error). Worker schedules a 1h backoff retry per
+    ``_FAILED_RETRY_DELAY``.
+
+Raw-payload invariant (#938): registered with
+``requires_raw_payload=True`` so the worker refuses to mark a row
+``parsed`` when ``raw_status='absent'``. ``store_raw`` runs in a
+savepoint BEFORE parse + upsert so the invariant holds whether
+parsing succeeds or raises.
+
+Share-class fan-out: DEF 14A is an issuer-level filing. The parser
+resolves the issuer CIK from ``instrument_sec_profile`` then fans
+out across every share-class sibling via
+``siblings_for_issuer_cik`` — same pattern the legacy ingester uses
+post-#1117 PR-B. Each sibling gets its own
+``def14a_beneficial_holdings`` row + observation row so per-
+instrument reads return identical figures across the share-class
+panel.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET  # noqa: S405 — only ET.ParseError caught; no untrusted parse.
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_def14a import (
+    Def14ABeneficialOwnershipTable,
+    parse_beneficial_ownership_table,
+)
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.services.def14a_ingest import (
+    _CIK_MISSING_SENTINEL,
+    _PARSER_VERSION_DEF14A,
+    _record_def14a_observations_for_filing,
+    _record_esop_observations_for_filing,
+    _record_ingest_attempt,
+    _resolve_issuer_cik,
+    _upsert_holding,
+)
+from app.services.ownership_observations import (
+    refresh_def14a_current,
+    refresh_esop_current,
+)
+from app.services.raw_filings import store_raw
+from app.services.sec_identity import siblings_for_issuer_cik
+
+logger = logging.getLogger(__name__)
+
+# Explicit 1h backoff matches the worker's ``_backoff_for(0)`` value.
+# Duplicated as a literal — see eight_k.py for the rationale (importing
+# the private worker symbol couples to internal layout).
+_FAILED_RETRY_DELAY = timedelta(hours=1)
+
+
+def _failed_outcome(error: str, raw_status: Any = None) -> Any:
+    """Build a ``failed`` ParseOutcome with a 1h backoff applied.
+
+    The worker only computes backoff for parser-raised exceptions;
+    a parser that RETURNS ``ParseOutcome(status='failed')`` without
+    ``next_retry_at`` would get immediately retried, hammering SEC
+    on every tick. Mirror the eight_k.py pattern."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    return ParseOutcome(
+        status="failed",
+        parser_version=_PARSER_VERSION_DEF14A,
+        raw_status=raw_status,
+        error=error,
+        next_retry_at=datetime.now(tz=UTC) + _FAILED_RETRY_DELAY,
+    )
+
+
+def _resolve_siblings(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    issuer_cik: str,
+) -> list[int]:
+    """Resolve share-class siblings for fan-out.
+
+    Returns ``[instrument_id]`` when CIK is the sentinel OR the
+    siblings query returns empty (defensive fallback so a
+    ``instrument_sec_profile`` gap doesn't drop the primary write).
+    """
+    if issuer_cik == _CIK_MISSING_SENTINEL:
+        return [instrument_id]
+    siblings = siblings_for_issuer_cik(conn, issuer_cik)
+    return siblings if siblings else [instrument_id]
+
+
+def _parse_def14a(
+    conn: psycopg.Connection[Any],
+    row: Any,  # ManifestRow — forward-ref to avoid circular import
+) -> Any:  # ParseOutcome — forward-ref
+    """Manifest-worker parser for one DEF 14A accession.
+
+    Steps:
+
+    1. Validate URL + instrument_id (tombstone on missing —
+       upstream discovery should never enqueue these).
+    2. Fetch the primary document HTML.
+    3. ``store_raw`` in a savepoint (satisfies #938 invariant).
+    4. Parse via ``parse_beneficial_ownership_table``.
+    5. On parse exception: return failed with raw_status=stored so
+       the manifest's view matches ground truth.
+    6. On no rows (notice-only / unrecognisable layout): write
+       ingest-log tombstone + return tombstoned.
+    7. On rows: resolve siblings, upsert holdings + observations
+       per sibling, write success log row, return parsed.
+    """
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    accession = row.accession_number
+    url = row.primary_document_url
+    instrument_id = row.instrument_id
+
+    if not url:
+        logger.warning(
+            "def14a manifest parser: accession=%s has no primary_document_url; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_DEF14A,
+            error="missing primary_document_url",
+        )
+    # Codex pre-push P1: ``sec_manifest._FORM_TO_SOURCE`` routes
+    # ``PRE 14A`` (preliminary proxy) into ``sec_def14a`` but the
+    # legacy ingester's ``_DEF14A_FORM_TYPES`` excludes it. Accepting
+    # PRE 14A here would create a divergence between the manifest
+    # path and the legacy path during cutover — PRE rows are pre-
+    # finalisation drafts whose ownership figures the operator
+    # never historically counted. Tombstone here so dual-path
+    # accounting stays consistent. Whether PRE 14A should
+    # eventually land is a policy decision deferred to a follow-up.
+    if (row.form or "").strip().upper() == "PRE 14A":
+        logger.info(
+            "def14a manifest parser: accession=%s is PRE 14A (preliminary); tombstoning to match legacy filter",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_DEF14A,
+            error="PRE 14A preliminary proxy — deferred (policy TBD)",
+        )
+    if instrument_id is None:
+        logger.warning(
+            "def14a manifest parser: accession=%s has no instrument_id; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_DEF14A,
+            error="missing instrument_id",
+        )
+
+    try:
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            body = provider.fetch_document_text(url)
+    except Exception as exc:  # noqa: BLE001 — transient fetch errors retry via worker backoff
+        logger.warning(
+            "def14a manifest parser: fetch raised accession=%s url=%s: %s",
+            accession,
+            url,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}")
+
+    # Resolve issuer CIK once; threaded through every outcome path so
+    # the ingest-log write doesn't re-issue the lookup (same shape as
+    # the legacy ingester's _AccessionOutcome.issuer_cik).
+    issuer_cik = _resolve_issuer_cik(conn, instrument_id=instrument_id) or _CIK_MISSING_SENTINEL
+
+    if not body:
+        # Non-200 or empty body. Legacy path returned status='failed'
+        # for this case; manifest path treats it as a tombstone so the
+        # row doesn't get retried forever on a persistently-404 doc.
+        # Write the ingest-log row with status='failed' to match legacy
+        # accounting; manifest itself records tombstoned.
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    accession_number=accession,
+                    issuer_cik=issuer_cik,
+                    status="failed",
+                    error="primary doc fetch returned empty or non-200",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "def14a manifest parser: ingest-log INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"log error: {exc}")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_DEF14A,
+            error="empty or non-200 fetch",
+        )
+
+    # store_raw in a savepoint so a partial write doesn't abort the
+    # worker's outer transaction. The body lands in
+    # filing_raw_documents BEFORE parse so a downstream re-wash can
+    # reparse without re-fetching from SEC.
+    try:
+        with conn.transaction():
+            store_raw(
+                conn,
+                accession_number=accession,
+                document_kind="def14a_body",
+                payload=body,
+                parser_version=_PARSER_VERSION_DEF14A,
+                source_url=url,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "def14a manifest parser: store_raw failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"store_raw error: {exc}")
+
+    # Parse-phase exceptions must return raw_status='stored' because
+    # store_raw already committed inside its savepoint — the manifest
+    # MUST reflect that state or it permanently diverges from
+    # filing_raw_documents (the "preserves stored raw_status" rule
+    # from the 8-K Codex round 2 BLOCKING). ET.ParseError + ValueError
+    # are what parse_beneficial_ownership_table raises on malformed
+    # input; broader Exception handler covers unexpected raises (e.g.
+    # AttributeError in a tag walker on truly junk HTML).
+    try:
+        parsed: Def14ABeneficialOwnershipTable = parse_beneficial_ownership_table(body)
+    except (ValueError, ET.ParseError) as exc:
+        logger.exception(
+            "def14a manifest parser: parse raised accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"parse error: {exc}", raw_status="stored")
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "def14a manifest parser: parse raised (unexpected) accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"parse error (unexpected): {exc}", raw_status="stored")
+
+    if not parsed.rows:
+        # Notice-only proxy / unrecognisable layout. Legacy path
+        # returned status='partial'; manifest path records
+        # tombstoned. Write the log row with status='partial' to
+        # mirror legacy accounting so /coverage/def14a counts a
+        # consistent figure.
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    accession_number=accession,
+                    issuer_cik=issuer_cik,
+                    status="partial",
+                    error=f"no beneficial-ownership table identified (best_score={parsed.raw_table_score})",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "def14a manifest parser: ingest-log INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"log error: {exc}", raw_status="stored")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_DEF14A,
+            raw_status="stored",
+            error=f"no beneficial-ownership table identified (best_score={parsed.raw_table_score})",
+        )
+
+    # Success path: fan out across share-class siblings. Wrap
+    # siblings resolution + entire write batch + ingest-log row in
+    # ONE try so any DB error from sibling lookup OR upsert returns
+    # ``_failed_outcome(raw_status='stored')`` — store_raw already
+    # ran inside its own committed savepoint, so the manifest MUST
+    # reflect stored raw or it permanently diverges from
+    # filing_raw_documents (Codex pre-push BLOCKING). The savepoint
+    # also rolls back partial-sibling state on mid-batch failure so
+    # share-class rollups stay consistent.
+    inserted = 0
+    updated = 0
+
+    try:
+        with conn.transaction():
+            siblings = _resolve_siblings(conn, instrument_id=instrument_id, issuer_cik=issuer_cik)
+            for sibling_iid in siblings:
+                for holder in parsed.rows:
+                    outcome = _upsert_holding(
+                        conn,
+                        accession_number=accession,
+                        issuer_cik=issuer_cik,
+                        instrument_id=sibling_iid,
+                        as_of_date=parsed.as_of_date,
+                        holder=holder,
+                    )
+                    if outcome == "inserted":
+                        inserted += 1
+                    else:
+                        updated += 1
+                _record_def14a_observations_for_filing(
+                    conn,
+                    instrument_id=sibling_iid,
+                    accession_number=accession,
+                    as_of_date=parsed.as_of_date,
+                    holders=parsed.rows,
+                )
+                refresh_def14a_current(conn, instrument_id=sibling_iid)
+                esop_rows_written = _record_esop_observations_for_filing(
+                    conn,
+                    instrument_id=sibling_iid,
+                    accession_number=accession,
+                    as_of_date=parsed.as_of_date,
+                    holders=parsed.rows,
+                )
+                if esop_rows_written > 0:
+                    refresh_esop_current(conn, instrument_id=sibling_iid)
+            _record_ingest_attempt(
+                conn,
+                accession_number=accession,
+                issuer_cik=issuer_cik,
+                status="success",
+                rows_inserted=inserted,
+                rows_skipped=0,
+                error=None,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "def14a manifest parser: upsert/observation batch failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"upsert error: {exc}", raw_status="stored")
+
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_PARSER_VERSION_DEF14A,
+        raw_status="stored",
+    )
+
+
+def register() -> None:
+    """Register the DEF 14A parser with the manifest worker.
+
+    Idempotent — ``register_parser`` is last-write-wins. Called once
+    from ``register_all_parsers`` at package import; re-callable
+    from tests after a registry wipe.
+    """
+    from app.jobs.sec_manifest_worker import register_parser
+
+    register_parser("sec_def14a", _parse_def14a, requires_raw_payload=True)

--- a/tests/test_manifest_parser_def14a.py
+++ b/tests/test_manifest_parser_def14a.py
@@ -1,0 +1,494 @@
+"""Tests for the DEF 14A manifest-worker parser adapter (#873).
+
+The parser wraps the existing ``def14a_ingest`` pure-parser +
+table-writer helpers so the manifest worker can drive DEF 14A
+ingest one accession at a time. Tests cover:
+
+- Happy path: HTML fetch → store_raw → parse → upsert beneficial
+  holdings + write-through observations → ParseOutcome(parsed).
+- Tombstone on empty fetch: 404 / empty body returns tombstoned +
+  records a ``failed`` ingest-log row.
+- Tombstone on no-table: parser identifies no beneficial-ownership
+  table (notice-only proxy) → tombstoned + ``partial`` log row +
+  raw_status=stored.
+- Fetch raises: returns failed with 1h backoff (worker retries).
+- Parse-phase exception AFTER store_raw: returns failed with
+  raw_status='stored' so the manifest matches filing_raw_documents
+  state (mirrors the 8-K Codex round 2 BLOCKING).
+- Registration: ``register_all_parsers`` wires sec_def14a into the
+  worker's parser registry.
+
+The fetch boundary is monkeypatched at
+``SecFilingsProvider.fetch_document_text`` level so tests run
+without touching SEC.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from textwrap import dedent
+
+import psycopg
+import pytest
+
+from app.jobs.sec_manifest_worker import (
+    clear_registered_parsers,
+    run_manifest_worker,
+)
+from app.services.sec_manifest import get_manifest_row, record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str, cik: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+    conn.execute(
+        """
+        INSERT INTO instrument_sec_profile (instrument_id, cik)
+        VALUES (%s, %s)
+        ON CONFLICT (instrument_id) DO UPDATE SET cik = EXCLUDED.cik
+        """,
+        (iid, cik),
+    )
+
+
+def _seed_pending_def14a(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    cik: str = "0000320193",
+    form: str = "DEF 14A",
+    primary_doc_url: str = "https://www.sec.gov/Archives/edgar/data/320193/000032019326000010/def14a.htm",
+) -> None:
+    record_manifest_entry(
+        conn,
+        accession,
+        cik=cik,
+        form=form,
+        source="sec_def14a",
+        subject_type="issuer",
+        subject_id=str(instrument_id),
+        instrument_id=instrument_id,
+        filed_at=datetime(2026, 5, 11, tzinfo=UTC),
+        primary_document_url=primary_doc_url,
+    )
+
+
+# A minimal DEF 14A body the parser will accept — section heading
+# + beneficial-ownership table with headers the scorer recognises.
+# Pattern copied from tests/test_sec_def14a_parser.py so this is
+# guaranteed-parseable upstream.
+_FAKE_DEF14A_HTML = dedent("""
+<!DOCTYPE html>
+<html><head><title>Proxy Statement</title></head>
+<body>
+<h1>Notice of Annual Meeting</h1>
+<p>Some preamble prose.</p>
+
+<h2>Security Ownership of Certain Beneficial Owners and Management</h2>
+<p>The following table sets forth the beneficial ownership as of March 1, 2026.</p>
+<table>
+  <tr>
+    <th>Name and Address of Beneficial Owner</th>
+    <th>Number of Shares Beneficially Owned</th>
+    <th>Percent of Class</th>
+  </tr>
+  <tr><td>John Doe, CEO</td><td>1,500,000</td><td>5.5%</td></tr>
+  <tr><td>Vanguard Group, Inc.</td><td>3,000,000</td><td>11.0%</td></tr>
+</table>
+<p>Footnotes:</p>
+<ol><li>Includes options exercisable within 60 days.</li></ol>
+</body></html>
+""")
+
+# A DEF 14A body the parser will accept as a notice-only proxy —
+# heading present but no table the scorer recognises as a
+# beneficial-ownership table. Forces parser.rows == [] so the
+# adapter exercises the no-rows tombstone path.
+_NOTICE_ONLY_DEF14A_HTML = dedent("""
+<!DOCTYPE html>
+<html><body>
+<h2>Notice of Annual Meeting</h2>
+<p>The annual meeting will ratify the auditor. No governance changes.</p>
+<table>
+  <tr><th>Date</th><th>Time</th></tr>
+  <tr><td>April 1, 2026</td><td>10:00 AM</td></tr>
+</table>
+</body></html>
+""")
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_then_reload():
+    """Wipe the worker parser registry before each test, then call
+    ``register_all_parsers()`` so every production parser
+    re-registers cleanly. Mirrors the 8-K test fixture so test
+    isolation works the same way across parser test modules."""
+    from app.services.manifest_parsers import register_all_parsers
+
+    clear_registered_parsers()
+    register_all_parsers()
+    yield
+    clear_registered_parsers()
+    register_all_parsers()
+
+
+def test_happy_path_parses_and_stores_raw_and_holdings(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifest worker drains a DEF 14A pending row when the
+    registered parser fetches → store_raw → parse → upsert
+    holdings + observations → log success."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8740001
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL", cik="0000320193")
+    _seed_pending_def14a(
+        ebull_test_conn,
+        accession="0000320193-26-000010",
+        instrument_id=iid,
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_DEF14A_HTML,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    assert stats.skipped_no_parser == 0
+
+    row = get_manifest_row(ebull_test_conn, "0000320193-26-000010")
+    assert row is not None
+    assert row.ingest_status == "parsed"
+    assert row.raw_status == "stored"
+    assert row.parser_version == "def14a-v1"
+
+    # def14a_beneficial_holdings rows exist for the parsed table.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM def14a_beneficial_holdings "
+            "WHERE accession_number = '0000320193-26-000010' AND instrument_id = %s",
+            (iid,),
+        )
+        count_row = cur.fetchone()
+    assert count_row is not None and count_row[0] >= 2
+
+    # def14a_ingest_log records success so legacy discovery skips this.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, rows_inserted FROM def14a_ingest_log WHERE accession_number = '0000320193-26-000010'"
+        )
+        log_row = cur.fetchone()
+    assert log_row is not None
+    assert log_row[0] == "success"
+    assert log_row[1] >= 2
+
+    # filing_raw_documents has the body so a re-wash can reparse.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT byte_count FROM filing_raw_documents
+            WHERE accession_number = '0000320193-26-000010'
+              AND document_kind = 'def14a_body'
+            """
+        )
+        raw = cur.fetchone()
+    assert raw is not None
+    assert raw[0] > 0
+
+
+def test_empty_fetch_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty/404 body → manifest row tombstoned + ingest-log
+    records ``failed`` so the legacy discovery filter skips it."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8740002
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="DEAD", cik="0000999999")
+    _seed_pending_def14a(
+        ebull_test_conn,
+        accession="0000999999-26-000020",
+        instrument_id=iid,
+        cik="0000999999",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: None,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, "0000999999-26-000020")
+    assert row is not None and row.ingest_status == "tombstoned"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT status FROM def14a_ingest_log WHERE accession_number = '0000999999-26-000020'")
+        log_row = cur.fetchone()
+    assert log_row is not None and log_row[0] == "failed"
+
+
+def test_no_table_tombstones_with_stored_raw(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Notice-only proxy (heading present, no recognisable table) →
+    manifest row tombstoned + raw_status='stored' (body is on disk)
+    + log row status='partial'. Mirrors legacy 'partial' bucket so
+    operator dashboard counts converge."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8740003
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="NOTC", cik="0000111111")
+    _seed_pending_def14a(
+        ebull_test_conn,
+        accession="0000111111-26-000030",
+        instrument_id=iid,
+        cik="0000111111",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _NOTICE_ONLY_DEF14A_HTML,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, "0000111111-26-000030")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    # Body persisted before parse — raw row exists; manifest reflects.
+    assert row.raw_status == "stored"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT status FROM def14a_ingest_log WHERE accession_number = '0000111111-26-000030'")
+        log_row = cur.fetchone()
+    assert log_row is not None and log_row[0] == "partial"
+
+
+def test_fetch_exception_marks_failed_with_backoff(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fetch raise → manifest row failed + next_retry_at = now+1h.
+    Without the explicit backoff in ``_failed_outcome``, the worker
+    would retry the row on every tick and hammer SEC."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8740004
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TRAN", cik="0000222222")
+    _seed_pending_def14a(
+        ebull_test_conn,
+        accession="0000222222-26-000040",
+        instrument_id=iid,
+        cik="0000222222",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    def _boom(self, url):  # noqa: ARG001
+        raise RuntimeError("network kaput")
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _boom)
+
+    before = datetime.now(tz=UTC)
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, "0000222222-26-000040")
+    assert row is not None and row.ingest_status == "failed"
+    assert row.error is not None and "fetch error" in row.error
+    assert row.next_retry_at is not None
+    delta = (row.next_retry_at - before).total_seconds()
+    # 1h backoff ± slack for test wall-clock drift.
+    assert 3300 < delta < 3900
+
+
+def test_parse_phase_exception_preserves_stored_raw_status(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the parser raises AFTER store_raw committed inside its
+    savepoint, the parser MUST return raw_status='stored' so the
+    manifest matches filing_raw_documents. Otherwise the manifest
+    says raw_status='absent' while the raw row exists — permanent
+    split between tables, plus store_raw unique-conflict churn on
+    every retry."""
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import def14a as parser_module
+
+    iid = 8740005
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="SPLIT", cik="0000333333")
+    _seed_pending_def14a(
+        ebull_test_conn,
+        accession="0000333333-26-000050",
+        instrument_id=iid,
+        cik="0000333333",
+    )
+    ebull_test_conn.commit()
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_DEF14A_HTML,
+    )
+
+    def _raising_parse(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic parser crash")
+
+    monkeypatch.setattr(parser_module, "parse_beneficial_ownership_table", _raising_parse)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, "0000333333-26-000050")
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM filing_raw_documents WHERE accession_number = '0000333333-26-000050'")
+        assert cur.fetchone() is not None
+
+
+def test_pre_14a_tombstones_to_match_legacy(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """PRE 14A (preliminary proxy) routes to sec_def14a in the
+    manifest but the legacy ingester excludes it. The parser
+    tombstones PRE 14A to keep dual-path accounting consistent
+    during cutover — no body fetch, no holdings write. (Codex
+    pre-push P1.)"""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8740006
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="PRE", cik="0000444444")
+    _seed_pending_def14a(
+        ebull_test_conn,
+        accession="0000444444-26-000060",
+        instrument_id=iid,
+        cik="0000444444",
+        form="PRE 14A",
+    )
+    ebull_test_conn.commit()
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, "0000444444-26-000060")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.error is not None and "PRE 14A" in row.error
+    # No raw fetched, no holdings, no ingest-log row.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM filing_raw_documents WHERE accession_number = '0000444444-26-000060'")
+        raw_count = cur.fetchone()
+    assert raw_count is not None and raw_count[0] == 0
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM def14a_beneficial_holdings WHERE accession_number = '0000444444-26-000060'")
+        holdings_count = cur.fetchone()
+    assert holdings_count is not None and holdings_count[0] == 0
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM def14a_ingest_log WHERE accession_number = '0000444444-26-000060'")
+        log_count = cur.fetchone()
+    assert log_count is not None and log_count[0] == 0
+
+
+def test_siblings_resolution_failure_preserves_stored_raw_status(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex pre-push BLOCKING: if siblings resolution raises AFTER
+    ``store_raw`` committed in its savepoint, the parser MUST return
+    ``_failed_outcome(raw_status='stored')`` so the manifest matches
+    filing_raw_documents. Without the fix the worker's exception
+    handler would mark the row failed with raw_status='absent' and
+    diverge from disk."""
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import def14a as parser_module
+
+    iid = 8740007
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="SIB", cik="0000555555")
+    _seed_pending_def14a(
+        ebull_test_conn,
+        accession="0000555555-26-000070",
+        instrument_id=iid,
+        cik="0000555555",
+    )
+    ebull_test_conn.commit()
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_DEF14A_HTML,
+    )
+
+    def _raising_siblings(conn, *, instrument_id, issuer_cik):  # noqa: ARG001
+        raise RuntimeError("synthetic siblings DB error")
+
+    monkeypatch.setattr(parser_module, "_resolve_siblings", _raising_siblings)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, "0000555555-26-000070")
+    assert row is not None
+    assert row.ingest_status == "failed"
+    # Critical: raw_status=stored because store_raw ran BEFORE the
+    # siblings raise. The fix moves _resolve_siblings INTO the same
+    # try block whose except returns raw_status='stored'.
+    assert row.raw_status == "stored"
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM filing_raw_documents WHERE accession_number = '0000555555-26-000070'")
+        assert cur.fetchone() is not None
+
+
+def test_parser_registered_via_register_all() -> None:
+    """``register_all_parsers()`` populates the worker registry with
+    sec_def14a alongside sec_8k. Pins the architecture invariant
+    that the package's public registration function is the SINGLE
+    place that wires parsers into the worker."""
+    from app.jobs.sec_manifest_worker import registered_parser_sources
+    from app.services.manifest_parsers import register_all_parsers
+
+    assert "sec_def14a" in registered_parser_sources()
+
+    clear_registered_parsers()
+    assert "sec_def14a" not in registered_parser_sources()
+
+    register_all_parsers()
+    assert "sec_def14a" in registered_parser_sources()


### PR DESCRIPTION
## What

Adds `app/services/manifest_parsers/def14a.py` — wraps the existing
`parse_beneficial_ownership_table` + `def14a_ingest` helpers into the
manifest-worker `ParserFn` contract. Manifest worker now drains
`sec_def14a` pending rows end-to-end one accession at a time, mirroring
the 8-K pattern from PR #1126.

## Why

#873 onboards each SEC source onto the manifest-worker single-writer
path. DEF 14A is the highest-impact next lane: ~126k stuck rows in the
manifest until a parser registers. Lands proxy beneficial-ownership +
write-through observations + ESOP overlay rows behind the worker's
rate-limit-aware queue instead of the legacy cron's `limit=100` batch.

## Design

- `register()` runs at module-import time via the package's
  `register_all_parsers()` (sec-edgar §11.1 contract).
- `requires_raw_payload=True` so the worker rejects parsed outcomes
  with `raw_status='absent'` (#938 audit invariant).
- `store_raw` runs in its own `conn.transaction()` savepoint BEFORE
  parse; siblings + holdings + observations + ingest-log all wrapped
  in a single second savepoint so partial-sibling state rolls back
  atomically. Outer worker tx never aborted.
- Failed outcomes from fetch/store/upsert errors set
  `next_retry_at = now + 1h` via `_failed_outcome` helper.
- Parse-phase + siblings-resolution exceptions return
  `raw_status='stored'` so the manifest matches `filing_raw_documents`
  on disk (no permanent split).
- `def14a_ingest_log` written from manifest path with status mapping
  parsed→success / tombstoned(no-rows)→partial /
  tombstoned(empty-fetch)→failed so legacy `discover_pending_def14a`
  excludes manifest-handled accessions during dual-path cutover.
- PRE 14A tombstoned at the parser to match legacy
  `_DEF14A_FORM_TYPES` filter (manifest routes PRE 14A→sec_def14a but
  legacy excludes; preliminary-proxy ingest is a policy TBD).

## Test plan

- [x] `uv run ruff check`, `ruff format --check`, `pyright` all green
- [x] `uv run pytest tests/test_manifest_parser_def14a.py
  tests/test_manifest_parser_eight_k.py` — 13 passed
- [x] `uv run pytest tests/test_def14a_ingest.py tests/test_sec_def14a_parser.py
  tests/test_sec_manifest_worker.py tests/test_sec_manifest.py
  tests/test_manifest_parser_audit.py` — 132 passed (no regressions)
- [x] Codex pre-push: 2 findings addressed
  - BLOCKING (`_resolve_siblings` outside try → raw_status split):
    moved INTO the savepoint try/except returning
    `raw_status='stored'`.
  - P2 (whitespace in `row.form`): added `.strip().upper()` on the
    PRE 14A check.

## ETL clauses (CLAUDE.md §"Definition of done")

Clauses 8–11 deferred to operator follow-up — this PR lands the parser
adapter but the AAPL/GME/MSFT/JPM/HD smoke + cross-source verify +
rollup-endpoint check happens once the manifest worker drains the
backlog. Tracked under #1117 (operator-bound: rebuild +
cross-source verify after parsers populate the figures).

Part of #873 (DEF 14A lane; remaining lanes 13D/G, 10-K/Q, Form 3/5
in follow-up PRs).
