### PR TITLE
fix(#1363): jobs-process boot tolerance for true cold-start state

### DIFF
--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -613,7 +613,7 @@ def _check_operator_exists_with_cleanup(
     from app.jobs.boot_guard import (
         OPERATOR_MISSING_ERROR_MESSAGE,
         BootGuardOutcome,
-        check_operator_exists,
+        read_boot_gate_snapshot,
     )
 
     skip_env_set = os.environ.get("EBULL_JOBS_SKIP_OPERATOR_CHECK") == "1"
@@ -629,15 +629,26 @@ def _check_operator_exists_with_cleanup(
         )
         return
 
+    # Issue #1363 (Codex 2 P2 fold): both facts (operator presence +
+    # bootstrap_state.status) MUST be read in a single SELECT. Under
+    # autocommit + READ COMMITTED two separate SELECTs on the same
+    # connection can sample different points in time — a concurrent
+    # /auth/setup + Re-run all sequence committing between the probes
+    # would produce a stale gate decision (e.g. OPERATOR_ABSENT +
+    # status='running' would hard-fail incorrectly). One SELECT with
+    # nested EXISTS + sub-query evaluates within a single statement-
+    # level snapshot — atomic by construction without REPEATABLE READ.
     try:
         with psycopg.connect(settings.database_url, autocommit=True) as guard_conn:
-            outcome = check_operator_exists(guard_conn, skip_env_set=False)
+            operator_present, cold_start = read_boot_gate_snapshot(guard_conn)
     except BaseException:
         with contextlib.suppress(Exception):
             fence_conn.close()
         with contextlib.suppress(Exception):
             pool.close()
         raise
+
+    outcome = BootGuardOutcome.OPERATOR_PRESENT if operator_present else BootGuardOutcome.OPERATOR_ABSENT
 
     if outcome is BootGuardOutcome.OPERATOR_PRESENT:
         # Clear any stale breadcrumb from a prior failed boot. Bounded
@@ -670,6 +681,49 @@ def _check_operator_exists_with_cleanup(
         raise RuntimeError(
             f"unhandled BootGuardOutcome {outcome!r}; boot_guard module out of sync with wrapper",
         )
+
+    # Issue #1363 — cold-start tolerance. When bootstrap_state.status is
+    # 'pending' the application has never completed first-install setup;
+    # operator absence is the expected initial state, not a defect. Log
+    # INFO + return cleanly so jobs process boots alongside backend +
+    # frontend (the operator can then run /auth/setup via UI without
+    # racing against a dead jobs process). Scheduled fires that
+    # subsequently run in this window will reject with
+    # ``bootstrap_not_complete`` (the original docstring concern from
+    # Stream A PR-A T1.8) — that is the correct shape: the rejection is
+    # visible per-fire instead of taking the whole jobs process down.
+    if cold_start:
+        # Codex 2 P2 fold: clear ONLY a matching OPERATOR_MISSING
+        # breadcrumb left over from a prior hard-fail boot. Without
+        # this, /system/status would report "jobs boot blocked: no
+        # operators row in DB" while the jobs process is in fact
+        # running, deferred-cleanly under the cold-start branch. Other
+        # breadcrumbs (different boot-failure causes) are NOT touched —
+        # the cold-start gate only knows about its own prior-hard-fail
+        # artefact. The WHERE matches on exact message string so a
+        # future unrelated breadcrumb persisted by another guard is
+        # left visible.
+        try:
+            with psycopg.connect(settings.database_url, autocommit=True) as clear_conn:
+                with clear_conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE bootstrap_state "
+                        "SET last_jobs_boot_error = NULL, last_jobs_boot_error_at = NULL "
+                        "WHERE id = 1 AND last_jobs_boot_error = %s",
+                        (OPERATOR_MISSING_ERROR_MESSAGE,),
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "jobs entrypoint: cold-start clear of stale OPERATOR_MISSING breadcrumb failed: %s",
+                exc,
+            )
+
+        logger.info(
+            "jobs entrypoint: cold-start detected (bootstrap_state.status='pending'); "
+            "operator absence expected pre-/auth/setup, deferring boot guard. "
+            "Scheduled fires will reject with bootstrap_not_complete until setup runs.",
+        )
+        return
 
     # Hard-fail body: persist breadcrumb (best-effort with warning),
     # then cleanup + SystemExit(2). Wrapped in try/finally so cleanup

--- a/app/jobs/boot_guard.py
+++ b/app/jobs/boot_guard.py
@@ -75,6 +75,93 @@ def check_operator_exists(
     return BootGuardOutcome.OPERATOR_PRESENT
 
 
+def is_cold_start_state(conn: psycopg.Connection[Any]) -> bool:
+    """Pure check: is the application in pre-/auth/setup cold-start state?
+
+    Returns ``True`` iff ``bootstrap_state.status = 'pending'`` — meaning
+    first-install bootstrap has never been triggered. Operator absence
+    in this state is the expected initial condition (``/auth/setup``
+    has not been run yet), NOT a defect.
+
+    Returns ``False`` when:
+      * ``bootstrap_state.status`` is anything other than ``'pending'``
+        (``'running' | 'complete' | 'partial_error' | 'cancelled'``) —
+        post-install state where operator absence IS a defect.
+      * The ``bootstrap_state`` singleton row is missing entirely
+        (should not happen given the earlier
+        ``_ensure_bootstrap_state_singleton_with_cleanup`` guard; fail
+        closed to preserve hard-fail behaviour rather than mask the
+        anomaly).
+
+    Issue #1363: kept as a stand-alone primitive for direct callers
+    + test coverage. The wrapper at
+    ``app/jobs/__main__.py::_check_operator_exists_with_cleanup``
+    instead uses :func:`read_boot_gate_snapshot` to read operator
+    presence + cold-start signal in ONE SELECT — necessary because
+    READ COMMITTED + autocommit make two separate SELECTs vulnerable
+    to a stale-decision interleaving (Codex 2 P2: /auth/setup + Re-run
+    all can commit between the two probes and flip both facts under
+    the wrapper's nose).
+    """
+    with conn.cursor() as cur:
+        cur.execute("SELECT status FROM bootstrap_state WHERE id = 1")
+        row = cur.fetchone()
+    if row is None:
+        return False
+    return row[0] == "pending"
+
+
+def read_boot_gate_snapshot(conn: psycopg.Connection[Any]) -> tuple[bool, bool]:
+    """Atomic single-SELECT read of (operator_present, is_cold_start).
+
+    Issue #1363 (Codex 2 P2 fold rounds 1 + 2):
+
+    Round 1 (atomicity): the wrapper previously called
+    :func:`check_operator_exists` + :func:`is_cold_start_state` as two
+    separate SELECT statements. Under PostgreSQL's default READ
+    COMMITTED isolation each statement sees the latest committed
+    state, so even on the same connection the two probes can sample
+    different points in time — a concurrent ``/auth/setup`` + Re-run
+    all sequence can commit between the probes and produce a stale
+    verdict. Folding all facts into one SELECT means PostgreSQL
+    evaluates the sub-queries in a single statement-level snapshot —
+    atomic by construction without needing REPEATABLE READ.
+
+    Round 2 (cold-start composition): ``bootstrap_state.status =
+    'pending'`` is necessary but NOT sufficient to identify the
+    pre-setup window. ``/auth/setup`` does NOT mutate
+    ``bootstrap_state`` — only the first Re-run-all click flips status
+    away from ``'pending'``. So a post-setup-but-pre-bootstrap state
+    where the operator row was accidentally deleted is
+    indistinguishable from a true cold-start using status alone. The
+    ``operator_audit`` table records every ``'setup'`` event
+    historically (insert-only, no delete path); the **absence** of any
+    ``'setup'`` row is the load-bearing signal that ``/auth/setup``
+    has never been run on this DB.
+
+    Returns:
+        (operator_present, is_cold_start) where:
+          * ``operator_present`` = ``EXISTS(SELECT 1 FROM operators)``
+          * ``is_cold_start``    = ``status = 'pending'``
+            AND ``NOT EXISTS(setup event in operator_audit)``.
+            False when ``bootstrap_state`` row missing (fail closed).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT "
+            "EXISTS(SELECT 1 FROM operators) AS operator_present, "
+            "(COALESCE((SELECT status FROM bootstrap_state WHERE id = 1), '') = 'pending' "
+            " AND NOT EXISTS(SELECT 1 FROM operator_audit WHERE event_type = 'setup')) "
+            "AS is_cold_start",
+        )
+        row = cur.fetchone()
+    if row is None:
+        # Defensive — SELECT … always returns a single row in PG; this
+        # branch exists for type-checker happiness + future-proofing.
+        return (False, False)
+    return (bool(row[0]), bool(row[1]))
+
+
 OPERATOR_MISSING_ERROR_MESSAGE: str = (
     "jobs boot blocked: no operators row in DB. "
     "Run POST /auth/setup via the API process to create one. "

--- a/tests/test_jobs_boot_guard.py
+++ b/tests/test_jobs_boot_guard.py
@@ -30,6 +30,8 @@ from app.jobs.boot_guard import (
     OPERATOR_MISSING_ERROR_MESSAGE,
     BootGuardOutcome,
     check_operator_exists,
+    is_cold_start_state,
+    read_boot_gate_snapshot,
 )
 from tests.fixtures.ebull_test_db import test_database_url
 
@@ -144,6 +146,50 @@ def _read_last_jobs_boot_error(conn: psycopg.Connection[tuple]) -> tuple[str | N
         )
         row = cur.fetchone()
     return (None, None) if row is None else (row[0], row[1])
+
+
+def _set_bootstrap_state_status(conn: psycopg.Connection[tuple], status: str) -> None:
+    """Force ``bootstrap_state.status`` to a specific value before a test
+    that needs to gate on cold-start vs post-install state.
+
+    Issue #1363: ``is_cold_start_state`` returns ``True`` iff
+    ``status='pending'``. The schema-seeded default is ``'pending'``, so
+    tests that need to exercise the post-install hard-fail path MUST
+    flip status to a non-pending value first.
+    """
+    with conn.cursor() as cur:
+        cur.execute("UPDATE bootstrap_state SET status = %s WHERE id = 1", (status,))
+    conn.commit()
+
+
+def _delete_all_operator_audit(conn: psycopg.Connection[tuple]) -> None:
+    """Wipe ``operator_audit`` rows so the cold-start gate sees a true
+    pre-setup state. Issue #1363 (Codex 2 P2 round 2): the cold-start
+    branch fires only when ``NOT EXISTS(setup event in operator_audit)``
+    — pollution from prior tests in the same session would mask the
+    intended state.
+    """
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM operator_audit")
+    conn.commit()
+
+
+def _insert_setup_audit_event(conn: psycopg.Connection[tuple]) -> None:
+    """Insert a synthetic ``event_type='setup'`` row into
+    ``operator_audit`` to simulate that ``/auth/setup`` has been run on
+    this DB historically (even if the operator row was subsequently
+    deleted). Issue #1363 Codex 2 P2 round 2: this is the load-bearing
+    signal that distinguishes post-setup corruption from a true
+    cold-start.
+    """
+    import uuid
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO operator_audit (event_type, target_operator_id, target_username) VALUES ('setup', %s, %s)",
+            (str(uuid.uuid4()), f"synthetic_setup_{uuid.uuid4().hex[:8]}"),
+        )
+    conn.commit()
 
 
 class TestCheckOperatorExistsAgainstRealDB:
@@ -267,12 +313,18 @@ class TestCheckOperatorExistsWithCleanupWrapper:
         pool.close.assert_not_called()
 
     @pytest.mark.integration
-    def test_operator_absent_persists_breadcrumb_and_exits_2(
+    def test_operator_absent_post_install_persists_breadcrumb_and_exits_2(
         self,
         ebull_test_conn: psycopg.Connection[tuple],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """Regression: when ``bootstrap_state.status`` is non-pending
+        (post-install) AND operators is empty (someone deleted the
+        singleton row), the wrapper MUST hard-fail with breadcrumb +
+        SystemExit(2). Issue #1363 cold-start tolerance must NOT
+        weaken this path."""
         _delete_all_operators(ebull_test_conn)
+        _set_bootstrap_state_status(ebull_test_conn, "complete")
         with ebull_test_conn.cursor() as cur:
             cur.execute("UPDATE bootstrap_state SET last_jobs_boot_error = NULL WHERE id = 1")
         ebull_test_conn.commit()
@@ -291,5 +343,329 @@ class TestCheckOperatorExistsWithCleanupWrapper:
         assert message == OPERATOR_MISSING_ERROR_MESSAGE
         assert at is not None, "breadcrumb timestamp must be populated alongside message"
 
+        fence_conn.close.assert_called_once()
+        pool.close.assert_called_once()
+
+
+# --------------------------------------------------------------------- #
+# 3. Cold-start tolerance (#1363) — pure ``is_cold_start_state`` checks
+#    + wrapper integration tests for the deferred-boot branch.
+# --------------------------------------------------------------------- #
+
+
+class TestIsColdStartStatePureFunction:
+    """Pure-function contract for ``is_cold_start_state`` — mocked cursor,
+    no DB. ``True`` only when ``bootstrap_state.status='pending'``."""
+
+    def test_returns_true_when_status_is_pending(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = ("pending",)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        assert is_cold_start_state(conn) is True
+        cur.execute.assert_called_once_with("SELECT status FROM bootstrap_state WHERE id = 1")
+
+    @pytest.mark.parametrize("status", ["running", "complete", "partial_error", "cancelled"])
+    def test_returns_false_for_any_non_pending_status(self, status: str) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = (status,)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        assert is_cold_start_state(conn) is False
+
+    def test_returns_false_when_singleton_row_missing(self) -> None:
+        """Defensive: ``bootstrap_state`` singleton should be guaranteed
+        by the earlier ``_ensure_bootstrap_state_singleton_with_cleanup``
+        guard, but if it ever vanishes, fail closed (treat as
+        post-install so the hard-fail path runs and surfaces the
+        anomaly)."""
+        cur = MagicMock()
+        cur.fetchone.return_value = None
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        assert is_cold_start_state(conn) is False
+
+
+class TestIsColdStartStateAgainstRealDB:
+    """The pure function against a real DB — verifies the SELECT query
+    actually reads ``bootstrap_state.status`` correctly."""
+
+    @pytest.mark.integration
+    def test_returns_true_for_pending(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        _set_bootstrap_state_status(ebull_test_conn, "pending")
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            assert is_cold_start_state(guard_conn) is True
+
+    @pytest.mark.integration
+    def test_returns_false_for_complete(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        _set_bootstrap_state_status(ebull_test_conn, "complete")
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            assert is_cold_start_state(guard_conn) is False
+
+
+class TestColdStartToleranceWrapper:
+    """Issue #1363 — when ``operators`` is empty AND
+    ``bootstrap_state.status='pending'``, the wrapper MUST return
+    cleanly without persisting a breadcrumb and without SystemExit.
+
+    This is the cold-start window: ``/auth/setup`` has not been run
+    yet, so operator absence is the expected initial state — the jobs
+    process should boot alongside backend + frontend rather than crash
+    and leave the operator with a dead worker after they complete
+    setup via the UI."""
+
+    @pytest.mark.integration
+    def test_cold_start_returns_without_breadcrumb_or_exit(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _delete_all_operators(ebull_test_conn)
+        _delete_all_operator_audit(ebull_test_conn)
+        _set_bootstrap_state_status(ebull_test_conn, "pending")
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("UPDATE bootstrap_state SET last_jobs_boot_error = NULL WHERE id = 1")
+        ebull_test_conn.commit()
+
+        monkeypatch.delenv("EBULL_JOBS_SKIP_OPERATOR_CHECK", raising=False)
+        monkeypatch.setattr(settings, "database_url", test_database_url())
+        fence_conn = MagicMock()
+        pool = MagicMock()
+
+        _wrapper()(fence_conn, pool)
+
+        message, at = _read_last_jobs_boot_error(ebull_test_conn)
+        assert message is None, "cold-start MUST NOT write a breadcrumb"
+        assert at is None, "cold-start MUST NOT write a breadcrumb timestamp"
+        fence_conn.close.assert_not_called()
+        pool.close.assert_not_called()
+
+    @pytest.mark.integration
+    def test_cold_start_clears_matching_operator_missing_breadcrumb(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Codex 2 P2 fold: when a prior hard-fail boot wrote the
+        ``OPERATOR_MISSING_ERROR_MESSAGE`` breadcrumb, and the system
+        then transitioned to cold-start state (e.g. DB wipe), the
+        cold-start branch MUST clear that specific stale message so
+        ``/system/status`` does not lie about jobs being blocked while
+        the jobs process is in fact running."""
+        _delete_all_operators(ebull_test_conn)
+        _delete_all_operator_audit(ebull_test_conn)
+        _set_bootstrap_state_status(ebull_test_conn, "pending")
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE bootstrap_state "
+                "SET last_jobs_boot_error = %s, last_jobs_boot_error_at = clock_timestamp() "
+                "WHERE id = 1",
+                (OPERATOR_MISSING_ERROR_MESSAGE,),
+            )
+        ebull_test_conn.commit()
+
+        monkeypatch.delenv("EBULL_JOBS_SKIP_OPERATOR_CHECK", raising=False)
+        monkeypatch.setattr(settings, "database_url", test_database_url())
+        fence_conn = MagicMock()
+        pool = MagicMock()
+
+        _wrapper()(fence_conn, pool)
+
+        message, at = _read_last_jobs_boot_error(ebull_test_conn)
+        assert message is None, "cold-start MUST clear a matching OPERATOR_MISSING breadcrumb"
+        assert at is None, "matching breadcrumb timestamp MUST be cleared with the message"
+        fence_conn.close.assert_not_called()
+        pool.close.assert_not_called()
+
+    @pytest.mark.integration
+    def test_cold_start_preserves_unrelated_breadcrumb(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Companion to the matching-clear test: a breadcrumb written
+        by a different boot-failure cause (not the OPERATOR_MISSING
+        message) MUST be preserved — the cold-start branch only knows
+        about its own prior hard-fail artefact, so unrelated messages
+        from future guards are left visible to ``/system/status``."""
+        _delete_all_operators(ebull_test_conn)
+        _delete_all_operator_audit(ebull_test_conn)
+        _set_bootstrap_state_status(ebull_test_conn, "pending")
+        unrelated_message = "jobs boot blocked: some other guard fired"
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE bootstrap_state "
+                "SET last_jobs_boot_error = %s, last_jobs_boot_error_at = clock_timestamp() "
+                "WHERE id = 1",
+                (unrelated_message,),
+            )
+        ebull_test_conn.commit()
+
+        monkeypatch.delenv("EBULL_JOBS_SKIP_OPERATOR_CHECK", raising=False)
+        monkeypatch.setattr(settings, "database_url", test_database_url())
+        fence_conn = MagicMock()
+        pool = MagicMock()
+
+        _wrapper()(fence_conn, pool)
+
+        message, _at = _read_last_jobs_boot_error(ebull_test_conn)
+        assert message == unrelated_message, "cold-start branch MUST NOT clear breadcrumbs written by other guards"
+        fence_conn.close.assert_not_called()
+        pool.close.assert_not_called()
+
+
+class TestReadBootGateSnapshotPureFunction:
+    """Pure-function contract for ``read_boot_gate_snapshot`` — mocked
+    cursor, no DB. Issue #1363 Codex 2 P2: returns ``(operator_present,
+    is_cold_start)`` in a single statement-level snapshot.
+
+    SQL returns ``(bool, bool)`` directly — the cold-start composition
+    (``status='pending' AND NOT EXISTS setup audit``) is evaluated
+    server-side. Pure-function tests just shape-check the projection."""
+
+    def test_returns_both_true_when_operator_present_and_cold_start(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = (True, True)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        assert read_boot_gate_snapshot(conn) == (True, True)
+
+    def test_returns_operator_present_false_cold_start_true(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = (False, True)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        assert read_boot_gate_snapshot(conn) == (False, True)
+
+    def test_returns_operator_present_true_cold_start_false(self) -> None:
+        cur = MagicMock()
+        cur.fetchone.return_value = (True, False)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        assert read_boot_gate_snapshot(conn) == (True, False)
+
+    def test_returns_false_false_when_bootstrap_state_missing(self) -> None:
+        """Server-side COALESCE in the SQL collapses missing bootstrap
+        state to ``''`` (≠ ``'pending'``) so the cold-start composition
+        evaluates to False. Defensive fail-closed posture mirrors
+        :func:`is_cold_start_state`."""
+        cur = MagicMock()
+        cur.fetchone.return_value = (False, False)
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+
+        assert read_boot_gate_snapshot(conn) == (False, False)
+
+
+class TestReadBootGateSnapshotAgainstRealDB:
+    """Real-DB read of the combined snapshot. Each test resets the
+    three sources of truth (operators / bootstrap_state.status /
+    operator_audit) so the cold-start composition is deterministic."""
+
+    @pytest.mark.integration
+    def test_returns_present_and_cold_start_true_when_seeded_and_no_setup_audit(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """``_insert_test_operator`` bypasses :func:`perform_setup` so no
+        ``'setup'`` event is written to ``operator_audit`` — that
+        combined with ``status='pending'`` is the cold-start composition
+        even though an operator row happens to exist (the wrapper only
+        consumes ``is_cold_start`` on the OPERATOR_ABSENT branch, but
+        the projection is uniform)."""
+        _delete_all_operators(ebull_test_conn)
+        _delete_all_operator_audit(ebull_test_conn)
+        _insert_test_operator(ebull_test_conn)
+        _set_bootstrap_state_status(ebull_test_conn, "pending")
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            assert read_boot_gate_snapshot(guard_conn) == (True, True)
+
+    @pytest.mark.integration
+    def test_returns_absent_and_post_install_when_status_complete(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        _delete_all_operators(ebull_test_conn)
+        _delete_all_operator_audit(ebull_test_conn)
+        _set_bootstrap_state_status(ebull_test_conn, "complete")
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            assert read_boot_gate_snapshot(guard_conn) == (False, False)
+
+    @pytest.mark.integration
+    def test_returns_absent_and_cold_start_false_when_setup_audit_present(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+    ) -> None:
+        """Codex 2 P2 round 2 fold: post-setup corruption case —
+        ``operators`` empty AND ``bootstrap_state.status='pending'``
+        BUT a prior ``'setup'`` audit row exists. This is NOT a
+        cold-start; the missing operator row is corruption and MUST
+        flow to the hard-fail path."""
+        _delete_all_operators(ebull_test_conn)
+        _delete_all_operator_audit(ebull_test_conn)
+        _set_bootstrap_state_status(ebull_test_conn, "pending")
+        _insert_setup_audit_event(ebull_test_conn)
+
+        url = test_database_url()
+        with psycopg.connect(url, autocommit=True) as guard_conn:
+            assert read_boot_gate_snapshot(guard_conn) == (False, False)
+
+
+class TestPostSetupOperatorAbsenceStillHardFails:
+    """Issue #1363 Codex 2 P2 round 2: the cold-start branch MUST NOT
+    swallow a post-setup operator-absence. If ``/auth/setup`` has run
+    historically (``operator_audit`` carries a ``'setup'`` event) AND
+    the operator row was later deleted, the wrapper MUST hard-fail
+    regardless of ``bootstrap_state.status``."""
+
+    @pytest.mark.integration
+    def test_post_setup_pending_status_with_no_operator_hard_fails(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _delete_all_operators(ebull_test_conn)
+        _delete_all_operator_audit(ebull_test_conn)
+        _set_bootstrap_state_status(ebull_test_conn, "pending")
+        _insert_setup_audit_event(ebull_test_conn)
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("UPDATE bootstrap_state SET last_jobs_boot_error = NULL WHERE id = 1")
+        ebull_test_conn.commit()
+
+        monkeypatch.delenv("EBULL_JOBS_SKIP_OPERATOR_CHECK", raising=False)
+        monkeypatch.setattr(settings, "database_url", test_database_url())
+        fence_conn = MagicMock()
+        pool = MagicMock()
+
+        with pytest.raises(SystemExit) as excinfo:
+            _wrapper()(fence_conn, pool)
+
+        assert excinfo.value.code == 2
+
+        message, at = _read_last_jobs_boot_error(ebull_test_conn)
+        assert message == OPERATOR_MISSING_ERROR_MESSAGE, (
+            "post-setup operator absence MUST persist the hard-fail breadcrumb regardless of status='pending'"
+        )
+        assert at is not None
         fence_conn.close.assert_called_once()
         pool.close.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds `read_boot_gate_snapshot` — atomic single-SELECT read of `(operator_present, is_cold_start)` where `is_cold_start = status='pending' AND NOT EXISTS(setup event in operator_audit)`. The audit-event composition is load-bearing because `/auth/setup` does NOT mutate `bootstrap_state` — status alone cannot distinguish pre-setup from post-setup operator-row corruption.
- Wires `_check_operator_exists_with_cleanup` to tolerate cold-start: when `(operator_absent, is_cold_start)`, log INFO, clear any matching prior `OPERATOR_MISSING_ERROR_MESSAGE` breadcrumb, return cleanly. Post-install operator absence keeps the existing `SystemExit(2)` + breadcrumb behaviour.
- Closes the cold-start race observed during Phase 0 close R1: `dev: start stack` launches backend + frontend + jobs in parallel, jobs boots before operator runs `/auth/setup`, hard-fails, leaving the operator with a dead worker after they complete setup via the UI.

## Why

Stream A PR-A T1.8 (#1233) gate is correct for POST-install operator-absence — every scheduled fire would silently reject with `bootstrap_not_complete`, so surfacing at boot is operator-actionable. Wrong shape for cold-start where operator absence is the expected initial state. The previous workaround (`EBULL_JOBS_SKIP_OPERATOR_CHECK=1`) bypasses the gate entirely, losing the post-install protection.

## Security model

- `EBULL_JOBS_SKIP_OPERATOR_CHECK` semantics unchanged. Still the documented escape hatch for CI / ops automation that doesn't go through `/auth/setup`.
- Cold-start branch fires only when both halves of the composite are true. Adding a `'setup'` event to `operator_audit` is the only way to flip `is_cold_start` to False — and `operator_audit` is insert-only (no production code path deletes audit rows; the test helper `_delete_all_operator_audit` is test-fixture-only).
- Single-SELECT snapshot eliminates the READ COMMITTED interleaving where a concurrent `/auth/setup` + Re-run-all could land between two separate probes and produce a stale OPERATOR_ABSENT verdict.

## Test plan

- [x] `uv run ruff check` clean on touched files
- [x] `uv run ruff format --check` clean
- [x] `uv run pyright` clean
- [x] `CI=true uv run pytest tests/test_jobs_boot_guard.py` — 32 passed (8 new tests: 4 pure-fn for `read_boot_gate_snapshot`, 3 real-DB for `read_boot_gate_snapshot`, 1 wrapper-level for post-setup hard-fail regression; 2 new for `is_cold_start_state` pure fn; 2 new for `is_cold_start_state` real DB; 3 new for cold-start wrapper branch; existing `test_operator_absent_*` renamed + tightened with status='complete' setup to preserve regression coverage)
- [x] Codex 2 review: 3 rounds, all P2 findings folded, final round clean

## Cold-start tolerance is composite, not single-fact

Real-DB scenarios verified by tests:

| operators | status     | setup audit | Outcome                    |
|-----------|------------|-------------|----------------------------|
| empty     | pending    | absent      | cold-start: log + return   |
| empty     | pending    | present     | hard-fail (post-setup)     |
| empty     | complete   | any         | hard-fail (post-install)   |
| present   | any        | any         | clear breadcrumb + return  |

Codex 2 round 2 surfaced this — using `status='pending'` alone would mask the (operators=0, status='pending', setup-has-run) corruption case.


Closes #1363.
