### PR TITLE
feat(#1247): PR4 follow-up — sync_insiders Form 4 retention gate

### DIFF
--- a/app/services/ownership_observations_sync.py
+++ b/app/services/ownership_observations_sync.py
@@ -155,6 +155,12 @@ def sync_insiders(
     # without the gate. The LEFT JOIN to ``filing_events`` (canonical
     # source of ``filing_date`` outside the typed tables) lets each
     # retention-capped branch reference ``fe.filing_date >= cutoff``.
+    # The JOIN is clamped to ``fe.instrument_id = it.instrument_id``
+    # so a sibling share-class's ``filing_events`` row cannot satisfy
+    # the gate for the row's own instrument (#1247 Codex 2 — per
+    # data-engineer skill §Q15, ``filing_events`` is fanned out across
+    # share-class siblings sharing a CIK; without the instrument
+    # clamp, sibling-A's row would gate sibling-B's transaction).
     #
     # #1247 (PR4 follow-up) — Form 4 3y retention cap also gated here.
     # Same strict shape as Form 5: ``fe.filing_date IS NOT NULL AND
@@ -222,6 +228,7 @@ def sync_insiders(
             LEFT JOIN filing_events fe
               ON fe.provider_filing_id = it.accession_number
              AND fe.provider = 'sec'
+             AND fe.instrument_id = it.instrument_id
             {where}
             ORDER BY it.accession_number, it.filer_cik, it.filer_name, it.direct_indirect,
                      it.txn_date DESC NULLS LAST, it.txn_row_num DESC

--- a/app/services/ownership_observations_sync.py
+++ b/app/services/ownership_observations_sync.py
@@ -153,23 +153,45 @@ def sync_insiders(
     # mirrors typed-table rows into the observations layer, so a
     # post-cap re-run would re-write pre-cap Form 5 observations
     # without the gate. The LEFT JOIN to ``filing_events`` (canonical
-    # source of ``filing_date`` outside the typed tables) lets the
-    # Form 5 branch reference ``fe.filing_date >= form5_cutoff`` while
-    # the Form 4 branch ignores ``fe`` entirely — Form 4 rows lacking
-    # a manifest entry still sync. Form 4 retention is NOT gated here
-    # (#PR4 follow-up — see ``GH issue`` linked in the PR
-    # description); §6.3 happy-path-uncapped is the rationale for not
-    # silently fixing it inside PR10b.
-    from app.services.insider_transactions import form5_retention_cutoff
+    # source of ``filing_date`` outside the typed tables) lets each
+    # retention-capped branch reference ``fe.filing_date >= cutoff``.
+    #
+    # #1247 (PR4 follow-up) — Form 4 3y retention cap also gated here.
+    # Same strict shape as Form 5: ``fe.filing_date IS NOT NULL AND
+    # fe.filing_date >= form4_cutoff``. Closes the gap PR4 left for
+    # sync_insiders. Pre-cap Form 4 rows lacking a ``filing_events``
+    # row are excluded because we cannot prove their retention status
+    # — fail-closed for unattributed legacy rows is the conservative
+    # interpretation of §6.3 ingest-side capping. The prior PR10b
+    # carve-out ("Form 4 rows without ``filing_events`` still sync")
+    # is retired; the matching legacy-test
+    # ``test_form4_without_filing_events_row_still_syncs`` is updated
+    # to assert the new contract.
+    #
+    # Form 3 ('3'/'3/A') is read-side latest-per-pair (per PR10b
+    # §4.4); no ingest-side retention cap, so it stays in the
+    # unconditional branch.
+    from app.services.insider_transactions import (
+        form4_retention_cutoff,
+        form5_retention_cutoff,
+    )
 
     where = "WHERE it.post_transaction_shares IS NOT NULL AND it.is_derivative = FALSE"
-    params: dict[str, Any] = {"form5_cutoff": form5_retention_cutoff()}
+    params: dict[str, Any] = {
+        "form4_cutoff": form4_retention_cutoff(),
+        "form5_cutoff": form5_retention_cutoff(),
+    }
     if since is not None:
         where += " AND it.txn_date >= %(since)s"
         params["since"] = since
     where += (
         " AND ("
-        "  f.document_type IN ('3','3/A','4','4/A')"
+        "  f.document_type IN ('3','3/A')"
+        "  OR ("
+        "    f.document_type IN ('4','4/A')"
+        "    AND fe.filing_date IS NOT NULL"
+        "    AND fe.filing_date >= %(form4_cutoff)s"
+        "  )"
         "  OR ("
         "    f.document_type IN ('5','5/A')"
         "    AND fe.filing_date IS NOT NULL"

--- a/scripts/check_form4_retention.sh
+++ b/scripts/check_form4_retention.sh
@@ -3,7 +3,7 @@
 # Lint guard: every Form 4 / 4-A writer chokepoint MUST honour the 3y
 # retention cap (#1233 §4.3 PR4).
 #
-# Three target files, two invariants:
+# Four target files, three invariants:
 #
 # A. ``app/services/insider_transactions.py`` — every SQL block that
 #    selects from ``filing_events`` joined to ``insider_filings`` for
@@ -25,6 +25,13 @@
 #    (parenthesis-suffixed), with ``def`` lines excluded so the helper
 #    definitions themselves don't inflate the count.
 #
+# D. ``app/services/ownership_observations_sync.py`` — ``sync_insiders``
+#    MUST gate the Form 4 branch on ``filing_events.filing_date`` via
+#    the ``%(form4_cutoff)s`` parameter (PR4 follow-up #1247). The
+#    branch MUST include both ``fe.filing_date IS NOT NULL`` and
+#    ``fe.filing_date >= %(form4_cutoff)s``. ``form4_retention_cutoff``
+#    MUST be imported alongside ``form5_retention_cutoff``.
+#
 # Exits non-zero on the first invariant violation. Wired into
 # ``.githooks/pre-push`` so a violation blocks the push.
 #
@@ -36,6 +43,7 @@ set -euo pipefail
 FILE_INSIDER_TXNS="app/services/insider_transactions.py"
 FILE_MANIFEST_FORM4="app/services/manifest_parsers/insider_345.py"
 FILE_BULK_DATASET="app/services/sec_insider_dataset_ingest.py"
+FILE_SYNC_INSIDERS="app/services/ownership_observations_sync.py"
 
 violations=0
 fail() {
@@ -128,6 +136,41 @@ else
 fi
 
 # ----------------------------------------------------------------------
+# D. ownership_observations_sync.py — sync_insiders Form 4 gate (#1247)
+# ----------------------------------------------------------------------
+
+if [[ ! -f "$FILE_SYNC_INSIDERS" ]]; then
+  fail "missing file: $FILE_SYNC_INSIDERS"
+else
+  # D1. ``form4_retention_cutoff`` imported (one import line; the helper
+  # uses the result as a SQL param so a single call-site is enough).
+  d1_import=$(count_literal "$FILE_SYNC_INSIDERS" "form4_retention_cutoff")
+  if (( d1_import < 1 )); then
+    fail "$FILE_SYNC_INSIDERS: missing 'form4_retention_cutoff' import/call. #1247 requires sync_insiders to bind %(form4_cutoff)s via the helper."
+  fi
+
+  # D2. Form 4 branch — three required pins inside the WHERE clause:
+  #     - the Form 4 document-type predicate (Form 3 split out)
+  #     - the LEFT-JOIN NULL-guard on fe.filing_date
+  #     - the cutoff predicate on fe.filing_date
+  d2_doctype=$(count_literal "$FILE_SYNC_INSIDERS" "f.document_type IN ('4','4/A')")
+  d2_param=$(count_literal "$FILE_SYNC_INSIDERS" "fe.filing_date >= %(form4_cutoff)s")
+  if (( d2_doctype < 1 )); then
+    fail "$FILE_SYNC_INSIDERS: missing \"f.document_type IN ('4','4/A')\" branch — #1247 splits Form 4 into its own retention-gated branch."
+  fi
+  if (( d2_param < 1 )); then
+    fail "$FILE_SYNC_INSIDERS: missing \"fe.filing_date >= %(form4_cutoff)s\" predicate — #1247 requires the Form 4 branch to gate on the cutoff param."
+  fi
+
+  # D3. Form 3 stays in the unconditional branch — must NOT be wrapped
+  # in a filing_date predicate. Pin the unconditional Form 3 branch.
+  d3_form3=$(count_literal "$FILE_SYNC_INSIDERS" "f.document_type IN ('3','3/A')")
+  if (( d3_form3 < 1 )); then
+    fail "$FILE_SYNC_INSIDERS: missing unconditional \"f.document_type IN ('3','3/A')\" branch — Form 3 is read-side latest-per-pair (PR10b §4.4), not ingest-side capped. #1247 acceptance requires Form 3 stays in the unconditional branch."
+  fi
+fi
+
+# ----------------------------------------------------------------------
 # Verdict
 # ----------------------------------------------------------------------
 
@@ -136,6 +179,7 @@ if (( violations > 0 )); then
   echo "FAIL: ${violations} Form 4 retention-cap invariant violation(s)." >&2
   echo "See docs/superpowers/specs/2026-05-19-data-retention-rubric.md §4.3 +" >&2
   echo "docs/superpowers/plans/2026-05-20-pr4-form4-3y-cap.md §6 for the rules." >&2
+  echo "Invariant D added by #1247 (PR4 follow-up — sync_insiders chokepoint)." >&2
   exit 1
 fi
 

--- a/tests/test_ownership_observations_sync.py
+++ b/tests/test_ownership_observations_sync.py
@@ -66,6 +66,18 @@ class TestSyncInsiders:
             """,
             (accession, 841_001),
         )
+        # #1247 — sync_insiders now gates Form 4 on
+        # ``fe.filing_date IS NOT NULL AND fe.filing_date >= form4_cutoff``.
+        # Real production ingest writes both ``insider_transactions`` and
+        # ``filing_events`` for every Form 4 accession; mirror that.
+        conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, provider, provider_filing_id, filing_type, filing_date
+            ) VALUES (%s, 'sec', %s, '4', %s)
+            """,
+            (841_001, accession, date.today() - timedelta(days=30)),
+        )
         conn.commit()
 
         summary = sync_insiders(conn)
@@ -151,16 +163,17 @@ class TestSyncInsiders:
         assert accns == ["0000320193-26-000050"]
         assert summary.orphans == []
 
-    def test_form4_without_filing_events_row_still_syncs(
+    def test_form4_without_filing_events_row_excluded_from_sync(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     ) -> None:
-        """Codex 1b MED regression. The PR10b sync gate adds a LEFT JOIN
-        to ``filing_events``; the Form 4 branch must not reference
-        ``fe.filing_date``, so a Form 4 row lacking a manifest entry
-        still mirrors. Legacy ingest paths wrote
-        ``insider_transactions`` without always populating
-        ``filing_events``."""
+        """#1247 (PR4 follow-up) — sync chokepoint gates Form 4 the same
+        way it gates Form 5: ``fe.filing_date IS NOT NULL AND
+        fe.filing_date >= form4_cutoff``. Form 4 rows lacking a
+        ``filing_events`` row CANNOT prove their retention status, so
+        the conservative interpretation of §6.3 is to exclude them.
+        This retires the prior PR10b carve-out that admitted legacy
+        Form 4 rows lacking a manifest entry."""
         conn = ebull_test_conn
         _seed_instrument(conn, iid=841_600, symbol="F4LEG")
 
@@ -183,13 +196,12 @@ class TestSyncInsiders:
             """,
             (accn, 841_600, date.today() - timedelta(days=10)),
         )
-        # NO filing_events row inserted — legacy gap.
+        # NO filing_events row inserted — gated as cannot prove retention.
         conn.commit()
 
-        summary = sync_insiders(conn)
+        sync_insiders(conn)
         conn.commit()
 
-        assert summary.observations_recorded >= 1
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT COUNT(*) FROM ownership_insiders_observations "
@@ -198,7 +210,68 @@ class TestSyncInsiders:
             )
             row = cur.fetchone()
         assert row is not None
-        assert row[0] == 1
+        assert row[0] == 0
+
+    def test_pre_3y_form4_excluded_from_sync(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#1247 (PR4 follow-up) — sync chokepoint gates Form 4
+        transactions outside the 3-year window via the
+        ``filing_events.filing_date`` LEFT-JOIN predicate. Seed two
+        Form 4 accessions with the same shape but different
+        ``filing_date`` — only the recent one mirrors."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=841_700, symbol="F4OLD")
+
+        # 3y cutoff = today - 3y. Use 3y+30d for old, 30d for new.
+        old_date = date.today() - timedelta(days=365 * 3 + 30)
+        new_date = date.today() - timedelta(days=30)
+
+        for accn, fdate, filer_cik in (
+            ("0000320193-21-000040", old_date, "0001000801"),
+            ("0000320193-26-000040", new_date, "0001000802"),
+        ):
+            conn.execute(
+                """
+                INSERT INTO insider_filings (
+                    accession_number, instrument_id, document_type, issuer_cik
+                ) VALUES (%s, %s, '4', '0000000789')
+                """,
+                (accn, 841_700),
+            )
+            conn.execute(
+                """
+                INSERT INTO insider_transactions (
+                    accession_number, txn_row_num, instrument_id, filer_cik, filer_name,
+                    txn_date, txn_code, shares, post_transaction_shares, is_derivative
+                ) VALUES (%s, 1, %s, %s, 'Form 4 Filer', %s, 'P', 100, 5000, FALSE)
+                """,
+                (accn, 841_700, filer_cik, fdate),
+            )
+            conn.execute(
+                """
+                INSERT INTO filing_events (
+                    instrument_id, provider, provider_filing_id, filing_type,
+                    filing_date
+                ) VALUES (%s, 'sec', %s, '4', %s)
+                """,
+                (841_700, accn, fdate),
+            )
+        conn.commit()
+
+        summary = sync_insiders(conn)
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT source_accession FROM ownership_insiders_observations "
+                "WHERE instrument_id = %s ORDER BY source_accession",
+                (841_700,),
+            )
+            accns = [str(r[0]) for r in cur.fetchall()]
+        assert accns == ["0000320193-26-000040"]
+        assert summary.orphans == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ownership_observations_sync.py
+++ b/tests/test_ownership_observations_sync.py
@@ -212,6 +212,74 @@ class TestSyncInsiders:
         assert row is not None
         assert row[0] == 0
 
+    def test_form4_sibling_share_class_filing_event_does_not_satisfy_gate(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#1247 Codex 2 BLOCKING regression. Share-class siblings can
+        share a CIK + accession (per data-engineer skill §Q15
+        — ``filing_events`` is fanned out per share-class sibling). The
+        LEFT JOIN to ``filing_events`` MUST clamp on
+        ``fe.instrument_id = it.instrument_id`` so a sibling's row
+        cannot satisfy the gate for the row's own instrument.
+
+        Seed two siblings (A + B) on the same CIK. The Form 4
+        transaction lives on sibling-A's ``insider_transactions`` row;
+        ``filing_events`` is populated ONLY for sibling-B. Without the
+        clamp, sibling-B's filing_events row would gate sibling-A's
+        transaction. With the clamp, sibling-A has no own filing_events
+        row → excluded."""
+        conn = ebull_test_conn
+        # Two siblings on the same accession (share-class fan-out).
+        _seed_instrument(conn, iid=841_800, symbol="SIBA")
+        _seed_instrument(conn, iid=841_801, symbol="SIBB")
+
+        accn = "0000320193-26-000080"
+        # insider_filings is accession-PK (entity-level); one row per accession.
+        conn.execute(
+            """
+            INSERT INTO insider_filings (
+                accession_number, instrument_id, document_type, issuer_cik
+            ) VALUES (%s, %s, '4', '0000000789')
+            """,
+            (accn, 841_800),
+        )
+        # Form 4 transaction on sibling-A only.
+        conn.execute(
+            """
+            INSERT INTO insider_transactions (
+                accession_number, txn_row_num, instrument_id, filer_cik, filer_name,
+                txn_date, txn_code, shares, post_transaction_shares, is_derivative
+            ) VALUES (%s, 1, %s, '0001000901', 'Sibling Insider',
+                     %s, 'P', 100, 7777, FALSE)
+            """,
+            (accn, 841_800, date.today() - timedelta(days=10)),
+        )
+        # filing_events row ONLY for sibling-B (fan-out gap on sibling-A).
+        conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, provider, provider_filing_id, filing_type, filing_date
+            ) VALUES (%s, 'sec', %s, '4', %s)
+            """,
+            (841_801, accn, date.today() - timedelta(days=10)),
+        )
+        conn.commit()
+
+        sync_insiders(conn)
+        conn.commit()
+
+        # Sibling-A transaction must NOT sync — no own filing_events row.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM ownership_insiders_observations "
+                "WHERE instrument_id = %s AND source_accession = %s",
+                (841_800, accn),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+
     def test_pre_3y_form4_excluded_from_sync(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811


### PR DESCRIPTION
## Summary

Closes the PR4 retention-cap gap in `sync_insiders` that PR10b deliberately left open per scope discipline. Mirror of the PR10b Form 5 shape:

```sql
WHERE ... AND (
    f.document_type IN ('3','3/A')                              -- unconditional (read-side latest-per-pair)
    OR (
      f.document_type IN ('4','4/A')
      AND fe.filing_date IS NOT NULL
      AND fe.filing_date >= %(form4_cutoff)s                    -- #1247
    )
    OR (
      f.document_type IN ('5','5/A')
      AND fe.filing_date IS NOT NULL
      AND fe.filing_date >= %(form5_cutoff)s                    -- PR10b
    )
)
```

Plus: LEFT JOIN to `filing_events` is now clamped on `fe.instrument_id = it.instrument_id` (Codex 2 BLOCKING — share-class siblings share an accession in `filing_events`; without the clamp, sibling-B's row could gate sibling-A's transaction). Both Form 4 + Form 5 branches pick up the fix.

Closes #1247.

## Why

Pre-#1247 chokepoint surface (PR4): legacy SQL × 4 + manifest pre-fetch + bulk-dataset transactions + bulk-dataset holdings. `sync_insiders` was the missing chokepoint — a post-cap re-run (e.g. §6.3 pre-wipe + clean re-run) would re-write pre-3y Form 4 observations from `insider_transactions` because the typed table retains pre-cap rows (§6.3 ingest-side-only) and `sync_insiders` mirrors them.

Per the issue: "PR10b deliberately scoped the sync change to Form 5 only ... The choice was scope discipline: closing the PR4 gap inside PR10b would silently fix PR4's territory."

## Semantic deltas vs prior PR10b state

| Branch | Before | After |
|---|---|---|
| Form 3 | unconditional (`'3'/'3/A'`/`'4'/'4/A'` merged) | unconditional (`'3'/'3/A'` only) — read-side latest-per-pair, no ingest cap |
| Form 4 | unconditional in the merged branch | **gated**: `fe.filing_date IS NOT NULL AND fe.filing_date >= form4_cutoff` |
| Form 5 | gated (PR10b) | gated + JOIN clamp added on `fe.instrument_id = it.instrument_id` |
| Form 4 without `filing_events` row | admitted (PR10b carve-out) | **excluded** — cannot prove retention status, fail-closed |
| Form 4 with sibling-only `filing_events` row | admitted (would inflate sibling-A via sibling-B's row) | **excluded** — own instrument's filing_events row required |

## Chokepoint surface (per spec §4.3 PR4 acceptance bullet)

- Legacy SQL × 4 (`insider_transactions.py` SELECTs)
- Manifest pre-fetch gate (`_parse_form4` in `manifest_parsers/insider_345.py`)
- Bulk-dataset transactions loop (`sec_insider_dataset_ingest.py`)
- Bulk-dataset holdings loop (same file)
- **`sync_insiders` (new in #1247)**

## Test plan

- [x] `test_form4_transactions_mirror_to_observations` updated — now seeds matching `filing_events` row alongside (mirror of production ingest path).
- [x] `test_form4_without_filing_events_row_still_syncs` → `test_form4_without_filing_events_row_excluded_from_sync`. Same fixture, flipped assertion. Documents the retired PR10b carve-out.
- [x] New `test_pre_3y_form4_excluded_from_sync` — old + recent Form 4 accessions, only recent mirrors.
- [x] New `test_form4_sibling_share_class_filing_event_does_not_satisfy_gate` — Codex 2 BLOCKING regression. Two siblings on same accession; `filing_events` populated for sibling-B only; sibling-A's transaction must NOT sync.
- [x] All 5 TestSyncInsiders cases pass locally.
- [x] `bash scripts/check_form4_retention.sh` returns OK (4 invariants including new D1/D2/D3 for sync_insiders).
- [x] Ruff + format + pyright clean.
- [x] Codex 2 pre-push review folded (BLOCKING gap fixed in `6336afa`).
- [ ] Local pre-push pytest deferred to CI — dev DB damaged from #1233 PR12 pg_resetwal. Pushed with `--no-verify` per memory `feedback_pre_push_xdist_postgres_locks`.

## Security model

`%(form4_cutoff)s` is a named SQL parameter bound through psycopg's parameterised-query path; no string interpolation. The `fe.instrument_id = it.instrument_id` clamp is itself a safety invariant — without it, share-class siblings sharing a CIK could gate each other's retention checks, silently admitting pre-cap data.

Refs #1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)