### PR TITLE
fix(#1139): atomic bootstrap enqueue + retry-failed hardening

### DIFF
--- a/app/api/bootstrap.py
+++ b/app/api/bootstrap.py
@@ -37,6 +37,8 @@ from app.services.bootstrap_orchestrator import (
 )
 from app.services.bootstrap_state import (
     BootstrapAlreadyRunning,
+    BootstrapNoPriorRun,
+    BootstrapNotResettable,
     BootstrapNotRunning,
     cancel_run,
     force_mark_complete,
@@ -46,7 +48,7 @@ from app.services.bootstrap_state import (
     start_run,
 )
 from app.services.process_stop import StopAlreadyPendingError
-from app.services.sync_orchestrator.dispatcher import publish_manual_job_request
+from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
 
 logger = logging.getLogger(__name__)
 
@@ -365,18 +367,42 @@ def run_bootstrap(
     in depth via the partial unique index on
     ``bootstrap_runs(status='running')``.
 
-    On success: creates a new ``bootstrap_runs`` row, seeds 17
-    pending ``bootstrap_stages`` rows, flips the singleton state to
+    #1139 — ``start_run`` and the ``pending_job_requests`` insert
+    share one outer transaction on the request's pooled connection.
+    psycopg3 nests ``start_run``'s own ``with conn.transaction():``
+    as a SAVEPOINT, so a publish failure rolls both the SAVEPOINT
+    and the outer transaction back — the singleton cannot strand at
+    ``status='running'`` with no queue row.
+
+    On success: creates a new ``bootstrap_runs`` row (with the
+    request operator's UUID stamped on
+    ``triggered_by_operator_id`` for audit), seeds the pending
+    ``bootstrap_stages`` rows, flips the singleton state to
     ``running``, then publishes a ``manual_job`` queue row pointing
     at the ``bootstrap_orchestrator`` invoker. Returns 202 with the
     new ``run_id`` and the queue ``request_id``.
     """
+    requested_by = _identify_requestor(request)
+    operator_uuid = _operator_uuid(request)
     try:
-        run_id = start_run(
-            conn,
-            operator_id=None,
-            stage_specs=get_bootstrap_stage_specs(),
-        )
+        with conn.transaction():
+            run_id = start_run(
+                conn,
+                operator_id=operator_uuid,
+                stage_specs=get_bootstrap_stage_specs(),
+            )
+            try:
+                request_id = publish_manual_job_request_with_conn(
+                    conn,
+                    JOB_BOOTSTRAP_ORCHESTRATOR,
+                    requested_by=requested_by,
+                )
+            except psycopg.OperationalError as exc:
+                logger.exception("bootstrap: queue publish failed (transient)")
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail={"error": "queue_publish_failed"},
+                ) from exc
     except BootstrapAlreadyRunning as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -386,13 +412,12 @@ def run_bootstrap(
             },
         ) from exc
 
-    requested_by = _identify_requestor(request)
-    request_id = publish_manual_job_request(JOB_BOOTSTRAP_ORCHESTRATOR, requested_by=requested_by)
     logger.info(
-        "bootstrap: queued run_id=%d request_id=%d requested_by=%s",
+        "bootstrap: queued run_id=%d request_id=%d requested_by=%s operator_id=%s",
         run_id,
         request_id,
         requested_by,
+        operator_uuid,
     )
     return BootstrapRunQueuedResponse(run_id=run_id, request_id=request_id)
 
@@ -413,57 +438,71 @@ def retry_failed(
 ) -> BootstrapRunQueuedResponse:
     """Re-run failed stages (and their downstream same-lane peers).
 
-    For a ``partial_error`` state. Reuses the latest
-    ``bootstrap_runs.id`` rather than creating a new run.
+    For a ``partial_error`` / ``cancelled`` state. Reuses the latest
+    ``bootstrap_runs.id`` rather than creating a new run; the
+    original ``triggered_by_operator_id`` is NOT overwritten (#1139).
 
     409 if a run is already in flight. 404 if there is no prior run
     or the latest run has no failed stages to retry.
+
+    #1139 — helper + publish share one transaction; if publish fails
+    the stage reset rolls back. The pre-lock ``read_state`` is gone:
+    the helper is the sole authoritative gate inside the singleton
+    ``FOR UPDATE`` lock, so a stale ``last_run_id`` race is no
+    longer possible.
     """
-    state = read_state(conn)
-    if state.status == "running":
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "error": "bootstrap_running",
-                "current_run_id": state.last_run_id,
-            },
-        )
-    if state.last_run_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="no prior bootstrap run to retry",
-        )
-
-    try:
-        reset_count = reset_failed_stages_for_retry(conn, run_id=state.last_run_id)
-    except BootstrapAlreadyRunning as exc:
-        # Concurrent ``start_run`` flipped state to ``running`` between
-        # our pre-check above and the FOR UPDATE acquisition inside
-        # ``reset_failed_stages_for_retry``. Treat as 409 — same
-        # contract as the /run handler.
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "error": "bootstrap_running",
-                "current_run_id": exc.run_id,
-            },
-        ) from exc
-    if reset_count == 0:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="latest run has no failed stages to retry",
-        )
-
     requested_by = _identify_requestor(request)
-    request_id = publish_manual_job_request(JOB_BOOTSTRAP_ORCHESTRATOR, requested_by=requested_by)
+    with conn.transaction():
+        try:
+            run_id, reset_count = reset_failed_stages_for_retry(conn)
+        except BootstrapNoPriorRun as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="no prior bootstrap run to retry",
+            ) from exc
+        except BootstrapAlreadyRunning as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "bootstrap_running",
+                    "current_run_id": exc.run_id,
+                },
+            ) from exc
+        except BootstrapNotResettable as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "bootstrap_not_resettable",
+                    "current_status": exc.status,
+                },
+            ) from exc
+        if reset_count == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="latest run has no failed stages to retry",
+            )
+
+        try:
+            request_id = publish_manual_job_request_with_conn(
+                conn,
+                JOB_BOOTSTRAP_ORCHESTRATOR,
+                requested_by=requested_by,
+            )
+        except psycopg.OperationalError as exc:
+            logger.exception("bootstrap: queue publish failed (transient)")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={"error": "queue_publish_failed"},
+            ) from exc
+
     logger.info(
         "bootstrap: retry-failed run_id=%d reset_count=%d request_id=%d requested_by=%s",
-        state.last_run_id,
+        run_id,
         reset_count,
         request_id,
         requested_by,
     )
-    return BootstrapRunQueuedResponse(run_id=state.last_run_id, request_id=request_id)
+    return BootstrapRunQueuedResponse(run_id=run_id, request_id=request_id)
 
 
 # ---------------------------------------------------------------------------

--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -39,6 +39,8 @@ from app.jobs.runtime import VALID_JOB_NAMES
 from app.services.bootstrap_orchestrator import JOB_BOOTSTRAP_ORCHESTRATOR, get_bootstrap_stage_specs
 from app.services.bootstrap_state import (
     BootstrapAlreadyRunning,
+    BootstrapNoPriorRun,
+    BootstrapNotResettable,
     BootstrapNotRunning,
 )
 from app.services.bootstrap_state import (
@@ -1039,23 +1041,44 @@ def _apply_bootstrap_iterate_reset(conn: psycopg.Connection[Any]) -> None:
     Reuses ``bootstrap_state.reset_failed_stages_for_retry`` — the
     same helper the legacy ``POST /system/bootstrap/retry-failed``
     endpoint uses. The helper takes ``SELECT ... FOR UPDATE`` on the
-    bootstrap_state singleton internally, so a concurrent ``start_run``
-    racing in between the precondition gate and this call surfaces as
-    ``BootstrapAlreadyRunning`` and we map it to 409.
+    bootstrap_state singleton internally and is the sole authoritative
+    gate (#1139). All state/eligibility checks happen under that
+    lock; this caller passes no ``run_id`` argument and surfaces the
+    helper's three typed exceptions:
+
+      * ``BootstrapAlreadyRunning``  → 409 ``bootstrap_already_running``
+        (concurrent ``start_run`` slipped in between the precondition
+        gate and the FOR UPDATE acquisition).
+      * ``BootstrapNoPriorRun``      → 409 ``bootstrap_not_resumable``
+        (preserves the pre-#1139 detail string).
+      * ``BootstrapNotResettable``   → 409 ``bootstrap_not_resettable``
+        (singleton in a status that's not in {partial_error, cancelled}).
+
+    Returns silently on success. If the helper returns
+    ``reset_count == 0`` (latest run had no failed stages), raises
+    ``bootstrap_no_failed_stages`` so the trigger does NOT enqueue
+    the orchestrator for a no-op round (#1139 — pre-fix the caller
+    enqueued regardless).
     """
-    state_row = conn.execute("SELECT last_run_id FROM bootstrap_state WHERE id = 1").fetchone()
-    if state_row is None:
-        raise _conflict("bootstrap_state_missing", advice="run sql/129 migration")
-    last_run_id = state_row[0]
-    if last_run_id is None:
+    try:
+        _run_id, reset_count = bootstrap_reset_failed_stages(conn)
+    except BootstrapAlreadyRunning as exc:
+        raise _conflict("bootstrap_already_running") from exc
+    except BootstrapNoPriorRun as exc:
         raise _conflict(
             "bootstrap_not_resumable",
             advice="no prior bootstrap run to retry",
+        ) from exc
+    except BootstrapNotResettable as exc:
+        raise _conflict(
+            "bootstrap_not_resettable",
+            advice=f"singleton status {exc.status!r} is not resettable",
+        ) from exc
+    if reset_count == 0:
+        raise _conflict(
+            "bootstrap_no_failed_stages",
+            advice="latest run has no failed stages to iterate",
         )
-    try:
-        bootstrap_reset_failed_stages(conn, run_id=int(last_run_id))
-    except BootstrapAlreadyRunning as exc:
-        raise _conflict("bootstrap_already_running") from exc
 
 
 def _apply_bootstrap_full_wash_reset(
@@ -1078,11 +1101,10 @@ def _apply_bootstrap_full_wash_reset(
     'running'; ``start_run``'s internal ``FOR UPDATE`` is the
     defence-in-depth against a concurrent ``start_run`` slipping in.
     """
-    operator_id = str(operator_uuid) if operator_uuid is not None else None
     try:
         bootstrap_start_run(
             conn,
-            operator_id=operator_id,
+            operator_id=operator_uuid,
             stage_specs=get_bootstrap_stage_specs(),
         )
     except BootstrapAlreadyRunning as exc:

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -70,6 +70,30 @@ class BootstrapNotRunning(RuntimeError):
     """
 
 
+class BootstrapNoPriorRun(RuntimeError):
+    """Raised by ``reset_failed_stages_for_retry`` when the singleton's
+    ``last_run_id`` is NULL — no prior bootstrap run exists to retry.
+
+    Maps to 404. Precedes the status-check inside the helper so a fresh
+    install (`status='pending', last_run_id IS NULL`) returns the same
+    operator message as the wipe-then-mark-partial edge case. Issue #1139.
+    """
+
+
+class BootstrapNotResettable(RuntimeError):
+    """Raised by ``reset_failed_stages_for_retry`` when the singleton's
+    ``status`` is not in the resettable set (``partial_error`` or
+    ``cancelled``) but a prior run does exist.
+
+    Maps to 409 ``bootstrap_not_resettable``. Carries the current status
+    so the API response detail can name it. Issue #1139.
+    """
+
+    def __init__(self, status: str) -> None:
+        super().__init__(f"bootstrap state {status!r} is not resettable")
+        self.status = status
+
+
 class BootstrapStageCancelled(RuntimeError):
     """Raised by a long-running stage invoker when it observes the
     bootstrap-run cancel signal at one of its checkpoints.
@@ -245,7 +269,7 @@ def read_latest_run_with_stages(
 def start_run(
     conn: psycopg.Connection[Any],
     *,
-    operator_id: str | None,
+    operator_id: UUID | None,
     stage_specs: Sequence[StageSpec],
 ) -> int:
     """Create a new bootstrap run + seed pending stage rows.
@@ -257,6 +281,13 @@ def start_run(
     then flips ``bootstrap_state.status`` to ``running``.
 
     Returns the new ``bootstrap_runs.id``.
+
+    ``operator_id`` populates ``bootstrap_runs.triggered_by_operator_id``
+    for audit. ``None`` is correct for service-token initiated runs;
+    only operator-session callers populate the column. The retry path
+    must NOT overwrite this column on the existing row (#1139 — that
+    would corrupt original-run audit); only fresh runs created here
+    take a value.
 
     All work happens inside one transaction so a partial commit cannot
     leave a half-seeded run.
@@ -625,42 +656,47 @@ def finalize_run(
 
 def reset_failed_stages_for_retry(
     conn: psycopg.Connection[Any],
-    *,
-    run_id: int,
-) -> int:
+) -> tuple[int, int]:
     """Reset failed + later-numbered same-lane stages for retry.
 
-    Spec §"retry-failed dependency-aware reset". Returns the number
-    of rows reset to ``pending``.
+    Derives the target ``run_id`` from ``bootstrap_state.last_run_id``
+    under the same ``FOR UPDATE`` lock that gates status — callers
+    pass no ``run_id`` argument, so the stale-id race (#1139) is
+    structurally impossible.
 
-    Algorithm (one transaction, ``SELECT ... FOR UPDATE`` on the
-    singleton up front to prevent a concurrent ``start_run`` from
-    transitioning state to ``running`` between the API's earlier
-    status read and this reset — TOCTOU avoidance):
+    Returns ``(run_id, reset_count)`` on success. ``reset_count == 0``
+    means the singleton was in a resettable status but the latest run
+    had no failed stages — the helper does NOT flip state in that
+    case (nothing to retry); the API maps to 404.
 
-    1. Lock the bootstrap_state singleton row (``FOR UPDATE``).
-    2. Raise ``BootstrapAlreadyRunning`` if status flipped to
-       ``running`` since the API's pre-check; the API maps this to
-       a 409 response.
-    3. Find all failed (error) stages on the latest run.
-    4. For each lane that has at least one failed stage, find the
-       smallest ``stage_order`` of a failed stage in that lane.
-    5. Reset every stage in that lane with ``stage_order >=`` the
-       smallest-failed-order to ``pending``, regardless of current
-       status. The orchestrator's per-stage pre-check skips stages
-       already in ``success`` so only re-running re-enqueued
-       pending stages happens.
-    6. Flip bootstrap_state.status back to ``running``.
+    Raises (precedence — first match wins inside the lock):
+      * ``BootstrapNoPriorRun``     — singleton.last_run_id IS NULL
+                                      (any status). API → 404.
+      * ``BootstrapAlreadyRunning`` — singleton.status == 'running'.
+                                      API → 409 ``bootstrap_running``.
+      * ``BootstrapNotResettable``  — singleton.status in
+                                      {pending, complete} (i.e. not
+                                      in {partial_error, cancelled}).
+                                      API → 409 ``bootstrap_not_resettable``.
 
-    If no failed stages exist, returns 0 and leaves state untouched.
+    No-prior-run precedence means a fresh install
+    (``pending + last_run_id NULL``) returns the same 404 as the
+    wipe-then-mark-partial edge case — preserves the original
+    /retry-failed contract.
     """
     with conn.transaction():
         state_row = conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1 FOR UPDATE").fetchone()
         if state_row is None:
             raise RuntimeError("bootstrap_state singleton row missing")
         current_status, current_last_run_id = state_row
+        if current_last_run_id is None:
+            raise BootstrapNoPriorRun()
         if current_status == "running":
-            raise BootstrapAlreadyRunning(run_id=current_last_run_id or 0)
+            raise BootstrapAlreadyRunning(run_id=current_last_run_id)
+        if current_status not in ("partial_error", "cancelled"):
+            raise BootstrapNotResettable(status=current_status)
+
+        run_id = int(current_last_run_id)
 
         failed_rows = conn.execute(
             """
@@ -673,7 +709,7 @@ def reset_failed_stages_for_retry(
             {"run_id": run_id},
         ).fetchall()
         if not failed_rows:
-            return 0
+            return (run_id, 0)
 
         total_reset = 0
         for lane, min_order in failed_rows:
@@ -712,7 +748,7 @@ def reset_failed_stages_for_retry(
             {"run_id": run_id},
         )
 
-    return total_reset
+    return (run_id, total_reset)
 
 
 def force_mark_complete(
@@ -1083,6 +1119,8 @@ def reap_orphaned_running(
 
 __all__ = [
     "BootstrapAlreadyRunning",
+    "BootstrapNoPriorRun",
+    "BootstrapNotResettable",
     "BootstrapNotRunning",
     "BootstrapStageCancelled",
     "BootstrapState",

--- a/app/services/sync_orchestrator/dispatcher.py
+++ b/app/services/sync_orchestrator/dispatcher.py
@@ -136,31 +136,68 @@ def publish_manual_job_request(
     fence-check as ``UniqueViolation`` — handler maps to 409.
     """
     with psycopg.connect(settings.database_url, autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO pending_job_requests
-                    (request_kind, job_name, payload, requested_by, process_id, mode)
-                VALUES ('manual_job', %(job_name)s, %(payload)s, %(requested_by)s,
-                        %(process_id)s, %(mode)s)
-                RETURNING request_id
-                """,
-                {
-                    "job_name": job_name,
-                    "payload": Jsonb(payload) if payload is not None else None,
-                    "requested_by": requested_by,
-                    "process_id": process_id,
-                    "mode": mode,
-                },
-            )
-            row = cur.fetchone()
-            if row is None:
-                raise RuntimeError("INSERT...RETURNING produced no row")
-            request_id = int(row[0])
-            cur.execute(
-                "SELECT pg_notify(%s, %s)",
-                (NOTIFY_CHANNEL, str(request_id)),
-            )
+        return publish_manual_job_request_with_conn(
+            conn,
+            job_name,
+            requested_by=requested_by,
+            process_id=process_id,
+            mode=mode,
+            payload=payload,
+        )
+
+
+def publish_manual_job_request_with_conn(
+    conn: psycopg.Connection[Any],
+    job_name: str,
+    *,
+    requested_by: str | None = None,
+    process_id: str | None = None,
+    mode: Literal["iterate", "full_wash"] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> int:
+    """Same as ``publish_manual_job_request`` but uses the caller's
+    connection. Caller is responsible for the surrounding transaction
+    and commit.
+
+    Issue #1139: the bootstrap API needs the queue INSERT to live in
+    the same transaction as ``start_run`` / ``reset_failed_stages_for_retry``
+    so a publish failure rolls the state mutation back. The old
+    autocommit-only helper splits the work across two connections,
+    which strands the singleton at ``status='running'`` whenever the
+    publish step fails after the state commit lands.
+
+    NOTIFY semantics under a shared txn: PostgreSQL flushes the
+    notification queue at commit boundary, so the listener observes
+    the wakeup exactly when (and only when) the queue row is durable.
+    Strictly safer than the autocommit shape, which could fire NOTIFY
+    in a separate txn before the queue row's own commit returned to
+    the client.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO pending_job_requests
+                (request_kind, job_name, payload, requested_by, process_id, mode)
+            VALUES ('manual_job', %(job_name)s, %(payload)s, %(requested_by)s,
+                    %(process_id)s, %(mode)s)
+            RETURNING request_id
+            """,
+            {
+                "job_name": job_name,
+                "payload": Jsonb(payload) if payload is not None else None,
+                "requested_by": requested_by,
+                "process_id": process_id,
+                "mode": mode,
+            },
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise RuntimeError("INSERT...RETURNING produced no row")
+        request_id = int(row[0])
+        cur.execute(
+            "SELECT pg_notify(%s, %s)",
+            (NOTIFY_CHANNEL, str(request_id)),
+        )
     return request_id
 
 
@@ -363,6 +400,7 @@ __all__ = [
     "mark_request_dispatched",
     "mark_request_rejected",
     "publish_manual_job_request",
+    "publish_manual_job_request_with_conn",
     "publish_sync_request",
     "reset_stale_in_flight",
     "scope_from_json",

--- a/docs/superpowers/specs/2026-05-13-atomic-bootstrap-enqueue.md
+++ b/docs/superpowers/specs/2026-05-13-atomic-bootstrap-enqueue.md
@@ -1,0 +1,492 @@
+# Atomic bootstrap run enqueue + retry-failed + operator audit
+
+**Date:** 2026-05-13
+**Issue:** [#1139](https://github.com/Luke-Bradford/eBull/issues/1139)
+(Task B of [#1136](https://github.com/Luke-Bradford/eBull/issues/1136) audit)
+**Status:** Draft — pending Codex review
+
+## 1. Problem
+
+`POST /system/bootstrap/run` (`app/api/bootstrap.py::run_bootstrap`)
+and `POST /system/bootstrap/retry-failed`
+(`app/api/bootstrap.py::retry_failed`) call two side-effecting
+functions back-to-back:
+
+1. `start_run(conn, ...)` (or `reset_failed_stages_for_retry(conn, run_id=...)`)
+   — runs inside its own `with conn.transaction():` block. Commits on
+   success: `bootstrap_state.status='running'`, `bootstrap_runs` row
+   inserted (or stages reset), pending stage rows seeded.
+2. `publish_manual_job_request(JOB_BOOTSTRAP_ORCHESTRATOR, ...)` —
+   `app/services/sync_orchestrator/dispatcher.py:105`. Opens a fresh
+   `psycopg.connect(..., autocommit=True)` connection and inserts a
+   `pending_job_requests` row + `pg_notify` for the listener.
+
+If step (1) commits and step (2) raises (DB blip, pool exhausted,
+insert/constraint failure, NOTIFY failure), the singleton stays at
+`status='running'` with seeded `pending` stages and **no orchestrator
+queue row**. From the API's perspective: 500. From the operator's
+perspective: bootstrap stuck "running" with nothing draining; only
+escape is a manual SQL or a `/mark-complete` (which is 409-gated by
+`status='running'`, so won't even work).
+
+Same shape for `/retry-failed`: reset commits, publish fails, run is
+stranded.
+
+Audit §3 in #1136 flagged this as a real window. Codex agreed in the
+spec review for #1138.
+
+Secondary defect, same audit clause: `start_run(operator_id=None, ...)`
+is hardcoded in the API even when the request bears an authenticated
+operator id. `bootstrap_runs.triggered_by_operator_id` therefore
+always reads NULL for user-triggered runs, breaking audit forensics
+("which operator kicked off this rebuild?"). The `/cancel` endpoint
+already extracts the operator UUID via `_operator_uuid(request)`;
+`/run` just doesn't use it.
+
+## 2. Goal
+
+Eliminate the stuck-run window by making run-creation/reset + queue
+publish a **single transaction** on a single connection. Both
+mutations land or neither lands. Propagate operator identity into
+`bootstrap_runs.triggered_by_operator_id` for the audit trail.
+
+## 3. Non-goals
+
+- A boot-reaper sweep (issue option (c)). Once the txn is atomic the
+  reaper has nothing to sweep — there is no "started but never
+  queued" state to recover. If a later decoupled-queue path appears
+  (cross-DB queue, message broker), a reaper is the correct fix at
+  that point; punt to a follow-up ticket then.
+- Auto-recovery of orphan rows from any pre-fix stranded runs.
+  Cleanup is a one-shot explicit-SQL operator step on dev DB; the
+  exact statements are in §6.
+- Refactoring `cancel_run` / `force_mark_complete` to also wrap a
+  publish — they don't publish to the queue in the current flow.
+
+## 4. Design
+
+### 4.1 Shared-connection publish helper
+
+Add to `app/services/sync_orchestrator/dispatcher.py`:
+
+```python
+def publish_manual_job_request_with_conn(
+    conn: psycopg.Connection[Any],
+    job_name: str,
+    *,
+    requested_by: str | None = None,
+    process_id: str | None = None,
+    mode: Literal["iterate", "full_wash"] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> int:
+    """Same as publish_manual_job_request but uses the caller's
+    connection. Caller is responsible for the surrounding transaction
+    / commit. INSERT + pg_notify both stay buffered until the caller
+    commits — Postgres flushes NOTIFY on commit, so the listener sees
+    the wakeup exactly when (and only when) the queue row is durable.
+    """
+```
+
+Implementation: same INSERT + pg_notify SQL as the existing helper,
+just executed on `conn.cursor()` instead of `psycopg.connect(...)`.
+No autocommit override; the caller owns the txn.
+
+The existing `publish_manual_job_request(...)` stays — only the
+bootstrap API needs the shared-conn variant. Other callers (jobs UI,
+processes endpoints) still open their own conn.
+
+### 4.2 API wrap
+
+Refactor `run_bootstrap`:
+
+```python
+operator_id = _operator_uuid(request)
+try:
+    with conn.transaction():
+        run_id = start_run(
+            conn,
+            operator_id=operator_id,
+            stage_specs=get_bootstrap_stage_specs(),
+        )
+        requested_by = _identify_requestor(request)
+        request_id = publish_manual_job_request_with_conn(
+            conn,
+            JOB_BOOTSTRAP_ORCHESTRATOR,
+            requested_by=requested_by,
+        )
+except BootstrapAlreadyRunning as exc:
+    raise HTTPException(409, ...)
+```
+
+`start_run` already opens its own inner `with conn.transaction():` —
+psycopg3 nests that as a SAVEPOINT. If `publish_manual_job_request_with_conn`
+raises, the SAVEPOINT is gone with the outer rollback and **nothing
+commits**. Single-flight is preserved (the inner txn still acquires
+the `FOR UPDATE` lock on `bootstrap_state`).
+
+Same shape for `retry_failed`: drop the pre-lock `read_state` call
+(it's racy — Codex R1 W §6 / §7). Change
+`reset_failed_stages_for_retry`'s signature to **derive** the target
+run id from the singleton under lock — no `run_id` parameter, no
+caller-supplied stale read. Then wrap the helper +
+`publish_manual_job_request_with_conn` in one `with conn.transaction():`
+on the API side. The helper returns `(run_id, reset_count)` so the
+API has both for the response body.
+
+### 4.3 `reset_failed_stages_for_retry` hardening (Codex R1 BLOCKING §2 + §3, R2 BLOCKING §1)
+
+Current signature:
+
+```python
+def reset_failed_stages_for_retry(conn, *, run_id: int) -> int:
+```
+
+New signature:
+
+```python
+def reset_failed_stages_for_retry(conn) -> tuple[int, int]:
+    """Reset failed + later-numbered same-lane stages for retry.
+
+    Derives the target ``run_id`` from ``bootstrap_state.last_run_id``
+    under the same ``FOR UPDATE`` lock that the state-check uses.
+    Caller passes nothing.
+
+    Returns ``(run_id, reset_count)`` on success. ``reset_count`` is
+    0 when the singleton is in a resettable status but the latest
+    run has no failed stages — the helper does NOT flip state in
+    that case (nothing to retry) and the API maps it to 404.
+
+    Raises (precedence order — first matching wins):
+      BootstrapNoPriorRun      — singleton.last_run_id IS NULL,
+                                 regardless of status (API 404,
+                                 preserves the existing /retry-failed
+                                 "no prior bootstrap run to retry" 404
+                                 contract — Codex R3 WARNING §2 /
+                                 R4 WARNING §1).
+      BootstrapAlreadyRunning  — singleton.status == 'running' (API 409).
+      BootstrapNotResettable   — singleton.status in {pending, complete};
+                                 i.e. not in {partial_error, cancelled}.
+                                 (API 409 ``bootstrap_not_resettable``.)
+    """
+```
+
+`BootstrapNoPriorRun` precedes the status check on purpose: a fresh
+install (`pending + last_run_id NULL`) and a wipe-then-mark-partial
+(`partial_error + last_run_id NULL`) both deserve the same operator
+message — "there is no run to retry; trigger /run first" — and the
+existing endpoint returned 404 for both. Keeping the 404 shape
+preserves any FE/runbook that already depends on it.
+
+Resolution shape (precedence top-to-bottom):
+
+| Singleton state at FOR UPDATE                                          | Helper return / raise                                            | API status                       |
+| ---                                                                    | ---                                                              | ---                              |
+| `last_run_id IS NULL` (any status)                                     | raises `BootstrapNoPriorRun()`                                   | 404 `no_prior_run`               |
+| `running` (last_run_id set)                                            | raises `BootstrapAlreadyRunning(run_id)`                         | 409 `bootstrap_running`          |
+| `pending` or `complete` (last_run_id set)                              | raises `BootstrapNotResettable(status)`                          | 409 `bootstrap_not_resettable`   |
+| `partial_error` or `cancelled`, valid `last_run_id`, no failed stages  | returns `(last_run_id, 0)`  (state untouched)                    | 404 `no_failed_stages`           |
+| `partial_error` or `cancelled`, valid `last_run_id`, ≥1 failed stage   | returns `(last_run_id, n)` and flips state back to `running`     | 202                              |
+
+`BootstrapRunIdMismatch` from the previous draft is dropped — once
+the helper derives `run_id` under lock there is no stale id to
+compare against.
+
+Both call sites updated:
+
+- `app/api/bootstrap.py::retry_failed` — drop the pre-lock
+  `read_state` call entirely. Call the no-arg helper. Catch
+  `BootstrapAlreadyRunning` → 409 (existing). Catch
+  `BootstrapNotResettable` → 409 `bootstrap_not_resettable`. Catch
+  `BootstrapNoPriorRun` → 404 (existing 404 text preserved). On
+  return: if `reset_count == 0` → 404 `no failed stages to retry`
+  (existing 404 text preserved). On `reset_count > 0` → enqueue
+  publish, return 202.
+- `app/api/processes.py::_apply_bootstrap_iterate_reset` (Codex R2
+  BLOCKING §2 + R3 BLOCKING §1) — drop the local
+  `SELECT last_run_id` pre-read; the helper is now authoritative.
+  Catch:
+  - `BootstrapAlreadyRunning` → `_conflict("bootstrap_already_running")` (existing).
+  - `BootstrapNotResettable` → `_conflict("bootstrap_not_resettable")` (new — without this the call site would surface 500).
+  - `BootstrapNoPriorRun` → `_conflict("bootstrap_not_resumable")` (preserves the helper's current 409 text).
+  - Return value: if `reset_count == 0`, **do not enqueue the
+    orchestrator** — surface `_conflict("bootstrap_no_failed_stages",
+    advice="latest run has no failed stages to iterate")` so the
+    processes shim doesn't fire a no-op orchestrator run. Pre-fix
+    the helper raised on no-failed silently and the caller still
+    enqueued; the new shape makes the no-op explicit (Codex R3
+    BLOCKING §1).
+
+Add two new exception classes in `bootstrap_state.py`:
+`BootstrapNotResettable` (carries `status` for the response detail)
+and `BootstrapNoPriorRun` (parameterless). Keep
+`BootstrapAlreadyRunning` (unchanged).
+
+Existing direct callers of the helper (Codex R4 WARNING §2) that
+must update from `reset_failed_stages_for_retry(conn, run_id=...)`
+→ `reset_failed_stages_for_retry(conn)` and unpack the tuple
+return:
+
+- `tests/test_bootstrap_cancel.py:479`
+- `tests/test_bootstrap_cancel.py:663`
+- `tests/test_bootstrap_state.py:188`
+- `tests/test_bootstrap_state.py:220`
+- `tests/test_bootstrap_flow_integration.py:210`
+
+Each call site is in a test that already seeds the singleton
+appropriately (sets `last_run_id` before calling the helper); the
+update is mechanical — drop the kwarg, unpack `(run_id, count)`,
+compare `count` to the existing assertion. No semantic change for
+the cancelled-stage retry path that those tests cover.
+
+### 4.4 Operator identity propagation (Codex R1 BLOCKING §4 — scope to /run only)
+
+`start_run`'s `operator_id` parameter type is `str | None`. The DB
+column is `UUID REFERENCES operators(operator_id)`. Widen to `UUID
+| None` for type-clarity and pass the parsed UUID through on the
+**`/run` path only**.
+
+`/retry-failed` re-uses the existing `bootstrap_runs` row; updating
+its `triggered_by_operator_id` would corrupt the original-run audit
+("who started this run?" → would silently change to the retry
+operator's UUID). Don't touch the column on retry. Existing audit of
+who-triggered-retry can ride on application logs (already emitted by
+`logger.info("bootstrap: retry-failed ...")`); a separate audit
+column is out of scope and filed as follow-up tech-debt if needed.
+
+Reuse the existing `_operator_uuid(request)` helper on the API side
+(it already handles "not a UUID → log + audit as NULL" for malformed
+state). Pass into `/run` only.
+
+Service-token-only paths leave `triggered_by_operator_id` `None`
+honestly — documented in the `start_run` docstring as "NULL is
+correct for service-token initiated runs; only operator-session
+callers populate the column".
+
+### 4.5 NOTIFY semantics under shared txn
+
+The existing autocommit version fires NOTIFY immediately on each
+statement. The shared-conn variant defers NOTIFY to outer commit
+(PostgreSQL's actual semantics — `pg_notify` queues are flushed at
+commit boundary). The orchestrator listener observes the wakeup the
+moment the queue row is durable — strictly safer than the
+fire-then-commit ordering of the old code, which could in principle
+have woken the listener for a row that hadn't yet committed (psycopg
+autocommit puts each statement in its own txn so it commits before
+the NOTIFY queue flush, but the ordering was racier in the
+multi-statement case). The new shape is correct-by-construction.
+
+## 5. Tests
+
+### 5.1 Mock-level (unit, in `tests/test_api_bootstrap.py`)
+
+- **Existing happy-path test stays** — covers normal flow.
+- **New: publish failure rolls back start_run**. Patch
+  `app.api.bootstrap.publish_manual_job_request_with_conn` to raise.
+  Assert response is 500 (or 503 — see §5.3) AND that `start_run`'s
+  effects don't leak (the mock conn's transaction context manager
+  saw an exception). Since these are mocks, the verification is "the
+  conn's `__enter__`/`__exit__` were entered + exited with an
+  exception"; real rollback semantics belong in the integration test.
+- **Same for retry-failed.**
+- **New: operator UUID passed through**. Stub request middleware to
+  set `request.state.operator_id = "<uuid>"`. Assert `start_run` is
+  called with `operator_id=<UUID>` (not None).
+
+### 5.2 Real-DB integration (new file `tests/test_bootstrap_atomic_enqueue.py`)
+
+Uses `ebull_test_conn` per `feedback_test_db_isolation`.
+
+- **rollback_on_publish_failure** — call the API handler via
+  TestClient with a monkeypatch that makes
+  `publish_manual_job_request_with_conn` raise. After the call,
+  query `bootstrap_state.status`, `bootstrap_runs`, `bootstrap_stages`
+  — all unchanged (no `running` row, no seeded stages). Also assert
+  no `pending_job_requests` row exists for the bootstrap job.
+- **commit_on_success** — opposite: both tables populated, queue row
+  present, NOTIFY fires. Verified by a dedicated `LISTEN` connection
+  that has issued `LISTEN ebull_job_request` and committed BEFORE
+  the API call; poll `conn.notifies()` for up to 5s after the
+  publishing commit (the autocommit-era `~100ms` budget was flaky).
+- **retry_failed_rollback** — seed a `partial_error` run with a
+  failed stage, monkeypatch publish to raise, call
+  `/retry-failed`, assert stage stays `error` (not reset to
+  `pending`) and state stays `partial_error`.
+- **retry_failed_targets_singleton_last_run_id** (Codex R1 WARNING
+  §7 — superseded shape) — seed run 1 in `partial_error`, then
+  insert run 2 in `partial_error` and explicitly set
+  `bootstrap_state.last_run_id = 2`. Call `/retry-failed`. Assert
+  the helper resets stages on run 2 (not run 1) and that run 1's
+  stage rows are untouched. The new helper derives the target run
+  from the singleton under lock — there is no stale caller-supplied
+  id to mismatch against, so the race the audit flagged is
+  structurally impossible.
+- **retry_failed_no_prior_run** — singleton at `partial_error`,
+  `last_run_id IS NULL` (e.g. a wipe-then-mark-partial-error edge
+  case). Call `/retry-failed`; assert 404 — existing contract
+  preserved (Codex R3 WARNING §2). Helper raises
+  `BootstrapNoPriorRun`.
+- **retry_failed_pending_state_no_prior_run_404** (Codex R4 WARNING
+  §1) — singleton at `pending` with `last_run_id IS NULL` (the
+  fresh-install state). Call `/retry-failed`; assert 404 (the
+  no-prior-run branch precedes the status check — preserves the
+  existing 404 contract for fresh installs).
+- **retry_failed_pending_with_orphan_last_run_409** — synthetic
+  fixture where singleton is `pending` but `last_run_id` is set
+  (shouldn't happen in normal flow but possible via raw SQL).
+  Assert 409 `error="bootstrap_not_resettable"` — status check
+  fires after no-prior-run check is bypassed.
+- **retry_failed_no_failed_stages** — singleton at `partial_error`,
+  `last_run_id` set, but all stages already `success`. Helper
+  returns `(run_id, 0)`. API maps to 404, **does NOT enqueue**
+  (assert `pending_job_requests` count unchanged) — pre-fix
+  behaviour: also no enqueue (current API already 404-guarded).
+- **retry_failed_wrong_status** — singleton at `complete`. Call
+  helper directly; assert `BootstrapNotResettable`; assert state
+  still `complete`. API-level twin: call `/retry-failed`; assert
+  409 `error="bootstrap_not_resettable"`.
+- **iterate_reset_processes_endpoint_widened_catch** (Codex R2
+  BLOCKING §2 — implementation finding) — the processes endpoint's
+  PR-#1071 precondition gate at
+  `app/api/processes.py::_check_bootstrap_iterate_preconditions`
+  catches `complete`/`pending` *before* the trigger reaches
+  `_apply_bootstrap_iterate_reset`, surfacing
+  `bootstrap_not_resumable` (lines 911-917). The helper-level
+  `BootstrapNotResettable` catch (lines 1072-1076) is therefore
+  reachable only via a TOCTOU race between the precondition gate
+  and the singleton FOR UPDATE — not via a straightforward complete-
+  state call. The defense-in-depth catch is still required (without
+  it the race surfaces as 500); the explicit complete-state test in
+  the original spec is unreachable in practice and is dropped in
+  favour of:
+  - The existing `test_trigger_bootstrap_iterate_from_pending_returns_409`
+    (precondition gate hit; preserved behaviour).
+  - **iterate_reset_processes_no_failed_stages_no_enqueue** below
+    (helper-level no-op-no-enqueue path; exercises the new code).
+- **iterate_reset_processes_no_failed_stages_no_enqueue** (Codex
+  R3 BLOCKING §1 + WARNING §4) — singleton at `partial_error`,
+  no failed stages. Hit the processes iterate shim. Assert 409
+  `error="bootstrap_no_failed_stages"` AND that
+  `pending_job_requests` has no new orchestrator row (the
+  processes endpoint must not enqueue on the no-op).
+- **iterate_reset_processes_no_prior_run** (Codex R3 WARNING §4)
+  — singleton at `partial_error`, `last_run_id IS NULL`. Hit the
+  iterate shim. Assert 409 `error="bootstrap_not_resumable"`
+  (preserves the existing processes-endpoint text).
+- **operator_uuid_persisted** — call `/run` with a stubbed operator
+  session A; assert `bootstrap_runs.triggered_by_operator_id =
+  <uuidA>`. Then (Codex R4 NIT §3 + R5 NIT §1) transition the
+  run to a fully-consistent retryable state by directly setting
+  one stage to `error`, flipping `bootstrap_runs.status =
+  'partial_error'` with `completed_at = now()`, AND flipping
+  `bootstrap_state.status = 'partial_error'` — keeps the run +
+  singleton consistent (don't drive a real orchestrator round in
+  this test). Call `/retry-failed` with a
+  *different* operator session B; assert the call succeeds AND
+  that `bootstrap_runs.triggered_by_operator_id` is still
+  `<uuidA>` — NOT overwritten to B (Codex R1 BLOCKING §4
+  regression guard). The retry path does not read or write the
+  column at all in the new code, but the test pins the invariant.
+
+### 5.3 Error-code shape (Codex BLOCKING §1 — phase-aware)
+
+Catching a bare `Exception` around the combined block mislabels
+`start_run` failures (FK violation, schema drift, programming error)
+as `queue_publish_failed`. Phase-aware shape:
+
+- `start_run` raises `BootstrapAlreadyRunning` → 409 (existing
+  contract, unchanged).
+- `start_run` raises anything else → propagate untouched; FastAPI
+  turns it into 500 with the original stack in logs. No re-wrap.
+- `publish_manual_job_request_with_conn` raises
+  `psycopg.OperationalError` → 503 with `{"error":
+  "queue_publish_failed"}`. Transient; FE renders retry toast.
+- `publish_manual_job_request_with_conn` raises anything else →
+  propagate untouched → 500. Programming error or constraint
+  violation; needs a fix, not a retry.
+
+Concrete shape:
+
+```python
+try:
+    with conn.transaction():
+        run_id = start_run(conn, operator_id=operator_uuid, stage_specs=...)
+        try:
+            request_id = publish_manual_job_request_with_conn(
+                conn, JOB_BOOTSTRAP_ORCHESTRATOR, requested_by=requested_by,
+            )
+        except psycopg.OperationalError as exc:
+            logger.exception("bootstrap: queue publish failed (transient)")
+            raise HTTPException(503, {"error": "queue_publish_failed"}) from exc
+except BootstrapAlreadyRunning as exc:
+    raise HTTPException(409, ...)
+```
+
+The inner `HTTPException` raise inside `with conn.transaction():`
+propagates out — psycopg sees the exception and rolls the outer
+txn back. FastAPI then serves the 503.
+
+## 6. Migration / rollout
+
+- No schema change.
+- No data migration. Pre-existing stranded `running` rows (if any
+  exist in dev/prod from before this fix) cannot be cleared via
+  `/mark-complete` — that endpoint is 409-gated by
+  `status='running'` (Codex R1 WARNING §5 — earlier spec wording
+  was wrong). Operator cleanup path is explicit SQL on dev DB,
+  honouring the existing CHECK constraint
+  (`status IN ('pending','running','complete','partial_error','cancelled')`
+  per `sql/129_bootstrap_state.sql` + `sql/136_bootstrap_runs_cancel.sql`):
+
+  ```sql
+  -- Stale-run cleanup (use only if you confirm no orchestrator is draining)
+  UPDATE bootstrap_state SET status='partial_error' WHERE id=1 AND status='running';
+  UPDATE bootstrap_runs  SET status='partial_error', completed_at=now()
+   WHERE status='running';
+  UPDATE bootstrap_stages SET status='error', last_error='stranded-pre-1139'
+   WHERE status IN ('pending','running');
+  ```
+
+  (`bootstrap_stages.status` accepts `'error'`; only the parent
+  `bootstrap_runs.status` is constrained — Codex R2 BLOCKING §3.)
+
+  Then `/mark-complete` or `/retry-failed` is reachable again. This
+  is a one-shot transitional cleanup; post-merge no new stranded
+  rows can be created.
+- Backwards-compatible: callers of `publish_manual_job_request`
+  (non-bootstrap) are not touched.
+
+## 7. Smoke / verification
+
+`uv run pytest tests/test_api_bootstrap.py tests/test_bootstrap_atomic_enqueue.py tests/smoke/test_app_boots.py -q`
+
+Manual verification on dev DB:
+
+1. Start dev stack.
+2. `curl -X POST :8000/system/bootstrap/run -H 'X-Service-Token: ...'`
+   — expect 202 with run_id + request_id.
+3. Inspect: `psql -c "SELECT status FROM bootstrap_state"` shows
+   `running`; `psql -c "SELECT request_id FROM pending_job_requests
+   ORDER BY request_id DESC LIMIT 1"` shows the new row.
+4. Operator-side audit: `psql -c "SELECT triggered_by_operator_id
+   FROM bootstrap_runs ORDER BY id DESC LIMIT 1"` is the operator's
+   UUID (not NULL).
+
+## 8. Risk / rollback
+
+Risk: the shared-conn variant of publish bypasses the autocommit
+contract. If a future caller copies the pattern but forgets the
+surrounding `with conn.transaction():`, the queue insert will sit
+in an open implicit psycopg txn until pool checkin, which commits.
+The risk is "row arrives later than expected" — never destructive.
+Mitigation: the helper is named explicitly `_with_conn` and the
+docstring says "caller owns the txn".
+
+Rollback: revert the PR. No DB shape change, no data migration.
+
+## 9. Out-of-scope follow-ups
+
+- A reaper exists in skeleton at `app/jobs/runtime.py` for orphan
+  process cleanup; if a future cross-DB or message-broker queue
+  splits this txn back apart, add `bootstrap` to its sweep then.
+- Task C / #1140 (capability + rows_written gates) is unblocked by
+  #1138 and lands separately.

--- a/tests/test_api_bootstrap.py
+++ b/tests/test_api_bootstrap.py
@@ -147,7 +147,7 @@ def test_run_creates_new_run_and_publishes_queue_row(client: TestClient) -> None
     _install_conn()
     with (
         patch("app.api.bootstrap.start_run", return_value=42) as start_mock,
-        patch("app.api.bootstrap.publish_manual_job_request", return_value=99) as publish_mock,
+        patch("app.api.bootstrap.publish_manual_job_request_with_conn", return_value=99) as publish_mock,
     ):
         resp = client.post("/system/bootstrap/run")
 
@@ -157,9 +157,10 @@ def test_run_creates_new_run_and_publishes_queue_row(client: TestClient) -> None
     assert body["request_id"] == 99
     start_mock.assert_called_once()
     publish_mock.assert_called_once()
-    # The publish call must use the orchestrator job name.
+    # The publish call must use the orchestrator job name (positional arg 1
+    # after the conn passed at arg 0 — #1139 shared-conn signature).
     publish_args = publish_mock.call_args
-    assert publish_args.args[0] == "bootstrap_orchestrator"
+    assert publish_args.args[1] == "bootstrap_orchestrator"
 
 
 def test_run_returns_409_when_already_running(client: TestClient) -> None:
@@ -168,7 +169,7 @@ def test_run_returns_409_when_already_running(client: TestClient) -> None:
     _install_conn()
     with (
         patch("app.api.bootstrap.start_run", side_effect=BootstrapAlreadyRunning(run_id=7)),
-        patch("app.api.bootstrap.publish_manual_job_request") as publish_mock,
+        patch("app.api.bootstrap.publish_manual_job_request_with_conn") as publish_mock,
     ):
         resp = client.post("/system/bootstrap/run")
 
@@ -179,69 +180,132 @@ def test_run_returns_409_when_already_running(client: TestClient) -> None:
     publish_mock.assert_not_called()
 
 
+def test_run_returns_503_on_publish_operational_error(client: TestClient) -> None:
+    """#1139 — transient OperationalError from publish maps to 503.
+
+    The outer ``with conn.transaction():`` sees the HTTPException, rolls
+    back (verified end-to-end in the integration test), and surfaces
+    503 ``queue_publish_failed`` so the FE can render a retry toast.
+    """
+    import psycopg
+
+    _install_conn()
+    with (
+        patch("app.api.bootstrap.start_run", return_value=42),
+        patch(
+            "app.api.bootstrap.publish_manual_job_request_with_conn",
+            side_effect=psycopg.OperationalError("connection wedged"),
+        ),
+    ):
+        resp = client.post("/system/bootstrap/run")
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error"] == "queue_publish_failed"
+
+
 # ---------------------------------------------------------------------------
 # POST /system/bootstrap/retry-failed
 # ---------------------------------------------------------------------------
 
 
 def test_retry_failed_resets_and_publishes(client: TestClient) -> None:
-    from app.services.bootstrap_state import BootstrapState
-
     _install_conn()
     with (
         patch(
-            "app.api.bootstrap.read_state",
-            return_value=BootstrapState(status="partial_error", last_run_id=42, last_completed_at=None),
-        ),
-        patch("app.api.bootstrap.reset_failed_stages_for_retry", return_value=3) as reset_mock,
-        patch("app.api.bootstrap.publish_manual_job_request", return_value=100) as publish_mock,
+            "app.api.bootstrap.reset_failed_stages_for_retry",
+            return_value=(42, 3),
+        ) as reset_mock,
+        patch("app.api.bootstrap.publish_manual_job_request_with_conn", return_value=100) as publish_mock,
     ):
         resp = client.post("/system/bootstrap/retry-failed")
 
     assert resp.status_code == 202
     assert resp.json() == {"run_id": 42, "request_id": 100}
-    reset_mock.assert_called_once_with(_anyconn(), run_id=42)
+    # No-arg call shape (#1139 — helper is sole gate, derives run_id under lock).
+    reset_mock.assert_called_once_with(_anyconn())
     publish_mock.assert_called_once()
 
 
 def test_retry_failed_returns_409_while_running(client: TestClient) -> None:
-    from app.services.bootstrap_state import BootstrapState
+    from app.services.bootstrap_state import BootstrapAlreadyRunning
 
     _install_conn()
     with patch(
-        "app.api.bootstrap.read_state",
-        return_value=BootstrapState(status="running", last_run_id=7, last_completed_at=None),
+        "app.api.bootstrap.reset_failed_stages_for_retry",
+        side_effect=BootstrapAlreadyRunning(run_id=7),
     ):
         resp = client.post("/system/bootstrap/retry-failed")
     assert resp.status_code == 409
-    assert resp.json()["detail"]["error"] == "bootstrap_running"
+    detail = resp.json()["detail"]
+    assert detail["error"] == "bootstrap_running"
+    assert detail["current_run_id"] == 7
 
 
 def test_retry_failed_returns_404_with_no_prior_run(client: TestClient) -> None:
-    from app.services.bootstrap_state import BootstrapState
+    from app.services.bootstrap_state import BootstrapNoPriorRun
 
     _install_conn()
     with patch(
-        "app.api.bootstrap.read_state",
-        return_value=BootstrapState(status="pending", last_run_id=None, last_completed_at=None),
+        "app.api.bootstrap.reset_failed_stages_for_retry",
+        side_effect=BootstrapNoPriorRun(),
     ):
         resp = client.post("/system/bootstrap/retry-failed")
     assert resp.status_code == 404
 
 
+def test_retry_failed_returns_409_when_not_resettable(client: TestClient) -> None:
+    """#1139 — pending/complete/etc surface as 409 bootstrap_not_resettable.
+
+    Preserves the operator-visible distinction between "no prior run"
+    (404) and "wrong status for retry" (409).
+    """
+    from app.services.bootstrap_state import BootstrapNotResettable
+
+    _install_conn()
+    with patch(
+        "app.api.bootstrap.reset_failed_stages_for_retry",
+        side_effect=BootstrapNotResettable(status="complete"),
+    ):
+        resp = client.post("/system/bootstrap/retry-failed")
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error"] == "bootstrap_not_resettable"
+    assert detail["current_status"] == "complete"
+
+
 def test_retry_failed_returns_404_when_no_failed_stages(client: TestClient) -> None:
-    from app.services.bootstrap_state import BootstrapState
+    _install_conn()
+    with (
+        patch(
+            "app.api.bootstrap.reset_failed_stages_for_retry",
+            return_value=(42, 0),
+        ),
+        patch("app.api.bootstrap.publish_manual_job_request_with_conn") as publish_mock,
+    ):
+        resp = client.post("/system/bootstrap/retry-failed")
+    assert resp.status_code == 404
+    publish_mock.assert_not_called()
+
+
+def test_retry_failed_returns_503_on_publish_operational_error(client: TestClient) -> None:
+    """#1139 — publish failure on retry path rolls back the reset."""
+    import psycopg
 
     _install_conn()
     with (
         patch(
-            "app.api.bootstrap.read_state",
-            return_value=BootstrapState(status="partial_error", last_run_id=42, last_completed_at=None),
+            "app.api.bootstrap.reset_failed_stages_for_retry",
+            return_value=(42, 3),
         ),
-        patch("app.api.bootstrap.reset_failed_stages_for_retry", return_value=0),
+        patch(
+            "app.api.bootstrap.publish_manual_job_request_with_conn",
+            side_effect=psycopg.OperationalError("connection wedged"),
+        ),
     ):
         resp = client.post("/system/bootstrap/retry-failed")
-    assert resp.status_code == 404
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error"] == "queue_publish_failed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap_atomic_enqueue.py
+++ b/tests/test_bootstrap_atomic_enqueue.py
@@ -1,0 +1,570 @@
+"""Real-DB integration tests for #1139.
+
+End-to-end coverage of the atomic enqueue contract:
+
+  * ``POST /system/bootstrap/run`` and ``POST /system/bootstrap/retry-failed``
+    create the run / reset stages AND insert the
+    ``pending_job_requests`` row inside a single transaction. A publish
+    failure rolls **both** sides back so the singleton never strands at
+    ``status='running'`` with no queue row.
+  * ``bootstrap_runs.triggered_by_operator_id`` is populated from the
+    request's authenticated operator UUID on ``/run`` and is **not**
+    overwritten by a subsequent ``/retry-failed`` from a different
+    operator.
+  * The new ``BootstrapNoPriorRun`` / ``BootstrapNotResettable`` /
+    ``BootstrapAlreadyRunning`` precedence inside the no-arg
+    ``reset_failed_stages_for_retry`` matches the spec table in
+    docs/superpowers/specs/2026-05-13-atomic-bootstrap-enqueue.md.
+
+The processes-endpoint coverage of ``_apply_bootstrap_iterate_reset``'s
+new exception handling + no-op-no-enqueue path lives in
+``tests/test_processes_endpoints.py``.
+
+DB-backed: the contract under test is the atomicity of two SQL writes
+on the same connection. Mocks can't show that the publish failure
+rolls back the singleton flip — that's a Postgres guarantee, and
+verifying it requires the real engine.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_conn
+from app.main import app
+from app.services.bootstrap_state import (
+    BootstrapAlreadyRunning,
+    BootstrapNoPriorRun,
+    BootstrapNotResettable,
+    StageSpec,
+    finalize_run,
+    mark_stage_error,
+    mark_stage_running,
+    mark_stage_success,
+    read_latest_run_with_stages,
+    read_state,
+    reset_failed_stages_for_retry,
+    start_run,
+)
+
+client = TestClient(app)
+
+
+# Use a stage-spec triple that mirrors the production lanes used by
+# the orchestrator so the lane-min-order walk in
+# ``reset_failed_stages_for_retry`` exercises the same code path as
+# production (one init, one etoro, one sec).
+_SPECS = (
+    StageSpec(stage_key="universe_sync", stage_order=1, lane="init", job_name="nightly_universe_sync"),
+    StageSpec(stage_key="candle_refresh", stage_order=2, lane="etoro", job_name="daily_candle_refresh"),
+    StageSpec(stage_key="cusip_universe_backfill", stage_order=3, lane="sec", job_name="cusip_universe_backfill"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn_override(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> Iterator[None]:
+    """Route the FastAPI ``get_conn`` dep to the test DB connection.
+
+    Mirrors the pattern in tests/test_processes_endpoints.py. Required
+    because the #1139 contract under test is that the handler's
+    transaction shares a single connection with the publish helper —
+    that only holds when the test connection is the one the handler
+    uses.
+    """
+
+    def _yield_conn() -> Iterator[psycopg.Connection[tuple]]:
+        yield ebull_test_conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+
+def _reset_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        UPDATE bootstrap_state
+           SET status            = 'pending',
+               last_run_id       = NULL,
+               last_completed_at = NULL
+         WHERE id = 1
+        """
+    )
+    conn.commit()
+
+
+def _wipe_pending_requests(conn: psycopg.Connection[tuple]) -> None:
+    """Delete bootstrap-orchestrator queue rows so the tests' assertions
+    count their own. Scoped DELETE rather than TRUNCATE because
+    ``job_runs`` FK-references ``pending_job_requests``; TRUNCATE
+    would 42P12 against the referenced table.
+    """
+    conn.execute("DELETE FROM pending_job_requests WHERE job_name = 'bootstrap_orchestrator'")
+    conn.commit()
+
+
+def _count_orchestrator_requests(conn: psycopg.Connection[tuple]) -> int:
+    row = conn.execute("SELECT COUNT(*) FROM pending_job_requests WHERE job_name = 'bootstrap_orchestrator'").fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _ensure_operator(conn: psycopg.Connection[tuple], operator_id: UUID) -> None:
+    """Insert a minimal operator row so FK constraints on
+    ``bootstrap_runs.triggered_by_operator_id`` (UUID REFERENCES
+    operators(operator_id)) are satisfied. ON CONFLICT keeps it
+    idempotent across re-runs that re-use the same UUID. The
+    username embeds the UUID so concurrent tests can each insert
+    their own operator without colliding on the UNIQUE(username).
+    """
+    conn.execute(
+        """
+        INSERT INTO operators (operator_id, username, password_hash)
+        VALUES (%s, %s, %s)
+        ON CONFLICT (operator_id) DO NOTHING
+        """,
+        (operator_id, f"op-{operator_id}", "test-not-a-real-hash"),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# /run — happy path + rollback-on-publish-failure
+# ---------------------------------------------------------------------------
+
+
+def test_run_commits_state_and_queue_row_together(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """Happy path: /run inserts the bootstrap_runs row, seeds stages,
+    flips singleton to running, AND inserts the pending_job_requests
+    row — all visible after the single shared transaction commits.
+    """
+    _reset_state(ebull_test_conn)
+    _wipe_pending_requests(ebull_test_conn)
+
+    # Skip the real spec list (24 stages); patch the spec factory to
+    # the minimal triple above so this test doesn't depend on the
+    # production lane shape.
+    from app.api import bootstrap as bootstrap_api
+
+    orig_specs = bootstrap_api.get_bootstrap_stage_specs
+    bootstrap_api.get_bootstrap_stage_specs = lambda: _SPECS  # type: ignore[assignment]
+    try:
+        resp = client.post("/system/bootstrap/run")
+    finally:
+        bootstrap_api.get_bootstrap_stage_specs = orig_specs  # type: ignore[assignment]
+
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["run_id"] is not None
+    assert body["request_id"] is not None
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "running"
+    assert state.last_run_id == body["run_id"]
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    assert snap.run_id == body["run_id"]
+    assert {s.stage_key for s in snap.stages} == {spec.stage_key for spec in _SPECS}
+
+    assert _count_orchestrator_requests(ebull_test_conn) == 1
+
+
+def test_run_rolls_back_when_publish_raises(
+    conn_override: None,
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Publish failure mid-transaction rolls back the singleton flip,
+    the bootstrap_runs row, and the seeded stages. No stranded
+    'running' state, no orphan queue row. The exact failure window
+    #1139 closes."""
+    _reset_state(ebull_test_conn)
+    _wipe_pending_requests(ebull_test_conn)
+
+    from app.api import bootstrap as bootstrap_api
+
+    def _boom(*_args: object, **_kwargs: object) -> int:
+        raise psycopg.OperationalError("queue write wedged")
+
+    monkeypatch.setattr(bootstrap_api, "publish_manual_job_request_with_conn", _boom)
+
+    orig_specs = bootstrap_api.get_bootstrap_stage_specs
+    bootstrap_api.get_bootstrap_stage_specs = lambda: _SPECS  # type: ignore[assignment]
+    try:
+        resp = client.post("/system/bootstrap/run")
+    finally:
+        bootstrap_api.get_bootstrap_stage_specs = orig_specs  # type: ignore[assignment]
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error"] == "queue_publish_failed"
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "pending", "singleton must NOT have flipped to running"
+    assert state.last_run_id is None, "singleton must NOT carry a run_id from the rolled-back run"
+
+    runs_row = ebull_test_conn.execute("SELECT COUNT(*) FROM bootstrap_runs").fetchone()
+    assert runs_row is not None
+    assert runs_row[0] == 0, "bootstrap_runs INSERT must be rolled back"
+
+    stages_row = ebull_test_conn.execute("SELECT COUNT(*) FROM bootstrap_stages").fetchone()
+    assert stages_row is not None
+    assert stages_row[0] == 0, "bootstrap_stages seed must be rolled back"
+
+    assert _count_orchestrator_requests(ebull_test_conn) == 0
+
+
+def test_run_persists_operator_uuid_on_triggered_by(
+    conn_override: None,
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The request's authenticated operator UUID is stamped on
+    ``bootstrap_runs.triggered_by_operator_id`` for audit (#1139)."""
+    op_uuid = uuid4()
+    _ensure_operator(ebull_test_conn, op_uuid)
+    _reset_state(ebull_test_conn)
+    _wipe_pending_requests(ebull_test_conn)
+
+    from app.api import bootstrap as bootstrap_api
+
+    def _identity(_req: object) -> UUID:
+        return op_uuid
+
+    monkeypatch.setattr(bootstrap_api, "_operator_uuid", _identity)
+
+    orig_specs = bootstrap_api.get_bootstrap_stage_specs
+    bootstrap_api.get_bootstrap_stage_specs = lambda: _SPECS  # type: ignore[assignment]
+    try:
+        resp = client.post("/system/bootstrap/run")
+    finally:
+        bootstrap_api.get_bootstrap_stage_specs = orig_specs  # type: ignore[assignment]
+
+    assert resp.status_code == 202, resp.text
+    run_id = resp.json()["run_id"]
+
+    row = ebull_test_conn.execute(
+        "SELECT triggered_by_operator_id FROM bootstrap_runs WHERE id = %s", (run_id,)
+    ).fetchone()
+    assert row is not None
+    assert row[0] == op_uuid
+
+
+# ---------------------------------------------------------------------------
+# /retry-failed — sole-gate helper + rollback + operator non-overwrite
+# ---------------------------------------------------------------------------
+
+
+def _seed_partial_error_run(conn: psycopg.Connection[tuple]) -> int:
+    """Seed a singleton+run pair where one stage is in 'error' and
+    the singleton + run are both 'partial_error'. Returns the run id.
+    """
+    _reset_state(conn)
+    run_id = start_run(conn, operator_id=None, stage_specs=_SPECS)
+    conn.commit()
+
+    # Two stages succeed, one fails.
+    mark_stage_running(conn, run_id=run_id, stage_key="universe_sync")
+    mark_stage_success(conn, run_id=run_id, stage_key="universe_sync")
+    mark_stage_running(conn, run_id=run_id, stage_key="candle_refresh")
+    mark_stage_success(conn, run_id=run_id, stage_key="candle_refresh")
+    mark_stage_running(conn, run_id=run_id, stage_key="cusip_universe_backfill")
+    mark_stage_error(
+        conn,
+        run_id=run_id,
+        stage_key="cusip_universe_backfill",
+        error_message="seeded for #1139 test",
+    )
+    finalize_run(conn, run_id=run_id)
+    conn.commit()
+    assert read_state(conn).status == "partial_error"
+    return run_id
+
+
+def test_retry_failed_commits_reset_and_queue_row_together(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    _seed_partial_error_run(ebull_test_conn)
+    _wipe_pending_requests(ebull_test_conn)
+
+    resp = client.post("/system/bootstrap/retry-failed")
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["request_id"] is not None
+
+    assert read_state(ebull_test_conn).status == "running"
+    assert _count_orchestrator_requests(ebull_test_conn) == 1
+
+
+def test_retry_failed_rolls_back_when_publish_raises(
+    conn_override: None,
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = _seed_partial_error_run(ebull_test_conn)
+    _wipe_pending_requests(ebull_test_conn)
+
+    from app.api import bootstrap as bootstrap_api
+
+    def _boom(*_args: object, **_kwargs: object) -> int:
+        raise psycopg.OperationalError("queue write wedged")
+
+    monkeypatch.setattr(bootstrap_api, "publish_manual_job_request_with_conn", _boom)
+
+    resp = client.post("/system/bootstrap/retry-failed")
+    assert resp.status_code == 503
+
+    # Stage stays 'error', singleton stays 'partial_error' — reset rolled back.
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    by_key = {s.stage_key: s for s in snap.stages}
+    assert by_key["cusip_universe_backfill"].status == "error"
+    assert read_state(ebull_test_conn).status == "partial_error"
+    assert read_state(ebull_test_conn).last_run_id == run_id
+
+    # No queue row landed.
+    assert _count_orchestrator_requests(ebull_test_conn) == 0
+
+
+def test_retry_failed_does_not_overwrite_original_triggered_by(
+    conn_override: None,
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1139 — retry path must not touch ``triggered_by_operator_id``.
+
+    Operator A starts the run; operator B retries it. The audit column
+    must still name operator A so post-mortem can answer "who started
+    this run?" correctly.
+    """
+    op_a = uuid4()
+    op_b = uuid4()
+    _ensure_operator(ebull_test_conn, op_a)
+    _ensure_operator(ebull_test_conn, op_b)
+    _reset_state(ebull_test_conn)
+
+    # Start as operator A (call helper directly — bypasses identity middleware).
+    run_id = start_run(ebull_test_conn, operator_id=op_a, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    # Drive the run to partial_error with one failed stage.
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="universe_sync")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="universe_sync")
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="candle_refresh")
+    mark_stage_error(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="candle_refresh",
+        error_message="seeded for triggered_by non-overwrite test",
+    )
+    finalize_run(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    assert read_state(ebull_test_conn).status == "partial_error"
+
+    _wipe_pending_requests(ebull_test_conn)
+
+    # Now operator B triggers /retry-failed.
+    from app.api import bootstrap as bootstrap_api
+
+    monkeypatch.setattr(bootstrap_api, "_operator_uuid", lambda _req: op_b)
+
+    resp = client.post("/system/bootstrap/retry-failed")
+    assert resp.status_code == 202, resp.text
+
+    # Audit column still names operator A.
+    row = ebull_test_conn.execute(
+        "SELECT triggered_by_operator_id FROM bootstrap_runs WHERE id = %s", (run_id,)
+    ).fetchone()
+    assert row is not None
+    assert row[0] == op_a, "retry must NOT overwrite the original triggered_by_operator_id"
+
+
+# ---------------------------------------------------------------------------
+# Helper precedence — direct calls (not through the API)
+# ---------------------------------------------------------------------------
+
+
+def test_helper_no_prior_run_takes_precedence(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """Fresh-install state: status='pending', last_run_id IS NULL.
+    Helper raises BootstrapNoPriorRun BEFORE the status check fires —
+    preserves the pre-#1139 404 contract for "no prior run".
+    """
+    _reset_state(ebull_test_conn)
+    with pytest.raises(BootstrapNoPriorRun):
+        reset_failed_stages_for_retry(ebull_test_conn)
+    assert read_state(ebull_test_conn).status == "pending"
+
+
+def test_helper_no_prior_run_even_with_partial_error_status(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Synthetic: singleton flipped to partial_error but last_run_id NULL
+    (could only happen via raw SQL). Helper still raises
+    BootstrapNoPriorRun — no-prior-run precedes status check.
+    """
+    _reset_state(ebull_test_conn)
+    ebull_test_conn.execute("UPDATE bootstrap_state SET status='partial_error' WHERE id=1")
+    ebull_test_conn.commit()
+
+    with pytest.raises(BootstrapNoPriorRun):
+        reset_failed_stages_for_retry(ebull_test_conn)
+    assert read_state(ebull_test_conn).status == "partial_error"
+
+
+def test_helper_not_resettable_for_complete(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """Singleton='complete' with valid last_run_id: helper raises
+    BootstrapNotResettable. Verifies the helper is sole authoritative
+    gate (#1139) — no caller can sneak past with a stale read.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+    for spec in _SPECS:
+        mark_stage_running(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+        mark_stage_success(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+    finalize_run(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+    assert read_state(ebull_test_conn).status == "complete"
+
+    with pytest.raises(BootstrapNotResettable) as exc_info:
+        reset_failed_stages_for_retry(ebull_test_conn)
+    assert exc_info.value.status == "complete"
+    assert read_state(ebull_test_conn).status == "complete"
+
+
+def test_helper_already_running_when_singleton_running(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Singleton='running' is the operator-friendly precedence:
+    BootstrapAlreadyRunning, NOT BootstrapNotResettable.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+
+    with pytest.raises(BootstrapAlreadyRunning) as exc_info:
+        reset_failed_stages_for_retry(ebull_test_conn)
+    assert exc_info.value.run_id == run_id
+    assert read_state(ebull_test_conn).status == "running"
+
+
+def test_retry_failed_targets_singleton_last_run_id(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """#1139 — the new helper derives the target ``run_id`` from
+    ``bootstrap_state.last_run_id`` under the FOR UPDATE lock, so a
+    caller cannot accidentally retry an older run. Seed two runs
+    (one older, one current), set the singleton to the current one,
+    and confirm the API only resets stages on the current run.
+    """
+    _reset_state(ebull_test_conn)
+
+    # Run 1: completed, then a fresh run 2 takes its place. Drive 2
+    # into partial_error with one failed stage. Singleton.last_run_id
+    # already points at run 2 (start_run wrote it).
+    run_1 = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+    for spec in _SPECS:
+        mark_stage_running(ebull_test_conn, run_id=run_1, stage_key=spec.stage_key)
+        mark_stage_success(ebull_test_conn, run_id=run_1, stage_key=spec.stage_key)
+    finalize_run(ebull_test_conn, run_id=run_1)
+    ebull_test_conn.commit()
+    assert read_state(ebull_test_conn).status == "complete"
+    # Reset the singleton to 'pending' to allow the second start_run
+    # (start_run rejects 'running' and 'complete'-then-restart needs
+    # the singleton clear; the helpers used in this test fixture
+    # mirror the real "operator restarts after a complete run" flow).
+    _reset_state(ebull_test_conn)
+    run_2 = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+    assert run_2 != run_1
+    mark_stage_running(ebull_test_conn, run_id=run_2, stage_key="cusip_universe_backfill")
+    mark_stage_error(
+        ebull_test_conn,
+        run_id=run_2,
+        stage_key="cusip_universe_backfill",
+        error_message="seeded",
+    )
+    finalize_run(ebull_test_conn, run_id=run_2)
+    ebull_test_conn.commit()
+    state = read_state(ebull_test_conn)
+    assert state.status == "partial_error"
+    assert state.last_run_id == run_2
+    _wipe_pending_requests(ebull_test_conn)
+
+    # Trigger retry. The helper derives run_id from the singleton, so
+    # it targets run 2 (NOT run 1, whose stage rows must be untouched).
+    resp = client.post("/system/bootstrap/retry-failed")
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["run_id"] == run_2
+
+    # Run 1's stage history is unchanged (forensic).
+    run_1_rows = ebull_test_conn.execute(
+        "SELECT status FROM bootstrap_stages WHERE bootstrap_run_id = %s",
+        (run_1,),
+    ).fetchall()
+    assert all(r[0] == "success" for r in run_1_rows), "run 1 stages must be untouched"
+
+
+def test_retry_failed_pending_no_prior_run_returns_404(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """#1139 — fresh install (pending + last_run_id NULL): API returns
+    404, preserving the pre-#1139 ``no prior bootstrap run to retry``
+    contract. The helper's ``BootstrapNoPriorRun`` precedes the
+    status check so this path fires before the pending-state-409
+    branch.
+    """
+    _reset_state(ebull_test_conn)
+    resp = client.post("/system/bootstrap/retry-failed")
+    assert resp.status_code == 404, resp.text
+
+
+def test_helper_zero_reset_when_partial_error_has_no_failed_stages(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Synthetic edge case: singleton in partial_error but every stage
+    on the latest run is 'success'. Helper returns (run_id, 0) and
+    leaves state untouched — API maps to 404, processes endpoint
+    maps to 409 'bootstrap_no_failed_stages' (neither enqueues).
+    """
+    _reset_state(ebull_test_conn)
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
+    ebull_test_conn.commit()
+    for spec in _SPECS:
+        mark_stage_running(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+        mark_stage_success(ebull_test_conn, run_id=run_id, stage_key=spec.stage_key)
+    ebull_test_conn.commit()
+
+    # Force singleton + run into a "partial_error with all-success
+    # stages" state (couldn't be reached by finalize_run, but covers
+    # the edge case via raw SQL — what a manual operator fix could
+    # leave).
+    ebull_test_conn.execute(
+        "UPDATE bootstrap_runs SET status='partial_error', completed_at=now() WHERE id=%s",
+        (run_id,),
+    )
+    ebull_test_conn.execute("UPDATE bootstrap_state SET status='partial_error' WHERE id=1")
+    ebull_test_conn.commit()
+
+    helper_run_id, reset_count = reset_failed_stages_for_retry(ebull_test_conn)
+    assert helper_run_id == run_id
+    assert reset_count == 0
+    # State must NOT flip back to running on a no-op retry.
+    assert read_state(ebull_test_conn).status == "partial_error"

--- a/tests/test_bootstrap_cancel.py
+++ b/tests/test_bootstrap_cancel.py
@@ -476,8 +476,9 @@ def test_reset_failed_for_retry_picks_up_cancelled_stages(
     # Bravo + charlie are now ``cancelled``; retry-failed should reset
     # them to ``pending`` (cancelled is treated like error/blocked for
     # the lane-min-order logic).
-    reset = reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id)
+    helper_run_id, reset = reset_failed_stages_for_retry(ebull_test_conn)
     ebull_test_conn.commit()
+    assert helper_run_id == run_id
     assert reset > 0
 
     rows = ebull_test_conn.execute(
@@ -660,11 +661,12 @@ def test_cancel_then_iterate_resumes_via_reset_failed(
     assert read_state(ebull_test_conn).status == "cancelled"
 
     # Operator clicks Iterate (= reset failed/pending + republish).
-    reset_count = reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id)
+    helper_run_id, reset_count = reset_failed_stages_for_retry(ebull_test_conn)
     ebull_test_conn.commit()
 
     # alpha success preserved; bravo + charlie were swept to error
     # and reset back to pending.
+    assert helper_run_id == run_id
     assert reset_count == 2
     snap = read_latest_run_with_stages(ebull_test_conn)
     assert snap is not None

--- a/tests/test_bootstrap_flow_integration.py
+++ b/tests/test_bootstrap_flow_integration.py
@@ -207,7 +207,8 @@ def test_bootstrap_partial_error_then_retry_failed(
     pass2_invokers = {spec.job_name: _make_pass2(spec.job_name) for spec in get_bootstrap_stage_specs()}
     monkeypatch.setattr(runtime_module, "_INVOKERS", pass2_invokers)
 
-    reset_count = reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id)
+    helper_run_id, reset_count = reset_failed_stages_for_retry(ebull_test_conn)
+    assert helper_run_id == run_id
     assert reset_count > 0
     ebull_test_conn.commit()
 

--- a/tests/test_bootstrap_state.py
+++ b/tests/test_bootstrap_state.py
@@ -185,7 +185,8 @@ def test_reset_failed_stages_resets_failed_and_downstream_in_lane(
     finalize_run(ebull_test_conn, run_id=run_id)
     assert read_state(ebull_test_conn).status == "partial_error"
 
-    reset_count = reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id)
+    helper_run_id, reset_count = reset_failed_stages_for_retry(ebull_test_conn)
+    assert helper_run_id == run_id
     # s2 (failed) + s3 (downstream same lane) = 2 stages reset.
     assert reset_count == 2
     ebull_test_conn.commit()
@@ -204,9 +205,15 @@ def test_reset_failed_stages_resets_failed_and_downstream_in_lane(
     assert state.status == "running"
 
 
-def test_reset_failed_stages_no_op_when_no_failures(
+def test_reset_failed_stages_raises_when_singleton_complete(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
+    """After finalize_run lands a successful run, the singleton is
+    'complete'. The helper must reject (not silently 0-return)
+    because 'complete' is outside the resettable status set
+    {partial_error, cancelled} (#1139 — helper is now sole gate)."""
+    from app.services.bootstrap_state import BootstrapNotResettable
+
     _reset_state(ebull_test_conn)
     run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=_SPECS)
     ebull_test_conn.commit()
@@ -217,7 +224,9 @@ def test_reset_failed_stages_no_op_when_no_failures(
     finalize_run(ebull_test_conn, run_id=run_id)
     ebull_test_conn.commit()
 
-    assert reset_failed_stages_for_retry(ebull_test_conn, run_id=run_id) == 0
+    with pytest.raises(BootstrapNotResettable) as exc_info:
+        reset_failed_stages_for_retry(ebull_test_conn)
+    assert exc_info.value.status == "complete"
     assert read_state(ebull_test_conn).status == "complete"
 
 

--- a/tests/test_processes_endpoints.py
+++ b/tests/test_processes_endpoints.py
@@ -155,6 +155,53 @@ def test_trigger_bootstrap_iterate_from_pending_returns_409(
     assert detail["reason"] == "bootstrap_not_resumable"
 
 
+def test_trigger_bootstrap_iterate_no_failed_stages_does_not_enqueue(
+    conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
+) -> None:
+    """#1139 — iterate against a partial_error run that has no failed
+    stages (synthetic edge case from manual operator fixes) must NOT
+    enqueue a no-op orchestrator round. Surface as 409
+    ``bootstrap_no_failed_stages`` instead.
+    """
+    _ensure_kill_switch_off(ebull_test_conn)
+    run = ebull_test_conn.execute(
+        """
+        INSERT INTO bootstrap_runs (status, completed_at)
+        VALUES ('partial_error', now())
+        RETURNING id
+        """
+    ).fetchone()
+    assert run is not None
+    run_id = int(run[0])
+    ebull_test_conn.execute(
+        """
+        INSERT INTO bootstrap_stages
+            (bootstrap_run_id, stage_key, stage_order, lane, job_name,
+             status, started_at, completed_at, last_error)
+        VALUES (%s, 'init', 0, 'init', 'job_x', 'success', now(), now(), NULL)
+        """,
+        (run_id,),
+    )
+    _seed_bootstrap_state(ebull_test_conn, "partial_error")
+    ebull_test_conn.execute(
+        "UPDATE bootstrap_state SET last_run_id = %s WHERE id = 1",
+        (run_id,),
+    )
+    ebull_test_conn.execute("DELETE FROM pending_job_requests WHERE job_name = 'bootstrap_orchestrator'")
+    ebull_test_conn.commit()
+
+    resp = client.post("/system/processes/bootstrap/trigger", json={"mode": "iterate"})
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["reason"] == "bootstrap_no_failed_stages"
+
+    # Pin the actual no-op guarantee: NO orchestrator queue row landed.
+    count_row = ebull_test_conn.execute(
+        "SELECT COUNT(*) FROM pending_job_requests WHERE job_name = 'bootstrap_orchestrator'"
+    ).fetchone()
+    assert count_row is not None
+    assert int(count_row[0]) == 0
+
+
 def test_trigger_bootstrap_full_wash_inserts_fence_row(
     conn_override: None, ebull_test_conn: psycopg.Connection[tuple]
 ) -> None:


### PR DESCRIPTION
## Summary

- `/system/bootstrap/run` and `/system/bootstrap/retry-failed` now wrap `start_run` (or `reset_failed_stages_for_retry`) and the orchestrator queue INSERT in a single transaction on the request's pooled connection. Closes the stuck-run window flagged by the #1136 audit §3: pre-fix a publish failure after the state commit stranded the singleton at `status='running'` with no `pending_job_requests` row.
- `reset_failed_stages_for_retry` is now the **sole authoritative gate** — no `run_id` arg, derives target run under the singleton `FOR UPDATE` lock. Returns `(run_id, reset_count)`. New precedence: `BootstrapNoPriorRun` → 404, `BootstrapAlreadyRunning` → 409 `bootstrap_running`, `BootstrapNotResettable` → 409 `bootstrap_not_resettable`. The 404 contract for fresh-install retry is preserved.
- `bootstrap_runs.triggered_by_operator_id` is now stamped on `/run` from the authenticated operator UUID and is NOT overwritten by `/retry-failed` (original-run audit preserved).
- `app/api/processes.py::_apply_bootstrap_iterate_reset` widened to catch the new exceptions AND refuse to enqueue when the helper returns `reset_count == 0` (was silently enqueueing a no-op pre-fix).

Spec: `docs/superpowers/specs/2026-05-13-atomic-bootstrap-enqueue.md`. Codex reviewed at checkpoint 1 (spec, 4 rounds) and checkpoint 2 (diff, no blocking findings).

Closes #1139.

## Security model

No auth-surface change. The two endpoints already gate on `require_session_or_service_token`. The shared-conn publish helper bypasses the autocommit contract by design — caller owns the txn. Helper is private to the bootstrap API path; existing autocommit callers (`/sync`, jobs UI, processes endpoints) are untouched.

Operator-UUID stamping uses the existing `_operator_uuid(request)` helper from the `/cancel` endpoint, which handles malformed UUIDs by logging and writing NULL — never raising.

## Test plan

- [x] `uv run pytest tests/test_bootstrap_atomic_enqueue.py` (13 new real-DB tests, all pass)
- [x] `uv run pytest tests/test_api_bootstrap.py` (16 mock-level, all pass — updated for new helper return shape + exception types + shared-conn publish)
- [x] `uv run pytest tests/test_bootstrap_state.py tests/test_bootstrap_cancel.py tests/test_bootstrap_flow_integration.py` (helper test callers updated to no-arg signature, all pass)
- [x] `uv run pytest tests/test_processes_endpoints.py` (35 pass with `-p no:xdist` to dodge environmental Postgres lock OOM)
- [x] `uv run pytest tests/smoke/test_app_boots.py` (5 pass; lifespan unchanged)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright app/ tests/test_bootstrap_atomic_enqueue.py` (clean)

## Notes for reviewer

The integration tests in `tests/test_bootstrap_atomic_enqueue.py` exercise the rollback semantics on a real Postgres engine — mocks can't prove the singleton flip rolls back when the publish step raises, since that's a Postgres txn guarantee, not Python control flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)