### PR TITLE
feat: focused /setup/broker page — chrome-free key entry + validate-before-save

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { IngestHealthPage } from "@/pages/IngestHealthPage";
 import { CoverageInsufficientPage } from "@/pages/CoverageInsufficientPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
+import { BrokerSetupPage } from "@/pages/BrokerSetupPage";
 import { LoginPage } from "@/pages/LoginPage";
 import { SetupPage } from "@/pages/SetupPage";
 import { OperatorsPage } from "@/pages/OperatorsPage";
@@ -37,6 +38,17 @@ export function App() {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/setup" element={<SetupPage />} />
+        {/* Chrome-free broker-credentials setup. Requires auth but
+            renders outside AppShell so the operator sees only the
+            key-entry form until eToro creds are validated + saved. */}
+        <Route
+          path="/setup/broker"
+          element={
+            <RequireAuth>
+              <BrokerSetupPage />
+            </RequireAuth>
+          }
+        />
         <Route
           element={
             <RequireAuth>

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -9,9 +9,15 @@
  *   - status === "needs_setup":  redirect to /setup
  *   - status === "unauthenticated": redirect to /login?next=<current path>
  *   - status === "authenticated" + no active broker_credentials:
- *                                redirect to /settings UNLESS already there
- *                                (eBull is eToro-binding; main app inert
- *                                without credentials — CLAUDE.md I12).
+ *                                redirect to /setup/broker UNLESS already
+ *                                on that path. The focused chrome-free
+ *                                page renders only the key-entry form so
+ *                                the operator is not distracted by the
+ *                                main app shell with its sidebar +
+ *                                Settings/Budget/etc. surface while keys
+ *                                are still missing (eBull is eToro-binding;
+ *                                main app inert without credentials —
+ *                                CLAUDE.md I12).
  *   - status === "authenticated":   render children.
  *
  * No fancy spinner -- the loading window is intentionally tiny and any
@@ -24,9 +30,11 @@ import { Navigate, useLocation } from "react-router-dom";
 import { useSession } from "@/lib/session";
 
 // Routes that an authenticated operator can reach with no active
-// broker_credentials. /settings is where the add-credentials form lives;
-// /logout must always be reachable. Keep this list intentionally tiny.
-const BROKER_FREE_PATHS: readonly string[] = ["/settings", "/logout"];
+// broker_credentials. /setup/broker is the focused chrome-free key-
+// entry page; /logout must always be reachable so the operator can
+// switch accounts even from a creds-missing state. Keep this list
+// intentionally tiny — the gate is the WHOLE point.
+const BROKER_FREE_PATHS: readonly string[] = ["/setup/broker", "/logout"];
 
 export function RequireAuth({ children }: { children: ReactNode }): JSX.Element {
   const { status, bootstrapState } = useSession();
@@ -49,14 +57,14 @@ export function RequireAuth({ children }: { children: ReactNode }): JSX.Element 
     return <Navigate to={`/login?next=${next}`} replace />;
   }
 
-  // Authenticated but no active broker credentials → force /settings.
-  // The check is strict path-prefix so sub-routes of /settings (e.g.
-  // /settings/something) stay reachable; everything else redirects.
+  // Authenticated but no active broker credentials → force /setup/broker.
+  // Strict path-prefix match so sub-routes of /setup/broker remain
+  // reachable; every other path redirects.
   if (
     bootstrapState?.needs_broker_credentials &&
     !BROKER_FREE_PATHS.some((p) => location.pathname === p || location.pathname.startsWith(p + "/"))
   ) {
-    return <Navigate to="/settings" replace />;
+    return <Navigate to="/setup/broker" replace />;
   }
 
   return <>{children}</>;

--- a/frontend/src/pages/BrokerSetupPage.tsx
+++ b/frontend/src/pages/BrokerSetupPage.tsx
@@ -1,0 +1,255 @@
+/**
+ * /setup/broker — focused eToro credentials setup wizard.
+ *
+ * Displayed instead of the main app shell whenever the logged-in
+ * operator has no active broker credential set. eBull is fundamentally
+ * eToro-binding (CLAUDE.md non-negotiable I12 — eToro is the sole
+ * execution boundary); without keys the main app is inert, so we route
+ * the operator to this chrome-free single-form page instead of the
+ * Settings page (which buries the credential form mid-page next to
+ * other settings the operator doesn't care about right now).
+ *
+ * Contract: the Save button runs validation BEFORE saving — keys are
+ * never persisted unless the eToro `/api/v1/me` probe succeeds. This
+ * matches the operator ask "enter and validate keys before getting
+ * into the site" (2026-05-22).
+ *
+ * Flow:
+ *   1. Operator enters api_key + user_key.
+ *   2. Click Save → frontend calls validateBrokerCredential (no save).
+ *   3. On validate success: createBrokerCredential × 2 (api_key + user_key).
+ *   4. Refresh bootstrap state → RequireAuth gate releases → main app.
+ *   5. On validate failure: surface eToro's note + keep keys in form;
+ *      do NOT save.
+ *
+ * The Test connection button is available as an optional dry-run check
+ * before commit. Save also validates, so Test is redundant for the
+ * happy path; kept for parity with the SettingsPage flow.
+ */
+
+import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { ApiError } from "@/api/client";
+import {
+  type ValidateCredentialResponse,
+  createBrokerCredential,
+  validateBrokerCredential,
+} from "@/api/brokerCredentials";
+import { ValidationResultDisplay } from "@/components/broker/ValidationResultDisplay";
+import { ENVIRONMENT } from "@/lib/credentialSetMode";
+import { useSession } from "@/lib/session";
+
+const MIN_SECRET_LEN = 4;
+
+export function BrokerSetupPage(): JSX.Element {
+  const { status, bootstrapState, refreshBootstrapState, logout } = useSession();
+  const navigate = useNavigate();
+
+  const [apiKey, setApiKey] = useState("");
+  const [userKey, setUserKey] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [validating, setValidating] = useState(false);
+  const [validationResult, setValidationResult] =
+    useState<ValidateCredentialResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auth gates — page is only meaningful when logged in + still missing creds.
+  useEffect(() => {
+    if (status === "loading") return;
+    if (status === "unauthenticated") {
+      navigate("/login", { replace: true });
+      return;
+    }
+    if (status === "needs_setup") {
+      navigate("/setup", { replace: true });
+      return;
+    }
+    if (bootstrapState && !bootstrapState.needs_broker_credentials) {
+      // Creds already present (or just landed) — release to the main app.
+      navigate("/", { replace: true });
+    }
+  }, [status, bootstrapState, navigate]);
+
+  const keysReady =
+    apiKey.length >= MIN_SECRET_LEN && userKey.length >= MIN_SECRET_LEN;
+
+  async function handleTestConnection(): Promise<void> {
+    setError(null);
+    setValidationResult(null);
+    setValidating(true);
+    try {
+      const result = await validateBrokerCredential({
+        api_key: apiKey,
+        user_key: userKey,
+        environment: ENVIRONMENT,
+      });
+      setValidationResult(result);
+    } catch {
+      setError("Could not reach the validator. Try again.");
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      // Validate before saving — operator ask: never persist keys that
+      // don't authenticate against eToro.
+      const validation = await validateBrokerCredential({
+        api_key: apiKey,
+        user_key: userKey,
+        environment: ENVIRONMENT,
+      });
+      setValidationResult(validation);
+
+      if (!validation.auth_valid) {
+        setError(
+          validation.note ||
+            "eToro rejected these credentials. Check the keys and try again.",
+        );
+        return;
+      }
+
+      // Save both rows. createBrokerCredential is idempotent on the
+      // partial-UNIQUE (operator_id, provider, label) WHERE NOT revoked
+      // index; if the prior save succeeded but the second one failed we
+      // do not duplicate.
+      await createBrokerCredential({
+        provider: "etoro",
+        label: "api_key",
+        environment: ENVIRONMENT,
+        secret: apiKey,
+      });
+      await createBrokerCredential({
+        provider: "etoro",
+        label: "user_key",
+        environment: ENVIRONMENT,
+        secret: userKey,
+      });
+
+      // Flip the RequireAuth gate.
+      await refreshBootstrapState();
+      navigate("/", { replace: true });
+    } catch (err: unknown) {
+      if (err instanceof ApiError && err.status === 409) {
+        setError(
+          "Credentials already saved against this operator. " +
+            "Sign out and back in, or revoke the existing set in Settings.",
+        );
+      } else {
+        setError("Could not save credentials. Try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleSignOut(): Promise<void> {
+    try {
+      await logout();
+    } catch {
+      // logout itself navigates to /login; swallow surface error.
+    }
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-slate-50 dark:bg-slate-900/40 text-sm text-slate-400">
+        Loading…
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center bg-slate-50 dark:bg-slate-900/40">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md rounded border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6 shadow-sm"
+      >
+        <h1 className="mb-1 text-lg font-semibold text-slate-800 dark:text-slate-100">
+          Add eToro credentials
+        </h1>
+        <p className="mb-4 text-xs text-slate-500 dark:text-slate-400">
+          eBull needs your eToro API key + user key to connect. Keys are
+          validated against eToro before being saved. Stored encrypted at
+          rest under your master key; never displayed back.
+        </p>
+
+        <label className="mb-3 block text-sm">
+          <span className="mb-1 block text-slate-600 dark:text-slate-300">
+            Public key (API key)
+          </span>
+          <input
+            type="password"
+            autoComplete="off"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            required
+            minLength={MIN_SECRET_LEN}
+            className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm dark:bg-slate-800 dark:text-slate-100"
+          />
+        </label>
+        <label className="mb-4 block text-sm">
+          <span className="mb-1 block text-slate-600 dark:text-slate-300">
+            Private key (user key)
+          </span>
+          <input
+            type="password"
+            autoComplete="off"
+            value={userKey}
+            onChange={(e) => setUserKey(e.target.value)}
+            required
+            minLength={MIN_SECRET_LEN}
+            className="w-full rounded border border-slate-300 dark:border-slate-700 px-2 py-1.5 text-sm dark:bg-slate-800 dark:text-slate-100"
+          />
+        </label>
+
+        {validationResult !== null && (
+          <div className="mb-3">
+            <ValidationResultDisplay result={validationResult} error={null} />
+          </div>
+        )}
+
+        {error !== null && (
+          <div
+            role="alert"
+            className="mb-3 rounded bg-rose-50 dark:bg-rose-900/30 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleTestConnection}
+            disabled={!keysReady || validating || submitting}
+            className="flex-1 rounded border border-slate-300 dark:border-slate-700 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 disabled:opacity-50"
+          >
+            {validating ? "Testing…" : "Test connection"}
+          </button>
+          <button
+            type="submit"
+            disabled={!keysReady || submitting || validating}
+            className="flex-1 rounded bg-slate-800 dark:bg-slate-700 py-2 text-sm font-medium text-white disabled:bg-slate-400 dark:disabled:bg-slate-600"
+          >
+            {submitting ? "Saving…" : "Save & continue"}
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleSignOut}
+          className="mt-4 block w-full text-center text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          Sign out
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/BrokerSetupPage.tsx
+++ b/frontend/src/pages/BrokerSetupPage.tsx
@@ -35,6 +35,7 @@ import { ApiError } from "@/api/client";
 import {
   type ValidateCredentialResponse,
   createBrokerCredential,
+  revokeBrokerCredential,
   validateBrokerCredential,
 } from "@/api/brokerCredentials";
 import { ValidationResultDisplay } from "@/components/broker/ValidationResultDisplay";
@@ -115,22 +116,52 @@ export function BrokerSetupPage(): JSX.Element {
         return;
       }
 
-      // Save both rows. createBrokerCredential is idempotent on the
-      // partial-UNIQUE (operator_id, provider, label) WHERE NOT revoked
-      // index; if the prior save succeeded but the second one failed we
-      // do not duplicate.
-      await createBrokerCredential({
-        provider: "etoro",
-        label: "api_key",
-        environment: ENVIRONMENT,
-        secret: apiKey,
-      });
-      await createBrokerCredential({
-        provider: "etoro",
-        label: "user_key",
-        environment: ENVIRONMENT,
-        secret: userKey,
-      });
+      // Save both rows. The partial-UNIQUE (operator_id, provider,
+      // label, environment) WHERE NOT revoked index means a duplicate
+      // active row throws 409 — so the second create cannot land if
+      // the first one is left behind. Bot iter 1 caught the deadlock:
+      // if api_key save succeeds but user_key save fails (network
+      // blip, race, etc.), the operator is stuck on /setup/broker
+      // because every retry 409s on api_key + /settings is gated out.
+      //
+      // Recovery: capture the first save's id and revoke it on the
+      // second failure so a retry can land cleanly. Best-effort —
+      // a revoke that itself fails still leaves the operator with an
+      // actionable error message naming the stuck label.
+      let firstSaveId: string | null = null;
+      try {
+        const firstSave = await createBrokerCredential({
+          provider: "etoro",
+          label: "api_key",
+          environment: ENVIRONMENT,
+          secret: apiKey,
+        });
+        firstSaveId = firstSave.credential.id;
+
+        await createBrokerCredential({
+          provider: "etoro",
+          label: "user_key",
+          environment: ENVIRONMENT,
+          secret: userKey,
+        });
+      } catch (saveErr: unknown) {
+        if (firstSaveId !== null) {
+          // The api_key save succeeded; user_key save threw. Revoke
+          // the orphan so the next retry doesn't 409.
+          try {
+            await revokeBrokerCredential(firstSaveId);
+          } catch {
+            setError(
+              "Partial save: api_key was stored but user_key failed, and " +
+                "the recovery revoke ALSO failed. Sign out and contact " +
+                "operator support — the api_key row needs manual revoke " +
+                "before the next attempt can land.",
+            );
+            return;
+          }
+        }
+        throw saveErr;
+      }
 
       // Flip the RequireAuth gate.
       await refreshBootstrapState();
@@ -138,8 +169,8 @@ export function BrokerSetupPage(): JSX.Element {
     } catch (err: unknown) {
       if (err instanceof ApiError && err.status === 409) {
         setError(
-          "Credentials already saved against this operator. " +
-            "Sign out and back in, or revoke the existing set in Settings.",
+          "Credentials already saved against this operator under a " +
+            "different label. Sign out and back in to retry.",
         );
       } else {
         setError("Could not save credentials. Try again.");

--- a/frontend/src/pages/BrokerSetupPage.tsx
+++ b/frontend/src/pages/BrokerSetupPage.tsx
@@ -169,8 +169,9 @@ export function BrokerSetupPage(): JSX.Element {
     } catch (err: unknown) {
       if (err instanceof ApiError && err.status === 409) {
         setError(
-          "Credentials already saved against this operator under a " +
-            "different label. Sign out and back in to retry.",
+          "A credential row already exists for this label. " +
+            "Sign out and back in to retry, or revoke the existing row " +
+            "via operator support.",
         );
       } else {
         setError("Could not save credentials. Try again.");


### PR DESCRIPTION
## Summary

Operator feedback post-#1261 broker-credentials gate: "I'd expect to need to only see the need to enter and validate keys before getting into the site". The previous gate redirected to /settings — full app shell, sidebar visible, broker form buried mid-page next to budget / display-currency / capital-event sections the operator doesn't care about while keys are missing.

This PR adds `/setup/broker` — a focused chrome-free wizard mirroring the LoginPage / SetupPage layout. Two key fields, Test connection + Save & continue. **Save runs eToro validation FIRST**; keys are never persisted unless they authenticate.

Three changes:

1. **New `frontend/src/pages/BrokerSetupPage.tsx`** — single centered card on full-screen background; no sidebar; sign-out link in footer.
2. **`frontend/src/App.tsx`** — new top-level route `/setup/broker` mounted OUTSIDE AppShell. Still wrapped in `RequireAuth` so unauthenticated visitors bounce to /login.
3. **`frontend/src/components/RequireAuth.tsx`** — `BROKER_FREE_PATHS` and force-redirect target both swap from `/settings` to `/setup/broker`.

## Why

Per CLAUDE.md non-negotiable I12: eToro is the sole execution boundary. A logged-in operator with no broker credentials is functionally unable to use eBull. Pre-PR the /settings page tried to surface the add-creds form but couldn't focus the operator's attention. This PR makes the gated state explicit: ONE page, ONE form, ONE action.

## Validation contract

```
Save click
  └─ validateBrokerCredential(api_key, user_key, ENVIRONMENT)
       ├─ !auth_valid → surface note + DO NOT save + DO NOT release gate
       └─ auth_valid  → createBrokerCredential(api_key)
                      → createBrokerCredential(user_key)
                      → refreshBootstrapState() → RequireAuth releases
                      → navigate to "/"
```

Optional Test connection button remains for explicit dry-run (parity with SettingsPage UX), but Save also validates → Test is redundant for the happy path.

## Test plan

- [x] `pnpm typecheck` clean (1 error caught + fixed: ValidationResultDisplay requires `error` prop, added `error={null}`).
- [x] `pnpm test:unit` — 861/861 pass; no new behaviour tests added (component is bare-render + relies on the existing useSession + brokerCredentials API mocks pattern; could add a behaviour test in a follow-up).
- [ ] Local pre-push pytest deferred to CI — dev DB still has prior pg_resetwal damage; pushed with `--no-verify` per memory `feedback_pre_push_xdist_postgres_locks`.

## Security model

Validation is mandatory on the Save path. Keys never persisted unless eToro `/api/v1/me` returns 200. `/setup/broker` mounted inside RequireAuth → unauthenticated bypass not possible. The `BROKER_FREE_PATHS` list is intentionally minimal (two entries: `/setup/broker`, `/logout`) — every other route force-redirects until creds present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)