### PR TITLE
feat(#873): manifest-worker Form 3 + Form 4 parser adapter

### DIFF
--- a/app/services/manifest_parsers/__init__.py
+++ b/app/services/manifest_parsers/__init__.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 from app.services.manifest_parsers import def14a as _def14a
 from app.services.manifest_parsers import eight_k as _eight_k
+from app.services.manifest_parsers import insider_345 as _insider_345
 from app.services.manifest_parsers import sec_13dg as _sec_13dg
 
 
@@ -46,6 +47,7 @@ def register_all_parsers() -> None:
     _eight_k.register()
     _def14a.register()
     _sec_13dg.register()  # registers BOTH sec_13d and sec_13g
+    _insider_345.register()  # registers sec_form3 + sec_form4 (Form 5 NYI)
 
 
 # Run once at package import.

--- a/app/services/manifest_parsers/insider_345.py
+++ b/app/services/manifest_parsers/insider_345.py
@@ -245,11 +245,45 @@ def _parse_form4(
                 parsed=parsed,
             )
     except Exception as exc:  # noqa: BLE001
+        # PR #1130 review WARNING: deterministic constraint failures
+        # on ``insider_filings`` / ``insider_transactions`` (bad date,
+        # FK miss, unique violation under unexpected state) MUST NOT
+        # retry hourly forever — the bad XML stays bad. Mirror the
+        # Form 3 policy (tombstone-on-upsert-fail) for symmetry across
+        # the insider lanes. Legacy Form 4 ingester at
+        # insider_transactions.py:1593 also has the retry-loop bug;
+        # that's tracked separately for a legacy patch + 8-K / 13D/G
+        # consistency sweep. Transient/deterministic discrimination
+        # via psycopg exception class is the proper long-term fix
+        # (deferred).
         logger.exception(
-            "form4 manifest parser: upsert failed accession=%s",
+            "form4 manifest parser: upsert failed accession=%s; tombstoning per Form 3 parity",
             accession,
         )
-        return _failed_outcome(f"upsert error: {exc}", parser_version=_PARSER_VERSION_FORM4, raw_status="stored")
+        try:
+            with conn.transaction():
+                _write_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                )
+        except Exception:  # noqa: BLE001 — tombstone failure shouldn't mask upsert failure
+            logger.exception(
+                "form4 manifest parser: tombstone INSERT failed after upsert error accession=%s",
+                accession,
+            )
+            return _failed_outcome(
+                f"upsert+tombstone error: {exc}",
+                parser_version=_PARSER_VERSION_FORM4,
+                raw_status="stored",
+            )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM4,
+            raw_status="stored",
+            error=f"upsert failed: {exc}",
+        )
 
     return ParseOutcome(
         status="parsed",

--- a/app/services/manifest_parsers/insider_345.py
+++ b/app/services/manifest_parsers/insider_345.py
@@ -1,0 +1,463 @@
+"""Form 3 / Form 4 manifest-worker parser adapter (#873).
+
+Wraps the existing ``parse_form_3_xml`` / ``parse_form_4_xml`` + the
+matching upsert paths into the manifest-worker ``ParserFn`` contract.
+One callable is registered against each source — Form 3 and Form 4
+share the EDGAR ownership XML namespace but persist into different
+tables (``insider_initial_holdings`` vs ``insider_transactions``)
+and have separate parser_version watermarks, so they are kept as two
+sibling callables (not merged into one dispatch).
+
+Form 5 (annual statement of changes in beneficial ownership) is
+NOT covered by this PR — the legacy ingester does not parse Form 5
+and adding it requires a Form 5 parser + upsert path. Form 5
+manifest rows continue to skip with ``no parser`` until the
+legacy support lands.
+
+ParseOutcome contract:
+
+  * ``status='parsed'`` + ``raw_status='stored'`` — XML persisted in
+    ``filing_raw_documents``; ``insider_filings`` + per-form child
+    tables upserted; observations write-through + per-instrument
+    ``ownership_insiders_current`` refresh fan out across share-class
+    siblings.
+  * ``status='tombstoned'`` — fetch returned non-200/empty body OR
+    the parser returned ``None`` (malformed XML, missing required
+    fields). Matches legacy semantics so dashboard counts converge.
+  * ``status='failed'`` — transient error (fetch raise, store_raw
+    error, upsert error). Worker schedules a 1h backoff retry.
+
+Raw-payload invariant (#938): registered with
+``requires_raw_payload=True``. ``store_raw`` runs in its own
+savepoint BEFORE parse + upsert so the invariant holds whether
+downstream succeeds or raises.
+
+URL canonicalisation: legacy ``_canonical_form_4_url`` strips the
+SEC XSL-rendering prefix so the fetch returns raw XML (not
+XSL-transformed HTML). Applied here so the manifest's
+``primary_document_url`` — which may be the XSL-rendered URL from
+Atom discovery — gets normalised before the fetch.
+
+Share-class fan-out: legacy ``upsert_filing`` /
+``upsert_form_3_filing`` ALREADY fan out across siblings via
+``siblings_for_issuer_cik`` internally — the manifest parser does
+NOT need to repeat the loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.services.insider_form3_ingest import (
+    _FORM3_PARSER_VERSION,
+    _write_form_3_tombstone,
+    upsert_form_3_filing,
+)
+from app.services.insider_transactions import (
+    _PARSER_VERSION_FORM4,
+    _canonical_form_4_url,
+    _write_tombstone,
+    parse_form_3_xml,
+    parse_form_4_xml,
+    upsert_filing,
+)
+from app.services.raw_filings import store_raw
+
+logger = logging.getLogger(__name__)
+
+_FAILED_RETRY_DELAY = timedelta(hours=1)
+
+
+_FORM3_PARSER_VERSION_STR = f"form3-v{_FORM3_PARSER_VERSION}"
+
+
+def _failed_outcome(error: str, *, parser_version: str, raw_status: Any = None) -> Any:
+    """Build a ``failed`` ParseOutcome with a 1h backoff applied.
+
+    Pattern mirrors the other per-source adapters — see eight_k.py
+    for the rationale on duplicating the literal instead of importing
+    the worker's private ``_backoff_for(0)``."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    return ParseOutcome(
+        status="failed",
+        parser_version=parser_version,
+        raw_status=raw_status,
+        error=error,
+        next_retry_at=datetime.now(tz=UTC) + _FAILED_RETRY_DELAY,
+    )
+
+
+def _parse_form4(
+    conn: psycopg.Connection[Any],
+    row: Any,  # ManifestRow
+) -> Any:  # ParseOutcome
+    """Manifest-worker parser for one Form 4 / 4/A accession."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    accession = row.accession_number
+    instrument_id = row.instrument_id
+    url = row.primary_document_url
+
+    if instrument_id is None:
+        logger.warning(
+            "form4 manifest parser: accession=%s has no instrument_id; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM4,
+            error="missing instrument_id",
+        )
+    if not url:
+        logger.warning(
+            "form4 manifest parser: accession=%s has no primary_document_url; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM4,
+            error="missing primary_document_url",
+        )
+
+    canonical_url = _canonical_form_4_url(url)
+
+    try:
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            xml = provider.fetch_document_text(canonical_url)
+    except Exception as exc:  # noqa: BLE001 — transient retries via 1h backoff
+        logger.warning(
+            "form4 manifest parser: fetch raised accession=%s url=%s: %s",
+            accession,
+            canonical_url,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}", parser_version=_PARSER_VERSION_FORM4)
+
+    if not xml:
+        # Empty / non-200. Legacy tombstones the row in insider_filings;
+        # mirror so dashboard counts match. Savepoint isolates the
+        # tombstone write from the outer worker tx.
+        try:
+            with conn.transaction():
+                _write_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "form4 manifest parser: tombstone INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"tombstone error: {exc}", parser_version=_PARSER_VERSION_FORM4)
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM4,
+            error="empty or non-200 fetch",
+        )
+
+    try:
+        with conn.transaction():
+            store_raw(
+                conn,
+                accession_number=accession,
+                document_kind="form4_xml",
+                payload=xml,
+                parser_version=_PARSER_VERSION_FORM4,
+                source_url=canonical_url,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "form4 manifest parser: store_raw failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"store_raw error: {exc}", parser_version=_PARSER_VERSION_FORM4)
+
+    # Parse-phase exceptions AFTER store_raw must return
+    # raw_status='stored' so the manifest matches filing_raw_documents
+    # state. One broad-except block writes the same tombstone path
+    # regardless of exception class — see review-prevention-log.md
+    # entry "Manifest parser parse-failure branch must write ingest-log
+    # on EVERY exception class" (PR #1129).
+    try:
+        parsed = parse_form_4_xml(xml)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "form4 manifest parser: parse raised accession=%s",
+            accession,
+        )
+        try:
+            with conn.transaction():
+                _write_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "form4 manifest parser: tombstone INSERT failed after parse error accession=%s",
+                accession,
+            )
+        return _failed_outcome(f"parse error: {exc}", parser_version=_PARSER_VERSION_FORM4, raw_status="stored")
+
+    if parsed is None:
+        try:
+            with conn.transaction():
+                _write_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "form4 manifest parser: tombstone INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"tombstone error: {exc}", parser_version=_PARSER_VERSION_FORM4, raw_status="stored")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM4,
+            raw_status="stored",
+            error="parser returned None (malformed XML or missing required fields)",
+        )
+
+    # upsert_filing handles siblings fan-out + observation
+    # write-through + refresh_insiders_current internally. Single
+    # savepoint covers every child write so a mid-batch failure rolls
+    # back atomically across share-class siblings.
+    try:
+        with conn.transaction():
+            upsert_filing(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=canonical_url,
+                parsed=parsed,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "form4 manifest parser: upsert failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"upsert error: {exc}", parser_version=_PARSER_VERSION_FORM4, raw_status="stored")
+
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_PARSER_VERSION_FORM4,
+        raw_status="stored",
+    )
+
+
+def _parse_form3(
+    conn: psycopg.Connection[Any],
+    row: Any,  # ManifestRow
+) -> Any:  # ParseOutcome
+    """Manifest-worker parser for one Form 3 / 3/A accession.
+
+    Same shape as ``_parse_form4`` but routes through
+    ``parse_form_3_xml`` + ``upsert_form_3_filing``. Form 3 is the
+    insider's initial-statement filing — first-time-named officers,
+    directors, 10%+ owners — whose holdings populate the
+    ``insider_initial_holdings`` table that backstops the cumulative
+    insider-cohort view when no transactions exist yet.
+    """
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    accession = row.accession_number
+    instrument_id = row.instrument_id
+    url = row.primary_document_url
+
+    if instrument_id is None:
+        logger.warning(
+            "form3 manifest parser: accession=%s has no instrument_id; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_FORM3_PARSER_VERSION_STR,
+            error="missing instrument_id",
+        )
+    if not url:
+        logger.warning(
+            "form3 manifest parser: accession=%s has no primary_document_url; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_FORM3_PARSER_VERSION_STR,
+            error="missing primary_document_url",
+        )
+
+    canonical_url = _canonical_form_4_url(url)
+
+    try:
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            xml = provider.fetch_document_text(canonical_url)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "form3 manifest parser: fetch raised accession=%s url=%s: %s",
+            accession,
+            canonical_url,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
+
+    if not xml:
+        try:
+            with conn.transaction():
+                _write_form_3_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "form3 manifest parser: tombstone INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"tombstone error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_FORM3_PARSER_VERSION_STR,
+            error="empty or non-200 fetch",
+        )
+
+    try:
+        with conn.transaction():
+            store_raw(
+                conn,
+                accession_number=accession,
+                document_kind="form3_xml",
+                payload=xml,
+                parser_version=_FORM3_PARSER_VERSION_STR,
+                source_url=canonical_url,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "form3 manifest parser: store_raw failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"store_raw error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
+
+    try:
+        parsed = parse_form_3_xml(xml)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "form3 manifest parser: parse raised accession=%s",
+            accession,
+        )
+        try:
+            with conn.transaction():
+                _write_form_3_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "form3 manifest parser: tombstone INSERT failed after parse error accession=%s",
+                accession,
+            )
+        return _failed_outcome(f"parse error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR, raw_status="stored")
+
+    if parsed is None:
+        try:
+            with conn.transaction():
+                _write_form_3_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "form3 manifest parser: tombstone INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(
+                f"tombstone error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR, raw_status="stored"
+            )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_FORM3_PARSER_VERSION_STR,
+            raw_status="stored",
+            error="parser returned None (malformed XML or missing required fields)",
+        )
+
+    try:
+        with conn.transaction():
+            upsert_form_3_filing(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=canonical_url,
+                parsed=parsed,
+            )
+    except Exception as exc:  # noqa: BLE001
+        # Legacy Form 3 ingester (insider_form3_ingest.py:685) tombstones
+        # on upsert failure so a deterministic constraint violation
+        # doesn't loop the scheduler refetching the same dead XML on
+        # every tick. Mirror that policy here: write the tombstone in a
+        # fresh savepoint, then transition the manifest row to
+        # ``tombstoned`` (not ``failed``) so the worker doesn't schedule
+        # a 1h retry on a deterministic bug. A parser-version bump will
+        # re-pick the accession via the existing manifest rewash path.
+        logger.exception(
+            "form3 manifest parser: upsert failed accession=%s; tombstoning per legacy parity",
+            accession,
+        )
+        try:
+            with conn.transaction():
+                _write_form_3_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                )
+        except Exception:  # noqa: BLE001 — tombstone failure shouldn't mask upsert failure
+            logger.exception(
+                "form3 manifest parser: tombstone INSERT failed after upsert error accession=%s",
+                accession,
+            )
+            return _failed_outcome(
+                f"upsert+tombstone error: {exc}",
+                parser_version=_FORM3_PARSER_VERSION_STR,
+                raw_status="stored",
+            )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_FORM3_PARSER_VERSION_STR,
+            raw_status="stored",
+            error=f"upsert failed: {exc}",
+        )
+
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_FORM3_PARSER_VERSION_STR,
+        raw_status="stored",
+    )
+
+
+def register() -> None:
+    """Register Form 3 + Form 4 parsers with the manifest worker.
+
+    Form 5 is intentionally NOT registered — the legacy ingester
+    has no Form 5 parser; Form 5 manifest rows continue to skip
+    until upstream support lands.
+    """
+    from app.jobs.sec_manifest_worker import register_parser
+
+    register_parser("sec_form4", _parse_form4, requires_raw_payload=True)
+    register_parser("sec_form3", _parse_form3, requires_raw_payload=True)

--- a/tests/test_manifest_parser_insider_345.py
+++ b/tests/test_manifest_parser_insider_345.py
@@ -442,6 +442,56 @@ def test_form4_parse_phase_exception_preserves_stored_raw_status(
         assert cur.fetchone() is not None
 
 
+def test_form4_upsert_failure_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #1130 review WARNING: Form 4 upsert failure must tombstone
+    (not failed+1h retry) so deterministic constraint violations on
+    insider_filings/insider_transactions don't loop the worker
+    refetching the same dead XML hourly. Symmetry with Form 3 policy."""
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import insider_345 as parser_module
+
+    iid = 8760010
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="UFAIL4")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000222222-26-000010",
+        instrument_id=iid,
+        source="sec_form4",
+        form="4",
+    )
+    ebull_test_conn.commit()
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_4_XML,
+    )
+
+    def _raising_upsert(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic Form 4 upsert constraint violation")
+
+    monkeypatch.setattr(parser_module, "upsert_filing", _raising_upsert)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    assert stats.failed == 0
+    row = get_manifest_row(ebull_test_conn, "0000222222-26-000010")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "upsert failed" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT is_tombstone FROM insider_filings WHERE accession_number = '0000222222-26-000010'")
+        f = cur.fetchone()
+    assert f is not None and f[0] is True
+
+
 def test_form3_upsert_failure_tombstones_per_legacy_parity(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_manifest_parser_insider_345.py
+++ b/tests/test_manifest_parser_insider_345.py
@@ -1,0 +1,581 @@
+"""Tests for the Form 3 / Form 4 manifest-worker parser adapter (#873).
+
+One callable registered per source — Form 3 and Form 4 share the
+EDGAR ownership XML namespace but persist into different tables
+(``insider_initial_holdings`` vs ``insider_transactions``) and
+carry separate parser_version watermarks. Form 5 is intentionally
+unregistered (no legacy support yet) and continues to skip.
+
+Tests cover:
+
+- Happy path Form 4: XML fetch → store_raw → parse → upsert
+  ``insider_filings`` + ``insider_transactions`` rows → observation
+  write-through.
+- Happy path Form 3: XML fetch → store_raw → parse → upsert
+  ``insider_initial_holdings`` rows.
+- Tombstone on empty fetch: writes a tombstone row in
+  ``insider_filings`` so legacy discovery skips the accession.
+- Tombstone on parse-None (malformed XML): same tombstone path,
+  raw_status='stored' so manifest matches filing_raw_documents.
+- Parse-phase exception preserves raw_status='stored'.
+- Fetch raises: returns failed + 1h backoff.
+- Form 5 unregistered: sec_form5 source is debug-skipped by the
+  worker (no parser).
+- URL canonicalisation: SEC XSL-rendered URL → raw XML URL via
+  ``_canonical_form_4_url``.
+- Registration: register_all_parsers wires sec_form3 + sec_form4
+  but NOT sec_form5.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from textwrap import dedent
+
+import psycopg
+import pytest
+
+from app.jobs.sec_manifest_worker import (
+    clear_registered_parsers,
+    run_manifest_worker,
+)
+from app.services.sec_manifest import get_manifest_row, record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+_FAKE_FORM_4_XML = dedent("""<?xml version="1.0"?>
+<ownershipDocument>
+  <documentType>4</documentType>
+  <periodOfReport>2026-04-15</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000001</rptOwnerCik>
+      <rptOwnerName>Jane Smith</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isDirector>1</isDirector>
+      <isOfficer>1</isOfficer>
+      <officerTitle>Chief Financial Officer</officerTitle>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <securityTitle><value>Common Stock</value></securityTitle>
+      <transactionDate><value>2026-04-15</value></transactionDate>
+      <transactionCoding>
+        <transactionCode>P</transactionCode>
+      </transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>250</value></transactionShares>
+        <transactionPricePerShare><value>185.42</value></transactionPricePerShare>
+        <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+  <ownerSignature>
+    <signatureName>Jane Smith</signatureName>
+    <signatureDate>2026-04-16</signatureDate>
+  </ownerSignature>
+</ownershipDocument>
+""")
+
+
+_FAKE_FORM_3_XML = dedent("""<?xml version="1.0"?>
+<ownershipDocument>
+  <schemaVersion>X0202</schemaVersion>
+  <documentType>3</documentType>
+  <periodOfReport>2026-01-15</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000001</rptOwnerCik>
+      <rptOwnerName>Smith, Jane</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isOfficer>1</isOfficer>
+      <officerTitle>Chief Financial Officer</officerTitle>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeHolding>
+      <securityTitle><value>Common Stock</value></securityTitle>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>50000</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </nonDerivativeHolding>
+  </nonDerivativeTable>
+  <ownerSignature>
+    <signatureName>Jane Smith</signatureName>
+    <signatureDate>2026-01-16</signatureDate>
+  </ownerSignature>
+</ownershipDocument>
+""")
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+
+
+def _seed_pending(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    source: str,
+    form: str,
+    url: str = "https://www.sec.gov/Archives/edgar/data/320193/000032019326000010/primary_doc.xml",
+) -> None:
+    record_manifest_entry(
+        conn,
+        accession,
+        cik="0000320193",
+        form=form,
+        source=source,  # type: ignore[arg-type]
+        subject_type="issuer",
+        subject_id=str(instrument_id),
+        instrument_id=instrument_id,
+        filed_at=datetime(2026, 5, 11, tzinfo=UTC),
+        primary_document_url=url,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_then_reload():
+    from app.services.manifest_parsers import register_all_parsers
+
+    clear_registered_parsers()
+    register_all_parsers()
+    yield
+    clear_registered_parsers()
+    register_all_parsers()
+
+
+def test_form4_happy_path(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifest worker drains a Form 4 pending row: fetch → store_raw
+    → parse → upsert insider_filings + insider_transactions."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760001
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000320193-26-000010",
+        instrument_id=iid,
+        source="sec_form4",
+        form="4",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_4_XML,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, "0000320193-26-000010")
+    assert row is not None and row.ingest_status == "parsed"
+    assert row.raw_status == "stored"
+    assert row.parser_version == "form4-v1"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT document_type, is_tombstone FROM insider_filings WHERE accession_number = '0000320193-26-000010'"
+        )
+        f = cur.fetchone()
+    assert f is not None
+    assert f[0] == "4"
+    assert f[1] is False
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM insider_transactions WHERE accession_number = '0000320193-26-000010'")
+        c = cur.fetchone()
+    assert c is not None and c[0] >= 1
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT byte_count FROM filing_raw_documents "
+            "WHERE accession_number = '0000320193-26-000010' AND document_kind = 'form4_xml'"
+        )
+        r = cur.fetchone()
+    assert r is not None and r[0] > 0
+
+
+def test_form3_happy_path(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Form 3 routes through parse_form_3_xml + upsert_form_3_filing →
+    insider_initial_holdings row."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760002
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL3")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000320193-26-000020",
+        instrument_id=iid,
+        source="sec_form3",
+        form="3",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_3_XML,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form3", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, "0000320193-26-000020")
+    assert row is not None and row.ingest_status == "parsed"
+    assert row.raw_status == "stored"
+    assert row.parser_version == "form3-v1"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT document_type FROM insider_filings WHERE accession_number = '0000320193-26-000020'")
+        f = cur.fetchone()
+    assert f is not None and f[0] == "3"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM insider_initial_holdings WHERE accession_number = '0000320193-26-000020'")
+        c = cur.fetchone()
+    assert c is not None and c[0] >= 1
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM filing_raw_documents "
+            "WHERE accession_number = '0000320193-26-000020' AND document_kind = 'form3_xml'"
+        )
+        assert cur.fetchone() is not None
+
+
+def test_form4_empty_fetch_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty/404 → manifest tombstoned + insider_filings tombstone row."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760003
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="DEAD4")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000999999-26-000010",
+        instrument_id=iid,
+        source="sec_form4",
+        form="4",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: None,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, "0000999999-26-000010")
+    assert row is not None and row.ingest_status == "tombstoned"
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT is_tombstone FROM insider_filings WHERE accession_number = '0000999999-26-000010'")
+        f = cur.fetchone()
+    assert f is not None and f[0] is True
+
+
+def test_form4_parse_none_tombstones_with_stored_raw(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed XML → parser returns None → manifest tombstoned with
+    raw_status='stored' since store_raw committed BEFORE the parse."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760004
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="MAL4")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000888888-26-000010",
+        instrument_id=iid,
+        source="sec_form4",
+        form="4",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    # Body is non-empty but not ownership XML — parser returns None.
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: "<not-ownership-xml/>",
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, "0000888888-26-000010")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+
+
+def test_form4_fetch_exception_marks_failed_with_backoff(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fetch raise → failed + 1h backoff so worker doesn't hammer SEC."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760005
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="BOOM4")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000777777-26-000010",
+        instrument_id=iid,
+        source="sec_form4",
+        form="4",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    def _boom(self, url):  # noqa: ARG001
+        raise RuntimeError("network kaput")
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _boom)
+
+    before = datetime.now(tz=UTC)
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, "0000777777-26-000010")
+    assert row is not None and row.ingest_status == "failed"
+    assert row.error is not None and "fetch error" in row.error
+    assert row.next_retry_at is not None
+    delta = (row.next_retry_at - before).total_seconds()
+    assert 3300 < delta < 3900
+
+
+def test_form4_parse_phase_exception_preserves_stored_raw_status(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parse raise AFTER store_raw → failed + raw_status='stored'."""
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import insider_345 as parser_module
+
+    iid = 8760006
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="CRASH4")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000666666-26-000010",
+        instrument_id=iid,
+        source="sec_form4",
+        form="4",
+    )
+    ebull_test_conn.commit()
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_4_XML,
+    )
+
+    def _raising_parse(xml):  # noqa: ARG001
+        raise RuntimeError("synthetic Form 4 parser crash")
+
+    monkeypatch.setattr(parser_module, "parse_form_4_xml", _raising_parse)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, "0000666666-26-000010")
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM filing_raw_documents WHERE accession_number = '0000666666-26-000010'")
+        assert cur.fetchone() is not None
+
+
+def test_form3_upsert_failure_tombstones_per_legacy_parity(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex pre-push: Form 3 upsert failure must tombstone (matching
+    legacy ``_process_form_3_candidates`` at insider_form3_ingest.py:685)
+    so a deterministic constraint violation doesn't loop the worker
+    refetching the same dead XML hourly. Manifest row transitions to
+    ``tombstoned`` (not ``failed``) and writes the tombstone row in
+    ``insider_filings``."""
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import insider_345 as parser_module
+
+    iid = 8760009
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="UFAIL3")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000333333-26-000010",
+        instrument_id=iid,
+        source="sec_form3",
+        form="3",
+    )
+    ebull_test_conn.commit()
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_3_XML,
+    )
+
+    def _raising_upsert(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic upsert constraint violation")
+
+    monkeypatch.setattr(parser_module, "upsert_form_3_filing", _raising_upsert)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form3", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    assert stats.failed == 0
+    row = get_manifest_row(ebull_test_conn, "0000333333-26-000010")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "upsert failed" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT is_tombstone FROM insider_filings WHERE accession_number = '0000333333-26-000010'")
+        f = cur.fetchone()
+    assert f is not None and f[0] is True
+
+
+def test_xsl_url_canonicalised_before_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Atom discovery may carry the XSL-rendered URL (with
+    ``/xslF345X05/`` segment). The parser canonicalises it before
+    fetch so the worker reads raw XML, not XSL-transformed HTML."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760007
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="XSL4")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000555555-26-000010",
+        instrument_id=iid,
+        source="sec_form4",
+        form="4",
+        url="https://www.sec.gov/Archives/edgar/data/320193/000032019326000010/xslF345X05/primary_doc.xml",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    fetched_urls: list[str] = []
+
+    def _capture(self, url):  # noqa: ARG001
+        fetched_urls.append(url)
+        return _FAKE_FORM_4_XML
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _capture)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    # Confirm canonicalisation actually stripped the XSL segment.
+    assert len(fetched_urls) == 1
+    assert "/xslF345X05/" not in fetched_urls[0]
+
+
+def test_form5_unregistered_skips(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Form 5 (annual statement) has no registered parser. The worker
+    debug-skips the row and the manifest stays pending so a future
+    Form 5 onboarding sees the same backlog."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760008
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="ANN5")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000444444-26-000010",
+        instrument_id=iid,
+        source="sec_form5",
+        form="5",
+    )
+    ebull_test_conn.commit()
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.skipped_no_parser == 1
+    assert stats.parsed == 0
+    assert stats.tombstoned == 0
+    row = get_manifest_row(ebull_test_conn, "0000444444-26-000010")
+    assert row is not None and row.ingest_status == "pending"
+
+
+def test_parser_registered_form3_and_form4_but_not_form5() -> None:
+    """sec_form3 + sec_form4 wired; sec_form5 deliberately NOT."""
+    from app.jobs.sec_manifest_worker import registered_parser_sources
+    from app.services.manifest_parsers import register_all_parsers
+
+    sources = registered_parser_sources()
+    assert "sec_form3" in sources
+    assert "sec_form4" in sources
+    assert "sec_form5" not in sources
+
+    clear_registered_parsers()
+    assert "sec_form3" not in registered_parser_sources()
+    register_all_parsers()
+    assert "sec_form3" in registered_parser_sources()
+    assert "sec_form4" in registered_parser_sources()
+    assert "sec_form5" not in registered_parser_sources()


### PR DESCRIPTION
## What

Adds `app/services/manifest_parsers/insider_345.py` — two ParserFn
callables wired against `sec_form3` and `sec_form4` respectively.
Drains the Form 3 + Form 4 backlog (~197k Form 3/5 combined + the
Form 4 atom freshness lane) through the generic manifest worker.
Mirrors the 8-K / DEF 14A / 13D/G pattern. Form 5 is intentionally
NOT registered — the legacy ingester has no Form 5 parser, so
sec_form5 manifest rows continue to skip with `no parser` until
upstream support lands.

## Why

Closes the last big SEC ownership lane on the parser registration
contract from sec-edgar §11.1. Form 4 is the dominant insider
filing on EDGAR daily volume (~3k accessions/day) and Form 3 is
the initial-statement filing that backstops the insider-cohort
view when there are no subsequent transactions yet.

## Design

- Two sibling callables (not a merged dispatch) — Form 3 and 4 share
  the EDGAR ownership XML namespace but persist into different child
  tables (`insider_initial_holdings` vs `insider_transactions`) and
  have separate `parser_version` watermarks.
- `requires_raw_payload=True` for both (XML body persisted before
  parse so #938 audit invariant holds).
- URL canonicalised via `_canonical_form_4_url` before fetch so a
  manifest row carrying the Atom XSL-rendered URL still fetches raw
  XML (not XSL-transformed HTML).
- `upsert_filing` / `upsert_form_3_filing` already handle siblings
  fan-out + observation write-through internally — the manifest
  parser does NOT repeat the loop.
- store_raw + upsert wrapped in `conn.transaction()` savepoints.
- Failed outcomes set `next_retry_at = now + 1h`.
- Parse-phase exceptions + upsert-phase exceptions preserve
  `raw_status='stored'` so manifest matches `filing_raw_documents`.
- Form 3 upsert-exception path tombstones (matching legacy
  `_process_form_3_candidates` at insider_form3_ingest.py:685) so
  deterministic constraint violations don't loop the worker hourly.

## Test plan

- [x] `uv run ruff check`, `ruff format`, `pyright` all green
- [x] `uv run pytest tests/test_manifest_parser_insider_345.py` — 10/10
- [x] Codex pre-push: 1 finding addressed
  - Form 3 upsert-exception path missing tombstone-on-failure (vs
    legacy) — fixed: now writes `_write_form_3_tombstone` in a fresh
    savepoint and transitions manifest to `tombstoned` (not
    `failed`).
  - Re-review: confirmed correct + complete; no new findings.

## ETL clauses (CLAUDE.md §"Definition of done")

Clauses 8–11 deferred to operator follow-up — this PR lands the
parser adapters; smoke/cross-source/rollup verification happens
once the manifest worker drains the Form 3/4 backlog. Tracked under
#1117.

Part of #873 (Form 3 + Form 4 lanes; Form 5 + 10-K/Q in follow-up
PRs).