### PR TITLE
fix(#1225): _resolve_stage_rows hardening + source-1 contract pin

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -1279,6 +1279,35 @@ def _resolve_stage_rows(
        ``JobLock`` for this stage; the upper bound rejects same-
        ``job_name`` scheduled fires that landed after lock release.
 
+    Source contract is structurally asymmetric for the 5 bulk
+    ingester jobs (``sec_submissions_ingest_job``,
+    ``sec_companyfacts_ingest_job``, ``sec_13f_ingest_from_dataset_job``,
+    ``sec_insider_ingest_from_dataset_job``,
+    ``sec_nport_ingest_from_dataset_job``). Per ``#1225`` audit:
+
+    * Source 1 IS populated — each bulk job calls
+      ``_record_archive_result(rows_written=...)`` per archive (see
+      ``app/services/sec_bulk_orchestrator_jobs.py:211/280/386/579/744``).
+    * Source 2 is effectively dead — ``record_archive_result_if_absent``
+      writes ``__job__`` with ``rows_written=0``, so this source
+      always falls through to source 3 for the 5 bulk jobs (they don't
+      overload ``__job__`` themselves).
+    * Source 3 is structurally dead — the 5 bulk jobs are registered
+      via ``_adapt_zero_arg`` (not ``_tracked_job``) at
+      ``app/jobs/runtime.py:371-377``, so no ``job_runs`` row is
+      written. The window query returns nothing.
+
+    Therefore source 1 is load-bearing for these 5 jobs. Any code
+    path that fails to populate ``bootstrap_archive_results`` non-
+    ``__job__`` rows for them produces NULL → strict-gate cap death
+    → downstream blockage. Audit memo at
+    ``docs/proposals/etl/audits/1225-rows-processed-null.md``.
+
+    Caller (``_run_one_stage`` at ``bootstrap_orchestrator.py``) wraps
+    this function in a 2-attempt retry + contained-fail loop. Raising
+    here is acceptable and surfaces as a stage-error rather than a
+    silent NULL on success (#1225 fix).
+
     #1140 / Task C of #1136 audit (spec at
     docs/superpowers/specs/2026-05-13-precondition-final-data-gates.md).
     """
@@ -1500,22 +1529,66 @@ def _run_one_stage(
     # #1140 Task C — resolve rows_processed from the side-channels and
     # commit it onto the stage row so the cap-eval layer + the
     # operator panel aggregate read real numbers instead of NULL.
+    #
+    # #1225 — retry-once + contained-fail on persistent
+    # resolver exception. The original implementation swallowed any
+    # exception (DB blip, serialisation failure, network glitch) into
+    # ``resolved_rows = None``, which then flowed silently into
+    # ``mark_stage_success`` as NULL and tripped the downstream
+    # strict-gate floor at ``_capability_is_dead`` — producing the
+    # run_id=3 (2026-05-17) S23/S24 blocked-on-success symptom.
+    #
+    # The fix: distinguish "resolver ran successfully and legitimately
+    # returned None (no side-channel data)" from "resolver raised on
+    # both attempts" via the ``resolution_succeeded`` flag. On
+    # persistent failure, persist ``mark_stage_error`` + return a
+    # contained ``_StageOutcome(success=False, ...)``. Raw raise is
+    # NOT acceptable — ``fut.result()`` at the dispatcher
+    # (``_phase_batched_dispatch:2040``) would re-raise and tear
+    # through the orchestrator. See docs/proposals/etl/audits/1225-
+    # rows-processed-null.md for forensic context.
     resolved_rows: int | None = None
-    try:
-        with psycopg.connect(database_url) as conn:
-            resolved_rows = _resolve_stage_rows(
-                conn,
-                bootstrap_run_id=run_id,
-                stage_key=stage_key,
-                job_name=job_name,
-                job_runs_id_before=job_runs_id_before,
-                job_runs_id_after=job_runs_id_after,
+    last_resolution_error: str | None = None
+    resolution_succeeded = False
+    for attempt in range(2):
+        try:
+            with psycopg.connect(database_url) as conn:
+                resolved_rows = _resolve_stage_rows(
+                    conn,
+                    bootstrap_run_id=run_id,
+                    stage_key=stage_key,
+                    job_name=job_name,
+                    job_runs_id_before=job_runs_id_before,
+                    job_runs_id_after=job_runs_id_after,
+                )
+            resolution_succeeded = True
+            break  # success — ``resolved_rows`` may legitimately be None (no side-channel)
+        except Exception as exc:  # noqa: BLE001 — captured below for stage error
+            last_resolution_error = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "bootstrap stage %s: resolve_rows attempt %d failed: %s",
+                stage_key,
+                attempt + 1,
+                exc,
             )
-    except Exception as exc:  # noqa: BLE001 — auditing must not fail the stage
-        logger.warning(
-            "bootstrap stage %s: failed to resolve rows_processed: %s",
-            stage_key,
-            exc,
+
+    if not resolution_succeeded:
+        error_msg = f"rows_processed_resolution_failed after 2 attempts: {last_resolution_error}"
+        # Persist stage status to 'error' BEFORE returning the
+        # contained outcome so the DB matches dispatcher memory.
+        with psycopg.connect(database_url) as conn:
+            mark_stage_error(
+                conn,
+                run_id=run_id,
+                stage_key=stage_key,
+                error_message=error_msg,
+            )
+            conn.commit()
+        return _StageOutcome(
+            stage_key=stage_key,
+            success=False,
+            error=error_msg,
+            rows_processed=None,
         )
 
     with psycopg.connect(database_url) as conn:

--- a/docs/proposals/etl/audits/1225-rows-processed-null.md
+++ b/docs/proposals/etl/audits/1225-rows-processed-null.md
@@ -1,0 +1,120 @@
+# Audit memo — #1225 bulk SEC ingesters land `rows_processed=NULL`
+
+**Status**: Forensic record (does NOT gate the #1225 fix)
+**Date**: 2026-05-25
+**Author**: Phase 0 §2.1 work
+**Source PR**: fix/1225-rows-processed-null-resolver-hardening
+**Reference**: `docs/proposals/etl/phase-0-instrumentation.md` §2.1
+
+## Symptom (issue body)
+
+Run_id=3 (dev DB, 2026-05-17): S23 (`ownership_observations_backfill`) and S24 (`fundamentals_sync`) ended `blocked` with structured reason:
+
+```
+S23: missing capability institutional_inputs_seeded; no surviving provider met
+     rows floor 1 (providers: sec_13f_ingest_from_dataset=success
+     [rows_processed=NULL], sec_13f_recent_sweep=?)
+S24: missing capability fundamentals_raw_seeded; no surviving provider met
+     rows floor 1 (providers: sec_companyfacts_ingest=success
+     [rows_processed=NULL])
+```
+
+`sec_13f_ingest_from_dataset` and `sec_companyfacts_ingest` landed `status='success'` but `bootstrap_stages.rows_processed=NULL`. The strict-gate cap-eval (`_capability_is_dead` at `bootstrap_orchestrator.py:732`, floor=1) marked the capability dead → S23/S24 blocked.
+
+## Run_id=3 evidence is GONE
+
+The 2026-05-17 dev DB state cannot be reproduced. Subsequent merges to main mutated the relevant code paths:
+
+- **#1233 PR-3** (COPY refactor) — touched bulk-ingester rowcount paths
+- **#1233 PR-12** (MERGE writer) — touched `ownership_*_current` refresh helpers
+- **#1294** (`1692252`, 2026-05-23) — fixed `sec_companyfacts_ingest` `rows_written` semantics specifically
+- **#1218** (XBRL partition guards) — touched downstream ingest path
+
+Audit cannot dispositively reproduce the original NULL. This memo is FORENSIC — documents the diagnosis + cites the fix. The fix lands regardless.
+
+## 4-candidate decision tree (per Phase 0 §2.1 plan v1.5)
+
+The plan listed 4 root-cause candidates. Multi-agent + Codex review eliminated/recharacterised them all:
+
+### Candidate 1 — `_current_running_bootstrap_run_id()` returns wrong run
+
+**Symptom**: when bulk job runs OUTSIDE orchestrator context (manual `/jobs/<name>/run` fire), `_current_running_bootstrap_run_id()` at `sec_bulk_orchestrator_jobs.py:90` returns `None`, the `if run_id is not None` guard skips `_record_archive_result`, source 1 stays empty for that run.
+
+**Disposition**: PARTIAL — collapses onto Candidate 2 as the same chokepoint (writer side). Manual-fire path has `run_id=None` so the resolver isn't invoked anyway (no stage to resolve); cannot produce the run_id=3 symptom (`success [rows_processed=NULL]` on a stage row).
+
+### Candidate 2 — writer/reader run-id mismatch
+
+**Symptom**: `_record_archive_result` writes with `_current_running_bootstrap_run_id()` value; `_resolve_stage_rows` reads with `_run_one_stage`'s `bootstrap_run_id` param. Failover/race could diverge.
+
+**Disposition**: CANNOT FIRE on healthy DB. `sql/129` line 75-76 has partial UNIQUE `bootstrap_runs_one_running_idx ON bootstrap_runs(status) WHERE status='running'`. At most one `running` row. `_current_running_bootstrap_run_id`'s `ORDER BY id DESC LIMIT 1` resolves deterministically. Merged into Candidate 1 (same chokepoint, different angles).
+
+### Candidate 3 — `rows_skipped` semantics on no-op rerun
+
+**Symptom**: `companyfacts.facts_seen=0` on no-op rerun gives `rows_written=0`; strict-gate floor=1 marks cap dead.
+
+**Disposition**: ALREADY FIXED by #1294 (commit `1692252`). Test `tests/test_companyfacts_rows_processed.py` covers the regression. Other 4 bulk ingesters (`sec_submissions`, `sec_13f_ingest_from_dataset`, `sec_insider_ingest_from_dataset`, `sec_nport_ingest_from_dataset`) all `raise RuntimeError` on `total_written == 0` (lines 425, 605, 794 of `sec_bulk_orchestrator_jobs.py`) — so they produce `status='error'`, not `success`+0. Candidate 3 cannot produce `success`+NULL anywhere; produces 0 (companyfacts, now fixed) or error (others).
+
+### Candidate 4 — transaction discipline (`_record_archive_result` shares ingester `with conn.transaction()`)
+
+**Disposition**: STALE against current code. `_record_archive_result` at `sec_bulk_orchestrator_jobs.py:124-133` opens its own `psycopg.connect()` + commits independently. NOT shared with ingester. Survives ingester rollback. Cannot fire.
+
+## NEW CANDIDATE 5 — `_resolve_stage_rows` exceptions silently swallowed (THE REAL BUG CLASS)
+
+**Discovery**: Codex iter-1 review of plan §2.1 spotted the swallow at `bootstrap_orchestrator.py:1503-1518` (pre-fix):
+
+```python
+resolved_rows: int | None = None
+try:
+    with psycopg.connect(database_url) as conn:
+        resolved_rows = _resolve_stage_rows(conn, ...)
+except Exception as exc:  # noqa: BLE001 — auditing must not fail the stage
+    logger.warning("... failed to resolve rows_processed: %s", stage_key, exc)
+
+# resolved_rows still None here ⇒ mark_stage_success writes NULL ⇒ strict-gate fires
+mark_stage_success(..., rows_processed=resolved_rows)
+```
+
+**Any DB error during resolution** (`SerializationFailure`, `OperationalError` connection blip, `DataError` from prepared-statement hash mismatch, etc.) → `resolved_rows` stays `None` → `bootstrap_stages.rows_processed=NULL` → strict-gate floor=1 marks cap dead → S23/S24 block.
+
+This is the load-bearing bug class. Matches the run_id=3 symptom exactly. Any of the post-#1140 bulk-ingester runs that experienced a transient resolver-side DB error would have produced the observed NULL.
+
+## NEW CANDIDATE 6 — `_resolve_stage_rows` source contract is structurally asymmetric for the 5 bulk jobs
+
+**Discovery**: data-engineer lens review during plan §2.1 audit.
+
+The 3-source precedence in `_resolve_stage_rows` (`bootstrap_orchestrator.py:1253`):
+- **Source 1** (`bootstrap_archive_results` non-`__job__` rows SUM): populated by each of 5 bulk ingester `_record_archive_result` calls at `sec_bulk_orchestrator_jobs.py:211/280/386/579/744`. ✓ FUNCTIONAL.
+- **Source 2** (`__job__` row > 0): orchestrator writes `__job__` with `rows_written=0` via `record_archive_result_if_absent` at `bootstrap_orchestrator.py:1481-1492`. Always 0 for the 5 bulk jobs. ✗ EFFECTIVELY DEAD.
+- **Source 3** (`job_runs.row_count`): the 5 bulk jobs are wrapped via `_adapt_zero_arg` at `app/jobs/runtime.py:371-377`, NOT via `_tracked_job`. No `job_runs` row is written. ✗ STRUCTURALLY DEAD.
+
+**Net**: Source 1 is the only functional source for these 5 jobs. Any code path that fails to populate it OR resolves through an exception → NULL.
+
+## Fix shipped in #1225
+
+Per Phase 0 §2.1 v5.2:
+
+- **Layer A** — `_resolve_stage_rows` invocation retry-once + contained-fail in `_run_one_stage`. On persistent failure (both attempts raise), call `mark_stage_error(..., error_message="rows_processed_resolution_failed after 2 attempts: <exc>")` + `conn.commit()` + return `_StageOutcome(success=False, ...)`. Stage status persists at `error` (not `running` or `success`). Operator sees real error immediately, not days later when downstream cap dies.
+
+- **Layer B** — parametrized regression test at `tests/test_bootstrap_rows_processed_resolution.py` covers 5 bulk stage keys in orchestrated context. Asserts `_resolve_stage_rows` returns SUM when source 1 is populated. Plus a separate Layer A exception-path test that mocks `_resolve_stage_rows` to raise twice and asserts the contained-fail behaviour.
+
+- **Layer C** — `_resolve_stage_rows` docstring updated at `bootstrap_orchestrator.py:1253` to document the asymmetric source contract for the 5 bulk jobs (source 1 is load-bearing; sources 2 and 3 are dead by design).
+
+## Manual-fire path NOT in scope
+
+Manual-fire (`/jobs/<name>/run` outside bootstrap) has `_current_running_bootstrap_run_id()=None`. The bulk wrappers skip `_record_archive_result`. `_resolve_stage_rows` is NOT invoked outside orchestration (no stage row exists). Manual-fire's "NULL" is correct-by-design — there is no `bootstrap_stages` row to populate.
+
+## Cross-impact
+
+- `_resolve_stage_rows` is called at exactly 1 site (`bootstrap_orchestrator.py:1505`). Layer A change does not widen reader contract.
+- `record_archive_result_if_absent` callers — unaffected.
+- `_record_archive_result` callers in tests — only `tests/test_companyfacts_rows_processed.py` exists pre-fix; new `tests/test_bootstrap_rows_processed_resolution.py` adds 5 parametrized cases + 1 Layer A case.
+- Tests asserting `bootstrap_stages.rows_processed IS NULL` under failure mode — verified none exist (grep clean). Layer A's "mark stage error on persistent failure" changes the contract from "silent success with NULL rows" to "loud error with `rows_processed_resolution_failed` prefix message"; no existing test breaks.
+
+## Lessons + prevention candidates
+
+- **Silent-exception-swallow pattern is a NULL-producing bug class**. The `try/except: logger.warning` + use-the-still-None-value pattern at `bootstrap_orchestrator.py:1503-1518` is the canonical shape. Consider a lint pass for similar patterns in audit/observability code paths.
+- **Asymmetric source contracts deserve docstring callouts**. Future maintainers reading `_resolve_stage_rows` without the asymmetry note will assume sources 2 + 3 are reasonable fallbacks for ANY job, and will design fixes that "fall through to source 3" — which is dead for these 5 jobs. Layer C docstring update mitigates.
+
+## Forensic disposition
+
+#1225 closed in this PR via structural fix (Layers A/B/C). Audit memo (this doc) records what could and couldn't be proven from current-state evidence. Original 2026-05-17 incident is forensically closed.

--- a/tests/test_bootstrap_rows_processed_resolution.py
+++ b/tests/test_bootstrap_rows_processed_resolution.py
@@ -75,10 +75,12 @@ def _seed_run(conn: psycopg.Connection[tuple], stage_key: str) -> int:
     """Create a minimal bootstrap_runs + bootstrap_stages row for the test
     stage. Returns run_id.
 
-    Resets ``bootstrap_state.status`` to ``'idle'`` first — the singleton
-    is NOT truncated by ``_PLANNER_TABLES`` (intentionally; the row is the
-    boot-state lock). A prior test leaving it at ``'running'`` would
-    cause ``start_run`` to raise ``BootstrapAlreadyRunning``.
+    Resets ``bootstrap_state.status`` to ``'pending'`` first — the
+    singleton is NOT truncated by ``_PLANNER_TABLES`` (intentionally;
+    the row is the boot-state lock). A prior test leaving it at
+    ``'running'`` would cause ``start_run`` to raise
+    ``BootstrapAlreadyRunning``. ``'pending'`` is the post-init fresh
+    state allowed by ``bootstrap_state_status_check`` (sql/136).
     """
     with conn.transaction():
         # Valid status values per sql/136 CHECK: pending, running, complete,

--- a/tests/test_bootstrap_rows_processed_resolution.py
+++ b/tests/test_bootstrap_rows_processed_resolution.py
@@ -1,0 +1,312 @@
+"""#1225 — rows_processed resolution hardening.
+
+Two test classes:
+
+* Layer A: ``_run_one_stage`` retry-once + contained-fail on persistent
+  ``_resolve_stage_rows`` exception. Pre-fix: any DB error during
+  resolution silently produced ``bootstrap_stages.rows_processed=NULL``
+  which then tripped the downstream strict-gate floor and blocked S23/S24.
+  Post-fix: retry once, then mark stage ``error`` + return contained
+  ``_StageOutcome(success=False, error="rows_processed_resolution_failed
+  after 2 attempts: ...")``.
+
+* Layer B: contract pin for the 5 bulk ingester stages. The source
+  contract is structurally asymmetric for these stages (sources 2 + 3
+  of ``_resolve_stage_rows`` are dead by design — see updated docstring
+  at ``app/services/bootstrap_orchestrator.py::_resolve_stage_rows``).
+  Source 1 (``bootstrap_archive_results`` non-``__job__`` rows) is the
+  load-bearing source. Parametrized regression: for each of the 5
+  stage_keys, simulate a ``_record_archive_result`` write and assert
+  ``_resolve_stage_rows`` returns the expected SUM (non-None).
+
+Forensic context: ``docs/proposals/etl/audits/1225-rows-processed-null.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import psycopg
+import pytest
+
+from app.services import bootstrap_orchestrator
+from app.services.bootstrap_orchestrator import (
+    _resolve_stage_rows,
+    _run_one_stage,
+    _StageOutcome,
+)
+from app.services.bootstrap_preconditions import record_archive_result_if_absent
+from app.services.bootstrap_state import StageSpec, start_run
+from tests.fixtures.ebull_test_db import ebull_test_conn, test_database_url
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable"),
+    # _run_one_stage uses _adapt_zero_arg invokers + opens own psycopg
+    # connections; pin to one xdist worker so the per-test DB isn't
+    # racing with a parallel test on the same fixture.
+    pytest.mark.xdist_group(name="rows_processed_resolution"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Layer B fixtures
+# ---------------------------------------------------------------------------
+
+# 5 bulk ingester stage_keys per Phase 0 audit. Each writes
+# bootstrap_archive_results non-__job__ rows via _record_archive_result.
+# Source 1 is load-bearing because sources 2+3 are structurally dead
+# (see _resolve_stage_rows docstring).
+BULK_INGEST_STAGE_KEYS = (
+    "sec_submissions_ingest",
+    "sec_companyfacts_ingest",
+    "sec_13f_ingest_from_dataset",
+    "sec_insider_ingest_from_dataset",
+    "sec_nport_ingest_from_dataset",
+)
+
+
+def _seed_run(conn: psycopg.Connection[tuple], stage_key: str) -> int:
+    """Create a minimal bootstrap_runs + bootstrap_stages row for the test
+    stage. Returns run_id.
+
+    Resets ``bootstrap_state.status`` to ``'idle'`` first — the singleton
+    is NOT truncated by ``_PLANNER_TABLES`` (intentionally; the row is the
+    boot-state lock). A prior test leaving it at ``'running'`` would
+    cause ``start_run`` to raise ``BootstrapAlreadyRunning``.
+    """
+    with conn.transaction():
+        # Valid status values per sql/136 CHECK: pending, running, complete,
+        # partial_error, cancelled. 'pending' is the post-init fresh state.
+        conn.execute("UPDATE bootstrap_state SET status = 'pending' WHERE id = 1")
+    return start_run(
+        conn,
+        operator_id=None,
+        stage_specs=[
+            StageSpec(
+                stage_key=stage_key,
+                stage_order=1,
+                lane="sec_rate",  # any valid Lane literal
+                job_name=stage_key,
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer B — source-1 contract pin (parametrized over 5 bulk stages)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("stage_key", BULK_INGEST_STAGE_KEYS)
+def test_resolver_returns_sum_when_source1_populated(
+    stage_key: str,
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1225 Layer B contract pin — for each of 5 bulk stages, a populated
+    source 1 (bootstrap_archive_results non-__job__ rows) MUST resolve to
+    the SUM.
+
+    Pure resolver-side regression: prevents a future refactor from breaking
+    the only functional source for these 5 stages.
+    """
+    run_id = _seed_run(ebull_test_conn, stage_key)
+    ebull_test_conn.commit()
+
+    # Simulate ingester writes via _record_archive_result (the same path
+    # the 5 bulk jobs use at sec_bulk_orchestrator_jobs.py:211/280/386/579/744).
+    # Two synthetic archives with non-zero rows_written.
+    record_archive_result_if_absent(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key=stage_key,
+        archive_name=f"{stage_key}_archive_a.zip",
+        rows_written=42,
+    )
+    record_archive_result_if_absent(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key=stage_key,
+        archive_name=f"{stage_key}_archive_b.zip",
+        rows_written=8,
+    )
+    ebull_test_conn.commit()
+
+    resolved = _resolve_stage_rows(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key=stage_key,
+        job_name=stage_key,
+        job_runs_id_before=0,
+        job_runs_id_after=0,
+    )
+
+    assert resolved == 50, (
+        f"Source 1 resolution broken for {stage_key!r}: expected SUM=50 "
+        f"(42+8), got {resolved!r}. Source 1 is the only functional source "
+        f"for the 5 bulk jobs — see _resolve_stage_rows docstring."
+    )
+
+
+@pytest.mark.parametrize("stage_key", BULK_INGEST_STAGE_KEYS)
+def test_orchestrated_run_one_stage_persists_rows_processed_via_invoker_archive_writes(
+    stage_key: str,
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1225 Layer B end-to-end — exercise the full _run_one_stage chain
+    for each of the 5 bulk stages with a fake invoker that calls
+    _record_archive_result (the same path real bulk ingesters use at
+    sec_bulk_orchestrator_jobs.py:211/280/386/579/744).
+
+    Asserts the orchestrated flow lands a non-NULL bootstrap_stages.rows_processed
+    via the source-1 path. Catches writer-path regression classes:
+    - bulk job stops calling _record_archive_result → archive_results empty → NULL
+    - stage_key drift between writer and resolver → resolver finds nothing → NULL
+    - _run_one_stage resolver-output-to-mark_stage_success wiring breaks
+      (e.g. NULL passed even when resolver returned an int)
+
+    Out of scope (separate failure mode): _current_running_bootstrap_run_id()
+    drift in production bulk-job wrappers. This test uses a fake invoker that
+    closes over the run_id; the helper's wrong-run failure mode is its own
+    test surface (and is gated upstream by the singleton-running invariant
+    at sql/129).
+    """
+    run_id = _seed_run(ebull_test_conn, stage_key)
+    ebull_test_conn.commit()
+    db_url = test_database_url()
+
+    # Fake invoker that mirrors what real bulk ingesters do at their
+    # _record_archive_result call sites: write a non-__job__ archive
+    # results row keyed to the orchestrated run_id + stage_key.
+    invoker_call_count = {"n": 0}
+
+    def _fake_bulk_invoker(*args: Any, **kwargs: Any) -> None:  # noqa: ARG001
+        invoker_call_count["n"] += 1
+        # Open own connection (mirrors _record_archive_result pattern at
+        # sec_bulk_orchestrator_jobs.py:124).
+        with psycopg.connect(db_url) as conn:
+            record_archive_result_if_absent(
+                conn,
+                bootstrap_run_id=run_id,
+                stage_key=stage_key,
+                archive_name=f"{stage_key}_e2e_archive.zip",
+                rows_written=123,
+            )
+            conn.commit()
+
+    outcome = _run_one_stage(
+        run_id=run_id,
+        stage_key=stage_key,
+        job_name=stage_key,
+        invoker=_fake_bulk_invoker,
+        database_url=db_url,
+        params={},
+    )
+
+    # Invoker actually ran
+    assert invoker_call_count["n"] == 1, f"Fake invoker called {invoker_call_count['n']} times; expected 1"
+
+    # Stage succeeded with non-NULL rows_processed (the bug class fix)
+    assert outcome.success is True, f"Expected success outcome; got {outcome!r}"
+    assert outcome.rows_processed == 123, (
+        f"Expected rows_processed=123 from orchestrated invocation; got "
+        f"{outcome.rows_processed!r}. This is the run_id=3 symptom — "
+        f"writer wrote source-1 but resolver returned NULL anyway."
+    )
+
+    # DB stage row reflects the same (no silent NULL on success)
+    with psycopg.connect(db_url) as verify_conn, verify_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, rows_processed FROM bootstrap_stages WHERE bootstrap_run_id = %s AND stage_key = %s",
+            (run_id, stage_key),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        status, rows_processed = row
+        assert status == "success"
+        assert rows_processed == 123, f"DB stage rows_processed mismatch: expected 123, got {rows_processed!r}"
+
+
+# ---------------------------------------------------------------------------
+# Layer A — resolver exception handling
+# ---------------------------------------------------------------------------
+
+
+def test_run_one_stage_returns_contained_fail_when_resolver_raises_twice(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1225 Layer A — when _resolve_stage_rows raises on BOTH attempts,
+    _run_one_stage must:
+
+    1. NOT silently swallow + write NULL (pre-fix behaviour that
+       produced run_id=3 S23/S24 blocked-on-success).
+    2. Mark stage 'error' in DB BEFORE returning.
+    3. Return _StageOutcome(success=False, error="rows_processed_resolution_failed
+       after 2 attempts: ...").
+    4. NOT raise raw — exception must NOT escape to future.result() at
+       _phase_batched_dispatch:2040 (would tear through the orchestrator).
+    """
+    stage_key = "sec_submissions_ingest"
+    run_id = _seed_run(ebull_test_conn, stage_key)
+    ebull_test_conn.commit()
+
+    # Fake invoker returns immediately (the stage "succeeds" before
+    # rows_processed resolution kicks in).
+    def _fake_invoker(*args: Any, **kwargs: Any) -> None:  # noqa: ARG001
+        return None
+
+    # _run_one_stage signature: (run_id, stage_key, job_name, invoker, database_url, params)
+    # We need _resolve_stage_rows to raise on both attempts.
+    resolve_call_count = {"n": 0}
+
+    def _always_raise(*args: Any, **kwargs: Any) -> int | None:  # noqa: ARG001
+        resolve_call_count["n"] += 1
+        raise psycopg.errors.SerializationFailure("synthetic SerializationFailure for #1225 Layer A regression test")
+
+    # ``conn.info.dsn`` masks the password; use the fixture helper which
+    # constructs the full URL with credentials so the test can open
+    # additional connections inside ``_run_one_stage``.
+    db_url = test_database_url()
+
+    with patch.object(bootstrap_orchestrator, "_resolve_stage_rows", side_effect=_always_raise):
+        outcome = _run_one_stage(
+            run_id=run_id,
+            stage_key=stage_key,
+            job_name=stage_key,
+            invoker=_fake_invoker,
+            database_url=db_url,
+            params={},
+        )
+
+    # Assertion 1 — resolver was called twice (retry once)
+    assert resolve_call_count["n"] == 2, f"Expected 2 resolver attempts (retry-once); got {resolve_call_count['n']}"
+
+    # Assertion 2 — outcome is contained-fail
+    assert isinstance(outcome, _StageOutcome)
+    assert outcome.success is False, f"Expected contained-fail _StageOutcome; got success={outcome.success!r}"
+    assert outcome.error is not None
+    assert outcome.error.startswith("rows_processed_resolution_failed after 2 attempts:"), (
+        f"Error message must start with prefix; got: {outcome.error!r}"
+    )
+    assert outcome.rows_processed is None
+
+    # Assertion 3 — DB persists stage as 'error' (NOT 'running' or 'success')
+    with psycopg.connect(db_url) as verify_conn, verify_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, last_error FROM bootstrap_stages WHERE bootstrap_run_id = %s AND stage_key = %s",
+            (run_id, stage_key),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        status, last_error = row
+        assert status == "error", (
+            f"DB stage status must be 'error' after resolver-failure; got {status!r}. "
+            f"Pre-fix bug: status would have stayed 'running' (process gone, no recovery)."
+        )
+        assert last_error is not None
+        assert "rows_processed_resolution_failed" in last_error


### PR DESCRIPTION
## Summary

Per Phase 0 sub-plan §2.1 v5.2 (`docs/proposals/etl/phase-0-instrumentation.md` v1.5, APPROVED by Codex iter-7).

Hardens the `_resolve_stage_rows` invocation in `_run_one_stage` against silent exception swallow (the load-bearing bug class that produced run_id=3 S23/S24 `success [rows_processed=NULL]` symptom). Adds 11 regression tests + forensic audit memo + asymmetric source contract documentation.

Closes #1225

## Changes

- **app/services/bootstrap_orchestrator.py**:
  - **Layer A**: `_resolve_stage_rows` invocation now retry-once + contained-fail. On persistent failure: `mark_stage_error` + commit + return `_StageOutcome(success=False, error="rows_processed_resolution_failed after 2 attempts: ...")`. Stage status persists at `'error'` (not `'running'` or silent `'success'` with NULL).
  - **Layer C**: `_resolve_stage_rows` docstring extended with asymmetric source contract for 5 bulk jobs (source 1 is load-bearing; sources 2 + 3 are dead by design).
- **tests/test_bootstrap_rows_processed_resolution.py** (NEW, ~245 LOC, 11 tests):
  - Layer A (1): mock resolver to raise twice; assert contained fail + DB persistence
  - Layer B (10): 5 resolver-contract + 5 orchestrated end-to-end (parametrized over bulk stage_keys)
- **docs/proposals/etl/audits/1225-rows-processed-null.md** (NEW): forensic audit memo

## Review provenance (7 Codex plan iterations + 2 Codex diff iterations + multi-agent)

- **Multi-agent + Codex iter-1**: surfaced 4-candidate plan was structurally wrong (candidates 3+4 stale; 1+2 collapse; NEW Candidate 5 exception swallow; NEW Candidate 6 asymmetric source contract)
- **Codex iter-2-7**: iterative refinement of Layer A pseudocode (raw raise → contained _StageOutcome + mark_stage_error persistence + resolution_succeeded boolean to avoid the false-success bug)
- **Codex on diff iter-1 BLOCKING**: Layer B was resolver-only; didn't exercise full `_run_one_stage` chain → added 5 orchestrated end-to-end tests
- **Codex on diff iter-2**: NIT only (comment overclaim) → folded

## Acceptance evidence

| Gate | Result |
|---|---|
| `uv run ruff check` + `format` + `pyright` | green ✓ |
| `pytest tests/test_bootstrap_rows_processed_resolution.py` | 11 passed ✓ |
| Audit memo committed at `docs/proposals/etl/audits/1225-rows-processed-null.md` | ✓ |
| Cross-impact grep on `_resolve_stage_rows` callers | single call site, no breakage ✓ |

## Cross-impact

- `_resolve_stage_rows` has exactly 1 caller (`_run_one_stage`). Layer A doesn't widen reader contract.
- `mark_stage_error` already imported. No new imports.
- No test asserts `rows_processed IS NULL` under failure mode (grep clean). Layer A changes contract from "silent success with NULL" to "loud error with prefix message"; no breakage.
- `tests/test_companyfacts_rows_processed.py` (#1294) unaffected — different code path.

## Manual-fire is out of scope

Manual-fire (`/jobs/<name>/run` outside bootstrap) has `_current_running_bootstrap_run_id()=None` so the bulk wrappers skip `_record_archive_result` and `_resolve_stage_rows` is never invoked. There's no `bootstrap_stages` row to populate — the NULL is correct-by-design in that path.

## Security and audit model

No execution path touched. Hardens the bookkeeping path so a transient resolver-side DB error surfaces as a loud stage `error` (operator sees the real exception immediately via `bootstrap_stages.last_error`) instead of a silent `success` with NULL that takes days to surface via downstream cap death.

## Test plan

- [x] Layer A test: resolver raises twice → contained `_StageOutcome(success=False, ...)` + DB `status='error'`
- [x] Layer B resolver-contract: 5 parametrized cases pass
- [x] Layer B end-to-end: 5 parametrized cases exercise `_run_one_stage` → fake invoker → `_record_archive_result` → resolver → persisted DB row
- [x] Pre-push gates green

## Note on Phase 0 sub-plan doc

`docs/proposals/etl/phase-0-instrumentation.md` (v1.5 APPROVED by Codex iter-5; §2.1 evolved to v5.2 in 7 iterations) is the spec. Plan doc lands as separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)