### PR TITLE
fix(#1340): S23 NPORT local-zip enumeration + S12 ingest-log seeding

### DIFF
--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import zipfile
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -66,6 +65,7 @@ from app.services.processes.bootstrap_cancel_signal import (
     bootstrap_cancel_requested,
 )
 from app.services.sec_manifest import is_amendment_form, map_form_to_source, record_manifest_entry
+from app.services.sec_submissions_zip import PRIMARY_SUBMISSIONS_URL_RE
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +75,9 @@ logger = logging.getLogger(__name__)
 # Secondary pages ``CIK<10>-submissions-<NNN>.json`` are NOT in the bulk
 # archive (canonical reference: app/services/sec_submissions_files_walk.py:16-23),
 # so the regex deliberately excludes them.
-_PRIMARY_SUBMISSIONS_URL_RE = re.compile(r"^https://data\.sec\.gov/submissions/CIK(\d{10})\.json$")
+# #1340 — single source of truth for the primary-URL contract, shared with
+# S23's ``ZipBackedArchiveFetcher`` so the two consumers cannot drift.
+_PRIMARY_SUBMISSIONS_URL_RE = PRIMARY_SUBMISSIONS_URL_RE
 
 
 def _make_zip_http_get(

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -332,12 +332,21 @@ Capability = Literal[
     #     largest write fanout of any audited pair (institutional 13F
     #     rows during a full bootstrap can total tens of millions).
     #
-    # Both caps are PROVIDED on SUCCESS by their respective bulk
+    #   * ``nport_dataset_processed`` (#1340) — S12 sec_nport_ingest_from_dataset
+    #     and S23 sec_n_port_ingest both write ``ownership_funds_observations``.
+    #     They run on different lanes (db vs sec_rate) so PR-2 ``as_completed``
+    #     parallelism would let them write concurrently. Same row-lock shape;
+    #     ALSO required for correctness — S23 reads the ``n_port_ingest_log``
+    #     rows S12 seeds (#1340) to skip bulk-loaded accessions, so S23 must
+    #     run after S12 commits.
+    #
+    # All caps are PROVIDED on SUCCESS by their respective bulk
     # ingester and ON SKIP for cascade-skip parity. Required by the
     # legacy stages downstream so they serialise after the bulk
     # ingester terminalises.
     "insider_dataset_processed",
     "institutional_dataset_processed",
+    "nport_dataset_processed",
 ]
 
 
@@ -383,7 +392,7 @@ _STAGE_PROVIDES: Final[dict[str, tuple[Capability, ...]]] = {
         "institutional_inputs_seeded",
         "institutional_dataset_processed",
     ),
-    "sec_nport_ingest_from_dataset": ("nport_inputs_seeded",),
+    "sec_nport_ingest_from_dataset": ("nport_inputs_seeded", "nport_dataset_processed"),
     "sec_submissions_files_walk": ("submissions_secondary_pages_walked",),
     "filings_history_seed": ("filing_events_seeded",),
     # sec_first_install_drain runs with follow_pagination=True
@@ -429,6 +438,11 @@ _STAGE_PROVIDES_ON_SKIP: Final[dict[str, tuple[Capability, ...]]] = {
     # ``submissions_processed`` cascade-skip entry.
     "sec_insider_ingest_from_dataset": ("insider_dataset_processed",),
     "sec_13f_ingest_from_dataset": ("institutional_dataset_processed",),
+    # #1340 — S12 NPORT bulk ingester. Cascade-skip parity: if S7 is
+    # skipped on slow-connection fallback, S12 cascade-skips but the
+    # ordering cap still flows so S23 proceeds (it falls back to the
+    # full HTTP enumeration path with an empty n_port_ingest_log).
+    "sec_nport_ingest_from_dataset": ("nport_dataset_processed",),
 }
 
 
@@ -517,6 +531,7 @@ _ORDERING_ONLY_CAPS: Final[frozenset[Capability]] = frozenset(
         "submissions_processed",
         "insider_dataset_processed",
         "institutional_dataset_processed",
+        "nport_dataset_processed",
     }
 )
 
@@ -589,7 +604,11 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
     "sec_form3_ingest": CapRequirement(all_of=("cik_mapping_ready", "insider_dataset_processed")),
     "sec_8k_events_ingest": CapRequirement(all_of=("filing_events_seeded", "submissions_secondary_pages_walked")),
     "sec_13f_recent_sweep": CapRequirement(all_of=("cik_mapping_ready", "institutional_dataset_processed")),
-    "sec_n_port_ingest": CapRequirement(all_of=("cik_mapping_ready",)),
+    # #1340 — ``nport_dataset_processed`` orders S23 after S12 (the bulk NPORT
+    # ingester): both write ``ownership_funds_observations`` (lock contention)
+    # AND S23 reads the ``n_port_ingest_log`` rows S12 seeds to skip bulk-loaded
+    # accessions, so S12 must commit first.
+    "sec_n_port_ingest": CapRequirement(all_of=("cik_mapping_ready", "nport_dataset_processed")),
     # #1174 — dedicated MF directory refresh + N-CSR drain (S25 + S26).
     "mf_directory_sync": CapRequirement(all_of=("universe_seeded",)),
     "sec_n_csr_bootstrap_drain": CapRequirement(all_of=("class_id_mapping_ready",)),
@@ -1177,8 +1196,15 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
         # dispatch ``sec_n_port_ingest`` with empty params → full
         # cohort (safety-net for previously-inactive trusts re-
         # emerging).
+        # #1340 — ``use_bulk_zip=True`` routes the PRIMARY per-CIK
+        # ``submissions/CIK<10>.json`` enumeration reads through the local
+        # submissions.zip (S7 landed it; S8/S16 leave it on disk per the
+        # #1340 deletion deferral) instead of HTTP. Document bodies + zip
+        # misses still hit HTTP. Bootstrap-only via JOB_INTERNAL_KEYS —
+        # manual API path rejects. S23 deletes the zip on its success path.
         params={
             "min_last_seen_filed_at": _PARAM_DYNAMIC_BOOTSTRAP_NPORT_CUTOFF,
+            "use_bulk_zip": True,
         },
     ),
     _spec("ownership_observations_backfill", 24, "db", "ownership_observations_backfill"),

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -190,7 +190,11 @@ JOB_INTERNAL_KEYS: dict[str, frozenset[str]] = {
     # exposing it on the manual API would let an operator accidentally
     # drop the standalone path's full-cohort safety-net (mirror of the
     # ``min_last_13f_hr_at`` posture on sec_13f_quarterly_sweep above).
-    "sec_n_port_ingest": frozenset({"min_last_seen_filed_at"}),
+    # #1340 — ``use_bulk_zip`` routes PRIMARY per-CIK submissions.json
+    # enumeration reads to the local bulk archive on the bootstrap path
+    # (same posture + freshness caveat as sec_first_install_drain above).
+    # Manual API rejects it for the same on-disk-freshness reason.
+    "sec_n_port_ingest": frozenset({"min_last_seen_filed_at", "use_bulk_zip"}),
 }
 
 

--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -80,6 +80,9 @@ class NPortIngestResult:
     rows_skipped_bad_data: int = 0
     rows_skipped_retention: int = 0  # PR7 #1233 §4.6
     parse_errors: int = 0
+    # #1340 — distinct accessions seeded into n_port_ingest_log so the per-CIK
+    # HTTP sweep (S23) skips bulk-loaded filings.
+    ingest_log_rows_seeded: int = 0
     touched_instrument_ids: set[int] = field(default_factory=set)
 
 
@@ -366,6 +369,51 @@ DO UPDATE SET
 """
 
 
+# #1340 — seed ``n_port_ingest_log`` from the same staging table so the per-CIK
+# HTTP sweep (``sec_n_port_ingest`` / S23) skips every accession the bulk path
+# already loaded (its ``_existing_accessions_for_fund_filer`` reads this log
+# regardless of status). Set-based, one statement, no per-row round-trips.
+# Grouped by accession (the log PK); ``MAX(fund_series_id)`` picks one of the
+# accession's series for the informational column — every staged value already
+# satisfies the ``^S[0-9]{9}$`` CHECK (it passed the observations drain above).
+# ``status='success'`` is honest for a SEEDED accession: every seeded
+# accession had all its in-universe holdings resolved (recoverable-miss
+# accessions are excluded via ``%(unresolved_accns)s``), so S23 re-fetching
+# it would yield nothing new. ``COUNT(*)`` is the staged-row count for the
+# accession (an informational figure; the DISTINCT-ON drain may collapse a
+# handful of duplicate holding-ids, so it is an upper bound, not an exact
+# landed count). Runs BEFORE commit while ``_stg_nport`` (ON COMMIT DROP)
+# is alive, and BEFORE ``series_upsert_buffer.clear()``.
+_SEED_NPORT_INGEST_LOG_SQL = """
+INSERT INTO n_port_ingest_log (
+    accession_number, filer_cik, fund_series_id, period_of_report,
+    status, holdings_inserted, holdings_skipped, error
+)
+SELECT
+    source_accession,
+    MAX(fund_filer_cik),
+    MAX(fund_series_id),
+    MAX(period_end),
+    'success',
+    COUNT(*),
+    0,
+    NULL
+FROM _stg_nport
+WHERE source_accession IS NOT NULL
+  AND source_accession <> ALL(%(unresolved_accns)s::text[])
+GROUP BY source_accession
+ON CONFLICT (accession_number) DO UPDATE SET
+    filer_cik = EXCLUDED.filer_cik,
+    fund_series_id = EXCLUDED.fund_series_id,
+    period_of_report = EXCLUDED.period_of_report,
+    status = EXCLUDED.status,
+    holdings_inserted = EXCLUDED.holdings_inserted,
+    holdings_skipped = EXCLUDED.holdings_skipped,
+    error = EXCLUDED.error,
+    fetched_at = NOW()
+"""
+
+
 # ---------------------------------------------------------------------------
 # Public entrypoint
 # ---------------------------------------------------------------------------
@@ -423,6 +471,16 @@ def ingest_nport_dataset_archive(
     # #1233 PR-1a — buffer of (cusip, filer_cik, period_end) triples
     # for every unresolved-CUSIP holding. Mirrors the 13F path.
     unresolved_buffer: list[tuple[str, str, date]] = []
+
+    # #1340 — accessions with at least one holding whose CUSIP is valid but
+    # NOT YET in the cusip_map (buffered above for the S13 OpenFIGI sweep).
+    # These are RECOVERABLE: a later resolution could ingest the held-back
+    # holdings, so S23's per-CIK sweep must keep them re-fetchable. We
+    # therefore EXCLUDE these accessions from the n_port_ingest_log seed
+    # below — only fully-resolved accessions are marked done. (Empty-CUSIP
+    # holdings are permanently unresolvable for everyone, so accessions that
+    # only lose empty-CUSIP rows stay eligible to seed.)
+    unresolved_accns: set[str] = set()
 
     # PR-3: CREATE TEMP TABLE before opening the COPY context.
     with conn.cursor() as cur:
@@ -563,6 +621,10 @@ def ingest_nport_dataset_archive(
                     if filer_cik_raw_buf and period_end_early is not None:
                         filer_cik_buf = filer_cik_raw_buf.zfill(10)
                         unresolved_buffer.append((cusip, filer_cik_buf, period_end_early))
+                    # #1340 — recoverable miss: hold this accession back from
+                    # the n_port_ingest_log seed so S23 can re-fetch it after
+                    # the CUSIP resolves.
+                    unresolved_accns.add(accn)
                     result.rows_skipped_unresolved_cusip += 1
                     continue
 
@@ -690,6 +752,19 @@ def ingest_nport_dataset_archive(
             )
             series_failed.add(series_id)
             result.parse_errors += 1
+
+    # #1340 — seed n_port_ingest_log from staging so S23's per-CIK HTTP sweep
+    # skips the accessions this bulk path FULLY loaded. Accessions with any
+    # recoverable (valid-but-unmapped) CUSIP are held back so S23 can still
+    # re-fetch them after resolution. Must run before commit (while _stg_nport
+    # is alive) and before the buffer clear below.
+    with conn.cursor() as cur:
+        cur.execute(
+            _SEED_NPORT_INGEST_LOG_SQL,
+            {"unresolved_accns": sorted(unresolved_accns)},
+        )
+        result.ingest_log_rows_seeded = cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+
     series_upsert_buffer.clear()
 
     # Flush accumulated unresolved CUSIPs AFTER the staging drain so

--- a/app/services/sec_submissions_zip.py
+++ b/app/services/sec_submissions_zip.py
@@ -1,0 +1,119 @@
+"""Local ``submissions.zip`` accelerator for bootstrap SEC stages (#1340).
+
+The bulk ``submissions.zip`` archive published by SEC contains every CIK's
+primary ``CIK<10>.json`` submissions index. Bootstrap stages that would
+otherwise issue one per-CIK HTTP fetch of
+``https://data.sec.gov/submissions/CIK<10>.json`` to enumerate a filer's
+accessions can instead read that entry from the already-landed local archive,
+eliminating thousands of rate-limited HTTP round-trips.
+
+Two consumers share this module so the primary-URL contract cannot drift:
+
+* **S16 first-install drain** (#1277) — ``HttpGet``-shaped; imports
+  :data:`PRIMARY_SUBMISSIONS_URL_RE` only (its ``_make_zip_http_get`` keeps its
+  own ``(int, bytes)`` routing).
+* **S23 N-PORT trust ingest** (#1340) — ``SecArchiveFetcher``-shaped; wraps a
+  real fetcher in :class:`ZipBackedArchiveFetcher`.
+
+Secondary pages ``CIK<10>-submissions-<NNN>.json`` are NOT in the bulk archive
+(canonical reference: ``app/services/sec_submissions_files_walk.py:16-23``), so
+:data:`PRIMARY_SUBMISSIONS_URL_RE` deliberately matches the primary index only.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import zipfile
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+# Primary submissions URL pattern. Routes ONLY the primary ``CIK<10>.json``
+# index to the local archive; secondary pages + every other URL fall through to
+# the real HTTP transport.
+PRIMARY_SUBMISSIONS_URL_RE = re.compile(r"^https://data\.sec\.gov/submissions/CIK(\d{10})\.json$")
+
+
+class _DocFetcher(Protocol):
+    """The single method :class:`ZipBackedArchiveFetcher` delegates to.
+
+    Structurally identical to ``app.services.n_port_ingest.SecArchiveFetcher``;
+    re-declared here to keep this module import-light (no dependency on the
+    N-PORT service)."""
+
+    def fetch_document_text(self, absolute_url: str) -> str | None: ...
+
+
+def match_primary_submissions_cik(url: str) -> str | None:
+    """Return the zero-padded 10-digit CIK if ``url`` is a primary submissions
+    URL, else ``None``."""
+    match = PRIMARY_SUBMISSIONS_URL_RE.match(url)
+    return match.group(1) if match is not None else None
+
+
+def read_zip_entry(zf: zipfile.ZipFile, entry_name: str) -> bytes | None:
+    """Return the bytes of ``entry_name`` from ``zf``.
+
+    Returns ``None`` when the member is absent (``KeyError``). Re-raises
+    ``zipfile.BadZipFile`` / ``OSError`` for the caller to handle (corrupt or
+    truncated member surfaced mid-read) — callers route those to an HTTP
+    fallback rather than dropping the resource.
+    """
+    try:
+        with zf.open(entry_name) as fh:
+            return fh.read()
+    except KeyError:
+        return None
+
+
+class ZipBackedArchiveFetcher:
+    """Wrap a :class:`_DocFetcher`; serve primary submissions URLs from a local
+    ``submissions.zip`` and delegate everything else to the wrapped fetcher.
+
+    The zip is a **pure accelerator, never a coverage reducer** (#1340 Codex 1
+    BLOCKING-1): only a clean zip HIT short-circuits the HTTP fetch. Every
+    non-hit — member absent, bad bytes, corrupt member, or a non-primary URL —
+    delegates to ``fallback.fetch_document_text`` so a trust newly present in
+    the directory but absent/stale in the local archive still gets its real
+    submissions fetch. (Contrast S16's ``_make_zip_http_get``, which returns a
+    ``404`` on miss because the drain records ``not_found`` via the manifest;
+    S23's ``fetch_document_text`` contract maps ``None`` to "no work for this
+    filer", so a miss MUST fall through to HTTP.)
+
+    Caller owns the open :class:`zipfile.ZipFile` lifecycle (``try/finally``),
+    mirroring ``_make_zip_http_get``.
+    """
+
+    def __init__(self, zf: zipfile.ZipFile, *, fallback: _DocFetcher) -> None:
+        self._zf = zf
+        self._fallback = fallback
+
+    def fetch_document_text(self, absolute_url: str) -> str | None:
+        cik = match_primary_submissions_cik(absolute_url)
+        if cik is None:
+            # Non-primary URL (NPORT-P document body, secondary page, other).
+            return self._fallback.fetch_document_text(absolute_url)
+        entry_name = f"CIK{cik}.json"
+        try:
+            data = read_zip_entry(self._zf, entry_name)
+        except (zipfile.BadZipFile, OSError) as exc:
+            logger.warning(
+                "submissions-zip: entry %s unreadable (%s) — delegating to HTTP",
+                entry_name,
+                exc,
+            )
+            return self._fallback.fetch_document_text(absolute_url)
+        if data is None:
+            # Member absent: trust newer than the archive (or stale archive).
+            # Fall through to the real fetcher to preserve coverage.
+            return self._fallback.fetch_document_text(absolute_url)
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            logger.warning(
+                "submissions-zip: entry %s not valid utf-8 (%s) — delegating to HTTP",
+                entry_name,
+                exc,
+            )
+            return self._fallback.fetch_document_text(absolute_url)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4793,13 +4793,12 @@ def sec_first_install_drain(params: Mapping[str, Any]) -> None:
 
     Internal-only invariants (NOT operator-exposed): ``follow_pagination=True``.
 
-    Disk-hygiene side effect: on SUCCESS, ``submissions.zip`` is
-    deleted from ``<data>/sec/bulk/`` regardless of which drain path
-    ran (zip or HTTP). S8 ``sec_submissions_ingest_job`` deferred its
-    deletion to here so the drain could observe the archive (#1277
-    BLOCKING-1 fold). Unconditional cleanup avoids orphaning the
-    archive on the ``use_bulk_zip=False`` rollback path (#1277
-    IMPORTANT-4 fold).
+    Disk-hygiene note: #1340 moved the post-drain ``submissions.zip``
+    deletion OUT of this stage. S23 ``sec_n_port_ingest`` now also reads
+    the archive (local-zip enumeration of trust submissions), so the
+    cleanup fires at S23's exit instead — see
+    ``_cleanup_submissions_zip_after_drain``. S16 leaves the archive on
+    disk for S23.
     """
     from app.jobs.sec_first_install_drain import run_first_install_drain
     from app.security.master_key import resolve_data_dir
@@ -4864,10 +4863,8 @@ def sec_first_install_drain(params: Mapping[str, Any]) -> None:
                 archive_path=archive_path,
                 max_subjects=max_subjects,
             )
-        # Unconditional post-drain disk-hygiene on the SUCCESS path. S8
-        # deferred its deletion to here. Bypassed when the drain raises
-        # (control flow leaves the with-block before this point).
-        _cleanup_submissions_zip_after_drain(candidate)
+        # #1340 — submissions.zip cleanup moved to S23 (sec_n_port_ingest),
+        # which now also consumes the archive. S16 no longer deletes it.
         tracker.row_count = stats.manifest_rows_upserted
         logger.info(
             "sec_first_install_drain: ciks_processed=%d skipped=%d "
@@ -4886,9 +4883,10 @@ def _cleanup_submissions_zip_after_drain(archive_path: Path) -> None:
 
     Mirrors ``_delete_archive_after_success`` semantics
     (`app/services/sec_bulk_orchestrator_jobs.py:136`). Lifecycle moved
-    from S8 to S16 per #1277 BLOCKING-1: S16 needs to read the archive,
-    so S8 can't drop it post-ingest. After S16 completes (either path),
-    no other stage consumes the zip — safe to delete.
+    S8 → S16 (#1277), then S16 → S23 (#1340): S23 ``sec_n_port_ingest``
+    reads the archive for local-zip enumeration of trust submissions, so
+    it runs after S16 and is the last bootstrap consumer of the zip. S23
+    calls this on its SUCCESS path.
     """
     try:
         archive_path.unlink(missing_ok=True)
@@ -5463,10 +5461,31 @@ def sec_n_port_ingest(params: Mapping[str, Any]) -> None:
         Admin "Run now" / manual sweep paths pass an empty dict, which
         resolves to ``None`` here → full cohort (safety-net for
         previously-inactive trusts re-emerging — #1010 precedent).
+      * ``use_bulk_zip`` (bool, bootstrap-only via JOB_INTERNAL_KEYS) —
+        route the PRIMARY per-CIK ``submissions/CIK<10>.json`` reads
+        (the S23 enumeration long-pole) through the local
+        ``submissions.zip`` that S7 landed (and S8/S16 left on disk per
+        the #1340 deletion deferral) instead of HTTP. NPORT-P document
+        bodies + any zip miss still hit HTTP. Provenance-verified
+        against the current bootstrap-run manifest. Default ``False``.
+        Spec: #1340.
+
+    Disk-hygiene side effect: on SUCCESS, ``submissions.zip`` is deleted
+    from ``<data>/sec/bulk/`` (S23 is the last bootstrap consumer of the
+    archive; #1340 moved the deletion here from S16). Unconditional on
+    the success path regardless of which enumeration path ran.
     """
-    from app.providers.implementations.sec_edgar import SecFilingsProvider
+    import zipfile
+
+    # ``SecFilingsProvider`` is imported at module scope (top of file); the S16
+    # invoker uses the module-level name too. No local re-import (keeps it
+    # patchable via ``scheduler.SecFilingsProvider`` and avoids shadowing).
+    from app.security.master_key import resolve_data_dir
+    from app.services.bootstrap_state import resolve_progress_context
     from app.services.n_port_ingest import ingest_all_fund_filers
+    from app.services.sec_bulk_download import assert_archive_belongs_to_run
     from app.services.sec_nport_filer_directory import list_nport_filer_ciks
+    from app.services.sec_submissions_zip import ZipBackedArchiveFetcher
 
     min_last_seen_filed_at = params.get("min_last_seen_filed_at")
     if min_last_seen_filed_at is not None and not isinstance(min_last_seen_filed_at, datetime):
@@ -5474,6 +5493,51 @@ def sec_n_port_ingest(params: Mapping[str, Any]) -> None:
             "sec_n_port_ingest: ``min_last_seen_filed_at`` must be a datetime; "
             f"got {type(min_last_seen_filed_at).__name__}"
         )
+
+    # #1340 IMPORTANT-2 mirror — strict bool; reject "false"/0/None coercion at
+    # the param boundary. Bootstrap dispatch passes a bool; this guards a future
+    # JSON-deserialised string regression.
+    use_bulk_zip_param = params.get("use_bulk_zip", False)
+    if isinstance(use_bulk_zip_param, bool):
+        use_bulk_zip = use_bulk_zip_param
+    else:
+        logger.warning(
+            "sec_n_port_ingest: use_bulk_zip must be bool, got %r — treating as False",
+            use_bulk_zip_param,
+        )
+        use_bulk_zip = False
+
+    target_dir = resolve_data_dir() / "sec" / "bulk"
+    candidate = target_dir / "submissions.zip"
+    # Whether this is a bootstrap dispatch — gates BOTH the zip provenance
+    # check AND the post-drain cleanup. Unlike S16 (bootstrap-only),
+    # ``sec_n_port_ingest`` ALSO runs monthly + via Admin "Run now"; outside
+    # bootstrap the submissions.zip lifecycle is owned by the bulk-download
+    # path, so S23 must not delete an archive it never managed.
+    progress_ctx = resolve_progress_context()
+    in_bootstrap = progress_ctx is not None
+
+    archive_path: Path | None = None
+    if use_bulk_zip:
+        if not candidate.exists():
+            logger.warning(
+                "sec_n_port_ingest: use_bulk_zip=True but %s missing — HTTP fallback",
+                candidate,
+            )
+            use_bulk_zip = False
+        elif progress_ctx is None:
+            logger.warning("sec_n_port_ingest: use_bulk_zip=True outside bootstrap dispatch — HTTP fallback")
+            use_bulk_zip = False
+        else:
+            try:
+                assert_archive_belongs_to_run(target_dir, "submissions.zip", bootstrap_run_id=progress_ctx.run_id)
+                archive_path = candidate
+            except Exception as exc:  # noqa: BLE001 — downgrade safety
+                logger.warning(
+                    "sec_n_port_ingest: archive provenance mismatch (%s) — HTTP fallback",
+                    exc,
+                )
+                use_bulk_zip = False
 
     deadline_seconds = settings.sec_n_port_sweep_deadline_seconds
 
@@ -5492,34 +5556,61 @@ def sec_n_port_ingest(params: Mapping[str, Any]) -> None:
             # ingest_all_fund_filers only sees min_period_of_report.
             # Codex 2 pre-push BLOCKING fold.
             from app.services.bootstrap_state import (
-                resolve_progress_context as _resolve_progress_context_s23,
-            )
-            from app.services.bootstrap_state import (
                 set_stage_target as _set_stage_target_s23,
             )
 
-            _progress_ctx_s23 = _resolve_progress_context_s23()
-            if _progress_ctx_s23 is not None:
+            if progress_ctx is not None:
                 _fp_s23 = (
                     f"min_last_seen_filed_at="
                     f"{min_last_seen_filed_at.date().isoformat() if min_last_seen_filed_at else 'none'};"
                     f"deadline_seconds={deadline_seconds if deadline_seconds is not None else 'none'};"
+                    f"use_bulk_zip={use_bulk_zip};"
                     f"directory=sec_nport_filer_directory"
                 )
                 _set_stage_target_s23(
-                    run_id=_progress_ctx_s23.run_id,
-                    stage_key=_progress_ctx_s23.stage_key,
+                    run_id=progress_ctx.run_id,
+                    stage_key=progress_ctx.stage_key,
                     target_count=len(ciks),
                     cohort_fingerprint=_fp_s23,
                 )
 
-            summaries = ingest_all_fund_filers(
-                conn,
-                sec,
-                ciks=ciks,
-                deadline_seconds=deadline_seconds,
-                source_label="sec_n_port_ingest",
-            )
+            # #1340 — wrap the real fetcher so PRIMARY submissions reads hit the
+            # local zip; the ZipFile lifecycle is caller-owned (try/finally).
+            # A corrupt/truncated archive that passed exists()+provenance must
+            # NOT fail S23 — open errors downgrade to HTTP (zip = pure
+            # accelerator, never a hard dependency). Codex 2 BLOCKING fold.
+            fetcher: Any = sec
+            zip_handle: zipfile.ZipFile | None = None
+            if archive_path is not None:
+                try:
+                    zip_handle = zipfile.ZipFile(archive_path)
+                    fetcher = ZipBackedArchiveFetcher(zip_handle, fallback=sec)
+                except (zipfile.BadZipFile, OSError) as exc:
+                    logger.warning(
+                        "sec_n_port_ingest: submissions.zip unreadable (%s) — HTTP fallback",
+                        exc,
+                    )
+                    zip_handle = None
+                    fetcher = sec
+            try:
+                summaries = ingest_all_fund_filers(
+                    conn,
+                    fetcher,
+                    ciks=ciks,
+                    deadline_seconds=deadline_seconds,
+                    source_label="sec_n_port_ingest",
+                )
+            finally:
+                if zip_handle is not None:
+                    zip_handle.close()
+
+        # #1340 — post-drain disk-hygiene on the SUCCESS path (after the
+        # with-block; bypassed when the body raises). BOOTSTRAP ONLY: S23 is
+        # the last bootstrap consumer of submissions.zip and owns its deletion
+        # there. Outside bootstrap the archive belongs to the bulk-download
+        # lifecycle — S23 must not delete it (Codex 2 IMPORTANT fold).
+        if in_bootstrap:
+            _cleanup_submissions_zip_after_drain(candidate)
 
         total_filers = len(ciks)
         processed = len(summaries)

--- a/docs/proposals/etl/1340-s23-nport-local-zip.md
+++ b/docs/proposals/etl/1340-s23-nport-local-zip.md
@@ -1,0 +1,278 @@
+# #1340 — S23 NPORT trust ingest: local-zip enumeration + bulk-seeded skip
+
+Status: PROPOSAL (Codex 1 pending)
+Phase: bootstrap-sub-1h master plan v5.2 §7 Phase 2 row 4
+Sibling precedent: #1277 (S16 local-zip), #1341 (S14 pipelined)
+
+## 1. Problem
+
+Bootstrap stage **S23 `sec_n_port_ingest`** (HTTP-walks `sec_nport_filer_directory`
+trust cohort, ingests pending NPORT-P / NPORT-P/A into
+`ownership_funds_observations`) is a long pole. Acceptance: S23 < 10 min.
+
+The dominant cost is **one per-trust-CIK HTTP fetch of the primary
+`https://data.sec.gov/submissions/CIK<10>.json`** to enumerate accessions,
+fired *before* any skip check:
+
+- `app/services/n_port_ingest.py:732` — `submissions_payload = sec.fetch_document_text(_submissions_url(cik))`
+- skip-vs-`n_port_ingest_log` happens *after*, at `n_port_ingest.py:745-749`.
+
+Cohort ≈ 3-4k active trusts (post-#1010 `min_last_seen_filed_at` bound). At the
+shared `sec_rate` ≈ 7-10 req/s ceiling, ~3.5k enumeration fetches ≈ 6-8 min
+*before* any document body is fetched.
+
+Secondary redundancy: **S12 `sec_nport_ingest_from_dataset`** already loaded the
+current-quarter NPORT-P holdings from the bulk `nport.zip` into
+`ownership_funds_observations` — but it does **not** write `n_port_ingest_log`,
+so S23 re-fetches + re-parses those same current-quarter accessions over HTTP.
+
+## 2. Why the original ticket design is retargeted
+
+Issue #1340 prescribed (a) `ManifestSubjectType` enum addition (`nport_trust`),
+(b) NPORT-trust manifest extraction from `submissions.zip`, (c) S23 fast-path
+`if subject_type=='nport_trust' and _bulk_already_seeded(conn, cik): continue`.
+
+Grep-verified against the code, all three premises fail (same class as #1341):
+
+| Ticket premise | Reality (file:line) |
+|---|---|
+| Requires `ManifestSubjectType` enum addition | `fund_series` already in the Literal (`sec_manifest.py:137`) + DB CHECK (`sql/118:50`). N-PORT manifest rows already carry `institutional_filer`/`fund_series` (`manifest_parsers/sec_n_port.py:28-30`). No new value needed. |
+| S23 fast-path keys on `sec_filing_manifest.subject_type` | S23 never reads the manifest; it skips via `n_port_ingest_log` (`n_port_ingest.py:621-634`). `_bulk_already_seeded` does not exist (grep: 0 matches). |
+| `submissions.zip` *manifest* extraction is the upstream half | `sec_submissions_files_walk.py` emits **no** NPORT rows and walks only tradable *issuer* CIKs (`:181 WHERE …is_tradable=TRUE`), never trust CIKs. |
+
+Retarget approved by operator 2026-05-28 → **local-zip enumeration + S12 bulk-seeded
+skip** (this spec). Mirrors the established #1277/#1341 local-zip pattern; no
+manifest, no enum.
+
+## 3. Design
+
+Two complementary changes + the supporting cap-gate and zip-lifecycle move.
+
+### 3.1 Local-zip submissions enumeration (the dominant win)
+
+S23's per-CIK primary `submissions/CIK<10>.json` reads route to the already-landed
+local `submissions.zip` (1.54 GB; contains **every** CIK incl. trusts) instead of
+HTTP — identical to #1277's S16 fix, adapted to S23's `SecArchiveFetcher` protocol.
+
+**New shared module `app/services/sec_submissions_zip.py`** — single source of
+truth for the primary-URL contract, so S16 and S23 cannot drift:
+
+```python
+PRIMARY_SUBMISSIONS_URL_RE = re.compile(r"^https://data\.sec\.gov/submissions/CIK(\d{10})\.json$")
+
+def match_primary_submissions_cik(url: str) -> str | None:
+    """Return the zero-padded 10-digit CIK if url is a primary submissions URL, else None."""
+
+def read_zip_entry(zf: zipfile.ZipFile, entry_name: str) -> bytes | None:
+    """Return entry bytes, or None on KeyError (member absent). Raises on BadZipFile/OSError."""
+
+class ZipBackedArchiveFetcher:
+    """Wrap a SecArchiveFetcher; route primary submissions URLs to a local ZipFile.
+    fetch_document_text(url) -> str | None:
+      - primary URL, zip HIT → decode utf-8, return str
+      - primary URL, zip MISS or any zip/decode error → DELEGATE to wrapped fetcher
+      - non-primary URL (NPORT-P doc bodies, secondary pages) → delegate to wrapped fetcher
+    Caller owns the open ZipFile lifecycle (try/finally), mirroring _make_zip_http_get."""
+```
+
+- **`app/jobs/sec_first_install_drain.py`** changes ONE line: its local
+  `_PRIMARY_SUBMISSIONS_URL_RE = re.compile(...)` becomes
+  `from app.services.sec_submissions_zip import PRIMARY_SUBMISSIONS_URL_RE`. Body
+  of `_make_zip_http_get` otherwise unchanged → #1277's tests still pin S16
+  behaviour. (Minimal-risk reuse, no logic refactor of merged code.)
+- **Zip is a pure accelerator, never a coverage reducer (Codex 1 BLOCKING-1).**
+  Unlike S16's `_make_zip_http_get` (returns `404` on miss because the drain
+  records `not_found` via the manifest), S23's `fetch_document_text` contract maps
+  `None` → "404/error → **no work for this filer**" (`n_port_ingest.py:732-735`).
+  A trust newly present in `sec_nport_filer_directory` but absent/stale in the
+  local `submissions.zip` would then be silently dropped. So `ZipBackedArchiveFetcher`
+  **delegates to the wrapped HTTP fetcher on ANY non-hit**: `KeyError` (member
+  absent), `UnicodeDecodeError` (bad bytes), `BadZipFile`/`OSError` (corrupt/
+  truncated member). Only a clean zip HIT short-circuits HTTP. `read_zip_entry`
+  returns `None` on `KeyError` and *raises* on `BadZipFile`/`OSError`; the fetcher
+  catches both → delegate. utf-8 decode failure → delegate.
+- Net: the common case (trust in zip) does zero enumeration HTTP; the rare
+  miss/stale case falls through to one real HTTP fetch — preserving coverage.
+
+### 3.2 S23 invoker wiring (`scheduler.py::sec_n_port_ingest`, :5441)
+
+Mirror S16's invoker (`scheduler.py:4804-4881`) exactly:
+
+- New bootstrap-only param `use_bulk_zip` (bool, strict — non-bool → warn + False,
+  per #1277 IMPORTANT-2). Added to `JOB_INTERNAL_KEYS["sec_n_port_ingest"]`
+  (`param_metadata.py:159`) so the operator API path rejects it.
+- Resolve `candidate = resolve_data_dir()/"sec"/"bulk"/"submissions.zip"`
+  unconditionally (so cleanup fires on every path).
+- If `use_bulk_zip` AND `candidate.exists()` AND `resolve_progress_context() is not None`
+  AND `assert_archive_belongs_to_run(target_dir, "submissions.zip", bootstrap_run_id=ctx.run_id)`
+  passes → open zip, wrap `sec` in `ZipBackedArchiveFetcher`. Any failure → HTTP
+  fallback (downgrade-safe, log a warning), `use_bulk_zip=False`.
+- The `zipfile.ZipFile(archive_path)` open is **guarded** (Codex 2 BLOCKING):
+  a corrupt/truncated archive that passed `exists()` + provenance raises
+  `BadZipFile`/`OSError` → log + fall back to the raw HTTP fetcher (`zip_handle=None`,
+  `fetcher=sec`). The zip is a pure accelerator; an open failure never fails S23.
+- `try/finally`: close the ZipFile; then `_cleanup_submissions_zip_after_drain(candidate)`
+  on the SUCCESS path, **gated to bootstrap dispatch only** (see §3.4).
+- Bootstrap stage spec (`bootstrap_orchestrator.py:1180`) gains
+  `"use_bulk_zip": True` alongside the existing `min_last_seen_filed_at` sentinel.
+
+### 3.3 S12 writes `n_port_ingest_log` (skip current-quarter doc re-fetch)
+
+`sec_nport_dataset_ingest.py` — after the staging drain + series-upsert loop
+(`:674-689`), **still inside the orchestrator's per-archive transaction, before
+commit, and before any `series_upsert_buffer` mutation/clear** (Codex 1 finding 3),
+write one `n_port_ingest_log` row per distinct accession it loaded:
+
+- Source the `(accession, filer_cik, period_end, series_id)` tuples from the
+  existing `series_upsert_buffer` (already collected at `:598-606`), deduped to
+  distinct accession. The buffer is iterated read-only by the series loop and is
+  NOT cleared — confirm at implementation time (grep `series_upsert_buffer` for any
+  `.clear()`/reassignment) and place the log write after the loop while the list is
+  still populated.
+- Per-accession `holdings_inserted` count: `SELECT source_accession, COUNT(*) FROM
+  _stg_nport GROUP BY source_accession` issued **before commit** while `_stg_nport`
+  (`ON COMMIT DROP`) is still alive; it carries `source_accession` (the COPY column
+  written at `:630`).
+- `status='success'` (CHECK allows `success|partial|failed`; `_existing_accessions_for_fund_filer`
+  reads accessions *regardless of status* (`n_port_ingest.py:628`), so any value
+  triggers the S23 skip — `success` is the honest label for a seeded accession).
+- One set-based `INSERT … SELECT … FROM _stg_nport GROUP BY source_accession …
+  ON CONFLICT (accession_number) DO UPDATE` — no per-row round-trips, no buffer
+  dependency. `MAX(fund_series_id)` picks one of the accession's series for the
+  informational column (every staged value already satisfies `^S[0-9]{9}$` — it
+  passed the observations drain). `COUNT(*)` is the staged-row count (upper bound;
+  the DISTINCT-ON drain may collapse a few duplicate holding-ids — Codex 2 NIT,
+  documented inline; informational only).
+
+**Correctness — only fully-resolved accessions are seeded (Codex 2 BLOCKING-1)**:
+S12 must NOT mark an accession done if it held back any **recoverable** holding —
+a valid CUSIP not yet in the cusip_map, buffered for the S13 OpenFIGI sweep. If
+seeded, S23 would skip that accession forever and the held-back holdings would
+never be ingested even after the CUSIP resolves. So S12 tracks `unresolved_accns`
+(accessions with ≥1 valid-but-unmapped CUSIP holding) and the seed SQL excludes
+them: `AND source_accession <> ALL(%(unresolved_accns)s::text[])`. Empty-CUSIP
+holdings are permanently unresolvable for everyone, so an accession that only
+loses empty-CUSIP rows stays eligible. A seeded (clean) accession yields nothing
+new on S23 re-fetch — S23 applies identical equity/long/unit gates and reads a
+subset of the resolvers — so no coverage is lost. Only **current-quarter**
+accessions are in `nport.zip`; older quarters of S23's ~4-quarter horizon are not
+bulk-covered → S23 still HTTP-fetches those bodies (bounded; the dominant
+enumeration HTTP is eliminated by §3.1).
+
+### 3.4 Zip lifecycle: defer cleanup S16 → S23
+
+`submissions.zip` is deleted at **S16's exit** today
+(`scheduler.py:4870 _cleanup_submissions_zip_after_drain`). S23 runs *after* S16
+(stage_order 16 < 23, both `sec_rate` lane → serialised). So the zip is gone
+before S23 unless cleanup moves:
+
+- **S16**: remove the `_cleanup_submissions_zip_after_drain(candidate)` call
+  (`scheduler.py:4870`); update the docstring + the helper's comment
+  (`:4889-4891` "no other stage consumes the zip" is now false → "S23 consumes it").
+- **S23**: add the unconditional-on-success `_cleanup_submissions_zip_after_drain(candidate)`
+  at its exit (same shape S16 had).
+- **Helper sharing**: `_cleanup_submissions_zip_after_drain` is module-private in
+  `scheduler.py`; S23's invoker is in the same module → call directly.
+- **Cleanup fires on the SUCCESS path only, and only in bootstrap dispatch**
+  (Codex 2 IMPORTANT). Unlike S16 (bootstrap-only job), `sec_n_port_ingest` ALSO
+  runs monthly + via Admin "Run now" — outside bootstrap the `submissions.zip`
+  lifecycle is owned by the bulk-download path, so S23 must not delete an archive
+  it never managed. Gate: `if in_bootstrap` (`resolve_progress_context() is not None`).
+  In bootstrap, an S23 *error* still leaves the zip on disk (cleanup is after the
+  `with` block) so the dispatcher's retry can reuse it; only a clean success deletes.
+- **Skip-safety backstop (Codex 1 finding 2 — corrected)**: `raw_data_retention_sweep`
+  is scoped to `data/raw/**` only (`scheduler.py:839-844, 3864-3905`) — it does
+  **NOT** clean `<data>/sec/bulk/submissions.zip`. The real backstops are: (a) S23's
+  ordering cap `nport_dataset_processed` terminalises on *any* terminal status of
+  S12, so S23's body runs in every bootstrap that reaches stage 23 — the
+  never-runs case requires the run to be cancelled/abandoned before S23; (b) the
+  next bootstrap's `sec_bulk_download` re-download **overwrites the file in place**
+  (single 1.54 GB file, bounded — not unbounded growth) and provenance-stamps it to
+  the new run. A cancelled-before-S23 run therefore leaves at most one stale 1.54 GB
+  archive until the next bootstrap, which is the same residual #1277 accepted.
+- **Non-bootstrap S23** (monthly steady-state, empty params): `use_bulk_zip`
+  defaults False, `candidate` typically absent → `unlink(missing_ok=True)` no-ops.
+  No behaviour change.
+
+### 3.5 Ordering cap-gate S12 → S23 (correctness + latent contention fix)
+
+S12 (`db` lane) and S23 (`sec_rate` lane) run on **different lanes** → the
+dispatcher may run them concurrently. Both write `ownership_funds_observations`.
+This is the same latent row-lock contention the §6.5.10 audit fixed for
+S22↔S10 / S19↔S11 / S20↔S11 — and S23 now additionally needs S12's
+`n_port_ingest_log` rows *visible* before its skip check. One cap-gate solves both.
+
+Add `nport_dataset_processed` (ordering-only cap), mirroring
+`institutional_dataset_processed` exactly:
+
+- `_STAGE_PROVIDES["sec_nport_ingest_from_dataset"]` += `nport_dataset_processed`
+- `_STAGE_PROVIDES_ON_SKIP["sec_nport_ingest_from_dataset"]` += `nport_dataset_processed`
+  (slow-connection-fallback parity: bulk skip still unblocks S23)
+- `_STAGE_REQUIRES_CAPS["sec_n_port_ingest"]` = `all_of=("cik_mapping_ready", "nport_dataset_processed")`
+- add `"nport_dataset_processed"` to `_ORDERING_ONLY_CAPS` (terminalises on any
+  terminal status — "no concurrent writer remains")
+- register the new capability name in the `Capability` set / catalogue invariant.
+
+## 4. Files touched
+
+| File | Change |
+|---|---|
+| `app/services/sec_submissions_zip.py` | NEW — `PRIMARY_SUBMISSIONS_URL_RE`, `match_primary_submissions_cik`, `read_zip_entry`, `ZipBackedArchiveFetcher` |
+| `app/jobs/sec_first_install_drain.py` | import `PRIMARY_SUBMISSIONS_URL_RE` from shared module (drop local copy) |
+| `app/services/sec_nport_dataset_ingest.py` | write `n_port_ingest_log` per bulk-loaded accession (pre-commit) |
+| `app/workers/scheduler.py` | S23 invoker: `use_bulk_zip` + zip-fetcher + cleanup-at-exit; S16: drop cleanup call + fix comment |
+| `app/services/bootstrap_orchestrator.py` | S23 stage params `use_bulk_zip=True`; `nport_dataset_processed` cap (provides/provides_on_skip/requires/ordering-only/catalogue) |
+| `app/services/processes/param_metadata.py` | `JOB_INTERNAL_KEYS["sec_n_port_ingest"]` += `use_bulk_zip` |
+
+## 5. Tests
+
+- `sec_submissions_zip`: primary URL hit → zip str (utf-8 decoded); non-primary URL
+  → delegate; `read_zip_entry` returns None on KeyError, raises on BadZipFile/OSError.
+  `ZipBackedArchiveFetcher.fetch_document_text`: **every non-hit delegates to the
+  wrapped fetcher** — assert delegate called for (a) member-absent KeyError, (b)
+  UnicodeDecodeError on bad bytes, (c) BadZipFile/OSError, (d) non-primary URL; and
+  the wrapped result (incl. its `None`) is returned verbatim. A clean hit must NOT
+  call the wrapped fetcher.
+- S12 log-write: after a bulk ingest, `n_port_ingest_log` has one `success` row per
+  distinct loaded accession, correct `filer_cik`/`period_end`/`holdings_inserted`;
+  idempotent on re-run.
+- S23 invoker: `use_bulk_zip=True` + present provenance-valid zip → no per-CIK
+  primary HTTP (assert wrapped-fetcher routing via monkeypatched module attr,
+  #1341 seam style); zip absent → HTTP fallback; provenance mismatch → fallback;
+  cleanup fires on success path; non-bool `use_bulk_zip` → False.
+- S16: `_cleanup_submissions_zip_after_drain` no longer called by drain invoker
+  (zip survives to S23). #1277 zip-routing tests unaffected.
+- Cap-gate: catalogue invariant accepts `nport_dataset_processed`; S23 requires it;
+  S12 provides on success+skip; ordering-only set membership.
+- End-to-end skip: bulk-load accession A for trust T (writes log) → S23 over T with
+  zip enumeration skips A's body fetch (in `already` set), still ingests
+  un-bulk-covered older accession B.
+
+## 6. Floors / perf-claims
+
+This retarget touches `n_port_ingest_log` + `ownership_funds_observations` + the S23
+invoker — it does **NOT** touch `sec_filing_manifest` and runs **no** perf-bench
+against it. The deferred `sec_filing_manifest` floor seeder STUB obligation
+(handoff) therefore does not bind here; it stays deferred to a ticket that actually
+benches that table. `etl-perf-claims`: the < 10 min S23 claim is verified by the
+R3 measurement run wall-clock, not a synthetic bench.
+
+## 7. Acceptance
+
+- S23 bootstrap wall-clock < 10 min (eliminate ~3.5k per-CIK enumeration HTTP).
+- Smoke panel funds slice unchanged (AAPL/GME/MSFT/JPM/HD `ownership-funds-current`
+  row count within ±1% of pre-change).
+- Pre-push gate green (ruff/format/pyright + unit; PG-dependent tests via CI if dev
+  PG is in WAL-recovery — per #1346/#1277/#1341 precedent).
+
+## 8. Risks / conscious tradeoffs
+
+- **Disk window**: `submissions.zip` (1.54 GB) now on disk S8→S23 instead of S8→S16.
+  ~7 extra stages of residency. Accepted (#1277 already extended S8→S16).
+- **S27 N-CSR** runs after S23 and currently HTTP-walks (does not use the zip).
+  Deleting the zip at S23 does not regress N-CSR (it never read the zip). A future
+  ticket making N-CSR zip-aware would move cleanup further; out of #1340 scope.
+- **Status='success' on partial bulk loads**: a bulk accession with some
+  unresolved-CUSIP holdings is logged `success`. By §3.3 this is correct (no S23
+  re-fetch recovers them). Honest label; informational `holdings_inserted` reflects
+  what landed.

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -122,14 +122,18 @@ def test_stage_catalogue_lane_composition() -> None:
     by_lane: dict[str, int] = {}
     for spec in specs:
         by_lane[spec.lane] = by_lane.get(spec.lane, 0) + 1
-    # 1 + 1 + 16 + 1 + 7 + 1 = 27 stages.
+    # 1 + 1 + 16 + 1 + 6 + 1 + 1 = 27 stages.
     # The "+ 1 openfigi" is #1233 PR-1b's S13 cusip_resolver_post_bulk_sweep.
+    # ``db_fundamentals_raw`` carries S25 fundamentals_sync (Stream A PR-C2
+    # lane reassignment); this expectation was stale pre-#1340 (expected
+    # db:7 before the split — corrected here to match production).
     assert by_lane == {
         "init": 1,
         "etoro": 1,
         "sec_rate": 16,
         "sec_bulk_download": 1,
-        "db": 7,
+        "db": 6,
+        "db_fundamentals_raw": 1,
         "openfigi": 1,
     }
 
@@ -827,6 +831,27 @@ def test_dataset_processed_caps_provided_by_bulk_ingesters_on_success_and_skip()
     assert "insider_dataset_processed" in _STAGE_PROVIDES_ON_SKIP["sec_insider_ingest_from_dataset"]
     assert "institutional_dataset_processed" in _STAGE_PROVIDES["sec_13f_ingest_from_dataset"]
     assert "institutional_dataset_processed" in _STAGE_PROVIDES_ON_SKIP["sec_13f_ingest_from_dataset"]
+    # #1340 — NPORT family: S12 bulk provides on success + skip.
+    assert "nport_dataset_processed" in _STAGE_PROVIDES["sec_nport_ingest_from_dataset"]
+    assert "nport_dataset_processed" in _STAGE_PROVIDES_ON_SKIP["sec_nport_ingest_from_dataset"]
+
+
+def test_n_port_ingest_requires_nport_dataset_processed() -> None:
+    """#1340 — S23 (sec_n_port_ingest) and S12 (sec_nport_ingest_from_dataset)
+    both write ``ownership_funds_observations`` AND S23 reads the
+    ``n_port_ingest_log`` rows S12 seeds (to skip bulk-loaded accessions).
+    The ordering cap serialises S23 after S12 commits — fixes both the
+    cross-lane (db vs sec_rate) lock contention and the visibility race.
+    """
+    from app.services.bootstrap_orchestrator import _ORDERING_ONLY_CAPS
+
+    s23 = _STAGE_REQUIRES_CAPS["sec_n_port_ingest"]
+    assert "nport_dataset_processed" in s23.all_of, (
+        "sec_n_port_ingest must require nport_dataset_processed (#1340 lock-contention + log-visibility serialisation)"
+    )
+    assert "nport_dataset_processed" in _ORDERING_ONLY_CAPS, (
+        "nport_dataset_processed must be an ordering-only cap (terminalises on any terminal status of S12)"
+    )
 
 
 def test_ordering_only_caps_disjoint_from_strict_gate_caps() -> None:
@@ -848,6 +873,7 @@ def test_ordering_only_caps_disjoint_from_strict_gate_caps() -> None:
             "submissions_processed",
             "insider_dataset_processed",
             "institutional_dataset_processed",
+            "nport_dataset_processed",
         }
     ), (
         "_ORDERING_ONLY_CAPS membership changed without updating the test. "

--- a/tests/test_scheduler_sec_first_install_drain_invoker.py
+++ b/tests/test_scheduler_sec_first_install_drain_invoker.py
@@ -7,8 +7,13 @@ Covers T6 / T6b / T6c (spec §4) without requiring a live PG:
   * Archive provenance mismatch downgrades to HTTP.
   * Outside-bootstrap-dispatch downgrades to HTTP.
   * Missing archive downgrades to HTTP.
-  * Unconditional cleanup deletes the archive on success regardless of path.
-  * Cleanup is bypassed when ``run_first_install_drain`` raises.
+
+#1340 UPDATE: S16 no longer deletes ``submissions.zip``. S23
+``sec_n_port_ingest`` now also consumes the archive (local-zip
+enumeration) and is the last bootstrap consumer, so it owns the
+deletion. S16 PRESERVES the archive on every path — these tests assert
+the archive survives the drain (the deletion assertions moved to
+``tests/test_scheduler_sec_n_port_ingest_invoker.py``).
 
 These complement the integration tests in
 ``tests/test_sec_first_install_drain.py`` (T2 / T3) which exercise the
@@ -19,8 +24,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from app.jobs.sec_first_install_drain import DrainStats
 from app.services.bootstrap_state import BootstrapProgressContext
@@ -132,8 +135,8 @@ class TestSchedulerInvoker:
         call = drain_spy.call_args
         assert call.kwargs["use_bulk_zip"] is False
         assert call.kwargs["archive_path"] is None
-        # Archive deleted unconditionally on success.
-        assert not archive.exists()
+        # #1340 — S16 preserves the archive for S23 (no longer deletes).
+        assert archive.exists()
 
     def test_outside_bootstrap_dispatch_downgrades(self, tmp_path: Path) -> None:
         # T6 — use_bulk_zip=True but no progress context → downgrade.
@@ -147,7 +150,8 @@ class TestSchedulerInvoker:
         call = drain_spy.call_args
         assert call.kwargs["use_bulk_zip"] is False
         assert call.kwargs["archive_path"] is None
-        assert not archive.exists()
+        # #1340 — S16 preserves the archive for S23.
+        assert archive.exists()
 
     def test_missing_archive_downgrades(self, tmp_path: Path) -> None:
         # T6 — use_bulk_zip=True but archive missing → downgrade.
@@ -163,7 +167,7 @@ class TestSchedulerInvoker:
         call = drain_spy.call_args
         assert call.kwargs["use_bulk_zip"] is False
         assert call.kwargs["archive_path"] is None
-        # Cleanup still tries; file already missing.
+        # File was never created; S16 doesn't create it.
         assert not archive.exists()
 
     def test_provenance_mismatch_downgrades(self, tmp_path: Path) -> None:
@@ -181,9 +185,8 @@ class TestSchedulerInvoker:
         call = drain_spy.call_args
         assert call.kwargs["use_bulk_zip"] is False
         assert call.kwargs["archive_path"] is None
-        # Archive STILL deleted post-drain — cleanup is unconditional
-        # (IMPORTANT-4 fold of #1277 spec v1.2).
-        assert not archive.exists()
+        # #1340 — S16 preserves the archive for S23 on every path.
+        assert archive.exists()
 
     def test_use_bulk_zip_true_with_provenanced_archive(self, tmp_path: Path) -> None:
         # T6 — use_bulk_zip=True + archive present + provenance passes →
@@ -198,30 +201,12 @@ class TestSchedulerInvoker:
         call = drain_spy.call_args
         assert call.kwargs["use_bulk_zip"] is True
         assert call.kwargs["archive_path"] == archive
-        # Archive deleted post-drain.
-        assert not archive.exists()
-
-    def test_cleanup_skipped_when_drain_raises(self, tmp_path: Path) -> None:
-        # T12 — drain raise leaves the archive on disk for operator
-        # triage. Control flow exits the with-block before
-        # _cleanup_submissions_zip_after_drain.
-        archive = _bulk_archive_at(tmp_path)
-        patches, drain_spy = _patch_invoker_dependencies(
-            archive,
-            progress_context=BootstrapProgressContext(run_id=42, stage_key="sec_first_install_drain"),
-        )
-        drain_spy.side_effect = RuntimeError("boom")
-        with _stack(patches):
-            with pytest.raises(RuntimeError, match="boom"):
-                scheduler.sec_first_install_drain({"use_bulk_zip": True})
-        assert archive.exists(), (
-            "Drain raise must leave submissions.zip on disk for operator triage — cleanup is on the success path only"
-        )
+        # #1340 — S16 preserves the archive for S23 (deletion moved to S23).
+        assert archive.exists()
 
     def test_use_bulk_zip_false_default_no_zip_path(self, tmp_path: Path) -> None:
         # Default-path sanity: use_bulk_zip omitted → drain called with
-        # use_bulk_zip=False + archive_path=None. Archive STILL deleted
-        # (unconditional cleanup; IMPORTANT-4).
+        # use_bulk_zip=False + archive_path=None.
         archive = _bulk_archive_at(tmp_path)
         patches, drain_spy = _patch_invoker_dependencies(
             archive,
@@ -232,6 +217,5 @@ class TestSchedulerInvoker:
         call = drain_spy.call_args
         assert call.kwargs["use_bulk_zip"] is False
         assert call.kwargs["archive_path"] is None
-        # Cleanup still fires — locks the rollback path's disk-clean
-        # invariant (T11b sibling).
-        assert not archive.exists()
+        # #1340 — S16 preserves the archive for S23 on the HTTP-default path too.
+        assert archive.exists()

--- a/tests/test_scheduler_sec_n_port_ingest_invoker.py
+++ b/tests/test_scheduler_sec_n_port_ingest_invoker.py
@@ -1,0 +1,191 @@
+"""Scheduler-invoker tests for ``sec_n_port_ingest`` local-zip path (#1340).
+
+Covers (no live PG):
+  * Strict-bool coercion of ``use_bulk_zip``.
+  * use_bulk_zip=True + provenanced archive → ingest gets a
+    ``ZipBackedArchiveFetcher``; archive deleted on success (S23 owns cleanup).
+  * Missing archive / outside dispatch / provenance mismatch → HTTP fallback
+    (the raw ``SecFilingsProvider`` is passed, not the zip wrapper).
+  * Cleanup is unconditional on the success path (mirrors S16's old invariant,
+    now owned by S23).
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.services.bootstrap_state import BootstrapProgressContext
+from app.services.sec_submissions_zip import ZipBackedArchiveFetcher
+from app.workers import scheduler
+
+
+def _patch_invoker_dependencies(
+    archive_path: Path,
+    *,
+    progress_context: BootstrapProgressContext | None,
+    assert_provenance_raises: Exception | None = None,
+):
+    fake_conn_ctx = MagicMock()
+    fake_conn_ctx.__enter__.return_value = MagicMock()
+    fake_conn_ctx.__exit__.return_value = False
+
+    sec_obj = MagicMock(name="SecFilingsProvider_instance")
+    fake_sec_ctx = MagicMock()
+    fake_sec_ctx.__enter__.return_value = sec_obj
+    fake_sec_ctx.__exit__.return_value = False
+
+    fake_tracker_ctx = MagicMock()
+    fake_tracker_ctx.__enter__.return_value = MagicMock()
+    fake_tracker_ctx.__exit__.return_value = False
+
+    def _assert_provenance(*args, **kwargs):
+        if assert_provenance_raises is not None:
+            raise assert_provenance_raises
+
+    ingest_spy = MagicMock(return_value=[])
+
+    patches = (
+        patch.object(scheduler, "SecFilingsProvider", return_value=fake_sec_ctx),
+        patch("psycopg.connect", return_value=fake_conn_ctx),
+        patch.object(scheduler, "_tracked_job", return_value=fake_tracker_ctx),
+        patch("app.services.n_port_ingest.ingest_all_fund_filers", ingest_spy),
+        patch(
+            "app.services.sec_nport_filer_directory.list_nport_filer_ciks",
+            return_value=["0000320193"],
+        ),
+        patch(
+            "app.security.master_key.resolve_data_dir",
+            return_value=archive_path.parents[2],
+        ),
+        patch(
+            "app.services.bootstrap_state.resolve_progress_context",
+            return_value=progress_context,
+        ),
+        patch("app.services.bootstrap_state.set_stage_target", MagicMock()),
+        patch(
+            "app.services.sec_bulk_download.assert_archive_belongs_to_run",
+            side_effect=_assert_provenance,
+        ),
+    )
+    return patches, ingest_spy, sec_obj
+
+
+def _stack(patches):
+    import contextlib
+
+    cm = contextlib.ExitStack()
+    for p in patches:
+        cm.enter_context(p)
+    return cm
+
+
+def _valid_bulk_archive_at(tmp_path: Path) -> Path:
+    """Write a REAL (openable) submissions.zip at <data>/sec/bulk/.
+
+    S23 opens the ZipFile in the invoker (unlike S16, which delegates to the
+    mocked drain), so the bytes must be a valid zip.
+    """
+    archive = tmp_path / "sec" / "bulk" / "submissions.zip"
+    archive.parent.mkdir(parents=True)
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("CIK0000320193.json", b'{"cik":"320193"}')
+    return archive
+
+
+class TestSecNPortIngestInvoker:
+    def test_strict_bool_non_bool_downgrades(self, tmp_path: Path) -> None:
+        archive = _valid_bulk_archive_at(tmp_path)
+        patches, ingest_spy, sec_obj = _patch_invoker_dependencies(
+            archive,
+            progress_context=BootstrapProgressContext(run_id=7, stage_key="sec_n_port_ingest"),
+        )
+        with _stack(patches):
+            scheduler.sec_n_port_ingest({"use_bulk_zip": "true"})
+        # String "true" is not a bool → HTTP fallback: raw provider passed.
+        assert ingest_spy.call_args.args[1] is sec_obj
+        # Cleanup unconditional on success.
+        assert not archive.exists()
+
+    def test_outside_bootstrap_dispatch_downgrades_and_preserves_archive(self, tmp_path: Path) -> None:
+        # No progress context = not a bootstrap dispatch (monthly / Admin run).
+        # Zip path downgraded AND the archive is preserved — outside bootstrap
+        # S23 does not own the submissions.zip lifecycle (#1340 Codex 2).
+        archive = _valid_bulk_archive_at(tmp_path)
+        patches, ingest_spy, sec_obj = _patch_invoker_dependencies(
+            archive,
+            progress_context=None,
+        )
+        with _stack(patches):
+            scheduler.sec_n_port_ingest({"use_bulk_zip": True})
+        assert ingest_spy.call_args.args[1] is sec_obj
+        assert archive.exists()
+
+    def test_corrupt_archive_downgrades_to_http(self, tmp_path: Path) -> None:
+        # Archive passes exists() + provenance but is not a valid zip → the
+        # ZipFile open raises BadZipFile → S23 must fall back to HTTP, not
+        # crash (#1340 Codex 2 BLOCKING: zip is a pure accelerator).
+        archive = tmp_path / "sec" / "bulk" / "submissions.zip"
+        archive.parent.mkdir(parents=True)
+        archive.write_bytes(b"not a zip at all")
+        patches, ingest_spy, sec_obj = _patch_invoker_dependencies(
+            archive,
+            progress_context=BootstrapProgressContext(run_id=7, stage_key="sec_n_port_ingest"),
+        )
+        with _stack(patches):
+            scheduler.sec_n_port_ingest({"use_bulk_zip": True})
+        # Fell back to the raw provider (no wrapper) and did not raise.
+        assert ingest_spy.call_args.args[1] is sec_obj
+        # In bootstrap → cleanup still fires.
+        assert not archive.exists()
+
+    def test_missing_archive_downgrades(self, tmp_path: Path) -> None:
+        archive = tmp_path / "sec" / "bulk" / "submissions.zip"
+        archive.parent.mkdir(parents=True)  # do NOT create the file
+        patches, ingest_spy, sec_obj = _patch_invoker_dependencies(
+            archive,
+            progress_context=BootstrapProgressContext(run_id=7, stage_key="sec_n_port_ingest"),
+        )
+        with _stack(patches):
+            scheduler.sec_n_port_ingest({"use_bulk_zip": True})
+        assert ingest_spy.call_args.args[1] is sec_obj
+        assert not archive.exists()
+
+    def test_provenance_mismatch_downgrades(self, tmp_path: Path) -> None:
+        archive = _valid_bulk_archive_at(tmp_path)
+        patches, ingest_spy, sec_obj = _patch_invoker_dependencies(
+            archive,
+            progress_context=BootstrapProgressContext(run_id=7, stage_key="sec_n_port_ingest"),
+            assert_provenance_raises=RuntimeError("run_id mismatch"),
+        )
+        with _stack(patches):
+            scheduler.sec_n_port_ingest({"use_bulk_zip": True})
+        # Provenance failure → fallback to raw provider, but archive STILL
+        # deleted post-drain (unconditional success-path cleanup).
+        assert ingest_spy.call_args.args[1] is sec_obj
+        assert not archive.exists()
+
+    def test_use_bulk_zip_true_wraps_fetcher_and_cleans(self, tmp_path: Path) -> None:
+        archive = _valid_bulk_archive_at(tmp_path)
+        patches, ingest_spy, _sec_obj = _patch_invoker_dependencies(
+            archive,
+            progress_context=BootstrapProgressContext(run_id=7, stage_key="sec_n_port_ingest"),
+        )
+        with _stack(patches):
+            scheduler.sec_n_port_ingest({"use_bulk_zip": True})
+        # The ingester received the zip-backed wrapper, not the raw provider.
+        assert isinstance(ingest_spy.call_args.args[1], ZipBackedArchiveFetcher)
+        # S23 owns the deletion now.
+        assert not archive.exists()
+
+    def test_default_no_zip_path(self, tmp_path: Path) -> None:
+        archive = _valid_bulk_archive_at(tmp_path)
+        patches, ingest_spy, sec_obj = _patch_invoker_dependencies(
+            archive,
+            progress_context=BootstrapProgressContext(run_id=7, stage_key="sec_n_port_ingest"),
+        )
+        with _stack(patches):
+            scheduler.sec_n_port_ingest({})
+        assert ingest_spy.call_args.args[1] is sec_obj
+        assert not archive.exists()

--- a/tests/test_sec_nport_dataset_ingest.py
+++ b/tests/test_sec_nport_dataset_ingest.py
@@ -165,6 +165,132 @@ class TestIngestNPortDatasetArchive:
             assert period.isoformat() == "2025-09-30"
             assert source == "nport"
 
+    def test_bulk_seeds_n_port_ingest_log(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # #1340 — every accession the bulk path loads gets a 'success'
+        # n_port_ingest_log row so the per-CIK HTTP sweep (S23) skips it.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        accn = "0001234567-25-000042"
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": accn,
+                    "FILING_DATE": "2025-11-30",
+                    "SUB_TYPE": "NPORT-P",
+                    "REPORT_DATE": "2025-09-30",
+                },
+            ],
+            registrants=[
+                {"ACCESSION_NUMBER": accn, "CIK": "1234567", "REGISTRANT_NAME": "Big Fund Trust"},
+            ],
+            fund_info=[
+                {"ACCESSION_NUMBER": accn, "SERIES_ID": "S000004310", "SERIES_NAME": "Big Fund Equity Series"},
+            ],
+            holdings=[
+                {
+                    "ACCESSION_NUMBER": accn,
+                    "HOLDING_ID": "1",
+                    "ISSUER_CUSIP": "037833100",
+                    "BALANCE": "500000",
+                    "UNIT": "NS",
+                    "CURRENCY_CODE": "USD",
+                    "CURRENCY_VALUE": "75000000",
+                    "PAYOFF_PROFILE": "Long",
+                    "ASSET_CAT": "EC",
+                },
+            ],
+        )
+        archive_path = tmp_path / "nport.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.ingest_log_rows_seeded == 1
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT filer_cik, fund_series_id, period_of_report, status, holdings_inserted
+                FROM n_port_ingest_log
+                WHERE accession_number = %s
+                """,
+                (accn,),
+            )
+            row = cur.fetchone()
+        assert row is not None, "bulk ingest must seed n_port_ingest_log for S23 skip"
+        (filer_cik, series_id, period, status, inserted) = row
+        assert filer_cik == "0001234567"
+        assert series_id == "S000004310"
+        assert period.isoformat() == "2025-09-30"
+        assert status == "success"
+        assert inserted == 1
+
+    def test_bulk_skips_seeding_accession_with_unresolved_cusip(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        # #1340 — an accession with a valid-but-unmapped CUSIP holding is
+        # RECOVERABLE (buffered for the S13 OpenFIGI sweep). It must NOT be
+        # seeded into n_port_ingest_log, so S23 can re-fetch it after the
+        # CUSIP resolves. Universe seeded for AAPL only; the holding's CUSIP
+        # (a fake) is unmapped.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        accn = "0009999999-25-000077"
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": accn,
+                    "FILING_DATE": "2025-11-30",
+                    "SUB_TYPE": "NPORT-P",
+                    "REPORT_DATE": "2025-09-30",
+                },
+            ],
+            registrants=[
+                {"ACCESSION_NUMBER": accn, "CIK": "9999999", "REGISTRANT_NAME": "Unmapped Fund Trust"},
+            ],
+            fund_info=[
+                {"ACCESSION_NUMBER": accn, "SERIES_ID": "S000009999", "SERIES_NAME": "Unmapped Series"},
+            ],
+            holdings=[
+                {
+                    "ACCESSION_NUMBER": accn,
+                    "HOLDING_ID": "1",
+                    "ISSUER_CUSIP": "000000001",  # not in cusip_map
+                    "BALANCE": "500000",
+                    "UNIT": "NS",
+                    "CURRENCY_CODE": "USD",
+                    "CURRENCY_VALUE": "75000000",
+                    "PAYOFF_PROFILE": "Long",
+                    "ASSET_CAT": "EC",
+                },
+            ],
+        )
+        archive_path = tmp_path / "nport.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.rows_skipped_unresolved_cusip == 1
+        assert result.ingest_log_rows_seeded == 0
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM n_port_ingest_log WHERE accession_number = %s", (accn,))
+            assert cur.fetchone() is None, (
+                "accession with an unresolved CUSIP must NOT be seeded — S23 retry path preserved"
+            )
+
     def test_non_ec_asset_skipped(
         self,
         ebull_test_conn: psycopg.Connection[tuple],

--- a/tests/test_sec_submissions_zip.py
+++ b/tests/test_sec_submissions_zip.py
@@ -1,0 +1,124 @@
+"""Unit tests for the shared ``submissions.zip`` accelerator (#1340).
+
+No DB / no HTTP — exercises the URL matcher, the zip-entry reader, and the
+``ZipBackedArchiveFetcher`` routing contract (every non-hit delegates to the
+wrapped fetcher; only a clean hit short-circuits).
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.sec_submissions_zip import (
+    PRIMARY_SUBMISSIONS_URL_RE,
+    ZipBackedArchiveFetcher,
+    match_primary_submissions_cik,
+    read_zip_entry,
+)
+
+_PRIMARY = "https://data.sec.gov/submissions/CIK0000320193.json"
+_SECONDARY = "https://data.sec.gov/submissions/CIK0000320193-submissions-001.json"
+_DOC = "https://www.sec.gov/Archives/edgar/data/320193/000032019324000123/primary_doc.xml"
+
+
+def _zip_with(entries: dict[str, bytes]) -> zipfile.ZipFile:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    buf.seek(0)
+    return zipfile.ZipFile(buf)
+
+
+class TestMatchPrimaryCik:
+    def test_primary_url_matches(self) -> None:
+        assert match_primary_submissions_cik(_PRIMARY) == "0000320193"
+
+    def test_secondary_url_no_match(self) -> None:
+        assert match_primary_submissions_cik(_SECONDARY) is None
+
+    def test_doc_url_no_match(self) -> None:
+        assert match_primary_submissions_cik(_DOC) is None
+
+    def test_regex_anchored(self) -> None:
+        # Trailing junk must not match (anchored $).
+        assert PRIMARY_SUBMISSIONS_URL_RE.match(_PRIMARY + "?x=1") is None
+
+
+class TestReadZipEntry:
+    def test_hit_returns_bytes(self) -> None:
+        zf = _zip_with({"CIK0000320193.json": b'{"cik":"320193"}'})
+        assert read_zip_entry(zf, "CIK0000320193.json") == b'{"cik":"320193"}'
+
+    def test_miss_returns_none(self) -> None:
+        zf = _zip_with({"CIK0000320193.json": b"{}"})
+        assert read_zip_entry(zf, "CIK9999999999.json") is None
+
+    def test_read_error_raises(self) -> None:
+        zf = MagicMock(spec=zipfile.ZipFile)
+        zf.open.side_effect = zipfile.BadZipFile("crc mismatch")
+        with pytest.raises(zipfile.BadZipFile):
+            read_zip_entry(zf, "CIK0000320193.json")
+
+
+class TestZipBackedArchiveFetcher:
+    def test_primary_hit_decodes_and_skips_fallback(self) -> None:
+        zf = _zip_with({"CIK0000320193.json": b'{"cik":"320193"}'})
+        fallback = MagicMock()
+        fetcher = ZipBackedArchiveFetcher(zf, fallback=fallback)
+        assert fetcher.fetch_document_text(_PRIMARY) == '{"cik":"320193"}'
+        fallback.fetch_document_text.assert_not_called()
+
+    def test_primary_miss_delegates(self) -> None:
+        zf = _zip_with({"CIK0000000001.json": b"{}"})
+        fallback = MagicMock()
+        fallback.fetch_document_text.return_value = '{"from":"http"}'
+        fetcher = ZipBackedArchiveFetcher(zf, fallback=fallback)
+        assert fetcher.fetch_document_text(_PRIMARY) == '{"from":"http"}'
+        fallback.fetch_document_text.assert_called_once_with(_PRIMARY)
+
+    def test_primary_miss_propagates_fallback_none(self) -> None:
+        # A genuine 404 at the HTTP layer (fallback returns None) is returned
+        # verbatim — caller's "no work" path still reachable when truly absent.
+        zf = _zip_with({"CIK0000000001.json": b"{}"})
+        fallback = MagicMock()
+        fallback.fetch_document_text.return_value = None
+        fetcher = ZipBackedArchiveFetcher(zf, fallback=fallback)
+        assert fetcher.fetch_document_text(_PRIMARY) is None
+
+    def test_primary_bad_zip_delegates(self) -> None:
+        zf = MagicMock(spec=zipfile.ZipFile)
+        zf.open.side_effect = zipfile.BadZipFile("truncated")
+        fallback = MagicMock()
+        fallback.fetch_document_text.return_value = "http-body"
+        fetcher = ZipBackedArchiveFetcher(zf, fallback=fallback)
+        assert fetcher.fetch_document_text(_PRIMARY) == "http-body"
+        fallback.fetch_document_text.assert_called_once_with(_PRIMARY)
+
+    def test_primary_bad_utf8_delegates(self) -> None:
+        zf = _zip_with({"CIK0000320193.json": b"\xff\xfe\x00bad"})
+        fallback = MagicMock()
+        fallback.fetch_document_text.return_value = "http-body"
+        fetcher = ZipBackedArchiveFetcher(zf, fallback=fallback)
+        assert fetcher.fetch_document_text(_PRIMARY) == "http-body"
+        fallback.fetch_document_text.assert_called_once_with(_PRIMARY)
+
+    def test_secondary_url_delegates(self) -> None:
+        zf = _zip_with({"CIK0000320193.json": b"{}"})
+        fallback = MagicMock()
+        fallback.fetch_document_text.return_value = "secondary-body"
+        fetcher = ZipBackedArchiveFetcher(zf, fallback=fallback)
+        assert fetcher.fetch_document_text(_SECONDARY) == "secondary-body"
+        fallback.fetch_document_text.assert_called_once_with(_SECONDARY)
+
+    def test_doc_url_delegates(self) -> None:
+        zf = _zip_with({"CIK0000320193.json": b"{}"})
+        fallback = MagicMock()
+        fallback.fetch_document_text.return_value = "<xml/>"
+        fetcher = ZipBackedArchiveFetcher(zf, fallback=fallback)
+        assert fetcher.fetch_document_text(_DOC) == "<xml/>"
+        fallback.fetch_document_text.assert_called_once_with(_DOC)


### PR DESCRIPTION
## What

Make bootstrap stage **S23 `sec_n_port_ingest`** fast (< 10 min) by eliminating its per-trust-CIK `submissions.json` HTTP enumeration.

**Retarget (operator-approved):** #1340 originally prescribed a `ManifestSubjectType` enum addition + submissions.zip *manifest* extraction + a `_bulk_already_seeded` manifest fast-path. Grep-verified, all three premises are stale:
- `fund_series` already exists in the `ManifestSubjectType` Literal + DB CHECK.
- S23 skips via `n_port_ingest_log`, not the manifest; `_bulk_already_seeded` doesn't exist.
- `sec_submissions_files_walk` emits no NPORT rows and walks only tradable issuer CIKs.

The real long-pole is `n_port_ingest.py:732` — one HTTP `submissions/CIK<10>.json` fetch per trust CIK (~3.5k at shared 7 req/s) before any skip-check. Fix mirrors the established #1277 (S16) / #1341 (S14) **local-zip** pattern.

## Changes

- **`app/services/sec_submissions_zip.py` (NEW)** — shared `PRIMARY_SUBMISSIONS_URL_RE` + `ZipBackedArchiveFetcher`. Pure accelerator: only a clean zip hit short-circuits; every non-hit (member absent / bad utf-8 / BadZipFile / OSError / non-primary URL) delegates to the wrapped HTTP fetcher, so coverage is never reduced.
- **S16 `sec_first_install_drain.py`** — imports the shared regex (single source of truth; body unchanged).
- **S12 `sec_nport_dataset_ingest.py`** — seeds `n_port_ingest_log` (one set-based `INSERT … FROM _stg_nport GROUP BY source_accession`) for **fully-resolved** accessions so S23 skips bulk-loaded filings. Accessions with any valid-but-unmapped (recoverable, buffered for the S13 OpenFIGI sweep) CUSIP are **held back** so S23 retains its retry path.
- **S23 `scheduler.py`** — `use_bulk_zip` routes primary submissions reads to the local zip (guarded open → HTTP fallback on corrupt archive); `submissions.zip` cleanup moved S16 → S23 (last bootstrap consumer), gated to bootstrap dispatch only (S23 also runs monthly + via Admin).
- **`bootstrap_orchestrator.py`** — new `nport_dataset_processed` ordering cap (S12 provides on success+skip; S23 requires). Serialises the two cross-lane writers to `ownership_funds_observations` **and** guarantees S23 sees S12's log rows. Mirrors the §6.5.10 audit pattern (S22↔S10 etc.).
- **`param_metadata.py`** — `use_bulk_zip` added to `JOB_INTERNAL_KEYS["sec_n_port_ingest"]` (bootstrap-only; manual API rejects).

**Drive-by:** corrected stale `test_stage_catalogue_lane_composition` (expected `db: 7`; production has `db: 6` + `db_fundamentals_raw: 1` from the Stream A PR-C2 S25 lane reassignment). Pre-existing, unrelated to #1340 — verified failing on `main` with this branch's orchestrator change stashed; corrected to unblock CI.

## Security model

No new external surface. `use_bulk_zip` is bootstrap-internal (`JOB_INTERNAL_KEYS`) — the operator API rejects it. Zip reads are local-file only; provenance-verified against the current bootstrap run (`assert_archive_belongs_to_run`) before use. No new SQL injection surface — the log-seed uses a parameterised array (`%(unresolved_accns)s`).

## Test plan

- `tests/test_sec_submissions_zip.py` — fetcher routing: hit decodes + skips fallback; every non-hit (KeyError / UnicodeDecodeError / BadZipFile / non-primary) delegates.
- `tests/test_scheduler_sec_n_port_ingest_invoker.py` — strict-bool, provenance pass→wrap, missing/outside-dispatch/provenance-mismatch→fallback, corrupt-archive→HTTP fallback, bootstrap-only cleanup (outside bootstrap preserves the archive).
- `tests/test_scheduler_sec_first_install_drain_invoker.py` — S16 now preserves the archive for S23.
- `tests/test_bootstrap_orchestrator.py` — `nport_dataset_processed` requires/provides/ordering-only invariants.
- `tests/test_sec_nport_dataset_ingest.py` — S12 seeds `n_port_ingest_log` for clean accessions; **excludes** accessions with an unresolved CUSIP.

Local gates green: `ruff check` / `ruff format --check` / `pyright` clean; 45 unit tests pass. **DB-integration tests (16) are CI-gated** — dev Postgres is mid-WAL-recovery this session (precedent #1346/#1277/#1341). Codex 1 CLEAN; Codex 2 found 2 BLOCKING + 1 IMPORTANT, all folded, re-pass CLEAN.

## Operator follow-up (post-merge)

S23 wall-clock < 10 min is verified by the R3 measurement run on a clean dev DB (needs Postgres recovered / container memory bump).

Closes #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)