### PR TITLE
feat(#1233): companyfacts 20y retention cap + concept whitelist on every write path

### DIFF
--- a/app/providers/implementations/sec_fundamentals.py
+++ b/app/providers/implementations/sec_fundamentals.py
@@ -132,18 +132,56 @@ _PERIOD_MAX: Final[date] = date(2100, 1, 1)
 _REJ_END_OUT_OF_WINDOW: Final[str] = "period_end_out_of_window"
 _REJ_START_OUT_OF_WINDOW: Final[str] = "period_start_out_of_window"
 _REJ_START_AFTER_END: Final[str] = "period_start_after_period_end"
+# #1233 — XBRL retention horizon. Pre-cutoff facts are rejected at the
+# parser so the bulk ingest never persists them. Independent of
+# _PERIOD_MIN (which is a data-shape sanity guard for parser bugs).
+_REJ_END_BEFORE_RETENTION_CUTOFF: Final[str] = "period_end_before_retention_cutoff"
+
+# #1233 — Spec `docs/superpowers/specs/2026-05-19-data-retention-rubric.md`
+# §4.1. Companyfacts retention cap is 20y of financial history per CIK.
+# Operators that need deeper history re-ingest via
+# `POST /jobs/sec_rebuild/run` with an explicit since override.
+_RETENTION_YEARS: Final[int] = 20
+
+
+def _default_retention_cutoff(*, today: date | None = None) -> date:
+    """Return the default companyfacts retention cutoff (``today - 20y``).
+
+    ``today`` is parametrised so tests can pin a stable reference
+    date without monkeypatching ``date.today()``. Production callers
+    omit it and the current UTC date is used.
+    """
+    from datetime import UTC, datetime
+
+    ref = today if today is not None else datetime.now(tz=UTC).date()
+    # date.replace handles leap-day source dates (Feb 29) by raising
+    # ValueError on non-leap target years; fall back to Mar 1 in that
+    # edge case so the cutoff is always well-defined.
+    try:
+        return ref.replace(year=ref.year - _RETENTION_YEARS)
+    except ValueError:
+        return date(ref.year - _RETENTION_YEARS, 3, 1)
 
 
 def _classify_period_rejection(
     period_start: date | None,
     period_end: date,
+    *,
+    retention_cutoff: date | None = None,
 ) -> str | None:
     """Return one of the ``_REJ_*`` reason constants if the
     ``(period_start, period_end)`` pair should be rejected, or
-    ``None`` if the pair is in-window and well-ordered.
+    ``None`` if the pair is in-window, well-ordered, and inside the
+    retention horizon.
 
     Pure date predicate — no logging, no XBRL-shape coupling, so the
     helper is trivially testable.
+
+    ``retention_cutoff`` (#1233) — when non-None, rejects facts whose
+    ``period_end`` is strictly before the cutoff (typically
+    ``_default_retention_cutoff()`` = today - 20y). Independent from
+    the ``_PERIOD_MIN`` / ``_PERIOD_MAX`` data-shape sanity guards
+    (#1218) which catch parser-bug junk like year-6016 / pre-1900.
     """
     if not (_PERIOD_MIN <= period_end < _PERIOD_MAX):
         return _REJ_END_OUT_OF_WINDOW
@@ -152,6 +190,8 @@ def _classify_period_rejection(
             return _REJ_START_OUT_OF_WINDOW
         if period_start > period_end:
             return _REJ_START_AFTER_END
+    if retention_cutoff is not None and period_end < retention_cutoff:
+        return _REJ_END_BEFORE_RETENTION_CUTOFF
     return None
 
 
@@ -359,6 +399,7 @@ def _extract_facts_from_section(
     *,
     taxonomy: str,
     allowed_tags: frozenset[str] | None = None,
+    retention_cutoff: date | None = None,
 ) -> list[XbrlFact]:
     """Extract XBRL facts from one ``facts.<taxonomy>`` section.
 
@@ -371,6 +412,16 @@ def _extract_facts_from_section(
     ``financial_facts_raw`` captures the full richness of each
     filing instead of the narrow ``TRACKED_CONCEPTS`` editorial
     subset.
+
+    ``retention_cutoff`` (#1233) — when set, rejects facts whose
+    ``period_end`` is strictly before the cutoff with a per-(accession,
+    reason) WARN. Bulk ingest callers
+    (:func:`app.services.sec_companyfacts_ingest.ingest_companyfacts_archive`)
+    pass ``_default_retention_cutoff()`` (= today - 20y) to honour
+    the spec at
+    ``docs/superpowers/specs/2026-05-19-data-retention-rubric.md`` §4.1.
+    Per-CIK API callers omit the cutoff to keep ad-hoc deep-dive
+    reads unbounded.
     """
     facts: list[XbrlFact] = []
     # Per-call WARN dedup on ``(accession, reason)`` — without this, a
@@ -411,7 +462,11 @@ def _extract_facts_from_section(
                 # has a 5000-row alarm; silently routing parser bugs into
                 # it is a non-actionable signal. Skip + WARN with reason
                 # + full provenance instead.
-                rejection_reason = _classify_period_rejection(period_start, period_end)
+                # #1233 — additionally rejects facts older than the 20y
+                # retention horizon when ``retention_cutoff`` is set.
+                rejection_reason = _classify_period_rejection(
+                    period_start, period_end, retention_cutoff=retention_cutoff
+                )
                 if rejection_reason is not None:
                     key = (accn, rejection_reason)
                     if key not in warned_rejections:
@@ -646,14 +701,15 @@ class SecFundamentalsProvider(FundamentalsProvider):
         employee count. Stamped with ``taxonomy='dei'`` so downstream
         normalisation routes them independently.
 
-        **#451 Phase A**: extractor no longer filters on the
-        editorial ``TRACKED_CONCEPTS`` allowlist. Every concept the
-        issuer reports lands in ``financial_facts_raw`` so segment
-        reporting, deferred-tax breakdown, lease liabilities, and
-        the rest of the long tail are queryable from SQL. The
-        ``TRACKED_CONCEPTS`` alias map is still used by downstream
-        ``financial_periods`` projection logic to select canonical
-        synonyms when aggregating.
+        **#1233**: applies the canonical companyfacts caps —
+        ``_ALL_TRACKED_TAGS`` (us-gaap whitelist) +
+        ``_ALL_TRACKED_DEI_TAGS`` (DEI whitelist) +
+        ``_default_retention_cutoff()`` (today - 20y). This is the
+        steady-state refresh path that runs after the bulk bootstrap;
+        without the caps here a subsequent refresh of any CIK would
+        re-populate pre-cutoff + off-whitelist rows in
+        ``financial_facts_raw`` and undo the bootstrap-time discipline
+        (Codex 2 P1 catch).
         """
         raw = self._fetch_company_facts(cik)
         if raw is None:
@@ -664,11 +720,26 @@ class SecFundamentalsProvider(FundamentalsProvider):
         if not gaap_section and not dei_section:
             logger.info("No us-gaap or dei facts for %s (CIK %s)", symbol, cik)
             return []
+        retention_cutoff = _default_retention_cutoff()
         facts: list[XbrlFact] = []
         if gaap_section:
-            facts.extend(_extract_facts_from_section(gaap_section, taxonomy="us-gaap"))
+            facts.extend(
+                _extract_facts_from_section(
+                    gaap_section,
+                    taxonomy="us-gaap",
+                    allowed_tags=_ALL_TRACKED_TAGS,
+                    retention_cutoff=retention_cutoff,
+                )
+            )
         if dei_section:
-            facts.extend(_extract_facts_from_section(dei_section, taxonomy="dei"))
+            facts.extend(
+                _extract_facts_from_section(
+                    dei_section,
+                    taxonomy="dei",
+                    allowed_tags=_ALL_TRACKED_DEI_TAGS,
+                    retention_cutoff=retention_cutoff,
+                )
+            )
         return facts
 
     def extract_concept_catalog(self, symbol: str, cik: str) -> list[XbrlConceptCatalogEntry]:
@@ -691,6 +762,14 @@ class SecFundamentalsProvider(FundamentalsProvider):
 
         Preferred call for the ingester path so we don't double
         round-trip SEC for facts + catalogue on every refresh.
+
+        **#1233**: applies the canonical companyfacts caps to the
+        fact stream (whitelist + 20y retention cutoff). Catalogue
+        entries stay uncapped — the catalogue is a per-concept
+        metadata snapshot (label, description, units) keyed on
+        concept name; capping the catalogue would orphan downstream
+        UI rendering for any concept that exists in catalogue but
+        was filtered from facts.
         """
         raw = self._fetch_company_facts(cik)
         if raw is None:
@@ -701,13 +780,28 @@ class SecFundamentalsProvider(FundamentalsProvider):
         if not gaap_section and not dei_section:
             logger.info("No us-gaap or dei facts for %s (CIK %s)", symbol, cik)
             return [], []
+        retention_cutoff = _default_retention_cutoff()
         facts: list[XbrlFact] = []
         entries: list[XbrlConceptCatalogEntry] = []
         if gaap_section:
-            facts.extend(_extract_facts_from_section(gaap_section, taxonomy="us-gaap"))
+            facts.extend(
+                _extract_facts_from_section(
+                    gaap_section,
+                    taxonomy="us-gaap",
+                    allowed_tags=_ALL_TRACKED_TAGS,
+                    retention_cutoff=retention_cutoff,
+                )
+            )
             entries.extend(_extract_catalog_from_section(gaap_section, taxonomy="us-gaap"))
         if dei_section:
-            facts.extend(_extract_facts_from_section(dei_section, taxonomy="dei"))
+            facts.extend(
+                _extract_facts_from_section(
+                    dei_section,
+                    taxonomy="dei",
+                    allowed_tags=_ALL_TRACKED_DEI_TAGS,
+                    retention_cutoff=retention_cutoff,
+                )
+            )
             entries.extend(_extract_catalog_from_section(dei_section, taxonomy="dei"))
         return facts, entries
 

--- a/app/services/sec_companyfacts_ingest.py
+++ b/app/services/sec_companyfacts_ingest.py
@@ -30,7 +30,12 @@ from typing import Any
 import psycopg
 
 from app.providers.fundamentals import XbrlFact
-from app.providers.implementations.sec_fundamentals import _extract_facts_from_section
+from app.providers.implementations.sec_fundamentals import (
+    _ALL_TRACKED_DEI_TAGS,
+    _ALL_TRACKED_TAGS,
+    _default_retention_cutoff,
+    _extract_facts_from_section,
+)
 from app.services.fundamentals import (
     finish_ingestion_run,
     start_ingestion_run,
@@ -75,15 +80,38 @@ def extract_facts_from_companyfacts_payload(
     public ``extract_facts(symbol, cik)`` method on the provider
     self-fetches over HTTP; for bulk ingest we have the payload
     already.
+
+    #1233 — applies the canonical companyfacts caps at extraction:
+    `_ALL_TRACKED_TAGS` (us-gaap whitelist of ~50 numeric concepts) +
+    `_ALL_TRACKED_DEI_TAGS` (DEI shares-outstanding / public-float /
+    employees) + `_default_retention_cutoff()` (today - 20y). Per
+    spec `docs/superpowers/specs/2026-05-19-data-retention-rubric.md`
+    §4.1, bulk ingest is the canonical "must apply caps" path; the
+    per-CIK API extractor stays uncapped for ad-hoc deep-dive use.
     """
     raw_facts: dict[str, Any] = payload.get("facts", {})
     gaap_section = raw_facts.get("us-gaap", {})
     dei_section = raw_facts.get("dei", {})
+    retention_cutoff = _default_retention_cutoff()
     facts: list[XbrlFact] = []
     if gaap_section:
-        facts.extend(_extract_facts_from_section(gaap_section, taxonomy="us-gaap"))
+        facts.extend(
+            _extract_facts_from_section(
+                gaap_section,
+                taxonomy="us-gaap",
+                allowed_tags=_ALL_TRACKED_TAGS,
+                retention_cutoff=retention_cutoff,
+            )
+        )
     if dei_section:
-        facts.extend(_extract_facts_from_section(dei_section, taxonomy="dei"))
+        facts.extend(
+            _extract_facts_from_section(
+                dei_section,
+                taxonomy="dei",
+                allowed_tags=_ALL_TRACKED_DEI_TAGS,
+                retention_cutoff=retention_cutoff,
+            )
+        )
     return facts
 
 

--- a/tests/test_sec_fundamentals_period_end_guard.py
+++ b/tests/test_sec_fundamentals_period_end_guard.py
@@ -20,10 +20,13 @@ from typing import Any
 import pytest
 
 from app.providers.implementations.sec_fundamentals import (
+    _REJ_END_BEFORE_RETENTION_CUTOFF,
     _REJ_END_OUT_OF_WINDOW,
     _REJ_START_AFTER_END,
     _REJ_START_OUT_OF_WINDOW,
+    _RETENTION_YEARS,
     _classify_period_rejection,
+    _default_retention_cutoff,
     _extract_facts_from_section,
 )
 
@@ -242,3 +245,209 @@ def test_extractor_logs_distinct_reasons_for_same_accession(caplog: pytest.LogCa
     messages = " ".join(r.getMessage() for r in relevant)
     assert _REJ_END_OUT_OF_WINDOW in messages
     assert _REJ_START_OUT_OF_WINDOW in messages
+
+
+# ---------------------------------------------------------------------------
+# #1233 — retention cutoff (20y companyfacts cap)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultRetentionCutoff:
+    """``_default_retention_cutoff()`` returns today minus the
+    canonical ``_RETENTION_YEARS`` window."""
+
+    def test_default_today_is_today_minus_20y(self) -> None:
+        cutoff = _default_retention_cutoff(today=date(2026, 5, 20))
+        assert cutoff == date(2006, 5, 20)
+
+    def test_leap_day_today_falls_back_to_march_1(self) -> None:
+        # 2024-02-29 is a leap day; 2004 was a leap year (Feb 29
+        # exists), so the .replace path succeeds. 2024 is not a leap
+        # year shifted by 20y to 2004... actually 2004 IS a leap year
+        # so this test the SAFE path. Test the unsafe path with 2096-
+        # not-leap.
+        # 2024 is a leap year. today-20y = 2004 (also leap), Feb 29 exists.
+        assert _default_retention_cutoff(today=date(2024, 2, 29)) == date(2004, 2, 29)
+
+    def test_leap_day_with_non_leap_target_falls_back(self) -> None:
+        # 2020 is a leap year, 2000 is also a leap year → Feb 29 OK.
+        # 2120 is a leap year. 2100 is NOT a leap year (century rule).
+        # So 2120-02-29 minus 20y -> 2100-02-29 doesn't exist → fall
+        # back to Mar 1.
+        cutoff = _default_retention_cutoff(today=date(2120, 2, 29))
+        assert cutoff == date(2100, 3, 1)
+
+    def test_retention_years_constant_is_twenty(self) -> None:
+        # Pin the constant — spec §4.1 specifies 20y.
+        assert _RETENTION_YEARS == 20
+
+
+class TestClassifyPeriodRejectionWithCutoff:
+    """``_classify_period_rejection(retention_cutoff=...)`` rejects
+    facts older than the cutoff with ``_REJ_END_BEFORE_RETENTION_CUTOFF``."""
+
+    def test_no_cutoff_keeps_old_period(self) -> None:
+        # Without a cutoff, an 1995 period_end is in-window (>1900) +
+        # well-ordered → None.
+        assert _classify_period_rejection(date(1995, 1, 1), date(1995, 12, 31)) is None
+
+    def test_cutoff_rejects_pre_cutoff_period(self) -> None:
+        cutoff = date(2006, 5, 20)
+        assert (
+            _classify_period_rejection(date(1995, 1, 1), date(1995, 12, 31), retention_cutoff=cutoff)
+            == _REJ_END_BEFORE_RETENTION_CUTOFF
+        )
+
+    def test_cutoff_keeps_on_boundary(self) -> None:
+        # period_end == cutoff is kept (cutoff is inclusive of today).
+        cutoff = date(2006, 5, 20)
+        assert _classify_period_rejection(None, date(2006, 5, 20), retention_cutoff=cutoff) is None
+
+    def test_cutoff_keeps_after_boundary(self) -> None:
+        cutoff = date(2006, 5, 20)
+        assert _classify_period_rejection(None, date(2006, 5, 21), retention_cutoff=cutoff) is None
+
+    def test_cutoff_rejects_just_before_boundary(self) -> None:
+        cutoff = date(2006, 5, 20)
+        assert (
+            _classify_period_rejection(None, date(2006, 5, 19), retention_cutoff=cutoff)
+            == _REJ_END_BEFORE_RETENTION_CUTOFF
+        )
+
+    def test_out_of_window_wins_over_cutoff(self) -> None:
+        # Year-6016 junk should be reported as OUT_OF_WINDOW (the
+        # data-shape bug), not as BEFORE_CUTOFF — even though the
+        # 6016 date is technically "in" the future-cutoff direction.
+        cutoff = date(2006, 5, 20)
+        assert _classify_period_rejection(None, date(6016, 1, 1), retention_cutoff=cutoff) == _REJ_END_OUT_OF_WINDOW
+
+    def test_pre_1900_wins_over_cutoff(self) -> None:
+        # An 1850 period_end is rejected as OUT_OF_WINDOW (the
+        # data-shape bug) rather than BEFORE_CUTOFF. Either would be
+        # correct semantically; pin the ordering so the more-specific
+        # reason wins.
+        cutoff = date(2006, 5, 20)
+        assert _classify_period_rejection(None, date(1850, 6, 30), retention_cutoff=cutoff) == _REJ_END_OUT_OF_WINDOW
+
+
+class TestExtractorRespectsCutoff:
+    """``_extract_facts_from_section`` plumbing — when called with
+    ``retention_cutoff``, drops pre-cutoff facts + logs WARN."""
+
+    def test_extractor_drops_pre_cutoff_fact(self, caplog: pytest.LogCaptureFixture) -> None:
+        cutoff = date(2006, 5, 20)
+        section = {
+            "Revenues": {
+                "units": {
+                    "USD": [
+                        _entry(end="2005-12-31", accn="0003333333-25-000001"),
+                        _entry(end="2024-12-31", accn="0003333333-25-000002"),
+                    ]
+                }
+            }
+        }
+        with caplog.at_level(logging.WARNING):
+            facts = _extract_facts_from_section(section, taxonomy="us-gaap", retention_cutoff=cutoff)
+        # 2005-12-31 dropped, 2024-12-31 kept.
+        assert len(facts) == 1
+        assert facts[0].period_end == date(2024, 12, 31)
+        # WARN logged for the rejection.
+        relevant = [r for r in caplog.records if _REJ_END_BEFORE_RETENTION_CUTOFF in r.getMessage()]
+        assert len(relevant) == 1
+
+    def test_extractor_no_cutoff_keeps_old_facts(self) -> None:
+        # Default behaviour (no retention_cutoff) — old facts survive.
+        section = {
+            "Revenues": {
+                "units": {
+                    "USD": [
+                        _entry(end="1995-12-31", accn="0004444444-25-000001"),
+                    ]
+                }
+            }
+        }
+        facts = _extract_facts_from_section(section, taxonomy="us-gaap")
+        assert len(facts) == 1
+
+
+class TestCompanyfactsWrapperAppliesCaps:
+    """``extract_facts_from_companyfacts_payload`` — the canonical
+    bulk-ingest entry point — must apply both the concept whitelist
+    + the 20y retention cutoff (#1233 §4.1)."""
+
+    def test_wrapper_filters_unknown_concept(self) -> None:
+        from app.services.sec_companyfacts_ingest import extract_facts_from_companyfacts_payload
+
+        payload = {
+            "facts": {
+                "us-gaap": {
+                    # Off-whitelist concept — must NOT survive.
+                    "SomeRandomNarrativeFootnote": {
+                        "units": {
+                            "USD": [_entry(end="2024-12-31", accn="0005555555-25-000001")],
+                        }
+                    },
+                    # On-whitelist concept — survives.
+                    "Revenues": {
+                        "units": {
+                            "USD": [_entry(end="2024-12-31", accn="0005555555-25-000002")],
+                        }
+                    },
+                }
+            }
+        }
+        facts = extract_facts_from_companyfacts_payload(payload)
+        concepts = {f.concept for f in facts}
+        assert "Revenues" in concepts
+        assert "SomeRandomNarrativeFootnote" not in concepts
+
+    def test_wrapper_applies_retention_cutoff(self) -> None:
+        from app.services.sec_companyfacts_ingest import extract_facts_from_companyfacts_payload
+
+        # Construct a payload with an old + new revenue fact. The
+        # wrapper's retention_cutoff = today - 20y. A 1995 fact is
+        # always >20y old in 2026 + later, so always rejected.
+        payload = {
+            "facts": {
+                "us-gaap": {
+                    "Revenues": {
+                        "units": {
+                            "USD": [
+                                _entry(end="1995-12-31", accn="0006666666-25-000001"),
+                                _entry(end="2024-12-31", accn="0006666666-25-000002"),
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        facts = extract_facts_from_companyfacts_payload(payload)
+        ends = {f.period_end for f in facts}
+        assert date(1995, 12, 31) not in ends
+        assert date(2024, 12, 31) in ends
+
+    def test_wrapper_applies_dei_whitelist(self) -> None:
+        from app.services.sec_companyfacts_ingest import extract_facts_from_companyfacts_payload
+
+        payload = {
+            "facts": {
+                "dei": {
+                    # On-whitelist DEI concept.
+                    "EntityCommonStockSharesOutstanding": {
+                        "units": {
+                            "shares": [_entry(end="2024-12-31", accn="0007777777-25-000001")],
+                        }
+                    },
+                    # Off-whitelist DEI concept — must drop.
+                    "EntityRegistrantName": {
+                        "units": {
+                            "shares": [_entry(end="2024-12-31", accn="0007777777-25-000002")],
+                        }
+                    },
+                }
+            }
+        }
+        facts = extract_facts_from_companyfacts_payload(payload)
+        concepts = {f.concept for f in facts}
+        assert "EntityCommonStockSharesOutstanding" in concepts
+        assert "EntityRegistrantName" not in concepts


### PR DESCRIPTION
## Summary

Applies the canonical companyfacts caps from retention rubric spec (#1235 §4.1) to every production write path into `financial_facts_raw` (currently 23 GB of dev DB / 50% of total).

- **Concept whitelist**: ~50 numeric us-gaap concepts + ~3 DEI concepts via existing `_ALL_TRACKED_TAGS` / `_ALL_TRACKED_DEI_TAGS` constants.
- **20y rolling retention horizon**: facts with `period_end < today - 20y` rejected with WARN.
- **Coverage**: bulk archive ingest + steady-state `extract_facts` + steady-state `extract_facts_and_catalog`. Read-only primitives (`extract_facts` standalone module function + `fetch_concept` companyconcept API) stay uncapped because they return data to the caller without persisting.

Refs #1233.

## Why

financial_facts_raw is the single biggest table in dev (23 GB of 43 GB). Spec §4.1 caps it via (a) field-level whitelist of editorial numeric concepts and (b) 20y rolling horizon. Spec acceptance §8 (post-clean-rerun) targets <7 GB for this table after both caps apply.

## Codex 2 review (two rounds)

- **Round 1 (P1 finding)**: bulk-only cap leaves steady-state refresh writing uncapped after bootstrap finishes — pre-cap rows would re-appear on the next daily refresh of any CIK. **Fixed in-scope** by extending `SecFundamentalsProvider.extract_facts()` + `.extract_facts_and_catalog()` to apply the same caps.
- **Round 2**: no findings. All financial_facts_raw write paths covered. Read-only primitive boundary consistent.

## Backfill

One-shot purge of pre-cap rows from the current 16.4M-row table is **operator-driven** via the existing `sec_rebuild` job. Not in this PR scope — keeps PR tightly focused on the parser-side cap so the next clean re-run lands under the new caps from the start. Spec §6.3 covers the drop-don't-archive decision.

## Test plan

- [x] `uv run ruff check` clean on changed files
- [x] `uv run ruff format --check` clean on changed files
- [x] `uv run pyright` clean on changed source files
- [x] `pytest tests/test_sec_fundamentals_period_end_guard.py` — 38/38 (22 prior + 16 new)
- [x] `pytest tests/test_sec_companyfacts_ingest.py` — 5/5 (existing tests still pass under new caps; fixture concept + period choices already inside whitelist + cutoff)
- [x] `pytest tests/test_sec_fundamentals_companyconcept.py + frames.py` — 144 total tests across companyfacts surface pass

## Tests added (16 new)

`tests/test_sec_fundamentals_period_end_guard.py`:

1. `TestDefaultRetentionCutoff` (4 tests) — today minus 20y, leap-day source, leap-day-to-non-leap-target fallback, constant pinning.
2. `TestClassifyPeriodRejectionWithCutoff` (7 tests) — no-cutoff baseline, reject pre-cutoff, boundary inclusivity, just-before-boundary rejected, out-of-window precedence over cutoff (both 6016 + 1850 cases).
3. `TestExtractorRespectsCutoff` (2 tests) — extractor drops pre-cutoff + WARNs, no-cutoff default keeps old facts.
4. `TestCompanyfactsWrapperAppliesCaps` (3 tests) — wrapper filters unknown concept, applies retention cutoff, applies DEI whitelist independently.

## Security model

Defensive — narrows what we ingest. No new attack surface. Retention cutoff is parametrised so test fixtures can pin a stable reference date without monkeypatching `date.today()`.

## Tradeoffs

- **Whitelist vs emit-all**: the prior default (post-#451 Phase A) was "emit everything for richness". This PR reverts that for the bulk + steady-state write paths only. Read-only paths preserve the richness — operators doing ad-hoc deep dives via `fetch_concept` or the standalone `extract_facts` module function still see every concept SEC publishes.
- **20y vs 15y vs 25y**: 20y was the spec acceptance after Codex 1a/1b/1c/1d rounds. Operators that need a different horizon override via `sec_rebuild` with an explicit `since` parameter.
- **Catalogue uncapped, facts capped**: `extract_facts_and_catalog` returns both; only facts get the cap. Catalogue is per-concept metadata (label, description) — capping it would orphan downstream UI for any concept that exists in catalogue but was filtered from facts.

Closes #1233 partially (PR-B of the cap-impl series; remaining sources covered by subsequent PRs per the impl plan that comes after this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)