### PR TITLE
fix(#1144): add background problemMatcher so dev: start stack fans out

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -56,8 +56,8 @@
         "pattern": { "regexp": "^$" },
         "background": {
           "activeOnStart": true,
-          "beginsPattern": ".",
-          "endsPattern": "."
+          "beginsPattern": "^\\x00$",
+          "endsPattern": "^\\x00$"
         }
       }
     },
@@ -94,8 +94,8 @@
         "pattern": { "regexp": "^$" },
         "background": {
           "activeOnStart": true,
-          "beginsPattern": ".",
-          "endsPattern": "."
+          "beginsPattern": "^\\x00$",
+          "endsPattern": "^\\x00$"
         }
       }
     },
@@ -129,8 +129,8 @@
         "pattern": { "regexp": "^$" },
         "background": {
           "activeOnStart": true,
-          "beginsPattern": ".",
-          "endsPattern": "."
+          "beginsPattern": "^\\x00$",
+          "endsPattern": "^\\x00$"
         }
       }
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -51,7 +51,15 @@
         "group": "ebull-stack",
         "clear": false
       },
-      "problemMatcher": []
+      "problemMatcher": {
+        "owner": "ebull-backend",
+        "pattern": { "regexp": "^$" },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "."
+        }
+      }
     },
     {
       "label": "stack: frontend",
@@ -81,7 +89,15 @@
         "group": "ebull-stack",
         "clear": false
       },
-      "problemMatcher": []
+      "problemMatcher": {
+        "owner": "ebull-frontend",
+        "pattern": { "regexp": "^$" },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "."
+        }
+      }
     },
     {
       "label": "stack: jobs",
@@ -108,7 +124,15 @@
         "group": "ebull-stack",
         "clear": false
       },
-      "problemMatcher": []
+      "problemMatcher": {
+        "owner": "ebull-jobs",
+        "pattern": { "regexp": "^$" },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "."
+        }
+      }
     },
     {
       "label": "stack: backend+frontend",


### PR DESCRIPTION
## What

Adds a minimal background `problemMatcher` (with `activeOnStart: true`) to the three leaf tasks `stack: backend`, `stack: frontend`, `stack: jobs` so VS Code's `dependsOrder: sequence` on the parent `dev: start stack` can advance past `stack: prepare` and fan the compound `stack: backend+frontend` out to its leaves.

## Why

On macOS, opening the folder in VS Code ran `stack.sh` (postgres + redis + migrate) successfully but never spawned uvicorn / vite / `app.jobs`. Workaround was to manually run `stack: backend+frontend` from the command palette, which fanned out fine.

Root cause: each leaf was declared `isBackground: true` with `"problemMatcher": []`. With no `problemMatcher.background`, VS Code has no signal for when a background task transitions to active. The sequencer either stalls waiting for an "active" signal that never arrives, or short-circuits the command-less compound `stack: backend+frontend` before it dispatches its dependencies.

`activeOnStart: true` is the kingpin: tells VS Code the task is live the moment its terminal spawns. `beginsPattern` / `endsPattern` are required by the schema and set to a no-op `.` regex — the readiness signal is `activeOnStart`, not the patterns. Distinct `owner` strings per leaf so VS Code's problem-state machine tracks each independently.

Windows reportedly worked already (likely a pwsh-side timing difference). This change is additive and should be neutral or positive on Windows.

## Test plan

- [ ] macOS: `Cmd+Q` VS Code → reopen folder → `dev: start stack` runs prepare then opens backend / frontend / jobs terminal tabs; ports 8000 + 5173 listen; `pgrep -fl 'app.jobs'` returns a process.
- [ ] Windows: confirm no regression on the same flow.

Closes #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)