### PR TITLE
feat(#1233): Stream A PR-A — jobs-process operator-existence boot guard (T1.8)

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -126,6 +126,21 @@ class CredentialHealthSummary(BaseModel):
     last_error: str | None = None
 
 
+class JobsBootError(BaseModel):
+    """Operator-actionable jobs-process boot breadcrumb.
+
+    Populated by ``app/jobs/__main__.py::_check_operator_exists_with_cleanup``
+    (Stream A PR-A T1.8, #1233) when the jobs process hard-fails to boot
+    because no ``operators`` row exists (i.e. ``/auth/setup`` has not been
+    run yet). Cleared by a successful boot of the same guard.
+
+    Both fields are non-NULL together OR NULL together.
+    """
+
+    message: str
+    at: datetime
+
+
 class SystemStatusResponse(BaseModel):
     checked_at: datetime
     overall_status: OverallStatus
@@ -133,6 +148,10 @@ class SystemStatusResponse(BaseModel):
     jobs: list[JobHealthResponse]
     kill_switch: KillSwitchStateResponse
     credential_health: CredentialHealthSummary
+    # Populated when the jobs process most-recently failed to boot
+    # because of a hard-fail boot-guard condition (today: missing
+    # operator row). NULL on healthy systems. Wired in Stream A PR-A.
+    jobs_boot_error: JobsBootError | None = None
 
 
 class JobOverviewResponse(BaseModel):
@@ -365,6 +384,7 @@ def get_system_status(
         layers = check_all_layers(conn, now=now)
         jobs = [check_job_health(conn, job.name) for job in SCHEDULED_JOBS]
         ks = get_kill_switch_status(conn)
+        jobs_boot_error = _read_jobs_boot_error(conn)
     except Exception as exc:
         # Log the full exception server-side; the HTTP detail is a fixed
         # string so we never leak internal schema, table names, or driver
@@ -386,7 +406,35 @@ def get_system_status(
             reason=ks.get("reason"),
         ),
         credential_health=_build_credential_health_summary(conn),
+        jobs_boot_error=jobs_boot_error,
     )
+
+
+def _read_jobs_boot_error(conn: psycopg.Connection[object]) -> JobsBootError | None:
+    """Surface the jobs-process boot-failure breadcrumb (Stream A PR-A
+    T1.8, #1233).
+
+    Returns the persisted breadcrumb from
+    ``bootstrap_state.{last_jobs_boot_error, last_jobs_boot_error_at}``
+    or ``None`` when the last boot succeeded / never ran post-migration.
+
+    SQL contract: both columns are non-NULL together (per the wrapper
+    in ``app/jobs/__main__.py::_check_operator_exists_with_cleanup`` —
+    the breadcrumb write sets both columns in one UPDATE; the clear-
+    on-success path nulls both). A row with one NULL and one non-NULL
+    is treated as "no breadcrumb" to fail-safe.
+    """
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        cur.execute(
+            "SELECT last_jobs_boot_error, last_jobs_boot_error_at FROM bootstrap_state WHERE id = 1",
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    message, at = row
+    if message is None or at is None:
+        return None
+    return JobsBootError(message=message, at=at)
 
 
 def _build_credential_health_summary(conn: psycopg.Connection[object]) -> CredentialHealthSummary:

--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -572,6 +572,149 @@ def _ensure_transaction_cost_config_singleton_with_cleanup(
         raise
 
 
+def _check_operator_exists_with_cleanup(
+    fence_conn: psycopg.Connection[Any],
+    pool: Any,
+) -> None:
+    """Stream A PR-A T1.8 (#1233): hard-fail jobs-process boot when no
+    operator row exists.
+
+    Operator absence means ``POST /auth/setup`` has not been run yet.
+    Every scheduled fire would silently reject with
+    ``bootstrap_not_complete`` (operator sees no ingestion + no error
+    until they grep stderr). Surfacing the gap at boot time gives an
+    operator-actionable message AND persists a breadcrumb to
+    ``bootstrap_state.last_jobs_boot_error`` (sql/171) for
+    ``/system/status`` visibility.
+
+    Escape hatch: ``EBULL_JOBS_SKIP_OPERATOR_CHECK=1`` env var skips
+    the check for cold-start scenarios (CI bootstrap, ops automation
+    that creates the operator AFTER jobs starts). Env var deliberately
+    chosen over CLI flag — harder to set in error per
+    docs/proposals/etl/stream-a-run-8-fixes.md §1 T1.8 + §21.
+
+    Semantically distinct from sibling ``_ensure_*_with_cleanup``
+    helpers (which RE-SEED missing default singletons): operator
+    existence cannot be re-seeded — the operator must run
+    ``/auth/setup`` manually. Named ``_check_*`` not ``_ensure_*``
+    to signal "verify; fail if missing" vs "create if missing"
+    (per spec Architect-lens IMPORTANT).
+
+    On hard-fail:
+      1. Persist ``bootstrap_state.last_jobs_boot_error`` so
+         ``/system/status`` surfaces the failure cause.
+      2. Release the singleton fence advisory lock.
+      3. Close the pool.
+      4. ``raise SystemExit(2)``.
+
+    On clean exit (operator present): clear any stale breadcrumb so a
+    recovered boot does not leave a misleading error visible.
+    """
+    from app.jobs.boot_guard import (
+        OPERATOR_MISSING_ERROR_MESSAGE,
+        BootGuardOutcome,
+        check_operator_exists,
+    )
+
+    skip_env_set = os.environ.get("EBULL_JOBS_SKIP_OPERATOR_CHECK") == "1"
+
+    # Architect IMPORTANT: env-skip path MUST NOT dial the DB. Cold-start
+    # is the documented escape-hatch use case — the DB may not yet be
+    # reachable when the operator sets the env var. Returning before
+    # ANY ``psycopg.connect`` call honours that contract.
+    if skip_env_set:
+        logger.info(
+            "jobs entrypoint: operator-existence check skipped via EBULL_JOBS_SKIP_OPERATOR_CHECK=1 "
+            "(env-skip path does not dial DB; stale breadcrumb NOT cleared on this path)",
+        )
+        return
+
+    try:
+        with psycopg.connect(settings.database_url, autocommit=True) as guard_conn:
+            outcome = check_operator_exists(guard_conn, skip_env_set=False)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            fence_conn.close()
+        with contextlib.suppress(Exception):
+            pool.close()
+        raise
+
+    if outcome is BootGuardOutcome.OPERATOR_PRESENT:
+        # Clear any stale breadcrumb from a prior failed boot. Bounded
+        # WHERE keeps this a no-op when nothing to clear (cheap +
+        # auditable in pg_stat_statements). Reviewer + DE IMPORTANT:
+        # log a warning if the clear UPDATE fails so the silent swallow
+        # is visible in stderr — the operator otherwise sees a stale
+        # breadcrumb in /system/status with no explanation.
+        try:
+            with psycopg.connect(settings.database_url, autocommit=True) as clear_conn:
+                with clear_conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE bootstrap_state "
+                        "SET last_jobs_boot_error = NULL, last_jobs_boot_error_at = NULL "
+                        "WHERE id = 1 AND last_jobs_boot_error IS NOT NULL",
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "jobs entrypoint: failed to clear stale last_jobs_boot_error breadcrumb: %s",
+                exc,
+            )
+        return
+
+    # SKIPPED_BY_ENV cannot occur here — the early-return above handles
+    # env-skip without opening a connection. Defensive closed-set check
+    # in case ``boot_guard.BootGuardOutcome`` ever gains a 4th member
+    # (the catalogue test in tests/test_jobs_boot_guard.py would also
+    # catch this, but defence-in-depth is cheap).
+    if outcome is not BootGuardOutcome.OPERATOR_ABSENT:
+        raise RuntimeError(
+            f"unhandled BootGuardOutcome {outcome!r}; boot_guard module out of sync with wrapper",
+        )
+
+    # Hard-fail body: persist breadcrumb (best-effort with warning),
+    # then cleanup + SystemExit(2). Wrapped in try/finally so cleanup
+    # + exit ALWAYS run even if breadcrumb write raises something
+    # exotic — matches sibling helpers' except BaseException pattern
+    # (Architect IMPORTANT).
+    #
+    # Reviewer IMPORTANT: ``logger.critical`` not ``logger.error`` —
+    # hard-fail boot is syslog-grade visibility, not a recoverable
+    # runtime error.
+    logger.critical("jobs entrypoint: %s", OPERATOR_MISSING_ERROR_MESSAGE)
+    try:
+        try:
+            with psycopg.connect(settings.database_url, autocommit=True) as breadcrumb_conn:
+                with breadcrumb_conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE bootstrap_state "
+                        "SET last_jobs_boot_error = %s, last_jobs_boot_error_at = clock_timestamp() "
+                        "WHERE id = 1",
+                        (OPERATOR_MISSING_ERROR_MESSAGE,),
+                    )
+                    if cur.rowcount == 0:
+                        # bootstrap_state row missing despite the earlier
+                        # _ensure_bootstrap_state_singleton_with_cleanup
+                        # guard. DE IMPORTANT: surface via warning — the
+                        # boot still hard-fails on SystemExit + stderr
+                        # log, but /system/status will not show the
+                        # cause without the breadcrumb row.
+                        logger.warning(
+                            "jobs entrypoint: bootstrap_state singleton row absent at breadcrumb write; "
+                            "/system/status will not show this failure cause",
+                        )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "jobs entrypoint: failed to persist last_jobs_boot_error breadcrumb: %s",
+                exc,
+            )
+    finally:
+        with contextlib.suppress(Exception):
+            fence_conn.close()
+        with contextlib.suppress(Exception):
+            pool.close()
+    raise SystemExit(2)
+
+
 def _boot_id() -> str:
     """Per-process identifier used as ``claimed_by`` on queue rows.
 
@@ -659,6 +802,19 @@ def serve(stop_event: threading.Event | None = None) -> int:
 
     _ensure_bootstrap_state_singleton_with_cleanup(fence_conn, pool)
     logger.info("jobs entrypoint: bootstrap_state singleton guard passed")
+
+    # #1233 Stream A PR-A T1.8 — hard-fail boot when no operator row
+    # exists. Operator absence means /auth/setup has not run; every
+    # scheduled fire would reject silently with bootstrap_not_complete.
+    # Persists ``bootstrap_state.last_jobs_boot_error`` on hard-fail so
+    # ``/system/status`` surfaces the cause. Escape hatch:
+    # ``EBULL_JOBS_SKIP_OPERATOR_CHECK=1`` env var.
+    #
+    # Runs AFTER ``_ensure_bootstrap_state_singleton_with_cleanup``
+    # because the breadcrumb-write path depends on the
+    # ``bootstrap_state`` row being seeded.
+    _check_operator_exists_with_cleanup(fence_conn, pool)
+    logger.info("jobs entrypoint: operator-existence guard passed")
 
     # #1232 follow-up — same singleton-vanish posture for budget_config
     # and transaction_cost_config. Without these mirrors, execution-

--- a/app/jobs/boot_guard.py
+++ b/app/jobs/boot_guard.py
@@ -1,0 +1,89 @@
+"""Stream A PR-A T1.8 (#1233): jobs-process boot guard for operator existence.
+
+The jobs daemon has no useful work to do until ``/auth/setup`` has
+created the operator row. Pre-#1233 the jobs process would happily
+boot against an unprepared DB and every scheduled fire would reject
+silently with ``bootstrap_not_complete`` — operator sees nothing
+ingested and has to grep stderr to discover the root cause.
+
+This module owns the **pure check**:
+
+    check_operator_exists(conn, *, skip_env_set=False) -> BootGuardOutcome
+
+The wrapper that performs the DB connection lifecycle + cleanup-on-fail
++ ``SystemExit(2)`` lives at
+``app/jobs/__main__.py::_check_operator_exists_with_cleanup`` to match
+the existing ``_ensure_*_with_cleanup`` chain conventions. The pure
+function here is testable without driving the boot path
+(``tests/test_jobs_boot_guard.py``).
+
+Semantically distinct from sibling ``_ensure_*_with_cleanup`` helpers,
+which RE-SEED missing default singletons (kill_switch, bootstrap_state,
+runtime_config, budget_config, transaction_cost_config). Operator
+absence cannot be re-seeded — the operator must invoke
+``POST /auth/setup`` manually with a desired master-key + password.
+Hence ``_check_*`` (verify; fail if missing) not ``_ensure_*`` (create
+if missing).
+
+Spec: docs/proposals/etl/stream-a-run-8-fixes.md §1 T1.8 + §13
+(Stream A v2.3, 2026-05-24).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+import psycopg
+
+
+class BootGuardOutcome(Enum):
+    """Closed-set result of the operator-existence boot check.
+
+    Closed-set per CLAUDE.md ``rows_skipped`` discipline — every call
+    site exhaustively matches all three members; an unmatched outcome
+    is a defect, not a default.
+    """
+
+    OPERATOR_PRESENT = "operator_present"
+    OPERATOR_ABSENT = "operator_absent"
+    SKIPPED_BY_ENV = "skipped_by_env"
+
+
+def check_operator_exists(
+    conn: psycopg.Connection[Any],
+    *,
+    skip_env_set: bool,
+) -> BootGuardOutcome:
+    """Pure check: does the ``operators`` table have ≥ 1 row?
+
+    Honours the ``EBULL_JOBS_SKIP_OPERATOR_CHECK=1`` escape hatch via
+    the ``skip_env_set`` arg (caller reads the env var; this function
+    stays pure).
+
+    Performs ONE SELECT against the supplied connection. Owns no
+    connection lifecycle, no cleanup, no env var read — every side
+    effect is in the caller (``_check_operator_exists_with_cleanup``
+    in ``app/jobs/__main__.py``).
+    """
+    if skip_env_set:
+        return BootGuardOutcome.SKIPPED_BY_ENV
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM operators LIMIT 1")
+        if cur.fetchone() is None:
+            return BootGuardOutcome.OPERATOR_ABSENT
+    return BootGuardOutcome.OPERATOR_PRESENT
+
+
+OPERATOR_MISSING_ERROR_MESSAGE: str = (
+    "jobs boot blocked: no operators row in DB. "
+    "Run POST /auth/setup via the API process to create one. "
+    "Cold-start override: set EBULL_JOBS_SKIP_OPERATOR_CHECK=1 in the jobs-process env."
+)
+"""Operator-actionable string persisted to ``bootstrap_state.last_jobs_boot_error``
+on hard-fail. Surfaced via ``GET /system/status``.
+
+Kept here (rather than inline in ``__main__.py``) so the test layer can
+assert the exact wording without importing ``__main__`` (which has
+side-effectful imports — APScheduler etc.).
+"""

--- a/sql/171_bootstrap_state_last_jobs_boot_error.sql
+++ b/sql/171_bootstrap_state_last_jobs_boot_error.sql
@@ -1,0 +1,66 @@
+-- 171_bootstrap_state_last_jobs_boot_error.sql
+--
+-- Stream A PR-A T1.8 (#1233): boot-failure breadcrumb columns on
+-- bootstrap_state singleton.
+--
+-- The jobs-process boot guard ``_check_operator_exists_with_cleanup``
+-- (app/jobs/__main__.py) persists an operator-actionable error
+-- message + timestamp here on hard-fail. ``GET /system/status``
+-- (app/api/system.py) surfaces the breadcrumb so an operator can
+-- triage "jobs unhealthy because <reason> at <when>" without
+-- grepping stderr.
+--
+-- SINGLE-WRITER contract: only the operator-existence guard touches
+-- these columns. Sibling ``_ensure_*_with_cleanup`` helpers do NOT
+-- write here — they recover by re-INSERTing missing default
+-- singletons, not by persisting a breadcrumb. Adding a second writer
+-- requires explicit conflict-key + audit-trail design.
+--
+-- NULL semantics: "last boot succeeded, OR jobs has never run since
+-- this migration applied". A successful boot CLEARs both columns
+-- (``UPDATE ... WHERE last_jobs_boot_error IS NOT NULL``) so a
+-- recovered boot does not leave a stale error breadcrumb.
+--
+-- ``last_jobs_boot_error_at`` is stamped via ``clock_timestamp()``
+-- at write time (NOT ``transaction_timestamp()``/``NOW()``) per
+-- ``.claude/skills/data-engineer/SKILL.md`` §6.5.8 — the wrapper's
+-- breadcrumb write is its own short autocommit transaction so the
+-- difference does not matter today, but using ``clock_timestamp()``
+-- keeps the convention consistent if a future caller hoists the
+-- write into a longer-running transaction.
+--
+-- CHECK length cap (≤ 8192 chars): the current writer pins a
+-- ~200-char constant, but the cap pre-empts a future "let's append
+-- the stack trace" footgun that would bloat the singleton row.
+--
+-- Idempotent: ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS`` is safe
+-- to re-apply. CHECK constraint named explicitly so re-application
+-- is also idempotent.
+--
+-- Spec: docs/proposals/etl/stream-a-run-8-fixes.md §4 + §16 + §1 T1.8
+-- (Stream A v2.3, post-Codex-1 re-pass + 3-lens code review 2026-05-24).
+
+BEGIN;
+
+ALTER TABLE bootstrap_state
+    ADD COLUMN IF NOT EXISTS last_jobs_boot_error    TEXT;
+
+ALTER TABLE bootstrap_state
+    ADD COLUMN IF NOT EXISTS last_jobs_boot_error_at TIMESTAMPTZ;
+
+-- Length cap on the breadcrumb (defence-in-depth, single writer
+-- today). Idempotent: named CHECK + DROP IF EXISTS pattern.
+ALTER TABLE bootstrap_state
+    DROP CONSTRAINT IF EXISTS bootstrap_state_last_jobs_boot_error_len_check;
+
+ALTER TABLE bootstrap_state
+    ADD CONSTRAINT bootstrap_state_last_jobs_boot_error_len_check
+    CHECK (last_jobs_boot_error IS NULL OR length(last_jobs_boot_error) <= 8192);
+
+COMMENT ON COLUMN bootstrap_state.last_jobs_boot_error IS
+    'Operator-actionable string set by the operator-existence boot guard (_check_operator_exists_with_cleanup, #1233 Stream A PR-A) on hard-fail; cleared by successful boot. SINGLE-WRITER — sibling _ensure_*_with_cleanup helpers do NOT touch this column.';
+
+COMMENT ON COLUMN bootstrap_state.last_jobs_boot_error_at IS
+    'Wall-clock UTC at which last_jobs_boot_error was set (clock_timestamp() at write time). NULL iff last_jobs_boot_error IS NULL. Lets the operator see WHEN the failure happened, not only WHAT.';
+
+COMMIT;

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -34,7 +34,14 @@ _NOW = datetime(2026, 4, 7, 12, 30, 0, tzinfo=UTC)
 
 
 def _mock_conn() -> MagicMock:
-    return MagicMock()
+    conn = MagicMock()
+    # Pre-configure cursor().fetchone() to return None so direct SQL
+    # readers (e.g. ``_read_jobs_boot_error`` since Stream A PR-A
+    # #1233) default to "no breadcrumb" instead of returning a
+    # MagicMock that would fail Pydantic validation. Per-test overrides
+    # can shadow this for tests that need a populated row.
+    conn.cursor.return_value.__enter__.return_value.fetchone.return_value = None
+    return conn
 
 
 def _override_conn(conn: MagicMock) -> None:
@@ -351,6 +358,108 @@ class TestSystemStatus:
 
         assert resp.status_code == 200
         assert resp.json()["overall_status"] == "degraded"
+
+    def test_jobs_boot_error_null_when_no_breadcrumb(self) -> None:
+        """Stream A PR-A T1.8 (#1233): /system/status surfaces NULL
+        ``jobs_boot_error`` when bootstrap_state row has neither column
+        populated (healthy or never-failed boot)."""
+        _override_conn(_mock_conn())  # default fetchone() = None
+
+        with (
+            patch("app.api.system.check_all_layers", return_value=_all_ok_layers()),
+            patch(
+                "app.api.system.check_job_health",
+                side_effect=lambda _conn, name: _success_job_health(name),
+            ),
+            patch(
+                "app.api.system.get_kill_switch_status",
+                return_value={
+                    "is_active": False,
+                    "activated_at": None,
+                    "activated_by": None,
+                    "reason": None,
+                },
+            ),
+        ):
+            resp = client.get("/system/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "jobs_boot_error" in body
+        assert body["jobs_boot_error"] is None
+
+    def test_jobs_boot_error_surfaces_breadcrumb_when_present(self) -> None:
+        """Stream A PR-A T1.8 (#1233): /system/status surfaces the
+        persisted breadcrumb (both message + timestamp) when the jobs
+        process most-recently hard-failed boot."""
+        conn = _mock_conn()
+        breadcrumb_at = _NOW - timedelta(minutes=5)
+        breadcrumb_msg = (
+            "jobs boot blocked: no operators row in DB. Run POST /auth/setup via the API process to create one."
+        )
+        conn.cursor.return_value.__enter__.return_value.fetchone.return_value = (
+            breadcrumb_msg,
+            breadcrumb_at,
+        )
+        _override_conn(conn)
+
+        with (
+            patch("app.api.system.check_all_layers", return_value=_all_ok_layers()),
+            patch(
+                "app.api.system.check_job_health",
+                side_effect=lambda _conn, name: _success_job_health(name),
+            ),
+            patch(
+                "app.api.system.get_kill_switch_status",
+                return_value={
+                    "is_active": False,
+                    "activated_at": None,
+                    "activated_by": None,
+                    "reason": None,
+                },
+            ),
+        ):
+            resp = client.get("/system/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["jobs_boot_error"] is not None
+        assert body["jobs_boot_error"]["message"] == breadcrumb_msg
+        # Pydantic emits ISO-8601 with timezone; compare via datetime
+        # parse to avoid serialization quirks.
+        assert datetime.fromisoformat(body["jobs_boot_error"]["at"]) == breadcrumb_at
+
+    def test_jobs_boot_error_fails_safe_on_partial_row(self) -> None:
+        """Defence-in-depth: if a future bug writes only one of the two
+        columns, /system/status MUST treat it as "no breadcrumb"
+        rather than returning a half-populated object."""
+        conn = _mock_conn()
+        conn.cursor.return_value.__enter__.return_value.fetchone.return_value = (
+            "stray message without timestamp",
+            None,
+        )
+        _override_conn(conn)
+
+        with (
+            patch("app.api.system.check_all_layers", return_value=_all_ok_layers()),
+            patch(
+                "app.api.system.check_job_health",
+                side_effect=lambda _conn, name: _success_job_health(name),
+            ),
+            patch(
+                "app.api.system.get_kill_switch_status",
+                return_value={
+                    "is_active": False,
+                    "activated_at": None,
+                    "activated_by": None,
+                    "reason": None,
+                },
+            ),
+        ):
+            resp = client.get("/system/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["jobs_boot_error"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_jobs_boot_guard.py
+++ b/tests/test_jobs_boot_guard.py
@@ -1,0 +1,295 @@
+"""Tests for ``app.jobs.boot_guard`` (Stream A PR-A T1.8, #1233).
+
+Two layers (per spec §20 + Test-lens IMPORTANT — pure-function refactor
+keeps unit tests fast + table-driven; integration covers the wrapper's
+DB-side breadcrumb + cleanup contract):
+
+1. **Pure-function unit tests** for ``check_operator_exists``: no DB,
+   mocked cursor; 3 cases over ``BootGuardOutcome``.
+
+2. **Integration tests** against the real test DB
+   (``ebull_test_conn`` fixture) for both the pure function (real
+   SELECT) and the wrapper (``_check_operator_exists_with_cleanup``)
+   — covers the breadcrumb-write contract + cleanup-on-fail contract.
+
+The wrapper integration tests monkeypatch ``settings.database_url``
+to the per-worker test DB so the wrapper's own ``psycopg.connect``
+calls hit the right database.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.config import settings
+from app.jobs.boot_guard import (
+    OPERATOR_MISSING_ERROR_MESSAGE,
+    BootGuardOutcome,
+    check_operator_exists,
+)
+from tests.fixtures.ebull_test_db import test_database_url
+
+# --------------------------------------------------------------------- #
+# 1. Pure-function unit tests (mocked cursor, no DB)
+# --------------------------------------------------------------------- #
+
+
+class TestCheckOperatorExistsPureFunction:
+    """Pure-function contract — closed-set ``BootGuardOutcome`` over the
+    three input combinations. No DB required; uses a mocked cursor so
+    the test runs in every CI environment."""
+
+    def test_returns_operator_present_when_select_finds_a_row(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = (1,)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        outcome = check_operator_exists(conn, skip_env_set=False)
+
+        assert outcome is BootGuardOutcome.OPERATOR_PRESENT
+        cur.execute.assert_called_once_with("SELECT 1 FROM operators LIMIT 1")
+
+    def test_returns_operator_absent_when_select_finds_no_rows(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = None
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        outcome = check_operator_exists(conn, skip_env_set=False)
+
+        assert outcome is BootGuardOutcome.OPERATOR_ABSENT
+        cur.execute.assert_called_once_with("SELECT 1 FROM operators LIMIT 1")
+
+    def test_returns_skipped_by_env_when_flag_true_and_skips_db(self) -> None:
+        """Env-skip path MUST NOT touch the connection (cold-start path
+        may run before the DB is reachable)."""
+        conn = MagicMock()
+
+        outcome = check_operator_exists(conn, skip_env_set=True)
+
+        assert outcome is BootGuardOutcome.SKIPPED_BY_ENV
+        conn.cursor.assert_not_called()
+
+
+class TestBootGuardOutcomeIsClosedSet:
+    """Pin the enum to its three members so a future refactor that
+    silently adds a fourth member trips a test."""
+
+    def test_enum_has_exactly_three_members(self) -> None:
+        assert {m.name for m in BootGuardOutcome} == {
+            "OPERATOR_PRESENT",
+            "OPERATOR_ABSENT",
+            "SKIPPED_BY_ENV",
+        }
+
+    def test_enum_values_are_unique_lowercase_strings(self) -> None:
+        values = [m.value for m in BootGuardOutcome]
+        assert len(set(values)) == len(values)
+        assert all(isinstance(v, str) and v == v.lower() for v in values)
+
+
+class TestOperatorMissingErrorMessage:
+    """Error breadcrumb must be operator-actionable — pin substrings
+    so a future "shorten the message" edit can't strip the actionable
+    parts."""
+
+    def test_mentions_auth_setup_endpoint(self) -> None:
+        assert "/auth/setup" in OPERATOR_MISSING_ERROR_MESSAGE
+
+    def test_mentions_skip_env_var_name_for_cold_start(self) -> None:
+        assert "EBULL_JOBS_SKIP_OPERATOR_CHECK" in OPERATOR_MISSING_ERROR_MESSAGE
+
+    def test_starts_with_operator_actionable_prefix(self) -> None:
+        # "jobs boot blocked" lets the operator grep stderr for the marker.
+        assert OPERATOR_MISSING_ERROR_MESSAGE.startswith("jobs boot blocked")
+
+
+# --------------------------------------------------------------------- #
+# 2. Integration tests — real DB via ``ebull_test_conn``.
+# --------------------------------------------------------------------- #
+
+
+pytestmark_integration = pytest.mark.integration
+
+
+def _delete_all_operators(conn: psycopg.Connection[tuple]) -> None:
+    """Helper — wipe operators (and the FK-cascading sessions) before
+    a test that needs an empty table."""
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM sessions")
+        cur.execute("DELETE FROM operators")
+    conn.commit()
+
+
+def _insert_test_operator(conn: psycopg.Connection[tuple]) -> None:
+    import uuid
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s, %s, %s)",
+            (str(uuid.uuid4()), f"boot_guard_test_{uuid.uuid4().hex[:8]}", "x"),
+        )
+    conn.commit()
+
+
+def _read_last_jobs_boot_error(conn: psycopg.Connection[tuple]) -> tuple[str | None, Any]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_jobs_boot_error, last_jobs_boot_error_at FROM bootstrap_state WHERE id = 1",
+        )
+        row = cur.fetchone()
+    return (None, None) if row is None else (row[0], row[1])
+
+
+class TestCheckOperatorExistsAgainstRealDB:
+    """The pure function against a real DB — verifies the SELECT query
+    actually returns rows correctly from the live ``operators`` table."""
+
+    @pytest.mark.integration
+    def test_returns_present_with_seeded_operator(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        _delete_all_operators(ebull_test_conn)
+        _insert_test_operator(ebull_test_conn)
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            outcome = check_operator_exists(guard_conn, skip_env_set=False)
+
+        assert outcome is BootGuardOutcome.OPERATOR_PRESENT
+
+    @pytest.mark.integration
+    def test_returns_absent_with_empty_operators_table(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        _delete_all_operators(ebull_test_conn)
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            outcome = check_operator_exists(guard_conn, skip_env_set=False)
+
+        assert outcome is BootGuardOutcome.OPERATOR_ABSENT
+
+
+# --------------------------------------------------------------------- #
+# Wrapper tests — drive ``_check_operator_exists_with_cleanup`` against
+# the real test DB. Imported lazily to avoid pulling in __main__'s
+# side-effectful imports at module-load time.
+# --------------------------------------------------------------------- #
+
+
+def _wrapper() -> Any:
+    """Lazy import so the rest of the file can run without paying for
+    ``app.jobs.__main__``'s import-time side effects (APScheduler,
+    listener supervision, etc.).
+    """
+    from app.jobs.__main__ import _check_operator_exists_with_cleanup
+
+    return _check_operator_exists_with_cleanup
+
+
+class TestCheckOperatorExistsWithCleanupWrapper:
+    """End-to-end wrapper contract:
+
+    * env-skip path returns cleanly without touching DB or fence/pool.
+    * operator-present path clears any stale breadcrumb.
+    * operator-absent path persists the breadcrumb, closes fence + pool,
+      and raises ``SystemExit(2)``.
+    """
+
+    @pytest.mark.integration
+    def test_env_skip_does_not_touch_db_or_pool(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Env-skip path MUST NOT dial the DB — cold-start use case
+        is documented as "DB may not be reachable yet". Verify the
+        wrapper returns BEFORE any psycopg.connect call. Architect
+        IMPORTANT — broken in v1 of PR-A (connect was unconditional)."""
+        monkeypatch.setenv("EBULL_JOBS_SKIP_OPERATOR_CHECK", "1")
+        connect_call_count = 0
+        real_connect = psycopg.connect
+
+        def _counting_connect(*args: Any, **kwargs: Any) -> Any:
+            nonlocal connect_call_count
+            connect_call_count += 1
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr(psycopg, "connect", _counting_connect)
+        # Also patch through the import path used by the wrapper.
+        from app.jobs import __main__ as jobs_main
+
+        monkeypatch.setattr(jobs_main.psycopg, "connect", _counting_connect)
+
+        fence_conn = MagicMock()
+        pool = MagicMock()
+
+        _wrapper()(fence_conn, pool)
+
+        assert connect_call_count == 0, "env-skip path must not dial DB (cold-start contract)"
+        fence_conn.close.assert_not_called()
+        pool.close.assert_not_called()
+
+    @pytest.mark.integration
+    def test_operator_present_clears_stale_breadcrumb(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _delete_all_operators(ebull_test_conn)
+        _insert_test_operator(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE bootstrap_state SET last_jobs_boot_error = %s WHERE id = 1",
+                ("stale error from a prior failed boot",),
+            )
+        ebull_test_conn.commit()
+
+        monkeypatch.delenv("EBULL_JOBS_SKIP_OPERATOR_CHECK", raising=False)
+        monkeypatch.setattr(settings, "database_url", test_database_url())
+        fence_conn = MagicMock()
+        pool = MagicMock()
+
+        _wrapper()(fence_conn, pool)
+
+        message, at = _read_last_jobs_boot_error(ebull_test_conn)
+        assert message is None, "successful boot must clear the stale breadcrumb message"
+        assert at is None, "successful boot must clear the stale breadcrumb timestamp"
+        fence_conn.close.assert_not_called()
+        pool.close.assert_not_called()
+
+    @pytest.mark.integration
+    def test_operator_absent_persists_breadcrumb_and_exits_2(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _delete_all_operators(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("UPDATE bootstrap_state SET last_jobs_boot_error = NULL WHERE id = 1")
+        ebull_test_conn.commit()
+
+        monkeypatch.delenv("EBULL_JOBS_SKIP_OPERATOR_CHECK", raising=False)
+        monkeypatch.setattr(settings, "database_url", test_database_url())
+        fence_conn = MagicMock()
+        pool = MagicMock()
+
+        with pytest.raises(SystemExit) as excinfo:
+            _wrapper()(fence_conn, pool)
+
+        assert excinfo.value.code == 2
+
+        message, at = _read_last_jobs_boot_error(ebull_test_conn)
+        assert message == OPERATOR_MISSING_ERROR_MESSAGE
+        assert at is not None, "breadcrumb timestamp must be populated alongside message"
+
+        fence_conn.close.assert_called_once()
+        pool.close.assert_called_once()


### PR DESCRIPTION
## Summary

Stream A PR-A of #1233 Tier 1 bootstrap optimisation. Hard-fail jobs-process boot when no `operators` row exists. Pre-#1233 the daemon would happily start against an unprepared DB and every scheduled fire would silently reject with `bootstrap_not_complete` — operator saw no ingestion and had to grep stderr.

**Refs #1233** (umbrella — Stream A is A→B→C→D; this is PR-A only).

- NEW `app/jobs/boot_guard.py` — pure function + closed-set enum + actionable error message.
- NEW migration `sql/171_bootstrap_state_last_jobs_boot_error.sql` — adds `last_jobs_boot_error TEXT` + `last_jobs_boot_error_at TIMESTAMPTZ` + length-cap CHECK to `bootstrap_state`.
- NEW `_check_operator_exists_with_cleanup(fence_conn, pool)` wrapper in `app/jobs/__main__.py`, slotted after the bootstrap_state singleton guard. Hard-fail → `logger.critical` + persist breadcrumb (message + UTC timestamp via `clock_timestamp()`) + try/finally cleanup → `SystemExit(2)`. Escape hatch: `EBULL_JOBS_SKIP_OPERATOR_CHECK=1` env var (early-return BEFORE dialling DB so cold-start works with PG unreachable).
- `/system/status` (`app/api/system.py`) surfaces the breadcrumb via new `JobsBootError` model on `SystemStatusResponse.jobs_boot_error`. Fail-safe on half-populated rows.
- Helper named `_check_*` not `_ensure_*` because operator absence is unrecoverable (semantic-honest distinct from 5 sibling helpers that RE-SEED missing default singletons).

## Why

Per spec §1 T1.8 (`docs/proposals/etl/stream-a-run-8-fixes.md` v2.3, #1306) — and v3 Codex CTO biggest risk: bootstrap deferring correctness to non-firing scheduled jobs. PR-A is the first of A→B→C→D per spec §1.6.

## Security model

- Read scope: `SELECT 1 FROM operators LIMIT 1` (no PII; just existence). `SELECT last_jobs_boot_error, last_jobs_boot_error_at FROM bootstrap_state WHERE id = 1` is operator-only via `/system/status`'s existing `require_session_or_service_token`. No new auth surface.
- Write scope: parameterised UPDATE of two columns on the singleton row; SINGLE-WRITER guarantee (other helpers do not touch these columns) pinned in migration COMMENT.
- Env var: `EBULL_JOBS_SKIP_OPERATOR_CHECK=1` is read at jobs-process boot only, must be explicitly set to literal "1" (no falsy default-passthrough). Documented in the wrapper docstring + `OPERATOR_MISSING_ERROR_MESSAGE`.

## Conscious tradeoffs

- Three short-lived autocommit connections per boot guard call (check / clear / breadcrumb). Cheap on a healthy DB; consistent with sibling `_ensure_*` helpers' pattern of NOT piggybacking on the fence_conn (which must stay clean for the heartbeat thread).
- Env-skip path does NOT clear stale breadcrumb (Codex 2 LOW). Documented in the wrapper log line — the cold-start scenario this serves is "DB may not yet be reachable", so attempting a clear would defeat the no-DB-touch contract.
- T1.8 alone does not surface the breadcrumb in the admin-UI banner — `/system/status` exposes the field; a follow-up frontend tick can render it. Out of scope for PR-A.

## Test plan

- [x] `tests/test_jobs_boot_guard.py` — 9 unit tests (pure function over 3 outcomes; enum closed-set + value invariants; error-message substring invariants) + 2 integration tests against real DB + 3 wrapper end-to-end tests including "env-skip MUST NOT dial DB" (asserts via `psycopg.connect` counter), "operator-present clears stale breadcrumb" (verifies both columns NULL), "operator-absent persists + exits 2 + closes fence/pool" (verifies message + timestamp both populated).
- [x] `tests/test_api_system.py` — 3 new tests: NULL when empty; populated when set; NULL on half-populated row (fail-safe).
- [x] `uv run ruff check` + `ruff format --check` + `pyright` PASS on the 6 impacted files.
- [x] `uv run pytest tests/test_jobs_boot_guard.py tests/test_api_system.py tests/smoke/test_jobs_process_boots.py` — 28 PASS + 5 integration tests skipped (local PG in recovery mode; CI runs them fresh).

## Review trail

Self-review + 3-lens committee (Architect via `feature-dev:code-architect` + Adversarial Reviewer via `feature-dev:code-reviewer` + Data Engineer via `general-purpose`) + Codex 2 pre-push checkpoint (`codex exec`). All BLOCKING findings folded; full audit in commit body. Memory: `~/.claude/projects/.../memory/project_stream_a_*`.

## Related

- Spec PR #1306 (Stream A v2.3 + 8 supporting skills).
- Next: PR-B `feature/1233-pr-b-sidecar` (T1.3 sidecar + agent-CIK filter; depends on PR-A merged per spec §1.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)