### PR TITLE
feat(#932): adopt EdgarTools FundReport as N-PORT parser drop-in

### DIFF
--- a/.claude/skills/data-sources/edgartools.md
+++ b/.claude/skills/data-sources/edgartools.md
@@ -20,7 +20,7 @@ Network-required (live filing fetch + identity required):
 | Form | Entry point | Notes |
 |---|---|---|
 | 10-K / 10-Q / 8-K / 6-K / 20-F / 40-F | `Company("AAPL").latest_tenk` or `filing.obj()` | XBRL-backed reports |
-| N-PORT (P / EX / /A) | `FundReport.parse_fund_xml(xml)` | **Pydantic strict — see Gotcha G3** |
+| N-PORT (P / EX / /A) | `FundReport.parse_fund_xml(xml)` (dict) | **Structural + internal Pydantic cliffs — see Gotcha G3.** Live wrapper at `app/services/n_port_ingest.py` (#932). |
 | N-CSR | `FundShareholderReport.from_filing(filing)` | iXBRL OEF taxonomy. **No CUSIP at holding level** (#918 closeout). |
 | N-CEN | `FundCensus.from_filing(filing)` | structured census |
 | N-MFP2/3 | `MoneyMarketFund.from_filing(filing)` | money-market holdings |
@@ -126,15 +126,16 @@ def _edgar_parsers() -> tuple[Any, Any]:
 ### G2 — Interactive identity prompt in batch contexts
 `unset EDGAR_IDENTITY; python -c "from edgar import get_filings; get_filings(2026,1)"` blocks 60s. Always export `EDGAR_IDENTITY` before HTTP-touching call.
 
-### G3 — N-PORT Pydantic validation cliff
-`FundReport(**parse_fund_xml(xml))` raises `pydantic.ValidationError` on synthetic fixtures missing required fields (`<regCik>`, `<regStreet1>`). Required fields are non-`Optional`. Punted #932.
+### G3 — N-PORT structural + Pydantic cliffs
 
-Workaround options:
-- **A** — use full real-world XML in fixtures (25KB+ each).
-- **B** — use the dict path: `report_dict = FundReport.parse_fund_xml(xml)` then walk `report_dict["investments"]` directly. Skip the model layer.
-- **C** — direct lxml parsing (`~150 LoC`, 10-20× faster, no validation cliff). Recommended for #932 if revisited.
+`FundReport.parse_fund_xml(xml)` returns a `Dict[str, Any]` with keys `header / general_info / fund_info / investments`. Two failure modes (#932 spike `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md` §4):
 
-**Rule of thumb**: if the form's module imports `from pydantic import BaseModel`, expect a validation cliff for synthetic fixtures. Spike fixture compatibility BEFORE committing to a drop-in.
+1. **Structural cliff (observed on synthetic fixtures)**: the parser unconditionally dereferences `<filerInfo>` + `<fundInfo>` + `<returnInfo>` + `<monthlyTotReturns>` blocks. Missing any block → `AttributeError: 'NoneType' object has no attribute 'find'`. Hand-trimmed fixtures must include all four blocks plus `GeneralInfo` non-Optional text fields (`<regName>`, `<regCik>`, `<regFileNumber>`, `<regStreet1>` with non-empty content), `<fundInfo>` 9 required Decimal fields, and empty `<othMon1/2/3/>` tags under `<returnInfo>`.
+2. **Internal Pydantic cliff (latent on real-world payloads)**: `InvestmentOrSecurity.value_usd: Decimal` is non-Optional at `edgar/funds/reports.py:346`. An NPORT-P row that omits `<valUSD>` raises `pydantic.ValidationError` mid-iteration, aborting the whole-accession parse. Unobserved on the Vanguard probe sample but theoretically possible.
+
+**Rule of thumb**: if a form's module imports `from pydantic import BaseModel`, expect a validation cliff for synthetic fixtures AND for real-world payloads with missing required Decimal cells. Wrap the parser call AND the post-parse dict-key dereferences in `try/except (AttributeError, KeyError, decimal.InvalidOperation, ValueError, TypeError, pydantic.ValidationError)` and convert to a parser-specific error type so accession-level tombstones fire. `KeyError` defends against dict-shape drift on pin bump.
+
+Pinned at edgartools 5.30.2 by `pyproject.toml:21` (#925). Live wrapper at `app/services/n_port_ingest.py::parse_n_port_payload` (#932). See `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md` for the full empirical analysis.
 
 ### G4 — Type-label rewrite (`SH` → `Shares`, `PRN` → `Principal`)
 `parse_infotable_xml` output's `Type` column has values `"Shares"` / `"Principal"`, NOT the SEC two-letter codes. eBull maps back at [app/providers/implementations/sec_13f.py:210-213](../../../app/providers/implementations/sec_13f.py#L210-L213) (`_TYPE_CODE_FROM_LABEL`).
@@ -180,7 +181,7 @@ Need to parse SEC data?
 │   ├─ Form 3/4/5                        → edgartools (BeautifulSoup, fixture-safe)
 │   ├─ Schedule 13D/G post-2024-12-19    → edgartools
 │   ├─ Form 144                          → edgartools
-│   ├─ N-PORT                            → roll our own (Pydantic cliff)
+│   ├─ N-PORT                            → edgartools wrapper (#932 — see G3 + spike doc)
 │   └─ Anything else                     → investigate first
 │
 ├─ Need live HTTP fetch + auth?
@@ -215,7 +216,7 @@ Need to parse SEC data?
 | 13F INFOTABLE → typed | **best** | partial (download only) | no | ~50 LoC |
 | Form 3/4/5 transactions | **best** (full insider model) | partial | no | hard |
 | 13D/13G structured XML | **best** (post-2024-12-19) | partial | no | possible |
-| N-PORT XML | yes (Pydantic strict) | no | no | ~150 LoC viable |
+| N-PORT XML | **best** (wrapper + tombstone catch, #932) | no | no | ~150 LoC viable |
 | 10-K/10-Q XBRL | **best** (full statements engine) | no | no | painful |
 | companyfacts JSON | wraps cleanly | no | no | ~20 LoC |
 | Bulk archive download | yes (`download_edgar_data()`) | yes (faster on AWS path) | no | manual |
@@ -231,8 +232,9 @@ Confirmed via `grep -rn "from edgar\b\|import edgar\b" app/ tests/`:
 | [app/providers/implementations/sec_13f.py:77-80](../../../app/providers/implementations/sec_13f.py#L77-L80) | lazy `_edgar_parsers()` factory imports both static parsers |
 | [app/providers/implementations/sec_13f.py:237](../../../app/providers/implementations/sec_13f.py#L237) | `parse_primary_doc()` calls `edgar_parse_primary(xml)` |
 | [app/providers/implementations/sec_13f.py:308-309](../../../app/providers/implementations/sec_13f.py#L308-L309) | `parse_infotable()` calls `edgar_parse_infotable(xml)` |
+| `app/services/n_port_ingest.py::parse_n_port_payload` (#932) | lazy `_edgar_fund_report()` + `_pydantic_validation_error()` factories; wraps `FundReport.parse_fund_xml(xml)` with `try/except` over all 6 failure classes (AttributeError / KeyError / InvalidOperation / ValueError / TypeError / pydantic.ValidationError) |
 
-**No other code in eBull imports `edgar`.** All other SEC paths (`sec_edgar.py`, `sec_submissions.py`, `sec_daily_index.py`, `sec_13dg.py`, `sec_fundamentals.py`, `sec_getcurrent.py`) are direct httpx/lxml.
+All other SEC paths (`sec_edgar.py`, `sec_submissions.py`, `sec_daily_index.py`, `sec_13dg.py`, `sec_fundamentals.py`, `sec_getcurrent.py`) remain direct httpx/lxml.
 
 ## Upgrade procedure
 

--- a/app/services/n_port_ingest.py
+++ b/app/services/n_port_ingest.py
@@ -13,16 +13,22 @@ Spec:
 docs/superpowers/specs/2026-05-04-ownership-full-decomposition-design.md
 (Phase 3, §"Source matrix" + §"Per-category natural keys").
 
-## Parser posture — lxml-direct, NOT EdgarTools
+## Parser posture — EdgarTools FundReport wrapper (#932)
 
-The spec recommended EdgarTools as a parser dep. The codebase already
-parses 13F-HR / 13D/G / Form 4 with stdlib ``xml.etree.ElementTree``;
-extending that pattern to N-PORT keeps the parser self-contained,
-zero-dep, and offline-deterministic. The EdgarTools 13F drop-in is
-tracked separately as #925; if N-PORT parsing turns out to need
-EdgarTools' fallback heuristics, that's a follow-up — for now the
-hand-rolled parser covers every well-formed NPORT-P SEC publishes
-(per the EDGAR XSD).
+Wraps ``edgar.funds.reports.FundReport.parse_fund_xml`` (lazy-imported
+via :func:`_edgar_fund_report` per the #925 13F-HR drop-in pattern).
+Preserves the public :class:`NPortFiling` / :class:`NPortHolding`
+dataclass surface so the ingester body is unchanged.
+
+The previous stdlib-``xml.etree.ElementTree`` parser was replaced by
+this wrapper after the #932 spike (see
+``docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md``)
+confirmed FEASIBLE for the probed real-SEC NPORT-P shape. The wrapper
+catches every EdgarTools failure mode (structural-block dereferences,
+internal ``pydantic.ValidationError`` on missing required Decimal
+fields, dict-shape drift on pin bump) and converts to
+:class:`NPortParseError` so accession-level tombstones fire via
+:func:`_ingest_single_accession`.
 
 Codex pre-impl review (2026-05-05) findings folded in:
 
@@ -47,7 +53,6 @@ from __future__ import annotations
 import json
 import logging
 import time
-import xml.etree.ElementTree as ET  # noqa: S405 — we only use ET to catch ParseError on malformed input
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
@@ -71,8 +76,10 @@ logger = logging.getLogger(__name__)
 # affects what lands in ``ownership_funds_observations``. Re-wash
 # workflows compare against this constant and reset
 # ``filing_raw_documents.parser_version`` mismatches back to ``pending``
-# in the manifest worker (#869).
-_PARSER_VERSION_NPORT = "nport-v1"
+# in the manifest worker (#869). The bump propagates to the manifest
+# adapter (`app/services/manifest_parsers/sec_n_port.py`) via direct
+# symbol import.
+_PARSER_VERSION_NPORT = "nport-v2-edgartools"
 
 
 # Both spellings appear in the SEC submissions API. The current
@@ -313,145 +320,190 @@ def _safe_iso_datetime(text: str | None) -> datetime | None:
 
 
 # ---------------------------------------------------------------------------
-# N-PORT XML parser
+# N-PORT XML parser — EdgarTools FundReport wrapper (#932)
 # ---------------------------------------------------------------------------
-
-
-# N-PORT publishes XBRL-shaped XML under the SEC ``edgar/nport``
-# namespace. The relevant elements live under
-# ``{nport}genInfo`` (header) and ``{nport}invstOrSecs/invstOrSec``
-# (per-holding records). The parser is namespace-aware to defend
-# against SEC's namespace evolutions across N-PORT-1 → N-PORT-2 → etc.
-# ``ET.iterparse`` could be used for memory savings on >1MB files but
-# in practice N-PORT XMLs land at 200KB-2MB; ``fromstring`` is fine.
-def _stripns(tag: str) -> str:
-    """Drop XML namespace prefix: ``{ns}foo`` → ``foo``."""
-    if "}" in tag:
-        return tag.split("}", 1)[1]
-    return tag
-
-
-def _find_text(elem: ET.Element, *, local_name: str) -> str | None:
-    """Return the text of the first descendant whose local-name
-    (namespace-stripped) matches ``local_name``, or ``None``."""
-    for child in elem.iter():
-        if _stripns(child.tag) == local_name:
-            text = (child.text or "").strip()
-            return text or None
-    return None
-
-
-def _children_by_local_name(elem: ET.Element, *, local_name: str) -> list[ET.Element]:
-    """Direct-children filter by local name (not full descendant scan)."""
-    return [c for c in elem if _stripns(c.tag) == local_name]
-
-
-def _decimal_or_none(text: str | None) -> Decimal | None:
-    if not text:
-        return None
-    try:
-        return Decimal(text.strip())
-    except InvalidOperation, AttributeError:
-        return None
 
 
 def parse_n_port_payload(xml: str) -> NPortFiling:
     """Parse an NPORT-P primary doc XML into an :class:`NPortFiling`.
 
-    Pure XML-in / dataclass-out — no network calls, no DB access.
-    Raises :class:`NPortParseError` on malformed XML, or
-    :class:`NPortMissingSeriesError` if the filing has no ``seriesId``.
+    Wraps ``edgar.funds.reports.FundReport.parse_fund_xml`` (#932,
+    superseding the stdlib-ET parser from #917). EdgarTools is lazy-
+    imported at first call so module import stays side-effect-free
+    (#925 pattern; mirrors ``app/providers/implementations/sec_13f.py``
+    L76-80).
 
-    Holdings are emitted in document order. The ingester filters /
-    transforms downstream — this parser surfaces every well-formed
-    holding without applying business logic (debt / short / preferred
-    rows are surfaced; the ingester drops them via the equity-common
-    guard).
+    Catches every EdgarTools failure mode (structural-block dereferences,
+    internal Pydantic ``ValidationError`` on missing required Decimal
+    fields, dict-shape drift) and converts to :class:`NPortParseError`
+    so ``_ingest_single_accession``'s tombstone path fires.
+
+    Preserves all six #917 Codex pre-impl invariants:
+      * ``period_end`` mandatory → :class:`NPortParseError` if missing.
+      * ``series_id`` mandatory → :class:`NPortMissingSeriesError`
+        (distinct from generic :class:`NPortParseError`).
+      * ``cik`` mandatory, with ``regCik`` → header
+        ``issuer_credentials.cik`` fallback.
+      * ``filed_at`` returned as ``None`` from the parser — the ingester
+        layers in submissions-index ``filingDate`` before any midnight
+        fallback. EdgarTools' ``parse_fund_xml`` does not surface a
+        header-level filedAt field.
+      * ``units`` passthrough (strip-only; the ingester rejects non-NS).
+      * ``balance`` ``None`` → drop row.
+
+    EdgarTools field-name trap: ``general_info.fiscal_year_end`` stores
+    the ``repPdEnd`` text (period end), NOT the fund's fiscal-year-end.
+    Documented at the golden-replay test.
+
+    Pure XML-in / dataclass-out. No network calls, no DB access.
     """
+    fund_report = _edgar_fund_report()
+    pydantic_validation_error = _pydantic_validation_error()
+    xml_syntax_error = _lxml_syntax_error()
+
+    # Catch scope covers BOTH the EdgarTools parser call AND the
+    # post-parse normalisation. Any KeyError (dict-shape drift on pin
+    # bump), AttributeError (missing typed object attribute), or
+    # InvalidOperation / ValueError that fires during normalisation
+    # must surface as NPortParseError so the tombstone path fires.
+    # lxml.etree.XMLSyntaxError covers the edge case where both the
+    # primary lxml parse AND EdgarTools' recover=True fallback fail
+    # (e.g. empty payload, null-byte body): EdgarTools re-raises the
+    # raw XMLSyntaxError without classifying it. Codex 2 round 1.
+    # NPortMissingSeriesError / NPortParseError are re-raised
+    # explicitly to preserve their dedicated tombstone paths.
     try:
-        root = ET.fromstring(xml)  # noqa: S314 — we accept SEC-published XML; parser is stdlib, no DTD resolution
-    except ET.ParseError as exc:
-        raise NPortParseError(f"NPORT-P XML parse failed: {exc}") from exc
+        parsed = fund_report.parse_fund_xml(xml)
 
-    # ----- header (genInfo + filer identity) -----
-    # The NPORT-P XML carries:
-    #   formData/genInfo/regCik         — registered investment company CIK
-    #   formData/genInfo/seriesId       — SEC series identifier (S0000xxxxx)
-    #   formData/genInfo/seriesName     — fund series human-readable name
-    #   formData/genInfo/repPdEnd       — period_of_report end date
-    #   headerData/filerInfo/filer/issuerCredentials/cik (for the registrant)
-    # Walk by local-name to be robust to namespace versioning.
-    cik_text = _find_text(root, local_name="regCik") or _find_text(root, local_name="cik")
-    series_id = _find_text(root, local_name="seriesId")
-    series_name = _find_text(root, local_name="seriesName") or ""
-    period_end_text = _find_text(root, local_name="repPdEnd")
-    filed_at_text = _find_text(root, local_name="filedAt") or _find_text(root, local_name="acceptedDate")
+        general_info = parsed["general_info"]
+        cik_text = (general_info.cik or "").strip() or _header_issuer_cik(parsed.get("header"))
+        series_id_raw = (general_info.series_id or "").strip()
+        period_end_text = (general_info.fiscal_year_end or "").strip() or None
+        series_name = (general_info.series_name or "").strip()
 
-    if not cik_text:
-        raise NPortParseError("NPORT-P: missing regCik / cik in header")
-    if not series_id:
-        # Codex pre-impl review #2 — refuse to synthesise.
-        raise NPortMissingSeriesError(
-            "NPORT-P: missing seriesId in genInfo header; refusing to "
-            "synthesise an identity. Filing tombstoned for operator review."
-        )
-    if not period_end_text:
-        raise NPortParseError("NPORT-P: missing repPdEnd in genInfo header")
-
-    period_end = _safe_iso_date(period_end_text)
-    if period_end is None:
-        raise NPortParseError(f"NPORT-P: malformed repPdEnd={period_end_text!r}")
-
-    # Codex pre-push review #1: do NOT default ``filed_at`` to
-    # ``period_end`` midnight inside the parser. Two filings sharing a
-    # period (NPORT-P + NPORT-P/A) would then carry identical
-    # ``filed_at`` values and the ``_current`` refresh tie-break would
-    # pick the wrong one. The ingester layers in the submissions-index
-    # ``filingDate`` (always present in the ``recent`` array) before
-    # any midnight fallback — see ``_ingest_single_accession``.
-    filed_at = _safe_iso_datetime(filed_at_text)
-
-    # ----- holdings -----
-    holdings: list[NPortHolding] = []
-    for holding_elem in root.iter():
-        if _stripns(holding_elem.tag) != "invstOrSec":
-            continue
-        cusip = _find_text(holding_elem, local_name="cusip") or ""
-        issuer_name = _find_text(holding_elem, local_name="name") or ""
-        balance_text = _find_text(holding_elem, local_name="balance")
-        value_text = _find_text(holding_elem, local_name="valUSD")
-        payoff_profile = _find_text(holding_elem, local_name="payoffProfile") or ""
-        asset_cat = _find_text(holding_elem, local_name="assetCat") or ""
-        issuer_cat = _find_text(holding_elem, local_name="issuerCat") or ""
-        units = _find_text(holding_elem, local_name="units") or ""
-
-        balance = _decimal_or_none(balance_text)
-        if balance is None:
-            # No balance = unparseable holding; skip silently. The
-            # ingester counts these via the parser-failure path.
-            continue
-
-        holdings.append(
-            NPortHolding(
-                cusip=cusip.strip().upper(),
-                issuer_name=issuer_name,
-                shares=balance,
-                value_usd=_decimal_or_none(value_text),
-                payoff_profile=payoff_profile,
-                asset_category=asset_cat,
-                issuer_category=issuer_cat,
-                units=units,
+        if not cik_text:
+            raise NPortParseError("NPORT-P: missing regCik / header issuer_credentials.cik")
+        if not series_id_raw:
+            # Codex #917 pre-impl review #2 — refuse to synthesise.
+            raise NPortMissingSeriesError(
+                "NPORT-P: missing seriesId in genInfo header; refusing to "
+                "synthesise an identity. Filing tombstoned for operator review."
             )
-        )
+        if not period_end_text:
+            raise NPortParseError("NPORT-P: missing repPdEnd in genInfo header")
+        period_end = _safe_iso_date(period_end_text)
+        if period_end is None:
+            raise NPortParseError(f"NPORT-P: malformed repPdEnd={period_end_text!r}")
 
-    return NPortFiling(
-        filer_cik=_zero_pad_cik(cik_text),
-        series_id=series_id,
-        series_name=series_name,
-        period_end=period_end,
-        filed_at=filed_at,
-        holdings=tuple(holdings),
-    )
+        # Codex #917 pre-push review #1: do NOT default filed_at to
+        # period_end midnight inside the parser. Two filings sharing a
+        # period (NPORT-P + NPORT-P/A) would then carry identical
+        # filed_at values and the _current refresh tie-break would pick
+        # the wrong one. The ingester layers in the submissions-index
+        # filingDate before any midnight fallback.
+        filed_at: datetime | None = None
+
+        holdings: list[NPortHolding] = []
+        for investment in parsed["investments"]:
+            balance = investment.balance
+            if balance is None:
+                # No balance = unparseable holding; parser-level drop.
+                continue
+            # Strip + upper categorical fields. The downstream ingester
+            # guards (units != "NS", payoff_profile != "Long",
+            # asset_category != "EC") are exact-equality so a stray
+            # leading/trailing whitespace from a future EdgarTools
+            # whitespace-preservation change would mis-drop valid rows.
+            holdings.append(
+                NPortHolding(
+                    cusip=(investment.cusip or "").strip().upper(),
+                    issuer_name=(investment.name or "").strip(),
+                    shares=balance,
+                    value_usd=investment.value_usd,
+                    payoff_profile=(investment.payoff_profile or "").strip(),
+                    asset_category=(investment.asset_category or "").strip(),
+                    issuer_category=(investment.issuer_category or "").strip(),
+                    units=(investment.units or "").strip(),
+                )
+            )
+
+        return NPortFiling(
+            filer_cik=_zero_pad_cik(cik_text),
+            series_id=series_id_raw,
+            series_name=series_name,
+            period_end=period_end,
+            filed_at=filed_at,
+            holdings=tuple(holdings),
+        )
+    except NPortMissingSeriesError:
+        # Distinct from generic NPortParseError tombstone path.
+        raise
+    except NPortParseError:
+        # Already-classified parser error; preserve verbatim.
+        raise
+    except (
+        AttributeError,
+        KeyError,
+        InvalidOperation,
+        ValueError,
+        TypeError,
+        pydantic_validation_error,
+        xml_syntax_error,
+    ) as exc:
+        raise NPortParseError(f"NPORT-P EdgarTools parse failed: {exc}") from exc
+
+
+def _edgar_fund_report() -> Any:
+    """Lazy import: defer EdgarTools' filesystem-cache mkdir
+    (``~/.edgar/_tcache``) until first parse call. Mirrors the lazy
+    factory at ``app/providers/implementations/sec_13f.py``:76-80."""
+    from edgar.funds.reports import FundReport
+
+    return FundReport
+
+
+def _pydantic_validation_error() -> type[Exception]:
+    """Lazy import: ``pydantic.ValidationError`` for the wrapper's
+    catch list. Pydantic comes in transitively via edgartools but we
+    hold our own reference to its ValidationError type to keep the
+    catch clause explicit. Lazy to keep module import side-effect-free.
+    """
+    from pydantic import ValidationError
+
+    return ValidationError
+
+
+def _lxml_syntax_error() -> type[Exception]:
+    """Lazy import: ``lxml.etree.XMLSyntaxError`` for the wrapper's
+    catch list. EdgarTools' ``parse_fund_xml`` raw-parses with
+    ``etree.fromstring`` and falls back to ``recover=True`` on
+    ``XMLSyntaxError``; if the recover-mode parse ALSO fails (empty
+    body, null-byte body, etc.), the raw exception escapes without
+    classification. Lazy to keep module import side-effect-free.
+    """
+    from lxml.etree import XMLSyntaxError
+
+    return XMLSyntaxError
+
+
+def _header_issuer_cik(header: Any) -> str | None:
+    """Best-effort dereference of
+    ``parsed['header'].filer_info.issuer_credentials.cik``. ``None`` if
+    any intermediate is ``None`` or missing.
+
+    Mirrors the ``regCik`` → header ``cik`` fallback that the pre-#932
+    stdlib parser performed via
+    ``_find_text(root, local_name='cik')``.
+    """
+    if header is None:
+        return None
+    try:
+        cik = header.filer_info.issuer_credentials.cik
+    except AttributeError:
+        return None
+    if not cik:
+        return None
+    return cik.strip() or None
 
 
 # ---------------------------------------------------------------------------

--- a/docs/superpowers/plans/2026-05-18-n-port-edgartools-dropin-plan.md
+++ b/docs/superpowers/plans/2026-05-18-n-port-edgartools-dropin-plan.md
@@ -1,0 +1,433 @@
+# #932 — N-PORT EdgarTools `FundReport` parser drop-in (impl plan)
+
+> Status: DRAFT 2026-05-18.
+>
+> Spec: `docs/superpowers/specs/2026-05-18-n-port-edgartools-dropin.md` (CLEAN through Codex 1a r4).
+> Spike: `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md` (CLEAN through Codex 1a r3).
+> Branch: `fix/932-nport-edgartools-spike` (current; will be the impl branch — single PR bundles spike + spec + plan + impl).
+
+## 0. Scope guardrail
+
+Parser-only per #932 issue body. Touchpoints:
+
+- `app/services/n_port_ingest.py` — parse function body + version constant + lazy-import helpers.
+- `app/services/manifest_parsers/sec_n_port.py` — UNCHANGED beyond auto-propagation of the version constant.
+- `tests/test_n_port_ingest.py` — 7 tests touched + 1 new + 1 helper.
+- `tests/test_manifest_parser_sec_n_port.py` — happy-path assertions updated + version-bump assertion added.
+- `tests/fixtures/sec/nport_p_test_fund.xml` — REPLACED with real Vanguard 500 fixture.
+- `tests/fixtures/sec/nport_p_missing_series.xml` — REWRITTEN to clear EdgarTools structural requirements while still missing `<seriesId>`.
+- `.claude/skills/data-sources/edgartools.md` §G3 — REWRITTEN.
+- `/Users/lukebradford/.claude/projects/-Users-lukebradford-Dev-eBull/memory/feedback_pydantic_validation_cliff.md` — UPDATED.
+- `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md` — already on branch (spike doc).
+- `docs/superpowers/specs/2026-05-18-n-port-edgartools-dropin.md` — already on branch (spec).
+- This plan doc.
+
+NO changes to:
+
+- Schema (`ownership_funds_*` tables).
+- Ingester body (`_ingest_single_accession` write-side guards / tombstone / log).
+- Operator-visible rollup endpoint (deferred to #919).
+- Submissions-index walker (`parse_submissions_index`).
+- DB helpers (`_existing_accessions_for_fund_filer`, `_record_ingest_attempt`, `_resolve_cusip_to_instrument_id`).
+
+## 1. Task ordering
+
+### T1 — Fetch canonical Vanguard 500 fixture
+
+**Goal:** obtain the real Vanguard 500 Index Fund (series `S000002277`) NPORT-P primary doc + record the golden-replay anchor values.
+
+**Steps:**
+
+1. Write a one-shot probe script at `/Users/lukebradford/Dev/eBull/.scratch_nport_fetch.py` (gitignored — deleted post-task):
+
+   ```python
+   from app.config import settings
+   from app.providers.implementations.sec_edgar import SecFilingsProvider
+   from app.services.n_port_ingest import (
+       _archive_file_url,
+       _submissions_url,
+       parse_submissions_index,
+   )
+
+   TARGET_SERIES = "S000002277"  # Vanguard 500 Index Fund
+   CIK = "0000036405"
+   OUT_PATH = "tests/fixtures/sec/nport_p_test_fund.xml"
+
+   with SecFilingsProvider(user_agent=settings.sec_user_agent) as sec:
+       subs = sec.fetch_document_text(_submissions_url(CIK))
+       refs = parse_submissions_index(subs)
+       from edgar.funds.reports import FundReport
+       for ref in refs:
+           primary = sec.fetch_document_text(
+               _archive_file_url(CIK, ref.accession_number, "primary_doc.xml")
+           )
+           if primary is None:
+               continue
+           # Parse-then-check (NOT a string search): EdgarTools' parser
+           # strips namespaces internally, so prefixed XML
+           # (<nport:seriesId>...) parses to general_info.series_id
+           # cleanly. A literal `<seriesId>...` string search would miss
+           # prefixed payloads.
+           try:
+               parsed = FundReport.parse_fund_xml(primary)
+           except Exception:  # noqa: BLE001 — probe-time tolerance
+               continue
+           if (parsed["general_info"].series_id or "").strip() != TARGET_SERIES:
+               continue
+           open(OUT_PATH, "w").write(primary)
+           print(f"saved {ref.accession_number}: {len(primary)} bytes; series_id={parsed['general_info'].series_id}")
+           break
+   ```
+
+2. Run: `uv run python /Users/lukebradford/Dev/eBull/.scratch_nport_fetch.py`. Expected: one Vanguard 500 NPORT-P primary_doc.xml saved at `tests/fixtures/sec/nport_p_test_fund.xml`. SEC HTTP request count: 1 submissions JSON + N primary docs until S000002277 matched (typically ≤10 candidates per Vanguard registrant per quarter).
+
+3. Probe parse_fund_xml against the saved fixture and record the golden-replay anchor values:
+
+   ```python
+   from edgar.funds.reports import FundReport
+   from decimal import Decimal
+   xml = open("tests/fixtures/sec/nport_p_test_fund.xml").read()
+   parsed = FundReport.parse_fund_xml(xml)
+   inv = parsed["investments"]
+   print("count:", len(inv))
+   top = max(inv, key=lambda x: x.value_usd if x.value_usd is not None else Decimal(0))
+   print("top:", top.name, top.cusip, top.balance, top.units, top.value_usd, top.payoff_profile, top.asset_category)
+   print("sum_value_usd:", sum(x.value_usd for x in inv if x.value_usd is not None))
+   print("period_end:", parsed["general_info"].fiscal_year_end)
+   print("series_id:", parsed["general_info"].series_id)
+   print("series_name:", parsed["general_info"].series_name)
+   ```
+
+4. Record the 7 anchor values in this plan doc's T1-RESULTS section below. These become the literal assertions in `test_golden_replay_first_row_count_total`.
+
+5. Delete `/Users/lukebradford/Dev/eBull/.scratch_nport_fetch.py`. Verify `git status` shows only `tests/fixtures/sec/nport_p_test_fund.xml` modified.
+
+**Acceptance:** T1-RESULTS table below is filled in with non-placeholder values + the fixture file is on disk.
+
+#### T1-RESULTS
+
+Captured 2026-05-18 via `.scratch_nport_fetch.py` (deleted post-task). Risk-register fallback fired: `S000002277` is not under CIK 36405 (the synthetic fixture's claim was wrong); selected the most recent NPORT-P with ≥100 holdings + complete `valUSD` coverage instead.
+
+| Field | Value |
+|---|---|
+| Accession | `0000036405-26-000074` |
+| Filed date (submissions-index `filingDate`) | `2026-02-26` |
+| `period_of_report` (submissions-index `reportDate`) | `2025-12-31` |
+| `general_info.cik` | `'0000036405'` |
+| `general_info.series_id` | `'S000002840'` |
+| `general_info.series_name` | `'VANGUARD VALUE INDEX FUND'` |
+| `general_info.fiscal_year_end` | `'2025-12-31'` (string text; `_safe_iso_date` → `date(2025, 12, 31)`) |
+| Holdings count | `323` |
+| Top holding by `value_usd` — name | `'JPMorgan Chase & Co'` |
+| Top holding CUSIP | `'46625H100'` |
+| Top holding shares (`balance`) | `Decimal('24052035.00000000')` |
+| Top holding `units` | `'NS'` |
+| Top holding `value_usd` | `Decimal('7750046717.70000000')` |
+| Top holding `payoff_profile` | `'Long'` |
+| Top holding `asset_category` | `'EC'` |
+| Top holding `issuer_category` | `'CORP'` |
+| Sum of all `value_usd` | `Decimal('217419611080.71000000')` |
+| Holdings with `value_usd is None` | `0` |
+
+**T4 / T5 / T10 assertion source-of-truth:** every assertion that references `series_id` / `series_name` / `period_end` / top-holding fields / total `value_usd` / holdings count MUST cite these values verbatim. Bonus: the top holding (JPM CUSIP `46625H100`) is in the standard smoke panel (`AAPL` / `GME` / `MSFT` / `JPM` / `HD`) — the manifest happy-path test can seed JPM's CUSIP mapping and assert at least one landed row using the canonical smoke-panel CUSIP.
+
+### T2 — Write the new missing-series fixture
+
+**Goal:** rewrite `tests/fixtures/sec/nport_p_missing_series.xml` per spec §4.2 concrete shape.
+
+**Steps:**
+
+1. Replace file content with the spec §4.2 XML verbatim (regName + regCik + regFileNumber + regStreet1 all present with non-empty text; `<seriesId>` deliberately omitted; 9 fundInfo Decimal fields = 0; returnInfo with empty monthlyTotReturns + 3 empty othMon tags; filerInfo + issuerCredentials with cik/ccc).
+
+2. Verify behaviour: `uv run python -c "from edgar.funds.reports import FundReport; from app.services.n_port_ingest import parse_n_port_payload, NPortMissingSeriesError; xml = open('tests/fixtures/sec/nport_p_missing_series.xml').read(); FundReport.parse_fund_xml(xml); print('parse_fund_xml CLEAN')"` — confirms EdgarTools doesn't crash on this fixture. (Wrapper not yet implemented at this task; we're verifying the fixture alone.)
+
+3. After T3 lands, verify `parse_n_port_payload(xml)` raises `NPortMissingSeriesError`.
+
+**Acceptance:** fixture written; T2 verification command succeeds.
+
+### T3 — Implement the wrapper
+
+**Goal:** replace `parse_n_port_payload` body per spec §3.1 verbatim.
+
+**Steps:**
+
+1. Modify `app/services/n_port_ingest.py`:
+
+   - Bump `_PARSER_VERSION_NPORT = "nport-v1"` → `"nport-v2-edgartools"` (line 75).
+   - Add module-level `from typing import Any` (already imported).
+   - Replace `parse_n_port_payload(xml: str) -> NPortFiling` body (lines 358-454) with the spec §3.1 implementation. The function signature + docstring (rewritten per spec §3.1) preserve the same public contract.
+   - Add three module-level factory functions after `parse_n_port_payload`:
+     - `_edgar_fund_report() -> Any` (lazy import of `FundReport`).
+     - `_pydantic_validation_error() -> type[Exception]` (lazy import of `ValidationError`).
+     - `_header_issuer_cik(header: Any) -> str | None` (best-effort attribute walk).
+   - Remove unused helpers: `_stripns`, `_find_text`, `_children_by_local_name`, `_decimal_or_none`. Grep-verify no other caller:
+
+     ```bash
+     # Removed helpers — must return ZERO matches after removal
+     # (definitions + all call-sites gone).
+     rg -n "\b(_stripns|_find_text|_children_by_local_name|_decimal_or_none)\b" app tests
+
+     # Parser callers + version constant — must cover the manifest
+     # adapter's direct symbol import at
+     # app/services/manifest_parsers/sec_n_port.py:60-68 plus the call
+     # site at :182.
+     rg -n "parse_n_port_payload|_PARSER_VERSION_NPORT" app tests
+     ```
+
+     - First command (removed helpers): expect **zero matches** after removal.
+     - Second command (`parse_n_port_payload` + `_PARSER_VERSION_NPORT`): expect call-sites at `app/services/n_port_ingest.py` (definition + version-constant def), `app/services/manifest_parsers/sec_n_port.py` (direct import + 7 version-constant uses), `tests/test_n_port_ingest.py`, `tests/test_manifest_parser_sec_n_port.py`. No other callers.
+   - Remove module-level `import xml.etree.ElementTree as ET` (line 50) AND the `# noqa: S405` comment if `ET` is no longer referenced anywhere in the file. Verify via grep.
+   - Keep `from decimal import Decimal, InvalidOperation` — both still used (Decimal for typing, InvalidOperation for the wrapper's catch clause).
+
+2. Verify import side-effect remains:
+
+   ```bash
+   uv run python -c "import app.services.n_port_ingest; print('module import clean')"
+   ```
+
+   No EdgarTools side-effect on bare module import.
+
+3. Verify lazy-import path:
+
+   ```bash
+   uv run python -c "
+   from app.services.n_port_ingest import parse_n_port_payload, _edgar_fund_report
+   fr = _edgar_fund_report()
+   print('FundReport:', fr.__name__)
+   "
+   ```
+
+**Acceptance:** wrapper body in place; both verification commands succeed.
+
+### T4 — Update existing N-PORT tests
+
+**Goal:** apply the test surgery in spec §5.
+
+**Steps:**
+
+1. **`TestParseNPortPayload::test_extracts_header_and_holdings`** — rewrite to assert against T1-RESULTS anchor values. Tolerant assertions on series name (case-insensitive startswith). `filed_at is None` (per wrapper contract).
+
+2. **`TestParseNPortPayload::test_raises_missing_series_id`** — UNCHANGED (uses the new missing-series fixture from T2).
+
+3. **`TestParseNPortPayload::test_raises_on_malformed_xml`** — verify behaviour with `"<not><well><formed>"`. If EdgarTools' `recover=True` parser silently succeeds and the failure surfaces only inside the wrapper's normalisation try-block (via `KeyError` on `parsed["general_info"]` or similar), the test still passes — the wrapper's catch-list converts to `NPortParseError`. If it doesn't surface as `NPortParseError`, change the malformed input to `"<edgarSubmission>X</edgarSubmission>"` or similar that DOES survive recover-mode but fails normalisation.
+
+4. **`TestParseNPortPayload::test_runs_offline_no_network`** — unchanged structure; uses T1 fixture; same `urllib.request.urlopen` + `httpx` patches; asserts `parsed.series_id == <T1-RESULTS series_id>` (literal from T1-RESULTS, NOT hardcoded `"S000002277"` — same source-of-truth rule as the risk-register fallback note).
+
+5. **`TestParseNPortPayload::test_golden_replay_first_row_count_total`** — NEW. Locks: top-by-`value_usd` holding's cusip + shares + value_usd, total holdings count, and `sum(h.value_usd for h in parsed.holdings if h.value_usd)`. All values from T1-RESULTS table.
+
+6. **`TestIngestFundNPort` — three refactored tests**:
+
+   For each of `test_ingest_drops_non_equity_short_unresolved`, `test_idempotent_reingest`, `test_amendment_uses_submissions_filed_at_when_header_missing`:
+
+   - Replace the `fixture_xml = ...` line with construction of an `NPortFiling` via the new `_make_filter_path_filing()` helper (or two filings for the amendment test).
+   - Replace the `fetcher = _FakeFetcher({primary_url: fixture_xml, ...})` with a `_FakeFetcher` that still returns a real (or stub) XML for the primary_url (so `raw_filings.store_raw` writes a row), but with `monkeypatch.setattr("app.services.n_port_ingest.parse_n_port_payload", lambda xml: filing)` per-test. Use a small stub XML or copy the T2 missing-series fixture (the parser is monkeypatched so its content doesn't matter — the bytes are stored in `filing_raw_documents` but never re-parsed in-test).
+
+   **Monkeypatch target rule** (guardrail):
+   - For ingester-driven tests through `_ingest_single_accession`: target `app.services.n_port_ingest.parse_n_port_payload` (module-local global lookup).
+   - For manifest-adapter-driven tests: target `app.services.manifest_parsers.sec_n_port.parse_n_port_payload` — the adapter imports the symbol with `from app.services.n_port_ingest import parse_n_port_payload` at line ~60, binding it into its own namespace. A service-side monkeypatch does NOT affect the manifest adapter's reference. Current T4 + T5 plan does not require manifest-side monkeypatching (manifest tests stay on the real parser), but the guardrail is documented here for future work.
+   - For `test_ingest_drops_non_equity_short_unresolved`, add assertion `assert row[0] == 1 and parser_version_row[0] == "nport-v2-edgartools"` on the `filing_raw_documents` row (parser-version bump regression guard).
+
+7. **`TestIngestFundNPort::test_missing_series_id_tombstones_failed`** — UNCHANGED (real parser path through the updated missing-series fixture).
+
+8. **Add `_make_filter_path_filing` helper** at module-level per spec §5.8.
+
+9. **TestFundsSchema / TestIngestAllStatusPrecedence / TestManifestFormCodes / test_accession_ref_dataclass_is_frozen** — UNCHANGED.
+
+10. **TestParseSubmissionsIndex / TestRecordFundObservation** — UNCHANGED.
+
+**Acceptance:** `uv run pytest tests/test_n_port_ingest.py -x -q` passes.
+
+### T5 — Update manifest-parser tests
+
+**Goal:** apply spec §5.7.
+
+**Steps:**
+
+1. `tests/test_manifest_parser_sec_n_port.py`:
+
+   - `_FAKE_NPORT_XML` continues to point at the same path; the file content changed in T1.
+   - Happy-path test: row-count + specific-CUSIP assertions need updating to match the real-fixture distribution. Seed CUSIP mappings for the top-N holdings from T1-RESULTS (at least AAPL + MSFT + the actual top holding). Assert at least 1 holding row landed in `ownership_funds_current` (NOT a specific count — the real Vanguard 500 has ~500 holdings, the seeded CUSIPs determine landed rows; assertion should be tolerant).
+   - Parser-version assertion: add `parser_version == "nport-v2-edgartools"` to every `filing_raw_documents` assertion site.
+   - Missing-series tombstone test: UNCHANGED structure; the fixture content updated in T2 still raises `NPortMissingSeriesError`.
+   - Malformed-XML test: same posture as T4 §3.
+
+2. Run: `uv run pytest tests/test_manifest_parser_sec_n_port.py -x -q`.
+
+**Acceptance:** all manifest-parser tests pass.
+
+### T6 — Skill update
+
+**Goal:** rewrite `.claude/skills/data-sources/edgartools.md` §G3 per spec §6.1.
+
+**Steps:**
+
+1. Replace the §G3 block. Verify in-file references (line numbers, links) remain valid.
+2. Add a back-reference to the spike doc: `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md`.
+
+**Acceptance:** rg confirms `#932` + `2026-05-18-n-port-edgartools` appear in §G3.
+
+### T7 — Memory update
+
+**Goal:** update `feedback_pydantic_validation_cliff.md` per spec §6.2.
+
+**Steps:**
+
+1. Add a section noting the #932 case where the OBSERVED failure was structural (synthetic fixture) but a SEPARATE internal Pydantic cliff remains theoretically possible.
+2. Cross-link to `[[us-source-coverage]]` and the spike doc.
+
+**Acceptance:** memory file mentions #932 + the structural-vs-Pydantic distinction.
+
+### T8 — Local gates
+
+**Goal:** pass the pre-push checklist.
+
+**Steps:**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest tests/test_n_port_ingest.py tests/test_manifest_parser_sec_n_port.py -x -q
+uv run pytest tests/smoke/test_app_boots.py -x -q
+uv run pytest -x -q
+```
+
+All six must pass.
+
+Pyright-specific check: the wrapper uses `Any` for `_edgar_fund_report() -> Any` to defer the FundReport type-import. If pyright complains about return-type inference at the call site, add `# type: ignore[no-any-return]` only at the specific call site, never module-wide.
+
+**Acceptance:** all six commands exit 0.
+
+### T9 — Codex 2 pre-push review
+
+**Goal:** non-negotiable per CLAUDE.md Codex checkpoint #2.
+
+**Steps:**
+
+```bash
+codex exec "Review diff on branch fix/932-nport-edgartools-spike against:
+  - spec: docs/superpowers/specs/2026-05-18-n-port-edgartools-dropin.md
+  - spike: docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md
+  - plan: docs/superpowers/plans/2026-05-18-n-port-edgartools-dropin-plan.md
+
+Focus on:
+- Wrapper try/except scope (does any path bypass the catch list?).
+- _PARSER_VERSION_NPORT bump propagation through manifest adapter
+  (direct import at app/services/manifest_parsers/sec_n_port.py:60-68
+  + 7 call-sites).
+- Manifest adapter holds a direct-imported parser reference; verify no
+  service-side monkeypatch accidentally relies on patching the adapter
+  too.
+- Test refactor coverage: do the monkeypatched tests still exercise
+  every assertion the original tests exercised?
+- Fixture replacement: does the new missing-series fixture actually
+  clear EdgarTools structural requirements (filerInfo + 9 fundInfo
+  decimals + othMon1/2/3 + GeneralInfo non-Optional text fields)?
+- Helper cleanup: are the removed helpers truly unused?
+- PR body field coverage: Closes #932 / What / Why / Security model /
+  Test plan / ETL DoD clauses #8-#12 framing / golden fixture
+  accession + anchor values / rollback path.
+Reply terse."
+```
+
+Fix anything real before pushing.
+
+**Acceptance:** Codex CLEAN OR all findings addressed.
+
+### T10 — Push + PR
+
+**Goal:** open PR with self-contained body per CLAUDE.md PR discipline.
+
+**Steps:**
+
+1. `git add -A` then `git status` to confirm staged set matches §0 scope.
+2. Commit:
+
+   ```text
+   feat(#932): adopt EdgarTools as N-PORT FundReport parser drop-in
+
+   Wraps app/services/n_port_ingest.py::parse_n_port_payload around
+   edgar.funds.reports.FundReport.parse_fund_xml (lazy-imported, same
+   pattern as #925's 13F-HR drop-in). Preserves the NPortFiling /
+   NPortHolding public dataclass surface so the manifest-adapter +
+   ingester bodies stay unchanged.
+
+   ...
+   Closes #932.
+
+   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+   ```
+
+3. `git push -u origin fix/932-nport-edgartools-spike`.
+4. `gh pr create` with body covering:
+   - **Closes #932** (auto-close trigger word; CI enforced per `feedback_pr_auto_close_required.md`).
+   - **What changed**: wrapper, fixture replace (named accession + anchor values from T1-RESULTS), missing-series fixture rewrite, parser-version bump (`nport-v1` → `nport-v2-edgartools`), skill + memory update.
+   - **Why**: per #932 issue body + spike findings.
+   - **No schema migration**: parser-only scope; `ownership_funds_*` tables untouched.
+   - **Security model**: no new HTTP path; rate-limit pool preserved (`SecFilingsProvider._http`); raw-payload persistence ordering at `_ingest_single_accession:786-798` unchanged; EdgarTools `parse_fund_xml` is pure-string-in / dict-out.
+   - **Manifest adapter propagation**: `app/services/manifest_parsers/sec_n_port.py` direct-imports `_PARSER_VERSION_NPORT` (line 61) + `parse_n_port_payload`; the version bump auto-propagates to 7 call-sites (lines 87 / 111 / 155 / 166 / 205 / 403 / 410). No adapter changes needed.
+   - **Test plan**: `pytest tests/test_n_port_ingest.py tests/test_manifest_parser_sec_n_port.py` + golden replay test pins T1 anchor values.
+   - **ETL DoD clauses #8-#12 framing**: smoke N/A (no operator-visible figure surfaces N-PORT in v1; rollup deferred to #919); cross-source = independent raw XML spot-check (true cross-source N/A until #919); backfill = operator follow-up via `POST /jobs/sec_rebuild/run` body `{"source": "sec_n_port"}` post-merge.
+   - **Rollback / backfill / rewash path**: revert via `git revert <merge SHA>` is safe (parser-version constant goes back to `nport-v1`, manifest worker re-drains via the same mismatch detection). Operator-side rewash post-merge is a single endpoint call (no schema rollback needed).
+   - **Golden fixture anchor values**: T1-RESULTS table reproduced verbatim from plan (accession + filed date + count + top holding + total).
+
+**Acceptance:** PR opened; Claude bot review fires.
+
+### T11 — Bot review resolution
+
+**Goal:** drive to APPROVE on latest commit + CI green.
+
+**Steps:**
+
+1. Poll `gh pr view <N> --comments` + `gh pr checks <N>`.
+2. Triage each finding into FIXED / DEFERRED / REBUTTED per CLAUDE.md.
+3. Fix in-scope per `feedback_fix_in_scope_default.md`. No new tech-debt tickets per plan §1 autonomy contract.
+4. Re-push; restart poll loop.
+5. On rebuttal-only round: Codex checkpoint #3 before merge.
+
+**Acceptance:** APPROVE on most recent commit + CI green.
+
+### T12 — Merge + handover
+
+**Goal:** close the loop.
+
+**Steps:**
+
+1. Squash + merge.
+2. Delete local + remote branch.
+3. Update `docs/superpowers/plans/2026-05-17-us-etl-completion.md` Phase 5 close-out handover.
+4. Update `/Users/lukebradford/.claude/projects/-Users-lukebradford-Dev-eBull/memory/MEMORY.md` if a new project memory file is needed (probably just an update to the existing US source coverage entry).
+
+**Acceptance:** branch deleted; plan doc updated; main reflects the merge SHA.
+
+## 2. Risk register
+
+| Risk | Mitigation |
+|---|---|
+| T1 fetch fails for `S000002277` (e.g. CIK 36405 retired the series, or no recent NPORT-P) | Fall back to any other `S0000xxxxx` series under CIK 36405 (Vanguard Index Funds). **All T4 / T5 / T10 assertions are derived from T1-RESULTS verbatim** — if a fallback series is used, every `S000002277` literal in those tasks is rewritten to the actual chosen series_id (e.g. `parsed.series_id == "<actual_series_id>"`). T1-RESULTS is the single source of truth; no test or PR-body literal should hardcode `S000002277` independent of T1-RESULTS. The risk-mitigation does NOT relax to a "starts with S000" pattern — exact-equality lock is preserved against whatever series T1 selected. |
+| Real-fixture has missing `<valUSD>` cells | Wrapper's `pydantic.ValidationError` catch routes to `NPortParseError` → accession-level tombstone. If observed during T1 probe, retry with a different accession (newer = less likely to have placeholder cells). |
+| T4 §3 malformed-XML test surprises (recover-mode parser silently passes) | Spec §5.1 explicitly anticipates; impl pivots to a different malformed input that still fails. |
+| Pyright complains about `Any`-typed FundReport return | Module-level helpers annotated as `Any`; pyright accepts. If a specific call-site complains, narrow with `# type: ignore[<rule>]` at that site only. |
+| Manifest test's row-count assertion is too tight | Spec §5.7 allows tolerance — assert ≥ 1 landed row, not exact count. |
+| `_make_filter_path_filing` helper carries an unintended invariant violation (e.g. CUSIP not length 9) | Per-test assertion fails loudly; helper is in same file as the test, fix-in-scope. |
+| Bot flags missing operator-visible figure (ETL DoD #11) | PR body explicitly records N/A status — rollup is #919 deferred. REBUTTED with §"#919 deferred" reasoning. |
+| Bot flags the parser-version bump as un-tested in legacy path | T4 §6 adds the explicit parser-version assertion in `test_ingest_drops_non_equity_short_unresolved`. |
+| Manifest adapter direct-imports `parse_n_port_payload` into its own namespace; service-side `monkeypatch.setattr("app.services.n_port_ingest.parse_n_port_payload", ...)` does NOT affect the adapter | Manifest tests use the real parser (T5 keeps real-fixture path). T4 §6 guardrail rule documents this. Future contributor adding manifest-side monkeypatch must target `app.services.manifest_parsers.sec_n_port.parse_n_port_payload`. |
+| T1 fixture selection misses prefixed XML (`<nport:seriesId>...`) | T1 step 1 uses `FundReport.parse_fund_xml(primary)` parse-then-check (NOT string search) — EdgarTools strips namespaces internally so prefixed payloads parse cleanly. |
+
+## 3. Out of scope (explicit)
+
+- Schema migrations.
+- Ingester body changes (`_ingest_single_accession`, write-side guards).
+- Rollup endpoint (#919).
+- N-CSR / Form 3/4/5 / 13D-G EdgarTools drop-ins.
+- New tech-debt tickets per plan §1 autonomy contract.
+- Probing FundReport against non-Vanguard / amendment / oddball fund families (impl risk-accepts the Vanguard-equity-index shape; future regressions surface as accession-level tombstones with operator-visible counts).
+
+## 4. References
+
+- Spec: `docs/superpowers/specs/2026-05-18-n-port-edgartools-dropin.md`.
+- Spike: `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md`.
+- Issue: `gh issue view 932`.
+- Parent plan: `docs/superpowers/plans/2026-05-17-us-etl-completion.md` §2 Phase 5 PR 10.
+- Sibling PR #931: `gh pr view 931` (13F-HR drop-in, merged 2026-05-05, commit `0428dbf`).

--- a/docs/superpowers/specs/2026-05-18-n-port-edgartools-dropin.md
+++ b/docs/superpowers/specs/2026-05-18-n-port-edgartools-dropin.md
@@ -1,0 +1,454 @@
+# #932 — N-PORT EdgarTools `FundReport` parser drop-in (spec)
+
+> Status: DRAFT 2026-05-18.
+>
+> Issue: #932.
+> Plan: `docs/superpowers/plans/2026-05-17-us-etl-completion.md` §2 Phase 5 PR 10.
+> Spike: `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md` (CLEAN through Codex 1a r3 — verdict FEASIBLE for the probed Vanguard-equity-index NPORT-P shape).
+> Architectural predecessor: PR #931 (#925 13F-HR parser drop-in — merged 2026-05-05, commit `0428dbf`) — same lazy-import + wrapper + golden-replay shape. PR #1203 was the spike-only closeout for #925 administrative state; not architecturally relevant here.
+
+## 1. Goal
+
+Replace the stdlib-`xml.etree.ElementTree` body of `app/services/n_port_ingest.py::parse_n_port_payload` with a thin wrapper over `edgar.funds.reports.FundReport.parse_fund_xml`. Preserve the public `NPortFiling` / `NPortHolding` dataclass surface. Preserve every #917 Codex pre-impl invariant. Bump the parser-version constant to trigger manifest-worker rewash. Replace the hand-trimmed fixture with a real Vanguard 500 Index Fund (series `S000002277`) NPORT-P primary doc.
+
+Scope is **parser-only** per #932 issue body. Manifest-adapter restructure is out of scope.
+
+## 2. Settled-decisions preservation
+
+Per the spike doc §2:
+
+| Decision | Status |
+|---|---|
+| §"Fundamentals provider posture" (#532) — free regulated source only | PRESERVED. EdgarTools is a parsing library, not a data source. |
+| §"Provider design rule" — providers thin, DB lookups in services | PRESERVED. Parser body change inside the existing service layer. |
+| §"Filing event storage" — raw-payload persistence per #1168 | PRESERVED. `_ingest_single_accession` fetches → `raw_filings.store_raw` → `conn.commit()` → `parse_n_port_payload(...)`. No call ordering change. |
+| §"Source priority for fund metadata (#1171)" — `ORDER BY period_end DESC, filed_at DESC, source_accession DESC` | PRESERVED. `filed_at` parser-side returns `None` so the ingester's submissions-index fallback fires; tie-breaks unchanged. |
+
+Prevention-log entries (per spike §2): rate-limit pool (PRESERVED — wrapper does not fetch), raw-payload persistence (PRESERVED — no ordering change), Pydantic validation cliff (mitigated via wrapper `try/except` + tombstone), EdgarTools internal-path stability (mitigated via tight pin + golden replay).
+
+## 3. Implementation contract
+
+### 3.1 Wrapper body — `app/services/n_port_ingest.py::parse_n_port_payload`
+
+Replaces the existing ~80 LoC of XML walking. The body is exactly what the spike doc §6 outlined; final approved form:
+
+```python
+def parse_n_port_payload(xml: str) -> NPortFiling:
+    """Parse an NPORT-P primary doc XML into an NPortFiling.
+
+    Wraps edgartools' edgar.funds.reports.FundReport.parse_fund_xml (#932,
+    superseding the stdlib-ET parser from #917). The wrapper:
+
+    * Lazy-imports edgartools at first call so module import remains
+      side-effect-free (#925 pattern; mirrors sec_13f.py:76-80).
+    * Catches every EdgarTools parser failure class (AttributeError,
+      InvalidOperation, ValueError, TypeError, pydantic.ValidationError)
+      and converts to NPortParseError so _ingest_single_accession's
+      tombstone path at n_port_ingest.py:820-836 fires.
+    * Preserves the six #917 Codex pre-impl invariants verbatim
+      (period_end / series_id / cik mandatory; filed_at None passed to
+      the ingester for submissions-index fallback; units passthrough;
+      balance None drop).
+    * Preserves the regCik → header issuer_credentials.cik fallback
+      chain from the prior parser (n_port_ingest.py:384 pre-#932).
+
+    Note on EdgarTools field naming: ``general_info.fiscal_year_end``
+    confusingly stores ``repPdEnd`` text (the period_end), NOT the fund's
+    actual fiscal-year-end. See spike doc §4.4. The golden replay test
+    locks this mapping against pin bumps.
+
+    Pure XML-in / dataclass-out. No network calls, no DB access.
+    Raises NPortParseError on malformed XML or any parser failure
+    listed above; raises NPortMissingSeriesError if the filing has no
+    seriesId (refuses to synthesise identity per Codex review #2).
+    """
+    fund_report = _edgar_fund_report()
+    pydantic_validation_error = _pydantic_validation_error()
+    # Catch scope covers BOTH the EdgarTools parser call AND the
+    # post-parse normalisation. Any KeyError (dict-shape drift on pin
+    # bump), AttributeError (missing typed object attribute), or
+    # int/Decimal coercion ValueError that fires during normalisation
+    # must also surface as NPortParseError so _ingest_single_accession's
+    # tombstone path at n_port_ingest.py:820-836 fires; otherwise the
+    # filer-batch driver at ingest_fund_n_port catches with `Exception`
+    # at a coarser layer and the per-accession tombstone is lost.
+    # NPortMissingSeriesError is re-raised explicitly so its dedicated
+    # tombstone path (different from the generic NPortParseError path)
+    # fires.
+    try:
+        parsed = fund_report.parse_fund_xml(xml)
+
+        general_info = parsed["general_info"]
+        cik_text = (general_info.cik or "").strip() or _header_issuer_cik(parsed.get("header"))
+        series_id_raw = (general_info.series_id or "").strip()
+        period_end_text = (general_info.fiscal_year_end or "").strip() or None  # carries repPdEnd
+        series_name = (general_info.series_name or "").strip()
+
+        if not cik_text:
+            raise NPortParseError("NPORT-P: missing regCik / header cik")
+        if not series_id_raw:
+            raise NPortMissingSeriesError(
+                "NPORT-P: missing seriesId in genInfo header; refusing to "
+                "synthesise an identity. Filing tombstoned for operator review."
+            )
+        if not period_end_text:
+            raise NPortParseError("NPORT-P: missing repPdEnd in genInfo header")
+        period_end = _safe_iso_date(period_end_text)
+        if period_end is None:
+            raise NPortParseError(f"NPORT-P: malformed repPdEnd={period_end_text!r}")
+
+        # EdgarTools' parse_fund_xml does NOT surface a header-level
+        # filedAt field. Returning None here triggers the ingester's
+        # documented fallback to the submissions-index filingDate at
+        # _ingest_single_accession (#917 Codex pre-push review #1).
+        # Never default to period_end midnight inside the parser.
+        filed_at: datetime | None = None
+
+        holdings: list[NPortHolding] = []
+        for investment in parsed["investments"]:
+            balance = investment.balance
+            if balance is None:
+                # No balance = unparseable holding; parser-level drop.
+                continue
+            # Strip + upper categorical fields. The downstream
+            # ingester guards (units != "NS", payoff_profile != "Long",
+            # asset_category != "EC") are exact-equality so a stray
+            # leading/trailing whitespace from a future EdgarTools
+            # whitespace-preservation change would mis-drop valid rows.
+            # CUSIP is also case-normalised to upper (mirrors the
+            # pre-#932 stdlib parser's `.strip().upper()` contract).
+            holdings.append(
+                NPortHolding(
+                    cusip=(investment.cusip or "").strip().upper(),
+                    issuer_name=(investment.name or "").strip(),
+                    shares=balance,
+                    value_usd=investment.value_usd,
+                    payoff_profile=(investment.payoff_profile or "").strip(),
+                    asset_category=(investment.asset_category or "").strip(),
+                    issuer_category=(investment.issuer_category or "").strip(),
+                    units=(investment.units or "").strip(),
+                )
+            )
+
+        return NPortFiling(
+            filer_cik=_zero_pad_cik(cik_text),
+            series_id=series_id_raw,
+            series_name=series_name,
+            period_end=period_end,
+            filed_at=filed_at,
+            holdings=tuple(holdings),
+        )
+    except NPortMissingSeriesError:
+        # Distinct from generic NPortParseError tombstone path.
+        raise
+    except NPortParseError:
+        # Already-classified parser error; preserve verbatim.
+        raise
+    except (AttributeError, KeyError, InvalidOperation, ValueError, TypeError, pydantic_validation_error) as exc:
+        raise NPortParseError(f"NPORT-P EdgarTools parse failed: {exc}") from exc
+
+
+def _edgar_fund_report() -> Any:
+    """Lazy import: defer EdgarTools' filesystem-cache mkdir
+    (`~/.edgar/_tcache`) until first parse call. Mirrors the lazy
+    factory at app/providers/implementations/sec_13f.py:76-80."""
+    from edgar.funds.reports import FundReport
+    return FundReport
+
+
+def _pydantic_validation_error() -> type[Exception]:
+    """Lazy import: pydantic comes in via edgartools but we hold our
+    own reference to its ValidationError type for the wrapper's catch
+    list. Lazy to keep module import side-effect-free."""
+    from pydantic import ValidationError
+    return ValidationError
+
+
+def _header_issuer_cik(header: Any) -> str | None:
+    """Best-effort dereference of parsed['header'].filer_info.
+    issuer_credentials.cik. None if any intermediate is None or missing.
+
+    Mirrors the regCik → header cik fallback that the pre-#932 stdlib
+    parser performed via _find_text(root, local_name='cik') at
+    n_port_ingest.py:384."""
+    if header is None:
+        return None
+    try:
+        cik = header.filer_info.issuer_credentials.cik
+    except AttributeError:
+        return None
+    if not cik:
+        return None
+    return cik.strip() or None
+```
+
+### 3.2 What changes in the module
+
+- **Removed**: `_stripns`, `_find_text`, `_children_by_local_name`, `_decimal_or_none` helpers (lines ~327-355). Verified via grep no other caller. The module's `import xml.etree.ElementTree as ET` import + the `# noqa: S405` comment can also be removed once `ET.ParseError` is no longer referenced.
+- **Added**: `_edgar_fund_report`, `_pydantic_validation_error`, `_header_issuer_cik` factories.
+- **Modified**: `parse_n_port_payload` body (the only behaviour change). Public dataclasses + custom exceptions unchanged.
+- **Bumped**: `_PARSER_VERSION_NPORT = "nport-v1"` → `"nport-v2-edgartools"`. This triggers manifest-worker rewash via parser-version mismatch detection (#869) AND the legacy `raw_filings.store_raw(parser_version=...)` path at `n_port_ingest.py:786-793` propagates the new tag forward.
+
+### 3.3 Existing module shape preserved
+
+- `_NPORT_FORM_TYPES` frozenset.
+- `AccessionRef` / `NPortHolding` / `NPortFiling` / `IngestSummary` / `_AccessionOutcome` / `_MutableSummary` dataclasses.
+- `NPortParseError` / `NPortMissingSeriesError` exceptions.
+- `SecArchiveFetcher` Protocol.
+- `_zero_pad_cik` / `_accession_no_dashes` / `_submissions_url` / `_archive_file_url` URL helpers.
+- `parse_submissions_index` walker + `_safe_iso_date` / `_safe_iso_datetime` helpers.
+- `_existing_accessions_for_fund_filer` / `_record_ingest_attempt` / `_resolve_cusip_to_instrument_id` DB helpers.
+- `ingest_fund_n_port` / `ingest_all_fund_filers` / `_ingest_single_accession` / `iter_fund_observations` public + driver functions.
+
+## 4. Fixture changes
+
+### 4.1 Replace `tests/fixtures/sec/nport_p_test_fund.xml`
+
+The current 4.3KB synthetic file is deleted. Replaced with a real **Vanguard 500 Index Fund (series `S000002277`)** NPORT-P primary doc, fetched via the shared `SecFilingsProvider` rate-limit pool. The selection rule:
+
+1. Iterate `parse_submissions_index(SecFilingsProvider.fetch_document_text(_submissions_url("0000036405")))`.
+2. Pick the most recent `NPORT-P` accession whose `general_info.series_id == "S000002277"` (verified via a one-off probe parse).
+3. Save the primary_doc.xml as `tests/fixtures/sec/nport_p_test_fund.xml`.
+
+Expected size ~200-350KB (per the §5 spike probe of sibling Vanguard funds: 191KB / 317KB).
+
+### 4.2 Update `tests/fixtures/sec/nport_p_missing_series.xml`
+
+The current 686-byte file lacks the structural blocks EdgarTools' parser dereferences unconditionally; the missing-series test would crash on a generic `NPortParseError` before reaching the dedicated `NPortMissingSeriesError` path.
+
+**Required structural blocks** (empirically verified against `edgartools==5.30.2` at `edgar/funds/reports.py:1241-1348`):
+
+| Path | What EdgarTools does | Mandatory in fixture |
+|---|---|---|
+| `<headerData>` | `header_el = root.find("headerData")` | YES |
+| `<headerData><filerInfo>` | `filer_info_tag = header_el.find("filerInfo")` (NEXT line dereferences `.find(".//issuerCredentials")` so cannot be None) | YES |
+| `<filerInfo>...<issuerCredentials>` | `.find(".//issuerCredentials")` — `IssuerCredentials(cik=str, ccc=str)`. Both fields are non-Optional Pydantic `str`; the tag must include `<cik>` + `<ccc>` text children (empty strings are accepted, missing children raise `ValidationError` mid-parse). | YES (descendant; nest under `<filer>` for canonical shape) |
+| `<filerInfo>...<seriesClassInfo>` | `.find(".//seriesClassInfo")` — `SeriesClassInfo.from_xml(None)` handles None (returns `None`) | OPTIONAL |
+| `<formData>` | `form_data_tag = root.find("formData")` | YES |
+| `<formData><genInfo>` | `general_info_tag = form_data_tag.find("genInfo")` | YES |
+| `<genInfo>` Pydantic-required text fields | `GeneralInfo` model (`edgar/funds/reports.py:126-145`) declares `name: str`, `cik: str`, `file_number: str`, `street1: str` as non-Optional. EdgarTools' `_text()` returns `None` for self-closing or absent tags; that None then fails Pydantic `str` validation. **Tags must be present AND carry non-empty text content** (`<regName>X</regName>`, not `<regName/>`). | YES — `<regName>`, `<regCik>`, `<regFileNumber>`, `<regStreet1>` all present with non-empty text |
+| `<formData><fundInfo>` | `fund_info_tag = form_data_tag.find("fundInfo")` (NEXT line dereferences `.find("curMetrics")`) | YES |
+| `<fundInfo>` 9 Decimal-required fields | `Decimal(_text(fund_info_tag, "<name>"))` raises `InvalidOperation` if None. Required fields: `totAssets`, `totLiabs`, `netAssets`, `assetsAttrMiscSec`, `assetsInvested`, `amtPayOneYrBanksBorr`, `amtPayOneYrCtrldComp`, `amtPayOneYrOthAffil`, `amtPayOneYrOther` | YES — each as `<name>0</name>` is sufficient |
+| `<fundInfo><returnInfo>` | `return_info_tag = fund_info_tag.find("returnInfo")` (NEXT line `.find("monthlyTotReturns")`) | YES |
+| `<returnInfo><monthlyTotReturns>` | `monthlyTotReturns.findall("monthlyTotReturn")` — empty list is OK | YES (empty self-closing tag is sufficient) |
+| `<returnInfo><othMon1/2/3>` | `RealizedChange.from_xml(tag)` returns `None` when tag is None, then `ReturnInfo(other_mon1=RealizedChange, ...)` (non-Optional at `reports.py:232-236`) raises `pydantic.ValidationError` mid-parse. Empty self-closing tag → `from_xml(tag)` returns a `RealizedChange` instance (with `decimal_or_na` defaulting on missing attrs). | YES (each as `<othMon1/>` self-closing) |
+| `<fundInfo><mon1Flow / mon2Flow / mon3Flow>` | `MonthlyFlow.from_xml(tag)` returns None when tag is None | OPTIONAL |
+| `<formData><invstOrSecs>` | `investment_or_secs_tag = form_data_tag.find("invstOrSecs")` — `if not None:` iterates; empty self-closing tag is OK | OPTIONAL (recommended self-closing) |
+
+The missing-series fixture **must** carry every YES row above with `<seriesId>` deliberately omitted under `<genInfo>` to exercise the `NPortMissingSeriesError` path. Expected file size grows from 686 bytes to ~1.5KB.
+
+Concrete minimal shape (each numeric field as `0`; language hint `xml`):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+  <headerData>
+    <submissionType>NPORT-P</submissionType>
+    <filerInfo>
+      <filer>
+        <issuerCredentials>
+          <cik>0000036405</cik>
+          <ccc>XXXXXXXX</ccc>
+        </issuerCredentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <genInfo>
+      <regName>Vanguard Index Funds</regName>
+      <regCik>0000036405</regCik>
+      <regFileNumber>811-02652</regFileNumber>
+      <regStreet1>PO Box 2600</regStreet1>
+      <seriesName>Mystery Fund No Series Id</seriesName>
+      <repPdEnd>2025-12-31</repPdEnd>
+    </genInfo>
+    <fundInfo>
+      <totAssets>0</totAssets>
+      <totLiabs>0</totLiabs>
+      <netAssets>0</netAssets>
+      <assetsAttrMiscSec>0</assetsAttrMiscSec>
+      <assetsInvested>0</assetsInvested>
+      <amtPayOneYrBanksBorr>0</amtPayOneYrBanksBorr>
+      <amtPayOneYrCtrldComp>0</amtPayOneYrCtrldComp>
+      <amtPayOneYrOthAffil>0</amtPayOneYrOthAffil>
+      <amtPayOneYrOther>0</amtPayOneYrOther>
+      <returnInfo>
+        <monthlyTotReturns/>
+        <othMon1/>
+        <othMon2/>
+        <othMon3/>
+      </returnInfo>
+    </fundInfo>
+    <invstOrSecs/>
+  </formData>
+</edgarSubmission>
+```
+
+Impl PR's responsibility: verify this fixture clears EdgarTools structurally + still raises `NPortMissingSeriesError` (not generic `NPortParseError`) via the `test_raises_missing_series_id` test.
+
+### 4.3 No additional fixtures
+
+The ingester filter-path tests (non-equity drop, short drop, unresolved-CUSIP drop, PA-units drop, zero-shares drop) refactor to construct `NPortFiling` / `NPortHolding` instances directly in Python and monkeypatch `n_port_ingest.parse_n_port_payload` at the call-site. The parser is tested separately against the real Vanguard fixture; the ingester filter logic is tested without involving XML at all. Justified by:
+
+- Cleanly separates parser-correctness tests from ingester-filter tests.
+- Eliminates the maintenance burden of a hand-rolled synthetic NPORT-P matching EdgarTools' structural requirements.
+- Test intent becomes obvious — the construct-`NPortFiling`-with-7-rows pattern says "this test exercises ingester filtering" without the reader scrolling through 100 lines of XML.
+
+## 5. Test changes
+
+### 5.1 `tests/test_n_port_ingest.py::TestParseNPortPayload`
+
+- **`test_extracts_header_and_holdings`** — REWRITE. Assert against the new real Vanguard 500 fixture. Expected assertions:
+  - `parsed.filer_cik == "0000036405"`
+  - `parsed.series_id == "S000002277"`
+  - `parsed.series_name` starts with `"Vanguard 500 Index Fund"` (case-insensitive — the SEC payload uses `"Vanguard 500 Index Fund"` or `"VANGUARD 500 INDEX FUND"`; the test should be tolerant).
+  - `parsed.period_end == date(2025, 12, 31)` (or whatever the chosen fixture's `repPdEnd` is — locked at fixture-fetch time).
+  - `parsed.filed_at is None` (per the wrapper's documented contract — filed_at is layered in by the ingester from submissions-index).
+  - `len(parsed.holdings) >= 400` (Vanguard 500 has ~500 stocks; the actual count is locked at fixture-fetch time).
+  - First-row assertions: top holding by `value_usd` is one of the AAPL / MSFT / NVDA / GOOGL / AMZN cohort with a 9-digit CUSIP + `units == "NS"` + `payoff_profile == "Long"` + `asset_category == "EC"`.
+
+- **`test_raises_missing_series_id`** — KEEP. Uses the updated `nport_p_missing_series.xml` (§4.2). Asserts `NPortMissingSeriesError` raised.
+
+- **`test_raises_on_malformed_xml`** — KEEP. Uses inline `"<not><well><formed>"`. Need to confirm EdgarTools' `etree.fromstring` (with `recover=True` fallback at `reports.py:1228-1230`) does not silently succeed — verify at impl time. If it does, change the malformed input to something that the recover-mode parser still rejects (e.g., trailing-garbage-after-root or a missing `</edgarSubmission>`).
+
+- **`test_runs_offline_no_network`** — KEEP semantics. Asserts no `urllib.request.urlopen` / `httpx.get` / `httpx.Client.request` call during parse. Point at the new fixture path. EdgarTools' `parse_fund_xml` is documented as pure-XML-in / dict-out; the test guards against future regressions where a refactor introduces an HTTP call inside the lazy-import path.
+
+- **`test_golden_replay_first_row_count_total`** — NEW. Golden-file replay: locks the most-valuable-by-`value_usd` holding's `cusip` + `shares` + `value_usd` AND the total `sum(value_usd)` AND the holdings count to exact values. This is the pin-bump regression guard. If EdgarTools renames a field or changes the Decimal coercion in a future minor bump, this test fails loudly.
+
+### 5.2 `tests/test_n_port_ingest.py::TestParseSubmissionsIndex`
+
+UNCHANGED. Submissions-index walker is independent of the parser.
+
+### 5.3 `tests/test_n_port_ingest.py::TestRecordFundObservation`
+
+UNCHANGED. DB writer tests use `record_fund_observation` directly.
+
+### 5.4 `tests/test_n_port_ingest.py::TestIngestFundNPort`
+
+**Three of the four tests REFACTOR; one remains integration.** Each test currently feeds the synthetic `nport_p_test_fund.xml` through `ingest_fund_n_port`, then asserts on the row-distribution outcome. After §4.3:
+
+- **`test_ingest_drops_non_equity_short_unresolved`** — REFACTOR. Monkeypatched parser returns 7 holdings: AAPL (Long EC NS) + MSFT (Long EC NS) + ACME-DBT + SHRT-X (Short EC NS) + ZZZZ (Long EC NS unresolved CUSIP) + CVBND (Long EC PA) + ZRO (Long EC NS zero-shares). Assertions identical to current: `holdings_inserted == 2`, drop counters, `partial` status, AAPL row landing, sec_fund_series upsert, raw payload row. The raw-payload-row assertion additionally checks `parser_version == "nport-v2-edgartools"` (parser-version-bump regression guard — §7).
+- **`test_idempotent_reingest`** — REFACTOR. Monkeypatched parser returns ANY valid 7-row `NPortFiling`. Assertion: second invocation's `_FakeFetcher.fetch_log` does NOT contain the primary_doc URL.
+- **`test_amendment_uses_submissions_filed_at_when_header_missing`** — REFACTOR. Monkeypatched parser returns two different `NPortFiling`s (one per accession) with `filed_at=None` for both. Submissions-index filingDate `2026-03-15` vs `2026-02-26` drives the tie-break. Amendment wins; AAPL shares = `Decimal("1234567")`.
+- **`test_missing_series_id_tombstones_failed`** — STAYS as integration test. Uses `nport_p_missing_series.xml` (real path: fixture XML → real EdgarTools parser → `NPortMissingSeriesError`). This is the only end-to-end test that proves the wrapper's `NPortMissingSeriesError` actually propagates through the tombstone path against a real EdgarTools parse. Do NOT stub it.
+
+For the three patched tests, the monkeypatch target is `app.services.n_port_ingest.parse_n_port_payload` (called inside `_ingest_single_accession` at line 801). The patch is per-test scoped — applied via `monkeypatch.setattr(...)` inside each test function so other tests in the same module see the real parser.
+
+### 5.5 `tests/test_n_port_ingest.py::TestFundsSchema` / `TestIngestAllStatusPrecedence` / `TestManifestFormCodes`
+
+UNCHANGED. Schema-level + runner-level tests are parser-independent.
+
+### 5.7 `tests/test_manifest_parser_sec_n_port.py`
+
+The manifest-worker adapter at `app/services/manifest_parsers/sec_n_port.py` calls `parse_n_port_payload` through the same code path the legacy ingester uses, and the test file at `tests/test_manifest_parser_sec_n_port.py:39-40` reads both fixtures at module-import time. Touchpoints after §4 + §7:
+
+- `_FAKE_NPORT_XML = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(...)` — points at the new real Vanguard 500 fixture. The happy-path test's row-count + AAPL/MSFT specific assertions will need updating to match the real-fixture distribution (the real fixture has ~500 Long-EC-NS rows; the test seeds CUSIP mappings for AAPL + MSFT — for the impl PR's spike-fetched accession, decide whether to seed additional cohorts or assert against the top-N).
+- `_FAKE_NPORT_MISSING_SERIES_XML = (_FIXTURE_DIR / "nport_p_missing_series.xml").read_text(...)` — points at the updated missing-series fixture (§4.2). Behaviour unchanged: missing-series → `NPortMissingSeriesError` → audit log `failed`.
+- **Parser-version assertion (NEW)**: every happy-path manifest test that asserts on `filing_raw_documents` rows MUST additionally assert `parser_version == "nport-v2-edgartools"`. Pin-bump regression guard parallel to §5.4.
+- **Adapter wiring (UNCHANGED)**: `register_all_parsers` registration test stays identical; the adapter file at `app/services/manifest_parsers/sec_n_port.py` imports `_PARSER_VERSION_NPORT` via the `from app.services.n_port_ingest import _PARSER_VERSION_NPORT` symbol (line 61), so the bump auto-propagates to the adapter's 7 call-sites (lines 87, 111, 155, 166, 205, 403, 410).
+
+### 5.8 Test helper — `_make_filter_path_filing`
+
+Add a module-level helper in `tests/test_n_port_ingest.py` that constructs a 7-row `NPortFiling` with the canonical filter-path distribution, parameterised by `series_id` / `period_end` / `aapl_balance`:
+
+```python
+def _make_filter_path_filing(
+    *,
+    filer_cik: str = "0000036405",
+    series_id: str = "S000002277",
+    series_name: str = "Vanguard 500 Index Fund (TEST)",
+    period_end: date = date(2025, 12, 31),
+    filed_at: datetime | None = None,
+    aapl_balance: Decimal = Decimal("1000000"),
+) -> NPortFiling:
+    ...
+```
+
+Used by the three patched tests in §5.4.
+
+## 6. Skill + memory updates (in-scope)
+
+Per the spike doc §8.1.
+
+### 6.1 `.claude/skills/data-sources/edgartools.md`
+
+§G3 "N-PORT Pydantic validation cliff" — REWRITE. The current text is wrong on the location of the cliff. Replace with:
+
+```
+### G3 — N-PORT structural + Pydantic cliffs
+
+`FundReport.parse_fund_xml(xml)` returns a `Dict[str, Any]` with keys
+`header / general_info / fund_info / investments`. Two failure modes:
+
+1. **Structural cliff (observed on synthetic fixtures)**: the parser
+   unconditionally dereferences `<filerInfo>` + `<fundInfo>` +
+   `<returnInfo>` + `<monthlyTotReturns>` blocks. Missing any block →
+   `AttributeError: 'NoneType' object has no attribute 'find'`. Hand-
+   trimmed fixtures must include all four blocks.
+2. **Internal Pydantic cliff (latent on real-world payloads)**:
+   `InvestmentOrSecurity.value_usd: Decimal` is non-Optional at
+   `edgar/funds/reports.py:346`. An NPORT-P row that omits `<valUSD>`
+   raises `pydantic.ValidationError` mid-iteration, aborting the
+   whole-accession parse. Unobserved on the Vanguard probe sample
+   (#932 spike §5) but theoretically possible.
+
+**Rule of thumb**: if a form's module imports `from pydantic import
+BaseModel`, expect a validation cliff for synthetic fixtures AND for
+real-world payloads with missing required Decimal cells. Wrap the
+parser call AND the post-parse dict-key dereferences in `try/except
+(AttributeError, KeyError, decimal.InvalidOperation, ValueError,
+TypeError, pydantic.ValidationError)` and convert to a parser-specific
+error type so accession-level tombstones fire. `KeyError` defends
+against dict-shape drift on pin bump.
+
+Pinned at edgartools 5.30.2 by `pyproject.toml:21` (#925). See
+`docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md`
+for the full empirical analysis.
+```
+
+### 6.2 `feedback_pydantic_validation_cliff.md` memory
+
+UPDATE — add a section noting the #932 case where the OBSERVED failure was structural (synthetic fixture) but a SEPARATE internal Pydantic cliff remains theoretically possible per the InvestmentOrSecurity.value_usd Decimal non-Optional constraint. Mitigation pattern: wrap parser in try/except + convert to accession-level tombstone.
+
+## 7. Parser-version bump + operator follow-up
+
+`_PARSER_VERSION_NPORT = "nport-v2-edgartools"`. Affects:
+
+- **Manifest worker** rewash path (#869) — `filing_raw_documents.parser_version != _PARSER_VERSION_NPORT` rows are reset to `pending` and re-drained on the next manifest tick.
+- **Legacy `raw_filings.store_raw`** path at `n_port_ingest.py:786-793` — the legacy ingest path stamps the new version on every fresh write.
+
+**Operator follow-up (post-merge)**:
+
+1. Trigger `POST /jobs/sec_rebuild/run` with `{"source": "sec_n_port"}` to reset manifest rows + redrain. Estimated payload count: ~200-1000 N-PORT accessions across the active fund-filer universe; at 10 req/s shared SEC budget the rewash drains in ~20-100 seconds.
+2. Confirm `n_port_ingest_log` rows shift from old-version-tombstone (if any) to fresh `success` / `partial` per the new parser.
+3. Spot-check one operator-visible figure — but per ETL DoD §"Operator runbook" the only operator-visible N-PORT figure in v1 is the rollup endpoint deferred to #919, so no smoke-panel-visible figure changes hands. Document this explicitly in PR body.
+
+## 8. ETL DoD clauses #8-#12
+
+| Clause | Status |
+|---|---|
+| **#8 (smoke against 3-5 instruments)** | N/A in operator-visible sense — N-PORT does not surface to the standard AAPL/GME/MSFT/JPM/HD smoke panel in v1 (the rollup endpoint is deferred to #919). PR body records this. |
+| **#9 (cross-source verify)** | **Independent raw XML spot-check** against the live SEC NPORT-P at `www.sec.gov/Archives/edgar/data/...` (not a true cross-source verification — that requires #919's rollup + an external source like Morningstar / SEC EDGAR Fund Browser — both deferred). PR body records this framing explicitly. True cross-source verification is N/A until #919 lands. |
+| **#10 (backfill executed)** | Operator follow-up §7 records the `POST /jobs/sec_rebuild/run` invocation post-merge. |
+| **#11 (operator-visible figure verified)** | N/A — no rollup endpoint surfaces N-PORT in v1; deferred to #919. PR body records this. |
+| **#12 (PR description records verification + commit SHA for #8-#11)** | PR body satisfies via explicit annotations of N/A status + the §7 operator-trigger plan. |
+
+## 9. Smoke + cross-source verification
+
+The PR's "operator-visible figure" surface is currently empty (rollup endpoint deferred to #919). The PR body MUST therefore record:
+
+- **What was exercised**: the canonical Vanguard 500 fixture's first-row + count + total `value_usd` golden replay (`test_golden_replay_first_row_count_total`).
+- **What was NOT exercised**: rollup-endpoint smoke, operator-side panel verification — both deferred to #919.
+- **Independent raw XML spot-check** (NOT true cross-source — mirrors §8 framing): one holding's `value_usd` from the live SEC EDGAR `www.sec.gov/Archives` raw NPORT-P primary doc, asserted equal to the parser's Decimal output. True cross-source verification against an independent source (Morningstar / SEC EDGAR Fund Browser) is N/A until #919's rollup endpoint lands.
+
+## 10. Open questions
+
+None. The spike doc resolved every open question. The spec is ready for Codex 1a review.
+
+## 11. References
+
+- Issue: `gh issue view 932`.
+- Spike: `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md`.
+- Sibling PR #931: `gh pr view 931` (#925 13F-HR parser drop-in, merged 2026-05-05, commit `0428dbf`).
+- Settled decisions cited: §"Fundamentals provider posture", §"Provider design rule", §"Filing event storage", §"Source priority for fund metadata (#1171)".
+- Prevention log cited: rate-limit pool sharing (510-513), raw-payload persistence (#1168), Pydantic validation cliff (`feedback_pydantic_validation_cliff.md`), EdgarTools internal-path stability (`.claude/skills/data-sources/edgartools.md` §G13).

--- a/docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md
+++ b/docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md
@@ -1,0 +1,484 @@
+# N-PORT EdgarTools `FundReport` drop-in feasibility spike
+
+> Status: **COMPLETED 2026-05-18** — findings + verdict gathered; recommendation locked.
+>
+> Issue: #932 (OPEN at spike time).
+> Plan context: `docs/superpowers/plans/2026-05-17-us-etl-completion.md` §2 Phase 5 PR 10.
+> Predecessor spike: `docs/superpowers/spikes/2026-05-18-13f-hr-edgartools-feasibility.md` (#925 — DONE-AS-FRAMED-PRE-DATED).
+> Predecessor session pre-finding: empirical probe revealed `FundReport.parse_fund_xml` crashes on the synthetic fixture at `tests/fixtures/sec/nport_p_test_fund.xml`. This spike disambiguates parser-coverage cliff vs Pydantic validation cliff against a real-SEC-NPORT-P payload.
+
+## 1. Context recap
+
+Plan §2 Phase 5 PR 10 framed #932 as: **"Same shape as PR 9. Memory `[[edgartools]]` documents the Pydantic validation cliff. Pre-impl spike against existing N-PORT golden fixtures."**
+
+Two empirical facts force the spike to disambiguate two distinct cliffs against a real SEC payload:
+
+1. **Documented Pydantic cliff** at `.claude/skills/data-sources/edgartools.md` §G3: "`FundReport(**parse_fund_xml(xml))` raises `pydantic.ValidationError` on synthetic fixtures missing required fields (`<regCik>`, `<regStreet1>`). Required fields are non-`Optional`. Punted #932." The skill recommended path C (direct lxml ~150 LoC) if revisited.
+
+2. **Pre-finding from PR #1203 / #925 closeout session** (recorded in handover): `FundReport.parse_fund_xml` crashes with `AttributeError: 'NoneType' object has no attribute 'find'` on the synthetic fixture at `tests/fixtures/sec/nport_p_test_fund.xml`. This is a **structural-element cliff**, not a Pydantic validation cliff — the parser unconditionally dereferences `header_el.find("filerInfo")` then walks deeper for `issuerCredentials`, and the synthetic fixture has no `<filerInfo>` block.
+
+The spike's job: **fetch a real Vanguard NPORT-P primary doc via the shared `SecFilingsProvider` rate-limit pool, probe `FundReport.parse_fund_xml` against it, and determine whether either cliff is binding for production NPORT-P payloads.**
+
+The companion spike for PR 9 (#925, 13F-HR EdgarTools drop-in) is at `docs/superpowers/spikes/2026-05-18-13f-hr-edgartools-feasibility.md`. The 13F-HR verdict was DONE-AS-FRAMED-PRE-DATED (PR #931 shipped 2026-05-05). #932 follows the same SPIKE-FIRST shape but is genuinely OPEN at the parser-replacement layer.
+
+## 2. Settled-decisions check
+
+| Decision | Relevance | Preservation |
+|---|---|---|
+| §"Fundamentals provider posture" (#532) — free regulated-source only | EdgarTools is a parsing library, not a paid data source. | PRESERVED. |
+| §"Provider design rule" — providers thin, DB lookups in services | The wrapper sits in `app/services/n_port_ingest.py::parse_n_port_payload`, replacing the body but preserving the service-layer placement. Public `NPortFiling` / `NPortHolding` dataclass surface is unchanged. | PRESERVED. |
+| §"Filing event storage" — raw-payload persistence per #1168 | The N-PORT ingester already stores raw `primary_doc.xml` via `raw_filings.store_raw` BEFORE parse at `app/services/n_port_ingest.py:786-798`. The wrapper does not change the fetch / store sequence; it only swaps the parse step. | PRESERVED — unchanged. |
+| §"Source priority for fund metadata (#1171)" | Per `(instrument_id, period_end)` winner via `ORDER BY period_end DESC, filed_at DESC, source_accession DESC`. The wrapper preserves the `period_end` + `filed_at` invariants from #917 verbatim (period_end mandatory; filed_at falls back to submissions-index `filingDate`, never silently to `period_end` midnight). | PRESERVED. |
+
+Prevention log entries (binding):
+
+| Entry | File:line | How it gates this spike |
+|---|---|---|
+| "Multiple `ResilientClient` instances sharing a rate limit must share throttle state" | `docs/review-prevention-log.md:510-513` + local SEC invariant at `app/providers/implementations/sec_edgar.py:54-80, 237-253` | The wrapper does NOT introduce any HTTP fetch — `FundReport.parse_fund_xml(xml)` is a pure-string-in / dict-out function. The N-PORT ingester continues to fetch primary docs via `SecFilingsProvider.fetch_document_text` (10 r/s shared via `_PROCESS_RATE_LIMIT_CLOCK`). EdgarTools' `HTTP_MGR` is never invoked. **PRESERVED.** |
+| "Raw API payload must be persisted before any parse / normalise step" (#1168) | `docs/review-prevention-log.md` (the #1168 entry) | `parse_n_port_payload` is called by `_ingest_single_accession` AFTER `raw_filings.store_raw` + `conn.commit()` at `app/services/n_port_ingest.py:786-798`. Wrapper does not change call ordering. **PRESERVED.** |
+| "Pydantic validation cliff — spike fixture compatibility BEFORE drop-in" | `feedback_pydantic_validation_cliff.md` | This is the rule the spike honours. Outcome: the cliff is structural (missing `<filerInfo>` / `<fundInfo>` blocks in synthetic fixtures), not Pydantic-validation, but the discipline is the same — probe real-world fixtures BEFORE committing. |
+| "EdgarTools internal module path is the only stability contract" | `.claude/skills/data-sources/edgartools.md` §G13 | `edgar.funds.reports.FundReport.parse_fund_xml` is an internal-looking path under the funds namespace. Mitigation: pin tight (already `edgartools==5.30.2` exact), golden-file replay, audit on every minor bump. The 13F-HR spike (`docs/superpowers/spikes/2026-05-18-13f-hr-edgartools-feasibility.md` §2 + §11) already documents this mitigation pattern for 13F-HR static parsers under `edgar.thirteenf.parsers`. |
+| "Skills must own integrity, not inventory" | `feedback_skills_must_own_integrity.md` | The skill's §G3 statement about a "Pydantic validation cliff" is empirically wrong for `edgartools==5.30.2`: `parse_fund_xml` returns a `Dict[str, Any]` (not a Pydantic-constructed `FundReport`), and the crash on synthetic fixtures is structural (`AttributeError`), not Pydantic-validation. The skill needs updating in-scope with this spike's findings. |
+
+## 3. Empirical state of #932
+
+### 3.1 Issue body (verbatim scope)
+
+`gh issue view 932 --json title,body,state` returns the following scope:
+
+- Lazy-import `edgar.funds.reports` inside `parse_n_port_payload` to keep module import side-effect-free (#925 pattern).
+- Wrap `FundReport.parse_fund_xml(xml)` output into existing `NPortFiling` / `NPortHolding` dataclasses.
+- Preserve Codex-validated invariants from #917:
+  - `period_end` mandatory (NPortParseError if missing)
+  - `series_id` mandatory (NPortMissingSeriesError if missing — refuses to synthesise identity)
+  - `cik` mandatory
+  - `filed_at` must NOT default to `period_end` midnight inside the parser (the ingester layers in submissions-index `filingDate`)
+  - `units` passthrough (downstream guard rejects non-NS even on EC)
+  - `balance` None → drop row
+- Replace hand-trimmed fixture at `tests/fixtures/sec/nport_p_test_fund.xml` with a real Vanguard 500 NPORT-P fixture; lock first-row + holdings count + total value via golden-file replay.
+
+Out of scope per the issue body:
+
+- Schema changes to `ownership_funds_*` tables.
+- Ingester body changes (write-side guards, tombstone, log).
+- Operator-visible rollup integration (deferred to #919).
+
+### 3.2 Current parser shape
+
+`app/services/n_port_ingest.py::parse_n_port_payload` (lines 358-454) — pure XML-in / dataclass-out, walks namespace-stripped local names via `_stripns()` + `_find_text()` + `_children_by_local_name()`. ~100 LoC of stdlib `xml.etree.ElementTree` walking + `Decimal` coercion. No network, no DB. Codex pre-impl review #1-#6 invariants enforced inline.
+
+### 3.3 Existing synthetic fixture
+
+`tests/fixtures/sec/nport_p_test_fund.xml` (4.3KB, 7 holdings) — modelled on a real Vanguard 500 Index Fund NPORT-P payload but **simplified flat shape** with:
+
+- `<edgarSubmission>` root + `<headerData><submissionType>NPORT-P</submissionType></headerData>` only — **no `<filerInfo>` block, no `<issuerCredentials>`, no `<seriesClassInfo>`**.
+- `<formData><genInfo>` carrying just `regCik / seriesId / seriesName / repPdEnd / filedAt`.
+- **No `<fundInfo>` block** — neither `totAssets` nor `netAssets` nor `curMetrics` nor `returnInfo`.
+- `<formData><invstOrSecs><invstOrSec>` × 7 with the 7 contract-exercising rows enumerated in the fixture XML comment.
+
+The fixture documents itself as designed for the stdlib local-name walker:
+
+> Real-world NPORT-P uses the `http://www.sec.gov/edgar/nport` namespace and an XBRL container. This fixture uses a simplified flat shape that the lxml-direct parser (which walks by local-name) accepts identically.
+
+The simplified shape is the root cause of the EdgarTools parser-coverage cliff in §4.1 below.
+
+## 4. EdgarTools API surface analysis
+
+### 4.1 What EdgarTools 5.30.2 exposes for N-PORT
+
+Probed via `uv run python` against the pinned `edgartools==5.30.2`:
+
+```
+from edgar.funds.reports import FundReport
+print(FundReport.parse_fund_xml.__func__.__code__.co_firstlineno)  # -> 1213
+```
+
+`parse_fund_xml` is a classmethod **returning a `Dict[str, Any]`** (signature at `.venv/lib/python3.14/site-packages/edgar/funds/reports.py:1214`):
+
+```python
+@classmethod
+def parse_fund_xml(cls, xml: Union[str, Any]) -> Dict[str, Any]:
+    ...
+    return {'header': header,
+            'general_info': general_info,
+            'fund_info': fund_info,
+            'investments': investments_or_securities}
+```
+
+The four keys hold typed objects, NOT raw nested dicts:
+
+- `header: Header` — `submission_type`, `is_confidential`, `filer_info` (`issuer_credentials` + `series_class_info`).
+- `general_info: GeneralInfo` — `name, cik, file_number, reg_lei, street1, …, series_name, series_id, series_lei, fiscal_year_end, rep_period_date, is_final_filing`.
+- `fund_info: FundInfo` — `total_assets, total_liabilities, net_assets, assets_invested, current_metrics, return_info, monthly_flow1/2/3, …`.
+- `investments: List[InvestmentOrSecurity]` — per-row `name, lei, title, cusip, identifiers, balance, units, value_usd, pct_value, payoff_profile, asset_category, issuer_category, investment_country, debt_security, security_lending, derivative_info, …`.
+
+**The skill's §G3 statement "`FundReport(**parse_fund_xml(xml))` raises pydantic.ValidationError" is empirically wrong at `edgartools==5.30.2`.** `parse_fund_xml` constructs `FundReport`-internal-typed objects already and returns them in a dict; there is no separate Pydantic-constructor step that the wrapper needs to invoke. The skill needs updating in-scope with this spike's findings.
+
+### 4.2 Required-block dereferences (the actual cliff)
+
+Inspection of `parse_fund_xml` body at `edgar/funds/reports.py:1213-1410`:
+
+| Line | Dereference | Required structural element |
+|---|---|---|
+| 1241 | `header_el = root.find("headerData")` | `<headerData>` root child |
+| 1242 | `filer_info_tag = header_el.find("filerInfo")` | `<headerData><filerInfo>` |
+| 1244 | `issuer_credentials_tag = filer_info_tag.find(".//issuerCredentials")` | `<filerInfo><filer><issuerCredentials>` |
+| 1245 | `series_class_info_tag = filer_info_tag.find(".//seriesClassInfo")` | `<filerInfo><filer><seriesClassInfo>` |
+| 1259 | `form_data_tag = root.find("formData")` | `<formData>` root child |
+| 1262 | `general_info_tag = form_data_tag.find("genInfo")` | `<formData><genInfo>` |
+| 1306 | `fund_info_tag = form_data_tag.find("fundInfo")` | `<formData><fundInfo>` |
+| 1325 | `return_info_tag = fund_info_tag.find("returnInfo")` | `<fundInfo><returnInfo>` |
+| 1326 | `monthly_returns_tag = return_info_tag.find("monthlyTotReturns")` | `<returnInfo><monthlyTotReturns>` |
+| 1334-1348 | `Decimal(_text(fund_info_tag, "totAssets" / "totLiabs" / "netAssets" / …))` | `<fundInfo>` must carry the 7 required Decimal fields |
+
+A missing block at any of those lines raises `AttributeError: 'NoneType' object has no attribute …`. The synthetic fixture has no `<filerInfo>` so the crash fires at line 1244.
+
+**Empirical scope of the "real NPORT-P always carries these blocks" claim:** The §5 probe sampled two Vanguard equity index funds (Value + Mid-Cap Value, both period 2025-12-31). The XSD requirements at 17 CFR §270.30b1-9 mandate §A general-info + §B fund-info + §C investments as required-by-rule, but the SEC EDGAR XSD itself includes optional sub-elements within those sections (e.g. `returnInfo / monthlyTotReturns / monthly_flow1/2/3` may be omitted for funds that have not yet operated a full quarter; `curMetrics` may be empty for funds without interest-rate-sensitive holdings). The verdict therefore is **feasible for the probed real NPORT-P shape; impl must golden-test against the canonical Vanguard 500 fixture AND retain the parse-failure tombstone path (`_AccessionOutcome(status='failed')` at `n_port_ingest.py:820-836`) so edge-shape funds that crash `parse_fund_xml` tombstone cleanly rather than aborting the filer batch.** The wrapper's `try/except` catch (§6) is the load-bearing mitigation for unprobed structural shapes; it is not "defensive programming for impossible states."
+
+### 4.2.1 Pydantic cliff inside `parse_fund_xml` — separate from the structural cliff
+
+Although `parse_fund_xml` returns a dict (not a Pydantic-constructed `FundReport`), the function constructs Pydantic `BaseModel` instances internally for each `<invstOrSec>` row at `reports.py:1376-1399`:
+
+```python
+investments_or_security = InvestmentOrSecurity(
+    name=_text(investment_tag, "name"),
+    ...
+    value_usd=_opt_decimal(investment_tag, "valUSD"),
+    ...
+)
+```
+
+`InvestmentOrSecurity.value_usd: Decimal` is declared **non-Optional** at `edgar/funds/reports.py:346`. `_opt_decimal` returns `Decimal | None`. If a real NPORT-P row omits `<valUSD>` (e.g. a legally-empty mid-quarter row, or a confidential-pricing carve-out), `_opt_decimal` returns `None` and Pydantic raises `pydantic.ValidationError` mid-iteration — **aborting the entire dict construction**, so even well-formed surrounding holdings are lost.
+
+The current eBull stdlib parser at `app/services/n_port_ingest.py:439` uses `_decimal_or_none(value_text)` and assigns `value_usd: Decimal | None` to `NPortHolding`; downstream the ingester treats `value_usd=None` as "write the row with NULL market_value_usd". So a real NPORT-P with a single missing `<valUSD>` cell:
+
+- Current parser: writes all rows; the one with missing valUSD lands with `NULL` market_value_usd.
+- EdgarTools wrapper: raises `NPortParseError`; **the whole accession tombstones to `status='failed'` and ZERO rows are written.**
+
+This is a behavioural regression risk the impl PR MUST surface. Mitigations (impl-phase decision):
+
+- **Catch + tombstone (current §6 wrapper)**: behaviour matches "missing valUSD = malformed filing"; loses well-formed rows in the same accession. Operator-visible tombstone counter goes up.
+- **Catch + fall back to current stdlib parser**: keeps row-level resilience but couples the wrapper to the parser it's replacing. Complexity not worth it for a per-row edge case.
+- **Pre-validate XML for missing `<valUSD>` before EdgarTools dispatch**: ad-hoc; defeats the simplification.
+
+The §5 probe did NOT exercise this Pydantic cliff (both Vanguard fixtures had `valUSD` populated for every row). Frequency of missing-`<valUSD>` is unknown until the impl PR runs a broader probe across non-Vanguard fund families. Spec-phase MUST decide which mitigation lands, document the trade-off, and golden-test the chosen behaviour.
+
+### 4.3 What `parse_fund_xml` does that we don't need
+
+- `header.is_confidential` — eBull doesn't track confidential filings (we only ingest the public quarterly NPORT-P slice; monthly NPORT-MFP is confidential and out of scope per `n_port_ingest.py:6-11`).
+- `general_info.street1 / city / zip_or_postal_code / phone / state / country` — operator address fields; we don't use.
+- `fund_info.current_metrics / return_info / monthly_flow1/2/3` — interest-rate sensitivity + monthly returns + monthly cash flows; out of scope for ownership v1.
+- `investment.debt_security / security_lending / derivative_info` — out of scope (we drop non-equity-common via the asset-category guard before any of these matter).
+
+The wrapper consumes only the fields we already use: `general_info.{cik, series_id, series_name, fiscal_year_end}` (the last carrying `repPdEnd` text per the issue's documented risk) + `general_info.rep_period_date` (carrying `repPdDate`) + per-holding `{name, cusip, balance, units, value_usd, payoff_profile, asset_category, issuer_category}`.
+
+### 4.4 `general_info.fiscal_year_end` field-name trap
+
+Issue body §"Risks" calls this out:
+
+> EdgarTools' `general_info.fiscal_year_end` confusingly stores `repPdEnd` text (not actual fiscal-year-end). Wrapper documents the mapping; golden-file replay locks behaviour against pin bumps.
+
+Confirmed at `edgar/funds/reports.py:1300`:
+
+```python
+fiscal_year_end=_text(general_info_tag, "repPdEnd"),
+rep_period_date=_text(general_info_tag, "repPdDate"),
+```
+
+The wrapper maps `general_info.fiscal_year_end` → `NPortFiling.period_end` (after `date.fromisoformat`) and documents the EdgarTools mis-naming so a future pin bump that renames the attribute (e.g. to `report_period_end`) surfaces as a failing golden replay rather than a silent semantic drift.
+
+The same mapping also handles the empirical observation that `general_info.rep_period_date` carries `repPdDate` (the SEC report-period anchor date, typically same-or-adjacent to `repPdEnd`), which is a different field eBull does not consume.
+
+## 5. Empirical probe — real Vanguard NPORT-P
+
+### 5.1 Fetch via shared `SecFilingsProvider` rate-limit pool
+
+Per the prevention-log entry on shared rate-limit state, the fetch uses `SecFilingsProvider.fetch_document_text` (not EdgarTools' `HTTP_MGR`, not direct `httpx`). Probe script (in-repo path required for `app.*` imports; cleaned up post-spike):
+
+```python
+from app.config import settings
+from app.providers.implementations.sec_edgar import SecFilingsProvider
+from app.services.n_port_ingest import _archive_file_url, _submissions_url, parse_submissions_index
+
+with SecFilingsProvider(user_agent=settings.sec_user_agent) as sec:
+    submissions = sec.fetch_document_text(_submissions_url("0000036405"))  # Vanguard Index Funds
+    refs = parse_submissions_index(submissions)
+    for ref in refs[:2]:
+        primary = sec.fetch_document_text(
+            _archive_file_url("0000036405", ref.accession_number, "primary_doc.xml")
+        )
+        # ... probe FundReport.parse_fund_xml(primary)
+```
+
+Two real NPORT-P primary docs fetched (period_end 2025-12-31, filed 2026-02-26):
+
+| Accession | Series | Series name | Size | Holdings |
+|---|---|---|---|---|
+| `0000036405-26-000074` | `S000002840` | Vanguard Value Index Fund | 317,699 bytes | 323 |
+| `0000036405-26-000073` | `S000012757` | Vanguard Mid-Cap Value Index Fund | 191,526 bytes | 186 |
+
+The CIK 36405 registrant (Vanguard Index Funds) holds ~313 NPORT-P accessions in its `recent[]` window (one per fund-series per quarter). The actual canonical "Vanguard 500 Index Fund" series is `S000002277` under this same CIK; impl-phase will iterate `recent[]` to grab a 500-series accession specifically per #932 issue body acceptance #4.
+
+### 5.2 `FundReport.parse_fund_xml` outcome on each fixture
+
+| Fixture | Result | First holding |
+|---|---|---|
+| Synthetic `nport_p_test_fund.xml` (4.3KB) | **CRASH** — `AttributeError: 'NoneType' object has no attribute 'find'` at `reports.py:1244` (missing `<filerInfo>`) | n/a |
+| Vanguard Value Index `0000036405-26-000074.xml` (317KB) | **OK** — dict with 4 keys, `investments` count 323 | `name='United Airlines Holdings Inc' cusip='910047109' balance=Decimal('3015716.00000000') units='NS' value_usd=Decimal('337217363.12000000') payoff='Long' asset_cat='EC' issuer_cat=<set>` |
+| Vanguard Mid-Cap Value `0000036405-26-000073.xml` (191KB) | **OK** — dict with 4 keys, `investments` count 186 | `name='United Airlines Holdings Inc' cusip='910047109' balance=Decimal('1938967.00000000') units='NS' value_usd=Decimal('216815289.94000000') payoff='Long' asset_cat='EC' issuer_cat=<set>` |
+
+Both real fixtures parse cleanly with zero exceptions. All fields required by the wrapper (`name, cusip, balance, units, value_usd, payoff_profile, asset_category, issuer_category`) are populated as expected Python typed objects (`str`, `Decimal`, `str`, …).
+
+### 5.3 What the probe confirms and what it does not
+
+The **observed** crash on the synthetic fixture is structural (missing `<filerInfo>` block) — **not** an externally-visible `FundReport(**dict)` Pydantic validation cliff like the one the skill §G3 documents. The skill §G3 framing is wrong on the location of the cliff (it's internal to `parse_fund_xml`, not on a separate `FundReport(**dict)` step) but the *category* "Pydantic cliff" remains a live possibility per §4.2.1 — `parse_fund_xml` constructs `InvestmentOrSecurity` Pydantic models mid-iteration, and `value_usd: Decimal` is non-Optional. A real NPORT-P with a missing `<valUSD>` cell would raise `pydantic.ValidationError` inside `parse_fund_xml`, causing accession-level tombstone rather than per-row drop.
+
+The §5 probe sampled two Vanguard equity index funds with `<valUSD>` populated for every holding. **The probe therefore confirms feasibility for the observed shape; it does NOT prove feasibility universally.** Broader probes across non-Vanguard families + amendments (NPORT-P/A) + edge-shape funds (newly-incepted, fund-of-funds, money-market) MUST land at impl-spec phase or be explicitly deferred with a tombstone-counter monitoring plan.
+
+Therefore:
+
+- **Path A (real-fixture drop-in)**: FEASIBLE for the probed Vanguard-equity-index shape. The skill's §G3 path-A "use full real-world XML in fixtures (25KB+ each)" is the correct primary fixture — and the real Vanguard fixtures are 191KB / 317KB, well above the 25KB threshold the skill named. The wrapper's try/except (catching `AttributeError`, `decimal.InvalidOperation`, `ValueError`, `TypeError`, `pydantic.ValidationError`) maps every observed-and-anticipated EdgarTools failure mode to `NPortParseError` → accession-level tombstone via `_ingest_single_accession`'s existing `NPortParseError` handler at `n_port_ingest.py:820-836`.
+- **Path B (dict-only workaround)**: REDUNDANT. `parse_fund_xml` already returns a dict. There is no separate `FundReport(**dict)` constructor layer for the wrapper to skip. The skill §G3 path-B framing was incorrect.
+- **Path C (direct lxml ~150 LoC rewrite)**: NOT NEEDED. The existing stdlib parser at `parse_n_port_payload` IS the direct-XML rewrite; the question of this spike is whether replacing it with the EdgarTools wrapper is feasible. It is, via Path A.
+- **REBUTTED (close #932 INFEASIBLE + freeze stdlib parser)**: REJECTED. The observed synthetic crash is structural and is mitigated by switching to a real fixture (already required by issue body §4). The unobserved internal Pydantic cliff is mitigated by the wrapper's `try/except` + tombstone path. Neither blocks the drop-in.
+
+## 6. Wrapper shape — implementation outline
+
+The drop-in replaces only the body of `parse_n_port_payload`:
+
+```python
+def parse_n_port_payload(xml: str) -> NPortFiling:
+    fund_report = _edgar_fund_report()  # lazy-import factory (#925 pattern)
+    # Catch every exception class the EdgarTools parser can raise:
+    #   - AttributeError: missing structural block (e.g. <filerInfo>,
+    #     <fundInfo>, <returnInfo>, <monthlyTotReturns>); the synthetic
+    #     fixture's failure mode, see §4.2.
+    #   - decimal.InvalidOperation: malformed Decimal text in
+    #     <totAssets> / <netAssets> etc. (`Decimal("bogus")` raises
+    #     `InvalidOperation`, which inherits from `ArithmeticError`, NOT
+    #     `ValueError`). reports.py:1334+ uses bare `Decimal(_text(...))`.
+    #   - ValueError: other coercion failures (e.g. `int()` on non-numeric
+    #     text inside the parser).
+    #   - TypeError: edge-case None coercion downstream of an optional
+    #     block dereference.
+    #   - pydantic.ValidationError: missing required Decimal field in an
+    #     <invstOrSec> row (e.g. <valUSD> absent → InvestmentOrSecurity
+    #     constructor rejects non-Optional Decimal); see §4.2.1 for the
+    #     accession-level tombstone semantics.
+    try:
+        parsed = fund_report.parse_fund_xml(xml)
+    except (AttributeError, InvalidOperation, ValueError, TypeError, ValidationError) as exc:
+        raise NPortParseError(f"NPORT-P EdgarTools parse failed: {exc}") from exc
+
+    general_info = parsed["general_info"]
+    # Mirror the current parser's regCik → header cik fallback at
+    # app/services/n_port_ingest.py:384. `parse_fund_xml` exposes the
+    # header issuer-credentials CIK via parsed["header"].filer_info.
+    # issuer_credentials.cik. Prefer general_info.cik (regCik) but fall
+    # back so the wrapper's contract matches the existing one.
+    cik_text = general_info.cik or _header_issuer_cik(parsed["header"])
+    series_id = general_info.series_id
+    period_end_text = general_info.fiscal_year_end  # carries repPdEnd; see §4.4
+    if not cik_text:
+        raise NPortParseError("NPORT-P: missing regCik / header cik in header")
+    if not series_id:
+        raise NPortMissingSeriesError(
+            "NPORT-P: missing seriesId in genInfo header; refusing to "
+            "synthesise an identity."
+        )
+    if not period_end_text:
+        raise NPortParseError("NPORT-P: missing repPdEnd in genInfo header")
+    period_end = _safe_iso_date(period_end_text)
+    if period_end is None:
+        raise NPortParseError(f"NPORT-P: malformed repPdEnd={period_end_text!r}")
+
+    # Codex pre-push review #1 (carried over from #917): do NOT default
+    # filed_at to period_end midnight inside the parser. The ingester
+    # layers in submissions-index filingDate. EdgarTools' parse_fund_xml
+    # does not surface a header-level filedAt field — return None so the
+    # ingester's documented fallback path fires.
+    filed_at = None
+
+    holdings: list[NPortHolding] = []
+    for investment in parsed["investments"]:
+        balance = investment.balance
+        if balance is None:
+            continue  # No balance = unparseable holding; skip
+        holdings.append(
+            NPortHolding(
+                cusip=(investment.cusip or "").strip().upper(),
+                issuer_name=investment.name or "",
+                shares=balance,
+                value_usd=investment.value_usd,
+                payoff_profile=investment.payoff_profile or "",
+                asset_category=investment.asset_category or "",
+                issuer_category=investment.issuer_category or "",
+                units=investment.units or "",
+            )
+        )
+
+    return NPortFiling(
+        filer_cik=_zero_pad_cik(cik_text),
+        series_id=series_id,
+        series_name=general_info.series_name or "",
+        period_end=period_end,
+        filed_at=filed_at,
+        holdings=tuple(holdings),
+    )
+
+
+def _edgar_fund_report() -> Any:
+    """Lazy import per #925 pattern — defer EdgarTools' filesystem-cache
+    mkdir (`~/.edgar/_tcache`) until first parse call. Mirrors the lazy
+    import at `app/providers/implementations/sec_13f.py:76-80`."""
+    from edgar.funds.reports import FundReport
+    return FundReport
+
+
+def _header_issuer_cik(header: Any) -> str | None:
+    """Best-effort dereference of parsed["header"].filer_info.
+    issuer_credentials.cik. None if any intermediate is None."""
+    try:
+        return header.filer_info.issuer_credentials.cik or None
+    except AttributeError:
+        return None
+```
+
+`ValidationError` is `pydantic.ValidationError` — must import inside the wrapper file (lazy alongside `_edgar_fund_report` to keep module import side-effect-free). `InvalidOperation` is `decimal.InvalidOperation` (already in scope at module top — `from decimal import Decimal, InvalidOperation`).
+
+### 6.1 What the wrapper deletes from the current parser
+
+The current `parse_n_port_payload` body (lines 371-454, ~80 LoC of XML-walking):
+
+- `ET.fromstring(xml)` + `ET.ParseError` handling — replaced by EdgarTools' lxml parse.
+- `_stripns` / `_find_text` / `_children_by_local_name` / `_decimal_or_none` helpers — replaced by EdgarTools' typed `InvestmentOrSecurity` attribute access. These helpers stay only if other callers use them (grep verification at impl phase).
+- Per-holding `_find_text(elem, local_name="cusip" / "name" / "balance" / "valUSD" / "payoffProfile" / "assetCat" / "issuerCat" / "units")` loop — replaced by per-holding attribute access.
+- `Decimal(text.strip())` coercion + `InvalidOperation` handling — replaced by EdgarTools' `_opt_decimal` (already returns `Decimal | None` with the same semantics).
+
+### 6.2 What the wrapper preserves
+
+- All six #917 Codex pre-impl invariants (period_end mandatory, series_id mandatory, cik mandatory, filed_at never silently defaulted to period_end midnight, units passthrough, balance None drop).
+- The cik fallback chain `regCik → header issuer_credentials.cik` (mirroring `app/services/n_port_ingest.py:384`).
+- The public `NPortFiling` / `NPortHolding` dataclass surface — ingester body unchanged.
+- The `_NPORT_FORM_TYPES` frozenset (`NPORT-P`, `NPORT-P/A`, `N-PORT`, `N-PORT/A`) — submissions-index walking is separate and not touched.
+- The parser-version constant `_PARSER_VERSION_NPORT`. Bump to `"nport-v2-edgartools"` to trigger re-wash across **both** the manifest-worker rewash path (parser-version mismatch detection at #869) **and** the legacy `raw_filings.store_raw(parser_version=_PARSER_VERSION_NPORT, ...)` path at `app/services/n_port_ingest.py:786-793` — both consumers must observe the new constant for a parser-bump rewash to be complete. Impl PR's PR body documents the operator-side trigger (`POST /jobs/sec_rebuild/run` with `{"source": "sec_n_port"}` or equivalent).
+
+### 6.3 Fixture replacement (issue body acceptance #4)
+
+Replace `tests/fixtures/sec/nport_p_test_fund.xml` with a real Vanguard 500 Index Fund (series `S000002277`) NPORT-P primary doc, fetched via the same `SecFilingsProvider`-routed probe used in §5. Adjust existing tests in `tests/test_n_port_ingest.py` accordingly:
+
+- Replace the per-row drop-counter assertions (which currently rely on the synthetic 7-row fixture's hand-crafted distribution) with golden-file assertions against the real fixture's first-row + holdings count + total value.
+- Keep `tests/fixtures/sec/nport_p_missing_series.xml` as-is — its purpose is to exercise the `NPortMissingSeriesError` tombstone path, which is wrapper-agnostic (we still raise that error explicitly).
+
+The existing fixture's behavioural coverage (non-equity drop, short drop, non-share-units drop, zero-shares drop, no-CUSIP drop) is exercised by the ingester at `_ingest_single_accession` lines 871-903 against parsed holdings — not by the parser. The replacement fixture's natural row distribution will exercise the equity-common-Long-NS happy path; the drop-counter paths get covered by per-test fixtures constructed in code (small `NPortFiling` dataclass instances passed directly to the ingester's helper functions) OR by smaller dedicated synthetic fixtures that exercise only the ingester's filtering logic (which doesn't touch the parser).
+
+## 7. Decision rule per plan §2 Phase 5 PR 10
+
+The plan's decision rule:
+
+> Spike INFEASIBLE → close #932 REBUTTED + freeze stdlib-ElementTree at `app/services/n_port_ingest.py::parse_n_port_payload`; spike OK → drop-in (parser-only scope per #932 issue body — NOT the manifest-adapter restructure variant rejected in PR 9). Three workarounds enumerated at edgartools §G3 if Pydantic constructor is unreachable.
+
+Outcome: **spike OK → DROP-IN.** The three workarounds at §G3 collapse to "Path A" (real fixture), since the observed synthetic-fixture cliff is structural (mitigated by switching to a real fixture) and the internal Pydantic cliff (§4.2.1) is handled by the wrapper's `try/except` → `NPortParseError` → accession-level tombstone semantics. The dict path is already the default `parse_fund_xml` return shape; Path B is redundant; Path C is not needed.
+
+Manifest-adapter restructure framing is NOT applicable to #932 in the first place — #932 is parser-only scope per its issue body. The "rejected variant" in PR 9 was specific to 13F-HR (where the manifest adapter has ~530 lines of orchestration that #925's plan-§2-PR9 entry mistakenly framed as removable). N-PORT's manifest adapter (`app/services/n_port_ingest.py`) is structurally similar; the wrapper PR does NOT touch it.
+
+## 8. Verdict + recommendation
+
+**Path A (drop-in with real fixture) is FEASIBLE for the probed Vanguard-equity-index NPORT-P shape.** Real Vanguard NPORT-P payloads parse cleanly through `FundReport.parse_fund_xml`. The OBSERVED cliff on the synthetic fixture is structural (missing `<filerInfo>` block) and is mitigated by switching to a real-world fixture, which the issue body §4 already requires. A SEPARATE, UNOBSERVED internal Pydantic cliff (§4.2.1) remains theoretically possible if real-world NPORT-P rows omit `<valUSD>` — mitigated by the wrapper's `try/except` catch-all → `NPortParseError` → accession-level tombstone, but the regression-from-current-behaviour trade-off (per-row drop becomes per-accession drop) must be acknowledged in the impl PR.
+
+### 8.1 Recommended impl scope
+
+1. **Wrapper** at `app/services/n_port_ingest.py::parse_n_port_payload` — body replacement per §6.
+2. **Lazy-import factory** `_edgar_fund_report()` mirrors `app/providers/implementations/sec_13f.py:76-80`.
+3. **Parser-version bump** `_PARSER_VERSION_NPORT = "nport-v2-edgartools"` — triggers manifest-worker rewash on next manifest tick via the parser-version mismatch contract at #869.
+4. **Fixture replacement** at `tests/fixtures/sec/nport_p_test_fund.xml` — Vanguard 500 Index Fund (series `S000002277`) real NPORT-P primary doc.
+5. **Golden replay test** at `tests/test_n_port_ingest.py` — assert first-row + holdings count + total `value_usd` sum against the real fixture.
+6. **Test surgery** for the drop-counter tests in `test_n_port_ingest.py` — extract the per-counter cases into in-code `NPortHolding` dataclass instances (which is what those tests should have been using all along, since they exercise the ingester not the parser).
+7. **Helper cleanup** — remove `_stripns`, `_find_text`, `_children_by_local_name`, `_decimal_or_none` if no other caller depends on them (grep-verify at impl phase).
+8. **Skill update** at `.claude/skills/data-sources/edgartools.md` §G3 — correct the Pydantic-validation-cliff framing to "structural-element cliff on synthetic fixtures missing `<filerInfo>` / `<fundInfo>`; mitigation = real-fixture goldens" + cite this spike doc.
+9. **Memory refresh** at `feedback_pydantic_validation_cliff.md` — note the N-PORT case is structural not Pydantic, but the discipline (spike fixture compatibility BEFORE drop-in) is identical.
+
+### 8.2 What is NOT recommended
+
+- **Switching to `Filing.obj()` / `FundReport.from_filing(filing)`** — would trigger SEC fetches via EdgarTools' `HTTP_MGR`, bypassing eBull's shared rate-limit pool (prevention-log:510-513). Same hard rejection as the 13F-HR spike §2.
+- **Removing the `NPortFiling` / `NPortHolding` public dataclass surface in favour of EdgarTools types directly** — would couple the ingester body to EdgarTools' internal type shapes (`GeneralInfo`, `InvestmentOrSecurity`), breaking the wrapper abstraction. The dataclass surface is the seam that lets the impl PR be parser-only.
+- **Extending the wrapper to also consume `fund_info.total_assets / net_assets`** — out of scope per #932 issue body "Out of scope: Schema changes to `ownership_funds_*` tables". Fund-level NAV is a #919 deferred item; the wrapper consumes only the per-holding fields the ingester already uses.
+- **Removing the existing `parse_submissions_index` walker or `_NPORT_FORM_TYPES` frozenset** — those are submissions-index logic, not primary-doc parser logic; out of scope.
+
+### 8.3 Settled-decisions impact
+
+| Decision (§2) | Outcome |
+|---|---|
+| §"Fundamentals provider posture" (#532) | PRESERVED. |
+| §"Provider design rule" | PRESERVED — parser body change only; service-layer placement unchanged. |
+| §"Filing event storage" — raw-payload persistence per #1168 | PRESERVED — fetch/store sequence unchanged. |
+| §"Source priority for fund metadata (#1171)" | PRESERVED — `period_end` + `filed_at` semantics unchanged. |
+
+## 9. Cross-spike note
+
+The 13F-HR spike (`docs/superpowers/spikes/2026-05-18-13f-hr-edgartools-feasibility.md`) at §9 documents:
+
+> #932's scope is structurally narrower than the plan §2 PR 9 alternative framing: replace the stdlib-ElementTree NPORT-P parser at `app/services/n_port_ingest.py::parse_n_port_payload` with a thin wrapper over `edgar.funds.reports.FundReport.parse_fund_xml`, preserving the public `NPortFiling` / `NPortHolding` dataclass surface — mirroring the parser-only scope PR #931 actually shipped for 13F-HR. **#932 does NOT propose adopting `Filing.obj()` for the N-PORT manifest path**, which is the structurally infeasible variant rejected here.
+>
+> The Pydantic validation cliff documented in `[[edgartools]]` memory + #932 applies to N-PORT (`FundReport.parse_fund_xml`), not to 13F-HR. The 13F-HR Berkshire 2024Q3 golden fixture parses cleanly through EdgarTools' static parsers (no Pydantic-constructor crash; §3.3 replay confirms). PR 10's spike must independently verify whether the existing N-PORT fixtures at `tests/fixtures/sec/nport_p_*.xml` clear `FundReport.parse_fund_xml`'s Pydantic constructor; that is a separate empirical question this spike does not address.
+
+This spike answers that cross-reference partially: the existing synthetic fixture does NOT clear `parse_fund_xml`, and the OBSERVED failure mode is structural-element-missing (`<filerInfo>` block absent), not externally-visible Pydantic-validation. Real Vanguard NPORT-P primary docs clear `parse_fund_xml` without exception. A SEPARATE internal Pydantic cliff (§4.2.1) is theoretically possible on real-world filings with missing `<valUSD>` cells but has not been observed in the probed sample. The 13F-HR spike's "separate empirical question" is hereby answered for the Vanguard-equity-index NPORT-P shape; the broader probe-space remains an impl-PR concern.
+
+## 10. Execution constraints + out of scope
+
+- The probe issued 3 SEC HTTP requests (1 submissions JSON + 2 primary docs) at 10 r/s budget. No SEC fair-use violation.
+- No new dependencies introduced. `edgartools==5.30.2` is already pinned at `pyproject.toml:21` (#925).
+- The scratch probe script was created at the repo root for `app.*` import resolution, then deleted post-probe. The two fetched fixtures were moved to `/tmp/` for the spike PR (impl PR re-fetches the canonical Vanguard 500 fixture).
+- ETL clauses #8-#12: NOT APPLICABLE to this spike PR (docs-only). The impl PR (drop-in) MUST satisfy clauses #8-#12 against the smoke panel (AAPL/GME/MSFT/JPM/HD) for any `ownership_funds_*` rollup endpoint that surfaces post-drop-in — although N-PORT ingest itself only touches the fund-side rollup (#919 deferred), so the standard smoke panel may not exercise an operator-visible figure change. Impl PR records this explicitly in §"ETL DoD clauses" of its PR body.
+
+Out of scope:
+
+- Schema changes to `ownership_funds_observations` / `ownership_funds_current` — #932 issue body §"Out of scope".
+- Ingester body changes (`_ingest_single_accession` write-side guards, tombstone, log) — #932 issue body §"Out of scope".
+- Operator-visible rollup integration — deferred to #919.
+- N-CSR drop-in — #918 closed (synth no-op, `docs/superpowers/spikes/2026-05-14-n-csr-feasibility.md` INFEASIBLE-CONFIRMED).
+- Form 3/4/5 / 13D/G EdgarTools drop-ins — not in #932 scope.
+
+## 11. Verification commands (reproducible)
+
+```
+# Reproduce synthetic-fixture cliff (returns AttributeError)
+uv run python -c "
+from edgar.funds.reports import FundReport
+xml = open('tests/fixtures/sec/nport_p_test_fund.xml').read()
+try:
+    FundReport.parse_fund_xml(xml)
+except Exception as e:
+    print(f'CRASH: {type(e).__name__}: {e}')
+"
+
+# Inspect parse_fund_xml surface
+uv run python -c "
+from edgar.funds.reports import FundReport
+import inspect
+print(f'returns Dict[str, Any]: {inspect.signature(FundReport.parse_fund_xml).return_annotation}')
+"
+
+# Fetch real Vanguard NPORT-P via shared rate-limit pool (in-repo, then delete)
+# See §5.1 for the script body. Save to .scratch_nport_probe.py at repo root, run, delete.
+
+# Confirm pin
+grep edgartools pyproject.toml
+```
+
+All four reproduce the empirical state recorded in §3 + §4 + §5.
+
+## 12. Pre-impl checklist for the drop-in PR
+
+- [ ] Branch `fix/932-nport-edgartools-dropin` (off main; spike doc lands first via the current branch `fix/932-nport-edgartools-spike` OR is bundled into the drop-in branch).
+- [ ] Lazy-import factory `_edgar_fund_report()` added; module-level `from edgar...` import absent (proven by grep).
+- [ ] `parse_n_port_payload` body replaced; `NPortFiling` / `NPortHolding` surface unchanged.
+- [ ] `_PARSER_VERSION_NPORT` bumped to `"nport-v2-edgartools"`.
+- [ ] `tests/fixtures/sec/nport_p_test_fund.xml` replaced with real Vanguard 500 (series S000002277) NPORT-P primary doc.
+- [ ] Existing `tests/test_n_port_ingest.py` drop-counter tests rewritten to use in-code `NPortHolding` instances OR small dedicated synthetic fixtures targeted at the ingester filter paths.
+- [ ] Golden replay test added: first-row issuer / cusip / shares / value_usd + holdings count + total holdings value sum.
+- [ ] Skill `.claude/skills/data-sources/edgartools.md` §G3 updated.
+- [ ] Memory `feedback_pydantic_validation_cliff.md` updated.
+- [ ] Codex 1a on spec; Codex 1b on plan; Codex 2 pre-push on diff.
+- [ ] PR body documents the parser-version bump + the operator-side rewash trigger (`POST /jobs/sec_rebuild/run` with `{"source": "sec_n_port"}` or equivalent).
+- [ ] PR body satisfies ETL clauses #8-#12 framing (smoke panel: N-PORT ingest does not change an operator-visible figure in v1 since #919 is deferred; record this explicitly).

--- a/tests/fixtures/sec/nport_p_missing_series.xml
+++ b/tests/fixtures/sec/nport_p_missing_series.xml
@@ -1,21 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Negative-test NPORT-P fixture for #917 — no seriesId.
+    Negative-test NPORT-P fixture for #932 — no seriesId.
 
-    The ingester must tombstone this accession as failed
-    (NPortMissingSeriesError) rather than synthesising a
-    collision-prone fallback identity. Codex pre-impl review #2.
+    Updated 2026-05-18 (#932) to clear EdgarTools' structural
+    requirements while still omitting <seriesId>. The wrapper must
+    tombstone this accession as NPortMissingSeriesError (not generic
+    NPortParseError) per Codex #917 pre-impl review #2.
+
+    Structural requirements verified empirically against edgartools
+    ==5.30.2 (edgar/funds/reports.py:1241-1348):
+      - headerData > filerInfo > filer > issuerCredentials (cik+ccc str)
+      - formData > genInfo with regName / regCik / regFileNumber /
+        regStreet1 non-empty text (Pydantic GeneralInfo non-Optional)
+      - formData > fundInfo with 9 required Decimal fields
+      - fundInfo > returnInfo > monthlyTotReturns (empty OK) + othMon1/2/3
+        (Pydantic ReturnInfo non-Optional RealizedChange)
+      - formData > invstOrSecs (empty OK)
 -->
 <edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
-    <headerData>
-        <submissionType>NPORT-P</submissionType>
-    </headerData>
-    <formData>
-        <genInfo>
-            <regCik>0000036405</regCik>
-            <seriesName>Mystery Fund No Series Id</seriesName>
-            <repPdEnd>2025-12-31</repPdEnd>
-        </genInfo>
-        <invstOrSecs/>
-    </formData>
+  <headerData>
+    <submissionType>NPORT-P</submissionType>
+    <filerInfo>
+      <filer>
+        <issuerCredentials>
+          <cik>0000036405</cik>
+          <ccc>XXXXXXXX</ccc>
+        </issuerCredentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <genInfo>
+      <regName>Vanguard Index Funds</regName>
+      <regCik>0000036405</regCik>
+      <regFileNumber>811-02652</regFileNumber>
+      <regStreet1>PO Box 2600</regStreet1>
+      <seriesName>Mystery Fund No Series Id</seriesName>
+      <repPdEnd>2025-12-31</repPdEnd>
+    </genInfo>
+    <fundInfo>
+      <totAssets>0</totAssets>
+      <totLiabs>0</totLiabs>
+      <netAssets>0</netAssets>
+      <assetsAttrMiscSec>0</assetsAttrMiscSec>
+      <assetsInvested>0</assetsInvested>
+      <amtPayOneYrBanksBorr>0</amtPayOneYrBanksBorr>
+      <amtPayOneYrCtrldComp>0</amtPayOneYrCtrldComp>
+      <amtPayOneYrOthAffil>0</amtPayOneYrOthAffil>
+      <amtPayOneYrOther>0</amtPayOneYrOther>
+      <returnInfo>
+        <monthlyTotReturns/>
+        <othMon1/>
+        <othMon2/>
+        <othMon3/>
+      </returnInfo>
+    </fundInfo>
+    <invstOrSecs/>
+  </formData>
 </edgarSubmission>

--- a/tests/fixtures/sec/nport_p_test_fund.xml
+++ b/tests/fixtures/sec/nport_p_test_fund.xml
@@ -1,109 +1,9296 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Hand-trimmed NPORT-P fixture for #917 testing.
+<?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/nport" xmlns:com="http://www.sec.gov/edgar/common" xmlns:ncom="http://www.sec.gov/edgar/nportcommon" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sec.gov/edgar/nport eis_NPORT_Filer.xsd">
+  <headerData>
+    <submissionType>NPORT-P</submissionType>
+    <isConfidential>false</isConfidential>
+    <filerInfo>
 
-    Synthetic test fund modelled on a real Vanguard 500 Index Fund
-    NPORT-P primary doc (period 2025-12-31). Truncated to 7 holdings
-    that exercise every write-side path:
+      <filer>
+        <issuerCredentials>
+          <cik>0000036405</cik>
+          <ccc>XXXXXXXX</ccc>
+        </issuerCredentials>
+      </filer>
 
-      1. AAPL   — Long equity-common NS, valid CUSIP → write
-      2. MSFT   — Long equity-common NS, valid CUSIP → write
-      3. ACME-D — Long DEBT (assetCat=DBT)            → drop (non-equity)
-      4. SHRT-X — Short equity-common                  → drop (short)
-      5. ZZZZ   — Long equity-common NS, unknown CUSIP → drop (no extids)
-      6. CVBND  — Long equity-common, units=PA (conv bond) → drop (non-share-units)
-      7. ZEROS  — Long equity-common NS, balance=0    → drop (zero-shares)
 
-    Real-world NPORT-P uses the
-    ``http://www.sec.gov/edgar/nport`` namespace and an XBRL container.
-    This fixture uses a simplified flat shape that the lxml-direct
-    parser (which walks by local-name) accepts identically.
--->
-<edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
-    <headerData>
-        <submissionType>NPORT-P</submissionType>
-    </headerData>
-    <formData>
-        <genInfo>
-            <regCik>0000036405</regCik>
-            <seriesId>S000002277</seriesId>
-            <seriesName>Vanguard 500 Index Fund (TEST)</seriesName>
-            <repPdEnd>2025-12-31</repPdEnd>
-            <filedAt>2026-02-26</filedAt>
-        </genInfo>
-        <invstOrSecs>
-            <invstOrSec>
-                <name>APPLE INC</name>
-                <cusip>037833100</cusip>
-                <balance>1000000</balance>
-                <units>NS</units>
-                <valUSD>225000000.00</valUSD>
-                <pctVal>3.45</pctVal>
-                <payoffProfile>Long</payoffProfile>
-                <assetCat>EC</assetCat>
-                <issuerCat>CORP</issuerCat>
-            </invstOrSec>
-            <invstOrSec>
-                <name>MICROSOFT CORP</name>
-                <cusip>594918104</cusip>
-                <balance>500000</balance>
-                <units>NS</units>
-                <valUSD>210000000.00</valUSD>
-                <pctVal>3.21</pctVal>
-                <payoffProfile>Long</payoffProfile>
-                <assetCat>EC</assetCat>
-                <issuerCat>CORP</issuerCat>
-            </invstOrSec>
-            <invstOrSec>
-                <name>ACME CORP NOTE 5%</name>
-                <cusip>000000ACM</cusip>
-                <balance>1000000</balance>
-                <units>PA</units>
-                <valUSD>1010000.00</valUSD>
-                <payoffProfile>Long</payoffProfile>
-                <assetCat>DBT</assetCat>
-                <issuerCat>CORP</issuerCat>
-            </invstOrSec>
-            <invstOrSec>
-                <name>SHORT TARGET INC</name>
-                <cusip>000000SHX</cusip>
-                <balance>50000</balance>
-                <units>NS</units>
-                <valUSD>5000000.00</valUSD>
-                <payoffProfile>Short</payoffProfile>
-                <assetCat>EC</assetCat>
-                <issuerCat>CORP</issuerCat>
-            </invstOrSec>
-            <invstOrSec>
-                <name>UNRESOLVED CO</name>
-                <cusip>000000ZZZ</cusip>
-                <balance>10000</balance>
-                <units>NS</units>
-                <valUSD>123456.00</valUSD>
-                <payoffProfile>Long</payoffProfile>
-                <assetCat>EC</assetCat>
-                <issuerCat>CORP</issuerCat>
-            </invstOrSec>
-            <invstOrSec>
-                <name>CONVERTIBLE BOND CO</name>
-                <cusip>000000CVB</cusip>
-                <balance>5000000</balance>
-                <units>PA</units>
-                <valUSD>5500000.00</valUSD>
-                <payoffProfile>Long</payoffProfile>
-                <assetCat>EC</assetCat>
-                <issuerCat>CORP</issuerCat>
-            </invstOrSec>
-            <invstOrSec>
-                <name>ZERO BALANCE CO</name>
-                <cusip>000000ZRO</cusip>
-                <balance>0</balance>
-                <units>NS</units>
-                <valUSD>0.00</valUSD>
-                <payoffProfile>Long</payoffProfile>
-                <assetCat>EC</assetCat>
-                <issuerCat>CORP</issuerCat>
-            </invstOrSec>
-        </invstOrSecs>
-    </formData>
+      <seriesClassInfo>
+        <seriesId>S000002840</seriesId>
+        <classId>C000007778</classId>
+        <classId>C000007777</classId>
+        <classId>C000007775</classId>
+        <classId>C000007776</classId>
+      </seriesClassInfo>
+
+
+    </filerInfo>
+  </headerData>
+  <formData>
+    <genInfo>
+      <regName>VANGUARD INDEX FUNDS</regName>
+      <regFileNumber>811-02652</regFileNumber>
+      <regCik>0000036405</regCik>
+      <regLei>549300G6KNDK44WUN559</regLei>
+      <regStreet1>100 Vanguard Boulevard</regStreet1>
+      <regCity>Malvern</regCity>
+      <regStateConditional regCountry="US" regState="US-PA"/>
+      <regZipOrPostalCode>19355</regZipOrPostalCode>
+      <regPhone>610-669-1000</regPhone>
+      <seriesName>VANGUARD VALUE INDEX FUND</seriesName>
+      <seriesId>S000002840</seriesId>
+      <seriesLei>HH8Q33B0J5YWPPIGZP55</seriesLei>
+      <repPdEnd>2025-12-31</repPdEnd>
+      <repPdDate>2025-12-31</repPdDate>
+      <isFinalFiling>N</isFinalFiling>
+    </genInfo>
+    <fundInfo>
+      <totAssets>217769774533.52</totAssets>
+      <totLiabs>9017418.05</totLiabs>
+      <netAssets>217760757115.47</netAssets>
+      <assetsAttrMiscSec>0.00000000</assetsAttrMiscSec>
+      <assetsInvested>0.00000000</assetsInvested>
+      <amtPayOneYrBanksBorr>0.00000000</amtPayOneYrBanksBorr>
+      <amtPayOneYrCtrldComp>0.00000000</amtPayOneYrCtrldComp>
+      <amtPayOneYrOthAffil>0.00000000</amtPayOneYrOthAffil>
+      <amtPayOneYrOther>0.00000000</amtPayOneYrOther>
+      <amtPayAftOneYrBanksBorr>0.00000000</amtPayAftOneYrBanksBorr>
+      <amtPayAftOneYrCtrldComp>0.00000000</amtPayAftOneYrCtrldComp>
+      <amtPayAftOneYrOthAffil>0.00000000</amtPayAftOneYrOthAffil>
+      <amtPayAftOneYrOther>0.00000000</amtPayAftOneYrOther>
+      <delayDeliv>0.00000000</delayDeliv>
+      <standByCommit>0.00000000</standByCommit>
+      <liquidPref>0.00000000</liquidPref>
+      <cshNotRptdInCorD>16999450.98000000</cshNotRptdInCorD>
+      <isNonCashCollateral>N</isNonCashCollateral>
+      <returnInfo>
+        <monthlyTotReturns>
+          <monthlyTotReturn classId="C000007778" rtn1="-0.42363792" rtn2="2.57418277" rtn3="0.78851344"/>
+          <monthlyTotReturn classId="C000007777" rtn1="-0.41242782" rtn2="2.56764218" rtn3="0.79805560"/>
+          <monthlyTotReturn classId="C000007775" rtn1="-0.42599972" rtn2="2.56693348" rtn3="0.76837043"/>
+          <monthlyTotReturn classId="C000007776" rtn1="-0.42611683" rtn2="2.56764218" rtn3="0.79584279"/>
+        </monthlyTotReturns>
+        <monthlyReturnCats>
+          <commodityContracts>
+            <mon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <forwardCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </forwardCategory>
+            <futureCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </futureCategory>
+            <optionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </optionCategory>
+            <swaptionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swaptionCategory>
+            <swapCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swapCategory>
+            <warrantCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </warrantCategory>
+            <otherCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </otherCategory>
+          </commodityContracts>
+          <creditContracts>
+            <mon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <forwardCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </forwardCategory>
+            <futureCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </futureCategory>
+            <optionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </optionCategory>
+            <swaptionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swaptionCategory>
+            <swapCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swapCategory>
+            <warrantCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </warrantCategory>
+            <otherCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </otherCategory>
+          </creditContracts>
+          <equityContracts>
+            <mon1 netRealizedGain="94739711.32000000" netUnrealizedAppr="-36988469.32000000"/>
+            <mon2 netRealizedGain="-44624894.66000000" netUnrealizedAppr="41863553.65000000"/>
+            <mon3 netRealizedGain="2133821.69000000" netUnrealizedAppr="-56904932.34000000"/>
+            <forwardCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </forwardCategory>
+            <futureCategory>
+              <instrMon1 netRealizedGain="2145191.32000000" netUnrealizedAppr="323000.18000000"/>
+              <instrMon2 netRealizedGain="533438.96000000" netUnrealizedAppr="-209696.35000000"/>
+              <instrMon3 netRealizedGain="2133821.69000000" netUnrealizedAppr="-3072769.28000000"/>
+            </futureCategory>
+            <optionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </optionCategory>
+            <swaptionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swaptionCategory>
+            <swapCategory>
+              <instrMon1 netRealizedGain="92594520.00000000" netUnrealizedAppr="-37311469.50000000"/>
+              <instrMon2 netRealizedGain="-45158333.62000000" netUnrealizedAppr="42073250.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="-53832163.06000000"/>
+            </swapCategory>
+            <warrantCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </warrantCategory>
+            <otherCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </otherCategory>
+          </equityContracts>
+          <foreignExchgContracts>
+            <mon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <forwardCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </forwardCategory>
+            <futureCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </futureCategory>
+            <optionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </optionCategory>
+            <swaptionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swaptionCategory>
+            <swapCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swapCategory>
+            <warrantCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </warrantCategory>
+            <otherCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </otherCategory>
+          </foreignExchgContracts>
+          <interestRtContracts>
+            <mon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <forwardCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </forwardCategory>
+            <futureCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </futureCategory>
+            <optionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </optionCategory>
+            <swaptionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swaptionCategory>
+            <swapCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swapCategory>
+            <warrantCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </warrantCategory>
+            <otherCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </otherCategory>
+          </interestRtContracts>
+          <otherContracts>
+            <mon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <mon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            <forwardCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </forwardCategory>
+            <futureCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </futureCategory>
+            <optionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </optionCategory>
+            <swaptionCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swaptionCategory>
+            <swapCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </swapCategory>
+            <warrantCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </warrantCategory>
+            <otherCategory>
+              <instrMon1 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon2 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+              <instrMon3 netRealizedGain="0.00000000" netUnrealizedAppr="0.00000000"/>
+            </otherCategory>
+          </otherContracts>
+        </monthlyReturnCats>
+        <othMon1 netRealizedGain="190608678.30000000" netUnrealizedAppr="-1476228326.14000000"/>
+        <othMon2 netRealizedGain="280416205.02000000" netUnrealizedAppr="4754165235.82000000"/>
+        <othMon3 netRealizedGain="446316230.94000000" netUnrealizedAppr="749867768.79000000"/>
+      </returnInfo>
+      <mon1Flow redemption="1191405230.04000000" reinvestment="1978.02000000" sales="2216054647.21002000"/>
+      <mon2Flow redemption="1122148490.46000000" reinvestment="0.00000000" sales="3296446774.09998000"/>
+      <mon3Flow redemption="3281548322.32000000" reinvestment="278617635.59000000" sales="4649612774.28003000"/>
+
+
+    </fundInfo>
+    <invstOrSecs>
+      <invstOrSec>
+        <name>United Airlines Holdings Inc</name>
+        <lei>98450079DA0B78DD6764</lei>
+        <title>UNITED AIRLINES</title>
+        <cusip>910047109</cusip>
+        <identifiers>
+          <isin value="US9100471096"/>
+        </identifiers>
+        <balance>3015716.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>337217363.12000000</valUSD>
+        <pctVal>0.154856810559</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Digital Realty Trust Inc</name>
+        <lei>549300HKCZ31D08NEI41</lei>
+        <title>DIGITAL REALTY</title>
+        <cusip>253868103</cusip>
+        <identifiers>
+          <isin value="US2538681030"/>
+        </identifiers>
+        <balance>3161076.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>489050067.96000000</valUSD>
+        <pctVal>0.224581359120</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>General Motors Co</name>
+        <lei>54930070NSV60J38I987</lei>
+        <title>GENERAL MOTORS C</title>
+        <cusip>37045V100</cusip>
+        <identifiers>
+          <isin value="US37045V1008"/>
+        </identifiers>
+        <balance>8584898.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>698123905.36000000</valUSD>
+        <pctVal>0.320592155633</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>eBay Inc</name>
+        <lei>OML71K8X303XQONU6T67</lei>
+        <title>EBAY INC</title>
+        <cusip>278642103</cusip>
+        <identifiers>
+          <isin value="US2786421030"/>
+        </identifiers>
+        <balance>4159570.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>362298547.00000000</valUSD>
+        <pctVal>0.166374580892</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Duke Energy Corp</name>
+        <lei>I1BZKREC126H0VB1BL91</lei>
+        <title>DUKE ENERGY CORP</title>
+        <cusip>26441C204</cusip>
+        <identifiers>
+          <isin value="US26441C2044"/>
+        </identifiers>
+        <balance>7159644.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>839181873.24000000</valUSD>
+        <pctVal>0.385368734181</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Kenvue Inc</name>
+        <lei>5493008HSF8L4M2LIJ82</lei>
+        <title>KENVUE INC</title>
+        <cusip>49177J102</cusip>
+        <identifiers>
+          <isin value="US49177J1025"/>
+        </identifiers>
+        <balance>17630344.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>304123434.00000000</valUSD>
+        <pctVal>0.139659430849</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Waste Management Inc</name>
+        <lei>549300YX8JIID70NFS41</lei>
+        <title>WASTE MANAGEMENT</title>
+        <cusip>94106L109</cusip>
+        <identifiers>
+          <isin value="US94106L1098"/>
+        </identifiers>
+        <balance>3707390.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>814550656.90000000</valUSD>
+        <pctVal>0.374057597746</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Thermo Fisher Scientific Inc</name>
+        <lei>HCHV7422L5HDJZCRFL38</lei>
+        <title>THERMO FISHER</title>
+        <cusip>883556102</cusip>
+        <identifiers>
+          <isin value="US8835561023"/>
+        </identifiers>
+        <balance>3457523.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2003461702.35000000</valUSD>
+        <pctVal>0.920028810006</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>News Corp</name>
+        <lei>549300ITS31QK8VRBQ14</lei>
+        <title>NEWS CORP-CL A</title>
+        <cusip>65249B109</cusip>
+        <identifiers>
+          <isin value="US65249B1098"/>
+        </identifiers>
+        <balance>2235836.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>58400036.32000000</valUSD>
+        <pctVal>0.026818439232</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>State Street Corp</name>
+        <lei>549300ZFEEJ2IP5VME73</lei>
+        <title>STATE ST CORP</title>
+        <cusip>857477103</cusip>
+        <identifiers>
+          <isin value="US8574771031"/>
+        </identifiers>
+        <balance>2441943.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>315035066.43000000</valUSD>
+        <pctVal>0.144670265939</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Gartner Inc</name>
+        <lei>PP55B5R38BFB8O8HH686</lei>
+        <title>GARTNER INC</title>
+        <cusip>366651107</cusip>
+        <identifiers>
+          <isin value="US3666511072"/>
+        </identifiers>
+        <balance>315087.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>79490148.36000000</valUSD>
+        <pctVal>0.036503431294</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Dow Inc</name>
+        <lei>5493003S21INSLK2IP73</lei>
+        <title>DOW INC</title>
+        <cusip>260557103</cusip>
+        <identifiers>
+          <isin value="US2605571031"/>
+        </identifiers>
+        <balance>3247372.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>75923557.36000000</valUSD>
+        <pctVal>0.034865582929</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>GE HealthCare Technologies Inc</name>
+        <lei>549300OI9J7XOWZMUN85</lei>
+        <title>GE HEALTHCARE TE</title>
+        <cusip>36266G107</cusip>
+        <identifiers>
+          <isin value="US36266G1076"/>
+        </identifiers>
+        <balance>3982373.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>326634233.46000000</valUSD>
+        <pctVal>0.149996830368</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Zimmer Biomet Holdings Inc</name>
+        <lei>2P2YLDVPES3BXQ1FRB91</lei>
+        <title>ZIMMER BIOMET HO</title>
+        <cusip>98956P102</cusip>
+        <identifiers>
+          <isin value="US98956P1021"/>
+        </identifiers>
+        <balance>1823837.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>163999423.04000000</valUSD>
+        <pctVal>0.075311743590</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Phillips 66</name>
+        <lei>5493005JBO5YSIGK1814</lei>
+        <title>PHILLIPS 66</title>
+        <cusip>718546104</cusip>
+        <identifiers>
+          <isin value="US7185461040"/>
+        </identifiers>
+        <balance>3707901.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>478467545.04000000</valUSD>
+        <pctVal>0.219721657555</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Medtronic PLC</name>
+        <lei>549300GX3ZBSQWUXY261</lei>
+        <title>MEDTRONIC PLC</title>
+        <cusip>G5960L103</cusip>
+        <identifiers>
+          <isin value="IE00BTN1Y115"/>
+        </identifiers>
+        <balance>11797987.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1133314631.22000000</valUSD>
+        <pctVal>0.520440251141</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Aon PLC</name>
+        <lei>635400FALWQYX5E6QC64</lei>
+        <title>AON PLC-CLASS A</title>
+        <cusip>G0403H108</cusip>
+        <identifiers>
+          <isin value="IE00BLP1HW54"/>
+        </identifiers>
+        <balance>1879048.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>663078458.24000000</valUSD>
+        <pctVal>0.304498600676</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Procter &amp; Gamble Co/The</name>
+        <lei>2572IBTT8CCZW6AU4141</lei>
+        <title>PROCTER &amp; GAMBLE</title>
+        <cusip>742718109</cusip>
+        <identifiers>
+          <isin value="US7427181091"/>
+        </identifiers>
+        <balance>21504193.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>3081765898.83000000</valUSD>
+        <pctVal>1.415207193275</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Xcel Energy Inc</name>
+        <lei>LGJNMI9GH8XIDG5RCM61</lei>
+        <title>XCEL ENERGY INC</title>
+        <cusip>98389B100</cusip>
+        <identifiers>
+          <isin value="US98389B1008"/>
+        </identifiers>
+        <balance>5443750.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>402075375.00000000</valUSD>
+        <pctVal>0.184640878515</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Nasdaq Inc</name>
+        <lei>549300L8X1Q78ERXFD06</lei>
+        <title>NASDAQ INC</title>
+        <cusip>631103108</cusip>
+        <identifiers>
+          <isin value="US6311031081"/>
+        </identifiers>
+        <balance>4729318.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>459358657.34000000</valUSD>
+        <pctVal>0.210946482472</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>N/A</name>
+        <lei>N/A</lei>
+        <title>TRS:KROGER CO USD 2027-Jan-29</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="CONTRACT_VANGUARD_ID" value="V1048197501"/>
+        </identifiers>
+        <balance>1000000.00000000</balance>
+        <units>NC</units>
+        <curCd>USD</curCd>
+        <valUSD>-180000.00000000</valUSD>
+        <pctVal>-0.00008265952</pctVal>
+        <payoffProfile>N/A</payoffProfile>
+        <assetCat>DE</assetCat>
+        <issuerConditional desc="N/A" issuerCat="OTHER"/>
+        <invCountry>N/A</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>2</fairValLevel>
+        <derivativeInfo>
+          <swapDeriv derivCat="SWP">
+            <counterparties>
+              <counterpartyName>GOLDMAN SACHS INTERNATIONAL</counterpartyName>
+              <counterpartyLei>W22LROWP2IHZNBB6K528</counterpartyLei>
+            </counterparties>
+            <descRefInstrmnt>
+              <otherRefInst>
+                <issuerName>N/A</issuerName>
+                <issueTitle>KROGER CO</issueTitle>
+                <identifiers>
+                  <cusip value="501044101"/>
+                </identifiers>
+              </otherRefInst>
+            </descRefInstrmnt>
+            <swapFlag>Y</swapFlag>
+            <otherRecDesc fixedOrFloating="Other">Receive positive return on reference instrument</otherRecDesc>
+            <floatingPmntDesc curCd="USD" fixedOrFloating="Floating" floatingRtIndex="OBFR01" floatingRtSpread="0.00000000" pmntAmt="0.00000000">
+              <rtResetTenors>
+                <rtResetTenor rateTenor="Day" rateTenorUnit="394" resetDt="Month" resetDtUnit="1"/>
+              </rtResetTenors>
+            </floatingPmntDesc>
+            <terminationDt>2027-01-29</terminationDt>
+            <upfrontPmnt>0.00000000</upfrontPmnt>
+            <pmntCurCd>USD</pmntCurCd>
+            <upfrontRcpt>0.00000000</upfrontRcpt>
+            <rcptCurCd>USD</rcptCurCd>
+            <notionalAmt>62660000.00000000</notionalAmt>
+            <curCd>USD</curCd>
+            <unrealizedAppr>-180000.00000000</unrealizedAppr>
+          </swapDeriv>
+        </derivativeInfo>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Extra Space Storage Inc</name>
+        <lei>N/A</lei>
+        <title>EXTRA SPACE STOR</title>
+        <cusip>30225T102</cusip>
+        <identifiers>
+          <isin value="US30225T1025"/>
+        </identifiers>
+        <balance>1953247.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>254351824.34000000</valUSD>
+        <pctVal>0.116803333947</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>CSX Corp</name>
+        <lei>549300JVQR4N1MMP3Q88</lei>
+        <title>CSX CORP</title>
+        <cusip>126408103</cusip>
+        <identifiers>
+          <isin value="US1264081035"/>
+        </identifiers>
+        <balance>17136673.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>621204396.25000000</valUSD>
+        <pctVal>0.285269212175</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Westinghouse Air Brake Technologies Corp</name>
+        <lei>06BTX5UWZD0GQ5N5Y745</lei>
+        <title>WABTEC CORP</title>
+        <cusip>929740108</cusip>
+        <identifiers>
+          <isin value="US9297401088"/>
+        </identifiers>
+        <balance>1573322.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>335825580.90000000</valUSD>
+        <pctVal>0.154217676935</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Markel Group Inc</name>
+        <lei>549300SCNO12JLWIK605</lei>
+        <title>MARKEL GROUP INC</title>
+        <cusip>570535104</cusip>
+        <identifiers>
+          <isin value="US5705351048"/>
+        </identifiers>
+        <balance>110192.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>236874232.80000000</valUSD>
+        <pctVal>0.108777281975</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Quest Diagnostics Inc</name>
+        <lei>8MCWUBXQ0WE04KMXBX50</lei>
+        <title>QUEST DIAGNOSTIC</title>
+        <cusip>74834L100</cusip>
+        <identifiers>
+          <isin value="US74834L1008"/>
+        </identifiers>
+        <balance>1023671.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>177637628.63000000</valUSD>
+        <pctVal>0.081574674419</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>AT&amp;T Inc</name>
+        <lei>549300Z40J86GGSTL398</lei>
+        <title>AT&amp;T INC</title>
+        <cusip>00206R102</cusip>
+        <identifiers>
+          <isin value="US00206R1023"/>
+        </identifiers>
+        <balance>65242183.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1620615825.72000000</valUSD>
+        <pctVal>0.744218493353</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Alliant Energy Corp</name>
+        <lei>5493009ML300G373MZ12</lei>
+        <title>ALLIANT ENERGY</title>
+        <cusip>018802108</cusip>
+        <identifiers>
+          <isin value="US0188021085"/>
+        </identifiers>
+        <balance>2365657.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>153791361.57000000</valUSD>
+        <pctVal>0.070624002050</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Amgen Inc</name>
+        <lei>62QBXGPJ34PQ72Z12S66</lei>
+        <title>AMGEN INC</title>
+        <cusip>031162100</cusip>
+        <identifiers>
+          <isin value="US0311621009"/>
+        </identifiers>
+        <balance>4955479.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1621977831.49000000</valUSD>
+        <pctVal>0.744843953049</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Brown &amp; Brown Inc</name>
+        <lei>549300PC8KTJ71XKFY89</lei>
+        <title>BROWN &amp; BROWN</title>
+        <cusip>115236101</cusip>
+        <identifiers>
+          <isin value="US1152361010"/>
+        </identifiers>
+        <balance>1335299.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>106423330.30000000</valUSD>
+        <pctVal>0.048871675369</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>International Paper Co</name>
+        <lei>824LMFJDH41EY779Q875</lei>
+        <title>INTL PAPER CO</title>
+        <cusip>460146103</cusip>
+        <identifiers>
+          <isin value="US4601461035"/>
+        </identifiers>
+        <balance>4859382.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>191411056.98000000</valUSD>
+        <pctVal>0.087899702184</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>AbbVie Inc</name>
+        <lei>FR5LCKFTG8054YNNRU85</lei>
+        <title>ABBVIE INC</title>
+        <cusip>00287Y109</cusip>
+        <identifiers>
+          <isin value="US00287Y1091"/>
+        </identifiers>
+        <balance>16264625.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>3716304166.25000000</valUSD>
+        <pctVal>1.706599579959</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>KKR &amp; Co Inc</name>
+        <lei>54930013V5I303TF9571</lei>
+        <title>KKR &amp; CO INC</title>
+        <cusip>48251W104</cusip>
+        <identifiers>
+          <isin value="US48251W1045"/>
+        </identifiers>
+        <balance>6152102.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>784269962.96000000</valUSD>
+        <pctVal>0.360152110668</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Genuine Parts Co</name>
+        <lei>549300D46DQVEU651W04</lei>
+        <title>GENUINE PARTS CO</title>
+        <cusip>372460105</cusip>
+        <identifiers>
+          <isin value="US3724601055"/>
+        </identifiers>
+        <balance>1280196.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>157412900.16000000</valUSD>
+        <pctVal>0.072287083423</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Entergy Corp</name>
+        <lei>4XM3TW50JULSLG8BNC79</lei>
+        <title>ENTERGY CORP</title>
+        <cusip>29364G103</cusip>
+        <identifiers>
+          <isin value="US29364G1031"/>
+        </identifiers>
+        <balance>4109814.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>379870108.02000000</valUSD>
+        <pctVal>0.174443785488</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Evergy Inc</name>
+        <lei>549300PGTHDQY6PSUI61</lei>
+        <title>EVERGY INC</title>
+        <cusip>30034W106</cusip>
+        <identifiers>
+          <isin value="US30034W1062"/>
+        </identifiers>
+        <balance>1057217.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>76637660.33000000</valUSD>
+        <pctVal>0.035193512984</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Analog Devices Inc</name>
+        <lei>GYVOE5EZ4GDAVTU4CQ61</lei>
+        <title>ANALOG DEVICES</title>
+        <cusip>032654105</cusip>
+        <identifiers>
+          <isin value="US0326541051"/>
+        </identifiers>
+        <balance>4506131.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1222062727.20000000</valUSD>
+        <pctVal>0.561195113108</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Huntington Bancshares Inc/OH</name>
+        <lei>549300XTVCVV9I7B5T19</lei>
+        <title>HUNTINGTON BANC</title>
+        <cusip>446150104</cusip>
+        <identifiers>
+          <isin value="US4461501045"/>
+        </identifiers>
+        <balance>14407462.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>249969465.70000000</valUSD>
+        <pctVal>0.114790869122</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Trane Technologies PLC</name>
+        <lei>549300BURLR9SLYY2705</lei>
+        <title>TRANE TECHNOLOGI</title>
+        <cusip>G8994E103</cusip>
+        <identifiers>
+          <isin value="IE00BK9ZQ967"/>
+        </identifiers>
+        <balance>2040608.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>794204633.60000000</valUSD>
+        <pctVal>0.364714305791</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>T-Mobile US Inc</name>
+        <lei>549300QHIJYOHPACPG31</lei>
+        <title>T-MOBILE US INC</title>
+        <cusip>872590104</cusip>
+        <identifiers>
+          <isin value="US8725901040"/>
+        </identifiers>
+        <balance>2058634.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>417985047.36000000</valUSD>
+        <pctVal>0.191946911324</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Constellation Brands Inc</name>
+        <lei>5493005GKEG8QCVY7037</lei>
+        <title>CONSTELLATION-A</title>
+        <cusip>21036P108</cusip>
+        <identifiers>
+          <isin value="US21036P1084"/>
+        </identifiers>
+        <balance>1288406.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>177748491.76000000</valUSD>
+        <pctVal>0.081625584937</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>N/A</name>
+        <lei>N/A</lei>
+        <title>TRS:GOLDMAN SACHS GROUP INC USD 2027-Aug-31</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="CONTRACT_VANGUARD_ID" value="V1048207501"/>
+        </identifiers>
+        <balance>115000.00000000</balance>
+        <units>NC</units>
+        <curCd>USD</curCd>
+        <valUSD>-3224600.00000000</valUSD>
+        <pctVal>-0.00148079940</pctVal>
+        <payoffProfile>N/A</payoffProfile>
+        <assetCat>DE</assetCat>
+        <issuerConditional desc="N/A" issuerCat="OTHER"/>
+        <invCountry>N/A</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>2</fairValLevel>
+        <derivativeInfo>
+          <swapDeriv derivCat="SWP">
+            <counterparties>
+              <counterpartyName>BANK OF AMERICA, N.A.</counterpartyName>
+              <counterpartyLei>B4TYDEB6GKMZO031MB27</counterpartyLei>
+            </counterparties>
+            <descRefInstrmnt>
+              <otherRefInst>
+                <issuerName>N/A</issuerName>
+                <issueTitle>GOLDMAN SACHS GP</issueTitle>
+                <identifiers>
+                  <cusip value="38141G104"/>
+                </identifiers>
+              </otherRefInst>
+            </descRefInstrmnt>
+            <swapFlag>Y</swapFlag>
+            <otherRecDesc fixedOrFloating="Other">Receive positive return on reference instrument</otherRecDesc>
+            <floatingPmntDesc curCd="USD" fixedOrFloating="Floating" floatingRtIndex="OBFR01" floatingRtSpread="0.00000000" pmntAmt="0.00000000">
+              <rtResetTenors>
+                <rtResetTenor rateTenor="Day" rateTenorUnit="608" resetDt="Month" resetDtUnit="1"/>
+              </rtResetTenors>
+            </floatingPmntDesc>
+            <terminationDt>2027-08-31</terminationDt>
+            <upfrontPmnt>0.00000000</upfrontPmnt>
+            <pmntCurCd>USD</pmntCurCd>
+            <upfrontRcpt>0.00000000</upfrontRcpt>
+            <rcptCurCd>USD</rcptCurCd>
+            <notionalAmt>104309600.00000000</notionalAmt>
+            <curCd>USD</curCd>
+            <unrealizedAppr>-3224600.00000000</unrealizedAppr>
+          </swapDeriv>
+        </derivativeInfo>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Lennar Corp</name>
+        <lei>529900G61XVRLX5TJX09</lei>
+        <title>LENNAR CORP-B</title>
+        <cusip>526057302</cusip>
+        <identifiers>
+          <isin value="US5260573028"/>
+        </identifiers>
+        <balance>15602.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1484062.24000000</valUSD>
+        <pctVal>0.000681510415</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>ConocoPhillips</name>
+        <lei>WPTL2Z3FIYTHSP5V2253</lei>
+        <title>CONOCOPHILLIPS</title>
+        <cusip>20825C104</cusip>
+        <identifiers>
+          <isin value="US20825C1045"/>
+        </identifiers>
+        <balance>11371919.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1064525337.59000000</valUSD>
+        <pctVal>0.488850861693</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Southern Co/The</name>
+        <lei>549300FC3G3YU2FBZD92</lei>
+        <title>SOUTHERN CO</title>
+        <cusip>842587107</cusip>
+        <identifiers>
+          <isin value="US8425871071"/>
+        </identifiers>
+        <balance>10124689.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>882872880.80000000</valUSD>
+        <pctVal>0.405432499636</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Dover Corp</name>
+        <lei>549300FMC2ALGA7N9E80</lei>
+        <title>DOVER CORP</title>
+        <cusip>260003108</cusip>
+        <identifiers>
+          <isin value="US2600031080"/>
+        </identifiers>
+        <balance>1262215.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>246434856.60000000</valUSD>
+        <pctVal>0.113167707471</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Willis Towers Watson PLC</name>
+        <lei>549300WHC56FF48KL350</lei>
+        <title>WILLIS TOWERS WA</title>
+        <cusip>G96629103</cusip>
+        <identifiers>
+          <isin value="IE00BDB6Q211"/>
+        </identifiers>
+        <balance>881125.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>289537675.00000000</valUSD>
+        <pctVal>0.132961364956</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Ford Motor Co</name>
+        <lei>20S05OYHG0MQM4VUIC57</lei>
+        <title>FORD MOTOR CO</title>
+        <cusip>345370860</cusip>
+        <identifiers>
+          <isin value="US3453708600"/>
+        </identifiers>
+        <balance>36016322.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>472534144.64000000</valUSD>
+        <pctVal>0.216996924009</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>CRH PLC</name>
+        <lei>549300MIDJNNTH068E74</lei>
+        <title>CRH PLC</title>
+        <cusip>G25508105</cusip>
+        <identifiers>
+          <isin value="IE0001827041"/>
+        </identifiers>
+        <balance>6165553.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>769461014.40000000</valUSD>
+        <pctVal>0.353351551763</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Waters Corp</name>
+        <lei>5T547R1474YC9HOD8Q74</lei>
+        <title>WATERS CORP</title>
+        <cusip>941848103</cusip>
+        <identifiers>
+          <isin value="US9418481035"/>
+        </identifiers>
+        <balance>273937.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>104049490.71000000</valUSD>
+        <pctVal>0.047781561787</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Expeditors International of Washington Inc</name>
+        <lei>984500B055A804AB6E40</lei>
+        <title>EXPEDITORS INTL</title>
+        <cusip>302130109</cusip>
+        <identifiers>
+          <isin value="US3021301094"/>
+        </identifiers>
+        <balance>1233381.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>183786102.81000000</valUSD>
+        <pctVal>0.084398174053</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Constellation Energy Corp</name>
+        <lei>549300F8Y20RYGNGV346</lei>
+        <title>CONSTELLATION EN</title>
+        <cusip>21037T109</cusip>
+        <identifiers>
+          <isin value="US21037T1097"/>
+        </identifiers>
+        <balance>2874934.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1015627934.18000000</valUSD>
+        <pctVal>0.466396217405</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Progressive Corp/The</name>
+        <lei>529900TACNVLY9DCR586</lei>
+        <title>PROGRESSIVE CORP</title>
+        <cusip>743315103</cusip>
+        <identifiers>
+          <isin value="US7433151039"/>
+        </identifiers>
+        <balance>5396434.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1228875950.48000000</valUSD>
+        <pctVal>0.564323878534</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Prudential Financial Inc</name>
+        <lei>5PRBRS5FEH7NREC8OR45</lei>
+        <title>PRUDENTL FINL</title>
+        <cusip>744320102</cusip>
+        <identifiers>
+          <isin value="US7443201022"/>
+        </identifiers>
+        <balance>3220965.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>363582529.20000000</valUSD>
+        <pctVal>0.166964210639</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Eversource Energy</name>
+        <lei>SJ7XXD41SQU3ZNWUJ746</lei>
+        <title>EVERSOURCE ENERG</title>
+        <cusip>30040W108</cusip>
+        <identifiers>
+          <isin value="US30040W1080"/>
+        </identifiers>
+        <balance>3452729.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>232472243.57000000</valUSD>
+        <pctVal>0.106755802399</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Otis Worldwide Corp</name>
+        <lei>549300ZLBKR8VSU25153</lei>
+        <title>OTIS WORLDWI</title>
+        <cusip>68902V107</cusip>
+        <identifiers>
+          <isin value="US68902V1070"/>
+        </identifiers>
+        <balance>3586457.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>313277018.95000000</valUSD>
+        <pctVal>0.143862936141</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Ferguson Enterprises Inc</name>
+        <lei>2138003JYQMRP3SLX189</lei>
+        <title>FERGUSON ENTERPR</title>
+        <cusip>31488V107</cusip>
+        <identifiers>
+          <isin value="US31488V1070"/>
+        </identifiers>
+        <balance>1803563.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>401527230.69000000</valUSD>
+        <pctVal>0.184389159924</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Bristol-Myers Squibb Co</name>
+        <lei>HLYYNH7UQUORYSJQCN42</lei>
+        <title>BRISTOL-MYER SQB</title>
+        <cusip>110122108</cusip>
+        <identifiers>
+          <isin value="US1101221083"/>
+        </identifiers>
+        <balance>18734224.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1010524042.56000000</valUSD>
+        <pctVal>0.464052410519</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cigna Group/The</name>
+        <lei>549300VIWYMSIGT1U456</lei>
+        <title>THE CIGNA GROUP</title>
+        <cusip>125523100</cusip>
+        <identifiers>
+          <isin value="US1255231003"/>
+        </identifiers>
+        <balance>2458265.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>676588275.95000000</valUSD>
+        <pctVal>0.310702573279</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Trimble Inc</name>
+        <lei>549300E2MI7NSZFQWS19</lei>
+        <title>TRIMBLE INC</title>
+        <cusip>896239100</cusip>
+        <identifiers>
+          <isin value="US8962391004"/>
+        </identifiers>
+        <balance>2189541.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>171550537.35000000</valUSD>
+        <pctVal>0.078779363013</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>United Rentals Inc</name>
+        <lei>5323X5O7RN0NKFCDRY08</lei>
+        <title>UNITED RENTALS</title>
+        <cusip>911363109</cusip>
+        <identifiers>
+          <isin value="US9113631090"/>
+        </identifiers>
+        <balance>585583.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>473924033.56000000</valUSD>
+        <pctVal>0.217635188193</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>T Rowe Price Group Inc</name>
+        <lei>549300SIV6FPS9Y7IH33</lei>
+        <title>T ROWE PRICE GRP</title>
+        <cusip>74144T108</cusip>
+        <identifiers>
+          <isin value="US74144T1088"/>
+        </identifiers>
+        <balance>2008349.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>205614770.62000000</valUSD>
+        <pctVal>0.094422325373</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>IQVIA Holdings Inc</name>
+        <lei>549300W3R20NM4KQPH86</lei>
+        <title>IQVIA HOLDINGS I</title>
+        <cusip>46266C105</cusip>
+        <identifiers>
+          <isin value="US46266C1053"/>
+        </identifiers>
+        <balance>1488884.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>335609342.44000000</valUSD>
+        <pctVal>0.154118376003</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Goldman Sachs Group Inc/The</name>
+        <lei>784F5XWPLTWKTBV3E584</lei>
+        <title>GOLDMAN SACHS GP</title>
+        <cusip>38141G104</cusip>
+        <identifiers>
+          <isin value="US38141G1040"/>
+        </identifiers>
+        <balance>2645195.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2325126405.00000000</valUSD>
+        <pctVal>1.067743534601</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>US Bancorp</name>
+        <lei>N1GZ7BBF3NP8GI976H15</lei>
+        <title>US BANCORP</title>
+        <cusip>902973304</cusip>
+        <identifiers>
+          <isin value="US9029733048"/>
+        </identifiers>
+        <balance>14304969.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>763313145.84000000</valUSD>
+        <pctVal>0.350528330242</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Capital One Financial Corp</name>
+        <lei>ZUE8T73ROZOF6FLBAR73</lei>
+        <title>CAPITAL ONE FINA</title>
+        <cusip>14040H105</cusip>
+        <identifiers>
+          <isin value="US14040H1059"/>
+        </identifiers>
+        <balance>5850450.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1417915062.00000000</valUSD>
+        <pctVal>0.651134336958</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>3M Co</name>
+        <lei>LUZQVYP4VS22CLWDAR65</lei>
+        <title>3M CO</title>
+        <cusip>88579Y101</cusip>
+        <identifiers>
+          <isin value="US88579Y1010"/>
+        </identifiers>
+        <balance>4888616.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>782667421.60000000</valUSD>
+        <pctVal>0.359416192323</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Steel Dynamics Inc</name>
+        <lei>549300HGGKEL4FYTTQ83</lei>
+        <title>STEEL DYNAMICS</title>
+        <cusip>858119100</cusip>
+        <identifiers>
+          <isin value="US8581191009"/>
+        </identifiers>
+        <balance>638340.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>108166713.00000000</valUSD>
+        <pctVal>0.049672270813</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Fox Corp</name>
+        <lei>549300DDU6FDRBIELS05</lei>
+        <title>FOX CORP - A</title>
+        <cusip>35137L105</cusip>
+        <identifiers>
+          <isin value="US35137L1052"/>
+        </identifiers>
+        <balance>1714363.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>125268504.41000000</valUSD>
+        <pctVal>0.057525748013</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>ONEOK Inc</name>
+        <lei>2T3D6M0JSY48PSZI1Q41</lei>
+        <title>ONEOK INC</title>
+        <cusip>682680103</cusip>
+        <identifiers>
+          <isin value="US6826801036"/>
+        </identifiers>
+        <balance>5790537.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>425604469.50000000</valUSD>
+        <pctVal>0.195445899039</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Kimberly-Clark Corp</name>
+        <lei>MP3J6QPYPGN75NVW2S34</lei>
+        <title>KIMBERLY-CLARK</title>
+        <cusip>494368103</cusip>
+        <identifiers>
+          <isin value="US4943681035"/>
+        </identifiers>
+        <balance>3053937.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>308111703.93000000</valUSD>
+        <pctVal>0.141490922428</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Aflac Inc</name>
+        <lei>549300N0B7DOGLXWPP39</lei>
+        <title>AFLAC INC</title>
+        <cusip>001055102</cusip>
+        <identifiers>
+          <isin value="US0010551028"/>
+        </identifiers>
+        <balance>4823330.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>531868599.10000000</valUSD>
+        <pctVal>0.244244466333</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Citizens Financial Group Inc</name>
+        <lei>2138004JDDA4ZQUPFW65</lei>
+        <title>CITIZENS FINANCI</title>
+        <cusip>174610105</cusip>
+        <identifiers>
+          <isin value="US1746101054"/>
+        </identifiers>
+        <balance>3754692.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>219311559.72000000</valUSD>
+        <pctVal>0.100712158896</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>ON Semiconductor Corp</name>
+        <lei>ZV20P4CNJVT8V1ZGJ064</lei>
+        <title>ON SEMICONDUCTOR</title>
+        <cusip>682189105</cusip>
+        <identifiers>
+          <isin value="US6821891057"/>
+        </identifiers>
+        <balance>3702909.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>200512522.35000000</valUSD>
+        <pctVal>0.092079273146</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Regeneron Pharmaceuticals Inc</name>
+        <lei>549300RCBFWIRX3HYQ56</lei>
+        <title>REGENERON PHARM</title>
+        <cusip>75886F107</cusip>
+        <identifiers>
+          <isin value="US75886F1075"/>
+        </identifiers>
+        <balance>902972.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>696976997.64000000</valUSD>
+        <pctVal>0.320065473169</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>CBRE Group Inc</name>
+        <lei>52990016II9MJ2OSWA10</lei>
+        <title>CBRE GROUP INC-A</title>
+        <cusip>12504L109</cusip>
+        <identifiers>
+          <isin value="US12504L1098"/>
+        </identifiers>
+        <balance>2738668.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>440350427.72000000</valUSD>
+        <pctVal>0.202217531548</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>NextEra Energy Inc</name>
+        <lei>254900RHL9MEUS5NKX63</lei>
+        <title>NEXTERA ENERGY</title>
+        <cusip>65339F101</cusip>
+        <identifiers>
+          <isin value="US65339F1012"/>
+        </identifiers>
+        <balance>18165535.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1458329149.80000000</valUSD>
+        <pctVal>0.669693276748</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Tyson Foods Inc</name>
+        <lei>WD6L6041MNRW1JE49D58</lei>
+        <title>TYSON FOODS-A</title>
+        <cusip>902494103</cusip>
+        <identifiers>
+          <isin value="US9024941034"/>
+        </identifiers>
+        <balance>2604837.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>152695544.94000000</valUSD>
+        <pctVal>0.070120781614</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Charles Schwab Corp/The</name>
+        <lei>549300VSGCJ7E698NM85</lei>
+        <title>SCHWAB (CHARLES)</title>
+        <cusip>808513105</cusip>
+        <identifiers>
+          <isin value="US8085131055"/>
+        </identifiers>
+        <balance>15534968.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1552098652.88000000</valUSD>
+        <pctVal>0.712754067096</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Honeywell International Inc</name>
+        <lei>ISRPG12PN4EIEOEMW547</lei>
+        <title>HONEYWELL INTL</title>
+        <cusip>438516106</cusip>
+        <identifiers>
+          <isin value="US4385161066"/>
+        </identifiers>
+        <balance>5842592.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1139831273.28000000</valUSD>
+        <pctVal>0.523432820669</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Deere &amp; Co</name>
+        <lei>PWFTNG3EI0Y73OXWDH08</lei>
+        <title>DEERE &amp; CO</title>
+        <cusip>244199105</cusip>
+        <identifiers>
+          <isin value="US2441991054"/>
+        </identifiers>
+        <balance>2363376.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1100316964.32000000</valUSD>
+        <pctVal>0.505287076925</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Bank of New York Mellon Corp/The</name>
+        <lei>WFLLPEPC7FZXENRZV188</lei>
+        <title>BANK NY MELLON</title>
+        <cusip>064058100</cusip>
+        <identifiers>
+          <isin value="US0640581007"/>
+        </identifiers>
+        <balance>6417560.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>745014540.40000000</valUSD>
+        <pctVal>0.342125252625</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>PACCAR Inc</name>
+        <lei>KDTEY8BWE486IKZ3CC07</lei>
+        <title>PACCAR INC</title>
+        <cusip>693718108</cusip>
+        <identifiers>
+          <isin value="US6937181088"/>
+        </identifiers>
+        <balance>4833209.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>529284717.59000000</valUSD>
+        <pctVal>0.243057897392</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>HCA Healthcare Inc</name>
+        <lei>529900PH4ZGUH2MNEU89</lei>
+        <title>HCA HEALTHCARE I</title>
+        <cusip>40412C101</cusip>
+        <identifiers>
+          <isin value="US40412C1018"/>
+        </identifiers>
+        <balance>1469953.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>686262257.58000000</valUSD>
+        <pctVal>0.315145054908</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Ventas Inc</name>
+        <lei>ORQTRC074CWLT3DKHT41</lei>
+        <title>VENTAS INC</title>
+        <cusip>92276F100</cusip>
+        <identifiers>
+          <isin value="US92276F1003"/>
+        </identifiers>
+        <balance>4322853.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>334502365.14000000</valUSD>
+        <pctVal>0.153610030370</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>American Electric Power Co Inc</name>
+        <lei>1B4S6S7G0TW5EE83BO58</lei>
+        <title>AMERICAN ELECTRI</title>
+        <cusip>025537101</cusip>
+        <identifiers>
+          <isin value="US0255371017"/>
+        </identifiers>
+        <balance>4915066.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>566756260.46000000</valUSD>
+        <pctVal>0.260265562981</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>SLB Ltd</name>
+        <lei>213800ZUA17OK3QLGM62</lei>
+        <title>SLB LTD</title>
+        <cusip>806857108</cusip>
+        <identifiers>
+          <isin value="AN8068571086"/>
+        </identifiers>
+        <balance>13747956.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>527646551.28000000</valUSD>
+        <pctVal>0.242305619373</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Xylem Inc/NY</name>
+        <lei>549300DF5MV96DRYLQ48</lei>
+        <title>XYLEM INC</title>
+        <cusip>98419M100</cusip>
+        <identifiers>
+          <isin value="US98419M1009"/>
+        </identifiers>
+        <balance>2240547.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>305117690.46000000</valUSD>
+        <pctVal>0.140116012867</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Vanguard Cmt Funds-Vanguard Market Liquidity Fund</name>
+        <lei>1I6HV0TLSTR3A4XQ6L78</lei>
+        <title>Vanguard Market Liquidity Fund</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="FAID" value="SLBBH1142"/>
+        </identifiers>
+        <balance>53.10200000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>5310.20000000</valUSD>
+        <pctVal>0.000002438547</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>STIV</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Qnity Electronics Inc</name>
+        <lei>254900RSUG4J9TFFZX53</lei>
+        <title>QNITY ELECTRONIC</title>
+        <cusip>74743L100</cusip>
+        <identifiers>
+          <isin value="US74743L1008"/>
+        </identifiers>
+        <balance>963791.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>78693535.15000000</valUSD>
+        <pctVal>0.036137610923</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>CME Group Inc</name>
+        <lei>LCZ7XYGSLJUHFXXNXD88</lei>
+        <title>CME GROUP INC</title>
+        <cusip>12572Q105</cusip>
+        <identifiers>
+          <isin value="US12572Q1058"/>
+        </identifiers>
+        <balance>3318472.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>906208333.76000000</valUSD>
+        <pctVal>0.416148596176</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Chubb Ltd</name>
+        <lei>E0JAN6VLUDI1HITHT809</lei>
+        <title>CHUBB LTD</title>
+        <cusip>H1467J104</cusip>
+        <identifiers>
+          <isin value="CH0044328745"/>
+        </identifiers>
+        <balance>3259631.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1017396027.72000000</valUSD>
+        <pctVal>0.467208160550</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Eaton Corp PLC</name>
+        <lei>549300VDIGTMXUNT7H71</lei>
+        <title>EATON CORP PLC</title>
+        <cusip>G29183103</cusip>
+        <identifiers>
+          <isin value="IE00B8KQN827"/>
+        </identifiers>
+        <balance>3574231.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1138428315.81000000</valUSD>
+        <pctVal>0.522788555151</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>General Dynamics Corp</name>
+        <lei>9C1X8XOOTYY2FNYTVH06</lei>
+        <title>GENERAL DYNAMICS</title>
+        <cusip>369550108</cusip>
+        <identifiers>
+          <isin value="US3695501086"/>
+        </identifiers>
+        <balance>2237242.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>753189891.72000000</valUSD>
+        <pctVal>0.345879533896</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Electronic Arts Inc</name>
+        <lei>549300O7A67PUEYKDL45</lei>
+        <title>ELECTRONIC ARTS</title>
+        <cusip>285512109</cusip>
+        <identifiers>
+          <isin value="US2855121099"/>
+        </identifiers>
+        <balance>2301729.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>470312286.57000000</valUSD>
+        <pctVal>0.215976603314</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Biogen Inc</name>
+        <lei>W8J5WZB5IY3K0NDQT671</lei>
+        <title>BIOGEN INC</title>
+        <cusip>09062X103</cusip>
+        <identifiers>
+          <isin value="US09062X1037"/>
+        </identifiers>
+        <balance>1350109.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>237605682.91000000</valUSD>
+        <pctVal>0.109113178176</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>VICI Properties Inc</name>
+        <lei>254900RKH6RY9KCJQH63</lei>
+        <title>VICI PROPERTIES</title>
+        <cusip>925652109</cusip>
+        <identifiers>
+          <isin value="US9256521090"/>
+        </identifiers>
+        <balance>9835824.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>276583370.88000000</valUSD>
+        <pctVal>0.127012495062</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Merck &amp; Co Inc</name>
+        <lei>4YV9Y5M8S0BRK1RP0397</lei>
+        <title>MERCK &amp; CO</title>
+        <cusip>58933Y105</cusip>
+        <identifiers>
+          <isin value="US58933Y1055"/>
+        </identifiers>
+        <balance>22841212.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2404265975.12000000</valUSD>
+        <pctVal>1.104085973509</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Keysight Technologies Inc</name>
+        <lei>549300GLKVIO8YRCYN02</lei>
+        <title>KEYSIGHT TEC</title>
+        <cusip>49338L103</cusip>
+        <identifiers>
+          <isin value="US49338L1035"/>
+        </identifiers>
+        <balance>1575554.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>320136817.26000000</valUSD>
+        <pctVal>0.147013089732</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Public Storage</name>
+        <lei>N/A</lei>
+        <title>PUBLIC STORAGE</title>
+        <cusip>74460D109</cusip>
+        <identifiers>
+          <isin value="US74460D1090"/>
+        </identifiers>
+        <balance>1453268.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>377123046.00000000</valUSD>
+        <pctVal>0.173182280864</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Sempra</name>
+        <lei>PBBKGKLRK5S5C0Y4T545</lei>
+        <title>SEMPRA</title>
+        <cusip>816851109</cusip>
+        <identifiers>
+          <isin value="US8168511090"/>
+        </identifiers>
+        <balance>6006427.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>530307439.83000000</valUSD>
+        <pctVal>0.243527551453</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>N/A</name>
+        <lei>N/A</lei>
+        <title>TRS:NEXTERA ENERGY INC USD 2027-Jan-29</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="CONTRACT_VANGUARD_ID" value="V1048197701"/>
+        </identifiers>
+        <balance>1000000.00000000</balance>
+        <units>NC</units>
+        <curCd>USD</curCd>
+        <valUSD>-1370000.00000000</valUSD>
+        <pctVal>-0.00062913080</pctVal>
+        <payoffProfile>N/A</payoffProfile>
+        <assetCat>DE</assetCat>
+        <issuerConditional desc="N/A" issuerCat="OTHER"/>
+        <invCountry>N/A</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>2</fairValLevel>
+        <derivativeInfo>
+          <swapDeriv derivCat="SWP">
+            <counterparties>
+              <counterpartyName>GOLDMAN SACHS INTERNATIONAL</counterpartyName>
+              <counterpartyLei>W22LROWP2IHZNBB6K528</counterpartyLei>
+            </counterparties>
+            <descRefInstrmnt>
+              <otherRefInst>
+                <issuerName>N/A</issuerName>
+                <issueTitle>NEXTERA ENERGY</issueTitle>
+                <identifiers>
+                  <cusip value="65339F101"/>
+                </identifiers>
+              </otherRefInst>
+            </descRefInstrmnt>
+            <swapFlag>Y</swapFlag>
+            <otherRecDesc fixedOrFloating="Other">Receive positive return on reference instrument</otherRecDesc>
+            <floatingPmntDesc curCd="USD" fixedOrFloating="Floating" floatingRtIndex="OBFR01" floatingRtSpread="0.00000000" pmntAmt="0.00000000">
+              <rtResetTenors>
+                <rtResetTenor rateTenor="Day" rateTenorUnit="394" resetDt="Month" resetDtUnit="1"/>
+              </rtResetTenors>
+            </floatingPmntDesc>
+            <terminationDt>2027-01-29</terminationDt>
+            <upfrontPmnt>0.00000000</upfrontPmnt>
+            <pmntCurCd>USD</pmntCurCd>
+            <upfrontRcpt>0.00000000</upfrontRcpt>
+            <rcptCurCd>USD</rcptCurCd>
+            <notionalAmt>81650000.00000000</notionalAmt>
+            <curCd>USD</curCd>
+            <unrealizedAppr>-1370000.00000000</unrealizedAppr>
+          </swapDeriv>
+        </derivativeInfo>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Dominion Energy Inc</name>
+        <lei>ILUL7B6Z54MRYCF6H308</lei>
+        <title>DOMINION ENERGY</title>
+        <cusip>25746U109</cusip>
+        <identifiers>
+          <isin value="US25746U1097"/>
+        </identifiers>
+        <balance>7858288.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>460417093.92000000</valUSD>
+        <pctVal>0.211432537257</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Berkshire Hathaway Inc</name>
+        <lei>5493000C01ZX7D35SD85</lei>
+        <title>BERKSHIRE HATH-A</title>
+        <cusip>084670108</cusip>
+        <identifiers>
+          <isin value="US0846701086"/>
+        </identifiers>
+        <balance>1773.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1338260400.00000000</valUSD>
+        <pctVal>0.614555357782</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Western Digital Corp</name>
+        <lei>549300QQXOOYEF89IC56</lei>
+        <title>WESTERN DIGITAL</title>
+        <cusip>958102105</cusip>
+        <identifiers>
+          <isin value="US9581021055"/>
+        </identifiers>
+        <balance>3146361.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>542023609.47000000</valUSD>
+        <pctVal>0.248907845770</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>General Mills Inc</name>
+        <lei>2TGYMUGI08PO8X8L6150</lei>
+        <title>GENERAL MILLS IN</title>
+        <cusip>370334104</cusip>
+        <identifiers>
+          <isin value="US3703341046"/>
+        </identifiers>
+        <balance>4908794.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>228258921.00000000</valUSD>
+        <pctVal>0.104820962244</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Lowe's Cos Inc</name>
+        <lei>WAFCR4OKGSC504WU3E95</lei>
+        <title>LOWE'S COS INC</title>
+        <cusip>548661107</cusip>
+        <identifiers>
+          <isin value="US5486611073"/>
+        </identifiers>
+        <balance>5162208.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1244918081.28000000</valUSD>
+        <pctVal>0.571690738850</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Automatic Data Processing Inc</name>
+        <lei>HGBOLILQXWER4SAL2I23</lei>
+        <title>AUTOMATIC DATA</title>
+        <cusip>053015103</cusip>
+        <identifiers>
+          <isin value="US0530151036"/>
+        </identifiers>
+        <balance>1861025.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>478711460.75000000</valUSD>
+        <pctVal>0.219833668421</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Gen Digital Inc</name>
+        <lei>YF6ZV0M6AU4FY94MK914</lei>
+        <title>GEN DIGITAL INC</title>
+        <cusip>668771108</cusip>
+        <identifiers>
+          <isin value="US6687711084"/>
+        </identifiers>
+        <balance>2554310.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>69451688.90000000</valUSD>
+        <pctVal>0.031893574315</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>FirstEnergy Corp</name>
+        <lei>549300SVYJS666PQJH88</lei>
+        <title>FIRSTENERGY CORP</title>
+        <cusip>337932107</cusip>
+        <identifiers>
+          <isin value="US3379321074"/>
+        </identifiers>
+        <balance>5045524.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>225888109.48000000</valUSD>
+        <pctVal>0.103732239211</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Raymond James Financial Inc</name>
+        <lei>RGUZHJ05YTITL6D76949</lei>
+        <title>RAYMOND JAMES</title>
+        <cusip>754730109</cusip>
+        <identifiers>
+          <isin value="US7547301090"/>
+        </identifiers>
+        <balance>1628976.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>261597255.84000000</valUSD>
+        <pctVal>0.120130577843</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Equifax Inc</name>
+        <lei>5493004MCF8JDC86VS77</lei>
+        <title>EQUIFAX INC</title>
+        <cusip>294429105</cusip>
+        <identifiers>
+          <isin value="US2944291051"/>
+        </identifiers>
+        <balance>563122.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>122186211.56000000</valUSD>
+        <pctVal>0.056110298833</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cincinnati Financial Corp</name>
+        <lei>254900Q4WEDMZBOZ0002</lei>
+        <title>CINCINNATI FIN</title>
+        <cusip>172062101</cusip>
+        <identifiers>
+          <isin value="US1720621010"/>
+        </identifiers>
+        <balance>1435853.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>234503511.96000000</valUSD>
+        <pctVal>0.107688600584</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Linde PLC</name>
+        <lei>5299003QR1WT0EF88V51</lei>
+        <title>LINDE PLC</title>
+        <cusip>G54950103</cusip>
+        <identifiers>
+          <isin value="IE000S9YS762"/>
+        </identifiers>
+        <balance>4297147.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1832260509.33000000</valUSD>
+        <pctVal>0.841409872743</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Dell Technologies Inc</name>
+        <lei>549300TJB5YBRUPOG437</lei>
+        <title>DELL TECHN-C</title>
+        <cusip>24703L202</cusip>
+        <identifiers>
+          <isin value="US24703L2025"/>
+        </identifiers>
+        <balance>2945388.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>370765441.44000000</valUSD>
+        <pctVal>0.170262744468</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>N/A</name>
+        <lei>N/A</lei>
+        <title>TRS:CITIGROUP INC USD 2027-Aug-31</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="CONTRACT_VANGUARD_ID" value="V1048207401"/>
+        </identifiers>
+        <balance>650000.00000000</balance>
+        <units>NC</units>
+        <curCd>USD</curCd>
+        <valUSD>-2424500.00000000</valUSD>
+        <pctVal>-0.00111337783</pctVal>
+        <payoffProfile>N/A</payoffProfile>
+        <assetCat>DE</assetCat>
+        <issuerConditional desc="N/A" issuerCat="OTHER"/>
+        <invCountry>N/A</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>2</fairValLevel>
+        <derivativeInfo>
+          <swapDeriv derivCat="SWP">
+            <counterparties>
+              <counterpartyName>BANK OF AMERICA, N.A.</counterpartyName>
+              <counterpartyLei>B4TYDEB6GKMZO031MB27</counterpartyLei>
+            </counterparties>
+            <descRefInstrmnt>
+              <otherRefInst>
+                <issuerName>N/A</issuerName>
+                <issueTitle>CITIGROUP INC</issueTitle>
+                <identifiers>
+                  <cusip value="172967424"/>
+                </identifiers>
+              </otherRefInst>
+            </descRefInstrmnt>
+            <swapFlag>Y</swapFlag>
+            <otherRecDesc fixedOrFloating="Other">Receive positive return on reference instrument</otherRecDesc>
+            <floatingPmntDesc curCd="USD" fixedOrFloating="Floating" floatingRtIndex="OBFR01" floatingRtSpread="0.00000000" pmntAmt="0.00000000">
+              <rtResetTenors>
+                <rtResetTenor rateTenor="Day" rateTenorUnit="608" resetDt="Month" resetDtUnit="1"/>
+              </rtResetTenors>
+            </floatingPmntDesc>
+            <terminationDt>2027-08-31</terminationDt>
+            <upfrontPmnt>0.00000000</upfrontPmnt>
+            <pmntCurCd>USD</pmntCurCd>
+            <upfrontRcpt>0.00000000</upfrontRcpt>
+            <rcptCurCd>USD</rcptCurCd>
+            <notionalAmt>78273000.00000000</notionalAmt>
+            <curCd>USD</curCd>
+            <unrealizedAppr>-2424500.00000000</unrealizedAppr>
+          </swapDeriv>
+        </derivativeInfo>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Loews Corp</name>
+        <lei>R8V1FN4M5ITGZOG7BS19</lei>
+        <title>LOEWS CORP</title>
+        <cusip>540424108</cusip>
+        <identifiers>
+          <isin value="US5404241086"/>
+        </identifiers>
+        <balance>1521595.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>160239169.45000000</valUSD>
+        <pctVal>0.073584961575</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Intel Corp</name>
+        <lei>KNX4USFCNGPY45LOCE31</lei>
+        <title>INTEL CORP</title>
+        <cusip>458140100</cusip>
+        <identifiers>
+          <isin value="US4581401001"/>
+        </identifiers>
+        <balance>37312096.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1376816342.40000000</valUSD>
+        <pctVal>0.632261000851</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Air Products and Chemicals Inc</name>
+        <lei>7QEON6Y1RL5XR3R1W237</lei>
+        <title>AIR PRODS &amp; CHEM</title>
+        <cusip>009158106</cusip>
+        <identifiers>
+          <isin value="US0091581068"/>
+        </identifiers>
+        <balance>2048437.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>506004907.74000000</valUSD>
+        <pctVal>0.232367353256</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Union Pacific Corp</name>
+        <lei>549300LMMRSZZCZ8CL11</lei>
+        <title>UNION PAC CORP</title>
+        <cusip>907818108</cusip>
+        <identifiers>
+          <isin value="US9078181081"/>
+        </identifiers>
+        <balance>5458713.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1262709491.16000000</valUSD>
+        <pctVal>0.579860902343</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>DR Horton Inc</name>
+        <lei>529900ZIUEYVSB8QDD25</lei>
+        <title>DR HORTON INC</title>
+        <cusip>23331A109</cusip>
+        <identifiers>
+          <isin value="US23331A1097"/>
+        </identifiers>
+        <balance>2418934.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>348399064.02000000</valUSD>
+        <pctVal>0.159991666375</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>American Water Works Co Inc</name>
+        <lei>549300DXHIJQMD5WFW18</lei>
+        <title>AMERICAN WATER W</title>
+        <cusip>030420103</cusip>
+        <identifiers>
+          <isin value="US0304201033"/>
+        </identifiers>
+        <balance>1795534.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>234317187.00000000</valUSD>
+        <pctVal>0.107603036517</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Hartford Financial Services Group Inc/The</name>
+        <lei>IU7C3FTM7Y3BQM112U94</lei>
+        <title>HARTFORD INSURAN</title>
+        <cusip>416515104</cusip>
+        <identifiers>
+          <isin value="US4165151048"/>
+        </identifiers>
+        <balance>2564312.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>353362193.60000000</valUSD>
+        <pctVal>0.162270832578</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Veralto Corp</name>
+        <lei>635400FJE6GSOJUSNY27</lei>
+        <title>VERALTO CORP</title>
+        <cusip>92338C103</cusip>
+        <identifiers>
+          <isin value="US92338C1036"/>
+        </identifiers>
+        <balance>2170831.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>216605517.18000000</valUSD>
+        <pctVal>0.099469491220</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Home Depot Inc/The</name>
+        <lei>QEKMOTMBBKA8I816DO57</lei>
+        <title>HOME DEPOT INC</title>
+        <cusip>437076102</cusip>
+        <identifiers>
+          <isin value="US4370761029"/>
+        </identifiers>
+        <balance>9161339.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>3152416749.90000000</valUSD>
+        <pctVal>1.447651446320</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Halliburton Co</name>
+        <lei>ENYF8GB5SMQZ25S06U51</lei>
+        <title>HALLIBURTON CO</title>
+        <cusip>406216101</cusip>
+        <identifiers>
+          <isin value="US4062161017"/>
+        </identifiers>
+        <balance>6970562.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>196988082.12000000</valUSD>
+        <pctVal>0.090460781239</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Occidental Petroleum Corp</name>
+        <lei>IM7X0T3ECJW4C1T7ON55</lei>
+        <title>OCCIDENTAL PETE</title>
+        <cusip>674599105</cusip>
+        <identifiers>
+          <isin value="US6745991058"/>
+        </identifiers>
+        <balance>6799903.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>279612011.36000000</valUSD>
+        <pctVal>0.128403306024</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Colgate-Palmolive Co</name>
+        <lei>YMEGZFW4SBUSS5BQXF88</lei>
+        <title>COLGATE-PALMOLIV</title>
+        <cusip>194162103</cusip>
+        <identifiers>
+          <isin value="US1941621039"/>
+        </identifiers>
+        <balance>7418006.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>586170834.12000000</valUSD>
+        <pctVal>0.269181115038</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Dollar General Corp</name>
+        <lei>OPX52SQVOZI8IVSWYU66</lei>
+        <title>DOLLAR GENERAL C</title>
+        <cusip>256677105</cusip>
+        <identifiers>
+          <isin value="US2566771059"/>
+        </identifiers>
+        <balance>2025483.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>268923377.91000000</valUSD>
+        <pctVal>0.123494876428</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Consolidated Edison Inc</name>
+        <lei>54930033SBW53OO8T749</lei>
+        <title>CONS EDISON INC</title>
+        <cusip>209115104</cusip>
+        <identifiers>
+          <isin value="US2091151041"/>
+        </identifiers>
+        <balance>3321565.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>329897835.80000000</valUSD>
+        <pctVal>0.151495540413</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Nucor Corp</name>
+        <lei>549300GGJCRSI2TIEJ46</lei>
+        <title>NUCOR CORP</title>
+        <cusip>670346105</cusip>
+        <identifiers>
+          <isin value="US6703461052"/>
+        </identifiers>
+        <balance>2000799.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>326350324.89000000</valUSD>
+        <pctVal>0.149866453998</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cummins Inc</name>
+        <lei>ZUNI8PYC725B6H8JU438</lei>
+        <title>CUMMINS INC</title>
+        <cusip>231021106</cusip>
+        <identifiers>
+          <isin value="US2310211063"/>
+        </identifiers>
+        <balance>1270309.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>648429229.05000000</valUSD>
+        <pctVal>0.297771388031</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>McCormick &amp; Co Inc/MD</name>
+        <lei>549300JQQA6MQ4OJP259</lei>
+        <title>MCCORMICK-N/V</title>
+        <cusip>579780206</cusip>
+        <identifiers>
+          <isin value="US5797802064"/>
+        </identifiers>
+        <balance>2330495.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>158730014.45000000</valUSD>
+        <pctVal>0.072891928073</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Emerson Electric Co</name>
+        <lei>FGLT0EWZSUIRRITFOA30</lei>
+        <title>EMERSON ELEC CO</title>
+        <cusip>291011104</cusip>
+        <identifiers>
+          <isin value="US2910111044"/>
+        </identifiers>
+        <balance>5170096.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>686175141.12000000</valUSD>
+        <pctVal>0.315105049325</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Marsh &amp; McLennan Cos Inc</name>
+        <lei>549300XMP3KDCKJXIU47</lei>
+        <title>MARSH &amp; MCLENNAN</title>
+        <cusip>571748102</cusip>
+        <identifiers>
+          <isin value="US5717481023"/>
+        </identifiers>
+        <balance>4508503.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>836417476.56000000</valUSD>
+        <pctVal>0.384099269142</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>MetLife Inc</name>
+        <lei>C4BXATY60WC6XEOZDX54</lei>
+        <title>METLIFE INC</title>
+        <cusip>59156R108</cusip>
+        <identifiers>
+          <isin value="US59156R1086"/>
+        </identifiers>
+        <balance>5154010.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>406857549.40000000</valUSD>
+        <pctVal>0.186836946559</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Pfizer Inc</name>
+        <lei>765LHXWGK1KXCLTFYQ30</lei>
+        <title>PFIZER INC</title>
+        <cusip>717081103</cusip>
+        <identifiers>
+          <isin value="US7170811035"/>
+        </identifiers>
+        <balance>52323615.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1302858013.50000000</valUSD>
+        <pctVal>0.598297889279</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Weyerhaeuser Co</name>
+        <lei>08IRJODWFYBI7QWRGS31</lei>
+        <title>WEYERHAEUSER CO</title>
+        <cusip>962166104</cusip>
+        <identifiers>
+          <isin value="US9621661043"/>
+        </identifiers>
+        <balance>3317140.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>78583046.60000000</valUSD>
+        <pctVal>0.036086872419</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>PG&amp;E Corp</name>
+        <lei>8YQ2GSDWYZXO2EDN3511</lei>
+        <title>PG&amp;E CORP</title>
+        <cusip>69331C108</cusip>
+        <identifiers>
+          <isin value="US69331C1080"/>
+        </identifiers>
+        <balance>19698359.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>316552629.13000000</valUSD>
+        <pctVal>0.145367160420</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Target Corp</name>
+        <lei>8WDDFXB5T1Z6J0XC1L66</lei>
+        <title>TARGET CORP</title>
+        <cusip>87612E106</cusip>
+        <identifiers>
+          <isin value="US87612E1064"/>
+        </identifiers>
+        <balance>4166995.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>407323761.25000000</valUSD>
+        <pctVal>0.187051040162</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>PPG Industries Inc</name>
+        <lei>549300BKPEP01R3V6C59</lei>
+        <title>PPG INDS INC</title>
+        <cusip>693506107</cusip>
+        <identifiers>
+          <isin value="US6935061076"/>
+        </identifiers>
+        <balance>2065058.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>211585842.68000000</valUSD>
+        <pctVal>0.097164358483</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Microchip Technology Inc</name>
+        <lei>5493007PTFULNYZJ1R12</lei>
+        <title>MICROCHIP TECH</title>
+        <cusip>595017104</cusip>
+        <identifiers>
+          <isin value="US5950171042"/>
+        </identifiers>
+        <balance>4973511.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>316912120.92000000</valUSD>
+        <pctVal>0.145532246084</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Ameren Corp</name>
+        <lei>XRZQ5S7HYJFPHJ78L959</lei>
+        <title>AMEREN CORP</title>
+        <cusip>023608102</cusip>
+        <identifiers>
+          <isin value="US0236081024"/>
+        </identifiers>
+        <balance>2489423.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>248593780.78000000</valUSD>
+        <pctVal>0.114159127692</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Elevance Health Inc</name>
+        <lei>8MYN82XMYQH89CTMTH67</lei>
+        <title>ELEVANCE HEALTH</title>
+        <cusip>036752103</cusip>
+        <identifiers>
+          <isin value="US0367521038"/>
+        </identifiers>
+        <balance>2045192.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>716942055.60000000</valUSD>
+        <pctVal>0.329233818387</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Walmart Inc</name>
+        <lei>Y87794H0US1R65VBXU25</lei>
+        <title>WALMART INC</title>
+        <cusip>931142103</cusip>
+        <identifiers>
+          <isin value="US9311421039"/>
+        </identifiers>
+        <balance>40354281.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>4495870446.21000000</valUSD>
+        <pctVal>2.064591667371</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Equity Residential</name>
+        <lei>5493008RACSH5EP3PI59</lei>
+        <title>EQUITY RESIDENTI</title>
+        <cusip>29476L107</cusip>
+        <identifiers>
+          <isin value="US29476L1070"/>
+        </identifiers>
+        <balance>3326290.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>209689321.60000000</valUSD>
+        <pctVal>0.096293438899</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Fox Corp</name>
+        <lei>549300DDU6FDRBIELS05</lei>
+        <title>FOX CORP - B</title>
+        <cusip>35137L204</cusip>
+        <identifiers>
+          <isin value="US35137L2043"/>
+        </identifiers>
+        <balance>1314287.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>85336654.91000000</valUSD>
+        <pctVal>0.039188261484</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>American International Group Inc</name>
+        <lei>ODVCVCQG2BP6VHV36M30</lei>
+        <title>AMERICAN INTERNA</title>
+        <cusip>026874784</cusip>
+        <identifiers>
+          <isin value="US0268747849"/>
+        </identifiers>
+        <balance>4965578.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>424805197.90000000</valUSD>
+        <pctVal>0.195078857883</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>CMS Energy Corp</name>
+        <lei>549300IA9XFBAGNIBW29</lei>
+        <title>CMS ENERGY CORP</title>
+        <cusip>125896100</cusip>
+        <identifiers>
+          <isin value="US1258961002"/>
+        </identifiers>
+        <balance>2800603.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>195846167.79000000</valUSD>
+        <pctVal>0.089936391838</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Estee Lauder Cos Inc/The</name>
+        <lei>549300VFZ8XJ9NUPU221</lei>
+        <title>ESTEE LAUDER</title>
+        <cusip>518439104</cusip>
+        <identifiers>
+          <isin value="US5184391044"/>
+        </identifiers>
+        <balance>1944902.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>203670137.44000000</valUSD>
+        <pctVal>0.093529311772</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Regions Financial Corp</name>
+        <lei>CW05CS5KW59QTC0DG824</lei>
+        <title>REGIONS FINANCIA</title>
+        <cusip>7591EP100</cusip>
+        <identifiers>
+          <isin value="US7591EP1005"/>
+        </identifiers>
+        <balance>8069424.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>218681390.40000000</valUSD>
+        <pctVal>0.100422772815</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Mondelez International Inc</name>
+        <lei>549300DV9GIB88LZ5P30</lei>
+        <title>MONDELEZ INTER-A</title>
+        <cusip>609207105</cusip>
+        <identifiers>
+          <isin value="US6092071058"/>
+        </identifiers>
+        <balance>11874796.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>639220268.68000000</valUSD>
+        <pctVal>0.293542453262</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Principal Financial Group Inc</name>
+        <lei>CUMYEZJOAF02RYZ1JJ85</lei>
+        <title>PRINCIPAL FINL</title>
+        <cusip>74251V102</cusip>
+        <identifiers>
+          <isin value="US74251V1026"/>
+        </identifiers>
+        <balance>2021762.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>178339626.02000000</valUSD>
+        <pctVal>0.081897045354</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Seagate Technology Holdings PLC</name>
+        <lei>635400RUXIFEZSRU8X70</lei>
+        <title>SEAGATE TECHNOLO</title>
+        <cusip>G7997R103</cusip>
+        <identifiers>
+          <isin value="IE00BKVD2N49"/>
+        </identifiers>
+        <balance>982702.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>270626303.78000000</valUSD>
+        <pctVal>0.124276893304</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Rocket Cos Inc</name>
+        <lei>N/A</lei>
+        <title>ROCKET COS INC-A</title>
+        <cusip>77311W101</cusip>
+        <identifiers>
+          <isin value="US77311W1018"/>
+        </identifiers>
+        <balance>8454247.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>163674221.92000000</valUSD>
+        <pctVal>0.075162404874</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>M&amp;T Bank Corp</name>
+        <lei>549300WYXDDBYRASEG81</lei>
+        <title>M&amp;T BANK CORP</title>
+        <cusip>55261F104</cusip>
+        <identifiers>
+          <isin value="US55261F1049"/>
+        </identifiers>
+        <balance>1414345.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>284962230.60000000</valUSD>
+        <pctVal>0.130860231372</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>NIKE Inc</name>
+        <lei>787RXPR0UX0O0XUXPZ81</lei>
+        <title>NIKE INC -CL B</title>
+        <cusip>654106103</cusip>
+        <identifiers>
+          <isin value="US6541061031"/>
+        </identifiers>
+        <balance>10944899.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>697299515.29000000</valUSD>
+        <pctVal>0.320213579584</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Parker-Hannifin Corp</name>
+        <lei>5493002CONDB4N2HKI23</lei>
+        <title>PARKER HANNIFIN</title>
+        <cusip>701094104</cusip>
+        <identifiers>
+          <isin value="US7010941042"/>
+        </identifiers>
+        <balance>1161188.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1020637804.48000000</valUSD>
+        <pctVal>0.468696847861</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>PayPal Holdings Inc</name>
+        <lei>5493005X2GO78EFZ3E94</lei>
+        <title>PAYPAL HOLDINGS</title>
+        <cusip>70450Y103</cusip>
+        <identifiers>
+          <isin value="US70450Y1038"/>
+        </identifiers>
+        <balance>8610716.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>502693600.08000000</valUSD>
+        <pctVal>0.230846735995</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Arch Capital Group Ltd</name>
+        <lei>549300AYR4P8AFKDCE43</lei>
+        <title>ARCH CAPITAL GRP</title>
+        <cusip>G0450A105</cusip>
+        <identifiers>
+          <isin value="BMG0450A1053"/>
+        </identifiers>
+        <balance>3170307.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>304095847.44000000</valUSD>
+        <pctVal>0.139646762560</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Arthur J Gallagher &amp; Co</name>
+        <lei>54930049QLLMPART6V29</lei>
+        <title>ARTHUR J GALLAGH</title>
+        <cusip>363576109</cusip>
+        <identifiers>
+          <isin value="US3635761097"/>
+        </identifiers>
+        <balance>2363255.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>611586761.45000000</valUSD>
+        <pctVal>0.280852606112</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>NiSource Inc</name>
+        <lei>549300D8GOWWH0SJB189</lei>
+        <title>NISOURCE INC</title>
+        <cusip>65473P105</cusip>
+        <identifiers>
+          <isin value="US65473P1057"/>
+        </identifiers>
+        <balance>2195806.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>91696858.56000000</valUSD>
+        <pctVal>0.042108991433</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>News Corp</name>
+        <lei>549300ITS31QK8VRBQ14</lei>
+        <title>NEWS CORP-CL B</title>
+        <cusip>65249B208</cusip>
+        <identifiers>
+          <isin value="US65249B2088"/>
+        </identifiers>
+        <balance>98135.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2907740.05000000</valUSD>
+        <pctVal>0.001335291118</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Valero Energy Corp</name>
+        <lei>549300XTO5VR8SKV1V74</lei>
+        <title>VALERO ENERGY</title>
+        <cusip>91913Y100</cusip>
+        <identifiers>
+          <isin value="US91913Y1001"/>
+        </identifiers>
+        <balance>2806945.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>456942576.55000000</valUSD>
+        <pctVal>0.209836970904</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Ingersoll Rand Inc</name>
+        <lei>5299004C02FMZCUOIR50</lei>
+        <title>INGERSOLL-RAND I</title>
+        <cusip>45687V106</cusip>
+        <identifiers>
+          <isin value="US45687V1061"/>
+        </identifiers>
+        <balance>3636056.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>288048356.32000000</valUSD>
+        <pctVal>0.132277440681</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Roper Technologies Inc</name>
+        <lei>54930003T4SXCIWVXY35</lei>
+        <title>ROPER TECHNOLOGI</title>
+        <cusip>776696106</cusip>
+        <identifiers>
+          <isin value="US7766961061"/>
+        </identifiers>
+        <balance>990614.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>440952009.82000000</valUSD>
+        <pctVal>0.202493789818</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>W R Berkley Corp</name>
+        <lei>SQOAGCLKBDWNVYV1OV80</lei>
+        <title>WR BERKLEY CORP</title>
+        <cusip>084423102</cusip>
+        <identifiers>
+          <isin value="US0844231029"/>
+        </identifiers>
+        <balance>2622953.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>183921464.36000000</valUSD>
+        <pctVal>0.084460334725</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Zoom Video Communications Inc</name>
+        <lei>549300T9GCHU0ODOM055</lei>
+        <title>ZOOM COMMUNICATI</title>
+        <cusip>98980L101</cusip>
+        <identifiers>
+          <isin value="US98980L1017"/>
+        </identifiers>
+        <balance>2321813.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>200349243.77000000</valUSD>
+        <pctVal>0.092004292428</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Corpay Inc</name>
+        <lei>549300DG6RR0NQSFLN74</lei>
+        <title>CORPAY INC</title>
+        <cusip>219948106</cusip>
+        <identifiers>
+          <isin value="US2199481068"/>
+        </identifiers>
+        <balance>611614.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>184053001.02000000</valUSD>
+        <pctVal>0.084520738932</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>KeyCorp</name>
+        <lei>RKPI3RZGV1V1FJTH5T61</lei>
+        <title>KEYCORP</title>
+        <cusip>493267108</cusip>
+        <identifiers>
+          <isin value="US4932671088"/>
+        </identifiers>
+        <balance>10058061.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>207598379.04000000</valUSD>
+        <pctVal>0.095333237168</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>PulteGroup Inc</name>
+        <lei>N/A</lei>
+        <title>PULTEGROUP INC</title>
+        <cusip>745867101</cusip>
+        <identifiers>
+          <isin value="US7458671010"/>
+        </identifiers>
+        <balance>1793712.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>210330669.12000000</valUSD>
+        <pctVal>0.096587958228</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Royal Caribbean Cruises Ltd</name>
+        <lei>K2NEH8QNVW44JIWK7Z55</lei>
+        <title>ROYAL CARIBBEAN</title>
+        <cusip>V7780T103</cusip>
+        <identifiers>
+          <isin value="LR0008862868"/>
+        </identifiers>
+        <balance>1129392.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>315010016.64000000</valUSD>
+        <pctVal>0.144658762585</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Vanguard Cmt Funds-Vanguard Market Liquidity Fund</name>
+        <lei>1I6HV0TLSTR3A4XQ6L78</lei>
+        <title>Vanguard Market Liquidity Fund</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="FAID" value="CMT001142"/>
+        </identifiers>
+        <balance>608034454.50000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>608034454.50000000</valUSD>
+        <pctVal>0.279221317263</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>STIV</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>International Flavors &amp; Fragrances Inc</name>
+        <lei>BZLRL03D3GPGMOGFO832</lei>
+        <title>INTL FLVR &amp; FRAG</title>
+        <cusip>459506101</cusip>
+        <identifiers>
+          <isin value="US4595061015"/>
+        </identifiers>
+        <balance>2238951.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>150882907.89000000</valUSD>
+        <pctVal>0.069288383218</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Hewlett Packard Enterprise Co</name>
+        <lei>549300BX44RGX6ANDV88</lei>
+        <title>HEWLETT PACKA</title>
+        <cusip>42824C109</cusip>
+        <identifiers>
+          <isin value="US42824C1099"/>
+        </identifiers>
+        <balance>12142498.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>291662801.96000000</valUSD>
+        <pctVal>0.133937264832</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Fiserv Inc</name>
+        <lei>GI7UBEJLXYLGR2C7GV83</lei>
+        <title>FISERV INC</title>
+        <cusip>337738108</cusip>
+        <identifiers>
+          <isin value="US3377381088"/>
+        </identifiers>
+        <balance>4949926.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>332486529.42000000</valUSD>
+        <pctVal>0.152684319169</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Fidelity National Information Services Inc</name>
+        <lei>6WQI0GK1PRFVBA061U48</lei>
+        <title>FIDELITY NATIONA</title>
+        <cusip>31620M106</cusip>
+        <identifiers>
+          <isin value="US31620M1062"/>
+        </identifiers>
+        <balance>4765916.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>316742777.36000000</valUSD>
+        <pctVal>0.145454480208</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Coca-Cola Co/The</name>
+        <lei>UWJKFUJFZ02DKWI3RY53</lei>
+        <title>COCA-COLA CO/THE</title>
+        <cusip>191216100</cusip>
+        <identifiers>
+          <isin value="US1912161007"/>
+        </identifiers>
+        <balance>31669039.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2213982516.49000000</valUSD>
+        <pctVal>1.016704086547</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Northern Trust Corp</name>
+        <lei>549300GLF98S992BC502</lei>
+        <title>NORTHERN TRUST</title>
+        <cusip>665859104</cusip>
+        <identifiers>
+          <isin value="US6658591044"/>
+        </identifiers>
+        <balance>1653337.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>225829300.83000000</valUSD>
+        <pctVal>0.103705233128</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Church &amp; Dwight Co Inc</name>
+        <lei>POOXSI30AWAQGYJZC921</lei>
+        <title>CHURCH &amp; DWIGHT</title>
+        <cusip>171340102</cusip>
+        <identifiers>
+          <isin value="US1713401024"/>
+        </identifiers>
+        <balance>2209918.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>185301624.30000000</valUSD>
+        <pctVal>0.085094131171</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Freeport-McMoRan Inc</name>
+        <lei>549300IRDTHJQ1PVET45</lei>
+        <title>FREEPORT-MCMORAN</title>
+        <cusip>35671D857</cusip>
+        <identifiers>
+          <isin value="US35671D8570"/>
+        </identifiers>
+        <balance>13214311.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>671154855.69000000</valUSD>
+        <pctVal>0.308207440394</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Abbott Laboratories</name>
+        <lei>HQD377W2YR662HK5JX27</lei>
+        <title>ABBOTT LABS</title>
+        <cusip>002824100</cusip>
+        <identifiers>
+          <isin value="US0028241000"/>
+        </identifiers>
+        <balance>16002232.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2004919647.28000000</valUSD>
+        <pctVal>0.920698326841</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Hershey Co/The</name>
+        <lei>21X2CX66SU2BR6QTAD08</lei>
+        <title>HERSHEY CO/THE</title>
+        <cusip>427866108</cusip>
+        <identifiers>
+          <isin value="US4278661081"/>
+        </identifiers>
+        <balance>1363575.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>248143378.50000000</valUSD>
+        <pctVal>0.113952294153</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Synchrony Financial</name>
+        <lei>549300RS7EWPM9MA6C78</lei>
+        <title>SYNCHRONY FINANC</title>
+        <cusip>87165B103</cusip>
+        <identifiers>
+          <isin value="US87165B1035"/>
+        </identifiers>
+        <balance>3314662.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>276542250.66000000</valUSD>
+        <pctVal>0.126993611853</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Crown Castle Inc</name>
+        <lei>54930012H97VSM0I2R19</lei>
+        <title>CROWN CASTLE INC</title>
+        <cusip>22822V101</cusip>
+        <identifiers>
+          <isin value="US22822V1017"/>
+        </identifiers>
+        <balance>4007563.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>356152123.81000000</valUSD>
+        <pctVal>0.163552023113</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Ulta Beauty Inc</name>
+        <lei>529900CIV6HN8M28YM82</lei>
+        <title>ULTA BEAUTY INC</title>
+        <cusip>90384S303</cusip>
+        <identifiers>
+          <isin value="US90384S3031"/>
+        </identifiers>
+        <balance>412624.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>249641646.24000000</valUSD>
+        <pctVal>0.114640328012</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Caterpillar Inc</name>
+        <lei>WRJR7GS4GTRECRRTVX92</lei>
+        <title>CATERPILLAR INC</title>
+        <cusip>149123101</cusip>
+        <identifiers>
+          <isin value="US1491231015"/>
+        </identifiers>
+        <balance>4306710.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2467184957.70000000</valUSD>
+        <pctVal>1.132979601274</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Williams Cos Inc/The</name>
+        <lei>D71FAKCBLFS2O0RBPG08</lei>
+        <title>WILLIAMS COS INC</title>
+        <cusip>969457100</cusip>
+        <identifiers>
+          <isin value="US9694571004"/>
+        </identifiers>
+        <balance>11238496.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>675545994.56000000</valUSD>
+        <pctVal>0.310223937273</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Carrier Global Corp</name>
+        <lei>549300JE3W6CWY2NAN77</lei>
+        <title>CARRIER GLOB</title>
+        <cusip>14448C104</cusip>
+        <identifiers>
+          <isin value="US14448C1045"/>
+        </identifiers>
+        <balance>7363015.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>389061712.60000000</valUSD>
+        <pctVal>0.178664750138</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Citigroup Inc</name>
+        <lei>6SHGI4ZSSLCXXQSBB395</lei>
+        <title>CITIGROUP INC</title>
+        <cusip>172967424</cusip>
+        <identifiers>
+          <isin value="US1729674242"/>
+        </identifiers>
+        <balance>15816050.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1845574874.50000000</valUSD>
+        <pctVal>0.847524089715</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>LyondellBasell Industries NV</name>
+        <lei>BN6WCCZ8OVP3ITUUVN49</lei>
+        <title>LYONDELLBASELL-A</title>
+        <cusip>N53745100</cusip>
+        <identifiers>
+          <isin value="NL0009434992"/>
+        </identifiers>
+        <balance>1184762.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>51300194.60000000</valUSD>
+        <pctVal>0.023558053011</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Intercontinental Exchange Inc</name>
+        <lei>5493000F4ZO33MV32P92</lei>
+        <title>INTERCONT EXCH I</title>
+        <cusip>45866F104</cusip>
+        <identifiers>
+          <isin value="US45866F1049"/>
+        </identifiers>
+        <balance>5247192.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>849835216.32000000</valUSD>
+        <pctVal>0.390260957748</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>NVR Inc</name>
+        <lei>529900RWXR4JI3JYTV70</lei>
+        <title>NVR INC</title>
+        <cusip>62944T105</cusip>
+        <identifiers>
+          <isin value="US62944T1051"/>
+        </identifiers>
+        <balance>24752.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>180510643.04000000</valUSD>
+        <pctVal>0.082894018844</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>QUALCOMM Inc</name>
+        <lei>H1J8DDZKZP6H7RWC0H53</lei>
+        <title>QUALCOMM INC</title>
+        <cusip>747525103</cusip>
+        <identifiers>
+          <isin value="US7475251036"/>
+        </identifiers>
+        <balance>9855995.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1685867944.75000000</valUSD>
+        <pctVal>0.774183543022</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Comcast Corp</name>
+        <lei>51M0QTTNCGUN7KFCFZ59</lei>
+        <title>COMCAST CORP-A</title>
+        <cusip>20030N101</cusip>
+        <identifiers>
+          <isin value="US20030N1019"/>
+        </identifiers>
+        <balance>33448389.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>999772347.21000000</valUSD>
+        <pctVal>0.459115021665</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Texas Instruments Inc</name>
+        <lei>WDJNR2L6D8RWOEB8T652</lei>
+        <title>TEXAS INSTRUMENT</title>
+        <cusip>882508104</cusip>
+        <identifiers>
+          <isin value="US8825081040"/>
+        </identifiers>
+        <balance>4180898.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>725343994.02000000</valUSD>
+        <pctVal>0.333092152887</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Marathon Petroleum Corp</name>
+        <lei>3BNYRYQHD39K4LCKQF12</lei>
+        <title>MARATHON PETROLE</title>
+        <cusip>56585A102</cusip>
+        <identifiers>
+          <isin value="US56585A1025"/>
+        </identifiers>
+        <balance>2766385.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>449897192.55000000</valUSD>
+        <pctVal>0.206601592733</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Kroger Co/The</name>
+        <lei>6CPEOKI6OYJ13Q6O7870</lei>
+        <title>KROGER CO</title>
+        <cusip>501044101</cusip>
+        <identifiers>
+          <isin value="US5010441013"/>
+        </identifiers>
+        <balance>4488559.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>280445166.32000000</valUSD>
+        <pctVal>0.128785907082</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Illinois Tool Works Inc</name>
+        <lei>76NA4I14SZCFAYMNSV04</lei>
+        <title>ILLINOIS TOOL WO</title>
+        <cusip>452308109</cusip>
+        <identifiers>
+          <isin value="US4523081093"/>
+        </identifiers>
+        <balance>2536288.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>624687734.40000000</valUSD>
+        <pctVal>0.286868829202</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>N/A</name>
+        <lei>N/A</lei>
+        <title>TRS:NETAPP INC USD 2026-Aug-31</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="CONTRACT_VANGUARD_ID" value="V1048177301"/>
+        </identifiers>
+        <balance>33343.00000000</balance>
+        <units>NC</units>
+        <curCd>USD</curCd>
+        <valUSD>-114033.06000000</valUSD>
+        <pctVal>-0.00005236621</pctVal>
+        <payoffProfile>N/A</payoffProfile>
+        <assetCat>DE</assetCat>
+        <issuerConditional desc="N/A" issuerCat="OTHER"/>
+        <invCountry>N/A</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>2</fairValLevel>
+        <derivativeInfo>
+          <swapDeriv derivCat="SWP">
+            <counterparties>
+              <counterpartyName>BANK OF AMERICA, N.A.</counterpartyName>
+              <counterpartyLei>B4TYDEB6GKMZO031MB27</counterpartyLei>
+            </counterparties>
+            <descRefInstrmnt>
+              <otherRefInst>
+                <issuerName>N/A</issuerName>
+                <issueTitle>NETAPP INC</issueTitle>
+                <identifiers>
+                  <cusip value="64110D104"/>
+                </identifiers>
+              </otherRefInst>
+            </descRefInstrmnt>
+            <swapFlag>Y</swapFlag>
+            <otherRecDesc fixedOrFloating="Other">Receive positive return on reference instrument</otherRecDesc>
+            <floatingPmntDesc curCd="USD" fixedOrFloating="Floating" floatingRtIndex="OBFR01" floatingRtSpread="0.00000000" pmntAmt="0.00000000">
+              <rtResetTenors>
+                <rtResetTenor rateTenor="Day" rateTenorUnit="243" resetDt="Month" resetDtUnit="1"/>
+              </rtResetTenors>
+            </floatingPmntDesc>
+            <terminationDt>2026-08-31</terminationDt>
+            <upfrontPmnt>0.00000000</upfrontPmnt>
+            <pmntCurCd>USD</pmntCurCd>
+            <upfrontRcpt>0.00000000</upfrontRcpt>
+            <rcptCurCd>USD</rcptCurCd>
+            <notionalAmt>3684734.93000000</notionalAmt>
+            <curCd>USD</curCd>
+            <unrealizedAppr>-114033.06000000</unrealizedAppr>
+          </swapDeriv>
+        </derivativeInfo>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Snap-on Inc</name>
+        <lei>HHWAT5TDOYZMM26KKQ73</lei>
+        <title>SNAP-ON INC</title>
+        <cusip>833034101</cusip>
+        <identifiers>
+          <isin value="US8330341012"/>
+        </identifiers>
+        <balance>478686.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>164955195.60000000</valUSD>
+        <pctVal>0.075750653049</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>CenterPoint Energy Inc</name>
+        <lei>21TPXMRRHFKOBHDC8J74</lei>
+        <title>CENTERPOINT ENER</title>
+        <cusip>15189T107</cusip>
+        <identifiers>
+          <isin value="US15189T1079"/>
+        </identifiers>
+        <balance>6008163.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>230352969.42000000</valUSD>
+        <pctVal>0.105782590247</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Broadridge Financial Solutions Inc</name>
+        <lei>549300KZDJZQ2YIHRC28</lei>
+        <title>BROADRIDGE FINL</title>
+        <cusip>11133T103</cusip>
+        <identifiers>
+          <isin value="US11133T1034"/>
+        </identifiers>
+        <balance>537137.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>119872864.29000000</valUSD>
+        <pctVal>0.055047964508</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Zoetis Inc</name>
+        <lei>549300HD9Q1LOC9KLJ48</lei>
+        <title>ZOETIS INC</title>
+        <cusip>98978V103</cusip>
+        <identifiers>
+          <isin value="US98978V1035"/>
+        </identifiers>
+        <balance>1825000.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>229621500.00000000</valUSD>
+        <pctVal>0.105446685179</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Medline Inc</name>
+        <lei>984500FAN6J1P8566D43</lei>
+        <title>MEDLINE INC-A</title>
+        <cusip>58507V107</cusip>
+        <identifiers>
+          <isin value="US58507V1070"/>
+        </identifiers>
+        <balance>1895379.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>79605918.00000000</valUSD>
+        <pctVal>0.036556594978</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Mid-America Apartment Communities Inc</name>
+        <lei>549300FQZKFR5YNSHZ21</lei>
+        <title>MID-AMERICA APAR</title>
+        <cusip>59522J103</cusip>
+        <identifiers>
+          <isin value="US59522J1034"/>
+        </identifiers>
+        <balance>538805.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>74845402.55000000</valUSD>
+        <pctVal>0.034370473147</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Diamondback Energy Inc</name>
+        <lei>549300R22LSX6OHWEN64</lei>
+        <title>DIAMONDBACK ENER</title>
+        <cusip>25278X109</cusip>
+        <identifiers>
+          <isin value="US25278X1090"/>
+        </identifiers>
+        <balance>1713941.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>257656750.53000000</valUSD>
+        <pctVal>0.118321020712</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Berkshire Hathaway Inc</name>
+        <lei>5493000C01ZX7D35SD85</lei>
+        <title>BERKSHIRE HATH-B</title>
+        <cusip>084670702</cusip>
+        <identifiers>
+          <isin value="US0846707026"/>
+        </identifiers>
+        <balance>14366543.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>7221342838.95000000</valUSD>
+        <pctVal>3.316181912024</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Kinder Morgan Inc</name>
+        <lei>549300WR7IX8XE0TBO16</lei>
+        <title>KINDER MORGAN IN</title>
+        <cusip>49456B101</cusip>
+        <identifiers>
+          <isin value="US49456B1017"/>
+        </identifiers>
+        <balance>17402732.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>478401102.68000000</valUSD>
+        <pctVal>0.219691145924</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Verizon Communications Inc</name>
+        <lei>2S72QS2UO2OESLG6Y829</lei>
+        <title>VERIZON COMMUNIC</title>
+        <cusip>92343V104</cusip>
+        <identifiers>
+          <isin value="US92343V1044"/>
+        </identifiers>
+        <balance>34922396.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1422389189.08000000</valUSD>
+        <pctVal>0.653188943646</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Philip Morris International Inc</name>
+        <lei>HL3H1H2BGXWVG3BSWR90</lei>
+        <title>PHILIP MORRIS IN</title>
+        <cusip>718172109</cusip>
+        <identifiers>
+          <isin value="US7181721090"/>
+        </identifiers>
+        <balance>14325298.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2297777799.20000000</valUSD>
+        <pctVal>1.055184519762</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Agilent Technologies Inc</name>
+        <lei>QUIX8Y7A2WP0XRMW7G29</lei>
+        <title>AGILENT TECH INC</title>
+        <cusip>00846U101</cusip>
+        <identifiers>
+          <isin value="US00846U1016"/>
+        </identifiers>
+        <balance>2604819.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>354437721.33000000</valUSD>
+        <pctVal>0.162764735953</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>TransUnion</name>
+        <lei>549300ZS772LUNUMRB03</lei>
+        <title>TRANSUNION</title>
+        <cusip>89400J107</cusip>
+        <identifiers>
+          <isin value="US89400J1079"/>
+        </identifiers>
+        <balance>893626.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>76628429.50000000</valUSD>
+        <pctVal>0.035189274006</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>McKesson Corp</name>
+        <lei>549300WZWOM80UCFSF54</lei>
+        <title>MCKESSON CORP</title>
+        <cusip>58155Q103</cusip>
+        <identifiers>
+          <isin value="US58155Q1031"/>
+        </identifiers>
+        <balance>1135858.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>931732958.82000000</valUSD>
+        <pctVal>0.427870003375</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Edwards Lifesciences Corp</name>
+        <lei>YA13X31F3V31L8TMPR58</lei>
+        <title>EDWARDS LIFE</title>
+        <cusip>28176E108</cusip>
+        <identifiers>
+          <isin value="US28176E1082"/>
+        </identifiers>
+        <balance>5340299.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>455260489.75000000</valUSD>
+        <pctVal>0.209064523737</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Lockheed Martin Corp</name>
+        <lei>DPRBOZP0K5RM2YE8UU08</lei>
+        <title>LOCKHEED MARTIN</title>
+        <cusip>539830109</cusip>
+        <identifiers>
+          <isin value="US5398301094"/>
+        </identifiers>
+        <balance>2129506.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1029978167.02000000</valUSD>
+        <pctVal>0.472986125077</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Realty Income Corp</name>
+        <lei>549300CUWDAUZSH43859</lei>
+        <title>REALTY INCOME</title>
+        <cusip>756109104</cusip>
+        <identifiers>
+          <isin value="US7561091049"/>
+        </identifiers>
+        <balance>4232877.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>238607276.49000000</valUSD>
+        <pctVal>0.109573129543</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Baker Hughes Co</name>
+        <lei>N/A</lei>
+        <title>BAKER HUGHES CO</title>
+        <cusip>05722G100</cusip>
+        <identifiers>
+          <isin value="US05722G1004"/>
+        </identifiers>
+        <balance>9080846.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>413541726.84000000</valUSD>
+        <pctVal>0.189906451611</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Strategy Inc</name>
+        <lei>549300WQTWEJUEHXQX21</lei>
+        <title>STRATEGY INC</title>
+        <cusip>594972408</cusip>
+        <identifiers>
+          <isin value="US5949724083"/>
+        </identifiers>
+        <balance>1231829.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>187176416.55000000</valUSD>
+        <pctVal>0.085955072451</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Teledyne Technologies Inc</name>
+        <lei>549300VSMO9KYQWDND94</lei>
+        <title>TELEDYNE TECH</title>
+        <cusip>879360105</cusip>
+        <identifiers>
+          <isin value="US8793601050"/>
+        </identifiers>
+        <balance>432011.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>220640978.03000000</valUSD>
+        <pctVal>0.101322653793</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Charter Communications Inc</name>
+        <lei>0J0XRGZE3PBRFEZ7MV65</lei>
+        <title>CHARTER COMMUN-A</title>
+        <cusip>16119P108</cusip>
+        <identifiers>
+          <isin value="US16119P1084"/>
+        </identifiers>
+        <balance>774205.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>161615293.75000000</valUSD>
+        <pctVal>0.074216904776</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Coterra Energy Inc</name>
+        <lei>FCNMH6O7VWU7LHXMK351</lei>
+        <title>COTERRA ENERGY I</title>
+        <cusip>127097103</cusip>
+        <identifiers>
+          <isin value="US1270971039"/>
+        </identifiers>
+        <balance>3328221.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>87598776.72000000</valUSD>
+        <pctVal>0.040227072076</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Carnival Corp</name>
+        <lei>F1OF2ZSX47CR0BCWA982</lei>
+        <title>CARNIVAL CORP</title>
+        <cusip>143658300</cusip>
+        <identifiers>
+          <isin value="PA1436583006"/>
+        </identifiers>
+        <balance>9670078.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>295324182.12000000</valUSD>
+        <pctVal>0.135618642234</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Accenture PLC</name>
+        <lei>5493000EWHDSR3MZWH98</lei>
+        <title>ACCENTURE PLC-A</title>
+        <cusip>G1151C101</cusip>
+        <identifiers>
+          <isin value="IE00B4BNMY34"/>
+        </identifiers>
+        <balance>5731933.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1537877623.90000000</valUSD>
+        <pctVal>0.706223492364</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>L3Harris Technologies Inc</name>
+        <lei>549300UTE50ZMDBG8A20</lei>
+        <title>L3HARRIS TECHNOL</title>
+        <cusip>502431109</cusip>
+        <identifiers>
+          <isin value="US5024311095"/>
+        </identifiers>
+        <balance>1721410.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>505354333.70000000</valUSD>
+        <pctVal>0.232068596929</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cboe Global Markets Inc</name>
+        <lei>529900RLNSGA90UPEH54</lei>
+        <title>CBOE GLOBAL MARK</title>
+        <cusip>12503M108</cusip>
+        <identifiers>
+          <isin value="US12503M1080"/>
+        </identifiers>
+        <balance>962997.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>241712247.00000000</valUSD>
+        <pctVal>0.110998992748</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Exxon Mobil Corp</name>
+        <lei>J3WHBG0MTS7O8ZVMDC91</lei>
+        <title>EXXON MOBIL CORP</title>
+        <cusip>30231G102</cusip>
+        <identifiers>
+          <isin value="US30231G1022"/>
+        </identifiers>
+        <balance>38809148.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>4670292870.32000000</valUSD>
+        <pctVal>2.144689856971</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Danaher Corp</name>
+        <lei>S4BKK9OTCEWQ3YHPFM11</lei>
+        <title>DANAHER CORP</title>
+        <cusip>235851102</cusip>
+        <identifiers>
+          <isin value="US2358511028"/>
+        </identifiers>
+        <balance>5850210.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1339230073.20000000</valUSD>
+        <pctVal>0.615000650686</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Allstate Corp/The</name>
+        <lei>OBT0W1ED8G0NWVOLOJ77</lei>
+        <title>ALLSTATE CORP</title>
+        <cusip>020002101</cusip>
+        <identifiers>
+          <isin value="US0200021014"/>
+        </identifiers>
+        <balance>2408163.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>501259128.45000000</valUSD>
+        <pctVal>0.230187998558</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Dollar Tree Inc</name>
+        <lei>549300PMSTQITB1WHR43</lei>
+        <title>DOLLAR TREE INC</title>
+        <cusip>256746108</cusip>
+        <identifiers>
+          <isin value="US2567461080"/>
+        </identifiers>
+        <balance>1783169.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>219347618.69000000</valUSD>
+        <pctVal>0.100728717880</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Corebridge Financial Inc</name>
+        <lei>549300XY1661QCIA7J65</lei>
+        <title>COREBRIDGE FINAN</title>
+        <cusip>21871X109</cusip>
+        <identifiers>
+          <isin value="US21871X1090"/>
+        </identifiers>
+        <balance>1275762.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>38489739.54000000</valUSD>
+        <pctVal>0.017675241420</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Hubbell Inc</name>
+        <lei>54930088VDQ6840Y6597</lei>
+        <title>HUBBELL INC</title>
+        <cusip>443510607</cusip>
+        <identifiers>
+          <isin value="US4435106079"/>
+        </identifiers>
+        <balance>244477.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>108574680.47000000</valUSD>
+        <pctVal>0.049859617457</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Iron Mountain Inc</name>
+        <lei>SQL3F6CKNNBM3SQGHX24</lei>
+        <title>IRON MOUNTAIN</title>
+        <cusip>46284V101</cusip>
+        <identifiers>
+          <isin value="US46284V1017"/>
+        </identifiers>
+        <balance>2584218.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>214360883.10000000</valUSD>
+        <pctVal>0.098438711336</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Martin Marietta Materials Inc</name>
+        <lei>5299005MZ4WZECVATV08</lei>
+        <title>MARTIN MAR MTLS</title>
+        <cusip>573284106</cusip>
+        <identifiers>
+          <isin value="US5732841060"/>
+        </identifiers>
+        <balance>277491.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>172782546.06000000</valUSD>
+        <pctVal>0.079345125516</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Northrop Grumman Corp</name>
+        <lei>RIMU48P07456QXSO0R61</lei>
+        <title>NORTHROP GRUMMAN</title>
+        <cusip>666807102</cusip>
+        <identifiers>
+          <isin value="US6668071029"/>
+        </identifiers>
+        <balance>1313427.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>748929209.67000000</valUSD>
+        <pctVal>0.343922945341</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Truist Financial Corp</name>
+        <lei>549300DRQQI75D2JP341</lei>
+        <title>TRUIST FINANCIAL</title>
+        <cusip>89832Q109</cusip>
+        <identifiers>
+          <isin value="US89832Q1094"/>
+        </identifiers>
+        <balance>11772538.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>579326594.98000000</valUSD>
+        <pctVal>0.266038106522</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Chevron Corp</name>
+        <lei>N/A</lei>
+        <title>CHEVRON CORP</title>
+        <cusip>166764100</cusip>
+        <identifiers>
+          <isin value="US1667641005"/>
+        </identifiers>
+        <balance>17603290.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2682917428.90000000</valUSD>
+        <pctVal>1.232048172700</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>WEC Energy Group Inc</name>
+        <lei>549300IGLYTZUK3PVP70</lei>
+        <title>WEC ENERGY GROUP</title>
+        <cusip>92939U106</cusip>
+        <identifiers>
+          <isin value="US92939U1060"/>
+        </identifiers>
+        <balance>2993646.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>315709907.16000000</valUSD>
+        <pctVal>0.144980166005</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>RTX Corp</name>
+        <lei>I07WOS4YJ0N7YRFE7309</lei>
+        <title>RTX CORP</title>
+        <cusip>75513E101</cusip>
+        <identifiers>
+          <isin value="US75513E1010"/>
+        </identifiers>
+        <balance>12338668.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2262911711.20000000</valUSD>
+        <pctVal>1.039173330022</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Public Service Enterprise Group Inc</name>
+        <lei>PUSS41EMO3E6XXNV3U28</lei>
+        <title>PUB SERV ENTERP</title>
+        <cusip>744573106</cusip>
+        <identifiers>
+          <isin value="US7445731067"/>
+        </identifiers>
+        <balance>4593520.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>368859656.00000000</valUSD>
+        <pctVal>0.169387570509</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Packaging Corp of America</name>
+        <lei>549300XZP8MFZFY8TJ84</lei>
+        <title>PACKAGING CORP</title>
+        <cusip>695156109</cusip>
+        <identifiers>
+          <isin value="US6951561090"/>
+        </identifiers>
+        <balance>828008.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>170760089.84000000</valUSD>
+        <pctVal>0.078416374052</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>CDW Corp/DE</name>
+        <lei>9845001B052ABF0B6755</lei>
+        <title>CDW CORP/DE</title>
+        <cusip>12514G108</cusip>
+        <identifiers>
+          <isin value="US12514G1085"/>
+        </identifiers>
+        <balance>1198083.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>163178904.60000000</valUSD>
+        <pctVal>0.074934945470</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>United Parcel Service Inc</name>
+        <lei>D01LMJZU09ULLNCY6Z23</lei>
+        <title>UNITED PARCEL-B</title>
+        <cusip>911312106</cusip>
+        <identifiers>
+          <isin value="US9113121068"/>
+        </identifiers>
+        <balance>6800590.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>674550522.10000000</valUSD>
+        <pctVal>0.309766796844</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Keurig Dr Pepper Inc</name>
+        <lei>DYTQ8KRTKO7Y2BVU5K74</lei>
+        <title>KEURIG DR PEPPER</title>
+        <cusip>49271V100</cusip>
+        <identifiers>
+          <isin value="US49271V1008"/>
+        </identifiers>
+        <balance>11877313.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>332683537.13000000</valUSD>
+        <pctVal>0.152774788964</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>General Electric Co</name>
+        <lei>3C7474T6CDKPR9K6YT90</lei>
+        <title>GENERAL ELECTRIC</title>
+        <cusip>369604301</cusip>
+        <identifiers>
+          <isin value="US3696043013"/>
+        </identifiers>
+        <balance>4610834.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1420275197.02000000</valUSD>
+        <pctVal>0.652218157134</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>HP Inc</name>
+        <lei>WHKXQACZ14C5XRO8LW03</lei>
+        <title>HP INC</title>
+        <cusip>40434L105</cusip>
+        <identifiers>
+          <isin value="US40434L1052"/>
+        </identifiers>
+        <balance>8601686.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>191645564.08000000</valUSD>
+        <pctVal>0.088007392433</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Becton Dickinson &amp; Co</name>
+        <lei>ICE2EP6D98PQUILVRZ91</lei>
+        <title>BECTON DICKINSON</title>
+        <cusip>075887109</cusip>
+        <identifiers>
+          <isin value="US0758871091"/>
+        </identifiers>
+        <balance>2626664.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>509756682.48000000</valUSD>
+        <pctVal>0.234090241617</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Travelers Cos Inc/The</name>
+        <lei>549300Y650407RU8B149</lei>
+        <title>TRAVELERS COS IN</title>
+        <cusip>89417E109</cusip>
+        <identifiers>
+          <isin value="US89417E1091"/>
+        </identifiers>
+        <balance>2052770.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>595426466.20000000</valUSD>
+        <pctVal>0.273431482369</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>International Business Machines Corp</name>
+        <lei>VGRQXHF3J8VDLUA7XE92</lei>
+        <title>IBM</title>
+        <cusip>459200101</cusip>
+        <identifiers>
+          <isin value="US4592001014"/>
+        </identifiers>
+        <balance>8602069.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2548018858.49000000</valUSD>
+        <pctVal>1.170100109974</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Morgan Stanley</name>
+        <lei>IGJSJL3JD5P30I6NJZ34</lei>
+        <title>MORGAN STANLEY</title>
+        <cusip>617446448</cusip>
+        <identifiers>
+          <isin value="US6174464486"/>
+        </identifiers>
+        <balance>10969449.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1947406280.97000000</valUSD>
+        <pctVal>0.894287063824</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Warner Bros Discovery Inc</name>
+        <lei>5493006ZCRFWKF6B1K26</lei>
+        <title>WARNER BROS DISC</title>
+        <cusip>934423104</cusip>
+        <identifiers>
+          <isin value="US9344231041"/>
+        </identifiers>
+        <balance>21664035.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>624357488.70000000</valUSD>
+        <pctVal>0.286717173916</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Corning Inc</name>
+        <lei>549300X2937PB0CJ7I56</lei>
+        <title>CORNING INC</title>
+        <cusip>219350105</cusip>
+        <identifiers>
+          <isin value="US2193501051"/>
+        </identifiers>
+        <balance>7100969.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>621760845.64000000</valUSD>
+        <pctVal>0.285524744621</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>N/A</name>
+        <lei>N/A</lei>
+        <title>TRS:JPMORGAN CHASE &amp; CO USD 2027-Aug-31</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="CONTRACT_VANGUARD_ID" value="V1048207601"/>
+        </identifiers>
+        <balance>1000000.00000000</balance>
+        <units>NC</units>
+        <curCd>USD</curCd>
+        <valUSD>-5690000.00000000</valUSD>
+        <pctVal>-0.00261295932</pctVal>
+        <payoffProfile>N/A</payoffProfile>
+        <assetCat>DE</assetCat>
+        <issuerConditional desc="N/A" issuerCat="OTHER"/>
+        <invCountry>N/A</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>2</fairValLevel>
+        <derivativeInfo>
+          <swapDeriv derivCat="SWP">
+            <counterparties>
+              <counterpartyName>BANK OF AMERICA, N.A.</counterpartyName>
+              <counterpartyLei>B4TYDEB6GKMZO031MB27</counterpartyLei>
+            </counterparties>
+            <descRefInstrmnt>
+              <otherRefInst>
+                <issuerName>N/A</issuerName>
+                <issueTitle>JPMORGAN CHASE</issueTitle>
+                <identifiers>
+                  <cusip value="46625H100"/>
+                </identifiers>
+              </otherRefInst>
+            </descRefInstrmnt>
+            <swapFlag>Y</swapFlag>
+            <otherRecDesc fixedOrFloating="Other">Receive positive return on reference instrument</otherRecDesc>
+            <floatingPmntDesc curCd="USD" fixedOrFloating="Floating" floatingRtIndex="OBFR01" floatingRtSpread="0.00000000" pmntAmt="0.00000000">
+              <rtResetTenors>
+                <rtResetTenor rateTenor="Day" rateTenorUnit="608" resetDt="Month" resetDtUnit="1"/>
+              </rtResetTenors>
+            </floatingPmntDesc>
+            <terminationDt>2027-08-31</terminationDt>
+            <upfrontPmnt>0.00000000</upfrontPmnt>
+            <pmntCurCd>USD</pmntCurCd>
+            <upfrontRcpt>0.00000000</upfrontRcpt>
+            <rcptCurCd>USD</rcptCurCd>
+            <notionalAmt>327910000.00000000</notionalAmt>
+            <curCd>USD</curCd>
+            <unrealizedAppr>-5690000.00000000</unrealizedAppr>
+          </swapDeriv>
+        </derivativeInfo>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>EOG Resources Inc</name>
+        <lei>XWTZDRYZPBUHIQBKDB46</lei>
+        <title>EOG RESOURCES</title>
+        <cusip>26875P101</cusip>
+        <identifiers>
+          <isin value="US26875P1012"/>
+        </identifiers>
+        <balance>4993422.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>524359244.22000000</valUSD>
+        <pctVal>0.240796023657</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Global Payments Inc</name>
+        <lei>549300NOMHGVQBX6S778</lei>
+        <title>GLOBAL PAYMENTS</title>
+        <cusip>37940X102</cusip>
+        <identifiers>
+          <isin value="US37940X1028"/>
+        </identifiers>
+        <balance>2178921.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>168648485.40000000</valUSD>
+        <pctVal>0.077446683981</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>FedEx Corp</name>
+        <lei>549300E707U7WNPZN687</lei>
+        <title>FEDEX CORP</title>
+        <cusip>31428X106</cusip>
+        <identifiers>
+          <isin value="US31428X1063"/>
+        </identifiers>
+        <balance>1954289.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>564515920.54000000</valUSD>
+        <pctVal>0.259236755059</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Edison International</name>
+        <lei>549300I7ROF15MAEVP56</lei>
+        <title>EDISON INTL</title>
+        <cusip>281020107</cusip>
+        <identifiers>
+          <isin value="US2810201077"/>
+        </identifiers>
+        <balance>3541039.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>212533160.78000000</valUSD>
+        <pctVal>0.097599385488</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Devon Energy Corp</name>
+        <lei>54930042348RKR3ZPN35</lei>
+        <title>DEVON ENERGY CO</title>
+        <cusip>25179M103</cusip>
+        <identifiers>
+          <isin value="US25179M1036"/>
+        </identifiers>
+        <balance>5772807.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>211457920.41000000</valUSD>
+        <pctVal>0.097105614074</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Micron Technology Inc</name>
+        <lei>B3DXGBC8GAIYWI2Z0172</lei>
+        <title>MICRON TECH</title>
+        <cusip>595112103</cusip>
+        <identifiers>
+          <isin value="US5951121038"/>
+        </identifiers>
+        <balance>10356144.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2955747059.04000000</valUSD>
+        <pctVal>1.357336876576</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>CVS Health Corp</name>
+        <lei>549300EJG376EN5NQE29</lei>
+        <title>CVS HEALTH CORP</title>
+        <cusip>126650100</cusip>
+        <identifiers>
+          <isin value="US1266501006"/>
+        </identifiers>
+        <balance>11682169.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>927096931.84000000</valUSD>
+        <pctVal>0.425741049085</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Motorola Solutions Inc</name>
+        <lei>6S552MUG6KGJVEBSEC55</lei>
+        <title>MOTOROLA SOLUTIO</title>
+        <cusip>620076307</cusip>
+        <identifiers>
+          <isin value="US6200763075"/>
+        </identifiers>
+        <balance>766397.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>293775298.04000000</valUSD>
+        <pctVal>0.134907364362</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Applied Materials Inc</name>
+        <lei>41BNNE1AFPNAZELZ6K07</lei>
+        <title>APPLIED MATERIAL</title>
+        <cusip>038222105</cusip>
+        <identifiers>
+          <isin value="US0382221051"/>
+        </identifiers>
+        <balance>3665574.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>942015862.26000000</valUSD>
+        <pctVal>0.432592113812</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Fortive Corp</name>
+        <lei>549300MU9YQJYHDQEF63</lei>
+        <title>FORTIVE CORP</title>
+        <cusip>34959J108</cusip>
+        <identifiers>
+          <isin value="US34959J1088"/>
+        </identifiers>
+        <balance>2922969.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>161377118.49000000</valUSD>
+        <pctVal>0.074107530037</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Norfolk Southern Corp</name>
+        <lei>54930036C8MWP850MI84</lei>
+        <title>NORFOLK SOUTHERN</title>
+        <cusip>655844108</cusip>
+        <identifiers>
+          <isin value="US6558441084"/>
+        </identifiers>
+        <balance>2064941.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>596189765.52000000</valUSD>
+        <pctVal>0.273782004350</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Garmin Ltd</name>
+        <lei>2549001E0HIPIJQ0W046</lei>
+        <title>GARMIN LTD</title>
+        <cusip>H2906T109</cusip>
+        <identifiers>
+          <isin value="CH0114405324"/>
+        </identifiers>
+        <balance>1504495.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>305186810.75000000</valUSD>
+        <pctVal>0.140147754256</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>JPMorgan Chase &amp; Co</name>
+        <lei>8I5DZWZKVSZI1NUHU748</lei>
+        <title>JPMORGAN CHASE</title>
+        <cusip>46625H100</cusip>
+        <identifiers>
+          <isin value="US46625H1005"/>
+        </identifiers>
+        <balance>24052035.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>7750046717.70000000</valUSD>
+        <pctVal>3.558973076857</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Centene Corp</name>
+        <lei>549300Z7JJ4TQSQGT333</lei>
+        <title>CENTENE CORP</title>
+        <cusip>15135B101</cusip>
+        <identifiers>
+          <isin value="US15135B1017"/>
+        </identifiers>
+        <balance>2261685.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>93068337.75000000</valUSD>
+        <pctVal>0.042738801509</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Delta Air Lines Inc</name>
+        <lei>Q2CCMS6R0AS67HJMBN42</lei>
+        <title>DELTA AIR LI</title>
+        <cusip>247361702</cusip>
+        <identifiers>
+          <isin value="US2473617023"/>
+        </identifiers>
+        <balance>6009020.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>417025988.00000000</valUSD>
+        <pctVal>0.191506492503</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Wells Fargo &amp; Co</name>
+        <lei>PBLD0EJDB5FWOLXP3B76</lei>
+        <title>WELLS FARGO &amp; CO</title>
+        <cusip>949746101</cusip>
+        <identifiers>
+          <isin value="US9497461015"/>
+        </identifiers>
+        <balance>28887857.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2692348272.40000000</valUSD>
+        <pctVal>1.236379000543</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Sysco Corp</name>
+        <lei>5RGWIFLMGH3YS7KWI652</lei>
+        <title>SYSCO CORP</title>
+        <cusip>871829107</cusip>
+        <identifiers>
+          <isin value="US8718291078"/>
+        </identifiers>
+        <balance>4406792.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>324736502.48000000</valUSD>
+        <pctVal>0.149125355174</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Essex Property Trust Inc</name>
+        <lei>549300TR2H2VEFX0NC60</lei>
+        <title>ESSEX PROPERTY</title>
+        <cusip>297178105</cusip>
+        <identifiers>
+          <isin value="US2971781057"/>
+        </identifiers>
+        <balance>296418.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>77566662.24000000</valUSD>
+        <pctVal>0.035620128836</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>PPL Corp</name>
+        <lei>9N3UAJSNOUXFKQLF3V18</lei>
+        <title>PPL CORP</title>
+        <cusip>69351T106</cusip>
+        <identifiers>
+          <isin value="US69351T1060"/>
+        </identifiers>
+        <balance>6467038.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>226475670.76000000</valUSD>
+        <pctVal>0.104002058846</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Paychex Inc</name>
+        <lei>529900K900DW6SUBM174</lei>
+        <title>PAYCHEX INC</title>
+        <cusip>704326107</cusip>
+        <identifiers>
+          <isin value="US7043261079"/>
+        </identifiers>
+        <balance>1490396.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>167192623.28000000</valUSD>
+        <pctVal>0.076778123613</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cardinal Health Inc</name>
+        <lei>CCU46N3GJMF4OK4N7U60</lei>
+        <title>CARDINAL HEALTH</title>
+        <cusip>14149Y108</cusip>
+        <identifiers>
+          <isin value="US14149Y1082"/>
+        </identifiers>
+        <balance>2186498.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>449325339.00000000</valUSD>
+        <pctVal>0.206338986395</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>STERIS PLC</name>
+        <lei>N/A</lei>
+        <title>STERIS PLC</title>
+        <cusip>G8473T100</cusip>
+        <identifiers>
+          <isin value="IE00BFY8C754"/>
+        </identifiers>
+        <balance>903253.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>228992700.56000000</valUSD>
+        <pctVal>0.105157928174</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Bank of America Corp</name>
+        <lei>9DJT3UXIJIZJI4WXO774</lei>
+        <title>BANK OF AMERICA</title>
+        <cusip>060505104</cusip>
+        <identifiers>
+          <isin value="US0605051046"/>
+        </identifiers>
+        <balance>58482155.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>3216518525.00000000</valUSD>
+        <pctVal>1.477088235551</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>AMETEK Inc</name>
+        <lei>549300WZDEF9KKE40E98</lei>
+        <title>AMETEK INC</title>
+        <cusip>031100100</cusip>
+        <identifiers>
+          <isin value="US0311001004"/>
+        </identifiers>
+        <balance>2118544.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>434958268.64000000</valUSD>
+        <pctVal>0.199741346605</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Leidos Holdings Inc</name>
+        <lei>549300IUTGTP6EJP8124</lei>
+        <title>LEIDOS HOLDINGS</title>
+        <cusip>525327102</cusip>
+        <identifiers>
+          <isin value="US5253271028"/>
+        </identifiers>
+        <balance>588317.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>106132386.80000000</valUSD>
+        <pctVal>0.048738068422</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>DTE Energy Co</name>
+        <lei>549300IX8SD6XXD71I78</lei>
+        <title>DTE ENERGY CO</title>
+        <cusip>233331107</cusip>
+        <identifiers>
+          <isin value="US2333311072"/>
+        </identifiers>
+        <balance>1624619.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>209543358.62000000</valUSD>
+        <pctVal>0.096226409843</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Archer-Daniels-Midland Co</name>
+        <lei>549300LO13MQ9HYSTR83</lei>
+        <title>ARCHER-DANIELS</title>
+        <cusip>039483102</cusip>
+        <identifiers>
+          <isin value="US0394831020"/>
+        </identifiers>
+        <balance>4422513.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>254250272.37000000</valUSD>
+        <pctVal>0.116756699295</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Jacobs Solutions Inc</name>
+        <lei>254900E3KHXCC2C8K272</lei>
+        <title>JACOBS SOLUTIONS</title>
+        <cusip>46982L108</cusip>
+        <identifiers>
+          <isin value="US46982L1089"/>
+        </identifiers>
+        <balance>546417.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>72378395.82000000</valUSD>
+        <pctVal>0.033237575391</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Humana Inc</name>
+        <lei>529900YLDW34GJAO4J06</lei>
+        <title>HUMANA INC</title>
+        <cusip>444859102</cusip>
+        <identifiers>
+          <isin value="US4448591028"/>
+        </identifiers>
+        <balance>1106787.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>283481354.31000000</valUSD>
+        <pctVal>0.130180184007</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>PepsiCo Inc</name>
+        <lei>FJSUNZKFNQ5YPJ5OT455</lei>
+        <title>PEPSICO INC</title>
+        <cusip>713448108</cusip>
+        <identifiers>
+          <isin value="US7134481081"/>
+        </identifiers>
+        <balance>12583098.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1805926224.96000000</valUSD>
+        <pctVal>0.829316654149</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Lennar Corp</name>
+        <lei>529900G61XVRLX5TJX09</lei>
+        <title>LENNAR CORP-A</title>
+        <cusip>526057104</cusip>
+        <identifiers>
+          <isin value="US5260571048"/>
+        </identifiers>
+        <balance>1950189.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>200479429.20000000</valUSD>
+        <pctVal>0.092064076124</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Johnson Controls International plc</name>
+        <lei>549300XQ6S1GYKGBL205</lei>
+        <title>JOHNSON CONTROLS</title>
+        <cusip>G51502105</cusip>
+        <identifiers>
+          <isin value="IE00BY7QL619"/>
+        </identifiers>
+        <balance>5624083.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>673483939.25000000</valUSD>
+        <pctVal>0.309277001132</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Gilead Sciences Inc</name>
+        <lei>549300WTZWR07K8MNV44</lei>
+        <title>GILEAD SCIENCES</title>
+        <cusip>375558103</cusip>
+        <identifiers>
+          <isin value="US3755581036"/>
+        </identifiers>
+        <balance>11417591.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1401395119.34000000</valUSD>
+        <pctVal>0.643548056088</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>NetApp Inc</name>
+        <lei>QTX3D84DZDD5JYOCYH15</lei>
+        <title>NETAPP INC</title>
+        <cusip>64110D104</cusip>
+        <identifiers>
+          <isin value="US64110D1046"/>
+        </identifiers>
+        <balance>1789347.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>191621170.23000000</valUSD>
+        <pctVal>0.087996190299</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Southwest Airlines Co</name>
+        <lei>UDTZ87G0STFETI6HGH41</lei>
+        <title>SOUTHWEST AIR</title>
+        <cusip>844741108</cusip>
+        <identifiers>
+          <isin value="US8447411088"/>
+        </identifiers>
+        <balance>4759284.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>196701207.72000000</valUSD>
+        <pctVal>0.090329042902</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>UnitedHealth Group Inc</name>
+        <lei>549300GHBMY8T5GXDE41</lei>
+        <title>UNITEDHEALTH GRP</title>
+        <cusip>91324P102</cusip>
+        <identifiers>
+          <isin value="US91324P1021"/>
+        </identifiers>
+        <balance>8336111.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2751833602.21000000</valUSD>
+        <pctVal>1.263695827779</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Exelon Corp</name>
+        <lei>3SOUA6IRML7435B56G12</lei>
+        <title>EXELON CORP</title>
+        <cusip>30161N101</cusip>
+        <identifiers>
+          <isin value="US30161N1019"/>
+        </identifiers>
+        <balance>9290278.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>404963218.02000000</valUSD>
+        <pctVal>0.185967032528</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Simon Property Group Inc</name>
+        <lei>529900GQL5X8H7AO3T64</lei>
+        <title>SIMON PROPERTY</title>
+        <cusip>828806109</cusip>
+        <identifiers>
+          <isin value="US8288061091"/>
+        </identifiers>
+        <balance>2854153.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>528332261.83000000</valUSD>
+        <pctVal>0.242620511073</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>F&amp;G Annuities &amp; Life Inc</name>
+        <lei>N/A</lei>
+        <title>F&amp;G ANNUITIES</title>
+        <cusip>30190A104</cusip>
+        <identifiers>
+          <isin value="US30190A1043"/>
+        </identifiers>
+        <balance>43199.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1332689.15000000</valUSD>
+        <pctVal>0.000611996930</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Darden Restaurants Inc</name>
+        <lei>CY1NFSCCB5GUXC7WZC70</lei>
+        <title>DARDEN RESTAURAN</title>
+        <cusip>237194105</cusip>
+        <identifiers>
+          <isin value="US2371941053"/>
+        </identifiers>
+        <balance>1070519.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>196996906.38000000</valUSD>
+        <pctVal>0.090464833512</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Kraft Heinz Co/The</name>
+        <lei>9845007488EC87F5AF14</lei>
+        <title>KRAFT HEINZ CO/T</title>
+        <cusip>500754106</cusip>
+        <identifiers>
+          <isin value="US5007541064"/>
+        </identifiers>
+        <balance>7625021.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>184906759.25000000</valUSD>
+        <pctVal>0.084912801415</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Altria Group Inc</name>
+        <lei>XSGZFLO9YTNO9VCQV219</lei>
+        <title>ALTRIA GROUP INC</title>
+        <cusip>02209S103</cusip>
+        <identifiers>
+          <isin value="US02209S1033"/>
+        </identifiers>
+        <balance>15448305.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>890749266.30000000</valUSD>
+        <pctVal>0.409049489953</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>American Tower Corp</name>
+        <lei>5493006ORUSIL88JOE18</lei>
+        <title>AMERICAN TOWER C</title>
+        <cusip>03027X100</cusip>
+        <identifiers>
+          <isin value="US03027X1000"/>
+        </identifiers>
+        <balance>2154058.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>378187963.06000000</valUSD>
+        <pctVal>0.173671311612</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Ross Stores Inc</name>
+        <lei>549300ENZFLPGRDFZQ60</lei>
+        <title>ROSS STORES INC</title>
+        <cusip>778296103</cusip>
+        <identifiers>
+          <isin value="US7782961038"/>
+        </identifiers>
+        <balance>2992995.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>539158119.30000000</valUSD>
+        <pctVal>0.247591956623</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Corteva Inc</name>
+        <lei>549300WZN9I2QKLS0O94</lei>
+        <title>CORTEVA INC</title>
+        <cusip>22052L104</cusip>
+        <identifiers>
+          <isin value="US22052L1044"/>
+        </identifiers>
+        <balance>6285587.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>421322896.61000000</valUSD>
+        <pctVal>0.193479717002</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Fifth Third Bancorp</name>
+        <lei>THRNG6BD57P9QWTQLG42</lei>
+        <title>FIFTH THIRD BANC</title>
+        <cusip>316773100</cusip>
+        <identifiers>
+          <isin value="US3167731005"/>
+        </identifiers>
+        <balance>6083097.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>284749770.57000000</valUSD>
+        <pctVal>0.130762665570</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cencora Inc</name>
+        <lei>AI8GXW8LG5WK7E9UD086</lei>
+        <title>CENCORA INC</title>
+        <cusip>03073E105</cusip>
+        <identifiers>
+          <isin value="US03073E1055"/>
+        </identifiers>
+        <balance>1695959.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>572810152.25000000</valUSD>
+        <pctVal>0.263045628531</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>N/A</name>
+        <lei>N/A</lei>
+        <title>TRS:BANK OF AMERICA CORP USD 2027-Jan-29</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <other otherDesc="CONTRACT_VANGUARD_ID" value="V1048192601"/>
+        </identifiers>
+        <balance>2000000.00000000</balance>
+        <units>NC</units>
+        <curCd>USD</curCd>
+        <valUSD>-1760000.00000000</valUSD>
+        <pctVal>-0.00080822643</pctVal>
+        <payoffProfile>N/A</payoffProfile>
+        <assetCat>DE</assetCat>
+        <issuerConditional desc="N/A" issuerCat="OTHER"/>
+        <invCountry>N/A</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>2</fairValLevel>
+        <derivativeInfo>
+          <swapDeriv derivCat="SWP">
+            <counterparties>
+              <counterpartyName>CITIBANK N.A.</counterpartyName>
+              <counterpartyLei>E57ODZWZ7FF32TWEFA76</counterpartyLei>
+            </counterparties>
+            <descRefInstrmnt>
+              <otherRefInst>
+                <issuerName>N/A</issuerName>
+                <issueTitle>BANK OF AMERICA</issueTitle>
+                <identifiers>
+                  <cusip value="060505104"/>
+                </identifiers>
+              </otherRefInst>
+            </descRefInstrmnt>
+            <swapFlag>Y</swapFlag>
+            <otherRecDesc fixedOrFloating="Other">Receive positive return on reference instrument</otherRecDesc>
+            <floatingPmntDesc curCd="USD" fixedOrFloating="Floating" floatingRtIndex="OBFR01" floatingRtSpread="0.00000000" pmntAmt="0.00000000">
+              <rtResetTenors>
+                <rtResetTenor rateTenor="Day" rateTenorUnit="394" resetDt="Month" resetDtUnit="1"/>
+              </rtResetTenors>
+            </floatingPmntDesc>
+            <terminationDt>2027-01-29</terminationDt>
+            <upfrontPmnt>0.00000000</upfrontPmnt>
+            <pmntCurCd>USD</pmntCurCd>
+            <upfrontRcpt>0.00000000</upfrontRcpt>
+            <rcptCurCd>USD</rcptCurCd>
+            <notionalAmt>111760000.00000000</notionalAmt>
+            <curCd>USD</curCd>
+            <unrealizedAppr>-1760000.00000000</unrealizedAppr>
+          </swapDeriv>
+        </derivativeInfo>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Vistra Corp</name>
+        <lei>549300KP43CPCUJOOG15</lei>
+        <title>VISTRA CORP</title>
+        <cusip>92840M102</cusip>
+        <identifiers>
+          <isin value="US92840M1027"/>
+        </identifiers>
+        <balance>3117997.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>503026456.01000000</valUSD>
+        <pctVal>0.230999589950</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Johnson &amp; Johnson</name>
+        <lei>549300G0CFPGEF6X2043</lei>
+        <title>JOHNSON&amp;JOHNSON</title>
+        <cusip>478160104</cusip>
+        <identifiers>
+          <isin value="US4781601046"/>
+        </identifiers>
+        <balance>22171956.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>4588486294.20000000</valUSD>
+        <pctVal>2.107122676730</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Invitation Homes Inc</name>
+        <lei>N/A</lei>
+        <title>INVITATION HOMES</title>
+        <cusip>46187W107</cusip>
+        <identifiers>
+          <isin value="US46187W1071"/>
+        </identifiers>
+        <balance>5359521.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>148941088.59000000</valUSD>
+        <pctVal>0.068396661805</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>BlackRock Funding Inc/DE</name>
+        <lei>529900VBK42Y5HHRMD23</lei>
+        <title>BLACKROCK INC</title>
+        <cusip>09290D101</cusip>
+        <identifiers>
+          <isin value="US09290D1019"/>
+        </identifiers>
+        <balance>1284999.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1375385829.66000000</valUSD>
+        <pctVal>0.631604081414</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Tractor Supply Co</name>
+        <lei>549300OJ9VZHZRO6I137</lei>
+        <title>TRACTOR SUPPLY</title>
+        <cusip>892356106</cusip>
+        <identifiers>
+          <isin value="US8923561067"/>
+        </identifiers>
+        <balance>4862758.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>243186527.58000000</valUSD>
+        <pctVal>0.111676011234</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cisco Systems Inc</name>
+        <lei>549300LKFJ962MZ46593</lei>
+        <title>CISCO SYSTEMS</title>
+        <cusip>17275R102</cusip>
+        <identifiers>
+          <isin value="US17275R1023"/>
+        </identifiers>
+        <balance>32724514.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>2520769313.42000000</valUSD>
+        <pctVal>1.157586585760</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>N/A</name>
+        <lei>N/A</lei>
+        <title>S&amp;P500 EMINI FUT  Mar26</title>
+        <cusip>N/A</cusip>
+        <identifiers>
+          <ticker value="ESH6"/>
+        </identifiers>
+        <balance>428.00000000</balance>
+        <units>NC</units>
+        <curCd>USD</curCd>
+        <valUSD>-1157923.57000000</valUSD>
+        <pctVal>-0.00053174115</pctVal>
+        <payoffProfile>N/A</payoffProfile>
+        <assetCat>DE</assetCat>
+        <issuerConditional desc="N/A" issuerCat="OTHER"/>
+        <invCountry>N/A</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <derivativeInfo>
+          <futrDeriv derivCat="FUT">
+            <counterparties>
+              <counterpartyName>MORGAN STANLEY &amp; CO LLC</counterpartyName>
+              <counterpartyLei>9R7GPTSO7KV3UQJZQ078</counterpartyLei>
+            </counterparties>
+            <payOffProf>Long</payOffProf>
+            <descRefInstrmnt>
+              <indexBasketInfo>
+                <indexName>S&amp;P 500 Index</indexName>
+                <indexIdentifier>SPX</indexIdentifier>
+              </indexBasketInfo>
+            </descRefInstrmnt>
+            <expDate>2026-03-20</expDate>
+            <notionalAmt>148657423.57000000</notionalAmt>
+            <curCd>USD</curCd>
+            <unrealizedAppr>-1157923.57000000</unrealizedAppr>
+          </futrDeriv>
+        </derivativeInfo>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>TE Connectivity PLC</name>
+        <lei>6367003TB6K484NFHE54</lei>
+        <title>TE CONNECTIVITY</title>
+        <cusip>G87052109</cusip>
+        <identifiers>
+          <isin value="IE000IVNQZ81"/>
+        </identifiers>
+        <balance>2707268.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>615930542.68000000</valUSD>
+        <pctVal>0.282847355436</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Rockwell Automation Inc</name>
+        <lei>VH3R4HHBHH12O0EXZJ88</lei>
+        <title>ROCKWELL AUTOMAT</title>
+        <cusip>773903109</cusip>
+        <identifiers>
+          <isin value="US7739031091"/>
+        </identifiers>
+        <balance>1033252.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>402007355.64000000</valUSD>
+        <pctVal>0.184609642694</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>American Express Co</name>
+        <lei>R4PP93JZOLY261QX3811</lei>
+        <title>AMERICAN EXPRESS</title>
+        <cusip>025816109</cusip>
+        <identifiers>
+          <isin value="US0258161092"/>
+        </identifiers>
+        <balance>4437460.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1641638327.00000000</valUSD>
+        <pctVal>0.753872437231</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Ameriprise Financial Inc</name>
+        <lei>6ZLKQF7QB6JAEKQS5388</lei>
+        <title>AMERIPRISE FINAN</title>
+        <cusip>03076C106</cusip>
+        <identifiers>
+          <isin value="US03076C1062"/>
+        </identifiers>
+        <balance>855020.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>419250506.80000000</valUSD>
+        <pctVal>0.192528035057</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>SS&amp;C Technologies Holdings Inc</name>
+        <lei>529900POY8H7NPPNKK71</lei>
+        <title>SS&amp;C TECHNOLOGIE</title>
+        <cusip>78467J100</cusip>
+        <identifiers>
+          <isin value="US78467J1007"/>
+        </identifiers>
+        <balance>1908902.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>166876212.84000000</valUSD>
+        <pctVal>0.076632821749</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cognizant Technology Solutions Corp</name>
+        <lei>5493006IEVQEFQO40L83</lei>
+        <title>COGNIZANT TECH-A</title>
+        <cusip>192446102</cusip>
+        <identifiers>
+          <isin value="US1924461023"/>
+        </identifiers>
+        <balance>4441768.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>368666744.00000000</valUSD>
+        <pctVal>0.169298981544</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Prologis Inc</name>
+        <lei>529900DFH19P073LZ636</lei>
+        <title>PROLOGIS INC</title>
+        <cusip>74340W103</cusip>
+        <identifiers>
+          <isin value="US74340W1036"/>
+        </identifiers>
+        <balance>8523273.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1088081031.18000000</valUSD>
+        <pctVal>0.499668097040</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Republic Services Inc</name>
+        <lei>NKNQHM6BLECKVOQP7O46</lei>
+        <title>REPUBLIC SVCS</title>
+        <cusip>760759100</cusip>
+        <identifiers>
+          <isin value="US7607591002"/>
+        </identifiers>
+        <balance>1851784.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>392448583.12000000</valUSD>
+        <pctVal>0.180220067342</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>AvalonBay Communities Inc</name>
+        <lei>K9G90K85RBWD2LAGQX17</lei>
+        <title>AVALONBAY COMMUN</title>
+        <cusip>053484101</cusip>
+        <identifiers>
+          <isin value="US0534841012"/>
+        </identifiers>
+        <balance>1303116.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>236267961.96000000</valUSD>
+        <pctVal>0.108498870544</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Cheniere Energy Inc</name>
+        <lei>MIHC87W9WTYSYZWV1J40</lei>
+        <title>CHENIERE ENERGY</title>
+        <cusip>16411R208</cusip>
+        <identifiers>
+          <isin value="US16411R2085"/>
+        </identifiers>
+        <balance>1980690.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>385026329.10000000</valUSD>
+        <pctVal>0.176811623085</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Newmont Corp</name>
+        <lei>549300VSP3RIX7FGDZ51</lei>
+        <title>NEWMONT CORP</title>
+        <cusip>651639106</cusip>
+        <identifiers>
+          <isin value="US6516391066"/>
+        </identifiers>
+        <balance>10042507.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1002744323.95000000</valUSD>
+        <pctVal>0.460479811529</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Interactive Brokers Group Inc</name>
+        <lei>5493004DT6DCDUZNDM53</lei>
+        <title>INTERACTIVE BROK</title>
+        <cusip>45841N107</cusip>
+        <identifiers>
+          <isin value="US45841N1072"/>
+        </identifiers>
+        <balance>1946829.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>125200572.99000000</valUSD>
+        <pctVal>0.057494552576</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Labcorp Holdings Inc</name>
+        <lei>N/A</lei>
+        <title>LABCORP HOLDINGS</title>
+        <cusip>504922105</cusip>
+        <identifiers>
+          <isin value="US5049221055"/>
+        </identifiers>
+        <balance>762936.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>191405383.68000000</valUSD>
+        <pctVal>0.087897096894</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>PNC Financial Services Group Inc/The</name>
+        <lei>CFGNEKW0P8842LEUIA51</lei>
+        <title>PNC FINANCIAL SE</title>
+        <cusip>693475105</cusip>
+        <identifiers>
+          <isin value="US6934751057"/>
+        </identifiers>
+        <balance>3608875.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>753280478.75000000</valUSD>
+        <pctVal>0.345921133232</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+      <invstOrSec>
+        <name>Walt Disney Co/The</name>
+        <lei>549300GZKULIZ0WOW665</lei>
+        <title>WALT DISNEY CO/T</title>
+        <cusip>254687106</cusip>
+        <identifiers>
+          <isin value="US2546871060"/>
+        </identifiers>
+        <balance>16429951.00000000</balance>
+        <units>NS</units>
+        <curCd>USD</curCd>
+        <valUSD>1869235525.27000000</valUSD>
+        <pctVal>0.858389523452</pctVal>
+        <payoffProfile>Long</payoffProfile>
+        <assetCat>EC</assetCat>
+        <issuerCat>CORP</issuerCat>
+        <invCountry>US</invCountry>
+
+        <isRestrictedSec>N</isRestrictedSec>
+
+        <fairValLevel>1</fairValLevel>
+        <securityLending>
+          <isCashCollateral>N</isCashCollateral>
+          <isNonCashCollateral>N</isNonCashCollateral>
+          <isLoanByFund>N</isLoanByFund>
+        </securityLending>
+      </invstOrSec>
+    </invstOrSecs>
+    <signature>
+      <ncom:dateSigned>2026-02-26</ncom:dateSigned>
+      <ncom:nameOfApplicant>VANGUARD INDEX FUNDS</ncom:nameOfApplicant>
+      <ncom:signature>Ashley Grim</ncom:signature>
+      <ncom:signerName>Ashley Grim</ncom:signerName>
+      <ncom:title>Treasurer</ncom:title>
+    </signature>
+  </formData>
 </edgarSubmission>

--- a/tests/test_manifest_parser_sec_n_port.py
+++ b/tests/test_manifest_parser_sec_n_port.py
@@ -114,10 +114,17 @@ def test_happy_path_parses_and_writes_fund_observation(
 ) -> None:
     """Manifest worker drains an NPORT-P pending row: fetch →
     store_raw → parse → series upsert → fund observation per
-    resolvable Long-EC-NS holding → log success."""
-    iid_aapl = 8800001
-    _seed_instrument(ebull_test_conn, iid=iid_aapl, symbol="AAPL")
-    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid_aapl, cusip="037833100")
+    resolvable Long-EC-NS holding → log success.
+
+    Post-#932: the canonical fixture is a real Vanguard Value Index
+    Fund (series S000002840) NPORT-P with 323 holdings. The top
+    holding by value_usd is JPMorgan Chase (CUSIP 46625H100), which
+    is in the standard smoke panel; seed JPM and assert the JPM
+    observation lands.
+    """
+    iid_jpm = 8800001
+    _seed_instrument(ebull_test_conn, iid=iid_jpm, symbol="JPM")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid_jpm, cusip="46625H100")
     accession = "0001234500-25-000603"
     filer_cik = "0000036405"
     _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
@@ -145,17 +152,35 @@ def test_happy_path_parses_and_writes_fund_observation(
         )
         assert cur.fetchone() is not None
 
-    # Series row persisted.
+    # Parser-version regression guard (#932): raw doc carries the
+    # bumped parser_version constant.
     with ebull_test_conn.cursor() as cur:
-        cur.execute("SELECT fund_filer_cik FROM sec_fund_series WHERE fund_series_id = 'S000002277'")
+        cur.execute(
+            """
+            SELECT parser_version
+            FROM filing_raw_documents
+            WHERE accession_number = %s AND document_kind = 'nport_xml'
+            """,
+            (accession,),
+        )
+        raw = cur.fetchone()
+    assert raw is not None
+    assert raw[0] == "nport-v2-edgartools"
+
+    # Series row persisted (real Vanguard Value Index Fund series
+    # post-#932 fixture replacement).
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT fund_filer_cik FROM sec_fund_series WHERE fund_series_id = 'S000002840'")
         series = cur.fetchone()
     assert series is not None and series[0] == filer_cik
 
-    # AAPL fund observation persisted.
+    # JPM fund observation persisted (the real Vanguard Value Index
+    # Fund fixture has JPMorgan Chase as its top holding by value_usd;
+    # CUSIP 46625H100 was seeded above).
     with ebull_test_conn.cursor() as cur:
         cur.execute(
             "SELECT instrument_id FROM ownership_funds_observations WHERE source_accession = %s AND instrument_id = %s",
-            (accession, iid_aapl),
+            (accession, iid_jpm),
         )
         assert cur.fetchone() is not None
 
@@ -167,8 +192,9 @@ def test_happy_path_parses_and_writes_fund_observation(
         )
         log = cur.fetchone()
     assert log is not None
-    # The golden fixture has 7 holdings; only 1 CUSIP (AAPL) resolves
-    # in this minimal seed. Others land in skipped buckets → partial.
+    # The real fixture has 323 holdings; only 1 CUSIP (JPM) resolves
+    # in this minimal seed. The other 322 land in skipped buckets
+    # (no-CUSIP) → partial.
     assert log[0] in ("success", "partial")
 
 
@@ -307,8 +333,12 @@ def test_deterministic_upsert_exception_tombstones_with_log(
     from app.services.manifest_parsers import sec_n_port as parser_module
 
     iid = 8800010
-    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
-    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip="037833100")
+    # Seed JPM (the real Vanguard Value Index Fund fixture's top
+    # holding; CUSIP 46625H100) so the parser yields at least one
+    # resolvable row → record_fund_observation actually gets called →
+    # the monkeypatched raise fires.
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="JPM")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip="46625H100")
     accession = "0001234500-25-000704"
     filer_cik = "0000036405"
     _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)
@@ -357,8 +387,10 @@ def test_transient_upsert_exception_retries(
     from app.services.manifest_parsers import sec_n_port as parser_module
 
     iid = 8800011
-    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
-    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip="037833100")
+    # Seed JPM (real fixture's top holding) so record_fund_observation
+    # gets called for at least one resolvable row.
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="JPM")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip="46625H100")
     accession = "0001234500-25-000705"
     filer_cik = "0000036405"
     _seed_pending_n_port(ebull_test_conn, accession=accession, filer_cik=filer_cik)

--- a/tests/test_n_port_ingest.py
+++ b/tests/test_n_port_ingest.py
@@ -1,24 +1,33 @@
-"""Tests for the N-PORT ingester (#917 — Phase 3 PR1).
+"""Tests for the N-PORT ingester (#917 + #932).
 
 Three boundaries:
 
-* Pure XML-in / dataclass-out parser (``parse_n_port_payload``).
+* EdgarTools-wrapped parser (``parse_n_port_payload``, #932) — pure
+  XML-in / dataclass-out.
 * DB write-through helpers (``record_fund_observation`` +
   ``refresh_funds_current``) — exercised against the real
   ``ebull_test`` DB.
 * SEC HTTP fetcher — abstracted as a :class:`Protocol` so tests
   use a deterministic in-memory fake.
 
-Codex pre-impl review (2026-05-05) findings exercised:
+Codex #917 pre-impl review findings exercised:
 
-* #1 — parser accepts ``NPORT-P`` / ``NPORT-P/A`` / ``N-PORT`` /
-  ``N-PORT/A`` form spellings.
+* #1 — submissions-index walker accepts ``NPORT-P`` / ``NPORT-P/A``
+  / ``N-PORT`` / ``N-PORT/A`` form spellings.
 * #2 — fixture missing seriesId tombstones as failed.
-* #3 + #4 — debt / preferred / short / no-cusip rows are dropped
-  by the equity-common-Long write-side guard.
+* #3 + #4 — debt / preferred / short / no-cusip / non-NS / zero-share
+  rows are dropped by the equity-common-Long write-side guard.
 * #5 — amendments win over originals in ``_current``.
 * #6 — parser runs offline (test asserts no network calls).
 * #11 — ingest log measures parsed accessions.
+
+Post-#932 (EdgarTools FundReport drop-in):
+
+* Parser tests use a real Vanguard Value Index Fund (S000002840)
+  NPORT-P primary doc; golden replay locks first-row + count + total.
+* Ingester filter-path tests monkeypatch ``parse_n_port_payload`` at
+  the module-local global with hand-constructed :class:`NPortFiling`
+  / :class:`NPortHolding` dataclass instances (no XML involved).
 """
 
 from __future__ import annotations
@@ -35,6 +44,8 @@ import pytest
 
 from app.services.n_port_ingest import (
     AccessionRef,
+    NPortFiling,
+    NPortHolding,
     NPortMissingSeriesError,
     NPortParseError,
     ingest_fund_n_port,
@@ -118,66 +129,231 @@ class _FakeFetcher:
         return self._payloads.get(absolute_url)
 
 
+def _make_filter_path_filing(
+    *,
+    filer_cik: str = "0000036405",
+    series_id: str = "S000099999",
+    series_name: str = "Test Fund Series",
+    period_end: date = date(2025, 12, 31),
+    filed_at: datetime | None = None,
+    aapl_balance: Decimal = Decimal("1000000"),
+) -> NPortFiling:
+    """Construct an :class:`NPortFiling` with the canonical
+    seven-row distribution used by the ingester filter-path tests.
+
+    The seven rows are designed to exercise each ingester guard
+    (`_ingest_single_accession` at `app/services/n_port_ingest.py:894-925`):
+
+    1. AAPL  — Long EC NS valid CUSIP  → WRITE
+    2. MSFT  — Long EC NS valid CUSIP  → WRITE
+    3. ACME  — Long DBT (non-equity)   → DROP (non_equity)
+    4. SHRT  — Short EC NS             → DROP (short)
+    5. ZZZZ  — Long EC NS unknown CUSIP→ DROP (no_cusip)
+    6. CVBND — Long EC PA (conv bond)  → DROP (non_share_units)
+    7. ZRO   — Long EC NS balance 0    → DROP (zero_shares)
+
+    Used post-#932 in place of XML-fixture-driven tests for the
+    filter-path coverage: the parser is monkeypatched at the
+    module-local global, so the bytes stored in ``filing_raw_documents``
+    are irrelevant. The wrapper itself is exercised against the real
+    Vanguard fixture in :class:`TestParseNPortPayload`.
+    """
+    return NPortFiling(
+        filer_cik=filer_cik,
+        series_id=series_id,
+        series_name=series_name,
+        period_end=period_end,
+        filed_at=filed_at,
+        holdings=(
+            NPortHolding(
+                cusip="037833100",
+                issuer_name="APPLE INC",
+                shares=aapl_balance,
+                value_usd=Decimal("225000000.00"),
+                payoff_profile="Long",
+                asset_category="EC",
+                issuer_category="CORP",
+                units="NS",
+            ),
+            NPortHolding(
+                cusip="594918104",
+                issuer_name="MICROSOFT CORP",
+                shares=Decimal("500000"),
+                value_usd=Decimal("210000000.00"),
+                payoff_profile="Long",
+                asset_category="EC",
+                issuer_category="CORP",
+                units="NS",
+            ),
+            NPortHolding(
+                cusip="000000ACM",
+                issuer_name="ACME CORP NOTE 5%",
+                shares=Decimal("1000000"),
+                value_usd=Decimal("1010000.00"),
+                payoff_profile="Long",
+                asset_category="DBT",
+                issuer_category="CORP",
+                units="PA",
+            ),
+            NPortHolding(
+                cusip="000000SHX",
+                issuer_name="SHORT TARGET INC",
+                shares=Decimal("50000"),
+                value_usd=Decimal("5000000.00"),
+                payoff_profile="Short",
+                asset_category="EC",
+                issuer_category="CORP",
+                units="NS",
+            ),
+            NPortHolding(
+                cusip="000000ZZZ",
+                issuer_name="UNRESOLVED CO",
+                shares=Decimal("10000"),
+                value_usd=Decimal("123456.00"),
+                payoff_profile="Long",
+                asset_category="EC",
+                issuer_category="CORP",
+                units="NS",
+            ),
+            NPortHolding(
+                cusip="000000CVB",
+                issuer_name="CONVERTIBLE BOND CO",
+                shares=Decimal("5000000"),
+                value_usd=Decimal("5500000.00"),
+                payoff_profile="Long",
+                asset_category="EC",
+                issuer_category="CORP",
+                units="PA",
+            ),
+            NPortHolding(
+                cusip="000000ZRO",
+                issuer_name="ZERO BALANCE CO",
+                shares=Decimal("0"),
+                value_usd=Decimal("0.00"),
+                payoff_profile="Long",
+                asset_category="EC",
+                issuer_category="CORP",
+                units="NS",
+            ),
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Parser unit tests (offline, no DB)
 # ---------------------------------------------------------------------------
 
 
 class TestParseNPortPayload:
+    """Tests against the canonical real-Vanguard fixture.
+
+    Fixture: ``tests/fixtures/sec/nport_p_test_fund.xml`` is a real
+    Vanguard Value Index Fund NPORT-P primary doc (accession
+    ``0000036405-26-000074``, filed ``2026-02-26``, period end
+    ``2025-12-31``, series ``S000002840``, 323 holdings, top holding
+    JPMorgan Chase CUSIP ``46625H100``). See plan doc T1-RESULTS for
+    the full anchor-value table.
+    """
+
     def test_extracts_header_and_holdings(self) -> None:
         xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
         parsed = parse_n_port_payload(xml)
         assert parsed.filer_cik == "0000036405"
-        assert parsed.series_id == "S000002277"
-        assert parsed.series_name.startswith("Vanguard 500 Index Fund")
+        # T1-RESULTS series_id (S000002277 fallback fired during T1 —
+        # Vanguard 500's series is not under this CIK; locked to the
+        # Vanguard Value Index Fund actually fetched).
+        assert parsed.series_id == "S000002840"
+        # Case-tolerant assertion: SEC payload uses upper-case
+        # 'VANGUARD VALUE INDEX FUND'.
+        assert parsed.series_name.lower().startswith("vanguard value index fund")
         assert parsed.period_end == date(2025, 12, 31)
-        assert parsed.filed_at == datetime(2026, 2, 26, tzinfo=UTC)
-        # 7 holdings parsed total (the ingester filters down to
-        # equity-common Long NS with valid CUSIPs + positive shares;
-        # the parser surfaces all of them).
-        assert len(parsed.holdings) == 7
-        h = {h.cusip: h for h in parsed.holdings}
-        assert h["037833100"].shares == Decimal("1000000")
-        assert h["037833100"].asset_category == "EC"
-        assert h["037833100"].payoff_profile == "Long"
-        assert h["037833100"].units == "NS"
-        assert h["594918104"].asset_category == "EC"
-        # Debt holding is surfaced by the parser (its own assetCat='DBT').
-        assert h["000000ACM"].asset_category == "DBT"
-        # Short equity holding is surfaced.
-        assert h["000000SHX"].payoff_profile == "Short"
-        # Convertible bond — Long EC but units=PA (principal amount).
-        assert h["000000CVB"].asset_category == "EC"
-        assert h["000000CVB"].payoff_profile == "Long"
-        assert h["000000CVB"].units == "PA"
-        # Zero-balance equity-common.
-        assert h["000000ZRO"].shares == Decimal("0")
+        # EdgarTools' parse_fund_xml does not surface a header-level
+        # filedAt; the ingester layers in submissions-index filingDate.
+        assert parsed.filed_at is None
+        # T1-RESULTS holdings count.
+        assert len(parsed.holdings) == 323
+
+    def test_golden_replay_first_row_count_total(self) -> None:
+        """Golden-file replay: locks top-by-value holding + total
+        value_usd sum + holdings count to the T1-RESULTS anchor
+        values. Pin-bump regression guard — if EdgarTools renames a
+        field, changes Decimal coercion, or reorders investments in a
+        future minor bump, this test fails loudly.
+        """
+        xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+        parsed = parse_n_port_payload(xml)
+
+        assert len(parsed.holdings) == 323
+
+        top = max(
+            parsed.holdings,
+            key=lambda h: h.value_usd if h.value_usd is not None else Decimal(0),
+        )
+        assert top.cusip == "46625H100"  # JPMorgan Chase & Co
+        assert top.issuer_name == "JPMorgan Chase & Co"
+        assert top.shares == Decimal("24052035.00000000")
+        assert top.units == "NS"
+        assert top.value_usd == Decimal("7750046717.70000000")
+        assert top.payoff_profile == "Long"
+        assert top.asset_category == "EC"
+        assert top.issuer_category == "CORP"
+
+        total = sum(
+            (h.value_usd for h in parsed.holdings if h.value_usd is not None),
+            start=Decimal(0),
+        )
+        assert total == Decimal("217419611080.71000000")
+
+        # Holdings without value_usd (per T1-RESULTS: 0 on the
+        # canonical fixture). The Pydantic InvestmentOrSecurity model
+        # at edgartools 5.30.2 declares value_usd non-Optional; a
+        # value_usd=None would surface as a parse-time ValidationError
+        # before reaching here, so this is a defence-in-depth assert.
+        assert sum(1 for h in parsed.holdings if h.value_usd is None) == 0
 
     def test_raises_missing_series_id(self) -> None:
         xml = (_FIXTURE_DIR / "nport_p_missing_series.xml").read_text(encoding="utf-8")
         with pytest.raises(NPortMissingSeriesError):
             parse_n_port_payload(xml)
 
+    def test_raises_on_empty_xml(self) -> None:
+        # Codex 2 round 1 finding: ``FundReport.parse_fund_xml("")``
+        # raises ``lxml.etree.XMLSyntaxError`` (after EdgarTools'
+        # recover=True fallback also fails). Wrapper's catch list MUST
+        # include XMLSyntaxError so empty / null-byte payloads
+        # tombstone cleanly as NPortParseError rather than escaping
+        # ``_ingest_single_accession``'s accession-level handler.
+        with pytest.raises(NPortParseError):
+            parse_n_port_payload("")
+        with pytest.raises(NPortParseError):
+            parse_n_port_payload("\x00")
+
     def test_raises_on_malformed_xml(self) -> None:
+        # EdgarTools' lxml parser has recover=True fallback at
+        # edgar/funds/reports.py:1228-1230, so this input survives the
+        # raw parse step but fails downstream when the wrapper tries
+        # to access parsed["general_info"] / parsed["header"] (missing
+        # structural blocks raise AttributeError, caught by the
+        # wrapper's catch list and converted to NPortParseError).
         with pytest.raises(NPortParseError):
             parse_n_port_payload("<not><well><formed>")
 
     def test_runs_offline_no_network(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Codex pre-impl review #6: the parser must not reach the
-        network. Patch every HTTP entrypoint to raise; the parse must
-        still succeed."""
-        # ``urllib.request.urlopen`` is the stdlib HTTP client; patch
-        # at the public attribute so any code path that imports it
-        # raises immediately.
+        """Codex #917 pre-impl review #6: the parser must not reach
+        the network. Patch every HTTP entrypoint to raise; the parse
+        must still succeed.
+
+        Post-#932: EdgarTools' ``parse_fund_xml`` is documented as
+        pure-string-in / dict-out; this test guards against future
+        regressions where a refactor introduces an HTTP call inside
+        the lazy-import path.
+        """
         import urllib.request
 
         def _block(*args: object, **kwargs: object) -> object:
             raise AssertionError("parser made an HTTP request — must run offline")
 
         monkeypatch.setattr(urllib.request, "urlopen", _block)
-        # ``httpx`` may not be imported by the parser, but if a future
-        # change introduces it, the test must still trip. Use
-        # ``importlib`` to reach into it only if installed.
         try:
             import httpx
 
@@ -188,7 +364,8 @@ class TestParseNPortPayload:
 
         xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
         parsed = parse_n_port_payload(xml)
-        assert parsed.series_id == "S000002277"
+        # T1-RESULTS series_id.
+        assert parsed.series_id == "S000002840"
 
 
 # ---------------------------------------------------------------------------
@@ -443,26 +620,43 @@ class TestIngestFundNPort:
         conn.commit()
         return conn
 
-    def test_ingest_drops_non_equity_short_unresolved(self, _setup: psycopg.Connection[tuple]) -> None:
+    def test_ingest_drops_non_equity_short_unresolved(
+        self, _setup: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Filter-path coverage via monkeypatched parser (#932).
+
+        The parser is patched at the module-local global
+        ``app.services.n_port_ingest.parse_n_port_payload`` so the
+        bytes stored in ``filing_raw_documents`` are irrelevant. The
+        ingester's filter logic is exercised against a hand-constructed
+        :class:`NPortFiling` from :func:`_make_filter_path_filing`.
+        """
         conn = _setup
         accession = "0000036405-26-000001"
         primary_url = _archive_url("0000036405", accession, "primary_doc.xml")
         submissions_url = "https://data.sec.gov/submissions/CIK0000036405.json"
-        fixture_xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+        filing = _make_filter_path_filing(series_id="S000002840")
+        # Bytes content is irrelevant — the parser is monkeypatched
+        # below. A non-empty stub is needed only because raw_filings.
+        # store_raw NOT NULL-rejects empty payloads.
+        stub_xml = b"<edgarSubmission/>".decode()
+        monkeypatch.setattr(
+            "app.services.n_port_ingest.parse_n_port_payload",
+            lambda _xml: filing,
+        )
         fetcher = _FakeFetcher(
             {
                 submissions_url: _submissions_json(accessions=[(accession, "NPORT-P", "2026-02-26", "2025-12-31")]),
-                primary_url: fixture_xml,
+                primary_url: stub_xml,
             }
         )
 
         summary = ingest_fund_n_port(conn, fetcher, filer_cik="0000036405")
         conn.commit()
 
-        # Fixture has 7 holdings: AAPL + MSFT pass guards. ACME-debt
-        # drops on assetCat, SHRT-X drops on Short, ZZZZ drops on
-        # missing CUSIP mapping, CVBND drops on units=PA, ZRO drops
-        # on zero shares.
+        # AAPL + MSFT pass guards. ACME drops on non-equity, SHRT
+        # drops on Short, ZZZZ drops on missing CUSIP mapping, CVBND
+        # drops on units=PA, ZRO drops on zero shares.
         assert summary.holdings_inserted == 2
         assert summary.holdings_skipped_non_equity == 1
         assert summary.holdings_skipped_short == 1
@@ -481,27 +675,32 @@ class TestIngestFundNPort:
             rows = cur.fetchall()
         assert len(rows) == 1
         assert rows[0]["shares"] == Decimal("1000000.0000")
-        assert rows[0]["fund_series_id"] == "S000002277"
+        assert rows[0]["fund_series_id"] == "S000002840"
 
         # sec_fund_series upserted.
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
                 "SELECT fund_series_name, fund_filer_cik FROM sec_fund_series WHERE fund_series_id = %s",
-                ("S000002277",),
+                ("S000002840",),
             )
             series_rows = cur.fetchall()
         assert len(series_rows) == 1
         assert series_rows[0]["fund_filer_cik"] == "0000036405"
 
-        # Raw payload stored before parse (prevention-log #1168).
-        with conn.cursor() as cur:
+        # Raw payload stored before parse (prevention-log #1168) +
+        # parser-version-bump regression guard (#932).
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
-                "SELECT COUNT(*) FROM filing_raw_documents WHERE accession_number = %s AND document_kind = %s",
+                """
+                SELECT parser_version
+                FROM filing_raw_documents
+                WHERE accession_number = %s AND document_kind = %s
+                """,
                 (accession, "nport_xml"),
             )
-            row = cur.fetchone()
-        assert row is not None
-        assert row[0] == 1
+            raw_rows = cur.fetchall()
+        assert len(raw_rows) == 1
+        assert raw_rows[0]["parser_version"] == "nport-v2-edgartools"
 
         # Tombstone log row written.
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -515,17 +714,22 @@ class TestIngestFundNPort:
         assert log_rows[0]["holdings_inserted"] == 2
         assert log_rows[0]["holdings_skipped"] == 5
 
-    def test_idempotent_reingest(self, _setup: psycopg.Connection[tuple]) -> None:
+    def test_idempotent_reingest(self, _setup: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch) -> None:
         """Re-running the same accession after the tombstone is stamped
         doesn't re-fetch primary_doc."""
         conn = _setup
         accession = "0000036405-26-000001"
         primary_url = _archive_url("0000036405", accession, "primary_doc.xml")
         submissions_url = "https://data.sec.gov/submissions/CIK0000036405.json"
-        fixture_xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
+        filing = _make_filter_path_filing(series_id="S000002840")
+        stub_xml = b"<edgarSubmission/>".decode()
+        monkeypatch.setattr(
+            "app.services.n_port_ingest.parse_n_port_payload",
+            lambda _xml: filing,
+        )
         payloads = {
             submissions_url: _submissions_json(accessions=[(accession, "NPORT-P", "2026-02-26", "2025-12-31")]),
-            primary_url: fixture_xml,
+            primary_url: stub_xml,
         }
         fetcher_first = _FakeFetcher(payloads)
         ingest_fund_n_port(conn, fetcher_first, filer_cik="0000036405")
@@ -538,22 +742,48 @@ class TestIngestFundNPort:
         assert submissions_url in fetcher_second.fetch_log
         assert primary_url not in fetcher_second.fetch_log
 
-    def test_amendment_uses_submissions_filed_at_when_header_missing(self, _setup: psycopg.Connection[tuple]) -> None:
-        """Codex pre-push review #1: when the primary doc lacks a
-        header ``filedAt``, the ingester must fall back to the
-        submissions-index ``filingDate``. Otherwise an amendment
-        sharing a period with its original would silently tie on
-        ``filed_at`` (period_end midnight) and the older accession
-        would win the tie-break."""
+    def test_amendment_uses_submissions_filed_at_when_header_missing(
+        self, _setup: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex #917 pre-push review #1: when the parser returns
+        ``filed_at=None`` (always true post-#932 since EdgarTools'
+        parse_fund_xml doesn't surface a header filedAt), the ingester
+        must fall back to the submissions-index ``filingDate``.
+        Otherwise an amendment sharing a period with its original would
+        silently tie on ``filed_at`` (period_end midnight) and the
+        older accession would win the tie-break.
+        """
         conn = _setup
         accession_orig = "0000036405-26-000010"
         accession_amend = "0000036405-26-000011"
-        # Build a primary doc XML that lacks a <filedAt> header.
-        fixture_xml = (_FIXTURE_DIR / "nport_p_test_fund.xml").read_text(encoding="utf-8")
-        no_header_xml = fixture_xml.replace("<filedAt>2026-02-26</filedAt>", "")
-        # Also vary the AAPL share count between original and amendment
-        # so the test can prove which row wins.
-        amended_xml = no_header_xml.replace("<balance>1000000</balance>", "<balance>1234567</balance>", 1)
+        # Original + amendment differ on AAPL share count so the test
+        # can prove which row wins. Both parsers return filed_at=None
+        # to exercise the submissions-index fallback path.
+        filing_orig = _make_filter_path_filing(
+            series_id="S000002840",
+            aapl_balance=Decimal("1000000"),
+        )
+        filing_amend = _make_filter_path_filing(
+            series_id="S000002840",
+            aapl_balance=Decimal("1234567"),
+        )
+
+        # The fixture is keyed by accession in `_ingest_single_accession`
+        # via the XML bytes' identity (the wrapper is monkeypatched).
+        # Return the right NPortFiling per-accession by parsing the
+        # accession out of the URL we last looked up.
+        def _patched_parser(xml: str) -> NPortFiling:
+            if xml == _orig_marker:
+                return filing_orig
+            return filing_amend
+
+        _orig_marker = b"<edgarSubmission><id>orig</id></edgarSubmission>".decode()
+        _amend_marker = b"<edgarSubmission><id>amend</id></edgarSubmission>".decode()
+        monkeypatch.setattr(
+            "app.services.n_port_ingest.parse_n_port_payload",
+            _patched_parser,
+        )
+
         primary_url_orig = _archive_url("0000036405", accession_orig, "primary_doc.xml")
         primary_url_amend = _archive_url("0000036405", accession_amend, "primary_doc.xml")
         submissions_url = "https://data.sec.gov/submissions/CIK0000036405.json"
@@ -565,8 +795,8 @@ class TestIngestFundNPort:
                         (accession_amend, "NPORT-P/A", "2026-03-15", "2025-12-31"),
                     ]
                 ),
-                primary_url_orig: no_header_xml,
-                primary_url_amend: amended_xml,
+                primary_url_orig: _orig_marker,
+                primary_url_amend: _amend_marker,
             }
         )
         ingest_fund_n_port(conn, fetcher, filer_cik="0000036405")


### PR DESCRIPTION
## What changed

Replaces the stdlib-`xml.etree.ElementTree` body of `app/services/n_port_ingest.py::parse_n_port_payload` with a lazy-imported wrapper over `edgar.funds.reports.FundReport.parse_fund_xml` (#932). Preserves the public `NPortFiling` / `NPortHolding` dataclass surface so the ingester body + manifest adapter remain unchanged.

- **Wrapper body** at `app/services/n_port_ingest.py`. Lazy-imports `FundReport` (`_edgar_fund_report`), `pydantic.ValidationError` (`_pydantic_validation_error`), and `lxml.etree.XMLSyntaxError` (`_lxml_syntax_error`). Catch list covers every observed failure mode + dict-shape drift: `(AttributeError, KeyError, decimal.InvalidOperation, ValueError, TypeError, pydantic.ValidationError, lxml.etree.XMLSyntaxError)` → `NPortParseError`. `NPortMissingSeriesError` re-raised explicitly.
- **Parser-version bump**: `_PARSER_VERSION_NPORT = "nport-v1"` → `"nport-v2-edgartools"`. Auto-propagates to the manifest adapter via direct symbol import at `app/services/manifest_parsers/sec_n_port.py:60-68` (7 call-sites).
- **Canonical fixture** at `tests/fixtures/sec/nport_p_test_fund.xml`: replaced the 4.3KB synthetic with a real Vanguard Value Index Fund (series `S000002840`) NPORT-P primary doc, accession `0000036405-26-000074`, filed 2026-02-26, period end 2025-12-31, 323 holdings, top holding JPMorgan Chase CUSIP `46625H100` (in standard smoke panel) with `value_usd = $7.75B`, total `value_usd = $217.4B`.
- **Negative fixture** at `tests/fixtures/sec/nport_p_missing_series.xml`: rewritten to clear EdgarTools structural requirements (`<filerInfo>` + `<fundInfo>` 9 Decimal-required fields + `<returnInfo>` with `<othMon1/2/3/>`) while still missing `<seriesId>` to exercise `NPortMissingSeriesError`.
- **Tests**:
  - `tests/test_n_port_ingest.py::TestParseNPortPayload` rewritten against the real fixture + new `test_golden_replay_first_row_count_total` (pin-bump regression guard) + new `test_raises_on_empty_xml` (Codex 2 r1 XMLSyntaxError edge case).
  - `TestIngestFundNPort` 3 of 4 tests refactored to monkeypatch `parse_n_port_payload` at the module-local global, with `_make_filter_path_filing()` helper constructing the canonical 7-row filter-path distribution as `NPortFiling`. `test_missing_series_id_tombstones_failed` stays as integration test through the real parser.
  - `tests/test_manifest_parser_sec_n_port.py` happy-path retargeted at JPM (real fixture's top holding) + new `parser_version == "nport-v2-edgartools"` assertion; tombstone tests retargeted at JPM CUSIP `46625H100`.
- **Skill** `.claude/skills/data-sources/edgartools.md` §G3 rewritten with structural + Pydantic cliff distinction; live wrapper cited.
- **Memory** `feedback_pydantic_validation_cliff.md` updated with the #932 outcome (Path A FEASIBLE; structural-vs-Pydantic distinction; wrapper catch-list pattern).
- **Docs**: spike + spec + plan landed at `docs/superpowers/{spikes,specs,plans}/2026-05-18-n-port-edgartools-*.md`.

Helper cleanup: removed `_stripns`, `_find_text`, `_children_by_local_name`, `_decimal_or_none` (n_port_ingest-local) + `import xml.etree.ElementTree as ET`. `sec_13dg.py`'s independent `_decimal_or_none` is untouched.

## Why

#932 closes the parser-version gap between the EdgarTools-wrapped 13F-HR path (PR #931, 2026-05-05) and the N-PORT path, which was tracked as a deferred follow-up. The spike at `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md` verified:

- Real Vanguard NPORT-P parses cleanly through `FundReport.parse_fund_xml` (323/186-holding fixtures both clean).
- The "Pydantic validation cliff" documented in `.claude/skills/data-sources/edgartools.md` §G3 was wrong on location — the observed crash on the synthetic fixture is **structural** (missing `<filerInfo>` block), not Pydantic-validation. A separate internal Pydantic cliff (`InvestmentOrSecurity.value_usd: Decimal` non-Optional) is theoretically possible on real payloads with missing `<valUSD>` cells but is unobserved on the Vanguard probe sample — mitigated by the wrapper's catch list.

## No schema migration

Parser-only scope per #932 issue body. `ownership_funds_*` tables untouched.

## Security model

- No new HTTP path. EdgarTools' `parse_fund_xml` is pure-string-in / dict-out; the ingester continues to fetch primary docs via `SecFilingsProvider.fetch_document_text` against the shared `_PROCESS_RATE_LIMIT_CLOCK` (10 r/s shared SEC budget per #537 + #726).
- Raw-payload persistence ordering at `_ingest_single_accession:786-798` unchanged: fetch → `raw_filings.store_raw` → `conn.commit()` → `parse_n_port_payload(...)`. Prevention-log #1168 preserved.
- The wrapper's lazy-import factories defer EdgarTools' filesystem-cache mkdir (`~/.edgar/_tcache`) until first parse call, preserving the pure-parser contract on read-only `$HOME` (CI / Docker).

## Test plan

- [x] `uv run pytest tests/test_n_port_ingest.py tests/test_manifest_parser_sec_n_port.py` — 38 passed locally.
- [x] `uv run pytest tests/smoke/test_app_boots.py` — passed.
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean.
- [x] `uv run pyright app/services/n_port_ingest.py app/services/manifest_parsers/sec_n_port.py tests/test_n_port_ingest.py tests/test_manifest_parser_sec_n_port.py` — 0 errors.
- [ ] Full `uv run pytest` — running.
- [x] Codex 1a spike (CLEAN r3) + spec (CLEAN r4) + Codex 1b plan (CLEAN r4) + Codex 2 pre-push (CLEAN r2 — 1 MED XMLSyntaxError surfaced + fixed).

## ETL DoD clauses #8-#12 framing

- **#8 (smoke against 3-5 instruments)**: N/A in operator-visible sense — N-PORT does not surface to the standard `AAPL` / `GME` / `MSFT` / `JPM` / `HD` smoke panel in v1. The rollup endpoint (`/instruments/{symbol}/ownership-rollup` fund-side) is deferred to #919. The golden replay test does exercise the **JPM** member of the smoke panel as the canonical fixture's top holding.
- **#9 (cross-source verify)**: Independent raw XML spot-check against the SEC EDGAR primary doc at `www.sec.gov/Archives/edgar/data/36405/000003640526000074/primary_doc.xml`. Top holding JPMorgan Chase value_usd asserted = `Decimal('7750046717.70000000')` (matches SEC raw payload). True cross-source verification against an independent source (Morningstar / SEC EDGAR Fund Browser) is N/A until #919 lands.
- **#10 (backfill executed)**: Operator follow-up post-merge — `POST /jobs/sec_rebuild/run` with body `{"source": "sec_n_port"}` resets manifest rows with `parser_version != 'nport-v2-edgartools'` to `pending` and re-drains via the manifest worker at 10 req/s shared budget.
- **#11 (operator-visible figure verified)**: N/A in v1 — no rollup endpoint surfaces N-PORT; deferred to #919. Documented here explicitly.
- **#12 (PR records verification + commit SHA)**: This PR body satisfies via the explicit N/A annotations + the §"Operator follow-up" plan.

## Manifest adapter propagation

`app/services/manifest_parsers/sec_n_port.py` direct-imports `_PARSER_VERSION_NPORT` (line 61) + `parse_n_port_payload` (line 67). The parser-version bump auto-propagates to 7 call-sites (lines 87, 111, 155, 166, 205, 403, 410). No adapter changes needed; the manifest-parser test file adds the parser-version assertion to confirm propagation.

## Rollback / backfill / rewash path

- Revert via `git revert <merge SHA>` is safe — the parser-version constant goes back to `nport-v1`, the manifest worker re-drains via the same mismatch-detection mechanism, and `_decimal_or_none` / `_find_text` / `_stripns` / `_children_by_local_name` come back (no other caller depends on them within `n_port_ingest.py`).
- No schema rollback needed.

## References

- Issue: #932
- Architectural sibling: PR #931 (13F-HR EdgarTools drop-in, merged 2026-05-05, commit `0428dbf`)
- Spike: `docs/superpowers/spikes/2026-05-18-n-port-edgartools-feasibility.md`
- Spec: `docs/superpowers/specs/2026-05-18-n-port-edgartools-dropin.md`
- Plan: `docs/superpowers/plans/2026-05-18-n-port-edgartools-dropin-plan.md`
- Parent plan: `docs/superpowers/plans/2026-05-17-us-etl-completion.md` §2 Phase 5 PR 10

Closes #932.