### PR TITLE
fix(#1176): n_csr bootstrap drain filters to universe-mapped trusts

### DIFF
--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -553,18 +553,42 @@ class _TrustDrainOutcome:
 
 
 def _iter_trust_ciks(conn: psycopg.Connection[Any]) -> Iterable[str]:
-    """Yield distinct trust_cik values from cik_refresh_mf_directory.
+    """Yield distinct trust_cik values for trusts with at least one
+    universe-mapped class (#1176).
 
-    Deterministic ORDER BY for crash-resume + test reproducibility; the
-    manifest UPSERT idempotency carries actual safety across re-runs.
+    Filters via INNER JOIN against ``external_identifiers
+    (provider='sec', identifier_type='class_id')`` — only trusts whose
+    mf-directory class_id resolves to an in-universe instrument are
+    walked. Non-universe trusts can never produce parseable
+    fund-metadata observations (the parser would fetch their iXBRL +
+    tombstone with ``INSTRUMENT_NOT_IN_UNIVERSE``), so enqueueing them
+    burns SEC rate-budget + parser wall-clock for guaranteed-tombstone
+    rows.
+
+    Atomicity rationale: ``refresh_mf_directory`` populates
+    ``cik_refresh_mf_directory`` AND
+    ``external_identifiers (identifier_type='class_id')`` in the same
+    transaction (``app/services/mf_directory.py``), so there is no
+    race window where a class_id appears in the directory before its
+    ext-id row lands. The JOIN is therefore exhaustive of every
+    drain-relevant trust at any consistent read snapshot.
+
+    Deterministic ORDER BY for crash-resume + test reproducibility;
+    the manifest UPSERT idempotency carries actual safety across
+    re-runs.
     """
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT DISTINCT trust_cik
-            FROM cik_refresh_mf_directory
-            WHERE trust_cik IS NOT NULL
-            ORDER BY trust_cik
+            SELECT DISTINCT mf.trust_cik
+            FROM cik_refresh_mf_directory mf
+            JOIN external_identifiers ei
+              ON ei.identifier_value = mf.class_id
+             AND ei.provider = 'sec'
+             AND ei.identifier_type = 'class_id'
+             AND ei.is_primary = TRUE
+            WHERE mf.trust_cik IS NOT NULL
+            ORDER BY mf.trust_cik
             """
         )
         for (cik,) in cur.fetchall():

--- a/tests/test_sec_first_install_drain.py
+++ b/tests/test_sec_first_install_drain.py
@@ -418,35 +418,110 @@ def _by_url(mapping: dict[str, dict | bytes | Exception | int]):
 
 
 def _seed_trust(conn: psycopg.Connection[tuple], trust_cik: str) -> None:
-    """Seed one row in ``cik_refresh_mf_directory`` for a trust."""
-    conn.execute(
-        """
-        INSERT INTO cik_refresh_mf_directory (class_id, series_id, symbol, trust_cik)
-        VALUES (%s, %s, %s, %s)
-        ON CONFLICT (class_id) DO NOTHING
-        """,
-        (f"C{trust_cik[-9:]}", f"S{trust_cik[-9:]}", "VFIAX", trust_cik),
-    )
+    """Seed one universe-mapped trust.
+
+    Per #1176: bootstrap_n_csr_drain filters trusts via JOIN against
+    ``external_identifiers (provider='sec', identifier_type='class_id')``,
+    so a test trust needs BOTH the directory row AND an ext-id row
+    referencing an instrument to be walked. Helper creates the full
+    chain: instrument + directory row + ext-id row.
+    """
+    class_id = f"C{trust_cik[-9:]}"
+    series_id = f"S{trust_cik[-9:]}"
+    symbol = "VFIAX"
+    # Use a stable instrument_id derived from the CIK so multiple
+    # trusts coexist without collision.
+    instrument_id = 9000 + int(trust_cik[-4:])
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+            VALUES (%s, %s, %s, '4', 'USD', TRUE)
+            ON CONFLICT (instrument_id) DO NOTHING
+            """,
+            (instrument_id, symbol, f"{symbol} fund"),
+        )
+        cur.execute(
+            """
+            INSERT INTO cik_refresh_mf_directory (class_id, series_id, symbol, trust_cik)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (class_id) DO NOTHING
+            """,
+            (class_id, series_id, symbol, trust_cik),
+        )
+        cur.execute(
+            """
+            INSERT INTO external_identifiers (
+                instrument_id, provider, identifier_type, identifier_value, is_primary
+            )
+            VALUES (%s, 'sec', 'class_id', %s, TRUE)
+            ON CONFLICT DO NOTHING
+            """,
+            (instrument_id, class_id),
+        )
     conn.commit()
 
 
 def _seed_n_trusts(conn: psycopg.Connection[tuple], n: int) -> list[str]:
-    """Seed N distinct trusts with synthetic CIKs."""
+    """Seed N distinct universe-mapped trusts.
+
+    Each trust gets instrument + directory row + ext-id row (#1176
+    JOIN requires the full chain).
+    """
     ciks: list[str] = []
     with conn.cursor() as cur:
         for i in range(n):
             cik = str(100000 + i).zfill(10)
             ciks.append(cik)
+            class_id = f"C{cik[-9:]}"
+            series_id = f"S{cik[-9:]}"
+            symbol = f"FUND{i:04d}"
+            instrument_id = 8000 + i
+            cur.execute(
+                """
+                INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+                VALUES (%s, %s, %s, '4', 'USD', TRUE)
+                ON CONFLICT (instrument_id) DO NOTHING
+                """,
+                (instrument_id, symbol, f"{symbol} fund"),
+            )
             cur.execute(
                 """
                 INSERT INTO cik_refresh_mf_directory (class_id, series_id, symbol, trust_cik)
                 VALUES (%s, %s, %s, %s)
                 ON CONFLICT (class_id) DO NOTHING
                 """,
-                (f"C{cik[-9:]}", f"S{cik[-9:]}", f"FUND{i:04d}", cik),
+                (class_id, series_id, symbol, cik),
+            )
+            cur.execute(
+                """
+                INSERT INTO external_identifiers (
+                    instrument_id, provider, identifier_type, identifier_value, is_primary
+                )
+                VALUES (%s, 'sec', 'class_id', %s, TRUE)
+                ON CONFLICT DO NOTHING
+                """,
+                (instrument_id, class_id),
             )
     conn.commit()
     return ciks
+
+
+def _seed_non_universe_trust(conn: psycopg.Connection[tuple], trust_cik: str) -> None:
+    """Seed a trust in cik_refresh_mf_directory WITHOUT an ext-id row.
+
+    Used to verify #1176 JOIN filter excludes non-universe trusts.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO cik_refresh_mf_directory (class_id, series_id, symbol, trust_cik)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (class_id) DO NOTHING
+            """,
+            (f"C{trust_cik[-9:]}", f"S{trust_cik[-9:]}", f"X{trust_cik[-3:]}", trust_cik),
+        )
+    conn.commit()
 
 
 def _submissions_url(cik: str) -> str:
@@ -864,3 +939,46 @@ class TestNCsrBootstrapDrain:
         assert row is not None
         # #956 contract — one row per (subject_type, subject_id, source).
         assert int(row[0]) == 1
+
+    # ------------------------------------------------------------------
+    # Case 14 — #1176: cohort filter to trusts with universe-mapped classes
+    # ------------------------------------------------------------------
+    def test_universe_class_filter_excludes_unmapped_trusts(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#1176 — drain must skip trusts whose mf_directory rows have no
+        matching ``external_identifiers (identifier_type='class_id')``
+        row. Non-universe trusts produce only INSTRUMENT_NOT_IN_UNIVERSE
+        tombstones; enqueueing them wastes SEC rate-budget + parser
+        wall-clock.
+        """
+        universe_trust = "0000036405"  # Vanguard — gets full chain
+        non_universe_a = "0000999991"  # mf_directory only, no ext-id
+        non_universe_b = "0000999992"  # mf_directory only, no ext-id
+
+        _seed_trust(ebull_test_conn, universe_trust)
+        _seed_non_universe_trust(ebull_test_conn, non_universe_a)
+        _seed_non_universe_trust(ebull_test_conn, non_universe_b)
+
+        today = date.today()
+        rows = [("0001104659-26-000080", today.isoformat(), "N-CSR", "n.htm")]
+        payload = _make_submissions_payload(cik=universe_trust, rows=rows)
+
+        # Track which trust URLs the drain visits.
+        visited_urls: list[str] = []
+
+        def tracking_http(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+            visited_urls.append(url)
+            # Only the universe trust's URL should be requested.
+            if url == _submissions_url(universe_trust):
+                return 200, json.dumps(payload).encode("utf-8")
+            raise AssertionError(f"drain visited non-universe trust URL: {url}")
+
+        stats = bootstrap_n_csr_drain(ebull_test_conn, http_get=tracking_http)
+        ebull_test_conn.commit()
+
+        # Only the universe trust was fetched.
+        assert stats.trusts_processed == 1
+        assert visited_urls == [_submissions_url(universe_trust)]
+        assert stats.manifest_rows_upserted == 1


### PR DESCRIPTION
## Summary

- `bootstrap_n_csr_drain` (S26, landed in #1175) walked **every** trust in `cik_refresh_mf_directory` — 1,171 trusts on dev DB. Only ~77 of those have at least one universe-mapped `class_id` in `external_identifiers`. The remaining 1,094 trusts enqueued ~9,000 manifest rows that all tombstone with `INSTRUMENT_NOT_IN_UNIVERSE` after fetching iXBRL.
- Fix: `_iter_trust_ciks` now INNER JOINs `cik_refresh_mf_directory` against `external_identifiers (provider='sec', identifier_type='class_id', is_primary=TRUE)`. Only trusts with ≥1 primary-mapped universe class are walked.
- Expected bootstrap wall-clock drops from ~11 min to ~10s; manifest worker drain drops proportionally (only ~100 rows enqueued vs ~9,000).

Closes #1176.
Refs #1174 (parent ticket / first attempt, MERGED 2026-05-15 at `9a06530` / PR #1175).

## Why this was missed in #1175

Spec + plan + Codex 1a/1b/2 reviewed the enqueue contract for **correctness** (subject_type wiring, horizon filter, source filter, pagination, cancel cadence, idempotency). None reviewed **cost** at the manifest-rows-enqueued-per-bootstrap level. Smoke revealed the throughput gap — drain converged at 200 rows / ~10s per tick (2 rows/sec), wall-clock ~80 min for 9,435 pending rows; ETL DoD clause 10 ("backfill executed") becomes impractical at that pace.

## Why `is_primary = TRUE`

Codex pre-push round 1 caught that the parser resolver at `_fund_class_resolver.py:62` filters `is_primary = TRUE`. Without the same predicate in the drain filter, a demoted ext-id row would slip through and tombstone at parse time, weakening the "only parseable universe trusts" predicate.

## Atomicity rationale (no race window)

`mf_directory.refresh_mf_directory()` populates both `cik_refresh_mf_directory` and `external_identifiers (class_id rows)` in the same transaction (`mf_directory.py:88` `with conn.transaction()`). A class is in the directory iff its ext-id row was written in the same atomic write — the JOIN sees every drain-relevant trust at any consistent read snapshot.

## Test plan

- [x] New case 14 in `tests/test_sec_first_install_drain.py`: seed 1 universe-mapped trust + 2 non-universe trusts; assert drain visits only the universe trust's URL and writes only its manifest row.
- [x] Existing `_seed_trust` / `_seed_n_trusts` helpers extended to populate the full chain (instruments + directory + ext-id). All 12 prior tests still pass.
- [x] Local gates: ruff check + format check + pyright (all CLEAN).
- [ ] Post-merge: dispatch S25 → S26 → manifest worker on dev DB; verify drain converges in < 5 min and `fund_metadata_current` populates for the universe-mapped trusts (VOO / IVV / AGG).

## Security model

No surface change. Same subject_type / instrument_id / CHECK constraint as #1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)