### PR TITLE
fix(#1137): repair bootstrap test + doc drift after 24-stage rewrite

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -1,28 +1,43 @@
 """First-install bootstrap orchestrator.
 
-Runs the 17-stage end-to-end first-install backfill described in
-``docs/superpowers/specs/2026-05-07-first-install-bootstrap.md``.
+Runs the 24-stage end-to-end first-install backfill described in
+``docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md``
+(supersedes the original 17-stage shape in
+``docs/superpowers/specs/2026-05-07-first-install-bootstrap.md``).
 
-Three phases:
+Phases (S-numbers match the runbook stage list):
 
-1. **Phase A — init** (sequential, single thread): runs the universe
-   sync (A1). Every Phase B stage depends on a populated
-   ``instruments`` table.
-2. **Phase B — lanes** (two threads in parallel): the eToro lane
-   (E1: candle refresh) runs alongside the SEC lane (S1..S15:
-   filer directories, CIK refresh, filing-events seed, manifest
-   drain, typed parsers, ownership rollup, fundamentals).
-3. **Phase C — finalize** (sequential): inspects per-stage outcomes
-   and transitions ``bootstrap_state`` to ``complete`` or
-   ``partial_error``.
+1. **Phase A — init** (sequential, ``init`` lane): S1 ``universe_sync``.
+   Every later stage depends on a populated ``instruments`` table.
+2. **Phase B — lanes** (parallel by source lock): the eToro lane
+   (S2 ``candle_refresh``) runs alongside the SEC reference lane
+   (S3..S6: filer directories, CIK refresh).
+3. **Phase A3 — bulk archive download** (``sec_bulk_download`` lane):
+   S7 ``sec_bulk_download`` ships fixed-URL SEC archives in one
+   request, disjoint from the per-IP ``sec_rate`` budget.
+4. **Phase C — DB-bound bulk ingest** (``db`` lane): S8..S12 ingest
+   the bulk archives into ``filing_events`` / ``ownership_*`` /
+   ``company_facts``.
+5. **Phase C' — secondary-pages walker** (``sec_rate``): S13
+   ``sec_submissions_files_walk`` covers deep-history submission
+   pages the bulk archive truncates.
+6. **Legacy / fallback chain** (``sec_rate``): S14..S22 ingest the
+   per-filing path. Idempotent no-ops when Phase C populated rows;
+   primary write path on the slow-connection bypass (see #1041).
+7. **Phase E — final derivations** (``db`` lane): S23
+   ``ownership_observations_backfill`` + S24 ``fundamentals_sync``.
+8. **Finalize**: inspects per-stage outcomes and transitions
+   ``bootstrap_state`` to ``complete`` or ``partial_error``.
 
 Per-stage execution contract (every stage):
 
 1. Pre-check stage status; skip if ``success``.
 2. Mark stage ``running``.
 3. Acquire ``JobLock(database_url, job_name)`` — same primitive
-   that scheduled + manual paths use.
-4. Invoke ``_INVOKERS[job_name]()``.
+   that scheduled + manual paths use; resolves to a per-source
+   advisory lock (PR1a #1064).
+4. Invoke ``_INVOKERS[job_name](params)`` (PR1b-2 #1064 widened the
+   contract from zero-arg to ``(Mapping) -> None``).
 5. Catch exceptions; record ``error`` with truncated message.
 6. On success record ``success`` + ``rows_processed``.
 
@@ -245,9 +260,11 @@ _STAGE_REQUIRES: Final[dict[str, tuple[str, ...]]] = {
 }
 
 
-# Lane override map — stage_key → lane name, used by the new
+# Lane override map — stage_key → lane name, used by the
 # concurrency dispatcher. Stages NOT in this map default to their
-# StageSpec.lane field (so existing 17-stage runs still work).
+# ``StageSpec.lane`` field; the override map lets the dispatcher
+# refine the lane (e.g. retire ``etoro`` for SEC-lane stages) without
+# rewriting every spec.
 _STAGE_LANE_OVERRIDES: Final[dict[str, str]] = {
     "cusip_universe_backfill": "sec_rate",
     "sec_13f_filer_directory_sync": "sec_rate",
@@ -992,9 +1009,10 @@ __all__ = [
 
 # Stage count assertion — pin so a future refactor that adds /
 # removes a spec deliberately surfaces in code review and doesn't
-# silently break the tests + frontend that hardcode "17 stages".
+# silently break the tests + frontend + runbook that hardcode the
+# current 24-stage shape.
 assert len(_BOOTSTRAP_STAGE_SPECS) == 24, (
     f"_BOOTSTRAP_STAGE_SPECS expected 24 stages, got {len(_BOOTSTRAP_STAGE_SPECS)}; "
-    "update the spec, frontend, and stage_count tests in lockstep. "
+    "update the spec, frontend, runbook, and stage_count tests in lockstep. "
     "#1027 added 7 bulk-archive stages (sec_bulk_download + C1.a/C2/C3/C4/C5 ingesters + C1.b walker)."
 )

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -7,7 +7,9 @@ singleton scheduler-gate state. Spec:
 Three tables (sql/129_bootstrap_state.sql):
 
   - ``bootstrap_runs``    — one row per "Run bootstrap" click.
-  - ``bootstrap_stages``  — one row per stage in a run (18 stages today).
+  - ``bootstrap_stages``  — one row per stage in a run (24 stages today;
+                            catalogue lives in
+                            ``app/services/bootstrap_orchestrator.py::_BOOTSTRAP_STAGE_SPECS``).
   - ``bootstrap_state``   — singleton row (id=1) with the canonical
                             ``_bootstrap_complete`` gate status.
 
@@ -95,8 +97,10 @@ class StageSpec:
     """Static definition of a stage. Lives in code, not DB.
 
     The orchestrator service builds the canonical ordered list of
-    18 specs (1 init + 1 eToro + 16 SEC) and passes it to ``start_run``,
-    which materialises one ``bootstrap_stages`` row per spec.
+    24 specs (1 init + 1 eToro + 1 sec_bulk_download + 7 db + 14 sec_rate;
+    see ``app/services/bootstrap_orchestrator.py::_BOOTSTRAP_STAGE_SPECS``)
+    and passes it to ``start_run``, which materialises one
+    ``bootstrap_stages`` row per spec.
     """
 
     stage_key: str

--- a/docs/wiki/runbooks/runbook-first-install-bootstrap.md
+++ b/docs/wiki/runbooks/runbook-first-install-bootstrap.md
@@ -27,34 +27,56 @@ Click "Run bootstrap" on the admin page when:
 Do **not** run it as part of routine ops: scheduled jobs handle
 incremental refresh once bootstrap is complete.
 
-## 2. What runs (17 stages)
+## 2. What runs (24 stages)
 
-Phases in order; spec §"Stages and lanes" is the source of truth:
+Phases in order; the catalogue lives in
+``app/services/bootstrap_orchestrator.py::_BOOTSTRAP_STAGE_SPECS`` and
+is the source of truth (asserted == 24 at module load). Spec:
+``docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md``.
 
-1. **Phase A — init** (sequential, single thread): ``universe_sync``
-   (~30s, ~1.5k rows).
-2. **Phase B — eToro lane** (parallel with SEC lane):
-   ``candle_refresh`` (full universe; minutes).
-3. **Phase B — SEC lane** (sequential, shared 11 req/s bucket; 15
-   stages):
-   - ``cusip_universe_backfill``
-   - ``sec_13f_filer_directory_sync``
-   - ``sec_nport_filer_directory_sync``
-   - ``cik_refresh`` (``daily_cik_refresh``)
-   - ``filings_history_seed`` (PR1c #1064 — promoted from the bespoke
-     ``bootstrap_filings_history_seed`` wrapper; bootstrap stage 14
-     dispatches with ``params={days_back: 730, filing_types: <three-tier
-     allow-list>}``)
-   - ``sec_first_install_drain`` (~60min for ~12k filers; bootstrap
-     stage 15 dispatches with ``params={max_subjects: None}``)
-   - ``sec_def14a_bootstrap`` / ``sec_business_summary_bootstrap`` /
-     insider/Form 3/8-K typed parsers
-   - ``sec_13f_quarterly_sweep`` / ``sec_n_port_ingest``
-   - ``ownership_observations_backfill``
-   - ``fundamentals_sync``
+1. **Phase A — init** (sequential, ``init`` lane, single thread):
+   - S1 ``universe_sync`` (``nightly_universe_sync``; ~30s, ~1.5k rows).
+1. **Phase B — eToro lane** (parallel with SEC):
+   - S2 ``candle_refresh`` (``daily_candle_refresh``; full universe).
+1. **Phase B — SEC reference lane** (``sec_rate``; shared 10 req/s bucket):
+   - S3 ``cusip_universe_backfill``
+   - S4 ``sec_13f_filer_directory_sync``
+   - S5 ``sec_nport_filer_directory_sync``
+   - S6 ``cik_refresh`` (``daily_cik_refresh``)
+1. **Phase A3 — bulk archive download** (``sec_bulk_download`` lane;
+   disjoint from ``sec_rate``):
+   - S7 ``sec_bulk_download`` (#1020; fixed-URL SEC archives).
+1. **Phase C — DB-bound bulk ingesters** (``db`` lane; same-source
+   serialisation under one ``JobLock`` per #1064):
+   - S8 ``sec_submissions_ingest``
+   - S9 ``sec_companyfacts_ingest``
+   - S10 ``sec_13f_ingest_from_dataset``
+   - S11 ``sec_insider_ingest_from_dataset``
+   - S12 ``sec_nport_ingest_from_dataset``
+1. **Phase C' — secondary-pages walker** (``sec_rate``):
+   - S13 ``sec_submissions_files_walk``
+1. **Legacy / fallback chain** (``sec_rate``; idempotent no-ops when
+   Phase C populated rows; primary write path on the slow-connection
+   bypass — see #1041):
+   - S14 ``filings_history_seed`` (``params={days_back: 730,
+     filing_types: <three-tier allow-list>}``)
+   - S15 ``sec_first_install_drain`` (``params={max_subjects: None}``)
+   - S16 ``sec_def14a_bootstrap``
+   - S17 ``sec_business_summary_bootstrap``
+   - S18 ``sec_insider_transactions_backfill``
+   - S19 ``sec_form3_ingest``
+   - S20 ``sec_8k_events_ingest``
+   - S21 ``sec_13f_recent_sweep`` (``sec_13f_quarterly_sweep`` with
+     ``min_period_of_report`` ≈ today − 380d; #1008 bound)
+   - S22 ``sec_n_port_ingest``
+1. **Phase E — final derivations** (``db`` lane):
+   - S23 ``ownership_observations_backfill``
+   - S24 ``fundamentals_sync``
 
-Total wall-clock: typically **60–90 minutes**, dominated by the SEC
-manifest drain (``sec_first_install_drain``).
+Total wall-clock: typically **60–90 minutes** on the bulk path,
+dominated by ``sec_bulk_download`` + ``sec_submissions_files_walk``.
+The legacy ``sec_first_install_drain`` path (slow-connection fallback)
+dominates wall-clock when the bulk archives are skipped.
 
 ## 3. Watching it
 
@@ -90,7 +112,7 @@ After the run finalises with at least one error,
   Re-publishes the orchestrator queue row. Successful prior stages
   stay ``success`` and are skipped.
 - **Re-run all** — creates a brand-new ``bootstrap_runs`` row +
-  freshly seeds 17 ``bootstrap_stages`` rows. Use when an operator
+  freshly seeds 24 ``bootstrap_stages`` rows. Use when an operator
   wants to widen historical depth or after a config change that
   affects upstream ingest (e.g. CIK universe expansion).
 - **Mark complete** — operator escape hatch. Forces
@@ -143,19 +165,26 @@ will summarise; per-CIK detail is in the underlying
 
 ### Typed parsers — `instruments=0` after the drain
 
-If S6/S7/S8/etc parsers report 0 instruments processed, check that
-``filings_history_seed`` (S5) actually populated ``filing_events`` —
-without ``filing_events`` rows for the relevant form type, the
-parser candidate selectors find nothing.
+If S16/S17/S18/S19/S20 typed parsers (def14a / business summary /
+insider txns / Form 3 / 8-K) report 0 instruments processed, check
+that S14 ``filings_history_seed`` actually populated ``filing_events``
+— without ``filing_events`` rows for the relevant form type, the
+parser candidate selectors find nothing. On the bulk path (#1020),
+S8 ``sec_submissions_ingest`` + S13 ``sec_submissions_files_walk``
+seed the same ``filing_events`` rows; verify those completed before
+suspecting the legacy chain.
 
 ## 7. Scheduler gate behaviour
 
 While ``bootstrap_state.status`` is anything other than ``complete``,
-14 scheduled jobs skip-and-log instead of firing:
+the SCHEDULED_JOBS entries with ``prerequisite=_bootstrap_complete``
+skip-and-log instead of firing. Grep
+``app/workers/scheduler.py`` for ``_bootstrap_complete`` for the
+current list; representative members:
 
 - ``orchestrator_full_sync`` (entire DAG-walk path)
 - ``fundamentals_sync`` (also gated by ``_has_any_coverage``)
-- 12 SEC ingest / bootstrap / backfill jobs
+- SEC ingest / bootstrap / backfill jobs
 
 A skip writes a ``job_runs`` row with ``status='skipped'`` and the
 reason ``"first-install bootstrap not complete; visit /admin to
@@ -163,6 +192,8 @@ run"``. Manual triggers (``POST /jobs/{name}/run``) bypass the gate
 deliberately so an operator override stays available pre-bootstrap.
 
 The bootstrap orchestrator itself dispatches stage jobs by direct
-invocation (``_INVOKERS[name]()``), bypassing the scheduler-side
-gate but acquiring the per-job ``JobLock`` so manual / scheduled
-triggers cannot run twice simultaneously.
+invocation (``_INVOKERS[name](params)``; PR1b #1064 widened the
+contract from zero-arg to ``(Mapping) -> None``), bypassing the
+scheduler-side gate but acquiring the per-source ``JobLock``
+(PR1a #1064) so manual / scheduled triggers cannot run twice
+simultaneously.

--- a/tests/test_bootstrap_flow_integration.py
+++ b/tests/test_bootstrap_flow_integration.py
@@ -70,8 +70,12 @@ def _patch_orchestrator_invokers(
 
     calls: dict[str, list[str]] = {"order": []}
 
-    def _make_fake(name: str) -> Callable[[], None]:
-        def _fake() -> None:
+    # PR1b-2 #1064 widened ``JobInvoker`` to ``(Mapping) -> None``;
+    # bootstrap dispatch passes ``effective_params`` positionally.
+    # Fakes accept-and-ignore so the test stub satisfies the runtime
+    # contract.
+    def _make_fake(name: str) -> Callable[..., None]:
+        def _fake(_params: object = None) -> None:
             calls["order"].append(name)
 
         return _fake
@@ -168,8 +172,8 @@ def test_bootstrap_partial_error_then_retry_failed(
     calls_pass1: dict[str, list[str]] = {"order": []}
     failing = {"sec_def14a_bootstrap"}
 
-    def _make_pass1(name: str) -> Callable[[], None]:
-        def _fake() -> None:
+    def _make_pass1(name: str) -> Callable[..., None]:
+        def _fake(_params: object = None) -> None:
             calls_pass1["order"].append(name)
             if name in failing:
                 raise RuntimeError(f"forced {name} failure")
@@ -194,8 +198,8 @@ def test_bootstrap_partial_error_then_retry_failed(
     # Second pass: replace invokers with a successful set + reset failed stages.
     calls_pass2: dict[str, list[str]] = {"order": []}
 
-    def _make_pass2(name: str) -> Callable[[], None]:
-        def _fake() -> None:
+    def _make_pass2(name: str) -> Callable[..., None]:
+        def _fake(_params: object = None) -> None:
             calls_pass2["order"].append(name)
 
         return _fake

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -74,6 +74,25 @@ def _bind_settings_to_test_db(monkeypatch: pytest.MonkeyPatch) -> str:
     return url
 
 
+def _register_synthetic_jobs(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, str]) -> None:
+    """Add synthetic ``job_name -> Lane`` entries to the source-lock
+    registry so ``JobLock(database_url, job_name)`` resolves without
+    raising ``KeyError`` for fixture-only job names.
+
+    PR1a #1064 made ``JobLock`` eagerly resolve job_name -> source via
+    ``app.jobs.sources.source_for``; tests that construct synthetic
+    stage specs (e.g. ``alpha_job``, ``bravo_job``) must therefore
+    register the name. The registry is a process-wide dict cached
+    behind ``get_job_name_to_source``; monkeypatch.setitem reverses
+    each insert at teardown.
+    """
+    from app.jobs.sources import get_job_name_to_source
+
+    registry = get_job_name_to_source()
+    for name, lane in mapping.items():
+        monkeypatch.setitem(registry, name, lane)  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # Catalogue invariants
 # ---------------------------------------------------------------------------
@@ -146,6 +165,7 @@ def test_run_one_stage_records_success(
 ) -> None:
     _reset_state(ebull_test_conn)
     test_db_url = _bind_settings_to_test_db(monkeypatch)
+    _register_synthetic_jobs(monkeypatch, {"alpha_job": "init"})
     from app.services.bootstrap_state import StageSpec
 
     specs = (StageSpec(stage_key="alpha", stage_order=1, lane="init", job_name="alpha_job"),)
@@ -178,6 +198,7 @@ def test_run_one_stage_records_error_on_invoker_exception(
 ) -> None:
     _reset_state(ebull_test_conn)
     test_db_url = _bind_settings_to_test_db(monkeypatch)
+    _register_synthetic_jobs(monkeypatch, {"bravo_job": "init"})
     from app.services.bootstrap_state import StageSpec
 
     specs = (StageSpec(stage_key="bravo", stage_order=1, lane="init", job_name="bravo_job"),)


### PR DESCRIPTION
## Summary

Task D of the #1136 first-install bootstrap audit. Smallest of the five split tasks; lands first so A/B/C have a green test gate to validate against.

- Runbook + docstrings now agree on the 24-stage shape (was 17 / 18 / mixed).
- Two broken bootstrap tests repaired against the PR1a/PR1b-2 #1064 contracts (`JobLock` per-source registry + `JobInvoker = (Mapping) -> None`).

Closes #1137.

## What

| File | Change |
|---|---|
| `docs/wiki/runbooks/runbook-first-install-bootstrap.md` | §2 rewritten with S1..S24 list grouped by phase (init / eToro / SEC ref / bulk download / DB ingest / walker / legacy chain / Phase E). §4 / §6 / §7 stage-number refs refreshed; scheduler-gate count generalised (was hardcoded `14`). |
| `app/services/bootstrap_state.py` | `StageSpec` docstring 18 → 24 specs, with lane breakdown + cross-ref to catalogue. |
| `app/services/bootstrap_orchestrator.py` | Module docstring rewritten to 24-stage phase walkthrough; widened invoker contract noted (PR1a/PR1b-2 #1064); stale "17-stage runs still work" comment generalised; stage-count assertion comment now references runbook lockstep. |
| `tests/test_bootstrap_orchestrator.py` | New `_register_synthetic_jobs` helper uses `monkeypatch.setitem` on `get_job_name_to_source()` so fixture-only job names (`alpha_job`, `bravo_job`) resolve through the PR1a #1064 source-lock registry. |
| `tests/test_bootstrap_flow_integration.py` | Three fake-invoker factories widened from `Callable[[], None]` to `Callable[..., None]` with `_params: object = None` to satisfy the PR1b-2 #1064 `JobInvoker = (Mapping) -> None` contract. |

## Why

#1136 §6 flagged drift after the 24-stage rewrite:

> The runbook still says "17 stages"; code asserts 24. `bootstrap_state.py` docstrings still mention 18 stages in places. Some focused bootstrap tests are currently stale.

Before this PR, `tests/test_bootstrap_orchestrator.py::test_run_one_stage_records_*` (2 tests) and `tests/test_bootstrap_flow_integration.py::*` (2 tests) failed against the PR1a/PR1b-2 contracts.

## Out of scope

Fallback-shape tests (partial bulk failure / intentional slow-connection skip / legacy recovery) explicitly deferred to Task A (#1138) — the capability layer is the natural hook for those assertions per the audit. Tracking continues in #1136 / #1138.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 577 files already formatted
- [x] `uv run pyright` — 0 errors / 0 warnings
- [x] `uv run pytest tests/test_bootstrap_orchestrator.py tests/test_bootstrap_flow_integration.py -n0` — 15 passed
- [x] `codex exec` review — two rounds, both green (caught two additional drift sites in round 1 which round 2 confirmed fixed)
- [ ] Claude review bot
- [ ] CI green on most recent commit

## Settled-decisions / prevention-log

No settled decision is changed. The PR1a source-lock decision (#1064 PR1a — "production code MUST register; tests use `JobLock.test_only_per_name` or registry mutation") is preserved: tests use the registry-mutation path via the new helper, which is the documented escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)