### PR TITLE
fix(#1415): guarded master.idx gap-close + watermark per-source hardening

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -335,6 +335,8 @@ _INVOKERS[_scheduler.JOB_SEC_DAILY_INDEX_RECONCILE] = _adapt_zero_arg(_scheduler
 _INVOKERS[_scheduler.JOB_SEC_PER_CIK_POLL] = _adapt_zero_arg(_scheduler.sec_per_cik_poll)
 # G12 — Layer-4 cross-quarter discovery (weekly Sun 05:15 UTC).
 _INVOKERS[_scheduler.JOB_SEC_MASTER_IDX_QUARTERLY_SWEEP] = _adapt_zero_arg(_scheduler.sec_master_idx_quarterly_sweep)
+# #1415 — bootstrap S15 recent-window gap-close (filing-metadata scoped).
+_INVOKERS[_scheduler.JOB_SEC_MASTER_IDX_GAP_CLOSE] = _adapt_zero_arg(_scheduler.sec_master_idx_gap_close)
 _INVOKERS[_scheduler.JOB_SEC_REBUILD] = _scheduler.sec_rebuild  # params-taking, no _adapt_zero_arg
 # G6/#915 — FINRA bimonthly short interest (daily 12:00 UTC). Zero-param
 # manual surface; extended-window backfill via REPL runbook.

--- a/app/jobs/sec_master_idx_quarterly_sweep.py
+++ b/app/jobs/sec_master_idx_quarterly_sweep.py
@@ -194,12 +194,13 @@ def run_master_idx_quarterly_sweep(
     ``source_allowlist=None`` (default) discovers EVERY mapped form (the
     steady-state G12 safety-net behaviour). The #1413/#1415 bootstrap
     gap-close passes a FILING-METADATA allowlist so the recent-window pass
-    advances only filing-metadata watermarks (8-K/10-K/DEF14A/13D-G/N-CSR)
-    and NEVER seeds a manifest/freshness row for a bulk-dataset ownership
-    source (13F-HR/N-PORT/Form-3/4/5). Those observations come from the
-    quarterly bulk datasets, not the manifest worker, so a discovery-side
-    watermark advance would push the steady-state cursor ahead of loaded
-    data (silent gap, spec §4.3 pillar 3).
+    advances only filing-metadata watermarks (8-K/10-K/DEF14A/13D-G) and
+    NEVER seeds a manifest/freshness row for a bulk-dataset ownership source
+    (13F-HR/N-PORT/Form-3/4/5). Those observations come from the quarterly
+    bulk datasets, not the manifest worker, so a discovery-side watermark
+    advance would push the steady-state cursor ahead of loaded data (silent
+    gap, spec §4.3 pillar 3). (N-CSR is also excluded — see
+    ``GAP_CLOSE_FILING_METADATA_SOURCES`` for why.)
     """
     if now is None:
         now = datetime.now(tz=UTC)

--- a/app/jobs/sec_master_idx_quarterly_sweep.py
+++ b/app/jobs/sec_master_idx_quarterly_sweep.py
@@ -193,14 +193,15 @@ def run_master_idx_quarterly_sweep(
 
     ``source_allowlist=None`` (default) discovers EVERY mapped form (the
     steady-state G12 safety-net behaviour). The #1413/#1415 bootstrap
-    gap-close passes a FILING-METADATA allowlist so the recent-window pass
-    advances only filing-metadata watermarks (8-K/10-K/DEF14A/13D-G) and
-    NEVER seeds a manifest/freshness row for a bulk-dataset ownership source
-    (13F-HR/N-PORT/Form-3/4/5). Those observations come from the quarterly
-    bulk datasets, not the manifest worker, so a discovery-side watermark
-    advance would push the steady-state cursor ahead of loaded data (silent
-    gap, spec §4.3 pillar 3). (N-CSR is also excluded — see
-    ``GAP_CLOSE_FILING_METADATA_SOURCES`` for why.)
+    gap-close passes a FILING-METADATA allowlist (the
+    ``GAP_CLOSE_FILING_METADATA_SOURCES`` set — 8-K / 10-K / 10-Q / DEF14A /
+    13D / 13G) so the recent-window pass advances only those filing-metadata
+    watermarks and NEVER seeds a manifest/freshness row for a bulk-dataset
+    ownership source (13F-HR/N-PORT/Form-3/4/5). Those observations come from
+    the quarterly bulk datasets, not the manifest worker, so a discovery-side
+    watermark advance would push the steady-state cursor ahead of loaded data
+    (silent gap, spec §4.3 pillar 3). N-CSR is also excluded — see
+    ``GAP_CLOSE_FILING_METADATA_SOURCES`` for why.
     """
     if now is None:
         now = datetime.now(tz=UTC)

--- a/app/jobs/sec_master_idx_quarterly_sweep.py
+++ b/app/jobs/sec_master_idx_quarterly_sweep.py
@@ -37,6 +37,30 @@ from app.services.sec_manifest import record_manifest_entry
 logger = logging.getLogger(__name__)
 
 
+# #1415 — FILING-METADATA sources the bootstrap recent-window gap-close
+# (``sec_master_idx_gap_close``) is allowed to seed + advance. EXCLUDES the
+# bulk-dataset-sourced ownership families (sec_13f_hr / sec_n_port /
+# sec_form3 / sec_form4 / sec_form5): their observations come from the
+# quarterly bulk datasets (bootstrap S10/S11/S12), NOT the manifest worker,
+# so a discovery-side watermark advance from this pass would push the
+# steady-state cursor ahead of loaded data (silent gap, spec §4.3 pillar 3).
+# DEF14A / 13D / 13G ARE included — the manifest worker parses their
+# observations from the seeded manifest rows post-bootstrap, so seeding +
+# advancing the watermark is eventually consistent (the worker fills the
+# observation; the watermark only says "we know this filing exists").
+# ``sec_n_csr`` is deliberately NOT included: N-CSR filers are fund TRUSTS,
+# whose CIKs are not in ``build_preloaded_subject_resolver`` (issuers +
+# institutional + blockholder only) until S26 ``mf_directory_sync`` seeds the
+# fund directory — which runs AFTER this stage (order 15). N-CSR rows here
+# would resolve as unknown-subject and never seed; N-CSR discovery is
+# steady-state's job (post-S26 directory + Atom/daily-index), and N-CSR is
+# not panel-relevant (funds slice = bulk N-PORT). The unscoped weekly G12
+# sweep passes source_allowlist=None (full discovery).
+GAP_CLOSE_FILING_METADATA_SOURCES: frozenset[str] = frozenset(
+    {"sec_8k", "sec_10k", "sec_10q", "sec_def14a", "sec_13d", "sec_13g"}
+)
+
+
 @dataclass(frozen=True)
 class QuarterStats:
     year: int
@@ -150,6 +174,7 @@ def run_master_idx_quarterly_sweep(
     now: datetime | None = None,
     subject_resolver: SubjectResolver | None = None,
     quarters: Sequence[tuple[int, int]] | None = None,
+    source_allowlist: frozenset[str] | None = None,
 ) -> MasterIdxSweepStats:
     """One quarterly-sweep cycle.
 
@@ -165,6 +190,16 @@ def run_master_idx_quarterly_sweep(
     ``subject_resolver=None`` (default) preloads the universe map via
     ``build_preloaded_subject_resolver``. Tests inject a pre-built
     resolver.
+
+    ``source_allowlist=None`` (default) discovers EVERY mapped form (the
+    steady-state G12 safety-net behaviour). The #1413/#1415 bootstrap
+    gap-close passes a FILING-METADATA allowlist so the recent-window pass
+    advances only filing-metadata watermarks (8-K/10-K/DEF14A/13D-G/N-CSR)
+    and NEVER seeds a manifest/freshness row for a bulk-dataset ownership
+    source (13F-HR/N-PORT/Form-3/4/5). Those observations come from the
+    quarterly bulk datasets, not the manifest worker, so a discovery-side
+    watermark advance would push the steady-state cursor ahead of loaded
+    data (silent gap, spec §4.3 pillar 3).
     """
     if now is None:
         now = datetime.now(tz=UTC)
@@ -187,6 +222,15 @@ def run_master_idx_quarterly_sweep(
             for row in read_master_idx(http_get, year, q, allow_404=is_current):
                 index_rows += 1
                 if row.source is None:
+                    skipped_unmapped += 1
+                    continue
+                # #1415 — bootstrap gap-close guard: skip any source outside
+                # the filing-metadata allowlist so the recent-window pass
+                # never seeds a manifest/freshness row for a bulk-dataset
+                # ownership source (would advance its watermark ahead of the
+                # parsed observations). Counted as skipped_unmapped (mapped
+                # form, out of this sweep's scope).
+                if source_allowlist is not None and row.source not in source_allowlist:
                     skipped_unmapped += 1
                     continue
                 subject: ResolvedSubject | None = resolver(conn, row.cik)

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -103,6 +103,7 @@ JOB_BOOTSTRAP_ORCHESTRATOR = "bootstrap_orchestrator"
 # below carry the canonical names and a future rename is single-site.
 from app.workers.scheduler import (  # noqa: E402  (after dataclass to avoid cycle)
     JOB_SEC_FIRST_INSTALL_DRAIN,
+    JOB_SEC_MASTER_IDX_GAP_CLOSE,
 )
 
 # These already exist as scheduled jobs but were not registered in
@@ -577,6 +578,13 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
     # adds S16 ``follow_pagination=False`` in bootstrap so its secondary-
     # page HTTP walk is collapsed too — Step 2.3.)
     "sec_first_install_drain": CapRequirement(all_of=("cik_mapping_ready", "submissions_processed")),
+    # #1415 (P3) — recent-window gap-close. Needs the issuer CIK map
+    # (``cik_mapping_ready``, S6) for subject resolution and waits for the
+    # bulk submissions ingest (``submissions_processed``, S8 ordering cap) so
+    # the two manifest writers don't contend. Provides no capability — pure
+    # filing-metadata discovery (the ``sec_master_idx_gap_close`` invoker is
+    # source-allowlist-scoped so it never touches ownership watermarks).
+    "sec_master_idx_gap_close": CapRequirement(all_of=("cik_mapping_ready", "submissions_processed")),
     # #1413 — S17 sec_def14a_bootstrap, S19 sec_insider_transactions_backfill,
     # S20 sec_form3_ingest, S22 sec_13f_recent_sweep, S23 sec_n_port_ingest
     # DROPPED (bulk-only). The bulk ingesters S10/S11/S12 already write the
@@ -1103,13 +1111,19 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # byte-for-byte what S8 ``sec_submissions_ingest`` already wrote from
     # submissions.zip. ``filing_events_seeded`` is re-homed to S8 (+ S16).
     #
-    # NOTE: the master.idx recent-window gap-close (bulk-lag → filing-
-    # metadata coverage) was DEFERRED to P3 (watermark hardening). Its
-    # correctness is inseparable from the per-source watermark guard —
-    # ``record_manifest_entry`` advances ``data_freshness_index`` for the
-    # form's source, so an un-guarded gap-close would push OWNERSHIP-source
-    # watermarks (13F/N-PORT/Form-3/4) ahead of the parsed observations
-    # (silent-gap, pillar 3). P3 adds the stage WITH the guard atomically.
+    # #1415 (P3) — recent-window gap-close in the freed S15 slot (order 15).
+    # The bulk archives lag real-time by days; this walks the current + prev
+    # quarter ``full-index/{year}/QTR{q}/form.idx`` ONCE per quarter (two
+    # ~50MB downloads, ZERO per-CIK HTTP) to close the bulk-cutoff→now gap in
+    # FILING-METADATA coverage. The ``sec_master_idx_gap_close`` invoker is
+    # scoped via ``GAP_CLOSE_FILING_METADATA_SOURCES`` so it advances ONLY
+    # filing-metadata watermarks (8-K/10-K/10-Q/DEF14A/13D/13G), NEVER the
+    # bulk-dataset ownership sources (13F-HR/N-PORT/Form-3/4/5) — that
+    # would push their cursor ahead of the parsed observations (silent-gap,
+    # spec §4.3 pillar 3). Requires cik_mapping_ready (subject resolution) +
+    # submissions_processed (serialise after bulk S8 to avoid manifest write
+    # contention). Provides nothing — pure filing-metadata discovery.
+    _spec("sec_master_idx_gap_close", 15, "sec_rate", JOB_SEC_MASTER_IDX_GAP_CLOSE),
     # S16 ``sec_first_install_drain`` stays (DB-bound manifest seed from
     # bulk filing_events); #1413 adds its ``follow_pagination=False``
     # bootstrap param so its secondary-page HTTP walk is also collapsed.
@@ -1179,10 +1193,13 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # steady-state / lazy-on-view (N-CSR annual-report bodies have NO bulk
     # artifact). It provided no required capability (terminal). The funds
     # panel slice renders from bulk N-PORT (S12 ownership_funds_observations),
-    # not N-CSR. N-CSR DISCOVERY (manifest rows) is still bulk-seeded via S8
-    # + the master.idx gap-close; the steady-state manifest worker parses the
-    # bodies post-complete. ``class_id_mapping_ready`` (provided by S26) is
-    # now provided-but-unconsumed (harmless; S26 stays for the steady-state map).
+    # not N-CSR. N-CSR DISCOVERY is steady-state's job: the S15 gap-close
+    # deliberately excludes ``sec_n_csr`` (fund-trust CIKs aren't in the S15
+    # subject resolver until S26 seeds the MF directory), and post-complete
+    # the Atom/daily-index layers + manifest worker discover + parse N-CSR
+    # against the S26-seeded fund directory. ``class_id_mapping_ready``
+    # (provided by S26) is now provided-but-unconsumed (harmless; S26 stays
+    # to seed the fund directory the steady-state N-CSR path needs).
 )
 
 
@@ -2916,11 +2933,11 @@ __all__ = [
 # removes a spec deliberately surfaces in code review and doesn't
 # silently break the tests + frontend + runbook that hardcode the
 # current stage shape.
-assert len(_BOOTSTRAP_STAGE_SPECS) == 19, (
-    f"_BOOTSTRAP_STAGE_SPECS expected 19 stages, got {len(_BOOTSTRAP_STAGE_SPECS)}; "
+assert len(_BOOTSTRAP_STAGE_SPECS) == 20, (
+    f"_BOOTSTRAP_STAGE_SPECS expected 20 stages, got {len(_BOOTSTRAP_STAGE_SPECS)}; "
     "update the spec, frontend, runbook, and stage_count tests in lockstep. "
     "#1233 PR-1b inserted S13 cusip_resolver_post_bulk_sweep; "
     "#1413 (bulk-only bootstrap) dropped 8 per-CIK HTTP stages "
-    "(S14/S15/S17/S19/S20/S22/S23 + S27 sec_n_csr_bootstrap_drain): 27 - 8 = 19. "
-    "The master.idx recent-window gap-close is deferred to P3 (watermark hardening)."
+    "(S14/S15/S17/S19/S20/S22/S23 + S27 sec_n_csr_bootstrap_drain): 27 - 8 = 19; "
+    "#1415 (P3) added the S15-slot master.idx recent-window gap-close: 19 + 1 = 20."
 )

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -7,8 +7,9 @@ singleton scheduler-gate state. Spec:
 Three tables (sql/129_bootstrap_state.sql):
 
   - ``bootstrap_runs``    — one row per "Run bootstrap" click.
-  - ``bootstrap_stages``  — one row per stage in a run (19 stages today,
-                            #1413 bulk-only collapse; catalogue lives in
+  - ``bootstrap_stages``  — one row per stage in a run (20 stages today,
+                            #1413 bulk-only collapse + #1415 master.idx
+                            gap-close; catalogue lives in
                             ``app/services/bootstrap_orchestrator.py::_BOOTSTRAP_STAGE_SPECS``).
   - ``bootstrap_state``   — singleton row (id=1) with the canonical
                             ``_bootstrap_complete`` gate status.

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -335,6 +335,8 @@ JOB_SEC_ATOM_FAST_LANE = "sec_atom_fast_lane"
 JOB_SEC_DAILY_INDEX_RECONCILE = "sec_daily_index_reconcile"
 JOB_SEC_PER_CIK_POLL = "sec_per_cik_poll"
 JOB_SEC_MASTER_IDX_QUARTERLY_SWEEP = "sec_master_idx_quarterly_sweep"
+# #1415 — bootstrap-only recent-window gap-close (filing-metadata scoped).
+JOB_SEC_MASTER_IDX_GAP_CLOSE = "sec_master_idx_gap_close"
 JOB_SEC_REBUILD = "sec_rebuild"
 JOB_FINRA_SHORT_INTEREST_REFRESH = "finra_short_interest_refresh"
 JOB_FINRA_REGSHO_DAILY_REFRESH = "finra_regsho_daily_refresh"
@@ -5289,6 +5291,60 @@ def sec_master_idx_quarterly_sweep() -> None:
             ]
             raise RuntimeError(
                 f"sec_master_idx_quarterly_sweep: {stats.failed_quarters} of "
+                f"{len(stats.quarters)} quarters failed; "
+                f"total_upserted={stats.total_upserted}; "
+                f"failed: {'; '.join(failed_details)}"
+            )
+
+
+def sec_master_idx_gap_close() -> None:
+    """``_INVOKERS['sec_master_idx_gap_close']`` — #1415 bootstrap stage S15.
+
+    Recent-window gap-close: walks the current + previous calendar quarter
+    ``full-index/{year}/QTR{q}/form.idx`` ONCE per quarter (two ~50MB
+    downloads, ZERO per-CIK HTTP) to close the gap between the bulk-archive
+    cutoff and ~now in FILING-METADATA coverage. Reuses
+    ``run_master_idx_quarterly_sweep`` but scoped via
+    ``GAP_CLOSE_FILING_METADATA_SOURCES`` so it NEVER seeds a manifest /
+    freshness row for a bulk-dataset ownership source (13F-HR / N-PORT /
+    Form-3/4/5) — advancing those watermarks from discovery would push the
+    steady-state cursor ahead of the parsed observations (silent gap, spec
+    §4.3 pillar 3). Bootstrap-only; the unscoped weekly G12
+    ``sec_master_idx_quarterly_sweep`` stays full-discovery.
+
+    Per-quarter commit / rollback isolation lives inside
+    ``run_master_idx_quarterly_sweep``; failure surfaces as a
+    ``RuntimeError`` so ``_tracked_job`` records ``status='failure'`` with
+    the failed-quarter detail (mirror of the G12 invoker).
+    """
+    from app.jobs.sec_master_idx_quarterly_sweep import (
+        GAP_CLOSE_FILING_METADATA_SOURCES,
+        run_master_idx_quarterly_sweep,
+    )
+
+    with _tracked_job(JOB_SEC_MASTER_IDX_GAP_CLOSE) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            stats = run_master_idx_quarterly_sweep(
+                conn,
+                http_get=_make_sec_http_get(sec),  # type: ignore[arg-type]
+                source_allowlist=GAP_CLOSE_FILING_METADATA_SOURCES,
+            )
+        tracker.row_count = stats.total_upserted
+        logger.info(
+            "sec_master_idx_gap_close: quarters=%d total_upserted=%d failed=%d (filing-metadata only)",
+            len(stats.quarters),
+            stats.total_upserted,
+            stats.failed_quarters,
+        )
+        if stats.failed_quarters > 0:
+            failed_details = [
+                f"{q.year}Q{q.quarter}: {q.error_detail or 'unknown'}" for q in stats.quarters if q.failed
+            ]
+            raise RuntimeError(
+                f"sec_master_idx_gap_close: {stats.failed_quarters} of "
                 f"{len(stats.quarters)} quarters failed; "
                 f"total_upserted={stats.total_upserted}; "
                 f"failed: {'; '.join(failed_details)}"

--- a/tests/test_bootstrap_flow_integration.py
+++ b/tests/test_bootstrap_flow_integration.py
@@ -124,8 +124,8 @@ def test_bootstrap_end_to_end(
     assert met is False
     assert "first-install bootstrap not complete" in reason
 
-    # 2. start_run seeds 19 stages atomically (#1413 bulk-only bootstrap
-    # dropped 8 per-CIK HTTP stages: 27 - 8 = 19).
+    # 2. start_run seeds 20 stages atomically (#1413 dropped 8 per-CIK HTTP
+    # stages + #1415 added the master.idx gap-close: 27 - 8 + 1 = 20).
     run_id = start_run(
         ebull_test_conn,
         operator_id=None,
@@ -136,7 +136,7 @@ def test_bootstrap_end_to_end(
     snap = read_latest_run_with_stages(ebull_test_conn)
     assert snap is not None
     assert snap.run_id == run_id
-    assert len(snap.stages) == 19
+    assert len(snap.stages) == 20
     assert all(s.status == "pending" for s in snap.stages)
 
     # 3. State is running, gate stays closed.
@@ -148,8 +148,8 @@ def test_bootstrap_end_to_end(
     # 4. Orchestrator drives Phase A → B → C with the stubbed invokers.
     run_bootstrap_orchestrator()
 
-    # 5. Every fake invoker fired once (19 stages post-#1413 bulk-only).
-    assert len(calls["order"]) == 19
+    # 5. Every fake invoker fired once (20 stages post-#1413/#1415).
+    assert len(calls["order"]) == 20
 
     # 6. State is complete; gate releases.
     state = read_state(ebull_test_conn)

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -104,21 +104,21 @@ def _register_synthetic_jobs(monkeypatch: pytest.MonkeyPatch, mapping: dict[str,
 # ---------------------------------------------------------------------------
 
 
-def test_stage_catalogue_has_nineteen_stages() -> None:
+def test_stage_catalogue_has_twenty_stages() -> None:
     """Catalogue size pinned to surface adds/removes in code review.
 
     #1413 (bulk-only bootstrap) dropped 8 per-CIK HTTP stages
     (S14 submissions_files_walk, S15 filings_history_seed, S17 def14a,
     S19 insider_transactions_backfill, S20 form3, S22 13f_recent_sweep,
     S23 n_port_ingest, S27 sec_n_csr_bootstrap_drain) → 27 - 8 = 19.
-    (The master.idx recent-window gap-close is deferred to P3 — its
-    watermark per-source guard lands atomically with it.)
+    #1415 (P3) added the S15-slot master.idx recent-window gap-close
+    (filing-metadata-scoped, with the per-source watermark guard) → 20.
 
-    19 = 1 init + 1 etoro + 8 sec_rate + 1 sec_bulk_download + 6 db
+    20 = 1 init + 1 etoro + 9 sec_rate + 1 sec_bulk_download + 6 db
     + 1 db_fundamentals_raw + 1 openfigi.
     """
     specs = get_bootstrap_stage_specs()
-    assert len(specs) == 19
+    assert len(specs) == 20
 
 
 def test_stage_catalogue_lane_composition() -> None:
@@ -126,14 +126,15 @@ def test_stage_catalogue_lane_composition() -> None:
     by_lane: dict[str, int] = {}
     for spec in specs:
         by_lane[spec.lane] = by_lane.get(spec.lane, 0) + 1
-    # #1413 — 1 + 1 + 8 + 1 + 6 + 1 + 1 = 19 stages. sec_rate: 16 − 8 per-CIK
-    # HTTP stages removed (incl. S27 N-CSR drain) = 8. ``db`` = 6 (5 bulk
-    # ingesters + ownership_observations_backfill); ``db_fundamentals_raw`` =
-    # 1 (S25 fundamentals_sync); ``openfigi`` = 1 (S13 cusip_resolver_post_bulk_sweep).
+    # #1413 — sec_rate: 16 − 8 per-CIK HTTP stages removed (incl. S27 N-CSR
+    # drain) = 8; #1415 + 1 master.idx gap-close = 9. Total 1 + 1 + 9 + 1 + 6
+    # + 1 + 1 = 20. ``db`` = 6 (5 bulk ingesters + ownership_observations_backfill);
+    # ``db_fundamentals_raw`` = 1 (S25 fundamentals_sync); ``openfigi`` = 1
+    # (S13 cusip_resolver_post_bulk_sweep).
     assert by_lane == {
         "init": 1,
         "etoro": 1,
-        "sec_rate": 8,
+        "sec_rate": 9,
         "sec_bulk_download": 1,
         "db": 6,
         "db_fundamentals_raw": 1,
@@ -349,9 +350,9 @@ def test_orchestrator_happy_path_completes(
     state = read_state(ebull_test_conn)
     assert state.status == "complete"
 
-    # #1413 (bulk-only bootstrap) dropped 8 per-CIK HTTP stages → 19
-    # invokers fire on the happy path.
-    assert len(calls["order"]) == 19
+    # #1413 dropped 8 per-CIK HTTP stages + #1415 added the master.idx
+    # gap-close → 20 invokers fire on the happy path.
+    assert len(calls["order"]) == 20
     # Phase A's universe sync was first.
     assert calls["order"][0] == "nightly_universe_sync"
 
@@ -812,6 +813,34 @@ def test_s16_no_longer_provides_secondary_pages_walked() -> None:
     (Capability Literal + provides + every consumer).
     """
     assert "submissions_secondary_pages_walked" not in _STAGE_PROVIDES.get("sec_first_install_drain", ())
+
+
+def test_master_idx_gap_close_stage_present() -> None:
+    """#1415 (P3) — the recent-window gap-close occupies the freed S15 slot
+    (order 15), runs on ``sec_rate``, and dispatches the bootstrap-only
+    ``sec_master_idx_gap_close`` invoker (NOT the unscoped weekly G12
+    ``sec_master_idx_quarterly_sweep``). The dedicated invoker is what carries
+    the filing-metadata ``source_allowlist`` so the gap-close never advances
+    an ownership-source watermark (the per-source guard). It gates on
+    ``cik_mapping_ready`` + ``submissions_processed`` and provides NO
+    capability (pure filing-metadata discovery — must never advertise an
+    ownership cap, P3 invariant).
+    """
+    spec = next(
+        (s for s in _BOOTSTRAP_STAGE_SPECS if s.stage_key == "sec_master_idx_gap_close"),
+        None,
+    )
+    assert spec is not None, "sec_master_idx_gap_close missing from _BOOTSTRAP_STAGE_SPECS"
+    assert spec.stage_order == 15
+    assert spec.lane == "sec_rate"
+    assert spec.job_name == "sec_master_idx_gap_close", (
+        "must dispatch the source-allowlist-scoped bootstrap invoker, not the unscoped G12 sweep"
+    )
+    req = _STAGE_REQUIRES_CAPS["sec_master_idx_gap_close"]
+    assert set(req.all_of) == {"cik_mapping_ready", "submissions_processed"}
+    assert req.any_of == ()
+    assert "sec_master_idx_gap_close" not in _STAGE_PROVIDES
+    assert "sec_master_idx_gap_close" not in _STAGE_PROVIDES_ON_SKIP
 
 
 @pytest.mark.parametrize("stage_key", ["sec_business_summary_bootstrap", "sec_8k_events_ingest"])

--- a/tests/test_cusip_resolver_openfigi.py
+++ b/tests/test_cusip_resolver_openfigi.py
@@ -634,8 +634,8 @@ def test_stage_orders_are_unique_and_ascending() -> None:
     orders = [spec.stage_order for spec in _BOOTSTRAP_STAGE_SPECS]
     assert orders == sorted(orders), f"stage_order not ascending: {orders}"
     assert len(set(orders)) == len(orders), f"duplicate stage_orders: {orders}"
-    # Pin the post-collapse count (27 - 8 per-CIK HTTP stages = 19; gap-close deferred to P3).
-    assert len(_BOOTSTRAP_STAGE_SPECS) == 19
+    # Pin the post-collapse count (27 - 8 per-CIK HTTP stages + 1 master.idx gap-close (#1415) = 20).
+    assert len(_BOOTSTRAP_STAGE_SPECS) == 20
 
 
 def test_openfigi_lane_in_max_concurrency_map() -> None:

--- a/tests/test_data_freshness.py
+++ b/tests/test_data_freshness.py
@@ -200,6 +200,7 @@ class TestSeedFromManifest:
 
         row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1701", source="sec_form4")
         assert row is not None
+        assert row.last_known_filed_at is not None
         assert row.last_known_filed_at == archive_filed_at, (
             "freshness watermark must be the archive's filed_at, not load time"
         )

--- a/tests/test_data_freshness.py
+++ b/tests/test_data_freshness.py
@@ -171,6 +171,42 @@ class TestSeedFromManifest:
         )
         transition_status(conn, accession, ingest_status="parsed")
 
+    def test_freshness_watermark_is_data_event_date_not_load_time(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#650 contamination lock (P3 / #1415) — ``last_known_filed_at`` MUST
+        reflect the filing's real ``filed_at`` (data-event date), NEVER
+        ``now()`` / load-extraction time. The bulk archives lag real-time by
+        days; a watermark set from ``now()`` would silently skip the gap
+        between the archive's filed_at and now (spec §4.3 pillar 3). Seed a
+        manifest row whose filed_at is 5 days in the past; the watermark must
+        equal that filed_at, not ~now.
+        """
+        _seed_instrument(ebull_test_conn, iid=1701, symbol="AAPL", cik="0000320193")
+        now = datetime.now(tz=UTC)
+        archive_filed_at = (now - timedelta(days=5)).replace(microsecond=0)
+        self._seed_manifest_row(
+            ebull_test_conn,
+            accession="ACC-650",
+            subject_type="issuer",
+            subject_id="1701",
+            source="sec_form4",
+            cik="0000320193",
+            instrument_id=1701,
+            filed_at=archive_filed_at,
+        )
+        ebull_test_conn.commit()
+
+        row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1701", source="sec_form4")
+        assert row is not None
+        assert row.last_known_filed_at == archive_filed_at, (
+            "freshness watermark must be the archive's filed_at, not load time"
+        )
+        # Explicit anti-contamination: the watermark is provably ~5d old, so it
+        # was NOT silently set to now()/extraction time.
+        assert (now - row.last_known_filed_at) >= timedelta(days=4, hours=23)
+
     def test_seeds_one_row_per_subject_source(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -491,6 +491,13 @@ class TestProductionInvokerRegistry:
             # lane-source cross-check at ``app/jobs/sources.py``. No
             # cadence → on-demand/bootstrap-only, like its S13 sibling.
             "fundamentals_sync_bootstrap",
+            # #1415 (P3) — bootstrap-only recent-window gap-close (S15 slot).
+            # Reuses the G12 sweep logic but scoped to filing-metadata sources
+            # (source_allowlist guard). Separate job_name from the weekly
+            # SCHEDULED G12 ``sec_master_idx_quarterly_sweep`` so the
+            # filing-metadata-scoped bootstrap dispatch and the unscoped
+            # weekly cron coexist. No cadence → on-demand/bootstrap-only.
+            "sec_master_idx_gap_close",
         }
         assert on_demand == expected_on_demand, (
             f"Unexpected on-demand invokers (update this test if intentional): "

--- a/tests/test_sec_master_idx_quarterly_sweep.py
+++ b/tests/test_sec_master_idx_quarterly_sweep.py
@@ -145,6 +145,29 @@ CIK|Company Name|Form Type|Date Filed|Filename
 320193|Apple Inc.|S-1|2026-05-15|edgar/data/320193/0000320193-26-000099.txt
 """
 
+# #1415 — a filing-metadata form (8-K → sec_8k) AND a bulk-dataset
+# ownership form (13F-HR → sec_13f_hr) in the same quarter, for the
+# source_allowlist filter test.
+_MIXED_8K_AND_13FHR_Q2 = b"""\
+Description:           Master Index of EDGAR Dissemination Feed
+Last Data Received:    June 30, 2026
+
+CIK|Company Name|Form Type|Date Filed|Filename
+--------------------------------------------------------------------------------
+320193|Apple Inc.|8-K|2026-05-15|edgar/data/320193/0000320193-26-000042.txt
+1067983|Berkshire Hathaway Inc|13F-HR|2026-05-15|edgar/data/1067983/0001067983-26-000002.txt
+"""
+
+# Header-only (zero rows) valid index — used as the prev-quarter body so
+# it neither fails nor adds rows.
+_EMPTY_IDX = b"""\
+Description:           Master Index of EDGAR Dissemination Feed
+Last Data Received:    March 31, 2026
+
+CIK|Company Name|Form Type|Date Filed|Filename
+--------------------------------------------------------------------------------
+"""
+
 
 # -- Tests: pure-function helpers -------------------------------------------
 
@@ -233,6 +256,58 @@ class TestRunMasterIdxQuarterlySweep:
         assert q1.upserted == 1
         # Total
         assert stats.total_upserted == 2
+
+    def test_source_allowlist_filters_ownership_sources(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#1415 — the bootstrap gap-close passes a filing-metadata
+        ``source_allowlist`` so it advances ONLY filing-metadata watermarks,
+        never the bulk-dataset ownership sources (13F-HR / N-PORT / Form-3/4/5
+        — their observations come from the quarterly bulk datasets, NOT the
+        manifest worker, so a discovery-side watermark advance would push the
+        steady-state cursor ahead of loaded data: silent gap, spec §4.3).
+
+        A 13F-HR row alongside an 8-K must be SKIPPED (no manifest row, no
+        ``data_freshness_index`` row) when ``source_allowlist={"sec_8k"}``.
+        """
+        _seed_issuer(ebull_test_conn, instrument_id=7, cik="0000320193", symbol="AAPL")
+        _seed_institutional_filer(ebull_test_conn, cik="0001067983", name="Berkshire Hathaway Inc")
+        ebull_test_conn.commit()
+
+        now = datetime(2026, 5, 17, tzinfo=UTC)  # CQ=Q2, CQ-1=Q1
+        resolver = _static_resolver(
+            {
+                "0000320193": ResolvedSubject(subject_type="issuer", subject_id="7", instrument_id=7),
+                "0001067983": ResolvedSubject(
+                    subject_type="institutional_filer", subject_id="0001067983", instrument_id=None
+                ),
+            }
+        )
+        stats = run_master_idx_quarterly_sweep(
+            ebull_test_conn,
+            http_get=_make_dispatch_http_get(
+                {
+                    _quarter_url(2026, 2): (200, _MIXED_8K_AND_13FHR_Q2),
+                    _quarter_url(2026, 1): (200, _EMPTY_IDX),
+                }
+            ),
+            now=now,
+            subject_resolver=resolver,
+            source_allowlist=frozenset({"sec_8k"}),
+        )
+        ebull_test_conn.commit()
+
+        # Only the 8-K upserted; the 13F-HR row is filtered by the allowlist.
+        assert stats.failed_quarters == 0
+        assert stats.total_upserted == 1
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM sec_filing_manifest WHERE source = 'sec_8k'")
+            assert cur.fetchone()[0] == 1  # type: ignore[index]
+            cur.execute("SELECT count(*) FROM sec_filing_manifest WHERE source = 'sec_13f_hr'")
+            assert cur.fetchone()[0] == 0, "13F-HR must NOT be seeded by the guarded gap-close"  # type: ignore[index]
+            cur.execute("SELECT count(*) FROM data_freshness_index WHERE source = 'sec_13f_hr'")
+            assert cur.fetchone()[0] == 0, "ownership-source watermark must NOT advance from gap-close discovery"  # type: ignore[index]
 
     def test_unmapped_form_skipped(
         self,


### PR DESCRIPTION
Closes #1415. Phase 3 of the bootstrap-ETL redesign (spec
`docs/proposals/etl/2026-06-01-bootstrap-etl-redesign-design.md` §4.3; follows
#1413 / PR #1414).

## What

Re-adds the **master.idx recent-window gap-close** stage (deferred from P2 —
its correctness is inseparable from the per-source watermark guard, per the
#1414 Codex ckpt-2 silent-gap finding) **with** that guard, plus a watermark
contamination regression lock.

- **`source_allowlist` param** on `run_master_idx_quarterly_sweep` — skips rows
  whose form-derived source is outside the allowlist (before
  `record_manifest_entry`, so no manifest row AND no `data_freshness_index`
  seed). Default `None` = full discovery → the steady-state weekly **G12 sweep
  is unchanged**.
- **New bootstrap-only invoker `sec_master_idx_gap_close`** wraps the sweep with
  `GAP_CLOSE_FILING_METADATA_SOURCES = {sec_8k, sec_10k, sec_10q, sec_def14a,
  sec_13d, sec_13g}`. **Excludes** the bulk-dataset-sourced ownership families
  (`sec_13f_hr` / `sec_n_port` / `sec_form3/4/5`): their observations come from
  the quarterly bulk datasets (bootstrap S10/S11/S12), NOT the manifest worker,
  so a discovery-side watermark advance would push the steady-state cursor
  ahead of loaded data (**silent gap**, spec §4.3 pillar 3). DEF14A/13D/13G are
  included — the worker parses their observations from the seeded manifest rows
  post-bootstrap, so seeding + advancing is eventually consistent.
- **New gap-close stage** (order 15, freed S15 slot, `sec_rate`; requires
  `cik_mapping_ready` + `submissions_processed`; provides nothing). Catalogue
  **19 → 20**, sec_rate **8 → 9**. Registered in `_INVOKERS` + the on-demand set.
- **#650 contamination lock:** a manifest row with `filed_at = now()−5d` →
  `data_freshness_index.last_known_filed_at` == that filed_at, never `now()` /
  load time.

## Codex checkpoint-2

Confirmed the ownership partition (the critical silent-gap concern) is correct
(13F-HR/N-PORT/Form-3/4/5 excluded before any manifest/freshness write).
**One finding, fixed:** `sec_n_csr` was initially in the allowlist but N-CSR
filers are fund **trusts** whose CIKs aren't in the S15 subject resolver until
S26 `mf_directory_sync` seeds the MF directory (runs *after* S15) — so N-CSR
rows would resolve as unknown-subject and never seed. Removed `sec_n_csr` from
the allowlist + corrected the comments; N-CSR discovery is steady-state's job
(post-S26 directory + Atom/daily-index), and N-CSR isn't panel-relevant
(funds slice = bulk N-PORT).

## Security model

No auth/authz change. The gap-close invoker is bootstrap/on-demand only (zero
operator params). No new raw SQL.

## Test plan

- `ruff` + `ruff format --check` + `pyright` — clean.
- 21 chokepoint-lint scripts — pass.
- Targeted `-n0`: master.idx sweep (+ source_allowlist filter test) + scheduler
  wiring, orchestrator, flow integration, cusip, jobs runtime, job registry,
  source registry, data freshness (+ #650 lock) — all green on the recreated
  dev volume.
- Codex ckpt-2 — partition correct; one finding fixed (above).

**`--no-verify`:** full xdist suite is environmentally unrunnable on this VM
(migration scratch-DB bloat → ~40-min checkpoint DROPs); documented precedent.
Diff is lint/format/pyright/targeted-`-n0`/Codex-green.

## DoD 8–12

Batched into the **P6 clean-bootstrap drive** — the gap-close's bulk-lag
coverage is verified live (post-bulk-cutoff accession count) at P6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
