### PR TITLE
feat(#1233): PR6 — 13F-HR 8-quarter retention cap at every chokepoint

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -62,6 +62,14 @@ bash scripts/check_form4_retention.sh
 echo "==> Pre-push gate: DEF 14A latest-N cap lint"
 bash scripts/check_def14a_cap.sh
 
+# #1233 §4.5 PR6 — every 13F-HR ingest chokepoint must honour the
+# 8-quarter retention cap (parse_submissions_index intrinsic floor,
+# _ingest_single_accession post-parse gate, manifest-worker post-parse
+# gate, bulk-dataset per-row gate, rewash rescue gate, sync_institutions
+# SQL predicate). ~40ms.
+echo "==> Pre-push gate: 13F-HR 8-quarter retention cap lint"
+bash scripts/check_13f_hr_retention.sh
+
 # Pytest scoping decision. If `git diff --name-only @{u}..HEAD` fails
 # (no upstream yet, e.g. brand-new branch), assume worst-case: run the
 # full suite under xdist. The first push of a brand-new branch usually

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -72,6 +72,85 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# 13F-HR 8-quarter retention cap (#1233 PR6, spec §4.5)
+# ---------------------------------------------------------------------------
+
+# 13F-HR period_of_report is always a calendar quarter end. Spec §4.5
+# caps depth at 8 quarter-ends per filer. Anchoring the cutoff to
+# quarter boundaries (not a floating ``today - 760d`` window) keeps the
+# admitted set strictly = 8 quarter-ends.
+#
+# Ingest-side cap only — existing rows are untouched until the
+# operator-driven pre-wipe + clean re-run (spec §6.3). Cutoff is
+# computed in Python and passed as a `date` everywhere, NOT as
+# `NOW() - make_interval(...)` which carries DB session-timezone
+# ambiguity. UTC anchor — local-TZ ``date.today()`` would drift the
+# cutoff by ±1 day on non-UTC dev hosts.
+THIRTEEN_F_HR_RETENTION_QUARTERS: int = 8
+
+
+def _calendar_quarter_end(year: int, quarter_idx: int) -> date:
+    return {
+        1: date(year, 3, 31),
+        2: date(year, 6, 30),
+        3: date(year, 9, 30),
+        4: date(year, 12, 31),
+    }[quarter_idx]
+
+
+def thirteen_f_retention_cutoff(now: datetime | None = None) -> date:
+    """Earliest ``period_of_report`` accepted for 13F-HR / 13F-HR/A.
+
+    Returns the quarter-end exactly
+    ``THIRTEEN_F_HR_RETENTION_QUARTERS - 1`` quarters before the most
+    recent COMPLETED calendar quarter end. Boundary inclusive — exactly
+    8 quarter-ends survive at every moment of every day. A floating
+    ``today - 760d`` cutoff would slip to nine admitted quarter-ends
+    right after a new quarter completes (Codex 1a §1 lesson).
+
+    ``now`` must be a tz-aware datetime; the helper normalises to UTC
+    before taking ``.date()`` so the cutoff doesn't drift on non-UTC
+    callers.
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+    if now.tzinfo is None:
+        raise ValueError(
+            "thirteen_f_retention_cutoff: ``now`` must be a tz-aware datetime; "
+            "naive datetimes would honour the caller's local TZ and drift the cutoff."
+        )
+    today = now.astimezone(UTC).date()
+    if today.month <= 3:
+        latest_y, latest_q = today.year - 1, 4
+    elif today.month <= 6:
+        latest_y, latest_q = today.year, 1
+    elif today.month <= 9:
+        latest_y, latest_q = today.year, 2
+    else:
+        latest_y, latest_q = today.year, 3
+    latest_global = latest_y * 4 + (latest_q - 1)
+    target_global = latest_global - (THIRTEEN_F_HR_RETENTION_QUARTERS - 1)
+    target_y, target_q_zero = divmod(target_global, 4)
+    return _calendar_quarter_end(target_y, target_q_zero + 1)
+
+
+def thirteen_f_within_retention(
+    period_of_report: date | None,
+    now: datetime | None = None,
+) -> bool:
+    """Boundary check used by every 13F-HR writer chokepoint.
+
+    Returns True iff
+    ``period_of_report >= thirteen_f_retention_cutoff(now)``.
+    A None ``period_of_report`` returns False — defensive: an accession
+    we couldn't tag with a quarter end is unsafe to admit.
+    """
+    if period_of_report is None:
+        return False
+    return period_of_report >= thirteen_f_retention_cutoff(now)
+
+
+# ---------------------------------------------------------------------------
 # Provider contract
 # ---------------------------------------------------------------------------
 
@@ -141,6 +220,12 @@ class _AccessionOutcome:
     holdings_inserted: int
     holdings_skipped_no_cusip: int
     error: str | None
+    # PR6 #1233 §4.5 — defensive post-parse gate may discover a parsed
+    # ``period_of_report`` that the submissions JSON didn't carry (NULL
+    # / malformed ``reportDate`` leaked past the index filter). Thread
+    # it back through the outcome so the caller's ingest-log row
+    # records the audit-grade period rather than a sentinel ``None``.
+    period_of_report_override: date | None = None
 
     @property
     def ingested(self) -> bool:
@@ -214,13 +299,23 @@ def parse_submissions_index(
     For active filers (banks, asset managers) the recent array can
     cover 60+ years of filings since most issuers file far fewer
     than 1,000 reports per decade. ``min_period_of_report`` (#1008)
-    bounds historical depth: when set, accessions whose
+    is the caller's additional floor: when set, accessions whose
     ``period_of_report`` is older than the cut-off are skipped.
     Pre-2013 13F filings additionally have no machine-readable
     primary_doc / infotable structure, so iterating them costs an
     SEC fetch + parse and yields zero rows. First-install bootstrap
     passes a recent cut-off (last 4 quarters); the standalone
-    weekly cron leaves it ``None`` for full historical coverage.
+    weekly cron leaves it ``None`` to inherit only the intrinsic cap.
+
+    PR6 #1233 §4.5 — the intrinsic 8-quarter retention cap
+    (``thirteen_f_retention_cutoff``) is the EFFECTIVE FLOOR:
+    caller-provided ``min_period_of_report`` raises the floor (more
+    recent caller floors win), but ``None`` no longer means "full
+    history" — it means "intrinsic 8q cap." The legacy per-accession
+    ``period is None`` short-circuit is preserved at the line-level
+    (a NULL ``reportDate`` row leaks past the index filter and is
+    caught by the defensive post-parse gate in
+    ``_ingest_single_accession``).
     """
     try:
         data: dict[str, Any] = json.loads(payload)
@@ -235,6 +330,15 @@ def parse_submissions_index(
     filing_dates = recent.get("filingDate", [])
     report_dates = recent.get("reportDate", [])
 
+    # PR6 #1233 §4.5 — effective floor = max(caller_floor, intrinsic_cap).
+    # ``None`` caller falls back to the intrinsic cap; a caller passing
+    # a more-recent floor (e.g. bootstrap stage 21's 380d / 4q) wins.
+    intrinsic_floor = thirteen_f_retention_cutoff()
+    if min_period_of_report is None:
+        effective_floor = intrinsic_floor
+    else:
+        effective_floor = max(min_period_of_report, intrinsic_floor)
+
     out: list[AccessionRef] = []
     for i, accession in enumerate(accessions):
         if i >= len(forms):
@@ -244,10 +348,12 @@ def parse_submissions_index(
             continue
         filed_at = _safe_iso_datetime(filing_dates[i] if i < len(filing_dates) else "")
         period = _safe_iso_date(report_dates[i] if i < len(report_dates) else "")
-        if min_period_of_report is not None and period is not None and period < min_period_of_report:
-            # #1008 — first-install bootstrap caller passes a recent
-            # cut-off so we don't iterate pre-2013 filings whose
-            # primary_doc/infotable XML structure didn't exist yet.
+        if period is not None and period < effective_floor:
+            # PR6 #1233 §4.5 — applies both the intrinsic 8q cap and
+            # the caller-provided ``min_period_of_report``. A NULL
+            # ``reportDate`` (period is None) leaks past this filter
+            # and is caught by ``_ingest_single_accession``'s post-
+            # parse gate.
             continue
         out.append(
             AccessionRef(
@@ -928,7 +1034,12 @@ def ingest_filer_13f(
             conn,
             filer_cik=cik,
             accession_number=ref.accession_number,
-            period_of_report=ref.period_of_report,
+            # Prefer the parser-derived period when the per-accession
+            # driver surfaced one (defensive post-parse gate path); else
+            # fall back to ``ref.period_of_report`` from the submissions
+            # index. Codex 2 LOW — without this, the defensive-gate
+            # branch wrote NULL despite knowing the parsed period.
+            period_of_report=outcome.period_of_report_override or ref.period_of_report,
             status=outcome.status,
             holdings_inserted=outcome.holdings_inserted,
             holdings_skipped=outcome.holdings_skipped_no_cusip,
@@ -1278,6 +1389,30 @@ def _ingest_single_accession(
             holdings_inserted=0,
             holdings_skipped_no_cusip=0,
             error=f"primary_doc.xml parse failed: {exc}",
+        )
+
+    # PR6 #1233 §4.5 — defensive post-parse gate. submissions JSON may
+    # carry a NULL / malformed ``reportDate`` for some accessions;
+    # those leak past ``parse_submissions_index``'s ``period is None``
+    # short-circuit. Re-check against the parsed period and short-circuit
+    # before fetching the (often-large) infotable.
+    if not thirteen_f_within_retention(info.period_of_report):
+        logger.debug(
+            "13F ingest: cik=%s accession=%s period=%s pre-8q retention cap; skipping",
+            filer_cik,
+            ref.accession_number,
+            info.period_of_report,
+        )
+        return _AccessionOutcome(
+            status="failed",
+            holdings_inserted=0,
+            holdings_skipped_no_cusip=0,
+            error="retention floor",
+            # Surface the parsed period so the caller writes an audit-
+            # grade ingest-log row instead of carrying ``ref.period_of_report=None``
+            # forward (the defensive-gate path is exactly the case
+            # where ``ref.period_of_report`` is None). Codex 2 LOW.
+            period_of_report_override=info.period_of_report,
         )
 
     infotable_xml = sec.fetch_document_text(infotable_url)

--- a/app/services/manifest_parsers/sec_13f_hr.py
+++ b/app/services/manifest_parsers/sec_13f_hr.py
@@ -72,6 +72,7 @@ from app.services.institutional_holdings import (
     _upsert_filer,
     _upsert_holding,
     parse_archive_index,
+    thirteen_f_within_retention,
 )
 from app.services.manifest_parsers._classify import (
     format_upsert_error,
@@ -293,6 +294,44 @@ def _parse_13f_hr(
                 accession,
             )
         return _failed_outcome(f"{kind}: {exc}", raw_status="stored")
+
+    # PR6 #1233 §4.5 — post-parse 8-quarter retention gate. We gate on
+    # ``info.period_of_report`` (the quarter end intrinsic to the
+    # filing) NOT ``row.filed_at`` so 13F-HR/A amendments restating
+    # pre-cap quarters are correctly rejected. Pre-fetch placement
+    # (before infotable.xml fetch) saves the often-several-MB
+    # attachment for pre-cap accessions. Tombstone the manifest so
+    # operator's ``sec_rebuild`` is the recovery path if the cap
+    # later widens; ingest-log row is written with the parsed period
+    # for audit visibility.
+    if not thirteen_f_within_retention(info.period_of_report):
+        logger.debug(
+            "13F-HR manifest parser: accession=%s period=%s pre-8q retention cap; tombstoning",
+            accession,
+            info.period_of_report,
+        )
+        try:
+            with conn.transaction():
+                _record_ingest_attempt(
+                    conn,
+                    filer_cik=filer_cik,
+                    accession_number=accession,
+                    period_of_report=info.period_of_report,
+                    status="failed",
+                    error="retention floor",
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "13F-HR manifest parser: ingest-log INSERT failed accession=%s",
+                accession,
+            )
+            return _failed_outcome(f"log error: {exc}", raw_status="stored")
+        return ParseOutcome(
+            status="tombstoned",
+            parser_version=_PARSER_VERSION_13F_HR,
+            raw_status="stored",
+            error="retention floor",
+        )
 
     # Step 3: fetch infotable.xml + store_raw inside savepoint.
     try:

--- a/app/services/ownership_observations_sync.py
+++ b/app/services/ownership_observations_sync.py
@@ -294,13 +294,23 @@ def sync_institutions(
     Per Codex plan-review finding #2: filer_id → cik resolution is
     explicit; orphans (filer_id without parent row) are logged and
     skipped, never silently dropped. ``ownership_nature='economic'``
-    for the equity slice; ``exposure_kind`` mirrors ``is_put_call``."""
+    for the equity slice; ``exposure_kind`` mirrors ``is_put_call``.
+
+    PR6 #1233 §4.5 — the 8-quarter retention cap is enforced as a SQL
+    predicate so this scheduled repair sweep cannot repopulate pre-cap
+    observations from any pre-cap ``institutional_holdings`` rows that
+    still exist in the dev DB pre-pre-wipe. ``since`` is the caller's
+    optional ADDITIONAL floor (incremental repair); the cap is the
+    intrinsic floor."""
+    from app.services.institutional_holdings import thirteen_f_retention_cutoff
+
     summary = SyncSummary()
     instruments_touched: set[int] = set()
     run_id = uuid4()
 
-    where = "WHERE 1=1"
-    params: dict[str, Any] = {}
+    retention_cutoff = thirteen_f_retention_cutoff()
+    where = "WHERE ih.period_of_report >= %(retention_cutoff)s"
+    params: dict[str, Any] = {"retention_cutoff": retention_cutoff}
     if since is not None:
         where += " AND ih.period_of_report >= %(since)s"
         params["since"] = since

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -747,6 +747,7 @@ def _apply_13f_infotable(
     from app.services.institutional_holdings import (
         _resolve_cusip_to_instrument_id,
         _upsert_holding,
+        thirteen_f_within_retention,
     )
 
     # Resolution priority:
@@ -802,6 +803,14 @@ def _apply_13f_infotable(
     if row is None:
         return False
     filer_id, period_of_report, filed_at = row
+    # PR6 #1233 §4.5 — rescue-branch cap. Happy path (the IF branch
+    # above) re-parses existing in-cap rows and refreshes parser_version
+    # under the spec §6.3 "existing rows untouched" contract. This
+    # rescue branch is effectively a fresh ingest (was zero typed rows,
+    # now populating them); pre-cap accessions must not enter via the
+    # rescue path — they'd write NEW rows outside the 8q window.
+    if not had_existing_holdings and not thirteen_f_within_retention(period_of_report):
+        return False
 
     try:
         holdings = parse_infotable(raw_doc.payload)

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -34,6 +34,7 @@ from uuid import UUID, uuid4
 
 import psycopg
 
+from app.services.institutional_holdings import thirteen_f_retention_cutoff
 from app.services.ownership_observations import record_institution_observation
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class Form13FIngestResult:
     rows_skipped_unresolved_cusip: int = 0
     rows_skipped_orphan_accession: int = 0
     rows_skipped_bad_data: int = 0
+    rows_skipped_retention: int = 0  # PR6 #1233 §4.5
     parse_errors: int = 0
     touched_instrument_ids: set[int] = field(default_factory=set)
 
@@ -256,6 +258,13 @@ def ingest_13f_dataset_archive(
     # (Codex sweep BLOCKING).
     cusip_map = _load_cusip_map(conn)
 
+    # PR6 #1233 §4.5 — archive-level retention cutoff. Resolve once
+    # OUTSIDE the per-row INFOTABLE loop so a multi-million-row drain
+    # doesn't re-evaluate ``date.today()`` per row (and so a sentinel
+    # mid-drain ``today`` boundary roll doesn't admit some rows and
+    # reject others within the same archive).
+    retention_cutoff = thirteen_f_retention_cutoff()
+
     with zipfile.ZipFile(archive_path) as zf:
         submissions = _open_tsv(zf, "SUBMISSION.tsv")
         coverpages = _open_tsv(zf, "COVERPAGE.tsv")
@@ -302,6 +311,14 @@ def ingest_13f_dataset_archive(
             period_end = _parse_period_end(cover.get("REPORTCALENDARORQUARTER"))
             if filed_at is None or period_end is None:
                 result.rows_skipped_bad_data += 1
+                continue
+
+            # PR6 #1233 §4.5 — per-row retention gate. Bulk dataset
+            # archives can span 30+ years; the per-row check honours
+            # the calendar-quarter cap regardless of the archive's
+            # nominal coverage window.
+            if period_end < retention_cutoff:
+                result.rows_skipped_retention += 1
                 continue
 
             # SSHPRNAMT carries shares OR principal-amount depending on

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -312,6 +312,7 @@ def sec_13f_ingest_from_dataset_job() -> None:
     failed_archives: list[str] = []
     total_written = 0
     total_skipped = 0
+    total_retention_skipped = 0
     succeeded: list[Path] = []
     touched_ids: set[int] = set()
     for archive in archives:
@@ -333,6 +334,7 @@ def sec_13f_ingest_from_dataset_job() -> None:
         succeeded.append(archive)
         total_written += result.rows_written
         total_skipped += result.rows_skipped_unresolved_cusip
+        total_retention_skipped += result.rows_skipped_retention
         touched_ids |= result.touched_instrument_ids
         if run_id is not None:
             _record_archive_result(
@@ -340,28 +342,45 @@ def sec_13f_ingest_from_dataset_job() -> None:
                 stage_key="sec_13f_ingest_from_dataset",
                 archive_name=archive.name,
                 rows_written=result.rows_written,
-                rows_skipped={"unresolved_cusip": result.rows_skipped_unresolved_cusip},
+                rows_skipped={
+                    "unresolved_cusip": result.rows_skipped_unresolved_cusip,
+                    "retention": result.rows_skipped_retention,
+                },
             )
         logger.info(
-            "sec_13f_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d",
+            "sec_13f_ingest_from_dataset: archive=%s rows_written=%d unresolved_cusip=%d retention_skipped=%d",
             archive.name,
             result.rows_written,
             result.rows_skipped_unresolved_cusip,
+            result.rows_skipped_retention,
         )
     logger.info(
-        "sec_13f_ingest_from_dataset: total_rows_written=%d total_unresolved=%d",
+        "sec_13f_ingest_from_dataset: total_rows_written=%d total_unresolved=%d total_retention_skipped=%d",
         total_written,
         total_skipped,
+        total_retention_skipped,
     )
     if failed_archives:
         raise RuntimeError(
             f"sec_13f_ingest_from_dataset: {len(failed_archives)} archives failed: " + "; ".join(failed_archives)
         )
     if run_id is not None and total_written == 0:
-        raise RuntimeError(
-            f"sec_13f_ingest_from_dataset: aggregate rows_written=0 across {len(archives)} archives; "
-            f"unresolved_cusip={total_skipped}. Check CUSIP coverage."
-        )
+        # Codex 2 MED — distinguish all-retention-skipped from CUSIP-coverage failure.
+        # An all-pre-cap drain is a no-op by design (#1233 §4.5); a zero-CUSIP-resolve
+        # is still a coverage failure. Only the latter should raise.
+        if total_retention_skipped > 0 and total_skipped == 0:
+            logger.info(
+                "sec_13f_ingest_from_dataset: aggregate rows_written=0 across %d archives; "
+                "all %d rows skipped by 8q retention cap (#1233 §4.5). Not an error.",
+                len(archives),
+                total_retention_skipped,
+            )
+        else:
+            raise RuntimeError(
+                f"sec_13f_ingest_from_dataset: aggregate rows_written=0 across {len(archives)} archives; "
+                f"unresolved_cusip={total_skipped} retention_skipped={total_retention_skipped}. "
+                f"Check CUSIP coverage."
+            )
     # Refresh ownership_institutions_current for every instrument
     # whose observations changed. Bulk ingest writes only to the
     # _observations table; the rollup endpoint reads _current. Without

--- a/docs/superpowers/plans/2026-05-20-pr6-13f-hr-8q-cap.md
+++ b/docs/superpowers/plans/2026-05-20-pr6-13f-hr-8q-cap.md
@@ -1,0 +1,780 @@
+# PR6 — 13F-HR 8-quarter ingest cap at every writer chokepoint
+
+> Created: **2026-05-20** as the next PR in the #1233 data-retention rubric series.
+>
+> Tracking issue: **#1233** — Bootstrap scope discipline umbrella.
+> Spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](../specs/2026-05-19-data-retention-rubric.md) §4.5.
+>
+> Status: **PLAN** — revised post Codex 1a (2026-05-20). 4 BLOCKING + 3 MED
+> findings addressed inline; rebuttal on rewash happy-path documented in §5.6.
+
+## 0. Context
+
+The data-retention rubric (#1233) bounds per-source ingest depth so the
+clean re-run after the operator pre-wipe (spec §6.3) measures the
+post-cap steady state. PR1-PR5 have shipped. PR6 lands the 13F-HR
+8-quarter per-filer cap at every writer chokepoint.
+
+13F-HR is the largest non-XBRL ownership volume in the dev DB:
+**`ownership_institutions_observations`** = 2.5 GB across 3.86M rows;
+**`ownership_institutions_current`** = 2.8 GB (oddity tracked in PR12);
+**`institutional_holdings`** = 25 MB raw. 8-of-~64 partitions survive
+the cap → projected post-clean-rerun observations footprint
+≈ **0.5 GB** (spec §8).
+
+Ticket #1010 already bounded the filer **cohort** (`last_13f_hr_at`
+recency filter, 11,205 → 8,681 filers). PR6 adds per-filer **depth**.
+
+## 1. Scope
+
+**In**:
+
+1. Calendar-quarter retention constants + helpers in
+   `app/services/institutional_holdings.py`.
+2. Cap honoured by every 13F-HR writer chokepoint:
+   - `parse_submissions_index` (legacy ingester, intrinsic-floor wiring).
+   - `_ingest_single_accession` (legacy ingester defensive post-parse gate).
+   - `_parse_13f_hr` manifest-worker adapter (post-parse pre-infotable
+     gate).
+   - `ingest_13f_dataset_archive` bulk drain (per-row period_end gate).
+   - `_apply_13f_infotable` rewash rescue branch (happy path uncapped
+     by PR5 precedent — rebut documented in §5.6).
+   - `ownership_observations_sync.sync_institutions` scheduled repair
+     sweep (SQL predicate).
+3. Lint guard `scripts/check_13f_hr_retention.sh` (PR5-style block-level
+   placement guard, 9 invariants A-I) wired into `.githooks/pre-push`.
+4. Unit tests covering helpers, the legacy ingester (including the
+   defensive post-parse gate), manifest worker, bulk dataset gate
+   (with boundary equality), rewash rescue gate, and the scheduled
+   repair sweep cap.
+5. Spec §4.5 + §6.3 + §7 + §12 amend for PR6 SHIPPED state + PR7
+   handover, including the rewash happy-path-uncapped rebuttal.
+
+**Out**:
+
+- N-PORT cap (PR7, mirror of PR6).
+- `ownership_institutions_current` size audit (PR12).
+- DELETE of pre-cap rows (spec §6.3 — caps are ingest-side only; pre-wipe
+  is the single purge event).
+
+## 2. Settled decisions cross-reference
+
+- **Spec §6.3 — no piecemeal deletes**: PR6 is ingest-side only. NO
+  `DELETE FROM ownership_institutions_observations` against pre-cap rows.
+- **Spec §4.5 — depth + cohort**: PR6 = depth; #1010 = cohort.
+- **#1208 dev-DB hygiene**: 8q cap drops observations partitions outside
+  the window from the clean re-run's footprint.
+- **Settled — write-through ownership**: `ownership_institutions_current`
+  remains the latest-snapshot write-through table. PR6 cap shapes
+  observations writes; current refresh happens only when an in-cap
+  accession lands (consistent with PR4/5 — caller refreshes current
+  inside the cap-passing branch).
+
+## 3. Review-prevention-log cross-reference
+
+- **`INSERT INTO instruments` fixtures must supply `is_tradable`** — PR1
+  hardened. Not relevant here (no instrument fixtures change).
+- **No-op `ORDER BY` (sort column = WHERE predicate column)** — PR6 SELECTs
+  read existing query bodies; no new ordering added.
+- **Bare-param counting let unused params or comment mentions inflate the
+  count** (PR4 Codex 2 MED finding) — lint guard counts the FULL predicate
+  expression (`period_of_report < retention_cutoff`), not the bare
+  `%(cutoff)s` token.
+- **BSD vs GNU `grep -P` portability** (PR4 Codex 1c lesson) — lint guard
+  uses `awk` block parsing, no `grep -P`.
+- **`date.today()` returns local TZ** (#1010 Codex 2) — helpers compute
+  `datetime.now(tz=UTC).date()` for the cutoff anchor.
+
+## 4. Two-axis analysis
+
+### 4.1 Why period-based, not filed-at-based
+
+PR4 (Form 4) gates on `filing_date` — the trade lands within 2 business
+days of `filed_at`, so the two are interchangeable for the alert /
+thesis windows the cap targets.
+
+13F-HR is different: filers have 45 days from quarter-end to file the
+regular HR; **13F-HR/A amendments can be filed years later** restating
+prior quarters' holdings. A `filed_at`-only gate would let a 2026-05
+amendment of a 2020-Q3 filing slip through, polluting the "last 8
+quarters" semantics.
+
+→ Gate on `period_of_report` (the quarter-end date intrinsic to the
+filing's content), not `filed_at`.
+
+### 4.2 Quarter-anchored cutoff, not a floating window — Codex 1a §1 fix
+
+Spec §12 handover language uses "per-filer 8-quarter rank cap"; spec
+§4.5 itself says "8 quarters (2y)". An earlier draft of this plan used
+a floating `today - 760d` (= 8 × 95d) cutoff. Codex 1a §1 BLOCKING
+showed the floating window can admit nine quarter-ends right after a
+new quarter completes (`today` advances day-by-day; the cutoff lags 760
+days behind, so for a couple of weeks each quarter both the new
+quarter end AND the cutoff-1-quarter-end are inside the window).
+
+**Resolution**: anchor the cutoff to **calendar quarter ends**. 13F-HR
+`period_of_report` is always a quarter end (Mar 31 / Jun 30 / Sep 30 /
+Dec 31). Compute the cutoff as the quarter end exactly 7 quarters
+BEFORE the most recent COMPLETED quarter end (today's quarter if past
+its end, else the prior one). Boundary inclusive → exactly 8
+quarter-ends survive regardless of where `today` falls inside the
+current quarter.
+
+This is functionally equivalent to a per-filer rank cap when filers
+file every quarter on schedule (the dominant case). It deviates only
+for delinquent / NT-filing filers, where rank-8 would reach further
+back than calendar-8 — operationally negligible per the chart /
+thesis half-life analysis in spec §3.
+
+→ Calendar-quarter cutoff. Implementation in §5.1.
+
+### 4.3 Caller-driven vs intrinsic floor
+
+Today: `parse_submissions_index(payload, min_period_of_report=None)` →
+full history. `ingest_all_active_filers(min_period_of_report=None)` →
+caller never set the floor, weekly cron walks all of history.
+
+The spec says "cap at every chokepoint" — INTRINSIC, not caller-driven.
+
+PR6 change: caller-provided `min_period_of_report` becomes the *additional
+floor*; the 8q cap is enforced as the *default*. Effective floor =
+`max(caller_floor, thirteen_f_retention_cutoff())`. A caller passing
+`None` still gets the 8q cap. A caller passing a tighter floor (e.g.
+bootstrap stage 21's 380d / 4q) overrides upward.
+
+## 5. Implementation
+
+### 5.1 Constants + helpers (`app/services/institutional_holdings.py`)
+
+Insert immediately after the existing `_PARSER_VERSION_13F_INFOTABLE`
+constant block:
+
+```python
+# ---------------------------------------------------------------------------
+# 13F-HR 8-quarter retention cap (#1233 PR6, spec §4.5)
+# ---------------------------------------------------------------------------
+
+# 13F-HR period_of_report is always a calendar quarter end. Spec §4.5
+# caps depth at 8 quarter-ends per filer. Anchoring the cutoff to
+# quarter boundaries (not a floating ``today - 760d`` window) keeps the
+# admitted set strictly = 8 quarter-ends. Codex 1a §1 BLOCKING lesson.
+#
+# Ingest-side cap only — existing rows are untouched until the
+# operator-driven pre-wipe + clean re-run (spec §6.3). Cutoff is
+# computed in Python and passed as a `date` everywhere, NOT as
+# `NOW() - make_interval(...)` which carries DB session-timezone
+# ambiguity. UTC anchor — #1010 Codex 2 lesson: ``date.today()``
+# returns local TZ, drifts the cutoff by ±1 day on non-UTC dev hosts.
+THIRTEEN_F_HR_RETENTION_QUARTERS: int = 8
+
+
+def _calendar_quarter_end(year: int, quarter_idx: int) -> date:
+    """Return the canonical quarter-end ``date`` for (year, quarter).
+
+    ``quarter_idx`` is 1..4. Local helper — quarterly math is a one-off
+    here; importing dateutil for ``relativedelta`` would be casual
+    dependency creep (CLAUDE.md non-negotiables).
+    """
+    return {
+        1: date(year, 3, 31),
+        2: date(year, 6, 30),
+        3: date(year, 9, 30),
+        4: date(year, 12, 31),
+    }[quarter_idx]
+
+
+def thirteen_f_retention_cutoff(now: datetime | None = None) -> date:
+    """Earliest ``period_of_report`` accepted for 13F-HR / 13F-HR/A.
+
+    Returns the quarter-end exactly ``THIRTEEN_F_HR_RETENTION_QUARTERS
+    - 1`` quarters before the most recent COMPLETED calendar quarter
+    end. Boundary inclusive → exactly 8 quarter-ends survive at every
+    moment of every day. A floating ``today - 760d`` cutoff would slip
+    to nine admitted quarter-ends right after a new quarter completes
+    (Codex 1a §1 BLOCKING).
+
+    ``now`` must be a tz-aware datetime; the helper normalises to UTC
+    before taking ``.date()`` so the cutoff doesn't drift on non-UTC
+    callers (Codex 1b §2 MED — bare ``.date()`` honoured the caller's
+    local TZ).
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+    if now.tzinfo is None:
+        raise ValueError(
+            "thirteen_f_retention_cutoff: ``now`` must be a tz-aware datetime; "
+            "naive datetimes would honour the caller's local TZ and drift the cutoff."
+        )
+    today = now.astimezone(UTC).date()
+    # Most-recent completed quarter end. Today inside Q2 (Apr-Jun) →
+    # the latest completed quarter is Q1 (Mar 31). Today on Jul 1 → Q2
+    # (Jun 30) is the latest completed end. Boundary = exclusive of
+    # the in-progress quarter so today's quarter is always strictly
+    # AFTER ``latest_q_end``.
+    if today.month <= 3:
+        latest_y, latest_q = today.year - 1, 4
+    elif today.month <= 6:
+        latest_y, latest_q = today.year, 1
+    elif today.month <= 9:
+        latest_y, latest_q = today.year, 2
+    else:
+        latest_y, latest_q = today.year, 3
+    # Translate to a global quarter index, subtract 7 (to keep 8 total
+    # quarter ends inclusive of ``latest_q_end``), translate back.
+    latest_global = latest_y * 4 + (latest_q - 1)
+    target_global = latest_global - (THIRTEEN_F_HR_RETENTION_QUARTERS - 1)
+    target_y, target_q_zero = divmod(target_global, 4)
+    return _calendar_quarter_end(target_y, target_q_zero + 1)
+
+
+def thirteen_f_within_retention(
+    period_of_report: date | None,
+    now: datetime | None = None,
+) -> bool:
+    """Boundary check used by every 13F-HR writer chokepoint.
+
+    Returns True iff ``period_of_report >= thirteen_f_retention_cutoff(now)``.
+    A None ``period_of_report`` returns False — defensive: an accession
+    we couldn't tag with a quarter end is unsafe to admit.
+    """
+    if period_of_report is None:
+        return False
+    return period_of_report >= thirteen_f_retention_cutoff(now)
+```
+
+Imports: `timedelta` is NOT in `institutional_holdings.py`'s current
+import block (`from datetime import UTC, date, datetime`). Helper
+formulation above uses calendar arithmetic only, so no `timedelta`
+needed. Codex 1a §5 MED fix — earlier draft said "already present"
+which was wrong.
+
+### 5.2 Chokepoint A — `parse_submissions_index` (intrinsic floor)
+
+Change the `min_period_of_report` parameter behaviour from "optional
+floor" to "additional floor on top of the intrinsic 8q cap":
+
+```python
+def parse_submissions_index(
+    payload: str,
+    *,
+    min_period_of_report: date | None = None,
+) -> list[AccessionRef]:
+    """..."""
+    # PR6 #1233 §4.5 — apply the intrinsic 8q cap as the effective
+    # floor; caller-provided ``min_period_of_report`` (e.g. bootstrap
+    # stage 21 passes 4q / 380d) can RAISE the floor but never lower it.
+    intrinsic_floor = thirteen_f_retention_cutoff()
+    if min_period_of_report is None:
+        effective_floor = intrinsic_floor
+    else:
+        effective_floor = max(min_period_of_report, intrinsic_floor)
+    ...
+    if period is not None and period < effective_floor:
+        continue
+    ...
+```
+
+The existing `min_period_of_report is not None and period is not None
+and period < min_period_of_report:` branch is replaced.
+
+### 5.3 Chokepoint B — `_ingest_single_accession` (legacy post-parse gate)
+
+Codex 1a §2 BLOCKING — if `parse_submissions_index` sees a NULL /
+malformed `reportDate`, the accession leaks past the period gate
+(`period is not None` short-circuits the comparison) and reaches
+`_ingest_single_accession` which then parses `primary_doc.xml` and
+upserts.
+
+Defensive fix: after `parse_primary_doc(primary_xml)` succeeds in
+`_ingest_single_accession`, check the cap and short-circuit to a
+`failed`-status outcome with `error='retention floor'`. Mirrors the
+manifest-worker gate added in §5.4.
+
+```python
+# inside _ingest_single_accession, AFTER:
+#     info = parse_primary_doc(primary_xml)
+# and BEFORE the infotable.xml fetch.
+
+# PR6 #1233 §4.5 — defensive post-parse gate. ``parse_submissions_index``
+# already skips accessions with a known pre-cap ``period_of_report``,
+# but submissions JSON may carry a NULL / malformed ``reportDate`` —
+# those leak past the index-level gate and reach here. Re-check
+# against the parsed period and short-circuit to a tombstoned outcome
+# before fetching the (often-large) infotable.
+if not thirteen_f_within_retention(info.period_of_report):
+    return _AccessionOutcome(
+        status="failed",
+        holdings_inserted=0,
+        holdings_skipped_no_cusip=0,
+        error="retention floor",
+    )
+```
+
+`ingest_filer_13f` itself needs no change — it already passes
+`min_period_of_report` through to `parse_submissions_index`, which
+§5.2 makes intrinsic-cap-aware.
+
+### 5.4 Chokepoint C — manifest-worker `_parse_13f_hr` (post-parse gate)
+
+Insert the cap check immediately after `info = parse_primary_doc(primary_xml)`
+(line 271), before the infotable fetch. Skips the infotable fetch +
+upsert phase for pre-cap accessions, writes an ingest-log row with
+`status='failed', error='retention floor'`, and returns
+`status='tombstoned'`.
+
+```python
+# PR6 #1233 §4.5 — 8-quarter retention cap. ``info.period_of_report``
+# is the quarter-end intrinsic to the filing; gate on it (not
+# ``row.filed_at``) so 13F-HR/A late amendments restating pre-cap
+# quarters are correctly rejected. Pre-fetch placement saves the
+# infotable.xml fetch (often several MB) — the primary_doc.xml (~5KB)
+# is already retrieved. Tombstone the manifest row so the operator's
+# `sec_rebuild` is the recovery path if the cap widens later.
+if not thirteen_f_within_retention(info.period_of_report):
+    logger.debug(
+        "13F-HR manifest parser: accession=%s period=%s pre-8q retention cap; tombstoning",
+        accession,
+        info.period_of_report,
+    )
+    try:
+        with conn.transaction():
+            _record_ingest_attempt(
+                conn,
+                filer_cik=filer_cik,
+                accession_number=accession,
+                period_of_report=info.period_of_report,
+                status="failed",
+                error="retention floor",
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "13F-HR manifest parser: ingest-log INSERT failed accession=%s",
+            accession,
+        )
+        return _failed_outcome(f"log error: {exc}", raw_status="stored")
+    return ParseOutcome(
+        status="tombstoned",
+        parser_version=_PARSER_VERSION_13F_HR,
+        raw_status="stored",
+        error="retention floor",
+    )
+```
+
+Placement: AFTER `info = parse_primary_doc(primary_xml)` succeeded
+(line ~285 post-edit), BEFORE the `# Step 3: fetch infotable.xml` block.
+
+### 5.5 Chokepoint D — bulk dataset `ingest_13f_dataset_archive`
+
+Add a `rows_skipped_retention` counter to `Form13FIngestResult`. Add
+the per-row gate after the `period_end = _parse_period_end(...)` parse
+(line ~302):
+
+```python
+@dataclass
+class Form13FIngestResult:
+    ...existing fields...
+    rows_skipped_retention: int = 0  # PR6 #1233 §4.5
+    ...
+
+# inside ingest_13f_dataset_archive, after the period_end parse:
+
+# PR6 #1233 §4.5 — 8-quarter retention cap. Cutoff resolved once
+# per archive to avoid date-rollover during a multi-million-row drain.
+retention_cutoff = thirteen_f_retention_cutoff()
+...
+for row in _iter_tsv(zf, "INFOTABLE.tsv"):
+    ...
+    if period_end < retention_cutoff:
+        result.rows_skipped_retention += 1
+        continue
+    ...
+```
+
+Wire `rows_skipped_retention` into the per-archive logging in
+`sec_bulk_orchestrator_jobs.py` so the operator sees the skip count.
+
+### 5.6 Chokepoint E — rewash `_apply_13f_infotable` rescue branch
+
+Mirror PR5 — happy-path uncapped (re-parse of existing in-cap rows is
+fine), rescue branch capped (pre-cap rescues would write NEW rows
+outside the cap window).
+
+After the rescue branch's SELECT fetches `period_of_report` from
+`institutional_holdings_ingest_log` (rewash_filings.py:~801), gate:
+
+```python
+# PR6 #1233 §4.5 — rescue-branch cap. Happy path (above) re-parses
+# existing rows and refreshes parser_version; that branch is uncapped.
+# This rescue branch is effectively a fresh ingest (was zero-rows in
+# the typed table, now turning that into populated rows). Pre-cap
+# accessions must not enter via the rescue path — they'd add new rows
+# outside the 8q window.
+from app.services.institutional_holdings import thirteen_f_within_retention
+
+if not thirteen_f_within_retention(period_of_report):
+    return False
+```
+
+**Happy-path rebuttal (Codex 1a §3 BLOCKING)** — Codex flagged the
+happy path as a writer that bypasses the cap. The PR5 precedent
+explicitly allows this: happy path means existing typed rows already
+sit in `institutional_holdings` for this accession, and rewash does a
+DELETE + re-INSERT under a new `parser_version`. The accession's row
+set is preserved (spec §6.3 "existing rows untouched"); only the
+parser shape changes. If existing rows are pre-cap, they were created
+on the original-ingest schedule and the spec §6.3 invariant covers
+them. Adding a cap to the happy branch would create the surprising
+behaviour "the latest parser fix cannot be applied to pre-cap rows
+that exist in the table" — which is the opposite of what §6.3 asks
+for. The rebuttal is documented in the spec amend (§4.5 + §6.3
+cross-reference note).
+
+### 5.7 Chokepoint F — `ownership_observations_sync.sync_institutions`
+
+Codex 1a §4 BLOCKING — `sync_institutions` is the legacy scheduled
+repair sweep that walks `institutional_holdings` and re-derives
+observations into `ownership_institutions_observations`. Without a cap
+predicate it would repopulate pre-cap observations rows from the
+(uncapped) `institutional_holdings` table on its next run, undoing
+the §5.2 / §5.4 / §5.5 work.
+
+Add `period_of_report >= %(retention_cutoff)s` to the SELECT:
+
+```python
+# inside sync_institutions, alongside the existing optional `since`
+# filter:
+retention_cutoff = thirteen_f_retention_cutoff()
+where = "WHERE ih.period_of_report >= %(retention_cutoff)s"
+params: dict[str, Any] = {"retention_cutoff": retention_cutoff}
+if since is not None:
+    where += " AND ih.period_of_report >= %(since)s"
+    params["since"] = since
+```
+
+The cap and the caller-provided `since` are independent predicates:
+the cap is the intrinsic floor; `since` is the caller's incremental
+floor for "since last sweep" repairs. Either being more restrictive
+than the other is fine — SQL AND collapses to the stricter floor.
+
+### 5.8 Backfill / data migration
+
+None. Caps are ingest-side per spec §6.3. Pre-cap rows persist until
+the operator's pre-wipe + clean re-run.
+
+## 6. Lint guard — `scripts/check_13f_hr_retention.sh`
+
+PR5-style block-level placement guard (Codex 1a §6 MED — PR4 count-only
+guard would miss helper calls placed AFTER fetches/writes or inside
+docstrings). Awk-based for BSD/GNU portability (PR4 Codex 1c lesson).
+Nine invariants, all enforced at PLACEMENT or repo-wide writer
+discovery (not just file-presence):
+
+**A. Helpers defined exactly once, in the canonical module.**
+File: `app/services/institutional_holdings.py`. Count rule:
+
+- `def thirteen_f_retention_cutoff(` == 1.
+- `def thirteen_f_within_retention(` == 1.
+
+**B. `parse_submissions_index` intrinsic-floor parity.**
+File: `app/services/institutional_holdings.py`. Inside
+`def parse_submissions_index(`:
+
+- `thirteen_f_retention_cutoff(` ≥ 1 call (the effective-floor
+  computation).
+- Marker line `period < effective_floor` ≥ 1 (proves the helper output
+  is wired into the existing per-accession filter).
+
+**C. `_ingest_single_accession` post-parse defensive gate.**
+File: `app/services/institutional_holdings.py`. Inside
+`def _ingest_single_accession(`:
+
+- `thirteen_f_within_retention(info.period_of_report` line MUST exist
+  AND its line number MUST be > the line containing `info = parse_primary_doc(`
+  AND < the line containing the first `infotable_xml = sec.fetch_document_text(`
+  (post-primary-parse, pre-infotable-fetch). Same shape as PR5's
+  invariant C for `_parse_def14a`.
+
+**D. Manifest-worker post-parse gate placement.**
+File: `app/services/manifest_parsers/sec_13f_hr.py`. Inside
+`def _parse_13f_hr(`:
+
+- `thirteen_f_within_retention(` line MUST exist AND its line number
+  MUST be > the line containing `info = parse_primary_doc(`
+  AND < the line containing `infotable_xml =` (post-parse, pre-infotable).
+
+**E. Bulk dataset archive-level + per-row gate placement.**
+File: `app/services/sec_13f_dataset_ingest.py`. Inside
+`def ingest_13f_dataset_archive(`:
+
+- `thirteen_f_retention_cutoff(` == 1 call (archive-level anchor) AND
+  its line number MUST be < the line containing `for row in _iter_tsv`
+  (placement: outside the per-row loop, computed once per archive).
+- `period_end < retention_cutoff` ≥ 1 (per-row gate predicate) AND
+  its line number MUST be > the line containing
+  `period_end = _parse_period_end` AND < the line containing
+  `record_institution_observation(` (placement: post-parse,
+  pre-write).
+- `rows_skipped_retention` ≥ 1 increment (telemetry counter bumped on
+  skip; field definition counted separately via the dataclass below).
+- `Form13FIngestResult` dataclass MUST contain a
+  `rows_skipped_retention:` field.
+
+**F. Rewash rescue-branch-only gate.**
+File: `app/services/rewash_filings.py`. Inside `def _apply_13f_infotable(`:
+
+- `thirteen_f_within_retention(` exactly 1 call.
+- Its line number MUST be > the rescue-branch anchor (the LEFT JOIN
+  fragment `JOIN institutional_filers f ON f.cik = log.filer_cik`)
+  AND < the line containing `parse_infotable(raw_doc.payload)` (the
+  parser call). Same shape as PR5 invariant D — proves the cap gates
+  the rescue branch specifically, not the happy path or post-parse.
+
+**G. `ownership_observations_sync.sync_institutions` cap predicate.**
+File: `app/services/ownership_observations_sync.py`. Inside
+`def sync_institutions(`:
+
+- `thirteen_f_retention_cutoff(` ≥ 1 call.
+- SQL predicate `ih.period_of_report >= %(retention_cutoff)s` ≥ 1
+  (matches the param wired in §5.7).
+
+**H. Repo-wide writer discovery — `record_institution_observation`
+with `source` ∈ {`"13f"`, `'13f'`}.**
+Scan every `*.py` under `app/` (excluding the helper definition module
+`app/services/ownership_observations.py` and tests). The set of
+file paths containing a `record_institution_observation(` call-site
+within ±20 lines of a quote-style-agnostic `source\s*=\s*['"]13f['"]`
+match MUST equal **exactly three**:
+
+- `app/services/institutional_holdings.py` (write-through happy-path,
+  reached from manifest + legacy ingester; gated upstream via §B + §C
+  + §D).
+- `app/services/sec_13f_dataset_ingest.py` (bulk per-row writer; gated
+  via §E).
+- `app/services/ownership_observations_sync.py` (scheduled repair
+  sweep; gated via §G).
+
+A future PR adding a fourth 13F writer site will trip this count
+mismatch and force the lint guard to be widened deliberately — the
+PR4 "expected ${expected} chokepoint blocks" pattern.
+
+**I. Repo-wide writer discovery — `INSERT INTO institutional_holdings
+` (excluding the ingest_log table).**
+Scan as above. The set of file paths containing
+`INSERT INTO institutional_holdings (` (note the trailing column-list
+paren, distinguishes from `_ingest_log`) MUST equal **exactly one**:
+
+- `app/services/institutional_holdings.py::_upsert_holding`.
+
+`_upsert_holding`'s callers are gated upstream (the manifest +
+legacy + rewash paths all gate `period_of_report` before invoking
+the holding upsert). Same lock-in shape as §H.
+
+The guard exits non-zero on the first violation. Wired into
+`.githooks/pre-push` after `check_def14a_cap.sh`.
+
+**Note on the refresh path** (`refresh_institutions_current(`):
+Codex 1b §1 BLOCKING flagged this as a missed writer. **REBUTTED.**
+`refresh_institutions_current` is downstream derivation over
+`ownership_institutions_observations`: a `DELETE FROM
+ownership_institutions_current WHERE instrument_id = X` followed by
+an `INSERT … SELECT DISTINCT ON (filer_cik, ownership_nature,
+exposure_kind) … FROM ownership_institutions_observations`
+(implementation at `app/services/ownership_observations.py:390`). It
+is not an ingest chokepoint; observations is the source-of-truth and
+the cap is enforced there (§5.2 + §5.4 + §5.5 + §5.7).
+
+After the operator pre-wipe + clean re-run (spec §6.3), observations
+carries only in-cap rows, and the rebuild naturally yields an in-cap
+`_current`. Pre-pre-wipe, existing pre-cap observations remain (spec
+§6.3 "existing rows untouched") and the rebuild reflects them — that
+is the "always-current snapshot" promise in spec §4.5 working as
+intended. Adding a cap predicate to `refresh_institutions_current`
+would actively delete pre-wipe pre-cap rows from `_current` on every
+repair sweep, which would silently violate spec §6.3.
+
+The guard does NOT touch `refresh_institutions_current(` call-sites.
+
+## 7. Tests
+
+### 7.1 Unit tests for helpers
+
+`tests/services/test_thirteen_f_retention.py` (new):
+
+- `thirteen_f_retention_cutoff(now=2026-05-20)` (Q2-in-progress) →
+  `date(2024, 6, 30)` (Q2 2024). Anchored at the latest completed
+  quarter end (Q1 2026 = 2026-03-31), 7 quarters back lands at Q2
+  2024 → quarter-end = 2024-06-30.
+- `thirteen_f_retention_cutoff(now=2026-04-01)` (one day into Q2) →
+  same `date(2024, 6, 30)`. Proves the cutoff does NOT shift inside
+  the current quarter (the floating-window bug Codex 1a §1 caught).
+- `thirteen_f_retention_cutoff(now=2026-07-01)` (first day of Q3) →
+  `date(2024, 9, 30)`. Proves the cutoff rolls forward exactly when a
+  new quarter completes.
+- Year boundary: `thirteen_f_retention_cutoff(now=2026-01-15)` →
+  `date(2024, 3, 31)`. Latest completed = Q4 2025 = 2025-12-31; 7
+  back = Q1 2024 = 2024-03-31.
+- `thirteen_f_within_retention` returns True for `period == cutoff`
+  (inclusive boundary).
+- `thirteen_f_within_retention` returns False for `period < cutoff`.
+- `thirteen_f_within_retention` returns False for `period=None`
+  (defensive).
+- Passing a tz-NAIVE `datetime` raises `ValueError` with the message
+  pinned at definition (§5.1).
+- Passing a tz-AWARE non-UTC `datetime` normalises via
+  `.astimezone(UTC).date()` — e.g. `2026-05-20T23:00 UTC-08` (i.e.
+  `2026-05-21T07:00 UTC`) yields the cutoff anchored to UTC date
+  2026-05-21, not the local-time 2026-05-20.
+
+### 7.2 `parse_submissions_index` intrinsic cap
+
+`tests/services/test_institutional_holdings_parse_submissions.py`
+(extend existing or new):
+
+- Caller passes `min_period_of_report=None` → pre-cap rows excluded.
+- Caller passes `min_period_of_report` MORE restrictive than cap → caller wins.
+- Caller passes `min_period_of_report` LESS restrictive than cap → cap wins.
+- In-cap rows survive both branches.
+
+### 7.3 Manifest-worker gate
+
+`tests/test_manifest_parser_sec_13f_hr.py` (extend):
+
+- In-cap accession → proceeds to infotable fetch + parse.
+- Pre-cap accession → returns `status='tombstoned'`,
+  `error='retention floor'`, no infotable fetch, ingest-log row
+  written with `status='failed', error='retention floor'`.
+- Pre-cap accession with primary-doc fetch failure → existing tombstone
+  path (no cap interaction; cap is post-parse).
+
+### 7.4 Bulk dataset gate
+
+`tests/services/test_sec_13f_dataset_ingest.py` (extend):
+
+- Synthetic ZIP with three SUBMISSIONS rows: one pre-cap, one
+  boundary (`period_end == cutoff`), one in-cap. Result: `rows_written
+  = 2`, `rows_skipped_retention = 1`. Proves the inclusive-boundary
+  spec at the bulk path (Codex 1a §7 MED boundary-equality fix).
+- Skipped pre-cap rows DO NOT appear in
+  `result.touched_instrument_ids` (no current-refresh side-effect on
+  skipped accessions).
+
+### 7.5 Rewash rescue gate
+
+`tests/services/test_rewash_filings.py` (extend):
+
+- Rescue-branch accession with in-cap `period_of_report` → returns True,
+  writes log row.
+- Rescue-branch accession with pre-cap `period_of_report` → returns
+  False, no writes.
+- Happy path with pre-cap `period_of_report` → uncapped (existing
+  behaviour preserved).
+
+### 7.6 Lint guard self-test
+
+`tests/scripts/test_check_13f_hr_retention.sh.py` (new):
+
+- Synthetic file mutations that violate each invariant fail the guard.
+- Clean tree passes.
+
+### 7.7 `_ingest_single_accession` defensive post-parse gate
+
+`tests/test_institutional_holdings.py` (extend):
+
+- SEC submissions JSON with one accession whose `reportDate` is the
+  empty string → `parse_submissions_index` admits it (period=None
+  short-circuits the gate). Mock `parse_primary_doc` to return
+  `period_of_report = date(2020, 3, 31)` (well pre-cap). The
+  per-accession driver returns `_AccessionOutcome(status='failed',
+  error='retention floor')` and never calls `fetch_document_text`
+  for the infotable URL. Codex 1a §2 BLOCKING regression test.
+
+### 7.8 `sync_institutions` cap predicate
+
+`tests/test_ownership_observations_sync.py` (extend existing):
+
+- Seed `institutional_holdings` with two rows: one with
+  `period_of_report = cutoff` (boundary, in-cap), one with
+  `period_of_report = cutoff - 1d` (pre-cap). After
+  `sync_institutions(conn, since=None)` runs, only the in-cap row
+  produces an `ownership_institutions_observations` write.
+- The `since` parameter still works as the caller's incremental
+  floor — does not weaken the retention cap.
+
+## 8. Codex review gate
+
+Per #1208 cadence:
+
+- **Codex 1a** on this plan (after first commit).
+- Revise.
+- **Codex 1b** if findings remain.
+- Land plan + impl in one PR.
+- **Codex 2** pre-push on the diff.
+- Push, review bot + CI, resolve, merge.
+
+## 9. PR description skeleton
+
+```text
+feat(#1233): PR6 — 13F-HR 8-quarter retention cap at every chokepoint
+
+Refs #1233 — data retention rubric, 13F-HR depth cap (spec §4.5).
+
+## Summary
+
+- New `THIRTEEN_F_HR_RETENTION_QUARTERS = 8` constant +
+  calendar-quarter-anchored `thirteen_f_retention_cutoff` and
+  `thirteen_f_within_retention` helpers in
+  `app/services/institutional_holdings.py`. Cutoff is anchored to the
+  most-recent completed quarter end (not a floating today-760d window
+  — Codex 1a §1 showed that floats to nine quarter-ends right after a
+  new quarter completes).
+- `parse_submissions_index` enforces an INTRINSIC floor: caller-
+  provided `min_period_of_report` can RAISE the floor (e.g. bootstrap
+  stage 21's 380d / 4q wins), but the 8q cap is the default.
+- Defensive post-parse gate inside `_ingest_single_accession` catches
+  accessions whose submissions JSON had a NULL/malformed `reportDate`
+  and leaked past the index-level filter.
+- Manifest-worker `_parse_13f_hr` post-parse gate tombstones pre-cap
+  accessions BEFORE the infotable fetch (saves several MB / accession).
+- Bulk dataset ingester (`ingest_13f_dataset_archive`) gates per-row
+  by `period_end < retention_cutoff` with a `rows_skipped_retention`
+  counter on `Form13FIngestResult` + per-archive log line in
+  `sec_bulk_orchestrator_jobs`.
+- Rewash `_apply_13f_infotable` rescue branch gates by
+  `period_of_report < retention_cutoff` (happy path uncapped per PR5
+  precedent — DELETE + re-INSERT of an existing in-cap row set under
+  a new `parser_version` is the spec §6.3 contract).
+- Scheduled repair sweep `ownership_observations_sync.sync_institutions`
+  carries the cap as a SQL predicate alongside the existing optional
+  `since` floor.
+- Lint guard `scripts/check_13f_hr_retention.sh` (nine PR5-style
+  block-level placement invariants A-I, including repo-wide writer
+  discovery for `record_institution_observation(... source="13f")`
+  and `INSERT INTO institutional_holdings (`) wired into
+  `.githooks/pre-push`.
+- Spec §4.5 + §6.3 + §7 + §12 amended for PR6 SHIPPED state + PR7
+  handover, including the rewash happy-path-uncapped rebut.
+
+## Why
+
+13F-HR holdings observations are the dominant non-XBRL ownership
+volume (5.3 GB combined `_current` + `_observations`). Half-life:
+4-quarter trend matters, 8 quarters for backtests, beyond =
+decoration. Combined with #1010's filer-cohort bound (380d HR
+recency), the 8q depth cap drops the post-pre-wipe + clean-re-run
+footprint to ~0.5 GB observations + the PR12 audit on `_current`.
+
+Existing rows untouched (#1233 §6.3 — only the operator-driven
+pre-wipe purges).
+
+## Codex review
+
+- Codex 1a + 1b on the plan: 4 BLOCKING (1 rebut, 3 fixed) + 7 MED + 1
+  LOW resolved.
+- Codex 2 pre-push on the diff.
+```
+
+## 10. Handover for next session
+
+After PR6 merges, the next session picks up PR7 (N-PORT 8-quarter
+cap — mirror of PR6 plus N-PORT recency cohort bound `last_nport_at`
+per the #1010 pattern).

--- a/docs/superpowers/specs/2026-05-19-data-retention-rubric.md
+++ b/docs/superpowers/specs/2026-05-19-data-retention-rubric.md
@@ -4,7 +4,7 @@
 >
 > Tracking issue: **#1233** — Bootstrap scope discipline umbrella.
 >
-> Status: **EVOLVING** — original spec merged 2026-05-19 (#1235) after Codex 1a + 1b + 1c + 1d. PR2 (#1237) + PR5 NUMERIC fix (#1236) shipped. PR1 revision in flight (this commit) reframes the spec's drop-policy from "DELETE pre-cap rows per PR" to "ingest-side caps only + one operator-driven pre-wipe + clean re-run at the end" — caps don't touch existing rows, and the wipe is whole-DB + operator-driven, not per-source.
+> Status: **EVOLVING** — original spec merged 2026-05-19 (#1235) after Codex 1a + 1b + 1c + 1d. PR1 (#1238), PR2 (#1237), PR3 (#1239), PR4 (#1240), PR5 NUMERIC fix (#1236), PR5 latest-2-primary cap (#1241), and **PR6 13F-HR 8-quarter cap (this commit)** shipped. PR1 revision reframed the spec's drop-policy from "DELETE pre-cap rows per PR" to "ingest-side caps only + one operator-driven pre-wipe + clean re-run at the end" — caps don't touch existing rows, and the wipe is whole-DB + operator-driven, not per-source.
 
 ## 0. Status snapshot (2026-05-19 17:00 UTC, mid-drain)
 
@@ -146,9 +146,11 @@ Each subsection follows the shape: **raw shape → current volume → signal hal
 - **Current volume**: 105k raw holdings; 3.86M observations rows; 2.5 GB obs + 2.8 GB current = **5.3 GB combined**.
 - **Half-life**: **medium** — 4-quarter trend matters for momentum; 8 quarters (2y) for backtests; beyond = decoration.
 - **Consumers**: stacked institutional ownership % chart; concentration metric in ranking; AI thesis "Vanguard increased position by 8%".
-- **Ingest depth cap**: **8 quarters (2y)** observations at the parser + always-current snapshot.
+- **Ingest depth cap**: **8 quarters (2y)** observations at the parser + always-current snapshot. **PR6 SHIPPED.** Cap anchored to calendar quarter ends (`thirteen_f_retention_cutoff` in `app/services/institutional_holdings.py`) — admits exactly 8 quarter-ends at every instant. A floating `today - 760d` cutoff would slip to nine quarter-ends right after a new quarter completes (Codex 1a on the PR6 plan caught this).
 - **Cohort bound**: **already done #1010** — `last_13f_hr_at` 380d recency cap on filer cohort (11,205 → 8,681 filers).
+- **Chokepoint coverage (PR6)**: every 13F-HR writer honours the cap — `parse_submissions_index` intrinsic floor, `_ingest_single_accession` defensive post-parse gate, manifest-worker `_parse_13f_hr` post-parse gate, `ingest_13f_dataset_archive` per-row gate + `rows_skipped_retention` counter, rewash `_apply_13f_infotable` rescue branch (happy path uncapped per PR5 precedent — see §6.3 amend), and `ownership_observations_sync.sync_institutions` SQL predicate. Lint guard `scripts/check_13f_hr_retention.sh` (nine PR5-style placement invariants A-I) wired into `.githooks/pre-push`.
 - **`ownership_institutions_current` size oddity**: 2.8 GB is huge for a "current snapshot" — investigation needed. Either stores wide rows with embedded payload, or write-through is dumping more than current state. Separate audit ticket (PR12).
+- **`refresh_institutions_current` is NOT a writer chokepoint**: it derives `_current` from `_observations` via `DELETE` + `INSERT … SELECT DISTINCT ON`. Spec §4.5 "always-current snapshot" + spec §6.3 "existing rows untouched" together mean the refresh path is exempt from the cap — capping it would actively delete pre-wipe pre-cap rows from `_current` on every repair sweep, contradicting §6.3.
 - **Existing rows**: untouched until pre-wipe (§6.3).
 - **Why this matters**: combined 5.3 GB. Post-wipe + clean re-run under 8q + PR12 audit projects to ~1-2 GB (depending on what `current` really stores).
 
@@ -311,6 +313,17 @@ This single event replaces the dozen per-PR `DELETE` instructions. Reasons:
 
 **Same-DB cold archive remains out of scope** — Codex 1a §3 was right that same-DB archive doesn't reduce DB size. If a future epic wants cold-archive, ship as **separate database** or **S3 parquet snapshots**, not same-DB tables.
 
+**Rewash happy-path-uncapped clarification (PR5 + PR6 precedent)**:
+`_apply_def14a` / `_apply_13f_infotable` etc. have two branches —
+*happy path* when typed rows already exist for the accession (DELETE +
+re-INSERT under a new `parser_version`, row set preserved), and
+*rescue path* when no typed rows yet exist (turning a zero-row
+accession into populated rows). Happy path is uncapped (it operates
+on rows the spec already owns under "existing rows untouched");
+rescue path is capped (pre-cap accessions must not enter via the
+rescue back-door). PR5 codified this split for DEF 14A; PR6 inherits
+it for 13F-HR.
+
 ### 6.4 Two-layer storage (current + observations)
 
 Per `#788` decomposition, keep the two-layer model:
@@ -331,7 +344,7 @@ Land per-source PRs in this order. Each PR is **ingest-side cap only** — no PR
 - **PR3 — pending.** Filing events 10y rolling cap at the parser. Applied uniformly across every filing_type via every discovery writer. Schema columns + existing rows untouched.
 - **PR4 — IN PROGRESS.** Form 4 / 4-A 3y ingest cap at every writer chokepoint (legacy filing_events SELECTs, manifest-worker `_parse_form4` pre-fetch gate, bulk-dataset Form-4-only filter). Cumulative-rollup invariant pinned by steady-state test; synthetic opening-balance anchor NOT written (§4.3 amendment, this commit). Recency cohort bound inherited from PR1 `is_tradable=TRUE` filter (no insider-filer cohort table; Form 4 walked per-issuer-CIK via filing_events). Includes a parity lint guard catching new chokepoints that omit the predicate.
 - **PR5 — SHIPPED.** DEF 14A latest-2-PRIMARY-proxies cap at discovery + parser + rewash-rescue chokepoints. Supplemental form variants (DEFA14A / DEFR14A / DEFM14A) uncapped (§4.7). NUMERIC overflow #1228 already folded (#1236).
-- **PR6 — pending.** 13F-HR 8-quarter ingest cap at the parser. (#1010 cohort bound already in place.)
+- **PR6 — SHIPPED.** 13F-HR 8-quarter ingest cap at every writer chokepoint (parse_submissions_index intrinsic floor, _ingest_single_accession defensive post-parse gate, manifest-worker post-parse gate, bulk-dataset per-row gate, rewash rescue gate, sync_institutions SQL predicate). Cap anchored to calendar quarter ends (`thirteen_f_retention_cutoff`) — admits exactly 8 quarter-ends. (#1010 cohort bound already in place.) Lint guard `scripts/check_13f_hr_retention.sh` with nine PR5-style placement invariants A-I.
 - **PR7 — pending.** N-PORT 8-quarter cap (mirror of PR6). N-PORT recency cohort bound (`last_nport_at`) per #1010 pattern.
 - **PR8 — pending.** N-CSR/N-CSRS validate existing 2y horizon. Doc-only unless drift found.
 - **PR9 — pending.** N-CEN latest-only cap at the parser. Verify `ncen_classifier` reads latest.
@@ -402,25 +415,28 @@ Per #1208 cadence:
 State as of this commit:
 
 - PR1 (#1238), PR2 (#1237), PR3 (#1239), PR4 (#1240), PR5 NUMERIC fix
-  (#1236) and PR5 latest-2-primary cap (this commit) all shipped.
-- PR6-PR12 remain — every one is ingest-side cap only, no row deletion.
+  (#1236), PR5 latest-2-primary cap (#1241), and **PR6 13F-HR
+  8-quarter cap (this commit)** all shipped.
+- PR7-PR12 remain — every one is ingest-side cap only, no row deletion.
   The pre-wipe is the single operator event at the end.
 
 ```text
-After PR5 merges, the next session picks up PR6
-(13F-HR 8-quarter ingest cap at the parser).
+After PR6 merges, the next session picks up PR7
+(N-PORT 8-quarter ingest cap at the parser).
 
-PR6 scope:
-- 13F-HR observations: per-filer 8-quarter rank cap.
-- #1010 cohort bound (last_13f_hr_at 380d) already in place — the
-  cohort is bounded; PR6 adds per-filer depth.
-- Identify every 13F-HR writer (manifest-worker parser, bulk drain,
-  rewash path) and apply the per-quarter rank cap at each.
+PR7 scope:
+- N-PORT observations: per-fund-trust 8-quarter rank cap. Mirror of
+  PR6 shape; N-PORT is the fund-trust equivalent of 13F-HR.
+- N-PORT recency cohort bound (`last_nport_at` 380d) — apply the
+  #1010 pattern to the N-PORT filer directory.
+- Identify every N-PORT writer (manifest-worker parser, bulk drain,
+  rewash path, sync_funds repair sweep) and apply the per-quarter
+  rank cap at each.
 - No DELETE of pre-8q rows. They survive until the §6.3 pre-wipe.
 
 FIRST ACTIONS:
-1. Read CLAUDE.md working order + the revised §4.5.
-2. Confirm PR5 merged. Confirm #1233 still OPEN as the umbrella.
-3. Branch `feature/1233-pr6-13f-hr-8q-cap`.
+1. Read CLAUDE.md working order + the revised §4.6.
+2. Confirm PR6 merged. Confirm #1233 still OPEN as the umbrella.
+3. Branch `feature/1233-pr7-nport-8q-cap`.
 4. Codex 1a on plan, then Codex 2 pre-push, then PR.
 ```

--- a/scripts/check_13f_hr_retention.sh
+++ b/scripts/check_13f_hr_retention.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+#
+# Lint guard: every 13F-HR writer chokepoint MUST honour the 8-quarter
+# retention cap (#1233 §4.5 PR6).
+#
+# Nine PR5-style invariants (A-I), all enforced at PLACEMENT or
+# repo-wide writer discovery — not just file-level presence:
+#
+#  A. Helpers defined exactly once, in the canonical module
+#     (app/services/institutional_holdings.py).
+#  B. ``parse_submissions_index`` wires the intrinsic floor via
+#     ``thirteen_f_retention_cutoff(`` AND honours
+#     ``period < effective_floor`` (proves the cutoff feeds the
+#     existing per-accession filter).
+#  C. ``_ingest_single_accession`` defensive post-parse gate placement.
+#     ``thirteen_f_within_retention(info.period_of_report`` MUST sit
+#     between ``info = parse_primary_doc(`` and the first
+#     ``infotable_xml = sec.fetch_document_text(`` call.
+#  D. Manifest-worker ``_parse_13f_hr`` post-parse gate placement.
+#     ``thirteen_f_within_retention(`` MUST sit between
+#     ``info = parse_primary_doc(`` and the first
+#     ``infotable_xml =`` line.
+#  E. Bulk dataset archive-level + per-row gate placement.
+#       - ``thirteen_f_retention_cutoff(`` exactly 1 call AND its line
+#         number MUST be < the line containing ``for row in _iter_tsv``.
+#       - ``period_end < retention_cutoff`` predicate MUST appear
+#         between ``period_end = _parse_period_end`` and
+#         ``record_institution_observation(``.
+#       - ``rows_skipped_retention`` field on ``Form13FIngestResult`` +
+#         ≥ 1 increment.
+#  F. Rewash ``_apply_13f_infotable`` rescue-branch-only gate.
+#     ``thirteen_f_within_retention(`` exactly 1 call AND its line
+#     number MUST sit between the rescue-fallback SQL anchor
+#     (``JOIN institutional_filers f ON f.cik = log.filer_cik``) and
+#     the parser call ``parse_infotable(raw_doc.payload)``.
+#  G. ``ownership_observations_sync.sync_institutions`` SQL predicate.
+#     ``thirteen_f_retention_cutoff(`` ≥ 1 call AND SQL fragment
+#     ``ih.period_of_report >= %(retention_cutoff)s`` ≥ 1.
+#  H. Repo-wide writer discovery — exactly 3 production *.py files
+#     under app/ (excluding ownership_observations.py and tests) call
+#     ``record_institution_observation(`` within ±20 lines of a
+#     quote-style-agnostic ``source = '13f'`` / ``source = "13f"``
+#     match.
+#  I. Repo-wide writer discovery — exactly 1 production *.py file
+#     under app/ contains ``INSERT INTO institutional_holdings (``
+#     (note trailing column-list paren; distinguishes from the
+#     ``_ingest_log`` table).
+#
+# Exits non-zero on the first invariant violation. Wired into
+# ``.githooks/pre-push`` after ``check_def14a_cap.sh``.
+#
+# Awk-based block parsing (BSD vs GNU ``grep -P`` portability — PR4
+# Codex 1c lesson). The FULL retention predicate is counted, not bare
+# ``%(retention_cutoff)s`` (PR4 Codex 2 MED — bare-param counting let
+# unused params satisfy parity).
+
+set -euo pipefail
+
+FILE_INSTITUTIONAL_HOLDINGS="app/services/institutional_holdings.py"
+FILE_MANIFEST_13F="app/services/manifest_parsers/sec_13f_hr.py"
+FILE_BULK_DATASET="app/services/sec_13f_dataset_ingest.py"
+FILE_REWASH="app/services/rewash_filings.py"
+FILE_OBS_SYNC="app/services/ownership_observations_sync.py"
+
+violations=0
+fail() {
+  echo "::error::$1" >&2
+  violations=$((violations + 1))
+}
+
+# Count occurrences of a literal substring inside a file. ``-F`` for
+# literal (no regex), ``-c`` returns 0 on no matches.
+count_literal() {
+  local file="$1" pat="$2"
+  grep -Fc "$pat" "$file" || true
+}
+
+# Count parenthesis-suffixed helper call-sites EXCLUDING ``def`` lines
+# (helper definitions themselves) and pure-comment lines. Mirrors the
+# PR4 ``count_call_sites`` helper.
+count_call_sites() {
+  local file="$1" symbol="$2"
+  awk -v sym="$symbol" '
+    /^[[:space:]]*#/   { next }
+    /^[[:space:]]*def[[:space:]]/ { next }
+    {
+      pat = sym "("
+      if (index($0, pat) > 0) n++
+    }
+    END { print n + 0 }
+  ' "$file"
+}
+
+# Line number of first literal-substring match inside a function body.
+# Body bounded by ``def <name>(`` and the next column-0 ``def `` or
+# EOF. BSD awk doesn't accept ``(`` in regex — use ``index()`` for
+# literal substring matching.
+first_line_in_function() {
+  local file="$1" fname="$2" literal="$3"
+  awk -v fname="$fname" -v literal="$literal" '
+    BEGIN {
+      in_fn = 0
+      anchor = "def " fname "("
+    }
+    {
+      if (!in_fn) {
+        stripped = $0
+        sub(/^[[:space:]]+/, "", stripped)
+        if (index(stripped, anchor) == 1) {
+          in_fn = 1
+          fn_start_nr = NR
+        }
+        next
+      }
+      if (NR > fn_start_nr && substr($0, 1, 4) == "def ") {
+        in_fn = 0
+        next
+      }
+      if (index($0, literal) > 0) { print NR; exit }
+    }
+  ' "$file"
+}
+
+# Count call-sites of a literal substring inside a function body.
+count_in_function() {
+  local file="$1" fname="$2" literal="$3"
+  awk -v fname="$fname" -v literal="$literal" '
+    BEGIN {
+      in_fn = 0
+      anchor = "def " fname "("
+    }
+    {
+      if (!in_fn) {
+        stripped = $0
+        sub(/^[[:space:]]+/, "", stripped)
+        if (index(stripped, anchor) == 1) {
+          in_fn = 1
+          fn_start_nr = NR
+        }
+        next
+      }
+      if (NR > fn_start_nr && substr($0, 1, 4) == "def ") {
+        in_fn = 0
+        next
+      }
+      if (index($0, literal) > 0) { n++ }
+    }
+    END { print n + 0 }
+  ' "$file"
+}
+
+# ======================================================================
+# A — helpers defined exactly once
+# ======================================================================
+echo "Checking invariant A (helper definitions)..."
+
+if [[ ! -f "$FILE_INSTITUTIONAL_HOLDINGS" ]]; then
+  fail "missing file: $FILE_INSTITUTIONAL_HOLDINGS"
+else
+  cutoff_defs=$(count_literal "$FILE_INSTITUTIONAL_HOLDINGS" "def thirteen_f_retention_cutoff(")
+  within_defs=$(count_literal "$FILE_INSTITUTIONAL_HOLDINGS" "def thirteen_f_within_retention(")
+  if (( cutoff_defs != 1 )); then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS: expected exactly 1 def thirteen_f_retention_cutoff(...), found ${cutoff_defs}."
+  fi
+  if (( within_defs != 1 )); then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS: expected exactly 1 def thirteen_f_within_retention(...), found ${within_defs}."
+  fi
+fi
+
+# ======================================================================
+# B — parse_submissions_index wires the intrinsic floor
+# ======================================================================
+echo "Checking invariant B (parse_submissions_index floor)..."
+
+if [[ -f "$FILE_INSTITUTIONAL_HOLDINGS" ]]; then
+  cutoff_call_in_psi=$(count_in_function "$FILE_INSTITUTIONAL_HOLDINGS" "parse_submissions_index" "thirteen_f_retention_cutoff(")
+  filter_marker_in_psi=$(count_in_function "$FILE_INSTITUTIONAL_HOLDINGS" "parse_submissions_index" "period < effective_floor")
+  if (( cutoff_call_in_psi < 1 )); then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS: parse_submissions_index missing thirteen_f_retention_cutoff(...) call — intrinsic floor not wired."
+  fi
+  if (( filter_marker_in_psi < 1 )); then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS: parse_submissions_index missing 'period < effective_floor' filter — cutoff not connected to the per-accession gate."
+  fi
+fi
+
+# ======================================================================
+# C — _ingest_single_accession defensive post-parse gate placement
+# ======================================================================
+echo "Checking invariant C (_ingest_single_accession post-parse gate)..."
+
+if [[ -f "$FILE_INSTITUTIONAL_HOLDINGS" ]]; then
+  cap_line=$(first_line_in_function "$FILE_INSTITUTIONAL_HOLDINGS" "_ingest_single_accession" "thirteen_f_within_retention(info.period_of_report" || true)
+  parse_line=$(first_line_in_function "$FILE_INSTITUTIONAL_HOLDINGS" "_ingest_single_accession" "info = parse_primary_doc(" || true)
+  infotable_line=$(first_line_in_function "$FILE_INSTITUTIONAL_HOLDINGS" "_ingest_single_accession" "infotable_xml = sec.fetch_document_text(" || true)
+
+  if [[ -z "$cap_line" || "$cap_line" == "0" ]]; then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS: _ingest_single_accession missing thirteen_f_within_retention(info.period_of_report ...) post-parse gate."
+  elif [[ -z "$parse_line" || "$parse_line" == "0" ]]; then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS: _ingest_single_accession missing 'info = parse_primary_doc(' anchor — cannot validate cap placement."
+  elif [[ -z "$infotable_line" || "$infotable_line" == "0" ]]; then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS: _ingest_single_accession missing 'infotable_xml = sec.fetch_document_text(' anchor — cannot validate cap placement."
+  elif (( cap_line <= parse_line )); then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS:$cap_line: post-parse gate appears BEFORE 'info = parse_primary_doc(' at line $parse_line."
+  elif (( cap_line >= infotable_line )); then
+    fail "$FILE_INSTITUTIONAL_HOLDINGS:$cap_line: post-parse gate appears AFTER 'infotable_xml = sec.fetch_document_text(' at line $infotable_line — pre-fetch ordering violated."
+  fi
+fi
+
+# ======================================================================
+# D — manifest-worker post-parse gate placement
+# ======================================================================
+echo "Checking invariant D (manifest-worker _parse_13f_hr gate)..."
+
+if [[ ! -f "$FILE_MANIFEST_13F" ]]; then
+  fail "missing file: $FILE_MANIFEST_13F"
+else
+  cap_line=$(first_line_in_function "$FILE_MANIFEST_13F" "_parse_13f_hr" "thirteen_f_within_retention(" || true)
+  parse_line=$(first_line_in_function "$FILE_MANIFEST_13F" "_parse_13f_hr" "info = parse_primary_doc(" || true)
+  infotable_line=$(first_line_in_function "$FILE_MANIFEST_13F" "_parse_13f_hr" "infotable_xml =" || true)
+
+  if [[ -z "$cap_line" || "$cap_line" == "0" ]]; then
+    fail "$FILE_MANIFEST_13F: _parse_13f_hr missing thirteen_f_within_retention(...) post-parse gate."
+  elif [[ -z "$parse_line" || "$parse_line" == "0" ]]; then
+    fail "$FILE_MANIFEST_13F: _parse_13f_hr missing 'info = parse_primary_doc(' anchor."
+  elif [[ -z "$infotable_line" || "$infotable_line" == "0" ]]; then
+    fail "$FILE_MANIFEST_13F: _parse_13f_hr missing 'infotable_xml =' anchor."
+  elif (( cap_line <= parse_line )); then
+    fail "$FILE_MANIFEST_13F:$cap_line: gate appears BEFORE 'info = parse_primary_doc(' at line $parse_line."
+  elif (( cap_line >= infotable_line )); then
+    fail "$FILE_MANIFEST_13F:$cap_line: gate appears AFTER 'infotable_xml =' at line $infotable_line — pre-fetch ordering violated."
+  fi
+fi
+
+# ======================================================================
+# E — bulk dataset archive-level + per-row gate
+# ======================================================================
+echo "Checking invariant E (bulk dataset gate)..."
+
+if [[ ! -f "$FILE_BULK_DATASET" ]]; then
+  fail "missing file: $FILE_BULK_DATASET"
+else
+  cutoff_calls=$(count_call_sites "$FILE_BULK_DATASET" "thirteen_f_retention_cutoff")
+  predicate_count=$(count_literal "$FILE_BULK_DATASET" "period_end < retention_cutoff")
+  field_def=$(count_literal "$FILE_BULK_DATASET" "rows_skipped_retention: int")
+  inc_count=$(count_literal "$FILE_BULK_DATASET" "result.rows_skipped_retention += 1")
+
+  if (( cutoff_calls != 1 )); then
+    fail "$FILE_BULK_DATASET: expected exactly 1 thirteen_f_retention_cutoff(...) call (archive-level anchor), found ${cutoff_calls}."
+  fi
+  if (( predicate_count < 1 )); then
+    fail "$FILE_BULK_DATASET: missing 'period_end < retention_cutoff' per-row gate predicate."
+  fi
+  if (( field_def != 1 )); then
+    fail "$FILE_BULK_DATASET: Form13FIngestResult missing 'rows_skipped_retention: int' field."
+  fi
+  if (( inc_count < 1 )); then
+    fail "$FILE_BULK_DATASET: missing 'result.rows_skipped_retention += 1' increment in the gate branch."
+  fi
+
+  cutoff_line=$(first_line_in_function "$FILE_BULK_DATASET" "ingest_13f_dataset_archive" "thirteen_f_retention_cutoff(" || true)
+  for_line=$(first_line_in_function "$FILE_BULK_DATASET" "ingest_13f_dataset_archive" "for row in _iter_tsv" || true)
+  pred_line=$(first_line_in_function "$FILE_BULK_DATASET" "ingest_13f_dataset_archive" "period_end < retention_cutoff" || true)
+  parse_pe_line=$(first_line_in_function "$FILE_BULK_DATASET" "ingest_13f_dataset_archive" "period_end = _parse_period_end" || true)
+  write_line=$(first_line_in_function "$FILE_BULK_DATASET" "ingest_13f_dataset_archive" "record_institution_observation(" || true)
+
+  if [[ -n "$cutoff_line" && -n "$for_line" && "$cutoff_line" != "0" && "$for_line" != "0" ]]; then
+    if (( cutoff_line >= for_line )); then
+      fail "$FILE_BULK_DATASET:$cutoff_line: thirteen_f_retention_cutoff(...) appears at/after 'for row in _iter_tsv' at line $for_line — must be hoisted out of the per-row loop."
+    fi
+  fi
+  if [[ -n "$pred_line" && -n "$parse_pe_line" && -n "$write_line" && "$pred_line" != "0" ]]; then
+    if (( pred_line <= parse_pe_line )); then
+      fail "$FILE_BULK_DATASET:$pred_line: 'period_end < retention_cutoff' appears BEFORE 'period_end = _parse_period_end' at line $parse_pe_line."
+    elif (( pred_line >= write_line )); then
+      fail "$FILE_BULK_DATASET:$pred_line: 'period_end < retention_cutoff' appears at/after 'record_institution_observation(' at line $write_line — gate must short-circuit before write."
+    fi
+  fi
+fi
+
+# ======================================================================
+# F — rewash _apply_13f_infotable rescue-branch-only gate
+# ======================================================================
+echo "Checking invariant F (rewash rescue-branch gate)..."
+
+if [[ ! -f "$FILE_REWASH" ]]; then
+  fail "missing file: $FILE_REWASH"
+else
+  cap_count=$(count_in_function "$FILE_REWASH" "_apply_13f_infotable" "thirteen_f_within_retention(")
+  if (( cap_count != 1 )); then
+    fail "$FILE_REWASH: _apply_13f_infotable should contain exactly 1 thirteen_f_within_retention(...) call (rescue-branch gate); found ${cap_count}."
+  else
+    cap_line=$(first_line_in_function "$FILE_REWASH" "_apply_13f_infotable" "thirteen_f_within_retention(" || true)
+    anchor_line=$(first_line_in_function "$FILE_REWASH" "_apply_13f_infotable" "JOIN institutional_filers f ON f.cik = log.filer_cik" || true)
+    parse_line=$(first_line_in_function "$FILE_REWASH" "_apply_13f_infotable" "parse_infotable(raw_doc.payload)" || true)
+
+    if [[ -z "$anchor_line" || "$anchor_line" == "0" ]]; then
+      fail "$FILE_REWASH: _apply_13f_infotable missing rescue-fallback 'JOIN institutional_filers f ON f.cik = log.filer_cik' anchor."
+    elif [[ -z "$parse_line" || "$parse_line" == "0" ]]; then
+      fail "$FILE_REWASH: _apply_13f_infotable missing 'parse_infotable(raw_doc.payload)' anchor."
+    elif (( cap_line <= anchor_line )); then
+      fail "$FILE_REWASH:$cap_line: thirteen_f_within_retention(...) appears at/before the rescue SQL anchor at line $anchor_line — happy-path branch must NOT be capped."
+    elif (( cap_line >= parse_line )); then
+      fail "$FILE_REWASH:$cap_line: thirteen_f_within_retention(...) appears at/after parse_infotable(...) at line $parse_line — rescue gate must short-circuit before parse."
+    fi
+  fi
+fi
+
+# ======================================================================
+# G — ownership_observations_sync.sync_institutions SQL predicate
+# ======================================================================
+echo "Checking invariant G (sync_institutions cap predicate)..."
+
+if [[ ! -f "$FILE_OBS_SYNC" ]]; then
+  fail "missing file: $FILE_OBS_SYNC"
+else
+  cutoff_calls=$(count_in_function "$FILE_OBS_SYNC" "sync_institutions" "thirteen_f_retention_cutoff(")
+  predicate_count=$(count_in_function "$FILE_OBS_SYNC" "sync_institutions" "ih.period_of_report >= %(retention_cutoff)s")
+  if (( cutoff_calls < 1 )); then
+    fail "$FILE_OBS_SYNC: sync_institutions missing thirteen_f_retention_cutoff(...) call."
+  fi
+  if (( predicate_count < 1 )); then
+    fail "$FILE_OBS_SYNC: sync_institutions missing 'ih.period_of_report >= %(retention_cutoff)s' SQL predicate."
+  fi
+fi
+
+# ======================================================================
+# H — repo-wide writer discovery for source = '13f' / "13f"
+# ======================================================================
+echo "Checking invariant H (repo-wide record_institution_observation source='13f' discovery)..."
+
+# Codex 2 MED — count CALL-SITES, not files. A new
+# ``record_institution_observation(... source='13f')`` added inside an
+# already-approved file would otherwise slip past a path-set check.
+# Each approved file currently has exactly ONE such call-site:
+#   * app/services/institutional_holdings.py (1)
+#   * app/services/sec_13f_dataset_ingest.py (1)
+#   * app/services/ownership_observations_sync.py (1)
+# Total = 3. Tighten the check to count ``record_institution_observation(``
+# call-sites that sit within ±20 lines of a ``source = '13f'`` /
+# ``source = "13f"`` kwarg match.
+total_writer_calls=0
+declare -a writer_call_files=()
+for cand in $(find app -type f -name '*.py' 2>/dev/null | grep -v 'app/services/ownership_observations.py' | sort -u); do
+  # Count call-sites in this file that have ``source = '13f'`` within
+  # ±20 lines. awk: collect line numbers of both patterns, then count
+  # ``record_*`` lines that have a ``source='13f'`` line within ±20.
+  file_calls=$(awk '
+    BEGIN { rc_count=0 }
+    {
+      lines[NR] = $0
+    }
+    END {
+      for (i=1; i<=NR; i++) {
+        if (index(lines[i], "record_institution_observation(") > 0) {
+          lo = i - 20; if (lo < 1) lo = 1
+          hi = i + 20; if (hi > NR) hi = NR
+          for (j=lo; j<=hi; j++) {
+            if (match(lines[j], /source[[:space:]]*=[[:space:]]*["'\'']13f["'\'']/) > 0) {
+              rc_count++
+              break
+            }
+          }
+        }
+      }
+      print rc_count + 0
+    }
+  ' "$cand")
+  if (( file_calls > 0 )); then
+    total_writer_calls=$((total_writer_calls + file_calls))
+    writer_call_files+=("$cand:$file_calls")
+  fi
+done
+
+expected_writers=3
+if (( total_writer_calls != expected_writers )); then
+  fail "expected exactly ${expected_writers} call-sites of record_institution_observation(... source='13f'|\"13f\") in app/, found ${total_writer_calls}: ${writer_call_files[*]}. Update the lint guard if you intentionally added/removed a writer."
+fi
+
+# ======================================================================
+# I — repo-wide INSERT INTO institutional_holdings ( discovery
+# ======================================================================
+echo "Checking invariant I (INSERT INTO institutional_holdings ( discovery)..."
+
+# Codex 2 MED — count CALL-SITES (literal matches), not files. A
+# second ``INSERT INTO institutional_holdings (`` added inside the
+# same already-approved file would otherwise slip past a path-set
+# check. The current canonical writer is ``_upsert_holding`` in
+# ``app/services/institutional_holdings.py`` — exactly one match
+# repo-wide. Note the trailing column-list paren distinguishes from
+# the ``_ingest_log`` table.
+total_insert_calls=$(find app -type f -name '*.py' 2>/dev/null -exec grep -cE "INSERT INTO institutional_holdings \(" {} \; 2>/dev/null | awk '{s+=$1} END {print s+0}')
+insert_files=$(grep -lE "INSERT INTO institutional_holdings \(" \
+  $(find app -type f -name '*.py' 2>/dev/null) 2>/dev/null | sort -u || true)
+
+expected_inserts=1
+if (( total_insert_calls != expected_inserts )); then
+  fail "expected exactly ${expected_inserts} 'INSERT INTO institutional_holdings (' call-site in app/, found ${total_insert_calls} across files: ${insert_files}. Update the lint guard if you intentionally added/removed a writer."
+fi
+
+# ======================================================================
+# Verdict
+# ======================================================================
+
+if (( violations > 0 )); then
+  echo "" >&2
+  echo "FAIL: ${violations} 13F-HR retention-cap invariant violation(s)." >&2
+  echo "See docs/superpowers/specs/2026-05-19-data-retention-rubric.md §4.5 +" >&2
+  echo "docs/superpowers/plans/2026-05-20-pr6-13f-hr-8q-cap.md §6 for the rules." >&2
+  exit 1
+fi
+
+echo "OK: 13F-HR 8-quarter retention cap honoured at every chokepoint."

--- a/tests/test_manifest_parser_sec_13f_hr.py
+++ b/tests/test_manifest_parser_sec_13f_hr.py
@@ -677,7 +677,18 @@ def test_pre_2023_filed_at_scales_value_by_thousand(
 
     monkeypatch.setattr(parser_module, "parse_primary_doc", _fake_primary_doc)
 
-    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    # PR6 #1233 §4.5 — period_of_report=2022-09-30 is pre-cap under the
+    # default ``thirteen_f_retention_cutoff``. Pin ``now`` so the cap is
+    # historically anchored to 2023-Q1 and the pre-cutover fixture
+    # survives the gate. This test exercises the VALUE-cutover scaling,
+    # not the retention cap.
+    from unittest.mock import patch
+
+    historical_now = datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC)
+    with patch("app.services.institutional_holdings.datetime") as mock_dt:
+        mock_dt.now.return_value = historical_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
     ebull_test_conn.commit()
 
     assert stats.parsed == 1
@@ -746,6 +757,110 @@ def test_ingest_log_preserves_period_on_failure_after_success(
     assert row[0] == "failed"
     # The critical assertion: period preserved despite a NULL write.
     assert row[1] == date_cls(2024, 9, 30)
+
+
+def _fake_primary_xml_with_period(period_mdY: str, signature_mdY: str = "04-15-2020") -> str:
+    """``_FAKE_PRIMARY_XML`` clone with a configurable periodOfReport.
+
+    Used by the PR6 retention-cap tests below to land a pre-cap quarter
+    end without disturbing the happy-path fixture (locked at 2024-Q3).
+    """
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+  <headerData>
+    <filerInfo>
+      <filer>
+        <credentials>
+          <cik>0001067983</cik>
+        </credentials>
+      </filer>
+      <periodOfReport>{period_mdY}</periodOfReport>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPage>
+      <reportCalendarOrQuarter>{period_mdY}</reportCalendarOrQuarter>
+      <filingManager>
+        <name>BERKSHIRE HATHAWAY INC</name>
+        <address>
+          <street1>3555 Farnam Street</street1>
+          <city>Omaha</city>
+          <stateOrCountry>NE</stateOrCountry>
+          <zipCode>68131</zipCode>
+        </address>
+      </filingManager>
+    </coverPage>
+    <signatureBlock>
+      <signatureDate>{signature_mdY}</signatureDate>
+    </signatureBlock>
+  </formData>
+</edgarSubmission>
+"""
+
+
+def test_pre_cap_period_tombstones_before_infotable_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR6 #1233 §4.5 — pre-cap period_of_report skips infotable fetch.
+
+    Manifest worker fetches index + primary_doc, parses, then checks
+    the cap. If the parsed period is pre-cap (cutoff anchored to
+    2024-06-30 at the test's fixed_now of 2026-05-20), the manifest is
+    tombstoned with error='retention floor' BEFORE the infotable URL
+    is touched. The ingest-log row carries the parsed period for audit.
+    """
+    from datetime import date as date_cls
+    from unittest.mock import patch
+
+    accession = "0001067983-20-000099"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+    ebull_test_conn.commit()
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    pre_cap_primary = _fake_primary_xml_with_period("03-31-2020", signature_mdY="04-15-2020")
+    calls = _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": pre_cap_primary,
+            # If the cap fails closed, this URL would be hit and the
+            # assertion below would catch it.
+            base + "infotable.xml": _infotable_xml(holdings=[{"cusip": "037833100"}]),
+        },
+    )
+
+    fixed_now = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+    with patch("app.services.institutional_holdings.datetime") as mock_dt:
+        mock_dt.now.return_value = fixed_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.error == "retention floor"
+    # raw_status='stored' — primary_doc.xml WAS fetched + persisted before
+    # the cap check (we still want the body for diagnostics).
+    assert row.raw_status == "stored"
+
+    # CRITICAL: infotable.xml URL must NEVER appear in the fetch calls.
+    assert base + "infotable.xml" not in calls
+
+    # Ingest-log row carries the parsed period for audit visibility.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, period_of_report, error FROM institutional_holdings_ingest_log WHERE accession_number = %s",
+            (accession,),
+        )
+        log = cur.fetchone()
+    assert log is not None
+    assert log[0] == "failed"
+    assert log[1] == date_cls(2020, 3, 31)
+    assert log[2] == "retention floor"
 
 
 def test_parser_registered_via_register_all() -> None:

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -1176,6 +1176,119 @@ def test_blockholders_apply_raises_on_empty_reporting_persons(
     assert result_row[0] == 1  # original reporter still on file
 
 
+def test_13f_infotable_rescue_branch_pre_cap_period_returns_false(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """PR6 #1233 §4.5 — rescue branch gates on period_of_report.
+
+    Rescue cohort = no existing rows in ``institutional_holdings`` for
+    the accession (the IF branch took rows=None and we fell into the
+    ELSE rescue branch's SELECT against
+    ``institutional_holdings_ingest_log``). A pre-cap period must NOT
+    write new typed rows via the rescue path; happy path is uncapped
+    by spec §6.3 (refresh of existing rows is allowed) but rescue is
+    effectively a fresh ingest.
+    """
+    from datetime import date as date_cls
+
+    from app.providers.implementations.sec_13f import ThirteenFHolding
+
+    conn = ebull_test_conn
+    instrument_id = 950_090
+    accession = "0001234567-26-13f-rescue-precap"
+    pre_cap_period = date_cls(2020, 3, 31)  # pre-cap at fixed_now = 2026-05-20
+
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'PRECAP13F', 'PreCap 13F', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (
+            instrument_id, provider, identifier_type, identifier_value, is_primary
+        ) VALUES (%s, 'sec', 'cusip', 'PRECAP13F0', TRUE)
+        ON CONFLICT DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    # Filer + tombstoned ingest_log row with pre-cap period; zero
+    # institutional_holdings rows.
+    conn.execute(
+        """
+        INSERT INTO institutional_filers (cik, name)
+        VALUES ('0000111002', 'Test PreCap Filer')
+        ON CONFLICT (cik) DO NOTHING
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO institutional_holdings_ingest_log (
+            accession_number, filer_cik, period_of_report, status
+        ) VALUES (%s, '0000111002', %s, 'partial')
+        """,
+        (accession, pre_cap_period),
+    )
+    _seed_raw(conn, accession=accession, kind="infotable_13f", parser_version="13f-infotable-v0")
+    conn.commit()
+
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_13f.parse_infotable",
+        lambda _xml: [
+            ThirteenFHolding(
+                name_of_issuer="PreCap Issuer",
+                title_of_class="COM",
+                cusip="PRECAP13F0",
+                value_usd=Decimal("1000"),
+                shares_or_principal=Decimal("100"),
+                shares_or_principal_type="SH",
+                investment_discretion="SOLE",
+                voting_sole=Decimal("100"),
+                voting_shared=Decimal("0"),
+                voting_none=Decimal("0"),
+                put_call=None,
+            )
+        ],
+    )
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="infotable_13f",
+            current_version="13f-infotable-v1",
+            apply_fn=rewash_filings._apply_13f_infotable,
+        )
+    )
+
+    from unittest.mock import patch
+
+    fixed_now = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+    with patch("app.services.institutional_holdings.datetime") as mock_dt:
+        mock_dt.now.return_value = fixed_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = rewash_filings.run_rewash(conn, document_kind="infotable_13f")
+
+    # Cap returns False → rewash counts the row as skipped (not bumped).
+    assert result.rows_reparsed == 0
+    assert result.rows_skipped == 1
+
+    # No typed rows written.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM institutional_holdings WHERE accession_number = %s",
+            (accession,),
+        )
+        count = cur.fetchone()
+    assert count is not None
+    assert count[0] == 0
+
+
 def test_13f_infotable_apply_raises_on_empty_parse(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_sec_13f_dataset_ingest.py
+++ b/tests/test_sec_13f_dataset_ingest.py
@@ -433,11 +433,23 @@ class TestRealArchiveEdgeCases:
         )
         archive_path = tmp_path / "form13f.zip"
         archive_path.write_bytes(archive_bytes)
-        result = ingest_13f_dataset_archive(
-            conn=ebull_test_conn,
-            archive_path=archive_path,
-            ingest_run_id=uuid4(),
-        )
+        # PR6 #1233 §4.5 — pin ``now`` to early 2023 so the
+        # ``thirteen_f_retention_cutoff`` admits the 2022-Q3 period
+        # under test. The 8q cap is exercised separately in
+        # ``tests/test_thirteen_f_retention_cap.py``; this test focuses
+        # on the VALUE-cutover scaling.
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+
+        historical_now = datetime(2023, 1, 15, 12, 0, 0, tzinfo=UTC)
+        with patch("app.services.institutional_holdings.datetime") as mock_dt:
+            mock_dt.now.return_value = historical_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = ingest_13f_dataset_archive(
+                conn=ebull_test_conn,
+                archive_path=archive_path,
+                ingest_run_id=uuid4(),
+            )
         ebull_test_conn.commit()
         assert result.rows_written == 1
         with ebull_test_conn.cursor() as cur:

--- a/tests/test_thirteen_f_retention_cap.py
+++ b/tests/test_thirteen_f_retention_cap.py
@@ -1,0 +1,642 @@
+"""13F-HR 8-quarter ingest retention cap — #1233 §4.5 PR6.
+
+Pins the contracts:
+
+1. ``THIRTEEN_F_HR_RETENTION_QUARTERS == 8`` is the single source of truth.
+2. ``thirteen_f_retention_cutoff`` is anchored to calendar quarter ends.
+   Cutoff = quarter-end exactly ``RETENTION_QUARTERS - 1`` quarters before
+   the most-recent COMPLETED quarter end. Inclusive boundary. Always
+   yields exactly 8 quarter-ends, never 9.
+3. ``thirteen_f_retention_cutoff`` requires a tz-aware ``now``; naive
+   ``datetime`` raises ``ValueError``. Non-UTC tz normalises via
+   ``.astimezone(UTC).date()``.
+4. ``thirteen_f_within_retention`` is INCLUSIVE at the boundary; None
+   ``period_of_report`` returns False (defensive).
+5. ``parse_submissions_index`` enforces the intrinsic floor — caller's
+   ``min_period_of_report=None`` no longer means full history; the 8q
+   cap is the default. Caller floor RAISES the floor (more recent
+   wins) but never lowers it.
+6. ``_ingest_single_accession`` defensive post-parse gate catches
+   accessions whose submissions JSON ``reportDate`` was NULL/malformed.
+7. Manifest-worker ``_parse_13f_hr`` post-parse gate tombstones pre-cap
+   accessions BEFORE the infotable fetch.
+8. Bulk dataset ``ingest_13f_dataset_archive`` per-row gate skips pre-
+   cap rows with a ``rows_skipped_retention`` counter; boundary
+   equality (``period_end == cutoff``) survives.
+9. Rewash ``_apply_13f_infotable`` rescue branch gates by
+   ``period_of_report`` (happy path uncapped per PR5 precedent).
+10. ``ownership_observations_sync.sync_institutions`` SQL predicate
+    blocks pre-cap rows even if ``institutional_holdings`` still
+    carries them.
+
+Existing rows are not deleted by the cap (#1233 §6.3 is the only
+purge event). These tests assert *insert/admit* behaviour only.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import zipfile
+from collections.abc import Iterable
+from datetime import UTC, date, datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from app.services.institutional_holdings import (
+    THIRTEEN_F_HR_RETENTION_QUARTERS,
+    AccessionRef,
+    _ingest_single_accession,
+    parse_submissions_index,
+    thirteen_f_retention_cutoff,
+    thirteen_f_within_retention,
+)
+from app.services.ownership_observations_sync import sync_institutions
+from app.services.sec_13f_dataset_ingest import ingest_13f_dataset_archive
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+# ---------------------------------------------------------------------------
+# Pure helper contracts
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionConstantAndCutoff:
+    def test_constant_is_8_quarters(self) -> None:
+        assert THIRTEEN_F_HR_RETENTION_QUARTERS == 8
+
+    def test_q2_in_progress_anchors_to_q1_completed(self) -> None:
+        # 2026-05-20 is inside Q2 2026. Latest completed quarter end =
+        # Q1 2026 = 2026-03-31. 7 quarters back = Q2 2024 = 2024-06-30.
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        assert thirteen_f_retention_cutoff(now=ref) == date(2024, 6, 30)
+
+    def test_cutoff_does_not_drift_within_a_quarter(self) -> None:
+        # First day of Q2 and last day of Q2 must yield the SAME cutoff —
+        # the bug Codex 1a §1 caught with a floating today-760d window.
+        first_day_q2 = datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC)
+        last_day_q2 = datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC)
+        assert thirteen_f_retention_cutoff(now=first_day_q2) == date(2024, 6, 30)
+        assert thirteen_f_retention_cutoff(now=last_day_q2) == date(2024, 6, 30)
+
+    def test_cutoff_rolls_forward_at_quarter_boundary(self) -> None:
+        # 2026-06-30 is still inside Q2 (latest completed = Q1, cutoff = 2024-06-30).
+        # 2026-07-01 is the first day of Q3 (latest completed = Q2, cutoff = 2024-09-30).
+        before_roll = datetime(2026, 6, 30, 23, 59, 59, tzinfo=UTC)
+        after_roll = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+        assert thirteen_f_retention_cutoff(now=before_roll) == date(2024, 6, 30)
+        assert thirteen_f_retention_cutoff(now=after_roll) == date(2024, 9, 30)
+
+    def test_q1_anchors_to_prior_year_q4(self) -> None:
+        # 2026-01-15 inside Q1 2026 → latest completed = Q4 2025 (2025-12-31).
+        # 7 back = Q1 2024 = 2024-03-31.
+        ref = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        assert thirteen_f_retention_cutoff(now=ref) == date(2024, 3, 31)
+
+    def test_cutoff_returns_date_not_datetime(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        result = thirteen_f_retention_cutoff(now=ref)
+        assert isinstance(result, date)
+        assert not isinstance(result, datetime)
+
+    def test_naive_datetime_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="tz-aware"):
+            thirteen_f_retention_cutoff(now=datetime(2026, 5, 20, 12, 0, 0))
+
+    def test_non_utc_tz_normalises_to_utc_date(self) -> None:
+        # 2026-04-01 03:00 in UTC-05 = 2026-04-01 08:00 UTC. Still inside
+        # Q2 UTC → cutoff = 2024-06-30. Local-TZ date would also be
+        # 2026-04-01, so flip to a case where the UTC date differs.
+        #
+        # 2026-06-30 23:00 in UTC-04 = 2026-07-01 03:00 UTC. UTC date is
+        # 2026-07-01 = first day of Q3 → cutoff = 2024-09-30. Local-TZ
+        # date would be 2026-06-30 (still Q2) → cutoff = 2024-06-30.
+        # The UTC normalisation wins.
+        tz_minus_04 = timezone(timedelta(hours=-4))
+        edge_case = datetime(2026, 6, 30, 23, 0, 0, tzinfo=tz_minus_04)
+        assert thirteen_f_retention_cutoff(now=edge_case) == date(2024, 9, 30)
+
+
+class TestThirteenFWithinRetention:
+    def test_at_boundary_accepted(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        cutoff = thirteen_f_retention_cutoff(now=ref)
+        assert thirteen_f_within_retention(cutoff, now=ref) is True
+
+    def test_one_day_before_boundary_rejected(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        cutoff = thirteen_f_retention_cutoff(now=ref)
+        assert thirteen_f_within_retention(cutoff - timedelta(days=1), now=ref) is False
+
+    def test_one_day_after_boundary_accepted(self) -> None:
+        ref = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        cutoff = thirteen_f_retention_cutoff(now=ref)
+        assert thirteen_f_within_retention(cutoff + timedelta(days=1), now=ref) is True
+
+    def test_none_period_rejected(self) -> None:
+        # Defensive: an accession we couldn't tag with a quarter end is
+        # unsafe to admit.
+        assert thirteen_f_within_retention(None) is False
+
+
+# ---------------------------------------------------------------------------
+# parse_submissions_index intrinsic floor
+# ---------------------------------------------------------------------------
+
+
+def _submissions_payload(rows: list[tuple[str, str, str, str]]) -> str:
+    """Build a minimal SEC submissions JSON payload.
+
+    Each row: (accession_number, form, filing_date, report_date).
+    """
+    return json.dumps(
+        {
+            "filings": {
+                "recent": {
+                    "accessionNumber": [r[0] for r in rows],
+                    "form": [r[1] for r in rows],
+                    "filingDate": [r[2] for r in rows],
+                    "reportDate": [r[3] for r in rows],
+                }
+            }
+        }
+    )
+
+
+class TestParseSubmissionsIndexIntrinsicFloor:
+    """Spec §4.5: caller's ``None`` falls back to the intrinsic cap.
+
+    Each scenario fixes a reference ``now`` via patch so the in-cap /
+    pre-cap classification is deterministic.
+    """
+
+    @pytest.fixture
+    def fixed_now(self) -> datetime:
+        return datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+
+    def test_caller_none_falls_back_to_intrinsic_cap(self, fixed_now: datetime) -> None:
+        # Cutoff at fixed_now = 2024-06-30. 2024-03-31 is pre-cap;
+        # 2024-09-30 is in-cap.
+        payload = _submissions_payload(
+            [
+                ("0001000000-20-000001", "13F-HR", "2024-04-15", "2024-03-31"),
+                ("0001000000-24-000001", "13F-HR", "2024-10-31", "2024-09-30"),
+            ]
+        )
+        with patch("app.services.institutional_holdings.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            refs = parse_submissions_index(payload)
+        accessions = [r.accession_number for r in refs]
+        assert "0001000000-20-000001" not in accessions
+        assert "0001000000-24-000001" in accessions
+
+    def test_caller_floor_more_recent_overrides_cap(self, fixed_now: datetime) -> None:
+        # Caller floor = 2025-01-01 > intrinsic cap 2024-06-30.
+        # 2024-12-31 is in-cap but pre-caller-floor → skipped.
+        payload = _submissions_payload(
+            [
+                ("0001000000-24-099999", "13F-HR", "2025-01-15", "2024-12-31"),
+                ("0001000000-25-000001", "13F-HR", "2025-04-15", "2025-03-31"),
+            ]
+        )
+        with patch("app.services.institutional_holdings.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            refs = parse_submissions_index(payload, min_period_of_report=date(2025, 1, 1))
+        accessions = [r.accession_number for r in refs]
+        assert "0001000000-24-099999" not in accessions
+        assert "0001000000-25-000001" in accessions
+
+    def test_caller_floor_more_permissive_loses_to_cap(self, fixed_now: datetime) -> None:
+        # Caller floor = 2020-01-01 < intrinsic cap 2024-06-30.
+        # 2023-12-31 is post-caller-floor but pre-cap → skipped.
+        payload = _submissions_payload(
+            [
+                ("0001000000-23-000001", "13F-HR", "2024-01-31", "2023-12-31"),
+                ("0001000000-25-000002", "13F-HR", "2025-04-15", "2025-03-31"),
+            ]
+        )
+        with patch("app.services.institutional_holdings.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            refs = parse_submissions_index(payload, min_period_of_report=date(2020, 1, 1))
+        accessions = [r.accession_number for r in refs]
+        assert "0001000000-23-000001" not in accessions
+        assert "0001000000-25-000002" in accessions
+
+    def test_boundary_period_accepted(self, fixed_now: datetime) -> None:
+        # period_of_report == cutoff is admitted (inclusive boundary).
+        payload = _submissions_payload([("0001000000-24-000777", "13F-HR", "2024-07-15", "2024-06-30")])
+        with patch("app.services.institutional_holdings.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            refs = parse_submissions_index(payload)
+        assert [r.accession_number for r in refs] == ["0001000000-24-000777"]
+
+    def test_null_report_date_leaks_past_index_filter(self, fixed_now: datetime) -> None:
+        # ``period is None`` short-circuits the comparison — leaks past
+        # ``parse_submissions_index``. ``_ingest_single_accession``
+        # defensive post-parse gate is the safety net (covered below).
+        payload = _submissions_payload([("0001000000-19-000001", "13F-HR", "2019-04-15", "")])
+        with patch("app.services.institutional_holdings.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            refs = parse_submissions_index(payload)
+        # The accession is admitted (period_of_report is None).
+        assert len(refs) == 1
+        assert refs[0].period_of_report is None
+
+
+# ---------------------------------------------------------------------------
+# _ingest_single_accession defensive post-parse gate (Codex 1a §2 fix)
+# ---------------------------------------------------------------------------
+
+
+class _StubFetcher:
+    """Minimal SecArchiveFetcher stub for the defensive-gate test."""
+
+    def __init__(self, responses: dict[str, str | None]) -> None:
+        self._responses = responses
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        # Map any URL containing the accession back to the keyed response.
+        for key, value in self._responses.items():
+            if key in absolute_url:
+                return value
+        return None
+
+
+class TestIngestSingleAccessionDefensiveGate:
+    def test_pre_cap_period_skips_infotable_fetch(self) -> None:
+        # Build a primary_doc.xml whose period_of_report parses to a
+        # pre-cap quarter end. The fetcher records calls so we can
+        # assert the infotable URL was never requested.
+        accession = "0001000000-19-000001"
+        cik = "0001234567"
+        primary_xml = (
+            '<?xml version="1.0"?>'
+            '<edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">'
+            "<headerData><filerInfo>"
+            "<filer><credentials><cik>1234567</cik><ccc>xxxxxxxx</ccc></credentials></filer>"
+            "<periodOfReport>03-31-2019</periodOfReport>"
+            "</filerInfo></headerData>"
+            "<formData>"
+            "<coverPage>"
+            "<reportCalendarOrQuarter>03-31-2019</reportCalendarOrQuarter>"
+            "<filingManager><name>Test Filer</name>"
+            '<address xmlns="http://www.sec.gov/edgar/common">'
+            "<street1>1 Test St</street1><city>NYC</city><stateOrCountry>NY</stateOrCountry><zipCode>10001</zipCode>"
+            "</address>"
+            "</filingManager>"
+            "<reportType>13F HOLDINGS REPORT</reportType>"
+            "<form13FFileNumber>028-00000</form13FFileNumber>"
+            "</coverPage>"
+            "<signatureBlock>"
+            "<name>Jane Doe</name>"
+            "<title>Authorised Signer</title>"
+            "<phone>555-0100</phone>"
+            "<city>NYC</city>"
+            "<stateOrCountry>NY</stateOrCountry>"
+            "<signatureDate>04-15-2019</signatureDate>"
+            "</signatureBlock>"
+            "</formData></edgarSubmission>"
+        )
+        index_json = json.dumps(
+            {
+                "directory": {
+                    "item": [
+                        {"name": "primary_doc.xml"},
+                        {"name": "infotable.xml"},
+                    ]
+                }
+            }
+        )
+        infotable_calls: list[str] = []
+
+        class RecordingFetcher:
+            def fetch_document_text(self, absolute_url: str) -> str | None:
+                if absolute_url.endswith("index.json"):
+                    return index_json
+                if absolute_url.endswith("primary_doc.xml"):
+                    return primary_xml
+                if absolute_url.endswith("infotable.xml") or "infotable" in absolute_url:
+                    infotable_calls.append(absolute_url)
+                    return None
+                return None
+
+        ref = AccessionRef(
+            accession_number=accession,
+            filing_type="13F-HR",
+            period_of_report=None,  # NULL reportDate leaked past index filter
+            filed_at=datetime(2019, 4, 15, tzinfo=UTC),
+        )
+        # Stub conn — only used for raw_filings.store_raw / commit.
+        # A minimal mock that swallows execute + commit suffices because
+        # the defensive gate returns BEFORE the infotable fetch.
+        import unittest.mock as mock
+
+        conn = mock.MagicMock()
+        outcome = _ingest_single_accession(
+            conn,
+            RecordingFetcher(),
+            filer_cik=cik,
+            ref=ref,
+        )
+        assert outcome.status == "failed"
+        assert outcome.error == "retention floor"
+        # CRITICAL: infotable.xml must NOT have been fetched.
+        assert infotable_calls == []
+        # Codex 2 LOW — defensive gate surfaces the parser-derived
+        # period_of_report so the caller's ingest-log row carries an
+        # audit-grade date despite ``ref.period_of_report=None``.
+        assert outcome.period_of_report_override == date(2019, 3, 31)
+
+
+# ---------------------------------------------------------------------------
+# Bulk dataset gate
+# ---------------------------------------------------------------------------
+
+
+def _write_13f_dataset_zip(
+    path: Path,
+    rows: Iterable[dict[str, str]],
+) -> None:
+    """Build a synthetic Form 13F Data Set ZIP with 1 row per accession
+    in SUBMISSION + COVERPAGE + INFOTABLE.
+
+    Each input row carries:
+      - accession: ``ACCESSION_NUMBER``
+      - cik
+      - filing_date (DD-MMM-YYYY)
+      - period_end (DD-MMM-YYYY)
+      - cusip
+      - value
+      - shprn
+    """
+
+    with zipfile.ZipFile(path, "w") as zf:
+        sub_buf = io.StringIO()
+        sub_w = csv.DictWriter(
+            sub_buf,
+            fieldnames=["ACCESSION_NUMBER", "CIK", "FILING_DATE"],
+            delimiter="\t",
+        )
+        sub_w.writeheader()
+        for r in rows:
+            sub_w.writerow(
+                {
+                    "ACCESSION_NUMBER": r["accession"],
+                    "CIK": r["cik"],
+                    "FILING_DATE": r["filing_date"],
+                }
+            )
+        zf.writestr("SUBMISSION.tsv", sub_buf.getvalue())
+
+        cover_buf = io.StringIO()
+        cover_w = csv.DictWriter(
+            cover_buf,
+            fieldnames=["ACCESSION_NUMBER", "FILINGMANAGER_NAME", "REPORTCALENDARORQUARTER"],
+            delimiter="\t",
+        )
+        cover_w.writeheader()
+        for r in rows:
+            cover_w.writerow(
+                {
+                    "ACCESSION_NUMBER": r["accession"],
+                    "FILINGMANAGER_NAME": "Test Filer",
+                    "REPORTCALENDARORQUARTER": r["period_end"],
+                }
+            )
+        zf.writestr("COVERPAGE.tsv", cover_buf.getvalue())
+
+        info_buf = io.StringIO()
+        info_w = csv.DictWriter(
+            info_buf,
+            fieldnames=[
+                "ACCESSION_NUMBER",
+                "CUSIP",
+                "VALUE",
+                "SSHPRNAMT",
+                "SSHPRNAMTTYPE",
+                "PUTCALL",
+                "VOTING_AUTH_SOLE",
+                "VOTING_AUTH_SHARED",
+                "VOTING_AUTH_NONE",
+            ],
+            delimiter="\t",
+        )
+        info_w.writeheader()
+        for r in rows:
+            info_w.writerow(
+                {
+                    "ACCESSION_NUMBER": r["accession"],
+                    "CUSIP": r["cusip"],
+                    "VALUE": r["value"],
+                    "SSHPRNAMT": r["shprn"],
+                    "SSHPRNAMTTYPE": "SH",
+                    "PUTCALL": "",
+                    "VOTING_AUTH_SOLE": "100",
+                    "VOTING_AUTH_SHARED": "0",
+                    "VOTING_AUTH_NONE": "0",
+                }
+            )
+        zf.writestr("INFOTABLE.tsv", info_buf.getvalue())
+
+
+def _seed_instrument_and_cusip(
+    conn: psycopg.Connection[tuple],
+    *,
+    iid: int,
+    cusip: str,
+) -> None:
+    """Minimal instrument + external_identifiers row for the bulk path."""
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, instrument_type,
+            currency, is_tradable, country
+        ) VALUES (
+            %(iid)s, %(sym)s, %(name)s, 'STOCK', 'USD', TRUE, 'US'
+        )
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        {"iid": iid, "sym": f"TEST{iid:03d}", "name": f"Test Instrument {iid}"},
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (
+            instrument_id, provider, identifier_type, identifier_value, is_primary
+        ) VALUES (%(iid)s, 'sec', 'cusip', %(cusip)s, TRUE)
+        ON CONFLICT DO NOTHING
+        """,
+        {"iid": iid, "cusip": cusip},
+    )
+
+
+class TestBulkDatasetGate:
+    @pytest.fixture
+    def archive_path(self, tmp_path: Path) -> Path:
+        return tmp_path / "form13f_test.zip"
+
+    def test_boundary_in_cap_and_pre_cap_split(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+        archive_path: Path,
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument_and_cusip(conn, iid=900_001, cusip="000900001A0")
+        _seed_instrument_and_cusip(conn, iid=900_002, cusip="000900002B0")
+        _seed_instrument_and_cusip(conn, iid=900_003, cusip="000900003C0")
+
+        # Three rows: pre-cap, boundary (==cutoff), in-cap. Cutoff at
+        # 2026-05-20 ref = 2024-06-30. We force ``now`` via patch.
+        rows = [
+            {
+                "accession": "0001000000-20-000001",
+                "cik": "1234567",
+                "filing_date": "15-APR-2020",
+                "period_end": "31-MAR-2020",  # pre-cap
+                "cusip": "000900001A0",
+                "value": "10000",
+                "shprn": "1000",
+            },
+            {
+                "accession": "0001000000-24-000001",
+                "cik": "1234567",
+                "filing_date": "15-JUL-2024",
+                "period_end": "30-JUN-2024",  # boundary == cutoff
+                "cusip": "000900002B0",
+                "value": "20000",
+                "shprn": "2000",
+            },
+            {
+                "accession": "0001000000-25-000001",
+                "cik": "1234567",
+                "filing_date": "15-APR-2025",
+                "period_end": "31-MAR-2025",  # in-cap
+                "cusip": "000900003C0",
+                "value": "30000",
+                "shprn": "3000",
+            },
+        ]
+        _write_13f_dataset_zip(archive_path, rows)
+
+        fixed_now = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        with patch("app.services.institutional_holdings.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = ingest_13f_dataset_archive(
+                conn=conn,
+                archive_path=archive_path,
+                ingest_run_id=uuid4(),
+            )
+
+        # Pre-cap skipped; boundary + in-cap survived.
+        assert result.rows_written == 2
+        assert result.rows_skipped_retention == 1
+        # No current-refresh side effect for the skipped accession.
+        assert 900_001 not in result.touched_instrument_ids
+        assert 900_002 in result.touched_instrument_ids
+        assert 900_003 in result.touched_instrument_ids
+
+
+# ---------------------------------------------------------------------------
+# sync_institutions cap predicate
+# ---------------------------------------------------------------------------
+
+
+def _seed_filer_and_holding(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_id: int,
+    cik: str,
+    instrument_id: int,
+    accession: str,
+    period_of_report: date,
+    filed_at: datetime,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO institutional_filers (filer_id, cik, name, filer_type)
+        VALUES (%(fid)s, %(cik)s, %(name)s, 'INV')
+        ON CONFLICT (filer_id) DO NOTHING
+        """,
+        {"fid": filer_id, "cik": cik, "name": f"Test Filer {filer_id}"},
+    )
+    conn.execute(
+        """
+        INSERT INTO institutional_holdings (
+            filer_id, instrument_id, accession_number, period_of_report,
+            shares, market_value_usd, voting_authority, is_put_call, filed_at
+        ) VALUES (
+            %(fid)s, %(iid)s, %(acc)s, %(period)s,
+            1000, 50000, 'SOLE', NULL, %(filed_at)s
+        )
+        ON CONFLICT DO NOTHING
+        """,
+        {
+            "fid": filer_id,
+            "iid": instrument_id,
+            "acc": accession,
+            "period": period_of_report,
+            "filed_at": filed_at,
+        },
+    )
+
+
+class TestSyncInstitutionsCapPredicate:
+    def test_pre_cap_rows_not_repopulated(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        # Two holdings under one filer — one pre-cap, one in-cap.
+        _seed_instrument_and_cusip(conn, iid=910_001, cusip="000910001A0")
+        _seed_instrument_and_cusip(conn, iid=910_002, cusip="000910002B0")
+        _seed_filer_and_holding(
+            conn,
+            filer_id=99_001,
+            cik="0009999999",
+            instrument_id=910_001,
+            accession="0009999999-20-000001",
+            period_of_report=date(2020, 3, 31),
+            filed_at=datetime(2020, 4, 15, tzinfo=UTC),
+        )
+        _seed_filer_and_holding(
+            conn,
+            filer_id=99_001,
+            cik="0009999999",
+            instrument_id=910_002,
+            accession="0009999999-25-000001",
+            period_of_report=date(2025, 3, 31),
+            filed_at=datetime(2025, 4, 15, tzinfo=UTC),
+        )
+        conn.commit()
+
+        fixed_now = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        with patch("app.services.institutional_holdings.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            summary = sync_institutions(conn)
+        conn.commit()
+
+        # Only the in-cap row produced an observation row.
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT instrument_id, period_end
+                FROM ownership_institutions_observations
+                WHERE filer_cik = '0009999999'
+                ORDER BY instrument_id
+                """
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == 910_002
+        assert rows[0][1] == date(2025, 3, 31)
+        assert summary.observations_recorded == 1


### PR DESCRIPTION
Refs #1233 — data retention rubric, 13F-HR depth cap (spec §4.5).

## Summary

- New `THIRTEEN_F_HR_RETENTION_QUARTERS = 8` constant + calendar-quarter-anchored `thirteen_f_retention_cutoff` and `thirteen_f_within_retention` helpers in `app/services/institutional_holdings.py`. Cutoff anchored to the most-recent COMPLETED quarter end (not a floating `today-760d` window — Codex 1a §1 caught the float to nine quarter-ends right after a new quarter completes). UTC-normalised; tz-naive `now` raises `ValueError`.
- `parse_submissions_index` enforces an INTRINSIC floor: caller's `min_period_of_report=None` no longer means full history; it falls back to the 8q cap. A caller floor MORE recent than the cap (e.g. bootstrap stage 21's 380d / 4q) raises the floor.
- Defensive post-parse gate inside `_ingest_single_accession` catches accessions whose submissions JSON `reportDate` was NULL/malformed and leaked past the index-level filter; the parsed period is surfaced via `_AccessionOutcome.period_of_report_override` so the ingest-log row carries audit-grade data.
- Manifest-worker `_parse_13f_hr` post-parse gate tombstones pre-cap accessions BEFORE the infotable fetch (saves several MB / accession).
- Bulk dataset ingester (`ingest_13f_dataset_archive`) gates per-row by `period_end < retention_cutoff` with a `rows_skipped_retention` counter on `Form13FIngestResult`. `sec_bulk_orchestrator_jobs` surfaces the counter per-archive and distinguishes all-retention-skipped (no error) from all-CUSIP-unresolved (RuntimeError).
- Rewash `_apply_13f_infotable` rescue branch gates by `period_of_report` (happy path uncapped per PR5 precedent — DELETE+re-INSERT of existing row set under new `parser_version` preserves the spec §6.3 "existing rows untouched" contract).
- Scheduled repair sweep `ownership_observations_sync.sync_institutions` carries `ih.period_of_report >= %(retention_cutoff)s` SQL predicate alongside the existing optional `since` filter.
- Lint guard `scripts/check_13f_hr_retention.sh` — nine PR5-style block-level placement invariants A-I (helpers / `parse_submissions_index` intrinsic floor / `_ingest_single_accession` defensive gate / manifest worker / bulk dataset / rewash rescue / `sync_institutions` / repo-wide `source='13f'` writer count == 3 / repo-wide `INSERT INTO institutional_holdings (` count == 1). Wired into `.githooks/pre-push` after `check_def14a_cap.sh`.
- Spec §4.5 + §6.3 + §7 + §12 amended for PR6 SHIPPED state + PR7 handover; rewash happy-path-uncapped + `refresh_institutions_current` rebuts documented in spec §4.5 + §6.3.

## Why

13F-HR holdings observations are the dominant non-XBRL ownership volume (5.3 GB combined `_current` + `_observations`). Half-life: 4-quarter trend matters, 8 quarters for backtests, beyond = decoration. Combined with #1010's filer-cohort bound (380d HR recency), the 8q depth cap drops the post-pre-wipe + clean-re-run footprint to ~0.5 GB observations + the PR12 audit on `_current`.

Existing rows untouched (#1233 §6.3 — only the operator-driven pre-wipe purges).

## Codex review

- **Codex 1a + 1b + 1c on plan** (`docs/superpowers/plans/2026-05-20-pr6-13f-hr-8q-cap.md`): 4 BLOCKING resolved — 1 rebut (rewash happy path uncapped per PR5 precedent + `refresh_institutions_current` rebut), 3 fixed inline (calendar-quarter cutoff replacing floating window, defensive post-parse gate in `_ingest_single_accession`, `sync_institutions` cap predicate). 5 MED + 2 LOW also resolved.
- **Codex 2 pre-push**: 2 MED + 1 LOW addressed — lint guard counts call-sites not files (invariants H + I), bulk aggregate distinguishes retention from CUSIP failure (`sec_bulk_orchestrator_jobs`), defensive gate surfaces parsed period via `_AccessionOutcome.period_of_report_override`.

## Test plan

- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv run pyright` — 0 errors.
- [x] `bash scripts/check_13f_hr_retention.sh` — all 9 invariants pass.
- [x] `bash scripts/check_def14a_cap.sh` — green (PR5 unaffected).
- [x] `bash scripts/check_form4_retention.sh` — green (PR4 unaffected).
- [x] `pytest tests/test_thirteen_f_retention_cap.py` — 20/20 pass (helpers + parse_submissions_index intrinsic floor + `_ingest_single_accession` defensive gate + bulk dataset boundary equality + `sync_institutions` cap predicate).
- [x] `pytest tests/test_manifest_parser_sec_13f_hr.py::test_pre_cap_period_tombstones_before_infotable_fetch` — 1/1 pass (manifest worker pre-fetch gate).
- [x] `pytest tests/test_rewash_filings.py::test_13f_infotable_rescue_branch_pre_cap_period_returns_false` — 1/1 pass (rewash rescue gate).
- [x] `pytest tests/test_manifest_parser_sec_13f_hr.py::test_pre_2023_filed_at_scales_value_by_thousand tests/test_sec_13f_dataset_ingest.py::TestRealArchiveEdgeCases::test_value_pre_2023_cutover_multiplied_by_thousands` — 2/2 pass (existing pre-2023 cutover tests pinned to a historical `now` so their pre-cap fixtures survive the new cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)