### PR TITLE
feat(#1233): Stream A PR-B — sec submissions files[] sidecar (T1.3)

### DIFF
--- a/app/services/bootstrap_preconditions.py
+++ b/app/services/bootstrap_preconditions.py
@@ -471,12 +471,26 @@ def assert_c1b_preconditions(
     bootstrap_run_id: int,
     bulk_dir: Any | None = None,
 ) -> None:
-    """C1.b: C1.a succeeded in current run AND wrote ≥ 1 row.
+    """C1.b: C1.a succeeded in current run AND populated the sidecar.
 
-    Without the rows-written check, a zero-row C1.a (e.g. universe
-    had no SEC-mapped instruments) would pass this gate and let
-    C1.b proceed to walk an empty CIK list. Codex review
-    BLOCKING for #1020.
+    Pre-Stream-A PR-B (#1233), this gated on ``rows_written > 0``
+    (i.e. ``filings_upserted``). That's a false-negative footgun
+    under retention drops: a run where every filing was older than
+    the 10y retention cap would record ``rows_written=0`` even
+    though the sidecar was correctly populated for every CIK, and
+    C1.b would refuse to walk despite having work to do (Codex 2
+    pre-push review MEDIUM).
+
+    Stream A PR-B sidecar telemetry now lives in
+    ``rows_skipped.ciks_sidecared`` (sec_bulk_orchestrator_jobs.py).
+    The gate now accepts EITHER:
+      * ``rows_written > 0`` (legacy — historical filings landed); OR
+      * ``rows_skipped->>'ciks_sidecared' > 0`` (sidecar populated even
+        when retention dropped all filings).
+
+    Original BLOCKING (Codex #1020) is preserved: a truly zero-work
+    run (universe has no SEC-mapped instruments → 0 filings AND
+    0 sidecar rows) still fails the gate.
     """
     if bulk_dir is not None:
         assert_not_fallback_mode(bulk_dir, bootstrap_run_id=bootstrap_run_id)
@@ -488,7 +502,10 @@ def assert_c1b_preconditions(
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT rows_written FROM bootstrap_archive_results
+            SELECT
+                rows_written,
+                COALESCE((rows_skipped->>'ciks_sidecared')::INT, 0) AS ciks_sidecared
+            FROM bootstrap_archive_results
             WHERE bootstrap_run_id = %s
               AND stage_key = 'sec_submissions_ingest'
               AND archive_name = 'submissions.zip'
@@ -496,9 +513,17 @@ def assert_c1b_preconditions(
             (bootstrap_run_id,),
         )
         row = cur.fetchone()
-        if row is None or int(row[0]) <= 0:
+        if row is None:
             raise BootstrapPreconditionError(
-                f"PRECONDITION: sec_submissions_ingest wrote 0 rows in run_id={bootstrap_run_id}; C1.b cannot proceed."
+                "PRECONDITION: sec_submissions_ingest audit row missing for "
+                f"run_id={bootstrap_run_id}; C1.b cannot proceed."
+            )
+        rows_written = int(row[0] or 0)
+        ciks_sidecared = int(row[1] or 0)
+        if rows_written <= 0 and ciks_sidecared <= 0:
+            raise BootstrapPreconditionError(
+                f"PRECONDITION: sec_submissions_ingest wrote 0 filings AND 0 sidecar rows in "
+                f"run_id={bootstrap_run_id}; C1.b cannot proceed."
             )
 
 

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -189,12 +189,21 @@ def sec_submissions_ingest_job() -> None:
         captured["filings_upserted"] = result.filings_upserted
         captured["profiles_upserted"] = result.profiles_upserted
         captured["parse_errors"] = result.parse_errors
+        # Stream A PR-B T1.3 (#1233): per-archive sidecar telemetry
+        # captured here so the audit row below persists it. Without
+        # this, the Stream-C C7 gate has no auditable per-run figure
+        # for sidecar coverage (DE MEDIUM pre-push review).
+        captured["ciks_sidecared"] = result.ciks_sidecared
+        captured["sidecar_pages_indexed"] = result.sidecar_pages_indexed
         logger.info(
-            "sec_submissions_ingest: matched=%d filings_upserted=%d profiles=%d parse_errors=%d",
+            "sec_submissions_ingest: matched=%d filings_upserted=%d profiles=%d parse_errors=%d "
+            "ciks_sidecared=%d sidecar_pages_indexed=%d",
             result.instruments_matched,
             result.filings_upserted,
             result.profiles_upserted,
             result.parse_errors,
+            result.ciks_sidecared,
+            result.sidecar_pages_indexed,
         )
 
     _run_with_conn(_do)
@@ -204,7 +213,11 @@ def sec_submissions_ingest_job() -> None:
             stage_key="sec_submissions_ingest",
             archive_name="submissions.zip",
             rows_written=captured.get("filings_upserted", 0),
-            rows_skipped={"parse_errors": captured.get("parse_errors", 0)},
+            rows_skipped={
+                "parse_errors": captured.get("parse_errors", 0),
+                "ciks_sidecared": captured.get("ciks_sidecared", 0),
+                "sidecar_pages_indexed": captured.get("sidecar_pages_indexed", 0),
+            },
         )
     _delete_archive_after_success(archive)
 

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -1,4 +1,7 @@
-"""C1.b — per-CIK ``filings.files[]`` secondary-pages walker (#1027).
+"""C1.b — per-CIK ``filings.files[]`` secondary-pages walker (#1027,
+rewritten in Stream A PR-B T1.3 #1233 to consume the
+``sec_cik_submissions_files_index`` sidecar instead of re-fetching the
+primary submissions.json).
 
 The bulk ``submissions.zip`` archive published by SEC contains every
 CIK's ``filings.recent`` block (last ~12 months / 1000 most-recent
@@ -6,20 +9,36 @@ filings). For deeper history, SEC paginates older filings under
 ``filings.files[]`` — secondary JSON URLs the bulk archive does NOT
 include.
 
-C1.a (bulk submissions ingester, #1022) reads the bulk archive's
-``recent`` block. C1.b walks each CIK's secondary pages — bounded
-by the per-CIK rate budget — to seed ``filing_events`` with the
-deeper history that the existing ``sec_first_install_drain`` would
-otherwise have walked one CIK at a time at 7 req/s.
+C1.a (bulk submissions ingester, ``sec_submissions_ingest``) reads the
+bulk archive's ``recent`` block AND — since Stream A PR-B — populates
+``sec_cik_submissions_files_index`` from the same in-memory payload.
+C1.b walks the per-CIK page descriptors from the sidecar and fetches
+each secondary page over HTTP, bounded by the per-CIK rate budget.
 
-This is a ~150–300 secondary-page-fetch job for a typical 1.5 k
-universe (most CIKs have <12 months of history; only the
-deepest-history filers cross into the secondary-page region).
-Walked AFTER C1.a + Phase B so the CUSIP universe + filer
-directories are in place; rate-limited via the existing process-wide
-SEC clock.
+Pre-PR-B, this walker re-fetched the primary submissions.json for every
+in-universe CIK JUST to read ``filings.files[]`` again — even though
+C1.a already had that data minutes earlier. The sidecar eliminates
+those ~5,105 redundant primary fetches (~12 min wall-clock at SEC's
+7 req/s budget). Secondary pages are STILL fetched over HTTP (they
+are NOT in the bulk archive — confirmed at the spec §0.5 grep proof
+referencing this file's pre-PR-B docstring).
 
-Spec: docs/superpowers/specs/2026-05-08-bulk-datasets-first-bootstrap.md
+Sentinel-row behaviour (Codex v2 BLOCKING + spec §4):
+  * CIK with ≥ 1 real sidecar page → walk those pages.
+  * CIK with exactly the sentinel ``__no_overflow_pages__`` row → skip
+    secondary walk; CIK is "processed with zero overflow" (e.g. AAPL
+    whose ``recent`` array fits the 1000-cap).
+  * CIK with zero sidecar rows (in-universe, not an agent CIK) →
+    fail-closed; surface as a parse-error and continue with the rest
+    of the cohort. Indicates an S8 ordering bug or a CIK added to
+    universe after S8 ran.
+  * CIK in ``KNOWN_FILING_AGENT_CIKS`` → not in the populated set;
+    skipped at sidecar-populate time. S14 also skips them at consume
+    so URL-construction never targets an agent CIK (would 404 every
+    time per ``sec-edgar.md §3.7``).
+
+Spec: docs/proposals/etl/stream-a-run-8-fixes.md v2.3 §1 T1.3 + §13 + §14
+(post-Codex-1 re-pass + 3-lens code review 2026-05-24).
 """
 
 from __future__ import annotations
@@ -32,12 +51,20 @@ import psycopg
 
 from app.config import settings
 from app.providers.implementations.sec_edgar import (
+    KNOWN_FILING_AGENT_CIKS,
     SecFilingsProvider,
     _normalise_submissions_block,
 )
 from app.services.filings import _upsert_filing
 
 logger = logging.getLogger(__name__)
+
+
+# Stream A PR-B T1.3 (#1233): sentinel page-name pattern written by
+# the sidecar populate in sec_submissions_ingest._refresh_cik_sidecar.
+# Distinguishes "CIK processed; no overflow pages" from "CIK not yet
+# populated".
+_SIDECAR_SENTINEL_PAGE_NAME: str = "__no_overflow_pages__"
 
 
 @dataclass
@@ -48,37 +75,74 @@ class FilesWalkResult:
     secondary_pages_fetched: int = 0
     filings_upserted: int = 0
     parse_errors: int = 0
+    # Stream A PR-B T1.3 (#1233): per-CIK sidecar telemetry.
+    # ``ciks_with_no_overflow`` counts CIKs that had only the sentinel
+    # row (zero secondary pages — skipped without HTTP). Closed-set
+    # bookkeeping per spec §15 to keep ``parse_errors`` from
+    # double-counting legitimate "no-overflow" CIKs as errors.
+    ciks_with_no_overflow: int = 0
+    ciks_with_empty_sidecar: int = 0
 
 
 def _list_cik_secondary_pages(
     conn: psycopg.Connection[Any],
-) -> list[tuple[int, str, str]]:
-    """Return ``[(instrument_id, cik_padded, symbol)]`` for every
+) -> list[tuple[int, str, str, list[str]]]:
+    """Return ``[(instrument_id, cik_padded, symbol, sidecar_pages)]`` for every
     CIK-mapped universe instrument.
 
     Joins ``external_identifiers`` to ``instruments`` so the writer
     below threads the canonical ticker through to
-    ``_normalise_submissions_block`` + ``_upsert_filing``. Passing
-    ``str(instrument_id)`` as the symbol corrupts every
-    ``filing_events.raw_payload_json`` row — Codex review BLOCKING
-    for PR #1035, parity with the same fix in PR #1030 (C1.a).
+    ``_normalise_submissions_block`` + ``_upsert_filing`` (Codex review
+    BLOCKING for PR #1035, parity with the same fix in PR #1030 / C1.a).
+
+    Stream A PR-B (#1233): also LEFT JOINs ``sec_cik_submissions_files_index``
+    and aggregates the per-CIK page list. The aggregate preserves the
+    sentinel page name when present so callers can distinguish:
+
+      * ``sidecar_pages == []``                               — empty sidecar (fail-closed)
+      * ``sidecar_pages == ['__no_overflow_pages__']``         — processed; no overflow
+      * ``sidecar_pages == [<one or more real CIK*-...json>]`` — overflow exists; walk
+
+    NOT NULL-safe: a row in ``sec_cik_submissions_files_index`` is
+    always either a sentinel row OR a row with a non-NULL page_name
+    matching the regex CHECK (sql/172). ``array_agg`` on a NOT NULL
+    column never injects NULL into the aggregate.
     """
-    out: list[tuple[int, str, str]] = []
+    out: list[tuple[int, str, str, list[str]]] = []
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT ei.instrument_id, ei.identifier_value, i.symbol
+            SELECT
+                ei.instrument_id,
+                ei.identifier_value,
+                i.symbol,
+                COALESCE(
+                    array_agg(s.page_name) FILTER (WHERE s.page_name IS NOT NULL),
+                    ARRAY[]::TEXT[]
+                )
             FROM external_identifiers ei
-            JOIN instruments i ON i.instrument_id = ei.instrument_id
+            JOIN instruments i
+              ON i.instrument_id = ei.instrument_id
+            LEFT JOIN sec_cik_submissions_files_index s
+              -- LPAD is defensive: sec_identity.py:44 normalises CIKs to
+              -- 10-digit zero-padded BEFORE writing to external_identifiers
+              -- (and the sidecar's own CHECK enforces the 10-digit shape on
+              -- the s.cik side), so the LPAD is a no-op for any row written
+              -- by current code. Kept against the historical-data case
+              -- where pre-sec_identity.py:44 inserts may carry unpadded
+              -- values. Negligible perf cost at 12k-CIK cohort (hash-join).
+              ON s.cik = LPAD(ei.identifier_value, 10, '0')
             WHERE ei.provider = 'sec'
               AND ei.identifier_type = 'cik'
               AND i.is_tradable = TRUE
+            GROUP BY ei.instrument_id, ei.identifier_value, i.symbol
             """,
         )
         for row in cur.fetchall():
-            instrument_id, identifier, symbol = row
+            instrument_id, identifier, symbol, sidecar_pages = row
             cik = str(identifier).zfill(10)
-            out.append((int(instrument_id), cik, str(symbol or "")))
+            pages_list: list[str] = list(sidecar_pages or [])
+            out.append((int(instrument_id), cik, str(symbol or ""), pages_list))
     return out
 
 
@@ -90,42 +154,61 @@ def walk_files_pages(
     universe instrument and append discovered filings to
     ``filing_events``.
 
-    The walker reuses the existing ``SecFilingsProvider`` HTTP client
-    (which already shares the process-wide rate-limit clock) so this
-    pass coexists with concurrent SEC ingest jobs without bursting
-    the per-IP budget.
+    Stream A PR-B (#1233): consumes the sidecar
+    (``sec_cik_submissions_files_index``) instead of re-fetching each
+    CIK's primary ``submissions/CIK<10>.json`` — eliminates ~5,105
+    redundant primary HTTP calls per Run-#8.
+
+    Secondary-page fetches over HTTP are UNCHANGED — they were never
+    in the bulk archive.
     """
     result = FilesWalkResult()
     targets = _list_cik_secondary_pages(conn)
 
     with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-        for instrument_id, cik, symbol in targets:
+        for instrument_id, cik, symbol, sidecar_pages in targets:
+            # Agent CIKs are excluded by the populate path
+            # (sec_submissions_ingest._refresh_cik_sidecar) so their
+            # sidecar_pages list is empty by design. Skip them here
+            # silently — they do NOT count toward ciks_visited (the
+            # counter reflects "real CIKs we did or attempted work for"
+            # per Architect IMPORTANT — pre-PR-B post-review fix).
+            if cik in KNOWN_FILING_AGENT_CIKS:
+                continue
+
             result.ciks_visited += 1
-            try:
-                # Fetch primary submissions.json (rate-limited).
-                # The provider exposes ``fetch_submissions(cik)`` which
-                # returns the parsed dict for the given CIK; the dict's
-                # ``filings.files[]`` array names secondary pages.
-                primary = provider.fetch_submissions(cik)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("files walk: primary fetch failed for CIK %s: %s", cik, exc)
+
+            if not sidecar_pages:
+                # Empty sidecar for an in-universe CIK that is NOT an
+                # agent. Indicates an S8 ordering bug or a CIK added
+                # to the universe after S8 ran. Per-CIK log is DEBUG
+                # to avoid stderr spam at scale (8.7k CIK cohort — a
+                # systemic S8 failure would otherwise log 8,700
+                # WARNING lines); a single end-of-walk summary
+                # WARNING is emitted below (per Architect IMPORTANT).
+                logger.debug(
+                    "files walk: empty sidecar for in-universe CIK %s; "
+                    "S8 must populate sec_cik_submissions_files_index first",
+                    cik,
+                )
+                result.ciks_with_empty_sidecar += 1
                 result.parse_errors += 1
                 continue
 
-            if not isinstance(primary, dict):
+            if sidecar_pages == [_SIDECAR_SENTINEL_PAGE_NAME]:
+                # CIK processed with zero overflow pages (sentinel
+                # row). No HTTP fetch needed.
+                result.ciks_with_no_overflow += 1
                 continue
-            filings_block = primary.get("filings")
-            files: list[Any] = []
-            if isinstance(filings_block, dict):
-                raw_files = filings_block.get("files")
-                if isinstance(raw_files, list):
-                    files = raw_files
 
-            for entry in files:
-                if not isinstance(entry, dict):
-                    continue
-                page_name = entry.get("name")
-                if not page_name:
+            for page_name in sidecar_pages:
+                # Defensive — the only sentinel allowed is
+                # _SIDECAR_SENTINEL_PAGE_NAME; the schema CHECK already
+                # rejects any other sentinel-shaped value. A real CIK
+                # with overflow pages will never have the sentinel
+                # mixed in (the populate path writes one or the other).
+                # Skip sentinel rows defensively.
+                if page_name == _SIDECAR_SENTINEL_PAGE_NAME:
                     continue
                 try:
                     page = provider.fetch_submissions_page(page_name)
@@ -175,6 +258,25 @@ def walk_files_pages(
                             exc,
                         )
                         result.parse_errors += 1
+
+    # End-of-walk SUMMARY warning when ≥ 1 in-universe non-agent CIK
+    # had an empty sidecar. Single log line replaces the per-CIK spam
+    # that pre-review-v2 emitted (Architect IMPORTANT).
+    if result.ciks_with_empty_sidecar > 0:
+        logger.warning(
+            "files walk: %d in-universe CIK(s) had empty sidecar — "
+            "sec_submissions_ingest (S8) must populate "
+            "sec_cik_submissions_files_index before S14 runs. "
+            "Counters: visited=%d empty=%d no_overflow=%d pages=%d filings=%d errors=%d",
+            result.ciks_with_empty_sidecar,
+            result.ciks_visited,
+            result.ciks_with_empty_sidecar,
+            result.ciks_with_no_overflow,
+            result.secondary_pages_fetched,
+            result.filings_upserted,
+            result.parse_errors,
+        )
+
     return result
 
 
@@ -211,10 +313,12 @@ def sec_submissions_files_walk_job() -> None:
         result = walk_files_pages(conn=conn)
         conn.commit()
     logger.info(
-        "sec_submissions_files_walk: ciks=%d pages=%d filings=%d parse_errors=%d",
+        "sec_submissions_files_walk: ciks=%d pages=%d filings=%d no_overflow=%d empty_sidecar=%d parse_errors=%d",
         result.ciks_visited,
         result.secondary_pages_fetched,
         result.filings_upserted,
+        result.ciks_with_no_overflow,
+        result.ciks_with_empty_sidecar,
         result.parse_errors,
     )
     if run_id is not None:
@@ -233,7 +337,11 @@ def sec_submissions_files_walk_job() -> None:
                     stage_key="sec_submissions_files_walk",
                     archive_name="__job__",
                     rows_written=result.filings_upserted,
-                    rows_skipped={"parse_errors": result.parse_errors},
+                    rows_skipped={
+                        "parse_errors": result.parse_errors,
+                        "no_overflow": result.ciks_with_no_overflow,
+                        "empty_sidecar": result.ciks_with_empty_sidecar,
+                    },
                 )
                 conn.commit()
         except Exception as exc:  # noqa: BLE001 — audit must not block stage

--- a/app/services/sec_submissions_ingest.py
+++ b/app/services/sec_submissions_ingest.py
@@ -31,11 +31,22 @@ from typing import Any
 
 import psycopg
 
-from app.providers.implementations.sec_edgar import _normalise_submissions_block
+from app.providers.implementations.sec_edgar import (
+    KNOWN_FILING_AGENT_CIKS,
+    _normalise_submissions_block,
+)
 from app.services.filings import _upsert_filing
 from app.services.sec_entity_profile import parse_entity_profile, upsert_entity_profile
 
 logger = logging.getLogger(__name__)
+
+
+# Stream A PR-B T1.3 (#1233): sentinel row inserted into
+# ``sec_cik_submissions_files_index`` for CIKs with zero overflow
+# pages. Distinguishes "CIK processed; no overflow" from "CIK not
+# yet populated". S14 + the Stream-C C7 gate honour this explicitly
+# — see sql/172 header + spec §4.
+_SIDECAR_SENTINEL_PAGE_NAME: str = "__no_overflow_pages__"
 
 
 _CIK_FILENAME_RE = re.compile(r"^CIK(\d{10})\.json$")
@@ -55,12 +66,154 @@ class SubmissionsIngestResult:
     profiles_upserted: int
     archive_entries_skipped: int = 0
     parse_errors: int = 0
+    # Stream A PR-B T1.3 (#1233): per-archive sidecar telemetry.
+    # ``ciks_sidecared`` counts CIKs for which we wrote ≥ 1 sidecar
+    # row (real-page rows OR a sentinel — agent CIKs are excluded
+    # by filter and do NOT contribute). ``sidecar_pages_indexed``
+    # counts real-page rows only (sentinel rows do not).
+    ciks_sidecared: int = 0
+    sidecar_pages_indexed: int = 0
 
 
 def _cik_from_filename(name: str) -> str | None:
     """Parse the 10-digit CIK out of a ``CIK<10>.json`` archive entry name."""
     m = _CIK_FILENAME_RE.match(name)
     return m.group(1) if m else None
+
+
+def _load_current_bootstrap_run_id(
+    conn: psycopg.Connection[Any],
+) -> int | None:
+    """Return the currently-running ``bootstrap_runs.id`` or ``None``.
+
+    Stream A PR-B T1.3 (#1233) — sidecar populate threads this through
+    so each row carries the bootstrap-run lineage when written under
+    a tracked bootstrap. A steady-state S8 refresh (no running
+    bootstrap) yields ``None``, which the writer stores as the FK
+    nullable column and stamps ``populate_origin='steady_state'``.
+
+    Read once per archive ingest; cached for the duration so the
+    per-CIK loop does not re-query.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM bootstrap_runs WHERE status = 'running' ORDER BY id DESC LIMIT 1",
+        )
+        row = cur.fetchone()
+    return int(row[0]) if row else None
+
+
+def _refresh_cik_sidecar(
+    conn: psycopg.Connection[Any],
+    *,
+    cik: str,
+    payload: dict[str, Any],
+    bootstrap_run_id: int | None,
+    result: SubmissionsIngestResult,
+) -> None:
+    """Stream A PR-B T1.3 (#1233): refresh ``sec_cik_submissions_files_index``
+    for one CIK from the in-memory submissions payload.
+
+    Called from the OUTER per-CIK transaction in ``ingest_submissions_archive``
+    BEFORE the ``for instrument_id, symbol in matched_instruments:`` sibling
+    loop — putting it inside ``_ingest_one`` would repeat the DELETE+INSERT
+    N times per share-class CIK (one per sibling), per Codex 1 re-pass
+    IMPORTANT. Single refresh per (CIK, archive-entry) here.
+
+    Skips agent CIKs (``KNOWN_FILING_AGENT_CIKS`` at
+    ``app/providers/implementations/sec_edgar.py:98``) — sidecar stays
+    a "real-filer-only" index. Agent CIKs are NOT in the populated
+    set; S14 + the Stream-C C7 gate know to expect zero rows for them.
+
+    Per-CIK DELETE + INSERT (not global TRUNCATE). The OUTER per-CIK
+    transaction (sec_submissions_ingest.py:148-176) gives atomicity:
+    if any sibling-instrument write later raises, the DELETE rolls
+    back too — prior committed rows for that CIK SURVIVE.
+
+    On zero overflow pages (e.g. AAPL — ``recent`` fits under 1000-cap),
+    writes ONE sentinel row with ``page_name='__no_overflow_pages__'``
+    instead of zero rows. Distinguishes "CIK processed; no overflow"
+    from "CIK not yet populated" — per sql/172 header + spec §4 / §14.
+    """
+    if cik in KNOWN_FILING_AGENT_CIKS:
+        return
+
+    origin = "bootstrap" if bootstrap_run_id is not None else "steady_state"
+
+    filings_block = payload.get("filings")
+    files_entries: list[Any] = []
+    if isinstance(filings_block, dict):
+        raw_files = filings_block.get("files")
+        if isinstance(raw_files, list):
+            files_entries = raw_files
+
+    real_pages: list[tuple[str, str, str]] = []
+    malformed_count = 0
+    for entry in files_entries:
+        if not isinstance(entry, dict):
+            malformed_count += 1
+            continue
+        name = entry.get("name")
+        filing_from = entry.get("filingFrom")
+        filing_to = entry.get("filingTo")
+        if not (isinstance(name, str) and isinstance(filing_from, str) and isinstance(filing_to, str)):
+            malformed_count += 1
+            continue
+        real_pages.append((name, filing_from, filing_to))
+
+    # Codex 2 HIGH (pre-push review): if files[] was NON-EMPTY but every
+    # entry was malformed, writing the sentinel would falsely tell S14
+    # "this CIK has no overflow" when reality is "we could not parse
+    # the overflow descriptors". Fail-loud instead: increment parse_errors,
+    # skip the sidecar write entirely — S14 will then fail-closed on
+    # empty sidecar and the operator will see the cause via
+    # ciks_with_empty_sidecar + this parse_errors increment.
+    if files_entries and not real_pages:
+        logger.warning(
+            "submissions ingest: CIK %s files[] had %d entries but ALL malformed; "
+            "skipping sidecar write to avoid false-sentinel; S14 will fail-closed",
+            cik,
+            malformed_count,
+        )
+        result.parse_errors += 1
+        return
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM sec_cik_submissions_files_index WHERE cik = %s",
+            (cik,),
+        )
+        if real_pages:
+            cur.executemany(
+                "INSERT INTO sec_cik_submissions_files_index "
+                "(cik, page_name, filing_from, filing_to, bootstrap_run_id, populate_origin) "
+                "VALUES (%s, %s, %s, %s, %s, %s)",
+                [
+                    (cik, name, filing_from, filing_to, bootstrap_run_id, origin)
+                    for name, filing_from, filing_to in real_pages
+                ],
+            )
+            result.sidecar_pages_indexed += len(real_pages)
+            if malformed_count:
+                # Partial-malformed (some good, some bad) — log + count
+                # but DO write the good rows. Operator sees the gap.
+                logger.info(
+                    "submissions ingest: CIK %s files[] had %d malformed entries "
+                    "(skipped); %d well-formed pages indexed",
+                    cik,
+                    malformed_count,
+                    len(real_pages),
+                )
+        else:
+            # Truly empty files[] (or missing filings block) → sentinel.
+            # The malformed-only case is handled above.
+            cur.execute(
+                "INSERT INTO sec_cik_submissions_files_index "
+                "(cik, page_name, bootstrap_run_id, populate_origin) "
+                "VALUES (%s, %s, %s, %s)",
+                (cik, _SIDECAR_SENTINEL_PAGE_NAME, bootstrap_run_id, origin),
+            )
+    result.ciks_sidecared += 1
 
 
 def _load_cik_to_instrument(
@@ -115,6 +268,13 @@ def ingest_submissions_archive(
     if cik_to_instrument is None:
         cik_to_instrument = _load_cik_to_instrument(conn)
 
+    # Stream A PR-B T1.3 (#1233): captured once per archive ingest so
+    # the per-CIK sidecar writer threads run-lineage without re-
+    # querying for every entry. ``None`` when running outside a tracked
+    # bootstrap (steady-state refresh) — writer stores NULL bootstrap_run_id
+    # + ``populate_origin='steady_state'``.
+    bootstrap_run_id = _load_current_bootstrap_run_id(conn)
+
     result = SubmissionsIngestResult(
         archive_entries_seen=0,
         instruments_matched=0,
@@ -153,6 +313,22 @@ def ingest_submissions_archive(
                         logger.debug("submissions ingest: bad payload for %s: %s", entry_name, exc)
                         result.parse_errors += 1
                         raise _SkipEntry from exc
+
+                    # Stream A PR-B T1.3 (#1233): refresh sidecar ONCE
+                    # PER CIK in the OUTER block (not inside _ingest_one
+                    # — that would re-DELETE+INSERT N times for share-
+                    # class siblings, per Codex 1 re-pass IMPORTANT).
+                    # Atomicity: the surrounding ``with conn.transaction()``
+                    # gives "DELETE rolls back if any sibling write
+                    # raises" so the sidecar is always consistent with
+                    # the rest of the per-CIK ingest.
+                    _refresh_cik_sidecar(
+                        conn,
+                        cik=cik,
+                        payload=payload,
+                        bootstrap_run_id=bootstrap_run_id,
+                        result=result,
+                    )
 
                     for instrument_id, symbol in matched_instruments:
                         result.instruments_matched += 1

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1509,3 +1509,21 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Prevention: `refreshed_at` (and any update-timestamp column the writer mutates on every call) MUST be EXCLUDED from the diff predicate on both LHS and RHS. The drift watermark for the repair-sweep MUST live in a separate side-table (e.g. `ownership_refresh_state.last_drained_observations_max_ingested_at`) updated on every refresh attempt regardless of MERGE outcome. The watermark value MUST be captured pre-MERGE in a Python variable (race-safe: prevents the post-MERGE UPSERT advancing past observations the MERGE did not see if new obs land between SELECT and MERGE).
 - Generalises to: any diff-aware reconciler (`UPSERT … WHERE EXCLUDED.x IS DISTINCT FROM …`, materialised-view refresh diffs, cache-revalidation predicates). Whenever the predicate compares "what's stored" to "what we just computed", any column the writer mutates on every call must be excluded from the comparison — otherwise the comparison is vacuously true and the optimisation is defeated.
 - Enforced in: `scripts/check_ownership_refresh_writer_pattern.sh` invariant E (refreshed_at not in IS DISTINCT FROM tuples) + invariant I (refreshed_at = now() lives only in UPDATE SET); `tests/test_ownership_refresh_writer_merge.py` case 2 (no-op churn — xmin stability + pgstattuple dead-tuple delta + refreshed_at unchanged) + case 8 (repair-sweep no-loop) + case 9 (known_to expiry watermark alignment); `docs/superpowers/specs/2026-05-21-pr12-ownership-current-writer-merge.md` §3.3 + §4.2; this prevention log.
+
+### Integration tests must use DELTA-based counter assertions, never exact-equality on DB-global counters
+
+- First seen in: 2026-05-24 — #1233 PR-B (PR #1308) bot review iter 1 BLOCKING. Tests in `tests/test_s14_uses_sidecar.py` called `walk_files_pages(conn=ebull_test_conn)` (which iterates EVERY in-universe CIK in the per-worker test DB) and asserted `result.parse_errors == 0`, `result.secondary_pages_fetched == 0`, etc. Any other tradable CIK in the test DB with an empty sidecar would inflate `parse_errors` + `ciks_with_empty_sidecar` and cause spurious failure.
+- Symptom: per-worker test DB picks up `bf719c5`'s prior test residue (or any concurrent test's side effect) — exact-equality assertion fails on a counter that includes rows outside the test's control. Test is green locally on a freshly-wiped DB; fails in CI / on a polluted DB. Classic flake-vector class.
+- Prevention: any integration test that calls a function iterating the full DB cohort MUST use DELTA-based assertions:
+  ```python
+  baseline = walk_files_pages(conn=ebull_test_conn)
+  _seed_test_data(ebull_test_conn)
+  try:
+      after = walk_files_pages(conn=ebull_test_conn)
+      assert after.counter_x - baseline.counter_x == EXPECTED_DELTA
+  finally:
+      _wipe_test_data(ebull_test_conn)
+  ```
+  OR use `>= N` / `<= N` bounds (less precise but acceptable for "at least this happened"); NEVER `== 0` / `== N` on accumulators that include rows outside the test's control.
+- Generalises to: any integration test against a shared per-worker test DB where the function under test iterates rows beyond the fixture-seeded set (`walk_files_pages`, `sync_all_observations`, `compute_coverage_audit`, etc.). The delta pattern is the canonical fix.
+- Enforced in: this prevention log; future bot review will catch on PR-B-style test additions; `.claude/skills/engineering/test-quality.md` should add a "DB-global counter exact-equality forbidden" rule (follow-up tightening).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ dev = [
   "pytest-xdist>=3.5",
   "pytest-testmon>=2.2",
   "httpx>=0.27.0",
+  # Stream A PR-B T1.3 (#1233): contract test for
+  # sec_submissions_files_walk (S14) asserts ZERO PRIMARY-page HTTP
+  # calls when the sidecar is populated. respx mocks httpx at the
+  # transport layer — smallest primitive that satisfies the contract.
+  "respx>=0.21",
 ]
 
 [tool.ruff]

--- a/sql/172_sec_cik_submissions_files_index.sql
+++ b/sql/172_sec_cik_submissions_files_index.sql
@@ -1,0 +1,128 @@
+-- 172_sec_cik_submissions_files_index.sql
+--
+-- Stream A PR-B T1.3 (#1233): sidecar table for SEC submissions
+-- ``filings.files[]`` page-descriptor enumeration.
+--
+-- WHAT IT REPLACES
+-- ----------------
+-- Pre-PR-B, ``sec_submissions_files_walk`` (S14) re-fetches each
+-- CIK's primary ``data.sec.gov/submissions/CIK<10>.json`` JUST to
+-- read ``filings.files[]`` again — even though ``sec_submissions_ingest``
+-- (S8) already read that same JSON from ``submissions.zip`` minutes
+-- earlier. At Run #7 cohort sizes (~8.7k CIK post-#1222) this is
+-- ~5,105 redundant primary HTTP calls / ~12 min wall-clock at SEC's
+-- 7 req/s budget.
+--
+-- WHAT IT ADDS
+-- ------------
+-- One row per (cik, secondary-page-name) populated by S8 during the
+-- per-CIK transaction at ``sec_submissions_ingest.py:147`` from the
+-- in-memory submissions payload. S14 consumes the sidecar instead
+-- of re-fetching the primary; secondary-page bodies are still
+-- fetched over HTTP (they are NOT in the bulk archive — confirmed
+-- at ``sec_submissions_files_walk.py:1-7`` docstring).
+--
+-- SENTINEL ROW PATTERN
+-- --------------------
+-- A CIK with ZERO overflow pages (e.g. AAPL — ``recent`` array fits
+-- under the 1000-cap) writes ONE sentinel row with
+-- ``page_name='__no_overflow_pages__'`` instead of zero rows. This
+-- distinguishes "CIK processed; no overflow" from "CIK not yet
+-- populated". S14 + the Stream-C C7 gate honour this explicitly:
+--
+--   sidecar state for CIK X        | meaning              | S14 / C7 action
+--   ------------------------------ | -------------------- | ---------------
+--   1+ real-page rows              | overflow exists      | walk pages
+--   exactly 1 sentinel row         | processed; no over-  | skip walk
+--                                  | flow                 | (C7 passes)
+--   zero rows                      | not yet populated    | S14 fail-closed;
+--                                  |                      | C7 fails
+--
+-- Without the sentinel, AAPL (0 overflow) and a never-populated CIK
+-- look identical; either C7 false-fails everyone or S14 silently
+-- does nothing for valid CIKs.
+--
+-- AGENT-CIK FILTER
+-- ----------------
+-- The populate path (S8) skips CIKs in
+-- ``KNOWN_FILING_AGENT_CIKS`` (``app/providers/implementations/sec_edgar.py``)
+-- so the sidecar stays a "real-filer-only" index. S14 + C7 know to
+-- expect zero rows for agent CIKs; they are NOT in the populated
+-- set.
+--
+-- PER-CIK DELETE + INSERT
+-- -----------------------
+-- Idempotent rebuild per S8 ingest of that CIK. NOT a global
+-- TRUNCATE — S8 is per-CIK at the transaction level; global TRUNCATE
+-- would leave the sidecar empty between CIK 1 and CIK N during a
+-- long-running ingest, breaking S14 fail-closed semantics for all
+-- not-yet-processed CIKs. On per-CIK transaction rollback (INSERT
+-- raises mid-CIK), the DELETE rolls back too — prior committed rows
+-- for that CIK SURVIVE.
+--
+-- INDEX BUDGET
+-- ------------
+-- 1 index (PK only). PG B-tree handles cik-only equality + range
+-- via PK prefix scan; a standalone ``cik`` index would be dead
+-- weight.
+--
+-- Spec: docs/proposals/etl/stream-a-run-8-fixes.md v2.3 §4 + §14
+-- (post-Codex-1 re-pass + 3-lens code review 2026-05-24).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS sec_cik_submissions_files_index (
+    -- 10-digit zero-padded CIK (CHECK-enforced).
+    cik              TEXT       NOT NULL,
+    -- Either a sentinel ``__no_overflow_pages__`` OR a SEC overflow
+    -- page name shaped ``CIKnnnnnnnnnn-submissions-nnn.json``
+    -- (CHECK-enforced via disjunction).
+    page_name        TEXT       NOT NULL,
+    -- Inclusive date range covered by the page; NULL for sentinel.
+    filing_from      DATE,
+    filing_to        DATE,
+    -- Wall-clock stamp of the row write. ``clock_timestamp()``
+    -- (NOT ``NOW()`` / ``transaction_timestamp()``) per
+    -- ``.claude/skills/data-engineer/SKILL.md`` §6.5.8 — avoids
+    -- artificially-old stamps if a future caller hoists the write
+    -- into a longer-running transaction.
+    discovered_at    TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    -- Bootstrap-run lineage. NULL when populated by a steady-state
+    -- S8 refresh (outside a tracked bootstrap_runs row). FK on
+    -- ``id`` (NOT ``run_id`` — verified at sql/129:66).
+    bootstrap_run_id BIGINT     REFERENCES bootstrap_runs(id) ON DELETE SET NULL,
+    -- Audit-lineage discriminator. Distinguishes "NULL bootstrap_run_id
+    -- because steady-state refresh" (origin='steady_state') from
+    -- "NULL bootstrap_run_id because buggy code path forgot to thread
+    -- it" (origin='bootstrap' + NULL run id = violation worth noting).
+    populate_origin  TEXT       NOT NULL DEFAULT 'bootstrap'
+                                CHECK (populate_origin IN ('bootstrap', 'steady_state')),
+    PRIMARY KEY (cik, page_name),
+    -- CIK shape: 10 digits, zero-padded. Single regex CHECK is
+    -- cheap and pre-empts a future writer inserting unpadded.
+    CHECK (cik ~ '^[0-9]{10}$'),
+    -- Page-name shape: either sentinel OR tight regex matching the
+    -- actual SEC overflow-page naming convention. ``LIKE`` patterns
+    -- were too loose — they admitted garbage like ``CIK-submissions-.json``.
+    CHECK (
+        page_name = '__no_overflow_pages__'
+        OR page_name ~ '^CIK[0-9]{10}-submissions-[0-9]{3}\.json$'
+    ),
+    -- Real-page rows MUST have both date columns populated;
+    -- sentinel rows MUST have both NULL. Composite CHECK pins the
+    -- disjunction so a partial-population bug can't slip past.
+    CHECK (
+        (page_name = '__no_overflow_pages__' AND filing_from IS NULL AND filing_to IS NULL)
+        OR (
+            page_name <> '__no_overflow_pages__'
+            AND filing_from IS NOT NULL
+            AND filing_to IS NOT NULL
+            AND filing_from <= filing_to
+        )
+    )
+);
+
+COMMENT ON TABLE sec_cik_submissions_files_index IS
+    'Sidecar cache of SEC submissions filings.files[] page descriptors per CIK (#1233 Stream A PR-B). Populated by sec_submissions_ingest (S8) during per-CIK ingest; consumed by sec_submissions_files_walk (S14) instead of re-fetching primary submissions.json. SINGLE-WRITER: S8 only. Sentinel-row pattern (page_name=__no_overflow_pages__) distinguishes "processed, no overflow" from "not yet populated".';
+
+COMMIT;

--- a/sql/173_bootstrap_runs_stream_c_gate.sql
+++ b/sql/173_bootstrap_runs_stream_c_gate.sql
@@ -54,8 +54,10 @@ ALTER TABLE bootstrap_runs
         OR stream_c_gate_status IN ('pending', 'passed')
         OR (
             -- Literal underscore + ≥1 trailing char. Rejects bare 'failed_'
-            -- (Codex 2 LOW pre-push review). ESCAPE '\\' makes '\_' a
-            -- literal underscore, not a LIKE wildcard.
+            -- (Codex 2 LOW pre-push review). ESCAPE '\' makes '\_' a
+            -- literal underscore, not a LIKE wildcard. (Single backslash
+            -- under PG default standard_conforming_strings=on; do NOT
+            -- double-escape — bot review iter 1 nitpick.)
             stream_c_gate_status LIKE 'failed\_%' ESCAPE '\'
             AND length(stream_c_gate_status) > length('failed_')
         )

--- a/sql/173_bootstrap_runs_stream_c_gate.sql
+++ b/sql/173_bootstrap_runs_stream_c_gate.sql
@@ -1,0 +1,80 @@
+-- 173_bootstrap_runs_stream_c_gate.sql
+--
+-- Stream A PR-B T1.3 / §1.8 (#1233): operator-attestation columns
+-- on bootstrap_runs for the Stream-C correctness gate runbook.
+--
+-- WHAT IT ADDS
+-- ------------
+--   * ``stream_c_gate_status`` TEXT — status of the 7-check
+--     post-bootstrap acceptance runbook (``app/cli/runbooks/
+--     stream_a_stream_c_gate.py``, ships in PR-D). Status values:
+--       - NULL                  : gate never run for this bootstrap.
+--       - 'pending'             : gate started, not yet decided.
+--       - 'passed'              : all 7 checks passed (or warned).
+--       - 'failed_<check_id>'   : one specific check failed; suffix
+--                                 names the failing C1-C7 check.
+--     CHECK uses LIKE 'failed\_%' ESCAPE '\' — literal underscore,
+--     not LIKE wildcard (Codex 1 re-pass BLOCKING). Without the
+--     ESCAPE clause, ``failedX...`` would match and admit garbage.
+--
+--   * ``coverage_floor_ratio`` NUMERIC(5,4) — measured CUSIP
+--     coverage ratio at S13 OpenFIGI sweep completion. The
+--     existing ``coverage_floor_met`` BOOLEAN (sql/167) is a
+--     point-in-time decision against a hard-coded 0.80 threshold;
+--     storing the ratio alongside the boolean lets operators
+--     retroactively answer "what was coverage at Run-N?" after any
+--     future threshold revision without re-running bootstrap.
+--
+-- BOTH COLUMNS ARE NULLABLE — historical bootstrap_runs rows pre-
+-- migration carry NULL; new rows default NULL (populated only when
+-- the relevant pipeline step runs).
+--
+-- Idempotent: ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS`` + named
+-- ``DROP CONSTRAINT IF EXISTS`` + ``ADD CONSTRAINT`` for the CHECK.
+-- Safe to re-apply.
+--
+-- Spec: docs/proposals/etl/stream-a-run-8-fixes.md v2.3 §4 + §16 + §1.8
+-- (Stream A v2.3, post-Codex-1 re-pass + 3-lens code review 2026-05-24).
+
+BEGIN;
+
+ALTER TABLE bootstrap_runs
+    ADD COLUMN IF NOT EXISTS stream_c_gate_status TEXT;
+
+ALTER TABLE bootstrap_runs
+    ADD COLUMN IF NOT EXISTS coverage_floor_ratio NUMERIC(5,4);
+
+ALTER TABLE bootstrap_runs
+    DROP CONSTRAINT IF EXISTS bootstrap_runs_stream_c_gate_status_check;
+
+ALTER TABLE bootstrap_runs
+    ADD CONSTRAINT bootstrap_runs_stream_c_gate_status_check
+    CHECK (
+        stream_c_gate_status IS NULL
+        OR stream_c_gate_status IN ('pending', 'passed')
+        OR (
+            -- Literal underscore + ≥1 trailing char. Rejects bare 'failed_'
+            -- (Codex 2 LOW pre-push review). ESCAPE '\\' makes '\_' a
+            -- literal underscore, not a LIKE wildcard.
+            stream_c_gate_status LIKE 'failed\_%' ESCAPE '\'
+            AND length(stream_c_gate_status) > length('failed_')
+        )
+    );
+
+ALTER TABLE bootstrap_runs
+    DROP CONSTRAINT IF EXISTS bootstrap_runs_coverage_floor_ratio_range_check;
+
+ALTER TABLE bootstrap_runs
+    ADD CONSTRAINT bootstrap_runs_coverage_floor_ratio_range_check
+    CHECK (
+        coverage_floor_ratio IS NULL
+        OR (coverage_floor_ratio >= 0 AND coverage_floor_ratio <= 1)
+    );
+
+COMMENT ON COLUMN bootstrap_runs.stream_c_gate_status IS
+    'Status of the Stream-C correctness gate runbook (#1233 Stream A §1.8). NULL = never run; pending / passed / failed_<check_id> (literal underscore via ESCAPE; bare "failed_" rejected).';
+
+COMMENT ON COLUMN bootstrap_runs.coverage_floor_ratio IS
+    'Measured CUSIP coverage ratio at S13 OpenFIGI sweep completion (NUMERIC(5,4); range CHECK enforces [0, 1]). Sibling of coverage_floor_met BOOLEAN (sql/167); preserved for retroactive threshold-change analysis without re-running bootstrap.';
+
+COMMIT;

--- a/tests/test_s14_uses_sidecar.py
+++ b/tests/test_s14_uses_sidecar.py
@@ -1,0 +1,233 @@
+"""Tests for ``app.services.sec_submissions_files_walk.walk_files_pages``
+(Stream A PR-B T1.3, #1233) — the S14 sidecar consumer that REPLACED the
+pre-PR-B "re-fetch primary submissions.json per CIK" behaviour.
+
+Covers:
+  * Sidecar-empty → ``ciks_with_empty_sidecar`` + ``parse_errors`` both
+    increment for an in-universe CIK that is NOT an agent.
+  * Sidecar with only sentinel → ``ciks_with_no_overflow`` increments;
+    no HTTP issued; ``parse_errors`` stays 0.
+  * Sidecar with real pages → secondary pages fetched (HTTP); fixture
+    accessions appended to filing_events.
+  * Agent CIK with empty sidecar (expected) → silently skipped; NEITHER
+    ``parse_errors`` NOR ``ciks_with_empty_sidecar`` increments.
+  * Contract: ZERO PRIMARY ``data.sec.gov/submissions/CIK<10>.json``
+    HTTP calls when the sidecar is populated. Pinned via ``respx`` at
+    the httpx transport layer so a future caller bypassing
+    ``SecFilingsProvider`` would still trip the assertion.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import psycopg
+import psycopg.rows
+import pytest
+import respx
+from httpx import Response
+
+from app.providers.implementations.sec_edgar import KNOWN_FILING_AGENT_CIKS
+from app.services.sec_submissions_files_walk import walk_files_pages
+
+_REAL_CIK = "0009999998"
+_REAL_SYMBOL = "STREAMA"
+_OVERFLOW_PAGE = f"CIK{_REAL_CIK}-submissions-001.json"
+
+
+def _wipe_test_instrument(conn: psycopg.Connection[tuple]) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM sec_cik_submissions_files_index WHERE cik = %s", (_REAL_CIK,))
+        cur.execute(
+            "DELETE FROM external_identifiers "
+            "WHERE provider = 'sec' AND identifier_type = 'cik' AND identifier_value = %s",
+            (_REAL_CIK,),
+        )
+        cur.execute("DELETE FROM instruments WHERE symbol = %s", (_REAL_SYMBOL,))
+    conn.commit()
+
+
+def _seed_test_instrument(conn: psycopg.Connection[tuple]) -> int:
+    """``instruments.instrument_id`` is BIGINT PRIMARY KEY (no DEFAULT,
+    no sequence — manually assigned per sql/001:2). Allocate one
+    above the current MAX so we don't clash with prod-like data the
+    test DB may already carry."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(instrument_id), 0) FROM instruments")
+        row = cur.fetchone()
+        assert row is not None
+        iid = int(row[0]) + 1
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable) "
+            "VALUES (%s, %s, %s, %s, TRUE)",
+            (iid, _REAL_SYMBOL, "Stream A Test Co.", "NASDAQ"),
+        )
+        cur.execute(
+            "INSERT INTO external_identifiers "
+            "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (%s, 'sec', 'cik', %s, TRUE)",
+            (iid, _REAL_CIK),
+        )
+    conn.commit()
+    return iid
+
+
+def _insert_sidecar(
+    conn: psycopg.Connection[tuple],
+    *,
+    cik: str,
+    pages: list[tuple[str, str | None, str | None]],
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM sec_cik_submissions_files_index WHERE cik = %s", (cik,))
+        for name, ff, ft in pages:
+            cur.execute(
+                "INSERT INTO sec_cik_submissions_files_index "
+                "(cik, page_name, filing_from, filing_to, bootstrap_run_id, populate_origin) "
+                "VALUES (%s, %s, %s, %s, NULL, 'steady_state')",
+                (cik, name, ff, ft),
+            )
+    conn.commit()
+
+
+@pytest.fixture
+def s14_test_instrument(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> Iterator[int]:
+    _wipe_test_instrument(ebull_test_conn)
+    iid = _seed_test_instrument(ebull_test_conn)
+    yield iid
+    _wipe_test_instrument(ebull_test_conn)
+
+
+class TestS14SidecarConsume:
+    @pytest.mark.integration
+    def test_empty_sidecar_for_in_universe_cik_is_parse_error(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        s14_test_instrument: int,
+    ) -> None:
+        # No sidecar row inserted — empty.
+        result = walk_files_pages(conn=ebull_test_conn)
+
+        assert result.ciks_with_empty_sidecar >= 1
+        assert result.parse_errors >= 1
+        assert result.secondary_pages_fetched == 0  # never reached HTTP
+
+    @pytest.mark.integration
+    def test_sentinel_row_skips_secondary_walk_silently(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        s14_test_instrument: int,
+    ) -> None:
+        _insert_sidecar(
+            ebull_test_conn,
+            cik=_REAL_CIK,
+            pages=[("__no_overflow_pages__", None, None)],
+        )
+
+        result = walk_files_pages(conn=ebull_test_conn)
+
+        assert result.ciks_with_no_overflow >= 1
+        # No HTTP — the sentinel branch never enters the fetch loop.
+        assert result.secondary_pages_fetched == 0
+        # Sentinel-only is NOT an error.
+        assert result.ciks_with_empty_sidecar == 0
+
+    @pytest.mark.integration
+    def test_agent_cik_with_empty_sidecar_is_not_an_error(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """An agent CIK in the universe with no sidecar row is EXPECTED
+        (populate filters them out). Must NOT increment parse_errors
+        or ciks_with_empty_sidecar."""
+        agent_cik = next(iter(KNOWN_FILING_AGENT_CIKS))
+        _wipe_test_instrument(ebull_test_conn)
+
+        # Seed instrument with the agent CIK.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT COALESCE(MAX(instrument_id), 0) FROM instruments")
+            row = cur.fetchone()
+            assert row is not None
+            iid = int(row[0]) + 1
+            cur.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name, exchange, is_tradable) "
+                "VALUES (%s, %s, %s, %s, TRUE)",
+                (iid, _REAL_SYMBOL, "Agent CIK Test Co.", "NASDAQ"),
+            )
+            cur.execute(
+                "INSERT INTO external_identifiers "
+                "(instrument_id, provider, identifier_type, identifier_value, is_primary) "
+                "VALUES (%s, 'sec', 'cik', %s, TRUE)",
+                (iid, agent_cik),
+            )
+        ebull_test_conn.commit()
+
+        try:
+            result = walk_files_pages(conn=ebull_test_conn)
+            assert result.ciks_with_empty_sidecar == 0, "agent CIK empty sidecar must NOT count as error"
+            assert result.parse_errors == 0
+            assert result.secondary_pages_fetched == 0
+        finally:
+            with ebull_test_conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM external_identifiers "
+                    "WHERE provider = 'sec' AND identifier_type = 'cik' AND identifier_value = %s",
+                    (agent_cik,),
+                )
+                cur.execute("DELETE FROM instruments WHERE symbol = %s", (_REAL_SYMBOL,))
+            ebull_test_conn.commit()
+
+
+class TestS14ZeroPrimaryHttpContract:
+    """Pinned contract: ``walk_files_pages`` MUST issue ZERO HTTP calls
+    to the primary ``data.sec.gov/submissions/CIK<10>.json`` URL when
+    the sidecar is populated. Asserted at the httpx transport layer
+    via respx so a future code path that bypasses ``SecFilingsProvider``
+    would still trip the test."""
+
+    @pytest.mark.integration
+    def test_no_primary_fetch_when_sidecar_has_real_pages(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        s14_test_instrument: int,
+    ) -> None:
+        _insert_sidecar(
+            ebull_test_conn,
+            cik=_REAL_CIK,
+            pages=[(_OVERFLOW_PAGE, "2010-01-15", "2012-06-30")],
+        )
+
+        # respx registers wire-level mocks. We register:
+        #   * the secondary page URL → 200 with a minimal-shape body
+        #     so _normalise_submissions_block returns 0 filings (no
+        #     filing_events writes needed for the contract test).
+        #   * an explicit assert-not-called on the primary URL.
+        primary_url = f"https://data.sec.gov/submissions/CIK{_REAL_CIK}.json"
+        secondary_url = f"https://data.sec.gov/submissions/{_OVERFLOW_PAGE}"
+
+        empty_secondary_body: dict[str, Any] = {
+            "filings": {
+                "accessionNumber": [],
+                "filingDate": [],
+                "form": [],
+                "acceptanceDateTime": [],
+                "primaryDocument": [],
+            },
+        }
+
+        with respx.mock(assert_all_called=False) as mock:
+            primary_route = mock.get(primary_url).mock(return_value=Response(200, json={}))
+            mock.get(secondary_url).mock(return_value=Response(200, json=empty_secondary_body))
+
+            result = walk_files_pages(conn=ebull_test_conn)
+
+        # The load-bearing assertion — primary URL was NEVER hit.
+        assert primary_route.call_count == 0, (
+            f"S14 issued {primary_route.call_count} PRIMARY {primary_url} fetch(es); "
+            "sidecar exists so the primary refetch contract is violated"
+        )
+        # secondary_pages_fetched should reflect the real fetch via respx.
+        assert result.secondary_pages_fetched >= 1

--- a/tests/test_s14_uses_sidecar.py
+++ b/tests/test_s14_uses_sidecar.py
@@ -102,38 +102,55 @@ def s14_test_instrument(
 
 
 class TestS14SidecarConsume:
+    """All assertions use DELTA against a BASELINE call so the tests are
+    robust to other rows in the shared per-worker test DB (per PR #1308
+    review bot BLOCKING — exact equality on DB-global counters is a
+    flake vector on any non-empty test DB)."""
+
     @pytest.mark.integration
     def test_empty_sidecar_for_in_universe_cik_is_parse_error(
         self,
         ebull_test_conn: psycopg.Connection[tuple],
-        s14_test_instrument: int,
     ) -> None:
-        # No sidecar row inserted — empty.
-        result = walk_files_pages(conn=ebull_test_conn)
+        # Capture baseline FIRST, before seeding the test instrument,
+        # so the delta reflects only our row's contribution.
+        baseline = walk_files_pages(conn=ebull_test_conn)
+        _wipe_test_instrument(ebull_test_conn)
+        _seed_test_instrument(ebull_test_conn)
+        try:
+            # No sidecar row inserted for _REAL_CIK — empty sidecar branch.
+            after = walk_files_pages(conn=ebull_test_conn)
 
-        assert result.ciks_with_empty_sidecar >= 1
-        assert result.parse_errors >= 1
-        assert result.secondary_pages_fetched == 0  # never reached HTTP
+            assert after.ciks_with_empty_sidecar - baseline.ciks_with_empty_sidecar == 1
+            assert after.parse_errors - baseline.parse_errors == 1
+            assert after.secondary_pages_fetched == baseline.secondary_pages_fetched
+        finally:
+            _wipe_test_instrument(ebull_test_conn)
 
     @pytest.mark.integration
     def test_sentinel_row_skips_secondary_walk_silently(
         self,
         ebull_test_conn: psycopg.Connection[tuple],
-        s14_test_instrument: int,
     ) -> None:
-        _insert_sidecar(
-            ebull_test_conn,
-            cik=_REAL_CIK,
-            pages=[("__no_overflow_pages__", None, None)],
-        )
+        baseline = walk_files_pages(conn=ebull_test_conn)
+        _wipe_test_instrument(ebull_test_conn)
+        _seed_test_instrument(ebull_test_conn)
+        try:
+            _insert_sidecar(
+                ebull_test_conn,
+                cik=_REAL_CIK,
+                pages=[("__no_overflow_pages__", None, None)],
+            )
+            after = walk_files_pages(conn=ebull_test_conn)
 
-        result = walk_files_pages(conn=ebull_test_conn)
-
-        assert result.ciks_with_no_overflow >= 1
-        # No HTTP — the sentinel branch never enters the fetch loop.
-        assert result.secondary_pages_fetched == 0
-        # Sentinel-only is NOT an error.
-        assert result.ciks_with_empty_sidecar == 0
+            assert after.ciks_with_no_overflow - baseline.ciks_with_no_overflow == 1
+            # Sentinel branch never enters the fetch loop.
+            assert after.secondary_pages_fetched == baseline.secondary_pages_fetched
+            # Sentinel-only is NOT an error.
+            assert after.ciks_with_empty_sidecar == baseline.ciks_with_empty_sidecar
+            assert after.parse_errors == baseline.parse_errors
+        finally:
+            _wipe_test_instrument(ebull_test_conn)
 
     @pytest.mark.integration
     def test_agent_cik_with_empty_sidecar_is_not_an_error(
@@ -142,9 +159,12 @@ class TestS14SidecarConsume:
     ) -> None:
         """An agent CIK in the universe with no sidecar row is EXPECTED
         (populate filters them out). Must NOT increment parse_errors
-        or ciks_with_empty_sidecar."""
+        or ciks_with_empty_sidecar. Delta-based assertions (per PR #1308
+        review bot BLOCKING)."""
         agent_cik = next(iter(KNOWN_FILING_AGENT_CIKS))
         _wipe_test_instrument(ebull_test_conn)
+
+        baseline = walk_files_pages(conn=ebull_test_conn)
 
         # Seed instrument with the agent CIK.
         with ebull_test_conn.cursor() as cur:
@@ -166,10 +186,17 @@ class TestS14SidecarConsume:
         ebull_test_conn.commit()
 
         try:
-            result = walk_files_pages(conn=ebull_test_conn)
-            assert result.ciks_with_empty_sidecar == 0, "agent CIK empty sidecar must NOT count as error"
-            assert result.parse_errors == 0
-            assert result.secondary_pages_fetched == 0
+            after = walk_files_pages(conn=ebull_test_conn)
+            # Delta on the three counters that the agent-CIK branch
+            # must NOT touch — robust to any other rows in the test DB.
+            assert (
+                after.ciks_with_empty_sidecar == baseline.ciks_with_empty_sidecar
+            ), "agent CIK empty sidecar must NOT count as error"
+            assert after.parse_errors == baseline.parse_errors
+            assert after.secondary_pages_fetched == baseline.secondary_pages_fetched
+            # And ciks_visited must NOT increment for the agent CIK
+            # (Architect IMPORTANT — guard fires before counter).
+            assert after.ciks_visited == baseline.ciks_visited
         finally:
             with ebull_test_conn.cursor() as cur:
                 cur.execute(

--- a/tests/test_s14_uses_sidecar.py
+++ b/tests/test_s14_uses_sidecar.py
@@ -112,10 +112,12 @@ class TestS14SidecarConsume:
         self,
         ebull_test_conn: psycopg.Connection[tuple],
     ) -> None:
-        # Capture baseline FIRST, before seeding the test instrument,
-        # so the delta reflects only our row's contribution.
-        baseline = walk_files_pages(conn=ebull_test_conn)
+        # WIPE FIRST so a dirty _REAL_CIK row left by a killed prior
+        # run doesn't get counted in baseline; then capture baseline;
+        # then seed + measure delta (bot review iter 2 WARNING — baseline-
+        # before-wipe was a flake vector).
         _wipe_test_instrument(ebull_test_conn)
+        baseline = walk_files_pages(conn=ebull_test_conn)
         _seed_test_instrument(ebull_test_conn)
         try:
             # No sidecar row inserted for _REAL_CIK — empty sidecar branch.
@@ -132,8 +134,9 @@ class TestS14SidecarConsume:
         self,
         ebull_test_conn: psycopg.Connection[tuple],
     ) -> None:
-        baseline = walk_files_pages(conn=ebull_test_conn)
+        # Wipe BEFORE baseline (bot review iter 2 WARNING).
         _wipe_test_instrument(ebull_test_conn)
+        baseline = walk_files_pages(conn=ebull_test_conn)
         _seed_test_instrument(ebull_test_conn)
         try:
             _insert_sidecar(
@@ -189,9 +192,9 @@ class TestS14SidecarConsume:
             after = walk_files_pages(conn=ebull_test_conn)
             # Delta on the three counters that the agent-CIK branch
             # must NOT touch — robust to any other rows in the test DB.
-            assert (
-                after.ciks_with_empty_sidecar == baseline.ciks_with_empty_sidecar
-            ), "agent CIK empty sidecar must NOT count as error"
+            assert after.ciks_with_empty_sidecar == baseline.ciks_with_empty_sidecar, (
+                "agent CIK empty sidecar must NOT count as error"
+            )
             assert after.parse_errors == baseline.parse_errors
             assert after.secondary_pages_fetched == baseline.secondary_pages_fetched
             # And ciks_visited must NOT increment for the agent CIK

--- a/tests/test_sec_cik_submissions_files_index.py
+++ b/tests/test_sec_cik_submissions_files_index.py
@@ -63,11 +63,24 @@ def _wipe_test_cik(conn: psycopg.Connection[tuple]) -> None:
 
 @pytest.fixture
 def guard_conn() -> Iterator[psycopg.Connection[tuple]]:
-    """Autocommit connection to the per-worker test DB — matches the
-    shape that production callers use (each ``_refresh_cik_sidecar``
-    site runs inside an outer ``with conn.transaction()`` block; the
-    guard conn here is a single-tx-per-call substitute fine for
-    deterministic test assertions)."""
+    """Autocommit connection to the per-worker test DB — DIVERGES FROM
+    PRODUCTION semantics (per PR #1308 review bot iter 2 WARNING).
+
+    Production callers always wrap ``_refresh_cik_sidecar`` in
+    ``with conn.transaction()`` (sec_submissions_ingest.py:148-176) so
+    DELETE + INSERT are atomic per-CIK: an INSERT failure rolls back
+    the DELETE and prior committed sidecar rows for that CIK SURVIVE.
+
+    Under THIS fixture's autocommit, the DELETE commits before the
+    INSERT runs; an INSERT failure leaves the CIK with zero rows.
+    The atomicity contract is therefore NOT exercised here — the
+    dedicated test ``TestSidecarPerCikSavepointAtomicity`` uses the
+    transactional ``ebull_test_conn`` fixture for that.
+
+    This fixture is fine for tests that only verify the WRITER's
+    output shape under successful execution (sentinel vs real-pages,
+    populate_origin, idempotent re-runs) — NOT for atomicity tests.
+    """
     conn = psycopg.connect(test_database_url(), autocommit=True)
     try:
         yield conn

--- a/tests/test_sec_cik_submissions_files_index.py
+++ b/tests/test_sec_cik_submissions_files_index.py
@@ -1,0 +1,421 @@
+"""Tests for ``app.services.sec_submissions_ingest._refresh_cik_sidecar``
+(Stream A PR-B T1.3, #1233) — the sidecar populate path that writes
+``sec_cik_submissions_files_index`` rows per CIK.
+
+Covers:
+  * Agent-CIK filter — sidecar is "real-filer-only" index.
+  * Sentinel-row pattern when files[] is empty.
+  * Real-page rows when files[] has overflow entries.
+  * Per-CIK DELETE + INSERT idempotency (re-running on same CIK
+    leaves the sidecar in the same shape, even if new pages dropped).
+  * Malformed page-entry handling — skips bad entries, still
+    populates the good ones; fully-malformed list yields sentinel.
+  * ``populate_origin`` discriminator: ``bootstrap`` when run_id
+    present; ``steady_state`` when None.
+  * Per-CIK transaction atomicity — INSERT failure rolls back the
+    DELETE (prior committed sidecar state SURVIVES).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.providers.implementations.sec_edgar import KNOWN_FILING_AGENT_CIKS
+from app.services.sec_submissions_ingest import (
+    SubmissionsIngestResult,
+    _refresh_cik_sidecar,
+)
+from tests.fixtures.ebull_test_db import test_database_url
+
+_TEST_CIK = "0001234567"
+
+
+def _empty_result() -> SubmissionsIngestResult:
+    return SubmissionsIngestResult(
+        archive_entries_seen=0,
+        instruments_matched=0,
+        filings_upserted=0,
+        profiles_upserted=0,
+    )
+
+
+def _read_sidecar_rows(conn: psycopg.Connection[tuple], cik: str) -> list[dict[str, object]]:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT cik, page_name, filing_from, filing_to, bootstrap_run_id, populate_origin "
+            "FROM sec_cik_submissions_files_index "
+            "WHERE cik = %s "
+            "ORDER BY page_name",
+            (cik,),
+        )
+        return list(cur.fetchall())
+
+
+def _wipe_test_cik(conn: psycopg.Connection[tuple]) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM sec_cik_submissions_files_index WHERE cik = %s", (_TEST_CIK,))
+    conn.commit()
+
+
+@pytest.fixture
+def guard_conn() -> Iterator[psycopg.Connection[tuple]]:
+    """Autocommit connection to the per-worker test DB — matches the
+    shape that production callers use (each ``_refresh_cik_sidecar``
+    site runs inside an outer ``with conn.transaction()`` block; the
+    guard conn here is a single-tx-per-call substitute fine for
+    deterministic test assertions)."""
+    conn = psycopg.connect(test_database_url(), autocommit=True)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+class TestRefreshCikSidecar:
+    """Pure-function contract over the sidecar writer."""
+
+    @pytest.mark.integration
+    def test_agent_cik_filter_skips_sidecar_write(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """KNOWN_FILING_AGENT_CIKS rows MUST NOT be written. Sidecar is
+        a real-filer-only index per sql/172 header + §0.8 grep proof.
+
+        Cleanup wipes the agent-CIK row explicitly (NOT _TEST_CIK) so a
+        regression that writes a row leaves no flake-vector for the
+        next test in this worker (Reviewer + Architect IMPORTANT — both
+        lenses caught the prior cleanup mismatch).
+        """
+        agent_cik = next(iter(KNOWN_FILING_AGENT_CIKS))
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("DELETE FROM sec_cik_submissions_files_index WHERE cik = %s", (agent_cik,))
+        ebull_test_conn.commit()
+
+        try:
+            result = _empty_result()
+            _refresh_cik_sidecar(
+                ebull_test_conn,
+                cik=agent_cik,
+                payload={
+                    "filings": {
+                        "files": [
+                            {
+                                "name": f"CIK{agent_cik}-submissions-001.json",
+                                "filingFrom": "2020-01-01",
+                                "filingTo": "2020-12-31",
+                            }
+                        ]
+                    }
+                },
+                bootstrap_run_id=None,
+                result=result,
+            )
+            ebull_test_conn.commit()
+
+            rows = _read_sidecar_rows(ebull_test_conn, agent_cik)
+            assert rows == [], "agent CIK must produce zero sidecar rows"
+            assert result.ciks_sidecared == 0
+            assert result.sidecar_pages_indexed == 0
+        finally:
+            with ebull_test_conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM sec_cik_submissions_files_index WHERE cik = %s",
+                    (agent_cik,),
+                )
+            ebull_test_conn.commit()
+
+    @pytest.mark.integration
+    def test_writes_real_page_rows_when_files_present(
+        self,
+        guard_conn: psycopg.Connection[tuple],
+    ) -> None:
+        _wipe_test_cik(guard_conn)
+        payload = {
+            "filings": {
+                "files": [
+                    {
+                        "name": f"CIK{_TEST_CIK}-submissions-001.json",
+                        "filingFrom": "2010-01-15",
+                        "filingTo": "2012-06-30",
+                    },
+                    {
+                        "name": f"CIK{_TEST_CIK}-submissions-002.json",
+                        "filingFrom": "2012-07-01",
+                        "filingTo": "2015-03-31",
+                    },
+                ],
+            },
+        }
+        result = _empty_result()
+
+        _refresh_cik_sidecar(
+            guard_conn,
+            cik=_TEST_CIK,
+            payload=payload,
+            bootstrap_run_id=None,
+            result=result,
+        )
+
+        rows = _read_sidecar_rows(guard_conn, _TEST_CIK)
+        assert len(rows) == 2
+        assert {r["page_name"] for r in rows} == {
+            f"CIK{_TEST_CIK}-submissions-001.json",
+            f"CIK{_TEST_CIK}-submissions-002.json",
+        }
+        assert all(r["filing_from"] is not None and r["filing_to"] is not None for r in rows)
+        assert all(r["populate_origin"] == "steady_state" for r in rows)  # run_id was None
+        assert all(r["bootstrap_run_id"] is None for r in rows)
+        assert result.ciks_sidecared == 1
+        assert result.sidecar_pages_indexed == 2
+
+    @pytest.mark.integration
+    def test_writes_sentinel_when_files_empty(
+        self,
+        guard_conn: psycopg.Connection[tuple],
+    ) -> None:
+        _wipe_test_cik(guard_conn)
+        payload: dict[str, object] = {"filings": {"recent": {}, "files": []}}
+        result = _empty_result()
+
+        _refresh_cik_sidecar(
+            guard_conn,
+            cik=_TEST_CIK,
+            payload=payload,
+            bootstrap_run_id=None,
+            result=result,
+        )
+
+        rows = _read_sidecar_rows(guard_conn, _TEST_CIK)
+        assert len(rows) == 1
+        assert rows[0]["page_name"] == "__no_overflow_pages__"
+        assert rows[0]["filing_from"] is None
+        assert rows[0]["filing_to"] is None
+        assert rows[0]["populate_origin"] == "steady_state"
+        assert result.ciks_sidecared == 1
+        # Sentinel rows do NOT count toward sidecar_pages_indexed.
+        assert result.sidecar_pages_indexed == 0
+
+    @pytest.mark.integration
+    def test_writes_sentinel_when_filings_block_missing(
+        self,
+        guard_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """Defensive: payload with no ``filings`` key (rare but possible
+        for placeholder responses) still produces a sentinel — the CIK
+        was processed even though there was nothing to index."""
+        _wipe_test_cik(guard_conn)
+        result = _empty_result()
+
+        _refresh_cik_sidecar(
+            guard_conn,
+            cik=_TEST_CIK,
+            payload={},
+            bootstrap_run_id=None,
+            result=result,
+        )
+
+        rows = _read_sidecar_rows(guard_conn, _TEST_CIK)
+        assert len(rows) == 1
+        assert rows[0]["page_name"] == "__no_overflow_pages__"
+
+    @pytest.mark.integration
+    def test_per_cik_delete_then_insert_rebuilds_idempotently(
+        self,
+        guard_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """Second call with different files[] entries replaces the
+        first call's rows wholesale (not appends)."""
+        _wipe_test_cik(guard_conn)
+        first_payload = {
+            "filings": {
+                "files": [
+                    {
+                        "name": f"CIK{_TEST_CIK}-submissions-001.json",
+                        "filingFrom": "2010-01-15",
+                        "filingTo": "2012-06-30",
+                    },
+                ],
+            },
+        }
+        second_payload = {
+            "filings": {
+                "files": [
+                    {
+                        "name": f"CIK{_TEST_CIK}-submissions-002.json",
+                        "filingFrom": "2012-07-01",
+                        "filingTo": "2015-03-31",
+                    },
+                    {
+                        "name": f"CIK{_TEST_CIK}-submissions-003.json",
+                        "filingFrom": "2015-04-01",
+                        "filingTo": "2018-12-31",
+                    },
+                ],
+            },
+        }
+        result = _empty_result()
+        _refresh_cik_sidecar(guard_conn, cik=_TEST_CIK, payload=first_payload, bootstrap_run_id=None, result=result)
+        _refresh_cik_sidecar(guard_conn, cik=_TEST_CIK, payload=second_payload, bootstrap_run_id=None, result=result)
+
+        rows = _read_sidecar_rows(guard_conn, _TEST_CIK)
+        assert {r["page_name"] for r in rows} == {
+            f"CIK{_TEST_CIK}-submissions-002.json",
+            f"CIK{_TEST_CIK}-submissions-003.json",
+        }
+        assert f"CIK{_TEST_CIK}-submissions-001.json" not in {r["page_name"] for r in rows}
+
+    @pytest.mark.integration
+    def test_malformed_page_entries_skipped_well_formed_kept(
+        self,
+        guard_conn: psycopg.Connection[tuple],
+    ) -> None:
+        _wipe_test_cik(guard_conn)
+        payload = {
+            "filings": {
+                "files": [
+                    {
+                        "name": f"CIK{_TEST_CIK}-submissions-001.json",
+                        "filingFrom": "2010-01-15",
+                        "filingTo": "2012-06-30",
+                    },
+                    {"name": None},  # malformed
+                    "not a dict",  # malformed
+                    {"name": f"CIK{_TEST_CIK}-submissions-002.json"},  # missing dates
+                ],
+            },
+        }
+        result = _empty_result()
+
+        _refresh_cik_sidecar(
+            guard_conn,
+            cik=_TEST_CIK,
+            payload=payload,
+            bootstrap_run_id=None,
+            result=result,
+        )
+
+        rows = _read_sidecar_rows(guard_conn, _TEST_CIK)
+        assert {r["page_name"] for r in rows} == {f"CIK{_TEST_CIK}-submissions-001.json"}
+        assert result.sidecar_pages_indexed == 1
+
+    @pytest.mark.integration
+    def test_populate_origin_bootstrap_when_run_id_present(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """`populate_origin='bootstrap'` when bootstrap_run_id is not
+        None; FK to bootstrap_runs(id) must be valid. We seed a real
+        bootstrap_runs row so the FK insert succeeds."""
+        _wipe_test_cik(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            # Seed a bootstrap_runs row with explicit status='running' so the helper
+            # has a real FK target. Default columns are nullable.
+            cur.execute(
+                "INSERT INTO bootstrap_runs (status, triggered_by_operator_id) VALUES ('running', NULL) RETURNING id",
+            )
+            row = cur.fetchone()
+            assert row is not None
+            run_id = int(row[0])
+        ebull_test_conn.commit()
+
+        try:
+            result = _empty_result()
+            _refresh_cik_sidecar(
+                ebull_test_conn,
+                cik=_TEST_CIK,
+                payload={"filings": {"files": []}},
+                bootstrap_run_id=run_id,
+                result=result,
+            )
+            ebull_test_conn.commit()
+
+            rows = _read_sidecar_rows(ebull_test_conn, _TEST_CIK)
+            assert len(rows) == 1
+            assert rows[0]["populate_origin"] == "bootstrap"
+            assert rows[0]["bootstrap_run_id"] == run_id
+        finally:
+            with ebull_test_conn.cursor() as cur:
+                cur.execute("DELETE FROM sec_cik_submissions_files_index WHERE cik = %s", (_TEST_CIK,))
+                cur.execute("DELETE FROM bootstrap_runs WHERE id = %s", (run_id,))
+            ebull_test_conn.commit()
+
+
+class TestSidecarPerCikSavepointAtomicity:
+    """Per spec §14 + DE BLOCKING: on per-CIK transaction rollback
+    (e.g. an INSERT failure inside the outer ``with conn.transaction()``
+    block), the DELETE rolls back too — prior committed sidecar rows
+    for that CIK SURVIVE.
+
+    These tests exercise the contract end-to-end by simulating the
+    OUTER transaction wrapper around _refresh_cik_sidecar."""
+
+    @pytest.mark.integration
+    def test_prior_rows_survive_when_sibling_write_raises_inside_outer_tx(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        # Seed a "prior committed" sidecar state for the test CIK.
+        _wipe_test_cik(ebull_test_conn)
+        prior_payload = {
+            "filings": {
+                "files": [
+                    {
+                        "name": f"CIK{_TEST_CIK}-submissions-001.json",
+                        "filingFrom": "2010-01-15",
+                        "filingTo": "2012-06-30",
+                    },
+                ],
+            },
+        }
+        _refresh_cik_sidecar(
+            ebull_test_conn,
+            cik=_TEST_CIK,
+            payload=prior_payload,
+            bootstrap_run_id=None,
+            result=_empty_result(),
+        )
+        ebull_test_conn.commit()
+        assert len(_read_sidecar_rows(ebull_test_conn, _TEST_CIK)) == 1
+
+        # Now simulate the production shape: an OUTER per-CIK
+        # ``with conn.transaction()`` that calls _refresh_cik_sidecar
+        # AND then raises in a sibling code path. The savepoint rollback
+        # MUST restore the prior committed sidecar row.
+        new_payload = {
+            "filings": {
+                "files": [
+                    {
+                        "name": f"CIK{_TEST_CIK}-submissions-999.json",
+                        "filingFrom": "2020-01-01",
+                        "filingTo": "2020-12-31",
+                    },
+                ],
+            },
+        }
+        try:
+            with ebull_test_conn.transaction():
+                _refresh_cik_sidecar(
+                    ebull_test_conn,
+                    cik=_TEST_CIK,
+                    payload=new_payload,
+                    bootstrap_run_id=None,
+                    result=_empty_result(),
+                )
+                # Simulate a sibling-instrument write failure.
+                raise RuntimeError("simulated sibling write failure")
+        except RuntimeError:
+            pass
+
+        rows = _read_sidecar_rows(ebull_test_conn, _TEST_CIK)
+        assert len(rows) == 1
+        assert rows[0]["page_name"] == f"CIK{_TEST_CIK}-submissions-001.json", (
+            "rollback must restore the PRIOR committed row, not the in-flight new row"
+        )
+
+        # Cleanup.
+        _wipe_test_cik(ebull_test_conn)

--- a/tests/test_sec_entry_points_is_tradable_filter.py
+++ b/tests/test_sec_entry_points_is_tradable_filter.py
@@ -115,7 +115,10 @@ class TestSubmissionsFilesWalkFiltersDelisted:
 
         rows = _list_cik_secondary_pages(ebull_test_conn)
 
-        ciks = {cik for _, cik, _ in rows}
+        # Tuple shape updated in #1233 Stream A PR-B: now 4-tuple
+        # (instrument_id, cik, symbol, sidecar_pages) — added per-CIK
+        # sidecar page list for S14 to consume without re-fetching primary.
+        ciks = {cik for _, cik, _, _ in rows}
         assert "0000830001" in ciks
         assert "0000830002" not in ciks, "delisted CIK must be filtered (#1233 §6.2)"
 

--- a/uv.lock
+++ b/uv.lock
@@ -335,6 +335,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-testmon" },
     { name = "pytest-xdist" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -364,6 +365,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-testmon", specifier = ">=2.2" },
     { name = "pytest-xdist", specifier = ">=3.5" },
+    { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.4.0" },
 ]
 
@@ -1159,6 +1161,18 @@ wheels = [
 [package.optional-dependencies]
 hiredis = [
     { name = "hiredis" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Stream A PR-B of #1233 Tier 1 bootstrap optimisation. Caches SEC submissions `filings.files[]` page descriptors in a NEW sidecar table populated by S8 (`sec_submissions_ingest`) during the per-CIK ingest transaction. S14 (`sec_submissions_files_walk`) consumes the sidecar instead of re-fetching each CIK's primary `submissions/CIK<10>.json` JUST to read `files[]` again.

**Refs #1233** (umbrella — Stream A is A→B→C→D; this is PR-B).

Wall-clock impact: eliminates ~5,105 PRIMARY HTTP calls / ~12 min at SEC's 7 req/s budget per Run #8. Secondary-page bodies are STILL fetched over HTTP (they were never in the bulk archive) — savings is "primary-fetch elimination only" per spec §5.

## What changes

- NEW `sql/172_sec_cik_submissions_files_index.sql` — sidecar table with **sentinel-row pattern** (`page_name='__no_overflow_pages__'` for CIKs with zero overflow); SINGLE-WRITER COMMENT; CHECKs (cik regex + page_name disjunction + composite filing dates vs sentinel); `populate_origin` discriminator; FK `bootstrap_runs(id) ON DELETE SET NULL`.
- NEW `sql/173_bootstrap_runs_stream_c_gate.sql` — schema-prep columns for the Stream-C gate runbook (lands in PR-D): `stream_c_gate_status TEXT` with CHECK admitting `pending` / `passed` / `failed_<check_id>` (literal `_` via `ESCAPE '\'`; bare `failed_` rejected) + `coverage_floor_ratio NUMERIC(5,4)` with `[0, 1]` range CHECK.
- MODIFIED `app/services/sec_submissions_ingest.py` — new `_refresh_cik_sidecar` + `_load_current_bootstrap_run_id` helpers; call site in OUTER per-CIK transaction at line ~158 BEFORE the sibling-instrument loop (per-CIK refresh runs ONCE for share-class CIKs, not N times); `KNOWN_FILING_AGENT_CIKS` filter at populate; per-CIK DELETE+INSERT (not global TRUNCATE); malformed-only `files[]` → fail-loud (no false-sentinel).
- REWRITTEN `app/services/sec_submissions_files_walk.py` — `_list_cik_secondary_pages` LEFT JOINs sidecar + array_agg; `walk_files_pages` is sentinel-aware; agent-CIK silently skipped BEFORE `ciks_visited` increment; empty-sidecar logged at DEBUG per-CIK + summary WARNING at end (replaces pre-fix per-CIK WARNING that would spam 8,700× on systemic S8 failure); ZERO PRIMARY HTTP fetches when sidecar populated (pinned via respx contract test).
- MODIFIED `app/services/sec_bulk_orchestrator_jobs.py` — persists `ciks_sidecared` + `sidecar_pages_indexed` to `bootstrap_archive_results.rows_skipped`.
- MODIFIED `app/services/bootstrap_preconditions.py` — `assert_c1b_preconditions` extended: accepts EITHER `rows_written > 0` OR `rows_skipped->>'ciks_sidecared' > 0` (pre-PR-B, a retention-heavy run could populate sidecar correctly but have `rows_written=0` and be blocked from C1.b — Codex 2 MEDIUM).
- NEW `respx>=0.21` dev dep — smallest httpx transport-layer mock for the ZERO-PRIMARY-HTTP contract test.

## Why

Per spec §1 T1.3 + §4 + §14 (`docs/proposals/etl/stream-a-run-8-fixes.md` v2.3, PR #1306) — Codex CTO v3 biggest risk + Codex v2 BLOCKING. PR-B is the second of A→B→C→D per spec §1.6.

## Security model

- Read scope: existing operator-only auth on consume paths; no new HTTP exposed; sidecar table is internal-state-only (no public endpoint).
- Write scope: SINGLE-WRITER (S8 only) pinned in migration COMMENT; per-CIK DELETE+INSERT inside outer per-CIK transaction; FK enforces `bootstrap_runs` reference; CHECK constraints enforce shape invariants.
- No PII; the sidecar holds only CIK-numbers + page filenames already public on SEC's site.

## Conscious tradeoffs

- Sentinel-row pattern (instead of separate "processed_ciks" table) — collapses two-table JOIN to one and lets a single atomic DELETE+INSERT per CIK roll back together. Slightly non-obvious at the consume site but the docstring + COMMENT explicitly justify it.
- Per-CIK DELETE+INSERT (instead of global TRUNCATE) — atomicity per CIK rather than per archive; mid-archive failure leaves prior committed rows for other CIKs intact.
- Malformed-only `files[]` (every entry shape-wrong) → DO NOT write sentinel (which would falsely claim "no overflow"); skip + parse_error + log warning. S14 will fail-closed on empty sidecar so the operator sees the gap loudly. Codex 2 HIGH.
- C1.b readiness gate widened to also accept `ciks_sidecared > 0` — defends against the retention-drop scenario where `rows_written=0` despite sidecar populated correctly.
- LPAD on the JOIN preserved as defensive normalisation against any historical-data unpadded `external_identifiers` row (zero perf impact at 12k-CIK cohort via hash-join).

## Test plan

- [x] `tests/test_sec_cik_submissions_files_index.py` — 8 tests: agent-CIK filter; real-page write; sentinel; missing-filings-block fallback; per-CIK DELETE+INSERT idempotency; malformed-entry handling; `populate_origin` discriminator; per-CIK transaction atomicity (INSERT failure rolls back DELETE — prior rows survive).
- [x] `tests/test_s14_uses_sidecar.py` — 4 tests: empty-sidecar fail-closed; sentinel skip; agent-CIK silent skip; ZERO-PRIMARY-HTTP contract via respx.
- [x] `uv run ruff check` + `ruff format --check` + `pyright` PASS on all 8 impacted files.
- [x] `uv run pytest tests/test_sec_cik_submissions_files_index.py tests/test_s14_uses_sidecar.py tests/test_jobs_boot_guard.py tests/test_api_system.py` — 43 PASS (28 PR-B-impacted + 15 PR-A regression).

## Review trail

Self-review + 3-lens committee (Architect via `feature-dev:code-architect` + Adversarial Reviewer via `feature-dev:code-reviewer` + Data Engineer via `general-purpose`) + Codex 2 pre-push checkpoint (`codex exec`). 9 BLOCKING / IMPORTANT folded; audit in commit body.

## Related

- Spec PR #1306 (Stream A v2.3 + 8 supporting skills).
- PR-A merged: bf719c5 (jobs-process operator-existence boot guard).
- Next: PR-C `feature/1233-pr-c-fundamentals` (T1.2 fundamentals_sync_bootstrap + `fundamentals/` package conversion; depends on PR-B merged per spec §1.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)