### PR TITLE
feat(#1233): Stream A PR-C1 — fundamentals_sync 4-cap strengthening (T1.2 part 1)

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -600,10 +600,12 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
     # bootstrap and re-introduce HTTP backfill.
     #
     # Terminal-status safety: ``submissions_processed`` is in
-    # ``_ORDERING_ONLY_CAPS`` (line 515), so the dispatcher at line 764
-    # marks it satisfied on ``blocked|error|cancelled`` terminals too —
-    # this cap addition does NOT create a stuck-S25 failure mode when
-    # S8 errors.
+    # ``_ORDERING_ONLY_CAPS`` (the frozenset defined just above), so
+    # ``_satisfied_capabilities`` adds it on ``blocked|error|cancelled``
+    # terminals + ``_capability_is_dead`` treats those terminal providers
+    # as still satisfying ordering caps — this cap addition does NOT
+    # create a stuck-S25 failure mode when S8 errors. Symbol references
+    # over line refs (line numbers drift; Codex 2 LOW pre-merge review).
     #
     # Spec: docs/proposals/etl/stream-a-run-8-fixes.md v2.3 §13.
     "fundamentals_sync": CapRequirement(

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -591,7 +591,29 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
             "nport_inputs_seeded",
         ),
     ),
-    "fundamentals_sync": CapRequirement(all_of=("fundamentals_raw_seeded",)),
+    # Stream A PR-C1 T1.2 (#1233): strengthened from 1-cap to 4-cap
+    # requirement. Pre-PR-C1, S25 only waited for ``fundamentals_raw_seeded``
+    # (S9 companyfacts ingest). The audit-during-bootstrap defence in
+    # T1.2's bootstrap entrypoint (lands in PR-C2) needs to know that
+    # bulk archives + CIK mapping + S8 terminalisation are all done
+    # too — otherwise ``audit_all_instruments`` would misclassify mid-
+    # bootstrap and re-introduce HTTP backfill.
+    #
+    # Terminal-status safety: ``submissions_processed`` is in
+    # ``_ORDERING_ONLY_CAPS`` (line 515), so the dispatcher at line 764
+    # marks it satisfied on ``blocked|error|cancelled`` terminals too —
+    # this cap addition does NOT create a stuck-S25 failure mode when
+    # S8 errors.
+    #
+    # Spec: docs/proposals/etl/stream-a-run-8-fixes.md v2.3 §13.
+    "fundamentals_sync": CapRequirement(
+        all_of=(
+            "bulk_archives_ready",
+            "cik_mapping_ready",
+            "submissions_processed",
+            "fundamentals_raw_seeded",
+        ),
+    ),
 }
 
 
@@ -1138,6 +1160,16 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
         },
     ),
     _spec("ownership_observations_backfill", 24, "db", "ownership_observations_backfill"),
+    # Stream A spec v2.3 §5 calls for S25 to be reassigned to the
+    # ``db_fundamentals_raw`` lane. DEFERRED to PR-C2 — the steady-
+    # state ``fundamentals_sync`` ScheduledJob (app/workers/scheduler.py:618)
+    # is registered with source="db" and the lane-source registry
+    # cross-check (app/jobs/sources.py:get_job_name_to_source) raises
+    # JobSourceRegistryError if the bootstrap-stage lane diverges
+    # from the scheduled-job source for the same job_name. PR-C2
+    # introduces a separately-registered ``fundamentals_sync_bootstrap``
+    # invoker that CAN safely live on the dedicated lane without
+    # touching the steady-state job.
     _spec("fundamentals_sync", 25, "db", "fundamentals_sync"),
     # #1174 — dedicated MF directory refresh + N-CSR fund-scoped bootstrap
     # drain (T8 deferred from #1171). S25 (post #1233 PR-1b: S26) advertises

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -962,7 +962,13 @@ def test_intentional_slow_connection_skip_cascade(
         assert statuses[key] == "skipped", f"{key} expected skipped, got {statuses[key]}"
         assert key not in calls["order"], f"{key} should not have been invoked under cascade"
 
-    # S24 fundamentals_sync cascades skipped (sole provider S9 skipped).
+    # S25 fundamentals_sync cascades skipped. Post-PR-C1 (#1233) the
+    # cap requirement is 4-cap (bulk_archives_ready + cik_mapping_ready
+    # + submissions_processed + fundamentals_raw_seeded); under the
+    # slow-connection path S7 (sec_bulk_download) skips → ALL FOUR
+    # cap-providers downstream cascade-skip → S25 cascade-skips. Same
+    # outcome as the pre-PR-C1 1-cap shape (where the sole provider
+    # was S9 sec_companyfacts_ingest); test stays valid.
     assert statuses["fundamentals_sync"] == "skipped"
 
     # Legacy chain runs.

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -1390,7 +1390,11 @@ def test_fundamentals_sync_stays_on_db_lane_pending_pr_c2() -> None:
     This invariant pin is intentional — flip the expected value when
     PR-C2 lands the bootstrap-only invoker.
     """
-    fundamentals_spec = next(s for s in _BOOTSTRAP_STAGE_SPECS if s.stage_key == "fundamentals_sync")
+    fundamentals_spec = next(
+        (s for s in _BOOTSTRAP_STAGE_SPECS if s.stage_key == "fundamentals_sync"),
+        None,
+    )
+    assert fundamentals_spec is not None, "fundamentals_sync stage missing from _BOOTSTRAP_STAGE_SPECS"
     assert fundamentals_spec.stage_order == 25
     assert fundamentals_spec.lane == "db", (
         "fundamentals_sync stays on 'db' until PR-C2 introduces fundamentals_sync_bootstrap "

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -1344,3 +1344,55 @@ def test_strict_cap_exclusion_neutral_provider_does_not_satisfy_or_kill() -> Non
     # (the exclusion is form3-specific), so scenario-1 rows satisfy it.
     caps = _satisfied_capabilities(statuses_only_bulk, rows_only_bulk)
     assert "insider_inputs_seeded" in caps
+
+
+# ---------------------------------------------------------------------------
+# Stream A PR-C1 T1.2 (#1233): fundamentals_sync cap-strengthen + lane delta.
+# ---------------------------------------------------------------------------
+
+
+def test_fundamentals_sync_requires_four_caps_after_pr_c1() -> None:
+    """Stream A PR-C1 T1.2 (#1233): S25 ``fundamentals_sync`` is
+    strengthened from a 1-cap requirement (`fundamentals_raw_seeded`
+    only) to the 4-cap tuple needed by the bootstrap entrypoint's
+    audit-during-bootstrap defence (which lands in PR-C2).
+
+    All four caps are verified real (spec §0.1 grep proof). Terminal-
+    status safety: ``submissions_processed`` is in
+    ``_ORDERING_ONLY_CAPS`` so the dispatcher satisfies the cap on
+    ``blocked|error|cancelled`` as well as ``success|skipped`` — no
+    stuck-S25 failure mode when S8 errors.
+
+    Regression sentinel — relaxing this requirement back to a subset
+    would re-expose the audit-during-bootstrap trap that Codex v3
+    finding #8 flagged.
+    """
+    req = _STAGE_REQUIRES_CAPS["fundamentals_sync"]
+    assert set(req.all_of) == {
+        "bulk_archives_ready",
+        "cik_mapping_ready",
+        "submissions_processed",
+        "fundamentals_raw_seeded",
+    }, "fundamentals_sync must require the 4-cap PR-C1 tuple (#1233 §13)"
+
+
+def test_fundamentals_sync_stays_on_db_lane_pending_pr_c2() -> None:
+    """Stream A spec v2.3 §5 calls for S25 ``fundamentals_sync`` to be
+    reassigned to ``db_fundamentals_raw``. DEFERRED to PR-C2 because the
+    steady-state ``fundamentals_sync`` ScheduledJob is registered with
+    ``source="db"`` and the lane-source registry cross-check at
+    ``app/jobs/sources.py:get_job_name_to_source`` raises
+    ``JobSourceRegistryError`` if the bootstrap-stage lane diverges
+    from the scheduled-job source for the same job_name. PR-C2
+    introduces a separately-registered ``fundamentals_sync_bootstrap``
+    invoker that CAN safely live on the dedicated lane.
+
+    This invariant pin is intentional — flip the expected value when
+    PR-C2 lands the bootstrap-only invoker.
+    """
+    fundamentals_spec = next(s for s in _BOOTSTRAP_STAGE_SPECS if s.stage_key == "fundamentals_sync")
+    assert fundamentals_spec.stage_order == 25
+    assert fundamentals_spec.lane == "db", (
+        "fundamentals_sync stays on 'db' until PR-C2 introduces fundamentals_sync_bootstrap "
+        "on its own job_name (#1233 §5 deferral)"
+    )


### PR DESCRIPTION
## Summary

Strengthen `fundamentals_sync` (S25) `CapRequirement` from the 1-cap `("fundamentals_raw_seeded",)` to the 4-cap tuple `("bulk_archives_ready", "cik_mapping_ready", "submissions_processed", "fundamentals_raw_seeded")` per Stream A spec v2.3 §13.

**Refs #1233** (umbrella — Stream A is A→B→C→D; this is PR-C1 of the split PR-C).

PR-A merged (`bf719c5`) — jobs-process operator-existence boot guard. PR-B merged (`830e67e`) — sec submissions files[] sidecar. PR-C scope was split per session-budget decision: **PR-C1 = cap-strengthen + tests**; PR-C2 (future session) will introduce `fundamentals_sync_bootstrap` as a separately-registered invoker + `fundamentals/` package conversion + `siblings_for_issuer_cik` share-class fan-out + lane reassignment to `db_fundamentals_raw`.

## Why

The bootstrap entrypoint that PR-C2 will introduce (`fundamentals_sync_bootstrap`) needs `audit_all_instruments` to see the FULL bootstrap picture — bulk archives + CIK mapping + S8 terminalisation + companyfacts ingest — before classifying coverage. Without all 4 caps satisfied, the audit misclassifies mid-bootstrap and re-introduces HTTP backfill (Codex v3 finding #8).

Landing the cap-strengthen NOW (ahead of PR-C2) means: invariant is in place when PR-C2 wires the new invoker; cap edge exercised by every existing bootstrap test that reaches S25 (any unsoundness surfaces in CI before PR-C2 lands); smaller diff = faster review.

## Security model

- Pure schema-of-orchestrator change. No new code paths. No new auth surface. No external HTTP added.
- `submissions_processed` is in `_ORDERING_ONLY_CAPS` (line 515) — dispatcher at line 764 marks ordering-only caps satisfied on `blocked|error|cancelled` terminals as well as `success|skipped`, so the cap addition does NOT create a stuck-S25 failure mode when S8 errors. Verified by test.

## Conscious tradeoffs

- **Lane reassignment deferred to PR-C2.** Spec v2.3 §5 calls for S25 to be reassigned to `db_fundamentals_raw`, but the steady-state `fundamentals_sync` `ScheduledJob` (`app/workers/scheduler.py:618`) is registered with `source="db"` and the lane-source registry cross-check at `app/jobs/sources.py:get_job_name_to_source` raises `JobSourceRegistryError` if bootstrap-stage lane diverges from scheduled-job source for the same `job_name`. PR-C2 introduces a separately-registered `fundamentals_sync_bootstrap` invoker on its own `job_name` that CAN safely live on the dedicated lane. The deferred-state invariant is pinned by `test_fundamentals_sync_stays_on_db_lane_pending_pr_c2` — flip the expected value when PR-C2 lands.

## Test plan

- [x] `test_fundamentals_sync_requires_four_caps_after_pr_c1` — invariant pin on the 4-cap tuple.
- [x] `test_fundamentals_sync_stays_on_db_lane_pending_pr_c2` — explicit deferral marker.
- [x] All 37 existing `test_bootstrap_orchestrator.py` tests PASS.
- [x] `uv run ruff check` + `ruff format --check` + `pyright` PASS on the 2 impacted files.

## Related

- Spec PR #1306 (Stream A v2.3 + 8 supporting skills).
- PR-A merged: `bf719c5` (jobs-process operator-existence boot guard).
- PR-B merged: `830e67e` (sec submissions files[] sidecar).
- Next: PR-C2 `feature/1233-pr-c2-fundamentals-package` (fundamentals/ package conversion + `fundamentals_sync_bootstrap` entrypoint + `siblings_for_issuer_cik` fan-out + lane reassignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)