### PR TITLE
feat(#1233): PR-5a bootstrap manifest-reset prelude

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -743,6 +743,32 @@ Every job in `SCHEDULED_JOBS` declares a `prerequisite: PrerequisiteFn | None`. 
 7. **Test invariants.** Every job needs a registry-shape test (`tests/test_job_registry.py`) covering source non-NULL + params_metadata validates + prerequisite is callable.
 8. **Queue/audit terminal-state correctness.** When the prelude (source lock acquisition, prereq check, `bootstrap_state` gate, fence-held opt-out) skips the body without invoking the underlying job, the corresponding `pending_job_requests` row MUST transition to `rejected` (not `completed`) with a structured `error_msg`. `mark_request_completed` after a skipped body produces an audit row that says "ran successfully" when the job never ran. PREVENTION-log-grade hazard — see PR #1072 BLOCKING and PR #1078 (orchestrator opt-out fence). The skipped/rejected vs completed distinction is the operator's only signal that a manual trigger didn't actually do what they asked. Grep `mark_request_completed` and verify each call site has the matching `mark_request_rejected` for the prelude-skip path.
 
+### 6.5.8 Bootstrap manifest-reset prelude (#1233 PR-5a)
+
+`run_bootstrap_orchestrator` runs a one-shot `reset_manifest_for_run` prelude AFTER the `running` snapshot validation and BEFORE the dispatcher loop. It UPDATEs `sec_filing_manifest`:
+
+```
+SET ingest_status='pending', next_retry_at=NULL, error=NULL, last_attempted_at=NULL
+WHERE source = ANY(_BOOTSTRAP_MANIFEST_SOURCES::text[])
+  AND ingest_status='failed'
+  AND last_attempted_at IS NOT NULL
+  AND last_attempted_at < bootstrap_runs.triggered_at
+```
+
+**Why:** a cancelled prior run can leave `failed` rows with `next_retry_at` in the future; without the reset, those rows refuse to drain in the new run even when parser_version bumped or the failure was transient. Run #4 inherited 1.18M `failed` rows from cancelled run #3 — the prelude prevents that recurrence.
+
+**Source whitelist** = SEC subset of `ManifestSource` (every value except `finra_short_interest` / `finra_regsho_daily`). FINRA sources are owned by non-bootstrap drivers; the bootstrap orchestrator must not flip their failure state. The whitelist is computed at module load from `_MANIFEST_SOURCES_BY_STAGE` ([app/services/bootstrap_orchestrator.py](../../../app/services/bootstrap_orchestrator.py)).
+
+**Time filter** = strict `<` against `bootstrap_runs.triggered_at`. A concurrent live cron writer landing a fresh `failed` row mid-reset has `last_attempted_at >= NOW() >= reset_started_at` and survives the predicate. Boundary case: equal timestamps are NOT reset (this is the operator's signal that the failure came from the running orchestrator itself, not the prior cancelled run).
+
+The `last_attempted_at` stamp itself uses `clock_timestamp()` (statement-time wall-clock) rather than `NOW()` (= `transaction_timestamp()`, fixed at tx start). A worker tx that began BEFORE `bootstrap_runs.triggered_at` but commits AFTER would otherwise stamp the row with a tx-start time that survives the reset predicate and gets erroneously flipped — `clock_timestamp()` removes that race.
+
+**Opt-out** = `bootstrap_runs.params['reset_failed_manifest']` (default TRUE; column added in sql/169 as `JSONB NOT NULL DEFAULT '{}'::jsonb` with `jsonb_typeof = 'object'` CHECK). Set FALSE via `POST /system/bootstrap/run` body `{"reset_failed_manifest": false}` when an operator deliberately wants to preserve stale `failed` rows from a prior run (e.g. debugging which accessions tripped a parser bug; letting routine backoff drive drainage). The orchestrator tests for exact `is False` so type-drift (string `"false"`, integer `0`) fail-closed against silent opt-out.
+
+**Idempotency:** the reset is a single SQL UPDATE; a second invocation finds zero matching rows. Re-queuing the orchestrator after a worker crash is safe.
+
+**Out of scope:** the prelude does NOT touch rows in any other state — `pending` rows stay pending, `parsed` stays parsed, `tombstoned` stays tombstoned. A stuck-`pending` row is the manifest-worker's problem (#1224); a `tombstoned` row needs an explicit `POST /jobs/sec_rebuild/run`.
+
 ## 6. Known live caveats / tech debt
 
 - **Coverage = telemetry not gate**: per-category universe estimates still NULL for Tier 0 (`_read_universe_estimates` returns all-None). Banner reports `unknown_universe` on most instruments. Real estimates seeded in #790 / Batch 2.

--- a/app/api/bootstrap.py
+++ b/app/api/bootstrap.py
@@ -367,6 +367,24 @@ def get_bootstrap_status(
 # ---------------------------------------------------------------------------
 
 
+class BootstrapRunRequest(BaseModel):
+    """Optional body for ``POST /system/bootstrap/run``.
+
+    Today carries one operator-facing knob:
+
+    * ``reset_failed_manifest`` — default TRUE. Controls the #1233 PR-5a
+      manifest-reset prelude. Set FALSE to preserve stale ``failed``
+      manifest rows from a prior cancelled run (debugging the rows
+      themselves, or letting their existing backoff watermark drive
+      drainage).
+
+    The body is optional: callers that POST with no body get the
+    default-everything behaviour (matches the pre-PR-5a contract).
+    """
+
+    reset_failed_manifest: bool = True
+
+
 @router.post(
     "/run",
     status_code=status.HTTP_202_ACCEPTED,
@@ -374,6 +392,7 @@ def get_bootstrap_status(
 )
 def run_bootstrap(
     request: Request,
+    body: BootstrapRunRequest | None = None,
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> BootstrapRunQueuedResponse:
     """Trigger a fresh bootstrap run.
@@ -400,12 +419,19 @@ def run_bootstrap(
     """
     requested_by = _identify_requestor(request)
     operator_uuid = _operator_uuid(request)
+    # #1233 PR-5a — persist the operator-facing param dict on
+    # ``bootstrap_runs.params``. Empty-body POST falls back to the
+    # default-everything ``BootstrapRunRequest()`` instance. The dict
+    # is structurally validated at the JSONB CHECK constraint level
+    # (sql/169 ``bootstrap_runs_params_object_chk``).
+    run_params = (body or BootstrapRunRequest()).model_dump()
     try:
         with conn.transaction():
             run_id = start_run(
                 conn,
                 operator_id=operator_uuid,
                 stage_specs=get_bootstrap_stage_specs(),
+                params=run_params,
             )
             try:
                 request_id = publish_manual_job_request_with_conn(

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -50,7 +50,7 @@ parallel manual / scheduled trigger cannot run twice simultaneously.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, time, timedelta
 from typing import Any, Final, Literal
@@ -1893,6 +1893,189 @@ def _phase_batched_dispatch(
     return statuses, False
 
 
+# ---------------------------------------------------------------------------
+# Manifest reset prelude (#1233 PR-5a / spec §9)
+# ---------------------------------------------------------------------------
+#
+# Background: run #4 inherited 1.18M ``sec_filing_manifest`` rows from
+# the cancelled run #3, including ``ingest_status='failed'`` rows whose
+# ``next_retry_at`` watermarks lived in the future. Those rows refused
+# to drain in the new run even when (a) the parser_version had bumped
+# since the prior attempt, or (b) the failure was transient. Operator-
+# visible symptom: bootstrap completes with stale failure state.
+#
+# The prelude flips ``failed`` rows back to ``pending`` at run start
+# subject to two gates:
+#
+# 1. Source whitelist — only the subset of ``ManifestSource`` values
+#    the orchestrator's stage catalogue actually drives. FINRA sources
+#    have their own non-bootstrap drivers; their failure state must not
+#    be papered over here. The set is derived statically from
+#    ``_MANIFEST_SOURCES_BY_STAGE``.
+#
+# 2. Time filter — only rows whose ``last_attempted_at`` is strictly
+#    before the current run's start watermark (``triggered_at``). A
+#    concurrent live cron writer landing a fresh ``failed`` row mid-
+#    reset survives because its ``last_attempted_at >= reset_started_at``.
+#
+# The reset is idempotent: re-invoking against the same run is a no-op
+# once the predicate's tail-end is empty.
+
+# Per-stage manifest source sets. Pinned here so adding a new stage
+# that writes manifest rows for an existing source family becomes a
+# single-line edit, not a sweep. Stages NOT in this mapping (init /
+# eToro / cusip / cik refresh / bulk download / Phase C bulk
+# ingesters / openfigi sweep / mf_directory_sync / observations
+# backfill / fundamentals_sync) do not write to ``sec_filing_manifest``
+# — their data lands in other tables.
+#
+# The aggregate union (``_BOOTSTRAP_MANIFEST_SOURCES``) is what
+# ``reset_manifest_for_run`` flips. Per-stage breakdown is documented
+# here so a future stage-trim audit can answer "which manifest
+# sources lose coverage if I drop stage X?" without re-reading every
+# invoker body.
+_MANIFEST_SOURCES_BY_STAGE: Final[dict[str, frozenset[str]]] = {
+    # filings_history_seed walks the per-issuer filings history; the
+    # form-type allow-list (``SEC_INGEST_KEEP_FORMS``) covers every
+    # issuer-scoped SEC manifest source.
+    "filings_history_seed": frozenset(
+        {
+            "sec_form3",
+            "sec_form4",
+            "sec_form5",
+            "sec_13d",
+            "sec_13g",
+            "sec_def14a",
+            "sec_10k",
+            "sec_10q",
+            "sec_8k",
+            "sec_xbrl_facts",
+        }
+    ),
+    # sec_first_install_drain is the manifest worker itself; it drains
+    # every pending manifest row regardless of source.
+    "sec_first_install_drain": frozenset(
+        {
+            "sec_form3",
+            "sec_form4",
+            "sec_form5",
+            "sec_13d",
+            "sec_13g",
+            "sec_13f_hr",
+            "sec_def14a",
+            "sec_n_port",
+            "sec_n_csr",
+            "sec_10k",
+            "sec_10q",
+            "sec_8k",
+            "sec_xbrl_facts",
+        }
+    ),
+    "sec_def14a_bootstrap": frozenset({"sec_def14a"}),
+    "sec_business_summary_bootstrap": frozenset({"sec_10k"}),
+    "sec_insider_transactions_backfill": frozenset({"sec_form4"}),
+    "sec_form3_ingest": frozenset({"sec_form3"}),
+    "sec_8k_events_ingest": frozenset({"sec_8k"}),
+    "sec_13f_recent_sweep": frozenset({"sec_13f_hr"}),
+    "sec_n_port_ingest": frozenset({"sec_n_port"}),
+    "sec_n_csr_bootstrap_drain": frozenset({"sec_n_csr"}),
+}
+
+
+def _bootstrap_manifest_sources() -> frozenset[str]:
+    """Union of every manifest source a bootstrap stage drives.
+
+    Computed once at module import (idempotent — pure function over
+    the static map). Returned as a frozenset so callers can pass it
+    straight to the SQL ``ANY()`` binding without aliasing concerns.
+    """
+    out: set[str] = set()
+    for sources in _MANIFEST_SOURCES_BY_STAGE.values():
+        out.update(sources)
+    return frozenset(out)
+
+
+_BOOTSTRAP_MANIFEST_SOURCES: Final[frozenset[str]] = _bootstrap_manifest_sources()
+
+
+def reset_manifest_for_run(
+    conn: psycopg.Connection[Any],
+    *,
+    sources: Iterable[str],
+    reset_started_at: datetime,
+) -> int:
+    """Flip stale ``failed`` manifest rows back to ``pending`` at run start.
+
+    Reasons a row's failure state may be stale at run start:
+
+    * Parser version bumped since the prior attempt — the new parser
+      may extract a previously-failed body successfully.
+    * Backoff watermark (``next_retry_at``) is in the future but the
+      operator deliberately triggered a fresh bootstrap; the watermark
+      semantic targets routine retry pacing, not full-run resets.
+    * The prior failure was transient (network blip mid-fetch); the
+      run-start reset gives every accession a fresh attempt.
+
+    Two filters keep the reset narrow:
+
+    * ``source = ANY(sources)`` — only sources the orchestrator drives.
+      Sources owned by non-bootstrap drivers (FINRA short-interest /
+      RegSHO) are untouched.
+    * ``last_attempted_at < reset_started_at`` — defends against a
+      concurrent live cron worker landing a fresh ``failed`` row
+      mid-reset. Such a row has ``last_attempted_at >= NOW() >=
+      reset_started_at`` and would survive the filter even if the
+      orchestrator's ``UPDATE`` was already in flight when the worker
+      committed.
+
+    Rows in any other ``ingest_status`` (pending / fetched / parsed /
+    tombstoned) are left untouched: a stuck-``pending`` row is the
+    worker's problem; a ``parsed`` row stays parsed; a ``tombstoned``
+    row needs an explicit operator action (``POST /jobs/sec_rebuild``).
+
+    Returns the count of rows flipped for telemetry. Idempotent — a
+    second invocation finds zero matching rows.
+
+    The caller must commit the connection's transaction; the helper
+    does not start its own ``with conn.transaction():`` because the
+    orchestrator's prelude lives outside any open transaction (each
+    ``with psycopg.connect()`` block opens its own).
+    """
+    source_list = list(sources)
+    if not source_list:
+        # Empty source set means no stages in the catalogue write to
+        # ``sec_filing_manifest`` — defense-in-depth no-op. ``ANY('{}'
+        # )`` would match nothing anyway, but the early return saves a
+        # round trip and keeps the log line accurate.
+        logger.info("reset_manifest_for_run: empty source set; nothing to reset")
+        return 0
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE sec_filing_manifest
+               SET ingest_status     = 'pending',
+                   next_retry_at     = NULL,
+                   error             = NULL,
+                   last_attempted_at = NULL
+             WHERE source = ANY(%(sources)s::text[])
+               AND ingest_status = 'failed'
+               AND last_attempted_at IS NOT NULL
+               AND last_attempted_at < %(reset_started_at)s
+            """,
+            {"sources": source_list, "reset_started_at": reset_started_at},
+        )
+        count = cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+
+    logger.info(
+        "reset_manifest_for_run: %d failed rows flipped to pending (reset_started_at=%s, sources=%d)",
+        count,
+        reset_started_at.isoformat(),
+        len(source_list),
+    )
+    return count
+
+
 def run_bootstrap_orchestrator() -> None:
     """``_INVOKERS['bootstrap_orchestrator']`` — drive a queued run
     via lane-aware phase-batched dispatch (#1020).
@@ -1923,6 +2106,54 @@ def run_bootstrap_orchestrator() -> None:
             snapshot.run_status,
         )
         return
+
+    # #1233 PR-5a — manifest reset prelude.
+    #
+    # Runs AFTER the snapshot validation (so we know this run is
+    # actually ``running`` and not a stale ``complete`` row the
+    # orchestrator was re-invoked against) and BEFORE every dispatcher
+    # bookkeeping step (so a flipped row has the maximum time to drain
+    # in the same run). The opt-out key
+    # ``params['reset_failed_manifest']`` defaults to TRUE; an operator
+    # who wants to preserve stale failure state on a re-run can flip
+    # it FALSE at API-call time.
+    #
+    # The reset opens its own short-lived ``psycopg.connect()`` block
+    # rather than reusing the dispatcher's per-stage connections —
+    # the prelude must commit before the first stage runs so a stage
+    # that itself dispatches a manifest-touching invoker sees the
+    # ``pending`` state. Bundling the reset with a long-lived dispatch
+    # transaction would queue every reset row update behind every
+    # stage's row-level locks.
+    #
+    # Opt-out type discipline (Codex pre-push LOW): the JSONB CHECK
+    # only pins object SHAPE — a future internal writer that persists
+    # ``{"reset_failed_manifest": "false"}`` (string) or ``0`` (number)
+    # would pass shape validation, and naive truthiness ``.get()``
+    # would mis-classify the string ``"false"`` as truthy. Test for
+    # exact ``is False``: only the JSON boolean ``false`` (which
+    # psycopg decodes to Python ``False``) flips the prelude off.
+    # Every other persisted value (missing key, ``None``, ``"false"``,
+    # ``0``, ``1``, ``"true"``) preserves the default reset-on
+    # semantic — fail-closed against silent opt-out via type drift.
+    if snapshot.params.get("reset_failed_manifest", True) is not False:
+        with psycopg.connect(database_url) as conn:
+            reset_count = reset_manifest_for_run(
+                conn,
+                sources=_BOOTSTRAP_MANIFEST_SOURCES,
+                reset_started_at=snapshot.triggered_at,
+            )
+            conn.commit()
+        logger.info(
+            "bootstrap_orchestrator: run_id=%d manifest reset flipped %d rows",
+            run_id,
+            reset_count,
+        )
+    else:
+        logger.info(
+            "bootstrap_orchestrator: run_id=%d manifest reset skipped (params.reset_failed_manifest=False)",
+            run_id,
+        )
 
     # PR1c #1064 — build a stage_key → params lookup from the static
     # ``_BOOTSTRAP_STAGE_SPECS`` so the per-stage params dict can be
@@ -2087,6 +2318,7 @@ __all__ = [
     "JOB_MF_DIRECTORY_SYNC",
     "JOB_SEC_N_CSR_BOOTSTRAP_DRAIN",
     "get_bootstrap_stage_specs",
+    "reset_manifest_for_run",
     "run_bootstrap_orchestrator",
 ]
 

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -184,12 +184,21 @@ class StageRow:
 
 @dataclass(frozen=True)
 class RunSnapshot:
-    """Latest run + its stages, read in a single transaction."""
+    """Latest run + its stages, read in a single transaction.
+
+    ``params`` is the JSONB dict persisted on ``bootstrap_runs`` (sql/169,
+    #1233 PR-5a). Empty-object default on the column keeps the read
+    path branch-free — consumers call ``snapshot.params.get('<knob>',
+    <default>)`` without distinguishing NULL from missing. Today the
+    only consumer is the manifest-reset prelude
+    (``app/services/bootstrap_orchestrator.py::reset_manifest_for_run``).
+    """
 
     run_id: int
     run_status: RunStatus
     triggered_at: datetime
     completed_at: datetime | None
+    params: Mapping[str, Any] = field(default_factory=dict)
     stages: Sequence[StageRow] = field(default_factory=tuple)
 
 
@@ -293,7 +302,7 @@ def read_latest_run_with_stages(
     with conn.transaction():
         run_row = conn.execute(
             """
-            SELECT id, status, triggered_at, completed_at
+            SELECT id, status, triggered_at, completed_at, params
               FROM bootstrap_runs
              ORDER BY id DESC
              LIMIT 1
@@ -301,13 +310,14 @@ def read_latest_run_with_stages(
         ).fetchone()
         if run_row is None:
             return None
-        run_id, run_status, triggered_at, completed_at = run_row
+        run_id, run_status, triggered_at, completed_at, params = run_row
         return _read_run_with_stage_rows(
             conn,
             run_id=run_id,
             run_status=run_status,
             triggered_at=triggered_at,
             completed_at=completed_at,
+            params=params,
         )
 
 
@@ -334,7 +344,7 @@ def read_run_with_stages(
     with conn.transaction():
         run_row = conn.execute(
             """
-            SELECT id, status, triggered_at, completed_at
+            SELECT id, status, triggered_at, completed_at, params
               FROM bootstrap_runs
              WHERE id = %(run_id)s
             """,
@@ -342,13 +352,14 @@ def read_run_with_stages(
         ).fetchone()
         if run_row is None:
             return None
-        row_id, run_status, triggered_at, completed_at = run_row
+        row_id, run_status, triggered_at, completed_at, params = run_row
         return _read_run_with_stage_rows(
             conn,
             run_id=row_id,
             run_status=run_status,
             triggered_at=triggered_at,
             completed_at=completed_at,
+            params=params,
         )
 
 
@@ -359,6 +370,7 @@ def _read_run_with_stage_rows(
     run_status: RunStatus,
     triggered_at: datetime,
     completed_at: datetime | None,
+    params: Mapping[str, Any] | None,
 ) -> RunSnapshot:
     """Helper: project the stage rows for an already-located run row."""
     stage_rows = conn.execute(
@@ -398,6 +410,10 @@ def _read_run_with_stage_rows(
         run_status=run_status,
         triggered_at=triggered_at,
         completed_at=completed_at,
+        # JSONB column ``bootstrap_runs.params`` is NOT NULL DEFAULT
+        # '{}'::jsonb (sql/169); the ``or {}`` guards a legacy snapshot
+        # path that pre-dated the column, defense in depth.
+        params=params or {},
         stages=stages,
     )
 
@@ -407,6 +423,7 @@ def start_run(
     *,
     operator_id: UUID | None,
     stage_specs: Sequence[StageSpec],
+    params: Mapping[str, Any] | None = None,
 ) -> int:
     """Create a new bootstrap run + seed pending stage rows.
 
@@ -439,13 +456,27 @@ def start_run(
         if current_status == "running":
             raise BootstrapAlreadyRunning(run_id=last_run_id or 0)
 
+        # #1233 PR-5a — operator-supplied params dict persists on
+        # bootstrap_runs.params (sql/169 JSONB column, NOT NULL DEFAULT
+        # '{}'::jsonb). Passing ``None`` falls back to the column
+        # default. ``Jsonb`` adapter pins the type for psycopg3 — a
+        # raw dict would be ambiguous against the JSONB column.
+        from psycopg.types.json import Jsonb
+
         run_row = conn.execute(
             """
-            INSERT INTO bootstrap_runs (triggered_by_operator_id, status)
-            VALUES (%(operator_id)s, 'running')
+            INSERT INTO bootstrap_runs (triggered_by_operator_id, status, params)
+            VALUES (
+                %(operator_id)s,
+                'running',
+                COALESCE(%(params)s::jsonb, '{}'::jsonb)
+            )
             RETURNING id
             """,
-            {"operator_id": operator_id},
+            {
+                "operator_id": operator_id,
+                "params": Jsonb(dict(params)) if params else None,
+            },
         ).fetchone()
         if run_row is None:
             raise RuntimeError("INSERT INTO bootstrap_runs returned no row")

--- a/app/services/sec_manifest.py
+++ b/app/services/sec_manifest.py
@@ -380,9 +380,22 @@ def transition_status(
         # static analysis (pyright LiteralString) passes; the clause
         # tokens are module-local constants — never user input — but
         # composing through ``sql.SQL`` keeps the type safety habit.
+        # #1233 PR-5a — use ``clock_timestamp()`` rather than ``NOW()``
+        # (= ``transaction_timestamp()``, fixed at tx start). The
+        # bootstrap manifest reset prelude
+        # (``app/services/bootstrap_orchestrator.py::reset_manifest_for_run``)
+        # filters ``last_attempted_at < bootstrap_runs.triggered_at`` to
+        # protect concurrent live cron writes. ``NOW()`` would mis-stamp
+        # a long-running worker transaction's commit with its tx-start
+        # time — a worker tx begun before ``triggered_at`` but
+        # committing AFTER it would write a stale ``last_attempted_at``
+        # that survives the reset predicate and gets erroneously
+        # flipped to ``pending``. ``clock_timestamp()`` evaluates at
+        # statement time, so the stamp reflects when the failure was
+        # actually recorded.
         set_clauses: list[sql.Composable] = [
             sql.SQL("ingest_status = %(status)s"),
-            sql.SQL("last_attempted_at = COALESCE(%(attempt)s, NOW())"),
+            sql.SQL("last_attempted_at = COALESCE(%(attempt)s, clock_timestamp())"),
         ]
         params: dict[str, Any] = {
             "accession": accession_number,

--- a/sql/169_bootstrap_runs_params.sql
+++ b/sql/169_bootstrap_runs_params.sql
@@ -1,0 +1,90 @@
+-- 169_bootstrap_runs_params.sql
+--
+-- #1233 PR-5a (spec §9) — operator-facing param dict on bootstrap_runs.
+--
+-- ## What this adds
+--
+-- One JSONB column on ``bootstrap_runs``:
+--   * ``params`` — opaque JSON dict the API caller passes through to
+--     run-time prelude logic. Today the only consumer is the manifest
+--     reset prelude (``reset_manifest_for_run``); the column is sized
+--     for future per-run operator knobs (e.g. "skip stage X this run",
+--     "force re-download bulk archive") without churning the schema.
+--
+-- ## Why JSONB (not discrete columns)
+--
+-- Adding one BOOLEAN per knob would scale linearly with prelude
+-- features; every new knob ships a migration + an audit-table change
+-- + a backfill story. JSONB defaults to ``'{}'::jsonb`` so legacy rows
+-- (every existing bootstrap_runs row pre-#1233) read as "no overrides"
+-- without a one-shot UPDATE.
+--
+-- ## Why NOT NULL DEFAULT '{}'
+--
+-- Keeps the read path branch-free. Every consumer can call
+-- ``row['params'].get('reset_failed_manifest', True)`` without first
+-- distinguishing NULL from empty-object. The empty-object default is
+-- semantically equivalent to NULL but eliminates the dual-state code
+-- path. CHECK constraint enforces JSONB object shape (not array, not
+-- scalar) so a future bug that writes ``null`` or ``[]`` trips the DB
+-- guard instead of silently passing through ``.get()``.
+--
+-- ## Idempotent
+--
+-- ADD COLUMN IF NOT EXISTS guards repeat application. CHECK constraint
+-- adds via NOT VALID + VALIDATE pattern on re-application would be
+-- harmless on an empty new column; we use a single ADD CONSTRAINT IF
+-- NOT EXISTS gated by ``DO $$`` so a re-applied migration is safe.
+
+BEGIN;
+
+-- #1233 PR-5a — concurrency hardening for the manifest-reset prelude.
+--
+-- The reset predicate filters ``last_attempted_at < bootstrap_runs.triggered_at``
+-- to leave concurrent live cron writes alone (Codex pre-push HIGH).
+-- That predicate is sound only if ``last_attempted_at`` reflects when
+-- the worker statement ACTUALLY executed — not when its transaction
+-- began. PG's ``NOW()`` is ``transaction_timestamp()`` (fixed at tx
+-- start); a long-running worker tx begun BEFORE the bootstrap run
+-- triggered, but committing AFTER, would write a stale stamp that
+-- survives the reset predicate and gets erroneously flipped.
+--
+-- ``clock_timestamp()`` is per-statement wall-clock — its value
+-- always reflects when the UPDATE actually ran inside the worker tx.
+-- Combined with the parallel ``last_attempted_at = clock_timestamp()``
+-- swap in ``app/services/sec_manifest.py::transition_status``, the
+-- watermark predicate becomes race-safe.
+--
+-- Idempotent: CREATE OR REPLACE rewrites the trigger body. The trigger
+-- definition itself is unchanged (BEFORE UPDATE, per-row).
+CREATE OR REPLACE FUNCTION sec_filing_manifest_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at := clock_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE bootstrap_runs
+    ADD COLUMN IF NOT EXISTS params JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Pin the JSONB-object shape so future writers can't sneak in a
+-- top-level array / scalar / null without tripping the DB guard.
+-- ``jsonb_typeof`` is stable + cheap; CHECK runs only on INSERT /
+-- UPDATE of the column.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = 'bootstrap_runs_params_object_chk'
+           AND conrelid = 'bootstrap_runs'::regclass
+    ) THEN
+        ALTER TABLE bootstrap_runs
+            ADD CONSTRAINT bootstrap_runs_params_object_chk
+            CHECK (jsonb_typeof(params) = 'object');
+    END IF;
+END
+$$;
+
+COMMIT;

--- a/tests/test_bootstrap_manifest_reset.py
+++ b/tests/test_bootstrap_manifest_reset.py
@@ -1,0 +1,758 @@
+"""Tests for ``bootstrap_orchestrator.reset_manifest_for_run`` (#1233 PR-5a).
+
+Run-start prelude that flips stale ``ingest_status='failed'`` manifest
+rows back to ``pending`` so a fresh bootstrap is not poisoned by
+backoff watermarks from a cancelled prior run.
+
+Coverage:
+
+* Happy path: 10 failed rows pre-seeded, every one flipped + retry
+  state cleared.
+* Source-filter: a row owned by a non-bootstrap source (FINRA
+  short-interest) is left untouched.
+* Time-filter: a row whose ``last_attempted_at >= reset_started_at``
+  (simulating a concurrent live cron writer) is left untouched.
+* Opt-out: ``bootstrap_runs.params = {'reset_failed_manifest': False}``
+  short-circuits the prelude inside ``run_bootstrap_orchestrator``.
+* Non-``failed`` rows (pending / fetched / parsed / tombstoned) are
+  untouched even when source + time-filter match.
+* Idempotency: a second invocation returns 0.
+
+The reset itself is a pure SQL UPDATE; we do NOT spin the full
+dispatcher loop here. End-to-end orchestrator integration is covered
+by ``tests/test_bootstrap_orchestrator.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import psycopg
+import pytest
+from psycopg.types.json import Jsonb
+
+from app.services.bootstrap_orchestrator import (
+    _BOOTSTRAP_MANIFEST_SOURCES,
+    _MANIFEST_SOURCES_BY_STAGE,
+    reset_manifest_for_run,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+_TEST_INSTRUMENT_ID = 9251233  # PR-5a fixture instrument; pinned per-test to keep cohorts isolated.
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple]) -> int:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange,
+                                  currency, is_tradable)
+        VALUES (%s, 'TST_PR5A', 'TST_PR5A Co', 'TEST', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (_TEST_INSTRUMENT_ID,),
+    )
+    return _TEST_INSTRUMENT_ID
+
+
+def _wipe_manifest(conn: psycopg.Connection[tuple]) -> None:
+    """Clear every manifest row this test family writes. The shared
+    ``ebull_test_conn`` truncate covers ``sec_filing_manifest`` already
+    on setup; this is defense-in-depth for tests sharing a transaction.
+    """
+    conn.execute("DELETE FROM sec_filing_manifest WHERE accession_number LIKE 'PR5A-%'")
+
+
+def _insert_manifest_row(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession_number: str,
+    source: str,
+    form: str,
+    ingest_status: str,
+    last_attempted_at: datetime | None,
+    next_retry_at: datetime | None,
+    error: str | None,
+    instrument_id: int,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO sec_filing_manifest (
+            accession_number, cik, form, source,
+            subject_type, subject_id, instrument_id,
+            filed_at,
+            ingest_status, last_attempted_at, next_retry_at, error
+        ) VALUES (
+            %s, '0000000001', %s, %s,
+            'issuer', %s, %s,
+            now(),
+            %s, %s, %s, %s
+        )
+        """,
+        (
+            accession_number,
+            form,
+            source,
+            str(instrument_id),
+            instrument_id,
+            ingest_status,
+            last_attempted_at,
+            next_retry_at,
+            error,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Catalogue / source-set sanity
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_manifest_sources_includes_every_sec_source() -> None:
+    """The aggregate union covers every SEC-family manifest source.
+
+    FINRA sources (``finra_short_interest`` / ``finra_regsho_daily``)
+    are intentionally excluded — they have non-bootstrap drivers.
+    """
+    expected_sec = {
+        "sec_form3",
+        "sec_form4",
+        "sec_form5",
+        "sec_13d",
+        "sec_13g",
+        "sec_13f_hr",
+        "sec_def14a",
+        "sec_n_port",
+        "sec_n_csr",
+        "sec_10k",
+        "sec_10q",
+        "sec_8k",
+        "sec_xbrl_facts",
+    }
+    assert _BOOTSTRAP_MANIFEST_SOURCES == expected_sec
+    # Defense against silent drift: the per-stage breakdown's union
+    # must equal the aggregate constant.
+    union: set[str] = set()
+    for sources in _MANIFEST_SOURCES_BY_STAGE.values():
+        union.update(sources)
+    assert union == _BOOTSTRAP_MANIFEST_SOURCES
+
+
+def test_finra_sources_not_in_bootstrap_set() -> None:
+    """FINRA sources must NOT be in the bootstrap manifest set.
+
+    Their failure state is owned by ``finra_*`` scheduled jobs; flipping
+    them at bootstrap start would mask real failures from the operator.
+    """
+    assert "finra_short_interest" not in _BOOTSTRAP_MANIFEST_SOURCES
+    assert "finra_regsho_daily" not in _BOOTSTRAP_MANIFEST_SOURCES
+
+
+# ---------------------------------------------------------------------------
+# Helper round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_reset_flips_ten_failed_rows_to_pending(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """10 stale failed rows → 10 rows reset; retry state cleared."""
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale_attempt = reset_started_at - timedelta(hours=1)
+    future_retry = reset_started_at + timedelta(hours=6)
+
+    sources = sorted(_BOOTSTRAP_MANIFEST_SOURCES)
+    for i in range(10):
+        _insert_manifest_row(
+            ebull_test_conn,
+            accession_number=f"PR5A-FAIL-{i:04d}",
+            source=sources[i % len(sources)],
+            form="4" if sources[i % len(sources)] == "sec_form4" else "10-K",
+            ingest_status="failed",
+            last_attempted_at=stale_attempt,
+            next_retry_at=future_retry,
+            error=f"forced failure {i}",
+            instrument_id=iid,
+        )
+    ebull_test_conn.commit()
+
+    reset_count = reset_manifest_for_run(
+        ebull_test_conn,
+        sources=_BOOTSTRAP_MANIFEST_SOURCES,
+        reset_started_at=reset_started_at,
+    )
+    ebull_test_conn.commit()
+
+    assert reset_count == 10
+
+    rows = ebull_test_conn.execute(
+        """
+        SELECT accession_number, ingest_status, next_retry_at, error, last_attempted_at
+          FROM sec_filing_manifest
+         WHERE accession_number LIKE 'PR5A-FAIL-%'
+         ORDER BY accession_number
+        """
+    ).fetchall()
+    assert len(rows) == 10
+    for row in rows:
+        _, status_str, next_retry, error, last_attempted = row
+        assert status_str == "pending"
+        assert next_retry is None
+        assert error is None
+        assert last_attempted is None
+
+
+def test_source_filter_leaves_non_bootstrap_sources_untouched(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A failed row from a non-bootstrap source (FINRA) is left alone."""
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale_attempt = reset_started_at - timedelta(hours=1)
+
+    # One SEC row (in scope) + one FINRA row (out of scope).
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-SEC",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=stale_attempt,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="sec failure",
+        instrument_id=iid,
+    )
+    # FINRA rows are universe-scoped (no instrument); use subject_type
+    # 'finra_universe' to satisfy the CHECK constraint.
+    ebull_test_conn.execute(
+        """
+        INSERT INTO sec_filing_manifest (
+            accession_number, cik, form, source,
+            subject_type, subject_id, instrument_id,
+            filed_at,
+            ingest_status, last_attempted_at, next_retry_at, error
+        ) VALUES (
+            'PR5A-FAIL-FINRA', '0000000001', 'SI', 'finra_short_interest',
+            'finra_universe', 'FINRA_SI', NULL,
+            now(),
+            'failed', %s, %s, 'finra failure'
+        )
+        """,
+        (stale_attempt, reset_started_at + timedelta(hours=6)),
+    )
+    ebull_test_conn.commit()
+
+    reset_count = reset_manifest_for_run(
+        ebull_test_conn,
+        sources=_BOOTSTRAP_MANIFEST_SOURCES,
+        reset_started_at=reset_started_at,
+    )
+    ebull_test_conn.commit()
+    assert reset_count == 1
+
+    sec_row = ebull_test_conn.execute(
+        "SELECT ingest_status, next_retry_at, error FROM sec_filing_manifest WHERE accession_number = 'PR5A-FAIL-SEC'"
+    ).fetchone()
+    assert sec_row == ("pending", None, None)
+
+    finra_row = ebull_test_conn.execute(
+        "SELECT ingest_status, next_retry_at, error FROM sec_filing_manifest WHERE accession_number = 'PR5A-FAIL-FINRA'"
+    ).fetchone()
+    assert finra_row is not None
+    finra_status, finra_retry, finra_error = finra_row
+    assert finra_status == "failed"
+    assert finra_retry is not None
+    assert finra_error == "finra failure"
+
+
+def test_time_filter_leaves_concurrent_writes_untouched(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Row stamped AT or AFTER reset_started_at survives the reset."""
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale = reset_started_at - timedelta(seconds=1)
+    fresh_eq = reset_started_at  # boundary case: equal must NOT be reset.
+    fresh_gt = reset_started_at + timedelta(seconds=1)  # strict greater.
+
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-STALE",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=stale,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="stale failure",
+        instrument_id=iid,
+    )
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-FRESH-EQ",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=fresh_eq,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="fresh failure equal",
+        instrument_id=iid,
+    )
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-FRESH-GT",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=fresh_gt,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="fresh failure greater",
+        instrument_id=iid,
+    )
+    ebull_test_conn.commit()
+
+    reset_count = reset_manifest_for_run(
+        ebull_test_conn,
+        sources=_BOOTSTRAP_MANIFEST_SOURCES,
+        reset_started_at=reset_started_at,
+    )
+    ebull_test_conn.commit()
+
+    assert reset_count == 1
+
+    stale_row = ebull_test_conn.execute(
+        "SELECT ingest_status FROM sec_filing_manifest WHERE accession_number = 'PR5A-FAIL-STALE'"
+    ).fetchone()
+    assert stale_row == ("pending",)
+
+    eq_row = ebull_test_conn.execute(
+        "SELECT ingest_status, error FROM sec_filing_manifest WHERE accession_number = 'PR5A-FAIL-FRESH-EQ'"
+    ).fetchone()
+    assert eq_row == ("failed", "fresh failure equal")
+
+    gt_row = ebull_test_conn.execute(
+        "SELECT ingest_status, error FROM sec_filing_manifest WHERE accession_number = 'PR5A-FAIL-FRESH-GT'"
+    ).fetchone()
+    assert gt_row == ("failed", "fresh failure greater")
+
+
+def test_non_failed_rows_left_untouched(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Pending / fetched / parsed / tombstoned rows are never flipped."""
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale = reset_started_at - timedelta(hours=1)
+
+    for status_value, error_value in (
+        ("pending", None),
+        ("fetched", None),
+        ("parsed", None),
+        ("tombstoned", "give up"),
+    ):
+        _insert_manifest_row(
+            ebull_test_conn,
+            accession_number=f"PR5A-{status_value.upper()}",
+            source="sec_form4",
+            form="4",
+            ingest_status=status_value,
+            last_attempted_at=stale,
+            next_retry_at=None,
+            error=error_value,
+            instrument_id=iid,
+        )
+    ebull_test_conn.commit()
+
+    reset_count = reset_manifest_for_run(
+        ebull_test_conn,
+        sources=_BOOTSTRAP_MANIFEST_SOURCES,
+        reset_started_at=reset_started_at,
+    )
+    ebull_test_conn.commit()
+
+    assert reset_count == 0
+
+    statuses = ebull_test_conn.execute(
+        """
+        SELECT accession_number, ingest_status
+          FROM sec_filing_manifest
+         WHERE accession_number LIKE 'PR5A-%'
+         ORDER BY accession_number
+        """
+    ).fetchall()
+    assert statuses == [
+        ("PR5A-FETCHED", "fetched"),
+        ("PR5A-PARSED", "parsed"),
+        ("PR5A-PENDING", "pending"),
+        ("PR5A-TOMBSTONED", "tombstoned"),
+    ]
+
+
+def test_reset_is_idempotent(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Re-invoking after a successful reset returns 0 (nothing left)."""
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale = reset_started_at - timedelta(hours=1)
+
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-IDEM",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=stale,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="boom",
+        instrument_id=iid,
+    )
+    ebull_test_conn.commit()
+
+    first = reset_manifest_for_run(
+        ebull_test_conn,
+        sources=_BOOTSTRAP_MANIFEST_SOURCES,
+        reset_started_at=reset_started_at,
+    )
+    ebull_test_conn.commit()
+    assert first == 1
+
+    second = reset_manifest_for_run(
+        ebull_test_conn,
+        sources=_BOOTSTRAP_MANIFEST_SOURCES,
+        reset_started_at=reset_started_at,
+    )
+    ebull_test_conn.commit()
+    assert second == 0
+
+
+def test_empty_source_set_is_a_no_op(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Passing an empty source set short-circuits before SQL.
+
+    Defense-in-depth: ``ANY('{}')`` would match no rows anyway, but the
+    early return avoids the round trip and keeps the log line accurate.
+    A row that WOULD have qualified under the normal source set must
+    survive.
+    """
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale = reset_started_at - timedelta(hours=1)
+
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-EMPTY",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=stale,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="boom",
+        instrument_id=iid,
+    )
+    ebull_test_conn.commit()
+
+    reset_count = reset_manifest_for_run(
+        ebull_test_conn,
+        sources=frozenset(),
+        reset_started_at=reset_started_at,
+    )
+    ebull_test_conn.commit()
+
+    assert reset_count == 0
+    row = ebull_test_conn.execute(
+        "SELECT ingest_status, error FROM sec_filing_manifest WHERE accession_number = 'PR5A-FAIL-EMPTY'"
+    ).fetchone()
+    assert row == ("failed", "boom")
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator-level opt-out
+# ---------------------------------------------------------------------------
+
+
+def _reset_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        UPDATE bootstrap_state
+           SET status            = 'pending',
+               last_run_id       = NULL,
+               last_completed_at = NULL
+         WHERE id = 1
+        """
+    )
+    conn.commit()
+
+
+def test_opt_out_skips_reset_inside_orchestrator(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``params={'reset_failed_manifest': False}`` → orchestrator skips
+    the reset prelude and the stale failed row survives.
+
+    We bypass the full dispatcher loop by short-circuiting after the
+    prelude — the test patches ``_phase_batched_dispatch`` to return
+    an empty status set so the run terminalises cleanly.
+    """
+    from app.config import settings as app_settings
+    from app.services import bootstrap_orchestrator
+    from app.services.bootstrap_state import StageSpec, start_run
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    _reset_state(ebull_test_conn)
+    test_db_url = test_database_url()
+    monkeypatch.setattr(app_settings, "database_url", test_db_url)
+
+    # Register synthetic job-name in the source registry; the
+    # orchestrator dispatch path will skip the stage entirely because
+    # we monkeypatch ``_phase_batched_dispatch`` below, but JobLock
+    # construction inside ``_RunnableStage`` does not need a registered
+    # name (it is only constructed when dispatched).
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale = reset_started_at - timedelta(hours=1)
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-OPTOUT",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=stale,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="boom",
+        instrument_id=iid,
+    )
+    ebull_test_conn.commit()
+
+    # Seed a run with the opt-out param set. ``start_run`` requires at
+    # least one stage spec; use a single inert stage that the patched
+    # dispatch will skip.
+    specs = (StageSpec(stage_key="noop", stage_order=1, lane="init", job_name="noop_job"),)
+    run_id = start_run(
+        ebull_test_conn,
+        operator_id=None,
+        stage_specs=specs,
+        params={"reset_failed_manifest": False},
+    )
+    ebull_test_conn.commit()
+    assert run_id > 0
+
+    # Confirm the JSONB persisted shape — the opt-out roundtrips.
+    row = ebull_test_conn.execute("SELECT params FROM bootstrap_runs WHERE id = %s", (run_id,)).fetchone()
+    assert row is not None
+    assert row[0] == {"reset_failed_manifest": False}
+
+    # Patch the dispatcher so the run terminalises without trying to
+    # invoke the noop stage. The prelude runs BEFORE the dispatcher
+    # call, so this patch does not gate the reset under test.
+    def _noop_dispatch(*_args: object, **_kwargs: object) -> tuple[dict[str, str], bool]:
+        return ({}, False)
+
+    monkeypatch.setattr(
+        bootstrap_orchestrator,
+        "_phase_batched_dispatch",
+        _noop_dispatch,
+    )
+
+    bootstrap_orchestrator.run_bootstrap_orchestrator()
+
+    # The opt-out row must still be ``failed`` with its original
+    # error + next_retry_at intact.
+    after = ebull_test_conn.execute(
+        """
+        SELECT ingest_status, next_retry_at, error
+          FROM sec_filing_manifest
+         WHERE accession_number = 'PR5A-FAIL-OPTOUT'
+        """
+    ).fetchone()
+    assert after is not None
+    status_after, retry_after, error_after = after
+    assert status_after == "failed"
+    assert retry_after is not None
+    assert error_after == "boom"
+
+
+def test_default_run_resets_manifest_inside_orchestrator(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run with no ``reset_failed_manifest`` override flips the row.
+
+    Mirror of the opt-out test with the default-TRUE param semantic.
+    """
+    from app.config import settings as app_settings
+    from app.services import bootstrap_orchestrator
+    from app.services.bootstrap_state import StageSpec, start_run
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    _reset_state(ebull_test_conn)
+    test_db_url = test_database_url()
+    monkeypatch.setattr(app_settings, "database_url", test_db_url)
+
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale = reset_started_at - timedelta(hours=1)
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-DEFAULT",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=stale,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="boom",
+        instrument_id=iid,
+    )
+    ebull_test_conn.commit()
+
+    specs = (StageSpec(stage_key="noop", stage_order=1, lane="init", job_name="noop_job"),)
+    # No params → defaults to '{}'::jsonb on the column.
+    run_id = start_run(ebull_test_conn, operator_id=None, stage_specs=specs)
+    ebull_test_conn.commit()
+    assert run_id > 0
+
+    def _noop_dispatch(*_args: object, **_kwargs: object) -> tuple[dict[str, str], bool]:
+        return ({}, False)
+
+    monkeypatch.setattr(
+        bootstrap_orchestrator,
+        "_phase_batched_dispatch",
+        _noop_dispatch,
+    )
+
+    bootstrap_orchestrator.run_bootstrap_orchestrator()
+
+    after = ebull_test_conn.execute(
+        """
+        SELECT ingest_status, next_retry_at, error, last_attempted_at
+          FROM sec_filing_manifest
+         WHERE accession_number = 'PR5A-FAIL-DEFAULT'
+        """
+    ).fetchone()
+    assert after is not None
+    status_after, retry_after, error_after, attempted_after = after
+    assert status_after == "pending"
+    assert retry_after is None
+    assert error_after is None
+    assert attempted_after is None
+
+
+# ---------------------------------------------------------------------------
+# Migration smoke — ``params`` column shape
+# ---------------------------------------------------------------------------
+
+
+def test_opt_out_only_honours_exact_boolean_false(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persisted truthy / falsy non-bool values do NOT opt out.
+
+    The JSONB CHECK constraint (sql/169) pins object SHAPE but not the
+    inner value type. A future internal writer that persisted
+    ``{"reset_failed_manifest": "false"}`` (string) or ``0`` (number)
+    would pass shape validation. Naive ``.get()`` truthiness would
+    treat the string ``"false"`` as truthy — easy to mis-read in
+    review. The orchestrator uses ``is not False`` so ONLY the exact
+    JSON boolean ``false`` opts out; every other persisted value
+    preserves the default reset-on semantic.
+    """
+    from app.config import settings as app_settings
+    from app.services import bootstrap_orchestrator
+    from app.services.bootstrap_state import StageSpec, start_run
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    _reset_state(ebull_test_conn)
+    test_db_url = test_database_url()
+    monkeypatch.setattr(app_settings, "database_url", test_db_url)
+
+    iid = _seed_instrument(ebull_test_conn)
+    _wipe_manifest(ebull_test_conn)
+    reset_started_at = datetime.now(tz=UTC)
+    stale = reset_started_at - timedelta(hours=1)
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="PR5A-FAIL-TYPE",
+        source="sec_form4",
+        form="4",
+        ingest_status="failed",
+        last_attempted_at=stale,
+        next_retry_at=reset_started_at + timedelta(hours=6),
+        error="boom",
+        instrument_id=iid,
+    )
+    ebull_test_conn.commit()
+
+    # Persist a string "false" — passes JSONB object-shape check but
+    # is NOT the boolean ``false``.
+    specs = (StageSpec(stage_key="noop", stage_order=1, lane="init", job_name="noop_job"),)
+    run_id = start_run(
+        ebull_test_conn,
+        operator_id=None,
+        stage_specs=specs,
+        params={"reset_failed_manifest": "false"},
+    )
+    ebull_test_conn.commit()
+    assert run_id > 0
+
+    def _noop_dispatch(*_args: object, **_kwargs: object) -> tuple[dict[str, str], bool]:
+        return ({}, False)
+
+    monkeypatch.setattr(
+        bootstrap_orchestrator,
+        "_phase_batched_dispatch",
+        _noop_dispatch,
+    )
+
+    bootstrap_orchestrator.run_bootstrap_orchestrator()
+
+    # Reset MUST have fired — string "false" did NOT opt out.
+    after = ebull_test_conn.execute(
+        """
+        SELECT ingest_status, error
+          FROM sec_filing_manifest
+         WHERE accession_number = 'PR5A-FAIL-TYPE'
+        """
+    ).fetchone()
+    assert after == ("pending", None)
+
+
+def test_bootstrap_runs_params_jsonb_object_check(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """sql/169 enforces ``params`` is a JSONB object (not array / scalar)."""
+    _reset_state(ebull_test_conn)
+    # Object is allowed.
+    ebull_test_conn.execute(
+        "INSERT INTO bootstrap_runs (status, params) VALUES ('complete', %s)",
+        (Jsonb({"reset_failed_manifest": True}),),
+    )
+    ebull_test_conn.commit()
+
+    # Array must trip the CHECK constraint.
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(
+            "INSERT INTO bootstrap_runs (status, params) VALUES ('complete', %s)",
+            (Jsonb([1, 2, 3]),),
+        )
+    ebull_test_conn.rollback()
+
+    # Scalar must also trip.
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(
+            "INSERT INTO bootstrap_runs (status, params) VALUES ('complete', %s)",
+            (Jsonb("not an object"),),
+        )
+    ebull_test_conn.rollback()


### PR DESCRIPTION
## Summary

Run-start prelude that flips stale `ingest_status='failed'` manifest rows back to `pending` so a fresh bootstrap is not poisoned by backoff watermarks left by a cancelled prior run.

- New helper `reset_manifest_for_run(conn, *, sources, reset_started_at)` UPDATEs `sec_filing_manifest` with strict source whitelist + strict-`<` time filter against `bootstrap_runs.triggered_at` (defends against concurrent live cron writes).
- Wired into `run_bootstrap_orchestrator` prelude AFTER `running` snapshot validation, BEFORE the dispatcher loop. Source set = `_BOOTSTRAP_MANIFEST_SOURCES` (SEC subset of `ManifestSource`; FINRA sources excluded — owned by non-bootstrap drivers).
- Operator opt-out: `bootstrap_runs.params['reset_failed_manifest']` (default TRUE). New JSONB column added by `sql/169_bootstrap_runs_params.sql` (`NOT NULL DEFAULT '{}'::jsonb` + `jsonb_typeof = 'object'` CHECK).
- Orchestrator tests for exact `is False` so type-drift (string `"false"`, integer `0`) fail-closed against silent opt-out.

## Race-correctness side-fix

Swap `NOW()` → `clock_timestamp()` in `app/services/sec_manifest.py::transition_status` and the `sec_filing_manifest_touch_updated_at` trigger (sql/169 redefines).

`NOW()` is `transaction_timestamp()` (fixed at tx start); a long-running worker tx begun BEFORE `bootstrap_runs.triggered_at` but committing AFTER would write a stale `last_attempted_at` that survives the reset predicate and gets erroneously flipped. `clock_timestamp()` evaluates per-statement, so the stamp reflects when the failure was actually recorded.

Race coverage audited: the only non-FINRA writer to `last_attempted_at` on a `failed` row is `transition_status` (now `clock_timestamp()`). FINRA writers still use `NOW()` but FINRA sources are excluded from the reset source whitelist. The `#1131 backfill` sweep in `sec_manifest.py` transitions to `tombstoned` (non-failed), so the reset predicate cannot touch its rows.

## Why

Run #4 inherited 1.18M `failed` rows from cancelled run #3, none of which would drain in the new run because `next_retry_at` was 24h+ ahead. Manifest-worker has no concept of "fresh bootstrap = clear backoff". Without the prelude, a bootstrap completes but the manifest worker doesn't catch up for days.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pyright` — clean
- [x] `uv run pytest tests/test_bootstrap_manifest_reset.py` — 12/12 pass
- [x] `uv run pytest tests/test_bootstrap_orchestrator.py tests/test_bootstrap_state.py tests/test_api_bootstrap.py tests/test_bootstrap_cancel.py` — 71+ tests pass, no regressions
- [x] Codex 2 pre-push review: **no findings** (race coverage verified, SQL injection clean, idempotency confirmed, opt-out fail-closed semantics validated)

## Test coverage

Tests at `tests/test_bootstrap_manifest_reset.py`:

1. `test_bootstrap_manifest_sources_includes_every_sec_source` — aggregate union covers every SEC `ManifestSource` value; FINRA excluded.
2. `test_finra_sources_not_in_bootstrap_set` — explicit exclusion check.
3. `test_reset_flips_ten_failed_rows_to_pending` — happy-path 10-row flip; `next_retry_at` / `error` / `last_attempted_at` all NULL post-reset.
4. `test_source_filter_leaves_non_bootstrap_sources_untouched` — FINRA row survives.
5. `test_time_filter_leaves_concurrent_writes_untouched` — boundary case: `last_attempted_at >= reset_started_at` (both equal and strict-greater) is preserved.
6. `test_non_failed_rows_left_untouched` — pending/fetched/parsed/tombstoned all preserved.
7. `test_reset_is_idempotent` — second invocation returns 0.
8. `test_empty_source_set_is_a_no_op` — early-return short-circuit.
9. `test_opt_out_skips_reset_inside_orchestrator` — full orchestrator integration with `params={"reset_failed_manifest": False}`.
10. `test_default_run_resets_manifest_inside_orchestrator` — default-TRUE path through orchestrator.
11. `test_opt_out_only_honours_exact_boolean_false` — type-drift fails-closed (`"false"` string does NOT opt out).
12. `test_bootstrap_runs_params_jsonb_object_check` — sql/169 CHECK constraint rejects array / scalar.

## Operator notes

- This is the bootstrap orchestrator prelude only; routine cron `sec_manifest_worker` paths are unchanged.
- The `clock_timestamp()` swap on `transition_status` is a strict improvement: production correctness was never load-bearing on `transaction_timestamp()` semantics — the prior `NOW()` happened to be correct for most cases but inverted under long worker transactions that PR-5a needed to safely race against.
- ETL/parser DoD clauses 8-12 do not apply: this PR adds a run-start prelude with no parser changes, no schema migration affecting ownership / fundamentals / observations data, and no operator-visible figure changes. The migration adds a metadata column on `bootstrap_runs`.

Refs #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)