### PR TITLE
fix(#1233): #1296 — auto-resume in-flight bootstrap on jobs-process restart

### DIFF
--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -747,11 +747,16 @@ def serve(stop_event: threading.Event | None = None) -> int:
             with psycopg.connect(settings.database_url, autocommit=True) as conn:
                 decision = attempt_boot_resume(conn, requested_by=boot_id)
             if decision.decision == "resumed":
+                # Source the cap from bootstrap_state so the log line
+                # tracks widening of the cap automatically. Bot
+                # NITPICK on PR #1301.
+                from app.services.bootstrap_state import _MAX_BOOT_RESUMES
+
                 logger.info(
                     "jobs entrypoint: bootstrap auto-resume enqueued (run_id=%d, attempt=%d/%d)",
                     decision.run_id or -1,
                     decision.attempts,
-                    1,  # _MAX_BOOT_RESUMES default; keep in sync if widened
+                    _MAX_BOOT_RESUMES,
                 )
             else:
                 if decision.decision == "terminated_max_attempts":

--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -748,8 +748,7 @@ def serve(stop_event: threading.Event | None = None) -> int:
                 decision = attempt_boot_resume(conn, requested_by=boot_id)
             if decision.decision == "resumed":
                 logger.info(
-                    "jobs entrypoint: bootstrap auto-resume enqueued "
-                    "(run_id=%d, attempt=%d/%d)",
+                    "jobs entrypoint: bootstrap auto-resume enqueued (run_id=%d, attempt=%d/%d)",
                     decision.run_id or -1,
                     decision.attempts,
                     1,  # _MAX_BOOT_RESUMES default; keep in sync if widened

--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -714,21 +714,61 @@ def serve(stop_event: threading.Event | None = None) -> int:
         except Exception:
             logger.exception("jobs entrypoint: reaper failed; continuing")
 
-        # Step 4b — bootstrap reaper (#994). If a previous jobs process
-        # crashed mid-bootstrap, ``bootstrap_state.status='running'``
-        # is now stale — no live thread is executing it. Sweep
-        # in-flight + still-pending stages on the latest run to
-        # ``error`` and transition state to ``partial_error`` so the
-        # operator can retry-failed from the admin panel rather than
-        # being stuck looking at a stale Running spinner.
+        # Step 4b — bootstrap recovery (#994 + #1296).
+        #
+        # If a previous jobs process crashed mid-bootstrap,
+        # ``bootstrap_state.status='running'`` is now stale — no live
+        # thread is executing the run.
+        #
+        # Pre-#1296: this step terminated the run to ``partial_error``
+        # so the operator could retry-failed from the admin panel.
+        # Operator-friendly for genuine bugs, painful for transient
+        # crashes (OOM, kill -9, segfault) where the desired behaviour
+        # is to resume where the dead process left off.
+        #
+        # Post-#1296: first try :func:`attempt_boot_resume` —
+        #   * ``resumed`` → counter bumped + ``bootstrap_orchestrator``
+        #     queue row enqueued. The orchestrator's PR-6
+        #     ``reap_orphaned_running_stages`` resets stuck ``running``
+        #     stages to ``pending`` so the dispatcher picks them up.
+        # SKIP the terminate reaper — the run is recoverable.
+        #   * ``terminated_max_attempts`` → resume cap exhausted (i.e.
+        #     the prior boot already auto-resumed and the process
+        #     crashed AGAIN). Fall through to the terminate reaper so
+        #     the operator can intervene rather than entering an
+        #     infinite resume loop.
+        #   * ``no_in_flight_run`` → no-op.
         try:
-            from app.services.bootstrap_state import reap_orphaned_running
+            from app.services.bootstrap_state import (
+                attempt_boot_resume,
+                reap_orphaned_running,
+            )
 
             with psycopg.connect(settings.database_url, autocommit=True) as conn:
-                if reap_orphaned_running(conn):
-                    logger.info("jobs entrypoint: bootstrap reaper transitioned a stuck running run to partial_error")
+                decision = attempt_boot_resume(conn, requested_by=boot_id)
+            if decision.decision == "resumed":
+                logger.info(
+                    "jobs entrypoint: bootstrap auto-resume enqueued "
+                    "(run_id=%d, attempt=%d/%d)",
+                    decision.run_id or -1,
+                    decision.attempts,
+                    1,  # _MAX_BOOT_RESUMES default; keep in sync if widened
+                )
+            else:
+                if decision.decision == "terminated_max_attempts":
+                    logger.warning(
+                        "jobs entrypoint: bootstrap auto-resume cap reached "
+                        "(run_id=%d, attempts=%d) — falling through to terminate reaper",
+                        decision.run_id or -1,
+                        decision.attempts,
+                    )
+                with psycopg.connect(settings.database_url, autocommit=True) as conn:
+                    if reap_orphaned_running(conn):
+                        logger.info(
+                            "jobs entrypoint: bootstrap reaper transitioned a stuck running run to partial_error"
+                        )
         except Exception:
-            logger.exception("jobs entrypoint: bootstrap reaper failed; continuing")
+            logger.exception("jobs entrypoint: bootstrap recovery failed; continuing")
 
         # Step 5 — process_stop boot-recovery (#1065). Sweep abandoned
         # cooperative-cancel signals (>6h, never observed) and stuck

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -31,7 +31,7 @@ import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Final, Literal
 from uuid import UUID
 
 import psycopg
@@ -555,6 +555,15 @@ def mark_stage_success(
     ``error``. The dispatcher's wait()/checkpoint ordering already
     avoids the race in the normal flow, but pinning the helper to
     "only advance from running" keeps the invariant local.
+
+    #1296 — reset ``bootstrap_runs.boot_resume_attempts`` to 0 on
+    any stage success. The counter caps how many auto-resumes a
+    run can absorb before being terminated; resetting on stage
+    progress means a long-running bootstrap that survives a crash,
+    resumes, and then runs healthily regains its full resume
+    budget for any subsequent crash. Without this reset, a multi-
+    crash run would falsely hit the cap even though intermediate
+    progress proved each resume worked.
     """
     conn.execute(
         """
@@ -572,6 +581,19 @@ def mark_stage_success(
             "stage_key": stage_key,
             "rows_processed": rows_processed,
         },
+    )
+    # #1296 — reset the counter on stage progress so the resume
+    # budget is "consecutive resumes WITHOUT a successful stage",
+    # not "total resumes across the run's lifetime". Guarded by
+    # ``> 0`` so the no-op case skips an UPDATE round-trip.
+    conn.execute(
+        """
+        UPDATE bootstrap_runs
+           SET boot_resume_attempts = 0
+         WHERE id = %(run_id)s
+           AND boot_resume_attempts > 0
+        """,
+        {"run_id": run_id},
     )
 
 
@@ -1155,6 +1177,163 @@ def mark_run_cancelled(
         )
 
 
+# #1296 — auto-resume cap. Bumping past this means the resume attempt
+# itself crashed the process — fall through to the terminate reaper so
+# the operator can retry-failed from the admin panel rather than the
+# process getting stuck in an infinite resume → crash loop.
+_MAX_BOOT_RESUMES: Final[int] = 1
+
+
+@dataclass(frozen=True)
+class BootResumeDecision:
+    """Outcome of :func:`attempt_boot_resume` — drives the jobs
+    entrypoint's choice between auto-resume and terminate reaper.
+    """
+
+    decision: Literal["resumed", "terminated_max_attempts", "no_in_flight_run"]
+    run_id: int | None
+    attempts: int
+
+
+def attempt_boot_resume(
+    conn: psycopg.Connection[Any],
+    *,
+    requested_by: str,
+    max_attempts: int = _MAX_BOOT_RESUMES,
+) -> BootResumeDecision:
+    """Auto-resume an in-flight bootstrap on jobs-process start (#1296).
+
+    Pre-#1296 the boot-time reaper (:func:`reap_orphaned_running`)
+    treats every observed ``bootstrap_state.status='running'`` as a
+    dead run and terminates it to ``partial_error``. That leaves the
+    operator to click "retry-failed" — fine for genuine bugs, painful
+    for transient crashes (OOM, kill -9, segfault) where the desired
+    behaviour is to pick up where the dead process left off.
+
+    Decision tree:
+
+      * ``bootstrap_state.status != 'running'`` (or
+        ``last_run_id IS NULL``) → ``no_in_flight_run``. No-op.
+      * ``bootstrap_runs.status != 'running'`` →
+        ``terminated_max_attempts`` (Codex 2 MEDIUM on #1296: a
+        stale singleton can point at a terminal run row; resume
+        must not enqueue work for a finalised run).
+      * ``cancel_requested_at IS NOT NULL`` → ``terminated_max_attempts``.
+        Operator clicked cancel before the crash; honour the cancel
+        intent rather than auto-resuming.
+      * ``boot_resume_attempts >= max_attempts`` →
+        ``terminated_max_attempts``. The cap prevents a crash-during-
+        resume infinite loop. **The counter is reset to 0 inside**
+        :func:`mark_stage_success` (Codex 2 BLOCKING on #1296), so a
+        run that actually makes progress after a resume regains the
+        full resume budget on a subsequent crash.
+      * Otherwise → ``resumed``. Increment
+        ``bootstrap_runs.boot_resume_attempts``; publish a
+        ``manual_job`` queue row for ``bootstrap_orchestrator`` so
+        the next listener tick picks it up. The orchestrator's PR-6
+        ``reap_orphaned_running_stages`` will reset stuck ``running``
+        stages back to ``pending`` (lock-not-held probe + grace) and
+        the dispatcher resumes from the recoverable state.
+
+    Atomic in one transaction: counter bump + queue INSERT share the
+    same outer tx so either both land or neither (no orphaned resume
+    request, no orphaned counter increment).
+
+    Lock-order discipline (Codex 2 HIGH on #1296): lock
+    ``bootstrap_runs`` BEFORE ``bootstrap_state``, matching
+    :func:`finalize_run` / :func:`cancel_run` / :func:`mark_run_cancelled`.
+    Locking state first would deadlock against a concurrent finalizer
+    that already holds the run row.
+
+    The caller (jobs entrypoint) interprets the decision:
+      * ``resumed`` → skip the existing :func:`reap_orphaned_running`
+        terminate sweep; let the orchestrator handle it.
+      * ``terminated_max_attempts`` → fall through to
+        :func:`reap_orphaned_running` so the run transitions to
+        ``partial_error`` / ``cancelled`` and the admin panel shows
+        the operator their retry-failed button.
+      * ``no_in_flight_run`` → no action either way.
+    """
+    # Lazy imports to avoid a module cycle: bootstrap_orchestrator
+    # imports bootstrap_state, so importing it here at top would close
+    # the cycle.
+    from app.services.bootstrap_orchestrator import JOB_BOOTSTRAP_ORCHESTRATOR
+    from app.services.sync_orchestrator.dispatcher import (
+        publish_manual_job_request_with_conn,
+    )
+
+    with conn.transaction():
+        # Step 1 — unlocked probe of the singleton. Cheap; resolves
+        # the run_id we need to lock. The actual decision happens
+        # under FOR UPDATE locks on the run + state rows below.
+        probe = conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1").fetchone()
+        if probe is None or probe[0] != "running" or probe[1] is None:
+            return BootResumeDecision(decision="no_in_flight_run", run_id=None, attempts=0)
+        run_id = int(probe[1])
+
+        # Step 2 — lock the RUN row FIRST (run-then-state ordering
+        # matches finalize_run / cancel_run; reversing the order
+        # would deadlock against a concurrent finalizer).
+        run = conn.execute(
+            """
+            SELECT status,
+                   boot_resume_attempts,
+                   cancel_requested_at IS NOT NULL
+              FROM bootstrap_runs
+             WHERE id = %s
+             FOR UPDATE
+            """,
+            (run_id,),
+        ).fetchone()
+        if run is None:
+            # state.last_run_id pointed at a row that no longer
+            # exists — pathological state. Terminate so the operator
+            # sees a clear error rather than a silently-skipped resume.
+            return BootResumeDecision(decision="terminated_max_attempts", run_id=run_id, attempts=0)
+        run_status, attempts, cancel_requested = str(run[0]), int(run[1]), bool(run[2])
+
+        # Step 3 — Codex 2 MEDIUM on #1296: re-check the run itself
+        # is actually running. A stale state singleton can point at
+        # a finalised row (e.g. mid-finalize crash) — auto-resuming
+        # a terminal run would silently flip it back to running.
+        if run_status != "running":
+            return BootResumeDecision(
+                decision="terminated_max_attempts",
+                run_id=run_id,
+                attempts=attempts,
+            )
+        if cancel_requested:
+            return BootResumeDecision(
+                decision="terminated_max_attempts",
+                run_id=run_id,
+                attempts=attempts,
+            )
+        if attempts >= max_attempts:
+            return BootResumeDecision(
+                decision="terminated_max_attempts",
+                run_id=run_id,
+                attempts=attempts,
+            )
+
+        # Step 4 — lock state SECOND (run-then-state). Re-confirm
+        # under both locks; a concurrent transition that landed
+        # between Step 1's probe and now is rare but possible.
+        state = conn.execute("SELECT status, last_run_id FROM bootstrap_state WHERE id = 1 FOR UPDATE").fetchone()
+        if state is None or state[0] != "running" or state[1] != run_id:
+            return BootResumeDecision(decision="no_in_flight_run", run_id=run_id, attempts=attempts)
+
+        conn.execute(
+            "UPDATE bootstrap_runs SET boot_resume_attempts = boot_resume_attempts + 1 WHERE id = %s",
+            (run_id,),
+        )
+        publish_manual_job_request_with_conn(
+            conn,
+            JOB_BOOTSTRAP_ORCHESTRATOR,
+            requested_by=requested_by,
+        )
+        return BootResumeDecision(decision="resumed", run_id=run_id, attempts=attempts + 1)
+
+
 def reap_orphaned_running(
     conn: psycopg.Connection[Any],
 ) -> bool:
@@ -1428,6 +1607,7 @@ def compute_retryable_view(
 
 
 __all__ = [
+    "BootResumeDecision",
     "BootstrapAlreadyRunning",
     "BootstrapNoPriorRun",
     "BootstrapNotResettable",
@@ -1444,6 +1624,7 @@ __all__ = [
     "StageSpec",
     "StageStatus",
     "StopAlreadyPendingError",
+    "attempt_boot_resume",
     "cancel_run",
     "compute_retryable_view",
     "finalize_run",

--- a/sql/170_bootstrap_runs_boot_resume_attempts.sql
+++ b/sql/170_bootstrap_runs_boot_resume_attempts.sql
@@ -35,7 +35,8 @@ ALTER TABLE bootstrap_runs
 
 COMMENT ON COLUMN bootstrap_runs.boot_resume_attempts IS
     '#1296 — count of jobs-process restarts that auto-enqueued an orchestrator '
-    'resume for this run. Bounded by _MAX_BOOT_RESUMES in app/jobs/__main__.py '
-    '(default 1) so a crash-during-resume cannot loop forever.';
+    'resume for this run. Bounded by _MAX_BOOT_RESUMES in '
+    'app/services/bootstrap_state.py (default 1) so a crash-during-resume '
+    'cannot loop forever.';
 
 COMMIT;

--- a/sql/170_bootstrap_runs_boot_resume_attempts.sql
+++ b/sql/170_bootstrap_runs_boot_resume_attempts.sql
@@ -1,0 +1,41 @@
+-- 170_bootstrap_runs_boot_resume_attempts.sql
+--
+-- #1233 / #1296 — auto-resume an in-flight bootstrap after jobs-process
+-- restart.
+--
+-- Adds ``bootstrap_runs.boot_resume_attempts INT NOT NULL DEFAULT 0``.
+-- Each time the jobs entrypoint observes a ``running`` bootstrap_state
+-- at boot, it increments this counter on the in-flight bootstrap_run
+-- and self-enqueues a ``bootstrap_orchestrator`` job request so the
+-- orchestrator's PR-6 reaper (``reap_orphaned_running_stages``) can
+-- reset stuck ``running`` stages back to ``pending`` and the
+-- dispatcher resumes.
+--
+-- Why a counter and not a boolean
+-- ===============================
+-- If the jobs process crashes AGAIN mid-resume (e.g. the same code
+-- path that killed it last time fires again), an unbounded resume
+-- loop would loop forever. The counter caps attempts at
+-- ``_MAX_BOOT_RESUMES`` (default 1, configurable at the call site).
+-- Above the cap, the existing ``bootstrap_state.reap_orphaned_running``
+-- path fires — terminate the run as ``partial_error`` so the operator
+-- can retry-failed from the admin panel.
+--
+-- Why NOT NULL DEFAULT 0
+-- ======================
+-- Existing runs predate this column. The default makes the existing
+-- rows safely "never resumed" without a backfill.
+--
+-- Idempotent.
+
+BEGIN;
+
+ALTER TABLE bootstrap_runs
+    ADD COLUMN IF NOT EXISTS boot_resume_attempts INT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN bootstrap_runs.boot_resume_attempts IS
+    '#1296 — count of jobs-process restarts that auto-enqueued an orchestrator '
+    'resume for this run. Bounded by _MAX_BOOT_RESUMES in app/jobs/__main__.py '
+    '(default 1) so a crash-during-resume cannot loop forever.';
+
+COMMIT;

--- a/tests/test_bootstrap_auto_resume.py
+++ b/tests/test_bootstrap_auto_resume.py
@@ -1,0 +1,260 @@
+"""#1233 / #1296 — bootstrap auto-resume on jobs-process restart.
+
+Verifies :func:`app.services.bootstrap_state.attempt_boot_resume`:
+
+- ``no_in_flight_run`` when bootstrap_state.status != 'running'.
+- ``no_in_flight_run`` when bootstrap_state.last_run_id IS NULL.
+- ``terminated_max_attempts`` when the run has been auto-resumed
+  ``_MAX_BOOT_RESUMES`` times already (i.e. the prior boot's resume
+  also crashed). Falls through to the existing reaper at the call
+  site.
+- ``terminated_max_attempts`` when the operator clicked Cancel
+  before the crash — honour the cancel intent rather than
+  auto-resuming.
+- ``resumed`` on first attempt: counter bumped + a
+  ``manual_job`` queue row enqueued for ``bootstrap_orchestrator``.
+
+Migration sql/170 is verified implicitly: the per-worker template DB
+applies it, so a broken migration would prevent ``ebull_test_conn``
+from connecting.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.bootstrap_state import (
+    BootResumeDecision,
+    StageSpec,
+    attempt_boot_resume,
+    start_run,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable"),
+]
+
+
+def _reset_state(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        UPDATE bootstrap_state
+           SET status='pending', last_run_id=NULL, last_completed_at=NULL
+         WHERE id=1
+        """
+    )
+    conn.commit()
+
+
+def _seed_running_run(conn: psycopg.Connection[tuple]) -> int:
+    """Create a bootstrap_runs row in ``running`` and flip
+    bootstrap_state. Returns the run_id."""
+    specs = (
+        StageSpec(
+            stage_key="universe_sync",
+            stage_order=1,
+            lane="init",
+            job_name="universe_sync",
+        ),
+    )
+    run_id = start_run(conn, operator_id=None, stage_specs=specs)
+    conn.commit()
+    return run_id
+
+
+def _read_counter(conn: psycopg.Connection[tuple], run_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT boot_resume_attempts FROM bootstrap_runs WHERE id = %s",
+            (run_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _count_queue_rows(conn: psycopg.Connection[tuple], job_name: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) FROM pending_job_requests
+             WHERE job_name = %s
+               AND request_kind = 'manual_job'
+            """,
+            (job_name,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def test_returns_no_in_flight_when_state_not_running(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    decision = attempt_boot_resume(ebull_test_conn, requested_by="test")
+    assert decision == BootResumeDecision(decision="no_in_flight_run", run_id=None, attempts=0)
+
+
+def test_returns_resumed_on_first_attempt(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _reset_state(ebull_test_conn)
+    run_id = _seed_running_run(ebull_test_conn)
+    queue_before = _count_queue_rows(ebull_test_conn, "bootstrap_orchestrator")
+
+    decision = attempt_boot_resume(ebull_test_conn, requested_by="test-boot")
+    ebull_test_conn.commit()
+
+    assert decision.decision == "resumed"
+    assert decision.run_id == run_id
+    assert decision.attempts == 1
+    assert _read_counter(ebull_test_conn, run_id) == 1
+    assert _count_queue_rows(ebull_test_conn, "bootstrap_orchestrator") == queue_before + 1
+
+
+def test_second_attempt_returns_terminated_max_attempts(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Cap is 1 by default — the prior boot already auto-resumed.
+    A second crash means resume is broken; fall through to the
+    terminate reaper.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = _seed_running_run(ebull_test_conn)
+
+    first = attempt_boot_resume(ebull_test_conn, requested_by="boot-1")
+    ebull_test_conn.commit()
+    assert first.decision == "resumed"
+    assert _read_counter(ebull_test_conn, run_id) == 1
+
+    queue_before = _count_queue_rows(ebull_test_conn, "bootstrap_orchestrator")
+    second = attempt_boot_resume(ebull_test_conn, requested_by="boot-2")
+    ebull_test_conn.commit()
+
+    assert second.decision == "terminated_max_attempts"
+    assert second.run_id == run_id
+    assert second.attempts == 1
+    # Counter NOT incremented past the cap; no extra queue row.
+    assert _read_counter(ebull_test_conn, run_id) == 1
+    assert _count_queue_rows(ebull_test_conn, "bootstrap_orchestrator") == queue_before
+
+
+def test_operator_cancel_returns_terminated(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """When the operator clicked Cancel before the crash, the
+    resume must honour the cancel intent — not auto-restart a
+    cancelled run.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = _seed_running_run(ebull_test_conn)
+    ebull_test_conn.execute(
+        "UPDATE bootstrap_runs SET cancel_requested_at = NOW() WHERE id = %s",
+        (run_id,),
+    )
+    ebull_test_conn.commit()
+
+    decision = attempt_boot_resume(ebull_test_conn, requested_by="test")
+    ebull_test_conn.commit()
+
+    assert decision.decision == "terminated_max_attempts"
+    assert decision.run_id == run_id
+    # Counter MUST NOT advance on cancel-driven termination — if the
+    # operator later un-cancels (which they can't today, but the
+    # invariant is "we did not auto-resume") the cap budget is
+    # preserved.
+    assert _read_counter(ebull_test_conn, run_id) == 0
+
+
+def test_terminated_when_run_status_is_not_running(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Codex 2 MEDIUM on #1296: a stale state singleton can point
+    at a finalised ``bootstrap_runs`` row (e.g. mid-finalize crash
+    where bootstrap_state was updated before bootstrap_runs in some
+    code path, or operator SQL hand-edit). The resume MUST NOT
+    flip a terminal run back to running — it must terminate.
+    """
+    _reset_state(ebull_test_conn)
+    run_id = _seed_running_run(ebull_test_conn)
+    # Stale-singleton scenario: run finalised but state still says running.
+    ebull_test_conn.execute(
+        "UPDATE bootstrap_runs SET status = 'partial_error' WHERE id = %s",
+        (run_id,),
+    )
+    ebull_test_conn.commit()
+
+    decision = attempt_boot_resume(ebull_test_conn, requested_by="test")
+    ebull_test_conn.commit()
+
+    assert decision.decision == "terminated_max_attempts"
+    assert decision.run_id == run_id
+    # No counter advance — terminal-run guard fires before the bump.
+    assert _read_counter(ebull_test_conn, run_id) == 0
+    # No queue row enqueued for a terminal run.
+    assert _count_queue_rows(ebull_test_conn, "bootstrap_orchestrator") == 0
+
+
+def test_stage_success_resets_resume_counter(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Codex 2 BLOCKING on #1296: the cap is "consecutive crashes
+    without a successful stage", not "total resumes for the run's
+    lifetime". ``mark_stage_success`` must zero the counter so a
+    healthy resume regains its full resume budget for any subsequent
+    crash. Without this reset, an operator restart later in the same
+    run would hit the cap and terminate a healthy bootstrap.
+    """
+    from app.services.bootstrap_state import mark_stage_running, mark_stage_success
+
+    _reset_state(ebull_test_conn)
+    run_id = _seed_running_run(ebull_test_conn)
+
+    # First crash → resume → counter=1.
+    first = attempt_boot_resume(ebull_test_conn, requested_by="boot-1")
+    ebull_test_conn.commit()
+    assert first.decision == "resumed"
+    assert _read_counter(ebull_test_conn, run_id) == 1
+
+    # Resume succeeds: orchestrator transitions a stage to success.
+    mark_stage_running(ebull_test_conn, run_id=run_id, stage_key="universe_sync")
+    mark_stage_success(ebull_test_conn, run_id=run_id, stage_key="universe_sync", rows_processed=42)
+    ebull_test_conn.commit()
+
+    # Counter must be 0 — the resume worked.
+    assert _read_counter(ebull_test_conn, run_id) == 0, (
+        "boot_resume_attempts not reset after stage success — the resume "
+        "budget will be permanently exhausted by the first restart even "
+        "though the run is healthy"
+    )
+
+
+def test_higher_max_attempts_allows_more_resumes(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The cap is a parameter — production passes the default
+    (1) but tests + future operator overrides can widen it. Verify
+    the counter advances cleanly up to ``max_attempts``.
+    """
+    _reset_state(ebull_test_conn)
+    _seed_running_run(ebull_test_conn)
+
+    for n in range(1, 4):
+        decision = attempt_boot_resume(ebull_test_conn, requested_by=f"boot-{n}", max_attempts=3)
+        ebull_test_conn.commit()
+        assert decision.decision == "resumed"
+        assert decision.attempts == n
+
+    # 4th attempt past cap.
+    decision = attempt_boot_resume(ebull_test_conn, requested_by="boot-4", max_attempts=3)
+    ebull_test_conn.commit()
+    assert decision.decision == "terminated_max_attempts"
+    assert decision.attempts == 3


### PR DESCRIPTION
## Summary
- When the jobs process dies mid-bootstrap (OOM, kill -9, segfault, crash-during-stage), the next restart now auto-resumes the in-flight run instead of immediately terminating it to ``partial_error``.
- New schema (sql/170) adds ``bootstrap_runs.boot_resume_attempts`` counter, capped at 1 by default, RESET on any stage success. Resume budget = consecutive crashes WITHOUT progress; a healthy resume earns back a full budget.
- New helper ``attempt_boot_resume()`` runs BEFORE the existing terminate reaper at jobs boot Step 4b. On ``resumed``, the orchestrator picks up via the standard ``manual_job`` queue path and PR-6 ``reap_orphaned_running_stages`` resets stuck ``running`` stages.

Refs #1233. Closes #1296.

## Why
The existing boot-time reaper (``reap_orphaned_running``) treats every observed ``bootstrap_state.status='running'`` as a dead run and transitions it to ``partial_error``. Forces the operator to retry-failed from the admin panel even for a single OOM. The intended UX for a transient crash is auto-recovery without operator intervention.

## What changed
- [sql/170_bootstrap_runs_boot_resume_attempts.sql](sql/170_bootstrap_runs_boot_resume_attempts.sql): adds the counter column.
- [app/services/bootstrap_state.py](app/services/bootstrap_state.py):
  - ``BootResumeDecision`` dataclass carrying the verdict + run_id + attempts.
  - ``attempt_boot_resume(conn, requested_by, max_attempts=_MAX_BOOT_RESUMES)``: locks run → state in the documented order; checks ``run.status='running'`` (Codex MEDIUM fix); reads ``cancel_requested_at`` + counter; bumps + enqueues manual_job for ``bootstrap_orchestrator``.
  - ``mark_stage_success`` extended: zeros ``boot_resume_attempts`` on any stage success (Codex BLOCKING fix — budget is "consecutive crashes without progress").
- [app/jobs/__main__.py](app/jobs/__main__.py) Step 4b: invoke ``attempt_boot_resume`` first; on ``resumed`` SKIP the existing terminate reaper; on other decisions fall through.

## Codex 2 pre-push findings folded
- **BLOCKING** — counter conflated "resume already requested" with "resume crashed". A multi-restart scenario hits the cap even when the bootstrap is healthy. Fixed by zeroing on stage success so the cap measures consecutive failures only.
- **HIGH** — lock-order reversed vs ``finalize_run`` / ``cancel_run`` (state-then-runs vs runs-then-state). Deadlock risk against a concurrent finalizer. Fixed by locking ``bootstrap_runs`` FIRST under FOR UPDATE, then ``bootstrap_state``.
- **MEDIUM** — terminal run status not checked. A stale ``bootstrap_state.status='running'`` pointing at a finalised ``bootstrap_runs`` row would silently flip the terminal run back to running. Fixed with ``run.status='running'`` guard under FOR UPDATE.

## Tests (7 new + 35 existing pass)
[tests/test_bootstrap_auto_resume.py](tests/test_bootstrap_auto_resume.py):
- ``test_returns_no_in_flight_when_state_not_running`` — early-out no-op.
- ``test_returns_resumed_on_first_attempt`` — counter bump + queue row enqueued.
- ``test_second_attempt_returns_terminated_max_attempts`` — cap exhaustion under default max_attempts=1.
- ``test_operator_cancel_returns_terminated`` — honour cancel intent over auto-resume.
- ``test_terminated_when_run_status_is_not_running`` (Codex MEDIUM regression sentinel).
- ``test_stage_success_resets_resume_counter`` (Codex BLOCKING regression sentinel).
- ``test_higher_max_attempts_allows_more_resumes`` — parameterised cap behaviour.

Existing ``test_bootstrap_orchestrator.py`` — 35/35 pass (no regressions).

## Test plan
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run pyright`
- [x] `pytest tests/test_bootstrap_auto_resume.py` — 7/7
- [x] `pytest tests/test_bootstrap_orchestrator.py` — 35/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)