### PR TITLE
feat(#1449): dev-PG crash-loop / stuck-recovery detector (D1)

### DIFF
--- a/docs/operator/runbooks/pg-crash-loop-detector.md
+++ b/docs/operator/runbooks/pg-crash-loop-detector.md
@@ -1,0 +1,39 @@
+# Runbook — dev Postgres crash-loop detector (D1, #1449)
+
+## Why
+On 2026-06-03 the dev Postgres OOM-killed during WAL recovery and `restart: unless-stopped` looped it **silently for ~18h** (RestartCount 19). Nothing noticed because the app can't detect a wedged PG — its lifespan blocks on PG, so it never even binds its port. RCA: [`docs/proposals/etl/2026-06-03-pg-recovery-oom-rca.md`](../../proposals/etl/2026-06-03-pg-recovery-oom-rca.md).
+
+Defenses, layered:
+- **D2** (#1447) — `restart: on-failure:5` + healthcheck stops the *infinite* loop (it now exits after 5 and shows `unhealthy`/`exited`).
+- **D1** (this) — `scripts/pg_crash_loop_detector.py` watches from *outside* the app+PG (via the Docker daemon) and **alerts proactively** in minutes, whatever the cause.
+
+## What it alerts on
+- **Crash-loop:** `docker inspect` RestartCount rises ≥3 within 15 min.
+- **Stuck recovery:** `pg_controldata` shows `in crash recovery` with the REDO location **frozen** for >10 min (the exact OOM-loop signature).
+
+Alert = macOS notification + a JSON status file (`~/.cache/ebull/pg_crash_loop_status.json`) + a loud stderr line.
+
+## Quick manual probe
+```bash
+uv run python -m scripts.pg_crash_loop_detector --once          # single check, exit 2 if alerting
+uv run python -m scripts.pg_crash_loop_detector                 # foreground loop (Ctrl-C to stop)
+```
+Note: `--once` cannot detect a *stall* (that needs history across time); use the loop, or launchd below.
+
+## Install (launchd, wire once)
+```bash
+REPO="$(pwd)"                                   # from the eBull checkout root
+sed "s#__REPO__#${REPO}#g" scripts/com.ebull.pg-crash-loop-detector.plist \
+  > ~/Library/LaunchAgents/com.ebull.pg-crash-loop-detector.plist
+launchctl load ~/Library/LaunchAgents/com.ebull.pg-crash-loop-detector.plist
+```
+Logs: `var/log/pg-crash-loop-detector.log`. Stop: `launchctl unload ~/Library/LaunchAgents/com.ebull.pg-crash-loop-detector.plist`.
+
+## When it fires
+1. `docker ps` / `docker inspect ebull-postgres --format '{{.RestartCount}} {{.State.Status}}'`.
+2. `docker logs ebull-postgres --tail 40` → look for `terminated by signal 9: Killed` (OOM during recovery).
+3. `docker exec ebull-postgres pg_controldata -D /var/lib/postgresql/data` → frozen REDO across restarts confirms the wedge.
+4. Follow the RCA's decisive call (§ VERDICT): a relation-count-driven recovery OOM does not recover under the 6 g cap → **wipe + re-bootstrap**. See SKILL §14.1.
+
+## Tuning
+`--restart-threshold` / `--restart-window-s` / `--recovery-stall-s` / `--interval` / `--renotify-s`. Defaults: 3 restarts / 15 min, 10 min stall, 60 s poll, 15 min re-alert.

--- a/scripts/com.ebull.pg-crash-loop-detector.plist
+++ b/scripts/com.ebull.pg-crash-loop-detector.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd LaunchAgent for the dev-PG crash-loop detector (D1, #1449).
+
+  Wire once (see docs/operator/runbooks/pg-crash-loop-detector.md):
+    1. Replace __REPO__ below with your absolute eBull checkout path.
+    2. cp scripts/com.ebull.pg-crash-loop-detector.plist \
+         ~/Library/LaunchAgents/com.ebull.pg-crash-loop-detector.plist
+    3. launchctl load ~/Library/LaunchAgents/com.ebull.pg-crash-loop-detector.plist
+
+  Runs the detector in loop mode (it maintains its own poll history, which the
+  recovery-stall signal needs). KeepAlive restarts it if it dies. It talks only
+  to the Docker daemon, so it keeps watching even when Postgres + the app are down.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ebull.pg-crash-loop-detector</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__REPO__/.venv/bin/python</string>
+        <string>-m</string>
+        <string>scripts.pg_crash_loop_detector</string>
+        <string>--container</string>
+        <string>ebull-postgres</string>
+        <string>--interval</string>
+        <string>60</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <!-- Docker CLI lives in /usr/local/bin or /opt/homebrew/bin on macOS. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardErrorPath</key>
+    <string>__REPO__/var/log/pg-crash-loop-detector.log</string>
+    <key>StandardOutPath</key>
+    <string>__REPO__/var/log/pg-crash-loop-detector.log</string>
+</dict>
+</plist>

--- a/scripts/pg_crash_loop_detector.py
+++ b/scripts/pg_crash_loop_detector.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Dev Postgres crash-loop / stuck-recovery detector (D1, #1449).
+
+Runs OUTSIDE the app and Postgres — it talks only to the Docker daemon —
+so it can alert even when BOTH are down. That is the exact blind spot that
+let the dev PG OOM-recovery loop run silently for ~18h (RCA 2026-06-03):
+the app could not even bind its port (lifespan blocks on PG), so nothing
+in-process could notice, and ``restart: unless-stopped`` hid the loop.
+
+D2 (#1447) stops the *infinite* loop (``restart: on-failure:5`` + a
+healthcheck). D1 here adds a *proactive alert* so the operator learns in
+minutes, regardless of the future root cause.
+
+Two signals, both in the pure ``evaluate`` policy (unit-tested, no IO):
+
+  A. **Crash-loop** — ``RestartCount`` rises by >= ``restart_threshold``
+     within ``restart_window_s``. The container is being restarted faster
+     than it can come up.
+  B. **Stuck recovery** — cluster state is ``in crash recovery`` (or
+     ``in archive recovery``) with a FROZEN "Latest checkpoint's REDO
+     location" for > ``recovery_stall_s``. A redo pointer that never
+     advances is the precise OOM-loop signature (each attempt replays the
+     same span and dies before checkpointing).
+
+On alert: a macOS notification (``osascript``), a JSON status file, and a
+loud stderr line. Single-shot (``--once``, for cron/launchd/tests) or a
+polling loop (default).
+
+Wire it once (launchd) — see ``scripts/com.ebull.pg-crash-loop-detector.plist``
+and ``docs/operator/runbooks/pg-crash-loop-detector.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+# Cluster states (from ``pg_controldata``) that mean "replaying WAL, not yet
+# accepting connections". A frozen redo LSN across these is the wedge.
+_RECOVERY_STATES: frozenset[str] = frozenset({"in crash recovery", "in archive recovery"})
+
+_DEFAULT_CONTAINER = "ebull-postgres"
+_DEFAULT_PGDATA = "/var/lib/postgresql/data"
+_DEFAULT_STATUS_FILE = Path.home() / ".cache" / "ebull" / "pg_crash_loop_status.json"
+
+
+@dataclass(frozen=True)
+class Sample:
+    """One observation of the container + cluster at ``ts`` (epoch seconds).
+
+    ``restart_count`` / ``cluster_state`` / ``redo_lsn`` are ``None`` when
+    the corresponding probe could not be read (container gone, ``pg_exec``
+    failed because PG is mid-restart, etc.) — a missing probe is never
+    treated as a healthy reading.
+    """
+
+    ts: float
+    restart_count: int | None
+    cluster_state: str | None
+    redo_lsn: str | None
+
+
+def evaluate(
+    samples: list[Sample],
+    *,
+    now: float,
+    restart_threshold: int = 3,
+    restart_window_s: float = 900.0,
+    recovery_stall_s: float = 600.0,
+) -> str | None:
+    """Pure policy: return a human alert reason, or ``None`` if healthy.
+
+    No IO — this is the unit-testable core. ``samples`` is the rolling
+    history oldest→newest; ``now`` is epoch seconds.
+    """
+    if not samples:
+        return None
+    cur = samples[-1]
+
+    # Signal A — crash-loop: RestartCount climbed past the threshold within
+    # the window. Compare against the MIN in-window (the container may have
+    # been recreated, resetting the counter, so a simple last-minus-first
+    # could go negative; min is the robust baseline).
+    if cur.restart_count is not None:
+        in_window = [s.restart_count for s in samples if s.restart_count is not None and s.ts >= now - restart_window_s]
+        if in_window:
+            delta = cur.restart_count - min(in_window)
+            if delta >= restart_threshold:
+                return (
+                    f"crash-loop: RestartCount rose +{delta} (to {cur.restart_count}) "
+                    f"within {int(restart_window_s // 60)}min"
+                )
+
+    # Signal B — stuck recovery: in a recovery state with the redo LSN frozen
+    # for longer than the stall budget. Walk back over the consecutive recent
+    # samples that are ALL in recovery with the SAME redo LSN; if that span is
+    # long enough, recovery is wedged (not merely slow-but-advancing).
+    if cur.cluster_state in _RECOVERY_STATES and cur.redo_lsn is not None:
+        oldest_frozen_ts = cur.ts
+        for s in reversed(samples):
+            if s.cluster_state in _RECOVERY_STATES and s.redo_lsn == cur.redo_lsn:
+                oldest_frozen_ts = s.ts
+            else:
+                break
+        frozen_for = cur.ts - oldest_frozen_ts
+        if frozen_for >= recovery_stall_s:
+            return (
+                f"recovery stalled: state={cur.cluster_state!r}, redo frozen at "
+                f"{cur.redo_lsn} for {int(frozen_for // 60)}min"
+            )
+
+    return None
+
+
+# ──────────────────────────── IO shell ────────────────────────────────
+
+
+def _run(cmd: list[str], timeout: float = 10.0) -> str | None:
+    """Run ``cmd``, return stripped stdout, or ``None`` on any failure."""
+    try:
+        out = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=True,
+        )
+    except subprocess.SubprocessError, OSError:  # py3.14 PEP 758: paren-free except tuple
+        return None
+    return out.stdout.strip()
+
+
+def _inspect_restart_count(container: str) -> int | None:
+    raw = _run(["docker", "inspect", "--format", "{{.RestartCount}}", container])
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _pg_controldata(container: str, pgdata: str) -> tuple[str | None, str | None]:
+    """Return (cluster_state, redo_lsn) from ``pg_controldata``.
+
+    Reads the control file, which works even mid-recovery (the postmaster
+    need not accept connections). ``(None, None)`` if the exec fails.
+    """
+    raw = _run(["docker", "exec", container, "pg_controldata", "-D", pgdata])
+    if raw is None:
+        return None, None
+    state: str | None = None
+    redo: str | None = None
+    for line in raw.splitlines():
+        if line.startswith("Database cluster state:"):
+            state = line.split(":", 1)[1].strip()
+        elif line.startswith("Latest checkpoint's REDO location:"):
+            redo = line.split(":", 1)[1].strip()
+    return state, redo
+
+
+def sample_now(container: str, pgdata: str, *, now: float) -> Sample:
+    restart_count = _inspect_restart_count(container)
+    state, redo = _pg_controldata(container, pgdata)
+    return Sample(ts=now, restart_count=restart_count, cluster_state=state, redo_lsn=redo)
+
+
+def _notify(reason: str, *, container: str, status_file: Path) -> None:
+    title = f"⚠️ {container} wedged"
+    # macOS native notification — no third-party dependency. Best-effort.
+    _run(
+        [
+            "osascript",
+            "-e",
+            f"display notification {json.dumps(reason)} with title {json.dumps(title)}",
+        ],
+        timeout=5.0,
+    )
+    try:
+        status_file.parent.mkdir(parents=True, exist_ok=True)
+        status_file.write_text(json.dumps({"ts": time.time(), "container": container, "reason": reason}))
+    except OSError:
+        pass
+    print(f"[pg-crash-loop-detector] ALERT: {container}: {reason}", file=sys.stderr, flush=True)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--container", default=_DEFAULT_CONTAINER)
+    p.add_argument("--pgdata", default=_DEFAULT_PGDATA)
+    p.add_argument("--interval", type=float, default=60.0, help="poll seconds (loop mode)")
+    p.add_argument("--restart-threshold", type=int, default=3)
+    p.add_argument("--restart-window-s", type=float, default=900.0)
+    p.add_argument("--recovery-stall-s", type=float, default=600.0)
+    p.add_argument("--renotify-s", type=float, default=900.0, help="re-alert cadence while still wedged")
+    p.add_argument("--status-file", type=Path, default=_DEFAULT_STATUS_FILE)
+    p.add_argument("--once", action="store_true", help="single check then exit (cron/launchd/tests)")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    history: list[Sample] = []
+    # Keep enough history to span the longer of the two windows.
+    retain_s = max(args.restart_window_s, args.recovery_stall_s) * 2
+    last_alert_ts = 0.0
+
+    def _tick() -> str | None:
+        nonlocal last_alert_ts
+        now = time.time()
+        history.append(sample_now(args.container, args.pgdata, now=now))
+        # Trim history outside the retention window.
+        cutoff = now - retain_s
+        del history[: max(0, len(history) - 1 - sum(1 for s in history if s.ts >= cutoff))]
+        reason = evaluate(
+            history,
+            now=now,
+            restart_threshold=args.restart_threshold,
+            restart_window_s=args.restart_window_s,
+            recovery_stall_s=args.recovery_stall_s,
+        )
+        if reason is not None and (now - last_alert_ts) >= args.renotify_s:
+            _notify(reason, container=args.container, status_file=args.status_file)
+            last_alert_ts = now
+        return reason
+
+    if args.once:
+        # Single-shot needs >1 sample to judge a window; the caller (cron/
+        # launchd) provides cadence. Persist/rehydrate is out of scope — the
+        # loop mode is the primary runtime; --once is for tests + a quick
+        # manual probe.
+        return 2 if _tick() else 0
+
+    print(
+        f"[pg-crash-loop-detector] watching {args.container} every {args.interval:.0f}s "
+        f"(restart>={args.restart_threshold}/{int(args.restart_window_s // 60)}min, "
+        f"recovery-stall>{int(args.recovery_stall_s // 60)}min)",
+        file=sys.stderr,
+        flush=True,
+    )
+    while True:
+        _tick()
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pg_crash_loop_detector.py
+++ b/tests/test_pg_crash_loop_detector.py
@@ -1,0 +1,95 @@
+"""Pure-policy tests for the dev-PG crash-loop detector (D1, #1449).
+
+Only ``evaluate`` is exercised — it is IO-free, so the whole alert/no-alert
+matrix runs in microseconds without Docker or a database.
+"""
+
+from __future__ import annotations
+
+from scripts.pg_crash_loop_detector import Sample, evaluate
+
+_NOW = 10_000.0
+_HEALTHY = "in production"  # any non-recovery pg_controldata state
+
+
+def _restart_series(counts: list[tuple[float, int]]) -> list[Sample]:
+    """Build samples with given (ts_offset_from_now, restart_count)."""
+    return [Sample(ts=_NOW - off, restart_count=c, cluster_state=_HEALTHY, redo_lsn=None) for off, c in counts]
+
+
+def _recovery_series(entries: list[tuple[float, str]]) -> list[Sample]:
+    """Build in-recovery samples with given (ts_offset_from_now, redo_lsn)."""
+    return [
+        Sample(ts=_NOW - off, restart_count=5, cluster_state="in crash recovery", redo_lsn=redo)
+        for off, redo in entries
+    ]
+
+
+def test_empty_history_is_healthy() -> None:
+    assert evaluate([], now=_NOW) is None
+
+
+def test_crash_loop_threshold_breached() -> None:
+    # +3 restarts over ~12min (inside the 15min window) → alert.
+    samples = _restart_series([(720, 4), (480, 5), (240, 6), (0, 7)])
+    reason = evaluate(samples, now=_NOW)
+    assert reason is not None
+    assert "crash-loop" in reason
+
+
+def test_crash_loop_below_threshold_is_healthy() -> None:
+    # Only +2 inside the window → no alert.
+    samples = _restart_series([(480, 5), (240, 6), (0, 7)])
+    assert evaluate(samples, now=_NOW) is None
+
+
+def test_old_restarts_outside_window_dont_alert() -> None:
+    # The +3 happened >15min ago; current window shows a flat counter.
+    samples = _restart_series([(2000, 1), (1900, 2), (1850, 3), (240, 4), (0, 4)])
+    assert evaluate(samples, now=_NOW) is None
+
+
+def test_container_recreation_resets_counter_no_false_positive() -> None:
+    # Counter reset to 0 after a recreate, then one restart → min-baseline
+    # keeps the delta at +1, not a spurious negative/large value.
+    samples = _restart_series([(800, 9), (300, 0), (0, 1)])
+    assert evaluate(samples, now=_NOW) is None
+
+
+def test_recovery_frozen_redo_alerts() -> None:
+    # Same redo LSN across 12min of in-recovery samples (> 10min stall) → alert.
+    samples = _recovery_series([(720, "1A/D3"), (480, "1A/D3"), (240, "1A/D3"), (0, "1A/D3")])
+    reason = evaluate(samples, now=_NOW)
+    assert reason is not None
+    assert "recovery stalled" in reason
+    assert "1A/D3" in reason
+
+
+def test_recovery_advancing_redo_is_healthy() -> None:
+    # Redo LSN advances each sample → recovery is progressing, not wedged.
+    samples = _recovery_series([(720, "1A/10"), (480, "1B/20"), (240, "1C/30"), (0, "1D/40")])
+    assert evaluate(samples, now=_NOW) is None
+
+
+def test_recovery_just_started_under_stall_budget_is_healthy() -> None:
+    # Frozen, but only for ~4min (< 10min budget) → not yet an alert.
+    samples = _recovery_series([(240, "1A/D3"), (120, "1A/D3"), (0, "1A/D3")])
+    assert evaluate(samples, now=_NOW) is None
+
+
+def test_redo_change_resets_the_frozen_span() -> None:
+    # Old frozen span ended when redo advanced; the current frozen span is
+    # short → no alert (guards against counting a stale frozen prefix).
+    # Old 1A/D3 froze for 300s long ago, then redo advanced to 1B/E4 which has
+    # only been frozen 300s (< 600s budget) → no alert. Guards against counting
+    # a stale frozen prefix from before the redo advanced.
+    samples = _recovery_series([(1200, "1A/D3"), (900, "1A/D3"), (300, "1B/E4"), (150, "1B/E4"), (0, "1B/E4")])
+    assert evaluate(samples, now=_NOW) is None
+
+
+def test_thresholds_are_configurable() -> None:
+    samples = _recovery_series([(400, "1A/D3"), (0, "1A/D3")])
+    # Default 600s stall budget → 400s span is healthy.
+    assert evaluate(samples, now=_NOW) is None
+    # Tighten to 300s → the same 400s span now alerts.
+    assert evaluate(samples, now=_NOW, recovery_stall_s=300.0) is not None


### PR DESCRIPTION
Closes #1449. RCA: `docs/proposals/etl/2026-06-03-pg-recovery-oom-rca.md`.

## What
The dev PG OOM-recovery loop ran **silently for ~18h** (RestartCount 19) — the app can't detect a wedged PG (its lifespan blocks on PG so it never binds its port). **D2** (#1447) stops the *infinite* loop; **D1** here adds a *proactive alert*.

`scripts/pg_crash_loop_detector.py` runs **outside** the app and Postgres (Docker daemon only), so it alerts even when both are down:
- Pure `evaluate()` policy (IO-free, 10 unit tests): **crash-loop** (RestartCount +≥3 within 15 min, min-baseline robust to container recreation) and **stuck recovery** (`pg_controldata` state `in crash recovery` with a FROZEN REDO location >10 min — the exact OOM-loop signature).
- Alert = macOS `osascript` notification + JSON status file + loud stderr.
- IO shell reads `docker inspect` RestartCount + `docker exec … pg_controldata`; every probe failure is recorded as `None`, never as a healthy reading.
- `scripts/com.ebull.pg-crash-loop-detector.plist` (launchd) + `docs/operator/runbooks/pg-crash-loop-detector.md` for one-time wiring.

## Security / scope
- No execution path, no app/runtime code touched. New standalone script + test + plist + runbook only. Read-only `docker inspect`/`exec`; no DB connection, no mutation.

## Test plan
- `tests/test_pg_crash_loop_detector.py`: **10 passed** — alert/no-alert matrix (threshold breached/not, outside-window, recreate-reset, frozen-redo, advancing-redo, under-budget, redo-change resets span, configurable thresholds).
- Live `--once` smoke against `ebull-postgres` + `ebull-postgres-test`.
- `ruff check` + `ruff format --check` + `pyright` + `shellcheck` clean.

## Notes
- Pushed with the wedged-dev `--no-verify` exception (dev PG is the cluster this whole incident wedged; the D1 test is pure and passes). Branch is off `main`; disjoint from #1447 (C1) — no shared files.
- `except A, B:` (no parens) in `_run` is valid Python 3.14 (PEP 758); ruff format normalises to it — commented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)