### PR TITLE
fix(#1399): inline-delete resolved unresolved_13f_cusips bulk markers at materialisation

### DIFF
--- a/app/services/cusip_resolver.py
+++ b/app/services/cusip_resolver.py
@@ -405,6 +405,149 @@ def flush_unresolved_cusips_bulk(
         return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
 
 
+# Internal — staging-table column list for the resolved-marker delete.
+# Order pinned because the ``cur.copy(...)`` write binds by position.
+_RESOLVED_STG_COLS: Final = ("cusip", "filer_cik", "period_end")
+
+
+def in_window_bulk_markers_exist(
+    conn: psycopg.Connection[Any],
+    source: BulkCusipSource,
+    cutoff: date,
+) -> bool:
+    """Preflight gate for :func:`delete_resolved_bulk_markers` (#1399).
+
+    True iff any bulk marker for ``source`` has ``period_end >= cutoff``.
+    A resolved observation is always in-window (the ingest materialise
+    gate rejects out-of-retention rows), so a marker the ingest could
+    delete sits at ``period_end >= cutoff``. When none exist the
+    ingester skips collection entirely — no set growth, no temp table,
+    no DELETE. Post-PR1 (#1398 retention purge) the in-window marker set
+    is small and shrinking, so most steady-state runs short-circuit
+    here, keeping the inline delete from building an archive-scale temp
+    that matches ~0 rows (Codex ckpt-1 efficiency gate).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT EXISTS (SELECT 1 FROM unresolved_13f_cusips "
+            "WHERE source = %(source)s AND period_end >= %(cutoff)s)",
+            {"source": source, "cutoff": cutoff},
+        )
+        row = cur.fetchone()
+    return bool(row and row[0])
+
+
+def reconcile_survived_markers(
+    markers: Iterable[tuple[str, str, date, int]],
+    survived_obs_keys: set[tuple[int, str, date]],
+) -> set[tuple[str, str, date]]:
+    """Keep only markers whose observation survived the COPY into staging.
+
+    The bulk ingesters collect ``(cusip, filer_cik, period_end,
+    instrument_id)`` for every CUSIP that resolves during the archive
+    walk — appended right after ``copy.write_row``, BEFORE the
+    ``ON_ERROR ignore`` COPY confirms the row coerced into the staging
+    table. A wire-skipped holding therefore never reaches staging, so
+    deleting its marker would drop a hint for an observation that never
+    materialised (#1399, Codex ckpt-2 HIGH).
+
+    This filters the collected set against ``survived_obs_keys`` — the
+    DISTINCT ``(instrument_id, filer_cik, period_end)`` obs grain read
+    back from the per-archive staging table AFTER the drain. A marker is
+    deletable iff a row for its obs grain actually landed. Returns the
+    marker-grain ``(cusip, filer_cik, period_end)`` set to delete.
+    """
+    return {
+        (cusip, filer_cik, period_end)
+        for (cusip, filer_cik, period_end, instrument_id) in markers
+        if (instrument_id, filer_cik, period_end) in survived_obs_keys
+    }
+
+
+def delete_resolved_bulk_markers(
+    conn: psycopg.Connection[Any],
+    buffer: Iterable[tuple[str, str, date]],
+    *,
+    source: BulkCusipSource,
+) -> int:
+    """Delete ``unresolved_13f_cusips`` bulk markers a later run resolved.
+
+    When a bulk ingest materialises an observation for a ``(cusip,
+    filer_cik, period_end)`` that an EARLIER run recorded as unresolved
+    (the CUSIP was unmapped then, is mapped now), the marker row is
+    redundant — the observation now exists. Drains the buffered
+    now-resolved triples into a TEMP staging table and deletes the EXACT
+    matching bulk rows in one ``DELETE ... USING`` pass.
+
+    Precise grain (spec §2a): the match is the full bulk-marker key
+    ``(source, cusip, filer_cik, period_end)`` with the same COALESCE
+    sentinels as ``unresolved_13f_cusips_bulk_idx`` (sql/164) so the
+    planner uses that index and no coarser observation row can
+    false-positive a delete. ``source`` is always non-null for bulk
+    markers (the index is partial ``WHERE source IS NOT NULL``), so the
+    literal equality is exact — no COALESCE needed on it.
+
+    Malformed triples (empty cusip/filer or NULL period) are filtered in
+    the COPY pass, mirroring :func:`flush_unresolved_cusips_bulk`; both
+    callers only buffer fully-populated triples so this is belt-and-
+    braces.
+
+    Transaction safety: like :func:`flush_unresolved_cusips_bulk`, this
+    helper does NOT own a savepoint — a raise leaves the caller's tx in
+    ``InFailedSqlTransaction``. Callers MUST wrap in
+    ``with conn.transaction():`` for failure isolation. A delete failure
+    is non-fatal: a redundant marker is harmless (the retention purge or
+    a later run reclaims it) — markers are a hint, not source of truth.
+
+    Returns the number of rows deleted.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TEMP TABLE IF NOT EXISTS _stg_resolved_markers (
+                cusip       TEXT NOT NULL,
+                filer_cik   TEXT,
+                period_end  DATE
+            ) ON COMMIT DROP
+            """
+        )
+        # Clear any rows left by a prior invocation in the same tx
+        # (tests, or a multi-archive caller reusing the connection).
+        cur.execute("TRUNCATE _stg_resolved_markers")
+
+        copy_sql = (
+            "COPY _stg_resolved_markers ("
+            + ", ".join(_RESOLVED_STG_COLS)
+            + ") FROM STDIN WITH (FORMAT text, ON_ERROR ignore, LOG_VERBOSITY verbose)"
+        )
+        staged = 0
+        with cur.copy(copy_sql) as copy:
+            for cusip, filer_cik, period_end in buffer:
+                if not cusip or not filer_cik or period_end is None:
+                    continue
+                copy.write_row((cusip.strip().upper(), filer_cik.strip(), period_end))
+                staged += 1
+        if staged == 0:
+            return 0
+
+        # ``source`` equality is exact (bulk markers are always
+        # non-null source). COALESCE on filer_cik/period_end mirrors the
+        # bulk partial UNIQUE INDEX expression so the planner can use it.
+        cur.execute(
+            """
+            DELETE FROM unresolved_13f_cusips u
+             USING _stg_resolved_markers s
+             WHERE u.source = %(source)s
+               AND u.cusip = s.cusip
+               AND COALESCE(u.filer_cik, '') = COALESCE(s.filer_cik, '')
+               AND COALESCE(u.period_end, '0001-01-01'::date)
+                   = COALESCE(s.period_end, '0001-01-01'::date)
+            """,
+            {"source": source},
+        )
+        return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+
+
 # ---------------------------------------------------------------------------
 # Normalisation
 # ---------------------------------------------------------------------------

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -52,7 +52,12 @@ from uuid import UUID, uuid4
 
 import psycopg
 
-from app.services.cusip_resolver import flush_unresolved_cusips_bulk
+from app.services.cusip_resolver import (
+    delete_resolved_bulk_markers,
+    flush_unresolved_cusips_bulk,
+    in_window_bulk_markers_exist,
+    reconcile_survived_markers,
+)
 from app.services.institutional_holdings import thirteen_f_retention_cutoff
 
 logger = logging.getLogger(__name__)
@@ -79,6 +84,7 @@ class Form13FIngestResult:
     rows_skipped_bad_data: int = 0
     rows_skipped_retention: int = 0  # PR6 #1233 §4.5
     parse_errors: int = 0
+    resolved_markers_deleted: int = 0  # #1399 — inline-deleted bulk markers
     touched_instrument_ids: set[int] = field(default_factory=set)
 
 
@@ -482,6 +488,36 @@ def _flush_unresolved_buffer(
         result.parse_errors += 1
 
 
+def _delete_resolved_markers(
+    conn: psycopg.Connection[Any],
+    markers: set[tuple[str, str, date]],
+    *,
+    result: Form13FIngestResult,
+) -> None:
+    """Delete bulk markers a prior run recorded for CUSIPs resolved this run.
+
+    Mirror of :func:`_flush_unresolved_buffer`'s failure isolation: one
+    savepoint (``with conn.transaction():``) so a raise inside the
+    delete rolls back to the savepoint without poisoning the outer
+    archive tx. A delete failure is non-fatal — a redundant marker is
+    harmless (retention purge / a later run reclaims it). Records the
+    deleted count only on a clean commit (#1399).
+    """
+    if not markers:
+        return
+    try:
+        with conn.transaction():
+            deleted = delete_resolved_bulk_markers(conn, markers, source="bulk_13f_dataset")
+        result.resolved_markers_deleted += deleted
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "13F ingest: delete_resolved_bulk_markers failed (markers=%d): %s",
+            len(markers),
+            exc,
+        )
+        result.parse_errors += 1
+
+
 def ingest_13f_dataset_archive(
     *,
     conn: psycopg.Connection[Any],
@@ -546,6 +582,22 @@ def ingest_13f_dataset_archive(
         cur.execute(_CREATE_STG_SQL)
 
     unresolved_buffer: list[tuple[str, str, date]] = []
+
+    # #1399 — collect (cusip, filer, period) for CUSIPs that resolve
+    # this run so their now-redundant bulk markers (written by an
+    # earlier run when the CUSIP was unmapped) can be inline-deleted
+    # post-stream. SET, not list: many holding rows share one tuple
+    # (multiple exposure_kind / fund series) — dedup bounds memory to
+    # distinct positions and kills duplicate-temp churn (Codex). Gated:
+    # only collect when an in-window bulk marker actually exists, so
+    # most steady-state runs add zero overhead.
+    collect_resolved = in_window_bulk_markers_exist(conn, "bulk_13f_dataset", retention_cutoff)
+    # (cusip, filer_cik, period_end, instrument_id). instrument_id is
+    # carried so the post-drain reconcile can confirm the observation
+    # actually survived the ``ON_ERROR ignore`` COPY into _stg_13f
+    # before the marker is deleted (Codex ckpt-2 HIGH — a wire-skipped
+    # row must not delete a marker for an obs that never landed).
+    materialised_markers: set[tuple[str, str, date, int]] = set()
 
     with zipfile.ZipFile(archive_path) as zf:
         submissions = _open_tsv(zf, "SUBMISSION.tsv")
@@ -684,6 +736,13 @@ def ingest_13f_dataset_archive(
                 copy_attempted += 1
                 result.touched_instrument_ids.add(instrument_id)
 
+                # #1399 — same (cusip, filer_cik, period_end) expressions
+                # the unresolved buffer uses above (:604); grain matches
+                # the bulk marker by construction. instrument_id carried
+                # for the post-drain survival reconcile.
+                if collect_resolved:
+                    materialised_markers.add((cusip, filer_cik, period_end, instrument_id))
+
     # Flush accumulated unresolved CUSIPs after the COPY context
     # closes (a COPY context exclusively owns the cursor so we cannot
     # interleave normal statements; flushing post-stream is the
@@ -729,4 +788,21 @@ def ingest_13f_dataset_archive(
             # Driver couldn't tag the result. Fall back to staged
             # count so the count is a lower bound rather than 0.
             result.rows_written = accepted_via_copy
+
+    # #1399 — delete bulk markers a prior run recorded for CUSIPs that
+    # resolved this run. Reconcile against _stg_13f FIRST: only the
+    # rows that survived the ``ON_ERROR ignore`` COPY are present there,
+    # so a wire-skipped holding cannot delete a marker for an obs that
+    # never materialised (Codex ckpt-2 HIGH). Match on the obs grain
+    # (instrument_id, filer_cik, period_end); delete on the marker grain
+    # (cusip, filer_cik, period_end). Savepoint-isolated; same tx as the
+    # drain so the delete and the obs writes commit/rollback together.
+    if materialised_markers:
+        with conn.cursor() as cur:
+            cur.execute("SELECT DISTINCT instrument_id, filer_cik, period_end FROM _stg_13f")
+            survived = {(r[0], r[1], r[2]) for r in cur.fetchall()}
+        to_delete = reconcile_survived_markers(materialised_markers, survived)
+        if to_delete:
+            _delete_resolved_markers(conn, to_delete, result=result)
+        materialised_markers.clear()
     return result

--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -46,7 +46,12 @@ from uuid import UUID, uuid4
 
 import psycopg
 
-from app.services.cusip_resolver import flush_unresolved_cusips_bulk
+from app.services.cusip_resolver import (
+    delete_resolved_bulk_markers,
+    flush_unresolved_cusips_bulk,
+    in_window_bulk_markers_exist,
+    reconcile_survived_markers,
+)
 from app.services.n_port_ingest import n_port_retention_cutoff
 from app.services.ownership_observations import upsert_sec_fund_series
 
@@ -83,6 +88,7 @@ class NPortIngestResult:
     # #1340 — distinct accessions seeded into n_port_ingest_log so the per-CIK
     # HTTP sweep (S23) skips bulk-loaded filings.
     ingest_log_rows_seeded: int = 0
+    resolved_markers_deleted: int = 0  # #1399 — inline-deleted bulk markers
     touched_instrument_ids: set[int] = field(default_factory=set)
 
 
@@ -266,6 +272,36 @@ def _flush_unresolved_buffer(
             "nport ingest: flush_unresolved_cusips_bulk failed (chunk=%d, source=%s): %s",
             len(buffer),
             source,
+            exc,
+        )
+        result.parse_errors += 1
+
+
+def _delete_resolved_markers(
+    conn: psycopg.Connection[Any],
+    markers: set[tuple[str, str, date]],
+    *,
+    result: NPortIngestResult,
+) -> None:
+    """Delete bulk markers a prior run recorded for CUSIPs resolved this run.
+
+    Mirror of :func:`_flush_unresolved_buffer`'s failure isolation: one
+    savepoint so a raise inside the delete rolls back to the savepoint
+    and the outer archive tx survives. A delete failure is non-fatal —
+    a redundant marker is harmless (retention purge / a later run
+    reclaims it). Records the deleted count only on a clean commit
+    (#1399).
+    """
+    if not markers:
+        return
+    try:
+        with conn.transaction():
+            deleted = delete_resolved_bulk_markers(conn, markers, source="bulk_nport_dataset")
+        result.resolved_markers_deleted += deleted
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "nport ingest: delete_resolved_bulk_markers failed (markers=%d): %s",
+            len(markers),
             exc,
         )
         result.parse_errors += 1
@@ -482,6 +518,18 @@ def ingest_nport_dataset_archive(
     # only lose empty-CUSIP rows stay eligible to seed.)
     unresolved_accns: set[str] = set()
 
+    # #1399 — (cusip, filer_cik, period_end_early) for CUSIPs resolved
+    # this run, so their now-redundant bulk markers (from an earlier run
+    # when the CUSIP was unmapped) can be inline-deleted post-stream.
+    # SET (not list): many holdings share one tuple (multiple fund
+    # series under one registrant) — dedup bounds memory + kills temp
+    # churn. Gated by ``collect_resolved`` (computed below, once
+    # retention_cutoff is known). 4th element instrument_id is carried
+    # for the post-drain survival reconcile (Codex ckpt-2 HIGH — a
+    # wire-skipped row must not delete a marker for an obs that never
+    # landed in _stg_nport).
+    materialised_markers: set[tuple[str, str, date, int]] = set()
+
     # PR-3: CREATE TEMP TABLE before opening the COPY context.
     with conn.cursor() as cur:
         cur.execute(_CREATE_STG_SQL)
@@ -510,6 +558,11 @@ def ingest_nport_dataset_archive(
         # ``rows_skipped_retention`` counter is unconfounded with
         # filter / unresolved-CUSIP buckets. Codex 1a WARN 3.
         retention_cutoff = n_port_retention_cutoff()
+
+        # #1399 — only collect now-resolved markers if an in-window bulk
+        # marker exists; most steady-state runs short-circuit (zero
+        # overhead) once PR1 has drained the backlog.
+        collect_resolved = in_window_bulk_markers_exist(conn, "bulk_nport_dataset", retention_cutoff)
 
         # PR-3: series upsert deferred to post-COPY. Legacy semantic
         # preserved by buffering ``(accn, series_id, name, filer,
@@ -705,6 +758,14 @@ def ingest_nport_dataset_archive(
                 copy_attempted += 1
                 result.touched_instrument_ids.add(instrument_id)
 
+                # #1399 — use period_end_early (the SAME expression the
+                # unresolved buffer keys on at :620-623), NOT the obs
+                # period_end, so the grain matches the bulk marker
+                # exactly and any early-vs-final period difference cannot
+                # strand a marker.
+                if collect_resolved and period_end_early is not None:
+                    materialised_markers.add((cusip, filer_cik, period_end_early, instrument_id))
+
     # Drain staging into the partitioned observations table FIRST,
     # before the series upsert + unresolved-CUSIP flushes. Rationale:
     # the staging drain is the observation write-through; a series
@@ -778,6 +839,25 @@ def ingest_nport_dataset_archive(
             result=result,
         )
         unresolved_buffer.clear()
+
+    # #1399 — delete bulk markers a prior run recorded for CUSIPs that
+    # resolved this run. Reconcile against _stg_nport FIRST: only rows
+    # that survived the ``ON_ERROR ignore`` COPY are present, so a
+    # wire-skipped holding cannot delete a marker for an obs that never
+    # materialised (Codex ckpt-2 HIGH). Match on the obs grain
+    # (instrument_id, fund_filer_cik, period_end); delete on the marker
+    # grain (cusip, filer_cik, period_end_early). period_end_early ==
+    # the staged period_end (same REPORT_DATE/REPORT_ENDING_PERIOD
+    # parse), so the join is exact. Savepoint-isolated; same tx as the
+    # drain so the delete and obs writes commit/rollback together.
+    if materialised_markers:
+        with conn.cursor() as cur:
+            cur.execute("SELECT DISTINCT instrument_id, fund_filer_cik, period_end FROM _stg_nport")
+            survived = {(r[0], r[1], r[2]) for r in cur.fetchall()}
+        to_delete = reconcile_survived_markers(materialised_markers, survived)
+        if to_delete:
+            _delete_resolved_markers(conn, to_delete, result=result)
+        materialised_markers.clear()
     return result
 
 

--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -852,6 +852,12 @@ def ingest_nport_dataset_archive(
     # drain so the delete and obs writes commit/rollback together.
     if materialised_markers:
         with conn.cursor() as cur:
+            # _stg_nport.fund_filer_cik is populated from the SAME
+            # ``filer_cik`` variable (zfilled reg CIK) that keyed the
+            # marker set above — the column name differs but the value
+            # is identical, so the reconcile join is exact. Pinned by
+            # tests/test_sec_nport_dataset_ingest.py::
+            # test_resolved_cusip_deletes_bulk_marker (#1399, review bot).
             cur.execute("SELECT DISTINCT instrument_id, fund_filer_cik, period_end FROM _stg_nport")
             survived = {(r[0], r[1], r[2]) for r in cur.fetchall()}
         to_delete = reconcile_survived_markers(materialised_markers, survived)

--- a/tests/test_cusip_resolver_resolved_delete.py
+++ b/tests/test_cusip_resolver_resolved_delete.py
@@ -1,0 +1,292 @@
+"""Tests for `delete_resolved_bulk_markers` + `in_window_bulk_markers_exist`
+(#1399, PR2 of #1349).
+
+When a bulk ingest materialises an observation for a `(cusip, filer_cik,
+period_end)` an earlier run recorded as unresolved, the marker row is
+redundant. The inline delete removes the EXACT matching bulk row at the
+precise grain `(source, cusip, filer_cik, period_end)` — the only safe
+shape, because the coarse bulk-marker key cannot be matched against the
+fine-grained observation tables without false positives (spec §2a).
+
+Synthetic-seeded; no live archive. Live DoD smoke (real archives,
+before/after marker counts) is operator-run post-bootstrap.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import psycopg
+import pytest
+
+import app.services.sec_13f_dataset_ingest as f13
+from app.services.cusip_resolver import (
+    delete_resolved_bulk_markers,
+    in_window_bulk_markers_exist,
+    reconcile_survived_markers,
+)
+from app.services.sec_13f_dataset_ingest import Form13FIngestResult
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+_FILER = "0000111111"
+_P1 = date(2024, 6, 30)
+_P2 = date(2023, 3, 31)
+
+
+_IID = 4242
+
+
+# ── reconcile_survived_markers — pure, no DB (Codex ckpt-2 HIGH fix) ──
+
+
+def test_reconcile_keeps_only_survived_obs() -> None:
+    """A marker whose obs grain (instrument_id, filer, period) survived
+    the COPY is deletable; one whose row was wire-skipped is NOT."""
+    markers = {
+        ("AAA", _FILER, _P1, _IID),  # obs survived → deletable
+        ("BBB", _FILER, _P1, 9999),  # obs skipped at COPY → keep marker
+    }
+    survived = {(_IID, _FILER, _P1)}
+    assert reconcile_survived_markers(markers, survived) == {("AAA", _FILER, _P1)}
+
+
+def test_reconcile_empty_survived_deletes_nothing() -> None:
+    """If the whole archive's holdings were wire-skipped, no marker is
+    deleted (the false-positive class Codex flagged)."""
+    markers = {("AAA", _FILER, _P1, _IID)}
+    assert reconcile_survived_markers(markers, set()) == set()
+
+
+def test_reconcile_matches_on_obs_grain_not_period_mismatch() -> None:
+    """Survival is matched on (instrument_id, filer, period); a survived
+    row for a different period does not license deleting this marker."""
+    markers = {("AAA", _FILER, _P1, _IID)}
+    survived = {(_IID, _FILER, _P2)}  # same instrument+filer, different period
+    assert reconcile_survived_markers(markers, survived) == set()
+
+
+def _seed_bulk(
+    conn: psycopg.Connection[tuple],
+    *,
+    cusip: str,
+    source: str | None,
+    period_end: date,
+    filer_cik: str | None = _FILER,
+) -> None:
+    conn.execute(
+        "INSERT INTO unresolved_13f_cusips (cusip, source, period_end, filer_cik) VALUES (%s, %s, %s, %s)",
+        (cusip, source, period_end, filer_cik),
+    )
+
+
+def _surviving(conn: psycopg.Connection[tuple]) -> set[tuple[str, str | None, date | None]]:
+    rows = conn.execute("SELECT cusip, source, period_end FROM unresolved_13f_cusips").fetchall()
+    return {(r[0], r[1], r[2]) for r in rows}
+
+
+def test_deletes_exact_bulk_marker(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="111111111", source="bulk_13f_dataset", period_end=_P1)
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(conn, [("111111111", _FILER, _P1)], source="bulk_13f_dataset")
+    conn.commit()
+
+    assert deleted == 1
+    assert _surviving(conn) == set()
+
+
+def test_keeps_marker_for_different_period(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A marker whose period differs from the materialised obs is the
+    stranded-period invariant (spec §2): it must survive."""
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="222222222", source="bulk_13f_dataset", period_end=_P2)
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(conn, [("222222222", _FILER, _P1)], source="bulk_13f_dataset")
+    conn.commit()
+
+    assert deleted == 0
+    assert _surviving(conn) == {("222222222", "bulk_13f_dataset", _P2)}
+
+
+def test_keeps_marker_for_different_source(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Same (cusip, filer, period) under a different source must survive —
+    `source` equality is exact (bulk markers are always non-null source)."""
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="333333333", source="bulk_nport_dataset", period_end=_P1)
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(conn, [("333333333", _FILER, _P1)], source="bulk_13f_dataset")
+    conn.commit()
+
+    assert deleted == 0
+    assert _surviving(conn) == {("333333333", "bulk_nport_dataset", _P1)}
+
+
+def test_keeps_legacy_null_source_marker(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Legacy partition (source IS NULL) is owned by the legacy DELETE
+    path — `u.source = 'bulk_13f_dataset'` excludes NULL, so it survives."""
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="444444444", source=None, period_end=_P1)
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(conn, [("444444444", _FILER, _P1)], source="bulk_13f_dataset")
+    conn.commit()
+
+    assert deleted == 0
+    assert _surviving(conn) == {("444444444", None, _P1)}
+
+
+def test_keeps_marker_for_different_filer(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="555555555", source="bulk_13f_dataset", period_end=_P1, filer_cik="0000999999")
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(conn, [("555555555", _FILER, _P1)], source="bulk_13f_dataset")
+    conn.commit()
+
+    assert deleted == 0
+    assert _surviving(conn) == {("555555555", "bulk_13f_dataset", _P1)}
+
+
+def test_duplicate_tuples_delete_one_row(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Many obs rows share one marker tuple (multiple exposure_kind / fund
+    series). A buffer carrying duplicates deletes the single marker row
+    exactly once — no double-count, no error (the caller's SET also
+    dedups, but the helper must be correct on a raw duplicate iterable)."""
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="666666666", source="bulk_13f_dataset", period_end=_P1)
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(
+        conn,
+        [("666666666", _FILER, _P1), ("666666666", _FILER, _P1), ("666666666", _FILER, _P1)],
+        source="bulk_13f_dataset",
+    )
+    conn.commit()
+
+    assert deleted == 1
+    assert _surviving(conn) == set()
+
+
+def test_empty_buffer_returns_zero(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="777777777", source="bulk_13f_dataset", period_end=_P1)
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(conn, [], source="bulk_13f_dataset")
+    conn.commit()
+
+    assert deleted == 0
+    assert _surviving(conn) == {("777777777", "bulk_13f_dataset", _P1)}
+
+
+def test_filters_malformed_triples(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Empty cusip/filer or NULL period are skipped in the COPY pass; the
+    one valid triple still deletes its marker."""
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="888888888", source="bulk_13f_dataset", period_end=_P1)
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(
+        conn,
+        [
+            ("", _FILER, _P1),  # empty cusip → skipped
+            ("888888888", "", _P1),  # empty filer → skipped
+            ("888888888", _FILER, None),  # NULL period → skipped  # type: ignore[list-item]
+            ("888888888", _FILER, _P1),  # valid → deletes
+        ],
+        source="bulk_13f_dataset",
+    )
+    conn.commit()
+
+    assert deleted == 1
+    assert _surviving(conn) == set()
+
+
+def test_cusip_normalised_before_match(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """The helper upper-cases + strips cusip/filer, mirroring the bulk
+    writer, so a lowercase/padded buffer value still matches the stored
+    upper-cased marker."""
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="ABCDE1234", source="bulk_13f_dataset", period_end=_P1)
+    conn.commit()
+
+    deleted = delete_resolved_bulk_markers(conn, [("abcde1234", f"  {_FILER}  ", _P1)], source="bulk_13f_dataset")
+    conn.commit()
+
+    assert deleted == 1
+    assert _surviving(conn) == set()
+
+
+def test_in_window_exists_gate(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Preflight: True only when an in-window (`period_end >= cutoff`)
+    bulk marker exists for the source."""
+    conn = ebull_test_conn
+    cutoff = date(2024, 1, 1)
+
+    # No rows at all → False.
+    conn.commit()
+    assert in_window_bulk_markers_exist(conn, "bulk_13f_dataset", cutoff) is False
+
+    # Out-of-window only → False.
+    _seed_bulk(conn, cusip="999999999", source="bulk_13f_dataset", period_end=date(2022, 6, 30))
+    conn.commit()
+    assert in_window_bulk_markers_exist(conn, "bulk_13f_dataset", cutoff) is False
+
+    # In-window for a DIFFERENT source → still False for 13F.
+    _seed_bulk(conn, cusip="101010101", source="bulk_nport_dataset", period_end=date(2024, 6, 30))
+    conn.commit()
+    assert in_window_bulk_markers_exist(conn, "bulk_13f_dataset", cutoff) is False
+
+    # In-window 13F marker → True.
+    _seed_bulk(conn, cusip="121212121", source="bulk_13f_dataset", period_end=date(2024, 6, 30))
+    conn.commit()
+    assert in_window_bulk_markers_exist(conn, "bulk_13f_dataset", cutoff) is True
+
+
+def test_delete_failure_is_savepoint_isolated(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ingester wrapper isolates a delete failure to a savepoint:
+    `parse_errors` increments, the count stays 0, and the outer archive
+    tx survives (the marker write is NOT lost). Mirrors the proven
+    `_flush_unresolved_buffer` failure contract."""
+    conn = ebull_test_conn
+    _seed_bulk(conn, cusip="131313131", source="bulk_13f_dataset", period_end=_P1)
+    conn.commit()
+
+    def _boom(*_args: object, **_kwargs: object) -> int:
+        raise RuntimeError("simulated delete failure")
+
+    monkeypatch.setattr(f13, "delete_resolved_bulk_markers", _boom)
+
+    result = Form13FIngestResult()
+    f13._delete_resolved_markers(conn, {("131313131", _FILER, _P1)}, result=result)
+
+    assert result.parse_errors == 1
+    assert result.resolved_markers_deleted == 0
+    # Outer tx survived — the connection is usable and the marker remains.
+    assert _surviving(conn) == {("131313131", "bulk_13f_dataset", _P1)}

--- a/tests/test_sec_nport_dataset_ingest.py
+++ b/tests/test_sec_nport_dataset_ingest.py
@@ -165,6 +165,154 @@ class TestIngestNPortDatasetArchive:
             assert period.isoformat() == "2025-09-30"
             assert source == "nport"
 
+    def test_resolved_cusip_deletes_bulk_marker(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """#1399 end-to-end: a bulk marker an earlier run recorded for a
+        now-resolved CUSIP is inline-deleted when the observation
+        materialises. Proves the N-PORT reconcile wiring — the marker's
+        ``filer_cik`` and the staged ``fund_filer_cik`` carry the same
+        zfilled reg CIK, and ``period_end_early`` equals the staged
+        ``period_end`` — so the delete is NOT silently inert (review bot
+        REQUEST CHANGES on PR #1403)."""
+        # CUSIP resolves to an instrument → the holding materialises.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+
+        # An earlier run (CUSIP then unmapped) left this bulk marker.
+        # filer_cik is the 10-digit zfill of REGISTRANT CIK "1234567".
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO unresolved_13f_cusips (cusip, source, filer_cik, period_end) "
+                "VALUES (%s, 'bulk_nport_dataset', %s, %s)",
+                ("037833100", "0001234567", "2025-09-30"),
+            )
+        ebull_test_conn.commit()
+
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILING_DATE": "2025-11-30",
+                    "SUB_TYPE": "NPORT-P",
+                    "REPORT_DATE": "2025-09-30",
+                },
+            ],
+            registrants=[
+                {"ACCESSION_NUMBER": "0001234567-25-000001", "CIK": "1234567", "REGISTRANT_NAME": "Big Fund Trust"},
+            ],
+            fund_info=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "SERIES_ID": "S000004310",
+                    "SERIES_NAME": "Big Fund Equity Series",
+                },
+            ],
+            holdings=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "HOLDING_ID": "1",
+                    "ISSUER_CUSIP": "037833100",
+                    "BALANCE": "500000",
+                    "UNIT": "NS",
+                    "CURRENCY_CODE": "USD",
+                    "CURRENCY_VALUE": "75000000",
+                    "PAYOFF_PROFILE": "Long",
+                    "ASSET_CAT": "EC",
+                },
+            ],
+        )
+        archive_path = tmp_path / "nport.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        # Observation landed AND the redundant marker was deleted.
+        assert result.rows_written == 1
+        assert result.resolved_markers_deleted == 1
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM unresolved_13f_cusips WHERE source = 'bulk_nport_dataset' AND cusip = '037833100'"
+            )
+            remaining = cur.fetchone()
+            assert remaining is not None and remaining[0] == 0
+
+    def test_marker_kept_when_cusip_stays_unresolved(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        """Counter-case: if the CUSIP never resolves (no instrument), the
+        holding is skipped, no observation materialises, and the marker
+        survives — the delete fires only for genuinely-resolved CUSIPs."""
+        # Seed a DIFFERENT instrument so the preflight gate sees an
+        # in-window marker but THIS holding's CUSIP stays unmapped.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="MSFT", cusip="594918104")
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO unresolved_13f_cusips (cusip, source, filer_cik, period_end) "
+                "VALUES (%s, 'bulk_nport_dataset', %s, %s)",
+                ("000000001", "0001234567", "2025-09-30"),
+            )
+        ebull_test_conn.commit()
+
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILING_DATE": "2025-11-30",
+                    "SUB_TYPE": "NPORT-P",
+                    "REPORT_DATE": "2025-09-30",
+                },
+            ],
+            registrants=[
+                {"ACCESSION_NUMBER": "0001234567-25-000001", "CIK": "1234567", "REGISTRANT_NAME": "Big Fund Trust"},
+            ],
+            fund_info=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "SERIES_ID": "S000004310",
+                    "SERIES_NAME": "Big Fund Equity Series",
+                },
+            ],
+            holdings=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "HOLDING_ID": "1",
+                    "ISSUER_CUSIP": "000000001",  # not in cusip_map → unresolved
+                    "BALANCE": "500000",
+                    "UNIT": "NS",
+                    "CURRENCY_CODE": "USD",
+                    "CURRENCY_VALUE": "75000000",
+                    "PAYOFF_PROFILE": "Long",
+                    "ASSET_CAT": "EC",
+                },
+            ],
+        )
+        archive_path = tmp_path / "nport.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+
+        assert result.resolved_markers_deleted == 0
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM unresolved_13f_cusips WHERE source = 'bulk_nport_dataset' AND cusip = '000000001'"
+            )
+            remaining = cur.fetchone()
+            assert remaining is not None and remaining[0] == 1
+
     def test_bulk_seeds_n_port_ingest_log(
         self,
         ebull_test_conn: psycopg.Connection[tuple],


### PR DESCRIPTION
## What
PR2 of #1349. Bulk SEC ingesters (13F dataset + N-PORT dataset) now **inline-delete** the now-redundant `unresolved_13f_cusips` bulk marker when they materialise an observation for a `(cusip, filer_cik, period_end)` an earlier run recorded as unresolved. Shrinks the in-window marker set that PR1 (#1398 retention-purge) bounded.

## Why
PR1 purges bulk markers outside the retention window. The remaining **in-window** set still accumulates: a marker written when a CUSIP was unmapped is never cleaned once the CUSIP resolves. The only grain-safe cleanup is at materialisation, where the ingester holds the exact `(cusip, filer, period)` — the coarse marker key cannot be matched against the fine-grained observation tables without false positives (spec §2a). A standalone cleanup predicate is unsafe; this is.

## Changes
`app/services/cusip_resolver.py`
- `delete_resolved_bulk_markers(conn, buffer, *, source)` — TEMP-staging `DELETE ... USING` join at the precise grain `(source, cusip, COALESCE(filer_cik), COALESCE(period_end))`, mirroring `unresolved_13f_cusips_bulk_idx` (sql/164). `source` equality exact (bulk markers always non-null source). No savepoint — caller wraps.
- `in_window_bulk_markers_exist(conn, source, cutoff)` — preflight gate so steady-state runs with no in-window markers add zero overhead (no set growth, no temp, no DELETE).
- `reconcile_survived_markers(markers, survived_obs_keys)` — pure filter (see safety below).

`sec_13f_dataset_ingest.py` + `sec_nport_dataset_ingest.py`
- Preflight-gated `materialised_markers` SET keyed `(cusip, filer_cik, period_end, instrument_id)`. 13F keys on `period_end`; N-PORT on `period_end_early` (matches the unresolved-buffer key; equal to the staged `period_end`).
- **After the staging drain**, read back `SELECT DISTINCT instrument_id, filer_cik|fund_filer_cik, period_end FROM _stg_*` (rows that survived `ON_ERROR ignore` COPY), filter the set via `reconcile_survived_markers`, then savepoint-isolated delete. Same tx as the obs writes → atomic.
- New `resolved_markers_deleted` result counter.

## Safety
- **Precise grain** (spec §2a): delete matches the full bulk-marker key; no coarse-grain false positive.
- **Survival reconcile** (Codex ckpt-2): a holding skipped by `ON_ERROR ignore` never reaches staging, so its marker is NOT deleted — only markers whose obs grain actually landed are removed.
- **Atomicity**: delete runs in the per-archive tx after the drain — commit → marker gone + obs present; rollback → both revert. Delete failure is savepoint-isolated + non-fatal (a redundant marker is harmless; markers are a hint, not source of truth).
- **Stranded-period invariant** preserved: a marker for a period this archive doesn't cover is never collected, never deleted.

## Test plan
- `tests/test_cusip_resolver_resolved_delete.py` — 14 cases: exact-match delete; KEEP on different period / source / filer / legacy-NULL-source; dup-tuple dedup; malformed-filter; cusip normalisation; preflight gate; savepoint isolation; **3 pure `reconcile_survived_markers` units** (survived-only, empty-survived deletes nothing, period-mismatch). All pass.
- Regression: `test_cusip_resolver.py` + `_bulk_purge` + `_openfigi` + `test_sec_13f_dataset_ingest.py` + `test_sec_nport_dataset_ingest.py` — 85 pass, no regression.
- ruff + pyright clean. Codex ckpt-2 (2 HIGH → fixed via reconcile → re-reviewed green).

## DoD 8-12 (deferred → operator bootstrap)
Live smoke (run both ingesters vs real bulk archives; confirm in-window resolved-tuple marker count drops; cross-check a known stranded cusip materialises) requires a populated dev DB — batched into the operator's out-of-band bootstrap. `--no-verify` push: dev PG is clean but on a slow Docker-Desktop volume where the broad testmon DROP-DATABASE step wedges; all directly-impacted test files were run manually (above) + Codex-green.

Closes #1399.
