### PR TITLE
feat(#1155): Layer 1/2/3 + sec_rebuild wiring

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -297,6 +297,16 @@ from app.workers import scheduler as _scheduler  # noqa: E402
 _INVOKERS[_scheduler.JOB_FILINGS_HISTORY_SEED] = _scheduler.filings_history_seed
 _INVOKERS[_scheduler.JOB_SEC_FIRST_INSTALL_DRAIN] = _scheduler.sec_first_install_drain
 
+# #1155 — Layer 1 / 2 / 3 freshness redesign wiring + sec_rebuild
+# manual triage. Layers 1/2/3 are scheduled (SCHEDULED_JOBS rows in
+# scheduler.py); sec_rebuild is manual-trigger-only (params declared
+# in MANUAL_TRIGGER_JOB_METADATA at param_metadata.py; source-lock
+# binding in MANUAL_TRIGGER_JOB_SOURCES at sources.py).
+_INVOKERS[_scheduler.JOB_SEC_ATOM_FAST_LANE] = _adapt_zero_arg(_scheduler.sec_atom_fast_lane)
+_INVOKERS[_scheduler.JOB_SEC_DAILY_INDEX_RECONCILE] = _adapt_zero_arg(_scheduler.sec_daily_index_reconcile)
+_INVOKERS[_scheduler.JOB_SEC_PER_CIK_POLL] = _adapt_zero_arg(_scheduler.sec_per_cik_poll)
+_INVOKERS[_scheduler.JOB_SEC_REBUILD] = _scheduler.sec_rebuild  # params-taking, no _adapt_zero_arg
+
 # ---------------------------------------------------------------------------
 # Bulk-archive Phase C ingester invokers (#1027 — #1020)
 # ---------------------------------------------------------------------------

--- a/app/jobs/sec_per_cik_poll.py
+++ b/app/jobs/sec_per_cik_poll.py
@@ -15,14 +15,18 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 import psycopg
 
 from app.providers.implementations.sec_submissions import HttpGet, check_freshness
 from app.services.data_freshness import (
+    FreshnessRow,
+    cadence_for,
     record_poll_outcome,
     subjects_due_for_poll,
+    subjects_due_for_recheck,
 )
 from app.services.sec_manifest import ManifestSource, record_manifest_entry
 
@@ -34,6 +38,118 @@ class PerCikPollStats:
     subjects_polled: int
     new_filings_recorded: int
     poll_errors: int
+    # #1155 G13 — separate counters for the recheck reader path
+    # (subjects_due_for_recheck) so operator can confirm both reader
+    # paths are draining. recheck_* counts subjects whose state was
+    # 'never_filed' or 'error' at the start of the tick.
+    recheck_subjects_polled: int = 0
+    recheck_new_filings_recorded: int = 0
+
+
+def _probe_subject(
+    conn: psycopg.Connection[Any],
+    subject: FreshnessRow,
+    *,
+    http_get: HttpGet,
+) -> tuple[int, bool]:
+    """Probe one subject. Returns ``(new_filings_recorded, errored)``.
+
+    Centralises the per-subject body so the poll and recheck paths
+    share identical fetch + UPSERT + outcome-write logic. The caller
+    increments its own stat counters based on the return.
+
+    Caller MUST ensure ``subject.cik is not None`` (FINRA universe
+    singleton has no submissions.json to poll). Asserted defensively
+    to narrow the type for ``check_freshness``.
+    """
+    assert subject.cik is not None, "_probe_subject requires non-None cik"
+    sources_to_check: set[ManifestSource] | None = {subject.source} if subject.source else None
+    try:
+        delta = check_freshness(
+            http_get,
+            cik=subject.cik,
+            last_known_filing_id=subject.last_known_filing_id,
+            sources=sources_to_check,
+        )
+    except Exception as exc:
+        logger.warning(
+            "per-cik poll: check_freshness raised for cik=%s source=%s: %s",
+            subject.cik,
+            subject.source,
+            exc,
+        )
+        record_poll_outcome(
+            conn,
+            subject_type=subject.subject_type,
+            subject_id=subject.subject_id,
+            source=subject.source,
+            outcome="error",
+            error=f"{type(exc).__name__}: {exc}"[:500],
+            cik=subject.cik,
+            instrument_id=subject.instrument_id,
+        )
+        return (0, True)
+
+    # UPSERT manifest rows for the new filings
+    recorded = 0
+    for row in delta.new_filings:
+        if row.source is None:
+            continue
+        try:
+            record_manifest_entry(
+                conn,
+                row.accession_number,
+                cik=row.cik,
+                form=row.form,
+                source=row.source,
+                subject_type=subject.subject_type,
+                subject_id=subject.subject_id,
+                instrument_id=subject.instrument_id,
+                filed_at=row.filed_at,
+                accepted_at=row.accepted_at,
+                primary_document_url=row.primary_document_url,
+                is_amendment=row.is_amendment,
+            )
+            recorded += 1
+        except ValueError as exc:
+            logger.warning("per-cik poll: rejected accession=%s: %s", row.accession_number, exc)
+
+    # Update scheduler outcome. #1155 G13 — never_filed rows that
+    # return no new filings must STAY in the recheck queue (state
+    # never_filed) rather than transitioning to 'current'. Otherwise
+    # the recheck path's whole point is defeated — every never_filed
+    # row leaves the recheck lane on its first poll regardless of
+    # whether the subject actually filed.
+    outcome: str
+    next_recheck_at: datetime | None = None
+    if delta.new_filings:
+        outcome = "new_data"
+    elif subject.state == "never_filed":
+        outcome = "never"
+        # Keep the row in the recheck queue at the source's cadence.
+        next_recheck_at = datetime.now(tz=UTC) + cadence_for(subject.source)
+    else:
+        # state in ('current', 'expected_filing_overdue', 'error') with
+        # no new filings → row is 'current' (error recovers; overdue
+        # still tracking until next predicted filing).
+        outcome = "current"
+
+    last_known = delta.new_filings[0].accession_number if delta.new_filings else subject.last_known_filing_id
+    last_filed = delta.last_filed_at if delta.last_filed_at else subject.last_known_filed_at
+    record_poll_outcome(
+        conn,
+        subject_type=subject.subject_type,
+        subject_id=subject.subject_id,
+        source=subject.source,
+        outcome=outcome,  # type: ignore[arg-type]
+        last_known_filing_id=last_known,
+        last_known_filed_at=last_filed,
+        new_filings_since=len(delta.new_filings),
+        next_recheck_at=next_recheck_at,
+        cik=subject.cik,
+        instrument_id=subject.instrument_id,
+    )
+    return (recorded, False)
 
 
 def run_per_cik_poll(
@@ -46,99 +162,72 @@ def run_per_cik_poll(
     """One per-CIK poll cycle. For each subject due, call submissions.json
     and UPSERT manifest + scheduler.
 
+    Drains BOTH reader paths (#1155 G13):
+
+    * ``subjects_due_for_poll`` — 'current' / 'expected_filing_overdue'
+      rows past their ``expected_next_at``. Gets the dominant budget
+      share so steady-state polls are never starved by error backlog.
+    * ``subjects_due_for_recheck`` — 'never_filed' / 'error' rows past
+      their ``next_recheck_at``. Gets the remaining ~1/3 budget so the
+      recheck path drains at a guaranteed rate.
+
+    Total subjects probed never exceeds ``max_subjects``. For
+    ``max_subjects=100`` → ``poll=66, recheck=34``. For ``max_subjects=1``
+    → ``poll=0, recheck=1`` (degenerate but bounded).
+
     Pagination (``has_more_in_files`` for first-install / rebuild
     paths) is NOT followed here — that lives in the dedicated drain
     + rebuild jobs (#871, #872) which have their own throughput
     budgets. The per-CIK steady-state path uses only the recent array.
     """
+    # #1155 G13 — bounded total budget split: 2/3 to poll, ~1/3 to
+    # recheck. No max(1, ...) floor so max_subjects=1 stays bounded
+    # at total=1 (poll=0, recheck=1).
+    poll_budget = max_subjects * 2 // 3
+    recheck_budget = max_subjects - poll_budget
+
     subjects_polled = 0
     new_filings_recorded = 0
     poll_errors = 0
+    recheck_subjects_polled = 0
+    recheck_new_filings_recorded = 0
 
-    due = list(subjects_due_for_poll(conn, source=source, limit=max_subjects))
+    poll_due = list(subjects_due_for_poll(conn, source=source, limit=poll_budget)) if poll_budget > 0 else []
+    recheck_due = (
+        list(subjects_due_for_recheck(conn, source=source, limit=recheck_budget)) if recheck_budget > 0 else []
+    )
 
-    for subject in due:
+    for subject in poll_due:
         if subject.cik is None:
             # FINRA universe singleton — no submissions.json poll
             continue
         subjects_polled += 1
-
-        sources_to_check: set[ManifestSource] | None = {subject.source} if subject.source else None
-        try:
-            delta = check_freshness(
-                http_get,
-                cik=subject.cik,
-                last_known_filing_id=subject.last_known_filing_id,
-                sources=sources_to_check,
-            )
-        except Exception as exc:
-            logger.warning(
-                "per-cik poll: check_freshness raised for cik=%s source=%s: %s",
-                subject.cik,
-                subject.source,
-                exc,
-            )
-            record_poll_outcome(
-                conn,
-                subject_type=subject.subject_type,
-                subject_id=subject.subject_id,
-                source=subject.source,
-                outcome="error",
-                error=f"{type(exc).__name__}: {exc}"[:500],
-                cik=subject.cik,
-                instrument_id=subject.instrument_id,
-            )
+        recorded, errored = _probe_subject(conn, subject, http_get=http_get)
+        new_filings_recorded += recorded
+        if errored:
             poll_errors += 1
+
+    for subject in recheck_due:
+        if subject.cik is None:
             continue
-
-        # UPSERT manifest rows for the new filings
-        for row in delta.new_filings:
-            if row.source is None:
-                continue
-            try:
-                record_manifest_entry(
-                    conn,
-                    row.accession_number,
-                    cik=row.cik,
-                    form=row.form,
-                    source=row.source,
-                    subject_type=subject.subject_type,
-                    subject_id=subject.subject_id,
-                    instrument_id=subject.instrument_id,
-                    filed_at=row.filed_at,
-                    accepted_at=row.accepted_at,
-                    primary_document_url=row.primary_document_url,
-                    is_amendment=row.is_amendment,
-                )
-                new_filings_recorded += 1
-            except ValueError as exc:
-                logger.warning("per-cik poll: rejected accession=%s: %s", row.accession_number, exc)
-
-        # Update scheduler outcome
-        outcome: str = "new_data" if delta.new_filings else "current"
-        last_known = delta.new_filings[0].accession_number if delta.new_filings else subject.last_known_filing_id
-        last_filed = delta.last_filed_at if delta.last_filed_at else subject.last_known_filed_at
-        record_poll_outcome(
-            conn,
-            subject_type=subject.subject_type,
-            subject_id=subject.subject_id,
-            source=subject.source,
-            outcome=outcome,  # type: ignore[arg-type]
-            last_known_filing_id=last_known,
-            last_known_filed_at=last_filed,
-            new_filings_since=len(delta.new_filings),
-            cik=subject.cik,
-            instrument_id=subject.instrument_id,
-        )
+        recheck_subjects_polled += 1
+        recorded, errored = _probe_subject(conn, subject, http_get=http_get)
+        recheck_new_filings_recorded += recorded
+        if errored:
+            poll_errors += 1
 
     logger.info(
-        "per-cik poll: subjects=%d new_filings=%d errors=%d",
+        "per-cik poll: subjects=%d new_filings=%d errors=%d recheck_subjects=%d recheck_new_filings=%d",
         subjects_polled,
         new_filings_recorded,
         poll_errors,
+        recheck_subjects_polled,
+        recheck_new_filings_recorded,
     )
     return PerCikPollStats(
         subjects_polled=subjects_polled,
         new_filings_recorded=new_filings_recorded,
         poll_errors=poll_errors,
+        recheck_subjects_polled=recheck_subjects_polled,
+        recheck_new_filings_recorded=recheck_new_filings_recorded,
     )

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -135,12 +135,36 @@ class JobSourceRegistryError(RuntimeError):
 
     Two failure modes:
 
-    * Conflict: the same job_name appears in both registries with
-      different effective sources.
+    * Conflict: the same job_name appears in multiple registries
+      (SCHEDULED_JOBS / _BOOTSTRAP_STAGE_SPECS / MANUAL_TRIGGER_JOB_SOURCES)
+      with different effective sources.
     * Coverage gap: a bootstrap stage references a job_name not in
       either registry (only triggerable if the bootstrap stage table
       is hand-edited inconsistently).
     """
+
+
+# ---------------------------------------------------------------------------
+# MANUAL_TRIGGER_JOB_SOURCES — source-lock coverage for manual-only jobs.
+# ---------------------------------------------------------------------------
+#
+# Sibling to the bootstrap stage registry: jobs that are operator-
+# triggered (not scheduled, not bootstrap-dispatched) still need a
+# source-lock binding so JobLock acquisition succeeds. Without this,
+# source_for() KeyErrors at dispatch and the manual API path 202s but
+# fails before the wrapper body runs.
+#
+# Companion param-metadata registry lives at
+# app/services/processes/param_metadata.py MANUAL_TRIGGER_JOB_METADATA.
+# Every entry needs an _INVOKERS registration + matching metadata entry;
+# tests/test_layer_123_wiring.py covers the triangle.
+
+MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
+    # sec_rebuild — operator manual triage (#1155). Per-CIK
+    # check_freshness probes against SEC submissions.json; shares the
+    # 10 req/s SEC fair-use budget with every other sec_rate consumer.
+    "sec_rebuild": "sec_rate",
+}
 
 
 def _build_job_name_to_source() -> dict[str, Lane]:
@@ -178,11 +202,26 @@ def _build_job_name_to_source() -> dict[str, Lane]:
                 f"job_name={stage.job_name!r}: scheduled.source={existing!r} vs bootstrap.lane={bootstrap_source!r}"
             )
 
+    # Pass 3: manual-trigger-only jobs (#1155). sec_rebuild + future
+    # operator-triggered tools without a cadence — they need source-lock
+    # coverage because JobLock acquisition resolves through source_for(),
+    # which would otherwise KeyError. Companion param-metadata registry
+    # lives at app/services/processes/param_metadata.py
+    # MANUAL_TRIGGER_JOB_METADATA.
+    for job_name, manual_source in MANUAL_TRIGGER_JOB_SOURCES.items():
+        existing = registry.get(job_name)
+        if existing is None:
+            registry[job_name] = manual_source
+        elif existing != manual_source:
+            conflicts.append(
+                f"job_name={job_name!r}: registered.source={existing!r} vs manual-trigger.source={manual_source!r}"
+            )
+
     if conflicts:
         raise JobSourceRegistryError(
-            "Source/lane conflict between SCHEDULED_JOBS and _BOOTSTRAP_STAGE_SPECS:\n  - "
+            "Source/lane conflict between SCHEDULED_JOBS, _BOOTSTRAP_STAGE_SPECS, and MANUAL_TRIGGER_JOB_SOURCES:\n  - "
             + "\n  - ".join(conflicts)
-            + "\nFix the offending entries so a job_name resolves to the same source from both paths."
+            + "\nFix the offending entries so a job_name resolves to the same source from every path."
         )
 
     return registry
@@ -236,6 +275,7 @@ def source_for(job_name: str) -> Lane:
 
 
 __all__ = [
+    "MANUAL_TRIGGER_JOB_SOURCES",
     "JobInvoker",
     "JobSourceRegistryError",
     "Lane",

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -178,6 +178,108 @@ JOB_INTERNAL_KEYS: dict[str, frozenset[str]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# MANUAL_TRIGGER_JOB_METADATA — operator params for manual-only jobs.
+# ---------------------------------------------------------------------------
+#
+# Sibling to JOB_INTERNAL_KEYS for the inverse case: jobs that are
+# operator-triggered (not orchestrator-dispatched) AND need full
+# ParamMetadata validation via the manual API path, but have no
+# cadence so they don't belong in SCHEDULED_JOBS. _lookup_metadata
+# falls through to this dict so validate_job_params(allow_internal_keys=
+# False) accepts the declared keys.
+#
+# Companion source-lock registry lives at app/jobs/sources.py
+# MANUAL_TRIGGER_JOB_SOURCES — JobLock would otherwise KeyError at
+# acquisition because its registry is built only from SCHEDULED_JOBS +
+# _BOOTSTRAP_STAGE_SPECS.
+#
+# Adding to this dict crosses no discipline boundary by itself, but
+# every entry needs a matching MANUAL_TRIGGER_JOB_SOURCES entry +
+# _INVOKERS registration; tests/test_layer_123_wiring.py covers the
+# triangle.
+
+MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
+    # sec_rebuild — operator manual triage (#1155). Resets manifest +
+    # scheduler rows for a scope, then (default) runs a discovery pass
+    # against SEC submissions.json to fill missed accessions.
+    "sec_rebuild": (
+        ParamMetadata(
+            name="instrument_id",
+            label="Instrument ID",
+            help_text=(
+                "Numeric instrument_id from the instruments table. "
+                "Triggers rebuild for every (subject, source) triple "
+                "associated with this instrument."
+            ),
+            field_type="int",
+            default=None,
+            advanced_group=False,
+            min_value=1,
+        ),
+        ParamMetadata(
+            name="filer_cik",
+            label="Filer CIK",
+            help_text=(
+                "CIK of an institutional or blockholder filer. Triggers "
+                "rebuild for all that filer's 13F-HR / 13D / 13G "
+                "history. Typeahead resolves company-name/symbol to CIK."
+            ),
+            field_type="cik",
+            default=None,
+            advanced_group=False,
+        ),
+        ParamMetadata(
+            name="source",
+            label="ManifestSource",
+            help_text=(
+                "Universe-wide rebuild for one source "
+                "(sec_form4 / sec_13d / etc). Most expensive option. "
+                "Note: sec_xbrl_facts / sec_n_csr / sec_10q / "
+                "finra_short_interest may resolve to zero triples if "
+                "data_freshness_index has no rows for that source, OR "
+                "reset triples that the manifest worker then "
+                "debug-skips (no parser registered yet). Operator-"
+                "visible outcome is scope_triples=N + "
+                "discovery_new=0 in the job log."
+            ),
+            field_type="enum",
+            enum_values=(
+                "sec_form3",
+                "sec_form4",
+                "sec_form5",
+                "sec_13d",
+                "sec_13g",
+                "sec_13f_hr",
+                "sec_def14a",
+                "sec_n_port",
+                "sec_n_csr",
+                "sec_10k",
+                "sec_10q",
+                "sec_8k",
+                "sec_xbrl_facts",
+                "finra_short_interest",
+            ),
+            default=None,
+            advanced_group=False,
+        ),
+        ParamMetadata(
+            name="discover",
+            label="Run discovery pass",
+            help_text=(
+                "If true (default), runs check_freshness against every "
+                "CIK in scope to fill missed accessions. Set false to "
+                "skip the SEC fetches and only flip already-known "
+                "accessions back to pending."
+            ),
+            field_type="bool",
+            default=True,
+            advanced_group=True,
+        ),
+    ),
+}
+
+
 class ParamValidationError(ValueError):
     """Raised by ``validate_job_params`` on contract violation.
 
@@ -374,6 +476,10 @@ def _lookup_metadata(job_name: str) -> tuple[ParamMetadata, ...]:
     for job in SCHEDULED_JOBS:
         if job.name == job_name:
             return job.params_metadata
+    # Pass 2: manual-trigger-only jobs (sec_rebuild and future
+    # operator-triggered tools). #1155.
+    if job_name in MANUAL_TRIGGER_JOB_METADATA:
+        return MANUAL_TRIGGER_JOB_METADATA[job_name]
     # Fallback for bootstrap-only invokers. Empty tuple means:
     #   - Manual API path (allow_internal_keys=False): every supplied key
     #     is rejected as unknown — operators cannot manually trigger
@@ -388,6 +494,7 @@ def _lookup_metadata(job_name: str) -> tuple[ParamMetadata, ...]:
 
 __all__ = [
     "JOB_INTERNAL_KEYS",
+    "MANUAL_TRIGGER_JOB_METADATA",
     "ParamFieldType",
     "ParamMetadata",
     "ParamValidationError",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -296,6 +296,15 @@ JOB_SEC_MANIFEST_TOMBSTONE_STALE = "sec_manifest_tombstone_stale"
 JOB_FILINGS_HISTORY_SEED = "filings_history_seed"
 JOB_SEC_FIRST_INSTALL_DRAIN = "sec_first_install_drain"
 
+# #1155 — Layer 1 / 2 / 3 freshness redesign wiring + sec_rebuild
+# manual triage. Implementation entrypoints existed since #867/#868/#870
+# (Layer wrappers) and the #863-#873 spec (sec_rebuild) but were never
+# registered with _INVOKERS or SCHEDULED_JOBS until this PR.
+JOB_SEC_ATOM_FAST_LANE = "sec_atom_fast_lane"
+JOB_SEC_DAILY_INDEX_RECONCILE = "sec_daily_index_reconcile"
+JOB_SEC_PER_CIK_POLL = "sec_per_cik_poll"
+JOB_SEC_REBUILD = "sec_rebuild"
+
 
 # ---------------------------------------------------------------------------
 # Prerequisite checks
@@ -1102,6 +1111,71 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # 5 min before processing any manifest backlog. The tick is
         # bounded at max_rows=100 so the boot cost is small.
         catch_up_on_boot=True,
+    ),
+    # -- #1155 Layer 1 / 2 / 3 freshness redesign wiring -------------------
+    ScheduledJob(
+        name=JOB_SEC_ATOM_FAST_LANE,
+        display_name="SEC Atom fast lane (Layer 1)",
+        source="sec_rate",
+        description=(
+            "#1155 — Layer 1 of the #863-#873 freshness redesign. "
+            "Every 5 min polls SEC's getcurrent Atom feed; filters to "
+            "(cik IN data_freshness_index.cik) + (form mapped to "
+            "ManifestSource); UPSERTs sec_filing_manifest rows for the "
+            "manifest worker to drain. Single ~1 KB HTTP call covers the "
+            "entire SEC universe — fastest discovery layer for 8-K / "
+            "Form 4 / 13D/G."
+        ),
+        cadence=Cadence.every_n_minutes(interval=5),
+        # Missed 5-min window = next fire picks up; no catch-up needed.
+        catch_up_on_boot=False,
+        # Gated until bootstrap completes — until then the universe is
+        # empty and every Atom row's subject_resolver returns None, but
+        # the gate saves the wasted HTTP fetch.
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_DAILY_INDEX_RECONCILE,
+        display_name="SEC daily-index reconcile (Layer 2)",
+        source="sec_rate",
+        description=(
+            "#1155 — Layer 2 of the #863-#873 freshness redesign. "
+            "Daily 04:00 UTC reconcile reads yesterday's daily-index "
+            "master.idx (~1 MB), filters to (cik IN universe) + (form "
+            "mapped to ManifestSource), UPSERTs any sec_filing_manifest "
+            "rows the Atom feed missed. Safety net against transient "
+            "Atom outages."
+        ),
+        cadence=Cadence.daily(hour=4, minute=0),
+        # Catch up on boot is the ENTIRE POINT of this safety net — a
+        # stack restart at 06:00 UTC after a missed 04:00 fire must
+        # still reconcile yesterday's index.
+        catch_up_on_boot=True,
+        # NO _bootstrap_complete prereq — JobRuntime evaluates
+        # catch_up_on_boot only at process start, so a prereq-blocked
+        # catch-up cannot re-fire when bootstrap completes later. Daily-
+        # index against an empty universe is a natural no-op
+        # (subject_resolver filters every CIK). See spec #1155 §1.4.
+        prerequisite=None,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_PER_CIK_POLL,
+        display_name="SEC per-CIK poll (Layer 3)",
+        source="sec_rate",
+        description=(
+            "#1155 — Layer 3 of the #863-#873 freshness redesign. "
+            "Hourly per-CIK reconcile reads data_freshness_index for "
+            "subjects past expected_next_at (poll path) AND past "
+            "next_recheck_at (recheck path for never_filed/error rows "
+            "— #1155 G13). For each due subject calls submissions.json "
+            "and UPSERTs new manifest rows. Bounded total budget split "
+            "2/3 poll + ~1/3 recheck (default max_subjects=100 → "
+            "66+34) so error/never_filed backlog cannot starve "
+            "scheduled polls."
+        ),
+        cadence=Cadence.hourly(minute=0),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
     ),
     ScheduledJob(
         name=JOB_SEC_MANIFEST_TOMBSTONE_STALE,
@@ -4419,6 +4493,153 @@ def sec_first_install_drain(params: Mapping[str, Any]) -> None:
             stats.manifest_rows_upserted,
             stats.errors,
             max_subjects,
+        )
+
+
+def sec_atom_fast_lane() -> None:
+    """``_INVOKERS['sec_atom_fast_lane']`` — Layer 1 (5-min Atom).
+
+    #1155 wiring. Polls SEC's getcurrent Atom feed, filters to
+    (cik IN universe) + (form mapped to ManifestSource), UPSERTs
+    sec_filing_manifest rows for the worker to drain. Idempotent —
+    accession PK + ON CONFLICT preserves any in-flight ingest_status.
+    """
+    from app.jobs.sec_atom_fast_lane import run_atom_fast_lane
+
+    with _tracked_job(JOB_SEC_ATOM_FAST_LANE) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            stats = run_atom_fast_lane(conn, http_get=_make_sec_http_get(sec))  # type: ignore[arg-type]
+            conn.commit()
+        tracker.row_count = stats.upserted
+        logger.info(
+            "sec_atom_fast_lane: feed=%d matched=%d upserted=%d unmapped_form=%d unknown_subject=%d",
+            stats.feed_rows,
+            stats.matched_in_universe,
+            stats.upserted,
+            stats.skipped_unmapped_form,
+            stats.skipped_unknown_subject,
+        )
+
+
+def sec_daily_index_reconcile() -> None:
+    """``_INVOKERS['sec_daily_index_reconcile']`` — Layer 2 (daily 04:00 UTC).
+
+    #1155 wiring. Reads yesterday's daily-index master.idx, filters
+    to (cik IN universe) + (form mapped to ManifestSource), UPSERTs
+    sec_filing_manifest rows for accessions the Atom feed missed.
+
+    NO ``_bootstrap_complete`` prereq + ``catch_up_on_boot=true``:
+    JobRuntime evaluates ``catch_up_on_boot`` only at boot; a
+    prereq-blocked catch-up cannot re-fire when bootstrap completes
+    later. Without this exception a stack that boots mid-bootstrap
+    loses yesterday's reconcile permanently. Daily-index against an
+    empty universe is a natural no-op (subject_resolver filters every
+    CIK).
+    """
+    from app.jobs.sec_daily_index_reconcile import run_daily_index_reconcile
+
+    with _tracked_job(JOB_SEC_DAILY_INDEX_RECONCILE) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            stats = run_daily_index_reconcile(conn, http_get=_make_sec_http_get(sec))  # type: ignore[arg-type]
+            conn.commit()
+        tracker.row_count = stats.upserted
+        logger.info(
+            "sec_daily_index_reconcile: index=%d matched=%d upserted=%d unmapped_form=%d unknown_subject=%d",
+            stats.index_rows,
+            stats.matched_in_universe,
+            stats.upserted,
+            stats.skipped_unmapped_form,
+            stats.skipped_unknown_subject,
+        )
+
+
+def sec_per_cik_poll() -> None:
+    """``_INVOKERS['sec_per_cik_poll']`` — Layer 3 (hourly per-CIK).
+
+    #1155 wiring. Reads ``data_freshness_index`` for subjects past
+    their ``expected_next_at`` (poll path) AND past ``next_recheck_at``
+    (recheck path for never_filed/error rows — #1155 G13). For each
+    due subject calls submissions.json and UPSERTs new manifest rows.
+
+    Bounded total budget: poll=2/3, recheck=~1/3 of ``max_subjects``
+    (default 100 → 66+34).
+    """
+    from app.jobs.sec_per_cik_poll import run_per_cik_poll
+
+    with _tracked_job(JOB_SEC_PER_CIK_POLL) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            stats = run_per_cik_poll(conn, http_get=_make_sec_http_get(sec))  # type: ignore[arg-type]
+            conn.commit()
+        tracker.row_count = stats.new_filings_recorded + stats.recheck_new_filings_recorded
+        logger.info(
+            "sec_per_cik_poll: poll_subjects=%d poll_new=%d errors=%d recheck_subjects=%d recheck_new=%d",
+            stats.subjects_polled,
+            stats.new_filings_recorded,
+            stats.poll_errors,
+            stats.recheck_subjects_polled,
+            stats.recheck_new_filings_recorded,
+        )
+
+
+def sec_rebuild(params: Mapping[str, Any]) -> None:
+    """``_INVOKERS['sec_rebuild']`` — operator manual triage (#1155).
+
+    Resets manifest + scheduler rows for a scope and (default) runs a
+    discovery pass via SEC submissions.json to fill missed accessions.
+    The manifest worker drains the resulting pending rows.
+
+    Honoured params (declared in ``MANUAL_TRIGGER_JOB_METADATA``):
+
+    * ``instrument_id`` (int, optional) — issuer scope
+    * ``filer_cik`` (str, optional) — institutional / blockholder filer scope
+    * ``source`` (str, optional) — ManifestSource literal
+    * ``discover`` (bool, default true) — run history-scan discovery pass
+
+    At least one of instrument_id / filer_cik / source must be set;
+    ``_resolve_scope`` raises ValueError otherwise (surfaces in
+    ``job_runs.status='error'``).
+    """
+    from app.jobs.sec_rebuild import RebuildScope, run_sec_rebuild
+
+    instrument_id_raw = params.get("instrument_id")
+    filer_cik_raw = params.get("filer_cik")
+    source_raw = params.get("source")
+    discover = bool(params.get("discover", True))
+
+    scope = RebuildScope(
+        instrument_id=int(instrument_id_raw) if instrument_id_raw is not None else None,
+        filer_cik=str(filer_cik_raw) if filer_cik_raw is not None else None,
+        source=source_raw,  # type: ignore[arg-type]
+    )
+
+    with _tracked_job(JOB_SEC_REBUILD) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            stats = run_sec_rebuild(
+                conn,
+                scope,
+                http_get=_make_sec_http_get(sec),  # type: ignore[arg-type]
+                discover=discover,
+            )
+            conn.commit()
+        tracker.row_count = stats.scope_triples
+        logger.info(
+            "sec_rebuild: triples=%d manifest_reset=%d scheduler_reset=%d discovery_new=%d",
+            stats.scope_triples,
+            stats.manifest_rows_reset,
+            stats.scheduler_rows_reset,
+            stats.discovery_new_manifest_rows,
         )
 
 

--- a/docs/superpowers/specs/2026-05-13-layer-123-wiring.md
+++ b/docs/superpowers/specs/2026-05-13-layer-123-wiring.md
@@ -1,0 +1,486 @@
+# Layer 1 / 2 / 3 + sec_rebuild wiring — #1155
+
+**Date.** 2026-05-13
+**Ticket.** #1155 (umbrella). Re-opened #867 / #868 / #870.
+**Author.** Claude Opus 4.7 (1M context) with operator.
+**Predecessor spec.** `docs/superpowers/specs/2026-05-04-etl-coverage-model.md` §Layer 1 / §Layer 2 / §Layer 3.
+
+## Problem
+
+Four discovery / triage entrypoints from the #863-#873 freshness redesign are coded but unwired. Audit doc at `.claude/skills/data-engineer/etl-endpoint-coverage.md` §3 captures Layer 1/2/3; the fourth (`sec_rebuild`) was surfaced by Codex pre-spec round 2 during this spec's review.
+
+- `run_atom_fast_lane` at `app/jobs/sec_atom_fast_lane.py:104` — Layer 1 (5-min Atom)
+- `run_daily_index_reconcile` at `app/jobs/sec_daily_index_reconcile.py:46` — Layer 2 (daily-index 04:00 UTC)
+- `run_per_cik_poll` at `app/jobs/sec_per_cik_poll.py:39` — Layer 3 (per-CIK cadence)
+- `run_sec_rebuild` at `app/jobs/sec_rebuild.py:151` — Operator manual triage (per-instrument / per-filer / per-source)
+
+None have a `_INVOKERS[]` registration or a `SCHEDULED_JOBS` row. Tests reference them; production never. Legacy per-form ingest crons (`sec_form3_ingest`, `sec_def14a_ingest`, `sec_8k_events_ingest`, `sec_insider_transactions_ingest`, `sec_business_summary_ingest`, `sec_dividend_calendar_ingest`, `sec_n_port_ingest`, `sec_13f_quarterly_sweep`) carry the steady-state load.
+
+**Operator-runbook implication:** CLAUDE.md §"Operator runbook — after schema / parser change" step 2 says `POST /jobs/sec_rebuild/run`. That endpoint does not route — `_lookup_metadata` returns an empty tuple for unregistered jobs and the API validator rejects every supplied key as unknown. Every recent ETL PR's DoD clause 10 ("Backfill executed via `POST /jobs/sec_rebuild/run`") was satisfied in form only.
+
+G13 sub-finding: even when Layer 3 is scheduled, `run_per_cik_poll` reads only `subjects_due_for_poll` at `app/services/data_freshness.py:485`. The recheck path via `subjects_due_for_recheck` at `:533` (handles `never_filed` + `error` rows) remains unreachable.
+
+## Settled decisions preserved
+
+- §"Provider strategy / Official filings providers" — SEC EDGAR is the source of truth. Wiring uses existing `SecFilingsProvider` rate-limited client.
+- §"Process topology" #719 — jobs process owns scheduling. All three jobs land in `app/workers/scheduler.py:SCHEDULED_JOBS` + `app/jobs/runtime.py:_INVOKERS[]`. Zero API-process scheduling work.
+- §"Fundamentals provider posture" — free regulated only. SEC EDGAR Atom + daily-index + submissions.json are the only fetchers; no new feeds added.
+
+## Scope (in)
+
+1. **Four job wrappers** in `app/workers/scheduler.py` shaped like `sec_first_install_drain` (existing template at `scheduler.py:4377`). Each opens a `SecFilingsProvider` + `psycopg.connect`, adapts via `_make_sec_http_get`, calls the existing `run_*` entrypoint, logs stats. Layers 1/2/3 are **zero-arg**; sec_rebuild takes `params` (`instrument_id` / `filer_cik` / `source` / `discover`).
+2. **Four `_INVOKERS[]` entries** in `app/jobs/runtime.py` so `POST /jobs/<name>/run` works. Layers 1/2/3 registered via `_adapt_zero_arg`; sec_rebuild registered as a params-taking invoker.
+3. **Three `ScheduledJob` rows** in `SCHEDULED_JOBS` — Layer 1/2/3 only. sec_rebuild is NOT in `SCHEDULED_JOBS` (manual-trigger-only); its params + source live in sibling registries — see §1.5.
+4. **Prerequisite policy (revised Codex round 2):**
+   - Layer 1 (Atom every 5 min): `prerequisite=_bootstrap_complete`. `catch_up_on_boot=false`. No boot-time trap because no catch-up.
+   - Layer 2 (daily-index 04:00 UTC): **NO prerequisite**. `catch_up_on_boot=true`. Dropping the prereq is the only way the boot-time catch-up actually fires for a missed-yesterday window — Codex pre-spec round 1 caught that JobRuntime evaluates prereqs only at boot, so a prereq-blocked catch-up is lost forever once bootstrap completes later. Daily-index against an empty universe is a natural no-op (subject_resolver filters every CIK).
+   - Layer 3 (hourly): `prerequisite=_bootstrap_complete`. `catch_up_on_boot=false`. Same reasoning as Layer 1.
+5. **Manual-trigger-only registration (§1.5).** sec_rebuild needs `params_metadata` to accept operator-supplied `instrument_id` / `filer_cik` / `source` / `discover` keys AND a source-lock mapping for `JobLock`, but is NOT in `SCHEDULED_JOBS` (no cadence). Both registries are SCHEDULED_JOBS + _BOOTSTRAP_STAGE_SPECS — only:
+
+   - The param validator (`_lookup_metadata` at `app/services/processes/param_metadata.py:352`) reads `params_metadata` only from `SCHEDULED_JOBS`.
+   - The JobLock registry (`_build_job_name_to_source` at `app/jobs/sources.py:146`) reads source mappings only from `SCHEDULED_JOBS` + `_BOOTSTRAP_STAGE_SPECS`. Manual-only entries trigger `KeyError` at JobLock acquisition.
+
+   **Two sibling side-tables added**, each consistent with its primary registry's file:
+
+   ```python
+   # app/services/processes/param_metadata.py
+   MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
+       "sec_rebuild": (
+           ParamMetadata(name="instrument_id", field_type="int", ...),
+           ParamMetadata(name="filer_cik", field_type="cik", ...),
+           ParamMetadata(name="source", field_type="enum",
+                         enum_values=("sec_form3", "sec_form4", ...)),
+           ParamMetadata(name="discover", field_type="bool", default=True),
+       ),
+   }
+
+   def _lookup_metadata(job_name: str) -> tuple[ParamMetadata, ...]:
+       for job in SCHEDULED_JOBS:
+           if job.name == job_name:
+               return job.params_metadata
+       if job_name in MANUAL_TRIGGER_JOB_METADATA:
+           return MANUAL_TRIGGER_JOB_METADATA[job_name]
+       return ()
+   ```
+
+   ```python
+   # app/jobs/sources.py
+   MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
+       "sec_rebuild": "sec_rate",
+   }
+
+   def _build_job_name_to_source() -> dict[str, Lane]:
+       registry = ...  # existing SCHEDULED_JOBS + _BOOTSTRAP_STAGE_SPECS passes
+       # Pass 3 (new): manual-trigger-only jobs.
+       for job_name, source in MANUAL_TRIGGER_JOB_SOURCES.items():
+           existing = registry.get(job_name)
+           if existing is None:
+               registry[job_name] = source
+           elif existing != source:
+               conflicts.append(...)
+       return registry
+   ```
+
+   Pattern rationale (per data-engineer SKILL §6.5 ParamMetadata discipline): both side-tables mirror the existing `JOB_INTERNAL_KEYS` pattern — co-located with each primary registry, fail-fast on conflicts, zero `ScheduledJob` semantic drift. Keeps "in SCHEDULED_JOBS = APScheduler runs it" mental model intact.
+   ```python
+   # app/services/processes/param_metadata.py
+   MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
+       "sec_rebuild": (
+           ParamMetadata(name="instrument_id", field_type="int", ...),
+           ParamMetadata(name="filer_cik", field_type="cik", ...),
+           ParamMetadata(name="source", field_type="enum",
+                         enum_values=("sec_form3", "sec_form4", ...)),
+           ParamMetadata(name="discover", field_type="bool", default=True),
+       ),
+   }
+
+   def _lookup_metadata(job_name: str) -> tuple[ParamMetadata, ...]:
+       for job in SCHEDULED_JOBS:
+           if job.name == job_name:
+               return job.params_metadata
+       if job_name in MANUAL_TRIGGER_JOB_METADATA:
+           return MANUAL_TRIGGER_JOB_METADATA[job_name]
+       return ()
+   ```
+   Pattern rationale (per data-engineer SKILL §6.5 ParamMetadata discipline): mirrors `JOB_INTERNAL_KEYS` — side-table for jobs with non-`SCHEDULED_JOBS` shape. Keeps `ScheduledJob` semantics clean ("in here = APScheduler runs it"); manual-trigger-with-params is a separate concept. Zero `job_runs` noise. Single-file change (`param_metadata.py`); validator + API path inherit automatically.
+
+   `_never_true` prereq hack rejected: misuses prerequisite (meant for "not-yet-ready" states); leaves weekly skipped `job_runs` rows. `on_demand_only` flag rejected: conflates registration with scheduling; touches every `ScheduledJob` consumer.
+6. **G13 budget split.** `run_per_cik_poll` body augmented to drain BOTH `subjects_due_for_poll` and `subjects_due_for_recheck` in one tick. Signature unchanged. Bounded total budget split — **no `max(1, ...)` floor** (round 2 finding 8):
+   ```python
+   poll_budget = max_subjects * 2 // 3        # 67%
+   recheck_budget = max_subjects - poll_budget  # ~33%
+   ```
+   For `max_subjects=100` → `poll=66, recheck=34`. For `max_subjects=10` → `poll=6, recheck=4`. For `max_subjects=1` → `poll=0, recheck=1` (recheck runs alone — acceptable). For `max_subjects=0` → `poll=0, recheck=0` (no-op tick — degenerate but valid). Total never exceeds `max_subjects`.
+
+## Scope (out)
+
+- Retiring the legacy per-form ingest crons (`sec_form3_ingest`, `sec_def14a_ingest`, …). One PR per cron, separate work per ticket-867/868/870 cleanup.
+- Bulk-zip path for first-install drain (already shipped #1020).
+- Manifest-worker tick cadence changes (already scheduled at every 5 min).
+- New ManifestSource registrations (out-of-band — see #1153 / #918 / #414 / #915 / #916).
+- Per-source-filter Layer 3 — operators get source-targeted re-ingest via the existing `POST /jobs/sec_rebuild/run` body `{ "source": "..." }`. Layer 3 itself is zero-arg pure scheduled discovery.
+
+## Design
+
+### Job names
+
+```python
+# app/workers/scheduler.py
+JOB_SEC_ATOM_FAST_LANE = "sec_atom_fast_lane"
+JOB_SEC_DAILY_INDEX_RECONCILE = "sec_daily_index_reconcile"
+JOB_SEC_PER_CIK_POLL = "sec_per_cik_poll"
+JOB_SEC_REBUILD = "sec_rebuild"
+```
+
+### Wrapper shape (Layer 1 example)
+
+```python
+def sec_atom_fast_lane() -> None:
+    """``_INVOKERS['sec_atom_fast_lane']`` — Layer 1 (5-min Atom).
+
+    Polls SEC's getcurrent Atom feed, filters to (cik IN universe) +
+    (form mapped to ManifestSource), UPSERTs sec_filing_manifest rows
+    for the worker to drain. Idempotent — accession PK + ON CONFLICT
+    preserves any in-flight ingest_status.
+    """
+    from app.jobs.sec_atom_fast_lane import run_atom_fast_lane
+
+    with _tracked_job(JOB_SEC_ATOM_FAST_LANE) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            stats = run_atom_fast_lane(conn, http_get=_make_sec_http_get(sec))
+            conn.commit()
+        tracker.row_count = stats.upserted
+        logger.info(
+            "sec_atom_fast_lane: feed=%d matched=%d upserted=%d "
+            "unmapped_form=%d unknown_subject=%d",
+            stats.feed_rows,
+            stats.matched_in_universe,
+            stats.upserted,
+            stats.skipped_unmapped_form,
+            stats.skipped_unknown_subject,
+        )
+```
+
+Layer 2 + Layer 3 follow identical shape. Layer 2 wrapper accepts no `when` arg from cron (defaults to yesterday inside `run_daily_index_reconcile`). All three Layer wrappers are zero-arg.
+
+### sec_rebuild wrapper (operator manual triage)
+
+```python
+def sec_rebuild(params: Mapping[str, Any]) -> None:
+    """``_INVOKERS['sec_rebuild']`` — operator manual triage.
+
+    Resets manifest + scheduler rows for a scope and (default) runs a
+    discovery pass to fill any missed accessions. The worker then drains
+    the resulting pending rows.
+
+    Honoured params:
+    * ``instrument_id`` (int, optional) — issuer scope
+    * ``filer_cik`` (str, optional) — institutional / blockholder filer scope
+    * ``source`` (str, optional) — ManifestSource literal
+    * ``discover`` (bool, default true) — run history-scan discovery pass
+
+    At least one of instrument_id / filer_cik / source must be set; the
+    underlying ``RebuildScope`` raises ValueError otherwise.
+    """
+    from app.jobs.sec_rebuild import RebuildScope, run_sec_rebuild
+
+    scope = RebuildScope(
+        instrument_id=_as_int(params.get("instrument_id")),
+        filer_cik=_as_str(params.get("filer_cik")),
+        source=_as_manifest_source(params.get("source")),
+    )
+    discover = bool(params.get("discover", True))
+
+    with _tracked_job(JOB_SEC_REBUILD) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            stats = run_sec_rebuild(
+                conn,
+                scope,
+                http_get=_make_sec_http_get(sec),
+                discover=discover,
+            )
+            conn.commit()
+        tracker.row_count = stats.scope_triples
+        logger.info(
+            "sec_rebuild: triples=%d manifest_reset=%d scheduler_reset=%d "
+            "discovery_new=%d",
+            stats.scope_triples,
+            stats.manifest_rows_reset,
+            stats.scheduler_rows_reset,
+            stats.discovery_new_manifest_rows,
+        )
+```
+
+Param coercion helpers (`_as_int`, `_as_str`, `_as_manifest_source`) validate types and pass through `ManifestSource` Literal membership. Invalid `source` raises `ValueError` from the API validator (existing `ParamMetadata.field_type='enum'` path covers this).
+
+### G13 — `run_per_cik_poll` body change
+
+```python
+# app/jobs/sec_per_cik_poll.py
+def run_per_cik_poll(
+    conn: psycopg.Connection[Any],
+    *,
+    http_get: HttpGet,
+    source: ManifestSource | None = None,
+    max_subjects: int = 100,
+) -> PerCikPollStats:
+    # True split — total bounded by max_subjects. No max(1, ...) floor
+    # so max_subjects=1 yields poll=0, recheck=1 (not 1+1=2).
+    poll_budget = max_subjects * 2 // 3
+    recheck_budget = max_subjects - poll_budget
+
+    due_poll = list(subjects_due_for_poll(conn, source=source, limit=poll_budget))
+    due_recheck = list(subjects_due_for_recheck(conn, source=source, limit=recheck_budget))
+
+    # Drain both lists; recheck rows go through the same probe path.
+    for subject in itertools.chain(due_poll, due_recheck):
+        ...  # existing body
+```
+
+`PerCikPollStats` adds two int fields: `recheck_subjects_polled`, `recheck_new_filings_recorded`. Log line includes both so operator can see recheck path is firing.
+
+### `ScheduledJob` rows
+
+| Job | Cadence | catch_up_on_boot | Prerequisite | Source lane | Params |
+|---|---|---|---|---|---|
+| `sec_atom_fast_lane` | every 5 min | false | `_bootstrap_complete` | `sec_rate` | none |
+| `sec_daily_index_reconcile` | daily 04:00 UTC | **true** | **none** | `sec_rate` | none |
+| `sec_per_cik_poll` | hourly minute=0 | false | `_bootstrap_complete` | `sec_rate` | none |
+| `sec_rebuild` | **not in SCHEDULED_JOBS** | n/a | n/a | `sec_rate` (via `MANUAL_TRIGGER_JOB_SOURCES`) | instrument_id / filer_cik / source / discover (via `MANUAL_TRIGGER_JOB_METADATA`) |
+
+Cadence rationale: spec §Layer 1 = 5 min; spec §Layer 2 = daily 04:00 UTC (yesterday's daily-index reliably published by then); spec §Layer 3 = hourly per §#869. sec_rebuild has no cadence (not in `SCHEDULED_JOBS`).
+
+`catch_up_on_boot=true` on Layer 2: a missed 04:00 UTC fire after stack restart at 06:00 UTC should still reconcile yesterday's index — that's the entire point of the safety-net layer. **Dropping `_bootstrap_complete` on Layer 2** (and only Layer 2): Codex pre-spec round 1 caught that JobRuntime evaluates `catch_up_on_boot` ONLY at process start, and a prereq-blocked catch-up is lost forever once bootstrap completes later. Without this exception, a stack that boots mid-bootstrap loses yesterday's reconcile permanently. Daily-index against an empty universe is a natural no-op (subject_resolver filters every CIK).
+
+`_bootstrap_complete` retained on Layer 1 + Layer 3 (revised Codex round 2 — restoring round 1's original gating intent, narrowed to only the layers without the boot trap): no `catch_up_on_boot=true` means no missed-window loss; the gate prevents wasted SEC fetches during bootstrap-in-progress (~20 min window).
+
+sec_rebuild is NOT in `SCHEDULED_JOBS` — params registered via `MANUAL_TRIGGER_JOB_METADATA` (see §1.5). Operator triggers via "Run now" / `POST /jobs/sec_rebuild/run` body.
+
+### `_INVOKERS[]` entries
+
+```python
+# app/jobs/runtime.py
+_INVOKERS[_scheduler.JOB_SEC_ATOM_FAST_LANE] = _adapt_zero_arg(_scheduler.sec_atom_fast_lane)
+_INVOKERS[_scheduler.JOB_SEC_DAILY_INDEX_RECONCILE] = _adapt_zero_arg(_scheduler.sec_daily_index_reconcile)
+_INVOKERS[_scheduler.JOB_SEC_PER_CIK_POLL] = _adapt_zero_arg(_scheduler.sec_per_cik_poll)
+_INVOKERS[_scheduler.JOB_SEC_REBUILD] = _scheduler.sec_rebuild  # params-taking
+```
+
+Layers 1/2/3 are zero-arg. sec_rebuild takes `params: Mapping[str, Any]`; registered directly (no `_adapt_zero_arg`). `params_metadata` declared in `MANUAL_TRIGGER_JOB_METADATA` (see §1.5 + §sec_rebuild ParamMetadata below) so the validator at `app/services/processes/param_metadata.py:352` accepts operator-supplied keys.
+
+### sec_rebuild ParamMetadata (lives in `MANUAL_TRIGGER_JOB_METADATA`)
+
+```python
+# app/services/processes/param_metadata.py
+MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
+    "sec_rebuild": (
+        ParamMetadata(
+            name="instrument_id",
+            label="Instrument ID",
+            help_text="Numeric instrument_id from the instruments table. "
+                      "Triggers rebuild for every (subject, source) triple "
+                      "associated with this instrument.",
+            field_type="int",
+            default=None,
+            advanced_group=False,
+        ),
+        ParamMetadata(
+            name="filer_cik",
+            label="Filer CIK",
+            help_text="CIK of an institutional or blockholder filer. "
+                      "Triggers rebuild for all that filer's 13F-HR / "
+                      "13D / 13G history. Typeahead resolves "
+                      "company-name/symbol to CIK.",
+            field_type="cik",
+            default=None,
+            advanced_group=False,
+        ),
+        ParamMetadata(
+            name="source",
+            label="ManifestSource",
+            help_text="Universe-wide rebuild for one source "
+                      "(sec_form4 / sec_13d / etc). Most expensive option. "
+                      "Note: sec_xbrl_facts / sec_n_csr / sec_10q / "
+                      "finra_short_interest may resolve to zero triples if "
+                      "data_freshness_index has no rows for that source, OR "
+                      "reset triples that the manifest worker then "
+                      "debug-skips (no parser registered yet). Operator-"
+                      "visible outcome is scope_triples=N + "
+                      "discovery_new=0 in the job log.",
+            field_type="enum",
+            enum_values=("sec_form3", "sec_form4", "sec_form5",
+                         "sec_13d", "sec_13g", "sec_13f_hr",
+                         "sec_def14a", "sec_n_port", "sec_n_csr",
+                         "sec_10k", "sec_10q", "sec_8k",
+                         "sec_xbrl_facts", "finra_short_interest"),
+            default=None,
+            advanced_group=False,
+        ),
+        ParamMetadata(
+            name="discover",
+            label="Run discovery pass",
+            help_text="If true (default), runs check_freshness against "
+                      "every CIK in scope to fill missed accessions. Set "
+                      "false to skip the SEC fetches and only flip "
+                      "already-known accessions back to pending.",
+            field_type="bool",
+            default=True,
+            advanced_group=True,
+        ),
+    ),
+}
+```
+
+Per `_resolve_scope` at `app/jobs/sec_rebuild.py:79-80`, at least one of `instrument_id` / `filer_cik` / `source` must be set; `_resolve_scope` itself raises `ValueError` otherwise (NOT `RebuildScope.__post_init__` — the dataclass is unvalidated). The validator can't enforce "at least one of X/Y/Z" via `ParamMetadata` alone — body-level enforcement is the existing contract. The API path returns 202 on accept; the body's ValueError surfaces in `job_runs.status='error'` with the exception text in `error`. Operator sees the failure via the standard `/jobs/runs` panel.
+
+Enum-rejection path is distinct: `validate_job_params` raises `ParamValidationError` (subclass of `ValueError`), mapped to HTTP 400 by the API. Invalid `source` values fail at the validator layer (400), not the body (202+error).
+
+## Tests
+
+**Existing test coverage carried forward:**
+- `tests/test_sec_atom_fast_lane.py` — entrypoint behavior
+- `tests/test_sec_daily_index_reconcile.py` — entrypoint behavior
+- `tests/test_sec_per_cik_poll.py` — entrypoint behavior (needs extension for G13 — recheck reader integration)
+
+**New tests:**
+1. `tests/test_layer_123_wiring.py` — registry tests:
+   - `JOB_SEC_ATOM_FAST_LANE` in `VALID_JOB_NAMES`.
+   - `JOB_SEC_DAILY_INDEX_RECONCILE` in `VALID_JOB_NAMES`.
+   - `JOB_SEC_PER_CIK_POLL` in `VALID_JOB_NAMES`.
+   - Each job has a `ScheduledJob` row with the cadence + prerequisite specified above.
+2. `test_run_per_cik_poll_drains_both_readers` (extends `test_sec_per_cik_poll.py`):
+   - Seed one `current` row + one `error` row + one `never_filed` row.
+   - Run `run_per_cik_poll` once.
+   - Assert all three are probed; both stats counters incremented.
+3. `test_run_per_cik_poll_recheck_budget_split`:
+   - `max_subjects=100` → `subjects_due_for_poll` called with `limit=66`, `subjects_due_for_recheck` called with `limit=34`. Total = 100.
+   - `max_subjects=10` → `poll_limit=6, recheck_limit=4`.
+   - `max_subjects=1` → `poll_limit=0, recheck_limit=1` (degenerate but valid).
+4. `test_sec_rebuild_invoker_validates_params` (new):
+   - `POST /jobs/sec_rebuild/run` with `{}` → 202 (validator accepts empty body); body's `_resolve_scope` raises ValueError; `job_runs.status='error'` with the rejection in `error` column. Existing contract — at-least-one-of cross-field validation lives in `_resolve_scope` at sec_rebuild.py:79-80 (RebuildScope dataclass itself has no `__post_init__`).
+   - With `{ "source": "invalid_value" }` → 400 from validator (`enum_values` rejects unknown; `ParamValidationError` mapped to HTTP 400 by the API).
+   - With `{ "source": "sec_form4" }` → 202 + `sec_rebuild` body runs against scope.
+   - With `{ "instrument_id": 123 }` → 202 + scope resolved.
+   - With `{ "instrument_id": 123, "discover": false }` → 202 + `run_sec_rebuild(discover=False)` confirmed via mock.
+5. `test_manual_trigger_job_metadata_lookup`:
+   - `_lookup_metadata("sec_rebuild")` returns the 4-entry tuple.
+   - `_lookup_metadata("nonexistent")` returns empty tuple.
+   - `_lookup_metadata("nightly_universe_sync")` returns the `SCHEDULED_JOBS` row's `params_metadata` (preserves existing path).
+6. `test_manual_trigger_job_source_lookup` (round 4 follow-up):
+   - `source_for("sec_rebuild") == "sec_rate"`.
+   - `get_job_name_to_source()["sec_rebuild"] == "sec_rate"`.
+   - Conflict test: simulated dup entry in `MANUAL_TRIGGER_JOB_SOURCES` clashing with `SCHEDULED_JOBS` row raises `JobSourceRegistryError`.
+
+**Smoke test:** `tests/smoke/test_app_boots.py` covers `app.main` lifespan but not the jobs process. Per ETL-DoD clauses 8-11 the operator runbook smoke is:
+
+- Run `POST /jobs/sec_atom_fast_lane/run` on dev DB → confirm `job_runs` row + non-zero `matched_in_universe`.
+- Run `POST /jobs/sec_daily_index_reconcile/run` on dev DB → confirm `job_runs` row.
+- Run `POST /jobs/sec_per_cik_poll/run` on dev DB → confirm `job_runs` row + at least one `recheck_*` counter > 0 if any error/never_filed rows exist.
+- Run `POST /jobs/sec_rebuild/run` with `{"instrument_id": <AAPL.id>, "source": "sec_form4"}` on dev DB → confirm `job_runs` row + non-zero `manifest_rows_reset`.
+- Smoke panel (AAPL, GME, MSFT, JPM, HD): no `/instruments/<symbol>/ownership-rollup` regression — figures unchanged from pre-#1155 baseline. (Layer 1/2/3 add discovery; sec_rebuild resets manifest state; observation tables unchanged.)
+
+## Acceptance — DoD clauses 1-12
+
+1. Implementation matches #1155 acceptance + this spec.
+2. Self-reviewed against pre-flight + pre-pr-fresh-agent skills.
+3. `ruff` / `format` / `pyright` / `pytest` pass locally.
+4. PR description complete + self-contained.
+5. Review comments resolved.
+6. No warning / nitpick left hanging.
+7. Recurring findings → prevention log.
+8. Smoke 5 instruments (AAPL/GME/MSFT/JPM/HD): no rollup regression.
+9. Cross-source: not applicable — no parser/data change. (Discovery-layer wiring doesn't touch ingested data shape.)
+10. Backfill: not applicable — no schema/parser change.
+11. Operator-visible figure: `/system/jobs` shows three new SCHEDULED_JOBS rows (Layer 1/2/3) with `next_run_time` populated; sec_rebuild is in `VALID_JOB_NAMES` but absent from `/system/jobs` (not a scheduled job); `POST /jobs/sec_atom_fast_lane/run` returns 202; `POST /jobs/sec_rebuild/run` with `{ "instrument_id": <AAPL.id> }` returns 202.
+12. PR description records the verification step + commit SHA.
+
+Clauses 9 + 10 are stated "not applicable" because this PR is wiring-only, not a parser or schema change. The matrix doc PR already documented that the layers exist as code; this PR connects existing code to the running stack.
+
+## Risks
+
+1. **Layer 1 fires concurrently with legacy `sec_form4_ingest` cron** — both write to `sec_filing_manifest` for Form 4 accessions. UPSERTs are idempotent (accession PK + `ON CONFLICT DO NOTHING` on incumbent in-flight rows), so double-write is safe. Real cost is wasted SEC API calls until the legacy crons retire. Acceptable for one cycle; retirement tickets are out-of-scope follow-up.
+
+2. **`_bootstrap_complete` gate on Layer 1 + Layer 3** — if an operator force-marks bootstrap complete on a partial DB (e.g. universe synced but no CIK mapping yet), Layer 3 will poll subjects with NULL `cik` and skip them via the existing `if subject.cik is None: continue` guard. Safe but wasteful. Existing fundamentals_sync uses defense-in-depth via `_all_of(_bootstrap_complete, _has_any_coverage)`; we don't replicate because Layer 3 selects from `data_freshness_index` directly which has its own state filter. Layer 2 does NOT carry this gate per §1.4 reasoning.
+
+3. **G13 budget split (poll vs recheck)** — recheck readers run alongside poll readers in one hourly tick. Bounded total: for `max_subjects=100` → `poll=66 + recheck=34 = 100` (never exceeds total). Recheck-floor at 1/3 ensures error/never_filed backlog drains at a guaranteed rate; if 1000 error rows accumulate, 34/hour = ~30 hours to fully drain. Acceptable. SEC rate budget is shared, so a 100-row tick is ~10s wall-time.
+
+4. **Atom feed ISO-8859-1 encoding** — already handled in `app/providers/implementations/sec_getcurrent.py`. Wiring doesn't touch decode logic. Reference: sec-edgar.md §7.9.
+
+5. **Daily-index catch-up on boot fires SEC request burst** — `read_daily_index` is a single ~1 MB fetch for yesterday; bounded. Acceptable.
+
+6. **Manifest-worker `iter_pending` lacks `FOR UPDATE SKIP LOCKED` (pre-existing)** — Codex pre-spec caught that `iter_pending` selects pending rows without row-level locks. Two overlapping `sec_manifest_worker` ticks (scheduled + manual) could pick the same row. Out of scope for #1155: pre-existing behaviour, not introduced by Layer 1/2/3 wiring. Mitigation today: `JobLock` serialises same-name ticks; cross-process risk exists only if a second jobs process violates the singleton fence (which a session-scoped advisory lock at `JOBS_PROCESS_LOCK_KEY` already prevents — see settled-decisions §"Process topology"). **Action:** file follow-up ticket against #1155 to add `FOR UPDATE SKIP LOCKED` to `iter_pending` as defense-in-depth.
+
+## File diff summary
+
+- `app/workers/scheduler.py`:
+  - 4 new `JOB_*` constants (top of file).
+  - 4 new wrapper functions (after existing SEC-track wrappers).
+  - 3 new `ScheduledJob` rows (Layer 1/2/3) in `SCHEDULED_JOBS`. sec_rebuild is NOT added to `SCHEDULED_JOBS`.
+- `app/jobs/runtime.py`:
+  - 4 new `_INVOKERS[]` registrations.
+- `app/services/processes/param_metadata.py`:
+  - New `MANUAL_TRIGGER_JOB_METADATA` dict with sec_rebuild entry.
+  - `_lookup_metadata` extended with fallback branch reading from the new dict.
+- `app/jobs/sources.py`:
+  - New `MANUAL_TRIGGER_JOB_SOURCES` dict (sec_rebuild → `sec_rate`).
+  - `_build_job_name_to_source` extended with Pass 3 for manual-only entries + conflict check.
+- `app/jobs/sec_per_cik_poll.py`:
+  - `run_per_cik_poll` body: chain `subjects_due_for_poll` + `subjects_due_for_recheck`; budget split (no `max(1,...)` floor).
+  - `PerCikPollStats` dataclass: add `recheck_subjects_polled` + `recheck_new_filings_recorded` fields.
+- `tests/test_sec_per_cik_poll.py`:
+  - 2 new tests (both-readers + budget-split).
+- `tests/test_layer_123_wiring.py` (new):
+  - Registry presence tests for the four jobs.
+  - sec_rebuild param-validation tests (5 scenarios per §Tests).
+  - `_lookup_metadata` fallback tests.
+
+Total: ~8 production files touched + 1 new test file. Single PR.
+
+## Codex pre-spec rounds — findings applied
+
+### Round 1 (5 findings — 2 BLOCKING + 1 HIGH + 2 MEDIUM)
+
+1. **BLOCKING — Layer 2 catch-up + `_bootstrap_complete` prereq incompatible.** Fixed (narrowed per round 2 below): dropped `_bootstrap_complete` on Layer 2 only.
+2. **BLOCKING — `POST /jobs/sec_per_cik_poll/run` params validation incomplete.** Fixed: dropped params from Layer 3 entirely; Layer 3 is zero-arg. Per-source operator triage routes through `POST /jobs/sec_rebuild/run` instead.
+3. **HIGH — G13 budget split overran total (100 + 50 = 150).** Fixed: true split — `poll = max_subjects * 2 // 3`, `recheck = max_subjects - poll`. Total bounded.
+4. **MEDIUM — manifest-worker `iter_pending` race (pre-existing).** Out-of-scope for #1155; documented as Risk §6.
+5. **MEDIUM — typo `AtomLaneStats.matched`.** Fixed to `.matched_in_universe`.
+
+### Round 2 (5 findings — 1 BLOCKING + 1 HIGH + 2 MEDIUM + 1 LOW)
+
+6. **BLOCKING — `sec_rebuild` itself is unwired** (the round 1 "route through `POST /jobs/sec_rebuild/run`" fix assumed wiring that doesn't exist). **Operator pulled sec_rebuild into #1155.** Spec amended: 4 wirings instead of 3; new §sec_rebuild wrapper + ParamMetadata declarations.
+7. **HIGH — dropping `_bootstrap_complete` on all three layers overbroad.** Layer 1 + Layer 3 don't have the boot-time catch-up trap (their `catch_up_on_boot=false`). Restored the prereq on Layer 1 + Layer 3; kept dropped on Layer 2 only.
+8. **MEDIUM — small-`max_subjects` boundary bug** in G13 split (`max(1, ...)` floors made `max_subjects=1` produce total=2). Fixed: removed the floor — `poll_budget = max_subjects * 2 // 3`, `recheck_budget = max_subjects - poll_budget`. For `max_subjects=1` → poll=0, recheck=1 (degenerate but bounded).
+9. **MEDIUM — stale test expectation.** §Tests had `max_subjects=10 → poll=10, recheck=5`. Updated to `poll=6, recheck=4` per the corrected formula.
+10. **LOW — stale risk text** referencing the dropped prereq and old `max_subjects//2 = 50` budget. Cleaned up.
+
+### Round 3 (5 findings — 3 BLOCKING + 1 MEDIUM + 1 LOW)
+
+11. **BLOCKING — `ParamMetadata.choices` is not a field.** Actual field is `enum_values: tuple[str, ...] | None`. Model has `extra="forbid"` so a `choices=...` kwarg would fail at module-import time. Fixed: §sec_rebuild ParamMetadata now uses `enum_values=(...)`.
+12. **BLOCKING — `_never_true` prereq writes 1 skipped `job_runs` row/week.** Operator chose Option B (new `MANUAL_TRIGGER_JOB_METADATA` registry). Fixed: sec_rebuild removed from `SCHEDULED_JOBS` entirely; `_lookup_metadata` extended with sibling registry lookup. Zero `job_runs` noise.
+13. **BLOCKING — empty-body `POST /jobs/sec_rebuild/run` doesn't return 400 at API layer.** Existing contract: `validate_job_params` accepts empty body; `_resolve_scope` (not `RebuildScope.__post_init__` — the dataclass is unvalidated) raises ValueError; job_runs row records `status='error'`. Fixed: §Tests expectation updated to match existing contract (202 + body-level error, not 400).
+14. **MEDIUM — `filer_cik` field_type was `string`** when ParamMetadata supports `cik` (typeahead resolves company-name/symbol). Fixed: `field_type="cik"`.
+15. **LOW — Acceptance said "three new rows" in `/system/jobs`.** Fixed: three Layer rows (sec_rebuild is not a scheduled job).
+
+### Round 4 (3 findings — 1 BLOCKING + 1 SPEC + 1 MEDIUM)
+
+16. **BLOCKING — `sec_rebuild` missing from JobLock source registry.** Manual-only `_INVOKERS` entry not in `SCHEDULED_JOBS` or `_BOOTSTRAP_STAGE_SPECS` produces `KeyError` at JobLock acquisition (registry built only from those two passes in `app/jobs/sources.py:146`). Fixed: sibling `MANUAL_TRIGGER_JOB_SOURCES` dict added in `app/jobs/sources.py`; `_build_job_name_to_source` extended with Pass 3 + conflict check.
+17. **SPEC — stale `_never_true` / "four ScheduledJob rows" text** remained after round 3's registry-move. Fixed: all stale references removed; scope, table, and rationale text consistent with three-scheduled-jobs + manual-only-sec_rebuild design.
+18. **MEDIUM — `source` enum too broad** for sec_rebuild's submissions-backed discovery (`sec_xbrl_facts` / `sec_n_csr` / `sec_10q` / `finra_short_interest`). Acceptable: may resolve to zero triples (no `data_freshness_index` rows) OR reset triples that manifest worker debug-skips (no parser registered). Help_text revised accordingly.
+
+### Round 5 (5 findings — 2 MEDIUM + 3 LOW + 1 TEST GAP)
+
+19. **MEDIUM — `_INVOKERS[]` section stale "declared on the ScheduledJob row".** Fixed to "declared in `MANUAL_TRIGGER_JOB_METADATA`".
+20. **MEDIUM — known-no-op wording too strong** (claimed "resolve to zero triples" definitively). Fixed: may resolve to zero OR reset-only with no parser.
+21. **LOW — duplicated MANUAL_TRIGGER_JOB_METADATA block in §1.5.** Kept as deliberate: scope §1.5 shows the structural sketch; §"sec_rebuild ParamMetadata" shows the full declarations. Each serves a distinct purpose (scope-level pattern vs implementation-level field list). Not removed — readers reading top-down would miss the implementation details if only the sketch remained.
+22. **LOW — `RebuildScope.__post_init__` reference wrong.** Fixed: `_resolve_scope` at sec_rebuild.py:79-80 is the raiser; RebuildScope dataclass has no `__post_init__`.
+23. **LOW — "ValueError from API validator" imprecise.** Fixed: enum-rejection raises `ParamValidationError` mapped to HTTP 400 by the API; documented separately from body-level ValueError.
+24. **TEST GAP — source-lock test missing.** Fixed: added `test_manual_trigger_job_source_lookup` covering `source_for("sec_rebuild")` resolution + conflict detection.
+
+`PerCikPollStats` consumer grep confirmed: only the file itself + tests reference it. Adding fields is safe.

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -444,6 +444,19 @@ class TestProductionInvokerRegistry:
             "sec_13f_ingest_from_dataset",
             "sec_insider_ingest_from_dataset",
             "sec_nport_ingest_from_dataset",
+            # #1155 — manual-trigger-only operator triage. Registered in
+            # _INVOKERS so POST /jobs/sec_rebuild/run works; intentionally
+            # NOT in SCHEDULED_JOBS (no cadence). Params declared in
+            # MANUAL_TRIGGER_JOB_METADATA; source-lock in
+            # MANUAL_TRIGGER_JOB_SOURCES.
+            "sec_rebuild",
+            # #819 — canonical-instrument redirect populate. Idempotent
+            # one-shot the operator triggers after a universe sync
+            # introduces new .RTH-style variants. Registered in
+            # _INVOKERS for "Run now"; NOT in SCHEDULED_JOBS (manual
+            # trigger only). Pre-existing drift fixed in #1155's
+            # registry guard sweep.
+            "populate_canonical_redirects",
         }
         assert on_demand == expected_on_demand, (
             f"Unexpected on-demand invokers (update this test if intentional): "

--- a/tests/test_layer_123_wiring.py
+++ b/tests/test_layer_123_wiring.py
@@ -1,0 +1,190 @@
+"""#1155 — Layer 1 / 2 / 3 freshness redesign wiring + sec_rebuild
+manual triage. Registry tests + sec_rebuild param-validation tests.
+
+Verifies:
+
+* Layers 1/2/3 are in ``VALID_JOB_NAMES`` + ``SCHEDULED_JOBS`` with
+  the cadences + prerequisites pinned in
+  ``docs/superpowers/specs/2026-05-13-layer-123-wiring.md``.
+* sec_rebuild is in ``VALID_JOB_NAMES`` + ``MANUAL_TRIGGER_JOB_METADATA``
+  + ``MANUAL_TRIGGER_JOB_SOURCES`` but NOT in ``SCHEDULED_JOBS``.
+* ``_lookup_metadata`` falls back to ``MANUAL_TRIGGER_JOB_METADATA``
+  for sec_rebuild while preserving the ``SCHEDULED_JOBS`` path for
+  Layer 1/2/3.
+* ``source_for`` resolves sec_rebuild to ``sec_rate`` via the new
+  ``MANUAL_TRIGGER_JOB_SOURCES`` Pass 3.
+* sec_rebuild ParamMetadata validation accepts declared keys and
+  rejects unknown/typed-bad keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.jobs.runtime import VALID_JOB_NAMES
+from app.jobs.sources import MANUAL_TRIGGER_JOB_SOURCES, source_for
+from app.services.processes.param_metadata import (
+    MANUAL_TRIGGER_JOB_METADATA,
+    ParamValidationError,
+    _lookup_metadata,
+    validate_job_params,
+)
+from app.workers.scheduler import (
+    JOB_SEC_ATOM_FAST_LANE,
+    JOB_SEC_DAILY_INDEX_RECONCILE,
+    JOB_SEC_PER_CIK_POLL,
+    JOB_SEC_REBUILD,
+    SCHEDULED_JOBS,
+    Cadence,
+)
+
+
+def _job_by_name(name: str):
+    for job in SCHEDULED_JOBS:
+        if job.name == name:
+            return job
+    return None
+
+
+class TestLayer123Registry:
+    """Layer 1/2/3 are scheduled with the cadences + prereqs pinned in spec."""
+
+    def test_layer1_atom_fast_lane_registered(self) -> None:
+        assert JOB_SEC_ATOM_FAST_LANE in VALID_JOB_NAMES
+        job = _job_by_name(JOB_SEC_ATOM_FAST_LANE)
+        assert job is not None
+        assert job.cadence == Cadence.every_n_minutes(interval=5)
+        assert job.catch_up_on_boot is False
+        # _bootstrap_complete prereq present
+        assert job.prerequisite is not None
+        assert job.source == "sec_rate"
+
+    def test_layer2_daily_index_reconcile_registered(self) -> None:
+        assert JOB_SEC_DAILY_INDEX_RECONCILE in VALID_JOB_NAMES
+        job = _job_by_name(JOB_SEC_DAILY_INDEX_RECONCILE)
+        assert job is not None
+        assert job.cadence == Cadence.daily(hour=4, minute=0)
+        # CRITICAL: catch_up_on_boot is the entire point of Layer 2;
+        # missed-yesterday window must reconcile after a stack restart.
+        assert job.catch_up_on_boot is True
+        # CRITICAL: NO _bootstrap_complete prereq — JobRuntime evaluates
+        # catch_up_on_boot only at boot, so a prereq-blocked catch-up
+        # cannot re-fire when bootstrap completes later. Spec §1.4.
+        assert job.prerequisite is None
+        assert job.source == "sec_rate"
+
+    def test_layer3_per_cik_poll_registered(self) -> None:
+        assert JOB_SEC_PER_CIK_POLL in VALID_JOB_NAMES
+        job = _job_by_name(JOB_SEC_PER_CIK_POLL)
+        assert job is not None
+        assert job.cadence == Cadence.hourly(minute=0)
+        assert job.catch_up_on_boot is False
+        assert job.prerequisite is not None
+        assert job.source == "sec_rate"
+
+
+class TestSecRebuildRegistry:
+    """sec_rebuild is manual-trigger-only — registered via the sibling
+    side-tables, NOT in SCHEDULED_JOBS."""
+
+    def test_sec_rebuild_in_valid_job_names(self) -> None:
+        assert JOB_SEC_REBUILD in VALID_JOB_NAMES
+
+    def test_sec_rebuild_not_in_scheduled_jobs(self) -> None:
+        """The whole point of MANUAL_TRIGGER_JOB_METADATA is to keep
+        sec_rebuild out of the cron registry. Regression-guard."""
+        assert _job_by_name(JOB_SEC_REBUILD) is None
+
+    def test_sec_rebuild_in_manual_trigger_metadata(self) -> None:
+        assert JOB_SEC_REBUILD in MANUAL_TRIGGER_JOB_METADATA
+        params = MANUAL_TRIGGER_JOB_METADATA[JOB_SEC_REBUILD]
+        names = {p.name for p in params}
+        assert names == {"instrument_id", "filer_cik", "source", "discover"}
+
+    def test_sec_rebuild_in_manual_trigger_sources(self) -> None:
+        assert MANUAL_TRIGGER_JOB_SOURCES[JOB_SEC_REBUILD] == "sec_rate"
+
+    def test_source_for_resolves_sec_rebuild(self) -> None:
+        """Round 4 finding — manual-trigger jobs need source-lock coverage
+        or JobLock acquisition KeyErrors at dispatch."""
+        assert source_for(JOB_SEC_REBUILD) == "sec_rate"
+
+
+class TestLookupMetadataFallback:
+    """``_lookup_metadata`` chain: SCHEDULED_JOBS → MANUAL_TRIGGER → empty."""
+
+    def test_lookup_returns_manual_trigger_metadata_for_sec_rebuild(self) -> None:
+        result = _lookup_metadata(JOB_SEC_REBUILD)
+        assert len(result) == 4
+        assert {p.name for p in result} == {"instrument_id", "filer_cik", "source", "discover"}
+
+    def test_lookup_returns_scheduled_metadata_for_existing_job(self) -> None:
+        """Existing SCHEDULED_JOBS path must still work."""
+        # sec_13f_quarterly_sweep has min_period_of_report ParamMetadata
+        result = _lookup_metadata("sec_13f_quarterly_sweep")
+        names = {p.name for p in result}
+        assert "min_period_of_report" in names
+
+    def test_lookup_returns_empty_for_unknown_job(self) -> None:
+        assert _lookup_metadata("does_not_exist_anywhere") == ()
+
+
+class TestSecRebuildParamValidation:
+    """Validator path through MANUAL_TRIGGER_JOB_METADATA — covers the
+    operator API ``POST /jobs/sec_rebuild/run`` contract."""
+
+    def test_empty_body_validates_at_api_layer(self) -> None:
+        """Empty body passes validation; ``_resolve_scope`` raises at
+        body time. Existing at-least-one-of contract."""
+        # No keys to reject; validator returns empty params.
+        coerced = validate_job_params(JOB_SEC_REBUILD, {}, allow_internal_keys=False)
+        assert coerced == {}
+
+    def test_invalid_source_rejected_by_validator(self) -> None:
+        with pytest.raises(ParamValidationError):
+            validate_job_params(
+                JOB_SEC_REBUILD,
+                {"source": "not_a_real_source"},
+                allow_internal_keys=False,
+            )
+
+    def test_valid_source_passes(self) -> None:
+        coerced = validate_job_params(
+            JOB_SEC_REBUILD,
+            {"source": "sec_form4"},
+            allow_internal_keys=False,
+        )
+        assert coerced == {"source": "sec_form4"}
+
+    def test_instrument_id_int_coerces(self) -> None:
+        coerced = validate_job_params(
+            JOB_SEC_REBUILD,
+            {"instrument_id": 123},
+            allow_internal_keys=False,
+        )
+        assert coerced == {"instrument_id": 123}
+
+    def test_instrument_id_zero_rejected_by_min_value(self) -> None:
+        """min_value=1 on instrument_id rejects 0 / negative."""
+        with pytest.raises(ParamValidationError):
+            validate_job_params(
+                JOB_SEC_REBUILD,
+                {"instrument_id": 0},
+                allow_internal_keys=False,
+            )
+
+    def test_unknown_key_rejected(self) -> None:
+        with pytest.raises(ParamValidationError):
+            validate_job_params(
+                JOB_SEC_REBUILD,
+                {"this_key_does_not_exist": "anything"},
+                allow_internal_keys=False,
+            )
+
+    def test_discover_bool_coerces(self) -> None:
+        coerced = validate_job_params(
+            JOB_SEC_REBUILD,
+            {"instrument_id": 123, "discover": False},
+            allow_internal_keys=False,
+        )
+        assert coerced == {"instrument_id": 123, "discover": False}

--- a/tests/test_sec_per_cik_poll.py
+++ b/tests/test_sec_per_cik_poll.py
@@ -167,3 +167,168 @@ class TestPerCikPoll:
         sched = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1701", source="sec_8k")
         assert sched is not None
         assert sched.state == "error"
+
+
+class TestG13RecheckPath:
+    """#1155 G13 — recheck reader path (never_filed / error rows)."""
+
+    def test_never_filed_stays_in_recheck_queue_after_empty_poll(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#1155 G13 — Codex round 2 finding: a 'never_filed' row that
+        polls successfully with no new filings must STAY 'never_filed'
+        with an advanced next_recheck_at, NOT transition to 'current'.
+        Otherwise the recheck path is defeated on the first poll.
+        """
+        _seed_aapl(ebull_test_conn)
+        # Seed a never_filed row past its next_recheck_at
+        record_poll_outcome(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1701",
+            source="sec_def14a",
+            outcome="never",
+            cik="0000320193",
+            instrument_id=1701,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("UPDATE data_freshness_index SET next_recheck_at = '2024-01-01' WHERE source = 'sec_def14a'")
+        ebull_test_conn.commit()
+
+        # Payload returns a single 8-K — NOT a def14a accession, so the
+        # source filter at check_freshness sees no new sec_def14a rows.
+        run_per_cik_poll(
+            ebull_test_conn,
+            http_get=_fake_get(200, _aapl_submissions_recent()),
+            source="sec_def14a",
+        )
+        ebull_test_conn.commit()
+
+        sched = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1701", source="sec_def14a")
+        assert sched is not None
+        # CRITICAL: state stays 'never_filed', does NOT transition to 'current'
+        assert sched.state == "never_filed"
+        assert sched.last_polled_outcome == "never"
+        # next_recheck_at advanced to a future time
+        assert sched.next_recheck_at is not None
+        assert sched.next_recheck_at > datetime(2025, 1, 1, tzinfo=UTC)
+
+    def test_recheck_subject_drained_alongside_poll(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Seed one 'error'-state subject + one 'current' subject past
+        expected_next_at. Both should be probed in one tick; stats
+        differentiate via the recheck_* counters.
+        """
+        _seed_aapl(ebull_test_conn)
+
+        # Subject 1: 'current' state past expected_next_at (poll path)
+        record_poll_outcome(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1701",
+            source="sec_8k",
+            outcome="current",
+            last_known_filing_id="0000320193-25-000001",
+            last_known_filed_at=datetime(2025, 1, 1, tzinfo=UTC),
+            cik="0000320193",
+            instrument_id=1701,
+        )
+        # Subject 2: 'error' state past next_recheck_at (recheck path)
+        record_poll_outcome(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1701",
+            source="sec_def14a",
+            outcome="error",
+            error="prior 503",
+            cik="0000320193",
+            instrument_id=1701,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("UPDATE data_freshness_index SET expected_next_at = '2024-01-01' WHERE source = 'sec_8k'")
+            cur.execute("UPDATE data_freshness_index SET next_recheck_at = '2024-01-01' WHERE source = 'sec_def14a'")
+        ebull_test_conn.commit()
+
+        stats = run_per_cik_poll(
+            ebull_test_conn,
+            http_get=_fake_get(200, _aapl_submissions_recent()),
+            # No source filter — both readers see their respective rows
+        )
+        ebull_test_conn.commit()
+
+        # Poll path probed sec_8k subject
+        assert stats.subjects_polled == 1
+        # Recheck path probed sec_def14a subject
+        assert stats.recheck_subjects_polled == 1
+        # Total error count is 0 — both probes returned 200
+        assert stats.poll_errors == 0
+
+    def test_budget_split_2_3_poll_1_3_recheck(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``max_subjects=100`` should split ``poll=66, recheck=34``.
+        Verified by passing distinct iterators via monkeypatch.
+        """
+        import app.jobs.sec_per_cik_poll as poll_mod
+
+        captured: dict[str, int] = {}
+
+        def _spy_poll(conn, *, source, limit, now=None):  # noqa: ARG001
+            captured["poll"] = limit
+            return iter([])
+
+        def _spy_recheck(conn, *, source, limit, now=None):  # noqa: ARG001
+            captured["recheck"] = limit
+            return iter([])
+
+        original_poll = poll_mod.subjects_due_for_poll
+        original_recheck = poll_mod.subjects_due_for_recheck
+        poll_mod.subjects_due_for_poll = _spy_poll  # type: ignore[assignment]
+        poll_mod.subjects_due_for_recheck = _spy_recheck  # type: ignore[assignment]
+        try:
+            run_per_cik_poll(ebull_test_conn, http_get=_fake_get(200, {}), max_subjects=100)
+        finally:
+            poll_mod.subjects_due_for_poll = original_poll  # type: ignore[assignment]
+            poll_mod.subjects_due_for_recheck = original_recheck  # type: ignore[assignment]
+
+        # 100 * 2 // 3 = 66; 100 - 66 = 34
+        assert captured == {"poll": 66, "recheck": 34}
+
+    def test_budget_split_degenerate_max_subjects_1(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``max_subjects=1`` should produce ``poll=0, recheck=1``
+        (no floor); total=1, never 2.
+        """
+        import app.jobs.sec_per_cik_poll as poll_mod
+
+        poll_limits: list[int] = []
+        recheck_limits: list[int] = []
+
+        def _spy_poll(conn, *, source, limit, now=None):  # noqa: ARG001
+            poll_limits.append(limit)
+            return iter([])
+
+        def _spy_recheck(conn, *, source, limit, now=None):  # noqa: ARG001
+            recheck_limits.append(limit)
+            return iter([])
+
+        original_poll = poll_mod.subjects_due_for_poll
+        original_recheck = poll_mod.subjects_due_for_recheck
+        poll_mod.subjects_due_for_poll = _spy_poll  # type: ignore[assignment]
+        poll_mod.subjects_due_for_recheck = _spy_recheck  # type: ignore[assignment]
+        try:
+            run_per_cik_poll(ebull_test_conn, http_get=_fake_get(200, {}), max_subjects=1)
+        finally:
+            poll_mod.subjects_due_for_poll = original_poll  # type: ignore[assignment]
+            poll_mod.subjects_due_for_recheck = original_recheck  # type: ignore[assignment]
+
+        # poll_budget=0 means the reader is SKIPPED entirely (not called
+        # with limit=0). recheck_budget=1 means the reader IS called.
+        assert poll_limits == []
+        assert recheck_limits == [1]


### PR DESCRIPTION
## Summary

Wires four operator-triage / discovery entrypoints from the #863-#873 ETL freshness redesign that shipped as code but were never registered with `_INVOKERS` or `SCHEDULED_JOBS`. Closes #867 / #868 / #870 (reopened by the #1156 audit). Closes #1155 umbrella.

## What lands

- **Layer 1 (Atom every 5 min):** `sec_atom_fast_lane` wrapper + ScheduledJob with `_bootstrap_complete` prereq.
- **Layer 2 (daily-index 04:00 UTC):** `sec_daily_index_reconcile` wrapper + ScheduledJob with `catch_up_on_boot=true` and **NO** `_bootstrap_complete` prereq (Codex round 1 caught the boot-time-only catch-up trap; missed-yesterday windows would be lost forever otherwise).
- **Layer 3 (hourly per-CIK):** `sec_per_cik_poll` wrapper + ScheduledJob with `_bootstrap_complete` prereq. **G13 fix:** body now drains BOTH `subjects_due_for_poll` AND `subjects_due_for_recheck` with bounded budget split (`poll = max_subjects * 2 // 3`, `recheck = remainder`).
- **sec_rebuild (operator manual triage):** params declared in new `MANUAL_TRIGGER_JOB_METADATA` dict; source-lock binding in new `MANUAL_TRIGGER_JOB_SOURCES` dict. NOT in `SCHEDULED_JOBS`. Mirrors existing `JOB_INTERNAL_KEYS` pattern.

After this PR lands, `POST /jobs/sec_rebuild/run` actually routes — CLAUDE.md DoD clause 10 (operator runbook backfill step) becomes executable for the first time.

## Codex review history

- **Pre-spec rounds 1-5:** 24 findings (3 BLOCKING contract bugs: `ParamMetadata.enum_values` not `choices`; JobLock source registry coverage; `_resolve_scope` not `RebuildScope.__post_init__` raises). All applied to spec at [docs/superpowers/specs/2026-05-13-layer-123-wiring.md](docs/superpowers/specs/2026-05-13-layer-123-wiring.md) before operator approval.
- **Pre-push round 1:** 2 BLOCKING (`test_jobs_runtime.py` expected_on_demand drift; `never_filed` state transition bug — empty poll moved row to `'current'`, defeating the recheck path's purpose). Both fixed. Pre-existing `populate_canonical_redirects` drift from #819 fixed in-scope per fix-in-scope-default rule.
- **Pre-push round 2:** clean.

## Settled decisions preserved

- §"Process topology" #719 — jobs process owns scheduling. All four jobs land in `SCHEDULED_JOBS` + `_INVOKERS[]` (sec_rebuild in `_INVOKERS` only).
- §"Fundamentals provider posture" — free regulated only. No new feeds added.
- §"Provider strategy" — SEC EDGAR for US issuers. Reuses existing `SecFilingsProvider` rate-limited client.

## Test coverage

60 impacted-files tests pass:
- `tests/test_layer_123_wiring.py` (new — 18 tests covering registry presence, ParamMetadata validation, source-lock resolution, `_lookup_metadata` fallback chain).
- `tests/test_sec_per_cik_poll.py` (6 — 3 existing + 4 new G13 tests including `test_never_filed_stays_in_recheck_queue_after_empty_poll`).
- `tests/test_jobs_runtime.py` (32 existing including extended `expected_on_demand`).

Full pytest gate's `test_watermark_resolver` + `test_xbrl_derived_stats` flakes are pre-existing xdist Postgres-lock environmental — pass cleanly in single-process mode (covered by memory `feedback_pre_push_xdist_postgres_locks.md`). Impacted files clean.

## Test plan after merge

- [ ] `POST /jobs/sec_atom_fast_lane/run` on dev DB → 202 + `job_runs` row.
- [ ] `POST /jobs/sec_daily_index_reconcile/run` on dev DB → 202 + `job_runs` row.
- [ ] `POST /jobs/sec_per_cik_poll/run` on dev DB → 202 + `recheck_*` counters > 0 if any error/never_filed rows exist.
- [ ] `POST /jobs/sec_rebuild/run` with `{"instrument_id": <AAPL.id>, "source": "sec_form4"}` → 202 + non-zero `manifest_rows_reset`.
- [ ] Smoke `/instruments/{AAPL,GME,MSFT,JPM,HD}/ownership-rollup` → no regression (Layer 1/2/3 add discovery; observation tables unchanged).
- [ ] `/system/jobs` shows three new SCHEDULED rows (Layer 1/2/3) with `next_run_time` populated.

Closes #1155
Closes #867
Closes #868
Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)