### PR TITLE
feat(#1136): /system/bootstrap-status + dispatch hardening (Phase A.3 audit subset)

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -44,7 +44,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from app.api.auth import require_session_or_service_token
+from app.api.bootstrap import BootstrapApiStatus, LaneApi, StageApiStatus
 from app.db import get_conn
+from app.services.bootstrap_state import (
+    compute_retryable_view,
+    read_run_with_stages,
+    read_state,
+)
 from app.services.ops_monitor import (
     JobHealth,
     LayerHealth,
@@ -571,6 +577,149 @@ class PostgresHealthResponse(BaseModel):
     financial_facts_raw_default_breached_warn: bool | None
     metric_errors: list[str]
     collected_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap status overview (#1136 Phase A.3 audit endpoint)
+# ---------------------------------------------------------------------------
+#
+# Lean operator readout mirroring the ``/system/postgres-health`` shape:
+# per-stage ``(status, last_error, retryable, attempt_count,
+# completed_at)`` plus a top-level summary and ``retry_available`` /
+# ``retry_blocked_reason`` pair. Lets the operator drive T9-POST drain
+# without log-grepping or replaying ``reset_failed_stages_for_retry``
+# precedence by hand.
+#
+# Distinct from ``GET /system/bootstrap/status`` (rich admin-page
+# payload — archive_results, bulk_manifest, full stage params); this
+# is the audit-shape sibling. Both endpoints read the same tables.
+
+
+class BootstrapStatusSummary(BaseModel):
+    total: int
+    pending: int
+    running: int
+    success: int
+    error: int
+    blocked: int
+    skipped: int
+    cancelled: int
+
+
+class BootstrapStatusStageOverview(BaseModel):
+    stage_key: str
+    stage_order: int
+    lane: LaneApi
+    status: StageApiStatus
+    last_error: str | None
+    attempt_count: int
+    completed_at: datetime | None
+    retryable: bool
+
+
+class BootstrapStatusOverview(BaseModel):
+    state_status: BootstrapApiStatus
+    current_run_id: int | None
+    last_completed_at: datetime | None
+    summary: BootstrapStatusSummary
+    retry_available: bool
+    retry_blocked_reason: (
+        Literal[
+            "bootstrap_running",
+            "no_prior_run",
+            "state_not_resettable",
+            "no_failed_stages",
+        ]
+        | None
+    )
+    stages: list[BootstrapStatusStageOverview]
+    collected_at: datetime
+
+
+@router.get("/bootstrap-status", response_model=BootstrapStatusOverview)
+def get_bootstrap_status_overview(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> BootstrapStatusOverview:
+    """Lean operator readout of bootstrap state + per-stage retryability.
+
+    Spec: ``docs/superpowers/specs/2026-05-19-1136-bootstrap-state-audit.md``.
+
+    Failure posture mirrors ``/system/postgres-health``:
+      * DB unreachable → 503.
+      * No prior run → 200 with ``state_status='pending'``, empty
+        stages, ``retry_blocked_reason='no_prior_run'``.
+
+    Run identification pins on ``bootstrap_state.last_run_id`` (NOT
+    ``ORDER BY bootstrap_runs.id DESC``) so the readout reflects what
+    ``/retry-failed`` would target — the two can diverge transiently
+    during ``start_run`` or after a post-restart sweep that re-seeded
+    a row without touching the singleton.
+    """
+    now = _utcnow()
+    try:
+        with conn.transaction():
+            state = read_state(conn)
+            if state.last_run_id is None:
+                snapshot = None
+            else:
+                snapshot = read_run_with_stages(conn, run_id=state.last_run_id)
+    except psycopg.Error as exc:
+        logger.exception("bootstrap-status: DB-level failure")
+        raise HTTPException(status_code=503, detail="bootstrap status unavailable") from exc
+
+    view = compute_retryable_view(state, snapshot)
+
+    summary = BootstrapStatusSummary(
+        total=0, pending=0, running=0, success=0, error=0, blocked=0, skipped=0, cancelled=0
+    )
+    stage_overviews: list[BootstrapStatusStageOverview] = []
+    if snapshot is not None:
+        for stage in snapshot.stages:
+            stage_overviews.append(
+                BootstrapStatusStageOverview(
+                    stage_key=stage.stage_key,
+                    stage_order=stage.stage_order,
+                    lane=stage.lane,
+                    status=stage.status,
+                    last_error=stage.last_error,
+                    attempt_count=stage.attempt_count,
+                    completed_at=stage.completed_at,
+                    retryable=view.stage_retryable.get(stage.stage_key, False),
+                )
+            )
+        counter_map: dict[str, int] = {
+            "pending": 0,
+            "running": 0,
+            "success": 0,
+            "error": 0,
+            "blocked": 0,
+            "skipped": 0,
+            "cancelled": 0,
+        }
+        for stage in snapshot.stages:
+            if stage.status in counter_map:
+                counter_map[stage.status] += 1
+        summary = BootstrapStatusSummary(
+            total=len(snapshot.stages),
+            pending=counter_map["pending"],
+            running=counter_map["running"],
+            success=counter_map["success"],
+            error=counter_map["error"],
+            blocked=counter_map["blocked"],
+            skipped=counter_map["skipped"],
+            cancelled=counter_map["cancelled"],
+        )
+
+    return BootstrapStatusOverview(
+        state_status=state.status,
+        current_run_id=state.last_run_id,
+        last_completed_at=state.last_completed_at,
+        summary=summary,
+        retry_available=view.retry_available,
+        retry_blocked_reason=view.retry_blocked_reason,
+        stages=stage_overviews,
+        collected_at=now,
+    )
 
 
 @router.get("/postgres-health", response_model=PostgresHealthResponse)

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -1746,6 +1746,16 @@ def run_bootstrap_orchestrator() -> None:
     # DB doesn't store params (immutable across runs; lives in code),
     # so the dispatch path consults the spec table at run time.
     stage_params_by_key: dict[str, Mapping[str, Any]] = {spec.stage_key: spec.params for spec in _BOOTSTRAP_STAGE_SPECS}
+    # #1136 Phase A.3 dispatch hardening — index the catalogue by
+    # ``stage_key`` so the dispatcher resolves ``job_name`` from the
+    # spec rather than the DB row's persisted ``job_name``. Removes
+    # the stale-name failure mode observed in run_id=3 stage 21
+    # (where the DB row carried ``bootstrap_sec_13f_recent_sweep``
+    # after PR1c #1064 renamed the canonical to
+    # ``JOB_SEC_13F_QUARTERLY_SWEEP``). The DB column stays as the
+    # audit snapshot of "what the run was created to dispatch" — the
+    # runtime decision is logged below for forensic replay.
+    spec_by_stage_key: dict[str, StageSpec] = {spec.stage_key: spec for spec in _BOOTSTRAP_STAGE_SPECS}
 
     # Pre-populate statuses with stages already in a terminal state
     # so the dependency graph sees them when a downstream pending
@@ -1768,12 +1778,60 @@ def run_bootstrap_orchestrator() -> None:
             preexisting_rows_processed[stage.stage_key] = stage.rows_processed
             logger.info("bootstrap dispatcher: skipping %s (already %s)", stage.stage_key, stage.status)
             continue
-        invoker = _INVOKERS.get(stage.job_name)
-        if invoker is None:
+        # #1136 Phase A.3 — resolve job_name from the catalogue by
+        # stage_key. Fail closed if the stage_key has been trimmed
+        # from the catalogue (silently dispatching the DB row's
+        # stored job_name would lose canonical params /
+        # CapRequirement / lane semantics — worst-of-both-worlds).
+        canonical_spec = spec_by_stage_key.get(stage.stage_key)
+        if canonical_spec is None:
             logger.error(
-                "bootstrap dispatcher: stage %s has unknown job_name %r; marking error",
+                "bootstrap dispatcher: stage_key %r not in current catalogue; "
+                "stored_job_name=%r is stale, refusing to dispatch",
                 stage.stage_key,
                 stage.job_name,
+            )
+            with psycopg.connect(database_url) as conn:
+                # pending → running → error: ``mark_stage_error`` has
+                # ``AND status = 'running'`` so a direct call against
+                # the pending row would silently no-op and let the
+                # stage survive finalize_run still pending (Codex 1b
+                # finding §1).
+                mark_stage_running(conn, run_id=run_id, stage_key=stage.stage_key)
+                mark_stage_error(
+                    conn,
+                    run_id=run_id,
+                    stage_key=stage.stage_key,
+                    error_message=(
+                        f"stage_key {stage.stage_key!r} not in current bootstrap catalogue; "
+                        f"row job_name={stage.job_name!r} is stale and dispatch is refused"
+                    ),
+                )
+                conn.commit()
+            continue
+        effective_job_name = canonical_spec.job_name
+        if effective_job_name != stage.job_name:
+            # Forensic trail — DB row stays as the audit snapshot;
+            # the log line records the runtime decision (Codex 1a §4).
+            logger.info(
+                "bootstrap dispatcher: stage %s remapped stored_job_name=%r -> "
+                "effective_job_name=%r (catalogue rename)",
+                stage.stage_key,
+                stage.job_name,
+                effective_job_name,
+            )
+        invoker = _INVOKERS.get(effective_job_name)
+        if invoker is None:
+            # Catalogue carries the stage_key but its job_name is not
+            # registered — points at a registry / SCHEDULED_JOBS gap,
+            # NOT a stale-DB-row case. The catalogue-invariant test
+            # (`tests/test_bootstrap_orchestrator_source_registry.py`)
+            # is meant to prevent this at push time; the runtime guard
+            # is defense-in-depth.
+            logger.error(
+                "bootstrap dispatcher: stage %s effective_job_name %r is unregistered in _INVOKERS; marking error",
+                stage.stage_key,
+                effective_job_name,
             )
             with psycopg.connect(database_url) as conn:
                 mark_stage_running(conn, run_id=run_id, stage_key=stage.stage_key)
@@ -1781,14 +1839,18 @@ def run_bootstrap_orchestrator() -> None:
                     conn,
                     run_id=run_id,
                     stage_key=stage.stage_key,
-                    error_message=f"unknown job_name {stage.job_name!r}",
+                    error_message=f"unknown job_name {effective_job_name!r}",
                 )
                 conn.commit()
             continue
         runnable.append(
             _RunnableStage(
                 stage_key=stage.stage_key,
-                job_name=stage.job_name,
+                # effective_job_name flows into _RunnableStage so all
+                # downstream consumers — validate_job_params,
+                # _run_one_stage, _snapshot_job_runs_max_id — see the
+                # canonical name (Codex 1a §3).
+                job_name=effective_job_name,
                 lane=_effective_lane(stage.stage_key, stage.lane),
                 invoker=invoker,
                 requires=_STAGE_REQUIRES_CAPS.get(stage.stage_key, CapRequirement()),

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -241,18 +241,76 @@ def read_latest_run_with_stages(
         if run_row is None:
             return None
         run_id, run_status, triggered_at, completed_at = run_row
+        return _read_run_with_stage_rows(
+            conn,
+            run_id=run_id,
+            run_status=run_status,
+            triggered_at=triggered_at,
+            completed_at=completed_at,
+        )
 
-        stage_rows = conn.execute(
+
+def read_run_with_stages(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+) -> RunSnapshot | None:
+    """Return a specific bootstrap_runs row + its stages, or None.
+
+    Used by ``GET /system/bootstrap-status`` (#1136 Phase A.3 audit
+    endpoint) which pins on ``bootstrap_state.last_run_id`` rather
+    than ``ORDER BY id DESC LIMIT 1``. The two diverge transiently
+    during ``start_run`` and any post-restart sweep that re-seeded a
+    row without touching the singleton — the retry semantics the
+    endpoint advertises target ``last_run_id`` because that is what
+    ``reset_failed_stages_for_retry`` reads.
+
+    Returns ``None`` when the run row has been deleted out-of-band
+    (manual cleanup); the caller should surface ``last_run_id`` with
+    empty stages as an operator-visible stale-pointer signal rather
+    than masking it as "no prior run."
+    """
+    with conn.transaction():
+        run_row = conn.execute(
             """
-            SELECT id, bootstrap_run_id, stage_key, stage_order, lane, job_name,
-                   status, started_at, completed_at, rows_processed,
-                   expected_units, units_done, last_error, attempt_count
-              FROM bootstrap_stages
-             WHERE bootstrap_run_id = %(run_id)s
-             ORDER BY stage_order ASC, id ASC
+            SELECT id, status, triggered_at, completed_at
+              FROM bootstrap_runs
+             WHERE id = %(run_id)s
             """,
             {"run_id": run_id},
-        ).fetchall()
+        ).fetchone()
+        if run_row is None:
+            return None
+        row_id, run_status, triggered_at, completed_at = run_row
+        return _read_run_with_stage_rows(
+            conn,
+            run_id=row_id,
+            run_status=run_status,
+            triggered_at=triggered_at,
+            completed_at=completed_at,
+        )
+
+
+def _read_run_with_stage_rows(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+    run_status: RunStatus,
+    triggered_at: datetime,
+    completed_at: datetime | None,
+) -> RunSnapshot:
+    """Helper: project the stage rows for an already-located run row."""
+    stage_rows = conn.execute(
+        """
+        SELECT id, bootstrap_run_id, stage_key, stage_order, lane, job_name,
+               status, started_at, completed_at, rows_processed,
+               expected_units, units_done, last_error, attempt_count
+          FROM bootstrap_stages
+         WHERE bootstrap_run_id = %(run_id)s
+         ORDER BY stage_order ASC, id ASC
+        """,
+        {"run_id": run_id},
+    ).fetchall()
 
     stages = tuple(
         StageRow(
@@ -1139,6 +1197,144 @@ def reap_orphaned_running(
     return True
 
 
+# ---------------------------------------------------------------------------
+# Retry-view computation (#1136 Phase A.3 audit endpoint)
+# ---------------------------------------------------------------------------
+
+
+RetryBlockedReason = Literal[
+    "bootstrap_running",
+    "no_prior_run",
+    "state_not_resettable",
+    "no_failed_stages",
+]
+"""Why ``/system/bootstrap/retry-failed`` would refuse the next click.
+
+``None`` when the click would succeed (retry-available). Each
+non-None value mirrors the exception precedence inside
+``reset_failed_stages_for_retry``:
+
+* ``"no_prior_run"``         — ``state.last_run_id IS NULL``.
+* ``"bootstrap_running"``    — ``state.status == 'running'``.
+* ``"state_not_resettable"`` — ``state.status NOT IN
+                               ('partial_error', 'cancelled')``.
+* ``"no_failed_stages"``     — singleton is in a resettable status but
+                               latest run has no
+                               ``error``/``blocked``/``cancelled``
+                               stage; helper returns 0 reset rows and
+                               the API maps to 404.
+"""
+
+
+_FAILED_STATUSES: frozenset[str] = frozenset({"error", "blocked", "cancelled"})
+_RESETTABLE_STATE_STATUSES: frozenset[str] = frozenset({"partial_error", "cancelled"})
+
+
+@dataclass(frozen=True)
+class RetryView:
+    """Pure-data view of the bootstrap-retry surface.
+
+    Computed from ``(BootstrapState, RunSnapshot | None)`` without DB
+    access; the API endpoint serialises it directly. Per-stage
+    ``stage_retryable`` is keyed by ``stage_key``.
+
+    Semantics mirror ``reset_failed_stages_for_retry``:
+
+    * ``retry_available`` is True iff a ``/retry-failed`` call would
+      reset at least one stage (and not raise).
+    * ``stage_retryable[stage_key]`` is True iff that specific stage
+      row would be transitioned to ``pending`` by the reset SQL —
+      i.e. it sits in a lane with at least one failed row AND its
+      ``stage_order >= MIN(stage_order)`` over the failed rows of
+      that lane. The stage's *own* status is irrelevant to the
+      predicate; a ``success`` row downstream of a same-lane failure
+      gets reset alongside the failures (#1136 audit findings §3 +
+      §4.2).
+    """
+
+    retry_available: bool
+    retry_blocked_reason: RetryBlockedReason | None
+    stage_retryable: Mapping[str, bool]
+
+
+def compute_retryable_view(
+    state: BootstrapState,
+    snapshot: RunSnapshot | None,
+) -> RetryView:
+    """Project the retry surface from state + run snapshot.
+
+    Pure function. Mirrors the precedence inside
+    ``reset_failed_stages_for_retry`` so the operator readout
+    reflects what the next click will do — not what the row reads as
+    today. Detailed semantics in
+    ``docs/superpowers/specs/2026-05-19-1136-bootstrap-state-audit.md``
+    §4.2.
+    """
+    # Precedence 1: no prior run.
+    if state.last_run_id is None:
+        return RetryView(
+            retry_available=False,
+            retry_blocked_reason="no_prior_run",
+            stage_retryable={},
+        )
+
+    # Precedence 2: bootstrap currently running.
+    if state.status == "running":
+        return RetryView(
+            retry_available=False,
+            retry_blocked_reason="bootstrap_running",
+            stage_retryable={stage.stage_key: False for stage in (snapshot.stages if snapshot else ())},
+        )
+
+    # Precedence 3: singleton status not in (partial_error, cancelled).
+    if state.status not in _RESETTABLE_STATE_STATUSES:
+        return RetryView(
+            retry_available=False,
+            retry_blocked_reason="state_not_resettable",
+            stage_retryable={stage.stage_key: False for stage in (snapshot.stages if snapshot else ())},
+        )
+
+    # State is resettable; need a snapshot to compute per-lane mins.
+    if snapshot is None or not snapshot.stages:
+        return RetryView(
+            retry_available=False,
+            retry_blocked_reason="no_failed_stages",
+            stage_retryable={},
+        )
+
+    min_failed_order_by_lane: dict[str, int] = {}
+    for stage in snapshot.stages:
+        if stage.status not in _FAILED_STATUSES:
+            continue
+        current = min_failed_order_by_lane.get(stage.lane)
+        if current is None or stage.stage_order < current:
+            min_failed_order_by_lane[stage.lane] = stage.stage_order
+
+    if not min_failed_order_by_lane:
+        # Resettable singleton but no failed rows on the latest run —
+        # /retry-failed would 404 with "no failed stages to retry"
+        # because reset_count==0.
+        return RetryView(
+            retry_available=False,
+            retry_blocked_reason="no_failed_stages",
+            stage_retryable={stage.stage_key: False for stage in snapshot.stages},
+        )
+
+    stage_retryable: dict[str, bool] = {}
+    for stage in snapshot.stages:
+        min_order = min_failed_order_by_lane.get(stage.lane)
+        if min_order is None:
+            stage_retryable[stage.stage_key] = False
+            continue
+        stage_retryable[stage.stage_key] = stage.stage_order >= min_order
+
+    return RetryView(
+        retry_available=True,
+        retry_blocked_reason=None,
+        stage_retryable=stage_retryable,
+    )
+
+
 __all__ = [
     "BootstrapAlreadyRunning",
     "BootstrapNoPriorRun",
@@ -1148,6 +1344,8 @@ __all__ = [
     "BootstrapState",
     "BootstrapStatus",
     "Lane",
+    "RetryBlockedReason",
+    "RetryView",
     "RunSnapshot",
     "RunStatus",
     "StageRow",
@@ -1155,6 +1353,7 @@ __all__ = [
     "StageStatus",
     "StopAlreadyPendingError",
     "cancel_run",
+    "compute_retryable_view",
     "finalize_run",
     "force_mark_complete",
     "mark_run_cancelled",
@@ -1165,6 +1364,7 @@ __all__ = [
     "mark_stage_skipped",
     "mark_stage_success",
     "read_latest_run_with_stages",
+    "read_run_with_stages",
     "read_state",
     "reap_orphaned_running",
     "reset_failed_stages_for_retry",

--- a/docs/superpowers/plans/2026-05-19-post-1208-cleardown.md
+++ b/docs/superpowers/plans/2026-05-19-post-1208-cleardown.md
@@ -40,13 +40,15 @@ Three deliverables. Each follows the #1208-shape cadence: spike → spec → Cod
 - **Estimate:** ~150 LOC. One PR.
 - **Spec gate:** `docs/superpowers/specs/2026-05-NN-1218-parser-period-end.md` + Codex 1a/1b.
 
-### Phase A.2 — #1010 13F sweep cohort bound
+### Phase A.2 — #1010 13F sweep cohort bound — CLOSED 2026-05-19
+
+**Merged:** PR #1222 / `240112e`.
+**Spec:** `docs/superpowers/specs/2026-05-19-1010-13f-cohort-bound.md`.
 
 - **Symptom:** `bootstrap_sec_13f_recent_sweep` walks 11,205 filers @ 23/min = ~8 h on first install. Most are sub-$100M managers filing empty 13F-NTs. Bootstrap times out + retries forever.
-- **Scope:** add `last_13f_hr_at` column to `institutional_filers`; populate during `sec_13f_filer_directory_sync` by tracking last `13F-HR` (excluding -NT/-A) per CIK; sweep excludes filers older than 4 quarters. Optional secondary cap on top-N by AUM if cheap to derive.
-- **Why pre-bootstrap:** without this, the bootstrap drain literally cannot finish in a reasonable window. Operator retry burns 8 h per attempt.
-- **Estimate:** ~250 LOC. One PR. Migration adds the column + a back-population query.
-- **Spec gate:** `docs/superpowers/specs/2026-05-NN-1010-13f-cohort-bound.md` + Codex 1a/1b.
+- **Scope (delivered):** added `last_13f_hr_at` column to `institutional_filers`; populated during `sec_13f_filer_directory_sync` by tracking 13F-HR / HR-A only (NT/NT-A excluded); `list_directory_filer_ciks(min_last_13f_hr_at=...)` filters cohort; bootstrap stage 21 dispatches `_PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF` resolved to UTC start-of-day `today() - 380d`. AUM cap deferred (not needed; recency alone landed acceptance).
+- **Outcome:** cohort 11,205 → 8,718 (78% have backfill) → 8,681 (within 380d). Subsequent `sec_13f_filer_directory_sync` runs converge to form.idx ground truth (NT-only filers re-revealed as NULL).
+- **Iteration:** Codex 1a (6 findings: NULLIF guard, `_upsert_filer` advance, UTC-midnight cutoff, backfill caveat, shared-cutoff justification, default ordering preserved), Codex 1b (4 follow-ups: exact-equality test, naive ISO UTC tag, retired-cron wording, boundary-test UTC midnight explicit), Codex 1c clean, Codex 2 MEDIUM (`date.today()` is local TZ → `datetime.now(tz=UTC).date()`). Bot APPROVE round 1 + APPROVE round 2 after NITPICK fix (`__import__("datetime").timezone.utc` → `from datetime import UTC`).
 
 ### Phase A.3 — #1136 bootstrap state-machine audit (scope subset)
 
@@ -180,6 +182,66 @@ When §D + §E land (any time):
 8. N-PORT data populated (Phase E #917).
 
 ## 12. Handover for next session
+
+```
+Pick up Phase A.3 of docs/superpowers/plans/2026-05-19-post-1208-cleardown.md
+(post-#1208 clear-down + bootstrap completion, autonomous-execution
+contract per #1208 plan §1 — no operator signoff between Codex
+iterations, drive PR to merge in one session).
+
+PHASE A.3 SCOPE — #1136 bootstrap state-machine audit (subset):
+
+- Audit current bootstrap_stages to identify which stage(s) failed in
+  run_id=3.
+- For each failed stage: confirm the underlying ETL is patched (Phase
+  A.1 #1218 / A.2 #1010 / a previous fix) + add a regression test
+  that the stage now succeeds against a fresh DB.
+- Operator-visible: GET /system/bootstrap-status (mirror of
+  /system/postgres-health shape) returning (stage, last_status,
+  last_error, retryable) per stage. Lets operator drive T9-POST
+  without log-grepping.
+
+FIRST ACTIONS:
+
+1. Read CLAUDE.md working order. Confirm #1136 still OPEN.
+2. Read app/services/processes/bootstrap_orchestrator and the
+   bootstrap_stages schema in sql/.
+3. Spike: SELECT stage_key, status, last_error FROM bootstrap_stages
+   WHERE run_id = (SELECT last_run_id FROM bootstrap_state WHERE id=1);
+4. Read app/api/system.py (postgres-health) for the endpoint shape.
+
+DESIGN STEPS:
+- Mirror #1208 / #1218 / #1010 cadence: spike → spec → Codex 1a/1b
+  → impl → Codex 2 → push → bot → merge.
+- Spec at docs/superpowers/specs/2026-05-NN-1136-bootstrap-state-audit.md.
+- Implementation: stage audit script + /system/bootstrap-status
+  endpoint + regression tests for previously-failing stages.
+
+CONTEXT FROM A.1 + A.2 (just merged):
+- PR #1220 f451e18 merged 2026-05-19. Phase A.1 closed #1218.
+- PR #1222 240112e merged 2026-05-19. Phase A.2 closed #1010.
+- Same Codex/bot/merge cadence worked in both; bot's NITPICK fixed
+  pre-merge in A.2.
+
+NON-NEGOTIABLES (carried from #1208 + #1218 + #1010):
+- Per CLAUDE.md: read settled-decisions + prevention-log + relevant
+  skills BEFORE writing code.
+- Per feedback_post_push_cycle: poll gh pr view + gh pr checks
+  IMMEDIATELY after push.
+- Per feedback_no_fake_polling: NEVER narrate "waiting/polling"
+  without invoking actual check tool that turn.
+- Per feedback_pr_auto_close_required: PR body MUST contain
+  `Closes #1136` on its own line (or scope-subset reference if the
+  full umbrella stays open).
+
+If A.3 lands clean, next session = Phase C operator T9-POST drive
+(no code; admin UI clicks + monitor /system/bootstrap-status until
+every stage = complete).
+```
+
+---
+
+## 12.OLD. (archived) Phase A.1 handover
 
 ```
 Pick up Phase A.1 of docs/superpowers/plans/2026-05-19-post-1208-cleardown.md

--- a/docs/superpowers/specs/2026-05-19-1136-bootstrap-state-audit.md
+++ b/docs/superpowers/specs/2026-05-19-1136-bootstrap-state-audit.md
@@ -1,0 +1,451 @@
+# #1136 — Bootstrap state-machine audit (Phase 4 trim) + operator-visibility endpoint
+
+> Created **2026-05-19** as Phase A.3 of
+> [`docs/superpowers/plans/2026-05-19-post-1208-cleardown.md`](../plans/2026-05-19-post-1208-cleardown.md).
+> Partial-closes #1136 (umbrella stays open for the deferred items in §6).
+> Same cadence as #1218 / #1010 (PR #1220 / PR #1222).
+
+## 1. Problem
+
+`bootstrap_state` has sat at `partial_error` since 2026-05-17 (run_id=3).
+Operator drive-back to `complete` requires hitting "Retry failed" from
+the admin UI, but the operator currently has no readout that answers
+the two T9-POST questions cleanly:
+
+1. **Which stages failed and which of those failures are
+   operator-retryable** (i.e. `/system/bootstrap/retry-failed` would
+   actually advance them) versus structural blockers that need a code
+   fix first?
+2. **What is the current retry-availability of the run overall** —
+   would the next click do anything, or would it 4xx?
+
+The existing `GET /system/bootstrap/status` endpoint returns the
+per-stage rows verbatim (status / last_error / archive_results /
+bulk_manifest), but does NOT compute a `retryable` predicate and does
+NOT summarise whether `/retry-failed` would succeed. The operator has
+to read every `last_error` and mentally replay the precedence rules
+inside `reset_failed_stages_for_retry` to know what a retry will do.
+
+There is also one stale-data failure mode the retry path cannot heal
+on its own (see §3 below — S21 in run_id=3).
+
+## 2. Goal
+
+Three deliverables:
+
+1. **Audit:** confirm the run_id=3 failure set, classify each failure
+   as patched / retryable-by-current-contract / out-of-scope-deferred,
+   and record the classification in this spec so reviewers can read
+   the closure rationale without log-grepping.
+2. **Operator endpoint:** `GET /system/bootstrap-status` (mirror of
+   the `/system/postgres-health` lean readout shape) returning
+   `(stage_key, status, last_error, retryable, attempt_count,
+   completed_at)` per stage + a top-level summary + a
+   `retry_available` / `retry_blocked_reason` pair so the operator can
+   drive T9-POST without log-grepping.
+3. **Dispatch hardening:** the dispatcher resolves `job_name` from
+   `_BOOTSTRAP_STAGE_SPECS` by `stage_key` instead of reading it from
+   `bootstrap_stages.job_name`. Removes the one stale-data failure
+   mode the retry path cannot self-heal (S21 in run_id=3). Existing
+   DB column stays in place for forensic audit; it just stops being a
+   dispatch input.
+
+## 3. Audit of run_id=3 — failure classification
+
+```text
+state: partial_error  last_run_id=3  last_completed_at=2026-05-17 05:30:37 UTC
+```
+
+Stages 1-15 success. Stages 16-24 below. Per-lane minimum-failed
+`stage_order` (drives reset scope — see §4.2):
+
+* `sec_rate` lane: `MIN(stage_order WHERE status IN
+  ('error','blocked','cancelled')) = 17` → reset on retry touches
+  S17-S22 (S16 stays put).
+* `db` lane: same MIN = 23 → reset touches S23-S24 (S8-S12 stay put).
+
+| Stage | Status | attempt | Failure mode | Patched by | Phase A.3 decision |
+|---|---|---|---|---|---|
+| 16 `sec_def14a_bootstrap` | **pending** | 2 | Run finalised with this stage still pending. `finalize_run` counts only error/blocked/cancelled toward `partial_error`; a stuck `pending` is silently passed through. The retry-failed reset is scoped to `stage_order >= MIN(sec_rate failed) = 17`, so S16 at order 16 is **never re-dispatched** by a retry click — that is the root of "stuck pending" for run_id=3. | nothing yet | DEFER — separate ticket; needs dispatcher root-cause investigation (why the run finalised with S16 still pending in the first place). Operator-visible via the new endpoint as `retryable=False, last_error=null`. |
+| 17 `sec_business_summary_bootstrap` | error | 2 | `JobLock` contention — competing scheduled cron / manual run held the source advisory lock. Error message literally tells the operator to retry after the other run completes. | nothing — by design | KEEP behaviour; surface as `retryable=True`. Retry-failed reset puts it back to `pending`, next dispatch reclaims the lock. |
+| 18 `sec_insider_transactions_backfill` | error | 2 | Same as S17. | nothing | Same as S17. |
+| 19 `sec_form3_ingest` | error | 2 | Same as S17. | nothing | Same as S17. |
+| 20 `sec_8k_events_ingest` | error | 2 | Same as S17. | nothing | Same as S17. |
+| 21 `sec_13f_recent_sweep` | error | 2 | `unknown job_name 'bootstrap_sec_13f_recent_sweep'` — PR1c #1064 renamed the canonical to `JOB_SEC_13F_QUARTERLY_SWEEP` but the DB row's `job_name` was set at run-creation time and never updated. The dispatcher reads `_INVOKERS.get(stage.job_name)` (`bootstrap_orchestrator.py:1771`), the stale name returns `None`, the stage is marked error before any work runs. Retry-failed leaves `job_name` untouched, so the next retry hits the same wall. | **#1136 / this spec — §4.3 dispatch hardening** | FIX in scope. |
+| 22 `sec_n_port_ingest` | error | 2 | Same as S17 (lock contention). | nothing | Same as S17. |
+| 23 `ownership_observations_backfill` | blocked | 0 | `missing capability institutional_inputs_seeded; no surviving provider met rows floor 1 (providers: sec_13f_ingest_from_dataset=success [rows_processed=NULL], sec_13f_recent_sweep=?)` — bulk provider landed `success` but its `rows_processed` is NULL, so the strict-gate floor of 1 (#1140) marks the cap dead. | nothing yet | DEFER — separate ticket. Real ETL bug: the bulk ingester wrapper does not propagate row counts to `mark_stage_success`. Operator-visible via the new endpoint as `retryable=True` mechanically, **but the retry is expected to re-block immediately**: the retry resets only S23-S24 (db-lane reset floor=23), leaves the upstream success rows alone, and the cap-eval reads the same NULL-row-count providers and marks the cap dead again. Self-healing requires the row-count fix to land first. |
+| 24 `fundamentals_sync` | blocked | 2 | `missing capability fundamentals_raw_seeded; no surviving provider met rows floor 1 (providers: sec_companyfacts_ingest=success [rows_processed=NULL])` — same shape as S23. | nothing yet | DEFER — same ticket as S23 (bulk providers' row-count propagation). `retryable=True` mechanically; re-blocks until row-count fix lands. |
+
+**Net Phase A.3 fix budget:** one dispatch-hardening change (§4.3,
+covers S21) + one operator endpoint (§4.1 + §4.2) + regression tests
+(§5). Everything else either retries-clean today (S17-S20, S22), or
+retries-and-re-blocks-honestly (S23-S24 — the new endpoint flags the
+"retryable but expected to re-block" shape as `retryable=True`
+because that matches what `/retry-failed` will actually do; the
+operator's downstream observation that the re-block recurred is the
+trigger to chase the row-count followup), or falls to a follow-up
+ticket (S16 stuck-pending).
+
+## 4. Design
+
+### 4.1 Endpoint
+
+`GET /system/bootstrap-status` lives in `app/api/system.py` (next to
+`/system/postgres-health`). Pydantic response model:
+
+```python
+class BootstrapStatusSummary(BaseModel):
+    total: int
+    pending: int
+    running: int
+    success: int
+    error: int
+    blocked: int
+    skipped: int
+    cancelled: int
+
+
+class BootstrapStatusStageOverview(BaseModel):
+    stage_key: str
+    stage_order: int
+    lane: LaneApi          # reuse from app/api/bootstrap.py
+    status: StageApiStatus # reuse from app/api/bootstrap.py
+    last_error: str | None
+    attempt_count: int
+    completed_at: datetime | None
+    retryable: bool
+
+
+class BootstrapStatusOverview(BaseModel):
+    state_status: BootstrapApiStatus
+    current_run_id: int | None
+    last_completed_at: datetime | None
+    summary: BootstrapStatusSummary
+    retry_available: bool
+    retry_blocked_reason: Literal[
+        "bootstrap_running",
+        "no_prior_run",
+        "state_not_resettable",
+        "no_failed_stages",
+    ] | None
+    stages: list[BootstrapStatusStageOverview]
+    collected_at: datetime
+```
+
+Auth: same `require_session_or_service_token` dependency the rest of
+the `/system/*` router uses.
+
+Failure posture (mirrors `/system/postgres-health`):
+
+* DB unreachable → 503 with detail `"bootstrap status unavailable"`.
+* No prior run → 200 with `state_status="pending"`,
+  `current_run_id=None`, `stages=[]`, `retry_available=False`,
+  `retry_blocked_reason="no_prior_run"`.
+
+Snapshot read happens inside one `conn.transaction()` so the state +
+run + stage rows come from a single READ COMMITTED window — same
+contract as `_build_status_response` in `app/api/bootstrap.py`.
+
+**Run-id pinning (Codex 1b §2):** the endpoint reads stages keyed
+off `bootstrap_state.last_run_id`, NOT `ORDER BY bootstrap_runs.id
+DESC LIMIT 1`. The two diverge transiently — `start_run` inserts a
+new `bootstrap_runs` row inside a transaction that also flips the
+singleton to that new id, but a reader observing in between (or a
+post-restart sweep that re-seeded a row without touching the
+singleton) would point at the wrong run. The retry semantics this
+endpoint advertises target the singleton's `last_run_id` because
+that is what `reset_failed_stages_for_retry` reads. So:
+
+```python
+state = read_state(conn)
+if state.last_run_id is None:
+    snap = None
+else:
+    snap = read_run_with_stages(conn, run_id=state.last_run_id)
+```
+
+A new helper `read_run_with_stages(conn, *, run_id)` lives next to
+`read_latest_run_with_stages` in `app/services/bootstrap_state.py`
+— same query, parameterised on `run_id` instead of `ORDER BY id
+DESC LIMIT 1`. If the run row vanished (manual DB cleanup) the
+helper returns `None` and the endpoint surfaces
+`current_run_id=state.last_run_id` with `stages=[]` —
+operator-visible "stale pointer" rather than a misleading old run.
+
+### 4.2 Retryable computation
+
+Pure function in `app/services/bootstrap_state.py` (new
+`compute_retryable_view`, exported), unit-tested without a live DB.
+Inputs: `BootstrapState`, `RunSnapshot | None`. Output: the
+`(retry_available, retry_blocked_reason, per_stage_retryable: dict)`
+triple the endpoint serialises.
+
+Per-stage `retryable` is True iff `reset_failed_stages_for_retry`
+would set this stage's `status` back to `pending` on the next call.
+Per the helper's SQL ([bootstrap_state.py:718-749]
+(../../../app/services/bootstrap_state.py)) the reset walks **every
+same-lane row with `stage_order >= MIN(stage_order)` over failed
+rows in that lane** — regardless of the row's own current status.
+A `success` stage downstream of a same-lane failure is reset to
+`pending` along with the failures. A `pending` stage upstream of
+the first failure is NOT reset.
+
+The predicate therefore is:
+
+1. `state.status in ("partial_error", "cancelled")`, AND
+2. `stage.lane` has at least one row in
+   `(error, blocked, cancelled)`, AND
+3. `stage.stage_order >= MIN(stage_order)` over those failed
+   same-lane rows.
+
+The stage's own current status is irrelevant to the predicate — it
+is what the SQL reset will do, not what the row reads as today.
+
+`retry_blocked_reason` precedence (first match wins, mirroring the
+helper's exception precedence inside the singleton `FOR UPDATE`):
+
+1. `state.last_run_id is None` → `"no_prior_run"`.
+2. `state.status == "running"` → `"bootstrap_running"`.
+3. `state.status not in ("partial_error", "cancelled")` →
+   `"state_not_resettable"`.
+4. No stage in `(error, blocked, cancelled)` →
+   `"no_failed_stages"`.
+5. Otherwise → `None` and `retry_available=True`.
+
+**Worked example — run_id=3** (validates the implementation against
+the live state in §3):
+
+* `state.status="partial_error"`, `last_run_id=3` → not blocked at
+  the state level.
+* `sec_rate` lane: failed rows = {S17 error, S18 error, S19 error,
+  S20 error, S21 error, S22 error}, `MIN=17`. → S16 (order 16) is
+  **not** retryable (16 < 17 — that is the root of "stuck pending,"
+  not "pending status itself"). S17-S22 all retryable.
+* `db` lane: failed rows = {S23 blocked, S24 blocked}, `MIN=23`. →
+  S23, S24 retryable. S8-S12 (success, orders 8-12) untouched
+  because 8-12 < 23.
+* `init` / `etoro` lanes: no failed rows → no resets in those lanes.
+  S1, S2 retryable=False.
+
+So the endpoint will report `retryable=True` for S17-S24 and
+`retryable=False` for S1-S16 plus the success stages outside the
+failed-lane reset window.
+
+### 4.3 Dispatch hardening — resolve job_name by stage_key
+
+Today `app/services/bootstrap_orchestrator.py:1771` reads
+`_INVOKERS.get(stage.job_name)` where `stage` is the DB row. A
+catalogue rename (PR1c #1064 → `JOB_SEC_13F_QUARTERLY_SWEEP`) cannot
+backfill the in-DB column on existing runs, so a retry of an old run
+hits an unknown job_name and errors before invocation.
+
+Fix: build a `stage_key → spec` map from `_BOOTSTRAP_STAGE_SPECS` at
+the top of `run_bootstrap_orchestrator`, look up `spec.job_name` by
+`stage.stage_key`, and **fail closed** if the stage_key is not in the
+catalogue (Codex 1a §5 — falling back to the DB row's `job_name` for
+an unknown stage_key would dispatch a stale stage without canonical
+params / lane / caps, the worst-of-both-worlds).
+
+```python
+spec_by_key = {spec.stage_key: spec for spec in _BOOTSTRAP_STAGE_SPECS}
+# ...
+canonical_spec = spec_by_key.get(stage.stage_key)
+if canonical_spec is None:
+    # Catalogue trim removed this stage_key but live DB rows still
+    # exist (e.g. an old `dividend_calendar` row from a pre-#719
+    # install). Refuse to dispatch — silently invoking
+    # stage.job_name from the DB row would lose canonical params,
+    # CapRequirement, and lane semantics. Mark error so the
+    # operator sees the gap.
+    #
+    # mark_stage_error has `AND status = 'running'`; against a
+    # `pending` row it no-ops silently and the stage would survive
+    # into finalize_run still pending (Codex 1b §1). Run the
+    # pending → running → error sequence the existing unknown-
+    # job-name path already uses at bootstrap_orchestrator.py:1778.
+    with psycopg.connect(database_url) as conn:
+        mark_stage_running(conn, run_id=run_id, stage_key=stage.stage_key)
+        mark_stage_error(
+            conn,
+            run_id=run_id,
+            stage_key=stage.stage_key,
+            error_message=(
+                f"stage_key {stage.stage_key!r} not in current bootstrap catalogue; "
+                f"row job_name={stage.job_name!r} is stale and dispatch is refused"
+            ),
+        )
+        conn.commit()
+    continue
+effective_job_name = canonical_spec.job_name
+invoker = _INVOKERS.get(effective_job_name)
+```
+
+`effective_job_name` must flow through every downstream consumer that
+currently reads `stage.job_name`, not just the `_INVOKERS` lookup
+(Codex 1a §3). Concretely:
+
+* `validate_job_params(..., job_name=effective_job_name, ...)` at
+  `bootstrap_orchestrator.py:1643` — otherwise the validator looks up
+  a registry entry under the stale name and the stage still fails
+  before invocation.
+* `_RunnableStage.job_name = effective_job_name` at
+  `bootstrap_orchestrator.py:1791` — propagates to `_run_one_stage`
+  and the `_snapshot_job_runs_max_id(job_name=...)` rows-resolution
+  helper.
+* Structured log at info level when `effective_job_name !=
+  stage.job_name`: `"bootstrap dispatcher: stage %s remapped
+  stored_job_name=%r → effective_job_name=%r (catalogue rename)"`
+  (Codex 1a §4). Preserves the forensic trail; the DB row is the
+  long-term audit record, the log line records the runtime decision.
+
+The DB column `bootstrap_stages.job_name` stays as the
+audit-snapshot of "what the run was created to dispatch" — never
+overwritten, never used for dispatch decisions. The audit value of
+that column is preserved (Codex 1a §4 concern: do not silently
+rewrite historical rows).
+
+Single-site change. No schema migration. No data fix-up script — the
+next retry of run_id=3 (T9-POST) self-heals because the dispatcher
+no longer cares about the stale string. The forensic record of
+`bootstrap_stages.job_name='bootstrap_sec_13f_recent_sweep'` survives
+in the DB for anyone reading the run's history.
+
+## 5. Tests
+
+### 5.1 Pure-function tests (`tests/test_bootstrap_retry_view.py`, new)
+
+`compute_retryable_view`:
+
+* Empty state (no run) → `retry_available=False, reason="no_prior_run", stages=[]`.
+* `state.status="running"` → `reason="bootstrap_running"`, every stage
+  `retryable=False`.
+* `state.status="complete"` → `reason="state_not_resettable"`.
+* `state.status="pending"` with `last_run_id=None` →
+  `reason="no_prior_run"`.
+* `state.status="partial_error"` with all stages success →
+  `reason="no_failed_stages"`.
+* `state.status="partial_error"` with one stage in `error` →
+  `retry_available=True`, that stage `retryable=True`, others
+  `retryable=False` (different lane).
+* Lane-downstream propagation: stages S17/S18 in same lane both
+  `error`; S19 in same lane `success` but `stage_order > min(failed)`
+  → S19 `retryable=True` (helper will reset it too).
+* **Own-status irrelevance** (Codex 1b §3): a `pending` row in the
+  same lane as a failure, with `stage_order >= MIN(failed_order)`,
+  is `retryable=True`. The predicate looks at lane + order, not the
+  row's own status.
+* `pending` stage in a lane with another lane's failure →
+  `retryable=False` (helper only touches the failed lane).
+* Pre-min-order rows are NOT retryable even when same-lane failures
+  exist: place S16 in `pending`, S17 in `error`, both in `sec_rate`;
+  S16 has `stage_order < min(failed)` → `retryable=False`. Exact
+  shape of run_id=3 S16.
+* `cancelled` state with `cancelled` stages → all cancelled stages
+  `retryable=True`.
+
+### 5.2 API tests (`tests/test_api_bootstrap_status_overview.py`, new)
+
+* 200 with `state="pending"` shape (no run).
+* 200 with `state="partial_error"` shape — sum of summary counters
+  equals total; `retry_available=True`; at least one stage
+  `retryable=True`.
+* 503 when `read_state` raises `psycopg.Error` (DB unreachable).
+* Auth: 401 without session token.
+* **Run-id pinning** (Codex 1c MEDIUM): mock `read_state` to return
+  `last_run_id=42` and patch the new `read_run_with_stages(conn,
+  run_id=...)` helper. Assert the endpoint passes 42 (not the
+  latest-id-by-DESC). A second test seeds a `read_state` with
+  `last_run_id=42` plus a `read_run_with_stages` that returns `None`
+  (run row vanished); endpoint should still 200 with
+  `current_run_id=42, stages=[]` — operator-visible stale pointer.
+
+Mock pattern mirrors `tests/test_api_bootstrap.py`'s
+`_install_conn()` + `dependency_overrides`.
+
+### 5.3 Dispatch-hardening regression — `tests/test_bootstrap_orchestrator.py` (extend)
+
+* `test_dispatch_resolves_job_name_from_spec_by_stage_key`: seed a
+  `bootstrap_stages` row with `stage_key="sec_13f_recent_sweep"` and
+  `job_name="bootstrap_sec_13f_recent_sweep"` (the deleted wrapper).
+  Patch `_INVOKERS` to register only the canonical
+  `JOB_SEC_13F_QUARTERLY_SWEEP`. Assert the dispatcher resolves the
+  spec-side name AND param validation sees that name (Codex 1b §5):
+  the test fixture seeds `params={"source_label":
+  "sec_edgar_13f_directory_bootstrap"}` which is allow-listed via
+  `JOB_INTERNAL_KEYS` for the canonical `sec_13f_quarterly_sweep`
+  job; under the stale `bootstrap_sec_13f_recent_sweep` name the
+  validator has no registry entry and rejects the param. The test
+  asserts the stage reaches success (invoker called once), not just
+  that the unknown-job-name branch wasn't taken.
+* `test_dispatch_unknown_stage_key_fails_closed` (Codex 1b §4): seed
+  a `bootstrap_stages` row with `stage_key="dividend_calendar"` (a
+  catalogue-trimmed key from a pre-#719 install) and any `job_name`.
+  Assert the dispatcher marks the stage `error` (NOT silently
+  `pending`) with an error message containing the stale
+  `stage_key`. Validates the mark_stage_running + mark_stage_error
+  pair from §4.3 (against the silent-no-op pitfall in Codex 1b §1).
+
+### 5.4 Catalogue-invariant — existing `tests/test_bootstrap_orchestrator_source_registry.py`
+
+Existing test asserts every `_BOOTSTRAP_STAGE_SPECS.job_name` is
+registered in `_INVOKERS`. Confirmed still passing on main; this PR
+does not weaken it.
+
+## 6. Out of scope — follow-up tickets to file at merge
+
+Three findings the audit surfaced that are NOT addressed here:
+
+1. **S16 stuck-pending root cause** — `finalize_run` and / or the
+   dispatcher loop should sweep any non-terminal stage to `error` /
+   `blocked` before finalising, or refuse to finalise. Needs
+   replay-against-DB investigation. File a `tech-debt` ticket
+   referencing run_id=3 S16 as the exemplar.
+2. **Bulk ingester `rows_processed=NULL`** — `sec_13f_ingest_from_dataset`
+   and `sec_companyfacts_ingest` land `success` without writing a row
+   count to `mark_stage_success`, defeating the strict-gate floor.
+   File an `area: filings` ticket referencing run_id=3 S23/S24 as the
+   exemplars; #1140 (Task C) is the original strict-gate ticket and
+   should cross-reference.
+3. **JobLock contention with standalone crons during bootstrap retry**
+   — S17/S18/S19/S20/S22 all errored with "another instance holds the
+   advisory lock; retry after the other run completes." Behaviour is
+   correct (lock prevents double-dispatch) and the error message
+   directs the operator. No follow-up needed unless the noise becomes
+   an operator-UX papercut, in which case the orchestrator can grow a
+   `wait-for-lock-with-timeout` mode in a separate ticket.
+
+Issue #1136 stays open after this PR merges; the umbrella's remaining
+items (#1041 slow-connection, #649 self-healing freshness, #1064
+admin hub follow-ups) stay tracked as documented in §1 of the plan.
+
+## 7. Rollout
+
+1. Branch `feature/1136-bootstrap-state-audit`.
+2. Implement §4.1 + §4.2 + §4.3 + §5 in one PR.
+3. Pre-push: `uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest`.
+4. Codex 2 on the diff. Push only after clean.
+5. Bot review + CI poll.
+6. Merge on APPROVE-on-latest + CI green.
+7. Update auto-memory + close-out comment on the issue.
+8. **T9-POST follow-up** (operator, not this PR): hit
+   `/system/bootstrap/retry-failed`. The §4.3 dispatch hardening means
+   S21 now invokes correctly. S17/S18/S19/S20/S22 retry-claim the
+   locks (standalone crons have long-since released them). S16
+   remains `pending` and is flagged by the new endpoint as
+   `retryable=False` — that one's the followup-ticket case.
+
+## 8. Acceptance
+
+1. `GET /system/bootstrap-status` returns 200 with the §4.1 shape
+   against the dev DB.
+2. `retry_available=True` matches reality:
+   `/system/bootstrap/retry-failed` returns 202 (not 404 / 409).
+3. Per-stage `retryable` against run_id=3 reads as predicted by §4.2
+   worked example: `retryable=True` for S17-S24, `retryable=False`
+   for S1-S16 (S16 = before-first-failed-same-lane-order, not because
+   it is pending).
+4. New tests in §5 all pass.
+5. No regression in existing `/system/bootstrap/status` shape — the
+   richer endpoint is left untouched.
+6. Bot review on the latest commit returns APPROVE and CI is green.
+7. Auto-memory + issue close-out comment posted with merge SHA.

--- a/tests/test_api_bootstrap_status_overview.py
+++ b/tests/test_api_bootstrap_status_overview.py
@@ -1,0 +1,262 @@
+"""Tests for ``GET /system/bootstrap-status`` (#1136 Phase A.3 audit endpoint).
+
+Lean operator readout sibling to ``/system/bootstrap/status``; mirrors
+the ``/system/postgres-health`` failure posture. Pins on
+``bootstrap_state.last_run_id`` rather than ``ORDER BY id DESC LIMIT 1``
+so the readout reflects what ``/retry-failed`` would actually target.
+
+Mock pattern mirrors ``tests/test_api_bootstrap.py`` — patch the
+``read_state`` / ``read_run_with_stages`` re-exports the endpoint module
+imports, plus a ``MagicMock`` connection so the FastAPI dependency
+chain is happy without a live DB.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.bootstrap_state import BootstrapState, RunSnapshot, StageRow
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def cleanup() -> Iterator[None]:
+    yield
+    from app.db import get_conn
+
+    app.dependency_overrides.pop(get_conn, None)
+
+
+def _install_conn() -> MagicMock:
+    conn = MagicMock()
+
+    def _dep() -> Iterator[MagicMock]:
+        yield conn
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    return conn
+
+
+def _stage(stage_key: str, stage_order: int, lane: str, status: str, **kwargs: object) -> StageRow:
+    return StageRow(
+        id=stage_order,
+        bootstrap_run_id=int(kwargs.get("bootstrap_run_id", 42) or 42),  # type: ignore[arg-type]
+        stage_key=stage_key,
+        stage_order=stage_order,
+        lane=lane,  # type: ignore[arg-type]
+        job_name=str(kwargs.get("job_name", "x")),
+        status=status,  # type: ignore[arg-type]
+        started_at=None,
+        completed_at=kwargs.get("completed_at"),  # type: ignore[arg-type]
+        rows_processed=kwargs.get("rows_processed"),  # type: ignore[arg-type]
+        expected_units=None,
+        units_done=None,
+        last_error=kwargs.get("last_error"),  # type: ignore[arg-type]
+        attempt_count=int(kwargs.get("attempt_count", 1) or 1),  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# No-prior-run shape
+# ---------------------------------------------------------------------------
+
+
+def test_get_status_overview_no_prior_run(client: TestClient) -> None:
+    _install_conn()
+    with (
+        patch(
+            "app.api.system.read_state",
+            return_value=BootstrapState(status="pending", last_run_id=None, last_completed_at=None),
+        ),
+        patch("app.api.system.read_run_with_stages") as read_run_mock,
+    ):
+        resp = client.get("/system/bootstrap-status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["state_status"] == "pending"
+    assert body["current_run_id"] is None
+    assert body["stages"] == []
+    assert body["retry_available"] is False
+    assert body["retry_blocked_reason"] == "no_prior_run"
+    assert body["summary"]["total"] == 0
+    # No need to consult the run table when there's no run id.
+    read_run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# partial_error shape — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_get_status_overview_partial_error(client: TestClient) -> None:
+    _install_conn()
+    snap = RunSnapshot(
+        run_id=42,
+        run_status="partial_error",
+        triggered_at=datetime(2026, 5, 17, 1, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 5, 17, 5, 30, tzinfo=UTC),
+        stages=(
+            _stage("init", 1, "init", "success"),
+            _stage("s17", 17, "sec_rate", "error", last_error="lock contention"),
+            _stage("s18", 18, "sec_rate", "error"),
+            _stage("s19", 19, "sec_rate", "success"),  # downstream-of-failure
+            _stage("s23", 23, "db", "blocked"),
+        ),
+    )
+    state = BootstrapState(
+        status="partial_error",
+        last_run_id=42,
+        last_completed_at=datetime(2026, 5, 17, 5, 30, tzinfo=UTC),
+    )
+    with (
+        patch("app.api.system.read_state", return_value=state),
+        patch("app.api.system.read_run_with_stages", return_value=snap),
+    ):
+        resp = client.get("/system/bootstrap-status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["state_status"] == "partial_error"
+    assert body["current_run_id"] == 42
+    assert body["retry_available"] is True
+    assert body["retry_blocked_reason"] is None
+
+    # Per-stage retryable mirrors the lane-min-order predicate.
+    by_key = {s["stage_key"]: s for s in body["stages"]}
+    assert by_key["init"]["retryable"] is False
+    assert by_key["s17"]["retryable"] is True
+    assert by_key["s18"]["retryable"] is True
+    assert by_key["s19"]["retryable"] is True  # success but >= min(sec_rate failed)
+    assert by_key["s23"]["retryable"] is True
+
+    # Summary counts sum to total.
+    s = body["summary"]
+    assert s["total"] == 5
+    assert s["success"] == 2
+    assert s["error"] == 2
+    assert s["blocked"] == 1
+    assert s["pending"] == 0
+    assert (
+        s["success"] + s["error"] + s["blocked"] + s["pending"] + s["running"] + s["skipped"] + s["cancelled"]
+        == s["total"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run-id pinning (Codex 1b §2)
+# ---------------------------------------------------------------------------
+
+
+def test_get_status_overview_pins_on_last_run_id(client: TestClient) -> None:
+    """Endpoint reads stages keyed off ``bootstrap_state.last_run_id``.
+
+    Two runs could exist with the singleton pointed at the *older*
+    one (e.g. post-restart sweep re-seeded a row without touching the
+    singleton). The readout must follow the singleton, not
+    ``ORDER BY bootstrap_runs.id DESC``.
+    """
+    _install_conn()
+    older_snap = RunSnapshot(
+        run_id=42,
+        run_status="partial_error",
+        triggered_at=datetime(2026, 5, 17, 1, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 5, 17, 5, 30, tzinfo=UTC),
+        stages=(_stage("older_stage", 1, "init", "success", bootstrap_run_id=42),),
+    )
+    state = BootstrapState(
+        status="partial_error",
+        last_run_id=42,  # singleton pinned at older
+        last_completed_at=datetime(2026, 5, 17, 5, 30, tzinfo=UTC),
+    )
+
+    captured_run_ids: list[int] = []
+
+    def _capture(_conn: object, *, run_id: int) -> RunSnapshot:
+        captured_run_ids.append(run_id)
+        return older_snap
+
+    with (
+        patch("app.api.system.read_state", return_value=state),
+        patch("app.api.system.read_run_with_stages", side_effect=_capture),
+    ):
+        resp = client.get("/system/bootstrap-status")
+
+    assert resp.status_code == 200
+    assert captured_run_ids == [42]  # NOT some newer-by-DESC id
+    assert resp.json()["current_run_id"] == 42
+    assert resp.json()["stages"][0]["stage_key"] == "older_stage"
+
+
+def test_get_status_overview_stale_last_run_id_returns_empty_stages(
+    client: TestClient,
+) -> None:
+    """If ``last_run_id`` points at a deleted run, surface that honestly.
+
+    Don't mask as "no prior run" — operator needs to see the stale
+    pointer. ``current_run_id`` stays populated from state; stages is
+    empty.
+    """
+    _install_conn()
+    state = BootstrapState(
+        status="partial_error",
+        last_run_id=42,
+        last_completed_at=datetime(2026, 5, 17, tzinfo=UTC),
+    )
+    with (
+        patch("app.api.system.read_state", return_value=state),
+        patch("app.api.system.read_run_with_stages", return_value=None),
+    ):
+        resp = client.get("/system/bootstrap-status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["state_status"] == "partial_error"
+    assert body["current_run_id"] == 42  # operator sees the stale pointer
+    assert body["stages"] == []
+    # Singleton said resettable but no stages → no_failed_stages.
+    assert body["retry_blocked_reason"] == "no_failed_stages"
+
+
+# ---------------------------------------------------------------------------
+# Failure posture
+# ---------------------------------------------------------------------------
+
+
+def test_get_status_overview_returns_503_on_db_error(client: TestClient) -> None:
+    _install_conn()
+    with patch("app.api.system.read_state", side_effect=psycopg.OperationalError("boom")):
+        resp = client.get("/system/bootstrap-status")
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "bootstrap status unavailable"
+
+
+def test_router_carries_auth_dependency() -> None:
+    """Endpoint inherits the router-level ``require_session_or_service_token``.
+
+    Validating the auth-reject flow live would require either a real
+    DB pool (because the dep itself depends on ``get_conn``) or a
+    second layered override; both are heavier than the structural
+    invariant that every ``/system/*`` route shares one auth dep.
+    Assert that invariant directly so future renames don't accidentally
+    strip the protection.
+    """
+    from app.api.auth import require_session_or_service_token
+    from app.api.system import router
+
+    dep_callables = {dep.dependency for dep in router.dependencies}
+    assert require_session_or_service_token in dep_callables

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -457,8 +457,13 @@ def test_orchestrator_unknown_job_name_recorded_as_error(
     ebull_test_conn: psycopg.Connection[tuple],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """If a stage's job_name is missing from _INVOKERS, the orchestrator
-    must mark that stage error rather than crash.
+    """Registry-side gap: catalogue stage_key resolves to a job_name
+    that is not in _INVOKERS. Orchestrator must mark error, not crash.
+
+    #1136 Phase A.3 — uses a catalogue stage_key (``universe_sync``)
+    so the dispatch hardening's "stage_key not in catalogue" branch
+    is skipped; the registry-side guard is what fires when _INVOKERS
+    is forced empty.
     """
     _reset_state(ebull_test_conn)
     _bind_settings_to_test_db(monkeypatch)
@@ -466,10 +471,12 @@ def test_orchestrator_unknown_job_name_recorded_as_error(
     from app.jobs import runtime as runtime_module
     from app.services.bootstrap_state import StageSpec
 
-    # Empty registry on purpose — nothing is invokable.
+    # Empty registry on purpose — every catalogue lookup misses.
     monkeypatch.setattr(runtime_module, "_INVOKERS", {})
 
-    specs = (StageSpec(stage_key="orphan", stage_order=1, lane="init", job_name="nonexistent_job"),)
+    # Catalogue stage_key + ``init`` lane so no upstream blocks
+    # cascade-block this; isolated single-row scenario.
+    specs = (StageSpec(stage_key="universe_sync", stage_order=1, lane="init", job_name="nightly_universe_sync"),)
     start_run(ebull_test_conn, operator_id=None, stage_specs=specs)
     ebull_test_conn.commit()
 
@@ -481,6 +488,116 @@ def test_orchestrator_unknown_job_name_recorded_as_error(
     assert snap.stages[0].status == "error"
     assert snap.stages[0].last_error is not None
     assert "unknown job_name" in snap.stages[0].last_error
+
+    state = read_state(ebull_test_conn)
+    assert state.status == "partial_error"
+
+
+def test_dispatch_resolves_job_name_from_spec_by_stage_key(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1136 Phase A.3 — dispatcher uses spec.job_name, not stage.job_name.
+
+    Reproduces the run_id=3 S21 regression class. PR1c #1064 renamed
+    the canonical 13F-sweep wrapper from ``bootstrap_sec_13f_recent_sweep``
+    to ``sec_13f_quarterly_sweep`` but bootstrap_stages.job_name for
+    an in-flight run was never updated. Pre-#1136 the dispatcher
+    looked up ``_INVOKERS.get(stage.job_name)`` and errored
+    "unknown job_name 'bootstrap_sec_13f_recent_sweep'". Post-#1136
+    it resolves by stage_key from ``_BOOTSTRAP_STAGE_SPECS`` and
+    dispatches the canonical name.
+
+    The test asserts the effective name reaches both the invoker
+    lookup AND param validation (Codex 1b §5) — the seeded stage
+    carries the bootstrap-only ``source_label`` internal-key param
+    which is allow-listed under the canonical job's metadata but
+    has no entry under the stale name.
+    """
+    _reset_state(ebull_test_conn)
+    _bind_settings_to_test_db(monkeypatch)
+    calls = _patch_invokers_with_fakes(monkeypatch)
+
+    # Seed a normal run.
+    run_id = start_run(
+        ebull_test_conn,
+        operator_id=None,
+        stage_specs=get_bootstrap_stage_specs(),
+    )
+    # Rewrite the S21 stage row to carry the stale wrapper name —
+    # this is what an in-flight retry of pre-PR1c run looks like.
+    ebull_test_conn.execute(
+        """
+        UPDATE bootstrap_stages
+           SET job_name = 'bootstrap_sec_13f_recent_sweep'
+         WHERE bootstrap_run_id = %s
+           AND stage_key = 'sec_13f_recent_sweep'
+        """,
+        (run_id,),
+    )
+    ebull_test_conn.commit()
+
+    run_bootstrap_orchestrator()
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    s21 = next(s for s in snap.stages if s.stage_key == "sec_13f_recent_sweep")
+    # Post-fix: stage runs to success under the canonical name even
+    # though the DB row still carries the stale string.
+    assert s21.status == "success", s21.last_error
+    # The canonical invoker — not the stale wrapper — appears in the
+    # call log.
+    from app.workers.scheduler import JOB_SEC_13F_QUARTERLY_SWEEP
+
+    assert JOB_SEC_13F_QUARTERLY_SWEEP in calls["order"]
+    assert "bootstrap_sec_13f_recent_sweep" not in calls["order"]
+    # DB column stays as the audit snapshot — never silently rewritten.
+    assert s21.job_name == "bootstrap_sec_13f_recent_sweep"
+
+
+def test_dispatch_unknown_stage_key_fails_closed(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1136 Phase A.3 — catalogue-trimmed stage_key fails closed.
+
+    A pre-#719 install might still carry rows for a stage_key that
+    has been removed from ``_BOOTSTRAP_STAGE_SPECS`` (e.g. legacy
+    ``dividend_calendar``). Silently dispatching the DB row's
+    ``stage.job_name`` would lose canonical params / CapRequirement /
+    lane semantics. The dispatcher must mark error instead — and
+    the error must actually land (Codex 1b §1: ``mark_stage_error``
+    no-ops against pending rows; the path must run pending → running
+    → error).
+    """
+    _reset_state(ebull_test_conn)
+    _bind_settings_to_test_db(monkeypatch)
+    _patch_invokers_with_fakes(monkeypatch)
+
+    from app.services.bootstrap_state import StageSpec
+
+    # ``dividend_calendar`` is not in _BOOTSTRAP_STAGE_SPECS today (#260
+    # retired the standalone cron). The stage_key existing in a DB row
+    # is the exact pre-#719-install survivor case.
+    specs = (StageSpec(stage_key="dividend_calendar", stage_order=1, lane="init", job_name="dividend_calendar_job"),)
+    start_run(ebull_test_conn, operator_id=None, stage_specs=specs)
+    ebull_test_conn.commit()
+
+    run_bootstrap_orchestrator()
+
+    snap = read_latest_run_with_stages(ebull_test_conn)
+    assert snap is not None
+    assert len(snap.stages) == 1
+    row = snap.stages[0]
+    # Critical: row did NOT survive in pending. That's the silent-
+    # no-op pitfall Codex 1b §1 flagged.
+    assert row.status == "error", (
+        f"unknown stage_key must reach terminal error; "
+        f"got status={row.status!r} (silent no-op? mark_stage_running missing?)"
+    )
+    assert row.last_error is not None
+    assert "dividend_calendar" in row.last_error
+    assert "not in current bootstrap catalogue" in row.last_error
 
     state = read_state(ebull_test_conn)
     assert state.status == "partial_error"

--- a/tests/test_bootstrap_retry_view.py
+++ b/tests/test_bootstrap_retry_view.py
@@ -1,0 +1,305 @@
+"""Pure-function tests for ``compute_retryable_view`` (#1136 Phase A.3).
+
+Mirrors the SQL semantics of ``reset_failed_stages_for_retry`` at
+``app/services/bootstrap_state.py`` exactly: lane-MIN over failed
+stage_orders + ``stage.stage_order >= min_failed_order``, with the
+stage's own current status ignored. See
+``docs/superpowers/specs/2026-05-19-1136-bootstrap-state-audit.md``
+§4.2 for the predicate and the run_id=3 worked example.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.services.bootstrap_state import (
+    BootstrapState,
+    RunSnapshot,
+    StageRow,
+    compute_retryable_view,
+)
+
+
+def _stage(
+    stage_key: str,
+    stage_order: int,
+    lane: str,
+    status: str,
+    *,
+    rows_processed: int | None = None,
+    attempt_count: int = 1,
+) -> StageRow:
+    return StageRow(
+        id=stage_order,
+        bootstrap_run_id=1,
+        stage_key=stage_key,
+        stage_order=stage_order,
+        lane=lane,  # type: ignore[arg-type]
+        job_name="x",
+        status=status,  # type: ignore[arg-type]
+        started_at=None,
+        completed_at=None,
+        rows_processed=rows_processed,
+        expected_units=None,
+        units_done=None,
+        last_error=None,
+        attempt_count=attempt_count,
+    )
+
+
+def _snap(*stages: StageRow, run_status: str = "partial_error") -> RunSnapshot:
+    return RunSnapshot(
+        run_id=1,
+        run_status=run_status,  # type: ignore[arg-type]
+        triggered_at=datetime(2026, 5, 17, tzinfo=UTC),
+        completed_at=datetime(2026, 5, 17, 5, 30, tzinfo=UTC),
+        stages=tuple(stages),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Precedence: blocked-reason short circuits
+# ---------------------------------------------------------------------------
+
+
+def test_no_prior_run() -> None:
+    state = BootstrapState(status="pending", last_run_id=None, last_completed_at=None)
+    view = compute_retryable_view(state, None)
+    assert view.retry_available is False
+    assert view.retry_blocked_reason == "no_prior_run"
+    assert view.stage_retryable == {}
+
+
+def test_bootstrap_running() -> None:
+    state = BootstrapState(status="running", last_run_id=7, last_completed_at=None)
+    snap = _snap(
+        _stage("s1", 1, "init", "success"),
+        _stage("s2", 2, "sec_rate", "running"),
+        run_status="running",
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.retry_available is False
+    assert view.retry_blocked_reason == "bootstrap_running"
+    # Every stage retryable=False — never advertise retry while running.
+    assert all(value is False for value in view.stage_retryable.values())
+    assert set(view.stage_retryable) == {"s1", "s2"}
+
+
+def test_state_not_resettable_complete() -> None:
+    state = BootstrapState(
+        status="complete",
+        last_run_id=7,
+        last_completed_at=datetime(2026, 5, 17, tzinfo=UTC),
+    )
+    snap = _snap(_stage("s1", 1, "init", "success"), run_status="complete")
+    view = compute_retryable_view(state, snap)
+    assert view.retry_blocked_reason == "state_not_resettable"
+    assert view.retry_available is False
+
+
+def test_state_not_resettable_pending_with_run_id() -> None:
+    # Edge case: pending state but last_run_id set (e.g. wipe-then-mark
+    # path). No prior failures to reset; should report state_not_resettable
+    # because pending is not in the resettable set.
+    state = BootstrapState(status="pending", last_run_id=7, last_completed_at=None)
+    snap = _snap(_stage("s1", 1, "init", "success"))
+    view = compute_retryable_view(state, snap)
+    assert view.retry_blocked_reason == "state_not_resettable"
+
+
+def test_no_failed_stages_with_resettable_state() -> None:
+    state = BootstrapState(
+        status="partial_error",
+        last_run_id=7,
+        last_completed_at=datetime(2026, 5, 17, tzinfo=UTC),
+    )
+    snap = _snap(_stage("s1", 1, "init", "success"))
+    view = compute_retryable_view(state, snap)
+    assert view.retry_available is False
+    assert view.retry_blocked_reason == "no_failed_stages"
+    assert view.stage_retryable == {"s1": False}
+
+
+def test_no_failed_stages_with_no_snapshot() -> None:
+    state = BootstrapState(status="partial_error", last_run_id=7, last_completed_at=None)
+    view = compute_retryable_view(state, None)
+    assert view.retry_blocked_reason == "no_failed_stages"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path retryability
+# ---------------------------------------------------------------------------
+
+
+def test_single_error_one_lane_retryable() -> None:
+    state = BootstrapState(
+        status="partial_error",
+        last_run_id=7,
+        last_completed_at=datetime(2026, 5, 17, tzinfo=UTC),
+    )
+    snap = _snap(
+        _stage("init", 1, "init", "success"),
+        _stage("sec1", 2, "sec_rate", "error"),
+        _stage("db1", 3, "db", "success"),
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.retry_available is True
+    assert view.retry_blocked_reason is None
+    assert view.stage_retryable == {"init": False, "sec1": True, "db1": False}
+
+
+def test_lane_downstream_success_is_retryable() -> None:
+    """Same-lane success row with stage_order >= MIN(failed) gets reset."""
+    state = BootstrapState(status="partial_error", last_run_id=7, last_completed_at=None)
+    snap = _snap(
+        _stage("s17", 17, "sec_rate", "error"),
+        _stage("s18", 18, "sec_rate", "error"),
+        _stage("s19", 19, "sec_rate", "success"),  # success but >= min(17)
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.stage_retryable["s17"] is True
+    assert view.stage_retryable["s18"] is True
+    assert view.stage_retryable["s19"] is True
+
+
+def test_own_status_irrelevance_pending_in_failed_lane() -> None:
+    """Pending downstream in same failed lane → retryable=True.
+
+    Codex 1b §3 — the predicate is lane+order, not the row's own
+    status. A pending stage with stage_order >= MIN(failed) WILL be
+    reset alongside the failures.
+    """
+    state = BootstrapState(status="partial_error", last_run_id=7, last_completed_at=None)
+    snap = _snap(
+        _stage("s17", 17, "sec_rate", "error"),
+        _stage("s20", 20, "sec_rate", "pending"),  # pending but >= min(17)
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.stage_retryable["s17"] is True
+    assert view.stage_retryable["s20"] is True
+
+
+def test_pre_min_order_row_not_retryable() -> None:
+    """Pending stage upstream of first failed row → retryable=False.
+
+    Exact shape of run_id=3 S16: stage_order=16, sec_rate lane,
+    pending; first sec_rate failure is at order 17. Reset SQL only
+    walks stage_order >= 17, so S16 stays put.
+    """
+    state = BootstrapState(status="partial_error", last_run_id=3, last_completed_at=None)
+    snap = _snap(
+        _stage("s16", 16, "sec_rate", "pending"),
+        _stage("s17", 17, "sec_rate", "error"),
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.stage_retryable["s16"] is False
+    assert view.stage_retryable["s17"] is True
+
+
+def test_pending_in_unfailed_lane_not_retryable() -> None:
+    """Helper only resets failed lanes. Pending in another lane stays."""
+    state = BootstrapState(status="partial_error", last_run_id=7, last_completed_at=None)
+    snap = _snap(
+        _stage("init", 1, "init", "pending"),  # no init-lane failures
+        _stage("sec1", 2, "sec_rate", "error"),
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.stage_retryable["init"] is False
+    assert view.stage_retryable["sec1"] is True
+
+
+def test_cancelled_state_with_cancelled_stages() -> None:
+    state = BootstrapState(status="cancelled", last_run_id=7, last_completed_at=None)
+    snap = _snap(
+        _stage("a", 1, "sec_rate", "cancelled"),
+        _stage("b", 2, "sec_rate", "cancelled"),
+        run_status="cancelled",
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.retry_available is True
+    assert view.retry_blocked_reason is None
+    assert view.stage_retryable == {"a": True, "b": True}
+
+
+def test_blocked_status_is_failed() -> None:
+    """`blocked` counts as failed for reset purposes (matches SQL)."""
+    state = BootstrapState(status="partial_error", last_run_id=7, last_completed_at=None)
+    snap = _snap(
+        _stage("a", 1, "db", "success"),
+        _stage("b", 2, "db", "blocked"),
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.retry_available is True
+    assert view.stage_retryable == {"a": False, "b": True}
+
+
+def test_run_id_3_worked_example() -> None:
+    """Mirror the run_id=3 audit § 4.2 worked example exactly.
+
+    Validates the predicate against the live dev-DB state recorded in
+    the spec. S1-S16 retryable=False; S17-S24 retryable=True.
+    """
+    state = BootstrapState(
+        status="partial_error",
+        last_run_id=3,
+        last_completed_at=datetime(2026, 5, 17, 5, 30, 37, tzinfo=UTC),
+    )
+    snap = _snap(
+        _stage("universe_sync", 1, "init", "success"),
+        _stage("candle_refresh", 2, "etoro", "success"),
+        _stage("cusip_universe_backfill", 3, "sec_rate", "success"),
+        _stage("sec_13f_filer_directory_sync", 4, "sec_rate", "success"),
+        _stage("sec_nport_filer_directory_sync", 5, "sec_rate", "success"),
+        _stage("cik_refresh", 6, "sec_rate", "success"),
+        _stage("sec_bulk_download", 7, "sec_bulk_download", "success"),
+        _stage("sec_submissions_ingest", 8, "db", "success"),
+        _stage("sec_companyfacts_ingest", 9, "db", "success"),
+        _stage("sec_13f_ingest_from_dataset", 10, "db", "success"),
+        _stage("sec_insider_ingest_from_dataset", 11, "db", "success"),
+        _stage("sec_nport_ingest_from_dataset", 12, "db", "success"),
+        _stage("sec_submissions_files_walk", 13, "sec_rate", "success"),
+        _stage("filings_history_seed", 14, "sec_rate", "success"),
+        _stage("sec_first_install_drain", 15, "sec_rate", "success"),
+        _stage("sec_def14a_bootstrap", 16, "sec_rate", "pending"),
+        _stage("sec_business_summary_bootstrap", 17, "sec_rate", "error"),
+        _stage("sec_insider_transactions_backfill", 18, "sec_rate", "error"),
+        _stage("sec_form3_ingest", 19, "sec_rate", "error"),
+        _stage("sec_8k_events_ingest", 20, "sec_rate", "error"),
+        _stage("sec_13f_recent_sweep", 21, "sec_rate", "error"),
+        _stage("sec_n_port_ingest", 22, "sec_rate", "error"),
+        _stage("ownership_observations_backfill", 23, "db", "blocked"),
+        _stage("fundamentals_sync", 24, "db", "blocked"),
+    )
+    view = compute_retryable_view(state, snap)
+    assert view.retry_available is True
+    expected = {
+        # init / etoro / sec_bulk_download lanes have no failures.
+        "universe_sync": False,
+        "candle_refresh": False,
+        "sec_bulk_download": False,
+        # sec_rate lane: min failed order = 17. Anything < 17 stays put.
+        "cusip_universe_backfill": False,
+        "sec_13f_filer_directory_sync": False,
+        "sec_nport_filer_directory_sync": False,
+        "cik_refresh": False,
+        "sec_submissions_files_walk": False,
+        "filings_history_seed": False,
+        "sec_first_install_drain": False,
+        "sec_def14a_bootstrap": False,  # S16 — pre-min-order
+        # sec_rate lane >= 17.
+        "sec_business_summary_bootstrap": True,
+        "sec_insider_transactions_backfill": True,
+        "sec_form3_ingest": True,
+        "sec_8k_events_ingest": True,
+        "sec_13f_recent_sweep": True,
+        "sec_n_port_ingest": True,
+        # db lane: success rows 8-12 stay put; min failed order = 23.
+        "sec_submissions_ingest": False,
+        "sec_companyfacts_ingest": False,
+        "sec_13f_ingest_from_dataset": False,
+        "sec_insider_ingest_from_dataset": False,
+        "sec_nport_ingest_from_dataset": False,
+        "ownership_observations_backfill": True,
+        "fundamentals_sync": True,
+    }
+    assert view.stage_retryable == expected


### PR DESCRIPTION
## Summary

- Lean operator readout at `GET /system/bootstrap-status` mirroring the `/system/postgres-health` shape. Per-stage `(status, last_error, retryable, attempt_count, completed_at)` + top-level summary + `retry_available` / `retry_blocked_reason`. Pins on `bootstrap_state.last_run_id` so the readout reflects what `/retry-failed` actually targets.
- Pure-function `compute_retryable_view` in `app/services/bootstrap_state.py` mirrors `reset_failed_stages_for_retry` SQL: state precedence + lane `MIN(stage_order)` + `stage.stage_order >= min`. Stage own-status is irrelevant.
- Dispatcher resolves `job_name` from `_BOOTSTRAP_STAGE_SPECS` by `stage_key`, fails closed for unknown stage_keys. Removes the run_id=3 S21 stale-name failure mode. DB `job_name` stays as audit snapshot; remap recorded via structured log.

Phase A.3 of `docs/superpowers/plans/2026-05-19-post-1208-cleardown.md`. Spec at `docs/superpowers/specs/2026-05-19-1136-bootstrap-state-audit.md`.

## Why

`bootstrap_state` has sat at `partial_error` since 2026-05-17 (run_id=3). T9-POST drain requires the operator to read every `last_error` and mentally replay `reset_failed_stages_for_retry` precedence to know which click does what. New endpoint surfaces retryability honestly so the operator can drive the drain without log-grepping; dispatch hardening removes the one stale-data failure mode the retry path cannot self-heal.

## Audit findings (full table in spec §3)

run_id=3 stages 1-15 success; stages 16-24 broken down:
- S16 (`pending`) — finalised with stage still pending; root cause TBD (follow-up ticket).
- S17-S20, S22 (`error` — JobLock contention) — self-heals on retry.
- S21 (`error` — unknown stale job_name) — **fixed by this PR's dispatch hardening**.
- S23, S24 (`blocked` — capability dead with `rows_processed=NULL`) — retryable mechanically; re-blocks until follow-up row-count fix lands.

Three follow-up tickets to file at merge per spec §6 (S16 stuck-pending root cause; bulk-ingester row counts; JobLock-contention UX).

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean (0 errors)
- [x] `uv run pytest tests/test_bootstrap_retry_view.py tests/test_api_bootstrap_status_overview.py tests/test_bootstrap_orchestrator.py tests/test_bootstrap_state.py tests/test_bootstrap_state_gate.py tests/test_api_bootstrap.py tests/test_bootstrap_atomic_enqueue.py tests/test_bootstrap_fallback_skip.py tests/test_bootstrap_orchestrator_source_registry.py tests/test_bootstrap_adapter.py tests/test_bootstrap_cancel.py tests/test_bootstrap_rows_processed_gates.py tests/smoke/test_app_boots.py tests/test_universal_gate_carve_out.py` — all green (~180 tests)
- [x] New tests cover: pure-function retry view (incl. run_id=3 worked example), endpoint shape + run-id pinning + stale-pointer surface, S21 regression (`source_label` internal-key validates under canonical name), unknown stage_key fail-closed (asserts row reaches `error`, not silent pending).

**Pre-existing failure on main** (unrelated to this PR): `tests/test_bootstrap_state_prerequisite.py::test_every_scheduled_job_either_gated_or_explicitly_excluded` flags three jobs (`sec_daily_index_reconcile`, `sec_manifest_tombstone_stale`, `sec_manifest_worker`) missing from `NON_GATED_SCHEDULED`. Reproduced on `main` (240112e) before this branch's first commit. Separate follow-up.

## Codex review history

- Codex 1a on spec: 6 findings — retryable semantics misclaim, effective_job_name flow gaps, S23/S24 self-healing wrong, unknown-stage_key fallback risk, acceptance incomplete. All addressed in spec round 2.
- Codex 1b on revised spec: 5 findings — `mark_stage_error` no-ops on pending (need pending → running → error), run-id pinning, additional tests (own-status irrelevance + unknown stage_key fail-closed + S21 param validation). All addressed in spec round 3.
- Codex 1c on revised spec: 1 MEDIUM — add API test for run-id pinning. Addressed.
- Codex 2 pre-push on diff: 1 NITPICK — ASCII arrow in remap log. Fixed.

## Settled-decisions alignment

Universal bootstrap-state gate (#1064 PR1b-2) and the `exempt_from_universal_bootstrap_gate` carve-out (#1181) untouched. The new endpoint is a read-only audit surface; the run-id pinning preserves the `start_run` / `reset_failed_stages_for_retry` `FOR UPDATE` contract by reading state first and the run row second within one transaction.

Partial-closes #1136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)