### PR TITLE
fix(#1233): NPORT bulk ingest precision truncation — quantise BALANCE before > 0 gate

### DIFF
--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -39,9 +39,9 @@ import zipfile
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
-from decimal import Decimal, InvalidOperation
+from decimal import ROUND_HALF_EVEN, Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Final, Literal
 from uuid import UUID, uuid4
 
 import psycopg
@@ -57,6 +57,15 @@ logger = logging.getLogger(__name__)
 # for rationale (per-batch incremental commit so a multi-million-row
 # archive doesn't hold the open transaction across the whole drain).
 _UNRESOLVED_FLUSH_BATCH = 1000
+
+# Precision of ``ownership_funds_observations.shares`` (sql/123:84 —
+# NUMERIC(24, 4) NOT NULL CHECK (shares > 0)). The pre-validation gate
+# must quantise BALANCE to this scale BEFORE the > 0 predicate, because
+# a fractional-share holding like 0.00005 passes ``> 0`` but truncates
+# to 0.0000 on COPY into the staging table → trips the strict CHECK on
+# the drain INSERT. Pre-PR-3 per-row INSERT masked this via per-row
+# SAVEPOINT; the COPY-batched path cannot.
+_BALANCE_QUANTUM: Final = Decimal("0.0001")
 
 
 @dataclass
@@ -524,6 +533,30 @@ def ingest_nport_dataset_archive(
                 if balance is None or balance <= 0:
                     result.rows_skipped_non_positive_shares += 1
                     continue
+                # PR-3 regression guard: ``ownership_funds_observations.shares``
+                # is NUMERIC(24, 4) with a strict ``CHECK (shares > 0)``
+                # (sql/123:84). A fractional-share holding like 0.00005
+                # passes the ``> 0`` predicate above but quantises to
+                # 0.0000 on COPY into staging, then trips the CHECK on
+                # the INSERT...SELECT drain — aborting the entire archive.
+                # Pre-PR-3 per-row INSERT path masked this via per-row
+                # SAVEPOINT (counted as bad_data, loop continued); the
+                # COPY-batched path cannot. Quantise here at the same
+                # precision the column will store, and reject the row
+                # if it underflows to zero.
+                # ROUND_HALF_EVEN matches Postgres NUMERIC coercion
+                # semantics exactly — what PG would do on INSERT, we do
+                # here so the pre-validation outcome lines up with the
+                # CHECK constraint outcome. ``0.00005 → 0.0000`` (tie
+                # to even, reject); ``0.00006 → 0.0001`` (accept);
+                # ``0.00004 → 0.0000`` (reject). Codex 2 finding on
+                # the fix branch — implicit rounding mode was a
+                # forensic gap.
+                balance_q = balance.quantize(_BALANCE_QUANTUM, rounding=ROUND_HALF_EVEN)
+                if balance_q <= 0:
+                    result.rows_skipped_non_positive_shares += 1
+                    continue
+                balance = balance_q
 
                 cusip = (holding.get("ISSUER_CUSIP") or "").strip().upper()
                 if not cusip:

--- a/tests/test_pr3_copy_refactor.py
+++ b/tests/test_pr3_copy_refactor.py
@@ -33,6 +33,7 @@ import io
 import os
 import time
 import zipfile
+from decimal import Decimal
 from pathlib import Path
 from uuid import uuid4
 
@@ -723,6 +724,273 @@ class TestThroughputNPort:
             f"({rows_per_sec:.0f} rows/s) — well above the budget; "
             f"likely reverted to per-row INSERT."
         )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestNPortSharesPrecisionTruncation:
+    """``ownership_funds_observations.shares`` is NUMERIC(24, 4) with
+    a strict ``CHECK (shares > 0)``. A fractional-share holding like
+    0.00005 passes ``balance > 0`` in Python but quantises to 0.0000 on
+    COPY into the staging table → trips the CHECK on the INSERT...SELECT
+    drain, aborting the entire archive.
+
+    Pre-PR-3 the per-row INSERT path masked this via per-row SAVEPOINT
+    (counted as bad_data, loop continued). The COPY-batched path lost
+    that tolerance. Fix: quantise BALANCE to NUMERIC(24, 4) precision
+    before the > 0 gate.
+
+    Regression discovered live during bootstrap run #5 (2026-05-23):
+    ``ownership_funds_observations_shares_check`` violation on
+    Washington Mutual Investors Fund holding 147552177 (BALANCE source
+    rounded to 0.0000 in NPORT 2025q2-q4 archives).
+    """
+
+    def test_fractional_share_below_scale_skipped_not_archive_aborted(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        iid = _seed_universe_with_cusip(ebull_test_conn, symbol="PREC", cusip="037833100")
+        submissions = [
+            {
+                "ACCESSION_NUMBER": "0009999999-25-000001",
+                "FILING_DATE": "2025-11-14",
+                "REPORT_DATE": "2025-09-30",
+            }
+        ]
+        registrants = [{"ACCESSION_NUMBER": "0009999999-25-000001", "CIK": "9999999"}]
+        fund_info = [
+            {
+                "ACCESSION_NUMBER": "0009999999-25-000001",
+                "SERIES_ID": "S000099001",
+                "SERIES_NAME": "Precision Series",
+            }
+        ]
+        # Two holdings:
+        #   - HOLDING_ID=1: legitimate 100 shares — must land.
+        #   - HOLDING_ID=2: 0.00005 shares — passes ``> 0`` but quantises
+        #     to 0.0000 → would trip CHECK if not pre-quantised.
+        holdings = [
+            {
+                "ACCESSION_NUMBER": "0009999999-25-000001",
+                "ISSUER_CUSIP": "037833100",
+                "BALANCE": "100",
+                "ASSET_CAT": "EC",
+                "PAYOFF_PROFILE": "Long",
+                "UNIT": "NS",
+                "HOLDING_ID": "1",
+                "CURRENCY_CODE": "USD",
+                "CURRENCY_VALUE": "10000",
+            },
+            {
+                "ACCESSION_NUMBER": "0009999999-25-000001",
+                "ISSUER_CUSIP": "037833100",
+                "BALANCE": "0.00005",  # underflows NUMERIC(24, 4) → 0.0000
+                "ASSET_CAT": "EC",
+                "PAYOFF_PROFILE": "Long",
+                "UNIT": "NS",
+                "HOLDING_ID": "2",
+                "CURRENCY_CODE": "USD",
+                "CURRENCY_VALUE": "1",
+            },
+        ]
+        archive_bytes = _build_nport_zip(
+            submissions=submissions,
+            registrants=registrants,
+            fund_info=fund_info,
+            holdings=holdings,
+        )
+        archive_path = tmp_path / "nport_prec.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        # The fractional row counts as non-positive (the gate rejects
+        # the post-quantise zero), not as a CHECK violation that
+        # crashes the whole archive.
+        assert result.rows_skipped_non_positive_shares == 1
+        assert result.rows_written == 1
+        assert iid in result.touched_instrument_ids
+        # And the legitimate row landed.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT shares FROM ownership_funds_observations WHERE instrument_id = %s AND source_document_id = %s",
+                (iid, "0009999999-25-000001:1"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == Decimal("100.0000")
+
+    def test_half_even_accept_0_00006_lands_as_0_0001(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """ROUND_HALF_EVEN: 0.00006 → 0.0001 (rounds away from zero,
+        not toward), so the row MUST land (not be skipped). Pins the
+        rounding mode against accidental switch to ROUND_DOWN which
+        would erroneously skip this row."""
+        iid = _seed_universe_with_cusip(ebull_test_conn, symbol="HEUP", cusip="037833100")
+        archive_bytes = _build_nport_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000003",
+                    "FILING_DATE": "2025-11-14",
+                    "REPORT_DATE": "2025-09-30",
+                }
+            ],
+            registrants=[{"ACCESSION_NUMBER": "0009999999-25-000003", "CIK": "9999997"}],
+            fund_info=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000003",
+                    "SERIES_ID": "S000099003",
+                    "SERIES_NAME": "HalfEvenUp Series",
+                }
+            ],
+            holdings=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000003",
+                    "ISSUER_CUSIP": "037833100",
+                    "BALANCE": "0.00006",
+                    "ASSET_CAT": "EC",
+                    "PAYOFF_PROFILE": "Long",
+                    "UNIT": "NS",
+                    "HOLDING_ID": "1",
+                    "CURRENCY_CODE": "USD",
+                    "CURRENCY_VALUE": "1",
+                }
+            ],
+        )
+        archive_path = tmp_path / "nport_he_up.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_skipped_non_positive_shares == 0
+        assert result.rows_written == 1
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT shares FROM ownership_funds_observations WHERE instrument_id = %s AND source_document_id = %s",
+                (iid, "0009999999-25-000003:1"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == Decimal("0.0001")
+
+    def test_half_even_reject_0_00004_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """ROUND_HALF_EVEN: 0.00004 → 0.0000 (rounds toward zero), so
+        skipped. Pins symmetry with the 0.00005 case."""
+        iid = _seed_universe_with_cusip(ebull_test_conn, symbol="HEDN", cusip="037833100")
+        archive_bytes = _build_nport_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000004",
+                    "FILING_DATE": "2025-11-14",
+                    "REPORT_DATE": "2025-09-30",
+                }
+            ],
+            registrants=[{"ACCESSION_NUMBER": "0009999999-25-000004", "CIK": "9999996"}],
+            fund_info=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000004",
+                    "SERIES_ID": "S000099004",
+                    "SERIES_NAME": "HalfEvenDown Series",
+                }
+            ],
+            holdings=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000004",
+                    "ISSUER_CUSIP": "037833100",
+                    "BALANCE": "0.00004",
+                    "ASSET_CAT": "EC",
+                    "PAYOFF_PROFILE": "Long",
+                    "UNIT": "NS",
+                    "HOLDING_ID": "1",
+                    "CURRENCY_CODE": "USD",
+                    "CURRENCY_VALUE": "1",
+                }
+            ],
+        )
+        archive_path = tmp_path / "nport_he_dn.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_skipped_non_positive_shares == 1
+        assert result.rows_written == 0
+        del iid
+
+    def test_exactly_0_0001_shares_lands_not_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """Boundary: 0.0001 is the smallest representable positive share
+        at NUMERIC(24, 4). Must land, not be rejected by the gate."""
+        iid = _seed_universe_with_cusip(ebull_test_conn, symbol="PRECB", cusip="037833100")
+        archive_bytes = _build_nport_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000002",
+                    "FILING_DATE": "2025-11-14",
+                    "REPORT_DATE": "2025-09-30",
+                }
+            ],
+            registrants=[{"ACCESSION_NUMBER": "0009999999-25-000002", "CIK": "9999998"}],
+            fund_info=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000002",
+                    "SERIES_ID": "S000099002",
+                    "SERIES_NAME": "Boundary Series",
+                }
+            ],
+            holdings=[
+                {
+                    "ACCESSION_NUMBER": "0009999999-25-000002",
+                    "ISSUER_CUSIP": "037833100",
+                    "BALANCE": "0.0001",
+                    "ASSET_CAT": "EC",
+                    "PAYOFF_PROFILE": "Long",
+                    "UNIT": "NS",
+                    "HOLDING_ID": "1",
+                    "CURRENCY_CODE": "USD",
+                    "CURRENCY_VALUE": "1",
+                }
+            ],
+        )
+        archive_path = tmp_path / "nport_prec_boundary.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_skipped_non_positive_shares == 0
+        assert result.rows_written == 1
+        del iid
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

**Live PR-3 regression discovered during bootstrap run #5 (2026-05-23, ~7.5 min into S12).** 4 NPORT archives aborted with `ownership_funds_observations_shares_check` violation. Run #5 finished as `partial_error` because S13 OpenFIGI sweep + S23 backfill depend on `nport_inputs_seeded` cap.

## Root cause

`ownership_funds_observations.shares` is NUMERIC(24, 4) with strict `CHECK (shares > 0)` ([sql/123:84](sql/123_ownership_funds.sql#L84)). A fractional-share holding like 0.00005:
1. Passes the `balance > 0` predicate at [sec_nport_dataset_ingest.py:524](app/services/sec_nport_dataset_ingest.py#L524) (Decimal compares fine)
2. Quantises to 0.0000 when COPY writes it into NUMERIC(24, 4) staging
3. Trips the strict CHECK on the INSERT...SELECT drain — **aborts the entire archive**

Pre-PR-3 the per-row INSERT path masked this via per-row SAVEPOINT (counted as `rows_skipped_bad_data`, loop continued). The COPY-batched path cannot tolerate per-row CHECK violations at the drain step.

## Fix

```python
balance = _parse_decimal(holding.get("BALANCE"))
if balance is None or balance <= 0:
    result.rows_skipped_non_positive_shares += 1
    continue
# NEW: quantise to NUMERIC(24, 4) precision matching the column,
# using ROUND_HALF_EVEN to match Postgres NUMERIC coercion exactly.
balance_q = balance.quantize(_BALANCE_QUANTUM, rounding=ROUND_HALF_EVEN)
if balance_q <= 0:
    result.rows_skipped_non_positive_shares += 1
    continue
balance = balance_q
```

`_BALANCE_QUANTUM = Decimal("0.0001")`. Reassigning `balance = balance_q` ensures `copy.write_row` writes the value the gate validated.

## Tests

`tests/test_pr3_copy_refactor.py::TestNPortSharesPrecisionTruncation` — 4 cases:
- 0.00005 underflows → skipped, archive completes (regression case)
- 0.00006 → rounds to 0.0001, lands (HALF_EVEN behavior pinned)
- 0.00004 → rounds to 0.0000, skipped (HALF_EVEN symmetry)
- 0.0001 boundary → lands

All 4 pass.

## Codex 2 pre-push

Caught implicit rounding mode (would not have been forensically obvious if HALF_EVEN was implicit). Fix now uses explicit `ROUND_HALF_EVEN` import + regression tests for HALF_EVEN's tie-to-even semantics.

## Scope audit (Codex finding)

`ownership_institutions_observations.shares` (13F) and `ownership_insiders_observations.shares` (insider) are NUMERIC(24, 4) / NUMERIC(20, 4) WITHOUT strict positive CHECK constraints — same quantisation happens but no archive-abort failure mode. Left alone.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` 0 errors
- [x] `uv run pytest tests/test_pr3_copy_refactor.py::TestNPortSharesPrecisionTruncation` — 4/4 pass
- [x] Codex 2 pre-push: addressed implicit-rounding finding
- [ ] Live smoke: re-run bootstrap with NPORT archives that previously failed — covered post-merge

## ETL DoD clauses 8-12

8. Smoke instruments: the 4 failing NPORT archives in run #5 contained Washington Mutual Investors Fund (CIK 0000729528, series S000008794). Post-merge smoke = re-trigger bootstrap and confirm all 4 NPORT archives complete.
9. Cross-source: SEC NPORT-P readme.pdf documents BALANCE as the share count; NUMERIC(24, 4) is our schema choice (not SEC's) — the precision truncation is purely our boundary.
10. Backfill: post-merge, re-trigger bootstrap.
11. Operator-visible: `/instruments/<symbol>/ownership-rollup` funds panel for any fund-held instrument.
12. Verification SHA: this PR (post-CI).

Refs #1233