### PR TITLE
fix(smoke): allowlist 6 dev-DB-targeted test files in destructive-path guard

### DIFF
--- a/tests/smoke/test_no_settings_url_in_destructive_paths.py
+++ b/tests/smoke/test_no_settings_url_in_destructive_paths.py
@@ -132,6 +132,70 @@ _ALLOWED: dict[str, str] = {
     # ``settings.database_url``. No writes anywhere — only
     # ``SELECT column_name FROM information_schema.columns``.
     "smoke/test_schema_drift.py": "read-only information_schema introspection of the live dev DB schema",
+    # Read-only safety-primitive tests. ``test_runbook_safety.py``
+    # (#1233 Stream A PR-D) exercises ``app/runbooks/safety.py``
+    # primitives — ``assert_dev_db`` verifies
+    # ``current_database()`` against an allowlist that
+    # *specifically targets the dev DB name*, and
+    # ``assert_jobs_process_stopped`` /
+    # ``wait_for_jobs_process_started`` probe
+    # ``JOBS_PROCESS_LOCK_KEY`` which is per-database (the
+    # production fence holds against the live dev DB, not a test
+    # one). Routing these to ``ebull_test_<worker>`` would defeat
+    # the test's premise. Read-only: ``SELECT current_database()`` +
+    # ``pg_try_advisory_lock`` + ``pg_advisory_unlock`` — no
+    # destructive writes.
+    "test_runbook_safety.py": (
+        "read-only safety-primitive tests; verify dev-DB-targeted behaviour by design (#1233 Stream A PR-D)"
+    ),
+    # Read-only pg_settings introspection. ``test_pg_settings_call_sites.py``
+    # (#1187) verifies ``max_locks_per_transaction`` GUC on the live
+    # dev DB — the value lives in postgresql.conf, not a test
+    # template, so a per-worker DB derived from the template would
+    # not reflect operator-tunable postgres.conf state. Read-only:
+    # ``SHOW max_locks_per_transaction`` only.
+    "test_pg_settings_call_sites.py": "read-only pg_settings introspection of the live dev DB GUC (#1187)",
+    # Read-only singleton-fence tests. ``test_jobs_process_probe_fence.py``
+    # (#1233 Stream A PR-D) exercises the JOBS_PROCESS_LOCK_KEY
+    # session-scoped advisory lock that the jobs daemon holds against
+    # the dev DB. The fence's correctness depends on testing against
+    # the same DB the daemon connects to. Read-only:
+    # ``pg_try_advisory_lock`` / ``pg_advisory_unlock`` /
+    # ``pg_stat_activity`` introspection — no DML.
+    "test_jobs_process_probe_fence.py": (
+        "read-only singleton-fence advisory-lock tests against the live dev DB (#1233 Stream A PR-D)"
+    ),
+    # Per-worker test DB via monkeypatched ``settings.database_url``.
+    # ``test_orchestrator_cancel.py`` (#1064 PR6) connects via
+    # ``psycopg.connect(settings.database_url)`` INSIDE production
+    # code under test (the orchestrator's cancel checkpoint), but the
+    # ``settings_use_test_db`` fixture monkeypatches
+    # ``settings.database_url`` to ``test_database_url()`` BEFORE any
+    # destructive code runs. The substring match in the docstring +
+    # the production-code description is a false positive: at runtime
+    # all DELETE / INSERT / UPDATE statements hit the per-worker test
+    # DB, never the dev DB.
+    "test_orchestrator_cancel.py": (
+        "monkeypatches settings.database_url to per-worker test DB before any destructive write (#1064 PR6)"
+    ),
+    # Same monkeypatch pattern. ``test_job_lock_reentrancy.py``
+    # (#1184) repoints ``settings.database_url`` to
+    # ``test_database_url()`` via ``monkeypatch.setattr`` at fixture
+    # setup, then exercises JobLock re-entrancy semantics that
+    # production code reaches via ``connect(settings.database_url)``.
+    # Module docstring explicitly documents this routing. No
+    # destructive write hits the dev DB.
+    "test_job_lock_reentrancy.py": (
+        "monkeypatches settings.database_url to per-worker test DB before any destructive write (#1184)"
+    ),
+    # The conftest contains the forbidden substring inside
+    # *docstrings + error-message strings* that warn future authors
+    # about the exact footgun. Including the message in the warning
+    # is the entire point — the smoke gate's substring grep cannot
+    # distinguish "documents the antipattern" from "executes the
+    # antipattern". Verified: no live ``psycopg.connect(settings.database_url)``
+    # call site in tests/conftest.py.
+    "conftest.py": "occurrences are inside docstrings/warning-message strings, not live call sites",
 }
 
 _TESTS_DIR = Path(__file__).resolve().parents[1]

--- a/tests/smoke/test_no_settings_url_in_destructive_paths.py
+++ b/tests/smoke/test_no_settings_url_in_destructive_paths.py
@@ -230,3 +230,29 @@ def test_no_test_writes_to_dev_database_url() -> None:
         "database, not the dev DB. See tests/test_operator_setup_race.py "
         "for the pattern, and the docstring of this file for guidance."
     )
+
+
+def test_allowed_keys_resolve_to_real_files() -> None:
+    """Every ``_ALLOWED`` key must resolve to an actual file under tests/.
+
+    The guard uses exact dict-key matching (``rel in _ALLOWED``), so a
+    typo or stale key (e.g. ``"tests/conftest.py"`` vs the correct
+    ``"conftest.py"``) would silently become dead config: it never
+    matches anything, but it also never fails the suite. This invariant
+    asserts every key points at a file that actually exists today.
+
+    Catches the bot-suggested footgun class: "a bare ``conftest.py``
+    silently allowlists every subdir conftest". Under exact-match
+    semantics it does NOT (bot was hedging — the matcher is
+    ``if rel in _ALLOWED:`` not ``any(k in rel for k in _ALLOWED)``),
+    but the invariant test makes that semantic explicit: a key only
+    works if it resolves to one specific file.
+    """
+    missing: list[str] = []
+    for key in _ALLOWED:
+        if not (_TESTS_DIR / key).is_file():
+            missing.append(key)
+    assert not missing, (
+        "_ALLOWED keys must resolve to actual files under tests/. "
+        "These keys point at no file (typo, stale, or wrongly path-prefixed):\n" + "\n".join(f"  {k}" for k in missing)
+    )


### PR DESCRIPTION
## Summary

- ``tests/smoke/test_no_settings_url_in_destructive_paths.py`` has been failing locally since several recent PRs landed 5 new test files that legitimately reference ``settings.database_url`` (CI doesn't run pytest per #928 → silent drift).
- Discovered during the §C pre-Run-#8 gates pass ([pre-run-8-blockers.md](docs/operator/runbooks/pre-run-8-blockers.md#L51)).
- Each new ``_ALLOWED`` entry carries the inline justification mandated by the header rule: *"Read-only paths only; every entry must be justified inline."*

## Files allowlisted (6)

| file | reason | landed in |
|---|---|---|
| ``test_runbook_safety.py`` | Read-only safety-primitive tests; targets dev DB by design (assert_dev_db / JOBS_PROCESS_LOCK_KEY probes) | #1311 |
| ``test_pg_settings_call_sites.py`` | Read-only ``SHOW max_locks_per_transaction`` against the live postgresql.conf GUC | #1188 |
| ``test_jobs_process_probe_fence.py`` | Read-only singleton-fence advisory-lock tests | #1311 |
| ``test_orchestrator_cancel.py`` | Monkeypatches ``settings.database_url`` to per-worker test DB before any destructive write | #1079 |
| ``test_job_lock_reentrancy.py`` | Same monkeypatch pattern | #1186 |
| ``tests/conftest.py`` | Substring appears only inside docstrings/warning-message strings, not live call sites | (legacy docstrings) |

## Security model

This is a TEST-INFRA change only. No production code touched. The guard's purpose — preventing future authors from typing ``psycopg.connect(settings.database_url)`` + a destructive write — is preserved. Every allowlisted file was manually grep-verified clean for live ``TRUNCATE`` / ``DELETE`` / ``DROP`` / ``UPDATE`` / ``INSERT`` against ``settings.database_url`` (the orchestrator_cancel / job_lock_reentrancy files DO have destructive SQL, but they execute against the per-worker test DB via the monkeypatched ``settings.database_url`` — verified by reading the fixture setup).

## Test plan

- [x] ``uv run pytest tests/smoke/`` — 96 passed, 3 skipped (was: 95 passed, 1 failed, 3 skipped before this PR)
- [x] ``uv run ruff check`` + ``ruff format --check`` + ``uv run pyright`` — all clean
- [x] Codex 2 pre-push (``codex exec review --base main``) — APPROVE, no findings

## Conscious trade-offs

- **Substring grep stays**: a proper AST-walk that distinguishes string literals from live call sites would catch this ambiguity at source. Out of scope for this fix — file a follow-up if the allowlist drifts again.
- **No CI re-instatement**: #928 decision (pytest off CI) holds. The pre-push hook still skips pytest. The structural answer is to mirror smoke tests into CI (tracked at #1329); that's polish-priority, not Run-#8-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)