### PR TITLE
fix(#1233): extend PR-1292 cap-ordering to S22↔S10 / S19↔S11 / S20↔S11

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -867,7 +867,16 @@ Fix shape (`submissions_processed` capability):
 2. If cross-lane (the dispatcher would run them concurrent), introduce an ordering cap.
 3. The cap should be provided ON SKIP if the downstream's slow-connection-fallback path requires the run to continue.
 
-**Open lock-contention audit (incomplete):** PR-1292 fixed S15↔S8 only. Same shape may exist for S17/S18/S19/S20/S21/S22 vs S8/S9/S11. Tracked in `project_1233_bootstrap_optimisation.md`.
+**Lock-contention audit COMPLETE (2026-05-23):** PR-1292 fixed S15↔S8. The 2026-05-23 audit identified 3 more pairs needing cap-gates:
+- **S22 sec_13f_recent_sweep ↔ S10 sec_13f_ingest_from_dataset** — both write `ownership_institutions_observations`. Cap: `institutional_dataset_processed`.
+- **S19 sec_insider_transactions_backfill ↔ S11 sec_insider_ingest_from_dataset** — both write `ownership_insiders_observations`. Cap: `insider_dataset_processed`.
+- **S20 sec_form3_ingest ↔ S11** — same shared table as S19. Same cap.
+
+All three cap-gates land in the same PR mirroring PR-1292's pattern: bulk ingester provides cap on success (`_STAGE_PROVIDES`) AND on skip (`_STAGE_PROVIDES_ON_SKIP`) for slow-connection-fallback parity; legacy stage requires it in `_STAGE_REQUIRES_CAPS`.
+
+S17 sec_def14a_bootstrap / S18 sec_business_summary_bootstrap / S21 sec_8k_events_ingest — verified SAFE (disjoint writes, already chained behind `submissions_secondary_pages_walked` which transitively depends on S8).
+
+**Ordering-only cap semantic:** these three caps (plus `submissions_processed`) are advertised whenever the upstream stage reaches ANY terminal status — not just success/skip but also blocked/error/cancelled. The cap's only meaning is "no concurrent writer remains"; once the upstream stage has terminalised, the legacy chain can write safely regardless of how the upstream ended. The `_ORDERING_ONLY_CAPS` frozenset is the dispatch hook in `_satisfied_capabilities` + `_capability_is_dead`. Without this concession, a cascade-blocked bulk stage would falsely gate its legacy counterpart from recovering (`test_partial_bulk_failure_legacy_recovers` regression sentinel).
 
 ### 6.5.11 NUMERIC precision gate for bulk ingest (#1233 PR-1291)
 

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -311,6 +311,31 @@ Capability = Literal[
     # skipped → S8 cascade-skipped) still flows into S15 as the
     # legacy chain owner of ``filing_events_seeded``.
     "submissions_processed",
+    # #1233 — extension of the PR-1292 cap-ordering pattern to the
+    # other bulk/legacy pairs flagged by the 2026-05-23 lock-contention
+    # audit. Same shape:
+    #
+    #   * ``insider_dataset_processed`` — S11 sec_insider_ingest_from_dataset
+    #     and S19 sec_insider_transactions_backfill + S20 sec_form3_ingest
+    #     all write ``ownership_insiders_observations``. Without an
+    #     ordering cap, PR-2 ``as_completed`` parallelism would let the
+    #     bulk path and the legacy backfills run concurrently against
+    #     overlapping (instrument_id, holder, observed_at) rows —
+    #     identical row-lock storm shape as the S8↔S15 case PR-1292
+    #     fixed.
+    #
+    #   * ``institutional_dataset_processed`` — S10 sec_13f_ingest_from_dataset
+    #     and S22 sec_13f_recent_sweep both write
+    #     ``ownership_institutions_observations``. Same pattern;
+    #     largest write fanout of any audited pair (institutional 13F
+    #     rows during a full bootstrap can total tens of millions).
+    #
+    # Both caps are PROVIDED on SUCCESS by their respective bulk
+    # ingester and ON SKIP for cascade-skip parity. Required by the
+    # legacy stages downstream so they serialise after the bulk
+    # ingester terminalises.
+    "insider_dataset_processed",
+    "institutional_dataset_processed",
 ]
 
 
@@ -342,8 +367,20 @@ _STAGE_PROVIDES: Final[dict[str, tuple[Capability, ...]]] = {
     "sec_submissions_ingest": ("filing_events_seeded", "submissions_processed"),
     "sec_companyfacts_ingest": ("fundamentals_raw_seeded",),
     # Bulk ownership ingester covers both insider transactions + Form 3.
-    "sec_insider_ingest_from_dataset": ("insider_inputs_seeded", "form3_inputs_seeded"),
-    "sec_13f_ingest_from_dataset": ("institutional_inputs_seeded",),
+    # #1233 lock-contention cap-gates: bulk ingesters advertise an
+    # ordering cap on top of their content caps. Required by S19/S20
+    # (insider) and S22 (institutional) so the legacy backfills wait
+    # for the bulk path to terminalise. See ``insider_dataset_processed``
+    # / ``institutional_dataset_processed`` docstrings.
+    "sec_insider_ingest_from_dataset": (
+        "insider_inputs_seeded",
+        "form3_inputs_seeded",
+        "insider_dataset_processed",
+    ),
+    "sec_13f_ingest_from_dataset": (
+        "institutional_inputs_seeded",
+        "institutional_dataset_processed",
+    ),
     "sec_nport_ingest_from_dataset": ("nport_inputs_seeded",),
     "sec_submissions_files_walk": ("submissions_secondary_pages_walked",),
     "filings_history_seed": ("filing_events_seeded",),
@@ -380,6 +417,16 @@ _STAGE_PROVIDES_ON_SKIP: Final[dict[str, tuple[Capability, ...]]] = {
     # as success" — the cap is purely an ordering constraint on S15,
     # not a content-validity signal.
     "sec_submissions_ingest": ("submissions_processed",),
+    # #1233 lock-contention cap-gates: same cascade-skip parity as
+    # ``sec_submissions_ingest``. If S7 sec_bulk_download is skipped
+    # on slow-connection fallback (#1041), S10/S11 cascade-skip too —
+    # but the ordering cap still flows so the legacy ingesters
+    # proceed without waiting on a bulk run that will never happen.
+    # The cap is purely an ordering constraint; the cap-on-skip does
+    # NOT masquerade as "content was ingested", same as the existing
+    # ``submissions_processed`` cascade-skip entry.
+    "sec_insider_ingest_from_dataset": ("insider_dataset_processed",),
+    "sec_13f_ingest_from_dataset": ("institutional_dataset_processed",),
 }
 
 
@@ -444,6 +491,34 @@ _STRICT_CAP_PROVIDER_EXCLUSIONS: Final[dict[Capability, frozenset[str]]] = {
 }
 
 
+# #1233 lock-contention cap-gates — "ordering-only" caps that
+# advertise "the upstream stage has terminalised, no concurrent
+# writer remains" rather than "the upstream produced usable content".
+# These caps are SATISFIED on ANY terminal status of their provider
+# stage (success / skipped / blocked / error / cancelled), not just
+# success or skip.
+#
+# Rationale: the row-lock storm shape PR-1292 fixed exists ONLY while
+# the bulk stage is actively writing. Once the bulk stage has
+# terminalised — for any reason, including a cascade-block from an
+# earlier failure — the legacy downstream can write safely. Without
+# this concession the cap-gate would FALSELY block the legacy
+# recovery path during a partial-bulk-failure run
+# (``test_partial_bulk_failure_legacy_recovers``).
+#
+# Content caps (``filing_events_seeded``, ``insider_inputs_seeded``,
+# etc.) deliberately stay non-ordering: they must observe actual
+# content writes to be satisfied. Ordering caps only need the
+# upstream stage to be done.
+_ORDERING_ONLY_CAPS: Final[frozenset[Capability]] = frozenset(
+    {
+        "submissions_processed",
+        "insider_dataset_processed",
+        "institutional_dataset_processed",
+    }
+)
+
+
 # Stage-key → CapRequirement. Replaces the old AND-only
 # ``_STAGE_REQUIRES`` (#1138 Task A). Every entry in
 # ``_BOOTSTRAP_STAGE_SPECS`` must appear here (enforced by the
@@ -487,10 +562,18 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
     "sec_business_summary_bootstrap": CapRequirement(
         all_of=("filing_events_seeded", "submissions_secondary_pages_walked")
     ),
-    "sec_insider_transactions_backfill": CapRequirement(all_of=("cik_mapping_ready",)),
-    "sec_form3_ingest": CapRequirement(all_of=("cik_mapping_ready",)),
+    # #1233 lock-contention cap-gates — same shape as PR-1292 for
+    # S15↔S8. The legacy backfills (S19/S20) and the legacy 13F sweep
+    # (S22) all write the same observation table their bulk
+    # counterparts (S11 / S10) write. Without the ordering cap, PR-2
+    # cross-lane parallelism lets them run concurrently and produces
+    # the row-lock storm shape that killed bootstrap run #5. Caps are
+    # ``*_dataset_processed`` (provided by S11 / S10 on success or
+    # skip), so the legacy stages run AFTER the bulk path terminalises.
+    "sec_insider_transactions_backfill": CapRequirement(all_of=("cik_mapping_ready", "insider_dataset_processed")),
+    "sec_form3_ingest": CapRequirement(all_of=("cik_mapping_ready", "insider_dataset_processed")),
     "sec_8k_events_ingest": CapRequirement(all_of=("filing_events_seeded", "submissions_secondary_pages_walked")),
-    "sec_13f_recent_sweep": CapRequirement(all_of=("cik_mapping_ready",)),
+    "sec_13f_recent_sweep": CapRequirement(all_of=("cik_mapping_ready", "institutional_dataset_processed")),
     "sec_n_port_ingest": CapRequirement(all_of=("cik_mapping_ready",)),
     # #1174 — dedicated MF directory refresh + N-CSR drain (S25 + S26).
     "mf_directory_sync": CapRequirement(all_of=("universe_seeded",)),
@@ -609,6 +692,16 @@ def _satisfied_capabilities(
                     caps.add(cap)
         elif status == "skipped":
             caps.update(provides_on_skip.get(stage_key, ()))
+        elif status in ("blocked", "error", "cancelled"):
+            # #1233 — ordering-only caps advertise "upstream is done"
+            # regardless of how it ended. Content caps stay unsatisfied
+            # on terminal failure (no usable rows landed). Without this
+            # branch a cascade-blocked bulk ingester would falsely gate
+            # its legacy counterpart from recovering — see
+            # ``_ORDERING_ONLY_CAPS`` docstring.
+            for cap in provides.get(stage_key, ()):
+                if cap in _ORDERING_ONLY_CAPS:
+                    caps.add(cap)
     return caps
 
 
@@ -619,6 +712,7 @@ def _capability_is_dead(
     *,
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
     provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
+    provides: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES,
     min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
     exclusions: Mapping[Capability, frozenset[str]] = _STRICT_CAP_PROVIDER_EXCLUSIONS,
 ) -> bool:
@@ -661,6 +755,15 @@ def _capability_is_dead(
         if status == "skipped":
             on_skip = provides_on_skip.get(provider_key, ())
             if cap in on_skip:
+                return False
+        # #1233 ordering-only caps: a cascade-blocked / errored /
+        # cancelled provider STILL satisfies the cap because the
+        # cap's only semantic is "this stage is no longer writing".
+        # Content caps stay dead on terminal failure (handled by the
+        # ``return True`` fallthrough below).
+        if status in ("blocked", "error", "cancelled") and cap in _ORDERING_ONLY_CAPS:
+            on_provides = provides.get(provider_key, ())
+            if cap in on_provides:
                 return False
     return True
 
@@ -739,6 +842,7 @@ def _classify_requirement_unsatisfiable(
     *,
     providers_map: Mapping[Capability, tuple[str, ...]] = _CAPABILITY_PROVIDERS,
     provides_on_skip: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES_ON_SKIP,
+    provides: Mapping[str, tuple[Capability, ...]] = _STAGE_PROVIDES,
     min_rows: Mapping[Capability, int] = _CAPABILITY_MIN_ROWS,
     exclusions: Mapping[Capability, frozenset[str]] = _STRICT_CAP_PROVIDER_EXCLUSIONS,
 ) -> tuple[Literal["skip_only", "error"], list[Capability]] | None:
@@ -765,6 +869,7 @@ def _classify_requirement_unsatisfiable(
         rows_processed,
         providers_map=providers_map,
         provides_on_skip=provides_on_skip,
+        provides=provides,
         min_rows=min_rows,
         exclusions=exclusions,
     )
@@ -1733,6 +1838,7 @@ def _phase_batched_dispatch(
                     rows_processed,
                     providers_map=effective_providers_inverse,
                     provides_on_skip=effective_provides_on_skip,
+                    provides=effective_provides,
                     min_rows=effective_min_rows,
                     exclusions=effective_exclusions,
                 )

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -714,6 +714,139 @@ def test_submissions_processed_provided_by_s8_on_success_and_skip() -> None:
     assert "submissions_processed" in _STAGE_PROVIDES_ON_SKIP["sec_submissions_ingest"]
 
 
+# ---------------------------------------------------------------------------
+# #1233 extended lock-contention cap-gates — same pattern as PR-1292
+# for the other bulk/legacy pairs flagged by the 2026-05-23 audit.
+# ---------------------------------------------------------------------------
+
+
+def test_insider_legacy_backfills_require_insider_dataset_processed() -> None:
+    """S19 (sec_insider_transactions_backfill) and S20 (sec_form3_ingest)
+    BOTH write ``ownership_insiders_observations`` via the legacy
+    per-filing path. S11 (sec_insider_ingest_from_dataset) writes the
+    same table from the bulk dataset. PR-2 cross-lane parallelism would
+    let them run concurrently against overlapping
+    (instrument_id, holder, observed_at) rows — same row-lock storm
+    shape that PR-1292 fixed for S15↔S8.
+
+    Regression sentinel: any future edit that drops the
+    ``insider_dataset_processed`` requirement from S19 or S20 would
+    re-introduce the contention silently.
+    """
+    s19 = _STAGE_REQUIRES_CAPS["sec_insider_transactions_backfill"]
+    s20 = _STAGE_REQUIRES_CAPS["sec_form3_ingest"]
+    assert "insider_dataset_processed" in s19.all_of, (
+        "sec_insider_transactions_backfill must require insider_dataset_processed (#1233 lock-contention serialisation)"
+    )
+    assert "insider_dataset_processed" in s20.all_of, (
+        "sec_form3_ingest must require insider_dataset_processed (#1233 lock-contention serialisation)"
+    )
+
+
+def test_thirteen_f_recent_sweep_requires_institutional_dataset_processed() -> None:
+    """S22 (sec_13f_recent_sweep) and S10 (sec_13f_ingest_from_dataset)
+    both write ``ownership_institutions_observations``. Same shape as
+    the S19/S20 case above but on the institutional family — and the
+    largest write fanout of any audited pair (institutional 13F rows
+    during a full bootstrap can total tens of millions).
+    """
+    s22 = _STAGE_REQUIRES_CAPS["sec_13f_recent_sweep"]
+    assert "institutional_dataset_processed" in s22.all_of, (
+        "sec_13f_recent_sweep must require institutional_dataset_processed (#1233 lock-contention serialisation)"
+    )
+
+
+def test_dataset_processed_caps_provided_by_bulk_ingesters_on_success_and_skip() -> None:
+    """Companion invariant to the requires-side tests. Each new
+    ordering cap is advertised by its bulk ingester on BOTH success
+    AND skip — the skip entry preserves cascade-skip parity (S7
+    skipped → S10/S11 cascade-skipped → legacy chain still gets the
+    ordering cap satisfied so it does not deadlock).
+    """
+    from app.services.bootstrap_orchestrator import (
+        _STAGE_PROVIDES,
+        _STAGE_PROVIDES_ON_SKIP,
+    )
+
+    assert "insider_dataset_processed" in _STAGE_PROVIDES["sec_insider_ingest_from_dataset"]
+    assert "insider_dataset_processed" in _STAGE_PROVIDES_ON_SKIP["sec_insider_ingest_from_dataset"]
+    assert "institutional_dataset_processed" in _STAGE_PROVIDES["sec_13f_ingest_from_dataset"]
+    assert "institutional_dataset_processed" in _STAGE_PROVIDES_ON_SKIP["sec_13f_ingest_from_dataset"]
+
+
+def test_ordering_only_caps_disjoint_from_strict_gate_caps() -> None:
+    """Codex 2 LOW on #1233 cap-gates: pin the ``_ORDERING_ONLY_CAPS``
+    allowlist as an explicit invariant. Members must NOT also be
+    strict-gate caps (``_CAPABILITY_MIN_ROWS``) — ordering caps fire
+    on any terminal status, strict-gate caps require a row floor on
+    ``success``; conflating the two would let a strict cap leak into
+    the terminal-failure escape hatch and falsely satisfy a content
+    requirement.
+    """
+    from app.services.bootstrap_orchestrator import (
+        _CAPABILITY_MIN_ROWS,
+        _ORDERING_ONLY_CAPS,
+    )
+
+    assert _ORDERING_ONLY_CAPS == frozenset(
+        {
+            "submissions_processed",
+            "insider_dataset_processed",
+            "institutional_dataset_processed",
+        }
+    ), (
+        "_ORDERING_ONLY_CAPS membership changed without updating the test. "
+        "New ordering caps must be added consciously: they advertise on "
+        "ANY terminal status, including error/blocked/cancelled — a content "
+        "cap added here would silently bypass the strict-gate row floor."
+    )
+    leaks = _ORDERING_ONLY_CAPS & _CAPABILITY_MIN_ROWS.keys()
+    assert not leaks, (
+        f"ordering-only caps overlap strict-gate caps: {leaks}. "
+        "An ordering cap fires on terminal failure regardless of row "
+        "count; a strict-gate cap requires rows on success. Combining "
+        "both would let a zero-row failure satisfy a content cap."
+    )
+
+
+def test_ordering_caps_satisfied_on_terminal_failure_but_content_caps_are_not() -> None:
+    """Codex 2 LOW on #1233 cap-gates: prove the terminal-failure
+    escape hatch in ``_satisfied_capabilities`` works as documented.
+    An ordering cap (``insider_dataset_processed``) advertised by
+    ``sec_insider_ingest_from_dataset`` (S11) MUST be satisfied
+    whenever S11 reaches blocked / error / cancelled. The adjacent
+    content cap (``insider_inputs_seeded``) advertised by the same
+    stage MUST NOT — content caps stay dead on terminal failure so
+    downstream content consumers correctly block.
+
+    Tests the exact bug pattern Codex caught on
+    ``test_partial_bulk_failure_legacy_recovers`` regression: ordering
+    cap must flow through to legacy chain, content cap must not.
+    """
+    from app.services.bootstrap_orchestrator import _satisfied_capabilities
+
+    for terminal_status in ("blocked", "error", "cancelled"):
+        caps = _satisfied_capabilities(
+            statuses={"sec_insider_ingest_from_dataset": terminal_status},
+            rows_processed={"sec_insider_ingest_from_dataset": None},
+        )
+        assert "insider_dataset_processed" in caps, (
+            f"ordering cap missing on status={terminal_status!r} — legacy recovery chain would falsely block"
+        )
+        assert "insider_inputs_seeded" not in caps, (
+            f"content cap leaked on status={terminal_status!r} — downstream consumer would falsely proceed"
+        )
+
+    # Same shape for institutional pair.
+    for terminal_status in ("blocked", "error", "cancelled"):
+        caps = _satisfied_capabilities(
+            statuses={"sec_13f_ingest_from_dataset": terminal_status},
+            rows_processed={"sec_13f_ingest_from_dataset": None},
+        )
+        assert "institutional_dataset_processed" in caps
+        assert "institutional_inputs_seeded" not in caps
+
+
 def test_partial_bulk_failure_legacy_recovers(
     ebull_test_conn: psycopg.Connection[tuple],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -846,6 +846,28 @@ def test_ordering_caps_satisfied_on_terminal_failure_but_content_caps_are_not() 
         assert "institutional_dataset_processed" in caps
         assert "institutional_inputs_seeded" not in caps
 
+    # Bot WARNING on PR #1299: ``submissions_processed`` is also a
+    # member of ``_ORDERING_ONLY_CAPS`` and thus gains the
+    # terminal-failure escape hatch. Pre-#1299 the cap fired on
+    # success OR skip only; the extension is intentional — the
+    # cap's semantic is "S8 is done writing filing_events", which
+    # holds whenever S8 terminalises. Without this assertion the
+    # silent extension would be unpinned.
+    for terminal_status in ("blocked", "error", "cancelled"):
+        caps = _satisfied_capabilities(
+            statuses={"sec_submissions_ingest": terminal_status},
+            rows_processed={"sec_submissions_ingest": None},
+        )
+        assert "submissions_processed" in caps, (
+            f"submissions_processed missing on status={terminal_status!r} — "
+            "legacy filings_history_seed would falsely block (PR-1292 + #1299)"
+        )
+        # Content cap MUST stay dead on terminal failure.
+        assert "filing_events_seeded" not in caps, (
+            f"filing_events_seeded leaked on status={terminal_status!r} — "
+            "content cap escaped through the ordering escape hatch"
+        )
+
 
 def test_partial_bulk_failure_legacy_recovers(
     ebull_test_conn: psycopg.Connection[tuple],


### PR DESCRIPTION
## Summary
- Closes the 2026-05-23 lock-contention audit. Three more bulk/legacy pairs gain cap-gates matching PR-1292's S15↔S8 pattern.
- New caps: ``insider_dataset_processed`` (S11 provides; S19+S20 require) and ``institutional_dataset_processed`` (S10 provides; S22 requires).
- New ``_ORDERING_ONLY_CAPS`` semantic: ordering caps are advertised on ANY terminal status (success/skipped/blocked/error/cancelled), so the legacy recovery chain survives a partial bulk-failure run.

Refs #1233.

## Why
PR-1292 fixed the row-lock storm where S15 ``filings_history_seed`` and S8 ``sec_submissions_ingest`` both wrote ``filing_events`` concurrently after PR-2 cross-lane parallelism landed. The 2026-05-23 audit identified three more pairs with the same shape:

| Bulk stage | Legacy stage(s) | Shared table |
|---|---|---|
| S10 ``sec_13f_ingest_from_dataset`` | S22 ``sec_13f_recent_sweep`` | ``ownership_institutions_observations`` (largest write fanout) |
| S11 ``sec_insider_ingest_from_dataset`` | S19 ``sec_insider_transactions_backfill`` | ``ownership_insiders_observations`` |
| S11 ``sec_insider_ingest_from_dataset`` | S20 ``sec_form3_ingest`` | ``ownership_insiders_observations`` |

S17 / S18 / S21 verified SAFE (disjoint writes / chained behind ``submissions_secondary_pages_walked``).

## What changed
- New caps in ``Capability`` Literal: ``insider_dataset_processed``, ``institutional_dataset_processed``.
- ``_STAGE_PROVIDES`` updated: S11 and S10 each advertise the new caps on success (alongside their existing content caps).
- ``_STAGE_PROVIDES_ON_SKIP`` updated: same on cascade-skip (slow-connection-fallback parity, identical shape to PR-1292's S8 entry).
- ``_STAGE_REQUIRES_CAPS`` updated: S19 + S20 each add ``insider_dataset_processed``; S22 adds ``institutional_dataset_processed``. ``cik_mapping_ready`` retained.
- New ``_ORDERING_ONLY_CAPS`` frozenset + branch in ``_satisfied_capabilities`` / ``_capability_is_dead``: ordering caps fire on any terminal status (success / skipped / blocked / error / cancelled). Content caps stay strict.
- ``_classify_requirement_unsatisfiable`` + ``_capability_is_dead`` gain a ``provides`` parameter so synthetic dispatcher tests can exercise the escape hatch (Codex 2 LOW #3).

## Why the ordering-cap escape hatch
Without it, partial-bulk-failure runs deadlock:
S7 errors → S11/S10 cascade-block → ``insider_dataset_processed`` / ``institutional_dataset_processed`` stay dead → legacy chain (S19/S20/S22) BLOCKED → ``ownership_observations_backfill`` BLOCKED.

With the escape hatch, the cap's "no concurrent writer" semantic still holds when the bulk stage terminalises (regardless of why), so the legacy chain proceeds and per-family content caps land. Content caps remain unaffected — they still gate on actual rows.

## Codex 2 pre-push (no BLOCKING/HIGH/MEDIUM; 3 LOW folded)
- LOW — ``_ORDERING_ONLY_CAPS`` had no invariant proving its members are ordering-only. Added ``test_ordering_only_caps_disjoint_from_strict_gate_caps``.
- LOW — coverage missing for the terminal-failure escape hatch directly. Added ``test_ordering_caps_satisfied_on_terminal_failure_but_content_caps_are_not``.
- LOW — ``_classify_requirement_unsatisfiable`` did not propagate effective ``provides``. Wired it through.

## Tests
- 5 new sentinels in [tests/test_bootstrap_orchestrator.py](tests/test_bootstrap_orchestrator.py):
  - ``test_insider_legacy_backfills_require_insider_dataset_processed``
  - ``test_thirteen_f_recent_sweep_requires_institutional_dataset_processed``
  - ``test_dataset_processed_caps_provided_by_bulk_ingesters_on_success_and_skip``
  - ``test_ordering_only_caps_disjoint_from_strict_gate_caps``
  - ``test_ordering_caps_satisfied_on_terminal_failure_but_content_caps_are_not``
- Existing ``test_partial_bulk_failure_legacy_recovers`` (regression sentinel for the escape hatch) still passes — verifies the legacy chain actually recovers when S7 errors.
- ``pytest tests/test_bootstrap_orchestrator.py`` — 35 / 35 pass.

## Skill update
- [.claude/skills/data-engineer/SKILL.md](.claude/skills/data-engineer/SKILL.md) §6.5.10 — replaced the "Open lock-contention audit (incomplete)" callout with the completed audit outcome + ``_ORDERING_ONLY_CAPS`` semantic note.

## Test plan
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run pyright`
- [x] `pytest tests/test_bootstrap_orchestrator.py` — 35/35
- [ ] End-to-end measurement — deferred to bootstrap run #7 after the rest of the #1233 follow-up queue lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)