### PR TITLE
feat(#1347): bootstrap recency-bound cohort for S17 DEF 14A + S18 business-summary

### DIFF
--- a/app/services/business_summary.py
+++ b/app/services/business_summary.py
@@ -47,6 +47,7 @@ from app.services.bootstrap_state import (
     set_stage_processed,
     set_stage_target,
 )
+from app.services.filings import bootstrap_filings_recency_floor
 
 logger = logging.getLogger(__name__)
 
@@ -1494,6 +1495,13 @@ def bootstrap_business_summaries(
     # including the `tables_null AND quarantine_elapsed` AND-guard
     # (PR1 audit memo §3 S18 note).
     progress_ctx = resolve_progress_context()
+    # #1347 — the 13-month recency floor applies ONLY under an orchestrated
+    # bootstrap run. The weekly safety-net auto-fire (Sun 04:00 UTC), manual
+    # POST, and post-outage catch-up fire this chunker WITHOUT a bootstrap
+    # context (progress_ctx None) → unbounded full-backlog drain, unchanged.
+    # This is also what repairs an active-but-delinquent filer (latest 10-K
+    # >13mo) skipped by the bounded first-install run — within ≤7 days.
+    min_filing_date = bootstrap_filings_recency_floor() if progress_ctx is not None else None
     if progress_ctx is not None:
         fingerprint = (
             f"chunk_limit={chunk_limit};"
@@ -1502,7 +1510,8 @@ def bootstrap_business_summaries(
             f"distinct_on=instrument_id;"
             f"ordering=filing_date_desc,filing_event_id_desc;"
             f"url_filter=true;"
-            f"pending_predicate_v2=bs_null_OR_acn_diff_OR_retry_due_OR_(tables_null_AND_quarantine_elapsed)"
+            f"pending_predicate_v2=bs_null_OR_acn_diff_OR_retry_due_OR_(tables_null_AND_quarantine_elapsed);"
+            f"min_filing_date={min_filing_date.isoformat() if min_filing_date is not None else 'none'}"
         )
         set_stage_target(
             run_id=progress_ctx.run_id,
@@ -1519,6 +1528,7 @@ def bootstrap_business_summaries(
             limit=chunk_limit,
             prefetch_urls=prefetch_urls,
             prefetch_user_agent=prefetch_user_agent,
+            min_filing_date=min_filing_date,
         )
         total_scanned += chunk.filings_scanned
         total_inserted += chunk.rows_inserted
@@ -1614,6 +1624,7 @@ def ingest_business_summaries(
     limit: int = 200,
     prefetch_urls: bool = False,
     prefetch_user_agent: str | None = None,
+    min_filing_date: date | None = None,
 ) -> IngestResult:
     """Scan 10-K filings, fetch primary doc, extract Item 1, upsert.
 
@@ -1665,6 +1676,8 @@ def ingest_business_summaries(
                 WHERE fe.provider = 'sec'
                   AND fe.filing_type IN ('10-K', '10-K/A')
                   AND fe.primary_document_url IS NOT NULL
+                  AND (%(min_filing_date)s::date IS NULL
+                       OR fe.filing_date >= %(min_filing_date)s)
                 ORDER BY fe.instrument_id, fe.filing_date DESC, fe.filing_event_id DESC
             )
             SELECT lpi.instrument_id,
@@ -1695,9 +1708,9 @@ def ingest_business_summaries(
                    )
                )
             ORDER BY lpi.filing_date DESC, lpi.filing_event_id DESC
-            LIMIT %s
+            LIMIT %(limit)s
             """,
-            (limit,),
+            {"limit": limit, "min_filing_date": min_filing_date},
         )
         for row in cur.fetchall():
             candidates.append((int(row[0]), str(row[1]), str(row[2]), str(row[3]), row[4]))

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -53,6 +53,7 @@ from app.services.bootstrap_state import (
     set_stage_processed,
     set_stage_target,
 )
+from app.services.filings import bootstrap_filings_recency_floor
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
 from app.services.ownership_observations import (
     record_def14a_observation,
@@ -196,9 +197,18 @@ def discover_pending_def14a(
     *,
     instrument_id: int | None = None,
     limit: int = 100,
+    min_filing_date: date | None = None,
 ) -> list[AccessionRef]:
     """Return DEF 14A accessions in ``filing_events`` that have not
     yet been attempted (no row in ``def14a_ingest_log``).
+
+    ``min_filing_date`` (#1347) is an OPTIONAL recency floor: when set,
+    only accessions with ``filing_date >= min_filing_date`` are
+    considered. ``None`` (default) = full historical backlog. The
+    bootstrap chunker passes the 13-month floor under an orchestrated
+    first-install run; steady-state / weekly safety-net / per-instrument
+    triage pass ``None`` (unbounded). Applied inside the rank CTE so it
+    bounds the ``DEF14A_LATEST_PER_FILER_CAP`` universe before ranking.
 
     Filters on ``filing_type IN _DEF14A_FORM_TYPES`` and
     ``primary_document_url IS NOT NULL`` — accessions without a
@@ -246,6 +256,8 @@ def discover_pending_def14a(
                       AND fe.primary_document_url IS NOT NULL
                       AND log.accession_number IS NULL
                       AND fe.instrument_id = %(iid)s
+                      AND (%(min_filing_date)s::date IS NULL
+                           OR fe.filing_date >= %(min_filing_date)s)
                     ORDER BY fe.filing_date DESC, fe.filing_event_id DESC
                     LIMIT %(limit)s
                     """,
@@ -253,6 +265,7 @@ def discover_pending_def14a(
                         "forms": list(_DEF14A_FORM_TYPES),
                         "iid": instrument_id,
                         "limit": limit,
+                        "min_filing_date": min_filing_date,
                     },
                 )
             else:
@@ -269,6 +282,8 @@ def discover_pending_def14a(
                         WHERE fe.provider = 'sec'
                           AND fe.filing_type = ANY(%(forms)s)
                           AND isp.cik = %(target_cik)s
+                          AND (%(min_filing_date)s::date IS NULL
+                               OR fe.filing_date >= %(min_filing_date)s)
                         ORDER BY fe.provider_filing_id, fe.instrument_id
                     ),
                     ranked AS (
@@ -301,6 +316,7 @@ def discover_pending_def14a(
                         "target_cik": target_cik,
                         "cap": DEF14A_LATEST_PER_FILER_CAP,
                         "limit": limit,
+                        "min_filing_date": min_filing_date,
                     },
                 )
         else:
@@ -321,6 +337,8 @@ def discover_pending_def14a(
                         ON isp.instrument_id = fe.instrument_id
                     WHERE fe.provider = 'sec'
                       AND fe.filing_type = ANY(%(forms)s)
+                      AND (%(min_filing_date)s::date IS NULL
+                           OR fe.filing_date >= %(min_filing_date)s)
                     ORDER BY fe.provider_filing_id, (isp.cik IS NULL),
                              fe.instrument_id
                 ),
@@ -349,6 +367,7 @@ def discover_pending_def14a(
                     "forms": list(_DEF14A_FORM_TYPES),
                     "cap": DEF14A_LATEST_PER_FILER_CAP,
                     "limit": limit,
+                    "min_filing_date": min_filing_date,
                 },
             )
         rows = cur.fetchall()
@@ -973,6 +992,7 @@ def ingest_def14a(
     limit: int = 100,
     prefetch_urls: bool = False,
     prefetch_user_agent: str | None = None,
+    min_filing_date: date | None = None,
 ) -> IngestSummary:
     """Discover pending DEF 14A accessions and ingest each.
 
@@ -986,7 +1006,7 @@ def ingest_def14a(
     matching log entries). Mirrors the institutional-holdings
     ingester's commit cadence.
     """
-    pending = discover_pending_def14a(conn, instrument_id=instrument_id, limit=limit)
+    pending = discover_pending_def14a(conn, instrument_id=instrument_id, limit=limit, min_filing_date=min_filing_date)
     if not pending:
         return IngestSummary(
             accessions_seen=0,
@@ -1212,6 +1232,11 @@ def bootstrap_def14a(
     # `_DEF14A_FORM_TYPES` cardinality (computed below) is included so
     # the operator can audit the cohort form-type set.
     progress_ctx = resolve_progress_context()
+    # #1347 — the 13-month recency floor applies ONLY under an orchestrated
+    # bootstrap run. The weekly safety-net auto-fire (Sun 02:30 UTC), manual
+    # POST, and post-outage catch-up fire this chunker WITHOUT a bootstrap
+    # context (progress_ctx None) → unbounded full-backlog drain, unchanged.
+    min_filing_date = bootstrap_filings_recency_floor() if progress_ctx is not None else None
     if progress_ctx is not None:
         fingerprint = (
             f"chunk_limit={chunk_limit};"
@@ -1221,7 +1246,8 @@ def bootstrap_def14a(
             f"rank_scope=def14a_with_cik;"
             f"rank_predicate=type<>DEF14A_OR_cik_null_OR_rank<=cap;"
             f"url_filter=true;tombstone_filter=true;"
-            f"pending_predicate_v1=true"
+            f"pending_predicate_v1=true;"
+            f"min_filing_date={min_filing_date.isoformat() if min_filing_date is not None else 'none'}"
         )
         set_stage_target(
             run_id=progress_ctx.run_id,
@@ -1238,6 +1264,7 @@ def bootstrap_def14a(
             limit=chunk_limit,
             prefetch_urls=prefetch_urls,
             prefetch_user_agent=prefetch_user_agent,
+            min_filing_date=min_filing_date,
         )
         total_seen += chunk.accessions_seen
         total_succeeded += chunk.accessions_succeeded

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -39,7 +39,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 
 import psycopg
 
@@ -116,6 +116,40 @@ def filing_within_retention(filing_date: date, now: datetime | None = None) -> b
     retained (no off-by-one drop on the rolling boundary).
     """
     return filing_date >= filing_events_retention_cutoff(now)
+
+
+# ---------------------------------------------------------------------------
+# #1347 — first-install cohort recency floor for S17 (DEF 14A bootstrap) and
+# S18 (business-summary bootstrap). These two stages otherwise walk the FULL
+# historical filing_events backlog and deadline-cut at 60 min (Run #8). The
+# floor is applied ONLY under an orchestrated bootstrap run (the chunkers gate
+# on ``resolve_progress_context()``); the weekly safety-net auto-fire + manual
+# POST + post-outage catch-up stay unbounded. 13 months ≈ latest annual proxy /
+# 10-K per issuer + a fiscal-year-boundary buffer. Single-symbol edit with grep
+# visibility, not a hidden magic number per writer.
+# ---------------------------------------------------------------------------
+BOOTSTRAP_FILINGS_RECENCY_DAYS: int = 396
+
+
+def bootstrap_filings_recency_floor(now: datetime | None = None) -> date:
+    """Earliest ``filing_date`` an orchestrated first-install bootstrap of S17 /
+    S18 considers. Returns a ``date`` (``filing_events.filing_date`` is a DATE
+    column — no time-of-day semantics).
+
+    Mirrors :func:`app.services.institutional_holdings.thirteen_f_retention_cutoff`:
+    reject a naive ``now`` then normalise to UTC, so the calendar day never
+    drifts with the host timezone (``date.today()`` would — Codex catch on
+    #1010's cutoff). ``now`` is injectable for tests.
+    """
+    if now is None:
+        now = datetime.now(tz=UTC)
+    # ``tzinfo is None`` OR a tzinfo whose ``utcoffset()`` is None is naive by
+    # Python's definition — ``astimezone(UTC)`` would then assume host-local
+    # time and defeat the UTC contract (Codex #1347 LOW). Stricter than the
+    # sibling thirteen_f_retention_cutoff guard on purpose.
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("bootstrap_filings_recency_floor requires a tz-aware now")
+    return now.astimezone(UTC).date() - timedelta(days=BOOTSTRAP_FILINGS_RECENCY_DAYS)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/proposals/etl/1347-s17-s18-recency-bound.md
+++ b/docs/proposals/etl/1347-s17-s18-recency-bound.md
@@ -1,0 +1,145 @@
+# #1347 — S17 + S18 bootstrap recency-bound cohort
+
+Status: proposal. Phase 3 PR1 of the bootstrap-sub-1h plan. Window decision:
+**13 months** (operator-confirmed 2026-05-29; master plan §Phase 3; supersedes
+the 4-year alternative floated in #1342's comment).
+
+## 0. TL;DR
+
+S17 `sec_def14a_bootstrap` + S18 `sec_business_summary_bootstrap` walk the FULL
+historical `filing_events` backlog and deadline-cut at 60 min (Run #8). Add an
+OPTIONAL `min_filing_date` recency bound to both discovery selectors. The bound
+is applied ONLY under a true orchestrated bootstrap run (`resolve_progress_context()
+is not None`); the WEEKLY safety-net auto-fire + manual POST + post-outage
+catch-up (same invoker, but progress_ctx None) stay UNBOUNDED. Cohort ~50k →
+~5-10k → drains inside budget. ~60 min combined saving. #1342's parallelise
+premise is already shipped (#1045 PipelinedSecFetcher in both invokers) → close
+#1342 as superseded.
+
+**Gate correction (Codex checkpoint-1):** the invokers are NOT first-install
+only — they auto-fire weekly (S17 Sun 02:30 UTC, S18 Sun 04:00 UTC) as
+unbounded safety-nets and run on manual POST / post-outage catch-up. Keying the
+bound on invoker identity would wrongly bound those. `active_bootstrap_run` is
+entered only by the orchestrator (`bootstrap_orchestrator.py:1472`), so
+`resolve_progress_context()` is the correct first-install discriminator — same
+gate P2 #1377 / the S15 design use.
+
+## 1. Surface (optional param + chunker-resolved gate)
+
+Single source of truth — new helper in `app/services/filings.py` (already holds
+`SEC_INGEST_KEEP_FORMS` + retention helpers):
+```python
+BOOTSTRAP_FILINGS_RECENCY_DAYS = 396  # 13 months ≈ latest annual proxy / 10-K + FY-boundary buffer
+
+def bootstrap_filings_recency_floor(now: datetime | None = None) -> date:
+    """First-install cohort floor for S17/S18. Mirrors
+    thirteen_f_retention_cutoff (institutional_holdings.py:105-126):
+    reject naive now, normalise to UTC. Never date.today() (local-TZ
+    drift — Codex catch on #1010's cutoff)."""
+    if now is None:
+        now = datetime.now(tz=UTC)
+    if now.tzinfo is None:
+        raise ValueError("bootstrap_filings_recency_floor requires tz-aware now")
+    return now.astimezone(UTC).date() - timedelta(days=BOOTSTRAP_FILINGS_RECENCY_DAYS)
+```
+
+DEF 14A (S17):
+- `discover_pending_def14a(conn, *, instrument_id=None, limit=100, min_filing_date: date | None = None)` — `app/services/def14a_ingest.py:194`
+- `ingest_def14a(..., min_filing_date: date | None = None)` — `:968`, passes to discover
+- `bootstrap_def14a(..., min_filing_date: date | None = None)` — `:1164`. Resolves the gate: when its own `progress_ctx is not None`, default `min_filing_date` to `bootstrap_filings_recency_floor()`; else `None`. Passes to `ingest_def14a` + records the value in the #1273 cohort fingerprint.
+- invoker `sec_def14a_bootstrap` — `app/workers/scheduler.py:4326` — UNCHANGED (chunker owns the gate).
+
+Business summary (S18):
+- `ingest_business_summaries(..., min_filing_date: date | None = None)` — `app/services/business_summary.py:1610`
+- `bootstrap_business_summaries(..., min_filing_date: date | None = None)` — `:1452`. Same chunker-resolved gate on its own `progress_ctx`; passes through + records in fingerprint.
+- invoker `sec_business_summary_bootstrap` — `app/workers/scheduler.py:4156` — UNCHANGED.
+
+Why the chunker, not the invoker: the bound must apply only to TRUE orchestrated
+bootstrap, not the weekly safety-net / manual catch-up that share the invoker.
+The chunkers ALREADY call `resolve_progress_context()` for instrumentation, so
+the gate lives there. `min_filing_date` stays an explicit param (default `None`)
+so tests + per-instrument triage can override without a bootstrap context.
+
+## 2. SQL predicate (NULL-guarded — one shape, all branches)
+
+Add to each candidate query's WHERE, inert when the param is NULL:
+```sql
+AND (%(min_filing_date)s::date IS NULL OR fe.filing_date >= %(min_filing_date)s)
+```
+- DEF 14A: add to the `per_accession` CTE WHERE in BOTH the per-instrument
+  (`:266`) and universe-wide (`:319`) branches, and the CIK-MISSING legacy
+  branch (`:241`). Placing it in the CTE bounds the rank universe before
+  `ROW_NUMBER()` — equivalent result to filtering post-rank (we want
+  `rank ≤ cap AND filed ≥ floor`), cheaper. The latest-N-per-CIK cap
+  (`DEF14A_LATEST_PER_FILER_CAP`) is unchanged and composes.
+- Business summary: add to the `latest_per_instrument` CTE WHERE (`:1665-1667`).
+  Already `DISTINCT ON (instrument_id)` newest 10-K, so the bound EXCLUDES
+  instruments whose newest 10-K is staler than 13 months (delisted / lapsed
+  filers). Active filers always have a ≤15-month-old 10-K (annual cadence +
+  ~90d filing lag); 13 months risks excluding a late-cycle filer until its
+  next 10-K — self-heals via the unbounded steady-state path. Acceptable v1
+  floor (same posture as #1305 depth floor).
+
+## 3. Instrumentation (#1273 — no silent caps)
+
+Both chunkers stamp a `cohort_fingerprint` via `set_stage_target`. Append the
+bound so the operator sees it:
+- `bootstrap_def14a` fingerprint (`def14a_ingest.py:1216-1225`): add
+  `min_filing_date={iso-or-'none'}`.
+- `bootstrap_business_summaries` fingerprint (if present): same.
+Terminal log lines already report counts; no cap is applied silently.
+
+## 4. Bootstrap-vs-steady-state correctness
+
+The bound is keyed by `resolve_progress_context()` inside the chunker, NOT by
+invoker identity (Codex checkpoint-1 fix):
+- **Orchestrated first-install bootstrap** (`active_bootstrap_run` set by
+  `bootstrap_orchestrator.py:1472`) → `progress_ctx` non-None → 13mo bound.
+- **Weekly safety-net auto-fire** (S17 Sun 02:30, S18 Sun 04:00 UTC), **manual
+  POST**, **post-outage catch-up** → same invoker, but fired directly (no
+  orchestrator) → `progress_ctx` None → UNBOUNDED. Full historical backlog
+  drained, behaviour unchanged.
+- **Manifest worker + `sec_10k.py`** (S18 steady-state) / **daily DEF 14A cron**
+  (S17) / **per-instrument operator triage** → never enter the chunker with a
+  bootstrap context → unbounded.
+
+This resolves the S18 active-but-delinquent-filer undercoverage: a filer whose
+latest 10-K is >13mo (NT-extended / delinquent) is skipped by the first-install
+bootstrap, but the WEEKLY unbounded safety-net repairs the gap within ≤7 days —
+not "next annual filing." Same applies to S17 DEF 14A. Tail-history backfill is
+preserved exactly where the issue requires it.
+
+## 5. Test plan
+
+Unit (extend `tests/test_def14a_ingest.py`, `tests/test_business_summary*.py`):
+1. `discover_pending_def14a(min_filing_date=floor)` excludes a pre-floor
+   accession; includes a post-floor one; boundary (`= floor`) included (`>=`).
+2. `min_filing_date=None` → unbounded (existing behaviour, regression guard).
+3. per-instrument triage branch with `min_filing_date=None` → unbounded.
+4. `ingest_business_summaries(min_filing_date=floor)` excludes instrument whose
+   latest 10-K is pre-floor; includes within-floor.
+5. chunkers (`bootstrap_def14a` / `bootstrap_business_summaries`) apply the
+   floor ONLY under a bootstrap context: with `progress_ctx` set (patched), the
+   threaded `min_filing_date` equals `bootstrap_filings_recency_floor()`; with
+   `progress_ctx` None (weekly/manual path), it stays `None` (unbounded). Plus a
+   direct unit test on `bootstrap_filings_recency_floor`: naive `now` raises;
+   aware non-UTC `now` normalises to the correct UTC calendar day.
+
+DoD 8-12 (ETL clauses): smoke panel AAPL/GME/MSFT/JPM/HD — confirm each has a
+DEF 14A + business summary within the 13mo cohort post-bootstrap; backfill via
+the bootstrap invoker on dev DB; operator-visible figure (ownership rollup +
+business panel render). Batched into the end-of-ETL clean bootstrap per the
+#1337 epic convention (operator-driven).
+
+## 6. #1342 disposition
+
+Close as superseded: parallelise (PipelinedSecFetcher `prefetch_urls=True`) is
+already in both invokers (#1045 — verified `scheduler.py:4337`, `:4185`); the
+only residual (cohort tightening) IS this PR. No separate code.
+
+## 7. References
+
+- Plan: `docs/proposals/etl/bootstrap-sub-1h-plan.md` §Phase 3
+- Selectors: `def14a_ingest.py:194`, `business_summary.py:1610`
+- UTC-cutoff prevention: memory `project_1010_13f_cohort_bound` (date.today vs UTC)
+- Cohort-bound precedent: #1010 (13F), #1222 (NPORT)

--- a/tests/test_filings_recency_bound.py
+++ b/tests/test_filings_recency_bound.py
@@ -1,0 +1,233 @@
+"""#1347 — S17 + S18 bootstrap recency-bound cohort.
+
+Pins:
+1. ``bootstrap_filings_recency_floor`` — UTC-normalised, naive rejected,
+   13-month (396d) offset. Pure unit (no DB).
+2. ``discover_pending_def14a(min_filing_date=...)`` — excludes pre-floor
+   accessions, includes the boundary (``>=``), ``None`` is unbounded.
+3. ``ingest_business_summaries(min_filing_date=...)`` — excludes an
+   instrument whose latest 10-K is staler than the floor; includes
+   within-floor; ``None`` is unbounded.
+
+The chunker-level gate (``progress_ctx``-derived floor) is exercised by the
+existing bootstrap tests; here we pin the value-agnostic selectors + the pure
+floor helper, which is where the correctness lives.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta, timezone
+from typing import cast
+
+import psycopg
+import pytest
+
+from app.services.business_summary import ingest_business_summaries
+from app.services.def14a_ingest import discover_pending_def14a
+from app.services.filings import (
+    BOOTSTRAP_FILINGS_RECENCY_DAYS,
+    bootstrap_filings_recency_floor,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+# ---------------------------------------------------------------------------
+# Pure helper — no DB
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapFilingsRecencyFloor:
+    def test_offset_is_396_days(self) -> None:
+        now = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+        floor = bootstrap_filings_recency_floor(now)
+        assert (now.date() - floor).days == BOOTSTRAP_FILINGS_RECENCY_DAYS == 396
+
+    def test_naive_now_rejected(self) -> None:
+        with pytest.raises(ValueError, match="tz-aware"):
+            bootstrap_filings_recency_floor(datetime(2026, 5, 29, 12, 0))  # noqa: DTZ001 — intentional naive
+
+    def test_non_utc_now_normalised_to_utc_calendar_day(self) -> None:
+        # 23:00 at UTC-5 is 04:00 the NEXT calendar day in UTC. The floor
+        # must anchor to the UTC day (2026-05-30), not the local day.
+        est = timezone(timedelta(hours=-5))
+        now = datetime(2026, 5, 29, 23, 0, tzinfo=est)
+        floor = bootstrap_filings_recency_floor(now)
+        assert floor == date(2026, 5, 30) - timedelta(days=BOOTSTRAP_FILINGS_RECENCY_DAYS)
+
+
+# ---------------------------------------------------------------------------
+# Integration — selectors against the dev DB
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+        VALUES (%s, %s, %s, TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_profile(conn: psycopg.Connection[tuple], *, instrument_id: int, cik: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instrument_sec_profile (instrument_id, cik)
+        VALUES (%s, %s)
+        ON CONFLICT (instrument_id) DO UPDATE SET cik = EXCLUDED.cik
+        """,
+        (instrument_id, cik),
+    )
+
+
+def _seed_filing_event(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    accession: str,
+    filing_date: date,
+    filing_type: str = "DEF 14A",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type,
+            provider, provider_filing_id, primary_document_url
+        ) VALUES (%s, %s, %s, 'sec', %s, 'https://example.test/doc.htm')
+        ON CONFLICT (provider, provider_filing_id, instrument_id) DO NOTHING
+        """,
+        (instrument_id, filing_date, filing_type, accession),
+    )
+
+
+_FLOOR = date(2025, 1, 1)
+
+
+class TestDef14aDiscoverRecencyBound:
+    def test_floor_excludes_pre_within_cap(
+        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+    ) -> None:
+        """Two DEF 14A — both within the latest-2-per-filer cap, so the cap
+        drops neither. The floor is the ONLY discriminator: with the floor,
+        only the post-floor accession survives; with ``None``, both do."""
+        conn = ebull_test_conn
+        iid = 1_347_001
+        _seed_instrument(conn, iid=iid, symbol="RECA")
+        _seed_profile(conn, instrument_id=iid, cik="0001347001")
+        _seed_filing_event(conn, instrument_id=iid, accession="REC-PRE", filing_date=date(2024, 1, 1))
+        _seed_filing_event(conn, instrument_id=iid, accession="REC-POST", filing_date=date(2026, 1, 1))
+        conn.commit()
+
+        ours = {"REC-PRE", "REC-POST"}
+        bounded = {
+            r.accession_number
+            for r in discover_pending_def14a(conn, min_filing_date=_FLOOR, limit=100)
+            if r.accession_number in ours
+        }
+        unbounded = {
+            r.accession_number
+            for r in discover_pending_def14a(conn, min_filing_date=None, limit=100)
+            if r.accession_number in ours
+        }
+        assert bounded == {"REC-POST"}  # floor excludes pre, NOT the cap
+        assert unbounded == ours  # both within cap → unbounded returns both
+
+    def test_boundary_is_inclusive(
+        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+    ) -> None:
+        """A filing dated exactly on the floor is retained (``>=``)."""
+        conn = ebull_test_conn
+        iid = 1_347_002
+        _seed_instrument(conn, iid=iid, symbol="RECB")
+        _seed_profile(conn, instrument_id=iid, cik="0001347002")
+        _seed_filing_event(conn, instrument_id=iid, accession="REC-BND", filing_date=_FLOOR)
+        conn.commit()
+
+        bounded = {
+            r.accession_number
+            for r in discover_pending_def14a(conn, min_filing_date=_FLOOR, limit=100)
+            if r.accession_number == "REC-BND"
+        }
+        assert bounded == {"REC-BND"}
+
+
+class TestBusinessSummaryRecencyBound:
+    class _NullFetcher:
+        """Returns no body — we assert on candidate selection
+        (``filings_scanned``), not on parse output."""
+
+        def fetch_document_text(self, absolute_url: str) -> str | None:
+            return None
+
+    def _seed_10k(
+        self,
+        conn: psycopg.Connection[tuple],
+        *,
+        instrument_id: int,
+        accession: str,
+        filing_date: date,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO filing_events (
+                instrument_id, filing_date, filing_type,
+                provider, provider_filing_id, primary_document_url
+            ) VALUES (%s, %s, '10-K', 'sec', %s, 'https://example.test/10k.htm')
+            ON CONFLICT (provider, provider_filing_id, instrument_id) DO NOTHING
+            """,
+            (instrument_id, filing_date, accession),
+        )
+
+    def test_stale_latest_10k_excluded_by_floor(
+        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid = 1_347_010
+        _seed_instrument(conn, iid=iid, symbol="BSA")
+        self._seed_10k(conn, instrument_id=iid, accession="BSA-STALE", filing_date=date(2023, 1, 1))
+        conn.commit()
+
+        result = ingest_business_summaries(
+            conn, cast("object", self._NullFetcher()), min_filing_date=_FLOOR  # type: ignore[arg-type]
+        )
+        scanned = {
+            iid
+            for (iid,) in conn.execute(
+                "SELECT instrument_id FROM filing_events WHERE provider_filing_id = 'BSA-STALE'"
+            ).fetchall()
+        }
+        # Stale-latest instrument is in filing_events but excluded from the
+        # bounded cohort → not scanned.
+        assert iid in scanned  # sanity: row exists
+        assert result.filings_scanned == 0
+
+    def test_within_floor_10k_scanned(
+        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid = 1_347_011
+        _seed_instrument(conn, iid=iid, symbol="BSB")
+        self._seed_10k(conn, instrument_id=iid, accession="BSB-FRESH", filing_date=date(2026, 2, 1))
+        conn.commit()
+
+        result = ingest_business_summaries(
+            conn, cast("object", self._NullFetcher()), min_filing_date=_FLOOR  # type: ignore[arg-type]
+        )
+        assert result.filings_scanned == 1
+
+    def test_none_is_unbounded(
+        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        iid = 1_347_012
+        _seed_instrument(conn, iid=iid, symbol="BSC")
+        self._seed_10k(conn, instrument_id=iid, accession="BSC-OLD", filing_date=date(2019, 6, 1))
+        conn.commit()
+
+        result = ingest_business_summaries(
+            conn, cast("object", self._NullFetcher()), min_filing_date=None  # type: ignore[arg-type]
+        )
+        assert result.filings_scanned == 1

--- a/tests/test_filings_recency_bound.py
+++ b/tests/test_filings_recency_bound.py
@@ -17,7 +17,6 @@ floor helper, which is where the correctness lives.
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta, timezone
-from typing import cast
 
 import psycopg
 import pytest
@@ -195,8 +194,8 @@ class TestBusinessSummaryRecencyBound:
 
         result = ingest_business_summaries(
             conn,
-            cast("object", self._NullFetcher()),
-            min_filing_date=_FLOOR,  # type: ignore[arg-type]
+            self._NullFetcher(),
+            min_filing_date=_FLOOR,
         )
         scanned = {
             iid
@@ -221,8 +220,8 @@ class TestBusinessSummaryRecencyBound:
 
         result = ingest_business_summaries(
             conn,
-            cast("object", self._NullFetcher()),
-            min_filing_date=_FLOOR,  # type: ignore[arg-type]
+            self._NullFetcher(),
+            min_filing_date=_FLOOR,
         )
         assert result.filings_scanned == 1
 
@@ -238,7 +237,7 @@ class TestBusinessSummaryRecencyBound:
 
         result = ingest_business_summaries(
             conn,
-            cast("object", self._NullFetcher()),
-            min_filing_date=None,  # type: ignore[arg-type]
+            self._NullFetcher(),
+            min_filing_date=None,
         )
         assert result.filings_scanned == 1

--- a/tests/test_filings_recency_bound.py
+++ b/tests/test_filings_recency_bound.py
@@ -108,7 +108,8 @@ _FLOOR = date(2025, 1, 1)
 
 class TestDef14aDiscoverRecencyBound:
     def test_floor_excludes_pre_within_cap(
-        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     ) -> None:
         """Two DEF 14A — both within the latest-2-per-filer cap, so the cap
         drops neither. The floor is the ONLY discriminator: with the floor,
@@ -136,7 +137,8 @@ class TestDef14aDiscoverRecencyBound:
         assert unbounded == ours  # both within cap → unbounded returns both
 
     def test_boundary_is_inclusive(
-        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     ) -> None:
         """A filing dated exactly on the floor is retained (``>=``)."""
         conn = ebull_test_conn
@@ -182,7 +184,8 @@ class TestBusinessSummaryRecencyBound:
         )
 
     def test_stale_latest_10k_excluded_by_floor(
-        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     ) -> None:
         conn = ebull_test_conn
         iid = 1_347_010
@@ -191,7 +194,9 @@ class TestBusinessSummaryRecencyBound:
         conn.commit()
 
         result = ingest_business_summaries(
-            conn, cast("object", self._NullFetcher()), min_filing_date=_FLOOR  # type: ignore[arg-type]
+            conn,
+            cast("object", self._NullFetcher()),
+            min_filing_date=_FLOOR,  # type: ignore[arg-type]
         )
         scanned = {
             iid
@@ -205,7 +210,8 @@ class TestBusinessSummaryRecencyBound:
         assert result.filings_scanned == 0
 
     def test_within_floor_10k_scanned(
-        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     ) -> None:
         conn = ebull_test_conn
         iid = 1_347_011
@@ -214,12 +220,15 @@ class TestBusinessSummaryRecencyBound:
         conn.commit()
 
         result = ingest_business_summaries(
-            conn, cast("object", self._NullFetcher()), min_filing_date=_FLOOR  # type: ignore[arg-type]
+            conn,
+            cast("object", self._NullFetcher()),
+            min_filing_date=_FLOOR,  # type: ignore[arg-type]
         )
         assert result.filings_scanned == 1
 
     def test_none_is_unbounded(
-        self, ebull_test_conn: psycopg.Connection[tuple]  # noqa: F811
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     ) -> None:
         conn = ebull_test_conn
         iid = 1_347_012
@@ -228,6 +237,8 @@ class TestBusinessSummaryRecencyBound:
         conn.commit()
 
         result = ingest_business_summaries(
-            conn, cast("object", self._NullFetcher()), min_filing_date=None  # type: ignore[arg-type]
+            conn,
+            cast("object", self._NullFetcher()),
+            min_filing_date=None,  # type: ignore[arg-type]
         )
         assert result.filings_scanned == 1


### PR DESCRIPTION
## What
13-month (396d) recency floor for the S17 `sec_def14a_bootstrap` + S18 `sec_business_summary_bootstrap` cohorts, applied **only under an orchestrated bootstrap run**. Both stages deadline-cut at 60 min on Run #8 walking the full historical `filing_events` backlog (~50k accessions); the floor trims to ~5-10k → drains inside budget (~60 min combined saving).

## Why
Per #1347: the 1-hour scheduler deadline GUARANTEES partial drain on the unbounded cohort → silent undercoverage. Most issuers file ~1 proxy / ~1 10-K per year, so a 13-month window captures the latest annual filing per issuer + a fiscal-year buffer. Window = 13 months (operator-confirmed; master plan §Phase 3; the 4-year alternative in #1342's comment was declined).

## How (key decisions)
- **Gate on `resolve_progress_context()`, not invoker identity** (Codex checkpoint-1 fix). The invokers also auto-fire weekly (S17 Sun 02:30, S18 Sun 04:00 UTC) + manual POST + post-outage catch-up — those fire WITHOUT a bootstrap context → `progress_ctx` None → **unbounded, unchanged**. This also repairs an active-but-delinquent filer (latest 10-K >13mo) skipped by the bounded run, within ≤7 days.
- New `bootstrap_filings_recency_floor()` in `filings.py` — single source of truth, UTC-normalised, rejects naive / None-utcoffset `now` (`date.today()` local-TZ drift was a Codex catch on #1010).
- NULL-guarded predicate in all 3 `discover_pending_def14a` branches (inside the `per_accession` CTE so it bounds the `DEF14A_LATEST_PER_FILER_CAP` rank universe — composes with the cap) + the S18 `latest_per_instrument` CTE. `LIMIT` converted to a named param (psycopg forbids mixing positional/named).
- #1273 cohort fingerprints extended with `min_filing_date` (no silent cap).

**#1342 closed-as-superseded:** its parallelise premise (PipelinedSecFetcher) already shipped via #1045 (`prefetch_urls=True` in both invokers, verified `scheduler.py:4337` / `:4185`); the only residual (cohort tightening) IS this PR.

## Test plan
- `tests/test_filings_recency_bound.py` (8): pure floor helper (UTC normalise / naive reject / 396d offset); DEF 14A discover (floor isolated from the latest-N cap, boundary inclusive `>=`, `None` unbounded); business-summary (stale-latest-10-K excluded, within-floor scanned, `None` unbounded).
- Regression: def14a + business_summary + retention suites — **108 passed**.
- `ruff` / `ruff format` / `pyright` clean. Codex checkpoint-1 (spec, 2 rounds) + checkpoint-2 (diff) clean.

DoD 8-11 (live backfill + operator-visible figure) batched into the end-of-ETL clean bootstrap per the #1337 epic convention (dev DB fresh-empty; operator-driven).

Closes #1347
Closes #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)