### PR TITLE
feat(#1233): PR-1a bulk-path unresolved-CUSIP capture + schema split

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -65,9 +65,14 @@ Hard-rule corollaries:
 | `instrument_sec_profile` | sql/051 | 1:1 SEC submissions metadata (cik, sic, former_names, has_insider_issuer). ON DELETE CASCADE from instruments |
 | `instrument_cik_history` | sql/102 | CIK chain per instrument with date ranges. `btree_gist` exclusion forbids overlapping ranges; partial UNIQUE WHERE `effective_to IS NULL` |
 | `instrument_symbol_history` | sql/103 | Symbol chain (FB→META, BBBY→BBBYQ). Same temporal-overlap GiST exclude |
-| `unresolved_13f_cusips` | sql/099 | Buffer for 13F-supplied CUSIPs not yet resolved to instruments |
+| `unresolved_13f_cusips` | sql/099 + sql/164 | Buffer for SEC-supplied CUSIPs not yet resolved to instruments. **Two-writer split** (#1233 PR-1a): legacy per-filing path (`source IS NULL`, partial UNIQUE `..._legacy_idx`) carries `name_of_issuer` + `last_accession_number`; bulk-dataset path (`source IN ('bulk_13f_dataset','bulk_nport_dataset')`, partial UNIQUE `..._bulk_idx`) carries `filer_cik` + `period_end` instead and leaves issuer name NULL until the OpenFIGI sweep (PR-1b) fills it |
 
-**No dedicated `cusip_map` table.** CUSIP→instrument lives in `external_identifiers WHERE provider='sec' AND identifier_type='cusip'`. Promotion path: 13F-HR ingest → unresolved → CUSIP backfill (#914 weekly) writes `external_identifiers` → `cusip_resolver.sweep_resolvable_unresolved_cusips` rewashes the source 13F (`app/services/cusip_resolver.py:425+`).
+**No dedicated `cusip_map` table.** CUSIP→instrument lives in `external_identifiers WHERE provider='sec' AND identifier_type='cusip'`. Promotion paths:
+
+* **Legacy per-filing** (#781 / #836): 13F-HR ingest writes `(cusip, name_of_issuer, accession)` via `institutional_holdings._record_unresolved_cusip` (`source=NULL`) → CUSIP backfill (#914 weekly) writes `external_identifiers` → `cusip_resolver.sweep_resolvable_unresolved_cusips` rewashes the source 13F (`app/services/cusip_resolver.py:425+`).
+* **Bulk dataset** (#1233 PR-1a): `sec_13f_dataset_ingest` / `sec_nport_dataset_ingest` capture `(cusip, filer_cik, period_end, source)` via `cusip_resolver.record_unresolved_cusip_from_bulk` for every unresolved CUSIP they encounter. Written under per-row savepoints, flushed every 1000 rows + at archive boundary. PR-1b's OpenFIGI sweep reads these rows, calls OpenFIGI for the ticker + issuer name, and either resolves the CUSIP into `external_identifiers` (provider='openfigi') OR tombstones the row.
+
+**Why two writers, not one?** The bulk-dataset path doesn't have issuer name on the per-holding row (the SEC FORM 13F INFOTABLE / FUND_REPORTED_HOLDING tables carry CUSIP + filer + period only). The legacy path's `_record_unresolved_cusip` REQUIRES `name_of_issuer + accession_number` (both NOT NULL in pre-#1233 schema). Splitting the writers — instead of relaxing the legacy signature — keeps the per-filing path's invariants intact and lets the bulk path use a separate partial UNIQUE that includes `(filer_cik, period_end, source)` so the same CUSIP can have multiple bulk rows (one per filer × period) without colliding.
 
 **Identity-graph cheat sheet**:
 - Instrument = `BIGINT instrument_id` (eToro-derived).

--- a/app/services/cusip_resolver.py
+++ b/app/services/cusip_resolver.py
@@ -53,8 +53,9 @@ import logging
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
+from datetime import date
 from difflib import SequenceMatcher
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 import psycopg
 import psycopg.rows
@@ -194,6 +195,73 @@ class _Match:
 
 
 # ---------------------------------------------------------------------------
+# Bulk-path unresolved-CUSIP writer (#1233 PR-1a)
+# ---------------------------------------------------------------------------
+
+
+# Valid ``source`` values for the bulk-path writer. Mirrors the
+# CHECK constraint on ``unresolved_13f_cusips.source`` added by
+# sql/164. Keep in sync with PR-1b if new bulk sources are added.
+BulkCusipSource = Literal["bulk_13f_dataset", "bulk_nport_dataset"]
+
+
+def record_unresolved_cusip_from_bulk(
+    conn: psycopg.Connection[Any],
+    *,
+    cusip: str,
+    filer_cik: str,
+    period_end: date,
+    source: BulkCusipSource,
+) -> None:
+    """Bulk-path unresolved-CUSIP write. Idempotent.
+
+    Distinct from the legacy :func:`_record_unresolved_cusip`
+    (``app/services/institutional_holdings.py``) which requires
+    ``name_of_issuer`` + ``accession_number`` — both available on
+    the per-filing path. The bulk Form 13F / N-PORT datasets carry
+    ``period_end`` + filer CIK but **not** issuer name (the dataset
+    INFOTABLE row publishes CUSIP only; issuer name is filled later
+    by the PR-1b OpenFIGI sweep which writes back the ``name`` field
+    OpenFIGI returns).
+
+    Idempotent on the partial UNIQUE INDEX
+    ``unresolved_13f_cusips_bulk_idx`` (sql/164). A second call with
+    the same ``(cusip, filer_cik, period_end, source)`` tuple is a
+    no-op. A call with a different ``(filer_cik, period_end, source)``
+    for the same CUSIP inserts a new row — the bulk path records
+    *every* (cusip × filer × period) observation so the sweep can
+    rewash the right accessions once the CUSIP resolves.
+
+    The caller is responsible for committing the transaction.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO unresolved_13f_cusips (
+                cusip, name_of_issuer, last_accession_number,
+                filer_cik, period_end, source
+            )
+            VALUES (
+                %(cusip)s, NULL, NULL,
+                %(filer_cik)s, %(period_end)s, %(source)s
+            )
+            ON CONFLICT (
+                cusip,
+                COALESCE(filer_cik, ''),
+                COALESCE(period_end, '0001-01-01'::date),
+                COALESCE(source, '')
+            ) WHERE source IS NOT NULL DO NOTHING
+            """,
+            {
+                "cusip": cusip.strip().upper(),
+                "filer_cik": filer_cik.strip(),
+                "period_end": period_end,
+                "source": source,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # Normalisation
 # ---------------------------------------------------------------------------
 
@@ -271,13 +339,22 @@ def _select_pending_unresolved(
 ) -> list[dict[str, Any]]:
     """Return up to ``limit`` unresolved CUSIPs that haven't been
     tombstoned, ordered by observation count DESC so the
-    highest-leverage entries resolve first."""
+    highest-leverage entries resolve first.
+
+    Scoped to legacy rows (``source IS NULL``) so the post-sql/164
+    bulk rows (which carry NULL ``name_of_issuer`` / NULL
+    ``last_accession_number`` by design) are NOT picked up by the
+    legacy fuzzy-name resolver — it would call ``_normalise_name(None)``
+    and tombstone every bulk row as ``unresolvable``. PR-1b's
+    OpenFIGI sweep owns the bulk partition independently.
+    """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
             SELECT cusip, name_of_issuer, observation_count
             FROM unresolved_13f_cusips
             WHERE resolution_status IS NULL
+              AND source IS NULL
             ORDER BY observation_count DESC, last_observed_at DESC
             LIMIT %(limit)s
             """,
@@ -409,9 +486,12 @@ def _promote_to_external_identifier(
         existing_iid = int(existing[0])
         if existing_iid == instrument_id:
             # Already mapped to the same instrument — source row is
-            # safely redundant.
+            # safely redundant. Scope the DELETE to the legacy
+            # partition (sql/164 #1233 PR-1a): a CUSIP may have
+            # multiple bulk rows whose lifecycle is owned by the
+            # PR-1b OpenFIGI sweep, not by this legacy resolver.
             conn.execute(
-                "DELETE FROM unresolved_13f_cusips WHERE cusip = %s",
+                "DELETE FROM unresolved_13f_cusips WHERE cusip = %s AND source IS NULL",
                 (cusip_norm,),
             )
             return "already_resolved"
@@ -428,8 +508,9 @@ def _promote_to_external_identifier(
         """,
         {"iid": instrument_id, "cusip": cusip_norm},
     )
+    # Legacy partition only — see comment above.
     conn.execute(
-        "DELETE FROM unresolved_13f_cusips WHERE cusip = %s",
+        "DELETE FROM unresolved_13f_cusips WHERE cusip = %s AND source IS NULL",
         (cusip_norm,),
     )
     return "inserted"
@@ -459,6 +540,11 @@ def _tombstone(
 
     The row stays in the table for operator audit; clearing
     ``resolution_status`` forces a retry on the next run.
+
+    Scoped to the legacy partition (``source IS NULL``) — the bulk
+    rows (sql/164 #1233 PR-1a) have their own status lifecycle owned
+    by PR-1b's OpenFIGI sweep. A legacy tombstone must NOT mutate
+    bulk rows for the same CUSIP.
     """
     conn.execute(
         """
@@ -466,6 +552,7 @@ def _tombstone(
         SET resolution_status = %s,
             last_observed_at = NOW()
         WHERE cusip = %s
+          AND source IS NULL
         """,
         (status, cusip.strip().upper()),
     )
@@ -636,7 +723,14 @@ def _select_resolvable_via_extid(
     """Return up to ``limit`` pending unresolved CUSIPs whose CUSIP
     already has a row in ``external_identifiers``. Ordered by
     observation_count DESC so the highest-leverage entries (Fortune-100
-    names with hundreds of stranded observations) resolve first."""
+    names with hundreds of stranded observations) resolve first.
+
+    Scoped to legacy rows (``source IS NULL``) — the extid sweep
+    relies on ``last_accession_number`` to drive the per-filing
+    rewash, and bulk rows (sql/164 #1233 PR-1a) leave that NULL
+    by design. PR-1b's OpenFIGI sweep handles the bulk partition
+    via its own re-ingest path (``rewash_bulk_source_filings``).
+    """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
@@ -649,6 +743,7 @@ def _select_resolvable_via_extid(
              AND ei.provider = 'sec'
              AND ei.identifier_type = 'cusip'
             WHERE u.resolution_status IS NULL
+              AND u.source IS NULL
             ORDER BY u.observation_count DESC, u.last_observed_at DESC
             LIMIT %(limit)s
             """,
@@ -737,6 +832,10 @@ def sweep_resolvable_unresolved_cusips(
         # so the loser cleanly skips.
         with conn.transaction():
             with conn.cursor() as cur:
+                # Legacy partition only (sql/164 #1233 PR-1a) — the
+                # ``last_accession_number`` rewash semantics don't
+                # apply to bulk rows; PR-1b's OpenFIGI sweep owns
+                # that lifecycle separately.
                 cur.execute(
                     """
                     UPDATE unresolved_13f_cusips
@@ -744,6 +843,7 @@ def sweep_resolvable_unresolved_cusips(
                         last_observed_at = NOW()
                     WHERE cusip = %s
                       AND resolution_status IS NULL
+                      AND source IS NULL
                     """,
                     (cusip,),
                 )

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -643,12 +643,21 @@ def _record_unresolved_cusip(
     disambiguation, mapping correction) is fixed. Bot review of
     #781 caught the absence of this note.
     """
+    # sql/164 (#1233 PR-1a) dropped the legacy PRIMARY KEY on
+    # ``cusip`` and replaced it with TWO partial UNIQUE indexes
+    # (``..._legacy_idx`` for ``source IS NULL`` and ``..._bulk_idx``
+    # for ``source IS NOT NULL``). PG can no longer infer the
+    # legacy index from ``ON CONFLICT (cusip)`` alone — both
+    # indexes have ``cusip`` as the leading column. The
+    # ``WHERE source IS NULL`` clause disambiguates: it matches the
+    # legacy partial index's predicate exactly, so PG picks the
+    # right index for the upsert. Semantics unchanged from sql/099.
     conn.execute(
         """
         INSERT INTO unresolved_13f_cusips (
             cusip, name_of_issuer, last_accession_number
         ) VALUES (%(cusip)s, %(name)s, %(accession)s)
-        ON CONFLICT (cusip) DO UPDATE SET
+        ON CONFLICT (cusip) WHERE source IS NULL DO UPDATE SET
             name_of_issuer = EXCLUDED.name_of_issuer,
             last_accession_number = EXCLUDED.last_accession_number,
             observation_count = unresolved_13f_cusips.observation_count + 1,

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -34,6 +34,7 @@ from uuid import UUID, uuid4
 
 import psycopg
 
+from app.services.cusip_resolver import record_unresolved_cusip_from_bulk
 from app.services.institutional_holdings import thirteen_f_retention_cutoff
 from app.services.ownership_observations import record_institution_observation
 
@@ -46,6 +47,17 @@ logger = logging.getLogger(__name__)
 # Hoisted to module level so the cutover constant isn't re-built
 # on every INFOTABLE row. Codex pre-push NITPICK for #1054.
 _VALUE_DOLLARS_CUTOVER = date(2023, 1, 3)
+
+
+# #1233 PR-1a — flush the unresolved-CUSIP buffer every N rows. 1000
+# is the spec-mandated batch size; tuned so an archive of millions
+# of INFOTABLE rows commits incrementally without holding the open
+# transaction across the whole archive (would block other workers
+# and balloon WAL). The flush is idempotent on the partial UNIQUE
+# index ``unresolved_13f_cusips_bulk_idx`` (sql/164), so even a
+# crash mid-flush leaves a consistent partial set that the next run
+# will append to safely.
+_UNRESOLVED_FLUSH_BATCH = 1000
 
 
 @dataclass
@@ -233,6 +245,46 @@ def _iter_tsv(zf: zipfile.ZipFile, name: str):
         yield from csv.DictReader(text, delimiter="\t")
 
 
+def _flush_unresolved_buffer(
+    conn: psycopg.Connection[Any],
+    buffer: list[tuple[str, str, date]],
+    *,
+    source: Literal["bulk_13f_dataset", "bulk_nport_dataset"],
+) -> None:
+    """Drain ``buffer`` into ``unresolved_13f_cusips`` via the bulk
+    helper. Each row is written under its own savepoint so a single
+    malformed (cusip, filer, period) triple (e.g. CHECK violation
+    on a future tightening of ``filer_cik`` shape) can't poison the
+    enclosing per-archive transaction. Buffer is cleared in place
+    on the caller's reference — callers reuse the same list across
+    the loop.
+
+    #1233 PR-1a flush hook. Mirrored verbatim in
+    ``sec_nport_dataset_ingest._flush_unresolved_buffer``.
+    """
+    if not buffer:
+        return
+    for cusip, filer_cik, period_end in buffer:
+        try:
+            with conn.transaction():
+                record_unresolved_cusip_from_bulk(
+                    conn,
+                    cusip=cusip,
+                    filer_cik=filer_cik,
+                    period_end=period_end,
+                    source=source,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "13F ingest: record_unresolved_cusip_from_bulk failed for cusip=%s filer=%s period=%s: %s",
+                cusip,
+                filer_cik,
+                period_end,
+                exc,
+            )
+    buffer.clear()
+
+
 def ingest_13f_dataset_archive(
     *,
     conn: psycopg.Connection[Any],
@@ -257,6 +309,12 @@ def ingest_13f_dataset_archive(
     # otherwise dominate cost on multi-million-row INFOTABLE.tsv
     # (Codex sweep BLOCKING).
     cusip_map = _load_cusip_map(conn)
+
+    # #1233 PR-1a — buffer of (cusip, filer_cik, period_end) triples
+    # for every unresolved CUSIP this archive yields. Flushed every
+    # _UNRESOLVED_FLUSH_BATCH rows and again at archive boundary so
+    # the partial last-batch is never lost on completion.
+    unresolved_buffer: list[tuple[str, str, date]] = []
 
     # PR6 #1233 §4.5 — archive-level retention cutoff. Resolve once
     # OUTSIDE the per-row INFOTABLE loop so a multi-million-row drain
@@ -291,11 +349,15 @@ def ingest_13f_dataset_archive(
                 result.rows_skipped_bad_data += 1
                 continue
 
-            instrument_id = cusip_map.get(cusip)
-            if instrument_id is None:
-                result.rows_skipped_unresolved_cusip += 1
-                continue
-
+            # Parse filer_cik + period_end EARLY so the unresolved-CUSIP
+            # branch (#1233 PR-1a) can capture (cusip, filer_cik,
+            # period_end, source='bulk_13f_dataset') into the buffer
+            # for PR-1b's OpenFIGI sweep. Bad-data rows whose
+            # filer/period can't be parsed fall through to the normal
+            # ``rows_skipped_bad_data`` counter; unresolved-CUSIP rows
+            # whose filer/period DID parse are counted +1 in
+            # ``rows_skipped_unresolved_cusip`` and appended to the
+            # buffer in the same step.
             filer_cik = str(sub.get("CIK") or "").strip()
             if not filer_cik:
                 result.rows_skipped_bad_data += 1
@@ -311,6 +373,21 @@ def ingest_13f_dataset_archive(
             period_end = _parse_period_end(cover.get("REPORTCALENDARORQUARTER"))
             if filed_at is None or period_end is None:
                 result.rows_skipped_bad_data += 1
+                continue
+
+            instrument_id = cusip_map.get(cusip)
+            if instrument_id is None:
+                # PR-1a #1233 §4 — buffer the (cusip, filer_cik,
+                # period_end) triple so PR-1b's OpenFIGI sweep can
+                # resolve + rewash. Buffer flushed every
+                # ``_UNRESOLVED_FLUSH_BATCH`` rows and again at
+                # archive boundary (post-loop). Counter still
+                # increments here to keep dropped-row telemetry
+                # consistent with the pre-PR-1a baseline.
+                result.rows_skipped_unresolved_cusip += 1
+                unresolved_buffer.append((cusip, filer_cik, period_end))
+                if len(unresolved_buffer) >= _UNRESOLVED_FLUSH_BATCH:
+                    _flush_unresolved_buffer(conn, unresolved_buffer, source="bulk_13f_dataset")
                 continue
 
             # PR6 #1233 §4.5 — per-row retention gate. Bulk dataset
@@ -395,4 +472,9 @@ def ingest_13f_dataset_archive(
                     exc,
                 )
                 result.parse_errors += 1
+
+    # #1233 PR-1a — final flush at archive boundary. Picks up the
+    # partial last batch (< _UNRESOLVED_FLUSH_BATCH rows) so nothing
+    # is dropped on completion.
+    _flush_unresolved_buffer(conn, unresolved_buffer, source="bulk_13f_dataset")
     return result

--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -35,11 +35,12 @@ from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID, uuid4
 
 import psycopg
 
+from app.services.cusip_resolver import record_unresolved_cusip_from_bulk
 from app.services.n_port_ingest import n_port_retention_cutoff
 from app.services.ownership_observations import (
     record_fund_observation,
@@ -47,6 +48,12 @@ from app.services.ownership_observations import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# #1233 PR-1a — see ``sec_13f_dataset_ingest._UNRESOLVED_FLUSH_BATCH``
+# for rationale (per-batch incremental commit so a multi-million-row
+# archive doesn't hold the open transaction across the whole drain).
+_UNRESOLVED_FLUSH_BATCH = 1000
 
 
 @dataclass
@@ -209,6 +216,40 @@ def _iter_tsv(zf: zipfile.ZipFile, *candidate_names: str):
         yield from csv.DictReader(text, delimiter="\t")
 
 
+def _flush_unresolved_buffer(
+    conn: psycopg.Connection[Any],
+    buffer: list[tuple[str, str, date]],
+    *,
+    source: Literal["bulk_13f_dataset", "bulk_nport_dataset"],
+) -> None:
+    """Drain ``buffer`` into ``unresolved_13f_cusips`` via the bulk
+    helper. Each row is written under its own savepoint so a single
+    malformed triple can't poison the enclosing per-archive
+    transaction. Buffer is cleared in place. #1233 PR-1a.
+    """
+    if not buffer:
+        return
+    for cusip, filer_cik, period_end in buffer:
+        try:
+            with conn.transaction():
+                record_unresolved_cusip_from_bulk(
+                    conn,
+                    cusip=cusip,
+                    filer_cik=filer_cik,
+                    period_end=period_end,
+                    source=source,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "nport ingest: record_unresolved_cusip_from_bulk failed for cusip=%s filer=%s period=%s: %s",
+                cusip,
+                filer_cik,
+                period_end,
+                exc,
+            )
+    buffer.clear()
+
+
 # ---------------------------------------------------------------------------
 # Public entrypoint
 # ---------------------------------------------------------------------------
@@ -244,6 +285,10 @@ def ingest_nport_dataset_archive(
         ingest_run_id = uuid4()
     result = NPortIngestResult()
     cusip_map = _load_cusip_map(conn)
+
+    # #1233 PR-1a — buffer of (cusip, filer_cik, period_end) triples
+    # for every unresolved-CUSIP holding. Mirrors the 13F path.
+    unresolved_buffer: list[tuple[str, str, date]] = []
 
     with zipfile.ZipFile(archive_path) as zf:
         submissions = _open_tsv(zf, "SUBMISSION.tsv")
@@ -342,6 +387,28 @@ def ingest_nport_dataset_archive(
                 continue
             instrument_id = cusip_map.get(cusip)
             if instrument_id is None:
+                # #1233 PR-1a — buffer the (cusip, filer_cik, period_end)
+                # triple for PR-1b's OpenFIGI sweep. Parse filer_cik
+                # from REGISTRANT here (the next gate would parse it
+                # anyway for the write path); fall through to the
+                # counter increment in either branch so the
+                # ``rows_skipped_unresolved_cusip`` semantics match
+                # pre-PR-1a baseline exactly. If period_end didn't
+                # parse early (``period_end_early`` is None) we drop
+                # the buffer write — the bulk index requires a
+                # period_end for the partial UNIQUE clause to
+                # disambiguate; an un-parseable period would fail the
+                # bad-data write path anyway.
+                filer_cik_raw_buf = (reg.get("CIK") or "").strip()
+                if filer_cik_raw_buf and period_end_early is not None:
+                    filer_cik_buf = filer_cik_raw_buf.zfill(10)
+                    unresolved_buffer.append((cusip, filer_cik_buf, period_end_early))
+                    if len(unresolved_buffer) >= _UNRESOLVED_FLUSH_BATCH:
+                        _flush_unresolved_buffer(
+                            conn,
+                            unresolved_buffer,
+                            source="bulk_nport_dataset",
+                        )
                 result.rows_skipped_unresolved_cusip += 1
                 continue
 
@@ -455,6 +522,8 @@ def ingest_nport_dataset_archive(
                 )
                 result.parse_errors += 1
 
+    # #1233 PR-1a — flush partial last batch at archive boundary.
+    _flush_unresolved_buffer(conn, unresolved_buffer, source="bulk_nport_dataset")
     return result
 
 

--- a/docs/superpowers/specs/2026-05-22-bootstrap-etl-optimisation-v3.md
+++ b/docs/superpowers/specs/2026-05-22-bootstrap-etl-optimisation-v3.md
@@ -1,0 +1,462 @@
+# Bootstrap ETL — comprehensive optimisation spec **v3**
+
+**Date:** 2026-05-22 (v3 after v2 review converged on 4 CRITICAL + 5 HIGH new defects)
+**Status:** DRAFT v3 — incorporates v2 review (`/tmp/spec-v2-review.md`) + Codex 2 spec review.
+**Supersedes:** v1, v2. Both retained for audit trail.
+
+---
+
+## Changelog v2 → v3
+
+| v2 defect | v2 framing | v3 fix |
+|---|---|---|
+| H4 `partial_complete` enum | demote to non-existent status | v3: keep `complete` + new column `bootstrap_runs.coverage_floor_met BOOLEAN`. CHECK constraint untouched. Operator panel reads the column. |
+| H5(a) reaper hash mismatch | `hashtextextended` ≠ JobLock's `hashtext` | v3: use `hashtext('job_source:' || %(source)s)::int` matching JobLock at `app/jobs/locks.py:224`. |
+| H5(c) heartbeat per-subsystem | not per-stage | v3: drop the heartbeat check. Reaper criterion = lock-NOT-held + stage `started_at > 5 min ago`. Re-entrancy edge accepted as residual risk; documented. |
+| N1 PR-1a writer signature | `_record_unresolved_cusip` needs name_of_issuer | v3: new helper `record_unresolved_cusip_from_bulk(conn, *, cusip, filer_cik_or_null, period_end, source)`. Sidesteps name_of_issuer requirement (it's optional in v3's schema). |
+| C2 schema mismatch | ON CONFLICT against columns that don't exist | v3: SQL migration `sql/<N>_unresolved_13f_cusips_bulk_columns.sql` adds nullable `filer_cik TEXT`, `period_end DATE`, `source TEXT`; adds UNIQUE INDEX `unresolved_13f_cusips_bulk_idx` on `(cusip, filer_cik, period_end, source) WHERE source IS NOT NULL`. Backwards-compat: existing legacy writes (`source IS NULL`) keep using the original `cusip` PK. |
+| Codex critical: `_load_cusip_map` only reads `provider='sec'` | OpenFIGI promotions invisible | v3: extend `_load_cusip_map` (`sec_13f_dataset_ingest.py:67-97`, `sec_nport_dataset_ingest.py:153-180`) to `WHERE provider IN ('sec', 'openfigi') AND identifier_type='cusip'`. `bootstrap_preconditions.compute_cusip_coverage` (`:188`) same change. **30 extra LoC in PR-1b.** |
+| N6 S12.5 lane misuse | `sec_rate` budget conflated | v3: NEW `openfigi` lane. Registered in `Lane` (`app/jobs/sources.py`), `_LANE_MAX_CONCURRENCY` adds entry, `bootstrap_stages.lane` CHECK migration adds value. PR-1b ships the lane migration. |
+| N8 stage_order SMALLINT collision | no room for "12.5" | v3: renumber. Migration shifts S13-S26 → S14-S27. S13 (new) = cusip_resolver_post_bulk_sweep. PR-1b ships the renumber migration. |
+| H9 GOOGL acceptance | unconditional but PR-B deferred | v3: assertion = `GET /instruments/GOOGL/ownership-rollup` returns 200 with EITHER non-empty body OR `partial_data_reason='share_class_sibling_pre_PR_B'`. Endpoint change scoped in PR-1b. |
+| Codex H "12k / 250 = 48 min" | spec said 30 | v3: budget S13 (new ordering) = **up to 48 min unkeyed / 5 min keyed**. 5-instrument panel ≠ universe; the 48-min figure assumes all unresolved CUSIPs sweep. Realistic: bootstrap-time unresolved set ~7-12k CUSIPs. |
+| C3 TEMP TABLE timing | ON COMMIT DROP ambiguity | v3: PR-3 spec MANDATES "CREATE TEMP TABLE inside the same transaction as the COPY+INSERT+commit", re-created each per-archive iteration. Test fixture invariant. |
+| C4 ETag multipart stability | -184 part-count suffix | v3: ETag-keyed reuse augmented with content SHA-256 verification on reuse path (defence-in-depth: ETag = freshness check, SHA-256 = local integrity check). Per-night ETag stability accepted as empirical observation; if SEC repartitions, ETag changes, reuse correctly skips. |
+| H2 OpenFIGI rate limits unverified | doc-derived | v3: PR-0 (NEW) — empirical OpenFIGI probe. Land BEFORE PR-1b. Records fixtures with actual headers + per-row error shapes + 429 retry behaviour. |
+| C5 dispatcher test rework | budgeted but unspecified | v3: explicitly lists tests to rewrite. |
+| N3 ThreadPoolExecutor lifetime | 8+ pools alive 90 min | v3: register pools in a single `LaneExecutorRegistry` context manager scoped to `run_bootstrap_orchestrator`. Test fixture injects a sync `MockExecutor` for deterministic unit tests. |
+| Codex M S12.5 cancel-mid-sweep | undocumented | v3: §12 robustness assertion + test added. |
+| Codex M S9 budget | 10 min unverified | v3: budget bumped to 15-20 min OR ship a S9 COPY refactor as PR-3.b (split). v3 picks the latter — S9 is in scope. |
+| Adversarial §7 90-min over-conservative | real 47-57 min | v3: target **≤ 60 min Tier 1** (was 90); hard ceiling 90. Tier 2 ≤ 45. |
+| Codex M S15 rewash | bulk rows skipped before sweep | v3: PR-1b's sweep triggers `_rewash_originating_filings` for bulk-source rows (currently only legacy). Spec includes `rewash_bulk_source_filings` extension. |
+
+---
+
+## 1. Goals (revised)
+
+| Target | v2 | v3 |
+|---|---|---|
+| Cold-install wall-clock Tier 1 | ≤ 90 min | **≤ 60 min** (45 min target with OpenFIGI key) |
+| Cold-install wall-clock Tier 2 | ≤ 45 min | **≤ 30 min** |
+| Daily-refresh wall-clock | ≤ 5 min | ≤ 5 min |
+| CUSIP coverage at run COMPLETION | ≥ 80% | ≥ 80% (record-only, `coverage_floor_met` column) |
+| Ownership categories populated at "complete" | 10 of 10 | 10 of 10 |
+| Operator-visible drop telemetry | admin panel | admin panel + `coverage_floor_met` boolean |
+| Process-crash recovery | reaper | reaper (lock-probe + grace window) |
+| Wasted re-download | 0 bytes | 0 bytes (ETag-keyed reuse + SHA-256) |
+
+---
+
+## 2. Pre-requisite work (must land before PR-1b)
+
+### SD-1 settled-decisions entry: OpenFIGI
+
+Concrete patch (paste-ready):
+
+```markdown
+## OpenFIGI as approved external CUSIP-resolver fallback (2026-05-22)
+
+**Decision:** OpenFIGI v3 API at `https://api.openfigi.com/v3/mapping`
+is approved as a CUSIP-resolution fallback for the eBull universe.
+
+**Constraints:**
+- Free tier: 25 req/min unkeyed × max 10 jobs/POST = 250 mappings/min.
+- Keyed tier: 25 req/6s × max 100 jobs/POST = 25,000 mappings/min.
+- Operator-keyed mode requires `OPENFIGI_API_KEY` env var; default is unkeyed.
+- The response **does not contain CUSIP**. Approved usage is CUSIP→ticker
+  (idType=ID_CUSIP, idValue=<cusip>); the response includes ticker which
+  resolves against `instruments.symbol`.
+- Forbidden: ticker→CUSIP flow (response shape does not return CUSIP).
+
+**ToS posture:** OpenFIGI free tier permits programmatic use within rate
+limits. Operator approves prior to PR-1b merge.
+```
+
+### SD-2 settled-decisions entry: ETag-keyed reuse (PR-5b prerequisite)
+
+```markdown
+## Bulk archive reuse keyed on SEC ETag + SHA-256 (2026-05-22)
+
+**Decision:** The Codex review BLOCKING for #1020 prohibited reusing a
+prior-run .zip. With SEC's stable S3-backed ETag (probed 2026-05-22 against
+`submissions.zip` returning `etag: "504b124e9474334e889e9e525db95c14-184"`),
+reuse is permitted when ALL of:
+(1) local `.zip.etag` sidecar matches SEC's HEAD response,
+(2) SHA-256 of local file matches `.zip.sha256` sidecar.
+The run-manifest records `reuse_reason: 'etag_match_sha256_verified'`.
+Forced override: `BOOTSTRAP_FORCE_REDOWNLOAD=1` env var.
+**Empirical:** SEC ignores If-None-Match / If-Modified-Since; reuse uses
+client-side header comparison.
+```
+
+### PR-0 (NEW): OpenFIGI empirical probe + recorded fixtures
+
+**Scope (~150 LoC):**
+- `tests/integration/test_openfigi_live_probe.py` — gated by `OPENFIGI_LIVE_PROBE=1` env var.
+- Records response headers + bodies for: (a) successful CUSIP→ticker for 5 known CUSIPs (AAPL, MSFT, GOOG, BRK.A, JPM), (b) batch of 10 with 1 invalid CUSIP, (c) rate-limit-saturation 429 response shape, (d) `Retry-After` + `ratelimit-remaining` header presence.
+- Writes fixtures to `tests/fixtures/openfigi/` for use by PR-1b unit tests.
+- Operator runs probe once; commits fixtures with the PR-0 merge.
+
+**Why first:** v2's rate-limit numbers came from docs, not measurement. PR-1b needs verified contract.
+
+---
+
+## 3. Revised PR ordering + LoC budgets
+
+```
+SD-1 + SD-2 settled-decisions  → PR-0 OpenFIGI empirical probe
+                                          ↓
+                                  PR-1a unresolved-CUSIP capture + schema migration
+                                          ↓
+                                  PR-1b OpenFIGI resolver + Phase D sweep stage + cusip_map fix
+                                          ↓
+                                  PR-2 dispatcher parallelism
+                                          ↓
+                                  PR-3 COPY refactor (13F, NPORT, insider, companyfacts)
+                                          ↓
+                                  PR-4 batched _current refresh
+                                          ↓
+                                  PR-5a manifest reset + PR-5b ETag reuse (parallel)
+                                          ↓
+                                  PR-6 reaper + PR-8 daily refresh + PR-7 cap floor (conditional)
+```
+
+| PR | Service LoC | Test LoC | Schema LoC | Skill LoC | Total |
+|---|---|---|---|---|---|
+| PR-0 | 100 | 150 | - | - | 250 |
+| PR-1a | 250 | 150 | 50 | 50 | 500 |
+| PR-1b | 600 | 350 | 100 (lane migration + stage renumber) | 150 | 1200 |
+| PR-2 | 300 | 300 | - | 100 | 700 |
+| PR-3 | 800 | 500 | - | 50 | 1350 |
+| PR-4 | 200 | 200 | - | 50 | 450 |
+| PR-5a | 150 | 100 | - | 30 | 280 |
+| PR-5b | 350 | 250 | - | 50 | 650 |
+| PR-6 | 250 | 200 | - | 50 | 500 |
+| PR-7 | 30 | 50 | - | 20 | 100 |
+| PR-8 | 250 | 200 | - | 50 | 500 |
+| **Total** | **3280** | **2450** | **150** | **600** | **~6480** |
+
+---
+
+## 4. PR-1a — Bulk-path unresolved-CUSIP capture
+
+### Schema migration (~50 LoC)
+
+```sql
+-- sql/<N>_unresolved_13f_cusips_bulk_columns.sql
+ALTER TABLE unresolved_13f_cusips
+  ADD COLUMN filer_cik TEXT,
+  ADD COLUMN period_end DATE,
+  ADD COLUMN source TEXT;
+
+CREATE UNIQUE INDEX unresolved_13f_cusips_bulk_idx
+  ON unresolved_13f_cusips (cusip, COALESCE(filer_cik, ''), COALESCE(period_end, '0001-01-01'::date), COALESCE(source, ''))
+  WHERE source IS NOT NULL;
+-- The original (cusip)-PK path stays for legacy per-filing writes
+-- where filer_cik/period_end/source are NULL. The new bulk path
+-- writes with all four populated.
+```
+
+### Service (~250 LoC)
+
+New helper in `app/services/cusip_resolver.py`:
+
+```python
+def record_unresolved_cusip_from_bulk(
+    conn: psycopg.Connection[Any],
+    *,
+    cusip: str,
+    filer_cik: str,
+    period_end: date,
+    source: Literal['bulk_13f_dataset', 'bulk_nport_dataset'],
+) -> None:
+    """Bulk-path-specific unresolved-CUSIP write.
+
+    Distinct from the legacy ``_record_unresolved_cusip`` (which needs
+    ``name_of_issuer + accession_number`` only available on per-filing
+    path). The bulk dataset carries period_end + filer_cik but not the
+    issuer name; we store None for ``name_of_issuer`` and let the sweep
+    fill it from OpenFIGI's response (``name`` field).
+
+    Idempotent on the new partial UNIQUE INDEX.
+    """
+    with conn.cursor() as cur:
+        cur.execute("""
+            INSERT INTO unresolved_13f_cusips
+              (cusip, name_of_issuer, last_accession_number, filer_cik, period_end, source)
+            VALUES (%(cusip)s, NULL, NULL, %(filer_cik)s, %(period_end)s, %(source)s)
+            ON CONFLICT (cusip, COALESCE(filer_cik, ''), COALESCE(period_end, '0001-01-01'::date), COALESCE(source, ''))
+            WHERE source IS NOT NULL DO NOTHING
+        """, {"cusip": cusip, "filer_cik": filer_cik, "period_end": period_end, "source": source})
+```
+
+Call sites:
+- `sec_13f_dataset_ingest.py:294-297` — replace counter-only increment with batched call to the new helper (accumulate 1000 rows then INSERT).
+- `sec_nport_dataset_ingest.py:341-345` — same.
+
+---
+
+## 5. PR-1b — OpenFIGI resolver + sweep + Phase D stage + cusip_map fix
+
+### Lane migration (`sql/<N>_bootstrap_stages_lane_openfigi.sql`)
+
+```sql
+ALTER TABLE bootstrap_stages DROP CONSTRAINT bootstrap_stages_lane_check;
+ALTER TABLE bootstrap_stages ADD CONSTRAINT bootstrap_stages_lane_check
+  CHECK (lane IN ('init', 'etoro', 'sec', 'sec_rate', 'sec_bulk_download',
+                  'db', 'db_filings', 'db_fundamentals_raw', 'db_ownership_inst',
+                  'db_ownership_insider', 'db_ownership_funds',
+                  'openfigi'));
+```
+
+### Stage renumber migration (`sql/<N>_bootstrap_stages_insert_cusip_sweep.sql`)
+
+```sql
+-- Renumber S13-S26 to S14-S27 in any in-flight run + the spec catalogue
+UPDATE bootstrap_stages SET stage_order = stage_order + 1
+ WHERE stage_order >= 13;
+-- New S13 = cusip_resolver_post_bulk_sweep — inserted by the orchestrator
+-- when run_bootstrap_orchestrator scaffolds stages from the spec.
+```
+
+### Source/Lane registration
+
+`app/jobs/sources.py` — add `'openfigi'` to `Lane` Literal.
+`app/services/bootstrap_orchestrator.py:233-259` — `_LANE_MAX_CONCURRENCY['openfigi'] = 1`.
+
+### OpenFIGI resolver (~400 LoC)
+
+New module `app/services/openfigi_resolver.py`:
+
+```python
+class OpenFigiResolver:
+    BASE = "https://api.openfigi.com/v3/mapping"
+    UNKEYED_PER_MIN = 25
+    UNKEYED_BATCH = 10
+    KEYED_PER_6S = 25
+    KEYED_BATCH = 100
+
+    def __init__(self, api_key: str | None) -> None:
+        self.api_key = api_key
+        self.rate_limiter = _RateLimiter(
+            per_window=self.KEYED_PER_6S if api_key else self.UNKEYED_PER_MIN,
+            window_seconds=6 if api_key else 60,
+        )
+
+    def resolve_cusips(self, cusips: Iterable[str]) -> dict[str, OpenFigiMapping]:
+        """Batch resolve CUSIPs → mappings. Returns only successful resolutions."""
+        batch_size = self.KEYED_BATCH if self.api_key else self.UNKEYED_BATCH
+        results: dict[str, OpenFigiMapping] = {}
+        for chunk in _batched(cusips, batch_size):
+            with self.rate_limiter:
+                resp = self._post(chunk)
+            for cusip, mapping in zip(chunk, self._parse_response(resp), strict=True):
+                if mapping is not None:
+                    results[cusip] = mapping
+        return results
+
+    def _post(self, cusips: list[str]) -> httpx.Response:
+        body = [{"idType": "ID_CUSIP", "idValue": c} for c in cusips]
+        headers = {}
+        if self.api_key:
+            headers["X-OPENFIGI-APIKEY"] = self.api_key
+        resp = httpx.post(self.BASE, json=body, headers=headers, timeout=30)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", "60"))
+            time.sleep(retry_after)
+            return self._post(cusips)  # one retry
+        resp.raise_for_status()
+        return resp
+
+    def _parse_response(self, resp: httpx.Response) -> list[OpenFigiMapping | None]:
+        # OpenFIGI returns array parallel to input. Each entry is either
+        # {'data': [...]} or {'warning': '...'} or {'error': '...'}.
+        out: list[OpenFigiMapping | None] = []
+        for entry in resp.json():
+            if "data" in entry and entry["data"]:
+                first = entry["data"][0]
+                out.append(OpenFigiMapping(
+                    ticker=first.get("ticker"),
+                    name=first.get("name"),
+                    exch_code=first.get("exchCode"),
+                    share_class_figi=first.get("shareClassFIGI"),
+                ))
+            else:
+                out.append(None)
+        return out
+```
+
+### Sweep extension (`cusip_resolver.py`)
+
+Extend `sweep_resolvable_unresolved_cusips`:
+
+1. Pre-existing path: name-fuzzy via SEC 13F List (0.92 threshold).
+2. NEW path: for remaining unresolved, call `OpenFigiResolver.resolve_cusips()`.
+3. For each successful resolution: match `mapping.ticker` against `instruments.symbol` (exact); if match → write `external_identifiers (provider='openfigi', identifier_type='cusip', instrument_id, identifier_value, is_primary=FALSE)`.
+4. Trigger `rewash_bulk_source_filings(conn, cusip)` — NEW helper that finds bulk-source unresolved rows and removes them so subsequent bulk re-ingest picks them up; OR (lighter) materialises the now-resolvable rows into `ownership_*_observations` directly.
+
+### `_load_cusip_map` extension
+
+```python
+# sec_13f_dataset_ingest.py:67-97  (and sec_nport equivalent at :153-180)
+def _load_cusip_map(conn: psycopg.Connection[Any]) -> dict[str, int]:
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT identifier_value, instrument_id
+              FROM external_identifiers
+             WHERE provider IN ('sec', 'openfigi')
+               AND identifier_type = 'cusip'
+        """)
+        return dict(cur.fetchall())
+
+# bootstrap_preconditions.py:188 (compute_cusip_coverage):
+# SELECT COUNT(DISTINCT instrument_id) FROM external_identifiers
+#   WHERE provider IN ('sec', 'openfigi') AND identifier_type='cusip'
+```
+
+### Phase D stage S13 (new ordering)
+
+`_BOOTSTRAP_STAGE_SPECS`:
+
+```python
+StageSpec(
+    stage_key="cusip_resolver_post_bulk_sweep",
+    stage_order=13,
+    lane="openfigi",
+    job_name=JOB_CUSIP_RESOLVER_POST_BULK_SWEEP,
+    params={"max_batches": 200},
+    requires=CapRequirement(all_of=("institutional_inputs_seeded", "nport_inputs_seeded")),
+    provides=(),  # No new cap; writes to existing external_identifiers
+)
+```
+
+### Floor-gate without `partial_complete`
+
+`bootstrap_runs` migration adds `coverage_floor_met BOOLEAN DEFAULT NULL`. `finalize_run` (`app/services/bootstrap_state.py`) sets it based on post-sweep `compute_cusip_coverage`. Admin panel renders an amber badge if `coverage_floor_met=FALSE`; run still transitions to `complete`.
+
+---
+
+## 6. PR-2 — Dispatcher parallelism
+
+(Unchanged from v2 §6 except for:)
+- Persistent pool registry context-manager: `with LaneExecutorRegistry() as registry: ...`
+- Test fixture injects `MockExecutor` for deterministic ordering.
+- Tests to rewrite: `tests/test_bootstrap_orchestrator.py`, `tests/test_bootstrap_orchestrator_source_registry.py`, `tests/test_bootstrap_adapter.py`, `tests/test_bootstrap_atomic_enqueue.py`.
+
+---
+
+## 7. PR-3 — COPY refactor (NOW includes S9 companyfacts)
+
+(v2 §7 + S9 added based on Codex M finding):
+
+| Stage | LoC delta | Wall-clock target |
+|---|---|---|
+| S10 13F | 250 | 80 min → 5 min |
+| S11 insider | 200 | 10 min → 2 min |
+| S12 NPORT | 250 | 46 min → 4 min |
+| S9 companyfacts | 200 | 20 min → 5 min |
+
+Pattern: per-archive `BEGIN; CREATE TEMP TABLE _stg ON COMMIT DROP; COPY ... INTO _stg; INSERT INTO target SELECT ... FROM _stg ON CONFLICT ...; COMMIT;` — TEMP table dropped at commit, freshly recreated next iteration.
+
+Lint: `scripts/check_bulk_ingest_copy_pattern.sh` (positive name per v2 review N2).
+
+---
+
+## 8-13. (PR-4 through PR-8)
+
+(v2 §8-§13 with minor fixes per v2 review.)
+
+---
+
+## 14. Honest wall-clock budget (post-Codex re-derivation)
+
+Per-lane critical path (with PR-2 cross-lane parallelism + dedicated `openfigi` lane):
+
+```
+init:       S1 (10s)
+etoro:      S2 (4 min)
+sec_rate:   S3+S4+S5+S6+S7 = 6 min  →  S14+S15+S16+S17+S18+S19+S20+S21+S22 (post-renumber) = ~30 min total
+sec_bulk_download: S7 = 5 min (or 30s if PR-5b reuse)
+db_filings: S8 = 10 min
+db_fundamentals_raw: S9 = 5 min (post PR-3.b)
+db_ownership_inst:  S10 = 5 min
+db_ownership_insider: S11 = 2 min
+db_ownership_funds: S12 = 4 min
+openfigi:   S13 (sweep) = up to 48 min unkeyed / 5 min keyed
+db:         S23-S27 = ~10 min combined
+```
+
+**Critical path with PR-2 + parallel `openfigi` lane:**
+- Phase A: max(10s, 4 min, 6 min) = 6 min (parallel init / etoro / sec_rate)
+- Phase C (parallel db lanes + sec_rate S14+): max(10, 9, 5, 5, 2, 4, ~30) = max(10, 30) = 30 min (sec_rate dominates)
+- Phase D: max(openfigi 48 min unkeyed, db ~10 min) = 48 min unkeyed / 10 min keyed
+
+**Total Tier 1: ~6 + 30 + 10 = 46 min** (keyed) or **~6 + 30 + 48 = 84 min** (unkeyed).
+
+With operator-supplied OpenFIGI key → **Tier 1 ≤ 45 min target achievable.**
+
+Without key → **Tier 1 ≤ 90 min ceiling.**
+
+Tier 2 (catalogue collapse + S15 replacement + parallel sec_rate within lane):
+- sec_rate critical drops to ~15 min
+- openfigi keyed = 5 min
+- **Tier 2 ≤ 30 min.**
+
+---
+
+## 15. Acceptance criteria (revised)
+
+```
+ASSERT bootstrap_runs.status = 'complete'
+ASSERT bootstrap_runs.coverage_floor_met = TRUE
+   OR (coverage_floor_met = FALSE AND CUSIP coverage between 50% and 80%)
+   -- below 50%: hard refuse via existing bootstrap_preconditions floor
+ASSERT bootstrap_runs elapsed ≤ 60 min (Tier 1 keyed) / ≤ 90 min (Tier 1 unkeyed)
+ASSERT every stage IN ('success', 'skipped')
+ASSERT external_identifiers (provider IN ('sec','openfigi'), identifier_type='cusip') count ≥ 0.50 × tradable instruments
+ASSERT ownership_*_current rows ≥ _CAPABILITY_MIN_ROWS[corresponding cap]
+ASSERT bootstrap_archive_results aggregate drop rate < 25% per archive
+ASSERT financial_facts_raw rows > 0
+ASSERT instrument_share_count_latest has rows for {AAPL, GME, MSFT, JPM, HD}
+ASSERT GET /instruments/AAPL/ownership-rollup non-empty within 1s
+ASSERT GET /instruments/GOOGL/ownership-rollup returns 200 with EITHER
+   non-empty body OR partial_data_reason='share_class_sibling_pre_PR_B'
+ASSERT data_freshness_index has rows for all (subject, source) triples touched
+```
+
+Robustness (CI-testable):
+
+```
+ASSERT mid-archive operator cancel observed within 60s
+ASSERT process crash mid-stage: reaper resets to pending within 6 min (5 min grace + 1 min poll)
+ASSERT OpenFIGI 429 with Retry-After: resolver backs off + completes batch
+ASSERT OpenFIGI 5xx extended outage: bootstrap completes with coverage_floor_met=FALSE
+ASSERT two operators trigger bootstrap simultaneously: partial-unique index blocks second
+ASSERT S13 cancel mid-sweep: buffer rows remain unresolved for next sweep
+```
+
+---
+
+## 16-20. (Migration safety, out-of-scope, skill updates, decision log, review gate)
+
+(Carried from v2 with adjustments noted in changelog.)
+
+---
+
+## 21. v3 review gate
+
+Before any implementation:
+
+1. **Codex 2 spec review on v3** (re-run).
+2. **Third clean-agent adversarial pass on v3** — must report ≤ 2 HIGH findings to converge.
+3. **Operator sign-off** on SD-1, SD-2 + Tier 1 plan + 60-min target (keyed) / 90-min ceiling (unkeyed).
+
+If v3 review still finds ≥ 3 HIGH defects: v4. Per iterative-refinement memory: keep going until convergence.
+
+---
+
+## Closing
+
+v3 addresses every CRITICAL + HIGH from v2 review. The architectural insight from the adversarial pass that 90 min is too conservative — actual is 47-57 min with `openfigi` lane separated — moves the Tier 1 target to **60 min keyed / 90 min unkeyed**, retiring the 45-min Tier 2 stretch goal as actually achievable in Tier 1 with operator-provided API key.
+
+Spec growing larger reflects honest design — not bloat. Code remains minimal: target Tier 1 net repo delta = +6480 LoC across 11 PRs, of which 2450 LoC is tests.

--- a/sql/164_unresolved_13f_cusips_bulk_columns.sql
+++ b/sql/164_unresolved_13f_cusips_bulk_columns.sql
@@ -1,0 +1,112 @@
+-- 164_unresolved_13f_cusips_bulk_columns.sql
+--
+-- #1233 PR-1a (spec §4) — Bulk-path unresolved-CUSIP capture.
+--
+-- The legacy per-filing writer ``_record_unresolved_cusip``
+-- (app/services/institutional_holdings.py) writes one row per CUSIP
+-- with ``name_of_issuer`` + ``last_accession_number`` (both NOT NULL
+-- at schema 099). The bulk-path ingesters
+-- (``sec_13f_dataset_ingest`` / ``sec_nport_dataset_ingest``) iterate
+-- millions of INFOTABLE / FUND_REPORTED_HOLDING rows and want to
+-- record the *(cusip, filer_cik, period_end)* triple for every
+-- unresolved CUSIP so the PR-1b OpenFIGI sweep can fill in the
+-- ticker + issuer name later. The bulk path does **not** have the
+-- issuer name (the dataset TSV lacks it on the per-holding row;
+-- only filer name + accession + period are available).
+--
+-- This migration:
+--
+--   1. Drops the legacy PRIMARY KEY on ``cusip``. A given CUSIP can
+--      now have multiple bulk-path rows (one per
+--      ``(filer_cik, period_end, source)``) plus AT MOST one legacy
+--      per-filing row. Existing call sites that previously assumed
+--      single-row-per-CUSIP (DELETE / UPDATE WHERE cusip = $1) keep
+--      working in practice because: (a) the legacy path still owns
+--      the ``source IS NULL`` partition under its own partial UNIQUE
+--      (see below), and (b) the resolver helpers ``DELETE … WHERE
+--      cusip = …`` will simply remove every row for that CUSIP after
+--      a successful promotion — which is the correct semantics once
+--      OpenFIGI / fuzzy match resolves it.
+--   2. Drops NOT NULL on ``name_of_issuer`` and
+--      ``last_accession_number``. Bulk-path rows leave these NULL;
+--      the OpenFIGI sweep (PR-1b) fills ``name_of_issuer`` from
+--      OpenFIGI's response.
+--   3. Adds nullable ``filer_cik TEXT``, ``period_end DATE``,
+--      ``source TEXT``.
+--   4. Adds partial UNIQUE INDEX
+--      ``unresolved_13f_cusips_bulk_idx`` on
+--      ``(cusip, COALESCE(filer_cik,''), COALESCE(period_end,'0001-01-01'),
+--        COALESCE(source,''))`` WHERE ``source IS NOT NULL`` —
+--      the bulk-path ON CONFLICT target.
+--   5. Adds partial UNIQUE INDEX
+--      ``unresolved_13f_cusips_legacy_idx`` on ``(cusip)`` WHERE
+--      ``source IS NULL`` — preserves the legacy
+--      ``ON CONFLICT (cusip) DO UPDATE`` shape used by
+--      ``_record_unresolved_cusip``.
+--
+-- Idempotent: every step uses IF EXISTS / IF NOT EXISTS so a re-run
+-- against an already-migrated database is a no-op.
+
+BEGIN;
+
+-- Step 1: drop legacy PRIMARY KEY (constraint name follows PG's
+-- default `_pkey` convention from sql/099). PG names the constraint
+-- ``unresolved_13f_cusips_pkey`` regardless of column ordering.
+ALTER TABLE unresolved_13f_cusips
+    DROP CONSTRAINT IF EXISTS unresolved_13f_cusips_pkey;
+
+-- Step 2: relax NOT NULL on legacy columns. The legacy writer keeps
+-- supplying both (the helper still requires them via Python types);
+-- the bulk writer leaves them NULL.
+ALTER TABLE unresolved_13f_cusips
+    ALTER COLUMN name_of_issuer DROP NOT NULL,
+    ALTER COLUMN last_accession_number DROP NOT NULL;
+
+-- Step 3: add bulk-path columns. All nullable to preserve legacy
+-- rows that pre-date this migration.
+ALTER TABLE unresolved_13f_cusips
+    ADD COLUMN IF NOT EXISTS filer_cik TEXT,
+    ADD COLUMN IF NOT EXISTS period_end DATE,
+    ADD COLUMN IF NOT EXISTS source TEXT;
+
+-- Step 3a: constrain ``source`` to the two bulk-source values plus
+-- NULL (legacy). PR-1b may extend this set; the CHECK is named so
+-- a future migration can DROP + re-ADD cleanly.
+ALTER TABLE unresolved_13f_cusips
+    DROP CONSTRAINT IF EXISTS unresolved_13f_cusips_source_check;
+ALTER TABLE unresolved_13f_cusips
+    ADD CONSTRAINT unresolved_13f_cusips_source_check
+    CHECK (source IS NULL OR source IN (
+        'bulk_13f_dataset',
+        'bulk_nport_dataset'
+    ));
+
+-- Step 4: bulk-path partial UNIQUE INDEX. COALESCE expressions
+-- collapse NULLs into deterministic sentinels so the index treats
+-- the (cusip, filer_cik, period_end, source) tuple as a single key
+-- — PostgreSQL would otherwise treat NULLs as never-equal and the
+-- partial index would not enforce uniqueness on missing values.
+-- (Codex review §H on PR-1a: spec said "ON CONFLICT against the
+-- new partial UNIQUE INDEX" — the inference target must match the
+-- index expression list exactly, see test in helper docstring.)
+CREATE UNIQUE INDEX IF NOT EXISTS unresolved_13f_cusips_bulk_idx
+    ON unresolved_13f_cusips (
+        cusip,
+        COALESCE(filer_cik, ''),
+        COALESCE(period_end, '0001-01-01'::date),
+        COALESCE(source, '')
+    )
+    WHERE source IS NOT NULL;
+
+-- Step 5: legacy-path partial UNIQUE INDEX. Replaces the dropped
+-- PRIMARY KEY on (cusip) for the legacy ``source IS NULL``
+-- partition. Keeps ``_record_unresolved_cusip``'s
+-- ``ON CONFLICT (cusip) DO UPDATE …`` shape working (PG infers the
+-- index by matching the unique column list under a WHERE predicate
+-- — we'll add an explicit WHERE to the helper's ON CONFLICT clause
+-- in the call-site change so the inference is unambiguous).
+CREATE UNIQUE INDEX IF NOT EXISTS unresolved_13f_cusips_legacy_idx
+    ON unresolved_13f_cusips (cusip)
+    WHERE source IS NULL;
+
+COMMIT;

--- a/tests/test_unresolved_cusip_bulk_capture.py
+++ b/tests/test_unresolved_cusip_bulk_capture.py
@@ -1,0 +1,997 @@
+"""#1233 PR-1a — bulk-path unresolved-CUSIP capture.
+
+Verifies:
+
+* Migration ``sql/164`` applies cleanly to ``ebull_test_template``
+  (verified implicitly — the per-worker DB is built from the
+  template, so a broken migration would prevent ``ebull_test_conn``
+  from connecting). Re-application is idempotent (explicit test).
+* ``record_unresolved_cusip_from_bulk`` writes one row per
+  ``(cusip, filer_cik, period_end, source)`` tuple. Re-call with
+  same tuple is no-op (partial UNIQUE on ``..._bulk_idx``).
+* Different ``(filer_cik, period_end, source)`` for the same
+  CUSIP create separate rows.
+* Bulk 13F ingest fixture lands one row per unresolved CUSIP.
+* Bulk N-PORT ingest fixture lands one row per unresolved CUSIP.
+* Legacy ``_record_unresolved_cusip`` still works (writes with
+  ``source=NULL``) and shares the table without colliding with
+  bulk rows.
+* The legacy resolver / extid sweep (``cusip_resolver.py``) ONLY
+  reads/mutates legacy rows (``source IS NULL``); bulk rows for
+  the same CUSIP are untouched. Codex BLOCKING + HIGH on PR-1a
+  pre-push review.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import zipfile
+from datetime import date
+from pathlib import Path
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from app.services.cusip_resolver import (
+    record_unresolved_cusip_from_bulk,
+    resolve_unresolved_cusips,
+    sweep_resolvable_unresolved_cusips,
+)
+from app.services.institutional_holdings import _record_unresolved_cusip
+from app.services.sec_13f_dataset_ingest import ingest_13f_dataset_archive
+from app.services.sec_nport_dataset_ingest import ingest_nport_dataset_archive
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+
+# ---------------------------------------------------------------------------
+# Constants — picked so all test data passes the 8-quarter retention gate
+# (PR6/PR7) regardless of when the suite runs in 2026.
+# ---------------------------------------------------------------------------
+
+
+# Latest completed quarter as of 2026-05-22 = 2026-03-31. The retention
+# gate admits the 8 most recent quarter-ends inclusive — 2024Q2 onward.
+# Using the latest completed quarter end means the tests stay in-window
+# for the next ~24 months without churn.
+_PERIOD_END = date(2026, 3, 31)
+_FILED_AT = "2026-05-15"  # post-2023-01-03 dollars cutover
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_bulk_rows(conn: psycopg.Connection[tuple]) -> int:
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM unresolved_13f_cusips WHERE source IS NOT NULL")
+        row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
+
+
+def _count_legacy_rows(conn: psycopg.Connection[tuple]) -> int:
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM unresolved_13f_cusips WHERE source IS NULL")
+        row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
+
+
+def _build_13f_zip(
+    *,
+    submissions: list[dict[str, str]],
+    coverpages: list[dict[str, str]],
+    infotable: list[dict[str, str]],
+) -> bytes:
+    def _to_tsv(rows: list[dict[str, str]]) -> str:
+        if not rows:
+            return ""
+        fieldnames = sorted({k for row in rows for k in row.keys()})
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+        return buf.getvalue()
+
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w") as zf:
+        zf.writestr("SUBMISSION.tsv", _to_tsv(submissions))
+        zf.writestr("COVERPAGE.tsv", _to_tsv(coverpages))
+        zf.writestr("INFOTABLE.tsv", _to_tsv(infotable))
+    return out.getvalue()
+
+
+def _build_nport_zip(
+    *,
+    submissions: list[dict[str, str]],
+    registrants: list[dict[str, str]],
+    fund_info: list[dict[str, str]],
+    holdings: list[dict[str, str]],
+) -> bytes:
+    def _to_tsv(rows: list[dict[str, str]]) -> str:
+        if not rows:
+            return ""
+        fieldnames = sorted({k for row in rows for k in row.keys()})
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+        return buf.getvalue()
+
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w") as zf:
+        zf.writestr("SUBMISSION.tsv", _to_tsv(submissions))
+        zf.writestr("REGISTRANT.tsv", _to_tsv(registrants))
+        zf.writestr("FUND_REPORTED_INFO.tsv", _to_tsv(fund_info))
+        zf.writestr("FUND_REPORTED_HOLDING.tsv", _to_tsv(holdings))
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Schema / migration smoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestMigration164:
+    def test_partial_unique_indexes_present(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """Both partial UNIQUE indexes from sql/164 exist on the
+        worker's private DB (built from ``ebull_test_template`` which
+        has all migrations applied)."""
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT indexname
+                FROM pg_indexes
+                WHERE tablename = 'unresolved_13f_cusips'
+                  AND indexname IN (
+                    'unresolved_13f_cusips_bulk_idx',
+                    'unresolved_13f_cusips_legacy_idx'
+                  )
+                ORDER BY indexname
+                """,
+            )
+            names = [r[0] for r in cur.fetchall()]
+        assert names == [
+            "unresolved_13f_cusips_bulk_idx",
+            "unresolved_13f_cusips_legacy_idx",
+        ]
+
+    def test_legacy_pk_dropped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """The legacy PRIMARY KEY on ``cusip`` is gone after sql/164;
+        partial UNIQUE indexes take over."""
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT 1
+                FROM pg_constraint
+                WHERE conrelid = 'unresolved_13f_cusips'::regclass
+                  AND contype = 'p'
+                """,
+            )
+            assert cur.fetchone() is None
+
+    def test_migration_is_idempotent(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """Re-running ``sql/164`` against an already-migrated DB is a
+        no-op (no errors, schema unchanged). Guards against operator
+        re-application via ``psql -f`` or partial migration recovery.
+        """
+        sql_path = Path(__file__).resolve().parents[1] / "sql" / "164_unresolved_13f_cusips_bulk_columns.sql"
+        sql_text = sql_path.read_text(encoding="utf-8")
+        with psycopg.ClientCursor(ebull_test_conn) as cur:
+            # ClientCursor uses the simple query protocol — matches
+            # what app/db/migrations.py uses, so this proves the
+            # exact code path the runner would take.
+            cur.execute(sql_text)  # type: ignore[call-overload]
+        ebull_test_conn.commit()
+
+        # Schema is unchanged: same two partial UNIQUE indexes + same
+        # nullable columns + same source CHECK + no PK.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'unresolved_13f_cusips'
+                  AND indexname LIKE 'unresolved_13f_cusips_%_idx'
+                ORDER BY indexname
+                """,
+            )
+            indexes = [r[0] for r in cur.fetchall()]
+        assert indexes == [
+            "unresolved_13f_cusips_bulk_idx",
+            "unresolved_13f_cusips_legacy_idx",
+        ]
+
+    def test_bulk_columns_present_and_nullable(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """The three new columns exist with the expected types and
+        every legacy column that used to be NOT NULL is now nullable
+        (so the bulk path can leave issuer name / accession empty)."""
+        expected = {
+            "filer_cik": ("text", "YES"),
+            "period_end": ("date", "YES"),
+            "source": ("text", "YES"),
+            "name_of_issuer": ("text", "YES"),
+            "last_accession_number": ("text", "YES"),
+        }
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT column_name, data_type, is_nullable
+                FROM information_schema.columns
+                WHERE table_name = 'unresolved_13f_cusips'
+                  AND column_name = ANY(%s)
+                ORDER BY column_name
+                """,
+                (list(expected.keys()),),
+            )
+            actual = {row[0]: (row[1], row[2]) for row in cur.fetchall()}
+        assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# Helper unit behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestRecordUnresolvedCusipFromBulk:
+    def test_first_insert_creates_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="00BULK0001",
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT cusip, filer_cik, period_end, source,
+                       name_of_issuer, last_accession_number
+                FROM unresolved_13f_cusips
+                WHERE cusip = %s
+                """,
+                ("00BULK0001",),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row[0] == "00BULK0001"
+        assert row[1] == "0001234567"
+        assert row[2] == _PERIOD_END
+        assert row[3] == "bulk_13f_dataset"
+        # Bulk path leaves issuer name + accession blank; OpenFIGI
+        # sweep (PR-1b) fills name_of_issuer.
+        assert row[4] is None
+        assert row[5] is None
+
+    def test_duplicate_tuple_is_no_op(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        for _ in range(3):
+            record_unresolved_cusip_from_bulk(
+                ebull_test_conn,
+                cusip="00BULK0002",
+                filer_cik="0001234567",
+                period_end=_PERIOD_END,
+                source="bulk_13f_dataset",
+            )
+        ebull_test_conn.commit()
+        assert _count_bulk_rows(ebull_test_conn) == 1
+
+    def test_different_filer_cik_creates_separate_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="00BULK0003",
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="00BULK0003",
+            filer_cik="0009999999",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        ebull_test_conn.commit()
+        assert _count_bulk_rows(ebull_test_conn) == 2
+
+    def test_different_period_end_creates_separate_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="00BULK0004",
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="00BULK0004",
+            filer_cik="0001234567",
+            period_end=date(2025, 12, 31),
+            source="bulk_13f_dataset",
+        )
+        ebull_test_conn.commit()
+        assert _count_bulk_rows(ebull_test_conn) == 2
+
+    def test_different_source_creates_separate_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="00BULK0005",
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="00BULK0005",
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_nport_dataset",
+        )
+        ebull_test_conn.commit()
+        assert _count_bulk_rows(ebull_test_conn) == 2
+
+
+# ---------------------------------------------------------------------------
+# Legacy / bulk coexistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestLegacyWriterCoexistence:
+    def test_legacy_writer_still_works(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """Legacy ``_record_unresolved_cusip`` still upserts one row
+        per CUSIP under the new partial UNIQUE
+        ``unresolved_13f_cusips_legacy_idx``."""
+        _record_unresolved_cusip(
+            ebull_test_conn,
+            cusip="00LEGACY01",
+            name_of_issuer="Legacy Issuer Inc",
+            accession_number="0000000-00-000001",
+        )
+        _record_unresolved_cusip(
+            ebull_test_conn,
+            cusip="00LEGACY01",
+            name_of_issuer="Legacy Issuer Inc Updated",
+            accession_number="0000000-00-000002",
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT cusip, name_of_issuer, last_accession_number,
+                       observation_count, source
+                FROM unresolved_13f_cusips
+                WHERE cusip = %s
+                """,
+                ("00LEGACY01",),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        cusip, name, accn, obs_count, source = rows[0]
+        assert cusip == "00LEGACY01"
+        assert name == "Legacy Issuer Inc Updated"
+        assert accn == "0000000-00-000002"
+        assert obs_count == 2
+        assert source is None
+
+    def test_legacy_and_bulk_coexist_for_same_cusip(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """A CUSIP can have ONE legacy row (source IS NULL) AND
+        multiple bulk rows (source IS NOT NULL) simultaneously —
+        the partial indexes don't cross-collide."""
+        cusip = "00MIX00001"
+        _record_unresolved_cusip(
+            ebull_test_conn,
+            cusip=cusip,
+            name_of_issuer="Mixed Issuer Inc",
+            accession_number="0000000-00-000099",
+        )
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip=cusip,
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip=cusip,
+            filer_cik="0009999999",
+            period_end=_PERIOD_END,
+            source="bulk_nport_dataset",
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM unresolved_13f_cusips WHERE cusip = %s",
+                (cusip,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+        assert int(row[0]) == 3
+
+
+# ---------------------------------------------------------------------------
+# 13F bulk-ingest integration — five unresolved CUSIPs land five rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestBulk13FIngestUnresolvedCapture:
+    def test_five_unresolved_cusips_yield_five_bulk_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """A 13F archive with 5 unresolved CUSIPs writes 5 rows into
+        ``unresolved_13f_cusips`` with ``source='bulk_13f_dataset'``.
+        Zero resolved rows are emitted because we seed no
+        ``external_identifiers``."""
+        accession = "0001234567-26-000001"
+        submissions = [
+            {
+                "ACCESSION_NUMBER": accession,
+                "CIK": "1234567",
+                "FILING_DATE": _FILED_AT,
+            },
+        ]
+        coverpages = [
+            {
+                "ACCESSION_NUMBER": accession,
+                "FILINGMANAGER_NAME": "Test Fund",
+                "REPORTCALENDARORQUARTER": _PERIOD_END.isoformat(),
+            },
+        ]
+        unresolved_cusips = [
+            "U0000001A1",
+            "U0000002B2",
+            "U0000003C3",
+            "U0000004D4",
+            "U0000005E5",
+        ]
+        infotable = [
+            {
+                "ACCESSION_NUMBER": accession,
+                "CUSIP": cusip,
+                "VALUE": "1000",
+                "SSHPRNAMT": "100",
+                "VOTING_AUTH_SOLE": "100",
+            }
+            for cusip in unresolved_cusips
+        ]
+        archive_path = tmp_path / "form13f_unresolved.zip"
+        archive_path.write_bytes(
+            _build_13f_zip(
+                submissions=submissions,
+                coverpages=coverpages,
+                infotable=infotable,
+            )
+        )
+
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_skipped_unresolved_cusip == 5
+        assert result.rows_written == 0
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT cusip, filer_cik, period_end, source
+                FROM unresolved_13f_cusips
+                WHERE source = 'bulk_13f_dataset'
+                ORDER BY cusip
+                """,
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 5
+        assert [r[0] for r in rows] == sorted(unresolved_cusips)
+        # Same filer + period for every row (single-submission fixture).
+        assert all(r[1] == "0001234567" for r in rows)
+        assert all(r[2] == _PERIOD_END for r in rows)
+        assert all(r[3] == "bulk_13f_dataset" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# N-PORT bulk-ingest integration — five unresolved CUSIPs land five rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestBulkNPortIngestUnresolvedCapture:
+    def test_five_unresolved_cusips_yield_five_bulk_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """A N-PORT archive with 5 EC/Long/NS unresolved CUSIPs writes
+        5 rows into ``unresolved_13f_cusips`` with
+        ``source='bulk_nport_dataset'``."""
+        accession = "0007654321-26-000001"
+        submissions = [
+            {
+                "ACCESSION_NUMBER": accession,
+                "FILING_DATE": _FILED_AT,
+                "SUB_TYPE": "NPORT-P",
+                "REPORT_DATE": _PERIOD_END.isoformat(),
+            },
+        ]
+        registrants = [
+            {
+                "ACCESSION_NUMBER": accession,
+                "CIK": "7654321",
+                "REGISTRANT_NAME": "Test Trust",
+            },
+        ]
+        fund_info = [
+            {
+                "ACCESSION_NUMBER": accession,
+                "SERIES_ID": "S000004310",
+                "SERIES_NAME": "Test Equity Series",
+            },
+        ]
+        unresolved_cusips = [
+            "N0000001A1",
+            "N0000002B2",
+            "N0000003C3",
+            "N0000004D4",
+            "N0000005E5",
+        ]
+        holdings = [
+            {
+                "ACCESSION_NUMBER": accession,
+                "HOLDING_ID": str(i),
+                "ISSUER_CUSIP": cusip,
+                "ASSET_CAT": "EC",
+                "PAYOFF_PROFILE": "Long",
+                "UNIT": "NS",
+                "BALANCE": "1000",
+                "CURRENCY_CODE": "USD",
+                "CURRENCY_VALUE": "10000",
+            }
+            for i, cusip in enumerate(unresolved_cusips, start=1)
+        ]
+        archive_path = tmp_path / "nport_unresolved.zip"
+        archive_path.write_bytes(
+            _build_nport_zip(
+                submissions=submissions,
+                registrants=registrants,
+                fund_info=fund_info,
+                holdings=holdings,
+            )
+        )
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_skipped_unresolved_cusip == 5
+        assert result.rows_written == 0
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT cusip, filer_cik, period_end, source
+                FROM unresolved_13f_cusips
+                WHERE source = 'bulk_nport_dataset'
+                ORDER BY cusip
+                """,
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 5
+        assert [r[0] for r in rows] == sorted(unresolved_cusips)
+        assert all(r[1] == "0007654321" for r in rows)
+        assert all(r[2] == _PERIOD_END for r in rows)
+        assert all(r[3] == "bulk_nport_dataset" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Resolved rows MUST NOT land in the unresolved table — guards against the
+# capture branch leaking past the cusip_map.get() check.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestResolvedCusipDoesNotCapture:
+    def test_resolved_cusip_in_13f_archive_is_not_captured(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """If the CUSIP resolves via external_identifiers, the ingester
+        writes the observation and DOES NOT add a row to
+        ``unresolved_13f_cusips``."""
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+                "VALUES (%s, %s, %s, 'USD', TRUE)",
+                (90001, "RES1", "Resolved Co"),
+            )
+            cur.execute(
+                "INSERT INTO external_identifiers "
+                "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+                "VALUES (%s, 'sec', 'cusip', %s, TRUE)",
+                (90001, "RESOLVED01"),
+            )
+        ebull_test_conn.commit()
+
+        accession = "0001234567-26-000099"
+        archive_path = tmp_path / "form13f_resolved.zip"
+        archive_path.write_bytes(
+            _build_13f_zip(
+                submissions=[
+                    {
+                        "ACCESSION_NUMBER": accession,
+                        "CIK": "1234567",
+                        "FILING_DATE": _FILED_AT,
+                    }
+                ],
+                coverpages=[
+                    {
+                        "ACCESSION_NUMBER": accession,
+                        "FILINGMANAGER_NAME": "Test Fund",
+                        "REPORTCALENDARORQUARTER": _PERIOD_END.isoformat(),
+                    }
+                ],
+                infotable=[
+                    {
+                        "ACCESSION_NUMBER": accession,
+                        "CUSIP": "RESOLVED01",
+                        "VALUE": "1000",
+                        "SSHPRNAMT": "100",
+                        "VOTING_AUTH_SOLE": "100",
+                    }
+                ],
+            )
+        )
+
+        bulk_before = _count_bulk_rows(ebull_test_conn)
+        legacy_before = _count_legacy_rows(ebull_test_conn)
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_written == 1
+        assert result.rows_skipped_unresolved_cusip == 0
+        assert _count_bulk_rows(ebull_test_conn) == bulk_before
+        assert _count_legacy_rows(ebull_test_conn) == legacy_before
+
+    def test_resolved_cusip_in_nport_archive_is_not_captured(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """N-PORT mirror of the 13F resolved-CUSIP no-capture invariant.
+        Codex MED on PR-1a pre-push: 13F path had this, N-PORT didn't.
+        """
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+                "VALUES (%s, %s, %s, 'USD', TRUE)",
+                (90002, "RES2", "Resolved N-PORT Co"),
+            )
+            cur.execute(
+                "INSERT INTO external_identifiers "
+                "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+                "VALUES (%s, 'sec', 'cusip', %s, TRUE)",
+                (90002, "RESOLVED02"),
+            )
+        ebull_test_conn.commit()
+
+        accession = "0007654321-26-000099"
+        archive_path = tmp_path / "nport_resolved.zip"
+        archive_path.write_bytes(
+            _build_nport_zip(
+                submissions=[
+                    {
+                        "ACCESSION_NUMBER": accession,
+                        "FILING_DATE": _FILED_AT,
+                        "SUB_TYPE": "NPORT-P",
+                        "REPORT_DATE": _PERIOD_END.isoformat(),
+                    }
+                ],
+                registrants=[
+                    {
+                        "ACCESSION_NUMBER": accession,
+                        "CIK": "7654321",
+                        "REGISTRANT_NAME": "Test Trust",
+                    }
+                ],
+                fund_info=[
+                    {
+                        "ACCESSION_NUMBER": accession,
+                        "SERIES_ID": "S000004310",
+                        "SERIES_NAME": "Test Equity Series",
+                    }
+                ],
+                holdings=[
+                    {
+                        "ACCESSION_NUMBER": accession,
+                        "HOLDING_ID": "1",
+                        "ISSUER_CUSIP": "RESOLVED02",
+                        "ASSET_CAT": "EC",
+                        "PAYOFF_PROFILE": "Long",
+                        "UNIT": "NS",
+                        "BALANCE": "1000",
+                        "CURRENCY_CODE": "USD",
+                        "CURRENCY_VALUE": "10000",
+                    }
+                ],
+            )
+        )
+
+        bulk_before = _count_bulk_rows(ebull_test_conn)
+        legacy_before = _count_legacy_rows(ebull_test_conn)
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_written == 1
+        assert result.rows_skipped_unresolved_cusip == 0
+        assert _count_bulk_rows(ebull_test_conn) == bulk_before
+        assert _count_legacy_rows(ebull_test_conn) == legacy_before
+
+
+# ---------------------------------------------------------------------------
+# Partition isolation — the legacy resolver / extid sweep must NOT touch
+# bulk rows. Codex BLOCKING + HIGH on PR-1a pre-push review.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestLegacyResolverIgnoresBulkRows:
+    def test_resolve_unresolved_cusips_skips_bulk_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """``resolve_unresolved_cusips`` reads only legacy rows. A bulk
+        row with NULL ``name_of_issuer`` would otherwise be picked up
+        and ``_normalise_name(None)`` would crash or silently
+        tombstone the bulk row as ``unresolvable``."""
+        # Seed one bulk row only.
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="BULKONLY01",
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        ebull_test_conn.commit()
+
+        # No legacy rows + bulk rows are filtered → report sees zero
+        # candidates.
+        report = resolve_unresolved_cusips(ebull_test_conn)
+        assert report.candidates_seen == 0
+        assert report.tombstoned_unresolvable == 0
+
+        # The bulk row is untouched: status still NULL.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT resolution_status FROM unresolved_13f_cusips WHERE cusip = %s AND source = %s",
+                ("BULKONLY01", "bulk_13f_dataset"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] is None
+
+    def test_extid_sweep_skips_bulk_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """``sweep_resolvable_unresolved_cusips`` reads only legacy
+        rows. A bulk row with NULL ``last_accession_number`` would
+        otherwise be picked up and the rewash call would target
+        accession ``"None"``."""
+        # Seed instrument + extid mapping so the sweep would otherwise
+        # pick the row.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+                "VALUES (%s, %s, %s, 'USD', TRUE)",
+                (90003, "BULK3", "Bulk Test Inc"),
+            )
+            cur.execute(
+                "INSERT INTO external_identifiers "
+                "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+                "VALUES (%s, 'sec', 'cusip', %s, TRUE)",
+                (90003, "BULKSWEEP1"),
+            )
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip="BULKSWEEP1",
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        ebull_test_conn.commit()
+
+        report = sweep_resolvable_unresolved_cusips(ebull_test_conn)
+        assert report.candidates_seen == 0
+        assert report.promoted == 0
+
+        # Bulk row stays pending; status untouched.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT resolution_status FROM unresolved_13f_cusips WHERE cusip = %s AND source = %s",
+                ("BULKSWEEP1", "bulk_13f_dataset"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] is None
+
+    def test_legacy_tombstone_does_not_mutate_bulk_rows_for_same_cusip(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """A legacy tombstone (e.g. ``unresolvable`` when no candidate
+        crosses the fuzzy threshold) MUST mutate only the legacy row.
+        Bulk rows sharing the same CUSIP keep ``resolution_status =
+        NULL`` so PR-1b's OpenFIGI sweep can still pick them up.
+
+        Codex MED follow-up on PR-1a: previous tests covered DELETE
+        isolation but not UPDATE isolation."""
+        cusip = "TOMBSHARE1"
+
+        # Two rows: one legacy + one bulk, same CUSIP.
+        _record_unresolved_cusip(
+            ebull_test_conn,
+            cusip=cusip,
+            name_of_issuer="Z-Some Weird Unmatchable Name Inc",
+            accession_number="0000000-26-000100",
+        )
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip=cusip,
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        ebull_test_conn.commit()
+
+        # Run the legacy resolver. With no matching instrument, the
+        # legacy row gets tombstoned ``unresolvable``.
+        report = resolve_unresolved_cusips(ebull_test_conn)
+        assert report.tombstoned_unresolvable == 1
+        assert report.promotions == 0
+
+        # Legacy row status is now ``unresolvable``.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT resolution_status FROM unresolved_13f_cusips WHERE cusip = %s AND source IS NULL",
+                (cusip,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "unresolvable"
+
+        # Bulk row status stays NULL — UNTOUCHED.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT resolution_status FROM unresolved_13f_cusips WHERE cusip = %s AND source = %s",
+                (cusip, "bulk_13f_dataset"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] is None
+
+    def test_legacy_promotion_does_not_delete_bulk_rows_for_same_cusip(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """A legacy row whose CUSIP gets promoted to
+        ``external_identifiers`` is DELETEd, but bulk rows sharing
+        that CUSIP MUST survive (different lifecycle owned by PR-1b
+        sweep)."""
+        cusip = "SHARED0001"
+
+        # Bulk row for the CUSIP.
+        record_unresolved_cusip_from_bulk(
+            ebull_test_conn,
+            cusip=cusip,
+            filer_cik="0001234567",
+            period_end=_PERIOD_END,
+            source="bulk_13f_dataset",
+        )
+        # Legacy row for the same CUSIP.
+        _record_unresolved_cusip(
+            ebull_test_conn,
+            cusip=cusip,
+            name_of_issuer="Shared Co Inc",
+            accession_number="0000000-26-000099",
+        )
+        # Instrument + name to allow the legacy resolver to fuzzy-match.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+                "VALUES (%s, %s, %s, 'USD', TRUE)",
+                (90004, "SHRD", "Shared Co Inc"),
+            )
+        ebull_test_conn.commit()
+
+        report = resolve_unresolved_cusips(ebull_test_conn)
+        # The legacy row resolved (similarity 1.0).
+        assert report.promotions == 1
+
+        # Bulk row survives.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM unresolved_13f_cusips WHERE cusip = %s AND source = %s",
+                (cusip, "bulk_13f_dataset"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert int(row[0]) == 1
+        # Legacy row is gone.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM unresolved_13f_cusips WHERE cusip = %s AND source IS NULL",
+                (cusip,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert int(row[0]) == 0


### PR DESCRIPTION
## Summary

First of 11 PRs implementing the bootstrap ETL optimisation (#1233, spec v3 at `docs/superpowers/specs/2026-05-22-bootstrap-etl-optimisation-v3.md` §4). Adds a second writer path to `unresolved_13f_cusips` so the bulk 13F / N-PORT dataset ingesters can capture unresolved-CUSIP observations without the issuer-name field that only per-filing ingest has.

- New helper `cusip_resolver.record_unresolved_cusip_from_bulk(conn, *, cusip, filer_cik, period_end, source)` — idempotent on partial UNIQUE `unresolved_13f_cusips_bulk_idx`.
- Schema migration `sql/164` drops the legacy PK on `cusip`, relaxes NOT NULL on `name_of_issuer` + `last_accession_number`, adds the three bulk columns, adds two partial UNIQUE indexes (one per writer partition), and a CHECK on `source`.
- Bulk 13F + N-PORT ingesters batch-buffer `(cusip, filer_cik, period_end)` triples and flush every 1000 rows + at archive boundary.
- Legacy resolver paths (`resolve_unresolved_cusips`, `sweep_resolvable_unresolved_cusips`, `_tombstone`, `_promote_to_external_identifier`) all gain `AND source IS NULL` so they never touch bulk rows (which carry NULL issuer-name + NULL accession by design).
- Legacy `_record_unresolved_cusip` ON CONFLICT clause widened to `(cusip) WHERE source IS NULL` so PG can disambiguate the two indexes.

PR-1b (next) wires the OpenFIGI resolver against these captured rows.

## Why two writers, not one?

The bulk SEC datasets carry CUSIP + filer_cik + period_end per holding — but **not** the issuer name (only at filer level, not per holding). The legacy `_record_unresolved_cusip` writer requires `name_of_issuer + accession_number` (both `NOT NULL` pre-#1233). Relaxing that signature would corrupt every existing call site that depends on the NOT NULL invariant for downstream fuzzy match. Splitting the writers is the lower-risk path; the partial UNIQUE indexes guarantee the two partitions never collide.

## Verification

Smoke test against dev DB:

| Step | Result |
|---|---|
| Migration applied | OK |
| Migration re-applied (idempotency) | OK (no-op) |
| 5-instrument synthetic 13F archive (3 resolved AAPL/MSFT/GME + 5 unresolved) | 3 obs written, +5 bulk rows, 0 legacy delta |
| Resolved-CUSIP no-capture invariant | confirmed (13F + N-PORT tests) |
| Legacy resolver / extid sweep ignore bulk rows | confirmed (3 partition-isolation tests) |
| `_record_unresolved_cusip` legacy upsert still works | confirmed (2 coexistence tests) |

19 tests in `tests/test_unresolved_cusip_bulk_capture.py`; 44 pre-existing related tests still pass.

## Security model

`record_unresolved_cusip_from_bulk` is internal-only — called by the bulk dataset ingesters which run server-side. No new HTTP surface. CUSIP / filer_cik / period_end are parsed from SEC dataset TSVs before reaching the helper.

## Out of scope

- OpenFIGI resolver service (PR-1b).
- `_load_cusip_map` extension to `provider IN ('sec','openfigi')` (PR-1b).
- Phase D sweep stage (PR-1b).
- Backfill of pre-existing bulk-source unresolved CUSIPs — there is no historical bulk data; the table starts collecting on next dataset ingest.

## Test plan

- [ ] CI green on all gates (lint / format / pyright / pytest).
- [ ] Reviewer confirms schema migration is reversible (DROP CONSTRAINT IF EXISTS + DROP INDEX IF EXISTS by name).
- [ ] Reviewer confirms partition isolation: legacy resolver / sweep / tombstone / DELETE all scoped to `source IS NULL`.
- [ ] Reviewer confirms bulk path can't fail-poison: each buffer flush row in its own savepoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Refs #1233
