### PR TITLE
feat(#873): manifest-worker 13F-HR + NPORT-P thin parser adapters

### DIFF
--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -460,6 +460,17 @@ def _record_ingest_attempt(
             %(status)s, %(holdings_inserted)s, %(holdings_skipped)s, %(error)s
         )
         ON CONFLICT (accession_number) DO UPDATE SET
+            -- PR #1133 Codex pre-push (Finding 3): a pre-parse log
+            -- row (fetch-404 / parse-error) carries period_of_report
+            -- NULL; the later success-path write supplies the real
+            -- period. COALESCE prefers the EXCLUDED value when it is
+            -- non-NULL, but falls back to the existing column so a
+            -- subsequent failure-row write (which lacks period) does
+            -- not erase a previously-known good period.
+            period_of_report = COALESCE(
+                EXCLUDED.period_of_report,
+                institutional_holdings_ingest_log.period_of_report
+            ),
             status = EXCLUDED.status,
             holdings_inserted = EXCLUDED.holdings_inserted,
             holdings_skipped = EXCLUDED.holdings_skipped,

--- a/app/services/manifest_parsers/__init__.py
+++ b/app/services/manifest_parsers/__init__.py
@@ -37,6 +37,8 @@ from app.services.manifest_parsers import def14a as _def14a
 from app.services.manifest_parsers import eight_k as _eight_k
 from app.services.manifest_parsers import insider_345 as _insider_345
 from app.services.manifest_parsers import sec_13dg as _sec_13dg
+from app.services.manifest_parsers import sec_13f_hr as _sec_13f_hr
+from app.services.manifest_parsers import sec_n_port as _sec_n_port
 
 
 def register_all_parsers() -> None:
@@ -48,6 +50,8 @@ def register_all_parsers() -> None:
     _def14a.register()
     _sec_13dg.register()  # registers BOTH sec_13d and sec_13g
     _insider_345.register()  # registers sec_form3 + sec_form4 (Form 5 NYI)
+    _sec_13f_hr.register()
+    _sec_n_port.register()
 
 
 # Run once at package import.

--- a/app/services/manifest_parsers/sec_13f_hr.py
+++ b/app/services/manifest_parsers/sec_13f_hr.py
@@ -1,0 +1,527 @@
+"""SEC 13F-HR manifest-worker parser adapter (#873).
+
+13F-HR is filed quarterly by every institutional manager with
+discretionary AUM > $100M (15 USC 78m(f)). The bulk path
+(``app/services/sec_13f_dataset_ingest.py``) ingests the quarterly
+ZIP archive for historical drains — that's the workhorse. This thin
+adapter handles atom-discovered freshness only: one accession at a
+time, fetch + parse both XML attachments, upsert via the existing
+``institutional_holdings`` primitives.
+
+ParseOutcome contract:
+
+  * ``status='parsed'`` + ``raw_status='stored'`` — both
+    ``primary_doc.xml`` and ``infotable.xml`` persisted in
+    ``filing_raw_documents``; ``institutional_filers`` upserted;
+    ``institutional_holdings`` rows upserted per resolved CUSIP;
+    ``unresolved_13f_cusips`` recorded for un-resolved holdings; one
+    ``institutional_holdings_ingest_log`` row with status='success'
+    or 'partial' (partial = at least one unresolved CUSIP, gated on
+    #740 backfill).
+  * ``status='tombstoned'`` — archive index 404 / both attachments
+    missing / fetch returned empty body. Mirrors the legacy 'failed'
+    accounting in the ingest log so dashboard counts converge.
+  * ``status='failed'`` — transient error (fetch raise, store_raw
+    error, transient psycopg ``OperationalError`` on upsert). Worker
+    schedules a 1h backoff retry per ``_FAILED_RETRY_DELAY``.
+
+Subject identity (sec-edgar §3.6): 13F-HR is filer-scoped — the
+manifest row carries ``subject_type='institutional_filer'``,
+``subject_id=<filer_cik>``, ``instrument_id=NULL``. Issuer linkage is
+per-row by CUSIP inside the infotable, resolved at parse time via
+``_resolve_cusip_to_instrument_id``.
+
+Raw-payload invariant (#938): registered with
+``requires_raw_payload=True``. Both attachments are stored in
+savepoints BEFORE parse so the invariant holds whether parsing
+succeeds or raises.
+
+#1131 discrimination: transient psycopg ``OperationalError`` on the
+filer/holdings upsert keeps the manifest in ``failed`` with the 1h
+backoff; deterministic constraint violations write the audit-log
+row with status='failed' and tombstone the manifest. See
+``app/services/manifest_parsers/_classify.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET  # noqa: S405 — only ET.ParseError caught; no untrusted parse.
+from dataclasses import replace
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_13f import (
+    parse_infotable,
+    parse_primary_doc,
+)
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.services.institutional_holdings import (
+    _PARSER_VERSION_13F_INFOTABLE,
+    _PARSER_VERSION_13F_PRIMARY,
+    ThirteenFHolding,
+    _archive_file_url,
+    _record_13f_observations_for_filing,
+    _record_ingest_attempt,
+    _record_unresolved_cusip,
+    _resolve_cusip_to_instrument_id,
+    _upsert_filer,
+    _upsert_holding,
+    parse_archive_index,
+)
+from app.services.manifest_parsers._classify import (
+    format_upsert_error,
+    is_transient_upsert_error,
+)
+from app.services.ownership_observations import refresh_institutions_current
+from app.services.raw_filings import store_raw
+
+logger = logging.getLogger(__name__)
+
+_FAILED_RETRY_DELAY = timedelta(hours=1)
+# Composite parser version — the manifest stores one ``parser_version``
+# per row; the 13F path actually has two (primary_doc + infotable).
+# Compose them so a rewash that bumps either triggers a re-parse.
+_PARSER_VERSION_13F_HR = f"13f-hr-primary:{_PARSER_VERSION_13F_PRIMARY}+infotable:{_PARSER_VERSION_13F_INFOTABLE}"
+
+# 13F-HR Column 4 (VALUE) unit cutover. Pre-cutover filings reported
+# VALUE in $thousands; post-cutover in $dollars (SEC EDGAR Release
+# 22.4.1, see sec-edgar skill §7.1). The bulk dataset path applies
+# this at app/services/sec_13f_dataset_ingest.py:325; the per-filing
+# parser at app/providers/implementations/sec_13f.py does NOT (it
+# preserves the raw value), so the service layer must branch on
+# ``filed_at``. Pre-cutover amendments filed late still report
+# thousands — a 2022Q4 restatement landed in March 2023 would carry
+# dollars even though its period_end is pre-cutover, so the cutover
+# is keyed by ``filed_at``, not ``period_of_report``.
+_VALUE_DOLLARS_CUTOVER = date(2023, 1, 3)
+
+
+def _failed_outcome(error: str, raw_status: Any = None) -> Any:
+    """Build a ``failed`` ParseOutcome with a 1h backoff applied."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    return ParseOutcome(
+        status="failed",
+        parser_version=_PARSER_VERSION_13F_HR,
+        raw_status=raw_status,
+        error=error,
+        next_retry_at=datetime.now(tz=UTC) + _FAILED_RETRY_DELAY,
+    )
+
+
+def _parse_13f_hr(
+    conn: psycopg.Connection[Any],
+    row: Any,  # ManifestRow — forward-ref to avoid circular import
+) -> Any:  # ParseOutcome — forward-ref
+    """Manifest-worker parser for one 13F-HR / 13F-HR/A accession."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    accession = row.accession_number
+    filer_cik = (row.cik or "").strip()
+
+    if not filer_cik:
+        logger.warning(
+            "13F-HR manifest parser: accession=%s has no filer cik; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_13F_HR,
+            error="missing filer cik",
+        )
+
+    # Step 1: archive index walk. Manifest's ``primary_document_url`` is
+    # typically the filing-index page (or one of the attachments); we
+    # need both ``primary_doc.xml`` and ``infotable.xml`` names which
+    # come from ``index.json``. Same pattern as the legacy ingester
+    # ``_ingest_single_accession``.
+    base_url = _archive_file_url(filer_cik, accession, "")
+    index_url = base_url + "index.json"
+
+    try:
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            index_payload = provider.fetch_document_text(index_url)
+    except Exception as exc:  # noqa: BLE001 — transient fetch errors retry via backoff
+        logger.warning(
+            "13F-HR manifest parser: index fetch raised accession=%s url=%s: %s",
+            accession,
+            index_url,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}")
+
+    if not index_payload:
+        # 404 / non-200 on index.json — accession is unreachable.
+        # Mirror legacy ingest-log 'failed' so dashboard counts match.
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    period_of_report=None,
+                    status="failed",
+                    error="archive index.json fetch failed",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "13F-HR manifest parser: ingest-log INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"log error: {exc}")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_13F_HR,
+            error="archive index.json fetch failed",
+        )
+
+    primary_name, infotable_name = parse_archive_index(index_payload)
+    if primary_name is None or infotable_name is None:
+        # Index found but missing one of the two required attachments.
+        # Deterministic — re-fetching the same index yields the same
+        # gap. Tombstone with audit-log entry.
+        log_error = f"archive index missing files (primary={primary_name!r}, infotable={infotable_name!r})"
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    period_of_report=None,
+                    status="failed",
+                    error=log_error,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "13F-HR manifest parser: ingest-log INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"log error: {exc}")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_13F_HR,
+            error=log_error,
+        )
+
+    primary_url = _archive_file_url(filer_cik, accession, primary_name)
+    infotable_url = _archive_file_url(filer_cik, accession, infotable_name)
+
+    # Step 2: fetch primary_doc.xml + store_raw inside savepoint.
+    try:
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            primary_xml = provider.fetch_document_text(primary_url)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "13F-HR manifest parser: primary_doc fetch raised accession=%s: %s",
+            accession,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}")
+
+    if not primary_xml:
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    period_of_report=None,
+                    status="failed",
+                    error="primary_doc.xml fetch failed",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "13F-HR manifest parser: ingest-log INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"log error: {exc}")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_13F_HR,
+            error="primary_doc.xml fetch failed",
+        )
+
+    try:
+        with conn.transaction():
+            store_raw(
+                conn,
+                accession_number=accession,
+                document_kind="primary_doc",
+                payload=primary_xml,
+                parser_version=_PARSER_VERSION_13F_PRIMARY,
+                source_url=primary_url,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "13F-HR manifest parser: primary_doc store_raw failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"store_raw error: {exc}")
+
+    # Parse primary_doc — single broad-except so unexpected raises
+    # still ingest-log + return raw_status='stored' (rule from #1129).
+    try:
+        info = parse_primary_doc(primary_xml)
+    except Exception as exc:  # noqa: BLE001
+        is_schema = isinstance(exc, (ValueError, ET.ParseError))
+        kind = "primary_doc.xml parse failed" if is_schema else "primary_doc.xml parse failed (unexpected)"
+        logger.exception(
+            "13F-HR manifest parser: primary_doc parse raised accession=%s (unexpected=%s)",
+            accession,
+            not is_schema,
+        )
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    period_of_report=None,
+                    status="failed",
+                    error=f"{kind}: {exc}",
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "13F-HR manifest parser: ingest-log INSERT failed after parse error accession=%s",
+                accession,
+            )
+        return _failed_outcome(f"{kind}: {exc}", raw_status="stored")
+
+    # Step 3: fetch infotable.xml + store_raw inside savepoint.
+    try:
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            infotable_xml = provider.fetch_document_text(infotable_url)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "13F-HR manifest parser: infotable fetch raised accession=%s: %s",
+            accession,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}", raw_status="stored")
+
+    if not infotable_xml:
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    period_of_report=info.period_of_report,
+                    status="failed",
+                    error="infotable.xml fetch failed",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "13F-HR manifest parser: ingest-log INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"log error: {exc}", raw_status="stored")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_13F_HR,
+            raw_status="stored",
+            error="infotable.xml fetch failed",
+        )
+
+    try:
+        with conn.transaction():
+            store_raw(
+                conn,
+                accession_number=accession,
+                document_kind="infotable_13f",
+                payload=infotable_xml,
+                parser_version=_PARSER_VERSION_13F_INFOTABLE,
+                source_url=infotable_url,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "13F-HR manifest parser: infotable store_raw failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"store_raw error: {exc}", raw_status="stored")
+
+    try:
+        holdings: list[ThirteenFHolding] = parse_infotable(infotable_xml)
+    except Exception as exc:  # noqa: BLE001
+        is_schema = isinstance(exc, (ValueError, ET.ParseError))
+        kind = "infotable.xml parse failed" if is_schema else "infotable.xml parse failed (unexpected)"
+        logger.exception(
+            "13F-HR manifest parser: infotable parse raised accession=%s (unexpected=%s)",
+            accession,
+            not is_schema,
+        )
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    period_of_report=info.period_of_report,
+                    status="failed",
+                    error=f"{kind}: {exc}",
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "13F-HR manifest parser: ingest-log INSERT failed after parse error accession=%s",
+                accession,
+            )
+        return _failed_outcome(f"{kind}: {exc}", raw_status="stored")
+
+    # Step 4: upsert filer + holdings + observations + ingest-log.
+    # Single try block so any DB error during the batch returns
+    # ``_failed_outcome(raw_status='stored')`` and stays consistent
+    # with the manifest's view of stored raw bytes. #1131 discrimination
+    # selects transient (retry) vs deterministic (tombstone + ingest-log).
+    period = info.period_of_report
+    filed_at = info.filed_at or (
+        datetime(period.year, period.month, period.day, tzinfo=UTC) if period is not None else row.filed_at
+    )
+    inserted = 0
+    skipped_no_cusip = 0
+    skipped_non_sh = 0
+
+    # VALUE cutover: pre-2023-01-03 filings report Column 4 in
+    # thousands. The bulk dataset path applies this; the per-filing
+    # parser preserves the raw value, so this adapter applies the
+    # transform before passing to ``_upsert_holding``. Skipped if
+    # filed_at unavailable (defensive — would only happen with a
+    # SEC-supplied filing missing both header and submissions-index
+    # timestamps, which the bulk path also fails closed on).
+    needs_thousands_scaling = filed_at is not None and filed_at.date() < _VALUE_DOLLARS_CUTOVER
+
+    try:
+        with conn.transaction():
+            filer_id = _upsert_filer(conn, info)
+
+            # Dedupe by (instrument_id, exposure) to match the DB unique
+            # key collapse — same pattern as the legacy ingester
+            # (institutional_holdings.py:1302).
+            resolved_by_key: dict[tuple[int, str], tuple[int, ThirteenFHolding]] = {}
+            for holding in holdings:
+                # Codex pre-push (#1133): drop PRN (bond principal)
+                # rows so they do not silently land as shares. The
+                # bulk dataset path filters at
+                # sec_13f_dataset_ingest.py:311; per-filing path
+                # historically did NOT, so this is a fix the manifest
+                # adapter inherits. SSHPRNAMTTYPE values are 'SH'
+                # (shares) or 'PRN' (principal-of-bonds, dollars).
+                if holding.shares_or_principal_type != "SH":
+                    skipped_non_sh += 1
+                    continue
+
+                # VALUE cutover transform (see _VALUE_DOLLARS_CUTOVER).
+                if needs_thousands_scaling:
+                    holding = replace(holding, value_usd=holding.value_usd * Decimal("1000"))
+
+                instrument_id = _resolve_cusip_to_instrument_id(conn, holding.cusip)
+                if instrument_id is None:
+                    skipped_no_cusip += 1
+                    _record_unresolved_cusip(
+                        conn,
+                        cusip=holding.cusip,
+                        name_of_issuer=holding.name_of_issuer,
+                        accession_number=accession,
+                    )
+                    continue
+                if _upsert_holding(
+                    conn,
+                    filer_id=filer_id,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    period_of_report=period,
+                    filed_at=filed_at,
+                    holding=holding,
+                ):
+                    inserted += 1
+                exposure_key = holding.put_call if holding.put_call in ("PUT", "CALL") else "EQUITY"
+                resolved_by_key.setdefault((instrument_id, exposure_key), (instrument_id, holding))
+
+            resolved_holdings: list[tuple[int, ThirteenFHolding]] = list(resolved_by_key.values())
+            if resolved_holdings:
+                _record_13f_observations_for_filing(
+                    conn,
+                    filer_id=filer_id,
+                    accession_number=accession,
+                    period_of_report=period,
+                    filed_at=filed_at,
+                    resolved_holdings=resolved_holdings,
+                )
+                for unique_instrument_id in {iid for iid, _ in resolved_holdings}:
+                    refresh_institutions_current(conn, instrument_id=unique_instrument_id)
+
+            total_skipped = skipped_no_cusip + skipped_non_sh
+            status = "partial" if total_skipped > 0 else "success"
+            error_bits: list[str] = []
+            if skipped_no_cusip > 0:
+                error_bits.append(f"{skipped_no_cusip} unresolved CUSIPs (gated by #740 backfill)")
+            if skipped_non_sh > 0:
+                error_bits.append(f"{skipped_non_sh} PRN rows dropped (bond principal, not shares)")
+            log_error = "; ".join(error_bits) if error_bits else None
+            _record_ingest_attempt(
+                conn,
+                filer_cik=filer_cik,
+                accession_number=accession,
+                period_of_report=period,
+                status=status,
+                holdings_inserted=inserted,
+                holdings_skipped=total_skipped,
+                error=log_error,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "13F-HR manifest parser: upsert/observation batch failed accession=%s",
+            accession,
+        )
+        if is_transient_upsert_error(exc):
+            return _failed_outcome(format_upsert_error(exc), raw_status="stored")
+        # Deterministic — write ingest-log 'failed' in a fresh
+        # savepoint then tombstone the manifest.
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    period_of_report=period,
+                    status="failed",
+                    error=format_upsert_error(exc),
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "13F-HR manifest parser: ingest-log INSERT failed after upsert error accession=%s",
+                accession,
+            )
+            return _failed_outcome(
+                f"upsert+log error: {type(exc).__name__}: {exc}",
+                raw_status="stored",
+            )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_13F_HR,
+            raw_status="stored",
+            error=format_upsert_error(exc),
+        )
+
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_PARSER_VERSION_13F_HR,
+        raw_status="stored",
+    )
+
+
+def register() -> None:
+    """Register the 13F-HR parser with the manifest worker.
+
+    Idempotent — ``register_parser`` is last-write-wins. The bulk
+    quarterly path (``sec_13f_dataset_ingest``) continues to handle
+    historical drains in parallel; the manifest path drives
+    atom-discovered freshness one accession at a time.
+    """
+    from app.jobs.sec_manifest_worker import register_parser
+
+    register_parser("sec_13f_hr", _parse_13f_hr, requires_raw_payload=True)

--- a/app/services/manifest_parsers/sec_n_port.py
+++ b/app/services/manifest_parsers/sec_n_port.py
@@ -1,0 +1,425 @@
+"""SEC NPORT-P manifest-worker parser adapter (#873).
+
+NPORT-P is filed monthly by registered investment companies (mutual
+funds, ETFs, closed-end funds) detailing their portfolio holdings.
+The bulk path is the monthly per-CIK ingest in
+``app/services/n_port_ingest.py``; the quarterly dataset job
+(``sec_nport_dataset_ingest``) covers historical backfill. This thin
+manifest adapter handles atom-discovered freshness one accession at
+a time, mirroring ``app/services/manifest_parsers/sec_13f_hr.py``.
+
+ParseOutcome contract:
+
+  * ``status='parsed'`` + ``raw_status='stored'`` — primary_doc.xml
+    persisted; ``sec_fund_series`` upserted; per-holding rows
+    filtered (equity-common only, Long only, NS units only, non-zero
+    shares, resolved CUSIP) and written via ``record_fund_observation``;
+    ``ownership_funds_current`` refreshed per touched instrument; one
+    ``n_port_ingest_log`` row with status='success' / 'partial'.
+  * ``status='tombstoned'`` — primary_doc.xml fetch failed,
+    ``NPortMissingSeriesError`` raised (filing lacks series id), or
+    parse otherwise raised deterministically. ``n_port_ingest_log``
+    records 'failed' so dashboard counts converge.
+  * ``status='failed'`` — transient error (fetch raise, store_raw
+    error, psycopg ``OperationalError`` on upsert). Worker schedules
+    1h backoff retry.
+
+Subject identity (sec-edgar §3.6): NPORT-P is fund-trust-scoped —
+manifest row carries ``subject_type='institutional_filer'``
+(filer-scoped reuse; the trust CIK is the filer) OR
+``subject_type='fund_series'`` depending on discovery path. The
+adapter only requires ``row.cik``; the parser extracts the series
+id from the XML payload.
+
+#1131 discrimination: transient psycopg ``OperationalError`` on the
+observation upsert retries via 1h backoff; deterministic constraint
+violations write the audit-log row with status='failed' and
+tombstone the manifest. See
+``app/services/manifest_parsers/_classify.py``.
+
+Raw-payload invariant (#938): registered with
+``requires_raw_payload=True``; the parser stores the body BEFORE
+parsing so a downstream re-wash can reparse without re-fetching SEC.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.services.manifest_parsers._classify import (
+    format_upsert_error,
+    is_transient_upsert_error,
+)
+from app.services.n_port_ingest import (
+    _PARSER_VERSION_NPORT,
+    NPortMissingSeriesError,
+    NPortParseError,
+    _archive_file_url,
+    _record_ingest_attempt,
+    _resolve_cusip_to_instrument_id,
+    parse_n_port_payload,
+)
+from app.services.ownership_observations import (
+    record_fund_observation,
+    refresh_funds_current,
+    upsert_sec_fund_series,
+)
+from app.services.raw_filings import store_raw
+
+logger = logging.getLogger(__name__)
+
+_FAILED_RETRY_DELAY = timedelta(hours=1)
+
+
+def _failed_outcome(error: str, raw_status: Any = None) -> Any:
+    """Build a ``failed`` ParseOutcome with a 1h backoff applied."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    return ParseOutcome(
+        status="failed",
+        parser_version=_PARSER_VERSION_NPORT,
+        raw_status=raw_status,
+        error=error,
+        next_retry_at=datetime.now(tz=UTC) + _FAILED_RETRY_DELAY,
+    )
+
+
+def _parse_n_port(
+    conn: psycopg.Connection[Any],
+    row: Any,  # ManifestRow — forward-ref to avoid circular import
+) -> Any:  # ParseOutcome — forward-ref
+    """Manifest-worker parser for one NPORT-P / NPORT-P/A accession."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    accession = row.accession_number
+    filer_cik = (row.cik or "").strip()
+
+    if not filer_cik:
+        logger.warning(
+            "n_port manifest parser: accession=%s has no filer cik; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_NPORT,
+            error="missing filer cik",
+        )
+
+    # NPORT-P primary doc lives at the accession's primary_doc.xml.
+    primary_url = _archive_file_url(filer_cik, accession, "primary_doc.xml")
+
+    try:
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            primary_xml = provider.fetch_document_text(primary_url)
+    except Exception as exc:  # noqa: BLE001 — transient fetch errors retry via backoff
+        logger.warning(
+            "n_port manifest parser: fetch raised accession=%s url=%s: %s",
+            accession,
+            primary_url,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}")
+
+    if not primary_xml:
+        # 404 / empty — mirror legacy 'failed' accounting in the
+        # ingest log; manifest itself tombstones so the worker stops
+        # re-fetching a persistently-404 doc.
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    fund_series_id=None,
+                    period_of_report=row.filed_at.date() if row.filed_at else None,
+                    status="failed",
+                    holdings_inserted=0,
+                    holdings_skipped=0,
+                    error="primary_doc.xml fetch failed",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "n_port manifest parser: ingest-log INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"log error: {exc}")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_NPORT,
+            error="primary_doc.xml fetch failed",
+        )
+
+    try:
+        with conn.transaction():
+            store_raw(
+                conn,
+                accession_number=accession,
+                document_kind="nport_xml",
+                payload=primary_xml,
+                parser_version=_PARSER_VERSION_NPORT,
+                source_url=primary_url,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "n_port manifest parser: store_raw failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"store_raw error: {exc}")
+
+    # Parse-phase: NPortMissingSeriesError + NPortParseError are
+    # deterministic — the filing's XML shape itself is the problem.
+    # Tombstone with log entry. Unexpected exceptions also caught so a
+    # parser-crash doesn't leak past the worker's generic handler with
+    # the raw row diverging from the manifest's view.
+    try:
+        parsed = parse_n_port_payload(primary_xml)
+    except NPortMissingSeriesError as exc:
+        log_error = f"missing series: {exc}"
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    fund_series_id=None,
+                    period_of_report=None,
+                    status="failed",
+                    holdings_inserted=0,
+                    holdings_skipped=0,
+                    error=log_error,
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "n_port manifest parser: ingest-log INSERT failed after missing-series accession=%s",
+                accession,
+            )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_NPORT,
+            raw_status="stored",
+            error=log_error,
+        )
+    except Exception as exc:  # noqa: BLE001
+        is_schema = isinstance(exc, NPortParseError)
+        kind = "parse failed" if is_schema else "parse failed (unexpected)"
+        logger.exception(
+            "n_port manifest parser: parse raised accession=%s (unexpected=%s)",
+            accession,
+            not is_schema,
+        )
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    fund_series_id=None,
+                    period_of_report=None,
+                    status="failed",
+                    holdings_inserted=0,
+                    holdings_skipped=0,
+                    error=f"{kind}: {exc}",
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "n_port manifest parser: ingest-log INSERT failed after parse error accession=%s",
+                accession,
+            )
+        return _failed_outcome(f"{kind}: {exc}", raw_status="stored")
+
+    # Upsert phase. Mirror the legacy filter ladder from
+    # ``n_port_ingest._ingest_single_accession``. Wrap the entire
+    # batch in one savepoint so a mid-batch DB error rolls back
+    # partial state, and apply #1131 discrimination on the upsert
+    # exception class.
+    inserted = 0
+    skipped_no_cusip = 0
+    skipped_non_equity = 0
+    skipped_short = 0
+    skipped_non_share_units = 0
+    skipped_zero_shares = 0
+    touched_instruments: set[int] = set()
+    run_id = uuid4()
+
+    if parsed.filed_at is not None:
+        filed_at = parsed.filed_at
+    elif row.filed_at is not None:
+        filed_at = row.filed_at
+    else:
+        filed_at = datetime(parsed.period_end.year, parsed.period_end.month, parsed.period_end.day, tzinfo=UTC)
+
+    try:
+        with conn.transaction():
+            upsert_sec_fund_series(
+                conn,
+                fund_series_id=parsed.series_id,
+                fund_series_name=parsed.series_name,
+                fund_filer_cik=parsed.filer_cik,
+                last_seen_period_end=parsed.period_end,
+            )
+
+            for holding in parsed.holdings:
+                # Apply the equity-common-Long write-side guards as drop
+                # filters BEFORE the helper's value-error raise so the
+                # operator-visible counters stay accurate. Same order as
+                # legacy ingester: non-equity → short → units → zero-shares
+                # → no-cusip (most specific first).
+                if holding.asset_category != "EC":
+                    skipped_non_equity += 1
+                    continue
+                if holding.payoff_profile != "Long":
+                    skipped_short += 1
+                    continue
+                if holding.units != "NS":
+                    skipped_non_share_units += 1
+                    continue
+                if holding.shares is None or holding.shares <= 0:
+                    skipped_zero_shares += 1
+                    continue
+                if not holding.cusip or len(holding.cusip) != 9:
+                    skipped_no_cusip += 1
+                    continue
+                instrument_id = _resolve_cusip_to_instrument_id(conn, holding.cusip)
+                if instrument_id is None:
+                    skipped_no_cusip += 1
+                    continue
+
+                try:
+                    record_fund_observation(
+                        conn,
+                        instrument_id=instrument_id,
+                        fund_series_id=parsed.series_id,
+                        fund_series_name=parsed.series_name,
+                        fund_filer_cik=parsed.filer_cik,
+                        source_document_id=accession,
+                        source_accession=accession,
+                        source_field=None,
+                        source_url=primary_url,
+                        filed_at=filed_at,
+                        period_start=None,
+                        period_end=parsed.period_end,
+                        ingest_run_id=run_id,
+                        shares=holding.shares,
+                        market_value_usd=holding.value_usd,
+                        payoff_profile=holding.payoff_profile,
+                        asset_category=holding.asset_category,
+                    )
+                    inserted += 1
+                    touched_instruments.add(instrument_id)
+                except ValueError:
+                    # Helper-side guard rejected — log + count as
+                    # non-equity (closest existing bucket). The loop
+                    # guards above mirror the helper; reaching this
+                    # branch signals a parser-helper contract drift.
+                    logger.exception(
+                        "n_port manifest parser: helper-side guard rejected holding "
+                        "cik=%s accession=%s cusip=%s (parser-helper contract drift)",
+                        filer_cik,
+                        accession,
+                        holding.cusip,
+                    )
+                    skipped_non_equity += 1
+
+            for unique_instrument_id in touched_instruments:
+                refresh_funds_current(conn, instrument_id=unique_instrument_id)
+
+            total_skipped = (
+                skipped_no_cusip + skipped_non_equity + skipped_short + skipped_non_share_units + skipped_zero_shares
+            )
+            if not parsed.holdings:
+                # Legal-empty NPORT-P — fund holding only cash mid-quarter.
+                status = "success"
+                log_error: str | None = None
+            elif inserted == 0 and total_skipped > 0:
+                # Every parsed holding filtered out.
+                status = "partial"
+                log_error = (
+                    f"all holdings filtered (non-equity={skipped_non_equity}, short={skipped_short}, "
+                    f"non-share-units={skipped_non_share_units}, zero-shares={skipped_zero_shares}, "
+                    f"no-cusip={skipped_no_cusip})"
+                )
+            elif total_skipped > 0:
+                status = "partial"
+                log_error = (
+                    f"non-equity={skipped_non_equity}, short={skipped_short}, "
+                    f"non-share-units={skipped_non_share_units}, zero-shares={skipped_zero_shares}, "
+                    f"no-cusip={skipped_no_cusip}"
+                )
+            else:
+                status = "success"
+                log_error = None
+
+            _record_ingest_attempt(
+                conn,
+                filer_cik=filer_cik,
+                accession_number=accession,
+                fund_series_id=parsed.series_id,
+                period_of_report=parsed.period_end,
+                status=status,
+                holdings_inserted=inserted,
+                holdings_skipped=total_skipped,
+                error=log_error,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "n_port manifest parser: upsert/observation batch failed accession=%s",
+            accession,
+        )
+        if is_transient_upsert_error(exc):
+            return _failed_outcome(format_upsert_error(exc), raw_status="stored")
+        # Deterministic — write ingest-log 'failed' in a fresh savepoint
+        # then tombstone the manifest.
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    fund_series_id=parsed.series_id,
+                    period_of_report=parsed.period_end,
+                    status="failed",
+                    holdings_inserted=0,
+                    holdings_skipped=0,
+                    error=format_upsert_error(exc),
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "n_port manifest parser: ingest-log INSERT failed after upsert error accession=%s",
+                accession,
+            )
+            return _failed_outcome(
+                f"upsert+log error: {type(exc).__name__}: {exc}",
+                raw_status="stored",
+            )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_NPORT,
+            raw_status="stored",
+            error=format_upsert_error(exc),
+        )
+
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_PARSER_VERSION_NPORT,
+        raw_status="stored",
+    )
+
+
+def register() -> None:
+    """Register the NPORT-P parser with the manifest worker.
+
+    Idempotent — ``register_parser`` is last-write-wins. The bulk
+    monthly / quarterly paths continue to handle historical drains
+    in parallel; the manifest path drives atom-discovered freshness
+    one accession at a time.
+    """
+    from app.jobs.sec_manifest_worker import register_parser
+
+    register_parser("sec_n_port", _parse_n_port, requires_raw_payload=True)

--- a/tests/test_manifest_parser_sec_13f_hr.py
+++ b/tests/test_manifest_parser_sec_13f_hr.py
@@ -1,0 +1,761 @@
+"""Tests for the 13F-HR manifest-worker parser adapter (#873).
+
+The bulk path (``app/services/sec_13f_dataset_ingest.py``) handles
+quarterly archive drains; this thin manifest adapter handles
+atom-discovered freshness one accession at a time. Tests cover:
+
+* Happy path: index.json walk → primary_doc.xml + infotable.xml
+  fetch → store_raw twice → parse → upsert filer + holding +
+  observations → ingest-log success.
+* CUSIP unresolved: holding rows skipped, log status='partial'.
+* Tombstone on index.json 404 / empty body.
+* Tombstone on archive index missing primary_doc OR infotable.
+* Tombstone on primary_doc.xml or infotable.xml empty body.
+* Fetch raise → ``failed`` with 1h backoff.
+* Parse-phase exception preserves ``raw_status='stored'``.
+* Deterministic upsert exception tombstones the manifest + writes
+  ingest-log 'failed'.
+* Transient psycopg ``OperationalError`` on upsert retries via 1h
+  backoff (no ingest-log row written so the retry sees a clean slate).
+* Registration: ``register_all_parsers`` wires ``sec_13f_hr``.
+
+The fetch boundary is monkeypatched at
+``SecFilingsProvider.fetch_document_text`` so tests run without
+touching SEC.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+import psycopg
+import pytest
+
+from app.jobs.sec_manifest_worker import (
+    clear_registered_parsers,
+    run_manifest_worker,
+)
+from app.services.sec_manifest import get_manifest_row, record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+_FAKE_PRIMARY_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+  <headerData>
+    <filerInfo>
+      <filer>
+        <credentials>
+          <cik>0001067983</cik>
+        </credentials>
+      </filer>
+      <periodOfReport>09-30-2024</periodOfReport>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPage>
+      <reportCalendarOrQuarter>09-30-2024</reportCalendarOrQuarter>
+      <filingManager>
+        <name>BERKSHIRE HATHAWAY INC</name>
+        <address>
+          <street1>3555 Farnam Street</street1>
+          <city>Omaha</city>
+          <stateOrCountry>NE</stateOrCountry>
+          <zipCode>68131</zipCode>
+        </address>
+      </filingManager>
+    </coverPage>
+    <signatureBlock>
+      <signatureDate>11-14-2024</signatureDate>
+    </signatureBlock>
+  </formData>
+</edgarSubmission>
+"""
+
+
+def _infotable_xml(*, holdings: Iterable[dict[str, str]]) -> str:
+    rows: list[str] = []
+    for h in holdings:
+        rows.append(
+            f"""<infoTable>
+  <nameOfIssuer>{h.get("name", "APPLE INC")}</nameOfIssuer>
+  <titleOfClass>COM</titleOfClass>
+  <cusip>{h["cusip"]}</cusip>
+  <value>{h.get("value", "69900000")}</value>
+  <shrsOrPrnAmt>
+    <sshPrnamt>{h.get("shares", "300000000")}</sshPrnamt>
+    <sshPrnamtType>{h.get("amt_type", "SH")}</sshPrnamtType>
+  </shrsOrPrnAmt>
+  <investmentDiscretion>SOLE</investmentDiscretion>
+  <votingAuthority>
+    <Sole>{h.get("sole", "300000000")}</Sole>
+    <Shared>0</Shared>
+    <None>0</None>
+  </votingAuthority>
+</infoTable>"""
+        )
+    body = "\n  ".join(rows)
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+  {body}
+</informationTable>
+"""
+
+
+def _index_json(*, primary: str | None = "primary_doc.xml", infotable: str | None = "infotable.xml") -> str:
+    items: list[dict[str, str]] = []
+    if primary:
+        items.append({"name": primary, "type": "text", "size": "1234"})
+    if infotable:
+        items.append({"name": infotable, "type": "text", "size": "5678"})
+    items.append({"name": "filing-index-headers.html", "type": "text", "size": "100"})
+    return json.dumps({"directory": {"name": "/Archives/...", "item": items}})
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+
+
+def _seed_cusip_mapping(conn: psycopg.Connection[tuple], *, instrument_id: int, cusip: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cusip', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
+        """,
+        (instrument_id, cusip.upper()),
+    )
+
+
+def _seed_pending_13f_hr(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    filer_cik: str,
+) -> None:
+    """Seed a pending manifest row. 13F-HR is filer-scoped — no
+    instrument_id (issuer linkage resolves per-row by CUSIP)."""
+    record_manifest_entry(
+        conn,
+        accession,
+        cik=filer_cik,
+        form="13F-HR",
+        source="sec_13f_hr",
+        subject_type="institutional_filer",
+        subject_id=filer_cik,
+        instrument_id=None,
+        filed_at=datetime(2024, 11, 14, tzinfo=UTC),
+        primary_document_url=f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/"
+        f"{accession.replace('-', '')}/{accession}-index.htm",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_then_reload():
+    from app.services.manifest_parsers import register_all_parsers
+
+    clear_registered_parsers()
+    register_all_parsers()
+    yield
+    clear_registered_parsers()
+    register_all_parsers()
+
+
+def _patch_fetch_map(monkeypatch: pytest.MonkeyPatch, payloads: dict[str, str | None]) -> list[str]:
+    """Monkeypatch ``SecFilingsProvider.fetch_document_text`` to return
+    payloads keyed by URL. Returns the URL-call list for assertions."""
+    calls: list[str] = []
+
+    from app.providers.implementations import sec_edgar
+
+    def _fake(self, url: str):  # noqa: ARG001
+        calls.append(url)
+        return payloads.get(url)
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _fake)
+    return calls
+
+
+def test_happy_path_parses_both_xmls_and_writes_observations(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifest worker drains a 13F-HR row end-to-end: index → primary
+    → infotable → upsert filer + holding + observation → log success."""
+    iid = 8790001
+    cusip = "037833100"  # AAPL
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip=cusip)
+    accession = "0001067983-25-000001"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+            base + "infotable.xml": _infotable_xml(holdings=[{"cusip": cusip}]),
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "parsed"
+    assert row.raw_status == "stored"
+
+    # Both raw bodies persisted.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT document_kind FROM filing_raw_documents WHERE accession_number = %s ORDER BY document_kind",
+            (accession,),
+        )
+        kinds = [r[0] for r in cur.fetchall()]
+    assert "primary_doc" in kinds
+    assert "infotable_13f" in kinds
+
+    # Holding row persisted.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT instrument_id FROM institutional_holdings WHERE accession_number = %s",
+            (accession,),
+        )
+        holdings = cur.fetchall()
+    assert len(holdings) == 1
+    assert holdings[0][0] == iid
+
+    # Audit log success.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, holdings_inserted FROM institutional_holdings_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None
+    assert log[0] == "success"
+    assert log[1] == 1
+
+
+def test_unresolved_cusip_logs_partial(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No CUSIP→instrument mapping → holding row skipped, log
+    status='partial', tracking row in unresolved_13f_cusips."""
+    accession = "0001067983-25-000002"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+            base + "infotable.xml": _infotable_xml(holdings=[{"cusip": "999999999"}]),
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None and row.ingest_status == "parsed"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, holdings_inserted, holdings_skipped FROM institutional_holdings_ingest_log "
+            "WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None
+    assert log[0] == "partial"
+    assert log[1] == 0
+    assert log[2] == 1
+
+
+def test_index_404_tombstones_with_log(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accession = "0001067983-25-000003"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(monkeypatch, {base + "index.json": None})
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None and row.ingest_status == "tombstoned"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status FROM institutional_holdings_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None and log[0] == "failed"
+
+
+def test_index_missing_primary_doc_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Index found but primary_doc.xml entry absent — deterministic
+    gap; tombstone the manifest + log 'failed'."""
+    accession = "0001067983-25-000004"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(monkeypatch, {base + "index.json": _index_json(primary=None)})
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None and row.ingest_status == "tombstoned"
+    assert row.error is not None and "archive index missing files" in row.error
+
+
+def test_infotable_empty_body_tombstones_preserving_stored_raw(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """primary_doc fetched + stored; infotable returns None → tombstone
+    with raw_status='stored' (primary_doc is already on disk)."""
+    accession = "0001067983-25-000005"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+            base + "infotable.xml": None,
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+    # primary_doc raw row exists.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'primary_doc'",
+            (accession,),
+        )
+        assert cur.fetchone() is not None
+
+
+def test_fetch_exception_marks_failed_with_backoff(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accession = "0001067983-25-000006"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    def _boom(self, url):  # noqa: ARG001
+        raise RuntimeError("network kaput")
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _boom)
+
+    before = datetime.now(tz=UTC)
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None and row.ingest_status == "failed"
+    assert row.error is not None and "fetch error" in row.error
+    assert row.next_retry_at is not None
+    delta = (row.next_retry_at - before).total_seconds()
+    assert 3300 < delta < 3900  # ~1h backoff ± slack
+
+
+def test_parse_phase_exception_preserves_stored_raw_status(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parse of primary_doc raises after store_raw committed → manifest
+    must reflect raw_status='stored' so the next retry sees the stored
+    body (no re-fetch from SEC)."""
+    from app.services.manifest_parsers import sec_13f_hr as parser_module
+
+    accession = "0001067983-25-000007"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+        },
+    )
+
+    def _raising(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic primary_doc parse crash")
+
+    monkeypatch.setattr(parser_module, "parse_primary_doc", _raising)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+
+
+def test_deterministic_upsert_exception_tombstones_with_log(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #1131: a non-transient upsert exception writes an audit-log
+    row with status='failed' + tombstones the manifest."""
+    from app.services.manifest_parsers import sec_13f_hr as parser_module
+
+    iid = 8790010
+    cusip = "037833100"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip=cusip)
+    accession = "0001067983-25-000008"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+            base + "infotable.xml": _infotable_xml(holdings=[{"cusip": cusip}]),
+        },
+    )
+
+    def _raising_upsert(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic 13F-HR upsert violation")
+
+    monkeypatch.setattr(parser_module, "_upsert_holding", _raising_upsert)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    assert stats.failed == 0
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "RuntimeError" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, error FROM institutional_holdings_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None
+    assert log[0] == "failed"
+    assert log[1] is not None and "RuntimeError" in log[1]
+
+
+def test_transient_upsert_exception_retries(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #1131: an ``OperationalError`` on upsert keeps the manifest
+    in ``failed`` with 1h backoff — no ingest-log row, no tombstone."""
+    import psycopg.errors
+
+    from app.services.manifest_parsers import sec_13f_hr as parser_module
+
+    iid = 8790011
+    cusip = "037833100"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip=cusip)
+    accession = "0001067983-25-000009"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+            base + "infotable.xml": _infotable_xml(holdings=[{"cusip": cusip}]),
+        },
+    )
+
+    def _raising_upsert(*args, **kwargs):  # noqa: ARG001
+        raise psycopg.errors.DeadlockDetected("synthetic deadlock")
+
+    monkeypatch.setattr(parser_module, "_upsert_holding", _raising_upsert)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    assert stats.tombstoned == 0
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "DeadlockDetected" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM institutional_holdings_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        # No log row — transient must keep the retry path clean.
+        assert cur.fetchone() is None
+
+
+def test_prn_holdings_dropped_not_written_as_shares(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex pre-push (Finding 1): SSHPRNAMTTYPE='PRN' rows carry
+    bond principal amounts in dollars, NOT share counts. The adapter
+    MUST drop them before write so they don't silently land in
+    ``institutional_holdings.shares``. Mirrors the bulk dataset
+    path's filter at sec_13f_dataset_ingest.py:311."""
+    iid = 8790020
+    cusip_eq = "037833100"
+    # Bond CUSIP intentionally unmapped — the PRN-drop filter rejects
+    # the row before CUSIP resolution, so we don't need a mapping.
+    cusip_bond = "037833555"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip=cusip_eq)
+    accession = "0001067983-25-000020"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+            base + "infotable.xml": _infotable_xml(
+                holdings=[
+                    {"cusip": cusip_eq, "amt_type": "SH", "shares": "1000"},
+                    {"cusip": cusip_bond, "amt_type": "PRN", "shares": "5000000"},
+                ]
+            ),
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    # Only the SH row landed; PRN dropped.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM institutional_holdings WHERE accession_number = %s",
+            (accession,),
+        )
+        rowcount = cur.fetchone()
+    assert rowcount is not None
+    assert rowcount[0] == 1
+
+    # Log status='partial' with the PRN drop count surfaced.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, holdings_inserted, holdings_skipped, error FROM "
+            "institutional_holdings_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None
+    assert log[0] == "partial"
+    assert log[1] == 1
+    assert log[2] == 1  # 1 PRN row skipped
+    assert log[3] is not None and "PRN rows dropped" in log[3]
+
+
+def test_pre_2023_filed_at_scales_value_by_thousand(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex pre-push (Finding 2): pre-2023-01-03 filings reported
+    Column 4 in thousands, post in dollars. SEC EDGAR Release 22.4.1
+    is keyed by filed_at (not period_end) because a pre-cutover
+    restatement filed late carries dollars.
+
+    Test: fixture's signatureDate=11-14-2024 lands the filing
+    post-cutover by default. Patch ``parse_primary_doc`` to return an
+    info whose ``filed_at`` is pre-cutover; assert the value lands
+    1000x the raw XML number."""
+    from datetime import date as date_cls
+    from decimal import Decimal as _Decimal
+
+    from app.providers.implementations.sec_13f import ThirteenFFilerInfo
+    from app.services.manifest_parsers import sec_13f_hr as parser_module
+
+    iid = 8790030
+    cusip = "037833100"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip=cusip)
+    accession = "0001067983-22-000030"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+            base + "infotable.xml": _infotable_xml(
+                holdings=[{"cusip": cusip, "value": "1234"}],  # raw value (would be thousands)
+            ),
+        },
+    )
+
+    pre_cutover_filed_at = datetime(2022, 11, 14, tzinfo=UTC)
+
+    def _fake_primary_doc(_xml: str) -> ThirteenFFilerInfo:
+        return ThirteenFFilerInfo(
+            cik="0001067983",
+            name="BERKSHIRE HATHAWAY INC",
+            period_of_report=date_cls(2022, 9, 30),
+            filed_at=pre_cutover_filed_at,
+            table_value_total_usd=_Decimal("123"),
+        )
+
+    monkeypatch.setattr(parser_module, "parse_primary_doc", _fake_primary_doc)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT market_value_usd FROM institutional_holdings WHERE accession_number = %s",
+            (accession,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    # Pre-cutover raw value 1234 → scaled to 1234 * 1000 = 1_234_000.
+    assert row[0] == _Decimal("1234000")
+
+
+def test_ingest_log_preserves_period_on_failure_after_success(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex pre-push (Finding 3): a failure-row INSERT/UPDATE that
+    carries period_of_report=NULL must NOT erase a previously-known
+    good period_of_report. COALESCE on the ON CONFLICT path keeps the
+    existing value when EXCLUDED is NULL.
+
+    Direct SQL test of the ON CONFLICT semantics — fastest path to
+    pinning the behaviour without staging an end-to-end retry
+    interleave."""
+    from datetime import date as date_cls
+
+    from app.services.institutional_holdings import _record_ingest_attempt
+
+    accession = "0001067983-25-000040"
+    filer_cik = "0001067983"
+
+    # First write: success row with a real period.
+    _record_ingest_attempt(
+        ebull_test_conn,
+        filer_cik=filer_cik,
+        accession_number=accession,
+        period_of_report=date_cls(2024, 9, 30),
+        status="success",
+        holdings_inserted=10,
+        holdings_skipped=0,
+        error=None,
+    )
+    ebull_test_conn.commit()
+
+    # Second write: failure row with period=NULL (e.g. pre-parse
+    # 404 retry). Must not erase the period column.
+    _record_ingest_attempt(
+        ebull_test_conn,
+        filer_cik=filer_cik,
+        accession_number=accession,
+        period_of_report=None,
+        status="failed",
+        error="primary_doc.xml fetch failed",
+    )
+    ebull_test_conn.commit()
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, period_of_report FROM institutional_holdings_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "failed"
+    # The critical assertion: period preserved despite a NULL write.
+    assert row[1] == date_cls(2024, 9, 30)
+
+
+def test_parser_registered_via_register_all() -> None:
+    """``register_all_parsers()`` wires ``sec_13f_hr`` alongside the
+    other manifest parsers."""
+    from app.jobs.sec_manifest_worker import registered_parser_sources
+    from app.services.manifest_parsers import register_all_parsers
+
+    assert "sec_13f_hr" in registered_parser_sources()
+    clear_registered_parsers()
+    assert "sec_13f_hr" not in registered_parser_sources()
+    register_all_parsers()
+    assert "sec_13f_hr" in registered_parser_sources()

--- a/tests/test_manifest_parser_sec_n_port.py
+++ b/tests/test_manifest_parser_sec_n_port.py
@@ -1,0 +1,399 @@
+"""Tests for the NPORT-P manifest-worker parser adapter (#873).
+
+Mirrors ``test_manifest_parser_sec_13f_hr.py`` shape:
+
+* Happy path: primary_doc.xml fetch → store_raw → parse_n_port_payload
+  → series upsert → record_fund_observation per resolvable Long-EC-NS
+  holding → refresh_funds_current → ingest-log success.
+* Tombstone on fetch 404 (audit log 'failed').
+* Tombstone on ``NPortMissingSeriesError`` (audit log 'failed').
+* Tombstone on ``NPortParseError`` (audit log 'failed', raw_status
+  preserved).
+* Fetch raise → ``failed`` with 1h backoff.
+* Deterministic upsert exception → tombstone + audit-log 'failed'.
+* Transient ``OperationalError`` on upsert → ``failed`` with 1h
+  backoff (no audit-log row).
+* Registration: ``register_all_parsers`` wires ``sec_n_port``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from app.jobs.sec_manifest_worker import (
+    clear_registered_parsers,
+    run_manifest_worker,
+)
+from app.services.sec_manifest import get_manifest_row, record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "sec"
+_FAKE_NPORT_XML = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+_FAKE_NPORT_MISSING_SERIES_XML = (_FIXTURE_DIR / "nport_p_missing_series.xml").read_text(encoding="utf-8")
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+
+
+def _seed_cusip_mapping(conn: psycopg.Connection[tuple], *, instrument_id: int, cusip: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cusip', %s, TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
+        """,
+        (instrument_id, cusip.upper()),
+    )
+
+
+def _seed_pending_n_port(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    filer_cik: str,
+) -> None:
+    record_manifest_entry(
+        conn,
+        accession,
+        cik=filer_cik,
+        form="NPORT-P",
+        source="sec_n_port",
+        subject_type="institutional_filer",
+        subject_id=filer_cik,
+        instrument_id=None,
+        filed_at=datetime(2026, 2, 26, tzinfo=UTC),
+        primary_document_url=f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/"
+        f"{accession.replace('-', '')}/primary_doc.xml",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_then_reload():
+    from app.services.manifest_parsers import register_all_parsers
+
+    clear_registered_parsers()
+    register_all_parsers()
+    yield
+    clear_registered_parsers()
+    register_all_parsers()
+
+
+def _patch_fetch_map(monkeypatch: pytest.MonkeyPatch, payloads: dict[str, str | None]) -> list[str]:
+    calls: list[str] = []
+    from app.providers.implementations import sec_edgar
+
+    def _fake(self, url: str):  # noqa: ARG001
+        calls.append(url)
+        return payloads.get(url)
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _fake)
+    return calls
+
+
+def test_happy_path_parses_and_writes_fund_observation(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifest worker drains an NPORT-P pending row: fetch →
+    store_raw → parse → series upsert → fund observation per
+    resolvable Long-EC-NS holding → log success."""
+    iid_aapl = 8800001
+    _seed_instrument(ebull_test_conn, iid=iid_aapl, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid_aapl, cusip="037833100")
+    accession = "0001234500-25-000603"
+    filer_cik = "0000036405"
+    _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    primary_url = (
+        f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/primary_doc.xml"
+    )
+    _patch_fetch_map(monkeypatch, {primary_url: _FAKE_NPORT_XML})
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_n_port", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "parsed"
+    assert row.raw_status == "stored"
+
+    # raw body persisted under document_kind='nport_xml'.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'nport_xml'",
+            (accession,),
+        )
+        assert cur.fetchone() is not None
+
+    # Series row persisted.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT fund_filer_cik FROM sec_fund_series WHERE fund_series_id = 'S000002277'")
+        series = cur.fetchone()
+    assert series is not None and series[0] == filer_cik
+
+    # AAPL fund observation persisted.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT instrument_id FROM ownership_funds_observations WHERE source_accession = %s AND instrument_id = %s",
+            (accession, iid_aapl),
+        )
+        assert cur.fetchone() is not None
+
+    # Ingest log success/partial.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status FROM n_port_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None
+    # The golden fixture has 7 holdings; only 1 CUSIP (AAPL) resolves
+    # in this minimal seed. Others land in skipped buckets → partial.
+    assert log[0] in ("success", "partial")
+
+
+def test_fetch_404_tombstones_with_log(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accession = "0001234500-25-000700"
+    filer_cik = "0000036405"
+    _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    primary_url = (
+        f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/primary_doc.xml"
+    )
+    _patch_fetch_map(monkeypatch, {primary_url: None})
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_n_port", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None and row.ingest_status == "tombstoned"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, error FROM n_port_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None
+    assert log[0] == "failed"
+    assert log[1] is not None and "primary_doc.xml fetch failed" in log[1]
+
+
+def test_missing_series_tombstones_with_log(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accession = "0001234500-25-000701"
+    filer_cik = "0000036405"
+    _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    primary_url = (
+        f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/primary_doc.xml"
+    )
+    _patch_fetch_map(monkeypatch, {primary_url: _FAKE_NPORT_MISSING_SERIES_XML})
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_n_port", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "missing series" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, error FROM n_port_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None and log[0] == "failed"
+
+
+def test_malformed_xml_tombstones_with_log(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accession = "0001234500-25-000702"
+    filer_cik = "0000036405"
+    _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    primary_url = (
+        f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/primary_doc.xml"
+    )
+    _patch_fetch_map(monkeypatch, {primary_url: "<not><well><formed>"})
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_n_port", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    # NPortParseError leads to _failed_outcome (transient bucket per
+    # the parse-phase preserve-raw policy), not tombstone. raw_status
+    # is preserved as 'stored'.
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+
+
+def test_fetch_exception_marks_failed_with_backoff(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accession = "0001234500-25-000703"
+    filer_cik = "0000036405"
+    _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    def _boom(self, url):  # noqa: ARG001
+        raise RuntimeError("network kaput")
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _boom)
+
+    before = datetime.now(tz=UTC)
+    stats = run_manifest_worker(ebull_test_conn, source="sec_n_port", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.error is not None and "fetch error" in row.error
+    assert row.next_retry_at is not None
+    delta = (row.next_retry_at - before).total_seconds()
+    assert 3300 < delta < 3900
+
+
+def test_deterministic_upsert_exception_tombstones_with_log(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #1131: a non-transient observation upsert exception
+    tombstones the manifest + writes ingest-log 'failed'."""
+    from app.services.manifest_parsers import sec_n_port as parser_module
+
+    iid = 8800010
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip="037833100")
+    accession = "0001234500-25-000704"
+    filer_cik = "0000036405"
+    _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    primary_url = (
+        f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/primary_doc.xml"
+    )
+    _patch_fetch_map(monkeypatch, {primary_url: _FAKE_NPORT_XML})
+
+    def _raising(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic n_port observation upsert violation")
+
+    monkeypatch.setattr(parser_module, "record_fund_observation", _raising)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_n_port", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    assert stats.failed == 0
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "RuntimeError" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, error FROM n_port_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None
+    assert log[0] == "failed"
+    assert log[1] is not None and "RuntimeError" in log[1]
+
+
+def test_transient_upsert_exception_retries(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #1131: ``OperationalError`` on the observation upsert keeps
+    the manifest in ``failed`` with 1h backoff — no audit-log row."""
+    import psycopg.errors
+
+    from app.services.manifest_parsers import sec_n_port as parser_module
+
+    iid = 8800011
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip="037833100")
+    accession = "0001234500-25-000705"
+    filer_cik = "0000036405"
+    _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    primary_url = (
+        f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/primary_doc.xml"
+    )
+    _patch_fetch_map(monkeypatch, {primary_url: _FAKE_NPORT_XML})
+
+    def _raising(*args, **kwargs):  # noqa: ARG001
+        raise psycopg.errors.SerializationFailure("synthetic serialisation failure")
+
+    monkeypatch.setattr(parser_module, "record_fund_observation", _raising)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_n_port", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    assert stats.tombstoned == 0
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "SerializationFailure" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM n_port_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        assert cur.fetchone() is None
+
+
+def test_parser_registered_via_register_all() -> None:
+    from app.jobs.sec_manifest_worker import registered_parser_sources
+    from app.services.manifest_parsers import register_all_parsers
+
+    assert "sec_n_port" in registered_parser_sources()
+    clear_registered_parsers()
+    assert "sec_n_port" not in registered_parser_sources()
+    register_all_parsers()
+    assert "sec_n_port" in registered_parser_sources()

--- a/tests/test_manifest_parser_sec_n_port.py
+++ b/tests/test_manifest_parser_sec_n_port.py
@@ -7,8 +7,9 @@ Mirrors ``test_manifest_parser_sec_13f_hr.py`` shape:
   holding → refresh_funds_current → ingest-log success.
 * Tombstone on fetch 404 (audit log 'failed').
 * Tombstone on ``NPortMissingSeriesError`` (audit log 'failed').
-* Tombstone on ``NPortParseError`` (audit log 'failed', raw_status
-  preserved).
+* Malformed XML raises ``NPortParseError`` — returns ``failed`` with
+  ``raw_status='stored'`` (NOT tombstoned, since a future amendment
+  or parser-version bump could resolve).
 * Fetch raise → ``failed`` with 1h backoff.
 * Deterministic upsert exception → tombstone + audit-log 'failed'.
 * Transient ``OperationalError`` on upsert → ``failed`` with 1h
@@ -236,10 +237,17 @@ def test_missing_series_tombstones_with_log(
     assert log is not None and log[0] == "failed"
 
 
-def test_malformed_xml_tombstones_with_log(
+def test_malformed_xml_marks_failed_preserving_raw_status(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Malformed XML raises ``NPortParseError`` AFTER ``store_raw``
+    committed. The parser returns ``_failed_outcome(raw_status='stored')``
+    so the worker retries on backoff (XML malformation could be
+    transient if a follow-up amendment lands) and the manifest's
+    ``raw_status`` matches the stored body. NOT tombstoned —
+    deliberate, because a parser-version bump or a future amendment
+    could resolve the parse failure."""
     accession = "0001234500-25-000702"
     filer_cik = "0000036405"
     _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
@@ -256,9 +264,6 @@ def test_malformed_xml_tombstones_with_log(
     assert stats.failed == 1
     row = get_manifest_row(ebull_test_conn, accession)
     assert row is not None
-    # NPortParseError leads to _failed_outcome (transient bucket per
-    # the parse-phase preserve-raw policy), not tombstone. raw_status
-    # is preserved as 'stored'.
     assert row.ingest_status == "failed"
     assert row.raw_status == "stored"
 


### PR DESCRIPTION
Refs #873.

## What

Two thin manifest-worker parser adapters that delegate to existing parsers + writers:

- **13F-HR** (`app/services/manifest_parsers/sec_13f_hr.py`) — index.json walk → primary_doc.xml + infotable.xml fetch + parse → institutional_filers + institutional_holdings upsert + observations write-through. Composite parser_version covers both primary_doc + infotable watermarks. Drops PRN (bond-principal) rows. Applies 2023-01-03 VALUE-in-thousands cutover via filed_at branch (mirrors bulk dataset path).
- **NPORT-P** (`app/services/manifest_parsers/sec_n_port.py`) — primary_doc.xml fetch + parse → sec_fund_series + record_fund_observation per Long-EC-NS holding with resolved CUSIP. Legacy filter ladder (non-equity / short / non-share-units / zero-shares / no-cusip) replicated inline so the operator-visible counters stay accurate.

Both apply #1131 transient/deterministic discrimination on the upsert phase. Both register via `app/services/manifest_parsers/__init__.py::register_all_parsers`.

Side fix: `institutional_holdings_ingest_log` ON CONFLICT now COALESCEs `period_of_report` so a pre-parse failure-row write does not erase a previously-known good period (Codex Finding 3).

## Why

Bulk paths (`sec_13f_dataset_ingest`, `n_port_ingest.ingest_fund_n_port`) handle quarterly/monthly drains. Manifest path drives atom-discovered freshness one accession at a time — fast turn-around for newly-filed accessions without waiting for the next bulk window.

## Test plan

- [x] 10 13F-HR tests (happy path, fetch 404, index missing primary, infotable empty, fetch raise, parse-phase exception, deterministic + transient upsert, PRN drop, VALUE cutover, ingest-log period preservation, registration).
- [x] 8 NPORT-P tests (happy path, fetch 404, missing series, malformed XML, fetch raise, deterministic + transient upsert, registration).
- [x] `uv run ruff check .` / `ruff format --check .` / `uv run pyright` all green.
- [x] Codex pre-push round 1 caught 3 findings (PRN drop, VALUE cutover, period_of_report ON CONFLICT) — all fixed inline. Re-review pending.
- [ ] Operator follow-up after merge: atom-discovered 13F-HR + NPORT-P will start landing through the manifest worker; verify on `/coverage/manifest-parsers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)