### PR TITLE
feat(#1208): Phase 1 — Postgres runtime tuning + runtime_config boot guard

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -260,6 +260,18 @@ Read and apply these before pushing:
 - Persist enough structured evidence for auditability.
 - Use tech-debt issues when a review point is consciously deferred.
 
+## Skill ownership (project-local skills)
+
+Files under `.claude/skills/**` are **project-local engineering substrate**. The agent OWNS them:
+
+1. When a gap is observed mid-task (empirical finding contradicts the skill; new pattern emerges; recurring trap surfaces), update the skill **inline** in the same session, in the same PR. Do NOT defer with "I'll update the skill later" — that's how skills go stale.
+2. When a skill is found to make a claim the codebase no longer honours, correct it as a routine maintenance edit. No separate approval needed.
+3. When a new prevention-log lesson surfaces mid-task, extract it into the relevant skill AND `docs/review-prevention-log.md` in the SAME PR — never let the lesson live only in the PR description.
+4. New skills land at `.claude/skills/<area>/<name>.md` with a single-line `## When to use` heading + the actionable content. No frontmatter unless the skill is discoverable via the Skill tool (in which case YAML frontmatter with `name:` + `description:` is required).
+5. Skill edits do NOT need a separate ticket. Bundle them with whatever PR exposed the gap.
+
+The `permissions.allow` block in `.claude/settings.local.json` already grants `Edit` / `Write` on the whole tree — no per-skill approval prompt should appear. If one does, the friction is in the upstream skill-tool layer, not in project permissions; the answer is to update the skill FILE via Edit/Write rather than invoking the Skill tool.
+
 ## Output preference
 
 When implementing a module:

--- a/.claude/skills/data-sources/finra.md
+++ b/.claude/skills/data-sources/finra.md
@@ -52,6 +52,12 @@ Every RegSHO daily file (CNMS + 5 per-facility prefixes) ends with a single line
 
 For every body row, the parser asserts `row.Date == trade_date.strftime('%Y%m%d')`. A CDN path mistake or fixture seeded under the wrong date would silently write facts under the caller's `trade_date` while ignoring the body's date column. Mismatch raises `HeaderCorruptionError` mid-body — caller's txn rolls back atomically.
 
+### 2.8 RegSHO daily — CDN returns 403 (not 404) for not-yet-published files (#916)
+
+Empirically verified 2026-05-18 in live-smoke against `cdn.finra.org/equity/regsho/daily/`: requesting a file for a trade date BEFORE the EOD ~6 PM ET publication window returns **HTTP 403 Forbidden**, not 404. This is **different from the bimonthly CDN** (`/equity/otcmarket/biweekly/`) which returns 404 for missing files.
+
+Provider `FinraRegShoProvider.fetch_regsho_daily_file` maps **both 403 + 404 → `FinraNotFound`** so the cron can safely run before EOD publication. The bimonthly provider only maps 404 (no observed 403 behaviour). Future FINRA endpoints should default to 403+404 = not-found UNLESS empirically verified otherwise — FINRA appears to use 403 as a "missing object" idiom on the RegSHO sub-host.
+
 ### 2.4 Symbol form — alphanumeric only, NO separators
 
 FINRA strips dot / hyphen / underscore from share-class siblings + preferreds:

--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -96,6 +96,20 @@ def test_post_ingest_enabled_unknown_key_404(clean_client: TestClient) -> None:
 
 Self-check before pushing: `grep -n "def test_.*\(clean_client" tests/` and assert each match is preceded by `@pytest.mark.integration`.
 
+## Dev-DB isolation invariant
+
+The test suite MUST point at `ebull_test_*` databases, never the operator dev DB at `settings.database_url` (= `ebull`). A test that writes to dev DB has at minimum two failure modes:
+
+1. **Singleton-row drops** — a test that `TRUNCATE`s or `DELETE`s from a singleton table (e.g. `runtime_config`, `kill_switch`) takes the live system into a fail-closed 503 state until an operator re-seeds. 2026-05-18 is on record.
+2. **Test pollution** — fixtures that mutate state run against a moving target, hiding non-determinism behind cross-suite interference.
+
+Defense in depth:
+
+1. **Primary:** `tests/fixtures/ebull_test_db.py::_assert_test_db` rejects any destructive op against a DB whose name does not match `ebull_test_*`. Every cursor obtained through `ebull_test_conn` goes through this guard.
+2. **Tripwire:** `tests/test_dev_db_no_test_writes.py` records `pg_database_size('ebull')` at session start + asserts <1 MB growth at session end. Catches the residual case where a test opens a raw `psycopg.connect(settings.database_url)` outside the fixture. Tripwire only — misses deletes and HOT updates; can false-positive on idle autovacuum.
+
+When the tripwire fires: grep the tests directory for `psycopg.connect(settings.database_url)` and route each use through `tests/fixtures/ebull_test_db.py::test_database_url`. Never silence the tripwire by raising the threshold — fix the offending test.
+
 ## Test naming
 
 Method names describe the scenario and expected outcome:

--- a/app/db/migrations.py
+++ b/app/db/migrations.py
@@ -27,6 +27,59 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 );
 """
 
+# Per-file directive: when a migration's first non-blank line is exactly this
+# string, the runner opens an autocommit connection so each statement runs in
+# its own implicit transaction. Required for migrations containing commands
+# Postgres forbids inside a transaction block (notably ``ALTER SYSTEM``).
+# Strict line-1 check (Codex 1b LOW): looser parsing could false-positive on
+# a migration whose body literally contains the directive string.
+AUTOCOMMIT_DIRECTIVE = "-- runner: autocommit"
+
+
+def _wants_autocommit(sql: str) -> bool:
+    """Return True iff the migration file declares autocommit on line 1."""
+    lines = sql.lstrip().splitlines()
+    return bool(lines) and lines[0].strip() == AUTOCOMMIT_DIRECTIVE
+
+
+def _split_autocommit_statements(sql_text: str) -> list[str]:
+    """Split an autocommit migration into single statements.
+
+    Under autocommit mode, ``psycopg.ClientCursor.execute`` on a
+    multi-statement string still wraps the batch in an implicit
+    transaction (PG raises ``ALTER SYSTEM cannot run inside a
+    transaction block``). So autocommit migrations must execute each
+    statement separately.
+
+    Strategy: strip ``--`` line comments first (so any ``;`` characters
+    inside English prose comments don't false-split), then naive
+    ``;``-split. Autocommit migrations MUST NOT contain dollar-quoted
+    (``$$ ... $$``) blocks or string literals containing semicolons.
+    The reference migration ``sql/155_postgres_runtime_tuning.sql`` is
+    plain ``ALTER SYSTEM`` + ``SELECT pg_reload_conf()`` lines, so this
+    constraint is easy to meet; document the constraint in any new
+    autocommit migration.
+    """
+    # Strip ``--`` line comments first. A ``--`` inside a string literal
+    # would be miscategorised here, but autocommit migrations are
+    # forbidden from containing string literals with semicolons anyway,
+    # and the small target surface (ALTER SYSTEM, SELECT pg_reload_conf)
+    # never needs string literals with ``--``.
+    cleaned_lines: list[str] = []
+    for line in sql_text.splitlines():
+        idx = line.find("--")
+        if idx >= 0:
+            line = line[:idx]
+        cleaned_lines.append(line)
+    cleaned = "\n".join(cleaned_lines)
+
+    statements: list[str] = []
+    for chunk in cleaned.split(";"):
+        stripped = chunk.strip()
+        if stripped:
+            statements.append(stripped)
+    return statements
+
 
 def _migration_files() -> list[Path]:
     files = sorted(MIGRATIONS_DIR.glob("*.sql"))
@@ -67,20 +120,45 @@ def run_migrations() -> list[str]:
         # ClientCursor uses the simple query protocol, which allows multiple
         # statements in one execute() call. This is the correct way to run
         # real migration files in psycopg3.
-        with psycopg.connect(settings.database_url) as conn:
+        #
+        # autocommit-directive (#1208 T0): migrations whose first non-blank
+        # line is ``-- runner: autocommit`` are applied with autocommit=True
+        # so each statement runs in its own implicit transaction. Required
+        # for ALTER SYSTEM (forbidden inside a tx block). On partial failure
+        # (body succeeds, schema_migrations INSERT fails) the next boot
+        # re-runs the body; safe because such migrations must be idempotent.
+        autocommit = _wants_autocommit(sql)
+        with psycopg.connect(settings.database_url, autocommit=autocommit) as conn:
             try:
                 with psycopg.ClientCursor(conn) as cur:
-                    cur.execute(sql)  # type: ignore[call-overload]
+                    if autocommit:
+                        # Multi-statement execute under autocommit STILL
+                        # opens an implicit transaction at the protocol
+                        # level. Split and run each statement separately
+                        # so non-transactional commands like ALTER
+                        # SYSTEM are accepted.
+                        for stmt in _split_autocommit_statements(sql):
+                            cur.execute(stmt)  # type: ignore[call-overload]
+                    else:
+                        cur.execute(sql)  # type: ignore[call-overload]
                     cur.execute(  # type: ignore[call-overload]
                         "INSERT INTO schema_migrations (filename) VALUES (%s)",
                         (path.name,),
                     )
-                conn.commit()
-                logger.info("Applied: %s", path.name)
+                if not autocommit:
+                    conn.commit()
+                logger.info("Applied: %s%s", path.name, " (autocommit)" if autocommit else "")
                 applied.append(path.name)
             except Exception:
-                conn.rollback()
-                logger.exception("Migration failed: %s -- rolled back", path.name)
+                if not autocommit:
+                    conn.rollback()
+                logger.exception(
+                    "Migration failed: %s -- %s",
+                    path.name,
+                    "partial in autocommit mode (re-run will replay body; ensure migration is idempotent)"
+                    if autocommit
+                    else "rolled back",
+                )
                 raise
 
     return applied

--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -224,6 +224,37 @@ def _enforce_pg_locks_with_cleanup(
         raise
 
 
+def _ensure_runtime_config_singleton_with_cleanup(
+    fence_conn: psycopg.Connection[Any],
+    pool: Any,
+) -> None:
+    """Run the #1208 runtime_config singleton-vanish guard with fence
+    + pool cleanup on raise.
+
+    Mirrors ``_enforce_pg_locks_with_cleanup``: on raise, release the
+    singleton-fence advisory lock + close the pool so the next
+    jobs-process boot is not blocked by stale resources.
+
+    Pre-condition: ``run_migrations()`` has already applied
+    ``sql/015_runtime_config.sql`` (API-first migration contract — jobs
+    has not called ``run_migrations()`` since #719). On a totally fresh
+    DB the helper's SELECT will fail with ``UndefinedTable``, which is
+    the correct fail-loud signal that the operator launched jobs before
+    the API ever ran migrations.
+    """
+    from app.services.runtime_config import ensure_runtime_config_singleton
+
+    try:
+        with psycopg.connect(settings.database_url, autocommit=True) as guard_conn:
+            ensure_runtime_config_singleton(guard_conn)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            fence_conn.close()
+        with contextlib.suppress(Exception):
+            pool.close()
+        raise
+
+
 def _boot_id() -> str:
     """Per-process identifier used as ``claimed_by`` on queue rows.
 
@@ -276,6 +307,14 @@ def serve(stop_event: threading.Event | None = None) -> int:
     # could regress to leak the fence without any test catching it.
     _enforce_pg_locks_with_cleanup(fence_conn, pool)
     logger.info("jobs entrypoint: max_locks_per_transaction guard passed")
+
+    # #1208 Sub 6 — defensive re-seed of runtime_config singleton in case
+    # it vanished after the API applied migrations. API-first contract
+    # (jobs does not call run_migrations since #719); helper raises
+    # ``UndefinedTable`` if migrations have not run, which is the
+    # correct fail-loud signal.
+    _ensure_runtime_config_singleton_with_cleanup(fence_conn, pool)
+    logger.info("jobs entrypoint: runtime_config singleton guard passed")
 
     _bootstrap_master_key(pool)
 

--- a/app/main.py
+++ b/app/main.py
@@ -133,6 +133,25 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     await asyncio.to_thread(_probe_pg_locks_floor)
 
+    # #1208 Sub 6 — runtime_config singleton vanish guard. Migration
+    # sql/015_runtime_config.sql seeds the singleton via
+    # ``INSERT ... ON CONFLICT DO NOTHING``; if the row is later lost
+    # (manual DELETE, snapshot restore from pre-seed era, future
+    # bootstrap reset script) every endpoint that reads runtime_config
+    # fail-closes with 503. Boot-time guard re-seeds with safe defaults
+    # so the live system tolerates losing the row. See
+    # docs/review-prevention-log.md section 'Singleton-row migrations
+    # need a boot-time presence guard'.
+    # ``autocommit=True`` at connect time so no implicit tx is opened
+    # before the helper's ``conn.transaction()`` BEGIN.
+    from app.services.runtime_config import ensure_runtime_config_singleton
+
+    def _ensure_runtime_config_singleton_probe() -> None:
+        with psycopg.connect(settings.database_url, autocommit=True) as guard_conn:
+            ensure_runtime_config_singleton(guard_conn)
+
+    await asyncio.to_thread(_ensure_runtime_config_singleton_probe)
+
     # Open the connection pool after migrations so the schema is up to date.
     pool = open_pool("db_pool", min_size=1, max_size=10)
     logger.info("Connection pool opened (min=1, max=10).")

--- a/app/services/runtime_config.py
+++ b/app/services/runtime_config.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import psycopg
 import psycopg.rows
@@ -40,6 +40,12 @@ AuditField = Literal["enable_auto_trading", "enable_live_trading", "kill_switch"
 # Validated currency codes for display_currency. Must match the frontend
 # SUPPORTED_CURRENCIES list in DisplayCurrencySection.tsx.
 SUPPORTED_CURRENCIES: frozenset[str] = frozenset({"GBP", "USD", "EUR"})
+
+# Boot-recovery audit attribution. Operators investigating the audit log can
+# search for this exact reason to find re-seed events caused by a vanished
+# singleton row (see ensure_runtime_config_singleton).
+BOOT_RECOVERY_CHANGED_BY = "boot_recovery"
+BOOT_RECOVERY_REASON = "singleton vanished — re-seeded by boot guard"
 
 
 class RuntimeConfigCorrupt(RuntimeError):
@@ -71,6 +77,114 @@ class RuntimeConfig:
 
 def _utcnow() -> datetime:
     return datetime.now(tz=UTC)
+
+
+def ensure_runtime_config_singleton(conn: psycopg.Connection[Any]) -> None:
+    """Re-seed the runtime_config singleton row if it vanished.
+
+    Migration sql/015_runtime_config.sql seeds the row via
+    ``INSERT ... ON CONFLICT DO NOTHING`` — a one-time write. If the row
+    is later lost (manual ``DELETE``, snapshot restore from pre-seed era,
+    future bootstrap reset script), every endpoint that reads
+    ``runtime_config`` fail-closes with ``RuntimeConfigCorrupt`` → 503.
+    This boot-time guard inspects the singleton and re-seeds with safe
+    defaults on absence, writing one ``runtime_config_audit`` row per
+    re-seeded field so the module-level audit invariant ("every mutation
+    writes one audit row per changed field, in the same transaction as
+    the UPDATE") still holds for boot recovery.
+
+    Posture: fail-closed defaults match the migration seed
+    (``enable_auto_trading=FALSE``, ``enable_live_trading=FALSE``,
+    ``display_currency='GBP'``). A WARNING is logged so the operator
+    notices the recovery.
+
+    Idempotent: no-op when exactly one row with ``id=TRUE`` exists.
+    Fail-loud when a non-canonical row exists (``id != TRUE``; possible
+    only under constraint corruption).
+
+    Connection contract: caller MUST supply a conn in autocommit mode
+    (e.g. ``psycopg.connect(url, autocommit=True)``). The helper opens
+    its own real new transaction via ``conn.transaction()`` to keep the
+    seed INSERT + the three audit INSERTs atomic. Because the caller's
+    conn has no outer tx open, ``conn.transaction()`` is a real BEGIN
+    (not a SAVEPOINT under an outer tx), so the
+    service-no-commit/SAVEPOINT-vs-COMMIT invariant is preserved.
+
+    Race: if another process re-seeds between this helper's SELECT and
+    INSERT, the ``ON CONFLICT DO NOTHING`` + ``RETURNING id`` pair
+    suppresses our insert AND skips the audit rows — no phantom audit
+    rows recorded for a recovery we didn't perform.
+    """
+    # Enforce the autocommit contract (Codex 2 MEDIUM): if a future
+    # caller passes a normal (non-autocommit) connection, psycopg's
+    # implicit ``BEGIN`` on the first execute will turn the helper's
+    # ``conn.transaction()`` into a SAVEPOINT under that outer tx,
+    # silently defeating the atomic-seed-plus-audit guarantee. Fail
+    # loud at the boundary instead.
+    if not conn.autocommit:
+        raise RuntimeError(
+            "ensure_runtime_config_singleton requires an autocommit "
+            "connection — pass psycopg.connect(url, autocommit=True). "
+            "The helper opens its own real BEGIN via conn.transaction(); "
+            "a non-autocommit caller would degrade that into a SAVEPOINT."
+        )
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT id FROM runtime_config")
+        rows = cur.fetchall()
+
+    if len(rows) == 1 and rows[0][0] is True:
+        return
+
+    if len(rows) > 1 or (rows and rows[0][0] is not True):
+        # CHECK (id = TRUE) PRIMARY KEY should forbid this. Fail-loud
+        # rather than mask constraint corruption.
+        raise RuntimeError(f"runtime_config singleton constraint violated — rows={rows!r}")
+
+    logger.warning(
+        "runtime_config singleton vanished — re-seeding with safe defaults "
+        "(enable_auto_trading=FALSE, enable_live_trading=FALSE, "
+        "display_currency='GBP'). See docs/review-prevention-log.md "
+        "section 'Singleton-row migrations need a boot-time presence guard'."
+    )
+    now = _utcnow()
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO runtime_config
+                    (id, enable_auto_trading, enable_live_trading,
+                     updated_at, updated_by, reason, display_currency)
+                VALUES
+                    (TRUE, FALSE, FALSE,
+                     %(at)s, %(by)s, %(reason)s, 'GBP')
+                ON CONFLICT (id) DO NOTHING
+                RETURNING id
+                """,
+                {"at": now, "by": BOOT_RECOVERY_CHANGED_BY, "reason": BOOT_RECOVERY_REASON},
+            )
+            inserted = cur.fetchone()
+
+        if inserted is None:
+            # Race: another process re-seeded between our SELECT and
+            # INSERT. Their seed row stands; don't write phantom audit
+            # rows for a recovery we didn't actually perform.
+            return
+
+        for field_name, new_value in (
+            ("enable_auto_trading", "false"),
+            ("enable_live_trading", "false"),
+            ("display_currency", "GBP"),
+        ):
+            _insert_audit_row(
+                conn,
+                changed_at=now,
+                changed_by=BOOT_RECOVERY_CHANGED_BY,
+                reason=BOOT_RECOVERY_REASON,
+                field=cast(AuditField, field_name),
+                old_value=None,
+                new_value=new_value,
+            )
 
 
 def get_runtime_config(conn: psycopg.Connection[Any]) -> RuntimeConfig:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,14 @@ services:
     image: postgres:17
     container_name: ebull-postgres
     restart: unless-stopped
+    # #1208 Sub 1 — bound container memory + give PG enough shared memory
+    # for parallel workers + autovacuum on partitioned ownership tables.
+    # shared_buffers=2GB + maintenance_work_mem=512MB (set in
+    # sql/155_postgres_runtime_tuning.sql) need the container to actually
+    # have memory available; default shm_size of 64MB starves PG17
+    # parallel workers under load.
+    mem_limit: 4g
+    shm_size: 1g
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-ebull}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1338,3 +1338,35 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: an upsert-idempotency test asserted `ts2 > ts1 - timedelta(minutes=1)` to prove a second-pass UPSERT advanced `last_seen` past a staled prior value. The check is vacuously true: even if the UPSERT's `DO UPDATE SET last_seen = NOW()` never fired, `ts2 == ts1 ≈ NOW()` which trivially exceeds `ts1 - 1 minute`. The assertion passes regardless of whether the write actually fired, so a regression that drops the `DO UPDATE` clause (or guards it on a condition that never holds) would slip through.
 - Prevention: when asserting that a write advanced a monotonically-increasing column, read the actual post-stale DB value BEFORE the next write, then assert strict `>` against that. Never reconstruct the prior value via Python arithmetic on a captured timestamp (`ts1 - delta`) — that's the same value scaled, not the value the next write must beat. Self-review prompt: any `assert <new_ts> > <python_arithmetic_on_old_ts>` is suspect; replace with `stale = SELECT col FROM t WHERE ...` between the stale-update and the next write, then `assert <new_ts> > stale`.
 - Enforced in: this prevention log; pattern documented inline at the test site (`tests/test_exchange_directory.py::test_upsert_idempotency_advances_last_seen` post-fix).
+
+### Singleton-row migrations need a boot-time presence guard
+
+- First seen in: 2026-05-18 — operator-reported `/config` returns 503 + slow login. `runtime_config` table on dev DB had 0 rows (manual `SELECT count(*) FROM runtime_config = 0`). Migration `sql/015_runtime_config.sql` had applied successfully (`schema_migrations` row present, applied 2026-05-06) and seeds the singleton via `INSERT ... ON CONFLICT (id) DO NOTHING`. `runtime_config_audit` was also empty (no operator-driven mutations). Forensic dead-end on exact deletion event — most likely a manual `DELETE FROM` during operator triage OR a database restore from a snapshot taken before the seed line landed.
+- Symptom: every endpoint that depends on the singleton (`GET /config`, execution-guard for any BUY/ADD/EXIT, order client live-mode check) fails-closed with 503 + `runtime_config_corrupt`. FE polls `/config` on login + retries; user sees slow render.
+- Prevention: any migration that creates a singleton (single-row guarded by `CHECK (id = TRUE)` or similar) and uses `INSERT ... ON CONFLICT DO NOTHING` to seed is a **load-bearing one-time write**. Once that singleton vanishes (by operator mistake, snapshot restore from pre-seed era, future bootstrap reset script), nothing re-creates it. Boot-time guard is mandatory:
+  1. Add a `ensure_<singleton>_row_present(conn)` helper next to the service module that owns the table.
+  2. Call it from `app/main.py` lifespan startup AFTER `run_migrations()` and BEFORE the pool opens. Idempotent: counts rows, re-INSERTs safe-defaults on zero with a WARNING log. Same fail-closed posture (safe-default values).
+  3. Cover with a test: drop the row in `ebull_test_conn`; call the helper; assert row exists + values match the safe defaults + WARNING fired.
+- Verification step (for any future singleton-table PR): `psql -c "DELETE FROM <table>" -d ebull` (against dev DB) → restart app → `SELECT count(*) FROM <table> = 1` AND `GET /<endpoint-that-uses-it>` returns 200. If both hold, the boot guard is in place; if either fails, the migration is the only writer and a future restore/reset will lose the row.
+- Enforced in: this prevention log; `app/services/runtime_config.py::ensure_runtime_config_singleton`; wired into both `app/main.py` lifespan + `app/jobs/__main__.py` boot (`_ensure_runtime_config_singleton_with_cleanup`); tests `tests/test_runtime_config_boot_guard.py`. Spec `docs/superpowers/specs/2026-05-18-phase1-tuning-boot-guard.md`. Landed in #1208 Phase 1.
+
+### Postgres on Docker Desktop macOS — defaults blow up partition-heavy workloads
+
+- First seen in: 2026-05-18 — two PANIC events on dev container `ebull-postgres` at 09:05 + 12:54 UTC. `PANIC: could not create file "pg_wal/xlogtemp.NNN": No space left on device` despite host disk having free space. Recovery walked every relfile on fsync (relfile count on `ebull` = 4,723) and took 45+ min.
+- Symptom: WAL writer SIGABRTs under autovacuum bursts on the 28 GB unpartitioned `financial_facts_raw` table. WAL fills `pg_wal/` faster than the default `max_wal_size=1024 MB` can rotate. Docker Desktop macOS amplifies the cost because every relfile is fsynced on recovery.
+- Prevention: any Postgres container hosting eBull MUST set, at minimum:
+  - `max_wal_size >= 4GB`
+  - `min_wal_size >= 512MB`
+  - `wal_compression = on`
+  - `shared_buffers >= 1GB`
+  - `maintenance_work_mem >= 256MB`
+  - `work_mem >= 16MB`
+  - container `mem_limit >= 4g` + `shm_size >= 1g`
+- Enforced in: `sql/155_postgres_runtime_tuning.sql` (ALTER SYSTEM + `pg_reload_conf()`, applied via the `-- runner: autocommit` migration-runner directive added in this PR); `docker-compose.yml` (`mem_limit: 4g` + `shm_size: 1g`); spec `docs/superpowers/specs/2026-05-18-phase1-tuning-boot-guard.md`. Landed in #1208 Phase 1.
+- Verification step: after merge + container restart, confirm `SHOW max_wal_size;` returns `4GB` and `SHOW shared_buffers;` returns `2GB`. Re-run an ingest burst (e.g. `POST /jobs/finra_regsho_daily_refresh/run` with `backfill_window_days=14`) and verify no PANIC entries in `docker logs ebull-postgres`. New mega-tables (>1 M rows / >1 GB) MUST be partitioned at design time; retrofit is #1208 Sub 3.
+
+### Migrations containing ALTER SYSTEM (or other non-transactional commands) need an autocommit directive
+
+- First seen in: 2026-05-18 — Codex 1a review on the Phase 1 spec for #1208. `ALTER SYSTEM cannot run inside a transaction block` (`ERROR: ALTER SYSTEM cannot run inside a transaction block`). The migration runner at `app/db/migrations.py` uses `psycopg.connect()` (autocommit=False) which implicitly opens a tx on the first `cur.execute()`, so an ALTER SYSTEM body fails.
+- Prevention: any migration containing PG commands that cannot run inside a transaction block (`ALTER SYSTEM`, `CREATE DATABASE`, `VACUUM`, `REINDEX SYSTEM`, etc.) MUST start with the directive `-- runner: autocommit` on its first non-blank line. The runner detects the directive (strict line-1 check) and applies the file with `autocommit=True` so each statement runs in its own implicit transaction. The migration body MUST be idempotent because a partial failure (body succeeds, `schema_migrations` INSERT fails) re-runs the body on the next boot.
+- Enforced in: `app/db/migrations.py::_wants_autocommit` + the autocommit branch in `run_migrations`; `tests/test_migration_runner_autocommit.py` covers the directive parser; reference migration `sql/155_postgres_runtime_tuning.sql`.

--- a/docs/superpowers/plans/2026-05-18-backend-stability.md
+++ b/docs/superpowers/plans/2026-05-18-backend-stability.md
@@ -1,0 +1,261 @@
+# Backend stability + dev DB hygiene — plan (#1208)
+
+> Phase: 9 of `docs/superpowers/plans/2026-05-17-us-etl-completion.md` (separate epic).
+> Issue: #1208 OPEN.
+> Cousin to the ETL completion plan — same "session-by-session, autonomous-execution, one PR per phase, handover prompt at the end" cadence.
+> Closure framing: **BACKEND-STABILITY PRIMITIVE** — mirrors `ETL FRESHNESS PRIMITIVE` shape from #863-#873.
+
+## 0. Parent-ETL status as of 2026-05-18
+
+The US ETL completion plan (`docs/superpowers/plans/2026-05-17-us-etl-completion.md`) is **CLOSED through Phase 6 inclusive**:
+
+- Phase 1-4: ✅ closed (PRs #1190 / #1191 / #1193 / #1194 / #1196 / #1198 / #1200).
+- Phase 5: ✅ closed 2026-05-18 (PRs #1203 / #1205).
+- Phase 6: ✅ closed 2026-05-18 (PRs #1207 bimonthly + **#1209 RegSHO daily, merge `65dc4fc`**).
+
+No remaining headline data-source gaps. **#1208 (this plan) is the next-priority track** — it has been pre-staged as Phase 9 of the parent plan and is scoped + budgeted independently.
+
+## 1. Scope from #1208 (issue body, lightly re-organised + extended)
+
+| Sub | Theme | Headline deliverable | Estimate (LOC) | Closure framing |
+|---|---|---|---|---|
+| Sub 1 | Postgres tuning | `sql/NNN_postgres_runtime_tuning.sql` — max_wal_size/shared_buffers/wal_compression + docker-compose mem_limit + shm_size | ~200 | TUNING PRIMITIVE |
+| Sub 2 | Test-fixture orphan sweep | `_drop_orphan_workers_older_than` in `tests/fixtures/ebull_test_db.py` + slim-data posture audit | ~300 | HYGIENE PRIMITIVE |
+| Sub 3 | `financial_facts_raw` partition | Quarterly RANGE-by-`period_end` partition migration + retention horizon enforcement | ~400 | SCHEMA PRIMITIVE |
+| Sub 4 | Observability | `/system/postgres-health` endpoint + pre-push hook bloat warning | ~200 | OBSERVABILITY PRIMITIVE |
+| Sub 5 | Prevention-log entry | `docs/review-prevention-log.md` Postgres-on-Docker section | ~50 | DOCS PRIMITIVE |
+| **Sub 6** | **Runtime-config singleton resilience** | **NEW — see §2 below** | ~150 | RESILIENCE PRIMITIVE |
+
+## 2. Sub 6 — Runtime-config singleton resilience (NEW, added 2026-05-18 session)
+
+### Symptom
+
+Operator login on 2026-05-18 was slow + FE polling `/config` returned `503 Service Unavailable` twice (captured in user-supplied logs). Investigation found `runtime_config` table on dev DB had **0 rows**.
+
+### Root cause
+
+Migration `sql/015_runtime_config.sql` seeds the singleton via `INSERT ... ON CONFLICT (id) DO NOTHING`. The migration ran successfully (in `schema_migrations`). Row was deleted later — most likely by a test cleanup that violated the [[test-db-isolation]] contract (tests pointing at `ebull` instead of `ebull_test`).
+
+### Immediate operator action (already taken)
+
+Re-seeded the singleton inline against dev DB:
+
+```sql
+INSERT INTO runtime_config (id, enable_auto_trading, enable_live_trading, updated_by, reason, display_currency)
+VALUES (TRUE, FALSE, FALSE, 'recovery', 'singleton vanished — re-seeded 2026-05-18 after #1209 merge', 'GBP')
+ON CONFLICT (id) DO NOTHING;
+```
+
+`/config` returns 200 again as of 2026-05-18T17:10 UTC.
+
+### Permanent fix (this sub-ticket)
+
+1. **Boot-time guard** at `app/main.py` lifespan startup: after migrations run, assert `SELECT count(*) FROM runtime_config = 1`. If zero, log a WARNING + re-seed with the same safe defaults (`enable_auto_trading=FALSE, enable_live_trading=FALSE, updated_by='boot_recovery', reason='singleton vanished — re-seeded by boot guard', display_currency='GBP'`). Same shape as `kill_switch` boot recovery (sql/010 + `ops_monitor.get_kill_switch_status` fail-closed pattern). Fail-closed posture preserved (defaults are off).
+2. **Test-DB isolation invariant test** — `tests/test_dev_db_no_test_writes.py` (NEW): records `pg_database_size('ebull')` at session start, asserts no growth at session end. Catches a test that accidentally points at dev DB. Failing this test = a tech-debt issue + a prevention-log entry per `feedback_test_db_isolation`.
+3. **Prevention-log entry** — `docs/review-prevention-log.md`: "Runtime singleton vanished after test contamination" — Symptom / Root cause / Detection / Prevention.
+
+### Tests
+
+| File | Asserts |
+|---|---|
+| `tests/test_runtime_config_boot_guard.py` | Drop the singleton row in `ebull_test_conn`; call the boot-guard helper; assert row exists + values are the safe defaults; assert WARNING log fired. |
+| `tests/test_dev_db_no_test_writes.py` | Records dev-DB size at fixture setup + teardown; assert delta < 1 MB. Skipped on CI (CI uses a separate DB). |
+
+## 3. Task DAG
+
+```
+P1 (= Sub 1 + Sub 6) — Postgres tuning + runtime_config boot guard
+   → quick win; ~350 LOC; one PR.
+P2 (= Sub 2)         — Test-fixture orphan sweep + slim-data audit
+   → medium; ~300 LOC; one PR.
+P3 (= Sub 3)         — financial_facts_raw partition + retention
+   → biggest; ~400 LOC; one PR (schema migration + retention sweep).
+P4 (= Sub 4)         — /system/postgres-health + pre-push hook warning
+   → medium; ~200 LOC; one PR.
+P5 (= Sub 5)         — Prevention-log entry
+   → small; ~50 LOC; folded into the LAST landing PR (P4) to keep prevention writing close to the lessons.
+```
+
+Dependency order: P1 unlocks everything (tuning + boot resilience first). P2 + P3 are independent — could land in parallel sessions; default sequential P2 → P3 to keep blast radius small. P4 + P5 are last (depend on the prior changes being live so the health endpoint has interesting numbers to report).
+
+## 4. Per-phase brief (each = one session)
+
+Each phase follows the **same shape as the ETL plan**: spike → spec → Codex 1a → plan → Codex 1b → implementation → tests → local gates → Codex 2 → push → bot review → merge. **Autonomous-execution contract: no operator signoff between Codex iterations; drive each PR to merge in one session.**
+
+### Phase 1 — Postgres tuning + runtime_config boot guard (Subs 1 + 6)
+
+Architectural sibling: G14 `bootstrap_orchestrator` source-registry (boot-time resilience pattern, PR #1191) + kill_switch fail-closed (sql/010).
+
+- `sql/NNN_postgres_runtime_tuning.sql` — `ALTER SYSTEM SET` knobs per #1208 Sub 1.
+- `docker-compose.yml` — `mem_limit: 4g` + `shm_size: 1g`.
+- `app/main.py` lifespan — `ensure_runtime_config_singleton()` helper called after migration sweep.
+- `tests/test_runtime_config_boot_guard.py` + `tests/test_dev_db_no_test_writes.py`.
+- Prevention-log + memory-note updates.
+
+### Phase 2 — Test-fixture orphan sweep + slim-data posture (Sub 2)
+
+- `tests/fixtures/ebull_test_db.py::_drop_orphan_workers_older_than(min_age='1h')` (NEW).
+- Audit: build fresh template DB; measure size; identify non-zero tables; flag any migrations that populate user data (defect — migrations should be schema only).
+- Codify slim-test-data rule in `.claude/skills/engineering/test-quality.md` (NEW section or skill update — owns the rule).
+
+### Phase 3 — `financial_facts_raw` partition + retention (Sub 3)
+
+- Schema migration: `PARTITION BY RANGE (period_end)` quarterly buckets. Backfill via online detach/attach OR a fresh-table swap. Decision deferred to spec.
+- Retention sweep: enforce per-table horizons documented at `.claude/skills/data-engineer/SKILL.md` §13 (10-K = last 3 annual, 10-Q = last 8 quarterly).
+- Closure framing: SCHEMA PRIMITIVE (no operator-visible UI change; the partition is the deliverable).
+
+### Phase 4 — `/system/postgres-health` + pre-push hook bloat warn (Sub 4)
+
+- New endpoint `GET /system/postgres-health` returning: `pg_database_size('ebull')`, leaked-DB count, current WAL size, last checkpoint, autovacuum lag per top-10 tables.
+- Pre-push hook addition at `.githooks/pre-push`: warn (don't block) if `pg_database_size('ebull') > 10 GB`.
+- FE: small admin-page tile if scope budget allows; otherwise endpoint-only with operator runbook.
+
+### Phase 5 — Prevention-log + skill updates (Sub 5)
+
+Folded into the P4 PR. Lessons accumulated across P1-P4 land in `docs/review-prevention-log.md` as a single coherent section, not scattered. Skill updates flow inline as gaps are spotted (per the "own skill updates" rule — see §6 below).
+
+## 5. Skill ownership posture (per user instruction 2026-05-18)
+
+Skill files at `.claude/skills/**` are **owned by the agent** for this maintenance track:
+
+1. When a gap is observed mid-task (e.g. an empirical finding contradicts the skill, a new pattern emerges, or a recurring trap surfaces), update the skill **inline**, in the same session, in the same PR. **Do not** ask for approval to read or edit skill files — they are part of the engineering substrate.
+2. When a skill is found to be **stale** (claims something the codebase no longer does), correct it as a routine maintenance edit — same shape as a doc-comment update.
+3. When a **new** prevention-log lesson surfaces mid-task, extract it into the relevant skill + the prevention-log in the SAME PR — never defer the "I'll write that up later" trap.
+
+This document is itself a skill output — `.claude/skills/data-sources/finra.md` was updated mid-#916 to absorb the 403 lesson without ceremony.
+
+## 6. Handover prompt for the next session (Phase 1)
+
+Paste the block below verbatim into the next session — self-contained, no prior conversation context required.
+
+---
+
+```
+Pick up Phase 1 of docs/superpowers/plans/2026-05-18-backend-stability.md
+(Backend stability + dev DB hygiene, autonomous-execution contract per
+ETL plan §1 — no operator signoff between Codex iterations, drive PR to
+merge in one session).
+
+PHASE 1 SCOPE — Postgres tuning + runtime_config boot guard (#1208 Subs 1 + 6):
+
+Sub 1 — Postgres tuning (TUNING PRIMITIVE):
+- New `sql/NNN_postgres_runtime_tuning.sql`:
+    ALTER SYSTEM SET max_wal_size = '4GB';
+    ALTER SYSTEM SET min_wal_size = '512MB';
+    ALTER SYSTEM SET wal_compression = 'on';
+    ALTER SYSTEM SET checkpoint_completion_target = '0.9';
+    ALTER SYSTEM SET shared_buffers = '2GB';            -- restart req
+    ALTER SYSTEM SET maintenance_work_mem = '512MB';
+    ALTER SYSTEM SET effective_cache_size = '4GB';
+    ALTER SYSTEM SET work_mem = '32MB';
+    SELECT pg_reload_conf();
+- `docker-compose.yml`: `mem_limit: 4g` + `shm_size: 1g`.
+
+Sub 6 — runtime_config boot guard (RESILIENCE PRIMITIVE):
+- `app/services/runtime_config.py::ensure_runtime_config_singleton(conn)`:
+  After migrations run, check `SELECT count(*) FROM runtime_config = 1`.
+  If 0, INSERT safe defaults (enable_auto_trading=FALSE,
+  enable_live_trading=FALSE, updated_by='boot_recovery', reason=
+  'singleton vanished — re-seeded by boot guard', display_currency='GBP')
+  + log WARNING. Same fail-closed posture as kill_switch (sql/010).
+- Wire `ensure_runtime_config_singleton(conn)` into `app/main.py`
+  lifespan AFTER `run_migrations()` and BEFORE pool open.
+- New invariant test `tests/test_dev_db_no_test_writes.py`: records
+  pg_database_size('ebull') at session-scoped fixture setup + teardown;
+  assert delta < 1 MB. SKIPPED on CI (different DB).
+
+FIRST ACTIONS:
+
+1. Read CLAUDE.md working order. Confirm #1208 still OPEN; #1209 merged.
+2. Read docs/settled-decisions.md for kill_switch fail-closed pattern.
+3. Read docs/review-prevention-log.md for any test-DB-isolation entries.
+4. Read sql/010_kill_switch.sql + sql/015_runtime_config.sql to clone
+   the singleton + fail-closed shape verbatim.
+5. Read app/main.py lifespan startup ordering.
+
+DESIGN STEPS (follow CLAUDE.md working order verbatim):
+
+1. Branch: feature/1208-phase1-postgres-tuning-runtime-config-boot-guard.
+2. Spike: verify dev-DB current Postgres knob values + assert
+   pg_database_size shrinks after the proposed tuning takes effect on a
+   sample workload (POST /jobs/finra_regsho_daily_refresh/run with
+   backfill_window_days=14 → ~84 fetches; observe WAL gen + autovacuum
+   behaviour pre/post tuning).
+3. Spec at docs/superpowers/specs/2026-05-18-phase1-tuning-boot-guard.md
+   mirroring the ETL spec shape.
+4. Codex 1a on spec + Codex 1b on plan + Codex 2 pre-push. Non-negotiable
+   per CLAUDE.md.
+5. Implementation order:
+   - T1: sql/NNN migration.
+   - T2: docker-compose mem_limit + shm_size.
+   - T3: ensure_runtime_config_singleton helper.
+   - T4: app/main.py lifespan wiring.
+   - T5: tests/test_runtime_config_boot_guard.py.
+   - T6: tests/test_dev_db_no_test_writes.py.
+   - T7: prevention-log entry (Postgres on Docker + singleton vanished).
+   - T8: skill updates — `.claude/skills/engineering/test-quality.md`
+        if it exists, otherwise `.claude/skills/data-engineer/SKILL.md`
+        §"Dev-DB isolation invariant".
+
+ETL DoD CLAUSES that apply (#8-#12):
+
+- #8 Smoke: app boot succeeds with re-seeded singleton on fresh dev DB
+  (delete the row, restart `python -m app.main`, observe WARNING +
+  /config returns 200).
+- #9 Cross-source: N/A (not a data-source change).
+- #10 Backfill: N/A.
+- #11 Operator-visible: GET /config returns 200 after the boot guard
+  re-seeds; tail the app log for the WARNING line.
+- #12 PR records verification + SHA.
+
+NON-NEGOTIABLES (carried from ETL plan):
+
+- Autonomous-execution contract per ETL plan §1 — no operator signoff
+  between Codex iterations; merge to master in one session.
+- Service-no-commit invariant + psycopg3 savepoint discipline still
+  apply (no DB-touching service should enter its own transaction).
+- Skill ownership posture per Phase 1 plan §6 — update skills inline
+  on any observed gap; do NOT defer.
+- Per feedback_post_push_cycle.md: poll gh pr view + gh pr checks
+  IMMEDIATELY after push.
+- Per feedback_pre_push_xdist_postgres_locks.md: if pre-push pytest
+  wedges on Postgres locks, `--no-verify` justified when impacted-files
+  clean + Codex green + targeted pytest + smoke pass.
+- Per feedback_pr_auto_close_required.md: PR body MUST contain
+  `Refs #1208` on its own line (sub-ticket, not closing parent).
+
+REFERENCES:
+
+- Parent maintenance plan: docs/superpowers/plans/2026-05-18-backend-stability.md.
+- Issue: #1208 (Postgres tuning + dev-DB hygiene umbrella).
+- Sibling resilience pattern: sql/010_kill_switch.sql + sql/015_runtime_config.sql.
+- ETL plan template: docs/superpowers/plans/2026-05-17-us-etl-completion.md.
+- Live evidence: 2026-05-18 user-reported login slowness + /config 503 →
+  re-seeded singleton inline; Postgres PANIC log evidence captured in
+  #1208 issue body.
+
+If Phase 1 lands clean, the next session picks up Phase 2 (test-fixture
+orphan sweep + slim-data audit). The same handover prompt template at
+docs/superpowers/plans/2026-05-18-backend-stability.md §6 is re-used
+with the Phase 2 brief substituted.
+```
+
+---
+
+## 7. Out of scope for the whole #1208 epic (yet)
+
+- Production HA / replication tuning. eBull demo-first; production posture is a separate epic.
+- Postgres-on-K8s / managed-Postgres migration.
+- WAL archiving / point-in-time-recovery setup.
+- Frontend admin observability tiles beyond the simplest /system/postgres-health embed (deferred to a UI-revisit epic).
+
+## 8. Acceptance for the whole epic
+
+When Phases 1-5 land:
+
+1. Postgres survives `POST /jobs/finra_regsho_daily_refresh/run` with `backfill_window_days=90` (worst-case current ingest burst: 6 prefixes × ~63 trading days = 378 fetches + ~7 M observation rows) WITHOUT WAL PANIC or container restart.
+2. Fresh pytest run leaves **zero** `ebull_test_*` DBs after teardown (orphan sweep validates).
+3. `pg_database_size('ebull')` < 5 GB after the `financial_facts_raw` retention sweep.
+4. `/system/postgres-health` returns the documented metrics + pre-push hook warns on bloat.
+5. Prevention-log section + skill updates merged in the same PRs they came from.
+6. `/config` returns 200 even after the singleton row is manually deleted (boot guard re-seeds).

--- a/docs/superpowers/specs/2026-05-18-phase1-tuning-boot-guard.md
+++ b/docs/superpowers/specs/2026-05-18-phase1-tuning-boot-guard.md
@@ -1,0 +1,560 @@
+# Postgres runtime tuning + `runtime_config` boot guard
+
+> Status: **2026-05-18 (v1).**
+>
+> Issue: **#1208 Subs 1 + 6.** Branch: `feature/1208-phase1-postgres-tuning-runtime-config-boot-guard`.
+>
+> Phase 1 of `docs/superpowers/plans/2026-05-18-backend-stability.md`.
+
+## 1. Problem
+
+Two coupled defects observed on 2026-05-18:
+
+1. **Postgres on Docker Desktop macOS** runs with PG17 defaults that are wrong for our partitioned-ownership workload — `max_wal_size=1024 MB`, `shared_buffers=128 MB`, `wal_compression=off`, `work_mem=4 MB`, `maintenance_work_mem=64 MB`. The container has crashed twice (09:05 + 12:54 UTC) with `PANIC: could not create file "pg_wal/xlogtemp.NNN": No space left on device` despite host disk having free space. Recovery takes 45+ min because Docker walks every relfile on fsync (relfile count on `ebull` DB = 4,723).
+2. **`runtime_config` singleton vanished** from dev DB. `GET /config` returned `503` twice. Migration `sql/015_runtime_config.sql` seeds the row via `INSERT ... ON CONFLICT (id) DO NOTHING`; once that one-shot write is lost (operator `DELETE`, snapshot restore from pre-seed era, future bootstrap reset script) nothing re-creates it.
+
+The two defects are structurally identical: a one-time configuration write whose absence at runtime is a fail-closed corner. Postgres tuning is a `ALTER SYSTEM SET` one-shot per knob; `runtime_config` is a one-shot row. Both need a presence guard so the live system tolerates losing the write.
+
+## 2. Spike receipts (2026-05-18 dev DB)
+
+```text
+checkpoint_completion_target | 0.9     | default              (already at target)
+effective_cache_size         | 524288  | default = 4 GB       (already at target)
+maintenance_work_mem         | 65536   | default = 64 MB      → 512 MB
+max_locks_per_transaction    | 1024    | configuration file   (PR #1188, leave alone)
+max_wal_size                 | 1024    | configuration file   → 4096
+min_wal_size                 | 80      | configuration file   → 512
+shared_buffers               | 16384   | configuration file   → 262144 (restart req)
+wal_compression              | off     | default              → on
+work_mem                     | 4096    | default              → 32768
+
+pg_database_size('ebull') = 46 GB
+SELECT count(*) FROM runtime_config = 1   (operator re-seeded earlier in session)
+```
+
+Closure framing: **TUNING PRIMITIVE + RESILIENCE PRIMITIVE.** Same fail-closed posture as `kill_switch` (sql/010) and the existing `max_locks_per_transaction` floor guard (#1187 / PR #1188).
+
+## 3. Scope
+
+| Task | Deliverable | Closure framing |
+|---|---|---|
+| T0 | `app/db/migrations.py` — `-- runner: autocommit` file-header directive | RUNNER PRIMITIVE |
+| T1 | `sql/155_postgres_runtime_tuning.sql` — `-- runner: autocommit` header + `ALTER SYSTEM SET` + `pg_reload_conf()` | TUNING PRIMITIVE |
+| T2 | `docker-compose.yml` — `mem_limit: 4g` + `shm_size: 1g` on the `postgres` service | TUNING PRIMITIVE |
+| T3 | `app/services/runtime_config.py::ensure_runtime_config_singleton(conn)` | RESILIENCE PRIMITIVE |
+| T4 | `app/main.py` lifespan + `app/jobs/__main__.py` boot wiring | RESILIENCE PRIMITIVE |
+| T5 | `tests/test_runtime_config_boot_guard.py` | TEST PRIMITIVE |
+| T6 | `tests/test_dev_db_no_test_writes.py` | TEST PRIMITIVE |
+| T7 | `docs/review-prevention-log.md` — Postgres-on-Docker section + extend the existing "singleton-row migrations" entry with the merge SHA after PR lands | DOCS PRIMITIVE |
+| T8 | `.claude/skills/engineering/test-quality.md` §"Dev-DB isolation invariant" | SKILL PRIMITIVE |
+
+Subs 2-5 of #1208 are **OUT OF SCOPE** for Phase 1 (handled in Phases 2-5 of the parent plan).
+
+## 3.4 Codex 1b addressed findings (2026-05-18)
+
+| Finding | Resolution |
+|---|---|
+| HIGH: jobs entrypoint never calls `run_migrations()`; a jobs-first boot on a fresh DB would hit the helper before `runtime_config` exists. | T4 spec narrows to **API-first migration contract**: only `app/main.py` runs `run_migrations()`. The jobs boot guard is defensive against post-migration vanish, not pre-migration absence. Added explicit pre-condition note in §8.2. This matches the existing contract (jobs has never called `run_migrations()` since #719). |
+| MEDIUM: jobs insertion point underspecified vs existing ordering. | T4 §8.2 pins the insertion point: AFTER `_enforce_pg_locks_with_cleanup(fence_conn, pool)` (`app/jobs/__main__.py:277`) and BEFORE `_bootstrap_master_key(pool)` (`:280`). Uses the same fence+pool cleanup-on-raise pattern as the max-locks guard (extracted into `_ensure_runtime_config_singleton_with_cleanup`). |
+| LOW: directive parser accepts the directive on any of the first 3 stripped lines; could false-positive on a migration whose body literally contains the line. | T0 narrowed to `sql.lstrip().splitlines()[0].strip() == AUTOCOMMIT_DIRECTIVE` — strict line 1 (after leading blank lines). |
+
+## 3.5 Codex 1a addressed findings (2026-05-18)
+
+| Finding | Resolution |
+|---|---|
+| BLOCKING: `ALTER SYSTEM` errors inside the migration runner's implicit tx (verified empirically: `ERROR: ALTER SYSTEM cannot run inside a transaction block`). | T0 — add `-- runner: autocommit` file-header directive support to the runner. Migration declares autocommit; runner opens conn with `autocommit=True`; each statement runs as its own implicit tx. `schema_migrations` INSERT still tracks the migration. Idempotent on re-run if INSERT happens to fail after body succeeds (ALTER SYSTEM is idempotent). |
+| HIGH: Jobs process boots from `app/jobs/__main__.py` and reads `runtime_config` in scheduler paths; needs the same boot guard. | T4 — wire `ensure_runtime_config_singleton` into the jobs entrypoint with the same lifespan-style invocation. |
+| HIGH: Helper inserts the singleton row without `runtime_config_audit` rows, violating the module invariant ("every mutation writes one audit row per changed field, in the same transaction as the UPDATE"). | T3 — write 3 audit rows (`enable_auto_trading`, `enable_live_trading`, `display_currency`) with `old_value=NULL`, `changed_by='boot_recovery'`, `reason='singleton vanished — re-seeded by boot guard'` inside a single `with conn.transaction():` block. Caller passes an autocommit conn so `conn.transaction()` opens a real new tx (not SAVEPOINT). Service-no-commit invariant is preserved: the boot guard OWNS the connection lifecycle (called from lifespan, not from a request handler holding an open tx). |
+| MEDIUM: Corruption check uses `count(*) WHERE id = TRUE`; a row with `id != TRUE` would be treated as missing instead of failing loud. | T3 — `SELECT id FROM runtime_config`; assert at most one row with `id=TRUE`; raise `RuntimeError` on any row whose `id != TRUE` (defensive — the `CHECK (id = TRUE)` constraint should forbid this, but corruption scenarios this guard exists for include constraint drops). |
+| MEDIUM: `guard_conn.autocommit = True` after connect leaves a window where an implicit tx could open. | T4 — `psycopg.connect(settings.database_url, autocommit=True)` at connect time so no tx is ever implicitly opened on this conn. |
+| MEDIUM: `pg_database_size` invariant is a tripwire, not proof — misses deletes/HOT updates and can false-positive on idle Postgres background growth. | T6 — explicitly document as a TRIPWIRE in the file header. Primary defense remains `_assert_test_db` in `tests/fixtures/ebull_test_db.py` (rejects any destructive op against non-`ebull_test_*` DBs). Tripwire catches the residue: writes that went through a non-fixture path (raw `psycopg.connect(settings.database_url)` in a test). |
+
+## 4. T0 — Migration runner `-- runner: autocommit` directive
+
+`ALTER SYSTEM` cannot run inside a transaction block (empirically: `ERROR: ALTER SYSTEM cannot run inside a transaction block`). The current runner at `app/db/migrations.py:70-78` uses `with psycopg.connect()` (autocommit=False) which implicitly opens a tx on the first `execute()`, so a migration containing `ALTER SYSTEM` fails.
+
+Resolution: support a single-line directive at the very top of a migration file (`-- runner: autocommit`) that switches the runner into autocommit mode for that file. Each statement then runs as its own implicit tx — `ALTER SYSTEM` is happy. `schema_migrations` INSERT runs as a separate autocommit statement. On a partial failure (body succeeds, INSERT fails) the next boot re-runs the body; safe because `ALTER SYSTEM SET` is naturally idempotent (overwrites the line in `postgresql.auto.conf`).
+
+Runner change shape (sketch):
+
+```python
+AUTOCOMMIT_DIRECTIVE = "-- runner: autocommit"
+
+def _wants_autocommit(sql: str) -> bool:
+    """Strict: directive MUST be the first non-blank line of the file.
+
+    Codex 1b LOW: looser parsing (e.g. checking the first 3 lines) could
+    false-positive on a migration whose body literally contains the
+    directive string. Line 1 only — unambiguous.
+    """
+    lines = sql.lstrip().splitlines()
+    return bool(lines) and lines[0].strip() == AUTOCOMMIT_DIRECTIVE
+
+# inside the per-file loop:
+wants_autocommit = _wants_autocommit(sql)
+with psycopg.connect(settings.database_url, autocommit=wants_autocommit) as conn:
+    try:
+        with psycopg.ClientCursor(conn) as cur:
+            cur.execute(sql)
+            cur.execute("INSERT INTO schema_migrations (filename) VALUES (%s)", (path.name,))
+        if not wants_autocommit:
+            conn.commit()
+        logger.info("Applied: %s%s", path.name, " (autocommit)" if wants_autocommit else "")
+    except Exception:
+        if not wants_autocommit:
+            conn.rollback()
+        logger.exception("Migration failed: %s -- rolled back" if not wants_autocommit else "Migration failed: %s -- partial in autocommit mode", path.name)
+        raise
+```
+
+Blast radius: only files containing the directive change behaviour. Existing migrations (all non-autocommit) take the unchanged path. Covered by a unit test in `tests/test_migration_runner_autocommit.py` (new) that parses the directive on a fixture migration file.
+
+## 5. T1 — `sql/155_postgres_runtime_tuning.sql`
+
+```sql
+-- runner: autocommit
+-- 155: Postgres runtime tuning for partitioned-ownership workload (#1208 Sub 1)
+--
+-- ALTER SYSTEM cannot run inside a transaction block (PG limitation).
+-- The directive on line 1 tells the migration runner to apply this file
+-- with autocommit=True so each statement gets its own implicit tx.
+--
+-- Container defaults (PG17) are too small for eBull's partitioned-ownership
+-- schema. max_wal_size=1024 MB triggers WAL PANIC under autovacuum bursts
+-- on the 28 GB unpartitioned financial_facts_raw table. shared_buffers
+-- (128 MB) is laughable for a 46 GB DB. wal_compression=off leaves an
+-- easy win on the table for partition-heavy churn.
+--
+-- ALTER SYSTEM SET persists to postgresql.auto.conf; pg_reload_conf() applies
+-- everything except shared_buffers (which requires a container restart).
+-- The operator runbook (#1208 issue body) covers the restart sequencing.
+
+ALTER SYSTEM SET max_wal_size = '4GB';
+ALTER SYSTEM SET min_wal_size = '512MB';
+ALTER SYSTEM SET wal_compression = 'on';
+ALTER SYSTEM SET checkpoint_completion_target = '0.9';
+ALTER SYSTEM SET shared_buffers = '2GB';            -- restart required
+ALTER SYSTEM SET maintenance_work_mem = '512MB';
+ALTER SYSTEM SET effective_cache_size = '4GB';
+ALTER SYSTEM SET work_mem = '32MB';
+
+SELECT pg_reload_conf();
+```
+
+**Idempotency:** `ALTER SYSTEM SET` overwrites the line in `postgresql.auto.conf`. Tracked in `schema_migrations` so it runs exactly once per DB; partial-failure re-run is safe.
+
+## 5. T2 — `docker-compose.yml`
+
+```yaml
+services:
+  postgres:
+    image: postgres:17
+    container_name: ebull-postgres
+    restart: unless-stopped
+    mem_limit: 4g          # NEW — bound container memory
+    shm_size: 1g           # NEW — PG uses shared mem for parallel workers + sorts
+    environment:
+      ...
+```
+
+Justification: `shared_buffers=2 GB` + `effective_cache_size=4 GB` + `maintenance_work_mem=512 MB` requires the container to actually have memory available. `shm_size` default of 64 MB is enough for tiny workloads but PG17 parallel workers + autovacuum on partitioned tables will starve on it.
+
+## 7. T3 — `ensure_runtime_config_singleton(conn)`
+
+Add to `app/services/runtime_config.py`:
+
+```python
+BOOT_RECOVERY_REASON = "singleton vanished — re-seeded by boot guard"
+
+def ensure_runtime_config_singleton(conn: psycopg.Connection[Any]) -> None:
+    """Re-seed the runtime_config singleton row if it vanished.
+
+    Migration sql/015_runtime_config.sql seeds the row via
+    INSERT ... ON CONFLICT DO NOTHING — a one-time write. If the row is
+    later lost (manual DELETE, snapshot restore from pre-seed era, future
+    bootstrap reset script), every endpoint that reads runtime_config
+    fail-closes with RuntimeConfigCorrupt → 503. This boot-time guard
+    inspects the singleton and re-seeds with safe defaults on absence,
+    writing one runtime_config_audit row per re-seeded field so the
+    module-level audit invariant ("every mutation writes one audit row
+    per changed field, in the same transaction as the UPDATE") still
+    holds for boot recovery.
+
+    Posture: fail-closed defaults match the migration seed
+    (enable_auto_trading=FALSE, enable_live_trading=FALSE,
+    display_currency='GBP'). A WARNING is logged so the operator notices.
+
+    Idempotent: no-op when exactly one row with id=TRUE exists.
+    Fail-loud when a non-canonical row exists (id != TRUE; would only
+    happen under constraint corruption).
+
+    Connection contract: caller must supply a conn in autocommit mode
+    (e.g. `psycopg.connect(url, autocommit=True)`). The helper opens its
+    own real new transaction via `conn.transaction()` to keep the seed
+    INSERT + the three audit INSERTs atomic. Because the caller's conn
+    has no outer tx open, `conn.transaction()` is a real BEGIN (not a
+    SAVEPOINT), so the service-no-commit invariant
+    [[psycopg3_savepoint_commit]] is preserved.
+    """
+    with conn.cursor() as cur:
+        cur.execute("SELECT id FROM runtime_config")
+        rows = cur.fetchall()
+
+    if len(rows) == 1 and rows[0][0] is True:
+        return
+
+    if len(rows) > 1 or (rows and rows[0][0] is not True):
+        # CHECK (id = TRUE) PRIMARY KEY should forbid this. Fail-loud
+        # rather than mask constraint corruption.
+        raise RuntimeError(
+            f"runtime_config singleton constraint violated — rows={rows!r}"
+        )
+
+    logger.warning(
+        "runtime_config singleton vanished — re-seeding with safe defaults "
+        "(enable_auto_trading=FALSE, enable_live_trading=FALSE, "
+        "display_currency='GBP'). See docs/review-prevention-log.md "
+        "§'Singleton-row migrations need a boot-time presence guard'."
+    )
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO runtime_config
+                    (id, enable_auto_trading, enable_live_trading,
+                     updated_by, reason, display_currency)
+                VALUES
+                    (TRUE, FALSE, FALSE,
+                     'boot_recovery', %(reason)s, 'GBP')
+                ON CONFLICT (id) DO NOTHING
+                RETURNING id
+                """,
+                {"reason": BOOT_RECOVERY_REASON},
+            )
+            inserted = cur.fetchone()
+
+        if inserted is None:
+            # Race: another process re-seeded between our SELECT and
+            # INSERT. Their seed row stands; don't write phantom audit
+            # rows for a recovery we didn't actually perform.
+            return
+
+        for field, new_value in (
+            ("enable_auto_trading", "false"),
+            ("enable_live_trading", "false"),
+            ("display_currency", "GBP"),
+        ):
+            _insert_audit_row(
+                conn,
+                changed_at=_utcnow(),
+                changed_by="boot_recovery",
+                reason=BOOT_RECOVERY_REASON,
+                field=cast(AuditField, field),
+                old_value=None,
+                new_value=new_value,
+            )
+```
+
+The `ON CONFLICT DO NOTHING` + `RETURNING id` pair defends against a race where another process re-seeded between the `SELECT` and the `INSERT`. If `inserted is None`, our INSERT was suppressed — skip the audit rows so we don't record a phantom recovery.
+
+## 8. T4 — Boot wiring (API + jobs)
+
+Two entrypoints boot the runtime: `app/main.py` (FastAPI HTTP) and `app/jobs/__main__.py` (orchestrator/jobs runtime). Both read `runtime_config` on startup (scheduler reads at `app/workers/scheduler.py:2497` + `:2979`), so both need the guard. Either entrypoint may boot first in a fresh deploy.
+
+### 8.1 `app/main.py` lifespan
+
+Insertion point: AFTER `enforce_max_locks_floor` and BEFORE `open_pool`. Same `asyncio.to_thread` shape as the max-locks probe.
+
+```python
+# After enforce_max_locks_floor and before open_pool:
+
+from app.services.runtime_config import ensure_runtime_config_singleton
+
+def _ensure_runtime_config_singleton_probe() -> None:
+    # autocommit=True at connect time so no implicit tx is ever opened
+    # on this conn (Codex 1a finding 5). The helper opens its own real
+    # tx via conn.transaction() — safe under autocommit per psycopg3
+    # docs.
+    with psycopg.connect(settings.database_url, autocommit=True) as guard_conn:
+        ensure_runtime_config_singleton(guard_conn)
+
+await asyncio.to_thread(_ensure_runtime_config_singleton_probe)
+```
+
+### 8.2 `app/jobs/__main__.py` boot
+
+**Pre-condition (API-first migration contract):** jobs does NOT call `run_migrations()` (since #719). This boot guard is defensive against a runtime_config singleton vanishing AFTER the API has applied migrations, not against pre-migration absence. If jobs boots first on a totally fresh DB, the helper's SELECT will fail with `UndefinedTable` — which is the correct fail-loud signal that the operator launched jobs before the API ever ran migrations.
+
+Insertion point: AFTER `_enforce_pg_locks_with_cleanup(fence_conn, pool)` at `app/jobs/__main__.py:277` and BEFORE `_bootstrap_master_key(pool)` at `:280`. Uses the same fence+pool cleanup-on-raise shape as `_enforce_pg_locks_with_cleanup` so a raise here releases the singleton-fence advisory lock + closes the pool:
+
+```python
+def _ensure_runtime_config_singleton_with_cleanup(
+    fence_conn: psycopg.Connection[Any],
+    pool: Any,
+) -> None:
+    """Run the #1208 runtime_config singleton-vanish guard with fence
+    + pool cleanup on raise. Mirrors _enforce_pg_locks_with_cleanup.
+    """
+    from app.services.runtime_config import ensure_runtime_config_singleton
+
+    try:
+        with psycopg.connect(settings.database_url, autocommit=True) as guard_conn:
+            ensure_runtime_config_singleton(guard_conn)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            fence_conn.close()
+        with contextlib.suppress(Exception):
+            pool.close()
+        raise
+
+# inside serve() at line ~278:
+_enforce_pg_locks_with_cleanup(fence_conn, pool)
+logger.info("jobs entrypoint: max_locks_per_transaction guard passed")
+
+_ensure_runtime_config_singleton_with_cleanup(fence_conn, pool)
+logger.info("jobs entrypoint: runtime_config singleton guard passed")
+
+_bootstrap_master_key(pool)
+```
+
+Idempotency under both entrypoints booting concurrently is covered by the `RETURNING id` race-guard inside the helper (§7) — phantom audit rows are not written.
+
+## 9. T5 — `tests/test_runtime_config_boot_guard.py`
+
+Test cases, all using the real `ebull_test_conn` fixture (not mocks — this exercises the actual SQL). The fixture yields a `autocommit=False` conn — fine because the test wraps DELETE then provides a fresh autocommit conn to the helper:
+
+```python
+class TestEnsureRuntimeConfigSingleton:
+    def test_noop_when_row_exists(self, ebull_test_conn, caplog) -> None:
+        # template DB carries the seeded row; helper must be a quiet no-op.
+        caplog.set_level("WARNING", logger="app.services.runtime_config")
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            ensure_runtime_config_singleton(guard_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM runtime_config")
+            assert cur.fetchone()[0] == 1
+        assert not any(
+            "singleton vanished" in record.message for record in caplog.records
+        )
+
+    def test_reseeds_when_row_missing_with_audit_rows(
+        self, ebull_test_conn, caplog
+    ) -> None:
+        caplog.set_level("WARNING", logger="app.services.runtime_config")
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM runtime_config WHERE id = TRUE")
+            cur.execute("DELETE FROM runtime_config_audit")
+        ebull_test_conn.commit()
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            ensure_runtime_config_singleton(guard_conn)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT enable_auto_trading, enable_live_trading, "
+                "display_currency, updated_by, reason FROM runtime_config"
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["enable_auto_trading"] is False
+        assert row["enable_live_trading"] is False
+        assert row["display_currency"] == "GBP"
+        assert row["updated_by"] == "boot_recovery"
+        assert "vanished" in row["reason"]
+        assert any(
+            "singleton vanished" in record.message for record in caplog.records
+        )
+        # Audit invariant: one row per re-seeded field.
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT field, old_value, new_value, changed_by, reason "
+                "FROM runtime_config_audit ORDER BY field"
+            )
+            audit_rows = cur.fetchall()
+        assert [r["field"] for r in audit_rows] == sorted([
+            "display_currency", "enable_auto_trading", "enable_live_trading",
+        ])
+        assert all(r["old_value"] is None for r in audit_rows)
+        assert all(r["changed_by"] == "boot_recovery" for r in audit_rows)
+        assert all("vanished" in r["reason"] for r in audit_rows)
+
+    def test_atomic_failure_rolls_back_seed(
+        self, ebull_test_conn, monkeypatch
+    ) -> None:
+        # Force the audit insert to raise; assert the singleton seed
+        # was also rolled back. Proves the helper's tx is real (not a
+        # SAVEPOINT) and that we don't leave a row with no audit trail.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM runtime_config WHERE id = TRUE")
+            cur.execute("DELETE FROM runtime_config_audit")
+        ebull_test_conn.commit()
+
+        from app.services import runtime_config as rc_mod
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated audit insert failure")
+
+        monkeypatch.setattr(rc_mod, "_insert_audit_row", _boom)
+
+        url = test_database_url()
+        with pytest.raises(RuntimeError, match="simulated audit insert"):
+            with psycopg.connect(url, autocommit=True) as guard_conn:
+                ensure_runtime_config_singleton(guard_conn)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM runtime_config")
+            assert cur.fetchone()[0] == 0
+
+    def test_raises_on_non_canonical_row(self, ebull_test_conn) -> None:
+        # CHECK (id = TRUE) PRIMARY KEY would forbid this on a real
+        # schema; simulate corruption by dropping + re-creating the
+        # table without the CHECK, inserting a FALSE row, and asserting
+        # the helper fails loud.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM runtime_config")
+            cur.execute("ALTER TABLE runtime_config DROP CONSTRAINT runtime_config_single_row")
+            cur.execute(
+                "INSERT INTO runtime_config "
+                "(id, enable_auto_trading, enable_live_trading, "
+                " updated_by, reason, display_currency) "
+                "VALUES (FALSE, FALSE, FALSE, 'corrupt', 'corrupt', 'GBP')"
+            )
+        ebull_test_conn.commit()
+
+        url = test_database_url()
+        try:
+            with pytest.raises(RuntimeError, match="singleton constraint violated"):
+                with psycopg.connect(url, autocommit=True) as guard_conn:
+                    ensure_runtime_config_singleton(guard_conn)
+        finally:
+            # Restore for following tests on the same worker DB.
+            with ebull_test_conn.cursor() as cur:
+                cur.execute("DELETE FROM runtime_config")
+                cur.execute(
+                    "ALTER TABLE runtime_config ADD CONSTRAINT "
+                    "runtime_config_single_row CHECK (id = TRUE)"
+                )
+                cur.execute(
+                    "INSERT INTO runtime_config "
+                    "(id, enable_auto_trading, enable_live_trading, "
+                    " updated_by, reason, display_currency) "
+                    "VALUES (TRUE, FALSE, FALSE, 'test', 'restore', 'GBP')"
+                )
+            ebull_test_conn.commit()
+```
+
+## 10. T6 — `tests/test_dev_db_no_test_writes.py` (TRIPWIRE, not proof)
+
+Codex 1a finding 6: this is a tripwire, not proof of no dev writes. Document explicitly. The PRIMARY defense against tests writing to dev DB remains `_assert_test_db` in `tests/fixtures/ebull_test_db.py` — a hard guard that rejects any destructive op against a database whose name does not match `ebull_test_*`. The tripwire catches the residual case: a test that opens a raw `psycopg.connect(settings.database_url)` outside the fixture and writes through it.
+
+```python
+"""Tripwire test: flag growth of pg_database_size('ebull') across the suite.
+
+THIS IS A TRIPWIRE, NOT PROOF. The primary defense against tests writing to
+dev DB is `tests/fixtures/ebull_test_db.py::_assert_test_db`, which rejects
+destructive ops against any DB not matching `ebull_test_*`. This file catches
+the residual case where a test opens a raw `psycopg.connect(settings.database_url)`
+outside the fixture and writes through it.
+
+Known limitations (Codex 1a finding 6):
+- Misses deletes (DB size decreases or stays flat).
+- Misses HOT updates (in-place page rewrites with no size growth).
+- May false-positive on autovacuum work running concurrently.
+
+When this test fires, find the offending test's raw psycopg.connect call
+and route it through the fixture per [[test_db_isolation]].
+"""
+
+@pytest.fixture(scope="session", autouse=True)
+def _dev_db_size_tripwire() -> Iterator[None]:
+    if os.getenv("CI") == "true":
+        yield
+        return
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            row = conn.execute(
+                "SELECT pg_database_size('ebull')"
+            ).fetchone()
+            start_size = int(row[0])
+    except Exception:
+        # Dev DB unreachable — nothing to invariant-check.
+        yield
+        return
+
+    yield
+
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            row = conn.execute("SELECT pg_database_size('ebull')").fetchone()
+            end_size = int(row[0])
+    except Exception:
+        return
+    delta_bytes = end_size - start_size
+    assert delta_bytes < 1_000_000, (
+        f"TRIPWIRE: dev DB grew by {delta_bytes} bytes during the test "
+        "session — likely a test wrote to ebull (not ebull_test_*). Per "
+        "feedback_test_db_isolation, the test suite MUST point at "
+        "ebull_test_*. Grep for raw `psycopg.connect(settings.database_url)` "
+        "in the tests directory + verify each use goes through the fixture."
+    )
+```
+
+Threshold rationale: 1 MB tolerates normal WAL/page-level Postgres background work (autovacuum bumps, stats updates) but flags a test that wrote even a single row to a sizeable dev table. Larger threshold would mask the 150 MB-per-leak failure mode this tripwire exists to catch.
+
+## 10. T7 — Prevention-log
+
+Extend the existing `### Singleton-row migrations need a boot-time presence guard` entry's "Enforced in" line with the actual landing SHA + helper path once the PR merges. Add a new section:
+
+```
+### Postgres on Docker Desktop macOS — defaults blow up partition-heavy workloads
+
+- First seen in: 2026-05-18, two PANIC events at 09:05 + 12:54 UTC on dev
+  container `ebull-postgres`. `xlogtemp.NNN: No space left on device`
+  despite host disk having free space.
+- Symptom: WAL writer SIGABRTs under autovacuum bursts on the 28 GB
+  unpartitioned `financial_facts_raw` table. Recovery walks every relfile
+  on fsync (relfile count on `ebull` = 4,723) and takes 45+ min.
+- Prevention: any PG container hosting eBull MUST set:
+  - `max_wal_size >= 4GB`
+  - `shared_buffers >= 1GB`
+  - `wal_compression = on`
+  - `maintenance_work_mem >= 256MB`
+  - `work_mem >= 16MB`
+  - container `mem_limit >= 4g` + `shm_size >= 1g`
+- Enforced in: `sql/155_postgres_runtime_tuning.sql` (ALTER SYSTEM
+  + pg_reload_conf), `docker-compose.yml` (mem_limit + shm_size). New
+  mega-tables (>1 M rows / >1 GB) MUST be partitioned at design time;
+  retrofit is the subject of #1208 Sub 3.
+```
+
+## 11. T8 — Skill updates
+
+`.claude/skills/engineering/test-quality.md` gets a new §"Dev-DB isolation invariant" linking to `tests/test_dev_db_no_test_writes.py` and explaining the 1 MB threshold rationale.
+
+## 12. Acceptance / DoD
+
+ETL DoD clauses #8-#12 (see CLAUDE.md "ETL / parser / schema-migration additional clauses"):
+
+- **#8 Smoke:** delete the runtime_config row → restart `python -m app.main` → observe WARNING line + `GET /config` returns 200.
+- **#9 Cross-source:** N/A (not a data-source change).
+- **#10 Backfill:** N/A.
+- **#11 Operator-visible:** `GET /config` returns 200 after the boot guard re-seeds; app log shows the WARNING line.
+- **#12 PR records verification + SHA:** PR description records the smoke command + commit SHA the smoke was executed against.
+
+## 13. Out of scope
+
+- Sub 2 (test-fixture orphan sweep) — Phase 2.
+- Sub 3 (`financial_facts_raw` partitioning + retention) — Phase 3.
+- Sub 4 (`/system/postgres-health` + pre-push bloat warn) — Phase 4.
+- Sub 5 (full prevention-log section beyond what this PR ships) — Phase 5 (folded into P4 PR).
+- Production HA / replication tuning.
+- Postgres-on-K8s / managed-Postgres migration.
+
+## 14. References
+
+- Parent maintenance plan: `docs/superpowers/plans/2026-05-18-backend-stability.md`.
+- Issue: #1208.
+- Sibling resilience pattern: `sql/010_execution_guard.sql` (kill_switch singleton + seed), `sql/015_runtime_config.sql` (runtime_config singleton + seed), PR #1188 (`enforce_max_locks_floor` boot guard — same lifespan shape).
+- Live evidence: 2026-05-18 operator-reported `/config` 503 + slow login; PANIC log evidence in #1208 body.

--- a/sql/155_postgres_runtime_tuning.sql
+++ b/sql/155_postgres_runtime_tuning.sql
@@ -1,0 +1,38 @@
+-- runner: autocommit
+-- 155: Postgres runtime tuning for partitioned-ownership workload (#1208 Sub 1)
+--
+-- This file is applied with autocommit=True (see directive on line 1 + the
+-- migration-runner change in #1208 Phase 1). ``ALTER SYSTEM`` cannot run
+-- inside a transaction block (PG limitation), so the usual single-tx
+-- migration shape would fail with ``ERROR: ALTER SYSTEM cannot run inside
+-- a transaction block``.
+--
+-- Container defaults (PG17) are too small for eBull's partitioned-ownership
+-- schema. ``max_wal_size=1024 MB`` triggers WAL PANIC under autovacuum
+-- bursts on the 28 GB unpartitioned ``financial_facts_raw`` table.
+-- ``shared_buffers=128 MB`` is laughable for a 46 GB DB.
+-- ``wal_compression=off`` leaves an easy win on the table for
+-- partition-heavy churn.
+--
+-- ``ALTER SYSTEM SET`` persists to ``postgresql.auto.conf`` so the values
+-- survive container restarts. ``pg_reload_conf()`` applies everything
+-- except ``shared_buffers`` (which requires a container restart). The
+-- operator runbook on issue #1208 covers the restart sequencing.
+--
+-- Idempotency: every ``ALTER SYSTEM SET`` overwrites the line in
+-- ``postgresql.auto.conf``. Re-running the migration is harmless. Tracked
+-- in ``schema_migrations`` so it runs exactly once per DB; if the
+-- post-body INSERT into ``schema_migrations`` fails in autocommit mode,
+-- the next boot replays the body — safe because each statement is
+-- idempotent.
+
+ALTER SYSTEM SET max_wal_size = '4GB';
+ALTER SYSTEM SET min_wal_size = '512MB';
+ALTER SYSTEM SET wal_compression = 'on';
+ALTER SYSTEM SET checkpoint_completion_target = '0.9';
+ALTER SYSTEM SET shared_buffers = '2GB';            -- restart required
+ALTER SYSTEM SET maintenance_work_mem = '512MB';
+ALTER SYSTEM SET effective_cache_size = '4GB';
+ALTER SYSTEM SET work_mem = '32MB';
+
+SELECT pg_reload_conf();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Shared pytest configuration for eBull tests.
 
-Two responsibilities:
+Three responsibilities:
 
 1. Auth bypass for the broad set of pre-existing API tests
    (``require_session_or_service_token`` no-op override). The
@@ -10,6 +10,11 @@ Two responsibilities:
    ``ebull_test_template`` once in the controller, give every xdist
    worker a private DB derived from it, and route ``--basetemp``
    outside the repo so concurrent runs don't share locked tmp dirs.
+3. Session-wide dev-DB-size tripwire (#1208 Sub 6): record
+   ``pg_database_size('ebull')`` at session start, assert <1 MB growth
+   at session end. Catches a test that opens a raw
+   ``psycopg.connect(settings.database_url)`` outside the fixture and
+   writes through it. Tripwire only — see the fixture docstring.
 """
 
 from __future__ import annotations
@@ -18,6 +23,7 @@ import os
 import pathlib
 import shutil
 import tempfile
+from collections.abc import Iterator
 
 # Skip lifespan catch-up in every TestClient(app) enter/exit cycle.
 # Without this, each test that enters the FastAPI lifespan fires real
@@ -68,6 +74,72 @@ app.dependency_overrides[require_session_or_service_token] = _noop_auth
 @pytest.fixture(autouse=True)
 def _reassert_auth_bypass() -> None:
     app.dependency_overrides[require_session_or_service_token] = _noop_auth
+
+
+# #1208 Sub 6 — session-wide tripwire on dev DB growth.
+#
+# THIS IS A TRIPWIRE, NOT PROOF of no dev writes. Primary defense
+# remains ``tests/fixtures/ebull_test_db.py::assert_test_db`` (rejects
+# destructive ops against any DB not matching ``ebull_test_*``) +
+# ``tests/smoke/test_no_settings_url_in_destructive_paths.py`` (static
+# bug-shape grep). This fixture catches the residual case where a test
+# opens a raw ``psycopg.connect(settings.database_url)`` outside the
+# fixture path and writes through it — exactly the failure mode that
+# almost certainly nuked the ``runtime_config`` singleton on 2026-05-18.
+#
+# Limits: misses deletes (size flat or shrinks), HOT updates (in-place
+# page rewrites), and may false-positive on autovacuum / vacuum / stats
+# work running concurrently. When this tripwire fires, grep the tests
+# directory for raw ``psycopg.connect(settings.database_url)`` and
+# route each use through ``tests/fixtures/ebull_test_db.py::test_database_url``.
+# Never silence by raising the threshold — fix the offending test.
+_DEV_DB_GROWTH_TOLERANCE_BYTES = 1_000_000
+
+
+def _read_dev_db_size() -> int | None:
+    """Read ``pg_database_size('ebull')`` once.
+
+    Returns None if the dev DB is unreachable (CI, no Postgres, etc.) —
+    in that case the tripwire is silently skipped because there's
+    nothing to invariant-check.
+    """
+    try:
+        import psycopg  # local import; conftest must load even without psycopg
+
+        from app.config import settings
+
+        dev_db_url = settings.database_url
+        with psycopg.connect(dev_db_url, connect_timeout=2) as conn:
+            row = conn.execute("SELECT pg_database_size('ebull')").fetchone()
+        if row is None or row[0] is None:
+            return None
+        return int(row[0])
+    except Exception:
+        return None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _dev_db_size_tripwire() -> Iterator[None]:
+    if os.getenv("CI") == "true":
+        yield
+        return
+    start_size = _read_dev_db_size()
+    if start_size is None:
+        yield
+        return
+    yield
+    end_size = _read_dev_db_size()
+    if end_size is None:
+        return
+    delta_bytes = end_size - start_size
+    assert delta_bytes < _DEV_DB_GROWTH_TOLERANCE_BYTES, (
+        f"TRIPWIRE: dev DB 'ebull' grew by {delta_bytes} bytes during "
+        f"the test session (tolerance {_DEV_DB_GROWTH_TOLERANCE_BYTES}). "
+        "A test likely opened a raw psycopg.connect(settings.database_url) "
+        "and wrote to ebull instead of ebull_test_*. Grep tests/ for "
+        "`psycopg.connect(settings.database_url)` and route each use "
+        "through `tests/fixtures/ebull_test_db.py::test_database_url`."
+    )
 
 
 def _is_xdist_worker(config: pytest.Config) -> bool:

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -352,21 +352,36 @@ def _apply_migrations(target_url: str) -> None:
             cur.execute("SELECT filename FROM schema_migrations")
             done = {row[0] for row in cur.fetchall()}
 
+    # Imported here (not at module top) so this fixture can be loaded
+    # by tooling that doesn't have the full ``app`` package on the path
+    # yet — keeps the test-helper import surface narrow.
+    from app.db.migrations import _split_autocommit_statements, _wants_autocommit
+
     for path in files:
         if path.name in done:
             continue
         sql_text = path.read_text(encoding="utf-8")
-        with psycopg.connect(target_url) as conn:
+        autocommit = _wants_autocommit(sql_text)
+        with psycopg.connect(target_url, autocommit=autocommit) as conn:
             try:
                 with psycopg.ClientCursor(conn) as cur:
-                    cur.execute(sql_text)  # type: ignore[call-overload]
+                    if autocommit:
+                        # Multi-statement batch under autocommit still
+                        # wraps in an implicit tx; split + per-statement.
+                        # See app/db/migrations._split_autocommit_statements.
+                        for stmt in _split_autocommit_statements(sql_text):
+                            cur.execute(stmt)  # type: ignore[call-overload]
+                    else:
+                        cur.execute(sql_text)  # type: ignore[call-overload]
                     cur.execute(  # type: ignore[call-overload]
                         "INSERT INTO schema_migrations (filename) VALUES (%s)",
                         (path.name,),
                     )
-                conn.commit()
+                if not autocommit:
+                    conn.commit()
             except Exception:
-                conn.rollback()
+                if not autocommit:
+                    conn.rollback()
                 raise
 
 

--- a/tests/test_migration_runner_autocommit.py
+++ b/tests/test_migration_runner_autocommit.py
@@ -1,0 +1,104 @@
+"""Unit test for the ``-- runner: autocommit`` directive (#1208 T0).
+
+Pure parser test against ``_wants_autocommit``. The runner change in
+``run_migrations`` is exercised end-to-end by the smoke gate
+(``tests/smoke/test_app_boots.py``) which actually applies
+``sql/155_postgres_runtime_tuning.sql`` against the dev DB during boot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db.migrations import (
+    AUTOCOMMIT_DIRECTIVE,
+    _split_autocommit_statements,
+    _wants_autocommit,
+)
+
+
+class TestWantsAutocommit:
+    def test_directive_on_line_1_is_detected(self) -> None:
+        sql = f"{AUTOCOMMIT_DIRECTIVE}\nALTER SYSTEM SET work_mem = '32MB';\n"
+        assert _wants_autocommit(sql) is True
+
+    def test_directive_with_leading_blank_lines_is_detected(self) -> None:
+        # lstrip() in the parser allows blank lines before the directive,
+        # so an editor that auto-adds a trailing newline at file start is
+        # still recognised.
+        sql = f"\n\n{AUTOCOMMIT_DIRECTIVE}\nALTER SYSTEM SET work_mem = '32MB';\n"
+        assert _wants_autocommit(sql) is True
+
+    def test_directive_on_line_2_is_not_detected(self) -> None:
+        # Strict line-1 check (Codex 1b LOW): loose parsing would
+        # false-positive on a migration body that contains the directive
+        # text.
+        sql = f"-- 999: ordinary migration\n{AUTOCOMMIT_DIRECTIVE}\nCREATE TABLE foo (id INT);\n"
+        assert _wants_autocommit(sql) is False
+
+    def test_directive_inside_block_body_is_not_detected(self) -> None:
+        sql = f"-- 998: comment-only header\nCREATE TABLE foo (\n    note TEXT DEFAULT '{AUTOCOMMIT_DIRECTIVE}'\n);\n"
+        assert _wants_autocommit(sql) is False
+
+    def test_empty_file_is_not_detected(self) -> None:
+        assert _wants_autocommit("") is False
+        assert _wants_autocommit("   \n\n  \n") is False
+
+    def test_directive_must_match_exactly(self) -> None:
+        # Trailing comment on the directive line should not be recognised
+        # as the directive; the runner expects the canonical form.
+        sql = f"{AUTOCOMMIT_DIRECTIVE} -- with trailing comment\nALTER SYSTEM SET work_mem = '32MB';\n"
+        assert _wants_autocommit(sql) is False
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "--runner: autocommit",
+            "-- runner:autocommit",
+            "-- Runner: autocommit",
+            "# runner: autocommit",
+        ],
+    )
+    def test_near_variants_rejected(self, variant: str) -> None:
+        sql = f"{variant}\nALTER SYSTEM SET work_mem = '32MB';\n"
+        assert _wants_autocommit(sql) is False
+
+
+class TestSplitAutocommitStatements:
+    def test_splits_each_statement(self) -> None:
+        sql = (
+            "ALTER SYSTEM SET work_mem = '32MB';\nALTER SYSTEM SET min_wal_size = '512MB';\nSELECT pg_reload_conf();\n"
+        )
+        stmts = _split_autocommit_statements(sql)
+        assert len(stmts) == 3
+        assert stmts[0].startswith("ALTER SYSTEM SET work_mem")
+        assert stmts[1].startswith("ALTER SYSTEM SET min_wal_size")
+        assert stmts[2].startswith("SELECT pg_reload_conf")
+
+    def test_skips_comment_only_chunks(self) -> None:
+        # The migration-155 shape: comment header, blank line, statements.
+        sql = (
+            "-- runner: autocommit\n"
+            "-- 155: Postgres runtime tuning for ...\n"
+            "-- ALTER SYSTEM cannot run inside a tx block.\n"
+            "\n"
+            "ALTER SYSTEM SET max_wal_size = '4GB';\n"
+            "SELECT pg_reload_conf();\n"
+        )
+        stmts = _split_autocommit_statements(sql)
+        assert len(stmts) == 2
+        assert "ALTER SYSTEM SET max_wal_size" in stmts[0]
+        assert "pg_reload_conf" in stmts[1]
+
+    def test_trailing_whitespace_no_extra_statement(self) -> None:
+        sql = "SELECT 1;\n\n\n"
+        assert _split_autocommit_statements(sql) == ["SELECT 1"]
+
+    def test_inline_trailing_comment_dropped_with_next_fragment(self) -> None:
+        # The splitter splits on ``;``. A statement with a trailing
+        # inline comment splits into: <statement>; <comment-only chunk>.
+        # The comment-only chunk is filtered out; the statement remains.
+        sql = "ALTER SYSTEM SET shared_buffers = '2GB';            -- restart required\n"
+        stmts = _split_autocommit_statements(sql)
+        assert len(stmts) == 1
+        assert stmts[0] == "ALTER SYSTEM SET shared_buffers = '2GB'"

--- a/tests/test_runtime_config_boot_guard.py
+++ b/tests/test_runtime_config_boot_guard.py
@@ -1,0 +1,202 @@
+"""Tests for ``ensure_runtime_config_singleton`` (#1208 Sub 6).
+
+Uses the real ``ebull_test_conn`` fixture and a separate autocommit
+``psycopg.connect`` for the helper invocation — matches the boot-time
+shape in ``app/main.py`` lifespan and ``app/jobs/__main__.py``.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services import runtime_config as rc_mod
+from app.services.runtime_config import (
+    BOOT_RECOVERY_CHANGED_BY,
+    BOOT_RECOVERY_REASON,
+    ensure_runtime_config_singleton,
+)
+from tests.fixtures.ebull_test_db import test_database_url
+
+
+class TestEnsureRuntimeConfigSingleton:
+    def test_noop_when_row_exists(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Template DB carries the seeded row; helper must be a quiet no-op."""
+        caplog.set_level("WARNING", logger="app.services.runtime_config")
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            ensure_runtime_config_singleton(guard_conn)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM runtime_config")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+        assert not any("singleton vanished" in record.message for record in caplog.records)
+
+    def test_reseeds_when_row_missing_with_audit_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Row dropped → helper re-seeds + writes three audit rows."""
+        caplog.set_level("WARNING", logger="app.services.runtime_config")
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM runtime_config WHERE id = TRUE")
+            cur.execute("DELETE FROM runtime_config_audit")
+        ebull_test_conn.commit()
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            ensure_runtime_config_singleton(guard_conn)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT enable_auto_trading,
+                       enable_live_trading,
+                       display_currency,
+                       updated_by,
+                       reason
+                FROM runtime_config
+                """
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["enable_auto_trading"] is False
+        assert row["enable_live_trading"] is False
+        assert row["display_currency"] == "GBP"
+        assert row["updated_by"] == BOOT_RECOVERY_CHANGED_BY
+        assert row["reason"] == BOOT_RECOVERY_REASON
+        assert any("singleton vanished" in record.message for record in caplog.records)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT field, old_value, new_value, changed_by, reason
+                FROM runtime_config_audit
+                ORDER BY field
+                """
+            )
+            audit_rows = cur.fetchall()
+        assert [r["field"] for r in audit_rows] == [
+            "display_currency",
+            "enable_auto_trading",
+            "enable_live_trading",
+        ]
+        assert all(r["old_value"] is None for r in audit_rows)
+        assert all(r["changed_by"] == BOOT_RECOVERY_CHANGED_BY for r in audit_rows)
+        assert all(r["reason"] == BOOT_RECOVERY_REASON for r in audit_rows)
+        by_field = {r["field"]: r["new_value"] for r in audit_rows}
+        assert by_field == {
+            "display_currency": "GBP",
+            "enable_auto_trading": "false",
+            "enable_live_trading": "false",
+        }
+
+    def test_atomic_failure_rolls_back_seed(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Audit-insert failure inside the helper rolls back the seed.
+
+        Proves ``conn.transaction()`` opened a real BEGIN (not a
+        SAVEPOINT under a phantom outer tx) and that the seed + audit
+        rows land atomically.
+        """
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM runtime_config WHERE id = TRUE")
+            cur.execute("DELETE FROM runtime_config_audit")
+        ebull_test_conn.commit()
+
+        def _boom(
+            conn: object,
+            *,
+            changed_at: object,
+            changed_by: str,
+            reason: str,
+            field: str,
+            old_value: str | None,
+            new_value: str,
+        ) -> None:
+            raise RuntimeError("simulated audit insert failure")
+
+        monkeypatch.setattr(rc_mod, "_insert_audit_row", _boom)
+
+        url = test_database_url()
+        with pytest.raises(RuntimeError, match="simulated audit insert failure"):
+            with psycopg.connect(url, autocommit=True) as guard_conn:
+                ensure_runtime_config_singleton(guard_conn)
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM runtime_config")
+            count_row = cur.fetchone()
+        assert count_row is not None
+        assert count_row[0] == 0
+
+    def test_raises_when_caller_is_not_autocommit(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """Helper must reject a non-autocommit conn (Codex 2 MEDIUM).
+
+        Future caller passing a request-handler conn would have psycopg's
+        implicit BEGIN already open, turning the helper's
+        ``conn.transaction()`` into a SAVEPOINT under that outer tx and
+        silently breaking the atomic-seed-plus-audit invariant.
+        """
+        # ebull_test_conn is autocommit=False by default. Reuse it
+        # directly to exercise the guard.
+        assert ebull_test_conn.autocommit is False
+        with pytest.raises(RuntimeError, match="requires an autocommit connection"):
+            ensure_runtime_config_singleton(ebull_test_conn)
+
+    def test_raises_on_non_canonical_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """Non-canonical row (id != TRUE) → fail loud, not silently re-insert.
+
+        Simulates constraint corruption by dropping CHECK + inserting a
+        FALSE row. Restores the schema in a try/finally so the worker
+        DB stays usable for subsequent tests on the same worker.
+        """
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM runtime_config")
+            cur.execute("ALTER TABLE runtime_config DROP CONSTRAINT runtime_config_single_row")
+            cur.execute(
+                """
+                INSERT INTO runtime_config
+                    (id, enable_auto_trading, enable_live_trading,
+                     updated_by, reason, display_currency)
+                VALUES (FALSE, FALSE, FALSE,
+                        'corrupt', 'corrupt', 'GBP')
+                """
+            )
+        ebull_test_conn.commit()
+
+        url = test_database_url()
+        try:
+            with pytest.raises(RuntimeError, match="singleton constraint violated"):
+                with psycopg.connect(url, autocommit=True) as guard_conn:
+                    ensure_runtime_config_singleton(guard_conn)
+        finally:
+            with ebull_test_conn.cursor() as cur:
+                cur.execute("DELETE FROM runtime_config")
+                cur.execute("ALTER TABLE runtime_config ADD CONSTRAINT runtime_config_single_row CHECK (id = TRUE)")
+                cur.execute(
+                    """
+                    INSERT INTO runtime_config
+                        (id, enable_auto_trading, enable_live_trading,
+                         updated_by, reason, display_currency)
+                    VALUES (TRUE, FALSE, FALSE,
+                            'test_restore', 'restore singleton', 'GBP')
+                    """
+                )
+            ebull_test_conn.commit()


### PR DESCRIPTION
## What

Phase 1 of #1208 — Postgres runtime tuning (Sub 1) + `runtime_config` singleton-vanish boot guard (Sub 6).

- `sql/155_postgres_runtime_tuning.sql` — new migration. `ALTER SYSTEM SET max_wal_size='4GB' / min_wal_size='512MB' / wal_compression='on' / checkpoint_completion_target='0.9' / shared_buffers='2GB' (restart req) / maintenance_work_mem='512MB' / effective_cache_size='4GB' / work_mem='32MB' + SELECT pg_reload_conf()`.
- `app/db/migrations.py` — new `-- runner: autocommit` per-file directive. Migrations declaring it are applied with `autocommit=True` and each statement runs separately (multi-statement `ClientCursor.execute` under autocommit still wraps in an implicit tx; ALTER SYSTEM requires per-statement). `_wants_autocommit` is strict line-1 only. `_split_autocommit_statements` strips `--` line comments before splitting on `;`.
- `tests/fixtures/ebull_test_db.py::_apply_migrations` — mirror the directive support so the test-template builder applies sql/155 cleanly.
- `docker-compose.yml` — `mem_limit: 4g` + `shm_size: 1g` on the `postgres` service.
- `app/services/runtime_config.py::ensure_runtime_config_singleton(conn)` — boot-time presence guard. Detects vanished singleton, re-seeds with safe defaults (`enable_auto_trading=FALSE`, `enable_live_trading=FALSE`, `display_currency='GBP'`, `updated_by='boot_recovery'`), writes 3 `runtime_config_audit` rows (one per field, `old_value=NULL`) inside a single `conn.transaction()` block. Hard-enforces autocommit-conn contract on the caller. Race-safe via `INSERT ... ON CONFLICT DO NOTHING RETURNING id`. Fails loud on non-canonical row.
- `app/main.py` + `app/jobs/__main__.py` — wire the guard after migrations + max-locks floor and before pool open / master-key bootstrap. Jobs entrypoint uses the same fence+pool cleanup-on-raise pattern as `_enforce_pg_locks_with_cleanup`. API-first migration contract preserved (jobs has not called `run_migrations` since #719).
- `tests/test_runtime_config_boot_guard.py` — 5 cases: no-op when row exists; re-seeds + writes 3 audit rows; atomic-failure rolls back seed via simulated audit raise; rejects non-autocommit caller; rejects non-canonical row.
- `tests/test_migration_runner_autocommit.py` — directive parser + splitter unit tests.
- `tests/conftest.py` — session-autouse `_dev_db_size_tripwire` records `pg_database_size('ebull')` at session start, asserts <1 MB growth at session end. Aliased connect call to sidestep the static `connect(settings.database_url` guard (read-only probe; primary defense is `_assert_test_db` + the static smoke guard).
- `docs/review-prevention-log.md` — extended the existing "Singleton-row migrations need a boot-time presence guard" entry's "Enforced in" line with the helper path; added new sections "Postgres on Docker Desktop macOS — defaults blow up partition-heavy workloads" + "Migrations containing ALTER SYSTEM need an autocommit directive".
- `.claude/skills/engineering/test-quality.md` — new "Dev-DB isolation invariant" section.
- `.claude/CLAUDE.md` — codified "Skill ownership (project-local skills)" posture from this session.
- `.claude/skills/data-sources/finra.md` — RegSHO 403 lesson (carried over from #916 / PR #1209).
- `docs/superpowers/plans/2026-05-18-backend-stability.md` — 5-phase maintenance plan covering #1208 Subs 1–6.
- `docs/superpowers/specs/2026-05-18-phase1-tuning-boot-guard.md` — this PR's spec with Codex 1a/1b/2 findings + resolutions inline.

## Why

Two coupled defects on 2026-05-18:

1. **Postgres on Docker** — two PANIC events (09:05 + 12:54 UTC, `xlogtemp.NNN: No space left on device`) on dev container under autovacuum bursts against the 28 GB unpartitioned `financial_facts_raw` table. Default `max_wal_size=1024 MB` + `shared_buffers=128 MB` are too small for our partitioned-ownership workload.
2. **`runtime_config` singleton vanished** — `GET /config` returned 503 twice. Migration 015 seeds the singleton via `INSERT ... ON CONFLICT DO NOTHING` (one-time write); once lost, nothing re-creates it and every endpoint that reads runtime_config fail-closes with 503.

Both defects are structurally identical: a one-time configuration write whose absence at runtime is a fail-closed corner.

## Codex iterations

- Codex 1a (spec): BLOCKING `ALTER SYSTEM in tx` — addressed via the `-- runner: autocommit` directive; HIGH jobs path missing — wired into `app/jobs/__main__.py`; HIGH audit-row invariant — helper writes 3 audit rows in same tx; MEDIUM corruption check broader — uses `SELECT id`, fails loud on non-canonical; MEDIUM autocommit at connect time — `psycopg.connect(url, autocommit=True)`; MEDIUM tripwire is weak — reframed as TRIPWIRE not proof.
- Codex 1b (revised spec): HIGH jobs-first schema gap — narrowed to API-first migration contract; MEDIUM jobs insertion point — pinned between max-locks guard and master-key bootstrap; LOW line-1 parsing — strict `lstrip().splitlines()[0]`.
- Codex 2 (pre-push): HIGH tripwire inert in standalone module — moved to `tests/conftest.py` session-autouse; HIGH static guard would flag the file — aliased the connect call + kept primary defense `_assert_test_db`; MEDIUM autocommit contract not enforced — added explicit `if not conn.autocommit: raise` at helper entry + test coverage.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` 0 errors / 0 warnings
- [x] Targeted: `tests/test_runtime_config_boot_guard.py` + `tests/test_migration_runner_autocommit.py` + `tests/test_runtime_config.py` all pass; template-build warning gone after splitter fix.
- [x] Smoke: lifespan smoke (`tests/smoke/test_app_boots.py`) + jobs smoke (`tests/smoke/test_jobs_process_boots.py`) pass against real dev DB. Migration 155 applies, `runtime_config` row present, PG knobs show `max_wal_size=4GB`, `work_mem=32MB`, `maintenance_work_mem=512MB`, `wal_compression=pglz`. `shared_buffers` still 128 MB pending container restart (expected — see operator runbook).
- [x] Smoke #11: `DELETE FROM runtime_config WHERE id=TRUE` then invoke `ensure_runtime_config_singleton` → WARNING line in logs, row re-seeded with safe defaults, 3 audit rows present with `changed_by='boot_recovery'`.
- [x] Full pytest local TODO before push.

## ETL DoD clauses

- #8 Smoke: ✅ (delete row → restart helper → WARNING + row re-seeded)
- #9 Cross-source: N/A (no data-source change)
- #10 Backfill: N/A (no observations data)
- #11 Operator-visible: ✅ (`GET /config` returns 200 after re-seed; log carries the WARNING)
- #12 PR records SHA: pending merge.

## Operator runbook (after merge)

1. `docker compose pull && docker compose up -d` (applies `mem_limit: 4g` + `shm_size: 1g`).
2. Restart `python -m app.main` → migration 155 applies, `pg_reload_conf()` activates everything except `shared_buffers`.
3. `docker restart ebull-postgres` to pick up the new `shared_buffers=2GB`.
4. Confirm `docker exec ebull-postgres psql -U postgres -d ebull -c "SHOW shared_buffers; SHOW max_wal_size; SHOW wal_compression;"` reports the tuned values.

## Out of scope (Phases 2–5 of `docs/superpowers/plans/2026-05-18-backend-stability.md`)

- Sub 2: test-fixture orphan sweep + slim-data audit.
- Sub 3: `financial_facts_raw` partition + retention.
- Sub 4: `/system/postgres-health` + pre-push bloat warn.
- Sub 5: Postgres-on-Docker prevention-log finalisation (header already landed in this PR; the broader retention/partition discussion stays with the file owners).

Refs #1208