### PR TITLE
docs(#1233): PR12 design spec — ownership_*_current writer rewrite (MERGE + watermark side-table)

### DIFF
--- a/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
+++ b/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
@@ -1,0 +1,343 @@
+# PR12 — `ownership_*_current` writer rewrite (DELETE+INSERT → diff-aware MERGE)
+
+> Created: **2026-05-21** as the final PR in the data-retention rubric umbrella.
+>
+> Tracking issue: **#1233** — Bootstrap scope discipline umbrella.
+>
+> Parent spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 / §4.6 / §6.4 / §7 / §8.
+>
+> Status: **DESIGN** — drafted post-PR11 (SHIPPED #1253 020e701). PR11 closed the SC 13D/G activation work; PR12 is the last entry in §7 implementation sequence. After PR12 lands, the operator triggers the §6.3 pre-wipe + clean re-run, and the parent umbrella #1233 closes.
+
+## 0. Status snapshot (2026-05-21 dev DB)
+
+```text
+                  table family                  | total size | heap     | indexes | toast  | tuple_percent
+------------------------------------------------+------------+----------+---------+--------+---------------
+ ownership_funds_current (write-through)        |    2364 MB |  2080 MB |  283 MB | 624 kB |        10.22 %
+ ownership_institutions_current (write-through) |     671 MB |   376 MB |  295 MB | 136 kB |        77.35 %
+ ownership_insiders_current                     |      29 MB |   ~14 MB |  ~14 MB |  small |        n/a
+ ownership_def14a_current                       |      14 MB |    ~7 MB |   ~7 MB |  small |        n/a
+ ownership_treasury_current                     |     384 kB |    small |   small |  small |        n/a
+ ownership_esop_current                         |      72 kB |    small |   small |  small |        n/a
+ ownership_blockholders_current                 |      24 kB |    small |   small |  small |        n/a
+```
+
+`pgstattuple('ownership_funds_current')` raw output:
+
+```text
+ table_len  | tuple_count | tuple_len | tuple_percent | dead_tuple_count | dead_tuple_len | dead_tuple_percent | free_space  | free_percent
+------------+-------------+-----------+---------------+------------------+----------------+--------------------+-------------+--------------
+ 2180743168 |      785688 | 222803168 |         10.22 |                0 |              0 |                  0 |  1945107808 |        89.19
+```
+
+786k live rows, ~222 MB live data, ~1855 MB free space, 0 dead tuples (autovacuum already swept). Pages emptied, never returned to OS — pure free-space bloat. Only `VACUUM FULL` or `TRUNCATE` (the operator pre-wipe) reclaims it.
+
+Schema invariants verified across all 7 `_current` tables:
+
+```text
+ table                          | PK
+ ownership_funds_current        | (instrument_id, fund_series_id)
+ ownership_institutions_current | (instrument_id, filer_cik, ownership_nature, exposure_kind)
+ ownership_insiders_current     | (instrument_id, holder_identity_key, ownership_nature)
+ ownership_blockholders_current | (instrument_id, reporter_cik, ownership_nature)
+ ownership_def14a_current       | (instrument_id, holder_name_key, ownership_nature)
+ ownership_esop_current         | (instrument_id, plan_name)
+ ownership_treasury_current     | (instrument_id)
+```
+
+All 7 carry `refreshed_at TIMESTAMPTZ NOT NULL DEFAULT now()`. All 7 lead PK with `instrument_id`. All 7 are written exclusively by sibling `refresh_*_current(conn, *, instrument_id) -> int` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py).
+
+Postgres confirmed at **17.9** in dev (`PostgreSQL 17.9 (Debian 17.9-1.pgdg13+1)`). `MERGE` with `WHEN NOT MATCHED BY SOURCE` is supported.
+
+## 1. Problem statement
+
+The 7 `refresh_*_current` helpers share an identical pattern:
+
+```python
+with conn.transaction(), conn.cursor() as cur:
+    cur.execute("SELECT pg_advisory_xact_lock(hashtextextended('refresh_X_current', 0) # %s::bigint)", (instrument_id,))
+    cur.execute("DELETE FROM ownership_X_current WHERE instrument_id = %s", (instrument_id,))
+    cur.execute("INSERT INTO ownership_X_current (...) SELECT DISTINCT ON (...) FROM ownership_X_observations WHERE instrument_id = %s AND known_to IS NULL ORDER BY ...", (instrument_id,))
+    cur.execute("SELECT COUNT(*) FROM ownership_X_current WHERE instrument_id = %s", (instrument_id,))
+```
+
+Every call manufactures **N dead tuples** (N = rows in the instrument's latest-set) regardless of whether the resolved set actually changed. Bootstrap drains call the helper after every observation batch:
+
+| Caller | Helper | Source |
+| --- | --- | --- |
+| `app/services/manifest_parsers/sec_n_port.py:404` | `refresh_funds_current` | manifest worker per-accession |
+| `app/services/n_port_ingest.py:1150` | `refresh_funds_current` | per-CIK ingest |
+| `app/services/sec_bulk_orchestrator_jobs.py:761` | `refresh_funds_current` | bulk archive drain |
+| `app/services/manifest_parsers/sec_13f_hr.py:527` | `refresh_institutions_current` | manifest worker per-accession |
+| `app/services/institutional_holdings.py:1552` | `refresh_institutions_current` | per-CIK ingest |
+| `app/services/sec_bulk_orchestrator_jobs.py:425` | `refresh_institutions_current` | bulk archive drain |
+| `app/services/ownership_observations_sync.py:404` | `refresh_institutions_current` | observations sync |
+| `app/services/rewash_filings.py:1075` | `refresh_institutions_current` | rewash rescue |
+| `app/jobs/ownership_observations_repair.py:70` | `refresh_institutions_current` | one-shot repair |
+
+`ownership_funds_current` bloats worst because each instrument's latest-set carries ~86 fund-series rows vs ~5-15 institutional-filer rows. Per-call dead-tuple bursts are 6-15x larger for funds than institutions; autovacuum's `vacuum_scale_factor=0.2` cannot keep pace with bootstrap-rate churn.
+
+Result: `ownership_funds_current` 10.22% tuple density. `ownership_institutions_current` 77.35% — healthy today but the same pattern, primed to degrade if any future write-through-bound source widens its per-instrument fanout (PR12's preventive scope).
+
+## 2. Non-goals
+
+- Row deletion of pre-existing rows (parent spec §6.3 — operator pre-wipe handles reshape).
+- `VACUUM FULL` against existing tables (operator-driven, separate event; pre-wipe TRUNCATEs anyway).
+- Schema changes — PK shapes, column lists, partitioning all unchanged.
+- Frontend / API surface — `_current` reads unaffected (same row shapes, same indexes, same PKs).
+- Writer signature changes — `refresh_X_current(conn, *, instrument_id) -> int` preserved for every caller.
+- Cap-shape changes — observations write-side caps from PR1–PR11 stand as-is.
+
+## 3. Two-axis decision
+
+### 3.1 Writer pattern — diff-aware MERGE
+
+Single MERGE statement per helper. `WHEN MATCHED AND (...) IS DISTINCT FROM (...)` skips writes when business columns are identical; `WHEN NOT MATCHED BY TARGET` inserts new rows; `WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %s` deletes rows that fall out of the latest set.
+
+PG17 `WHEN NOT MATCHED BY SOURCE` is load-bearing — PG15/16 only have `BY TARGET`, which forces a two-statement workaround. Dev DB is PG17.9; boot-time guard added (§7).
+
+### 3.2 Migration scope — all 7 helpers
+
+Per parent spec §7 "ownership_*_current size audit + remediation" and `feedback_no_punting_complete_work` ("default to full scope; no multiple-choice"). Uniform pattern, single lint guard, no tech-debt followups. Tiny tables get preventive fix at near-zero cost.
+
+## 4. Writer rewrite
+
+Each helper becomes one MERGE statement inside the existing transaction + advisory lock. Template (`ownership_funds_current` shown; per-helper differences in PK / DISTINCT ON / column list only):
+
+```python
+def refresh_funds_current(conn: psycopg.Connection[Any], *, instrument_id: int) -> int:
+    """Deterministically reconcile ``ownership_funds_current`` rows for
+    one instrument from its observations.
+
+    Diff-aware MERGE: UPDATE only when business columns IS DISTINCT FROM
+    the new set; INSERT new rows; DELETE rows that fall out of the
+    latest set (NOT MATCHED BY SOURCE scope-clamped to this instrument).
+    refreshed_at is excluded from the diff predicate so idempotent
+    re-runs do not manufacture dead tuples (PR12 fix for the
+    ownership_funds_current bloat surfaced post-PR11)."""
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_advisory_xact_lock(
+                (hashtextextended('refresh_funds_current', 0) # %s::bigint)
+            )
+            """,
+            (instrument_id,),
+        )
+        cur.execute(
+            """
+            MERGE INTO ownership_funds_current AS tgt
+            USING (
+                SELECT DISTINCT ON (fund_series_id)
+                    instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                    ownership_nature,
+                    source, source_document_id, source_accession, source_url,
+                    filed_at, period_start, period_end,
+                    shares, market_value_usd, payoff_profile, asset_category
+                FROM ownership_funds_observations
+                WHERE instrument_id = %(iid)s AND known_to IS NULL
+                ORDER BY
+                    fund_series_id,
+                    filed_at DESC,
+                    period_end DESC,
+                    source_document_id ASC
+            ) AS src
+            ON tgt.instrument_id = src.instrument_id
+               AND tgt.fund_series_id = src.fund_series_id
+            WHEN MATCHED AND (
+                tgt.fund_series_name, tgt.fund_filer_cik, tgt.ownership_nature,
+                tgt.source, tgt.source_document_id, tgt.source_accession, tgt.source_url,
+                tgt.filed_at, tgt.period_start, tgt.period_end,
+                tgt.shares, tgt.market_value_usd, tgt.payoff_profile, tgt.asset_category
+            ) IS DISTINCT FROM (
+                src.fund_series_name, src.fund_filer_cik, src.ownership_nature,
+                src.source, src.source_document_id, src.source_accession, src.source_url,
+                src.filed_at, src.period_start, src.period_end,
+                src.shares, src.market_value_usd, src.payoff_profile, src.asset_category
+            ) THEN UPDATE SET
+                fund_series_name   = src.fund_series_name,
+                fund_filer_cik     = src.fund_filer_cik,
+                ownership_nature   = src.ownership_nature,
+                source             = src.source,
+                source_document_id = src.source_document_id,
+                source_accession   = src.source_accession,
+                source_url         = src.source_url,
+                filed_at           = src.filed_at,
+                period_start       = src.period_start,
+                period_end         = src.period_end,
+                shares             = src.shares,
+                market_value_usd   = src.market_value_usd,
+                payoff_profile     = src.payoff_profile,
+                asset_category     = src.asset_category,
+                refreshed_at       = now()
+            WHEN NOT MATCHED BY TARGET THEN INSERT (
+                instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                ownership_nature, source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, market_value_usd, payoff_profile, asset_category
+            ) VALUES (
+                src.instrument_id, src.fund_series_id, src.fund_series_name, src.fund_filer_cik,
+                src.ownership_nature, src.source, src.source_document_id, src.source_accession, src.source_url,
+                src.filed_at, src.period_start, src.period_end,
+                src.shares, src.market_value_usd, src.payoff_profile, src.asset_category
+            )
+            WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %(iid)s THEN DELETE
+            """,
+            {"iid": instrument_id},
+        )
+        cur.execute(
+            "SELECT COUNT(*) FROM ownership_funds_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+```
+
+### 4.1 Per-helper differences
+
+| Helper | PK | DISTINCT ON | Notes |
+| --- | --- | --- | --- |
+| `refresh_insiders_current` | `(instrument_id, holder_identity_key, ownership_nature)` | `(holder_identity_key, ownership_nature)` | Keeps cross-source priority CASE chain in `ORDER BY` (Form 4 > Form 3 > 13D/G > DEF14A > 13F > N-PORT/N-CSR > XBRL DEI > 10-K note > FINRA SI). |
+| `refresh_institutions_current` | `(instrument_id, filer_cik, ownership_nature, exposure_kind)` | `(filer_cik, ownership_nature, exposure_kind)` | Three-tuple grouping preserves EQUITY/PUT/CALL split. |
+| `refresh_blockholders_current` | `(instrument_id, reporter_cik, ownership_nature)` | `(reporter_cik, ownership_nature)` | Per-helper ORDER BY preserved. |
+| `refresh_def14a_current` | `(instrument_id, holder_name_key, ownership_nature)` | `(holder_name_key, ownership_nature)` | Existing legacy-ESOP exclusion in USING WHERE preserved. |
+| `refresh_esop_current` | `(instrument_id, plan_name)` | `(plan_name)` | Smallest column list. |
+| `refresh_treasury_current` | `(instrument_id)` | `(instrument_id)` | Single-row-per-instrument table; MERGE still applies but DELETE branch fires only on shrinkage. |
+| `refresh_funds_current` | `(instrument_id, fund_series_id)` | `(fund_series_id)` | Template above. |
+
+### 4.2 Diff-predicate column list contract
+
+`refreshed_at` is **excluded** from the `IS DISTINCT FROM` tuples on both sides. Including it would defeat the no-op optimisation — `now()` on the source side always differs from the stored value, every MATCHED row would re-fire UPDATE, dead tuples back to N per call.
+
+`refreshed_at` is **set** in the UPDATE SET clause when the WHEN MATCHED + DISTINCT predicate fires. When business columns are unchanged, the row is skipped entirely → `refreshed_at` stays at the prior pass's value. Operator-visible semantics: `refreshed_at` advances only when an actual business-data change lands, not on every refresh attempt.
+
+INSERT branch omits `refreshed_at` → column `DEFAULT now()` fires.
+
+### 4.3 Scope clamp — load-bearing
+
+`WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %(iid)s THEN DELETE` is the per-instrument scope clamp. Without the `AND tgt.instrument_id = %(iid)s` predicate, MERGE walks the **entire target table** and DELETEs every row not in the (single-instrument) source — catastrophic global data loss. Pinned by lint invariant D (§5). Also pinned at runtime by the **scope clamp** test case (§6).
+
+### 4.4 Concurrency
+
+Per-instrument `pg_advisory_xact_lock` serialises concurrent refreshes for the same `(helper, instrument_id)` pair. Disjoint instrument refreshes run in parallel; PG MERGE takes row-level locks on the rows it touches → disjoint instrument_id rows do not block each other. Transaction wraps the MERGE so a failure rolls back both the advisory lock acquisition and any partial MERGE writes.
+
+## 5. Lint guard
+
+New script: [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh). Wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after PR11's `check_13dg_retention.sh`.
+
+Awk-based function-body block walker (PR4 Codex 1c lesson) so reformatting cannot trip the guard; empty-grep `wc -l` guards (PR10a Codex iter 1 lesson) so missing-anchor doesn't silently pass.
+
+Per helper (×7: `insiders / institutions / blockholders / treasury / def14a / funds / esop`):
+
+| Invariant | What it pins | How |
+| --- | --- | --- |
+| **A** | Helper defined exactly once in `app/services/ownership_observations.py` | grep `^def refresh_<X>_current\(` → count == 1 |
+| **B** | No legacy `DELETE FROM ownership_<X>_current` inside helper body | awk-extract body span `def refresh_<X>_current` → next `^def `; grep inside → count == 0 |
+| **C** | `MERGE INTO ownership_<X>_current AS tgt` opener present | grep inside body span → count == 1 |
+| **D** | `WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id` clamp present (catastrophic data-loss class) | grep inside body span → count == 1 |
+| **E** | `refreshed_at` NOT inside diff predicate's `IS DISTINCT FROM` tuples | awk-extract span from `WHEN MATCHED AND (` to `) THEN UPDATE`; grep inside → count == 0 |
+| **F** | `pg_advisory_xact_lock` preserved on function-namespace hash | grep `hashtextextended\('refresh_<X>_current'` inside body → count == 1 |
+| **G** | DISTINCT ON columns match per-helper expected tuple | grep `DISTINCT ON \(<expected cols>\)` inside body → count == 1 |
+
+7 helpers × 7 invariants = 49 checks. Pure text walk, no DB dependency, sub-second runtime.
+
+Lint also audits the **legacy `DELETE FROM ownership_*_current`** pattern anywhere under `app/` (outside the 7 helper bodies) — count == 0. Catches a future regression where a sibling service tries to inline its own DELETE+INSERT against `_current`.
+
+## 6. Tests
+
+New file: [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py). 5 cases × 7 helpers = 35 parametrised cases.
+
+`pg_stat_user_tables` rejected as the no-op-churn assertion source (async stats-collector flush has several-hundred-ms lag → flaky). Switched to `pgstattuple` + `xmin` per row.
+
+| Case | Setup | Action | Assertion |
+| --- | --- | --- | --- |
+| **insert** | empty `_current` for instrument; write 1 observation | `refresh_X_current(conn, instrument_id=I)` | row present; `SELECT xmin FROM _current WHERE instrument_id=I` returns a fresh xid |
+| **no-op churn** | row present from prior refresh; no observation change; capture `xmin0` + `pgstattuple(table).{table_len, tuple_count}` | `refresh_X_current(I)` again | `xmin == xmin0` (row not rewritten); `pgstattuple(table).table_len` unchanged; `dead_tuple_count` delta == 0 — **load-bearing; proves the bloat fix** |
+| **update (amendment)** | row present `xmin0`; insert later-`filed_at` observation, same PK, different `shares` | refresh | row present; `xmin > xmin0`; `shares` reflects amendment; `refreshed_at > refreshed_at0` |
+| **delete (`known_to` expiry)** | row present; `UPDATE _observations SET known_to = now() WHERE …` | refresh | row absent |
+| **scope clamp** | rows present for instrument A and instrument B; capture B's `xmin0` | `refresh_X_current(I=A)` with no observation change | B's row still present; B's `xmin == xmin0`. **Pins `AND tgt.instrument_id = %s` SOURCE clamp** |
+
+`refreshed_at` invariants:
+- **no-op churn**: `refreshed_at` unchanged post-refresh (proves diff-predicate excludes it).
+- **update**: `refreshed_at` advances (proves UPDATE SET sets it).
+
+`pgstattuple` requires `CREATE EXTENSION` — [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisioning gains the extension. Single edit; inherited by every per-worker DB via template clone (#893 architecture).
+
+## 7. Postgres version guard
+
+`MERGE WHEN NOT MATCHED BY SOURCE` requires PG ≥ 17. Without a boot-time guard, a PG16 deployment would pass lint and crash at first refresh with `syntax error at or near "BY"`.
+
+Mirror #1187's `max_locks_per_transaction` boot pattern. New cross-cutting check at lifespan startup — either extends [`app/main.py`](../../../app/main.py) lifespan or sits as a sibling in `app/system/postgres_health.py`. Assertion: `SELECT current_setting('server_version_num')::int >= 170000`. Fail-closed: refuse to boot under PG < 17. Smoke test `tests/smoke/test_app_boots.py` exercises lifespan → guard gated by the pre-push smoke gate.
+
+Single-fact assertion; cross-cutting; minimal blast radius.
+
+## 8. Operator semantics
+
+PR12 ships the **writer**. It does NOT shrink the pre-existing dead space:
+- `ownership_funds_current` heap stays at 2080 MB post-merge.
+- `ownership_institutions_current` heap stays at 376 MB post-merge.
+- `GET /system/postgres-health` (Phase 4 of #1208) continues to report `db_size ≈ 41 GB` until the §6.3 operator pre-wipe.
+
+Reclaim path is the **operator pre-wipe + clean re-run** (parent spec §6.3 + §8 acceptance). PR12's contribution is ensuring the clean re-run does not re-bloat the new write-through pattern.
+
+No `DELETE FROM ownership_*_current` lands in this PR. The MERGE's `WHEN NOT MATCHED BY SOURCE THEN DELETE` is steady-state writer behaviour identical to today's DELETE+INSERT (a row drops out of `_current` only when its only observation expires via `known_to` or when caps shed it post-wipe). Read-side `_current` consumers see no behavioural change — same row shapes, same dedup ordering, same priorities, same indexes.
+
+## 9. Definition of done
+
+CLAUDE.md §"Definition of done" + §"ETL / parser / schema-migration additional clauses" both apply.
+
+1. 7 `refresh_*_current` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py) rewritten to single-statement MERGE per §4 template. Signature `(conn, *, instrument_id) -> int` preserved.
+2. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (49 checks: 7 helpers × 7 invariants A-G) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
+3. [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py) — 35 parametrised cases. Load-bearing no-op-churn case uses `xmin` + `pgstattuple`.
+4. [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisions `pgstattuple` extension.
+5. Boot-time PG ≥ 17 guard at lifespan (mirror #1187 pattern). Pinned by `tests/smoke/test_app_boots.py`.
+6. Smoke verification against AAPL / GME / MSFT / JPM / HD (CLAUDE.md panel) — for each instrument, call `refresh_funds_current` and `refresh_institutions_current` twice in succession; assert `pgstattuple.table_len` delta == 0 + `xmin` stability per row across the second call. PR description records each instrument's outcome and the commit SHA per CLAUDE.md ETL clause 12.
+7. Parent spec amendment — [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 + §4.6 + §7 + §8 updated: PR12 status flipped to SHIPPED, writer-pattern documented, Phase 2 (`<15 GB hot`) acceptance unblocked.
+8. New prevention-log entry — "MERGE WHEN NOT MATCHED BY SOURCE must carry the per-scope `AND tgt.<scope_col> = %(scope)s` clamp" (catastrophic data-loss class).
+9. Data-engineer skill update ([`.claude/skills/data-engineer/SKILL.md`](../../../.claude/skills/data-engineer/SKILL.md) + memory) — write-through section gains "diff-aware MERGE replaces DELETE+INSERT" rule + lint-guard pointer.
+10. Codex 2 pre-push green; bot review APPROVE on latest commit; CI green; merge.
+
+## 10. Acceptance — cross-reference to parent spec §8
+
+PR12 alone does not move the post-merge dev DB size (per §8 above). Acceptance is measured AFTER the operator-driven §6.3 pre-wipe + clean re-run, which lands the bounded set under all PR1-PR12 caps.
+
+Per parent spec §8 acceptance tiers:
+
+- **v1 bar (`<20 GB hot`)** — PR12 audit complete (this spec) + writer remediation merged + pre-wipe + clean re-run lands `ownership_funds_current + ownership_institutions_current` somewhere in the original 5.3 GB ballpark (writer fix alone, no cap shrinkage on either source — per spec §4.5 and §4.6 the observations caps were already shipped via PR6 + PR7). Acceptable.
+- **Phase 2 stretch (`<15 GB hot`)** — PR12 writer fix + observations caps from PR6/PR7 + clean re-run lands combined `_current` ≤ 1 GB. The 2080 MB → ~250 MB compression on funds_current comes from: (a) 786k live rows × 280 B real-data row width = ~220 MB heap + ~80 MB indexes; (b) zero bloat under diff-aware MERGE. ✅ Phase 2 unblocked by PR12.
+- **Ambitious (`<10 GB hot`)** — requires further `companyfacts` tightening (Phase 3 ticket; out of #1233 scope).
+
+PR12 measurement protocol post pre-wipe + clean re-run:
+
+```sql
+SELECT relname, pg_size_pretty(pg_total_relation_size(oid)) AS sz, pg_total_relation_size(oid) AS bytes
+FROM pg_class
+WHERE relname IN ('ownership_funds_current', 'ownership_institutions_current')
+ORDER BY pg_total_relation_size(oid) DESC;
+```
+
+Plus per-helper pgstattuple to confirm tuple_percent ≥ 70% (healthy density floor).
+
+## 11. Codex review gate
+
+Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
+
+- **Codex 1a** on this spec (after first commit on `feature/1233-pr12-design-spec`).
+- Revise per findings.
+- **Codex 1b** on revised spec.
+- Revise.
+- **Codex 1c** if needed.
+- Spec lands as DOC PR (no code yet).
+- Implementation plan = separate doc (`docs/superpowers/plans/2026-05-21-pr12-ownership-current-writer-merge-impl.md`). Codex 1a / 1b on the plan.
+- PR12 implementation PR follows standard #1208 cadence: self-review → Codex 2 pre-push → push → bot review → resolve → APPROVE on latest commit → merge.
+
+## 12. Handover for next session
+
+State at this commit:
+
+- Parent umbrella #1233 still OPEN. PR1-PR11 all SHIPPED (PR11 #1253 020e701 merged 2026-05-21).
+- This is the DESIGN doc for PR12. Implementation has not started.
+- Branch: `feature/1233-pr12-design-spec`.
+- Next: Codex 1a on this spec; revise; Codex 1b; doc PR; then writing-plans skill → implementation plan → execution.
+
+After PR12 merges, the operator triggers the §6.3 pre-wipe + clean re-run and #1233 closes per parent spec §8.

--- a/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
+++ b/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
@@ -6,7 +6,7 @@
 >
 > Parent spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 / §4.6 / §6.4 / §7 / §8.
 >
-> Status: **DESIGN (rev 4)** — Codex 1a → rev 2 (5H + 7M + 4L). Codex 1b → rev 3 (3H + 7M + 4L). Codex 1c on rev 3 found 1 HIGH (rev 3's obs-anchored `GROUP BY instrument_id` predicate scans the full observations table per sweep — breaks the "<100ms healthy install" claim on funds-scale tables without a dedicated `(instrument_id, ingested_at)` index) + 3 MED (backfill from `_current.refreshed_at` lags obs MAX by tx-time-vs-clock_timestamp skew → first-sweep false-drift; missing `known_to` expiry watermark test; tuple_percent ≥ 70% floor too tight for state table churn-vs-autovacuum cadence) + 3 LOW (stale "5 categories" text; "always advances" wording inaccurate; handover stale). Rev 4 folds all 1c findings: state-anchored predicate primary path with LATERAL obs-MAX + UNION orphan tail; per-observations-table `(instrument_id, ingested_at DESC)` indexes provisioned in sql/163; backfill switched to `MAX(obs.ingested_at) GROUP BY obs.instrument_id` (uses obs MAX directly, eliminates skew); new case 4b watermark-alignment test on `known_to` expiry; state-table acceptance switched to dead-tuple bound; stale text purged.
+> Status: **DESIGN (rev 5)** — Codex 1a → rev 2 (5H+7M+4L). Codex 1b → rev 3 (3H+7M+4L). Codex 1c → rev 4 (1H+3M+3L). Codex 1d on rev 4 returned 3 HIGH (backfill from obs MAX MASKS real drift — false-negative regression vs rev 3's false-positive; "<100ms × 87k LATERAL probes" cost math optimistic; orphan UNION tail still scans 3.68M-row funds obs each sweep) + 3 MED (5 of 7 ingested_at indexes already exist in sql/119 — only funds + esop missing; case 9 raw UPDATE on `known_to` doesn't bump `ingested_at`; lint P doesn't pin index/backfill load-bearing semantics) + 1 LOW (non-goal wording stale re: sweep redesign). Rev 5 folds 1d: backfill reverted to `MAX(_current.refreshed_at) GROUP BY instrument_id` (false-positive over false-negative — one extra refresh-storm-during-first-sweep is benign; missed drift is silent staleness, unacceptable); orphan UNION tail DROPPED (state-anchored primary path only; write-through invariant trusted; gap documented as known limitation); "<100ms" hard claim replaced with "sub-second steady state, requires post-impl EXPLAIN ANALYZE"; sql/163 indexes scoped to funds + esop only (avoid sql/119 duplicates); case 9 setup uses explicit `SET ingested_at = clock_timestamp()` in fixture; lint P extended to pin index + backfill shape; non-goal §2 acknowledges sweep changes.
 
 ## 0. Status snapshot (2026-05-21 dev DB)
 
@@ -92,7 +92,7 @@ Caller inventory (refresh callers across the codebase):
 - Frontend / API surface — `_current` reads unaffected (same row shapes, same indexes, same PKs).
 - Writer signature changes — `refresh_X_current(conn, *, instrument_id) -> int` preserved for every caller.
 - Cap-shape changes — observations write-side caps from PR1–PR11 stand as-is.
-- Repair-sweep redesign beyond the predicate switch — sweep keeps its weekly cron, per-category loop, savepoint-per-instrument shape.
+- Repair-sweep redesign beyond the predicate switch + 7-category expansion — sweep keeps its weekly cron, per-category loop, savepoint-per-instrument shape. The `_CATEGORIES` list grows from 5 to 7 (adds `funds` + `esop`) to align with the state-table CHECK constraint — minimal additive change, not a redesign.
 
 ## 3. Decisions
 
@@ -131,23 +131,19 @@ CREATE INDEX IF NOT EXISTS idx_ownership_refresh_state_category
 - PK `(instrument_id, category)` caps the table at 7 × |distinct-instrument-ids| rows (currently ~87k in dev; grows linearly with universe). UPSERT-only writer with no row growth past the cap → bloat surface tiny + autovacuum-manageable.
 - CHECK lists all **7 categories** (Codex 1b MED-4 — current repair sweep iterates only 5; PR12 expands the sweep's `_CATEGORIES` list to include `funds` + `esop` for uniformity).
 
-**Per-observations-table `(instrument_id, ingested_at DESC)` indexes** (new, in same sql/163 migration) — load-bearing for the repair-sweep predicate cost target (Codex 1c HIGH-1):
+**Per-observations-table `(instrument_id, ingested_at DESC)` indexes** — sql/119 (#864 / #873) already provisioned these for 5 categories (insiders / institutions / blockholders / treasury / def14a). sql/163 adds the 2 missing indexes only (Codex 1d MED-1 — avoid duplicate-index landmines):
 
 ```sql
--- Per observations table, repeated 7 times in the migration:
-CREATE INDEX IF NOT EXISTS idx_ownership_funds_obs_instrument_ingested_at
+-- sql/163 — funds and esop only; the other 5 already exist from sql/119.
+CREATE INDEX IF NOT EXISTS idx_funds_obs_instrument_ingested
     ON ownership_funds_observations (instrument_id, ingested_at DESC);
--- (sibling CREATE INDEX statements for insiders / institutions / blockholders /
---  treasury / def14a / esop observations tables, including partition propagation
---  via PARTITION INDEX where the parent table is partitioned by period_end —
---  funds + institutions + insiders + blockholders + treasury + def14a + esop
---  observations are all RANGE-partitioned per migration 114-style schema; PG17
---  cascades CREATE INDEX from parent to all partitions automatically.)
+CREATE INDEX IF NOT EXISTS idx_esop_obs_instrument_ingested
+    ON ownership_esop_observations (instrument_id, ingested_at DESC);
 ```
 
-Without these indexes the LATERAL `MAX(ingested_at)` lookups per state row would fall back to per-partition seq-scan + aggregate → tens of seconds on funds (3.68M obs rows). With the index, each lookup is an index-only scan returning 1 row → <1ms × ~87k state rows = <100ms total sweep cost on healthy install (matches the repair docstring's target).
+These indexes back the LATERAL `MAX(ingested_at)` correlated subquery in the repair-sweep predicate (below). Each lookup becomes an index-only scan returning 1 row — without them, the lookup falls back to per-partition seq-scan + aggregate (tens of seconds on funds at 3.68M obs rows).
 
-**Migration backfill** is in the same SQL file; one INSERT per category, sourced from **observations MAX(ingested_at)** rather than `_current.refreshed_at` (Codex 1c MED-1 — `_current.refreshed_at` uses transaction `now()` while `observations.ingested_at` uses `clock_timestamp()`; the latter can be later within the same refresh tx, so backfilling from `_current.refreshed_at` would seed an under-estimate and cause first-sweep false drift). Backfilling from obs MAX asserts the write-through invariant "_current reflects observations as of obs MAX ingested_at" — which is the steady-state contract:
+**Migration backfill** is in the same SQL file; one INSERT per category, sourced from **`MAX(_current.refreshed_at) GROUP BY instrument_id`** (Codex 1d HIGH-1 — backfilling from `MAX(obs.ingested_at)` would *mask* real drift if `_current` was never reconciled, a silent-staleness regression unacceptable for a safety-net job; backfilling from `_current.refreshed_at` may cause a one-off first-sweep refresh storm against instruments where obs `clock_timestamp()` ran slightly later than refresh-tx `now()`, but every such refresh is a MERGE no-op (the diff predicate skips writes) → benign extra cost, never missed drift):
 
 ```sql
 -- Per category, repeated 7 times in the migration:
@@ -156,21 +152,20 @@ INSERT INTO ownership_refresh_state (
     last_drained_observations_max_ingested_at, last_refresh_attempted_at
 )
 SELECT
-    obs.instrument_id,
+    c.instrument_id,
     'funds',
-    MAX(obs.ingested_at),
-    now()
-FROM ownership_funds_observations obs
-GROUP BY obs.instrument_id
+    MAX(c.refreshed_at),
+    MAX(c.refreshed_at)
+FROM ownership_funds_current c
+GROUP BY c.instrument_id
 ON CONFLICT (instrument_id, category) DO NOTHING;
 ```
 
-If write-through has been broken (observations exist but `_current` never reconciled), the first post-deploy sweep will still find drift legitimately — repair fires, MERGE reconciles, state advances. Honest behaviour, not silent skip.
+Operator-visible: the first repair-sweep tick after deploy may select more instruments than steady state due to the tx-time vs clock_timestamp skew, with each selection costing one MERGE no-op (~1ms per instrument under the diff predicate). One-time event; subsequent sweeps return to steady state.
 
-**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) — **state-anchored primary path** (cheap correlated LATERAL `MAX` per state row, indexed by §3.3 indexes) + **orphan tail** for the rare "obs exists but state row missing" case (write-through gap caught at next sweep):
+**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) — **state-anchored single-query** (Codex 1d HIGH-3 — the UNION orphan tail from rev 4 anti-joined observations every sweep, full-table-ish cost on funds even when zero rows matched; dropped in favour of the write-through invariant + a separate operator-driven backfill if drift between obs-existence and state-row-existence is ever discovered):
 
 ```sql
--- Primary path: state-anchored, cheap with the new (instrument_id, ingested_at DESC) index.
 SELECT s.instrument_id
 FROM ownership_refresh_state s
 LEFT JOIN LATERAL (
@@ -179,30 +174,17 @@ LEFT JOIN LATERAL (
     WHERE o.instrument_id = s.instrument_id
 ) sub ON TRUE
 WHERE s.category = %s
-  AND s.last_drained_observations_max_ingested_at IS DISTINCT FROM sub.obs_max
-
-UNION
-
--- Orphan tail: obs exists for an instrument with no state row for this category.
--- Defence-in-depth against a broken write-through that wrote obs without firing
--- refresh + ownership_refresh_state UPSERT. Backfill covers all _current rows
--- at deploy time so this branch fires only on post-deploy write-through gaps.
-SELECT DISTINCT o.instrument_id
-FROM ownership_X_observations o
-WHERE NOT EXISTS (
-    SELECT 1 FROM ownership_refresh_state s
-    WHERE s.instrument_id = o.instrument_id AND s.category = %s
-);
+  AND s.last_drained_observations_max_ingested_at IS DISTINCT FROM sub.obs_max;
 ```
 
-NULL semantics on the primary branch:
+NULL semantics on this branch:
 
 - Both `s.last_drained` and `sub.obs_max` present, equal → not distinct → no drift.
 - Both present, different → distinct → drift → refresh fires.
 - `s.last_drained` present, `sub.obs_max` NULL (all obs deleted for instrument) → distinct → drift → refresh fires → MERGE NOT MATCHED BY SOURCE deletes any orphan `_current` rows → state UPSERT writes watermark = NULL → next sweep both NULL → not distinct → no drift.
 - Both NULL → not distinct → no drift (steady state for empty instrument).
 
-Orphan-tail cost: full obs table scan with `NOT EXISTS` filter. Healthy install: zero rows match (every obs-bearing instrument has a state row after backfill) → planner uses index-only-distinct on observations PK + anti-join against state PK → cheap. If the tail starts returning many rows, that signals a write-through regression and the sweep cost is the right signal to surface (loud failure mode).
+**Known limitation (documented gap)** — an instrument with observations but no `ownership_refresh_state` row (write-through fired the observation write but skipped or crashed before reaching the refresh helper) will not be detected by the sweep. The write-through invariant pins this: every observation-writer caller in the codebase invokes `refresh_X_current` immediately after `record_X_observation`. If a future bug breaks that pattern, drift is detectable by an out-of-band reconciliation query (cheap aggregate vs state-table size); not part of the in-band sweep cost.
 
 ## 4. Writer rewrite
 
@@ -369,7 +351,7 @@ The `WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %(iid)s THEN DELETE` cla
 - Concurrent **observation writers** (record_*_observation called from a sibling code path) do not block on the advisory lock. They may commit between the lock acquisition and the MERGE's source-subquery scan; the MERGE will see whatever was committed at scan time. The repair-sweep predicate (§3.3) catches any obs writes that committed after the most recent refresh — that is the whole point of the watermark.
 - PG MERGE takes row-level locks on matched/updated target rows + the locks released at COMMIT. Concurrent same-instrument refreshes (advisory lock contention) → serialised. Concurrent different-instrument refreshes → row-level locks are disjoint by PK; no contention.
 
-## 5. Lint guard (85 clause-counts total — 81 per-helper + 4 cross-cutting)
+## 5. Lint guard (91 clause-counts total — 81 per-helper + 10 cross-cutting)
 
 New script: [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh). Wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after PR11's `check_13dg_retention.sh`. Awk-based function-body block walker (PR4 Codex 1c lesson); every grep guarded against empty-input by exact-count assertion (PR10a Codex iter 1 lesson).
 
@@ -399,9 +381,9 @@ Plus 4 cross-cutting checks:
 | **M** | No `DELETE FROM ownership_*_current` anywhere under `app/` outside the 7 helper bodies | grep across `app/**/*.py` minus the 7 helper bodies → count == 0 |
 | **N** | No `DELETE FROM ownership_*_current` anywhere under `scripts/` and `app/jobs/` (catches future writers landing outside `app/services/`) | grep across both trees → count == 0 |
 | **O** | `ownership_observations_repair.py` predicate references `ownership_refresh_state.last_drained_observations_max_ingested_at` (not legacy `c.refreshed_at < ...` form) | grep `c.refreshed_at <` → count == 0 inside the repair file |
-| **P** | Migration `sql/163_ownership_refresh_state.sql` exists and creates the table with the documented PK and CHECK constraint | targeted grep |
+| **P** | Migration `sql/163_ownership_refresh_state.sql` pins all rev-5 contracts (Codex 1d MED-3): table + indexes + backfill | 7 targeted grep checks against the migration file with exact-count assertions — (P1) `CREATE TABLE IF NOT EXISTS ownership_refresh_state` opener present; (P2) PK is `(instrument_id, category)`; (P3) CHECK lists exactly the 7 category literals; (P4) `CREATE INDEX IF NOT EXISTS idx_funds_obs_instrument_ingested` present; (P5) `CREATE INDEX IF NOT EXISTS idx_esop_obs_instrument_ingested` present; (P6) backfill source shape `FROM ownership_X_current c GROUP BY c.instrument_id` (not from observations MAX); (P7) backfill repeated 7 times (one per category). |
 
-Total: **85 lint clause-counts** (81 per-helper + 4 cross-cutting). Pure text walk, no DB dependency, sub-second runtime.
+Total: **91 lint clause-counts** (81 per-helper + 10 cross-cutting — M, N, O, P1-P7). Pure text walk, no DB dependency, sub-second runtime.
 
 ## 6. Tests (52 parametrised cases)
 
@@ -419,7 +401,7 @@ New file: [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_o
 | 6 | **priority-chain regression (insiders only)** | write 2 observations same `(holder_identity_key, ownership_nature)`: source='form4' (priority 1) + source='13d' (priority 3); equal period_end + filed_at | refresh | `_current.source == 'form4'` (priority chain unchanged). Pins the cross-source `CASE source WHEN ... ASC` ORDER BY chain (lint invariant H + runtime). |
 | 7 | **per-helper filter regression** | (a) **treasury**: write 1 obs with `treasury_shares=NULL` AND 1 obs with `treasury_shares=12345` same period; (b) **def14a**: write 1 obs `holder_role='esop'`, 1 obs `holder_role='principal' AND holder_name ILIKE '%ESOP%'`, 1 obs `holder_role='principal' AND holder_name='Vanguard'` | refresh | (a) `_current.treasury_shares == 12345` (NULL-displacement guard works); (b) `_current` row count == 1; only the Vanguard row survives (ESOP regex + holder_role='esop' both excluded). |
 | 8 | **repair-sweep no-loop** | row present in `_current` + `ownership_refresh_state`; UPSERT same obs row (DO UPDATE clause bumps `obs.ingested_at`); refresh fires (no diff → MERGE no-op) | run `_drifted_instruments` again with the new predicate | empty list (state-table watermark advanced; sweep no longer re-selects). **Pins the §3.3 watermark fix end-to-end.** |
-| 9 | **`known_to` expiry watermark alignment** (Codex 1c MED-2) | row present in `_current` + state; `UPDATE _observations SET known_to = now()` on the active observation (no row deletion, just expiry); refresh fires (MERGE NOT MATCHED BY SOURCE → DELETE on `_current`; state UPSERT advances watermark to new obs MAX, which now reflects the expired row's bumped `ingested_at`) | run `_drifted_instruments` again | empty list. **Pins the all-observations population alignment between watermark capture and repair predicate** — if the watermark used `known_to IS NULL` while the predicate used all obs (or vice versa), expiry would create a false drift trigger. |
+| 9 | **`known_to` expiry watermark alignment** (Codex 1c MED-2) | row present in `_current` + state; `UPDATE _observations SET known_to = now(), ingested_at = clock_timestamp() WHERE …` on the active observation (Codex 1d MED-2 — raw UPDATE of `known_to` alone does NOT bump `ingested_at`; the production ingest path's DO UPDATE clause bumps both, the test must mirror that to actually exercise the alignment); refresh fires (MERGE NOT MATCHED BY SOURCE → DELETE on `_current`; state UPSERT advances watermark to new obs MAX which now includes the expired row's bumped `ingested_at`) | run `_drifted_instruments` again | empty list. **Pins the all-observations population alignment between watermark capture and repair predicate** — if the watermark used `known_to IS NULL` while the predicate used all obs (or vice versa), expiry would create a false drift trigger. |
 
 Total: 5 base cases × 7 helpers = 35 + 1 priority-chain (insiders) + 2 filter-regression (treasury + def14a) + 7 repair-sweep no-loop + 7 known_to expiry watermark = **52 parametrised cases**.
 
@@ -449,20 +431,20 @@ Reclaim path is the **operator pre-wipe + clean re-run** (parent spec §6.3 + §
 
 **Read-side unchanged**: no `_current` consumer sees behavioural change. Same row shapes, same dedup ordering, same priorities, same indexes. The MERGE's `WHEN NOT MATCHED BY SOURCE THEN DELETE` is steady-state writer behaviour identical to today's DELETE+INSERT (a row drops out of `_current` only when its only observation expires via `known_to` or when caps shed it post-wipe).
 
-**Sweep cost**: repair sweep stays at "<100ms on healthy install" — the state-anchored predicate does ~87k cheap LATERAL `MAX(ingested_at)` lookups (index-only scans on the new per-observations-table `(instrument_id, ingested_at DESC)` indexes from §3.3). The orphan UNION tail is zero rows on healthy install (write-through invariant holds → every obs-bearing instrument has a state row after backfill). If the orphan tail starts returning many rows, that's a write-through regression signal — sweep cost growth is the correct alarm channel.
+**Sweep cost**: the state-anchored predicate does ~87k LATERAL `MAX(ingested_at)` lookups (index-only scans). Steady-state target is **sub-second** (≤ 1-2s) on healthy install (Codex 1d HIGH-2 — "<100ms × 87k = <100ms" math was wrong; even at index-only scan + ~10μs per row, 87k probes is ~1s wall clock under realistic PG planner overhead). Exact ceiling requires post-implementation `EXPLAIN ANALYZE` against a populated dev DB; spec asks for that as part of §9 DoD #8 verification. First sweep post-deploy may take longer due to backfill-skew false-positive refresh storm (each false-positive is a MERGE no-op; bounded by universe size × ~1ms per call); operator-acceptable one-off event.
 
 ## 9. Definition of done
 
 CLAUDE.md §"Definition of done" + §"ETL / parser / schema-migration additional clauses" both apply.
 
 1. 7 `refresh_*_current` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py) rewritten to single-statement MERGE + `ownership_refresh_state` UPSERT per §4 template + §4.1 per-helper differences. Signature `(conn, *, instrument_id) -> int` preserved on every helper.
-2. New migration `sql/163_ownership_refresh_state.sql` creates the table with the schema in §3.3 + 7 `(instrument_id, ingested_at DESC)` indexes on each observations table (load-bearing for sweep cost — Codex 1c HIGH-1) + idempotent backfill via `MAX(observations.ingested_at) GROUP BY instrument_id` per category (Codex 1c MED-1 — eliminates `_current.refreshed_at` vs `clock_timestamp()` skew). Runs inside the standard migration runner; no `-- runner: autocommit` directive required.
-3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form (state-anchored LATERAL `MAX(ingested_at)` primary path + UNION orphan tail; `IS DISTINCT FROM` NULL-safe). `_CATEGORIES` list expanded to all 7 categories — adds `funds` + `esop` lambdas wiring `refresh_funds_current` + `refresh_esop_current` so the sweep stays uniform with the state-table CHECK constraint (Codex 1b MED-4).
-4. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (85 clause-counts: 81 per-helper + 4 cross-cutting, per §5) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
+2. New migration `sql/163_ownership_refresh_state.sql` creates the table with the schema in §3.3 + 2 `(instrument_id, ingested_at DESC)` indexes on funds + esop observations tables (sql/119 already covers the other 5 — Codex 1d MED-1) + idempotent backfill via `MAX(_current.refreshed_at) GROUP BY instrument_id` per category (Codex 1d HIGH-1 — false-positive over false-negative; backfilling from obs MAX would mask drift). Runs inside the standard migration runner; no `-- runner: autocommit` directive required.
+3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form (state-anchored single-query LATERAL `MAX(ingested_at)` with `IS DISTINCT FROM`; orphan UNION tail dropped per Codex 1d HIGH-3). `_CATEGORIES` list expanded to all 7 categories — adds `funds` + `esop` lambdas wiring `refresh_funds_current` + `refresh_esop_current` so the sweep stays uniform with the state-table CHECK constraint (Codex 1b MED-4).
+4. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (91 clause-counts: 81 per-helper + 10 cross-cutting M/N/O/P1-P7, per §5) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
 5. [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py) — 52 parametrised cases (7 × 5 base + insiders priority-chain + treasury null guard + def14a ESOP exclusion + 7 repair-sweep no-loop + 7 known_to expiry watermark alignment per §6). Load-bearing no-op-churn case uses per-row `xmin::text` equality + `pgstattuple` on both `_current` and `ownership_refresh_state`.
 6. [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisions `pgstattuple` extension; failure to provision triggers `pytest.fail` in no-op-churn case (no silent skips).
 7. Boot-time PG ≥ 17 guard at lifespan (mirror #1187 pattern). Pinned by `tests/smoke/test_app_boots.py`.
-8. Smoke verification against AAPL / GME / MSFT / JPM / HD (CLAUDE.md panel) post-merge: for each instrument, call `refresh_funds_current` and `refresh_institutions_current` twice in succession; assert `pgstattuple.table_len` delta == 0 + per-row `xmin::text` stability across the second call. Additionally call `refresh_treasury_current` and `refresh_def14a_current` for at least one instrument each to exercise the small-table helpers + their per-helper filters (Codex 1a LOW-4). PR description records each instrument's outcome and the commit SHA per CLAUDE.md ETL clause 12.
+8. Smoke verification against AAPL / GME / MSFT / JPM / HD (CLAUDE.md panel) post-merge: for each instrument, call `refresh_funds_current` and `refresh_institutions_current` twice in succession; assert `pgstattuple.table_len` delta == 0 + per-row `xmin::text` stability across the second call. Additionally call `refresh_treasury_current` and `refresh_def14a_current` for at least one instrument each to exercise the small-table helpers + their per-helper filters (Codex 1a LOW-4). EXPLAIN ANALYZE the repair-sweep predicate against a populated dev DB and record steady-state wall clock — confirms sub-second target (Codex 1d HIGH-2). PR description records each instrument's outcome, the EXPLAIN ANALYZE timing, and the commit SHA per CLAUDE.md ETL clause 12.
 9. Parent spec amendment — [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 + §4.6 + §7 + §8 updated: PR12 status flipped to SHIPPED, writer-pattern + watermark side-table documented, Phase 2 (`<15 GB hot`) acceptance unblocked.
 10. New prevention-log entries:
     - "MERGE WHEN NOT MATCHED BY SOURCE must carry the per-scope `AND tgt.<scope_col> = %(scope)s` clamp on BOTH the ON clause AND the DELETE clause (lint pins both literals)" — catastrophic data-loss class.
@@ -499,9 +481,10 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 
 - **Codex 1a** on this spec — completed; 5 HIGH + 7 MED + 4 LOW folded into rev 2.
 - **Codex 1b** on rev 2 — completed; 3 HIGH + 7 MED + 4 LOW folded into rev 3.
-- **Codex 1c** on rev 3 — completed; 1 HIGH + 3 MED + 3 LOW folded into rev 4 (this commit).
-- **Codex 1d** on rev 4 (next).
-- Codex 1e if needed.
+- **Codex 1c** on rev 3 — completed; 1 HIGH + 3 MED + 3 LOW folded into rev 4.
+- **Codex 1d** on rev 4 — completed; 3 HIGH + 3 MED + 1 LOW folded into rev 5 (this commit).
+- **Codex 1e** on rev 5 (next).
+- Codex 1f if needed.
 - Spec lands as DOC PR (no code yet).
 - Implementation plan = separate doc (`docs/superpowers/plans/2026-05-21-pr12-ownership-current-writer-merge-impl.md`). Codex 1a / 1b on the plan.
 - PR12 implementation PR follows standard #1208 cadence: self-review → Codex 2 pre-push → push → bot review → resolve → APPROVE on latest commit → merge.
@@ -511,8 +494,8 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 State at this commit:
 
 - Parent umbrella #1233 still OPEN. PR1-PR11 all SHIPPED (PR11 #1253 020e701 merged 2026-05-21).
-- This is the DESIGN doc for PR12 (rev 4 post-Codex 1c).
+- This is the DESIGN doc for PR12 (rev 5 post-Codex 1d).
 - Branch: `feature/1233-pr12-design-spec`.
-- Next: Codex 1d on rev 4; revise if needed; doc PR; then writing-plans skill → implementation plan → execution.
+- Next: Codex 1e on rev 5; revise if needed; doc PR; then writing-plans skill → implementation plan → execution.
 
 After PR12 merges, the operator triggers the §6.3 pre-wipe + clean re-run and #1233 closes per parent spec §8.

--- a/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
+++ b/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
@@ -1,4 +1,4 @@
-# PR12 — `ownership_*_current` writer rewrite (DELETE+INSERT → diff-aware MERGE)
+# PR12 — `ownership_*_current` writer rewrite (DELETE+INSERT → diff-aware MERGE) + `ownership_refresh_state` watermark side-table
 
 > Created: **2026-05-21** as the final PR in the data-retention rubric umbrella.
 >
@@ -6,7 +6,7 @@
 >
 > Parent spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 / §4.6 / §6.4 / §7 / §8.
 >
-> Status: **DESIGN** — drafted post-PR11 (SHIPPED #1253 020e701). PR11 closed the SC 13D/G activation work; PR12 is the last entry in §7 implementation sequence. After PR12 lands, the operator triggers the §6.3 pre-wipe + clean re-run, and the parent umbrella #1233 closes.
+> Status: **DESIGN (rev 2)** — initial draft addressed bloat via diff-aware MERGE; Codex 1a found 5 HIGH (repair-sweep watermark breakage, ON-clause scope-clamp shape, per-helper WHERE filter omissions, lint string-match too weak, test-matrix priority/filter coverage gap) + 7 MED + 4 LOW. Rev 2 folds all findings in: separate `ownership_refresh_state` side-table watermark + tightened lint (84 checks) + extended test matrix (≥56 cases) + concurrency contract + CI extension provisioning.
 
 ## 0. Status snapshot (2026-05-21 dev DB)
 
@@ -32,22 +32,25 @@
 
 786k live rows, ~222 MB live data, ~1855 MB free space, 0 dead tuples (autovacuum already swept). Pages emptied, never returned to OS — pure free-space bloat. Only `VACUUM FULL` or `TRUNCATE` (the operator pre-wipe) reclaims it.
 
-Schema invariants verified across all 7 `_current` tables:
+All 7 `_current` tables share: `instrument_id` leads PK; `refreshed_at TIMESTAMPTZ NOT NULL DEFAULT now()` is present; sibling `refresh_X_current(conn, *, instrument_id) -> int` in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py).
+
+PK and per-helper WHERE filter inventory (audited against current code; this table is **load-bearing** for §4.1):
 
 ```text
- table                          | PK
- ownership_funds_current        | (instrument_id, fund_series_id)
- ownership_institutions_current | (instrument_id, filer_cik, ownership_nature, exposure_kind)
- ownership_insiders_current     | (instrument_id, holder_identity_key, ownership_nature)
- ownership_blockholders_current | (instrument_id, reporter_cik, ownership_nature)
- ownership_def14a_current       | (instrument_id, holder_name_key, ownership_nature)
- ownership_esop_current         | (instrument_id, plan_name)
- ownership_treasury_current     | (instrument_id)
+ helper                            | PK                                                                | extra WHERE filter (after instrument_id = %s AND known_to IS NULL)
+-----------------------------------+-------------------------------------------------------------------+------------------------------------------------------------------
+ refresh_insiders_current          | (instrument_id, holder_identity_key, ownership_nature)            | (none — but cross-source priority CASE in ORDER BY)
+ refresh_institutions_current      | (instrument_id, filer_cik, ownership_nature, exposure_kind)       | (none)
+ refresh_blockholders_current      | (instrument_id, reporter_cik, ownership_nature)                   | (none)
+ refresh_treasury_current          | (instrument_id)                                                   | AND treasury_shares IS NOT NULL                       ← null-displacement guard
+ refresh_def14a_current            | (instrument_id, holder_name_key, ownership_nature)                | AND shares IS NOT NULL                                ← null-displacement guard
+                                   |                                                                   | AND holder_role IS DISTINCT FROM 'esop'               ← post-#843 parser tag
+                                   |                                                                   | AND holder_name !~* %s (_ESOP_HOLDER_NAME_SQL_REGEX)  ← legacy pre-#843 row exclusion
+ refresh_funds_current             | (instrument_id, fund_series_id)                                   | (none)
+ refresh_esop_current              | (instrument_id, plan_name)                                        | (none)
 ```
 
-All 7 carry `refreshed_at TIMESTAMPTZ NOT NULL DEFAULT now()`. All 7 lead PK with `instrument_id`. All 7 are written exclusively by sibling `refresh_*_current(conn, *, instrument_id) -> int` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py).
-
-Postgres confirmed at **17.9** in dev (`PostgreSQL 17.9 (Debian 17.9-1.pgdg13+1)`). `MERGE` with `WHEN NOT MATCHED BY SOURCE` is supported.
+Postgres confirmed at **17.9** (`PostgreSQL 17.9 (Debian 17.9-1.pgdg13+1)`). `MERGE WHEN NOT MATCHED BY SOURCE` is supported.
 
 ## 1. Problem statement
 
@@ -57,11 +60,17 @@ The 7 `refresh_*_current` helpers share an identical pattern:
 with conn.transaction(), conn.cursor() as cur:
     cur.execute("SELECT pg_advisory_xact_lock(hashtextextended('refresh_X_current', 0) # %s::bigint)", (instrument_id,))
     cur.execute("DELETE FROM ownership_X_current WHERE instrument_id = %s", (instrument_id,))
-    cur.execute("INSERT INTO ownership_X_current (...) SELECT DISTINCT ON (...) FROM ownership_X_observations WHERE instrument_id = %s AND known_to IS NULL ORDER BY ...", (instrument_id,))
+    cur.execute("INSERT INTO ownership_X_current (...) SELECT DISTINCT ON (...) FROM ownership_X_observations WHERE instrument_id = %s AND known_to IS NULL <extra filters> ORDER BY ...", (...))
     cur.execute("SELECT COUNT(*) FROM ownership_X_current WHERE instrument_id = %s", (instrument_id,))
 ```
 
-Every call manufactures **N dead tuples** (N = rows in the instrument's latest-set) regardless of whether the resolved set actually changed. Bootstrap drains call the helper after every observation batch:
+Two cost vectors:
+
+**Primary** — every call manufactures **N dead tuples** (N = rows in instrument's latest-set) regardless of whether the resolved set actually changed. Bootstrap drains call the helper after every observation batch (8 distinct callers, see Problem-statement table below). `ownership_funds_current` bloats worst because each instrument's latest-set carries ~86 fund-series rows vs ~5-15 institutional-filer rows.
+
+**Secondary (Codex 1a HIGH-1)** — the repair sweep [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) uses `c.refreshed_at < (SELECT MAX(o.ingested_at) FROM obs WHERE instrument_id = c.instrument_id)` as its drift watermark. Under the current DELETE+INSERT pattern, every refresh call (no-op or not) advances `_current.refreshed_at` because the row is rewritten. Under diff-aware MERGE, no-op refreshes leave `refreshed_at` frozen, so the predicate is **permanently true** for any instrument whose observations got re-UPSERTed (re-ingest of same data, parser-version rewash, manifest worker double-drain). Repair sweep re-selects + re-calls refresh forever. Under MERGE no-op the per-call cost is cheap (~1ms), but the sweep degrades from "<100ms on healthy install" (per repair docstring) to "X seconds per affected instrument forever". Operator-visible regression — not acceptable per `feedback_fix_in_scope_default` (small + coupled + unblocked = fix-now).
+
+Caller inventory (refresh callers across the codebase):
 
 | Caller | Helper | Source |
 | --- | --- | --- |
@@ -73,48 +82,101 @@ Every call manufactures **N dead tuples** (N = rows in the instrument's latest-s
 | `app/services/sec_bulk_orchestrator_jobs.py:425` | `refresh_institutions_current` | bulk archive drain |
 | `app/services/ownership_observations_sync.py:404` | `refresh_institutions_current` | observations sync |
 | `app/services/rewash_filings.py:1075` | `refresh_institutions_current` | rewash rescue |
-| `app/jobs/ownership_observations_repair.py:70` | `refresh_institutions_current` | one-shot repair |
-
-`ownership_funds_current` bloats worst because each instrument's latest-set carries ~86 fund-series rows vs ~5-15 institutional-filer rows. Per-call dead-tuple bursts are 6-15x larger for funds than institutions; autovacuum's `vacuum_scale_factor=0.2` cannot keep pace with bootstrap-rate churn.
-
-Result: `ownership_funds_current` 10.22% tuple density. `ownership_institutions_current` 77.35% — healthy today but the same pattern, primed to degrade if any future write-through-bound source widens its per-instrument fanout (PR12's preventive scope).
+| `app/jobs/ownership_observations_repair.py:70` | (all 5 categories via lambda) | weekly repair sweep |
 
 ## 2. Non-goals
 
 - Row deletion of pre-existing rows (parent spec §6.3 — operator pre-wipe handles reshape).
 - `VACUUM FULL` against existing tables (operator-driven, separate event; pre-wipe TRUNCATEs anyway).
-- Schema changes — PK shapes, column lists, partitioning all unchanged.
+- Schema changes to existing `_current` tables — PK shapes, column lists, partitioning all unchanged. (One **new** table `ownership_refresh_state` is added; §3.3.)
 - Frontend / API surface — `_current` reads unaffected (same row shapes, same indexes, same PKs).
 - Writer signature changes — `refresh_X_current(conn, *, instrument_id) -> int` preserved for every caller.
 - Cap-shape changes — observations write-side caps from PR1–PR11 stand as-is.
+- Repair-sweep redesign beyond the predicate switch — sweep keeps its weekly cron, per-category loop, savepoint-per-instrument shape.
 
-## 3. Two-axis decision
+## 3. Decisions
 
 ### 3.1 Writer pattern — diff-aware MERGE
 
-Single MERGE statement per helper. `WHEN MATCHED AND (...) IS DISTINCT FROM (...)` skips writes when business columns are identical; `WHEN NOT MATCHED BY TARGET` inserts new rows; `WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %s` deletes rows that fall out of the latest set.
+Single MERGE statement per helper. `WHEN MATCHED AND (...) IS DISTINCT FROM (...)` skips writes when business columns are identical; `WHEN NOT MATCHED BY TARGET` inserts new rows; `WHEN NOT MATCHED BY SOURCE` deletes rows that fall out of the latest set. Scope clamp on the ON clause (§4.3) keeps the planner from scanning the entire target table.
 
-PG17 `WHEN NOT MATCHED BY SOURCE` is load-bearing — PG15/16 only have `BY TARGET`, which forces a two-statement workaround. Dev DB is PG17.9; boot-time guard added (§7).
+PG17 `WHEN NOT MATCHED BY SOURCE` is load-bearing — PG15/16 only have `BY TARGET`. Dev DB is PG17.9; boot-time guard added (§7).
 
 ### 3.2 Migration scope — all 7 helpers
 
-Per parent spec §7 "ownership_*_current size audit + remediation" and `feedback_no_punting_complete_work` ("default to full scope; no multiple-choice"). Uniform pattern, single lint guard, no tech-debt followups. Tiny tables get preventive fix at near-zero cost.
+Per parent spec §7 "ownership_*_current size audit + remediation" and `feedback_no_punting_complete_work` ("default to full scope; no multiple-choice"). Uniform pattern, single lint guard, no tech-debt followups. The 5 small-table helpers (insiders/blockholders/treasury/def14a/esop) get preventive fix at near-zero cost — their bespoke filters are pinned by lint invariants per-helper so 7-helper scope does not import 5 unaudited bespoke semantics (Codex 1a MED-7).
+
+### 3.3 Watermark contract — separate `ownership_refresh_state` side-table
+
+**New table** breaks the conflation between "_current's last-write timestamp" (storage-layer concern) and "repair-sweep drift watermark" (consumer concern).
+
+```sql
+-- sql/163_ownership_refresh_state.sql
+CREATE TABLE IF NOT EXISTS ownership_refresh_state (
+    instrument_id                            BIGINT      NOT NULL,
+    category                                 TEXT        NOT NULL CHECK (category IN (
+        'insiders', 'institutions', 'blockholders', 'treasury', 'def14a', 'funds', 'esop'
+    )),
+    last_drained_observations_max_ingested_at TIMESTAMPTZ,
+    last_refresh_attempted_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (instrument_id, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_refresh_state_category
+    ON ownership_refresh_state (category, last_drained_observations_max_ingested_at);
+```
+
+- `last_drained_observations_max_ingested_at` is the **drift watermark** — set by each `refresh_X_current` call to the `MAX(ingested_at)` over `ownership_X_observations` for the instrument as of refresh time. NULL means "never drained" → repair sweep picks it up.
+- `last_refresh_attempted_at` records the most recent refresh call (whether MERGE wrote rows or not). Operator-visible "did we run". Not used by sweep predicate; useful for ops dashboards.
+- PK `(instrument_id, category)` keeps the table at ≤ 7 × 12,417 = ~87k rows. UPSERT-only writer with no row growth past the cap → bloat surface tiny + autovacuum-manageable.
+
+**Migration backfill** is in the same SQL file: for each existing `_current` row populate `ownership_refresh_state` with `last_drained_observations_max_ingested_at = _current.refreshed_at`, `last_refresh_attempted_at = _current.refreshed_at`. This avoids a "first sweep post-deploy storm" where every instrument looks un-drained — backfill carries the existing watermark forward verbatim. Migration runs inside one tx; idempotent via `ON CONFLICT (instrument_id, category) DO NOTHING`.
+
+**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py):
+
+```sql
+-- Before (current):
+SELECT c.instrument_id FROM ownership_X_current c
+WHERE c.refreshed_at < (SELECT MAX(o.ingested_at) FROM ownership_X_observations o WHERE o.instrument_id = c.instrument_id)
+GROUP BY c.instrument_id;
+
+-- After (PR12):
+SELECT s.instrument_id FROM ownership_refresh_state s
+LEFT JOIN LATERAL (
+    SELECT MAX(o.ingested_at) AS obs_max
+    FROM ownership_X_observations o
+    WHERE o.instrument_id = s.instrument_id
+) sub ON TRUE
+WHERE s.category = %s
+  AND (s.last_drained_observations_max_ingested_at IS NULL
+       OR sub.obs_max IS NOT NULL AND sub.obs_max > s.last_drained_observations_max_ingested_at);
+```
+
+Plus a tail clause that catches the new case "instrument has observations but no state row" (only fires until backfill stabilises; safe to keep as defence-in-depth):
+
+```sql
+UNION
+SELECT DISTINCT o.instrument_id FROM ownership_X_observations o
+LEFT JOIN ownership_refresh_state s ON s.instrument_id = o.instrument_id AND s.category = %s
+WHERE o.known_to IS NULL AND s.instrument_id IS NULL;
+```
 
 ## 4. Writer rewrite
 
-Each helper becomes one MERGE statement inside the existing transaction + advisory lock. Template (`ownership_funds_current` shown; per-helper differences in PK / DISTINCT ON / column list only):
+Each helper becomes one MERGE statement + one UPSERT into `ownership_refresh_state`, inside the existing transaction + advisory lock. Template (`ownership_funds_current` shown; per-helper differences in §4.1):
 
 ```python
 def refresh_funds_current(conn: psycopg.Connection[Any], *, instrument_id: int) -> int:
-    """Deterministically reconcile ``ownership_funds_current`` rows for
-    one instrument from its observations.
+    """Diff-aware MERGE reconciler for ``ownership_funds_current``.
 
-    Diff-aware MERGE: UPDATE only when business columns IS DISTINCT FROM
-    the new set; INSERT new rows; DELETE rows that fall out of the
-    latest set (NOT MATCHED BY SOURCE scope-clamped to this instrument).
-    refreshed_at is excluded from the diff predicate so idempotent
-    re-runs do not manufacture dead tuples (PR12 fix for the
-    ownership_funds_current bloat surfaced post-PR11)."""
+    UPDATE only when business columns IS DISTINCT FROM the new set;
+    INSERT new rows; DELETE rows that fall out of the latest set
+    (NOT MATCHED BY SOURCE scoped via the ON clause to this instrument).
+    refreshed_at advances on the UPDATE path only; the operator-visible
+    drift watermark for repair-sweep lives in ownership_refresh_state
+    (#1233 PR12 — separates write-side dead-tuple budget from watermark
+    semantics so no-op refreshes do not trigger forever-loops in the
+    repair sweep)."""
     with conn.transaction(), conn.cursor() as cur:
         cur.execute(
             """
@@ -142,7 +204,7 @@ def refresh_funds_current(conn: psycopg.Connection[Any], *, instrument_id: int) 
                     period_end DESC,
                     source_document_id ASC
             ) AS src
-            ON tgt.instrument_id = src.instrument_id
+            ON tgt.instrument_id = %(iid)s
                AND tgt.fund_series_id = src.fund_series_id
             WHEN MATCHED AND (
                 tgt.fund_series_name, tgt.fund_filer_cik, tgt.ownership_nature,
@@ -186,6 +248,24 @@ def refresh_funds_current(conn: psycopg.Connection[Any], *, instrument_id: int) 
             {"iid": instrument_id},
         )
         cur.execute(
+            """
+            INSERT INTO ownership_refresh_state (
+                instrument_id, category,
+                last_drained_observations_max_ingested_at, last_refresh_attempted_at
+            )
+            SELECT
+                %(iid)s,
+                'funds',
+                (SELECT MAX(ingested_at) FROM ownership_funds_observations
+                 WHERE instrument_id = %(iid)s AND known_to IS NULL),
+                now()
+            ON CONFLICT (instrument_id, category) DO UPDATE SET
+                last_drained_observations_max_ingested_at = EXCLUDED.last_drained_observations_max_ingested_at,
+                last_refresh_attempted_at = EXCLUDED.last_refresh_attempted_at
+            """,
+            {"iid": instrument_id},
+        )
+        cur.execute(
             "SELECT COUNT(*) FROM ownership_funds_current WHERE instrument_id = %s",
             (instrument_id,),
         )
@@ -193,118 +273,154 @@ def refresh_funds_current(conn: psycopg.Connection[Any], *, instrument_id: int) 
         return int(row[0]) if row else 0
 ```
 
-### 4.1 Per-helper differences
+### 4.1 Per-helper differences (load-bearing — Codex 1a HIGH-3)
 
-| Helper | PK | DISTINCT ON | Notes |
-| --- | --- | --- | --- |
-| `refresh_insiders_current` | `(instrument_id, holder_identity_key, ownership_nature)` | `(holder_identity_key, ownership_nature)` | Keeps cross-source priority CASE chain in `ORDER BY` (Form 4 > Form 3 > 13D/G > DEF14A > 13F > N-PORT/N-CSR > XBRL DEI > 10-K note > FINRA SI). |
-| `refresh_institutions_current` | `(instrument_id, filer_cik, ownership_nature, exposure_kind)` | `(filer_cik, ownership_nature, exposure_kind)` | Three-tuple grouping preserves EQUITY/PUT/CALL split. |
-| `refresh_blockholders_current` | `(instrument_id, reporter_cik, ownership_nature)` | `(reporter_cik, ownership_nature)` | Per-helper ORDER BY preserved. |
-| `refresh_def14a_current` | `(instrument_id, holder_name_key, ownership_nature)` | `(holder_name_key, ownership_nature)` | Existing legacy-ESOP exclusion in USING WHERE preserved. |
-| `refresh_esop_current` | `(instrument_id, plan_name)` | `(plan_name)` | Smallest column list. |
-| `refresh_treasury_current` | `(instrument_id)` | `(instrument_id)` | Single-row-per-instrument table; MERGE still applies but DELETE branch fires only on shrinkage. |
-| `refresh_funds_current` | `(instrument_id, fund_series_id)` | `(fund_series_id)` | Template above. |
+| Helper | PK | DISTINCT ON | Extra WHERE filter | ORDER BY | category literal |
+| --- | --- | --- | --- | --- | --- |
+| `refresh_insiders_current` | `(instrument_id, holder_identity_key, ownership_nature)` | `(holder_identity_key, ownership_nature)` | (none) | `holder_identity_key, ownership_nature, <source-priority CASE> ASC, period_end DESC, filed_at DESC, source ASC, source_document_id ASC` | `'insiders'` |
+| `refresh_institutions_current` | `(instrument_id, filer_cik, ownership_nature, exposure_kind)` | `(filer_cik, ownership_nature, exposure_kind)` | (none) | `filer_cik, ownership_nature, exposure_kind, period_end DESC, filed_at DESC, source_document_id ASC` | `'institutions'` |
+| `refresh_blockholders_current` | `(instrument_id, reporter_cik, ownership_nature)` | `(reporter_cik, ownership_nature)` | (none) | `reporter_cik, ownership_nature, filed_at DESC, period_end DESC, source_document_id ASC` | `'blockholders'` |
+| `refresh_treasury_current` | `(instrument_id)` | `(instrument_id)` | `AND treasury_shares IS NOT NULL` | `instrument_id, period_end DESC, filed_at DESC, source_document_id ASC` | `'treasury'` |
+| `refresh_def14a_current` | `(instrument_id, holder_name_key, ownership_nature)` | `(holder_name_key, ownership_nature)` | `AND shares IS NOT NULL AND holder_role IS DISTINCT FROM 'esop' AND holder_name !~* %s (_ESOP_HOLDER_NAME_SQL_REGEX)` | `holder_name_key, ownership_nature, period_end DESC, filed_at DESC, source_document_id ASC` | `'def14a'` |
+| `refresh_funds_current` | `(instrument_id, fund_series_id)` | `(fund_series_id)` | (none) | `fund_series_id, filed_at DESC, period_end DESC, source_document_id ASC` | `'funds'` |
+| `refresh_esop_current` | `(instrument_id, plan_name)` | `(plan_name)` | (none) | `plan_name, filed_at DESC, period_end DESC, source_document_id ASC` | `'esop'` |
 
-### 4.2 Diff-predicate column list contract
+The insiders source-priority `CASE source WHEN 'form4' THEN 1 WHEN 'form3' THEN 2 ... END ASC` chain is preserved verbatim from current code (Form 4 > Form 3 > 13D > 13G > DEF14A > 13F > N-PORT/N-CSR > XBRL DEI > 10-K note > FINRA SI). The chain is part of insiders' ORDER BY clause inside the MERGE's USING subquery — no behavioural change vs today.
 
-`refreshed_at` is **excluded** from the `IS DISTINCT FROM` tuples on both sides. Including it would defeat the no-op optimisation — `now()` on the source side always differs from the stored value, every MATCHED row would re-fire UPDATE, dead tuples back to N per call.
+### 4.2 Diff-predicate column-list contract (Codex 1a MED-2)
 
-`refreshed_at` is **set** in the UPDATE SET clause when the WHEN MATCHED + DISTINCT predicate fires. When business columns are unchanged, the row is skipped entirely → `refreshed_at` stays at the prior pass's value. Operator-visible semantics: `refreshed_at` advances only when an actual business-data change lands, not on every refresh attempt.
+The `IS DISTINCT FROM` tuple lists on LHS and RHS must contain **exactly the same column names** in the same order; they must contain **every non-PK column** that appears in the UPDATE SET clause; they must **not** contain `refreshed_at`; they must **not** contain PK columns (PK columns are matched by the ON clause; the diff predicate covers business cols only).
 
-INSERT branch omits `refreshed_at` → column `DEFAULT now()` fires.
+Mechanical contract that lint invariant E + L pin:
 
-### 4.3 Scope clamp — load-bearing
+- LHS tuple cols ≡ RHS tuple cols (set equality + ordering)
+- LHS tuple cols ⊆ UPDATE SET targets ∪ {PK cols} (every diff col gets written if UPDATE fires)
+- UPDATE SET targets ≡ LHS tuple cols ∪ {`refreshed_at`} (UPDATE writes diff cols + refreshed_at, nothing else)
+- `refreshed_at` ∉ LHS, `refreshed_at` ∉ RHS
+- PK cols ∉ LHS, PK cols ∉ RHS
 
-`WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %(iid)s THEN DELETE` is the per-instrument scope clamp. Without the `AND tgt.instrument_id = %(iid)s` predicate, MERGE walks the **entire target table** and DELETEs every row not in the (single-instrument) source — catastrophic global data loss. Pinned by lint invariant D (§5). Also pinned at runtime by the **scope clamp** test case (§6).
+Operator-visible semantic: `refreshed_at` advances IFF business cols changed. The drift watermark for repair sweep is in `ownership_refresh_state.last_drained_observations_max_ingested_at` (§3.3), which always advances on every refresh attempt — no longer overloaded with the "did we attempt this" signal.
 
-### 4.4 Concurrency
+### 4.3 Scope clamp on ON clause + DELETE branch (Codex 1a HIGH-2 + HIGH-4)
 
-Per-instrument `pg_advisory_xact_lock` serialises concurrent refreshes for the same `(helper, instrument_id)` pair. Disjoint instrument refreshes run in parallel; PG MERGE takes row-level locks on the rows it touches → disjoint instrument_id rows do not block each other. Transaction wraps the MERGE so a failure rolls back both the advisory lock acquisition and any partial MERGE writes.
+The ON clause carries `tgt.instrument_id = %(iid)s` as a const predicate on target (NOT `tgt.instrument_id = src.instrument_id`). This lets the planner restrict target-side rows to the instrument's PK-index slice instead of considering the whole target table for `WHEN NOT MATCHED BY SOURCE` anti-join.
 
-## 5. Lint guard
+The `WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %(iid)s THEN DELETE` clause keeps the clamp as **defence-in-depth** — if a future refactor relaxes the ON clause to `tgt.instrument_id = src.instrument_id`, the NOT-MATCHED-BY-SOURCE branch still cannot DELETE rows from other instruments. Lint invariant D pins **both** clamps (ON-clause + DELETE-clause) by exact literal string `tgt.instrument_id = %(iid)s` — no substring tolerance, no `IS NOT NULL` decoy (Codex 1a HIGH-4).
 
-New script: [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh). Wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after PR11's `check_13dg_retention.sh`.
+### 4.4 Concurrency contract (Codex 1a MED-5)
 
-Awk-based function-body block walker (PR4 Codex 1c lesson) so reformatting cannot trip the guard; empty-grep `wc -l` guards (PR10a Codex iter 1 lesson) so missing-anchor doesn't silently pass.
+- `pg_advisory_xact_lock(hashtextextended('refresh_X_current', 0) # instrument_id::bigint)` serialises **same-helper, same-instrument** refresh calls. Cross-helper or cross-instrument calls do not contend on the lock.
+- The MERGE runs inside `with conn.transaction()` so the advisory lock + the MERGE writes + the `ownership_refresh_state` UPSERT all share one transaction; failure of any step rolls back the lot.
+- Default isolation is **READ COMMITTED**. The USING subquery sees observations committed before the MERGE's snapshot; observations committed during the MERGE call do NOT appear until the next refresh. This matches today's DELETE+INSERT semantics (the SELECT-into-INSERT step also uses READ COMMITTED).
+- Concurrent **observation writers** (record_*_observation called from a sibling code path) do not block on the advisory lock. They may commit between the lock acquisition and the MERGE's source-subquery scan; the MERGE will see whatever was committed at scan time. The repair-sweep predicate (§3.3) catches any obs writes that committed after the most recent refresh — that is the whole point of the watermark.
+- PG MERGE takes row-level locks on matched/updated target rows + the locks released at COMMIT. Concurrent same-instrument refreshes (advisory lock contention) → serialised. Concurrent different-instrument refreshes → row-level locks are disjoint by PK; no contention.
 
-Per helper (×7: `insiders / institutions / blockholders / treasury / def14a / funds / esop`):
+## 5. Lint guard (expanded — 7 helpers × 12 invariants = 84 checks)
 
-| Invariant | What it pins | How |
+New script: [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh). Wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after PR11's `check_13dg_retention.sh`. Awk-based function-body block walker (PR4 Codex 1c lesson); every grep guarded against empty-input by exact-count assertion (PR10a Codex iter 1 lesson).
+
+Per helper (×7):
+
+| Invariant | What it pins | Mechanism |
 | --- | --- | --- |
 | **A** | Helper defined exactly once in `app/services/ownership_observations.py` | grep `^def refresh_<X>_current\(` → count == 1 |
-| **B** | No legacy `DELETE FROM ownership_<X>_current` inside helper body | awk-extract body span `def refresh_<X>_current` → next `^def `; grep inside → count == 0 |
+| **B** | No legacy `DELETE FROM ownership_<X>_current` inside helper body | awk-extract body span; grep → count == 0 |
 | **C** | `MERGE INTO ownership_<X>_current AS tgt` opener present | grep inside body span → count == 1 |
-| **D** | `WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id` clamp present (catastrophic data-loss class) | grep inside body span → count == 1 |
-| **E** | `refreshed_at` NOT inside diff predicate's `IS DISTINCT FROM` tuples | awk-extract span from `WHEN MATCHED AND (` to `) THEN UPDATE`; grep inside → count == 0 |
+| **D** | Scope-clamp pinned by exact literal `tgt.instrument_id = %(iid)s` in **both** the ON clause and the NOT-MATCHED-BY-SOURCE DELETE clause | grep literal `tgt.instrument_id = %(iid)s` inside body span → count == 2 (one in ON, one in DELETE) |
+| **E** | `refreshed_at` NOT inside diff predicate's `IS DISTINCT FROM` tuples (either side) | awk-extract span from `WHEN MATCHED AND (` to `) THEN UPDATE`; grep → count == 0 |
 | **F** | `pg_advisory_xact_lock` preserved on function-namespace hash | grep `hashtextextended\('refresh_<X>_current'` inside body → count == 1 |
-| **G** | DISTINCT ON columns match per-helper expected tuple | grep `DISTINCT ON \(<expected cols>\)` inside body → count == 1 |
+| **G** | DISTINCT ON columns match per-helper expected tuple | grep literal `DISTINCT ON (<expected cols>)` inside body → count == 1 |
+| **H** | ORDER BY tuple matches per-helper expected list (whitespace-normalised) | awk-extract `ORDER BY` block; collapse whitespace; compare against per-helper expected string → equal |
+| **I** | UPDATE SET clause writes every non-PK business column AND `refreshed_at` (parity with diff tuples) | awk-extract UPDATE SET block; collect column names; assert set == diff-tuple-cols ∪ {refreshed_at} |
+| **J** | INSERT clause omits exactly `refreshed_at` from column list (DEFAULT now() fires) | awk-extract INSERT column list; assert `refreshed_at` ∉ list; assert set ≡ all-non-PK-cols ∪ {PK cols} |
+| **K** | Per-helper extra WHERE filter literal present inside USING subquery (e.g. treasury `AND treasury_shares IS NOT NULL`; def14a 3-clause ESOP filter) — see §4.1 column "Extra WHERE filter" | grep per-helper literal inside body span → count == 1 (or 0 for helpers with no extra filter; per-helper expected count) |
+| **L** | Helper UPSERTs into `ownership_refresh_state` with the matching category literal | grep `INSERT INTO ownership_refresh_state` inside body span → count == 1 AND grep `'<expected category>'` inside same block → count == 1 |
 
-7 helpers × 7 invariants = 49 checks. Pure text walk, no DB dependency, sub-second runtime.
+7 helpers × 12 invariants = **84 per-helper checks**.
 
-Lint also audits the **legacy `DELETE FROM ownership_*_current`** pattern anywhere under `app/` (outside the 7 helper bodies) — count == 0. Catches a future regression where a sibling service tries to inline its own DELETE+INSERT against `_current`.
+Plus 4 cross-cutting checks:
 
-## 6. Tests
+| Invariant | What it pins | Mechanism |
+| --- | --- | --- |
+| **M** | No `DELETE FROM ownership_*_current` anywhere under `app/` outside the 7 helper bodies | grep across `app/**/*.py` minus the 7 helper bodies → count == 0 |
+| **N** | No `DELETE FROM ownership_*_current` anywhere under `scripts/` and `app/jobs/` (catches future writers landing outside `app/services/`) | grep across both trees → count == 0 |
+| **O** | `ownership_observations_repair.py` predicate references `ownership_refresh_state.last_drained_observations_max_ingested_at` (not legacy `c.refreshed_at < ...` form) | grep `c.refreshed_at <` → count == 0 inside the repair file |
+| **P** | Migration `sql/163_ownership_refresh_state.sql` exists and creates the table with the documented PK and CHECK constraint | targeted grep |
 
-New file: [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py). 5 cases × 7 helpers = 35 parametrised cases.
+Total: **88 lint checks** (84 per-helper + 4 cross-cutting). Pure text walk, no DB dependency, sub-second runtime.
 
-`pg_stat_user_tables` rejected as the no-op-churn assertion source (async stats-collector flush has several-hundred-ms lag → flaky). Switched to `pgstattuple` + `xmin` per row.
+## 6. Tests (expanded — 7 helpers × 8 cases = 56 cases + cross-helper + cross-sweep)
 
-| Case | Setup | Action | Assertion |
-| --- | --- | --- | --- |
-| **insert** | empty `_current` for instrument; write 1 observation | `refresh_X_current(conn, instrument_id=I)` | row present; `SELECT xmin FROM _current WHERE instrument_id=I` returns a fresh xid |
-| **no-op churn** | row present from prior refresh; no observation change; capture `xmin0` + `pgstattuple(table).{table_len, tuple_count}` | `refresh_X_current(I)` again | `xmin == xmin0` (row not rewritten); `pgstattuple(table).table_len` unchanged; `dead_tuple_count` delta == 0 — **load-bearing; proves the bloat fix** |
-| **update (amendment)** | row present `xmin0`; insert later-`filed_at` observation, same PK, different `shares` | refresh | row present; `xmin > xmin0`; `shares` reflects amendment; `refreshed_at > refreshed_at0` |
-| **delete (`known_to` expiry)** | row present; `UPDATE _observations SET known_to = now() WHERE …` | refresh | row absent |
-| **scope clamp** | rows present for instrument A and instrument B; capture B's `xmin0` | `refresh_X_current(I=A)` with no observation change | B's row still present; B's `xmin == xmin0`. **Pins `AND tgt.instrument_id = %s` SOURCE clamp** |
+New file: [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py). Parametrised over the 7 helpers.
 
-`refreshed_at` invariants:
-- **no-op churn**: `refreshed_at` unchanged post-refresh (proves diff-predicate excludes it).
-- **update**: `refreshed_at` advances (proves UPDATE SET sets it).
+`pg_stat_user_tables` rejected as the no-op-churn assertion source (async stats-collector flush has multi-100ms lag → flaky). Switched to per-row `xmin` comparisons + `pgstattuple` for the load-bearing no-op-churn case. Per Codex 1a MED-1: every `xmin` comparison is **equality / inequality** (`xmin::text != xmin0::text`), never ordering (xid is not monotonic-comparable; wraparound + xid8 semantics make `>` wrong).
 
-`pgstattuple` requires `CREATE EXTENSION` — [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisioning gains the extension. Single edit; inherited by every per-worker DB via template clone (#893 architecture).
+| # | Case | Setup | Action | Assertion |
+| --- | --- | --- | --- | --- |
+| 1 | **insert** | empty `_current` for instrument I; write 1 observation | `refresh_X_current(I)` | row present; row's `xmin` is a fresh xid (not the pre-call xid) |
+| 2 | **no-op churn** | row present from prior refresh; no observation change; capture per-row `xmin0` + `pgstattuple(table).{table_len, tuple_count, dead_tuple_count}` | `refresh_X_current(I)` again | per-row `xmin::text == xmin0::text` (no rewrite); `pgstattuple.table_len` unchanged; `pgstattuple.dead_tuple_count` delta == 0; `_current.refreshed_at` unchanged (proves diff-predicate excludes it). **Load-bearing for primary bloat fix.** |
+| 3 | **update (amendment)** | row present `xmin0`, refreshed_at0; insert later-`filed_at` observation, same PK, different `shares` | refresh | row present; per-row `xmin::text != xmin0::text`; `shares` reflects amendment; `refreshed_at > refreshed_at0` (advances on actual diff). |
+| 4 | **delete (`known_to` expiry)** | row present; `UPDATE _observations SET known_to = now() WHERE …` | refresh | row absent (NOT MATCHED BY SOURCE → DELETE fired). |
+| 5 | **scope clamp** | rows present for instruments A and B; capture B's per-row `xmin0` | `refresh_X_current(A)` with no observation change | B's row present; B's per-row `xmin::text == xmin0::text` (other-instrument rows untouched). **Pins the literal `tgt.instrument_id = %(iid)s` clamp in ON clause + DELETE clause.** |
+| 6 | **priority-chain regression (insiders only)** | write 2 observations same `(holder_identity_key, ownership_nature)`: source='form4' (priority 1) + source='13d' (priority 3); equal period_end + filed_at | refresh | `_current.source == 'form4'` (priority chain unchanged). Pins the cross-source `CASE source WHEN ... ASC` ORDER BY chain (lint invariant H + runtime). |
+| 7 | **per-helper filter regression** | (a) **treasury**: write 1 obs with `treasury_shares=NULL` AND 1 obs with `treasury_shares=12345` same period; (b) **def14a**: write 1 obs `holder_role='esop'`, 1 obs `holder_role='principal' AND holder_name ILIKE '%ESOP%'`, 1 obs `holder_role='principal' AND holder_name='Vanguard'` | refresh | (a) `_current.treasury_shares == 12345` (NULL-displacement guard works); (b) `_current` row count == 1; only the Vanguard row survives (ESOP regex + holder_role='esop' both excluded). |
+| 8 | **repair-sweep no-loop** | row present in `_current` + `ownership_refresh_state`; UPSERT same obs row (DO UPDATE clause bumps `obs.ingested_at`); refresh fires (no diff → MERGE no-op) | run `_drifted_instruments` again with the new predicate | empty list (state-table watermark advanced; sweep no longer re-selects). **Pins the §3.3 watermark fix end-to-end.** |
+
+Total: 5 base cases × 7 helpers = 35 + 1 priority-chain (insiders) + 2 filter-regression (treasury + def14a) + 7 repair-sweep no-loop (all helpers) = **45 parametrised cases**, with helper-specific cases on top.
+
+**Extension provisioning + CI fail-loud** (Codex 1a MED-6): [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisioning gains `CREATE EXTENSION IF NOT EXISTS pgstattuple`. If the extension is missing at test time, the no-op-churn case fails loudly with a dedicated error message (`pytest.fail(f"pgstattuple extension missing in {db_name} — provisioning bug, do NOT skip")`) instead of skipping. CI provisioning step explicitly asserts the extension is present after template clone.
 
 ## 7. Postgres version guard
 
-`MERGE WHEN NOT MATCHED BY SOURCE` requires PG ≥ 17. Without a boot-time guard, a PG16 deployment would pass lint and crash at first refresh with `syntax error at or near "BY"`.
+`MERGE WHEN NOT MATCHED BY SOURCE` requires PG ≥ 17. Without a boot-time guard, a PG < 17 deployment would pass lint and crash at first refresh with `syntax error at or near "BY"`.
 
 Mirror #1187's `max_locks_per_transaction` boot pattern. New cross-cutting check at lifespan startup — either extends [`app/main.py`](../../../app/main.py) lifespan or sits as a sibling in `app/system/postgres_health.py`. Assertion: `SELECT current_setting('server_version_num')::int >= 170000`. Fail-closed: refuse to boot under PG < 17. Smoke test `tests/smoke/test_app_boots.py` exercises lifespan → guard gated by the pre-push smoke gate.
 
-Single-fact assertion; cross-cutting; minimal blast radius.
+Single-fact assertion; cross-cutting; minimal blast radius. PR description explicitly calls out that PG16 deployments will hard-fail at boot post-merge (Codex 1a LOW-1).
 
 ## 8. Operator semantics
 
-PR12 ships the **writer**. It does NOT shrink the pre-existing dead space:
+**Pre-existing dead space**: PR12 ships the **writer**. It does NOT shrink the pre-existing dead space:
+
 - `ownership_funds_current` heap stays at 2080 MB post-merge.
 - `ownership_institutions_current` heap stays at 376 MB post-merge.
 - `GET /system/postgres-health` (Phase 4 of #1208) continues to report `db_size ≈ 41 GB` until the §6.3 operator pre-wipe.
 
-Reclaim path is the **operator pre-wipe + clean re-run** (parent spec §6.3 + §8 acceptance). PR12's contribution is ensuring the clean re-run does not re-bloat the new write-through pattern.
+Reclaim path is the **operator pre-wipe + clean re-run** (parent spec §6.3 + §8 acceptance). PR12's contribution is ensuring the clean re-run does not re-bloat the new write-through pattern AND that the repair sweep stays cheap on healthy installs.
 
-No `DELETE FROM ownership_*_current` lands in this PR. The MERGE's `WHEN NOT MATCHED BY SOURCE THEN DELETE` is steady-state writer behaviour identical to today's DELETE+INSERT (a row drops out of `_current` only when its only observation expires via `known_to` or when caps shed it post-wipe). Read-side `_current` consumers see no behavioural change — same row shapes, same dedup ordering, same priorities, same indexes.
+**Lock / downtime cost of the operator pre-wipe** (Codex 1a LOW-2 — restated honestly): the parent spec's §6.3 pre-wipe is `TRUNCATE` of every observations + `_current` + `ownership_refresh_state` table. `TRUNCATE` takes an `ACCESS EXCLUSIVE` lock per table → all SELECT/INSERT/UPDATE traffic blocks for the truncate window. Dev DB at 43 GB the operation is typically <30s. Production-grade deployments would need a maintenance window — out of scope here (dev-DB-only operation by design).
+
+**Read-side unchanged**: no `_current` consumer sees behavioural change. Same row shapes, same dedup ordering, same priorities, same indexes. The MERGE's `WHEN NOT MATCHED BY SOURCE THEN DELETE` is steady-state writer behaviour identical to today's DELETE+INSERT (a row drops out of `_current` only when its only observation expires via `known_to` or when caps shed it post-wipe).
+
+**Sweep cost**: repair sweep stays at "<100ms on healthy install" — the watermark predicate now reflects "have we drained these observations" rather than "did we touch this row", so no-op refreshes do not re-trigger.
 
 ## 9. Definition of done
 
 CLAUDE.md §"Definition of done" + §"ETL / parser / schema-migration additional clauses" both apply.
 
-1. 7 `refresh_*_current` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py) rewritten to single-statement MERGE per §4 template. Signature `(conn, *, instrument_id) -> int` preserved.
-2. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (49 checks: 7 helpers × 7 invariants A-G) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
-3. [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py) — 35 parametrised cases. Load-bearing no-op-churn case uses `xmin` + `pgstattuple`.
-4. [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisions `pgstattuple` extension.
-5. Boot-time PG ≥ 17 guard at lifespan (mirror #1187 pattern). Pinned by `tests/smoke/test_app_boots.py`.
-6. Smoke verification against AAPL / GME / MSFT / JPM / HD (CLAUDE.md panel) — for each instrument, call `refresh_funds_current` and `refresh_institutions_current` twice in succession; assert `pgstattuple.table_len` delta == 0 + `xmin` stability per row across the second call. PR description records each instrument's outcome and the commit SHA per CLAUDE.md ETL clause 12.
-7. Parent spec amendment — [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 + §4.6 + §7 + §8 updated: PR12 status flipped to SHIPPED, writer-pattern documented, Phase 2 (`<15 GB hot`) acceptance unblocked.
-8. New prevention-log entry — "MERGE WHEN NOT MATCHED BY SOURCE must carry the per-scope `AND tgt.<scope_col> = %(scope)s` clamp" (catastrophic data-loss class).
-9. Data-engineer skill update ([`.claude/skills/data-engineer/SKILL.md`](../../../.claude/skills/data-engineer/SKILL.md) + memory) — write-through section gains "diff-aware MERGE replaces DELETE+INSERT" rule + lint-guard pointer.
-10. Codex 2 pre-push green; bot review APPROVE on latest commit; CI green; merge.
+1. 7 `refresh_*_current` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py) rewritten to single-statement MERGE + `ownership_refresh_state` UPSERT per §4 template + §4.1 per-helper differences. Signature `(conn, *, instrument_id) -> int` preserved on every helper.
+2. New migration `sql/163_ownership_refresh_state.sql` creates the table with the schema in §3.3, plus an idempotent backfill from existing `_current.refreshed_at`. Runs inside the standard migration runner; no `-- runner: autocommit` directive required (no ALTER SYSTEM / CREATE DATABASE / VACUUM / REINDEX SYSTEM).
+3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form (state-table watermark with LATERAL obs-MAX subquery + UNION defence-in-depth tail clause).
+4. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (88 checks: 7 × 12 per-helper + 4 cross-cutting) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
+5. [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py) — parametrised over 7 helpers × 5 base cases + insiders priority-chain + treasury null guard + def14a ESOP exclusion + 7 repair-sweep no-loop cases. Load-bearing no-op-churn case uses per-row `xmin::text` equality + `pgstattuple`.
+6. [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisions `pgstattuple` extension; failure to provision triggers `pytest.fail` in no-op-churn case (no silent skips).
+7. Boot-time PG ≥ 17 guard at lifespan (mirror #1187 pattern). Pinned by `tests/smoke/test_app_boots.py`.
+8. Smoke verification against AAPL / GME / MSFT / JPM / HD (CLAUDE.md panel) post-merge: for each instrument, call `refresh_funds_current` and `refresh_institutions_current` twice in succession; assert `pgstattuple.table_len` delta == 0 + per-row `xmin::text` stability across the second call. Additionally call `refresh_treasury_current` and `refresh_def14a_current` for at least one instrument each to exercise the small-table helpers + their per-helper filters (Codex 1a LOW-4). PR description records each instrument's outcome and the commit SHA per CLAUDE.md ETL clause 12.
+9. Parent spec amendment — [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 + §4.6 + §7 + §8 updated: PR12 status flipped to SHIPPED, writer-pattern + watermark side-table documented, Phase 2 (`<15 GB hot`) acceptance unblocked.
+10. New prevention-log entries:
+    - "MERGE WHEN NOT MATCHED BY SOURCE must carry the per-scope `AND tgt.<scope_col> = %(scope)s` clamp on BOTH the ON clause AND the DELETE clause (lint pins both literals)" — catastrophic data-loss class.
+    - "Diff-aware writers (MERGE … IS DISTINCT FROM) MUST NOT include the `refreshed_at`-style update-timestamp column in the diff predicate — drift watermarks belong in a separate side-table". Includes the forever-loop failure mode discovered in PR12 Codex 1a.
+11. Data-engineer skill update ([`.claude/skills/data-engineer/SKILL.md`](../../../.claude/skills/data-engineer/SKILL.md) + memory) — write-through section gains "diff-aware MERGE replaces DELETE+INSERT" rule + watermark side-table pointer + lint-guard pointer.
+12. Codex 2 pre-push green; bot review APPROVE on latest commit; CI green; merge.
 
 ## 10. Acceptance — cross-reference to parent spec §8
 
-PR12 alone does not move the post-merge dev DB size (per §8 above). Acceptance is measured AFTER the operator-driven §6.3 pre-wipe + clean re-run, which lands the bounded set under all PR1-PR12 caps.
+PR12 alone does not move the post-merge dev DB size (per §8 above). Acceptance is measured AFTER the operator-driven §6.3 pre-wipe + clean re-run.
 
 Per parent spec §8 acceptance tiers:
 
-- **v1 bar (`<20 GB hot`)** — PR12 audit complete (this spec) + writer remediation merged + pre-wipe + clean re-run lands `ownership_funds_current + ownership_institutions_current` somewhere in the original 5.3 GB ballpark (writer fix alone, no cap shrinkage on either source — per spec §4.5 and §4.6 the observations caps were already shipped via PR6 + PR7). Acceptable.
-- **Phase 2 stretch (`<15 GB hot`)** — PR12 writer fix + observations caps from PR6/PR7 + clean re-run lands combined `_current` ≤ 1 GB. The 2080 MB → ~250 MB compression on funds_current comes from: (a) 786k live rows × 280 B real-data row width = ~220 MB heap + ~80 MB indexes; (b) zero bloat under diff-aware MERGE. ✅ Phase 2 unblocked by PR12.
+- **v1 bar (`<20 GB hot`)** — PR12 audit complete (this spec) + writer remediation merged + pre-wipe + clean re-run lands `ownership_funds_current + ownership_institutions_current` somewhere in the original 5.3 GB ballpark (Codex 1a LOW-3 — DB-size projections in this spec apply only to the two `_current` tables; other hot tables are governed by their respective PR caps).
+- **Phase 2 stretch (`<15 GB hot`)** — PR12 writer fix + observations caps from PR6/PR7 + clean re-run lands combined `_current` ≤ 1 GB. The 2080 MB → ~250 MB compression on funds_current comes from: (a) 786k live rows × 280 B real-data row width = ~220 MB heap + ~80 MB indexes; (b) zero bloat under diff-aware MERGE; (c) repair sweep no longer triggers redundant refreshes that previously fed the bloat. ✅ Phase 2 unblocked by PR12.
 - **Ambitious (`<10 GB hot`)** — requires further `companyfacts` tightening (Phase 3 ticket; out of #1233 scope).
 
 PR12 measurement protocol post pre-wipe + clean re-run:
@@ -312,21 +428,19 @@ PR12 measurement protocol post pre-wipe + clean re-run:
 ```sql
 SELECT relname, pg_size_pretty(pg_total_relation_size(oid)) AS sz, pg_total_relation_size(oid) AS bytes
 FROM pg_class
-WHERE relname IN ('ownership_funds_current', 'ownership_institutions_current')
+WHERE relname IN ('ownership_funds_current', 'ownership_institutions_current', 'ownership_refresh_state')
 ORDER BY pg_total_relation_size(oid) DESC;
 ```
 
-Plus per-helper pgstattuple to confirm tuple_percent ≥ 70% (healthy density floor).
+Plus per-helper `pgstattuple` to confirm `tuple_percent` ≥ 70% (healthy density floor).
 
 ## 11. Codex review gate
 
 Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 
-- **Codex 1a** on this spec (after first commit on `feature/1233-pr12-design-spec`).
-- Revise per findings.
-- **Codex 1b** on revised spec.
-- Revise.
-- **Codex 1c** if needed.
+- **Codex 1a** on this spec — completed; 5 HIGH + 7 MED + 4 LOW folded into rev 2.
+- **Codex 1b** on rev 2 (after this commit).
+- Codex 1c if needed.
 - Spec lands as DOC PR (no code yet).
 - Implementation plan = separate doc (`docs/superpowers/plans/2026-05-21-pr12-ownership-current-writer-merge-impl.md`). Codex 1a / 1b on the plan.
 - PR12 implementation PR follows standard #1208 cadence: self-review → Codex 2 pre-push → push → bot review → resolve → APPROVE on latest commit → merge.
@@ -336,8 +450,8 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 State at this commit:
 
 - Parent umbrella #1233 still OPEN. PR1-PR11 all SHIPPED (PR11 #1253 020e701 merged 2026-05-21).
-- This is the DESIGN doc for PR12. Implementation has not started.
+- This is the DESIGN doc for PR12 (rev 2 post-Codex 1a).
 - Branch: `feature/1233-pr12-design-spec`.
-- Next: Codex 1a on this spec; revise; Codex 1b; doc PR; then writing-plans skill → implementation plan → execution.
+- Next: Codex 1b on rev 2; revise if needed; doc PR; then writing-plans skill → implementation plan → execution.
 
 After PR12 merges, the operator triggers the §6.3 pre-wipe + clean re-run and #1233 closes per parent spec §8.

--- a/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
+++ b/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
@@ -6,7 +6,7 @@
 >
 > Parent spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 / §4.6 / §6.4 / §7 / §8.
 >
-> Status: **DESIGN (rev 5)** — Codex 1a → rev 2 (5H+7M+4L). Codex 1b → rev 3 (3H+7M+4L). Codex 1c → rev 4 (1H+3M+3L). Codex 1d on rev 4 returned 3 HIGH (backfill from obs MAX MASKS real drift — false-negative regression vs rev 3's false-positive; "<100ms × 87k LATERAL probes" cost math optimistic; orphan UNION tail still scans 3.68M-row funds obs each sweep) + 3 MED (5 of 7 ingested_at indexes already exist in sql/119 — only funds + esop missing; case 9 raw UPDATE on `known_to` doesn't bump `ingested_at`; lint P doesn't pin index/backfill load-bearing semantics) + 1 LOW (non-goal wording stale re: sweep redesign). Rev 5 folds 1d: backfill reverted to `MAX(_current.refreshed_at) GROUP BY instrument_id` (false-positive over false-negative — one extra refresh-storm-during-first-sweep is benign; missed drift is silent staleness, unacceptable); orphan UNION tail DROPPED (state-anchored primary path only; write-through invariant trusted; gap documented as known limitation); "<100ms" hard claim replaced with "sub-second steady state, requires post-impl EXPLAIN ANALYZE"; sql/163 indexes scoped to funds + esop only (avoid sql/119 duplicates); case 9 setup uses explicit `SET ingested_at = clock_timestamp()` in fixture; lint P extended to pin index + backfill shape; non-goal §2 acknowledges sweep changes.
+> Status: **DESIGN (rev 6)** — Codex 1a → rev 2 (5H+7M+4L). Codex 1b → rev 3 (3H+7M+4L). Codex 1c → rev 4 (1H+3M+3L). Codex 1d → rev 5 (3H+3M+1L). Codex 1e on rev 5 returned 0 HIGH + 2 MED + 2 LOW (convergence). MED-1 was the load-bearing one: state-anchored per-row LATERAL `MAX(ingested_at)` against the RANGE-partitioned observations tables fans out to ~84 partitions per probe × ~87k state rows = minutes per sweep — NOT sub-second despite proper indexing (partition pruning by `period_end` doesn't help an `instrument_id` predicate). Rev 6 switches the sweep predicate to an obs-anchored CTE aggregate `MAX(ingested_at) GROUP BY instrument_id` (single full-index scan via Append + IndexScan; ~500ms-2s for funds; deterministically faster than per-row LATERAL fanout). Rev 6 also adds an out-of-band orphan-reconciliation script to DoD (pin the write-through invariant Codex 1e MED-2 flagged); refines first-sweep cost wording to "bounded + measured" (LOW-1); tightens P6 to pin the `MAX(c.refreshed_at)` literal (LOW-2).
 
 ## 0. Status snapshot (2026-05-21 dev DB)
 
@@ -141,7 +141,9 @@ CREATE INDEX IF NOT EXISTS idx_esop_obs_instrument_ingested
     ON ownership_esop_observations (instrument_id, ingested_at DESC);
 ```
 
-These indexes back the LATERAL `MAX(ingested_at)` correlated subquery in the repair-sweep predicate (below). Each lookup becomes an index-only scan returning 1 row — without them, the lookup falls back to per-partition seq-scan + aggregate (tens of seconds on funds at 3.68M obs rows).
+These indexes back the obs-anchored CTE aggregate (below) — a single `GROUP BY instrument_id` over each partitioned observations table. With the index in `(instrument_id, ingested_at DESC)` order PG can perform an index-only `Append + IndexScan` across all partitions and aggregate `MAX(ingested_at)` per instrument efficiently. Without them, the aggregate falls back to per-partition seq-scan + sort (tens of seconds on funds at 3.68M obs rows).
+
+Partition-fanout note (Codex 1e MED-1): the per-row LATERAL form `LEFT JOIN LATERAL (SELECT MAX(ingested_at) FROM obs WHERE instrument_id = s.instrument_id) sub` is *quadratic* in the partition count × state-row count (PG cannot prune partitions by `instrument_id` because partitioning is on `period_end`) — ~84 partitions × ~87k state-row probes is ~minutes per sweep on funds. The CTE-aggregate form (one full-index scan over each partition, materialised once, joined to state) is `O(total_obs_rows / index_block_size)` — sub-second to low-second range on funds. The aggregate form is the load-bearing choice.
 
 **Migration backfill** is in the same SQL file; one INSERT per category, sourced from **`MAX(_current.refreshed_at) GROUP BY instrument_id`** (Codex 1d HIGH-1 — backfilling from `MAX(obs.ingested_at)` would *mask* real drift if `_current` was never reconciled, a silent-staleness regression unacceptable for a safety-net job; backfilling from `_current.refreshed_at` may cause a one-off first-sweep refresh storm against instruments where obs `clock_timestamp()` ran slightly later than refresh-tx `now()`, but every such refresh is a MERGE no-op (the diff predicate skips writes) → benign extra cost, never missed drift):
 
@@ -161,20 +163,21 @@ GROUP BY c.instrument_id
 ON CONFLICT (instrument_id, category) DO NOTHING;
 ```
 
-Operator-visible: the first repair-sweep tick after deploy may select more instruments than steady state due to the tx-time vs clock_timestamp skew, with each selection costing one MERGE no-op (~1ms per instrument under the diff predicate). One-time event; subsequent sweeps return to steady state.
+Operator-visible: the first repair-sweep tick after deploy may select more instruments than steady state due to the tx-time vs clock_timestamp skew. Each false-positive selection costs one MERGE no-op (cost bounded by the diff-predicate skip path; per-call wall clock measured during the §9 DoD #8 smoke pass against the dev DB rather than assumed — Codex 1e LOW-1). One-time event; subsequent sweeps return to steady state.
 
-**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) — **state-anchored single-query** (Codex 1d HIGH-3 — the UNION orphan tail from rev 4 anti-joined observations every sweep, full-table-ish cost on funds even when zero rows matched; dropped in favour of the write-through invariant + a separate operator-driven backfill if drift between obs-existence and state-row-existence is ever discovered):
+**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) — **obs-anchored CTE aggregate** joined to state (Codex 1e MED-1 — the rev 5 state-anchored LATERAL form fanned out over RANGE-partitioned observations and could not be pruned by `instrument_id`; the CTE-aggregate form does ONE full-index scan per sweep tick instead of 87k probe-per-state-row scans):
 
 ```sql
+WITH obs_max AS (
+    SELECT instrument_id, MAX(ingested_at) AS m
+    FROM ownership_X_observations
+    GROUP BY instrument_id
+)
 SELECT s.instrument_id
 FROM ownership_refresh_state s
-LEFT JOIN LATERAL (
-    SELECT MAX(o.ingested_at) AS obs_max
-    FROM ownership_X_observations o
-    WHERE o.instrument_id = s.instrument_id
-) sub ON TRUE
+LEFT JOIN obs_max ON obs_max.instrument_id = s.instrument_id
 WHERE s.category = %s
-  AND s.last_drained_observations_max_ingested_at IS DISTINCT FROM sub.obs_max;
+  AND s.last_drained_observations_max_ingested_at IS DISTINCT FROM obs_max.m;
 ```
 
 NULL semantics on this branch:
@@ -381,7 +384,7 @@ Plus 4 cross-cutting checks:
 | **M** | No `DELETE FROM ownership_*_current` anywhere under `app/` outside the 7 helper bodies | grep across `app/**/*.py` minus the 7 helper bodies → count == 0 |
 | **N** | No `DELETE FROM ownership_*_current` anywhere under `scripts/` and `app/jobs/` (catches future writers landing outside `app/services/`) | grep across both trees → count == 0 |
 | **O** | `ownership_observations_repair.py` predicate references `ownership_refresh_state.last_drained_observations_max_ingested_at` (not legacy `c.refreshed_at < ...` form) | grep `c.refreshed_at <` → count == 0 inside the repair file |
-| **P** | Migration `sql/163_ownership_refresh_state.sql` pins all rev-5 contracts (Codex 1d MED-3): table + indexes + backfill | 7 targeted grep checks against the migration file with exact-count assertions — (P1) `CREATE TABLE IF NOT EXISTS ownership_refresh_state` opener present; (P2) PK is `(instrument_id, category)`; (P3) CHECK lists exactly the 7 category literals; (P4) `CREATE INDEX IF NOT EXISTS idx_funds_obs_instrument_ingested` present; (P5) `CREATE INDEX IF NOT EXISTS idx_esop_obs_instrument_ingested` present; (P6) backfill source shape `FROM ownership_X_current c GROUP BY c.instrument_id` (not from observations MAX); (P7) backfill repeated 7 times (one per category). |
+| **P** | Migration `sql/163_ownership_refresh_state.sql` pins all rev-6 contracts (Codex 1d MED-3 + Codex 1e LOW-2): table + indexes + backfill + literal aggregate expression | 7 targeted grep checks against the migration file with exact-count assertions — (P1) `CREATE TABLE IF NOT EXISTS ownership_refresh_state` opener present; (P2) PK is `(instrument_id, category)`; (P3) CHECK lists exactly the 7 category literals; (P4) `CREATE INDEX IF NOT EXISTS idx_funds_obs_instrument_ingested` present; (P5) `CREATE INDEX IF NOT EXISTS idx_esop_obs_instrument_ingested` present; (P6) backfill source uses literal `MAX(c.refreshed_at)` from `ownership_X_current c GROUP BY c.instrument_id` (not from observations MAX, not from `now()`, not from `MIN(c.refreshed_at)` — pin both the aggregate function and the source column to lock in the false-positive-over-false-negative trade-off); (P7) backfill block repeated 7 times (one per category). |
 
 Total: **91 lint clause-counts** (81 per-helper + 10 cross-cutting — M, N, O, P1-P7). Pure text walk, no DB dependency, sub-second runtime.
 
@@ -431,7 +434,7 @@ Reclaim path is the **operator pre-wipe + clean re-run** (parent spec §6.3 + §
 
 **Read-side unchanged**: no `_current` consumer sees behavioural change. Same row shapes, same dedup ordering, same priorities, same indexes. The MERGE's `WHEN NOT MATCHED BY SOURCE THEN DELETE` is steady-state writer behaviour identical to today's DELETE+INSERT (a row drops out of `_current` only when its only observation expires via `known_to` or when caps shed it post-wipe).
 
-**Sweep cost**: the state-anchored predicate does ~87k LATERAL `MAX(ingested_at)` lookups (index-only scans). Steady-state target is **sub-second** (≤ 1-2s) on healthy install (Codex 1d HIGH-2 — "<100ms × 87k = <100ms" math was wrong; even at index-only scan + ~10μs per row, 87k probes is ~1s wall clock under realistic PG planner overhead). Exact ceiling requires post-implementation `EXPLAIN ANALYZE` against a populated dev DB; spec asks for that as part of §9 DoD #8 verification. First sweep post-deploy may take longer due to backfill-skew false-positive refresh storm (each false-positive is a MERGE no-op; bounded by universe size × ~1ms per call); operator-acceptable one-off event.
+**Sweep cost**: the obs-anchored CTE-aggregate predicate (§3.3) does ONE full-index scan per category per sweep tick (Append + IndexScan via the `(instrument_id, ingested_at DESC)` indexes from sql/119 + sql/163), aggregated into the per-instrument `obs_max` then joined to the ~87k-row state table. Steady-state target: **sub-second to low-second range** (≤ 5s as a hard ceiling on funds, the largest table at 3.68M rows). Exact ceiling requires post-implementation `EXPLAIN ANALYZE` against a populated dev DB (§9 DoD #8). First sweep post-deploy may take longer due to backfill-skew false-positive refresh storm — each false-positive is a MERGE no-op; cost bounded by universe size × per-call MERGE wall clock; measured during smoke rather than assumed (Codex 1e LOW-1).
 
 ## 9. Definition of done
 
@@ -450,7 +453,8 @@ CLAUDE.md §"Definition of done" + §"ETL / parser / schema-migration additional
     - "MERGE WHEN NOT MATCHED BY SOURCE must carry the per-scope `AND tgt.<scope_col> = %(scope)s` clamp on BOTH the ON clause AND the DELETE clause (lint pins both literals)" — catastrophic data-loss class.
     - "Diff-aware writers (MERGE … IS DISTINCT FROM) MUST NOT include the `refreshed_at`-style update-timestamp column in the diff predicate — drift watermarks belong in a separate side-table". Includes the forever-loop failure mode discovered in PR12 Codex 1a.
 11. Data-engineer skill update ([`.claude/skills/data-engineer/SKILL.md`](../../../.claude/skills/data-engineer/SKILL.md) + memory) — write-through section gains "diff-aware MERGE replaces DELETE+INSERT" rule + watermark side-table pointer + lint-guard pointer.
-12. Codex 2 pre-push green; bot review APPROVE on latest commit; CI green; merge.
+12. Out-of-band orphan-reconciliation script `scripts/ownership_refresh_state_orphan_audit.sh` (Codex 1e MED-2) — operator-triggered, scans per category for `instrument_id` values that appear in `ownership_X_observations` but have no row in `ownership_refresh_state`. Healthy install: zero rows. Non-zero output indicates a write-through regression (some code path wrote an observation without firing the matching `refresh_X_current`); script exits non-zero so it's safe to wire into a separate cron later if observed in the wild. Pins the write-through invariant the dropped UNION orphan tail (§3.3) is delegating to.
+13. Codex 2 pre-push green; bot review APPROVE on latest commit; CI green; merge.
 
 ## 10. Acceptance — cross-reference to parent spec §8
 
@@ -482,9 +486,10 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 - **Codex 1a** on this spec — completed; 5 HIGH + 7 MED + 4 LOW folded into rev 2.
 - **Codex 1b** on rev 2 — completed; 3 HIGH + 7 MED + 4 LOW folded into rev 3.
 - **Codex 1c** on rev 3 — completed; 1 HIGH + 3 MED + 3 LOW folded into rev 4.
-- **Codex 1d** on rev 4 — completed; 3 HIGH + 3 MED + 1 LOW folded into rev 5 (this commit).
-- **Codex 1e** on rev 5 (next).
-- Codex 1f if needed.
+- **Codex 1d** on rev 4 — completed; 3 HIGH + 3 MED + 1 LOW folded into rev 5.
+- **Codex 1e** on rev 5 — completed; 0 HIGH + 2 MED + 2 LOW folded into rev 6 (this commit). Convergence reached at HIGH=0.
+- **Codex 1f** on rev 6 (next).
+- Codex 1g if needed.
 - Spec lands as DOC PR (no code yet).
 - Implementation plan = separate doc (`docs/superpowers/plans/2026-05-21-pr12-ownership-current-writer-merge-impl.md`). Codex 1a / 1b on the plan.
 - PR12 implementation PR follows standard #1208 cadence: self-review → Codex 2 pre-push → push → bot review → resolve → APPROVE on latest commit → merge.
@@ -494,8 +499,8 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 State at this commit:
 
 - Parent umbrella #1233 still OPEN. PR1-PR11 all SHIPPED (PR11 #1253 020e701 merged 2026-05-21).
-- This is the DESIGN doc for PR12 (rev 5 post-Codex 1d).
+- This is the DESIGN doc for PR12 (rev 6 post-Codex 1e).
 - Branch: `feature/1233-pr12-design-spec`.
-- Next: Codex 1e on rev 5; revise if needed; doc PR; then writing-plans skill → implementation plan → execution.
+- Next: Codex 1f on rev 6 (sanity-pass after the predicate-shape switch); doc PR if 1f is LOW-or-CLEAN; then writing-plans skill → implementation plan → execution.
 
 After PR12 merges, the operator triggers the §6.3 pre-wipe + clean re-run and #1233 closes per parent spec §8.

--- a/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
+++ b/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
@@ -6,7 +6,7 @@
 >
 > Parent spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 / §4.6 / §6.4 / §7 / §8.
 >
-> Status: **DESIGN (rev 3)** — initial draft addressed bloat via diff-aware MERGE; Codex 1a found 5 HIGH + 7 MED + 4 LOW → folded into rev 2 (side-table watermark + tightened lint + extended tests + concurrency contract + CI extension provisioning). Codex 1b on rev 2 found 3 HIGH (watermark-population mismatch + MERGE-vs-state UPSERT race + nondeterministic per-row backfill) + 7 MED + 4 LOW. Rev 3 folds the 1b findings: watermark captured pre-MERGE in Python var; observations-anchored single-query predicate via `IS DISTINCT FROM`; backfill via `MAX … GROUP BY (instrument_id, category)`; repair sweep expanded to all 7 categories; block-local lint for ON/DELETE clamps; per-clause lint for def14a 3-clause filter; state-table churn acceptance floor added.
+> Status: **DESIGN (rev 4)** — Codex 1a → rev 2 (5H + 7M + 4L). Codex 1b → rev 3 (3H + 7M + 4L). Codex 1c on rev 3 found 1 HIGH (rev 3's obs-anchored `GROUP BY instrument_id` predicate scans the full observations table per sweep — breaks the "<100ms healthy install" claim on funds-scale tables without a dedicated `(instrument_id, ingested_at)` index) + 3 MED (backfill from `_current.refreshed_at` lags obs MAX by tx-time-vs-clock_timestamp skew → first-sweep false-drift; missing `known_to` expiry watermark test; tuple_percent ≥ 70% floor too tight for state table churn-vs-autovacuum cadence) + 3 LOW (stale "5 categories" text; "always advances" wording inaccurate; handover stale). Rev 4 folds all 1c findings: state-anchored predicate primary path with LATERAL obs-MAX + UNION orphan tail; per-observations-table `(instrument_id, ingested_at DESC)` indexes provisioned in sql/163; backfill switched to `MAX(obs.ingested_at) GROUP BY obs.instrument_id` (uses obs MAX directly, eliminates skew); new case 4b watermark-alignment test on `known_to` expiry; state-table acceptance switched to dead-tuple bound; stale text purged.
 
 ## 0. Status snapshot (2026-05-21 dev DB)
 
@@ -82,7 +82,7 @@ Caller inventory (refresh callers across the codebase):
 | `app/services/sec_bulk_orchestrator_jobs.py:425` | `refresh_institutions_current` | bulk archive drain |
 | `app/services/ownership_observations_sync.py:404` | `refresh_institutions_current` | observations sync |
 | `app/services/rewash_filings.py:1075` | `refresh_institutions_current` | rewash rescue |
-| `app/jobs/ownership_observations_repair.py:70` | (all 5 categories via lambda) | weekly repair sweep |
+| `app/jobs/ownership_observations_repair.py:70` | (5 categories pre-PR12 via lambda; expanded to 7 in §3.3) | weekly repair sweep |
 
 ## 2. Non-goals
 
@@ -131,7 +131,23 @@ CREATE INDEX IF NOT EXISTS idx_ownership_refresh_state_category
 - PK `(instrument_id, category)` caps the table at 7 × |distinct-instrument-ids| rows (currently ~87k in dev; grows linearly with universe). UPSERT-only writer with no row growth past the cap → bloat surface tiny + autovacuum-manageable.
 - CHECK lists all **7 categories** (Codex 1b MED-4 — current repair sweep iterates only 5; PR12 expands the sweep's `_CATEGORIES` list to include `funds` + `esop` for uniformity).
 
-**Migration backfill** is in the same SQL file; one INSERT per category, aggregated via `MAX(_current.refreshed_at) GROUP BY (instrument_id, category)` (Codex 1b HIGH-3 — multi-row categories like funds/institutions/insiders/blockholders/def14a/esop carry many rows per instrument with different `refreshed_at` values; per-row `ON CONFLICT DO NOTHING` is nondeterministic; aggregate first):
+**Per-observations-table `(instrument_id, ingested_at DESC)` indexes** (new, in same sql/163 migration) — load-bearing for the repair-sweep predicate cost target (Codex 1c HIGH-1):
+
+```sql
+-- Per observations table, repeated 7 times in the migration:
+CREATE INDEX IF NOT EXISTS idx_ownership_funds_obs_instrument_ingested_at
+    ON ownership_funds_observations (instrument_id, ingested_at DESC);
+-- (sibling CREATE INDEX statements for insiders / institutions / blockholders /
+--  treasury / def14a / esop observations tables, including partition propagation
+--  via PARTITION INDEX where the parent table is partitioned by period_end —
+--  funds + institutions + insiders + blockholders + treasury + def14a + esop
+--  observations are all RANGE-partitioned per migration 114-style schema; PG17
+--  cascades CREATE INDEX from parent to all partitions automatically.)
+```
+
+Without these indexes the LATERAL `MAX(ingested_at)` lookups per state row would fall back to per-partition seq-scan + aggregate → tens of seconds on funds (3.68M obs rows). With the index, each lookup is an index-only scan returning 1 row → <1ms × ~87k state rows = <100ms total sweep cost on healthy install (matches the repair docstring's target).
+
+**Migration backfill** is in the same SQL file; one INSERT per category, sourced from **observations MAX(ingested_at)** rather than `_current.refreshed_at` (Codex 1c MED-1 — `_current.refreshed_at` uses transaction `now()` while `observations.ingested_at` uses `clock_timestamp()`; the latter can be later within the same refresh tx, so backfilling from `_current.refreshed_at` would seed an under-estimate and cause first-sweep false drift). Backfilling from obs MAX asserts the write-through invariant "_current reflects observations as of obs MAX ingested_at" — which is the steady-state contract:
 
 ```sql
 -- Per category, repeated 7 times in the migration:
@@ -140,37 +156,53 @@ INSERT INTO ownership_refresh_state (
     last_drained_observations_max_ingested_at, last_refresh_attempted_at
 )
 SELECT
-    c.instrument_id,
+    obs.instrument_id,
     'funds',
-    MAX(c.refreshed_at),
-    MAX(c.refreshed_at)
-FROM ownership_funds_current c
-GROUP BY c.instrument_id
+    MAX(obs.ingested_at),
+    now()
+FROM ownership_funds_observations obs
+GROUP BY obs.instrument_id
 ON CONFLICT (instrument_id, category) DO NOTHING;
 ```
 
-This carries the existing watermark forward verbatim, avoiding a "first sweep post-deploy storm" where every instrument looks un-drained.
+If write-through has been broken (observations exist but `_current` never reconciled), the first post-deploy sweep will still find drift legitimately — repair fires, MERGE reconciles, state advances. Honest behaviour, not silent skip.
 
-**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) — single observations-anchored LEFT JOIN query using `IS DISTINCT FROM` for NULL-safe comparison (Codex 1b MED-3 — collapses the rev-2 two-part predicate + UNION tail into one statement):
+**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) — **state-anchored primary path** (cheap correlated LATERAL `MAX` per state row, indexed by §3.3 indexes) + **orphan tail** for the rare "obs exists but state row missing" case (write-through gap caught at next sweep):
 
 ```sql
-SELECT obs.instrument_id
-FROM (
-    SELECT instrument_id, MAX(ingested_at) AS obs_max
-    FROM ownership_X_observations
-    GROUP BY instrument_id
-) obs
-LEFT JOIN ownership_refresh_state s
-    ON s.instrument_id = obs.instrument_id AND s.category = %s
-WHERE s.last_drained_observations_max_ingested_at IS DISTINCT FROM obs.obs_max;
+-- Primary path: state-anchored, cheap with the new (instrument_id, ingested_at DESC) index.
+SELECT s.instrument_id
+FROM ownership_refresh_state s
+LEFT JOIN LATERAL (
+    SELECT MAX(o.ingested_at) AS obs_max
+    FROM ownership_X_observations o
+    WHERE o.instrument_id = s.instrument_id
+) sub ON TRUE
+WHERE s.category = %s
+  AND s.last_drained_observations_max_ingested_at IS DISTINCT FROM sub.obs_max
+
+UNION
+
+-- Orphan tail: obs exists for an instrument with no state row for this category.
+-- Defence-in-depth against a broken write-through that wrote obs without firing
+-- refresh + ownership_refresh_state UPSERT. Backfill covers all _current rows
+-- at deploy time so this branch fires only on post-deploy write-through gaps.
+SELECT DISTINCT o.instrument_id
+FROM ownership_X_observations o
+WHERE NOT EXISTS (
+    SELECT 1 FROM ownership_refresh_state s
+    WHERE s.instrument_id = o.instrument_id AND s.category = %s
+);
 ```
 
-NULL semantics:
+NULL semantics on the primary branch:
 
-- `obs` row present, no `s` row → `s.<col>` is NULL, `obs.obs_max` is not NULL → `NULL IS DISTINCT FROM <value>` = TRUE → drift detected, refresh fires.
-- Both present, same value → not distinct → no drift.
-- Both present, different value (obs newer) → distinct → drift.
-- `obs` row absent (no observations) → instrument not in subquery → not in result. Orphan state-table rows (instrument with state but no obs) are not detected — acceptable; cleanup is an O(1) follow-up if it ever happens. Observations-anchored anchor keeps the common path tight.
+- Both `s.last_drained` and `sub.obs_max` present, equal → not distinct → no drift.
+- Both present, different → distinct → drift → refresh fires.
+- `s.last_drained` present, `sub.obs_max` NULL (all obs deleted for instrument) → distinct → drift → refresh fires → MERGE NOT MATCHED BY SOURCE deletes any orphan `_current` rows → state UPSERT writes watermark = NULL → next sweep both NULL → not distinct → no drift.
+- Both NULL → not distinct → no drift (steady state for empty instrument).
+
+Orphan-tail cost: full obs table scan with `NOT EXISTS` filter. Healthy install: zero rows match (every obs-bearing instrument has a state row after backfill) → planner uses index-only-distinct on observations PK + anti-join against state PK → cheap. If the tail starts returning many rows, that signals a write-through regression and the sweep cost is the right signal to surface (loud failure mode).
 
 ## 4. Writer rewrite
 
@@ -321,7 +353,7 @@ Mechanical contract that lint invariants E + I + J pin (simplified per Codex 1b 
 - **Diff cols** ∩ PK cols = ∅ (PK cols are matched by ON clause; not in the diff predicate).
 - `refreshed_at` ∉ diff cols, `refreshed_at` ∉ INSERT column list (so DEFAULT now() fires on insert).
 
-Operator-visible semantic: `refreshed_at` advances IFF business cols changed. The drift watermark for repair sweep is in `ownership_refresh_state.last_drained_observations_max_ingested_at` (§3.3), which always advances on every refresh attempt — no longer overloaded with the "did we attempt this" signal.
+Operator-visible semantic: `_current.refreshed_at` advances IFF business cols changed. The drift watermark for repair sweep is `ownership_refresh_state.last_drained_observations_max_ingested_at` (§3.3) — updated on **every** refresh attempt (Codex 1c LOW-2 — "updated on every attempt" is the accurate phrasing; the *value* only changes when `MAX(observations.ingested_at)` changed). The companion `last_refresh_attempted_at` column records the wall-clock of the call regardless.
 
 ### 4.3 Scope clamp on ON clause + DELETE branch (Codex 1a HIGH-2 + HIGH-4)
 
@@ -358,7 +390,7 @@ Per helper (×7):
 | **K** | Per-helper extra WHERE filter clauses present inside USING subquery — see §4.1 column "Extra WHERE filter" | Per-clause grep with per-helper expected counts (Codex 1b MED-6 — def14a's 3 clauses must be counted independently; one clause passing while the other two are dropped must fail the lint): treasury `AND treasury_shares IS NOT NULL` → count == 1; def14a (K1) `AND shares IS NOT NULL` → count == 1, (K2) `AND holder_role IS DISTINCT FROM 'esop'` → count == 1, (K3) `AND holder_name !~* %s` (the `_ESOP_HOLDER_NAME_SQL_REGEX` parameter) → count == 1. Insiders / institutions / blockholders / funds / esop have no extra filter; the K-class is skipped for those helpers (per-helper expected count = 0). |
 | **L** | Helper UPSERTs into `ownership_refresh_state` with the matching category literal | grep `INSERT INTO ownership_refresh_state` inside body span → count == 1 AND grep `'<expected category>'` inside same block → count == 1 |
 
-**84 base per-helper checks** (7 helpers × 12 invariants A-L), with K-class per-helper expected content varying per §4.1: def14a's K expands to 3 sub-clauses (K1/K2/K3), treasury's K is 1 clause, the other 5 helpers have no K-class clause. Exact total counting sub-clauses: 7 × 10 (A-J) + 7 × 1 (L) + 1 (treasury K) + 3 (def14a K1/K2/K3) = **81 per-helper clause-counts**.
+Per-helper clause-count breakdown (counting K-class sub-clauses individually per §4.1 — def14a K = K1+K2+K3, treasury K = 1, others have no K): 7 × 10 (A-J) + 7 × 1 (L) + 1 (treasury K) + 3 (def14a K1/K2/K3) = **81 per-helper clause-counts**.
 
 Plus 4 cross-cutting checks:
 
@@ -371,7 +403,7 @@ Plus 4 cross-cutting checks:
 
 Total: **85 lint clause-counts** (81 per-helper + 4 cross-cutting). Pure text walk, no DB dependency, sub-second runtime.
 
-## 6. Tests (45 parametrised cases + helper-specific overlays)
+## 6. Tests (52 parametrised cases)
 
 New file: [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py). Parametrised over the 7 helpers.
 
@@ -387,8 +419,9 @@ New file: [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_o
 | 6 | **priority-chain regression (insiders only)** | write 2 observations same `(holder_identity_key, ownership_nature)`: source='form4' (priority 1) + source='13d' (priority 3); equal period_end + filed_at | refresh | `_current.source == 'form4'` (priority chain unchanged). Pins the cross-source `CASE source WHEN ... ASC` ORDER BY chain (lint invariant H + runtime). |
 | 7 | **per-helper filter regression** | (a) **treasury**: write 1 obs with `treasury_shares=NULL` AND 1 obs with `treasury_shares=12345` same period; (b) **def14a**: write 1 obs `holder_role='esop'`, 1 obs `holder_role='principal' AND holder_name ILIKE '%ESOP%'`, 1 obs `holder_role='principal' AND holder_name='Vanguard'` | refresh | (a) `_current.treasury_shares == 12345` (NULL-displacement guard works); (b) `_current` row count == 1; only the Vanguard row survives (ESOP regex + holder_role='esop' both excluded). |
 | 8 | **repair-sweep no-loop** | row present in `_current` + `ownership_refresh_state`; UPSERT same obs row (DO UPDATE clause bumps `obs.ingested_at`); refresh fires (no diff → MERGE no-op) | run `_drifted_instruments` again with the new predicate | empty list (state-table watermark advanced; sweep no longer re-selects). **Pins the §3.3 watermark fix end-to-end.** |
+| 9 | **`known_to` expiry watermark alignment** (Codex 1c MED-2) | row present in `_current` + state; `UPDATE _observations SET known_to = now()` on the active observation (no row deletion, just expiry); refresh fires (MERGE NOT MATCHED BY SOURCE → DELETE on `_current`; state UPSERT advances watermark to new obs MAX, which now reflects the expired row's bumped `ingested_at`) | run `_drifted_instruments` again | empty list. **Pins the all-observations population alignment between watermark capture and repair predicate** — if the watermark used `known_to IS NULL` while the predicate used all obs (or vice versa), expiry would create a false drift trigger. |
 
-Total: 5 base cases × 7 helpers = 35 + 1 priority-chain (insiders) + 2 filter-regression (treasury + def14a) + 7 repair-sweep no-loop (all helpers) = **45 parametrised cases**, with helper-specific cases on top.
+Total: 5 base cases × 7 helpers = 35 + 1 priority-chain (insiders) + 2 filter-regression (treasury + def14a) + 7 repair-sweep no-loop + 7 known_to expiry watermark = **52 parametrised cases**.
 
 **Extension provisioning + CI fail-loud** (Codex 1a MED-6): [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisioning gains `CREATE EXTENSION IF NOT EXISTS pgstattuple`. If the extension is missing at test time, the no-op-churn case fails loudly with a dedicated error message (`pytest.fail(f"pgstattuple extension missing in {db_name} — provisioning bug, do NOT skip")`) instead of skipping. CI provisioning step explicitly asserts the extension is present after template clone.
 
@@ -416,17 +449,17 @@ Reclaim path is the **operator pre-wipe + clean re-run** (parent spec §6.3 + §
 
 **Read-side unchanged**: no `_current` consumer sees behavioural change. Same row shapes, same dedup ordering, same priorities, same indexes. The MERGE's `WHEN NOT MATCHED BY SOURCE THEN DELETE` is steady-state writer behaviour identical to today's DELETE+INSERT (a row drops out of `_current` only when its only observation expires via `known_to` or when caps shed it post-wipe).
 
-**Sweep cost**: repair sweep stays at "<100ms on healthy install" — the watermark predicate now reflects "have we drained these observations" rather than "did we touch this row", so no-op refreshes do not re-trigger.
+**Sweep cost**: repair sweep stays at "<100ms on healthy install" — the state-anchored predicate does ~87k cheap LATERAL `MAX(ingested_at)` lookups (index-only scans on the new per-observations-table `(instrument_id, ingested_at DESC)` indexes from §3.3). The orphan UNION tail is zero rows on healthy install (write-through invariant holds → every obs-bearing instrument has a state row after backfill). If the orphan tail starts returning many rows, that's a write-through regression signal — sweep cost growth is the correct alarm channel.
 
 ## 9. Definition of done
 
 CLAUDE.md §"Definition of done" + §"ETL / parser / schema-migration additional clauses" both apply.
 
 1. 7 `refresh_*_current` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py) rewritten to single-statement MERGE + `ownership_refresh_state` UPSERT per §4 template + §4.1 per-helper differences. Signature `(conn, *, instrument_id) -> int` preserved on every helper.
-2. New migration `sql/163_ownership_refresh_state.sql` creates the table with the schema in §3.3, plus an idempotent backfill from existing `_current.refreshed_at`. Runs inside the standard migration runner; no `-- runner: autocommit` directive required (no ALTER SYSTEM / CREATE DATABASE / VACUUM / REINDEX SYSTEM).
-3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form (observations-anchored single-query LEFT JOIN with `IS DISTINCT FROM`). `_CATEGORIES` list expanded to all 7 categories — adds `funds` + `esop` lambdas wiring `refresh_funds_current` + `refresh_esop_current` so the sweep stays uniform with the state-table CHECK constraint (Codex 1b MED-4).
+2. New migration `sql/163_ownership_refresh_state.sql` creates the table with the schema in §3.3 + 7 `(instrument_id, ingested_at DESC)` indexes on each observations table (load-bearing for sweep cost — Codex 1c HIGH-1) + idempotent backfill via `MAX(observations.ingested_at) GROUP BY instrument_id` per category (Codex 1c MED-1 — eliminates `_current.refreshed_at` vs `clock_timestamp()` skew). Runs inside the standard migration runner; no `-- runner: autocommit` directive required.
+3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form (state-anchored LATERAL `MAX(ingested_at)` primary path + UNION orphan tail; `IS DISTINCT FROM` NULL-safe). `_CATEGORIES` list expanded to all 7 categories — adds `funds` + `esop` lambdas wiring `refresh_funds_current` + `refresh_esop_current` so the sweep stays uniform with the state-table CHECK constraint (Codex 1b MED-4).
 4. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (85 clause-counts: 81 per-helper + 4 cross-cutting, per §5) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
-5. [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py) — parametrised over 7 helpers × 5 base cases + insiders priority-chain + treasury null guard + def14a ESOP exclusion + 7 repair-sweep no-loop cases. Load-bearing no-op-churn case uses per-row `xmin::text` equality + `pgstattuple`.
+5. [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py) — 52 parametrised cases (7 × 5 base + insiders priority-chain + treasury null guard + def14a ESOP exclusion + 7 repair-sweep no-loop + 7 known_to expiry watermark alignment per §6). Load-bearing no-op-churn case uses per-row `xmin::text` equality + `pgstattuple` on both `_current` and `ownership_refresh_state`.
 6. [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisions `pgstattuple` extension; failure to provision triggers `pytest.fail` in no-op-churn case (no silent skips).
 7. Boot-time PG ≥ 17 guard at lifespan (mirror #1187 pattern). Pinned by `tests/smoke/test_app_boots.py`.
 8. Smoke verification against AAPL / GME / MSFT / JPM / HD (CLAUDE.md panel) post-merge: for each instrument, call `refresh_funds_current` and `refresh_institutions_current` twice in succession; assert `pgstattuple.table_len` delta == 0 + per-row `xmin::text` stability across the second call. Additionally call `refresh_treasury_current` and `refresh_def14a_current` for at least one instrument each to exercise the small-table helpers + their per-helper filters (Codex 1a LOW-4). PR description records each instrument's outcome and the commit SHA per CLAUDE.md ETL clause 12.
@@ -456,16 +489,19 @@ WHERE relname IN ('ownership_funds_current', 'ownership_institutions_current', '
 ORDER BY pg_total_relation_size(oid) DESC;
 ```
 
-Per-helper `pgstattuple` confirms `tuple_percent` ≥ 70% on `_current` tables (healthy density floor). Same floor applies to `ownership_refresh_state` (Codex 1b MED-1 — state table churns 1 row UPSERT per refresh call; ≤87k row PK cap means autovacuum easily keeps up at default thresholds; floor pinned by acceptance script).
+Per-helper `pgstattuple` confirms `tuple_percent` ≥ 70% on `_current` tables (healthy density floor).
+
+State-table acceptance uses a **dead-tuple bound** rather than a fixed tuple_percent floor (Codex 1c MED-3 — default autovacuum at `scale_factor=0.2 + threshold=50` fires at `dead_tup > 0.2 × 87,000 + 50 ≈ 17,450`, so the state table's tuple_percent can dip below 70% between vacuum cycles under bootstrap-rate churn even though steady-state remains healthy). Acceptance: `pgstattuple(ownership_refresh_state).dead_tuple_count ≤ live_tuple_count` post-autovacuum (≤50% dead-tuple ratio). If a future tuning pass shows this dips too low under production load, add per-table `ALTER TABLE ownership_refresh_state SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_vacuum_threshold = 100)` as a tightening knob — out of PR12 scope unless the dev-DB profile shows it during the §6.3 clean re-run.
 
 ## 11. Codex review gate
 
 Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 
 - **Codex 1a** on this spec — completed; 5 HIGH + 7 MED + 4 LOW folded into rev 2.
-- **Codex 1b** on rev 2 — completed; 3 HIGH + 7 MED + 4 LOW folded into rev 3 (this commit).
-- **Codex 1c** on rev 3 (next).
-- Codex 1d if needed.
+- **Codex 1b** on rev 2 — completed; 3 HIGH + 7 MED + 4 LOW folded into rev 3.
+- **Codex 1c** on rev 3 — completed; 1 HIGH + 3 MED + 3 LOW folded into rev 4 (this commit).
+- **Codex 1d** on rev 4 (next).
+- Codex 1e if needed.
 - Spec lands as DOC PR (no code yet).
 - Implementation plan = separate doc (`docs/superpowers/plans/2026-05-21-pr12-ownership-current-writer-merge-impl.md`). Codex 1a / 1b on the plan.
 - PR12 implementation PR follows standard #1208 cadence: self-review → Codex 2 pre-push → push → bot review → resolve → APPROVE on latest commit → merge.
@@ -475,9 +511,8 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 State at this commit:
 
 - Parent umbrella #1233 still OPEN. PR1-PR11 all SHIPPED (PR11 #1253 020e701 merged 2026-05-21).
-- This is the DESIGN doc for PR12 (rev 3 post-Codex 1b).
-- This is the DESIGN doc for PR12 (rev 2 post-Codex 1a).
+- This is the DESIGN doc for PR12 (rev 4 post-Codex 1c).
 - Branch: `feature/1233-pr12-design-spec`.
-- Next: Codex 1b on rev 2; revise if needed; doc PR; then writing-plans skill → implementation plan → execution.
+- Next: Codex 1d on rev 4; revise if needed; doc PR; then writing-plans skill → implementation plan → execution.
 
 After PR12 merges, the operator triggers the §6.3 pre-wipe + clean re-run and #1233 closes per parent spec §8.

--- a/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
+++ b/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
@@ -6,7 +6,7 @@
 >
 > Parent spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 / §4.6 / §6.4 / §7 / §8.
 >
-> Status: **DESIGN (rev 6)** — Codex 1a → rev 2 (5H+7M+4L). Codex 1b → rev 3 (3H+7M+4L). Codex 1c → rev 4 (1H+3M+3L). Codex 1d → rev 5 (3H+3M+1L). Codex 1e on rev 5 returned 0 HIGH + 2 MED + 2 LOW (convergence). MED-1 was the load-bearing one: state-anchored per-row LATERAL `MAX(ingested_at)` against the RANGE-partitioned observations tables fans out to ~84 partitions per probe × ~87k state rows = minutes per sweep — NOT sub-second despite proper indexing (partition pruning by `period_end` doesn't help an `instrument_id` predicate). Rev 6 switches the sweep predicate to an obs-anchored CTE aggregate `MAX(ingested_at) GROUP BY instrument_id` (single full-index scan via Append + IndexScan; ~500ms-2s for funds; deterministically faster than per-row LATERAL fanout). Rev 6 also adds an out-of-band orphan-reconciliation script to DoD (pin the write-through invariant Codex 1e MED-2 flagged); refines first-sweep cost wording to "bounded + measured" (LOW-1); tightens P6 to pin the `MAX(c.refreshed_at)` literal (LOW-2).
+> Status: **DESIGN (rev 7 — FINAL for doc-PR)** — Codex 1a → rev 2 (5H+7M+4L). Codex 1b → rev 3 (3H+7M+4L). Codex 1c → rev 4 (1H+3M+3L). Codex 1d → rev 5 (3H+3M+1L). Codex 1e → rev 6 (0H+2M+2L). Codex 1f on rev 6 returned 0 HIGH + 1 MED + 3 LOW — MED tightens the orphan-audit DoD from "script exists" to "script runs + records zero rows at verification SHA"; LOWs (DoD #3 wording stale, EXPLAIN target wording alignment, lint O regression-guard for CTE shape) all folded in rev 7. Convergence is stable: HIGH=0 across two rounds, MED count diminishing. Spec sign-off: rev 7 ready for doc-PR; implementation plan via writing-plans skill follows.
 
 ## 0. Status snapshot (2026-05-21 dev DB)
 
@@ -354,7 +354,7 @@ The `WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %(iid)s THEN DELETE` cla
 - Concurrent **observation writers** (record_*_observation called from a sibling code path) do not block on the advisory lock. They may commit between the lock acquisition and the MERGE's source-subquery scan; the MERGE will see whatever was committed at scan time. The repair-sweep predicate (§3.3) catches any obs writes that committed after the most recent refresh — that is the whole point of the watermark.
 - PG MERGE takes row-level locks on matched/updated target rows + the locks released at COMMIT. Concurrent same-instrument refreshes (advisory lock contention) → serialised. Concurrent different-instrument refreshes → row-level locks are disjoint by PK; no contention.
 
-## 5. Lint guard (91 clause-counts total — 81 per-helper + 10 cross-cutting)
+## 5. Lint guard (93 clause-counts total — 81 per-helper + 12 cross-cutting)
 
 New script: [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh). Wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after PR11's `check_13dg_retention.sh`. Awk-based function-body block walker (PR4 Codex 1c lesson); every grep guarded against empty-input by exact-count assertion (PR10a Codex iter 1 lesson).
 
@@ -383,10 +383,10 @@ Plus 4 cross-cutting checks:
 | --- | --- | --- |
 | **M** | No `DELETE FROM ownership_*_current` anywhere under `app/` outside the 7 helper bodies | grep across `app/**/*.py` minus the 7 helper bodies → count == 0 |
 | **N** | No `DELETE FROM ownership_*_current` anywhere under `scripts/` and `app/jobs/` (catches future writers landing outside `app/services/`) | grep across both trees → count == 0 |
-| **O** | `ownership_observations_repair.py` predicate references `ownership_refresh_state.last_drained_observations_max_ingested_at` (not legacy `c.refreshed_at < ...` form) | grep `c.refreshed_at <` → count == 0 inside the repair file |
+| **O** | `ownership_observations_repair.py` predicate uses the rev-6 obs-anchored CTE aggregate shape (Codex 1f LOW-3 — forbids both regressions: legacy `c.refreshed_at <` form AND the rev-5 per-row LATERAL form that partition-fanouts) | Inside the repair file: (O1) grep `c.refreshed_at <` → count == 0 (no legacy form); (O2) grep `WITH obs_max AS` → count ≥ 1 (positive shape pin for the CTE aggregate); (O3) grep `LATERAL` inside the predicate-defining function body → count == 0 (no per-row LATERAL regression). |
 | **P** | Migration `sql/163_ownership_refresh_state.sql` pins all rev-6 contracts (Codex 1d MED-3 + Codex 1e LOW-2): table + indexes + backfill + literal aggregate expression | 7 targeted grep checks against the migration file with exact-count assertions — (P1) `CREATE TABLE IF NOT EXISTS ownership_refresh_state` opener present; (P2) PK is `(instrument_id, category)`; (P3) CHECK lists exactly the 7 category literals; (P4) `CREATE INDEX IF NOT EXISTS idx_funds_obs_instrument_ingested` present; (P5) `CREATE INDEX IF NOT EXISTS idx_esop_obs_instrument_ingested` present; (P6) backfill source uses literal `MAX(c.refreshed_at)` from `ownership_X_current c GROUP BY c.instrument_id` (not from observations MAX, not from `now()`, not from `MIN(c.refreshed_at)` — pin both the aggregate function and the source column to lock in the false-positive-over-false-negative trade-off); (P7) backfill block repeated 7 times (one per category). |
 
-Total: **91 lint clause-counts** (81 per-helper + 10 cross-cutting — M, N, O, P1-P7). Pure text walk, no DB dependency, sub-second runtime.
+Total: **93 lint clause-counts** (81 per-helper + 12 cross-cutting — M, N, O1-O3, P1-P7). Pure text walk, no DB dependency, sub-second runtime.
 
 ## 6. Tests (52 parametrised cases)
 
@@ -442,18 +442,18 @@ CLAUDE.md §"Definition of done" + §"ETL / parser / schema-migration additional
 
 1. 7 `refresh_*_current` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py) rewritten to single-statement MERGE + `ownership_refresh_state` UPSERT per §4 template + §4.1 per-helper differences. Signature `(conn, *, instrument_id) -> int` preserved on every helper.
 2. New migration `sql/163_ownership_refresh_state.sql` creates the table with the schema in §3.3 + 2 `(instrument_id, ingested_at DESC)` indexes on funds + esop observations tables (sql/119 already covers the other 5 — Codex 1d MED-1) + idempotent backfill via `MAX(_current.refreshed_at) GROUP BY instrument_id` per category (Codex 1d HIGH-1 — false-positive over false-negative; backfilling from obs MAX would mask drift). Runs inside the standard migration runner; no `-- runner: autocommit` directive required.
-3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form (state-anchored single-query LATERAL `MAX(ingested_at)` with `IS DISTINCT FROM`; orphan UNION tail dropped per Codex 1d HIGH-3). `_CATEGORIES` list expanded to all 7 categories — adds `funds` + `esop` lambdas wiring `refresh_funds_current` + `refresh_esop_current` so the sweep stays uniform with the state-table CHECK constraint (Codex 1b MED-4).
-4. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (91 clause-counts: 81 per-helper + 10 cross-cutting M/N/O/P1-P7, per §5) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
+3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form — **obs-anchored CTE aggregate** (`WITH obs_max AS (SELECT instrument_id, MAX(ingested_at) FROM ownership_X_observations GROUP BY instrument_id)` LEFT JOIN state, `IS DISTINCT FROM`; orphan UNION tail dropped per Codex 1d HIGH-3; per-row LATERAL replaced per Codex 1e MED-1 partition-fanout). `_CATEGORIES` list expanded to all 7 categories — adds `funds` + `esop` lambdas wiring `refresh_funds_current` + `refresh_esop_current` so the sweep stays uniform with the state-table CHECK constraint (Codex 1b MED-4).
+4. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (93 clause-counts: 81 per-helper + 12 cross-cutting M/N/O1-O3/P1-P7, per §5) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
 5. [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py) — 52 parametrised cases (7 × 5 base + insiders priority-chain + treasury null guard + def14a ESOP exclusion + 7 repair-sweep no-loop + 7 known_to expiry watermark alignment per §6). Load-bearing no-op-churn case uses per-row `xmin::text` equality + `pgstattuple` on both `_current` and `ownership_refresh_state`.
 6. [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisions `pgstattuple` extension; failure to provision triggers `pytest.fail` in no-op-churn case (no silent skips).
 7. Boot-time PG ≥ 17 guard at lifespan (mirror #1187 pattern). Pinned by `tests/smoke/test_app_boots.py`.
-8. Smoke verification against AAPL / GME / MSFT / JPM / HD (CLAUDE.md panel) post-merge: for each instrument, call `refresh_funds_current` and `refresh_institutions_current` twice in succession; assert `pgstattuple.table_len` delta == 0 + per-row `xmin::text` stability across the second call. Additionally call `refresh_treasury_current` and `refresh_def14a_current` for at least one instrument each to exercise the small-table helpers + their per-helper filters (Codex 1a LOW-4). EXPLAIN ANALYZE the repair-sweep predicate against a populated dev DB and record steady-state wall clock — confirms sub-second target (Codex 1d HIGH-2). PR description records each instrument's outcome, the EXPLAIN ANALYZE timing, and the commit SHA per CLAUDE.md ETL clause 12.
+8. Smoke verification against AAPL / GME / MSFT / JPM / HD (CLAUDE.md panel) post-merge: for each instrument, call `refresh_funds_current` and `refresh_institutions_current` twice in succession; assert `pgstattuple.table_len` delta == 0 + per-row `xmin::text` stability across the second call. Additionally call `refresh_treasury_current` and `refresh_def14a_current` for at least one instrument each to exercise the small-table helpers + their per-helper filters (Codex 1a LOW-4). EXPLAIN ANALYZE the repair-sweep predicate against a populated dev DB and record steady-state wall clock — must complete under the §8 hard ceiling (≤5s for the largest category funds — Codex 1d HIGH-2 / Codex 1f LOW-2 alignment). PR description records each instrument's outcome, the EXPLAIN ANALYZE timing, and the commit SHA per CLAUDE.md ETL clause 12.
 9. Parent spec amendment — [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 + §4.6 + §7 + §8 updated: PR12 status flipped to SHIPPED, writer-pattern + watermark side-table documented, Phase 2 (`<15 GB hot`) acceptance unblocked.
 10. New prevention-log entries:
     - "MERGE WHEN NOT MATCHED BY SOURCE must carry the per-scope `AND tgt.<scope_col> = %(scope)s` clamp on BOTH the ON clause AND the DELETE clause (lint pins both literals)" — catastrophic data-loss class.
     - "Diff-aware writers (MERGE … IS DISTINCT FROM) MUST NOT include the `refreshed_at`-style update-timestamp column in the diff predicate — drift watermarks belong in a separate side-table". Includes the forever-loop failure mode discovered in PR12 Codex 1a.
 11. Data-engineer skill update ([`.claude/skills/data-engineer/SKILL.md`](../../../.claude/skills/data-engineer/SKILL.md) + memory) — write-through section gains "diff-aware MERGE replaces DELETE+INSERT" rule + watermark side-table pointer + lint-guard pointer.
-12. Out-of-band orphan-reconciliation script `scripts/ownership_refresh_state_orphan_audit.sh` (Codex 1e MED-2) — operator-triggered, scans per category for `instrument_id` values that appear in `ownership_X_observations` but have no row in `ownership_refresh_state`. Healthy install: zero rows. Non-zero output indicates a write-through regression (some code path wrote an observation without firing the matching `refresh_X_current`); script exits non-zero so it's safe to wire into a separate cron later if observed in the wild. Pins the write-through invariant the dropped UNION orphan tail (§3.3) is delegating to.
+12. Out-of-band orphan-reconciliation script `scripts/ownership_refresh_state_orphan_audit.sh` (Codex 1e MED-2 + Codex 1f MED-1) — operator-triggered, scans per category for `instrument_id` values that appear in `ownership_X_observations` but have no row in `ownership_refresh_state`. **Script MUST be run post-migration + backfill as part of this PR's verification** (per Codex 1f MED-1 — adding the script without running it leaves the invariant unproven) and the PR description MUST record zero orphans for all 7 categories at the verification commit SHA. Healthy install: zero rows. Non-zero output indicates a write-through regression (some code path wrote an observation without firing the matching `refresh_X_current`); script exits non-zero so it's safe to wire into a separate cron later if observed in the wild. Pins the write-through invariant the dropped UNION orphan tail (§3.3) is delegating to.
 13. Codex 2 pre-push green; bot review APPROVE on latest commit; CI green; merge.
 
 ## 10. Acceptance — cross-reference to parent spec §8
@@ -487,9 +487,9 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 - **Codex 1b** on rev 2 — completed; 3 HIGH + 7 MED + 4 LOW folded into rev 3.
 - **Codex 1c** on rev 3 — completed; 1 HIGH + 3 MED + 3 LOW folded into rev 4.
 - **Codex 1d** on rev 4 — completed; 3 HIGH + 3 MED + 1 LOW folded into rev 5.
-- **Codex 1e** on rev 5 — completed; 0 HIGH + 2 MED + 2 LOW folded into rev 6 (this commit). Convergence reached at HIGH=0.
-- **Codex 1f** on rev 6 (next).
-- Codex 1g if needed.
+- **Codex 1e** on rev 5 — completed; 0 HIGH + 2 MED + 2 LOW folded into rev 6.
+- **Codex 1f** on rev 6 — completed; 0 HIGH + 1 MED + 3 LOW folded into rev 7 (this commit). Convergence stable at HIGH=0 + diminishing MED.
+- Spec sign-off: rev 7 is the final spec for doc-PR.
 - Spec lands as DOC PR (no code yet).
 - Implementation plan = separate doc (`docs/superpowers/plans/2026-05-21-pr12-ownership-current-writer-merge-impl.md`). Codex 1a / 1b on the plan.
 - PR12 implementation PR follows standard #1208 cadence: self-review → Codex 2 pre-push → push → bot review → resolve → APPROVE on latest commit → merge.
@@ -499,8 +499,8 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 State at this commit:
 
 - Parent umbrella #1233 still OPEN. PR1-PR11 all SHIPPED (PR11 #1253 020e701 merged 2026-05-21).
-- This is the DESIGN doc for PR12 (rev 6 post-Codex 1e).
+- This is the DESIGN doc for PR12 (rev 7 — FINAL — post-Codex 1f).
 - Branch: `feature/1233-pr12-design-spec`.
-- Next: Codex 1f on rev 6 (sanity-pass after the predicate-shape switch); doc PR if 1f is LOW-or-CLEAN; then writing-plans skill → implementation plan → execution.
+- Next: doc-PR push + bot review + merge; then writing-plans skill → implementation plan → execution.
 
 After PR12 merges, the operator triggers the §6.3 pre-wipe + clean re-run and #1233 closes per parent spec §8.

--- a/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
+++ b/docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md
@@ -6,7 +6,7 @@
 >
 > Parent spec: [`docs/superpowers/specs/2026-05-19-data-retention-rubric.md`](2026-05-19-data-retention-rubric.md) §4.5 / §4.6 / §6.4 / §7 / §8.
 >
-> Status: **DESIGN (rev 2)** — initial draft addressed bloat via diff-aware MERGE; Codex 1a found 5 HIGH (repair-sweep watermark breakage, ON-clause scope-clamp shape, per-helper WHERE filter omissions, lint string-match too weak, test-matrix priority/filter coverage gap) + 7 MED + 4 LOW. Rev 2 folds all findings in: separate `ownership_refresh_state` side-table watermark + tightened lint (84 checks) + extended test matrix (≥56 cases) + concurrency contract + CI extension provisioning.
+> Status: **DESIGN (rev 3)** — initial draft addressed bloat via diff-aware MERGE; Codex 1a found 5 HIGH + 7 MED + 4 LOW → folded into rev 2 (side-table watermark + tightened lint + extended tests + concurrency contract + CI extension provisioning). Codex 1b on rev 2 found 3 HIGH (watermark-population mismatch + MERGE-vs-state UPSERT race + nondeterministic per-row backfill) + 7 MED + 4 LOW. Rev 3 folds the 1b findings: watermark captured pre-MERGE in Python var; observations-anchored single-query predicate via `IS DISTINCT FROM`; backfill via `MAX … GROUP BY (instrument_id, category)`; repair sweep expanded to all 7 categories; block-local lint for ON/DELETE clamps; per-clause lint for def14a 3-clause filter; state-table churn acceptance floor added.
 
 ## 0. Status snapshot (2026-05-21 dev DB)
 
@@ -113,12 +113,12 @@ Per parent spec §7 "ownership_*_current size audit + remediation" and `feedback
 ```sql
 -- sql/163_ownership_refresh_state.sql
 CREATE TABLE IF NOT EXISTS ownership_refresh_state (
-    instrument_id                            BIGINT      NOT NULL,
-    category                                 TEXT        NOT NULL CHECK (category IN (
+    instrument_id                             BIGINT      NOT NULL,
+    category                                  TEXT        NOT NULL CHECK (category IN (
         'insiders', 'institutions', 'blockholders', 'treasury', 'def14a', 'funds', 'esop'
     )),
     last_drained_observations_max_ingested_at TIMESTAMPTZ,
-    last_refresh_attempted_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_refresh_attempted_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (instrument_id, category)
 );
 
@@ -126,40 +126,51 @@ CREATE INDEX IF NOT EXISTS idx_ownership_refresh_state_category
     ON ownership_refresh_state (category, last_drained_observations_max_ingested_at);
 ```
 
-- `last_drained_observations_max_ingested_at` is the **drift watermark** — set by each `refresh_X_current` call to the `MAX(ingested_at)` over `ownership_X_observations` for the instrument as of refresh time. NULL means "never drained" → repair sweep picks it up.
+- `last_drained_observations_max_ingested_at` is the **drift watermark** — set by each `refresh_X_current` call to `MAX(ingested_at)` over **all** rows in `ownership_X_observations` for the instrument (no `known_to IS NULL` filter — the repair sweep predicate operates over the same population, so the two sides must align; otherwise a `known_to` expiry would advance only one side and produce false drift, Codex 1b HIGH-1). NULL means "no observations at all" → predicate treats matching NULLs as no-drift (via `IS DISTINCT FROM`).
 - `last_refresh_attempted_at` records the most recent refresh call (whether MERGE wrote rows or not). Operator-visible "did we run". Not used by sweep predicate; useful for ops dashboards.
-- PK `(instrument_id, category)` keeps the table at ≤ 7 × 12,417 = ~87k rows. UPSERT-only writer with no row growth past the cap → bloat surface tiny + autovacuum-manageable.
+- PK `(instrument_id, category)` caps the table at 7 × |distinct-instrument-ids| rows (currently ~87k in dev; grows linearly with universe). UPSERT-only writer with no row growth past the cap → bloat surface tiny + autovacuum-manageable.
+- CHECK lists all **7 categories** (Codex 1b MED-4 — current repair sweep iterates only 5; PR12 expands the sweep's `_CATEGORIES` list to include `funds` + `esop` for uniformity).
 
-**Migration backfill** is in the same SQL file: for each existing `_current` row populate `ownership_refresh_state` with `last_drained_observations_max_ingested_at = _current.refreshed_at`, `last_refresh_attempted_at = _current.refreshed_at`. This avoids a "first sweep post-deploy storm" where every instrument looks un-drained — backfill carries the existing watermark forward verbatim. Migration runs inside one tx; idempotent via `ON CONFLICT (instrument_id, category) DO NOTHING`.
-
-**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py):
-
-```sql
--- Before (current):
-SELECT c.instrument_id FROM ownership_X_current c
-WHERE c.refreshed_at < (SELECT MAX(o.ingested_at) FROM ownership_X_observations o WHERE o.instrument_id = c.instrument_id)
-GROUP BY c.instrument_id;
-
--- After (PR12):
-SELECT s.instrument_id FROM ownership_refresh_state s
-LEFT JOIN LATERAL (
-    SELECT MAX(o.ingested_at) AS obs_max
-    FROM ownership_X_observations o
-    WHERE o.instrument_id = s.instrument_id
-) sub ON TRUE
-WHERE s.category = %s
-  AND (s.last_drained_observations_max_ingested_at IS NULL
-       OR sub.obs_max IS NOT NULL AND sub.obs_max > s.last_drained_observations_max_ingested_at);
-```
-
-Plus a tail clause that catches the new case "instrument has observations but no state row" (only fires until backfill stabilises; safe to keep as defence-in-depth):
+**Migration backfill** is in the same SQL file; one INSERT per category, aggregated via `MAX(_current.refreshed_at) GROUP BY (instrument_id, category)` (Codex 1b HIGH-3 — multi-row categories like funds/institutions/insiders/blockholders/def14a/esop carry many rows per instrument with different `refreshed_at` values; per-row `ON CONFLICT DO NOTHING` is nondeterministic; aggregate first):
 
 ```sql
-UNION
-SELECT DISTINCT o.instrument_id FROM ownership_X_observations o
-LEFT JOIN ownership_refresh_state s ON s.instrument_id = o.instrument_id AND s.category = %s
-WHERE o.known_to IS NULL AND s.instrument_id IS NULL;
+-- Per category, repeated 7 times in the migration:
+INSERT INTO ownership_refresh_state (
+    instrument_id, category,
+    last_drained_observations_max_ingested_at, last_refresh_attempted_at
+)
+SELECT
+    c.instrument_id,
+    'funds',
+    MAX(c.refreshed_at),
+    MAX(c.refreshed_at)
+FROM ownership_funds_current c
+GROUP BY c.instrument_id
+ON CONFLICT (instrument_id, category) DO NOTHING;
 ```
+
+This carries the existing watermark forward verbatim, avoiding a "first sweep post-deploy storm" where every instrument looks un-drained.
+
+**Repair-sweep predicate switch** in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) — single observations-anchored LEFT JOIN query using `IS DISTINCT FROM` for NULL-safe comparison (Codex 1b MED-3 — collapses the rev-2 two-part predicate + UNION tail into one statement):
+
+```sql
+SELECT obs.instrument_id
+FROM (
+    SELECT instrument_id, MAX(ingested_at) AS obs_max
+    FROM ownership_X_observations
+    GROUP BY instrument_id
+) obs
+LEFT JOIN ownership_refresh_state s
+    ON s.instrument_id = obs.instrument_id AND s.category = %s
+WHERE s.last_drained_observations_max_ingested_at IS DISTINCT FROM obs.obs_max;
+```
+
+NULL semantics:
+
+- `obs` row present, no `s` row → `s.<col>` is NULL, `obs.obs_max` is not NULL → `NULL IS DISTINCT FROM <value>` = TRUE → drift detected, refresh fires.
+- Both present, same value → not distinct → no drift.
+- Both present, different value (obs newer) → distinct → drift.
+- `obs` row absent (no observations) → instrument not in subquery → not in result. Orphan state-table rows (instrument with state but no obs) are not detected — acceptable; cleanup is an O(1) follow-up if it ever happens. Observations-anchored anchor keeps the common path tight.
 
 ## 4. Writer rewrite
 
@@ -186,6 +197,22 @@ def refresh_funds_current(conn: psycopg.Connection[Any], *, instrument_id: int) 
             """,
             (instrument_id,),
         )
+        # Codex 1b HIGH-2: capture watermark BEFORE MERGE in a separate
+        # statement so the value stored in ownership_refresh_state cannot
+        # advance past observations the MERGE did not see. Race direction
+        # under READ COMMITTED: an obs that commits between this SELECT
+        # and the MERGE's source-subquery snapshot will be merged + the
+        # state watermark will lag → next sweep finds drift → extra
+        # refresh (no-op for the freshly-merged row). Benign over-detect,
+        # never silent under-detect. Population aligned with §3.3 repair
+        # predicate (no `known_to IS NULL` filter — both sides operate
+        # over all observations for the instrument).
+        cur.execute(
+            "SELECT MAX(ingested_at) FROM ownership_funds_observations WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        watermark_row = cur.fetchone()
+        watermark = watermark_row[0] if watermark_row else None
         cur.execute(
             """
             MERGE INTO ownership_funds_current AS tgt
@@ -252,18 +279,14 @@ def refresh_funds_current(conn: psycopg.Connection[Any], *, instrument_id: int) 
             INSERT INTO ownership_refresh_state (
                 instrument_id, category,
                 last_drained_observations_max_ingested_at, last_refresh_attempted_at
+            ) VALUES (
+                %(iid)s, 'funds', %(watermark)s, now()
             )
-            SELECT
-                %(iid)s,
-                'funds',
-                (SELECT MAX(ingested_at) FROM ownership_funds_observations
-                 WHERE instrument_id = %(iid)s AND known_to IS NULL),
-                now()
             ON CONFLICT (instrument_id, category) DO UPDATE SET
                 last_drained_observations_max_ingested_at = EXCLUDED.last_drained_observations_max_ingested_at,
                 last_refresh_attempted_at = EXCLUDED.last_refresh_attempted_at
             """,
-            {"iid": instrument_id},
+            {"iid": instrument_id, "watermark": watermark},
         )
         cur.execute(
             "SELECT COUNT(*) FROM ownership_funds_current WHERE instrument_id = %s",
@@ -291,13 +314,12 @@ The insiders source-priority `CASE source WHEN 'form4' THEN 1 WHEN 'form3' THEN 
 
 The `IS DISTINCT FROM` tuple lists on LHS and RHS must contain **exactly the same column names** in the same order; they must contain **every non-PK column** that appears in the UPDATE SET clause; they must **not** contain `refreshed_at`; they must **not** contain PK columns (PK columns are matched by the ON clause; the diff predicate covers business cols only).
 
-Mechanical contract that lint invariant E + L pin:
+Mechanical contract that lint invariants E + I + J pin (simplified per Codex 1b MED-7 — exact ordered equality, no subset relations):
 
-- LHS tuple cols ≡ RHS tuple cols (set equality + ordering)
-- LHS tuple cols ⊆ UPDATE SET targets ∪ {PK cols} (every diff col gets written if UPDATE fires)
-- UPDATE SET targets ≡ LHS tuple cols ∪ {`refreshed_at`} (UPDATE writes diff cols + refreshed_at, nothing else)
-- `refreshed_at` ∉ LHS, `refreshed_at` ∉ RHS
-- PK cols ∉ LHS, PK cols ∉ RHS
+- **Diff cols** ≡ LHS tuple cols ≡ RHS tuple cols (exact ordered equality, same names same positions on both sides of `IS DISTINCT FROM`).
+- **Diff cols** ≡ UPDATE SET targets **minus** `{refreshed_at}` (UPDATE writes every diff col + `refreshed_at`, and nothing else).
+- **Diff cols** ∩ PK cols = ∅ (PK cols are matched by ON clause; not in the diff predicate).
+- `refreshed_at` ∉ diff cols, `refreshed_at` ∉ INSERT column list (so DEFAULT now() fires on insert).
 
 Operator-visible semantic: `refreshed_at` advances IFF business cols changed. The drift watermark for repair sweep is in `ownership_refresh_state.last_drained_observations_max_ingested_at` (§3.3), which always advances on every refresh attempt — no longer overloaded with the "did we attempt this" signal.
 
@@ -315,7 +337,7 @@ The `WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = %(iid)s THEN DELETE` cla
 - Concurrent **observation writers** (record_*_observation called from a sibling code path) do not block on the advisory lock. They may commit between the lock acquisition and the MERGE's source-subquery scan; the MERGE will see whatever was committed at scan time. The repair-sweep predicate (§3.3) catches any obs writes that committed after the most recent refresh — that is the whole point of the watermark.
 - PG MERGE takes row-level locks on matched/updated target rows + the locks released at COMMIT. Concurrent same-instrument refreshes (advisory lock contention) → serialised. Concurrent different-instrument refreshes → row-level locks are disjoint by PK; no contention.
 
-## 5. Lint guard (expanded — 7 helpers × 12 invariants = 84 checks)
+## 5. Lint guard (85 clause-counts total — 81 per-helper + 4 cross-cutting)
 
 New script: [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh). Wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after PR11's `check_13dg_retention.sh`. Awk-based function-body block walker (PR4 Codex 1c lesson); every grep guarded against empty-input by exact-count assertion (PR10a Codex iter 1 lesson).
 
@@ -326,17 +348,17 @@ Per helper (×7):
 | **A** | Helper defined exactly once in `app/services/ownership_observations.py` | grep `^def refresh_<X>_current\(` → count == 1 |
 | **B** | No legacy `DELETE FROM ownership_<X>_current` inside helper body | awk-extract body span; grep → count == 0 |
 | **C** | `MERGE INTO ownership_<X>_current AS tgt` opener present | grep inside body span → count == 1 |
-| **D** | Scope-clamp pinned by exact literal `tgt.instrument_id = %(iid)s` in **both** the ON clause and the NOT-MATCHED-BY-SOURCE DELETE clause | grep literal `tgt.instrument_id = %(iid)s` inside body span → count == 2 (one in ON, one in DELETE) |
+| **D** | Scope-clamp pinned by exact literal `tgt.instrument_id = %(iid)s` in **both** the ON clause and the NOT-MATCHED-BY-SOURCE DELETE clause | Block-local awk (Codex 1b MED-5 — count == 2 is satisfiable by two literals in wrong places): (D1) awk-extract the ON-clause span from `MERGE INTO ownership_<X>_current AS tgt` opener through the first `WHEN` keyword; grep literal `tgt.instrument_id = %(iid)s` inside → count == 1. (D2) awk-extract the `WHEN NOT MATCHED BY SOURCE` clause through the `THEN DELETE` terminator; grep literal `tgt.instrument_id = %(iid)s` inside → count == 1. |
 | **E** | `refreshed_at` NOT inside diff predicate's `IS DISTINCT FROM` tuples (either side) | awk-extract span from `WHEN MATCHED AND (` to `) THEN UPDATE`; grep → count == 0 |
 | **F** | `pg_advisory_xact_lock` preserved on function-namespace hash | grep `hashtextextended\('refresh_<X>_current'` inside body → count == 1 |
 | **G** | DISTINCT ON columns match per-helper expected tuple | grep literal `DISTINCT ON (<expected cols>)` inside body → count == 1 |
 | **H** | ORDER BY tuple matches per-helper expected list (whitespace-normalised) | awk-extract `ORDER BY` block; collapse whitespace; compare against per-helper expected string → equal |
 | **I** | UPDATE SET clause writes every non-PK business column AND `refreshed_at` (parity with diff tuples) | awk-extract UPDATE SET block; collect column names; assert set == diff-tuple-cols ∪ {refreshed_at} |
 | **J** | INSERT clause omits exactly `refreshed_at` from column list (DEFAULT now() fires) | awk-extract INSERT column list; assert `refreshed_at` ∉ list; assert set ≡ all-non-PK-cols ∪ {PK cols} |
-| **K** | Per-helper extra WHERE filter literal present inside USING subquery (e.g. treasury `AND treasury_shares IS NOT NULL`; def14a 3-clause ESOP filter) — see §4.1 column "Extra WHERE filter" | grep per-helper literal inside body span → count == 1 (or 0 for helpers with no extra filter; per-helper expected count) |
+| **K** | Per-helper extra WHERE filter clauses present inside USING subquery — see §4.1 column "Extra WHERE filter" | Per-clause grep with per-helper expected counts (Codex 1b MED-6 — def14a's 3 clauses must be counted independently; one clause passing while the other two are dropped must fail the lint): treasury `AND treasury_shares IS NOT NULL` → count == 1; def14a (K1) `AND shares IS NOT NULL` → count == 1, (K2) `AND holder_role IS DISTINCT FROM 'esop'` → count == 1, (K3) `AND holder_name !~* %s` (the `_ESOP_HOLDER_NAME_SQL_REGEX` parameter) → count == 1. Insiders / institutions / blockholders / funds / esop have no extra filter; the K-class is skipped for those helpers (per-helper expected count = 0). |
 | **L** | Helper UPSERTs into `ownership_refresh_state` with the matching category literal | grep `INSERT INTO ownership_refresh_state` inside body span → count == 1 AND grep `'<expected category>'` inside same block → count == 1 |
 
-7 helpers × 12 invariants = **84 per-helper checks**.
+**84 base per-helper checks** (7 helpers × 12 invariants A-L), with K-class per-helper expected content varying per §4.1: def14a's K expands to 3 sub-clauses (K1/K2/K3), treasury's K is 1 clause, the other 5 helpers have no K-class clause. Exact total counting sub-clauses: 7 × 10 (A-J) + 7 × 1 (L) + 1 (treasury K) + 3 (def14a K1/K2/K3) = **81 per-helper clause-counts**.
 
 Plus 4 cross-cutting checks:
 
@@ -347,9 +369,9 @@ Plus 4 cross-cutting checks:
 | **O** | `ownership_observations_repair.py` predicate references `ownership_refresh_state.last_drained_observations_max_ingested_at` (not legacy `c.refreshed_at < ...` form) | grep `c.refreshed_at <` → count == 0 inside the repair file |
 | **P** | Migration `sql/163_ownership_refresh_state.sql` exists and creates the table with the documented PK and CHECK constraint | targeted grep |
 
-Total: **88 lint checks** (84 per-helper + 4 cross-cutting). Pure text walk, no DB dependency, sub-second runtime.
+Total: **85 lint clause-counts** (81 per-helper + 4 cross-cutting). Pure text walk, no DB dependency, sub-second runtime.
 
-## 6. Tests (expanded — 7 helpers × 8 cases = 56 cases + cross-helper + cross-sweep)
+## 6. Tests (45 parametrised cases + helper-specific overlays)
 
 New file: [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py). Parametrised over the 7 helpers.
 
@@ -358,7 +380,7 @@ New file: [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_o
 | # | Case | Setup | Action | Assertion |
 | --- | --- | --- | --- | --- |
 | 1 | **insert** | empty `_current` for instrument I; write 1 observation | `refresh_X_current(I)` | row present; row's `xmin` is a fresh xid (not the pre-call xid) |
-| 2 | **no-op churn** | row present from prior refresh; no observation change; capture per-row `xmin0` + `pgstattuple(table).{table_len, tuple_count, dead_tuple_count}` | `refresh_X_current(I)` again | per-row `xmin::text == xmin0::text` (no rewrite); `pgstattuple.table_len` unchanged; `pgstattuple.dead_tuple_count` delta == 0; `_current.refreshed_at` unchanged (proves diff-predicate excludes it). **Load-bearing for primary bloat fix.** |
+| 2 | **no-op churn** | row present from prior refresh; no observation change; capture per-row `xmin0` + `pgstattuple(_current).{table_len, tuple_count, dead_tuple_count}` + `pgstattuple(ownership_refresh_state).{tuple_count, dead_tuple_count}` | `refresh_X_current(I)` again | per-row `xmin::text == xmin0::text` on `_current` (no rewrite); `pgstattuple(_current).table_len` unchanged; `pgstattuple(_current).dead_tuple_count` delta == 0; `_current.refreshed_at` unchanged (proves diff-predicate excludes it). State-table churn bounded (Codex 1b MED-2): `pgstattuple(ownership_refresh_state).tuple_count` delta == 0 (UPSERT into same PK row) AND `dead_tuple_count` delta ≤ 1 (the in-place state UPDATE produces at most 1 dead tuple per refresh call, autovacuum-bounded). **Load-bearing for primary bloat fix on `_current`; pins state-table bloat surface.** |
 | 3 | **update (amendment)** | row present `xmin0`, refreshed_at0; insert later-`filed_at` observation, same PK, different `shares` | refresh | row present; per-row `xmin::text != xmin0::text`; `shares` reflects amendment; `refreshed_at > refreshed_at0` (advances on actual diff). |
 | 4 | **delete (`known_to` expiry)** | row present; `UPDATE _observations SET known_to = now() WHERE …` | refresh | row absent (NOT MATCHED BY SOURCE → DELETE fired). |
 | 5 | **scope clamp** | rows present for instruments A and B; capture B's per-row `xmin0` | `refresh_X_current(A)` with no observation change | B's row present; B's per-row `xmin::text == xmin0::text` (other-instrument rows untouched). **Pins the literal `tgt.instrument_id = %(iid)s` clamp in ON clause + DELETE clause.** |
@@ -388,7 +410,9 @@ Single-fact assertion; cross-cutting; minimal blast radius. PR description expli
 
 Reclaim path is the **operator pre-wipe + clean re-run** (parent spec §6.3 + §8 acceptance). PR12's contribution is ensuring the clean re-run does not re-bloat the new write-through pattern AND that the repair sweep stays cheap on healthy installs.
 
-**Lock / downtime cost of the operator pre-wipe** (Codex 1a LOW-2 — restated honestly): the parent spec's §6.3 pre-wipe is `TRUNCATE` of every observations + `_current` + `ownership_refresh_state` table. `TRUNCATE` takes an `ACCESS EXCLUSIVE` lock per table → all SELECT/INSERT/UPDATE traffic blocks for the truncate window. Dev DB at 43 GB the operation is typically <30s. Production-grade deployments would need a maintenance window — out of scope here (dev-DB-only operation by design).
+**Honest bloat attribution** (Codex 1b LOW-4): the dominant bloat source under the old pattern is bootstrap / write-through refresh after every observation batch (per-call N-row DELETE+INSERT × ~9k N-PORT accessions × 86 rows-per-instrument). Repair-sweep retriggers under the legacy `c.refreshed_at < (...)` predicate are a **secondary** amplifier, not the primary mass. The diff-aware MERGE eliminates the secondary feeder; the new `ownership_refresh_state` watermark prevents the forever-loop regression that pure MERGE would have introduced. The primary write-side reduction comes from MERGE skipping no-op rewrites of business-identical rows, not from sweep behaviour.
+
+**Lock / downtime cost of the operator pre-wipe** (Codex 1a LOW-2): the parent spec's §6.3 pre-wipe is `TRUNCATE` of every observations + `_current` + `ownership_refresh_state` table. `TRUNCATE` takes an `ACCESS EXCLUSIVE` lock per table → all SELECT/INSERT/UPDATE traffic blocks for the truncate window. Dev DB at ~41 GB the operation is typically <30s. Production-grade deployments would need a maintenance window — out of scope here (dev-DB-only operation by design).
 
 **Read-side unchanged**: no `_current` consumer sees behavioural change. Same row shapes, same dedup ordering, same priorities, same indexes. The MERGE's `WHEN NOT MATCHED BY SOURCE THEN DELETE` is steady-state writer behaviour identical to today's DELETE+INSERT (a row drops out of `_current` only when its only observation expires via `known_to` or when caps shed it post-wipe).
 
@@ -400,8 +424,8 @@ CLAUDE.md §"Definition of done" + §"ETL / parser / schema-migration additional
 
 1. 7 `refresh_*_current` helpers in [`app/services/ownership_observations.py`](../../../app/services/ownership_observations.py) rewritten to single-statement MERGE + `ownership_refresh_state` UPSERT per §4 template + §4.1 per-helper differences. Signature `(conn, *, instrument_id) -> int` preserved on every helper.
 2. New migration `sql/163_ownership_refresh_state.sql` creates the table with the schema in §3.3, plus an idempotent backfill from existing `_current.refreshed_at`. Runs inside the standard migration runner; no `-- runner: autocommit` directive required (no ALTER SYSTEM / CREATE DATABASE / VACUUM / REINDEX SYSTEM).
-3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form (state-table watermark with LATERAL obs-MAX subquery + UNION defence-in-depth tail clause).
-4. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (88 checks: 7 × 12 per-helper + 4 cross-cutting) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
+3. Repair-sweep predicate switched in [`app/jobs/ownership_observations_repair.py`](../../../app/jobs/ownership_observations_repair.py) to the §3.3 form (observations-anchored single-query LEFT JOIN with `IS DISTINCT FROM`). `_CATEGORIES` list expanded to all 7 categories — adds `funds` + `esop` lambdas wiring `refresh_funds_current` + `refresh_esop_current` so the sweep stays uniform with the state-table CHECK constraint (Codex 1b MED-4).
+4. [`scripts/check_ownership_refresh_writer_pattern.sh`](../../../scripts/check_ownership_refresh_writer_pattern.sh) (85 clause-counts: 81 per-helper + 4 cross-cutting, per §5) wired into [`.githooks/pre-push`](../../../.githooks/pre-push) after `check_13dg_retention.sh`.
 5. [`tests/test_ownership_refresh_writer_merge.py`](../../../tests/test_ownership_refresh_writer_merge.py) — parametrised over 7 helpers × 5 base cases + insiders priority-chain + treasury null guard + def14a ESOP exclusion + 7 repair-sweep no-loop cases. Load-bearing no-op-churn case uses per-row `xmin::text` equality + `pgstattuple`.
 6. [`tests/fixtures/ebull_test_db.py`](../../../tests/fixtures/ebull_test_db.py) template provisions `pgstattuple` extension; failure to provision triggers `pytest.fail` in no-op-churn case (no silent skips).
 7. Boot-time PG ≥ 17 guard at lifespan (mirror #1187 pattern). Pinned by `tests/smoke/test_app_boots.py`.
@@ -420,7 +444,7 @@ PR12 alone does not move the post-merge dev DB size (per §8 above). Acceptance 
 Per parent spec §8 acceptance tiers:
 
 - **v1 bar (`<20 GB hot`)** — PR12 audit complete (this spec) + writer remediation merged + pre-wipe + clean re-run lands `ownership_funds_current + ownership_institutions_current` somewhere in the original 5.3 GB ballpark (Codex 1a LOW-3 — DB-size projections in this spec apply only to the two `_current` tables; other hot tables are governed by their respective PR caps).
-- **Phase 2 stretch (`<15 GB hot`)** — PR12 writer fix + observations caps from PR6/PR7 + clean re-run lands combined `_current` ≤ 1 GB. The 2080 MB → ~250 MB compression on funds_current comes from: (a) 786k live rows × 280 B real-data row width = ~220 MB heap + ~80 MB indexes; (b) zero bloat under diff-aware MERGE; (c) repair sweep no longer triggers redundant refreshes that previously fed the bloat. ✅ Phase 2 unblocked by PR12.
+- **Phase 2 stretch (`<15 GB hot`)** — PR12 writer fix + observations caps from PR6/PR7 + clean re-run lands combined `_current` ≤ 1 GB. The 2080 MB → ~250 MB compression on funds_current comes from: (a) 786k live rows × 280 B real-data row width = ~220 MB heap + ~80 MB indexes; (b) MERGE skipping no-op rewrites on business-identical refresh calls (primary saving). The repair-sweep watermark fix is a correctness fix that keeps the sweep cheap on healthy installs; it is not the headline bloat-reduction lever (Codex 1b LOW-4). ✅ Phase 2 unblocked by PR12.
 - **Ambitious (`<10 GB hot`)** — requires further `companyfacts` tightening (Phase 3 ticket; out of #1233 scope).
 
 PR12 measurement protocol post pre-wipe + clean re-run:
@@ -432,15 +456,16 @@ WHERE relname IN ('ownership_funds_current', 'ownership_institutions_current', '
 ORDER BY pg_total_relation_size(oid) DESC;
 ```
 
-Plus per-helper `pgstattuple` to confirm `tuple_percent` ≥ 70% (healthy density floor).
+Per-helper `pgstattuple` confirms `tuple_percent` ≥ 70% on `_current` tables (healthy density floor). Same floor applies to `ownership_refresh_state` (Codex 1b MED-1 — state table churns 1 row UPSERT per refresh call; ≤87k row PK cap means autovacuum easily keeps up at default thresholds; floor pinned by acceptance script).
 
 ## 11. Codex review gate
 
 Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 
 - **Codex 1a** on this spec — completed; 5 HIGH + 7 MED + 4 LOW folded into rev 2.
-- **Codex 1b** on rev 2 (after this commit).
-- Codex 1c if needed.
+- **Codex 1b** on rev 2 — completed; 3 HIGH + 7 MED + 4 LOW folded into rev 3 (this commit).
+- **Codex 1c** on rev 3 (next).
+- Codex 1d if needed.
 - Spec lands as DOC PR (no code yet).
 - Implementation plan = separate doc (`docs/superpowers/plans/2026-05-21-pr12-ownership-current-writer-merge-impl.md`). Codex 1a / 1b on the plan.
 - PR12 implementation PR follows standard #1208 cadence: self-review → Codex 2 pre-push → push → bot review → resolve → APPROVE on latest commit → merge.
@@ -450,6 +475,7 @@ Per #1208 cadence + CLAUDE.md "Codex second-opinion — mandatory checkpoints":
 State at this commit:
 
 - Parent umbrella #1233 still OPEN. PR1-PR11 all SHIPPED (PR11 #1253 020e701 merged 2026-05-21).
+- This is the DESIGN doc for PR12 (rev 3 post-Codex 1b).
 - This is the DESIGN doc for PR12 (rev 2 post-Codex 1a).
 - Branch: `feature/1233-pr12-design-spec`.
 - Next: Codex 1b on rev 2; revise if needed; doc PR; then writing-plans skill → implementation plan → execution.


### PR DESCRIPTION
## Summary

- Design spec for **PR12** — the final PR in the #1233 data-retention rubric umbrella. Rewrites all 7 `refresh_*_current` helpers in `app/services/ownership_observations.py` from the legacy DELETE+INSERT pattern to a single-statement PG17 `MERGE … WHEN NOT MATCHED BY SOURCE` diff-aware reconciler. Adds new `ownership_refresh_state` side-table to keep drift-watermark semantics out of `_current` row data (avoids defeating the bloat fix).
- Empirical evidence: `pgstattuple('ownership_funds_current')` = 10.22% tuple density (1855 MB free space of 2080 MB heap; 222 MB live data across 786k rows). `ownership_institutions_current` healthy at 77.35% but same writer — primed to degrade at fund-scale fanout.
- 6 Codex review rounds (1a–1f) over 7 revisions. HIGH count: 5 → 3 → 1 → 3 → 0 → 0 (stable two rounds). MED: 7 → 7 → 3 → 3 → 2 → 1.

Refs #1233.

## Test plan

- [ ] This PR is doc-only — no code changes. Lint + typecheck + tests should pass trivially.
- [ ] Bot review on doc spec.
- [ ] Implementation PR follows: writing-plans skill produces impl plan → Codex 1a/1b on plan → standard #1208 cadence (self-review → Codex 2 pre-push → push → bot → merge).

## References

- Parent spec: `docs/superpowers/specs/2026-05-19-data-retention-rubric.md` §4.5 / §4.6 / §6.4 / §7 / §8
- Prior umbrella PRs: #1237 PR2, #1239 PR3, #1240 PR4, #1236 + #1241 PR5, #1242 PR6, #1243 PR7, #1244 PR8, #1245 PR9, #1246 PR10a, #1248 PR10b, #1253 PR11
- This spec: `docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md` (1a23fbe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)