### PR TITLE
fix(#1452): first-run bootstrap shows "Run bootstrap", not destructive "Re-run all"

### DIFF
--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -321,6 +321,29 @@ describe("ProcessRow", () => {
     expect(screen.queryByRole("button", { name: "Full-wash" })).toBeNull();
   });
 
+  it("first-install bootstrap shows only 'Run bootstrap' (no Re-run/Cancel)", () => {
+    renderRow({
+      row: makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        display_name: "First-install bootstrap",
+        status: "pending_first_run",
+        can_iterate: false,
+        can_full_wash: true,
+        can_cancel: false,
+      }),
+    });
+    const runBtn = screen.getByRole("button", {
+      name: "Run bootstrap",
+    }) as HTMLButtonElement;
+    expect(runBtn).toBeTruthy();
+    expect(runBtn.disabled).toBe(false);
+    // Inapplicable affordances are hidden, not greyed, on a never-run row.
+    expect(screen.queryByRole("button", { name: "Re-run failed" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Re-run all" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
   it("scheduled_job row keeps Iterate / Full-wash labels", () => {
     renderRow({
       row: makeProcessRow({

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -76,8 +76,20 @@ export function ProcessRow({
   // (iterate / full_wash modes on the trigger endpoint) unchanged; only
   // the operator-visible label changes per mechanism.
   const isBootstrap = row.mechanism === "bootstrap";
+  // First install: nothing has ever run, so the only meaningful action is
+  // *starting* the bootstrap. "Re-run failed" / "Cancel" cannot apply
+  // (no failed stages, no active run) and "Re-run all" is the wrong verb —
+  // it's a first run, not a re-run, and there is nothing to wipe. Collapse
+  // to a single non-destructive "Run bootstrap" button (#1432). All other
+  // bootstrap states (partial_error / cancelled / running / complete) keep
+  // the full re-run / cancel vocabulary.
+  const isFirstRun = isBootstrap && row.status === "pending_first_run";
   const iterateLabel = isBootstrap ? "Re-run failed" : "Iterate";
-  const fullWashLabel = isBootstrap ? "Re-run all" : "Full-wash";
+  const fullWashLabel = isFirstRun
+    ? "Run bootstrap"
+    : isBootstrap
+      ? "Re-run all"
+      : "Full-wash";
 
   const iterateDisabled = !row.can_iterate || busy;
   const iterateTooltip = row.can_iterate
@@ -87,11 +99,13 @@ export function ProcessRow({
     : `${iterateLabel} is not available right now — open the process detail page for the precondition that is blocking it.`;
 
   const fullWashDisabled = !row.can_full_wash || busy;
-  const fullWashTooltip = row.can_full_wash
-    ? isBootstrap
-      ? "Reset every stage to pending; full first-install replay (typed-name confirm required)."
-      : "Reset watermark and re-fetch from epoch (typed-name confirm required)."
-    : `${fullWashLabel} is not available right now.`;
+  const fullWashTooltip = isFirstRun
+    ? "Start the first-install bootstrap — populates the universe + filings. Asks for confirmation first."
+    : row.can_full_wash
+      ? isBootstrap
+        ? "Reset every stage to pending; full first-install replay (confirm required)."
+        : "Reset watermark and re-fetch from epoch (confirm required)."
+      : `${fullWashLabel} is not available right now.`;
 
   const cancelDisabled = !row.can_cancel || busy;
   const cancelTooltip = row.can_cancel
@@ -158,25 +172,29 @@ export function ProcessRow({
       </td>
       <td className="px-2 py-2 text-right">
         <div className="flex flex-wrap items-center justify-end gap-1">
-          <ActionButton
-            label={iterateLabel}
-            tooltip={iterateTooltip}
-            disabled={iterateDisabled}
-            onClick={() => onIterate(row)}
-          />
+          {isFirstRun ? null : (
+            <ActionButton
+              label={iterateLabel}
+              tooltip={iterateTooltip}
+              disabled={iterateDisabled}
+              onClick={() => onIterate(row)}
+            />
+          )}
           <ActionButton
             label={fullWashLabel}
             tooltip={fullWashTooltip}
             disabled={fullWashDisabled}
             onClick={() => onFullWash(row)}
-            tone="danger"
+            tone={isFirstRun ? "primary" : "danger"}
           />
-          <ActionButton
-            label="Cancel"
-            tooltip={cancelTooltip}
-            disabled={cancelDisabled}
-            onClick={() => onCancel(row)}
-          />
+          {isFirstRun ? null : (
+            <ActionButton
+              label="Cancel"
+              tooltip={cancelTooltip}
+              disabled={cancelDisabled}
+              onClick={() => onCancel(row)}
+            />
+          )}
         </div>
         {triggerError ? (
           <div
@@ -275,12 +293,14 @@ function ActionButton({
   tooltip: string;
   disabled: boolean;
   onClick: () => void;
-  tone?: "default" | "danger";
+  tone?: "default" | "danger" | "primary";
 }) {
   const toneClass =
     tone === "danger"
       ? "border-red-300 bg-white text-red-700 hover:bg-red-50 dark:border-red-900 dark:bg-slate-900 dark:text-red-300 dark:hover:bg-red-950/40"
-      : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800/40";
+      : tone === "primary"
+        ? "border-blue-600 bg-blue-600 text-white hover:bg-blue-700 dark:border-blue-500 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-700"
+        : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800/40";
   return (
     <button
       type="button"

--- a/frontend/src/components/admin/ProcessesTable.test.tsx
+++ b/frontend/src/components/admin/ProcessesTable.test.tsx
@@ -378,6 +378,24 @@ describe("ProcessesTable", () => {
     ).toBeNull();
   });
 
+  it("gate banner uses 'run the bootstrap' copy (not 're-run') when pending", () => {
+    renderTableWithStatus(
+      [
+        makeProcessRow({
+          process_id: "bootstrap",
+          mechanism: "bootstrap",
+          display_name: "First-install bootstrap",
+          status: "pending_first_run",
+        }),
+      ],
+      "pending",
+    );
+    expect(
+      screen.getByText(/run the bootstrap from the bootstrap row/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/re-run failed stages/i)).toBeNull();
+  });
+
   it("renders all rows when bootstrap status is complete", () => {
     renderTableWithStatus(
       [
@@ -424,6 +442,31 @@ describe("ProcessesTable", () => {
       screen.getByText(/replays the full first-install bootstrap/i),
     ).toBeTruthy();
     expect(screen.queryByText(/resets the watermark/i)).toBeNull();
+  });
+
+  it("first-install bootstrap modal uses 'Start bootstrap' heading + non-destructive copy", async () => {
+    renderTableWithStatus(
+      [
+        makeProcessRow({
+          process_id: "bootstrap",
+          mechanism: "bootstrap",
+          display_name: "First-install bootstrap",
+          status: "pending_first_run",
+          can_iterate: false,
+          can_full_wash: true,
+          can_cancel: false,
+        }),
+      ],
+      "pending",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Run bootstrap" }));
+    expect(
+      await screen.findByRole("heading", { name: /Start bootstrap/i }),
+    ).toBeTruthy();
+    expect(screen.getByText(/Safe to run/i)).toBeTruthy();
+    // Destructive re-run copy must NOT appear on a never-run row.
+    expect(screen.queryByText(/resets every stage/i)).toBeNull();
+    expect(screen.queryByRole("heading", { name: /Re-run all/i })).toBeNull();
   });
 
   it("scheduled_job full-wash modal keeps original watermark copy", async () => {

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -209,6 +209,18 @@ export function ProcessesTable({
           <span className="font-semibold">{bootstrapStatus}</span>. Other
           categories are gated until bootstrap reaches{" "}
           <span className="font-semibold">complete</span> —{" "}
+          {/*
+            Deliberately keyed on `bootstrapStatus === "pending"` (the
+            bootstrap-status-endpoint vocabulary: pending|running|complete|
+            partial_error, wired from AdminPage `bootstrap.data?.status`),
+            NOT on the row-level `status === "pending_first_run"`
+            (ProcessStatus vocabulary) used by ProcessRow / ProcessDetailPage.
+            They are two enums over the SAME underlying `bootstrap_state`:
+            state 'pending' → endpoint "pending" AND row "pending_first_run",
+            so on a real first run both predicates fire together. Do NOT
+            "align" the literals — they intentionally differ because they
+            read different (but co-derived) status fields. (#1452)
+          */}
           {bootstrapStatus === "pending"
             ? "run the bootstrap from the bootstrap row."
             : "re-run failed stages or re-run all from the bootstrap row."}

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -208,8 +208,10 @@ export function ProcessesTable({
           First-install bootstrap is{" "}
           <span className="font-semibold">{bootstrapStatus}</span>. Other
           categories are gated until bootstrap reaches{" "}
-          <span className="font-semibold">complete</span> — re-run failed
-          stages or re-run all from the bootstrap row.
+          <span className="font-semibold">complete</span> —{" "}
+          {bootstrapStatus === "pending"
+            ? "run the bootstrap from the bootstrap row."
+            : "re-run failed stages or re-run all from the bootstrap row."}
         </div>
       ) : (
         <div className="flex flex-wrap items-center justify-between gap-2">
@@ -342,11 +344,27 @@ function FullWashConfirmDialog({
   // button itself stays red so the destructive intent is still clear;
   // the Cancel button remains as the obvious bail-out.
   const isBootstrap = row.mechanism === "bootstrap";
-  const heading = isBootstrap ? "Confirm Re-run all" : "Confirm full-wash";
-  const verb = isBootstrap ? "Re-run all" : "Full-wash";
-  const description = isBootstrap
-    ? `Re-run all resets every stage of ${row.display_name} to pending and replays the full first-install bootstrap. Stages re-run from scratch; ingested rows are deduped at the destination by ON CONFLICT.`
-    : `Full-wash resets the watermark for ${row.display_name} and re-fetches from epoch. ON CONFLICT idempotency prevents row duplication; the cost is bandwidth and rate-budget.`;
+  // First install (#1432): nothing has run yet, so this is a *start*, not
+  // a destructive re-run. Non-destructive copy + a primary (blue) confirm
+  // button rather than the red "wipe everything" framing the re-run states
+  // use. The underlying POST is still mode='full_wash' (resets stages to
+  // pending), but on a never-run row there is nothing to wipe.
+  const isFirstRun = isBootstrap && row.status === "pending_first_run";
+  const heading = isFirstRun
+    ? "Start bootstrap"
+    : isBootstrap
+      ? "Confirm Re-run all"
+      : "Confirm full-wash";
+  const verb = isFirstRun
+    ? "Run bootstrap"
+    : isBootstrap
+      ? "Re-run all"
+      : "Full-wash";
+  const description = isFirstRun
+    ? `Start the first-install bootstrap for ${row.display_name}. Walks the init → eToro → SEC stage sequence to populate the tradable universe and filings. Safe to run — this is the first run, nothing is overwritten.`
+    : isBootstrap
+      ? `Re-run all resets every stage of ${row.display_name} to pending and replays the full first-install bootstrap. Stages re-run from scratch; ingested rows are deduped at the destination by ON CONFLICT.`
+      : `Full-wash resets the watermark for ${row.display_name} and re-fetches from epoch. ON CONFLICT idempotency prevents row duplication; the cost is bandwidth and rate-budget.`;
   return (
     <Modal
       isOpen={true}
@@ -375,7 +393,11 @@ function FullWashConfirmDialog({
           onClick={onConfirm}
           disabled={busy}
           autoFocus
-          className="rounded border border-red-400 bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700 dark:bg-red-700 dark:hover:bg-red-800"
+          className={
+            isFirstRun
+              ? "rounded border border-blue-600 bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-500 dark:bg-blue-600 dark:hover:bg-blue-700"
+              : "rounded border border-red-400 bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700 dark:bg-red-700 dark:hover:bg-red-800"
+          }
         >
           {busy ? "Triggering…" : verb}
         </button>

--- a/frontend/src/pages/ProcessDetailPage.test.tsx
+++ b/frontend/src/pages/ProcessDetailPage.test.tsx
@@ -223,6 +223,44 @@ describe("ProcessDetailPage", () => {
     expect(screen.queryByRole("button", { name: "Iterate" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Full-wash" })).toBeNull();
   });
+
+  it("first-install bootstrap shows only 'Run bootstrap' + 'Start bootstrap' modal", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        display_name: "First-install bootstrap",
+        status: "pending_first_run",
+        can_iterate: false,
+        can_full_wash: true,
+        can_cancel: false,
+      }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    render(
+      <MemoryRouter initialEntries={["/admin/processes/bootstrap"]}>
+        <Routes>
+          <Route path="admin/processes/:id" element={<ProcessDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Run bootstrap" }),
+      ).toBeTruthy(),
+    );
+    // Inapplicable affordances hidden on a never-run row.
+    expect(screen.queryByRole("button", { name: "Re-run failed" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Re-run all" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    // Confirm modal uses non-destructive start framing.
+    fireEvent.click(screen.getByRole("button", { name: "Run bootstrap" }));
+    expect(
+      await screen.findByRole("heading", { name: /Start bootstrap/i }),
+    ).toBeTruthy();
+    expect(screen.getByText(/Safe to run/i)).toBeTruthy();
+    expect(screen.queryByText(/resets every stage/i)).toBeNull();
+  });
 });
 
 

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -450,48 +450,66 @@ function ActionBar({
   // Mechanism-specific labels — bootstrap maps iterate/full_wash to
   // "Re-run failed" / "Re-run all" per data-engineer skill §7.3.
   const isBootstrap = row.mechanism === "bootstrap";
+  // First install (#1432): collapse to a single non-destructive "Run
+  // bootstrap" button — mirrors the table-row affordance. "Re-run failed"
+  // / "Cancel" cannot apply on a never-run row.
+  const isFirstRun = isBootstrap && row.status === "pending_first_run";
   const iterateLabel = isBootstrap ? "Re-run failed" : "Iterate";
-  const fullWashLabel = isBootstrap ? "Re-run all" : "Full-wash";
+  const fullWashLabel = isFirstRun
+    ? "Run bootstrap"
+    : isBootstrap
+      ? "Re-run all"
+      : "Full-wash";
   const iterateTooltip = row.can_iterate
     ? isBootstrap
       ? "Resume incomplete + failed stages from where they stopped."
       : watermarkTooltip
     : `${iterateLabel} is not available right now.`;
-  const fullWashTooltip = row.can_full_wash
-    ? isBootstrap
-      ? "Reset every stage to pending; full first-install replay (typed-name confirm required)."
-      : "Reset watermark and re-fetch from epoch (typed-name confirm required)."
-    : `${fullWashLabel} is not available right now.`;
+  const fullWashTooltip = isFirstRun
+    ? "Start the first-install bootstrap — populates the universe + filings. Asks for confirmation first."
+    : row.can_full_wash
+      ? isBootstrap
+        ? "Reset every stage to pending; full first-install replay (confirm required)."
+        : "Reset watermark and re-fetch from epoch (confirm required)."
+      : `${fullWashLabel} is not available right now.`;
   return (
     <div className="flex flex-col items-end gap-1">
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onIterate}
-          disabled={!row.can_iterate || busy}
-          title={iterateTooltip}
-          className="rounded border border-slate-300 bg-white px-3 py-1 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800/40"
-        >
-          {iterateLabel}
-        </button>
+        {isFirstRun ? null : (
+          <button
+            type="button"
+            onClick={onIterate}
+            disabled={!row.can_iterate || busy}
+            title={iterateTooltip}
+            className="rounded border border-slate-300 bg-white px-3 py-1 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800/40"
+          >
+            {iterateLabel}
+          </button>
+        )}
         <button
           type="button"
           onClick={onFullWash}
           disabled={!row.can_full_wash || busy}
           title={fullWashTooltip}
-          className="rounded border border-red-300 bg-white px-3 py-1 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-900 dark:bg-slate-900 dark:text-red-300 dark:hover:bg-red-950/40"
+          className={
+            isFirstRun
+              ? "rounded border border-blue-600 bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-500 dark:bg-blue-600 dark:hover:bg-blue-700"
+              : "rounded border border-red-300 bg-white px-3 py-1 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-900 dark:bg-slate-900 dark:text-red-300 dark:hover:bg-red-950/40"
+          }
         >
           {fullWashLabel}
         </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={!row.can_cancel || busy}
-          title={row.can_cancel ? "Cooperative cancel — the worker stops at its next checkpoint." : "No active run to cancel."}
-          className="rounded border border-amber-300 bg-white px-3 py-1 text-sm font-medium text-amber-700 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-900 dark:bg-slate-900 dark:text-amber-300 dark:hover:bg-amber-950/40"
-        >
-          Cancel
-        </button>
+        {isFirstRun ? null : (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={!row.can_cancel || busy}
+            title={row.can_cancel ? "Cooperative cancel — the worker stops at its next checkpoint." : "No active run to cancel."}
+            className="rounded border border-amber-300 bg-white px-3 py-1 text-sm font-medium text-amber-700 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-900 dark:bg-slate-900 dark:text-amber-300 dark:hover:bg-amber-950/40"
+          >
+            Cancel
+          </button>
+        )}
       </div>
       {triggerError ? (
         <div
@@ -1445,8 +1463,19 @@ function FullWashConfirmDialog({
   // process names are internal identifiers, double-confirm with a
   // single click on the red verb button is the operator-locked UX.
   const isBootstrap = row.mechanism === "bootstrap";
-  const heading = isBootstrap ? "Confirm Re-run all" : "Confirm full-wash";
-  const verb = isBootstrap ? "Re-run all" : "Full-wash";
+  // First install (#1432): non-destructive "Start bootstrap" framing +
+  // blue confirm, mirroring the table-row modal.
+  const isFirstRun = isBootstrap && row.status === "pending_first_run";
+  const heading = isFirstRun
+    ? "Start bootstrap"
+    : isBootstrap
+      ? "Confirm Re-run all"
+      : "Confirm full-wash";
+  const verb = isFirstRun
+    ? "Run bootstrap"
+    : isBootstrap
+      ? "Re-run all"
+      : "Full-wash";
   return (
     <Modal isOpen={true} onRequestClose={onCancel} labelledBy="detail-fw-title">
       <h2
@@ -1456,7 +1485,15 @@ function FullWashConfirmDialog({
         {heading}
       </h2>
       <p className="mt-2 text-sm text-slate-700 dark:text-slate-300">
-        {isBootstrap ? (
+        {isFirstRun ? (
+          <>
+            Start the first-install bootstrap for{" "}
+            <span className="font-medium">{row.display_name}</span>. Walks the
+            init → eToro → SEC stage sequence to populate the tradable universe
+            and filings. Safe to run — this is the first run, nothing is
+            overwritten.
+          </>
+        ) : isBootstrap ? (
           <>
             Re-run all resets every stage of{" "}
             <span className="font-medium">{row.display_name}</span> to pending
@@ -1485,7 +1522,11 @@ function FullWashConfirmDialog({
           onClick={onConfirm}
           disabled={busy}
           autoFocus
-          className="rounded border border-red-400 bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700 dark:bg-red-700 dark:hover:bg-red-800"
+          className={
+            isFirstRun
+              ? "rounded border border-blue-600 bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-500 dark:bg-blue-600 dark:hover:bg-blue-700"
+              : "rounded border border-red-400 bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700 dark:bg-red-700 dark:hover:bg-red-800"
+          }
         >
           {busy ? "Triggering…" : verb}
         </button>


### PR DESCRIPTION
## What

On a never-run bootstrap (`status=pending_first_run`) the admin Processes UI showed three buttons keyed only on `mechanism`: two greyed dead buttons (**Re-run failed**, **Cancel** — neither can apply on a never-run row) plus a single red, destructive-toned **Re-run all** that is actually the only way to *start* the first install.

A first run is not a re-run, and there is nothing to wipe — the red "Re-run all" framing told the operator the opposite of the truth.

Branch the affordance on `status === "pending_first_run"` across all four operator-facing surfaces:

| Surface | Before | After |
|---|---|---|
| Table row button ([ProcessRow.tsx](frontend/src/components/admin/ProcessRow.tsx)) | `[Re-run failed*] [Re-run all!] [Cancel*]` | single blue **Run bootstrap** (iterate+cancel hidden) |
| Table confirm modal ([ProcessesTable.tsx](frontend/src/components/admin/ProcessesTable.tsx)) | red "Confirm Re-run all / wipe" | **Start bootstrap**, blue, "safe to run" |
| Detail-page action bar + modal ([ProcessDetailPage.tsx](frontend/src/pages/ProcessDetailPage.tsx)) | same red re-run framing | same blue start framing |
| Gate banner ([ProcessesTable.tsx](frontend/src/components/admin/ProcessesTable.tsx)) | "...re-run failed stages or re-run all" | "...**run the bootstrap** from the bootstrap row" |

All other bootstrap states (`partial_error` / `cancelled` / `running` / `complete`) keep the existing re-run / cancel vocabulary — those verbs are correct after a failure or cancellation.

## Why

Root cause is "wrong axis": the action affordance branched on `mechanism` (what kind of job) instead of `status` (what state it is in). The fresh-install operator's only valid action was labelled and styled as a destructive re-run, creating hesitation on the one button they are meant to press.

Drive-by: corrected stale tooltip "typed-name confirm required" → "confirm required" (type-to-confirm was removed in #1264).

## Test plan

- `pnpm typecheck` — clean
- `pnpm dark:check` — 182 files, no violations
- `pnpm test:unit` — 885 pass (+4 new: row button-collapse, table modal, detail page button+modal, gate banner copy)
- Codex: 4 review passes; each surfaced one additional surface (modal → detail page → gate banner) until grep-confirmed complete.

## Review notes

- **Banner predicate (review BLOCKING):** the banner keys on `bootstrapStatus === "pending"` (bootstrap-status-endpoint vocabulary) while the rows key on `status === "pending_first_run"` (ProcessStatus vocabulary). These are two enums over the **same** `bootstrap_state`: state `'pending'` → endpoint `"pending"` **and** row `"pending_first_run"` ([bootstrap_adapter.py `_STATE_TO_PROCESS_STATUS`](app/services/processes/bootstrap_adapter.py)), wired from [AdminPage `bootstrap.data?.status`](frontend/src/pages/AdminPage.tsx). Both fire together on a real first run — the predicates do not diverge. Added a code comment so the literals are not "aligned" in a future edit (which would break the banner). The suggested grep-parity CI check is intentionally **not** added — the literals *should* differ.

## Scope

- Frontend-only. Pushed with `--no-verify`: the pre-push pytest stage is blocked by a **pre-existing C1 test-cluster guard regression on `main`** (`_assert_not_dev_cluster` mis-fires on the redirect-then-reconnect pattern), fixed separately on branch `fix/1445`. lint/format/pyright/frontend hook stages all pass; only the infra-blocked pytest stage was bypassed (CLAUDE.md-sanctioned, precedent #1387).

Closes #1452
Refs #1432 (sibling — the clean-complete edge: destructive button shown on a *completed* run. This PR fixes the never-run edge; #1432 stays open.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)