### PR TITLE
docs(sec-edgar): refresh manifest-parser matrix + Option C rule + stranded-source map

### DIFF
--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -595,10 +595,54 @@ Every manifest parser MUST follow this contract on its upsert except: block. The
 |---|---|
 | 8-K (`app/services/manifest_parsers/eight_k.py`) | `_write_tombstone` row in `eight_k_filings` |
 | Form 3 / Form 4 (`app/services/manifest_parsers/insider_345.py`) | `_write_tombstone` / `_write_form_3_tombstone` row in `insider_filings` |
+| Form 5 (`app/services/manifest_parsers/insider_345.py`, `_parse_form5`) | `_write_tombstone(document_type='5')` row in `insider_filings`; observations land as `source='form4'` (enum lacks `form5`) — provenance preserved via `insider_filings.document_type='5'` JOIN |
 | 13D/G (`app/services/manifest_parsers/sec_13dg.py`) | `_record_ingest_attempt(status='failed')` in `blockholder_filings_ingest_log` |
 | DEF 14A (`app/services/manifest_parsers/def14a.py`) | `_record_ingest_attempt(status='failed')` in `def14a_ingest_log` |
+| 13F-HR (`app/services/manifest_parsers/sec_13f_hr.py`) | `_record_ingest_attempt(status='failed')` in `institutional_holdings_ingest_log`; PRN drop + 2023-01-03 VALUE cutover applied at parser layer |
+| NPORT-P (`app/services/manifest_parsers/sec_n_port.py`) | `_record_ingest_attempt(status='failed')` in `n_port_ingest_log` |
+| 10-K (`app/services/manifest_parsers/sec_10k.py`) | Returns `ParseOutcome(status='tombstoned')` only; manifest path does NOT call `record_parse_attempt` (the legacy helper mutates `source_accession` on UPDATE and would corrupt incumbent provenance). Manifest row's `tombstoned` state owns retry semantics. |
 
 Legacy ingesters (`ingest_insider_transactions`) apply the same discrimination on the upsert phase: deterministic writes `_write_tombstone` in a fresh tx so the candidate selector doesn't re-pick the accession on every tick; transient rolls back and continues so the next tick retries.
+
+### 11.4 Option C — `(filed_at, source_accession)` ON CONFLICT gate (#1151)
+
+The manifest worker drains `filed_at ASC` (oldest first; pinned in `iter_pending`). When a manifest adapter writes to a typed table keyed PER INSTRUMENT (one row per instrument across many filings, not one row per accession), a naive `ON CONFLICT (instrument_id) DO UPDATE` would render OLDEST → NEWEST per-instrument during first-install drain — final state correct but operator briefly sees stale-then-fresh.
+
+The fix: gate the UPDATE on the `(filed_at, source_accession)` tuple. SEC accession numbers are temporally ordered within an issuer, so they serve as a deterministic same-day tie-breaker.
+
+```sql
+ON CONFLICT (instrument_id) DO UPDATE SET ...
+WHERE
+    target_table.filed_at IS NULL
+    OR (EXCLUDED.filed_at IS NOT NULL
+        AND (EXCLUDED.filed_at, EXCLUDED.source_accession)
+            >= (target_table.filed_at, target_table.source_accession))
+RETURNING (xmax = 0) AS inserted
+```
+
+NULL handling:
+- Incumbent NULL → any dated write wins (legacy row re-baseline).
+- Incoming NULL against dated incumbent → suppressed (fail closed; no legitimate caller passes NULL post-Option-C).
+
+Return shape: `Literal['inserted', 'updated', 'suppressed']`. `cur.fetchone() is None` ⇒ suppressed; else `row[0]` distinguishes insert vs update.
+
+When to apply:
+- Adapter writes to a typed table keyed by instrument_id (not accession). Examples: `instrument_business_summary`.
+- NOT needed for adapters whose typed table is keyed by accession + child rows (Form 4, 13F, 13D/G, NPORT-P, DEF 14A — no per-instrument single-row collapse, no overwrite hazard).
+
+Adopted in #1152 (`instrument_business_summary` + `filed_at` column added by sql/148). If a future adapter writes a per-instrument typed table, apply the same gate.
+
+### 11.5 Stranded ManifestSource entries
+
+`ManifestSource` enum (sql/118 CHECK + `app/services/sec_manifest.py:106`) lists 14 values. Three carry no manifest parser by design:
+
+| Source | Why no parser |
+|---|---|
+| `sec_xbrl_facts` | XBRL Company Facts ingested via bulk Company Facts API path, NOT per-filing manifest dispatch. |
+| `sec_n_csr` | EdgarTools `FundShareholderReport` exposes only OEF iXBRL fund-level facts (NAV / expense ratio / top-holdings %); per-issuer Schedule of Investments lives in free-form HTML/PDF, not XBRL. CUSIP-resolved per-issuer holdings unextractable. Resolved as "not technically feasible as scoped" — see #918 closing comment. Discovery may still write manifest rows that never drain. Tech-debt eligible: either remove from `ManifestSource` Literal + `_FORM_TO_SOURCE` map, OR register a synth "no-op tombstone" parser. |
+| `sec_10q` | Blocked on #414 — the fundamentals ingest redesign owns the 10-Q parser. |
+
+`finra_short_interest` is not stranded — split tickets #915 (bimonthly) + #916 (RegSHO daily) are open. Parent #845 closed.
 
 ## 10. Sources
 


### PR DESCRIPTION
## What

Skill-drift catch-up. The manifest-parser tombstone-target matrix in `.claude/skills/data-sources/sec-edgar.md` §11.3 was missing four entries that shipped across previous PRs (Form 5 / #1134, 13F-HR + NPORT-P / #1133, 10-K / #1152). The Option C `(filed_at, source_accession)` ON CONFLICT gate introduced by #1151 was not pinned anywhere. Stranded `ManifestSource` enum entries (`sec_xbrl_facts` by design, `sec_n_csr` infeasible per #918, `sec_10q` blocked on #414) were undocumented.

This PR closes those three gaps. Doc-only.

## Why

Operator + future-author flow on questions like "are we done with US sources?" had to grep through six PRs + the closed #918 to reconstruct ground truth. The skill is now the single point of authority.

## Changes

Single file: `.claude/skills/data-sources/sec-edgar.md`.

- §11.3: 4 new rows (Form 5, 13F-HR, NPORT-P, 10-K). 10-K row explicitly notes the manifest path does NOT call `record_parse_attempt` (`source_accession` mutation hazard).
- §11.4 (new): Option C cross-cutting rule. Includes the canonical SQL pattern, NULL handling, the trinary return contract (`'inserted' | 'updated' | 'suppressed'`), and applicability conditions (typed table keyed per-instrument vs per-accession).
- §11.5 (new): stranded source map — three currently-unregistered sources + the reason each.

## Security model

Doc-only. No runtime path touched.

## Test plan

- [x] Manual review of the matrix against `app/services/manifest_parsers/__init__.py::register_all_parsers`.
- [x] Cross-checked Option C SQL against the production form in `app/services/business_summary.py::upsert_business_summary`.
- [x] Cross-checked stranded-source claims against:
  - `sec_xbrl_facts`: Company Facts bulk path in `sec_companyfacts_ingest.py`.
  - `sec_n_csr`: #918 closing comment.
  - `sec_10q`: #414 OPEN status.

Refs #437.
Refs #1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)