### PR TITLE
fix(#1432): de-emphasise bootstrap 'Re-run all' on a clean-complete run

### DIFF
--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -344,6 +344,44 @@ describe("ProcessRow", () => {
     expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
   });
 
+  it("clean-complete bootstrap de-emphasises 'Re-run all' to a neutral tone (#1432)", () => {
+    renderRow({
+      row: makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        status: "ok",
+        can_iterate: false,
+        can_full_wash: true,
+      }),
+    });
+    const btn = screen.getByRole("button", {
+      name: "Re-run all",
+    }) as HTMLButtonElement;
+    // Still available — full re-bootstrap is a legal action.
+    expect(btn.disabled).toBe(false);
+    // ...but no red destructive styling, since nothing failed.
+    expect(btn.className).not.toContain("text-red-700");
+    expect(btn.className).toContain("text-slate-700");
+    expect(btn.title).toContain("completed cleanly");
+  });
+
+  it("failed bootstrap keeps the red destructive 'Re-run all' tone", () => {
+    renderRow({
+      row: makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        status: "failed",
+        can_iterate: true,
+        can_full_wash: true,
+      }),
+    });
+    const btn = screen.getByRole("button", {
+      name: "Re-run all",
+    }) as HTMLButtonElement;
+    expect(btn.className).toContain("text-red-700");
+    expect(btn.className).not.toContain("text-slate-700");
+  });
+
   it("scheduled_job row keeps Iterate / Full-wash labels", () => {
     renderRow({
       row: makeProcessRow({

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -80,10 +80,16 @@ export function ProcessRow({
   // *starting* the bootstrap. "Re-run failed" / "Cancel" cannot apply
   // (no failed stages, no active run) and "Re-run all" is the wrong verb —
   // it's a first run, not a re-run, and there is nothing to wipe. Collapse
-  // to a single non-destructive "Run bootstrap" button (#1432). All other
-  // bootstrap states (partial_error / cancelled / running / complete) keep
-  // the full re-run / cancel vocabulary.
+  // to a single non-destructive "Run bootstrap" button (#1264). All other
+  // bootstrap states keep the full re-run / cancel vocabulary.
   const isFirstRun = isBootstrap && row.status === "pending_first_run";
+  // Clean-complete: the bootstrap finished with every stage successful
+  // (status='ok'). "Re-run all" is still a legal action (full re-bootstrap)
+  // but it is NOT the expected next step — nothing failed — so it must not
+  // wear the red destructive styling that signals "fix the failure here".
+  // Keep it enabled but de-emphasised to a neutral tone (#1432). The
+  // confirm dialog still guards the wipe.
+  const isCleanComplete = isBootstrap && row.status === "ok";
   const iterateLabel = isBootstrap ? "Re-run failed" : "Iterate";
   const fullWashLabel = isFirstRun
     ? "Run bootstrap"
@@ -102,9 +108,11 @@ export function ProcessRow({
   const fullWashTooltip = isFirstRun
     ? "Start the first-install bootstrap — populates the universe + filings. Asks for confirmation first."
     : row.can_full_wash
-      ? isBootstrap
-        ? "Reset every stage to pending; full first-install replay (confirm required)."
-        : "Reset watermark and re-fetch from epoch (confirm required)."
+      ? isCleanComplete
+        ? "Last bootstrap completed cleanly — this wipes every stage and replays the full install from scratch. Only needed to fully re-bootstrap (confirm required)."
+        : isBootstrap
+          ? "Reset every stage to pending; full first-install replay (confirm required)."
+          : "Reset watermark and re-fetch from epoch (confirm required)."
       : `${fullWashLabel} is not available right now.`;
 
   const cancelDisabled = !row.can_cancel || busy;
@@ -185,7 +193,7 @@ export function ProcessRow({
             tooltip={fullWashTooltip}
             disabled={fullWashDisabled}
             onClick={() => onFullWash(row)}
-            tone={isFirstRun ? "primary" : "danger"}
+            tone={isFirstRun ? "primary" : isCleanComplete ? "default" : "danger"}
           />
           {isFirstRun ? null : (
             <ActionButton

--- a/frontend/src/pages/ProcessDetailPage.test.tsx
+++ b/frontend/src/pages/ProcessDetailPage.test.tsx
@@ -224,6 +224,35 @@ describe("ProcessDetailPage", () => {
     expect(screen.queryByRole("button", { name: "Full-wash" })).toBeNull();
   });
 
+  it("clean-complete bootstrap de-emphasises 'Re-run all' to a neutral tone (#1432)", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        display_name: "First-install bootstrap",
+        status: "ok",
+        can_iterate: false,
+        can_full_wash: true,
+      }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    render(
+      <MemoryRouter initialEntries={["/admin/processes/bootstrap"]}>
+        <Routes>
+          <Route path="admin/processes/:id" element={<ProcessDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    const btn = (await screen.findByRole("button", {
+      name: "Re-run all",
+    })) as HTMLButtonElement;
+    // Still available, but no red destructive styling — nothing failed.
+    expect(btn.disabled).toBe(false);
+    expect(btn.className).not.toContain("text-red-700");
+    expect(btn.className).toContain("text-slate-700");
+    expect(btn.title).toContain("completed cleanly");
+  });
+
   it("first-install bootstrap shows only 'Run bootstrap' + 'Start bootstrap' modal", async () => {
     mockedDetail.mockResolvedValue(
       makeProcessRow({

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -450,10 +450,14 @@ function ActionBar({
   // Mechanism-specific labels — bootstrap maps iterate/full_wash to
   // "Re-run failed" / "Re-run all" per data-engineer skill §7.3.
   const isBootstrap = row.mechanism === "bootstrap";
-  // First install (#1432): collapse to a single non-destructive "Run
+  // First install (#1264): collapse to a single non-destructive "Run
   // bootstrap" button — mirrors the table-row affordance. "Re-run failed"
   // / "Cancel" cannot apply on a never-run row.
   const isFirstRun = isBootstrap && row.status === "pending_first_run";
+  // Clean-complete (#1432): bootstrap finished with every stage successful
+  // — "Re-run all" stays available but loses its red destructive tone, since
+  // nothing failed. Mirrors the table-row affordance.
+  const isCleanComplete = isBootstrap && row.status === "ok";
   const iterateLabel = isBootstrap ? "Re-run failed" : "Iterate";
   const fullWashLabel = isFirstRun
     ? "Run bootstrap"
@@ -468,9 +472,11 @@ function ActionBar({
   const fullWashTooltip = isFirstRun
     ? "Start the first-install bootstrap — populates the universe + filings. Asks for confirmation first."
     : row.can_full_wash
-      ? isBootstrap
-        ? "Reset every stage to pending; full first-install replay (confirm required)."
-        : "Reset watermark and re-fetch from epoch (confirm required)."
+      ? isCleanComplete
+        ? "Last bootstrap completed cleanly — this wipes every stage and replays the full install from scratch. Only needed to fully re-bootstrap (confirm required)."
+        : isBootstrap
+          ? "Reset every stage to pending; full first-install replay (confirm required)."
+          : "Reset watermark and re-fetch from epoch (confirm required)."
       : `${fullWashLabel} is not available right now.`;
   return (
     <div className="flex flex-col items-end gap-1">
@@ -494,7 +500,9 @@ function ActionBar({
           className={
             isFirstRun
               ? "rounded border border-blue-600 bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-500 dark:bg-blue-600 dark:hover:bg-blue-700"
-              : "rounded border border-red-300 bg-white px-3 py-1 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-900 dark:bg-slate-900 dark:text-red-300 dark:hover:bg-red-950/40"
+              : isCleanComplete
+                ? "rounded border border-slate-300 bg-white px-3 py-1 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800/40"
+                : "rounded border border-red-300 bg-white px-3 py-1 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-900 dark:bg-slate-900 dark:text-red-300 dark:hover:bg-red-950/40"
           }
         >
           {fullWashLabel}


### PR DESCRIPTION
## What
After a clean bootstrap (`bootstrap_state.status='complete'` → process `status='ok'`), the Processes row + detail bar rendered the full-wash **"Re-run all"** button in red destructive styling even though nothing failed. Full-wash stays a legal action, so the button stays enabled — it just drops to a neutral tone when `status==='ok'`, with a tooltip clarifying it wipes + replays a completed install.

- `ProcessRow.tsx` — `tone="default"` (neutral) when `isCleanComplete`; `danger` retained for failed/partial.
- `ProcessDetailPage.tsx` — same neutral className branch on the detail bar.
- `ProcessRow.test.tsx` — clean-complete → neutral (no `text-red-700`, has `text-slate-700`, tooltip "completed cleanly"); failed → red retained.

Mirrors the merged #1264 first-run affordance: keyed on the existing `status` field, **no backend/contract change**.

## Why
On a healthy completed bootstrap, a prominent red "Re-run all" reads as "fix the failure here" when there is none. Backend mapping (bootstrap_adapter.py:62-65) confirmed: `complete→ok`, `partial_error→failed`, `cancelled→cancelled` — so only the genuinely-clean state de-emphasises.

## Conscious tradeoff — confirm modals stay red
The confirm modals (`ProcessesTable` / `ProcessDetailPage`) intentionally KEEP the red destructive tone for clean-complete. Unlike first-run (genuinely safe, nothing overwritten → blue confirm), confirming a wipe of a *completed* install is destructive, so the final guard stays red. The de-emphasis targets the entry button (not the visually-dominant red default on a healthy row), not the post-click confirmation.

## Test plan
- `pnpm typecheck` clean.
- `pnpm test:unit` — full unit suite green (889 tests), incl. 2 new ProcessRow cases.
- `check-dark-classes.mjs` gate clean (183 files).

## Codex checkpoint-2
Confirmed `status==='ok'` correctly identifies clean-complete (not partial/failed). Flagged the two confirm-modal buttons — REBUTTED as above (destructive final guard stays red by design).

Closes #1432