### PR TITLE
fix(#1233): OpenFIGI key via Settings, not os.environ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ ETORO_ENV=demo
 # Companies House — UK filing documents (SEC EDGAR needs no key)
 COMPANIES_HOUSE_API_KEY=
 
+# OpenFIGI — optional CUSIP→ticker fallback resolver used by the
+# bootstrap Phase D sweep (#1233 PR-1b + SD-1). Register a free key at
+# https://www.openfigi.com/api. Without a key the resolver runs
+# unkeyed: 25 req/min × 10 jobs/POST = 250 mappings/min (~48 min on a
+# 12k unresolved CUSIP backlog). With a key: 25 req/6s × 100 jobs/POST
+# = 25,000 mappings/min (~5 min). Free either way; key is purely speed.
+OPENFIGI_API_KEY=
+
 # SEC EDGAR — no API key, but fair-use policy requires a User-Agent
 # with a contact email. SEC rejects requests with placeholder domains
 # (example.com, noreply@*) and any UA missing an email address — 403

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,14 @@ class Settings(BaseSettings):
 
     anthropic_api_key: str | None = None
 
+    # OpenFIGI free fallback CUSIP→ticker resolver (#1233 PR-1b + SD-1).
+    # Optional. Without a key the resolver runs unkeyed (25 req/min,
+    # max 10 jobs/POST = 250 mappings/min — ~48 min on a 12k unresolved
+    # CUSIP backlog). With a key (free tier, register at
+    # https://www.openfigi.com/api): 25 req/6s, max 100 jobs/POST =
+    # 25,000 mappings/min — sweep completes in ~5 min.
+    openfigi_api_key: str | None = None
+
     default_portfolio_mode: str = "balanced"
     max_active_positions: int = 20
     max_initial_position_pct: int = 5

--- a/app/services/openfigi_resolver.py
+++ b/app/services/openfigi_resolver.py
@@ -61,7 +61,6 @@ per-instance, not module-global).
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import time
 from collections.abc import Iterable, Iterator
@@ -264,7 +263,7 @@ class OpenFigiResolver:
 
     Usage::
 
-        resolver = OpenFigiResolver(api_key=os.environ.get("OPENFIGI_API_KEY"))
+        resolver = OpenFigiResolver.from_env()  # reads settings.openfigi_api_key
         mappings = resolver.resolve_cusips(["037833100", "594918104"])
         # → {"037833100": OpenFigiMapping(ticker="AAPL", ...),
         #    "594918104": OpenFigiMapping(ticker="MSFT", ...)}
@@ -299,9 +298,22 @@ class OpenFigiResolver:
 
     @classmethod
     def from_env(cls, *, client: httpx.Client | None = None) -> OpenFigiResolver:
-        """Read ``OPENFIGI_API_KEY`` and instantiate. Missing env var
-        falls back to unkeyed-tier rate limits (250 mappings/min)."""
-        return cls(api_key=os.environ.get("OPENFIGI_API_KEY") or None, client=client)
+        """Read OpenFIGI key from ``Settings`` and instantiate.
+
+        Resolution precedence (delegated to ``pydantic_settings``):
+          1. ``OPENFIGI_API_KEY`` environment variable (live env wins)
+          2. ``OPENFIGI_API_KEY=`` line in ``.env``
+          3. ``None`` → unkeyed tier (250 mappings/min)
+
+        Reading via ``settings.openfigi_api_key`` keeps the env-file vs
+        live-env precedence consistent with every other secret in the
+        repo. The prior ``os.environ.get`` shortcut silently bypassed
+        the .env loader — a key written into .env didn't actually reach
+        the resolver. Fixed in #1233 post-merge follow-up.
+        """
+        from app.config import settings
+
+        return cls(api_key=settings.openfigi_api_key or None, client=client)
 
     # -------- Context manager -------------------------------------------
 

--- a/tests/test_openfigi_resolver.py
+++ b/tests/test_openfigi_resolver.py
@@ -501,3 +501,41 @@ def test_mapping_dataclass_is_frozen() -> None:
     mapping = OpenFigiMapping(ticker="AAPL", name="APPLE INC", exch_code="US", share_class_figi=None)
     with pytest.raises(Exception):  # noqa: B017 — FrozenInstanceError varies
         mapping.ticker = "MSFT"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# from_env() — Settings integration (fix/1233-openfigi-key-via-settings)
+# ---------------------------------------------------------------------------
+
+
+class TestFromEnv:
+    """``OpenFigiResolver.from_env`` reads ``settings.openfigi_api_key``.
+
+    The prior shape (``os.environ.get('OPENFIGI_API_KEY')``) silently
+    bypassed the ``.env`` loader — keys written to ``.env`` never
+    reached the resolver. Reading via Settings keeps env-file precedence
+    consistent with every other secret in the repo.
+    """
+
+    def test_settings_key_promoted_to_keyed_tier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "openfigi_api_key", "test-key-keyed")
+        with OpenFigiResolver.from_env() as resolver:
+            assert resolver.keyed is True
+
+    def test_missing_settings_key_falls_back_to_unkeyed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "openfigi_api_key", None)
+        with OpenFigiResolver.from_env() as resolver:
+            assert resolver.keyed is False
+
+    def test_empty_string_settings_key_falls_back_to_unkeyed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty ``OPENFIGI_API_KEY=`` line in .env yields empty string,
+        not None; resolver must treat as unkeyed."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "openfigi_api_key", "")
+        with OpenFigiResolver.from_env() as resolver:
+            assert resolver.keyed is False


### PR DESCRIPTION
## Summary

PR-1b shipped `OpenFigiResolver.from_env()` reading `os.environ.get('OPENFIGI_API_KEY')` directly. This silently bypassed the `pydantic_settings` `.env` loader at [app/config.py:13](app/config.py#L13) — a key written into `.env` never reached the resolver. Operator footgun.

## Changes

- `app/config.py` — add `openfigi_api_key: str | None = None` Settings field.
- `app/services/openfigi_resolver.py` — `from_env()` now reads `settings.openfigi_api_key` (delegating env-file vs live-env precedence to `BaseSettings`, consistent with every other secret in the repo). Drop unused `import os`.
- `.env.example` — add `OPENFIGI_API_KEY=` line with rate-limit context (free tier 25/min → keyed 25/6s = 100× speedup on bootstrap CUSIP sweep).
- `tests/test_openfigi_resolver.py` — add `TestFromEnv` class with 3 cases (keyed, unkeyed, empty-string fallthrough).

## Empty-string fallback

`OPENFIGI_API_KEY=` (no value) in `.env` decodes to empty string, not None. Resolver uses `settings.openfigi_api_key or None` so empty string maps to unkeyed tier — doesn't accidentally send an empty `X-OPENFIGI-APIKEY` header.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` 0 errors
- [x] `uv run pytest tests/test_openfigi_resolver.py` — 24/24 pass (21 existing + 3 new)
- [x] Codex 2 pre-push: "No findings"

## ETL DoD clauses 8-12

Not applicable — config wiring, no schema/parser/ingest changes.

Refs #1233