### PR TITLE
fix(#1233): #1290 — jobs singleton-fence stale-lock reaper at boot

### DIFF
--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -44,9 +44,10 @@ import os
 import signal
 import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Final
 
 import psycopg
 
@@ -101,6 +102,178 @@ def _install_signal_handlers(stop_event: threading.Event) -> None:
                 logger.debug("jobs entrypoint: signal %s not registrable on this platform", name)
 
 
+# #1290: application_name stamped on the singleton-fence connection
+# so the stale-lock reaper can identify "our" idle-in-transaction
+# holder PIDs in ``pg_stat_activity``. Any third-party connection
+# that happened to acquire JOBS_PROCESS_LOCK_KEY (vanishingly
+# unlikely given its 64-bit ASCII-bytes value) is excluded by the
+# application_name filter so we never terminate a process that is
+# not ours.
+SINGLETON_FENCE_APPLICATION_NAME: Final[str] = "ebull-jobs-singleton-fence"
+
+# #1290: idle-grace window. A holder that's been ``state='idle'`` for
+# at least this long is assumed dead — its TCP socket from the old
+# python process never sent FIN, so the backend stays around until
+# kernel keepalive (default ~2h). Five minutes is short enough that
+# the operator doesn't twiddle their thumbs after ``kill -9``, long
+# enough that a genuinely starting concurrent boot whose first query
+# happens to be slow does not get terminated.
+#
+# CRITICAL: this only safely identifies a stale holder because the
+# live jobs process runs a fence-heartbeat thread that touches the
+# fence connection every ``SINGLETON_FENCE_HEARTBEAT_PERIOD_SECONDS``.
+# A live process's fence connection therefore advances ``state_change``
+# every period and never crosses the grace boundary. A dead process's
+# fence connection stops advancing the moment the python process
+# dies, and crosses the grace boundary after the configured window.
+# DO NOT REMOVE THE HEARTBEAT — Codex 2 pre-push BLOCKING on #1290:
+# without it, the reaper terminates the live singleton fence.
+SINGLETON_STALE_HOLDER_GRACE_SECONDS: Final[int] = 300
+
+# #1290: fence-heartbeat period. Must be < grace_seconds so a live
+# fence never stays idle long enough to qualify. 30s chosen for the
+# same reasons as the other supervised heartbeat loops: short enough
+# that the grace can be 5-10× without operator-perceptible delay,
+# long enough that the connection is at rest >99% of the time.
+SINGLETON_FENCE_HEARTBEAT_PERIOD_SECONDS: Final[float] = 30.0
+
+
+def _fence_heartbeat_loop(
+    fence: psycopg.Connection[Any],
+    fence_lock: threading.Lock,
+    stop_event: threading.Event,
+    *,
+    period_seconds: float = SINGLETON_FENCE_HEARTBEAT_PERIOD_SECONDS,
+) -> None:
+    """Periodically touch the singleton-fence connection to advance
+    ``pg_stat_activity.state_change``.
+
+    Without this thread, the fence backend goes idle immediately after
+    boot's ``fence.commit()`` and STAYS idle. Five minutes later it
+    looks indistinguishable from a stale post-kill -9 holder, so a
+    parallel jobs-process boot would happily reap the live fence and
+    acquire the lock — two jobs processes running concurrently.
+
+    The heartbeat itself is a trivial ``SELECT 1`` issued under the
+    fence lock so it does not race with the boot-time acquire or the
+    shutdown close. A failure here logs + breaks the loop without
+    raising — the next reaper probe will see the still-stale fence
+    and decide based on its own criteria. The main process keeps
+    running with a working lock until ordinary shutdown closes the
+    fence.
+    """
+    while not stop_event.wait(timeout=period_seconds):
+        try:
+            with fence_lock:
+                if fence.closed:
+                    return
+                # Fence opens with autocommit=True so this trivial
+                # SELECT transitions active → idle WITHOUT a
+                # transaction-bracketed phase. The reaper's
+                # ``state='idle'`` filter then catches a truly dead
+                # fence; a healthy fence's state_change keeps advancing.
+                fence.execute("SELECT 1").fetchone()
+        except Exception:
+            logger.exception(
+                "jobs entrypoint: fence heartbeat failed; the live-fence "
+                "liveness signal is now stale. The lock is still held "
+                "but a concurrent jobs boot >grace_seconds from now "
+                "could reap this fence."
+            )
+            return
+
+
+def _reap_stale_singleton_fence_holder(
+    database_url: str,
+    *,
+    lock_key: int,
+    grace_seconds: int = SINGLETON_STALE_HOLDER_GRACE_SECONDS,
+) -> int | None:
+    """Probe for a stale holder of the singleton advisory lock and
+    terminate it. Returns the reaped PID, or ``None`` if no eligible
+    holder exists.
+
+    Eligibility criteria — ALL must hold:
+
+      * The PID owns an advisory lock with ``locktype='advisory'``,
+        ``objsubid=1`` (session-scope), matching ``classid``/``objid``
+        halves of ``lock_key`` in the CURRENT database.
+      * ``pg_stat_activity.application_name = SINGLETON_FENCE_APPLICATION_NAME``
+        — only stale holders from a prior eBull jobs process are
+        candidates. Third-party connections that happen to have
+        acquired this exact 64-bit advisory key are excluded.
+      * ``pg_stat_activity.state = 'idle'`` AND
+        ``state_change < NOW() - INTERVAL '{grace}'`` — actively-busy
+        holders (state='active') or recently-changed-state holders
+        (potentially still booting) are excluded.
+
+    The probe + terminate happen on a dedicated short-lived
+    connection so the implicit autocommit semantics are explicit.
+
+    Notes:
+      * ``pg_terminate_backend`` requires superuser OR the
+        ``pg_signal_backend`` role membership. In the eBull dev/prod
+        setup the app user has been granted this role (sql/153);
+        without it the call returns ``false`` and the reaper logs +
+        bails. Either way, we never raise.
+      * Idempotent: the reaper is a no-op when no eligible PID
+        exists. Caller retries the lock acquire ONCE after a
+        successful reap — see :func:`_acquire_singleton_fence`.
+    """
+    classid = (lock_key >> 32) & 0xFFFF_FFFF
+    objid = lock_key & 0xFFFF_FFFF
+    try:
+        with psycopg.connect(database_url, autocommit=True) as probe:
+            row = probe.execute(
+                """
+                SELECT a.pid
+                  FROM pg_locks l
+                  JOIN pg_stat_activity a ON a.pid = l.pid
+                  JOIN pg_database d      ON d.oid = l.database
+                 WHERE l.locktype = 'advisory'
+                   AND l.objsubid = 1
+                   AND d.datname = current_database()
+                   AND l.classid = %(classid)s::oid
+                   AND l.objid   = %(objid)s::oid
+                   AND a.application_name = %(app_name)s
+                   AND a.state    = 'idle'
+                   AND a.state_change < NOW() - make_interval(secs => %(grace)s)
+                 LIMIT 1
+                """,
+                {
+                    "classid": classid,
+                    "objid": objid,
+                    "app_name": SINGLETON_FENCE_APPLICATION_NAME,
+                    "grace": grace_seconds,
+                },
+            ).fetchone()
+            if row is None:
+                return None
+            stale_pid = int(row[0])
+            term_row = probe.execute(
+                "SELECT pg_terminate_backend(%(pid)s)",
+                {"pid": stale_pid},
+            ).fetchone()
+            if not (term_row and term_row[0]):
+                logger.warning(
+                    "jobs entrypoint: pg_terminate_backend(%d) returned false "
+                    "— singleton-lock holder remains. Reap requires superuser "
+                    "or pg_signal_backend membership.",
+                    stale_pid,
+                )
+                return None
+            logger.info(
+                "jobs entrypoint: reaped stale singleton-fence holder (pid=%d, idle ≥ %ds, application_name=%r)",
+                stale_pid,
+                grace_seconds,
+                SINGLETON_FENCE_APPLICATION_NAME,
+            )
+            return stale_pid
+    except Exception:
+        logger.exception("jobs entrypoint: stale-holder reap probe failed; treating as no-op")
+        return None
+
+
 def _acquire_singleton_fence(database_url: str) -> psycopg.Connection[Any]:
     """Acquire the session-scoped advisory lock on a dedicated connection.
 
@@ -108,12 +281,59 @@ def _acquire_singleton_fence(database_url: str) -> psycopg.Connection[Any]:
     closes it LAST during shutdown so Postgres releases the lock only
     after every other subsystem has stopped.
 
-    Exits the process with code 2 when the lock is already held.
+    Exits the process with code 2 when the lock is already held AND
+    no stale holder could be reaped (#1290). On first failure we
+    consult :func:`_reap_stale_singleton_fence_holder` — if a prior
+    jobs-process backend is idle-in-postgres past the grace window,
+    terminate it and retry the lock acquire ONE more time. A
+    genuine concurrent boot (busy backend) is preserved.
+
+    The fence connection is opened with ``autocommit=True`` (Codex 2
+    round 2 BLOCKING on #1290): without it, ``SELECT
+    pg_try_advisory_lock(...)`` runs inside an implicit transaction and
+    the backend reports ``state='idle in transaction'`` until
+    ``.commit()`` lands. The reaper SQL filters on ``state='idle'``
+    only — a dead fence stuck mid-statement would be invisible to it
+    and the lock would be unreapable. Autocommit removes the
+    in-transaction window entirely.
+
+    The fence connection carries ``application_name='ebull-jobs-singleton-fence'``
+    so the reaper has a precise key to identify "our" stale backends.
     """
-    fence = psycopg.connect(database_url)
+    fence = psycopg.connect(
+        database_url,
+        autocommit=True,
+        application_name=SINGLETON_FENCE_APPLICATION_NAME,
+    )
     try:
         row = fence.execute("SELECT pg_try_advisory_lock(%s)", (JOBS_PROCESS_LOCK_KEY,)).fetchone()
         acquired = bool(row and row[0])
+        if not acquired:
+            # #1290: try once to reap a stale holder before refusing.
+            # The reaper uses its own short-lived connection so a
+            # failure there cannot corrupt the fence we still hold
+            # half-open here.
+            reaped = _reap_stale_singleton_fence_holder(database_url, lock_key=JOBS_PROCESS_LOCK_KEY)
+            if reaped is not None:
+                # Codex 2 round 3 HIGH on #1290: ``pg_terminate_backend``
+                # is ASYNCHRONOUS — it queues a SIGTERM for the target
+                # backend, returning ``true`` once the signal is sent
+                # but BEFORE the backend has actually exited. The
+                # backend's session-scope advisory lock is released
+                # only on exit. An immediate retry of
+                # ``pg_try_advisory_lock`` will still see the lock
+                # held until the OS scheduler runs the doomed backend
+                # one last time. Poll-retry for up to two seconds at
+                # 100 ms intervals — well above the kernel's
+                # SIGTERM-deliver-to-backend-exit latency in practice
+                # but bounded so a non-cooperative backend cannot
+                # delay startup indefinitely.
+                for _ in range(20):
+                    row = fence.execute("SELECT pg_try_advisory_lock(%s)", (JOBS_PROCESS_LOCK_KEY,)).fetchone()
+                    acquired = bool(row and row[0])
+                    if acquired:
+                        break
+                    time.sleep(0.1)
         if not acquired:
             logger.error(
                 "jobs entrypoint: another app.jobs process holds the singleton "
@@ -122,7 +342,6 @@ def _acquire_singleton_fence(database_url: str) -> psycopg.Connection[Any]:
             )
             fence.close()
             sys.exit(2)
-        fence.commit()  # release the implicit transaction; lock is session-scoped
     except SystemExit:
         raise
     except Exception:
@@ -381,6 +600,21 @@ def serve(stop_event: threading.Event | None = None) -> int:
     pool = open_pool("jobs_pool", min_size=1, max_size=4)
     fence_conn = _acquire_singleton_fence(settings.database_url)
     logger.info("jobs entrypoint: singleton fence acquired")
+    # #1290: fence-liveness infrastructure. The lock + stop-event are
+    # constructed UP-FRONT so the cleanup paths in the startup-guard
+    # wrappers can reference them — but the heartbeat THREAD itself
+    # starts AFTER every guard has passed. Codex 2 round 2 HIGH on
+    # #1290: if the heartbeat is already running while a guard raises
+    # and calls ``fence_conn.close()`` directly, the heartbeat's next
+    # ``execute()`` races against close on the same psycopg
+    # connection. Delaying the thread start until all guards pass
+    # avoids that race entirely. The startup window (every guard
+    # combined < 1 min on a healthy DB) is well inside the reaper
+    # grace, so a concurrent boot cannot incorrectly reap us during
+    # this pre-thread window.
+    fence_lock = threading.Lock()
+    fence_heartbeat_stop = threading.Event()
+    fence_heartbeat_thread: threading.Thread | None = None
 
     # PR1a #1064 — fail-fast at jobs entrypoint if SCHEDULED_JOBS and
     # _BOOTSTRAP_STAGE_SPECS disagree on a job_name's source. Mirrors
@@ -457,6 +691,21 @@ def serve(stop_event: threading.Event | None = None) -> int:
     credential_health_thread: threading.Thread | None = None
 
     try:
+        # #1290: start the fence heartbeat INSIDE the main try block
+        # so the finally-shutdown path stops it on every exit (Codex 2
+        # round 3 MEDIUM). Every startup guard above has passed, so
+        # the heartbeat thread can run safely; if anything in the
+        # try-body raises (queue boot-drain, runtime.start(), etc.),
+        # the finally clause sets fence_heartbeat_stop + joins the
+        # thread under fence_lock before closing the fence.
+        fence_heartbeat_thread = threading.Thread(
+            target=_fence_heartbeat_loop,
+            args=(fence_conn, fence_lock, fence_heartbeat_stop),
+            name="jobs-fence-heartbeat",
+            daemon=True,
+        )
+        fence_heartbeat_thread.start()
+        logger.info("jobs entrypoint: fence heartbeat started")
         # Step 4 — reaper.
         try:
             reaped = reap_orphaned_syncs(reap_all=True)
@@ -617,12 +866,24 @@ def serve(stop_event: threading.Event | None = None) -> int:
             logger.exception("jobs entrypoint: sync_executor.shutdown raised")
         for t in heartbeat_threads:
             t.join(timeout=2.0)
+        # #1290: stop the fence heartbeat BEFORE closing the fence,
+        # under the fence_lock, so the heartbeat does not race with
+        # close (psycopg's cursor is not thread-safe). The thread may
+        # be None if a startup guard raised before we reached the
+        # thread.start() call — in that case there is nothing to stop.
+        try:
+            fence_heartbeat_stop.set()
+            if fence_heartbeat_thread is not None:
+                fence_heartbeat_thread.join(timeout=2.0)
+        except Exception:
+            logger.exception("jobs entrypoint: fence heartbeat shutdown raised")
         try:
             pool.close()
         except Exception:
             logger.exception("jobs entrypoint: pool.close raised")
         try:
-            fence_conn.close()  # LAST — releases the singleton lock.
+            with fence_lock:
+                fence_conn.close()  # LAST — releases the singleton lock.
             logger.info("jobs entrypoint: singleton fence released")
         except Exception:
             logger.exception("jobs entrypoint: fence_conn.close raised")

--- a/tests/test_jobs_singleton_fence_reaper.py
+++ b/tests/test_jobs_singleton_fence_reaper.py
@@ -1,0 +1,348 @@
+"""#1290 — singleton-fence stale-lock reaper.
+
+Verifies :func:`app.jobs.__main__._reap_stale_singleton_fence_holder`:
+
+- Returns ``None`` when no eligible holder exists in the current DB.
+- Returns ``None`` when a holder exists but ``application_name`` does
+  NOT match the singleton-fence marker (the filter must prevent
+  third-party backends from being terminated).
+- Terminates the matching holder + returns its PID when all criteria
+  hold (application_name match + state='idle' + state_change older
+  than the grace window).
+
+Real backends; no mocks of pg_locks / pg_stat_activity. ``grace_seconds=0``
+is used to admit just-gone-idle backends so the test does not have to
+sleep through the production 5-minute grace.
+
+Each test isolates its own lock key via a per-test random int —
+:data:`app.jobs.locks.JOBS_PROCESS_LOCK_KEY` is held by the live
+dev jobs daemon at all times in a dev environment, so reusing it
+here would falsely reap that daemon's fence connection. The reaper's
+behaviour is identical regardless of the bigint value.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import threading
+import time
+
+import psycopg
+import pytest
+
+from app.jobs.__main__ import (
+    SINGLETON_FENCE_APPLICATION_NAME,
+    _acquire_singleton_fence,
+    _fence_heartbeat_loop,
+    _reap_stale_singleton_fence_holder,
+)
+from app.jobs.locks import JOBS_PROCESS_LOCK_KEY
+from tests.fixtures.ebull_test_db import test_database_url
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable"),
+]
+
+
+# Random per-test bigint clear of any real jobs-process key. Generated
+# once at module load so all tests in this file probe the same key but
+# every pytest run picks a fresh value (cross-run pollution-proof).
+_TEST_LOCK_KEY: int = 0x4000_0000_0000_0000 | (secrets.randbits(48))
+
+
+def _open_holder(*, application_name: str | None) -> psycopg.Connection[tuple]:
+    """Open a fresh autocommit connection and acquire the test lock on
+    it. Returned connection holds the lock until closed; caller MUST
+    close it to release the lock.
+    """
+    kwargs: dict[str, object] = {"autocommit": True}
+    if application_name is not None:
+        kwargs["application_name"] = application_name
+    conn = psycopg.connect(test_database_url(), **kwargs)  # type: ignore[arg-type]
+    row = conn.execute("SELECT pg_try_advisory_lock(%s)", (_TEST_LOCK_KEY,)).fetchone()
+    assert row is not None and row[0], "test holder failed to acquire lock"
+    return conn
+
+
+def test_no_holder_returns_none() -> None:
+    """No backend holds the test lock → reaper is a no-op."""
+    pid = _reap_stale_singleton_fence_holder(
+        test_database_url(),
+        lock_key=_TEST_LOCK_KEY,
+        grace_seconds=0,
+    )
+    assert pid is None
+
+
+def test_holder_with_non_matching_app_name_is_not_reaped() -> None:
+    """A holder whose application_name does NOT match the singleton-fence
+    marker must NOT be terminated. The filter prevents the reaper from
+    ever touching a third-party connection that happened to acquire
+    this key (vanishingly unlikely for the real JOBS_PROCESS_LOCK_KEY
+    bigint, but the safety net belongs at the SQL layer).
+    """
+    holder = _open_holder(application_name="some-other-tool")
+    try:
+        pid = _reap_stale_singleton_fence_holder(
+            test_database_url(),
+            lock_key=_TEST_LOCK_KEY,
+            grace_seconds=0,
+        )
+        assert pid is None
+        # Holder is still alive — a query through it succeeds.
+        ok_row = holder.execute("SELECT 1").fetchone()
+        assert ok_row == (1,)
+    finally:
+        holder.close()
+
+
+def test_stale_idle_holder_with_matching_app_name_is_reaped() -> None:
+    """A holder with application_name=SINGLETON_FENCE_APPLICATION_NAME
+    and ``state='idle'`` past the grace window is terminated. Reaper
+    returns the PID it killed.
+    """
+    holder = _open_holder(application_name=SINGLETON_FENCE_APPLICATION_NAME)
+    try:
+        holder_pid_row = holder.execute("SELECT pg_backend_pid()").fetchone()
+        assert holder_pid_row is not None
+        holder_pid = int(holder_pid_row[0])
+
+        reaped = _reap_stale_singleton_fence_holder(
+            test_database_url(),
+            lock_key=_TEST_LOCK_KEY,
+            grace_seconds=0,
+        )
+        assert reaped == holder_pid
+
+        # Trying to use the holder connection after pg_terminate_backend
+        # raises — the backend is gone, and psycopg detects the closed
+        # socket on the next attempted statement. (psycopg3 maps the
+        # underlying SSL/EOF to OperationalError.)
+        with pytest.raises(Exception):  # noqa: BLE001
+            holder.execute("SELECT 1").fetchone()
+    finally:
+        # Belt-and-braces: close the now-dead connection so its socket
+        # is released. If close itself raises (already-dead), swallow.
+        try:
+            holder.close()
+        except Exception:
+            pass
+
+
+def test_live_heartbeating_fence_is_not_reaped() -> None:
+    """Codex 2 BLOCKING on #1290: a healthy jobs process's fence
+    connection is idle most of the time. Without a liveness signal,
+    a parallel jobs-process boot would terminate it after the grace
+    window — two jobs processes running concurrently.
+
+    The fix is :func:`_fence_heartbeat_loop`: every period_seconds
+    it touches the fence connection so ``pg_stat_activity.state_change``
+    advances. With ``period < grace`` the live fence never qualifies.
+
+    This test runs the real heartbeat loop on a holder for >grace
+    seconds and asserts the reaper finds NO candidate to reap.
+    """
+    holder = _open_holder(application_name=SINGLETON_FENCE_APPLICATION_NAME)
+    holder_lock = threading.Lock()
+    stop_event = threading.Event()
+    heartbeat = threading.Thread(
+        target=_fence_heartbeat_loop,
+        args=(holder, holder_lock, stop_event),
+        kwargs={"period_seconds": 0.1},
+        name="test-fence-heartbeat",
+        daemon=True,
+    )
+    heartbeat.start()
+    try:
+        # Let the heartbeat run for 2 grace windows so the test
+        # would definitely catch any logic that fails to advance
+        # state_change. grace_seconds=1 keeps the test under 3s.
+        time.sleep(2.5)
+
+        reaped = _reap_stale_singleton_fence_holder(
+            test_database_url(),
+            lock_key=_TEST_LOCK_KEY,
+            grace_seconds=1,
+        )
+        assert reaped is None, (
+            "live heartbeating fence was incorrectly reaped — the "
+            "heartbeat is not advancing state_change. Without this "
+            "guard, the reaper would terminate the live singleton "
+            "fence connection and allow two jobs processes to run."
+        )
+
+        # And the holder is still alive (heartbeat keeps it working).
+        with holder_lock:
+            ok_row = holder.execute("SELECT 1").fetchone()
+            assert ok_row == (1,)
+    finally:
+        stop_event.set()
+        heartbeat.join(timeout=2.0)
+        try:
+            holder.close()
+        except Exception:
+            pass
+
+
+def test_dead_fence_after_heartbeat_stops_is_reaped() -> None:
+    """Complementary to the live case: when the heartbeat stops (the
+    python process died), state_change stops advancing. After
+    ``grace_seconds`` elapses, the reaper terminates the orphan
+    backend. Together with the live-fence test this proves the
+    state_change-based liveness signal works end-to-end.
+    """
+    holder = _open_holder(application_name=SINGLETON_FENCE_APPLICATION_NAME)
+    # Snapshot PID BEFORE the heartbeat starts. Running a query on the
+    # holder later (post-stop, pre-reap) would refresh state_change
+    # and mask the failure mode this test is designed to catch.
+    holder_pid_row = holder.execute("SELECT pg_backend_pid()").fetchone()
+    assert holder_pid_row is not None
+    holder_pid = int(holder_pid_row[0])
+
+    holder_lock = threading.Lock()
+    stop_event = threading.Event()
+    heartbeat = threading.Thread(
+        target=_fence_heartbeat_loop,
+        args=(holder, holder_lock, stop_event),
+        kwargs={"period_seconds": 0.1},
+        name="test-fence-heartbeat-dies",
+        daemon=True,
+    )
+    heartbeat.start()
+    try:
+        # Run heartbeat briefly, then kill it (simulating jobs-process
+        # death). state_change is fresh at this moment.
+        time.sleep(0.5)
+        stop_event.set()
+        heartbeat.join(timeout=2.0)
+
+        # Confirm reaper does NOT yet reap (state_change too fresh).
+        early = _reap_stale_singleton_fence_holder(
+            test_database_url(),
+            lock_key=_TEST_LOCK_KEY,
+            grace_seconds=2,
+        )
+        assert early is None, "reaper fired before grace window — false positive"
+
+        # Wait past the grace window — heartbeat is dead so
+        # state_change cannot advance. NB: do NOT touch the holder
+        # connection here; any query would refresh state_change and
+        # break the staleness detection.
+        time.sleep(2.5)
+
+        reaped = _reap_stale_singleton_fence_holder(
+            test_database_url(),
+            lock_key=_TEST_LOCK_KEY,
+            grace_seconds=2,
+        )
+        assert reaped == holder_pid
+    finally:
+        try:
+            holder.close()
+        except Exception:
+            pass
+
+
+def test_acquire_singleton_fence_pins_autocommit_and_holds_lock() -> None:
+    """Codex 2 round 3 LOW on #1290: pin :func:`_acquire_singleton_fence`
+    itself to ``autocommit=True`` and prove the session-scope advisory
+    lock survives autocommit statement boundaries.
+
+    Asserts:
+      1. The returned fence connection reports ``autocommit=True``.
+      2. While the fence is open, a sibling connection cannot acquire
+         the same advisory key (proves the lock is held session-wide,
+         not statement-wide — autocommit does NOT promote the lock to
+         transaction-scope).
+      3. Once the fence closes, the lock releases and a sibling can
+         acquire it.
+
+    Uses the real :data:`JOBS_PROCESS_LOCK_KEY` against the per-worker
+    test DB — the dev jobs daemon holds the key in its own dev DB
+    only, so this does not collide.
+    """
+    fence = _acquire_singleton_fence(test_database_url())
+    try:
+        assert fence.autocommit is True
+
+        # Sibling cannot acquire — proves session-scoped hold survives
+        # autocommit statement boundaries.
+        sibling = psycopg.connect(test_database_url(), autocommit=True)
+        try:
+            row = sibling.execute("SELECT pg_try_advisory_lock(%s)", (JOBS_PROCESS_LOCK_KEY,)).fetchone()
+            assert row is not None
+            assert row[0] is False, (
+                "sibling acquired lock while fence is open — autocommit "
+                "may have promoted the lock to transaction-scope. "
+                "Session-scope is critical: the lock MUST persist for "
+                "the lifetime of the fence connection."
+            )
+        finally:
+            sibling.close()
+    finally:
+        fence.close()
+
+    # After fence close, lock releases — sibling can now acquire.
+    sibling2 = psycopg.connect(test_database_url(), autocommit=True)
+    try:
+        row = sibling2.execute("SELECT pg_try_advisory_lock(%s)", (JOBS_PROCESS_LOCK_KEY,)).fetchone()
+        assert row is not None
+        assert row[0] is True, "lock not released after fence.close()"
+        # Tidy up: release the lock so subsequent tests in this DB
+        # are not affected. (Per-worker DB makes this defensive.)
+        sibling2.execute("SELECT pg_advisory_unlock(%s)", (JOBS_PROCESS_LOCK_KEY,))
+    finally:
+        sibling2.close()
+
+
+def test_reaper_excludes_other_databases() -> None:
+    """The reaper's ``database = current_database()`` clause must scope
+    the probe to the test DB only — a holder in the same PG cluster
+    but a different DB on the exact same advisory key must NOT be
+    reaped. Skip if no sibling DB exists to test against.
+    """
+    # The dev DB ``ebull`` (settings.database_url) is the natural
+    # sibling in any developer's local cluster. Skip if test DB IS
+    # the dev DB (single-database test runners) or if the dev DB is
+    # unreachable.
+    dev_db_url = os.environ.get("DATABASE_URL")
+    if not dev_db_url or dev_db_url == test_database_url():
+        pytest.skip("no separate dev DB available to test cross-DB isolation")
+
+    try:
+        sibling = psycopg.connect(
+            dev_db_url,
+            autocommit=True,
+            application_name=SINGLETON_FENCE_APPLICATION_NAME,
+            connect_timeout=2,
+        )
+    except Exception:
+        pytest.skip("dev DB unreachable; skipping cross-DB isolation test")
+
+    try:
+        row = sibling.execute("SELECT pg_try_advisory_lock(%s)", (_TEST_LOCK_KEY,)).fetchone()
+        if not (row and row[0]):
+            pytest.skip("sibling DB already holds the test key; skipping")
+
+        # Reaper probes test_database_url() only. The sibling holder
+        # in dev DB must be invisible to it.
+        reaped = _reap_stale_singleton_fence_holder(
+            test_database_url(),
+            lock_key=_TEST_LOCK_KEY,
+            grace_seconds=0,
+        )
+        assert reaped is None
+        ok_row = sibling.execute("SELECT 1").fetchone()
+        assert ok_row == (1,)
+    finally:
+        try:
+            sibling.execute("SELECT pg_advisory_unlock(%s)", (_TEST_LOCK_KEY,))
+        except Exception:
+            pass
+        try:
+            sibling.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- Boot-time recovery for the singleton advisory-lock holdover after a sudden jobs-process death (kill -9, OOM, segfault). Eliminates the operator's manual ``SELECT pg_terminate_backend(...)`` workaround.
- Live-fence liveness via a 30 s heartbeat thread on the dedicated fence connection so a healthy idle fence is never mistaken for a stale one.
- Fence opened with ``autocommit=True`` so a crashed backend cannot get stuck ``idle in transaction`` (unreapable by the reaper's ``state='idle'`` filter).

Closes #1290. Refs #1233.

## Why
``kill -9`` of the jobs process leaves the fence backend's TCP connection half-open. Postgres holds the advisory lock until kernel keepalive (~2 h on Linux). Next restart refuses with ``another app.jobs process holds the singleton advisory lock`` until either:
1. Operator manually kills the orphan via SQL.
2. The kernel keepalive eventually reaps the socket.

This change automates path 1.

## What changed
- New helper [app/jobs/__main__.py](app/jobs/__main__.py) ``_reap_stale_singleton_fence_holder(database_url, *, lock_key, grace_seconds=300)``:
  - Probes ``pg_locks JOIN pg_stat_activity`` on its own short-lived connection
  - Filters: ``locktype='advisory'`` + ``objsubid=1`` + ``database=current_database()`` + ``application_name='ebull-jobs-singleton-fence'`` + ``state='idle'`` + ``state_change < NOW() - grace``
  - Calls ``pg_terminate_backend(pid)``; returns the reaped PID or ``None``
- ``_acquire_singleton_fence`` now opens the fence with ``autocommit=True`` + the singleton ``application_name``. On failed initial acquire it invokes the reaper; on success it poll-retries the lock acquire for up to 2 s (``pg_terminate_backend`` is async — the lock releases when the doomed backend exits, not when the signal queues).
- New ``_fence_heartbeat_loop`` thread touches the fence every 30 s under ``fence_lock``. Started inside the main ``try/finally`` so shutdown stops + joins it before closing the fence.

## Codex 2 pre-push findings folded (3 rounds)
- **Round 1 BLOCKING** — live idle fence reapable after 5 min → added heartbeat thread.
- **Round 2 BLOCKING** — fence not autocommit; crash mid-statement = unreapable ``idle in transaction`` → fence opens with ``autocommit=True``.
- **Round 2 HIGH** — heartbeat started before main ``try/finally`` (cleanup races on guard raise) → thread.start() moved inside the try block.
- **Round 3 HIGH** — ``pg_terminate_backend`` async, immediate retry sees stale lock → added 20×100 ms poll-retry on acquire.
- **Round 3 LOW** — no test pinning ``fence.autocommit=True`` → added ``test_acquire_singleton_fence_pins_autocommit_and_holds_lock``.

## Tests
[tests/test_jobs_singleton_fence_reaper.py](tests/test_jobs_singleton_fence_reaper.py) — 6 integration tests + 1 conditional:
- ``test_no_holder_returns_none`` — reaper no-op when no holder.
- ``test_holder_with_non_matching_app_name_is_not_reaped`` — safety net against terminating third-party connections.
- ``test_stale_idle_holder_with_matching_app_name_is_reaped`` — positive path.
- ``test_live_heartbeating_fence_is_not_reaped`` — Codex round-1 BLOCKING regression guard.
- ``test_dead_fence_after_heartbeat_stops_is_reaped`` — proves the state_change-based liveness signal works end-to-end.
- ``test_acquire_singleton_fence_pins_autocommit_and_holds_lock`` — Codex round-3 LOW.
- ``test_reaper_excludes_other_databases`` — sibling-DB cross-pollination guard (skip-on-no-sibling).

## Test plan
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run pyright`
- [x] `pytest tests/test_jobs_singleton_fence_reaper.py` — 6 pass, 1 skipped (cross-DB)

## Operator follow-up
Not required for this PR; no schema migration, no scheduled-job changes. Effect is visible on the next jobs-process restart after a crash — the lock-acquire log line will reference the reap if one occurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)