### PR TITLE
fix: lower sec_bulk_download bandwidth threshold 13 → 5 mbps

### DIFF
--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -58,7 +58,16 @@ SEC_BASE_URL: Final[str] = "https://www.sec.gov"
 
 # Disk + bandwidth budgets. Configurable by env in callers.
 DEFAULT_MIN_FREE_BYTES: Final[int] = 25 * 1024**3  # 25 GB
-DEFAULT_BANDWIDTH_THRESHOLD_MBPS: Final[float] = 13.0
+# Bandwidth threshold tuned for the SEC archive single-stream limit
+# (typically 10-30 Mbps per TCP connection from sec.gov). Operator
+# 2026-05-22: prior 13 Mbps default forced fallback on a healthy
+# 100+ Mbps line because the 4 MB range-GET probe measured 9.5 Mbps —
+# normal for a single SEC stream. 5 Mbps admits modest broadband while
+# still excluding genuinely slow networks (sub-broadband, congested
+# tether). The fallback path's cascade-skip of bulk-dependent stages
+# (companyfacts, insider/13F/NPORT from dataset) loses half the data
+# pipeline silently — overshooting the threshold has high cost.
+DEFAULT_BANDWIDTH_THRESHOLD_MBPS: Final[float] = 5.0
 PROBE_BYTES: Final[int] = 4 * 1024 * 1024  # 4 MB range-GET probe
 DEFAULT_CONCURRENCY: Final[int] = 4  # one TCP connection per archive family
 DEFAULT_TIMEOUT_S: Final[float] = 600.0  # multi-GB transfers can take many minutes

--- a/uv.lock
+++ b/uv.lock
@@ -1240,14 +1240,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Symptom

Operator triggered first bootstrap on freshly-wiped dev DB. The slow-connection probe measured 9.5 Mbps (single 4 MB range-GET against sec.gov — entirely normal for one TCP stream). 13 Mbps threshold tripped → bulk_download skipped → CASCADE skipped 6 downstream stages including `sec_companyfacts_ingest` (XBRL financial facts), `fundamentals_sync`, insider/13F/NPORT bulk ingest. Half the data pipeline silently disabled.

## Fix

Drop `DEFAULT_BANDWIDTH_THRESHOLD_MBPS` from 13.0 → 5.0. Admits modest broadband; still gates genuinely slow connections.

## Follow-up tech-debt

- Make threshold env-configurable (currently a Final[float] constant).
- Improve probe shape (sustained multi-stream measurement rather than single 4 MB range-GET — TCP slow-start skews single-probe measurements low).
- Fallback path should not silently cascade-skip half the pipeline — operator should see the impact in advance + have an override.

Will file these as separate tickets after merge.

## Test plan

- [x] Ruff + format + pyright clean.
- [x] No existing tests pin the 13 mbps default value.
- [ ] After merge: cancel current bootstrap run + Re-run all on operator dev DB; verify sec_bulk_download SUCCESS instead of SKIPPED; verify cascade-skipped downstream stages now run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)