### PR TITLE
feat(#1233): PR-5b ETag-keyed bulk-archive reuse + SD-2

### DIFF
--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -8,7 +8,7 @@
 - **Rate limit: 10 req/s per IP, regardless of machine count.** Source: <https://www.sec.gov/about/developer-resources>.
 - **User-Agent required.** Format `<Name> <email>`. Missing or generic UA = immediate 403.
 - **Bulk over per-filing whenever possible.** `submissions.zip` (~1.54 GB) and `companyfacts.zip` (~1.38 GB) rebuild nightly ~03:00 ET.
-- **Conditional fetch supported.** Many endpoints emit `Last-Modified` / `ETag`. Always send `If-Modified-Since`.
+- **Conditional fetch is asymmetric.** Many per-CIK / per-filing endpoints honour `If-Modified-Since` against `Last-Modified` (304 on no-change). **Bulk archives (`submissions.zip`, `companyfacts.zip`, etc.) DO NOT** — empirical probe 2026-05-22: SEC returns `200 + full body` regardless of `If-None-Match` / `If-Modified-Since`. Bulk reuse uses client-side HEAD ETag comparison instead (see "Bulk-archive reuse contract" in §4).
 - **Three-tier polling.** Hot (Atom getcurrent) / Warm (daily-index) / Cold (per-CIK submissions JSON).
 - **Identifiers, never names.** TSLA = `TESLA INC` in SEC, `Tesla, Inc.` in broker. Fuzzy-name match is forbidden — use CIK / CUSIP bridges.
 
@@ -424,13 +424,34 @@ Required format: `<Name> <email>`. Email must be syntactically valid and routabl
 
 1. **Bulk archives over per-filing scrapes.** `submissions.zip` + `companyfacts.zip` replace ~10k requests with 1.
 2. **`If-Modified-Since` against `Last-Modified`** for any per-CIK or per-filing endpoint. Server returns 304 (no body) for unchanged. Pattern at [app/providers/implementations/sec_edgar.py:497-529](../../../app/providers/implementations/sec_edgar.py#L497-L529).
-3. **`If-None-Match` against `ETag`** for archive files. Frankfurter pattern at [app/providers/implementations/frankfurter.py:98-144](../../../app/providers/implementations/frankfurter.py#L98-L144) is the cleanest in-repo template.
+3. **`If-None-Match` against `ETag`** — works for some non-SEC archives (Frankfurter pattern at [app/providers/implementations/frankfurter.py:98-144](../../../app/providers/implementations/frankfurter.py#L98-L144) is the cleanest in-repo template). **Does NOT work for SEC bulk archives** — empirical probe 2026-05-22 returned `200 + full body` even with the exact ETag echoed back. For SEC bulk files use the client-side HEAD-compare reuse contract in the "Bulk-archive reuse contract" subsection below.
 4. **Three-tier polling**:
    - **Hot**: Atom `getcurrent` for 8-K. Poll every 5–10 min during business hours.
    - **Warm**: `daily-index/master.{YYYYMMDD}.idx` early-morning batch.
    - **Cold**: per-CIK submissions JSON re-pull weekly or per-event.
 5. **Cache fetched bytes** in `raw_filings` table so re-wash is local. [app/services/raw_filings.py:11](../../../app/services/raw_filings.py#L11).
 6. **Backoff on 429 / 503**. Exponential, max 8 attempts. Many transient blocks clear within 60s.
+
+### Bulk-archive reuse contract (PR-5b, #1233)
+
+Settled decision: [docs/settled-decisions.md "Bulk archive reuse keyed on SEC ETag + SHA-256"](../../../docs/settled-decisions.md). Implementation: [app/services/sec_bulk_download.py `_preflight_etag_keyed_reuse`](../../../app/services/sec_bulk_download.py).
+
+Per archive, before deciding to download:
+
+1. **HEAD against SEC** with `User-Agent: settings.sec_user_agent` — capture the `ETag` header (empirical example for `submissions.zip`: `"504b124e9474334e889e9e525db95c14-184"`, stable S3-backed).
+2. **Read sidecars** at `<archive>.zip.sha256` + `<archive>.zip.etag`.
+3. **Reuse iff ALL of**:
+   - local `.zip` exists,
+   - `.sha256` sidecar exists AND matches a fresh SHA-256 of the local file (catches on-disk corruption / sidecar tampering),
+   - `.etag` sidecar exists AND matches SEC's HEAD `ETag` (catches SEC-side rebuild).
+4. **On reuse**: stamp manifest with `reuse_reason: "etag_match_sha256_verified"`. Zero bytes downloaded.
+5. **On no reuse**: purge `.zip` + `.partial` + `.sha256` + `.etag` and proceed to download. On successful download, write fresh sidecars (atomic `tmp + rename`) and stamp manifest with `reuse_reason: "downloaded_in_run"`.
+
+**Operator override**: `BOOTSTRAP_FORCE_REDOWNLOAD=1` env bypasses reuse entirely (forces re-download of every archive).
+
+**Provenance preserved**: `assert_archive_belongs_to_run` still gates downstream Phase C stages on the manifest's `bootstrap_run_id` matching the current run — the manifest is stamped fresh every run regardless of reuse path, so prior-run leftovers cannot leak.
+
+**Why client-side and not `If-None-Match`**: empirically SEC's S3-backed bulk endpoints ignore both `If-None-Match` and `If-Modified-Since`. The HEAD → compare → conditional-GET dance gives us the same outcome (0 bytes when unchanged) without depending on a header SEC won't honour.
 
 ## 5. Identity resolution + canonical mapping
 

--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -35,7 +35,9 @@ Behaviours:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
+import os
 import shutil
 import time
 import zipfile
@@ -97,13 +99,26 @@ class BulkArchive:
 
 @dataclass
 class ArchiveDownloadResult:
-    """Per-archive outcome reported back to the orchestrator."""
+    """Per-archive outcome reported back to the orchestrator.
+
+    ``reuse_reason`` is the value stamped into the per-run manifest:
+    - ``"downloaded_in_run"``: the bytes were fetched in THIS run.
+    - ``"etag_match_sha256_verified"``: a prior-run .zip was reused
+      because SEC's HEAD ETag matched the local ``.zip.etag`` sidecar
+      AND the local file's SHA-256 matched ``.zip.sha256``.
+    Both reasons satisfy ``assert_archive_belongs_to_run`` provenance
+    because the manifest is stamped fresh with the current
+    ``bootstrap_run_id`` regardless of reuse path
+    (settled-decisions.md "Bulk archive reuse keyed on SEC ETag +
+    SHA-256").
+    """
 
     name: str
     path: Path | None
     bytes_downloaded: int
     skipped: bool = False
     error: str | None = None
+    reuse_reason: Literal["downloaded_in_run", "etag_match_sha256_verified"] | None = None
 
 
 @dataclass
@@ -268,34 +283,375 @@ def build_bulk_archive_inventory(
 # ---------------------------------------------------------------------------
 
 
-def _preflight_cleanup_stale_partials(target_dir: Path) -> None:
-    """Delete leftover ``*.partial`` AND complete ``*.zip`` files
-    from previous runs.
+def _validate_archive_name(name: str) -> str:
+    """Return ``name`` unchanged after defending against path-traversal.
 
-    Originally only cleaned partials — but the run-manifest provenance
-    contract (#1020) requires every archive in the current run's
-    manifest to have been physically downloaded in THIS run. Promoting
-    a prior-run complete ``.zip`` into the current manifest would let
-    stale data pass provenance. Solution: nuke everything, every run
-    re-downloads. Resume-from-partial (within the same run) still
-    works because the per-run download itself can interrupt and
-    leave a ``.partial`` that the next-attempt pre-flight wipes
-    before retrying.
+    ``archive.name`` is joined into ``target_dir`` in three layers
+    (purge / preflight / download) to derive concrete paths for the
+    archive, its sidecars, and the resume-partial. A crafted name
+    containing path separators or ``..`` would escape ``target_dir``
+    and could delete or overwrite arbitrary filesystem state. Today
+    every name comes from ``build_bulk_archive_inventory`` which we
+    control, but defense-in-depth: validate at the boundary so a
+    future caller-supplied inventory cannot bypass the check.
 
-    The run-manifest itself is also wiped so a stale manifest cannot
-    leak into the next run.
+    Rules:
+      - Must equal its basename (no separators).
+      - Must not be empty, ``.``, ``..``, or absolute.
+      - Must not contain backslashes or NUL.
+      - Codex 2 BLOCKING for PR-5b.
     """
+    if not name:
+        raise ValueError("archive name must be non-empty")
+    if name in (".", ".."):
+        raise ValueError(f"archive name must not be {name!r}")
+    if "/" in name or "\\" in name or "\x00" in name:
+        raise ValueError(f"archive name must not contain path separators or NUL: {name!r}")
+    if Path(name).is_absolute():
+        raise ValueError(f"archive name must be relative: {name!r}")
+    # Posix-form basename equality also catches drive letters on Win
+    # (``C:foo``) which would otherwise sneak past the separator check.
+    if Path(name).name != name:
+        raise ValueError(f"archive name must equal its basename: {name!r}")
+    return name
+
+
+def _resolve_archive_path(target_dir: Path, archive_name: str) -> Path:
+    """Return ``target_dir / archive_name`` after validation."""
+    return target_dir / _validate_archive_name(archive_name)
+
+
+def _sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    """Return hex SHA-256 of ``path``. Streams in 1 MB chunks (multi-GB safe)."""
+    hasher = hashlib.sha256()
+    with path.open("rb") as fh:
+        while True:
+            chunk = fh.read(chunk_size)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+_SIDECAR_TMP_TAG: Final[str] = f".tmp.{os.getpid()}"
+
+
+def _atomic_write_sidecar(target_path: Path, value: str) -> None:
+    """Write ``value`` to ``target_path`` atomically (tmp + rename).
+
+    Crash-mid-write must not leave a half-formed sidecar that the next
+    run accepts as authoritative. Sidecar contents are pure text (hex
+    digest or ETag string) so encoding is fixed UTF-8.
+
+    The tmp suffix incorporates the writer's PID so two concurrent
+    processes targeting the same archive (defensive — bootstrap is
+    singleton-gated, but a future operator override could fire two
+    sec_bulk_download runs side-by-side) don't clobber each other's
+    half-written sidecar before the final ``rename``. Codex 2 MEDIUM
+    for PR-5b.
+    """
+    tmp_path = target_path.with_suffix(target_path.suffix + _SIDECAR_TMP_TAG)
+    tmp_path.write_text(value, encoding="utf-8")
+    tmp_path.replace(target_path)
+
+
+def _read_sidecar(path: Path) -> str | None:
+    """Return stripped sidecar contents, or None if missing/unreadable."""
+    if not path.exists():
+        return None
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        logger.warning("sidecar read failed for %s: %s", path, exc)
+        return None
+
+
+def _purge_archive_artifacts(target_dir: Path, archive_name: str) -> None:
+    """Delete the .zip, .partial, .sha256 + .etag sidecars for ``archive_name``.
+
+    Used by the ETag-keyed pre-flight when a re-download is required so
+    no stale local state can leak into the next attempt. Also used as
+    the broad reset path when ``BOOTSTRAP_FORCE_REDOWNLOAD=1``.
+    """
+    base = _resolve_archive_path(target_dir, archive_name)
+    candidates = (
+        base,
+        base.with_suffix(base.suffix + ".partial"),
+        Path(str(base) + ".sha256"),
+        Path(str(base) + ".etag"),
+    )
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            path.unlink()
+            logger.info("preflight purge: removed %s", path)
+        except OSError as exc:
+            logger.warning("preflight purge: failed to remove %s: %s", path, exc)
+
+
+_FORCE_REDOWNLOAD_ENV: Final[str] = "BOOTSTRAP_FORCE_REDOWNLOAD"
+
+
+def _force_redownload_active() -> bool:
+    """Return True when the operator override env var is truthy."""
+    raw = os.environ.get(_FORCE_REDOWNLOAD_ENV, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+async def _head_etag(
+    client: httpx.AsyncClient,
+    url: str,
+    *,
+    rate_limiter: Any | None = None,
+) -> str | None:
+    """Return the ``ETag`` header from a HEAD against ``url``, or None.
+
+    Used by the pre-flight reuse path. Failure modes are tolerated by
+    the caller (no-reuse → re-download) — this helper never raises for
+    a missing or non-200 ETag, only for outright transport faults that
+    the caller must escalate.
+    """
+    if rate_limiter is not None:
+        await rate_limiter.acquire()
+    response = await client.head(url)
+    if response.status_code != 200:
+        logger.info(
+            "preflight HEAD non-200 for %s: status=%d — will re-download",
+            url,
+            response.status_code,
+        )
+        return None
+    etag = response.headers.get("etag") or response.headers.get("ETag")
+    if etag is None:
+        # Per spec: SEC sometimes serves static files without an ETag.
+        # No sidecar comparison possible → caller must re-download.
+        return None
+    return etag
+
+
+@dataclass(frozen=True)
+class _ArchiveReuseDecision:
+    """Outcome of the pre-flight reuse check for one archive."""
+
+    name: str
+    reused: bool
+    sec_etag: str | None  # remote ETag at preflight time, if HEAD succeeded
+    reason: str  # human-readable reason logged to operator
+
+
+async def _preflight_archive_reuse_decision(
+    client: httpx.AsyncClient,
+    archive: BulkArchive,
+    target_dir: Path,
+    *,
+    rate_limiter: Any | None = None,
+) -> _ArchiveReuseDecision:
+    """Decide whether ``archive`` can be reused from local disk.
+
+    Reuse criteria (ALL must hold):
+      1. Local ``.zip`` exists.
+      2. ``.zip.sha256`` sidecar exists AND matches a fresh SHA-256
+         of the local ``.zip``.
+      3. ``.zip.etag`` sidecar exists AND matches SEC's HEAD ``ETag``.
+
+    Operator override ``BOOTSTRAP_FORCE_REDOWNLOAD=1`` is handled at a
+    higher layer (the caller short-circuits before invoking this
+    helper) so the per-archive decision flow stays focused on
+    sidecar/HEAD comparison.
+
+    On any negative decision the caller is expected to purge the
+    archive's artefacts (.zip + .partial + sidecars) before retry.
+    """
+    zip_path = _resolve_archive_path(target_dir, archive.name)
+    sha_path = Path(str(zip_path) + ".sha256")
+    etag_path = Path(str(zip_path) + ".etag")
+    partial_path = zip_path.with_suffix(zip_path.suffix + ".partial")
+
+    # A leftover .partial alongside a complete .zip indicates a prior
+    # interrupted resume; safe path is full re-download.
+    if partial_path.exists():
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=None,
+            reason="partial_present",
+        )
+
+    if not zip_path.exists():
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=None,
+            reason="local_missing",
+        )
+
+    stored_sha = _read_sidecar(sha_path)
+    if stored_sha is None:
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=None,
+            reason="sha256_sidecar_missing",
+        )
+
+    stored_etag = _read_sidecar(etag_path)
+    if stored_etag is None:
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=None,
+            reason="etag_sidecar_missing",
+        )
+
+    # HEAD SEC for the live ETag. A non-200 / missing ETag means we
+    # cannot prove freshness; safe default is re-download.
+    try:
+        sec_etag = await _head_etag(client, archive.url, rate_limiter=rate_limiter)
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("preflight HEAD failed for %s: %s — will re-download", archive.url, exc)
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=None,
+            reason=f"head_failed: {type(exc).__name__}",
+        )
+
+    if sec_etag is None:
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=None,
+            reason="sec_etag_missing",
+        )
+
+    if sec_etag != stored_etag:
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=sec_etag,
+            reason="etag_mismatch",
+        )
+
+    # ETag matches → verify the local bytes actually still match the
+    # SHA-256 we stamped at download time (defends against on-disk
+    # corruption or a tampered sidecar).
+    try:
+        actual_sha = _sha256_file(zip_path)
+    except OSError as exc:
+        logger.warning("preflight SHA-256 failed for %s: %s — will re-download", zip_path, exc)
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=sec_etag,
+            reason=f"sha256_read_failed: {type(exc).__name__}",
+        )
+
+    if actual_sha != stored_sha:
+        return _ArchiveReuseDecision(
+            name=archive.name,
+            reused=False,
+            sec_etag=sec_etag,
+            reason="sha256_mismatch",
+        )
+
+    return _ArchiveReuseDecision(
+        name=archive.name,
+        reused=True,
+        sec_etag=sec_etag,
+        reason="etag_match_sha256_verified",
+    )
+
+
+async def _preflight_etag_keyed_reuse(
+    client: httpx.AsyncClient,
+    archives: Sequence[BulkArchive],
+    target_dir: Path,
+    *,
+    rate_limiter: Any | None = None,
+) -> dict[str, _ArchiveReuseDecision]:
+    """For each archive, decide reuse-or-redownload and clean up
+    non-reusable local state.
+
+    Replaces the older blanket ``_preflight_cleanup_stale_partials``
+    that nuked every prior-run ``.zip`` regardless of freshness. With
+    sidecar evidence + SEC's stable S3-backed ETag, an unchanged
+    archive can be reused safely (settled-decisions.md, "Bulk archive
+    reuse keyed on SEC ETag + SHA-256").
+
+    The stale ``.run_manifest.json`` is always deleted up front — the
+    next run will stamp a fresh manifest with the current
+    ``bootstrap_run_id`` regardless of which archives were reused vs
+    downloaded. This preserves the provenance contract that
+    ``assert_archive_belongs_to_run`` enforces (#1020).
+
+    Operator override: ``BOOTSTRAP_FORCE_REDOWNLOAD=1`` bypasses reuse
+    for every archive.
+    """
+    decisions: dict[str, _ArchiveReuseDecision] = {}
     if not target_dir.exists():
-        return
+        return decisions
+
+    # Always wipe the prior manifest so we never leak a stale run_id
+    # forward; the new manifest is written by write_run_manifest().
+    manifest_path = target_dir / RUN_MANIFEST_NAME
+    if manifest_path.exists():
+        try:
+            manifest_path.unlink()
+            logger.info("preflight: removed stale run manifest %s", manifest_path)
+        except OSError as exc:
+            logger.warning("preflight: failed to remove stale manifest %s: %s", manifest_path, exc)
+
+    force = _force_redownload_active()
+    if force:
+        logger.warning(
+            "preflight: %s=1 — purging all archives + sidecars (forced redownload)",
+            _FORCE_REDOWNLOAD_ENV,
+        )
+
+    expected_names: set[str] = set()
+    for archive in archives:
+        expected_names.add(archive.name)
+        if force:
+            decision = _ArchiveReuseDecision(
+                name=archive.name,
+                reused=False,
+                sec_etag=None,
+                reason="force_redownload_env",
+            )
+        else:
+            decision = await _preflight_archive_reuse_decision(client, archive, target_dir, rate_limiter=rate_limiter)
+        decisions[archive.name] = decision
+        if not decision.reused:
+            _purge_archive_artifacts(target_dir, archive.name)
+            logger.info(
+                "preflight: %s will re-download (reason=%s)",
+                archive.name,
+                decision.reason,
+            )
+        else:
+            logger.info(
+                "preflight: %s reused from disk (etag=%s)",
+                archive.name,
+                decision.sec_etag,
+            )
+
+    # Stray archives not in the current inventory should still be
+    # cleaned (e.g. an old 13F window dropped off the rolling list).
     for path in target_dir.iterdir():
         if not path.is_file():
             continue
-        if path.name.endswith(".partial") or path.name.endswith(".zip") or path.name == RUN_MANIFEST_NAME:
-            try:
-                path.unlink()
-                logger.info("preflight cleanup: removed %s", path)
-            except OSError as exc:
-                logger.warning("preflight cleanup: failed to remove %s: %s", path, exc)
+        name = path.name
+        if not (name.endswith(".zip") or name.endswith(".partial")):
+            continue
+        # Strip ``.partial`` to get the canonical archive name.
+        base_name = name[: -len(".partial")] if name.endswith(".partial") else name
+        if base_name in expected_names:
+            continue
+        # Also clean the matching sidecars if any.
+        _purge_archive_artifacts(target_dir, base_name)
+
+    return decisions
 
 
 def check_disk_space(target_dir: Path, *, min_free_bytes: int = DEFAULT_MIN_FREE_BYTES) -> tuple[bool, int]:
@@ -377,8 +733,8 @@ async def _head_size_and_type(
     url: str,
     *,
     rate_limiter: Any | None = None,
-) -> tuple[int, str]:
-    """Return (Content-Length, Content-Type) for ``url`` via HEAD.
+) -> tuple[int, str, str | None]:
+    """Return ``(Content-Length, Content-Type, ETag-or-None)`` for ``url``.
 
     ``rate_limiter`` acquires the shared SEC rate clock before the
     HEAD so it counts against the per-IP budget (#1042).
@@ -389,6 +745,12 @@ async def _head_size_and_type(
     lets the caller reject non-archive responses BEFORE downloading
     bytes, replacing the brittle ``expected_min_bytes`` floor that
     conflated "small file" with "corrupted file" (#1059).
+
+    ETag is returned so the caller can bind a resume Range request to
+    the specific resource version it HEAD'd — if SEC rebuilds the
+    archive between HEAD and the resume GET, ``If-Range`` makes the
+    server return a 200 (full body) instead of appending fresh bytes
+    onto a stale ``.partial``. Codex 2 LOW/MEDIUM for PR-5b.
     """
     if rate_limiter is not None:
         await rate_limiter.acquire()
@@ -399,7 +761,8 @@ async def _head_size_and_type(
     if length is None:
         raise RuntimeError(f"HEAD missing Content-Length: url={url}")
     content_type = (response.headers.get("content-type") or "").lower()
-    return int(length), content_type
+    etag = response.headers.get("etag") or response.headers.get("ETag")
+    return int(length), content_type, etag
 
 
 # Acceptable Content-Type values for SEC bulk archives. Real-world
@@ -560,20 +923,28 @@ async def _download_one(
     HEAD/GET so the bulk downloader counts against the per-IP budget
     shared with sec_edgar / pipelined fetcher (#1042).
     """
-    final_path = target_dir / archive.name
+    final_path = _resolve_archive_path(target_dir, archive.name)
     partial_path = final_path.with_suffix(final_path.suffix + ".partial")
 
     if final_path.exists() and _zip_round_trip(final_path):
-        # Already-good archive on disk; treat as skip.
+        # Already-good archive on disk; treat as skip. Under the
+        # ETag-keyed reuse model the pre-flight is expected to either
+        # remove a stale .zip or short-circuit reuse before reaching
+        # this branch, so this is a defensive fallback. Stamp the
+        # in-run reuse_reason so manifest provenance still ties this
+        # path to the current bootstrap_run_id.
         return ArchiveDownloadResult(
             name=archive.name,
             path=final_path,
             bytes_downloaded=0,
             skipped=True,
+            reuse_reason="downloaded_in_run",
         )
 
     try:
-        expected_total, content_type = await _head_size_and_type(client, archive.url, rate_limiter=rate_limiter)
+        expected_total, content_type, head_etag = await _head_size_and_type(
+            client, archive.url, rate_limiter=rate_limiter
+        )
     except Exception as exc:  # noqa: BLE001 — operator-visible message
         return ArchiveDownloadResult(
             name=archive.name,
@@ -597,6 +968,11 @@ async def _download_one(
         )
 
     # Resume from partial if present and shorter than expected.
+    # ``If-Range`` binds the resume to the exact resource version we
+    # HEAD'd a few ms earlier; if SEC rebuilds the archive between HEAD
+    # and the resume GET, the server returns 200 (full body) instead of
+    # 206 — the existing 200-fallback path below already discards the
+    # partial and restarts from zero. Codex 2 LOW/MEDIUM for PR-5b.
     headers: dict[str, str] = {}
     resume_from = 0
     if partial_path.exists():
@@ -606,7 +982,10 @@ async def _download_one(
         else:
             resume_from = existing
             headers["Range"] = f"bytes={existing}-"
+            if head_etag is not None:
+                headers["If-Range"] = head_etag
 
+    response_etag: str | None = None
     try:
         if rate_limiter is not None:
             await rate_limiter.acquire()
@@ -627,8 +1006,17 @@ async def _download_one(
                             bytes_downloaded=0,
                             error=f"GET failed: status={fresh.status_code}",
                         )
+                    response_etag = fresh.headers.get("etag") or fresh.headers.get("ETag")
                     await _stream_to_partial(fresh, partial_path, mode="wb", chunk_size=chunk_size)
             elif response.status_code in (200, 206):
+                # Only capture ETag on a full GET (200). A 206 partial
+                # response's ETag refers to the resumed slice's parent
+                # which is fine to record on completion, but if the
+                # server already produced an ETag on the initial GET
+                # earlier we'd be stamping the same value. Either way,
+                # ETag from the response covers the full resource for
+                # SEC's S3-backed bulk archives.
+                response_etag = response.headers.get("etag") or response.headers.get("ETag")
                 mode = "ab" if resume_from else "wb"
                 await _stream_to_partial(response, partial_path, mode=mode, chunk_size=chunk_size)
             else:
@@ -676,10 +1064,36 @@ async def _download_one(
         )
 
     partial_path.replace(final_path)
+
+    # ETag-keyed reuse depends on these sidecars being present after
+    # every successful download. SHA-256 is computed from the
+    # on-disk file (not streamed during download) so corruption that
+    # somehow survives the size + magic + zip-round-trip checks is
+    # still caught on the next pre-flight. Both writes are atomic
+    # (tmp + rename); failures here are logged but do not fail the
+    # download itself — the manifest still records success and the
+    # next run will simply re-download for "sidecar_missing".
+    try:
+        sha256_hex = _sha256_file(final_path)
+        _atomic_write_sidecar(Path(str(final_path) + ".sha256"), sha256_hex)
+    except OSError as exc:
+        logger.warning("sidecar write (sha256) failed for %s: %s", final_path, exc)
+    if response_etag is not None:
+        try:
+            _atomic_write_sidecar(Path(str(final_path) + ".etag"), response_etag)
+        except OSError as exc:
+            logger.warning("sidecar write (etag) failed for %s: %s", final_path, exc)
+    else:
+        logger.info(
+            "no ETag header on GET for %s — reuse pre-flight will force re-download next run",
+            archive.name,
+        )
+
     return ArchiveDownloadResult(
         name=archive.name,
         path=final_path,
         bytes_downloaded=final_size - resume_from,
+        reuse_reason="downloaded_in_run",
     )
 
 
@@ -751,6 +1165,11 @@ def write_run_manifest(
                 "name": r.name,
                 "bytes_downloaded": r.bytes_downloaded,
                 "error": r.error,
+                # Provenance: which path produced this archive in THIS
+                # run. Default to "downloaded_in_run" if the result
+                # predates the field (defensive — should not occur
+                # after PR-5b but keeps the manifest schema honest).
+                "reuse_reason": r.reuse_reason or "downloaded_in_run",
             }
             for r in archives
             if r.error is None and r.path is not None
@@ -781,6 +1200,9 @@ def read_run_manifest(target_dir: Path) -> dict | None:
         return None
 
 
+_ACCEPTED_REUSE_REASONS: Final[frozenset[str]] = frozenset({"downloaded_in_run", "etag_match_sha256_verified"})
+
+
 def assert_archive_belongs_to_run(
     target_dir: Path,
     archive_name: str,
@@ -788,7 +1210,18 @@ def assert_archive_belongs_to_run(
     bootstrap_run_id: int,
 ) -> None:
     """Raise if the archive at ``<bulk>/<archive_name>`` is not in the
-    current run's manifest."""
+    current run's manifest.
+
+    Provenance contract (#1020): every archive read by a Phase C
+    stage must trace to a manifest stamped with the current
+    ``bootstrap_run_id``. PR-5b widens the contract to accept BOTH
+    ``reuse_reason='downloaded_in_run'`` and
+    ``reuse_reason='etag_match_sha256_verified'`` — see
+    settled-decisions.md "Bulk archive reuse keyed on SEC ETag +
+    SHA-256". The manifest is rewritten every run regardless of
+    reuse path, so a stale prior-run manifest still fails the
+    ``bootstrap_run_id`` check below.
+    """
     manifest = read_run_manifest(target_dir)
     if manifest is None:
         raise RuntimeError(
@@ -800,10 +1233,22 @@ def assert_archive_belongs_to_run(
             f"PRECONDITION: bulk manifest run_id={manifest.get('bootstrap_run_id')!r} "
             f"!= current bootstrap_run_id={bootstrap_run_id}; archive is stale."
         )
-    archive_names = {a["name"] for a in manifest.get("archives", [])}
-    if archive_name not in archive_names:
+    archive_entry: dict[str, Any] | None = None
+    for entry in manifest.get("archives", []):
+        if entry.get("name") == archive_name:
+            archive_entry = entry
+            break
+    if archive_entry is None:
         raise RuntimeError(
             f"PRECONDITION: archive {archive_name!r} not in current-run manifest; sec_bulk_download did not land it."
+        )
+    # ``reuse_reason`` may be absent on manifests written by pre-PR-5b
+    # code paths; treat absent as the legacy default.
+    reuse_reason = archive_entry.get("reuse_reason") or "downloaded_in_run"
+    if reuse_reason not in _ACCEPTED_REUSE_REASONS:
+        raise RuntimeError(
+            f"PRECONDITION: archive {archive_name!r} has unexpected reuse_reason={reuse_reason!r}; "
+            f"accepted values are {sorted(_ACCEPTED_REUSE_REASONS)}."
         )
 
 
@@ -829,7 +1274,6 @@ async def download_bulk_archives(
     recorded on the result and surfaced in the admin UI.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
-    _preflight_cleanup_stale_partials(target_dir)
     has_space, free_bytes = check_disk_space(target_dir, min_free_bytes=min_free_bytes)
     if not has_space:
         return BulkDownloadResult(
@@ -869,7 +1313,18 @@ async def download_bulk_archives(
     )
 
     async with _make_client(user_agent) as client:
+        # ETag-keyed reuse pre-flight (PR-5b): for each archive,
+        # decide whether the existing local .zip + sidecars prove
+        # freshness against SEC's HEAD ETag. Non-reusable artefacts
+        # are purged before bandwidth probe + download. The stale
+        # run-manifest is always wiped (a fresh one is written
+        # post-download).
+        reuse_decisions = await _preflight_etag_keyed_reuse(client, archives, target_dir, rate_limiter=rate_limiter)
+
         # Bandwidth probe against the first archive (submissions.zip).
+        # If every archive is reused, the probe is unnecessary (0 bytes
+        # to fetch) but still cheap (4 MB range-GET) and confirms SEC
+        # is reachable before we declare the run a no-op.
         probe_url = archives[0].url
         try:
             measured = await measure_bandwidth_mbps(client, probe_url=probe_url, rate_limiter=rate_limiter)
@@ -897,7 +1352,22 @@ async def download_bulk_archives(
                 # (Codex sweep BLOCKING) don't condemn an archive.
                 return await _download_one_with_retry(client, archive, target_dir, rate_limiter=rate_limiter)
 
-        results = await asyncio.gather(*(_bounded(a) for a in archives))
+        async def _resolve(archive: BulkArchive) -> ArchiveDownloadResult:
+            decision = reuse_decisions.get(archive.name)
+            if decision is not None and decision.reused:
+                # 0-byte reuse: surface as a successful skip so the
+                # manifest writer records it with provenance
+                # ``etag_match_sha256_verified``. No network IO.
+                return ArchiveDownloadResult(
+                    name=archive.name,
+                    path=_resolve_archive_path(target_dir, archive.name),
+                    bytes_downloaded=0,
+                    skipped=True,
+                    reuse_reason="etag_match_sha256_verified",
+                )
+            return await _bounded(archive)
+
+        results = await asyncio.gather(*(_resolve(a) for a in archives))
 
     return BulkDownloadResult(
         mode="bulk",

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -607,6 +607,26 @@ rate limits. Operator approved 2026-05-22 prior to PR-1b merge.
 **Fixtures + skill:** `tests/fixtures/openfigi/`,
 `.claude/skills/data-sources/openfigi.md`.
 
+---
+
+## Bulk archive reuse keyed on SEC ETag + SHA-256 (2026-05-22)
+
+**Decision:** The Codex review BLOCKING for #1020 prohibited reusing a
+prior-run `.zip`. With SEC's stable S3-backed ETag, reuse is permitted
+when ALL of:
+(1) local `.zip.etag` sidecar matches SEC's HEAD response,
+(2) SHA-256 of local file matches `.zip.sha256` sidecar.
+The run-manifest records `reuse_reason: 'etag_match_sha256_verified'`.
+Forced override: `BOOTSTRAP_FORCE_REDOWNLOAD=1` env var.
+**Empirical:** SEC ignores `If-None-Match` / `If-Modified-Since` (both
+return 200 + full body regardless, probed 2026-05-22). Reuse therefore
+uses client-side header comparison: HEAD → compare ETag → conditional
+GET. The run-manifest is stamped fresh every run (download OR reuse),
+so `assert_archive_belongs_to_run` still gates Phase C on current
+`bootstrap_run_id` provenance regardless of reuse path.
+
+---
+
 ## Maintenance rule
 
 When a new repo-level decision is agreed and is likely to affect future implementation:

--- a/tests/fixtures/sec_bulk_head/README.md
+++ b/tests/fixtures/sec_bulk_head/README.md
@@ -1,0 +1,26 @@
+# sec_bulk_head fixtures
+
+Recorded SEC HEAD response headers for bulk archives.
+
+Used by `tests/test_sec_bulk_etag_reuse.py::TestRecordedHeadFixture` to
+pin the ETag-keyed reuse contract against the exact header shape SEC
+returns. Headers only — no bodies — because the multi-GB archives are
+out of scope for the fixture dir.
+
+## Recording procedure
+
+```
+curl -sI -A "eBull dev@example.com" <url> > headers.txt
+```
+
+Then extract `etag`, `content-length`, `content-type`, `last-modified`
+into a `<name>.headers.json` file (lowercased keys).
+
+## Empirical (2026-05-22)
+
+For `submissions.zip` (https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip):
+
+- `etag: "504b124e9474334e889e9e525db95c14-184"` (stable, S3-backed)
+- `If-None-Match` header sent by client → SEC ignores; returns
+  `200 + full body` regardless. This is why the reuse path uses
+  client-side HEAD ETag comparison and a conditional GET.

--- a/tests/fixtures/sec_bulk_head/submissions.zip.headers.json
+++ b/tests/fixtures/sec_bulk_head/submissions.zip.headers.json
@@ -1,0 +1,10 @@
+{
+  "_recorded_at": "2026-05-22T23:56:39Z",
+  "_url": "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip",
+  "_recorded_with": "curl -sI -A 'eBull dev@example.com'",
+  "content-type": "application/zip",
+  "content-length": "1541272031",
+  "last-modified": "Fri, 22 May 2026 04:36:27 GMT",
+  "etag": "\"504b124e9474334e889e9e525db95c14-184\"",
+  "accept-ranges": "bytes"
+}

--- a/tests/test_sec_bulk_download.py
+++ b/tests/test_sec_bulk_download.py
@@ -16,7 +16,7 @@ from app.services.sec_bulk_download import (
     BulkArchive,
     BulkDownloadResult,
     _download_one,
-    _preflight_cleanup_stale_partials,
+    _purge_archive_artifacts,
     _zip_round_trip,
     build_bulk_archive_inventory,
     check_disk_space,
@@ -143,25 +143,21 @@ class TestInventory:
 # ---------------------------------------------------------------------------
 
 
-class TestPreflightCleanup:
-    def test_removes_partial_and_complete_zips_for_run_manifest_contract(self, tmp_path: Path) -> None:
-        # Run-manifest provenance (#1020) demands every archive in the
-        # current run's manifest was physically downloaded in THIS run.
-        # Promoting a prior-run complete .zip into the manifest would let
-        # stale data pass provenance, so the pre-flight nukes BOTH
-        # complete .zip and stale .partial files. See
-        # _preflight_cleanup_stale_partials docstring.
-        complete = tmp_path / "submissions.zip"
-        complete.write_bytes(b"complete payload")
-        partial = tmp_path / "companyfacts.zip.partial"
-        partial.write_bytes(b"truncated payload")
-        _preflight_cleanup_stale_partials(tmp_path)
-        assert not complete.exists()
-        assert not partial.exists()
+class TestPreflightPurge:
+    def test_purge_archive_artifacts_removes_zip_partial_and_sidecars(self, tmp_path: Path) -> None:
+        # _purge_archive_artifacts is the per-archive cleanup the
+        # ETag-keyed pre-flight calls when reuse is rejected. It must
+        # delete the .zip, .partial, .sha256, and .etag in one call.
+        (tmp_path / "submissions.zip").write_bytes(b"complete payload")
+        (tmp_path / "submissions.zip.partial").write_bytes(b"resume tail")
+        (tmp_path / "submissions.zip.sha256").write_text("deadbeef")
+        (tmp_path / "submissions.zip.etag").write_text('"abc-123"')
+        _purge_archive_artifacts(tmp_path, "submissions.zip")
+        for name in ("submissions.zip", "submissions.zip.partial", "submissions.zip.sha256", "submissions.zip.etag"):
+            assert not (tmp_path / name).exists(), name
 
-    def test_no_op_when_dir_missing(self, tmp_path: Path) -> None:
-        # Should not raise on absent directory.
-        _preflight_cleanup_stale_partials(tmp_path / "does-not-exist")
+    def test_purge_archive_artifacts_no_op_when_missing(self, tmp_path: Path) -> None:
+        _purge_archive_artifacts(tmp_path, "absent.zip")
 
 
 class TestDiskPreflight:

--- a/tests/test_sec_bulk_etag_reuse.py
+++ b/tests/test_sec_bulk_etag_reuse.py
@@ -1,0 +1,808 @@
+"""Tests for the ETag-keyed bulk-archive reuse pre-flight (PR-5b).
+
+Settled decision: docs/settled-decisions.md, "Bulk archive reuse keyed
+on SEC ETag + SHA-256 (2026-05-22)". Spec:
+docs/superpowers/specs/2026-05-22-bootstrap-etl-optimisation-v2.md §10.
+
+These tests exercise ``_preflight_etag_keyed_reuse`` +
+``download_bulk_archives`` end-to-end against an in-process
+``httpx.MockTransport``. The cold-install / unchanged-SEC / changed-SEC
+matrix is the contract:
+
+  cold install                 -> downloads, writes sidecars
+  unchanged ETag + good SHA    -> 0-byte reuse, manifest reuse_reason
+  changed ETag                 -> redownload (purge + GET)
+  SHA mismatch on disk         -> redownload
+  missing sidecar              -> redownload (defensive)
+  BOOTSTRAP_FORCE_REDOWNLOAD=1 -> redownload regardless
+  .partial alongside .zip      -> redownload (interrupted prior run)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import zipfile
+from collections.abc import Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import httpx
+import pytest
+
+import app.services.sec_bulk_download as mod
+from app.services.sec_bulk_download import (
+    RUN_MANIFEST_NAME,
+    BulkArchive,
+    _ArchiveReuseDecision,
+    _atomic_write_sidecar,
+    _preflight_etag_keyed_reuse,
+    _sha256_file,
+    assert_archive_belongs_to_run,
+    download_bulk_archives,
+    write_run_manifest,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_zip_bytes(filenames: tuple[str, ...] = ("CIK0000320193.json",)) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name in filenames:
+            zf.writestr(name, b"{}")
+    return buf.getvalue()
+
+
+def _make_handler_with_etag(
+    archive_url: str,
+    archive_body: bytes,
+    *,
+    etag: str | None,
+    request_log: list[str] | None = None,
+) -> Callable[[httpx.Request], httpx.Response]:
+    """MockTransport handler that serves ``archive_body`` at ``archive_url``
+    with optional ``ETag`` header on both HEAD and GET.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request_log is not None:
+            range_header = request.headers.get("Range")
+            label = f"{request.method}"
+            if range_header:
+                label = f"{request.method}[Range={range_header}]"
+            request_log.append(f"{label} {request.url}")
+        if str(request.url) != archive_url:
+            return httpx.Response(404)
+        common_headers: dict[str, str] = {
+            "Content-Length": str(len(archive_body)),
+            "Content-Type": "application/zip",
+        }
+        if etag is not None:
+            common_headers["ETag"] = etag
+        if request.method == "HEAD":
+            return httpx.Response(200, headers=common_headers)
+        if request.method == "GET":
+            range_header = request.headers.get("Range")
+            if range_header:
+                spec = range_header.removeprefix("bytes=")
+                if "-" in spec:
+                    start_str, end_str = spec.split("-", 1)
+                    start = int(start_str) if start_str else 0
+                    end = int(end_str) if end_str else len(archive_body) - 1
+                    chunk = archive_body[start : end + 1]
+                    return httpx.Response(
+                        206,
+                        content=chunk,
+                        headers={
+                            "Content-Length": str(len(chunk)),
+                            "Content-Range": f"bytes {start}-{start + len(chunk) - 1}/{len(archive_body)}",
+                            **({"ETag": etag} if etag else {}),
+                        },
+                    )
+            return httpx.Response(200, content=archive_body, headers=common_headers)
+        return httpx.Response(405)
+
+    return handler
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, transport: httpx.MockTransport) -> None:
+    """Replace ``_make_client`` with a fixture-friendly factory."""
+
+    @asynccontextmanager
+    async def _patched(user_agent: str):
+        async with httpx.AsyncClient(
+            transport=transport,
+            headers={"User-Agent": user_agent, "Accept": "application/zip,*/*"},
+        ) as client:
+            yield client
+
+    monkeypatch.setattr(mod, "_make_client", _patched)
+
+
+# ---------------------------------------------------------------------------
+# Sidecar primitives
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarPrimitives:
+    def test_sha256_file_streams_multi_chunk(self, tmp_path: Path) -> None:
+        # 3 MB body across multiple 1 MB chunks: hash must match the
+        # one-shot hashlib computation.
+        body = (b"abc123" * (1024 * 1024 // 6 + 1))[: 3 * 1024 * 1024]
+        path = tmp_path / "x.zip"
+        path.write_bytes(body)
+        expected = hashlib.sha256(body).hexdigest()
+        assert _sha256_file(path) == expected
+
+    def test_atomic_sidecar_write_replaces_existing(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.zip.etag"
+        _atomic_write_sidecar(target, '"v1"')
+        assert target.read_text(encoding="utf-8") == '"v1"'
+        _atomic_write_sidecar(target, '"v2"')
+        assert target.read_text(encoding="utf-8") == '"v2"'
+        # No leftover .tmp.
+        assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+# ---------------------------------------------------------------------------
+# _preflight_etag_keyed_reuse — unit tests against MockTransport
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightDecision:
+    @pytest.mark.asyncio
+    async def test_cold_install_decides_redownload(self, tmp_path: Path) -> None:
+        # No local files at all → reuse rejected.
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, _build_zip_bytes(), etag='"e1"'))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is False
+        assert d.reason == "local_missing"
+
+    @pytest.mark.asyncio
+    async def test_etag_match_with_sha_match_decides_reuse(self, tmp_path: Path) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        (Path(str(zip_path) + ".sha256")).write_text(hashlib.sha256(body).hexdigest())
+        etag = '"504b124e9474334e889e9e525db95c14-184"'
+        (Path(str(zip_path) + ".etag")).write_text(etag)
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=etag))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is True
+        assert d.reason == "etag_match_sha256_verified"
+        assert d.sec_etag == etag
+        # Local files preserved.
+        assert zip_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_etag_mismatch_purges_local(self, tmp_path: Path) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        (Path(str(zip_path) + ".sha256")).write_text(hashlib.sha256(body).hexdigest())
+        (Path(str(zip_path) + ".etag")).write_text('"old"')
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag='"new"'))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is False
+        assert d.reason == "etag_mismatch"
+        # Purged: zip + sidecars removed.
+        assert not zip_path.exists()
+        assert not Path(str(zip_path) + ".sha256").exists()
+        assert not Path(str(zip_path) + ".etag").exists()
+
+    @pytest.mark.asyncio
+    async def test_sha_mismatch_purges_local_even_if_etag_matches(self, tmp_path: Path) -> None:
+        # Tampered .zip but sidecars look "correct" → SHA recomputation
+        # catches it.
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        # SHA sidecar points to a different content (corruption on disk).
+        (Path(str(zip_path) + ".sha256")).write_text(hashlib.sha256(b"different").hexdigest())
+        etag = '"e1"'
+        (Path(str(zip_path) + ".etag")).write_text(etag)
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=etag))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is False
+        assert d.reason == "sha256_mismatch"
+        assert not zip_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_missing_sha_sidecar_purges_local(self, tmp_path: Path) -> None:
+        # .zip exists but no .sha256 sidecar → defensive re-download.
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        (Path(str(zip_path) + ".etag")).write_text('"e1"')
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag='"e1"'))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is False
+        assert d.reason == "sha256_sidecar_missing"
+        assert not zip_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_missing_etag_sidecar_purges_local(self, tmp_path: Path) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        (Path(str(zip_path) + ".sha256")).write_text(hashlib.sha256(body).hexdigest())
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag='"e1"'))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is False
+        assert d.reason == "etag_sidecar_missing"
+        assert not zip_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_partial_alongside_zip_forces_redownload(self, tmp_path: Path) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        partial_path = zip_path.with_suffix(zip_path.suffix + ".partial")
+        partial_path.write_bytes(b"interrupted tail")
+        (Path(str(zip_path) + ".sha256")).write_text(hashlib.sha256(body).hexdigest())
+        (Path(str(zip_path) + ".etag")).write_text('"e1"')
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag='"e1"'))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is False
+        assert d.reason == "partial_present"
+        # Purge removes BOTH .zip and .partial.
+        assert not zip_path.exists()
+        assert not partial_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_head_without_etag_header_forces_redownload(self, tmp_path: Path) -> None:
+        # SEC sometimes serves static files without an ETag — we cannot
+        # prove freshness, safe default is re-download.
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        (Path(str(zip_path) + ".sha256")).write_text(hashlib.sha256(body).hexdigest())
+        (Path(str(zip_path) + ".etag")).write_text('"e1"')
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=None))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is False
+        assert d.reason == "sec_etag_missing"
+
+    @pytest.mark.asyncio
+    async def test_force_redownload_env_bypasses_reuse(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        (Path(str(zip_path) + ".sha256")).write_text(hashlib.sha256(body).hexdigest())
+        etag = '"e1"'
+        (Path(str(zip_path) + ".etag")).write_text(etag)
+
+        # Track HEAD calls — force-mode must NOT need them.
+        request_log: list[str] = []
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=etag, request_log=request_log))
+        monkeypatch.setenv("BOOTSTRAP_FORCE_REDOWNLOAD", "1")
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is False
+        assert d.reason == "force_redownload_env"
+        assert not zip_path.exists()
+        assert all(not entry.startswith("HEAD ") for entry in request_log), request_log
+
+    @pytest.mark.asyncio
+    async def test_preflight_wipes_stale_run_manifest(self, tmp_path: Path) -> None:
+        # Pre-existing run-manifest from a prior bootstrap must be
+        # removed up front; write_run_manifest re-stamps later.
+        manifest = tmp_path / RUN_MANIFEST_NAME
+        manifest.write_text('{"bootstrap_run_id": 99, "mode": "bulk", "archives": []}')
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, _build_zip_bytes(), etag='"e1"'))
+        async with httpx.AsyncClient(transport=transport) as client:
+            await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        assert not manifest.exists()
+
+    @pytest.mark.asyncio
+    async def test_stale_archive_not_in_inventory_is_cleaned(self, tmp_path: Path) -> None:
+        # A 13F window that rolled off the list must not stay on disk.
+        # Current inventory contains only ``archive.zip``; stray
+        # ``form13f_old.zip`` + sidecars should be purged.
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        stray = tmp_path / "form13f_old.zip"
+        stray.write_bytes(b"stale")
+        (Path(str(stray) + ".sha256")).write_text("dead")
+        (Path(str(stray) + ".etag")).write_text('"old"')
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, _build_zip_bytes(), etag='"e1"'))
+        async with httpx.AsyncClient(transport=transport) as client:
+            await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        assert not stray.exists()
+        assert not Path(str(stray) + ".sha256").exists()
+        assert not Path(str(stray) + ".etag").exists()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via download_bulk_archives
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndReuse:
+    @pytest.mark.asyncio
+    async def test_cold_install_writes_sidecars_and_downloaded_in_run_provenance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        etag = '"504b124e9474334e889e9e525db95c14-184"'
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=etag))
+        _patch_client(monkeypatch, transport)
+
+        result = await download_bulk_archives(
+            target_dir=tmp_path,
+            user_agent="ebull/test (admin@example.com)",
+            bandwidth_threshold_mbps=0.0,
+            min_free_bytes=1,
+            archives=[archive],
+            concurrency=1,
+        )
+
+        assert result.mode == "bulk"
+        assert len(result.archives) == 1
+        r = result.archives[0]
+        assert r.error is None
+        assert r.reuse_reason == "downloaded_in_run"
+        assert r.bytes_downloaded == len(body)
+        # Sidecars exist with expected content.
+        assert (tmp_path / "archive.zip").read_bytes() == body
+        sha_sidecar = (tmp_path / "archive.zip.sha256").read_text(encoding="utf-8").strip()
+        assert sha_sidecar == hashlib.sha256(body).hexdigest()
+        etag_sidecar = (tmp_path / "archive.zip.etag").read_text(encoding="utf-8").strip()
+        assert etag_sidecar == etag
+
+        # write_run_manifest path stamps reuse_reason.
+        write_run_manifest(tmp_path, bootstrap_run_id=42, archives=result.archives)
+        manifest = json.loads((tmp_path / RUN_MANIFEST_NAME).read_text())
+        assert manifest["archives"][0]["reuse_reason"] == "downloaded_in_run"
+        assert_archive_belongs_to_run(tmp_path, "archive.zip", bootstrap_run_id=42)
+
+    @pytest.mark.asyncio
+    async def test_rerun_with_unchanged_sec_reuses_zero_bytes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        etag = '"e1"'
+
+        # Cold install seeds the on-disk state.
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        _atomic_write_sidecar(Path(str(zip_path) + ".sha256"), hashlib.sha256(body).hexdigest())
+        _atomic_write_sidecar(Path(str(zip_path) + ".etag"), etag)
+
+        request_log: list[str] = []
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=etag, request_log=request_log))
+        _patch_client(monkeypatch, transport)
+
+        result = await download_bulk_archives(
+            target_dir=tmp_path,
+            user_agent="ebull/test (admin@example.com)",
+            bandwidth_threshold_mbps=0.0,
+            min_free_bytes=1,
+            archives=[archive],
+            concurrency=1,
+        )
+
+        assert result.mode == "bulk"
+        r = result.archives[0]
+        assert r.error is None
+        assert r.reuse_reason == "etag_match_sha256_verified"
+        assert r.bytes_downloaded == 0
+        # No FULL GET fired against the archive URL — only HEAD(s) +
+        # the bandwidth-probe Range-GET. (Range-GET of the first 4 MB
+        # is still issued; it does not download the archive body.)
+        full_gets = [e for e in request_log if e.startswith("GET ") and archive.url in e]
+        assert full_gets == [], f"unexpected full GETs during reuse: {full_gets!r}"
+
+        # Manifest provenance accepts the reuse reason.
+        write_run_manifest(tmp_path, bootstrap_run_id=43, archives=result.archives)
+        manifest = json.loads((tmp_path / RUN_MANIFEST_NAME).read_text())
+        assert manifest["archives"][0]["reuse_reason"] == "etag_match_sha256_verified"
+        assert_archive_belongs_to_run(tmp_path, "archive.zip", bootstrap_run_id=43)
+
+    @pytest.mark.asyncio
+    async def test_rerun_with_changed_sec_redownloads(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        old_body = _build_zip_bytes(filenames=("OLD.json",))
+        new_body = _build_zip_bytes(filenames=("NEW1.json", "NEW2.json"))
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        old_etag = '"v1"'
+        new_etag = '"v2"'
+
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(old_body)
+        _atomic_write_sidecar(Path(str(zip_path) + ".sha256"), hashlib.sha256(old_body).hexdigest())
+        _atomic_write_sidecar(Path(str(zip_path) + ".etag"), old_etag)
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, new_body, etag=new_etag))
+        _patch_client(monkeypatch, transport)
+
+        result = await download_bulk_archives(
+            target_dir=tmp_path,
+            user_agent="ebull/test (admin@example.com)",
+            bandwidth_threshold_mbps=0.0,
+            min_free_bytes=1,
+            archives=[archive],
+            concurrency=1,
+        )
+
+        assert result.mode == "bulk"
+        r = result.archives[0]
+        assert r.error is None
+        assert r.reuse_reason == "downloaded_in_run"
+        assert r.bytes_downloaded == len(new_body)
+        assert zip_path.read_bytes() == new_body
+        # Sidecars refreshed.
+        assert (tmp_path / "archive.zip.sha256").read_text(encoding="utf-8").strip() == hashlib.sha256(
+            new_body
+        ).hexdigest()
+        assert (tmp_path / "archive.zip.etag").read_text(encoding="utf-8").strip() == new_etag
+
+    @pytest.mark.asyncio
+    async def test_corrupt_local_sha_triggers_redownload(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        etag = '"e1"'
+
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        # Corrupt SHA sidecar.
+        _atomic_write_sidecar(Path(str(zip_path) + ".sha256"), "deadbeef" * 8)
+        _atomic_write_sidecar(Path(str(zip_path) + ".etag"), etag)
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=etag))
+        _patch_client(monkeypatch, transport)
+
+        result = await download_bulk_archives(
+            target_dir=tmp_path,
+            user_agent="ebull/test (admin@example.com)",
+            bandwidth_threshold_mbps=0.0,
+            min_free_bytes=1,
+            archives=[archive],
+            concurrency=1,
+        )
+
+        r = result.archives[0]
+        assert r.error is None
+        assert r.reuse_reason == "downloaded_in_run"
+        # SHA sidecar is now the correct value (rewritten by download).
+        assert (tmp_path / "archive.zip.sha256").read_text(encoding="utf-8").strip() == hashlib.sha256(body).hexdigest()
+
+    @pytest.mark.asyncio
+    async def test_force_env_redownloads_even_when_etag_matches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        etag = '"e1"'
+
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        _atomic_write_sidecar(Path(str(zip_path) + ".sha256"), hashlib.sha256(body).hexdigest())
+        _atomic_write_sidecar(Path(str(zip_path) + ".etag"), etag)
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=etag))
+        _patch_client(monkeypatch, transport)
+        monkeypatch.setenv("BOOTSTRAP_FORCE_REDOWNLOAD", "1")
+
+        result = await download_bulk_archives(
+            target_dir=tmp_path,
+            user_agent="ebull/test (admin@example.com)",
+            bandwidth_threshold_mbps=0.0,
+            min_free_bytes=1,
+            archives=[archive],
+            concurrency=1,
+        )
+
+        r = result.archives[0]
+        assert r.error is None
+        assert r.reuse_reason == "downloaded_in_run"
+        assert r.bytes_downloaded == len(body)
+
+    @pytest.mark.asyncio
+    async def test_partial_alongside_zip_triggers_full_redownload(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        etag = '"e1"'
+
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        partial_path = zip_path.with_suffix(zip_path.suffix + ".partial")
+        partial_path.write_bytes(b"interrupted")
+        _atomic_write_sidecar(Path(str(zip_path) + ".sha256"), hashlib.sha256(body).hexdigest())
+        _atomic_write_sidecar(Path(str(zip_path) + ".etag"), etag)
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=etag))
+        _patch_client(monkeypatch, transport)
+
+        result = await download_bulk_archives(
+            target_dir=tmp_path,
+            user_agent="ebull/test (admin@example.com)",
+            bandwidth_threshold_mbps=0.0,
+            min_free_bytes=1,
+            archives=[archive],
+            concurrency=1,
+        )
+
+        r = result.archives[0]
+        assert r.error is None
+        assert r.reuse_reason == "downloaded_in_run"
+        assert not partial_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# assert_archive_belongs_to_run accepts both reuse reasons
+# ---------------------------------------------------------------------------
+
+
+class TestAssertArchiveBelongsToRun:
+    def test_accepts_downloaded_in_run(self, tmp_path: Path) -> None:
+        path = tmp_path / RUN_MANIFEST_NAME
+        path.write_text(
+            json.dumps(
+                {
+                    "bootstrap_run_id": 1,
+                    "mode": "bulk",
+                    "archives": [
+                        {"name": "x.zip", "bytes_downloaded": 100, "error": None, "reuse_reason": "downloaded_in_run"}
+                    ],
+                }
+            )
+        )
+        assert_archive_belongs_to_run(tmp_path, "x.zip", bootstrap_run_id=1)
+
+    def test_accepts_etag_match_sha256_verified(self, tmp_path: Path) -> None:
+        path = tmp_path / RUN_MANIFEST_NAME
+        path.write_text(
+            json.dumps(
+                {
+                    "bootstrap_run_id": 1,
+                    "mode": "bulk",
+                    "archives": [
+                        {
+                            "name": "x.zip",
+                            "bytes_downloaded": 0,
+                            "error": None,
+                            "reuse_reason": "etag_match_sha256_verified",
+                        }
+                    ],
+                }
+            )
+        )
+        assert_archive_belongs_to_run(tmp_path, "x.zip", bootstrap_run_id=1)
+
+    def test_rejects_unknown_reuse_reason(self, tmp_path: Path) -> None:
+        path = tmp_path / RUN_MANIFEST_NAME
+        path.write_text(
+            json.dumps(
+                {
+                    "bootstrap_run_id": 1,
+                    "mode": "bulk",
+                    "archives": [{"name": "x.zip", "bytes_downloaded": 0, "error": None, "reuse_reason": "made_up"}],
+                }
+            )
+        )
+        with pytest.raises(RuntimeError, match="reuse_reason"):
+            assert_archive_belongs_to_run(tmp_path, "x.zip", bootstrap_run_id=1)
+
+    def test_missing_reuse_reason_defaults_to_downloaded_in_run(self, tmp_path: Path) -> None:
+        # Backward compatibility: manifests written by pre-PR-5b code
+        # paths may omit reuse_reason; the assertion must still pass.
+        path = tmp_path / RUN_MANIFEST_NAME
+        path.write_text(
+            json.dumps(
+                {
+                    "bootstrap_run_id": 1,
+                    "mode": "bulk",
+                    "archives": [{"name": "x.zip", "bytes_downloaded": 100, "error": None}],
+                }
+            )
+        )
+        assert_archive_belongs_to_run(tmp_path, "x.zip", bootstrap_run_id=1)
+
+
+# ---------------------------------------------------------------------------
+# Fixture round-trip — recorded SEC HEAD response
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "sec_bulk_head"
+
+
+def _load_fixture_etag(name: str) -> str:
+    """Read the recorded ETag for ``name`` from the fixture dir."""
+    path = _FIXTURE_DIR / f"{name}.headers.json"
+    headers = json.loads(path.read_text(encoding="utf-8"))
+    return headers["etag"]
+
+
+class TestRecordedHeadFixture:
+    @pytest.mark.asyncio
+    async def test_unchanged_etag_scenario_against_recorded_fixture(self, tmp_path: Path) -> None:
+        """Use the recorded SEC HEAD ETag for submissions.zip; verify
+        the reuse decision matches against the same ETag."""
+        recorded_etag = _load_fixture_etag("submissions.zip")
+        body = _build_zip_bytes()
+        archive = BulkArchive(name="submissions.zip", url="https://example.test/submissions.zip")
+
+        zip_path = tmp_path / archive.name
+        zip_path.write_bytes(body)
+        _atomic_write_sidecar(Path(str(zip_path) + ".sha256"), hashlib.sha256(body).hexdigest())
+        _atomic_write_sidecar(Path(str(zip_path) + ".etag"), recorded_etag)
+
+        transport = httpx.MockTransport(_make_handler_with_etag(archive.url, body, etag=recorded_etag))
+        async with httpx.AsyncClient(transport=transport) as client:
+            decisions = await _preflight_etag_keyed_reuse(client, [archive], tmp_path)
+        d = decisions[archive.name]
+        assert d.reused is True
+        assert d.sec_etag == recorded_etag
+
+
+# ---------------------------------------------------------------------------
+# Dataclass + module sanity
+# ---------------------------------------------------------------------------
+
+
+def test_archive_reuse_decision_is_immutable() -> None:
+    d = _ArchiveReuseDecision(name="x", reused=True, sec_etag='"e"', reason="ok")
+    with pytest.raises(Exception):
+        d.reused = False  # type: ignore[misc]
+
+
+class TestArchiveNameValidation:
+    """Defence-in-depth path-traversal guard added by Codex 2 BLOCKING."""
+
+    def test_validator_accepts_legit_inventory_names(self) -> None:
+        from app.services.sec_bulk_download import _validate_archive_name
+
+        for name in (
+            "submissions.zip",
+            "companyfacts.zip",
+            "form13f_01dec2025-28feb2026.zip",
+            "insider_2025q4.zip",
+            "nport_2025q4.zip",
+        ):
+            assert _validate_archive_name(name) == name
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",
+            ".",
+            "..",
+            "../escape.zip",
+            "../../etc/passwd",
+            "a/b.zip",
+            "a\\b.zip",
+            "/abs/path.zip",
+            "with\x00nul.zip",
+        ],
+    )
+    def test_validator_rejects_path_traversal(self, name: str) -> None:
+        from app.services.sec_bulk_download import _validate_archive_name
+
+        with pytest.raises(ValueError):
+            _validate_archive_name(name)
+
+    def test_purge_rejects_traversal_name_without_touching_outside_dir(self, tmp_path: Path) -> None:
+        from app.services.sec_bulk_download import _purge_archive_artifacts
+
+        outside = tmp_path.parent / "must_survive.zip"
+        outside.write_bytes(b"sentinel")
+        # Construct a target_dir under tmp_path and try a ../ name —
+        # validator must raise before any unlink fires.
+        target = tmp_path / "bulk"
+        target.mkdir()
+        with pytest.raises(ValueError):
+            _purge_archive_artifacts(target, "../must_survive.zip")
+        assert outside.exists()
+        outside.unlink()
+
+
+class TestIfRangeOnResume:
+    """If SEC rebuilds between HEAD and resume-GET, ``If-Range`` makes
+    the server return 200 + full body — the existing 200-after-Range
+    fallback discards the partial and restarts. Codex 2 LOW/MEDIUM."""
+
+    @pytest.mark.asyncio
+    async def test_if_range_header_sent_when_partial_exists(self, tmp_path: Path) -> None:
+        from app.services.sec_bulk_download import _download_one
+
+        body = _build_zip_bytes(filenames=("a.json", "b.json", "c.json", "d.json"))
+        archive = BulkArchive(name="archive.zip", url="https://example.test/archive.zip")
+        partial_path = tmp_path / "archive.zip.partial"
+        partial_path.write_bytes(body[: len(body) // 2])
+
+        seen_if_range: list[str] = []
+        etag = '"resume-binding"'
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if str(request.url) != archive.url:
+                return httpx.Response(404)
+            if request.method == "HEAD":
+                return httpx.Response(
+                    200,
+                    headers={
+                        "Content-Length": str(len(body)),
+                        "Content-Type": "application/zip",
+                        "ETag": etag,
+                    },
+                )
+            # GET — record the If-Range header.
+            if_range = request.headers.get("If-Range")
+            if if_range:
+                seen_if_range.append(if_range)
+            range_header = request.headers.get("Range")
+            if range_header:
+                start = int(range_header.removeprefix("bytes=").split("-", 1)[0])
+                chunk = body[start:]
+                return httpx.Response(
+                    206,
+                    content=chunk,
+                    headers={
+                        "Content-Length": str(len(chunk)),
+                        "Content-Range": f"bytes {start}-{len(body) - 1}/{len(body)}",
+                        "ETag": etag,
+                    },
+                )
+            return httpx.Response(200, content=body, headers={"Content-Length": str(len(body))})
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await _download_one(client, archive, tmp_path)
+        assert result.error is None
+        assert seen_if_range == [etag], f"expected If-Range to bind to HEAD etag, got {seen_if_range!r}"
+
+
+def test_force_redownload_env_var_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.services.sec_bulk_download import _force_redownload_active
+
+    for v in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv("BOOTSTRAP_FORCE_REDOWNLOAD", v)
+        assert _force_redownload_active() is True
+    for v in ("", "0", "false", "no", "off", "anythingelse"):
+        monkeypatch.setenv("BOOTSTRAP_FORCE_REDOWNLOAD", v)
+        assert _force_redownload_active() is False
+    # Cleanup
+    monkeypatch.delenv("BOOTSTRAP_FORCE_REDOWNLOAD", raising=False)
+    assert os.environ.get("BOOTSTRAP_FORCE_REDOWNLOAD") is None


### PR DESCRIPTION
## Summary

- Replace `_preflight_cleanup_stale_partials` (which nuked every prior-run `.zip`) with `_preflight_etag_keyed_reuse`. Per archive: HEAD SEC, compare ETag against `<archive>.zip.etag` sidecar, recompute SHA-256 against `<archive>.zip.sha256` sidecar, reuse on match (zero bytes downloaded). Empirical: SEC ignores `If-None-Match` / `If-Modified-Since` on bulk endpoints (probed 2026-05-22 against `submissions.zip`), so reuse is client-side compare.
- Run-manifest provenance contract preserved: each archive carries `reuse_reason ∈ {"downloaded_in_run", "etag_match_sha256_verified"}`; `assert_archive_belongs_to_run` continues to gate Phase C on `bootstrap_run_id` regardless of reuse path.
- Operator override `BOOTSTRAP_FORCE_REDOWNLOAD=1` forces re-download of every archive.

## Why

The Codex BLOCKING for #1020 prohibited reusing prior-run `.zip`s. SD-2 (`docs/settled-decisions.md`) carves an exception keyed on `(SEC ETag, SHA-256)` sidecar evidence. With SEC's stable S3-backed ETag (`etag: "504b124e9474334e889e9e525db95c14-184"` for `submissions.zip`, empirically unchanged across requests on 2026-05-22), an unchanged archive can be reused safely while the run-manifest is still stamped fresh.

This eliminates the wasted ~5.7 GB re-download on every bootstrap re-run when SEC hasn't rebuilt the archive.

## Security model

`_validate_archive_name()` (added under Codex 2 BLOCKING) guards every `target_dir / archive.name` join against path traversal — rejects `..`, separators, NUL, absolute paths. Defence-in-depth: today `archive.name` only comes from `build_bulk_archive_inventory` which we control, but the validator stops a future caller-supplied inventory from escaping `target_dir`.

Provenance contract: `assert_archive_belongs_to_run` now whitelists `reuse_reason` against `{"downloaded_in_run", "etag_match_sha256_verified"}` (or absent, treated as legacy default). Stale prior-run manifests still fail the `bootstrap_run_id` mismatch check because the new pre-flight always wipes the manifest up front and a fresh one is written after every run.

## Codex 2 fixes folded

- **BLOCKING**: `_validate_archive_name()` + `_resolve_archive_path()` wrappers applied at all four `target_dir / archive.name` join points (purge, preflight decision, download, post-reuse synthesis).
- **MEDIUM**: `_atomic_write_sidecar` tmp suffix is now `.tmp.<pid>` so two concurrent writers on the same archive don't clobber each other's pre-rename file.
- **LOW/MEDIUM**: `_head_size_and_type` widened to also return ETag; the resume `Range` GET now sets `If-Range: <head_etag>` so a SEC mid-download rebuild forces a 200 + full-body restart instead of appending fresh bytes onto a stale `.partial`.

## Tradeoffs

- HEAD per archive per bootstrap (~14 archives × 1 HEAD = 14 extra requests) costs ~2s against the shared 7 r/s budget. Worth it: average bootstrap reuse path drops from ~5.7 GB to 0 bytes.
- On a forced or first-run install, the HEAD is duplicative with the HEAD that `_download_one` issues. Did not consolidate — keeping the pre-flight HEAD separate from the download-time HEAD lets the pre-flight be skipped under force-mode without losing the size/type integrity check inside `_download_one`.
- `If-Range` is only honoured if the server includes a stable ETag (SEC does); falls back gracefully to plain Range if HEAD didn't carry an ETag.

## Test plan

- [x] Cold install writes `.sha256` + `.etag` sidecars + manifest provenance `downloaded_in_run`.
- [x] Re-run with unchanged SEC ETag: 0-byte reuse, manifest provenance `etag_match_sha256_verified`, no full GET fired.
- [x] Re-run with changed SEC ETag: purge + redownload, sidecars refreshed.
- [x] Local SHA mismatch (corruption): purge + redownload even if ETag matches.
- [x] Missing `.sha256` or `.etag` sidecar: defensive redownload.
- [x] `BOOTSTRAP_FORCE_REDOWNLOAD=1` set: always redownload (no HEAD even fired).
- [x] `.partial` alongside `.zip`: redownload.
- [x] HEAD without ETag header: redownload.
- [x] Stale `.run_manifest.json` from a prior run is wiped by preflight.
- [x] Stray archive not in the current inventory is cleaned (e.g. rolled-off 13F window).
- [x] Recorded-HEAD fixture (`tests/fixtures/sec_bulk_head/submissions.zip.headers.json`) replays the real SEC ETag against the reuse decision.
- [x] `_validate_archive_name` rejects `../`, separators, NUL, absolute paths.
- [x] Resume `Range` GET sends `If-Range` bound to HEAD's ETag.
- [x] Backward compatibility: manifest entries without `reuse_reason` field still pass `assert_archive_belongs_to_run`.

Gates: `uv run ruff check . && uv run ruff format --check . && uv run pyright app/services/sec_bulk_download.py tests/test_sec_bulk_etag_reuse.py tests/test_sec_bulk_download.py && uv run pytest tests/test_sec_bulk_etag_reuse.py tests/test_sec_bulk_download.py` — 60 tests pass.

Empirical smoke (2026-05-22, 23:56:39 UTC):
```
$ curl -sI -A "eBull dev@example.com" https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip
HTTP/2 200
content-type: application/zip
content-length: 1541272031
etag: "504b124e9474334e889e9e525db95c14-184"
```
Same etag still served on follow-up request with `If-None-Match` echoing the value back → `200 + full body`, confirming SEC does not honour conditional headers on bulk endpoints.

Refs #1233