### PR TITLE
feat(#1337 P1): bulk submissions.zip seeds filer-cohort manifest rows

### DIFF
--- a/app/services/sec_manifest.py
+++ b/app/services/sec_manifest.py
@@ -967,3 +967,37 @@ def is_amendment_form(form: str) -> bool:
     if canonical.endswith("/A"):
         return True
     return canonical in _NON_SUFFIX_AMENDMENT_FORMS
+
+
+# Per-cohort form allow-list for the bulk submissions.zip filer-writer
+# (#1337 P1 — see docs/proposals/etl/bulk-first-bootstrap.md §4). The
+# bulk path emits ``sec_filing_manifest`` rows for filer-cohort CIKs
+# (institutional_filer + blockholder_filer) by parsing the same
+# submissions.json payload S8 reads for issuers. A filer CIK files many
+# form types; we write a manifest row ONLY for the forms that define its
+# cohort — otherwise an institutional_filer that also files (say) a
+# stray non-13F form would get a misclassified ``institutional_filer``
+# row. Values verified against ``_FORM_TO_SOURCE`` above:
+#  - institutional_filer: 13F-HR / 13F-HR/A are the only 13F forms
+#    ``_FORM_TO_SOURCE`` maps (13F-NT notice-only is intentionally absent
+#    — the HTTP path drops it too).
+#  - blockholder_filer: both the short (``SC 13D``) and legacy long-form
+#    (``SCHEDULE 13D``) variants, original + amendment.
+# A CIK that is BOTH an issuer AND a filer hits both writers via the
+# multimap in ``sec_submissions_ingest._load_known_cik_subjects`` — the
+# issuer path picks up the 10-K, the filer path picks up the 13F.
+_FILER_COHORT_FORMS: dict[ManifestSubjectType, frozenset[str]] = {
+    "institutional_filer": frozenset({"13F-HR", "13F-HR/A"}),
+    "blockholder_filer": frozenset(
+        {
+            "SC 13D",
+            "SC 13D/A",
+            "SC 13G",
+            "SC 13G/A",
+            "SCHEDULE 13D",
+            "SCHEDULE 13D/A",
+            "SCHEDULE 13G",
+            "SCHEDULE 13G/A",
+        }
+    ),
+}

--- a/app/services/sec_submissions_ingest.py
+++ b/app/services/sec_submissions_ingest.py
@@ -27,7 +27,7 @@ import re
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import psycopg
 
@@ -35,8 +35,14 @@ from app.providers.implementations.sec_edgar import (
     KNOWN_FILING_AGENT_CIKS,
     _normalise_submissions_block,
 )
+from app.providers.implementations.sec_submissions import parse_submissions_page
 from app.services.filings import _upsert_filing
 from app.services.sec_entity_profile import parse_entity_profile, upsert_entity_profile
+from app.services.sec_manifest import (
+    _FILER_COHORT_FORMS,
+    ManifestSubjectType,
+    record_manifest_entry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +52,35 @@ __all__ = (
     "refresh_cik_sidecar",
     "repair_cik_sidecar_from_archive",
 )
+
+# #1337 P1 — bulk submissions.zip cohort roles. The bulk path widened
+# from issuer-only to "every CIK eBull tracks" so the per-CIK
+# submissions payload seeds ``sec_filing_manifest`` for filer cohorts
+# too (institutional_filer + blockholder_filer), collapsing S16's
+# per-CIK HTTP walk to a no-op fast-path (P2). NPORT trusts are
+# deliberately absent — ``ManifestSubjectType`` has no ``nport_trust``
+# variant and that extraction is a separate follow-up (spec §11).
+CikRole = Literal["issuer", "institutional_filer", "blockholder_filer"]
+
+
+@dataclass(frozen=True)
+class CikSubject:
+    """One CIK-role binding emitted by :func:`_load_known_cik_subjects`.
+
+    Multimap-valued so a single CIK can appear in multiple roles:
+      * share-class siblings (GOOG/GOOGL) each get an ``issuer`` subject
+        on the shared CIK (#1102);
+      * a self-managing asset manager whose ADR trades is BOTH an
+        ``issuer`` and an ``institutional_filer``.
+
+    ``instrument_id`` / ``symbol`` are set only for ``issuer`` subjects;
+    filer subjects carry the CIK as ``subject_id`` with both None.
+    """
+
+    subject_type: CikRole
+    subject_id: str
+    instrument_id: int | None
+    symbol: str | None
 
 
 # Stream A PR-B T1.3 (#1233): sentinel row inserted into
@@ -80,6 +115,13 @@ class SubmissionsIngestResult:
     # counts real-page rows only (sentinel rows do not).
     ciks_sidecared: int = 0
     sidecar_pages_indexed: int = 0
+    # #1337 P1: count of ``sec_filing_manifest`` rows upserted for
+    # filer-cohort CIKs (institutional_filer + blockholder_filer) via
+    # the new bulk filer-writer. ``record_manifest_entry`` is an
+    # ON CONFLICT DO UPDATE upsert (always writes one row), so each
+    # non-skipped, non-raising call increments this by exactly one.
+    # Default 0 for back-compat with callers reading the old fields.
+    filer_manifest_rows_upserted: int = 0
 
 
 def _cik_from_filename(name: str) -> str | None:
@@ -129,9 +171,9 @@ def refresh_cik_sidecar(
 
     Called from the OUTER per-CIK transaction in ``ingest_submissions_archive``
     BEFORE the ``for instrument_id, symbol in matched_instruments:`` sibling
-    loop — putting it inside ``_ingest_one`` would repeat the DELETE+INSERT
-    N times per share-class CIK (one per sibling), per Codex 1 re-pass
-    IMPORTANT. Single refresh per (CIK, archive-entry) here.
+    loop — putting it inside ``_ingest_one_issuer`` would repeat the
+    DELETE+INSERT N times per share-class CIK (one per sibling), per
+    Codex 1 re-pass IMPORTANT. Single refresh per (CIK, archive-entry) here.
 
     Skips agent CIKs (``KNOWN_FILING_AGENT_CIKS`` at
     ``app/providers/implementations/sec_edgar.py:98``) — sidecar stays
@@ -229,23 +271,29 @@ def refresh_cik_sidecar(
     result.ciks_sidecared += 1
 
 
-def _load_cik_to_instrument(
+def _load_known_cik_subjects(
     conn: psycopg.Connection[Any],
-) -> dict[str, list[tuple[int, str]]]:
-    """Return ``{cik_padded: [(instrument_id, symbol), ...]}`` for every
-    CIK-mapped instrument.
+) -> dict[str, list[CikSubject]]:
+    """Return ``{cik_padded: [CikSubject, ...]}`` for every CIK eBull
+    tracks across the issuer + filer cohorts (#1337 P1).
 
-    Reads ``external_identifiers`` SEC CIK rows joined to ``instruments``
-    so the writer below can pass the canonical ticker symbol — not a
-    stringified instrument_id — to ``_normalise_submissions_block`` and
-    ``_upsert_filing`` (Codex review BLOCKING for PR #1030).
+    Replaces the former ``_load_cik_to_instrument`` (issuer-only). The
+    multimap shape preserves two distinct fan-outs:
 
-    Multimap shape — share-class siblings (GOOG/GOOGL, BRK.A/BRK.B)
-    co-bind a single SEC CIK per #1102. Collapsing to
-    ``dict[str, tuple[int, str]]`` would silently drop one sibling on
-    every bulk run, leaving it without filings or entity profile.
+      * share-class siblings (GOOG/GOOGL, BRK.A/BRK.B) co-bind a single
+        SEC CIK per #1102 — each is its own ``issuer`` subject so both
+        receive filings + entity profile;
+      * a single CIK that is BOTH a tradable issuer AND a 13F /
+        13D/G filer appears under multiple ``subject_type`` roles.
+
+    Issuer rows carry the canonical ticker ``symbol`` and
+    ``instrument_id`` (Codex review BLOCKING for PR #1030 — the writer
+    must pass the ticker, not a stringified instrument id). Filer rows
+    carry the CIK as ``subject_id`` with ``instrument_id``/``symbol``
+    both None, matching ``record_manifest_entry``'s non-issuer contract.
     """
-    out: dict[str, list[tuple[int, str]]] = {}
+    out: dict[str, list[CikSubject]] = {}
+    # Issuer rows — behaviour preserved from the former loader.
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -257,29 +305,87 @@ def _load_cik_to_instrument(
               AND i.is_tradable = TRUE
             """,
         )
-        for row in cur.fetchall():
-            instrument_id, identifier, symbol = row
+        for instrument_id, identifier, symbol in cur.fetchall():
             cik = str(identifier).zfill(10)
-            out.setdefault(cik, []).append((int(instrument_id), str(symbol or "")))
+            iid = int(instrument_id)
+            out.setdefault(cik, []).append(
+                CikSubject(
+                    subject_type="issuer",
+                    subject_id=str(iid),
+                    instrument_id=iid,
+                    symbol=str(symbol or ""),
+                )
+            )
+    # Institutional-filer rows (new #1337 P1) — same cohort S16's
+    # per-CIK HTTP walk iterates today.
+    with conn.cursor() as cur:
+        cur.execute("SELECT cik FROM institutional_filers")
+        for (identifier,) in cur.fetchall():
+            cik = str(identifier).zfill(10)
+            out.setdefault(cik, []).append(
+                CikSubject(
+                    subject_type="institutional_filer",
+                    subject_id=cik,
+                    instrument_id=None,
+                    symbol=None,
+                )
+            )
+    # Blockholder-filer rows (new #1337 P1) — empty until the 13D/G
+    # manifest worker seeds ``blockholder_filers``; the join is cheap.
+    with conn.cursor() as cur:
+        cur.execute("SELECT cik FROM blockholder_filers")
+        for (identifier,) in cur.fetchall():
+            cik = str(identifier).zfill(10)
+            out.setdefault(cik, []).append(
+                CikSubject(
+                    subject_type="blockholder_filer",
+                    subject_id=cik,
+                    instrument_id=None,
+                    symbol=None,
+                )
+            )
     return out
+
+
+def _issuer_cik_set(subjects_by_cik: dict[str, list[CikSubject]]) -> set[str]:
+    """Project the multimap down to the issuer-only CIK set.
+
+    The ``sec_cik_submissions_files_index`` sidecar is an issuer-only
+    overflow-page index consumed solely by S14 (which walks
+    ``is_tradable=TRUE`` issuer CIKs). Filer-cohort CIKs must NOT seed
+    it — both the per-CIK sidecar write in :func:`ingest_submissions_archive`
+    and the in-universe filter in :func:`repair_cik_sidecar_from_archive`
+    gate on this projection so widening the cohort (#1337 P1) does not
+    write orphan sidecar rows for pure-filer CIKs.
+    """
+    return {cik for cik, subs in subjects_by_cik.items() if any(s.subject_type == "issuer" for s in subs)}
 
 
 def ingest_submissions_archive(
     *,
     conn: psycopg.Connection[Any],
     archive_path: Path,
-    cik_to_instrument: dict[str, list[tuple[int, str]]] | None = None,
+    cik_to_subjects: dict[str, list[CikSubject]] | None = None,
 ) -> SubmissionsIngestResult:
-    """Walk every ``CIK<10>.json`` entry in ``archive_path`` and upsert
-    matching universe instruments into ``filing_events`` + ``instrument_sec_profile``.
+    """Walk every ``CIK<10>.json`` entry in ``archive_path`` and seed the
+    universe from each matching CIK's submissions payload.
+
+    Two cohorts are written (#1337 P1):
+      * issuer CIKs → ``filing_events`` + ``instrument_sec_profile`` +
+        the ``sec_cik_submissions_files_index`` sidecar (unchanged);
+      * filer CIKs (institutional_filer + blockholder_filer) →
+        ``sec_filing_manifest`` rows for their cohort forms, exactly
+        what S16's per-CIK HTTP walk writes today. This lets S16
+        fast-path-skip those CIKs (P2).
 
     Returns a summary suitable for stage telemetry. Per-entry parse
     errors are counted, not raised — one bad CIK file in a 5-million-row
     archive must not block the rest. The bulk archive is treated as
     a soft source: corrupted entries are logged at DEBUG and counted.
     """
-    if cik_to_instrument is None:
-        cik_to_instrument = _load_cik_to_instrument(conn)
+    if cik_to_subjects is None:
+        cik_to_subjects = _load_known_cik_subjects(conn)
+    issuer_ciks = _issuer_cik_set(cik_to_subjects)
 
     # Stream A PR-B T1.3 (#1233): captured once per archive ingest so
     # the per-CIK sidecar writer threads run-lineage without re-
@@ -304,8 +410,8 @@ def ingest_submissions_archive(
                 # noise we silently skip.
                 continue
             result.archive_entries_seen += 1
-            matched_instruments = cik_to_instrument.get(cik, [])
-            if not matched_instruments:
+            matched_subjects = cik_to_subjects.get(cik, [])
+            if not matched_subjects:
                 # Universe gap — most CIKs in the archive are not in
                 # our universe. This is expected, not an error.
                 result.archive_entries_skipped += 1
@@ -328,33 +434,55 @@ def ingest_submissions_archive(
                         raise _SkipEntry from exc
 
                     # Stream A PR-B T1.3 (#1233): refresh sidecar ONCE
-                    # PER CIK in the OUTER block (not inside _ingest_one
-                    # — that would re-DELETE+INSERT N times for share-
-                    # class siblings, per Codex 1 re-pass IMPORTANT).
+                    # PER CIK in the OUTER block (not inside the issuer
+                    # writer — that would re-DELETE+INSERT N times for
+                    # share-class siblings, per Codex 1 re-pass IMPORTANT).
                     # Promoted to ``refresh_cik_sidecar`` (public) in
                     # PR-D so the repair runbook re-uses the same writer.
                     # Atomicity: the surrounding ``with conn.transaction()``
                     # gives "DELETE rolls back if any sibling write
                     # raises" so the sidecar is always consistent with
                     # the rest of the per-CIK ingest.
-                    refresh_cik_sidecar(
-                        conn,
-                        cik=cik,
-                        payload=payload,
-                        bootstrap_run_id=bootstrap_run_id,
-                        result=result,
-                    )
-
-                    for instrument_id, symbol in matched_instruments:
-                        result.instruments_matched += 1
-                        _ingest_one(
+                    #
+                    # #1337 P1: the sidecar is an issuer-only overflow
+                    # index (S14 walks issuer CIKs only). Gate the write
+                    # on issuer-role presence so cohort widening does not
+                    # write orphan sidecar rows for pure-filer CIKs.
+                    if cik in issuer_ciks:
+                        refresh_cik_sidecar(
                             conn,
-                            instrument_id=instrument_id,
-                            cik_padded=cik,
-                            symbol=symbol,
+                            cik=cik,
                             payload=payload,
+                            bootstrap_run_id=bootstrap_run_id,
                             result=result,
                         )
+
+                    for subject in matched_subjects:
+                        if subject.subject_type == "issuer":
+                            if subject.instrument_id is None:
+                                # Loader invariant: issuer subjects always
+                                # carry instrument_id. Fail loud (not
+                                # assert — stripped under python -O) if a
+                                # future change violates it.
+                                raise RuntimeError(f"issuer CikSubject missing instrument_id for cik={cik}")
+                            result.instruments_matched += 1
+                            _ingest_one_issuer(
+                                conn,
+                                instrument_id=subject.instrument_id,
+                                cik_padded=cik,
+                                symbol=subject.symbol or "",
+                                payload=payload,
+                                result=result,
+                            )
+                        else:
+                            _ingest_one_filer(
+                                conn,
+                                subject_type=subject.subject_type,
+                                subject_id=subject.subject_id,
+                                cik_padded=cik,
+                                payload=payload,
+                                result=result,
+                            )
             except _SkipEntry:
                 continue
             except Exception as exc:  # noqa: BLE001
@@ -367,7 +495,7 @@ def ingest_submissions_archive(
     return result
 
 
-def _ingest_one(
+def _ingest_one_issuer(
     conn: psycopg.Connection[Any],
     *,
     instrument_id: int,
@@ -376,7 +504,10 @@ def _ingest_one(
     payload: dict[str, Any],
     result: SubmissionsIngestResult,
 ) -> None:
-    """Upsert one CIK's submissions payload — filings + profile.
+    """Upsert one issuer CIK's submissions payload — filings + profile.
+
+    Renamed from ``_ingest_one`` (#1337 P1) to make room for the
+    filer-cohort sibling ``_ingest_one_filer``.
 
     ``symbol`` is the ticker for ``instrument_id``, threaded through
     so ``_normalise_submissions_block`` and ``_upsert_filing`` write
@@ -413,6 +544,92 @@ def _ingest_one(
             result.filings_upserted += 1
 
 
+def _ingest_one_filer(
+    conn: psycopg.Connection[Any],
+    *,
+    subject_type: ManifestSubjectType,
+    subject_id: str,
+    cik_padded: str,
+    payload: dict[str, Any],
+    result: SubmissionsIngestResult,
+) -> None:
+    """Seed ``sec_filing_manifest`` for one filer-cohort CIK (#1337 P1).
+
+    Filer cohorts (institutional_filer + blockholder_filer) are NOT
+    universe instruments — they have no ``instrument_id`` and do NOT
+    touch ``filing_events`` (that table is issuer-keyed). They write
+    manifest rows directly, exactly what S16's per-CIK HTTP walk does
+    today (``sec_first_install_drain.py``). Seeding them here lets P2
+    fast-path-skip the HTTP fetch.
+
+    Reuses :func:`parse_submissions_page` — the SAME pure parser the
+    freshness scheduler + S16 use — so date / primary-document-URL /
+    form→source / amendment parsing stays bit-for-bit in sync with the
+    HTTP path. Only the cohort form-filter (``_FILER_COHORT_FORMS``) is
+    bulk-path-specific: a filer that also files an off-cohort form gets
+    that row dropped here (the issuer path picks it up if the CIK is
+    also a tradable issuer, per the multimap).
+
+    Filing-agent CIKs are skipped (open question §12 #2 — they file on
+    behalf of others, so emitting them as ``institutional_filer`` rows
+    would be wrong). The guard is explicit here, NOT inherited from
+    ``refresh_cik_sidecar`` which only runs on the issuer path.
+    """
+    if cik_padded in KNOWN_FILING_AGENT_CIKS:
+        return
+
+    allowed_forms = _FILER_COHORT_FORMS.get(subject_type, frozenset())
+    if not allowed_forms:
+        # No cohort form-set defined for this subject_type — nothing to
+        # write. Defensive: the only filer types reaching here are the
+        # two with entries in ``_FILER_COHORT_FORMS``.
+        return
+
+    # SCOPE (P1 + Codex-2 P2 finding): we seed only the primary
+    # ``recent`` block; ``files[]`` secondary pages are NOT followed
+    # here (``_has_more`` is intentionally discarded). For a 13F /
+    # 13D/G filer the recent block (~1000 newest accessions) far
+    # exceeds the 8-quarter bulk retention horizon, so the overflow
+    # tail is older than anything the downstream 13F/13D-G ingest
+    # consumes. SAFE in P1 because S16 still HTTP-walks every filer CIK
+    # (no fast-path skip yet). When P2 adds the ``_bulk_already_seeded``
+    # skip gate, it MUST NOT skip a filer whose history overflowed into
+    # ``files[]`` — else those secondary-page rows never reach the
+    # manifest. Tracked as a P2 obligation in the #1337 epic.
+    rows, _has_more = parse_submissions_page(payload, cik=cik_padded)
+    for row in rows:
+        if row.source is None:
+            continue
+        if row.form.strip() not in allowed_forms:
+            continue
+        try:
+            record_manifest_entry(
+                conn,
+                row.accession_number,
+                cik=row.cik,
+                form=row.form,
+                source=row.source,
+                subject_type=subject_type,
+                subject_id=subject_id,
+                instrument_id=None,
+                filed_at=row.filed_at,
+                accepted_at=row.accepted_at,
+                primary_document_url=row.primary_document_url,
+                is_amendment=row.is_amendment,
+            )
+            # ON CONFLICT DO UPDATE always writes one row — count per
+            # non-raising call (no overcount; the form-filter skip above
+            # happens before the call).
+            result.filer_manifest_rows_upserted += 1
+        except ValueError as exc:
+            logger.warning(
+                "submissions ingest: rejected filer manifest accession=%s cik=%s: %s",
+                row.accession_number,
+                cik_padded,
+                exc,
+            )
+
+
 def repair_cik_sidecar_from_archive(
     conn: psycopg.Connection[Any],
     *,
@@ -434,13 +651,14 @@ def repair_cik_sidecar_from_archive(
         CIK SURVIVE if a later CIK raises.
 
     IN-UNIVERSE FILTER (per Codex 2 IMPORTANT fold of PR-D pre-push):
-    S8's production path resolves a per-CIK ``matched_instruments`` set
-    via ``_load_cik_to_instrument`` and skips entries with no match —
-    so production NEVER writes sidecar rows for out-of-universe CIKs.
-    The repair helper mirrors this: it loads the same in-universe CIK
-    set up front and skips any archive entry not in that set. Without
-    this filter, repair could inflate the C7 numerator with out-of-
-    universe CIKs and false-pass the Stream-C correctness gate.
+    S8's production sidecar write is gated on issuer-role presence (the
+    sidecar is an issuer-only overflow index) — so production NEVER
+    writes sidecar rows for out-of-universe OR pure-filer CIKs. The
+    repair helper mirrors this via the issuer-only projection
+    (``_issuer_cik_set(_load_known_cik_subjects(...))``, #1337 P1) and
+    skips any archive entry not in that set. Without this filter, repair
+    could inflate the C7 numerator with out-of-universe / filer CIKs and
+    false-pass the Stream-C correctness gate.
 
     Parameters
     ----------
@@ -471,7 +689,12 @@ def repair_cik_sidecar_from_archive(
     Sole external caller: ``app/runbooks/stream_a_t13_sidecar_repair.py``
     (#1233 PR-D v3 R4 fold).
     """
-    in_universe = set(_load_cik_to_instrument(conn).keys())
+    # Issuer-only projection (#1337 P1): the sidecar is an issuer-only
+    # index, so the repair in-universe filter must NOT include the new
+    # filer cohorts ``_load_known_cik_subjects`` now returns — else
+    # repair would write orphan sidecar rows for pure-filer CIKs and
+    # inflate the C7 numerator.
+    in_universe = _issuer_cik_set(_load_known_cik_subjects(conn))
     result = SubmissionsIngestResult(
         archive_entries_seen=0,
         instruments_matched=0,
@@ -490,11 +713,11 @@ def repair_cik_sidecar_from_archive(
             if cik is not None and entry_cik != cik:
                 continue
             if entry_cik not in in_universe:
-                # Mirrors S8: out-of-universe CIKs are skipped at the
-                # ``_load_cik_to_instrument`` boundary before the writer
-                # fires. Without this gate, repair could write sidecar
-                # rows for tickers that don't belong to any tradable
-                # instrument and inflate the C7 numerator.
+                # Mirrors S8: the sidecar write is gated on issuer-role
+                # presence (issuer-only index), so out-of-universe AND
+                # pure-filer CIKs are skipped. Without this gate, repair
+                # could write sidecar rows for CIKs that aren't tradable
+                # issuers and inflate the C7 numerator.
                 ciks_out_of_universe_skipped += 1
                 continue
             result.archive_entries_seen += 1

--- a/tests/test_sec_entry_points_is_tradable_filter.py
+++ b/tests/test_sec_entry_points_is_tradable_filter.py
@@ -7,9 +7,10 @@ operator value.
 
 Covered:
 
-1. ``app/services/sec_submissions_ingest.py::_load_cik_to_instrument``
-   — bulk archive walk; CIK → instrument_id map drives every
-   ``ingest_submissions_archive`` write.
+1. ``app/services/sec_submissions_ingest.py::_load_known_cik_subjects``
+   — bulk archive walk; CIK → subject multimap drives every
+   ``ingest_submissions_archive`` write. The issuer-cohort SELECT
+   (the only one with an ``is_tradable`` join) must filter delisted.
 2. ``app/services/sec_submissions_files_walk.py::_list_cik_secondary_pages``
    — per-CIK secondary-pages walk; same shape.
 3. ``app/services/finra_short_interest_ingest.py::build_preloaded_symbol_resolver``
@@ -72,11 +73,11 @@ def _seed_pair(
 
 
 class TestSubmissionsIngestCikMapFiltersDelisted:
-    def test_load_cik_to_instrument_skips_delisted(
+    def test_load_known_cik_subjects_skips_delisted(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     ) -> None:
-        from app.services.sec_submissions_ingest import _load_cik_to_instrument
+        from app.services.sec_submissions_ingest import _load_known_cik_subjects
 
         _seed_pair(
             ebull_test_conn,
@@ -89,9 +90,13 @@ class TestSubmissionsIngestCikMapFiltersDelisted:
         )
         ebull_test_conn.commit()
 
-        mapping = _load_cik_to_instrument(ebull_test_conn)
+        mapping = _load_known_cik_subjects(ebull_test_conn)
 
+        # The delisted CIK has no issuer subject; it could only appear
+        # if it were also a filer-cohort row (it isn't here), so the
+        # key must be absent entirely.
         assert "0000820001" in mapping, "tradable CIK must be present"
+        assert any(s.subject_type == "issuer" for s in mapping["0000820001"]), "must carry an issuer subject"
         assert "0000820002" not in mapping, "delisted CIK must be filtered (#1233 §6.2)"
 
 

--- a/tests/test_sec_submissions_ingest.py
+++ b/tests/test_sec_submissions_ingest.py
@@ -10,6 +10,9 @@ from pathlib import Path
 import psycopg
 import pytest
 
+from app.providers.implementations.sec_edgar import KNOWN_FILING_AGENT_CIKS
+from app.providers.implementations.sec_submissions import parse_submissions_page
+from app.services.sec_manifest import _FILER_COHORT_FORMS, map_form_to_source
 from app.services.sec_submissions_ingest import (
     SubmissionsIngestResult,
     _cik_from_filename,
@@ -36,6 +39,76 @@ class TestCikFromFilename:
     def test_non_cik_filename_rejected(self) -> None:
         assert _cik_from_filename("README.txt") is None
         assert _cik_from_filename("CIK0000320193-submissions-001.json") is None
+
+
+# ---------------------------------------------------------------------------
+# #1337 P1 — filer-cohort form filter (pure unit, no DB)
+# ---------------------------------------------------------------------------
+
+
+def _filer_payload() -> dict:
+    """A filer's submissions payload mixing cohort + off-cohort forms.
+
+    An institutional manager that ALSO filed a stray 10-K and a 13F-NT
+    notice — only the 13F-HR forms should survive the cohort filter.
+    """
+    return {
+        "cik": "0001000001",
+        "name": "Test Asset Manager LLC",
+        "filings": {
+            "recent": {
+                "accessionNumber": [
+                    "0001000001-25-000001",  # 13F-HR  -> kept (institutional)
+                    "0001000001-25-000002",  # 13F-HR/A -> kept
+                    "0001000001-25-000003",  # 13F-NT  -> dropped (unmapped)
+                    "0001000001-25-000004",  # 10-K    -> dropped (off-cohort)
+                    "0001000001-25-000005",  # SC 13G  -> dropped (wrong cohort)
+                ],
+                "filingDate": ["2025-11-14", "2025-11-20", "2025-08-14", "2025-03-01", "2025-02-14"],
+                "form": ["13F-HR", "13F-HR/A", "13F-NT", "10-K", "SC 13G"],
+                "primaryDocument": ["a.htm", "b.htm", "c.htm", "d.htm", "e.htm"],
+            },
+            "files": [],
+        },
+    }
+
+
+class TestFilerCohortForms:
+    """``_FILER_COHORT_FORMS`` must stay in sync with ``_FORM_TO_SOURCE``
+    — a form code that maps to no source would silently never match."""
+
+    def test_every_cohort_form_maps_to_a_source(self) -> None:
+        for cohort, forms in _FILER_COHORT_FORMS.items():
+            for form in forms:
+                assert map_form_to_source(form) is not None, (
+                    f"{cohort} cohort form {form!r} maps to no source — it would never be written"
+                )
+
+    def test_institutional_forms_map_to_13f_hr(self) -> None:
+        sources = {map_form_to_source(f) for f in _FILER_COHORT_FORMS["institutional_filer"]}
+        assert sources == {"sec_13f_hr"}
+
+    def test_blockholder_forms_map_to_13d_or_13g(self) -> None:
+        sources = {map_form_to_source(f) for f in _FILER_COHORT_FORMS["blockholder_filer"]}
+        assert sources == {"sec_13d", "sec_13g"}
+
+
+class TestFilerFormFilterPredicate:
+    """Exercises the exact gate ``_ingest_one_filer`` applies — a row is
+    written iff its source is mapped AND its form is in the cohort set —
+    against the canonical ``parse_submissions_page`` output. No DB."""
+
+    def _kept_forms(self, cohort: str) -> set[str]:
+        allowed = _FILER_COHORT_FORMS[cohort]  # type: ignore[index]
+        rows, _ = parse_submissions_page(_filer_payload(), cik="0001000001")
+        return {r.form.strip() for r in rows if r.source is not None and r.form.strip() in allowed}
+
+    def test_institutional_keeps_only_13f_hr(self) -> None:
+        assert self._kept_forms("institutional_filer") == {"13F-HR", "13F-HR/A"}
+
+    def test_blockholder_keeps_only_13dg(self) -> None:
+        # The sample payload only has SC 13G for the blockholder set.
+        assert self._kept_forms("blockholder_filer") == {"SC 13G"}
 
 
 # ---------------------------------------------------------------------------
@@ -309,3 +382,137 @@ class TestIngestSubmissionsArchive:
             row = cur.fetchone()
             assert row is not None
             assert row[0] == 2, f"expected 2 profiles, got {row[0]}"
+
+
+# ---------------------------------------------------------------------------
+# #1337 P1 — filer-cohort manifest seeding (DB integration)
+# ---------------------------------------------------------------------------
+
+
+def _seed_institutional_filer(conn: psycopg.Connection[tuple], *, cik_padded: str, name: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO institutional_filers (cik, name) VALUES (%s, %s) ON CONFLICT (cik) DO NOTHING",
+            (cik_padded, name),
+        )
+    conn.commit()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestFilerCohortManifestSeeding:
+    def test_institutional_filer_seeds_manifest_not_filing_events(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        cik = "0001000001"
+        _seed_institutional_filer(ebull_test_conn, cik_padded=cik, name="Test Asset Manager LLC")
+
+        archive_path = tmp_path / "submissions.zip"
+        archive_path.write_bytes(_build_archive({cik: _filer_payload()}))
+
+        result = ingest_submissions_archive(conn=ebull_test_conn, archive_path=archive_path)
+        ebull_test_conn.commit()
+
+        # Two cohort forms (13F-HR + 13F-HR/A) written; the 13F-NT / 10-K /
+        # SC 13G rows are dropped by the cohort form-filter.
+        assert result.filer_manifest_rows_upserted == 2
+        assert result.instruments_matched == 0  # not a universe instrument
+        assert result.filings_upserted == 0  # filer path never touches filing_events
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT form, subject_type, subject_id, instrument_id "
+                "FROM sec_filing_manifest WHERE cik = %s ORDER BY form",
+                (cik,),
+            )
+            rows = cur.fetchall()
+            assert {r[0] for r in rows} == {"13F-HR", "13F-HR/A"}
+            for _form, subject_type, subject_id, instrument_id in rows:
+                assert subject_type == "institutional_filer"
+                assert subject_id == cik
+                assert instrument_id is None
+
+            # No issuer-only sidecar rows for a pure-filer CIK (the
+            # filing_events absence is already proven by filings_upserted == 0,
+            # since filing_events is keyed by instrument_id which a pure
+            # filer lacks).
+            cur.execute(
+                "SELECT COUNT(*) FROM sec_cik_submissions_files_index WHERE cik = %s",
+                (cik,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 0, "pure-filer CIK must not seed the issuer-only sidecar"
+
+    def test_agent_cik_in_filer_cohort_is_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        agent_cik = next(iter(KNOWN_FILING_AGENT_CIKS))
+        _seed_institutional_filer(ebull_test_conn, cik_padded=agent_cik, name="Filing Agent Co")
+
+        payload = _filer_payload()
+        payload["cik"] = agent_cik
+        archive_path = tmp_path / "submissions.zip"
+        archive_path.write_bytes(_build_archive({agent_cik: payload}))
+
+        result = ingest_submissions_archive(conn=ebull_test_conn, archive_path=archive_path)
+        ebull_test_conn.commit()
+
+        assert result.filer_manifest_rows_upserted == 0, "agent CIKs must not seed filer manifest rows"
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM sec_filing_manifest WHERE cik = %s", (agent_cik,))
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 0
+
+    def test_dual_role_cik_writes_issuer_filings_and_filer_manifest(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """A CIK that is BOTH a tradable issuer AND a 13F filer: the
+        issuer path writes filing_events + sidecar (for the 10-K), the
+        filer path writes a 13F-HR manifest row. The multimap exposes
+        both roles on the one CIK (#1337 P1 risk §10.1 + §10.5)."""
+        cik = "0001000001"
+        iid = _seed_universe(ebull_test_conn, symbol="DUAL1", cik_padded=cik)
+        _seed_institutional_filer(ebull_test_conn, cik_padded=cik, name="Self-Managing Manager")
+
+        archive_path = tmp_path / "submissions.zip"
+        archive_path.write_bytes(_build_archive({cik: _filer_payload()}))
+
+        result = ingest_submissions_archive(conn=ebull_test_conn, archive_path=archive_path)
+        ebull_test_conn.commit()
+
+        assert result.instruments_matched == 1  # the issuer role
+        assert result.filer_manifest_rows_upserted == 2  # 13F-HR + 13F-HR/A
+
+        with ebull_test_conn.cursor() as cur:
+            # Issuer path wrote the 10-K to filing_events.
+            cur.execute(
+                "SELECT COUNT(*) FROM filing_events WHERE instrument_id = %s AND provider = 'sec'",
+                (iid,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] >= 1, "issuer path must write the 10-K to filing_events"
+
+            # Issuer path wrote a sidecar row (dual-role CIK still seeds it).
+            cur.execute("SELECT COUNT(*) FROM sec_cik_submissions_files_index WHERE cik = %s", (cik,))
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] >= 1, "dual-role CIK must still seed the issuer sidecar"
+
+            # Filer path wrote the 13F-HR manifest rows (instrument_id NULL).
+            cur.execute(
+                "SELECT COUNT(*) FROM sec_filing_manifest "
+                "WHERE cik = %s AND subject_type = 'institutional_filer' AND instrument_id IS NULL",
+                (cik,),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == 2


### PR DESCRIPTION
## What
Phase 2 (item 1) of the bootstrap-sub-60 plan. Widens the bulk `submissions.zip` ingest (S8) from issuer-only to **every CIK eBull tracks**, so the per-CIK submissions payload also seeds `sec_filing_manifest` for the `institutional_filer` + `blockholder_filer` cohorts — the writer P2's S16 fast-path will ride on.

- `sec_manifest.py`: `_FILER_COHORT_FORMS` (institutional → `13F-HR`/`13F-HR/A`; blockholder → `SC`/`SCHEDULE 13D`/`13G` ±`/A`), beside `_FORM_TO_SOURCE`.
- `sec_submissions_ingest.py`: `CikRole`/`CikSubject` types; `_load_cik_to_instrument` → `_load_known_cik_subjects` (issuer + institutional + blockholder multimap) + `_issuer_cik_set` projection; `SubmissionsIngestResult.filer_manifest_rows_upserted`; branched per-subject loop (`_ingest_one` → `_ingest_one_issuer` rename + new `_ingest_one_filer`).
- `_ingest_one_filer` **reuses** `parse_submissions_page` (the same parser S16 uses) so date/URL/source/amendment parsing stays bit-for-bit in sync; cohort form-filter + `KNOWN_FILING_AGENT_CIKS` skip; writes `sec_filing_manifest` only (no `filing_events` — that table is issuer-keyed).

## Why
S16 `sec_first_install_drain` HTTP-walks ~11k non-issuer filer CIKs one-by-one over the SEC 10 req/s budget, even though `submissions.zip` already has them on disk. P1 is the writer that seeds those manifest rows from the local zip; P2 (separate PR) adds the S16 skip gate for the ~55-60 min critical-path win. P1 alone saves 0 wall-clock (writer-only) — it's the prerequisite.

## Key decisions
1. **Sidecar gated on issuer-role presence** (deviation from spec §4). `sec_cik_submissions_files_index` is an issuer-only S14 overflow index; widening the cohort would otherwise write orphan rows for pure-filer CIKs. Applied to both `ingest_submissions_archive` and `repair_cik_sidecar_from_archive`'s in-universe filter.
2. **Reused `parse_submissions_page`** instead of the spec's hand-rolled parse — eliminates a drift-bug class; cut `_ingest_one_filer` from ~80 to ~25 LOC.
3. **Filer writer parses only the primary `recent` block**, not `files[]` overflow (Codex-2 P2 finding, **DEFERRED to #1337 P2**). Harmless here — S16 still HTTP-walks every filer CIK in P1. Documented as a hard P2 obligation in code: P2's `_bulk_already_seeded` skip gate MUST NOT skip a filer whose history overflowed into `files[]`. Safe because the recent block (~1000 newest) far exceeds the 8-quarter 13F bootstrap horizon.

## Security model
No auth/authz surface. All SQL is parameterised via `record_manifest_entry` (its non-issuer contract enforces `instrument_id IS NULL`). Service functions accept a caller `conn` and never commit/rollback. NPORT trusts deliberately out of scope (no `ManifestSubjectType` variant) — spec §11.

## Test plan
- `ruff check` / `ruff format --check` / `pyright` (repo-wide) — green.
- `pytest tests/test_sec_submissions_ingest.py tests/test_sec_entry_points_is_tradable_filter.py` — **19 passed (xdist)** on dev DB, incl. 3 new filer-cohort integration tests: pure-filer seeds manifest (no `filing_events`/sidecar), agent-CIK skipped, dual-role CIK writes both issuer filings + filer manifest. 8 pure-unit cover `_FILER_COHORT_FORMS`↔`_FORM_TO_SOURCE` consistency + the cohort form-filter predicate.
- Codex 2 pre-push review: 1 finding (the deferred P2 overflow item), rest clean.

DoD clauses 8-11 (live backfill `POST /jobs/sec_rebuild/run` + operator-visible figure) are batched into the planned clean bootstrap run alongside the rest of the ETL-side work, not run per-PR.

Closes part of #1337 (P1; P2 + P3 + P4 follow on separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)