### PR TITLE
feat(#1233): PR8 — N-CSR 730d retention cap at every chokepoint

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -79,6 +79,15 @@ bash scripts/check_13f_hr_retention.sh
 echo "==> Pre-push gate: N-PORT 8-quarter retention cap lint"
 bash scripts/check_nport_retention.sh
 
+# #1233 §4.12 PR8 — every N-CSR / N-CSRS ingest chokepoint must honour
+# the 730d filed-at retention cap (bootstrap_n_csr_drain via shared
+# helper + manifest-worker _parse_sec_n_csr pre-fetch gate). Smallest
+# chokepoint surface of any PR: no _ingest_single_accession, no
+# bulk-dataset, no rewash, no SQL repair sweep — see plan §6 for the
+# letter→chokepoint map. ~30ms.
+echo "==> Pre-push gate: N-CSR 730d retention cap lint"
+bash scripts/check_n_csr_retention.sh
+
 # Pytest scoping decision. If `git diff --name-only @{u}..HEAD` fails
 # (no upstream yet, e.g. brand-new branch), assume worst-case: run the
 # full suite under xdist. The first push of a brand-new branch usually

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -299,9 +299,11 @@ _INVOKERS[_scheduler.JOB_FILINGS_HISTORY_SEED] = _scheduler.filings_history_seed
 _INVOKERS[_scheduler.JOB_SEC_FIRST_INSTALL_DRAIN] = _scheduler.sec_first_install_drain
 
 # #1174 — dedicated MF directory refresh + N-CSR fund-scoped bootstrap
-# drain. Both invokers are params-aware natively (no ``_adapt_zero_arg``);
-# ``mf_directory_sync`` discards params, ``sec_n_csr_bootstrap_drain``
-# consumes ``horizon_days``.
+# drain. Both invokers are params-aware natively (no ``_adapt_zero_arg``).
+# Both discard params: ``mf_directory_sync`` never honoured any, and
+# ``sec_n_csr_bootstrap_drain`` had its ``horizon_days`` param removed
+# in PR8 (#1233 §4.12) when N_CSR_RETENTION_DAYS became the single
+# source of truth for the 730d cap.
 _INVOKERS[_scheduler.JOB_MF_DIRECTORY_SYNC] = _scheduler.mf_directory_sync
 _INVOKERS[_scheduler.JOB_SEC_N_CSR_BOOTSTRAP_DRAIN] = _scheduler.sec_n_csr_bootstrap_drain
 

--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -33,7 +33,7 @@ import json
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any
 
 import psycopg
@@ -46,6 +46,7 @@ from app.providers.implementations.sec_submissions import (
 )
 from app.services.bootstrap_preconditions import BootstrapPhaseSkipped
 from app.services.bootstrap_state import BootstrapStageCancelled
+from app.services.manifest_parsers.sec_n_csr import n_csr_retention_cutoff
 from app.services.processes.bootstrap_cancel_signal import (
     active_bootstrap_stage_key,
     bootstrap_cancel_requested,
@@ -771,11 +772,10 @@ def bootstrap_n_csr_drain(
     conn: psycopg.Connection[Any],
     *,
     http_get: HttpGet,
-    horizon_days: int = 730,
 ) -> NCsrDrainStats:
     """Walk fund-trust CIKs from ``cik_refresh_mf_directory`` + enqueue
-    last-``horizon_days`` N-CSR + N-CSRS accessions per trust to
-    ``sec_filing_manifest``.
+    N-CSR + N-CSRS accessions per trust to ``sec_filing_manifest``
+    within the 730d retention window (#1233 §4.12 / PR8).
 
     Pre-condition: ``class_id_mapping_ready`` capability (S25
     ``mf_directory_sync`` populates ``cik_refresh_mf_directory``). Raises
@@ -792,6 +792,13 @@ def bootstrap_n_csr_drain(
     ``subject_type='institutional_filer'`` + ``subject_id=trust_cik`` +
     ``instrument_id=None``. The parser fans out per-(series, class) at
     parse time.
+
+    Retention cap (PR8): cutoff resolved via ``n_csr_retention_cutoff``
+    in ``app/services/manifest_parsers/sec_n_csr.py`` so this drain
+    shares the single source of truth with the manifest-worker pre-
+    fetch gate. The previous ``horizon_days`` parameter is removed —
+    pre-cap deep dives use the parser gate's tombstone path (spec §8
+    acceptance #6 N-CSR exception).
     """
     # Entry guard — manual-trigger before S25 has ever fired.
     with conn.cursor() as cur:
@@ -801,7 +808,7 @@ def bootstrap_n_csr_drain(
     if directory_count == 0:
         raise BootstrapPhaseSkipped("class_id_mapping_ready unsatisfied — cik_refresh_mf_directory empty")
 
-    cutoff = datetime.now(UTC) - timedelta(days=horizon_days)
+    cutoff = n_csr_retention_cutoff()
     trusts_processed = 0
     trusts_skipped = 0
     secondary_pages_fetched = 0

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -968,12 +968,16 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # S26 (terminal) drains N-CSR + N-CSRS accessions per trust for the
     # #1171 fund-metadata parser to consume.
     _spec("mf_directory_sync", 25, "sec_rate", JOB_MF_DIRECTORY_SYNC),
+    # #1233 §4.12 / PR8 — S26 dispatches with no params. The 730d
+    # retention window is hard-pinned at
+    # ``app/services/manifest_parsers/sec_n_csr.py::N_CSR_RETENTION_DAYS``
+    # and the previous ``horizon_days`` param was removed (single
+    # source of truth for every N-CSR writer chokepoint).
     _spec(
         "sec_n_csr_bootstrap_drain",
         26,
         "sec_rate",
         JOB_SEC_N_CSR_BOOTSTRAP_DRAIN,
-        params={"horizon_days": 730},
     ),
 )
 

--- a/app/services/manifest_parsers/sec_n_csr.py
+++ b/app/services/manifest_parsers/sec_n_csr.py
@@ -70,6 +70,60 @@ _FAILED_RETRY_DELAY = timedelta(hours=1)
 # 24h backoff for resolver-pending miss (gives daily cik_refresh time).
 _PENDING_CIK_REFRESH_DELAY = timedelta(hours=24)
 
+# Spec #1233 §4.12 / PR8 — N-CSR / N-CSRS 2y filed-at sliding window.
+# Hard-pinned at module level so every writer chokepoint sees the same
+# number. Unlike PR6 (13F-HR) / PR7 (N-PORT), N-CSR has NO deep-dive
+# override: `sec_rebuild` requeues a manifest accession and the parser
+# gate runs on every parse, so a rebuilt pre-cap accession tombstones
+# with `outside_retention`. Pre-cap fund-metadata is not part of any
+# consumer surface (no chart depth requirement, no AI prompt depth
+# requirement, no alert window) — accepting the loss is the explicit
+# trade-off in spec §8 acceptance #6.
+N_CSR_RETENTION_DAYS: int = 730
+
+
+def n_csr_retention_cutoff(now: datetime | None = None) -> datetime:
+    """Earliest ``filed_at`` accepted for N-CSR / N-CSRS (#1233 §4.12).
+
+    Returns ``now - N_CSR_RETENTION_DAYS`` as a UTC-aware datetime.
+    Boundary inclusive — caller compares ``filed_at >= cutoff``.
+
+    ``now`` must be tz-aware; raises ``ValueError`` on tz-naive input
+    so the cutoff doesn't drift by ±1 day on non-UTC dev hosts (PR7
+    Codex 2 lesson — ``date.today()`` / ``datetime.now()`` honour the
+    caller's local TZ).
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+    if now.tzinfo is None:
+        raise ValueError(
+            "n_csr_retention_cutoff: ``now`` must be a tz-aware datetime; "
+            "naive datetimes would honour the caller's local TZ and drift the cutoff."
+        )
+    return now.astimezone(UTC) - timedelta(days=N_CSR_RETENTION_DAYS)
+
+
+def n_csr_within_retention(
+    filed_at: datetime | None,
+    now: datetime | None = None,
+) -> bool:
+    """Boundary check used by every N-CSR writer chokepoint (#1233 §4.12).
+
+    Returns True iff ``filed_at >= n_csr_retention_cutoff(now)``.
+    A ``None`` ``filed_at`` returns False — defensive: an accession we
+    couldn't tag with a filed-at timestamp is unsafe to admit. A tz-
+    naive ``filed_at`` raises ``ValueError`` for the same reason
+    ``n_csr_retention_cutoff`` rejects tz-naive ``now``.
+    """
+    if filed_at is None:
+        return False
+    if filed_at.tzinfo is None:
+        raise ValueError(
+            "n_csr_within_retention: ``filed_at`` must be a tz-aware datetime; "
+            "naive datetimes would honour the caller's local TZ."
+        )
+    return filed_at.astimezone(UTC) >= n_csr_retention_cutoff(now)
+
 
 def _failed_outcome(error: str, *, delay: timedelta = _FAILED_RETRY_DELAY) -> Any:
     """Build a ``failed`` ParseOutcome with retry backoff."""
@@ -262,6 +316,14 @@ def _parse_sec_n_csr(
 
     if not url:
         return _tombstoned("missing primary_document_url")
+
+    # Retention gate (#1233 §4.12 / PR8). ``filed_at`` predates the
+    # 730d window → tombstone BEFORE iXBRL fetch. Atom / daily-index /
+    # per-CIK poll / master-idx sweep enqueue N-CSR uncapped, so this
+    # is the single chokepoint that blocks pre-cap accessions from
+    # spending SEC HTTP budget + writing ``fund_metadata_observations``.
+    if not n_csr_within_retention(filed_at):
+        return _tombstoned("outside_retention")
 
     # 1. Fetch iXBRL companion.
     ixbrl_url = _ixbrl_companion_url(url)

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -178,11 +178,6 @@ JOB_INTERNAL_KEYS: dict[str, frozenset[str]] = {
     # proper ``ParamMetadata`` declarations.
     "filings_history_seed": frozenset({"days_back", "filing_types", "instrument_id"}),
     "sec_first_install_drain": frozenset({"max_subjects"}),
-    # #1174 — bootstrap S26 dispatches sec_n_csr_bootstrap_drain with a
-    # hardcoded ``horizon_days=730`` matching filings_history_seed's
-    # days_back. Internal-only — the operator does not tune the
-    # bootstrap-time retention window through the standard UX.
-    "sec_n_csr_bootstrap_drain": frozenset({"horizon_days"}),
     # PR7 #1233 §4.6 (mirror of #1010 for N-PORT). ``min_last_seen_filed_at``
     # is the recency cohort filter exclusive to bootstrap stage 22 —
     # exposing it on the manual API would let an operator accidentally

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4592,24 +4592,22 @@ def sec_n_csr_bootstrap_drain(params: Mapping[str, Any]) -> None:
     bootstrap drain for N-CSR / N-CSRS (#1174 / T8 deferred from #1171).
 
     Walks distinct trust CIKs from ``cik_refresh_mf_directory`` +
-    enqueues last-``horizon_days`` (default 730) N-CSR + N-CSRS
-    accessions per trust to ``sec_filing_manifest``. The manifest
-    worker drains via the #1171 fund-metadata parser.
+    enqueues N-CSR + N-CSRS accessions per trust to
+    ``sec_filing_manifest`` within the 730d retention window. The
+    manifest worker drains via the #1171 fund-metadata parser.
 
     Subject identity at every enqueue:
     ``subject_type='institutional_filer'`` + ``subject_id=trust_cik`` +
     ``instrument_id=None`` (matches the manifest CHECK constraint
     ``chk_manifest_issuer_has_instrument`` + N-PORT precedent).
 
-    Honoured params:
-
-    * ``horizon_days`` (int) — retention window in days. Default 730
-      (matches ``filings_history_seed.days_back``).
+    No params honoured. The 730d retention window is hard-pinned at
+    ``app/services/manifest_parsers/sec_n_csr.py::N_CSR_RETENTION_DAYS``
+    (#1233 §4.12 / PR8); the previous ``horizon_days`` param was
+    removed so every writer chokepoint shares one source of truth.
     """
+    del params  # no params honoured post-PR8 (#1233 §4.12)
     from app.jobs.sec_first_install_drain import bootstrap_n_csr_drain
-
-    horizon_days_param = params.get("horizon_days", 730)
-    horizon_days = int(horizon_days_param) if horizon_days_param is not None else 730
 
     with _tracked_job(JOB_SEC_N_CSR_BOOTSTRAP_DRAIN) as tracker:
         with (
@@ -4619,19 +4617,17 @@ def sec_n_csr_bootstrap_drain(params: Mapping[str, Any]) -> None:
             stats = bootstrap_n_csr_drain(
                 conn,
                 http_get=_make_sec_http_get(sec),  # type: ignore[arg-type]
-                horizon_days=horizon_days,
             )
         tracker.row_count = stats.manifest_rows_upserted
         logger.info(
             "sec_n_csr_bootstrap_drain: trusts=%d skipped=%d manifest_rows=%d "
-            "errors=%d secondary_pages=%d outside_horizon=%d horizon_days=%d",
+            "errors=%d secondary_pages=%d outside_horizon=%d",
             stats.trusts_processed,
             stats.trusts_skipped,
             stats.manifest_rows_upserted,
             stats.errors,
             stats.secondary_pages_fetched,
             stats.accessions_outside_horizon,
-            horizon_days,
         )
 
 

--- a/docs/superpowers/plans/2026-05-20-pr8-ncsr-730d-cap.md
+++ b/docs/superpowers/plans/2026-05-20-pr8-ncsr-730d-cap.md
@@ -1,0 +1,452 @@
+# PR8 — N-CSR / N-CSRS 730d filed-at ingest cap at every writer chokepoint
+
+> Created: **2026-05-20** as the next PR in the #1233 data-retention rubric series.
+>
+> Tracking issue: **#1233** — Bootstrap scope discipline umbrella.
+> Spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](../specs/2026-05-19-data-retention-rubric.md) §4.12.
+>
+> Status: **PLAN**.
+
+## 0. Context
+
+The data-retention rubric (#1233) bounds per-source ingest depth so the
+clean re-run after the operator pre-wipe (spec §6.3) measures the
+post-cap steady state. PR1-PR7 have shipped. PR8 lands the **N-CSR /
+N-CSRS 730d filed-at cap** at every writer chokepoint.
+
+PR8 was originally scoped doc-only (§4.12 "Retain as-is"). Drift audit
+2026-05-20 found the 730d cap exists ONLY in `bootstrap_n_csr_drain`
+(`app/jobs/sec_first_install_drain.py:770`); every other N-CSR write
+path bypasses it:
+
+- `app/jobs/sec_atom_fast_lane.py` — atom fast-lane writes ALL N-CSR
+  manifest rows uncapped.
+- `app/jobs/sec_daily_index_reconcile.py` — daily-index reconcile
+  writes ALL N-CSR manifest rows uncapped.
+- `app/jobs/sec_per_cik_poll.py` — per-CIK poll writes ALL N-CSR rows
+  surfaced by freshness uncapped.
+- `app/jobs/sec_master_idx_quarterly_sweep.py` — master-idx sweep writes
+  ALL N-CSR rows uncapped.
+- `app/services/manifest_parsers/sec_n_csr.py::_parse_sec_n_csr` —
+  manifest-worker parser fetches iXBRL + writes `fund_metadata_observations`
+  for every accession regardless of `row.filed_at`.
+
+So the spec was wrong: the cap was protecting one ingest path and
+nothing else. PR8 closes the drift.
+
+## 1. Scope
+
+**In**:
+
+1. Filed-at-anchored retention constants + helpers in
+   `app/services/manifest_parsers/sec_n_csr.py` (the canonical N-CSR
+   module — PR7 precedent: helpers live alongside the parser).
+2. Cap honoured at every N-CSR writer chokepoint:
+   - `bootstrap_n_csr_drain` uses the shared helper (replaces inlined
+     `cutoff = datetime.now(UTC) - timedelta(days=horizon_days)` math).
+   - `_parse_sec_n_csr` manifest-worker **pre-fetch** retention gate
+     placed BEFORE the iXBRL fetch (saves SEC HTTP budget on pre-cap
+     accessions that atom / daily / per-CIK / master-idx have already
+     enqueued uncapped). Distinct from PR6/PR7 vocabulary — their
+     gates are "post-parse" because they run AFTER the per-accession
+     payload parse, whereas N-CSR has no manifest-row-level payload
+     parse before fetch (the iXBRL companion IS the payload), so the
+     gate sits between manifest-row validation and HTTP fetch.
+3. **Remove the `horizon_days` parameter** from the public surface:
+   - `bootstrap_n_csr_drain(conn, *, http_get)` (no more `horizon_days`
+     kwarg).
+   - `app/workers/scheduler.py::sec_n_csr_bootstrap_drain(params)` stops
+     reading `params.get("horizon_days")`.
+   - `app/services/processes/param_metadata.py::JOB_INTERNAL_KEYS` —
+     drop the `"sec_n_csr_bootstrap_drain": frozenset({"horizon_days"})`
+     entry (or replace with `frozenset()`).
+   - `app/services/bootstrap_orchestrator.py` — S26 `StageSpec` drops
+     the `params={"horizon_days": 730}` kwarg (currently at
+     `bootstrap_orchestrator.py:976`). Without this, bootstrap
+     validation would reject the stage when `JOB_INTERNAL_KEYS`
+     stopped advertising `horizon_days` (Codex 1a BLOCKING 1).
+   - `tests/test_job_registry.py::test_only_bootstrap_lifted_stages_have_params`
+     — drop `"sec_n_csr_bootstrap_drain"` from `lifted_stage_keys`
+     (line 104). After the S26 `StageSpec.params` removal, the stage's
+     `params == {}` and the test's "non-empty params" assertion would
+     fail (Codex 1b BLOCKING).
+4. Lint guard `scripts/check_n_csr_retention.sh` with three placement
+   invariants (A / B / D — letters match the PR6/PR7 vocabulary for
+   grep-ability; C/E/F/G omitted because the corresponding chokepoints
+   do not exist for N-CSR; H omitted as redundant with D — see §6) +
+   repo-wide I.
+5. Tests for the helpers, the bootstrap-drain refactor parity, the
+   parser gate behaviour, and the lint guard.
+
+**Out**:
+
+- No DELETE against pre-cap rows in `fund_metadata_observations` /
+  `fund_metadata_current` (spec §6.3 invariant — only the pre-wipe
+  event touches existing rows).
+- No new cohort bound. The fund-trust universe (~3k trusts via
+  `cik_refresh_mf_directory`) is orders of magnitude smaller than the
+  13F-HR / N-PORT filer cohorts, so a `last_n_csr_at` recency bound
+  carries no measurable wall-clock saving. If a future audit shows
+  otherwise, add it as a follow-up PR.
+- No discovery-side filter on atom / daily-index / per-CIK / master-idx
+  (PR7 precedent — manifest worker is the single chokepoint before
+  observations are written).
+- No raw-payload retention change (separate ticket #1014).
+- No frontend changes.
+
+## 2. Cap shape — why filed_at, not period_of_report
+
+PR6 (13F-HR) anchors on calendar quarter-ends. PR7 (N-PORT) anchors on
+calendar month-ends. PR8 anchors on a sliding `filed_at >= NOW(UTC) -
+730d` window. Three reasons:
+
+1. **Manifest row carries `filed_at`, not `period_of_report`.** N-CSR
+   `period_of_report` lives inside the iXBRL payload; getting it
+   pre-fetch would require parsing first. The cap MUST run pre-fetch to
+   save SEC HTTP budget on the long tail of pre-cap accessions atom /
+   daily / per-CIK have enqueued.
+2. **No mod-3 fiscal-Q congruence-class argument applies.** N-CSR is
+   annual (per-CIK) + semi-annual (N-CSRS); not a per-quarter snapshot
+   like 13F or N-PORT. There is no "8 of every fiscal-Q class" pigeon-
+   hole here — just "everything filed in the last 2 years".
+3. **Consistent with bootstrap drain.** `bootstrap_n_csr_drain` already
+   filters by `row.filed_at >= cutoff` (`_within_horizon` helper at
+   `sec_first_install_drain.py:598`). PR8 lifts that math into a shared
+   helper rather than introducing a second anchor convention.
+
+Boundary: inclusive. `filed_at >= cutoff` admits accessions filed
+exactly at the 730d boundary; one millisecond earlier is rejected.
+
+UTC anchor: helper enforces tz-aware `now`; raises `ValueError` on
+tz-naive (per PR7 Codex 2 lesson — `date.today()` would drift the
+cutoff by ±1 day on non-UTC dev hosts).
+
+## 3. Constants + helpers
+
+In `app/services/manifest_parsers/sec_n_csr.py`:
+
+```python
+# Spec §4.12 — N-CSR / N-CSRS 2y filed-at sliding window.
+#
+# 730d is the spec'd cap (#1233 §4.12). Hard-pinned at module level so
+# every writer chokepoint sees the same number — no per-caller override.
+# Unlike PR6 (13F-HR) / PR7 (N-PORT), N-CSR has NO deep-dive override
+# path: `sec_rebuild` requeues a manifest accession, and the parser
+# gate runs on every parse, so a rebuilt pre-cap accession will
+# tombstone with `outside_retention`. This is intentional — spec §4.12
+# accepts pre-cap fund-metadata as not-wanted (the operator pre-wipe
+# + clean re-run lands the in-cap set; pre-cap rows are not part of
+# any consumer surface). If a future ticket needs pre-cap N-CSR for an
+# ad-hoc backfill, that ticket must add an explicit bypass flag at the
+# `ManifestRow` level + plumb it through the parser gate.
+N_CSR_RETENTION_DAYS: int = 730
+
+
+def n_csr_retention_cutoff(now: datetime | None = None) -> datetime:
+    """Earliest ``filed_at`` accepted for N-CSR / N-CSRS.
+
+    Returns ``now - N_CSR_RETENTION_DAYS`` as a UTC-aware datetime.
+    Boundary inclusive (caller compares ``filed_at >= cutoff``).
+
+    ``now`` must be tz-aware; the helper normalises to UTC. Raises
+    ``ValueError`` on tz-naive input — PR7 Codex 2 lesson, tz-naive
+    `now` would honour the caller's local TZ and drift the cutoff by
+    ±1 day on non-UTC dev hosts.
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+    if now.tzinfo is None:
+        raise ValueError(
+            "n_csr_retention_cutoff: ``now`` must be a tz-aware datetime; "
+            "naive datetimes would honour the caller's local TZ and drift the cutoff."
+        )
+    return now.astimezone(UTC) - timedelta(days=N_CSR_RETENTION_DAYS)
+
+
+def n_csr_within_retention(
+    filed_at: datetime | None,
+    now: datetime | None = None,
+) -> bool:
+    """Boundary check used by every N-CSR writer chokepoint.
+
+    Returns True iff ``filed_at >= n_csr_retention_cutoff(now)``.
+    A ``None`` ``filed_at`` returns False — defensive: an accession we
+    couldn't tag with a filed-at timestamp is unsafe to admit.
+    """
+    if filed_at is None:
+        return False
+    cutoff = n_csr_retention_cutoff(now)
+    if filed_at.tzinfo is None:
+        raise ValueError(
+            "n_csr_within_retention: ``filed_at`` must be a tz-aware datetime."
+        )
+    return filed_at.astimezone(UTC) >= cutoff
+```
+
+## 4. Bootstrap drain refactor
+
+Current (`sec_first_install_drain.py:770-815`):
+
+```python
+def bootstrap_n_csr_drain(
+    conn,
+    *,
+    http_get,
+    horizon_days: int = 730,
+) -> NCsrDrainStats:
+    ...
+    cutoff = datetime.now(UTC) - timedelta(days=horizon_days)
+    ...
+```
+
+New:
+
+```python
+from app.services.manifest_parsers.sec_n_csr import n_csr_retention_cutoff
+
+def bootstrap_n_csr_drain(
+    conn,
+    *,
+    http_get,
+) -> NCsrDrainStats:
+    ...
+    cutoff = n_csr_retention_cutoff()
+    ...
+```
+
+Caller updates:
+
+- `app/workers/scheduler.py::sec_n_csr_bootstrap_drain(params)` —
+  remove the `horizon_days_param` read + the kwarg pass-through; the
+  log line drops `horizon_days=%d` (no longer parameterised). Update
+  the docstring "Honoured params" block (currently states
+  `horizon_days` is honoured — replace with "no params honoured;
+  retention is hard-pinned at `N_CSR_RETENTION_DAYS`").
+- `app/services/processes/param_metadata.py` — remove the
+  `"sec_n_csr_bootstrap_drain": frozenset({"horizon_days"})` entry
+  (clears the dispatcher's expectation that this stage honours params).
+- `app/services/bootstrap_orchestrator.py` — S26 `StageSpec` drops
+  the `params={"horizon_days": 730}` kwarg
+  (`bootstrap_orchestrator.py:976`).
+- `tests/test_job_registry.py::test_only_bootstrap_lifted_stages_have_params`
+  — drop `"sec_n_csr_bootstrap_drain"` from `lifted_stage_keys`
+  (line 104).
+- `app/jobs/runtime.py:301-304` — refresh stale comment that says
+  `sec_n_csr_bootstrap_drain` "consumes `horizon_days`" (Codex 1b
+  NIT 2).
+
+`_within_horizon(filed_at, cutoff) -> bool` (in `sec_first_install_drain.py`)
+becomes a thin wrapper that just `return filed_at >= cutoff`. Could be
+deleted in favor of `n_csr_within_retention(filed_at)`, but that's a
+larger blast radius — keep it as a local thin wrapper for now (PR8
+follow-up tech-debt ticket if grepping reveals other call-sites).
+
+`NCsrDrainStats.accessions_outside_horizon` counter stays — semantics
+unchanged (counts rows rejected by the cutoff).
+
+## 5. Manifest-worker pre-fetch retention gate
+
+Current (`manifest_parsers/sec_n_csr.py:249`):
+
+```python
+def _parse_sec_n_csr(conn, row):
+    accession = row.accession_number
+    url = row.primary_document_url
+    filed_at = row.filed_at
+
+    if not url:
+        return _tombstoned("missing primary_document_url")
+
+    # 1. Fetch iXBRL companion.
+    ixbrl_url = _ixbrl_companion_url(url)
+    try:
+        ixbrl_bytes = _fetch_ixbrl(ixbrl_url)
+    ...
+```
+
+New (gate added between `if not url:` check and the fetch):
+
+```python
+def _parse_sec_n_csr(conn, row):
+    accession = row.accession_number
+    url = row.primary_document_url
+    filed_at = row.filed_at
+
+    if not url:
+        return _tombstoned("missing primary_document_url")
+
+    # Retention gate (#1233 §4.12 / PR8). filed_at predates the 730d
+    # window → tombstone BEFORE iXBRL fetch. Atom / daily-index / per-
+    # CIK / master-idx enqueue uncapped, so this gate is the single
+    # chokepoint before SEC HTTP budget is spent on pre-cap accessions.
+    if not n_csr_within_retention(filed_at):
+        return _tombstoned("outside_retention")
+
+    # 1. Fetch iXBRL companion.
+    ixbrl_url = _ixbrl_companion_url(url)
+    ...
+```
+
+Tombstone reason `"outside_retention"` is a deterministic string the
+manifest worker treats as terminal (no retry). Symmetric with PR7
+N-PORT's `"outside_retention_period"` — slight naming difference is
+intentional because N-CSR cap is filed-at-based not period-based, so
+"retention period" would be a misnomer.
+
+## 6. Lint guard `scripts/check_n_csr_retention.sh`
+
+PR6/PR7 invariant alphabet preserved for grep-ability:
+
+- **A. Helpers defined exactly once, in the canonical module**
+  (`app/services/manifest_parsers/sec_n_csr.py`):
+  - `def n_csr_retention_cutoff(` appears exactly 1 time (counts `def`
+    lines only — docstring references / imports don't count).
+  - `def n_csr_within_retention(` appears exactly 1 time (same
+    `def`-only count).
+  - `N_CSR_RETENTION_DAYS` appears exactly 1 time as a module-level
+    ASSIGNMENT — guard greps the regex `^N_CSR_RETENTION_DAYS:` (LHS
+    of an annotated assignment at column 0), not bare references.
+    Docstring / comment / usage call-sites don't count (Codex 1a WARN).
+- **B. Bootstrap drain uses the shared helper.**
+  `app/jobs/sec_first_install_drain.py::bootstrap_n_csr_drain` body
+  contains exactly 1 call to `n_csr_retention_cutoff(`. Direct
+  `datetime.now(UTC) - timedelta(days=730)` math inside that function
+  body MUST NOT appear (greppable: forbidden pattern
+  `timedelta\(days=730\)` inside the function block).
+- **D. Manifest-worker `_parse_sec_n_csr` pre-fetch retention gate
+  placement.** `n_csr_within_retention(` MUST appear in
+  `_parse_sec_n_csr` BEFORE the first `_fetch_ixbrl(` call (saves HTTP
+  budget on pre-cap accessions). Distinct from PR6/PR7's "post-parse"
+  vocabulary because N-CSR's iXBRL companion IS the payload — there is
+  no manifest-row-level payload parse before fetch.
+- **(C / E / F / G — omitted.)** N-CSR has no `_ingest_single_accession`,
+  no bulk-dataset archive, no rewash function, no SQL repair sweep.
+  This block in the script is a comment-only stub citing the spec so
+  future PRs adding any of those chokepoints know they need to extend
+  the guard.
+- **H. Omitted — redundant with D.** Unlike PR6 / PR7 (where helpers
+  + parser gate live in different modules so a global call-site
+  discovery sweep across `app/**/*.py` was meaningful), N-CSR's helper
+  + only chokepoint co-locate in
+  `app/services/manifest_parsers/sec_n_csr.py`. A repo-wide
+  call-site count would either (a) exclude the chokepoint we want to
+  assert OR (b) double-count helper-internal usages. Invariant D
+  already pins the call-site location; H adds no signal. Codex 1a
+  BLOCKING 2. If a future PR adds a second N-CSR chokepoint in a
+  different module, that PR must reinstate H scoped to count exactly
+  N gates across `app/` excluding the helper definitions specifically.
+- **I. Repo-wide writer discovery.** Exactly **one** production `*.py`
+  file under `app/` contains `INSERT INTO fund_metadata_observations`
+  (note: trailing column-list paren / open paren marker; mirrors PR7
+  N-PORT invariant I).
+
+Awk-based block parsing (BSD vs GNU `grep -P` portability — PR4 Codex
+1c lesson).
+
+Wired into `.githooks/pre-push` after `check_nport_retention.sh`.
+
+## 7. Tests
+
+`tests/test_n_csr_retention_helpers.py` (new file):
+
+1. `test_cutoff_is_730d_back_from_now`: pass tz-aware `now` of a known
+   date (e.g. 2026-05-20 UTC); assert cutoff = 2024-05-21 UTC (730d
+   prior). Use exact equality.
+2. `test_cutoff_normalises_to_utc`: pass `now` in non-UTC tz (e.g.
+   America/New_York); assert cutoff is UTC + matches the UTC-equivalent
+   730d-back calculation.
+3. `test_cutoff_raises_on_naive_now`: pass `now=datetime.now()` (naive);
+   assert `ValueError` with the expected message snippet.
+4. `test_within_retention_boundary_inclusive`: at exactly `cutoff`,
+   return True. One microsecond earlier, return False.
+5. `test_within_retention_none_filed_at`: `filed_at=None` → False.
+6. `test_within_retention_raises_on_naive_filed_at`: tz-naive
+   `filed_at` → `ValueError`.
+
+`tests/test_sec_n_csr_bootstrap_drain.py` (existing — locate + extend):
+
+7. `test_bootstrap_drain_signature_no_horizon_days`: assert the
+   `bootstrap_n_csr_drain` callable has no `horizon_days` parameter
+   (inspect-based — guards against accidental re-introduction).
+8. `test_bootstrap_drain_rejects_pre_cap_accession`: seed a trust + an
+   N-CSR accession with `filed_at = NOW - 1000d`; assert
+   `manifest_rows_upserted == 0` and `accessions_outside_horizon == 1`.
+9. `test_bootstrap_drain_admits_in_cap_accession`: seed a trust + an
+   N-CSR accession with `filed_at = NOW - 100d`; assert
+   `manifest_rows_upserted == 1`.
+
+`tests/test_manifest_parser_sec_n_csr.py` (existing — locate + extend):
+
+10. `test_parser_tombstones_pre_cap_filed_at`: synthesize a `ManifestRow`
+    with `filed_at = NOW(UTC) - 800d`; assert outcome is
+    `tombstoned("outside_retention")` and `_fetch_ixbrl` is NOT called
+    (mock the fetcher; assert `mock.assert_not_called()`).
+11. `test_parser_admits_in_cap_filed_at`: synthesize a `ManifestRow`
+    with `filed_at = NOW(UTC) - 100d`; verify the parser proceeds to
+    fetch + extract (mock the fetcher to return a deterministic iXBRL
+    body; assert outcome is `parsed`).
+
+`tests/test_n_csr_retention_lint.py` (new file):
+
+12. `test_lint_guard_invariants_pass_on_current_repo`: shell out to
+    `scripts/check_n_csr_retention.sh`, assert exit 0 (catches future
+    drift by being part of the pytest gate AND pre-push).
+13. `test_lint_guard_invariant_A_helpers_unique`: temporarily duplicate
+    the helper definition in a tmpdir copy of the source, run the
+    guard, assert exit non-zero.
+14. `test_lint_guard_invariant_B_bootstrap_uses_helper`: temporarily
+    add a forbidden `timedelta(days=730)` line inside
+    `bootstrap_n_csr_drain`'s body, run the guard, assert exit
+    non-zero.
+15. `test_lint_guard_invariant_D_parser_gate_before_fetch`: temporarily
+    move the `n_csr_within_retention` call AFTER the `_fetch_ixbrl`
+    call in a tmpdir source copy, run the guard, assert exit non-zero.
+
+## 8. Acceptance
+
+1. All four pre-push gates green: ruff check, ruff format --check,
+   pyright, pytest.
+2. `scripts/check_n_csr_retention.sh` exits 0 on the branch.
+3. Codex 1a on this plan: no BLOCKING.
+4. Codex 2 pre-push: no BLOCKING.
+5. Spec §4.12 + §7 PR8 status reads "SHIPPED".
+6. PR description follows the PR6/PR7 template (one-paragraph summary,
+   chokepoint enumeration, test enumeration, smoke-test note,
+   spec-cross-reference).
+7. Bot review on PR: ≤ 1 round if no rebuttals; ≤ 2 rounds otherwise.
+
+## 9. Smoke test (clauses 8-12 of CLAUDE.md ETL/parser)
+
+PR8 is ingest-cap only — no row changes, no schema migration. Per spec
+§6.3 caps don't touch existing rows. So:
+
+- **Clause 8 — smoke-test 3-5 instruments**: not directly applicable
+  (N-CSR is fund-trust-scoped, not issuer-scoped). Substitute: pick
+  3-5 fund trust CIKs (e.g. Vanguard, Fidelity, SPDR) + manually
+  trigger `sec_n_csr_bootstrap_drain` via the admin UI; verify
+  `accessions_outside_horizon` increments + `manifest_rows_upserted`
+  matches a hand-count of in-cap N-CSR + N-CSRS accessions on SEC
+  EDGAR for those CIKs. Capture screenshot in PR description.
+- **Clause 9 — cross-source verify**: spot-check one fund-trust's
+  in-cap accession count vs SEC EDGAR's company-search filings list
+  (filter to N-CSR + N-CSRS, last 730d). Record the trust CIK + the
+  in-cap count.
+- **Clause 10 — backfill**: N/A. PR8 is forward-looking; pre-cap rows
+  stay until the operator pre-wipe.
+- **Clause 11 — operator-visible figure**: N/A pre-wipe. Post-wipe,
+  the operator follows §6.3 + measures `fund_metadata_observations`
+  size against the projection in spec §8.
+- **Clause 12 — PR description records the verification**: PR body
+  cites the smoke-test fund CIKs + commit SHA at which they were
+  exercised.
+
+## 10. Codex review gate
+
+Per #1208 cadence + CLAUDE.md "Codex second-opinion mandatory
+checkpoints":
+
+- **Codex 1a** on this plan (now).
+- **Codex 1b** if Codex 1a returns BLOCKING.
+- **Codex 2** pre-push after local gates green.
+- **Codex 3** only if the post-push bot review yields rebuttal-only
+  findings.

--- a/docs/superpowers/specs/2026-05-19-data-retention-rubric.md
+++ b/docs/superpowers/specs/2026-05-19-data-retention-rubric.md
@@ -4,7 +4,7 @@
 >
 > Tracking issue: **#1233** — Bootstrap scope discipline umbrella.
 >
-> Status: **EVOLVING** — original spec merged 2026-05-19 (#1235) after Codex 1a + 1b + 1c + 1d. PR1 (#1238), PR2 (#1237), PR3 (#1239), PR4 (#1240), PR5 NUMERIC fix (#1236), PR5 latest-2-primary cap (#1241), and **PR6 13F-HR 8-quarter cap (this commit)** shipped. PR1 revision reframed the spec's drop-policy from "DELETE pre-cap rows per PR" to "ingest-side caps only + one operator-driven pre-wipe + clean re-run at the end" — caps don't touch existing rows, and the wipe is whole-DB + operator-driven, not per-source.
+> Status: **EVOLVING** — original spec merged 2026-05-19 (#1235) after Codex 1a + 1b + 1c + 1d. PR1 (#1238), PR2 (#1237), PR3 (#1239), PR4 (#1240), PR5 NUMERIC fix (#1236), PR5 latest-2-primary cap (#1241), PR6 13F-HR 8-quarter cap (#1242), PR7 N-PORT 8-quarter cap (#1243), and **PR8 N-CSR 730d cap (this commit)** shipped. PR1 revision reframed the spec's drop-policy from "DELETE pre-cap rows per PR" to "ingest-side caps only + one operator-driven pre-wipe + clean re-run at the end" — caps don't touch existing rows, and the wipe is whole-DB + operator-driven, not per-source.
 
 ## 0. Status snapshot (2026-05-19 17:00 UTC, mid-drain)
 
@@ -215,12 +215,16 @@ Aggregated under DEF 14A discovery (treasury share counts, ESOP plan holdings, b
 
 ### 4.12 N-CSR / N-CSRS (fund certified shareholder reports)
 
-- **Raw shape**: registered fund trust annual + semi-annual reports. Per-trust filings with portfolio holdings appendix.
-- **Current volume**: not yet exercised at universe scale in this drive. Ingest path lives in `app/jobs/sec_first_install_drain.py:512-815` (bootstrap_n_csr_drain). Existing `horizon_days=730` (2y) cap already in code.
-- **Half-life**: **medium** — funds report semi-annually; 4 semi-annual snapshots = 2y of position changes per trust.
-- **Consumers**: funds slice augmentation (N-PORT alone misses some trusts that file only N-CSR); AI thesis context for fund-held instruments.
-- **Ingest depth cap**: **730 days (2y) — already in code** (`bootstrap_n_csr_drain` `horizon_days=730`). Retain as-is.
-- **Cohort bound**: fund trusts only (sourced from `cik_refresh_mf_directory`). Issuer-scoped seed excludes N-CSR per `sec_first_install_drain.py:167`.
+- **Raw shape**: registered fund trust annual + semi-annual reports. Per-trust iXBRL filings parsed for fund-metadata (N-CSR holdings are NOT ingested — spike #918 §10.5 stands).
+- **Current volume**: not yet exercised at universe scale. Ingest path lives in `app/jobs/sec_first_install_drain.py:770` (bootstrap_n_csr_drain) + manifest-worker `app/services/manifest_parsers/sec_n_csr.py:_parse_sec_n_csr`. PR8 drift audit (2026-05-20) found the 730d cap was applied ONLY in bootstrap drain; atom fast-lane, daily-index reconcile, per-CIK poll, master-idx sweep all enqueue N-CSR uncapped, and the manifest-worker parser writes `fund_metadata_observations` for every accession regardless of `filed_at`.
+- **Half-life**: **medium** — funds report semi-annually (N-CSRS) + annually (N-CSR); 4 semi-annual + 2 annual snapshots = 2y of fund-metadata changes per trust.
+- **Consumers**: `fund_metadata_observations → fund_metadata_current` write-through (settled-decisions §"N-CSR / N-CSRS — winner selection in fund_metadata_current"); funds-slice augmentation (N-PORT alone misses trusts that file only N-CSR); AI thesis context for fund-held instruments.
+- **Ingest depth cap**: **730 days (2y) — PR8 SHIPPED.** Cap anchored to a sliding `filed_at >= NOW(UTC) - 730d` window via `n_csr_retention_cutoff` + `n_csr_within_retention` helpers in `app/services/manifest_parsers/sec_n_csr.py`. Distinct from PR6/PR7 which anchor on `period_of_report` calendar boundaries — N-CSR has no per-snapshot period concept at the manifest-row level (the iXBRL `period_of_report` is a narrative fiscal-period end, lags `filed_at` by ~60d), so the cap is filed-at based to stay consistent with bootstrap drain semantics.
+- **Chokepoint coverage (PR8)**: every N-CSR writer honours the cap — bootstrap drain `bootstrap_n_csr_drain` calls `n_csr_retention_cutoff()` (replaces the inlined `horizon_days=730` parameter; the param is removed from the public signature + scheduler invoker + param_metadata + bootstrap_orchestrator S26 StageSpec so there is no override knob) AND manifest-worker `_parse_sec_n_csr` **pre-fetch retention gate** (placed BEFORE iXBRL fetch — distinct from PR6/PR7's "post-parse" gates because N-CSR's iXBRL companion IS the payload, so the gate sits between manifest-row validation and HTTP fetch; saves SEC HTTP budget on pre-cap drift from atom/daily/per-CIK/master-idx). Atom / daily-index reconcile / per-CIK poll / master-idx sweep stay uncapped at MANIFEST DISCOVERY per PR7 precedent — the worker gate is the single chokepoint before `fund_metadata_observations` is touched.
+- **No `_ingest_single_accession` / no bulk-dataset / no rewash / no SQL repair sweep**: N-CSR has the smallest chokepoint surface of any source. There is no per-accession one-shot endpoint, no bulk archive (SEC publishes none for N-CSR), no `_apply_n_csr_*` rewash function, and no `sync_fund_metadata` SQL repair sweep. Lint guard `scripts/check_n_csr_retention.sh` intentionally omits invariants for those chokepoints — if any are added later, that PR is responsible for the gate + extending the lint guard.
+- **Cohort bound**: fund trusts only (sourced from `cik_refresh_mf_directory`, INNER JOIN on `external_identifiers (identifier_type='class_id', is_primary=TRUE)` — see `_iter_trust_ciks` at `sec_first_install_drain.py:555`). Issuer-scoped seed excludes N-CSR per `sec_first_install_drain.py:168`. No `last_n_csr_at` recency bound (mirror of #1010) — fund-trust universe is already orders of magnitude smaller than the 13F-HR / N-PORT filer cohorts, so the cohort bound carries no measurable wall-clock saving.
+- **Existing rows**: untouched until pre-wipe (§6.3).
+- **Why this matters**: not storage (small — `fund_metadata_observations` is ≲ 50 MB), but ingest-budget. Atom + daily reconcile + per-CIK poll currently enqueue every N-CSR they see; the worker would then iXBRL-fetch + parse every accession back to the trust's first filing. The PR8 worker gate tombstones pre-cap accessions BEFORE fetch — the load-bearing chokepoint.
 
 ### 4.13 N-CEN (annual fund census, classification only)
 
@@ -349,7 +353,7 @@ Land per-source PRs in this order. Each PR is **ingest-side cap only** — no PR
 - **PR5 — SHIPPED.** DEF 14A latest-2-PRIMARY-proxies cap at discovery + parser + rewash-rescue chokepoints. Supplemental form variants (DEFA14A / DEFR14A / DEFM14A) uncapped (§4.7). NUMERIC overflow #1228 already folded (#1236).
 - **PR6 — SHIPPED.** 13F-HR 8-quarter ingest cap at every writer chokepoint (parse_submissions_index intrinsic floor, _ingest_single_accession defensive post-parse gate, manifest-worker post-parse gate, bulk-dataset per-row gate, rewash rescue gate, sync_institutions SQL predicate). Cap anchored to calendar quarter ends (`thirteen_f_retention_cutoff`) — admits exactly 8 quarter-ends. (#1010 cohort bound already in place.) Lint guard `scripts/check_13f_hr_retention.sh` with nine PR5-style placement invariants A-I.
 - **PR7 — SHIPPED.** N-PORT 8-quarter (24-month) ingest cap at every writer chokepoint (parse_submissions_index intrinsic floor, _ingest_single_accession defensive post-parse gate, manifest-worker post-parse gate, bulk-dataset per-row gate). Cap anchored to **calendar month-ends** via `n_port_retention_cutoff` (NOT calendar-quarter-ends — fiscal-Q-non-calendar funds would otherwise be silently rejected). Cohort bound shipped in the same PR (mirror of #1010 — bootstrap stage 22 dispatches with `min_last_seen_filed_at = today - 380d` via `_PARAM_DYNAMIC_BOOTSTRAP_NPORT_CUTOFF`; daily / Admin / manual paths use full cohort). Lint guard `scripts/check_nport_retention.sh` with seven PR5-style placement invariants A/B/C/D/F/H/I (no E for rewash, no G for sync_funds — both chokepoints don't exist for N-PORT). `sec_n_port_ingest` migrated from `_adapt_zero_arg` to native `JobInvoker(params)` so stage 22 params reach the body.
-- **PR8 — pending.** N-CSR/N-CSRS validate existing 2y horizon. Doc-only unless drift found.
+- **PR8 — SHIPPED.** N-CSR / N-CSRS 730d filed-at ingest cap at every writer chokepoint (bootstrap drain via shared `n_csr_retention_cutoff` helper + manifest-worker `_parse_sec_n_csr` pre-fetch retention gate placed BEFORE iXBRL fetch). Drift audit found the original 730d cap existed ONLY in bootstrap drain — atom / daily-index / per-CIK poll / master-idx all enqueued uncapped, and the worker parsed every accession. `horizon_days` param removed from public signature + scheduler invoker + param_metadata (single source of truth in the helper). Lint guard `scripts/check_n_csr_retention.sh` with three placement invariants (A helpers in canonical module / B bootstrap drain uses helper / D manifest-worker gate placed before fetch). Smallest chokepoint surface of any PR — no `_ingest_single_accession`, no bulk-dataset, no rewash, no SQL repair sweep.
 - **PR9 — pending.** N-CEN latest-only cap at the parser. Verify `ncen_classifier` reads latest.
 - **PR10 — pending.** Form 3/5 latest-only at the parser + business summary (10-K Item 1) latest-only at the parser.
 - **PR11 — pending.** 13D/G activate dormant pipeline with 3y historical + current-state cap at the parser.
@@ -381,7 +385,7 @@ Measured after PR1-PR12 land + the operator-driven pre-wipe + clean bootstrap re
 3. **Chart pages**: every chart in §5.1 renders correctly for the standard panel (AAPL, GME, MSFT, JPM, HD) — Cypress / Playwright golden path.
 4. **AI thesis**: thesis-writer produces same-or-better quality output for the standard panel (manual eval; small comparison set).
 5. **No regression**: existing PRs + smoke tests pass without modification (no consumer-shape changes).
-6. **Operator override**: each cap has a documented "manual rebuild for ad-hoc deep dive" path (per-instrument or per-source override via `POST /jobs/sec_rebuild/run`).
+6. **Operator override**: each cap has a documented "manual rebuild for ad-hoc deep dive" path (per-instrument or per-source override via `POST /jobs/sec_rebuild/run`). **Exception: N-CSR (#4.12 / PR8).** N-CSR is hard-pinned at the parser gate with no bypass — `sec_rebuild` requeues will tombstone as `outside_retention` if `filed_at` predates the 730d window. Rationale: fund-metadata pre-cap rows are not part of any consumer surface (no chart depth requirement, no AI prompt depth requirement, no alert window). If a future ticket needs pre-cap N-CSR for an ad-hoc backfill, that ticket must add an explicit `bypass_retention` flag at the `ManifestRow` level + plumb it through the parser gate.
 
 ## 9. Open questions for review
 
@@ -419,32 +423,29 @@ State as of this commit:
 
 - PR1 (#1238), PR2 (#1237), PR3 (#1239), PR4 (#1240), PR5 NUMERIC fix
   (#1236), PR5 latest-2-primary cap (#1241), PR6 13F-HR 8-quarter
-  cap (#1242), and **PR7 N-PORT 8-quarter cap (this commit)** all
-  shipped.
-- PR8-PR12 remain — every one is ingest-side cap only, no row deletion.
+  cap (#1242), PR7 N-PORT 8-quarter cap (#1243), and **PR8 N-CSR
+  730d cap (this commit)** all shipped.
+- PR9-PR12 remain — every one is ingest-side cap only, no row deletion.
   The pre-wipe is the single operator event at the end.
 
 ```text
-After PR7 merges, the next session picks up PR8
-(N-CSR / N-CSRS validate existing 2y horizon; doc-only unless drift
-found).
+After PR8 merges, the next session picks up PR9 (N-CEN latest-only
+cap at the parser; verify `ncen_classifier` reads latest).
 
-PR8 scope:
-- Audit `app/jobs/sec_first_install_drain.py:770-815`
-  (`bootstrap_n_csr_drain`) — already passes `horizon_days=730`. Spec
-  §4.12 says "Retain as-is". Confirm no drift from spec wording vs
-  code; close out the spec PR otherwise without code changes.
-- Confirm `cik_refresh_mf_directory` still gates the N-CSR drain (no
-  full-universe walk).
-- If drift found, add minimal cap-confirmation comment + maybe a
-  trivial lint guard line; if no drift, PR is a §4.12 SHIPPED status
-  update.
+PR9 scope:
+- Audit the N-CEN parser (`app/services/manifest_parsers/sec_n_cen.py`
+  or equivalent) — confirm it overwrites a single row per CIK rather
+  than appending an observation per year.
+- Confirm `ncen_classifier` (`app/services/ncen_classifier.py`)
+  consumes the latest-only row.
+- If drift found (observations accumulating year-on-year), apply the
+  PR8 pattern: parser writes ONE row per CIK + lint guard rejecting
+  multi-row-per-CIK INSERTs.
 
 FIRST ACTIONS:
-1. Read CLAUDE.md working order + the revised §4.12 (currently
-   unchanged from initial spec; PR7 did not touch it).
-2. Confirm PR7 merged. Confirm #1233 still OPEN as the umbrella.
-3. Branch `feature/1233-pr8-ncsr-horizon-confirm`.
-4. Read `bootstrap_n_csr_drain` + confirm `horizon_days=730` is the
-   only depth knob; if so, doc-only spec PR + close.
+1. Read CLAUDE.md working order + revised §4.13.
+2. Confirm PR8 merged. Confirm #1233 still OPEN.
+3. Branch `feature/1233-pr9-ncen-latest-only-cap`.
+4. Read N-CEN parser + `ncen_classifier` + confirm single-row-per-CIK
+   semantics.
 ```

--- a/scripts/check_n_csr_retention.sh
+++ b/scripts/check_n_csr_retention.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# Lint guard: the 730d N-CSR / N-CSRS filed-at retention cap (#1233
+# §4.12 / PR8) MUST be honoured at every writer chokepoint.
+#
+# Letter labels A / B / D / I preserved from the PR6 (13F-HR) + PR7
+# (N-PORT) guard alphabet for grep-ability. The omitted letters
+# (C / E / F / G / H) correspond to chokepoints that DO NOT EXIST for
+# N-CSR:
+#
+#   C. _ingest_single_accession defensive post-parse gate
+#      → N-CSR has no per-accession one-shot endpoint.
+#   E. rewash _apply_n_csr_* rescue branch
+#      → no rewash function exists for N-CSR.
+#   F. bulk dataset archive-level + per-row gate
+#      → SEC publishes no bulk N-CSR archive.
+#   G. SQL repair sweep (sync_fund_metadata)
+#      → no repair-sweep function exists for N-CSR.
+#   H. repo-wide n_csr_within_retention(...) call-site count
+#      → redundant with D. Helper definitions AND parser gate live
+#        in the same module (sec_n_csr.py), so a global call-site
+#        sweep cannot distinguish "the chokepoint" from "the helper
+#        body". Reinstate H if a future PR adds a second N-CSR
+#        chokepoint in a different module.
+#
+# Future PRs adding any of those chokepoints MUST extend this guard.
+#
+# Invariants:
+#
+#  A. Helpers + retention constant defined exactly once, in the
+#     canonical module (app/services/manifest_parsers/sec_n_csr.py).
+#       - "def n_csr_retention_cutoff(" appears exactly 1 time.
+#       - "def n_csr_within_retention(" appears exactly 1 time.
+#       - "N_CSR_RETENTION_DAYS:" appears exactly 1 time at column 0
+#         (annotated assignment line — docstring / comment / usage
+#         references do not count).
+#  B. bootstrap_n_csr_drain (app/jobs/sec_first_install_drain.py) uses
+#     the shared helper.
+#       - "n_csr_retention_cutoff(" appears at least 1 time inside the
+#         function body.
+#       - "timedelta(days=730)" MUST NOT appear inside the body
+#         (forbidden inlined math — single source of truth must be in
+#         the helper).
+#  D. manifest-worker _parse_sec_n_csr (
+#     app/services/manifest_parsers/sec_n_csr.py) pre-fetch retention
+#     gate placement.
+#       - "n_csr_within_retention(" appears inside _parse_sec_n_csr.
+#       - The call MUST sit BEFORE the first "_fetch_ixbrl(" call so
+#         pre-cap accessions are tombstoned BEFORE the HTTP fetch
+#         spends SEC budget.
+#  I. Exactly 1 production *.py file under app/ contains
+#     "INSERT INTO fund_metadata_observations" (note: literal text
+#     match — mirrors PR7 N-PORT invariant I).
+#
+# Exits non-zero on the first invariant violation. Wired into
+# .githooks/pre-push after check_nport_retention.sh.
+#
+# Awk-based block parsing (BSD vs GNU `grep -P` portability — PR4
+# Codex 1c lesson). Helpers re-implemented locally so this script
+# stays self-contained.
+
+set -euo pipefail
+
+FILE_N_CSR_PARSER="app/services/manifest_parsers/sec_n_csr.py"
+FILE_BOOTSTRAP_DRAIN="app/jobs/sec_first_install_drain.py"
+
+violations=0
+fail() {
+  echo "::error::$1" >&2
+  violations=$((violations + 1))
+}
+
+# Count literal-substring occurrences inside a file.
+count_literal() {
+  local file="$1" pat="$2"
+  grep -Fc "$pat" "$file" || true
+}
+
+# Count exact regex matches anchored to column 0 (used for invariant A
+# to count ONLY the assignment line for N_CSR_RETENTION_DAYS).
+count_regex_at_col0() {
+  local file="$1" pattern="$2"
+  grep -Ec "^${pattern}" "$file" || true
+}
+
+# Line number of first literal-substring match inside a function body.
+# Body bounded by ``def <name>(`` (at any indent) and the next column-0
+# ``def `` or EOF.
+first_line_in_function() {
+  local file="$1" fname="$2" literal="$3"
+  awk -v fname="$fname" -v literal="$literal" '
+    BEGIN {
+      in_fn = 0
+      anchor = "def " fname "("
+    }
+    {
+      if (!in_fn) {
+        stripped = $0
+        sub(/^[[:space:]]+/, "", stripped)
+        if (index(stripped, anchor) == 1) {
+          in_fn = 1
+          fn_start_nr = NR
+        }
+        next
+      }
+      if (NR > fn_start_nr && substr($0, 1, 4) == "def ") {
+        in_fn = 0
+        next
+      }
+      if (index($0, literal) > 0) { print NR; exit }
+    }
+  ' "$file"
+}
+
+# Count literal-substring occurrences inside a function body. Same
+# bounds as first_line_in_function.
+count_in_function() {
+  local file="$1" fname="$2" literal="$3"
+  awk -v fname="$fname" -v literal="$literal" '
+    BEGIN {
+      in_fn = 0
+      anchor = "def " fname "("
+    }
+    {
+      if (!in_fn) {
+        stripped = $0
+        sub(/^[[:space:]]+/, "", stripped)
+        if (index(stripped, anchor) == 1) {
+          in_fn = 1
+          fn_start_nr = NR
+        }
+        next
+      }
+      if (NR > fn_start_nr && substr($0, 1, 4) == "def ") {
+        in_fn = 0
+        next
+      }
+      if (index($0, literal) > 0) { n++ }
+    }
+    END { print n + 0 }
+  ' "$file"
+}
+
+# ======================================================================
+# A — helpers defined exactly once
+# ======================================================================
+echo "Checking invariant A (helper definitions + constant)..."
+
+if [[ ! -f "$FILE_N_CSR_PARSER" ]]; then
+  fail "missing file: $FILE_N_CSR_PARSER"
+else
+  cutoff_defs=$(count_literal "$FILE_N_CSR_PARSER" "def n_csr_retention_cutoff(")
+  within_defs=$(count_literal "$FILE_N_CSR_PARSER" "def n_csr_within_retention(")
+  const_assigns=$(count_regex_at_col0 "$FILE_N_CSR_PARSER" "N_CSR_RETENTION_DAYS:")
+
+  if (( cutoff_defs != 1 )); then
+    fail "$FILE_N_CSR_PARSER: expected exactly 1 'def n_csr_retention_cutoff(', found ${cutoff_defs}."
+  fi
+  if (( within_defs != 1 )); then
+    fail "$FILE_N_CSR_PARSER: expected exactly 1 'def n_csr_within_retention(', found ${within_defs}."
+  fi
+  if (( const_assigns != 1 )); then
+    fail "$FILE_N_CSR_PARSER: expected exactly 1 column-0 'N_CSR_RETENTION_DAYS:' annotated assignment, found ${const_assigns}."
+  fi
+fi
+
+# ======================================================================
+# B — bootstrap_n_csr_drain uses the shared helper
+# ======================================================================
+echo "Checking invariant B (bootstrap_n_csr_drain uses shared helper)..."
+
+if [[ ! -f "$FILE_BOOTSTRAP_DRAIN" ]]; then
+  fail "missing file: $FILE_BOOTSTRAP_DRAIN"
+else
+  cutoff_call_in_drain=$(count_in_function "$FILE_BOOTSTRAP_DRAIN" "bootstrap_n_csr_drain" "n_csr_retention_cutoff(")
+  inlined_math_in_drain=$(count_in_function "$FILE_BOOTSTRAP_DRAIN" "bootstrap_n_csr_drain" "timedelta(days=730)")
+
+  if (( cutoff_call_in_drain < 1 )); then
+    fail "$FILE_BOOTSTRAP_DRAIN: bootstrap_n_csr_drain missing n_csr_retention_cutoff(...) call — shared helper not wired."
+  fi
+  if (( inlined_math_in_drain > 0 )); then
+    fail "$FILE_BOOTSTRAP_DRAIN: bootstrap_n_csr_drain contains forbidden inlined 'timedelta(days=730)' math — use the shared helper."
+  fi
+fi
+
+# ======================================================================
+# D — manifest-worker pre-fetch retention gate placement
+# ======================================================================
+echo "Checking invariant D (manifest-worker pre-fetch gate placement)..."
+
+if [[ -f "$FILE_N_CSR_PARSER" ]]; then
+  cap_line=$(first_line_in_function "$FILE_N_CSR_PARSER" "_parse_sec_n_csr" "n_csr_within_retention(" || true)
+  fetch_line=$(first_line_in_function "$FILE_N_CSR_PARSER" "_parse_sec_n_csr" "_fetch_ixbrl(" || true)
+
+  if [[ -z "$cap_line" || "$cap_line" == "0" ]]; then
+    fail "$FILE_N_CSR_PARSER: _parse_sec_n_csr missing n_csr_within_retention(...) pre-fetch gate."
+  elif [[ -z "$fetch_line" || "$fetch_line" == "0" ]]; then
+    fail "$FILE_N_CSR_PARSER: _parse_sec_n_csr missing '_fetch_ixbrl(' anchor — cannot validate gate placement."
+  elif (( cap_line >= fetch_line )); then
+    fail "$FILE_N_CSR_PARSER:$cap_line: pre-fetch gate appears AT/AFTER '_fetch_ixbrl(' at line $fetch_line — must short-circuit BEFORE the HTTP fetch."
+  fi
+fi
+
+# ======================================================================
+# I — exactly 1 production *.py file under app/ contains
+# 'INSERT INTO fund_metadata_observations'
+# ======================================================================
+echo "Checking invariant I (single INSERT INTO fund_metadata_observations writer)..."
+
+writer_files=$(grep -rl "INSERT INTO fund_metadata_observations" app --include="*.py" 2>/dev/null || true)
+writer_count=0
+if [[ -n "$writer_files" ]]; then
+  writer_count=$(echo "$writer_files" | wc -l | tr -d ' ')
+fi
+
+if (( writer_count != 1 )); then
+  fail "expected exactly 1 production *.py file under app/ with 'INSERT INTO fund_metadata_observations', found ${writer_count}:"
+  echo "$writer_files" >&2
+fi
+
+# ======================================================================
+# Summary
+# ======================================================================
+if (( violations > 0 )); then
+  echo "FAIL: ${violations} invariant violation(s) — N-CSR retention cap drift detected." >&2
+  exit 1
+fi
+
+echo "OK: N-CSR retention cap invariants A / B / D / I satisfied."

--- a/tests/test_check_n_csr_retention_lint.py
+++ b/tests/test_check_n_csr_retention_lint.py
@@ -1,0 +1,168 @@
+"""Meta-test for scripts/check_n_csr_retention.sh (#1233 §4.12 / PR8).
+
+Pins the lint guard against the failure modes the PR8 plan + Codex
+1a/1b/1c reviews identified:
+
+1. Clean source tree passes.
+2. Duplicating the helper definition trips invariant A.
+3. Removing the ``N_CSR_RETENTION_DAYS:`` annotated assignment trips
+   invariant A.
+4. Inlining ``timedelta(days=730)`` inside ``bootstrap_n_csr_drain``
+   trips invariant B.
+5. Removing the ``n_csr_retention_cutoff(`` call inside
+   ``bootstrap_n_csr_drain`` trips invariant B.
+6. Moving the parser gate AFTER ``_fetch_ixbrl(`` trips invariant D.
+7. Removing the parser gate entirely trips invariant D.
+8. The guard script is executable.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUARD = REPO_ROOT / "scripts" / "check_n_csr_retention.sh"
+SRC_PARSER = REPO_ROOT / "app/services/manifest_parsers/sec_n_csr.py"
+SRC_BOOTSTRAP = REPO_ROOT / "app/jobs/sec_first_install_drain.py"
+
+
+def _stage_tree(tmp_path: Path) -> None:
+    """Copy the two guarded files under their real paths so the
+    guard's hardcoded paths resolve when invoked with ``cwd=tmp_path``."""
+    for rel in (
+        "app/services/manifest_parsers/sec_n_csr.py",
+        "app/jobs/sec_first_install_drain.py",
+    ):
+        src = REPO_ROOT / rel
+        dst = tmp_path / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(src, dst)
+
+
+def _run_guard(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(GUARD)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_guard_is_executable() -> None:
+    import os
+
+    assert os.access(GUARD, os.X_OK), f"{GUARD} is not executable; chmod +x is required for the pre-push wire."
+
+
+def test_guard_passes_on_clean_tree() -> None:
+    """The current source tree must pass the guard."""
+    result = _run_guard(REPO_ROOT)
+    assert result.returncode == 0, f"Lint guard failed on clean tree:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+
+
+def test_guard_fails_on_duplicate_helper(tmp_path: Path) -> None:
+    """Adding a second ``def n_csr_retention_cutoff(`` trips A."""
+    _stage_tree(tmp_path)
+    target = tmp_path / "app/services/manifest_parsers/sec_n_csr.py"
+    text = target.read_text()
+    patched = text + "\n\ndef n_csr_retention_cutoff(now):\n    return now\n"
+    target.write_text(patched)
+
+    result = _run_guard(tmp_path)
+    assert result.returncode == 1
+    assert "expected exactly 1 'def n_csr_retention_cutoff(" in result.stderr
+
+
+def test_guard_fails_when_constant_assignment_removed(tmp_path: Path) -> None:
+    """Stripping the ``N_CSR_RETENTION_DAYS:`` annotated assignment
+    trips A (assignment line is the only reference that counts)."""
+    _stage_tree(tmp_path)
+    target = tmp_path / "app/services/manifest_parsers/sec_n_csr.py"
+    text = target.read_text()
+    patched = text.replace("N_CSR_RETENTION_DAYS: int = 730", "_N_CSR_RETENTION_DAYS = 730", 1)
+    assert patched != text, "expected the annotated assignment substring in source"
+    target.write_text(patched)
+
+    result = _run_guard(tmp_path)
+    assert result.returncode == 1
+    assert "column-0 'N_CSR_RETENTION_DAYS:'" in result.stderr
+
+
+def test_guard_fails_on_inlined_730d_math(tmp_path: Path) -> None:
+    """Inlining ``timedelta(days=730)`` inside ``bootstrap_n_csr_drain``
+    trips invariant B even when the helper call is still present."""
+    _stage_tree(tmp_path)
+    target = tmp_path / "app/jobs/sec_first_install_drain.py"
+    text = target.read_text()
+    patched = text.replace(
+        "cutoff = n_csr_retention_cutoff()",
+        ("cutoff = n_csr_retention_cutoff()\n    _shadow = datetime.now(UTC) - timedelta(days=730)"),
+        1,
+    )
+    assert patched != text, "expected the cutoff line in source"
+    target.write_text(patched)
+
+    result = _run_guard(tmp_path)
+    assert result.returncode == 1
+    assert "forbidden inlined 'timedelta(days=730)' math" in result.stderr
+
+
+def test_guard_fails_when_helper_call_missing(tmp_path: Path) -> None:
+    """Removing the ``n_csr_retention_cutoff(`` call inside
+    ``bootstrap_n_csr_drain`` trips invariant B."""
+    _stage_tree(tmp_path)
+    target = tmp_path / "app/jobs/sec_first_install_drain.py"
+    text = target.read_text()
+    patched = text.replace(
+        "cutoff = n_csr_retention_cutoff()",
+        "cutoff = datetime.now(UTC)  # bypass cap",
+        1,
+    )
+    assert patched != text, "expected helper call in source"
+    target.write_text(patched)
+
+    result = _run_guard(tmp_path)
+    assert result.returncode == 1
+    assert "shared helper not wired" in result.stderr
+
+
+def test_guard_fails_when_parser_gate_after_fetch(tmp_path: Path) -> None:
+    """Moving the gate after ``_fetch_ixbrl(`` trips invariant D."""
+    _stage_tree(tmp_path)
+    target = tmp_path / "app/services/manifest_parsers/sec_n_csr.py"
+    text = target.read_text()
+    # Strip the gate block in its current location...
+    gate_block = '    if not n_csr_within_retention(filed_at):\n        return _tombstoned("outside_retention")\n'
+    assert gate_block in text, "expected current gate block in source"
+    stripped = text.replace(gate_block, "", 1)
+    # ...and re-insert it AFTER the first ``_fetch_ixbrl(`` line.
+    fetch_marker = "        ixbrl_bytes = _fetch_ixbrl(ixbrl_url)\n"
+    assert fetch_marker in stripped, "expected fetch marker in source"
+    moved = stripped.replace(
+        fetch_marker,
+        fetch_marker + gate_block,
+        1,
+    )
+    assert moved != text, "no-op patch"
+    target.write_text(moved)
+
+    result = _run_guard(tmp_path)
+    assert result.returncode == 1
+    assert "must short-circuit BEFORE the HTTP fetch" in result.stderr
+
+
+def test_guard_fails_when_parser_gate_removed(tmp_path: Path) -> None:
+    """Removing the gate entirely trips invariant D."""
+    _stage_tree(tmp_path)
+    target = tmp_path / "app/services/manifest_parsers/sec_n_csr.py"
+    text = target.read_text()
+    gate_block = '    if not n_csr_within_retention(filed_at):\n        return _tombstoned("outside_retention")\n'
+    assert gate_block in text, "expected current gate block in source"
+    target.write_text(text.replace(gate_block, "", 1))
+
+    result = _run_guard(tmp_path)
+    assert result.returncode == 1
+    assert "missing n_csr_within_retention(...) pre-fetch gate" in result.stderr

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -49,6 +49,11 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         "db_ownership_inst",
         "db_ownership_insider",
         "db_ownership_funds",
+        # #915 / #916 (Phase 6 PRs 11+12, 2026-05-18). FINRA bimonthly
+        # short interest + RegSHO daily share a dedicated ``finra``
+        # Lane disjoint from sec_rate (CDN serves both endpoints with
+        # one shared throttle).
+        "finra",
     }
 )
 
@@ -99,9 +104,11 @@ class TestStageSpecParamsField:
             "filings_history_seed",
             "sec_first_install_drain",
             "sec_13f_recent_sweep",
-            # PR #1175 (#1174) — N-CSR/S fund-scoped bootstrap drain
-            # added with horizon_days=730 params.
-            "sec_n_csr_bootstrap_drain",
+            # PR8 #1233 §4.12 — sec_n_csr_bootstrap_drain previously
+            # carried ``horizon_days=730`` params; the param was
+            # removed when N_CSR_RETENTION_DAYS became the single
+            # source of truth, so the stage now dispatches with
+            # ``params={}`` and is intentionally absent from this set.
             # PR7 #1233 §4.6 — sec_n_port_ingest dispatches with
             # ``min_last_seen_filed_at`` resolved at dispatch time to
             # ``today - 380d`` (UTC midnight). Mirror of the #1010

--- a/tests/test_manifest_parser_sec_n_csr.py
+++ b/tests/test_manifest_parser_sec_n_csr.py
@@ -368,3 +368,61 @@ def test_ixbrl_companion_url_derivation() -> None:
 def test_register_idempotent() -> None:
     parser_mod.register()
     parser_mod.register()
+
+
+def test_pre_cap_filed_at_tombstones_before_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1233 §4.12 / PR8 — pre-fetch retention gate.
+
+    An accession with ``filed_at`` older than 730d MUST tombstone with
+    reason ``outside_retention`` BEFORE the iXBRL fetch runs. The fetch
+    spy asserts the gate short-circuits cleanly + saves SEC budget on
+    pre-cap drift from atom/daily/per-CIK/master-idx.
+    """
+    fetch_calls: list[str] = []
+
+    def _spy_fetch(url: str) -> bytes | None:
+        fetch_calls.append(url)
+        return b"<xml/>"
+
+    monkeypatch.setattr(parser_mod, "_fetch_ixbrl", _spy_fetch)
+
+    row = _ManifestRowStub(
+        accession_number="0001-22-OLD",
+        primary_document_url="https://www.sec.gov/Archives/edgar/data/819118/000099/primary_doc.htm",
+        # 1000 days back from any plausible "now" exceeds the 730d cap.
+        filed_at=datetime(2022, 1, 1, tzinfo=UTC),
+    )
+    outcome = parser_mod._parse_sec_n_csr(ebull_test_conn, row)
+    assert outcome.status == "tombstoned"
+    assert outcome.error == "outside_retention"
+    assert fetch_calls == []  # short-circuited before HTTP fetch
+
+
+def test_in_cap_filed_at_proceeds_past_gate(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1233 §4.12 / PR8 — gate admits in-cap accessions.
+
+    Companion of ``test_pre_cap_filed_at_tombstones_before_fetch`` —
+    pins that the gate isn't over-broad. ``filed_at`` 10 days back is
+    well inside the 730d window; the parser must proceed through fetch
+    + extract.
+    """
+    _seed_instrument(ebull_test_conn, iid=3801, symbol="VTSAX", class_id="C000000901")
+    ebull_test_conn.commit()
+    _patch_fetch_and_extract(
+        monkeypatch,
+        extract_returns=[_make_facts(class_id="C000000901")],
+    )
+
+    row = _ManifestRowStub(
+        accession_number="0001-26-INC",
+        primary_document_url="https://www.sec.gov/Archives/edgar/data/819118/000100/primary_doc.htm",
+        filed_at=datetime.now(tz=UTC),
+    )
+    outcome = parser_mod._parse_sec_n_csr(ebull_test_conn, row)
+    assert outcome.status == "parsed"

--- a/tests/test_n_csr_retention_helpers.py
+++ b/tests/test_n_csr_retention_helpers.py
@@ -1,0 +1,95 @@
+"""Unit tests for the N-CSR retention helpers (#1233 §4.12 / PR8).
+
+Pure-Python helpers — no DB. Covered:
+
+- ``n_csr_retention_cutoff`` returns ``now - 730d`` (UTC).
+- Helper normalises non-UTC ``now`` to UTC.
+- Helper raises on tz-naive ``now``.
+- ``n_csr_within_retention`` boundary inclusive (== cutoff → True;
+  cutoff - 1µs → False).
+- ``None`` filed_at → False.
+- tz-naive filed_at raises.
+
+PR7 N-PORT lesson: tz-naive ``now`` (or local ``datetime.now()``) would
+honour the caller's TZ and drift the cutoff by ±1 day on non-UTC dev
+hosts; both helpers fail-closed via ValueError.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from app.services.manifest_parsers.sec_n_csr import (
+    N_CSR_RETENTION_DAYS,
+    n_csr_retention_cutoff,
+    n_csr_within_retention,
+)
+
+
+class TestRetentionCutoff:
+    def test_default_now_returns_utc(self) -> None:
+        cutoff = n_csr_retention_cutoff()
+        assert cutoff.tzinfo is not None
+        assert cutoff.tzinfo.utcoffset(cutoff) == timedelta(0)
+
+    def test_exact_730d_offset(self) -> None:
+        now = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+        cutoff = n_csr_retention_cutoff(now)
+        # 730 days back: 2024-05-21 12:00:00 UTC.
+        assert cutoff == datetime(2024, 5, 20, 12, 0, 0, tzinfo=UTC)
+
+    def test_normalises_non_utc_to_utc(self) -> None:
+        ny = timezone(timedelta(hours=-5))
+        now_ny = datetime(2026, 5, 20, 7, 0, 0, tzinfo=ny)  # = 12:00 UTC
+        cutoff = n_csr_retention_cutoff(now_ny)
+        assert cutoff == datetime(2024, 5, 20, 12, 0, 0, tzinfo=UTC)
+
+    def test_raises_on_naive_now(self) -> None:
+        with pytest.raises(ValueError, match="tz-aware"):
+            n_csr_retention_cutoff(datetime(2026, 5, 20, 12, 0, 0))
+
+    def test_constant_equals_730(self) -> None:
+        # Drift sentinel — anybody bumping this without updating the
+        # spec § + plan + lint guard expectations would trip this.
+        assert N_CSR_RETENTION_DAYS == 730
+
+
+class TestWithinRetention:
+    NOW = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
+    CUTOFF = datetime(2024, 5, 20, 12, 0, 0, tzinfo=UTC)
+
+    def test_boundary_inclusive_at_cutoff(self) -> None:
+        assert n_csr_within_retention(self.CUTOFF, self.NOW) is True
+
+    def test_just_before_cutoff_rejected(self) -> None:
+        just_before = self.CUTOFF - timedelta(microseconds=1)
+        assert n_csr_within_retention(just_before, self.NOW) is False
+
+    def test_just_after_cutoff_admitted(self) -> None:
+        just_after = self.CUTOFF + timedelta(microseconds=1)
+        assert n_csr_within_retention(just_after, self.NOW) is True
+
+    def test_recent_filed_at_admitted(self) -> None:
+        recent = self.NOW - timedelta(days=10)
+        assert n_csr_within_retention(recent, self.NOW) is True
+
+    def test_far_past_filed_at_rejected(self) -> None:
+        far = self.NOW - timedelta(days=10_000)
+        assert n_csr_within_retention(far, self.NOW) is False
+
+    def test_none_filed_at_returns_false(self) -> None:
+        assert n_csr_within_retention(None, self.NOW) is False
+
+    def test_naive_filed_at_raises(self) -> None:
+        naive = datetime(2026, 5, 20, 12, 0, 0)
+        with pytest.raises(ValueError, match="tz-aware"):
+            n_csr_within_retention(naive, self.NOW)
+
+    def test_non_utc_filed_at_normalised(self) -> None:
+        # Filed at 2026-05-20 07:00 NY = 2026-05-20 12:00 UTC — well
+        # within the 730d window from 2026-05-20 12:00 UTC.
+        ny = timezone(timedelta(hours=-5))
+        non_utc = datetime(2026, 5, 20, 7, 0, 0, tzinfo=ny)
+        assert n_csr_within_retention(non_utc, self.NOW) is True

--- a/tests/test_n_csr_retention_helpers.py
+++ b/tests/test_n_csr_retention_helpers.py
@@ -37,7 +37,9 @@ class TestRetentionCutoff:
     def test_exact_730d_offset(self) -> None:
         now = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
         cutoff = n_csr_retention_cutoff(now)
-        # 730 days back: 2024-05-21 12:00:00 UTC.
+        # 730 days back from 2026-05-20: 2024-05-20 (2024 is leap, but
+        # Feb 29 lies before the window so subtracting 365*2 lands on
+        # the same MM-DD).
         assert cutoff == datetime(2024, 5, 20, 12, 0, 0, tzinfo=UTC)
 
     def test_normalises_non_utc_to_utc(self) -> None:

--- a/tests/test_sec_first_install_drain.py
+++ b/tests/test_sec_first_install_drain.py
@@ -982,3 +982,52 @@ class TestNCsrBootstrapDrain:
         assert stats.trusts_processed == 1
         assert visited_urls == [_submissions_url(universe_trust)]
         assert stats.manifest_rows_upserted == 1
+
+    # ------------------------------------------------------------------
+    # PR8 #1233 §4.12 — bootstrap drain hard-pins 730d cap; no
+    # ``horizon_days`` param + pre-cap accessions reject at the drain.
+    # ------------------------------------------------------------------
+    def test_signature_has_no_horizon_days_kwarg(self) -> None:
+        """The ``horizon_days`` kwarg was removed in PR8 so every N-CSR
+        writer chokepoint shares one source of truth (#1233 §4.12).
+        Guards against accidental re-introduction.
+        """
+        import inspect
+
+        sig = inspect.signature(bootstrap_n_csr_drain)
+        assert "horizon_days" not in sig.parameters, (
+            "bootstrap_n_csr_drain.horizon_days kwarg reintroduced — PR8 (#1233 §4.12) "
+            "hard-pins N_CSR_RETENTION_DAYS as the single source of truth."
+        )
+
+    def test_pre_cap_accessions_rejected_at_drain(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Accessions filed > 730d before today are skipped by the
+        drain's ``_within_horizon`` filter; in-cap rows still enqueue.
+        """
+        _seed_trust(ebull_test_conn, _VANGUARD_CIK)
+        today = date.today()
+        pre_cap = (today - timedelta(days=1000)).isoformat()
+        in_cap = today.isoformat()
+        rows = [
+            ("0001104659-22-000001", pre_cap, "N-CSR", "old1.htm"),
+            ("0001104659-22-000002", pre_cap, "N-CSRS", "old2.htm"),
+            ("0001104659-26-000001", in_cap, "N-CSR", "new1.htm"),
+        ]
+        payload = _make_submissions_payload(cik=_VANGUARD_CIK, rows=rows)
+        http_get = _by_url({_submissions_url(_VANGUARD_CIK): payload})
+
+        stats = bootstrap_n_csr_drain(ebull_test_conn, http_get=http_get)
+        ebull_test_conn.commit()
+
+        assert stats.manifest_rows_upserted == 1
+        assert stats.accessions_outside_horizon == 2
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT accession_number FROM sec_filing_manifest WHERE source = 'sec_n_csr' ORDER BY accession_number"
+            )
+            inserted = [r[0] for r in cur.fetchall()]
+        assert inserted == ["0001104659-26-000001"]


### PR DESCRIPTION
## Summary

Refs #1233 — data retention rubric, N-CSR / N-CSRS depth cap (spec §4.12). Drift audit during PR8 found the spec was wrong: the 730d cap existed ONLY in `bootstrap_n_csr_drain`. Atom fast-lane / daily-index reconcile / per-CIK poll / master-idx quarterly sweep all enqueue N-CSR manifest rows uncapped, and the manifest-worker `_parse_sec_n_csr` writes `fund_metadata_observations` for every accession regardless of `filed_at`. PR8 closes the drift.

- New `N_CSR_RETENTION_DAYS = 730` constant + `n_csr_retention_cutoff` / `n_csr_within_retention` helpers in `app/services/manifest_parsers/sec_n_csr.py`. UTC-anchored; tz-naive `now` / `filed_at` raise `ValueError`.
- Manifest-worker `_parse_sec_n_csr` **pre-fetch retention gate**: short-circuits with `_tombstoned("outside_retention")` BEFORE iXBRL fetch on pre-cap accessions. Distinct from PR6/PR7's "post-parse" vocabulary because N-CSR's iXBRL companion IS the payload (no manifest-row-level payload parse before fetch).
- `bootstrap_n_csr_drain` refactored to use the shared helper; `horizon_days` parameter removed from the public signature so every writer chokepoint shares one source of truth. Param chain pruned: scheduler invoker discards params + docstring updated; `JOB_INTERNAL_KEYS` entry dropped; `bootstrap_orchestrator` S26 `StageSpec.params` dropped; `test_job_registry.lifted_stage_keys` updated; `app/jobs/runtime.py:301-306` comment refreshed.
- Lint guard `scripts/check_n_csr_retention.sh` with placement invariants A / B / D / I (letters mirror PR6/PR7 alphabet; C/E/F/G/H omitted because no `_ingest_single_accession`, no bulk-dataset, no rewash, no SQL repair sweep, and helper + parser gate co-locate making H redundant with D). Wired into `.githooks/pre-push` after `check_nport_retention.sh`.
- Spec §4.12 + §7 PR8 + §8 acceptance #6 + §12 handover updated. §8 #6 documents the explicit "no N-CSR deep-dive override" exception — `sec_rebuild` requeues of pre-cap accessions tombstone at the parser gate by design.

## Security model

Pure ingest-side cap. Adds no new HTTP surface, no new SQL writes, no new endpoints. Tombstones reduce SEC HTTP budget consumed on pre-cap drift from atom/daily-index/per-CIK/master-idx. Existing rows untouched (spec §6.3 — caps don't reshape pre-cap data; the operator pre-wipe + clean re-run is the single event that lands the bounded set).

## Tradeoffs

- **No N-CSR deep-dive override.** Unlike PR6 (13F-HR) / PR7 (N-PORT), the parser gate is hard-pinned with no bypass flag. `sec_rebuild` requeues of pre-cap accessions tombstone with `outside_retention`. Spec §8 acceptance #6 captures the rationale — fund-metadata pre-cap rows are not part of any consumer surface (no chart depth requirement, no AI prompt depth requirement, no alert window). Future ad-hoc backfill = explicit `bypass_retention` flag at `ManifestRow` level (deferred ticket if/when needed).
- **Atom / daily-index / per-CIK / master-idx stay uncapped at MANIFEST DISCOVERY.** Same posture as PR7 N-PORT — the worker gate is the single chokepoint before observations are written. Wasted SEC HTTP on pre-cap discovery is accepted vs. per-source filters proliferating across every discovery writer.

## Drive-by

`tests/test_job_registry.py::_ALLOWED_SOURCES`: added `"finra"`. FINRA Phase 6 PRs (#1207 / #1209, 2026-05-18) introduced a dedicated `finra` Lane disjoint from `sec_rate` but missed this allow-list. Failure was pre-existing on `main`; PR8's touch on `test_job_registry.py` brought the file into the pre-push testmon scope, surfacing the regression. One-line fix.

## Codex

- Spec + plan: Codex 1a (3 BLOCKING + 1 WARN + 1 NIT), 1b (1 BLOCKING + 1 WARN + 2 NIT), 1c (clean), 1d (1 NIT). All resolved before code.
- Branch diff: Codex 2 — no BLOCKING, no parity violations.

## Test plan

- [x] `bash scripts/check_n_csr_retention.sh` exits 0 on the branch.
- [x] `uv run ruff check .` + `uv run ruff format --check .` green.
- [x] `uv run pyright` on touched files green.
- [x] `uv run pytest tests/test_n_csr_retention_helpers.py tests/test_check_n_csr_retention_lint.py tests/test_manifest_parser_sec_n_csr.py tests/test_sec_first_install_drain.py tests/test_job_registry.py` all green (13 + 8 + parser cases + drain cases + 37 registry).
- [x] Pre-push hook green end-to-end (full pytest suite ran under testmon scoped path).
- [ ] Smoke (post-merge): operator triggers `sec_n_csr_bootstrap_drain` against 3-5 fund-trust CIKs (Vanguard, Fidelity, SPDR, etc.); verify `accessions_outside_horizon` increments + `manifest_rows_upserted` matches a hand-count of in-cap N-CSR + N-CSRS accessions on SEC EDGAR for those CIKs. Per spec §6.3 no existing rows shift until the operator pre-wipe + clean re-run.

Closes #1233's PR8 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)