### PR TITLE
docs(skills): extract #1343 PR-B review lessons

### DIFF
--- a/.claude/skills/engineering/pr-authoring.md
+++ b/.claude/skills/engineering/pr-authoring.md
@@ -74,6 +74,12 @@ A good PR description answers:
 
 A bad PR description is just a restatement of the ticket title.
 
+## `verify-issue-link` CI gate — every `#N` in the TITLE needs a verb-link in the body
+
+The `verify-issue-link` job greps **every** `#N` out of the PR *title* and fails unless each appears in the body preceded by a recognised verb (`close[sd]`/`closing`/`fix(es|ed|ing)`/`resolve[sd]`/`resolving`/`refs?`/`references?`/`track[sd]`/`tracking`/`part of`/`umbrella`) + whitespace/colon + `#N`. Inline code and fenced/comment blocks are stripped first, so a `Closes #N` inside backticks or `<!-- -->` does **not** count.
+
+Trap: a title like `feat(#1384): … (#1343 PR-B)` references **two** issues. `Closes #1384` satisfies one; the other (`#1343`) must also be verb-linked — bare prose ("half of #1343") fails. Fix: add `Part of #1343.` (or `Refs #1343.`). Don't reference a closed/parent issue in the title unless you'll verb-link it. (PR #1385.)
+
 ## Pre-submit check
 
 Before opening or updating the PR, ask:

--- a/.claude/skills/frontend/async-data-loading.md
+++ b/.claude/skills/frontend/async-data-loading.md
@@ -141,6 +141,22 @@ this destructuring pattern is what lets ESLint see the contract.
 refs as local const bindings so ESLint can see their identity..."). Mirror it
 on every page that aggregates multiple `useAsync` calls.
 
+### `asyncData ?? prop` is unsafe when the two can describe different entities
+
+`useAsync` clears stale `data` **inside its effect** — i.e. *after* the render where `deps` changed. The `cancelled` flag stops a stale *resolution* from landing, but it does nothing about the render in between. So deriving displayed state as `asyncData ?? fallbackProp` flashes the *previous* entity for one frame whenever the selection changes.
+
+```tsx
+// WRONG — switching rows shows filing A's body under filing B for one render
+const body = useAsync(() => fetchBody(selected.id), [selected.id]);
+const shown = body.data ?? selected;   // body.data is still A on B's first render
+
+// RIGHT — prove the fetched data belongs to the current selection
+const shown =
+  body.data?.id === selected?.id ? body.data : selected;
+```
+
+Rule: when both `asyncData` and the fallback can describe *different* records, gate `asyncData` on an identity field (id / accession / symbol) before using it. Only safe to write `asyncData ?? prop` when they describe the *same* slot (e.g. a detail of the same fixed entity). Caught by Codex on #1343 PR-B (`EightKListPage` 8-K fetch-on-select).
+
 ### Cancellation
 
 Every effect that resolves async data must check a `cancelled` flag before calling state setters, so a stale resolution cannot overwrite a newer one. If you write a new async hook, this is non-negotiable.


### PR DESCRIPTION
## What
Two skill edits, docs-only:
- `async-data-loading`: `asyncData ?? prop` one-render stale-entity flash on selection change → gate on identity field (Codex ckpt2 finding on #1343 PR-B).
- `pr-authoring`: `verify-issue-link` CI requires every `#N` in the PR TITLE to be verb-linked in the body; multi-issue titles need each linked.

## Why
Skill-ownership discipline (CLAUDE.md): lessons surfaced in #1343 PR-B (PR #1385, merged) extracted into the owning skills. PR-B already merged, so this is the bundled follow-up.

## Test plan
Docs-only — no code, no gates affected.

Refs #1343

🤖 Generated with [Claude Code](https://claude.com/claude-code)