### PR TITLE
fix(#1322): manifest-source-has-sink-tables + categories-match-writers + negative smoke

### DIFF
--- a/app/services/manifest_parsers/finra_regsho_daily.py
+++ b/app/services/manifest_parsers/finra_regsho_daily.py
@@ -43,13 +43,18 @@ Non-caller invariant: this module does NOT call
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Final
 
 import psycopg
 
 logger = logging.getLogger(__name__)
 
 PARSER_VERSION = "finra-regsho-daily-v1"
+
+# #1322 — synth-noop parity flag. Enforced by
+# tests/smoke/test_etl_source_to_sink.py against MANIFEST_SOURCE_SINKS kind.
+# Flip to False (or remove) if this module ever grows into a real writer.
+_SYNTH_NOOP: Final[bool] = True
 
 
 def _parse_finra_regsho_daily(

--- a/app/services/manifest_parsers/finra_short_interest.py
+++ b/app/services/manifest_parsers/finra_short_interest.py
@@ -55,13 +55,18 @@ synth no-op pattern.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Final
 
 import psycopg
 
 logger = logging.getLogger(__name__)
 
 PARSER_VERSION = "finra-si-bimonthly-v1"
+
+# #1322 — synth-noop parity flag. Enforced by
+# tests/smoke/test_etl_source_to_sink.py against MANIFEST_SOURCE_SINKS kind.
+# Flip to False (or remove) if this module ever grows into a real writer.
+_SYNTH_NOOP: Final[bool] = True
 
 
 def _parse_finra_short_interest(

--- a/app/services/manifest_parsers/sec_10q.py
+++ b/app/services/manifest_parsers/sec_10q.py
@@ -55,13 +55,18 @@ Codex pre-spec review:
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Final
 
 import psycopg
 
 logger = logging.getLogger(__name__)
 
 _PARSER_VERSION_10Q = "10q-noop-v1"
+
+# #1322 — synth-noop parity flag. Enforced by
+# tests/smoke/test_etl_source_to_sink.py against MANIFEST_SOURCE_SINKS kind.
+# Flip to False (or remove) if this module ever grows into a real writer.
+_SYNTH_NOOP: Final[bool] = True
 
 
 def _parse_sec_10q(

--- a/app/services/manifest_parsers/sec_xbrl_facts.py
+++ b/app/services/manifest_parsers/sec_xbrl_facts.py
@@ -41,13 +41,18 @@ module is the second adopter of the synth no-op pattern.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Final
 
 import psycopg
 
 logger = logging.getLogger(__name__)
 
 _PARSER_VERSION_XBRL_FACTS = "xbrl-facts-noop-v1"
+
+# #1322 — synth-noop parity flag. Enforced by
+# tests/smoke/test_etl_source_to_sink.py against MANIFEST_SOURCE_SINKS kind.
+# Flip to False (or remove) if this module ever grows into a real writer.
+_SYNTH_NOOP: Final[bool] = True
 
 
 def _parse_sec_xbrl_facts(

--- a/scripts/_etl_source_inventory.py
+++ b/scripts/_etl_source_inventory.py
@@ -46,6 +46,92 @@ BULK_REFERENCE_SOURCES: tuple[str, ...] = (
 
 ALL_SOURCES: tuple[str, ...] = tuple(sorted(set(MANIFEST_SOURCES + AD_HOC_SOURCES + BULK_REFERENCE_SOURCES)))
 
+# #1322 — per-source sink declaration. The (source → target_tables, kind) mapping
+# is NOT derivable from ``ManifestSource`` alone:
+#  * 4 sources are pure synth-noop (sec_10q, sec_xbrl_facts, finra_*); the parser
+#    is registered but writes no sink-table rows (scheduled jobs own the writes).
+#  * sec_def14a fans out to TWO ownership categories (def14a + esop) — same parser,
+#    two observation streams.
+#  * sec_n_csr writes fund_metadata_observations, NOT an ownership category.
+#  * sec_10k / sec_8k write to business_summary / eight_k tables, distinct kinds.
+#
+# Each cited table is verified to exist in ``sql/*.sql`` at the time of declaration.
+# The closure test ``test_manifest_source_sinks_complete`` asserts the keyset
+# equals ``set(get_args(ManifestSource))`` so future ``Literal`` additions
+# without a sink declaration fail the smoke loudly.
+#
+# kind ∈ {ownership_observation, fund_metadata, business_summary, eight_k, synth_noop}
+MANIFEST_SOURCE_SINKS: dict[str, tuple[tuple[str, ...], str]] = {
+    "sec_form3": (
+        ("ownership_insiders_observations", "ownership_insiders_current"),
+        "ownership_observation",
+    ),
+    "sec_form4": (
+        ("ownership_insiders_observations", "ownership_insiders_current"),
+        "ownership_observation",
+    ),
+    "sec_form5": (
+        ("ownership_insiders_observations", "ownership_insiders_current"),
+        "ownership_observation",
+    ),
+    "sec_13d": (
+        ("ownership_blockholders_observations", "ownership_blockholders_current"),
+        "ownership_observation",
+    ),
+    "sec_13g": (
+        ("ownership_blockholders_observations", "ownership_blockholders_current"),
+        "ownership_observation",
+    ),
+    "sec_13f_hr": (
+        ("ownership_institutions_observations", "ownership_institutions_current"),
+        "ownership_observation",
+    ),
+    "sec_def14a": (
+        # Fan-out: same parser writes BOTH def14a and esop observation streams.
+        (
+            "ownership_def14a_observations",
+            "ownership_def14a_current",
+            "ownership_esop_observations",
+            "ownership_esop_current",
+        ),
+        "ownership_observation",
+    ),
+    "sec_n_port": (
+        ("ownership_funds_observations", "ownership_funds_current"),
+        "ownership_observation",
+    ),
+    "sec_n_csr": (
+        ("fund_metadata_observations", "fund_metadata_current"),
+        "fund_metadata",
+    ),
+    "sec_10k": (
+        ("instrument_business_summary", "instrument_business_summary_sections"),
+        "business_summary",
+    ),
+    "sec_10q": ((), "synth_noop"),
+    "sec_8k": (
+        ("eight_k_filings", "eight_k_items", "eight_k_exhibits"),
+        "eight_k",
+    ),
+    "sec_xbrl_facts": ((), "synth_noop"),
+    "finra_short_interest": ((), "synth_noop"),
+    "finra_regsho_daily": ((), "synth_noop"),
+}
+
+# Closure check enforced at import-time + by the smoke test.
+_declared = set(MANIFEST_SOURCE_SINKS.keys())
+_actual = set(MANIFEST_SOURCES)
+if _declared != _actual:
+    only_declared = _declared - _actual
+    only_actual = _actual - _declared
+    raise RuntimeError(
+        f"MANIFEST_SOURCE_SINKS drift vs ManifestSource Literal:\n"
+        f"  only in MANIFEST_SOURCE_SINKS (remove): {sorted(only_declared)}\n"
+        f"  only in ManifestSource (add a sink): {sorted(only_actual)}\n"
+        f"Every entry in ``ManifestSource`` (Literal at app/services/sec_manifest.py) "
+        f"MUST have a corresponding sink declaration."
+    )
+
 REQUIRED_SECTIONS: tuple[str, ...] = (
     "## 1. Origin",
     "## 2. Watermarking model",

--- a/tests/smoke/test_etl_source_to_sink.py
+++ b/tests/smoke/test_etl_source_to_sink.py
@@ -21,16 +21,23 @@ See ``docs/etl/sources/README.md`` for the full template + invariants.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
+from typing import Any, get_args
 
+import psycopg
 import pytest
 
 from app.services.sec_manifest import FORM_MAPPING_EXEMPT
+from app.services.sec_manifest import ManifestSource as _ManifestSource
 from scripts._etl_source_inventory import (
     AD_HOC_SOURCES as _AD_HOC_SOURCES,
 )
 from scripts._etl_source_inventory import (
     ALL_SOURCES as _ALL_SOURCES,
+)
+from scripts._etl_source_inventory import (
+    MANIFEST_SOURCE_SINKS,
 )
 from scripts._etl_source_inventory import (
     MANIFEST_SOURCES as _MANIFEST_SOURCES,
@@ -171,3 +178,136 @@ def test_manifest_source_has_freshness_cadence(source: str) -> None:
         f"seed_freshness_for_manifest_row cannot populate expected_next_at "
         f"and subjects_due_for_poll will never surface this source."
     )
+
+
+# ---------------------------------------------------------------------------
+# #1322 — manifest source → sink table smoke (per Phase 0 §2.3)
+# ---------------------------------------------------------------------------
+
+
+def _table_exists(conn: psycopg.Connection[Any], table_name: str) -> bool:
+    """Existence check via pg_tables — avoids the UndefinedTable
+    aborted-tx hazard of ``SELECT 1 FROM <table>`` (Codex iter-2
+    BLOCKING fold)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename=%s",
+            (table_name,),
+        )
+        return cur.fetchone() is not None
+
+
+def test_manifest_source_sinks_complete() -> None:
+    """#1322 — closure test: every ManifestSource entry MUST have a sink declaration.
+
+    A future Literal addition (e.g. sec_form6 lands) without a corresponding
+    MANIFEST_SOURCE_SINKS entry fails this test loudly. Catches drift between
+    the type contract (ManifestSource) and the sink mapping (used by all
+    downstream coverage tests). Codex iter-2 IMPORTANT-1 fold.
+    """
+    declared = set(MANIFEST_SOURCE_SINKS.keys())
+    actual = set(get_args(_ManifestSource))
+    only_declared = declared - actual
+    only_actual = actual - declared
+    assert declared == actual, (
+        f"MANIFEST_SOURCE_SINKS drift vs ManifestSource Literal:\n"
+        f"  only in MANIFEST_SOURCE_SINKS (remove): {sorted(only_declared)}\n"
+        f"  only in ManifestSource (add a sink): {sorted(only_actual)}\n"
+        f"Update scripts/_etl_source_inventory.py::MANIFEST_SOURCE_SINKS."
+    )
+
+
+_PARSER_MODULE_BY_SOURCE: dict[str, str] = {
+    "sec_form3": "app.services.manifest_parsers.insider_345",
+    "sec_form4": "app.services.manifest_parsers.insider_345",
+    "sec_form5": "app.services.manifest_parsers.insider_345",
+    "sec_13d": "app.services.manifest_parsers.sec_13dg",
+    "sec_13g": "app.services.manifest_parsers.sec_13dg",
+    "sec_13f_hr": "app.services.manifest_parsers.sec_13f_hr",
+    "sec_def14a": "app.services.manifest_parsers.def14a",
+    "sec_n_port": "app.services.manifest_parsers.sec_n_port",
+    "sec_n_csr": "app.services.manifest_parsers.sec_n_csr",
+    "sec_10k": "app.services.manifest_parsers.sec_10k",
+    "sec_10q": "app.services.manifest_parsers.sec_10q",
+    "sec_8k": "app.services.manifest_parsers.eight_k",
+    "sec_xbrl_facts": "app.services.manifest_parsers.sec_xbrl_facts",
+    "finra_short_interest": "app.services.manifest_parsers.finra_short_interest",
+    "finra_regsho_daily": "app.services.manifest_parsers.finra_regsho_daily",
+}
+
+
+@pytest.mark.parametrize("source,spec", sorted(MANIFEST_SOURCE_SINKS.items()))
+def test_manifest_source_has_sink_tables(
+    source: str,
+    spec: tuple[tuple[str, ...], str],
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1322 — every ManifestSource entry's declared sink tables MUST exist
+    in the DB; synth-noop sources MUST declare _SYNTH_NOOP=True in their
+    parser module (bidirectional parity per Codex iter-3 IMPORTANT fold).
+
+    Uses ``ebull_test_conn`` (worker-private DB per CLAUDE.md test isolation)
+    NOT ``settings.database_url`` — pg_tables read is harmless but the
+    convention is to never reach for dev DB from a test.
+    """
+    target_tables, kind = spec
+
+    # Sink-table existence check (read-only via pg_tables)
+    missing = [t for t in target_tables if not _table_exists(ebull_test_conn, t)]
+    assert not missing, (
+        f"Source {source!r} (kind={kind!r}) declares sink tables in "
+        f"MANIFEST_SOURCE_SINKS that don't exist in DB: {missing}. "
+        f"Either add the migration, or update MANIFEST_SOURCE_SINKS to "
+        f"reflect the real shape."
+    )
+
+    # Synth-noop parity: bidirectional flag check
+    module_path = _PARSER_MODULE_BY_SOURCE.get(source)
+    if module_path is None:
+        pytest.fail(
+            f"Source {source!r} missing _PARSER_MODULE_BY_SOURCE entry — "
+            f"update the dict in this test file when adding a new source."
+        )
+    parser_module = importlib.import_module(module_path)
+    flag = getattr(parser_module, "_SYNTH_NOOP", False)
+    expected = kind == "synth_noop"
+    assert flag is expected, (
+        f"Source {source!r} parity mismatch: kind={kind!r} implies "
+        f"_SYNTH_NOOP={expected}, but {module_path}._SYNTH_NOOP={flag}. "
+        f"Either flip the module flag OR update MANIFEST_SOURCE_SINKS kind."
+    )
+
+
+def test_categories_match_ownership_writers(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1322 — every _CATEGORIES entry must have:
+    (a) a callable refresh_fn (the lambda in the tuple)
+    (b) current_table exists in DB
+    (c) observations_table exists in DB
+    (d) corresponding refresh_<category>_current importable from
+        app.services.ownership_observations namespace
+
+    Direct iteration over _CATEGORIES (multi-agent B2 + Codex iter-1
+    BLOCKING-2 fold — no string templating). Uses ``ebull_test_conn``
+    per CLAUDE.md test isolation.
+    """
+    from app.jobs.ownership_observations_repair import _CATEGORIES
+    from app.services import ownership_observations
+
+    for current_table, observations_table, category_literal, refresh_fn in _CATEGORIES:
+        assert callable(refresh_fn), f"_CATEGORIES entry for {category_literal!r}: refresh_fn is not callable"
+        assert _table_exists(ebull_test_conn, current_table), (
+            f"_CATEGORIES entry for {category_literal!r}: current_table {current_table!r} does not exist in DB"
+        )
+        assert _table_exists(ebull_test_conn, observations_table), (
+            f"_CATEGORIES entry for {category_literal!r}: observations_table "
+            f"{observations_table!r} does not exist in DB"
+        )
+        expected_fn_name = f"refresh_{category_literal}_current"
+        assert hasattr(ownership_observations, expected_fn_name), (
+            f"_CATEGORIES entry for {category_literal!r}: "
+            f"app.services.ownership_observations is missing "
+            f"function {expected_fn_name!r}. Either rename the function "
+            f"or update _CATEGORIES."
+        )

--- a/tests/smoke/test_etl_source_to_sink.py
+++ b/tests/smoke/test_etl_source_to_sink.py
@@ -235,6 +235,20 @@ _PARSER_MODULE_BY_SOURCE: dict[str, str] = {
     "finra_regsho_daily": "app.services.manifest_parsers.finra_regsho_daily",
 }
 
+# #1322 PR #1354 bot iter-1 WARNING fold — parallel-dict drift guard.
+# Module-level closure assertion catches the "new source landed in
+# MANIFEST_SOURCE_SINKS but forgot to add a parser module entry here"
+# regression at COLLECTION time, not at parametrize-iteration time.
+# Mirrors the import-time check in scripts/_etl_source_inventory.py.
+assert set(_PARSER_MODULE_BY_SOURCE) == set(MANIFEST_SOURCE_SINKS), (
+    f"_PARSER_MODULE_BY_SOURCE drift vs MANIFEST_SOURCE_SINKS:\n"
+    f"  only in _PARSER_MODULE_BY_SOURCE: "
+    f"{sorted(set(_PARSER_MODULE_BY_SOURCE) - set(MANIFEST_SOURCE_SINKS))}\n"
+    f"  only in MANIFEST_SOURCE_SINKS: "
+    f"{sorted(set(MANIFEST_SOURCE_SINKS) - set(_PARSER_MODULE_BY_SOURCE))}\n"
+    f"Update _PARSER_MODULE_BY_SOURCE in tests/smoke/test_etl_source_to_sink.py."
+)
+
 
 @pytest.mark.parametrize("source,spec", sorted(MANIFEST_SOURCE_SINKS.items()))
 def test_manifest_source_has_sink_tables(

--- a/tests/smoke/test_etl_source_to_sink_negative.py
+++ b/tests/smoke/test_etl_source_to_sink_negative.py
@@ -1,0 +1,77 @@
+"""#1322 — empirical negative test for source-to-sink smoke.
+
+Isolated in its own file (per code-simplifier review F1 safety concern):
+DDL-in-test + ROLLBACK pattern carries pollution risk if the rollback ever
+fails on an exception path. Separate file confines the failure mode and
+caps the blast radius. The fixture (`ebull_test_conn`) owns the
+exception-path rollback + connection close in its own `finally`; this
+test does explicit SAVEPOINT/ROLLBACK TO SAVEPOINT for the inner DROP.
+
+Pattern (multi-agent IMPORTANT-I1 + I5 fold; prevention-log "psycopg v3
+conn.transaction() is savepoint not commit" applies):
+
+* BEGIN → SAVEPOINT s1 → DROP TABLE ownership_funds_current
+* Invoke positive-test assertion (must fire — table is gone)
+* ROLLBACK TO SAVEPOINT s1 → ROLLBACK
+* Post-rollback: assert table exists again (proves rollback worked, leaves
+  worker DB clean for subsequent tests in same xdist session)
+
+Target table choice (multi-agent IMPORTANT-I1 fold): `ownership_funds_current`
+has no inbound FKs per `sql/123_ownership_funds.sql`; in `_PLANNER_TABLES`;
+safe to drop transiently. NOT a partitioned table (would CASCADE across
+quarter partitions and break unrelated tests via savepoint scope).
+
+xdist_group serializes within worker group — no cross-test pollution
+even if pytest dispatched two tests in this file concurrently (it doesn't,
+but defence-in-depth).
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from tests.smoke.test_etl_source_to_sink import _table_exists
+
+pytestmark = pytest.mark.xdist_group(name="etl_source_to_sink_negative")
+
+_TARGET_TABLE = "ownership_funds_current"
+
+
+def test_negative_drop_target_fires_smoke_assertion_then_rolls_back(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1322 — empirical proof the positive smoke catches a dropped table.
+
+    DROP target → assert _table_exists returns False (positive smoke would
+    FAIL here) → ROLLBACK → assert _table_exists returns True (rollback
+    worked).
+
+    Uses ``ebull_test_conn`` (worker-private DB per CLAUDE.md test isolation
+    + Codex iter-on-diff cross-impact note) — never the dev DB. SAVEPOINT
+    + ROLLBACK confines the DROP to the test's own transaction.
+    """
+    # Pre-condition: table exists before DROP
+    assert _table_exists(ebull_test_conn, _TARGET_TABLE), (
+        f"Pre-condition failed: {_TARGET_TABLE!r} missing from ebull_test DB "
+        f"before negative test ran. Check migration state."
+    )
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SAVEPOINT s1")
+        cur.execute(f"DROP TABLE {_TARGET_TABLE}")
+
+        # Inside the savepoint: positive-smoke assertion MUST fire
+        assert not _table_exists(ebull_test_conn, _TARGET_TABLE), (
+            f"Negative test bug: after DROP {_TARGET_TABLE}, _table_exists still returns True — savepoint scope wrong"
+        )
+
+        cur.execute("ROLLBACK TO SAVEPOINT s1")
+        cur.execute("RELEASE SAVEPOINT s1")
+
+    # Post-rollback: table exists again (proves rollback worked)
+    assert _table_exists(ebull_test_conn, _TARGET_TABLE), (
+        f"ROLLBACK TO SAVEPOINT failed to restore {_TARGET_TABLE!r}. "
+        f"Worker DB is now poisoned for subsequent tests. Check savepoint "
+        f"scope + psycopg v3 conn.transaction() semantics."
+    )


### PR DESCRIPTION
## Summary

Per Phase 0 sub-plan §2.3 v2.2 (`docs/proposals/etl/phase-0-instrumentation.md` v1.5, APPROVED by Codex iter-4 NIT-only).

Adds explicit source→sink-table declaration + 3 parametrized closure smoke tests + 1 empirical negative test (SAVEPOINT+DROP+ROLLBACK).

Closes #1322

## Changes

- **NEW** `MANIFEST_SOURCE_SINKS` dict in `scripts/_etl_source_inventory.py` (15 entries, 5 kinds) + import-time closure check
- **NEW** `_SYNTH_NOOP: Final[bool] = True` module constants in 4 synth-noop parser modules
- **NEW** 3 tests in `tests/smoke/test_etl_source_to_sink.py`:
  - `test_manifest_source_sinks_complete` (closure: set-equality vs `ManifestSource` Literal)
  - `test_manifest_source_has_sink_tables` (parametrized 15 entries: pg_tables existence + bidirectional `_SYNTH_NOOP` parity per kind)
  - `test_categories_match_ownership_writers` (direct `_CATEGORIES` iteration)
- **NEW** `tests/smoke/test_etl_source_to_sink_negative.py`: SAVEPOINT + DROP `ownership_funds_current` + assert table-missing + ROLLBACK + assert table-exists-again; xdist_group serialized; uses `ebull_test_conn` (worker-private DB)

## Review provenance (4 Codex plan iterations + 2 Codex diff iterations + multi-agent)

- **CLAUDE.md overlay**: no settled-decision conflicts; prevention-log lines 230/345/473/637 relevant (savepoint discipline, conn ownership)
- **Multi-agent (data-engineer + code-simplifier + Codex parallel)**: 3 BLOCKING + 4 IMPORTANT → folded v2 (mapping not derivable from registries; explicit declaration; corrected parser path; pg_tables not SELECT 1; xdist_group + separate-file isolation; cross-impact with siblings)
- **Codex plan iter-2**: 2 IMPORTANT (closure assertion; bidirectional `_SYNTH_NOOP` parity) → folded v2.1
- **Codex plan iter-3**: 1 IMPORTANT (bidirectional parity exact wording) → folded v2.2
- **Codex plan iter-4**: CLEAN — APPROVED
- **Codex on diff iter-1**: NIT-only + 1 cross-impact (dev DB usage) → fixed: all DB-touching tests now use `ebull_test_conn` (worker-private)
- **Codex on diff iter-2**: NIT-only (doc wording) → folded same commit

## Acceptance evidence

| Gate | Result |
|---|---|
| `uv run ruff check` + `format` + `pyright` | green ✓ |
| `pytest tests/smoke/test_etl_source_to_sink.py` | 104 passed + 3 skipped ✓ |
| `pytest tests/smoke/test_etl_source_to_sink_negative.py` | 1 passed (pre/inside/post-rollback existence checks) ✓ |
| Import-time closure check on drift | raises `RuntimeError` (sample-tested) ✓ |
| All 15 `MANIFEST_SOURCE_SINKS` entries | spot-grep-verified against `sql/*.sql` ✓ |

## Cross-impact

- `tests/test_capability_manifest_mapping.py`: read-only on `ManifestSource`, no shared state with new tests
- `tests/test_ownership_refresh_writer_merge.py`: uses `ebull_test_conn` (same fixture); negative test serialized via xdist_group → no race
- No `_PARSERS.clear()` callers in `tests/`

## Security and audit model

No execution path touched. Pure smoke + lint tests. Negative test does DDL inside savepoint scope on worker-private DB; explicit `ROLLBACK TO SAVEPOINT` restores schema; fixture owns connection lifecycle.

## Test plan

- [x] 15 sink-table existence checks pass against ebull_test
- [x] Closure check + parity check + categories check all green
- [x] Negative test: pre-existence + savepoint DROP + missing-inside + ROLLBACK + post-existence all green
- [x] xdist run with `--dist=loadgroup` (covered by existing pyproject config)

## Note on Phase 0 sub-plan doc

`docs/proposals/etl/phase-0-instrumentation.md` (v1.5 — APPROVED by Codex iter-5) is the spec this PR executes against. Plan doc lands as separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)