### PR TITLE
fix(#1417): audit-ignore non-applicable vitest UI advisory (unblock supply-chain; defer vite-6 upgrade)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,13 @@
     "pnpm": ">=10.0.0"
   },
   "packageManager": "pnpm@10.30.3",
+  "pnpm": {
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-5xrq-8626-4rwp"
+      ]
+    }
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
Part of #1417 — interim supply-chain unblock; #1417 stays OPEN for the proper vitest-4/vite-6 upgrade (see Deferred below).

## What

`supply-chain` CI (`pnpm --dir frontend audit --audit-level high`) started
failing **repo-wide** (every PR, main included on re-run) after
**GHSA-5xrq-8626-4rwp** ("arbitrary file read when the Vitest UI server is
listening", **critical**) was published against `vitest <4.1.0`.

Add the GHSA to `frontend/package.json` → `pnpm.auditConfig.ignoreGhsas`.

## Why this is safe (non-applicable advisory)

`vitest` is a **dev-only** test runner. Every script uses `vitest run` (CI) or
`vitest` watch — **never `vitest --ui`**, so the vulnerable UI server is never
served. The advisory's attack surface (the Vitest UI HTTP server) does not exist
in our usage, in CI, or in any shipped artifact.

## Deferred (the proper fix)

Bumping to the patched `vitest ≥4.1.0` is a **multi-major** frontend toolchain
upgrade: vitest 4 peer-requires `vite ^6||^7||^8` (we're on vite ^5.4.8), so it
cascades vite 5→6 + `@vitejs/plugin-react` + a pnpm-10 build-script-approval
change for esbuild. That upgrade is tracked as the remaining work on **#1417**
and should land as its own focused frontend PR with the full `pnpm test` suite
re-verified — not bundled into a backend-blocking hotfix.

## Test plan

- `pnpm --dir frontend audit --audit-level high` → **exit 0** (critical ignored;
  remaining 4 vulns are moderate, below the `high` gate).
- Config-only: `pnpm-lock.yaml` + resolved deps unchanged (no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
