### PR TITLE
feat(#1233): PR-4 batched _current refresh post-bulk-ingest

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -364,6 +364,44 @@ WHERE s.category = '<cat>'
 
 Spec: `docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md`. Prevention-log entries: "MERGE WHEN NOT MATCHED BY SOURCE must carry the per-scope clamp on BOTH the ON clause AND the DELETE clause" + "Diff-aware writers must NOT include update-timestamp columns in the diff predicate".
 
+**Batched form for post-ingest hot-paths (#1233 PR-4, SHIPPED 2026-05-23)**:
+
+Three of the seven helpers also expose a batched form:
+
+- `refresh_insiders_current_batch(conn, *, instrument_ids)`
+- `refresh_institutions_current_batch(conn, *, instrument_ids)`
+- `refresh_funds_current_batch(conn, *, instrument_ids)`
+
+Used by `sec_bulk_orchestrator_jobs.py` after each bulk ingest. Collapses the per-instrument round-trip + lock + MERGE into one of each, scoped to the batch. Saves 5–10 min wall-clock per category at peak (~10k touched instruments × 50 ms each).
+
+Hard invariants pinned by `tests/test_ownership_observations_refresh_batch.py` (21 cases = 7 × 3 helpers):
+
+- **Deadlock-safe lock ordering**: the batched helper acquires ALL advisory locks for its batch in a single server-side query sorted by hashed lock key (`hashtextextended('refresh_X_current', 0) # iid::bigint`). NOT by raw `instrument_id` — the hash is not monotonic in `iid`, so two parallel callers seeing the same set in raw-int order could deadlock. Hash-key order makes both callers queue identically.
+- **DISTINCT ON / ORDER BY lead column**: batched USING subquery prepends `instrument_id` to both the DISTINCT ON tuple and the ORDER BY list so per-instrument partitioning matches the single-instrument helper exactly.
+- **ON clause**: drops the const clamp `tgt.instrument_id = %(iid)s` (no single iid in scope); uses `tgt.instrument_id = src.instrument_id` from MERGE's natural per-row matching.
+- **NOT MATCHED BY SOURCE clamp**: `tgt.instrument_id = ANY(%(ids)s::bigint[])` replaces the const clamp — the load-bearing scope guard against cross-instrument cartesian DELETE.
+- **Empty input**: no-op (returns 0, dispatches no SQL).
+- **Idempotency**: identical to single-instrument helper — IS DISTINCT FROM diff predicate skips UPDATE on no-op; xmin stays stable; row count unchanged.
+- **Caller normalisation**: `_normalise_instrument_ids` dedupes + sorts the input. A caller passing `[3, 1, 2, 1, 3]` behaves the same as `[1, 2, 3]`.
+- **Watermark UPSERT**: one `ownership_refresh_state` row per instrument in the batch, written via `executemany` — same shape as the single-instrument helper's single INSERT.
+
+Call-site pattern (in `sec_bulk_orchestrator_jobs.py`, mirrored across 13F / insider / N-PORT):
+
+```python
+_REFRESH_BATCH_CHUNK_SIZE: Final[int] = 200
+
+for chunk_start in range(0, len(sorted_ids), _REFRESH_BATCH_CHUNK_SIZE):
+    if bootstrap_cancel_requested():
+        raise BootstrapStageCancelled(...)
+    chunk = sorted_ids[chunk_start : chunk_start + _REFRESH_BATCH_CHUNK_SIZE]
+    with conn.transaction():
+        refresh_X_current_batch(conn, instrument_ids=chunk)
+```
+
+Cancel observation latency degrades from ~50 instruments (old serial loop) to ~`_REFRESH_BATCH_CHUNK_SIZE` (=200) instruments. Documented trade-off, accepted in spec §8.
+
+The four other helpers (blockholders / treasury / def14a / esop) keep the single-instrument path only — nothing in the bulk orchestrator loops over them at scale, so the batched form would be code without a caller.
+
 ### 2.11 Worker / job entry points
 
 [app/workers/scheduler.py:453](../../../app/workers/scheduler.py#L453) — `SCHEDULED_JOBS` declaration. [app/jobs/](../../../app/jobs/) package owns runtime side:

--- a/app/services/ownership_observations.py
+++ b/app/services/ownership_observations.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -1707,3 +1707,412 @@ def iter_insider_observations(
             )
         for row in cur.fetchall():
             yield dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Batched _current refreshers (#1233 PR-4)
+# ---------------------------------------------------------------------------
+#
+# Spec: docs/superpowers/specs/2026-05-22-bootstrap-etl-optimisation-v2.md §8.
+#
+# The serial refresh loop `for iid in touched_ids: refresh_X_current(conn, iid)`
+# inside `sec_bulk_orchestrator_jobs.py` costs one PG round-trip + one
+# advisory-lock acquire + one MERGE per touched instrument. At ~10k touched
+# instruments per 13F bulk run × 50 ms each = 5–10 min serial loop AFTER
+# ingest, and the same shape for insider + N-PORT. The batched helpers below
+# collapse the round-trips into a single statement per category while
+# preserving the diff-aware MERGE semantics established by PR12.
+#
+# Deadlock safety
+# ---------------
+# The single-instrument helpers each acquire one advisory lock keyed by
+# `hashtextextended('refresh_<category>_current', 0) # iid::bigint`. The
+# hash is NOT monotonic in `iid` — two parallel batch calls with overlapping
+# but un-sorted instrument sets would otherwise acquire locks in different
+# orders and could deadlock. The batched helpers acquire ALL locks for their
+# batch in a single server-side query sorted by the hashed lock key, so any
+# two batch callers see the same lock-acquire order for the same instrument
+# set. Sorting in SQL (not Python) avoids hashing the PG-side
+# `hashtextextended` algorithm in client code.
+#
+# Idempotency
+# -----------
+# The MERGE writer is no-op-on-same-input (IS DISTINCT FROM diff predicate
+# + WHEN NOT MATCHED BY SOURCE delete clamped to the batch). Re-running a
+# batched refresh on the same instrument set produces zero dead tuples and
+# leaves `refreshed_at` unchanged on every row that already matched (PR12
+# §3.3 invariant — preserved verbatim).
+#
+# Empty input
+# -----------
+# An empty `instrument_ids` is a no-op (returns 0 rows updated). The bulk
+# orchestrator already guards `if touched_ids:` upstream; the no-op here
+# is defence-in-depth.
+
+
+def _normalise_instrument_ids(instrument_ids: Iterable[int]) -> list[int]:
+    """Return a de-duplicated, sorted-by-int list of instrument_ids.
+
+    The MERGE writers downstream order locks by the hashed lock key
+    (not raw int), but we de-duplicate here so a caller that passes a
+    list rather than a set cannot inflate the lock-acquire count or
+    feed duplicate src rows to MERGE."""
+    return sorted({int(i) for i in instrument_ids})
+
+
+def refresh_insiders_current_batch(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_ids: Iterable[int],
+) -> int:
+    """Batched form of :func:`refresh_insiders_current`.
+
+    Semantically equivalent to looping over ``instrument_ids`` and calling
+    the single-instrument helper once per id, but collapses the per-id
+    round-trip + lock + MERGE into one of each, scoped to the batch.
+
+    Returns the number of distinct instrument_ids processed (0 if the
+    input was empty)."""
+    ids = _normalise_instrument_ids(instrument_ids)
+    if not ids:
+        return 0
+    with conn.transaction(), conn.cursor() as cur:
+        # Acquire ALL advisory locks for the batch in hash-key order
+        # (deadlock safety — see module-level note). One server-side
+        # query sorts the locks deterministically across callers.
+        cur.execute(
+            """
+            SELECT pg_advisory_xact_lock(lk)
+              FROM (
+                SELECT (hashtextextended('refresh_insiders_current', 0) # iid::bigint) AS lk
+                  FROM unnest(%(ids)s::bigint[]) AS iid
+                 ORDER BY lk
+              ) AS ordered_locks
+            """,
+            {"ids": ids},
+        )
+        # Capture per-instrument watermark BEFORE the MERGE so the state
+        # UPSERT cannot advance past observations the MERGE did not see
+        # (PR12 Codex 1b HIGH-2 race fix, preserved at batch scope).
+        cur.execute(
+            """
+            SELECT instrument_id, MAX(ingested_at)
+              FROM ownership_insiders_observations
+             WHERE instrument_id = ANY(%(ids)s::bigint[])
+             GROUP BY instrument_id
+            """,
+            {"ids": ids},
+        )
+        watermarks: dict[int, datetime | None] = {int(r[0]): r[1] for r in cur.fetchall()}
+        cur.execute(
+            """
+            MERGE INTO ownership_insiders_current AS tgt
+            USING (
+                SELECT DISTINCT ON (instrument_id, holder_identity_key, ownership_nature)
+                    instrument_id, holder_cik, holder_name, holder_identity_key,
+                    ownership_nature, source, source_document_id, source_accession,
+                    source_url, filed_at, period_start, period_end, shares
+                FROM ownership_insiders_observations
+                WHERE instrument_id = ANY(%(ids)s::bigint[]) AND known_to IS NULL
+                ORDER BY
+                    instrument_id,
+                    holder_identity_key,
+                    ownership_nature,
+                    CASE source
+                        WHEN 'form4'    THEN 1
+                        WHEN 'form3'    THEN 2
+                        WHEN '13d'      THEN 3
+                        WHEN '13g'      THEN 3
+                        WHEN 'def14a'   THEN 4
+                        WHEN '13f'      THEN 5
+                        WHEN 'nport'    THEN 6
+                        WHEN 'ncsr'     THEN 6
+                        WHEN 'xbrl_dei' THEN 7
+                        WHEN '10k_note' THEN 8
+                        WHEN 'finra_si' THEN 9
+                        ELSE 10
+                    END ASC,
+                    period_end DESC,
+                    filed_at DESC,
+                    source ASC,
+                    source_document_id ASC
+            ) AS src
+            ON tgt.instrument_id = src.instrument_id
+               AND tgt.holder_identity_key = src.holder_identity_key
+               AND tgt.ownership_nature = src.ownership_nature
+            WHEN MATCHED AND (
+                tgt.holder_cik, tgt.holder_name,
+                tgt.source, tgt.source_document_id, tgt.source_accession, tgt.source_url,
+                tgt.filed_at, tgt.period_start, tgt.period_end,
+                tgt.shares
+            ) IS DISTINCT FROM (
+                src.holder_cik, src.holder_name,
+                src.source, src.source_document_id, src.source_accession, src.source_url,
+                src.filed_at, src.period_start, src.period_end,
+                src.shares
+            ) THEN UPDATE SET
+                holder_cik         = src.holder_cik,
+                holder_name        = src.holder_name,
+                source             = src.source,
+                source_document_id = src.source_document_id,
+                source_accession   = src.source_accession,
+                source_url         = src.source_url,
+                filed_at           = src.filed_at,
+                period_start       = src.period_start,
+                period_end         = src.period_end,
+                shares             = src.shares,
+                refreshed_at       = now()
+            WHEN NOT MATCHED BY TARGET THEN INSERT (
+                instrument_id, holder_cik, holder_name, holder_identity_key,
+                ownership_nature, source, source_document_id, source_accession,
+                source_url, filed_at, period_start, period_end, shares
+            ) VALUES (
+                src.instrument_id, src.holder_cik, src.holder_name, src.holder_identity_key,
+                src.ownership_nature, src.source, src.source_document_id, src.source_accession,
+                src.source_url, src.filed_at, src.period_start, src.period_end, src.shares
+            )
+            WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = ANY(%(ids)s::bigint[]) THEN DELETE
+            """,
+            {"ids": ids},
+        )
+        # Batched UPSERT of ownership_refresh_state — one round-trip for
+        # the whole batch. Watermarks come from the pre-MERGE snapshot:
+        # any instrument with zero observations gets NULL watermark,
+        # mirroring the single-instrument helper.
+        rows = [(iid, watermarks.get(iid)) for iid in ids]
+        cur.executemany(
+            """
+            INSERT INTO ownership_refresh_state (
+                instrument_id, category,
+                last_drained_observations_max_ingested_at, last_refresh_attempted_at
+            ) VALUES (%s, 'insiders', %s, now())
+            ON CONFLICT (instrument_id, category) DO UPDATE SET
+                last_drained_observations_max_ingested_at = EXCLUDED.last_drained_observations_max_ingested_at,
+                last_refresh_attempted_at = EXCLUDED.last_refresh_attempted_at
+            """,
+            rows,
+        )
+    return len(ids)
+
+
+def refresh_institutions_current_batch(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_ids: Iterable[int],
+) -> int:
+    """Batched form of :func:`refresh_institutions_current`.
+
+    See :func:`refresh_insiders_current_batch` for the design contract."""
+    ids = _normalise_instrument_ids(instrument_ids)
+    if not ids:
+        return 0
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_advisory_xact_lock(lk)
+              FROM (
+                SELECT (hashtextextended('refresh_institutions_current', 0) # iid::bigint) AS lk
+                  FROM unnest(%(ids)s::bigint[]) AS iid
+                 ORDER BY lk
+              ) AS ordered_locks
+            """,
+            {"ids": ids},
+        )
+        cur.execute(
+            """
+            SELECT instrument_id, MAX(ingested_at)
+              FROM ownership_institutions_observations
+             WHERE instrument_id = ANY(%(ids)s::bigint[])
+             GROUP BY instrument_id
+            """,
+            {"ids": ids},
+        )
+        watermarks: dict[int, datetime | None] = {int(r[0]): r[1] for r in cur.fetchall()}
+        cur.execute(
+            """
+            MERGE INTO ownership_institutions_current AS tgt
+            USING (
+                SELECT DISTINCT ON (instrument_id, filer_cik, ownership_nature, exposure_kind)
+                    instrument_id, filer_cik, filer_name, filer_type, ownership_nature,
+                    source, source_document_id, source_accession, source_url,
+                    filed_at, period_start, period_end,
+                    shares, market_value_usd, voting_authority, exposure_kind
+                FROM ownership_institutions_observations
+                WHERE instrument_id = ANY(%(ids)s::bigint[]) AND known_to IS NULL
+                ORDER BY
+                    instrument_id,
+                    filer_cik,
+                    ownership_nature,
+                    exposure_kind,
+                    period_end DESC,
+                    filed_at DESC,
+                    source_document_id ASC
+            ) AS src
+            ON tgt.instrument_id = src.instrument_id
+               AND tgt.filer_cik = src.filer_cik
+               AND tgt.ownership_nature = src.ownership_nature
+               AND tgt.exposure_kind = src.exposure_kind
+            WHEN MATCHED AND (
+                tgt.filer_name, tgt.filer_type,
+                tgt.source, tgt.source_document_id, tgt.source_accession, tgt.source_url,
+                tgt.filed_at, tgt.period_start, tgt.period_end,
+                tgt.shares, tgt.market_value_usd, tgt.voting_authority
+            ) IS DISTINCT FROM (
+                src.filer_name, src.filer_type,
+                src.source, src.source_document_id, src.source_accession, src.source_url,
+                src.filed_at, src.period_start, src.period_end,
+                src.shares, src.market_value_usd, src.voting_authority
+            ) THEN UPDATE SET
+                filer_name         = src.filer_name,
+                filer_type         = src.filer_type,
+                source             = src.source,
+                source_document_id = src.source_document_id,
+                source_accession   = src.source_accession,
+                source_url         = src.source_url,
+                filed_at           = src.filed_at,
+                period_start       = src.period_start,
+                period_end         = src.period_end,
+                shares             = src.shares,
+                market_value_usd   = src.market_value_usd,
+                voting_authority   = src.voting_authority,
+                refreshed_at       = now()
+            WHEN NOT MATCHED BY TARGET THEN INSERT (
+                instrument_id, filer_cik, filer_name, filer_type, ownership_nature,
+                source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, market_value_usd, voting_authority, exposure_kind
+            ) VALUES (
+                src.instrument_id, src.filer_cik, src.filer_name, src.filer_type, src.ownership_nature,
+                src.source, src.source_document_id, src.source_accession, src.source_url,
+                src.filed_at, src.period_start, src.period_end,
+                src.shares, src.market_value_usd, src.voting_authority, src.exposure_kind
+            )
+            WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = ANY(%(ids)s::bigint[]) THEN DELETE
+            """,
+            {"ids": ids},
+        )
+        rows = [(iid, watermarks.get(iid)) for iid in ids]
+        cur.executemany(
+            """
+            INSERT INTO ownership_refresh_state (
+                instrument_id, category,
+                last_drained_observations_max_ingested_at, last_refresh_attempted_at
+            ) VALUES (%s, 'institutions', %s, now())
+            ON CONFLICT (instrument_id, category) DO UPDATE SET
+                last_drained_observations_max_ingested_at = EXCLUDED.last_drained_observations_max_ingested_at,
+                last_refresh_attempted_at = EXCLUDED.last_refresh_attempted_at
+            """,
+            rows,
+        )
+    return len(ids)
+
+
+def refresh_funds_current_batch(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_ids: Iterable[int],
+) -> int:
+    """Batched form of :func:`refresh_funds_current`.
+
+    See :func:`refresh_insiders_current_batch` for the design contract."""
+    ids = _normalise_instrument_ids(instrument_ids)
+    if not ids:
+        return 0
+    with conn.transaction(), conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT pg_advisory_xact_lock(lk)
+              FROM (
+                SELECT (hashtextextended('refresh_funds_current', 0) # iid::bigint) AS lk
+                  FROM unnest(%(ids)s::bigint[]) AS iid
+                 ORDER BY lk
+              ) AS ordered_locks
+            """,
+            {"ids": ids},
+        )
+        cur.execute(
+            """
+            SELECT instrument_id, MAX(ingested_at)
+              FROM ownership_funds_observations
+             WHERE instrument_id = ANY(%(ids)s::bigint[])
+             GROUP BY instrument_id
+            """,
+            {"ids": ids},
+        )
+        watermarks: dict[int, datetime | None] = {int(r[0]): r[1] for r in cur.fetchall()}
+        cur.execute(
+            """
+            MERGE INTO ownership_funds_current AS tgt
+            USING (
+                SELECT DISTINCT ON (instrument_id, fund_series_id)
+                    instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                    ownership_nature,
+                    source, source_document_id, source_accession, source_url,
+                    filed_at, period_start, period_end,
+                    shares, market_value_usd, payoff_profile, asset_category
+                FROM ownership_funds_observations
+                WHERE instrument_id = ANY(%(ids)s::bigint[]) AND known_to IS NULL
+                ORDER BY
+                    instrument_id,
+                    fund_series_id,
+                    filed_at DESC,
+                    period_end DESC,
+                    source_document_id ASC
+            ) AS src
+            ON tgt.instrument_id = src.instrument_id
+               AND tgt.fund_series_id = src.fund_series_id
+            WHEN MATCHED AND (
+                tgt.fund_series_name, tgt.fund_filer_cik, tgt.ownership_nature,
+                tgt.source, tgt.source_document_id, tgt.source_accession, tgt.source_url,
+                tgt.filed_at, tgt.period_start, tgt.period_end,
+                tgt.shares, tgt.market_value_usd, tgt.payoff_profile, tgt.asset_category
+            ) IS DISTINCT FROM (
+                src.fund_series_name, src.fund_filer_cik, src.ownership_nature,
+                src.source, src.source_document_id, src.source_accession, src.source_url,
+                src.filed_at, src.period_start, src.period_end,
+                src.shares, src.market_value_usd, src.payoff_profile, src.asset_category
+            ) THEN UPDATE SET
+                fund_series_name   = src.fund_series_name,
+                fund_filer_cik     = src.fund_filer_cik,
+                ownership_nature   = src.ownership_nature,
+                source             = src.source,
+                source_document_id = src.source_document_id,
+                source_accession   = src.source_accession,
+                source_url         = src.source_url,
+                filed_at           = src.filed_at,
+                period_start       = src.period_start,
+                period_end         = src.period_end,
+                shares             = src.shares,
+                market_value_usd   = src.market_value_usd,
+                payoff_profile     = src.payoff_profile,
+                asset_category     = src.asset_category,
+                refreshed_at       = now()
+            WHEN NOT MATCHED BY TARGET THEN INSERT (
+                instrument_id, fund_series_id, fund_series_name, fund_filer_cik,
+                ownership_nature, source, source_document_id, source_accession, source_url,
+                filed_at, period_start, period_end,
+                shares, market_value_usd, payoff_profile, asset_category
+            ) VALUES (
+                src.instrument_id, src.fund_series_id, src.fund_series_name, src.fund_filer_cik,
+                src.ownership_nature, src.source, src.source_document_id, src.source_accession, src.source_url,
+                src.filed_at, src.period_start, src.period_end,
+                src.shares, src.market_value_usd, src.payoff_profile, src.asset_category
+            )
+            WHEN NOT MATCHED BY SOURCE AND tgt.instrument_id = ANY(%(ids)s::bigint[]) THEN DELETE
+            """,
+            {"ids": ids},
+        )
+        rows = [(iid, watermarks.get(iid)) for iid in ids]
+        cur.executemany(
+            """
+            INSERT INTO ownership_refresh_state (
+                instrument_id, category,
+                last_drained_observations_max_ingested_at, last_refresh_attempted_at
+            ) VALUES (%s, 'funds', %s, now())
+            ON CONFLICT (instrument_id, category) DO UPDATE SET
+                last_drained_observations_max_ingested_at = EXCLUDED.last_drained_observations_max_ingested_at,
+                last_refresh_attempted_at = EXCLUDED.last_refresh_attempted_at
+            """,
+            rows,
+        )
+    return len(ids)

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -45,6 +45,21 @@ JOB_SEC_INSIDER_INGEST_FROM_DATASET: Final[str] = "sec_insider_ingest_from_datas
 JOB_SEC_NPORT_INGEST_FROM_DATASET: Final[str] = "sec_nport_ingest_from_dataset"
 
 
+# Post-ingest batched _current refresh chunk size (PR-4 spec §8).
+#
+# Each post-ingest job (13F / insider / NPORT) calls the matching
+# ``refresh_<category>_current_batch`` helper in chunks so the
+# cancel-poll cadence remains interactive. The single-instrument loop
+# polled every 50 ids; the batch path round-trips ONE MERGE per chunk,
+# so cancel observation latency degrades from ~50 instruments to
+# ~_REFRESH_BATCH_CHUNK_SIZE instruments. 200 is the documented
+# trade-off — large enough to dominate the per-batch fixed cost
+# (server-side hash-sort + lock acquire), small enough that an
+# operator cancel still lands within ~5 s of the next chunk boundary
+# even on a slow disk.
+_REFRESH_BATCH_CHUNK_SIZE: Final[int] = 200
+
+
 def _bulk_dir() -> Path:
     return resolve_data_dir() / "sec" / "bulk"
 
@@ -403,35 +418,47 @@ def sec_13f_ingest_from_dataset_job() -> None:
                 stage_key=active_bootstrap_stage_key() or "",
             )
 
-        from app.services.ownership_observations import refresh_institutions_current
+        from app.services.ownership_observations import refresh_institutions_current_batch
 
         refresh_failures: list[str] = []
+        sorted_ids = sorted(touched_ids)
         with psycopg.connect(settings.database_url) as conn:
-            for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
-                if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
-                    # #1114: stage_key sourced from contextvar.
+            # Chunk batched refresh so cancel observation stays interactive.
+            # Single-instrument loop polled every 50 ids; batched call
+            # round-trips one MERGE per CHUNK_SIZE ids, so we poll between
+            # chunks instead. Documented trade-off: cancel latency degrades
+            # from ~50 instruments to ~200 instruments. PR-4 spec §8.
+            for chunk_start in range(0, len(sorted_ids), _REFRESH_BATCH_CHUNK_SIZE):
+                if bootstrap_cancel_requested():
                     raise BootstrapStageCancelled(
                         f"sec_13f_ingest_from_dataset cancelled by operator after "
-                        f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
+                        f"refreshing {chunk_start}/{len(sorted_ids)} instruments",
                         stage_key=active_bootstrap_stage_key() or "",
                     )
-                # Per-iteration savepoint — refresh_institutions_current
-                # owns its own ``with conn.transaction()`` (sql/.py:404),
-                # so this is defence-in-depth against a future refactor
-                # of the helper that drops its internal txn wrap. PR
-                # review BLOCKING for #1047.
+                chunk = sorted_ids[chunk_start : chunk_start + _REFRESH_BATCH_CHUNK_SIZE]
+                # Per-chunk savepoint — refresh_institutions_current_batch
+                # owns its own ``with conn.transaction()``; this is
+                # defence-in-depth so one bad chunk does not abort the
+                # ambient connection's prior chunk commits. Mirrors the
+                # single-instrument loop's defence per PR #1047.
                 try:
                     with conn.transaction():
-                        refresh_institutions_current(conn, instrument_id=instrument_id)
+                        refresh_institutions_current_batch(conn, instrument_ids=chunk)
                 except Exception as exc:  # noqa: BLE001
                     logger.exception(
-                        "sec_13f_ingest_from_dataset: refresh_institutions_current failed for instrument=%d",
-                        instrument_id,
+                        "sec_13f_ingest_from_dataset: refresh_institutions_current_batch failed for "
+                        "chunk start=%d size=%d",
+                        chunk_start,
+                        len(chunk),
                     )
-                    refresh_failures.append(f"instrument={instrument_id}: {exc}")
+                    # Surface the first 5 instrument_ids in the chunk so
+                    # operator-visible error still names concrete ids.
+                    refresh_failures.append(
+                        f"chunk start={chunk_start} ids={chunk[:5]}{'...' if len(chunk) > 5 else ''}: {exc}"
+                    )
         if refresh_failures:
             raise RuntimeError(
-                f"sec_13f_ingest_from_dataset: {len(refresh_failures)}/{len(touched_ids)} "
+                f"sec_13f_ingest_from_dataset: {len(refresh_failures)} chunk(s) of {len(sorted_ids)} "
                 f"_current refreshes failed; archives retained for retry: " + "; ".join(refresh_failures[:5])
             )
         logger.info(
@@ -562,30 +589,37 @@ def sec_insider_ingest_from_dataset_job() -> None:
                 stage_key=active_bootstrap_stage_key() or "",
             )
 
-        from app.services.ownership_observations import refresh_insiders_current
+        from app.services.ownership_observations import refresh_insiders_current_batch
 
         refresh_failures: list[str] = []
+        sorted_ids = sorted(touched_ids)
         with psycopg.connect(settings.database_url) as conn:
-            for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
-                if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
-                    # #1114: stage_key sourced from contextvar.
+            # See sec_13f_ingest_from_dataset_job for the chunked-batch
+            # cancel-poll rationale (PR-4 spec §8).
+            for chunk_start in range(0, len(sorted_ids), _REFRESH_BATCH_CHUNK_SIZE):
+                if bootstrap_cancel_requested():
                     raise BootstrapStageCancelled(
                         f"sec_insider_ingest_from_dataset cancelled by operator after "
-                        f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
+                        f"refreshing {chunk_start}/{len(sorted_ids)} instruments",
                         stage_key=active_bootstrap_stage_key() or "",
                     )
+                chunk = sorted_ids[chunk_start : chunk_start + _REFRESH_BATCH_CHUNK_SIZE]
                 try:
                     with conn.transaction():
-                        refresh_insiders_current(conn, instrument_id=instrument_id)
+                        refresh_insiders_current_batch(conn, instrument_ids=chunk)
                 except Exception as exc:  # noqa: BLE001
                     logger.exception(
-                        "sec_insider_ingest_from_dataset: refresh_insiders_current failed for instrument=%d",
-                        instrument_id,
+                        "sec_insider_ingest_from_dataset: refresh_insiders_current_batch failed for "
+                        "chunk start=%d size=%d",
+                        chunk_start,
+                        len(chunk),
                     )
-                    refresh_failures.append(f"instrument={instrument_id}: {exc}")
+                    refresh_failures.append(
+                        f"chunk start={chunk_start} ids={chunk[:5]}{'...' if len(chunk) > 5 else ''}: {exc}"
+                    )
         if refresh_failures:
             raise RuntimeError(
-                f"sec_insider_ingest_from_dataset: {len(refresh_failures)}/{len(touched_ids)} "
+                f"sec_insider_ingest_from_dataset: {len(refresh_failures)} chunk(s) of {len(sorted_ids)} "
                 f"_current refreshes failed; archives retained for retry: " + "; ".join(refresh_failures[:5])
             )
         logger.info(
@@ -744,30 +778,36 @@ def sec_nport_ingest_from_dataset_job() -> None:
                 stage_key=active_bootstrap_stage_key() or "",
             )
 
-        from app.services.ownership_observations import refresh_funds_current
+        from app.services.ownership_observations import refresh_funds_current_batch
 
         refresh_failures: list[str] = []
+        sorted_ids = sorted(touched_ids)
         with psycopg.connect(settings.database_url) as conn:
-            for refresh_idx, instrument_id in enumerate(sorted(touched_ids)):
-                if refresh_idx % 50 == 0 and bootstrap_cancel_requested():
-                    # #1114: stage_key sourced from contextvar.
+            # See sec_13f_ingest_from_dataset_job for the chunked-batch
+            # cancel-poll rationale (PR-4 spec §8).
+            for chunk_start in range(0, len(sorted_ids), _REFRESH_BATCH_CHUNK_SIZE):
+                if bootstrap_cancel_requested():
                     raise BootstrapStageCancelled(
                         f"sec_nport_ingest_from_dataset cancelled by operator after "
-                        f"refreshing {refresh_idx}/{len(touched_ids)} instruments",
+                        f"refreshing {chunk_start}/{len(sorted_ids)} instruments",
                         stage_key=active_bootstrap_stage_key() or "",
                     )
+                chunk = sorted_ids[chunk_start : chunk_start + _REFRESH_BATCH_CHUNK_SIZE]
                 try:
                     with conn.transaction():
-                        refresh_funds_current(conn, instrument_id=instrument_id)
+                        refresh_funds_current_batch(conn, instrument_ids=chunk)
                 except Exception as exc:  # noqa: BLE001
                     logger.exception(
-                        "sec_nport_ingest_from_dataset: refresh_funds_current failed for instrument=%d",
-                        instrument_id,
+                        "sec_nport_ingest_from_dataset: refresh_funds_current_batch failed for chunk start=%d size=%d",
+                        chunk_start,
+                        len(chunk),
                     )
-                    refresh_failures.append(f"instrument={instrument_id}: {exc}")
+                    refresh_failures.append(
+                        f"chunk start={chunk_start} ids={chunk[:5]}{'...' if len(chunk) > 5 else ''}: {exc}"
+                    )
         if refresh_failures:
             raise RuntimeError(
-                f"sec_nport_ingest_from_dataset: {len(refresh_failures)}/{len(touched_ids)} "
+                f"sec_nport_ingest_from_dataset: {len(refresh_failures)} chunk(s) of {len(sorted_ids)} "
                 f"_current refreshes failed; archives retained for retry: " + "; ".join(refresh_failures[:5])
             )
         logger.info(

--- a/tests/test_ownership_observations_refresh_batch.py
+++ b/tests/test_ownership_observations_refresh_batch.py
@@ -1,0 +1,475 @@
+"""PR-4 batched ``refresh_*_current_batch`` contract tests (#1233).
+
+Spec: docs/superpowers/specs/2026-05-22-bootstrap-etl-optimisation-v2.md §8.
+
+Six pinned cases per batched helper:
+
+1. **Equivalence** — ``refresh_X_current_batch([a, b, c])`` produces the
+   same ``_current`` row set as
+   ``refresh_X_current(a) + refresh_X_current(b) + refresh_X_current(c)``.
+   Verified by snapshot diff + per-row checksum.
+2. **Empty input** — ``refresh_X_current_batch([])`` is a no-op
+   (returns 0; no SQL is dispatched against the MERGE target).
+3. **Idempotency** — re-running the same batch twice leaves
+   ``_current`` row count + ``refreshed_at`` unchanged (the diff-aware
+   MERGE writer is no-op on identical input — PR12 invariant).
+4. **NOT MATCHED BY SOURCE scope clamp** — running the batch against
+   only one of two seeded instruments DOES NOT delete the unseeded
+   instrument's rows.
+5. **Deadlock safety** — two threads call the same helper with
+   overlapping but un-sorted instrument sets. Neither deadlocks
+   (hash-key-ordered lock acquire is the invariant).
+6. **Watermark UPSERT** — each batched call writes one row per
+   instrument into ``ownership_refresh_state`` with the matching
+   category, mirroring the single-instrument helper.
+
+Three batched helpers covered (insiders / institutions / funds —
+matches the PR-4 scope; the other 4 categories keep the single-
+instrument path because nothing in the bulk orchestrator loops over
+them at scale).
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from app.services import ownership_observations as oo
+from tests.fixtures.ebull_test_db import test_database_url
+
+
+@dataclass(frozen=True)
+class BatchHelperCase:
+    name: str
+    single_fn: Callable[[psycopg.Connection[Any], int], int]
+    batch_fn: Callable[[psycopg.Connection[Any], list[int]], int]
+    current_table: str
+    observations_table: str
+    category_literal: str
+
+
+BATCH_HELPERS: list[BatchHelperCase] = [
+    BatchHelperCase(
+        "insiders",
+        lambda c, i: oo.refresh_insiders_current(c, instrument_id=i),
+        lambda c, ids: oo.refresh_insiders_current_batch(c, instrument_ids=ids),
+        "ownership_insiders_current",
+        "ownership_insiders_observations",
+        "insiders",
+    ),
+    BatchHelperCase(
+        "institutions",
+        lambda c, i: oo.refresh_institutions_current(c, instrument_id=i),
+        lambda c, ids: oo.refresh_institutions_current_batch(c, instrument_ids=ids),
+        "ownership_institutions_current",
+        "ownership_institutions_observations",
+        "institutions",
+    ),
+    BatchHelperCase(
+        "funds",
+        lambda c, i: oo.refresh_funds_current(c, instrument_id=i),
+        lambda c, ids: oo.refresh_funds_current_batch(c, instrument_ids=ids),
+        "ownership_funds_current",
+        "ownership_funds_observations",
+        "funds",
+    ),
+]
+
+
+@pytest.fixture
+def conn(ebull_test_conn):
+    return ebull_test_conn
+
+
+def _insert_instruments(conn, ids: list[int]) -> None:
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+            [(i, f"PR4-{i}", f"PR4 Test Co {i}") for i in ids],
+        )
+    conn.commit()
+
+
+def _seed_one(conn, helper: BatchHelperCase, instrument_id: int, *, idx: int = 0) -> None:
+    """Insert one observation appropriate to the helper's natural key.
+
+    Mirrors the seed helper in ``test_ownership_refresh_writer_merge.py``
+    but narrowed to the three categories PR-4 batches.
+    """
+    run_id = uuid4()
+    doc_id = f"PR4-{helper.name}-{instrument_id}-{idx}"
+    filed = datetime(2025, 1, 1 + idx, tzinfo=UTC)
+    period_end = date(2024, 12, 31)
+    if helper.name == "insiders":
+        oo.record_insider_observation(
+            conn,
+            instrument_id=instrument_id,
+            holder_cik=f"{instrument_id:010d}",
+            holder_name="Test Holder",
+            ownership_nature="direct",
+            source="form4",
+            source_document_id=doc_id,
+            source_accession=None,
+            source_field=None,
+            source_url=None,
+            filed_at=filed,
+            period_start=None,
+            period_end=period_end,
+            ingest_run_id=run_id,
+            shares=Decimal("100"),
+        )
+    elif helper.name == "institutions":
+        oo.record_institution_observation(
+            conn,
+            instrument_id=instrument_id,
+            filer_cik=f"{instrument_id:010d}",
+            filer_name="Test Filer",
+            filer_type="ETF",
+            ownership_nature="economic",
+            source="13f",
+            source_document_id=doc_id,
+            source_accession=None,
+            source_field=None,
+            source_url=None,
+            filed_at=filed,
+            period_start=None,
+            period_end=period_end,
+            ingest_run_id=run_id,
+            shares=Decimal("1000"),
+            market_value_usd=Decimal("50000"),
+            voting_authority="SOLE",
+            exposure_kind="EQUITY",
+        )
+    elif helper.name == "funds":
+        # Fund_series_id stable per instrument so multiple seeds on the
+        # same instrument SHARE a (instrument_id, fund_series_id) natural
+        # key. That forces the DISTINCT ON / ORDER BY winner-selection
+        # path in the MERGE writer to actually pick between observations
+        # — without this the per-idx seeds would all land on distinct
+        # natural keys and DISTINCT ON would be a no-op (Codex 2 LOW-1).
+        series_seq = 1000 + instrument_id * 10
+        # source_document_id MUST differ per idx so the observations
+        # writer's ON CONFLICT idempotency key (… , source_document_id, …)
+        # does not collapse the seeds into one row before DISTINCT ON
+        # ever sees them.
+        oo.record_fund_observation(
+            conn,
+            instrument_id=instrument_id,
+            fund_series_id=f"S{series_seq:09d}",
+            fund_series_name=f"Test Fund {instrument_id}-{idx}",
+            fund_filer_cik=f"{instrument_id:010d}",
+            source_document_id=doc_id,
+            source_accession=None,
+            source_field=None,
+            source_url=None,
+            filed_at=filed,
+            period_start=None,
+            period_end=period_end,
+            ingest_run_id=run_id,
+            shares=Decimal("500"),
+            market_value_usd=Decimal("25000"),
+            payoff_profile="Long",
+            asset_category="EC",
+        )
+    else:
+        pytest.fail(f"unknown helper: {helper.name}")
+    conn.commit()
+
+
+def _snapshot_current(conn, table: str, instrument_ids: list[int]) -> list[tuple]:
+    """Return the full ``_current`` row set for the given instruments,
+    deterministically ordered. ``refreshed_at`` excluded so that
+    re-running the helper twice (different now()) does not flip the
+    equivalence assertion."""
+    with conn.cursor() as cur:
+        cur.execute(
+            # row_to_json then strip the volatile columns. PG's ::jsonb -
+            # operator removes keys client-side without enumerating every
+            # column the helper might add later.
+            f"""
+            SELECT instrument_id,
+                   (to_jsonb(t.*) - 'refreshed_at')::text
+              FROM {table} AS t
+             WHERE instrument_id = ANY(%s::bigint[])
+             ORDER BY instrument_id, to_jsonb(t.*)::text
+            """,
+            (instrument_ids,),
+        )
+        return list(cur.fetchall())
+
+
+def _watermark_count(conn, instrument_ids: list[int], category: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM ownership_refresh_state WHERE category = %s AND instrument_id = ANY(%s::bigint[])",
+            (category, instrument_ids),
+        )
+        row = cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+# ----------------------------------------------------------------------
+# Case 1: equivalence vs serial loop
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("helper", BATCH_HELPERS, ids=lambda h: h.name)
+def test_batch_equivalent_to_serial_loop(conn, helper):
+    """``refresh_X_current_batch([a, b, c])`` produces the same row set
+    as the per-instrument serial loop. Verified by snapshot diff."""
+    ids = [1, 2, 3]
+    _insert_instruments(conn, ids)
+    for iid in ids:
+        # Two observations per instrument so the DISTINCT ON / ORDER BY
+        # logic actually picks the winning row instead of trivially
+        # taking the only row.
+        _seed_one(conn, helper, iid, idx=0)
+        _seed_one(conn, helper, iid, idx=1)
+
+    # Serial path — snapshot it, then wipe _current + refresh_state
+    # so we can re-run via the batched path and compare.
+    for iid in ids:
+        helper.single_fn(conn, iid)
+    conn.commit()
+    serial_snapshot = _snapshot_current(conn, helper.current_table, ids)
+
+    # Reset both _current and the refresh_state side-table so the
+    # batched path runs from a clean slate.
+    with conn.cursor() as cur:
+        cur.execute(
+            f"DELETE FROM {helper.current_table} WHERE instrument_id = ANY(%s::bigint[])",
+            (ids,),
+        )
+        cur.execute(
+            "DELETE FROM ownership_refresh_state WHERE category = %s AND instrument_id = ANY(%s::bigint[])",
+            (helper.category_literal, ids),
+        )
+    conn.commit()
+
+    helper.batch_fn(conn, ids)
+    conn.commit()
+    batch_snapshot = _snapshot_current(conn, helper.current_table, ids)
+
+    assert batch_snapshot == serial_snapshot, (
+        f"batch and serial paths diverged for helper={helper.name}: serial={serial_snapshot!r} batch={batch_snapshot!r}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Case 2: empty input
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("helper", BATCH_HELPERS, ids=lambda h: h.name)
+def test_batch_empty_input_is_noop(conn, helper):
+    """An empty ``instrument_ids`` returns 0 without raising and
+    without writing any row into either ``_current`` or
+    ``ownership_refresh_state``."""
+    pre_state_count = _watermark_count(conn, [], helper.category_literal)
+    result = helper.batch_fn(conn, [])
+    conn.commit()
+    assert result == 0
+    post_state_count = _watermark_count(conn, [], helper.category_literal)
+    assert pre_state_count == post_state_count
+
+
+# ----------------------------------------------------------------------
+# Case 3: idempotency
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("helper", BATCH_HELPERS, ids=lambda h: h.name)
+def test_batch_idempotent_on_re_run(conn, helper):
+    """Re-running the same batch leaves ``_current`` rows + xmin
+    unchanged (PR12 IS DISTINCT FROM diff predicate — no-op on
+    identical input). Watermark table sees its ``last_refresh_attempted_at``
+    advance but row count stays at len(ids)."""
+    ids = [1, 2]
+    _insert_instruments(conn, ids)
+    for iid in ids:
+        _seed_one(conn, helper, iid, idx=0)
+    helper.batch_fn(conn, ids)
+    conn.commit()
+
+    pre_snapshot = _snapshot_current(conn, helper.current_table, ids)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT instrument_id, xmin::text FROM {helper.current_table} "
+            "WHERE instrument_id = ANY(%s::bigint[]) ORDER BY instrument_id, xmin::text",
+            (ids,),
+        )
+        pre_xmin = cur.fetchall()
+    pre_watermark_count = _watermark_count(conn, ids, helper.category_literal)
+
+    helper.batch_fn(conn, ids)
+    conn.commit()
+
+    post_snapshot = _snapshot_current(conn, helper.current_table, ids)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT instrument_id, xmin::text FROM {helper.current_table} "
+            "WHERE instrument_id = ANY(%s::bigint[]) ORDER BY instrument_id, xmin::text",
+            (ids,),
+        )
+        post_xmin = cur.fetchall()
+    post_watermark_count = _watermark_count(conn, ids, helper.category_literal)
+
+    assert pre_snapshot == post_snapshot, "no-op re-run must not mutate _current rows"
+    assert pre_xmin == post_xmin, "no-op re-run must leave xmin stable (diff predicate skipped UPDATE)"
+    assert pre_watermark_count == post_watermark_count == len(ids)
+
+
+# ----------------------------------------------------------------------
+# Case 4: NOT MATCHED BY SOURCE scope clamp
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("helper", BATCH_HELPERS, ids=lambda h: h.name)
+def test_batch_not_matched_by_source_scope_clamped(conn, helper):
+    """Refreshing instrument A only must NOT delete instrument B's
+    rows even though B has stale ``_current`` rows. The
+    ``tgt.instrument_id = ANY(%(ids)s)`` clamp in the DELETE clause is
+    the load-bearing invariant."""
+    ids = [1, 2]
+    _insert_instruments(conn, ids)
+    for iid in ids:
+        _seed_one(conn, helper, iid, idx=0)
+    helper.batch_fn(conn, ids)
+    conn.commit()
+
+    # B's _current row must still exist after a refresh that names
+    # only A in the batch.
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {helper.current_table} WHERE instrument_id = %s",
+            (2,),
+        )
+        pre_b = int(cur.fetchone()[0])
+    assert pre_b >= 1
+
+    helper.batch_fn(conn, [1])
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {helper.current_table} WHERE instrument_id = %s",
+            (2,),
+        )
+        post_b = int(cur.fetchone()[0])
+    assert post_b == pre_b, (
+        "batch refresh of instrument A leaked into instrument B's _current rows — DELETE clause scope clamp violated"
+    )
+
+
+# ----------------------------------------------------------------------
+# Case 5: deadlock safety under concurrent batches
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("helper", BATCH_HELPERS, ids=lambda h: h.name)
+def test_batch_deadlock_safe_under_concurrent_overlap(conn, helper):
+    """Two threads call the batched helper with overlapping instrument
+    sets. Neither deadlocks because the SQL-side ``ORDER BY lk`` in the
+    lock-acquire query forces a deterministic hash-key sort across
+    callers — regardless of the order the caller passed in.
+
+    Codex 2 LOW-2 caveat: ``_normalise_instrument_ids`` already sorts
+    by int before the SQL runs, so the differing Python input orders
+    below are equivalent inputs to the SQL. The actual deadlock
+    safety claim is that the SQL acquires locks ordered by HASHED key
+    (not raw int) and therefore matches across callers even though
+    int-order and hash-order disagree for arbitrary ids. This test
+    asserts the integrative behaviour: two parallel overlapping
+    batches complete without PG raising ``DeadlockDetected`` (which
+    fires after ``deadlock_timeout`` = 1s by default). If we ever
+    regress to a Python-side or non-hash-ordered lock acquire, the
+    PG-level deadlock would surface here even though the Python
+    ordering looks fine.
+
+    Each thread opens its own connection (per-worker test DB derived
+    from ``test_database_url()``); the driver connection only seeds
+    the data.
+    """
+    ids = [1, 2, 3, 4, 5]
+    _insert_instruments(conn, ids)
+    for iid in ids:
+        _seed_one(conn, helper, iid, idx=0)
+    conn.commit()
+
+    url = test_database_url()
+
+    # Differing Python input orders. After _normalise_instrument_ids
+    # both threads issue SQL against the same sorted list; the SQL
+    # ORDER BY lk inside that statement is what prevents deadlocks.
+    thread_a_ids = [1, 2, 3, 4, 5]
+    thread_b_ids = [5, 4, 3, 2, 1]
+
+    errors: list[BaseException] = []
+
+    def _worker(target_ids: list[int]) -> None:
+        try:
+            with psycopg.connect(url) as worker_conn:
+                # PG default deadlock_timeout is 1s; if a real deadlock
+                # exists, the worker will receive a DeadlockDetected
+                # error within ~1s.
+                helper.batch_fn(worker_conn, target_ids)
+                worker_conn.commit()
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    ta = threading.Thread(target=_worker, args=(thread_a_ids,))
+    tb = threading.Thread(target=_worker, args=(thread_b_ids,))
+    ta.start()
+    tb.start()
+    # 30 s join is generous — a real deadlock surfaces in ~1 s.
+    ta.join(timeout=30)
+    tb.join(timeout=30)
+
+    assert not ta.is_alive() and not tb.is_alive(), (
+        "one or both worker threads still alive after 30s — likely deadlocked"
+    )
+    assert not errors, f"unexpected worker errors: {errors!r}"
+
+
+# ----------------------------------------------------------------------
+# Case 6: watermark UPSERT contract
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("helper", BATCH_HELPERS, ids=lambda h: h.name)
+def test_batch_writes_one_watermark_per_instrument(conn, helper):
+    """Each instrument in the batch produces exactly one
+    ``ownership_refresh_state`` row with the matching category. The
+    UPSERT path mirrors the single-instrument helper's INSERT … ON
+    CONFLICT shape."""
+    ids = [1, 2, 3]
+    _insert_instruments(conn, ids)
+    for iid in ids:
+        _seed_one(conn, helper, iid, idx=0)
+    helper.batch_fn(conn, ids)
+    conn.commit()
+
+    assert _watermark_count(conn, ids, helper.category_literal) == len(ids)
+
+    # Re-run does not duplicate rows — ON CONFLICT path.
+    helper.batch_fn(conn, ids)
+    conn.commit()
+    assert _watermark_count(conn, ids, helper.category_literal) == len(ids)
+
+
+# ----------------------------------------------------------------------
+# Case 7: duplicate / unsorted input normalised internally
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("helper", BATCH_HELPERS, ids=lambda h: h.name)
+def test_batch_normalises_duplicate_and_unsorted_input(conn, helper):
+    """Caller passing ``[3, 1, 2, 1, 3]`` MUST behave the same as
+    ``[1, 2, 3]`` — the helper de-dupes and sorts internally so a
+    misbehaving caller cannot inflate lock-acquire count or feed
+    duplicate src rows into the MERGE."""
+    ids = [1, 2, 3]
+    _insert_instruments(conn, ids)
+    for iid in ids:
+        _seed_one(conn, helper, iid, idx=0)
+
+    result = helper.batch_fn(conn, [3, 1, 2, 1, 3])
+    conn.commit()
+    # _normalise_instrument_ids returns a sorted, de-duplicated list
+    # of length 3. The helper returns that length.
+    assert result == 3
+    assert _watermark_count(conn, ids, helper.category_literal) == 3


### PR DESCRIPTION
## Summary

Replaces three serial post-ingest refresh loops in `sec_bulk_orchestrator_jobs.py` with batched MERGE writers. Saves 5–10 min wall-clock per category at peak (~10k touched instruments).

- New batched helpers in `app/services/ownership_observations.py` (`refresh_{insiders,institutions,funds}_current_batch`).
- Replaces serial loops at `sec_bulk_orchestrator_jobs.py:410-431` (13F), `:569-585` (insider), `:751-767` (NPORT).
- Deadlock-safe advisory lock acquire (server-side `ORDER BY lk` over hashed lock keys, NOT raw instrument_id).
- Chunked cancel-poll: now every `_REFRESH_BATCH_CHUNK_SIZE=200` instruments (was every 50 in the serial loop) — documented trade-off in spec §8.
- 21 batch tests (7 cases × 3 helpers) including equivalence vs serial loop, idempotency, concurrent deadlock safety, NOT MATCHED BY SOURCE scope clamp.

## Why

After bulk ingest commits per-archive, the post-loop `for iid in sorted(touched_ids): refresh_X_current(conn, iid)` cost one PG round-trip + advisory lock + MERGE per instrument. At ~10k touched instruments × ~70-400 ms each on dev DB = 5–10 min serial wall-clock after every 13F / insider / NPORT bulk run. Batching collapses to one of each per chunk.

## Architecture

| Aspect | Single-instrument helper (preserved) | Batched helper (new) |
| --- | --- | --- |
| Lock | `pg_advisory_xact_lock(hash # iid)` × 1 | `SELECT pg_advisory_xact_lock(lk) FROM (... ORDER BY lk)` × 1 query, N rows |
| USING WHERE | `instrument_id = %(iid)s` | `instrument_id = ANY(%(ids)s::bigint[])` |
| DISTINCT ON | `(per_helper_key)` | `(instrument_id, per_helper_key)` — instrument_id lead |
| ORDER BY | `(per_helper_key, …)` | `(instrument_id, per_helper_key, …)` |
| ON clause | `tgt.instrument_id = %(iid)s AND …` | `tgt.instrument_id = src.instrument_id AND …` |
| NOT MATCHED BY SOURCE | `AND tgt.instrument_id = %(iid)s` | `AND tgt.instrument_id = ANY(%(ids)s::bigint[])` |
| State UPSERT | one INSERT | `executemany` over `[(iid, watermark), …]` |

The seven single-instrument helpers stay verbatim — they are still the per-row path for write-through inside `record_*_observation()` and the repair sweep. Only the three categories the bulk orchestrator hot-loops over (insiders / institutions / funds) get a batched form. The PR12 lint at `scripts/check_ownership_refresh_writer_pattern.sh` (93 per-helper clauses) inherits unchanged — its body extraction terminates at the next column-0 `def`, so it pins the single-instrument writers and the batched MERGE shape is exercised by the new tests.

## Deadlock safety

PG `hashtextextended('refresh_X_current', 0) # iid::bigint` is not monotonic in `iid`. Two parallel callers passing the same instrument set in different raw-int orders would otherwise acquire locks in different orders → deadlock.

Solution: acquire ALL locks for the batch via one server-side query sorted by the hash key. SQL-side `ORDER BY lk` matches across callers regardless of Python input order. Tested via two-thread overlapping-set integration test (the test asserts no `DeadlockDetected` surfaces within `deadlock_timeout`=1s).

## Smoke

Dev DB, 50–100 instruments per category:
- insiders: serial 0.139s → batch 0.025s (**5.6×**)
- institutions: serial 20.804s → batch 3.547s (**5.9×**) — the hot 13F path
- funds: serial 8.076s → batch 1.296s (**6.2×**)

Smoke script kept under `/tmp/pr4_smoke_all.py` for reference.

## Acceptance per spec §8

- [x] All three batched helpers wrap the PR12 diff-aware MERGE writer.
- [x] Lock ordering deterministic across callers (server-side `ORDER BY lk`).
- [x] Idempotent re-run is a no-op (xmin stable, row count unchanged).
- [x] Empty input is a no-op.
- [x] NOT MATCHED BY SOURCE clamped to batch.
- [x] All gates pass: ruff check / ruff format check / pyright / pytest (21 new + 52 existing PR12 = 73 pass).
- [x] Codex 2 pre-push: no HIGH/MEDIUM findings; 2 LOW (funds DISTINCT ON exercise + deadlock test docstring) folded inline.
- [x] Measured ≥5× speedup on 100-instrument batch.

## Why no ETL clauses 8-12

This is a wall-clock optimisation of an existing write path. No schema change, no parser change, no new data shape. The diff-aware MERGE semantics are byte-identical to the single-instrument path (equivalence test pins this). `/instruments/{symbol}/ownership-rollup` is unaffected — it reads the same `_current` rows the helper writes, and those rows are identical to what the serial loop would have produced.

## Out of scope

- The other four categories (blockholders / treasury / def14a / esop) keep the single-instrument path only — nothing in the bulk orchestrator loops over them at scale, so the batched form would be code without a caller.
- Spec section header in v2 (`§8 PR-4`); the v3 spec referenced in the implementation kick-off doesn't exist yet and was not required for this PR.

## Test plan

- [x] `tests/test_ownership_observations_refresh_batch.py` — 21 cases pass.
- [x] `tests/test_ownership_refresh_writer_merge.py` — 52 PR12 cases pass (no regression).
- [x] `tests/test_ownership_observations.py` — 25 round-trip cases pass.
- [x] `scripts/check_ownership_refresh_writer_pattern.sh` — 93 invariants OK.
- [x] Dev DB smoke against 50-100 instruments per category — 5.6×–6.2× speedup observed.

Refs #1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)