### PR TITLE
feat(#1337 P2): S16 institutional-filer fast-path skip (bulk-seeded)

### DIFF
--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -114,6 +114,12 @@ When the tripwire fires: grep the tests directory for `psycopg.connect(settings.
 
 When the orphan sweep stops cleaning (leaked `ebull_test_*` DBs accumulate again): check `pg_stat_activity` for stuck keepalive connections from prior pytest runs; the sweep correctly skips DBs with any active backend. If the sweep itself is broken, `_drop_orphan_workers_older_than` raises `AssertionError` on a regex regression — read the warning and re-tighten the regex.
 
+## Scope shared-DB assertions to the entity under test
+
+In an integration test that runs against a per-worker DB shared across tests in the same worker, do NOT assert on a *global* shape of an accumulating table — `assert seen == []`, `assert len(rows) == 1`, `assert count == N`. Even with a per-test `TRUNCATE` rail, that assertion is implicitly coupled to the truncation behaviour: a future fixture change that stops truncating one table, or a sibling test that commits a row of the same kind, flips the result and the failure reads as a logic regression when it is test cross-talk.
+
+Assert on the **specific entity the test created** instead. Seed a unique key (CIK, accession, symbol) and assert membership on that key — `assert any(cik in url for url in seen)` / `assert not any(...)` — not the whole collection's cardinality. First seen: #1337 P2 (PR #1377) — `assert seen == []` on a recording `http_get` over a per-test-TRUNCATEd `institutional_filers`; the assertion happened to pass but was fragile by construction. The fix is CIK-targeted membership.
+
 ## Slim test-data posture
 
 Migrations are **schema-only**. Any `INSERT`/`UPDATE` in a `sql/NNN_*.sql` migration that puts more than ~5 rows of non-reference data into a public table is a defect — file a follow-up ticket, move the seed into a per-test fixture.

--- a/app/jobs/sec_first_install_drain.py
+++ b/app/jobs/sec_first_install_drain.py
@@ -59,6 +59,7 @@ from app.services.bootstrap_state import (
     set_stage_processed,
     set_stage_target,
 )
+from app.services.institutional_holdings import thirteen_f_retention_cutoff
 from app.services.manifest_parsers.sec_n_csr import n_csr_retention_cutoff
 from app.services.processes.bootstrap_cancel_signal import (
     active_bootstrap_stage_key,
@@ -403,6 +404,58 @@ def run_first_install_drain(
             zip_handle.close()
 
 
+def _bulk_already_seeded_13f(
+    conn: psycopg.Connection[Any],
+    *,
+    cik: str,
+    filed_before: datetime,
+) -> bool:
+    """#1337 P2 — true iff bulk (S8) has already seeded this institutional
+    filer's FULL parser-admissible 13F-HR window into ``sec_filing_manifest``.
+
+    Coverage proof (do not weaken without re-deriving):
+      * The ``sec_13f_hr`` manifest-worker parser tombstones any 13F-HR
+        whose ``period_of_report`` predates ``thirteen_f_retention_cutoff``
+        (the 8-quarter floor). So only 13F-HRs with
+        ``period_of_report >= cutoff_quarter_end`` ever yield holdings.
+      * A 13F-HR is filed AFTER its quarter ends, so ``filed_at`` >=
+        ``period_of_report`` for every accession.
+      * Therefore a seeded ``sec_13f_hr`` row with ``filed_at < cutoff``
+        necessarily has ``period_of_report < cutoff`` — it is itself
+        parser-INADMISSIBLE. Its presence proves S8's primary ``recent``
+        block reached back PAST the admissible window, so every
+        admissible 13F-HR for this CIK is already in the manifest.
+      * This bridge ("one pre-cutoff row ⇒ admissible window fully
+        present") relies on SEC's submissions ``recent`` block being the
+        contiguous newest-first slice S8 walked — which holds for a
+        first-install bulk write (S8 ran on a clean DB before this
+        drain). The CALLER therefore gates this on bootstrap context
+        (``progress_ctx is not None``); steady-state / manual / retry
+        runs, where stray rows of mixed provenance could falsely satisfy
+        the EXISTS, never take the skip and fall through to the full
+        HTTP walk.
+
+    Scoped to ``source='sec_13f_hr'`` (NOT just ``subject_type``) so an
+    unrelated old row can't prove 13F coverage, and so the query rides
+    ``idx_manifest_cik(cik, source, filed_at)`` directly. ``filed_at <``
+    is strict: a filing exactly on the cutoff quarter-end could be
+    admissible and must not count as proof of pre-window coverage.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1
+            FROM sec_filing_manifest
+            WHERE cik = %(cik)s
+              AND source = 'sec_13f_hr'
+              AND filed_at < %(filed_before)s
+            LIMIT 1
+            """,
+            {"cik": cik, "filed_before": filed_before},
+        )
+        return cur.fetchone() is not None
+
+
 def _run_first_install_drain_inner(
     conn: psycopg.Connection[Any],
     *,
@@ -477,6 +530,15 @@ def _run_first_install_drain_inner(
     # the helper short-circuits to False (contextvar unset), so
     # scheduled / manual triggers of this job are unaffected.
     _CANCEL_POLL_EVERY_N = 50
+
+    # #1337 P2 — institutional-filer fast-path cutoff. Computed once:
+    # ``thirteen_f_retention_cutoff`` returns the 8-quarter-back quarter
+    # END date; anchor it at UTC midnight as a tz-aware datetime so the
+    # ``filed_at`` (TIMESTAMPTZ) comparison in ``_bulk_already_seeded_13f``
+    # is offset-safe (no naive-datetime drift).
+    _filer_skip_cutoff = datetime.combine(thirteen_f_retention_cutoff(), datetime.min.time(), tzinfo=UTC)
+    _in_bootstrap = progress_ctx is not None
+
     for n, (subject, cik) in enumerate(_iter_in_universe_subjects(conn)):  # type: ignore[misc]
         if n % _CANCEL_POLL_EVERY_N == 0 and bootstrap_cancel_requested():
             # #1114: stage_key sourced from contextvar.
@@ -494,6 +556,29 @@ def _run_first_install_drain_inner(
         if skip_issuer_http and subject.subject_type == "issuer":
             ciks_skipped += 1
             continue
+
+        # #1337 P2 — institutional-filer fast-path. When the bulk S8
+        # writer already seeded this filer's full admissible 13F-HR
+        # window (proven by a pre-cutoff ``sec_13f_hr`` manifest row,
+        # see ``_bulk_already_seeded_13f``), skip the per-CIK HTTP walk
+        # — the ~55-60 min critical-path win on a fresh install.
+        #
+        # Gated on ``_in_bootstrap``: the coverage proof relies on S8
+        # having written the contiguous newest-first ``recent`` block
+        # on a clean DB before this stage. Outside a bootstrap dispatch
+        # (steady-state / manual / cron), manifest rows are of mixed
+        # provenance and a stray pre-cutoff row could falsely satisfy
+        # the EXISTS, so we never skip there — full HTTP walk, unchanged.
+        #
+        # blockholder_filer is deliberately NOT skipped: there is no
+        # validated 13D/G analogue of the 13F 8-quarter retention proof,
+        # so skipping would be unsound the moment that cohort is
+        # non-empty. Conservative by construction, not merely "empty
+        # today".
+        if _in_bootstrap and subject.subject_type == "institutional_filer":
+            if _bulk_already_seeded_13f(conn, cik=cik, filed_before=_filer_skip_cutoff):
+                ciks_skipped += 1
+                continue
 
         try:
             delta = check_freshness(

--- a/tests/test_sec_first_install_drain.py
+++ b/tests/test_sec_first_install_drain.py
@@ -6,23 +6,257 @@ from __future__ import annotations
 import json
 import zipfile
 from collections.abc import Sequence
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 import psycopg
 import pytest
 
 from app.jobs.sec_first_install_drain import (
+    _bulk_already_seeded_13f,
     bootstrap_n_csr_drain,
     run_first_install_drain,
     seed_manifest_from_filing_events,
 )
 from app.services.bootstrap_preconditions import BootstrapPhaseSkipped
 from app.services.bootstrap_state import BootstrapStageCancelled
-from app.services.sec_manifest import get_manifest_row
+from app.services.institutional_holdings import thirteen_f_retention_cutoff
+from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+from app.services.sec_manifest import get_manifest_row, record_manifest_entry
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
 
 pytestmark = pytest.mark.integration
+
+
+_FILER_CUTOFF_DT = datetime.combine(thirteen_f_retention_cutoff(), datetime.min.time(), tzinfo=UTC)
+
+
+def _seed_institutional_filer(conn: psycopg.Connection[tuple], *, cik: str, name: str = "Test Mgr") -> None:
+    conn.execute(
+        "INSERT INTO institutional_filers (cik, name) VALUES (%s, %s) ON CONFLICT (cik) DO NOTHING",
+        (cik, name),
+    )
+    conn.commit()
+
+
+def _seed_blockholder_filer(conn: psycopg.Connection[tuple], *, cik: str, name: str = "Test BH") -> None:
+    conn.execute(
+        "INSERT INTO blockholder_filers (cik, name) VALUES (%s, %s) ON CONFLICT (cik) DO NOTHING",
+        (cik, name),
+    )
+    conn.commit()
+
+
+def _seed_manifest_row(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    cik: str,
+    form: str,
+    source: str,
+    subject_type: str,
+    filed_at: datetime,
+) -> None:
+    record_manifest_entry(
+        conn,
+        accession,
+        cik=cik,
+        form=form,
+        source=source,  # type: ignore[arg-type]
+        subject_type=subject_type,  # type: ignore[arg-type]
+        subject_id=cik,
+        instrument_id=None,
+        filed_at=filed_at,
+    )
+    conn.commit()
+
+
+def _recording_get(payload: dict) -> tuple:
+    """Fake http_get that records every CIK URL it is asked to fetch."""
+    body = json.dumps(payload).encode("utf-8")
+    seen: list[str] = []
+
+    def _impl(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+        seen.append(url)
+        return 200, body
+
+    return _impl, seen
+
+
+class TestFilerFastPathSkip:
+    """#1337 P2 — S16 institutional-filer fast-path skip gate."""
+
+    def test_skips_filer_when_bulk_seeded_pre_cutoff(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        cik = "0009100001"
+        _seed_institutional_filer(ebull_test_conn, cik=cik)
+        # A pre-cutoff 13F-HR row proves the recent block spanned the
+        # full admissible window -> safe to skip in bootstrap.
+        _seed_manifest_row(
+            ebull_test_conn,
+            accession="0009100001-22-000001",
+            cik=cik,
+            form="13F-HR",
+            source="sec_13f_hr",
+            subject_type="institutional_filer",
+            filed_at=_FILER_CUTOFF_DT - timedelta(days=1),
+        )
+        http_get, seen = _recording_get(_AAPL_RECENT)
+        with active_bootstrap_run(99, "sec_first_install_drain"):
+            stats = run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
+        ebull_test_conn.commit()
+
+        assert seen == [], "filer with pre-cutoff bulk row must be skipped (no HTTP fetch)"
+        assert stats.ciks_skipped >= 1
+
+    def test_no_skip_when_only_in_window_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Overflow-safety: a filer whose only seeded 13F-HR is WITHIN the
+        admissible window has not proven full coverage (older in-window
+        rows may have spilled into files[]) -> must NOT skip."""
+        cik = "0009100002"
+        _seed_institutional_filer(ebull_test_conn, cik=cik)
+        _seed_manifest_row(
+            ebull_test_conn,
+            accession="0009100002-26-000001",
+            cik=cik,
+            form="13F-HR",
+            source="sec_13f_hr",
+            subject_type="institutional_filer",
+            filed_at=_FILER_CUTOFF_DT + timedelta(days=30),
+        )
+        http_get, seen = _recording_get(_AAPL_RECENT)
+        with active_bootstrap_run(99, "sec_first_install_drain"):
+            run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
+        ebull_test_conn.commit()
+
+        assert len(seen) == 1, "in-window-only filer must fall through to HTTP walk"
+
+    def test_no_skip_when_unseeded(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        cik = "0009100003"
+        _seed_institutional_filer(ebull_test_conn, cik=cik)
+        http_get, seen = _recording_get(_AAPL_RECENT)
+        with active_bootstrap_run(99, "sec_first_install_drain"):
+            run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
+        ebull_test_conn.commit()
+
+        assert len(seen) == 1, "unseeded filer must be HTTP-walked"
+
+    def test_no_skip_outside_bootstrap(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Steady-state safety: outside a bootstrap dispatch the coverage
+        proof's contiguous-recent-block assumption does not hold, so a
+        pre-cutoff row must NOT trigger a skip."""
+        cik = "0009100004"
+        _seed_institutional_filer(ebull_test_conn, cik=cik)
+        _seed_manifest_row(
+            ebull_test_conn,
+            accession="0009100004-22-000001",
+            cik=cik,
+            form="13F-HR",
+            source="sec_13f_hr",
+            subject_type="institutional_filer",
+            filed_at=_FILER_CUTOFF_DT - timedelta(days=1),
+        )
+        http_get, seen = _recording_get(_AAPL_RECENT)
+        # NO active_bootstrap_run wrapper -> progress_ctx is None.
+        run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
+        ebull_test_conn.commit()
+
+        assert len(seen) == 1, "steady-state drain must never take the filer skip"
+
+    def test_no_skip_blockholder_even_with_pre_cutoff_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """blockholder_filer is conservatively never skipped (no validated
+        13D/G retention proof), even with a pre-cutoff 13D manifest row."""
+        cik = "0009100005"
+        _seed_blockholder_filer(ebull_test_conn, cik=cik)
+        _seed_manifest_row(
+            ebull_test_conn,
+            accession="0009100005-22-000001",
+            cik=cik,
+            form="SC 13D",
+            source="sec_13d",
+            subject_type="blockholder_filer",
+            filed_at=_FILER_CUTOFF_DT - timedelta(days=1),
+        )
+        http_get, seen = _recording_get(_AAPL_RECENT)
+        with active_bootstrap_run(99, "sec_first_install_drain"):
+            run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
+        ebull_test_conn.commit()
+
+        assert len(seen) == 1, "blockholder must always be HTTP-walked"
+
+
+class TestBulkAlreadySeeded13f:
+    """#1337 P2 — the coverage-proof predicate, exercised directly."""
+
+    def test_true_when_pre_cutoff_13f_hr_row_exists(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        cik = "0009200001"
+        _seed_manifest_row(
+            ebull_test_conn,
+            accession="0009200001-22-000001",
+            cik=cik,
+            form="13F-HR",
+            source="sec_13f_hr",
+            subject_type="institutional_filer",
+            filed_at=_FILER_CUTOFF_DT - timedelta(days=1),
+        )
+        assert _bulk_already_seeded_13f(ebull_test_conn, cik=cik, filed_before=_FILER_CUTOFF_DT) is True
+
+    def test_false_when_only_in_window_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        cik = "0009200002"
+        _seed_manifest_row(
+            ebull_test_conn,
+            accession="0009200002-26-000001",
+            cik=cik,
+            form="13F-HR",
+            source="sec_13f_hr",
+            subject_type="institutional_filer",
+            filed_at=_FILER_CUTOFF_DT + timedelta(days=30),
+        )
+        assert _bulk_already_seeded_13f(ebull_test_conn, cik=cik, filed_before=_FILER_CUTOFF_DT) is False
+
+    def test_false_when_no_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        assert _bulk_already_seeded_13f(ebull_test_conn, cik="0009200003", filed_before=_FILER_CUTOFF_DT) is False
+
+    def test_false_for_pre_cutoff_row_of_other_source(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Source-scoped (Codex 1 BLOCKING): a pre-cutoff row of a
+        non-13F source must NOT prove 13F coverage."""
+        cik = "0009200004"
+        _seed_manifest_row(
+            ebull_test_conn,
+            accession="0009200004-22-000001",
+            cik=cik,
+            form="N-CSR",
+            source="sec_n_csr",
+            subject_type="institutional_filer",
+            filed_at=_FILER_CUTOFF_DT - timedelta(days=1),
+        )
+        assert _bulk_already_seeded_13f(ebull_test_conn, cik=cik, filed_before=_FILER_CUTOFF_DT) is False
 
 
 _AAPL_RECENT = {

--- a/tests/test_sec_first_install_drain.py
+++ b/tests/test_sec_first_install_drain.py
@@ -108,7 +108,9 @@ class TestFilerFastPathSkip:
             stats = run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
         ebull_test_conn.commit()
 
-        assert seen == [], "filer with pre-cutoff bulk row must be skipped (no HTTP fetch)"
+        # CIK-targeted (not `seen == []`): robust even if a future fixture
+        # change stops TRUNCATEing institutional_filers between tests.
+        assert not any(cik in url for url in seen), "filer with pre-cutoff bulk row must be skipped (no HTTP fetch)"
         assert stats.ciks_skipped >= 1
 
     def test_no_skip_when_only_in_window_rows(
@@ -134,7 +136,7 @@ class TestFilerFastPathSkip:
             run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
         ebull_test_conn.commit()
 
-        assert len(seen) == 1, "in-window-only filer must fall through to HTTP walk"
+        assert any(cik in url for url in seen), "in-window-only filer must fall through to HTTP walk"
 
     def test_no_skip_when_unseeded(
         self,
@@ -147,7 +149,7 @@ class TestFilerFastPathSkip:
             run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
         ebull_test_conn.commit()
 
-        assert len(seen) == 1, "unseeded filer must be HTTP-walked"
+        assert any(cik in url for url in seen), "unseeded filer must be HTTP-walked"
 
     def test_no_skip_outside_bootstrap(
         self,
@@ -172,7 +174,7 @@ class TestFilerFastPathSkip:
         run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
         ebull_test_conn.commit()
 
-        assert len(seen) == 1, "steady-state drain must never take the filer skip"
+        assert any(cik in url for url in seen), "steady-state drain must never take the filer skip"
 
     def test_no_skip_blockholder_even_with_pre_cutoff_row(
         self,
@@ -196,7 +198,7 @@ class TestFilerFastPathSkip:
             run_first_install_drain(ebull_test_conn, http_get=http_get, follow_pagination=False)
         ebull_test_conn.commit()
 
-        assert len(seen) == 1, "blockholder must always be HTTP-walked"
+        assert any(cik in url for url in seen), "blockholder must always be HTTP-walked"
 
 
 class TestBulkAlreadySeeded13f:


### PR DESCRIPTION
## What
P2 of bulk-first bootstrap — the **~55-60 min critical-path win**. When the bulk S8 writer (P1, #1376) already seeded a filer's full parser-admissible 13F-HR window into `sec_filing_manifest`, S16 (`sec_first_install_drain`) skips the per-CIK HTTP submissions walk for that `institutional_filer` CIK.

- New `_bulk_already_seeded_13f(conn, cik, filed_before)`: `EXISTS` a `source='sec_13f_hr'` manifest row with `filed_at < cutoff`.
- `cutoff = thirteen_f_retention_cutoff()` (8-quarter floor), anchored at UTC midnight; computed once before the per-CIK loop.
- Gate inserted after the issuer fast-path, scoped to `institutional_filer` AND `_in_bootstrap`.

## Why
S16 HTTP-walks ~8.7k institutional-filer CIKs one-by-one over the SEC 10 req/s budget on a fresh install. P1 already seeded their manifest rows from the local `submissions.zip`; P2 lets S16 skip the redundant fetch.

## Correctness — the coverage proof
The `sec_13f_hr` manifest-worker parser tombstones any 13F-HR whose `period_of_report` predates the 8-quarter cutoff. A 13F-HR is filed *after* its quarter ends (`filed_at >= period_of_report`). So a seeded `sec_13f_hr` row with `filed_at < cutoff_quarter_end` necessarily has `period_of_report < cutoff` — it is itself parser-**inadmissible**. Its presence proves S8's primary `recent` block reached back *past* the entire admissible window ⇒ every admissible 13F-HR for that CIK is already seeded ⇒ safe to skip. Filers whose recent block didn't reach a pre-cutoff row fall through to the HTTP walk (which paginates `files[]`) — this is the resolution of the deferred P1 overflow finding.

## Key decisions (Codex 1 on the plan: 2 BLOCKING + 3 IMPORTANT folded)
1. **Source-scoped** (`source='sec_13f_hr'`, not just `subject_type`) — an unrelated old row can't prove 13F coverage; also makes `idx_manifest_cik(cik, source, filed_at)` an exact index fit.
2. **Bootstrap-scoped** (`progress_ctx is not None`) — the contiguous-recent-block assumption holds only for a clean-DB first-install where S8 ran before S16. Steady-state / manual / retry runs fall through to the full HTTP walk so a stray pre-cutoff row of mixed provenance can't false-skip.
3. **`filed_at <` strict** — a filing exactly on the cutoff quarter-end may be admissible and must not count as pre-window proof.
4. **`blockholder_filer` never skipped** — no validated 13D/G analogue of the 13F retention proof; conservative by construction, not merely "empty today".

## Security model
No auth surface. Parameterised query. `_bulk_already_seeded_13f` accepts a caller `conn`, read-only, no commit/rollback.

## Test plan
- `ruff check` / `ruff format --check` / `pyright` (repo-wide) — green.
- `pytest tests/test_sec_first_install_drain.py` — **32 passed (xdist)**, incl. 9 new: skip on pre-cutoff row; **no-skip in-window-only (overflow safety)**; no-skip unseeded; no-skip steady-state (outside bootstrap); no-skip blockholder; + 4 direct `_bulk_already_seeded_13f` cases incl. source scoping.
- Codex 1 on plan + Codex 2 on diff (no findings).

DoD clauses 8-11 (live operator-visible figure) batched into the planned end-of-ETL clean bootstrap run.

Closes part of #1337 (P2; P3 + P4 follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)