### PR TITLE
feat(#1233): PR5 — DEF 14A latest-2-primary-proxies-per-filer cap

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -56,6 +56,12 @@ bash scripts/check_instruments_inserts.sh
 echo "==> Pre-push gate: Form 4 retention cap lint"
 bash scripts/check_form4_retention.sh
 
+# #1233 §4.7 PR5 — every DEF 14A ingest chokepoint must honour the
+# latest-2-primary-proxies-per-filer cap (discovery rank CTE, manifest-
+# worker pre-fetch gate, rewash rescue gate). ~40ms.
+echo "==> Pre-push gate: DEF 14A latest-N cap lint"
+bash scripts/check_def14a_cap.sh
+
 # Pytest scoping decision. If `git diff --name-only @{u}..HEAD` fails
 # (no upstream yet, e.g. brand-new branch), assume worst-case: run the
 # full suite under xdist. The first push of a brand-new branch usually

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -2511,6 +2511,10 @@ def get_def14a_drill(
         # that compared them and false-positived.
         cur.execute(
             """
+            -- DEF14A-CAP-EXEMPT: read-side coverage/diagnostic
+            -- query — reports what's been ingested; not a writer
+            -- chokepoint. #1233 PR5 cap applies only to ingest
+            -- decisions.
             SELECT provider_filing_id AS accession, filing_date
             FROM filing_events
             WHERE provider = 'sec'
@@ -2547,6 +2551,8 @@ def get_def14a_drill(
         # signal, not row-level.
         cur.execute(
             """
+            -- DEF14A-CAP-EXEMPT: read-side coverage/diagnostic
+            -- (tombstone-count). Not an ingest chokepoint.
             SELECT COUNT(DISTINCT log.accession_number) AS tombstone_count
             FROM def14a_ingest_log log
             WHERE log.status IN ('partial', 'failed')
@@ -2564,6 +2570,8 @@ def get_def14a_drill(
         tomb = cur.fetchone() or {"tombstone_count": 0}
         cur.execute(
             """
+            -- DEF14A-CAP-EXEMPT: read-side coverage/diagnostic
+            -- (raw-body count). Not an ingest chokepoint.
             SELECT COUNT(DISTINCT r.accession_number) AS body_count
             FROM filing_raw_documents r
             JOIN filing_events fe ON fe.provider_filing_id = r.accession_number
@@ -2588,6 +2596,8 @@ def get_def14a_drill(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
+            -- DEF14A-CAP-EXEMPT: read-side coverage/diagnostic
+            -- (discovered-unparsed count). Not an ingest chokepoint.
             SELECT COUNT(*) AS c
             FROM filing_events fe
             WHERE fe.provider = 'sec'

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -95,6 +95,23 @@ class SecDocFetcher(Protocol):
 _DEF14A_FORM_TYPES: frozenset[str] = frozenset(("DEF 14A", "DEFA14A", "DEFM14A", "DEFR14A"))
 
 
+# ---------------------------------------------------------------------------
+# Latest-N-primary-proxies-per-filer ingest cap (#1233 §4.7 PR5)
+# ---------------------------------------------------------------------------
+
+
+# Cap: keep latest 2 PRIMARY ``DEF 14A`` accessions per issuer CIK.
+# Supplemental variants (DEFA14A, DEFR14A, DEFM14A) are NOT capped —
+# they are amendments / merger proxies that would otherwise evict a
+# prior-year primary from the cap window. See spec §4.7.
+DEF14A_LATEST_PER_FILER_CAP: int = 2
+
+# Form type the cap partitions on. Imported by the manifest-worker
+# parser + lint guard so a future widening (e.g. include DEFA14A in
+# the cap) only edits one place.
+DEF14A_PRIMARY_FORM_TYPE: str = "DEF 14A"
+
+
 @dataclass(frozen=True)
 class AccessionRef:
     """One DEF 14A accession to ingest. Sourced from
@@ -192,42 +209,30 @@ def discover_pending_def14a(
     issuer (used by ad-hoc re-ingest scripts and the per-instrument
     backfill in PR 3); ``None`` returns the full pending set.
     """
-    # Per-#1117 PR-B: targeted selectors (`fe.instrument_id = %s`)
-    # only match one sibling's rows in filing_events — no fan-out
-    # multiplies, dedup unnecessary. Universe-wide selectors require
-    # the inner-CTE DISTINCT ON pattern so N siblings sharing a CIK
-    # do not consume N slots of the LIMIT budget for one accession.
-    where_iid = "AND fe.instrument_id = %(iid)s" if instrument_id is not None else ""
+    # #1233 PR5 — latest-N-primary cap applied via inline rank CTE.
+    # Per-instrument branch pre-scopes to target CIK in Python (one
+    # round-trip) so the rank universe is bounded to the filer's
+    # corpus. Universe-wide branch ranks every DEF 14A accession in
+    # one CTE and returns directly from the de-duped row set (NO
+    # outer JOIN back to filing_events — that would fan one accession
+    # to N sibling rows and burn the LIMIT slot).
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         if instrument_id is not None:
-            cur.execute(
-                f"""
-                SELECT fe.provider_filing_id, fe.instrument_id, fe.filing_date,
-                       fe.primary_document_url
-                FROM filing_events fe
-                LEFT JOIN def14a_ingest_log log
-                    ON log.accession_number = fe.provider_filing_id
-                WHERE fe.provider = 'sec'
-                  AND fe.filing_type = ANY(%(forms)s)
-                  AND fe.primary_document_url IS NOT NULL
-                  AND log.accession_number IS NULL
-                  {where_iid}
-                ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
-                LIMIT %(limit)s
-                """,
-                {
-                    "forms": list(_DEF14A_FORM_TYPES),
-                    "iid": instrument_id,
-                    "limit": limit,
-                },
-            )
-        else:
-            cur.execute(
-                """
-                WITH per_accession AS (
-                    SELECT DISTINCT ON (fe.provider_filing_id)
-                        fe.provider_filing_id, fe.instrument_id, fe.filing_date,
-                        fe.primary_document_url, fe.filing_event_id
+            target_cik = _resolve_target_cik_for_cap(conn, instrument_id=instrument_id)
+            if target_cik is None:
+                # CIK-truly-missing — legacy uncapped path for the
+                # calling instrument's own DEF 14A accessions. The
+                # parser-side helper (``def14a_within_cap``) returns
+                # ``True`` for these (CIK-missing carve-out at §3) so
+                # the existing CIK-MISSING tombstone path runs.
+                cur.execute(
+                    """
+                    -- DEF14A-CAP-EXEMPT: CIK-MISSING legacy uncapped
+                    -- (#1233 PR5 §2.6 — calling instrument has no profile
+                    -- and no sibling profile either; parser-side helper
+                    -- short-circuits CIK-missing).
+                    SELECT fe.provider_filing_id, fe.instrument_id,
+                           fe.filing_date, fe.primary_document_url
                     FROM filing_events fe
                     LEFT JOIN def14a_ingest_log log
                         ON log.accession_number = fe.provider_filing_id
@@ -235,15 +240,109 @@ def discover_pending_def14a(
                       AND fe.filing_type = ANY(%(forms)s)
                       AND fe.primary_document_url IS NOT NULL
                       AND log.accession_number IS NULL
-                    ORDER BY fe.provider_filing_id, fe.instrument_id
+                      AND fe.instrument_id = %(iid)s
+                    ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+                    LIMIT %(limit)s
+                    """,
+                    {
+                        "forms": list(_DEF14A_FORM_TYPES),
+                        "iid": instrument_id,
+                        "limit": limit,
+                    },
                 )
-                SELECT provider_filing_id, instrument_id, filing_date, primary_document_url
-                FROM per_accession
-                ORDER BY filing_date DESC, filing_event_id DESC
+            else:
+                cur.execute(
+                    """
+                    WITH per_accession AS (
+                        SELECT DISTINCT ON (fe.provider_filing_id)
+                            fe.provider_filing_id, fe.filing_date,
+                            fe.filing_type, fe.primary_document_url,
+                            fe.filing_event_id
+                        FROM filing_events fe
+                        JOIN instrument_sec_profile isp
+                            ON isp.instrument_id = fe.instrument_id
+                        WHERE fe.provider = 'sec'
+                          AND fe.filing_type = ANY(%(forms)s)
+                          AND isp.cik = %(target_cik)s
+                        ORDER BY fe.provider_filing_id, fe.instrument_id
+                    ),
+                    ranked AS (
+                        SELECT *,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY filing_type
+                                ORDER BY filing_date DESC, provider_filing_id DESC
+                            ) AS rank_within_form
+                        FROM per_accession
+                    )
+                    SELECT fe.provider_filing_id, fe.instrument_id,
+                           fe.filing_date, fe.primary_document_url
+                    FROM ranked r
+                    JOIN filing_events fe
+                        ON fe.provider_filing_id = r.provider_filing_id
+                       AND fe.provider = 'sec'
+                       AND fe.primary_document_url IS NOT NULL
+                    LEFT JOIN def14a_ingest_log log
+                        ON log.accession_number = r.provider_filing_id
+                    WHERE log.accession_number IS NULL
+                      AND fe.instrument_id = %(iid)s
+                      AND (r.filing_type <> 'DEF 14A'
+                           OR r.rank_within_form <= %(cap)s)
+                    ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+                    LIMIT %(limit)s
+                    """,
+                    {
+                        "forms": list(_DEF14A_FORM_TYPES),
+                        "iid": instrument_id,
+                        "target_cik": target_cik,
+                        "cap": DEF14A_LATEST_PER_FILER_CAP,
+                        "limit": limit,
+                    },
+                )
+        else:
+            cur.execute(
+                """
+                WITH per_accession AS (
+                    -- ORDER BY ``(isp.cik IS NULL)`` prefers
+                    -- profile-bearing siblings on DISTINCT ON
+                    -- (#1233 PR5 §2.2); ``fe.instrument_id`` is the
+                    -- deterministic tie-break across same-CIK
+                    -- siblings.
+                    SELECT DISTINCT ON (fe.provider_filing_id)
+                        fe.provider_filing_id, fe.instrument_id, fe.filing_date,
+                        fe.filing_type, fe.primary_document_url,
+                        fe.filing_event_id, isp.cik
+                    FROM filing_events fe
+                    LEFT JOIN instrument_sec_profile isp
+                        ON isp.instrument_id = fe.instrument_id
+                    WHERE fe.provider = 'sec'
+                      AND fe.filing_type = ANY(%(forms)s)
+                    ORDER BY fe.provider_filing_id, (isp.cik IS NULL),
+                             fe.instrument_id
+                ),
+                ranked AS (
+                    SELECT *,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY cik, filing_type
+                            ORDER BY filing_date DESC, provider_filing_id DESC
+                        ) AS rank_within_form
+                    FROM per_accession
+                )
+                SELECT r.provider_filing_id, r.instrument_id,
+                       r.filing_date, r.primary_document_url
+                FROM ranked r
+                LEFT JOIN def14a_ingest_log log
+                    ON log.accession_number = r.provider_filing_id
+                WHERE log.accession_number IS NULL
+                  AND r.primary_document_url IS NOT NULL
+                  AND (r.filing_type <> 'DEF 14A'
+                       OR r.cik IS NULL
+                       OR r.rank_within_form <= %(cap)s)
+                ORDER BY r.filing_date DESC, r.filing_event_id DESC
                 LIMIT %(limit)s
                 """,
                 {
                     "forms": list(_DEF14A_FORM_TYPES),
+                    "cap": DEF14A_LATEST_PER_FILER_CAP,
                     "limit": limit,
                 },
             )
@@ -281,6 +380,175 @@ def _resolve_issuer_cik(
         )
         row = cur.fetchone()
     return str(row[0]) if row is not None else None
+
+
+def _resolve_target_cik_for_cap(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+) -> str | None:
+    """Resolve the issuer CIK against which the latest-N cap is
+    enforced for ``instrument_id``.
+
+    Two-step lookup (#1233 PR5 §2.6.0):
+
+    1. Direct profile row on ``instrument_id``.
+    2. Sibling-via-filing_events fallback — find any DEF 14A
+       accession that ``instrument_id`` has a filing_events row for,
+       then locate a sibling instrument that DOES have a profile
+       row, and return its CIK.
+
+    Step 2 catches the #1102 PR-B fan-out gap: per-instrument-side
+    discovery for a sibling without ``instrument_sec_profile`` would
+    otherwise route through the legacy uncapped path even though
+    its share-class siblings carry the CIK.
+
+    Returns ``None`` only when NO sibling sharing any DEF 14A
+    accession with the calling instrument has a profile (genuine
+    CIK-MISSING — parser's CIK-MISSING sentinel handles it
+    downstream).
+    """
+    with conn.cursor() as cur:
+        # Step 1 — direct profile lookup. ``instrument_sec_profile.cik``
+        # is currently ``TEXT NOT NULL`` (sql/051) so the ``cik IS NOT
+        # NULL`` guard is defensive against a future migration that
+        # relaxes the constraint; today it is a no-op.
+        cur.execute(
+            """
+            SELECT cik
+            FROM instrument_sec_profile
+            WHERE instrument_id = %s AND cik IS NOT NULL
+            LIMIT 1
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return str(row[0])
+
+        # Step 2 — sibling-via-filing_events fallback. ``ORDER BY
+        # fe_sib.instrument_id LIMIT 1`` is the deterministic
+        # tie-break (mirrors the DISTINCT ON ordering used by the
+        # universe-wide discovery CTE).
+        cur.execute(
+            """
+            SELECT isp.cik
+            FROM filing_events fe_self
+            JOIN filing_events fe_sib
+                ON fe_sib.provider_filing_id = fe_self.provider_filing_id
+               AND fe_sib.provider = 'sec'
+               AND fe_sib.instrument_id <> fe_self.instrument_id
+            JOIN instrument_sec_profile isp ON isp.instrument_id = fe_sib.instrument_id
+            WHERE fe_self.instrument_id = %s
+              AND fe_self.provider = 'sec'
+              AND fe_self.filing_type = ANY(%s)
+              AND isp.cik IS NOT NULL
+            ORDER BY fe_sib.instrument_id
+            LIMIT 1
+            """,
+            (instrument_id, list(_DEF14A_FORM_TYPES)),
+        )
+        row = cur.fetchone()
+        return str(row[0]) if row is not None else None
+
+
+def def14a_within_cap(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession_number: str,
+    instrument_id: int,
+) -> bool:
+    """True iff ``accession_number`` is allowed to ingest under the
+    latest-2-primary-proxies-per-filer cap (#1233 §4.7 PR5).
+
+    Returns ``True`` for:
+    - non-DEF-14A primary form (DEFA14A, DEFR14A, DEFM14A) —
+      supplemental forms uncapped.
+    - DEF 14A primary AND within rank ``DEF14A_LATEST_PER_FILER_CAP``
+      for its issuer CIK.
+    - DEF 14A primary AND issuer CIK is missing (CIK-MISSING
+      tombstone path handled downstream).
+
+    Returns ``False`` for:
+    - DEF 14A primary AND rank > cap for its issuer CIK.
+    - Accession not present in ``filing_events`` (out-of-corpus —
+      safe default; manifest dispatched something we cannot rank).
+
+    SQL mirrors the discovery CTE so a single rank source-of-truth
+    is exercised at both discovery + per-row gate.
+    """
+    target_cik = _resolve_target_cik_for_cap(conn, instrument_id=instrument_id)
+
+    with conn.cursor() as cur:
+        # Locate this accession's filing_type from filing_events.
+        # Out-of-corpus refusal: no row → False.
+        cur.execute(
+            """
+            SELECT filing_type
+            FROM filing_events
+            WHERE provider = 'sec'
+              AND provider_filing_id = %s
+              AND filing_type = ANY(%s)
+            LIMIT 1
+            """,
+            (accession_number, list(_DEF14A_FORM_TYPES)),
+        )
+        ft_row = cur.fetchone()
+        if ft_row is None:
+            return False
+        filing_type = str(ft_row[0])
+
+        # Supplemental forms — uncapped (spec §4.7).
+        if filing_type != DEF14A_PRIMARY_FORM_TYPE:
+            return True
+
+        # CIK-truly-missing — legacy CIK-MISSING fast tombstone path
+        # downstream; bypass cap.
+        if target_cik is None:
+            return True
+
+        # Rank this accession against the CIK's primary DEF 14A
+        # corpus (across siblings, de-duped by accession). Mirrors
+        # the universe CTE in ``discover_pending_def14a``.
+        cur.execute(
+            """
+            WITH per_accession AS (
+                SELECT DISTINCT ON (fe.provider_filing_id)
+                    fe.provider_filing_id, fe.filing_date
+                FROM filing_events fe
+                JOIN instrument_sec_profile isp
+                    ON isp.instrument_id = fe.instrument_id
+                WHERE fe.provider = 'sec'
+                  AND fe.filing_type = %s
+                  AND isp.cik = %s
+                ORDER BY fe.provider_filing_id, fe.instrument_id
+            ),
+            ranked AS (
+                SELECT provider_filing_id,
+                       ROW_NUMBER() OVER (
+                           ORDER BY filing_date DESC, provider_filing_id DESC
+                       ) AS rank_within_form
+                FROM per_accession
+            )
+            SELECT rank_within_form
+            FROM ranked
+            WHERE provider_filing_id = %s
+            """,
+            (DEF14A_PRIMARY_FORM_TYPE, target_cik, accession_number),
+        )
+        rank_row = cur.fetchone()
+
+    if rank_row is None:
+        # Accession exists in filing_events but its profile-bearing
+        # sibling's CIK doesn't include it (data-integrity edge
+        # case — the per_accession CTE filters by
+        # ``isp.cik = target_cik``; if the accession's only
+        # filing_events row points at an instrument without a
+        # profile, that row is excluded here). Treat as
+        # out-of-target-corpus → refuse (False).
+        return False
+
+    return int(rank_row[0]) <= DEF14A_LATEST_PER_FILER_CAP
 
 
 def _record_ingest_attempt(

--- a/app/services/manifest_parsers/def14a.py
+++ b/app/services/manifest_parsers/def14a.py
@@ -69,6 +69,7 @@ from app.services.def14a_ingest import (
     _record_ingest_attempt,
     _resolve_issuer_cik,
     _upsert_holding,
+    def14a_within_cap,
 )
 from app.services.manifest_parsers._classify import (
     format_upsert_error,
@@ -189,6 +190,29 @@ def _parse_def14a(
             status="tombstoned",
             parser_version=_PARSER_VERSION_DEF14A,
             error="missing instrument_id",
+        )
+
+    # #1233 PR5 §4.2 — latest-N-primary-proxies-per-filer pre-fetch
+    # gate. Refuses pre-rank-2 DEF 14A accessions BEFORE the SEC HTTP
+    # call so no rate-limit budget is burned. Supplemental form
+    # variants (DEFA14A / DEFR14A / DEFM14A) and CIK-missing
+    # accessions pass the helper and proceed via their existing
+    # tombstone paths. Out-of-corpus rows (no filing_events source)
+    # refuse — safe default for manifest rows whose source-of-truth
+    # is missing.
+    if not def14a_within_cap(
+        conn,
+        accession_number=accession,
+        instrument_id=instrument_id,
+    ):
+        logger.debug(
+            "def14a manifest parser: accession=%s exceeds latest-N primary cap; tombstoning",
+            accession,
+        )
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_DEF14A,
+            error="latest-N primary cap",
         )
 
     try:

--- a/app/services/ownership_drillthrough.py
+++ b/app/services/ownership_drillthrough.py
@@ -458,6 +458,8 @@ def _def14a_state(conn: psycopg.Connection[Any], instrument_id: int) -> Pipeline
 
         cur.execute(
             """
+            -- DEF14A-CAP-EXEMPT: read-side drilldown diagnostic
+            -- (tombstone-count). Not an ingest chokepoint.
             SELECT COUNT(*) AS tombstone_count
             FROM def14a_ingest_log log
             WHERE log.status IN ('partial', 'failed')
@@ -480,6 +482,8 @@ def _def14a_state(conn: psycopg.Connection[Any], instrument_id: int) -> Pipeline
         # review caught the gap.
         cur.execute(
             """
+            -- DEF14A-CAP-EXEMPT: read-side drilldown diagnostic
+            -- (raw-body count). Not an ingest chokepoint.
             SELECT COUNT(DISTINCT r.accession_number) AS body_count
             FROM filing_raw_documents r
             JOIN filing_events fe ON fe.provider_filing_id = r.accession_number

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -433,7 +433,6 @@ def _apply_def14a(
     partial, but in re-wash context it means the new parser is
     weaker than the prior one against the same body."""
     from app.providers.implementations.sec_def14a import parse_beneficial_ownership_table
-    from app.services.def14a_ingest import _upsert_holding
 
     # Resolution priority:
     #   1. Existing typed rows in def14a_beneficial_holdings —
@@ -446,6 +445,8 @@ def _apply_def14a(
     #      in. Codex pre-push review caught this gap — without
     #      the fallback, the cohort rewash should rescue stays on
     #      the old parser_version forever.
+    from app.services.def14a_ingest import _upsert_holding, def14a_within_cap
+
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -473,6 +474,21 @@ def _apply_def14a(
                 (raw_doc.accession_number,),
             )
             row = cur.fetchone()
+        # #1233 PR5 §4.3 — rescue path is an ingest-side write; the
+        # cap MUST apply or this branch leaks out-of-cap accessions
+        # into ``def14a_beneficial_holdings``. Happy-path (above)
+        # skips the cap because it operates on already-existing
+        # typed rows (spec §6.3 — existing rows untouched).
+        if row is not None and not def14a_within_cap(
+            conn,
+            accession_number=raw_doc.accession_number,
+            instrument_id=int(row[1]),
+        ):
+            logger.debug(
+                "def14a rewash: accession=%s rescue path blocked by latest-N primary cap",
+                raw_doc.accession_number,
+            )
+            return False
     if row is None:
         return False
     issuer_cik, instrument_id = row

--- a/docs/superpowers/plans/2026-05-20-pr5-def14a-latest-2-cap.md
+++ b/docs/superpowers/plans/2026-05-20-pr5-def14a-latest-2-cap.md
@@ -1,0 +1,769 @@
+# PR5 — DEF 14A latest-2-proxies-per-filer ingest cap (#1233 retention rubric)
+
+> Created: **2026-05-20**. Revised after Codex 1a (10 findings) + Codex 1b
+> (5 residual issues) + Codex 1c (3 residual issues) + Codex 1d (2 residual
+> issues) + Codex 1e (1 residual issue — NULL cik mishandling).
+> Spec: `docs/superpowers/specs/2026-05-19-data-retention-rubric.md` §4.7 + §7.
+> PR4 (Form 4 3y cap) merged as #1240 (commit `97448d0`).
+> PR3 (filing_events 10y cap) merged as #1239 (commit `85c9de0`).
+> PR2 (XBRL 20y + whitelist) merged as #1237 (commit `ee95ca2`).
+> PR5 prior partial: NUMERIC overflow fix folded into #1236 (`b7c566d`).
+> Umbrella: **#1233**.
+
+## 1. Scope
+
+Apply the canonical DEF 14A depth cap — **latest 2 PRIMARY `DEF 14A` accessions
+per issuer CIK** — at every writer chokepoint. Supplemental form variants
+(`DEFA14A`, `DEFR14A`, `DEFM14A`) are uncapped: they're rare amendments/
+supplements/merger proxies that don't drive bandwidth pressure, and capping
+the primary while letting supplements through matches spec §4.7's
+"current + one prior for change tracking" intent (which was talking about
+annual primary proxies).
+
+**Ingest-side only** — no `DELETE FROM def14a_*` on pre-cap rows; existing
+rows survive until the operator-driven pre-wipe (spec §6.3).
+
+Three chokepoint families:
+
+- **Legacy `filing_events` → `def14a_beneficial_holdings` path**
+  (`discover_pending_def14a` selectors driving `ingest_def14a` /
+  `bootstrap_def14a`). Both per-instrument and universe-wide branches.
+- **Manifest-worker `_parse_def14a` path** — pre-fetch gate that tombstones
+  cap-bound rows before the SEC HTTP call.
+- **Rewash rescue path** in `_apply_def14a` — the fallback that writes typed
+  rows when none existed previously (Codex 1a finding #7). The happy-path
+  (re-parse of accessions WITH existing typed rows) stays uncapped because
+  it operates on already-existing-rows under spec §6.3.
+
+Out of scope:
+
+- Row deletion of any DEF 14A table — none.
+- PRE 14A policy — already tombstoned independently (manifest parser
+  line 173).
+- 13F-HR 8-quarter cap — PR6.
+
+## 2. Cap shape — rank-based on `DEF 14A` primary form only
+
+PR2 (XBRL 20y), PR3 (filing_events 10y), PR4 (Form 4 3y) are all **time-window**
+caps. PR5 is a **count-per-filer** cap: rank `filing_type = 'DEF 14A'`
+accessions per issuer CIK, keep top `DEF14A_LATEST_PER_FILER_CAP = 2`.
+
+`DEFA14A` (definitive additional materials), `DEFR14A` (revised definitive
+proxy), `DEFM14A` (merger proxy) bypass the cap entirely — they are
+supplemental / event-driven and a same-cycle DEFA14A shouldn't evict the
+prior-year DEF 14A from the cap window (Codex 1a finding #6).
+
+### 2.1 Ranking predicate
+
+```sql
+ROW_NUMBER() OVER (
+    PARTITION BY <issuer_cik>, filing_type
+    ORDER BY filing_date DESC, provider_filing_id DESC
+) AS rank_within_form
+```
+
+Then the cap filter is:
+
+```sql
+WHERE filing_type <> 'DEF 14A'  -- supplemental forms pass unconditionally
+   OR rank_within_form <= %(cap)s  -- primary DEF 14A capped
+```
+
+`provider_filing_id DESC` tie-break is deterministic (SEC accessions are
+strictly increasing lexicographically within a filer-year). Matches the
+legacy `discover_pending_def14a` `ORDER BY filing_date DESC, filing_event_id
+DESC` secondary ordering — we use `provider_filing_id` (not
+`filing_event_id`) because share-class siblings each produce their own
+`filing_event_id` for the same accession; the rank must be invariant of
+sibling fan-out.
+
+### 2.2 Issuer-CIK resolution — prefer profile-bearing siblings
+
+`instrument_sec_profile` may be missing for some siblings of a multi-listed
+issuer (per #1102 share-class CIK semantics, only one sibling carries the
+CIK row; the bulk-ingest fan-out is the PR-B follow-up still pending).
+
+DISTINCT-ON-the-lowest-instrument_id (the legacy de-dupe order) would
+arbitrarily keep a profile-less sibling, mis-CIK the accession, and the
+`cik IS NULL` carve-out (§2.4) would route it as uncapped. Codex 1a
+finding #2.
+
+Fix: order DISTINCT ON to prefer profile-bearing siblings:
+
+```sql
+SELECT DISTINCT ON (fe.provider_filing_id)
+    fe.provider_filing_id, fe.instrument_id, fe.filing_date,
+    fe.filing_type, fe.primary_document_url, fe.filing_event_id, isp.cik
+FROM filing_events fe
+LEFT JOIN instrument_sec_profile isp ON isp.instrument_id = fe.instrument_id
+WHERE fe.provider = 'sec'
+  AND fe.filing_type = ANY(%(forms)s)
+ORDER BY fe.provider_filing_id, (isp.cik IS NULL), fe.instrument_id
+```
+
+`(isp.cik IS NULL)` evaluates to FALSE (0) before TRUE (1) in ASC ordering,
+so non-NULL CIK rows are preferred. If NO sibling has a profile, all rows
+sort equally and the deterministic `fe.instrument_id` tie-break still holds
+— `cik` is NULL on the kept row → carve-out at §2.4 lets the accession
+pass.
+
+### 2.3 Missing-URL rows are part of the rank set
+
+Spec §4.7 says "latest 2 proxies per filer (current + one prior for change
+tracking)". If the latest 2 primary DEF 14A accessions for a filer haven't
+got URLs yet, the cap is satisfied — we wait for URLs to arrive on the
+next sync. We do NOT promote rank-3 to fillable. Codex 1a finding #3.
+
+The inner CTE therefore ranks **all** primary DEF 14A accessions (URL or
+not). The `primary_document_url IS NOT NULL` filter moves to the OUTER
+query (after the rank computation):
+
+```sql
+WITH per_accession AS ( ... -- ranked across ALL DEF 14A rows -- )
+SELECT ...
+FROM per_accession
+WHERE primary_document_url IS NOT NULL   -- only fetch URL-bearing
+  AND (filing_type <> 'DEF 14A' OR rank_within_form <= %(cap)s)
+  AND log.accession_number IS NULL
+```
+
+### 2.4 NULL-CIK carve-out
+
+`LEFT JOIN instrument_sec_profile`. Where `cik IS NULL` on the kept row, the
+PARTITION BY cik groups them all together (one giant null partition). To
+avoid that mis-rank, treat NULL-CIK rows as "pass" via the outer filter:
+
+```sql
+WHERE filing_type <> 'DEF 14A'
+   OR cik IS NULL                  -- CIK-MISSING: pass; downstream tombstone fast
+   OR rank_within_form <= %(cap)s
+```
+
+CIK-MISSING accessions still reach the parser, where the existing
+`_resolve_issuer_cik → 'CIK-MISSING'` sentinel path tombstones them. The
+cap doesn't drop a class of accessions that historically tombstoned via
+the sentinel.
+
+### 2.5 Ingest-log filter ordering
+
+The rank MUST be computed across ALL accessions for the CIK (including
+already-attempted ones in `def14a_ingest_log`). Otherwise once 2 are in
+the log, the 3rd appears as rank-1 in the un-attempted subset and gets
+fetched. The `log.accession_number IS NULL` exclusion lives in the
+**outer** query, AFTER the rank has already been computed against the
+full corpus.
+
+### 2.6 Per-instrument branch — pre-scoped to target CIK
+
+`discover_pending_def14a(instrument_id=X)` is used by ad-hoc re-ingest.
+
+Codex 1a finding #1: the naïve "universe CTE + outer
+`r.instrument_id=%(iid)s`" is BROKEN because the DISTINCT ON step kept
+one arbitrary sibling per accession, so the outer filter on the calling
+instrument matches zero or partial rows.
+
+Codex 1b finding #2: scanning + ranking the entire DEF 14A universe for
+every per-instrument call is wasteful. Pre-scope to target CIK in
+Python (one round-trip), then rank only that CIK's accessions.
+
+Resulting flow:
+
+1. Python resolves target CIK via the sibling-aware lookup at
+   §2.6.0. This catches the case where the calling instrument has no
+   `instrument_sec_profile` row but a share-class sibling does — the
+   cap MUST apply because the cap is per-CIK, not per-instrument
+   (Codex 1c finding #1).
+2. **CIK-known** (either direct or sibling-derived): rank only that
+   CIK's DEF 14A accessions across siblings. Outer JOIN returns rows
+   bound to the calling instrument.
+3. **CIK-truly-missing** (no profile anywhere in the share-class
+   fan-out): legacy un-capped path. Returns the calling instrument's
+   own DEF 14A accessions; the parser-side cap-helper bypasses
+   CIK-missing accessions (§3) so we keep legacy tombstone behaviour.
+
+### 2.6.0 Sibling-aware target CIK resolution
+
+```python
+def _resolve_target_cik_for_discovery(
+    conn: psycopg.Connection[tuple], *, instrument_id: int
+) -> str | None:
+    """Resolve the target CIK for per-instrument discovery.
+
+    Two-step lookup so the cap applies even when the calling
+    instrument has no instrument_sec_profile row but a share-class
+    sibling does (per #1102 PR-B fan-out is still pending — only one
+    sibling per accession typically carries the profile).
+
+    Returns None only when NO sibling sharing any DEF 14A accession
+    with the calling instrument has a profile (genuine CIK-MISSING).
+    """
+    with conn.cursor() as cur:
+        # Step 1: direct profile lookup. Codex 1e — guard against a
+        # profile row with NULL cik (legal schema state for some
+        # rescue rows); without `cik IS NOT NULL` the `str(row[0])`
+        # would return the literal "None" and skip the sibling
+        # fallback, leaking the cap.
+        cur.execute(
+            """
+            SELECT cik
+            FROM instrument_sec_profile
+            WHERE instrument_id = %s AND cik IS NOT NULL
+            LIMIT 1
+            """,
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return str(row[0])
+
+        # Step 2: sibling-via-filing_events fallback. `ORDER BY
+        # fe_sib.instrument_id LIMIT 1` is the deterministic
+        # tie-break (mirrors the DISTINCT ON ordering used by the
+        # universe-wide discovery CTE at §2.6.2). Codex 1d finding #2.
+        cur.execute(
+            """
+            SELECT isp.cik
+            FROM filing_events fe_self
+            JOIN filing_events fe_sib
+                ON fe_sib.provider_filing_id = fe_self.provider_filing_id
+               AND fe_sib.provider = 'sec'
+               AND fe_sib.instrument_id <> fe_self.instrument_id
+            JOIN instrument_sec_profile isp ON isp.instrument_id = fe_sib.instrument_id
+            WHERE fe_self.instrument_id = %s
+              AND fe_self.provider = 'sec'
+              AND fe_self.filing_type = ANY(%s)
+              AND isp.cik IS NOT NULL
+            ORDER BY fe_sib.instrument_id
+            LIMIT 1
+            """,
+            (instrument_id, list(_DEF14A_FORM_TYPES)),
+        )
+        row = cur.fetchone()
+        return str(row[0]) if row is not None else None
+```
+
+The helper `def14a_within_cap` uses the SAME two-step resolution so
+discovery and per-row gate agree on the target CIK.
+
+```sql
+-- per-instrument branch, CIK-known
+WITH per_accession AS (
+    SELECT DISTINCT ON (fe.provider_filing_id)
+        fe.provider_filing_id, fe.filing_date, fe.filing_type,
+        fe.primary_document_url, fe.filing_event_id
+    FROM filing_events fe
+    JOIN instrument_sec_profile isp ON isp.instrument_id = fe.instrument_id
+    WHERE fe.provider = 'sec'
+      AND fe.filing_type = ANY(%(forms)s)
+      AND isp.cik = %(target_cik)s
+    ORDER BY fe.provider_filing_id, fe.instrument_id
+),
+ranked AS (
+    SELECT *,
+        ROW_NUMBER() OVER (
+            PARTITION BY filing_type
+            ORDER BY filing_date DESC, provider_filing_id DESC
+        ) AS rank_within_form
+    FROM per_accession
+)
+SELECT fe.provider_filing_id, fe.instrument_id, fe.filing_date,
+       fe.primary_document_url
+FROM ranked r
+JOIN filing_events fe
+    ON fe.provider_filing_id = r.provider_filing_id
+   AND fe.provider = 'sec'
+   AND fe.primary_document_url IS NOT NULL
+LEFT JOIN def14a_ingest_log log
+    ON log.accession_number = r.provider_filing_id
+WHERE log.accession_number IS NULL
+  AND (r.filing_type <> 'DEF 14A' OR r.rank_within_form <= %(cap)s)
+  AND fe.instrument_id = %(iid)s
+ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
+LIMIT %(limit)s
+```
+
+Pre-scoping by `isp.cik = %(target_cik)s` in the inner CTE bounds the
+rank universe to the filer's history. Single PARTITION on filing_type
+(CIK is constant within the CTE).
+
+### 2.6.1 Calling instrument missing accession's filing_events row
+
+A sibling fan-out gap can mean the calling instrument doesn't have a
+filing_events row for an accession (the ingest only landed for the
+profile-bearing sibling, per #1102 PR-B pending). Pre-cap behaviour:
+the per-instrument selector returned zero rows for that accession. The
+cap doesn't change that — `fe.instrument_id = %(iid)s` in the outer
+JOIN still filters to the calling instrument's view. Acceptable: the
+per-instrument selector's contract is "accessions visible to this
+instrument", not "accessions belonging to the issuer".
+
+**Test scope clarification** (Codex 1c finding #2): the §6.2 "both
+siblings see the same 2 accessions" claim holds only when both
+siblings have filing_events rows for the accession (i.e. fan-out
+complete). When fan-out is incomplete, sibling-without-rows sees zero
+— matching legacy per-instrument behaviour. The cap doesn't promote
+sibling-B to see an accession it never had a filing_events row for;
+that would change the legacy contract. Test §6.2 must seed both
+sibling rows to assert the "same 2 accessions" invariant, and a
+separate test asserts the asymmetric-fan-out legacy preservation.
+
+### 2.6.2 Universe-wide branch
+
+```sql
+-- universe-wide branch
+WITH per_accession AS (
+    SELECT DISTINCT ON (fe.provider_filing_id)
+        fe.provider_filing_id, fe.instrument_id, fe.filing_date,
+        fe.filing_type, fe.primary_document_url, fe.filing_event_id,
+        isp.cik
+    FROM filing_events fe
+    LEFT JOIN instrument_sec_profile isp ON isp.instrument_id = fe.instrument_id
+    WHERE fe.provider = 'sec'
+      AND fe.filing_type = ANY(%(forms)s)
+    ORDER BY fe.provider_filing_id, (isp.cik IS NULL), fe.instrument_id
+),
+ranked AS (
+    SELECT *,
+        ROW_NUMBER() OVER (
+            PARTITION BY cik, filing_type
+            ORDER BY filing_date DESC, provider_filing_id DESC
+        ) AS rank_within_form
+    FROM per_accession
+)
+SELECT r.provider_filing_id, r.instrument_id, r.filing_date,
+       r.primary_document_url
+FROM ranked r
+LEFT JOIN def14a_ingest_log log
+    ON log.accession_number = r.provider_filing_id
+WHERE log.accession_number IS NULL
+  AND r.primary_document_url IS NOT NULL
+  AND (r.filing_type <> 'DEF 14A'
+       OR r.cik IS NULL
+       OR r.rank_within_form <= %(cap)s)
+ORDER BY r.filing_date DESC, r.filing_event_id DESC
+LIMIT %(limit)s
+```
+
+**Universe-wide returns directly from `ranked` — no outer JOIN back to
+`filing_events`.** Codex 1b finding #1: an outer JOIN without
+`instrument_id` scoping would fan one accession to N sibling rows,
+duplicating accessions and burning the LIMIT slot. The `per_accession`
+CTE already de-duped to one representative row per accession (the
+profile-bearing sibling, lowest iid tie-break) — use it directly.
+
+### 2.6.3 Conflicting profile-bearing CIKs (Codex 1b finding #3)
+
+If two profile-bearing siblings for the same accession have different
+`isp.cik` values, the DISTINCT ON deterministically keeps the
+lowest-iid sibling. The cap is then computed against THAT sibling's
+CIK. This is consistent (helper and discovery use the same
+DISTINCT ON ordering, so both pick the same kept row), but it is a
+data-integrity violation per #1102 "CIK = entity".
+
+PR5 does NOT add conflict detection in the SQL. The CIK column on
+`external_identifiers` already enforces partial-unique constraints
+(sql/143). A conflict at the `instrument_sec_profile` level (the table
+PR5 reads from) would already be a regression of #1102 invariants and
+out of scope here. The plan records this trade-off so a future audit
+ticket can revisit.
+
+Optional: add a low-cost sanity log in the helper when it detects
+`COUNT(DISTINCT cik) > 1` for the queried accession (single
+GROUP BY query, no per-row cost on the cap path). Defer to a follow-up
+if Codex 1c flags it again — keeps PR5 scope tight.
+
+## 3. Constants + helper
+
+`app/services/def14a_ingest.py`:
+
+```python
+DEF14A_LATEST_PER_FILER_CAP: int = 2
+DEF14A_PRIMARY_FORM_TYPE: str = "DEF 14A"
+
+
+def def14a_within_cap(
+    conn: psycopg.Connection[Any],
+    *,
+    accession_number: str,
+    instrument_id: int,
+) -> bool:
+    """True iff `accession_number` is allowed to ingest under the
+    latest-2-primary-proxies-per-filer cap (#1233 §4.7).
+
+    Returns True for:
+    - non-DEF-14A primary form (DEFA14A, DEFR14A, DEFM14A) — supplemental.
+    - DEF 14A primary AND within rank %(cap)s for its issuer CIK.
+    - DEF 14A primary AND issuer CIK is missing (CIK-MISSING
+      tombstone path handled downstream).
+
+    Returns False for:
+    - DEF 14A primary AND rank > cap for its issuer CIK.
+    - Accession not present in `filing_events` (out-of-corpus —
+      safe default; manifest dispatched something we cannot rank).
+      Codex 1a finding #8.
+
+    SQL mirrors the discovery CTE so a single rank source-of-truth
+    is exercised at both discovery + per-row gate.
+    """
+```
+
+### 3.1 Out-of-corpus default
+
+The helper returns **False (refuse)** when the accession is absent from
+`filing_events` (Codex 1a finding #8). The manifest worker is itself a
+chokepoint — a "pass on unknown" default would let an unranked accession
+through. Manifest rows whose `filing_events` source row is missing are
+data-integrity anomalies that should tombstone, not fetch.
+
+## 4. Chokepoint coverage
+
+### 4.1 Legacy discovery path
+
+`app/services/def14a_ingest.py::discover_pending_def14a`. Both branches
+get the CTE described in §2.6.
+
+| Branch | Current state | Fix |
+| --- | --- | --- |
+| `:202-223` per-instrument | No cap; targeted `fe.instrument_id=%(iid)s` | Replace with §2.6 per-instrument CTE shape |
+| `:224-249` universe-wide | `DISTINCT ON (provider_filing_id)` only | Replace with §2.6 universe shape (no `fe.instrument_id` outer filter) |
+
+Helper-bound: both branches pass `DEF14A_LATEST_PER_FILER_CAP` as
+`%(cap)s` param + `_DEF14A_FORM_TYPES` as `%(forms)s`. No magic literal in
+the SQL.
+
+### 4.2 Manifest-worker parser path
+
+`app/services/manifest_parsers/def14a.py::_parse_def14a`. Pre-fetch gate.
+
+**Explicit gate order** (Codex 1a finding #4 + #5):
+
+1. Missing URL → tombstone (line 154 — unchanged).
+2. PRE 14A → tombstone (line 173 — unchanged).
+3. Missing `instrument_id` → tombstone (line 183 — unchanged).
+4. **NEW: cap check via `def14a_within_cap`** (inserted at line ~193,
+   immediately before `fetch_document_text` at line 196).
+
+Cap check requires non-NULL `instrument_id` so it MUST follow the
+missing-iid guard. The PRE 14A check at line 173 fires before missing-iid
+so PRE 14A with no iid still tombstones as PRE policy — matching legacy
+behaviour. Form-type isn't passed to the helper because the helper reads
+`filing_type` from `filing_events` itself (single source of truth).
+
+```python
+if not def14a_within_cap(
+    conn,
+    accession_number=accession,
+    instrument_id=instrument_id,
+):
+    logger.debug(
+        "def14a manifest parser: accession=%s exceeds latest-2-primary cap; tombstoning",
+        accession,
+    )
+    return ParseOutcome(
+        status="tombstoned",
+        parser_version=_PARSER_VERSION_DEF14A,
+        error="latest-N primary cap",
+    )
+```
+
+No `def14a_ingest_log` row is written — capped rows are not "attempted"
+in the ingest-log sense; they're refused upstream. Manifest row
+transitions to `success` with the tombstoned outcome (mirrors PR4's
+manifest-worker tombstone semantics).
+
+Rewash via parser-version bump on a pre-fetch tombstone is NOT possible
+because no `filing_raw_documents` row exists; operator revival path is
+`POST /jobs/sec_rebuild/run` source reset (mirrors PR4 §6 trade-off).
+
+### 4.3 Rewash path — rescue is capped, happy-path is not
+
+`app/services/rewash_filings.py::_apply_def14a`. Codex 1a finding #7
+caught the leak: the rescue fallback (lines 462-475) writes NEW typed
+rows for accessions that previously had only an ingest_log entry. That
+IS an ingest-side write and the cap MUST apply.
+
+The happy-path (line 449-460 — typed rows already exist) is NOT capped:
+re-parsing existing populated rows is the spec §6.3 "existing rows
+untouched" carve-out (we're updating fields, not creating new typed-row
+entries for new accessions).
+
+Implementation:
+
+```python
+def _apply_def14a(conn, raw_doc):
+    # ... existing typed-row lookup at lines 449-460 ...
+    had_existing_rows = row is not None
+
+    if row is None:
+        # ... existing fallback to ingest_log + filing_events ...
+        # NEW: cap check on the rescue path before writing typed rows
+        if row is not None:
+            iid_for_cap = int(row[1])  # instrument_id from fallback row
+            if not def14a_within_cap(
+                conn,
+                accession_number=raw_doc.accession_number,
+                instrument_id=iid_for_cap,
+            ):
+                logger.debug(
+                    "def14a rewash: accession=%s rescue path blocked by latest-N cap",
+                    raw_doc.accession_number,
+                )
+                return False
+    if row is None:
+        return False
+    # ... rest of function unchanged ...
+```
+
+`return False` matches the existing "rewash isn't a first-time ingester"
+contract (line 428-430). Operator-visible: rescue cohort that's out-of-
+cap stays on the old parser_version. That's the correct behaviour —
+they're scheduled for the pre-wipe + clean re-run, not the rescue sweep.
+
+## 5. Lint guard
+
+`scripts/check_def14a_cap.sh`. Mirrors `scripts/check_form4_retention.sh`
+shape from PR4. Block-parsing via `awk` (BSD vs GNU `grep -P` portability).
+
+Four invariants — all enforce **block-level**, not file-level, parity.
+
+**A. Repo-wide DEF14A discovery block parity** (Codex 1a finding #9 +
+Codex 1b finding #4 + Codex 1c finding #3 + Codex 1d finding #1):
+
+   **Signal detection** — a SQL block is a DEF14A chokepoint if EITHER:
+
+   1. The block body contains a DEF14A form-type literal:
+      `'DEF 14A'` / `'DEFA14A'` / `'DEFM14A'` / `'DEFR14A'`.
+   2. The block body contains `filing_type = ANY(%(forms)s)`
+      (parameterised form) AND the surrounding ±20 lines of Python
+      source reference `_DEF14A_FORM_TYPES` (the parameter binding).
+
+   Both shapes appear in the codebase — the discovery CTEs use the
+   parameterised `ANY(%(forms)s)` with `_DEF14A_FORM_TYPES` passed as
+   the `forms` param. The lint catches both.
+
+   The SAME block MUST contain ONE of three block-level compliance
+   markers:
+
+   1. SQL predicate `rank_within_form <= %(cap)s` (the inline rank CTE
+      pattern used by `discover_pending_def14a`).
+   2. A `def14a_within_cap(` Python call within ±5 lines of the SQL
+      block boundary (the per-row Python-gate pattern, e.g. for paths
+      that fetch a candidate then check the cap before writing).
+   3. Single-line SQL comment `-- DEF14A-CAP-EXEMPT: <reason>` inside
+      the block (explicit operator override; must include a reason
+      string).
+
+   Block extraction: awk parses Python triple-quoted SQL literals
+   (`"""..."""` and `'''...'''`). For each block whose body contains a
+   DEF14A signal, the awk pass records the start + end line numbers.
+   Compliance check then scans (start-5 .. end+5) lines for any of
+   the three markers above. Files where any chokepoint block has zero
+   compliance markers fail.
+
+   File-level presence is NOT enough: a file with one compliant block
+   plus one uncapped block must fail. The awk pass tracks per-block
+   booleans, not per-file aggregates.
+
+**B. `app/services/def14a_ingest.py` per-block parity** (subset of A,
+   exercised independently for fast regression detection):
+
+   Every DEF14A-signal SQL block in `discover_pending_def14a` MUST
+   contain ONE of the three compliance markers from invariant A.
+   This explicitly mirrors A's "compliance marker count == chokepoint
+   count" rule, so the per-instrument CIK-truly-missing legacy
+   branch (which has no rank predicate by design — the cap relies on
+   the parser-side helper to gate CIK-missing accessions) carries an
+   inline `-- DEF14A-CAP-EXEMPT: CIK-MISSING legacy uncapped` SQL
+   comment. Without that marker, the block fails parity.
+
+**C. `app/services/manifest_parsers/def14a.py` pre-fetch placement**
+   (Codex 1a finding #10):
+
+   In `_parse_def14a` function body: the line number of the first
+   `def14a_within_cap(` call MUST be > the line number of the
+   missing-`instrument_id` check (so iid is non-None) AND < the line
+   number of the first `provider.fetch_document_text(` call. Awk
+   tracks line numbers; either ordering inversion fails.
+
+**D. `app/services/rewash_filings.py::_apply_def14a` rescue-branch
+   placement** (Codex 1b finding #5):
+
+   Extract `_apply_def14a` function body. Locate the rescue-fallback
+   block: the second `LEFT JOIN def14a_ingest_log` query that runs
+   when `had_existing_rows` is false (between the `if row is None:`
+   re-query and the parse step). The `def14a_within_cap(` call MUST
+   appear AFTER `had_existing_rows = row is not None` AND AFTER the
+   rescue-fallback SELECT that re-binds `row`, AND BEFORE the
+   `parse_beneficial_ownership_table(` call.
+
+   The lint asserts:
+   1. Exactly one `def14a_within_cap(` call in `_apply_def14a`.
+   2. Its line > the rescue-fallback SELECT's `SELECT log.issuer_cik`
+      anchor line.
+   3. Its line < `parse_beneficial_ownership_table(` line.
+
+   Placement-aware: a misplaced cap call on the happy-path branch
+   (before `had_existing_rows`) OR after the parse fails.
+
+Wired into `.githooks/pre-push`.
+
+## 6. Tests
+
+New file `tests/test_def14a_latest_n_cap.py`. Mirrors PR4's
+`test_insider_transactions_retention_cap.py` shape.
+
+### 6.1 Helper unit tests (`def14a_within_cap`)
+
+- 5 `DEF 14A` accessions for one CIK, ranked by `filing_date DESC`.
+  Top-2 pass, bottom-3 fail.
+- 5 `DEFA14A` for one CIK: all 5 pass (supplemental form uncapped).
+- Mixed: 3 DEF 14A + 2 DEFA14A in same year. Top-2 DEF 14A pass; bottom
+  DEF 14A fails; both DEFA14As pass.
+- Tie-break: same `filing_date`, different `provider_filing_id` → higher
+  `provider_filing_id` ranks higher.
+- CIK-missing (no `instrument_sec_profile` row): helper returns `True`
+  regardless of rank or form.
+- Share-class siblings sharing CIK: 5 DEF 14A × 2 siblings = 5 distinct
+  accessions ranked (not 10). Top-2 pass for both siblings; same set.
+- Profile-only-on-one-sibling: rank source is the profile-bearing
+  sibling; calling instrument may not have profile but its sibling does
+  → cap applies. Verifies §2.2 fix.
+- **NULL-cik direct profile + sibling fallback** (Codex 1e regression
+  test): seed calling instrument with `instrument_sec_profile.cik IS
+  NULL` and a sibling with non-NULL CIK → §2.6.0 step 1 skips the NULL
+  row (due to `WHERE cik IS NOT NULL`), step 2 finds the sibling's
+  CIK, cap applies.
+- Accession not in `filing_events`: helper returns `False` (out-of-corpus
+  refusal — §3.1).
+
+### 6.2 Discovery query (`discover_pending_def14a`)
+
+- Universe-wide: seed 5 DEF 14A across 2 CIKs, universe call → returns 4
+  (2 per CIK). Bottom 6 not returned.
+- Universe-wide with DEFA14A mixed: 3 DEF 14A + 2 DEFA14A → all 5
+  returned (DEF 14A cap = 2; DEFA14A unconditional).
+- Per-instrument: same 2-per-CIK set returned, scoped to the calling
+  instrument's filing_events row (Codex finding #1 regression test).
+- Per-instrument with sibling fan-out: sibling A and sibling B both
+  call → both see the same 2 accessions, each bound to its own
+  filing_events row.
+- Existing `def14a_ingest_log` row excludes accession even if within
+  rank — but the rank is computed across ALL accessions including
+  logged ones. Verify: log the top 2 of 5, query → returns 0 (not the
+  3rd) (Codex finding §2.5 regression test).
+- Missing-URL accession at rank 1/2: latest-2-with-URLs NOT promoted;
+  query returns 0 for that filer (Codex finding #3 regression test).
+- CIK-missing instrument: all its primary DEF 14A accessions returned
+  (uncapped path).
+- DISTINCT-ON-prefers-profile-bearing-sibling: seed 1 accession with 2
+  filing_events rows (one profile-bearing, one not) → rank computed
+  using the profile sibling's CIK (Codex finding #2 regression test).
+
+### 6.3 Parser pre-fetch gate (`_parse_def14a`)
+
+- Cap-bound DEF 14A accession (rank 3+ for its CIK): parser returns
+  tombstoned, NO HTTP call, NO `filing_raw_documents` write, NO
+  `def14a_ingest_log` row.
+- Within-cap DEF 14A (rank 1 or 2): parser proceeds (existing happy-path
+  test should still pass).
+- CIK-missing DEF 14A: parser bypasses cap (proceeds to existing
+  CIK-MISSING tombstone path).
+- DEFA14A at any rank: cap bypassed (supplemental form passes
+  unconditionally).
+- Out-of-corpus accession (no filing_events row): parser tombstones
+  (helper returns False).
+- Cap check fires AFTER PRE 14A + missing-iid checks (Codex finding #4 +
+  #5 regression test).
+
+### 6.4 Rewash path (`_apply_def14a`)
+
+- Happy-path: accession with existing typed rows → cap NOT consulted
+  (rewash proceeds even for rank-3+).
+- Rescue path on within-cap accession: rewash writes typed rows.
+- Rescue path on out-of-cap accession: rewash returns False, no typed
+  rows written (Codex finding #7 regression test).
+
+### 6.5 Lint guard meta-tests
+
+`tests/test_check_def14a_cap_lint.py` — verify:
+
+- Adding a new `filing_type = ANY(...)` block in a fresh file without
+  `def14a_within_cap(` or `%(cap)s` predicate → guard fails.
+- Removing the `def14a_within_cap(` call from `_parse_def14a` → guard
+  fails.
+- Moving the `def14a_within_cap(` call to AFTER `fetch_document_text(`
+  in `_parse_def14a` → guard fails (placement check).
+- Removing the cap call from `_apply_def14a` rescue branch → guard fails.
+
+## 7. Spec amendment
+
+Update spec §4.7:
+
+- Reword "**Ingest depth cap**: **latest 2 proxies per filer** (current
+  + one prior for change tracking) at the parser. Older filings not
+  fetched." to clarify: **latest 2 PRIMARY `DEF 14A` accessions** per
+  filer; `DEFA14A` / `DEFR14A` / `DEFM14A` uncapped.
+- Note Codex 1a finding #6 rationale: supplemental forms shouldn't evict
+  prior-year primary; uncapping them is the cleaner shape.
+
+Update spec §7:
+
+- PR5 status: "**PR5 — SHIPPED.** DEF 14A latest-2-primary-proxies cap
+  at discovery + parser + rewash-rescue chokepoints. NUMERIC overflow
+  #1228 already folded (#1236)."
+
+Update spec §12 handover: next session picks up PR6 (13F-HR 8-quarter
+cap, already cohort-bounded by #1010).
+
+## 8. Test plan
+
+- [ ] `uv run ruff check .` clean
+- [ ] `uv run ruff format --check .` clean
+- [ ] `uv run pyright` clean
+- [ ] `bash scripts/check_def14a_cap.sh` clean
+- [ ] `bash scripts/check_form4_retention.sh` clean (PR4 invariant survives)
+- [ ] `bash scripts/check_instruments_inserts.sh` clean (PR1 invariant)
+- [ ] `uv run pytest tests/test_def14a_latest_n_cap.py` — all green
+- [ ] `uv run pytest tests/test_check_def14a_cap_lint.py` — all green
+- [ ] `uv run pytest tests/test_def14a_ingest.py` — existing tests still green
+- [ ] `uv run pytest tests/test_manifest_parser_def14a.py` — existing tests
+  still green
+
+## 9. Trade-offs
+
+- **Latest-2-primary is operator-visible**: pre-rank-2 DEF 14A accessions
+  stop being ingested. Operator widens via `DEF14A_LATEST_PER_FILER_CAP`
+  if archaeology becomes a need.
+- **Supplemental forms uncapped**: a filer with 10 DEFA14As in one year
+  still ingests all 10. Acceptable because (a) DEFA14As are rare,
+  (b) capping them risks evicting a prior-year primary from the window,
+  (c) DEFA14As typically supplement the current cycle's primary —
+  losing them would damage current-state holders rollups.
+- **Out-of-corpus refusal**: manifest rows without `filing_events` source
+  tombstone (safe-default). Operator path to revive: rebuild
+  filing_events for the accession via `POST /jobs/sec_rebuild/run` source
+  reset, then re-enqueue the manifest row.
+- **Manifest tombstones not revivable via parser-version rewash**:
+  pre-fetch tombstones write no `filing_raw_documents` row (mirrors PR4).
+- **Cumulative state post-wipe**: pre-rank-2 primaries' top-5-holders
+  pies reset; the next clean ingest builds going forward from the
+  latest-2 only. Spec §6.3 — operator-accepted.
+
+## 10. Scope NOT in this PR
+
+- Existing pre-cap rows are untouched (#1233 §6.3 — operator-driven
+  pre-wipe is the single purge event).
+- PRE 14A policy change — already tombstoned (manifest parser line 173).
+- 13F-HR 8-quarter cap — PR6.
+- `ownership_*_current` size audit — PR12.
+
+## 11. Codex review gate
+
+- **Codex 1a — DONE** (10 findings).
+- **Codex 1b — DONE** (5 residual issues).
+- **Codex 1c — DONE** (3 residual issues).
+- **Codex 1d — DONE** (2 residual issues).
+- **Codex 1e — DONE** (1 residual issue).
+- **Codex 1f — DONE** (3 residual issues; this revision).
+- **Codex 2** pre-push on branch diff (mandatory per #1208 cadence).
+- Standard review-bot + CI cadence thereafter.

--- a/docs/superpowers/specs/2026-05-19-data-retention-rubric.md
+++ b/docs/superpowers/specs/2026-05-19-data-retention-rubric.md
@@ -169,7 +169,7 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 47k raw rows, 17 MB; 40k obs rows, 24 MB; combined ~50 MB.
 - **Half-life**: **slow state, but only LATEST matters** — DEF 14A is the annual snapshot; the prior year's snapshot is decoration.
 - **Consumers**: top-5-holders pie chart; AI thesis "Top 5 institutional holders are…"; executive-comp slice (separate epic).
-- **Ingest depth cap**: **latest 2 proxies per filer** (current + one prior for change tracking) at the parser. Older filings not fetched.
+- **Ingest depth cap**: **latest 2 PRIMARY `DEF 14A` accessions per filer** (current + one prior for change tracking) at every chokepoint (discovery rank CTE, manifest-worker pre-fetch gate, rewash rescue gate). Supplemental form variants (`DEFA14A`, `DEFR14A`, `DEFM14A`) are **uncapped** — a same-cycle DEFA14A shouldn't evict the prior-year primary `DEF 14A` from the cap window; supplements are rare amendments / merger proxies that don't drive bandwidth pressure. Codex 1a (PR5) lesson.
 - **NUMERIC overflow bug**: #1228 — fix already landed via PR5 fold-in (#1236).
 - **Existing rows**: untouched until pre-wipe (§6.3).
 - **Why this matters**: not storage (small); ingest-budget. DEF 14A is HTML scrape — 1h per pass with deadline cap; 5y of proxies × 5,174 filers = un-drainable in one pass. 2-proxy cap = ~80% reduction in candidate set.
@@ -330,7 +330,7 @@ Land per-source PRs in this order. Each PR is **ingest-side cap only** — no PR
 - **PR2 — SHIPPED (#1237).** Companyfacts XBRL concept whitelist (~50 numeric us-gaap + ~3 DEI concepts) + 20y rolling cap at the parser. Every write path (bulk + steady-state).
 - **PR3 — pending.** Filing events 10y rolling cap at the parser. Applied uniformly across every filing_type via every discovery writer. Schema columns + existing rows untouched.
 - **PR4 — IN PROGRESS.** Form 4 / 4-A 3y ingest cap at every writer chokepoint (legacy filing_events SELECTs, manifest-worker `_parse_form4` pre-fetch gate, bulk-dataset Form-4-only filter). Cumulative-rollup invariant pinned by steady-state test; synthetic opening-balance anchor NOT written (§4.3 amendment, this commit). Recency cohort bound inherited from PR1 `is_tradable=TRUE` filter (no insider-filer cohort table; Form 4 walked per-issuer-CIK via filing_events). Includes a parity lint guard catching new chokepoints that omit the predicate.
-- **PR5 — partially shipped (#1236 NUMERIC fix).** DEF 14A latest-2-proxies cap at the parser. NUMERIC overflow #1228 already folded.
+- **PR5 — SHIPPED.** DEF 14A latest-2-PRIMARY-proxies cap at discovery + parser + rewash-rescue chokepoints. Supplemental form variants (DEFA14A / DEFR14A / DEFM14A) uncapped (§4.7). NUMERIC overflow #1228 already folded (#1236).
 - **PR6 — pending.** 13F-HR 8-quarter ingest cap at the parser. (#1010 cohort bound already in place.)
 - **PR7 — pending.** N-PORT 8-quarter cap (mirror of PR6). N-PORT recency cohort bound (`last_nport_at`) per #1010 pattern.
 - **PR8 — pending.** N-CSR/N-CSRS validate existing 2y horizon. Doc-only unless drift found.
@@ -401,24 +401,26 @@ Per #1208 cadence:
 
 State as of this commit:
 
-- PR1 bundles cross-cutting code (country populate + is_tradable filter audit + lint guard) AND this spec revision (drop-policy → ingest-side-caps-only).
-- PR2 (#1237) + PR5 NUMERIC fix (#1236) already shipped.
-- PR3-PR12 remain — every one is ingest-side cap only, no row deletion. The pre-wipe is the single operator event at the end.
+- PR1 (#1238), PR2 (#1237), PR3 (#1239), PR4 (#1240), PR5 NUMERIC fix
+  (#1236) and PR5 latest-2-primary cap (this commit) all shipped.
+- PR6-PR12 remain — every one is ingest-side cap only, no row deletion.
+  The pre-wipe is the single operator event at the end.
 
 ```text
-After PR1 merges, the next session picks up PR3
-(filing_events 10y rolling cap at the parser).
+After PR5 merges, the next session picks up PR6
+(13F-HR 8-quarter ingest cap at the parser).
 
-PR3 scope:
-- Identify every filing_events discovery writer (Atom fast-lane, daily-index
-  reconcile, first-install drain, per-CIK poll, targeted rebuild).
-- Apply 10y depth cap at the parser layer so every writer respects it.
-- Preserve raw_payload_json (#1014 is the separate slice).
-- No DELETE of pre-10y rows. They survive until the §6.3 pre-wipe.
+PR6 scope:
+- 13F-HR observations: per-filer 8-quarter rank cap.
+- #1010 cohort bound (last_13f_hr_at 380d) already in place — the
+  cohort is bounded; PR6 adds per-filer depth.
+- Identify every 13F-HR writer (manifest-worker parser, bulk drain,
+  rewash path) and apply the per-quarter rank cap at each.
+- No DELETE of pre-8q rows. They survive until the §6.3 pre-wipe.
 
 FIRST ACTIONS:
-1. Read CLAUDE.md working order + the revised §3.3 / §4.2 / §6.3 / §7.
-2. Confirm PR1 merged. Confirm #1233 still OPEN as the umbrella.
-3. Branch `feature/1233-pr3-filing-events-10y-cap`.
+1. Read CLAUDE.md working order + the revised §4.5.
+2. Confirm PR5 merged. Confirm #1233 still OPEN as the umbrella.
+3. Branch `feature/1233-pr6-13f-hr-8q-cap`.
 4. Codex 1a on plan, then Codex 2 pre-push, then PR.
 ```

--- a/scripts/check_def14a_cap.sh
+++ b/scripts/check_def14a_cap.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+#
+# Lint guard: every DEF 14A writer chokepoint MUST honour the
+# latest-2-primary-proxies-per-filer cap (#1233 §4.7 PR5).
+#
+# Four block-level invariants (NOT file-level):
+#
+# A. Repo-wide DEF14A SQL block parity. Every SQL block under app/
+#    that contains a DEF14A signal (literal form-type strings OR
+#    parameterised `ANY(%(forms)s)` near `_DEF14A_FORM_TYPES`) MUST
+#    contain ONE of three block-level compliance markers:
+#      1. `rank_within_form <= %(cap)s` predicate (inline CTE
+#         pattern).
+#      2. `def14a_within_cap(` Python call within ±5 lines of the
+#         SQL block boundary (per-row helper pattern).
+#      3. `-- DEF14A-CAP-EXEMPT: <reason>` SQL comment inside the
+#         block (explicit operator override).
+#
+# B. `app/services/def14a_ingest.py::discover_pending_def14a` per-
+#    block parity. Same rule as A but scoped to that one function so
+#    a single-block regression is detected without parsing the whole
+#    repo.
+#
+# C. `app/services/manifest_parsers/def14a.py::_parse_def14a` pre-
+#    fetch placement. The `def14a_within_cap(` line MUST be > the
+#    missing-instrument_id check line AND < the first
+#    `provider.fetch_document_text(` call line.
+#
+# D. `app/services/rewash_filings.py::_apply_def14a` rescue-branch
+#    placement. Exactly one `def14a_within_cap(` call; its line MUST
+#    be > the rescue-fallback `SELECT log.issuer_cik` anchor AND <
+#    the `parse_beneficial_ownership_table(` call.
+#
+# Exits non-zero on the first invariant violation. Wired into
+# `.githooks/pre-push`.
+#
+# Block-parsing uses awk (BSD vs GNU `grep -P` portability — PR4
+# Codex 1c lesson).
+
+set -euo pipefail
+
+violations=0
+fail() {
+  echo "::error::$1" >&2
+  violations=$((violations + 1))
+}
+
+# ----------------------------------------------------------------------
+# Helper: extract every Python triple-quoted block (start_line:end_line)
+# for a single file. Detects both ``"""`` and ``'''`` quote styles
+# (single-line same-quote opens-and-closes excluded). Mixed-quote SQL
+# is vanishingly rare in this repo and a future hit would surface as a
+# parity failure rather than silent miss.
+# ----------------------------------------------------------------------
+extract_blocks() {
+  local file="$1"
+  awk '
+    {
+      n_dq = gsub(/"""/, "&", $0)
+      n_sq = gsub(/'\'''\'''\''/, "&", $0)
+      if (n_dq == 1) {
+        if (in_dq) { print start_dq ":" NR; in_dq = 0 }
+        else       { start_dq = NR;       in_dq = 1 }
+      }
+      if (n_sq == 1) {
+        if (in_sq) { print start_sq ":" NR; in_sq = 0 }
+        else       { start_sq = NR;       in_sq = 1 }
+      }
+    }
+  ' "$file"
+}
+
+# ----------------------------------------------------------------------
+# Helper: scan an arbitrary range of lines and return 1 if any marker
+# (literal form-type | ANY(%(forms)s) + _DEF14A_FORM_TYPES nearby) is
+# present. Used by invariants A + B.
+# ----------------------------------------------------------------------
+block_has_def14a_signal() {
+  local file="$1" start="$2" end="$3"
+  local block
+  block=$(awk -v s="$start" -v e="$end" 'NR>=s && NR<=e' "$file")
+
+  # Signal 1: literal form-type string inside the block.
+  if echo "$block" | grep -qE "'DEF 14A'|'DEFA14A'|'DEFM14A'|'DEFR14A'"; then
+    echo 1
+    return
+  fi
+
+  # Signal 2: `filing_type = ANY(%(forms)s)` inside the block AND
+  # `_DEF14A_FORM_TYPES` referenced within ±20 lines of the block.
+  if echo "$block" | grep -qE 'filing_type = ANY\(%\(forms\)s\)'; then
+    local ctx_start ctx_end
+    ctx_start=$((start - 20))
+    if (( ctx_start < 1 )); then ctx_start=1; fi
+    ctx_end=$((end + 20))
+    if awk -v s="$ctx_start" -v e="$ctx_end" 'NR>=s && NR<=e' "$file" \
+       | grep -q '_DEF14A_FORM_TYPES'; then
+      echo 1
+      return
+    fi
+  fi
+
+  echo 0
+}
+
+# ----------------------------------------------------------------------
+# Helper: check whether a block has at least one of the three
+# compliance markers (rank predicate, nearby def14a_within_cap call,
+# inline exemption marker).
+# ----------------------------------------------------------------------
+block_is_compliant() {
+  local file="$1" start="$2" end="$3"
+  local block
+  block=$(awk -v s="$start" -v e="$end" 'NR>=s && NR<=e' "$file")
+
+  # Marker 1: rank predicate inside the block.
+  if echo "$block" | grep -qE 'rank_within_form <= %\(cap\)s'; then
+    echo 1
+    return
+  fi
+
+  # Marker 3: inline exemption comment inside the block.
+  if echo "$block" | grep -qE -- '-- DEF14A-CAP-EXEMPT:'; then
+    echo 1
+    return
+  fi
+
+  # Marker 2: `def14a_within_cap(` Python call within ±5 lines of the
+  # block boundary.
+  local ctx_start ctx_end
+  ctx_start=$((start - 5))
+  if (( ctx_start < 1 )); then ctx_start=1; fi
+  ctx_end=$((end + 5))
+  if awk -v s="$ctx_start" -v e="$ctx_end" 'NR>=s && NR<=e' "$file" \
+     | grep -q 'def14a_within_cap('; then
+    echo 1
+    return
+  fi
+
+  echo 0
+}
+
+# ----------------------------------------------------------------------
+# Helper: line number of first match (literal substring) inside a
+# function body. BSD awk doesn't accept ``(`` in regex patterns — use
+# index() for literal substring matching.
+#
+# Body bounded by ``def <name>(`` and the next top-level ``def``
+# (column 0) or end-of-file. We don't track indent levels — every
+# top-level ``def`` ends the previous function.
+# ----------------------------------------------------------------------
+first_line_in_function() {
+  local file="$1" fname="$2" literal="$3"
+  awk -v fname="$fname" -v literal="$literal" '
+    BEGIN {
+      in_fn = 0
+      anchor = "def " fname "("
+    }
+    {
+      # Function start anchor — match leading ``def <fname>(``
+      # against the line. Use index() to avoid regex escaping of
+      # the open-paren in awk on BSD.
+      if (!in_fn) {
+        # Strip leading whitespace, then check prefix.
+        stripped = $0
+        sub(/^[[:space:]]+/, "", stripped)
+        if (index(stripped, anchor) == 1) {
+          in_fn = 1
+          fn_start_nr = NR
+        }
+        next
+      }
+      # In-function. Top-level ``def `` (column 0) ends the body.
+      if (NR > fn_start_nr && substr($0, 1, 4) == "def ") {
+        in_fn = 0
+        next
+      }
+      if (index($0, literal) > 0) { print NR; exit }
+    }
+  ' "$file"
+}
+
+# ======================================================================
+# Invariant A — repo-wide DEF14A SQL block parity (block-level)
+# ======================================================================
+
+echo "Checking invariant A (repo-wide DEF14A block parity)..."
+
+# Scan every Python file under app/ (tests excluded). Helper definition
+# in def14a_ingest.py is allowed an exemption marker on its own SQL
+# (the DISTINCT ON CTE inside ``def14a_within_cap`` IS the cap source
+# of truth).
+files_to_check=$(find app -type f -name '*.py' 2>/dev/null | sort)
+
+for file in $files_to_check; do
+  # Codex 2 MED — a here-string (``<<< "$blocks"``) needs a
+  # writable temp dir; on a read-only FS the loop is silently
+  # skipped while the script still exits 0. Process substitution
+  # (``< <(...)``) uses a FIFO, no temp file, so the loop runs
+  # in every environment. ``shopt -s lastpipe`` is unavailable
+  # in macOS bash 3.2, so we keep ``violations`` updates inside
+  # the subshell-less ``done < <(...)`` form (no pipeline) —
+  # the while body runs in the parent shell, fail() updates
+  # carry out correctly.
+  while IFS= read -r block_range; do
+    if [[ -z "$block_range" ]]; then continue; fi
+    start=$(echo "$block_range" | cut -d: -f1)
+    end=$(echo "$block_range" | cut -d: -f2)
+
+    has_signal=$(block_has_def14a_signal "$file" "$start" "$end")
+    if [[ "$has_signal" != "1" ]]; then continue; fi
+
+    is_compliant=$(block_is_compliant "$file" "$start" "$end")
+    if [[ "$is_compliant" != "1" ]]; then
+      fail "$file:$start: DEF14A chokepoint block (ends line $end) lacks compliance marker. Add rank_within_form <= %(cap)s predicate, OR def14a_within_cap(...) call within ±5 lines, OR -- DEF14A-CAP-EXEMPT: <reason> inline."
+    fi
+  done < <(extract_blocks "$file")
+done
+
+# ======================================================================
+# Invariant B — discover_pending_def14a per-block parity
+# ======================================================================
+# B is a strict subset of A (same per-block check, but scoped only to
+# def14a_ingest.py). Invariant A's full-file scan already covers
+# discover_pending_def14a's blocks, so B is exercised implicitly. We
+# keep B as a documented narrower regression check by re-scanning the
+# function explicitly — useful when developing in isolation against a
+# single file. Logic is the same as A; the re-run is a no-op when A
+# passes.
+
+echo "Checking invariant B (discover_pending_def14a per-block parity)..."
+
+FILE_DEF14A_INGEST="app/services/def14a_ingest.py"
+if [[ ! -f "$FILE_DEF14A_INGEST" ]]; then
+  fail "missing file: $FILE_DEF14A_INGEST"
+else
+  # Extract function body line range. BSD awk doesn't allow ``(``
+  # in regex — use literal-substring anchor on stripped line.
+  fn_range=$(awk '
+    BEGIN { in_fn = 0; start = 0; anchor = "def discover_pending_def14a(" }
+    {
+      if (!in_fn) {
+        stripped = $0
+        sub(/^[[:space:]]+/, "", stripped)
+        if (index(stripped, anchor) == 1) {
+          in_fn = 1; start = NR; next
+        }
+      } else {
+        if (NR > start && substr($0, 1, 4) == "def ") {
+          print start ":" (NR - 1); exit
+        }
+      }
+    }
+    END { if (in_fn && start > 0) print start ":" NR }
+  ' "$FILE_DEF14A_INGEST" | head -1)
+
+  if [[ -z "$fn_range" ]]; then
+    fail "$FILE_DEF14A_INGEST: discover_pending_def14a function not found"
+  else
+    fn_start=$(echo "$fn_range" | cut -d: -f1)
+    fn_end=$(echo "$fn_range" | cut -d: -f2)
+
+    while IFS= read -r block_range; do
+      if [[ -z "$block_range" ]]; then continue; fi
+      start=$(echo "$block_range" | cut -d: -f1)
+      end=$(echo "$block_range" | cut -d: -f2)
+      # Block must be inside the function body.
+      if (( start < fn_start || end > fn_end )); then continue; fi
+
+      has_signal=$(block_has_def14a_signal "$FILE_DEF14A_INGEST" "$start" "$end")
+      if [[ "$has_signal" != "1" ]]; then continue; fi
+
+      is_compliant=$(block_is_compliant "$FILE_DEF14A_INGEST" "$start" "$end")
+      if [[ "$is_compliant" != "1" ]]; then
+        fail "$FILE_DEF14A_INGEST:$start: discover_pending_def14a chokepoint block lacks compliance marker."
+      fi
+    done < <(extract_blocks "$FILE_DEF14A_INGEST")
+  fi
+fi
+
+# ======================================================================
+# Invariant C — _parse_def14a pre-fetch placement
+# ======================================================================
+
+echo "Checking invariant C (_parse_def14a pre-fetch placement)..."
+
+FILE_MANIFEST_DEF14A="app/services/manifest_parsers/def14a.py"
+if [[ ! -f "$FILE_MANIFEST_DEF14A" ]]; then
+  fail "missing file: $FILE_MANIFEST_DEF14A"
+else
+  cap_line=$(first_line_in_function "$FILE_MANIFEST_DEF14A" "_parse_def14a" 'def14a_within_cap(' || true)
+  iid_line=$(first_line_in_function "$FILE_MANIFEST_DEF14A" "_parse_def14a" 'if instrument_id is None' || true)
+  fetch_line=$(first_line_in_function "$FILE_MANIFEST_DEF14A" "_parse_def14a" 'fetch_document_text(' || true)
+
+  if [[ -z "$cap_line" || "$cap_line" == "0" ]]; then
+    fail "$FILE_MANIFEST_DEF14A: _parse_def14a missing def14a_within_cap(...) pre-fetch gate (#1233 PR5 §4.2)."
+  elif [[ -z "$iid_line" || "$iid_line" == "0" ]]; then
+    fail "$FILE_MANIFEST_DEF14A: _parse_def14a missing 'if instrument_id is None' anchor — cannot validate cap placement."
+  elif [[ -z "$fetch_line" || "$fetch_line" == "0" ]]; then
+    fail "$FILE_MANIFEST_DEF14A: _parse_def14a missing fetch_document_text() call — cannot validate cap placement."
+  elif (( cap_line < iid_line )); then
+    fail "$FILE_MANIFEST_DEF14A:$cap_line: def14a_within_cap(...) appears BEFORE the missing-instrument_id check at line $iid_line — helper needs a non-None iid."
+  elif (( cap_line > fetch_line )); then
+    fail "$FILE_MANIFEST_DEF14A:$cap_line: def14a_within_cap(...) appears AFTER fetch_document_text() at line $fetch_line — pre-fetch gate ordering violated."
+  fi
+fi
+
+# ======================================================================
+# Invariant D — _apply_def14a rescue-branch placement
+# ======================================================================
+
+echo "Checking invariant D (_apply_def14a rescue-branch placement)..."
+
+FILE_REWASH="app/services/rewash_filings.py"
+if [[ ! -f "$FILE_REWASH" ]]; then
+  fail "missing file: $FILE_REWASH"
+else
+  # Count cap calls in _apply_def14a. BSD awk pattern uses index()
+  # via literal substring (no parens in regex).
+  cap_count=$(awk '
+    BEGIN { in_fn = 0; start = 0; count = 0; anchor = "def _apply_def14a(" }
+    {
+      if (!in_fn) {
+        stripped = $0
+        sub(/^[[:space:]]+/, "", stripped)
+        if (index(stripped, anchor) == 1) { in_fn = 1; start = NR; next }
+      } else {
+        if (NR > start && substr($0, 1, 4) == "def ") { in_fn = 0; next }
+        if (index($0, "def14a_within_cap(") > 0) { count++ }
+      }
+    }
+    END { print count + 0 }
+  ' "$FILE_REWASH")
+
+  if [[ "$cap_count" != "1" ]]; then
+    fail "$FILE_REWASH: _apply_def14a should contain exactly 1 def14a_within_cap(...) call (rescue-branch gate, #1233 PR5 §4.3); found $cap_count."
+  else
+    cap_line=$(first_line_in_function "$FILE_REWASH" "_apply_def14a" 'def14a_within_cap(' || true)
+    anchor_line=$(first_line_in_function "$FILE_REWASH" "_apply_def14a" 'SELECT log.issuer_cik' || true)
+    parse_line=$(first_line_in_function "$FILE_REWASH" "_apply_def14a" 'parse_beneficial_ownership_table(' || true)
+
+    if [[ -z "$anchor_line" || "$anchor_line" == "0" ]]; then
+      fail "$FILE_REWASH: _apply_def14a missing rescue-fallback 'SELECT log.issuer_cik' anchor — cannot validate cap placement."
+    elif [[ -z "$parse_line" || "$parse_line" == "0" ]]; then
+      fail "$FILE_REWASH: _apply_def14a missing parse_beneficial_ownership_table() call — cannot validate cap placement."
+    elif (( cap_line <= anchor_line )); then
+      fail "$FILE_REWASH:$cap_line: def14a_within_cap(...) appears BEFORE the rescue-fallback SELECT at line $anchor_line — happy-path branch must NOT be capped."
+    elif (( cap_line >= parse_line )); then
+      fail "$FILE_REWASH:$cap_line: def14a_within_cap(...) appears AFTER parse_beneficial_ownership_table() at line $parse_line — rescue gate must short-circuit before parse."
+    fi
+  fi
+fi
+
+# ----------------------------------------------------------------------
+# Verdict
+# ----------------------------------------------------------------------
+
+if (( violations > 0 )); then
+  echo "" >&2
+  echo "FAIL: ${violations} DEF 14A latest-N cap invariant violation(s)." >&2
+  echo "See docs/superpowers/specs/2026-05-19-data-retention-rubric.md §4.7 +" >&2
+  echo "docs/superpowers/plans/2026-05-20-pr5-def14a-latest-2-cap.md §5 for the rules." >&2
+  exit 1
+fi
+
+echo "OK: DEF 14A latest-N primary cap honoured at every chokepoint."

--- a/tests/test_def14a_ingest.py
+++ b/tests/test_def14a_ingest.py
@@ -572,28 +572,40 @@ class TestBootstrapDef14a:
         self,
         _setup: psycopg.Connection[tuple],
     ) -> None:
-        """Three pending accessions, chunk_limit=2 → two chunks
-        consumed by one bootstrap call (the deadline doesn't fire,
-        the empty-chunk break does)."""
+        """Four pending accessions across TWO filers (2 each),
+        chunk_limit=2 → two chunks consumed by one bootstrap call
+        (the deadline doesn't fire, the empty-chunk break does).
+
+        #1233 PR5 cap: 2 primary accessions per filer is the cap.
+        Two filers × 2 accessions exercises the chunking loop while
+        keeping every accession within the cap so the legacy
+        "drains across chunks" contract holds.
+        """
         conn = _setup
+        # Filer A is the default ``839_001`` seeded in ``_setup``;
+        # seed a second filer here.
+        _seed_instrument(conn, iid=839_002, symbol="BOOTB")
+        _seed_sec_profile(conn, instrument_id=839_002, cik="0000839002")
+
         urls: dict[str, str | None] = {}
-        for i in range(3):
-            url = f"https://www.sec.gov/Archives/edgar/data/839001/000083900125-00000{i}/d.htm"
-            urls[url] = _proxy_html_with_table()
-            _seed_filing_event(
-                conn,
-                instrument_id=839_001,
-                accession=f"0000839001-25-00000{i}",
-                filing_date=date(2026, 1, 15 + i),
-                primary_document_url=url,
-            )
+        for filer_iid, base in [(839_001, "0000839001"), (839_002, "0000839002")]:
+            for i in range(2):
+                url = f"https://www.sec.gov/Archives/edgar/data/{filer_iid}/{base}25-00000{i}/d.htm"
+                urls[url] = _proxy_html_with_table()
+                _seed_filing_event(
+                    conn,
+                    instrument_id=filer_iid,
+                    accession=f"{base}-25-00000{i}",
+                    filing_date=date(2026, 1, 15 + i),
+                    primary_document_url=url,
+                )
         conn.commit()
         fetcher = _InMemoryFetcher(urls)
 
         summary = bootstrap_def14a(conn, fetcher, chunk_limit=2, max_runtime_seconds=60)
-        assert summary.accessions_seen == 3
-        assert summary.accessions_succeeded == 3
-        assert summary.rows_inserted == 9  # 3 holders × 3 accessions
+        assert summary.accessions_seen == 4
+        assert summary.accessions_succeeded == 4
+        assert summary.rows_inserted == 12  # 3 holders × 4 accessions
 
     def test_idempotent_second_run_is_noop(
         self,

--- a/tests/test_def14a_latest_n_cap.py
+++ b/tests/test_def14a_latest_n_cap.py
@@ -1,0 +1,802 @@
+"""DEF 14A latest-2-primary-proxies-per-filer cap — #1233 §4.7 PR5.
+
+Pins the contracts:
+
+1. ``DEF14A_LATEST_PER_FILER_CAP == 2`` and
+   ``DEF14A_PRIMARY_FORM_TYPE == 'DEF 14A'`` are the single
+   source of truth.
+2. ``def14a_within_cap`` helper:
+   - True for non-primary form types (DEFA14A / DEFR14A / DEFM14A).
+   - True for primary DEF 14A within rank ≤ 2 per issuer CIK.
+   - True for primary DEF 14A when issuer CIK is missing
+     (CIK-MISSING fast-tombstone preserved).
+   - False for primary DEF 14A beyond rank 2.
+   - False for accession absent from ``filing_events``
+     (out-of-corpus safe default).
+3. Discovery (``discover_pending_def14a``):
+   - Universe-wide cap latest-2 primary per CIK; supplements pass.
+   - Per-instrument cap respects the calling instrument's CIK
+     (sibling-aware via ``_resolve_target_cik_for_cap``).
+   - Rank computed across ALL accessions (including already-logged
+     ones) so a 3rd un-attempted accession is not promoted to
+     rank-1 once the top-2 are logged.
+   - URL-NULL accessions remain part of the ranking set (rank-1/2
+     with NULL URLs do not promote rank-3 with a URL).
+4. Parser pre-fetch gate (``_parse_def14a``): rank>2 accession is
+   tombstoned BEFORE the SEC HTTP call.
+5. Rewash rescue gate (``_apply_def14a``): happy-path uncapped;
+   rescue path refuses out-of-cap accessions.
+
+Existing rows are not deleted by the cap (#1233 §6.3 is the only
+purge event). These tests assert *insert* behaviour only.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services.def14a_ingest import (
+    DEF14A_LATEST_PER_FILER_CAP,
+    DEF14A_PRIMARY_FORM_TYPE,
+    _resolve_target_cik_for_cap,
+    def14a_within_cap,
+    discover_pending_def14a,
+)
+from app.services.sec_manifest import record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+# ---------------------------------------------------------------------------
+# Pure-constant contracts
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_cap_is_2(self) -> None:
+        assert DEF14A_LATEST_PER_FILER_CAP == 2
+
+    def test_primary_form_is_def_14a(self) -> None:
+        assert DEF14A_PRIMARY_FORM_TYPE == "DEF 14A"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests need the dev DB
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Seeders
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        )
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_profile(conn: psycopg.Connection[tuple], *, instrument_id: int, cik: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instrument_sec_profile (instrument_id, cik)
+        VALUES (%s, %s)
+        ON CONFLICT (instrument_id) DO UPDATE SET cik = EXCLUDED.cik
+        """,
+        (instrument_id, cik),
+    )
+
+
+def _seed_filing_event(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    filing_date: date,
+    filing_type: str = "DEF 14A",
+    primary_document_url: str | None = "https://example.test/proxy.htm",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type,
+            provider, provider_filing_id, primary_document_url
+        ) VALUES (%s, %s, %s, 'sec', %s, %s)
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO NOTHING
+        """,
+        (instrument_id, filing_date, filing_type, accession, primary_document_url),
+    )
+
+
+def _log_ingest_attempt(conn: psycopg.Connection[tuple], *, accession: str, cik: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO def14a_ingest_log (
+            accession_number, issuer_cik, status, rows_inserted, rows_skipped
+        ) VALUES (%s, %s, 'success', 0, 0)
+        ON CONFLICT (accession_number) DO NOTHING
+        """,
+        (accession, cik),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests (§6.1)
+# ---------------------------------------------------------------------------
+
+
+class TestDef14aWithinCap:
+    def test_top_two_primary_pass_bottom_three_fail(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid = 778_001
+        _seed_instrument(conn, iid=iid, symbol="CAP")
+        _seed_profile(conn, instrument_id=iid, cik="0000778001")
+        for i, fdate in enumerate(
+            [date(2022, 3, 1), date(2023, 3, 1), date(2024, 3, 1), date(2025, 3, 1), date(2026, 3, 1)]
+        ):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=f"0000778001-25-{i:06d}",
+                filing_date=fdate,
+            )
+        conn.commit()
+
+        # Latest two (2026, 2025) pass; 2024/2023/2022 fail.
+        assert def14a_within_cap(conn, accession_number="0000778001-25-000004", instrument_id=iid)
+        assert def14a_within_cap(conn, accession_number="0000778001-25-000003", instrument_id=iid)
+        assert not def14a_within_cap(conn, accession_number="0000778001-25-000002", instrument_id=iid)
+        assert not def14a_within_cap(conn, accession_number="0000778001-25-000001", instrument_id=iid)
+        assert not def14a_within_cap(conn, accession_number="0000778001-25-000000", instrument_id=iid)
+
+    def test_supplemental_forms_uncapped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """DEFA14A / DEFR14A / DEFM14A bypass the cap entirely."""
+        conn = ebull_test_conn
+        iid = 778_002
+        _seed_instrument(conn, iid=iid, symbol="SUP")
+        _seed_profile(conn, instrument_id=iid, cik="0000778002")
+        # 5 DEFA14A accessions for one filer — all should pass.
+        for i, fdate in enumerate(
+            [date(2022, 3, 1), date(2023, 3, 1), date(2024, 3, 1), date(2025, 3, 1), date(2026, 3, 1)]
+        ):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=f"0000778002-25-{i:06d}",
+                filing_date=fdate,
+                filing_type="DEFA14A",
+            )
+        conn.commit()
+
+        for i in range(5):
+            assert def14a_within_cap(
+                conn,
+                accession_number=f"0000778002-25-{i:06d}",
+                instrument_id=iid,
+            )
+
+    def test_mixed_primary_and_supplemental(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """3 DEF 14A + 2 DEFA14A: top-2 primary pass; oldest primary
+        fails; both DEFA14As pass unconditionally."""
+        conn = ebull_test_conn
+        iid = 778_003
+        _seed_instrument(conn, iid=iid, symbol="MIX")
+        _seed_profile(conn, instrument_id=iid, cik="0000778003")
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="P-OLD",
+            filing_date=date(2024, 3, 1),
+            filing_type="DEF 14A",
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="P-MID",
+            filing_date=date(2025, 3, 1),
+            filing_type="DEF 14A",
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="P-NEW",
+            filing_date=date(2026, 3, 1),
+            filing_type="DEF 14A",
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="A-2024",
+            filing_date=date(2024, 4, 1),
+            filing_type="DEFA14A",
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="A-2025",
+            filing_date=date(2025, 4, 1),
+            filing_type="DEFA14A",
+        )
+        conn.commit()
+
+        # Primaries: top-2 pass, oldest fails.
+        assert def14a_within_cap(conn, accession_number="P-NEW", instrument_id=iid)
+        assert def14a_within_cap(conn, accession_number="P-MID", instrument_id=iid)
+        assert not def14a_within_cap(conn, accession_number="P-OLD", instrument_id=iid)
+        # Supplementals: all pass regardless of rank.
+        assert def14a_within_cap(conn, accession_number="A-2024", instrument_id=iid)
+        assert def14a_within_cap(conn, accession_number="A-2025", instrument_id=iid)
+
+    def test_tie_break_on_provider_filing_id(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Same filing_date: higher provider_filing_id ranks higher."""
+        conn = ebull_test_conn
+        iid = 778_004
+        _seed_instrument(conn, iid=iid, symbol="TIE")
+        _seed_profile(conn, instrument_id=iid, cik="0000778004")
+        for acc in ("AAA", "BBB", "CCC"):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=acc,
+                filing_date=date(2026, 3, 1),
+            )
+        conn.commit()
+
+        # ORDER BY filing_date DESC, provider_filing_id DESC →
+        # ranks: CCC=1, BBB=2, AAA=3.
+        assert def14a_within_cap(conn, accession_number="CCC", instrument_id=iid)
+        assert def14a_within_cap(conn, accession_number="BBB", instrument_id=iid)
+        assert not def14a_within_cap(conn, accession_number="AAA", instrument_id=iid)
+
+    def test_cik_missing_passes(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Instrument with no profile (and no profile-bearing
+        sibling) bypasses the cap — preserves the legacy
+        CIK-MISSING tombstone path."""
+        conn = ebull_test_conn
+        iid = 778_005
+        _seed_instrument(conn, iid=iid, symbol="CKM")
+        # NO profile.
+        for i in range(5):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=f"CKM-{i:06d}",
+                filing_date=date(2024, 1, 1).replace(month=(i % 12) + 1),
+            )
+        conn.commit()
+
+        for i in range(5):
+            assert def14a_within_cap(conn, accession_number=f"CKM-{i:06d}", instrument_id=iid)
+
+    def test_share_class_siblings_rank_by_cik(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """5 accessions on a shared CIK with 2 siblings = 5 distinct
+        accessions ranked per CIK (not 10). Both siblings see the
+        same top-2."""
+        conn = ebull_test_conn
+        iid_a, iid_b = 778_006, 778_007
+        _seed_instrument(conn, iid=iid_a, symbol="SCA")
+        _seed_instrument(conn, iid=iid_b, symbol="SCB")
+        _seed_profile(conn, instrument_id=iid_a, cik="0000778050")
+        _seed_profile(conn, instrument_id=iid_b, cik="0000778050")
+        for i, fdate in enumerate(
+            [date(2022, 3, 1), date(2023, 3, 1), date(2024, 3, 1), date(2025, 3, 1), date(2026, 3, 1)]
+        ):
+            for iid in (iid_a, iid_b):
+                _seed_filing_event(
+                    conn,
+                    instrument_id=iid,
+                    accession=f"SCL-{i:06d}",
+                    filing_date=fdate,
+                )
+        conn.commit()
+
+        # Top-2 latest accessions: SCL-000004 + SCL-000003.
+        for iid in (iid_a, iid_b):
+            assert def14a_within_cap(conn, accession_number="SCL-000004", instrument_id=iid)
+            assert def14a_within_cap(conn, accession_number="SCL-000003", instrument_id=iid)
+            assert not def14a_within_cap(conn, accession_number="SCL-000002", instrument_id=iid)
+
+    def test_sibling_fallback_when_calling_instrument_lacks_profile(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Calling instrument has no profile but sibling does — the
+        sibling-via-filing_events fallback at §2.6.0 step 2 resolves
+        the CIK and the cap applies."""
+        conn = ebull_test_conn
+        iid_profile, iid_no_profile = 778_008, 778_009
+        _seed_instrument(conn, iid=iid_profile, symbol="SBP")
+        _seed_instrument(conn, iid=iid_no_profile, symbol="SBN")
+        _seed_profile(conn, instrument_id=iid_profile, cik="0000778100")
+        # iid_no_profile has NO profile row.
+
+        # 3 accessions per shared CIK, fanned out to both siblings.
+        for i, fdate in enumerate([date(2024, 3, 1), date(2025, 3, 1), date(2026, 3, 1)]):
+            for iid in (iid_profile, iid_no_profile):
+                _seed_filing_event(
+                    conn,
+                    instrument_id=iid,
+                    accession=f"SBL-{i:06d}",
+                    filing_date=fdate,
+                )
+        conn.commit()
+
+        # When called for the profile-less sibling, the helper must
+        # still cap. Top-2 (SBL-000002, SBL-000001) pass.
+        assert def14a_within_cap(conn, accession_number="SBL-000002", instrument_id=iid_no_profile)
+        assert def14a_within_cap(conn, accession_number="SBL-000001", instrument_id=iid_no_profile)
+        # Oldest (SBL-000000) fails — cap applied via sibling
+        # fallback, not bypassed as CIK-MISSING.
+        assert not def14a_within_cap(conn, accession_number="SBL-000000", instrument_id=iid_no_profile)
+
+    def test_out_of_corpus_accession_refuses(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Accession not present in filing_events → False (safe
+        default; manifest can't dispatch what we can't rank)."""
+        conn = ebull_test_conn
+        iid = 778_010
+        _seed_instrument(conn, iid=iid, symbol="OOC")
+        _seed_profile(conn, instrument_id=iid, cik="0000778010")
+        # No filing_events rows seeded.
+        conn.commit()
+
+        assert not def14a_within_cap(
+            conn,
+            accession_number="DOES-NOT-EXIST",
+            instrument_id=iid,
+        )
+
+
+class TestResolveTargetCikForCap:
+    def test_direct_profile(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid = 778_020
+        _seed_instrument(conn, iid=iid, symbol="DRT")
+        _seed_profile(conn, instrument_id=iid, cik="0000778020")
+        conn.commit()
+
+        assert _resolve_target_cik_for_cap(conn, instrument_id=iid) == "0000778020"
+
+    def test_sibling_fallback(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid_a, iid_b = 778_021, 778_022
+        _seed_instrument(conn, iid=iid_a, symbol="SFA")
+        _seed_instrument(conn, iid=iid_b, symbol="SFB")
+        _seed_profile(conn, instrument_id=iid_b, cik="0000778021")
+        # Shared DEF 14A accession on both siblings — sibling_b has profile.
+        for iid in (iid_a, iid_b):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession="SF-001",
+                filing_date=date(2026, 3, 1),
+            )
+        conn.commit()
+
+        # iid_a has no profile, sibling iid_b does — should resolve
+        # via fallback.
+        assert _resolve_target_cik_for_cap(conn, instrument_id=iid_a) == "0000778021"
+
+    def test_truly_missing_returns_none(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid = 778_023
+        _seed_instrument(conn, iid=iid, symbol="MIS")
+        # No profile, no filing_events rows.
+        conn.commit()
+
+        assert _resolve_target_cik_for_cap(conn, instrument_id=iid) is None
+
+
+# ---------------------------------------------------------------------------
+# Discovery query (§6.2)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverPendingDef14aCap:
+    def test_universe_returns_top_2_primary_per_cik(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        # Two filers, 5 primary DEF 14A each.
+        for filer_idx, base in [(0, 779_001), (1, 779_010)]:
+            _seed_instrument(conn, iid=base, symbol=f"U{filer_idx}")
+            _seed_profile(conn, instrument_id=base, cik=f"00007790{filer_idx:02d}")
+            for i, fdate in enumerate(
+                [date(2022, 3, 1), date(2023, 3, 1), date(2024, 3, 1), date(2025, 3, 1), date(2026, 3, 1)]
+            ):
+                _seed_filing_event(
+                    conn,
+                    instrument_id=base,
+                    accession=f"UNI-{filer_idx}-{i:06d}",
+                    filing_date=fdate,
+                )
+        conn.commit()
+
+        result = discover_pending_def14a(conn, limit=100)
+        accessions = sorted(r.accession_number for r in result)
+        # Top 2 per filer: indices 4 + 3.
+        expected = sorted([f"UNI-{f}-{i:06d}" for f in (0, 1) for i in (4, 3)])
+        assert accessions == expected
+
+    def test_universe_supplements_pass_unconditionally(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid = 779_020
+        _seed_instrument(conn, iid=iid, symbol="SUP")
+        _seed_profile(conn, instrument_id=iid, cik="0000779020")
+        # 3 DEF 14A + 2 DEFA14A.
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="P-OLD",
+            filing_date=date(2024, 3, 1),
+            filing_type="DEF 14A",
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="P-MID",
+            filing_date=date(2025, 3, 1),
+            filing_type="DEF 14A",
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="P-NEW",
+            filing_date=date(2026, 3, 1),
+            filing_type="DEF 14A",
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="A-1",
+            filing_date=date(2024, 4, 1),
+            filing_type="DEFA14A",
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="A-2",
+            filing_date=date(2025, 4, 1),
+            filing_type="DEFA14A",
+        )
+        conn.commit()
+
+        result = discover_pending_def14a(conn, limit=100)
+        accessions = sorted(r.accession_number for r in result)
+        # Top-2 primaries (P-NEW, P-MID) + both DEFA14As.
+        assert accessions == ["A-1", "A-2", "P-MID", "P-NEW"]
+
+    def test_per_instrument_returns_top_2_per_cik(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid = 779_030
+        _seed_instrument(conn, iid=iid, symbol="PI")
+        _seed_profile(conn, instrument_id=iid, cik="0000779030")
+        for i, fdate in enumerate(
+            [date(2022, 3, 1), date(2023, 3, 1), date(2024, 3, 1), date(2025, 3, 1), date(2026, 3, 1)]
+        ):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=f"PI-{i:06d}",
+                filing_date=fdate,
+            )
+        conn.commit()
+
+        result = discover_pending_def14a(conn, instrument_id=iid, limit=100)
+        accessions = sorted(r.accession_number for r in result)
+        assert accessions == ["PI-000003", "PI-000004"]
+
+    def test_rank_computed_across_logged_accessions(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Log the top-2 accessions. Discovery returns 0 (NOT the
+        3rd promoted to rank-1)."""
+        conn = ebull_test_conn
+        iid = 779_040
+        cik = "0000779040"
+        _seed_instrument(conn, iid=iid, symbol="LOG")
+        _seed_profile(conn, instrument_id=iid, cik=cik)
+        for i, fdate in enumerate([date(2024, 3, 1), date(2025, 3, 1), date(2026, 3, 1)]):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=f"LOG-{i:06d}",
+                filing_date=fdate,
+            )
+        # Mark the top-2 as already attempted.
+        _log_ingest_attempt(conn, accession="LOG-000002", cik=cik)
+        _log_ingest_attempt(conn, accession="LOG-000001", cik=cik)
+        conn.commit()
+
+        result = discover_pending_def14a(conn, limit=100)
+        accessions = [r.accession_number for r in result]
+        # LOG-000000 is rank 3 — capped out, NOT promoted to rank-1.
+        assert "LOG-000000" not in accessions
+
+    def test_url_null_rows_are_part_of_rank_set(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Latest 2 accessions have NULL URLs; the 3rd (with URL)
+        is NOT promoted. We wait for URLs on the top-2 instead."""
+        conn = ebull_test_conn
+        iid = 779_050
+        _seed_instrument(conn, iid=iid, symbol="URL")
+        _seed_profile(conn, instrument_id=iid, cik="0000779050")
+        # 3 accessions: top-2 NULL URL, oldest has URL.
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="URL-NEW",
+            filing_date=date(2026, 3, 1),
+            primary_document_url=None,
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="URL-MID",
+            filing_date=date(2025, 3, 1),
+            primary_document_url=None,
+        )
+        _seed_filing_event(
+            conn,
+            instrument_id=iid,
+            accession="URL-OLD",
+            filing_date=date(2024, 3, 1),
+            primary_document_url="https://example.test/old.htm",
+        )
+        conn.commit()
+
+        result = discover_pending_def14a(conn, limit=100)
+        accessions = [r.accession_number for r in result]
+        # URL-OLD ranks 3 by date — must NOT be returned even though
+        # it's the only one with a URL.
+        assert "URL-OLD" not in accessions
+
+    def test_cik_missing_per_instrument_returns_all(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Truly-CIK-missing instrument: per-instrument call returns
+        all its accessions uncapped (legacy path)."""
+        conn = ebull_test_conn
+        iid = 779_060
+        _seed_instrument(conn, iid=iid, symbol="CKM")
+        # No profile, no sibling — truly CIK-MISSING.
+        for i, fdate in enumerate([date(2024, 3, 1), date(2025, 3, 1), date(2026, 3, 1)]):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=f"CKM-{i:06d}",
+                filing_date=fdate,
+            )
+        conn.commit()
+
+        result = discover_pending_def14a(conn, instrument_id=iid, limit=100)
+        accessions = sorted(r.accession_number for r in result)
+        # All 3 returned — legacy uncapped path.
+        assert accessions == ["CKM-000000", "CKM-000001", "CKM-000002"]
+
+
+# ---------------------------------------------------------------------------
+# Manifest-worker parser pre-fetch gate (§6.3)
+# ---------------------------------------------------------------------------
+
+
+class TestParserPreFetchGate:
+    """Parser-side cap check tombstones cap-bound accessions BEFORE
+    the SEC HTTP call.
+
+    The pre-fetch ordering invariant is enforced by the lint guard
+    ``scripts/check_def14a_cap.sh`` invariant C; here we exercise
+    the behaviour: a fake fetcher records every call; the cap-bound
+    case yields zero calls.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_parsers(self) -> Any:
+        from app.jobs.sec_manifest_worker import clear_registered_parsers
+
+        clear_registered_parsers()
+        yield
+        clear_registered_parsers()
+
+    def test_cap_bound_accession_tombstones_without_fetch(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.providers.implementations.sec_edgar import SecFilingsProvider
+        from app.services.manifest_parsers.def14a import _parse_def14a
+
+        conn = ebull_test_conn
+        iid = 780_001
+        cik = "0000780001"
+        _seed_instrument(conn, iid=iid, symbol="PFG")
+        _seed_profile(conn, instrument_id=iid, cik=cik)
+        # 3 DEF 14A accessions; latest 2 are top-2, oldest is capped.
+        seed_data = [
+            ("PFG-NEW", date(2026, 3, 1)),
+            ("PFG-MID", date(2025, 3, 1)),
+            ("PFG-OLD", date(2024, 3, 1)),
+        ]
+        for acc, fdate in seed_data:
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=acc,
+                filing_date=fdate,
+                primary_document_url=f"https://example.test/{acc}.htm",
+            )
+        # Manifest row for the capped (oldest) accession.
+        record_manifest_entry(
+            conn,
+            "PFG-OLD",
+            cik=cik,
+            form="DEF 14A",
+            source="sec_def14a",
+            subject_type="issuer",
+            subject_id=str(iid),
+            instrument_id=iid,
+            filed_at=datetime(2024, 3, 1, tzinfo=UTC),
+            primary_document_url="https://example.test/PFG-OLD.htm",
+        )
+        conn.commit()
+
+        # Track any fetch attempts — must be zero.
+        calls: list[str] = []
+
+        def _fake_fetch(self: Any, url: str) -> str | None:
+            calls.append(url)
+            return "<html>UNREACHED</html>"
+
+        monkeypatch.setattr(SecFilingsProvider, "fetch_document_text", _fake_fetch)
+
+        # Fetch the manifest row and run the parser directly.
+        from app.services.sec_manifest import get_manifest_row
+
+        manifest_row = get_manifest_row(conn, "PFG-OLD")
+        assert manifest_row is not None
+
+        outcome = _parse_def14a(conn, manifest_row)
+
+        assert outcome.status == "tombstoned"
+        assert "latest-N primary cap" in (outcome.error or "")
+        assert calls == [], "parser must not call fetch_document_text for capped row"
+
+        # No ingest-log row written for the refused accession.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM def14a_ingest_log WHERE accession_number = %s",
+                ("PFG-OLD",),
+            )
+            count = cur.fetchone()[0]  # type: ignore[index]
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Rewash rescue gate (§6.4)
+# ---------------------------------------------------------------------------
+
+
+class TestRewashGate:
+    """Rewash carve-out: happy path is uncapped; rescue path is
+    capped."""
+
+    def test_rescue_path_refuses_out_of_cap_accession(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.raw_filings import RawFilingDocument
+        from app.services.rewash_filings import _apply_def14a
+
+        conn = ebull_test_conn
+        iid = 781_001
+        cik = "0000781001"
+        _seed_instrument(conn, iid=iid, symbol="RWG")
+        _seed_profile(conn, instrument_id=iid, cik=cik)
+        # 3 DEF 14A: top-2 + 1 out-of-cap. Log the top-2 as already
+        # ingested. The 3rd has a stored raw doc + ingest_log row
+        # (rescue cohort).
+        for i, (acc, fdate) in enumerate(
+            [("RWG-NEW", date(2026, 3, 1)), ("RWG-MID", date(2025, 3, 1)), ("RWG-OLD", date(2024, 3, 1))]
+        ):
+            _seed_filing_event(
+                conn,
+                instrument_id=iid,
+                accession=acc,
+                filing_date=fdate,
+                primary_document_url=f"https://example.test/{acc}.htm",
+            )
+        _log_ingest_attempt(conn, accession="RWG-NEW", cik=cik)
+        _log_ingest_attempt(conn, accession="RWG-MID", cik=cik)
+        # RWG-OLD: tombstoned earlier (status='partial' in real life),
+        # but we just need an ingest_log row exists for the rescue
+        # fallback to find.
+        conn.execute(
+            """
+            INSERT INTO def14a_ingest_log (
+                accession_number, issuer_cik, status, rows_inserted, rows_skipped
+            ) VALUES ('RWG-OLD', %s, 'partial', 0, 0)
+            ON CONFLICT (accession_number) DO NOTHING
+            """,
+            (cik,),
+        )
+        conn.commit()
+
+        # Build a minimal RawFilingDocument shaped like the rewash
+        # caller would have read from filing_raw_documents.
+        body = "<html>doesn't matter, won't be parsed</html>"
+        raw_doc = RawFilingDocument(
+            accession_number="RWG-OLD",
+            document_kind="def14a_body",
+            payload=body,
+            byte_count=len(body.encode("utf-8")),
+            parser_version="def14a-v0",
+            fetched_at=datetime(2024, 3, 1, tzinfo=UTC),
+            source_url=None,
+        )
+
+        result = _apply_def14a(conn, raw_doc)
+        # Rescue path: gate refuses → returns False.
+        assert result is False
+
+        # No typed rows written.
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*) FROM def14a_beneficial_holdings
+                WHERE accession_number = %s
+                """,
+                ("RWG-OLD",),
+            )
+            count = cur.fetchone()[0]  # type: ignore[index]
+        assert count == 0

--- a/tests/test_manifest_parser_def14a.py
+++ b/tests/test_manifest_parser_def14a.py
@@ -79,6 +79,22 @@ def _seed_pending_def14a(
         filed_at=datetime(2026, 5, 11, tzinfo=UTC),
         primary_document_url=primary_doc_url,
     )
+    # #1233 PR5 — the parser's pre-fetch cap-check (`def14a_within_cap`)
+    # reads `filing_type` from `filing_events` to decide whether the
+    # cap applies. A manifest row without a matching `filing_events`
+    # row is treated as out-of-corpus and tombstoned. Mirror the
+    # production wiring (manifest fan-out is paired with filing_events
+    # rows) so the cap can rank.
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type,
+            provider, provider_filing_id, primary_document_url
+        ) VALUES (%s, %s, %s, 'sec', %s, %s)
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO NOTHING
+        """,
+        (instrument_id, datetime(2026, 5, 11, tzinfo=UTC).date(), form, accession, primary_doc_url),
+    )
 
 
 # A minimal DEF 14A body the parser will accept — section heading


### PR DESCRIPTION
## Summary

- New `DEF14A_LATEST_PER_FILER_CAP = 2` cap on **primary `DEF 14A`** accessions per issuer CIK at three chokepoints: discovery rank CTE in `discover_pending_def14a`, manifest-worker `_parse_def14a` pre-fetch gate, rewash `_apply_def14a` rescue gate. Supplemental forms (DEFA14A / DEFR14A / DEFM14A) **uncapped** so a same-cycle DEFA14A doesn't evict prior-year primary.
- Helper `def14a_within_cap` + sibling-aware `_resolve_target_cik_for_cap` in `app/services/def14a_ingest.py`. Single rank source-of-truth.
- Block-level lint guard `scripts/check_def14a_cap.sh` enforces 4 invariants (repo-wide chokepoint parity, per-block `discover_pending_def14a` parity, parser pre-fetch placement, rewash rescue-branch placement). Wired into `.githooks/pre-push`.
- 6 read-side queries in `app/api/instruments.py` + `app/services/ownership_drillthrough.py` marked `-- DEF14A-CAP-EXEMPT:` (diagnostics, not ingest chokepoints).
- Spec §4.7 + §7 + §12 amended for PR5 SHIPPED + PR6 handover.

## Why

DEF 14A is HTML-scrape, ~1h per pass under deadline cap. 5y × 5,174 US filers = un-drainable. Latest-2-primary cap cuts candidate set ~80%. Prior-year primary kept for change tracking; older proxies are decoration. Existing rows untouched (#1233 §6.3 — pre-wipe is the single purge event).

## Security model

- Cap is **ingest-side only** — no `DELETE FROM def14a_*` against pre-cap rows. Spec §6.3 invariant.
- Out-of-corpus accessions refuse (False) — manifest rows without `filing_events` source-of-truth tombstone safely rather than fetch unranked.
- CIK-MISSING accessions still reach parser via existing sentinel path; cap explicitly bypasses them.
- Helper + discovery CTE share the same DISTINCT ON ordering (`profile-bearing siblings preferred, lowest iid tie-break`) so cap rank is deterministic across both surfaces.

## Codex review

- Codex 1a-1f on plan (6 rounds, 24 findings total): COUNT-vs-time shape, supplemental-form carve-out, URL-NULL in rank set, sibling-aware CIK resolution, deterministic ORDER BY, NULL-cik guard, lint signal detection covering `_DEF14A_FORM_TYPES` parameter shape, rescue-branch placement check. Plan clean before code.
- Codex 2 pre-push: 1 HIGH (uncommitted diff — resolved by commit), 1 MED (lint here-string fail-silent on read-only FS — fixed via process substitution + bash 3.2 compat), 1 LOW (awk now tracks `'''` and `"""` independently).

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` clean
- [x] `bash scripts/check_def14a_cap.sh` clean
- [x] `bash scripts/check_form4_retention.sh` clean (PR4 invariant survives)
- [x] `bash scripts/check_instruments_inserts.sh` clean (PR1 invariant)
- [x] `uv run pytest tests/test_def14a_latest_n_cap.py` — 21 passed
- [x] `uv run pytest tests/test_def14a_ingest.py tests/test_manifest_parser_def14a.py tests/test_def14a_drift.py tests/test_def14a_drill.py` — 77 passed
- [x] Pre-push hook scoped testmon pass on push
- [ ] CI green
- [ ] Claude review APPROVE on the most recent commit

## Tradeoffs

- **Latest-2-primary is operator-visible**: pre-rank-2 DEF 14A accessions stop being ingested. Operator widens via `DEF14A_LATEST_PER_FILER_CAP` if archaeology becomes a need.
- **Supplemental forms uncapped**: a filer with 10 DEFA14As in one year ingests all 10. Codex 1a §6 rationale — capping them would evict prior-year primary, breaking the spec §4.7 "current + one prior" intent.
- **Manifest tombstones not parser-version-rewashable**: pre-fetch tombstones write no `filing_raw_documents` row. Operator path: `POST /jobs/sec_rebuild/run` source reset (mirrors PR4).
- **Out-of-corpus refusal**: manifest rows without `filing_events` source tombstone. Pre-cap behaviour silently fetched; post-cap surfaces the integrity anomaly via tombstone outcome.
- **Cumulative state post-wipe**: pre-rank-2 primaries' top-5-holders pies reset after §6.3 pre-wipe — operator-accepted.

## Scope NOT in this PR

- Existing pre-cap rows untouched (#1233 §6.3).
- 13F-HR 8-quarter cap — PR6.
- `ownership_*_current` size audit — PR12.

Refs #1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)