### PR TITLE
fix(#1341): S14 pipelined HTTP for bootstrap (chunk-and-drain)

### DIFF
--- a/app/services/sec_pipelined_fetcher.py
+++ b/app/services/sec_pipelined_fetcher.py
@@ -35,6 +35,7 @@ import httpx
 from app.providers.implementations.sec_edgar import (
     _PROCESS_RATE_LIMIT_CLOCK,
     _PROCESS_RATE_LIMIT_LOCK,
+    SubmissionsPageResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,19 @@ logger = logging.getLogger(__name__)
 DEFAULT_TARGET_RPS: Final[float] = 7.0
 DEFAULT_CONCURRENCY: Final[int] = 4
 DEFAULT_TIMEOUT_S: Final[float] = 30.0
+
+
+# #1341 — caller-managed chunk size for the chunk-and-drain pattern
+# in `walk_files_pages`. Bounded peak heap at ~150-200 MB per chunk
+# (≈50 MB raw JSON + Python overhead). Tunable via module constant
+# without invoker shape change.
+DEFAULT_PREFETCH_CHUNK_SIZE: Final[int] = 1000
+
+
+# Sentinel host check — `SubmissionsPageResult` is keyed by submissions
+# page-name (e.g. `CIKxxxxxxxxxx-submissions-001.json`); URL is
+# constructed below.
+_SEC_SUBMISSIONS_URL_PREFIX: Final[str] = "https://data.sec.gov/submissions/"
 
 
 @dataclass(frozen=True)
@@ -316,3 +330,179 @@ class _CachedDocFetcher:
         self.cache_misses += 1
         # type: ignore[misc, attr-defined] — duck-typed fallback.
         return self._underlying.fetch_document_text(absolute_url)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# #1341 — secondary-submissions conditional prefetch for S14
+# (`sec_submissions_files_walk`) bootstrap path.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConditionalFetchTask:
+    """Per-page prefetch task carrying its own If-Modified-Since header.
+
+    Spec: docs/proposals/etl/1341-s14-pipelined-fetch.md §3.1.
+    """
+
+    page_name: str
+    if_modified_since: str | None
+
+
+def prefetch_submissions_pages_conditional(
+    tasks: list[ConditionalFetchTask],
+    *,
+    user_agent: str,
+    target_rps: float = DEFAULT_TARGET_RPS,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> dict[str, SubmissionsPageResult | None]:
+    """Bulk-fetch ONE CHUNK of SEC secondary submissions pages.
+
+    Caller (S14 walker) is responsible for chunking the full cohort
+    via the chunk-and-drain pattern at the walker; this function
+    fetches every task in `tasks` and returns one cache dict. The
+    caller drains the dict and drops it before invoking again for
+    the next chunk so peak heap stays bounded.
+
+    Returns ``{page_name: SubmissionsPageResult | None}``:
+
+    * key absent — fetch failed (transport / 429 / 5xx / malformed
+      body). Caller's cache-miss fallthrough hits the sync provider,
+      which owns the retry/quarantine contract.
+    * value ``None`` — 404; page absent.
+    * value ``SubmissionsPageResult(payload=None, last_modified=ims,
+      not_modified=True)`` — 304.
+    * value ``SubmissionsPageResult(payload=<dict>, last_modified=lm,
+      not_modified=False)`` — 200.
+
+    Per-task failures isolated via ``try/except``; one bad page never
+    aborts the chunk.
+
+    Mirrors ``prefetch_document_texts`` lifecycle: shared
+    ``_PROCESS_RATE_LIMIT_CLOCK`` so concurrent sync SEC traffic
+    co-exists under the 7 req/s ceiling.
+    """
+    if not tasks:
+        return {}
+    # Dedupe by page_name (defensive — sidecar PK guarantees
+    # uniqueness, but a chunking caller could in theory pass dups).
+    deduped: dict[str, ConditionalFetchTask] = {}
+    for task in tasks:
+        deduped.setdefault(task.page_name, task)
+    work = list(deduped.values())
+
+    base_headers = {
+        "User-Agent": user_agent,
+        "Accept-Encoding": "gzip, deflate",
+    }
+
+    async def _run() -> dict[str, SubmissionsPageResult | None]:
+        out: dict[str, SubmissionsPageResult | None] = {}
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            fetcher = PipelinedSecFetcher(
+                client=client,
+                target_rps=target_rps,
+                concurrency=concurrency,
+            )
+            fetch_tasks = [
+                FetchTask(
+                    key=task.page_name,
+                    url=f"{_SEC_SUBMISSIONS_URL_PREFIX}{task.page_name}",
+                    headers={
+                        **base_headers,
+                        **({"If-Modified-Since": task.if_modified_since} if task.if_modified_since else {}),
+                    },
+                )
+                for task in work
+            ]
+            ims_lookup = {task.page_name: task.if_modified_since for task in work}
+            async for result in fetcher.fetch_many(fetch_tasks):
+                page_name = str(result.key)
+                # Per-task failure isolation — omit from cache; loop
+                # fallthrough hits the sync provider's retry path.
+                if result.error is not None or result.response is None:
+                    continue
+                resp = result.response
+                try:
+                    if resp.status_code == 304:
+                        out[page_name] = SubmissionsPageResult(
+                            payload=None,
+                            last_modified=ims_lookup.get(page_name),
+                            not_modified=True,
+                        )
+                        continue
+                    if resp.status_code == 404:
+                        out[page_name] = None
+                        continue
+                    if 200 <= resp.status_code < 300:
+                        payload = resp.json()  # type: ignore[no-untyped-call]
+                        if not isinstance(payload, dict):
+                            # Malformed body — caller falls through.
+                            continue
+                        out[page_name] = SubmissionsPageResult(
+                            payload=payload,
+                            last_modified=resp.headers.get("Last-Modified"),
+                            not_modified=False,
+                        )
+                        continue
+                    # 429 / 5xx / other 4xx — OMIT from cache; loop
+                    # fallthrough hits the sync provider's retry path.
+                except (ValueError, OSError) as exc:
+                    # ValueError covers json.JSONDecodeError (subclass).
+                    logger.debug(
+                        "prefetch_submissions_pages_conditional: malformed body for %s: %s",
+                        page_name,
+                        exc,
+                    )
+                    continue
+        return out
+
+    return asyncio.run(_run())
+
+
+class _CachedSubmissionsPageFetcher:
+    """Wraps a sync ``SecFilingsProvider`` for the bootstrap S14 path.
+
+    Mirror of ``_CachedDocFetcher`` but for
+    ``fetch_submissions_page_conditional`` rather than
+    ``fetch_document_text``. Cache lookups honour the per-page
+    If-Modified-Since the caller passes; cache misses fall through
+    to the underlying provider's sync ResilientClient.
+
+    Cache contract:
+
+    * page_name in cache, value None → 404; return None.
+    * page_name in cache, value SubmissionsPageResult → return it.
+    * page_name NOT in cache → fall through to underlying provider.
+
+    Telemetry:
+
+    * ``cache_hits`` — page_name in cache (any value, including None).
+    * ``cache_misses`` — page_name NOT in cache (caller's per-CIK
+      loop visit went to the sync provider).
+    """
+
+    def __init__(
+        self,
+        underlying: object,
+        cache: dict[str, SubmissionsPageResult | None],
+    ) -> None:
+        self._underlying = underlying
+        self._cache = cache
+        self.cache_hits = 0
+        self.cache_misses = 0
+
+    def fetch_submissions_page_conditional(
+        self,
+        page_name: str,
+        *,
+        if_modified_since: str | None = None,
+    ) -> SubmissionsPageResult | None:
+        if page_name in self._cache:
+            self.cache_hits += 1
+            return self._cache[page_name]
+        self.cache_misses += 1
+        return self._underlying.fetch_submissions_page_conditional(  # type: ignore[attr-defined,no-any-return]
+            page_name, if_modified_since=if_modified_since
+        )

--- a/app/services/sec_submissions_files_walk.py
+++ b/app/services/sec_submissions_files_walk.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -69,7 +70,13 @@ from app.services.bootstrap_state import (
     set_stage_target,
 )
 from app.services.filings import _upsert_filing
-from app.services.watermarks import get_watermark, set_watermark
+from app.services.sec_pipelined_fetcher import (
+    DEFAULT_PREFETCH_CHUNK_SIZE,
+    ConditionalFetchTask,
+    _CachedSubmissionsPageFetcher,
+    prefetch_submissions_pages_conditional,
+)
+from app.services.watermarks import set_watermark
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +114,18 @@ class FilesWalkResult:
     # via If-Modified-Since round-trip. Distinct from parse_errors —
     # 304 is a success path that conserves the SEC 10 req/s budget.
     secondary_pages_not_modified: int = 0
+    # #1341 — pipelined prefetch telemetry (bootstrap-mode only).
+    # ``prefetch_pages_seeded`` counts unique pages successfully
+    # prefetched (size of returned cache dicts summed across chunks).
+    # ``loop_pages_from_prefetch`` / ``loop_pages_from_sync_fallback``
+    # count per-loop visits (may exceed seeded count for share-class
+    # siblings sharing CIK pages — these are loop consumptions, not
+    # unique fetches saved). ``prefetch_window_seconds_total`` sums
+    # per-chunk prefetch wall-clock deltas; ``None`` in steady-state.
+    prefetch_pages_seeded: int = 0
+    loop_pages_from_prefetch: int = 0
+    loop_pages_from_sync_fallback: int = 0
+    prefetch_window_seconds_total: float | None = None
 
 
 def _list_cik_secondary_pages(
@@ -171,6 +190,170 @@ def _list_cik_secondary_pages(
     return out
 
 
+def _load_all_watermarks_for_pages(
+    conn: psycopg.Connection[Any],
+    targets: list[tuple[int, str, str, list[str]]],
+) -> dict[tuple[str, str], str | None]:
+    """One SELECT → ``{(cik, page_name): if_modified_since}`` for the
+    whole cohort. Replaces ~17k per-page ``get_watermark`` round-trips
+    inside the walker loop (#1341 §6).
+
+    Missing rows map to ``None`` (no prior watermark — full fetch).
+    """
+    keys: list[str] = []
+    for _iid, cik, _sym, sidecar_pages in targets:
+        for page_name in sidecar_pages:
+            if page_name == _SIDECAR_SENTINEL_PAGE_NAME:
+                continue
+            keys.append(f"{cik}:{page_name}")
+    out: dict[tuple[str, str], str | None] = {}
+    if not keys:
+        return out
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT key, watermark
+            FROM external_data_watermarks
+            WHERE source = %s
+              AND key = ANY(%s)
+            """,
+            (_SOURCE_KEY_SUBMISSIONS_FILES, keys),
+        )
+        for row in cur.fetchall():
+            wm_key, watermark = row[0], row[1]
+            cik_part, _, page_part = str(wm_key).partition(":")
+            out[(cik_part, page_part)] = watermark if watermark else None
+    return out
+
+
+def _chunked(
+    seq: list[tuple[int, str, str, str]],
+    size: int,
+) -> Iterator[list[tuple[int, str, str, str]]]:
+    """Yield successive `size`-sized slices of ``seq``. Last slice may
+    be shorter. Empty ``seq`` yields nothing."""
+    if size < 1:
+        raise ValueError("size must be >= 1")
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]
+
+
+def _process_one_page(
+    conn: psycopg.Connection[Any],
+    *,
+    provider: SecFilingsProvider | _CachedSubmissionsPageFetcher,
+    instrument_id: int,
+    cik: str,
+    symbol: str,
+    page_name: str,
+    if_modified_since: str | None,
+    result: FilesWalkResult,
+) -> None:
+    """Per-(cik, page) drain step extracted from the legacy nested
+    loop. Transaction shape unchanged from pre-#1341:
+    per-filing transaction inside the page loop; per-page watermark
+    write after upsert-all-clean.
+    """
+    wm_key = f"{cik}:{page_name}"
+    try:
+        page_result = provider.fetch_submissions_page_conditional(
+            page_name,
+            if_modified_since=if_modified_since,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "files walk: secondary fetch failed for CIK %s/%s: %s",
+            cik,
+            page_name,
+            exc,
+        )
+        result.parse_errors += 1
+        return
+    if page_result is None:
+        # 404 — page absent. Nothing to record; no watermark
+        # write either (no Last-Modified to persist).
+        return
+    if page_result.not_modified:
+        # Server said 304. Skip parse + skip upsert (filings already
+        # known). Bump watermark_at only — the stored Last-Modified
+        # is still freshest the server has sent.
+        result.secondary_pages_not_modified += 1
+        with conn.transaction():
+            if if_modified_since is not None:
+                set_watermark(
+                    conn,
+                    source=_SOURCE_KEY_SUBMISSIONS_FILES,
+                    key=wm_key,
+                    watermark=if_modified_since,
+                    watermark_at=None,
+                )
+        return
+
+    page = page_result.payload
+    if page is None:
+        # Defensive: 200 with empty body should not happen,
+        # but the dataclass shape permits it. Skip safely.
+        return
+
+    result.secondary_pages_fetched += 1
+    try:
+        # ``symbol`` is the canonical ticker (e.g. "AAPL"),
+        # NOT a stringified instrument_id. Threaded from
+        # the universe lookup at the top of the walk so
+        # ``filing_events.raw_payload_json`` carries the
+        # right value. Codex review BLOCKING for PR #1035.
+        filings = _normalise_submissions_block(
+            page,
+            cik_padded=cik,
+            symbol=symbol or cik,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("files walk: normalise failed for %s: %s", page_name, exc)
+        result.parse_errors += 1
+        return
+
+    page_upsert_errors = 0
+    for filing in filings:
+        try:
+            with conn.transaction():
+                # ``_upsert_filing`` returns False when
+                # the 10y retention cap (#1233 §4.2) drops
+                # a pre-cutoff filing. Count only accepted
+                # rows.
+                if _upsert_filing(conn, str(instrument_id), "sec", filing):
+                    result.filings_upserted += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "files walk: upsert failed for %s/%s: %s",
+                cik,
+                filing.provider_filing_id,
+                exc,
+            )
+            result.parse_errors += 1
+            page_upsert_errors += 1
+
+    # Item 7 (#1233): persist the fresh Last-Modified
+    # watermark. set_watermark asserts INTRANS so it MUST
+    # land inside ``with conn.transaction():``. Write only
+    # when every filing on the page upserted cleanly OR
+    # was intentionally retention-dropped (the
+    # ``_upsert_filing returns False`` case which does NOT
+    # increment page_upsert_errors). If ANY filing raised,
+    # we leave the watermark unchanged so the next tick
+    # re-fetches + retries the failed filings instead of
+    # 304-skipping them forever. Codex 2 pre-push P1 fold
+    # 2026-05-24.
+    if page_result.last_modified is not None and page_upsert_errors == 0:
+        with conn.transaction():
+            set_watermark(
+                conn,
+                source=_SOURCE_KEY_SUBMISSIONS_FILES,
+                key=wm_key,
+                watermark=page_result.last_modified,
+                watermark_at=None,
+            )
+
+
 def walk_files_pages(
     *,
     conn: psycopg.Connection[Any],
@@ -184,18 +367,93 @@ def walk_files_pages(
     CIK's primary ``submissions/CIK<10>.json`` — eliminates ~5,105
     redundant primary HTTP calls per Run-#8.
 
-    Secondary-page fetches over HTTP are UNCHANGED — they were never
-    in the bulk archive.
+    #1341 (2026-05-28): when invoked under the bootstrap orchestrator
+    (``resolve_progress_context()`` returns non-None), the walker
+    prefetches every chunk of secondary pages concurrently (4-way
+    via ``PipelinedSecFetcher`` at the shared 7 req/s ceiling)
+    BEFORE draining each chunk per-(cik, page). Steady-state cron
+    / API path runs OUTSIDE the bootstrap context window → walker
+    uses the serial sync ResilientClient as before.
+
+    Secondary-page fetches over HTTP are UNCHANGED in semantics —
+    they were never in the bulk archive; this PR only compresses
+    the wall-clock via concurrent HTTP for the bootstrap path.
     """
     result = FilesWalkResult()
     targets = _list_cik_secondary_pages(conn)
 
+    progress_ctx = resolve_progress_context()
+    bootstrap_mode = progress_ctx is not None
+
+    # Pre-load watermarks for the whole cohort (one SELECT). Both
+    # bootstrap and steady-state paths use this; the IMS value pinned
+    # in this map is what the prefetch (bootstrap) AND the per-page
+    # loop send to the SEC.
+    watermarks = _load_all_watermarks_for_pages(conn, targets)
+
+    # Flatten the cohort into an ordered (instrument_id, cik, symbol,
+    # page_name) task list, SKIPPING agent CIKs / empty-sidecar /
+    # sentinel-only short-circuits — those don't need HTTP. Counter
+    # bookkeeping mirrors the pre-#1341 loop exactly so end-of-walk
+    # summary log fields line up.
+    fetch_tasks_ordered: list[tuple[int, str, str, str]] = []
+    for instrument_id, cik, symbol, sidecar_pages in targets:
+        # Agent CIKs are excluded by the populate path
+        # (sec_submissions_ingest.refresh_cik_sidecar) so their
+        # sidecar_pages list is empty by design. Skip them here
+        # silently — they do NOT count toward ciks_visited (the
+        # counter reflects "real CIKs we did or attempted work for"
+        # per Architect IMPORTANT — pre-PR-B post-review fix).
+        if cik in KNOWN_FILING_AGENT_CIKS:
+            continue
+
+        result.ciks_visited += 1
+
+        if not sidecar_pages:
+            # Empty sidecar for an in-universe CIK that is NOT an
+            # agent. Indicates an S8 ordering bug or a CIK added
+            # to the universe after S8 ran. Per-CIK log is DEBUG
+            # to avoid stderr spam at scale (8.7k CIK cohort — a
+            # systemic S8 failure would otherwise log 8,700
+            # WARNING lines); a single end-of-walk summary
+            # WARNING is emitted below (per Architect IMPORTANT).
+            logger.debug(
+                "files walk: empty sidecar for in-universe CIK %s; "
+                "S8 must populate sec_cik_submissions_files_index first",
+                cik,
+            )
+            result.ciks_with_empty_sidecar += 1
+            result.parse_errors += 1
+            continue
+
+        if sidecar_pages == [_SIDECAR_SENTINEL_PAGE_NAME]:
+            # CIK processed with zero overflow pages (sentinel
+            # row). No HTTP fetch needed.
+            result.ciks_with_no_overflow += 1
+            continue
+
+        for page_name in sidecar_pages:
+            # Defensive — the only sentinel allowed is
+            # _SIDECAR_SENTINEL_PAGE_NAME; the schema CHECK already
+            # rejects any other sentinel-shaped value. A real CIK
+            # with overflow pages will never have the sentinel
+            # mixed in (the populate path writes one or the other).
+            # Skip sentinel rows defensively.
+            if page_name == _SIDECAR_SENTINEL_PAGE_NAME:
+                continue
+            fetch_tasks_ordered.append((instrument_id, cik, symbol, page_name))
+
     # #1273 PR2 — long-pole stage instrumentation (S14). Pin
     # target_count + cohort fingerprint when called from the
-    # bootstrap dispatcher. Fingerprint pins the is_tradable filter
-    # + sidecar-state bucket counts so the operator can audit
-    # cohort composition.
-    progress_ctx = resolve_progress_context()
+    # bootstrap dispatcher AFTER the flatten loop so the bar's
+    # denominator is the FINAL total (`len(targets)` flatten-pass
+    # bumps + `len(fetch_tasks_ordered)` drain bumps) — otherwise
+    # processed could exceed target. Fingerprint exposes both
+    # buckets so the operator can audit cohort composition.
+    _progress_total = len(targets) + len(fetch_tasks_ordered)
+    _emit_every_n = max(1, _progress_total // 100) if _progress_total else 0
+    _last_progress_emit = time.monotonic()
+    _processed_count = 0
     if progress_ctx is not None:
         sentinel_count = sum(1 for t in targets if t[3] == [_SIDECAR_SENTINEL_PAGE_NAME])
         empty_count = sum(1 for t in targets if not t[3])
@@ -204,186 +462,98 @@ def walk_files_pages(
             f"is_tradable_only=true;"
             f"sidecar_sentinel={sentinel_count};"
             f"sidecar_real_pages={real_pages_count};"
-            f"sidecar_empty={empty_count}"
+            f"sidecar_empty={empty_count};"
+            f"fetch_tasks={len(fetch_tasks_ordered)}"
         )
         set_stage_target(
             run_id=progress_ctx.run_id,
             stage_key=progress_ctx.stage_key,
-            target_count=len(targets),
+            target_count=_progress_total,
             cohort_fingerprint=fingerprint,
         )
-    _emit_every_n = max(1, len(targets) // 100) if targets else 0
-    _last_progress_emit = time.monotonic()
-    _processed_count = 0
+
+    def _emit_progress() -> None:
+        nonlocal _last_progress_emit
+        if progress_ctx is None:
+            return
+        _now = time.monotonic()
+        if _processed_count % _emit_every_n == 0 or _now - _last_progress_emit > 30:
+            set_stage_processed(
+                run_id=progress_ctx.run_id,
+                stage_key=progress_ctx.stage_key,
+                processed_count=_processed_count,
+            )
+            _last_progress_emit = _now
+
+    # Bump once per target evaluated during flatten (covers
+    # agent-skipped / empty-sidecar / sentinel-only short-circuits)
+    # so the bar advances at the same per-target ratio as the
+    # pre-#1341 loop. The chunk drain below bumps once per task.
+    for _ in targets:
+        _processed_count += 1
+        _emit_progress()
+
+    prefetch_window_seconds_total = 0.0 if bootstrap_mode else None
 
     with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-        for instrument_id, cik, symbol, sidecar_pages in targets:
-            # #1273 PR2 — cadenced emit. Bump _processed_count at the
-            # TOP of every iteration so the bar advances against the
-            # full cohort `len(targets)` even for early-skip branches
-            # (agent CIKs / empty sidecar / sentinel-only). The
-            # operator-visible meaning is "CIKs evaluated" not "HTTP
-            # work done"; the legacy `result.*` counters retain the
-            # finer-grained bucketing for audit log.
-            _processed_count += 1
-            if progress_ctx is not None:
-                _now = time.monotonic()
-                if _processed_count % _emit_every_n == 0 or _now - _last_progress_emit > 30:
-                    set_stage_processed(
-                        run_id=progress_ctx.run_id,
-                        stage_key=progress_ctx.stage_key,
-                        processed_count=_processed_count,
+        # Chunk the task list. Bootstrap → prefetch chunk via
+        # PipelinedSecFetcher; steady-state → skip prefetch.
+        # Per-chunk discipline bounds peak heap: the chunk's
+        # cache dict and the SubmissionsPageResult payloads it
+        # holds are all dropped at the chunk-loop boundary.
+        for chunk in _chunked(fetch_tasks_ordered, DEFAULT_PREFETCH_CHUNK_SIZE):
+            wrapper: _CachedSubmissionsPageFetcher | None = None
+            if bootstrap_mode:
+                prefetch_tasks = [
+                    ConditionalFetchTask(
+                        page_name=page_name,
+                        if_modified_since=watermarks.get((cik_, page_name)),
                     )
-                    _last_progress_emit = _now
-            # Agent CIKs are excluded by the populate path
-            # (sec_submissions_ingest.refresh_cik_sidecar) so their
-            # sidecar_pages list is empty by design. Skip them here
-            # silently — they do NOT count toward ciks_visited (the
-            # counter reflects "real CIKs we did or attempted work for"
-            # per Architect IMPORTANT — pre-PR-B post-review fix).
-            if cik in KNOWN_FILING_AGENT_CIKS:
-                continue
-
-            result.ciks_visited += 1
-
-            if not sidecar_pages:
-                # Empty sidecar for an in-universe CIK that is NOT an
-                # agent. Indicates an S8 ordering bug or a CIK added
-                # to the universe after S8 ran. Per-CIK log is DEBUG
-                # to avoid stderr spam at scale (8.7k CIK cohort — a
-                # systemic S8 failure would otherwise log 8,700
-                # WARNING lines); a single end-of-walk summary
-                # WARNING is emitted below (per Architect IMPORTANT).
-                logger.debug(
-                    "files walk: empty sidecar for in-universe CIK %s; "
-                    "S8 must populate sec_cik_submissions_files_index first",
-                    cik,
+                    for (_iid, cik_, _sym, page_name) in chunk
+                ]
+                _t0 = time.monotonic()
+                chunk_cache = prefetch_submissions_pages_conditional(
+                    prefetch_tasks,
+                    user_agent=settings.sec_user_agent,
                 )
-                result.ciks_with_empty_sidecar += 1
-                result.parse_errors += 1
-                continue
+                assert prefetch_window_seconds_total is not None  # bootstrap_mode guard
+                prefetch_window_seconds_total += time.monotonic() - _t0
+                result.prefetch_pages_seeded += len(chunk_cache)
+                wrapper = _CachedSubmissionsPageFetcher(provider, chunk_cache)
+            provider_for_loop: SecFilingsProvider | _CachedSubmissionsPageFetcher = (
+                wrapper if wrapper is not None else provider
+            )
 
-            if sidecar_pages == [_SIDECAR_SENTINEL_PAGE_NAME]:
-                # CIK processed with zero overflow pages (sentinel
-                # row). No HTTP fetch needed.
-                result.ciks_with_no_overflow += 1
-                continue
+            # Per-(cik, page) drain of THIS chunk.
+            for instrument_id, cik, symbol, page_name in chunk:
+                _processed_count += 1
+                _emit_progress()
+                wm_key = (cik, page_name)
+                if_modified_since = watermarks.get(wm_key)
+                _process_one_page(
+                    conn,
+                    provider=provider_for_loop,
+                    instrument_id=instrument_id,
+                    cik=cik,
+                    symbol=symbol,
+                    page_name=page_name,
+                    if_modified_since=if_modified_since,
+                    result=result,
+                )
 
-            for page_name in sidecar_pages:
-                # Defensive — the only sentinel allowed is
-                # _SIDECAR_SENTINEL_PAGE_NAME; the schema CHECK already
-                # rejects any other sentinel-shaped value. A real CIK
-                # with overflow pages will never have the sentinel
-                # mixed in (the populate path writes one or the other).
-                # Skip sentinel rows defensively.
-                if page_name == _SIDECAR_SENTINEL_PAGE_NAME:
-                    continue
+            # Drain wrapper telemetry into result BEFORE dropping the
+            # wrapper — chunk-boundary `del` would otherwise lose
+            # cache_hits/cache_misses for this chunk.
+            if wrapper is not None:
+                result.loop_pages_from_prefetch += wrapper.cache_hits
+                result.loop_pages_from_sync_fallback += wrapper.cache_misses
 
-                # Item 7 (#1233): read Last-Modified watermark BEFORE
-                # the fetch so we can inject If-Modified-Since.
-                # Namespaced key keeps us disjoint from the legacy
-                # ``sec.submissions`` source (top-accession semantics).
-                wm_key = f"{cik}:{page_name}"
-                wm = get_watermark(conn, _SOURCE_KEY_SUBMISSIONS_FILES, wm_key)
-                if_modified_since = wm.watermark if wm and wm.watermark else None
-                try:
-                    page_result = provider.fetch_submissions_page_conditional(
-                        page_name,
-                        if_modified_since=if_modified_since,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug(
-                        "files walk: secondary fetch failed for CIK %s/%s: %s",
-                        cik,
-                        page_name,
-                        exc,
-                    )
-                    result.parse_errors += 1
-                    continue
-                if page_result is None:
-                    # 404 — page absent. Nothing to record; no watermark
-                    # write either (no Last-Modified to persist).
-                    continue
-                if page_result.not_modified:
-                    # CAVEMAN: server said 304. Skip parse + skip upsert
-                    # (filings already known). Bump watermark_at only —
-                    # the stored Last-Modified is still freshest the
-                    # server has sent.
-                    result.secondary_pages_not_modified += 1
-                    with conn.transaction():
-                        if if_modified_since is not None:
-                            set_watermark(
-                                conn,
-                                source=_SOURCE_KEY_SUBMISSIONS_FILES,
-                                key=wm_key,
-                                watermark=if_modified_since,
-                                watermark_at=None,
-                            )
-                    continue
+            # Drop chunk cache + wrapper before next chunk. Python
+            # GC reclaims SubmissionsPageResult payloads. Bounded
+            # peak heap = one chunk's worth.
+            wrapper = None
 
-                page = page_result.payload
-                if page is None:
-                    # Defensive: 200 with empty body should not happen,
-                    # but the dataclass shape permits it. Skip safely.
-                    continue
-
-                result.secondary_pages_fetched += 1
-                try:
-                    # ``symbol`` is the canonical ticker (e.g. "AAPL"),
-                    # NOT a stringified instrument_id. Threaded from
-                    # the universe lookup at the top of the walk so
-                    # ``filing_events.raw_payload_json`` carries the
-                    # right value. Codex review BLOCKING for PR #1035.
-                    filings = _normalise_submissions_block(
-                        page,
-                        cik_padded=cik,
-                        symbol=symbol or cik,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("files walk: normalise failed for %s: %s", page_name, exc)
-                    result.parse_errors += 1
-                    continue
-
-                page_upsert_errors = 0
-                for filing in filings:
-                    try:
-                        with conn.transaction():
-                            # ``_upsert_filing`` returns False when
-                            # the 10y retention cap (#1233 §4.2) drops
-                            # a pre-cutoff filing. Count only accepted
-                            # rows.
-                            if _upsert_filing(conn, str(instrument_id), "sec", filing):
-                                result.filings_upserted += 1
-                    except Exception as exc:  # noqa: BLE001
-                        logger.debug(
-                            "files walk: upsert failed for %s/%s: %s",
-                            cik,
-                            filing.provider_filing_id,
-                            exc,
-                        )
-                        result.parse_errors += 1
-                        page_upsert_errors += 1
-
-                # Item 7 (#1233): persist the fresh Last-Modified
-                # watermark. set_watermark asserts INTRANS so it MUST
-                # land inside ``with conn.transaction():``. Write only
-                # when every filing on the page upserted cleanly OR
-                # was intentionally retention-dropped (the
-                # ``_upsert_filing returns False`` case which does NOT
-                # increment page_upsert_errors). If ANY filing raised,
-                # we leave the watermark unchanged so the next tick
-                # re-fetches + retries the failed filings instead of
-                # 304-skipping them forever. Codex 2 pre-push P1 fold
-                # 2026-05-24.
-                if page_result.last_modified is not None and page_upsert_errors == 0:
-                    with conn.transaction():
-                        set_watermark(
-                            conn,
-                            source=_SOURCE_KEY_SUBMISSIONS_FILES,
-                            key=wm_key,
-                            watermark=page_result.last_modified,
-                            watermark_at=None,
-                        )
+    result.prefetch_window_seconds_total = prefetch_window_seconds_total
 
     # #1273 PR2 — final operator-progress emit on exit.
     if progress_ctx is not None:
@@ -448,7 +618,9 @@ def sec_submissions_files_walk_job() -> None:
         conn.commit()
     logger.info(
         "sec_submissions_files_walk: ciks=%d pages=%d filings=%d "
-        "no_overflow=%d empty_sidecar=%d not_modified=%d parse_errors=%d",
+        "no_overflow=%d empty_sidecar=%d not_modified=%d parse_errors=%d "
+        "prefetch_seeded=%d loop_from_prefetch=%d loop_from_sync=%d "
+        "prefetch_window_s=%s",
         result.ciks_visited,
         result.secondary_pages_fetched,
         result.filings_upserted,
@@ -456,6 +628,10 @@ def sec_submissions_files_walk_job() -> None:
         result.ciks_with_empty_sidecar,
         result.secondary_pages_not_modified,
         result.parse_errors,
+        result.prefetch_pages_seeded,
+        result.loop_pages_from_prefetch,
+        result.loop_pages_from_sync_fallback,
+        f"{result.prefetch_window_seconds_total:.1f}" if result.prefetch_window_seconds_total is not None else "n/a",
     )
     if run_id is not None:
         # The walker has already committed its writes; a failure of

--- a/docs/proposals/etl/1341-s14-pipelined-fetch.md
+++ b/docs/proposals/etl/1341-s14-pipelined-fetch.md
@@ -1,0 +1,682 @@
+# #1341 — S14 sec_submissions_files_walk: pipelined HTTP for bootstrap
+
+**Status**: draft 1.4 · 2026-05-28 · Phase 2 of [`bootstrap-sub-1h-plan.md`](./bootstrap-sub-1h-plan.md) §7.
+
+**Parent**: master plan v5.2 §7 Phase 2 row 3 (S14 master.idx walk — **retargeted** after grep-verified premise gap: master.idx walk writes `sec_filing_manifest`; S14 writes `filing_events` with per-accession `primary_document_url` that downstream parsers (`business_summary.py:1419`, `eight_k_events.py:734`, `ownership_observations_sync.py:225`, `rewash_filings.py:298`, `def14a_ingest.py`) depend on. master.idx primary URL is the complete-submission `.txt`, not the per-accession primary doc; substituting silently breaks those parsers).
+
+**Approach**: keep S14's correctness (per-page secondary `submissions.json` HTTP with conditional GET → `_upsert_filing` writes to `filing_events`) and parallelise the dominant cost — per-page HTTP RTT — via the existing `PipelinedSecFetcher` (`app/services/sec_pipelined_fetcher.py:142`). Mirrors the established `bootstrap_business_summaries` / `bootstrap_def14a` / 8-K bootstrap prefetch pattern at `app/services/business_summary.py:1717`, `app/services/def14a_ingest.py:1006`, `app/services/eight_k_events.py:773`. Bootstrap-only — steady-state cron path unchanged.
+
+**Baseline (Run #7)**: S14 ~41 min wall-clock.
+**Target (this PR)**: S14 < 10 min wall-clock (Phase 2 acceptance per master plan §7).
+
+**Changelog**:
+- v1.0 — 2026-05-28 — initial draft.
+- v1.4 — 2026-05-28 — Codex 1 v1.3 re-pass fold (0 BLOCKING + 1 IMPORTANT + 1 NIT):
+  - IMPORTANT-D (progress invariant): `set_stage_target` MUST be called AFTER the flatten loop, with `target_count = len(targets) + len(fetch_tasks_ordered)` (since the loop bumps once per target + once per task). v1.3 left `set_stage_target(target_count=len(targets))` at the top, so final `_processed_count` could exceed target by up to `len(fetch_tasks_ordered)`. v1.4 moves the `set_stage_target` call to AFTER the flatten pass and pins the correct total.
+  - NIT-D: removed "chunk boundary" from `prefetch_submissions_pages_conditional` test description — function does NOT chunk internally; the walker chunk-shape test (sibling row) covers that.
+- v1.3 — 2026-05-28 — Codex 1 v1.2 re-pass fold (0 BLOCKING + 3 IMPORTANT + 3 NIT):
+  - IMPORTANT-A (progress accounting): §3.4 walker pseudocode now pins explicit progress accounting. `_processed_count` increments once per `target` evaluated in the flatten-loop (covers agent-CIK / empty-sidecar / sentinel-only short-circuits exactly like the existing per-target visit) AND once more per `(cik, page)` task drained inside the chunk drain. Cadenced emit per existing `_emit_every_n` formula bumped at both sites. Final emit at end-of-walk unchanged.
+  - IMPORTANT-B (telemetry drain): §3.4 walker now drains `_CachedSubmissionsPageFetcher.cache_hits / cache_misses` into `result.loop_pages_from_prefetch` / `result.loop_pages_from_sync_fallback` AFTER each chunk's drain loop completes (`result.loop_pages_from_prefetch += wrapper.cache_hits` etc.) so wrapper counters survive the chunk-boundary `del`.
+  - IMPORTANT-C (multi-chunk window): `prefetch_window_seconds` renamed `prefetch_window_seconds_total` — summed across all chunks via per-chunk `time.monotonic()` deltas. Still `None` when bootstrap-mode is off.
+  - NIT-A: status header bumped to draft 1.3.
+  - NIT-B: §8 prose updated — "S14's writer + 4 other callers" not "7 other callers".
+  - NIT-C: stale watermark line refs `315, 380` → `317, 382` in body prose (matching §0 verbatim).
+- v1.2 — 2026-05-28 — Codex 1 v1.1 re-pass fold (1 BLOCKING + 2 IMPORTANT + 1 NIT):
+  - BLOCKING-4 (chunking did not bound peak heap): v1.1 returned one giant `dict[page_name, SubmissionsPageResult|None]` covering all 17k pages — only per-chunk HTTP buffers freed. v1.2 refactors to a **chunk-and-drain** pattern: walker iterates the cohort task list in chunk-sized slices; for each slice it (a) prefetches that slice → small dict, (b) drains it via per-(cik, page) loop with DB writes, (c) drops the dict and moves to next chunk. Peak heap = one chunk dict + steady-state walker state ≈ 150-200 MB. Returns shape of `prefetch_submissions_pages_conditional` unchanged (still `dict`) — caller's per-chunk discipline does the heap bounding.
+  - IMPORTANT-7 (§0 grep proofs not verbatim): re-grepped at v1.2. `submissions_secondary_pages_walked` and `filing_events_seeded` now show all matches; `_SOURCE_KEY_SUBMISSIONS_FILES` set-watermark lines now 317/382 (not 316/381); `JOB_SEC_SUBMISSIONS_FILES_WALK` grep narrowed to the actual one-line match.
+  - IMPORTANT-8 (test placement): `_load_all_watermarks_for_pages` is walker-local (lives in `app/services/sec_submissions_files_walk.py`). Test moves from `tests/test_sec_pipelined_fetcher.py` to `tests/test_s14_uses_sidecar.py`.
+  - NIT-3 (callsite count): §8 now says `_upsert_filing` is called from 5 sites (`app/services/coverage.py:1658`, `coverage.py:1778`, `filings.py:396`, `sec_submissions_files_walk.py:355`, `sec_submissions_ingest.py:412`), not "7 other callers".
+- v1.1 — 2026-05-28 — Codex 1 fold (3 BLOCKING + 6 IMPORTANT + 2 NIT):
+  - BLOCKING-1 (`_adapt_zero_arg` discards `StageSpec.params`): drop the `use_pipelined_prefetch` param plumb. Walker enables prefetch unconditionally when `resolve_progress_context()` returns non-None (i.e. dispatched from inside the bootstrap orchestrator). Steady-state cron / API path returns `None` → no prefetch. Mirrors #1273 PR2 pattern.
+  - BLOCKING-2 (`walk_files_pages` constructs its own provider): walker continues to construct its own `SecFilingsProvider`. When `resolve_progress_context()` is non-None, walker runs the prefetch + wraps its OWN provider with `_CachedSubmissionsPageFetcher` before entering the per-CIK loop. No external provider injection. Test seam = inject `_run_prefetch` callable via module-level monkeypatch / parametrised hook (covered in §20).
+  - BLOCKING-3 (sink registry incomplete): §8 now declares `app/services/fundamentals/__init__.py:_upsert_filing_from_master_index` (line 2251) as a third `filing_events` writer with COALESCE-preserve semantics on the URL columns. Interaction documented: per-accession URL ALWAYS wins (master-index writer COALESCEs into existing; `_upsert_filing` overwrites NULL/.txt URLs with per-accession URLs). No regression — S14 was already in this race before this PR.
+  - IMPORTANT-1: §0 grep proofs re-run + pasted verbatim.
+  - IMPORTANT-2: Test paths corrected — tree is flat `tests/test_<topic>.py`, not `tests/services/...`. Extends `tests/test_sec_pipelined_fetcher.py` (existing) + `tests/test_s14_uses_sidecar.py` (existing). Uses existing `tests/fixtures/sec/submissions_TEST.json` fixture.
+  - IMPORTANT-3 (malformed 200): `prefetch_submissions_pages_conditional` catches `json.JSONDecodeError` + any per-task exception + omits failing pages from the cache. Cache-miss fallthrough via `_CachedSubmissionsPageFetcher` triggers the sync provider's existing per-page error handling (`parse_errors` counter, transaction rollback). One bad page never aborts the prefetch.
+  - IMPORTANT-4 (watermark batching underspecified): §6 now spells out the batched load — single SELECT pre-loop builds `dict[(cik, page_name), str|None]`; per-task IMS resolves from this map; per-page loop uses the SAME map for IMS passed to the cached wrapper (cache hit returns the prefetch result; cache miss falls through to sync provider which reads the watermark itself for retry-correctness).
+  - IMPORTANT-5 (memory estimate too low): v1.1 ADDS chunked prefetch in v1 — default `prefetch_chunk_size=1000` pages per chunk = ~50 MB raw JSON + ~150-200 MB peak heap with Python overhead. Configurable via module constant (not param — keeps invoker shape). R3 measurement can tune if needed without a new ticket.
+  - IMPORTANT-6 (cache_hits semantics): renamed counters and clarified — `prefetch_pages_seeded` = unique pages successfully prefetched; `loop_pages_from_prefetch` = per-loop consumptions served from cache (will overcount unique fetches by share-class-sibling multiple-instrument_id-per-CIK factor; this is loop visits, not work saved); `loop_pages_from_sync_fallback` = cache misses that hit the sync provider in the per-CIK loop.
+  - NIT-1: §21 callsite cites corrected — `business_summary.py:1717` / `def14a_ingest.py:1006` / `eight_k_events.py:773` (the import-and-use sites), not `scheduler.py` (which only holds the dispatch shell).
+  - NIT-2: stale docstring in `_upsert_filing` (`filings.py:611`) referencing 2-tuple conflict key gets corrected inline in the implementation PR (skill ownership rule). Not a spec change.
+
+---
+
+## §0 Grep proof
+
+> Generated 2026-05-28 against branch main @ `3129584`. Outputs reproduced verbatim from the commands below; do NOT paraphrase.
+
+### Cap vocabulary (cited in §13)
+
+```
+$ grep -n "Capability = Literal\[" app/services/bootstrap_orchestrator.py
+288:Capability = Literal[
+$ grep -n '"submissions_secondary_pages_walked"' app/services/bootstrap_orchestrator.py
+294:    "submissions_secondary_pages_walked",
+387:    "sec_submissions_files_walk": ("submissions_secondary_pages_walked",),
+394:    "sec_first_install_drain": ("filing_events_seeded", "submissions_secondary_pages_walked"),
+576:    "sec_def14a_bootstrap": CapRequirement(all_of=("filing_events_seeded", "submissions_secondary_pages_walked")),
+578:        all_of=("filing_events_seeded", "submissions_secondary_pages_walked")
+590:    "sec_8k_events_ingest": CapRequirement(all_of=("filing_events_seeded", "submissions_secondary_pages_walked")),
+$ grep -n "filing_events_seeded" app/services/bootstrap_orchestrator.py
+293:    "filing_events_seeded",
+314:    # legacy chain owner of ``filing_events_seeded``.
+369:    "sec_submissions_ingest": ("filing_events_seeded", "submissions_processed"),
+388:    "filings_history_seed": ("filing_events_seeded",),
+394:    "sec_first_install_drain": ("filing_events_seeded", "submissions_secondary_pages_walked"),
+511:# Content caps (``filing_events_seeded``, ``insider_inputs_seeded``,
+556:    "sec_submissions_files_walk": CapRequirement(all_of=("filing_events_seeded",)),
+576:    "sec_def14a_bootstrap": CapRequirement(all_of=("filing_events_seeded", "submissions_secondary_pages_walked")),
+578:        all_of=("filing_events_seeded", "submissions_secondary_pages_walked")
+590:    "sec_8k_events_ingest": CapRequirement(all_of=("filing_events_seeded", "submissions_secondary_pages_walked")),
+```
+
+S14 produces `submissions_secondary_pages_walked` (declared line 294; produced line 387); requires `filing_events_seeded` (line 556 — `CapRequirement(all_of=("filing_events_seeded",))`). Neither cap is new in this PR.
+
+### filing_events writers (cited in §8) — verbatim, three writers
+
+```
+$ grep -n "INSERT INTO filing_events" app/services/filings.py app/services/fundamentals/__init__.py
+app/services/filings.py:573:        INSERT INTO filing_events (
+app/services/filings.py:643:        INSERT INTO filing_events (
+app/services/fundamentals/__init__.py:2309:        INSERT INTO filing_events (
+
+$ grep -n "_upsert_filing\b" app/services/filings.py
+63:# into one of three chokepoints — ``_upsert_filing`` /
+292:    # to `_upsert_filing`, which has historically tolerated either
+396:                    if _upsert_filing(conn, instrument_id, provider_name, result):
+552:    Mirrors ``_upsert_filing``'s idempotent ON CONFLICT semantics and
+611:def _upsert_filing(
+
+$ grep -rn "_upsert_filing(" app --include="*.py"
+app/services/coverage.py:1658:            if _upsert_filing(conn, str(instrument_id), "sec", r):
+app/services/coverage.py:1778:                if _upsert_filing(conn, str(instrument_id), "sec", r):
+app/services/filings.py:396:                    if _upsert_filing(conn, instrument_id, provider_name, result):
+app/services/sec_submissions_files_walk.py:355:                            if _upsert_filing(conn, str(instrument_id), "sec", filing):
+app/services/sec_submissions_ingest.py:412:        if _upsert_filing(conn, str(instrument_id), "sec", filing):
+```
+
+Three writers; all keyed `(provider, provider_filing_id, instrument_id)`:
+
+- `filings.py:543 _upsert_filing_event` — overwrites URL columns on conflict.
+- `filings.py:611 _upsert_filing` — overwrites URL columns on conflict (S14's writer + 4 other callers: coverage.py:1658, coverage.py:1778, filings.py:396, sec_submissions_ingest.py:412).
+- `fundamentals/__init__.py:2251 _upsert_filing_from_master_index` — `COALESCE(filing_events.<col>, EXCLUDED.<col>)` preserves existing URLs on conflict.
+
+### Watermark namespace (cited in §6)
+
+```
+$ grep -n "_SOURCE_KEY_SUBMISSIONS_FILES" app/services/sec_submissions_files_walk.py
+81:_SOURCE_KEY_SUBMISSIONS_FILES: str = "sec.last_modified.submissions_files"
+287:                wm = get_watermark(conn, _SOURCE_KEY_SUBMISSIONS_FILES, wm_key)
+317:                                source=_SOURCE_KEY_SUBMISSIONS_FILES,
+382:                            source=_SOURCE_KEY_SUBMISSIONS_FILES,
+```
+
+Watermark key = `f"{cik}:{page_name}"`. Source = `sec.last_modified.submissions_files`. Unchanged in this PR.
+
+### Watermark API (cited in §6)
+
+```
+$ grep -n "def get_watermark\|def set_watermark" app/services/watermarks.py
+101:def get_watermark(
+133:def set_watermark(
+```
+
+### PipelinedSecFetcher API (cited in §3.1)
+
+```
+$ grep -n "def prefetch_document_texts\|class PipelinedSecFetcher\|DEFAULT_TARGET_RPS\|DEFAULT_CONCURRENCY" app/services/sec_pipelined_fetcher.py
+46:DEFAULT_TARGET_RPS: Final[float] = 7.0
+47:DEFAULT_CONCURRENCY: Final[int] = 4
+142:class PipelinedSecFetcher:
+223:def prefetch_document_texts(
+```
+
+Existing prefetch returns `dict[url, str | None]` — bodies only, no Last-Modified / status. Insufficient for S14 (needs conditional GET trichotomy). New sibling required.
+
+### Existing prefetch consumers (cited in §21)
+
+```
+$ grep -n "prefetch_document_texts\|_CachedDocFetcher" app/services/business_summary.py app/services/def14a_ingest.py app/services/eight_k_events.py
+app/services/business_summary.py:1717:        from app.services.sec_pipelined_fetcher import _CachedDocFetcher, prefetch_document_texts
+app/services/def14a_ingest.py:1006:        from app.services.sec_pipelined_fetcher import _CachedDocFetcher, prefetch_document_texts
+app/services/eight_k_events.py:773:        from app.services.sec_pipelined_fetcher import _CachedDocFetcher, prefetch_document_texts
+```
+
+### Bootstrap context API (cited in §3.4, §13)
+
+```
+$ grep -n "def resolve_progress_context\|class BootstrapProgressContext" app/services/bootstrap_state.py
+896:class BootstrapProgressContext:
+911:def resolve_progress_context() -> BootstrapProgressContext | None:
+```
+
+Returns non-None inside the `active_bootstrap_run` contextvar window (bound by the orchestrator at `bootstrap_orchestrator.py:1446`); returns `None` otherwise (cron / API path).
+
+### Invoker shape (cited in §3.4)
+
+```
+$ grep -n "JOB_SEC_SUBMISSIONS_FILES_WALK\|sec_submissions_files_walk_job" app/jobs/runtime.py
+378:_INVOKERS[_files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK] = _adapt_zero_arg(_files_walk.sec_submissions_files_walk_job)
+```
+
+S14's invoker is `_adapt_zero_arg`-wrapped → `StageSpec.params` are DISCARDED. Walker MUST self-detect bootstrap mode via `resolve_progress_context()` — no param-flag plumb possible without re-shaping the invoker, which is OUT of scope.
+
+### Existing walker test (cited in §20)
+
+```
+$ ls tests/test_s14_uses_sidecar.py tests/test_sec_pipelined_fetcher.py tests/test_sec_cik_submissions_files_index.py 2>/dev/null
+tests/test_s14_uses_sidecar.py
+tests/test_sec_pipelined_fetcher.py
+tests/test_sec_cik_submissions_files_index.py
+```
+
+---
+
+## 1. Decisions
+
+1. Bootstrap S14 (`sec_submissions_files_walk_job` registered at `app/jobs/runtime.py:378`) prefetches every secondary `CIK<10>-submissions-NNN.json` page concurrently (4-way via `PipelinedSecFetcher` at the shared 7 req/s ceiling) BEFORE the per-CIK upsert loop runs. The loop consumes cached responses via a `_CachedSubmissionsPageFetcher` wrapper and proceeds with unchanged parse + watermark + upsert semantics.
+2. Steady-state cron path UNCHANGED — single-tenant operator invocation has no parallelism win over the shared sec_rate lane, and the prefetch's chunked memory budget is wasteful when the cohort is small. Walker self-detects bootstrap mode via `resolve_progress_context()` (returns non-None only inside the orchestrator's `active_bootstrap_run` contextvar window).
+3. Operator-visible figure: `filing_events` row count for any in-universe CIK with overflow pages — must match the serial baseline exactly (delta = 0 — pure perf change, no semantics shift). Verification panel = AAPL/GME/MSFT/JPM/HD.
+4. Rollback: revert this PR. No data migration, no schema change. The walker falls back to the serial sync ResilientClient path (the existing pre-PR behaviour).
+
+## 2. Identifiers + identity-drift
+
+CIK (zero-padded 10-digit string), page_name (regex `CIK\d{10}-submissions-\d{3}\.json`), accession_number. No new identifiers. No identity drift surface — purely lifts the existing identifier flow.
+
+## 3. Endpoint surface
+
+| URL | Method | Conditional | Body schema | Fixture |
+|---|---|---|---|---|
+| `https://data.sec.gov/submissions/<page_name>` | GET | If-Modified-Since | SEC submissions secondary-page JSON (recent[]-shape arrays) | `tests/fixtures/sec/submissions_TEST.json` (existing — re-used as the page-body fixture in `tests/test_s14_uses_sidecar.py`) |
+
+### 3.1 New function: `prefetch_submissions_pages_conditional`
+
+```python
+# app/services/sec_pipelined_fetcher.py
+
+@dataclass(frozen=True)
+class ConditionalFetchTask:
+    """Per-page prefetch task carrying its own If-Modified-Since header."""
+    page_name: str  # e.g. "CIK0000320193-submissions-001.json"
+    if_modified_since: str | None  # from external_data_watermarks
+
+
+DEFAULT_PREFETCH_CHUNK_SIZE: Final[int] = 1000
+
+
+def prefetch_submissions_pages_conditional(
+    tasks: list[ConditionalFetchTask],
+    *,
+    user_agent: str,
+    target_rps: float = DEFAULT_TARGET_RPS,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> dict[str, "SubmissionsPageResult | None"]:
+    """Bulk-fetch ONE CHUNK of SEC secondary submissions pages.
+
+    The CALLER (walker) is responsible for slicing the full cohort
+    task list into ``DEFAULT_PREFETCH_CHUNK_SIZE``-sized chunks and
+    invoking this function once per chunk so the dict it returns
+    (and any payloads it references) can be drained and dropped
+    BEFORE the next chunk is fetched. Function does NOT chunk
+    internally — it fetches the whole `tasks` list and returns a
+    cache for it. Caller bounds peak heap by chunk size; this
+    function does NOT.
+
+    Returns ``{page_name: SubmissionsPageResult | None}``:
+      * key absent — fetch failed (transport / 429 / 5xx / malformed
+        body). Caller's cache-miss fallthrough hits the sync
+        provider, which owns the retry / quarantine contract.
+      * value ``None`` — 404; page absent (caller's existing skip path).
+      * value ``SubmissionsPageResult(payload=None, last_modified=ims,
+        not_modified=True)`` — 304.
+      * value ``SubmissionsPageResult(payload=<dict>, last_modified=<lm>,
+        not_modified=False)`` — 200.
+
+    Per-task failures isolated via ``try/except`` (httpx.HTTPError +
+    OSError + json.JSONDecodeError + ValueError); one bad page is
+    omitted from the result dict, never aborts the chunk.
+
+    Tasks with the SAME page_name are de-duped via ``dict.fromkeys``
+    upfront. Returned dict keyed by ``page_name`` (NOT URL) — caller
+    has page_name from the sidecar.
+
+    Mirrors ``prefetch_document_texts`` lifecycle: shared
+    ``_PROCESS_RATE_LIMIT_CLOCK`` so concurrent sync SEC traffic
+    co-exists under the 7 req/s ceiling.
+    """
+```
+
+### 3.2 New wrapper: `_CachedSubmissionsPageFetcher`
+
+```python
+class _CachedSubmissionsPageFetcher:
+    """Wraps a sync ``SecFilingsProvider`` for the bootstrap S14 path.
+
+    Mirror of ``_CachedDocFetcher`` but for
+    ``fetch_submissions_page_conditional`` rather than
+    ``fetch_document_text``. Cache lookups MUST honour the
+    per-page If-Modified-Since the caller passes; cache misses fall
+    through to the underlying provider's sync ResilientClient.
+
+    Cache contract:
+      * page_name in cache, value None → 404; return None.
+      * page_name in cache, value SubmissionsPageResult → return it.
+      * page_name NOT in cache → fall through to underlying provider.
+
+    Telemetry:
+      * ``cache_hits``  — page_name in cache (any value, including None).
+      * ``cache_misses`` — page_name NOT in cache (caller's per-CIK loop
+        visit went to the sync provider).
+    """
+
+    def __init__(
+        self,
+        underlying: SecFilingsProvider,
+        cache: dict[str, SubmissionsPageResult | None],
+    ) -> None:
+        self._underlying = underlying
+        self._cache = cache
+        self.cache_hits = 0
+        self.cache_misses = 0
+
+    def fetch_submissions_page_conditional(
+        self,
+        page_name: str,
+        *,
+        if_modified_since: str | None = None,
+    ) -> SubmissionsPageResult | None:
+        if page_name in self._cache:
+            self.cache_hits += 1
+            return self._cache[page_name]
+        self.cache_misses += 1
+        return self._underlying.fetch_submissions_page_conditional(
+            page_name, if_modified_since=if_modified_since
+        )
+```
+
+`walk_files_pages` accepts the wrapper via duck-typing (only one method called). No new abstract base.
+
+### 3.3 Watermark batched load
+
+```python
+def _load_all_watermarks_for_pages(
+    conn: psycopg.Connection[Any],
+    targets: list[tuple[int, str, str, list[str]]],
+) -> dict[tuple[str, str], str | None]:
+    """One SELECT, returns ``{(cik, page_name): if_modified_since}``.
+
+    For every (cik, page_name) in the cohort's flattened sidecar pages,
+    look up the watermark under
+    ``source='sec.last_modified.submissions_files'``,
+    ``key=f'{cik}:{page_name}'``. Missing rows → value None.
+
+    Avoids ~17k per-page round-trips to external_data_watermarks
+    during the per-CIK loop.
+    """
+```
+
+### 3.4 Walker integration (`walk_files_pages`) — chunk-and-drain
+
+```python
+def walk_files_pages(*, conn: psycopg.Connection[Any]) -> FilesWalkResult:
+    result = FilesWalkResult()
+    targets = _list_cik_secondary_pages(conn)
+
+    progress_ctx = resolve_progress_context()
+    _last_progress_emit = time.monotonic()
+    _processed_count = 0
+
+    # Pre-load watermarks for the whole cohort (one SELECT).
+    watermarks = _load_all_watermarks_for_pages(conn, targets)
+    bootstrap_mode = progress_ctx is not None
+
+    # Flatten the cohort into an ordered (cik, page_name) task list,
+    # SKIPPING agent CIKs / empty-sidecar / sentinel-only short-
+    # circuits — those don't need HTTP. We do NOT emit progress yet
+    # because set_stage_target requires the FINAL total which depends
+    # on len(fetch_tasks_ordered) too (one bump per target + one
+    # bump per task — progress invariant: final processed ==
+    # len(targets) + len(fetch_tasks_ordered)).
+    fetch_tasks_ordered: list[tuple[int, str, str, str]] = []
+    for instrument_id, cik, symbol, sidecar_pages in targets:
+        if cik in KNOWN_FILING_AGENT_CIKS:
+            continue  # not counted in ciks_visited (existing semantics)
+        result.ciks_visited += 1
+        if not sidecar_pages:
+            result.ciks_with_empty_sidecar += 1
+            result.parse_errors += 1
+            continue
+        if sidecar_pages == [_SIDECAR_SENTINEL_PAGE_NAME]:
+            result.ciks_with_no_overflow += 1
+            continue
+        for page_name in sidecar_pages:
+            if page_name == _SIDECAR_SENTINEL_PAGE_NAME:
+                continue  # defensive — existing
+            fetch_tasks_ordered.append((instrument_id, cik, symbol, page_name))
+
+    # #1273 PR2 progress instrumentation — pin target_count to the
+    # FINAL TOTAL after flatten so the bar can't overshoot. Fingerprint
+    # exposes both buckets so the operator can audit cohort composition.
+    _progress_total = len(targets) + len(fetch_tasks_ordered)
+    _emit_every_n = max(1, _progress_total // 100) if _progress_total else 0
+    if progress_ctx is not None:
+        sentinel_count = sum(1 for t in targets if t[3] == [_SIDECAR_SENTINEL_PAGE_NAME])
+        empty_count = sum(1 for t in targets if not t[3])
+        real_pages_count = len(targets) - sentinel_count - empty_count
+        fingerprint = (
+            f"is_tradable_only=true;"
+            f"sidecar_sentinel={sentinel_count};"
+            f"sidecar_real_pages={real_pages_count};"
+            f"sidecar_empty={empty_count};"
+            f"fetch_tasks={len(fetch_tasks_ordered)}"
+        )
+        set_stage_target(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            target_count=_progress_total,
+            cohort_fingerprint=fingerprint,
+        )
+
+    def _emit_progress() -> None:
+        nonlocal _last_progress_emit
+        if progress_ctx is None:
+            return
+        _now = time.monotonic()
+        if _processed_count % _emit_every_n == 0 or _now - _last_progress_emit > 30:
+            set_stage_processed(
+                run_id=progress_ctx.run_id,
+                stage_key=progress_ctx.stage_key,
+                processed_count=_processed_count,
+            )
+            _last_progress_emit = _now
+
+    # Bump _processed_count once per target seen during flatten (covers
+    # agent-skipped / empty-sidecar / sentinel-only short-circuits) so
+    # the operator-visible progress reflects work observed in the same
+    # ratio as today's per-target loop.
+    for _ in targets:
+        _processed_count += 1
+        _emit_progress()
+
+    prefetch_window_seconds_total = 0.0 if bootstrap_mode else None
+
+    with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+        # Chunk the task list. Bootstrap → prefetch chunk via
+        # PipelinedSecFetcher; steady-state → skip prefetch.
+        # Per-chunk discipline bounds peak heap: the chunk's cache
+        # dict and the SubmissionsPageResult payloads it holds are
+        # all dropped at the chunk-loop boundary.
+        for chunk in _chunked(fetch_tasks_ordered, DEFAULT_PREFETCH_CHUNK_SIZE):
+            chunk_cache: dict[str, SubmissionsPageResult | None] = {}
+            wrapper: _CachedSubmissionsPageFetcher | None = None
+            if bootstrap_mode:
+                prefetch_tasks = [
+                    ConditionalFetchTask(
+                        page_name=page_name,
+                        if_modified_since=watermarks.get((cik, page_name)),
+                    )
+                    for (_iid, cik, _sym, page_name) in chunk
+                ]
+                _t0 = time.monotonic()
+                chunk_cache = prefetch_submissions_pages_conditional(
+                    prefetch_tasks,
+                    user_agent=settings.sec_user_agent,
+                )
+                prefetch_window_seconds_total += time.monotonic() - _t0
+                result.prefetch_pages_seeded += len(chunk_cache)
+                wrapper = _CachedSubmissionsPageFetcher(provider, chunk_cache)
+            provider_for_loop: SecFilingsProvider | _CachedSubmissionsPageFetcher = (
+                wrapper if wrapper is not None else provider
+            )
+
+            # Per-(cik, page) drain of THIS chunk. DB writes serial,
+            # transaction shape unchanged from today (per-filing
+            # transaction inside the page loop; per-page watermark
+            # write after upsert-all-clean).
+            for instrument_id, cik, symbol, page_name in chunk:
+                _processed_count += 1
+                _emit_progress()
+                wm_key = (cik, page_name)
+                if_modified_since = watermarks.get(wm_key)
+                _process_one_page(
+                    conn,
+                    provider=provider_for_loop,
+                    instrument_id=instrument_id,
+                    cik=cik,
+                    symbol=symbol,
+                    page_name=page_name,
+                    if_modified_since=if_modified_since,
+                    result=result,
+                )
+
+            # Drain wrapper telemetry into result BEFORE dropping the
+            # wrapper — chunk-boundary `del` would otherwise lose
+            # cache_hits/cache_misses for this chunk.
+            if wrapper is not None:
+                result.loop_pages_from_prefetch += wrapper.cache_hits
+                result.loop_pages_from_sync_fallback += wrapper.cache_misses
+
+            # Drop chunk cache before fetching next chunk — Python
+            # GC reclaims SubmissionsPageResult payloads. Bounded
+            # peak heap = one chunk's worth.
+            del chunk_cache
+            wrapper = None
+
+    result.prefetch_window_seconds_total = prefetch_window_seconds_total
+
+    # End-of-walk summary log + final progress emit — UNCHANGED.
+    if progress_ctx is not None:
+        set_stage_processed(
+            run_id=progress_ctx.run_id,
+            stage_key=progress_ctx.stage_key,
+            processed_count=_processed_count,
+        )
+    ...
+    return result
+```
+
+Progress accounting invariant: `_progress_total == len(targets) + len(fetch_tasks_ordered)` is pinned via `set_stage_target` AFTER the flatten pass so the operator-visible bar maxes out at the correct denominator. `_processed_count` final value == `_progress_total` (one bump per target observed + one bump per task drained). Final emit pins the counter. Operator-visible meaning is "evaluations performed" — strict superset of "CIKs visited" (matches today's `_processed_count` semantics with extra page-level granularity).
+
+`_chunked` is a trivial slicing helper (`itertools.batched` once Python 3.12+ is the floor; or a 4-line generator). `_process_one_page` is the extracted per-page body of today's nested loop (parse + per-filing transaction + watermark write). Test seam = `monkeypatch.setattr(sec_submissions_files_walk, "prefetch_submissions_pages_conditional", _fake)` (covered in §20).
+
+**Walker takes NO new parameters.** The chunk-and-drain pattern fits inside the existing `walk_files_pages(*, conn)` signature.
+
+## 4. Schema
+
+N/A — no schema change.
+
+## 5. Fetch strategy + rate-limit composition
+
+`per_resource_http` (unchanged from baseline). Composition: bootstrap path uses `PipelinedSecFetcher` for the prefetch (concurrency=4, target_rps=7); steady-state cron path uses the sync ResilientClient (concurrency=1, target_rps=7). Both share `_PROCESS_RATE_LIMIT_CLOCK` so non-S14 SEC traffic (per-CIK poll, atom fast lane, manifest worker) co-exists safely.
+
+**Lane contention**: S14 is on the `sec_rate` lane. Lane serialisation guarantees no concurrent stage on `sec_rate` runs during S14. The 4-way pipeline fully owns the lane's 7 req/s budget for the prefetch window — no starvation surface.
+
+## 6. Conditional-GET semantics
+
+**Pre-loop read** (this PR): one SELECT against `external_data_watermarks` filtered by `source='sec.last_modified.submissions_files'` AND `key IN (<all CIK:page_name pairs>)` returns the full `dict[(cik, page_name), str|None]` map. Pre-loop work; bootstrap and steady-state both use this.
+
+**Per-page IMS resolution** (loop): `if_modified_since = watermarks.get((cik, page_name))`. SAME value passed to the prefetch call AND to the loop's `provider_for_loop.fetch_submissions_page_conditional(...)`.
+
+**Response trichotomy** (unchanged):
+- 304 → bump `watermark_at` only (Last-Modified string unchanged); skip parse + skip upsert; count `secondary_pages_not_modified`.
+- 200 → parse via `_normalise_submissions_block` → per-filing `_upsert_filing` → on all-clean, persist new Last-Modified via `set_watermark`.
+- 404 → no watermark write; skip silently.
+
+**Post-prefetch ordering**: parse + upsert + watermark write happen serially in the existing per-CIK loop. No concurrency on DB writes. Cache lookup is read-only; the watermark write semantics are unchanged.
+
+**Cache miss on transient prefetch failure**: cache key absent. `_CachedSubmissionsPageFetcher.fetch_submissions_page_conditional` falls through to the sync provider, which sends its own GET with the same `if_modified_since` (read from the same `watermarks` dict). Sync provider's ResilientClient applies its existing retry / quarantine policy. Net effect: transient failures during prefetch fall through to the sync retry path — no worse than today.
+
+## 7. Retry posture per error-class
+
+| HTTP status (prefetch path) | Disposition |
+|---|---|
+| 200 | record `SubmissionsPageResult(payload=<dict>, ...)` in cache; loop processes via cache hit |
+| 304 | record `SubmissionsPageResult(payload=None, not_modified=True, ...)` in cache; loop bumps watermark_at via cache hit |
+| 404 | record `None` in cache; loop's cache hit returns None → existing skip path |
+| 429 / 5xx / transport error / malformed JSON / `json.JSONDecodeError` | OMIT from cache (`dict[page_name] not in cache`); loop's cache miss falls through to sync provider's existing retry path |
+
+## 8. Multi-writer sink registry
+
+**`filing_events`** — three writers, two conflict-resolution policies:
+
+| Writer | File | Conflict policy on URL columns |
+|---|---|---|
+| `_upsert_filing` (S14 + 4 other callers — coverage.py:1658, coverage.py:1778, filings.py:396, sec_submissions_ingest.py:412) | `app/services/filings.py:611` | `EXCLUDED.source_url` / `EXCLUDED.primary_document_url` — overwrite |
+| `_upsert_filing_event` (Chunk E single-accession 8-K gap fill) | `app/services/filings.py:543` | `EXCLUDED.source_url` / `EXCLUDED.primary_document_url` — overwrite |
+| `_upsert_filing_from_master_index` (master-index reconcile) | `app/services/fundamentals/__init__.py:2251` | `COALESCE(filing_events.<col>, EXCLUDED.<col>)` — preserve existing |
+
+All three keyed `(provider, provider_filing_id, instrument_id)`.
+
+**Interaction**: per-accession URLs ALWAYS win.
+- If master-index runs first → row carries the `.txt` complete-submission URL. S14 runs → `EXCLUDED` overwrites with the per-accession primary doc URL.
+- If S14 runs first → row carries the per-accession URL. Master-index runs → `COALESCE` preserves the per-accession URL; does NOT overwrite.
+
+This interaction is the SAME pre and post this PR (the prefetch is purely a perf rewrite of the HTTP layer; the writer is unchanged). Documented here per spec-template §8 because S14 is the more-correct writer in the triple and the spec must declare why the race resolves correctly.
+
+10y retention cap via `filing_within_retention` (`app/services/filings.py:114`) — pre-cap filings silently dropped by `_upsert_filing` (returns False). Telemetry: walker counts `result.filings_upserted` only for accepted rows (existing logic; not changed).
+
+**`external_data_watermarks`** (source `sec.last_modified.submissions_files`):
+- Single writer: `set_watermark` from `walk_files_pages` (lines 317, 382).
+- Conflict key: `(source, key)`. Unchanged.
+
+## 9. Watermark + retry-budget
+
+Unchanged. Per-page watermark write is gated on `page_upsert_errors == 0` (existing — every filing on the page upserted cleanly OR was intentionally retention-dropped via `_upsert_filing` returning False without raising). When a page raises mid-loop, the watermark stays at the prior value so the next tick re-fetches.
+
+## 10. Encoding / precision / NULL / timezone
+
+UTF-8 JSON. Date precision: SEC `filingDate` field (`YYYY-MM-DD`) — handled by `_normalise_submissions_block`. Timezone: filed_at stored as UTC at the `filing_events.filing_date` DATE column. No change.
+
+## 11. Backfill horizon + retention
+
+10y retention cap (`app/services/filings.py:79` — `filing_events_retention_cutoff`) — pre-cutoff filings silently dropped by `_upsert_filing`. Unchanged.
+
+No backfill required for this PR — the walker re-runs each bootstrap and steady-state cron tick from the same sidecar. First run post-merge populates the watermark for any new pages.
+
+## 12. Partition strategy + extension deadline
+
+N/A — `filing_events` is not range-partitioned. `external_data_watermarks` is a small fixed table.
+
+## 13. Bootstrap vs steady-state mode
+
+**Bootstrap mode** (this PR):
+- Stage 14 (`sec_submissions_files_walk` on `sec_rate` lane).
+- `resolve_progress_context()` returns non-None → walker runs chunk-and-drain prefetch.
+- Default `DEFAULT_PREFETCH_CHUNK_SIZE=1000`. Each chunk's prefetch dict + payloads live until the chunk drain completes; then dropped (`del`) before next chunk. Bounded peak heap ~150-200 MB per chunk (≈50 MB raw JSON + Python overhead).
+- Expected HTTP count to SEC: same total as today (one GET per page in the sidecar), temporally compressed to ~1/4 the wall-clock.
+
+**Steady-state mode** (unchanged):
+- Cron path runs OUTSIDE the orchestrator's `active_bootstrap_run` window → `resolve_progress_context()` returns None → walker uses the existing serial sync ResilientClient path.
+- Operator-trigger API runs OUTSIDE the orchestrator window → same as cron.
+
+**Bootstrap-mode discipline**: this stage is `per_resource_http` (not bulk-eligible — secondary pages are not in `submissions.zip` per `app/services/sec_submissions_files_walk.py:13-17`). Stage qualifies for the `per_resource_http` carve-out under `data-engineer/SKILL.md §6.5.15` — already established.
+
+## 14. Tombstones + soft-delete
+
+N/A — pure walker, no tombstone logic.
+
+## 15. `rows_skipped` closed-set + other
+
+Existing closed set on `FilesWalkResult` (`sec_submissions_files_walk.py:91-109`):
+- `ciks_with_no_overflow`
+- `ciks_with_empty_sidecar`
+- `parse_errors`
+- `secondary_pages_not_modified` (304)
+
+New telemetry (added to `FilesWalkResult`):
+- `prefetch_pages_seeded: int` — count of unique pages successfully prefetched (size of returned cache dict).
+- `loop_pages_from_prefetch: int` — per-loop visits served from the prefetch cache (may exceed `prefetch_pages_seeded` if a CIK's pages appear under multiple instrument_ids — share-class siblings; this counts loop consumptions, not unique fetches saved).
+- `loop_pages_from_sync_fallback: int` — per-loop visits that missed the prefetch cache and hit the sync provider.
+- `prefetch_window_seconds_total: float | None` — sum of per-chunk prefetch wall-clock deltas across all chunks; `None` when prefetch was disabled (steady-state mode).
+
+End-of-walk INFO log extended with these four.
+
+## 16. Schema-evolution migration path
+
+N/A — no schema change.
+
+## 17. Operator runbooks
+
+No operator action required. If R3 measurement (post-merge) shows memory pressure:
+- Tune `DEFAULT_PREFETCH_CHUNK_SIZE` constant down (no schema, no API change).
+- Or revert this PR (rollback path described in §1.4).
+
+No `app/runbooks/<source>_<endpoint>.py` artifact in this PR — there is no operator-driven verb (no DELETE, no re-ingest scope, no audit dump).
+
+## 18. Smoke matrix
+
+Bootstrap-driven, so dev-DB validation is via the live R3 measurement run (operator-driven post-merge). Pre-merge unit + integration tests cover:
+
+| Instrument | Why | Verification |
+|---|---|---|
+| AAPL (CIK 0000320193) | Long history; multiple secondary pages | `filing_events` row count post-walk matches serial baseline exactly |
+| GME (CIK 0001326380) | Moderate history; ~1 secondary page | Same as above |
+| MSFT (CIK 0000789019) | Long history; multiple secondary pages | Same as above |
+| JPM (CIK 0000019617) | Financial-services issuer | Same as above |
+| HD (CIK 0000354950) | Retail issuer; moderate history | Same as above |
+
+The pre-merge integration test in `tests/test_s14_uses_sidecar.py` (extended) asserts: walker with the cached wrapper (synthetic 5-CIK cohort, prefetch populated via in-process stub of `prefetch_submissions_pages_conditional`) produces IDENTICAL `filing_events` rows + `external_data_watermarks` rows to the walker run without prefetch.
+
+R3 measurement run records S14 wall-clock pre vs post.
+
+## 19. Cross-source verification
+
+For one instrument (AAPL) in the smoke panel, spot-check the resulting `filing_events` row count vs SEC EDGAR direct browser walk of `https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=0000320193&type=&dateb=&owner=include&count=40`. Recorded in PR description.
+
+## 20. Test placement
+
+| Test file | Type | New / Extend | Coverage |
+|---|---|---|---|
+| `tests/test_sec_pipelined_fetcher.py` | Unit | Extend | `prefetch_submissions_pages_conditional` happy path (200/304/404 trichotomy) + transport error cache omission + malformed-JSON cache omission + dedupe |
+| `tests/test_sec_pipelined_fetcher.py` | Unit | Extend | `_CachedSubmissionsPageFetcher` cache hit (200/304/404) / cache miss fallthrough / counter wiring |
+| `tests/test_s14_uses_sidecar.py` | Integration | Extend | Walker with prefetch wrapper (monkeypatched `prefetch_submissions_pages_conditional` → in-memory cache) produces identical `filing_events` rows + watermark writes vs walker without prefetch (`resolve_progress_context` returns None branch) |
+| `tests/test_s14_uses_sidecar.py` | Integration | Extend | Walker inside `active_bootstrap_run` context (monkeypatched `resolve_progress_context` → non-None) calls the prefetch function exactly once with the expected task list shape |
+| `tests/test_s14_uses_sidecar.py` | Unit | New test | `_load_all_watermarks_for_pages` returns the expected dict shape for a mocked cursor (walker-local helper; lives in `app/services/sec_submissions_files_walk.py`) |
+| `tests/test_s14_uses_sidecar.py` | Integration | New test | Chunk-and-drain shape: 2500-task cohort with `DEFAULT_PREFETCH_CHUNK_SIZE=1000` invokes `prefetch_submissions_pages_conditional` exactly 3 times (1000+1000+500); chunk cache is dropped between chunks (assertion: monkeypatched prefetch is called with disjoint task slices, no overlap) |
+
+No nightly; no contract test (purely internal behaviour).
+
+## 21. Rationale log
+
+**Decision:** prefetch + sync-loop wrapper rather than fully-async walker.
+**Rejected:** rewrite `walk_files_pages` as an async coroutine. Reason: DB writes are psycopg-sync; async sync mixing complicates lifecycle (asyncio.to_thread or sync-from-async patterns increase blast radius). Established `prefetch_document_texts` + sync-loop wrapper pattern at three callsites (`app/services/business_summary.py:1717`, `app/services/def14a_ingest.py:1006`, `app/services/eight_k_events.py:773`) proves the simpler shape is sufficient.
+
+**Decision:** new `prefetch_submissions_pages_conditional` rather than extend `prefetch_document_texts`.
+**Rejected:** generalise `prefetch_document_texts` to return `SubmissionsPageResult | str` union and handle conditional headers. Reason: function would become an unbounded union; three existing callers don't need conditional behaviour and would have to thread NULL headers everywhere. New function keeps the existing one's contract pristine; shared `_AsyncRateLimiter` + `_PROCESS_RATE_LIMIT_CLOCK` give the same rate-budget integration with zero duplication.
+
+**Decision:** new `_CachedSubmissionsPageFetcher` rather than extend `_CachedDocFetcher`.
+**Rejected:** add `fetch_submissions_page_conditional` method to `_CachedDocFetcher`. Reason: same shape-pollution concern. Duck-typed wrapper at the S14 callsite has zero collateral surface.
+
+**Decision:** chunk-and-drain in the WALKER, not internal-chunking inside `prefetch_submissions_pages_conditional`.
+**Rejected:** make `prefetch_submissions_pages_conditional` internally iterate chunks and return one giant union dict (v1.1 shape). Reason: Codex 1 v1.1 BLOCKING-4 — the union dict still holds all 17k payloads at end of run; only per-chunk HTTP buffers freed. Chunk-and-drain at the walker level lets the chunk dict + payloads be `del`-ed between chunks, bounding peak heap to one chunk's worth (~150-200 MB).
+
+**Decision:** walker self-detects bootstrap mode via `resolve_progress_context()`; no new param.
+**Rejected:** plumb `use_pipelined_prefetch=True` through `StageSpec.params`. Reason: Codex 1 BLOCKING-1 — `_adapt_zero_arg` discards params; full plumbing would require re-shaping the invoker. The contextvar approach mirrors #1273 PR2's `set_stage_target` pattern and is non-invasive.
+
+**Decision:** walker constructs its own provider AND its own wrapper internally; no external provider injection.
+**Rejected:** add `provider: SecFilingsProvider | _CachedSubmissionsPageFetcher` to `walk_files_pages` signature. Reason: Codex 1 BLOCKING-2 — the invoker only receives `(conn=...)`. Internal construction keeps the test seam at the `prefetch_submissions_pages_conditional` module symbol (monkeypatched in tests), not at the walker's signature.
+
+**Decision:** pre-load all watermarks in one SELECT before building `ConditionalFetchTask` list.
+**Rejected:** per-page `get_watermark` calls inside the prefetch loop. Reason: ~17k extra round-trips dwarf the SQL cost. One batched SELECT is O(cohort) DB cost. The pre-loaded dict is also the source of IMS for the per-CIK loop — same value used in both places, so prefetch and loop send the same conditional header.
+
+**Decision:** the master-index writer's `COALESCE` semantics + S14's `EXCLUDED` semantics are documented but UNCHANGED in this PR.
+**Rejected:** change `_upsert_filing` to use COALESCE for url columns. Reason: per-accession URLs are MORE correct (downstream parsers need them); preserving S14's "overwrite on conflict" is the intended interaction. Documented in §8 so future readers don't try to "harmonise" the writers and break the race resolution.
+
+## 22. Open questions
+
+None. Stale docstring in `_upsert_filing` (cited by Codex 1 NIT-2: it references a 2-tuple key but SQL uses 3-tuple) gets fixed inline in the implementation PR per the skill-ownership rule.
+
+---
+
+## Acceptance
+
+- Pre-merge: tests pass; serial-vs-prefetched parity verified on AAPL/GME/MSFT/JPM/HD fixtures.
+- Post-merge: R3 measurement run records S14 wall-clock < 10 min on clean-DB bootstrap.
+
+## Out
+
+- Master.idx walk for `sec_filing_manifest` parity. Already covered today by `sec_master_idx_quarterly_sweep` (`app/jobs/sec_master_idx_quarterly_sweep.py`) — no extra work needed.
+- Refactor of `walk_files_pages` to fully-async. Out of scope (per §21).
+- Refactor of `_drain_secondary_pages` redundant primary fetch (#1277 NIT-2). Out of scope.
+- Make `_adapt_zero_arg` params-aware. Out of scope; the contextvar approach is sufficient for this PR's needs.

--- a/tests/test_s14_uses_sidecar.py
+++ b/tests/test_s14_uses_sidecar.py
@@ -261,3 +261,264 @@ class TestS14ZeroPrimaryHttpContract:
         )
         # secondary_pages_fetched should reflect the real fetch via respx.
         assert result.secondary_pages_fetched >= 1
+
+
+# ---------------------------------------------------------------------------
+# #1341 — chunk-and-drain prefetch shape (walker control-flow tests,
+# pure-unit via monkeypatch — no DB).
+# ---------------------------------------------------------------------------
+
+
+class TestS14ChunkedHelpers:
+    def test_chunked_yields_correct_slices(self) -> None:
+        from app.services.sec_submissions_files_walk import _chunked
+
+        items: list[tuple[int, str, str, str]] = [(i, str(i), str(i), f"page-{i}") for i in range(7)]
+        chunks = list(_chunked(items, 3))
+        assert [len(c) for c in chunks] == [3, 3, 1]
+        # Slices must reassemble to the input in order (no overlap, no drops).
+        flattened: list[tuple[int, str, str, str]] = []
+        for c in chunks:
+            flattened.extend(c)
+        assert flattened == items
+
+    def test_chunked_empty_yields_nothing(self) -> None:
+        from app.services.sec_submissions_files_walk import _chunked
+
+        assert list(_chunked([], 10)) == []
+
+    def test_chunked_size_zero_raises(self) -> None:
+        from app.services.sec_submissions_files_walk import _chunked
+
+        with pytest.raises(ValueError):
+            list(_chunked([(1, "a", "a", "p")], 0))
+
+
+class TestS14LoadAllWatermarks:
+    def test_returns_dict_keyed_by_cik_page_tuple(self) -> None:
+        from app.services.sec_submissions_files_walk import (
+            _SIDECAR_SENTINEL_PAGE_NAME,
+            _load_all_watermarks_for_pages,
+        )
+
+        # Mock a psycopg connection with a cursor that returns rows.
+        class _Cur:
+            def __init__(self) -> None:
+                self.last_sql: str = ""
+                self.last_args: tuple[Any, ...] | None = None
+
+            def __enter__(self) -> _Cur:
+                return self
+
+            def __exit__(self, *a: object) -> None:
+                return None
+
+            def execute(self, sql: str, args: tuple[Any, ...]) -> None:
+                self.last_sql = sql
+                self.last_args = args
+
+            def fetchall(self) -> list[tuple[str, str]]:
+                return [
+                    ("0000320193:CIK0000320193-submissions-001.json", "Mon, 25 May 2026 00:00:00 GMT"),
+                    ("0000789019:CIK0000789019-submissions-002.json", "Tue, 26 May 2026 00:00:00 GMT"),
+                ]
+
+        class _Conn:
+            def __init__(self, cur: _Cur) -> None:
+                self._cur = cur
+
+            def cursor(self) -> _Cur:
+                return self._cur
+
+        cur = _Cur()
+        conn = _Conn(cur)
+        targets = [
+            (1, "0000320193", "AAPL", ["CIK0000320193-submissions-001.json"]),
+            (2, "0000789019", "MSFT", ["CIK0000789019-submissions-002.json"]),
+            # Sentinel-only sidecar — must NOT contribute a key.
+            (3, "0001326380", "GME", [_SIDECAR_SENTINEL_PAGE_NAME]),
+        ]
+        out = _load_all_watermarks_for_pages(conn, targets)  # type: ignore[arg-type]
+        assert out == {
+            ("0000320193", "CIK0000320193-submissions-001.json"): "Mon, 25 May 2026 00:00:00 GMT",
+            ("0000789019", "CIK0000789019-submissions-002.json"): "Tue, 26 May 2026 00:00:00 GMT",
+        }
+        assert cur.last_args is not None
+        # Sentinel page NOT in keys argument (defensive: schema CHECK
+        # also bars it, but the helper itself must skip it client-side).
+        assert _SIDECAR_SENTINEL_PAGE_NAME not in (cur.last_args[1] or [])
+
+    def test_empty_targets_returns_empty_dict(self) -> None:
+        from app.services.sec_submissions_files_walk import _load_all_watermarks_for_pages
+
+        class _Conn:
+            def cursor(self) -> Any:
+                raise AssertionError("must not query when no keys")
+
+        assert _load_all_watermarks_for_pages(_Conn(), []) == {}  # type: ignore[arg-type]
+
+
+class TestS14ChunkAndDrainShape:
+    """Walker control-flow assertions WITHOUT DB. Monkeypatches
+    `_list_cik_secondary_pages` (cohort source) +
+    `_load_all_watermarks_for_pages` (watermark source) +
+    `prefetch_submissions_pages_conditional` (the function under
+    bootstrap mode) + `SecFilingsProvider` (so the underlying
+    ResilientClient never wakes up). DB is never touched."""
+
+    def _install_walker_stubs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        targets: list[tuple[int, str, str, list[str]]],
+        prefetch_seam: list[list[Any]] | None = None,
+        bootstrap: bool,
+    ) -> tuple[list[list[Any]], list[Any]]:
+        """Returns (prefetch_calls, page_calls). page_calls captures
+        per-(name, ims) tuples from the sync fallback provider, which
+        in bootstrap mode should be EMPTY (everything served from
+        prefetch cache)."""
+        from app.providers.implementations.sec_edgar import SubmissionsPageResult
+        from app.services import sec_submissions_files_walk as mod
+        from app.services.bootstrap_state import BootstrapProgressContext
+
+        prefetch_calls: list[list[Any]] = prefetch_seam if prefetch_seam is not None else []
+        page_calls: list[tuple[str, str | None]] = []
+
+        def _fake_targets(_conn: Any) -> list[tuple[int, str, str, list[str]]]:
+            return targets
+
+        def _fake_watermarks(
+            _conn: Any, _targets: list[tuple[int, str, str, list[str]]]
+        ) -> dict[tuple[str, str], str | None]:
+            return {}
+
+        def _fake_prefetch(tasks: list[Any], **_kwargs: Any) -> dict[str, SubmissionsPageResult | None]:
+            prefetch_calls.append(list(tasks))
+            # Cache every task as 404 (None) so walker hits the
+            # 404 short-circuit in `_process_one_page` WITHOUT
+            # touching `conn` (which is a bare object() in these
+            # tests). Wrapper still bumps `cache_hits` for None
+            # values, so chunk-shape + telemetry assertions still
+            # exercise the cache-hit path end-to-end.
+            return dict.fromkeys((task.page_name for task in tasks), None)
+
+        class _StubProvider:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            def __enter__(self) -> _StubProvider:
+                return self
+
+            def __exit__(self, *a: object) -> None:
+                return None
+
+            def fetch_submissions_page_conditional(
+                self, name: str, *, if_modified_since: str | None = None
+            ) -> SubmissionsPageResult | None:
+                page_calls.append((name, if_modified_since))
+                return None
+
+        monkeypatch.setattr(mod, "_list_cik_secondary_pages", _fake_targets)
+        monkeypatch.setattr(mod, "_load_all_watermarks_for_pages", _fake_watermarks)
+        monkeypatch.setattr(mod, "prefetch_submissions_pages_conditional", _fake_prefetch)
+        monkeypatch.setattr(mod, "SecFilingsProvider", _StubProvider)
+        if bootstrap:
+            monkeypatch.setattr(
+                mod, "resolve_progress_context", lambda: BootstrapProgressContext(run_id=1, stage_key="x")
+            )
+            # set_stage_target + set_stage_processed are no-ops in test
+            # — they take run_id which isn't a real bootstrap_runs row.
+            monkeypatch.setattr(mod, "set_stage_target", lambda **_kwargs: None)
+            monkeypatch.setattr(mod, "set_stage_processed", lambda **_kwargs: None)
+        else:
+            monkeypatch.setattr(mod, "resolve_progress_context", lambda: None)
+        return prefetch_calls, page_calls
+
+    def test_bootstrap_mode_chunks_2500_into_three_slices(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 2500 unique CIKs × 1 page each = 2500 tasks. With
+        # DEFAULT_PREFETCH_CHUNK_SIZE=1000 → 3 chunks (1000+1000+500).
+        from app.services.sec_submissions_files_walk import walk_files_pages
+
+        targets: list[tuple[int, str, str, list[str]]] = [
+            (i, f"{i:010d}", f"SYM{i}", [f"CIK{i:010d}-submissions-001.json"]) for i in range(1, 2501)
+        ]
+        prefetch_calls, page_calls = self._install_walker_stubs(monkeypatch, targets=targets, bootstrap=True)
+
+        result = walk_files_pages(conn=object())  # type: ignore[arg-type]
+        assert [len(c) for c in prefetch_calls] == [1000, 1000, 500]
+        # No overlap between chunks — slices are disjoint.
+        seen_names: set[str] = set()
+        for chunk in prefetch_calls:
+            chunk_names = {t.page_name for t in chunk}
+            assert seen_names.isdisjoint(chunk_names)
+            seen_names |= chunk_names
+        assert len(seen_names) == 2500
+        # Cache covered every task → sync fallback NOT exercised.
+        assert page_calls == []
+        # Telemetry summed across chunks.
+        assert result.prefetch_pages_seeded == 2500
+        assert result.loop_pages_from_prefetch == 2500
+        assert result.loop_pages_from_sync_fallback == 0
+        assert result.prefetch_window_seconds_total is not None
+        assert result.prefetch_window_seconds_total >= 0
+
+    def test_steady_state_skips_prefetch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No bootstrap context → walker uses sync provider path; the
+        # prefetch function is NEVER called.
+        from app.services.sec_submissions_files_walk import walk_files_pages
+
+        targets: list[tuple[int, str, str, list[str]]] = [
+            (1, "0000000001", "S1", ["CIK0000000001-submissions-001.json"]),
+            (2, "0000000002", "S2", ["CIK0000000002-submissions-001.json"]),
+        ]
+        prefetch_calls, page_calls = self._install_walker_stubs(monkeypatch, targets=targets, bootstrap=False)
+
+        result = walk_files_pages(conn=object())  # type: ignore[arg-type]
+        assert prefetch_calls == []
+        # Sync provider invoked once per page (cache miss is the only
+        # path in steady-state mode).
+        assert [name for (name, _) in page_calls] == [
+            "CIK0000000001-submissions-001.json",
+            "CIK0000000002-submissions-001.json",
+        ]
+        # Steady-state telemetry: prefetch_window_seconds_total is None.
+        assert result.prefetch_window_seconds_total is None
+        assert result.prefetch_pages_seeded == 0
+        assert result.loop_pages_from_prefetch == 0
+        assert result.loop_pages_from_sync_fallback == 0  # wrapper not used
+
+    def test_short_circuit_targets_do_not_appear_in_fetch_tasks(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Agent CIK / empty sidecar / sentinel-only — none should be
+        # in the prefetch task list.
+        from app.providers.implementations.sec_edgar import KNOWN_FILING_AGENT_CIKS
+        from app.services.sec_submissions_files_walk import (
+            _SIDECAR_SENTINEL_PAGE_NAME,
+            walk_files_pages,
+        )
+
+        agent_cik = next(iter(KNOWN_FILING_AGENT_CIKS))
+        targets: list[tuple[int, str, str, list[str]]] = [
+            (1, agent_cik, "AGENT", []),  # agent CIK
+            (2, "0000000099", "EMPTY", []),  # empty sidecar
+            (3, "0000000100", "SENT", [_SIDECAR_SENTINEL_PAGE_NAME]),  # sentinel-only
+            (4, "0000000200", "REAL", ["CIK0000000200-submissions-001.json"]),
+        ]
+        prefetch_calls, _ = self._install_walker_stubs(monkeypatch, targets=targets, bootstrap=True)
+
+        result = walk_files_pages(conn=object())  # type: ignore[arg-type]
+        # Only the REAL CIK's page is in the prefetch.
+        assert len(prefetch_calls) == 1
+        assert [t.page_name for t in prefetch_calls[0]] == ["CIK0000000200-submissions-001.json"]
+        # Counters: agent CIK not visited; empty + sentinel + real all visited.
+        assert result.ciks_visited == 3
+        assert result.ciks_with_empty_sidecar == 1
+        assert result.ciks_with_no_overflow == 1
+        # Empty sidecar bumps parse_errors per existing semantics.
+        assert result.parse_errors == 1

--- a/tests/test_sec_pipelined_fetcher.py
+++ b/tests/test_sec_pipelined_fetcher.py
@@ -334,3 +334,236 @@ class TestCachedDocFetcher:
         assert wrapped.fetch_document_text("u") == "from_underlying"
         assert wrapped.cache_misses == 1
         assert wrapped.cache_hits == 0
+
+
+# ---------------------------------------------------------------------------
+# #1341 — prefetch_submissions_pages_conditional + _CachedSubmissionsPageFetcher
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchSubmissionsPagesConditional:
+    def _patch_transport(self, monkeypatch: pytest.MonkeyPatch, handler) -> None:  # type: ignore[no-untyped-def]
+        transport = httpx.MockTransport(handler)
+        original_init = httpx.AsyncClient.__init__
+
+        def patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            kwargs["transport"] = transport
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+
+    def test_empty_tasks_returns_empty_dict(self) -> None:
+        from app.services.sec_pipelined_fetcher import prefetch_submissions_pages_conditional
+
+        assert prefetch_submissions_pages_conditional([], user_agent="test/1.0") == {}
+
+    def test_200_returns_page_result_with_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"hello": "world"},
+                headers={"Last-Modified": "Wed, 27 May 2026 12:34:56 GMT"},
+            )
+
+        self._patch_transport(monkeypatch, handler)
+        result = prefetch_submissions_pages_conditional(
+            [ConditionalFetchTask(page_name="CIK0000320193-submissions-001.json", if_modified_since=None)],
+            user_agent="test/1.0",
+        )
+        page_result = result["CIK0000320193-submissions-001.json"]
+        assert page_result is not None
+        assert page_result.payload == {"hello": "world"}
+        assert page_result.last_modified == "Wed, 27 May 2026 12:34:56 GMT"
+        assert page_result.not_modified is False
+
+    def test_304_returns_page_result_with_ims(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        ims = "Tue, 26 May 2026 09:00:00 GMT"
+        self._patch_transport(monkeypatch, lambda r: httpx.Response(304))
+        result = prefetch_submissions_pages_conditional(
+            [ConditionalFetchTask(page_name="CIK0000789019-submissions-002.json", if_modified_since=ims)],
+            user_agent="test/1.0",
+        )
+        page_result = result["CIK0000789019-submissions-002.json"]
+        assert page_result is not None
+        assert page_result.payload is None
+        assert page_result.last_modified == ims
+        assert page_result.not_modified is True
+
+    def test_404_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        self._patch_transport(monkeypatch, lambda r: httpx.Response(404))
+        result = prefetch_submissions_pages_conditional(
+            [ConditionalFetchTask(page_name="CIK0000000001-submissions-099.json", if_modified_since=None)],
+            user_agent="test/1.0",
+        )
+        assert result == {"CIK0000000001-submissions-099.json": None}
+
+    def test_5xx_omitted_from_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        self._patch_transport(monkeypatch, lambda r: httpx.Response(503))
+        result = prefetch_submissions_pages_conditional(
+            [ConditionalFetchTask(page_name="CIK0000019617-submissions-001.json", if_modified_since=None)],
+            user_agent="test/1.0",
+        )
+        assert "CIK0000019617-submissions-001.json" not in result
+
+    def test_429_omitted_from_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        self._patch_transport(monkeypatch, lambda r: httpx.Response(429))
+        result = prefetch_submissions_pages_conditional(
+            [ConditionalFetchTask(page_name="CIK0000354950-submissions-001.json", if_modified_since=None)],
+            user_agent="test/1.0",
+        )
+        assert "CIK0000354950-submissions-001.json" not in result
+
+    def test_malformed_json_omitted_from_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        # 200 with non-JSON body → resp.json() raises ValueError →
+        # per-task try/except omits from cache.
+        self._patch_transport(monkeypatch, lambda r: httpx.Response(200, content=b"not-json-at-all"))
+        result = prefetch_submissions_pages_conditional(
+            [ConditionalFetchTask(page_name="CIK0001326380-submissions-001.json", if_modified_since=None)],
+            user_agent="test/1.0",
+        )
+        assert "CIK0001326380-submissions-001.json" not in result
+
+    def test_dedupe_by_page_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        hits: list[str] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            hits.append(req.url.path)
+            return httpx.Response(200, json={"x": 1})
+
+        self._patch_transport(monkeypatch, handler)
+        result = prefetch_submissions_pages_conditional(
+            [
+                ConditionalFetchTask(page_name="CIK0000320193-submissions-001.json", if_modified_since=None),
+                ConditionalFetchTask(page_name="CIK0000320193-submissions-001.json", if_modified_since="ignored"),
+            ],
+            user_agent="test/1.0",
+        )
+        # Dedupe → only one HTTP call.
+        assert len(hits) == 1
+        assert "CIK0000320193-submissions-001.json" in result
+
+    def test_ims_header_sent_when_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        captured_headers: list[dict[str, str]] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured_headers.append(dict(req.headers))
+            return httpx.Response(304)
+
+        self._patch_transport(monkeypatch, handler)
+        ims = "Mon, 25 May 2026 00:00:00 GMT"
+        prefetch_submissions_pages_conditional(
+            [ConditionalFetchTask(page_name="CIK0000320193-submissions-001.json", if_modified_since=ims)],
+            user_agent="test/1.0",
+        )
+        # Exactly one HTTP call; If-Modified-Since header present.
+        assert len(captured_headers) == 1
+        assert captured_headers[0].get("if-modified-since") == ims
+
+    def test_ims_header_omitted_when_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.services.sec_pipelined_fetcher import (
+            ConditionalFetchTask,
+            prefetch_submissions_pages_conditional,
+        )
+
+        captured_headers: list[dict[str, str]] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured_headers.append(dict(req.headers))
+            return httpx.Response(200, json={"x": 1})
+
+        self._patch_transport(monkeypatch, handler)
+        prefetch_submissions_pages_conditional(
+            [ConditionalFetchTask(page_name="CIK0000320193-submissions-001.json", if_modified_since=None)],
+            user_agent="test/1.0",
+        )
+        assert len(captured_headers) == 1
+        assert "if-modified-since" not in captured_headers[0]
+
+
+class TestCachedSubmissionsPageFetcher:
+    def test_cache_hit_returns_cached_result(self) -> None:
+        from app.providers.implementations.sec_edgar import SubmissionsPageResult
+        from app.services.sec_pipelined_fetcher import _CachedSubmissionsPageFetcher
+
+        class _Stub:
+            def fetch_submissions_page_conditional(self, name, *, if_modified_since=None):  # type: ignore[no-untyped-def]
+                raise AssertionError("should not be called on cache hit")
+
+        cached = SubmissionsPageResult(payload={"x": 1}, last_modified="lm", not_modified=False)
+        wrapped = _CachedSubmissionsPageFetcher(_Stub(), {"page": cached})
+        assert wrapped.fetch_submissions_page_conditional("page", if_modified_since="ims") is cached
+        assert wrapped.cache_hits == 1
+        assert wrapped.cache_misses == 0
+
+    def test_cache_hit_with_none_returns_none_no_fallback(self) -> None:
+        from app.services.sec_pipelined_fetcher import _CachedSubmissionsPageFetcher
+
+        calls: list[str] = []
+
+        class _Stub:
+            def fetch_submissions_page_conditional(self, name, *, if_modified_since=None):  # type: ignore[no-untyped-def]
+                calls.append(name)
+                return None
+
+        wrapped = _CachedSubmissionsPageFetcher(_Stub(), {"page": None})
+        assert wrapped.fetch_submissions_page_conditional("page") is None
+        assert calls == []  # cached permanent 404; no fallback
+        assert wrapped.cache_hits == 1
+
+    def test_cache_miss_falls_back_to_underlying_with_ims(self) -> None:
+        from app.providers.implementations.sec_edgar import SubmissionsPageResult
+        from app.services.sec_pipelined_fetcher import _CachedSubmissionsPageFetcher
+
+        calls: list[tuple[str, str | None]] = []
+        underlying_result = SubmissionsPageResult(payload={"y": 2}, last_modified="lm2", not_modified=False)
+
+        class _Stub:
+            def fetch_submissions_page_conditional(self, name, *, if_modified_since=None):  # type: ignore[no-untyped-def]
+                calls.append((name, if_modified_since))
+                return underlying_result
+
+        wrapped = _CachedSubmissionsPageFetcher(_Stub(), {})
+        assert wrapped.fetch_submissions_page_conditional("page", if_modified_since="ims") is underlying_result
+        assert calls == [("page", "ims")]
+        assert wrapped.cache_misses == 1
+        assert wrapped.cache_hits == 0


### PR DESCRIPTION
## Summary

- Bootstrap-mode S14 (`sec_submissions_files_walk`) prefetches every secondary `CIK<10>-submissions-NNN.json` page concurrently (4-way via existing `PipelinedSecFetcher` at the shared 7 req/s ceiling) BEFORE the per-CIK upsert loop runs.
- Steady-state cron path UNCHANGED — walker self-detects bootstrap mode via `resolve_progress_context()` (no new params; `_adapt_zero_arg` discards `StageSpec.params`).
- Chunk-and-drain (`DEFAULT_PREFETCH_CHUNK_SIZE=1000`) bounds peak heap to ~150-200 MB per chunk. Per-chunk telemetry drained into `FilesWalkResult` before chunk-boundary `del`.

## Retargeted from original ticket

Original #1341 prescription was master.idx walk. Grep-verified premise gap: master.idx writes `sec_filing_manifest`; S14 writes `filing_events` with per-accession `primary_document_url` that downstream parsers (`business_summary.py:1419`, `eight_k_events.py:734`, `ownership_observations_sync.py:225`, `rewash_filings.py:298`, `def14a_ingest.py`) depend on. master.idx primary URL is the complete-submission `.txt`, NOT the per-accession primary doc — substituting silently breaks those parsers. Also: `sec_filing_manifest` master.idx parity is already covered today by `sec_master_idx_quarterly_sweep` (`app/jobs/sec_master_idx_quarterly_sweep.py`).

This PR keeps S14 correctness; parallelises the dominant cost (per-page HTTP RTT) via the existing `PipelinedSecFetcher` pattern established at `app/services/business_summary.py:1717`, `app/services/def14a_ingest.py:1006`, `app/services/eight_k_events.py:773`.

## Wall-clock target

S14 baseline (Run #7): ~41 min wall-clock.
Phase 2 acceptance (master plan §7): S14 < 10 min.
Measurement: R3 measurement run (operator-driven, post-merge).

## Spec

`docs/proposals/etl/1341-s14-pipelined-fetch.md` v1.4 — 22-section template + §0 grep proof. Codex 1 CLEAN through 4 re-passes (folded 5 BLOCKING + 12 IMPORTANT + 6 NIT across the iteration).

## Changes

| File | Change |
|---|---|
| `app/services/sec_pipelined_fetcher.py` | NEW `ConditionalFetchTask`, `prefetch_submissions_pages_conditional`, `_CachedSubmissionsPageFetcher`. `DEFAULT_PREFETCH_CHUNK_SIZE=1000`. Mirrors existing `prefetch_document_texts` + `_CachedDocFetcher` pattern. |
| `app/services/sec_submissions_files_walk.py` | Refactored `walk_files_pages` to chunk-and-drain. NEW helpers: `_load_all_watermarks_for_pages` (one SELECT instead of ~17k per-page `get_watermark` calls), `_chunked` slicing iterator, `_process_one_page` (extracted from nested loop). NEW telemetry fields: `prefetch_pages_seeded`, `loop_pages_from_prefetch`, `loop_pages_from_sync_fallback`, `prefetch_window_seconds_total`. Progress-target denominator now correctly `len(targets) + len(fetch_tasks_ordered)` (set AFTER flatten so processed cannot overshoot). |
| `tests/test_sec_pipelined_fetcher.py` | NEW 10 unit tests covering `prefetch_submissions_pages_conditional` (200/304/404/429/5xx/malformed-JSON trichotomy + dedupe + IMS header propagation) + `_CachedSubmissionsPageFetcher` (cache hit/miss + counters). |
| `tests/test_s14_uses_sidecar.py` | NEW 11 unit tests covering `_chunked`, `_load_all_watermarks_for_pages`, and walker chunk-and-drain control flow (bootstrap chunks 2500-task cohort into 3 disjoint slices; steady-state skips prefetch; short-circuit targets do not appear in fetch tasks). |

## Sink interaction (per spec §8)

`filing_events` writers: `_upsert_filing` (S14 + 4 other callers — overwrites URL columns on conflict), `_upsert_filing_event` (8-K single-accession — overwrites), `_upsert_filing_from_master_index` (master-index reconcile — COALESCEs to preserve existing URLs). Per-accession URLs always win — interaction unchanged from pre-#1341 (this PR is a pure perf rewrite of the HTTP layer).

## Test plan

- [x] `uv run ruff check` — PASS
- [x] `uv run ruff format --check` — PASS
- [x] `uv run pyright` — PASS on touched files
- [x] 21 new unit tests PASS locally (`tests/test_sec_pipelined_fetcher.py::TestPrefetchSubmissionsPagesConditional`, `::TestCachedSubmissionsPageFetcher`; `tests/test_s14_uses_sidecar.py::TestS14ChunkedHelpers`, `::TestS14LoadAllWatermarks`, `::TestS14ChunkAndDrainShape`)
- [ ] CI runs full pytest including 4 existing DB-dependent S14 integration tests against Postgres service
- [ ] Operator-driven R3 measurement run post-merge: S14 wall-clock < 10 min on clean-DB bootstrap (Phase 2 acceptance gate)

## ETL clauses (CLAUDE.md DoD)

- **Smoke panel (clause 8):** AAPL/GME/MSFT/JPM/HD verification deferred to R3 measurement run — this PR is purely the HTTP-layer perf rewrite; no semantic change so existing pre-merge integration tests (already pinning `test_no_primary_fetch_when_sidecar_has_real_pages` contract + delta-based counter assertions) cover correctness.
- **Cross-source (clause 9):** AAPL `filing_events` row count vs SEC EDGAR direct browser walk to be recorded in operator follow-up after R3.
- **Backfill (clause 10):** N/A — no schema/parser change. The walker re-runs each bootstrap and steady-state cron tick.
- **Operator-visible figure (clause 11):** S14 wall-clock observed in `bootstrap_stages` row + scheduled-job dashboard; R3 measurement records the figure.
- **Verification SHA (clause 12):** This PR's HEAD SHA records the verified-locally state (lint/format/pyright + 21 unit tests). R3 measurement appended post-merge.

## Local PG note

Local PG container is in WAL recovery OOM loop (operator-known issue per master-plan handoff). DB-dependent integration tests blocked locally; CI will run the full suite.

## Codex review

- Codex 1 (spec): CLEAN through 4 re-passes
- Codex 2 (diff): 0 BLOCKING + 0 IMPORTANT + 1 NIT (DB parity test deferred to CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes #1341