### PR TITLE
feat(#873): manifest-worker Form 5 parser adapter

### DIFF
--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -62,6 +62,12 @@ from app.services.ownership_observations import (
 from app.services.sec_identity import siblings_for_issuer_cik
 
 _PARSER_VERSION_FORM4 = "form4-v1"
+# Form 5 (annual statement of changes in beneficial ownership) reuses the
+# Form 4 ownership XML schema. parse_form_5_xml returns the same
+# ParsedFiling shape; the only delta is the documentType gate. Separate
+# manifest parser_version string lets the worker route Form 5 backlog
+# through ``rewash`` independently from Form 4.
+_PARSER_VERSION_FORM5 = "form5-v1"
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +268,107 @@ def parse_form_4_xml(raw_xml: str) -> ParsedFiling | None:
     # Default filer_cik for transactions = first listed reporting
     # owner. Joint filings list all owners at filing-scope but don't
     # attribute individual transactions in the XML.
+    default_filer_cik = filers[0].filer_cik
+
+    transactions = _extract_transactions(root, default_filer_cik=default_filer_cik)
+
+    if not transactions:
+        return None
+
+    remarks = _text(root.find("./remarks"))
+    owner_sig = root.find("./ownerSignature")
+    signature_name = _text(owner_sig.find("./signatureName")) if owner_sig is not None else None
+    signature_date = _date(_text(owner_sig.find("./signatureDate"))) if owner_sig is not None else None
+
+    return ParsedFiling(
+        document_type=document_type,
+        period_of_report=period_of_report,
+        date_of_original_submission=date_of_original_submission,
+        not_subject_to_section_16=not_subject_to_section_16,
+        form3_holdings_reported=form3_holdings_reported,
+        form4_transactions_reported=form4_transactions_reported,
+        issuer_cik=issuer_cik,
+        issuer_name=issuer_name,
+        issuer_trading_symbol=issuer_trading_symbol,
+        remarks=remarks,
+        signature_name=signature_name,
+        signature_date=signature_date,
+        filers=filers,
+        footnotes=footnotes,
+        transactions=transactions,
+    )
+
+
+def parse_form_5_xml(raw_xml: str) -> ParsedFiling | None:
+    """Extract the structured transaction list from a Form 5 primary
+    document.
+
+    Form 5 is the annual statement of changes in beneficial ownership
+    (Rule 16a-3(f)) and uses the SAME EDGAR ownership XML schema as
+    Form 4. The parser shape mirrors :func:`parse_form_4_xml` byte-for-
+    byte except for the ``documentType`` gate. ``ParsedFiling`` is
+    intentionally the same dataclass — Form 5 transactions persist into
+    the same ``insider_filings`` + ``insider_transactions`` tables with
+    ``document_type='5'`` recording the provenance.
+
+    Form 5 holdings (the optional year-end balance reconciliation
+    section) are out of scope for this PR. The annual sections most
+    operators use are the late-Form-4 transactions in
+    ``<nonDerivativeTable>/<nonDerivativeTransaction>`` /
+    ``<derivativeTable>/<derivativeTransaction>``, which this parser
+    handles. A filing carrying ONLY holdings sections returns
+    ``None`` — the manifest adapter then writes a tombstone so the
+    worker stops re-fetching the same payload every tick.
+
+    Returns ``None`` when:
+
+    - Input is empty or fails to parse as XML.
+    - Document root is not ``ownershipDocument``.
+    - ``documentType`` is not ``5`` or ``5/A``.
+    - Zero reporting owners.
+    - Zero transactions across both the non-derivative and derivative
+      tables.
+
+    Observations: Form 5 transactions write through with
+    ``source='form4'``. The shared ``OwnershipSource`` enum on
+    ``ownership_*_observations`` does NOT include a ``form5`` value
+    (CHECK constraint, see sql/113-116); the operator-visible
+    provenance is preserved on ``insider_filings.document_type='5'``
+    via the JOIN at read time. Treating Form 5 transactions as Form 4
+    in the priority chain is correct semantically — they ARE late
+    Form 4 trades surfaced annually.
+    """
+    if not raw_xml:
+        return None
+    cleaned_xml = _XMLNS_RE.sub("", raw_xml)
+    try:
+        root = ET.fromstring(cleaned_xml)
+    except ET.ParseError:
+        return None
+
+    if _localname(root.tag) != "ownershipDocument":
+        return None
+
+    document_type = _text(root.find("./documentType")) or "5"
+    if document_type not in ("5", "5/A"):
+        return None
+
+    period_of_report = _date(_text(root.find("./periodOfReport")))
+    date_of_original_submission = _date(_text(root.find("./dateOfOriginalSubmission")))
+    not_subject_to_section_16 = _flag(_text(root.find("./notSubjectToSection16")))
+    form3_holdings_reported = _flag(_text(root.find("./form3HoldingsReported")))
+    form4_transactions_reported = _flag(_text(root.find("./form4TransactionsReported")))
+
+    issuer_el = root.find("./issuer")
+    issuer_cik = _text(issuer_el.find("./issuerCik")) if issuer_el is not None else None
+    issuer_name = _text(issuer_el.find("./issuerName")) if issuer_el is not None else None
+    issuer_trading_symbol = _text(issuer_el.find("./issuerTradingSymbol")) if issuer_el is not None else None
+
+    filers = _extract_filers(root)
+    if not filers:
+        return None
+
+    footnotes = _extract_footnotes(root)
     default_filer_cik = filers[0].filer_cik
 
     transactions = _extract_transactions(root, default_filer_cik=default_filer_cik)
@@ -1305,7 +1412,7 @@ def _primary_filer_role(parsed: ParsedFiling, cik: str | None) -> str | None:
 # ---------------------------------------------------------------------
 
 
-_TOMBSTONE_DOC_TYPE = "4"  # keep shape legal even for tombstones
+_TOMBSTONE_DOC_TYPE = "4"  # default keeps Form 4 callers untouched
 
 
 def _write_tombstone(
@@ -1314,6 +1421,7 @@ def _write_tombstone(
     instrument_id: int,
     accession_number: str,
     primary_document_url: str,
+    document_type: str = _TOMBSTONE_DOC_TYPE,
 ) -> None:
     """Mark an accession as unfetchable / unparseable at the filing
     level so the next ingester pass skips it.
@@ -1322,7 +1430,12 @@ def _write_tombstone(
     children. The reader excludes them via ``is_tombstone = FALSE``
     in the summary query. A re-parse that succeeds for the same
     accession flips the row back to live via the ON CONFLICT DO
-    UPDATE branch of :func:`upsert_filing`."""
+    UPDATE branch of :func:`upsert_filing`.
+
+    ``document_type`` is plumbed so Form 5 tombstones land with
+    ``document_type='5'`` (vs the legacy Form 4 default). Operator
+    audits filtering by ``document_type`` shouldn't see Form 5
+    failures misattributed to Form 4."""
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -1335,7 +1448,7 @@ def _write_tombstone(
             (
                 accession_number,
                 instrument_id,
-                _TOMBSTONE_DOC_TYPE,
+                document_type,
                 primary_document_url,
                 _PARSER_VERSION,
             ),

--- a/app/services/manifest_parsers/__init__.py
+++ b/app/services/manifest_parsers/__init__.py
@@ -49,7 +49,7 @@ def register_all_parsers() -> None:
     _eight_k.register()
     _def14a.register()
     _sec_13dg.register()  # registers BOTH sec_13d and sec_13g
-    _insider_345.register()  # registers sec_form3 + sec_form4 (Form 5 NYI)
+    _insider_345.register()  # registers sec_form3 + sec_form4 + sec_form5
     _sec_13f_hr.register()
     _sec_n_port.register()
 

--- a/app/services/manifest_parsers/insider_345.py
+++ b/app/services/manifest_parsers/insider_345.py
@@ -1,18 +1,25 @@
-"""Form 3 / Form 4 manifest-worker parser adapter (#873).
+"""Form 3 / Form 4 / Form 5 manifest-worker parser adapter (#873).
 
-Wraps the existing ``parse_form_3_xml`` / ``parse_form_4_xml`` + the
-matching upsert paths into the manifest-worker ``ParserFn`` contract.
-One callable is registered against each source — Form 3 and Form 4
-share the EDGAR ownership XML namespace but persist into different
-tables (``insider_initial_holdings`` vs ``insider_transactions``)
-and have separate parser_version watermarks, so they are kept as two
-sibling callables (not merged into one dispatch).
+Wraps ``parse_form_3_xml`` / ``parse_form_4_xml`` / ``parse_form_5_xml``
++ the matching upsert paths into the manifest-worker ``ParserFn``
+contract. Three callables registered against three sources — they
+share the EDGAR ownership XML namespace but Form 3 persists snapshot
+holdings into ``insider_initial_holdings`` while Form 4 / Form 5
+persist transactions into ``insider_transactions``. Separate
+parser_version watermarks let rewash target each form independently.
 
-Form 5 (annual statement of changes in beneficial ownership) is
-NOT covered by this PR — the legacy ingester does not parse Form 5
-and adding it requires a Form 5 parser + upsert path. Form 5
-manifest rows continue to skip with ``no parser`` until the
-legacy support lands.
+Form 5 (annual statement of changes in beneficial ownership, Rule
+16a-3(f)) shares the Form 4 ownership XML schema. The annual filing
+mainly captures late-reported Form 4 transactions; persistence reuses
+``insider_filings`` (with ``document_type='5'`` recording provenance)
+and ``insider_transactions``. Observation write-through emits
+``source='form4'`` since the ``OwnershipSource`` enum on the
+observations CHECK constraint does not include ``form5``;
+operator-visible provenance is preserved on ``insider_filings`` via
+the document_type JOIN. The optional Form 5 year-end holdings
+reconciliation section is out of scope — those filings return
+``None`` from the parser and tombstone via the standard manifest
+adapter path.
 
 ParseOutcome contract:
 
@@ -61,10 +68,12 @@ from app.services.insider_form3_ingest import (
 )
 from app.services.insider_transactions import (
     _PARSER_VERSION_FORM4,
+    _PARSER_VERSION_FORM5,
     _canonical_form_4_url,
     _write_tombstone,
     parse_form_3_xml,
     parse_form_4_xml,
+    parse_form_5_xml,
     upsert_filing,
 )
 from app.services.manifest_parsers._classify import (
@@ -498,14 +507,215 @@ def _parse_form3(
     )
 
 
-def register() -> None:
-    """Register Form 3 + Form 4 parsers with the manifest worker.
+def _parse_form5(
+    conn: psycopg.Connection[Any],
+    row: Any,  # ManifestRow
+) -> Any:  # ParseOutcome
+    """Manifest-worker parser for one Form 5 / 5/A accession.
 
-    Form 5 is intentionally NOT registered — the legacy ingester
-    has no Form 5 parser; Form 5 manifest rows continue to skip
-    until upstream support lands.
+    Same shape as ``_parse_form4`` but routes through
+    ``parse_form_5_xml``. Persistence reuses ``upsert_filing`` so the
+    transactions land in ``insider_transactions`` and the parent row
+    in ``insider_filings`` carries ``document_type='5'``. Tombstones
+    pass ``document_type='5'`` to ``_write_tombstone`` so operator
+    audits filtering by document_type see Form 5 failures distinctly.
+
+    ``document_kind='form5_xml'`` keeps the raw body distinct from
+    Form 4 in ``filing_raw_documents`` — a future Form 5 parser-
+    version bump rewashes only Form 5 rows.
     """
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    accession = row.accession_number
+    instrument_id = row.instrument_id
+    url = row.primary_document_url
+
+    if instrument_id is None:
+        logger.warning(
+            "form5 manifest parser: accession=%s has no instrument_id; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM5,
+            error="missing instrument_id",
+        )
+    if not url:
+        logger.warning(
+            "form5 manifest parser: accession=%s has no primary_document_url; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM5,
+            error="missing primary_document_url",
+        )
+
+    # SEC XSL-rendering prefix strip — Atom discovery may carry the
+    # rendered URL. ``_canonical_form_4_url`` matches any of the
+    # ``/xslF345Xnn/`` prefixes used by Forms 3/4/5 (shared XSL).
+    canonical_url = _canonical_form_4_url(url)
+
+    try:
+        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+            xml = provider.fetch_document_text(canonical_url)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "form5 manifest parser: fetch raised accession=%s url=%s: %s",
+            accession,
+            canonical_url,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}", parser_version=_PARSER_VERSION_FORM5)
+
+    if not xml:
+        try:
+            with conn.transaction():
+                _write_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                    document_type="5",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "form5 manifest parser: tombstone INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"tombstone error: {exc}", parser_version=_PARSER_VERSION_FORM5)
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM5,
+            error="empty or non-200 fetch",
+        )
+
+    try:
+        with conn.transaction():
+            store_raw(
+                conn,
+                accession_number=accession,
+                document_kind="form5_xml",
+                payload=xml,
+                parser_version=_PARSER_VERSION_FORM5,
+                source_url=canonical_url,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "form5 manifest parser: store_raw failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"store_raw error: {exc}", parser_version=_PARSER_VERSION_FORM5)
+
+    try:
+        parsed = parse_form_5_xml(xml)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "form5 manifest parser: parse raised accession=%s",
+            accession,
+        )
+        try:
+            with conn.transaction():
+                _write_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                    document_type="5",
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "form5 manifest parser: tombstone INSERT failed after parse error accession=%s",
+                accession,
+            )
+        return _failed_outcome(f"parse error: {exc}", parser_version=_PARSER_VERSION_FORM5, raw_status="stored")
+
+    if parsed is None:
+        try:
+            with conn.transaction():
+                _write_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                    document_type="5",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "form5 manifest parser: tombstone INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"tombstone error: {exc}", parser_version=_PARSER_VERSION_FORM5, raw_status="stored")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM5,
+            raw_status="stored",
+            error="parser returned None (malformed XML, wrong document_type, or holdings-only filing)",
+        )
+
+    try:
+        with conn.transaction():
+            upsert_filing(
+                conn,
+                instrument_id=instrument_id,
+                accession_number=accession,
+                primary_document_url=canonical_url,
+                parsed=parsed,
+            )
+    except Exception as exc:  # noqa: BLE001
+        # PR #1131 discrimination: transient ``OperationalError`` →
+        # 1h retry; deterministic constraint violation → tombstone so
+        # the worker stops re-fetching a permanently broken accession.
+        logger.exception(
+            "form5 manifest parser: upsert failed accession=%s",
+            accession,
+        )
+        if is_transient_upsert_error(exc):
+            return _failed_outcome(
+                format_upsert_error(exc),
+                parser_version=_PARSER_VERSION_FORM5,
+                raw_status="stored",
+            )
+        try:
+            with conn.transaction():
+                _write_tombstone(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession_number=accession,
+                    primary_document_url=canonical_url,
+                    document_type="5",
+                )
+        except Exception:  # noqa: BLE001 — tombstone failure shouldn't mask upsert failure
+            logger.exception(
+                "form5 manifest parser: tombstone INSERT failed after upsert error accession=%s",
+                accession,
+            )
+            return _failed_outcome(
+                f"upsert+tombstone error: {type(exc).__name__}: {exc}",
+                parser_version=_PARSER_VERSION_FORM5,
+                raw_status="stored",
+            )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_FORM5,
+            raw_status="stored",
+            error=format_upsert_error(exc),
+        )
+
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_PARSER_VERSION_FORM5,
+        raw_status="stored",
+    )
+
+
+def register() -> None:
+    """Register Form 3 + Form 4 + Form 5 parsers with the manifest
+    worker. All three share the EDGAR ownership XML schema but route
+    to distinct typed-table writes and carry independent
+    parser_version watermarks."""
     from app.jobs.sec_manifest_worker import register_parser
 
     register_parser("sec_form4", _parse_form4, requires_raw_payload=True)
     register_parser("sec_form3", _parse_form3, requires_raw_payload=True)
+    register_parser("sec_form5", _parse_form5, requires_raw_payload=True)

--- a/app/services/ownership_drillthrough.py
+++ b/app/services/ownership_drillthrough.py
@@ -281,7 +281,13 @@ def _form4_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
     pre-push review caught the prior version which counted
     ``insider_filings`` HEADERS (one per accession), giving the
     wrong "typed rows" count by orders of magnitude on busy
-    insiders."""
+    insiders.
+
+    Form 5 (annual statement) shares the ``insider_transactions``
+    table with ``document_type='5'``; both forms are included in the
+    counts so the operator-visible "insider transactions" pipeline
+    matches what's actually on file. Form 3 (initial holdings) lives
+    in ``insider_initial_holdings`` and gets its own pipeline state."""
     notes: list[str] = []
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         # Per-#1117 PR-B: insider_transactions + insider_filings are
@@ -294,7 +300,7 @@ def _form4_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
             SELECT COUNT(*) AS row_count, MAX(f.period_of_report) AS latest_period
             FROM insider_transactions t
             JOIN insider_filings f ON f.accession_number = t.accession_number
-            WHERE f.document_type = '4'
+            WHERE f.document_type IN ('4', '5', '5/A')
               AND f.is_tombstone = FALSE
               AND EXISTS (
                   SELECT 1 FROM filing_events fe
@@ -311,7 +317,7 @@ def _form4_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
             """
             SELECT COUNT(*) AS tombstone_count
             FROM insider_filings i
-            WHERE i.document_type = '4'
+            WHERE i.document_type IN ('4', '5', '5/A')
               AND i.is_tombstone = TRUE
               AND EXISTS (
                   SELECT 1 FROM filing_events fe
@@ -329,7 +335,7 @@ def _form4_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
             SELECT COUNT(DISTINCT r.accession_number) AS body_count
             FROM filing_raw_documents r
             JOIN insider_filings i ON i.accession_number = r.accession_number
-            WHERE r.document_kind = 'form4_xml'
+            WHERE r.document_kind IN ('form4_xml', 'form5_xml')
               AND i.is_tombstone = FALSE
               AND EXISTS (
                   SELECT 1 FROM filing_events fe
@@ -343,7 +349,7 @@ def _form4_state(conn: psycopg.Connection[Any], instrument_id: int) -> PipelineS
         body = cur.fetchone() or {"body_count": 0}
 
     if rows["row_count"] == 0:
-        notes.append("no Form 4 transactions")
+        notes.append("no Form 4/5 transactions")
     if tomb["tombstone_count"]:
         notes.append(f"{tomb['tombstone_count']} tombstoned filing(s)")
     if body["body_count"] and not rows["row_count"]:

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -61,6 +61,7 @@ DocumentKind = Literal[
     "primary_doc_13dg",
     "form4_xml",
     "form3_xml",
+    "form5_xml",
     "def14a_body",
     "nport_xml",
 ]

--- a/sql/146_filing_raw_documents_add_form5_xml.sql
+++ b/sql/146_filing_raw_documents_add_form5_xml.sql
@@ -1,0 +1,35 @@
+-- 146_filing_raw_documents_add_form5_xml.sql
+--
+-- Issue #873 — manifest-worker Form 5 parser adapter.
+--
+-- Adds the ``form5_xml`` document_kind to ``filing_raw_documents`` so the
+-- Form 5 manifest parser can persist the raw XML body distinctly from the
+-- Form 4 / Form 3 bodies. Mirrors the precedent set by sql/122 for N-PORT:
+-- a distinct kind keeps the re-wash targeting query simple — a future
+-- parser-version bump on Form 5 walks only ``form5_xml`` rows instead of
+-- filtering across the shared Form 4 set.
+--
+-- Form 5 (annual statement of changes in beneficial ownership) uses the
+-- same EDGAR ownership XML schema as Form 4. Persistence reuses
+-- ``insider_filings`` + ``insider_transactions`` with ``document_type='5'``;
+-- only the raw body kind needs its own enum slot.
+
+BEGIN;
+
+ALTER TABLE filing_raw_documents
+    DROP CONSTRAINT IF EXISTS filing_raw_documents_document_kind_check;
+
+ALTER TABLE filing_raw_documents
+    ADD CONSTRAINT filing_raw_documents_document_kind_check
+    CHECK (document_kind IN (
+        'primary_doc',
+        'infotable_13f',
+        'primary_doc_13dg',
+        'form4_xml',
+        'form3_xml',
+        'form5_xml',
+        'def14a_body',
+        'nport_xml'
+    ));
+
+COMMIT;

--- a/tests/test_insider_transactions.py
+++ b/tests/test_insider_transactions.py
@@ -23,6 +23,7 @@ from app.services.insider_transactions import (
     _canonical_form_4_url,
     filer_role_string,
     parse_form_4_xml,
+    parse_form_5_xml,
 )
 
 
@@ -635,3 +636,147 @@ class TestFilerRoleString:
 
     def test_no_flags_returns_none(self) -> None:
         assert filer_role_string(self._filer()) is None
+
+
+def _wrap_form5(inner_body: str, *, document_type: str = "5") -> str:
+    return f"""<?xml version="1.0"?>
+<ownershipDocument>
+  <documentType>{document_type}</documentType>
+  <periodOfReport>2025-12-31</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000005</rptOwnerCik>
+      <rptOwnerName>Form Five Filer</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isDirector>1</isDirector>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  {inner_body}
+</ownershipDocument>
+"""
+
+
+_FORM5_GIFT_TXN = """
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <securityTitle><value>Common Stock</value></securityTitle>
+      <transactionDate><value>2025-11-15</value></transactionDate>
+      <transactionCoding>
+        <transactionCode>G</transactionCode>
+      </transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>500</value></transactionShares>
+        <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>4500</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+"""
+
+
+class TestParseForm5Xml:
+    """parse_form_5_xml mirrors parse_form_4_xml structurally — the
+    same EDGAR ownership XML schema, the same ParsedFiling shape. The
+    documentType gate is the only delta."""
+
+    def test_basic_form5_gift_transaction(self) -> None:
+        parsed = parse_form_5_xml(_wrap_form5(_FORM5_GIFT_TXN))
+        assert parsed is not None
+        assert parsed.document_type == "5"
+        assert parsed.issuer_trading_symbol == "AAPL"
+        assert len(parsed.transactions) == 1
+        txn = parsed.transactions[0]
+        assert txn.txn_code == "G"
+        assert txn.shares == Decimal("500")
+        assert txn.acquired_disposed_code == "D"
+        assert txn.post_transaction_shares == Decimal("4500")
+
+    def test_amendment_accepted(self) -> None:
+        parsed = parse_form_5_xml(_wrap_form5(_FORM5_GIFT_TXN, document_type="5/A"))
+        assert parsed is not None
+        assert parsed.document_type == "5/A"
+
+    def test_form4_document_type_rejected(self) -> None:
+        # Mis-routed Form 4 → parser returns None so the adapter
+        # tombstones rather than mis-categorising the row.
+        assert parse_form_5_xml(_wrap_form5(_FORM5_GIFT_TXN, document_type="4")) is None
+
+    def test_form3_document_type_rejected(self) -> None:
+        assert parse_form_5_xml(_wrap_form5(_FORM5_GIFT_TXN, document_type="3")) is None
+
+    def test_empty_transactions_returns_none(self) -> None:
+        # Form 5 with only a holdings reconciliation section — out of
+        # scope for this PR; parser returns None so manifest adapter
+        # tombstones.
+        body = """
+          <nonDerivativeTable>
+            <nonDerivativeHolding>
+              <securityTitle><value>Common Stock</value></securityTitle>
+              <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction><value>5000</value></sharesOwnedFollowingTransaction>
+              </postTransactionAmounts>
+              <ownershipNature>
+                <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+              </ownershipNature>
+            </nonDerivativeHolding>
+          </nonDerivativeTable>
+        """
+        assert parse_form_5_xml(_wrap_form5(body)) is None
+
+    def test_malformed_xml_returns_none(self) -> None:
+        assert parse_form_5_xml("<not actually xml") is None
+        assert parse_form_5_xml("") is None
+
+    def test_non_ownership_root_returns_none(self) -> None:
+        assert parse_form_5_xml("<?xml version='1.0'?><somethingElse/>") is None
+
+    def test_missing_document_type_defaults_to_5(self) -> None:
+        """Parity with parse_form_4_xml / parse_form_3_xml: when
+        ``<documentType>`` is absent the parser defaults to the form
+        the manifest adapter routed to. Production XML missing the
+        element is rare; the manifest source ('sec_form5') is the
+        authoritative router so the default matches the route."""
+        xml = """<?xml version="1.0"?>
+<ownershipDocument>
+  <periodOfReport>2025-12-31</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000005</rptOwnerCik>
+      <rptOwnerName>Form Five Filer</rptOwnerName>
+    </reportingOwnerId>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <securityTitle><value>Common Stock</value></securityTitle>
+      <transactionDate><value>2025-11-15</value></transactionDate>
+      <transactionCoding><transactionCode>G</transactionCode></transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>100</value></transactionShares>
+        <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+</ownershipDocument>
+"""
+        parsed = parse_form_5_xml(xml)
+        assert parsed is not None
+        assert parsed.document_type == "5"

--- a/tests/test_manifest_parser_insider_345.py
+++ b/tests/test_manifest_parser_insider_345.py
@@ -1,30 +1,30 @@
-"""Tests for the Form 3 / Form 4 manifest-worker parser adapter (#873).
+"""Tests for the Form 3 / Form 4 / Form 5 manifest-worker parser
+adapter (#873).
 
-One callable registered per source — Form 3 and Form 4 share the
-EDGAR ownership XML namespace but persist into different tables
-(``insider_initial_holdings`` vs ``insider_transactions``) and
-carry separate parser_version watermarks. Form 5 is intentionally
-unregistered (no legacy support yet) and continues to skip.
+Three callables registered against three sources — they share the
+EDGAR ownership XML schema but persist into different tables
+(``insider_initial_holdings`` for Form 3 holdings;
+``insider_transactions`` for Form 4 + Form 5 transactions) and
+carry separate parser_version watermarks. Form 5 transactions
+write through with ``source='form4'`` (the observations CHECK enum
+lacks ``form5``); provenance is preserved on
+``insider_filings.document_type='5'``.
 
 Tests cover:
 
-- Happy path Form 4: XML fetch → store_raw → parse → upsert
-  ``insider_filings`` + ``insider_transactions`` rows → observation
-  write-through.
-- Happy path Form 3: XML fetch → store_raw → parse → upsert
-  ``insider_initial_holdings`` rows.
+- Happy path Form 4 / Form 3 / Form 5: XML fetch → store_raw →
+  parse → upsert + (for txn forms) observation write-through.
 - Tombstone on empty fetch: writes a tombstone row in
-  ``insider_filings`` so legacy discovery skips the accession.
+  ``insider_filings`` with the appropriate ``document_type``.
 - Tombstone on parse-None (malformed XML): same tombstone path,
   raw_status='stored' so manifest matches filing_raw_documents.
 - Parse-phase exception preserves raw_status='stored'.
 - Fetch raises: returns failed + 1h backoff.
-- Form 5 unregistered: sec_form5 source is debug-skipped by the
-  worker (no parser).
+- Deterministic upsert error tombstones; transient retries.
 - URL canonicalisation: SEC XSL-rendered URL → raw XML URL via
   ``_canonical_form_4_url``.
 - Registration: register_all_parsers wires sec_form3 + sec_form4
-  but NOT sec_form5.
+  + sec_form5.
 """
 
 from __future__ import annotations
@@ -82,6 +82,51 @@ _FAKE_FORM_4_XML = dedent("""<?xml version="1.0"?>
   <ownerSignature>
     <signatureName>Jane Smith</signatureName>
     <signatureDate>2026-04-16</signatureDate>
+  </ownerSignature>
+</ownershipDocument>
+""")
+
+
+_FAKE_FORM_5_XML = dedent("""<?xml version="1.0"?>
+<ownershipDocument>
+  <documentType>5</documentType>
+  <periodOfReport>2026-02-14</periodOfReport>
+  <issuer>
+    <issuerCik>0000320193</issuerCik>
+    <issuerName>Apple Inc.</issuerName>
+    <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+  </issuer>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerCik>0001000005</rptOwnerCik>
+      <rptOwnerName>Form Five Filer</rptOwnerName>
+    </reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isDirector>1</isDirector>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <securityTitle><value>Common Stock</value></securityTitle>
+      <transactionDate><value>2025-12-30</value></transactionDate>
+      <transactionCoding>
+        <transactionCode>G</transactionCode>
+      </transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>1000</value></transactionShares>
+        <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>9000</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
+      <ownershipNature>
+        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+      </ownershipNature>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+  <ownerSignature>
+    <signatureName>Form Five Filer</signatureName>
+    <signatureDate>2026-02-14</signatureDate>
   </ownerSignature>
 </ownershipDocument>
 """)
@@ -692,48 +737,361 @@ def test_xsl_url_canonicalised_before_fetch(
     assert "/xslF345X05/" not in fetched_urls[0]
 
 
-def test_form5_unregistered_skips(
+def test_form5_happy_path(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Form 5 (annual statement) has no registered parser. The worker
-    debug-skips the row and the manifest stays pending so a future
-    Form 5 onboarding sees the same backlog."""
+    """Form 5 routes through parse_form_5_xml + upsert_filing →
+    insider_filings(document_type='5') + insider_transactions row."""
     import app.services.manifest_parsers  # noqa: F401 — register
 
-    iid = 8760008
-    _seed_instrument(ebull_test_conn, iid=iid, symbol="ANN5")
+    iid = 8760080
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL5")
     _seed_pending(
         ebull_test_conn,
-        accession="0000444444-26-000010",
+        accession="0000320193-26-000050",
         instrument_id=iid,
         source="sec_form5",
         form="5",
     )
     ebull_test_conn.commit()
 
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_5_XML,
+    )
+
     stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
     ebull_test_conn.commit()
 
-    assert stats.skipped_no_parser == 1
-    assert stats.parsed == 0
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, "0000320193-26-000050")
+    assert row is not None and row.ingest_status == "parsed"
+    assert row.raw_status == "stored"
+    assert row.parser_version == "form5-v1"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT document_type, is_tombstone FROM insider_filings WHERE accession_number = '0000320193-26-000050'"
+        )
+        f = cur.fetchone()
+    assert f is not None
+    assert f[0] == "5"
+    assert f[1] is False
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM insider_transactions WHERE accession_number = '0000320193-26-000050'")
+        c = cur.fetchone()
+    assert c is not None and c[0] >= 1
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT byte_count FROM filing_raw_documents "
+            "WHERE accession_number = '0000320193-26-000050' AND document_kind = 'form5_xml'"
+        )
+        r = cur.fetchone()
+    assert r is not None and r[0] > 0
+
+    # Observation write-through emits source='form4' (no 'form5' in the
+    # ownership_*_observations source CHECK enum). The
+    # insider_filings.document_type='5' JOIN preserves operator-visible
+    # provenance.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT source FROM ownership_insiders_observations WHERE source_accession = '0000320193-26-000050'"
+        )
+        obs = cur.fetchall()
+    assert obs
+    assert all(o[0] == "form4" for o in obs)
+
+
+def test_form5_empty_fetch_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty/404 → manifest tombstoned + insider_filings tombstone with
+    document_type='5' (audit attribution stays Form 5, not Form 4)."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760081
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="DEAD5")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000999999-26-000050",
+        instrument_id=iid,
+        source="sec_form5",
+        form="5",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: None,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, "0000999999-26-000050")
+    assert row is not None and row.ingest_status == "tombstoned"
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT is_tombstone, document_type FROM insider_filings WHERE accession_number = '0000999999-26-000050'"
+        )
+        f = cur.fetchone()
+    assert f is not None
+    assert f[0] is True
+    assert f[1] == "5"
+
+
+def test_form5_parse_none_tombstones_with_stored_raw(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed XML → parser returns None → manifest tombstoned with
+    raw_status='stored' since store_raw committed BEFORE the parse."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760082
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="MAL5")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000888888-26-000050",
+        instrument_id=iid,
+        source="sec_form5",
+        form="5",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: "<not-ownership-xml/>",
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, "0000888888-26-000050")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+
+
+def test_form5_parse_phase_exception_preserves_stored_raw_status(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parse raise AFTER store_raw → failed + raw_status='stored'."""
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import insider_345 as parser_module
+
+    iid = 8760083
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="CRASH5")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000666666-26-000050",
+        instrument_id=iid,
+        source="sec_form5",
+        form="5",
+    )
+    ebull_test_conn.commit()
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_5_XML,
+    )
+
+    def _raising_parse(xml):  # noqa: ARG001
+        raise RuntimeError("synthetic Form 5 parser crash")
+
+    monkeypatch.setattr(parser_module, "parse_form_5_xml", _raising_parse)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, "0000666666-26-000050")
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM filing_raw_documents "
+            "WHERE accession_number = '0000666666-26-000050' AND document_kind = 'form5_xml'"
+        )
+        assert cur.fetchone() is not None
+
+
+def test_form5_fetch_exception_marks_failed_with_backoff(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fetch raise → failed + 1h backoff so worker doesn't hammer SEC."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8760084
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="BOOM5")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000777777-26-000050",
+        instrument_id=iid,
+        source="sec_form5",
+        form="5",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    def _boom(self, url):  # noqa: ARG001
+        raise RuntimeError("network kaput")
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _boom)
+
+    before = datetime.now(tz=UTC)
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, "0000777777-26-000050")
+    assert row is not None and row.ingest_status == "failed"
+    assert row.error is not None and "fetch error" in row.error
+    assert row.next_retry_at is not None
+    delta = (row.next_retry_at - before).total_seconds()
+    assert 3300 < delta < 3900
+
+
+def test_form5_upsert_failure_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #1131 discrimination: deterministic upsert error tombstones
+    the manifest row + writes a Form 5 tombstone in insider_filings so
+    the worker stops re-fetching dead XML hourly."""
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import insider_345 as parser_module
+
+    iid = 8760085
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="UFAIL5")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000222222-26-000050",
+        instrument_id=iid,
+        source="sec_form5",
+        form="5",
+    )
+    ebull_test_conn.commit()
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_5_XML,
+    )
+
+    def _raising_upsert(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic Form 5 upsert constraint violation")
+
+    monkeypatch.setattr(parser_module, "upsert_filing", _raising_upsert)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    assert stats.failed == 0
+    row = get_manifest_row(ebull_test_conn, "0000222222-26-000050")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+    assert row.error is not None
+    assert "upsert error" in row.error
+    assert "RuntimeError" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT is_tombstone, document_type FROM insider_filings WHERE accession_number = '0000222222-26-000050'"
+        )
+        f = cur.fetchone()
+    assert f is not None
+    assert f[0] is True
+    assert f[1] == "5"
+
+
+def test_form5_transient_upsert_exception_retries(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #1131: ``OperationalError`` on Form 5 upsert keeps the manifest
+    in ``failed`` with a 1h backoff — the DB-side state is the problem,
+    not the parsed XML. No insider_filings tombstone written."""
+    import psycopg.errors
+
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import insider_345 as parser_module
+
+    iid = 8760086
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TFAIL5")
+    _seed_pending(
+        ebull_test_conn,
+        accession="0000222222-26-000086",
+        instrument_id=iid,
+        source="sec_form5",
+        form="5",
+    )
+    ebull_test_conn.commit()
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_FORM_5_XML,
+    )
+
+    def _raising_upsert(*args, **kwargs):  # noqa: ARG001
+        raise psycopg.errors.SerializationFailure("synthetic serialisation failure")
+
+    monkeypatch.setattr(parser_module, "upsert_filing", _raising_upsert)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
     assert stats.tombstoned == 0
-    row = get_manifest_row(ebull_test_conn, "0000444444-26-000010")
-    assert row is not None and row.ingest_status == "pending"
+    row = get_manifest_row(ebull_test_conn, "0000222222-26-000086")
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+    assert row.error is not None
+    assert "SerializationFailure" in row.error
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM insider_filings WHERE accession_number = '0000222222-26-000086'")
+        assert cur.fetchone() is None
 
 
-def test_parser_registered_form3_and_form4_but_not_form5() -> None:
-    """sec_form3 + sec_form4 wired; sec_form5 deliberately NOT."""
+def test_parser_registers_form3_form4_form5() -> None:
+    """sec_form3 + sec_form4 + sec_form5 all wired by register_all_parsers."""
     from app.jobs.sec_manifest_worker import registered_parser_sources
     from app.services.manifest_parsers import register_all_parsers
 
     sources = registered_parser_sources()
     assert "sec_form3" in sources
     assert "sec_form4" in sources
-    assert "sec_form5" not in sources
+    assert "sec_form5" in sources
 
     clear_registered_parsers()
     assert "sec_form3" not in registered_parser_sources()
     register_all_parsers()
     assert "sec_form3" in registered_parser_sources()
     assert "sec_form4" in registered_parser_sources()
-    assert "sec_form5" not in registered_parser_sources()
+    assert "sec_form5" in registered_parser_sources()


### PR DESCRIPTION
## What

- `parse_form_5_xml` in `app/services/insider_transactions.py` — mirrors `parse_form_4_xml` with the documentType gate flipped to `5`/`5/A`. Returns `None` on holdings-only filings + malformed XML so the manifest adapter tombstones.
- `_parse_form5` adapter in `app/services/manifest_parsers/insider_345.py` — same shape as `_parse_form4`, persists Form 5 transactions into `insider_transactions` with `document_type='5'`. PR #1131 upsert exception discrimination contract followed (transient `OperationalError` → 1h retry; deterministic → tombstone with class name embedded).
- `_write_tombstone` gains a `document_type` kwarg (default `'4'`) so Form 5 tombstones attribute correctly. Existing Form 4 callers untouched.
- `sql/146_filing_raw_documents_add_form5_xml.sql` — adds `form5_xml` to the `document_kind` CHECK + parallel addition to `DocumentKind` Literal in `app/services/raw_filings.py`. Distinct kind keeps re-wash targeting simple (per sql/122 precedent for N-PORT).
- `_form4_state` drillthrough in `app/services/ownership_drillthrough.py` expanded to include `document_type IN ('4', '5', '5/A')` and `document_kind IN ('form4_xml', 'form5_xml')` so operator-visible counts surface the Form 5 lane.

## Why

`sec_form5` manifest rows have been accumulating since #1130 with no registered parser — `coverage/manifest-parsers` reports `has_registered_parser=False`. The lane skips per-row debug-log. Adding the adapter drains the backlog through the standard ingest path.

## Design decisions

1. **Form 5 transactions reuse `insider_filings` + `insider_transactions`** (with `document_type='5'`) rather than separate tables — Form 5 is the annual catch-up of Form 4 transactions, same data shape, same downstream readers.
2. **Observation write-through emits `source='form4'`.** The `ownership_*_observations` source CHECK enum across sql/113-116 hardcodes `('form4', 'form3', '13d', '13g', 'def14a', '13f', 'nport', 'ncsr', 'xbrl_dei', '10k_note', 'finra_si', 'derived')` — no `form5`. Adding it requires a 5-table CHECK migration + `OwnershipSource` enum + `_SOURCE_PRIORITY` + `refresh_insiders_current` priority chain SQL. Tagging Form 5 transactions as `form4` is semantically honest (they ARE late Form 4 trades surfaced annually); operator-visible provenance is preserved on `insider_filings.document_type='5'` via the JOIN. Reader endpoints that filter by `source` see Form 5 in the Form 4 bucket, which matches how they're traded.
3. **Form 5 holdings out of scope.** The optional year-end balance reconciliation section is rare in practice. Filings carrying ONLY holdings return `None` from the parser; the adapter writes a tombstone via the standard malformed-XML branch. Follow-up ticket can land a Form 5 holdings shape if operator evidence shows the lane is hit.
4. **Separate `parse_form_5_xml` rather than generalising `parse_form_4_xml`.** Matches the established Form 3 / Form 4 sibling-callable precedent — separate parser_version watermarks, separate dispatch, no shared mutation surface.
5. **`_form4_state` drillthrough updated, not split.** Operator sees one combined "insider transactions" lane covering Form 4 + Form 5; splitting into separate pipeline states would add UI churn for a low-volume Form 5 cadence. Pipeline `key` stays `insider_transactions`.

## Test plan

- [x] `parse_form_5_xml` happy path / 5/A amendment / Form 4 doc_type rejected / Form 3 doc_type rejected / holdings-only filing → None / malformed → None / non-ownership root → None / missing documentType defaults to '5' (documents intentional fallback parity with parse_form_4_xml).
- [x] `_parse_form5` integration: happy path / empty fetch tombstones with document_type='5' / parse-None tombstones with raw_status='stored' / parse-phase exception preserves raw_status='stored' / fetch exception → failed with 1h backoff / deterministic upsert error tombstones / transient `SerializationFailure` retries.
- [x] `register_all_parsers()` wires `sec_form3` + `sec_form4` + `sec_form5`.
- [x] Observation write-through emits `source='form4'` for Form 5 (asserted in happy-path test).
- [x] `_write_tombstone` document_type default unchanged → Form 4 / Form 3 callers untouched.
- [x] `uv run ruff check .` / `ruff format --check .` / `pyright` clean.
- [x] Migration 146 applied to dev DB.

## Out of scope / tech debt

- Form 5 holdings (year-end balance reconciliation section) — defer until operator evidence shows the lane needs it.
- `OwnershipSource` enum + observations CHECK relaxation to admit `form5` — operator-visible provenance currently flows via `insider_filings.document_type` JOIN; tightening provenance is a 5-migration touch.
- `_form4_state` drillthrough still misses `4/A` amendments (pre-existing `document_type = '4'` exact-match bug; not introduced by this PR). Worth a follow-up ticket.

## Codex pre-push (checkpoint 2)

Codex flagged 3 WARNINGs:
- W1 (`parse_form_5_xml` missing-documentType defaults to '5') — REBUTTED. Parity with parse_form_4_xml / parse_form_3_xml; manifest source ('sec_form5') is the authoritative router. Added an explicit unit test documenting the intentional fallback.
- W2 (Form 5 observations land as `source='form4'`) — REBUTTED. Scope-down decision; provenance preserved via `insider_filings.document_type` JOIN. Adding `'form5'` to the observation source enum is out of scope for this PR.
- W3 (downstream drillthrough excludes Form 5) — FIXED. Updated `_form4_state` to include `document_type IN ('4', '5', '5/A')` and `document_kind IN ('form4_xml', 'form5_xml')`.

## Refs

Refs #873