### PR TITLE
feat(#1233): PR3 — filing_events 10y rolling cap at the parser

### DIFF
--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -1648,12 +1648,18 @@ def backfill_filings(
         )
 
     conn.commit()  # M1 invariant before mutation block.
+    recent_results_upserted = 0
     with conn.transaction():
         for r in recent_results:
-            _upsert_filing(conn, str(instrument_id), "sec", r)
+            # ``_upsert_filing`` returns False when the 10y retention
+            # cap (#1233 §4.2) drops a pre-cutoff filing. Count only
+            # accepted rows so ``filings_upserted`` telemetry stays
+            # accurate during historical replays.
+            if _upsert_filing(conn, str(instrument_id), "sec", r):
+                recent_results_upserted += 1
     seen_filings.extend(recent_results)
     pages_fetched += 1
-    filings_upserted += len(recent_results)
+    filings_upserted += recent_results_upserted
 
     bar_met = probe_status(conn, instrument_id) in ("analysable", "fpi")
     if recent_results:
@@ -1764,12 +1770,16 @@ def backfill_filings(
             )
 
         conn.commit()  # M1 invariant.
+        page_results_upserted = 0
         with conn.transaction():
             for r in page_results:
-                _upsert_filing(conn, str(instrument_id), "sec", r)
+                # Count only writes that survived the retention cap
+                # (#1233 §4.2).
+                if _upsert_filing(conn, str(instrument_id), "sec", r):
+                    page_results_upserted += 1
         seen_filings.extend(page_results)
         pages_fetched += 1
-        filings_upserted += len(page_results)
+        filings_upserted += page_results_upserted
 
         if not bar_met:
             bar_met = probe_status(conn, instrument_id) in ("analysable", "fpi")

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -38,13 +38,79 @@ rows on first install (operator audit 2026-05-07).
 import json
 import logging
 from dataclasses import dataclass
-from datetime import date
+from datetime import UTC, date, datetime
 
 import psycopg
 
 from app.providers.filings import FilingEvent, FilingSearchResult, FilingsProvider
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# filing_events retention cap (#1233 §4.2)
+# ---------------------------------------------------------------------------
+
+
+# 10-year rolling cap on every filing_events ingest path. Discovery
+# writers (Atom fast-lane, daily-index reconcile, first-install drain,
+# per-CIK poll, targeted rebuild, master-index reconcile) all funnel
+# into one of three chokepoints — ``_upsert_filing`` /
+# ``_upsert_filing_event`` here, plus
+# ``fundamentals._upsert_filing_from_master_index`` — so capping at
+# the writer catches every code path uniformly.
+#
+# Existing rows are NOT deleted. The cap is ingest-side only; pre-cap
+# rows survive until the operator-driven pre-wipe + clean re-run
+# (spec §6.3). After the wipe the bounded set lands organically.
+#
+# Constant deliberately exported for testability + so future tuning
+# (e.g. tightening to 5y once a downstream chart only needs that
+# depth) is a single-symbol edit with grep visibility, not a hidden
+# magic number per writer.
+FILING_EVENTS_RETENTION_YEARS: int = 10
+
+
+def filing_events_retention_cutoff(now: datetime | None = None) -> date:
+    """Return the earliest ``filing_date`` accepted for ``filing_events``.
+
+    Rows with ``filing_date < cutoff`` are rejected at the writer
+    chokepoints (#1233 §4.2). Returns a ``date`` because
+    ``filing_events.filing_date`` is a DATE column — comparison must
+    not pull in time-of-day semantics.
+
+    Implements **calendar-year** subtraction (not ``365 *
+    FILING_EVENTS_RETENTION_YEARS`` days, which would drift past leap
+    days). Feb 29 boundary is handled explicitly: if today is Feb 29
+    and ``today.year - 10`` is not a leap year, the cutoff anchors to
+    Feb 28 of that earlier year. Codex 1a pre-push catch.
+
+    ``now`` is injectable so tests can pin a stable reference instant
+    without monkeypatching ``datetime.now``. Production callers pass
+    nothing and the helper defaults to ``datetime.now(tz=UTC)``.
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+    today = now.date()
+    target_year = today.year - FILING_EVENTS_RETENTION_YEARS
+    try:
+        return today.replace(year=target_year)
+    except ValueError:
+        # today == Feb 29 and target_year is not a leap year. Anchor
+        # to Feb 28 — the conservative choice (one day earlier window
+        # rather than one day later, so a filing at Feb 28 in the
+        # target year stays inside).
+        return date(target_year, 2, 28)
+
+
+def filing_within_retention(filing_date: date, now: datetime | None = None) -> bool:
+    """Boundary check used by every writer chokepoint.
+
+    Returns True iff ``filing_date >= filing_events_retention_cutoff(now)``.
+    Boundary is inclusive — a filing exactly at the cutoff date is
+    retained (no off-by-one drop on the rolling boundary).
+    """
+    return filing_date >= filing_events_retention_cutoff(now)
 
 
 # ---------------------------------------------------------------------------
@@ -302,11 +368,18 @@ def refresh_filings(
                 end_date=end_date,
                 filing_types=filing_types,
             )
+            results_upserted = 0
             with conn.transaction():
                 for result in results:
-                    _upsert_filing(conn, instrument_id, provider_name, result)
+                    # Count only rows the writer actually accepted.
+                    # The 10y retention cap (#1233 §4.2) drops pre-
+                    # cutoff filings; a naive ``len(results)`` would
+                    # over-report telemetry whenever the cap fires
+                    # during historical replays (Codex 1a #2).
+                    if _upsert_filing(conn, instrument_id, provider_name, result):
+                        results_upserted += 1
             # Count only after the transaction commits successfully
-            upserted += len(results)
+            upserted += results_upserted
         except Exception:
             logger.warning(
                 "Filings: failed to refresh instrument_id=%s via %s, skipping",
@@ -442,7 +515,21 @@ def _upsert_filing_event(
     payload shape but accepts the richer ``FilingEvent`` variant
     returned by ``FilingsProvider.get_filing``. Chunk E's 8-K gap
     fill path uses this when re-fetching a single accession (#268).
+
+    Filings older than the 10y retention cutoff (#1233 §4.2) are
+    rejected here — silently dropped with a DEBUG log so a noisy
+    upstream replay doesn't flood the operator log.
     """
+    filing_date = event.filed_at.date()
+    if not filing_within_retention(filing_date):
+        logger.debug(
+            "filing_events: skipping %s/%s — filing_date %s pre-%dy cutoff (#1233 §4.2)",
+            provider_name,
+            event.provider_filing_id,
+            filing_date.isoformat(),
+            FILING_EVENTS_RETENTION_YEARS,
+        )
+        return
     conn.execute(
         """
         INSERT INTO filing_events (
@@ -488,11 +575,31 @@ def _upsert_filing(
     instrument_id: str,
     provider_name: str,
     result: FilingSearchResult,
-) -> None:
-    """
-    Upsert a single filing into filing_events.
+) -> bool:
+    """Upsert a single filing into filing_events.
+
     Idempotent — keyed on (provider, provider_filing_id).
+
+    Filings older than the 10y retention cutoff (#1233 §4.2) are
+    rejected here — silently dropped with a DEBUG log so a noisy
+    upstream replay doesn't flood the operator log.
+
+    Returns ``True`` if the INSERT/UPDATE fired, ``False`` if the row
+    was dropped by the retention cap. Callers tracking
+    ``filings_upserted`` for telemetry must check the return value;
+    naively counting ``len(results)`` would over-report whenever the
+    cap drops historical filings (Codex 1a #2).
     """
+    filing_date = result.filed_at.date()
+    if not filing_within_retention(filing_date):
+        logger.debug(
+            "filing_events: skipping %s/%s — filing_date %s pre-%dy cutoff (#1233 §4.2)",
+            provider_name,
+            result.provider_filing_id,
+            filing_date.isoformat(),
+            FILING_EVENTS_RETENTION_YEARS,
+        )
+        return False
     conn.execute(
         """
         INSERT INTO filing_events (
@@ -534,3 +641,4 @@ def _upsert_filing(
             ),
         },
     )
+    return True

--- a/app/services/fundamentals.py
+++ b/app/services/fundamentals.py
@@ -38,6 +38,10 @@ from app.providers.implementations.sec_edgar import (
     parse_master_index,
 )
 from app.providers.implementations.sec_fundamentals import TRACKED_CONCEPTS
+from app.services.filings import (
+    FILING_EVENTS_RETENTION_YEARS,
+    filing_within_retention,
+)
 from app.services.ownership_observations import (
     record_treasury_observation,
     refresh_treasury_current,
@@ -2240,6 +2244,21 @@ def _upsert_filing_from_master_index(
             entry.cik,
         )
         filed_at = datetime.now(UTC)
+    # #1233 §4.2 — 10y rolling cap on filing_events. Master-index
+    # reconcile walks every form in the quarterly index, including
+    # decades-old filings that no current consumer renders. The
+    # canonical helper in ``filings`` ensures all three writers
+    # (this one + the two in ``filings.py``) share the same cutoff
+    # semantics — a single grep for the constant catches any future
+    # writer that needs the gate.
+    if not filing_within_retention(filed_at.date()):
+        logger.debug(
+            "filing_events: skipping sec/%s — filing_date %s pre-%dy cutoff (#1233 §4.2)",
+            entry.accession_number,
+            filed_at.date().isoformat(),
+            FILING_EVENTS_RETENTION_YEARS,
+        )
+        return
     conn.execute(
         """
         INSERT INTO filing_events (

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -161,8 +161,12 @@ def walk_files_pages(
                 for filing in filings:
                     try:
                         with conn.transaction():
-                            _upsert_filing(conn, str(instrument_id), "sec", filing)
-                            result.filings_upserted += 1
+                            # ``_upsert_filing`` returns False when
+                            # the 10y retention cap (#1233 §4.2) drops
+                            # a pre-cutoff filing. Count only accepted
+                            # rows.
+                            if _upsert_filing(conn, str(instrument_id), "sec", filing):
+                                result.filings_upserted += 1
                     except Exception as exc:  # noqa: BLE001
                         logger.debug(
                             "files walk: upsert failed for %s/%s: %s",

--- a/app/services/sec_submissions_ingest.py
+++ b/app/services/sec_submissions_ingest.py
@@ -214,5 +214,9 @@ def _ingest_one(
         symbol=symbol or cik_padded,
     )
     for filing in filings:
-        _upsert_filing(conn, str(instrument_id), "sec", filing)
-        result.filings_upserted += 1
+        # ``_upsert_filing`` returns False when the 10y retention cap
+        # (#1233 §4.2) drops a pre-cutoff filing. Count only accepted
+        # rows so ``SubmissionsIngestResult.filings_upserted`` stays
+        # accurate during the historical bulk archive walk.
+        if _upsert_filing(conn, str(instrument_id), "sec", filing):
+            result.filings_upserted += 1

--- a/tests/test_filing_events_retention_cap.py
+++ b/tests/test_filing_events_retention_cap.py
@@ -334,16 +334,35 @@ def test_no_writer_bypasses_the_gate() -> None:
     This is a defensive guard: a future PR that adds a fourth writer
     without the gate will fail this test, prompting the developer to
     either route through the existing chokepoints or add the gate
-    explicitly."""
+    explicitly.
+
+    Path is anchored to the repo root via ``__file__`` so the test
+    cannot pass vacuously when pytest is invoked from a subdirectory.
+    Bot review BLOCKING for PR #1239."""
     import subprocess
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    app_dir = repo_root / "app"
 
     proc = subprocess.run(
-        ["grep", "-rln", "INSERT INTO filing_events", "app/"],
+        ["grep", "-rln", "INSERT INTO filing_events", str(app_dir)],
         capture_output=True,
         text=True,
         check=False,
     )
     writer_files = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+    # The 3 chokepoints (filings.py x2 + fundamentals.py) PLUS any
+    # consumer that quotes the pattern in a docstring / comment.
+    # If grep finds zero matches, the path was wrong — assert
+    # non-empty so the test fails loudly rather than silently
+    # passing. Bot PREVENTION for PR #1239.
+    assert writer_files, (
+        f"grep found no ``INSERT INTO filing_events`` matches under {app_dir}. "
+        "The lint-style guard cannot run; verify the search path resolves correctly."
+    )
+
     # Allow a deny-list of files known not to need the gate (e.g.
     # SQL migrations, documentation generators). Currently empty —
     # every writer must invoke ``filing_within_retention``.
@@ -352,10 +371,13 @@ def test_no_writer_bypasses_the_gate() -> None:
     for f in writer_files:
         if f in deny_list:
             continue
-        # ``errors="replace"`` so a binary blob (e.g. a stray
-        # non-UTF8 fixture surfaced via grep) doesn't crash the lint
-        # — we only care about the ASCII helper name.
-        text = open(f, encoding="utf-8", errors="replace").read()
+        # Context manager so a permission error on a stale grep
+        # result doesn't leak a file handle. ``errors="replace"`` so
+        # a binary blob (stray non-UTF8 fixture surfaced via grep)
+        # doesn't crash the lint — we only care about the ASCII
+        # helper name. Bot WARNING for PR #1239.
+        with open(f, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
         if "filing_within_retention" not in text:
             bypassed.append(f)
     assert not bypassed, (

--- a/tests/test_filing_events_retention_cap.py
+++ b/tests/test_filing_events_retention_cap.py
@@ -1,0 +1,364 @@
+"""filing_events 10y retention cap — #1233 §4.2 PR3.
+
+Pins the three contracts:
+
+1. ``filing_events_retention_cutoff`` is ``now - 10y`` (rolling).
+2. ``filing_within_retention`` is inclusive at the boundary.
+3. Each of the three writer chokepoints — ``_upsert_filing``,
+   ``_upsert_filing_event``, and
+   ``fundamentals._upsert_filing_from_master_index`` — rejects rows
+   whose ``filing_date`` falls before the cutoff and accepts rows on
+   or after the boundary.
+
+Boundary contract matters because the rolling window means a filing
+"on the boundary" exists for exactly one day per year before falling
+off. An exclusive boundary would create a 1-day blip where the
+filing visibly drops + re-appears.
+
+Existing rows are not deleted by the cap (#1233 §6.3 is the only
+purge event). These tests therefore assert *insert* behaviour only;
+a pre-cap row already in the table stays put.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import psycopg
+import pytest
+
+from app.providers.filings import FilingEvent, FilingSearchResult
+from app.services.filings import (
+    FILING_EVENTS_RETENTION_YEARS,
+    _upsert_filing,
+    _upsert_filing_event,
+    filing_events_retention_cutoff,
+    filing_within_retention,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+
+# ---------------------------------------------------------------------------
+# Pure helper contracts
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionCutoff:
+    def test_constant_is_10_years(self) -> None:
+        assert FILING_EVENTS_RETENTION_YEARS == 10
+
+    def test_cutoff_is_now_minus_10_calendar_years(self) -> None:
+        """Calendar-year subtraction, NOT 365*10 days — leap days
+        would otherwise drift the boundary by ~2-3 days per decade
+        (Codex 1a #1)."""
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        cutoff = filing_events_retention_cutoff(now=ref)
+        # 10 calendar years before 2026-05-20 is exactly 2016-05-20.
+        assert cutoff == date(2016, 5, 20)
+
+    def test_cutoff_feb_29_anchors_to_feb_28_in_non_leap_target(self) -> None:
+        """today=Feb 29, target year non-leap → cutoff anchors to
+        Feb 28. Conservative: one day earlier, not later, so a
+        filing at Feb 28 in the target year stays inside the window."""
+        ref = datetime(2024, 2, 29, 12, 0, 0, tzinfo=UTC)  # 2024 is leap
+        cutoff = filing_events_retention_cutoff(now=ref)
+        # 2024 - 10 = 2014 (not a leap year) → Feb 28.
+        assert cutoff == date(2014, 2, 28)
+
+    def test_cutoff_returns_date_not_datetime(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        result = filing_events_retention_cutoff(now=ref)
+        # ``filing_events.filing_date`` is a DATE column; the cutoff
+        # must be ``date`` so equality / comparison stays type-pure.
+        assert isinstance(result, date)
+        assert not isinstance(result, datetime)
+
+
+class TestFilingWithinRetention:
+    def test_at_boundary_accepted(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        cutoff = filing_events_retention_cutoff(now=ref)
+        # The boundary date itself is INSIDE the window.
+        assert filing_within_retention(cutoff, now=ref) is True
+
+    def test_one_day_before_boundary_rejected(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        cutoff = filing_events_retention_cutoff(now=ref)
+        assert filing_within_retention(cutoff - timedelta(days=1), now=ref) is False
+
+    def test_one_day_after_boundary_accepted(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        cutoff = filing_events_retention_cutoff(now=ref)
+        assert filing_within_retention(cutoff + timedelta(days=1), now=ref) is True
+
+    def test_today_accepted(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        assert filing_within_retention(ref.date(), now=ref) is True
+
+    def test_future_filing_accepted(self) -> None:
+        """A future-dated filing (operator clock skew, weird provider)
+        is still inside the window — the cap is a lower bound, not a
+        range. Don't drop on the upper side."""
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        assert filing_within_retention(ref.date() + timedelta(days=1), now=ref) is True
+
+    def test_ancient_filing_rejected(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        ancient = date(1993, 1, 1)
+        assert filing_within_retention(ancient, now=ref) is False
+
+
+# ---------------------------------------------------------------------------
+# Writer-level integration
+# ---------------------------------------------------------------------------
+
+
+pytestmark_integration = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], instrument_id: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+            VALUES (%s, %s, %s, TRUE)
+            ON CONFLICT (instrument_id) DO NOTHING
+            """,
+            (instrument_id, f"FE{instrument_id}", f"Test FE{instrument_id}"),
+        )
+
+
+def _make_search_result(
+    *,
+    accession: str,
+    filed_at: datetime,
+    filing_type: str = "10-K",
+) -> FilingSearchResult:
+    return FilingSearchResult(
+        provider_filing_id=accession,
+        symbol="FE-TEST",
+        filed_at=filed_at,
+        filing_type=filing_type,
+        period_of_report=None,
+        primary_document_url=f"https://www.sec.gov/Archives/{accession}.htm",
+    )
+
+
+def _read_filing(conn: psycopg.Connection[tuple], *, instrument_id: int, accession: str) -> tuple | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT filing_date, filing_type FROM filing_events
+            WHERE provider = 'sec' AND provider_filing_id = %s AND instrument_id = %s
+            """,
+            (accession, instrument_id),
+        )
+        return cur.fetchone()
+
+
+@pytest.mark.integration
+class TestUpsertFilingRespectsCutoff:
+    def test_recent_filing_inserted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_instrument(ebull_test_conn, 540001)
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        result = _make_search_result(accession="0000000001-FE-A", filed_at=ref)
+        _upsert_filing(ebull_test_conn, "540001", "sec", result)
+        ebull_test_conn.commit()
+        row = _read_filing(ebull_test_conn, instrument_id=540001, accession="0000000001-FE-A")
+        assert row is not None
+        assert row[1] == "10-K"
+
+    def test_pre_cutoff_filing_dropped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A filing dated 15 years ago must be silently dropped — no
+        row in filing_events, no exception."""
+        _seed_instrument(ebull_test_conn, 540002)
+        # 15 years pre-now → outside the 10y window.
+        ancient = datetime.now(tz=UTC) - timedelta(days=365 * 15)
+        result = _make_search_result(accession="0000000002-FE-B", filed_at=ancient)
+        _upsert_filing(ebull_test_conn, "540002", "sec", result)
+        ebull_test_conn.commit()
+        assert _read_filing(ebull_test_conn, instrument_id=540002, accession="0000000002-FE-B") is None
+
+    def test_boundary_filing_inserted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A filing exactly at the boundary (10y - 0 days) is INSIDE
+        the window (inclusive boundary, pinned by
+        ``test_at_boundary_accepted`` above and reasserted at the
+        writer-level)."""
+        _seed_instrument(ebull_test_conn, 540003)
+        boundary_date = filing_events_retention_cutoff()
+        # Convert back to datetime for the writer signature.
+        boundary_dt = datetime.combine(boundary_date, datetime.min.time(), tzinfo=UTC)
+        result = _make_search_result(accession="0000000003-FE-C", filed_at=boundary_dt)
+        _upsert_filing(ebull_test_conn, "540003", "sec", result)
+        ebull_test_conn.commit()
+        row = _read_filing(ebull_test_conn, instrument_id=540003, accession="0000000003-FE-C")
+        assert row is not None
+
+
+@pytest.mark.integration
+class TestUpsertFilingEventRespectsCutoff:
+    """The richer ``_upsert_filing_event`` mirror of the same gate."""
+
+    def test_pre_cutoff_event_dropped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_instrument(ebull_test_conn, 540004)
+        ancient = datetime.now(tz=UTC) - timedelta(days=365 * 12)
+        event = FilingEvent(
+            provider_filing_id="0000000004-FE-D",
+            symbol="FE-TEST",
+            filed_at=ancient,
+            filing_type="8-K",
+            period_of_report=None,
+            primary_document_url="https://www.sec.gov/Archives/x.htm",
+            extracted_summary=None,
+            red_flag_score=None,
+            raw_payload={},
+        )
+        _upsert_filing_event(ebull_test_conn, "540004", "sec", event)
+        ebull_test_conn.commit()
+        assert _read_filing(ebull_test_conn, instrument_id=540004, accession="0000000004-FE-D") is None
+
+    def test_recent_event_inserted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed_instrument(ebull_test_conn, 540005)
+        event = FilingEvent(
+            provider_filing_id="0000000005-FE-E",
+            symbol="FE-TEST",
+            filed_at=datetime.now(tz=UTC),
+            filing_type="8-K",
+            period_of_report=None,
+            primary_document_url="https://www.sec.gov/Archives/y.htm",
+            extracted_summary=None,
+            red_flag_score=None,
+            raw_payload={},
+        )
+        _upsert_filing_event(ebull_test_conn, "540005", "sec", event)
+        ebull_test_conn.commit()
+        row = _read_filing(ebull_test_conn, instrument_id=540005, accession="0000000005-FE-E")
+        assert row is not None
+        assert row[1] == "8-K"
+
+
+@pytest.mark.integration
+class TestMasterIndexUpsertRespectsCutoff:
+    """Third chokepoint —
+    ``app/services/fundamentals.py::_upsert_filing_from_master_index``.
+
+    Imports lazily because the function is private + the module is
+    heavy. The test pins that the gate fires before the INSERT
+    executes."""
+
+    def test_pre_cutoff_master_index_entry_dropped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.providers.implementations.sec_edgar import MasterIndexEntry
+        from app.services.fundamentals import _upsert_filing_from_master_index
+
+        _seed_instrument(ebull_test_conn, 540006)
+        # 11 years pre-now → outside the 10y window.
+        ancient_date = (datetime.now(tz=UTC) - timedelta(days=365 * 11)).date().isoformat()
+        entry = MasterIndexEntry(
+            cik="0000000540",
+            company_name="Test FE540006",
+            form_type="10-K",
+            date_filed=ancient_date,
+            accession_number="0000540006-99-000001",
+        )
+        _upsert_filing_from_master_index(
+            ebull_test_conn,
+            instrument_id=540006,
+            entry=entry,
+            symbol="FE540006",
+        )
+        ebull_test_conn.commit()
+        assert (
+            _read_filing(
+                ebull_test_conn,
+                instrument_id=540006,
+                accession="0000540006-99-000001",
+            )
+            is None
+        )
+
+    def test_recent_master_index_entry_inserted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.providers.implementations.sec_edgar import MasterIndexEntry
+        from app.services.fundamentals import _upsert_filing_from_master_index
+
+        _seed_instrument(ebull_test_conn, 540007)
+        recent_date = (datetime.now(tz=UTC) - timedelta(days=30)).date().isoformat()
+        entry = MasterIndexEntry(
+            cik="0000000540",
+            company_name="Test FE540007",
+            form_type="10-Q",
+            date_filed=recent_date,
+            accession_number="0000540007-26-000001",
+        )
+        _upsert_filing_from_master_index(
+            ebull_test_conn,
+            instrument_id=540007,
+            entry=entry,
+            symbol="FE540007",
+        )
+        ebull_test_conn.commit()
+        row = _read_filing(
+            ebull_test_conn,
+            instrument_id=540007,
+            accession="0000540007-26-000001",
+        )
+        assert row is not None
+        assert row[1] == "10-Q"
+
+
+def test_no_writer_bypasses_the_gate() -> None:
+    """Lint-style check: enumerate every ``INSERT INTO filing_events``
+    site in app/ and confirm each is preceded by a
+    ``filing_within_retention`` guard (or imports the helper and
+    invokes it). #1233 §4.2 — caps must apply to every writer.
+
+    This is a defensive guard: a future PR that adds a fourth writer
+    without the gate will fail this test, prompting the developer to
+    either route through the existing chokepoints or add the gate
+    explicitly."""
+    import subprocess
+
+    proc = subprocess.run(
+        ["grep", "-rln", "INSERT INTO filing_events", "app/"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    writer_files = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    # Allow a deny-list of files known not to need the gate (e.g.
+    # SQL migrations, documentation generators). Currently empty —
+    # every writer must invoke ``filing_within_retention``.
+    deny_list: set[str] = set()
+    bypassed: list[str] = []
+    for f in writer_files:
+        if f in deny_list:
+            continue
+        # ``errors="replace"`` so a binary blob (e.g. a stray
+        # non-UTF8 fixture surfaced via grep) doesn't crash the lint
+        # — we only care about the ASCII helper name.
+        text = open(f, encoding="utf-8", errors="replace").read()
+        if "filing_within_retention" not in text:
+            bypassed.append(f)
+    assert not bypassed, (
+        f"INSERT INTO filing_events sites without filing_within_retention gate: {bypassed}. "
+        "Add the gate or route through app/services/filings.py chokepoints (#1233 §4.2)."
+    )


### PR DESCRIPTION
Refs #1233 — Part of the data retention cap-impl PR series.

## Summary

- 10-year rolling cap applied at every `filing_events` writer chokepoint (3 sites).
- `_upsert_filing` returns `bool`; 5 call sites updated to count only accepted rows so telemetry stays accurate during historical replays.
- 17 new tests covering helper boundary contracts, Feb 29 leap fallback, and writer-level integration for all 3 chokepoints, plus a lint-style 'no future writer can bypass the gate' guard.

## Why

`filing_events` is 5.79M rows / 4.3 GB on dev DB, spanning 1993-2026 (33 years). The 8-K event timeline chart applies a 2y filter at query time. Drilldown navigation tolerates 10y comfortably. Pre-10y rows satisfy no current consumer + cost ~3 GB of hot storage.

The cap is **ingest-side only** per the §6.3 spec revision in PR1. Existing rows are untouched. The post-wipe + clean re-run will land the bounded set; until then `filing_events` stays as-is.

## Security model

Defensive narrowing. Cap rejects rows whose `filing_date` is more than 10 calendar years in the past. No new attack surface; no auth changes. Cap is a lower bound only — future-dated filings (operator clock skew, weird provider) pass through (pinned by `test_future_filing_accepted`).

## Codex review

- **Codex 1a** (2 findings): calendar-year math drift (`365*10` days vs `now.replace(year=now.year-10)`) and over-counting via `len(results)` ignoring the cap. Both resolved.
- **Codex round 2** (1 new blocker): two additional `_upsert_filing` callers (`sec_submissions_ingest`, `sec_submissions_files_walk`) still ignored the bool return. Fixed.
- **Codex round 3**: no new blocker.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] `bash scripts/check_instruments_inserts.sh` clean
- [x] `uv run pytest tests/test_filing_events_retention_cap.py` — 17 passed
- [x] `uv run pytest tests/test_filings_backfill.py tests/test_sec_master_idx_quarterly_sweep.py tests/test_sec_daily_index_reconcile.py` — passed (41)
- [ ] CI green
- [ ] Claude review APPROVE on the most recent commit

## Tradeoffs

- **Writer-level vs fetch-level cap**: gates at the 3 chokepoints. Catches every replay path + alternate provider implementations without trusting every fetch caller. Doesn't reduce upstream HTTP volume; that's a future optimisation (pass `start_date=cutoff` to provider when a caller fetches broad history).
- **Calendar years vs 365-day intervals**: chose calendar (`now.replace(year=now.year-10)`) so the boundary stays stable. `365*10` days drifts ~2-3 days per decade due to leap days.
- **Feb 29 fallback**: anchors to Feb 28 of the target year (conservative — one day earlier window, so filings at Feb 28 in target year stay inside).
- **Silent DEBUG drop**: noisy historical replays would drown the log if we INFO-logged every drop. Per-row INFO too loud; aggregate INFO at job end can be added later if operators need visibility into "retention dropped N rows".

## Scope NOT in this PR

- Existing pre-10y rows are untouched (#1233 §6.3 — the operator-driven pre-wipe is the single purge event).
- Raw payload strip from `filing_events.raw_payload_json` — deferred to #1014.
- Provider-level `start_date=cutoff` optimization — separate ticket if HTTP budget becomes the bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)