### PR TITLE
feat(#1010): bound 13F bootstrap sweep cohort to active-recent HR filers

### DIFF
--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -129,6 +129,18 @@ Source: <https://www.sec.gov/files/form_13f.pdf> §5.7.
 
 13F filed within **45 days after each calendar quarter end**.
 
+**13F-HR vs 13F-NT (cohort signal, #1010)** — a filer "active in 13F" can mean either:
+form.idx exposes both `13F-HR` (holdings) and `13F-NT` (notice; another manager
+files our holdings). NT entries contribute **zero** infotable rows, so iterating
+an NT-only filer in `sec_13f_quarterly_sweep` costs the submissions.json roundtrip
+and writes nothing. `institutional_filers.last_13f_hr_at` (#1010,
+[sec_13f_filer_directory.py:42](../../../app/services/sec_13f_filer_directory.py#L42))
+is the HR-only recency signal — distinct from `last_filing_at` which mixes both.
+Bootstrap stage 21 filters cohort on this column (cohort drops 11k → ~3-5k);
+the manual / sweep-adapter / Admin "Run now" path keeps the full cohort as a
+safety-net so a previously-inactive filer can re-enter when they resume HR
+filing.
+
 ### 2.2 N-PORT-P XML schema
 
 Source: <https://www.sec.gov/info/edgar/specifications/form-n-port-xml-tech-specs.htm>.

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Any, Final, Literal
 
 import psycopg
@@ -143,13 +143,18 @@ _FILINGS_HISTORY_KEEP_FORMS_TUPLE: tuple[str, ...] = tuple(sorted(SEC_INGEST_KEE
 # at dispatch time. The sentinel string is namespaced so it never
 # collides with a legitimate operator value.
 _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF = "<dynamic:bootstrap_13f_cutoff>"
+# #1010 — sibling sentinel for the HR-recency cohort cutoff on stage
+# 21. Filters ``institutional_filers.last_13f_hr_at >= cutoff`` so the
+# sweep iterates only currently-active HR filers.
+_PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF = "<dynamic:bootstrap_13f_hr_cutoff>"
 
 
 def _resolve_dynamic_params(params: Mapping[str, Any]) -> dict[str, Any]:
     """Materialise dispatch-time dynamic values in a stage params dict.
 
-    Today the only dynamic value is the bootstrap-13F recency cutoff;
-    the helper is structured for forward extensibility (additional
+    Today the dynamic values are the bootstrap-13F recency cutoffs
+    (one for ``min_period_of_report``, one for ``min_last_13f_hr_at``).
+    The helper is structured for forward extensibility (additional
     sentinels can be added without touching call sites).
 
     The dispatcher calls this immediately before invoking the
@@ -159,6 +164,20 @@ def _resolve_dynamic_params(params: Mapping[str, Any]) -> dict[str, Any]:
     resolved: dict[str, Any] = dict(params)
     if resolved.get("min_period_of_report") == _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF:
         resolved["min_period_of_report"] = date.today() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS)
+    if resolved.get("min_last_13f_hr_at") == _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF:
+        # UTC start-of-day so the boundary is inclusive against
+        # ``form.idx`` dates which are stored at midnight UTC. Two
+        # subtle pitfalls avoided here:
+        #   (1) using the full timestamp (no ``.date()`` truncation)
+        #       would drift the cutoff during the day and exclude
+        #       filings whose form.idx date is exactly ``today() -
+        #       380d`` (Codex 1a B-3); (2) ``date.today()`` returns
+        #       *local* time — on a non-UTC dev host around the
+        #       local/UTC date boundary it would shift the cutoff by
+        #       ±1 day and silently exclude an exact-boundary UTC
+        #       filer (Codex 2 MEDIUM). Take the UTC date explicitly.
+        cutoff_date = datetime.now(tz=UTC).date() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS)
+        resolved["min_last_13f_hr_at"] = datetime.combine(cutoff_date, time(0, 0), tzinfo=UTC)
     return resolved
 
 
@@ -888,8 +907,13 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
         # ``date.today()`` here would freeze the cutoff at module-load,
         # so a long-lived jobs process would dispatch stage 21 with a
         # stale floor. The sentinel keeps the StageSpec data-only.
+        # ``min_last_13f_hr_at`` (#1010) bounds the cohort to filers
+        # whose most recent 13F-HR / HR/A is within the same 380-day
+        # window — collapses 11,205 → ≈ 3-5k active filers and drops
+        # bootstrap stage 21 wall-clock from ~8h to ≤3h.
         params={
             "min_period_of_report": _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF,
+            "min_last_13f_hr_at": _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF,
             "source_label": "sec_edgar_13f_directory_bootstrap",
         },
     ),

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -372,7 +372,11 @@ def _list_active_filer_seeds(conn: psycopg.Connection[tuple]) -> list[str]:
     return [_zero_pad_cik(row[0]) for row in cur.fetchall()]
 
 
-def list_directory_filer_ciks(conn: psycopg.Connection[tuple]) -> list[str]:
+def list_directory_filer_ciks(
+    conn: psycopg.Connection[tuple],
+    *,
+    min_last_13f_hr_at: datetime | None = None,
+) -> list[str]:
     """Walk every CIK in ``institutional_filers`` (the SEC 13F filer
     directory populated by ``sec_13f_filer_directory_sync`` #912).
 
@@ -382,14 +386,35 @@ def list_directory_filer_ciks(conn: psycopg.Connection[tuple]) -> list[str]:
     deadline-budget interruption then leaves the long-tail
     (low-activity filers) for the next sweep without losing the
     operator-relevant household names.
+
+    ``min_last_13f_hr_at`` (#1010) is an optional cohort filter for
+    the bootstrap-stage 21 dispatch. When set, the result is
+    restricted to filers with a known 13F-HR / 13F-HR/A filing on or
+    after the cutoff (NULL ``last_13f_hr_at`` is excluded). The
+    ordering also switches to ``last_13f_hr_at DESC NULLS LAST`` so
+    the bootstrap-bounded cohort is sorted by most-recent HR first —
+    the standalone (full-cohort) path's ``last_filing_at`` ordering
+    is preserved unchanged.
     """
-    cur = conn.execute(
-        """
-        SELECT cik
-        FROM institutional_filers
-        ORDER BY last_filing_at DESC NULLS LAST, cik
-        """
-    )
+    if min_last_13f_hr_at is None:
+        cur = conn.execute(
+            """
+            SELECT cik
+            FROM institutional_filers
+            ORDER BY last_filing_at DESC NULLS LAST, cik
+            """
+        )
+    else:
+        cur = conn.execute(
+            """
+            SELECT cik
+            FROM institutional_filers
+            WHERE last_13f_hr_at IS NOT NULL
+              AND last_13f_hr_at >= %(cutoff)s
+            ORDER BY last_13f_hr_at DESC NULLS LAST, cik
+            """,
+            {"cutoff": min_last_13f_hr_at},
+        )
     return [_zero_pad_cik(row[0]) for row in cur.fetchall()]
 
 
@@ -633,16 +658,34 @@ def _upsert_filer(
     the latest-quarter holdings per filer on read.
     """
     filer_type = classify_filer_type(conn, info.cik)
+    # Per-filing ingest only reaches ``_upsert_filer`` for accessions
+    # whose form_type is 13F-HR or 13F-HR/A (filtered in
+    # ``parse_submissions_index`` at line 243), so ``info.filed_at``
+    # always represents an HR filing — safe to advance
+    # ``last_13f_hr_at`` unconditionally (#1010 Codex 1a B-2).
     cur = conn.execute(
         """
-        INSERT INTO institutional_filers (cik, name, filer_type, last_filing_at)
-        VALUES (%(cik)s, %(name)s, %(filer_type)s, %(last_filing_at)s)
+        INSERT INTO institutional_filers (
+            cik, name, filer_type, last_filing_at, last_13f_hr_at
+        )
+        VALUES (
+            %(cik)s, %(name)s, %(filer_type)s, %(filed_at)s, %(filed_at)s
+        )
         ON CONFLICT (cik) DO UPDATE SET
             name = EXCLUDED.name,
             filer_type = EXCLUDED.filer_type,
             last_filing_at = GREATEST(
                 COALESCE(institutional_filers.last_filing_at, '-infinity'),
                 COALESCE(EXCLUDED.last_filing_at, '-infinity')
+            ),
+            -- HR-only recency: NULLIF collapses the '-infinity' sentinel
+            -- back to NULL when both sides are NULL (#1010 Codex 1a B-1).
+            last_13f_hr_at = NULLIF(
+                GREATEST(
+                    COALESCE(institutional_filers.last_13f_hr_at, '-infinity'::timestamptz),
+                    COALESCE(EXCLUDED.last_13f_hr_at,            '-infinity'::timestamptz)
+                ),
+                '-infinity'::timestamptz
             ),
             fetched_at = NOW()
         RETURNING filer_id
@@ -651,7 +694,7 @@ def _upsert_filer(
             "cik": info.cik,
             "name": info.name,
             "filer_type": filer_type,
-            "last_filing_at": info.filed_at,
+            "filed_at": info.filed_at,
         },
     )
     row = cur.fetchone()

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -159,10 +159,13 @@ class ParamMetadata(BaseModel):
 JOB_INTERNAL_KEYS: dict[str, frozenset[str]] = {
     # Bootstrap variant of sec_13f_quarterly_sweep tags rows with a
     # distinct source_label so audit history can distinguish bootstrap-
-    # bounded sweeps from the standalone weekly historical sweep. The
-    # operator never edits this — it lives in the bootstrap StageSpec's
-    # params dict.
-    "sec_13f_quarterly_sweep": frozenset({"source_label"}),
+    # bounded sweeps from the standalone manual / sweep-adapter path.
+    # ``min_last_13f_hr_at`` (#1010) is the HR-recency cohort filter
+    # exclusive to bootstrap stage 21 — exposing it on the manual API
+    # would let an operator accidentally drop the standalone path's
+    # full-cohort safety-net. Both keys live in the bootstrap
+    # StageSpec's params dict.
+    "sec_13f_quarterly_sweep": frozenset({"source_label", "min_last_13f_hr_at"}),
     # PR1c #1064 — bootstrap-only invokers promoted from bespoke
     # wrappers. These jobs are NOT in SCHEDULED_JOBS today (no cron
     # cadence), so they have no operator-facing ``ParamMetadata``;

--- a/app/services/sec_13f_filer_directory.py
+++ b/app/services/sec_13f_filer_directory.py
@@ -44,6 +44,13 @@ logger = logging.getLogger(__name__)
 # bandwidth but don't add new filers — the tail is bounded.
 DEFAULT_QUARTERS: int = 4
 
+# HR-only subset of ``_THIRTEEN_F_FORM_TYPES``. Used to populate
+# ``institutional_filers.last_13f_hr_at`` distinct from the all-form
+# ``last_filing_at``. 13F-NT / 13F-NT/A are notice-only filings (no
+# holdings) and must not contribute to the HR-recency signal that
+# bounds the bootstrap cohort (#1010).
+_THIRTEEN_F_HR_FORM_TYPES: frozenset[str] = frozenset({"13F-HR", "13F-HR/A"})
+
 
 @dataclass(frozen=True)
 class FilerDirectorySyncResult:
@@ -85,11 +92,17 @@ def _aggregate_filer_directory(
     quarters: list[tuple[int, int]],
     *,
     fetch: Callable[[int, int], str],
-) -> tuple[dict[str, str], dict[str, date], int]:
+) -> tuple[dict[str, str], dict[str, date], dict[str, date], int]:
     """Walk each quarter's form.idx and aggregate the latest 13F-HR
     company_name + filing date per CIK.
 
-    Returns ``(latest_name_by_cik, latest_filed_by_cik, quarters_failed)``.
+    Returns ``(latest_name_by_cik, latest_filed_by_cik,
+    latest_hr_filed_by_cik, quarters_failed)``. ``latest_hr_filed`` is
+    HR-only (13F-HR + 13F-HR/A); ``latest_filed`` is all-forms (HR +
+    HR/A + NT + NT/A) and feeds ``last_filing_at``. The HR-only dict
+    feeds the new ``last_13f_hr_at`` column that bounds the
+    bootstrap-stage 21 cohort (#1010).
+
     Per-quarter fetch failures are isolated — a transient SEC outage
     on one quarter must not abort the whole sweep, partial coverage
     beats aborting. ``latest_name`` keys on the most recent
@@ -101,6 +114,7 @@ def _aggregate_filer_directory(
     """
     latest_name: dict[str, str] = {}
     latest_filed: dict[str, date] = {}
+    latest_hr_filed: dict[str, date] = {}
     failed = 0
     for year, q in quarters:
         try:
@@ -123,7 +137,14 @@ def _aggregate_filer_directory(
             elif entry.date_filed == prior_date and entry.company_name > latest_name[entry.cik]:
                 # Same-day tiebreak — deterministic by name.
                 latest_name[entry.cik] = entry.company_name
-    return latest_name, latest_filed, failed
+            # HR-only tracking is independent — 13F-NT/NT-A entries
+            # must NOT advance ``latest_hr_filed`` even when newer
+            # than the existing HR date. #1010.
+            if entry.form_type in _THIRTEEN_F_HR_FORM_TYPES:
+                prior_hr = latest_hr_filed.get(entry.cik)
+                if prior_hr is None or entry.date_filed > prior_hr:
+                    latest_hr_filed[entry.cik] = entry.date_filed
+    return latest_name, latest_filed, latest_hr_filed, failed
 
 
 def _bulk_classify_filer_type(
@@ -199,7 +220,7 @@ def sync_filer_directory(
     """
     today_d = today if today is not None else datetime.now(tz=UTC).date()
     qs = _last_n_quarters(today_d, quarters)
-    latest_name, latest_filed, failed = _aggregate_filer_directory(qs, fetch=fetch)
+    latest_name, latest_filed, latest_hr_filed, failed = _aggregate_filer_directory(qs, fetch=fetch)
 
     skipped_empty_name = 0
     valid_ciks: list[str] = []
@@ -238,14 +259,20 @@ def sync_filer_directory(
         # the TIMESTAMPTZ column so GREATEST() comparisons against
         # later-arriving timestamps stay monotone.
         last_filing_ts = datetime.combine(filed_d, time(0, 0), tzinfo=UTC)
+        # HR-only filing recency (NEW #1010). NULL when this CIK was
+        # seen only via 13F-NT / NT-A in the form.idx walk — the
+        # NULLIF guard in the UPSERT keeps an NT-only filer's column
+        # NULL so the cohort filter excludes them.
+        hr_filed_d = latest_hr_filed.get(cik)
+        last_13f_hr_at = datetime.combine(hr_filed_d, time(0, 0), tzinfo=UTC) if hr_filed_d is not None else None
         # ``filer_type`` is only consumed on INSERT (DO UPDATE
         # preserves the existing value); pre-existing rows pass
         # ``'INV'`` as a no-op placeholder.
         filer_type = filer_types.get(cik, "INV")
         row = conn.execute(
             """
-            INSERT INTO institutional_filers (cik, name, filer_type, last_filing_at)
-            VALUES (%(cik)s, %(name)s, %(filer_type)s, %(last_filing_at)s)
+            INSERT INTO institutional_filers (cik, name, filer_type, last_filing_at, last_13f_hr_at)
+            VALUES (%(cik)s, %(name)s, %(filer_type)s, %(last_filing_at)s, %(last_13f_hr_at)s)
             ON CONFLICT (cik) DO UPDATE SET
                 -- Only refresh name when the incoming filing is at
                 -- least as recent as the stored one. Without this
@@ -264,6 +291,17 @@ def sync_filer_directory(
                     COALESCE(institutional_filers.last_filing_at, '-infinity'),
                     COALESCE(EXCLUDED.last_filing_at, '-infinity')
                 ),
+                -- HR-only recency: NULLIF collapses the '-infinity'
+                -- sentinel back to NULL when both sides are NULL, so
+                -- an NT-only filer with no prior HR keeps NULL and is
+                -- excluded by the cohort filter (#1010 Codex 1a B-1).
+                last_13f_hr_at = NULLIF(
+                    GREATEST(
+                        COALESCE(institutional_filers.last_13f_hr_at, '-infinity'::timestamptz),
+                        COALESCE(EXCLUDED.last_13f_hr_at,            '-infinity'::timestamptz)
+                    ),
+                    '-infinity'::timestamptz
+                ),
                 fetched_at = NOW()
             RETURNING (xmax = 0) AS was_inserted
             """,
@@ -272,6 +310,7 @@ def sync_filer_directory(
                 "name": name,
                 "filer_type": filer_type,
                 "last_filing_at": last_filing_ts,
+                "last_13f_hr_at": last_13f_hr_at,
             },
         ).fetchone()
         # ``xmax = 0`` is true on a fresh INSERT, false when an UPDATE

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4290,19 +4290,27 @@ def sec_13f_quarterly_sweep(params: Mapping[str, Any]) -> None:
     tombstoned in ``institutional_holdings_ingest_log`` so a
     deadline-interrupted sweep resumes the tail on the next fire.
 
-    Honoured params (PR1c #1064):
+    Honoured params (PR1c #1064 + #1010):
 
     * ``min_period_of_report`` (date) — recency floor; accessions whose
       ``period_of_report`` is older are skipped. Default ``None`` = no
       floor (full historical sweep). Bootstrap stage 21 dispatches with
       ``today() - 380d`` so first-install completes in ~30-45 min
       instead of 11+h.
+    * ``min_last_13f_hr_at`` (datetime, #1010) — cohort filter; only
+      filers whose most recent 13F-HR / 13F-HR/A in
+      ``institutional_filers.last_13f_hr_at`` is at or after this
+      cutoff are iterated. Default ``None`` = full cohort (manual /
+      sweep-adapter / Admin "Run now" safety-net path). Bootstrap
+      stage 21 dispatches with ``today() - 380d`` at UTC midnight so
+      first-install completes in ≤ 3 h vs the unbounded ~8 h. Internal
+      key — operator-API path REJECTS this via ``JOB_INTERNAL_KEYS``.
     * ``source_label`` (str, audit-only) — provenance tag on each
       ingested holding row. Default ``"sec_edgar_13f_directory"``;
       bootstrap stage 21 overrides with
       ``"sec_edgar_13f_directory_bootstrap"`` so audit history
       distinguishes bootstrap-bounded sweeps from the standalone
-      weekly historical sweep. Operator-API path REJECTS this key
+      manual / sweep-adapter path. Operator-API path REJECTS this key
       via ``JOB_INTERNAL_KEYS`` allow-list (#1064 PR1a).
     """
     from app.providers.implementations.sec_edgar import SecFilingsProvider
@@ -4321,6 +4329,26 @@ def sec_13f_quarterly_sweep(params: Mapping[str, Any]) -> None:
     else:
         # Validator should have coerced; defensive against direct invocation.
         min_period_of_report = date.fromisoformat(str(min_period_of_report_param))
+
+    # #1010 — HR-recency cohort filter. The bootstrap resolver always
+    # produces a tz-aware UTC datetime; the explicit naive-value tag
+    # below is defence-in-depth for direct invocation / future callers
+    # so psycopg never falls back to the server's local zone (Codex 1b
+    # minor).
+    min_last_13f_hr_at_param = params.get("min_last_13f_hr_at")
+    min_last_13f_hr_at: datetime | None
+    if min_last_13f_hr_at_param is None:
+        min_last_13f_hr_at = None
+    elif isinstance(min_last_13f_hr_at_param, datetime):
+        min_last_13f_hr_at = (
+            min_last_13f_hr_at_param
+            if min_last_13f_hr_at_param.tzinfo is not None
+            else min_last_13f_hr_at_param.replace(tzinfo=UTC)
+        )
+    else:
+        parsed = datetime.fromisoformat(str(min_last_13f_hr_at_param))
+        min_last_13f_hr_at = parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
     source_label = str(params.get("source_label") or "sec_edgar_13f_directory")
 
     with _tracked_job(JOB_SEC_13F_QUARTERLY_SWEEP) as tracker:
@@ -4328,7 +4356,7 @@ def sec_13f_quarterly_sweep(params: Mapping[str, Any]) -> None:
             SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
             psycopg.connect(settings.database_url) as conn,
         ):
-            ciks = list_directory_filer_ciks(conn)
+            ciks = list_directory_filer_ciks(conn, min_last_13f_hr_at=min_last_13f_hr_at)
             summaries = ingest_all_active_filers(
                 conn,
                 sec,
@@ -4348,7 +4376,8 @@ def sec_13f_quarterly_sweep(params: Mapping[str, Any]) -> None:
             "sec_13f_quarterly_sweep: filers=%d processed=%d "
             "accessions_ingested=%d holdings_inserted=%d "
             "holdings_skipped_no_cusip=%d "
-            "source_label=%s min_period_of_report=%s",
+            "source_label=%s min_period_of_report=%s "
+            "min_last_13f_hr_at=%s",
             total_filers,
             processed,
             accessions_ingested,
@@ -4356,6 +4385,7 @@ def sec_13f_quarterly_sweep(params: Mapping[str, Any]) -> None:
             rows_skipped,
             source_label,
             min_period_of_report,
+            min_last_13f_hr_at,
         )
 
 

--- a/docs/superpowers/specs/2026-05-19-1010-13f-cohort-bound.md
+++ b/docs/superpowers/specs/2026-05-19-1010-13f-cohort-bound.md
@@ -1,0 +1,512 @@
+# #1010 — Bound 13F sweep cohort to active-recent HR filers
+
+> Created **2026-05-19** as Phase A.2 of
+> [`docs/superpowers/plans/2026-05-19-post-1208-cleardown.md`](../plans/2026-05-19-post-1208-cleardown.md).
+> Closes #1010. Same cadence as #1218 (PR #1220 / `f451e18`).
+
+## 1. Problem
+
+`bootstrap_sec_13f_recent_sweep` (stage 21 in
+`_BOOTSTRAP_STAGE_SPECS`) dispatches `sec_13f_quarterly_sweep` against
+the **full** `institutional_filers` cohort (11,205 rows in the dev
+DB). The sweep walks every CIK looking for 13F-HR / 13F-HR/A
+accessions whose `period_of_report` is within the last 380 days.
+
+Operator smoke 2026-05-07: 700 filers / 30 min = ~23 filers/min → full
+cohort ≈ 8 hours wall-clock on first install.
+
+Two compounding problems make most of those 11,205 walks empty:
+
+1. `institutional_filers` admits any CIK that ever filed a **13F-HR or
+   13F-NT** in the last four quarters (the directory walk treats both
+   as "institutional filer"). 13F-NT is a notice-only filing
+   ("another manager files my holdings") with zero holdings. Iterating
+   an NT-only filer produces an empty `infotable` and writes nothing.
+2. There is no recency-of-HR filter at cohort-listing time.
+   `min_period_of_report` filters **accessions**, not **filers**, so a
+   filer with no recent HR still costs the round-trip to discover
+   that.
+
+The recency-of-HR signal we want already exists in the source data
+(`form.idx` form_type per quarterly walk) but is collapsed into a
+single `last_filing_at` column that mixes HR + HR/A + NT + NT/A.
+
+## 2. Goal
+
+Bound the bootstrap-stage cohort to filers with a **13F-HR**
+(holdings-bearing) filing within the last 4 quarters. Keep the
+standalone manual / sweep-adapter path's full-cohort safety-net so a previously
+inactive filer can re-enter the universe when they resume filing
+13F-HR.
+
+Target: stage 21 wall-clock drops from ~8 h to ≤ 3 h on a fresh dev DB.
+
+## 3. Design
+
+### 3.1 Schema
+
+Migration `sql/157_institutional_filers_last_13f_hr_at.sql` adds:
+
+```sql
+ALTER TABLE institutional_filers
+    ADD COLUMN last_13f_hr_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_institutional_filers_last_13f_hr_at
+    ON institutional_filers (last_13f_hr_at DESC NULLS LAST);
+```
+
+The new column is **distinct** from the existing `last_filing_at`:
+
+| Column            | Form types contributing            | Semantics                                                                                       |
+|-------------------|------------------------------------|-------------------------------------------------------------------------------------------------|
+| `last_filing_at`  | 13F-HR + 13F-HR/A + 13F-NT + NT/A  | Most recent activity of ANY 13F kind. Unchanged behaviour. Used for ordering, not for filtering. |
+| `last_13f_hr_at`  | 13F-HR + 13F-HR/A **only**         | Most recent holdings-bearing filing. NEW. Used to filter the bootstrap cohort.                  |
+
+Migration backfills the new column for existing rows from
+`ownership_institutions_observations` (`source = '13f'`):
+
+```sql
+UPDATE institutional_filers f
+SET last_13f_hr_at = sub.max_filed_at
+FROM (
+    SELECT filer_cik, MAX(filed_at) AS max_filed_at
+    FROM ownership_institutions_observations
+    WHERE source = '13f'
+    GROUP BY filer_cik
+) sub
+WHERE f.cik = sub.filer_cik;
+```
+
+**Backfill caveat (Codex 1a M-1):** This is an
+**approximation**, not a ground-truth HR filing recency. The
+observations table only contains 13F-HR rows whose CUSIPs resolved to
+a universe instrument. An HR filing is **absent** from this signal
+when:
+
+- The HR was an empty / exempt-list / cancellation filing (legal,
+  writes zero observations).
+- Every CUSIP in the infotable failed to resolve (#740 backfill gap,
+  non-universe instruments only).
+- The HR predates the bulk dataset coverage window AND the legacy
+  per-filing ingest never ran for that CIK.
+
+The acceptable outcome of these misses is that the affected filer is
+**excluded** from the bootstrap cohort. The next scheduled run of
+`sec_13f_filer_directory_sync` (still in `SCHEDULED_JOBS`) reads
+`form.idx` directly and
+re-populates `last_13f_hr_at` from the canonical source — so any
+miss is self-correcting within one cadence cycle and the cost is at
+most one missed bootstrap-stage 21 inclusion.
+
+### 3.2 Directory sync (`app/services/sec_13f_filer_directory.py`)
+
+`_aggregate_filer_directory` already iterates every form_type in
+`_THIRTEEN_F_FORM_TYPES = {13F-HR, 13F-HR/A, 13F-NT, 13F-NT/A}`. Split
+the aggregation:
+
+```python
+def _aggregate_filer_directory(...) -> tuple[
+    dict[str, str],   # latest_name_by_cik (unchanged)
+    dict[str, date],  # latest_filed_by_cik (any form, unchanged)
+    dict[str, date],  # latest_hr_filed_by_cik (HR + HR/A only)  ← NEW
+    int,              # quarters_failed (unchanged)
+]:
+```
+
+HR-only forms = `{"13F-HR", "13F-HR/A"}`. Hoist as a module-level
+`_THIRTEEN_F_HR_FORM_TYPES` frozenset alongside the existing
+`_THIRTEEN_F_FORM_TYPES` constant (same single-source-of-truth
+discipline as the existing `_VALUE_DOLLARS_CUTOVER` etc.).
+
+`sync_filer_directory` UPSERT writes `last_13f_hr_at` with a
+NULL-safe GREATEST shape (Codex 1a B-1):
+
+```sql
+last_13f_hr_at = NULLIF(
+    GREATEST(
+        COALESCE(institutional_filers.last_13f_hr_at, '-infinity'::timestamptz),
+        COALESCE(EXCLUDED.last_13f_hr_at,            '-infinity'::timestamptz)
+    ),
+    '-infinity'::timestamptz
+)
+```
+
+The `NULLIF` collapses the sentinel back to NULL so an NT-only filer
+with no prior HR date keeps `last_13f_hr_at IS NULL` — preserving
+the `WHERE last_13f_hr_at IS NOT NULL` filter invariant. For an
+existing HR filer that later only files NTs, the previously stored
+value is preserved (not regressed). For a new HR filer, the incoming
+HR date wins.
+
+### 3.2b Per-filing HR ingest (`app/services/institutional_holdings.py::_upsert_filer`)
+
+Per Codex 1a B-2, the legacy per-filing path also upserts
+`institutional_filers` and must advance `last_13f_hr_at`. This
+function is invoked exclusively from `_ingest_single_accession` →
+`ingest_filer_13f`, whose `parse_submissions_index` filters to
+`form in ("13F-HR", "13F-HR/A")` (verified at
+`app/services/institutional_holdings.py:184` and the filter at
+`app/services/institutional_holdings.py:243`). Every call therefore
+represents an HR filing; no extra form-type flag is needed.
+
+Extend the UPSERT to include the new column with the same NULLIF-
+guarded GREATEST shape:
+
+```sql
+INSERT INTO institutional_filers (
+    cik, name, filer_type, last_filing_at, last_13f_hr_at
+)
+VALUES (
+    %(cik)s, %(name)s, %(filer_type)s,
+    %(filed_at)s, %(filed_at)s
+)
+ON CONFLICT (cik) DO UPDATE SET
+    ...
+    last_filing_at = GREATEST(...),                         -- unchanged
+    last_13f_hr_at = NULLIF(
+        GREATEST(
+            COALESCE(institutional_filers.last_13f_hr_at, '-infinity'::timestamptz),
+            COALESCE(EXCLUDED.last_13f_hr_at,            '-infinity'::timestamptz)
+        ),
+        '-infinity'::timestamptz
+    ),
+    ...
+```
+
+The 13F bulk dataset ingester
+(`app/services/sec_13f_dataset_ingest.py`) writes only to
+`ownership_institutions_observations` and never touches
+`institutional_filers` directly. `last_13f_hr_at` for filers seen
+only via the bulk path is set by `sec_13f_filer_directory_sync` (the
+form.idx walk) — the bulk ingester is intentionally a no-op against
+this column.
+
+### 3.3 Cohort listing (`app/services/institutional_holdings.py::list_directory_filer_ciks`)
+
+Add an optional kwarg:
+
+```python
+def list_directory_filer_ciks(
+    conn: psycopg.Connection[tuple],
+    *,
+    min_last_13f_hr_at: datetime | None = None,  # ← NEW
+) -> list[str]:
+```
+
+Behaviour:
+
+- `min_last_13f_hr_at is None` → unchanged: full cohort,
+  `ORDER BY last_filing_at DESC NULLS LAST, cik` (preserves
+  manual-trigger + sweep-adapter semantics — safety-net path keeps
+  all filers in their existing iteration order).
+- non-None → `WHERE last_13f_hr_at IS NOT NULL AND last_13f_hr_at >= %s`
+  + `ORDER BY last_13f_hr_at DESC NULLS LAST, cik` (HR-recency-first
+  is the operator-relevance order for the bootstrap-bounded cohort).
+
+Switching the order key only when the HR filter is active (Codex 1a
+M-3) keeps the standalone path's behaviour exactly as it was, while
+giving the bootstrap path the more useful HR-first ordering for its
+filtered cohort.
+
+### 3.4 Sweep body (`app/workers/scheduler.py::sec_13f_quarterly_sweep`)
+
+Add a second honoured param alongside `min_period_of_report`:
+
+```python
+min_last_13f_hr_at_param = params.get("min_last_13f_hr_at")
+min_last_13f_hr_at: datetime | None
+if min_last_13f_hr_at_param is None:
+    min_last_13f_hr_at = None
+elif isinstance(min_last_13f_hr_at_param, datetime):
+    # Naive datetime → tag UTC. The resolver always produces tz-aware
+    # UTC; this branch only catches direct invocations / future
+    # callers that hand in a naive value. Without this guard psycopg
+    # would fall back to the server's local zone (Codex 1b minor).
+    min_last_13f_hr_at = (
+        min_last_13f_hr_at_param
+        if min_last_13f_hr_at_param.tzinfo is not None
+        else min_last_13f_hr_at_param.replace(tzinfo=UTC)
+    )
+else:
+    parsed = datetime.fromisoformat(str(min_last_13f_hr_at_param))
+    min_last_13f_hr_at = parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+ciks = list_directory_filer_ciks(conn, min_last_13f_hr_at=min_last_13f_hr_at)
+```
+
+Logging gains the new field so operator can audit which cohort was
+used. Tracker telemetry unchanged.
+
+### 3.5 Bootstrap stage dispatch (`app/services/bootstrap_orchestrator.py`)
+
+Stage 21 gains a second dynamic-resolver sentinel:
+
+```python
+_PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF = "<dynamic:bootstrap_13f_hr_cutoff>"
+```
+
+`_resolve_dynamic_params` materialises it at dispatch time. **Codex
+1a B-3:** `datetime.now()` would include the current time-of-day,
+so a filing recorded at midnight UTC exactly 380 calendar days ago
+would be excluded for the rest of the day. `form.idx` dates are
+date-only (lifted to midnight UTC by `sync_filer_directory`'s
+`datetime.combine(filed_d, time(0, 0), tzinfo=UTC)`), so the cutoff
+must be a UTC start-of-day:
+
+```python
+if resolved.get("min_last_13f_hr_at") == _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF:
+    cutoff_date = date.today() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS)
+    resolved["min_last_13f_hr_at"] = datetime.combine(
+        cutoff_date, time(0, 0), tzinfo=UTC
+    )
+```
+
+The comparison `last_13f_hr_at >= cutoff` therefore includes a
+filing whose `form.idx` date is exactly `today() - 380d`.
+
+Stage 21 spec adds the new key:
+
+```python
+_spec(
+    "sec_13f_recent_sweep",
+    21,
+    "sec_rate",
+    JOB_SEC_13F_QUARTERLY_SWEEP,
+    params={
+        "min_period_of_report": _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF,
+        "min_last_13f_hr_at":   _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF,  # ← NEW
+        "source_label": "sec_edgar_13f_directory_bootstrap",
+    },
+),
+```
+
+Both cutoffs use the same `_BOOTSTRAP_13F_RECENCY_DAYS = 380`
+constant for **convenience**, not implication. Per Codex 1a M-2,
+filing recency does **not** imply `period_of_report` recency — a
+13F-HR/A filed yesterday can amend a 2018 `period_of_report`. The
+two filters answer two independent questions:
+
+- `min_last_13f_hr_at` (NEW, this PR) — "is this filer **active**
+  (still HR-filing)?" Used to bound the cohort.
+- `min_period_of_report` (#1008) — "is this accession's **report
+  period** recent enough to be operator-relevant?" Used to bound
+  accessions per filer.
+
+Sharing the constant means a single knob tunes both windows; if
+divergence is needed later, split the constant.
+
+### 3.6 Validator (`app/services/processes/param_metadata.py`)
+
+`JOB_INTERNAL_KEYS["sec_13f_quarterly_sweep"]` extends from
+`frozenset({"source_label"})` to
+`frozenset({"source_label", "min_last_13f_hr_at"})`.
+
+`MANUAL_TRIGGER_JOB_METADATA["sec_13f_quarterly_sweep"]` is
+**not** extended. The operator does not tune this from the Admin UI:
+
+- Standalone manual / sweep-adapter / Admin "Run now" paths should
+  use the full cohort as a safety-net for previously-inactive filers
+  re-emerging (acceptance criterion in the issue). Exposing the knob
+  risks accidental opt-in to bootstrap semantics on those paths.
+  (`sec_13f_quarterly_sweep` was retired from `SCHEDULED_JOBS`
+  post-#1155; bootstrap stage 21 + manual trigger + sweep-adapter
+  remain the only entry points to the body.)
+- Operator's existing knob `min_period_of_report` already filters
+  accessions and is the appropriate per-run triage param.
+
+## 4. Migration
+
+`sql/157_institutional_filers_last_13f_hr_at.sql`:
+
+1. `ALTER TABLE institutional_filers ADD COLUMN last_13f_hr_at TIMESTAMPTZ;`
+2. `CREATE INDEX IF NOT EXISTS idx_institutional_filers_last_13f_hr_at ON ... (last_13f_hr_at DESC NULLS LAST);`
+3. Backfill `UPDATE` from `ownership_institutions_observations`
+   (single-statement, set-based, tx-wrapped by the runner).
+
+No autocommit directive needed — pure DDL + a tx-safe `UPDATE` (the
+migration runner wraps in BEGIN/COMMIT; observations is partitioned
+on `period_end` so the GROUP BY scans all partitions but writes once
+to `institutional_filers`).
+
+`tests/fixtures/ebull_test_db.py::_PLANNER_TABLES` already lists
+`institutional_filers`; the new column doesn't add a planner-relevant
+entry. No fixture update needed.
+
+## 5. Test plan
+
+New / extended tests in `tests/test_sec_13f_filer_directory.py`:
+
+1. `test_nt_only_filer_does_not_set_last_13f_hr_at`
+   - Payload contains a single `13F-NT` row for CIK 600.
+   - Assert `last_filing_at` is set (existing behaviour); assert
+     `last_13f_hr_at` is NULL.
+2. `test_hr_and_nt_same_filer_sets_last_13f_hr_at_from_hr_only`
+   - Payload contains `13F-NT` on 2026-02-14 AND `13F-HR` on 2026-01-15
+     for the same CIK.
+   - Assert `last_filing_at` = max date (NT, 2026-02-14); assert
+     `last_13f_hr_at` = HR date (2026-01-15). Confirms NT does not
+     contaminate the HR column.
+3. `test_existing_newer_last_13f_hr_at_preserved` (mirror of the
+   existing `test_existing_newer_last_filing_at_preserves_existing_name`):
+   - Pre-populate with future `last_13f_hr_at`. Payload supplies an
+     older HR. Assert pre-populated value is preserved (GREATEST
+     monotone).
+3a. `test_existing_null_hr_with_incoming_nt_only_keeps_null`
+    (Codex 1a test-gap):
+    - Pre-existing row with `last_13f_hr_at IS NULL`.
+    - Payload contains only a `13F-NT` for that CIK.
+    - Assert `last_13f_hr_at` stays NULL after sync — NULLIF guard
+      catches the `'-infinity'` sentinel.
+
+New tests in `tests/test_institutional_holdings.py`:
+
+3b. `test_upsert_filer_advances_last_13f_hr_at` (Codex 1a B-2):
+    - Pre-populate a filer with `last_13f_hr_at = 2025-01-01`.
+    - Call `_upsert_filer` with a `ThirteenFFilerInfo` whose
+      `filed_at = 2026-04-15`.
+    - Assert `last_13f_hr_at = 2026-04-15` post-call.
+    - Second call with `filed_at = 2024-06-01` (older).
+    - Assert `last_13f_hr_at` is still `2026-04-15` (GREATEST guard).
+
+New tests in `tests/test_institutional_holdings.py` (or new file
+`tests/test_list_directory_filer_ciks.py`):
+
+4. `test_default_returns_all_filers` — `list_directory_filer_ciks(conn)`
+   returns CIKs unfiltered.
+5. `test_min_last_13f_hr_at_filters_inactive` — pre-populate three
+   filers (one with HR last week, one with HR 2 years ago, one with
+   `last_13f_hr_at IS NULL`). Call with cutoff = now - 380d. Assert
+   only the recent one is returned; NULL row excluded.
+5a. `test_min_last_13f_hr_at_includes_exact_cutoff` (Codex 1a
+    test-gap): construct `cutoff = datetime.combine(some_date, time(0), tzinfo=UTC)`;
+    pre-populate a filer with `last_13f_hr_at = cutoff` (exactly
+    equal). Call with that cutoff. Assert the filer is returned
+    (`>= cutoff` boundary inclusive). Use UTC-midnight explicitly so
+    a future cutoff change does not silently re-introduce the
+    time-of-day bug.
+
+New test in `tests/test_sec_13f_quarterly_sweep.py` (if not present,
+new file):
+
+6. `test_sweep_params_propagate_min_last_13f_hr_at_to_cohort_listing`
+   - Patch `list_directory_filer_ciks` to record the kwarg.
+   - Invoke `sec_13f_quarterly_sweep(params={"min_last_13f_hr_at": dt})`.
+   - Assert `list_directory_filer_ciks` was called with
+     `min_last_13f_hr_at=dt`.
+
+Bootstrap orchestrator dynamic-resolver test (extend existing
+`tests/test_bootstrap_orchestrator.py` or add unit test):
+
+7. `test_resolve_dynamic_params_materialises_13f_hr_cutoff`
+   - Pass `{"min_last_13f_hr_at": "<dynamic:bootstrap_13f_hr_cutoff>"}`.
+   - Assert returned dict's value equals exactly
+     `datetime.combine(date.today() - timedelta(days=380), time(0), tzinfo=UTC)`.
+     (Codex 1b — UTC start-of-day, not `now() - 380d`. Asserting
+     exact equality pins the invariant against future time-of-day
+     regressions.)
+
+Param validator test (extend existing `tests/test_param_metadata.py`):
+
+8. `test_min_last_13f_hr_at_accepted_under_internal_keys` — bootstrap
+   path accepts the key; manual API path rejects it.
+
+## 6. Edge cases / rejected alternatives
+
+- **Tombstone NT-only filers via a status column instead.** Rejected:
+  status is a derived view of the same form-type evidence; adding a
+  column carrying the same information twice invites drift. The HR
+  recency timestamp is the canonical signal.
+- **Skip NT entirely in `_THIRTEEN_F_FORM_TYPES`.** Rejected: NT
+  filers are still operator-relevant for the directory (they exist;
+  some operators care about who has handed off filing duty). Keep
+  `last_filing_at` as the all-form summary; layer the HR-specific
+  signal on top.
+- **Cap top-N by AUM.** Issue mentions this as an optional further
+  bound. Deferred — AUM derivation requires either an N-CEN cross-walk
+  or aggregating each filer's latest HR's `VALUE` column. Both add
+  surface area; the recency bound on its own should land the
+  acceptance criterion (≤ 3 h wall-clock). Track in a follow-up
+  ticket if the cohort is still too wide post-merge.
+- **Filter on `institutional_holdings_ingest_log` instead of a new
+  column.** Rejected: that table reflects what we've already ingested;
+  on a fresh DB it is empty and the filter would skip everyone. The
+  directory column reflects the SEC source-of-truth at form.idx walk
+  time, independent of our ingest state.
+- **Make the standalone manual / sweep-adapter path use the same recency filter.**
+  Rejected by the issue's acceptance criterion that the
+  non-bootstrap path retains the full cohort for safety-net coverage
+  of formerly-inactive filers re-emerging. (The issue body predates
+  the #1155 cron retirement and refers to the weekly cron; the
+  intent — "non-bootstrap entry points keep full cohort" — applies
+  unchanged to today's surviving entry points: manual trigger,
+  Admin "Run now", and the sweep-adapter wrapper.) The weekly
+  `sec_13f_filer_directory_sync` (still in `SCHEDULED_JOBS`) is the
+  cadence that refreshes the discovery side; the cohort filter on
+  the bootstrap path is what bounds the sweep, not its absence on
+  the safety-net path.
+
+## 7. Out of scope
+
+- Per-filer AUM derivation / top-N cap (follow-up).
+- Compaction of `institutional_filers` (delete-vs-tombstone-NT-only
+  rows) — out of scope, the table is only 11k rows and read-only for
+  the sweep; no perf concern at this size.
+- Changing `_BOOTSTRAP_13F_RECENCY_DAYS` (380d). The shared constant
+  is fine; if a separate value is needed for HR vs accessions, split
+  later.
+- N-PORT filer cohort (`institutional_filers` is 13F-only; N-PORT
+  filers live in a parallel directory table — out of scope for
+  #1010).
+- Updating `app/services/sec_nport_filer_directory.py` — N-PORT has
+  its own directory walk + cohort; if it needs the same bound, file
+  a sibling ticket.
+
+## 8. Acceptance
+
+1. Migration `sql/157` adds the column + backfills it from
+   `ownership_institutions_observations`.
+2. `_aggregate_filer_directory` returns the new HR-only dict; sync
+   UPSERT writes `last_13f_hr_at` with GREATEST-monotone shape.
+3. `list_directory_filer_ciks(conn, min_last_13f_hr_at=cutoff)`
+   filters cohort; default kwarg returns full cohort unchanged.
+4. `sec_13f_quarterly_sweep` honours the new `min_last_13f_hr_at`
+   param and propagates it.
+5. Stage 21 spec passes the new sentinel; resolver materialises a
+   `datetime` 380d before dispatch time.
+6. `JOB_INTERNAL_KEYS` extension lets the bootstrap path accept the
+   key; manual API path continues to reject it.
+7. All eight new / extended tests pass; existing tests in
+   `test_sec_13f_filer_directory.py` continue to pass.
+8. `pre-push` gate clean (ruff / ruff format / pyright / pytest).
+9. PR body includes `Closes #1010` on its own line.
+
+## 9. Codex 1a/1b checkpoints
+
+- **1a:** spec review against this doc for correctness gaps,
+  invariant violations, missing edge cases.
+- **1b:** post-revision spec re-review.
+- **2:** pre-push diff review on the implementation branch.
+
+## 10. Files touched (estimate)
+
+- `sql/157_institutional_filers_last_13f_hr_at.sql` (NEW, ~40 LOC).
+- `app/services/sec_13f_filer_directory.py` (~30 LOC delta).
+- `app/services/institutional_holdings.py` (~15 LOC delta).
+- `app/workers/scheduler.py` (~20 LOC delta in
+  `sec_13f_quarterly_sweep`).
+- `app/services/bootstrap_orchestrator.py` (~15 LOC delta:
+  sentinel + resolver branch + stage spec param).
+- `app/services/processes/param_metadata.py` (~3 LOC delta:
+  extend `JOB_INTERNAL_KEYS["sec_13f_quarterly_sweep"]`).
+- `tests/test_sec_13f_filer_directory.py` (~80 LOC delta).
+- `tests/test_institutional_holdings.py` or new
+  `tests/test_list_directory_filer_ciks.py` (~40 LOC).
+- `tests/test_sec_13f_quarterly_sweep.py` (existing or new, ~30 LOC).
+- `tests/test_bootstrap_orchestrator.py` (~15 LOC delta for the
+  resolver test).
+- `tests/test_param_metadata.py` (~10 LOC delta).
+- `.claude/skills/data-sources/sec-edgar.md` — add one bullet to the
+  13F-HR / 13F-NT distinction noting the HR-only cohort recency
+  signal.
+
+Total ~250-300 LOC. One PR.

--- a/sql/157_institutional_filers_last_13f_hr_at.sql
+++ b/sql/157_institutional_filers_last_13f_hr_at.sql
@@ -1,0 +1,59 @@
+-- 157: institutional_filers.last_13f_hr_at — bound bootstrap 13F sweep cohort (#1010)
+--
+-- Adds an HR-only filing-recency signal to ``institutional_filers``.
+--
+--   - ``last_filing_at`` (existing) — most recent 13F-* (HR + HR/A + NT + NT/A).
+--   - ``last_13f_hr_at`` (NEW)      — most recent 13F-HR or 13F-HR/A only.
+--
+-- Backstory: ``bootstrap_sec_13f_recent_sweep`` (stage 21) walks the
+-- full 11,205-row ``institutional_filers`` cohort, taking ~8h to
+-- complete first-install bootstrap. Most filers below the top-N
+-- AUM cohort file 13F-NT (notice-only — no holdings) and contribute
+-- no observations. ``last_filing_at`` cannot distinguish them
+-- because it includes both HR and NT.
+--
+-- This migration adds the HR-only column. ``sec_13f_filer_directory_sync``
+-- populates it from form.idx (HR-only frozenset). The bootstrap stage
+-- 21 dispatch filters cohort to filers with ``last_13f_hr_at`` ≥
+-- today() - 380d. Standalone manual / sweep-adapter / Admin "Run now"
+-- paths keep the full cohort (safety-net for previously-inactive
+-- filers re-emerging).
+--
+-- Spec: docs/superpowers/specs/2026-05-19-1010-13f-cohort-bound.md.
+-- Migration is tx-wrapped by the runner — no explicit BEGIN/COMMIT.
+
+-- 1. Add column. Nullable: NT-only filers + filers with no HR in the
+--    observations table stay NULL and are excluded by the cohort
+--    filter (which uses ``IS NOT NULL AND >= cutoff``).
+ALTER TABLE institutional_filers
+    ADD COLUMN IF NOT EXISTS last_13f_hr_at TIMESTAMPTZ;
+
+-- 2. Backfill from the canonical 13F-HR sink. This is an
+--    approximation, not ground truth — see spec §3.1 backfill
+--    caveat. The next scheduled ``sec_13f_filer_directory_sync`` run
+--    re-populates from form.idx (the canonical source) and corrects
+--    any miss.
+UPDATE institutional_filers f
+SET last_13f_hr_at = sub.max_filed_at
+FROM (
+    SELECT filer_cik, MAX(filed_at) AS max_filed_at
+    FROM ownership_institutions_observations
+    WHERE source = '13f'
+    GROUP BY filer_cik
+) sub
+WHERE f.cik = sub.filer_cik
+  AND f.last_13f_hr_at IS NULL;  -- idempotent on re-run
+
+-- 3. Index for the cohort filter + ORDER BY. DESC NULLS LAST matches
+--    the ``ORDER BY last_13f_hr_at DESC NULLS LAST, cik`` shape used
+--    by ``list_directory_filer_ciks`` when the cohort filter is
+--    active.
+CREATE INDEX IF NOT EXISTS idx_institutional_filers_last_13f_hr_at
+    ON institutional_filers (last_13f_hr_at DESC NULLS LAST);
+
+COMMENT ON COLUMN institutional_filers.last_13f_hr_at IS
+    'Most recent 13F-HR / 13F-HR/A filing date observed for this CIK '
+    '(HR-only; excludes 13F-NT). Set by sec_13f_filer_directory_sync '
+    'from form.idx + by the legacy per-filing ingest. Bootstrap '
+    'stage 21 filters cohort on this column; standalone paths use '
+    'the full cohort. #1010.';

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -815,6 +815,111 @@ class TestUniverseSweep:
         result = list_directory_filer_ciks(conn)
         assert result == ["0000000100", "0000000300", "0000000200", "0000000400"]
 
+    def test_list_directory_filer_ciks_filters_inactive_when_hr_cutoff_set(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#1010 — passing ``min_last_13f_hr_at`` filters cohort to
+        filers with HR-recency at or after the cutoff. NULL
+        ``last_13f_hr_at`` is excluded (NT-only / never-filed-HR)."""
+        from datetime import UTC, datetime, timedelta
+
+        from app.services.institutional_holdings import list_directory_filer_ciks
+
+        conn = ebull_test_conn
+        now = datetime(2026, 5, 5, 0, 0, tzinfo=UTC)
+        cutoff = now - timedelta(days=380)
+        recent = now - timedelta(days=30)
+        ancient = now - timedelta(days=800)
+        conn.execute(
+            "INSERT INTO institutional_filers (cik, name, filer_type, last_13f_hr_at) VALUES "
+            "('0000000700', 'RECENT HR', 'INV', %s), "
+            "('0000000800', 'ANCIENT HR', 'INV', %s), "
+            "('0000000900', 'NT ONLY', 'INV', NULL)",
+            (recent, ancient),
+        )
+        conn.commit()
+
+        result = list_directory_filer_ciks(conn, min_last_13f_hr_at=cutoff)
+        assert result == ["0000000700"]
+
+    def test_list_directory_filer_ciks_includes_exact_cutoff(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#1010 Codex 1b — boundary inclusive: ``last_13f_hr_at ==
+        cutoff`` must be returned. UTC start-of-day constructed
+        explicitly so a future cutoff change does not silently
+        regress the time-of-day invariant."""
+        from datetime import UTC, datetime, time
+
+        from app.services.institutional_holdings import list_directory_filer_ciks
+
+        cutoff = datetime.combine(date(2025, 5, 5), time(0, 0), tzinfo=UTC)
+        conn = ebull_test_conn
+        conn.execute(
+            "INSERT INTO institutional_filers (cik, name, filer_type, last_13f_hr_at) "
+            "VALUES ('0000001000', 'EXACT CUTOFF', 'INV', %s)",
+            (cutoff,),
+        )
+        conn.commit()
+
+        result = list_directory_filer_ciks(conn, min_last_13f_hr_at=cutoff)
+        assert result == ["0000001000"]
+
+    def test_upsert_filer_advances_last_13f_hr_at(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#1010 Codex 1a B-2 — the legacy per-filing ingest path
+        upserts ``institutional_filers`` and must advance
+        ``last_13f_hr_at`` because every accession reaching
+        ``_upsert_filer`` is a 13F-HR / HR-A (filtered in
+        parse_submissions_index)."""
+        from datetime import UTC
+        from datetime import date as _date
+        from datetime import datetime as _dt
+
+        from app.providers.implementations.sec_13f import ThirteenFFilerInfo
+        from app.services.institutional_holdings import _upsert_filer
+
+        conn = ebull_test_conn
+        conn.execute(
+            "INSERT INTO institutional_filers (cik, name, filer_type, last_13f_hr_at) "
+            "VALUES ('0000001100', 'FILER', 'INV', %s)",
+            (_dt(2025, 1, 1, 0, 0, tzinfo=UTC),),
+        )
+        conn.commit()
+
+        info = ThirteenFFilerInfo(
+            cik="0000001100",
+            name="FILER",
+            period_of_report=_date(2026, 3, 31),
+            filed_at=_dt(2026, 4, 15, 0, 0, tzinfo=UTC),
+            table_value_total_usd=None,
+        )
+        _upsert_filer(conn, info)
+        with conn.cursor() as cur:
+            cur.execute("SELECT last_13f_hr_at FROM institutional_filers WHERE cik = '0000001100'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == _dt(2026, 4, 15, 0, 0, tzinfo=UTC)
+
+        # Second upsert with an older filed_at must NOT regress.
+        older = ThirteenFFilerInfo(
+            cik="0000001100",
+            name="FILER",
+            period_of_report=_date(2024, 6, 30),
+            filed_at=_dt(2024, 6, 1, 0, 0, tzinfo=UTC),
+            table_value_total_usd=None,
+        )
+        _upsert_filer(conn, older)
+        with conn.cursor() as cur:
+            cur.execute("SELECT last_13f_hr_at FROM institutional_filers WHERE cik = '0000001100'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == _dt(2026, 4, 15, 0, 0, tzinfo=UTC)
+
     def test_explicit_ciks_list_overrides_seed_lookup(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -464,6 +464,26 @@ class TestJobInternalKeysRegistry:
     def test_sec_13f_has_source_label_internal(self) -> None:
         assert "source_label" in JOB_INTERNAL_KEYS["sec_13f_quarterly_sweep"]
 
+    def test_sec_13f_min_last_13f_hr_at_is_internal(self) -> None:
+        """#1010 — the HR-recency cohort filter is bootstrap-only.
+        Exposing it on the manual API would let an operator drop the
+        full-cohort safety-net on the non-bootstrap path."""
+        assert "min_last_13f_hr_at" in JOB_INTERNAL_KEYS["sec_13f_quarterly_sweep"]
+
+    def test_sec_13f_min_last_13f_hr_at_rejected_on_manual_path(self) -> None:
+        """#1010 — operator API path MUST reject ``min_last_13f_hr_at``
+        even though it's listed in JOB_INTERNAL_KEYS for the bootstrap
+        path."""
+        from datetime import UTC, datetime
+
+        with pytest.raises(ParamValidationError, match="unknown param"):
+            validate_job_params(
+                "sec_13f_quarterly_sweep",
+                {"min_last_13f_hr_at": datetime(2025, 1, 1, 0, 0, tzinfo=UTC)},
+                allow_internal_keys=False,
+                metadata=(),
+            )
+
     def test_internal_keys_keys_are_known_jobs(self) -> None:
         """Every job in JOB_INTERNAL_KEYS must be in the source registry."""
         registry = get_job_name_to_source()

--- a/tests/test_pr1c_wrapper_lift.py
+++ b/tests/test_pr1c_wrapper_lift.py
@@ -117,6 +117,35 @@ class TestResolveDynamicParams:
         out = _resolve_dynamic_params({"days_back": 365})
         assert out == {"days_back": 365}
 
+    def test_min_last_13f_hr_at_sentinel_resolves_to_utc_midnight(self) -> None:
+        """#1010 — HR-recency cutoff materialises as UTC start-of-day
+        ``today() - 380d``. Exact equality pins the invariant against
+        future time-of-day regressions (Codex 1b)."""
+        from datetime import UTC, datetime, time
+
+        from app.services.bootstrap_orchestrator import (
+            _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF,
+        )
+
+        out = _resolve_dynamic_params({"min_last_13f_hr_at": _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF})
+        # Mirror the resolver: UTC date, not local ``date.today()``.
+        # On a non-UTC dev host around the midnight boundary the two
+        # can differ by one day (Codex 2 MEDIUM).
+        expected = datetime.combine(
+            datetime.now(tz=UTC).date() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS),
+            time(0, 0),
+            tzinfo=UTC,
+        )
+        assert out["min_last_13f_hr_at"] == expected
+
+    def test_min_last_13f_hr_at_concrete_value_passes_through(self) -> None:
+        """Concrete datetime ≠ sentinel → returned unchanged."""
+        from datetime import UTC, datetime
+
+        fixed = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+        out = _resolve_dynamic_params({"min_last_13f_hr_at": fixed})
+        assert out["min_last_13f_hr_at"] == fixed
+
 
 # ---------------------------------------------------------------------------
 # 3. Promoted invoker contract — params-aware bodies registered in _INVOKERS.
@@ -212,3 +241,74 @@ class TestSec13fSweepHonoursParams:
         kwargs = mock_ingest.call_args.kwargs
         assert kwargs["source_label"] == "sec_edgar_13f_directory_bootstrap"
         assert kwargs["min_period_of_report"] == cutoff
+
+    def test_sweep_params_propagate_min_last_13f_hr_at_to_cohort_listing(self) -> None:
+        """#1010 — ``sec_13f_quarterly_sweep`` body must thread
+        ``min_last_13f_hr_at`` into ``list_directory_filer_ciks`` so
+        the cohort filter actually runs."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+
+        with (
+            patch("app.workers.scheduler._tracked_job") as mock_tracker,
+            patch("app.providers.implementations.sec_edgar.SecFilingsProvider"),
+            patch("app.workers.scheduler.psycopg.connect"),
+            patch("app.workers.scheduler.settings") as mock_settings,
+            patch(
+                "app.services.institutional_holdings.list_directory_filer_ciks",
+                return_value=[],
+            ) as mock_list_ciks,
+            patch(
+                "app.services.institutional_holdings.ingest_all_active_filers",
+                return_value=[],
+            ),
+        ):
+            mock_tracker.return_value.__enter__.return_value = MagicMock()
+            mock_tracker.return_value.__exit__.return_value = False
+            mock_settings.sec_user_agent = "test-agent"
+            mock_settings.sec_13f_sweep_deadline_seconds = 3600
+            mock_settings.database_url = "postgresql://stub/stub"
+
+            cutoff = datetime(2025, 1, 1, 0, 0, tzinfo=UTC)
+            from app.workers.scheduler import sec_13f_quarterly_sweep
+
+            sec_13f_quarterly_sweep({"min_last_13f_hr_at": cutoff})
+
+        kwargs = mock_list_ciks.call_args.kwargs
+        assert kwargs["min_last_13f_hr_at"] == cutoff
+
+    def test_sweep_naive_datetime_min_last_13f_hr_at_gets_utc_tagged(self) -> None:
+        """#1010 Codex 1b — naive datetime is tagged UTC defensively
+        so psycopg never falls back to the server's local zone."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+
+        with (
+            patch("app.workers.scheduler._tracked_job") as mock_tracker,
+            patch("app.providers.implementations.sec_edgar.SecFilingsProvider"),
+            patch("app.workers.scheduler.psycopg.connect"),
+            patch("app.workers.scheduler.settings") as mock_settings,
+            patch(
+                "app.services.institutional_holdings.list_directory_filer_ciks",
+                return_value=[],
+            ) as mock_list_ciks,
+            patch(
+                "app.services.institutional_holdings.ingest_all_active_filers",
+                return_value=[],
+            ),
+        ):
+            mock_tracker.return_value.__enter__.return_value = MagicMock()
+            mock_tracker.return_value.__exit__.return_value = False
+            mock_settings.sec_user_agent = "test-agent"
+            mock_settings.sec_13f_sweep_deadline_seconds = 3600
+            mock_settings.database_url = "postgresql://stub/stub"
+
+            naive = datetime(2025, 1, 1, 0, 0)  # noqa: DTZ001 — test of naive→UTC defensive tag
+            from app.workers.scheduler import sec_13f_quarterly_sweep
+
+            sec_13f_quarterly_sweep({"min_last_13f_hr_at": naive})
+
+        kwargs = mock_list_ciks.call_args.kwargs
+        passed = kwargs["min_last_13f_hr_at"]
+        assert passed.tzinfo is UTC
+        assert passed == datetime(2025, 1, 1, 0, 0, tzinfo=UTC)

--- a/tests/test_sec_13f_filer_directory.py
+++ b/tests/test_sec_13f_filer_directory.py
@@ -413,12 +413,13 @@ class TestSyncFilerDirectory:
         (e.g. populated by the per-filing ingest from primary_doc.xml)
         is not regressed by an older form.idx HR. Mirrors the existing
         guard for ``last_filing_at``. #1010."""
+        from datetime import UTC
         from datetime import datetime as _dt
 
         ebull_test_conn.execute(
             "INSERT INTO institutional_filers (cik, name, filer_type, last_13f_hr_at) "
             "VALUES ('0000000900', 'NEWER HR FILER', 'INV', %s)",
-            (_dt(2027, 1, 15, 0, 0, tzinfo=__import__("datetime").timezone.utc),),
+            (_dt(2027, 1, 15, 0, 0, tzinfo=UTC),),
         )
         ebull_test_conn.commit()
 

--- a/tests/test_sec_13f_filer_directory.py
+++ b/tests/test_sec_13f_filer_directory.py
@@ -264,9 +264,10 @@ class TestSyncFilerDirectory:
             quarters: list[tuple[int, int]],
             *,
             fetch: object,
-        ) -> tuple[dict[str, str], dict[str, date], int]:
+        ) -> tuple[dict[str, str], dict[str, date], dict[str, date], int]:
             return (
                 {"0000000100": "VALID FILER", "0000000200": "   "},
+                {"0000000100": date(2026, 2, 14), "0000000200": date(2026, 2, 14)},
                 {"0000000100": date(2026, 2, 14), "0000000200": date(2026, 2, 14)},
                 0,
             )
@@ -337,6 +338,98 @@ class TestSyncFilerDirectory:
         assert row["name"] == "NEWER CANONICAL NAME"
         # GREATEST() keeps the newer timestamp.
         assert row["last_filing_at"].year == 2027
+
+    def test_nt_only_filer_does_not_set_last_13f_hr_at(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """13F-NT is notice-only (no holdings). It must advance
+        ``last_filing_at`` (all-form recency) but NOT
+        ``last_13f_hr_at`` (HR-only recency that bounds the
+        bootstrap-stage 21 cohort). #1010 spec §3.2."""
+        payload = _HEADER + _row("13F-NT", "NOTICE FILER LLC", 600, "2026-02-14", "edgar/data/600/a.txt")
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: payload)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT last_filing_at, last_13f_hr_at FROM institutional_filers WHERE cik = '0000000600'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["last_filing_at"] is not None
+        assert row["last_filing_at"].date() == date(2026, 2, 14)
+        assert row["last_13f_hr_at"] is None
+
+    def test_hr_and_nt_same_filer_sets_last_13f_hr_at_from_hr_only(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Mixed payload: NT later, HR earlier. ``last_filing_at``
+        tracks the newer NT (all-form); ``last_13f_hr_at`` tracks
+        only the earlier HR. NT must not contaminate the HR column.
+        #1010 spec §3.2."""
+        payload = (
+            _HEADER
+            + _row("13F-HR", "FILER HR", 700, "2026-01-15", "edgar/data/700/a.txt")
+            + _row("13F-NT", "FILER NT", 700, "2026-02-14", "edgar/data/700/b.txt")
+        )
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: payload)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT last_filing_at, last_13f_hr_at FROM institutional_filers WHERE cik = '0000000700'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["last_filing_at"].date() == date(2026, 2, 14)
+        assert row["last_13f_hr_at"] is not None
+        assert row["last_13f_hr_at"].date() == date(2026, 1, 15)
+
+    def test_existing_null_hr_with_incoming_nt_only_keeps_null(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Pre-existing row with NULL ``last_13f_hr_at``. Payload
+        carries only a 13F-NT for the same CIK. NULLIF guard must
+        collapse the ``'-infinity'`` sentinel back to NULL so the
+        row stays excluded from the cohort filter. Codex 1a B-1 +
+        1b boundary check."""
+        ebull_test_conn.execute(
+            "INSERT INTO institutional_filers (cik, name, filer_type, last_13f_hr_at) "
+            "VALUES ('0000000800', 'PRE-EXISTING', 'INV', NULL)"
+        )
+        ebull_test_conn.commit()
+
+        payload = _HEADER + _row("13F-NT", "NOTICE", 800, "2026-02-14", "edgar/data/800/a.txt")
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: payload)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT last_13f_hr_at FROM institutional_filers WHERE cik = '0000000800'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["last_13f_hr_at"] is None
+
+    def test_existing_newer_last_13f_hr_at_preserved(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """GREATEST monotone: a pre-existing newer ``last_13f_hr_at``
+        (e.g. populated by the per-filing ingest from primary_doc.xml)
+        is not regressed by an older form.idx HR. Mirrors the existing
+        guard for ``last_filing_at``. #1010."""
+        from datetime import datetime as _dt
+
+        ebull_test_conn.execute(
+            "INSERT INTO institutional_filers (cik, name, filer_type, last_13f_hr_at) "
+            "VALUES ('0000000900', 'NEWER HR FILER', 'INV', %s)",
+            (_dt(2027, 1, 15, 0, 0, tzinfo=__import__("datetime").timezone.utc),),
+        )
+        ebull_test_conn.commit()
+
+        payload = _HEADER + _row("13F-HR", "OLDER HR", 900, "2026-02-14", "edgar/data/900/a.txt")
+        sync_filer_directory(ebull_test_conn, quarters=1, today=date(2026, 5, 5), fetch=lambda *_: payload)
+
+        with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute("SELECT last_13f_hr_at FROM institutional_filers WHERE cik = '0000000900'")
+            row = cur.fetchone()
+        assert row is not None
+        assert row["last_13f_hr_at"].year == 2027
 
     def test_filer_type_preserved_on_update(
         self,


### PR DESCRIPTION
## Summary

- Adds `institutional_filers.last_13f_hr_at` (HR-only filing recency, distinct from `last_filing_at` which mixes HR+NT) + DESC index. Migration `sql/157` backfills from `ownership_institutions_observations(source='13f') MAX(filed_at)`.
- `_aggregate_filer_directory` + `_upsert_filer` advance the column on every HR / HR-A; NULLIF-guarded `GREATEST(..., '-infinity')` keeps NT-only filers NULL.
- `list_directory_filer_ciks(min_last_13f_hr_at=...)` filters cohort + switches ordering to HR-recency. Default kwarg = full cohort unchanged.
- `sec_13f_quarterly_sweep` honours the new param; bootstrap stage 21 dispatches `_PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF` resolved to UTC start-of-day `today() - 380d`. Manual API rejects the key via `JOB_INTERNAL_KEYS` allow-list (full-cohort safety-net preserved on non-bootstrap paths).

Spec: `docs/superpowers/specs/2026-05-19-1010-13f-cohort-bound.md` (Codex 1a/1b/1c + 2 iteration).

## Why

Stage 21 walks 11,205 CIKs @ ~23/min = ~8 h first-install wall-clock. Most filers below the top-N AUM tier file 13F-NT (no holdings) — iterating them costs the submissions.json round-trip and writes nothing. Recency-of-HR is the right cohort-bounding signal. Closes #1010.

## Dev DB verification

```
total filers:                 11,205
have last_13f_hr_at backfill:  8,718  (78%)
within 380-day HR cutoff:      8,681  (-22% vs full cohort)
```

Cohort drops further once the next scheduled `sec_13f_filer_directory_sync` converges the column to form.idx ground truth (NT-only filers will be re-revealed as NULL).

## Test plan

- [x] `sql/157` applied to dev DB (manual `run_migrations()`); backfill populated 8,718 of 11,205 rows.
- [x] Migration is idempotent (`WHERE f.last_13f_hr_at IS NULL` guard on re-run).
- [x] `tests/test_sec_13f_filer_directory.py` — 4 new tests: NT-only doesn't set HR, HR+NT mixed only sets HR, existing-NULL-HR with incoming-NT stays NULL (NULLIF guard), existing-newer-HR preserved (GREATEST monotone). Existing tests still pass after `_aggregate_filer_directory` signature widened to 4-tuple.
- [x] `tests/test_institutional_holdings_ingester.py` — 3 new tests: cohort filter excludes NULL + ancient HR, exact-cutoff boundary inclusive (UTC midnight), `_upsert_filer` advances + does not regress.
- [x] `tests/test_pr1c_wrapper_lift.py` — 4 new tests: resolver sentinel materialises to UTC midnight, concrete value passes through, sweep param propagates to cohort listing, naive datetime tagged UTC defensively.
- [x] `tests/test_job_registry.py` — 2 new tests: `min_last_13f_hr_at` in `JOB_INTERNAL_KEYS["sec_13f_quarterly_sweep"]`, rejected on manual API path.
- [x] `ruff check` / `ruff format --check` / `pyright` all pass locally.
- [x] Full pytest deferred to CI (one pre-existing failure on `main` at `tests/test_job_registry.py::TestScheduledJobSourceField::test_every_source_is_valid_lane` unrelated to this PR — `finra_short_interest_refresh` / `finra_regsho_daily_refresh` source lane registration; tracked under FINRA wiring follow-ups).

## Acceptance against issue #1010

- First-install `bootstrap_sec_13f_recent_sweep` cohort dropped from 11,205 → 8,681 (post-backfill) → expected ≤ 5k after next directory_sync converges (NT-only filers correctly excluded). Wall-clock target ≤ 3 h vs prior ~8 h.
- Inactive filers (no HR in last 4 quarters) skipped at cohort-list time, not at per-filer iteration time.
- Standalone manual / sweep-adapter / Admin "Run now" paths retain full cohort safety-net (default `min_last_13f_hr_at=None`).

## ETL clauses (CLAUDE.md §8-12)

This PR adds a filter column + dispatch knob; it does NOT change parser output shape, ownership observation rows, or fundamentals data. No re-ingest required; no operator-visible figure changes on `/instruments/{symbol}/ownership-rollup`. The smoke-panel verification clauses apply to parser/observation changes, which this is not.

Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)