### PR TITLE
feat(#1356): Phase 0.5 dispatcher residual-idle telemetry

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -49,10 +49,12 @@ parallel manual / scheduled trigger cannot run twice simultaneously.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, time, timedelta
+from pathlib import Path
 from typing import Any, Final, Literal
 
 import psycopg
@@ -1673,6 +1675,110 @@ class _RunnableStage:
     params: Mapping[str, Any] = field(default_factory=dict)
 
 
+# ---------------------------------------------------------------------------
+# Phase 0.5 dispatcher residual-idle telemetry (#1275 re-investigation)
+# ---------------------------------------------------------------------------
+#
+# Spec: docs/proposals/etl/phase-0-instrumentation.md §2.9.
+#
+# Captures per-iteration per-lane dispatcher state to JSONL so
+# scripts/dispatcher_idle_analysis.py can answer "did the dispatcher
+# leave actionable work undispatched while a lane sat idle?". The
+# question matters because #1275 hypothesised 30-50% wall-clock waste
+# pre-PR-2 (#1233 batch-join → FIRST_COMPLETED); the hypothesis was
+# never re-validated against the post-PR-2 dispatcher and Phase 0.5
+# is the empirical re-check.
+#
+# Per-lane ``idle_type`` classification (spec §2.9.2):
+#
+#   * ``"A"`` — dependency-natural: no ready stages, only blocked.
+#     This is the dispatcher correctly waiting for upstream caps.
+#   * ``"B"`` — actionable bug: at least one ready stage exists,
+#     the lane is idle anyway. This is the bug-shape #1275 hunts.
+#   * ``None`` — busy (in_flight > 0), drained (no pending), or a
+#     completion iteration (``wait_returned_empty=False``).
+#
+# Telemetry I/O failures are swallowed with a warning — the dispatcher
+# MUST NEVER crash on a telemetry write. The aggregator script runs
+# offline against the JSONL after a bootstrap run completes.
+
+_DISPATCHER_IDLE_DIR: Final[Path] = Path("var/dispatcher_idle")
+
+
+def _emit_dispatcher_telemetry(
+    *,
+    run_id: int,
+    iteration: int,
+    statuses: Mapping[str, str],
+    in_flight_keys: set[str],
+    lane_in_flight_count: Mapping[str, int],
+    caps: set[Capability],
+    by_key: Mapping[str, _RunnableStage],
+    wait_returned_empty: bool,
+    output_dir: Path = _DISPATCHER_IDLE_DIR,
+) -> None:
+    """Append one JSONL line per iteration to ``<output_dir>/<run_id>.jsonl``.
+
+    Fires on BOTH the wait-timeout branch and the completion branch
+    so residual-idle iterations (where no future completed within
+    ``_CANCEL_POLL_INTERVAL``) are captured — those are exactly the
+    iterations Phase 0.5 needs to classify.
+
+    Telemetry write failures are logged and swallowed. The dispatcher
+    must not crash on a telemetry error.
+    """
+    try:
+        pending_keys = [k for k, s in statuses.items() if s == "pending" and k not in in_flight_keys and k in by_key]
+        lane_pending_ready: dict[str, list[str]] = {}
+        lane_pending_blocked: dict[str, list[str]] = {}
+        for key in pending_keys:
+            stage = by_key[key]
+            if _requirement_satisfied(stage.requires, caps):
+                lane_pending_ready.setdefault(stage.lane, []).append(key)
+            else:
+                lane_pending_blocked.setdefault(stage.lane, []).append(key)
+
+        all_lanes = set(lane_in_flight_count.keys()) | set(lane_pending_ready.keys()) | set(lane_pending_blocked.keys())
+
+        lanes_out: dict[str, dict[str, Any]] = {}
+        for lane in sorted(all_lanes):
+            in_flight = lane_in_flight_count.get(lane, 0)
+            ready = sorted(lane_pending_ready.get(lane, []))
+            blocked = sorted(lane_pending_blocked.get(lane, []))
+            if in_flight > 0 or not wait_returned_empty:
+                idle_type: str | None = None
+            elif ready:
+                idle_type = "B"
+            elif blocked:
+                idle_type = "A"
+            else:
+                idle_type = None
+            lanes_out[lane] = {
+                "in_flight": in_flight,
+                "pending_ready": ready,
+                "pending_blocked": blocked,
+                "idle_type": idle_type,
+            }
+
+        record = {
+            "ts": datetime.now(UTC).isoformat(),
+            "run_id": run_id,
+            "iteration": iteration,
+            "wait_returned_empty": wait_returned_empty,
+            "lanes": lanes_out,
+        }
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path = output_dir / f"{run_id}.jsonl"
+        # Single write so an unlikely concurrent run against the same
+        # run_id cannot interleave halves of a line (POSIX append-mode
+        # write is atomic up to PIPE_BUF). Codex 2 fold.
+        with path.open("a") as fp:
+            fp.write(json.dumps(record) + "\n")
+    except Exception as exc:  # noqa: BLE001 - telemetry must not crash dispatcher
+        logger.warning("dispatcher telemetry write failed for run_id=%d: %s", run_id, exc)
+
+
 def _phase_batched_dispatch(
     *,
     run_id: int,
@@ -1831,6 +1937,11 @@ def _phase_batched_dispatch(
     # completed yet, the wait() timeout bounds cancel latency.
     _CANCEL_POLL_INTERVAL = 1.0
 
+    # Phase 0.5 dispatcher telemetry — monotonic per-run iteration
+    # counter so the analysis script can detect max consecutive runs
+    # of idle_type=="B" iterations.
+    iteration = 0
+
     def _check_cancel() -> bool:
         """Return True iff an operator-cancel has been observed.
         Side-effect: terminalises the run + state under a single tx
@@ -1888,6 +1999,7 @@ def _phase_batched_dispatch(
 
     try:
         while True:
+            iteration += 1
             # Cancel checkpoint — fires before EVERY submission round
             # and is re-checked after every completion. Pre-PR-2 only
             # checked between batches; PR-2 reduces observation
@@ -2098,7 +2210,26 @@ def _phase_batched_dispatch(
                 return_when=FIRST_COMPLETED,
                 timeout=_CANCEL_POLL_INTERVAL,
             )
-            if not done:
+            wait_returned_empty = not done
+            # Phase 0.5 telemetry — emit on BOTH branches (timeout +
+            # completion). Residual-idle iterations are exactly the
+            # ``wait_returned_empty=True`` rows; emitting unconditionally
+            # gives the analysis script the busy-iteration denominator
+            # too. ``in_flight`` reflects state BEFORE this iteration's
+            # completion is applied, which is what the classifier wants:
+            # the lane is "busy" if it had work in flight during the
+            # wait, regardless of whether that work just terminalised.
+            _emit_dispatcher_telemetry(
+                run_id=run_id,
+                iteration=iteration,
+                statuses=statuses,
+                in_flight_keys={sk for sk, _ in in_flight.values()},
+                lane_in_flight_count=lane_in_flight_count,
+                caps=caps,
+                by_key=by_key,
+                wait_returned_empty=wait_returned_empty,
+            )
+            if wait_returned_empty:
                 # Timeout fired — fall through to the cancel
                 # checkpoint at the top of the next iteration.
                 continue

--- a/scripts/dispatcher_idle_analysis.py
+++ b/scripts/dispatcher_idle_analysis.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Aggregate Phase 0.5 dispatcher residual-idle JSONL telemetry.
+
+Spec: docs/proposals/etl/phase-0-instrumentation.md §2.9.2.
+
+Reads one ``var/dispatcher_idle/<run_id>.jsonl`` file produced by
+``_emit_dispatcher_telemetry`` and emits per-lane aggregates to stdout
+as JSON for the operator's decision-rule evaluation (spec §2.9.3).
+
+Per-lane aggregates:
+
+* ``busy_iter`` — iterations where ``in_flight > 0`` for the lane
+  (denominator for the ``idle_b_iter > 10% busy_iter`` rule).
+* ``idle_a_iter`` — iterations classified ``"A"`` (dependency-natural).
+* ``idle_b_iter`` — iterations classified ``"B"`` (actionable bug).
+* ``idle_b_max_run_iters`` — longest consecutive run of ``"B"``-classified
+  iterations (sustained idle is the bug shape, not isolated blips).
+* ``idle_b_stages_seen`` — union of ``pending_ready`` stage names across
+  all ``"B"``-classified iterations (which stages were unjustly idle).
+
+CLI:
+    uv run python scripts/dispatcher_idle_analysis.py var/dispatcher_idle/17.jsonl
+    cat var/dispatcher_idle/17.jsonl | uv run python scripts/dispatcher_idle_analysis.py -
+
+Exit codes:
+    0 — parse + emit succeeded.
+    2 — bad input (missing file, malformed line).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any
+
+
+class _BadInput(Exception):
+    """Bad-input marker; mapped to exit code 2 by ``main``.
+
+    ``SystemExit(str)`` would exit with code 1; this wrapper lets the
+    CLI surface the message on stderr and exit with the documented
+    code 2 instead. Codex 2 fold.
+    """
+
+
+def _iter_records(source: Iterable[str]) -> Iterator[dict[str, Any]]:
+    for lineno, raw in enumerate(source, start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise _BadInput(f"line {lineno}: malformed JSONL ({exc})") from exc
+
+
+def aggregate(records: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Compute per-lane aggregates from a stream of telemetry records.
+
+    Records are consumed in order so consecutive-run detection works.
+    Lanes absent from a given record contribute nothing for that
+    iteration (their consecutive-B run does NOT reset — the lane was
+    not even mentioned, treat as "no observation").
+    """
+    busy: dict[str, int] = {}
+    idle_a: dict[str, int] = {}
+    idle_b: dict[str, int] = {}
+    cur_b_run: dict[str, int] = {}
+    max_b_run: dict[str, int] = {}
+    b_stages: dict[str, set[str]] = {}
+    total_iterations = 0
+    run_id: int | None = None
+
+    for record in records:
+        total_iterations += 1
+        if run_id is None:
+            run_id = record.get("run_id")
+        lanes = record.get("lanes") or {}
+        for lane, info in lanes.items():
+            in_flight = int(info.get("in_flight", 0))
+            idle_type = info.get("idle_type")
+            if in_flight > 0:
+                busy[lane] = busy.get(lane, 0) + 1
+                cur_b_run[lane] = 0
+            elif idle_type == "A":
+                idle_a[lane] = idle_a.get(lane, 0) + 1
+                cur_b_run[lane] = 0
+            elif idle_type == "B":
+                idle_b[lane] = idle_b.get(lane, 0) + 1
+                cur_b_run[lane] = cur_b_run.get(lane, 0) + 1
+                max_b_run[lane] = max(max_b_run.get(lane, 0), cur_b_run[lane])
+                for stage_key in info.get("pending_ready") or []:
+                    b_stages.setdefault(lane, set()).add(str(stage_key))
+            else:
+                # idle_type is None and in_flight==0 → drained / completion
+                # iteration. Does not count toward any bucket; consecutive
+                # B-run resets so a later isolated B blip is not chained
+                # to an earlier one across a drained gap.
+                cur_b_run[lane] = 0
+
+    all_lanes = sorted(set(busy) | set(idle_a) | set(idle_b) | set(max_b_run) | set(b_stages))
+    return {
+        "run_id": run_id,
+        "total_iterations": total_iterations,
+        "lanes": {
+            lane: {
+                "busy_iter": busy.get(lane, 0),
+                "idle_a_iter": idle_a.get(lane, 0),
+                "idle_b_iter": idle_b.get(lane, 0),
+                "idle_b_max_run_iters": max_b_run.get(lane, 0),
+                "idle_b_stages_seen": sorted(b_stages.get(lane, set())),
+            }
+            for lane in all_lanes
+        },
+    }
+
+
+def _open_source(path: str) -> Iterable[str]:
+    if path == "-":
+        return sys.stdin
+    p = Path(path)
+    if not p.is_file():
+        raise _BadInput(f"input not a file: {path}")
+    return p.read_text().splitlines()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument(
+        "input",
+        help="Path to <run_id>.jsonl, or '-' to read JSONL from stdin.",
+    )
+    args = parser.parse_args(argv)
+    try:
+        source = _open_source(args.input)
+        result = aggregate(_iter_records(source))
+    except _BadInput as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bootstrap_dispatcher_telemetry.py
+++ b/tests/test_bootstrap_dispatcher_telemetry.py
@@ -1,0 +1,407 @@
+"""Unit tests for ``_emit_dispatcher_telemetry`` + ``dispatcher_idle_analysis``.
+
+Spec: docs/proposals/etl/phase-0-instrumentation.md §2.9.
+
+The helper runs in the dispatcher's hot poll loop so the tests pin:
+
+* per-lane ``idle_type`` classification (A / B / null) under synthetic
+  ``statuses`` / ``in_flight`` / ``pending_keys``;
+* JSONL writes are append-only to ``<output_dir>/<run_id>.jsonl``;
+* I/O failures NEVER raise into the dispatcher;
+* aggregation matches the spec's per-lane definitions, including
+  ``idle_b_max_run_iters`` consecutive-run detection.
+
+No DB, no orchestrator boot — direct helper exercise. The integration
+contract (emission fires on both wait branches every iteration) is
+covered by the cross-lane parallelism tests reading the same JSONL
+file at run end if a future test wants it; the unit tests below pin
+the helper itself so a refactor cannot silently change the contract.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.services.bootstrap_orchestrator import (
+    CapRequirement,
+    _emit_dispatcher_telemetry,
+    _RunnableStage,
+)
+
+
+def _stage(stage_key: str, lane: str, *, requires: CapRequirement | None = None) -> _RunnableStage:
+    return _RunnableStage(
+        stage_key=stage_key,
+        job_name=f"synth_job_{stage_key}",
+        lane=lane,
+        invoker=lambda _params=None: None,
+        requires=requires or CapRequirement(),
+    )
+
+
+def _read_single_record(path: Path) -> dict[str, object]:
+    lines = path.read_text().splitlines()
+    assert len(lines) == 1, f"expected 1 JSONL line, got {len(lines)}: {lines!r}"
+    return json.loads(lines[0])
+
+
+# ---------------------------------------------------------------------------
+# Helper: writes JSONL with the expected envelope shape.
+# ---------------------------------------------------------------------------
+
+
+def test_emit_writes_jsonl_to_run_file(tmp_path: Path) -> None:
+    by_key = {"alpha": _stage("alpha", "init")}
+    _emit_dispatcher_telemetry(
+        run_id=42,
+        iteration=1,
+        statuses={"alpha": "pending"},
+        in_flight_keys=set(),
+        lane_in_flight_count={"init": 0},
+        caps=set(),
+        by_key=by_key,
+        wait_returned_empty=True,
+        output_dir=tmp_path,
+    )
+
+    record = _read_single_record(tmp_path / "42.jsonl")
+    assert record["run_id"] == 42
+    assert record["iteration"] == 1
+    assert record["wait_returned_empty"] is True
+    assert "ts" in record and isinstance(record["ts"], str)
+    assert "lanes" in record
+
+
+def test_emit_appends_one_line_per_invocation(tmp_path: Path) -> None:
+    by_key = {"alpha": _stage("alpha", "init")}
+    for i in range(3):
+        _emit_dispatcher_telemetry(
+            run_id=7,
+            iteration=i + 1,
+            statuses={"alpha": "pending"},
+            in_flight_keys=set(),
+            lane_in_flight_count={"init": 0},
+            caps=set(),
+            by_key=by_key,
+            wait_returned_empty=True,
+            output_dir=tmp_path,
+        )
+
+    lines = (tmp_path / "7.jsonl").read_text().splitlines()
+    assert len(lines) == 3
+    iters = [json.loads(line)["iteration"] for line in lines]
+    assert iters == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Classifier: idle_type A / B / null.
+# ---------------------------------------------------------------------------
+
+
+def test_classifies_idle_type_a_when_pending_blocked_only(tmp_path: Path) -> None:
+    """Blocked pending + no ready + wait_returned_empty + lane idle → A."""
+    by_key = {
+        "blocked_stage": _stage(
+            "blocked_stage",
+            "sec_rate",
+            requires=CapRequirement(all_of=("universe_seeded",)),
+        ),
+    }
+    _emit_dispatcher_telemetry(
+        run_id=1,
+        iteration=1,
+        statuses={"blocked_stage": "pending"},
+        in_flight_keys=set(),
+        lane_in_flight_count={"sec_rate": 0},
+        caps=set(),  # universe_seeded NOT present
+        by_key=by_key,
+        wait_returned_empty=True,
+        output_dir=tmp_path,
+    )
+
+    record = _read_single_record(tmp_path / "1.jsonl")
+    lane = record["lanes"]["sec_rate"]  # type: ignore[index]
+    assert lane["idle_type"] == "A"
+    assert lane["pending_ready"] == []
+    assert lane["pending_blocked"] == ["blocked_stage"]
+
+
+def test_classifies_idle_type_b_when_pending_ready_exists(tmp_path: Path) -> None:
+    """Ready pending + lane idle + wait_returned_empty → B (actionable bug)."""
+    by_key = {"ready_stage": _stage("ready_stage", "sec_rate")}  # no requires
+    _emit_dispatcher_telemetry(
+        run_id=1,
+        iteration=1,
+        statuses={"ready_stage": "pending"},
+        in_flight_keys=set(),
+        lane_in_flight_count={"sec_rate": 0},
+        caps=set(),
+        by_key=by_key,
+        wait_returned_empty=True,
+        output_dir=tmp_path,
+    )
+
+    record = _read_single_record(tmp_path / "1.jsonl")
+    lane = record["lanes"]["sec_rate"]  # type: ignore[index]
+    assert lane["idle_type"] == "B"
+    assert lane["pending_ready"] == ["ready_stage"]
+    assert lane["pending_blocked"] == []
+
+
+def test_busy_lane_idle_type_is_null(tmp_path: Path) -> None:
+    """``in_flight > 0`` always classifies as null (busy)."""
+    by_key = {"in_flight_stage": _stage("in_flight_stage", "sec_rate")}
+    _emit_dispatcher_telemetry(
+        run_id=1,
+        iteration=1,
+        statuses={"in_flight_stage": "pending"},  # still pending until completion applies
+        in_flight_keys={"in_flight_stage"},
+        lane_in_flight_count={"sec_rate": 1},
+        caps=set(),
+        by_key=by_key,
+        wait_returned_empty=True,
+        output_dir=tmp_path,
+    )
+
+    record = _read_single_record(tmp_path / "1.jsonl")
+    assert record["lanes"]["sec_rate"]["idle_type"] is None  # type: ignore[index]
+
+
+def test_completion_iteration_idle_type_is_null(tmp_path: Path) -> None:
+    """``wait_returned_empty=False`` → no classification fires (None)."""
+    by_key = {"ready_stage": _stage("ready_stage", "sec_rate")}
+    _emit_dispatcher_telemetry(
+        run_id=1,
+        iteration=1,
+        statuses={"ready_stage": "pending"},
+        in_flight_keys=set(),
+        lane_in_flight_count={"sec_rate": 0},
+        caps=set(),
+        by_key=by_key,
+        wait_returned_empty=False,
+        output_dir=tmp_path,
+    )
+
+    record = _read_single_record(tmp_path / "1.jsonl")
+    # Lane appears (pending_ready non-empty) but idle_type is null
+    # because a completion fired this iteration on some other lane.
+    assert record["lanes"]["sec_rate"]["idle_type"] is None  # type: ignore[index]
+
+
+def test_drained_lane_idle_type_is_null(tmp_path: Path) -> None:
+    """Lane has nothing pending and nothing in flight → null (drained)."""
+    _emit_dispatcher_telemetry(
+        run_id=1,
+        iteration=1,
+        statuses={},
+        in_flight_keys=set(),
+        lane_in_flight_count={"sec_rate": 0},
+        caps=set(),
+        by_key={},
+        wait_returned_empty=True,
+        output_dir=tmp_path,
+    )
+
+    record = _read_single_record(tmp_path / "1.jsonl")
+    assert record["lanes"]["sec_rate"]["idle_type"] is None  # type: ignore[index]
+
+
+def test_per_lane_classification_isolated(tmp_path: Path) -> None:
+    """Two lanes, different states — classified independently."""
+    by_key = {
+        "busy_one": _stage("busy_one", "init"),
+        "ready_one": _stage("ready_one", "sec_rate"),
+    }
+    _emit_dispatcher_telemetry(
+        run_id=1,
+        iteration=1,
+        statuses={"busy_one": "pending", "ready_one": "pending"},
+        in_flight_keys={"busy_one"},
+        lane_in_flight_count={"init": 1, "sec_rate": 0},
+        caps=set(),
+        by_key=by_key,
+        wait_returned_empty=True,
+        output_dir=tmp_path,
+    )
+
+    record = _read_single_record(tmp_path / "1.jsonl")
+    assert record["lanes"]["init"]["idle_type"] is None  # type: ignore[index]
+    assert record["lanes"]["sec_rate"]["idle_type"] == "B"  # type: ignore[index]
+
+
+def test_ignores_pending_keys_outside_by_key(tmp_path: Path) -> None:
+    """preexisting_statuses keys (not in ``by_key``) MUST be skipped —
+    they belong to a prior dispatch and have no lane on this run.
+    """
+    by_key = {"alpha": _stage("alpha", "init")}
+    _emit_dispatcher_telemetry(
+        run_id=1,
+        iteration=1,
+        statuses={"alpha": "pending", "preexisting_orphan": "pending"},
+        in_flight_keys=set(),
+        lane_in_flight_count={"init": 0},
+        caps=set(),
+        by_key=by_key,
+        wait_returned_empty=True,
+        output_dir=tmp_path,
+    )
+
+    record = _read_single_record(tmp_path / "1.jsonl")
+    assert "preexisting_orphan" not in record["lanes"]["init"]["pending_ready"]  # type: ignore[index]
+    assert "preexisting_orphan" not in record["lanes"]["init"]["pending_blocked"]  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Safety: I/O failure MUST NOT raise into the dispatcher.
+# ---------------------------------------------------------------------------
+
+
+def test_emit_swallows_io_failure(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pointing at a file path (not a directory) makes mkdir fail.
+    The helper must log + return cleanly — the dispatcher must NEVER
+    crash on telemetry I/O.
+    """
+    not_a_dir = tmp_path / "actually_a_file"
+    not_a_dir.write_text("blocking the directory creation")
+
+    by_key = {"alpha": _stage("alpha", "init")}
+    with caplog.at_level(logging.WARNING):
+        _emit_dispatcher_telemetry(
+            run_id=99,
+            iteration=1,
+            statuses={"alpha": "pending"},
+            in_flight_keys=set(),
+            lane_in_flight_count={"init": 0},
+            caps=set(),
+            by_key=by_key,
+            wait_returned_empty=True,
+            output_dir=not_a_dir,
+        )
+
+    assert any("dispatcher telemetry write failed" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Aggregator (scripts/dispatcher_idle_analysis.py).
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def _make_record(iteration: int, lanes: dict[str, dict[str, object]]) -> dict[str, object]:
+    return {
+        "ts": f"2026-05-27T00:00:{iteration:02d}+00:00",
+        "run_id": 17,
+        "iteration": iteration,
+        "wait_returned_empty": True,
+        "lanes": lanes,
+    }
+
+
+def _lane_state(
+    *,
+    in_flight: int = 0,
+    pending_ready: list[str] | None = None,
+    pending_blocked: list[str] | None = None,
+    idle_type: str | None = None,
+) -> dict[str, object]:
+    return {
+        "in_flight": in_flight,
+        "pending_ready": pending_ready or [],
+        "pending_blocked": pending_blocked or [],
+        "idle_type": idle_type,
+    }
+
+
+def test_aggregator_counts_busy_idle_a_idle_b(tmp_path: Path) -> None:
+    from scripts.dispatcher_idle_analysis import aggregate
+
+    records = [
+        _make_record(1, {"sec_rate": _lane_state(in_flight=1)}),
+        _make_record(2, {"sec_rate": _lane_state(pending_blocked=["x"], idle_type="A")}),
+        _make_record(3, {"sec_rate": _lane_state(pending_ready=["y"], idle_type="B")}),
+        _make_record(4, {"sec_rate": _lane_state(pending_ready=["y"], idle_type="B")}),
+    ]
+    result = aggregate(records)
+    lane = result["lanes"]["sec_rate"]
+    assert lane["busy_iter"] == 1
+    assert lane["idle_a_iter"] == 1
+    assert lane["idle_b_iter"] == 2
+    assert lane["idle_b_max_run_iters"] == 2
+    assert lane["idle_b_stages_seen"] == ["y"]
+    assert result["run_id"] == 17
+    assert result["total_iterations"] == 4
+
+
+def test_aggregator_resets_b_run_on_busy_or_a(tmp_path: Path) -> None:
+    """Consecutive run counter must reset whenever the lane stops
+    classifying as ``"B"`` (busy, ``"A"``, or drained gap).
+    """
+    from scripts.dispatcher_idle_analysis import aggregate
+
+    records = [
+        _make_record(1, {"l": _lane_state(pending_ready=["s"], idle_type="B")}),
+        _make_record(2, {"l": _lane_state(pending_ready=["s"], idle_type="B")}),
+        _make_record(3, {"l": _lane_state(in_flight=1)}),
+        _make_record(4, {"l": _lane_state(pending_ready=["s"], idle_type="B")}),
+    ]
+    result = aggregate(records)
+    assert result["lanes"]["l"]["idle_b_max_run_iters"] == 2  # 2-run, then 1-run; max = 2
+
+
+def test_aggregator_cli_round_trip(tmp_path: Path) -> None:
+    """Invoke the CLI end-to-end with a temp JSONL file."""
+    jsonl_path = tmp_path / "17.jsonl"
+    _write_jsonl(
+        jsonl_path,
+        [
+            _make_record(1, {"db": _lane_state(in_flight=1)}),
+            _make_record(2, {"db": _lane_state(pending_ready=["s2"], idle_type="B")}),
+        ],
+    )
+    repo_root = Path(__file__).resolve().parents[1]
+    proc = subprocess.run(
+        [sys.executable, "scripts/dispatcher_idle_analysis.py", str(jsonl_path)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["lanes"]["db"]["busy_iter"] == 1
+    assert payload["lanes"]["db"]["idle_b_iter"] == 1
+    assert payload["lanes"]["db"]["idle_b_stages_seen"] == ["s2"]
+
+
+def test_aggregator_rejects_malformed_jsonl(tmp_path: Path) -> None:
+    from scripts.dispatcher_idle_analysis import _BadInput, _iter_records
+
+    with pytest.raises(_BadInput, match="malformed JSONL"):
+        list(_iter_records(["{not json"]))
+
+
+def test_aggregator_cli_exits_2_on_missing_input(tmp_path: Path) -> None:
+    """Documented exit code 2 for bad input (vs the default code-1 from
+    a bare ``SystemExit(str)``). Codex 2 fold.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    proc = subprocess.run(
+        [sys.executable, "scripts/dispatcher_idle_analysis.py", str(tmp_path / "does_not_exist.jsonl")],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "input not a file" in proc.stderr


### PR DESCRIPTION
Part of #1356.

## Summary

Adds per-iteration JSONL telemetry to `_phase_batched_dispatch` so the "30-50% wall-clock waste" hypothesis from #1275 can be empirically re-validated POST-PR-2 (#1233 batch-join → FIRST_COMPLETED).

Plan: [`docs/proposals/etl/bootstrap-sub-1h-plan.md`](docs/proposals/etl/bootstrap-sub-1h-plan.md) v5.2 step 8 + [`docs/proposals/etl/phase-0-instrumentation.md`](docs/proposals/etl/phase-0-instrumentation.md) §2.9.

## What changed

- **`app/services/bootstrap_orchestrator.py`** — new `_emit_dispatcher_telemetry` helper writes one JSONL line per iteration to `var/dispatcher_idle/<run_id>.jsonl` with per-lane `idle_type` ∈ `{"A","B",null}`:
  - **A** — dependency-natural (only blocked pending), correct wait for upstream caps.
  - **B** — actionable bug (≥1 ready stage, lane idle anyway). This is the bug-shape #1275 hunts.
  - **null** — busy (`in_flight>0`) / drained / completion iteration.
- Emission fires on **BOTH** the `wait` timeout branch and the completion branch every iteration (per spec §2.9.1) so residual-idle (timeout) and busy denominator (completion) are both captured. Iteration counter introduced for max-consecutive-run detection.
- Telemetry I/O failures caught + logged — dispatcher MUST NEVER crash on a telemetry write. Single fp.write so a concurrent same-run_id append cannot interleave halves of a line (Codex 2 fold).
- **`scripts/dispatcher_idle_analysis.py`** — consumes the JSONL, emits per-lane `busy_iter / idle_a_iter / idle_b_iter / idle_b_max_run_iters / idle_b_stages_seen` aggregates for operator decision-rule eval (spec §2.9.3). Documented exit code 2 on bad input (Codex 2 fold).
- **`tests/test_bootstrap_dispatcher_telemetry.py`** — 15 unit tests: A/B/null classifier, lane isolation, drained-lane null, completion-iteration null, pre-existing-status orphan handling, per-lane independence, I/O failure swallowing, consecutive-B max-run, CLI round-trip, bad-input exit code.

## Out of scope

No measurement runs in this PR — telemetry-only per spec §3 step 8. R1 (control, pre-#1273) / R2 (post-#1273) / R3 (reproducibility) measurements land in subsequent Phase 0 steps after #1273 PR1+PR2 ship.

## CLAUDE.md overlay (step 0)

- Settled decisions applied: none directly. `var/` filesystem write follows the same convention as `app/runbooks/*.py:LOG_DIR = Path("var/runbooks")`. `/var/*` is gitignored except `/var/perf_baselines/`.
- Prevention-log entries relevant: none directly relevant.
- Branch: `feature/1356-phase-0-5-telemetry`.

## Codex 2 pre-push (mandatory)

Codex 2 raised 3 findings on the diff:

1. **Aggregator exit code** — `SystemExit(str)` exits with code 1, docstring promised code 2. **FIXED**: `_BadInput` wrapper + `main()` catches → `print(stderr) + return 2`. Test pinned via `test_aggregator_cli_exits_2_on_missing_input`.
2. **JSONL atomicity** — two-write `fp.write(json) + fp.write("\n")` could interleave halves under hypothetical concurrent append. **FIXED**: single `fp.write(json + "\n")`.
3. **Telemetry gap on except** — wrapper swallows entire body, an unexpected classifier error means no line that iteration. **REBUTTED** — spec wording "writes one JSONL line per iteration" is best-effort; the "never crash dispatcher" constraint is the harder requirement. Best-effort telemetry preferred over partial-record contamination.

## Verification

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
752 files already formatted

$ uv run pyright
0 errors, 0 warnings, 0 informations

$ uv run pytest tests/test_bootstrap_dispatcher_telemetry.py
15 passed in 4.07s

$ uv run pytest tests/test_bootstrap_dispatcher_cross_lane_parallelism.py \
                tests/test_bootstrap_cancel.py \
                tests/test_bootstrap_manifest_reset.py
37 passed in 27.13s   # regression net: existing dispatcher contract preserved

$ uv run pytest tests/smoke/test_app_boots.py
5 passed in 4.82s
```

Pre-existing #1358 test failures (`db_fundamentals_raw` lane composition, `test_stage_catalogue_lane_composition` + `test_orchestrator_skips_stages_already_success` + `test_every_scheduled_job_either_gated_or_explicitly_excluded`) unaffected — confirmed against clean main with `git checkout main -- app/services/bootstrap_orchestrator.py` then re-running the test.

## Test plan

- [x] Telemetry helper writes one JSONL line per call with correct envelope shape.
- [x] Classifier returns "A" for blocked-only pending, "B" for ready pending, null for busy / completion-iteration / drained.
- [x] I/O failure (output_dir points at a file) logs warning and returns cleanly.
- [x] Aggregator counts busy/A/B correctly + tracks max consecutive B run + accumulates stage names.
- [x] CLI round-trip via subprocess returns expected aggregates.
- [x] CLI exits with code 2 + stderr message on missing input.
- [x] Existing dispatcher contract tests (cross-lane parallelism, cancel, manifest reset) still pass.
- [x] Lifespan smoke test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)