### PR TITLE
feat(#1233): PR1 — instruments.country + is_tradable filters + lint guard + spec revision

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -43,6 +43,13 @@ uv run ruff format --check .
 echo "==> Pre-push gate: pyright"
 uv run pyright
 
+# #1233 §6.2 — every INSERT INTO instruments must list is_tradable in
+# its column list. Extends the prevention-log §"INSERT INTO instruments
+# fixtures must supply is_tradable" gate from tests/fixtures/ to the
+# whole tree. ~50ms; no docker / DB / Python dependency.
+echo "==> Pre-push gate: INSERT INTO instruments lint"
+bash scripts/check_instruments_inserts.sh
+
 # Pytest scoping decision. If `git diff --name-only @{u}..HEAD` fails
 # (no upstream yet, e.g. brand-new branch), assume worst-case: run the
 # full suite under xdist. The first push of a brand-new branch usually

--- a/app/services/finra_short_interest_ingest.py
+++ b/app/services/finra_short_interest_ingest.py
@@ -129,9 +129,16 @@ def build_preloaded_symbol_resolver(
     materialisation + O(1) per-row lookup vs the per-row 3-table
     default-resolver path.
     """
+    # Filter ``is_tradable = TRUE`` so delisted instruments don't bloat
+    # the resolver's collision space. FINRA bimonthly short-interest
+    # reports cover currently-listed securities only; a symbol that no
+    # longer trades cannot appear in today's FINRA payload, and keeping
+    # its row in the resolver only increases the chance of a normalised-
+    # symbol collision that forces the legitimate active row into the
+    # ambiguous bucket. #1233 §6.2.
     multimap: dict[str, set[int]] = {}
     with conn.cursor() as cur:
-        cur.execute("SELECT instrument_id, symbol FROM instruments")
+        cur.execute("SELECT instrument_id, symbol FROM instruments WHERE is_tradable = TRUE")
         for instrument_id, symbol in cur.fetchall():
             normalised = normalise_symbol(symbol)
             if not normalised:

--- a/app/services/mf_directory.py
+++ b/app/services/mf_directory.py
@@ -118,9 +118,12 @@ def refresh_mf_directory(
             if symbol_stripped is None:
                 continue
 
-            # Look up the matching instrument by symbol. Skip if not in universe.
+            # Look up the matching instrument by symbol. Skip if not in
+            # universe OR if delisted (#1233 §6.2 — seeding class_id for
+            # an inactive instrument burns scheduler budget for no
+            # operator value).
             cur.execute(
-                "SELECT instrument_id FROM instruments WHERE symbol = %s",
+                "SELECT instrument_id FROM instruments WHERE symbol = %s AND is_tradable = TRUE",
                 (symbol_stripped,),
             )
             inst_row = cur.fetchone()

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -70,7 +70,9 @@ def _list_cik_secondary_pages(
             SELECT ei.instrument_id, ei.identifier_value, i.symbol
             FROM external_identifiers ei
             JOIN instruments i ON i.instrument_id = ei.instrument_id
-            WHERE ei.provider = 'sec' AND ei.identifier_type = 'cik'
+            WHERE ei.provider = 'sec'
+              AND ei.identifier_type = 'cik'
+              AND i.is_tradable = TRUE
             """,
         )
         for row in cur.fetchall():

--- a/app/services/sec_submissions_ingest.py
+++ b/app/services/sec_submissions_ingest.py
@@ -86,7 +86,9 @@ def _load_cik_to_instrument(
             SELECT ei.instrument_id, ei.identifier_value, i.symbol
             FROM external_identifiers ei
             JOIN instruments i ON i.instrument_id = ei.instrument_id
-            WHERE ei.provider = 'sec' AND ei.identifier_type = 'cik'
+            WHERE ei.provider = 'sec'
+              AND ei.identifier_type = 'cik'
+              AND i.is_tradable = TRUE
             """,
         )
         for row in cur.fetchall():

--- a/app/services/universe.py
+++ b/app/services/universe.py
@@ -56,7 +56,31 @@ def sync_universe(
     deactivated = 0
 
     with conn.transaction():
-        # Upsert each record from the provider
+        # Upsert each record from the provider.
+        #
+        # ``country`` is NOT taken from the provider (eToro instruments
+        # endpoint does not expose it — see
+        # ``app/providers/implementations/etoro.py:350``). Derived
+        # instead from ``exchanges.country`` (operator-curated, ISO
+        # 3166-1 alpha-2) via the ``instruments.exchange =
+        # exchanges.exchange_id`` join.
+        #
+        # Semantic: the source of truth is the exchanges curator. A
+        # curated change ("exchange 5 is now uk_equity / GB") flows
+        # through to every instrument on that exchange on the next
+        # sync. There is NO instrument-level operator override (#1233
+        # §6.1).
+        #
+        # Edge case: if the exchange row is missing from ``exchanges``
+        # at upsert time (transient bootstrap order, brand-new
+        # exchange not yet seeded by sql/067), the CASE branch
+        # preserves the existing ``instruments.country`` rather than
+        # wiping it to NULL. The next sync, after sql/067 backfills
+        # the missing exchange, picks up the curated value. Codex 2
+        # pre-push catch (PR1 #1233).
+        #
+        # One-shot backfill for existing rows lives in
+        # ``sql/158_instruments_country_backfill.sql``.
         for rec in records:
             conn.execute(
                 """
@@ -68,7 +92,9 @@ def sync_universe(
                 )
                 VALUES (
                     %(provider_id)s, %(symbol)s, %(company_name)s, %(exchange)s,
-                    %(currency)s, %(sector)s, %(industry)s, %(country)s, %(is_tradable)s,
+                    %(currency)s, %(sector)s, %(industry)s,
+                    (SELECT country FROM exchanges WHERE exchange_id = %(exchange)s),
+                    %(is_tradable)s,
                     %(instrument_type)s, %(instrument_type_id)s, NOW(), NOW()
                 )
                 ON CONFLICT (instrument_id) DO UPDATE SET
@@ -78,7 +104,21 @@ def sync_universe(
                     currency           = COALESCE(EXCLUDED.currency, instruments.currency),
                     sector             = EXCLUDED.sector,
                     industry           = EXCLUDED.industry,
-                    country            = EXCLUDED.country,
+                    -- Preserve prior country if the exchange row is
+                    -- missing (transient bootstrap order); otherwise
+                    -- mirror the curator's value (which may legitimately
+                    -- be NULL for crypto / FX / index exchanges).
+                    country            = CASE
+                        WHEN EXISTS (
+                            SELECT 1 FROM exchanges
+                            WHERE exchange_id = EXCLUDED.exchange
+                        )
+                        THEN (
+                            SELECT country FROM exchanges
+                            WHERE exchange_id = EXCLUDED.exchange
+                        )
+                        ELSE instruments.country
+                    END,
                     is_tradable        = EXCLUDED.is_tradable,
                     -- COALESCE preserves a previously-known type when a
                     -- transient eToro response omits ``instrumentTypeName``
@@ -113,7 +153,6 @@ def sync_universe(
                     "currency": rec.currency,
                     "sector": rec.sector,
                     "industry": rec.industry,
-                    "country": rec.country,
                     "is_tradable": rec.is_tradable,
                     "instrument_type": rec.instrument_type,
                     "instrument_type_id": rec.instrument_type_id,

--- a/docs/superpowers/specs/2026-05-19-data-retention-rubric.md
+++ b/docs/superpowers/specs/2026-05-19-data-retention-rubric.md
@@ -4,7 +4,7 @@
 >
 > Tracking issue: **#1233** — Bootstrap scope discipline umbrella.
 >
-> Status: **READY FOR PR** — Codex 1a + 1b + 1c + 1d complete (all blocking + warning findings resolved). Empirical numbers captured mid-drain so the volumes here are a lower bound (S21 13F sweep still running; ownership rollups not yet refreshed).
+> Status: **EVOLVING** — original spec merged 2026-05-19 (#1235) after Codex 1a + 1b + 1c + 1d. PR2 (#1237) + PR5 NUMERIC fix (#1236) shipped. PR1 revision in flight (this commit) reframes the spec's drop-policy from "DELETE pre-cap rows per PR" to "ingest-side caps only + one operator-driven pre-wipe + clean re-run at the end" — caps don't touch existing rows, and the wipe is whole-DB + operator-driven, not per-source.
 
 ## 0. Status snapshot (2026-05-19 17:00 UTC, mid-drain)
 
@@ -43,7 +43,7 @@ Bootstrap currently ingests **all SEC sources for all CIK-holding instruments at
 2. **Storage.** 43 GB of dev DB. `financial_facts_raw` at 23 GB alone is half. Steady-state growth is unbounded.
 3. **SEC rate-limit budget.** 10 req/s shared. Universe-wide × 33y depth × per-accession HTTP for the non-bulk sources = days of wall-clock.
 
-We pull data that **never feeds a current-as-of-today thesis or chart**. The premise of this spec: every row in hot storage must justify itself against a downstream consumer (chart panel, AI prompt section, alert trigger, valuation model). If no current consumer cites it, it doesn't ingest — or it gets dropped post-retention horizon. (Same-DB cold archive is out per §6.3.)
+We pull data that **never feeds a current-as-of-today thesis or chart, and we pull it for sources at unbounded depth**. The premise of this spec: every cap is justified against a plausible downstream consumer (chart, AI prompt, alert, valuation model, future report). Caps are applied **at ingest time** so the table doesn't grow with noise; existing rows are untouched until the single operator-driven pre-wipe + clean re-run at the end (§6.3). Schema columns are preserved throughout — the product is reporting-incomplete by design, and columns the parser could fill stay populated even if no current consumer reads them.
 
 ### Why pre-wipe
 
@@ -81,14 +81,17 @@ How fast does the data stop being predictive?
 
 ### 3.3 Downstream consumer surface
 
-Every row in hot storage must feed at least one of:
+Every cap must be justified against a plausible downstream consumer:
 
 - **Chart panel** — currently-rendering surface on the instrument detail page.
 - **AI prompt section** — thesis-writer, thesis-critic, ranking-engine, valuation-analyst, news-sentiment.
 - **Alert trigger** — future surface (cluster insider buy, new 5%+ blockholder, material 8-K).
 - **Valuation model input** — backtest history depth, ranking factor.
+- **Future report** — any panel / prompt / chart not yet built but plausibly within scope; v1 is reporting-incomplete by design.
 
-Rows that match no current consumer are candidates for drop (no same-DB cold archive — see §6.3).
+**Important: this is an ingest-side discipline, not a row-deletion rule.** Caps gate what new ingests *write*. Existing rows are NEVER deleted on a per-source basis to align with this list. The product is reporting-incomplete; columns the parser could fill but no current consumer cites stay populated because tomorrow's report may want them. Schema columns are never removed during cap-shaping work.
+
+The only purge in this spec is the single **pre-wipe** event in §6.3 — operator-driven, whole-DB, run once before a clean-bootstrap re-run. After the wipe, the clean ingest pulls bounded data under the new caps. There is no piecemeal post-merge `DELETE` per PR.
 
 ## 4. Per-source rubric
 
@@ -100,10 +103,10 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 16.4M rows, 23 GB. Largest single table by far.
 - **Half-life**: **slow** — multi-year. 10y trend matters for valuation; CAGR models need 5y+.
 - **Consumers**: PE/PS/margin time-series charts; ranking engine factor inputs; valuation analyst inputs; AI thesis valuation context.
-- **Ingest depth cap (proposed)**: **20y** rolling window (`period_end >= NOW() - 20y`). No separate completeness SLA — the 20y cap *is* the completeness rule.
-- **Retention horizon cap (proposed)**: **20y in hot table**; older → **drop** (Codex 1a §3 — same-DB cold archive doesn't reduce DB size; if backtests later need pre-20y, re-ingest via `POST /jobs/sec_rebuild/run` with explicit horizon override).
-- **Field-level cap**: many XBRL concepts are textual annotations or auditor disclosures, not numbers. Filter on a whitelist of numeric concepts at ingest time. Drop or quarantine the rest. Estimated 30-50% row reduction.
-- **Why this matters**: half the DB. Even a 20% cut here = 4+ GB.
+- **Ingest depth cap**: **20y rolling window** (`period_end >= NOW() - 20y`) applied at the parser. Already landed via PR2 (#1237). Survives the pre-wipe + clean re-run as the steady-state cap.
+- **Field-level cap**: many XBRL concepts are textual annotations or auditor disclosures, not numbers. Whitelist of ~50 numeric concepts + ~3 DEI concepts is enforced at ingest. Already landed via PR2 (#1237). Schema column for `concept` is preserved — operator can widen the whitelist later without a migration.
+- **Existing rows**: untouched. The pre-wipe (§6.3) and subsequent clean re-run will land the bounded set; the in-place 16.4M-row table stays put until then.
+- **Why this matters**: half the DB. Post-wipe + clean re-run, the 20y + whitelist combo projects to ~7 GB for this table.
 
 ### 4.2 Filing events (`filing_events`)
 
@@ -111,10 +114,10 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 5.79M rows, 4.3 GB, 1993–2026.
 - **Half-life**: **slow** for navigation (drilldown link source); fast for "recent activity" displays.
 - **Consumers**: drilldown links from chart pages; AI thesis recent-events context; audit trail; 8-K event timeline chart (filtered view, not a separate table).
-- **Ingest depth cap (proposed)**: **10y** rolling window applied uniformly across every filing_type. The "8-K 2y for chart" referenced in §5.1 is a **query filter**, not a separate retention cap (Codex 1a §1 — earlier draft contradicted itself by treating 8-K as a separate retention shape).
-- **Retention horizon cap (proposed)**: **10y hot**, pre-2016 → drop. Operator re-ingests older slices on demand via `POST /jobs/sec_rebuild/run` with `since=<date>`.
-- **Raw payload**: `raw_payload_json` should be dropped from hot table after first parse; payload retention belongs in #1014 raw-payload retention slice. Estimated 40-60% size reduction on its own.
-- **Why this matters**: 4.3 GB. Drop pre-2016 = ~60-70% row reduction; payload-strip = additional 40-60% per-row reduction; ~3 GB saved.
+- **Ingest depth cap**: **10y rolling window** at ingest (every discovery writer — Atom, daily-index reconcile, first-install drain, per-CIK poll, targeted rebuild). The "8-K 2y for chart" referenced in §5.1 is a **query filter** that the consumer applies, not a parser-side cap (Codex 1a §1).
+- **Raw payload posture**: `raw_payload_json` is preserved in the schema. The strip-after-parse work is a **separate** ticket (#1014 raw-payload retention) so the ingest cap here doesn't conflate with the payload question.
+- **Existing rows**: untouched. The pre-wipe (§6.3) + clean re-run will land the bounded set under the new cap.
+- **Why this matters**: 4.3 GB. Post-wipe + clean re-run under the 10y cap projects to ~1 GB (60-70% row reduction at clean ingest time, schema intact).
 
 ### 4.3 Form 4 (insider transactions, `insider_transactions`)
 
@@ -122,10 +125,11 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 7,777 rows, 3.7 MB. **Under-ingested** — should be hundreds of thousands at universe scale × full history.
 - **Half-life**: **fast** — last 90d is the alert signal; last 12mo is the thesis signal; 5y old = decoration.
 - **Consumers**: insider buy/sell timeline chart; AI thesis "insiders bought $X in last 90d"; future cluster-buy alerts. **`ownership_insiders_current`** (29 MB) is the cumulative post-transaction holdings rollup derived from observations.
-- **Ingest depth cap (proposed)**: **3y** from today, per CIK.
-- **Retention horizon cap (proposed)**: **3y hot** on `insider_transactions` + `ownership_insiders_observations`, pre-3y → drop.
-- **Codex 1a §6 — cumulative ownership concern**: dropping pre-3y observations is safe **only if** `ownership_insiders_current` is maintained as a write-through cumulative ledger (not recomputed from observations on each refresh). Verification step in PR4: confirm `ownership_insiders_current` survives an observations truncate; if it recomputes from observations, freeze cumulative balance at the 3y boundary as an opening position so dropping older rows is non-destructive.
-- **Cohort bound**: only ingest for `is_tradable=TRUE` instruments. Form 4 for delisted = noise.
+- **Ingest depth cap**: **3y** from today, per CIK, at the parser. Rows outside the window aren't fetched.
+- **Cumulative ownership invariant**: the steady-state ingest cap is safe **only if** `ownership_insiders_current` is maintained as a write-through cumulative ledger (not recomputed from observations on each refresh). Verification step in the Form 4 cap PR: confirm `ownership_insiders_current` survives an observations truncate-from-clean-re-ingest; if it would recompute from observations, the parser writes a synthetic opening-balance row at the 3y boundary as a write-through anchor so the post-wipe re-ingest preserves cumulative state.
+- **Post-wipe semantics for cumulative state**: a whole-DB wipe (§6.3) deliberately resets `ownership_insiders_current` along with `ownership_insiders_observations`. The clean re-ingest under the 3y cap rebuilds cumulative state going forward from "no opening balance" — i.e. the post-wipe `ownership_insiders_current` reflects only trades observed inside the 3y window. Pre-3y cumulative position is lost by design. Operator accepts this as the trade-off for a bounded clean re-run; if pre-3y opening balance is later wanted, it requires a separate one-shot "deep history" sweep outside the cap (operator-driven, like `POST /jobs/sec_rebuild/run` with explicit depth override).
+- **Cohort bound**: only ingest for `is_tradable=TRUE` instruments (PR1 §6.2). Form 4 for delisted = ingest-budget noise.
+- **Existing rows**: untouched until pre-wipe (§6.3).
 - **Why this matters**: not size, but ingest-budget — universe-wide × 33y Form 4 ingest is the multi-day cost. 3y cap = ~90% reduction in candidate set.
 
 ### 4.4 Form 3 / Form 5 (initial / annual insider summary)
@@ -134,8 +138,7 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: low (no dedicated table for Form 3 visible; data threaded into insider_transactions).
 - **Half-life**: **latest only matters** — Form 3 is the initial filing, supplanted by ongoing Form 4s; Form 5 is annual catch-up.
 - **Consumers**: insider registry table (who is registered as an insider for this issuer).
-- **Ingest depth cap (proposed)**: **latest per insider-company pair**.
-- **Retention horizon cap (proposed)**: keep latest; drop older — they add no signal beyond what's already in Form 4 history.
+- **Ingest depth cap**: **latest per insider-company pair** at the parser. The post-wipe clean re-run naturally lands one row per pair under this rule.
 
 ### 4.5 13F-HR institutional holdings (`institutional_holdings`, `ownership_institutions_observations`)
 
@@ -143,11 +146,11 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 105k raw holdings; 3.86M observations rows; 2.5 GB obs + 2.8 GB current = **5.3 GB combined**.
 - **Half-life**: **medium** — 4-quarter trend matters for momentum; 8 quarters (2y) for backtests; beyond = decoration.
 - **Consumers**: stacked institutional ownership % chart; concentration metric in ranking; AI thesis "Vanguard increased position by 8%".
-- **Ingest depth cap (proposed)**: **8 quarters (2y)** observations + always-current snapshot.
+- **Ingest depth cap**: **8 quarters (2y)** observations at the parser + always-current snapshot.
 - **Cohort bound**: **already done #1010** — `last_13f_hr_at` 380d recency cap on filer cohort (11,205 → 8,681 filers).
-- **Retention horizon cap (proposed)**: **8 quarters hot** in observations; current snapshot always. Pre-8q → drop (per §6.3 no same-DB cold archive).
-- **`ownership_institutions_current` size oddity**: 2.8 GB is huge for a "current snapshot" — investigation needed. Either stores wide rows with embedded payload, or write-through is dumping more than current state. Separate audit ticket.
-- **Why this matters**: combined 5.3 GB. Cut to 2y observations = ~2-3 GB saved (depending on what `current` really stores).
+- **`ownership_institutions_current` size oddity**: 2.8 GB is huge for a "current snapshot" — investigation needed. Either stores wide rows with embedded payload, or write-through is dumping more than current state. Separate audit ticket (PR12).
+- **Existing rows**: untouched until pre-wipe (§6.3).
+- **Why this matters**: combined 5.3 GB. Post-wipe + clean re-run under 8q + PR12 audit projects to ~1-2 GB (depending on what `current` really stores).
 
 ### 4.6 N-PORT fund holdings (`ownership_funds_observations`)
 
@@ -155,10 +158,10 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 3.68M obs rows, 1.6 GB obs + 2.5 GB current = **4.1 GB combined**.
 - **Half-life**: same as 13F.
 - **Consumers**: funds slice of institutional ownership chart; potentially fold into 13F view if redundant.
-- **Ingest depth cap (proposed)**: **8 quarters** same as 13F.
-- **Cohort bound**: same recency-based filter pattern as #1010, applied to N-PORT filer registry.
-- **Retention horizon cap (proposed)**: **8 quarters hot**, current snapshot always.
-- **Why this matters**: similar to 13F — combined 4.1 GB; same proportional cut.
+- **Ingest depth cap**: **8 quarters** at the parser, same as 13F + always-current snapshot.
+- **Cohort bound**: same recency-based filter pattern as #1010, applied to N-PORT filer registry (`last_nport_at`).
+- **Existing rows**: untouched until pre-wipe (§6.3).
+- **Why this matters**: similar to 13F — combined 4.1 GB; same proportional projection post-wipe + clean re-run.
 
 ### 4.7 DEF 14A blockholders (`def14a_beneficial_holdings`, `ownership_def14a_observations`)
 
@@ -166,10 +169,10 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 47k raw rows, 17 MB; 40k obs rows, 24 MB; combined ~50 MB.
 - **Half-life**: **slow state, but only LATEST matters** — DEF 14A is the annual snapshot; the prior year's snapshot is decoration.
 - **Consumers**: top-5-holders pie chart; AI thesis "Top 5 institutional holders are…"; executive-comp slice (separate epic).
-- **Ingest depth cap (proposed)**: **latest 2 proxies per filer** (current + one prior for change tracking).
-- **Retention horizon cap (proposed)**: **latest 2 proxies hot**; older → drop. Current snapshot always.
-- **NUMERIC overflow bug**: #1228 affects this source. Fix lands before clean re-run.
-- **Why this matters**: not storage (small); ingest-budget. DEF 14A is HTML scrape — 1h per pass with deadline cap; 5y of proxies × 5,174 filers = un-drainable in one pass. 2-proxy cap = ~80% reduction.
+- **Ingest depth cap**: **latest 2 proxies per filer** (current + one prior for change tracking) at the parser. Older filings not fetched.
+- **NUMERIC overflow bug**: #1228 — fix already landed via PR5 fold-in (#1236).
+- **Existing rows**: untouched until pre-wipe (§6.3).
+- **Why this matters**: not storage (small); ingest-budget. DEF 14A is HTML scrape — 1h per pass with deadline cap; 5y of proxies × 5,174 filers = un-drainable in one pass. 2-proxy cap = ~80% reduction in candidate set.
 
 ### 4.8 13D/G blockholders
 
@@ -177,8 +180,8 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 0 ingested (table exists; pipeline not yet active).
 - **Half-life**: **fast for new-filing alert**, **slow for current state** (current 13D/G filers = decoration table).
 - **Consumers**: top concentrated holders panel; AI thesis "new blockholder X filed Y ago"; future alert on new 13D crossing.
-- **Ingest depth cap (proposed)**: **3y historical**, current state always.
-- **Retention horizon cap (proposed)**: **3y hot**, older → drop.
+- **Ingest depth cap**: **3y historical** at the parser + current state always.
+- **Existing rows**: 13D/G table is empty today (pipeline dormant); the cap shapes the first ingest.
 
 ### 4.9 8-K events (filtered view of `filing_events`)
 
@@ -195,8 +198,7 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 10,744 rows.
 - **Half-life**: **slow state, latest only** — business model doesn't change rapidly; the latest 10-K subsumes prior.
 - **Consumers**: instrument page text panel; AI thesis "company is in business of…" context.
-- **Ingest depth cap (proposed)**: **latest 10-K per CIK only**.
-- **Retention horizon cap (proposed)**: keep latest; drop prior.
+- **Ingest depth cap**: **latest 10-K per CIK** at the parser. Post-wipe clean re-run naturally lands one row per CIK.
 
 ### 4.11 Treasury / ESOP / blockholder slices
 
@@ -204,8 +206,7 @@ Aggregated under DEF 14A discovery (treasury share counts, ESOP plan holdings, b
 
 - **Half-life**: slow-state.
 - **Consumers**: capital structure panel; buyback / dilution context.
-- **Ingest depth cap**: latest 2 proxies per filer (same as DEF 14A).
-- **Retention horizon cap**: latest 2 hot.
+- **Ingest depth cap**: latest 2 proxies per filer (same as DEF 14A) at the parser.
 
 ### 4.12 N-CSR / N-CSRS (fund certified shareholder reports)
 
@@ -213,8 +214,7 @@ Aggregated under DEF 14A discovery (treasury share counts, ESOP plan holdings, b
 - **Current volume**: not yet exercised at universe scale in this drive. Ingest path lives in `app/jobs/sec_first_install_drain.py:512-815` (bootstrap_n_csr_drain). Existing `horizon_days=730` (2y) cap already in code.
 - **Half-life**: **medium** — funds report semi-annually; 4 semi-annual snapshots = 2y of position changes per trust.
 - **Consumers**: funds slice augmentation (N-PORT alone misses some trusts that file only N-CSR); AI thesis context for fund-held instruments.
-- **Ingest depth cap (proposed)**: **730 days (2y) — already in code**, retain as-is.
-- **Retention horizon cap (proposed)**: **2y hot** matching ingest; older → drop.
+- **Ingest depth cap**: **730 days (2y) — already in code** (`bootstrap_n_csr_drain` `horizon_days=730`). Retain as-is.
 - **Cohort bound**: fund trusts only (sourced from `cik_refresh_mf_directory`). Issuer-scoped seed excludes N-CSR per `sec_first_install_drain.py:167`.
 
 ### 4.13 N-CEN (annual fund census, classification only)
@@ -223,8 +223,7 @@ Aggregated under DEF 14A discovery (treasury share counts, ESOP plan holdings, b
 - **Current volume**: small; one row per investment-company CIK per year.
 - **Half-life**: **slow** — classification updates annually; latest N-CEN per CIK is sufficient.
 - **Consumers**: `app/services/ncen_classifier.py` filer-type classification feeds 13F-HR vs N-PORT routing; influences institutional vs funds ownership lane decision.
-- **Ingest depth cap (proposed)**: **latest N-CEN per CIK only**.
-- **Retention horizon cap (proposed)**: keep latest; drop prior. No value in N-CEN history beyond current classification.
+- **Ingest depth cap**: **latest N-CEN per CIK** at the parser. Post-wipe clean re-run lands one row per CIK.
 - **Why this matters**: small storage, but **load-bearing for filer classification** — Codex 1a caught the omission. Spec must acknowledge this source even though it's lightweight.
 
 ### 4.14 Metadata-only forms (Form D, Form 144, NT 10-Q, S-1/3/4/8/11, 424B)
@@ -234,9 +233,8 @@ These SEC filings are **discovered via the submissions manifest** and persisted 
 - **Raw shape**: index entry only (`filing_type`, `filing_date`, `source_url`).
 - **Half-life**: varies — Form 144 last 90d is the insider-sale-intent signal; S-1/424B are one-shot per offering; NT 10-Q is a late-filing notice (90d window).
 - **Consumers**: drilldown links; AI thesis "recently filed S-1" context; future Form 144 alert (intent-to-sell signal complementing Form 4 actuals).
-- **Ingest depth cap**: covered by `filing_events` 10y.
-- **Retention horizon cap**: covered by `filing_events` 10y.
-- **No separate parser retention required** unless a future ticket adds an observation table (e.g. Form 144 intent-to-sell extraction for the alerts epic — out of scope here).
+- **Ingest depth cap**: covered by `filing_events` 10y cap.
+- **No separate parser cap required** unless a future ticket adds an observation table (e.g. Form 144 intent-to-sell extraction for the alerts epic — out of scope here).
 
 ## 5. Downstream consumer map
 
@@ -293,13 +291,25 @@ Mapping each surface to the sources it needs. Used to validate the caps don't br
 
 **Decision**: audit + lint guard. Cron stages add the filter; bootstrap stages add the filter; the few legitimate "ingest delisted for back-history" paths require explicit override flag.
 
-### 6.3 Drop, don't archive (Codex 1a §3 revision)
+### 6.3 No piecemeal drops — one operator-driven pre-wipe + clean re-run
 
-Earlier draft proposed same-DB `*_archive_pre_NNNN` cold tables. Codex 1a flagged: same-DB archive doesn't reduce DB size, contradicting the storage-target acceptance.
+The original draft proposed per-PR `DELETE` of pre-cap rows. **Revoked.** Per-PR row-deletion conflates two concerns: (a) gate what new ingests write (ingest-side cap, safe + reversible), (b) reshape an existing table (destructive, hard to roll back, risks erasing data a future report may want).
 
-**Decision**: pre-cap rows **drop** in v1. No same-DB cold archive. If a backtest later demands pre-cap depth, operator re-ingests via `POST /jobs/sec_rebuild/run` with explicit `since=<date>` horizon override — SEC bulk endpoints are the source of truth; we don't need to be the archive.
+**Decision: caps are ingest-side only.** No PR in this spec issues `DELETE FROM <table>` against pre-cap rows. Existing rows stay until the single pre-wipe event below.
 
-Future epic: if cold-archive becomes desirable, ship as **separate database** or **S3 parquet snapshots**, not same-DB tables. Out of scope for this spec.
+**Pre-wipe event** (operator-driven, whole-DB, one-shot):
+
+1. Operator triggers a controlled wipe of the dev DB (`TRUNCATE` or DB re-creation) **after** PR1-PR12 land and all caps are merged.
+2. Bootstrap re-runs from a clean DB. Ingest is bounded by every cap in §4.
+3. Final DB size measures the post-wipe steady-state under the new caps.
+
+This single event replaces the dozen per-PR `DELETE` instructions. Reasons:
+
+- It's already on the operator's roadmap ("we will purge all reporting data once we're ready to test bootstrap timing"). The cap-shaping PRs are the precondition for that wipe, not a parallel concern.
+- Same outcome as in-place delete (clean ingest under new caps yields the same survivor set) without the risk of dropping rows a half-finished report still references.
+- Schema columns are preserved through the wipe — the wipe is `DELETE FROM` / `TRUNCATE`, not `DROP COLUMN` / `DROP TABLE`. Parsers fill what they always filled into the same columns.
+
+**Same-DB cold archive remains out of scope** — Codex 1a §3 was right that same-DB archive doesn't reduce DB size. If a future epic wants cold-archive, ship as **separate database** or **S3 parquet snapshots**, not same-DB tables.
 
 ### 6.4 Two-layer storage (current + observations)
 
@@ -314,75 +324,32 @@ Caps apply to **`*_observations`**; `*_current` is always latest.
 
 ## 7. Implementation sequence
 
-Land per-source PRs in this order, each gated by Codex 1a/1b + bot review:
+Land per-source PRs in this order. Each PR is **ingest-side cap only** — no PR issues `DELETE FROM <table>` against pre-cap rows (§6.3). Schema columns are preserved across every PR.
 
-1. **PR1 — Cross-cutting (#1233 §2 + §3).**
-   - Populate `instruments.country` from universe sync.
-   - Audit + add `is_tradable=TRUE` filter to every SEC stage entry point.
-   - Lint guard: CI grep `INSERT INTO instruments` must include `is_tradable`.
+- **PR1 — IN PROGRESS.** Cross-cutting (#1233 §2 + §3). Populate `instruments.country` from `exchanges.country` join + backfill migration; audit + add `is_tradable=TRUE` filter to every SEC stage entry point; lint guard greps `INSERT INTO instruments` for `is_tradable` in the column list (extends prevention-log §"`INSERT INTO instruments` fixtures must supply `is_tradable`" from tests/ to app/ + tests/). **Bundles spec revision** (this commit).
+- **PR2 — SHIPPED (#1237).** Companyfacts XBRL concept whitelist (~50 numeric us-gaap + ~3 DEI concepts) + 20y rolling cap at the parser. Every write path (bulk + steady-state).
+- **PR3 — pending.** Filing events 10y rolling cap at the parser. Applied uniformly across every filing_type via every discovery writer. Schema columns + existing rows untouched.
+- **PR4 — pending.** Form 4 3y cap at the parser + cumulative-rollup invariant check on `ownership_insiders_current` (synthetic opening-balance anchor at 3y boundary if recompute-from-observations). Recency cohort bound mirroring #1010.
+- **PR5 — partially shipped (#1236 NUMERIC fix).** DEF 14A latest-2-proxies cap at the parser. NUMERIC overflow #1228 already folded.
+- **PR6 — pending.** 13F-HR 8-quarter ingest cap at the parser. (#1010 cohort bound already in place.)
+- **PR7 — pending.** N-PORT 8-quarter cap (mirror of PR6). N-PORT recency cohort bound (`last_nport_at`) per #1010 pattern.
+- **PR8 — pending.** N-CSR/N-CSRS validate existing 2y horizon. Doc-only unless drift found.
+- **PR9 — pending.** N-CEN latest-only cap at the parser. Verify `ncen_classifier` reads latest.
+- **PR10 — pending.** Form 3/5 latest-only at the parser + business summary (10-K Item 1) latest-only at the parser.
+- **PR11 — pending.** 13D/G activate dormant pipeline with 3y historical + current-state cap at the parser.
+- **PR12 — pending.** `ownership_*_current` size audit + remediation (no row-deletion — schema audit only; if wide-row write bug found, fix the writer; existing rows reshape happens via the pre-wipe).
 
-2. **PR2 — Companyfacts XBRL concept whitelist + 20y depth cap.**
-   - Whitelist of ~50 numeric XBRL concepts (revenue, EPS, margins, …).
-   - Drop or quarantine non-whitelisted rows at ingest.
-   - 20y depth cap on bootstrap entry (`period_end >= NOW() - 20y`).
-   - Pre-20y rows → drop (no same-DB archive per §6.3).
-
-3. **PR3 — Filing events 10y hot + payload strip.**
-   - 10y depth cap on hot table.
-   - Pre-10y rows → drop (no same-DB archive per §6.3).
-   - Drop `raw_payload_json` from hot table (#1014 raw-payload retention).
-
-4. **PR4 — Form 4 3y depth cap + cumulative-rollup verification.**
-   - **Verification step FIRST** (Codex 1a §6 / 1b PARTIAL): confirm `ownership_insiders_current` is maintained as a write-through cumulative ledger, NOT recomputed from `ownership_insiders_observations` on each refresh. If recomputed, freeze opening cumulative balance at the 3y boundary as a write-through anchor row so dropping older observations is non-destructive. Acceptance fails until this verification is recorded in the PR description.
-   - 3y depth cap on `insider_transactions` ingest.
-   - Drop pre-3y rows from `insider_transactions` + `ownership_insiders_observations`.
-   - Recency cohort bound on Form 4 sweep (mirror of #1010 pattern).
-
-5. **PR5 — DEF 14A latest-2-proxies cap + #1228 NUMERIC fix.**
-   - Bundle the NUMERIC overflow fix from #1228.
-   - Latest-2-proxies-per-filer cap on ingest.
-   - Drop older from `def14a_beneficial_holdings` + `ownership_def14a_observations`.
-
-6. **PR6 — 13F-HR 8-quarter observations cap.**
-   - 8-quarter depth on `ownership_institutions_observations`.
-   - Drop pre-8q rows; `current` snapshot always.
-   - (`#1010` cohort bound already in place.)
-
-7. **PR7 — N-PORT 8-quarter cap (mirror of PR6).**
-   - Same shape applied to funds.
-   - Add N-PORT recency cohort bound (`last_nport_at`) per #1010 pattern.
-
-8. **PR8 — N-CSR/N-CSRS retain existing 2y horizon + observations cap.**
-   - Validate existing `horizon_days=730` in `bootstrap_n_csr_drain`.
-   - Document in spec; no code change unless audit finds drift.
-
-9. **PR9 — N-CEN latest-only.**
-   - Drop pre-latest N-CEN per CIK.
-   - Verify `ncen_classifier` reads from latest-only, not history.
-
-10. **PR10 — Form 3/5 latest-only + business summary latest-only.**
-    - Form 3/5: keep latest per insider-company pair.
-    - Business summary: drop prior; latest 10-K only.
-
-11. **PR11 — 13D/G 3y historical activation.**
-    - Activate the dormant 13D/G ingest pipeline.
-    - 3y depth cap; current state always.
-
-12. **PR12 — `ownership_*_current` size audit + remediation.**
-    - Investigate why `ownership_institutions_current` is 2.8 GB + `ownership_funds_current` is 2.5 GB. Either truncate-narrow the rows, or move bulky columns to observations.
-    - Cross-cutting; runs after PR6+PR7 land.
-
-After PR1-PR12 land + bootstrap drain re-runs cleanly under the new caps, **wipe + clean re-run** to validate. Measure end-to-end wall-clock + final DB size.
+After PR1-PR12 land, the operator triggers the **pre-wipe + clean re-run** (§6.3) — a whole-DB controlled wipe + clean bootstrap re-ingest under all caps. The clean re-run measures the new ceiling.
 
 ## 8. Acceptance
 
-Clean re-run after caps land (revised per Codex 1a §2 + §7):
+Measured after PR1-PR12 land + the operator-driven pre-wipe + clean bootstrap re-run (§6.3). The clean re-run lands the bounded set under all caps; the numbers below are the projection for that final state, not for any in-place delete pass.
 
 1. **Wall-clock**: full bootstrap drain (every bootstrap stage including N-CSR S25 fund-trust drain) completes in **a single business day (10-12h)** from fresh DB (was multi-day pre-caps).
    - **Why not < 8h**: SEC 10 req/s budget is shared across DEF14A HTML, Form 4, 13D/G, N-PORT, N-CSR, companyfacts per-CIK fetches. Even with caps, the per-accession candidate set remains large (5,174 US filers × multi-source + fund-trust universe for N-CSR). 10-12h is the realistic floor; sub-10h is a Phase 2 optimization (parallel SEC fetcher pools, CDN cache warm-up).
 2. **DB size**: post-clean-rerun `pg_database_size('ebull')` measured (excludes WAL — Postgres WAL lives outside per-database size accounting; tracked separately at the filesystem level via `pg_stat_wal` / `pg_ls_waldir()` if needed). Provisional breakdown:
    - `financial_facts_raw`: current 16.4M rows / 23 GB. Apply (a) 20y rolling cap → keep rows where `period_end >= NOW() - 20y` ≈ 60% of rows survive (proxy: 20y/33y); (b) whitelist of ~50 numeric concepts → assumed 50% row reduction inside the surviving 20y slice. Net: 16.4M × 0.60 × 0.50 ≈ 4.9M rows × ~1.5 KB/row (raw + tuple header + partitions) ≈ **~7 GB** including indexes + partition overhead.
-   - `filing_events`: current 5.79M rows / 4.3 GB. Apply 10y cap → ~30% rows survive (10y/33y); apply payload strip → row width drops ~50%. Net: 5.79M × 0.30 × 0.50 × ~600 B/row ≈ **~0.5 GB**; **~1 GB with indexes**.
+   - `filing_events`: current 5.79M rows / 4.3 GB. Apply 10y cap → ~30% rows survive (10y/33y). Net (no payload strip — deferred to #1014): 5.79M × 0.30 × ~750 B/row ≈ **~1.3 GB**; **~1.5 GB with indexes**. (With #1014's payload strip applied: row width drops ~50% → **~0.7 GB**; **~1 GB with indexes**.)
    - `ownership_institutions_current` + `ownership_funds_current`: **conditional on PR12 audit** — current 5.3 GB combined. Post-PR12 (audit + remediate wide-row writes) assumed ≤ 1 GB combined.
    - `ownership_institutions_observations` + `ownership_funds_observations` (8 quarters): current 4.1 GB combined across all-time partitions. 8-quarter cap retains 8 of ~64 partitions populated → ≈ 4.1 GB × 8/64 ≈ **~0.5 GB**.
    - `ownership_insiders_observations` (3y from current 316 MB across ~64 partitions): 316 MB × 12/64 ≈ **~60 MB**.
@@ -391,8 +358,8 @@ Clean re-run after caps land (revised per Codex 1a §2 + §7):
    - **Honest totals**:
      - **PR12 unsolved**: 7 + 1 + 5.3 + 0.5 + 0.06 + 0.15 ≈ **14 GB raw**, **~17 GB with 20% overhead**.
      - **PR12 solved**: 7 + 1 + 1 + 0.5 + 0.06 + 0.15 ≈ **9.7 GB raw**, **~12 GB with 20% overhead**.
-   - Operator acceptance tiers (all measured AFTER the post-PR1-PR12 wipe + clean re-run — the wipe gate per §7 is unconditional on PR1-PR12 having merged; the *tier* selected for acceptance depends on what state PR12 reached):
-     - **v1 bar — `<20 GB hot`**: PR12 merged with audit complete but remediation partial / deferred (current snapshots remain near 5.3 GB combined). ~57% reduction from current 43 GB. Acceptable for v1 ship.
+   - Operator acceptance tiers (all measured AFTER the §6.3 pre-wipe + clean re-run; the *tier* selected for acceptance depends on what state PR12 reached at wipe time):
+     - **v1 bar — `<20 GB hot`**: PR12 audit complete + caps merged but remediation partial / deferred (current snapshots remain near 5.3 GB combined under whatever the audit identifies as the cause). ~57% reduction from current 43 GB. Acceptable for v1 ship.
      - **Phase 2 stretch — `<15 GB hot`**: PR12 fully solved (current snapshots ≤ 1 GB combined). ~65% reduction.
      - **Ambitious stretch — `<10 GB hot`**: only achievable by also tightening companyfacts (e.g. 10y cap instead of 20y; concept whitelist trimmed to ~20 numeric concepts). Not in PR1-PR12 scope — proposed as a Phase 3 ticket if Phase 2 lands and storage remains a concern.
 3. **Chart pages**: every chart in §5.1 renders correctly for the standard panel (AAPL, GME, MSFT, JPM, HD) — Cypress / Playwright golden path.
@@ -406,7 +373,8 @@ Clean re-run after caps land (revised per Codex 1a §2 + §7):
 - **Insider horizon**: 3y or 5y for Form 4? Trade-off: cluster-buy signal richness vs ingest budget. Bias to 3y. Resolution depends on PR4 verification of `ownership_insiders_current` rollup semantics.
 - **8-K chart depth**: 2y or 3y? Trade-off: visual continuity vs storage. Bias to 2y. (Query-window only; doesn't affect retention.)
 - **`ownership_*_current` size oddity (PR12)**: biggest unknown affecting §8 DB-size target. Three-tier acceptance: v1 bar `<20 GB`, Phase 2 stretch `<15 GB` (PR12 solved), ambitious `<10 GB` (PR12 + companyfacts further tightening — Phase 3 if needed).
-- **Wipe gating**: clean re-run gate per §7 specifies PR1-PR12 must all land before wipe. Acceptance §8 is measured AFTER the clean re-run, so both tiers are evaluated against the same post-wipe state — no ambiguity in the gate.
+- **Wipe gating**: §6.3 + §7 specify that PR1-PR12 must all land before the operator-driven pre-wipe + clean re-run. Acceptance §8 is measured AFTER the clean re-run, so all tiers are evaluated against the same post-wipe state — no ambiguity in the gate.
+- **No piecemeal deletes**: §6.3 removed the per-PR `DELETE` instructions. Every cap in §4 is ingest-side only; existing rows are untouched until the single pre-wipe event. The trade-off is that the in-place 43 GB dev DB stays that size until the wipe — which is fine because the wipe is already on the operator's roadmap and is the only honest way to measure post-cap steady-state.
 - **Form 144 alert**: out of this spec, but the metadata is there in `filing_events` if a future ticket activates it.
 
 ## 10. Out of scope
@@ -429,25 +397,28 @@ Per #1208 cadence:
 - Implementation plan = separate doc (`docs/superpowers/plans/2026-05-19-data-retention-impl.md`), Codex 1a/1b on that.
 - PRs 1-12 each follow standard #1208 cadence.
 
-## 12. Handover for next session (impl plan kickoff)
+## 12. Handover for next session
+
+State as of this commit:
+
+- PR1 bundles cross-cutting code (country populate + is_tradable filter audit + lint guard) AND this spec revision (drop-policy → ingest-side-caps-only).
+- PR2 (#1237) + PR5 NUMERIC fix (#1236) already shipped.
+- PR3-PR12 remain — every one is ingest-side cap only, no row deletion. The pre-wipe is the single operator event at the end.
 
 ```text
-Pick up the impl-plan write-up for the data retention rubric spec at
-docs/superpowers/specs/2026-05-19-data-retention-rubric.md.
+After PR1 merges, the next session picks up PR3
+(filing_events 10y rolling cap at the parser).
 
-Spec is post-Codex (1a + 1b + 1c + 1d, all clean). After spec PR
-merges, write the impl plan covering
-PRs 1-12 with per-PR scope + LOC estimate + Codex gate + acceptance
-per PR.
-
-Wipe + clean re-run gated on PR1-PR12 landing.
+PR3 scope:
+- Identify every filing_events discovery writer (Atom fast-lane, daily-index
+  reconcile, first-install drain, per-CIK poll, targeted rebuild).
+- Apply 10y depth cap at the parser layer so every writer respects it.
+- Preserve raw_payload_json (#1014 is the separate slice).
+- No DELETE of pre-10y rows. They survive until the §6.3 pre-wipe.
 
 FIRST ACTIONS:
-1. Read CLAUDE.md working order + this spec end-to-end.
-2. Confirm #1233 + #1228 + #1234 still OPEN.
-3. Branch `feature/1233-data-retention-rubric-spec` is already created
-   (this session's branch).
-4. If Codex 1b not yet run: run it. Else: commit spec; push; create PR;
-   iterate to APPROVE; merge.
-5. Next session = impl plan.
+1. Read CLAUDE.md working order + the revised §3.3 / §4.2 / §6.3 / §7.
+2. Confirm PR1 merged. Confirm #1233 still OPEN as the umbrella.
+3. Branch `feature/1233-pr3-filing-events-10y-cap`.
+4. Codex 1a on plan, then Codex 2 pre-push, then PR.
 ```

--- a/scripts/check_instruments_inserts.sh
+++ b/scripts/check_instruments_inserts.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# Lint guard: every ``INSERT INTO instruments`` MUST list ``is_tradable``
+# in its column list. #1233 §6.2 + prevention-log §"INSERT INTO
+# instruments fixtures must supply is_tradable".
+#
+# Why: ``is_tradable`` is the universe filter for SEC bootstrap entry
+# points (#1233 §6.2). A row inserted without it relies on the
+# ``DEFAULT TRUE`` in sql/001 — which silently corrupts the fixture's
+# contract on any future schema migration that removes the default,
+# AND obscures the operator-visible "delisted vs tradable" signal at
+# the row's birth.
+#
+# The prevention-log entry called for the gate on ``tests/fixtures/``
+# only; #1233 extends it to the whole tree (``app/`` + ``tests/``)
+# because the same risk applies to any production write site.
+#
+# Codex 1a hardening pass (PR1 #1233 review):
+#
+# - **Case-insensitive** (``insert into instruments`` matches as well
+#   as the canonical ``INSERT INTO instruments``).
+# - **Schema-qualified** (``INSERT INTO public.instruments`` matches).
+# - **is_tradable must appear inside the column list** — between the
+#   opening ``(`` after ``instruments`` and the matching ``)`` — not
+#   just somewhere in the 30-line window. Catches the false-negative
+#   where ``is_tradable`` lives in a comment or in an ``ON CONFLICT``
+#   clause without being part of the actual column list.
+#
+# Exits non-zero on the first violation. Designed to be wired into
+# ``.githooks/pre-push`` so a violation blocks the push.
+
+set -euo pipefail
+
+# Search the source tree. Skip Python caches, virtualenvs, and
+# ``.git`` (git's index, packs, and refs would otherwise eat the
+# subprocess with binary noise).
+SEARCH_DIRS=(app tests sql scripts)
+# Files allowed to mention the pattern outside a real INSERT — the
+# guard script + its self-test + Markdown docs. Without this, the
+# script flags its own comments + its test's synthetic violations.
+SKIP_BASENAMES=("check_instruments_inserts.sh" "test_check_instruments_inserts_lint.py")
+# Case-insensitive pattern accepting optional ``schema.`` prefix.
+PATTERN_GREP='[Ii][Nn][Ss][Ee][Rr][Tt][[:space:]]+[Ii][Nn][Tt][Oo][[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*\.)?[Ii][Nn][Ss][Tt][Rr][Uu][Mm][Ee][Nn][Tt][Ss]\b'
+# Awk regex for the same opener (used to start the column-list slice).
+PATTERN_AWK='[Ii][Nn][Ss][Ee][Rr][Tt][[:space:]]+[Ii][Nn][Tt][Oo][[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*\.)?[Ii][Nn][Ss][Tt][Rr][Uu][Mm][Ee][Nn][Tt][Ss]'
+
+violations=0
+violation_files=()
+
+# Extract the (column, list) between the first ``(`` and the matching
+# ``)`` after an ``INSERT INTO instruments`` opener. The matching
+# accounts for newlines: the ``(`` may appear on a later line.
+# Returns the column-list text on stdout, or empty if no balanced
+# parens found within the candidate window.
+extract_column_list() {
+  local file="$1"
+  local start_line="$2"
+  # Read up to 100 lines from the opener — long enough for the most
+  # verbose INSERT in the tree, short enough that pathological files
+  # don't slow the gate.
+  local window_end=$((start_line + 100))
+  # ``LANG=C`` so awk uses byte semantics rather than the locale's
+  # multibyte semantics, which choke on non-UTF8 fixture bytes
+  # ("illegal byte sequence" abort under the default C.UTF-8 locale).
+  LANG=C awk -v start="$start_line" -v end="$window_end" -v pat="$PATTERN_AWK" '
+    BEGIN { found_open = 0; depth = 0; buffer = ""; lines_scanned = 0 }
+    NR < start { next }
+    NR > end { exit }
+    {
+      lines_scanned++
+      # If we have not seen the opening ``(`` within 5 lines of the
+      # opener match, the pattern is almost certainly inside a
+      # docstring / prose / comment — silently bail (no output) so
+      # the caller treats it as a non-match, not a violation.
+      if (!found_open && lines_scanned > 5) {
+        exit
+      }
+      line = $0
+      # On the opener line, drop everything up to and including the
+      # ``instruments`` token so we start matching parens at the
+      # column list, not at a syntactically-irrelevant earlier ``(``.
+      if (NR == start) {
+        sub(pat, "", line)
+      }
+      for (i = 1; i <= length(line); i++) {
+        ch = substr(line, i, 1)
+        if (!found_open) {
+          if (ch == "(") {
+            found_open = 1
+            depth = 1
+            continue
+          }
+          # Bail if we hit "VALUES" before any "(" — that means the
+          # INSERT used positional column list elsewhere or is
+          # malformed for our purposes.
+          rest = substr(line, i, 6)
+          if (toupper(rest) == "VALUES") {
+            exit
+          }
+          # Skip non-( non-VALUES chars without bailing on the line.
+          continue
+        }
+        if (ch == "(") {
+          depth++
+          buffer = buffer ch
+        } else if (ch == ")") {
+          depth--
+          if (depth == 0) {
+            print buffer
+            exit
+          }
+          buffer = buffer ch
+        } else {
+          buffer = buffer ch
+        }
+      }
+      if (found_open) {
+        buffer = buffer "\n"
+      }
+    }
+  ' "$file"
+}
+
+for dir in "${SEARCH_DIRS[@]}"; do
+  if [[ ! -d "${dir}" ]]; then
+    continue
+  fi
+  while IFS= read -r file; do
+    [[ -z "${file}" ]] && continue
+    # Skip files explicitly allowed to mention the pattern.
+    basename="${file##*/}"
+    skip=0
+    for sb in "${SKIP_BASENAMES[@]}"; do
+      if [[ "${basename}" == "${sb}" ]]; then
+        skip=1
+        break
+      fi
+    done
+    if (( skip )); then continue; fi
+    # Also skip Markdown — docstrings/specs may quote the pattern.
+    if [[ "${file}" == *.md ]]; then continue; fi
+    # For each opener line, slice out the actual column list and
+    # check ``is_tradable`` appears there.
+    while IFS=: read -r lineno _; do
+      [[ -z "${lineno}" ]] && continue
+      column_list="$(extract_column_list "${file}" "${lineno}")"
+      if [[ -z "${column_list}" ]]; then
+        # No balanced column list found within 5 lines of the
+        # opener — almost certainly a docstring / prose mention,
+        # not a real INSERT. Skip silently. The trade-off: a
+        # genuinely malformed INSERT (e.g. a stray ``INSERT INTO
+        # instruments`` followed by nothing) slips past. We accept
+        # that — such a statement would fail at parse time anyway,
+        # so the cost of a missed lint is bounded.
+        continue
+      fi
+      # Case-insensitive ``is_tradable`` match inside the column list.
+      if ! echo "${column_list}" | grep -qi 'is_tradable'; then
+        echo "::error file=${file},line=${lineno}::INSERT INTO instruments without is_tradable in column list"
+        violations=$((violations + 1))
+        violation_files+=("${file}:${lineno}")
+      fi
+    done < <(grep -nE "${PATTERN_GREP}" "${file}" || true)
+  done < <(grep -rlE "${PATTERN_GREP}" "${dir}" 2>/dev/null \
+             --exclude-dir=__pycache__ \
+             --exclude-dir=.venv \
+             --exclude-dir=.git \
+             --exclude='*.pyc' || true)
+done
+
+if (( violations > 0 )); then
+  echo ""
+  echo "FAIL: ${violations} INSERT INTO instruments site(s) missing is_tradable in the column list."
+  echo "Every write to the instruments table must set is_tradable explicitly — see #1233 §6.2 +"
+  echo "docs/review-prevention-log.md §'INSERT INTO instruments fixtures must supply is_tradable'."
+  echo ""
+  echo "Violating sites:"
+  for v in "${violation_files[@]}"; do
+    echo "  - ${v}"
+  done
+  exit 1
+fi
+
+echo "OK: every INSERT INTO instruments includes is_tradable in the column list."

--- a/sql/158_instruments_country_backfill.sql
+++ b/sql/158_instruments_country_backfill.sql
@@ -1,0 +1,43 @@
+-- 158: instruments.country — backfill from exchanges.country via instrument.exchange = exchange_id (#1233 §6.1)
+--
+-- Pre-existing `instruments.country` column (sql/001_init.sql) is 100% NULL
+-- because the eToro instruments endpoint does not expose country
+-- (see app/providers/implementations/etoro.py:350 — `country=None`).
+--
+-- The `exchanges` table (sql/067 + sql/068) already carries
+-- operator-curated `country` (ISO 3166-1 alpha-2) per exchange_id.
+-- This migration derives `instruments.country` from `exchanges.country`
+-- via `instruments.exchange = exchanges.exchange_id`.
+--
+-- Forward-compat: `app/services/universe.py` is updated in the same PR
+-- to derive country from the exchanges join on every upsert, so future
+-- universe syncs keep the value fresh as new exchanges land. This
+-- migration handles the one-shot backfill for rows already present.
+--
+-- Effect (dev DB at writing): ~10k rows updated (~80% of universe,
+-- matches the curated us_equity + non-equity asset_class set). Crypto /
+-- FX / index instruments stay NULL because exchanges.country is NULL
+-- for those asset classes (intentional — they have no country).
+--
+-- Migration is tx-wrapped by the runner — no explicit BEGIN/COMMIT.
+
+UPDATE instruments i
+SET country = e.country
+FROM exchanges e
+WHERE i.exchange = e.exchange_id
+  AND e.country IS NOT NULL
+  AND i.country IS DISTINCT FROM e.country;
+
+-- Index supports the cross-cutting "SEC ingest filters US-only via
+-- instruments.country='US'" pattern surfaced by #1233 §6.1. The
+-- universe filter (`is_tradable = TRUE`) already has its own index
+-- (idx_instruments_tradable from sql/001).
+CREATE INDEX IF NOT EXISTS idx_instruments_country
+    ON instruments (country);
+
+COMMENT ON COLUMN instruments.country IS
+    'ISO 3166-1 alpha-2 country code derived from exchanges.country '
+    '(via instruments.exchange = exchanges.exchange_id). NULL when the '
+    'exchange has no curated country (crypto, FX, index). Set by '
+    'sql/158 backfill + maintained by app/services/universe.py upsert. '
+    '#1233 §6.1.';

--- a/tests/services/test_business_summary_accession.py
+++ b/tests/services/test_business_summary_accession.py
@@ -15,7 +15,8 @@ from app.services.business_summary import (
 def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "GSE2", iid: int = 199) -> int:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
             (iid, symbol, "Test Co Accession"),
         )
         row = cur.fetchone()

--- a/tests/services/test_business_summary_history.py
+++ b/tests/services/test_business_summary_history.py
@@ -20,7 +20,8 @@ VALUES (%s, %s, %s, %s, %s, NULL, NULL)
 def _seed_instrument(conn: psycopg.Connection[tuple], iid: int = 5590) -> int:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
             (iid, "TEST559P2", "Test 559 P2"),
         )
         row = cur.fetchone()

--- a/tests/services/test_business_summary_tables.py
+++ b/tests/services/test_business_summary_tables.py
@@ -17,7 +17,8 @@ from app.services.business_summary import (
 def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "GSE", iid: int = 99) -> int:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
             (iid, symbol, "Test Co Tables"),
         )
         row = cur.fetchone()

--- a/tests/test_agent_cik_defense.py
+++ b/tests/test_agent_cik_defense.py
@@ -154,8 +154,8 @@ def _seed(
     )
     conn.execute(
         """
-        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
-        VALUES (%s, %s, %s, %s)
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+        VALUES (%s, %s, %s, %s, TRUE)
         ON CONFLICT (instrument_id) DO NOTHING
         """,
         (instrument_id, symbol, f"Test {symbol}", f"acd_{instrument_id}"),

--- a/tests/test_backfill_company_facts.py
+++ b/tests/test_backfill_company_facts.py
@@ -41,8 +41,8 @@ def _seed(
     )
     conn.execute(
         """
-        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
-        VALUES (%s, %s, %s, %s)
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+        VALUES (%s, %s, %s, %s, TRUE)
         ON CONFLICT (instrument_id) DO NOTHING
         """,
         (instrument_id, symbol, f"Test {symbol}", f"bcf_{instrument_id}"),

--- a/tests/test_backfill_xbrl_normalization.py
+++ b/tests/test_backfill_xbrl_normalization.py
@@ -39,8 +39,8 @@ def _seed_instrument(
     )
     conn.execute(
         """
-        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
-        VALUES (%s, %s, %s, %s)
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+        VALUES (%s, %s, %s, %s, TRUE)
         ON CONFLICT (instrument_id) DO NOTHING
         """,
         (instrument_id, symbol, f"Test {symbol}", f"bxn_{instrument_id}"),

--- a/tests/test_business_summary_ingest.py
+++ b/tests/test_business_summary_ingest.py
@@ -30,7 +30,8 @@ class _StubFetcher:
 def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "MMM", iid: int = 77) -> int:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
             (iid, symbol, "Test Co"),
         )
         row = cur.fetchone()

--- a/tests/test_check_instruments_inserts_lint.py
+++ b/tests/test_check_instruments_inserts_lint.py
@@ -1,0 +1,265 @@
+"""Unit test for scripts/check_instruments_inserts.sh (#1233 §6.2).
+
+The lint guard is wired into ``.githooks/pre-push`` so a push that
+introduces an ``INSERT INTO instruments`` site without ``is_tradable``
+in the column list is rejected. This test pins three contracts:
+
+1. The current tree passes (a regression test — any developer who
+   adds a violating INSERT will see this test fail locally before
+   the push gate fires).
+2. The guard returns non-zero + names the offending file when a
+   synthetic violation is introduced in a temp directory.
+3. The guard returns zero when the same synthetic INSERT includes
+   ``is_tradable`` in the column list.
+
+The shell script lives at the project root; the test invokes it via
+``bash`` with the synthetic dir as the only ``SEARCH_DIRS`` candidate
+(by writing it under a ``tests`` subdir that's part of the guard's
+default search list).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUARD = REPO_ROOT / "scripts" / "check_instruments_inserts.sh"
+
+
+def test_guard_passes_on_clean_tree() -> None:
+    """The current source tree must pass the guard. Any developer who
+    adds a violating INSERT (forgotten is_tradable) sees this fail."""
+    result = subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Lint guard failed on clean tree:\n"
+        f"STDOUT: {result.stdout}\n"
+        f"STDERR: {result.stderr}\n"
+        f"Every INSERT INTO instruments must list is_tradable explicitly."
+    )
+
+
+def test_guard_fails_on_synthetic_violation(tmp_path: Path) -> None:
+    """A synthetic INSERT without is_tradable must trip the guard."""
+    # The guard walks SEARCH_DIRS=(app tests sql scripts) relative to
+    # CWD. We point CWD at tmp_path with a synthetic ``tests`` subdir
+    # so the guard finds the violation but doesn't see the real repo.
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    violation = tests_dir / "synthetic_bad.py"
+    violation.write_text(
+        '"""Intentional violation for lint guard test."""\n'
+        'BAD_SQL = """\n'
+        "INSERT INTO instruments (instrument_id, symbol, company_name)\n"
+        "VALUES (1, 'TEST', 'Test')\n"
+        '"""\n'
+    )
+    result = subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1, (
+        f"Expected guard to fail; got returncode={result.returncode}.\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    )
+    assert "synthetic_bad.py" in result.stdout, f"Expected violation filename in output:\n{result.stdout}"
+    assert "is_tradable" in result.stdout, f"Expected guard to mention is_tradable in failure message:\n{result.stdout}"
+
+
+def test_guard_passes_when_is_tradable_present(tmp_path: Path) -> None:
+    """An INSERT that includes is_tradable in the column list passes."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    clean = tests_dir / "synthetic_good.py"
+    clean.write_text(
+        '"""Compliant INSERT for lint guard test."""\n'
+        'GOOD_SQL = """\n'
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)\n"
+        "VALUES (1, 'TEST', 'Test', TRUE)\n"
+        '"""\n'
+    )
+    result = subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Expected guard to pass; got returncode={result.returncode}.\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    )
+
+
+def test_guard_window_covers_multiline_inserts(tmp_path: Path) -> None:
+    """An INSERT statement whose column list is split across the
+    opener line and a later line still passes when is_tradable lives
+    inside the 30-line window. Pins the WINDOW_LINES contract."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    multiline = tests_dir / "synthetic_multiline.py"
+    multiline.write_text(
+        '"""Multi-line INSERT — is_tradable lives 5 lines down."""\n'
+        'SQL = """\n'
+        "INSERT INTO instruments (\n"
+        "    instrument_id,\n"
+        "    symbol,\n"
+        "    company_name,\n"
+        "    is_tradable\n"
+        ") VALUES (1, 'TEST', 'Test', TRUE)\n"
+        '"""\n'
+    )
+    result = subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_guard_is_executable() -> None:
+    """The script must have +x set so ``.githooks/pre-push`` can invoke
+    it via ``bash scripts/...`` without permission errors."""
+    assert GUARD.exists(), f"Guard script not found at {GUARD}"
+    # bash invocation works regardless of +x, but +x signals operator
+    # intent. Don't enforce mode bits on Windows checkouts where git
+    # may not preserve them.
+    import os
+    import sys
+
+    if sys.platform != "win32":
+        mode = os.stat(GUARD).st_mode & 0o777
+        assert mode & 0o100, f"Guard script not executable: mode={oct(mode)}"
+
+
+def test_guard_case_insensitive_catches_lowercase(tmp_path: Path) -> None:
+    """Codex 1a hardening: lowercase ``insert into instruments`` must
+    also trip the guard. Catches the false-negative where a developer
+    writes SQL in lowercase to dodge the literal-case match."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    violation = tests_dir / "synthetic_lowercase.py"
+    violation.write_text(
+        '"""Lowercase SQL bypass attempt."""\n'
+        'BAD_SQL = """\n'
+        "insert into instruments (instrument_id, symbol, company_name)\n"
+        "values (1, 'TEST', 'Test')\n"
+        '"""\n'
+    )
+    result = subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "synthetic_lowercase.py" in result.stdout
+
+
+def test_guard_schema_qualified_catches_public_prefix(tmp_path: Path) -> None:
+    """Codex 1a hardening: ``INSERT INTO public.instruments`` must
+    also trip the guard. Catches the false-negative where a schema
+    prefix sneaks past the literal-name match."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    violation = tests_dir / "synthetic_schema.py"
+    violation.write_text(
+        '"""Schema-qualified bypass attempt."""\n'
+        'BAD_SQL = """\n'
+        "INSERT INTO public.instruments (instrument_id, symbol, company_name)\n"
+        "VALUES (1, 'TEST', 'Test')\n"
+        '"""\n'
+    )
+    result = subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "synthetic_schema.py" in result.stdout
+
+
+def test_guard_ignores_is_tradable_outside_column_list(tmp_path: Path) -> None:
+    """Codex 1a hardening: ``is_tradable`` mentioned only in an
+    ``ON CONFLICT`` clause or a trailing comment — but missing from
+    the actual column list — must still fail. The guard slices the
+    column list (between the first ``(`` and matching ``)`` after
+    ``instruments``) and checks ``is_tradable`` lives THERE."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    violation = tests_dir / "synthetic_decoy.py"
+    violation.write_text(
+        '"""Decoy is_tradable outside column list."""\n'
+        'BAD_SQL = """\n'
+        "INSERT INTO instruments (instrument_id, symbol, company_name)\n"
+        "VALUES (1, 'TEST', 'Test')\n"
+        "ON CONFLICT (instrument_id) DO UPDATE SET\n"
+        "  is_tradable = EXCLUDED.is_tradable\n"
+        '"""\n'
+    )
+    result = subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1, (
+        f"Expected guard to fail; got returncode={result.returncode}.\nSTDOUT: {result.stdout}"
+    )
+    assert "synthetic_decoy.py" in result.stdout
+
+
+def test_guard_ignores_pattern_in_docstring_prose(tmp_path: Path) -> None:
+    """The guard must not flag prose / docstrings that quote the
+    pattern. Codex 1a hardening: bail silently when no ``(`` is
+    found within 5 lines of the opener (definitely not a real SQL
+    statement)."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    prose = tests_dir / "synthetic_docstring.py"
+    prose.write_text(
+        '"""Docstring that quotes the pattern in passing.\n'
+        "\n"
+        "Prevention: ``INSERT INTO instruments`` fixtures must supply\n"
+        "is_tradable.  We supply it explicitly even though it has a\n"
+        "default.\n"
+        '"""\n'
+        "\n"
+        "def f() -> None:\n"
+        "    pass\n"
+    )
+    result = subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Guard should not flag docstring prose; got returncode={result.returncode}.\nSTDOUT: {result.stdout}"
+    )
+
+
+@pytest.mark.skip(reason="documentation — pins the prevention-log line that motivates this guard")
+def test_documents_prevention_log_link() -> None:
+    """See docs/review-prevention-log.md §'INSERT INTO instruments
+    fixtures must supply is_tradable' for the original incident.
+
+    The prevention-log entry called for the gate in ``tests/fixtures/``
+    only; #1233 §6.2 extends it to the whole tree via this script.
+    """

--- a/tests/test_dividend_calendar_ingest.py
+++ b/tests/test_dividend_calendar_ingest.py
@@ -44,8 +44,8 @@ def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "KO") -> int
     with conn.cursor() as cur:
         cur.execute(
             """
-            INSERT INTO instruments (instrument_id, symbol, company_name)
-            VALUES (%s, %s, %s)
+            INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+            VALUES (%s, %s, %s, TRUE)
             RETURNING instrument_id
             """,
             (42, symbol, "Test Co"),

--- a/tests/test_eight_k_events_ingest.py
+++ b/tests/test_eight_k_events_ingest.py
@@ -48,7 +48,8 @@ def _seed_item_codes(conn: psycopg.Connection[tuple]) -> None:
 def _seed_instrument(conn: psycopg.Connection[tuple], symbol: str = "APEX", iid: int = 401) -> int:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
             (iid, symbol, "Apex Inc."),
         )
         row = cur.fetchone()

--- a/tests/test_etoro_websocket.py
+++ b/tests/test_etoro_websocket.py
@@ -482,7 +482,7 @@ class TestUpsertQuote:
     def _seed_instrument(self, conn: psycopg.Connection[tuple], iid: int = 1001) -> None:
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s)",
+                "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
                 (iid, "AAPL", "Apple Inc."),
             )
         conn.commit()
@@ -576,11 +576,11 @@ class TestFetchWatchedInstrumentIds:
     def test_returns_held_and_watchlist_union(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         with ebull_test_conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO instruments (instrument_id, symbol, company_name) "
-                "VALUES (1001, 'AAPL', 'Apple'), "
-                "(1002, 'MSFT', 'Microsoft'), "
-                "(1003, 'NVDA', 'Nvidia'), "
-                "(1004, 'GOOG', 'Google')"
+                "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+                "VALUES (1001, 'AAPL', 'Apple', TRUE), "
+                "(1002, 'MSFT', 'Microsoft', TRUE), "
+                "(1003, 'NVDA', 'Nvidia', TRUE), "
+                "(1004, 'GOOG', 'Google', TRUE)"
             )
             # Held = 1001, 1002. Watchlist = 1002, 1003. Result should
             # be the union {1001, 1002, 1003}; 1004 (neither) stays out.

--- a/tests/test_filings_bulk_resolve.py
+++ b/tests/test_filings_bulk_resolve.py
@@ -71,8 +71,8 @@ def _seed_instrument(
     )
     conn.execute(
         """
-        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
-        VALUES (%s, %s, %s, %s)
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+        VALUES (%s, %s, %s, %s, TRUE)
         ON CONFLICT (instrument_id) DO NOTHING
         """,
         (instrument_id, symbol, f"Test {symbol}", f"test_bulk_{instrument_id}"),

--- a/tests/test_filings_cancel_signal.py
+++ b/tests/test_filings_cancel_signal.py
@@ -69,8 +69,8 @@ def _seed_instrument_with_cik(
     )
     conn.execute(
         """
-        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
-        VALUES (%s, %s, %s, %s)
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+        VALUES (%s, %s, %s, %s, TRUE)
         ON CONFLICT (instrument_id) DO NOTHING
         """,
         (instrument_id, symbol, f"Test {symbol}", f"test_cancel_{instrument_id}"),

--- a/tests/test_finra_regsho_daily_ingest.py
+++ b/tests/test_finra_regsho_daily_ingest.py
@@ -52,8 +52,8 @@ _TRADE_DATE = date(2026, 5, 15)
 def _seed_instrument(conn: psycopg.Connection[tuple], *, instrument_id: int, symbol: str) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) "
-            "VALUES (%s, %s, %s) ON CONFLICT (instrument_id) DO NOTHING",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) ON CONFLICT (instrument_id) DO NOTHING",
             (instrument_id, symbol, symbol),
         )
 

--- a/tests/test_finra_regsho_daily_refresh.py
+++ b/tests/test_finra_regsho_daily_refresh.py
@@ -31,8 +31,8 @@ _EMPTY_FNRA = Path("tests/fixtures/finra/regsho/FNRA_empty_20260515.txt")
 def _seed_instrument(conn: psycopg.Connection[tuple], *, instrument_id: int, symbol: str) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) "
-            "VALUES (%s, %s, %s) ON CONFLICT (instrument_id) DO NOTHING",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) ON CONFLICT (instrument_id) DO NOTHING",
             (instrument_id, symbol, symbol),
         )
 

--- a/tests/test_finra_short_interest_ingest.py
+++ b/tests/test_finra_short_interest_ingest.py
@@ -47,8 +47,8 @@ _DEFECTS = Path("tests/fixtures/finra/shrt20260430_defects.csv")
 def _seed_instrument(conn: psycopg.Connection[tuple], *, instrument_id: int, symbol: str) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) "
-            "VALUES (%s, %s, %s) ON CONFLICT (instrument_id) DO NOTHING",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) ON CONFLICT (instrument_id) DO NOTHING",
             (instrument_id, symbol, symbol),
         )
 

--- a/tests/test_finra_short_interest_refresh.py
+++ b/tests/test_finra_short_interest_refresh.py
@@ -45,8 +45,8 @@ _PRISTINE = Path("tests/fixtures/finra/shrt20260430_sample.csv")
 def _seed_instrument(conn: psycopg.Connection[tuple], *, instrument_id: int, symbol: str) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) "
-            "VALUES (%s, %s, %s) ON CONFLICT (instrument_id) DO NOTHING",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) ON CONFLICT (instrument_id) DO NOTHING",
             (instrument_id, symbol, symbol),
         )
 

--- a/tests/test_force_refresh_fundamentals.py
+++ b/tests/test_force_refresh_fundamentals.py
@@ -40,8 +40,8 @@ def _seed(
     )
     ebull_test_conn.execute(
         """
-        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
-        VALUES (%s, %s, %s, %s)
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+        VALUES (%s, %s, %s, %s, TRUE)
         ON CONFLICT (instrument_id) DO NOTHING
         """,
         (instrument_id, symbol, f"Test {symbol}", f"frt_{instrument_id}"),

--- a/tests/test_insider_form3_ingest.py
+++ b/tests/test_insider_form3_ingest.py
@@ -46,7 +46,8 @@ class _StubFetcher:
 def _seed_instrument(conn: psycopg.Connection[tuple], iid: int = 991, symbol: str = "AAPL") -> int:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
             (iid, symbol, "Test Co"),
         )
         row = cur.fetchone()

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -57,7 +57,8 @@ class _StubFetcher:
 def _seed_instrument(conn: psycopg.Connection[tuple], iid: int = 99, symbol: str = "AAPL") -> int:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) VALUES (%s, %s, %s) RETURNING instrument_id",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
             (iid, symbol, "Test Co"),
         )
         row = cur.fetchone()

--- a/tests/test_migration_072_073_drop_fmp.py
+++ b/tests/test_migration_072_073_drop_fmp.py
@@ -182,8 +182,8 @@ def test_073_purges_fundamentals_snapshot_for_non_sec_cik_instruments(
             (exchange_id,),
         )
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name, exchange) "
-            "VALUES (%s, 'TST073A', 'Test 073 A', %s), (%s, 'TST073B', 'Test 073 B', %s)",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable) "
+            "VALUES (%s, 'TST073A', 'Test 073 A', %s, TRUE), (%s, 'TST073B', 'Test 073 B', %s, TRUE)",
             (sec_id, exchange_id, fmp_id, exchange_id),
         )
         # SEC-CIK on sec_id; fmp_id has no SEC CIK (FMP-only).

--- a/tests/test_migration_158_country_backfill.py
+++ b/tests/test_migration_158_country_backfill.py
@@ -1,0 +1,179 @@
+"""Regression tests for migration 158 (#1233 §6.1).
+
+Pins two contracts of the migration against a real ``ebull_test`` DB:
+
+1. ``instruments.country`` index exists (``idx_instruments_country``)
+   so the cross-cutting ``WHERE country='US'`` SEC filter has an
+   index-backed lookup path.
+2. The backfill UPDATE derives ``instruments.country`` from
+   ``exchanges.country`` via the ``instruments.exchange =
+   exchanges.exchange_id`` join, only when ``exchanges.country IS NOT
+   NULL`` (crypto / FX / index exchanges leave the instrument's
+   country NULL — they have no country).
+
+The migration runs at fixture setup so the index check passes by
+construction. The backfill SQL is re-executed inline against synthetic
+rows so the test pins the behaviour even if a later migration or a
+universe-sync upsert mutates the canonical instrument rows between
+test runs.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# Verbatim from sql/158_instruments_country_backfill.sql so a refactor
+# that changes the SQL is caught by this test failing rather than by
+# the auto-applied migration succeeding once and never being checked.
+_BACKFILL_SQL = """
+UPDATE instruments i
+SET country = e.country
+FROM exchanges e
+WHERE i.exchange = e.exchange_id
+  AND e.country IS NOT NULL
+  AND i.country IS DISTINCT FROM e.country
+"""
+
+
+def test_index_idx_instruments_country_exists(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM pg_indexes WHERE indexname = 'idx_instruments_country'",
+        )
+        row = cur.fetchone()
+    assert row is not None, "migration 158 should create idx_instruments_country"
+
+
+def _seed(
+    conn: psycopg.Connection[tuple],
+    *,
+    exchange_id: str,
+    exchange_country: str | None,
+    instrument_id: int,
+    symbol: str,
+    instrument_country: str | None = None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO exchanges (exchange_id, country, asset_class)
+            VALUES (%s, %s, 'us_equity')
+            ON CONFLICT (exchange_id) DO UPDATE SET country = EXCLUDED.country
+            """,
+            (exchange_id, exchange_country),
+        )
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, exchange, country, is_tradable)
+            VALUES (%s, %s, %s, %s, %s, TRUE)
+            ON CONFLICT (instrument_id) DO UPDATE SET
+                country = EXCLUDED.country,
+                exchange = EXCLUDED.exchange
+            """,
+            (instrument_id, symbol, f"Test {symbol}", exchange_id, instrument_country),
+        )
+
+
+def _read_country(conn: psycopg.Connection[tuple], instrument_id: int) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT country FROM instruments WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
+class TestBackfillCountryFromExchanges:
+    def test_us_exchange_populates_country(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+        _seed(
+            ebull_test_conn,
+            exchange_id="9580",
+            exchange_country="US",
+            instrument_id=958001,
+            symbol="MIG158A",
+            instrument_country=None,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_BACKFILL_SQL)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 958001) == "US"
+
+    def test_null_exchange_country_leaves_instrument_null(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed(
+            ebull_test_conn,
+            exchange_id="9581",
+            exchange_country=None,
+            instrument_id=958002,
+            symbol="MIG158B",
+            instrument_country=None,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_BACKFILL_SQL)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 958002) is None
+
+    def test_idempotent_on_already_correct_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``IS DISTINCT FROM`` guard means a re-run of the backfill
+        against a row already matching exchange country does not write
+        anything — the test pins this by asserting ``rowcount=0``."""
+        _seed(
+            ebull_test_conn,
+            exchange_id="9582",
+            exchange_country="GB",
+            instrument_id=958003,
+            symbol="MIG158C",
+            instrument_country="GB",
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_BACKFILL_SQL)
+            # Re-run on the same row scope.
+            cur.execute(
+                _BACKFILL_SQL + " AND i.instrument_id = %s",
+                (958003,),
+            )
+            assert cur.rowcount == 0
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 958003) == "GB"
+
+    def test_overwrites_when_exchange_curator_changes_country(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """If the operator re-curates an exchange from US→GB (and a
+        prior backfill landed US on the instrument), the next backfill
+        propagates the change."""
+        _seed(
+            ebull_test_conn,
+            exchange_id="9583",
+            exchange_country="US",
+            instrument_id=958004,
+            symbol="MIG158D",
+            instrument_country=None,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_BACKFILL_SQL)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 958004) == "US"
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE exchanges SET country = 'GB' WHERE exchange_id = %s",
+                ("9583",),
+            )
+            cur.execute(_BACKFILL_SQL)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 958004) == "GB"

--- a/tests/test_refresh_financial_facts_parallel.py
+++ b/tests/test_refresh_financial_facts_parallel.py
@@ -115,8 +115,8 @@ def _seed_instrument(conn: psycopg.Connection[tuple], instrument_id: int, symbol
     )
     conn.execute(
         """
-        INSERT INTO instruments (instrument_id, symbol, company_name, exchange)
-        VALUES (%s, %s, %s, %s)
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable)
+        VALUES (%s, %s, %s, %s, TRUE)
         ON CONFLICT (instrument_id) DO NOTHING
         """,
         (instrument_id, symbol, f"Test {symbol}", f"rfp_{instrument_id}"),

--- a/tests/test_sec_entity_change_log.py
+++ b/tests/test_sec_entity_change_log.py
@@ -166,8 +166,8 @@ class TestUpsertAppendsChangeLog:
     def _seed_instrument(self, conn: psycopg.Connection[tuple], iid: int = 901) -> int:
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO instruments (instrument_id, symbol, company_name) "
-                "VALUES (%s, %s, %s) RETURNING instrument_id",
+                "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+                "VALUES (%s, %s, %s, TRUE) RETURNING instrument_id",
                 (iid, "APEX", "Apex Inc."),
             )
             row = cur.fetchone()

--- a/tests/test_sec_entry_points_is_tradable_filter.py
+++ b/tests/test_sec_entry_points_is_tradable_filter.py
@@ -1,0 +1,281 @@
+"""SEC entry-point ``is_tradable`` filter audit (#1233 §6.2).
+
+Each of the four SEC ingest entry points modified by PR1 must skip
+delisted instruments (``is_tradable=FALSE``) when building the
+candidate set. Delisted instruments consume bootstrap budget for no
+operator value.
+
+Covered:
+
+1. ``app/services/sec_submissions_ingest.py::_load_cik_to_instrument``
+   — bulk archive walk; CIK → instrument_id map drives every
+   ``ingest_submissions_archive`` write.
+2. ``app/services/sec_submissions_files_walk.py::_list_cik_secondary_pages``
+   — per-CIK secondary-pages walk; same shape.
+3. ``app/services/finra_short_interest_ingest.py::build_preloaded_symbol_resolver``
+   — normalised-symbol resolver; delisted symbols inflate the
+   collision space and force the legitimate active row into the
+   ambiguous bucket.
+4. ``app/services/mf_directory.py::refresh_mf_directory`` —
+   class_id seeding; delisted fund classes burn scheduler budget.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_pair(
+    conn: psycopg.Connection[tuple],
+    *,
+    tradable_id: int,
+    delisted_id: int,
+    cik_tradable: str,
+    cik_delisted: str,
+    symbol_tradable: str,
+    symbol_delisted: str,
+) -> None:
+    """Seed two instruments — one tradable, one delisted — both with
+    SEC CIK external_identifiers. Every entry-point query should
+    return the tradable row only."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+            VALUES (%s, %s, %s, TRUE), (%s, %s, %s, FALSE)
+            ON CONFLICT (instrument_id) DO UPDATE SET
+                is_tradable = EXCLUDED.is_tradable,
+                symbol = EXCLUDED.symbol
+            """,
+            (
+                tradable_id,
+                symbol_tradable,
+                f"Test {symbol_tradable}",
+                delisted_id,
+                symbol_delisted,
+                f"Test {symbol_delisted}",
+            ),
+        )
+        cur.execute(
+            """
+            INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+            VALUES (%s, 'sec', 'cik', %s, TRUE), (%s, 'sec', 'cik', %s, TRUE)
+            ON CONFLICT DO NOTHING
+            """,
+            (tradable_id, cik_tradable, delisted_id, cik_delisted),
+        )
+
+
+class TestSubmissionsIngestCikMapFiltersDelisted:
+    def test_load_cik_to_instrument_skips_delisted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.sec_submissions_ingest import _load_cik_to_instrument
+
+        _seed_pair(
+            ebull_test_conn,
+            tradable_id=820001,
+            delisted_id=820002,
+            cik_tradable="0000820001",
+            cik_delisted="0000820002",
+            symbol_tradable="LIVE820",
+            symbol_delisted="DEAD820",
+        )
+        ebull_test_conn.commit()
+
+        mapping = _load_cik_to_instrument(ebull_test_conn)
+
+        assert "0000820001" in mapping, "tradable CIK must be present"
+        assert "0000820002" not in mapping, "delisted CIK must be filtered (#1233 §6.2)"
+
+
+class TestSubmissionsFilesWalkFiltersDelisted:
+    def test_load_cik_universe_skips_delisted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.sec_submissions_files_walk import _list_cik_secondary_pages
+
+        _seed_pair(
+            ebull_test_conn,
+            tradable_id=830001,
+            delisted_id=830002,
+            cik_tradable="0000830001",
+            cik_delisted="0000830002",
+            symbol_tradable="LIVE830",
+            symbol_delisted="DEAD830",
+        )
+        ebull_test_conn.commit()
+
+        rows = _list_cik_secondary_pages(ebull_test_conn)
+
+        ciks = {cik for _, cik, _ in rows}
+        assert "0000830001" in ciks
+        assert "0000830002" not in ciks, "delisted CIK must be filtered (#1233 §6.2)"
+
+
+class TestFinraResolverFiltersDelisted:
+    def test_preloaded_symbol_resolver_skips_delisted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.finra_short_interest_ingest import build_preloaded_symbol_resolver
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+                VALUES (%s, %s, %s, TRUE), (%s, %s, %s, FALSE)
+                ON CONFLICT (instrument_id) DO UPDATE SET
+                    is_tradable = EXCLUDED.is_tradable,
+                    symbol = EXCLUDED.symbol
+                """,
+                (
+                    870001,
+                    "LIVE870",
+                    "Test Live 870",
+                    870002,
+                    "DEAD870",
+                    "Test Dead 870",
+                ),
+            )
+        ebull_test_conn.commit()
+
+        resolver = build_preloaded_symbol_resolver(ebull_test_conn)
+
+        assert resolver("LIVE870") == 870001
+        assert resolver("DEAD870") is None, "delisted symbol must not resolve via FINRA SI resolver (#1233 §6.2)"
+
+    def test_delisted_does_not_create_ambiguous_collision(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A delisted symbol whose normalised key collides with a
+        tradable instrument's normalised key must NOT push the
+        tradable into the ambiguous bucket — because the delisted row
+        is filtered before normalisation."""
+        from app.services.finra_short_interest_ingest import build_preloaded_symbol_resolver, normalise_symbol
+
+        # Both normalise to "ZBRK872" so they would collide if the
+        # delisted row were retained.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+                VALUES (%s, 'ZBRK872.A', 'Live class A', TRUE),
+                       (%s, 'ZBRK872A',  'Delisted plain', FALSE)
+                ON CONFLICT (instrument_id) DO UPDATE SET
+                    is_tradable = EXCLUDED.is_tradable,
+                    symbol = EXCLUDED.symbol
+                """,
+                (872001, 872002),
+            )
+        ebull_test_conn.commit()
+
+        # Confirm the two normalise to the same key (so the test is
+        # meaningful — if normalise_symbol changes, this guard wakes).
+        assert normalise_symbol("ZBRK872.A") == normalise_symbol("ZBRK872A")
+
+        resolver = build_preloaded_symbol_resolver(ebull_test_conn)
+
+        # The tradable row resolves cleanly; the delisted one is
+        # filtered out before it can collide.
+        assert resolver("ZBRK872.A") == 872001
+
+
+class TestMfDirectoryFiltersDelisted:
+    def test_refresh_mf_directory_skips_delisted_fund_class(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``refresh_mf_directory`` resolves each fund-class symbol →
+        ``instrument_id`` via ``instruments`` and seeds an
+        ``external_identifiers (provider='sec', identifier_type='class_id')``
+        row only when the instrument is tradable. A delisted fund
+        class with the same symbol must NOT receive a class_id
+        external_identifier row.
+
+        This exercises the production ``refresh_mf_directory`` body
+        (Codex 1a #5 hardening — the prior SQL-only test pinned
+        only the SELECT shape, not the writer's behaviour)."""
+        import json
+
+        from app.services import mf_directory as mf_directory_module
+
+        # Seed two universe instruments sharing different symbols —
+        # one tradable, one delisted.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+                VALUES (%s, 'LIVEFUND880', 'Live fund', TRUE),
+                       (%s, 'DEADFUND880', 'Delisted fund', FALSE)
+                ON CONFLICT (instrument_id) DO UPDATE SET
+                    is_tradable = EXCLUDED.is_tradable,
+                    symbol = EXCLUDED.symbol
+                """,
+                (880001, 880002),
+            )
+        ebull_test_conn.commit()
+
+        # Stub ``_fetch_directory`` so the test doesn't hit
+        # data.sec.gov. Payload shape matches the real
+        # ``company_tickers_mf.json`` (fields + data rows).
+        payload = {
+            "fields": ["cik", "seriesId", "classId", "symbol"],
+            "data": [
+                # Tradable row — should seed class_id.
+                [1234567, "S000000001", "C000000001", "LIVEFUND880"],
+                # Delisted row — must NOT seed class_id (#1233 §6.2).
+                [1234568, "S000000002", "C000000002", "DEADFUND880"],
+            ],
+        }
+
+        def fake_fetch(provider: object) -> dict[str, object]:
+            return json.loads(json.dumps(payload))
+
+        monkeypatch.setattr(mf_directory_module, "_fetch_directory", fake_fetch)
+
+        # ``provider`` is unused (fake_fetch ignores it); pass a
+        # sentinel so the function doesn't try to open the real one.
+        class _NoOpProvider:
+            def __enter__(self) -> _NoOpProvider:
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                pass
+
+        result = mf_directory_module.refresh_mf_directory(
+            ebull_test_conn,
+            provider=_NoOpProvider(),  # type: ignore[arg-type]
+        )
+
+        # Both directory rows land in ``cik_refresh_mf_directory``
+        # (that table is the SEC mirror, no is_tradable filter).
+        assert result["directory_rows"] == 2
+
+        # Only the tradable row seeds a class_id external_identifier.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT instrument_id, identifier_value
+                FROM external_identifiers
+                WHERE provider = 'sec'
+                  AND identifier_type = 'class_id'
+                  AND identifier_value IN ('C000000001', 'C000000002')
+                """
+            )
+            ext_rows = cur.fetchall()
+        ebull_test_conn.commit()
+
+        assert ext_rows == [(880001, "C000000001")], (
+            f"Expected only the tradable instrument's class_id to seed; got {ext_rows!r}. "
+            "#1233 §6.2 — delisted fund classes must not seed class_id."
+        )

--- a/tests/test_sec_master_idx_quarterly_sweep.py
+++ b/tests/test_sec_master_idx_quarterly_sweep.py
@@ -78,8 +78,8 @@ def _seed_issuer(
     """
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO instruments (instrument_id, symbol, company_name) "
-            "VALUES (%s, %s, %s) ON CONFLICT (instrument_id) DO NOTHING",
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+            "VALUES (%s, %s, %s, TRUE) ON CONFLICT (instrument_id) DO NOTHING",
             (instrument_id, symbol, company_name or symbol),
         )
         cur.execute(

--- a/tests/test_universe_normaliser.py
+++ b/tests/test_universe_normaliser.py
@@ -368,3 +368,154 @@ class TestUniverseInstrumentTypeUpsert:
         sync_universe(provider, ebull_test_conn)
         ebull_test_conn.commit()
         assert _read_instrument_type_id(ebull_test_conn, 950012) == 6
+
+
+# ---------------------------------------------------------------------------
+# sync_universe — country derives from exchanges.country (#1233 §6.1)
+# ---------------------------------------------------------------------------
+
+
+def _read_country(conn: psycopg.Connection[tuple], instrument_id: int) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT country FROM instruments WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
+def _seed_exchange(conn: psycopg.Connection[tuple], *, exchange_id: str, country: str | None, asset_class: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO exchanges (exchange_id, country, asset_class)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (exchange_id) DO UPDATE SET country = EXCLUDED.country, asset_class = EXCLUDED.asset_class
+            """,
+            (exchange_id, country, asset_class),
+        )
+
+
+def _make_record_with_exchange(
+    *,
+    provider_id: str,
+    symbol: str,
+    exchange: str | None,
+) -> InstrumentRecord:
+    return InstrumentRecord(
+        provider_id=provider_id,
+        symbol=symbol,
+        company_name=f"{symbol} Co.",
+        exchange=exchange,
+        currency="USD",
+        sector=None,
+        industry=None,
+        country=None,  # provider does not supply country (#1233 §6.1)
+        is_tradable=True,
+        instrument_type=None,
+        instrument_type_id=None,
+    )
+
+
+@pytest.mark.integration
+class TestUniverseCountryDerivesFromExchanges:
+    """``instruments.country`` is derived from ``exchanges.country`` via
+    the ``instruments.exchange = exchanges.exchange_id`` join — eToro
+    does not expose country in the instruments endpoint (#1233 §6.1)."""
+
+    def test_us_exchange_populates_country_us(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # exchange_id='4' is curated as US equity per sql/067.
+        _seed_exchange(ebull_test_conn, exchange_id="4", country="US", asset_class="us_equity")
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="970001", symbol="USEQ1", exchange="4"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 970001) == "US"
+
+    def test_country_null_for_uncurated_exchange(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Crypto exchange has NULL country in seed (sql/067 line 92).
+        _seed_exchange(ebull_test_conn, exchange_id="8", country=None, asset_class="crypto")
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="970002", symbol="CRYPTO1", exchange="8"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 970002) is None
+
+    def test_country_refreshes_when_operator_recurates_exchange(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """Operator re-classifies an exchange from NULL→'US'; the next
+        sync_universe pass propagates the new country."""
+        _seed_exchange(ebull_test_conn, exchange_id="970", country=None, asset_class="unknown")
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="970003", symbol="RECLASS", exchange="970"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 970003) is None
+
+        # Operator curates the exchange.
+        _seed_exchange(ebull_test_conn, exchange_id="970", country="GB", asset_class="uk_equity")
+        ebull_test_conn.commit()
+
+        # Next provider pass — country derives fresh from the join.
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 970003) == "GB"
+
+    def test_missing_exchange_row_preserves_prior_country(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Codex 2 pre-push edge case: if the exchange row is missing
+        from ``exchanges`` (transient bootstrap order, brand-new
+        exchange not yet seeded by sql/067), the upsert must preserve
+        the existing ``instruments.country`` rather than wipe it to
+        NULL."""
+        # Seed a curated exchange + instrument with US country.
+        _seed_exchange(ebull_test_conn, exchange_id="971", country="US", asset_class="us_equity")
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="970005", symbol="STALEXCH", exchange="971"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_country(ebull_test_conn, 970005) == "US"
+
+        # Re-sync the same instrument, but with an exchange that does
+        # NOT exist in exchanges. (Simulates: eToro reports a new
+        # exchange the operator hasn't curated yet.)
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="970005", symbol="STALEXCH", exchange="99999"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+
+        # Country must NOT have been wiped — the CASE branch preserves
+        # the prior US value when the exchange row is missing.
+        assert _read_country(ebull_test_conn, 970005) == "US"
+
+    def test_record_country_field_ignored(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """The ``InstrumentRecord.country`` field is NOT wired through
+        the upsert — the upsert sources country from ``exchanges`` only,
+        so the dataclass field is irrelevant. This pins the behaviour:
+        a provider that mistakenly populates ``country`` from
+        instrument metadata cannot override the operator-curated
+        exchanges.country."""
+        _seed_exchange(ebull_test_conn, exchange_id="5", country="US", asset_class="us_equity")
+        provider = MagicMock()
+        rec = _make_record_with_exchange(provider_id="970004", symbol="OVERRIDE", exchange="5")
+        # Mutate the frozen dataclass — can't, but mock-construct an
+        # alternative by patching the dataclass replacement.
+        from dataclasses import replace
+
+        rec_with_bogus_country = replace(rec, country="XX")
+        provider.get_tradable_instruments.return_value = [rec_with_bogus_country]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        # exchanges.country wins.
+        assert _read_country(ebull_test_conn, 970004) == "US"


### PR DESCRIPTION
Refs #1233 — Part of the bootstrap-scope-discipline umbrella (cap-impl PR series).

## Summary

- **Spec revision**: change drop-policy from per-PR `DELETE pre-cap rows` to **ingest-side caps only + one operator-driven pre-wipe + clean re-run**. Schema columns preserved throughout.
- **`instruments.country` populate** from `exchanges.country` join — backfill migration + universe-sync derive on every run, with a CASE/EXISTS guard so a transient missing-exchange row preserves prior country (Codex 2 catch).
- **`is_tradable=TRUE` filter** added to 4 SEC ingest entry points (sec_submissions_ingest, sec_submissions_files_walk, finra_short_interest_ingest, mf_directory).
- **Lint guard** (`scripts/check_instruments_inserts.sh`) extends the prevention-log rule to the whole tree; case-insensitive + schema-qualified + column-list-scoped. Wired into `.githooks/pre-push`.
- **24 test-fixture INSERT sites** updated to comply with the guard.

## Why

`#1233 §6.1 + §6.2` cross-cutting plumbing. `instruments.country` was 100% NULL on dev DB; downstream consumers can't reliably filter `country='US'` without inferring from CIK presence. Delisted instruments consume SEC bootstrap budget for no operator value. Together these unblock the per-source caps in PR3-PR12 + the pre-wipe in §6.3.

Spec revision is bundled because the original draft's `DELETE pre-cap rows per PR` instruction conflicted with operator intent: data we don't currently use may still be valuable for future reports. Reframed as ingest-side caps + a single operator-driven whole-DB pre-wipe at the end.

## Security model

Defensive narrowing. The `is_tradable` filter excludes delisted rows from SEC ingest candidate sets — strictly tightens the universe scope, no new attack surface. The lint guard is local; it cannot reach the network or the DB.

`country` derivation source-of-truth is the `exchanges` curator (operator-controlled); the provider's `InstrumentRecord.country` is now explicitly ignored to prevent a malicious provider from overriding curated values. Pinned by `test_record_country_field_ignored`.

## Codex review

- **Codex 1a** (5 findings): country COALESCE-stickiness, comment claiming "operator override", Form 4 wipe semantics, lint-guard hardening, MF directory test exercising real `refresh_mf_directory`. All resolved.
- **Codex 2 pre-push** (1 new blocker): missing-exchange-row would wipe prior country. Fixed via CASE/EXISTS. Round 2 verify: green.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] `bash scripts/check_instruments_inserts.sh` clean
- [x] `uv run pytest tests/test_universe_normaliser.py tests/test_migration_158_country_backfill.py tests/test_sec_entry_points_is_tradable_filter.py tests/test_check_instruments_inserts_lint.py` — 45 passed
- [x] All 24 fixture-fix files pass — `uv run pytest` over them
- [ ] CI green
- [ ] Claude review APPROVE on the most recent commit

## Tradeoffs

- **Country source-of-truth choice**: derived from `exchanges.country`, NOT from the provider's `InstrumentRecord.country` field. Trade-off: operator-curated quality vs provider freshness. Decision: exchanges curator is the source of truth (mirrors the existing `instrument_type` / asset_class posture from #503 PR 4). The `InstrumentRecord.country` field stays on the dataclass for future providers that might legitimately expose it, but the universe.py upsert ignores it.
- **CASE/EXISTS for missing exchange**: trades a small SQL complexity for safety against bootstrap-order transients. The simpler `country = EXCLUDED.country` would wipe prior country whenever a brand-new exchange shows up before sql/067 backfills it.
- **Lint-guard scope**: covers `app/ tests/ sql/ scripts/` but excludes Markdown + the guard itself + its self-test (intentional carve-outs documented in the script).

## Scope NOT in this PR

- PR3 (filing_events 10y rolling cap) — next.
- Row-deletion of existing pre-cap rows — explicitly removed from PR3-12 per the spec revision; the pre-wipe at §6.3 is the only purge event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)