### PR TITLE
feat(G14): bootstrap_orchestrator source-registry entry

### DIFF
--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -70,6 +70,7 @@ Lane = Literal[
     "db_ownership_inst",
     "db_ownership_insider",
     "db_ownership_funds",
+    "bootstrap",
 ]
 """Source-level concurrency bucket. Operator-locked decision (#1064): same-source
 jobs serialise under one ``JobLock``; cross-source jobs run in parallel.
@@ -105,6 +106,24 @@ PR1c #1064 collapsed everything onto a single ``db`` source.
   writes ``insider_transactions`` + ``form3_holdings_initial``.
 * ``db_ownership_funds`` — ``sec_nport_ingest_from_dataset``;
   writes ``n_port_*`` + ``sec_fund_series``.
+
+The final lane is bootstrap-only:
+
+* ``bootstrap`` — ``bootstrap_orchestrator`` (G14). Deliberately
+  disjoint from every per-stage lane so the outer
+  ``JobLock(bootstrap_orchestrator)`` held by the queue listener
+  (``_run_manual``) cannot collide with the inner per-stage
+  ``JobLock(<stage_job>)`` acquisitions that bootstrap submits to a
+  ``ThreadPoolExecutor`` (``app/services/bootstrap_orchestrator.py:1603``).
+  Cross-thread ``ContextVar`` propagation is NOT automatic (see
+  ``tests/test_job_lock_reentrancy.py::test_threads_do_not_inherit_held_sources``),
+  so the #1184 same-context re-entrancy bypass cannot fire from inside
+  an executor worker thread. Picking a fresh lane is the surgical fix:
+  no stage owns ``bootstrap``, so cross-thread inner acquisitions never
+  contend with the outer lock. Multiple bootstrap triggers still
+  serialise on the ``bootstrap`` lane's Postgres advisory lock — the
+  ``bootstrap_state.status='running'`` fence is the primary serializer
+  at trigger-publish time; this is belt-and-braces at dispatch time.
 """
 
 
@@ -174,6 +193,32 @@ MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
     # check_freshness probes against SEC submissions.json; shares the
     # 10 req/s SEC fair-use budget with every other sec_rate consumer.
     "sec_rebuild": "sec_rate",
+    # bootstrap_orchestrator — first-install + admin retry trigger (G14).
+    # POST /system/bootstrap/run + POST /system/bootstrap/retry-failed
+    # publish_manual_job_request(JOB_BOOTSTRAP_ORCHESTRATOR); the queue
+    # listener routes through ``_run_manual`` which acquires
+    # ``JobLock(job_name)``. Without a registry entry the JobLock
+    # constructor's ``source_for(...)`` raised ``KeyError`` and the
+    # retry handler had to bypass JobLock via direct-Python invocation
+    # (PR #1188 T9-POST).
+    #
+    # Lane = ``bootstrap`` (NOT ``init``). Bootstrap submits its
+    # per-stage invokers to a ``ThreadPoolExecutor``
+    # (``app/services/bootstrap_orchestrator.py:1603``); Python's
+    # ``ContextVar`` is NOT auto-propagated to executor worker threads
+    # (regression-pinned by
+    # ``tests/test_job_lock_reentrancy.py::test_threads_do_not_inherit_held_sources``),
+    # so the #1184 same-context re-entrancy short-circuit CANNOT fire
+    # inside an executor worker. Picking any source that an inner stage
+    # also uses (``init`` collides with ``nightly_universe_sync``;
+    # ``db`` collides with several Phase E stages) would have the worker
+    # thread hit ``pg_try_advisory_lock`` on a lock the listener thread
+    # already holds, and the inner stage would fail with
+    # ``JobAlreadyRunning``. A fresh ``bootstrap`` lane is disjoint from
+    # every per-stage lane — no cross-thread contention is possible by
+    # construction. Disjointness invariant pinned by
+    # ``tests/test_bootstrap_orchestrator_source_registry.py::test_bootstrap_lane_disjoint_from_all_stage_lanes``.
+    "bootstrap_orchestrator": "bootstrap",
     # --- Orchestrator-adapter + manual-queue reach (#1183, #1184) ---
     # #260 (PR #262) moved the jobs below from standalone ScheduledJob
     # rows into orchestrator FULL / HIGH_FREQUENCY cadences. PR1a #1064

--- a/tests/test_bootstrap_orchestrator_source_registry.py
+++ b/tests/test_bootstrap_orchestrator_source_registry.py
@@ -1,0 +1,197 @@
+"""Source-registry coverage for ``bootstrap_orchestrator`` (G14).
+
+Surfaced as PR #1188 T9-POST: the admin retry endpoint publishes a
+manual-queue request for ``JOB_BOOTSTRAP_ORCHESTRATOR`` via
+``publish_manual_job_request``; the queue listener routes through
+``_run_manual``; ``_run_manual`` constructs ``JobLock(job_name)``;
+``JobLock.__init__`` calls ``app.jobs.sources.source_for(job_name)``.
+Pre-fix the registry had no entry for ``bootstrap_orchestrator`` so
+``source_for`` raised ``KeyError`` and the retry path required a
+direct-Python invocation workaround that bypassed JobLock.
+
+Pinning the contract here so a future PR that removes
+``"bootstrap_orchestrator": "bootstrap"`` from
+``MANUAL_TRIGGER_JOB_SOURCES`` fails CI rather than silently
+regressing the manual-queue dispatch path.
+
+Source choice — ``bootstrap`` (fresh lane, disjoint from every
+per-stage lane):
+
+- Bootstrap is a ``_PRELUDE_OPT_OUT_JOB`` (``app/jobs/runtime.py``):
+  the runtime acquires the outer ``JobLock`` then invokes
+  ``run_bootstrap_orchestrator`` directly. The orchestrator submits
+  per-stage invokers to a ``ThreadPoolExecutor``
+  (``app/services/bootstrap_orchestrator.py:1603``); per-stage
+  invokers acquire inner ``JobLock(<stage_job>)`` from worker threads.
+- Python's ``ContextVar`` is NOT auto-propagated across executor
+  worker threads (regression-pinned by
+  ``test_job_lock_reentrancy.py::test_threads_do_not_inherit_held_sources``),
+  so the #1184 same-context re-entrancy bypass CANNOT fire inside
+  the bootstrap executor's worker. Any source shared with an inner
+  stage (``init`` with ``nightly_universe_sync``; ``db`` with several
+  Phase E stages) would have the worker hit
+  ``pg_try_advisory_lock`` on a lock the listener thread already
+  holds → ``JobAlreadyRunning`` → stage fails.
+- A fresh ``bootstrap`` lane is disjoint from every per-stage lane.
+  Cross-thread inner acquisitions never contend with the outer lock
+  by construction. The disjointness invariant is regression-pinned
+  by ``test_bootstrap_lane_disjoint_from_all_stage_lanes`` below.
+
+Pattern reference: ``tests/test_layer_123_wiring.py::TestSecRebuildRegistry``
+for the sec_rebuild manual-trigger registry coverage shape.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import psycopg
+import pytest
+
+from app.jobs.locks import JobLock
+from app.jobs.sources import MANUAL_TRIGGER_JOB_SOURCES, source_for
+from app.services.bootstrap_orchestrator import JOB_BOOTSTRAP_ORCHESTRATOR
+from app.services.sync_orchestrator.dispatcher import publish_manual_job_request
+from tests.fixtures.ebull_test_db import ebull_test_conn, test_database_url  # noqa: F401 — fixture re-export
+
+
+class TestBootstrapOrchestratorRegistry:
+    """``bootstrap_orchestrator`` resolves to the fresh ``bootstrap``
+    source via ``MANUAL_TRIGGER_JOB_SOURCES``."""
+
+    def test_bootstrap_orchestrator_in_manual_trigger_sources(self) -> None:
+        assert JOB_BOOTSTRAP_ORCHESTRATOR in MANUAL_TRIGGER_JOB_SOURCES
+        assert MANUAL_TRIGGER_JOB_SOURCES[JOB_BOOTSTRAP_ORCHESTRATOR] == "bootstrap"
+
+    def test_source_for_resolves_bootstrap_orchestrator(self) -> None:
+        """The KeyError regression — ``JobLock(...).__init__`` calls
+        ``source_for`` directly. Pre-PR this raised at the queue
+        listener's ``_run_manual`` entry point and stranded the
+        admin retry path."""
+        assert source_for(JOB_BOOTSTRAP_ORCHESTRATOR) == "bootstrap"
+
+    def test_joblock_construct_does_not_raise(self) -> None:
+        """The narrow regression gate: constructing a JobLock for
+        ``bootstrap_orchestrator`` must NOT raise ``KeyError``.
+
+        Construction alone is enough — ``JobLock.__init__`` calls
+        ``source_for`` immediately. We do NOT enter the context
+        manager here (no Postgres advisory lock acquired); the goal
+        is to pin the registry lookup, not exercise the lock body."""
+        lock = JobLock(test_database_url(), JOB_BOOTSTRAP_ORCHESTRATOR)
+        assert lock._source == "bootstrap"  # noqa: SLF001 — invariant under test
+
+    def test_bootstrap_lane_disjoint_from_all_stage_lanes(self) -> None:
+        """Disjointness invariant — no per-stage job_name resolves to
+        the ``bootstrap`` lane.
+
+        This is the load-bearing safety property: if any inner-stage
+        invoker resolves to ``bootstrap`` (via a future SCHEDULED_JOBS
+        addition or a bootstrap stage that uses ``bootstrap`` as its
+        StageSpec.lane), the worker thread's inner
+        ``JobLock(<stage_job>)`` would attempt ``pg_try_advisory_lock``
+        on the same key the listener thread already holds — cross-
+        thread ContextVar bypass cannot fire — and the inner
+        acquisition would fail with ``JobAlreadyRunning``.
+
+        Two checks:
+
+        1. Walk ``_BOOTSTRAP_STAGE_SPECS`` directly — every stage
+           invoker MUST resolve to a non-``bootstrap`` lane via
+           ``source_for``. Catches future stage additions even if
+           the offending stage is also added to the registry under
+           the bootstrap key (which would make the registry-occupants
+           check pass false-positive).
+        2. The registry occupants of ``bootstrap`` MUST be exactly
+           ``{JOB_BOOTSTRAP_ORCHESTRATOR}``. Catches future
+           SCHEDULED_JOBS / MANUAL_TRIGGER additions that introduce a
+           new bootstrap-lane resident.
+
+        Failing either is the canary that the source-choice argument
+        in ``app/jobs/sources.py`` has been silently violated.
+        """
+        from app.jobs.sources import get_job_name_to_source
+        from app.services.bootstrap_orchestrator import _BOOTSTRAP_STAGE_SPECS
+
+        # Check 1 — every bootstrap-stage invoker resolves to a non-
+        # bootstrap lane. Stage names that ARE the orchestrator itself
+        # are excluded from this assertion (the orchestrator is the
+        # outer holder, not an inner stage).
+        bootstrap_lane_stage_violations = sorted(
+            stage.job_name
+            for stage in _BOOTSTRAP_STAGE_SPECS
+            if stage.job_name != JOB_BOOTSTRAP_ORCHESTRATOR and source_for(stage.job_name) == "bootstrap"
+        )
+        assert not bootstrap_lane_stage_violations, (
+            f"Bootstrap stage(s) resolve to the 'bootstrap' lane: "
+            f"{bootstrap_lane_stage_violations!r}. Inner stage JobLock acquires "
+            f"from worker threads; cross-thread ContextVar bypass is intentionally "
+            f"NOT automatic (test_job_lock_reentrancy.py::"
+            f"test_threads_do_not_inherit_held_sources). Move the offending "
+            f"stage(s) to a stage-specific lane."
+        )
+
+        # Check 2 — registry occupants of 'bootstrap' are exactly the
+        # orchestrator. Catches additions outside the stage table.
+        registry = get_job_name_to_source()
+        on_bootstrap_lane = sorted(name for name, lane in registry.items() if lane == "bootstrap")
+        assert on_bootstrap_lane == [JOB_BOOTSTRAP_ORCHESTRATOR], (
+            f"Expected only {JOB_BOOTSTRAP_ORCHESTRATOR!r} on the 'bootstrap' lane; "
+            f"found {on_bootstrap_lane!r}. Any non-orchestrator job sharing the "
+            f"'bootstrap' lane will collide with the outer listener-thread JobLock."
+        )
+
+
+@pytest.fixture()
+def _cleanup_requests() -> Generator[list[int]]:
+    created: list[int] = []
+    yield created
+    if created:
+        with psycopg.connect(test_database_url(), autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM pending_job_requests WHERE request_id = ANY(%s)",
+                    (created,),
+                )
+
+
+def test_publish_manual_job_request_bootstrap_orchestrator_no_keyerror(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811, ARG001 — ensures the worker test DB exists + is migrated
+    monkeypatch: pytest.MonkeyPatch,
+    _cleanup_requests: list[int],
+) -> None:
+    """End-to-end on the publish path: ``publish_manual_job_request``
+    lands a ``pending_job_requests`` row for ``bootstrap_orchestrator``
+    without raising.
+
+    This is the path the admin retry endpoint takes
+    (``app/api/bootstrap.py:498``). Pre-fix this published fine
+    (publish writes a queue row), but the next step
+    (``_run_manual``'s ``JobLock(job_name)`` construction) KeyError'd
+    on the unresolvable source. The full listener loop is hard to
+    exercise without a running jobs process; this test pins the
+    publish leg + relies on the unit-level
+    ``test_joblock_construct_does_not_raise`` above for the
+    JobLock-construction leg.
+
+    Together they cover the failure mode: row queued, JobLock
+    constructs cleanly, listener can proceed past the KeyError that
+    blocked the retry path."""
+    monkeypatch.setattr("app.config.settings.database_url", test_database_url())
+
+    request_id = publish_manual_job_request(JOB_BOOTSTRAP_ORCHESTRATOR)
+    _cleanup_requests.append(request_id)
+
+    with psycopg.connect(test_database_url(), autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT job_name, status FROM pending_job_requests WHERE request_id=%s",
+                (request_id,),
+            )
+            row = cur.fetchone()
+    assert row is not None
+    assert row[0] == JOB_BOOTSTRAP_ORCHESTRATOR
+    # Initial status is 'pending' — listener picks it up + transitions
+    # to 'claimed' on dispatch. We assert no immediate rejection
+    # (which would set status='rejected').
+    assert row[1] == "pending"


### PR DESCRIPTION
## Summary

- Register `bootstrap_orchestrator` in `MANUAL_TRIGGER_JOB_SOURCES` on a fresh `bootstrap` lane (added to `Lane` Literal).
- Closes **G14** in the US-ETL completion plan (PR #1189).

## Why

PR #1188 T9-POST surfaced the gap: admin "Retry failed" publishes a manual-queue request for `JOB_BOOTSTRAP_ORCHESTRATOR`; the queue listener routes through `_run_manual`; `_run_manual` constructs `JobLock(job_name)`; `JobLock.__init__` calls `app.jobs.sources.source_for(job_name)`. Pre-fix the registry had no entry → `KeyError` → the retry handler had to bypass JobLock via a direct-Python invocation workaround.

## Why NOT `init`

`init` was the obvious-and-wrong default (universe_sync is the only other init-lane job, and bootstrap dispatches it as a stage). The hidden bug:

- Bootstrap submits per-stage invokers to a `ThreadPoolExecutor` (`app/services/bootstrap_orchestrator.py:1603`).
- Python's `ContextVar` is **not** auto-propagated across executor worker threads (regression-pinned by `test_job_lock_reentrancy.py::test_threads_do_not_inherit_held_sources`).
- So the #1184 same-context re-entrancy bypass **cannot** fire inside a worker thread.
- If the outer source = `init`, the worker thread's inner `JobLock(nightly_universe_sync)` would attempt `pg_try_advisory_lock("init")` against a key the listener thread already holds → `JobAlreadyRunning` → stage fails.

Same flaw for `db`, `sec_rate`, etc. — any inner-stage lane collides under cross-thread.

## Why `bootstrap` (fresh lane)

Disjoint from every per-stage lane by construction. Cross-thread inner acquisitions never contend with the outer lock because no inner stage uses `bootstrap`.

Multiple bootstrap triggers still serialise via the `bootstrap` advisory lock; `bootstrap_state.status='running'` remains the primary trigger-publish-time fence.

## Files

- `app/jobs/sources.py` — add `"bootstrap"` to `Lane` Literal + `"bootstrap_orchestrator": "bootstrap"` entry + lane docstring explaining the cross-thread reasoning.
- `tests/test_bootstrap_orchestrator_source_registry.py` (new) — 5 tests including a load-bearing disjointness invariant that walks `_BOOTSTRAP_STAGE_SPECS` directly and asserts no stage resolves to `bootstrap`.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright` (scoped) — 0 errors
- [x] `uv run pytest tests/test_bootstrap_orchestrator_source_registry.py tests/test_job_registry.py tests/test_layer_123_wiring.py tests/test_job_lock_reentrancy.py tests/smoke/test_app_boots.py` — 70 passed
- [x] **Codex pre-push round 1**: BLOCKING — flagged the `init`-source cross-thread collision. Resolved by pivoting to fresh `bootstrap` lane.
- [x] **Codex pre-push round 2**: no correctness blockers; suggested tightening the disjointness invariant to walk `_BOOTSTRAP_STAGE_SPECS` directly (applied) + a stale-text nit (fixed).

## Settled-decisions / prevention-log

- Prevention-log lines 1330-1333 (`MANUAL_TRIGGER_JOB_SOURCES` source-coverage contract) directly apply — this PR adds the missing entry per the documented prevention pattern.
- New prevention-log candidate (could be extracted post-merge): "ThreadPoolExecutor workers don't inherit `ContextVar`; pick a disjoint source for invokers that fan stages out to threads." Captured in code/test comments for now; extract on review.

## ETL DoD clauses 8-12

N/A — this is a job-registry plumbing change, not an ETL/parser/schema-migration change. No observation data is written, no schema migration runs. The integration test exercises the queue-publish leg + `JobLock` construction leg, which together cover the entire failure mode.