### PR TITLE
fix: tolerate SEC daily-index 403 on weekend / before-publish-cutoff / future date

### DIFF
--- a/app/providers/implementations/sec_daily_index.py
+++ b/app/providers/implementations/sec_daily_index.py
@@ -30,12 +30,21 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Iterator
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time
+from zoneinfo import ZoneInfo
 
 from app.providers.implementations.sec_submissions import FilingIndexRow
 from app.services.sec_manifest import is_amendment_form, map_form_to_source
 
 logger = logging.getLogger(__name__)
+
+_ET = ZoneInfo("America/New_York")
+
+# Mirrors ``sec_edgar._MASTER_INDEX_PUBLISH_HOUR_ET`` — SEC publishes
+# the daily master-index ~22:00 ET on the same business day. Before
+# that moment a 403 on the current day is the "not yet published"
+# signal. After it, a 403 means SEC is actively blocking us.
+_MASTER_INDEX_PUBLISH_HOUR_ET = 22
 
 
 HttpGet = Callable[[str, dict[str, str]], tuple[int, bytes]]
@@ -150,6 +159,37 @@ def read_daily_index(
         logger.info("daily-index not published yet for %s (404)", when.isoformat())
         return
         yield  # pragma: no cover — keeps signature as Iterator
+    if status == 403:
+        # SEC's Archives host serves 403 (not 404) inconsistently for
+        # files that do not yet exist. Tolerated classes — mirroring
+        # ``SecFilingsProvider.fetch_master_index`` in sec_edgar.py:
+        #   1. Weekend (Sat/Sun) — SEC never publishes weekend indexes.
+        #   2. Current-day before the ~22:00-ET publish cutoff.
+        #   3. Future-dated (lookback windows straddling midnight TZ).
+        # Anything else (past weekday, or current weekday after the
+        # cutoff) raises — that's SEC refusing us (UA/rate-limit/WAF).
+        # US federal holidays also yield 403 but are not enumerated;
+        # the next business-day reconcile catches what they miss.
+        if when.weekday() >= 5:  # 5=Sat, 6=Sun
+            logger.info(
+                "daily-index 403 on %s treated as weekend (no publish)",
+                when.isoformat(),
+            )
+            return
+        now_et = datetime.now(_ET)
+        publish_due = datetime.combine(
+            when,
+            time(_MASTER_INDEX_PUBLISH_HOUR_ET, 0),
+            tzinfo=_ET,
+        )
+        if now_et < publish_due:
+            logger.info(
+                "daily-index 403 on %s treated as not-yet-published (now_et=%s publish_due=%s)",
+                when.isoformat(),
+                now_et.isoformat(timespec="minutes"),
+                publish_due.isoformat(timespec="minutes"),
+            )
+            return
     if status != 200:
         raise RuntimeError(f"daily-index fetch failed: status={status} when={when.isoformat()}")
 

--- a/tests/test_sec_submissions_provider.py
+++ b/tests/test_sec_submissions_provider.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
 
 import pytest
 
+from app.providers.implementations import sec_daily_index as sec_daily_index_mod
 from app.providers.implementations.sec_daily_index import (
     _accession_from_filename,
     parse_daily_index,
@@ -332,3 +334,73 @@ class TestReadDailyIndex:
     def test_non_404_non_200_raises(self) -> None:
         with pytest.raises(RuntimeError, match="status=500"):
             list(read_daily_index(_fake_get(500, b""), date(2026, 4, 30)))
+
+
+def _pin_now_et(monkeypatch: pytest.MonkeyPatch, iso_instant: str) -> None:
+    """Freeze ``datetime.now(_ET)`` inside ``sec_daily_index`` to ``iso_instant`` (ET-local).
+
+    Mirrors ``tests/test_sec_provider_master_index.py::_pin_now_et`` so
+    the daily-index reader's 403-publish-cutoff logic is testable
+    without freezegun.
+    """
+    frozen = datetime.fromisoformat(iso_instant).replace(tzinfo=ZoneInfo("America/New_York"))
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return frozen.astimezone(tz) if tz else frozen.replace(tzinfo=None)
+
+    monkeypatch.setattr(sec_daily_index_mod, "datetime", _FrozenDatetime)
+
+
+class TestReadDailyIndex403:
+    """403 tolerance for weekend / before-publish-cutoff / future dates.
+
+    Mirrors ``SecFilingsProvider.fetch_master_index`` in
+    ``app/providers/implementations/sec_edgar.py`` — the daily-index
+    reader must use the same envelope, otherwise a Sunday-night
+    apscheduler catch-up fires the reconcile job for Saturday and
+    crashes the worker with ``RuntimeError: daily-index fetch failed:
+    status=403``.
+    """
+
+    def test_403_on_saturday_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # 2026-05-23 is Saturday — SEC never publishes weekend daily indexes.
+        _pin_now_et(monkeypatch, "2026-05-25T12:00:00")
+        rows = list(read_daily_index(_fake_get(403, b""), date(2026, 5, 23)))
+        assert rows == []
+
+    def test_403_on_sunday_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # 2026-05-24 is Sunday.
+        _pin_now_et(monkeypatch, "2026-05-25T12:00:00")
+        rows = list(read_daily_index(_fake_get(403, b""), date(2026, 5, 24)))
+        assert rows == []
+
+    def test_403_on_weekday_before_publish_cutoff_returns_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 2026-05-25 is Monday; freeze ET clock at 12:00, before the
+        # 22:00-ET publish cutoff — current-day 403 is "not yet published".
+        _pin_now_et(monkeypatch, "2026-05-25T12:00:00")
+        rows = list(read_daily_index(_fake_get(403, b""), date(2026, 5, 25)))
+        assert rows == []
+
+    def test_403_on_weekday_after_publish_cutoff_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 23:00 ET on a weekday is past the 22:00 publish cutoff. A 403
+        # at that point is SEC actively refusing us (UA/rate-limit/WAF)
+        # — must surface, not silently swallow.
+        _pin_now_et(monkeypatch, "2026-05-25T23:00:00")
+        with pytest.raises(RuntimeError, match="status=403"):
+            list(read_daily_index(_fake_get(403, b""), date(2026, 5, 25)))
+
+    def test_403_on_future_date_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Future-dated 403 tolerated symmetrically with the master-index
+        # provider — callers may iterate a lookback window whose
+        # endpoints straddle midnight across timezones.
+        _pin_now_et(monkeypatch, "2026-05-25T12:00:00")
+        rows = list(read_daily_index(_fake_get(403, b""), date(2026, 5, 26)))
+        assert rows == []


### PR DESCRIPTION
## Summary

- ``read_daily_index`` raised ``RuntimeError`` on any 403 from SEC. Apscheduler catch-up after a weekend restart hit Saturday's daily-index, got 403, and crashed the worker — the runtime caught + rescheduled (so no data lost), but every restart produced a noisy stack trace until Monday's data was the target.
- Sibling provider ``SecFilingsProvider.fetch_master_index`` ([app/providers/implementations/sec_edgar.py:677-707](app/providers/implementations/sec_edgar.py#L677-L707)) already tolerated the same 403 envelope: weekend / before-22:00-ET publish cutoff / future-dated. The daily-index reader did not mirror.
- This PR mirrors the envelope into ``read_daily_index``: weekend or before-cutoff → empty iterator + ``info`` log. Anything else (past weekday, current weekday after the 22:00 ET cutoff) still raises — a real WAF/UA/rate-limit block must surface.

## Security model

Read-only HTTP to ``www.sec.gov``. No new credential surface; no DB writes; no authorization decisions changed. The change widens the "tolerated" envelope but the narrower "must raise" path (post-cutoff weekday 403) is exercised by the new ``test_403_on_weekday_after_publish_cutoff_raises`` test.

## Test plan

- [x] ``uv run pytest tests/test_sec_submissions_provider.py`` — 30 pass (5 new ``TestReadDailyIndex403`` cases + 25 existing).
- [x] ``uv run ruff check`` + ``ruff format --check`` + ``uv run pyright`` — all clean on the two touched files.
- [x] Pre-push hook ran cleanly (no ``--no-verify``).
- [x] Codex 2 pre-push review (``codex exec review --base main``) — APPROVE, no BLOCKING / IMPORTANT / NIT.
- [ ] Observed in production: next restart catch-up should INFO-log ``daily-index 403 on <weekend-date> treated as weekend (no publish)`` instead of stack-tracing.

## Conscious trade-offs

- **US federal holidays not enumerated**: a holiday on a weekday still raises if past the 22:00 ET cutoff. Sibling ``sec_edgar.py`` has the same gap. The next business-day reconcile catches anything the holiday day missed via the per-day watermark — this is the existing tolerance budget. Out of scope to enumerate holidays here; would belong in a shared module if added later.
- **22:00 ET cutoff inherited from sibling**: matches ``_MASTER_INDEX_PUBLISH_HOUR_ET`` exactly. If SEC ever shifts publish time, both constants must move together. Comment in ``sec_daily_index.py`` calls this out explicitly.
- **Test pattern**: ``_pin_now_et`` mirrors ``tests/test_sec_provider_master_index.py:125`` rather than depending on ``freezegun`` (not in this repo per the prevention-log convention).

## Files

- ``app/providers/implementations/sec_daily_index.py`` — new ``_ET`` + ``_MASTER_INDEX_PUBLISH_HOUR_ET`` constants; 403 branch added before the existing ``if status != 200`` guard.
- ``tests/test_sec_submissions_provider.py`` — new ``_pin_now_et`` helper + ``TestReadDailyIndex403`` (5 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)