### PR TITLE
fix(#1228,#1234): DEF14A percent clamp + IngestSummary exit_reason

### DIFF
--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -533,6 +533,17 @@ def _parse_percent(raw: str) -> Decimal | None:
     regex because that regex's trailing-asterisk branch would
     otherwise erase the cell content and return None — losing the
     less-than-1% signal the proxy explicitly conveys.
+
+    Out-of-range guard (#1228): clamps to ``[Decimal(0), Decimal(100)]``.
+    A real percent-of-class is bounded by definition (ownership is a
+    fraction of total shares). Values outside that band are almost
+    always a column-resolver misfire (positional fallback in
+    ``_resolve_columns`` mapped a shares-count column into
+    percent_idx). The schema is ``NUMERIC(8, 4)`` (max 9999.9999)
+    which raises ``NumericValueOutOfRange`` on 7-digit shares values
+    and previously aborted the whole batch in ``ingest_def14a``.
+    Returning ``None`` lets shares parse independently and the row
+    survives without a spurious percent.
     """
     if not raw:
         return None
@@ -548,9 +559,18 @@ def _parse_percent(raw: str) -> Decimal | None:
     if cleaned in ("", "-", "—", "–"):
         return None
     try:
-        return Decimal(cleaned)
+        value = Decimal(cleaned)
     except InvalidOperation:
         return None
+    # #1228 — clamp to the natural [0, 100] band. See docstring.
+    # NaN / Inf survive ``Decimal(cleaned)`` for inputs like ``"NaN"``
+    # or ``"Infinity"``; comparison against finite Decimals would
+    # raise ``InvalidOperation`` so reject them first.
+    if value.is_nan() or value.is_infinite():
+        return None
+    if value < Decimal(0) or value > Decimal(100):
+        return None
+    return value
 
 
 # Column-finder. DEF 14A tables vary in column order and labelling;

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -1370,6 +1370,12 @@ class IngestResult:
     rows_updated: int
     fetch_errors: int
     parse_misses: int
+    # #1234 — exit reason for deadline-bound bootstrap loops
+    # (``bootstrap_business_summaries``). ``None`` for single-chunk
+    # callers that don't loop. ``drained`` = candidate query returned
+    # zero rows. ``deadline`` = wall-clock cap fired before drain
+    # (silent undercoverage; operator re-trigger to finish).
+    exit_reason: Literal["drained", "deadline"] | None = None
 
 
 # Soft minimum body length below which the extractor is treated as a
@@ -1473,6 +1479,8 @@ def bootstrap_business_summaries(
     total_updated = 0
     total_fetch_errors = 0
     total_parse_misses = 0
+    # #1234 — track WHY the loop exits.
+    exit_reason: Literal["drained", "deadline"] = "deadline"
 
     while time.monotonic() < deadline:
         chunk = ingest_business_summaries(
@@ -1488,16 +1496,34 @@ def bootstrap_business_summaries(
         total_fetch_errors += chunk.fetch_errors
         total_parse_misses += chunk.parse_misses
         if chunk.filings_scanned == 0:
+            exit_reason = "drained"
             break
 
     logger.info(
-        "bootstrap_business_summaries complete: scanned=%d inserted=%d updated=%d fetch_errors=%d parse_misses=%d",
+        "bootstrap_business_summaries complete: scanned=%d inserted=%d updated=%d "
+        "fetch_errors=%d parse_misses=%d exit=%s",
         total_scanned,
         total_inserted,
         total_updated,
         total_fetch_errors,
         total_parse_misses,
+        exit_reason,
     )
+    # #1234 — deadline exit = silent undercoverage. WARNING-level log
+    # so operators see "candidate set may not be fully drained" without
+    # grepping. Full warnings_count wiring through _JobTracker is a
+    # follow-up (touches every tracked-job site).
+    if exit_reason == "deadline":
+        logger.warning(
+            "bootstrap_business_summaries hit wall-clock deadline "
+            "(max_runtime_seconds=%d) — candidate set may not be fully "
+            "drained. Re-trigger the stage to process the remaining "
+            "backlog. scanned=%d inserted=%d updated=%d.",
+            max_runtime_seconds,
+            total_scanned,
+            total_inserted,
+            total_updated,
+        )
 
     return IngestResult(
         filings_scanned=total_scanned,
@@ -1505,6 +1531,7 @@ def bootstrap_business_summaries(
         rows_updated=total_updated,
         fetch_errors=total_fetch_errors,
         parse_misses=total_parse_misses,
+        exit_reason=exit_reason,
     )
 
 

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -35,7 +35,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 from uuid import uuid4
 
 import psycopg
@@ -132,6 +132,12 @@ class IngestSummary:
     rows_inserted: int
     rows_updated: int
     first_error: str | None = None
+    # #1234 — exit reason for deadline-bound bootstrap loops
+    # (``bootstrap_def14a``). ``None`` for single-chunk callers that
+    # don't loop. ``drained`` = candidate query returned zero rows.
+    # ``deadline`` = wall-clock cap fired before drain (silent
+    # undercoverage signal; operator should re-trigger to finish).
+    exit_reason: Literal["drained", "deadline"] | None = None
 
     @property
     def accessions_ingested(self) -> int:
@@ -924,6 +930,8 @@ def bootstrap_def14a(
     total_inserted = 0
     total_updated = 0
     first_error: str | None = None
+    # #1234 — track WHY the loop exits.
+    exit_reason: Literal["drained", "deadline"] = "deadline"
 
     while time.monotonic() < deadline:
         chunk = ingest_def14a(
@@ -942,6 +950,7 @@ def bootstrap_def14a(
         if first_error is None and chunk.first_error is not None:
             first_error = chunk.first_error
         if chunk.accessions_seen == 0:
+            exit_reason = "drained"
             break
 
     # Bot review for #839 PR #850: enforce the accounting invariant
@@ -962,14 +971,30 @@ def bootstrap_def14a(
         )
 
     logger.info(
-        "bootstrap_def14a complete: seen=%d succeeded=%d partial=%d failed=%d inserted=%d updated=%d",
+        "bootstrap_def14a complete: seen=%d succeeded=%d partial=%d failed=%d inserted=%d updated=%d exit=%s",
         total_seen,
         total_succeeded,
         total_partial,
         total_failed,
         total_inserted,
         total_updated,
+        exit_reason,
     )
+    # #1234 — deadline exit = silent undercoverage. Loud WARNING so the
+    # operator log surface signals "stage marked SUCCESS but candidate
+    # set may not be fully drained — re-trigger if you want full
+    # coverage." Full warnings_count wiring through the _JobTracker is
+    # a follow-up (would touch every tracked-job site).
+    if exit_reason == "deadline":
+        logger.warning(
+            "bootstrap_def14a hit wall-clock deadline (max_runtime_seconds=%d) — "
+            "candidate set may not be fully drained. Re-trigger the stage to "
+            "process the remaining backlog. seen=%d inserted=%d updated=%d.",
+            max_runtime_seconds,
+            total_seen,
+            total_inserted,
+            total_updated,
+        )
 
     return IngestSummary(
         accessions_seen=total_seen,
@@ -979,6 +1004,7 @@ def bootstrap_def14a(
         rows_inserted=total_inserted,
         rows_updated=total_updated,
         first_error=first_error,
+        exit_reason=exit_reason,
     )
 
 

--- a/tests/test_business_summary_ingest.py
+++ b/tests/test_business_summary_ingest.py
@@ -980,3 +980,30 @@ class TestBootstrapDrain:
         )
         assert result.filings_scanned == 0
         assert rerun_fetcher.calls == []
+
+    def test_exit_reason_drained_when_queue_empties(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """#1234 — natural drain signals ``exit_reason='drained'``."""
+        fetcher = _StubFetcher({})
+        result = bootstrap_business_summaries(
+            ebull_test_conn,
+            cast("object", fetcher),  # type: ignore[arg-type]
+            chunk_limit=10,
+            max_runtime_seconds=10,
+        )
+        assert result.filings_scanned == 0
+        assert result.exit_reason == "drained"
+
+    def test_exit_reason_deadline_when_max_runtime_zero(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """#1234 — ``max_runtime_seconds=0`` exits the loop before any
+        chunk runs, so ``exit_reason='deadline'`` (the default). Pins
+        the deadline-bound exit signal so the orchestrator can later
+        surface a WARNING badge instead of silent SUCCESS."""
+        fetcher = _StubFetcher({})
+        result = bootstrap_business_summaries(
+            ebull_test_conn,
+            cast("object", fetcher),  # type: ignore[arg-type]
+            chunk_limit=10,
+            max_runtime_seconds=0,
+        )
+        assert result.filings_scanned == 0
+        assert result.exit_reason == "deadline"

--- a/tests/test_def14a_ingest.py
+++ b/tests/test_def14a_ingest.py
@@ -740,3 +740,33 @@ class TestBootstrapDef14a:
             == summary.accessions_succeeded + summary.accessions_partial + summary.accessions_failed
         )
         assert summary.accessions_failed >= 1
+
+    def test_exit_reason_drained_when_queue_empties(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """#1234 — when the candidate query returns zero rows, the
+        loop exits with ``exit_reason='drained'``. Confirms the natural
+        completion path is signalled explicitly so downstream
+        observability can distinguish from deadline-bound exits."""
+        conn = _setup
+        fetcher = _InMemoryFetcher({})
+        summary = bootstrap_def14a(conn, fetcher, chunk_limit=100, max_runtime_seconds=10)
+        assert summary.accessions_seen == 0
+        assert summary.exit_reason == "drained"
+
+    def test_exit_reason_deadline_when_max_runtime_zero(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """#1234 — when ``max_runtime_seconds=0`` the deadline expires
+        before the first chunk runs, so the loop never enters its body
+        and exits with ``exit_reason='deadline'`` (the default). Pin
+        the deadline-exit signal so a future regression that conflates
+        deadline-bound vs drained tripping is caught here."""
+        conn = _setup
+        fetcher = _InMemoryFetcher({})
+        summary = bootstrap_def14a(conn, fetcher, chunk_limit=100, max_runtime_seconds=0)
+        # Loop body never executed (deadline was 0); no work done.
+        assert summary.accessions_seen == 0
+        assert summary.exit_reason == "deadline"

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -26,6 +26,7 @@ from decimal import Decimal
 
 from app.providers.implementations.sec_def14a import (
     Def14ABeneficialOwnershipTable,
+    _parse_percent,
     extract_plan_name_and_trustee,
     is_esop_plan,
     parse_beneficial_ownership_table,
@@ -615,3 +616,72 @@ def test_parser_overrides_role_to_esop_for_matching_holder_name() -> None:
     assert plan_holder.holder_role == "esop"
     assert plan_holder.shares == Decimal("2000000")
     assert plan_holder.percent_of_class == Decimal("6.5")
+
+
+# ---------------------------------------------------------------------------
+# #1228 — _parse_percent out-of-range clamp
+# ---------------------------------------------------------------------------
+
+
+class TestParsePercentRangeClamp:
+    """Regression for #1228 — DEF14A NUMERIC(8,4) overflow when a
+    column-resolver misfire routes a 7-digit shares value into the
+    percent cell. Schema rejects values > 9999.9999 and previously
+    aborted the entire batch in ``ingest_def14a``."""
+
+    def test_valid_low_percent_passes(self) -> None:
+        assert _parse_percent("0.5") == Decimal("0.5")
+
+    def test_valid_mid_percent_passes(self) -> None:
+        assert _parse_percent("12.34") == Decimal("12.34")
+
+    def test_valid_max_boundary_100_passes(self) -> None:
+        assert _parse_percent("100") == Decimal("100")
+
+    def test_valid_zero_passes(self) -> None:
+        assert _parse_percent("0") == Decimal("0")
+
+    def test_misrouted_shares_count_rejected(self) -> None:
+        # 9,000,000 — typical 7-digit shares count misrouted into
+        # percent slot via positional fallback in ``_resolve_columns``.
+        assert _parse_percent("9000000") is None
+
+    def test_just_above_100_rejected(self) -> None:
+        # Real percent ownership cannot exceed 100. A 100.01 value is
+        # almost certainly a parsing artefact, not a real holding.
+        assert _parse_percent("100.01") is None
+
+    def test_just_below_zero_rejected(self) -> None:
+        assert _parse_percent("-0.01") is None
+
+    def test_comma_thousand_separator_shares_rejected(self) -> None:
+        # "9,000,000" — same as above with the SEC-canonical comma
+        # separator. ``_parse_percent`` strips commas + parses;
+        # the clamp catches the resulting 9000000 Decimal.
+        assert _parse_percent("9,000,000") is None
+
+    def test_asterisk_less_than_one_still_passes(self) -> None:
+        # Industry-convention asterisk maps to 0.5 — must not regress
+        # under the new clamp.
+        from app.providers.implementations.sec_def14a import _LESS_THAN_ONE_PERCENT_VALUE
+
+        assert _parse_percent("*") == _LESS_THAN_ONE_PERCENT_VALUE
+
+    def test_dash_returns_none(self) -> None:
+        assert _parse_percent("—") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert _parse_percent("") is None
+
+    def test_invalid_text_returns_none(self) -> None:
+        assert _parse_percent("N/A") is None
+
+    def test_nan_returns_none(self) -> None:
+        # ``Decimal("NaN")`` is a valid Decimal but comparing it
+        # against a finite Decimal raises ``InvalidOperation``. Guard
+        # explicitly so the clamp doesn't blow up on a malformed cell.
+        assert _parse_percent("NaN") is None
+
+    def test_infinity_returns_none(self) -> None:
+        assert _parse_percent("Infinity") is None
+        assert _parse_percent("-Infinity") is None


### PR DESCRIPTION
## Summary

Two bundled ETL-correctness fixes surfaced during 2026-05-19 T9-POST drive (Phase C of #1208 cleardown). Both are referenced by the retention rubric spec (PR #1235, just merged) and are prerequisites for the clean re-run exercise.

- **#1228** — DEF 14A NUMERIC(8,4) overflow on `percent_of_class`. Misrouted shares-count values (positional column-resolver fallback maps shares column into percent slot) were raising `NumericValueOutOfRange` and aborting whole batches. Parser now clamps to the natural `[0, 100]` band + rejects NaN/Inf belt-and-braces.
- **#1234** — `IngestSummary` / `IngestResult` `exit_reason` field. `bootstrap_def14a` and `bootstrap_business_summaries` deadline-bound loops previously returned the same shape whether the candidate query was actually drained or the 1h wall-clock cap fired. Now they signal `exit_reason="drained"` vs `"deadline"` + WARNING-level log on deadline so operators see "may not be fully drained — re-trigger to finish".

Full `_JobTracker.warnings_count` UI-badge wiring deferred (cross-cutting scheduler change). Logs are sufficient signal for v1.

Closes #1228
Closes #1234

## Why now

Both bugs were active during the live drive. #1228 caused ~13 DEF 14A accessions to silently drop per batch (47k holdings written, but real coverage gap). #1234 caused both `sec_def14a_bootstrap` (1h 00m) and `sec_business_summary_bootstrap` (1h 00m) to report SUCCESS while only partially draining their candidate sets.

Both blocking for the clean re-run validation per spec PR #1235 §8.

## Changes

### Parser fix (#1228)

- `app/providers/implementations/sec_def14a.py:527-553` — `_parse_percent` clamps to `[Decimal(0), Decimal(100)]`. Out-of-range → `None`. NaN/Inf → `None` (comparison would raise `InvalidOperation`).
- `tests/test_sec_def14a_parser.py` — new `TestParsePercentRangeClamp` class with 14 tests pinning valid + invalid + boundary + adversarial inputs.

### Exit-reason signal (#1234)

- `app/services/def14a_ingest.py:111-142` — `IngestSummary` gains `exit_reason: Literal["drained","deadline"] | None`.
- `app/services/def14a_ingest.py:917-996` — `bootstrap_def14a` tracks exit reason + logs WARNING on deadline exit.
- `app/services/business_summary.py:1365-1373` — same shape on `IngestResult`.
- `app/services/business_summary.py:1467-1525` — same wiring in `bootstrap_business_summaries`.
- `tests/test_def14a_ingest.py` + `tests/test_business_summary_ingest.py` — 4 new tests pinning drained vs deadline shapes.

## Test plan

- [x] `uv run ruff check` clean on all changed files
- [x] `uv run ruff format --check` clean on all changed files
- [x] `uv run pyright` clean on all changed source files
- [x] `pytest tests/test_sec_def14a_parser.py::TestParsePercentRangeClamp` — 14/14 pass
- [x] `pytest tests/test_def14a_ingest.py -k "exit_reason or RangeClamp or test_drains_multiple or test_idempotent"` — 16/16 pass
- [x] `pytest tests/test_business_summary_ingest.py -k "exit_reason"` — 2/2 pass
- [x] Codex 2 review on branch diff vs main — no actionable findings. Codex's NaN probe led to the belt-and-braces guard now in `_parse_percent`.

## Security model

No new attack surface. Parser-side input validation tightening (clamping numeric range, rejecting NaN/Inf) is defensive — closes a path where malformed SEC filings could DoS a batch by tripping a schema constraint.

## Tradeoffs

- **Logs vs UI badge for deadline exit**: operators see deadline-exit in WARNING logs immediately, but the orchestrator stage row still marks SUCCESS (not partial_success / warning) until `_JobTracker.warnings_count` is wired through `scheduler.py`. That follow-up touches every tracked-job site (~40 call sites); kept out of scope so this PR stays tightly focused on two bug fixes.
- **`_parse_percent` returns `None` instead of clamping to 100**: out-of-range values are almost always parser misfires, not real >100% holdings. Returning `None` makes the misfire surface as a missing `percent_of_class` (which downstream queries already handle as NULL) rather than a fake 100% hard-cap reading.

Refs #1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)