### PR TITLE
fix(#1365): S16 sec_first_install_drain wait for bulk path before draining

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -559,7 +559,20 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
     # S8 terminalises (success / skip). See cap docstring on
     # ``submissions_processed`` for the lock-contention rationale.
     "filings_history_seed": CapRequirement(all_of=("cik_mapping_ready", "submissions_processed")),
-    "sec_first_install_drain": CapRequirement(all_of=("cik_mapping_ready",)),
+    # #1365 — S16 fast-path at ``app/jobs/sec_first_install_drain.py:308``
+    # (``seed_manifest_from_filing_events``) only fires when ``filing_events``
+    # has SEC-provider rows AT FUNCTION ENTRY. Pre-#1365 S16 required only
+    # ``cik_mapping_ready`` so it raced ahead of the bulk path: with bulk-
+    # download still in flight, the fast-path read returned 0 rows and S16
+    # fell through to per-CIK HTTP for ~25k subjects (~85min observed on
+    # Run #8, ~3h projected on R1). Adding ``submissions_processed`` makes
+    # S16 wait for the bulk path to terminalise (success → filing_events
+    # populated, fast-path fires; skip → cascade-skip parity preserves the
+    # slow-connection fallback). Same shape as the PR-1292 fold on S15.
+    # Non-issuer subjects (institutional_filer + blockholder_filer) still
+    # walk HTTP — those have no bulk archives; only the issuer cohort
+    # short-circuits via filing_events.
+    "sec_first_install_drain": CapRequirement(all_of=("cik_mapping_ready", "submissions_processed")),
     "sec_def14a_bootstrap": CapRequirement(all_of=("filing_events_seeded", "submissions_secondary_pages_walked")),
     "sec_business_summary_bootstrap": CapRequirement(
         all_of=("filing_events_seeded", "submissions_secondary_pages_walked")

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -695,6 +695,36 @@ def test_filings_history_seed_requires_submissions_processed() -> None:
     )
 
 
+def test_sec_first_install_drain_requires_submissions_processed() -> None:
+    """Issue #1365 — S16 ``sec_first_install_drain`` MUST require
+    ``submissions_processed`` so it waits for the bulk path
+    (``sec_submissions_ingest``) to terminalise before starting.
+
+    Background: S16's fast-path at
+    ``app/jobs/sec_first_install_drain.py::seed_manifest_from_filing_events``
+    runs ONCE at function entry. If ``filing_events`` has no SEC rows
+    yet, S16 falls through to a per-CIK HTTP loop covering ~25k
+    subjects (~85 min observed on Run #8). The fast-path was supposed
+    to fire when the bulk path had already populated ``filing_events``,
+    but pre-#1365 S16 required only ``cik_mapping_ready`` and raced
+    ahead of ``sec_submissions_ingest``.
+
+    Adding ``submissions_processed`` (provided on SUCCESS or SKIP by
+    S8) makes S16 wait for the bulk path to terminalise: success →
+    filing_events populated → fast-path fires; skip → cascade-skip
+    parity preserves the slow-connection fallback.
+
+    Regression sentinel — a future spec edit that drops the requires
+    line would re-introduce the HTTP-instead-of-files fallback
+    silently and re-inflate S16 wall-clock by 5-10×.
+    """
+    req = _STAGE_REQUIRES_CAPS["sec_first_install_drain"]
+    assert "submissions_processed" in req.all_of, (
+        "sec_first_install_drain must require submissions_processed "
+        "(#1365 fast-path ordering invariant — wait for bulk path before draining)"
+    )
+
+
 def test_submissions_processed_provided_by_s8_on_success_and_skip() -> None:
     """Companion invariant to the above. ``submissions_processed`` is
     provided by ``sec_submissions_ingest`` (S8) on BOTH success AND


### PR DESCRIPTION
## Summary

- Adds ``submissions_processed`` to ``sec_first_install_drain``'s ``CapRequirement`` so S16 waits for ``sec_submissions_ingest`` (S8) to terminalise before starting. Same ordering-cap shape PR-1292 used for S15.
- Pre-#1365 S16 required only ``cik_mapping_ready`` — fired the moment cik mapping was ready, racing ahead of the bulk path. Its fast-path (``seed_manifest_from_filing_events`` at ``app/jobs/sec_first_install_drain.py:308``) runs once at function entry; ``filing_events`` was empty, so S16 fell through to per-CIK HTTP for ~25k subjects.
- Adds regression sentinel ``test_sec_first_install_drain_requires_submissions_processed``.

## Why

Observed on Phase 0 close R1 measurement, 2026-05-27: S16 started 16s BEFORE ``sec_bulk_download`` finished, fast-path saw 0 filing_events rows, ``target_cohort_fingerprint`` recorded ``fast_path_seeded=false``. 2078s in, S16 had processed 4841/~25k subjects via HTTP while ``filing_events`` separately accumulated 2.7M SEC rows that S16 could not retroactively consume. Run #8 saw the exact same shape (S16=85min).

The PR-1292 lock-contention fix already addressed the identical pattern on S15. S16 was missed because its ordering risk surfaces as wall-clock waste (slow HTTP loop) rather than DB lock contention, so the same audit pass didn't catch it.

## Security model

- No new endpoints, schema, or capabilities. Adds one element to an existing ``all_of`` tuple in ``_STAGE_REQUIRES_CAPS``.
- ``submissions_processed`` is provided by S8 on SUCCESS (bulk path landed → filing_events populated → S16 fast-path fires) AND on SKIP (cascade-skip parity preserves the slow-connection fallback where ``sec_bulk_download`` raises ``BootstrapPhaseSkipped`` and S8 never runs).
- Non-issuer subjects (institutional_filer + blockholder_filer) keep walking HTTP — those have no bulk archives. Only the issuer cohort short-circuits via filing_events.

## Test plan

- [x] ``uv run ruff check`` clean on touched files
- [x] ``uv run ruff format --check`` clean
- [x] ``uv run pyright`` clean
- [x] ``CI=true uv run pytest tests/test_bootstrap_orchestrator.py::test_sec_first_install_drain_requires_submissions_processed`` passes (new regression sentinel)
- [x] Existing ``test_filings_history_seed_requires_submissions_processed`` + ``test_submissions_processed_provided_by_s8_on_success_and_skip`` still pass — the ordering-cap producers are unchanged, only the consumer set grew
- [x] Codex 2 review: first-pass clean ("No actionable bugs introduced. Dependency addition for sec_first_install_drain is consistent with the existing submissions_processed ordering-cap semantics.")

## Estimated impact

S16 wall-clock: ~85 min → ~17 min on full bootstrap (issuer cohort drops from HTTP to in-DB read; only ~10k non-issuer subjects remain on HTTP at shared ~10 req/s). Cascading: frees sec_rate lane for S17/S18/S22 sooner. Phase 0 close R1 will retain its full receipts as the BAD-ordering reference run; R2 + R3 (post-#1365) measure the new floor.

## Cross-impact

- ``sec_first_install_drain`` continues to PROVIDE ``filing_events_seeded`` + ``submissions_secondary_pages_walked`` (unchanged). Downstream consumers unaffected.
- Slow-connection / no-bulk path retained — S8 cascade-skips still flow into ``submissions_processed`` via ``_STAGE_PROVIDES_ON_SKIP``.


Closes #1365.
