### PR TITLE
feat(#1168): sec_10q synth no-op manifest parser + close G4

### DIFF
--- a/.claude/skills/data-engineer/etl-endpoint-coverage.md
+++ b/.claude/skills/data-engineer/etl-endpoint-coverage.md
@@ -6,7 +6,7 @@
 
 **Maintenance.** When a new endpoint is added, add a row and link the wiring layers to file:line. When a layer is wired or unwired, update the row and update [[us-source-coverage]] in memory.
 
-Last audit pass: 2026-05-13 (post #1152 / #1154 / 10-K manifest adapter shipped).
+Last audit pass: 2026-05-14 (post #1168 / sec_10q synth no-op parser shipped — closes G4).
 
 ---
 
@@ -43,7 +43,7 @@ Definition: `app/services/sec_manifest.py:106-121` + CHECK constraint `sql/118:3
 | `sec_13f_hr` | Stage 10 bulk + Stage 21 recent-sweep | manifest worker (post-#1155 — `JOB_SEC_13F_QUARTERLY_SWEEP` moved to on-demand; bootstrap stage 21 still dispatches it via `_INVOKERS` with `min_period_of_report` from `MANUAL_TRIGGER_JOB_METADATA`) | 120d | both | `sec_rate` | ✅ `sec_13f_hr.py` (#1133) | **WIRED**, PRN drop + 2023-01-03 VALUE cutover applied parser-side |
 | `sec_n_port` | Stage 12 bulk + Stage 22 legacy ingest | manifest worker (post-#1155 — `JOB_SEC_N_PORT_INGEST` moved to on-demand; bootstrap stage 22 still dispatches via `_INVOKERS`) | 90d | both | `sec_rate` | ✅ `sec_n_port.py` (#1133) | **WIRED** |
 | `sec_10k` | Stage 17 `sec_business_summary_bootstrap` | manifest worker (post-#1155 retirement of legacy `sec_business_summary_ingest` cron) + weekly `sec_business_summary_bootstrap` safety net | 120d | both | `sec_rate` | ✅ `sec_10k.py` (#1152, 2026-05-13) | **WIRED** — Option C `(filed_at, source_accession)` gate applied (sql/148). Legacy daily 03:15 cron retired in the first #1155 cron-retirement sweep — manifest path is sole steady-state writer. |
-| `sec_10q` | — | — | 60d | manifest only | — | ❌ blocked on **#414** | **GAP** — 10-Q parser owned by fundamentals ingest redesign (#414); manifest rows drain to "no parser" |
+| `sec_10q` | — | manifest worker (synth no-op per #1168) | 60d | both | `sec_rate` (unused by parser) | ✅ `sec_10q.py` (#1168) | **WIRED** — synth no-op (sec-edgar §11.5.1). Financial data lands via Companyfacts XBRL; narrative HTML has no v1 consumer. Parser body is `return ParseOutcome(status='parsed', parser_version='10q-noop-v1')`. Closes G4. |
 | `sec_n_csr` | — | — | 200d | manifest only | — | ❌ pending re-spike **#918 REOPENED 2026-05-13** | **GAP** — original close cited only EdgarTools surface; operator wants sample-driven evidence on raw payloads + HTML SoI layout + commercial-use survey before "infeasible". Tech-debt #1153 on hold. |
 | `sec_xbrl_facts` | Stage 9 `sec_companyfacts_ingest` (bulk-zip) + Stage 24 `fundamentals_sync` | `JOB_FUNDAMENTALS_SYNC` cron (`scheduler.py:562`) | 120d | manifest only (rows discovered but parser is bulk-path, not manifest dispatch) | `sec_rate` | ❌ by design — Company Facts API bulk path | **WIRED**, not a parser gap. Manifest rows may accumulate without drain; tracked tech-debt: either remove from enum or register synth no-op parser. |
 | `finra_short_interest` | — | — | 20d | manifest only | — (FINRA host has no pool) | ❌ pending **#915** (bimonthly) + **#916** (RegSHO daily) | **GAP** — parent #845 closed but PR1/PR2 split open. ManifestSource enum entry has no fetcher anywhere. |
@@ -168,7 +168,7 @@ These endpoints don't have a `ManifestSource` because they're not per-filing dis
 | G1 | Layer 1 Atom fast-lane unwired | OPEN | **#867 REOPENED 2026-05-13** | Wire under #1155 |
 | G2 | Layer 2 daily-index reconcile unwired | OPEN | **#868 REOPENED 2026-05-13** | Wire under #1155 |
 | G3 | Layer 3 per-CIK poll unwired | OPEN | **#870 REOPENED 2026-05-13** | Wire under #1155 |
-| G4 | `sec_10q` parser | BLOCKED | **#414** | Owned by fundamentals ingest redesign |
+| G4 | `sec_10q` parser | ✅ CLOSED 2026-05-14 | **#1168** | Synth no-op parser registered (sec-edgar §11.5.1). Owner-attribution to #414 was stale; #414 is the fundamentals_sync redesign, not a 10-Q parser ticket. |
 | G5 | `sec_n_csr` parser feasibility | PENDING SPIKE | **#918 REOPENED 2026-05-13** | Sample-driven spike pending |
 | G6 | `finra_short_interest` ingest | OPEN | **#915 + #916** | Bimonthly + RegSHO daily; parent #845 closed |
 | G7 | `sec_xbrl_facts` ManifestSource has no parser | BY DESIGN | — | Company Facts API bulk path; tech-debt: either remove from enum or register synth no-op parser |

--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -634,15 +634,40 @@ Adopted in #1152 (`instrument_business_summary` + `filed_at` column added by sql
 
 ### 11.5 Stranded ManifestSource entries
 
-`ManifestSource` enum (sql/118 CHECK + `app/services/sec_manifest.py:106`) lists 14 values. Three carry no manifest parser by design:
+`ManifestSource` enum (sql/118 CHECK + `app/services/sec_manifest.py:106`) lists 14 values. Two carry no manifest parser by design:
 
 | Source | Why no parser |
 |---|---|
-| `sec_xbrl_facts` | XBRL Company Facts ingested via bulk Company Facts API path, NOT per-filing manifest dispatch. |
-| `sec_n_csr` | EdgarTools `FundShareholderReport` exposes only OEF iXBRL fund-level facts (NAV / expense ratio / top-holdings %); per-issuer Schedule of Investments lives in free-form HTML/PDF, not XBRL. CUSIP-resolved per-issuer holdings unextractable. Resolved as "not technically feasible as scoped" — see #918 closing comment. Discovery may still write manifest rows that never drain. Tech-debt eligible: either remove from `ManifestSource` Literal + `_FORM_TO_SOURCE` map, OR register a synth "no-op tombstone" parser. |
-| `sec_10q` | Blocked on #414 — the fundamentals ingest redesign owns the 10-Q parser. |
+| `sec_xbrl_facts` | XBRL Company Facts ingested via bulk Company Facts API path, NOT per-filing manifest dispatch. Eligible to adopt the §11.5.1 synth no-op shape so manifest rows drain. |
+| `sec_n_csr` | EdgarTools `FundShareholderReport` exposes only OEF iXBRL fund-level facts (NAV / expense ratio / top-holdings %); per-issuer Schedule of Investments lives in free-form HTML/PDF, not XBRL. **#918 REOPENED 2026-05-13 pending sample-driven re-spike** (acceptance criteria in the reopen comment) — original close cited only the EdgarTools surface, operator wants raw N-CSR payload survey + commercial-use vendor check before "infeasible" is final. Discovery may still write manifest rows that never drain in the interim. If the spike returns INFEASIBLE: adopt the §11.5.1 synth no-op shape so manifest rows drain; if FEASIBLE: register a real parser and remove this row. Tech-debt #1153 on hold pending the spike. |
 
 `finra_short_interest` is not stranded — split tickets #915 (bimonthly) + #916 (RegSHO daily) are open. Parent #845 closed.
+
+### 11.5.1 Synth no-op parser pattern (`sec_10q` exemplar)
+
+`sec_10q` was historically listed in §11.5 as "blocked on #414". Audit (2026-05-14, #1168) found #414's actual scope is the `fundamentals_sync` cron redesign — not a 10-Q manifest parser. The 10-Q's financial data already lands via Companyfacts XBRL; its narrative HTML has no operator-visible consumer in v1. The right fix was a synth no-op parser, not a fetcher.
+
+`app/services/manifest_parsers/sec_10q.py` (PR for #1168) is the canonical reference. Shape:
+
+- `requires_raw_payload=False` (no payload).
+- Parser body returns `ParseOutcome(status='parsed', parser_version='<source>-noop-v1')` without DB writes, fetches, or typed-table touches.
+- Durability test (`tests/test_manifest_parser_sec_10q.py::test_parser_does_not_touch_db_or_fetch`) asserts via sentinel connection + monkeypatched `store_raw` (both service-layer + module-local paths) + monkeypatched `fetch_document_text` that the parser stays a no-op. A future regression into a fetcher fails the test loudly.
+- `register_parser('<source>', _parse_<source>, requires_raw_payload=False)` in the source's `register()` callable.
+
+**When to use this pattern:**
+
+- A source's SQL coverage is complete via another path (e.g. Companyfacts XBRL).
+- The narrative payload has no operator-visible consumer in v1.
+- The manifest discovery row alone is sufficient audit.
+
+**When NOT to use this pattern:**
+
+- A typed-table consumer exists or is in scope (the parser must extract; see §11.1 for the full contract).
+- The narrative payload is the only source for an operator-visible figure (the parser must fetch + parse + write).
+
+If a future MD&A / risk-factor consumer for 10-Q materialises, that PR replaces the synth no-op with a full parser, adds the `fetch_document_text` allow-list entry + SQL normalisation path in lockstep per "Every structured field lands in SQL" (prevention-log #448).
+
+Eligible adoptions for the same shape: `sec_xbrl_facts` (companyfacts API is the per-period writer; manifest rows can drain via synth no-op); `sec_n_csr` if the #918 spike returns INFEASIBLE.
 
 ### 11.6 Discovery layer wiring (Layer 1 / 2 / 3) — audit 2026-05-13
 

--- a/app/services/manifest_parsers/__init__.py
+++ b/app/services/manifest_parsers/__init__.py
@@ -37,6 +37,7 @@ from app.services.manifest_parsers import def14a as _def14a
 from app.services.manifest_parsers import eight_k as _eight_k
 from app.services.manifest_parsers import insider_345 as _insider_345
 from app.services.manifest_parsers import sec_10k as _sec_10k
+from app.services.manifest_parsers import sec_10q as _sec_10q
 from app.services.manifest_parsers import sec_13dg as _sec_13dg
 from app.services.manifest_parsers import sec_13f_hr as _sec_13f_hr
 from app.services.manifest_parsers import sec_n_port as _sec_n_port
@@ -50,6 +51,7 @@ def register_all_parsers() -> None:
     _eight_k.register()
     _def14a.register()
     _sec_10k.register()
+    _sec_10q.register()  # synth no-op per sec-edgar §11.5.1 (#1168)
     _sec_13dg.register()  # registers BOTH sec_13d and sec_13g
     _insider_345.register()  # registers sec_form3 + sec_form4 + sec_form5
     _sec_13f_hr.register()

--- a/app/services/manifest_parsers/sec_10q.py
+++ b/app/services/manifest_parsers/sec_10q.py
@@ -1,0 +1,101 @@
+"""sec_10q manifest-worker parser — synth no-op adapter (#1168).
+
+10-Q financial-statement data already lands via the Companyfacts XBRL
+path (``fundamentals_sync`` daily cron + Stage 24 bootstrap). 10-Q
+narrative HTML (MD&A, risk-factors, controls) has no operator-visible
+consumer in v1. The manifest discovery row IS the audit signal for
+this source; no per-filing payload work is needed.
+
+This adapter exists to drain ``sec_filing_manifest`` rows for
+``source='sec_10q'`` cleanly so:
+
+- ``/coverage/manifest-parsers`` reports ``has_registered_parser=True``
+- ``WorkerStats.skipped_no_parser_by_source['sec_10q']`` stays at 0
+- Real lane-stuck conditions surface against a clean baseline
+
+If a future PR introduces an MD&A / risk-factor extraction consumer,
+that PR adds the fetcher + the
+``tests/test_fetch_document_text_callers.py`` allow-list update + the
+SQL normalisation pathway in lockstep, per the
+"Every structured field lands in SQL" prevention contract.
+
+ParseOutcome contract:
+
+* ``status='parsed'`` — always. The manifest row's existence proves
+  the filing was discovered; no further per-filing work is in scope.
+* No ``tombstoned`` branch — there is no failure mode that requires
+  permanent discard of the manifest row. The synth no-op does not
+  consume URL or instrument_id.
+* No ``failed`` branch — there is no DB write that can raise; there
+  is no fetch that can raise.
+
+Raw-payload invariant (#938): registered with
+``requires_raw_payload=False`` — this is a synth source per
+sec-edgar §11.5.1. The worker accepts ``parsed`` with
+``raw_status=None``.
+
+Pattern reference: sec-edgar §11.5.1 documents the "synth no-op
+parser" as the canonical fix for sources whose SQL coverage is
+complete via another path. This module is the canonical exemplar
+for the pattern; ``sec_xbrl_facts`` and (if INFEASIBLE) ``sec_n_csr``
+are eligible to adopt the same shape.
+
+Codex pre-spec review:
+
+* Round 1 BLOCKING ×3 against an earlier raw-fetch-no-op design
+  (fetch_document_text allow-list violation; raw persistence
+  redundant per prevention-log #470 since Companyfacts XBRL covers
+  the SQL surface; raise_for_status() body-loss timing). All
+  resolved by the pivot to true no-op in this module.
+* Round 2 BLOCKING (durability test too weak) + 3 WARNING. All
+  resolved in test shape — see
+  ``tests/test_manifest_parser_sec_10q.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+_PARSER_VERSION_10Q = "10q-noop-v1"
+
+
+def _parse_sec_10q(
+    conn: psycopg.Connection[Any],  # noqa: ARG001 — synth no-op uses no DB
+    row: Any,  # ManifestRow — forward-ref to avoid circular import
+) -> Any:  # ParseOutcome — forward-ref
+    """Synth no-op: mark the row parsed without touching SEC or DB.
+
+    The manifest discovery row IS the audit. Financial data lands via
+    Companyfacts XBRL; narrative HTML has no v1 consumer. Returning
+    ``parsed`` lets the worker transition the row and drains the lane
+    without burning fetch budget or writing redundant raw bytes.
+    """
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    logger.debug(
+        "sec_10q manifest parser: synth no-op for accession=%s "
+        "(financial data lands via Companyfacts XBRL; no per-filing payload work in v1)",
+        row.accession_number,
+    )
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_PARSER_VERSION_10Q,
+    )
+
+
+def register() -> None:
+    """Register the synth no-op parser with the manifest worker.
+
+    Idempotent — ``register_parser`` is last-write-wins. Called once
+    from ``app.services.manifest_parsers.register_all_parsers`` at
+    package import time, and re-callable from tests after a registry
+    wipe.
+    """
+    from app.jobs.sec_manifest_worker import register_parser
+
+    register_parser("sec_10q", _parse_sec_10q, requires_raw_payload=False)

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -256,7 +256,7 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
             help_text=(
                 "Universe-wide rebuild for one source "
                 "(sec_form4 / sec_13d / etc). Most expensive option. "
-                "Note: sec_xbrl_facts / sec_n_csr / sec_10q / "
+                "Note: sec_xbrl_facts / sec_n_csr / "
                 "finra_short_interest may resolve to zero triples if "
                 "data_freshness_index has no rows for that source, OR "
                 "reset triples that the manifest worker then "

--- a/docs/superpowers/specs/2026-05-14-sec-10q-manifest-parser-noop.md
+++ b/docs/superpowers/specs/2026-05-14-sec-10q-manifest-parser-noop.md
@@ -1,0 +1,307 @@
+# `sec_10q` manifest parser — synth no-op adapter
+
+Date: 2026-05-14
+Codex pre-spec round 1: 3 BLOCKING → pivoted from raw-fetch-no-op to true no-op (this revision).
+
+## Background — what the gap actually is
+
+Gap G4 in `.claude/skills/data-engineer/etl-endpoint-coverage.md` was historically attributed to **#414** ("Fundamentals ingest redesign"). Audit of #414's body + the 2026-04-28 scope-trim comment shows that ticket is about the `fundamentals_sync` cron's blocking behaviour during XBRL seed — **not** about wiring a `sec_10q` manifest parser. The "10-Q parser owned by #414" line in `[[us-source-coverage]]` and `etl-endpoint-coverage.md:46` is stale lineage and is re-pointed at the new ticket this spec opens.
+
+What 10-Qs actually carry:
+
+1. **XBRL financial facts** — quarterly revenue / EPS / balance sheet / cash flow. Already ingested via `data.sec.gov/api/xbrl/companyfacts/CIK*.json` by `fundamentals_sync` (Stage 24 + daily cron). Every Fundamentals metric in the catalog (`.claude/skills/metrics-analyst/SKILL.md` §2) lands per-quarter regardless of whether we parse the 10-Q HTML.
+2. **Filing metadata** — accession, filed_at, period_of_report. Already populated in `filing_events` by the legacy submissions ingest path. "Last 10-Q date" renders today (`metrics-analyst SKILL.md:361`).
+3. **Narrative HTML body** — MD&A, risk-factor updates, legal proceedings, controls. **Not extracted anywhere.** No operator-visible metric in the catalog consumes it as of 2026-05-14.
+
+What's currently broken:
+
+- `sec_10q` rows accumulate in `sec_filing_manifest` (post-#1155 Layer 1/2/3 wiring populates them aggressively).
+- No registered parser → worker debug-skips them → `skipped_no_parser_by_source['sec_10q']` grows.
+- The operator's manifest backlog signal carries permanent noise (`/coverage/manifest-parsers.has_registered_parser=False` for sec_10q) that masks real lane-stuck conditions.
+
+## Goal
+
+Register a synth no-op `sec_10q` parser with the manifest worker that transitions 10-Q / 10-Q/A rows from `pending` → `parsed` **without fetching the primary document and without writing any payload**. The parser asserts "the manifest discovery row IS the audit for this source; XBRL Company Facts owns the per-period data; no per-filing HTML extraction is required in v1."
+
+## Scope
+
+**In:**
+
+- `app/services/manifest_parsers/sec_10q.py` — new synth no-op adapter (~50 lines including docstring).
+- `app/services/manifest_parsers/__init__.py` — import + `register()` call.
+- `tests/test_manifest_parser_sec_10q.py` — adapter contract tests.
+- `app/services/processes/param_metadata.py:259` — remove `sec_10q` from the "may debug-skip" help text (it now has a parser).
+- `.claude/skills/data-engineer/etl-endpoint-coverage.md` — update §2 row 12 (`sec_10q`) + §7 G4 row.
+- `.claude/skills/data-sources/sec-edgar.md` §11.5 — remove `sec_10q` from stranded table; cite this PR as exemplar of the synth no-op pattern.
+
+**Out:**
+
+- Any payload fetch (`fetch_document_text`) — explicitly NOT added; preserves the pinned `tests/test_fetch_document_text_callers.py` contract.
+- Any `store_raw` call. No raw HTML archive in this PR.
+- Any typed-table extraction (MD&A text, risk-factor diffs, item-level structuring).
+- Any share-class fan-out (no per-instrument writes).
+- Any Option C `(filed_at, source_accession)` gate (no per-instrument typed-table to overwrite).
+- Any schema migration (`sec_10q` enum value already in `ManifestSource`; no new tables).
+- Retirement of `fundamentals_sync` / Companyfacts XBRL path. That remains the financial-data SoT.
+- Adjusting #414's scope. #414 stays as-is; this work closes G4 with a new ticket.
+
+## Architecture rationale — why a synth no-op
+
+Three options were considered. Codex pre-spec round 1 flagged the raw-only middle option as a contract violation; the true no-op is the only option that satisfies all invariants.
+
+| Option | What it does | Verdict |
+|---|---|---|
+| **A. Synth no-op (CHOSEN)** | Mark manifest `parsed` with no fetch, no store_raw, no typed write. `requires_raw_payload=False`. | Cleanest. Matches sec-edgar §11.5's documented tech-debt pattern: "register a synth 'no-op tombstone' parser". Honours the `fetch_document_text` allow-list contract. Zero new disk / fetch cost. |
+| B. Raw-only no-op (fetch + store_raw) | Fetch primary doc, archive HTML, mark parsed | **REJECTED.** Codex BLOCKING ×3: (1) violates pinned `fetch_document_text` caller allow-list; (2) prevention-log #470 says raw persistence "redundant, not audit" when SQL coverage complete (which it is via Companyfacts XBRL); (3) `raise_for_status()` runs before body is returned so 403/429/5xx bodies are dropped pre-persistence per prevention-log §544. |
+| C. Drop `sec_10q` from `ManifestSource` enum | Manifest stops manifesting 10-Qs | Loses discovery telemetry. Conflicts with #1155's "manifest is single source of truth" direction. §11.5 explicitly favours synth no-op over enum removal. |
+
+The synth no-op pattern is documented in sec-edgar §11.5 today **only** for `sec_n_csr` (the `sec_xbrl_facts` row notes its own tech-debt; the `sec_10q` row still says "Blocked on #414"). This PR is the first concrete application of the pattern AND simultaneously rewrites §11.5 so the table reflects the new reality. `sec_10q` exits the "stranded by design" table because it now has a registered parser; the §11.5 row count drops from "Three" to "Two", and a new exemplar callout names this PR's parser as the canonical reference for the pattern.
+
+Exact §11.5 replacement:
+
+```diff
+  ### 11.5 Stranded ManifestSource entries
+
+- `ManifestSource` enum (sql/118 CHECK + `app/services/sec_manifest.py:106`) lists 14 values. Three carry no manifest parser by design:
++ `ManifestSource` enum (sql/118 CHECK + `app/services/sec_manifest.py:106`) lists 14 values. Two carry no manifest parser by design:
+
+  | Source | Why no parser |
+  |---|---|
+  | `sec_xbrl_facts` | XBRL Company Facts ingested via bulk Company Facts API path, NOT per-filing manifest dispatch. |
+  | `sec_n_csr` | EdgarTools `FundShareholderReport` exposes only OEF iXBRL fund-level facts ... Tech-debt eligible: either remove from `ManifestSource` Literal + `_FORM_TO_SOURCE` map, OR register a synth no-op parser using the `sec_10q` shape (see [11.5.1 below](#1151-synth-no-op-parser-pattern-sec_10q)). |
+- | `sec_10q` | Blocked on #414 — the fundamentals ingest redesign owns the 10-Q parser. |
++
++ ### 11.5.1 Synth no-op parser pattern (`sec_10q` exemplar)
++
++ `sec_10q` was historically listed above as "blocked on #414". Audit (2026-05-14) found #414's scope is the `fundamentals_sync` cron redesign — NOT a 10-Q manifest parser. The 10-Q's financial data already lands via Companyfacts XBRL; its narrative HTML has no operator-visible consumer in v1. The right fix was a synth no-op parser, not a fetcher — `app/services/manifest_parsers/sec_10q.py` is the canonical reference. The shape:
++
++ - `requires_raw_payload=False` (no payload).
++ - Parser body returns `ParseOutcome(status='parsed', parser_version='<source>-noop-v1')` without DB writes, fetches, or typed-table touches.
++ - Durability test (`tests/test_manifest_parser_sec_10q.py::test_parser_does_not_touch_db_or_fetch`) asserts via sentinel connection + monkeypatched `store_raw` / `fetch_document_text` that the parser stays a no-op.
++ - `register_parser('<source>', _parse_<source>, requires_raw_payload=False)` in the source's `register()` callable.
++
++ Eligible adoptions: `sec_xbrl_facts` (companyfacts API is the per-period writer; manifest rows can drain via synth no-op); `sec_n_csr` if the #918 spike returns INFEASIBLE.
+
+  `finra_short_interest` is not stranded — split tickets #915 (bimonthly) + #916 (RegSHO daily) are open. Parent #845 closed.
+```
+
+The same shape can later be applied to `sec_xbrl_facts` (companyfacts-API path) and to `sec_n_csr` (if the #918 spike returns INFEASIBLE).
+
+If a future MD&A / risk-factor consumer materialises, **that PR** adds the fetcher + the allow-list update + the SQL normalisation in lockstep — exactly per the prevention contract. Until that consumer exists, fetching is premature.
+
+## Settled-decisions touched
+
+- **§"Filing event storage"** (settled-decisions.md:84) — `filing_events` stores metadata; "if full raw filing text is needed later, use a separate table, not `filing_events`". This PR writes nothing to `filing_events` and nothing to `filing_raw_documents`. PRESERVED.
+- **§"Fundamentals provider posture"** (settled-decisions.md:48) — Free regulated source only. US fundamentals via SEC XBRL Company Facts. PRESERVED: no fundamentals path change; the 10-Q financial data continues to land via Companyfacts XBRL.
+- **§"CIK = entity, CUSIP = security"** (settled-decisions.md:384) — Share-class fan-out applies to entity-level data writes per instrument. This PR writes nothing per instrument. NOT APPLICABLE.
+- **§"Process topology (#719)"** (settled-decisions.md:324) — Manifest worker runs in jobs process. The parser code lives in `app.services.manifest_parsers` and is imported by both API (`app/main.py`) and jobs (`app/jobs/__main__.py`) for registry-view consistency. PRESERVED.
+- **§"Product-visibility pivot"** (settled-decisions.md:306) — every new ticket should answer YES to "Would the operator feel this moves the product closer to 'I can manage my fund from this screen'?" — YES, indirectly: removes a permanent noise source from the manifest backlog signal so real lane-stuck conditions surface clearly.
+
+## Prevention-log entries that apply
+
+- **#470 "Raw payload persistence scope narrowed"** (prevention-log.md:530) — raw persistence redundant when SQL coverage complete. 10-Q financial data is SQL-complete via Companyfacts XBRL → no raw persistence required. PRESERVED.
+- **"Every structured field from an upstream document lands in SQL"** (prevention-log.md:1171 + `tests/test_fetch_document_text_callers.py`) — pinned `fetch_document_text` caller allow-list. This PR adds NO new caller. PRESERVED.
+- **"Bare call after committed savepoint can split raw/manifest status"** (prevention-log.md:1251) — no committed savepoint in this PR (no `store_raw`). NOT APPLICABLE.
+- **"Manifest parser parse-failure broad-except writes ingest-log on EVERY exception class"** (prevention-log.md:1257) — synth no-op has no parse step that can raise. NOT APPLICABLE.
+- **"Manifest parser upsert exception must discriminate transient vs deterministic"** (prevention-log.md:1263) — no upsert in this PR. NOT APPLICABLE.
+- **"Raw payload persistence must precede `raise_for_status()`"** (prevention-log.md:544) — no fetch in this PR. NOT APPLICABLE.
+
+## Implementation — `app/services/manifest_parsers/sec_10q.py`
+
+```python
+"""sec_10q manifest-worker parser — synth no-op adapter.
+
+10-Q financial-statement data already lands via the Companyfacts XBRL
+path (``fundamentals_sync`` daily cron + Stage 24 bootstrap). 10-Q
+narrative HTML (MD&A, risk-factors, controls) has no operator-visible
+consumer in v1. The manifest discovery row IS the audit signal for
+this source; no per-filing payload work is needed.
+
+This adapter exists to drain ``sec_filing_manifest`` rows for
+``source='sec_10q'`` cleanly so:
+
+- ``/coverage/manifest-parsers`` reports ``has_registered_parser=True``
+- ``WorkerStats.skipped_no_parser_by_source['sec_10q']`` stays at 0
+- Real lane-stuck conditions surface against a clean baseline
+
+If a future PR introduces an MD&A / risk-factor extraction consumer,
+that PR adds the fetcher + the
+``tests/test_fetch_document_text_callers.py`` allow-list update + the
+SQL normalisation pathway in lockstep, per the
+"Every structured field lands in SQL" prevention contract.
+
+ParseOutcome contract:
+
+* ``status='parsed'`` — always. The manifest row's existence proves
+  the filing was discovered; no further per-filing work is in scope.
+* No ``tombstoned`` branch — there is no failure mode that requires
+  permanent discard of the manifest row. Even a missing
+  ``primary_document_url`` is acceptable: a future MD&A PR would
+  need to handle that case, but for the synth no-op the URL is
+  unused.
+* No ``failed`` branch — there is no DB write that can raise; there
+  is no fetch that can raise.
+
+Raw-payload invariant (#938): registered with
+``requires_raw_payload=False`` — this is a synth source per
+sec-edgar §11.5. The worker accepts ``parsed`` with
+``raw_status=None``.
+
+Pattern reference: sec-edgar §11.5 documents the "synth no-op
+tombstone" parser as the recommended tech-debt fix for sources whose
+SQL coverage is complete via another path (``sec_xbrl_facts``,
+``sec_n_csr``). This PR is the first concrete application.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+_PARSER_VERSION_10Q = "10q-noop-v1"
+
+
+def _parse_sec_10q(
+    conn: psycopg.Connection[Any],
+    row: Any,  # ManifestRow — forward-ref to avoid circular import
+) -> Any:  # ParseOutcome — forward-ref
+    """Synth no-op: mark the row parsed without touching SEC or DB."""
+    from app.jobs.sec_manifest_worker import ParseOutcome
+
+    logger.debug(
+        "sec_10q manifest parser: synth no-op for accession=%s "
+        "(financial data lands via Companyfacts XBRL; no per-filing payload work in v1)",
+        row.accession_number,
+    )
+    return ParseOutcome(
+        status="parsed",
+        parser_version=_PARSER_VERSION_10Q,
+    )
+
+
+def register() -> None:
+    """Register the synth no-op parser with the manifest worker."""
+    from app.jobs.sec_manifest_worker import register_parser
+
+    register_parser("sec_10q", _parse_sec_10q, requires_raw_payload=False)
+```
+
+### Registration
+
+`app/services/manifest_parsers/__init__.py`:
+
+```python
+from app.services.manifest_parsers import sec_10q as _sec_10q  # new
+...
+def register_all_parsers() -> None:
+    _eight_k.register()
+    _def14a.register()
+    _sec_10k.register()
+    _sec_10q.register()  # new — synth no-op
+    _sec_13dg.register()
+    _insider_345.register()
+    _sec_13f_hr.register()
+    _sec_n_port.register()
+```
+
+### Param-metadata help text update
+
+`app/services/processes/param_metadata.py:259`:
+
+```diff
+- "Note: sec_xbrl_facts / sec_n_csr / sec_10q / "
+- "finra_short_interest may resolve to zero triples if "
++ "Note: sec_xbrl_facts / sec_n_csr / finra_short_interest "
++ "may resolve to zero triples if "
+  "data_freshness_index has no rows for that source, OR "
+  "reset triples that the manifest worker then "
+  "debug-skips (no parser registered yet). Operator-"
+  "visible outcome is scope_triples=N + "
+  "discovery_new=0 in the job log."
+```
+
+`sec_10q` exits the "no parser registered" list as of this PR. Operator now sees `parsed=N` for `sec_10q` rebuilds rather than `skipped_no_parser`.
+
+## Five-step contract (sec-edgar §11.1) compliance
+
+| # | Rule | How this PR satisfies |
+|---|---|---|
+| 1 | `register()` callable in `app/services/manifest_parsers/<source>.py` | `app/services/manifest_parsers/sec_10q.py::register` |
+| 2 | Import + register in `__init__.py::register_all_parsers` | added |
+| 3 | `requires_raw_payload=True` for payload-backed sources | NO — this is a synth no-op per §11.5. `requires_raw_payload=False` is correct because no payload is fetched or stored. |
+| 4 | Wrap every DB write in `conn.transaction()` | No DB writes in the parser. NOT APPLICABLE. |
+| 5 | Failed outcomes set `next_retry_at` explicitly | No failed branch. NOT APPLICABLE. |
+
+Rule 3 deviation is acceptable per §11.5's explicit allowance for synth no-op parsers ("synth no-op tombstone" — by design no payload).
+
+## Tests — `tests/test_manifest_parser_sec_10q.py`
+
+Four scenarios. ~120 lines.
+
+| Test | Manifest input | Expected outcome |
+|---|---|---|
+| `test_synth_no_op_marks_parsed` | pending 10-Q row, valid URL + instrument_id (via `record_manifest_entry` with `subject_type='issuer'`) | run via `run_manifest_worker(conn, source='sec_10q')`. Manifest row transitions to `parsed`, `parser_version='10q-noop-v1'`. Post-assert: zero `filing_raw_documents` rows for that accession; no rows in `instrument_business_summary` / `instrument_business_summary_sections` (sibling typed tables that COULD be written by accident). |
+| `test_synth_no_op_handles_10qa_amendment` | pending 10-Q/A row | manifest=`parsed`. Same code path; no fallback semantics. |
+| `test_register_all_parsers_includes_sec_10q` | (registry test) | `clear_registered_parsers()` → `register_all_parsers()` → assert `'sec_10q' in registered_parser_sources()`. The clear-first step is mandatory: a registry leak from a prior test would false-pass without `__init__.py` actually wiring `sec_10q`. |
+| `test_parser_does_not_touch_db_or_fetch` (durability gate) | Invoke `_parse_sec_10q(sentinel_conn, fake_row)` directly. `sentinel_conn` is a stub whose `execute` / `cursor` / `transaction` methods all raise `AssertionError("synth no-op must not touch DB")`. Monkeypatch BOTH `app.services.raw_filings.store_raw` AND `app.services.manifest_parsers.sec_10q.store_raw` (defensive — module-local import path) with a sentinel that raises if called. Monkeypatch `app.providers.implementations.sec_edgar.SecFilingsProvider.fetch_document_text` with a sentinel that raises if called. | Parser returns `ParseOutcome(status='parsed', parser_version='10q-noop-v1')` without invoking any of the sentinels. The triple-block test forces any future contributor who adds `conn.execute(...)`, `store_raw(...)`, or `fetch_document_text(...)` to also update this test — surfacing the spec-revision + Codex-review requirement instead of silently regressing into the raw-only design Codex round 1 rejected. |
+
+Total: 4 tests.
+
+The `monkeypatch(..., raising=False)` form is used on the parser-module-local `store_raw` symbol because today the module doesn't import it; without `raising=False`, monkeypatch fails on an absent attribute. The defensive symbol-patch catches a future regression where someone adds `from app.services.raw_filings import store_raw` at the top of `sec_10q.py` and uses the local binding.
+
+Fixtures: `ebull_test_conn` from `tests/fixtures/ebull_test_db.py`, `_seed_instrument` helper, `record_manifest_entry` to insert pending rows. Mirrors `tests/test_manifest_parser_sec_10k.py` shape but trimmed to the no-op surface. Note: `record_manifest_entry` enforces `subject_type='issuer' ⇒ instrument_id IS NOT NULL` ([app/services/sec_manifest.py:222-227](app/services/sec_manifest.py#L222-L227)), so "missing instrument_id" is not reachable via the helper and is NOT in the test matrix — the synth no-op parser doesn't read `instrument_id` regardless, so the case carries no behavioural coverage.
+
+## Validation — what to smoke after merge
+
+Per CLAUDE.md ETL DoD §8-11:
+
+1. **Smoke panel (clause 8):** AAPL, MSFT, JPM, HD, GME — each has multiple 10-Q filings in the last 8-quarter horizon. Trigger `POST /jobs/sec_rebuild/run` with `{"source": "sec_10q"}` on dev DB. Expected outcome: matching `sec_filing_manifest` rows transition from `pending` → `parsed` with `parser_version='10q-noop-v1'`. NO `filing_raw_documents` rows created; no typed tables written.
+2. **Cross-source verify (clause 9):** spot-check one accession on AAPL — fetch `https://data.sec.gov/submissions/CIK0000320193.json`, pick the latest `form='10-Q'` accession, confirm the matching `sec_filing_manifest` row has `ingest_status='parsed'` post-rebuild. Independent source: SEC EDGAR direct.
+3. **Backfill executed (clause 10):** `POST /jobs/sec_rebuild/run` with `{"source": "sec_10q"}` resets matching `sec_filing_manifest` rows to `pending`; manifest worker drains them on the next tick. Drain cost is one DB UPDATE per row (no SEC fetch, no payload write).
+4. **Operator-visible figure (clause 11):** the `/coverage/manifest-parsers` audit endpoint flips `has_registered_parser=True` for `sec_10q`; the per-source `skipped_no_parser_by_source['sec_10q']` counter is zero on the next worker tick.
+5. **PR description records SHA per clause** — per CLAUDE.md ETL DoD §12.
+
+Per operator direction 2026-05-13, clauses 8-11 verification is deferred to end-of-epic clean-test pass; this PR records the **coverage-parity argument** (no new operator-visible figure changes; no payload writes; no schema changes; no SQL coverage change) as the standalone per-PR gate.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Future contributor regresses to a raw-fetch design ("we should archive the HTML too") | `test_parser_does_not_touch_db_or_fetch` raises if `conn.execute` / `conn.cursor` / `conn.transaction` / `store_raw` / `fetch_document_text` is called. Forces spec-revision + Codex-review flow. The parser docstring + §11.5 reference make the design rationale explicit. |
+| Operator confusion — "parsed" without payload looks like a bug | Param-metadata help-text update names the synth no-op path explicitly. Docstring on the parser explains the design. Future ops-docs / runbook update can name the pattern by name ("synth no-op manifest sources"). |
+| If MD&A consumer materialises, this PR has to be partially undone | The undo is purely additive: a future PR adds a fetcher, swaps the parser body, and updates `requires_raw_payload=True`. The current PR's tests change (the "does not fetch" guard would be deleted). No data migration. No revert. |
+| Stale `[[us-source-coverage]]` line about "owned by #414" + ambiguous attribution in sec-edgar §11.5 | Both updated in this PR. Sec-edgar §11.5 row for `sec_10q` will be removed and a new "concrete synth no-op example" reference added pointing at this PR. Coverage matrix §2 row 12 + §7 G4 row both repointed at the new ticket. |
+
+## Out-of-scope follow-ups
+
+- Full MD&A extraction (typed table) — open if a thesis-writer / news-sentiment consumer requires it.
+- Risk-factor diff extraction (10-Q risk factors are deltas from 10-K) — open if operator-visible chart materialises.
+- Apply the same synth no-op pattern to `sec_xbrl_facts` (companyfacts-API path) — eligible tech-debt; §11.5 already notes it.
+- Apply the synth no-op pattern to `sec_n_csr` if the #918 re-spike returns INFEASIBLE.
+
+## Acceptance
+
+- New ticket opens, scope = this spec.
+- Parser registered in `register_all_parsers()`.
+- 4 tests pass (including the "does not touch DB or fetch" durability gate).
+- `/coverage/manifest-parsers` flips `has_registered_parser=True` for `sec_10q`.
+- `param_metadata.py:259` help text updated.
+- Coverage matrix §2 row 12 + §7 G4 + sec-edgar §11.5 + memory entries updated.
+- No new operator-visible chart; no schema migration; no SQL coverage change; no new `fetch_document_text` caller.
+- DoD §8-11 deferred to end-of-epic per operator direction; coverage-parity argument is the standalone per-PR gate.
+
+## References
+
+- `.claude/skills/data-sources/sec-edgar.md` §11.1 (architecture rule) + §11.2 (horizon) + §11.5 (stranded list — pattern source).
+- `.claude/skills/data-engineer/etl-endpoint-coverage.md` §2 row 12 + §7 G4 (to be updated).
+- `tests/test_fetch_document_text_callers.py` (the pinned caller contract this PR explicitly does NOT amend).
+- Memory: `[[us-source-coverage]]` line 28 + `[[873-manifest-worker-parser-rollout]]` "Remaining work" line 38 (both to be updated to point at the new ticket).
+- Sibling spec for shape (full parser): `docs/superpowers/specs/2026-05-13-1151-10k-manifest-parser.md`.
+- Settled-decisions §"Filing event storage" + §"Fundamentals provider posture" + §"Process topology" + §"Product-visibility pivot".
+- Prevention-log #470 (raw persistence redundant when SQL complete) + "Every structured field lands in SQL".
+- Codex pre-spec round 1 transcript: 3 BLOCKING, all resolved by pivot from raw-only to synth no-op.
+- Codex pre-spec round 2 transcript: 1 BLOCKING (durability-test shape) + 3 WARNING (§11.5 wording overstated; registry-test missing `clear_registered_parsers`; impossible "missing instrument_id" case). All resolved in this revision: durability gate strengthened to sentinel-conn + module-local `store_raw` patch; §11.5 includes explicit replacement text; `clear_registered_parsers()` added to registry test; impossible cases dropped.

--- a/tests/test_fetch_document_text_callers.py
+++ b/tests/test_fetch_document_text_callers.py
@@ -102,6 +102,14 @@ _ALLOWED_CALLER_FILES: frozenset[str] = frozenset(
         "tests/test_manifest_parser_sec_13f_hr.py",
         "tests/test_manifest_parser_sec_n_port.py",
         "tests/test_sec_pipelined_fetcher.py",
+        # Synth no-op manifest parser (#1168). NOT a caller — the
+        # parser body explicitly returns ParseOutcome(parsed) without
+        # any fetch. The grep matches only the docstring + module
+        # name, which reference the symbol to document the
+        # non-caller invariant. Adjacent test patches the method
+        # with a raising sentinel to enforce non-call at runtime.
+        "app/services/manifest_parsers/sec_10q.py",
+        "tests/test_manifest_parser_sec_10q.py",
         # This guard file itself references the method name in its
         # contract sentence.
         "tests/test_fetch_document_text_callers.py",

--- a/tests/test_manifest_parser_sec_10q.py
+++ b/tests/test_manifest_parser_sec_10q.py
@@ -1,0 +1,285 @@
+"""Tests for the 10-Q synth no-op manifest-worker parser adapter (#1168).
+
+Covers:
+
+- Happy path: manifest row transitions ``pending`` → ``parsed`` via
+  ``run_manifest_worker`` with no DB writes outside the manifest itself.
+- 10-Q/A amendment: same code path; no fallback semantics.
+- Registry wiring: ``register_all_parsers`` makes ``sec_10q``
+  discoverable via ``registered_parser_sources``, even after a registry
+  wipe.
+- Durability gate: the parser does NOT call ``conn.execute`` /
+  ``conn.cursor`` / ``conn.transaction`` / ``store_raw`` /
+  ``fetch_document_text``. A future contributor regressing this
+  module into a fetcher fails this test loudly — forcing the
+  spec-revision + Codex-review flow rather than silently regressing
+  into the raw-fetch design Codex round 1 rejected.
+
+Rationale: 10-Q financial data already lands via Companyfacts XBRL.
+10-Q narrative HTML has no operator-visible consumer in v1. The
+synth no-op is the documented sec-edgar §11.5.1 pattern.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.jobs.sec_manifest_worker import (
+    clear_registered_parsers,
+    registered_parser_sources,
+    run_manifest_worker,
+)
+from app.services.manifest_parsers.sec_10q import _parse_sec_10q
+from app.services.sec_manifest import get_manifest_row, record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+
+def _seed_instrument(
+    conn: psycopg.Connection[tuple],
+    *,
+    iid: int,
+    symbol: str,
+    cik: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+    if cik is not None:
+        conn.execute(
+            """
+            INSERT INTO external_identifiers (
+                instrument_id, provider, identifier_type, identifier_value,
+                is_primary, last_verified_at
+            )
+            VALUES (%s, 'sec', 'cik', %s, TRUE, NOW())
+            ON CONFLICT (provider, identifier_type, identifier_value, instrument_id)
+                WHERE provider = 'sec' AND identifier_type = 'cik'
+            DO NOTHING
+            """,
+            (iid, cik),
+        )
+
+
+def _seed_pending_10q(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    instrument_id: int,
+    cik: str = "0000999990",
+    form: str = "10-Q",
+    filed_at: datetime | None = None,
+    primary_doc_url: str | None = None,
+) -> None:
+    if filed_at is None:
+        filed_at = datetime(2026, 4, 30, tzinfo=UTC)
+    if primary_doc_url is None:
+        primary_doc_url = (
+            f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{accession.replace('-', '')}/primary_doc.htm"
+        )
+    record_manifest_entry(
+        conn,
+        accession,
+        cik=cik,
+        form=form,
+        source="sec_10q",
+        subject_type="issuer",
+        subject_id=str(instrument_id),
+        instrument_id=instrument_id,
+        filed_at=filed_at,
+        primary_document_url=primary_doc_url,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_then_reload():
+    """Pin the parser registry to ``register_all_parsers`` output for
+    every test. Mirrors the 10-K test fixture so cross-test registry
+    leaks (a foreign parser registering ``sec_10q``) cannot false-pass
+    the registry-wiring test below."""
+    from app.services.manifest_parsers import register_all_parsers
+
+    clear_registered_parsers()
+    register_all_parsers()
+    yield
+    clear_registered_parsers()
+    register_all_parsers()
+
+
+def _count_filing_raw_documents(conn: psycopg.Connection[tuple], accession: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM filing_raw_documents WHERE accession_number = %s",
+            (accession,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _count_business_summary(conn: psycopg.Connection[tuple], instrument_id: int) -> int:
+    """Cross-check: sibling parser writes to instrument_business_summary.
+    The synth no-op MUST NOT, even by accident."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM instrument_business_summary WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def test_synth_no_op_marks_parsed(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    """Happy path: pending 10-Q row drains to ``parsed`` via the worker.
+
+    Post-assert: no filing_raw_documents row (synth no-op stores
+    nothing); no instrument_business_summary row (sibling typed table
+    must not be written by accident).
+    """
+    conn = ebull_test_conn
+    iid = 901_001
+    accession = "0000000001-26-000001"
+    _seed_instrument(conn, iid=iid, symbol="SECTQ", cik="0000999991")
+    _seed_pending_10q(conn, accession=accession, instrument_id=iid, cik="0000999991")
+
+    stats = run_manifest_worker(conn, source="sec_10q", max_rows=5)
+    assert stats.parsed == 1
+    assert stats.failed == 0
+    assert stats.tombstoned == 0
+    assert stats.skipped_no_parser == 0
+
+    final = get_manifest_row(conn, accession)
+    assert final is not None
+    assert final.ingest_status == "parsed"
+    assert final.parser_version == "10q-noop-v1"
+
+    assert _count_filing_raw_documents(conn, accession) == 0
+    assert _count_business_summary(conn, iid) == 0
+
+
+def test_synth_no_op_handles_10qa_amendment(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """10-Q/A amendments parse the same way as plain 10-Q — no
+    fallback semantics, no special-casing. The synth no-op is form-
+    agnostic within the source."""
+    conn = ebull_test_conn
+    iid = 901_002
+    accession = "0000000002-26-000002"
+    _seed_instrument(conn, iid=iid, symbol="SECTQA", cik="0000999992")
+    _seed_pending_10q(
+        conn,
+        accession=accession,
+        instrument_id=iid,
+        cik="0000999992",
+        form="10-Q/A",
+    )
+
+    stats = run_manifest_worker(conn, source="sec_10q", max_rows=5)
+    assert stats.parsed == 1
+
+    final = get_manifest_row(conn, accession)
+    assert final is not None
+    assert final.ingest_status == "parsed"
+    assert final.parser_version == "10q-noop-v1"
+
+    assert _count_filing_raw_documents(conn, accession) == 0
+
+
+def test_register_all_parsers_includes_sec_10q() -> None:
+    """Registry-wiring test: after ``clear_registered_parsers`` +
+    ``register_all_parsers``, ``sec_10q`` IS in the registry.
+
+    The clear-first step is mandatory: without it a leaked registry
+    entry from a prior test would false-pass even when ``__init__.py``
+    does not wire ``sec_10q``. The autouse fixture does the same
+    thing, but this test asserts the invariant directly."""
+    from app.services.manifest_parsers import register_all_parsers
+
+    clear_registered_parsers()
+    register_all_parsers()
+
+    sources = registered_parser_sources()
+    assert "sec_10q" in sources
+    # Spot-check siblings — guards against a future refactor that
+    # accidentally drops every parser except sec_10q.
+    assert "sec_10k" in sources
+    assert "sec_8k" in sources
+
+
+class _NoTouchConnection:
+    """Sentinel connection — every DB-touch method raises.
+
+    Used by the durability gate test below to prove the parser does
+    not invoke conn.execute / conn.cursor / conn.transaction. If a
+    future contributor adds DB writes, this raises and the test
+    fails loudly."""
+
+    def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("synth no-op must not call conn.execute")
+
+    def cursor(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("synth no-op must not call conn.cursor")
+
+    def transaction(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("synth no-op must not call conn.transaction")
+
+
+class _NoTouchRow:
+    """Stub ManifestRow with the only attribute the synth no-op reads
+    (accession_number — for the debug log)."""
+
+    accession_number = "0000000099-26-000099"
+
+
+def test_parser_does_not_touch_db_or_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Durability gate (#1168).
+
+    The synth no-op parser MUST NOT call ``conn.execute`` /
+    ``conn.cursor`` / ``conn.transaction`` / ``store_raw`` /
+    ``fetch_document_text``. Triple-block:
+
+    1. Sentinel connection raises on any DB-touch method.
+    2. ``app.services.raw_filings.store_raw`` is patched to raise on
+       call (catches any future contributor importing it via the
+       service-layer path).
+    3. ``app.services.manifest_parsers.sec_10q.store_raw`` is patched
+       with ``raising=False`` (catches the alternate import path
+       where someone adds ``from app.services.raw_filings import
+       store_raw`` to ``sec_10q.py`` and uses the module-local name).
+    4. ``SecFilingsProvider.fetch_document_text`` is patched to raise
+       on call (catches a future fetcher addition).
+
+    A future PR that adds payload fetch / DB write / raw archival to
+    the parser fails this test — forcing spec-revision + Codex-review
+    rather than silently regressing into the raw-fetch design Codex
+    round 1 rejected.
+    """
+    from app.providers.implementations import sec_edgar
+    from app.services import raw_filings
+    from app.services.manifest_parsers import sec_10q as sec_10q_module
+
+    def _raise_store_raw(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("synth no-op must not call store_raw")
+
+    def _raise_fetch(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("synth no-op must not call fetch_document_text")
+
+    monkeypatch.setattr(raw_filings, "store_raw", _raise_store_raw)
+    monkeypatch.setattr(sec_10q_module, "store_raw", _raise_store_raw, raising=False)
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _raise_fetch)
+
+    outcome = _parse_sec_10q(_NoTouchConnection(), _NoTouchRow())  # type: ignore[arg-type]
+    assert outcome.status == "parsed"
+    assert outcome.parser_version == "10q-noop-v1"
+    assert outcome.raw_status is None
+    assert outcome.error is None


### PR DESCRIPTION
## What

Registers a synth no-op `sec_10q` manifest parser at `app/services/manifest_parsers/sec_10q.py`. Marks 10-Q / 10-Q/A manifest rows `parsed` without fetch / `store_raw` / typed-table writes. Closes G4 in the ETL endpoint coverage matrix.

## Why

`sec_10q` rows accumulate in `sec_filing_manifest` (post-#1155 Layer 1/2/3 wiring populates them aggressively); no registered parser → `skipped_no_parser_by_source['sec_10q']` grows; `/coverage/manifest-parsers` reports `has_registered_parser=False` permanently — a permanent noise source on the manifest backlog signal.

10-Q **financial data** already lands via Companyfacts XBRL (`fundamentals_sync` daily + Stage 24 bootstrap). 10-Q **narrative HTML** has no operator-visible consumer in v1. The manifest discovery row alone is sufficient audit; no per-filing payload work is needed.

Audit found G4's "owned by #414" attribution was stale — #414 is the `fundamentals_sync` redesign, not a 10-Q manifest parser ticket.

## Architecture: synth no-op (sec-edgar §11.5.1)

```python
def _parse_sec_10q(conn, row):
    return ParseOutcome(status="parsed", parser_version="10q-noop-v1")
```

`requires_raw_payload=False`. No fetch, no `store_raw`, no typed-table writes. First concrete application of the §11.5.1 pattern.

## Codex review trail

- **Pre-spec round 1:** 3 BLOCKING against an earlier raw-fetch-no-op design (allow-list contract violation; prevention-log #470 raw-persistence-redundant rule; `raise_for_status()` body-loss timing). Pivoted to true no-op.
- **Pre-spec round 2:** 1 BLOCKING (durability test too weak) + 3 WARNING. Resolved: sentinel-conn + module-local `store_raw` patch; `clear_registered_parsers()` added to registry test; impossible `instrument_id=None` case dropped.
- **Pre-spec round 3:** 1 WARNING (§11.5 diff shape) + 1 NIT. Both fixed.
- **Pre-push:** 0 BLOCKING, 1 WARNING (in-scope `sec_n_csr` doc drift in same touched file — fixed before push).

## Test plan

- [x] `tests/test_manifest_parser_sec_10q.py` — 4 tests, all pass:
  - `test_synth_no_op_marks_parsed` — happy path; asserts manifest=`parsed`, `parser_version='10q-noop-v1'`, zero `filing_raw_documents` rows, zero `instrument_business_summary` rows.
  - `test_synth_no_op_handles_10qa_amendment` — 10-Q/A same code path.
  - `test_register_all_parsers_includes_sec_10q` — registry-wiring test with explicit `clear_registered_parsers()` first.
  - `test_parser_does_not_touch_db_or_fetch` — **durability gate**: sentinel connection raises on `conn.execute` / `cursor` / `transaction`; `store_raw` patched on BOTH service-layer + module-local paths; `fetch_document_text` patched to raise. A future regression to a fetcher fails this test loudly.
- [x] `tests/test_fetch_document_text_callers.py` — guard test passes after allow-list extension (both new files are non-callers; the grep only matches docstring / monkeypatch references; inline comment explains).
- [x] `tests/smoke/test_app_boots.py` — lifespan boot smoke green.
- [x] `uv run ruff check` + `ruff format --check` + `pyright` on impacted files — all clean.

## Coverage parity argument (per-PR gate)

- No new operator-visible chart.
- No payload writes (no `store_raw`, no typed-table writes).
- No schema migration.
- No SQL coverage change.
- No new `fetch_document_text` caller.

CLAUDE.md ETL DoD §8-11 deferred to end-of-epic clean-test pass per operator direction 2026-05-13.

## Files

- `app/services/manifest_parsers/sec_10q.py` — **new**, synth no-op parser
- `tests/test_manifest_parser_sec_10q.py` — **new**, 4 tests
- `app/services/manifest_parsers/__init__.py` — +1 import + register
- `app/services/processes/param_metadata.py:259` — remove `sec_10q` from "may debug-skip" help text
- `tests/test_fetch_document_text_callers.py` — allow-list extension for the two new files (documented non-callers; symbol only appears in docstring + monkeypatch)
- `.claude/skills/data-sources/sec-edgar.md` — §11.5 Three→Two stranded, new §11.5.1 exemplar; in-scope fix to `sec_n_csr` row (was stale "infeasible" — #918 reopened 2026-05-13)
- `.claude/skills/data-engineer/etl-endpoint-coverage.md` — §2 row 12 + §7 G4 closed
- `docs/superpowers/specs/2026-05-14-sec-10q-manifest-parser-noop.md` — **new**, spec

Closes #1168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)