### PR TITLE
feat(#1155): move sec_def14a_ingest to on-demand

### DIFF
--- a/.claude/skills/data-engineer/etl-endpoint-coverage.md
+++ b/.claude/skills/data-engineer/etl-endpoint-coverage.md
@@ -34,7 +34,7 @@ Definition: `app/services/sec_manifest.py:106-121` + CHECK constraint `sql/118:3
 | Source | Bootstrap stage | Standard refresh | Freshness cadence | Watermark | Pool | Parser | Status |
 |---|---|---|---|---|---|---|---|
 | `sec_8k` | Stage 20 `sec_8k_events_ingest` | `JOB_SEC_8K_EVENTS_INGEST` cron (`scheduler.py:671`) + manifest worker | 14d | `data_freshness_index` + `sec_filing_manifest.next_retry_at` | `sec_rate` | ✅ `eight_k.py` (#1126) | **WIRED** |
-| `sec_def14a` | Stage 16 `sec_def14a_bootstrap` | `JOB_SEC_DEF14A_INGEST` cron (`scheduler.py:742`) + manifest worker | 365d | both | `sec_rate` | ✅ `def14a.py` (#1128) | **WIRED** |
+| `sec_def14a` | Stage 16 `sec_def14a_bootstrap` | manifest worker (post-#1155 — `JOB_SEC_DEF14A_INGEST` moved to on-demand) + weekly `sec_def14a_bootstrap` safety net | 365d | both | `sec_rate` | ✅ `def14a.py` (#1128) | **WIRED** |
 | `sec_13d` | Stage 14 `filings_history_seed` (730d) | manifest worker only | 90d | both | `sec_rate` | ✅ `sec_13dg.py` (#1129) | **WIRED**, but only manifest worker (no dedicated cron — depends on Layer 1/2/3, see §3) |
 | `sec_13g` | Stage 14 | manifest worker only | 90d | both | `sec_rate` | ✅ `sec_13dg.py` (#1129) | **WIRED**, same caveat |
 | `sec_form3` | Stage 19 `sec_form3_ingest` | `JOB_SEC_FORM3_INGEST` cron (`scheduler.py:722`) + manifest worker | 30d | both | `sec_rate` | ✅ `insider_345.py` (#1130) | **WIRED** |

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -730,29 +730,13 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
     ),
-    ScheduledJob(
-        name=JOB_SEC_DEF14A_INGEST,
-        display_name="SEC DEF 14A ingest",
-        source="sec_rate",
-        description=(
-            "Parse SEC DEF 14A proxy statements into "
-            "``def14a_beneficial_holdings`` (#769 / #805). DEF 14A is "
-            "the canonical annual reconciliation point for both insiders "
-            "(officers + directors with proxy-disclosed beneficial "
-            "ownership) and 5%+ blockholders. Without this ingest, the "
-            "ownership rollup's def14a_unmatched slice is always empty "
-            "and the DEF 14A drift detector has nothing to reconcile "
-            "against — surfacing 0 rows in dev DB on operator audit "
-            "2026-05-03. Cadence: daily — proxy filings appear "
-            "~quarterly per issuer so daily catches them within a day "
-            "of EDGAR availability without burning bandwidth. Idempotent "
-            "via the (accession, holder_name) UNIQUE on the holdings "
-            "table + the def14a_ingest_log tombstone."
-        ),
-        cadence=Cadence.daily(hour=4, minute=35),
-        catch_up_on_boot=False,
-        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
-    ),
+    # `sec_def14a_ingest` retired from SCHEDULED_JOBS post-#1155:
+    # Layer 1/2/3 discovery + `sec_manifest_worker` + `manifest_parsers/
+    # def14a.py` (#1128) carry every DEF 14A write to
+    # `def14a_beneficial_holdings`. Weekly `sec_def14a_bootstrap` Sunday
+    # safety-net stays for one-shot drain. Function body + `_INVOKERS`
+    # entry + sweep-adapter `sec_def14a_sweep` kept so Admin "Run now"
+    # + the per-source sweep UI remain operator-callable.
     ScheduledJob(
         name=JOB_OWNERSHIP_OBSERVATIONS_SYNC,
         display_name="Ownership repair sweep",

--- a/docs/wiki/job-registry-audit.md
+++ b/docs/wiki/job-registry-audit.md
@@ -105,7 +105,7 @@ These follow the same archetype: zero-arg body → calls `ingest_<thing>(conn, p
 | `sec_filing_documents_ingest` | SEC filing-documents manifest ingest | hourly :35 | `_bootstrap_complete` | `ingest_filing_documents(conn, provider)` | bounded 500/run |
 | `sec_8k_events_ingest` | SEC 8-K events ingest | hourly :20 | `_bootstrap_complete` | `ingest_8k_events(conn, provider)` | bounded 200/run |
 | `sec_form3_ingest` | SEC Form 3 ingest | daily 04:20 | `_bootstrap_complete` | `ingest_form_3_filings(conn, provider)` | bounded |
-| `sec_def14a_ingest` | SEC DEF 14A ingest | daily 04:35 | `_bootstrap_complete` | `ingest_def14a(conn, provider)` | bounded 100/run |
+| ~~`sec_def14a_ingest`~~ | ~~SEC DEF 14A ingest~~ | **on-demand** post-#1155 | — | `ingest_def14a(conn, provider)` | bounded 100/run; manifest worker + `def14a.py` (#1128) carry steady-state. Weekly `sec_def14a_bootstrap` safety-net + sweep-adapter `sec_def14a_sweep` kept. |
 
 **Proposed PR1 surface (per job):**
 - `instrument_id: int | None` (primary) — single-instrument targeting.

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -411,6 +411,12 @@ class TestProductionInvokerRegistry:
             # (no UI consumer). Function stays in _INVOKERS for manual
             # trigger from Admin "Run now".
             "attribution_summary",
+            # #1155 legacy-cron retirement sweep — moved from
+            # SCHEDULED_JOBS to on-demand. Steady-state writes now come
+            # from manifest worker + per-source parsers. Function bodies
+            # + _INVOKERS entries kept so Admin "Run now" + sweep-adapter
+            # + bootstrap-stage dispatch continue to work.
+            "sec_def14a_ingest",
             # #994 (first-install bootstrap orchestrator) — these jobs
             # are dispatched by the bootstrap orchestrator (not SCHEDULED)
             # but registered in _INVOKERS so the orchestrator can call


### PR DESCRIPTION
Part of #1155.

## What

Second retirement in the post-#1155 sweep. Drops the daily 04:35 UTC `ScheduledJob` row for `sec_def14a_ingest` but moves the job to **on-demand** rather than full delete: function body + `_INVOKERS` entry + sweep adapter + watermark + scheduled-adapter category all preserved.

## Why on-demand (not full delete)

`sec_def14a_ingest` has more consumers than `sec_business_summary_ingest` did:

- Sweep-adapter `sec_def14a_sweep` (`app/services/processes/ingest_sweep_adapter.py:140`) declares `underlying_job="sec_def14a_ingest"` — the operator-facing per-source sweep button in Admin dispatches via this name. Keep the invoker so the button still routes.
- Admin "Run now" via `POST /jobs/sec_def14a_ingest/run` remains a manual escape hatch.

Steady-state writes to `def14a_beneficial_holdings` now flow through Layer 1/2/3 discovery (#1157) + `sec_manifest_worker` + `manifest_parsers/def14a.py` (#1128). The weekly Sunday `sec_def14a_bootstrap` safety net is unchanged.

## Diff

- `app/workers/scheduler.py`: drop the `ScheduledJob(name=JOB_SEC_DEF14A_INGEST, ...)` row from `SCHEDULED_JOBS`. Replace with explanatory comment. Function body + constant untouched.
- `tests/test_jobs_runtime.py`: add `"sec_def14a_ingest"` to `expected_on_demand` set under the `TestProductionInvokerRegistry` drift-guard.
- `docs/wiki/job-registry-audit.md`: mark row as on-demand.
- `.claude/skills/data-engineer/etl-endpoint-coverage.md`: update `sec_def14a` standard-refresh column.

## Test plan

- [x] `uv run ruff check .` — clean.
- [x] `uv run pyright` — 0 errors.
- [x] `uv run pytest tests/test_jobs_runtime.py -n0` — 35 passed (drift-guard parity preserved).

## ETL DoD clauses 8-12 — deferred

Per operator direction (2026-05-13): bootstrap held broken intentionally; ETL DoD smoke clauses 8-11 batched to end-of-epic clean-test pass. Coverage-parity argument is the per-PR correctness gate. Parser imports the same `_upsert_holding` + `def14a_ingest_log` writers the cron's service module exposed — no divergence by construction.

## Out of scope

- Retiring more than one cron in this PR (per #1155 spec).
- Cleaning up the sweep-adapter virtual process_id (kept as operator UI affordance).
- Dividend-extraction parser-gap (filed as #1158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)