### PR TITLE
feat(#1233): PR-8 — daily SEC bulk-archive refresh (ETag-conditional)

### DIFF
--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -84,6 +84,26 @@ Pattern at [app/services/institutional_holdings.py:189-220](../../../app/service
 | Insider dataset | `https://www.sec.gov/data-research/sec-markets-data/insider-transactions-data-sets` | Quarterly | All Form 3/4/5 |
 | Financial-statement dataset | `https://www.sec.gov/dera/data/financial-statement-data-sets.html` | Quarterly | XBRL extract (10-K / 10-Q) |
 
+### Daily-refresh pathways (#1233 PR-8)
+
+Bulk archives are downloaded ONCE at first-install bootstrap. After that they stale forever unless explicitly re-pulled. Three SCHEDULED_JOBS in `app/workers/scheduler.py` close the loop by HEAD-ing the SEC URL each cycle, comparing against a local `.zip.etag` sidecar, and re-downloading only on change.
+
+| Job | Archive | Cadence (UTC) | Lane | Rationale for cadence |
+|---|---|---|---|---|
+| `sec_submissions_bulk_refresh` | `submissions.zip` | Daily 08:00 | `sec_bulk_download` | After SEC's ~03:00 ET nightly rebuild has propagated |
+| `sec_companyfacts_bulk_refresh` | `companyfacts.zip` | Daily 08:30 | `sec_bulk_download` | Staggered 30 min after submissions to avoid GB-scale stream collision |
+| `sec_quarterly_datasets_bulk_refresh` | All 13F + N-PORT + insider quarterly files | Monthly day-5 06:00 | `sec_bulk_download` | After quarterly publication cycle settles (publishes typically land within first business days) |
+
+**ETag-compare contract:** Each archive has two sidecars — `<archive>.etag` (verbatim SEC ETag with quotes) and `<archive>.sha256` (hex digest of bytes on disk). Both written atomically (tmp + rename) AFTER the `.zip` itself is replaced. Missing sidecar ⇒ treat as stale ⇒ refresh.
+
+**Bootstrap fence:** Refresh job skips while `bootstrap_state.status='running'` so PR-5b's bulk-download reuse path is never raced. Skip is recorded as `job_runs.status='success' + error_msg='bootstrap_running'` (the refresh ran fine, it just had nothing to do).
+
+**Fail-closed on SEC 5xx:** HEAD or GET non-200 ⇒ skip with structured reason, local file untouched. The next fire retries. Never corrupts on-disk archives.
+
+**Implementation:** `app/services/sec_bulk_refresh.py`. Shares the `_PROCESS_RATE_LIMIT_CLOCK` + `_PROCESS_RATE_LIMIT_LOCK` rate budget with every other SEC consumer (7 req/s ceiling).
+
+**Operator-visible:** `job_runs.row_count = bytes_downloaded`. A no-op fire ⇒ `row_count=0` + no error_msg. A real change ⇒ `row_count` ≈ archive size.
+
 ### Indexes + Atom feeds
 
 | Endpoint | URL | Refresh | Use For |

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -330,6 +330,16 @@ _INVOKERS[_scheduler.JOB_FINRA_SHORT_INTEREST_REFRESH] = _adapt_zero_arg(_schedu
 # shape — zero-param manual surface; extended-window backfill via REPL.
 _INVOKERS[_scheduler.JOB_FINRA_REGSHO_DAILY_REFRESH] = _adapt_zero_arg(_scheduler.finra_regsho_daily_refresh)
 
+# #1233 PR-8 — Daily bulk-archive refresh (ETag-conditional).
+# Each invoker HEADs the SEC URL once per fire and re-downloads
+# only when the ETag has changed since the local sidecar. Lane is
+# ``sec_bulk_download`` (registered automatically via SCHEDULED_JOBS).
+_INVOKERS[_scheduler.JOB_SEC_SUBMISSIONS_BULK_REFRESH] = _adapt_zero_arg(_scheduler.sec_submissions_bulk_refresh)
+_INVOKERS[_scheduler.JOB_SEC_COMPANYFACTS_BULK_REFRESH] = _adapt_zero_arg(_scheduler.sec_companyfacts_bulk_refresh)
+_INVOKERS[_scheduler.JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH] = _adapt_zero_arg(
+    _scheduler.sec_quarterly_datasets_bulk_refresh
+)
+
 # ---------------------------------------------------------------------------
 # Bulk-archive Phase C ingester invokers (#1027 — #1020)
 # ---------------------------------------------------------------------------

--- a/app/services/sec_bulk_refresh.py
+++ b/app/services/sec_bulk_refresh.py
@@ -1,0 +1,767 @@
+"""Daily refresh adapter for SEC bulk archives (#1233 PR-8).
+
+Architectural problem
+---------------------
+SEC's bulk archives (``submissions.zip``, ``companyfacts.zip``,
+quarterly 13F / NPORT / insider datasets) are downloaded ONLY at
+bootstrap time by ``app.services.sec_bulk_download``. After initial
+install they stale forever: operator daily updates against fresh
+discovery (Atom / daily-index) miss newly-published rows that landed
+inside the bulk archives between bootstraps. Bulk-ingest stages
+(Phase C in the bootstrap orchestrator) consume those archives as if
+they were canonical — silent freshness drift across the whole bulk
+plane.
+
+PR-8 closes this loop with three SCHEDULED_JOBS — one per archive
+family — that HEAD the live SEC URL each day and re-download only
+when the server's ETag has changed since the last successful local
+copy. The HEAD is the cheap probe; the download is the rare event.
+
+Contract
+--------
+``refresh_bulk_archive_if_stale(archive_name)`` returns a
+``RefreshResult`` whose ``etag_changed`` + ``bytes_downloaded`` +
+``skipped_reason`` fields fully describe the outcome:
+
+* ``etag_changed=False`` + ``bytes_downloaded=0`` + ``skipped_reason
+  =None``: HEAD ETag matched the local sidecar; no work.
+* ``etag_changed=True`` + ``bytes_downloaded>0`` + ``skipped_reason
+  =None``: SEC published an update; new file landed atomically,
+  sidecars rewritten.
+* ``etag_changed=False`` + ``bytes_downloaded=0`` + ``skipped_reason
+  =<str>``: skipped without contacting SEC. Reasons: bootstrap in
+  flight, SEC 5xx, HEAD missing ETag, archive name unknown.
+
+The job invokers (``sec_submissions_bulk_refresh_job`` /
+``sec_companyfacts_bulk_refresh_job`` /
+``sec_quarterly_datasets_bulk_refresh_job``) sum ``bytes_downloaded``
+across the archives they cover into ``tracker.row_count`` so the
+operator can see at a glance how much was actually transferred.
+
+Sidecars
+--------
+Two sibling files per archive at ``<bulk>/``:
+
+* ``<archive>.etag``    — SEC's HEAD ETag (verbatim, including quotes).
+* ``<archive>.sha256``  — SHA-256 hex digest of the local archive bytes.
+
+Both are written atomically (tmp + ``Path.replace``) AFTER the
+``.zip`` rename so a crash mid-write never leaves a sidecar
+referencing a partial download. On read, a missing or unreadable
+sidecar means "treat as stale" — the next refresh re-downloads
+and rebuilds the sidecar pair.
+
+Bootstrap fence
+---------------
+While ``bootstrap_state.status='running'`` the orchestrator's
+own bulk-download stage may be re-writing the same files. PR-5b's
+reuse path expects the sidecars to be stable mid-bootstrap, so
+this refresh adapter SKIPS while bootstrap is in flight rather
+than racing it. The fence is a single SELECT against the
+singleton row; no advisory lock is held.
+
+Rate limit
+----------
+HEAD + GET acquire from the shared
+``_PROCESS_RATE_LIMIT_CLOCK`` / ``_PROCESS_RATE_LIMIT_LOCK`` budget
+(7 req/s ceiling — same as ``sec_bulk_download``). The daily
+cadence + small HEAD payload means the typical fire spends ~1 budget
+slot; the rare changed-archive fire spends a stream's worth of
+GETs that count fully against SEC's per-IP budget.
+
+Fail-closed
+-----------
+* SEC 5xx on HEAD or GET → return ``skipped_reason`` (do NOT raise).
+  The local file is left untouched; the next fire retries.
+* HEAD has no ``ETag`` header → return ``skipped_reason="head_missing_etag"``.
+  Falling back to size-only compare is intentionally NOT done — SEC's
+  ETag is the contractual freshness signal; without it we have no
+  cheap way to tell stale from current.
+* GET returns non-200 / size mismatch / ZIP corrupt → keep the OLD
+  archive on disk and return ``skipped_reason``.
+* Bootstrap is running → ``skipped_reason="bootstrap_running"``.
+
+The operator-visible outcome of a skip is a ``job_runs`` row with
+``status='success'`` (the refresh itself ran fine), ``row_count=0``,
+and ``error_msg=<skipped_reason>`` so the admin UI surfaces the
+skip cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Final
+
+import httpx
+import psycopg
+
+from app.config import settings
+from app.security.master_key import resolve_data_dir
+from app.services.sec_bulk_download import (
+    BulkArchive,
+    _classify_content_type,
+    _has_zip_magic,
+    _make_client,
+    _zip_round_trip,
+    build_bulk_archive_inventory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    """Outcome of refreshing one archive.
+
+    Exactly one of these three combinations holds:
+
+    * ``etag_changed=True``  → ``bytes_downloaded > 0``, ``skipped_reason is None``.
+      A new copy landed; sidecars were rewritten.
+    * ``etag_changed=False`` + ``skipped_reason is None``:
+      HEAD ETag matched local sidecar; no transfer.
+    * ``skipped_reason is not None``:
+      skipped — bootstrap running, SEC error, HEAD missing ETag,
+      unknown archive_name, or archive currently absent from disk.
+      ``etag_changed=False`` and ``bytes_downloaded=0`` in this case.
+    """
+
+    archive_name: str
+    etag_changed: bool
+    bytes_downloaded: int
+    skipped_reason: str | None
+
+
+# ---------------------------------------------------------------------------
+# Sidecar helpers
+# ---------------------------------------------------------------------------
+
+
+SIDECAR_ETAG_SUFFIX: Final[str] = ".etag"
+SIDECAR_SHA256_SUFFIX: Final[str] = ".sha256"
+
+# SEC 5xx is the canonical "back off" signal; treat 4xx the same way
+# (4xx on a URL we control is operator-visible misconfiguration —
+# log loudly and skip, do not delete the local file).
+_TRANSIENT_HTTP_STATUSES: Final[tuple[int, ...]] = (
+    429,
+    500,
+    502,
+    503,
+    504,
+)
+
+
+def _etag_sidecar_path(archive_path: Path) -> Path:
+    return archive_path.with_name(archive_path.name + SIDECAR_ETAG_SUFFIX)
+
+
+def _sha256_sidecar_path(archive_path: Path) -> Path:
+    return archive_path.with_name(archive_path.name + SIDECAR_SHA256_SUFFIX)
+
+
+def _read_local_etag(archive_path: Path) -> str | None:
+    """Return the recorded ETag for ``archive_path`` or ``None``.
+
+    Returns ``None`` if the sidecar is missing, unreadable, or empty.
+    A missing sidecar means "treat as stale" — the refresh will
+    re-download and recreate it.
+    """
+    sidecar = _etag_sidecar_path(archive_path)
+    if not sidecar.exists():
+        return None
+    try:
+        content = sidecar.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        logger.warning("sec_bulk_refresh: unreadable etag sidecar at %s: %s", sidecar, exc)
+        return None
+    return content or None
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` via a sibling tempfile + rename.
+
+    Sidecars MUST be atomic: a crash mid-write that leaves a partial
+    ``.etag`` would make the next refresh skip a real update because
+    the truncated text won't equal SEC's full ETag (and we'd hit the
+    download path anyway — atomicity is belt-and-braces against
+    pathological half-states where the partial happens to be a prefix
+    of the live value).
+    """
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(path)
+
+
+def _compute_sha256(archive_path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    """Return the SHA-256 hex digest of the file at ``archive_path``.
+
+    Streamed in 1 MB chunks so a 1.5 GB ``submissions.zip`` does not
+    blow the process RSS. Caller is responsible for ensuring the
+    file exists.
+    """
+    hasher = hashlib.sha256()
+    with archive_path.open("rb") as fh:
+        while True:
+            chunk = fh.read(chunk_size)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap fence
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_running(conn: psycopg.Connection) -> bool:
+    """Return True if ``bootstrap_state.status='running'``.
+
+    A True result means PR-5b's bulk-download reuse path is or may
+    be writing to the same archives; the daily refresh must defer.
+    Defense-in-depth: also returns True if the row is missing (the
+    fail-closed direction).
+    """
+    row = conn.execute("SELECT status FROM bootstrap_state WHERE id = 1").fetchone()
+    if row is None:
+        # Fail closed — missing singleton is operator-visible elsewhere
+        # (ensure_bootstrap_state_singleton on boot); we refuse to race
+        # rather than guess.
+        return True
+    return str(row[0]) == "running"
+
+
+# ---------------------------------------------------------------------------
+# Archive name registry
+# ---------------------------------------------------------------------------
+
+
+_SUBMISSIONS_NAME: Final[str] = "submissions.zip"
+_COMPANYFACTS_NAME: Final[str] = "companyfacts.zip"
+
+
+def _archive_for_name(archive_name: str, *, today: date | None = None) -> BulkArchive | None:
+    """Return the ``BulkArchive`` for ``archive_name`` or ``None``.
+
+    The quarterly archives (form13f_*, insider_*, nport_*) are looked
+    up against the live inventory builder so the daily refresh always
+    targets the SAME files the bootstrap downloader would write. Any
+    drift between the two URL maps would let one job re-download
+    something the other treats as canonical.
+
+    ``today`` is forwarded so tests can pin the quarterly window
+    deterministically.
+    """
+    if archive_name == _SUBMISSIONS_NAME:
+        return BulkArchive(
+            name=_SUBMISSIONS_NAME,
+            url=f"https://www.sec.gov/Archives/edgar/daily-index/bulkdata/{_SUBMISSIONS_NAME}",
+        )
+    if archive_name == _COMPANYFACTS_NAME:
+        return BulkArchive(
+            name=_COMPANYFACTS_NAME,
+            url=f"https://www.sec.gov/Archives/edgar/daily-index/xbrl/{_COMPANYFACTS_NAME}",
+        )
+    inventory = build_bulk_archive_inventory(today=today)
+    for archive in inventory:
+        if archive.name == archive_name:
+            return archive
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Async core
+# ---------------------------------------------------------------------------
+
+
+def _resolve_target_dir() -> Path:
+    """Return the bulk-archives directory used by ``sec_bulk_download``."""
+    return resolve_data_dir() / "sec" / "bulk"
+
+
+async def _refresh_one_async(
+    *,
+    archive: BulkArchive,
+    target_dir: Path,
+    user_agent: str,
+) -> RefreshResult:
+    """HEAD + conditional download for one archive.
+
+    Returns a ``RefreshResult``; never raises on SEC HTTP errors —
+    they are captured into ``skipped_reason`` so a single transient
+    blip doesn't poison the whole job_run.
+    """
+    archive_path = target_dir / archive.name
+    local_etag = _read_local_etag(archive_path)
+
+    # Lazy import to avoid pulling sec_edgar (heavy) at module load.
+    from app.providers.implementations.sec_edgar import (
+        _PROCESS_RATE_LIMIT_CLOCK,
+        _PROCESS_RATE_LIMIT_LOCK,
+    )
+    from app.services.sec_pipelined_fetcher import _AsyncRateLimiter
+
+    rate_limiter = _AsyncRateLimiter(
+        target_rps=7.0,
+        shared_clock=_PROCESS_RATE_LIMIT_CLOCK,
+        shared_lock=_PROCESS_RATE_LIMIT_LOCK,
+    )
+
+    async with _make_client(user_agent) as client:
+        # HEAD probe ------------------------------------------------------
+        await rate_limiter.acquire()
+        try:
+            head = await client.head(archive.url)
+        except httpx.HTTPError as exc:
+            logger.warning("sec_bulk_refresh HEAD failed for %s: %s", archive.name, exc)
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason=f"head_transport_error: {type(exc).__name__}",
+            )
+
+        if head.status_code in _TRANSIENT_HTTP_STATUSES:
+            logger.warning(
+                "sec_bulk_refresh HEAD got %d for %s — skipping (will retry next fire)",
+                head.status_code,
+                archive.name,
+            )
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason=f"head_status_{head.status_code}",
+            )
+        if head.status_code != 200:
+            logger.error(
+                "sec_bulk_refresh HEAD got unexpected %d for %s",
+                head.status_code,
+                archive.name,
+            )
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason=f"head_status_{head.status_code}",
+            )
+
+        remote_etag = head.headers.get("etag")
+        if not remote_etag:
+            logger.warning("sec_bulk_refresh: %s HEAD response has no ETag header", archive.name)
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason="head_missing_etag",
+            )
+
+        content_type = (head.headers.get("content-type") or "").lower()
+        if _classify_content_type(content_type) == "bad":
+            logger.warning(
+                "sec_bulk_refresh: %s HEAD Content-Type=%r is not an archive — skipping",
+                archive.name,
+                content_type,
+            )
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason=f"head_bad_content_type: {content_type}",
+            )
+
+        content_length_raw = head.headers.get("content-length")
+        if content_length_raw is None:
+            logger.warning("sec_bulk_refresh: %s HEAD response missing Content-Length", archive.name)
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason="head_missing_content_length",
+            )
+        try:
+            expected_total = int(content_length_raw)
+        except ValueError:
+            logger.warning(
+                "sec_bulk_refresh: %s HEAD Content-Length=%r is not an integer",
+                archive.name,
+                content_length_raw,
+            )
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason="head_bad_content_length",
+            )
+
+        # Fast-path: ETag match AND we have a local file that
+        # round-trips. The round-trip is cheap (zipfile.ZipFile reads
+        # the central directory only) and catches the case where the
+        # ETag sidecar survived a crash that corrupted the archive.
+        if (
+            local_etag is not None
+            and local_etag == remote_etag
+            and archive_path.exists()
+            and _zip_round_trip(archive_path)
+        ):
+            logger.info(
+                "sec_bulk_refresh: %s fresh (etag=%s) — no transfer",
+                archive.name,
+                remote_etag,
+            )
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason=None,
+            )
+
+        # Seed-on-first-encounter: bootstrap downloader (sec_bulk_download)
+        # currently writes only the ``.zip`` itself — no ETag sidecar.
+        # PR-5b is in flight and will eventually do the sidecar write,
+        # but until then the FIRST refresh fire after install would see
+        # no sidecar and re-download the multi-GB archive even though
+        # the disk copy is fine. Detect this case and adopt the live
+        # HEAD ETag as the sidecar value, transferring zero bytes.
+        # Verified by: HEAD Content-Length must match local size AND the
+        # local ZIP must round-trip. If either fails we fall through to
+        # the slow path (a genuine re-download).
+        if (
+            local_etag is None
+            and archive_path.exists()
+            and archive_path.stat().st_size == expected_total
+            and _zip_round_trip(archive_path)
+        ):
+            sha256_hex = _compute_sha256(archive_path)
+            _atomic_write_text(_etag_sidecar_path(archive_path), remote_etag)
+            _atomic_write_text(_sha256_sidecar_path(archive_path), sha256_hex)
+            logger.info(
+                "sec_bulk_refresh: %s seeded sidecars from live HEAD (etag=%s sha256=%s size=%d) — no transfer",
+                archive.name,
+                remote_etag,
+                sha256_hex,
+                expected_total,
+            )
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason=None,
+            )
+
+        # Slow-path: stream the new copy to a sibling tempfile,
+        # validate ZIP integrity, then atomic-rename + write sidecars.
+        await rate_limiter.acquire()
+        partial_path = archive_path.with_name(archive_path.name + ".refresh.partial")
+        # Clear any partial from a prior failed refresh — we always
+        # restart fresh on the refresh path (the bootstrap downloader's
+        # resume logic is for the bootstrap budget; the daily refresh
+        # is a single-shot whole-archive re-pull).
+        if partial_path.exists():
+            try:
+                partial_path.unlink()
+            except OSError as exc:
+                logger.warning("sec_bulk_refresh: could not clear stale partial %s: %s", partial_path, exc)
+
+        bytes_written = 0
+        get_etag: str | None = None
+        try:
+            async with client.stream("GET", archive.url) as response:
+                if response.status_code in _TRANSIENT_HTTP_STATUSES:
+                    logger.warning(
+                        "sec_bulk_refresh GET got %d for %s — skipping (local file untouched)",
+                        response.status_code,
+                        archive.name,
+                    )
+                    return RefreshResult(
+                        archive_name=archive.name,
+                        etag_changed=False,
+                        bytes_downloaded=0,
+                        skipped_reason=f"get_status_{response.status_code}",
+                    )
+                if response.status_code != 200:
+                    logger.error(
+                        "sec_bulk_refresh GET got unexpected %d for %s",
+                        response.status_code,
+                        archive.name,
+                    )
+                    return RefreshResult(
+                        archive_name=archive.name,
+                        etag_changed=False,
+                        bytes_downloaded=0,
+                        skipped_reason=f"get_status_{response.status_code}",
+                    )
+
+                # Capture the GET response's ETag header BEFORE streaming
+                # so we can detect a CDN race where HEAD returns version
+                # A's ETag but GET serves version B's bytes (different
+                # ETag). Without this check, the post-rename sidecar would
+                # falsely advertise A's ETag against B's bytes and the
+                # next HEAD-match fast-path would wrongly skip future
+                # real updates.
+                get_etag = response.headers.get("etag")
+
+                with partial_path.open("wb") as fh:
+                    async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
+                        fh.write(chunk)
+                        bytes_written += len(chunk)
+        except (httpx.HTTPError, OSError) as exc:
+            logger.warning("sec_bulk_refresh GET transport failure for %s: %s", archive.name, exc)
+            # Discard partial; local file unaffected.
+            if partial_path.exists():
+                try:
+                    partial_path.unlink()
+                except OSError:
+                    pass
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason=f"get_transport_error: {type(exc).__name__}",
+            )
+
+        # Post-transfer integrity checks. ANY failure leaves the
+        # local archive on disk untouched — we discard the partial
+        # and skip.
+        if bytes_written != expected_total:
+            logger.error(
+                "sec_bulk_refresh: %s size mismatch — got %d, expected %d",
+                archive.name,
+                bytes_written,
+                expected_total,
+            )
+            try:
+                partial_path.unlink()
+            except OSError:
+                pass
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason="get_size_mismatch",
+            )
+
+        if not _has_zip_magic(partial_path):
+            logger.error("sec_bulk_refresh: %s downloaded content lacks ZIP magic", archive.name)
+            try:
+                partial_path.unlink()
+            except OSError:
+                pass
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason="get_no_zip_magic",
+            )
+
+        if not _zip_round_trip(partial_path):
+            logger.error("sec_bulk_refresh: %s ZIP round-trip failed", archive.name)
+            try:
+                partial_path.unlink()
+            except OSError:
+                pass
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason="get_zip_corrupt",
+            )
+
+        # CDN-race check: HEAD said version A, GET served version B.
+        # If the GET response carries an ETag and it disagrees with the
+        # HEAD ETag, we got bytes from a different version than what
+        # we'd record in the sidecar. Skip; the next fire will HEAD
+        # again and either see the new version stably or pick up the
+        # original. We do NOT proceed to overwrite the local file
+        # because doing so would let a stale sidecar's ETag (the HEAD
+        # ETag we'd write) misclassify the new bytes as "old version"
+        # forever. Missing GET ETag is tolerated — SEC's CDN does
+        # return one in practice (verified 2026-05-22) but absence
+        # alone shouldn't poison the path.
+        if get_etag is not None and get_etag != remote_etag:
+            logger.warning(
+                "sec_bulk_refresh: %s CDN race detected — HEAD etag=%s "
+                "GET etag=%s — discarding partial, retrying next fire",
+                archive.name,
+                remote_etag,
+                get_etag,
+            )
+            try:
+                partial_path.unlink()
+            except OSError:
+                pass
+            return RefreshResult(
+                archive_name=archive.name,
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason="get_etag_mismatch_with_head",
+            )
+
+        # Compute SHA-256 BEFORE the rename so the sidecar describes
+        # exactly the bytes that landed at archive_path.
+        sha256_hex = _compute_sha256(partial_path)
+
+        # ETag to record: prefer the GET response ETag (describes
+        # exactly the bytes we kept); fall back to HEAD when GET
+        # didn't supply one. Both agree at this point (mismatch was
+        # already returned above).
+        recorded_etag = get_etag or remote_etag
+
+        # Atomic rename — moves the validated copy into the canonical
+        # path, replacing any existing archive. Sidecars follow.
+        partial_path.replace(archive_path)
+        _atomic_write_text(_etag_sidecar_path(archive_path), recorded_etag)
+        _atomic_write_text(_sha256_sidecar_path(archive_path), sha256_hex)
+
+        logger.info(
+            "sec_bulk_refresh: %s updated — old_etag=%s new_etag=%s bytes=%d sha256=%s",
+            archive.name,
+            local_etag,
+            recorded_etag,
+            bytes_written,
+            sha256_hex,
+        )
+        return RefreshResult(
+            archive_name=archive.name,
+            etag_changed=True,
+            bytes_downloaded=bytes_written,
+            skipped_reason=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint (sync)
+# ---------------------------------------------------------------------------
+
+
+def refresh_bulk_archive_if_stale(archive_name: str) -> RefreshResult:
+    """HEAD the SEC URL for ``archive_name`` and re-download if changed.
+
+    Side effects, on a successful change:
+
+    * Writes ``<bulk>/<archive_name>`` (replacing the old copy via
+      atomic rename).
+    * Writes ``<bulk>/<archive_name>.etag`` (verbatim SEC ETag).
+    * Writes ``<bulk>/<archive_name>.sha256`` (hex digest of the
+      bytes that landed).
+
+    On any skip path the local archive + sidecars are untouched.
+
+    The function reads ``settings.sec_user_agent`` and
+    ``app.security.master_key.resolve_data_dir()`` directly so the
+    scheduled-job invokers can dispatch with no parameters.
+    """
+    target_dir = _resolve_target_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    archive = _archive_for_name(archive_name)
+    if archive is None:
+        logger.error("sec_bulk_refresh: unknown archive_name=%r — registry drift", archive_name)
+        return RefreshResult(
+            archive_name=archive_name,
+            etag_changed=False,
+            bytes_downloaded=0,
+            skipped_reason="unknown_archive_name",
+        )
+
+    # Bootstrap fence — open a fresh autocommit conn so the SELECT is
+    # not nested in any outer transaction held by the job runtime.
+    try:
+        with psycopg.connect(settings.database_url, autocommit=True) as conn:
+            if _bootstrap_running(conn):
+                logger.info(
+                    "sec_bulk_refresh: %s skipped — bootstrap_state.status='running'",
+                    archive_name,
+                )
+                return RefreshResult(
+                    archive_name=archive_name,
+                    etag_changed=False,
+                    bytes_downloaded=0,
+                    skipped_reason="bootstrap_running",
+                )
+    except psycopg.Error as exc:
+        # DB unreachable is a deployment-level failure; we don't
+        # want to hammer SEC while the DB is sick. Skip the fire and
+        # surface the reason.
+        logger.warning("sec_bulk_refresh: bootstrap_state probe failed: %s", exc)
+        return RefreshResult(
+            archive_name=archive_name,
+            etag_changed=False,
+            bytes_downloaded=0,
+            skipped_reason="bootstrap_state_probe_failed",
+        )
+
+    return asyncio.run(
+        _refresh_one_async(
+            archive=archive,
+            target_dir=target_dir,
+            user_agent=settings.sec_user_agent,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Archive-set helpers — declared here so the scheduler invokers
+# stay one-liners and the set membership is testable.
+# ---------------------------------------------------------------------------
+
+
+def _submissions_archive_names() -> tuple[str, ...]:
+    return (_SUBMISSIONS_NAME,)
+
+
+def _companyfacts_archive_names() -> tuple[str, ...]:
+    return (_COMPANYFACTS_NAME,)
+
+
+def _quarterly_dataset_archive_names(*, today: date | None = None) -> tuple[str, ...]:
+    """Return the quarterly-dataset archive names (13F + insider + NPORT).
+
+    Pulled from ``build_bulk_archive_inventory`` so the quarterly
+    refresh job targets the same files the bootstrap downloader
+    would.  ``today`` is honored for deterministic tests.
+    """
+    return tuple(
+        archive.name
+        for archive in build_bulk_archive_inventory(today=today)
+        if archive.name not in (_SUBMISSIONS_NAME, _COMPANYFACTS_NAME)
+    )
+
+
+def refresh_archive_set(archive_names: Sequence[str]) -> list[RefreshResult]:
+    """Refresh every archive in ``archive_names`` sequentially.
+
+    Sequential — not concurrent — for two reasons:
+
+    1. The shared rate limiter would queue them anyway; ``asyncio.run``
+       per archive simplifies error containment.
+    2. A bootstrap-in-flight skip on the first archive is the same
+       answer for every subsequent archive — we still pay one HEAD
+       per archive on a non-fenced fire, but the operator-visible
+       row_count and the job runtime are simpler.
+
+    The caller wraps this in ``_tracked_job`` and sums
+    ``bytes_downloaded`` into ``row_count``.
+    """
+    results: list[RefreshResult] = []
+    for name in archive_names:
+        results.append(refresh_bulk_archive_if_stale(name))
+    return results
+
+
+__all__ = [
+    "RefreshResult",
+    "refresh_archive_set",
+    "refresh_bulk_archive_if_stale",
+]

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -338,6 +338,18 @@ JOB_SEC_REBUILD = "sec_rebuild"
 JOB_FINRA_SHORT_INTEREST_REFRESH = "finra_short_interest_refresh"
 JOB_FINRA_REGSHO_DAILY_REFRESH = "finra_regsho_daily_refresh"
 
+# #1233 PR-8 — Daily bulk-archive refresh (ETag-conditional).
+# Closes the post-bootstrap freshness drift: bulk archives are
+# downloaded ONLY at bootstrap time today, then stale forever.
+# Each invoker HEADs the SEC URL, compares against the local
+# ``.zip.etag`` sidecar, and re-downloads only when changed.
+# Bootstrap-fenced — skips while ``bootstrap_state.status='running'``.
+# Lane = ``sec_bulk_download`` (disjoint from sec_rate by host
+# resource profile — these are large fixed-URL downloads).
+JOB_SEC_SUBMISSIONS_BULK_REFRESH = "sec_submissions_bulk_refresh"
+JOB_SEC_COMPANYFACTS_BULK_REFRESH = "sec_companyfacts_bulk_refresh"
+JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH = "sec_quarterly_datasets_bulk_refresh"
+
 # ---------------------------------------------------------------------------
 # Prerequisite checks
 # ---------------------------------------------------------------------------
@@ -1180,6 +1192,84 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
     ),
+    # -- #1233 PR-8 — Daily bulk-archive refresh (ETag-conditional) -------
+    # All three target the same ``sec_bulk_download`` Lane so they
+    # serialise behind the bootstrap downloader and behind each other
+    # — the shared SEC per-IP budget is honoured by the rate limiter
+    # inside ``refresh_bulk_archive_if_stale`` regardless.
+    #
+    # Cron schedules cluster post-SEC's nightly publish window (~03:00
+    # ET / 07:00-08:00 UTC) so HEAD races are minimal and a fresh ETag
+    # is available when the job fires.
+    ScheduledJob(
+        name=JOB_SEC_SUBMISSIONS_BULK_REFRESH,
+        display_name="SEC submissions.zip daily refresh",
+        source="sec_bulk_download",
+        description=(
+            "#1233 PR-8 — HEAD the SEC ``submissions.zip`` archive "
+            "daily and re-download only when the server ETag has "
+            "changed since the local sidecar. Closes the post-"
+            "bootstrap freshness drift on the bulk plane. Daily 08:00 "
+            "UTC lands ~1 h after SEC's 03:00 ET nightly rebuild. "
+            "Skips silently while a bootstrap is running so PR-5b's "
+            "reuse path is not raced. Skips on SEC 5xx + on missing "
+            "ETag header — local file is never corrupted. Most fires "
+            "transfer zero bytes; only when SEC re-publishes does the "
+            "full ~1.5 GB stream."
+        ),
+        cadence=Cadence.daily(hour=8, minute=0),
+        # No catch-up on boot — a missed 08:00 window naturally rolls
+        # forward to the next day. Catching up on every dev-stack
+        # restart could trigger a ~1.5 GB transfer on the boot path,
+        # which violates the "bounded cost per fire" criterion of the
+        # universal-gate carve-out and would burn SEC bandwidth on
+        # operator workflow steps that don't need it.
+        catch_up_on_boot=False,
+        # Gated by the standard bootstrap-complete prerequisite so the
+        # job stays quiet during first-install — the body's own
+        # ``bootstrap_running`` fence is belt-and-braces for the case
+        # where an operator re-runs bootstrap after first-install
+        # already finished (status flips from ``complete`` →
+        # ``running``).
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_COMPANYFACTS_BULK_REFRESH,
+        display_name="SEC companyfacts.zip daily refresh",
+        source="sec_bulk_download",
+        description=(
+            "#1233 PR-8 — HEAD the SEC ``companyfacts.zip`` archive "
+            "daily and re-download on ETag change. Daily 08:30 UTC "
+            "staggers 30 min after the submissions refresh so the two "
+            "potential ~1.4-1.5 GB transfers don't share the SEC "
+            "stream budget. Same bootstrap fence + skip semantics as "
+            "the submissions job."
+        ),
+        cadence=Cadence.daily(hour=8, minute=30),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH,
+        display_name="SEC quarterly datasets bulk refresh",
+        source="sec_bulk_download",
+        description=(
+            "#1233 PR-8 — HEAD every quarterly SEC dataset archive "
+            "(Form 13F rolling windows + Insider Transactions + "
+            "Form N-PORT) and re-download those whose ETag changed. "
+            "Monthly on the 5th at 06:00 UTC — after SEC's quarterly "
+            "publication cycle has settled (publishes typically land "
+            "within the first few business days of each new quarter; "
+            "the 5th gives the catalogue time to stabilise before we "
+            "probe). Same bootstrap fence + per-archive skip "
+            "semantics. Most months no quarterly archive will have "
+            "changed and the job transfers zero bytes — the HEADs are "
+            "the only SEC traffic."
+        ),
+        cadence=Cadence.monthly(day=5, hour=6, minute=0),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
     ScheduledJob(
         name=JOB_SEC_MANIFEST_TOMBSTONE_STALE,
         display_name="Manifest stale-failed sweep",
@@ -1339,6 +1429,7 @@ def _tracked_job(job_name: str) -> Generator[_JobTracker]:
                         tracker.run_id,
                         status="success",
                         row_count=tracker.row_count,
+                        error_msg=tracker.note,
                     )
                     if tracker.row_count is not None:
                         spike = check_row_count_spike(
@@ -1392,6 +1483,7 @@ def _tracked_job(job_name: str) -> Generator[_JobTracker]:
                     tracker.run_id,
                     status="success",
                     row_count=tracker.row_count,
+                    error_msg=tracker.note,
                 )
                 # Check for row-count spikes after recording the successful run.
                 # Exclude the current run_id so we compare against the *previous*
@@ -1405,12 +1497,21 @@ def _tracked_job(job_name: str) -> Generator[_JobTracker]:
 
 
 class _JobTracker:
-    """Mutable bag passed into the tracked_job context so the caller can set row_count."""
+    """Mutable bag passed into the tracked_job context so the caller can set row_count.
+
+    ``note`` — optional operator-visible string forwarded to
+    ``job_runs.error_msg`` on the SUCCESS path. Use it for soft-skip
+    digests (e.g. "bootstrap_running" or "all archives fresh") where
+    the body ran cleanly but the operator should know nothing happened.
+    Leaving it ``None`` records the success row with NULL error_msg
+    (the historical contract).
+    """
 
     def __init__(self, job_name: str) -> None:
         self.job_name = job_name
         self.run_id: int = 0
         self.row_count: int | None = None
+        self.note: str | None = None
 
 
 def _load_etoro_credentials(job_name: str) -> tuple[str, str] | None:
@@ -3959,6 +4060,96 @@ def sec_manifest_tombstone_stale() -> None:
             result.rows_skipped_transient,
             result.rows_skipped_race,
         )
+
+
+def _record_bulk_refresh_outcome(
+    tracker: _JobTracker,
+    results: list,  # list[RefreshResult] — annotation lazy to avoid import
+    *,
+    job_name: str,
+) -> None:
+    """Translate a list of ``RefreshResult`` into tracker state + a
+    single operator-visible log line.
+
+    Convention (per spec):
+      * ``row_count``  = total bytes downloaded across the archive set.
+      * ``tracker.note`` = a comma-joined ``name:reason`` digest when
+        ANY archive was skipped; ``None`` when every archive's outcome
+        was either a no-op or a fresh download. ``_tracked_job``
+        forwards ``tracker.note`` to ``job_runs.error_msg`` on the
+        SUCCESS path so a bootstrap-fence / SEC-5xx / missing-ETag
+        skip is operator-visible in the admin UI without raising
+        (the refresh itself ran fine, it just had nothing to do).
+
+    The function intentionally does NOT raise on a per-archive
+    skip — partial-success is the contractual mode for the quarterly
+    job (one 13F window can be stale while the others are fresh).
+    """
+    total_bytes = sum(r.bytes_downloaded for r in results)
+    tracker.row_count = total_bytes
+
+    skip_digest = ", ".join(f"{r.archive_name}:{r.skipped_reason}" for r in results if r.skipped_reason is not None)
+    if skip_digest:
+        tracker.note = skip_digest
+
+    changed = [r.archive_name for r in results if r.etag_changed]
+    fresh = [r.archive_name for r in results if not r.etag_changed and r.skipped_reason is None]
+    skipped = [r.archive_name for r in results if r.skipped_reason is not None]
+
+    logger.info(
+        "%s: changed=%s fresh_noop=%s skipped=%s bytes_downloaded=%d skip_digest=%s",
+        job_name,
+        changed,
+        fresh,
+        skipped,
+        total_bytes,
+        skip_digest or "-",
+    )
+
+
+def sec_submissions_bulk_refresh() -> None:
+    """#1233 PR-8 — Daily refresh of ``submissions.zip``.
+
+    HEADs the SEC URL once, compares ETag against the local sidecar,
+    re-downloads only when changed. Bootstrap-fenced inside
+    ``refresh_bulk_archive_if_stale`` so PR-5b's reuse path is not
+    raced.
+
+    Records ``tracker.row_count = bytes_downloaded`` so the operator
+    can see at a glance whether any transfer occurred. A no-op fire
+    (ETag match) records ``row_count=0`` with no error_msg — the
+    operator UI surfaces this as a clean SUCCESS.
+    """
+    from app.services.sec_bulk_refresh import _submissions_archive_names, refresh_archive_set
+
+    with _tracked_job(JOB_SEC_SUBMISSIONS_BULK_REFRESH) as tracker:
+        results = refresh_archive_set(_submissions_archive_names())
+        _record_bulk_refresh_outcome(tracker, results, job_name=JOB_SEC_SUBMISSIONS_BULK_REFRESH)
+
+
+def sec_companyfacts_bulk_refresh() -> None:
+    """#1233 PR-8 — Daily refresh of ``companyfacts.zip``."""
+    from app.services.sec_bulk_refresh import _companyfacts_archive_names, refresh_archive_set
+
+    with _tracked_job(JOB_SEC_COMPANYFACTS_BULK_REFRESH) as tracker:
+        results = refresh_archive_set(_companyfacts_archive_names())
+        _record_bulk_refresh_outcome(tracker, results, job_name=JOB_SEC_COMPANYFACTS_BULK_REFRESH)
+
+
+def sec_quarterly_datasets_bulk_refresh() -> None:
+    """#1233 PR-8 — Monthly refresh of quarterly bulk datasets.
+
+    Covers Form 13F rolling-window archives + Insider Transactions
+    quarterly archives + Form N-PORT quarterly archives. The exact
+    file set is computed from ``build_bulk_archive_inventory`` so
+    the refresh job targets the same files the bootstrap downloader
+    would write.
+    """
+    from app.services.sec_bulk_refresh import _quarterly_dataset_archive_names, refresh_archive_set
+
+    with _tracked_job(JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH) as tracker:
+        results = refresh_archive_set(_quarterly_dataset_archive_names())
+        _record_bulk_refresh_outcome(tracker, results, job_name=JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH)
 
 
 def sec_business_summary_bootstrap() -> None:

--- a/tests/test_sec_bulk_refresh.py
+++ b/tests/test_sec_bulk_refresh.py
@@ -1,0 +1,855 @@
+"""Tests for the SEC bulk-archive daily refresh adapter (#1233 PR-8)."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+import app.services.sec_bulk_refresh as refresh_mod
+from app.services.sec_bulk_download import BulkArchive
+from app.services.sec_bulk_refresh import (
+    _COMPANYFACTS_NAME,
+    _SUBMISSIONS_NAME,
+    RefreshResult,
+    _archive_for_name,
+    _atomic_write_text,
+    _bootstrap_running,
+    _companyfacts_archive_names,
+    _compute_sha256,
+    _etag_sidecar_path,
+    _quarterly_dataset_archive_names,
+    _read_local_etag,
+    _refresh_one_async,
+    _sha256_sidecar_path,
+    _submissions_archive_names,
+    refresh_bulk_archive_if_stale,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _zip_bytes(payload: bytes = b"{}") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("CIK0000320193.json", payload)
+    return buf.getvalue()
+
+
+def _make_handler(
+    *,
+    archive_url: str,
+    archive_body: bytes,
+    etag: str,
+    head_status: int = 200,
+    get_status: int = 200,
+    include_etag: bool = True,
+    include_content_length: bool = True,
+    content_type: str = "application/zip",
+    get_etag: str | None = None,
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Return a MockTransport handler with controllable HEAD + GET behaviour.
+
+    ``get_etag`` (when set) overrides the GET response's ETag header
+    independent of the HEAD ETag — exercises the CDN-race detection
+    path. Defaults to ``etag`` so HEAD/GET agree by default.
+    """
+    effective_get_etag = etag if get_etag is None else get_etag
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) != archive_url:
+            return httpx.Response(404)
+        if request.method == "HEAD":
+            if head_status != 200:
+                return httpx.Response(head_status)
+            headers: dict[str, str] = {"Content-Type": content_type}
+            if include_content_length:
+                headers["Content-Length"] = str(len(archive_body))
+            if include_etag:
+                headers["ETag"] = etag
+            return httpx.Response(200, headers=headers)
+        if request.method == "GET":
+            if get_status != 200:
+                return httpx.Response(get_status)
+            return httpx.Response(
+                200,
+                content=archive_body,
+                headers={
+                    "Content-Length": str(len(archive_body)),
+                    "ETag": effective_get_etag,
+                },
+            )
+        return httpx.Response(405)
+
+    return handler
+
+
+@asynccontextmanager
+async def _patched_make_client(
+    transport: httpx.MockTransport,
+) -> AsyncIterator[None]:
+    """Yield an httpx.AsyncClient over ``transport`` and patch the module-
+    level ``_make_client`` factory in ``sec_bulk_refresh`` to use it."""
+
+    @asynccontextmanager
+    async def _factory(user_agent: str) -> AsyncIterator[httpx.AsyncClient]:
+        async with httpx.AsyncClient(
+            transport=transport,
+            headers={"User-Agent": user_agent, "Accept": "application/zip,*/*"},
+        ) as client:
+            yield client
+
+    orig = refresh_mod._make_client
+    refresh_mod._make_client = _factory  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        refresh_mod._make_client = orig  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Archive lookup
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveLookup:
+    def test_submissions_lookup_returns_known_url(self) -> None:
+        archive = _archive_for_name(_SUBMISSIONS_NAME)
+        assert archive is not None
+        assert archive.name == _SUBMISSIONS_NAME
+        assert archive.url.endswith("/Archives/edgar/daily-index/bulkdata/submissions.zip")
+
+    def test_companyfacts_lookup_returns_known_url(self) -> None:
+        archive = _archive_for_name(_COMPANYFACTS_NAME)
+        assert archive is not None
+        assert archive.name == _COMPANYFACTS_NAME
+        assert archive.url.endswith("/Archives/edgar/daily-index/xbrl/companyfacts.zip")
+
+    def test_quarterly_archive_lookup_uses_inventory(self) -> None:
+        # Pick a known-shape quarterly name from the inventory builder.
+        names = _quarterly_dataset_archive_names()
+        assert names, "quarterly inventory must be non-empty"
+        first = names[0]
+        archive = _archive_for_name(first)
+        assert archive is not None
+        assert archive.name == first
+
+    def test_unknown_archive_returns_none(self) -> None:
+        assert _archive_for_name("not_a_real_archive.zip") is None
+
+
+# ---------------------------------------------------------------------------
+# Sidecar helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSidecars:
+    def test_atomic_write_replaces_existing(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.etag"
+        _atomic_write_text(target, "first")
+        assert target.read_text(encoding="utf-8") == "first"
+        _atomic_write_text(target, "second")
+        assert target.read_text(encoding="utf-8") == "second"
+        # No leftover tmpfile.
+        assert not (tmp_path / "x.etag.tmp").exists()
+
+    def test_read_local_etag_returns_none_when_missing(self, tmp_path: Path) -> None:
+        assert _read_local_etag(tmp_path / "submissions.zip") is None
+
+    def test_read_local_etag_strips_whitespace(self, tmp_path: Path) -> None:
+        archive_path = tmp_path / "submissions.zip"
+        _atomic_write_text(_etag_sidecar_path(archive_path), '  "abc-123"  \n')
+        assert _read_local_etag(archive_path) == '"abc-123"'
+
+    def test_compute_sha256_streams_large_file(self, tmp_path: Path) -> None:
+        # 5 MB file exercises the chunk loop (chunk_size=1MB).
+        path = tmp_path / "big.bin"
+        payload = b"x" * (5 * 1024 * 1024)
+        path.write_bytes(payload)
+        import hashlib
+
+        expected = hashlib.sha256(payload).hexdigest()
+        assert _compute_sha256(path) == expected
+
+
+# ---------------------------------------------------------------------------
+# Async refresh — unchanged-SEC path
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshOneAsyncUnchanged:
+    @pytest.mark.asyncio
+    async def test_etag_match_returns_no_op(self, tmp_path: Path) -> None:
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        body = _zip_bytes()
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        etag = '"504b124e9474334e889e9e525db95c14-184"'
+
+        # Pre-seed a matching ETag sidecar + a real (round-trippable)
+        # zip body at the canonical path.
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        archive_path.write_bytes(body)
+        _atomic_write_text(_etag_sidecar_path(archive_path), etag)
+
+        handler = _make_handler(archive_url=url, archive_body=body, etag=etag)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result == RefreshResult(
+            archive_name=_SUBMISSIONS_NAME,
+            etag_changed=False,
+            bytes_downloaded=0,
+            skipped_reason=None,
+        )
+        # Sidecar untouched, archive untouched.
+        assert _read_local_etag(archive_path) == etag
+        assert archive_path.read_bytes() == body
+        # No SHA-256 sidecar was created (we only create on download).
+        assert not _sha256_sidecar_path(archive_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# Async refresh — changed-SEC path
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshOneAsyncChanged:
+    @pytest.mark.asyncio
+    async def test_etag_change_triggers_download_and_writes_sidecars(self, tmp_path: Path) -> None:
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        new_body = _zip_bytes(payload=b'{"updated": true}')
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        old_etag = '"old-etag-aaaa"'
+        new_etag = '"new-etag-bbbb"'
+
+        # Pre-seed an OLD archive + sidecar.
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        old_body = _zip_bytes(payload=b'{"stale": true}')
+        archive_path.write_bytes(old_body)
+        _atomic_write_text(_etag_sidecar_path(archive_path), old_etag)
+
+        handler = _make_handler(archive_url=url, archive_body=new_body, etag=new_etag)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.archive_name == _SUBMISSIONS_NAME
+        assert result.etag_changed is True
+        assert result.bytes_downloaded == len(new_body)
+        assert result.skipped_reason is None
+        # Archive now holds the new body.
+        assert archive_path.read_bytes() == new_body
+        # ETag sidecar updated to the new value (verbatim, with quotes).
+        assert _read_local_etag(archive_path) == new_etag
+        # SHA-256 sidecar landed.
+        import hashlib
+
+        expected_sha = hashlib.sha256(new_body).hexdigest()
+        assert _sha256_sidecar_path(archive_path).read_text().strip() == expected_sha
+        # No leftover partial.
+        assert not (tmp_path / f"{_SUBMISSIONS_NAME}.refresh.partial").exists()
+
+    @pytest.mark.asyncio
+    async def test_missing_local_archive_triggers_initial_download(self, tmp_path: Path) -> None:
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        body = _zip_bytes()
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        etag = '"first-pull"'
+
+        # No pre-existing file or sidecar.
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        assert not archive_path.exists()
+        assert not _etag_sidecar_path(archive_path).exists()
+
+        handler = _make_handler(archive_url=url, archive_body=body, etag=etag)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.etag_changed is True
+        assert result.bytes_downloaded == len(body)
+        assert archive_path.read_bytes() == body
+        assert _read_local_etag(archive_path) == etag
+
+
+# ---------------------------------------------------------------------------
+# Async refresh — fail-closed paths
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshOneAsyncFailClosed:
+    @pytest.mark.asyncio
+    async def test_head_500_leaves_local_archive_alone(self, tmp_path: Path) -> None:
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+
+        # Pre-existing archive + ETag should be untouched by a SEC 5xx.
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        body = _zip_bytes()
+        archive_path.write_bytes(body)
+        _atomic_write_text(_etag_sidecar_path(archive_path), '"old-etag"')
+
+        handler = _make_handler(archive_url=url, archive_body=body, etag='"unused"', head_status=503)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.etag_changed is False
+        assert result.bytes_downloaded == 0
+        assert result.skipped_reason is not None and "503" in result.skipped_reason
+        # File + sidecar preserved.
+        assert archive_path.read_bytes() == body
+        assert _read_local_etag(archive_path) == '"old-etag"'
+
+    @pytest.mark.asyncio
+    async def test_head_missing_etag_skips(self, tmp_path: Path) -> None:
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        body = _zip_bytes()
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+
+        # No ETag header → skip with structured reason.
+        handler = _make_handler(archive_url=url, archive_body=body, etag="unused", include_etag=False)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.etag_changed is False
+        assert result.skipped_reason == "head_missing_etag"
+
+    @pytest.mark.asyncio
+    async def test_get_500_after_head_ok_preserves_old_archive(self, tmp_path: Path) -> None:
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        new_body = _zip_bytes(payload=b'{"new": true}')
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+
+        # Old archive present; new ETag advertised but GET fails.
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        old_body = _zip_bytes(payload=b'{"old": true}')
+        archive_path.write_bytes(old_body)
+        _atomic_write_text(_etag_sidecar_path(archive_path), '"old-etag"')
+
+        handler = _make_handler(archive_url=url, archive_body=new_body, etag='"new-etag"', get_status=502)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.etag_changed is False
+        assert result.skipped_reason == "get_status_502"
+        # Critically: the old archive + old sidecar survive.
+        assert archive_path.read_bytes() == old_body
+        assert _read_local_etag(archive_path) == '"old-etag"'
+        # No partial leftover.
+        assert not (tmp_path / f"{_SUBMISSIONS_NAME}.refresh.partial").exists()
+
+    @pytest.mark.asyncio
+    async def test_head_bad_content_type_skips(self, tmp_path: Path) -> None:
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+
+        # SEC served an HTML error page — pre-flight rejects.
+        handler = _make_handler(
+            archive_url=url,
+            archive_body=b"<html>error</html>",
+            etag='"x"',
+            content_type="text/html",
+        )
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.etag_changed is False
+        assert result.skipped_reason is not None
+        assert result.skipped_reason.startswith("head_bad_content_type")
+
+
+# ---------------------------------------------------------------------------
+# Seed-on-first-encounter (no sidecar yet, archive matches HEAD)
+# ---------------------------------------------------------------------------
+
+
+class TestSeedOnFirstEncounter:
+    @pytest.mark.asyncio
+    async def test_existing_archive_without_sidecar_is_seeded_without_download(self, tmp_path: Path) -> None:
+        """Bootstrap downloader writes the `.zip` but (today) NOT the
+        `.zip.etag` sidecar. The FIRST refresh fire must recognise the
+        existing valid archive matches HEAD by size+ZIP integrity and
+        adopt the live ETag as the sidecar — transferring ZERO bytes.
+        Without this, every install would re-download the multi-GB
+        archive on its first refresh fire.
+        """
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        body = _zip_bytes()
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        etag = '"seed-test-etag"'
+
+        # Archive present, NO sidecar. Bootstrap-downloader state.
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        archive_path.write_bytes(body)
+        assert not _etag_sidecar_path(archive_path).exists()
+        assert not _sha256_sidecar_path(archive_path).exists()
+
+        handler = _make_handler(archive_url=url, archive_body=body, etag=etag)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        # ZERO transfer — we adopted the HEAD ETag.
+        assert result.etag_changed is False
+        assert result.bytes_downloaded == 0
+        assert result.skipped_reason is None
+        # Sidecars now exist.
+        assert _read_local_etag(archive_path) == etag
+        import hashlib
+
+        assert _sha256_sidecar_path(archive_path).read_text().strip() == hashlib.sha256(body).hexdigest()
+        # Archive untouched.
+        assert archive_path.read_bytes() == body
+
+    @pytest.mark.asyncio
+    async def test_existing_archive_with_size_mismatch_falls_through_to_download(self, tmp_path: Path) -> None:
+        """If the local file exists but its size doesn't match HEAD's
+        Content-Length, the seed-on-first-encounter path must NOT
+        adopt — fall through to the genuine re-download. Otherwise
+        a stale/corrupted local archive would be canonicalised under
+        the live ETag.
+        """
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        new_body = _zip_bytes(payload=b'{"new": true}')
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        etag = '"seed-skip-test"'
+
+        # Local archive smaller than HEAD says (simulating partial / wrong version).
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        archive_path.write_bytes(b"truncated")
+        assert archive_path.stat().st_size != len(new_body)
+
+        handler = _make_handler(archive_url=url, archive_body=new_body, etag=etag)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        # Re-download happened — new body landed.
+        assert result.etag_changed is True
+        assert result.bytes_downloaded == len(new_body)
+        assert archive_path.read_bytes() == new_body
+
+
+# ---------------------------------------------------------------------------
+# CDN race: GET ETag mismatch with HEAD
+# ---------------------------------------------------------------------------
+
+
+class TestCdnRaceGetEtagMismatch:
+    @pytest.mark.asyncio
+    async def test_get_etag_differs_from_head_keeps_old_archive(self, tmp_path: Path) -> None:
+        """A CDN race can serve HEAD against version A and GET against
+        version B. If we wrote version B bytes under version A's ETag,
+        future HEAD-match fast-paths would wrongly skip real updates.
+        Detect the mismatch, discard the partial, retain the old
+        archive + sidecar.
+        """
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        body = _zip_bytes(payload=b'{"served": true}')
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        head_etag = '"head-version-A"'
+        get_response_etag = '"get-version-B"'
+
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        old_body = _zip_bytes(payload=b'{"old": true}')
+        archive_path.write_bytes(old_body)
+        _atomic_write_text(_etag_sidecar_path(archive_path), '"old-sidecar"')
+
+        handler = _make_handler(
+            archive_url=url,
+            archive_body=body,
+            etag=head_etag,
+            get_etag=get_response_etag,
+        )
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.etag_changed is False
+        assert result.bytes_downloaded == 0
+        assert result.skipped_reason == "get_etag_mismatch_with_head"
+        # OLD archive + sidecar survive — critical invariant.
+        assert archive_path.read_bytes() == old_body
+        assert _read_local_etag(archive_path) == '"old-sidecar"'
+        # No partial leftover.
+        assert not (tmp_path / f"{_SUBMISSIONS_NAME}.refresh.partial").exists()
+
+    @pytest.mark.asyncio
+    async def test_get_etag_matches_head_records_get_etag(self, tmp_path: Path) -> None:
+        """When HEAD + GET ETag agree, the sidecar records the GET
+        value (preferred — describes exactly the bytes we kept).
+        """
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        body = _zip_bytes()
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        etag = '"agreement"'
+
+        handler = _make_handler(archive_url=url, archive_body=body, etag=etag)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.etag_changed is True
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        assert _read_local_etag(archive_path) == etag
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap fence
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapFence:
+    def test_refresh_skips_when_bootstrap_running(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``refresh_bulk_archive_if_stale`` must NOT contact SEC while
+        ``bootstrap_state.status='running'`` — PR-5b's reuse path would
+        otherwise race the daily refresh.
+        """
+        # Patch the data dir to the test tmp_path.
+        monkeypatch.setattr(refresh_mod, "_resolve_target_dir", lambda: tmp_path)
+
+        # Force the bootstrap fence to report "running".
+        class _FakeConn:
+            def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+                class _Row:
+                    @staticmethod
+                    def fetchone() -> tuple[str]:
+                        return ("running",)
+
+                return _Row()
+
+            def __enter__(self) -> _FakeConn:
+                return self
+
+            def __exit__(self, *_exc: Any) -> bool:
+                return False
+
+        # Replace psycopg.connect (only in the module under test) with a
+        # context manager yielding the fake conn. Using monkeypatch.setattr
+        # against the imported ``psycopg`` symbol limits scope.
+        import psycopg
+
+        class _FakeContext:
+            def __enter__(self) -> _FakeConn:
+                return _FakeConn()
+
+            def __exit__(self, *_exc: Any) -> bool:
+                return False
+
+        monkeypatch.setattr(psycopg, "connect", lambda *_args, **_kwargs: _FakeContext())
+
+        # Sentinel: if the fence is honored, _refresh_one_async must NOT
+        # be invoked. Replace it with one that throws.
+        def _should_not_be_called(**_kwargs: Any) -> RefreshResult:
+            raise AssertionError("_refresh_one_async called despite bootstrap_running fence")
+
+        monkeypatch.setattr(refresh_mod, "_refresh_one_async", _should_not_be_called)
+
+        result = refresh_bulk_archive_if_stale(_SUBMISSIONS_NAME)
+
+        assert result.archive_name == _SUBMISSIONS_NAME
+        assert result.etag_changed is False
+        assert result.bytes_downloaded == 0
+        assert result.skipped_reason == "bootstrap_running"
+
+    def test_bootstrap_running_returns_true_when_status_is_running(self) -> None:
+        """Direct test of the predicate against a fake conn — ensures
+        the SELECT result is parsed correctly."""
+
+        class _Row:
+            @staticmethod
+            def fetchone() -> tuple[str]:
+                return ("running",)
+
+        class _Conn:
+            def execute(self, *_args: Any, **_kwargs: Any) -> _Row:
+                return _Row()
+
+        assert _bootstrap_running(_Conn()) is True  # type: ignore[arg-type]
+
+    def test_bootstrap_running_returns_false_when_status_is_complete(self) -> None:
+        class _Row:
+            @staticmethod
+            def fetchone() -> tuple[str]:
+                return ("complete",)
+
+        class _Conn:
+            def execute(self, *_args: Any, **_kwargs: Any) -> _Row:
+                return _Row()
+
+        assert _bootstrap_running(_Conn()) is False  # type: ignore[arg-type]
+
+    def test_bootstrap_running_fails_closed_on_missing_row(self) -> None:
+        """If the singleton row is missing, the fence must default to
+        ``True`` (refuse to race) — defense in depth against migration
+        corruption.
+        """
+
+        class _Row:
+            @staticmethod
+            def fetchone() -> None:
+                return None
+
+        class _Conn:
+            def execute(self, *_args: Any, **_kwargs: Any) -> _Row:
+                return _Row()
+
+        assert _bootstrap_running(_Conn()) is True  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit acquisition
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitAcquisition:
+    @pytest.mark.asyncio
+    async def test_refresh_acquires_from_shared_clock(self, tmp_path: Path) -> None:
+        """The refresh must acquire from the shared process rate-limit
+        clock — this proves it counts against SEC's per-IP budget the
+        same way every other SEC consumer does.
+
+        We assert by snapshotting the clock before + after a single
+        no-op fire: the clock must have advanced.
+        """
+        from app.providers.implementations.sec_edgar import (
+            _PROCESS_RATE_LIMIT_CLOCK,
+            _PROCESS_RATE_LIMIT_LOCK,
+        )
+
+        # Reset clock to zero so we can detect any advance.
+        with _PROCESS_RATE_LIMIT_LOCK:
+            _PROCESS_RATE_LIMIT_CLOCK[0] = 0.0
+
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        body = _zip_bytes()
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        etag = '"shared-clock-test"'
+
+        # Seed local sidecar so the HEAD path is a no-op (single acquire).
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        archive_path.write_bytes(body)
+        _atomic_write_text(_etag_sidecar_path(archive_path), etag)
+
+        handler = _make_handler(archive_url=url, archive_body=body, etag=etag)
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+
+        assert result.skipped_reason is None
+        # The shared clock advanced on the HEAD acquire.
+        with _PROCESS_RATE_LIMIT_LOCK:
+            advanced = _PROCESS_RATE_LIMIT_CLOCK[0]
+        assert advanced > 0.0, "Rate limiter did NOT acquire from the shared clock during HEAD"
+
+
+# ---------------------------------------------------------------------------
+# Operator force-override is bootstrap-only
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorForceOverrideIsBootstrapOnly:
+    def test_force_redownload_env_does_not_change_refresh_behaviour(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``BOOTSTRAP_FORCE_REDOWNLOAD=1`` is a bootstrap-time operator
+        override (PR-5b's territory). The daily refresh must ignore it —
+        operator forces the bootstrap downloader, not the refresh adapter.
+        """
+        monkeypatch.setenv("BOOTSTRAP_FORCE_REDOWNLOAD", "1")
+
+        # Walk through the source: there must be NO read of the env var
+        # in the refresh module. We assert by import-time string presence.
+        import inspect
+
+        src = inspect.getsource(refresh_mod)
+        assert "BOOTSTRAP_FORCE_REDOWNLOAD" not in src, (
+            "sec_bulk_refresh must not honour the BOOTSTRAP_FORCE_REDOWNLOAD "
+            "operator override; that flag belongs to the bootstrap downloader "
+            "(PR-5b). Daily refresh decisions are ETag-driven only."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scheduler + invoker registration
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerRegistration:
+    def test_all_three_jobs_are_in_scheduled_jobs(self) -> None:
+        from app.workers.scheduler import (
+            JOB_SEC_COMPANYFACTS_BULK_REFRESH,
+            JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH,
+            JOB_SEC_SUBMISSIONS_BULK_REFRESH,
+            SCHEDULED_JOBS,
+        )
+
+        names = {job.name for job in SCHEDULED_JOBS}
+        assert JOB_SEC_SUBMISSIONS_BULK_REFRESH in names
+        assert JOB_SEC_COMPANYFACTS_BULK_REFRESH in names
+        assert JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH in names
+
+    def test_all_three_jobs_are_in_invokers(self) -> None:
+        from app.jobs.runtime import _INVOKERS
+        from app.workers.scheduler import (
+            JOB_SEC_COMPANYFACTS_BULK_REFRESH,
+            JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH,
+            JOB_SEC_SUBMISSIONS_BULK_REFRESH,
+        )
+
+        assert JOB_SEC_SUBMISSIONS_BULK_REFRESH in _INVOKERS
+        assert JOB_SEC_COMPANYFACTS_BULK_REFRESH in _INVOKERS
+        assert JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH in _INVOKERS
+
+    def test_all_three_jobs_resolve_to_sec_bulk_download_source(self) -> None:
+        """The lane MUST be ``sec_bulk_download`` — disjoint from
+        ``sec_rate`` by design so daily refresh transfers don't steal
+        budget from per-CIK SEC fetches.
+        """
+        from app.jobs.sources import source_for
+        from app.workers.scheduler import (
+            JOB_SEC_COMPANYFACTS_BULK_REFRESH,
+            JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH,
+            JOB_SEC_SUBMISSIONS_BULK_REFRESH,
+        )
+
+        for name in (
+            JOB_SEC_SUBMISSIONS_BULK_REFRESH,
+            JOB_SEC_COMPANYFACTS_BULK_REFRESH,
+            JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH,
+        ):
+            assert source_for(name) == "sec_bulk_download"
+
+    def test_cadences_match_spec(self) -> None:
+        """The spec calls for cron schedules:
+
+        * ``submissions``    — ``0 8 * * *``    (daily 08:00 UTC)
+        * ``companyfacts``   — ``30 8 * * *``   (daily 08:30 UTC)
+        * ``quarterly``      — ``0 6 5 * *``    (monthly day-5 06:00 UTC)
+        """
+        from app.workers.scheduler import (
+            JOB_SEC_COMPANYFACTS_BULK_REFRESH,
+            JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH,
+            JOB_SEC_SUBMISSIONS_BULK_REFRESH,
+            SCHEDULED_JOBS,
+        )
+
+        by_name = {job.name: job for job in SCHEDULED_JOBS}
+
+        sub = by_name[JOB_SEC_SUBMISSIONS_BULK_REFRESH].cadence
+        assert sub.kind == "daily"
+        assert sub.hour == 8 and sub.minute == 0
+
+        cf = by_name[JOB_SEC_COMPANYFACTS_BULK_REFRESH].cadence
+        assert cf.kind == "daily"
+        assert cf.hour == 8 and cf.minute == 30
+
+        qtr = by_name[JOB_SEC_QUARTERLY_DATASETS_BULK_REFRESH].cadence
+        assert qtr.kind == "monthly"
+        assert qtr.day == 5
+        assert qtr.hour == 6 and qtr.minute == 0
+
+    def test_bulk_refresh_outcome_populates_tracker_note_on_skip(self) -> None:
+        """``_record_bulk_refresh_outcome`` must forward the skip digest
+        to ``tracker.note`` so ``_tracked_job`` writes it into
+        ``job_runs.error_msg`` on the SUCCESS path. Without this, a
+        bootstrap-fence / SEC-5xx / missing-ETag skip records a plain
+        success row and the operator has to read process logs to learn
+        why nothing happened.
+        """
+        from app.workers.scheduler import _JobTracker, _record_bulk_refresh_outcome
+
+        tracker = _JobTracker("test_job")
+        results = [
+            RefreshResult(
+                archive_name="submissions.zip",
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason="bootstrap_running",
+            ),
+        ]
+        _record_bulk_refresh_outcome(tracker, results, job_name="test_job")
+        assert tracker.note == "submissions.zip:bootstrap_running"
+        assert tracker.row_count == 0
+
+    def test_bulk_refresh_outcome_no_note_on_clean_no_op(self) -> None:
+        """When every archive's outcome is fresh (no transfer, no skip)
+        the tracker.note stays ``None`` — a clean SUCCESS row with NULL
+        error_msg.
+        """
+        from app.workers.scheduler import _JobTracker, _record_bulk_refresh_outcome
+
+        tracker = _JobTracker("test_job")
+        results = [
+            RefreshResult(
+                archive_name="submissions.zip",
+                etag_changed=False,
+                bytes_downloaded=0,
+                skipped_reason=None,
+            ),
+        ]
+        _record_bulk_refresh_outcome(tracker, results, job_name="test_job")
+        assert tracker.note is None
+        assert tracker.row_count == 0
+
+    def test_archive_set_helpers(self) -> None:
+        """Confirm the archive-set helpers return what the invokers
+        will iterate over."""
+        assert _submissions_archive_names() == (_SUBMISSIONS_NAME,)
+        assert _companyfacts_archive_names() == (_COMPANYFACTS_NAME,)
+        qtr = _quarterly_dataset_archive_names()
+        assert qtr  # non-empty
+        assert _SUBMISSIONS_NAME not in qtr
+        assert _COMPANYFACTS_NAME not in qtr
+        # All entries should be real archives.
+        for name in qtr:
+            assert _archive_for_name(name) is not None


### PR DESCRIPTION
## Summary

Closes the post-bootstrap freshness drift on the SEC bulk plane. Submissions / companyfacts / quarterly 13F+NPORT+insider archives are downloaded once at first-install bootstrap then stale forever. Three SCHEDULED_JOBS now HEAD the live SEC URL daily / monthly, compare against a local `.zip.etag` sidecar, and re-download only when the server's ETag has changed.

Refs #1233 (PR-8 of the bootstrap-ETL-optimisation v3 spec).

## What

- **New module** `app/services/sec_bulk_refresh.py` (~770 LoC with docs):
  - `refresh_bulk_archive_if_stale(archive_name) -> RefreshResult`
  - HEAD probe (shared SEC rate budget) → compare ETag → conditional stream-GET with ZIP integrity round-trip + size + ZIP-magic checks.
  - Atomic `.zip` replace then atomic `.etag` + `.sha256` sidecar writes.
  - **Bootstrap fence:** SKIP while `bootstrap_state.status='running'`.
  - **Seed-on-first-encounter:** existing archive without sidecar adopts HEAD ETag if size matches + ZIP round-trips (zero transfer); closes the first-fire-re-downloads-multi-GB trap pre-PR-5b.
  - **CDN-race guard:** HEAD/GET ETag mismatch ⇒ discard partial with `get_etag_mismatch_with_head`; old archive preserved.
  - **Fail-closed** on SEC 5xx / 4xx / missing ETag / size mismatch / ZIP corrupt — local file never corrupted on the skip path.
- **Three new SCHEDULED_JOBS** in `app/workers/scheduler.py`:
  - `sec_submissions_bulk_refresh` — daily 08:00 UTC
  - `sec_companyfacts_bulk_refresh` — daily 08:30 UTC
  - `sec_quarterly_datasets_bulk_refresh` — monthly day-5 06:00 UTC
  - All lane = `sec_bulk_download` (disjoint from `sec_rate`).
  - Gated by `_bootstrap_complete` prereq; body-level bootstrap-running fence is belt-and-braces.
- `_JobTracker` gains `note: str | None` and `_tracked_job` forwards it to `job_runs.error_msg` on the SUCCESS path. The refresh invokers populate `tracker.note` with the per-archive skip digest so bootstrap-fence / SEC-5xx / missing-ETag skips are operator-visible in the admin UI without raising.
- `_INVOKERS` registration in `app/jobs/runtime.py`.
- Skill update at `.claude/skills/data-sources/sec-edgar.md` — new "Daily-refresh pathways" subsection.

## Why

Operator daily updates against fresh discovery (Atom / daily-index) miss newly-published rows that land inside SEC's bulk archives between bootstraps. Bulk-ingest stages consume those archives as canonical — silent freshness drift across the whole bulk plane.

PR-8 makes the HEAD the cheap probe and the download the rare event. Most fires transfer zero bytes; the rare changed-archive fire spends a stream's worth of GETs against the SEC per-IP budget the same way every other SEC consumer does.

## Security model

- Read-only HEAD against fixed SEC URLs; conditional stream-GET with ZIP integrity verification before atomic file replace. No user input flows into URLs.
- Bootstrap fence opens an autocommit SELECT-only conn against `bootstrap_state` — no writes from the refresh path.
- SHA-256 + ETag sidecars provide provenance for later operators (or for PR-5b's reuse path).
- Rate limiter shares `_PROCESS_RATE_LIMIT_CLOCK` with every other SEC consumer so the daily refresh cannot exceed the 7 req/s ceiling.

## Conscious trade-offs

- **Monthly day-5 for quarterly:** A 404 skip in early month waits until next month. Spec-mandated cadence (`0 6 5 * *`); day-5 chosen to land after SEC's quarterly publish cycle settles. Acceptable trade-off — operator can manual-trigger via Admin "Run now" if a late-published archive is needed inside-month.
- **`_JobTracker.note` is a cross-cutting scheduler API extension:** Justified because surfacing skip reasons in `job_runs.error_msg` on SUCCESS is a general requirement that future soft-skip jobs will reuse. Backward-compatible — existing callers leave it `None`, recording the historical contract.
- **Did NOT modify `app/services/sec_bulk_download.py`:** PR-5b's territory; my refresh module includes its own seed-on-first-encounter path so PR-8 can land independently and continue working when PR-5b adds sidecar writes to the bootstrap path.

## Test plan

- [x] `tests/test_sec_bulk_refresh.py` — 32 tests:
  - Archive lookup (submissions, companyfacts, quarterly, unknown).
  - Sidecar atomic write + SHA-256 streaming.
  - ETag-match no-op.
  - ETag-change download + atomic sidecar writes.
  - Seed-on-first-encounter (existing archive matches HEAD ⇒ adopt, zero transfer).
  - Size mismatch falls through to genuine re-download.
  - CDN-race: GET ETag differs ⇒ discard + keep old archive.
  - HEAD 5xx / HEAD missing ETag / HEAD bad Content-Type fail-closed.
  - GET 5xx after HEAD ok preserves local file.
  - Bootstrap-running fence skips without contacting SEC.
  - Fence fails closed on missing singleton row.
  - Rate limiter acquires from shared `_PROCESS_RATE_LIMIT_CLOCK`.
  - `BOOTSTRAP_FORCE_REDOWNLOAD` env NOT honored (bootstrap-only).
  - Scheduler / `_INVOKERS` / `source_for` / cadence registration.
  - `tracker.note` propagation on skip vs clean no-op.
- [x] Live SEC HEAD smoke against `https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip` on 2026-05-22: status=200 etag=`"504b124e9474334e889e9e525db95c14-184"` content-length=1541272031 content-type=application/zip.
- [x] Gates: `uv run ruff check app/ tests/` + `ruff format --check` + `uv run pyright app/` + `pytest tests/test_sec_bulk_refresh.py tests/smoke/test_app_boots.py` — all green.
- [x] Codex review converged: round 1 surfaced 2 BLOCKING + 1 WARNING; round-2 follow-up review confirmed "No findings".
- [ ] Operator post-merge: after PR-5b lands, smoke a manual trigger via `POST /jobs/sec_submissions_bulk_refresh/run` against dev DB; confirm `job_runs.row_count=0` (ETag match) + clean SUCCESS in the admin UI.

## Pre-existing test failures on main (NOT caused by this PR)

Confirmed via stash + replay against main HEAD:
- `test_sec_bulk_cancel_signal::test_each_job_calls_only_its_own_ingester` — `rows_skipped_retention` attr missing on `SimpleNamespace`.
- `test_bootstrap_state_prerequisite::test_every_scheduled_job_either_gated_or_explicitly_excluded` — `sec_daily_index_reconcile / sec_manifest_tombstone_stale / sec_manifest_worker` not gated and not in NON_GATED_SCHEDULED.
- `test_jobs_listener::test_dispatch_manual_job_with_valid_name_calls_runtime`.

These should each be filed as separate tech-debt issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)