### PR TITLE
feat(#1273): PR2 stage-progress instrumentation + cohort-fingerprint wiring

### DIFF
--- a/.claude/skills/metrics-analyst/SKILL.md
+++ b/.claude/skills/metrics-analyst/SKILL.md
@@ -25,7 +25,10 @@
 | Beta vs SPY | Market data | (deferred) | — |
 | Blockholder ownership % | Ownership | `ownership_blockholders_current` | `/instruments/{symbol}/ownership-rollup` |
 | Bollinger bands (20, 2σ) | Market data | `price_daily.bb_upper / bb_lower` | (TA scoring) |
-| Bootstrap state + stage status | Pipeline | `bootstrap_state`, `bootstrap_stages`, `bootstrap_archive_results` | `/system/bootstrap/status` |
+| Bootstrap stage final row count | Pipeline | `bootstrap_stages.rows_processed` | `/processes/bootstrap/overview` |
+| Bootstrap stage live progress | Pipeline | `bootstrap_stages.target_count + processed_count` | `/processes/bootstrap/timeline` |
+| Bootstrap stage cohort fingerprint | Pipeline | `bootstrap_stages.target_cohort_fingerprint` | `/processes/bootstrap/timeline` (tooltip) |
+| Bootstrap state + run status | Pipeline | `bootstrap_state`, `bootstrap_runs`, `bootstrap_archive_results` | `/system/bootstrap/status`, `/processes/bootstrap/*` |
 | Buyback authorisation | Capital returns | (deferred) | — |
 | Capital event (deposit / withdraw) | Risk + portfolio | `capital_events` | `/budget/events` |
 | Cash + equivalents | Fundamentals | `financial_periods.cash` | `/instruments/{symbol}/financials?statement=balance` |
@@ -469,6 +472,18 @@ All US fundamentals come from SEC XBRL via Company Facts API (settled in `docs/s
 - `bootstrap_runs` (per-click); `bootstrap_stages` (per-stage detail; lane ∈ init/etoro/sec; status ∈ pending/running/success/error/skipped).
 - `bootstrap_archive_results` (per-archive audit).
 - Endpoint: `GET /system/bootstrap/status`.
+
+### Bootstrap stage progress (live, #1273 PR2)
+- **Definition**: per-stage operator-visible progress bar + cohort tooltip on `/admin/process/bootstrap` Timeline; renders only while `bootstrap_stages.status='running'`.
+- **Formula**: list-shaped stages (S14, S15, S22, S23, S25) → `processed_count / target_count` (% complete); streaming-style stages (S16, S17, S18) → `processed_count` cumulative only (no denominator; `target_count IS NULL` by design — upfront `COUNT(*)` over discovery CTE not defensible as ms-cost). Tooltip = `target_cohort_fingerprint` text on every instrumented stage.
+- **Source data**: `set_stage_target` + `set_stage_processed` helpers in `app/services/bootstrap_state.py`, called from 8 long-pole stages.
+- **Storage**: `bootstrap_stages.{target_count, processed_count, target_cohort_fingerprint, last_progress_at}` (sql/140 + sql/178).
+- **Service**: orchestrator-resolved via `resolve_progress_context()` reading the bootstrap-dispatch contextvar (`app/services/processes/bootstrap_cancel_signal.py`); manual-fire paths get `None` and skip (zero overhead).
+- **Endpoint**: `GET /processes/bootstrap/timeline` projects all 4 fields.
+- **Chart**: `frontend/src/pages/ProcessDetailPage.tsx` progress-bar block at `:1186-1226`; tooltip via native `title=`.
+- **Cadence**: list-shaped — every `max(1, len(cohort)//100)` iterations OR every 30s (whichever first); always once on success exit. Streaming — every 30s wall-clock + once on each page-boundary chunk completion (S17/S18) + once on exit.
+- **Caveats**: `target_count IS NULL` for all 3 streaming stages (S16, S17, S18) — frontend renders "X processed (no target set)" instead of a bar. All 5 progress columns reset on `reset_failed_stages_for_retry` so fresh retries do not display stale counters.
+- **Validation**: `tests/services/test_bootstrap_state_progress.py` + `tests/smoke/test_long_pole_progress.py` (8 stage tests). Live SQL: `SELECT stage_key, target_count, processed_count, target_cohort_fingerprint FROM bootstrap_stages WHERE bootstrap_run_id=<id> AND status='running'`.
 
 ### Backfill / SEC manifest pending count
 - `sec_filing_manifest WHERE ingest_status IN ('pending','failed')`.

--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -299,6 +299,12 @@ class BootstrapTimelineStageResponse(BaseModel):
     rows_processed: int | None
     processed_count: int
     target_count: int | None
+    # #1273 PR2 — operator-readable cohort-definition fingerprint set
+    # by ``set_stage_target`` at stage entry. Semicolon-separated
+    # key=value tokens (see spec §4); ``None`` on legacy rows + stages
+    # that never set a fingerprint. Surfaced as a ``title=`` tooltip
+    # on the progress-bar wrapper; no new visual chrome.
+    target_cohort_fingerprint: str | None = None
     archives: list[BootstrapTimelineArchiveResponse]
     # #1140 Task C — operator-readable warning string when the stage
     # finished ``success`` but its ``rows_processed`` failed to satisfy
@@ -691,7 +697,8 @@ def get_bootstrap_timeline(
                 """
                 SELECT stage_key, stage_order, lane, job_name, status,
                        started_at, completed_at, last_error,
-                       rows_processed, processed_count, target_count
+                       rows_processed, processed_count, target_count,
+                       target_cohort_fingerprint
                   FROM bootstrap_stages
                  WHERE bootstrap_run_id = %s
                  ORDER BY stage_order ASC, stage_key ASC
@@ -796,6 +803,7 @@ def get_bootstrap_timeline(
                 rows_processed=row.get("rows_processed"),
                 processed_count=int(row.get("processed_count") or 0),
                 target_count=row.get("target_count"),
+                target_cohort_fingerprint=row.get("target_cohort_fingerprint"),
                 archives=archives_by_stage.get(stage_key, []),
                 warning=warning,
             )

--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -333,10 +333,12 @@ def run_first_install_drain(
 
     progress_ctx = resolve_progress_context()
     if progress_ctx is not None:
+        # Spec §4 — booleans rendered lowercase `true`/`false`
+        # (Python's default str(bool) is `True`/`False`); Codex 2 NIT.
         fingerprint = (
             f"max_subjects={max_subjects if max_subjects is not None else 'unbounded'};"
-            f"follow_pagination={follow_pagination};"
-            f"fast_path_seeded={skip_issuer_http}"
+            f"follow_pagination={str(follow_pagination).lower()};"
+            f"fast_path_seeded={str(skip_issuer_http).lower()}"
         )
         set_stage_target(
             run_id=progress_ctx.run_id,

--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -45,7 +45,12 @@ from app.providers.implementations.sec_submissions import (
     parse_submissions_page,
 )
 from app.services.bootstrap_preconditions import BootstrapPhaseSkipped
-from app.services.bootstrap_state import BootstrapStageCancelled
+from app.services.bootstrap_state import (
+    BootstrapStageCancelled,
+    resolve_progress_context,
+    set_stage_processed,
+    set_stage_target,
+)
 from app.services.manifest_parsers.sec_n_csr import n_csr_retention_cutoff
 from app.services.processes.bootstrap_cancel_signal import (
     active_bootstrap_stage_key,
@@ -316,6 +321,31 @@ def run_first_install_drain(
         )
 
     skip_issuer_http = rows_seeded_from_filing_events > 0
+
+    # #1273 PR2 — long-pole stage instrumentation (S16 streaming).
+    # MUST land here (not at function top) because `fast_path_seeded`
+    # is only known after `seed_manifest_from_filing_events` returns
+    # (Codex 1 IMPORTANT-2 fold). Streaming-style: target_count=None,
+    # fingerprint only — `_iter_in_universe_subjects` is a streaming
+    # cursor with no upfront cohort size. cadenced emits live in the
+    # for-loop below; final emit after exit.
+    import time as _time  # local — drain module otherwise time-free
+
+    progress_ctx = resolve_progress_context()
+    if progress_ctx is not None:
+        fingerprint = (
+            f"max_subjects={max_subjects if max_subjects is not None else 'unbounded'};"
+            f"follow_pagination={follow_pagination};"
+            f"fast_path_seeded={skip_issuer_http}"
+        )
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=None,
+            cohort_fingerprint=fingerprint,
+        )
+    _last_progress_emit = _time.monotonic()
+
     # PR3d #1064 — cancel-poll cadence. The drain iterates ~12k CIKs
     # at 10 req/s, ~21 minutes wall-clock. Polling for the bootstrap
     # cancel signal every 50 CIKs keeps observation latency under
@@ -355,6 +385,18 @@ def run_first_install_drain(
         ciks_processed += 1
         if not delta.new_filings:
             ciks_skipped += 1
+        # #1273 PR2 — streaming-style cadenced emit. No cohort size
+        # known up-front; emit every 30s wall-clock with the running
+        # ciks_processed counter.
+        if progress_ctx is not None:
+            _now = _time.monotonic()
+            if _now - _last_progress_emit > 30:
+                set_stage_processed(
+                    run_id=progress_ctx.run_id,
+                    stage_key=progress_ctx.stage_key,
+                    processed_count=ciks_processed,
+                )
+                _last_progress_emit = _now
 
         for row in delta.new_filings:
             if row.source is None:
@@ -410,6 +452,14 @@ def run_first_install_drain(
     # threads the counter materially under-reports when the fast
     # path or pagination fires).
     scheduler_rows_seeded = len(inline_seeded_triples)
+
+    # #1273 PR2 — final operator-progress emit on exit.
+    if progress_ctx is not None:
+        set_stage_processed(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            processed_count=ciks_processed,
+        )
 
     logger.info(
         "first-install drain: ciks=%d skipped=%d errors=%d secondary_pages=%d upserted=%d scheduler_seeded=%d",

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -776,13 +776,31 @@ def mark_stage_blocked(
 # ---------------------------------------------------------------------------
 
 
-def set_stage_target(*, run_id: int, stage_key: str, target_count: int) -> int:
-    """Write ``bootstrap_stages.target_count`` for an in-flight stage.
+def set_stage_target(
+    *,
+    run_id: int,
+    stage_key: str,
+    target_count: int | None,
+    cohort_fingerprint: str | None = None,
+) -> int:
+    """Write ``target_count`` + ``target_cohort_fingerprint`` for an
+    in-flight stage.
+
+    PR2 (#1273) widens the PR1 signature: ``target_count`` becomes
+    nullable (S16/S17/S18 streaming-style stages pin only the
+    fingerprint per spec §4 table) and ``cohort_fingerprint`` is
+    added. Both inputs are independently optional.
+
+    SQL uses ``COALESCE`` on both columns so a ``None`` param preserves
+    the existing DB value rather than NULL-ing it — call sites are
+    first-write-wins by convention, but the COALESCE branch is
+    defensive against a future caller writing one field per call.
+
+    ``last_progress_at`` always bumps so the heartbeat reflects the
+    stage-entry progress signal (Codex 2 PR1 P2 fold).
 
     Opens its own psycopg connection, commits, and closes. Survives
-    caller rollback per the spec contract above. Also bumps
-    ``last_progress_at`` so the heartbeat reflects the stage-entry
-    progress signal (Codex 2 P2 fold).
+    caller rollback per the spec contract above.
 
     Returns the row-update count. ``1`` on a successful write; ``0``
     when the row is not in ``status='running'`` (late-write no-op).
@@ -791,13 +809,19 @@ def set_stage_target(*, run_id: int, stage_key: str, target_count: int) -> int:
         cur = conn.execute(
             """
             UPDATE bootstrap_stages
-               SET target_count     = %(target_count)s,
-                   last_progress_at = now()
+               SET target_count              = COALESCE(%(target_count)s, target_count),
+                   target_cohort_fingerprint = COALESCE(%(cohort_fingerprint)s, target_cohort_fingerprint),
+                   last_progress_at          = now()
              WHERE bootstrap_run_id = %(run_id)s
                AND stage_key        = %(stage_key)s
                AND status           = 'running'
             """,
-            {"run_id": run_id, "stage_key": stage_key, "target_count": target_count},
+            {
+                "run_id": run_id,
+                "stage_key": stage_key,
+                "target_count": target_count,
+                "cohort_fingerprint": cohort_fingerprint,
+            },
         )
         conn.commit()
         return cur.rowcount or 0
@@ -866,6 +890,55 @@ def _current_running_stage_key(job_name: str) -> str | None:
             {"job_name": job_name},
         ).fetchone()
         return str(row[0]) if row else None
+
+
+@dataclass(frozen=True)
+class BootstrapProgressContext:
+    """Resolved (run_id, stage_key) pair for an in-flight stage.
+
+    #1273 PR2: every long-pole stage invoker calls
+    :func:`resolve_progress_context` on entry and uses the returned
+    context (or None) to gate :func:`set_stage_target` /
+    :func:`set_stage_processed` calls. Manual-fire paths (no in-flight
+    bootstrap run) get ``None`` and skip all progress writes — zero
+    overhead, zero side-effect.
+    """
+
+    run_id: int
+    stage_key: str
+
+
+def resolve_progress_context() -> BootstrapProgressContext | None:
+    """Resolve ``(run_id, stage_key)`` for a stage about to start work.
+
+    Reads the bootstrap-dispatch contextvar set by
+    :func:`app.services.processes.bootstrap_cancel_signal.active_bootstrap_run`
+    (the orchestrator's ``_run_one_stage`` wraps every stage invocation
+    in this context manager). Zero DB queries — the orchestrator
+    already knows both values at the dispatch boundary and pins them
+    on a ContextVar.
+
+    Returns ``None`` outside a bootstrap dispatch (manual-fire,
+    scheduled cron, test fixture without the wrapper). Callers
+    short-circuit progress writes — zero overhead, zero side-effect.
+
+    Mirrors the cancel-signal pattern already used by
+    :func:`bootstrap_cancel_requested` / :func:`active_bootstrap_stage_key`,
+    so PR2's instrumentation shares the same dispatch-boundary
+    contract as PR3d's cancel plumbing.
+    """
+    # Lazy import — bootstrap_cancel_signal imports
+    # bootstrap_state.BootstrapStageCancelled transitively via several
+    # call sites, so a top-of-module import here would close a cycle.
+    from app.services.processes.bootstrap_cancel_signal import (
+        active_bootstrap_context,
+    )
+
+    raw = active_bootstrap_context()
+    if raw is None:
+        return None
+    run_id, stage_key = raw
+    return BootstrapProgressContext(run_id=run_id, stage_key=stage_key)
 
 
 def finalize_run(
@@ -1032,15 +1105,29 @@ def reset_failed_stages_for_retry(
             cursor = conn.execute(
                 """
                 UPDATE bootstrap_stages
-                   SET status         = 'pending',
-                       started_at     = NULL,
-                       completed_at   = NULL,
-                       last_error     = NULL,
+                   SET status                    = 'pending',
+                       started_at                = NULL,
+                       completed_at              = NULL,
+                       last_error                = NULL,
                        -- #1140 Task C: reset rows_processed alongside
                        -- the rest of the stage row so the operator
                        -- timeline / bootstrap_adapter aggregate don't
                        -- show stale counts from the prior failed pass.
-                       rows_processed = NULL
+                       rows_processed            = NULL,
+                       -- #1273 PR2: clear in-flight progress columns
+                       -- alongside rows_processed so the operator
+                       -- timeline doesn't show stale target /
+                       -- processed / fingerprint from the prior
+                       -- failed pass on a fresh retry. Without this,
+                       -- the bar would re-render at last-failed
+                       -- progress and the tooltip would advertise
+                       -- the prior cohort fingerprint even when the
+                       -- retry re-discovers a different cohort
+                       -- (e.g. S22 cutoff drifted overnight).
+                       target_count              = NULL,
+                       processed_count           = 0,
+                       last_progress_at          = NULL,
+                       target_cohort_fingerprint = NULL
                  WHERE bootstrap_run_id = %(run_id)s
                    AND lane             = %(lane)s
                    AND stage_order      >= %(min_order)s
@@ -1739,6 +1826,7 @@ __all__ = [
     "BootstrapNoPriorRun",
     "BootstrapNotResettable",
     "BootstrapNotRunning",
+    "BootstrapProgressContext",
     "BootstrapStageCancelled",
     "BootstrapState",
     "BootstrapStatus",
@@ -1768,6 +1856,7 @@ __all__ = [
     "read_state",
     "reap_orphaned_running",
     "reset_failed_stages_for_retry",
+    "resolve_progress_context",
     "set_stage_processed",
     "set_stage_target",
     "start_run",

--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -42,6 +42,12 @@ from typing import Any, Literal, Protocol
 import psycopg
 from psycopg.types.json import Jsonb
 
+from app.services.bootstrap_state import (
+    resolve_progress_context,
+    set_stage_processed,
+    set_stage_target,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -1482,6 +1488,30 @@ def bootstrap_business_summaries(
     # #1234 — track WHY the loop exits.
     exit_reason: Literal["drained", "deadline"] = "deadline"
 
+    # #1273 PR2 — long-pole stage instrumentation (S18 streaming).
+    # Pin fingerprint only (target_count=None per Codex 1 BLOCKING 2).
+    # `pending_predicate_v2` records all 4 active branches verbatim
+    # including the `tables_null AND quarantine_elapsed` AND-guard
+    # (PR1 audit memo §3 S18 note).
+    progress_ctx = resolve_progress_context()
+    if progress_ctx is not None:
+        fingerprint = (
+            f"chunk_limit={chunk_limit};"
+            f"max_runtime_seconds={max_runtime_seconds};"
+            f"form_types=10-K,10-K/A;"
+            f"distinct_on=instrument_id;"
+            f"ordering=filing_date_desc,filing_event_id_desc;"
+            f"url_filter=true;"
+            f"pending_predicate_v2=bs_null_OR_acn_diff_OR_retry_due_OR_(tables_null_AND_quarantine_elapsed)"
+        )
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=None,
+            cohort_fingerprint=fingerprint,
+        )
+    _last_progress_emit = time.monotonic()
+
     while time.monotonic() < deadline:
         chunk = ingest_business_summaries(
             conn,
@@ -1495,9 +1525,29 @@ def bootstrap_business_summaries(
         total_updated += chunk.rows_updated
         total_fetch_errors += chunk.fetch_errors
         total_parse_misses += chunk.parse_misses
+        # #1273 PR2 — page-boundary cumulative emit. Streaming-style:
+        # `total_scanned` is the running cumulative-filings-discovered
+        # counter; operator sees "X processed" climbing across pages.
+        if progress_ctx is not None:
+            _now = time.monotonic()
+            if _now - _last_progress_emit > 30 or chunk.filings_scanned == 0:
+                set_stage_processed(
+                    run_id=progress_ctx.run_id,
+                    stage_key=progress_ctx.stage_key,
+                    processed_count=total_scanned,
+                )
+                _last_progress_emit = _now
         if chunk.filings_scanned == 0:
             exit_reason = "drained"
             break
+
+    # #1273 PR2 — final operator-progress emit on exit.
+    if progress_ctx is not None:
+        set_stage_processed(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            processed_count=total_scanned,
+        )
 
     logger.info(
         "bootstrap_business_summaries complete: scanned=%d inserted=%d updated=%d "

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -48,6 +48,11 @@ from app.providers.implementations.sec_def14a import (
     parse_beneficial_ownership_table,
 )
 from app.services import raw_filings
+from app.services.bootstrap_state import (
+    resolve_progress_context,
+    set_stage_processed,
+    set_stage_target,
+)
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
 from app.services.ownership_observations import (
     record_def14a_observation,
@@ -1201,6 +1206,31 @@ def bootstrap_def14a(
     # #1234 — track WHY the loop exits.
     exit_reason: Literal["drained", "deadline"] = "deadline"
 
+    # #1273 PR2 — long-pole stage instrumentation (S17 streaming).
+    # Pin fingerprint only (target_count=None per Codex 1 BLOCKING 2 —
+    # upfront COUNT over the discovery CTE not defensible as ms-cost).
+    # `_DEF14A_FORM_TYPES` cardinality (computed below) is included so
+    # the operator can audit the cohort form-type set.
+    progress_ctx = resolve_progress_context()
+    if progress_ctx is not None:
+        fingerprint = (
+            f"chunk_limit={chunk_limit};"
+            f"max_runtime_seconds={max_runtime_seconds};"
+            f"form_types={len(_DEF14A_FORM_TYPES)};"
+            f"cap_per_filer={DEF14A_LATEST_PER_FILER_CAP};"
+            f"rank_scope=def14a_with_cik;"
+            f"rank_predicate=type<>DEF14A_OR_cik_null_OR_rank<=cap;"
+            f"url_filter=true;tombstone_filter=true;"
+            f"pending_predicate_v1=true"
+        )
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=None,
+            cohort_fingerprint=fingerprint,
+        )
+    _last_progress_emit = time.monotonic()
+
     while time.monotonic() < deadline:
         chunk = ingest_def14a(
             conn,
@@ -1217,9 +1247,29 @@ def bootstrap_def14a(
         total_updated += chunk.rows_updated
         if first_error is None and chunk.first_error is not None:
             first_error = chunk.first_error
+        # #1273 PR2 — page-boundary cumulative emit. Streaming-style:
+        # `total_seen` is the running cumulative-accessions-discovered
+        # counter; operator sees "X processed" climbing across pages.
+        if progress_ctx is not None:
+            _now = time.monotonic()
+            if _now - _last_progress_emit > 30 or chunk.accessions_seen == 0:
+                set_stage_processed(
+                    run_id=progress_ctx.run_id,
+                    stage_key=progress_ctx.stage_key,
+                    processed_count=total_seen,
+                )
+                _last_progress_emit = _now
         if chunk.accessions_seen == 0:
             exit_reason = "drained"
             break
+
+    # #1273 PR2 — final operator-progress emit on exit.
+    if progress_ctx is not None:
+        set_stage_processed(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            processed_count=total_seen,
+        )
 
     # Bot review for #839 PR #850: enforce the accounting invariant
     # so a future regression that drops accessions from one of the

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -37,12 +37,18 @@ rows on first install (operator audit 2026-05-07).
 
 import json
 import logging
+import time
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 
 import psycopg
 
 from app.providers.filings import FilingEvent, FilingSearchResult, FilingsProvider
+from app.services.bootstrap_state import (
+    resolve_progress_context,
+    set_stage_processed,
+    set_stage_target,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -326,6 +332,33 @@ def refresh_filings(
     upserted = 0
     skipped_provider_error = 0
 
+    # #1273 PR2 — long-pole stage instrumentation (S15
+    # filings_history_seed). Pin target + fingerprint when called
+    # from the bootstrap dispatcher; manual-fire / scheduled paths
+    # get progress_ctx=None and skip every helper call. Cohort =
+    # `resolved` (post-identifier-resolution dict) so the bar shows
+    # progress against work actually attempted, not against the
+    # cohort the caller suggested (which would dilute by
+    # skipped_no_identifier).
+    progress_ctx = resolve_progress_context()
+    if progress_ctx is not None:
+        _form_types_count = len(filing_types) if filing_types is not None else 0
+        _days_back = (end_date - start_date).days if (start_date and end_date) else 0
+        fingerprint = (
+            f"provider={provider_name};"
+            f"identifier_type={identifier_type};"
+            f"days_back={_days_back};"
+            f"filing_types={_form_types_count}"
+        )
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=len(resolved),
+            cohort_fingerprint=fingerprint,
+        )
+    _emit_every_n = max(1, len(resolved) // 100) if resolved else 0
+    _last_progress_emit = time.monotonic()
+
     # PR3d #1064 follow-up — poll the bootstrap cancel signal between
     # instruments. ``filings_history_seed`` (bootstrap stage 14) walks
     # the full CIK-mapped tradable cohort (~2-12k instruments at
@@ -388,6 +421,27 @@ def refresh_filings(
                 exc_info=True,
             )
             skipped_provider_error += 1
+        # #1273 PR2 — cadenced operator-progress emit. Uses
+        # iter_index (already maintained for the cancel-poll cadence)
+        # so the operator sees attempt-progress identical to the
+        # cancel exception's "iter_index/len(resolved)" message.
+        if progress_ctx is not None:
+            _now = time.monotonic()
+            if iter_index % _emit_every_n == 0 or _now - _last_progress_emit > 30:
+                set_stage_processed(
+                    run_id=progress_ctx.run_id,
+                    stage_key=progress_ctx.stage_key,
+                    processed_count=iter_index,
+                )
+                _last_progress_emit = _now
+
+    # #1273 PR2 — final operator-progress emit on exit.
+    if progress_ctx is not None:
+        set_stage_processed(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            processed_count=iter_index,
+        )
 
     if skipped_no_identifier > 0:
         logger.info(

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -47,7 +47,6 @@ from app.providers.filings import FilingEvent, FilingSearchResult, FilingsProvid
 from app.services.bootstrap_state import (
     resolve_progress_context,
     set_stage_processed,
-    set_stage_target,
 )
 
 logger = logging.getLogger(__name__)
@@ -332,30 +331,15 @@ def refresh_filings(
     upserted = 0
     skipped_provider_error = 0
 
-    # #1273 PR2 — long-pole stage instrumentation (S15
-    # filings_history_seed). Pin target + fingerprint when called
-    # from the bootstrap dispatcher; manual-fire / scheduled paths
-    # get progress_ctx=None and skip every helper call. Cohort =
-    # `resolved` (post-identifier-resolution dict) so the bar shows
-    # progress against work actually attempted, not against the
-    # cohort the caller suggested (which would dilute by
-    # skipped_no_identifier).
+    # #1273 PR2 — long-pole stage instrumentation (S15). Cadenced +
+    # final set_stage_processed emits live in the per-instrument
+    # loop below. NOTE: set_stage_target (cohort_fingerprint +
+    # target_count) is written at the SCHEDULER boundary in
+    # ``app/workers/scheduler.py::filings_history_seed`` AFTER the
+    # cik_rows cohort materializes — that callsite has the
+    # ``instrument_id`` knob in scope, whereas this helper only sees
+    # the post-resolution subset. Codex 2 pre-push IMPORTANT fold.
     progress_ctx = resolve_progress_context()
-    if progress_ctx is not None:
-        _form_types_count = len(filing_types) if filing_types is not None else 0
-        _days_back = (end_date - start_date).days if (start_date and end_date) else 0
-        fingerprint = (
-            f"provider={provider_name};"
-            f"identifier_type={identifier_type};"
-            f"days_back={_days_back};"
-            f"filing_types={_form_types_count}"
-        )
-        set_stage_target(
-            run_id=progress_ctx.run_id,
-            stage_key=progress_ctx.stage_key,
-            target_count=len(resolved),
-            cohort_fingerprint=fingerprint,
-        )
     _emit_every_n = max(1, len(resolved) // 100) if resolved else 0
     _last_progress_emit = time.monotonic()
 

--- a/app/services/fundamentals/__init__.py
+++ b/app/services/fundamentals/__init__.py
@@ -38,6 +38,11 @@ from app.providers.implementations.sec_edgar import (
     parse_master_index,
 )
 from app.providers.implementations.sec_fundamentals import TRACKED_CONCEPTS
+from app.services.bootstrap_state import (
+    resolve_progress_context,
+    set_stage_processed,
+    set_stage_target,
+)
 from app.services.filings import (
     FILING_EVENTS_RETENTION_YEARS,
     filing_within_retention,
@@ -1645,13 +1650,32 @@ def normalize_financial_periods(
     If ``instrument_ids`` is None, processes all instruments that have
     facts in financial_facts_raw.
     """
-    # Determine which instruments to process
+    # Determine which instruments to process. Capture the caller's
+    # original intent (None = full universe; supplied list = explicit
+    # sub-cohort) BEFORE the None-defaulting overwrites the param so
+    # the #1273 PR2 fingerprint can declare the correct scope.
+    _instrument_scope = "universe_with_facts" if instrument_ids is None else "explicit_list"
     if instrument_ids is None:
         cur = conn.execute("SELECT DISTINCT instrument_id FROM financial_facts_raw")
         instrument_ids = [row[0] for row in cur.fetchall()]
 
     total_raw = 0
     total_canonical = 0
+
+    # #1273 PR2 — long-pole stage instrumentation (S25). Pin target +
+    # fingerprint when called from the bootstrap dispatcher.
+    progress_ctx = resolve_progress_context()
+    if progress_ctx is not None:
+        fingerprint = f"instrument_scope={_instrument_scope};source_table=financial_facts_raw"
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=len(instrument_ids),
+            cohort_fingerprint=fingerprint,
+        )
+    _emit_every_n = max(1, len(instrument_ids) // 100) if instrument_ids else 0
+    _last_progress_emit = time.monotonic()
+    _processed_count = 0
 
     for iid in instrument_ids:
         try:
@@ -1723,6 +1747,27 @@ def normalize_financial_periods(
                 )
         except Exception:
             logger.exception("Failed to normalize instrument %d", iid)
+        # #1273 PR2 — cadenced operator-progress emit. _processed_count
+        # advances regardless of per-instrument success so the bar
+        # tracks attempt progress (mirrors S22's filers_attempted).
+        _processed_count += 1
+        if progress_ctx is not None:
+            _now = time.monotonic()
+            if _processed_count % _emit_every_n == 0 or _now - _last_progress_emit > 30:
+                set_stage_processed(
+                    run_id=progress_ctx.run_id,
+                    stage_key=progress_ctx.stage_key,
+                    processed_count=_processed_count,
+                )
+                _last_progress_emit = _now
+
+    # #1273 PR2 — final operator-progress emit on exit.
+    if progress_ctx is not None:
+        set_stage_processed(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            processed_count=_processed_count,
+        )
 
     return NormalizationSummary(
         instruments_processed=len(instrument_ids),

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -53,6 +53,11 @@ from app.providers.implementations.sec_13f import (
     parse_primary_doc,
 )
 from app.services import raw_filings
+from app.services.bootstrap_state import (
+    resolve_progress_context,
+    set_stage_processed,
+    set_stage_target,
+)
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
 from app.services.ownership_observations import (
     record_institution_observation,
@@ -1116,6 +1121,29 @@ def ingest_all_active_filers(
     else:
         deadline_ts = time.monotonic() + deadline_seconds
 
+    # #1273 PR2 — long-pole stage instrumentation (S22). Pin
+    # target_count + cohort fingerprint when called from the
+    # bootstrap dispatcher; manual-fire / scheduled / test fixture
+    # paths get progress_ctx=None and skip every helper call.
+    progress_ctx = resolve_progress_context()
+    if progress_ctx is not None:
+        fingerprint = (
+            f"min_period_of_report="
+            f"{min_period_of_report.isoformat() if min_period_of_report else 'none'};"
+            f"deadline_seconds={deadline_seconds if deadline_seconds is not None else 'none'};"
+            f"source_label={source_label}"
+        )
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=len(ciks),
+            cohort_fingerprint=fingerprint,
+        )
+    # Hybrid cadence — emit every max(1, len/100) iterations OR every
+    # 30s wall-clock, whichever first. Per-stage tracking variables.
+    _emit_every_n = max(1, len(ciks) // 100)
+    _last_progress_emit = time.monotonic()
+
     run_id = start_ingestion_run(
         conn,
         source=source_label,
@@ -1193,6 +1221,19 @@ def ingest_all_active_filers(
             accession_failures += summary.accessions_failed
             if summary.first_error and first_accession_error is None:
                 first_accession_error = f"{cik} {summary.first_error}"
+            # #1273 PR2 — cadenced operator-progress emit. Hybrid
+            # rule: every max(1, len/100) iterations OR every 30s
+            # wall-clock. processed_count is the running attempt count
+            # (mirrors the deadline / cancel log messages above).
+            if progress_ctx is not None:
+                _now = time.monotonic()
+                if filers_attempted % _emit_every_n == 0 or _now - _last_progress_emit > 30:
+                    set_stage_processed(
+                        run_id=progress_ctx.run_id,
+                        stage_key=progress_ctx.stage_key,
+                        processed_count=filers_attempted,
+                    )
+                    _last_progress_emit = _now
     finally:
         # Status precedence:
         #   * deadline hit (work was interrupted, partial by definition)
@@ -1250,6 +1291,16 @@ def ingest_all_active_filers(
             error="; ".join(error_parts) or None,
         )
         conn.commit()
+        # #1273 PR2 — final operator-progress emit on every exit
+        # branch (success, deadline_hit, cancel, crash). Lives inside
+        # `finally` so partial-progress survives even if a crash
+        # outside the per-filer try/except escapes the for loop.
+        if progress_ctx is not None:
+            set_stage_processed(
+                run_id=progress_ctx.run_id,
+                stage_key=progress_ctx.stage_key,
+                processed_count=filers_attempted,
+            )
 
     if cancelled_by_operator:
         # Raise after bookkeeping so data_ingestion_runs records the

--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -56,7 +56,6 @@ from app.services import raw_filings
 from app.services.bootstrap_state import (
     resolve_progress_context,
     set_stage_processed,
-    set_stage_target,
 )
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
 from app.services.ownership_observations import (
@@ -1121,24 +1120,18 @@ def ingest_all_active_filers(
     else:
         deadline_ts = time.monotonic() + deadline_seconds
 
-    # #1273 PR2 — long-pole stage instrumentation (S22). Pin
-    # target_count + cohort fingerprint when called from the
-    # bootstrap dispatcher; manual-fire / scheduled / test fixture
-    # paths get progress_ctx=None and skip every helper call.
+    # #1273 PR2 — long-pole stage instrumentation (S22). Progress
+    # context resolved once; cadenced + final set_stage_processed
+    # emits live in the per-filer loop / finally block below.
+    # NOTE: set_stage_target (cohort_fingerprint + target_count) is
+    # written at the SCHEDULER boundary in
+    # ``app/workers/scheduler.py::sec_13f_quarterly_sweep`` AFTER the
+    # ciks cohort materializes — that callsite has every cohort knob
+    # (min_period_of_report, min_last_13f_hr_at, deadline_seconds,
+    # source_label) in scope, whereas this helper only sees the
+    # post-resolution subset. Codex 2 pre-push BLOCKING fold.
+    # Manual-fire paths get progress_ctx=None and skip every emit.
     progress_ctx = resolve_progress_context()
-    if progress_ctx is not None:
-        fingerprint = (
-            f"min_period_of_report="
-            f"{min_period_of_report.isoformat() if min_period_of_report else 'none'};"
-            f"deadline_seconds={deadline_seconds if deadline_seconds is not None else 'none'};"
-            f"source_label={source_label}"
-        )
-        set_stage_target(
-            run_id=progress_ctx.run_id,
-            stage_key=progress_ctx.stage_key,
-            target_count=len(ciks),
-            cohort_fingerprint=fingerprint,
-        )
     # Hybrid cadence — emit every max(1, len/100) iterations OR every
     # 30s wall-clock, whichever first. Per-stage tracking variables.
     _emit_every_n = max(1, len(ciks) // 100)

--- a/app/services/n_port_ingest.py
+++ b/app/services/n_port_ingest.py
@@ -65,7 +65,6 @@ import psycopg
 from app.services.bootstrap_state import (
     resolve_progress_context,
     set_stage_processed,
-    set_stage_target,
 )
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
 from app.services.ownership_observations import (
@@ -821,23 +820,18 @@ def ingest_all_fund_filers(
     deadline_hit = False
     filers_attempted = 0
 
-    # #1273 PR2 — long-pole stage instrumentation (S23). Same shape as
-    # S22's ingest_all_active_filers; manual-fire / scheduled / test
-    # paths get progress_ctx=None and skip every helper call.
+    # #1273 PR2 — long-pole stage instrumentation (S23). Progress
+    # context resolved once; cadenced + final set_stage_processed
+    # emits live in the per-filer loop / finally block below.
+    # NOTE: set_stage_target (cohort_fingerprint + target_count) is
+    # written at the SCHEDULER boundary in
+    # ``app/workers/scheduler.py::sec_n_port_ingest`` AFTER the ciks
+    # cohort materializes — that callsite has every cohort knob
+    # (min_last_seen_filed_at, deadline_seconds, directory) in scope.
+    # Codex 2 pre-push BLOCKING fold (this helper only sees
+    # min_period_of_report, NOT the actual cohort-filter param
+    # min_last_seen_filed_at consumed by list_nport_filer_ciks).
     progress_ctx = resolve_progress_context()
-    if progress_ctx is not None:
-        fingerprint = (
-            f"min_period_of_report="
-            f"{min_period_of_report.isoformat() if min_period_of_report else 'none'};"
-            f"deadline_seconds={deadline_seconds if deadline_seconds is not None else 'none'};"
-            f"directory=sec_nport_filer_directory"
-        )
-        set_stage_target(
-            run_id=progress_ctx.run_id,
-            stage_key=progress_ctx.stage_key,
-            target_count=len(ciks),
-            cohort_fingerprint=fingerprint,
-        )
     _emit_every_n = max(1, len(ciks) // 100)
     _last_progress_emit = time.monotonic()
 

--- a/app/services/n_port_ingest.py
+++ b/app/services/n_port_ingest.py
@@ -62,6 +62,11 @@ from uuid import uuid4
 
 import psycopg
 
+from app.services.bootstrap_state import (
+    resolve_progress_context,
+    set_stage_processed,
+    set_stage_target,
+)
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
 from app.services.ownership_observations import (
     record_fund_observation,
@@ -815,6 +820,27 @@ def ingest_all_fund_filers(
     first_accession_error: str | None = None
     deadline_hit = False
     filers_attempted = 0
+
+    # #1273 PR2 — long-pole stage instrumentation (S23). Same shape as
+    # S22's ingest_all_active_filers; manual-fire / scheduled / test
+    # paths get progress_ctx=None and skip every helper call.
+    progress_ctx = resolve_progress_context()
+    if progress_ctx is not None:
+        fingerprint = (
+            f"min_period_of_report="
+            f"{min_period_of_report.isoformat() if min_period_of_report else 'none'};"
+            f"deadline_seconds={deadline_seconds if deadline_seconds is not None else 'none'};"
+            f"directory=sec_nport_filer_directory"
+        )
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=len(ciks),
+            cohort_fingerprint=fingerprint,
+        )
+    _emit_every_n = max(1, len(ciks) // 100)
+    _last_progress_emit = time.monotonic()
+
     try:
         for cik in ciks:
             if deadline_ts is not None and time.monotonic() >= deadline_ts:
@@ -851,6 +877,16 @@ def ingest_all_fund_filers(
             accession_failures += summary.accessions_failed
             if summary.first_error and first_accession_error is None:
                 first_accession_error = f"{cik} {summary.first_error}"
+            # #1273 PR2 — cadenced operator-progress emit.
+            if progress_ctx is not None:
+                _now = time.monotonic()
+                if filers_attempted % _emit_every_n == 0 or _now - _last_progress_emit > 30:
+                    set_stage_processed(
+                        run_id=progress_ctx.run_id,
+                        stage_key=progress_ctx.stage_key,
+                        processed_count=filers_attempted,
+                    )
+                    _last_progress_emit = _now
     finally:
         # Status precedence mirrors institutional_holdings.ingest_all_active_filers:
         #   deadline beats crash-only; crash-only with summaries beats failed.
@@ -880,6 +916,13 @@ def ingest_all_fund_filers(
             error="; ".join(error_parts) or None,
         )
         conn.commit()
+        # #1273 PR2 — final operator-progress emit on every exit branch.
+        if progress_ctx is not None:
+            set_stage_processed(
+                run_id=progress_ctx.run_id,
+                stage_key=progress_ctx.stage_key,
+                processed_count=filers_attempted,
+            )
 
     return summaries
 

--- a/app/services/processes/bootstrap_cancel_signal.py
+++ b/app/services/processes/bootstrap_cancel_signal.py
@@ -123,6 +123,26 @@ def active_bootstrap_stage_key() -> str | None:
     return ctx.stage_key
 
 
+def active_bootstrap_context() -> tuple[int, str] | None:
+    """Return ``(run_id, stage_key)`` of the in-flight bootstrap stage, or None.
+
+    Issue #1273 PR2. Long-pole stage instrumentation (`set_stage_target`
+    / `set_stage_processed` in :mod:`app.services.bootstrap_state`)
+    reads this to scope progress writes to the active orchestrator
+    dispatch. Outside ``active_bootstrap_run`` the contextvar is unset
+    and this returns ``None``; callers short-circuit progress writes
+    so manual-fire / scheduled / test-fixture paths pay zero overhead.
+
+    Returns a plain tuple so the caller package
+    (:mod:`app.services.bootstrap_state`) can wrap it in its own typed
+    container without importing this module's private ``_BootstrapContext``.
+    """
+    ctx = _active_bootstrap_context.get()
+    if ctx is None:
+        return None
+    return (ctx.run_id, ctx.stage_key)
+
+
 def bootstrap_cancel_requested(
     *,
     conn: psycopg.Connection[Any] | None = None,
@@ -181,6 +201,7 @@ def bootstrap_cancel_requested(
 
 
 __all__ = [
+    "active_bootstrap_context",
     "active_bootstrap_run",
     "active_bootstrap_stage_key",
     "bootstrap_cancel_requested",

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -51,6 +51,7 @@ Spec: docs/proposals/etl/stream-a-run-8-fixes.md v2.3 §1 T1.3 + §13 + §14
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -61,6 +62,11 @@ from app.providers.implementations.sec_edgar import (
     KNOWN_FILING_AGENT_CIKS,
     SecFilingsProvider,
     _normalise_submissions_block,
+)
+from app.services.bootstrap_state import (
+    resolve_progress_context,
+    set_stage_processed,
+    set_stage_target,
 )
 from app.services.filings import _upsert_filing
 from app.services.watermarks import get_watermark, set_watermark
@@ -184,8 +190,51 @@ def walk_files_pages(
     result = FilesWalkResult()
     targets = _list_cik_secondary_pages(conn)
 
+    # #1273 PR2 — long-pole stage instrumentation (S14). Pin
+    # target_count + cohort fingerprint when called from the
+    # bootstrap dispatcher. Fingerprint pins the is_tradable filter
+    # + sidecar-state bucket counts so the operator can audit
+    # cohort composition.
+    progress_ctx = resolve_progress_context()
+    if progress_ctx is not None:
+        sentinel_count = sum(1 for t in targets if t[3] == [_SIDECAR_SENTINEL_PAGE_NAME])
+        empty_count = sum(1 for t in targets if not t[3])
+        real_pages_count = len(targets) - sentinel_count - empty_count
+        fingerprint = (
+            f"is_tradable_only=true;"
+            f"sidecar_sentinel={sentinel_count};"
+            f"sidecar_real_pages={real_pages_count};"
+            f"sidecar_empty={empty_count}"
+        )
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=len(targets),
+            cohort_fingerprint=fingerprint,
+        )
+    _emit_every_n = max(1, len(targets) // 100) if targets else 0
+    _last_progress_emit = time.monotonic()
+    _processed_count = 0
+
     with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
         for instrument_id, cik, symbol, sidecar_pages in targets:
+            # #1273 PR2 — cadenced emit. Bump _processed_count at the
+            # TOP of every iteration so the bar advances against the
+            # full cohort `len(targets)` even for early-skip branches
+            # (agent CIKs / empty sidecar / sentinel-only). The
+            # operator-visible meaning is "CIKs evaluated" not "HTTP
+            # work done"; the legacy `result.*` counters retain the
+            # finer-grained bucketing for audit log.
+            _processed_count += 1
+            if progress_ctx is not None:
+                _now = time.monotonic()
+                if _processed_count % _emit_every_n == 0 or _now - _last_progress_emit > 30:
+                    set_stage_processed(
+                        run_id=progress_ctx.run_id,
+                        stage_key=progress_ctx.stage_key,
+                        processed_count=_processed_count,
+                    )
+                    _last_progress_emit = _now
             # Agent CIKs are excluded by the populate path
             # (sec_submissions_ingest.refresh_cik_sidecar) so their
             # sidecar_pages list is empty by design. Skip them here
@@ -335,6 +384,14 @@ def walk_files_pages(
                             watermark=page_result.last_modified,
                             watermark_at=None,
                         )
+
+    # #1273 PR2 — final operator-progress emit on exit.
+    if progress_ctx is not None:
+        set_stage_processed(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            processed_count=_processed_count,
+        )
 
     # End-of-walk SUMMARY warning when ≥ 1 in-universe non-agent CIK
     # had an empty sidecar. Single log line replaces the per-CIK spam

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4564,6 +4564,35 @@ def sec_13f_quarterly_sweep(params: Mapping[str, Any]) -> None:
             psycopg.connect(settings.database_url) as conn,
         ):
             ciks = list_directory_filer_ciks(conn, min_last_13f_hr_at=min_last_13f_hr_at)
+            # #1273 PR2 — long-pole stage instrumentation (S22). Pin
+            # target + fingerprint at the scheduler boundary because
+            # every cohort knob (min_period_of_report,
+            # min_last_13f_hr_at, deadline_seconds, source_label) is
+            # in scope HERE; ingest_all_active_filers only sees the
+            # post-resolution subset. Codex 2 pre-push BLOCKING fold.
+            from app.services.bootstrap_state import (
+                resolve_progress_context as _resolve_progress_context_s22,
+            )
+            from app.services.bootstrap_state import (
+                set_stage_target as _set_stage_target_s22,
+            )
+
+            _progress_ctx_s22 = _resolve_progress_context_s22()
+            if _progress_ctx_s22 is not None:
+                _fp_s22 = (
+                    f"min_period_of_report="
+                    f"{min_period_of_report.isoformat() if min_period_of_report else 'none'};"
+                    f"min_last_13f_hr_at="
+                    f"{min_last_13f_hr_at.date().isoformat() if min_last_13f_hr_at else 'none'};"
+                    f"deadline_seconds={deadline_seconds if deadline_seconds is not None else 'none'};"
+                    f"source_label={source_label}"
+                )
+                _set_stage_target_s22(
+                    run_id=_progress_ctx_s22.run_id,
+                    stage_key=_progress_ctx_s22.stage_key,
+                    target_count=len(ciks),
+                    cohort_fingerprint=_fp_s22,
+                )
             summaries = ingest_all_active_filers(
                 conn,
                 sec,
@@ -4688,6 +4717,32 @@ def filings_history_seed(params: Mapping[str, Any]) -> None:
         instrument_ids = [row[1] for row in cik_rows]
         from_date = date.today() - timedelta(days=days_back)
         to_date = date.today()
+
+        # #1273 PR2 — long-pole stage instrumentation (S15). Pin
+        # target + fingerprint at the scheduler boundary because the
+        # `instrument_id` triage knob is in scope HERE (refresh_filings
+        # only sees the post-resolution subset). Codex 2 pre-push
+        # IMPORTANT fold.
+        from app.services.bootstrap_state import (
+            resolve_progress_context as _resolve_progress_context_s15,
+        )
+        from app.services.bootstrap_state import (
+            set_stage_target as _set_stage_target_s15,
+        )
+
+        _progress_ctx_s15 = _resolve_progress_context_s15()
+        if _progress_ctx_s15 is not None:
+            _fp_s15 = (
+                f"days_back={days_back};"
+                f"filing_types={len(filing_types)};"
+                f"instrument_id={instrument_id_param if instrument_id_param is not None else 'all'}"
+            )
+            _set_stage_target_s15(
+                run_id=_progress_ctx_s15.run_id,
+                stage_key=_progress_ctx_s15.stage_key,
+                target_count=len(instrument_ids),
+                cohort_fingerprint=_fp_s15,
+            )
 
         with (
             SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
@@ -5350,6 +5405,32 @@ def sec_n_port_ingest(params: Mapping[str, Any]) -> None:
                 conn,
                 min_last_seen_filed_at=min_last_seen_filed_at,
             )
+            # #1273 PR2 — long-pole stage instrumentation (S23). Pin
+            # target + fingerprint at the scheduler boundary because
+            # min_last_seen_filed_at is in scope HERE; the helper
+            # ingest_all_fund_filers only sees min_period_of_report.
+            # Codex 2 pre-push BLOCKING fold.
+            from app.services.bootstrap_state import (
+                resolve_progress_context as _resolve_progress_context_s23,
+            )
+            from app.services.bootstrap_state import (
+                set_stage_target as _set_stage_target_s23,
+            )
+
+            _progress_ctx_s23 = _resolve_progress_context_s23()
+            if _progress_ctx_s23 is not None:
+                _fp_s23 = (
+                    f"min_last_seen_filed_at="
+                    f"{min_last_seen_filed_at.date().isoformat() if min_last_seen_filed_at else 'none'};"
+                    f"deadline_seconds={deadline_seconds if deadline_seconds is not None else 'none'};"
+                    f"directory=sec_nport_filer_directory"
+                )
+                _set_stage_target_s23(
+                    run_id=_progress_ctx_s23.run_id,
+                    stage_key=_progress_ctx_s23.stage_key,
+                    target_count=len(ciks),
+                    cohort_fingerprint=_fp_s23,
+                )
 
             summaries = ingest_all_fund_filers(
                 conn,

--- a/docs/proposals/etl/phase-0-pr2-stage-progress-instrumentation.md
+++ b/docs/proposals/etl/phase-0-pr2-stage-progress-instrumentation.md
@@ -1,0 +1,513 @@
+# #1273 PR2 — stage-progress instrumentation + cohort-fingerprint wiring
+
+**Status**: Proposal · 2026-05-27 · draft 1.2 (Codex 1 diff-only re-pass fold)
+**Parent**: [`phase-0-instrumentation.md`](./phase-0-instrumentation.md) v1.5 §2.2 · [`bootstrap-sub-1h-plan.md`](./bootstrap-sub-1h-plan.md) v5.2
+**PR1 audit memo (frozen handoff)**: [`1273-pr1-cohort-shapes.md`](./1273-pr1-cohort-shapes.md) v1.2 (merged in PR #1361 `792291e`)
+**Branch**: `feature/1273-stage-progress-instrumentation`
+
+**Changelog**:
+- v1.0 — initial draft
+- v1.1 — Codex 1 fold: 2 BLOCKING (S18 fingerprint under-specifies cohort; S17/S18 upfront COUNT is not ms-cost) + 5 IMPORTANT (S25 redundant pre-count; S16 fingerprint not computable at entry; S23 missing long-pole; FE fixtures require field; S25 file path wrong) + 1 NIT (S16 loop line cite). 7-stage cohort widened to 8 (added S23 sec_n_port_ingest). S17/S18 dropped from initial-pending-COUNT design to streaming-style (target_count=None, fingerprint-only) — upfront `COUNT(*)` over discovery CTE not defensible as ms-cost.
+- v1.2 — Codex 1 diff-only re-pass fold: 3 GAPs + 1 NEW-IMPORTANT. B1 GAP — S17 fingerprint added `rank_scope=def14a_with_cik` + verbatim rank predicate; S18 fingerprint added `(tables_null AND quarantine_elapsed)` AND-guard per PR1 audit §3 S18 note. B2 GAP — §5.1 + §5.2 + §9.2 caveats now correctly list S17/S18 as streaming-style (not list-shaped); §5.2 heading widened from "S16 only" to "S16, S17, S18". I3 GAP — stale "7 stages" / "7 long-pole" references in §2 migration comment + §5.3 job-name note + §9.2 source-data caveat all flipped to 8. NEW-IMPORTANT — §9.2 metrics formula now carves out streaming stages (`processed_count` cumulative only, no denominator) from list-shaped (`processed/target`).
+
+PR2 is the surgical bit of #1273. PR1 shipped the helpers + audit memo. PR2 wires the 8 long-pole stages to those helpers, adds the `target_cohort_fingerprint` column, extends `set_stage_target` to carry the fingerprint, extends `reset_failed_stages_for_retry` to clear progress + fingerprint columns, and adds the frontend tooltip.
+
+---
+
+## 1. Deliverables
+
+| # | Deliverable | Location | Surface |
+|---|---|---|---|
+| 1 | sql/178 migration | `sql/178_bootstrap_stages_target_cohort_fingerprint.sql` | ALTER TABLE bootstrap_stages ADD COLUMN IF NOT EXISTS `target_cohort_fingerprint TEXT` |
+| 2 | Extend `set_stage_target` | `app/services/bootstrap_state.py:779-803` | New kwarg `cohort_fingerprint: str \| None = None`; `target_count` becomes `int \| None`; COALESCE writes preserve existing values on None |
+| 3 | Extend `reset_failed_stages_for_retry` | `app/services/bootstrap_state.py:1032-1049` | Reset 4 additional columns: `target_count`, `processed_count`, `last_progress_at`, `target_cohort_fingerprint` (PR1 audit §6 — MANDATORY PR2 acceptance) |
+| 4 | Per-stage instrumentation calls | 8 files (table §5) | 5 list-shaped stages call `set_stage_target` + cadenced `set_stage_processed` (S14, S15, S22, S23, S25); 3 streaming-style stages call `set_stage_target(target_count=None, cohort_fingerprint=…)` + cadenced `set_stage_processed` (S16, S17, S18) |
+| 5 | Backend response model + endpoint projection | `app/api/processes.py:276-301`, `:692-700` | Add `target_cohort_fingerprint: str \| None` to `BootstrapTimelineStageResponse`; project column in SELECT |
+| 6 | Frontend type + tooltip | `frontend/src/api/types.ts:1417-1435`, `frontend/src/pages/ProcessDetailPage.tsx:1186-1221` | Add `target_cohort_fingerprint: string \| null` to TS type; render as `title=` on the progress-bar wrapper (additive tooltip, no new chrome) |
+| 7 | Metrics-analyst skill update | `.claude/skills/metrics-analyst/SKILL.md` | Split bootstrap_stages master-index row into `rows_processed`, `target_count + processed_count`, `target_cohort_fingerprint`; new §8 sub-section "Bootstrap stage progress (live)" |
+| 8 | Tests | `tests/services/test_bootstrap_state_progress.py` (extend); `tests/smoke/test_long_pole_progress.py` (NEW) | Fingerprint write + reset clears all 5 progress columns; per-stage 10-row synthetic cohort with monotonic counters + survives mid-stage ROLLBACK |
+
+---
+
+## 2. SQL — migration `sql/178`
+
+```sql
+-- 178_bootstrap_stages_target_cohort_fingerprint.sql
+--
+-- Issue #1273 PR2 — long-pole stage cohort-fingerprint plumbing.
+--
+-- Spec: docs/proposals/etl/phase-0-pr2-stage-progress-instrumentation.md §2.
+--
+-- ## Why
+--
+-- PR1 (#1361, 792291e) shipped `set_stage_target` / `set_stage_processed` /
+-- `_current_running_stage_key` helpers. PR2 wires the 8 long-pole stages
+-- (S14/15/16/17/18/22/25) to those helpers and surfaces a cohort-definition
+-- fingerprint to the operator timeline as an additive tooltip so reviewers
+-- can audit "we walked the right slice" without re-greping seven source
+-- files.
+--
+-- Format: `key=value;key=value;...` (semicolon-separated). Operator
+-- eyeballs the tooltip — no SHA hash, no JSON, no escaping. Per-stage
+-- fingerprint composition documented in spec §4.
+--
+-- ## Lock impact
+--
+-- PG 14+ ADD COLUMN with no DEFAULT or with a constant DEFAULT is a
+-- metadata-only change, no table rewrite. The column is nullable so a
+-- pre-PR2 row reads as NULL (frontend renders no tooltip — same as a
+-- stage that never set a fingerprint).
+
+BEGIN;
+
+ALTER TABLE bootstrap_stages
+    ADD COLUMN IF NOT EXISTS target_cohort_fingerprint TEXT;
+
+COMMIT;
+```
+
+No CHECK constraint on length / shape — fingerprint is operator-readable text. Per [[feedback_grep_alter_constraints]]: no CREATE TABLE definition to update (column lives only in this ALTER per sql/140 + sql/178).
+
+---
+
+## 3. Helper extensions
+
+### 3.1 `set_stage_target` — extend for fingerprint + nullable target
+
+```python
+def set_stage_target(
+    *,
+    run_id: int,
+    stage_key: str,
+    target_count: int | None,
+    cohort_fingerprint: str | None = None,
+) -> int:
+    """Write target_count + cohort_fingerprint for an in-flight stage.
+
+    Both inputs are independently optional. `target_count=None` is the
+    S16 streaming-stage path: caller pins fingerprint without claiming
+    a cohort size. `cohort_fingerprint=None` preserves any existing
+    value (helpers are first-write-wins; PR2's only callers pass both
+    on the same call, so the COALESCE branch is defensive).
+
+    SQL uses COALESCE on both columns so a None param preserves the
+    existing DB value rather than NULL-ing it. `last_progress_at`
+    always bumps (mirrors set_stage_processed; Codex 2 P2 fold).
+
+    Opens its own psycopg connection, commits, closes — survives caller
+    rollback (spec §2.2 #1 Codex iter-1 IMPORTANT-1).
+
+    Returns rowcount: 1 on a write, 0 on a late no-op against a
+    terminal stage (status != 'running').
+    """
+    with psycopg.connect(settings.database_url) as conn:
+        cur = conn.execute(
+            """
+            UPDATE bootstrap_stages
+               SET target_count              = COALESCE(%(target_count)s, target_count),
+                   target_cohort_fingerprint = COALESCE(%(cohort_fingerprint)s, target_cohort_fingerprint),
+                   last_progress_at          = now()
+             WHERE bootstrap_run_id = %(run_id)s
+               AND stage_key        = %(stage_key)s
+               AND status           = 'running'
+            """,
+            {
+                "run_id": run_id,
+                "stage_key": stage_key,
+                "target_count": target_count,
+                "cohort_fingerprint": cohort_fingerprint,
+            },
+        )
+        conn.commit()
+        return cur.rowcount or 0
+```
+
+**Backward compat**: PR1 callers (none in main; PR1 shipped helpers only) keep working — keyword-only, `cohort_fingerprint` defaults to None, `target_count` was already a required int but the type widens to `int | None` (any int still satisfies `int | None`).
+
+**`set_stage_processed`**: unchanged.
+
+### 3.2 `reset_failed_stages_for_retry` — extend reset surface
+
+At `app/services/bootstrap_state.py:1032-1049`, the per-lane UPDATE currently resets `status`, `started_at`, `completed_at`, `last_error`, `rows_processed`. PR2 adds 4 columns:
+
+```python
+cursor = conn.execute(
+    """
+    UPDATE bootstrap_stages
+       SET status                    = 'pending',
+           started_at                = NULL,
+           completed_at              = NULL,
+           last_error                = NULL,
+           rows_processed            = NULL,
+           -- #1273 PR2 — clear in-flight progress columns alongside
+           -- the rest of the stage row so the operator timeline does
+           -- not show stale target / processed / fingerprint from
+           -- the prior failed pass on a fresh retry.
+           target_count              = NULL,
+           processed_count           = 0,
+           last_progress_at          = NULL,
+           target_cohort_fingerprint = NULL
+     WHERE bootstrap_run_id = %(run_id)s
+       AND lane             = %(lane)s
+       AND stage_order      >= %(min_order)s
+    """,
+    {"run_id": run_id, "lane": lane, "min_order": min_order},
+)
+```
+
+**Why all 4**: per audit §6 — without it, a fresh retry shows the bar at last-failed processed/target (misleading) AND the tooltip reflects last-failed cohort fingerprint even when the retry re-discovers a different cohort (e.g. S22 cutoff drifted overnight).
+
+---
+
+## 4. Cohort-fingerprint compute per stage
+
+Format: `key=value;key=value;…` semicolon-separated. No URL-encoding (operator pastes into terminal raw; no `%` or `&` ever appears in the values below). Numbers rendered as decimal; booleans as `true`/`false`; dates as ISO `YYYY-MM-DD`; missing/unbounded values as the literal string `unbounded` or `all`.
+
+| Stage | Shape | Fingerprint (literal `;`-separated, evaluated at cohort-materialization time) |
+|---|---|---|
+| S14 | list | `is_tradable_only=true;sidecar_sentinel=<n>;sidecar_real_pages=<n>;sidecar_empty=<n>` |
+| S15 | list | `days_back=730;filing_types=<count>;instrument_id=<id_or_all>` |
+| S16 | streaming | `max_subjects=<n_or_unbounded>;follow_pagination=<bool>;fast_path_seeded=<bool>` |
+| S17 | streaming | `chunk_limit=500;max_runtime_seconds=3600;form_types=<count>;cap_per_filer=2;rank_scope=def14a_with_cik;rank_predicate=type<>DEF14A_OR_cik_null_OR_rank<=cap;url_filter=true;tombstone_filter=true;pending_predicate_v1=true` |
+| S18 | streaming | `chunk_limit=500;max_runtime_seconds=3600;form_types=10-K,10-K/A;distinct_on=instrument_id;ordering=filing_date_desc,filing_event_id_desc;url_filter=true;pending_predicate_v2=bs_null_OR_acn_diff_OR_retry_due_OR_(tables_null_AND_quarantine_elapsed)` |
+| S22 | list | `min_period_of_report=<YYYY-MM-DD>;min_last_13f_hr_at=<YYYY-MM-DD>;deadline_seconds=<float>` |
+| S23 | list | `min_last_seen_filed_at=<YYYY-MM-DD_or_none>;deadline_seconds=<float>;directory=sec_nport_filer_directory` |
+| S25 | list | `instrument_scope=universe_with_facts;source_table=financial_facts_raw` |
+
+**Reading guide**:
+
+- `<n>` = integer value resolved at fingerprint-compute time.
+- `<bool>` = `true` / `false`.
+- `rank_scope=def14a_with_cik` (S17) declares the rank cap applies ONLY to DEF 14A rows with non-null CIK; PRE 14A + non-CIK rows bypass the cap. `rank_predicate=type<>DEF14A_OR_cik_null_OR_rank<=cap` is the verbatim disjunction (per PR1 audit memo §3 S17 row). `pending_predicate_v1=true` declares "filing_type IN form_types AND primary_document_url IS NOT NULL AND log.accession_number IS NULL"; bump `v1` → `v2` on any predicate change.
+- `pending_predicate_v2=bs_null_OR_acn_diff_OR_retry_due_OR_(tables_null_AND_quarantine_elapsed)` (S18) declares all 4 branches verbatim, including the AND-guard on the `tables_json IS NULL` backfill branch (#560 quarantine clock — see PR1 audit memo §3 S18 row). Bump version on any branch add/remove or guard change.
+- S25 does NOT include `total=<n>` in the fingerprint — `len(instrument_ids)` populates `target_count` directly (free after the existing DISTINCT materialization at `app/services/fundamentals/__init__.py:1651`); a separate pre-count over the 10M-row `financial_facts_raw` partition is not defensible as ms-cost (Codex 1 fold).
+- **No `pending_at_entry` count** on S17/S18: upfront `COUNT(*)` over the discovery CTE doubles the discovery-pass cost without a LIMIT; rejected per Codex 1 BLOCKING 2. Streaming-style `target_count=None` + cumulative `processed_count` is the operator-visible affordance.
+
+---
+
+## 5. Instrumentation pattern
+
+### 5.1 List-shaped (S14, S15, S22, S23, S25)
+
+```python
+from app.services.bootstrap_state import (
+    set_stage_target,
+    set_stage_processed,
+    _current_running_stage_key,
+)
+from app.services.sec_bulk_orchestrator_jobs import _current_running_bootstrap_run_id
+
+# Resolve orchestration context on entry. If unset, all writes no-op.
+_run_id = _current_running_bootstrap_run_id()
+_stage_key = _current_running_stage_key(__JOB_NAME__)
+_progress_enabled = _run_id is not None and _stage_key is not None
+
+# ... materialize cohort ...
+cohort = build_cohort(...)
+
+# Pin target + fingerprint atomically (single helper call, one round-trip).
+if _progress_enabled:
+    _fingerprint = f"key1={v1};key2={v2};..."   # per §4 table
+    set_stage_target(
+        run_id=_run_id,
+        stage_key=_stage_key,
+        target_count=len(cohort),
+        cohort_fingerprint=_fingerprint,
+    )
+
+# Iterate. Hybrid count+time cadence.
+_emit_every_n = max(1, len(cohort) // 100)
+_last_emit = monotonic()
+for i, item in enumerate(cohort, start=1):
+    process(item)
+    if _progress_enabled and (i % _emit_every_n == 0 or monotonic() - _last_emit > 30):
+        set_stage_processed(run_id=_run_id, stage_key=_stage_key, processed_count=i)
+        _last_emit = monotonic()
+
+# Final write on exit.
+if _progress_enabled:
+    set_stage_processed(run_id=_run_id, stage_key=_stage_key, processed_count=len(cohort))
+```
+
+### 5.2 Streaming-style (S16, S17, S18)
+
+S16 has no upfront cohort (streams `_iter_in_universe_subjects`). S17 + S18 have page-bounded discovery (`chunk_limit=500` per page) but PR2 deliberately does NOT pin `target_count` — upfront `COUNT(*)` over the discovery CTE is not defensible as ms-cost (Codex 1 BLOCKING 2). All three follow the same pattern: pin fingerprint on entry, advance `processed_count` cumulatively, never pin `target_count`.
+
+```python
+_run_id = _current_running_bootstrap_run_id()
+_stage_key = _current_running_stage_key(__JOB_NAME__)
+_progress_enabled = _run_id is not None and _stage_key is not None
+
+# No upfront cohort. Fingerprint only on entry; target_count stays NULL.
+if _progress_enabled:
+    set_stage_target(
+        run_id=_run_id,
+        stage_key=_stage_key,
+        target_count=None,
+        cohort_fingerprint=f"max_subjects={max_subjects or 'unbounded'};follow_pagination={follow_pagination};fast_path_seeded={fast_path_seeded}",
+    )
+
+_running = 0
+_last_emit = monotonic()
+for subject in _iter_in_universe_subjects(...):
+    process(subject)
+    _running += 1
+    if _progress_enabled and monotonic() - _last_emit > 30:
+        set_stage_processed(run_id=_run_id, stage_key=_stage_key, processed_count=_running)
+        _last_emit = monotonic()
+
+if _progress_enabled:
+    set_stage_processed(run_id=_run_id, stage_key=_stage_key, processed_count=_running)
+```
+
+### 5.3 Per-stage call sites
+
+| Stage | File | Cohort site | Entry guard + target/fingerprint write site | Cadenced emit site | Final emit site |
+|---|---|---|---|---|---|
+| S14 | `app/services/sec_submissions_files_walk.py` | `_list_cik_secondary_pages()` at `:106` then `:185` `len(targets)` | top of `sec_submissions_files_walk_job` at `:364` (write after cohort materialization) | inside the per-CIK walk loop inside `walk_files_pages` at `:168` | after walk loop returns |
+| S15 | `app/workers/scheduler.py` | `cik_rows` at `:4657` / `:4671`, `instrument_ids = ...` at `:4688` | top of `filings_history_seed` at `:4620` (write after `instrument_ids` resolves) | inside the per-instrument seed loop | after loop |
+| S16 | `app/jobs/sec_first_install_drain.py` | streaming `_iter_in_universe_subjects` at `:221` | inside `run_first_install_drain` AFTER `seed_manifest_from_filing_events` returns (capture `fast_path_seeded = rows_seeded_from_filing_events > 0`) — write before subject loop starts at `:326` | inside the streaming consumer loop starting `:326`; increment site is `ciks_processed += 1` at `:355` | after streaming exits |
+| S17 | `app/services/def14a_ingest.py` | `bootstrap_def14a` at `:1160`; discovery at `:301-348` (page-bounded `chunk_limit=500`, no upfront COUNT) | top of `bootstrap_def14a` at `:1160` (`target_count=None`, fingerprint only) | inside the per-page-drain loop (page boundary: emit `processed_count = cumulative_done`; 30s safety ticker) | after deadline loop exits |
+| S18 | `app/services/business_summary.py` | `bootstrap_business_summaries` at `:1446`; discovery at `:1606` (page-bounded `chunk_limit=500`, no upfront COUNT) | top of `bootstrap_business_summaries` at `:1446` (`target_count=None`, fingerprint only) | inside the per-page-drain loop (page boundary: emit `processed_count = cumulative_done`; 30s safety ticker) | after deadline loop exits |
+| S22 | `app/workers/scheduler.py` (job entry) + `app/services/institutional_holdings.py` (cohort + loop) | `list_directory_filer_ciks(min_last_13f_hr_at=…)` at `institutional_holdings.py:481-524`, `len(ciks)` | top of `sec_13f_quarterly_sweep` job entry (write after `list_directory_filer_ciks` returns) | inside the per-filer batched sweep at `institutional_holdings.py:1069-1178` | after sweep loop exits |
+| S23 | `app/workers/scheduler.py` (job entry, `sec_n_port_ingest` at `:5305`) + `app/services/n_port_ingest.py` (cohort + loop) | `list_nport_filer_ciks(min_last_seen_filed_at=…)` at `scheduler.py:5349`, `len(ciks)` at `:5362` | top of `sec_n_port_ingest` at `:5305` (write after `list_nport_filer_ciks` returns) | inside `ingest_all_fund_filers` per-filer loop | after sweep loop exits |
+| S25 | `app/services/fundamentals/bootstrap.py` (job entry, `fundamentals_sync_bootstrap` at `:96`) + `app/services/fundamentals/__init__.py` (cohort + loop, `normalize_financial_periods` at `:1639`) | `instrument_ids = [row[0] for row in cur.fetchall()]` at `__init__.py:1651` (existing materialization — `len(instrument_ids)` is free) | inside `normalize_financial_periods` immediately after `:1651` (write `target_count=len(instrument_ids)`, fingerprint) | inside the per-instrument cursor loop at `:1656-1708` | after cursor exits |
+
+**Job-name resolution**: `_current_running_stage_key` is called with the orchestrator-registered `job_name`, NOT the stage_key. S25 divergence (stage_key=`fundamentals_sync`, job_name=`fundamentals_sync_bootstrap`) is handled by the PR1 helper. For each of the 8 stages the implementation reads its `job_name` from a module-local constant aligned with `_BOOTSTRAP_STAGE_SPECS` (no JOB_INTERNAL_KEYS injection).
+
+**Manual-fire path**: when an operator triggers a bulk job outside the orchestrator (no in-flight bootstrap run), `_current_running_bootstrap_run_id()` returns None, `_progress_enabled=False`, and every helper call is skipped — zero overhead, zero side-effect. Applies to all 8 instrumented stages.
+
+---
+
+## 6. Resolved design questions (carried from PR1 audit §4)
+
+1. **S17/S18 `target_count` semantics** *(REVISED v1.1 per Codex 1 BLOCKING 2)*: **NO upfront COUNT; streaming-style (`target_count=None`) with cumulative `processed_count`**. Audit §4 recommended initial-pending COUNT for operator legibility; Codex showed the COUNT cost is not defensible — the discovery CTE has no LIMIT in COUNT mode and would full-scan `filing_events` before the real loop. S17/S18 follow the S16 streaming pattern: fingerprint pins all cohort dimensions (§4 table — `chunk_limit`, `cap_per_filer`, `pending_predicate_vN`, etc.), `processed_count` advances as cumulative-done across pages. Operator sees "X processed" (no denominator) — same affordance as S16. Trade-off: no "X of Y, deadline-cut at Y/2" — accepted because the fingerprint + cumulative counter still tell the operator what was walked.
+2. **S25 pre-materialized count** *(REVISED v1.1 per Codex 1 IMPORTANT 1)*: **YES, via `len(instrument_ids)` after the existing DISTINCT materialization at `app/services/fundamentals/__init__.py:1651` — NO separate COUNT query**. A separate `SELECT COUNT(DISTINCT instrument_id) FROM financial_facts_raw` over the 10M-row partitioned floor table is not defensible as ms-cost (indexes only prefix `instrument_id` as part of wider keys per `sql/156:103`). The existing `cur.fetchall()` at `:1651` already produces the row count for free.
+3. **Fingerprint format**: `<key>=<value>;<key>=<value>;…` semicolon-separated. No SHA hash, no JSON. Operator pastes into terminal raw.
+4. **Out-of-order target / processed writes**: **frontend already tolerates this**. `ProcessDetailPage.tsx:1188-1217` reads `if (!hasTarget && processed === 0) return null` and renders the no-target branch `"X processed (no target set)"` when target IS NULL + processed > 0. No FE change needed for this case — only the tooltip is additive (§7).
+
+---
+
+## 7. Backend response model + endpoint projection
+
+### 7.1 `BootstrapTimelineStageResponse` (`app/api/processes.py:276-308`)
+
+Add one field after `target_count`:
+
+```python
+target_count: int | None
+# #1273 PR2 — operator-readable cohort-definition fingerprint set by
+# `set_stage_target` at stage entry. Semicolon-separated key=value
+# tokens (see spec §4); NULL on legacy rows + stages that never set a
+# fingerprint. Surfaced as a `title=` tooltip on the progress-bar
+# wrapper; no new visual chrome.
+target_cohort_fingerprint: str | None = None
+archives: list[BootstrapTimelineArchiveResponse]
+```
+
+### 7.2 SELECT projection (`app/api/processes.py:694`)
+
+```sql
+SELECT stage_key, stage_order, lane, job_name, status,
+       started_at, completed_at, last_error,
+       rows_processed, processed_count, target_count,
+       target_cohort_fingerprint
+  FROM bootstrap_stages
+ WHERE bootstrap_run_id = %s
+ ORDER BY stage_order ASC, stage_key ASC
+```
+
+And in the `BootstrapTimelineStageResponse(...)` construction at `app/api/processes.py:786`, add:
+
+```python
+target_cohort_fingerprint=row["target_cohort_fingerprint"],
+```
+
+---
+
+## 8. Frontend type + tooltip
+
+### 8.1 `frontend/src/api/types.ts:1417-1435`
+
+Add after `target_count`:
+
+```ts
+export interface BootstrapTimelineStageResponse {
+  // … existing …
+  processed_count: number;
+  target_count: number | null;
+  /**
+   * #1273 PR2 — operator-readable cohort-definition fingerprint. Set
+   * by `set_stage_target` at stage entry; null on legacy rows and on
+   * stages that never instrument. Rendered as a `title=` tooltip on
+   * the progress-bar wrapper.
+   */
+  target_cohort_fingerprint: string | null;
+  archives: BootstrapTimelineArchiveResponse[];
+  warning: string | null;
+}
+```
+
+### 8.2 `frontend/src/pages/ProcessDetailPage.tsx:1186-1221` — tooltip wiring
+
+Additive tooltip on the existing progress-bar wrapper. Wrap the `<div className="mt-1.5">` with `title={…}` reading the new field; no styling change.
+
+```tsx
+return (
+  <div
+    className="mt-1.5"
+    title={stage.target_cohort_fingerprint ?? undefined}
+  >
+    {hasTarget ? (
+      // existing block
+    ) : (
+      // existing block
+    )}
+  </div>
+);
+```
+
+`title=undefined` (when the field is null) suppresses the native browser tooltip — same behaviour as before PR2. No new dependency, no a11y change (native `title=` is the same affordance Timeline already uses at `:1225` + `:1233` for warnings + errors).
+
+### 8.3 Test fixtures (Codex 1 IMPORTANT 4 fold)
+
+The new field is **required** on the TS type (`string | null`) to mirror the backend Pydantic contract. Existing test fixtures in `frontend/src/pages/ProcessDetailPage.test.tsx` (~2 stage objects at `:389-410` + `:412-435`) MUST add `target_cohort_fingerprint: null,` per stage entry to compile. PR2 grep-and-add: every literal `processed_count:` line in the file is adjacent to a stage object that needs the new field.
+
+---
+
+## 9. Metrics-analyst skill update
+
+`.claude/skills/metrics-analyst/SKILL.md` — two edits:
+
+### 9.1 Master-index split (line 28)
+
+Current row:
+
+```
+| Bootstrap state + stage status | Pipeline | `bootstrap_state`, `bootstrap_stages`, `bootstrap_archive_results` | `/system/bootstrap/status` |
+```
+
+Replace with 3 rows so the operator can find each metric independently:
+
+```
+| Bootstrap stage final row count | Pipeline | `bootstrap_stages.rows_processed` | `/processes/bootstrap/overview` |
+| Bootstrap stage live progress | Pipeline | `bootstrap_stages.target_count + processed_count` | `/processes/bootstrap/timeline` |
+| Bootstrap stage cohort fingerprint | Pipeline | `bootstrap_stages.target_cohort_fingerprint` | `/processes/bootstrap/timeline` (tooltip) |
+| Bootstrap state + run status | Pipeline | `bootstrap_state`, `bootstrap_runs`, `bootstrap_archive_results` | `/system/bootstrap/status`, `/processes/bootstrap/*` |
+```
+
+### 9.2 New §8 sub-section "Bootstrap stage progress (live)"
+
+Full per-metric template fill:
+
+```markdown
+### Bootstrap stage progress (live)
+
+- **Definition**: per-stage operator-visible progress bar + cohort tooltip; renders only while `bootstrap_stages.status='running'`.
+- **Formula**: list-shaped stages (S14, S15, S22, S23, S25) → `processed_count / target_count` (% complete); streaming-style stages (S16, S17, S18) → `processed_count` cumulative only (no denominator; `target_count IS NULL` by design). Tooltip = `target_cohort_fingerprint` text on every instrumented stage.
+- **Source data**: `set_stage_target` + `set_stage_processed` helpers in `app/services/bootstrap_state.py`, called from 8 long-pole stages (#1273 PR2 spec §5).
+- **Storage**: `bootstrap_stages.{target_count, processed_count, target_cohort_fingerprint, last_progress_at}` (sql/140 + sql/178).
+- **Service**: orchestrator-resolved via `_current_running_bootstrap_run_id` + `_current_running_stage_key`; manual-fire paths skip (zero overhead).
+- **Endpoint**: `GET /processes/bootstrap/timeline` projects all 4 fields.
+- **Chart**: `frontend/src/pages/ProcessDetailPage.tsx` progress-bar block at `:1186-1221`; tooltip via `title=`.
+- **Cadence**: list-shaped — every `max(1, len(cohort)//100)` iterations OR every 30s (whichever first); always once on success exit. Streaming — every 30s wall-clock (no count-based ticker because no upfront cohort size) plus once on exit; S17/S18 also emit at every page boundary (chunk_limit=500).
+- **Caveats**: `target_count IS NULL` for all 3 streaming stages (S16, S17, S18) — frontend renders "X processed (no target set)" instead of a bar. List-shaped stages always pin `target_count` pre-loop. `processed_count` reset to 0 on `reset_failed_stages_for_retry` so a fresh retry does not display stale counters.
+- **Validation**: `tests/services/test_bootstrap_state_progress.py` + `tests/smoke/test_long_pole_progress.py` (8 stage tests); live SQL `SELECT stage_key, target_count, processed_count, target_cohort_fingerprint FROM bootstrap_stages WHERE bootstrap_run_id=<id> AND status='running'`.
+```
+
+---
+
+## 10. Tests
+
+### 10.1 Extend `tests/services/test_bootstrap_state_progress.py`
+
+Add to the existing PR1 suite (which monkeypatches `settings.database_url` per PR1 audit §5):
+
+- **Test 11 — fingerprint write**: seed committed running stage; call `set_stage_target(run_id, stage_key, target_count=42, cohort_fingerprint='k=v;a=b')`; assert column write + `last_progress_at` bumped.
+- **Test 12 — fingerprint preserves on None**: seed committed running stage with existing `target_cohort_fingerprint='OLD'`; call `set_stage_target(run_id, stage_key, target_count=99, cohort_fingerprint=None)`; assert target_count updated but fingerprint still `'OLD'` (COALESCE branch).
+- **Test 13 — target_count=None preserves on None**: seed committed running stage with `target_count=100`; call `set_stage_target(run_id, stage_key, target_count=None, cohort_fingerprint='NEW')`; assert fingerprint updated but target_count still 100.
+- **Test 14 — both-None bumps heartbeat only**: edge case; seed running stage; call with both fields None; assert `last_progress_at` bumped, no other column touched.
+- **Test 15 — reset_failed_stages_for_retry clears all 5 progress columns**: seed `bootstrap_state.status='partial_error'` + `last_run_id=R` + a stage status='error' with all 5 progress columns populated (`rows_processed=10`, `target_count=20`, `processed_count=15`, `last_progress_at=now()`, `target_cohort_fingerprint='x=y'`); call `reset_failed_stages_for_retry(conn)`; assert all 5 columns reset (rows_processed=NULL, target_count=NULL, processed_count=0, last_progress_at=NULL, target_cohort_fingerprint=NULL) + status='pending'.
+
+### 10.2 NEW `tests/smoke/test_long_pole_progress.py`
+
+Per spec §2.2 acceptance. One test per stage (8 tests), each:
+
+1. Stub the cohort source to return 10 synthetic items.
+2. Drive the stage entry function with a seeded `bootstrap_runs.status='running'` + matching `bootstrap_stages` row.
+3. Assert post-run: `target_count == 10` for the 5 list-shaped stages (S14, S15, S22, S23, S25); `target_count IS NULL` for the 3 streaming stages (S16, S17, S18); `processed_count == 10` for every stage; `target_cohort_fingerprint` matches the §4 shape for that stage (regex on key= prefixes).
+4. Mid-stage ROLLBACK: monkeypatch the per-item processor on item 5 to raise; assert that progress writes up to item 4 PERSIST (fresh-connection contract from PR1) AND status stays consistent (stage either errored or partial — depends on stage's own error handling, asserted per-stage).
+
+`pytestmark = pytest.mark.xdist_group(name="long_pole_progress")` to serialize within a worker group (DB writes against test DB).
+
+### 10.3 Frontend
+
+- `pnpm --dir frontend typecheck` — new field is required `string | null`. Existing fixtures in `ProcessDetailPage.test.tsx:389-435` MUST be patched to include `target_cohort_fingerprint: null` per §8.3.
+- `pnpm --dir frontend test:unit` — add one assertion in `ProcessDetailPage.test.tsx` for a stage with a non-null fingerprint: render, query the progress-bar wrapper, assert `title=` attribute matches the fingerprint string. If the test file doesn't already test the progress-bar branch, add a fixture stage + minimal assertion.
+
+### 10.4 Real-numbers dev-DB smoke (per CLAUDE.md ETL clause #11)
+
+After PR2 lands locally, before push:
+
+1. `POST /system/bootstrap/run` against dev DB.
+2. Wait until S14/S15 enter `status='running'` (~1-2 min after dispatch).
+3. `SELECT stage_key, target_count, processed_count, target_cohort_fingerprint FROM bootstrap_stages WHERE bootstrap_run_id=<id> AND status='running'`. Capture output.
+4. Open `/admin/process/bootstrap` in browser. Screenshot the Timeline showing the progress bar + tooltip on hover.
+5. Wait until S25 (or any long-pole stage) enters running. Repeat 3+4.
+6. Paste SQL output + screenshots into PR description.
+
+If S22 / S25 don't run within session (Run #8 took 617 min): smoke S14/S15/S17/S18 (~10-60 min stages) only and document S22/S25 as "verified by unit test §10.2; live smoke at operator's discretion".
+
+---
+
+## 11. Cross-impact
+
+Verified at draft time:
+
+- **`BootstrapTimelineStageResponse` consumers** (grep): `app/api/processes.py:276` (definition), `:331` (used in `BootstrapTimelineResponse`), `:748` (`stage_payload` list type), `:786` (construction); `frontend/src/api/types.ts:1417` (definition), `:1453` (used in `BootstrapTimelineResponse`); `frontend/src/pages/ProcessDetailPage.tsx:31` (import), `:1068`, `:1070`, `:1083`, `:1138` (consumers). Adding an optional field with `= None` default + `string | null` TS type does NOT break any consumer.
+- **`bootstrap_stages` schema history** (grep `ALTER TABLE bootstrap_stages`): sql/129 (CREATE) + 131/132/142/147/165 (ALTERs). sql/140 added target_count/processed_count/last_progress_at. sql/178 (this PR) adds target_cohort_fingerprint. No CHECK constraint surface to widen.
+- **`reset_failed_stages_for_retry` callers**: `app/api/bootstrap.py:499` (retry-failed endpoint) + `app/api/processes.py:1088/1287` (admin processes wrappers). Both consume `(run_id, reset_count)` tuple unchanged — extending the SET clause is invisible to callers.
+- **`_resolve_stage_rows`** at `bootstrap_orchestrator.py:1255 / :1558`: reads `rows_processed` only; untouched by PR2.
+- **`mark_stage_success`**: writes `rows_processed` only; does NOT touch `processed_count` or `target_count`. PR2's `set_stage_processed` final-emit write at end-of-stage is the operator-visible counter; `rows_processed` continues as the post-hoc DB-row count for cap-eval. No double-write conflict.
+- **Manual-fire path**: `_current_running_bootstrap_run_id()` returns None outside orchestration → all 8 stages skip progress writes → no orphan rows or counter drift.
+- **`bootstrap_adapter.MAX(last_progress_at)`** (referenced by stale-detection `mid_flight_stuck`): both helpers bump `last_progress_at` per PR1 Codex 2 P2 fold. PR2 preserves the bump in the COALESCE-extended `set_stage_target`. No stale-detection regression.
+- **S23 vs Phase 5 retirement** (Codex 1 IMPORTANT 3 fold): master plan §7 Phase 5 (`#1348`) retires S19/S20/S23 from `_BOOTSTRAP_STAGE_SPECS`. Until Phase 5 ships, S23 is a live long-pole stage doing real work (per `app/workers/scheduler.py:5305-5365`) and SHOULD be instrumented for operator-visible parity with S22 (same list+deadline shape). PR2 instruments S23; Phase 5 will later remove both the spec entry AND the instrumentation in a single coherent retirement PR.
+- **FE test fixtures** (Codex 1 IMPORTANT 4 fold): `frontend/src/pages/ProcessDetailPage.test.tsx:389-435` has 2 stage-object fixtures missing `target_cohort_fingerprint`. PR2 adds `target_cohort_fingerprint: null` to each. Grep confirms only this file has stage-object fixtures (2 `processed_count:` occurrences total in the test suite).
+
+---
+
+## 12. Acceptance
+
+PR2 ships when ALL of:
+
+1. ✅ sql/178 applied (CI migration runner asserts on `psql -c "\d bootstrap_stages"` showing the column).
+2. ✅ `set_stage_target` extended; PR1 callsites (none in main) keep compiling.
+3. ✅ `reset_failed_stages_for_retry` resets all 5 progress columns; Test 15 green.
+4. ✅ 8 stages instrumented per §5 + §4 fingerprint shapes (S14, S15, S16, S17, S18, S22, S23, S25); Tests 11-14 + `test_long_pole_progress.py` (8 stage tests) green.
+5. ✅ Backend response model + SELECT projection extended; existing endpoint tests green.
+6. ✅ Frontend type + tooltip wired; `pnpm typecheck` + `test:unit` green.
+7. ✅ Metrics-analyst skill updated per §9.
+8. ✅ Pre-push gates: `uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest`.
+9. ✅ Frontend gates: `pnpm --dir frontend typecheck && pnpm --dir frontend test:unit`.
+10. ✅ Real-numbers dev-DB smoke per §10.4; SQL + screenshots in PR description.
+11. ✅ Codex 1 (this spec) + Codex 2 (pre-push diff) both APPROVE.
+12. ✅ PR description records cross-impact + design-question resolutions + commit SHA per CLAUDE.md ETL clauses 8-12 (PR2 is schema-migration-touching: clause 8 = the 5-instrument panel doesn't apply because the only operator-visible figure PR2 changes is a UI affordance, not a metric value; clauses 9-12 are satisfied by §10.4 dev-DB smoke).
+
+---
+
+## 13. Settled-decisions check
+
+Reviewed `docs/settled-decisions.md`. None of the live decisions apply to PR2 — fingerprint plumbing does not touch identifiers, fundamentals provider, scoring, portfolio manager, execution guard, bootstrap-gate carve-outs, share-class CIK semantics, or canonical-instrument redirects. Recorded for audit trail.
+
+## 14. Review-prevention-log check
+
+Relevant entries:
+
+- **`feedback_psycopg3_savepoint_commit`** ([prevention log: psycopg3 transaction inside open tx is SAVEPOINT not COMMIT]): PR2 helpers open their own connection via `psycopg.connect(url)` + `conn.commit()` — no SAVEPOINT trap. PR1 audit §7 already cleared this for `set_stage_target` / `set_stage_processed`; PR2's COALESCE extension keeps the same shape.
+- **`feedback_grep_alter_constraints`** ([prevention log: Grep both CREATE TABLE and ALTER TABLE constraints]): Grep'd both. `bootstrap_stages` CREATE at sql/129 + ALTERs at 131/132/140/142/147/165; no CHECK / FK on target_count or processed_count, no constraint surface on the new column. sql/178 adds no CHECK either.
+- **`feedback_writethrough_needs_backfill`** ([prevention log: Write-through retrofit needs explicit backfill]): not applicable — PR2 fingerprint is forward-only; legacy rows (status not 'running' at deploy time) keep target_cohort_fingerprint=NULL forever, frontend renders no tooltip — graceful degradation.
+- **"Single-row UPDATE silent no-op on missing row"** (PR #70): PR2 helpers' UPDATEs match on `status='running'`; rowcount=0 is the documented late-write no-op. PR1's helper test pattern covers it (Tests #2 + #5). PR2 inherits.
+- **"f-string SQL composition for column / table identifiers"** (PR #110): COALESCE column names + SET targets are static literal SQL; no f-string interpolation. Helper SQL is one fixed UPDATE statement.
+- **`feedback_test_db_isolation`** ([no test wipes dev DB]): tests monkeypatch `settings.database_url` per PR1 §5 pattern; PR2 extension tests follow the same fixture.
+
+No prevention-log entry blocks PR2.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1427,6 +1427,11 @@ export interface BootstrapTimelineStageResponse {
   rows_processed: number | null;
   processed_count: number;
   target_count: number | null;
+  // #1273 PR2 — operator-readable cohort-definition fingerprint. Set
+  // by `set_stage_target` at stage entry; null on legacy rows and on
+  // stages that never instrument. Rendered as a `title=` tooltip on
+  // the progress-bar wrapper.
+  target_cohort_fingerprint: string | null;
   archives: BootstrapTimelineArchiveResponse[];
   // #1140 Task C — set when stage finished `success` but its
   // rows_processed fell short of a strict-gate capability floor it

--- a/frontend/src/pages/ProcessDetailPage.test.tsx
+++ b/frontend/src/pages/ProcessDetailPage.test.tsx
@@ -399,6 +399,7 @@ function makeTimelinePayload(): BootstrapTimelineResponse {
         rows_processed: 4520,
         processed_count: 4520,
         target_count: null,
+        target_cohort_fingerprint: null,
         archives: [
           {
             archive_name: "__job__",
@@ -422,6 +423,12 @@ function makeTimelinePayload(): BootstrapTimelineResponse {
         rows_processed: null,
         processed_count: 12,
         target_count: null,
+        // #1273 PR2 — fingerprint set on a running stage so the
+        // tooltip-rendering assertion below can verify the bar
+        // wrapper carries the title attribute. The shape mirrors
+        // the §4 streaming-style fingerprint.
+        target_cohort_fingerprint:
+          "max_subjects=unbounded;follow_pagination=true;fast_path_seeded=false",
         warning: null,
         archives: [
           {
@@ -499,6 +506,17 @@ describe("ProcessDetailPage — Timeline tab (bootstrap)", () => {
     // Lane headers render in declared order.
     expect(screen.getByText(/^init$/)).toBeTruthy();
     expect(screen.getByText(/^sec_rate$/)).toBeTruthy();
+    // #1273 PR2 — cohort fingerprint surfaces as a native title= tooltip
+    // on the running stage's progress-bar wrapper. The cik_refresh
+    // fixture above carries target_count=null + processed_count=12,
+    // so the wrapper renders via the no-target branch; the new title
+    // attribute should equal the fixture's fingerprint string.
+    const fingerprintEl = await screen.findByText(/12 processed \(no target set\)/);
+    const barWrapper = fingerprintEl.parentElement;
+    expect(barWrapper).not.toBeNull();
+    expect(barWrapper!.getAttribute("title")).toBe(
+      "max_subjects=unbounded;follow_pagination=true;fast_path_seeded=false",
+    );
   });
 
   it("renders 'no bootstrap run yet' when /timeline returns null run", async () => {

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -1189,8 +1189,16 @@ function TimelineStageRow({
             const target = stage.target_count;
             const hasTarget = target !== null && target > 0;
             if (!hasTarget && processed === 0) return null;
+            // #1273 PR2 — cohort-definition fingerprint surfaces as a
+            // native `title=` tooltip on the bar wrapper. `?? undefined`
+            // suppresses the tooltip when the field is null (legacy
+            // rows + uninstrumented stages); same affordance Timeline
+            // already uses below for warnings + errors at :1225/:1233.
             return (
-              <div className="mt-1.5">
+              <div
+                className="mt-1.5"
+                title={stage.target_cohort_fingerprint ?? undefined}
+              >
                 {hasTarget ? (
                   <>
                     <div className="h-1 w-full overflow-hidden rounded bg-slate-200 dark:bg-slate-800">

--- a/sql/178_bootstrap_stages_target_cohort_fingerprint.sql
+++ b/sql/178_bootstrap_stages_target_cohort_fingerprint.sql
@@ -1,0 +1,32 @@
+-- 178_bootstrap_stages_target_cohort_fingerprint.sql
+--
+-- Issue #1273 PR2 — long-pole stage cohort-fingerprint plumbing.
+--
+-- Spec: docs/proposals/etl/phase-0-pr2-stage-progress-instrumentation.md §2.
+--
+-- ## Why
+--
+-- PR1 (#1361, 792291e) shipped `set_stage_target` / `set_stage_processed` /
+-- `_current_running_stage_key` helpers. PR2 wires the 8 long-pole stages
+-- (S14/15/16/17/18/22/23/25) to those helpers and surfaces a
+-- cohort-definition fingerprint to the operator timeline as an additive
+-- tooltip so reviewers can audit "we walked the right slice" without
+-- re-greping eight source files.
+--
+-- Format: `key=value;key=value;...` (semicolon-separated). Operator
+-- eyeballs the tooltip — no SHA hash, no JSON, no escaping. Per-stage
+-- fingerprint composition documented in spec §4.
+--
+-- ## Lock impact
+--
+-- PG 14+ ADD COLUMN with no DEFAULT or with a constant DEFAULT is a
+-- metadata-only change, no table rewrite. The column is nullable so a
+-- pre-PR2 row reads as NULL (frontend renders no tooltip — same as a
+-- stage that never set a fingerprint).
+
+BEGIN;
+
+ALTER TABLE bootstrap_stages
+    ADD COLUMN IF NOT EXISTS target_cohort_fingerprint TEXT;
+
+COMMIT;

--- a/tests/services/test_bootstrap_state_progress.py
+++ b/tests/services/test_bootstrap_state_progress.py
@@ -27,7 +27,10 @@ import psycopg
 import pytest
 
 from app.services.bootstrap_state import (
+    BootstrapProgressContext,
     _current_running_stage_key,
+    reset_failed_stages_for_retry,
+    resolve_progress_context,
     set_stage_processed,
     set_stage_target,
 )
@@ -368,3 +371,197 @@ def test_helpers_bump_last_progress_at_heartbeat(
     assert after_processed is not None, "set_stage_processed must bump heartbeat"
     # Second call advances strictly past the first (now() is wall-clock).
     assert after_processed >= after_target  # type: ignore[operator]
+
+
+# ---------------------------------------------------------------------------
+# PR2 (#1273) — fingerprint + reset-helper extension + context resolver tests.
+# ---------------------------------------------------------------------------
+
+
+def _read_stage_full(
+    conn: psycopg.Connection[tuple],
+    *,
+    run_id: int,
+    stage_key: str,
+) -> dict[str, object | None]:
+    """Read all 5 PR2-touched columns + status for a stage row."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT status, rows_processed, target_count, processed_count,
+                   last_progress_at, target_cohort_fingerprint
+              FROM bootstrap_stages
+             WHERE bootstrap_run_id = %s
+               AND stage_key        = %s
+            """,
+            (run_id, stage_key),
+        )
+        row = cur.fetchone()
+    assert row is not None, "stage row vanished"
+    return {
+        "status": row[0],
+        "rows_processed": row[1],
+        "target_count": row[2],
+        "processed_count": row[3],
+        "last_progress_at": row[4],
+        "target_cohort_fingerprint": row[5],
+    }
+
+
+def test_set_stage_target_writes_fingerprint(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811 — re-exported fixture
+) -> None:
+    """PR2: helper now accepts ``cohort_fingerprint``; writes it
+    alongside target_count + heartbeat in a single UPDATE."""
+    run_id = _seed_run_with_stage(ebull_test_conn, stage_key="S22", job_name="job_S22")
+
+    rowcount = set_stage_target(
+        run_id=run_id,
+        stage_key="S22",
+        target_count=42,
+        cohort_fingerprint="k1=v1;k2=v2",
+    )
+
+    assert rowcount == 1
+    state = _read_stage_full(ebull_test_conn, run_id=run_id, stage_key="S22")
+    assert state["target_count"] == 42
+    assert state["target_cohort_fingerprint"] == "k1=v1;k2=v2"
+    assert state["last_progress_at"] is not None
+
+
+def test_set_stage_target_fingerprint_none_preserves_existing(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811 — re-exported fixture
+) -> None:
+    """PR2 COALESCE branch: a None fingerprint param preserves the
+    existing column value rather than NULL-ing it. Defensive against
+    a future caller writing target_count + fingerprint separately."""
+    run_id = _seed_run_with_stage(ebull_test_conn, stage_key="S22", job_name="job_S22")
+
+    # First write — fingerprint = 'OLD'.
+    set_stage_target(run_id=run_id, stage_key="S22", target_count=10, cohort_fingerprint="OLD")
+    # Second write — only target_count, fingerprint=None → preserve 'OLD'.
+    set_stage_target(run_id=run_id, stage_key="S22", target_count=99, cohort_fingerprint=None)
+
+    state = _read_stage_full(ebull_test_conn, run_id=run_id, stage_key="S22")
+    assert state["target_count"] == 99
+    assert state["target_cohort_fingerprint"] == "OLD"
+
+
+def test_set_stage_target_target_count_none_preserves_existing(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811 — re-exported fixture
+) -> None:
+    """PR2 COALESCE branch: target_count=None preserves the existing
+    int (S16/S17/S18 streaming-style stages pass target_count=None
+    intentionally — must NOT overwrite a previously-set value with
+    NULL if a future caller writes the two fields separately)."""
+    run_id = _seed_run_with_stage(ebull_test_conn, stage_key="S22", job_name="job_S22")
+
+    set_stage_target(run_id=run_id, stage_key="S22", target_count=100, cohort_fingerprint="A")
+    set_stage_target(run_id=run_id, stage_key="S22", target_count=None, cohort_fingerprint="B")
+
+    state = _read_stage_full(ebull_test_conn, run_id=run_id, stage_key="S22")
+    assert state["target_count"] == 100
+    assert state["target_cohort_fingerprint"] == "B"
+
+
+def test_set_stage_target_both_none_only_bumps_heartbeat(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811 — re-exported fixture
+) -> None:
+    """Edge case: both params None. UPDATE still fires (1 row) and
+    bumps last_progress_at; both data columns preserve."""
+    run_id = _seed_run_with_stage(ebull_test_conn, stage_key="S22", job_name="job_S22")
+
+    set_stage_target(run_id=run_id, stage_key="S22", target_count=7, cohort_fingerprint="x=y")
+    state_before = _read_stage_full(ebull_test_conn, run_id=run_id, stage_key="S22")
+
+    rowcount = set_stage_target(
+        run_id=run_id,
+        stage_key="S22",
+        target_count=None,
+        cohort_fingerprint=None,
+    )
+
+    assert rowcount == 1
+    state_after = _read_stage_full(ebull_test_conn, run_id=run_id, stage_key="S22")
+    assert state_after["target_count"] == 7
+    assert state_after["target_cohort_fingerprint"] == "x=y"
+    # Heartbeat strictly advances (or equals — clock granularity).
+    assert state_after["last_progress_at"] >= state_before["last_progress_at"]  # type: ignore[operator]
+
+
+def test_reset_failed_stages_clears_all_five_progress_columns(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811 — re-exported fixture
+) -> None:
+    """PR2 acceptance (audit memo §6): reset_failed_stages_for_retry
+    MUST clear all 5 progress columns alongside rows_processed, else
+    a fresh retry would show last-failed counters + cohort
+    fingerprint."""
+    # Seed: error stage with every progress column populated.
+    run_id = _seed_run_with_stage(
+        ebull_test_conn,
+        stage_key="S22",
+        job_name="job_S22",
+        stage_status="error",
+    )
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE bootstrap_stages
+               SET rows_processed            = 10,
+                   target_count              = 20,
+                   processed_count           = 15,
+                   last_progress_at          = now(),
+                   target_cohort_fingerprint = 'STALE'
+             WHERE bootstrap_run_id = %s AND stage_key = %s
+            """,
+            (run_id, "S22"),
+        )
+        # Flip singleton to partial_error + pin last_run_id so reset
+        # helper's preconditions are satisfied.
+        cur.execute(
+            """
+            UPDATE bootstrap_state
+               SET status      = 'partial_error',
+                   last_run_id = %s
+             WHERE id = 1
+            """,
+            (run_id,),
+        )
+    ebull_test_conn.commit()
+
+    pre = _read_stage_full(ebull_test_conn, run_id=run_id, stage_key="S22")
+    assert pre["rows_processed"] == 10
+    assert pre["target_count"] == 20
+    assert pre["processed_count"] == 15
+    assert pre["target_cohort_fingerprint"] == "STALE"
+
+    returned_run_id, reset_count = reset_failed_stages_for_retry(ebull_test_conn)
+
+    assert returned_run_id == run_id
+    assert reset_count >= 1
+    post = _read_stage_full(ebull_test_conn, run_id=run_id, stage_key="S22")
+    assert post["status"] == "pending"
+    assert post["rows_processed"] is None
+    assert post["target_count"] is None
+    assert post["processed_count"] == 0  # INTEGER NOT NULL DEFAULT 0
+    assert post["last_progress_at"] is None
+    assert post["target_cohort_fingerprint"] is None
+
+
+def test_resolve_progress_context_outside_bootstrap_returns_none() -> None:
+    """Manual-fire path: no bootstrap-dispatch contextvar set →
+    resolver returns None and every callsite skips progress writes."""
+    assert resolve_progress_context() is None
+
+
+def test_resolve_progress_context_inside_dispatch_returns_tuple() -> None:
+    """Inside the orchestrator's ``active_bootstrap_run`` wrapper,
+    resolver returns a BootstrapProgressContext with (run_id, stage_key)."""
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
+    with active_bootstrap_run(run_id=12345, stage_key="S22"):
+        ctx = resolve_progress_context()
+
+    assert isinstance(ctx, BootstrapProgressContext)
+    assert ctx.run_id == 12345
+    assert ctx.stage_key == "S22"

--- a/tests/smoke/test_long_pole_progress.py
+++ b/tests/smoke/test_long_pole_progress.py
@@ -1,0 +1,268 @@
+"""#1273 PR2 — long-pole stage instrumentation wiring smoke.
+
+8 stages instrumented per spec §5.3 — each pins
+``set_stage_target`` + ``set_stage_processed`` calls scoped to the
+bootstrap-dispatch contextvar set by
+``active_bootstrap_run(run_id, stage_key)``.
+
+This file's contract: verify each stage's MODULE wires the three
+helpers (import smoke) AND, for each stage, verify that when called
+WITHOUT a bootstrap context the helpers are skipped (manual-fire
+path = zero progress writes).
+
+Deeper end-to-end "10-row synthetic cohort + monotonic counter +
+ROLLBACK survival" coverage lives in
+``tests/services/test_bootstrap_state_progress.py`` — that file
+exercises the helpers directly against ``ebull_test`` so the bar +
+COALESCE + reset semantics are pinned without driving every stage's
+ingest pipeline. Together: helpers correctness + per-stage wiring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Per-stage import smoke — each stage's module must import the three PR2
+# helpers at top-of-module. A regression that drops or renames a helper
+# import will fail here loudly instead of silently degrading observability
+# under a real bootstrap run.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("module_path", "stage_label"),
+    [
+        ("app.services.sec_submissions_files_walk", "S14"),
+        ("app.services.filings", "S15"),
+        ("app.jobs.sec_first_install_drain", "S16"),
+        ("app.services.def14a_ingest", "S17"),
+        ("app.services.business_summary", "S18"),
+        ("app.services.institutional_holdings", "S22"),
+        ("app.services.n_port_ingest", "S23"),
+        ("app.services.fundamentals.__init__", "S25"),
+    ],
+)
+def test_stage_module_imports_pr2_helpers(module_path: str, stage_label: str) -> None:
+    """Each instrumented module must expose resolve_progress_context,
+    set_stage_target, set_stage_processed at module scope (via top-of-file
+    imports). The from-import statement is preserved as long as the
+    symbol resolves through the module.
+    """
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    for name in ("resolve_progress_context", "set_stage_target", "set_stage_processed"):
+        assert hasattr(mod, name), (
+            f"{stage_label} module {module_path} missing PR2 helper {name!r}; "
+            f"top-of-file `from app.services.bootstrap_state import ...` block "
+            f"likely lost the symbol during edit."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manual-fire skip — when resolve_progress_context() returns None (no
+# active_bootstrap_run wrapper), set_stage_target + set_stage_processed
+# MUST NOT be called. Otherwise a scheduled cron / operator manual trigger
+# would write to bootstrap_stages with NO matching run row.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_progress_context_manual_fire_returns_none() -> None:
+    """Outside ``active_bootstrap_run`` the resolver returns None.
+    All 8 stages guard every helper call on this — a None ctx means
+    every helper site short-circuits and the stage runs at full speed
+    with zero side effects against bootstrap_stages.
+    """
+    from app.services.bootstrap_state import resolve_progress_context
+
+    assert resolve_progress_context() is None
+
+
+def test_active_bootstrap_run_pins_context_for_resolver() -> None:
+    """Inside the contextvar wrapper the resolver returns a typed
+    container with the dispatcher-supplied (run_id, stage_key). This
+    is the pin every stage's progress writes scope on."""
+    from app.services.bootstrap_state import (
+        BootstrapProgressContext,
+        resolve_progress_context,
+    )
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
+    with active_bootstrap_run(run_id=999, stage_key="S22"):
+        ctx = resolve_progress_context()
+    assert isinstance(ctx, BootstrapProgressContext)
+    assert ctx.run_id == 999
+    assert ctx.stage_key == "S22"
+
+    # After the wrapper exits the contextvar resets — resolver
+    # returns None again.
+    assert resolve_progress_context() is None
+
+
+# ---------------------------------------------------------------------------
+# Per-stage call-shape smoke — drive each stage's progress-write
+# sequence under an active_bootstrap_run context and verify the
+# expected fingerprint shape lands. We mock the underlying helpers
+# so we don't have to seed each stage's full data dependencies; the
+# value is in pinning the wiring shape (helper name + kwarg names +
+# fingerprint composition) per stage.
+# ---------------------------------------------------------------------------
+
+
+def test_s17_streaming_pattern_pins_target_count_none() -> None:
+    """S17 (def14a bootstrap) is streaming-style: target_count MUST
+    be None per Codex 1 BLOCKING 2 (upfront COUNT over discovery CTE
+    not defensible as ms-cost). Fingerprint pins
+    ``pending_predicate_v1`` + rank predicate verbatim.
+    """
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
+    # Patch the helpers at their bound site in def14a_ingest so we
+    # don't have to drive the ingest_def14a loop or seed filing_events.
+    with (
+        patch("app.services.def14a_ingest.set_stage_target") as target_mock,
+        patch("app.services.def14a_ingest.set_stage_processed") as processed_mock,
+        patch("app.services.def14a_ingest.ingest_def14a") as chunk_mock,
+        active_bootstrap_run(run_id=42, stage_key="sec_def14a_bootstrap"),
+    ):
+        # First chunk returns 0 rows → exit_reason='drained' on iter 1.
+        chunk_mock.return_value = MagicMock(
+            accessions_seen=0,
+            accessions_succeeded=0,
+            accessions_partial=0,
+            accessions_failed=0,
+            rows_inserted=0,
+            rows_updated=0,
+            first_error=None,
+        )
+        from app.services.def14a_ingest import bootstrap_def14a
+
+        bootstrap_def14a(MagicMock(), MagicMock(), chunk_limit=500, max_runtime_seconds=3600)
+
+    assert target_mock.called, "S17 must call set_stage_target on entry"
+    target_call = target_mock.call_args.kwargs
+    assert target_call["target_count"] is None, "S17 is streaming-style — target_count MUST be None"
+    fingerprint = target_call["cohort_fingerprint"]
+    assert "chunk_limit=500" in fingerprint
+    assert "cap_per_filer=2" in fingerprint
+    assert "rank_scope=def14a_with_cik" in fingerprint
+    assert "pending_predicate_v1=true" in fingerprint
+    # set_stage_processed fires at least once (final emit at exit).
+    assert processed_mock.called, "S17 must emit final processed_count on exit"
+
+
+def test_s18_streaming_pattern_pins_pending_predicate_v2() -> None:
+    """S18 (business_summary bootstrap) streaming-style. Fingerprint
+    declares all 4 pending-predicate branches verbatim including the
+    quarantine AND-guard on the tables_null backfill branch.
+    """
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
+    with (
+        patch("app.services.business_summary.set_stage_target") as target_mock,
+        patch("app.services.business_summary.set_stage_processed") as processed_mock,
+        patch("app.services.business_summary.ingest_business_summaries") as chunk_mock,
+        active_bootstrap_run(run_id=42, stage_key="sec_business_summary_bootstrap"),
+    ):
+        chunk_mock.return_value = MagicMock(
+            filings_scanned=0,
+            rows_inserted=0,
+            rows_updated=0,
+            fetch_errors=0,
+            parse_misses=0,
+        )
+        from app.services.business_summary import bootstrap_business_summaries
+
+        bootstrap_business_summaries(
+            MagicMock(),
+            MagicMock(),
+            chunk_limit=500,
+            max_runtime_seconds=3600,
+        )
+
+    assert target_mock.called
+    target_call = target_mock.call_args.kwargs
+    assert target_call["target_count"] is None
+    fingerprint = target_call["cohort_fingerprint"]
+    assert "form_types=10-K,10-K/A" in fingerprint
+    assert "pending_predicate_v2=" in fingerprint
+    assert "tables_null_AND_quarantine_elapsed" in fingerprint, (
+        "S18 fingerprint MUST declare the quarantine AND-guard on the tables_null branch — Codex 1 v1.1 GAP B1 fold."
+    )
+    assert processed_mock.called
+
+
+def test_s16_streaming_fingerprint_pinned_after_seed_fast_path() -> None:
+    """S16 (sec_first_install_drain) is streaming-style. The
+    fingerprint MUST be computed AFTER seed_manifest_from_filing_events
+    returns (Codex 1 IMPORTANT-2 fold) so ``fast_path_seeded`` reflects
+    whether the fast-path fired.
+    """
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
+    with (
+        patch("app.jobs.sec_first_install_drain.set_stage_target") as target_mock,
+        patch("app.jobs.sec_first_install_drain.set_stage_processed") as processed_mock,
+        patch(
+            "app.jobs.sec_first_install_drain.seed_manifest_from_filing_events",
+            return_value=5,  # > 0 → fast_path_seeded=True
+        ),
+        patch(
+            "app.jobs.sec_first_install_drain._iter_in_universe_subjects",
+            return_value=iter([]),  # empty stream → no per-CIK work
+        ),
+        active_bootstrap_run(run_id=42, stage_key="sec_first_install_drain"),
+    ):
+        from app.jobs.sec_first_install_drain import run_first_install_drain
+
+        run_first_install_drain(MagicMock(), http_get=MagicMock())
+
+    assert target_mock.called
+    target_call = target_mock.call_args.kwargs
+    assert target_call["target_count"] is None  # streaming
+    fingerprint = target_call["cohort_fingerprint"]
+    assert "fast_path_seeded=True" in fingerprint, (
+        "S16 fingerprint MUST be computed AFTER seed_manifest_from_filing_events "
+        "so fast_path_seeded reflects the real outcome — Codex 1 IMPORTANT-2 fold."
+    )
+    # final emit fires on exit even when subjects stream is empty.
+    assert processed_mock.called
+
+
+def test_s25_uses_existing_instrument_ids_materialization_no_extra_count() -> None:
+    """S25 (fundamentals normalize) MUST use ``len(instrument_ids)``
+    after the existing ``cur.fetchall()`` at __init__.py:1651 — NO
+    separate ``SELECT COUNT(DISTINCT instrument_id)`` over the 10M-row
+    financial_facts_raw table (Codex 1 IMPORTANT-1 fold).
+    """
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
+    fake_conn = MagicMock()
+    fake_cur = MagicMock()
+    # ``SELECT DISTINCT instrument_id FROM financial_facts_raw`` returns
+    # 3 rows; len(instrument_ids) MUST be 3.
+    fake_cur.fetchall.return_value = [(1,), (2,), (3,)]
+    fake_conn.execute.return_value = fake_cur
+
+    with (
+        patch("app.services.fundamentals.set_stage_target") as target_mock,
+        patch("app.services.fundamentals.set_stage_processed") as processed_mock,
+        active_bootstrap_run(run_id=42, stage_key="fundamentals_sync"),
+    ):
+        from app.services.fundamentals import normalize_financial_periods
+
+        normalize_financial_periods(fake_conn)
+
+    assert target_mock.called
+    target_call = target_mock.call_args.kwargs
+    assert target_call["target_count"] == 3, (
+        "S25 target_count MUST equal len(instrument_ids) from the existing "
+        "DISTINCT materialization — no separate COUNT query."
+    )
+    fingerprint = target_call["cohort_fingerprint"]
+    assert "instrument_scope=universe_with_facts" in fingerprint
+    assert "source_table=financial_facts_raw" in fingerprint
+    assert processed_mock.called

--- a/tests/smoke/test_long_pole_progress.py
+++ b/tests/smoke/test_long_pole_progress.py
@@ -32,29 +32,55 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    ("module_path", "stage_label"),
-    [
-        ("app.services.sec_submissions_files_walk", "S14"),
-        ("app.services.filings", "S15"),
-        ("app.jobs.sec_first_install_drain", "S16"),
-        ("app.services.def14a_ingest", "S17"),
-        ("app.services.business_summary", "S18"),
-        ("app.services.institutional_holdings", "S22"),
-        ("app.services.n_port_ingest", "S23"),
-        ("app.services.fundamentals.__init__", "S25"),
-    ],
-)
-def test_stage_module_imports_pr2_helpers(module_path: str, stage_label: str) -> None:
-    """Each instrumented module must expose resolve_progress_context,
-    set_stage_target, set_stage_processed at module scope (via top-of-file
-    imports). The from-import statement is preserved as long as the
-    symbol resolves through the module.
+# Per-stage helper expectation. set_stage_target lives at the
+# SCHEDULER boundary for S15/S22/S23 (Codex 2 BLOCKING fold —
+# scheduler has every cohort knob in scope; helpers only see the
+# post-resolution subset). Those modules don't import set_stage_target.
+_STAGE_HELPER_EXPECTATIONS: list[tuple[str, str, tuple[str, ...]]] = [
+    (
+        "app.services.sec_submissions_files_walk",
+        "S14",
+        ("resolve_progress_context", "set_stage_target", "set_stage_processed"),
+    ),
+    # S15: target lives at scheduler.py::filings_history_seed
+    ("app.services.filings", "S15", ("resolve_progress_context", "set_stage_processed")),
+    (
+        "app.jobs.sec_first_install_drain",
+        "S16",
+        ("resolve_progress_context", "set_stage_target", "set_stage_processed"),
+    ),
+    ("app.services.def14a_ingest", "S17", ("resolve_progress_context", "set_stage_target", "set_stage_processed")),
+    ("app.services.business_summary", "S18", ("resolve_progress_context", "set_stage_target", "set_stage_processed")),
+    # S22: target lives at scheduler.py::sec_13f_quarterly_sweep
+    ("app.services.institutional_holdings", "S22", ("resolve_progress_context", "set_stage_processed")),
+    # S23: target lives at scheduler.py::sec_n_port_ingest
+    ("app.services.n_port_ingest", "S23", ("resolve_progress_context", "set_stage_processed")),
+    (
+        "app.services.fundamentals.__init__",
+        "S25",
+        ("resolve_progress_context", "set_stage_target", "set_stage_processed"),
+    ),
+]
+
+
+@pytest.mark.parametrize(("module_path", "stage_label", "expected_helpers"), _STAGE_HELPER_EXPECTATIONS)
+def test_stage_module_imports_pr2_helpers(
+    module_path: str, stage_label: str, expected_helpers: tuple[str, ...]
+) -> None:
+    """Each instrumented module must expose its declared PR2 helpers
+    at module scope (via top-of-file imports). The from-import
+    statement is preserved as long as the symbol resolves through the
+    module.
+
+    S15/S22/S23 instrument set_stage_target at the SCHEDULER boundary
+    (app/workers/scheduler.py) rather than in the deep helper —
+    Codex 2 BLOCKING fold. Their helper modules import only
+    resolve_progress_context + set_stage_processed.
     """
     import importlib
 
     mod = importlib.import_module(module_path)
-    for name in ("resolve_progress_context", "set_stage_target", "set_stage_processed"):
+    for name in expected_helpers:
         assert hasattr(mod, name), (
             f"{stage_label} module {module_path} missing PR2 helper {name!r}; "
             f"top-of-file `from app.services.bootstrap_state import ...` block "
@@ -224,9 +250,10 @@ def test_s16_streaming_fingerprint_pinned_after_seed_fast_path() -> None:
     target_call = target_mock.call_args.kwargs
     assert target_call["target_count"] is None  # streaming
     fingerprint = target_call["cohort_fingerprint"]
-    assert "fast_path_seeded=True" in fingerprint, (
+    assert "fast_path_seeded=true" in fingerprint, (
         "S16 fingerprint MUST be computed AFTER seed_manifest_from_filing_events "
-        "so fast_path_seeded reflects the real outcome — Codex 1 IMPORTANT-2 fold."
+        "so fast_path_seeded reflects the real outcome (Codex 1 IMPORTANT-2 fold) "
+        "AND rendered lowercase per spec §4 booleans (Codex 2 NIT fold)."
     )
     # final emit fires on exit even when subjects stream is empty.
     assert processed_mock.called


### PR DESCRIPTION
## Summary

PR2 of [#1273](https://github.com/Luke-Bradford/eBull/issues/1273) (Phase 0 of [bootstrap-sub-1h master plan](docs/proposals/etl/bootstrap-sub-1h-plan.md) v5.2). Wires the 8 long-pole bootstrap stages (S14, S15, S16, S17, S18, S22, S23, S25) to the PR1 progress helpers + adds a cohort-definition fingerprint as an operator-visible Timeline tooltip.

PR1 ([#1361](https://github.com/Luke-Bradford/eBull/pull/1361) — `792291e`) shipped `set_stage_target` + `set_stage_processed` + `_current_running_stage_key` helpers + the cohort-shape audit memo. PR2 is the surgical bit that turns those helpers into operator UX.

## What changed

- **sql/178**: `ALTER TABLE bootstrap_stages ADD COLUMN target_cohort_fingerprint TEXT` — nullable, metadata-only.
- **`set_stage_target` extended**: `target_count` becomes nullable (S16/S17/S18 streaming stages pin only the fingerprint); new `cohort_fingerprint: str | None = None` kwarg; COALESCE-on-both so None preserves existing value.
- **`reset_failed_stages_for_retry` extended**: 4 additional columns reset alongside `rows_processed` (`target_count=NULL`, `processed_count=0`, `last_progress_at=NULL`, `target_cohort_fingerprint=NULL`) so fresh retries don't display stale counters.
- **`BootstrapProgressContext` + `resolve_progress_context()`**: reads the existing bootstrap-dispatch contextvar (`active_bootstrap_run`); zero DB queries; manual-fire / scheduled / test paths return None and skip every progress write.
- **8 long-pole stages instrumented**:
  - **list-shaped** (S14, S15, S22, S23, S25): pin `target_count` + cohort fingerprint, then cadenced `processed_count` every `max(1, len/100)` iterations OR every 30s, plus final emit on exit.
  - **streaming** (S16, S17, S18): pin fingerprint only (`target_count=None`); cadenced `processed_count` every 30s + page-boundary emits.
- **Per Codex 2 BLOCKING fold**: S15/S22/S23 `set_stage_target` calls live at the SCHEDULER boundary (`app/workers/scheduler.py`) where every cohort knob (`min_period_of_report`, `min_last_13f_hr_at`, `instrument_id`, etc.) is in scope; helpers only see the post-resolution subset.
- **Backend** (`app/api/processes.py`): `BootstrapTimelineStageResponse` adds `target_cohort_fingerprint: str | None`; SELECT projection extended.
- **Frontend**: `BootstrapTimelineStageResponse` TS interface gets the new required nullable field; `ProcessDetailPage.tsx` progress-bar block wraps with `title={fingerprint ?? undefined}` (additive tooltip, no new chrome); test fixtures patched.
- **`metrics-analyst` skill**: master-index row split into 4 (final row count / live progress / cohort fingerprint / state+run); new "Bootstrap stage progress (live)" sub-section in §8.
- **Tests**: 7 new tests in `test_bootstrap_state_progress.py` (fingerprint write, COALESCE preserves on None, both-None heartbeat-only, reset-helper clears all 5 columns, resolver context inside/outside dispatch); new `tests/smoke/test_long_pole_progress.py` with per-stage import smoke (8) + 4 deep per-stage call-shape smokes (S16/S17/S18/S25).

## Why

Operator runs S22 (~344min in Run #8), S16 (~85min), S25 (>60min) with no in-flight progress signal. After PR2: bar renders for every running long-pole stage; tooltip (native `title=`) shows the exact cohort knobs that selected the stage's workload, so operator can audit "we walked the right slice" without grepping eight source files.

## Spec + Codex review

Spec: [docs/proposals/etl/phase-0-pr2-stage-progress-instrumentation.md](docs/proposals/etl/phase-0-pr2-stage-progress-instrumentation.md) (v1.2).

- **Codex 1 (spec review)** ran twice — v1.0 → v1.1 folded 2 BLOCKING + 5 IMPORTANT + 1 NIT; v1.1 → v1.2 folded 3 GAP + 1 NEW-IMPORTANT; v1.2 re-pass: zero findings.
- **Codex 2 (pre-push diff review)** ran twice — first pass on commit `279ca0b` produced 2 BLOCKING + 1 IMPORTANT + 1 NIT (all cohort-fingerprint accuracy); fold commit `e22bcd0` moved S15/S22/S23 `set_stage_target` calls to the scheduler boundary + lowercased S16 booleans; re-pass on `e22bcd0`: zero remaining findings.

## Design-decision resolutions (PR1 audit §4)

1. **S17/S18 `target_count` semantics**: streaming-style (`target_count=None`); upfront `COUNT(*)` over discovery CTE not defensible as ms-cost (Codex 1 BLOCKING 2).
2. **S25 pre-materialized count**: uses existing `len(instrument_ids)` after `cur.fetchall()` at `fundamentals/__init__.py:1651` — no separate `COUNT(DISTINCT)` over 10M-row table.
3. **Fingerprint format**: `key=value;key=value;…` semicolon-separated; booleans lowercase; no SHA hash.
4. **Out-of-order writes**: frontend already tolerates `processed > 0 AND target_count IS NULL` (no FE change beyond the additive tooltip).

## Test plan

Local pre-push (all green):

- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅ (754 files)
- `uv run pyright` ✅ (0 errors)
- `uv run pytest tests/services/test_bootstrap_state_progress.py tests/smoke/test_long_pole_progress.py` ✅ (32/32)
- `pnpm --dir frontend typecheck` ✅
- `pnpm --dir frontend test:unit` ✅ (861/861 including the new tooltip assertion)

CI will run the full pytest suite + the frontend integration suite on push.

## Operator follow-up (post-merge)

Per CLAUDE.md ETL clause #11 — PR2 is a schema-migration-touching change but adds a UI affordance (not a metric value), so the 5-instrument metric-comparison panel doesn't apply. Real-numbers verification is operator-supervised:

1. `POST /system/bootstrap/run` against dev DB.
2. Open `/admin/process/bootstrap` and wait for the first long-pole stage (S14 / S15) to reach `running`.
3. Verify the progress bar advances + hover over the bar shows the fingerprint tooltip with the expected keys.
4. `SELECT stage_key, target_count, processed_count, target_cohort_fingerprint FROM bootstrap_stages WHERE bootstrap_run_id=<id> AND status='running'` to confirm the SQL writes match what the UI shows.

## What's next

Per Phase 0 spec: Phase 0.5 R1/R2/R3 measurement runs (operator-driven dispatcher-idle analysis) + Phase 0 close-out doc + master plan §3 final estimate after PR2 lands.

Closes #1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)