### PR TITLE
feat(#1233): PR-6 — bootstrap orphan-stage reaper

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -822,6 +822,36 @@ The `last_attempted_at` stamp itself uses `clock_timestamp()` (statement-time wa
 **Idempotency:** the reset is a single SQL UPDATE; a second invocation finds zero matching rows. Re-queuing the orchestrator after a worker crash is safe.
 
 **Out of scope:** the prelude does NOT touch rows in any other state — `pending` rows stay pending, `parsed` stays parsed, `tombstoned` stays tombstoned. A stuck-`pending` row is the manifest-worker's problem (#1224); a `tombstoned` row needs an explicit `POST /jobs/sec_rebuild/run`.
+### 6.5.9 Bootstrap orphan-stage reaper (#1233 PR-6)
+
+When the jobs process crashes mid-stage, `bootstrap_stages.status` stays `'running'` forever. On restart, the dispatcher's `mark_stage_running(... AND status='pending')` silently no-ops against the stale row and the run sits stuck — operator must manually clear via Re-run failed.
+
+The `reap_orphaned_running_stages` prelude (in [`bootstrap_orchestrator.py`](../../../app/services/bootstrap_orchestrator.py)) runs at the top of `run_bootstrap_orchestrator`, immediately after the `read_latest_run_with_stages` snapshot and before the dispatcher loop. Reset criteria — ALL THREE must hold:
+
+1. `status = 'running'`.
+2. `started_at < NOW() - INTERVAL '5 minutes'` (`_REAPER_GRACE_SECONDS = 300`). The grace window is longer than the slowest known stage's start-up so a worker that's alive-but-slow doesn't get its row pulled out from under it.
+3. The corresponding `JobLock` advisory lock is NOT held in any Postgres session **in this database**. Probed via `SELECT 1 FROM pg_locks WHERE locktype='advisory' AND objsubid=1 AND database=(current DB OID) AND classid=... AND objid=...` — **read-only, NEVER acquires**. The `database` predicate matters when multiple eBull instances share a Postgres cluster (dev + ebull_test on localhost:5432): the same advisory key in a sibling DB would otherwise spuriously suppress reset in this DB.
+
+Lock key derivation MUST byte-for-byte match [`JobLock` at `app/jobs/locks.py:224`](../../../app/jobs/locks.py#L224): `hashtext('job_source:' || <source>)::int` (NOT `hashtextextended` — the JobLock key space is int4 by construction).
+
+**`pg_locks` shape gotcha (empirically verified 2026-05-23).** `hashtext` returns a signed `int4`. When that's widened to the bigint key for `pg_try_advisory_lock(bigint)`, the high 32 bits depend on the sign:
+
+- Positive hashtext (e.g. `hashtext('job_source:openfigi') = 1_447_707_902`): `pg_locks.classid = 0, objid = <hashtext>`.
+- Negative hashtext (e.g. `hashtext('job_source:finra') = -685_386_401`): `pg_locks.classid = 4_294_967_295 (= 0xFFFFFFFF), objid = <hashtext & 0xFFFFFFFF> = 3_609_580_895`.
+
+A naive probe of `classid = 0 AND objid = <hashtext>` would silently MISS every negative-hashtext key and reset stages whose workers are alive. The correct probe lets Postgres do the bigint split itself: `classid = ((K::bigint >> 32) & 4294967295)::oid AND objid = (K::bigint & 4294967295)::oid`. `objsubid = 1` is session-scope (the `JobLock` form); transaction-scoped advisory locks use `objsubid = 2` — we deliberately do NOT probe those.
+
+**Reset shape.** On match, the row transitions `running` → `pending`: `started_at` / `completed_at` cleared, `last_error` APPENDED (not replaced) with `'reaper: reset from orphaned running (<NOW()>)'`. The append preserves forensic context from the previous crash so the operator can still investigate via `last_error`.
+
+The UPDATE is guarded by `AND status = 'running'` so a stage that transitioned to `'success'` / `'error'` between the SELECT and the UPDATE is left alone (Codex pre-push W3 pattern).
+
+**Caveats — accepted residual risk.**
+
+* Cannot detect a hung-but-alive worker that holds the lock but makes no progress. The grace window catches the obvious case (worker crashed before its first commit); a deeper deadlock requires operator Re-run failed.
+* Cannot detect the #1184 re-entrancy edge case where the outer-thread holds the lock but the stage-thread itself crashed — the outer holder will release on its own crash, and the next reaper pass after grace will reset.
+* A stage whose `job_name` is not in the `app.jobs.sources.JOB_NAME_TO_SOURCE` registry is LEFT ALONE (logged as a warning). The reaper must never reset a stage whose lock-key shape it cannot derive — doing so would silently reset a stage whose worker IS alive (registry gap is an operator mistake, not a crash signal).
+
+Acceptance criterion (`docs/superpowers/specs/2026-05-22-bootstrap-etl-optimisation-v3.md` §15): "process crash mid-stage: reaper resets to pending within 6 min (5 min grace + 1 min poll)".
 
 ## 6. Known live caveats / tech debt
 

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -2076,6 +2076,223 @@ def reset_manifest_for_run(
     return count
 
 
+# ---------------------------------------------------------------------------
+# Orphan-stage reaper (#1233 PR-6)
+# ---------------------------------------------------------------------------
+#
+# Symptom this fixes: if the jobs process crashes mid-stage,
+# ``bootstrap_stages.status`` stays ``'running'`` forever. On jobs-process
+# restart, the dispatcher's ``_should_run`` accepts ``'running'`` as runnable
+# BUT the per-stage dispatcher path then calls
+# ``mark_stage_running(... AND status='pending')`` which silently no-ops
+# against the stale running row, and the run sits stuck. Operator has to
+# manually clear via Re-run failed.
+#
+# Solution: just before the dispatcher loop, sweep rows whose worker is
+# provably dead (advisory lock NOT held in any session) and whose
+# ``started_at`` is older than ``_REAPER_GRACE_SECONDS`` (5 min — longer
+# than the slowest known stage start-up). Stale rows transition back to
+# ``'pending'`` so the dispatcher can pick them up cleanly.
+#
+# Liveness probe: read-only ``SELECT FROM pg_locks`` — NEVER acquires.
+# Lock key derivation MUST match ``JobLock`` exactly: ``hashtext('job_source:'
+# || <source>)::int`` (NOT ``hashtextextended`` — the locks key space is
+# int4 by construction; see ``app/jobs/locks.py:224``).
+#
+# Caveats (documented residual risk):
+# * Cannot detect a hung-but-alive worker that holds the lock without
+#   making progress. The grace window catches the obvious case (worker
+#   crashed before its first commit); a deeper deadlock requires an
+#   operator Re-run failed.
+# * Cannot detect re-entrancy (#1184) edge where the outer-thread holds
+#   the lock but the stage-thread itself crashed — accepted residual risk
+#   because the outer holder will release on its own crash, and the next
+#   reaper pass after grace will reset.
+# * The reset path is guarded by ``AND status='running'`` so a stage that
+#   transitioned to ``'success'``/``'error'`` between the SELECT and the
+#   UPDATE is left alone (Codex pre-push W3 pattern).
+
+_REAPER_GRACE_SECONDS: Final[int] = 300
+"""Minimum age before a ``running`` stage with no held lock is reset.
+
+Longer than the slowest known stage's start-up window (Phase B SEC
+filer-directory fetches take up to ~3 min on cold caches). A reset that
+fires before the worker has reached its first transaction is the
+worst-case false positive — the dispatcher would then race the worker
+on the same stage row. 5 minutes is a safe over-estimate of "the worker
+would have committed SOMETHING by now if it were alive."
+"""
+
+
+def _hashtext_int(conn: psycopg.Connection[Any], text: str) -> int:
+    """Return Postgres ``hashtext(text)::int`` — JobLock's lock-key shape.
+
+    MUST match ``app/jobs/locks.py:224``:
+        SELECT pg_try_advisory_lock(hashtext(%s)::int)
+
+    ``hashtext`` (NOT ``hashtextextended``) returns int4; the cast to
+    ``::int`` is a no-op in current PG but kept explicit so the call
+    site here mirrors the JobLock SQL byte-for-byte. Computing this
+    Python-side via a re-implementation of PG's hashtext is hostile to
+    review — a single PG version drift between Python clone and PG
+    server would silently miscompute the key. Round-tripping through
+    the active connection is honest and cheap (one query per stage).
+
+    Returned int is the signed int4 value (can be negative). Empirical:
+    ``hashtext('job_source:finra') = -685386401``. Callers probing
+    ``pg_locks`` must split this signed-int-widened-to-bigint into
+    ``(classid, objid)`` halves — see the probe SQL in
+    ``reap_orphaned_running_stages``.
+    """
+    row = conn.execute("SELECT hashtext(%(text)s)::int", {"text": text}).fetchone()
+    if row is None:
+        # Defensive: hashtext is a deterministic builtin; an empty row
+        # means the connection or DB itself is in an unexpected state.
+        raise RuntimeError(f"hashtext({text!r}) returned no row")
+    return int(row[0])
+
+
+def reap_orphaned_running_stages(
+    conn: psycopg.Connection[Any],
+    *,
+    run_id: int,
+) -> int:
+    """Reset ``running`` stages whose worker is provably dead.
+
+    Criteria for reset:
+
+    1. ``bootstrap_stages.status = 'running'``.
+    2. ``started_at < NOW() - INTERVAL '5 minutes'`` (grace window).
+    3. The corresponding ``JobLock`` advisory lock is NOT held in any
+       Postgres session — probed read-only via ``pg_locks``.
+
+    Lock key = ``hashtext('job_source:' || source)::int`` where
+    ``source = app.jobs.sources.source_for(job_name)``. Bytes-for-bytes
+    match with ``JobLock``'s acquisition SQL (``app/jobs/locks.py:224``).
+
+    On reset the stage transitions ``running`` → ``pending``:
+      * ``started_at`` / ``completed_at`` cleared.
+      * ``last_error`` is APPENDED (not replaced) with a reaper marker
+        so forensic context for the next crash is preserved.
+
+    Returns the count of stages reset. Idempotent — repeat calls with
+    no orphans return 0.
+
+    Defensive fallbacks:
+      * ``source_for(job_name)`` raising ``KeyError`` (registry gap)
+        logs a warning and leaves the row alone. The reaper must never
+        reset a stage whose lock semantics it cannot prove.
+    """
+    # Lazy import: app.jobs.sources -> app.services.bootstrap_orchestrator
+    # at module load via the JOB_NAME_TO_SOURCE construction. Importing
+    # back here at top-of-module would close the cycle.
+    from app.jobs.sources import source_for
+
+    candidate_rows = conn.execute(
+        """
+        SELECT stage_key, job_name
+          FROM bootstrap_stages
+         WHERE bootstrap_run_id = %(run_id)s
+           AND status = 'running'
+           AND started_at IS NOT NULL
+           AND started_at < NOW() - make_interval(secs => %(grace)s)
+        """,
+        {"run_id": run_id, "grace": _REAPER_GRACE_SECONDS},
+    ).fetchall()
+
+    count = 0
+    for stage_key, job_name in candidate_rows:
+        try:
+            source = source_for(job_name)
+        except KeyError:
+            logger.warning(
+                "reap_orphaned_running_stages: stage %r job_name %r has no source mapping; "
+                "leaving stale running row alone (defensive — cannot prove lock-not-held without "
+                "the source key)",
+                stage_key,
+                job_name,
+            )
+            continue
+
+        lock_key = _hashtext_int(conn, f"job_source:{source}")
+        # ``pg_locks`` splits the bigint advisory-lock key into two
+        # uint32 halves: ``classid`` (high 32 bits) and ``objid`` (low
+        # 32 bits). For a *positive* int4 key like 1_447_707_902 the
+        # widening to int8 leaves the high half all-zero so
+        # ``classid=0``; for a *negative* int4 key like -685_386_401
+        # the sign-extension fills the high half with 1s so
+        # ``classid=4_294_967_295`` (= ``0xFFFFFFFF``). Probing only
+        # ``classid=0`` would miss every negative-hashtext key (e.g.
+        # ``job_source:finra``) and silently fail to detect the held
+        # lock — the reaper would then reset a stage whose worker IS
+        # alive. The arithmetic split is done PG-side via ``::bigint``
+        # so the byte shape is identical to the kernel split.
+        # ``objsubid=1`` is session-scope (PG sets ``=2`` for
+        # transaction-scoped advisory locks; the JobLock path uses
+        # the session form).
+        #
+        # ``database = (current_database OID)`` scopes the probe to
+        # locks held in THIS database only (Codex 2 medium). The same
+        # advisory key in a sibling DB on the same Postgres cluster
+        # (e.g. dev + ebull_test running on localhost:5432 with their
+        # own bootstrap processes) would otherwise spuriously satisfy
+        # the probe and suppress a legitimate reset in this DB.
+        # ``pg_locks.database`` is OID; ``current_database()`` returns
+        # name → join via ``pg_database`` rather than rely on a
+        # hardcoded OID literal.
+        held_row = conn.execute(
+            """
+            SELECT 1
+              FROM pg_locks
+             WHERE locktype = 'advisory'
+               AND objsubid = 1
+               AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+               AND classid  = ((%(lock_key)s::bigint >> 32) & 4294967295)::oid
+               AND objid    = (%(lock_key)s::bigint & 4294967295)::oid
+            """,
+            {"lock_key": lock_key},
+        ).fetchone()
+        if held_row is not None:
+            # Worker (or some other session) still holds the lock; the
+            # stage may actually be running. Skip reset; operator can
+            # force-cancel via the existing Re-run failed UX if the
+            # worker is hung-but-alive.
+            continue
+
+        result = conn.execute(
+            """
+            UPDATE bootstrap_stages
+               SET status       = 'pending',
+                   started_at   = NULL,
+                   completed_at = NULL,
+                   last_error   = COALESCE(last_error, '')
+                                  || CASE WHEN COALESCE(last_error, '') = '' THEN '' ELSE E'\n' END
+                                  || 'reaper: reset from orphaned running ('
+                                  || NOW()::text || ')'
+             WHERE bootstrap_run_id = %(run_id)s
+               AND stage_key        = %(stage_key)s
+               AND status           = 'running'
+            """,
+            {"run_id": run_id, "stage_key": stage_key},
+        )
+        if result.rowcount > 0:
+            count += 1
+
+    if count > 0:
+        logger.info(
+            "reap_orphaned_running_stages: run_id=%d reset %d orphan stage(s) back to pending",
+            run_id,
+            count,
+        )
+    else:
+        logger.debug(
+            "reap_orphaned_running_stages: run_id=%d no orphans (grace=%ds)",
+            run_id,
+            _REAPER_GRACE_SECONDS,
+        )
+    return count
+
+
 def run_bootstrap_orchestrator() -> None:
     """``_INVOKERS['bootstrap_orchestrator']`` — drive a queued run
     via lane-aware phase-batched dispatch (#1020).
@@ -2154,6 +2371,16 @@ def run_bootstrap_orchestrator() -> None:
             "bootstrap_orchestrator: run_id=%d manifest reset skipped (params.reset_failed_manifest=False)",
             run_id,
         )
+
+    # #1233 PR-6 — sweep stages stuck in ``running`` from a previous
+    # jobs-process crash. Reset is guarded by ``pg_locks`` evidence that
+    # the worker's advisory lock is no longer held + a 5-min grace
+    # window. Runs AFTER the manifest reset prelude and BEFORE the
+    # dispatcher loop so the freshly reset rows enter dispatch as
+    # ``pending``. Idempotent — zero orphans is the steady state.
+    with psycopg.connect(database_url) as conn:
+        reap_orphaned_running_stages(conn, run_id=run_id)
+        conn.commit()
 
     # PR1c #1064 — build a stage_key → params lookup from the static
     # ``_BOOTSTRAP_STAGE_SPECS`` so the per-stage params dict can be
@@ -2318,6 +2545,7 @@ __all__ = [
     "JOB_MF_DIRECTORY_SYNC",
     "JOB_SEC_N_CSR_BOOTSTRAP_DRAIN",
     "get_bootstrap_stage_specs",
+    "reap_orphaned_running_stages",
     "reset_manifest_for_run",
     "run_bootstrap_orchestrator",
 ]

--- a/tests/test_bootstrap_orphan_reaper.py
+++ b/tests/test_bootstrap_orphan_reaper.py
@@ -1,0 +1,490 @@
+"""Tests for the bootstrap orphan-stage reaper (#1233 PR-6).
+
+The reaper resets ``bootstrap_stages`` rows that have been stuck in
+``status='running'`` since a previous jobs-process crash so the
+dispatcher can pick them up cleanly on restart. Reset criteria:
+
+1. ``status = 'running'``.
+2. ``started_at`` older than ``_REAPER_GRACE_SECONDS`` (5 min).
+3. The corresponding JobLock advisory lock is NOT held in any session.
+
+All three predicates must hold; failing any one leaves the row alone.
+
+Test DB: each test starts from a TRUNCATEd ``ebull_test_conn`` so
+synthetic rows don't bleed between cases. Rows that simulate "started
+N minutes ago" use ``NOW() - INTERVAL '...'`` so the grace-window
+comparison is exercised against the real wall clock.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.bootstrap_orchestrator import (
+    _REAPER_GRACE_SECONDS,
+    _hashtext_int,
+    reap_orphaned_running_stages,
+)
+from app.services.bootstrap_state import StageSpec, start_run
+
+
+def _reset_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        UPDATE bootstrap_state
+           SET status            = 'pending',
+               last_run_id       = NULL,
+               last_completed_at = NULL
+         WHERE id = 1
+        """
+    )
+    conn.commit()
+
+
+def _register_synthetic_jobs(monkeypatch: pytest.MonkeyPatch, mapping: dict[str, str]) -> None:
+    """Add ``job_name -> Lane`` entries to the source-lock registry.
+
+    Same helper shape as ``tests/test_bootstrap_orchestrator.py``.
+    """
+    from app.jobs.sources import get_job_name_to_source
+
+    registry = get_job_name_to_source()
+    for name, lane in mapping.items():
+        monkeypatch.setitem(registry, name, lane)  # type: ignore[arg-type]
+
+
+def _seed_stage(
+    conn: psycopg.Connection[tuple],
+    *,
+    run_id: int,
+    stage_key: str,
+    status: str,
+    started_minutes_ago: int | None,
+    last_error: str | None = None,
+) -> None:
+    """Force a bootstrap_stages row to the given (status, started_at) shape.
+
+    Bypasses the ``mark_stage_*`` helpers so we can set ``started_at``
+    to a past time without sleeping.
+    """
+    conn.execute(
+        """
+        UPDATE bootstrap_stages
+           SET status     = %(status)s,
+               started_at = CASE
+                              WHEN %(minutes)s::int IS NULL THEN NULL
+                              ELSE NOW() - make_interval(mins => %(minutes)s::int)
+                            END,
+               last_error = %(last_error)s
+         WHERE bootstrap_run_id = %(run_id)s
+           AND stage_key        = %(stage_key)s
+        """,
+        {
+            "run_id": run_id,
+            "stage_key": stage_key,
+            "status": status,
+            "minutes": started_minutes_ago,
+            "last_error": last_error,
+        },
+    )
+    conn.commit()
+
+
+def _status_of(conn: psycopg.Connection[tuple], *, run_id: int, stage_key: str) -> str:
+    row = conn.execute(
+        "SELECT status FROM bootstrap_stages WHERE bootstrap_run_id = %s AND stage_key = %s",
+        (run_id, stage_key),
+    ).fetchone()
+    assert row is not None
+    return str(row[0])
+
+
+def _last_error_of(conn: psycopg.Connection[tuple], *, run_id: int, stage_key: str) -> str | None:
+    row = conn.execute(
+        "SELECT last_error FROM bootstrap_stages WHERE bootstrap_run_id = %s AND stage_key = %s",
+        (run_id, stage_key),
+    ).fetchone()
+    assert row is not None
+    return None if row[0] is None else str(row[0])
+
+
+def _make_test_run(
+    conn: psycopg.Connection[tuple],
+    *,
+    stages: list[tuple[str, str]],  # (stage_key, job_name) pairs; all on lane "init"
+) -> int:
+    """Materialise a minimal bootstrap run + stage rows for the reaper."""
+    specs = tuple(
+        StageSpec(
+            stage_key=stage_key,
+            stage_order=idx + 1,
+            lane="init",
+            job_name=job_name,
+        )
+        for idx, (stage_key, job_name) in enumerate(stages)
+    )
+    run_id = start_run(conn, operator_id=None, stage_specs=specs)
+    conn.commit()
+    return run_id
+
+
+# ---------------------------------------------------------------------------
+# _hashtext_int round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_hashtext_int_matches_joblock_acquisition_key(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """``_hashtext_int`` MUST byte-for-byte match the JobLock acquisition.
+
+    JobLock acquires via ``pg_try_advisory_lock(hashtext(%s)::int)``;
+    the reaper probes ``pg_locks`` using the same key. If the two
+    derivations diverge the reaper's lock-held check returns false
+    positives and resets stages whose workers are still alive.
+    """
+    for source in ("init", "etoro", "sec_rate", "db", "finra", "openfigi"):
+        lock_text = f"job_source:{source}"
+        python_key = _hashtext_int(ebull_test_conn, lock_text)
+
+        row = ebull_test_conn.execute("SELECT hashtext(%s)::int", (lock_text,)).fetchone()
+        assert row is not None
+        assert python_key == int(row[0])
+
+
+# ---------------------------------------------------------------------------
+# Reaper happy-path cases
+# ---------------------------------------------------------------------------
+
+
+def test_reaper_resets_stuck_stage_when_lock_not_held(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stage running 10 min with no held lock should be reset to pending.
+
+    No JobLock has been acquired in any session, so the ``pg_locks``
+    probe returns no row → reaper proceeds.
+    """
+    _reset_state(ebull_test_conn)
+    _register_synthetic_jobs(monkeypatch, {"stuck_job": "init"})
+
+    run_id = _make_test_run(ebull_test_conn, stages=[("stuck_stage", "stuck_job")])
+    _seed_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="stuck_stage",
+        status="running",
+        started_minutes_ago=10,
+    )
+
+    reset = reap_orphaned_running_stages(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    assert reset == 1
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="stuck_stage") == "pending"
+
+
+def test_reaper_skips_stuck_stage_when_lock_held(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a sibling session holds the lock, the stage might still be live.
+
+    Acquire ``pg_try_advisory_lock`` on the same key the reaper would
+    probe (``hashtext('job_source:init')::int``) from an autocommit
+    session, then call the reaper. The pg_locks row exists in that
+    other session → reaper leaves the stuck stage alone.
+    """
+    _reset_state(ebull_test_conn)
+    _register_synthetic_jobs(monkeypatch, {"locked_job": "init"})
+
+    run_id = _make_test_run(ebull_test_conn, stages=[("locked_stage", "locked_job")])
+    _seed_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="locked_stage",
+        status="running",
+        started_minutes_ago=10,
+    )
+
+    # Hold the lock from a SECOND connection so pg_locks shows it held
+    # globally (not just on `ebull_test_conn`). Same DB URL as the
+    # ebull_test fixture so we share the cluster's lock-table view.
+    # ``test_database_url()`` returns the worker-private DB URL with
+    # auth credentials intact; ``ebull_test_conn.info.dsn`` strips the
+    # password and would fail with ``fe_sendauth: no password supplied``.
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    holder_url = test_database_url()
+    with psycopg.connect(holder_url, autocommit=True) as holder:
+        held = holder.execute(
+            "SELECT pg_try_advisory_lock(hashtext(%s)::int)",
+            ("job_source:init",),
+        ).fetchone()
+        assert held is not None and held[0] is True
+
+        try:
+            reset = reap_orphaned_running_stages(ebull_test_conn, run_id=run_id)
+            ebull_test_conn.commit()
+        finally:
+            holder.execute(
+                "SELECT pg_advisory_unlock(hashtext(%s)::int)",
+                ("job_source:init",),
+            )
+
+    assert reset == 0
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="locked_stage") == "running"
+
+
+def test_reaper_leaves_recent_running_stage_alone(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stage started 2 min ago is INSIDE the 5-min grace window.
+
+    The worker is most likely still alive in the worker startup
+    window; the grace floor guards against premature reset.
+    """
+    _reset_state(ebull_test_conn)
+    _register_synthetic_jobs(monkeypatch, {"recent_job": "init"})
+
+    run_id = _make_test_run(ebull_test_conn, stages=[("recent_stage", "recent_job")])
+    _seed_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="recent_stage",
+        status="running",
+        started_minutes_ago=2,
+    )
+
+    # Even with NO lock held, the grace window means reaper must wait.
+    reset = reap_orphaned_running_stages(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    assert reset == 0
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="recent_stage") == "running"
+
+
+def test_reaper_resets_multiple_orphans_mixed_lock_state(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three stuck stages: 2 free + 1 lock-held → reaper resets 2.
+
+    Each stage maps to its own source so the per-source lock-held
+    decision is independent. Holding ``job_source:db`` should ONLY
+    suppress reset of the db-lane stage, not the init-lane or
+    etoro-lane stages.
+    """
+    _reset_state(ebull_test_conn)
+    _register_synthetic_jobs(
+        monkeypatch,
+        {
+            "alpha_job": "init",
+            "bravo_job": "etoro",
+            "charlie_job": "db",
+        },
+    )
+
+    run_id = _make_test_run(
+        ebull_test_conn,
+        stages=[
+            ("alpha_stage", "alpha_job"),
+            ("bravo_stage", "bravo_job"),
+            ("charlie_stage", "charlie_job"),
+        ],
+    )
+    for stage_key in ("alpha_stage", "bravo_stage", "charlie_stage"):
+        _seed_stage(
+            ebull_test_conn,
+            run_id=run_id,
+            stage_key=stage_key,
+            status="running",
+            started_minutes_ago=10,
+        )
+
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    holder_url = test_database_url()
+    with psycopg.connect(holder_url, autocommit=True) as holder:
+        held = holder.execute(
+            "SELECT pg_try_advisory_lock(hashtext(%s)::int)",
+            ("job_source:db",),
+        ).fetchone()
+        assert held is not None and held[0] is True
+
+        try:
+            reset = reap_orphaned_running_stages(ebull_test_conn, run_id=run_id)
+            ebull_test_conn.commit()
+        finally:
+            holder.execute(
+                "SELECT pg_advisory_unlock(hashtext(%s)::int)",
+                ("job_source:db",),
+            )
+
+    assert reset == 2
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="alpha_stage") == "pending"
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="bravo_stage") == "pending"
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="charlie_stage") == "running"
+
+
+def test_reaper_skips_stage_with_unknown_source_mapping(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A stage whose ``job_name`` is not in the source registry is left alone.
+
+    Defensive: the reaper MUST NOT reset a stage whose lock-key shape
+    it cannot derive, because doing so would silently reset a stage
+    whose worker is alive (the registry gap is the operator's mistake
+    — not a crash signal).
+
+    Synthetic job name ``ghost_job`` is NEVER registered; ``source_for``
+    raises ``KeyError`` → reaper logs a warning and skips.
+    """
+    _reset_state(ebull_test_conn)
+
+    run_id = _make_test_run(ebull_test_conn, stages=[("ghost_stage", "ghost_job")])
+    _seed_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="ghost_stage",
+        status="running",
+        started_minutes_ago=10,
+    )
+
+    reset = reap_orphaned_running_stages(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    assert reset == 0
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="ghost_stage") == "running"
+
+
+def test_reaper_appends_last_error_does_not_replace(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing last_error context is preserved + appended.
+
+    Forensic value: if the operator wants to investigate WHY the stage
+    crashed, the previous attempt's last_error must survive the
+    reaper's reset.
+    """
+    _reset_state(ebull_test_conn)
+    _register_synthetic_jobs(monkeypatch, {"forensic_job": "init"})
+
+    run_id = _make_test_run(ebull_test_conn, stages=[("forensic_stage", "forensic_job")])
+    _seed_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="forensic_stage",
+        status="running",
+        started_minutes_ago=10,
+        last_error="previous attempt: ConnectionResetError mid-COPY",
+    )
+
+    reset = reap_orphaned_running_stages(ebull_test_conn, run_id=run_id)
+    ebull_test_conn.commit()
+
+    assert reset == 1
+    last_error = _last_error_of(ebull_test_conn, run_id=run_id, stage_key="forensic_stage")
+    assert last_error is not None
+    assert "previous attempt: ConnectionResetError mid-COPY" in last_error
+    assert "reaper: reset from orphaned running" in last_error
+
+
+# ---------------------------------------------------------------------------
+# Idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_reaper_is_idempotent_when_no_orphans(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeat calls on a clean run return 0; never throws.
+
+    Steady state of every dispatcher prelude — the reaper MUST be safe
+    to call on every restart even when nothing is wrong.
+    """
+    _reset_state(ebull_test_conn)
+    _register_synthetic_jobs(monkeypatch, {"clean_job": "init"})
+
+    run_id = _make_test_run(ebull_test_conn, stages=[("clean_stage", "clean_job")])
+    # Stage stays at 'pending' default — no started_at.
+
+    for _ in range(3):
+        reset = reap_orphaned_running_stages(ebull_test_conn, run_id=run_id)
+        ebull_test_conn.commit()
+        assert reset == 0
+
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="clean_stage") == "pending"
+
+
+def test_reaper_grace_window_is_five_minutes() -> None:
+    """Pin the grace constant so a future surgery surfaces in review."""
+    assert _REAPER_GRACE_SECONDS == 300
+
+
+def test_reaper_detects_held_lock_for_negative_hashtext_source(
+    ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: negative hashtext keys must split correctly in pg_locks.
+
+    Empirical (2026-05-23): ``hashtext('job_source:finra') = -685_386_401``.
+    When widened to bigint for ``pg_try_advisory_lock(bigint)``, the
+    sign extension fills the high 32 bits with 1s, so ``pg_locks`` ends
+    up with ``classid=4_294_967_295`` (NOT 0) and ``objid=3_609_580_895``.
+    A naive ``classid=0 AND objid=<hashtext>`` probe would miss the
+    held lock entirely and the reaper would reset a stage whose worker
+    is alive.
+
+    This test pins the signed-split SQL end-to-end: acquire from a
+    sibling session, run the reaper against a stuck ``finra`` stage,
+    assert the reaper leaves it alone (== the probe found the held
+    lock).
+    """
+    _reset_state(ebull_test_conn)
+    _register_synthetic_jobs(monkeypatch, {"finra_neg_job": "finra"})
+
+    # Sanity: confirm 'finra' source key is negative; if a future
+    # source-naming change makes the hashtext positive this regression
+    # has lost its teeth and we should pick a different signature.
+    h = _hashtext_int(ebull_test_conn, "job_source:finra")
+    assert h < 0, (
+        f"job_source:finra hashtext is now {h}; pick a different negative-hashtext "
+        f"source for this regression test or revisit the probe shape."
+    )
+
+    run_id = _make_test_run(ebull_test_conn, stages=[("finra_stuck_stage", "finra_neg_job")])
+    _seed_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key="finra_stuck_stage",
+        status="running",
+        started_minutes_ago=10,
+    )
+
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    holder_url = test_database_url()
+    with psycopg.connect(holder_url, autocommit=True) as holder:
+        held = holder.execute(
+            "SELECT pg_try_advisory_lock(hashtext(%s)::int)",
+            ("job_source:finra",),
+        ).fetchone()
+        assert held is not None and held[0] is True
+
+        try:
+            reset = reap_orphaned_running_stages(ebull_test_conn, run_id=run_id)
+            ebull_test_conn.commit()
+        finally:
+            holder.execute(
+                "SELECT pg_advisory_unlock(hashtext(%s)::int)",
+                ("job_source:finra",),
+            )
+
+    assert reset == 0, "reaper should detect the negative-hashtext lock as held"
+    assert _status_of(ebull_test_conn, run_id=run_id, stage_key="finra_stuck_stage") == "running"


### PR DESCRIPTION
## Summary
- Add `reap_orphaned_running_stages` to the `run_bootstrap_orchestrator` prelude (after `read_latest_run_with_stages`, before the dispatcher loop) so a jobs-process crash mid-stage no longer leaves the run stuck. Reset criteria: `status='running'` + `started_at` older than 5 min + the JobLock advisory lock is NOT held in any session in this DB (read-only `pg_locks` probe — never acquires).
- Lock-key derivation MUST byte-for-byte match JobLock at `app/jobs/locks.py:224`: `hashtext('job_source:' || <source>)::int`. Empirical: `hashtext` returns signed int4 → `pg_locks` splits the bigint key into `(classid, objid)` halves differently for positive vs negative keys (classid=0 vs 0xFFFFFFFF). PG-side `::bigint` arithmetic in the probe matches both cases.
- `database = (current DB OID)` predicate scopes the probe to locks in THIS database — same advisory key in a sibling DB on a shared cluster (dev + ebull_test on localhost:5432) would otherwise spuriously suppress a legitimate reset.
- Defensive: stages whose `job_name` is not in `JOB_NAME_TO_SOURCE` registry are LEFT ALONE (warning logged). Reaper must never reset a stage whose lock semantics it cannot derive.
- Reset shape: `running` → `pending`, `started_at`/`completed_at` cleared, `last_error` APPENDED (not replaced) with reaper marker. UPDATE guarded by `AND status='running'` (Codex W3 pattern).
- Skill `.claude/skills/data-engineer/SKILL.md` §6.5.8 documents reaper criteria, pg_locks shape gotcha, and accepted residual risks (hung-but-alive worker; #1184 re-entrancy edge).

## Codex 2 history
- Round 1 medium: "pg_locks probe missing `database` filter for shared-cluster deployments" → FIXED in commit `6f60a76`.
- Round 1 test gap: "add negative-hashtext regression" → FIXED in commit `6f60a76` (`test_reaper_detects_held_lock_for_negative_hashtext_source` covers `job_source:finra` whose hashtext is -685,386,401).
- Round 2: clean.

## Test plan
- [x] `uv run pytest tests/test_bootstrap_orphan_reaper.py` — 10 cases pass (5 happy-path, 4 defensive, 1 negative-hashtext regression).
- [x] `uv run pytest tests/test_bootstrap_orchestrator.py tests/test_bootstrap_orchestrator_source_registry.py` — 33 existing tests still pass (no regression in the dispatcher).
- [x] `uv run pytest tests/smoke/test_app_boots.py` — 5 cases pass (no module-load side-effects).
- [x] `uv run ruff check .` + `ruff format --check .` + `uv run pyright` — clean.

## Refs
- Refs #1233 (bootstrap ETL optimisation v3 — PR-6 in the §3 PR-ordering matrix; acceptance criterion §15: "process crash mid-stage: reaper resets to pending within 6 min").

## Out of scope
- The dispatcher loop, stage catalogue, and `_should_run` predicate are untouched.
- The reaper is a self-contained prelude helper; it does not change the per-stage execution contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)