### PR TITLE
fix: drop type-to-confirm gate on Re-run all / Full-wash (#1264)

### DIFF
--- a/frontend/src/components/admin/ProcessesTable.test.tsx
+++ b/frontend/src/components/admin/ProcessesTable.test.tsx
@@ -113,32 +113,23 @@ describe("ProcessesTable", () => {
     expect(note.getAttribute("title")).toContain("already in flight");
   });
 
-  it("full-wash requires typed-name match before confirm enables", async () => {
+  it("full-wash confirm button is enabled immediately (no type-to-confirm)", async () => {
+    // Operator decision 2026-05-22 (#1264): type-to-confirm dropped —
+    // process names are internal identifiers, double-confirm with a
+    // single click on the red verb button is the chosen UX. The modal
+    // no longer renders the 'Process name confirmation' input.
     renderTable([
       makeProcessRow({ display_name: "Insider Form 4 ingest", can_full_wash: true }),
     ]);
     fireEvent.click(screen.getByRole("button", { name: "Full-wash" }));
     const dialog = await screen.findByRole("dialog");
-    const input = dialog.querySelector(
-      "input[aria-label='Process name confirmation']",
-    ) as HTMLInputElement;
-    const confirmBtn = dialog.querySelector(
-      "button[disabled]",
-    ) as HTMLButtonElement;
-    expect(confirmBtn.disabled).toBe(true);
-    fireEvent.change(input, { target: { value: "wrong" } });
     expect(
-      (
-        Array.from(dialog.querySelectorAll("button")).find(
-          (b) => b.textContent === "Full-wash",
-        ) as HTMLButtonElement
-      ).disabled,
-    ).toBe(true);
-    fireEvent.change(input, { target: { value: "Insider Form 4 ingest" } });
-    const confirmEnabled = Array.from(dialog.querySelectorAll("button")).find(
+      dialog.querySelector("input[aria-label='Process name confirmation']"),
+    ).toBeNull();
+    const confirmBtn = Array.from(dialog.querySelectorAll("button")).find(
       (b) => b.textContent === "Full-wash",
     ) as HTMLButtonElement;
-    expect(confirmEnabled.disabled).toBe(false);
+    expect(confirmBtn.disabled).toBe(false);
   });
 
   it("cancel modal exposes terminate behind 'More' disclosure with honest copy", async () => {

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -331,11 +331,16 @@ function FullWashConfirmDialog({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
-  const [typed, setTyped] = useState("");
-  const matches = typed === row.display_name;
   // PR3a #1064 — bootstrap mechanism uses different verbs per
   // data-engineer skill §7.3. Modal heading + body + confirm-button
   // copy follow the same swap; the underlying POST stays mode='full_wash'.
+  //
+  // Operator 2026-05-22 (#1264): the prior type-to-confirm gate
+  // ('type the process name exactly') was friction without safety —
+  // process names are internal identifiers the operator does not need
+  // to know. Replaced with a single click-through confirm. The verb
+  // button itself stays red so the destructive intent is still clear;
+  // the Cancel button remains as the obvious bail-out.
   const isBootstrap = row.mechanism === "bootstrap";
   const heading = isBootstrap ? "Confirm Re-run all" : "Confirm full-wash";
   const verb = isBootstrap ? "Re-run all" : "Full-wash";
@@ -357,21 +362,6 @@ function FullWashConfirmDialog({
       <p className="mt-2 text-sm text-slate-700 dark:text-slate-300">
         {description}
       </p>
-      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
-        Type the process name exactly to enable the confirm button.
-      </p>
-      <label className="mt-3 block text-xs font-medium text-slate-700 dark:text-slate-200">
-        Process name
-        <input
-          type="text"
-          value={typed}
-          onChange={(e) => setTyped(e.target.value)}
-          autoFocus
-          aria-label="Process name confirmation"
-          placeholder={row.display_name}
-          className="mt-1 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm font-mono text-slate-800 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
-        />
-      </label>
       <div className="mt-4 flex justify-end gap-2">
         <button
           type="button"
@@ -383,7 +373,8 @@ function FullWashConfirmDialog({
         <button
           type="button"
           onClick={onConfirm}
-          disabled={!matches || busy}
+          disabled={busy}
+          autoFocus
           className="rounded border border-red-400 bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700 dark:bg-red-700 dark:hover:bg-red-800"
         >
           {busy ? "Triggering…" : verb}

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -1282,9 +1282,10 @@ function FullWashConfirmDialog({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
-  const [typed, setTyped] = useState("");
-  const matches = typed === row.display_name;
   // PR3a #1064 — bootstrap mechanism uses different verbs.
+  // Operator 2026-05-22 (#1264): type-to-confirm gate dropped —
+  // process names are internal identifiers, double-confirm with a
+  // single click on the red verb button is the operator-locked UX.
   const isBootstrap = row.mechanism === "bootstrap";
   const heading = isBootstrap ? "Confirm Re-run all" : "Confirm full-wash";
   const verb = isBootstrap ? "Re-run all" : "Full-wash";
@@ -1313,21 +1314,6 @@ function FullWashConfirmDialog({
           </>
         )}
       </p>
-      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
-        Type the process name exactly to enable the confirm button.
-      </p>
-      <label className="mt-3 block text-xs font-medium text-slate-700 dark:text-slate-200">
-        Process name
-        <input
-          type="text"
-          value={typed}
-          onChange={(e) => setTyped(e.target.value)}
-          autoFocus
-          aria-label="Process name confirmation"
-          placeholder={row.display_name}
-          className="mt-1 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm font-mono text-slate-800 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
-        />
-      </label>
       <div className="mt-4 flex justify-end gap-2">
         <button
           type="button"
@@ -1339,7 +1325,8 @@ function FullWashConfirmDialog({
         <button
           type="button"
           onClick={onConfirm}
-          disabled={!matches || busy}
+          disabled={busy}
+          autoFocus
           className="rounded border border-red-400 bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700 dark:bg-red-700 dark:hover:bg-red-800"
         >
           {busy ? "Triggering…" : verb}


### PR DESCRIPTION
## Summary

Operator 2026-05-22: 'having to type that in each time is really starting to piss me off'. Type-to-confirm gate on the destructive-action confirm modals (Re-run all for bootstrap, Full-wash for scheduled jobs) added friction without safety — process names are internal identifiers the operator does not need to know.

Replaced with a single click-through confirm. Red verb button + 'Cancel' as default-bail-out remain. autoFocus on confirm button so Enter still confirms / Esc still cancels.

Two modal call sites:
- `components/admin/ProcessesTable.tsx::FullWashConfirmDialog`
- `pages/ProcessDetailPage.tsx::FullWashConfirmDialog`

Test updated to assert the input field is NOT rendered + the confirm button is enabled immediately.

Refs #1264 (other parts — state-aware button visibility, hide Re-run failed on first_run_pending — remain open, separate PR).

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test:unit` 861/861 pass; updated case asserts the new contract.
- [ ] Pre-push pytest deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)