### PR TITLE
fix(#1431): populate instruments.currency from operator-curated exchanges.currency

### DIFF
--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -341,9 +341,9 @@ def _normalise_instrument(item: Mapping[str, object]) -> InstrumentRecord | None
         symbol=str(symbol),
         company_name=str(item.get("instrumentDisplayName") or symbol),
         exchange=_str_or_none(item.get("exchangeID")),
-        # eToro instruments endpoint does not expose currency.
-        # Return None so enrichment (FMP profile) fills the real value.
-        # COALESCE upsert in universe.py preserves enriched currency.
+        # eToro instruments endpoint does not expose currency. Left None:
+        # universe.py derives it from the operator-curated exchanges.currency
+        # via the exchange join (same as country) — sql/159, #1431.
         currency=None,
         sector=_str_or_none(item.get("stocksIndustryId")),
         industry=None,  # secondary lookup deferred

--- a/app/services/universe.py
+++ b/app/services/universe.py
@@ -58,12 +58,14 @@ def sync_universe(
     with conn.transaction():
         # Upsert each record from the provider.
         #
-        # ``country`` is NOT taken from the provider (eToro instruments
-        # endpoint does not expose it — see
-        # ``app/providers/implementations/etoro.py:350``). Derived
-        # instead from ``exchanges.country`` (operator-curated, ISO
-        # 3166-1 alpha-2) via the ``instruments.exchange =
-        # exchanges.exchange_id`` join.
+        # ``country`` and ``currency`` are NOT taken from the provider
+        # (the eToro instruments endpoint exposes neither — see
+        # ``app/providers/implementations/etoro.py``). Both are derived
+        # from the operator-curated ``exchanges`` table (``country`` ISO
+        # 3166-1 alpha-2, ``currency`` ISO 4217) via the
+        # ``instruments.exchange = exchanges.exchange_id`` join. Currency
+        # is a property of where a listing trades (NYSE→USD, SIX→CHF,
+        # Oslo→NOK), not 1:1 with country — see sql/159 (#1431).
         #
         # Semantic: the source of truth is the exchanges curator. A
         # curated change ("exchange 5 is now uk_equity / GB") flows
@@ -80,7 +82,8 @@ def sync_universe(
         # pre-push catch (PR1 #1233).
         #
         # One-shot backfill for existing rows lives in
-        # ``sql/158_instruments_country_backfill.sql``.
+        # ``sql/158_instruments_country_backfill.sql`` (country) and
+        # ``sql/159_instruments_currency_backfill.sql`` (currency).
         for rec in records:
             conn.execute(
                 """
@@ -92,7 +95,8 @@ def sync_universe(
                 )
                 VALUES (
                     %(provider_id)s, %(symbol)s, %(company_name)s, %(exchange)s,
-                    %(currency)s, %(sector)s, %(industry)s,
+                    (SELECT currency FROM exchanges WHERE exchange_id = %(exchange)s),
+                    %(sector)s, %(industry)s,
                     (SELECT country FROM exchanges WHERE exchange_id = %(exchange)s),
                     %(is_tradable)s,
                     %(instrument_type)s, %(instrument_type_id)s, NOW(), NOW()
@@ -101,7 +105,21 @@ def sync_universe(
                     symbol             = EXCLUDED.symbol,
                     company_name       = EXCLUDED.company_name,
                     exchange           = EXCLUDED.exchange,
-                    currency           = COALESCE(EXCLUDED.currency, instruments.currency),
+                    -- Same shape as ``country`` below: mirror the
+                    -- curator's exchanges.currency, but preserve the prior
+                    -- value if the exchange row is missing (transient
+                    -- bootstrap order) rather than wiping it to NULL.
+                    currency           = CASE
+                        WHEN EXISTS (
+                            SELECT 1 FROM exchanges
+                            WHERE exchange_id = EXCLUDED.exchange
+                        )
+                        THEN (
+                            SELECT currency FROM exchanges
+                            WHERE exchange_id = EXCLUDED.exchange
+                        )
+                        ELSE instruments.currency
+                    END,
                     sector             = EXCLUDED.sector,
                     industry           = EXCLUDED.industry,
                     -- Preserve prior country if the exchange row is
@@ -133,8 +151,15 @@ def sync_universe(
                     instruments.symbol             IS DISTINCT FROM EXCLUDED.symbol             OR
                     instruments.company_name       IS DISTINCT FROM EXCLUDED.company_name       OR
                     instruments.exchange           IS DISTINCT FROM EXCLUDED.exchange           OR
-                    (EXCLUDED.currency IS NOT NULL AND
-                     instruments.currency IS DISTINCT FROM EXCLUDED.currency)                   OR
+                    -- Guarded by EXISTS so a missing exchange row (where
+                    -- the SET CASE preserves the prior currency) does NOT
+                    -- score as a change and force a redundant rewrite +
+                    -- last_seen_at bump. ``country`` below predates this
+                    -- and carries the same latent no-op in that rare state
+                    -- (exchange deleted / not-yet-seeded); not touched here
+                    -- to keep its shipped behaviour stable (#1431, Codex).
+                    (EXISTS (SELECT 1 FROM exchanges WHERE exchange_id = EXCLUDED.exchange)
+                     AND instruments.currency IS DISTINCT FROM EXCLUDED.currency)              OR
                     instruments.sector             IS DISTINCT FROM EXCLUDED.sector             OR
                     instruments.industry           IS DISTINCT FROM EXCLUDED.industry           OR
                     instruments.country            IS DISTINCT FROM EXCLUDED.country            OR
@@ -150,7 +175,6 @@ def sync_universe(
                     "symbol": rec.symbol,
                     "company_name": rec.company_name,
                     "exchange": rec.exchange,
-                    "currency": rec.currency,
                     "sector": rec.sector,
                     "industry": rec.industry,
                     "is_tradable": rec.is_tradable,

--- a/sql/159_instruments_currency_backfill.sql
+++ b/sql/159_instruments_currency_backfill.sql
@@ -1,0 +1,121 @@
+-- 159: instruments.currency — operator-curated exchanges.currency + backfill (#1431)
+--
+-- Pre-existing `instruments.currency` column (sql/001_init.sql) is 100% NULL
+-- across the whole universe (12,530 rows checked) because the eToro
+-- instruments endpoint does not expose currency (see
+-- app/providers/implementations/etoro.py — `currency=None`) and the
+-- "enriched separately by FMP" path referenced in old comments never
+-- shipped (no third-party fundamentals provider — settled-decisions
+-- "Fundamentals provider posture").
+--
+-- Consequence: get_portfolio defaults native currency to 'USD'
+-- (app/services/portfolio.py:200), so US listings render correctly but any
+-- non-USD listing (~40% of the universe: GBP / EUR / CHF / Nordic / HKD /
+-- AUD / JPY / AED) is silently treated as USD and NOT FX-converted into the
+-- operator's display currency — a latent valuation bug.
+--
+-- Fix mirrors sql/158 (country): the trading currency of a listing is a
+-- property of its exchange, so it lives on the operator-curated `exchanges`
+-- table and is derived onto each instrument via
+-- `instruments.exchange = exchanges.exchange_id`. `app/services/universe.py`
+-- is updated in the same PR to derive currency from the exchanges join on
+-- every upsert (same shape as country), so future syncs stay fresh. This
+-- migration adds the column, seeds it per curated exchange, and backfills
+-- the rows already present.
+--
+-- Migration is tx-wrapped by the runner — no explicit BEGIN/COMMIT.
+
+-- ---------------------------------------------------------------
+-- 1. New column on the existing `exchanges` table.
+--    ADD COLUMN IF NOT EXISTS (not CREATE IF NOT EXISTS) so re-apply
+--    on a DB where the column already exists is a no-op (prevention-log
+--    "new column in new-table migration" trap — here the table already
+--    exists, so the ALTER is the correct idempotent form).
+--    CHECK enforces ISO-4217 shape (3 uppercase letters) rather than a
+--    tight allow-list, so the operator can curate a new market's
+--    currency without a schema change, while garbage is still rejected
+--    (prevention-log "New TEXT columns in migrations need CHECK
+--    constraints"). NULL is permitted for asset classes with no single
+--    fiat (crypto / FX / index / commodity) and uncurated exchanges.
+-- ---------------------------------------------------------------
+ALTER TABLE exchanges ADD COLUMN IF NOT EXISTS currency TEXT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'exchanges_currency_iso4217_chk'
+          AND conrelid = 'exchanges'::regclass
+    ) THEN
+        ALTER TABLE exchanges
+            ADD CONSTRAINT exchanges_currency_iso4217_chk
+            CHECK (currency IS NULL OR currency ~ '^[A-Z]{3}$');
+    END IF;
+END $$;
+
+COMMENT ON COLUMN exchanges.currency IS
+    'ISO 4217 trading currency for listings on this exchange, '
+    'operator-curated. NULL when the exchange has no single fiat '
+    '(crypto / FX / index / commodity) or is not yet curated. Derived '
+    'onto instruments.currency via instruments.exchange = '
+    'exchanges.exchange_id (sql/159 backfill + app/services/universe.py '
+    'upsert). #1431.';
+
+-- ---------------------------------------------------------------
+-- 2. Seed currency per exchange, keyed on exchange_id (stable) and
+--    grouped by ISO-4217 code. Covers every exchange whose trading
+--    currency is unambiguous from its eToro `description`, INCLUDING
+--    venues still classified `asset_class='unknown'` with a NULL
+--    `country` (Tokyo-dup / Tadawul / Warsaw / Shenzhen / …): currency
+--    is independent FX metadata, so curating it does not depend on the
+--    operator first reclassifying the exchange's asset_class/country.
+--    Leaving these NULL would keep portfolio.py defaulting their
+--    listings to USD (the #1431 bug) for the ~170 instruments on them.
+--
+--    `WHERE currency IS NULL` guards an operator hand-edit from being
+--    clobbered on re-apply (same spirit as sql/067's ON CONFLICT DO
+--    NOTHING). Genuinely no-single-fiat venues stay NULL: crypto (8),
+--    FX (1), index/CFD (3), commodity (2), CME futures (40).
+-- ---------------------------------------------------------------
+UPDATE exchanges SET currency = 'USD' WHERE currency IS NULL AND exchange_id IN ('4','5','19','20','33');   -- Nasdaq / NYSE / OTC / CBOE / RTH
+UPDATE exchanges SET currency = 'GBP' WHERE currency IS NULL AND exchange_id IN ('7','42','43','44');        -- LSE + LSE AIM
+UPDATE exchanges SET currency = 'EUR' WHERE currency IS NULL AND exchange_id IN
+    ('6','9','10','11','17','22','23','30','38','32','34','51','52','53');                                    -- FRA/Paris/Madrid/Milan/Helsinki/Lisbon/Brussels/Amsterdam/Xetra + Vienna/Dublin/Tallinn/Vilnius/Riga
+UPDATE exchanges SET currency = 'CHF' WHERE currency IS NULL AND exchange_id = '12';                          -- SIX (Switzerland)
+UPDATE exchanges SET currency = 'NOK' WHERE currency IS NULL AND exchange_id = '14';                          -- Oslo
+UPDATE exchanges SET currency = 'SEK' WHERE currency IS NULL AND exchange_id = '15';                          -- Stockholm
+UPDATE exchanges SET currency = 'DKK' WHERE currency IS NULL AND exchange_id = '16';                          -- Copenhagen
+UPDATE exchanges SET currency = 'ISK' WHERE currency IS NULL AND exchange_id = '50';                          -- Nasdaq Iceland
+UPDATE exchanges SET currency = 'HKD' WHERE currency IS NULL AND exchange_id = '21';                          -- Hong Kong
+UPDATE exchanges SET currency = 'AUD' WHERE currency IS NULL AND exchange_id = '31';                          -- Sydney
+UPDATE exchanges SET currency = 'JPY' WHERE currency IS NULL AND exchange_id IN ('56','13');                  -- Tokyo / TYO
+UPDATE exchanges SET currency = 'AED' WHERE currency IS NULL AND exchange_id IN ('39','41');                  -- Dubai / Abu Dhabi
+UPDATE exchanges SET currency = 'CAD' WHERE currency IS NULL AND exchange_id IN ('18','48');                  -- Toronto / TSX Venture
+UPDATE exchanges SET currency = 'SAR' WHERE currency IS NULL AND exchange_id = '24';                          -- Tadawul (Saudi)
+UPDATE exchanges SET currency = 'CZK' WHERE currency IS NULL AND exchange_id = '35';                          -- Prague
+UPDATE exchanges SET currency = 'PLN' WHERE currency IS NULL AND exchange_id = '36';                          -- Warsaw
+UPDATE exchanges SET currency = 'HUF' WHERE currency IS NULL AND exchange_id = '37';                          -- Budapest
+UPDATE exchanges SET currency = 'CNY' WHERE currency IS NULL AND exchange_id IN ('45','46');                  -- Shenzhen / Shanghai
+UPDATE exchanges SET currency = 'INR' WHERE currency IS NULL AND exchange_id = '47';                          -- NSE India
+UPDATE exchanges SET currency = 'SGD' WHERE currency IS NULL AND exchange_id = '49';                          -- Singapore
+UPDATE exchanges SET currency = 'KRW' WHERE currency IS NULL AND exchange_id = '54';                          -- Korea
+UPDATE exchanges SET currency = 'TWD' WHERE currency IS NULL AND exchange_id = '55';                          -- Taiwan
+
+-- ---------------------------------------------------------------
+-- 3. One-shot backfill of instruments already present. Future syncs
+--    keep the value fresh via the exchanges join in universe.py.
+-- ---------------------------------------------------------------
+UPDATE instruments i
+SET currency = e.currency
+FROM exchanges e
+WHERE i.exchange = e.exchange_id
+  AND e.currency IS NOT NULL
+  AND i.currency IS DISTINCT FROM e.currency;
+
+COMMENT ON COLUMN instruments.currency IS
+    'ISO 4217 native trading currency, derived from exchanges.currency '
+    'via instruments.exchange = exchanges.exchange_id. NULL when the '
+    'exchange has no curated currency (crypto / FX / index / uncurated). '
+    'Consumed by app/services/portfolio.py for FX conversion to the '
+    'operator display currency. Set by sql/159 backfill + maintained by '
+    'app/services/universe.py upsert. #1431.';

--- a/tests/test_migration_159_currency_backfill.py
+++ b/tests/test_migration_159_currency_backfill.py
@@ -1,0 +1,187 @@
+"""Regression tests for migration 159 (#1431).
+
+Pins the contracts of the migration against a real ``ebull_test`` DB:
+
+1. ``exchanges.currency`` carries the ISO-4217 CHECK constraint
+   (``exchanges_currency_iso4217_chk``): NULL allowed, 3 uppercase
+   letters allowed, anything else rejected.
+2. The backfill UPDATE derives ``instruments.currency`` from
+   ``exchanges.currency`` via the ``instruments.exchange =
+   exchanges.exchange_id`` join, only when ``exchanges.currency IS NOT
+   NULL`` (crypto / FX / index / uncurated exchanges leave the
+   instrument's currency NULL — they have no single trading currency).
+
+Mirrors ``test_migration_158_country_backfill.py`` — currency is the
+same operator-curated exchange-join derivation as country, just not 1:1
+with country (CH→CHF, Nordics diverge from EUR).
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+
+# Verbatim from sql/159_instruments_currency_backfill.sql so a refactor
+# that changes the SQL is caught by this test failing rather than by the
+# auto-applied migration succeeding once and never being checked.
+_BACKFILL_SQL = """
+UPDATE instruments i
+SET currency = e.currency
+FROM exchanges e
+WHERE i.exchange = e.exchange_id
+  AND e.currency IS NOT NULL
+  AND i.currency IS DISTINCT FROM e.currency
+"""
+
+
+def test_check_constraint_exists(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM pg_constraint "
+            "WHERE conname = 'exchanges_currency_iso4217_chk' "
+            "AND conrelid = 'exchanges'::regclass",
+        )
+        assert cur.fetchone() is not None, "migration 159 should add the ISO-4217 CHECK on exchanges"
+
+
+@pytest.mark.parametrize("bad", ["usd", "US", "DOLLAR", "12", "us$"])
+def test_check_constraint_rejects_non_iso4217(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    bad: str,
+) -> None:
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO exchanges (exchange_id, asset_class) VALUES ('959bad', 'unknown') "
+            "ON CONFLICT (exchange_id) DO NOTHING",
+        )
+        with pytest.raises(psycopg.errors.CheckViolation):
+            cur.execute(
+                "UPDATE exchanges SET currency = %s WHERE exchange_id = '959bad'",
+                (bad,),
+            )
+    ebull_test_conn.rollback()
+
+
+def _seed(
+    conn: psycopg.Connection[tuple],
+    *,
+    exchange_id: str,
+    exchange_currency: str | None,
+    instrument_id: int,
+    symbol: str,
+    instrument_currency: str | None = None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO exchanges (exchange_id, currency, asset_class)
+            VALUES (%s, %s, 'us_equity')
+            ON CONFLICT (exchange_id) DO UPDATE SET currency = EXCLUDED.currency
+            """,
+            (exchange_id, exchange_currency),
+        )
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+            VALUES (%s, %s, %s, %s, %s, TRUE)
+            ON CONFLICT (instrument_id) DO UPDATE SET
+                currency = EXCLUDED.currency,
+                exchange = EXCLUDED.exchange
+            """,
+            (instrument_id, symbol, f"Test {symbol}", exchange_id, instrument_currency),
+        )
+
+
+def _read_currency(conn: psycopg.Connection[tuple], instrument_id: int) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT currency FROM instruments WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
+class TestBackfillCurrencyFromExchanges:
+    def test_curated_exchange_populates_currency(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+        _seed(
+            ebull_test_conn,
+            exchange_id="9590",
+            exchange_currency="USD",
+            instrument_id=959001,
+            symbol="MIG159A",
+            instrument_currency=None,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_BACKFILL_SQL)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 959001) == "USD"
+
+    def test_null_exchange_currency_leaves_instrument_null(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        _seed(
+            ebull_test_conn,
+            exchange_id="9591",
+            exchange_currency=None,
+            instrument_id=959002,
+            symbol="MIG159B",
+            instrument_currency=None,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_BACKFILL_SQL)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 959002) is None
+
+    def test_idempotent_on_already_correct_row(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """``IS DISTINCT FROM`` guard: a re-run against a row already
+        matching the exchange currency writes nothing (rowcount=0)."""
+        _seed(
+            ebull_test_conn,
+            exchange_id="9592",
+            exchange_currency="GBP",
+            instrument_id=959003,
+            symbol="MIG159C",
+            instrument_currency="GBP",
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_BACKFILL_SQL)
+            cur.execute(_BACKFILL_SQL + " AND i.instrument_id = %s", (959003,))
+            assert cur.rowcount == 0
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 959003) == "GBP"
+
+    def test_overwrites_when_exchange_curator_changes_currency(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Operator re-curating an exchange's currency propagates on the
+        next backfill (USD→CHF, e.g. a re-classified listing venue)."""
+        _seed(
+            ebull_test_conn,
+            exchange_id="9593",
+            exchange_currency="USD",
+            instrument_id=959004,
+            symbol="MIG159D",
+            instrument_currency=None,
+        )
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(_BACKFILL_SQL)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 959004) == "USD"
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute("UPDATE exchanges SET currency = 'CHF' WHERE exchange_id = '9593'")
+            cur.execute(_BACKFILL_SQL)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 959004) == "CHF"

--- a/tests/test_universe_normaliser.py
+++ b/tests/test_universe_normaliser.py
@@ -69,9 +69,10 @@ class TestNormaliseInstrument:
         assert record.sector == "42"
         assert record.is_tradable is True
 
-    def test_currency_is_none_without_enrichment(self) -> None:
-        """currency is None — eToro instruments endpoint does not expose
-        a currency field. Enrichment (FMP profile) fills the real value."""
+    def test_currency_is_none_from_normaliser(self) -> None:
+        """currency is None from the normaliser — the eToro instruments
+        endpoint does not expose it. universe.py derives it from the
+        operator-curated exchanges.currency join (sql/159, #1431)."""
         record = _normalise_instrument(FIXTURE_INSTRUMENT)
         assert record is not None
         assert record.currency is None
@@ -519,3 +520,118 @@ class TestUniverseCountryDerivesFromExchanges:
         ebull_test_conn.commit()
         # exchanges.country wins.
         assert _read_country(ebull_test_conn, 970004) == "US"
+
+
+# ---------------------------------------------------------------------------
+# sync_universe — currency derives from exchanges.currency (#1431)
+# ---------------------------------------------------------------------------
+
+
+def _read_currency(conn: psycopg.Connection[tuple], instrument_id: int) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT currency FROM instruments WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
+def _seed_exchange_currency(
+    conn: psycopg.Connection[tuple], *, exchange_id: str, currency: str | None, asset_class: str
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO exchanges (exchange_id, currency, asset_class)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (exchange_id) DO UPDATE SET currency = EXCLUDED.currency, asset_class = EXCLUDED.asset_class
+            """,
+            (exchange_id, currency, asset_class),
+        )
+
+
+@pytest.mark.integration
+class TestUniverseCurrencyDerivesFromExchanges:
+    """``instruments.currency`` is derived from ``exchanges.currency`` via
+    the ``instruments.exchange = exchanges.exchange_id`` join — eToro
+    does not expose currency in the instruments endpoint (#1431)."""
+
+    def test_curated_exchange_populates_currency(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        _seed_exchange_currency(ebull_test_conn, exchange_id="4", currency="USD", asset_class="us_equity")
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="972001", symbol="USCCY1", exchange="4"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 972001) == "USD"
+
+    def test_currency_null_for_uncurated_exchange(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Crypto exchange has NULL currency — no single trading fiat.
+        _seed_exchange_currency(ebull_test_conn, exchange_id="8", currency=None, asset_class="crypto")
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="972002", symbol="CRYPTOCCY", exchange="8"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 972002) is None
+
+    def test_currency_refreshes_when_operator_recurates_exchange(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        """Operator curates an exchange NULL→GBP; the next sync_universe
+        propagates the new currency."""
+        _seed_exchange_currency(ebull_test_conn, exchange_id="972", currency=None, asset_class="unknown")
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="972003", symbol="CCYRECLASS", exchange="972"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 972003) is None
+
+        _seed_exchange_currency(ebull_test_conn, exchange_id="972", currency="GBP", asset_class="uk_equity")
+        ebull_test_conn.commit()
+
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 972003) == "GBP"
+
+    def test_missing_exchange_row_preserves_prior_currency(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """If the exchange row is missing (transient bootstrap order), the
+        upsert preserves the existing ``instruments.currency`` rather than
+        wiping it to NULL — same CASE shape as country."""
+        _seed_exchange_currency(ebull_test_conn, exchange_id="973", currency="USD", asset_class="us_equity")
+        provider = MagicMock()
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="972005", symbol="STALECCY", exchange="973"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 972005) == "USD"
+
+        provider.get_tradable_instruments.return_value = [
+            _make_record_with_exchange(provider_id="972005", symbol="STALECCY", exchange="99998"),
+        ]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        assert _read_currency(ebull_test_conn, 972005) == "USD"
+
+    def test_record_currency_field_ignored(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """``InstrumentRecord.currency`` is NOT wired through the upsert
+        (binding removed in #1431) — the upsert sources currency from
+        ``exchanges`` only. A record carrying USD cannot override the
+        operator-curated exchanges.currency='GBP'."""
+        _seed_exchange_currency(ebull_test_conn, exchange_id="974", currency="GBP", asset_class="uk_equity")
+        provider = MagicMock()
+        # _make_record_with_exchange hardcodes currency='USD' on the record.
+        rec = _make_record_with_exchange(provider_id="972004", symbol="CCYOVERRIDE", exchange="974")
+        assert rec.currency == "USD"
+        provider.get_tradable_instruments.return_value = [rec]
+        sync_universe(provider, ebull_test_conn)
+        ebull_test_conn.commit()
+        # exchanges.currency wins over the record's USD.
+        assert _read_currency(ebull_test_conn, 972004) == "GBP"


### PR DESCRIPTION
## What
`instruments.currency` was NULL for all 12,530 rows. Fix derives it from the operator-curated `exchanges.currency` via `instruments.exchange = exchanges.exchange_id` — the same shape #1233 §6.1 / sql/158 use for `country`.

- **sql/159** — `ADD COLUMN exchanges.currency` + ISO-4217 `CHECK` (conrelid-qualified); seed every exchange whose trading currency is unambiguous from its eToro `description` (incl. venues still classified `asset_class='unknown'` — currency is independent FX metadata); one-shot `instruments` backfill.
- **app/services/universe.py** — derive currency from the exchanges join on upsert (same CASE shape as country); WHERE guarded by `EXISTS` so a missing exchange row does not force a redundant rewrite.
- **app/providers/implementations/etoro.py** — drop the dead "enriched by FMP" comment (that path never shipped — no third-party fundamentals provider per settled-decisions).

## Why
The eToro instruments endpoint exposes no currency, and the FMP-enrichment path referenced in old comments never shipped. `get_portfolio` defaults native ccy to USD (portfolio.py:200), so US listings rendered fine but ~40% of the universe (GBP/EUR/CHF/Nordic/HKD/AUD/JPY/AED/...) was silently treated as USD and never FX-converted into the operator's display currency — a latent valuation bug. Currency is a property of *where a listing trades* (NYSE→USD, SIX→CHF, Oslo→NOK), so it belongs on the operator-curated `exchanges` table, not the provider record.

## Settled-decisions / prevention-log
- Provider design rule (providers thin, service/curator resolves) — currency now sourced from the exchanges curator, not the provider. ✓
- #1233 §6.1 country-from-exchanges precedent — directly mirrored. ✓
- Prevention-log "new TEXT currency columns need a CHECK" — ISO-4217 regex CHECK added (allows future markets, rejects garbage, NULL-permitting). ✓
- Prevention-log "new column on existing table" — `ADD COLUMN IF NOT EXISTS`. ✓
- Stale prevention-log line ("currency enriched separately by FMP") is now superseded by this PR; the universe.py + etoro.py comments record the real path.

## Test plan
- `tests/test_migration_159_currency_backfill.py` — CHECK exists (conrelid-qualified) + rejects non-ISO-4217 + verbatim backfill SQL on synthetic exchanges (populate / NULL-leaves-null / idempotent rowcount=0 / re-curate overwrite).
- `tests/test_universe_normaliser.py` — `sync_universe` currency derivation: curated populates / uncurated NULL / operator re-curate / missing-exchange-row preserves prior / record-field-ignored.
- `ruff check` + `ruff format --check` + `pyright` clean on changed files; affected suites (api_instruments, portfolio_valuation, market_data, api_portfolio, quote_stream, api_instrument_summary) all green.

## DoD (schema/ETL clauses)
- **Backfill executed** on dev DB: 0 → 11,912 / 12,530 currency non-null (95.1%). Held panel GME/IEP/QQQ/VOO/BBBY (exch 4/5) all USD. Remaining NULL = crypto(295)/fx(63)/index(33)/commodity(59)/CME(168) — all USD-via-fallback, semantically correct (no single equity listing currency).
- **Cross-source**: per-exchange currency mappings are standard ISO 4217 by listing venue (LSE→GBP, SIX→CHF, Oslo→NOK, Warsaw→PLN, NSE India→INR, Tadawul→SAR, …), curated from each exchange's eToro `description`.
- **Operator-visible**: portfolio panel renders held positions correctly (all USD); the non-USD path (975 GBP / 1,961 EUR rows now populated) is the latent-bug fix. Portfolio endpoint is auth-gated — operator confirms in browser.

## Codex checkpoint-2 (folded before push)
1. Comprehensive exchange coverage — original draft missed Tokyo-dup / Tadawul / Vienna / Dublin / Prague / Warsaw / Budapest / Shenzhen / Shanghai / India / Singapore / Iceland / Baltics / Korea / Taiwan / Toronto / TSXV; now mapped.
2. `EXISTS` guard on the WHERE currency comparison so a missing exchange row doesn't force a redundant rewrite + `last_seen_at` bump (country predates this; left stable, noted in comment).
3. `conrelid='exchanges'::regclass` qualification on the CHECK lookup (migration + test).

Commit: 892da31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1431
