### PR TITLE
test(#1155): G13 — static AST invariants for recheck-reader wiring

### DIFF
--- a/.claude/skills/data-engineer/etl-endpoint-coverage.md
+++ b/.claude/skills/data-engineer/etl-endpoint-coverage.md
@@ -79,7 +79,7 @@ Steady-state filings discovery currently runs through the legacy per-form ingest
 
 `data_freshness._CADENCE` at `app/services/data_freshness.py:69` is queried by the per-CIK seeder (`seed_freshness_for_manifest_row`) on every manifest write, populating `expected_next_at`. `subjects_due_for_poll` at `app/services/data_freshness.py:485` is the consumer reader. `run_per_cik_poll` calls it correctly. But because Layer 3 is unwired (no `_INVOKERS[]` / `SCHEDULED_JOBS` row), no scheduled caller reaches that path. The table is read by tests + ad-hoc rebuild scripts only, not steady-state polling.
 
-**Sub-gap G13:** even after Layer 3 is wired, `run_per_cik_poll` reads only `subjects_due_for_poll`. The companion `subjects_due_for_recheck` at `app/services/data_freshness.py:533` (handles `never_filed` + `error` state rechecks) is referenced only by tests — production never reaches it. `#1155` acceptance should require both reader paths to fire.
+**Sub-gap G13:** ✅ CLOSED 2026-05-17 — `run_per_cik_poll` drains BOTH `subjects_due_for_poll` AND `subjects_due_for_recheck` per tick (`app/jobs/sec_per_cik_poll.py:195-198`) with a bounded 2/3 + ~1/3 budget split (`max_subjects=100` → poll=66, recheck=34). Integration coverage at `tests/test_sec_per_cik_poll.py::TestG13RecheckPath` proves the never_filed-stays-in-queue contract + alongside-poll drain; static AST invariants at `tests/test_g13_recheck_reader_invariants.py` guarantee a future refactor cannot silently drop one reader path. Hourly cadence asserted at `tests/test_layer_123_wiring.py::test_layer3_per_cik_poll_registered`.
 
 Once #1155 lands, the legacy crons above can be retired per spec §6. Each retirement is one PR + smoke per cron.
 
@@ -177,7 +177,7 @@ These endpoints don't have a `ManifestSource` because they're not per-filing dis
 | G10 | `companyconcept` API not consumed | OPEN (low) | — | Smaller-payload alternative to Companyfacts for known-tag pulls. Eligible. |
 | G11 | `frames` API not consumed | OPEN (low) | — | Cross-sectional one-fact-per-filer; sector aggregates use case. Eligible. |
 | G12 | Full-index `master.idx` quarterly not consumed | OPEN (low) | — | Cross-quarter discovery; only `form.idx` is consumed today. Eligible if cross-quarter walks become needed. |
-| G13 | `subjects_due_for_recheck` reader unused | OPEN | **#1155** (sub-finding) | `app/services/data_freshness.py:533` — handles `never_filed` + `error` state rechecks. Only tests reference it; runtime Layer 3 (when wired) reads only `subjects_due_for_poll` at `:485`. #1155 acceptance must require BOTH reader paths to fire. |
+| G13 | `subjects_due_for_recheck` reader unused | ✅ CLOSED 2026-05-17 | **#1155** (sub-finding) + verification PR | Both readers drained per tick at `app/jobs/sec_per_cik_poll.py:195-198` with bounded 2/3+1/3 budget split. Static AST invariants at `tests/test_g13_recheck_reader_invariants.py` guard the wiring against future refactor; integration drain proved by `tests/test_sec_per_cik_poll.py::TestG13RecheckPath`. |
 
 G1-G3 are the **headline finding** of this audit — the freshness redesign's three steady-state polling layers are coded but never scheduled. Without them, the table at §3 (legacy per-form ingest crons) carries discovery; `data_freshness._CADENCE` is a write-only ledger.
 

--- a/tests/test_g13_recheck_reader_invariants.py
+++ b/tests/test_g13_recheck_reader_invariants.py
@@ -14,6 +14,16 @@ was swapped for an equivalent-shape stub.
 
 Closes G13 row in
 ``.claude/skills/data-engineer/etl-endpoint-coverage.md`` §7.
+
+**Scope-walk discipline (from #1193 review feedback):** any
+intra-function AST check in this file MUST use the
+``_RunPerCikPollVisitor`` (or a visitor that mirrors its nested-
+scope skips). Naive ``ast.walk(stmt)`` recurses into nested
+``FunctionDef`` / ``AsyncFunctionDef`` / ``Lambda`` / ``ClassDef``
+bodies, producing an *asymmetric* invariant — a legitimately-added
+nested helper would false-trigger one check while another remained
+silent. Symmetric scope exclusion across all visitors is non-
+negotiable.
 """
 
 from __future__ import annotations
@@ -56,25 +66,39 @@ class TestG13ReaderImports:
         )
 
 
-class _ConsumedReaderVisitor(ast.NodeVisitor):
-    """Collects reader-call names whose return value is *consumed*.
+class _RunPerCikPollVisitor(ast.NodeVisitor):
+    """Single visitor that collects *both* intra-function invariants
+    under one nested-scope-skipping traversal:
 
-    A bare ``subjects_due_for_recheck(...)`` whose result is discarded
-    would still match a naive ``ast.walk`` scan; this visitor only
-    records the call when its return value is wrapped in an eager
-    materialiser (``list`` / ``tuple`` / ``set``) or directly iterated
-    (``for x in reader(...)``, ``yield from reader(...)``). That
-    matches the bounded-budget drain pattern the production code uses.
+    1. ``consumed`` — reader-call names whose return value is wrapped
+       in an eager materialiser (``list`` / ``tuple`` / ``set``) or
+       directly iterated (``for``, ``async for``, ``yield from``). A
+       bare ``subjects_due_for_recheck(...)`` whose result is dropped
+       does NOT satisfy this.
+    2. ``rebinds`` — reader names that appear as the target of an
+       ``ast.Assign`` / ``ast.AnnAssign`` inside the function. A local
+       stub (``subjects_due_for_recheck = lambda: iter([])``) would
+       otherwise leave the dead module import in place while defeating
+       the consumed-call invariant.
+
+    Both invariants share the same scope-skipping logic. Splitting
+    them across two visitors would have introduced an asymmetric
+    invariant (#1193 review WARNING): a legitimately-added nested
+    helper that locally reuses a name would false-trigger one check
+    but not the other.
 
     Nested ``FunctionDef`` / ``AsyncFunctionDef`` / ``Lambda`` /
     ``ClassDef`` scopes are NOT recursed into — a dead nested helper
-    must not be able to satisfy the invariant for the outer function.
+    must not be able to satisfy *or violate* the invariant for the
+    outer function.
     """
 
     _MATERIALISERS = frozenset({"list", "tuple", "set"})
 
-    def __init__(self) -> None:
+    def __init__(self, watch_names: tuple[str, ...]) -> None:
+        self._watch: frozenset[str] = frozenset(watch_names)
         self.consumed: set[str] = set()
+        self.rebinds: list[str] = []
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
         return  # skip nested function bodies
@@ -94,45 +118,63 @@ class _ConsumedReaderVisitor(ast.NodeVisitor):
             return node.func.id
         return None
 
+    def _record_consumed(self, node: ast.AST) -> None:
+        inner = self._inner_call_name(node)
+        if inner is not None and inner in self._watch:
+            self.consumed.add(inner)
+
     def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
         # Pattern: list(<reader>(...)) / tuple(...) / set(...)
         if isinstance(node.func, ast.Name) and node.func.id in self._MATERIALISERS and node.args:
-            inner = self._inner_call_name(node.args[0])
-            if inner is not None:
-                self.consumed.add(inner)
+            self._record_consumed(node.args[0])
         self.generic_visit(node)
 
     def visit_For(self, node: ast.For) -> None:  # noqa: N802
-        inner = self._inner_call_name(node.iter)
-        if inner is not None:
-            self.consumed.add(inner)
+        self._record_consumed(node.iter)
         self.generic_visit(node)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:  # noqa: N802
-        inner = self._inner_call_name(node.iter)
-        if inner is not None:
-            self.consumed.add(inner)
+        self._record_consumed(node.iter)
         self.generic_visit(node)
 
     def visit_YieldFrom(self, node: ast.YieldFrom) -> None:  # noqa: N802
-        inner = self._inner_call_name(node.value)
-        if inner is not None:
-            self.consumed.add(inner)
+        self._record_consumed(node.value)
         self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:  # noqa: N802
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id in self._watch:
+                self.rebinds.append(target.id)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:  # noqa: N802
+        if isinstance(node.target, ast.Name) and node.target.id in self._watch:
+            self.rebinds.append(node.target.id)
+        self.generic_visit(node)
+
+
+def _walk_run_per_cik_poll() -> _RunPerCikPollVisitor:
+    """Run the shared visitor against ``run_per_cik_poll``'s body."""
+    tree = _module_tree()
+    fn = _run_per_cik_poll_node(tree)
+    visitor = _RunPerCikPollVisitor(_REQUIRED_READERS)
+    for stmt in fn.body:
+        visitor.visit(stmt)
+    return visitor
 
 
 class TestG13ReaderCalls:
     """Both readers must be *called and consumed* inside
-    ``run_per_cik_poll``'s own body (not in a nested helper). A
-    stale import or a discarded-result call would let the recheck
-    path silently die."""
+    ``run_per_cik_poll``'s own body (not in a nested helper) and must
+    NOT be locally rebound to a stub. A stale import, discarded-result
+    call, or same-name stub would let the recheck path silently die.
+
+    Both assertions share one ``_RunPerCikPollVisitor`` traversal so
+    the nested-scope skip is applied symmetrically (see #1193 review
+    feedback)."""
 
     def test_both_readers_called_and_consumed_in_run_per_cik_poll(self) -> None:
-        tree = _module_tree()
-        fn = _run_per_cik_poll_node(tree)
-        visitor = _ConsumedReaderVisitor()
-        for stmt in fn.body:
-            visitor.visit(stmt)
+        visitor = _walk_run_per_cik_poll()
         missing = [name for name in _REQUIRED_READERS if name not in visitor.consumed]
         assert not missing, (
             f"run_per_cik_poll body missing CONSUMED reader calls: {missing}. "
@@ -151,21 +193,9 @@ class TestG13ReaderCalls:
         = lambda *a, **k: iter([])``) and the consumed-call invariant
         would still pass while production silently dropped the path.
         """
-        tree = _module_tree()
-        fn = _run_per_cik_poll_node(tree)
-        rebinds: list[str] = []
-        for stmt in fn.body:
-            for node in ast.walk(stmt):
-                if isinstance(node, ast.Assign):
-                    for target in node.targets:
-                        if isinstance(target, ast.Name) and target.id in _REQUIRED_READERS:
-                            rebinds.append(target.id)
-                elif isinstance(node, ast.AnnAssign):
-                    target = node.target
-                    if isinstance(target, ast.Name) and target.id in _REQUIRED_READERS:
-                        rebinds.append(target.id)
-        assert not rebinds, (
-            f"run_per_cik_poll locally rebinds reader name(s): {rebinds}. "
+        visitor = _walk_run_per_cik_poll()
+        assert not visitor.rebinds, (
+            f"run_per_cik_poll locally rebinds reader name(s): {visitor.rebinds}. "
             "A local stub would defeat the consumed-call invariant while "
             "leaving the dead module import in place. Per #1155 G13."
         )

--- a/tests/test_g13_recheck_reader_invariants.py
+++ b/tests/test_g13_recheck_reader_invariants.py
@@ -1,0 +1,200 @@
+"""Static AST invariants for #1155 G13 — Layer 3 recheck-reader wiring.
+
+Integration coverage of both reader paths already lives in
+``tests/test_sec_per_cik_poll.py`` (``TestG13RecheckPath``) and the
+hourly cadence is asserted in ``tests/test_layer_123_wiring.py``
+(``test_layer3_per_cik_poll_registered``).
+
+These tests are the *static* guarantee that a future refactor of
+``run_per_cik_poll`` cannot silently drop one of the two reader
+paths. Without them, removing the ``subjects_due_for_recheck`` call
+or import would leave only behavioural tests as the safety net —
+which would still pass if the dead import lingered or the call site
+was swapped for an equivalent-shape stub.
+
+Closes G13 row in
+``.claude/skills/data-engineer/etl-endpoint-coverage.md`` §7.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parent.parent / "app" / "jobs" / "sec_per_cik_poll.py"
+_REQUIRED_READERS = ("subjects_due_for_poll", "subjects_due_for_recheck")
+
+
+def _module_tree() -> ast.Module:
+    return ast.parse(_MODULE_PATH.read_text())
+
+
+def _run_per_cik_poll_node(tree: ast.Module) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_per_cik_poll":
+            return node
+    raise AssertionError("app/jobs/sec_per_cik_poll.py::run_per_cik_poll not found — refactored?")
+
+
+class TestG13ReaderImports:
+    """Both readers must be imported at module level from
+    ``app.services.data_freshness``. A drift here means a refactor
+    has split or rerouted the freshness-index access surface — the
+    matrix entry needs revisiting."""
+
+    def test_both_readers_imported_from_data_freshness(self) -> None:
+        tree = _module_tree()
+        imported_names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "app.services.data_freshness":
+                for alias in node.names:
+                    imported_names.add(alias.name)
+        missing = [name for name in _REQUIRED_READERS if name not in imported_names]
+        assert not missing, (
+            f"run_per_cik_poll module missing data_freshness imports: {missing}. "
+            "Both reader paths are required by #1155 G13."
+        )
+
+
+class _ConsumedReaderVisitor(ast.NodeVisitor):
+    """Collects reader-call names whose return value is *consumed*.
+
+    A bare ``subjects_due_for_recheck(...)`` whose result is discarded
+    would still match a naive ``ast.walk`` scan; this visitor only
+    records the call when its return value is wrapped in an eager
+    materialiser (``list`` / ``tuple`` / ``set``) or directly iterated
+    (``for x in reader(...)``, ``yield from reader(...)``). That
+    matches the bounded-budget drain pattern the production code uses.
+
+    Nested ``FunctionDef`` / ``AsyncFunctionDef`` / ``Lambda`` /
+    ``ClassDef`` scopes are NOT recursed into — a dead nested helper
+    must not be able to satisfy the invariant for the outer function.
+    """
+
+    _MATERIALISERS = frozenset({"list", "tuple", "set"})
+
+    def __init__(self) -> None:
+        self.consumed: set[str] = set()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        return  # skip nested function bodies
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        return
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:  # noqa: N802
+        return
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        return
+
+    @staticmethod
+    def _inner_call_name(node: ast.AST) -> str | None:
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            return node.func.id
+        return None
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        # Pattern: list(<reader>(...)) / tuple(...) / set(...)
+        if isinstance(node.func, ast.Name) and node.func.id in self._MATERIALISERS and node.args:
+            inner = self._inner_call_name(node.args[0])
+            if inner is not None:
+                self.consumed.add(inner)
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:  # noqa: N802
+        inner = self._inner_call_name(node.iter)
+        if inner is not None:
+            self.consumed.add(inner)
+        self.generic_visit(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:  # noqa: N802
+        inner = self._inner_call_name(node.iter)
+        if inner is not None:
+            self.consumed.add(inner)
+        self.generic_visit(node)
+
+    def visit_YieldFrom(self, node: ast.YieldFrom) -> None:  # noqa: N802
+        inner = self._inner_call_name(node.value)
+        if inner is not None:
+            self.consumed.add(inner)
+        self.generic_visit(node)
+
+
+class TestG13ReaderCalls:
+    """Both readers must be *called and consumed* inside
+    ``run_per_cik_poll``'s own body (not in a nested helper). A
+    stale import or a discarded-result call would let the recheck
+    path silently die."""
+
+    def test_both_readers_called_and_consumed_in_run_per_cik_poll(self) -> None:
+        tree = _module_tree()
+        fn = _run_per_cik_poll_node(tree)
+        visitor = _ConsumedReaderVisitor()
+        for stmt in fn.body:
+            visitor.visit(stmt)
+        missing = [name for name in _REQUIRED_READERS if name not in visitor.consumed]
+        assert not missing, (
+            f"run_per_cik_poll body missing CONSUMED reader calls: {missing}. "
+            "Both reader paths must (a) be called directly inside the function "
+            "(not in a nested helper) and (b) have their iterator drained via "
+            "list() / tuple() / set() / for-loop / yield from. Per #1155 G13; "
+            "see app/jobs/sec_per_cik_poll.py:195-198 for the wired pattern."
+        )
+
+    def test_reader_names_not_locally_rebound(self) -> None:
+        """Reject any ``ast.Assign`` / ``ast.AnnAssign`` inside
+        ``run_per_cik_poll`` that rebinds one of the reader names.
+
+        Without this, a future refactor could leave the import in
+        place and stub the reader locally (``subjects_due_for_recheck
+        = lambda *a, **k: iter([])``) and the consumed-call invariant
+        would still pass while production silently dropped the path.
+        """
+        tree = _module_tree()
+        fn = _run_per_cik_poll_node(tree)
+        rebinds: list[str] = []
+        for stmt in fn.body:
+            for node in ast.walk(stmt):
+                if isinstance(node, ast.Assign):
+                    for target in node.targets:
+                        if isinstance(target, ast.Name) and target.id in _REQUIRED_READERS:
+                            rebinds.append(target.id)
+                elif isinstance(node, ast.AnnAssign):
+                    target = node.target
+                    if isinstance(target, ast.Name) and target.id in _REQUIRED_READERS:
+                        rebinds.append(target.id)
+        assert not rebinds, (
+            f"run_per_cik_poll locally rebinds reader name(s): {rebinds}. "
+            "A local stub would defeat the consumed-call invariant while "
+            "leaving the dead module import in place. Per #1155 G13."
+        )
+
+    def test_run_per_cik_poll_returns_PerCikPollStats(self) -> None:
+        """Stats dataclass carries the ``recheck_*`` counters — proves
+        the caller-visible contract surfaces both reader outcomes.
+        A future change that flattens the dataclass would defeat the
+        operator's ability to see recheck-lane drain rates."""
+        tree = _module_tree()
+        fn = _run_per_cik_poll_node(tree)
+        assert isinstance(fn.returns, ast.Name) and fn.returns.id == "PerCikPollStats", (
+            "run_per_cik_poll return annotation drift — PerCikPollStats must remain "
+            "the caller-visible surface so recheck_* counters are observable."
+        )
+
+        stats_cls: ast.ClassDef | None = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "PerCikPollStats":
+                stats_cls = node
+                break
+        assert stats_cls is not None, "PerCikPollStats dataclass not found in module"
+
+        field_names: set[str] = set()
+        for stmt in stats_cls.body:
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                field_names.add(stmt.target.id)
+        for required in ("recheck_subjects_polled", "recheck_new_filings_recorded"):
+            assert required in field_names, (
+                f"PerCikPollStats missing field '{required}' — recheck-lane drain "
+                "rate would no longer be operator-visible. See #1155 G13."
+            )


### PR DESCRIPTION
## What

PR 3 of the [US ETL completion plan](docs/superpowers/plans/2026-05-17-us-etl-completion.md). Closes the **G13 sub-finding of #1155** with a static AST safety-net plus matrix close-out.

Refs #1155

## Why

Layer 3's per-CIK poll (`app/jobs/sec_per_cik_poll.py::run_per_cik_poll`) was updated in #1155 to drain BOTH `subjects_due_for_poll` AND `subjects_due_for_recheck`. Integration coverage already exists:

- `tests/test_sec_per_cik_poll.py::TestG13RecheckPath` — never_filed-stays-in-queue + alongside-drain
- `tests/test_sec_per_cik_poll.py::TestPerCikPoll.test_budget_split_*` — 66/34 split + degenerate floor
- `tests/test_layer_123_wiring.py::test_layer3_per_cik_poll_registered` — hourly cadence + prereq + source
- `tests/test_data_freshness.py::TestIterators::*` — reader-level SQL filter semantics

What was missing: a **static guarantee** that a future refactor cannot silently drop one of the two reader paths even if the integration tests are themselves refactored. This PR adds it.

## How

`tests/test_g13_recheck_reader_invariants.py` (4 tests, pure-static, no DB fixture):

1. `test_both_readers_imported_from_data_freshness` — `subjects_due_for_poll` AND `subjects_due_for_recheck` must appear in the module-level `from app.services.data_freshness import …`.
2. `test_both_readers_called_and_consumed_in_run_per_cik_poll` — both reader names must appear as **consumed** calls (`list(...)` / `tuple(...)` / `set(...)` / `for … in …` / `yield from …`) inside `run_per_cik_poll`'s top-level body. Visitor skips nested `FunctionDef` / `AsyncFunctionDef` / `Lambda` / `ClassDef` so a dead nested helper cannot satisfy the invariant.
3. `test_reader_names_not_locally_rebound` — no `ast.Assign` / `ast.AnnAssign` inside `run_per_cik_poll` may rebind a reader name. Defeats the "leave the import, stub the reader locally" regression.
4. `test_run_per_cik_poll_returns_PerCikPollStats` — return annotation + `recheck_subjects_polled` / `recheck_new_filings_recorded` fields must remain in the dataclass, so the operator-visible recheck-lane drain rate stays observable.

Matrix updates at `.claude/skills/data-engineer/etl-endpoint-coverage.md`:
- §3 sub-gap G13 narrative — production-never-reaches-it → ✅ CLOSED narrative naming the wiring file:line + the three test files.
- §7 gap register G13 row — OPEN → ✅ CLOSED 2026-05-17.

## Codex 2 pre-push

Two rounds. Round 1 flagged: (a) `ast.walk(fn)` recursed into nested scopes; (b) reader-call return value not checked as consumed. Both addressed with the `_ConsumedReaderVisitor`. Round 2 confirmed those fixes and flagged two residuals:

- **Local-rebind**: FIXED by `test_reader_names_not_locally_rebound`.
- **`if False:` reachability**: REBUTTED — full Python reachability is undecidable, the contrived `if False: list(reader(...))` form does not reflect a realistic regression, and the existing integration drain test (`test_recheck_subject_drained_alongside_poll`) would catch any behavioural regression where the reader is never reached at runtime. The static layer's job is to catch import / call-shape regressions; reachability is a runtime concern owned by the integration suite.

## Test plan

- [x] `uv run ruff check tests/test_g13_recheck_reader_invariants.py` — clean
- [x] `uv run ruff format --check tests/test_g13_recheck_reader_invariants.py` — clean
- [x] `uv run pyright tests/test_g13_recheck_reader_invariants.py` — 0 errors, 0 warnings
- [x] `uv run pytest tests/test_g13_recheck_reader_invariants.py` — 4 passed
- [x] `uv run pytest tests/test_sec_per_cik_poll.py tests/test_layer_123_wiring.py tests/test_data_freshness.py tests/test_g13_recheck_reader_invariants.py` — 51 passed (no integration regressions)

## ETL/parser/schema clauses (#8-#12) — N/A

This is a **test-only verification PR**:

- No parser change → smoke-against-3-5-instruments N/A.
- No schema migration → cross-source-verify N/A.
- No data-path change → backfill N/A.
- No operator-visible figure change → endpoint-verify N/A.

The matrix doc edit is metadata (sub-gap status), not an ETL behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)