### PR TITLE
fix(#1233): sql/175 — DEFAULT-partition junk blocks new partition CREATE

### DIFF
--- a/sql/175_financial_facts_raw_partitions_2040.sql
+++ b/sql/175_financial_facts_raw_partitions_2040.sql
@@ -33,12 +33,43 @@
 --
 -- Run order: after sql/156_financial_facts_raw_partition.sql.
 
--- Phase 1: defensive cleanup of XBRL parser garbage. Must run BEFORE
+-- Phase 1a: defensive cleanup of XBRL parser garbage. Must run BEFORE
 -- partition CREATE so the DEFAULT partition has no in-range rows
 -- blocking the new partition CHECK predicates.
 DELETE FROM financial_facts_raw
 WHERE filed_date IS NOT NULL
   AND period_end > filed_date + INTERVAL '5 years';
+
+-- Phase 1b: complementary assertion — refuse to proceed if any row in
+-- the 2031+ range has NULL filed_date. The Phase 1a predicate cannot
+-- catch those (no filed_date to compare against), but they would
+-- trigger the same CheckViolation on Phase 2. Bot iter 1 WARNING fold
+-- (PR #1314, 2026-05-24): bot caught the gap; dev DB had zero such
+-- rows so dev verification passed silently, but any DB with legacy
+-- NPORT bulk-ingest rows lacking filed_date could hit it.
+--
+-- The operator action on assertion-fail: audit the NULL-filed_date
+-- rows. If legitimate (rare — usually means upstream bulk ingest
+-- dropped the date), backfill filed_date from accession_number's
+-- header data + re-run. If junk, DELETE them explicitly.
+DO $$
+DECLARE
+    null_count INT;
+BEGIN
+    SELECT COUNT(*) INTO null_count
+    FROM financial_facts_raw
+    WHERE filed_date IS NULL
+      AND period_end >= DATE '2031-01-01';
+    IF null_count > 0 THEN
+        RAISE EXCEPTION
+            'sql/175 refuses to proceed: % row(s) in financial_facts_raw have '
+            'filed_date IS NULL AND period_end >= 2031-01-01. These would '
+            'trigger CheckViolation on the new quarterly-partition CREATE. '
+            'Audit + clean these rows first (backfill filed_date from accession '
+            'header data OR DELETE if junk), then re-run.',
+            null_count;
+    END IF;
+END $$;
 
 -- Phase 2: extend quarterly partitions through 2040 (10y headroom).
 DO $$

--- a/sql/175_financial_facts_raw_partitions_2040.sql
+++ b/sql/175_financial_facts_raw_partitions_2040.sql
@@ -9,11 +9,38 @@
 -- defeats partition pruning + retention sweep targets. New quarterly
 -- partitions restore both.
 --
--- Idempotent: every CREATE uses IF NOT EXISTS so re-running the migration
--- is safe.
+-- DEFAULT-stragglers cleanup (POST-MERGE FOLLOW-UP fix on this same
+-- migration file): the DEFAULT partition turned out to contain XBRL
+-- parser garbage (filings dated 2023-2024 claiming period_end years
+-- 2031+ — impossible). #1218 added a parser-side guard rejecting
+-- period_end < 1900 OR ≥ 2100, but the rows that landed before #1218
+-- still sit in DEFAULT and block new quarterly partition CREATE with
+-- "updated partition constraint for default partition would be
+-- violated by some row". 18 such rows in dev as of 2026-05-24 from
+-- 48 total junk rows (others sit in legitimately-named quarters
+-- from year-overflow bugs).
+--
+-- Cleanup predicate (strictly impossible-by-physics):
+--   period_end > filed_date + INTERVAL '5 years'
+-- A claimed fiscal-period end-date more than 5 years past the
+-- filing-date cannot be a real filing — no public company files
+-- accounts for periods 5+ years in the future. Tagging filed_date
+-- IS NOT NULL guards rows where the filing-date is genuinely
+-- unknown (legacy ingest gaps).
+--
+-- Idempotent: cleanup uses DELETE so re-run is a no-op once empty;
+-- every CREATE uses IF NOT EXISTS so re-running the migration is safe.
 --
 -- Run order: after sql/156_financial_facts_raw_partition.sql.
 
+-- Phase 1: defensive cleanup of XBRL parser garbage. Must run BEFORE
+-- partition CREATE so the DEFAULT partition has no in-range rows
+-- blocking the new partition CHECK predicates.
+DELETE FROM financial_facts_raw
+WHERE filed_date IS NOT NULL
+  AND period_end > filed_date + INTERVAL '5 years';
+
+-- Phase 2: extend quarterly partitions through 2040 (10y headroom).
 DO $$
 DECLARE
     y           INT;


### PR DESCRIPTION
**Part of #1233**

## Summary

Follow-up fix to PR #1312 (\`620e0af\`). \`sql/175\` failed on dev DB with:

\`\`\`
CheckViolation: updated partition constraint for default partition
\"financial_facts_raw_default\" would be violated by some row
CONTEXT: SQL statement \"CREATE TABLE IF NOT EXISTS financial_facts_raw_2031q3
PARTITION OF financial_facts_raw FOR VALUES FROM ('2031-07-01') TO ('2031-10-01')\"
\`\`\`

Root cause: \`financial_facts_raw_default\` contained **48 XBRL parser-garbage rows** (filings dated 2023-2024 claiming \`period_end\` years 2031+ — impossible). PG blocks new partitions whose range collides with rows in DEFAULT. #1218's parser-side guard ([1900, 2100) period_end window) prevents future cases but pre-#1218 rows remain.

## Fix

Add a Phase-1 cleanup DELETE at the top of \`sql/175\` using a strictly-impossible-by-physics predicate:

\`\`\`sql
DELETE FROM financial_facts_raw
WHERE filed_date IS NOT NULL
  AND period_end > filed_date + INTERVAL '5 years';
\`\`\`

No public filing claims accounts for a fiscal period 5+ years after its filing date. \`filed_date IS NOT NULL\` guards rows where the filing-date is legitimately unknown (pre-ingest gaps).

## Verification (dev DB, applied at \`a23b9d\`-ish working state)

- 48 junk rows cleaned across all partitions (18 in default).
- \`sql/175\` re-applied successfully.
- \`financial_facts_raw\` now has **126 partitions** (pre2010 + 84 quarterly 2010-2030 + default + 40 new 2031-2040).
- \`finra_regsho_daily_observations\` has 45 partitions (sql/174 unaffected — no DEFAULT collision since that table doesn't carry XBRL garbage).
- 0 remaining junk rows post-cleanup.

## Why missed in pre-merge review

Codex 2 reviewed \`sql/175\` as static SQL — both the loop bounds + idempotency claims hold against an empty-DEFAULT contract. The DEFAULT-stragglers case is a dev-DB-state interaction that needs the migration to actually run against the live DB to surface. Pre-push pytest uses the test-DB template which has an empty DEFAULT, so it also passed. The check that would catch this class: \`gh pr checks\` migration-application smoke against a snapshot of dev DB (not yet wired).

## Test plan

- [x] \`uv run python -m scripts.migrate\` succeeds against dev DB
- [x] 126 financial_facts_raw partitions + 45 finra_regsho_daily partitions verified
- [x] 0 junk rows remain
- [x] \`uv run ruff check sql/\` n/a (SQL not linted by ruff)
- [ ] Bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)