### PR TITLE
fix(#1140): precondition + final-data row-count gates

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -300,6 +300,11 @@ class BootstrapTimelineStageResponse(BaseModel):
     processed_count: int
     target_count: int | None
     archives: list[BootstrapTimelineArchiveResponse]
+    # #1140 Task C — operator-readable warning string when the stage
+    # finished ``success`` but its ``rows_processed`` failed to satisfy
+    # a strict-gate capability floor it provides. ``None`` for healthy
+    # stages and for stages that don't provide a strict-gate cap.
+    warning: str | None = None
 
 
 class BootstrapTimelineRunResponse(BaseModel):
@@ -310,6 +315,13 @@ class BootstrapTimelineRunResponse(BaseModel):
     triggered_at: datetime
     completed_at: datetime | None
     cancel_requested_at: datetime | None
+    # #1140 Task C — derived view: True iff at least one stage in the
+    # run carries a non-None ``warning``. Frontend renders an amber
+    # dot next to the run-level status when this is True and the
+    # status is ``complete`` (the partial_error red signal is louder
+    # than the amber warning, so the warning is suppressed for
+    # already-red runs).
+    has_warnings: bool = False
 
 
 class BootstrapTimelineResponse(BaseModel):
@@ -720,7 +732,21 @@ def get_bootstrap_timeline(
             )
         )
 
+    # #1140 Task C — derive per-stage `warning` from the cap layer.
+    # A stage that finished `success` but provides a strict-gate cap
+    # AND wrote 0 (or NULL) rows raises an operator-visible warning
+    # because its downstream consumers cannot be satisfied off this
+    # stage's contribution. Excluded multi-cap providers (e.g. bulk
+    # insider for form3) don't warn — they're neutral, not the
+    # responsible party for the cap.
+    from app.services.bootstrap_orchestrator import (
+        _CAPABILITY_MIN_ROWS,
+        _STAGE_PROVIDES,
+        _STRICT_CAP_PROVIDER_EXCLUSIONS,
+    )
+
     stage_payload: list[BootstrapTimelineStageResponse] = []
+    has_warnings = False
     for row in stage_rows:
         stage_key = str(row["stage_key"])
         display_name = _humanise_stage_key(stage_key)
@@ -735,6 +761,26 @@ def get_bootstrap_timeline(
             # historical truth — the catalogue is the deployable contract.
             stage_order = int(row["stage_order"])
             job_name = str(row["job_name"])
+
+        warning: str | None = None
+        if row["status"] == "success":
+            provided_caps = _STAGE_PROVIDES.get(stage_key, ())
+            strict_caps_unmet = [
+                cap
+                for cap in provided_caps
+                if cap in _CAPABILITY_MIN_ROWS
+                and stage_key not in _STRICT_CAP_PROVIDER_EXCLUSIONS.get(cap, frozenset())
+                and (row.get("rows_processed") is None or int(row["rows_processed"]) < _CAPABILITY_MIN_ROWS[cap])
+            ]
+            if strict_caps_unmet:
+                rows_val = row.get("rows_processed")
+                rows_str = "NULL" if rows_val is None else str(int(rows_val))
+                caps_str = ", ".join(strict_caps_unmet)
+                warning = (
+                    f"stage succeeded but rows_processed={rows_str}; "
+                    f"strict-gate capability {caps_str} cannot be satisfied"
+                )
+                has_warnings = True
 
         stage_payload.append(
             BootstrapTimelineStageResponse(
@@ -751,6 +797,7 @@ def get_bootstrap_timeline(
                 processed_count=int(row.get("processed_count") or 0),
                 target_count=row.get("target_count"),
                 archives=archives_by_stage.get(stage_key, []),
+                warning=warning,
             )
         )
 
@@ -760,6 +807,7 @@ def get_bootstrap_timeline(
         triggered_at=run_row["triggered_at"],
         completed_at=run_row.get("completed_at"),
         cancel_requested_at=run_row.get("cancel_requested_at"),
+        has_warnings=has_warnings,
     )
 
     return BootstrapTimelineResponse(run=run_payload, stages=stage_payload)

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -290,6 +290,61 @@ _STAGE_PROVIDES: Final[dict[str, tuple[Capability, ...]]] = {
 _STAGE_PROVIDES_ON_SKIP: Final[dict[str, tuple[Capability, ...]]] = {}
 
 
+# #1140 / Task C of #1136 audit — strict-gate row-count floors.
+#
+# For caps in this map: a provider stage's ``success`` status alone
+# does NOT advertise the cap; the provider's ``rows_processed`` must
+# also be ``>= min_rows``. Caps absent from this map fall back to
+# status-only gating (Task A behaviour preserved).
+#
+# Default ``min_rows = 1`` for the cap-providing stages whose
+# downstream consumers (``fundamentals_sync``,
+# ``ownership_observations_backfill``) MUST observe non-zero ingest
+# to be useful. The audit (#1136 §2 acceptance) requires this for
+# fundamentals + every ownership family.
+#
+# Threshold ``1`` is the cheapest non-trivial floor: any positive
+# write counts. Higher floors (e.g. universe-coverage ratios) are
+# out of scope for v1 — the structural hook stays the per-cap int
+# knob, no hardcoded percentages.
+#
+_CAPABILITY_MIN_ROWS: Final[dict[Capability, int]] = {
+    "fundamentals_raw_seeded": 1,
+    "insider_inputs_seeded": 1,
+    "form3_inputs_seeded": 1,
+    "institutional_inputs_seeded": 1,
+    "nport_inputs_seeded": 1,
+}
+
+
+# #1140 / Task C of #1136 audit — strict-gate provider exclusions.
+#
+# For a strict-gate cap, providers listed here CANNOT contribute to
+# satisfying the floor via their aggregate ``rows_processed``. Used
+# when a multi-cap provider's aggregate row count can't be split per
+# advertised cap. The provider's ``success`` still keeps the cap
+# alive (i.e. doesn't kill it) but doesn't satisfy the strict floor
+# either — the cap must be carried by other (single-cap) providers.
+#
+# Today the only entry is the bulk insider ingester
+# (``sec_insider_ingest_from_dataset``): it advertises both
+# ``insider_inputs_seeded`` and ``form3_inputs_seeded`` from a single
+# aggregate ``rows_processed`` (bulk maps rows to form3 vs form4
+# internally but records the sum). A bulk wash that landed 10 Form 4
+# + 0 Form 3 rows would otherwise falsely advertise
+# ``form3_inputs_seeded`` under the strict rule. Excluding the bulk
+# provider for ``form3_inputs_seeded`` forces the legacy
+# ``sec_form3_ingest`` (single-cap, scoped to form3) to validate the
+# form3 path — Codex pre-push round 2 BLOCKING.
+#
+# When per-family bulk row counts land (follow-up ticket) this map
+# entry can be dropped and the bulk provider can satisfy form3
+# directly.
+_STRICT_CAP_PROVIDER_EXCLUSIONS: Final[dict[Capability, frozenset[str]]] = {
+    "form3_inputs_seeded": frozenset({"sec_insider_ingest_from_dataset"}),
+}
+
+
 # Stage-key → CapRequirement. Replaces the old AND-only
 # ``_STAGE_REQUIRES`` (#1138 Task A). Every entry in
 # ``_BOOTSTRAP_STAGE_SPECS`` must appear here (enforced by the
@@ -368,22 +423,72 @@ _CAPABILITY_PROVIDERS: Final[dict[Capability, tuple[str, ...]]] = _build_capabil
 # ---------------------------------------------------------------------------
 
 
+def _provider_meets_floor(
+    cap: Capability,
+    provider_key: str,
+    rows_processed: int | None,
+    min_rows: Mapping[Capability, int],
+    *,
+    exclusions: Mapping[Capability, frozenset[str]] = _STRICT_CAP_PROVIDER_EXCLUSIONS,
+) -> bool:
+    """Return True iff a ``success`` provider's row count satisfies the
+    cap's strict-gate floor (if any).
+
+    Non-strict caps (absent from ``min_rows``) are always satisfied by
+    ``success`` — preserves Task A behaviour. Strict-gate caps require
+    ``rows_processed`` to be non-None AND ``>= floor``.
+
+    A provider in ``exclusions[cap]`` (e.g. a multi-cap bulk ingester
+    whose aggregate ``rows_processed`` can't be split per cap) cannot
+    satisfy a strict-gate floor — even with non-zero rows. The
+    provider is treated as if its row count was always below the
+    floor; the cap must be carried by another (single-cap) provider.
+    See ``_STRICT_CAP_PROVIDER_EXCLUSIONS`` for the rationale.
+
+    #1140 Task C.
+    """
+    floor = min_rows.get(cap)
+    if floor is None:
+        return True
+    if provider_key in exclusions.get(cap, frozenset()):
+        return False
+    if rows_processed is None:
+        return False
+    return rows_processed >= floor
+
+
 def _satisfied_capabilities(
     statuses: Mapping[str, str],
+    rows_processed: Mapping[str, int | None] | None = None,
     *,
     provides: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES,
     provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
+    min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
 ) -> set[Capability]:
-    """Cap set derived from current stage statuses.
+    """Cap set derived from current stage statuses + per-stage rows.
 
-    Production callers omit ``provides`` / ``provides_on_skip`` (the
-    module-level maps are used). Tests can pass overrides to register
+    For a cap ``C`` with ``min_rows[C] = N``: a provider ``P`` satisfies
+    ``C`` iff ``statuses[P] == 'success'`` AND ``rows_processed[P]``
+    is not None AND ``>= N``. ``skipped`` providers still satisfy via
+    ``provides_on_skip`` (the skip path is never row-counted).
+
+    For a cap ``C`` NOT in ``min_rows``: a provider ``P`` satisfies
+    ``C`` iff ``statuses[P] == 'success'`` (legacy Task A behaviour
+    preserved).
+
+    Production callers can omit ``rows_processed`` (defaults to an
+    empty mapping; strict-gate caps then fall to "below floor" since
+    every lookup returns None). Tests can pass overrides for
+    ``provides`` / ``provides_on_skip`` / ``min_rows`` to register
     synthetic caps for fixture stage_keys.
     """
+    rows = rows_processed or {}
     caps: set[Capability] = set()
     for stage_key, status in statuses.items():
         if status == "success":
-            caps.update(provides.get(stage_key, ()))
+            for cap in provides.get(stage_key, ()):
+                if _provider_meets_floor(cap, stage_key, rows.get(stage_key), min_rows):
+                    caps.add(cap)
         elif status == "skipped":
             caps.update(provides_on_skip.get(stage_key, ()))
     return caps
@@ -392,19 +497,27 @@ def _satisfied_capabilities(
 def _capability_is_dead(
     cap: Capability,
     statuses: Mapping[str, str],
+    rows_processed: Mapping[str, int | None] | None = None,
     *,
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
     provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
+    min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
 ) -> bool:
     """A cap is dead iff every registered provider is in a state where
     it cannot now (or in the future) provide the cap.
 
-    Cannot-provide states: ``error`` / ``blocked`` / ``cancelled``, or
-    ``skipped`` without an explicit ``provides_on_skip`` entry.
+    Cannot-provide states:
+    * ``error`` / ``blocked`` / ``cancelled`` — terminal failure.
+    * ``skipped`` without an explicit ``provides_on_skip`` entry.
+    * For strict-gate caps (``cap in min_rows``): ``success`` with
+      ``rows_processed`` either ``None`` or below ``min_rows[cap]``.
+      The provider already terminalised so no future write will
+      change its row count — the cap can never be satisfied via
+      this provider (#1140 Task C).
 
     Can-still-provide states: ``pending`` / ``running`` (provider
-    hasn't decided yet), ``success`` (cap satisfied), or ``skipped``
-    with the cap in ``provides_on_skip``.
+    hasn't decided yet); ``success`` meeting the floor (or no floor);
+    ``skipped`` with the cap in ``provides_on_skip``.
     """
     providers = providers_map.get(cap, ())
     if not providers:
@@ -412,12 +525,20 @@ def _capability_is_dead(
         # invariant test should have caught this at test time; runtime
         # check is defence-in-depth.
         return True
+    rows = rows_processed or {}
     for provider_key in providers:
         status = statuses.get(provider_key)
         if status is None:
             continue
-        if status in ("pending", "running", "success"):
+        if status in ("pending", "running"):
             return False
+        if status == "success":
+            if _provider_meets_floor(cap, provider_key, rows.get(provider_key), min_rows):
+                return False
+            # Below floor (or excluded multi-cap provider) — this
+            # provider cannot satisfy a strict cap. Keep checking the
+            # others (a parallel provider may still be alive).
+            continue
         if status == "skipped":
             on_skip = provides_on_skip.get(provider_key, ())
             if cap in on_skip:
@@ -428,17 +549,24 @@ def _capability_is_dead(
 def _classify_dead_cap(
     cap: Capability,
     statuses: Mapping[str, str],
+    rows_processed: Mapping[str, int | None] | None = None,
     *,
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
+    min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
 ) -> Literal["skip_only", "error"]:
     """Return the failure mode that killed a (confirmed-dead) cap.
 
-    Precondition: ``_capability_is_dead(cap, statuses)`` is True.
+    Precondition: ``_capability_is_dead(cap, statuses, rows_processed)``
+    is True.
 
     Returns ``"error"`` (block downstream) when ANY provider is in
-    ``error`` / ``blocked`` / ``cancelled``. Returns ``"skip_only"``
-    only when every dead provider is ``skipped`` without an explicit
-    ``provides_on_skip`` entry.
+    ``error`` / ``blocked`` / ``cancelled`` OR (for strict-gate caps)
+    in ``success`` with row count below the floor — a provider that
+    ran and produced too few rows is a failure mode, not a deliberate
+    bypass, so the operator should see ``blocked`` not ``skipped``.
+
+    Returns ``"skip_only"`` only when every dead provider is
+    ``skipped`` without an explicit ``provides_on_skip`` entry.
 
     Defensive default: a cap with zero registered providers, or a
     cap with NO ``skipped`` provider (only unknown/pending), is
@@ -448,12 +576,26 @@ def _classify_dead_cap(
     providers = providers_map.get(cap, ())
     if not providers:
         return "error"
+    rows = rows_processed or {}
     saw_skipped = False
     for provider_key in providers:
         status = statuses.get(provider_key)
         if status is None:
             continue
         if status in ("error", "blocked", "cancelled"):
+            return "error"
+        if status == "success" and not _provider_meets_floor(cap, provider_key, rows.get(provider_key), min_rows):
+            # #1140 Task C — provider succeeded but its row count
+            # didn't meet the strict floor. Excluded multi-cap providers
+            # (e.g. bulk insider for form3) are NEUTRAL — they cannot
+            # satisfy the floor but they shouldn't drive the
+            # classification either; the cap death is whatever the
+            # OTHER providers tell us. Skip them.
+            if provider_key in _STRICT_CAP_PROVIDER_EXCLUSIONS.get(cap, frozenset()):
+                continue
+            # Non-excluded provider under floor → classify as error so
+            # the consumer transitions to ``blocked`` with a structured
+            # reason naming the under-floor provider.
             return "error"
         if status == "skipped":
             saw_skipped = True
@@ -471,9 +613,11 @@ def _requirement_satisfied(req: CapRequirement, caps: set[Capability]) -> bool:
 def _classify_requirement_unsatisfiable(
     req: CapRequirement,
     statuses: Mapping[str, str],
+    rows_processed: Mapping[str, int | None] | None = None,
     *,
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
     provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
+    min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
 ) -> tuple[Literal["skip_only", "error"], list[Capability]] | None:
     """If ``req`` is unsatisfiable now, return ``(classification, dead_caps)``.
 
@@ -488,10 +632,17 @@ def _classify_requirement_unsatisfiable(
 
     Per #1138 §6.3: when unsatisfiable, classify ``"error"`` if any
     contributing dead cap is error-classified; otherwise
-    ``"skip_only"``.
+    ``"skip_only"``. #1140 Task C extends "error-classified" to include
+    strict-gate caps whose only surviving provider hit ``success`` but
+    under the row floor.
     """
     is_dead = lambda c: _capability_is_dead(  # noqa: E731
-        c, statuses, providers_map=providers_map, provides_on_skip=provides_on_skip
+        c,
+        statuses,
+        rows_processed,
+        providers_map=providers_map,
+        provides_on_skip=provides_on_skip,
+        min_rows=min_rows,
     )
     dead_in_all: list[Capability] = [c for c in req.all_of if is_dead(c)]
 
@@ -516,7 +667,16 @@ def _classify_requirement_unsatisfiable(
                     all_dead_caps.append(cap)
 
     for cap in all_dead_caps:
-        if _classify_dead_cap(cap, statuses, providers_map=providers_map) == "error":
+        if (
+            _classify_dead_cap(
+                cap,
+                statuses,
+                rows_processed,
+                providers_map=providers_map,
+                min_rows=min_rows,
+            )
+            == "error"
+        ):
             return ("error", all_dead_caps)
     return ("skip_only", all_dead_caps)
 
@@ -524,14 +684,41 @@ def _classify_requirement_unsatisfiable(
 def _format_block_reason(
     dead_caps: list[Capability],
     statuses: Mapping[str, str],
+    rows_processed: Mapping[str, int | None] | None = None,
     *,
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
+    min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
 ) -> str:
+    """Build the structured ``last_error`` string for a blocked stage.
+
+    For strict-gate caps the per-provider annotation includes
+    ``rows_processed=N`` or ``rows_processed=NULL`` so the operator
+    timeline reads exactly which provider fell short of the floor
+    (#1140 Task C).
+    """
+    rows = rows_processed or {}
     parts: list[str] = []
     for cap in dead_caps:
         providers = providers_map.get(cap, ())
-        provider_states = ", ".join(f"{p}={statuses.get(p, '?')}" for p in providers) or "(no providers)"
-        parts.append(f"missing capability {cap}; no surviving provider (providers: {provider_states})")
+        excluded_for_cap = _STRICT_CAP_PROVIDER_EXCLUSIONS.get(cap, frozenset())
+        annotated: list[str] = []
+        for p in providers:
+            status = statuses.get(p, "?")
+            if status == "success" and cap in min_rows:
+                value = rows.get(p)
+                rows_str = "NULL" if value is None else str(value)
+                marker = " [excluded]" if p in excluded_for_cap else ""
+                annotated.append(f"{p}=success [rows_processed={rows_str}]{marker}")
+            else:
+                annotated.append(f"{p}={status}")
+        provider_states = ", ".join(annotated) or "(no providers)"
+        floor = min_rows.get(cap)
+        if floor is not None:
+            parts.append(
+                f"missing capability {cap}; no surviving provider met rows floor {floor} (providers: {provider_states})"
+            )
+        else:
+            parts.append(f"missing capability {cap}; no surviving provider (providers: {provider_states})")
     return "; ".join(parts)
 
 
@@ -699,6 +886,115 @@ class _StageOutcome:
     # iteration's run-level cancel checkpoint then sweeps remaining
     # stages and terminalises the run.
     cancelled: bool = False
+    # #1140 Task C — resolved rows_processed for the stage's
+    # invocation. ``None`` when no side-channel has data (the cap-eval
+    # layer treats ``None`` as "below floor" for strict-gate caps,
+    # status-only for non-strict caps).
+    rows_processed: int | None = None
+
+
+def _snapshot_job_runs_max_id(
+    conn: psycopg.Connection[Any],
+    *,
+    job_name: str,
+) -> int:
+    """Return ``COALESCE(MAX(run_id), 0) FROM job_runs WHERE job_name = ...``.
+
+    Used by ``_run_one_stage`` to bracket the ``job_runs`` window
+    (see ``_resolve_stage_rows``). #1140 / Task C of #1136 audit.
+
+    ``job_runs.run_id`` (BIGSERIAL PRIMARY KEY per sql/014) is the
+    canonical id column — there is no ``id`` alias.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COALESCE(MAX(run_id), 0) FROM job_runs WHERE job_name = %s",
+            (job_name,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+
+def _resolve_stage_rows(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    stage_key: str,
+    job_name: str,
+    job_runs_id_before: int,
+    job_runs_id_after: int,
+) -> int | None:
+    """Resolve ``rows_processed`` for a freshly-succeeded stage.
+
+    Returns ``None`` when no side-channel has data. Resolution order:
+
+    1. Per-archive ``bootstrap_archive_results`` (non-``__job__``). If
+       ``COUNT > 0`` → return ``SUM(rows_written)``, preserving 0.
+       Phase C ingester shape (e.g. ``sec_companyfacts_ingest``).
+    2. ``__job__`` row with operator-set ``rows_written > 0``. Service-
+       invoker shape (e.g. ``sec_submissions_files_walk`` overloads
+       the provenance row with ``filings_upserted``). The default
+       orchestrator-written ``__job__`` row carries ``rows_written=0``
+       (with the new ``record_archive_result_if_absent`` it only fires
+       when the service invoker didn't already write); a ``0`` here
+       falls through to source 3.
+    3. ``job_runs.row_count`` for the latest matching run in the
+       ``id > job_runs_id_before AND id <= job_runs_id_after`` window.
+       The double bound pins to rows created while the dispatcher held
+       ``JobLock`` for this stage; the upper bound rejects same-
+       ``job_name`` scheduled fires that landed after lock release.
+
+    #1140 / Task C of #1136 audit (spec at
+    docs/superpowers/specs/2026-05-13-precondition-final-data-gates.md).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*), COALESCE(SUM(rows_written), 0)
+              FROM bootstrap_archive_results
+             WHERE bootstrap_run_id = %s
+               AND stage_key = %s
+               AND archive_name <> '__job__'
+            """,
+            (bootstrap_run_id, stage_key),
+        )
+        row = cur.fetchone()
+        archive_count = int(row[0]) if row else 0
+        archive_sum = int(row[1]) if row and row[1] is not None else 0
+        if archive_count > 0:
+            return archive_sum
+
+        cur.execute(
+            """
+            SELECT rows_written
+              FROM bootstrap_archive_results
+             WHERE bootstrap_run_id = %s
+               AND stage_key = %s
+               AND archive_name = '__job__'
+            """,
+            (bootstrap_run_id, stage_key),
+        )
+        row = cur.fetchone()
+        if row is not None and row[0] is not None and int(row[0]) > 0:
+            return int(row[0])
+
+        cur.execute(
+            """
+            SELECT row_count
+              FROM job_runs
+             WHERE job_name = %s
+               AND run_id > %s
+               AND run_id <= %s
+               AND status  = 'success'
+             ORDER BY run_id DESC
+             LIMIT 1
+            """,
+            (job_name, job_runs_id_before, job_runs_id_after),
+        )
+        row = cur.fetchone()
+        if row is not None and row[0] is not None:
+            return int(row[0])
+    return None
 
 
 def _run_one_stage(
@@ -733,6 +1029,16 @@ def _run_one_stage(
         mark_stage_running(conn, run_id=run_id, stage_key=stage_key)
         conn.commit()
 
+    # #1140 Task C — snapshot the job_runs MAX(id) BEFORE acquiring
+    # ``JobLock`` so the row resolver can pin its fallback window to
+    # rows created during this stage's run. ``job_runs_id_after`` is
+    # captured INSIDE the lock (after the invoker returns, before lock
+    # release) so a same-``job_name`` scheduled fire that lands after
+    # release cannot pollute the pick.
+    with psycopg.connect(database_url) as conn:
+        job_runs_id_before = _snapshot_job_runs_max_id(conn, job_name=job_name)
+    job_runs_id_after = job_runs_id_before  # set below; default if invoker raises
+
     # PR1c #1064 (Codex pre-push WARNING): the promoted scheduler-side
     # invokers call ``_tracked_job`` which reads ``_params_snapshot_var``
     # via ``consume_params_snapshot()`` to populate
@@ -759,6 +1065,28 @@ def _run_one_stage(
                 invoker(effective_params)
             finally:
                 _params_snapshot_var.reset(snap_token)
+            # #1140 Task C — capture the upper bound while still
+            # holding ``JobLock``. Any job_runs row created here must
+            # belong to our invocation; same-source serialisation
+            # prevents a parallel same-job_name fire from sneaking in.
+            #
+            # Wrapped in try/except so a snapshot failure (transient DB
+            # blip, pool exhausted) does NOT mark a successful invoker
+            # as error (Codex pre-push round 2 WARNING). The resolver
+            # falls back to ``job_runs_id_before`` window (which is the
+            # same value as ``job_runs_id_after`` initialised above) →
+            # an empty window → ``rows_processed = None``. The stage
+            # still records ``success``; cap-eval handles the None per
+            # the strict-gate rule.
+            try:
+                with psycopg.connect(database_url) as snap_conn:
+                    job_runs_id_after = _snapshot_job_runs_max_id(snap_conn, job_name=job_name)
+            except Exception as snap_exc:  # noqa: BLE001 — snapshot is best-effort
+                logger.warning(
+                    "bootstrap stage %s: failed to capture job_runs_id_after: %s",
+                    stage_key,
+                    snap_exc,
+                )
     except JobAlreadyRunning:
         message = (
             f"another instance of {job_name!r} holds the advisory lock; "
@@ -807,12 +1135,19 @@ def _run_one_stage(
     # downstream stages can verify provenance via the precondition
     # checker. C-stages write their own per-archive rows; this catches
     # the B-stages and any other invoker that doesn't self-record.
-    # Idempotent ON CONFLICT — no-op if the C-stage already wrote.
-    from app.services.bootstrap_preconditions import record_archive_result
+    #
+    # #1140 Task C — uses ``record_archive_result_if_absent`` (ON
+    # CONFLICT DO NOTHING) so a service invoker that already wrote
+    # ``__job__`` with a real ``rows_written`` count (e.g.
+    # ``sec_submissions_files_walk`` overloads the provenance row
+    # with ``filings_upserted``) is preserved. The pre-1140 helper
+    # was last-write-wins which clobbered the invoker's value back
+    # to 0.
+    from app.services.bootstrap_preconditions import record_archive_result_if_absent
 
     with psycopg.connect(database_url) as conn:
         try:
-            record_archive_result(
+            record_archive_result_if_absent(
                 conn,
                 bootstrap_run_id=run_id,
                 stage_key=stage_key,
@@ -827,10 +1162,41 @@ def _run_one_stage(
                 exc,
             )
 
+    # #1140 Task C — resolve rows_processed from the side-channels and
+    # commit it onto the stage row so the cap-eval layer + the
+    # operator panel aggregate read real numbers instead of NULL.
+    resolved_rows: int | None = None
+    try:
+        with psycopg.connect(database_url) as conn:
+            resolved_rows = _resolve_stage_rows(
+                conn,
+                bootstrap_run_id=run_id,
+                stage_key=stage_key,
+                job_name=job_name,
+                job_runs_id_before=job_runs_id_before,
+                job_runs_id_after=job_runs_id_after,
+            )
+    except Exception as exc:  # noqa: BLE001 — auditing must not fail the stage
+        logger.warning(
+            "bootstrap stage %s: failed to resolve rows_processed: %s",
+            stage_key,
+            exc,
+        )
+
     with psycopg.connect(database_url) as conn:
-        mark_stage_success(conn, run_id=run_id, stage_key=stage_key)
+        mark_stage_success(
+            conn,
+            run_id=run_id,
+            stage_key=stage_key,
+            rows_processed=resolved_rows,
+        )
         conn.commit()
-    return _StageOutcome(stage_key=stage_key, success=True, error=None)
+    return _StageOutcome(
+        stage_key=stage_key,
+        success=True,
+        error=None,
+        rows_processed=resolved_rows,
+    )
 
 
 def _should_run(stage_status: str) -> bool:
@@ -905,8 +1271,10 @@ def _phase_batched_dispatch(
     runnable: list[_RunnableStage],
     database_url: str,
     preexisting_statuses: dict[str, str] | None = None,
+    preexisting_rows_processed: dict[str, int | None] | None = None,
     provides_map: Mapping[str, tuple[Capability, ...]] | None = None,
     provides_on_skip_map: Mapping[str, tuple[Capability, ...]] | None = None,
+    min_rows_map: Mapping[Capability, int] | None = None,
 ) -> tuple[dict[str, str], bool]:
     """Dispatch ``runnable`` stages in phase-batched fashion with lane concurrency.
 
@@ -972,6 +1340,9 @@ def _phase_batched_dispatch(
     effective_provides_on_skip: Mapping[str, tuple[Capability, ...]] = (
         {**_STAGE_PROVIDES_ON_SKIP, **provides_on_skip_map} if provides_on_skip_map else _STAGE_PROVIDES_ON_SKIP
     )
+    effective_min_rows: Mapping[Capability, int] = (
+        {**_CAPABILITY_MIN_ROWS, **min_rows_map} if min_rows_map else _CAPABILITY_MIN_ROWS
+    )
     if provides_map or provides_on_skip_map:
         effective_providers_inverse: Mapping[Capability, tuple[str, ...]] = _build_capability_providers(
             effective_provides, effective_provides_on_skip
@@ -981,12 +1352,21 @@ def _phase_batched_dispatch(
 
     by_key = {r.stage_key: r for r in runnable}
     statuses: dict[str, str] = {r.stage_key: "pending" for r in runnable}
+    # #1140 Task C — parallel dict tracking rows_processed for each
+    # stage. Seeded from preexisting terminal stages (so a retry-pass
+    # respects what a prior pass wrote) and updated from each
+    # _StageOutcome as stages complete. The cap-eval helpers consult
+    # this to decide whether strict-gate caps are satisfied.
+    rows_processed: dict[str, int | None] = {r.stage_key: None for r in runnable}
     # Merge in upstream stages already in a terminal state so the
     # dependency check sees them.
     if preexisting_statuses:
         for key, status in preexisting_statuses.items():
             if key not in statuses:
                 statuses[key] = status
+    if preexisting_rows_processed:
+        for key, value in preexisting_rows_processed.items():
+            rows_processed[key] = value
 
     while True:
         # Cancel checkpoint — covers (W1) "before submitting Phase A's
@@ -1036,8 +1416,10 @@ def _phase_batched_dispatch(
         # wait for upstream pending/running providers.
         caps = _satisfied_capabilities(
             statuses,
+            rows_processed,
             provides=effective_provides,
             provides_on_skip=effective_provides_on_skip,
+            min_rows=effective_min_rows,
         )
         ready: list[_RunnableStage] = []
         cascade_transitioned = False
@@ -1050,8 +1432,10 @@ def _phase_batched_dispatch(
             classification = _classify_requirement_unsatisfiable(
                 req,
                 statuses,
+                rows_processed,
                 providers_map=effective_providers_inverse,
                 provides_on_skip=effective_provides_on_skip,
+                min_rows=effective_min_rows,
             )
             if classification is None:
                 continue  # still potentially satisfiable; wait
@@ -1060,7 +1444,9 @@ def _phase_batched_dispatch(
                 reason = _format_block_reason(
                     dead_caps,
                     statuses,
+                    rows_processed,
                     providers_map=effective_providers_inverse,
+                    min_rows=effective_min_rows,
                 )
                 with psycopg.connect(database_url) as conn:
                     mark_stage_blocked(
@@ -1209,6 +1595,10 @@ def _phase_batched_dispatch(
 
         for stage_key, fut in all_futures:
             outcome = fut.result()
+            # #1140 Task C — refresh the per-stage row count from the
+            # outcome so the next dispatcher iteration's cap-eval
+            # reads it.
+            rows_processed[stage_key] = outcome.rows_processed
             if outcome.skipped:
                 statuses[stage_key] = "skipped"
                 logger.info("bootstrap dispatcher: %s SKIPPED", stage_key)
@@ -1223,7 +1613,11 @@ def _phase_batched_dispatch(
                 logger.info("bootstrap dispatcher: %s CANCELLED (%s)", stage_key, outcome.error)
             elif outcome.success:
                 statuses[stage_key] = "success"
-                logger.info("bootstrap dispatcher: %s OK", stage_key)
+                logger.info(
+                    "bootstrap dispatcher: %s OK (rows_processed=%s)",
+                    stage_key,
+                    outcome.rows_processed,
+                )
             else:
                 statuses[stage_key] = "error"
                 logger.warning("bootstrap dispatcher: %s ERROR (%s)", stage_key, outcome.error)
@@ -1276,12 +1670,18 @@ def run_bootstrap_orchestrator() -> None:
     # because that upstream was filtered out of `runnable`. Codex
     # review BLOCKING for #1020 PR2.
     preexisting_statuses: dict[str, str] = {}
+    # #1140 Task C — seed rows_processed for preexisting terminal
+    # stages so the cap-eval layer can read them on retry passes.
+    # ``StageRow.rows_processed`` is already projected by
+    # ``read_latest_run_with_stages``.
+    preexisting_rows_processed: dict[str, int | None] = {}
     runnable: list[_RunnableStage] = []
     for stage in sorted(snapshot.stages, key=lambda s: s.stage_order):
         # Skip stages already in a terminal state (re-runs); record
         # their status so dispatch dependency checks see them.
         if stage.status in ("success", "error", "blocked", "skipped", "cancelled"):
             preexisting_statuses[stage.stage_key] = stage.status
+            preexisting_rows_processed[stage.stage_key] = stage.rows_processed
             logger.info("bootstrap dispatcher: skipping %s (already %s)", stage.stage_key, stage.status)
             continue
         invoker = _INVOKERS.get(stage.job_name)
@@ -1324,6 +1724,7 @@ def run_bootstrap_orchestrator() -> None:
         runnable=runnable,
         database_url=database_url,
         preexisting_statuses=preexisting_statuses,
+        preexisting_rows_processed=preexisting_rows_processed,
     )
 
     if cancelled:

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -464,6 +464,7 @@ def _satisfied_capabilities(
     provides: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES,
     provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
     min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
+    exclusions: Mapping[Capability, frozenset[str]] = _STRICT_CAP_PROVIDER_EXCLUSIONS,
 ) -> set[Capability]:
     """Cap set derived from current stage statuses + per-stage rows.
 
@@ -487,7 +488,7 @@ def _satisfied_capabilities(
     for stage_key, status in statuses.items():
         if status == "success":
             for cap in provides.get(stage_key, ()):
-                if _provider_meets_floor(cap, stage_key, rows.get(stage_key), min_rows):
+                if _provider_meets_floor(cap, stage_key, rows.get(stage_key), min_rows, exclusions=exclusions):
                     caps.add(cap)
         elif status == "skipped":
             caps.update(provides_on_skip.get(stage_key, ()))
@@ -502,6 +503,7 @@ def _capability_is_dead(
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
     provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
     min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
+    exclusions: Mapping[Capability, frozenset[str]] = _STRICT_CAP_PROVIDER_EXCLUSIONS,
 ) -> bool:
     """A cap is dead iff every registered provider is in a state where
     it cannot now (or in the future) provide the cap.
@@ -533,7 +535,7 @@ def _capability_is_dead(
         if status in ("pending", "running"):
             return False
         if status == "success":
-            if _provider_meets_floor(cap, provider_key, rows.get(provider_key), min_rows):
+            if _provider_meets_floor(cap, provider_key, rows.get(provider_key), min_rows, exclusions=exclusions):
                 return False
             # Below floor (or excluded multi-cap provider) — this
             # provider cannot satisfy a strict cap. Keep checking the
@@ -553,6 +555,7 @@ def _classify_dead_cap(
     *,
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
     min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
+    exclusions: Mapping[Capability, frozenset[str]] = _STRICT_CAP_PROVIDER_EXCLUSIONS,
 ) -> Literal["skip_only", "error"]:
     """Return the failure mode that killed a (confirmed-dead) cap.
 
@@ -584,14 +587,16 @@ def _classify_dead_cap(
             continue
         if status in ("error", "blocked", "cancelled"):
             return "error"
-        if status == "success" and not _provider_meets_floor(cap, provider_key, rows.get(provider_key), min_rows):
+        if status == "success" and not _provider_meets_floor(
+            cap, provider_key, rows.get(provider_key), min_rows, exclusions=exclusions
+        ):
             # #1140 Task C — provider succeeded but its row count
             # didn't meet the strict floor. Excluded multi-cap providers
             # (e.g. bulk insider for form3) are NEUTRAL — they cannot
             # satisfy the floor but they shouldn't drive the
             # classification either; the cap death is whatever the
             # OTHER providers tell us. Skip them.
-            if provider_key in _STRICT_CAP_PROVIDER_EXCLUSIONS.get(cap, frozenset()):
+            if provider_key in exclusions.get(cap, frozenset()):
                 continue
             # Non-excluded provider under floor → classify as error so
             # the consumer transitions to ``blocked`` with a structured
@@ -618,6 +623,7 @@ def _classify_requirement_unsatisfiable(
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
     provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
     min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
+    exclusions: Mapping[Capability, frozenset[str]] = _STRICT_CAP_PROVIDER_EXCLUSIONS,
 ) -> tuple[Literal["skip_only", "error"], list[Capability]] | None:
     """If ``req`` is unsatisfiable now, return ``(classification, dead_caps)``.
 
@@ -643,6 +649,7 @@ def _classify_requirement_unsatisfiable(
         providers_map=providers_map,
         provides_on_skip=provides_on_skip,
         min_rows=min_rows,
+        exclusions=exclusions,
     )
     dead_in_all: list[Capability] = [c for c in req.all_of if is_dead(c)]
 
@@ -674,6 +681,7 @@ def _classify_requirement_unsatisfiable(
                 rows_processed,
                 providers_map=providers_map,
                 min_rows=min_rows,
+                exclusions=exclusions,
             )
             == "error"
         ):
@@ -688,6 +696,7 @@ def _format_block_reason(
     *,
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
     min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
+    exclusions: Mapping[Capability, frozenset[str]] = _STRICT_CAP_PROVIDER_EXCLUSIONS,
 ) -> str:
     """Build the structured ``last_error`` string for a blocked stage.
 
@@ -700,7 +709,7 @@ def _format_block_reason(
     parts: list[str] = []
     for cap in dead_caps:
         providers = providers_map.get(cap, ())
-        excluded_for_cap = _STRICT_CAP_PROVIDER_EXCLUSIONS.get(cap, frozenset())
+        excluded_for_cap = exclusions.get(cap, frozenset())
         annotated: list[str] = []
         for p in providers:
             status = statuses.get(p, "?")
@@ -1275,6 +1284,7 @@ def _phase_batched_dispatch(
     provides_map: Mapping[str, tuple[Capability, ...]] | None = None,
     provides_on_skip_map: Mapping[str, tuple[Capability, ...]] | None = None,
     min_rows_map: Mapping[Capability, int] | None = None,
+    exclusions_map: Mapping[Capability, frozenset[str]] | None = None,
 ) -> tuple[dict[str, str], bool]:
     """Dispatch ``runnable`` stages in phase-batched fashion with lane concurrency.
 
@@ -1342,6 +1352,9 @@ def _phase_batched_dispatch(
     )
     effective_min_rows: Mapping[Capability, int] = (
         {**_CAPABILITY_MIN_ROWS, **min_rows_map} if min_rows_map else _CAPABILITY_MIN_ROWS
+    )
+    effective_exclusions: Mapping[Capability, frozenset[str]] = (
+        {**_STRICT_CAP_PROVIDER_EXCLUSIONS, **exclusions_map} if exclusions_map else _STRICT_CAP_PROVIDER_EXCLUSIONS
     )
     if provides_map or provides_on_skip_map:
         effective_providers_inverse: Mapping[Capability, tuple[str, ...]] = _build_capability_providers(
@@ -1420,6 +1433,7 @@ def _phase_batched_dispatch(
             provides=effective_provides,
             provides_on_skip=effective_provides_on_skip,
             min_rows=effective_min_rows,
+            exclusions=effective_exclusions,
         )
         ready: list[_RunnableStage] = []
         cascade_transitioned = False
@@ -1436,6 +1450,7 @@ def _phase_batched_dispatch(
                 providers_map=effective_providers_inverse,
                 provides_on_skip=effective_provides_on_skip,
                 min_rows=effective_min_rows,
+                exclusions=effective_exclusions,
             )
             if classification is None:
                 continue  # still potentially satisfiable; wait
@@ -1447,6 +1462,7 @@ def _phase_batched_dispatch(
                     rows_processed,
                     providers_map=effective_providers_inverse,
                     min_rows=effective_min_rows,
+                    exclusions=effective_exclusions,
                 )
                 with psycopg.connect(database_url) as conn:
                     mark_stage_blocked(

--- a/app/services/bootstrap_preconditions.py
+++ b/app/services/bootstrap_preconditions.py
@@ -558,3 +558,47 @@ def record_archive_result(
                 "rows_skipped": json.dumps(rows_skipped or {}),
             },
         )
+
+
+def record_archive_result_if_absent(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    stage_key: str,
+    archive_name: str,
+    rows_written: int,
+    rows_skipped: dict[str, int] | None = None,
+) -> None:
+    """Insert a ``bootstrap_archive_results`` row only if absent.
+
+    Same shape as ``record_archive_result`` but with
+    ``ON CONFLICT ... DO NOTHING`` semantics. Used by the orchestrator's
+    auto ``__job__`` provenance write at the end of ``_run_one_stage``
+    so a service invoker that already wrote ``__job__`` with a real
+    ``rows_written`` count (e.g. ``sec_submissions_files_walk``
+    overloads the provenance row with ``filings_upserted``) is NOT
+    clobbered by the orchestrator's subsequent default-zero write.
+
+    The shared ``record_archive_result`` upsert helper stays unchanged
+    because Phase C ingesters and retry paths still need last-write-
+    wins semantics on per-archive rows (#1140 / Task C of #1136).
+    """
+    import json
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO bootstrap_archive_results
+                (bootstrap_run_id, stage_key, archive_name, rows_written, rows_skipped, completed_at)
+            VALUES
+                (%(run_id)s, %(stage)s, %(archive)s, %(rows_written)s, %(rows_skipped)s::jsonb, NOW())
+            ON CONFLICT (bootstrap_run_id, stage_key, archive_name) DO NOTHING
+            """,
+            {
+                "run_id": bootstrap_run_id,
+                "stage": stage_key,
+                "archive": archive_name,
+                "rows_written": rows_written,
+                "rows_skipped": json.dumps(rows_skipped or {}),
+            },
+        )

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -716,10 +716,15 @@ def reset_failed_stages_for_retry(
             cursor = conn.execute(
                 """
                 UPDATE bootstrap_stages
-                   SET status       = 'pending',
-                       started_at   = NULL,
-                       completed_at = NULL,
-                       last_error   = NULL
+                   SET status         = 'pending',
+                       started_at     = NULL,
+                       completed_at   = NULL,
+                       last_error     = NULL,
+                       -- #1140 Task C: reset rows_processed alongside
+                       -- the rest of the stage row so the operator
+                       -- timeline / bootstrap_adapter aggregate don't
+                       -- show stale counts from the prior failed pass.
+                       rows_processed = NULL
                  WHERE bootstrap_run_id = %(run_id)s
                    AND lane             = %(lane)s
                    AND stage_order      >= %(min_order)s

--- a/docs/superpowers/specs/2026-05-13-precondition-final-data-gates.md
+++ b/docs/superpowers/specs/2026-05-13-precondition-final-data-gates.md
@@ -306,13 +306,13 @@ Strategy:
   upper bound to "rows created while we held the lock" — without
   it, another scheduled fire of the same `job_name` could acquire
   the lock immediately after our release and insert a higher id
-  before the resolver reads, polluting the `id DESC LIMIT 1`
+  before the resolver reads, polluting the `run_id DESC LIMIT 1`
   pick (Codex R2 BLOCKING §1).
 - After `JobLock` releases (BEFORE the orchestrator's auto
   `__job__` write), call `_resolve_stage_rows` with the captured
   `(job_runs_id_before, job_runs_id_after)` window. The
   resolver's `job_runs` fallback restricts to
-  `id > job_runs_id_before AND id <= job_runs_id_after`.
+  `run_id > job_runs_id_before AND run_id <= job_runs_id_after`.
 - The resolved integer (or `None` if no source has data) is
   passed to `mark_stage_success(rows_processed=N)` exactly as
   today.
@@ -357,8 +357,8 @@ def _resolve_stage_rows(
          right thing via source 3).
       3. job_runs.row_count from _tracked_job.
          SELECT row_count FROM job_runs WHERE job_name = %s AND
-         id > job_runs_id_before AND id <= job_runs_id_after AND
-         status = 'success' ORDER BY id DESC LIMIT 1. The
+         run_id > job_runs_id_before AND run_id <= job_runs_id_after AND
+         status = 'success' ORDER BY run_id DESC LIMIT 1. The
          double-bound `id > before AND id <= after` window pins the
          match to rows created while the dispatcher held the
          JobLock (the bounds are captured before lock acquisition
@@ -403,10 +403,10 @@ def _resolve_stage_rows(
             SELECT row_count
               FROM job_runs
              WHERE job_name = %s
-               AND id > %s
-               AND id <= %s
-               AND status = 'success'
-             ORDER BY id DESC
+               AND run_id > %s
+               AND run_id <= %s
+               AND status  = 'success'
+             ORDER BY run_id DESC
              LIMIT 1
             """,
             (job_name, job_runs_id_before, job_runs_id_after),

--- a/docs/superpowers/specs/2026-05-13-precondition-final-data-gates.md
+++ b/docs/superpowers/specs/2026-05-13-precondition-final-data-gates.md
@@ -1,0 +1,862 @@
+# Bootstrap precondition + final-data row-count gates
+
+**Date:** 2026-05-13
+**Issue:** [#1140](https://github.com/Luke-Bradford/eBull/issues/1140)
+(Task C of [#1136](https://github.com/Luke-Bradford/eBull/issues/1136)
+audit)
+**Status:** Draft — pending Codex review
+
+## 1. Problem
+
+Task A (#1138) introduced the capability layer
+(`_STAGE_REQUIRES_CAPS` / `_STAGE_PROVIDES` /
+`_satisfied_capabilities`) but advertises a capability the moment the
+provider stage's `bootstrap_stages.status` reaches `success`. The
+provider's `rows_processed` is not consulted. Two consequences flagged
+by the #1136 audit §2:
+
+- **Fundamentals gate is status-only.** `fundamentals_sync` (S24)
+  depends on `fundamentals_raw_seeded`, which `sec_companyfacts_ingest`
+  (S9) advertises on `success`. S9 can finish `success` with zero
+  `company_facts` rows ingested (empty CIK cohort, malformed archive
+  decoded as zero JSON objects, mapping-table drift). S24 then runs
+  and derives an empty fundamentals slice without any operator-visible
+  signal that the upstream produced no data.
+- **Ownership backfill gate is status-only.** Same shape for
+  `ownership_observations_backfill` (S23) — each per-family cap
+  (`insider_inputs_seeded`, `form3_inputs_seeded`,
+  `institutional_inputs_seeded`, `nport_inputs_seeded`) is satisfied
+  the moment any one provider hits `success`, even if that provider
+  ingested zero rows.
+
+The C1.b gate in `bootstrap_preconditions.py::assert_c1b_preconditions`
+already checks `sec_submissions_ingest` wrote ≥ 1 row in the current
+run (queries `bootstrap_archive_results.rows_written`). The same gate
+is missing for the final-derivation stages.
+
+Operator-side fallout: a bootstrap run can land in `complete` with
+the entire fundamentals / ownership slice silently empty. Coverage
+floors in `bootstrap_preconditions.py` are advisory (default
+`min_ratio=0.0`); they log but never block. Audit §2 acceptance:
+
+> Fundamentals + ownership final stages prove non-empty current-run
+> inputs OR surface a warning/partial state.
+
+> `complete with warnings` is operator-visible in process/timeline UI
+> (admin control hub).
+
+> Low coverage no longer masks an empty post-install state.
+
+Secondary defect surfaced during pre-spec audit: the orchestrator's
+`mark_stage_success` writes `bootstrap_stages.rows_processed`, but
+`_run_one_stage` never passes a value — every stage row in
+`bootstrap_stages` carries `rows_processed = NULL` regardless of
+what the invoker actually did. The `processes/bootstrap_adapter.py`
+aggregate at line 144 already `COALESCE(SUM(rows_processed), 0)`s
+the column, so the operator panel reads zero motion even on a
+healthy run. Populating the column is a structural prerequisite
+for the cap-eval widening below.
+
+## 2. Goal
+
+Make the capability dispatcher prove that strict-gate caps (the four
+per-family ownership caps + `fundamentals_raw_seeded`) carry a
+non-zero `rows_processed` from at least one surviving provider
+before advertising the cap. When a provider reaches `success` with
+`rows_processed = 0`, treat that provider as "alive but
+non-contributing" — the cap stays alive only if another provider can
+still satisfy it; if not, downstream consumers block or cascade-skip
+exactly the way Task A handles a dead-cap branch.
+
+Populate `bootstrap_stages.rows_processed` for every stage so the
+gate has real numbers to read.
+
+Surface "complete with warnings" in the admin process/timeline UI
+when at least one stage finished `success` but failed to satisfy a
+strict-gate cap (third visual state between green and red).
+
+## 3. Non-goals
+
+- **New DB enum status** (`complete_with_warnings` on
+  `bootstrap_state.status` or `bootstrap_runs.status`). The third
+  state is a derived view on the API side; no schema migration. A
+  future change can promote it to a first-class enum if the derived
+  view proves load-bearing, but that's wider blast radius than this
+  ticket needs.
+- **Widening `JobInvoker` to return `int | None`.** The contract
+  stays `Callable[[Mapping[str, Any]], None]`. The orchestrator
+  populates `rows_processed` from existing side-channels (job_runs
+  + bootstrap_archive_results), not from invoker return values.
+- **Cap-level coverage-ratio floors** (e.g. "advertise
+  `cik_mapping_ready` only if ≥ 80% of universe instruments are
+  mapped"). The audit explicitly endorses `min_rows` as the knob —
+  do not hardcode percentages. A future ticket can layer
+  ratio-based gates on top once min_rows is in place.
+- **Task A non-goals carry through**: capability provisioning on
+  partial-success within a single stage; per-row-archive-level
+  warnings; DB lane concurrency (Task E / #1141).
+- **Reworking `bootstrap_preconditions.py`'s coverage floors** to be
+  hard-blocking. They stay advisory; the row-count gate is the new
+  hard signal.
+
+## 4. Design
+
+### 4.1 Per-cap minimum-rows knob
+
+```python
+# Strict-gate caps: the dispatcher requires the provider's rows_processed
+# to meet this floor before advertising the cap. Caps absent from this
+# map fall back to status-only gating (current Task A behaviour).
+_CAPABILITY_MIN_ROWS: Final[dict[Capability, int]] = {
+    # Audit §2 acceptance — fundamentals derivation must prove its
+    # raw input was actually ingested.
+    "fundamentals_raw_seeded": 1,
+    # Audit §2 acceptance — ownership backfill must prove every
+    # per-family input was actually ingested.
+    "insider_inputs_seeded": 1,
+    "institutional_inputs_seeded": 1,
+    "nport_inputs_seeded": 1,
+}
+```
+
+**Multi-cap provider exclusion** (Codex pre-push round 2 BLOCKING):
+`sec_insider_ingest_from_dataset` is the only multi-cap provider in
+`_STAGE_PROVIDES` — it advertises BOTH `insider_inputs_seeded` and
+`form3_inputs_seeded` from a single aggregate `rows_processed`
+(the bulk ingester maps rows to form3 vs form4 internally but
+records the sum). A bulk wash that landed 10 Form 4 + 0 Form 3
+rows would falsely advertise `form3_inputs_seeded` under the naive
+strict-gate rule.
+
+To preserve the strict gate for form3 AND avoid the false positive,
+a parallel map `_STRICT_CAP_PROVIDER_EXCLUSIONS: dict[Capability,
+frozenset[str]]` lists per-cap providers that CANNOT contribute to
+the floor:
+
+```python
+_STRICT_CAP_PROVIDER_EXCLUSIONS: Final[dict[Capability, frozenset[str]]] = {
+    "form3_inputs_seeded": frozenset({"sec_insider_ingest_from_dataset"}),
+}
+```
+
+Semantics: the excluded provider is **neutral** for the strict cap.
+Its `success` status doesn't satisfy the floor (rows can't be
+trusted), but it also doesn't drive the cap's death-classification
+(it's not a failed provider, just one whose row signal is ambiguous).
+The cap stays alive iff another (non-excluded) provider satisfies
+the floor — for form3 that's the legacy `sec_form3_ingest` single-cap
+provider. If legacy succeeds with `rows_processed >= 1` the cap is
+satisfied; if it succeeds with rows=0 the cap is dead (classified
+error → consumer blocks). If only the bulk provider ran (legacy
+skipped or absent), the cap is dead too — no surviving non-excluded
+provider met the floor.
+
+When per-family bulk row counts land (follow-up ticket — either
+split the bulk-insider stage into two per-family stages OR write
+per-cap rows via the existing `bootstrap_archive_results` per-archive
+shape) the exclusion entry can be dropped and the bulk provider can
+satisfy `form3_inputs_seeded` directly.
+
+Default behaviour for unlisted caps is unchanged from Task A — the
+cap is satisfied iff at least one provider hit `success`. Only the
+five caps above pick up the new floor in v1. The blast radius is
+deliberately small: changing the gate for a cap can mask or unmask
+existing fallback paths, so each addition needs its own audit.
+
+The threshold `1` is the cheapest non-trivial floor: any positive
+write counts. A reviewer should not interpret `1` as "the system
+needs exactly one row to be useful" — it means "if zero rows landed
+we know something is wrong". Higher floors (e.g. `100` company_facts
+rows) are a follow-up scope decision and explicitly out for v1.
+
+### 4.2 Cap eval widening
+
+Today `_satisfied_capabilities(statuses)` returns the set of caps
+whose providers are in `success` (or `skipped` with a
+`_STAGE_PROVIDES_ON_SKIP` entry). The new signature consults
+`rows_processed`:
+
+```python
+def _satisfied_capabilities(
+    statuses: Mapping[str, str],
+    rows_processed: Mapping[str, int | None],
+    *,
+    provides: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES,
+    provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
+    min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
+) -> set[Capability]:
+    """Cap set derived from current stage statuses + per-stage rows.
+
+    For a cap C with min_rows[C] = N:
+      A provider P satisfies C iff statuses[P] == 'success' AND
+      rows_processed.get(P) is not None AND rows_processed[P] >= N.
+
+    For a cap C NOT in min_rows:
+      A provider P satisfies C iff statuses[P] == 'success'.
+      (Legacy Task A behaviour preserved.)
+
+    `skipped` providers continue to satisfy C iff C is in
+    `provides_on_skip[P]` — the skipped path is never row-counted
+    (the slow-connection fallback explicitly doesn't write rows
+    through the bulk stage).
+    """
+```
+
+A provider that reached `success` but failed the rows floor for a
+strict-gate cap does NOT contribute that cap. The provider stage's
+status stays `success` on the DB; only the cap-eval layer treats
+the provider as "non-contributing" for the strict cap.
+
+`_capability_is_dead` then needs to know: for a strict-gate cap, a
+provider in `success` with `rows_processed < min_rows` is **dead
+for this cap** (cannot now or in future provide it — the stage is
+already in a terminal state). The helper changes:
+
+```python
+def _capability_is_dead(
+    cap: Capability,
+    statuses: Mapping[str, str],
+    rows_processed: Mapping[str, int | None],
+    *,
+    providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
+    provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
+    min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
+) -> bool:
+    ...
+    floor = min_rows.get(cap)
+    for provider_key in providers:
+        status = statuses.get(provider_key)
+        if status in ("pending", "running"):
+            return False
+        if status == "success":
+            if floor is None:
+                return False                     # legacy behaviour
+            rows = rows_processed.get(provider_key)
+            if rows is not None and rows >= floor:
+                return False                     # provider satisfies the floor
+            # rows < floor (or NULL) → this provider is dead for the
+            # strict cap; keep checking the others.
+            continue
+        if status == "skipped":
+            on_skip = provides_on_skip.get(provider_key, ())
+            if cap in on_skip:
+                return False
+    return True
+```
+
+`_classify_dead_cap` change: a provider that's `success` but
+under-floor for a strict cap classifies as `"error"` (not
+`"skip_only"`). The intent matches operator expectation — the
+provider ran and produced zero rows, which is a failure mode, not a
+deliberate bypass. The dispatcher therefore **blocks** the
+downstream consumer with a structured reason, not cascade-skips:
+
+```text
+blocked: missing capability fundamentals_raw_seeded; no surviving
+provider met rows floor 1 (providers: sec_companyfacts_ingest=success
+[rows_processed=0])
+```
+
+`_format_block_reason` widens to include `rows_processed=N` /
+`rows_processed=NULL` annotations for `success` providers that
+failed the floor; other states render as today.
+
+### 4.3 Populating `bootstrap_stages.rows_processed`
+
+The orchestrator's `_run_one_stage` already records a `__job__` row
+in `bootstrap_archive_results` after a successful invoker exit, then
+calls `mark_stage_success(conn, run_id=..., stage_key=...)`. Today
+neither write supplies `rows_processed`.
+
+Three sources of row counts exist in current code, each authoritative
+for a different stage shape:
+
+1. **`bootstrap_archive_results` non-`__job__` rows** — Phase C
+   bulk wrappers in `app/services/sec_bulk_orchestrator_jobs.py`
+   (e.g. `sec_companyfacts_ingest_job`) write one row per archive
+   they processed. They do NOT use `_tracked_job` (Codex R1
+   BLOCKING §1 — the original spec wording wrongly claimed they
+   did), so this is their only signal.
+2. **`bootstrap_archive_results` `__job__` row with operator-set
+   `rows_written`** — service invokers like
+   `app/services/sec_submissions_files_walk.py:179` overload the
+   `__job__` provenance row to carry their real result count
+   (`rows_written=result.filings_upserted`). The orchestrator's
+   own auto-recorded `__job__` row defaults to `rows_written=0`
+   (`bootstrap_orchestrator.py:820`); the current upsert in
+   `record_archive_result` is last-write-wins, so the orchestrator's
+   subsequent default-zero write clobbers the invoker's value —
+   §4.3.1 introduces a `DO NOTHING` variant to fix this.
+3. **`job_runs.row_count`** — `_tracked_job(job_name)` in
+   `app/workers/scheduler.py` records this from the invoker's
+   `tracker.row_count = N` side-effect. Every cap-providing
+   scheduler invoker either already sets it (verified for
+   `sec_form3_ingest`, `sec_n_port_ingest`,
+   `sec_insider_transactions_backfill` per Codex R1 INFO §1) or
+   has the data available.
+
+Strategy:
+
+- BEFORE acquiring `JobLock` in `_run_one_stage`, snapshot
+  `SELECT COALESCE(MAX(id), 0) FROM job_runs WHERE job_name = %s`
+  into a local `job_runs_id_before` variable.
+- AFTER the invoker returns and BEFORE `JobLock` releases (still
+  inside the `with JobLock(...)` block), snapshot the same query
+  into `job_runs_id_after`. This second snapshot anchors the
+  upper bound to "rows created while we held the lock" — without
+  it, another scheduled fire of the same `job_name` could acquire
+  the lock immediately after our release and insert a higher id
+  before the resolver reads, polluting the `id DESC LIMIT 1`
+  pick (Codex R2 BLOCKING §1).
+- After `JobLock` releases (BEFORE the orchestrator's auto
+  `__job__` write), call `_resolve_stage_rows` with the captured
+  `(job_runs_id_before, job_runs_id_after)` window. The
+  resolver's `job_runs` fallback restricts to
+  `id > job_runs_id_before AND id <= job_runs_id_after`.
+- The resolved integer (or `None` if no source has data) is
+  passed to `mark_stage_success(rows_processed=N)` exactly as
+  today.
+
+```python
+def _resolve_stage_rows(
+    conn: psycopg.Connection[Any],
+    *,
+    bootstrap_run_id: int,
+    stage_key: str,
+    job_name: str,
+    job_runs_id_before: int,
+    job_runs_id_after: int,
+) -> int | None:
+    """Look up rows_processed from the three side-channels.
+
+    Returns None when no source has a value (callers preserve
+    legacy behaviour: cap-eval layer treats None as "below floor"
+    for strict caps, satisfied via status alone for non-strict).
+
+    Resolution order (first match wins):
+      1. Per-archive bootstrap_archive_results (non-__job__).
+         If COUNT > 0 → return SUM(rows_written), preserving 0.
+         This is the Phase C bulk-wrapper shape. SUM=0 with real
+         per-archive rows means "the C-stage ran every archive and
+         every archive was empty" — that's a real signal, not
+         absence of signal (Codex R1 BLOCKING §1).
+      2. __job__ row with operator-set rows_written.
+         If the __job__ row exists AND rows_written > 0 → return
+         that integer. Covers the service-invoker shape (e.g.
+         sec_submissions_files_walk overloads __job__ with its
+         real result count; Codex R1 BLOCKING §2). The default
+         orchestrator-written __job__ row carries rows_written=0
+         which intentionally falls through to source 3 — we can't
+         distinguish "service invoker explicitly set 0" from
+         "orchestrator default 0" without a side-channel, so we
+         prefer the job_runs fallback when the value is 0. In
+         practice the only service invokers that write __job__
+         set rows_written > 0 on success; if a future one needs to
+         report 0 explicitly, add a service-invoker-side
+         `_tracked_job` wrapper instead (which already does the
+         right thing via source 3).
+      3. job_runs.row_count from _tracked_job.
+         SELECT row_count FROM job_runs WHERE job_name = %s AND
+         id > job_runs_id_before AND id <= job_runs_id_after AND
+         status = 'success' ORDER BY id DESC LIMIT 1. The
+         double-bound `id > before AND id <= after` window pins the
+         match to rows created while the dispatcher held the
+         JobLock (the bounds are captured before lock acquisition
+         and just before lock release — see strategy bullet 1+2
+         above). Without the upper bound a same-job_name scheduled
+         fire that landed after our release could pollute the
+         pick (Codex R2 BLOCKING §1).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*), COALESCE(SUM(rows_written), 0)
+              FROM bootstrap_archive_results
+             WHERE bootstrap_run_id = %s
+               AND stage_key = %s
+               AND archive_name <> '__job__'
+            """,
+            (bootstrap_run_id, stage_key),
+        )
+        row = cur.fetchone()
+        archive_count = int(row[0]) if row else 0
+        archive_sum = int(row[1]) if row and row[1] is not None else 0
+        if archive_count > 0:
+            return archive_sum
+
+        cur.execute(
+            """
+            SELECT rows_written
+              FROM bootstrap_archive_results
+             WHERE bootstrap_run_id = %s
+               AND stage_key = %s
+               AND archive_name = '__job__'
+            """,
+            (bootstrap_run_id, stage_key),
+        )
+        row = cur.fetchone()
+        if row is not None and row[0] is not None and int(row[0]) > 0:
+            return int(row[0])
+
+        cur.execute(
+            """
+            SELECT row_count
+              FROM job_runs
+             WHERE job_name = %s
+               AND id > %s
+               AND id <= %s
+               AND status = 'success'
+             ORDER BY id DESC
+             LIMIT 1
+            """,
+            (job_name, job_runs_id_before, job_runs_id_after),
+        )
+        row = cur.fetchone()
+        if row is not None and row[0] is not None:
+            return int(row[0])
+    return None
+```
+
+Total cost per stage: 1 capture (before lock) + 3 reads (after
+invoker) + 1 already-existing UPDATE. No new indexes needed — every
+predicate hits an existing PK / FK / job_name index.
+
+#### 4.3.1 Why the resolver picks archive rows before `__job__`
+
+A C-stage that processed K archives writes K rows in
+`bootstrap_archive_results` AND the orchestrator auto-writes the
+`__job__` provenance row at `_run_one_stage:813-828`. Both shapes
+co-exist on the same `(bootstrap_run_id, stage_key)` key. The
+resolver checks the per-archive rows first because their sum is the
+real ingest count; the `__job__` row's `rows_written=0` is a
+provenance marker, not data.
+
+A C-stage where every archive landed empty (`rows_written=0` on
+every per-archive row) has `archive_count > 0` AND `archive_sum =
+0`. The resolver returns `0` — that's the correct semantic: "the
+stage ran every archive and produced zero rows", distinguishable
+from "the stage never wrote archive rows" (where `archive_count =
+0` and we fall through to source 2 / 3). This is the Codex R1
+BLOCKING §1 fix: pre-revision the spec returned `None` for a real
+zero, hiding the warning case.
+
+Service-invoker shape (source 2): `sec_submissions_files_walk` is
+the current example. It calls `record_archive_result(..., archive_name="__job__",
+rows_written=result.filings_upserted)` itself; the orchestrator's
+own auto-write at `_run_one_stage:813-828` then runs and calls
+`record_archive_result(..., archive_name="__job__", rows_written=0)`
+with `ON CONFLICT (run_id, stage_key, archive_name) DO UPDATE SET
+rows_written = EXCLUDED.rows_written`. The orchestrator's write
+fires AFTER the invoker's, so the final `rows_written` is 0 again
+— erasing the invoker's value.
+
+**Fix (part of this PR):** add a new helper
+`record_archive_result_if_absent(conn, *, bootstrap_run_id,
+stage_key, archive_name, rows_written, rows_skipped=None)` in
+`bootstrap_preconditions.py`. Same body as `record_archive_result`
+but with `ON CONFLICT (bootstrap_run_id, stage_key, archive_name) DO
+NOTHING`. The orchestrator's auto `__job__` write at
+`_run_one_stage:813-828` switches to this helper. The existing
+`record_archive_result` upsert helper stays unchanged — the
+shared C-stage / retry path still upserts as before, which is the
+correct semantic for per-archive retries (Codex R2 BLOCKING §2).
+
+Existing tests that read `__job__.rows_written = 0` after a
+vanilla B-stage continue to pass — the orchestrator still seeds
+the row when the invoker hasn't already.
+
+Audit step for the reviewer: grep for `record_archive_result(.*archive_name="__job__"`
+to enumerate every invoker that writes a non-default `__job__` row.
+Today the only one is `sec_submissions_files_walk`; if a future
+invoker writes `__job__` with `rows_written=0` on purpose, the
+resolver will fall through to `job_runs` — which is fine if the
+invoker also uses `_tracked_job`, and surfaceable in test as a
+NULL on the stage row otherwise.
+
+#### 4.3.2 Per-stage cap-providing inventory + row source
+
+For each cap-providing stage (the keys in `_STAGE_PROVIDES`), the
+resolved row count comes from:
+
+| Stage | Source | Already populated? |
+|---|---|---|
+| `universe_sync` | `job_runs.row_count` via `_universe_sync_job` tracker | yes (scheduler.py:1427) |
+| `cusip_universe_backfill` | `job_runs.row_count` | yes |
+| `cik_refresh` | `job_runs.row_count` via `_daily_cik_refresh` | yes (scheduler.py:1714) |
+| `sec_bulk_download` | `bootstrap_archive_results` (per-archive landed) | yes |
+| `sec_submissions_ingest` | `bootstrap_archive_results` | yes |
+| `sec_companyfacts_ingest` | `bootstrap_archive_results` | yes |
+| `sec_insider_ingest_from_dataset` | `bootstrap_archive_results` | yes |
+| `sec_13f_ingest_from_dataset` | `bootstrap_archive_results` | yes |
+| `sec_nport_ingest_from_dataset` | `bootstrap_archive_results` | yes |
+| `sec_submissions_files_walk` | `__job__.rows_written` (source 2) | yes — `sec_submissions_files_walk.py:228` writes `result.filings_upserted` |
+| `filings_history_seed` | `job_runs.row_count` | yes |
+| `sec_first_install_drain` | `job_runs.row_count` | yes |
+| `sec_insider_transactions_backfill` | `job_runs.row_count` | yes — `scheduler.py:4709` |
+| `sec_form3_ingest` | `job_runs.row_count` | yes — `scheduler.py:3935` (Codex R1 INFO §1) |
+| `sec_13f_recent_sweep` | `job_runs.row_count` | yes |
+| `sec_n_port_ingest` | `job_runs.row_count` | yes — `scheduler.py:4566` |
+
+Every cap-providing stage has at least one populated source. The
+strict-gate caps (`fundamentals_raw_seeded` +
+`insider_inputs_seeded` / `form3_inputs_seeded` /
+`institutional_inputs_seeded` / `nport_inputs_seeded`) all map onto
+stages whose row source is already populated, so the cap-eval
+widening in §4.1-§4.2 has real numbers to gate on from PR merge
+forward. The submissions walker (source 2) is non-strict today
+(its cap `submissions_secondary_pages_walked` doesn't appear in
+`_CAPABILITY_MIN_ROWS`); its `rows_processed` plumbing is for
+operator-panel visibility only.
+
+### 4.4 Dispatcher integration
+
+`_phase_batched_dispatch` already plumbs `statuses` through
+`_satisfied_capabilities` / `_capability_is_dead` /
+`_classify_requirement_unsatisfiable`. Add a parallel
+`rows_processed: dict[str, int | None]` dict alongside, populated
+each iteration by reading from `bootstrap_stages` along with the
+status refresh.
+
+The dispatcher currently re-reads stage statuses via the in-process
+`statuses` dict (mutated as stages complete). The new code also
+updates `rows_processed[stage_key]` from the outcome of
+`_run_one_stage` — `_StageOutcome` widens to carry the resolved
+`rows_processed: int | None` so the dispatcher doesn't need a
+round-trip to the DB.
+
+```python
+@dataclass(frozen=True)
+class _StageOutcome:
+    stage_key: str
+    success: bool
+    error: str | None
+    skipped: bool = False
+    cancelled: bool = False
+    rows_processed: int | None = None  # NEW
+```
+
+For preexisting terminal stages (from a `retry-failed` pass), the
+existing snapshot load at `run_bootstrap_orchestrator` already
+reads each stage's row from `bootstrap_stages`; widen the projection
+to include `rows_processed` and seed it into the dispatcher's dict.
+
+### 4.5 "Complete with warnings" UI surface
+
+API-side derivation, no DB enum.
+
+Add a `warning: str | None` field to
+`BootstrapTimelineStageResponse` (one per stage) and a
+`has_warnings: bool` field to `BootstrapTimelineRunResponse`. Both
+are derived from the timeline query:
+
+- `warning` is set on a stage row iff `status == 'success'` AND the
+  stage is a cap provider AND `rows_processed` is `0` or `NULL` AND
+  at least one cap the stage provides is in `_CAPABILITY_MIN_ROWS`
+  (i.e. strict-gate). Value is a short operator-readable string:
+  `"stage succeeded but wrote 0 rows; downstream caps cannot be satisfied"`.
+- `has_warnings` is `True` iff any stage in the run has `warning !=
+  None`.
+
+The frontend (`ProcessDetailPage.tsx` timeline tab + the
+`processes` table row for `bootstrap`) reads `warning` and renders
+an amber chip next to the stage's success tick. The processes table
+checks `has_warnings` and renders an amber dot next to the
+`complete` status text when set. Existing `STATUS_VISUAL` mapping
+in `frontend/src/components/admin/processStatus.ts` gains a new
+key `success_warning` (style: amber, hover tooltip = the stage's
+`warning` text).
+
+Pre-existing behaviour for `complete` / `partial_error` /
+`cancelled` is unchanged. A run that finishes `complete` AND
+`has_warnings == true` renders as `complete` with the amber dot —
+operator sees both "the run finished" and "but something inside
+needs attention". A run that finishes `partial_error` already
+renders red; the amber dot doesn't add information there and is
+suppressed (the red signal is louder).
+
+### 4.6 `processes/bootstrap_adapter.py` aggregate fixup
+
+`bootstrap_adapter.py:144` currently does
+`COALESCE(SUM(rows_processed), 0) AS rows_processed`. With this
+spec the column gets real numbers, so the aggregate starts reading
+non-zero on the operator panel — desired side effect (the panel
+has been showing zero motion for every bootstrap run since the
+24-stage rewrite).
+
+No change to the adapter SQL or shape. Verify the operator panel
+renders the aggregate correctly post-fix via the dev-DB smoke step
+in §6.
+
+## 5. Tests
+
+### 5.1 Unit (`tests/test_bootstrap_orchestrator.py`)
+
+Add four tests covering the cap-eval rule changes. All use the
+existing fixture mechanism with synthetic stage_keys and synthetic
+caps registered via `provides_map` / `provides_on_skip_map`
+overrides on `_phase_batched_dispatch`. A new override parameter
+`min_rows_map` plumbs the per-cap floors into the dispatcher for
+fixture-only caps; production code uses the module-level map.
+
+1. **`test_strict_cap_blocks_consumer_on_zero_rows`** — Provider
+   stage reaches `success` with `rows_processed=0`. Consumer with
+   a strict-gate cap requirement transitions to `blocked` with a
+   reason naming `rows_processed=0` and the cap. Run finalises as
+   `partial_error`.
+
+2. **`test_strict_cap_satisfied_by_one_of_two_providers`** — Cap
+   has two providers; one reaches `success` with `rows_processed=0`
+   (under floor), the other reaches `success` with
+   `rows_processed=5` (above floor). Consumer runs. Run finalises
+   as `complete`. Smokes the per-family ownership cap shape (bulk
+   ingester landed zero, legacy ingester landed rows).
+
+3. **`test_strict_cap_dead_on_zero_rows_classifies_error_not_skip`**
+   — Single-provider strict cap; provider reaches `success` with
+   `rows_processed=0`. Assert the dispatcher transitions the
+   consumer to `blocked` (not `skipped`). Distinct from Task A's
+   cascade-skip path, which only fires for `skipped` providers.
+
+4. **`test_non_strict_cap_unchanged_by_zero_rows`** — A cap NOT in
+   `_CAPABILITY_MIN_ROWS` is satisfied by a `success` provider
+   with `rows_processed=0` (legacy Task A behaviour preserved).
+   Asserts the new rule doesn't accidentally widen to caps it
+   shouldn't touch — guards against the blast-radius concern in
+   §4.1.
+
+Catalogue invariant test addition:
+
+5. **`test_min_rows_caps_have_at_least_one_provider`** — every key
+   in `_CAPABILITY_MIN_ROWS` is also a key in
+   `_CAPABILITY_PROVIDERS` (i.e. has at least one provider stage).
+   Catches a stale entry that names a removed cap.
+
+### 5.2 Real-DB integration (`tests/test_bootstrap_atomic_enqueue.py`
+or new file `tests/test_bootstrap_rows_processed_gates.py`)
+
+Uses `ebull_test_conn` per `feedback_test_db_isolation`.
+
+1. **`test_resolver_archive_sum_wins_when_count_positive`** —
+   seed `bootstrap_runs` + `bootstrap_stages` rows for
+   `sec_companyfacts_ingest`. Insert two
+   `bootstrap_archive_results` rows: (`__job__`, `rows_written=0`)
+   and (`companyfacts.zip`, `rows_written=42`). Call
+   `_resolve_stage_rows(...)` and assert the return is `42`.
+
+2. **`test_resolver_archive_sum_zero_preserved`** (Codex R1
+   BLOCKING §1 regression) — same setup but the per-archive row
+   carries `rows_written=0`. `__job__` row also `rows_written=0`.
+   Call `_resolve_stage_rows` and assert the return is `0` (NOT
+   `None` — `archive_count > 0` short-circuits before sources 2
+   and 3, preserving the real-zero signal that the C-stage ran
+   every archive and produced no rows).
+
+3. **`test_resolver_uses_job_row_when_set_above_zero`** (Codex
+   R1 BLOCKING §2 regression) — service-invoker shape: insert
+   only the `__job__` row with `rows_written=7` (mirrors
+   `sec_submissions_files_walk` overloading the provenance row).
+   No per-archive rows. Call `_resolve_stage_rows` and assert the
+   return is `7`.
+
+4. **`test_resolver_job_runs_window_excludes_outside_ids`**
+   (Codex R2 BLOCKING §1 regression) — no archive rows at all.
+   Insert THREE `job_runs` rows for the same `job_name`,
+   `status='success'`: one with `id < before` (`row_count=1`,
+   should be excluded), one with `id` in `(before, after]`
+   (`row_count=2`, the target), and one with `id > after`
+   (`row_count=3`, simulates a parallel scheduled fire after
+   JobLock release, should be excluded). Call
+   `_resolve_stage_rows(..., job_runs_id_before=before,
+   job_runs_id_after=after)` and assert the return is `2`.
+
+5. **`test_resolver_falls_back_to_job_runs_when_no_archive_rows`**
+   — no archive rows; one `job_runs` row inside the window with
+   `row_count=1500`. Call `_resolve_stage_rows` and assert the
+   return is `1500`. Negative variant: no archive rows AND no
+   `job_runs` row → return is `None`.
+
+6. **`test_orchestrator_job_row_preserves_invoker_value`** —
+   mirror the real write order. First call the EXISTING upsert
+   helper `record_archive_result(... archive_name="__job__",
+   rows_written=99)` to simulate the service invoker (e.g.
+   `sec_submissions_files_walk`). Then call the NEW
+   `record_archive_result_if_absent(... rows_written=0)` to
+   simulate the orchestrator's default auto-write. Re-read the
+   row and assert `rows_written` is still `99` — the orchestrator's
+   `DO NOTHING` write didn't overwrite the invoker's value (Codex
+   R2 BLOCKING §2 + R3 WARNING). Control: call
+   `record_archive_result(... rows_written=0)` (the existing
+   upsert helper) against the same row and assert the value flips
+   to `0` (upsert semantics unchanged by this PR).
+
+7. **`test_fundamentals_blocked_when_companyfacts_wrote_zero`** —
+   bootstrap end-to-end via fake invokers. Configure
+   `sec_companyfacts_ingest` fake to land `success` with zero
+   rows (its archive result row carries `rows_written=0`, no
+   fallback `job_runs.row_count`). Assert `fundamentals_sync`
+   transitions to `blocked` with a reason naming
+   `fundamentals_raw_seeded` + `rows_processed=0`. Assert the
+   timeline endpoint returns `warning` populated on the
+   `sec_companyfacts_ingest` row and `has_warnings=True` on the
+   run payload. Bootstrap finalises as `partial_error`.
+
+8. **`test_ownership_backfill_blocked_when_all_families_wrote_zero`**
+   — every per-family ownership provider (bulk + legacy) lands
+   `success` with `rows_processed=0`. Assert
+   `ownership_observations_backfill` transitions to `blocked` with
+   a reason naming the first-encountered dead family cap. Run
+   finalises as `partial_error`.
+
+9. **`test_ownership_backfill_runs_when_one_family_legacy_recovers`**
+   — bulk ownership ingester for the institutional family lands
+   `success` with `rows_processed=0`; legacy `sec_13f_recent_sweep`
+   lands `success` with `rows_processed=120`. Assert
+   `ownership_observations_backfill` runs to `success`. (Combined
+   with Task A's per-family cap shape — this is the regression
+   gate that the row-count widening doesn't break the bulk-OR-
+   legacy recovery story.)
+
+10. **`test_timeline_has_warnings_derived_from_stage_rows`** —
+    seed a finished `complete` run where one stage has
+    `rows_processed=0` and is a strict-cap provider (e.g.
+    `sec_companyfacts_ingest`). Call
+    `GET /processes/bootstrap/timeline` and assert
+    `response['run']['has_warnings'] == True` and
+    `response['stages'][i]['warning']` is the documented
+    operator-readable string. A control stage with
+    `rows_processed=42` has `warning == None`.
+
+### 5.3 Frontend (`frontend/src/pages/ProcessDetailPage.test.tsx`)
+
+1. **bootstrap-timeline renders warning chip on success+zero-rows
+   stage** — mock the timeline fetch to return a stage with
+   `status='success'`, `warning='stage succeeded but wrote 0 rows…'`.
+   Assert the amber chip + tooltip text render alongside the
+   success tick.
+2. **processes table renders amber dot on complete run with
+   has_warnings** — mock `fetchProcess('bootstrap')` to return
+   `complete` with the derived `has_warnings=true` shape. Assert
+   the amber dot is in the DOM and the status word is still
+   `complete` (not `partial_error`).
+
+## 6. Migration / rollout
+
+- **No schema change.** `bootstrap_stages.rows_processed` is an
+  existing column.
+- **No data migration.** Pre-fix runs with `rows_processed=NULL`
+  remain unchanged; the cap-eval layer treats NULL as "below
+  floor" for strict caps. On the next bootstrap run after merge,
+  the new dispatcher populates real values.
+- **Backwards-compatible.** Existing scheduler jobs that set
+  `tracker.row_count` continue to do so unchanged. Existing
+  `bootstrap_archive_results` writes are unchanged.
+- **Backfill of `rows_processed` on already-completed runs is
+  out of scope.** The operator sees `0` on the bootstrap_adapter
+  aggregate for old runs (same as today's display); new runs
+  start populating real values immediately.
+
+Manual verification on dev DB:
+
+1. Start dev stack.
+2. `curl -X POST :8000/system/bootstrap/run` — wait for run to
+   reach a terminal state (the dev stack already has a recent
+   complete run; this re-runs).
+3. `psql -c "SELECT stage_key, rows_processed FROM bootstrap_stages
+   WHERE bootstrap_run_id = (SELECT MAX(id) FROM bootstrap_runs)
+   ORDER BY stage_order"` — every stage that ran shows a non-NULL
+   `rows_processed` (some will be 0 by nature; cap-providing
+   strict-gate stages should be > 0 for the panel of 3-5 known
+   instruments AAPL/GME/MSFT/JPM/HD per CLAUDE.md).
+4. Hit `GET /processes/bootstrap/timeline` — assert the JSON
+   payload carries `rows_processed` on each stage AND
+   `has_warnings=False` (healthy run).
+5. Open the admin control hub and the bootstrap timeline drill-in;
+   confirm the row-count aggregate is non-zero (was always 0 on
+   the panel pre-fix; this is the regression gate).
+6. To exercise the warning path on dev: manually
+   `UPDATE bootstrap_stages SET rows_processed = 0 WHERE
+   stage_key = 'sec_companyfacts_ingest' AND bootstrap_run_id =
+   <id>`, then `GET /processes/bootstrap/timeline` and confirm
+   `warning` is set on that stage and `has_warnings=true` on the
+   run. Then revert the UPDATE.
+
+## 7. Acceptance criteria (from #1140 / #1136 audit §2)
+
+- [x] `fundamentals_sync` cannot proceed when `sec_companyfacts_ingest`
+  wrote zero rows. Test 7 in §5.2.
+- [x] `ownership_observations_backfill` cannot proceed when all four
+  per-family caps lack a row-producing provider. Test 8 in §5.2.
+- [x] Per-family bulk-OR-legacy recovery still works when at least one
+  provider produced rows. Test 9 in §5.2.
+- [x] Operator-visible "complete with warnings" surfaces on the admin
+  process timeline + processes table when a strict-cap provider
+  finished `success` with `rows_processed=0` AND downstream cap
+  consumers recovered via another provider. Test 10 in §5.2 + §5.3.
+- [x] `rows_processed` is populated for every stage after this PR
+  lands — operator panel aggregate stops reading zero.
+- [x] `min_rows` knob is configurable per cap (no hardcoded
+  percentages or absolute counts inside the eval rule). §4.1.
+
+## 8. Pre-flight review focus
+
+- **NULL vs 0 semantics** at the cap layer. `rows_processed = NULL`
+  must classify as "below floor" for strict-gate caps; otherwise
+  fundamentals_sync would silently pass when
+  `sec_companyfacts_ingest` doesn't write its row count for any
+  reason. §4.2 encodes this; reviewers should sanity-check it
+  matches the test expectations.
+- **`archive_count > 0` short-circuit** in `_resolve_stage_rows`
+  (§4.3.1). A C-stage where every archive landed `rows_written=0`
+  returns `archive_sum=0` (NOT `None`) — the resolver preserves the
+  real-zero signal that the C-stage ran every archive and produced
+  no rows. Test 2 in §5.2 is the regression gate. Pre-revision
+  drafts fell through to `job_runs` here, which would hide the
+  zero on the strict-cap warning surface.
+- **`job_runs` window scope** in `_resolve_stage_rows` (§4.3).
+  Two snapshots: `job_runs_id_before` captured before
+  `JobLock` acquisition, `job_runs_id_after` captured inside the
+  `with JobLock(...)` block AFTER the invoker returns. The
+  resolver uses `id > before AND id <= after`. Without the upper
+  bound a same-`job_name` scheduled fire that landed after lock
+  release could pollute the pick. Test 4 in §5.2 is the regression
+  gate.
+- **Orchestrator `__job__` write uses `record_archive_result_if_absent`**
+  (§4.3.1). The shared upsert helper `record_archive_result` is
+  unchanged — Phase C ingesters and retries still upsert as
+  before. Only the orchestrator's default-zero provenance write
+  uses the new `DO NOTHING` helper so a service invoker like
+  `sec_submissions_files_walk` that already wrote `__job__` with a
+  real count isn't overwritten by the default `rows_written=0`.
+  Test 6 in §5.2 is the regression gate.
+- **Per-family ownership rollout** is the highest-blast-radius
+  change. The four caps are strict; if any one cap has no
+  surviving provider with non-zero rows, the backfill blocks. A
+  reviewer should confirm the per-family caps map correctly to
+  the per-family row counts (e.g. `insider_inputs_seeded` rows
+  come from the insider ingester, not from the 13F ingester).
+- **Block reason wording**: the structured reason includes
+  `rows_processed=N` — that string lands in
+  `bootstrap_stages.last_error` (capped at 1000 chars) and
+  surfaces directly to the operator timeline. Phrasing should be
+  unambiguous in the partial-recovery case (one provider passed
+  the floor, others didn't, cap is alive — no block message
+  should fire in that case at all, but if it did the wording
+  needs to make clear which provider was the dead one).
+- **Frontend `success_warning` STATUS_VISUAL entry**: confirm
+  the amber palette matches existing dark-mode + the
+  class-hygiene gate at `frontend/scripts/check-dark-classes.mjs`.
+  Add a STATUS_VISUAL test if the existing
+  `processStatus.test.ts` covers the warning case.
+
+## 9. References
+
+- [#1136](https://github.com/Luke-Bradford/eBull/issues/1136) §2 + §4 — original audit
+- [#1140](https://github.com/Luke-Bradford/eBull/issues/1140) — sub-ticket
+- [#1138](https://github.com/Luke-Bradford/eBull/issues/1138) — Task A capability layer (prerequisite)
+- `docs/superpowers/specs/2026-05-13-bootstrap-capability-layer.md` — Task A spec
+- `app/services/bootstrap_orchestrator.py:254-340` — current `_STAGE_PROVIDES` / `_STAGE_REQUIRES_CAPS` / `_satisfied_capabilities`
+- `app/services/bootstrap_orchestrator.py:704-833` — current `_run_one_stage`
+- `app/services/bootstrap_preconditions.py:294-513` — existing precondition gates (unchanged by this spec)
+- `app/services/processes/bootstrap_adapter.py:144` — pre-existing rows_processed aggregate (consumer of the populated column)
+- `app/api/processes.py:636-765` — timeline endpoint (warning + has_warnings derivation lives here)
+- `frontend/src/components/admin/processStatus.ts` — `STATUS_VISUAL` map (new `success_warning` key)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1428,6 +1428,11 @@ export interface BootstrapTimelineStageResponse {
   processed_count: number;
   target_count: number | null;
   archives: BootstrapTimelineArchiveResponse[];
+  // #1140 Task C — set when stage finished `success` but its
+  // rows_processed fell short of a strict-gate capability floor it
+  // provides. Frontend renders an amber chip + tooltip alongside the
+  // success tick when present.
+  warning: string | null;
 }
 
 export interface BootstrapTimelineRunResponse {
@@ -1436,6 +1441,11 @@ export interface BootstrapTimelineRunResponse {
   triggered_at: string;
   completed_at: string | null;
   cancel_requested_at: string | null;
+  // #1140 Task C — derived: true iff any stage in the run carries a
+  // non-null `warning`. Frontend renders an amber dot beside a
+  // `complete` status when set; suppressed for `partial_error` runs
+  // (the red signal is louder).
+  has_warnings: boolean;
 }
 
 export interface BootstrapTimelineResponse {

--- a/frontend/src/pages/ProcessDetailPage.test.tsx
+++ b/frontend/src/pages/ProcessDetailPage.test.tsx
@@ -383,6 +383,7 @@ function makeTimelinePayload(): BootstrapTimelineResponse {
       triggered_at: "2026-05-09T10:00:00Z",
       completed_at: null,
       cancel_requested_at: null,
+      has_warnings: false,
     },
     stages: [
       {
@@ -406,6 +407,7 @@ function makeTimelinePayload(): BootstrapTimelineResponse {
             completed_at: "2026-05-09T10:00:30Z",
           },
         ],
+        warning: null,
       },
       {
         stage_key: "cik_refresh",
@@ -420,6 +422,7 @@ function makeTimelinePayload(): BootstrapTimelineResponse {
         rows_processed: null,
         processed_count: 12,
         target_count: null,
+        warning: null,
         archives: [
           {
             archive_name: "cik_index_2026Q2.zip",
@@ -507,6 +510,56 @@ describe("ProcessDetailPage — Timeline tab (bootstrap)", () => {
     renderBootstrap();
     fireEvent.click(await screen.findByRole("tab", { name: "Timeline" }));
     expect(await screen.findByText(/No bootstrap run yet/i)).toBeTruthy();
+  });
+
+  // #1140 Task C — warning chip on success+zero-rows strict-cap stage.
+  it("renders an amber warning chip on a success+rows=0 strict-cap stage", async () => {
+    mockedDetail.mockResolvedValueOnce(
+      makeProcessRow({ process_id: "bootstrap", display_name: "First-install bootstrap" }),
+    );
+    mockedRuns.mockResolvedValueOnce([]);
+    const payload = makeTimelinePayload();
+    // Override the universe_sync stage to carry a warning.
+    payload.stages[0]!.warning =
+      "stage succeeded but rows_processed=0; strict-gate capability fundamentals_raw_seeded cannot be satisfied";
+    mockedTimeline.mockResolvedValueOnce(payload);
+    renderBootstrap();
+    fireEvent.click(await screen.findByRole("tab", { name: "Timeline" }));
+    const chip = await screen.findByTestId("stage-warning-chip");
+    expect(chip).toBeTruthy();
+    expect(chip.getAttribute("title")).toContain("fundamentals_raw_seeded");
+  });
+
+  // #1140 Task C — run-level amber dot on complete + has_warnings.
+  it("renders the run amber dot when run is complete AND has_warnings", async () => {
+    mockedDetail.mockResolvedValueOnce(
+      makeProcessRow({ process_id: "bootstrap", display_name: "First-install bootstrap" }),
+    );
+    mockedRuns.mockResolvedValueOnce([]);
+    const payload = makeTimelinePayload();
+    payload.run!.status = "complete";
+    payload.run!.has_warnings = true;
+    mockedTimeline.mockResolvedValueOnce(payload);
+    renderBootstrap();
+    fireEvent.click(await screen.findByRole("tab", { name: "Timeline" }));
+    expect(await screen.findByTestId("run-warning-dot")).toBeTruthy();
+  });
+
+  // Control: run-level dot suppressed when run is partial_error (red signal
+  // already louder than amber warning).
+  it("does NOT render the run amber dot for partial_error runs even when has_warnings", async () => {
+    mockedDetail.mockResolvedValueOnce(
+      makeProcessRow({ process_id: "bootstrap", display_name: "First-install bootstrap" }),
+    );
+    mockedRuns.mockResolvedValueOnce([]);
+    const payload = makeTimelinePayload();
+    payload.run!.status = "partial_error";
+    payload.run!.has_warnings = true;
+    mockedTimeline.mockResolvedValueOnce(payload);
+    renderBootstrap();
+    fireEvent.click(await screen.findByRole("tab", { name: "Timeline" }));
+    await screen.findByText("Universe Sync");
+    expect(screen.queryByTestId("run-warning-dot")).toBeNull();
   });
 
   it("opens the archive-detail modal when an archive square is clicked", async () => {

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -11,6 +11,7 @@
  * page surfaces inline rather than escaping back to the table view.
  */
 
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
@@ -806,13 +807,22 @@ function DagRunSummary({ run }: { run: OrchestratorDagSyncRunResponse }) {
   );
 }
 
-function Cell({ label, value }: { label: string; value: string }) {
+function Cell({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | ReactNode;
+}) {
+  // `title` is set only when value is a plain string — ReactNode
+  // values (#1140 Task C run-warning chip) render their own tooltip.
+  const title = typeof value === "string" ? value : undefined;
   return (
     <div className="rounded border border-slate-200 bg-slate-50 p-2 text-sm dark:border-slate-800 dark:bg-slate-900/40">
       <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
         {label}
       </div>
-      <div className="mt-0.5 truncate text-slate-700 dark:text-slate-200" title={value}>
+      <div className="mt-0.5 truncate text-slate-700 dark:text-slate-200" title={title}>
         {value}
       </div>
     </div>
@@ -990,10 +1000,27 @@ function TimelineRunSummary({
 }: {
   run: NonNullable<BootstrapTimelineResponse["run"]>;
 }) {
+  // #1140 Task C — surface the run-level warning state when the run
+  // is `complete` AND at least one stage carries a warning. Red runs
+  // already shout; the amber dot is suppressed for them.
+  const showWarningDot = run.has_warnings && run.status === "complete";
+  const statusValue = showWarningDot ? (
+    <span className="inline-flex items-center gap-1">
+      <span>{run.status}</span>
+      <span
+        aria-label="Run completed with warnings"
+        title="One or more stages succeeded with rows_processed=0 — open Timeline tab for detail."
+        data-testid="run-warning-dot"
+        className="inline-block h-2 w-2 rounded-full bg-amber-500"
+      />
+    </span>
+  ) : (
+    run.status
+  );
   return (
     <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
       <Cell label="Run id" value={`#${run.run_id}`} />
-      <Cell label="Status" value={run.status} />
+      <Cell label="Status" value={statusValue} />
       <Cell label="Triggered" value={formatDateTime(run.triggered_at)} />
       <Cell
         label="Completed"
@@ -1103,6 +1130,16 @@ function TimelineStageRow({
             >
               {stage.status}
             </span>
+            {stage.warning ? (
+              <span
+                className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 dark:border-amber-400/30 dark:bg-amber-950/60 dark:text-amber-200"
+                title={stage.warning}
+                aria-label={`Warning: ${stage.warning}`}
+                data-testid="stage-warning-chip"
+              >
+                warning
+              </span>
+            ) : null}
             <span
               className="truncate font-medium text-slate-700 dark:text-slate-200"
               title={stage.display_name}
@@ -1113,6 +1150,14 @@ function TimelineStageRow({
           <div className="text-xs text-slate-500 dark:text-slate-400">
             {stage.job_name || stage.stage_key}
           </div>
+          {stage.warning ? (
+            <div
+              className="mt-1 truncate text-xs text-amber-700 dark:text-amber-300"
+              title={stage.warning}
+            >
+              {stage.warning}
+            </div>
+          ) : null}
           {stage.last_error ? (
             <div
               className="mt-1 truncate text-xs text-red-700 dark:text-red-300"

--- a/tests/test_bootstrap_flow_integration.py
+++ b/tests/test_bootstrap_flow_integration.py
@@ -60,6 +60,24 @@ def _override_get_conn(conn: psycopg.Connection[tuple]) -> None:
     app.dependency_overrides[get_conn] = _dep
 
 
+def _record_job_runs_success(job_name: str, *, row_count: int = 1) -> None:
+    """Mirror _tracked_job's job_runs write so the orchestrator's
+    rows_processed resolver (#1140 Task C) finds a real row_count.
+    Without this every fake-invoker stage would have rows_processed=NULL
+    and the strict-gate caps (per-family ownership + fundamentals_raw_seeded)
+    would block downstream consumers.
+    """
+    from app.config import settings as app_settings
+
+    with psycopg.connect(app_settings.database_url) as conn:
+        conn.execute(
+            "INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count) "
+            "VALUES (%s, now(), now(), 'success', %s)",
+            (job_name, row_count),
+        )
+        conn.commit()
+
+
 def _patch_orchestrator_invokers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> dict[str, list[str]]:
@@ -77,6 +95,7 @@ def _patch_orchestrator_invokers(
     def _make_fake(name: str) -> Callable[..., None]:
         def _fake(_params: object = None) -> None:
             calls["order"].append(name)
+            _record_job_runs_success(name)
 
         return _fake
 
@@ -177,6 +196,7 @@ def test_bootstrap_partial_error_then_retry_failed(
             calls_pass1["order"].append(name)
             if name in failing:
                 raise RuntimeError(f"forced {name} failure")
+            _record_job_runs_success(name)
 
         return _fake
 
@@ -201,6 +221,7 @@ def test_bootstrap_partial_error_then_retry_failed(
     def _make_pass2(name: str) -> Callable[..., None]:
         def _fake(_params: object = None) -> None:
             calls_pass2["order"].append(name)
+            _record_job_runs_success(name)
 
         return _fake
 

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -239,6 +239,8 @@ def _patch_invokers_with_fakes(
     monkeypatch: pytest.MonkeyPatch,
     *,
     failing_jobs: set[str] | None = None,
+    phase_skip_jobs: set[str] | None = None,
+    rows_by_job: dict[str, int] | None = None,
 ) -> dict[str, list[str]]:
     """Replace every _INVOKERS entry the orchestrator might dispatch
     with a deterministic in-process fake. Returns a calls dict so
@@ -248,9 +250,25 @@ def _patch_invokers_with_fakes(
     orchestrator service itself does (mark stage running / success /
     error). This keeps the test runtime well under one second per
     case.
+
+    #1140 Task C — each fake also inserts a ``job_runs`` row with
+    ``row_count = rows_by_job.get(job_name, 1)`` so the orchestrator's
+    ``_resolve_stage_rows`` source-3 fallback resolves to a real
+    number. Without this every stage's ``rows_processed`` would be
+    NULL and the strict-gate caps (per-family ownership +
+    ``fundamentals_raw_seeded``) would block downstream consumers in
+    every existing test. Tests that want to simulate "ran but wrote
+    zero" pass ``rows_by_job={"some_job_name": 0}``.
     """
+    import psycopg as _psycopg
+
+    from app.config import settings as _app_settings
+    from app.services.bootstrap_preconditions import BootstrapPhaseSkipped
+
     calls: dict[str, list[str]] = {"order": []}
     failing = failing_jobs or set()
+    phase_skipping = phase_skip_jobs or set()
+    rows = rows_by_job or {}
 
     def _make_fake(name: str) -> Callable[..., None]:
         # PR1b-2 (#1064) widened JobInvoker to ``(Mapping) -> None``;
@@ -261,6 +279,22 @@ def _patch_invokers_with_fakes(
             calls["order"].append(name)
             if name in failing:
                 raise RuntimeError(f"forced {name} failure")
+            if name in phase_skipping:
+                raise BootstrapPhaseSkipped(f"forced {name} phase skip")
+            # #1140 Task C — mirror _tracked_job's job_runs write so
+            # _resolve_stage_rows source 3 finds a real row_count for
+            # this stage. Capture started_at/finished_at as now() so
+            # the row's run_id falls inside the JobLock window.
+            row_count = rows.get(name, 1)
+            with _psycopg.connect(_app_settings.database_url) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count)
+                    VALUES (%s, now(), now(), 'success', %s)
+                    """,
+                    (name, row_count),
+                )
+                conn.commit()
 
         return _fake
 
@@ -576,25 +610,13 @@ def test_intentional_slow_connection_skip_cascade(
     `success` via legacy per-family caps. Walker S13 runs to success
     because legacy drain S15 provides `filing_events_seeded`.
     """
-    from app.services.bootstrap_preconditions import BootstrapPhaseSkipped
-
     _reset_state(ebull_test_conn)
     _bind_settings_to_test_db(monkeypatch)
 
-    calls: dict[str, list[str]] = {"order": []}
-
-    def _make_fake(name: str) -> Callable[..., None]:
-        def _fake(_params: object = None) -> None:
-            calls["order"].append(name)
-            if name == "sec_bulk_download":
-                raise BootstrapPhaseSkipped("slow connection; fallback path")
-
-        return _fake
-
-    from app.jobs import runtime as runtime_module
-
-    fake_invokers = {spec.job_name: _make_fake(spec.job_name) for spec in get_bootstrap_stage_specs()}
-    monkeypatch.setattr(runtime_module, "_INVOKERS", fake_invokers)
+    calls = _patch_invokers_with_fakes(
+        monkeypatch,
+        phase_skip_jobs={"sec_bulk_download"},
+    )
 
     start_run(ebull_test_conn, operator_id=None, stage_specs=get_bootstrap_stage_specs())
     ebull_test_conn.commit()
@@ -808,3 +830,197 @@ def test_cascade_recompute_on_non_topological_pending_order(
     downstream_row = next(s for s in snap.stages if s.stage_key == "downstream")
     assert downstream_row.last_error is not None
     assert "cascaded skip" in downstream_row.last_error
+
+
+# ---------------------------------------------------------------------------
+# #1140 Task C — strict-gate row-count cap-eval widening
+# ---------------------------------------------------------------------------
+
+
+def test_strict_cap_blocks_consumer_on_zero_rows(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single-provider strict cap with the provider succeeding at
+    rows_processed=0 transitions the consumer to ``blocked`` with a
+    structured "no surviving provider met rows floor" reason. Run
+    finalises ``partial_error``.
+
+    Exercises the real dispatcher end-to-end: the bulk
+    ``sec_companyfacts_ingest`` lands ``success`` with ``rows_processed=0``
+    (via the fake invoker's rows_by_job override); its sole cap
+    ``fundamentals_raw_seeded`` is strict-gated at min_rows=1; the
+    downstream ``fundamentals_sync`` blocks.
+    """
+    _reset_state(ebull_test_conn)
+    _bind_settings_to_test_db(monkeypatch)
+    _patch_invokers_with_fakes(
+        monkeypatch,
+        rows_by_job={"sec_companyfacts_ingest": 0},
+    )
+
+    start_run(ebull_test_conn, operator_id=None, stage_specs=get_bootstrap_stage_specs())
+    ebull_test_conn.commit()
+
+    run_bootstrap_orchestrator()
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    statuses = {stage.stage_key: stage.status for stage in snap.stages}
+
+    assert statuses["sec_companyfacts_ingest"] == "success"
+    assert statuses["fundamentals_sync"] == "blocked"
+
+    fundamentals_row = next(s for s in snap.stages if s.stage_key == "fundamentals_sync")
+    assert fundamentals_row.last_error is not None
+    assert "fundamentals_raw_seeded" in fundamentals_row.last_error
+    assert "rows floor 1" in fundamentals_row.last_error
+    assert "rows_processed=0" in fundamentals_row.last_error
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "partial_error"
+
+
+def test_strict_cap_satisfied_by_one_of_two_providers(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-family ownership cap with two providers (bulk + legacy):
+    one lands ``success`` with ``rows_processed=0`` (under floor), the
+    other lands ``success`` with ``rows_processed > 0``. The cap is
+    satisfied via the surviving provider so ``ownership_observations_backfill``
+    runs to success. Run finalises ``complete``.
+    """
+    _reset_state(ebull_test_conn)
+    _bind_settings_to_test_db(monkeypatch)
+    _patch_invokers_with_fakes(
+        monkeypatch,
+        # Bulk insider wash lands but writes 0 rows; legacy backfill
+        # writes rows. insider_inputs_seeded cap stays alive via legacy.
+        rows_by_job={"sec_insider_ingest_from_dataset": 0},
+    )
+
+    start_run(ebull_test_conn, operator_id=None, stage_specs=get_bootstrap_stage_specs())
+    ebull_test_conn.commit()
+
+    run_bootstrap_orchestrator()
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    statuses = {stage.stage_key: stage.status for stage in snap.stages}
+
+    assert statuses["sec_insider_ingest_from_dataset"] == "success"
+    assert statuses["sec_insider_transactions_backfill"] == "success"
+    # All four per-family caps satisfied → backfill runs.
+    assert statuses["ownership_observations_backfill"] == "success"
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "complete"
+
+
+def test_strict_cap_dead_on_zero_rows_classifies_error_not_skip() -> None:
+    """Unit test for the cap-eval helpers — confirms a strict cap
+    where the only provider is ``success`` with under-floor rows is
+    classified as error-dead (so consumer blocks), not skip-only-dead
+    (which would cascade-skip).
+    """
+    from app.services.bootstrap_orchestrator import (
+        _capability_is_dead,
+        _classify_dead_cap,
+    )
+
+    statuses = {"sec_companyfacts_ingest": "success"}
+    rows = {"sec_companyfacts_ingest": 0}
+    assert _capability_is_dead("fundamentals_raw_seeded", statuses, rows) is True
+    assert _classify_dead_cap("fundamentals_raw_seeded", statuses, rows) == "error"
+
+
+def test_non_strict_cap_unchanged_by_zero_rows() -> None:
+    """A cap NOT in ``_CAPABILITY_MIN_ROWS`` is satisfied by a
+    ``success`` provider regardless of ``rows_processed``. Legacy
+    Task A behaviour preserved — confirms the new strict-gate rule
+    doesn't widen to caps it shouldn't touch.
+
+    ``universe_seeded`` is not in the strict set; a ``universe_sync``
+    success with rows=0 still satisfies it.
+    """
+    from app.services.bootstrap_orchestrator import _satisfied_capabilities
+
+    caps = _satisfied_capabilities(
+        {"universe_sync": "success"},
+        {"universe_sync": 0},
+    )
+    assert "universe_seeded" in caps
+
+
+def test_strict_caps_have_at_least_one_provider() -> None:
+    """Every cap in ``_CAPABILITY_MIN_ROWS`` must have at least one
+    registered provider in ``_CAPABILITY_PROVIDERS``. Catches a stale
+    entry that names a removed cap before the dispatcher tries to
+    evaluate a never-satisfiable strict-gate requirement at runtime.
+    """
+    from app.services.bootstrap_orchestrator import _CAPABILITY_MIN_ROWS
+
+    missing = [c for c in _CAPABILITY_MIN_ROWS if not _CAPABILITY_PROVIDERS.get(c)]  # type: ignore[arg-type]
+    assert not missing, f"strict-gate caps with no provider: {missing}"
+
+
+def test_strict_cap_exclusion_neutral_provider_does_not_satisfy_or_kill() -> None:
+    """Codex pre-push round 2 BLOCKING regression — bulk insider
+    (excluded provider for ``form3_inputs_seeded``) is NEUTRAL for the
+    strict cap.
+
+    Scenarios:
+    1. Bulk insider success+rows=10, legacy form3 absent → cap dead
+       (no non-excluded provider met the floor). Classification is
+       "error" (the legacy provider hasn't been reached yet → fall
+       through to "error" default since no skipped provider exists).
+    2. Bulk insider success+rows=10, legacy form3 success+rows=5 →
+       cap alive (legacy meets floor).
+    3. Bulk insider success+rows=10, legacy form3 success+rows=0 →
+       cap dead, classified error (legacy under floor — that's the
+       responsible signal). Bulk's success+rows=10 is neutral, NOT
+       a satisfier, NOT a killer.
+    """
+    from app.services.bootstrap_orchestrator import (
+        _capability_is_dead,
+        _classify_dead_cap,
+        _satisfied_capabilities,
+    )
+
+    # Scenario 1: only bulk ran (legacy still pending unmodelled).
+    statuses_only_bulk = {"sec_insider_ingest_from_dataset": "success"}
+    rows_only_bulk = {"sec_insider_ingest_from_dataset": 10}
+    caps = _satisfied_capabilities(statuses_only_bulk, rows_only_bulk)
+    assert "form3_inputs_seeded" not in caps
+    # form3_inputs_seeded providers: bulk insider + legacy form3. Only
+    # bulk has reported — legacy is unknown (treated as no-info, not
+    # alive). With bulk neutral and no live legacy → cap dead.
+    assert _capability_is_dead("form3_inputs_seeded", statuses_only_bulk, rows_only_bulk) is True
+
+    # Scenario 2: bulk + legacy succeed with rows.
+    statuses_both = {
+        "sec_insider_ingest_from_dataset": "success",
+        "sec_form3_ingest": "success",
+    }
+    rows_both = {"sec_insider_ingest_from_dataset": 10, "sec_form3_ingest": 5}
+    caps = _satisfied_capabilities(statuses_both, rows_both)
+    assert "form3_inputs_seeded" in caps  # legacy carries it
+    assert _capability_is_dead("form3_inputs_seeded", statuses_both, rows_both) is False
+
+    # Scenario 3: bulk rows>0, legacy rows=0 → cap dead via legacy.
+    statuses_legacy_zero = {
+        "sec_insider_ingest_from_dataset": "success",
+        "sec_form3_ingest": "success",
+    }
+    rows_legacy_zero = {"sec_insider_ingest_from_dataset": 10, "sec_form3_ingest": 0}
+    caps = _satisfied_capabilities(statuses_legacy_zero, rows_legacy_zero)
+    assert "form3_inputs_seeded" not in caps
+    assert _capability_is_dead("form3_inputs_seeded", statuses_legacy_zero, rows_legacy_zero) is True
+    # Classification: bulk is excluded (skipped), legacy under floor → error.
+    assert _classify_dead_cap("form3_inputs_seeded", statuses_legacy_zero, rows_legacy_zero) == "error"
+
+    # Bonus: insider_inputs_seeded is NOT excluded for the bulk provider
+    # (the exclusion is form3-specific), so scenario-1 rows satisfy it.
+    caps = _satisfied_capabilities(statuses_only_bulk, rows_only_bulk)
+    assert "insider_inputs_seeded" in caps

--- a/tests/test_bootstrap_rows_processed_gates.py
+++ b/tests/test_bootstrap_rows_processed_gates.py
@@ -1,0 +1,526 @@
+"""Real-DB integration tests for #1140 Task C — precondition + final-data
+row-count gates (spec at
+docs/superpowers/specs/2026-05-13-precondition-final-data-gates.md).
+
+Covers:
+
+* ``_resolve_stage_rows`` source ordering (archive sum / __job__ / job_runs).
+* ``record_archive_result_if_absent`` DO NOTHING semantics vs. the
+  existing ``record_archive_result`` upsert.
+* Timeline endpoint surface — `warning` per-stage + `has_warnings`
+  per-run derivation.
+
+End-to-end orchestrator coverage for strict-cap blocking / per-family
+recovery lives in ``tests/test_bootstrap_orchestrator.py``
+(``test_strict_cap_blocks_consumer_on_zero_rows`` /
+``test_strict_cap_satisfied_by_one_of_two_providers``); this file
+exercises the lower-level helpers + the API derivation in isolation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+from psycopg.types.json import Jsonb
+
+from app.db import get_conn
+from app.main import app
+from app.services.bootstrap_orchestrator import (
+    _resolve_stage_rows,
+    _snapshot_job_runs_max_id,
+)
+from app.services.bootstrap_preconditions import (
+    record_archive_result,
+    record_archive_result_if_absent,
+)
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def conn_override(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> Iterator[None]:
+    def _yield_conn() -> Iterator[psycopg.Connection[tuple]]:
+        yield ebull_test_conn
+
+    app.dependency_overrides[get_conn] = _yield_conn
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+
+def _wipe_bootstrap_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute("DELETE FROM bootstrap_archive_results")
+    conn.execute("DELETE FROM bootstrap_stages")
+    conn.execute("DELETE FROM bootstrap_runs")
+    conn.execute("UPDATE bootstrap_state SET status='pending', last_run_id=NULL, last_completed_at=NULL WHERE id=1")
+
+
+def _insert_run(conn: psycopg.Connection[tuple], *, run_status: str = "complete") -> int:
+    row = conn.execute(
+        """
+        INSERT INTO bootstrap_runs (status, completed_at)
+        VALUES (%s, CASE WHEN %s IN ('complete', 'partial_error', 'cancelled') THEN now() ELSE NULL END)
+        RETURNING id
+        """,
+        (run_status, run_status),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _insert_stage(
+    conn: psycopg.Connection[tuple],
+    *,
+    run_id: int,
+    stage_key: str,
+    stage_order: int,
+    lane: str,
+    job_name: str,
+    status: str = "success",
+    rows_processed: int | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO bootstrap_stages (
+            bootstrap_run_id, stage_key, stage_order, lane, job_name,
+            status, started_at, completed_at, last_error, rows_processed,
+            processed_count, target_count
+        ) VALUES (%s, %s, %s, %s, %s, %s, now(), now(), NULL, %s, 0, NULL)
+        """,
+        (run_id, stage_key, stage_order, lane, job_name, status, rows_processed),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_stage_rows source ordering
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_archive_sum_wins_when_count_positive(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Per-archive rows present → return SUM(rows_written).
+
+    Spec §5.2 test 1.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="running")
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        stage_order=9,
+        lane="db",
+        job_name="sec_companyfacts_ingest",
+        status="running",
+    )
+    record_archive_result(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        archive_name="__job__",
+        rows_written=0,
+    )
+    record_archive_result(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        archive_name="companyfacts.zip",
+        rows_written=42,
+    )
+    ebull_test_conn.commit()
+
+    resolved = _resolve_stage_rows(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        job_name="sec_companyfacts_ingest",
+        job_runs_id_before=0,
+        job_runs_id_after=0,
+    )
+    assert resolved == 42
+
+
+def test_resolver_archive_sum_zero_preserved(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Codex R1 BLOCKING §1 regression — archive_count > 0 AND
+    SUM = 0 returns 0 (the C-stage ran every archive and produced
+    zero rows; that's a real signal, not absence). Pre-revision
+    drafts fell through to source 3 which would have returned None.
+
+    Spec §5.2 test 2.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="running")
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        stage_order=9,
+        lane="db",
+        job_name="sec_companyfacts_ingest",
+        status="running",
+    )
+    record_archive_result(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        archive_name="__job__",
+        rows_written=0,
+    )
+    record_archive_result(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        archive_name="companyfacts.zip",
+        rows_written=0,
+    )
+    ebull_test_conn.commit()
+
+    resolved = _resolve_stage_rows(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        job_name="sec_companyfacts_ingest",
+        job_runs_id_before=0,
+        job_runs_id_after=0,
+    )
+    assert resolved == 0
+
+
+def test_resolver_uses_job_row_when_set_above_zero(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Codex R1 BLOCKING §2 regression — service-invoker shape: only
+    the __job__ row exists, with operator-set rows_written > 0.
+    Resolver returns that integer (source 2).
+
+    Mirrors ``sec_submissions_files_walk`` overloading the provenance
+    row with ``filings_upserted``.
+
+    Spec §5.2 test 3.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="running")
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_submissions_files_walk",
+        stage_order=13,
+        lane="sec_rate",
+        job_name="sec_submissions_files_walk",
+        status="running",
+    )
+    record_archive_result(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_submissions_files_walk",
+        archive_name="__job__",
+        rows_written=7,
+    )
+    ebull_test_conn.commit()
+
+    resolved = _resolve_stage_rows(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_submissions_files_walk",
+        job_name="sec_submissions_files_walk",
+        job_runs_id_before=0,
+        job_runs_id_after=0,
+    )
+    assert resolved == 7
+
+
+def test_resolver_job_runs_window_excludes_outside_ids(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Codex R2 BLOCKING §1 regression — the (before, after] window
+    must exclude job_runs rows outside it.
+
+    Spec §5.2 test 4.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="running")
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="universe_sync",
+        stage_order=1,
+        lane="init",
+        job_name="nightly_universe_sync",
+        status="running",
+    )
+
+    # Three job_runs rows for the same job_name; only the middle one
+    # is inside (before, after].
+    job_name = "nightly_universe_sync"
+    # Row 1 — before our window.
+    ebull_test_conn.execute(
+        "INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count) "
+        "VALUES (%s, now(), now(), 'success', 1)",
+        (job_name,),
+    )
+    ebull_test_conn.commit()
+    before = _snapshot_job_runs_max_id(ebull_test_conn, job_name=job_name)
+    # Row 2 — inside the window.
+    ebull_test_conn.execute(
+        "INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count) "
+        "VALUES (%s, now(), now(), 'success', 2)",
+        (job_name,),
+    )
+    ebull_test_conn.commit()
+    after = _snapshot_job_runs_max_id(ebull_test_conn, job_name=job_name)
+    # Row 3 — after our window (simulates a parallel scheduled fire
+    # that landed after JobLock release).
+    ebull_test_conn.execute(
+        "INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count) "
+        "VALUES (%s, now(), now(), 'success', 3)",
+        (job_name,),
+    )
+    ebull_test_conn.commit()
+
+    resolved = _resolve_stage_rows(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="universe_sync",
+        job_name=job_name,
+        job_runs_id_before=before,
+        job_runs_id_after=after,
+    )
+    assert resolved == 2
+
+
+def test_resolver_falls_back_to_job_runs_or_none(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Source-3 happy path AND negative — no archive rows and no
+    job_runs row in window → ``None``.
+
+    Spec §5.2 test 5.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="running")
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="universe_sync",
+        stage_order=1,
+        lane="init",
+        job_name="nightly_universe_sync",
+        status="running",
+    )
+
+    job_name = "nightly_universe_sync"
+    before = _snapshot_job_runs_max_id(ebull_test_conn, job_name=job_name)
+    ebull_test_conn.execute(
+        "INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count) "
+        "VALUES (%s, now(), now(), 'success', 1500)",
+        (job_name,),
+    )
+    ebull_test_conn.commit()
+    after = _snapshot_job_runs_max_id(ebull_test_conn, job_name=job_name)
+
+    resolved = _resolve_stage_rows(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="universe_sync",
+        job_name=job_name,
+        job_runs_id_before=before,
+        job_runs_id_after=after,
+    )
+    assert resolved == 1500
+
+    # Negative: empty window → None.
+    resolved_empty = _resolve_stage_rows(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="universe_sync",
+        job_name=job_name,
+        job_runs_id_before=after,
+        job_runs_id_after=after,
+    )
+    assert resolved_empty is None
+
+
+# ---------------------------------------------------------------------------
+# record_archive_result_if_absent vs record_archive_result
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrator_job_row_preserves_invoker_value(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Codex R2 BLOCKING §2 regression — service invoker writes
+    ``__job__`` with a real ``rows_written``; the orchestrator's
+    subsequent ``record_archive_result_if_absent`` call (default 0)
+    is DO NOTHING so the invoker's value survives.
+
+    Control: the existing upsert helper still flips the value.
+
+    Spec §5.2 test 6.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="running")
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_submissions_files_walk",
+        stage_order=13,
+        lane="sec_rate",
+        job_name="sec_submissions_files_walk",
+        status="running",
+    )
+
+    # Service invoker (existing upsert) writes the real count.
+    record_archive_result(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_submissions_files_walk",
+        archive_name="__job__",
+        rows_written=99,
+    )
+    ebull_test_conn.commit()
+
+    # Orchestrator's auto-write (new DO NOTHING helper) with default
+    # rows_written=0 — must NOT overwrite.
+    record_archive_result_if_absent(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_submissions_files_walk",
+        archive_name="__job__",
+        rows_written=0,
+    )
+    ebull_test_conn.commit()
+
+    row = ebull_test_conn.execute(
+        "SELECT rows_written FROM bootstrap_archive_results "
+        "WHERE bootstrap_run_id = %s AND stage_key = %s AND archive_name = '__job__'",
+        (run_id, "sec_submissions_files_walk"),
+    ).fetchone()
+    assert row is not None
+    assert int(row[0]) == 99
+
+    # Control: existing upsert helper does flip the value.
+    record_archive_result(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key="sec_submissions_files_walk",
+        archive_name="__job__",
+        rows_written=0,
+    )
+    ebull_test_conn.commit()
+    row = ebull_test_conn.execute(
+        "SELECT rows_written FROM bootstrap_archive_results "
+        "WHERE bootstrap_run_id = %s AND stage_key = %s AND archive_name = '__job__'",
+        (run_id, "sec_submissions_files_walk"),
+    ).fetchone()
+    assert row is not None
+    assert int(row[0]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Timeline endpoint — warning / has_warnings derivation
+# ---------------------------------------------------------------------------
+
+
+def test_timeline_has_warnings_derived_from_stage_rows(
+    conn_override: None,
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A ``complete`` run with a strict-cap provider stage at
+    ``rows_processed=0`` surfaces a per-stage ``warning`` and
+    ``has_warnings=True`` on the run payload. Control: a stage with
+    ``rows_processed=42`` has ``warning=None``.
+
+    Spec §5.2 test 10.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="complete")
+    # Strict-cap provider with rows_processed=0 → warning.
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        stage_order=9,
+        lane="db",
+        job_name="sec_companyfacts_ingest",
+        status="success",
+        rows_processed=0,
+    )
+    # Control: same shape but rows_processed=42 → no warning.
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_insider_ingest_from_dataset",
+        stage_order=11,
+        lane="db",
+        job_name="sec_insider_ingest_from_dataset",
+        status="success",
+        rows_processed=42,
+    )
+    # Control: non-strict cap provider with rows_processed=0 → no warning.
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="universe_sync",
+        stage_order=1,
+        lane="init",
+        job_name="nightly_universe_sync",
+        status="success",
+        rows_processed=0,
+    )
+    ebull_test_conn.commit()
+
+    resp = client.get("/system/processes/bootstrap/timeline")
+    assert resp.status_code == 200
+    payload = resp.json()
+
+    assert payload["run"]["has_warnings"] is True
+
+    stages_by_key = {s["stage_key"]: s for s in payload["stages"]}
+    assert stages_by_key["sec_companyfacts_ingest"]["warning"] is not None
+    assert "fundamentals_raw_seeded" in stages_by_key["sec_companyfacts_ingest"]["warning"]
+    assert "rows_processed=0" in stages_by_key["sec_companyfacts_ingest"]["warning"]
+    assert stages_by_key["sec_insider_ingest_from_dataset"]["warning"] is None
+    assert stages_by_key["universe_sync"]["warning"] is None
+
+
+def test_timeline_no_warnings_when_all_strict_caps_pass(
+    conn_override: None,
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Healthy run: every strict-cap provider has rows_processed >= 1
+    → ``has_warnings=False`` and no per-stage ``warning``.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="complete")
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="sec_companyfacts_ingest",
+        stage_order=9,
+        lane="db",
+        job_name="sec_companyfacts_ingest",
+        status="success",
+        rows_processed=100,
+    )
+    ebull_test_conn.commit()
+
+    resp = client.get("/system/processes/bootstrap/timeline")
+    assert resp.status_code == 200
+    payload = resp.json()
+
+    assert payload["run"]["has_warnings"] is False
+    stages_by_key = {s["stage_key"]: s for s in payload["stages"]}
+    assert stages_by_key["sec_companyfacts_ingest"]["warning"] is None
+
+
+# Silence the rows_skipped param in _insert_archive variants by not using it.
+_ = Jsonb  # keep import for parity with the sibling timeline test file


### PR DESCRIPTION
## Summary
- Strict-gate cap rule (`_CAPABILITY_MIN_ROWS`): for `fundamentals_raw_seeded` + `insider_inputs_seeded` + `form3_inputs_seeded` + `institutional_inputs_seeded` + `nport_inputs_seeded`, a provider's `success` status alone no longer satisfies the cap — `rows_processed >= 1` is required. Below-floor producers cause downstream `blocked` with a structured "no surviving provider met rows floor N" reason.
- `bootstrap_stages.rows_processed` is now populated via a three-source resolver (per-archive sum / __job__ overload / job_runs.row_count windowed by captured before+after ids) — operator panel aggregate stops reading zero.
- New `record_archive_result_if_absent` (DO NOTHING) for the orchestrator's auto `__job__` write so a service invoker that overloaded `__job__` (e.g. `sec_submissions_files_walk`) isn't clobbered. Existing upsert helper unchanged for C-stage / retry paths.
- `reset_failed_stages_for_retry` clears `rows_processed` on reset.
- "Complete with warnings" UI: derived `warning` per stage + `has_warnings` per run on `/system/processes/bootstrap/timeline`. Frontend renders an amber chip beside the success tick + amber dot beside `complete` status. Suppressed for `partial_error` (red signal louder).

Closes #1140.

## Why
Codex audit (#1136 §2): `fundamentals_sync` gates on `sec_companyfacts_ingest` status alone, not rows_written>0; same for ownership backfill. Bootstrap can finish `complete` with empty fundamentals/ownership slices invisible to the operator. This PR adds strict-gate row floors at the cap layer + surfaces the warning state through the timeline.

## Multi-cap provider exclusion
`sec_insider_ingest_from_dataset` is the only multi-cap provider (insider + form3 from one aggregate `rows_processed`). New `_STRICT_CAP_PROVIDER_EXCLUSIONS` makes the bulk provider NEUTRAL for `form3_inputs_seeded` — it can't satisfy the floor (would be a false positive on Form-4-heavy washes) and can't kill the cap either. The legacy single-cap `sec_form3_ingest` carries the form3 strict gate. Per-family bulk row counts are deferred.

## Test plan
- [x] `uv run pytest tests/test_bootstrap_orchestrator.py` — 26 pass (5 new strict-cap + 1 new multi-cap exclusion test).
- [x] `uv run pytest tests/test_bootstrap_rows_processed_gates.py` — 8 pass (resolver source ordering + DO NOTHING helper + timeline derivation).
- [x] `uv run pytest tests/test_bootstrap_flow_integration.py tests/test_bootstrap_state.py tests/test_bootstrap_atomic_enqueue.py tests/test_bootstrap_timeline_endpoint.py tests/test_bootstrap_cancel.py` — all pass file-by-file.
- [x] `pnpm --dir frontend typecheck` — clean.
- [x] `pnpm --dir frontend test:unit src/pages/ProcessDetailPage.test.tsx` — 26 pass (3 new for warning chip + amber dot + suppression).
- [x] `uv run ruff check . && uv run ruff format --check` — clean.
- [x] `uv run pyright app/services/bootstrap_orchestrator.py app/services/bootstrap_preconditions.py app/api/processes.py tests/test_bootstrap_orchestrator.py tests/test_bootstrap_rows_processed_gates.py` — 0 errors.
- [ ] Manual verification on dev DB after merge per spec §6: `psql -c "SELECT stage_key, rows_processed FROM bootstrap_stages WHERE bootstrap_run_id = (SELECT MAX(id) FROM bootstrap_runs) ORDER BY stage_order"` shows non-NULL rows_processed; admin control hub timeline aggregate reads non-zero.

## Codex pre-push
3 rounds. Findings: aggregate multi-cap false positive (BLOCKING — fixed via exclusions map); reset_failed_stages stale rows_processed (WARNING — fixed); after-snapshot failure marking success as error (WARNING — fixed via inner try/except). Final round: no blockers.

## References
- Spec: docs/superpowers/specs/2026-05-13-precondition-final-data-gates.md
- Task A (#1138, MERGED): capability layer that this PR widens.
- Task B (#1139, MERGED): atomic enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)