### PR TITLE
feat(#1151): 10-K manifest adapter (final #873-series parser)

### DIFF
--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -36,7 +36,7 @@ import html
 import logging
 import re
 from dataclasses import dataclass
-from datetime import date
+from datetime import UTC, date, datetime, time
 from typing import Any, Literal, Protocol
 
 import psycopg
@@ -886,40 +886,75 @@ def extract_business_sections(raw_html: str) -> tuple[ParsedBusinessSection, ...
 # ---------------------------------------------------------------------
 
 
+UpsertOutcome = Literal["inserted", "updated", "suppressed"]
+
+
 def upsert_business_summary(
     conn: psycopg.Connection[Any],
     *,
     instrument_id: int,
     body: str,
     source_accession: str,
-) -> bool:
+    filed_at: datetime | None,
+) -> UpsertOutcome:
     """Insert or update one ``instrument_business_summary`` row.
 
-    Returns ``True`` on INSERT, ``False`` on UPDATE. The UPDATE path
-    overwrites the body + source_accession + timestamps so a later
-    10-K supersedes an older one cleanly. Resets the failure-tracking
-    columns (#533) so a previously-quarantined instrument that now
-    parses successfully exits quarantine cleanly."""
+    Returns the trinary outcome:
+
+    - ``'inserted'`` — no prior row; new row written.
+    - ``'updated'`` — prior row existed; row replaced.
+    - ``'suppressed'`` — prior row existed AND was newer (per the
+      ``(filed_at, source_accession)`` gate); no write performed.
+
+    The conditional ``ON CONFLICT`` gate (#1151) keeps the manifest-
+    driven path safe under filed_at-ASC drain order: an older
+    accession arriving after a newer one is already in the DB is a
+    no-op, so the operator never sees stale-then-fresh. SEC accession
+    numbers are temporally ordered within an issuer, so they serve as
+    a deterministic same-day tie-breaker.
+
+    NULL handling:
+
+    - Incumbent ``filed_at`` is NULL (legacy / pre-#1151 row) → any
+      new write wins. The first dated write re-baselines the row.
+    - Incoming ``filed_at`` is NULL against a dated incumbent →
+      ``'suppressed'``. No legitimate caller passes NULL after this
+      change; failing closed preserves the dated incumbent rather
+      than silently re-baselining on a bug surface.
+
+    The UPDATE path resets the failure-tracking columns (#533) so a
+    previously-quarantined instrument that now parses successfully
+    exits quarantine cleanly.
+    """
     with conn.cursor() as cur:
         cur.execute(
             """
             INSERT INTO instrument_business_summary
-                (instrument_id, body, source_accession)
-            VALUES (%s, %s, %s)
+                (instrument_id, body, source_accession, filed_at)
+            VALUES (%s, %s, %s, %s)
             ON CONFLICT (instrument_id) DO UPDATE SET
                 body                = EXCLUDED.body,
                 source_accession    = EXCLUDED.source_accession,
+                filed_at            = EXCLUDED.filed_at,
                 fetched_at          = NOW(),
                 last_parsed_at      = NOW(),
                 attempt_count       = 0,
                 last_failure_reason = NULL,
                 next_retry_at       = NULL
+            WHERE
+                instrument_business_summary.filed_at IS NULL
+                OR (EXCLUDED.filed_at IS NOT NULL
+                    AND (EXCLUDED.filed_at, EXCLUDED.source_accession)
+                        >= (instrument_business_summary.filed_at,
+                            instrument_business_summary.source_accession))
             RETURNING (xmax = 0) AS inserted
             """,
-            (instrument_id, body, source_accession),
+            (instrument_id, body, source_accession, filed_at),
         )
         row = cur.fetchone()
-        return bool(row[0]) if row else False
+    if row is None:
+        return "suppressed"
+    return "inserted" if bool(row[0]) else "updated"
 
 
 def upsert_business_sections(
@@ -1348,13 +1383,15 @@ def _find_prior_plain_10k(
     *,
     instrument_id: int,
     before_accession: str,
-) -> tuple[str, str] | None:
+) -> tuple[str, str, date] | None:
     """Find the most recent plain ``10-K`` (NOT ``10-K/A``) filing for
     ``instrument_id`` strictly older than the filing keyed by
     ``before_accession``.
 
-    Returns ``(provider_filing_id, primary_document_url)`` or ``None``
-    when no prior plain 10-K exists.
+    Returns ``(provider_filing_id, primary_document_url, filing_date)``
+    or ``None`` when no prior plain 10-K exists. The ``filing_date``
+    is threaded through so callers can persist the fallback's
+    ``filed_at`` on ``instrument_business_summary`` (#1151).
 
     Used by the 10-K/A fallback path (#534): when the latest filing is
     an amendment that omits Item 1 (Part-III amendments do this
@@ -1367,7 +1404,8 @@ def _find_prior_plain_10k(
         cur.execute(
             """
             SELECT fe.provider_filing_id,
-                   fe.primary_document_url
+                   fe.primary_document_url,
+                   fe.filing_date
               FROM filing_events fe
              WHERE fe.provider = 'sec'
                AND fe.filing_type = '10-K'
@@ -1386,7 +1424,17 @@ def _find_prior_plain_10k(
         row = cur.fetchone()
     if row is None:
         return None
-    return str(row[0]), str(row[1])
+    return str(row[0]), str(row[1]), row[2]
+
+
+def _filing_date_to_filed_at(filing_date: date | None) -> datetime | None:
+    """Coerce a ``filing_events.filing_date`` (DATE) to TIMESTAMPTZ at
+    midnight UTC for the ``instrument_business_summary.filed_at``
+    column. Returns None on None passthrough so legacy callers can
+    propagate "unknown" without inventing a sentinel."""
+    if filing_date is None:
+        return None
+    return datetime.combine(filing_date, time.min, tzinfo=UTC)
 
 
 def bootstrap_business_summaries(
@@ -1522,7 +1570,7 @@ def ingest_business_summaries(
     """
     conn.commit()
 
-    candidates: list[tuple[int, str, str, str]] = []
+    candidates: list[tuple[int, str, str, str, date]] = []
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -1543,7 +1591,8 @@ def ingest_business_summaries(
             SELECT lpi.instrument_id,
                    lpi.provider_filing_id,
                    lpi.primary_document_url,
-                   lpi.filing_type
+                   lpi.filing_type,
+                   lpi.filing_date
             FROM latest_per_instrument lpi
             LEFT JOIN instrument_business_summary bs
                    ON bs.instrument_id = lpi.instrument_id
@@ -1572,7 +1621,7 @@ def ingest_business_summaries(
             (limit,),
         )
         for row in cur.fetchall():
-            candidates.append((int(row[0]), str(row[1]), str(row[2]), str(row[3])))
+            candidates.append((int(row[0]), str(row[1]), str(row[2]), str(row[3]), row[4]))
     conn.commit()
 
     inserted = 0
@@ -1593,7 +1642,7 @@ def ingest_business_summaries(
         cache = prefetch_document_texts(urls, user_agent=ua)
         fetcher = _CachedDocFetcher(fetcher, cache)  # type: ignore[assignment]
 
-    for instrument_id, accession, url, filing_type in candidates:
+    for instrument_id, accession, url, filing_type, filing_date in candidates:
         try:
             html = fetcher.fetch_document_text(url)
         except Exception as exc:
@@ -1662,7 +1711,7 @@ def ingest_business_summaries(
                     before_accession=accession,
                 )
                 if prior is not None:
-                    fallback_acc, fallback_url = prior
+                    fallback_acc, fallback_url, fallback_filing_date = prior
                     logger.info(
                         "ingest_business_summaries: 10-K/A fallback accession=%s -> prior plain 10-K accession=%s",
                         accession,
@@ -1690,14 +1739,15 @@ def ingest_business_summaries(
                             fallback_body = None
                         if fallback_body is not None and len(fallback_body) >= _MIN_BODY_LEN:
                             try:
-                                did_insert = upsert_business_summary(
+                                outcome = upsert_business_summary(
                                     conn,
                                     instrument_id=instrument_id,
                                     body=fallback_body,
                                     source_accession=fallback_acc,
+                                    filed_at=_filing_date_to_filed_at(fallback_filing_date),
                                 )
                                 fallback_sections = extract_business_sections(fallback_html)
-                                if fallback_sections:
+                                if fallback_sections and outcome != "suppressed":
                                     try:
                                         upsert_business_sections(
                                             conn,
@@ -1713,9 +1763,9 @@ def ingest_business_summaries(
                                             exc_info=True,
                                         )
                                 conn.commit()
-                                if did_insert:
+                                if outcome == "inserted":
                                     inserted += 1
-                                else:
+                                elif outcome == "updated":
                                     updated += 1
                                 fallback_used = True
                             except Exception:
@@ -1749,11 +1799,12 @@ def ingest_business_summaries(
             continue
 
         try:
-            did_insert = upsert_business_summary(
+            outcome = upsert_business_summary(
                 conn,
                 instrument_id=instrument_id,
                 body=body,
                 source_accession=accession,
+                filed_at=_filing_date_to_filed_at(filing_date),
             )
             # #449 — also populate the sections table. We re-run the
             # sections extractor over the same HTML so the two writes
@@ -1762,22 +1813,28 @@ def ingest_business_summaries(
             # the extractor returns a single "general" block and the
             # blob view still renders. A failure inside the sections
             # upsert must not roll back the blob write.
-            sections = extract_business_sections(html)
-            if sections:
-                try:
-                    upsert_business_sections(
-                        conn,
-                        instrument_id=instrument_id,
-                        source_accession=accession,
-                        sections=sections,
-                    )
-                except Exception:
-                    logger.warning(
-                        "ingest_business_summaries: section upsert failed accession=%s "
-                        "(blob already stored; rendering degrades to blob-only)",
-                        accession,
-                        exc_info=True,
-                    )
+            #
+            # #1151 — sections only write when the parent upsert
+            # actually ran (inserted/updated). On 'suppressed' the
+            # parent's incumbent body is newer; rewriting sections
+            # under an older accession would dangle them.
+            if outcome != "suppressed":
+                sections = extract_business_sections(html)
+                if sections:
+                    try:
+                        upsert_business_sections(
+                            conn,
+                            instrument_id=instrument_id,
+                            source_accession=accession,
+                            sections=sections,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "ingest_business_summaries: section upsert failed accession=%s "
+                            "(blob already stored; rendering degrades to blob-only)",
+                            accession,
+                            exc_info=True,
+                        )
             conn.commit()
         except Exception:
             conn.rollback()
@@ -1795,10 +1852,12 @@ def ingest_business_summaries(
             conn.commit()
             continue
 
-        if did_insert:
+        if outcome == "inserted":
             inserted += 1
-        else:
+        elif outcome == "updated":
             updated += 1
+        # 'suppressed' is no-op counter-wise (#1151) — newer incumbent
+        # was already in place. Logged at DEBUG only.
 
     return IngestResult(
         filings_scanned=len(candidates),

--- a/app/services/manifest_parsers/__init__.py
+++ b/app/services/manifest_parsers/__init__.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 from app.services.manifest_parsers import def14a as _def14a
 from app.services.manifest_parsers import eight_k as _eight_k
 from app.services.manifest_parsers import insider_345 as _insider_345
+from app.services.manifest_parsers import sec_10k as _sec_10k
 from app.services.manifest_parsers import sec_13dg as _sec_13dg
 from app.services.manifest_parsers import sec_13f_hr as _sec_13f_hr
 from app.services.manifest_parsers import sec_n_port as _sec_n_port
@@ -48,6 +49,7 @@ def register_all_parsers() -> None:
     """
     _eight_k.register()
     _def14a.register()
+    _sec_10k.register()
     _sec_13dg.register()  # registers BOTH sec_13d and sec_13g
     _insider_345.register()  # registers sec_form3 + sec_form4 + sec_form5
     _sec_13f_hr.register()

--- a/app/services/manifest_parsers/sec_10k.py
+++ b/app/services/manifest_parsers/sec_10k.py
@@ -1,0 +1,455 @@
+"""10-K manifest-worker parser adapter (#1151).
+
+Wraps the existing pure-function parser
+``extract_business_section`` / ``extract_business_sections`` +
+table-writers ``upsert_business_summary`` /
+``upsert_business_sections`` from ``app.services.business_summary``
+so the generic manifest worker can drive 10-K Item 1 ingest one
+accession at a time.
+
+Pre-#1151 the legacy bulk path
+``business_summary.ingest_business_summaries`` scanned
+``filing_events`` for the newest 10-K per instrument and processed
+them in batches with its own backoff/quarantine machinery. That
+path still works (no breakage in this PR) but the manifest worker
+is the future-facing single-writer pattern from the #869 spec. As
+the manifest worker drains its backlog, the legacy job becomes
+redundant and can be retired in a follow-up.
+
+ParseOutcome contract:
+
+  * ``status='parsed'`` + ``raw_status='stored'`` — success path.
+    Raw HTML in ``filing_raw_documents``; one
+    ``instrument_business_summary`` row per share-class sibling;
+    one ``instrument_business_summary_sections`` row per subsection
+    per sibling. Also returned on the "newer accession is already
+    present" suppression branch — the DB state is already
+    correct, so the manifest's drain succeeds without a body write.
+  * ``status='tombstoned'`` — fetch returned non-200/empty body,
+    or parser couldn't extract Item 1 and (for 10-K/A) the prior
+    plain 10-K fallback also missed.
+  * ``status='failed'`` — transient error (fetch raised, store_raw
+    error, deterministic-vs-transient discrimination on upsert).
+    Worker schedules a 1h backoff retry per ``_FAILED_RETRY_DELAY``.
+
+Raw-payload invariant (#938): registered with
+``requires_raw_payload=True`` so the worker refuses to mark a row
+``parsed`` when ``raw_status='absent'``. ``store_raw`` runs in a
+savepoint BEFORE parse + upsert so the invariant holds whether
+parsing succeeds or raises.
+
+Share-class fan-out: 10-K Item 1 is an issuer-level narrative. The
+parser resolves the share-class siblings from
+``row.cik`` (via ``siblings_for_issuer_cik``) and writes the body +
+sections per sibling so GOOG and GOOGL both render the same
+narrative on per-instrument reads.
+
+Option C filed_at gate (#1151): ``upsert_business_summary``'s
+conditional ``ON CONFLICT`` accepts only filings whose
+``(filed_at, source_accession)`` tuple is greater-or-equal to the
+incumbent's. The manifest worker drains ``filed_at ASC`` (oldest
+first); without the gate the operator would briefly see the 2018
+Item 1 narrative mid-drain before the 2024 update fires. The gate
+returns ``'suppressed'`` for stale arrivals; the adapter treats
+that as a successful drain (no body write needed).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, time, timedelta
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.services.business_summary import (
+    _MIN_BODY_LEN,
+    _find_prior_plain_10k,
+    extract_business_section,
+    extract_business_sections,
+    upsert_business_sections,
+    upsert_business_summary,
+)
+from app.services.manifest_parsers._classify import (
+    format_upsert_error,
+    is_transient_upsert_error,
+)
+from app.services.raw_filings import store_raw
+from app.services.sec_identity import siblings_for_issuer_cik
+
+logger = logging.getLogger(__name__)
+
+
+# 10-K parser version. Independent of the parser version recorded by
+# the legacy bulk ingester so a parser-version bump in either path
+# can rewash without colliding with the other. Mirror the convention
+# in def14a.py (``_PARSER_VERSION_DEF14A``) + insider_345.py
+# (``_PARSER_VERSION_FORM4``).
+_PARSER_VERSION_10K = "10k-v1"
+
+# Explicit 1h backoff. Duplicated from the worker's internal
+# ``_backoff_for(0)`` value — see eight_k.py for the rationale
+# (importing the private worker symbol couples to internal layout).
+_FAILED_RETRY_DELAY = timedelta(hours=1)
+
+# Sentinel matches def14a / insider_345 pattern: when CIK is missing
+# from the manifest row we still want to write the canonical sibling
+# rather than drop the row entirely.
+_CIK_MISSING_SENTINEL = "__missing__"
+
+
+def _failed_outcome(error: str, raw_status: Any = None) -> Any:
+    """Build a ``failed`` ParseOutcome with a 1h backoff applied.
+
+    Setting ``next_retry_at`` here so the worker doesn't immediately
+    retry on the next tick — mirrors the pattern in eight_k.py and
+    def14a.py."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    return ParseOutcome(
+        status="failed",
+        parser_version=_PARSER_VERSION_10K,
+        raw_status=raw_status,
+        error=error,
+        next_retry_at=datetime.now(tz=UTC) + _FAILED_RETRY_DELAY,
+    )
+
+
+def _resolve_siblings(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    issuer_cik: str,
+) -> list[int]:
+    """Resolve share-class siblings for fan-out.
+
+    Always includes ``instrument_id`` in the returned set (Codex
+    checkpoint 2 HIGH): if ``siblings_for_issuer_cik`` returns a non-
+    empty but incomplete set because the canonical sibling's
+    ``external_identifiers`` row is missing or stale, dropping it from
+    fan-out leaves the operator-visible page empty for the canonical
+    listing. Failing closed by union-ing the manifest's
+    ``instrument_id`` in keeps the canonical sibling's write safe even
+    on a data-quality gap elsewhere.
+
+    Sentinel branch returns just the canonical sibling because we
+    have no CIK to query siblings against."""
+    if issuer_cik == _CIK_MISSING_SENTINEL:
+        return [instrument_id]
+    siblings = siblings_for_issuer_cik(conn, issuer_cik)
+    return sorted(set(siblings) | {instrument_id})
+
+
+def _fetch_html(
+    url: str,
+) -> str | None:
+    """Fetch a primary document over the rate-limited SEC client.
+
+    Returns the body on success, ``None`` on empty body (provider's
+    own 404/410/empty signal). Raises on transport-level failures so
+    the adapter can map them to a ``_failed_outcome``."""
+    with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+        return provider.fetch_document_text(url)
+
+
+def _parse_sec_10k(
+    conn: psycopg.Connection[Any],
+    row: Any,  # ManifestRow — forward-ref to avoid circular import
+) -> Any:  # ParseOutcome — forward-ref
+    """Manifest-worker parser for one 10-K (or 10-K/A) accession.
+
+    Steps:
+
+    1. Validate URL + instrument_id (tombstone on missing).
+    2. Fetch primary doc. Exception → failed. Empty → tombstone.
+    3. ``store_raw`` in a savepoint (#938 invariant).
+    4. Parse Item 1 via ``extract_business_section``.
+    5. If body None / too short AND form is 10-K/A: fall back to the
+       prior plain 10-K (mirrors legacy #534 path). Otherwise tombstone.
+    6. Extract sections from the chosen HTML (best-effort; sections=()
+       on extractor failure).
+    7. Resolve share-class siblings (#1117).
+    8. Inside ONE batched savepoint: upsert per sibling under the
+       conditional filed_at gate (Option C). A sections upsert failure
+       in a nested savepoint logs + degrades to blob-only. Deterministic
+       upsert error → tombstone with the savepoint rolling back partial
+       fan-out state.
+    """
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    accession = row.accession_number
+    url = row.primary_document_url
+    instrument_id = row.instrument_id
+    form = (row.form or "").strip().upper()
+    filed_at = row.filed_at
+    issuer_cik = row.cik or _CIK_MISSING_SENTINEL
+
+    if not url:
+        logger.warning(
+            "sec_10k manifest parser: accession=%s has no primary_document_url; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_10K,
+            error="missing primary_document_url",
+        )
+    if instrument_id is None:
+        logger.warning(
+            "sec_10k manifest parser: accession=%s has no instrument_id; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_10K,
+            error="missing instrument_id",
+        )
+
+    # 1. Fetch primary doc.
+    try:
+        html = _fetch_html(url)
+    except Exception as exc:  # noqa: BLE001 — transient fetch errors retry via worker backoff
+        logger.warning(
+            "sec_10k manifest parser: fetch raised accession=%s url=%s: %s",
+            accession,
+            url,
+            exc,
+        )
+        return _failed_outcome(f"fetch error: {exc}")
+
+    if not html:
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_10K,
+            error="empty or non-200 fetch",
+        )
+
+    # 2. Store raw BEFORE parse so the #938 invariant holds even when
+    # the parse later raises. Savepoint isolates a partial write from
+    # the worker's outer transaction.
+    try:
+        with conn.transaction():
+            store_raw(
+                conn,
+                accession_number=accession,
+                document_kind="primary_doc",
+                payload=html,
+                parser_version=_PARSER_VERSION_10K,
+                source_url=url,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "sec_10k manifest parser: store_raw failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"store_raw error: {exc}")
+
+    # 3. Parse Item 1. The bare-call-after-committed-savepoint rule
+    # (PR #1126) — wrap the next expression that can raise so an
+    # unhandled exception cannot leave the worker's outer tx aborted
+    # before transition_status runs.
+    try:
+        body = extract_business_section(html)
+    except Exception as exc:  # noqa: BLE001 — see PR #1129 pinned rule
+        logger.exception(
+            "sec_10k manifest parser: parse raised accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"parse error: {exc}", raw_status="stored")
+
+    chosen_accession = accession
+    chosen_filed_at = filed_at
+    chosen_html = html
+
+    # 4. 10-K/A fallback path (mirrors legacy #534).
+    if body is None or len(body) < _MIN_BODY_LEN:
+        if form != "10-K/A":
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_10K,
+                raw_status="stored",
+                error="no Item 1 marker (plain 10-K)",
+            )
+
+        prior = _find_prior_plain_10k(
+            conn,
+            instrument_id=instrument_id,
+            before_accession=accession,
+        )
+        if prior is None:
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_10K,
+                raw_status="stored",
+                error="10-K/A missing Item 1 and no prior plain 10-K",
+            )
+
+        fallback_acc, fallback_url, fallback_filing_date = prior
+        logger.info(
+            "sec_10k manifest parser: 10-K/A accession=%s -> prior plain 10-K accession=%s",
+            accession,
+            fallback_acc,
+        )
+
+        try:
+            fallback_html = _fetch_html(fallback_url)
+        except Exception as exc:  # noqa: BLE001 — original raw is stored already; retry as failed.
+            logger.warning(
+                "sec_10k manifest parser: 10-K/A fallback fetch raised accession=%s url=%s: %s",
+                fallback_acc,
+                fallback_url,
+                exc,
+            )
+            return _failed_outcome(f"fallback fetch error: {exc}", raw_status="stored")
+
+        if not fallback_html:
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_10K,
+                raw_status="stored",
+                error="10-K/A fallback returned empty body",
+            )
+
+        # Store fallback raw under fallback_acc so audit/rewash can
+        # find it under the accession the parent row will point at.
+        try:
+            with conn.transaction():
+                store_raw(
+                    conn,
+                    accession_number=fallback_acc,
+                    document_kind="primary_doc",
+                    payload=fallback_html,
+                    parser_version=_PARSER_VERSION_10K,
+                    source_url=fallback_url,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "sec_10k manifest parser: fallback store_raw failed accession=%s",
+                fallback_acc,
+            )
+            return _failed_outcome(f"fallback store_raw error: {exc}", raw_status="stored")
+
+        try:
+            fallback_body = extract_business_section(fallback_html)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "sec_10k manifest parser: 10-K/A fallback parse raised accession=%s",
+                fallback_acc,
+            )
+            return _failed_outcome(f"fallback parse error: {exc}", raw_status="stored")
+
+        if fallback_body is None or len(fallback_body) < _MIN_BODY_LEN:
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_10K,
+                raw_status="stored",
+                error="10-K/A fallback also missed Item 1",
+            )
+
+        body = fallback_body
+        chosen_accession = fallback_acc
+        chosen_filed_at = (
+            datetime.combine(fallback_filing_date, time.min, tzinfo=UTC) if fallback_filing_date is not None else None
+        )
+        chosen_html = fallback_html
+
+    assert body is not None  # narrowed by the fallback branch logic above
+
+    # 5. Extract sections once from the chosen HTML. Sections are a
+    # best-effort enrichment — a parser bug here must NOT escape after
+    # store_raw committed (otherwise raw_status='stored' preservation
+    # is violated per 8-K Codex round 2 BLOCKING).
+    try:
+        sections = extract_business_sections(chosen_html)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "sec_10k manifest parser: sections extractor raised accession=%s "
+            "(blob will still write; sections degrade to empty)",
+            chosen_accession,
+            exc_info=True,
+        )
+        sections = ()
+
+    # 6. Fan out across share-class siblings (#1117). ONE batched
+    # savepoint wraps sibling resolution + the whole write batch so a
+    # mid-batch failure unwinds partial state cleanly. Mirrors
+    # def14a._parse_def14a.
+    try:
+        with conn.transaction():
+            siblings = _resolve_siblings(conn, instrument_id=instrument_id, issuer_cik=issuer_cik)
+            for sibling_iid in siblings:
+                outcome = upsert_business_summary(
+                    conn,
+                    instrument_id=sibling_iid,
+                    body=body,
+                    source_accession=chosen_accession,
+                    filed_at=chosen_filed_at,
+                )
+                if outcome == "suppressed":
+                    logger.debug(
+                        "sec_10k manifest parser: filed_at gate suppressed sibling=%s accession=%s (incumbent newer)",
+                        sibling_iid,
+                        chosen_accession,
+                    )
+                    continue
+                if not sections:
+                    continue
+                # Nested savepoint absorbs a sections failure so the
+                # parent blob write survives. Matches legacy "sections
+                # are best-effort; blob-only fallback acceptable"
+                # semantics (business_summary.py:1774).
+                try:
+                    with conn.transaction():
+                        upsert_business_sections(
+                            conn,
+                            instrument_id=sibling_iid,
+                            source_accession=chosen_accession,
+                            sections=sections,
+                        )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "sec_10k manifest parser: sections upsert failed sibling=%s accession=%s "
+                        "(blob already stored; rendering degrades to blob-only)",
+                        sibling_iid,
+                        chosen_accession,
+                        exc_info=True,
+                    )
+    except Exception as exc:  # noqa: BLE001
+        # #1131 transient-vs-deterministic discrimination — a transient
+        # OperationalError can self-resolve on the next tick; everything
+        # else won't and should tombstone so the worker stops re-fetching.
+        # The outer savepoint already unwound any partial sibling writes
+        # by the time we reach this branch.
+        logger.exception(
+            "sec_10k manifest parser: fan-out batch failed accession=%s",
+            chosen_accession,
+        )
+        if is_transient_upsert_error(exc):
+            return _failed_outcome(format_upsert_error(exc), raw_status="stored")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_10K,
+            raw_status="stored",
+            error=format_upsert_error(exc),
+        )
+
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_PARSER_VERSION_10K,
+        raw_status="stored",
+    )
+
+
+def register() -> None:
+    """Register the 10-K parser with the manifest worker.
+
+    Idempotent — ``register_parser`` is last-write-wins, so calling
+    this twice with the same callable is a no-op. Called once from
+    ``app.services.manifest_parsers.register_all_parsers`` at package
+    import time, and re-callable from tests after a registry wipe.
+    """
+    from app.jobs.sec_manifest_worker import register_parser
+
+    register_parser("sec_10k", _parse_sec_10k, requires_raw_payload=True)

--- a/docs/superpowers/specs/2026-05-13-1151-10k-manifest-parser.md
+++ b/docs/superpowers/specs/2026-05-13-1151-10k-manifest-parser.md
@@ -1,0 +1,231 @@
+# 10-K manifest adapter (final #873-series parser) — #1151
+
+Date: 2026-05-13
+
+## Goal
+
+Register a `sec_10k` parser with the manifest worker so `10-K` / `10-K/A` rows in `sec_filing_manifest` drain through the single-writer manifest path. Final adapter in the #873-series rollout.
+
+## Scope
+
+In:
+
+- `sql/148_instrument_business_summary_filed_at.sql` — adds nullable `filed_at TIMESTAMPTZ` + backfill from `filing_events.filing_date`.
+- `app/services/business_summary.py::upsert_business_summary` — adds `filed_at` kwarg + conditional `ON CONFLICT` gated by `(filed_at, source_accession)` tuple (Option C); returns `Literal['inserted', 'updated', 'suppressed']`.
+- Legacy `ingest_business_summaries` + `_find_prior_plain_10k` fallback threads `filed_at` through (DATE → TIMESTAMPTZ via `datetime.combine(d, time.min, tzinfo=UTC)`).
+- `app/services/manifest_parsers/sec_10k.py` — new adapter, shape mirrors `def14a.py` (share-class fan-out) and `eight_k.py` (raw-payload contract).
+- `register_all_parsers()` wires it.
+- Tests + DB-level conditional-ON-CONFLICT regression test + share-class fanout test.
+
+Out:
+
+- Legacy `ingest_business_summaries` retirement.
+- 10-Q manifest adapter (blocked on #414).
+- N-PORT `period_of_report` overwrite bug.
+- Sections-orphan cleanup.
+
+## Why Option C
+
+`iter_pending` orders `filed_at ASC` (oldest first). Unconditional `ON CONFLICT (instrument_id) DO UPDATE` would render OLDEST → NEWEST per-instrument during the drain — final state correct but operator briefly sees the 2018 10-K body before the 2024 update fires. The conditional makes stale-arrival a no-op so the operator always sees monotonically-newer or unchanged.
+
+## Schema migration
+
+`sql/148_instrument_business_summary_filed_at.sql`:
+
+```sql
+ALTER TABLE instrument_business_summary
+    ADD COLUMN IF NOT EXISTS filed_at TIMESTAMPTZ;
+
+-- Backfill from filing_events. Match by source_accession against the
+-- canonical SEC accession; coerce DATE to TIMESTAMPTZ at midnight UTC.
+UPDATE instrument_business_summary ibs
+   SET filed_at = fe.filing_date::timestamptz
+  FROM filing_events fe
+ WHERE fe.provider = 'sec'
+   AND fe.provider_filing_id = ibs.source_accession
+   AND ibs.filed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_instrument_business_summary_filed_at
+    ON instrument_business_summary (filed_at);
+
+COMMENT ON COLUMN instrument_business_summary.filed_at IS
+    'TIMESTAMPTZ of the 10-K filing this row was extracted from. Gates '
+    'the conditional ON CONFLICT in upsert_business_summary so a '
+    'filed_at-ASC manifest drain does not render stale-then-fresh. '
+    'NULL means the row pre-dates the column or originated as a '
+    'service-level tombstone (record_parse_attempt).';
+```
+
+Nullable forever — tombstones from `record_parse_attempt` carry no source filing, and pre-#1151 rows whose `source_accession` does not match a `filing_events` row stay NULL.
+
+## `upsert_business_summary` change
+
+Signature change (legacy callers updated in lockstep):
+
+```python
+UpsertOutcome = Literal["inserted", "updated", "suppressed"]
+
+def upsert_business_summary(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    body: str,
+    source_accession: str,
+    filed_at: datetime | None,
+) -> UpsertOutcome:
+```
+
+SQL — gate on `(filed_at, source_accession)` tuple so two filings on the same calendar day still have a deterministic winner (SEC accessions are temporally ordered within an issuer):
+
+```sql
+INSERT INTO instrument_business_summary
+    (instrument_id, body, source_accession, filed_at)
+VALUES (%s, %s, %s, %s)
+ON CONFLICT (instrument_id) DO UPDATE SET
+    body                = EXCLUDED.body,
+    source_accession    = EXCLUDED.source_accession,
+    filed_at            = EXCLUDED.filed_at,
+    fetched_at          = NOW(),
+    last_parsed_at      = NOW(),
+    attempt_count       = 0,
+    last_failure_reason = NULL,
+    next_retry_at       = NULL
+WHERE
+    instrument_business_summary.filed_at IS NULL
+    OR (EXCLUDED.filed_at IS NOT NULL
+        AND (EXCLUDED.filed_at, EXCLUDED.source_accession)
+            >= (instrument_business_summary.filed_at, instrument_business_summary.source_accession))
+RETURNING (xmax = 0) AS inserted
+```
+
+Return:
+
+- `cur.fetchone() is None` → `'suppressed'` (UPDATE WHERE rejected — incumbent is newer or same-day-newer accession, or incoming filed_at is NULL against a dated incumbent).
+- `row[0] is True` → `'inserted'`.
+- `row[0] is False` → `'updated'`.
+
+NULL handling:
+
+- Incumbent NULL (legacy / pre-#1151 row) → any new write wins. The first dated write (manifest path) re-baselines the row.
+- Incoming NULL against a dated incumbent → `'suppressed'`. No legitimate caller passes NULL after this PR — manifest adapter always has `row.filed_at`; legacy callers thread `filing_date`. A NULL-incoming write would be a bug; failing closed (suppression) preserves the dated incumbent rather than silently re-baselining.
+
+## Legacy callers (`ingest_business_summaries`)
+
+Both call sites already have `provider_filing_id` for the candidate row. Extend the candidate `SELECT` to include `fe.filing_date`. Convert in the Python loop:
+
+```python
+from datetime import UTC, datetime, time
+filed_at_dt = datetime.combine(filing_date, time.min, tzinfo=UTC) if filing_date else None
+```
+
+Pass `filed_at=filed_at_dt` to `upsert_business_summary`. The 10-K/A fallback path uses `_find_prior_plain_10k`; extend its return tuple to include the fallback's `filing_date` and convert the same way.
+
+Counters `inserted` vs `updated` in `IngestResult` map to the trinary as:
+
+- `'inserted'` → `inserted += 1`
+- `'updated'` → `updated += 1`
+- `'suppressed'` → no-op (counter unchanged; logged at DEBUG). Legacy selector picks newest so this branch is essentially unreachable on the legacy path; treating it as a silent no-op avoids muddying `parse_misses` (which is reserved for fetch/parse failures, not "newer was already there").
+
+## Adapter shape (`sec_10k.py`)
+
+Mirrors `def14a.py` for share-class fan-out + `eight_k.py` for raw-payload contract.
+
+### Steps
+
+1. **Validate** — `row.primary_document_url`, `row.instrument_id`, `row.cik` non-null; missing → tombstone with descriptive error (no raw stored).
+2. **Fetch** — `SecFilingsProvider.fetch_document_text(url)`. Exception → `_failed_outcome(error=..., raw_status=None)` (1h backoff). Empty/None → tombstoned (no raw).
+3. **Store raw** — `store_raw(accession_number=accession, document_kind='primary_doc', payload=html, ...)` inside `with conn.transaction():`. Exception → `_failed_outcome`.
+4. **Parse Item 1** — `extract_business_section(html)`. Exception → `_failed_outcome(raw_status='stored')`.
+5. **Body extraction policy**:
+   - **Body found AND `len(body) >= _MIN_BODY_LEN`** → use this body, accession=`row.accession_number`, filed_at=`row.filed_at`, html=`html` for sections.
+   - **Body None / too short, `row.form == '10-K/A'`** → attempt fallback (see step 6).
+   - **Body None / too short, plain `10-K`, no fallback** → tombstone (raw stored).
+6. **10-K/A fallback** (mirrors legacy `business_summary.py:1657`–`1727`):
+   - Look up prior plain 10-K via extended `_find_prior_plain_10k`: returns `(provider_filing_id, primary_document_url, filing_date)` or `None`.
+   - `None` → tombstone (raw stored).
+   - Else fetch fallback HTML.
+     - Fallback fetch exception → `_failed_outcome(raw_status='stored')` (retry; original raw is already stored, no waste).
+     - Fallback returns empty → tombstone (raw stored).
+   - `store_raw(accession_number=fallback_acc, …)` inside `with conn.transaction():` so a partial write doesn't abort the worker's outer tx. Fallback `store_raw` exception → `_failed_outcome(raw_status='stored')` (original raw is already stored from step 3; do NOT downgrade `raw_status`).
+   - `extract_business_section(fallback_html)` → parse exception → `_failed_outcome(raw_status='stored')`; None / too short → tombstone (both raws stored).
+   - On success: use fallback body, accession=`fallback_acc`, filed_at=`datetime.combine(fallback_filing_date, time.min, tzinfo=UTC)`, html=`fallback_html` for sections.
+7. **Extract sections once** — `sections = extract_business_sections(chosen_html)` BEFORE the fan-out loop, wrapped in `try/except Exception: log + sections = ()`. Sections are a best-effort enrichment; a section-parser bug must not escape after `store_raw` ran (would violate `raw_status='stored'` preservation per 8-K Codex round 2 BLOCKING). On `sections=()` the fan-out still writes the parent blob; the sections table simply gets no rows for this accession.
+8. **Share-class fan-out — single batched savepoint** (mirrors `def14a._parse_def14a` lines 322–360). Wrap sibling resolution + entire parent/sections write batch in ONE `with conn.transaction():` so:
+   - A mid-batch failure rolls back the whole sibling fan-out (no partial state across siblings).
+   - Transient `OperationalError` anywhere → `_failed_outcome(raw_status='stored')`.
+   - Deterministic Postgres error anywhere → tombstone with `format_upsert_error(exc)` (the savepoint rollback unwinds any earlier sibling writes from the same batch before tombstone state is emitted).
+   - Sequence inside the savepoint:
+     1. `siblings = _resolve_siblings(conn, instrument_id=row.instrument_id, issuer_cik=row.cik)`.
+     2. For each `sibling_iid` in `siblings`:
+        - `outcome = upsert_business_summary(conn, instrument_id=sibling_iid, body=…, source_accession=…, filed_at=…)`.
+        - If `outcome in ('inserted', 'updated')` and `sections`: call `upsert_business_sections` inside a NESTED `with conn.transaction():` (savepoint-inside-savepoint). A sections exception is logged + swallowed, the nested savepoint rolls back so the outer batch's parent upsert survives, and the loop continues. Matches legacy "sections are best-effort enrichment; blob-only fallback is acceptable" (`business_summary.py:1774`). psycopg3 nests `conn.transaction()` cleanly as SAVEPOINT-within-SAVEPOINT.
+     3. Tally per-sibling outcomes (counters in WorkerStats-equivalent local vars).
+9. **Tombstone branches** — manifest path does NOT call `record_parse_attempt`. `record_parse_attempt` mutates `source_accession` on UPDATE and could corrupt an incumbent newer body's provenance. The manifest path returns `ParseOutcome(status='tombstoned')`; `transition_status` for tombstoned is terminal until a targeted rebuild re-promotes the row. `next_retry_at` is unused on tombstoned outcomes.
+10. **Return** — `ParseOutcome(status='parsed', parser_version=_PARSER_VERSION_10K, raw_status='stored')` whether siblings inserted/updated or all returned `'suppressed'`. Suppression means a newer accession is already in the DB — the manifest's job ("drain this row") is satisfied either way.
+
+### Parser version
+
+Define a new module-level constant in `sec_10k.py`: `_PARSER_VERSION_10K = "10k-v1"`. Used in every `ParseOutcome.parser_version` return. `business_summary.py` doesn't expose a version constant; the manifest layer owns this version label, matching the convention in `def14a.py` (`_PARSER_VERSION_DEF14A`) and `insider_345.py` (`_PARSER_VERSION_FORM4`).
+
+### `requires_raw_payload=True`
+
+Register with the #938 invariant set. The adapter stores raw before the parse → parsed/suppressed outcomes carry `raw_status='stored'` by construction.
+
+## Cross-cutting rule compliance
+
+- **#1131 — transient discrimination.** Use `is_transient_upsert_error` + `format_upsert_error`.
+- **#1126 — savepoint around store_raw + upsert.** Each in its own `with conn.transaction():`.
+- **#1129 — parse-failure broad-except.** One `except Exception` block per parse + persistence boundary.
+- **#1132 — psycopg3 transaction-vs-commit.** Worker owns the outer tx; we use savepoints only.
+- **#1133 — test-name vs assertion.** Every `test_*tombstone*` asserts `ingest_status == 'tombstoned'`.
+- **#1117 — share-class fanout per filing.** 10-K Item 1 is entity-level; per-instrument fan-out via `siblings_for_issuer_cik`.
+
+## Tests (`tests/test_manifest_parser_sec_10k.py`)
+
+Per the prevention log entry on "ON CONFLICT branch coverage" (line 582-583), at least one DB-level test exercises the conditional `WHERE` against the real schema.
+
+1. `test_happy_path_parses_and_stores_raw` — fresh accession, fresh instrument, body extracted, sections written, parent inserted.
+2. `test_happy_path_fans_out_to_share_class_siblings` — seed two siblings sharing CIK; one manifest row; both siblings receive body + sections; both rows point at the same accession.
+3. `test_happy_path_10ka_with_item1_present` — 10-K/A whose body parses directly (no fallback).
+4. `test_10ka_falls_back_to_prior_plain_10k` — 10-K/A Item 1 None; fallback returns hit; fallback fetched + raw stored under fallback_acc; parent + sections persisted under fallback_acc; fallback's filed_at threaded through.
+5. `test_10ka_fallback_no_prior_filing_tombstones` — no prior plain 10-K; tombstone with raw stored.
+6. `test_10ka_fallback_fetch_error_returns_failed_with_raw_stored` — fallback fetcher raises; outcome is `failed` not tombstone; original raw is in `filing_raw_documents`.
+7. `test_10ka_fallback_empty_body_tombstones` — fallback HTML empty.
+8. `test_10ka_fallback_parse_exception_returns_failed_with_raw_stored` — fallback `extract_business_section` raises.
+9. `test_fetch_error_returns_failed_outcome` — original fetcher raises; no raw stored; `next_retry_at` ~1h.
+10. `test_empty_body_tombstones_without_raw_stored` — original fetcher returns empty.
+11. `test_body_too_short_tombstones_with_raw_stored` — body shorter than `_MIN_BODY_LEN`.
+12. `test_filed_at_gate_suppresses_older_arrival` — seed `instrument_business_summary` with filed_at=2024 + accession=A1; manifest row filed_at=2020 + accession=A0; adapter returns parsed but body+sections unchanged.
+13. `test_filed_at_gate_allows_newer_arrival` — seed filed_at=2020; manifest filed_at=2024; body+sections updated.
+14. `test_same_day_accession_tiebreaker_picks_later_accession` — seed filed_at=2026-01-01 + accession=`0001-26-000001`; manifest filed_at=2026-01-01 + accession=`0001-26-000002` (later number) → wins. Reverse → suppressed.
+15. `test_null_incumbent_filed_at_allows_write` — pre-seeded legacy row with filed_at=NULL; adapter writes.
+16. `test_suppressed_parent_skips_sections_write` — seed sections under incumbent newer accession; adapter for older accession returns suppressed; sections untouched.
+17. `test_transient_upsert_error_returns_failed_outcome` — patch `upsert_business_summary` to raise `SerializationFailure`.
+18. `test_deterministic_upsert_error_tombstones` — patch to raise non-transient `psycopg.Error`.
+19. `test_tombstone_path_does_not_mutate_existing_body_summary_row` — pre-seed an incumbent with real body; adapter for older accession parses miss + tombstones; incumbent body + source_accession unchanged.
+20. `test_register_all_parsers_wires_sec_10k` — audit endpoint surfaces `has_registered_parser=True`.
+21. `test_section_extraction_exception_does_not_break_parent_write` — patch `extract_business_sections` to raise; parent blob still written; `ParseOutcome.status='parsed'`, `raw_status='stored'`; sections table row count unchanged.
+22. `test_partial_fanout_rollback_on_deterministic_error` — seed two siblings A + B sharing CIK; patch `upsert_business_summary` to succeed on A and raise `psycopg.errors.IntegrityError` on B; assert manifest tombstones, A's row reverts (savepoint rolls back), neither sibling has new blob.
+23. `test_fallback_store_raw_failure_returns_failed_with_original_raw_stored` — 10-K/A fallback path; patch `store_raw` to raise on fallback accession only; original accession's raw row exists; outcome is `failed` with `raw_status='stored'`; no parent write.
+
+## Smoke + verify (ETL clauses 8–12)
+
+After merge:
+
+- `POST /jobs/sec_rebuild/run` with `{"source": "sec_10k"}` on dev DB.
+- Wait for manifest drain on the panel AAPL / GME / MSFT / JPM / HD.
+- Verify `GET /instruments/{symbol}/research` (or the canonical 10-K Item 1 surface) renders fresh body.
+- Cross-source: spot-check one issuer's Item 1 against the SEC EDGAR direct page.
+- Record commit SHA + verification rows in PR body.
+
+## Risks / open questions
+
+1. **Sections rewrite on incumbent re-parse**: same-accession re-parse → `'updated'` → `upsert_business_sections` DELETE+INSERT for that accession only (savepoint-wrapped per #460 prevention).
+2. **Legacy path producing `'suppressed'`**: dead branch on legacy (selector picks newest). No-op on counters; debug-log only.
+3. **Backfill timing**: `instrument_business_summary` ≤4031 rows. Negligible.
+4. **`record_parse_attempt` mutation hazard noted but unfixed**: the helper still UPDATEs `source_accession` on failed retries via the legacy path. Out of scope here; manifest path simply doesn't call it. Tech-debt eligible if it bites operator-visible figures.
+
+## Codex checkpoints
+
+- **Checkpoint 1**: addressed three BLOCKING, two HIGH, one MEDIUM via this revision.
+- **Checkpoint 2** (before push): `codex.cmd exec review` on the branch diff.

--- a/sql/148_instrument_business_summary_filed_at.sql
+++ b/sql/148_instrument_business_summary_filed_at.sql
@@ -1,0 +1,47 @@
+-- 148_instrument_business_summary_filed_at.sql
+--
+-- Adds ``filed_at`` to ``instrument_business_summary`` so the
+-- manifest-driven 10-K parser (#1151) can gate ``ON CONFLICT DO
+-- UPDATE`` on filed_at-ASC drain order. Without this gate, the
+-- manifest worker would render OLDEST → NEWEST 10-K body per
+-- instrument during first-install drain: final state correct but
+-- operator briefly sees the 2018 Item 1 narrative before the 2024
+-- update fires.
+--
+-- Backfill matches by ``source_accession`` against
+-- ``filing_events.provider_filing_id`` for SEC rows. Pre-#1151 rows
+-- that pre-date their filing_events ancestor or were written from
+-- a filing we no longer have stay NULL — the new conditional ON
+-- CONFLICT treats NULL incumbents as "no incumbent" so the first
+-- dated write re-baselines them cleanly. Tombstone rows from
+-- ``record_parse_attempt`` carry no source filing and stay NULL
+-- forever; they are out of the manifest parser's path entirely.
+--
+-- Population: ``instrument_business_summary`` holds at most one row
+-- per instrument (~4031 in the current universe), so the backfill
+-- UPDATE scans a bounded set.
+
+ALTER TABLE instrument_business_summary
+    ADD COLUMN IF NOT EXISTS filed_at TIMESTAMPTZ;
+
+-- Coerce DATE → TIMESTAMPTZ explicitly under UTC so the result
+-- doesn't depend on session timezone. ``::timestamptz`` would use
+-- the session TZ (Codex pre-push round 2 finding) — the conditional
+-- ON CONFLICT gate compares wall-clock instants, so a session-TZ
+-- shift would silently move the gate's boundary.
+UPDATE instrument_business_summary ibs
+   SET filed_at = fe.filing_date::timestamp AT TIME ZONE 'UTC'
+  FROM filing_events fe
+ WHERE fe.provider = 'sec'
+   AND fe.provider_filing_id = ibs.source_accession
+   AND ibs.filed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_instrument_business_summary_filed_at
+    ON instrument_business_summary (filed_at);
+
+COMMENT ON COLUMN instrument_business_summary.filed_at IS
+    'TIMESTAMPTZ of the 10-K filing this row was extracted from. '
+    'Gates the conditional ON CONFLICT in upsert_business_summary '
+    'so a filed_at-ASC manifest drain does not render stale-then-'
+    'fresh. NULL means the row pre-dates the column or originated '
+    'as a service-level tombstone (record_parse_attempt).';

--- a/tests/test_fetch_document_text_callers.py
+++ b/tests/test_fetch_document_text_callers.py
@@ -53,6 +53,23 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "app/services/def14a_ingest.py",
         "app/services/ncen_classifier.py",
         "app/services/n_port_ingest.py",
+        # Manifest-worker adapters (#1126 / #1128 / #1129 / #1130 /
+        # #1133 / #1134 / #1151). Each one wraps a legacy service-layer
+        # ingester whose SQL normalisation already lives on this allow-
+        # list — the adapter is a thin per-accession driver, not a new
+        # disk-only persistence path.
+        "app/services/manifest_parsers/def14a.py",
+        "app/services/manifest_parsers/eight_k.py",
+        "app/services/manifest_parsers/insider_345.py",
+        "app/services/manifest_parsers/sec_10k.py",
+        "app/services/manifest_parsers/sec_13dg.py",
+        "app/services/manifest_parsers/sec_13f_hr.py",
+        "app/services/manifest_parsers/sec_n_port.py",
+        # Bounded pipelined fetcher (#1045) — concurrent transport
+        # wrapper used by ``ingest_business_summaries`` to prefetch
+        # primary docs. Doesn't persist anything itself; the wrapped
+        # caller (business_summary) owns the SQL normalisation.
+        "app/services/sec_pipelined_fetcher.py",
         # Provider implementation owns the method itself.
         "app/providers/implementations/sec_edgar.py",
         # Bounded-concurrency wrapper (#726). Calls the method via a
@@ -78,6 +95,16 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "tests/test_def14a_ingest.py",
         "tests/test_ncen_classifier.py",
         "tests/test_n_port_ingest.py",
+        # Manifest-worker adapter tests — exercise the adapters above
+        # and naturally reference fetch_document_text via monkeypatch.
+        "tests/test_manifest_parser_def14a.py",
+        "tests/test_manifest_parser_eight_k.py",
+        "tests/test_manifest_parser_insider_345.py",
+        "tests/test_manifest_parser_sec_10k.py",
+        "tests/test_manifest_parser_sec_13dg.py",
+        "tests/test_manifest_parser_sec_13f_hr.py",
+        "tests/test_manifest_parser_sec_n_port.py",
+        "tests/test_sec_pipelined_fetcher.py",
         # This guard file itself references the method name in its
         # contract sentence.
         "tests/test_fetch_document_text_callers.py",

--- a/tests/test_manifest_parser_sec_10k.py
+++ b/tests/test_manifest_parser_sec_10k.py
@@ -1,0 +1,1268 @@
+"""Tests for the 10-K manifest-worker parser adapter (#1151).
+
+Covers:
+
+- Happy path: HTML fetch → store_raw → parse → upsert blob + sections
+  → ParseOutcome(parsed).
+- Share-class fan-out: one manifest row writes both siblings.
+- 10-K/A fallback: prior plain 10-K rescue when amendment misses Item 1.
+- Empty / missing / parse-miss tombstones.
+- ``filed_at`` gate suppression + tie-break by accession.
+- NULL incumbent backwards compat.
+- Section-extraction failure isolation.
+- Partial fan-out rollback under deterministic upsert error.
+- Fallback store_raw failure preserves original raw + returns failed.
+- Transient vs deterministic upsert exceptions.
+- ``record_parse_attempt`` not invoked from the manifest path (no
+  corruption of an incumbent's body provenance).
+- Registration via ``register_all_parsers``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import psycopg
+import psycopg.errors
+import pytest
+
+from app.jobs.sec_manifest_worker import (
+    clear_registered_parsers,
+    registered_parser_sources,
+    run_manifest_worker,
+)
+from app.services.sec_manifest import get_manifest_row, record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+# Minimal HTML body the real ``extract_business_section`` parser
+# accepts: Item 1 heading + body + Item 1A boundary. The body length
+# is comfortably above ``_MIN_BODY_LEN`` (120 chars) so the parse-miss
+# branches must explicitly use shorter bodies or monkeypatching.
+_FAKE_10K_HTML = (
+    "<html><body>"
+    "<p>UNITED STATES SECURITIES AND EXCHANGE COMMISSION</p>"
+    "<p>FORM 10-K</p>"
+    "<h2>Item 1. Business</h2>"
+    "<p>Acme Corp is a fabricator of industrial widgets serving "
+    "the global market. Acme operates manufacturing facilities in "
+    "Ohio and Texas and sells through a network of distributors "
+    "across North America, Europe, and Asia. Our customers include "
+    "automotive OEMs and aerospace integrators. Strategic priorities "
+    "include capacity expansion and supplier diversification.</p>"
+    "<h2>Item 1A. Risk Factors</h2>"
+    "<p>The risks of our business include cyclicality and tariffs.</p>"
+    "</body></html>"
+)
+
+_FAKE_10KA_HTML_NO_ITEM_1 = (
+    "<html><body>"
+    "<p>UNITED STATES SECURITIES AND EXCHANGE COMMISSION</p>"
+    "<p>FORM 10-K/A</p>"
+    "<h2>Item 1A. Risk Factors</h2>"
+    "<p>The risks of our business include cyclicality and tariffs.</p>"
+    "<h2>Item 9B. Other Information</h2>"
+    "<p>Part-III amendment.</p>"
+    "</body></html>"
+)
+
+
+def _seed_instrument(
+    conn: psycopg.Connection[tuple],
+    *,
+    iid: int,
+    symbol: str,
+    cik: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+    if cik is not None:
+        conn.execute(
+            """
+            INSERT INTO external_identifiers (
+                instrument_id, provider, identifier_type, identifier_value,
+                is_primary, last_verified_at
+            )
+            VALUES (%s, 'sec', 'cik', %s, TRUE, NOW())
+            ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+                WHERE provider = 'sec' AND identifier_type = 'cik'
+            DO NOTHING
+            """,
+            (iid, cik),
+        )
+
+
+def _seed_pending_10k(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    cik: str = "0000999990",
+    form: str = "10-K",
+    filed_at: datetime | None = None,
+    primary_doc_url: str | None = None,
+) -> None:
+    if filed_at is None:
+        filed_at = datetime(2026, 3, 15, tzinfo=UTC)
+    if primary_doc_url is None:
+        primary_doc_url = (
+            f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{accession.replace('-', '')}/primary_doc.htm"
+        )
+    record_manifest_entry(
+        conn,
+        accession,
+        cik=cik,
+        form=form,
+        source="sec_10k",
+        subject_type="issuer",
+        subject_id=str(instrument_id),
+        instrument_id=instrument_id,
+        filed_at=filed_at,
+        primary_document_url=primary_doc_url,
+    )
+
+
+def _seed_filing_event(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    filing_type: str,
+    filing_date,
+    primary_doc_url: str,
+) -> None:
+    """Seed a filing_events row so _find_prior_plain_10k can locate the
+    fallback target during 10-K/A rescue tests."""
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            provider, provider_filing_id, instrument_id, filing_type,
+            filing_date, primary_document_url
+        )
+        VALUES ('sec', %s, %s, %s, %s, %s)
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO NOTHING
+        """,
+        (accession, instrument_id, filing_type, filing_date, primary_doc_url),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_then_reload():
+    from app.services.manifest_parsers import register_all_parsers
+
+    clear_registered_parsers()
+    register_all_parsers()
+    yield
+    clear_registered_parsers()
+    register_all_parsers()
+
+
+def _patch_fetch(monkeypatch, payload: str | None):
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: payload,
+    )
+
+
+def _patch_fetch_map(monkeypatch, payloads: dict[str, str | None]):
+    from app.providers.implementations import sec_edgar
+
+    def _fake(self, url: str):  # noqa: ARG001
+        return payloads.get(url)
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _fake)
+
+
+def _read_summary(conn, instrument_id):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT body, source_accession, filed_at FROM instrument_business_summary WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        return cur.fetchone()
+
+
+def _count_sections(conn, instrument_id, accession):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM instrument_business_summary_sections "
+            "WHERE instrument_id = %s AND source_accession = %s",
+            (instrument_id, accession),
+        )
+        return int(cur.fetchone()[0])
+
+
+# ---------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------
+
+
+def test_happy_path_parses_and_stores_raw(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifest worker drains a 10-K pending row: fetch → store_raw →
+    parse → blob + sections upserted; manifest row reflects parsed +
+    raw stored."""
+    iid = 10100001
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="ACME", cik="0000999991")
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999991-26-000001",
+        instrument_id=iid,
+        cik="0000999991",
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    assert stats.skipped_no_parser == 0
+
+    row = get_manifest_row(ebull_test_conn, "0000999991-26-000001")
+    assert row is not None
+    assert row.ingest_status == "parsed"
+    assert row.raw_status == "stored"
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert "industrial widgets" in body_row[0]
+    assert body_row[1] == "0000999991-26-000001"
+    assert body_row[2] is not None  # filed_at populated
+
+    # Raw stored under primary_doc.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT byte_count FROM filing_raw_documents "
+            "WHERE accession_number = '0000999991-26-000001' AND document_kind = 'primary_doc'"
+        )
+        raw = cur.fetchone()
+    assert raw is not None and raw[0] > 0
+
+
+def test_happy_path_fans_out_to_share_class_siblings(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two instruments sharing one CIK both receive blob + sections
+    from a single manifest row (10-K is entity-level; #1117 fan-out)."""
+    iid_a = 10100100
+    iid_b = 10100101
+    cik = "0000999992"
+    _seed_instrument(ebull_test_conn, iid=iid_a, symbol="ACMEA", cik=cik)
+    _seed_instrument(ebull_test_conn, iid=iid_b, symbol="ACMEB", cik=cik)
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999992-26-000002",
+        instrument_id=iid_a,
+        cik=cik,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    for iid in (iid_a, iid_b):
+        body_row = _read_summary(ebull_test_conn, iid)
+        assert body_row is not None, f"sibling iid={iid} missing blob"
+        assert body_row[1] == "0000999992-26-000002"
+        assert _count_sections(ebull_test_conn, iid, "0000999992-26-000002") > 0
+
+
+# ---------------------------------------------------------------------
+# 10-K/A fallback
+# ---------------------------------------------------------------------
+
+
+def test_10ka_with_item1_present_no_fallback(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """10-K/A whose body carries Item 1 directly parses without
+    triggering the prior-10-K fallback."""
+    iid = 10100200
+    cik = "0000999993"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AMNDR", cik=cik)
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999993-26-000003",
+        instrument_id=iid,
+        cik=cik,
+        form="10-K/A",
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert body_row[1] == "0000999993-26-000003"  # NOT a fallback acc
+
+
+def test_10ka_falls_back_to_prior_plain_10k(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When 10-K/A misses Item 1, the adapter fetches the prior plain
+    10-K from filing_events and persists the parent under the
+    fallback's accession + filed_at."""
+    iid = 10100300
+    cik = "0000999994"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="PTIII", cik=cik)
+
+    amendment_acc = "0000999994-26-000004"
+    fallback_acc = "0000999994-25-000010"
+    amendment_url = f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{amendment_acc.replace('-', '')}/amend.htm"
+    fallback_url = f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{fallback_acc.replace('-', '')}/original.htm"
+
+    from datetime import date
+
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=amendment_acc,
+        filing_type="10-K/A",
+        filing_date=date(2026, 4, 1),
+        primary_doc_url=amendment_url,
+    )
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=fallback_acc,
+        filing_type="10-K",
+        filing_date=date(2025, 3, 1),
+        primary_doc_url=fallback_url,
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession=amendment_acc,
+        instrument_id=iid,
+        cik=cik,
+        form="10-K/A",
+        filed_at=datetime(2026, 4, 1, tzinfo=UTC),
+        primary_doc_url=amendment_url,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            amendment_url: _FAKE_10KA_HTML_NO_ITEM_1,
+            fallback_url: _FAKE_10K_HTML,
+        },
+    )
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert body_row[1] == fallback_acc
+    # Filed-at is fallback's date.
+    assert body_row[2].year == 2025
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'primary_doc'",
+            (fallback_acc,),
+        )
+        assert cur.fetchone() is not None
+        cur.execute(
+            "SELECT 1 FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'primary_doc'",
+            (amendment_acc,),
+        )
+        assert cur.fetchone() is not None  # original raw stored too
+
+
+def test_10ka_no_prior_plain_10k_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """10-K/A misses Item 1 and no prior plain 10-K exists →
+    manifest row tombstoned with raw stored."""
+    iid = 10100400
+    cik = "0000999995"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="NOPRI", cik=cik)
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999995-26-000005",
+        instrument_id=iid,
+        cik=cik,
+        form="10-K/A",
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10KA_HTML_NO_ITEM_1)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999995-26-000005")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+
+
+def test_10ka_fallback_fetch_error_returns_failed_with_raw_stored(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the fallback fetch raises, the manifest returns ``failed``
+    (worker retries) with ``raw_status='stored'`` reflecting the
+    original 10-K/A raw that already landed."""
+    iid = 10100500
+    cik = "0000999996"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="FBFAI", cik=cik)
+
+    amendment_acc = "0000999996-26-000006"
+    fallback_acc = "0000999996-25-000020"
+    amendment_url = "https://example.test/amend.htm"
+    fallback_url = "https://example.test/fallback.htm"
+
+    from datetime import date
+
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=amendment_acc,
+        filing_type="10-K/A",
+        filing_date=date(2026, 5, 1),
+        primary_doc_url=amendment_url,
+    )
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=fallback_acc,
+        filing_type="10-K",
+        filing_date=date(2025, 4, 1),
+        primary_doc_url=fallback_url,
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession=amendment_acc,
+        instrument_id=iid,
+        cik=cik,
+        form="10-K/A",
+        primary_doc_url=amendment_url,
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    def _fake(self, url: str):  # noqa: ARG001
+        if url == fallback_url:
+            raise RuntimeError("synthetic fallback fetch error")
+        return _FAKE_10KA_HTML_NO_ITEM_1
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _fake)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, amendment_acc)
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "fallback fetch error" in row.error
+
+
+def test_10ka_fallback_empty_body_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iid = 10100600
+    cik = "0000999997"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="FBEMP", cik=cik)
+    amendment_acc = "0000999997-26-000007"
+    fallback_acc = "0000999997-25-000030"
+    amendment_url = "https://example.test/amend2.htm"
+    fallback_url = "https://example.test/fallback2.htm"
+
+    from datetime import date
+
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=amendment_acc,
+        filing_type="10-K/A",
+        filing_date=date(2026, 4, 15),
+        primary_doc_url=amendment_url,
+    )
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=fallback_acc,
+        filing_type="10-K",
+        filing_date=date(2025, 5, 15),
+        primary_doc_url=fallback_url,
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession=amendment_acc,
+        instrument_id=iid,
+        cik=cik,
+        form="10-K/A",
+        primary_doc_url=amendment_url,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            amendment_url: _FAKE_10KA_HTML_NO_ITEM_1,
+            fallback_url: None,
+        },
+    )
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, amendment_acc)
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+
+
+def test_10ka_fallback_parse_exception_returns_failed_with_raw_stored(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iid = 10100700
+    cik = "0000999998"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="FBPAR", cik=cik)
+    amendment_acc = "0000999998-26-000008"
+    fallback_acc = "0000999998-25-000040"
+    amendment_url = "https://example.test/amend3.htm"
+    fallback_url = "https://example.test/fallback3.htm"
+
+    from datetime import date
+
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=amendment_acc,
+        filing_type="10-K/A",
+        filing_date=date(2026, 6, 1),
+        primary_doc_url=amendment_url,
+    )
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=fallback_acc,
+        filing_type="10-K",
+        filing_date=date(2025, 6, 1),
+        primary_doc_url=fallback_url,
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession=amendment_acc,
+        instrument_id=iid,
+        cik=cik,
+        form="10-K/A",
+        primary_doc_url=amendment_url,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            amendment_url: _FAKE_10KA_HTML_NO_ITEM_1,
+            fallback_url: _FAKE_10K_HTML,
+        },
+    )
+
+    from app.services.manifest_parsers import sec_10k as parser_module
+
+    calls = {"count": 0}
+    real_extract = parser_module.extract_business_section
+
+    def _flaky(html):
+        calls["count"] += 1
+        if calls["count"] >= 2:  # the FALLBACK call raises
+            raise RuntimeError("synthetic fallback parse crash")
+        return real_extract(html)
+
+    monkeypatch.setattr(parser_module, "extract_business_section", _flaky)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, amendment_acc)
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "fallback parse error" in row.error
+
+
+def test_10ka_fallback_store_raw_failure_returns_failed_with_original_raw_stored(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fallback ``store_raw`` raise → ``failed`` with raw_status=stored;
+    the original amendment's raw row still exists; no parent write."""
+    iid = 10100800
+    cik = "0000999920"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="FBSTR", cik=cik)
+    amendment_acc = "0000999920-26-000080"
+    fallback_acc = "0000999920-25-000080"
+    amendment_url = "https://example.test/amend4.htm"
+    fallback_url = "https://example.test/fallback4.htm"
+
+    from datetime import date
+
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=amendment_acc,
+        filing_type="10-K/A",
+        filing_date=date(2026, 7, 1),
+        primary_doc_url=amendment_url,
+    )
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=fallback_acc,
+        filing_type="10-K",
+        filing_date=date(2025, 7, 1),
+        primary_doc_url=fallback_url,
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession=amendment_acc,
+        instrument_id=iid,
+        cik=cik,
+        form="10-K/A",
+        primary_doc_url=amendment_url,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            amendment_url: _FAKE_10KA_HTML_NO_ITEM_1,
+            fallback_url: _FAKE_10K_HTML,
+        },
+    )
+
+    from app.services.manifest_parsers import sec_10k as parser_module
+
+    real_store = parser_module.store_raw
+
+    def _flaky_store(conn, *, accession_number, **kwargs):
+        if accession_number == fallback_acc:
+            raise RuntimeError("synthetic fallback store_raw crash")
+        return real_store(conn, accession_number=accession_number, **kwargs)
+
+    monkeypatch.setattr(parser_module, "store_raw", _flaky_store)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, amendment_acc)
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is None  # no parent write
+
+    # Original raw still present.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM filing_raw_documents WHERE accession_number = %s",
+            (amendment_acc,),
+        )
+        assert cur.fetchone() is not None
+        cur.execute(
+            "SELECT 1 FROM filing_raw_documents WHERE accession_number = %s",
+            (fallback_acc,),
+        )
+        assert cur.fetchone() is None
+
+
+# ---------------------------------------------------------------------
+# Failure paths on the original fetch / parse
+# ---------------------------------------------------------------------
+
+
+def test_fetch_error_returns_failed_outcome(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iid = 10100900
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="FERR", cik="0000999921")
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999921-26-000009",
+        instrument_id=iid,
+        cik="0000999921",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    def _boom(self, url):  # noqa: ARG001
+        raise RuntimeError("network kaput")
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _boom)
+
+    before = datetime.now(tz=UTC)
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999921-26-000009")
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.error is not None and "fetch error" in row.error
+    assert row.next_retry_at is not None
+    delta = (row.next_retry_at - before).total_seconds()
+    assert 3300 < delta < 3900
+
+
+def test_empty_fetch_tombstones_without_raw_stored(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iid = 10101000
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="EMTY", cik="0000999922")
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999922-26-000010",
+        instrument_id=iid,
+        cik="0000999922",
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, None)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999922-26-000010")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM filing_raw_documents WHERE accession_number = '0000999922-26-000010'")
+        assert cur.fetchone() is None
+
+
+def test_plain_10k_no_item1_tombstones_with_raw_stored(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain 10-K (not amendment) whose body lacks Item 1 tombstones
+    immediately — the 10-K/A fallback path is reserved for the
+    amendment form."""
+    iid = 10101100
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="NOIT1", cik="0000999923")
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999923-26-000011",
+        instrument_id=iid,
+        cik="0000999923",
+        form="10-K",
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10KA_HTML_NO_ITEM_1)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999923-26-000011")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+
+
+# ---------------------------------------------------------------------
+# filed_at gate (Option C)
+# ---------------------------------------------------------------------
+
+
+def _seed_incumbent_summary(
+    conn,
+    *,
+    instrument_id: int,
+    body: str,
+    source_accession: str,
+    filed_at: datetime | None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO instrument_business_summary
+            (instrument_id, body, source_accession, filed_at)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (instrument_id) DO UPDATE SET
+            body = EXCLUDED.body,
+            source_accession = EXCLUDED.source_accession,
+            filed_at = EXCLUDED.filed_at
+        """,
+        (instrument_id, body, source_accession, filed_at),
+    )
+
+
+def test_filed_at_gate_suppresses_older_arrival(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Seed incumbent filed_at=2024 + accession=A1; manifest row
+    filed_at=2020 + accession=A0 → adapter returns parsed but body +
+    sections unchanged."""
+    iid = 10101200
+    cik = "0000999924"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="GATE", cik=cik)
+
+    _seed_incumbent_summary(
+        ebull_test_conn,
+        instrument_id=iid,
+        body="incumbent newer body sentinel " * 6,
+        source_accession="0000999924-24-000099",
+        filed_at=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999924-20-000099",
+        instrument_id=iid,
+        cik=cik,
+        filed_at=datetime(2020, 6, 1, tzinfo=UTC),
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999924-20-000099")
+    assert row is not None
+    assert row.ingest_status == "parsed"  # drain succeeded
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    # Body unchanged: the suppression kept the incumbent's body intact.
+    assert body_row[1] == "0000999924-24-000099"
+    assert body_row[0].startswith("incumbent newer body sentinel")
+
+
+def test_filed_at_gate_allows_newer_arrival(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iid = 10101300
+    cik = "0000999925"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="NEWR", cik=cik)
+    _seed_incumbent_summary(
+        ebull_test_conn,
+        instrument_id=iid,
+        body="incumbent older body sentinel " * 6,
+        source_accession="0000999925-20-000099",
+        filed_at=datetime(2020, 6, 1, tzinfo=UTC),
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999925-24-000099",
+        instrument_id=iid,
+        cik=cik,
+        filed_at=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert body_row[1] == "0000999925-24-000099"
+    assert "industrial widgets" in body_row[0]
+
+
+def test_same_day_accession_tiebreaker_picks_later(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two filings same filed_at but different accession numbers —
+    higher accession wins the (filed_at, accession) tuple gate."""
+    iid = 10101400
+    cik = "0000999926"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TIEBR", cik=cik)
+    _seed_incumbent_summary(
+        ebull_test_conn,
+        instrument_id=iid,
+        body="incumbent same-day earlier accession " * 5,
+        source_accession="0000999926-26-000001",
+        filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999926-26-000002",  # later accession
+        instrument_id=iid,
+        cik=cik,
+        filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert body_row[1] == "0000999926-26-000002"
+
+
+def test_same_day_accession_tiebreaker_suppresses_lower(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same filed_at, lower-accession arrival → suppressed; incumbent
+    higher-accession body must survive. Pin the reverse direction of
+    the (filed_at, accession) tuple gate."""
+    iid = 10101450
+    cik = "0000999926"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TIEBL", cik=cik)
+    _seed_incumbent_summary(
+        ebull_test_conn,
+        instrument_id=iid,
+        body="incumbent same-day higher accession sentinel " * 5,
+        source_accession="0000999926-26-000050",
+        filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999926-26-000049",  # LOWER accession arrives next
+        instrument_id=iid,
+        cik=cik,
+        filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert body_row[1] == "0000999926-26-000050"  # incumbent retained
+    assert body_row[0].startswith("incumbent same-day higher accession sentinel")
+
+
+def test_null_incumbent_filed_at_allows_write(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iid = 10101500
+    cik = "0000999927"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="NULLI", cik=cik)
+    _seed_incumbent_summary(
+        ebull_test_conn,
+        instrument_id=iid,
+        body="legacy row prior to filed_at column " * 5,
+        source_accession="legacy-accession",
+        filed_at=None,
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999927-26-000050",
+        instrument_id=iid,
+        cik=cik,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert body_row[1] == "0000999927-26-000050"
+
+
+def test_suppressed_parent_skips_sections_write(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Suppression branch must not DELETE+INSERT the incumbent's
+    sections — the older accession has nothing to contribute."""
+    iid = 10101600
+    cik = "0000999928"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="SKIPS", cik=cik)
+    incumbent_acc = "0000999928-24-000099"
+    _seed_incumbent_summary(
+        ebull_test_conn,
+        instrument_id=iid,
+        body="incumbent body " * 10,
+        source_accession=incumbent_acc,
+        filed_at=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+    # Seed a sections row under the incumbent accession.
+    ebull_test_conn.execute(
+        """
+        INSERT INTO instrument_business_summary_sections
+            (instrument_id, source_accession, section_order, section_key,
+             section_label, body)
+        VALUES (%s, %s, 1, 'general', 'Overview', 'sentinel section body')
+        """,
+        (iid, incumbent_acc),
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999928-20-000099",
+        instrument_id=iid,
+        cik=cik,
+        filed_at=datetime(2020, 6, 1, tzinfo=UTC),
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    # Incumbent sections still present.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT body FROM instrument_business_summary_sections WHERE instrument_id = %s AND source_accession = %s",
+            (iid, incumbent_acc),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "sentinel section body"
+
+    # No sections under the older accession.
+    assert _count_sections(ebull_test_conn, iid, "0000999928-20-000099") == 0
+
+
+# ---------------------------------------------------------------------
+# Upsert exception discrimination + partial-fanout rollback
+# ---------------------------------------------------------------------
+
+
+def test_transient_upsert_exception_retries(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iid = 10101700
+    cik = "0000999929"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TRANS", cik=cik)
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999929-26-000077",
+        instrument_id=iid,
+        cik=cik,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    from app.services.manifest_parsers import sec_10k as parser_module
+
+    def _raising(*args, **kwargs):  # noqa: ARG001
+        raise psycopg.errors.SerializationFailure("synthetic serialisation failure")
+
+    monkeypatch.setattr(parser_module, "upsert_business_summary", _raising)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999929-26-000077")
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "SerializationFailure" in row.error
+
+
+def test_deterministic_upsert_exception_tombstones(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iid = 10101800
+    cik = "0000999930"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="DETER", cik=cik)
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999930-26-000078",
+        instrument_id=iid,
+        cik=cik,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    from app.services.manifest_parsers import sec_10k as parser_module
+
+    def _raising(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic deterministic upsert error")
+
+    monkeypatch.setattr(parser_module, "upsert_business_summary", _raising)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999930-26-000078")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+    assert row.error is not None and "RuntimeError" in row.error
+
+
+def test_partial_fanout_rollback_on_deterministic_error(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sibling A upsert succeeds, sibling B raises a deterministic
+    error → savepoint rolls back A's write too; neither sibling has a
+    new blob, manifest tombstones."""
+    cik = "0000999931"
+    iid_a = 10101901
+    iid_b = 10101902
+    _seed_instrument(ebull_test_conn, iid=iid_a, symbol="FAA", cik=cik)
+    _seed_instrument(ebull_test_conn, iid=iid_b, symbol="FBB", cik=cik)
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999931-26-000091",
+        instrument_id=iid_a,
+        cik=cik,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    from app.services.manifest_parsers import sec_10k as parser_module
+
+    real_upsert = parser_module.upsert_business_summary
+
+    def _flaky(conn, *, instrument_id, **kwargs):
+        if instrument_id == iid_b:
+            raise RuntimeError("synthetic sibling B upsert error")
+        return real_upsert(conn, instrument_id=instrument_id, **kwargs)
+
+    monkeypatch.setattr(parser_module, "upsert_business_summary", _flaky)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999931-26-000091")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    # Critical: sibling A's blob is NOT present (savepoint rolled back).
+    for iid in (iid_a, iid_b):
+        body_row = _read_summary(ebull_test_conn, iid)
+        assert body_row is None, f"sibling iid={iid} should not have a blob after rollback"
+
+
+def test_section_extraction_exception_does_not_break_parent_write(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sections-extractor crash must not propagate; the parent blob
+    still writes; sections table stays empty for this accession."""
+    iid = 10102000
+    cik = "0000999932"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="SECRX", cik=cik)
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999932-26-000201",
+        instrument_id=iid,
+        cik=cik,
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, _FAKE_10K_HTML)
+
+    from app.services.manifest_parsers import sec_10k as parser_module
+
+    def _crash(_html):
+        raise RuntimeError("synthetic sections extractor crash")
+
+    monkeypatch.setattr(parser_module, "extract_business_sections", _crash)
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, "0000999932-26-000201")
+    assert row is not None
+    assert row.ingest_status == "parsed"
+    assert row.raw_status == "stored"
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert "industrial widgets" in body_row[0]
+
+    assert _count_sections(ebull_test_conn, iid, "0000999932-26-000201") == 0
+
+
+def test_tombstone_path_does_not_mutate_existing_body_summary_row(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the manifest path tombstones (parse miss, empty fetch,
+    deterministic upsert error), it MUST NOT call
+    ``record_parse_attempt`` — that helper mutates ``source_accession``
+    on an existing row and would corrupt the incumbent's provenance.
+    Pin the invariant: pre-seed a healthy incumbent, tombstone an
+    older accession's manifest row, and verify the incumbent body +
+    source_accession survive."""
+    iid = 10102100
+    cik = "0000999933"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="TMBS", cik=cik)
+    _seed_incumbent_summary(
+        ebull_test_conn,
+        instrument_id=iid,
+        body="healthy incumbent narrative " * 6,
+        source_accession="0000999933-24-000001",
+        filed_at=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession="0000999933-20-000077",
+        instrument_id=iid,
+        cik=cik,
+        filed_at=datetime(2020, 6, 1, tzinfo=UTC),
+    )
+    ebull_test_conn.commit()
+
+    _patch_fetch(monkeypatch, None)  # empty body → tombstone
+
+    run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert body_row[1] == "0000999933-24-000001"  # incumbent untouched
+    assert body_row[0].startswith("healthy incumbent narrative")
+
+
+# ---------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------
+
+
+def test_parser_registered_via_register_all() -> None:
+    from app.services.manifest_parsers import register_all_parsers
+
+    assert "sec_10k" in registered_parser_sources()
+    clear_registered_parsers()
+    assert "sec_10k" not in registered_parser_sources()
+    register_all_parsers()
+    assert "sec_10k" in registered_parser_sources()


### PR DESCRIPTION
## What

Final adapter in the manifest-worker parser rollout (#1126 / #1128 / #1129 / #1130 / #1133 / #1134 series). Wires `sec_10k` into `register_all_parsers()` so `10-K` / `10-K/A` rows in `sec_filing_manifest` drain through the single-writer manifest path. 8 of 9 SEC sources had manifest adapters; this closes the last one (10-Q remains blocked on #414).

## Why

Manifest worker drains `filed_at ASC`. Naive `ON CONFLICT (instrument_id) DO UPDATE` would render OLDEST → NEWEST per instrument during first-install drain — operator briefly sees the 2018 Item 1 narrative before the 2024 update fires. Option C makes the UPDATE conditional on `(filed_at, source_accession)` so stale arrivals are no-ops and only monotonic-or-equal arrivals update.

## Changes

- `sql/148_instrument_business_summary_filed_at.sql` — nullable `filed_at TIMESTAMPTZ` column + UTC-stable backfill (`AT TIME ZONE 'UTC'` rather than session-dependent `::timestamptz`) + index.
- `app/services/business_summary.py::upsert_business_summary` — required `filed_at: datetime | None` kwarg; returns `Literal['inserted', 'updated', 'suppressed']`; conditional ON CONFLICT gate on the `(filed_at, source_accession)` tuple. Legacy `ingest_business_summaries` + `_find_prior_plain_10k` thread `filing_date` through; `_filing_date_to_filed_at` converts DATE → midnight-UTC TIMESTAMPTZ.
- `app/services/manifest_parsers/sec_10k.py` — new per-accession adapter. Shape mirrors `def14a.py` (share-class fan-out via `siblings_for_issuer_cik`, union'd with the manifest's `instrument_id` for fail-closed) + `eight_k.py` (raw-payload contract). One batched savepoint wraps sibling resolution + write batch; nested savepoint absorbs best-effort sections failures.
- `app/services/manifest_parsers/__init__.py` — wires the new adapter into `register_all_parsers()`.
- `tests/test_manifest_parser_sec_10k.py` — 24 tests.
- `tests/test_fetch_document_text_callers.py` — extends the allow-list to include every manifest-worker adapter + `sec_pipelined_fetcher` (the pin was failing on main before this PR; fix-in-scope per CLAUDE.md feedback memory).

## Security model

No new external boundary. Existing SEC fetcher rate-limit + identity discipline applies. Schema migration is additive (nullable column + UTC-stable backfill); no destructive changes to operator-visible rows.

## Test plan

- [x] `uv run ruff check .` clean.
- [x] `uv run ruff format --check .` clean.
- [x] `uv run pyright` clean.
- [x] `tests/test_manifest_parser_sec_10k.py` — 24 passed.
- [x] `tests/test_business_summary*.py` + adjacent manifest-parser suites — 70 passed.
- [x] Migration applied to dev DB.
- [ ] Smoke vs AAPL / GME / MSFT / JPM / HD after merge via `POST /jobs/sec_rebuild/run {"source": "sec_10k"}` — operator follow-up.

## Codex checkpoints

- **Checkpoint 1 (spec)**: 4 rounds. 3 BLOCKING (share-class fan-out, fallback raw audit, fallback sections) + 2 HIGH (filed_at tie-break, parse-miss tombstone semantics) + 1 MEDIUM (fallback fetch/parse failure policy, DATE→TIMESTAMPTZ conversion) + doc-consistency findings addressed.
- **Checkpoint 2 (branch diff)**: 1 HIGH (sibling-set union with `instrument_id`) + 1 MEDIUM (`AT TIME ZONE 'UTC'` backfill) + 1 LOW (reverse same-day tie-break test) addressed.

## Spec

`docs/superpowers/specs/2026-05-13-1151-10k-manifest-parser.md`.

## Conscious tradeoffs

- Legacy `ingest_business_summaries` is NOT retired in this PR — both paths coexist until operator-confirmed parity. Retirement is a follow-up.
- `record_parse_attempt`'s mutation hazard on `source_accession` is documented but unfixed — the manifest path simply doesn't call it. Tech-debt eligible if it bites operator-visible figures.
- Sections-orphan accumulation under suppressed accessions is acceptable (incumbent stays, older accessions' sections never land).

Closes #1151. Refs #873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)