### PR TITLE
fix(#1270): reseed canonical exchanges rows on empty-table boot guard

### DIFF
--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -572,6 +572,32 @@ def _ensure_transaction_cost_config_singleton_with_cleanup(
         raise
 
 
+def _ensure_exchanges_seeded_with_cleanup(
+    fence_conn: psycopg.Connection[Any],
+    pool: Any,
+) -> None:
+    """#1270 — reseed canonical ``exchanges`` rows if the table is empty.
+
+    This jobs-side mirror is the load-bearing one: ``daily_cik_refresh``
+    (a bootstrap stage) runs in THIS process and joins ``exchanges`` to
+    pick the ``us_equity`` cohort. An empty table → zero CIKs stamped →
+    all issuer-side SEC ingest processes zero issuers. ``exchanges`` is
+    reference data seeded once by sql/067, not in any clean-DB-wipe
+    preserve list, so a wipe leaves it empty with no reseed path.
+    """
+    from app.services.exchanges import ensure_exchanges_seeded
+
+    try:
+        with psycopg.connect(settings.database_url, autocommit=True) as guard_conn:
+            ensure_exchanges_seeded(guard_conn)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            fence_conn.close()
+        with contextlib.suppress(Exception):
+            pool.close()
+        raise
+
+
 def _check_operator_exists_with_cleanup(
     fence_conn: psycopg.Connection[Any],
     pool: Any,
@@ -879,6 +905,13 @@ def serve(stop_event: threading.Event | None = None) -> int:
 
     _ensure_transaction_cost_config_singleton_with_cleanup(fence_conn, pool)
     logger.info("jobs entrypoint: transaction_cost_config singleton guard passed")
+
+    # #1270 — reseed canonical exchanges rows if empty. Load-bearing for
+    # the bootstrap: daily_cik_refresh's us_equity cohort JOIN runs in
+    # this process; an empty exchanges table → zero CIKs → all
+    # issuer-side SEC ingest no-ops.
+    _ensure_exchanges_seeded_with_cleanup(fence_conn, pool)
+    logger.info("jobs entrypoint: exchanges seed guard passed")
 
     _bootstrap_master_key(pool)
 

--- a/app/main.py
+++ b/app/main.py
@@ -215,6 +215,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     await asyncio.to_thread(_ensure_transaction_cost_config_singleton_probe)
 
+    # #1270 — reseed the canonical ``exchanges`` rows if the table is
+    # empty. Unlike the singletons above this is reference data seeded
+    # once by sql/067; a clean-DB wipe (exchanges is not in any preserve
+    # list) leaves it empty → the us_equity cohort JOIN in
+    # daily_cik_refresh returns zero rows → zero CIKs stamped → ALL
+    # issuer-side SEC ingest processes zero issuers and a bootstrap
+    # either hard-errors on the cohort guard or "completes" empty.
+    from app.services.exchanges import ensure_exchanges_seeded
+
+    def _ensure_exchanges_seeded_probe() -> None:
+        with psycopg.connect(settings.database_url, autocommit=True) as guard_conn:
+            ensure_exchanges_seeded(guard_conn)
+
+    await asyncio.to_thread(_ensure_exchanges_seeded_probe)
+
     # Open the connection pool after migrations so the schema is up to date.
     pool = open_pool("db_pool", min_size=1, max_size=10)
     logger.info("Connection pool opened (min=1, max=10).")

--- a/app/services/exchanges.py
+++ b/app/services/exchanges.py
@@ -20,12 +20,96 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import Any
 
 import psycopg
 
 from app.providers.implementations.etoro import EtoroMarketDataProvider
 
 logger = logging.getLogger(__name__)
+
+
+# #1270 — canonical exchange seed. Mirrors the explicit rows pinned by
+# sql/067 (the eight ids the SEC mapper has used since #496 + crypto).
+# Kept in sync with that migration's seed block.
+_CANONICAL_EXCHANGE_SEED: tuple[tuple[str, str | None, str], ...] = (
+    ("2", "US", "us_equity"),
+    ("4", "US", "us_equity"),
+    ("5", "US", "us_equity"),
+    ("6", "US", "us_equity"),
+    ("7", "US", "us_equity"),
+    ("19", "US", "us_equity"),
+    ("20", "US", "us_equity"),
+    ("8", None, "crypto"),
+)
+
+
+def ensure_exchanges_seeded(conn: psycopg.Connection[Any]) -> None:
+    """Re-seed the canonical exchange rows if the table is empty (#1270).
+
+    ``sql/067`` seeds the SEC-mapper exchange ids exactly once via
+    ``INSERT ... ON CONFLICT DO NOTHING``; ``schema_migrations`` blocks
+    the migration from re-running, and **no bootstrap stage reseeds
+    ``exchanges``**. ``exchanges`` is not in any clean-DB-wipe preserve
+    list, so after a TRUNCATE / dev-DB reset the table is empty. An
+    empty ``exchanges`` table silently breaks the whole issuer pipeline:
+    ``daily_cik_refresh`` selects its CIK-mapping cohort with
+    ``JOIN exchanges e ON e.exchange_id = i.exchange WHERE
+    e.asset_class = 'us_equity'`` (``app/workers/scheduler.py``), which
+    returns zero rows → zero CIKs stamped onto ``external_identifiers``
+    → the bulk submissions ingester reads an empty issuer cohort → ALL
+    issuer-side SEC ingest (companyfacts, submissions, insider, 8-K,
+    DEF 14A, business summary, fundamentals) processes zero issuers. A
+    clean bootstrap then either hard-errors on the cohort precondition
+    guard or "completes" having ingested nothing.
+
+    This boot guard closes that hole, mirroring the
+    ``ensure_*_singleton`` reference-row guards wired in
+    ``app/main.py`` / ``app/jobs/__main__.py``. It fires ONLY on the
+    empty-table wipe case — when any row exists, operator curation and
+    the weekly eToro refresh own steady state, so it is a no-op. The
+    canonical rows are re-inserted ``ON CONFLICT DO NOTHING`` so a
+    concurrent reseed can't collide.
+
+    Connection contract: caller MUST pass an autocommit conn (the
+    helper opens its own real ``conn.transaction()`` BEGIN, preserving
+    the service-layer no-bare-commit invariant).
+
+    Idempotent: no-op when ``exchanges`` is non-empty.
+    """
+    # Enforce the autocommit contract, mirroring the ensure_*_singleton
+    # guards (Codex MEDIUM): a non-autocommit caller would degrade the
+    # helper's ``conn.transaction()`` BEGIN into a SAVEPOINT under their
+    # outer tx, so a later rollback could silently undo the reseed and
+    # re-open the boot hole. Fail loud at the boundary.
+    if not conn.autocommit:
+        raise RuntimeError(
+            "ensure_exchanges_seeded requires an autocommit connection — "
+            "pass psycopg.connect(url, autocommit=True). The helper opens "
+            "its own real BEGIN via conn.transaction(); a non-autocommit "
+            "caller would degrade that into a SAVEPOINT."
+        )
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM exchanges")
+        row = cur.fetchone()
+        count = int(row[0]) if row and row[0] is not None else 0
+    if count > 0:
+        return
+    logger.warning(
+        "exchanges table empty at boot — reseeding %d canonical rows "
+        "(sql/067 seed lost to a clean-DB wipe; #1270 boot guard). "
+        "Without this the us_equity cohort JOIN is empty and all "
+        "issuer-side SEC ingest processes zero issuers.",
+        len(_CANONICAL_EXCHANGE_SEED),
+    )
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.executemany(
+                "INSERT INTO exchanges (exchange_id, country, asset_class) "
+                "VALUES (%s, %s, %s) ON CONFLICT (exchange_id) DO NOTHING",
+                _CANONICAL_EXCHANGE_SEED,
+            )
 
 
 @dataclass(frozen=True)

--- a/tests/test_exchanges_boot_guard.py
+++ b/tests/test_exchanges_boot_guard.py
@@ -1,0 +1,93 @@
+"""Tests for `ensure_exchanges_seeded` boot guard (#1270).
+
+`exchanges` is reference data seeded once by sql/067; nothing reseeds it
+after a clean-DB wipe, and an empty `exchanges` table silently empties
+the us_equity issuer cohort → all issuer-side SEC ingest no-ops. The
+boot guard reseeds the canonical rows when (and only when) the table is
+empty.
+
+Contract: like the `ensure_*_singleton` guards, it requires an
+autocommit connection (opens its own real BEGIN). Tests mirror the
+boot-time call shape with a fresh `psycopg.connect(..., autocommit=True)`
+and use the `ebull_test_conn` fixture (same worker DB) for setup/asserts.
+`exchanges` is NOT in the per-test TRUNCATE list; the template seeds it
+with exactly the 8 canonical rows (instruments is empty at migration
+time), so the empty→reseed tests self-restore to the original state.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.exchanges import _CANONICAL_EXCHANGE_SEED, ensure_exchanges_seeded
+from tests.fixtures.ebull_test_db import (
+    ebull_test_conn,  # noqa: F401 — fixture re-export
+    test_database_url,
+)
+
+
+def _rows(conn: psycopg.Connection[tuple]) -> set[tuple[str, str]]:
+    conn.rollback()  # drop any stale snapshot so we read committed state
+    return {(r[0], r[1]) for r in conn.execute("SELECT exchange_id, asset_class FROM exchanges").fetchall()}
+
+
+def test_reseeds_canonical_rows_when_empty(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    ebull_test_conn.execute("DELETE FROM exchanges")
+    ebull_test_conn.commit()
+
+    with psycopg.connect(test_database_url(), autocommit=True) as guard_conn:
+        ensure_exchanges_seeded(guard_conn)
+
+    rows = _rows(ebull_test_conn)
+    # All eight canonical rows present (= original template state restored).
+    assert rows == {(eid, cls) for (eid, _country, cls) in _CANONICAL_EXCHANGE_SEED}
+    assert {eid for (eid, cls) in rows if cls == "us_equity"} == {"2", "4", "5", "6", "7", "19", "20"}
+
+
+def test_noop_when_table_already_populated(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    # Migration-seeded → non-empty. Add a curated sentinel the guard must
+    # NOT touch or duplicate.
+    ebull_test_conn.execute(
+        "INSERT INTO exchanges (exchange_id, country, asset_class) "
+        "VALUES ('99', 'GB', 'uk_equity') ON CONFLICT (exchange_id) DO NOTHING"
+    )
+    ebull_test_conn.commit()
+    try:
+        before = _rows(ebull_test_conn)
+        assert ("99", "uk_equity") in before
+
+        with psycopg.connect(test_database_url(), autocommit=True) as guard_conn:
+            ensure_exchanges_seeded(guard_conn)
+
+        # No-op: guard fires only on an empty table; curated row intact.
+        assert _rows(ebull_test_conn) == before
+    finally:
+        ebull_test_conn.execute("DELETE FROM exchanges WHERE exchange_id = '99'")
+        ebull_test_conn.commit()
+
+
+def test_idempotent_on_repeated_calls(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    ebull_test_conn.execute("DELETE FROM exchanges")
+    ebull_test_conn.commit()
+
+    with psycopg.connect(test_database_url(), autocommit=True) as guard_conn:
+        ensure_exchanges_seeded(guard_conn)
+        ensure_exchanges_seeded(guard_conn)  # second call: now non-empty → no-op
+
+    assert len(_rows(ebull_test_conn)) == len(_CANONICAL_EXCHANGE_SEED)
+
+
+def test_raises_when_caller_is_not_autocommit(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A non-autocommit conn would degrade the reseed BEGIN into a
+    SAVEPOINT — fail loud at the boundary (mirrors the singleton guards)."""
+    with pytest.raises(RuntimeError, match="autocommit"):
+        ensure_exchanges_seeded(ebull_test_conn)


### PR DESCRIPTION
## What
Boot guard that reseeds the canonical `exchanges` rows when the table is empty. Closes #1270.

## Why (ETL readiness audit — confirmed completion blocker #1)
`exchanges` is reference data seeded **once** by `sql/067` (`INSERT ... ON CONFLICT DO NOTHING`); `schema_migrations` blocks the migration from re-running, **no bootstrap stage reseeds it**, and it is **not in any clean-DB-wipe preserve list**. So after a TRUNCATE / dev-DB reset the table is empty — and an empty `exchanges` silently breaks the entire issuer pipeline:

`daily_cik_refresh` (a bootstrap stage, runs in the jobs process) selects its CIK-mapping cohort with `JOIN exchanges e ON e.exchange_id = i.exchange WHERE e.asset_class = 'us_equity'`. Empty `exchanges` → 0 cohort rows → zero CIKs stamped onto `external_identifiers` → the bulk submissions ingester reads an empty issuer cohort → **all issuer-side SEC ingest (companyfacts, submissions, insider, 8-K, DEF 14A, business summary, fundamentals) processes zero issuers.** A clean bootstrap then either hard-errors on the cohort precondition guard or "completes" having ingested nothing. This is a primary cause of the never-completing / empty-data bootstrap runs.

## Change
- `app/services/exchanges.py::ensure_exchanges_seeded(conn)` — reseeds the 8 canonical sql/067 rows (`2,4,5,6,7,19,20 → us_equity`, `8 → crypto`) **only when the table is empty**; `ON CONFLICT DO NOTHING`; no-op when populated (operator curation + the weekly eToro refresh own steady state). Enforces the autocommit contract (raises otherwise), mirroring the existing `ensure_*_singleton` guards.
- Wired into **both** `app/main.py` lifespan and `app/jobs/__main__.py` boot (the jobs-side call is load-bearing — the cohort JOIN runs there), each next to the existing singleton guards with the same fence-conn/pool cleanup-on-failure shape.

## Test plan
- `tests/test_exchanges_boot_guard.py` (4): reseeds-when-empty (8 canonical, us_equity set correct); no-op-when-populated (curated sentinel untouched); idempotent on repeated calls; raises when caller is not autocommit. All pass.
- `tests/smoke/test_app_boots.py` passes — the new lifespan guard runs cleanly against the real dev DB (non-empty → no-op).
- ruff + pyright clean. Codex ckpt-2 (1 MEDIUM autocommit-enforcement → fixed → re-reviewed: no findings).

Seed rows verified against `sql/067_exchanges_metadata.sql`. No schema/migration change. Part 1 of 2 critical-path fixes from the ETL end-to-end readiness audit (other: #1265 master-key re-bootstrap, neutralised for the run by setting `EBULL_SECRETS_KEY`).
