### PR TITLE
fix(#1233): serialise S15 filings_history_seed after S8 sec_submissions_ingest (row-lock contention)

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -299,6 +299,18 @@ Capability = Literal[
     # Provided by S25 ``mf_directory_sync``; required by S26
     # ``sec_n_csr_bootstrap_drain``.
     "class_id_mapping_ready",
+    # PR-2 lock-contention fix: S8 (sec_submissions_ingest) and S15
+    # (filings_history_seed) both write to ``filing_events`` for the
+    # same ``(instrument_id, …)`` keys. PR-2's cross-lane parallelism
+    # let them run concurrently → row-level lock contention left S8
+    # stuck on a wait-graph for 17+ min during bootstrap run #5.
+    # Adding a hard ordering: S15 requires ``submissions_processed``
+    # which only S8 provides (on success OR skip). Effect: S15 runs
+    # AFTER S8 terminalises, eliminating concurrent writes.
+    # Provided ON SKIP so the slow-connection fallback (#1041 — S7
+    # skipped → S8 cascade-skipped) still flows into S15 as the
+    # legacy chain owner of ``filing_events_seeded``.
+    "submissions_processed",
 ]
 
 
@@ -327,7 +339,7 @@ _STAGE_PROVIDES: Final[dict[str, tuple[Capability, ...]]] = {
     # BootstrapPhaseSkipped (#1138 §4.3) so the stage transitions to
     # `skipped` and this provider entry never fires.
     "sec_bulk_download": ("bulk_archives_ready",),
-    "sec_submissions_ingest": ("filing_events_seeded",),
+    "sec_submissions_ingest": ("filing_events_seeded", "submissions_processed"),
     "sec_companyfacts_ingest": ("fundamentals_raw_seeded",),
     # Bulk ownership ingester covers both insider transactions + Form 3.
     "sec_insider_ingest_from_dataset": ("insider_inputs_seeded", "form3_inputs_seeded"),
@@ -357,7 +369,18 @@ _STAGE_PROVIDES: Final[dict[str, tuple[Capability, ...]]] = {
 # providing the same caps, not on a skipped bulk stage masquerading
 # as a provider. Add an entry here only when a skip is semantically
 # equivalent to success.
-_STAGE_PROVIDES_ON_SKIP: Final[dict[str, tuple[Capability, ...]]] = {}
+_STAGE_PROVIDES_ON_SKIP: Final[dict[str, tuple[Capability, ...]]] = {
+    # PR-2 lock-contention fix: S8 cascade-skipped on slow-connection
+    # (S7 skipped → bulk_archives_ready unprovided → S8 cascade-skipped)
+    # still satisfies the ``submissions_processed`` ordering cap so
+    # S15 (filings_history_seed) — the legacy chain owner of
+    # filing_events seeding on the slow path — proceeds. S8 SUCCESS
+    # also provides this cap (see ``_STAGE_PROVIDES`` above); the
+    # SKIP entry covers the cascade-skip case without "masquerading
+    # as success" — the cap is purely an ordering constraint on S15,
+    # not a content-validity signal.
+    "sec_submissions_ingest": ("submissions_processed",),
+}
 
 
 # #1140 / Task C of #1136 audit — strict-gate row-count floors.
@@ -455,7 +478,10 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
     # Phase C' — walker
     "sec_submissions_files_walk": CapRequirement(all_of=("filing_events_seeded",)),
     # Legacy chain
-    "filings_history_seed": CapRequirement(all_of=("cik_mapping_ready",)),
+    # ``submissions_processed`` cap pinned here serialises S15 after
+    # S8 terminalises (success / skip). See cap docstring on
+    # ``submissions_processed`` for the lock-contention rationale.
+    "filings_history_seed": CapRequirement(all_of=("cik_mapping_ready", "submissions_processed")),
     "sec_first_install_drain": CapRequirement(all_of=("cik_mapping_ready",)),
     "sec_def14a_bootstrap": CapRequirement(all_of=("filing_events_seeded", "submissions_secondary_pages_walked")),
     "sec_business_summary_bootstrap": CapRequirement(

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -673,6 +673,47 @@ def test_every_stage_appears_in_requires_caps() -> None:
     assert not missing, f"stages without _STAGE_REQUIRES_CAPS entry: {missing}"
 
 
+def test_filings_history_seed_requires_submissions_processed() -> None:
+    """Pin the PR-2 lock-contention fix: ``filings_history_seed`` (S15)
+    MUST require ``submissions_processed`` so it waits for S8
+    (``sec_submissions_ingest``) to terminalise before starting.
+
+    Background: S8 and S15 both write to ``filing_events`` for the same
+    ``(instrument_id, …)`` keys. Pre-PR-2 the dispatcher serialised
+    them via ``wait(ALL_COMPLETED)``; PR-2's cross-lane parallelism
+    let them run concurrently → row-lock contention left S8 stuck for
+    17+ min in bootstrap run #5. The fix expresses the ordering via
+    a ``submissions_processed`` capability that S8 provides on
+    success OR skip; S15 requires it.
+
+    Regression sentinel — a future spec edit that drops the requires
+    line would re-introduce the row-lock contention silently.
+    """
+    req = _STAGE_REQUIRES_CAPS["filings_history_seed"]
+    assert "submissions_processed" in req.all_of, (
+        "filings_history_seed must require submissions_processed (PR-2 lock-contention serialisation invariant)"
+    )
+
+
+def test_submissions_processed_provided_by_s8_on_success_and_skip() -> None:
+    """Companion invariant to the above. ``submissions_processed`` is
+    provided by ``sec_submissions_ingest`` (S8) on BOTH success AND
+    skip — the SKIP entry preserves the slow-connection fallback
+    where S7 → S8 cascade-skip and S15 still proceeds as the legacy
+    chain's filing_events seeder. Drop either provides entry and the
+    slow-connection path either deadlocks (no SKIP entry: S15 cascade-
+    skips, no provider) or reverts to the lock contention bug (no
+    SUCCESS entry: nothing waits on S8).
+    """
+    from app.services.bootstrap_orchestrator import (
+        _STAGE_PROVIDES,
+        _STAGE_PROVIDES_ON_SKIP,
+    )
+
+    assert "submissions_processed" in _STAGE_PROVIDES["sec_submissions_ingest"]
+    assert "submissions_processed" in _STAGE_PROVIDES_ON_SKIP["sec_submissions_ingest"]
+
+
 def test_partial_bulk_failure_legacy_recovers(
     ebull_test_conn: psycopg.Connection[tuple],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

**PR-2 parallelism regression discovered live during bootstrap run #5 (2026-05-23, 14:01 local).** Two PG backends BLOCKED on `Lock: transactionid` for 17 min and 7 min, visible in `pg_stat_activity` waiting on each other's row locks. Cancelled run #5 to unblock.

## Root cause

S8 (`sec_submissions_ingest`, db_filings lane) and S15 (`filings_history_seed`, sec_rate lane) both write to `filing_events` for the same `(instrument_id, …)` keys but from different paths:

- S8: from bulk `submissions.zip`
- S15: from per-CIK API walk (legacy)

Pre-PR-2 the dispatcher's `wait(ALL_COMPLETED)` accidentally serialised them. Post-PR-2 they run concurrently → row-level lock contention on shared `instrument_id` rows.

## Fix

Introduce `submissions_processed` capability:

```python
# Provided by S8 on SUCCESS AND SKIP
_STAGE_PROVIDES["sec_submissions_ingest"] = ("filing_events_seeded", "submissions_processed")
_STAGE_PROVIDES_ON_SKIP["sec_submissions_ingest"] = ("submissions_processed",)

# Required by S15
_STAGE_REQUIRES_CAPS["filings_history_seed"] = CapRequirement(
    all_of=("cik_mapping_ready", "submissions_processed")
)
```

## Effect matrix

| S8 outcome | submissions_processed | S15 behaviour |
|---|---|---|
| success | provided | runs after S8 terminalises — no concurrent writes |
| error | NOT provided | cascade-skip (downstream cascade-skip too — bulk path broken) |
| skip (slow-connection: S7→S8 cascade) | provided ON SKIP | runs as legacy fallback (preserves #1041) |

The SKIP provider entry deliberately violates the "skipped stages do not provide capabilities" default in `_STAGE_PROVIDES_ON_SKIP`'s docstring because `submissions_processed` is purely an **ordering constraint**, not a content-validity signal. The cap doesn't unlock anything downstream beyond S15's runnability.

## Tests

- `test_filings_history_seed_requires_submissions_processed` — pins the requires entry; regression sentinel against future spec edits.
- `test_submissions_processed_provided_by_s8_on_success_and_skip` — pins both provider entries; either dropped silently re-breaks parallelism OR breaks the slow-connection fallback.
- Pre-existing catalogue invariant tests automatically validate the new cap's wiring.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` 0 errors
- [x] `uv run pytest tests/test_bootstrap_orchestrator.py -k 'requires_submissions_processed or provided_by_s8 or every_required or every_stage'` — 4/4 pass
- [ ] Live smoke: re-trigger bootstrap, observe S15 starts AFTER S8 completes — covered post-merge

## ETL DoD clauses 8-12

Not strictly applicable (cap-layer ordering only, no schema/parser/ingest changes). Verified at run #6 (post-merge re-trigger).

Refs #1233