### PR TITLE
feat(#1305): operator note — bulk bootstrap depth floor on admin coverage card

### DIFF
--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -327,6 +327,17 @@ function CoverageSummaryCard({
           No instruments currently stuck below the analysable bar.
         </p>
       )}
+      {/* #1305 — operator awareness: bulk bootstrap seeds a rolling-window
+          DEPTH FLOOR, not full history. Source of truth for the depths:
+          app/services/sec_bulk_download.py:241-243 (n_quarters_13f=4,
+          n_quarters_insider=8, n_quarters_nport=4). Static note by design —
+          v1 has no API exposing these params (issue #1305: "no code change
+          for v1" beyond this note). If the defaults change, update this copy. */}
+      <p className="text-xs text-slate-500">
+        Bulk bootstrap covers a rolling-window depth floor: 13F ≈ 12 months,
+        N-PORT 1 year, insider (Form 3/4/5) 2 years. Deeper history requires a
+        re-bootstrap with widened depth params.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## What
Adds an operator-awareness note to the AdminPage "Filings coverage" card: bulk bootstrap seeds a rolling-window **depth floor** (13F ≈ 12 months, N-PORT 1 year, insider 2 years), not full history. Deeper history requires a re-bootstrap with widened depth params.

## Why
#1305 (source-coverage audit): operators can't tell from the UI that deep historical analysis isn't bootstrapped — only the rolling window is. Issue's suggested action is exactly this note ("no code change for v1" beyond operator awareness).

Static copy by design — v1 exposes no API for the depth params; deriving would be overkill for a doc note. A source-of-truth comment points at `app/services/sec_bulk_download.py:241-243` (`n_quarters_13f=4`, `n_quarters_insider=8`, `n_quarters_nport=4`) so the copy stays maintainable.

## Test plan
Frontend-only, no runtime touched. Gates green:
- `pnpm typecheck` ✓
- `pnpm dark:check` ✓ (182 files, 0 violations)
- `pnpm test:unit` ✓ (861 tests)
- Codex checkpoint-2: clean (verified depth→time mapping)

Closes #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)