### PR TITLE
fix(#1433): 13F null/zero/negative-share + ownership period_end [1900,2100) ingest guards

### DIFF
--- a/app/services/ownership_observations.py
+++ b/app/services/ownership_observations.py
@@ -59,7 +59,7 @@ from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Literal
+from typing import Any, Literal, TypeGuard
 from uuid import UUID
 
 import psycopg
@@ -73,6 +73,33 @@ import psycopg.rows
 # ``ValueError`` instead of a Postgres CHECK error rolling the
 # whole transaction.
 _FUND_SERIES_ID_RE = re.compile(r"^S[0-9]{9}$")
+
+# Sanity window for an ownership ``period_end`` before it reaches the
+# partitioned observation tables (#1433). Mirrors the #1218 XBRL guard
+# (``sec_fundamentals._PERIOD_MIN/_MAX``): EDGAR began 1993, so pre-1900
+# has no filer use-case; the 2100 ceiling catches parser-bug junk (the
+# year-6016 / pre-1900 shapes #1218 found in the wild) before it lands in
+# the DEFAULT partition. Single source for both the 13F and N-PORT bulk
+# ingesters. Half-open: ``[MIN, MAX)``.
+OWNERSHIP_PERIOD_END_MIN: date = date(1900, 1, 1)
+OWNERSHIP_PERIOD_END_MAX: date = date(2100, 1, 1)
+
+
+def period_end_within_bounds(period_end: date | None) -> TypeGuard[date]:
+    """True iff ``period_end`` is a non-NULL date in ``[1900, 2100)`` (#1433).
+
+    A NULL or out-of-window ``period_end`` is malformed: the bulk ingesters
+    skip the row rather than persist it into the DEFAULT partition where a
+    year-6016 value would silently corrupt every period-bounded rollup.
+
+    Declared as a ``TypeGuard[date]`` so a caller that bails on the False
+    case (``if not period_end_within_bounds(pe): continue``) narrows ``pe``
+    to a non-Optional ``date`` for the rest of the loop body.
+    """
+    if period_end is None:
+        return False
+    return OWNERSHIP_PERIOD_END_MIN <= period_end < OWNERSHIP_PERIOD_END_MAX
+
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -59,6 +59,7 @@ from app.services.cusip_resolver import (
     reconcile_survived_markers,
 )
 from app.services.institutional_holdings import thirteen_f_retention_cutoff
+from app.services.ownership_observations import period_end_within_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -644,16 +645,26 @@ def ingest_13f_dataset_archive(
                 filer_cik = filer_cik_raw.zfill(10)
 
                 period_end = _parse_period_end(cover.get("REPORTCALENDARORQUARTER"))
+                # #1433 — reject a NULL or out-of-[1900,2100) period_end
+                # before it reaches the partitioned table. Mirrors the
+                # #1218 XBRL guard: a year-6016 / pre-1900 value would land
+                # in the DEFAULT partition and silently skew every
+                # period-bounded institutional rollup. A 13F-HR with no
+                # parseable cover period has nothing to rewash either, so
+                # this also keeps it out of the unresolved-CUSIP buffer.
+                if not period_end_within_bounds(period_end):
+                    result.rows_skipped_bad_data += 1
+                    continue
                 filed_at = _parse_filing_date(sub.get("FILING_DATE") or sub.get("DATE_FILED"))
 
                 instrument_id = cusip_map.get(cusip)
                 if instrument_id is None:
                     result.rows_skipped_unresolved_cusip += 1
                     # PR-1a — record (cusip, filer, period) so the
-                    # PR-1b OpenFIGI sweep can rewash. Skip if period
-                    # parse failed (bulk-path index requires period).
-                    if period_end is not None:
-                        unresolved_buffer.append((cusip, filer_cik, period_end))
+                    # PR-1b OpenFIGI sweep can rewash. period_end is
+                    # guaranteed in-window (non-None) by the #1433 guard
+                    # above, so the bulk-path index always has a period.
+                    unresolved_buffer.append((cusip, filer_cik, period_end))
                     continue
 
                 filer_name = (cover.get("FILINGMANAGER_NAME") or "").strip()
@@ -662,7 +673,9 @@ def ingest_13f_dataset_archive(
                     # the CIK to keep the row instead of dropping it.
                     filer_name = f"CIK{filer_cik}"
 
-                if filed_at is None or period_end is None:
+                # period_end already validated in-window above (#1433); only
+                # filed_at remains to null-check here.
+                if filed_at is None:
                     result.rows_skipped_bad_data += 1
                     continue
 
@@ -683,6 +696,14 @@ def ingest_13f_dataset_archive(
                     result.rows_skipped_bad_data += 1
                     continue
                 shares = _parse_decimal(row.get("SSHPRNAMT"))
+                # #1433 — an SH-type 13F holding must carry a positive share
+                # count. NULL / 0 / negative SSHPRNAMT is malformed (the
+                # schema column is nullable, sql/114, so the guard lives
+                # here at parse) and would otherwise be summed into the
+                # institutional ownership rollup as a phantom position.
+                if shares is None or shares <= 0:
+                    result.rows_skipped_bad_data += 1
+                    continue
                 # VALUE column unit changed 2023-01-03 — pre-cutover it
                 # was reported in $thousands, post-cutover in $dollars.
                 # See _VALUE_DOLLARS_CUTOVER constant at module top.

--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -53,7 +53,7 @@ from app.services.cusip_resolver import (
     reconcile_survived_markers,
 )
 from app.services.n_port_ingest import n_port_retention_cutoff
-from app.services.ownership_observations import upsert_sec_fund_series
+from app.services.ownership_observations import period_end_within_bounds, upsert_sec_fund_series
 
 logger = logging.getLogger(__name__)
 
@@ -612,7 +612,18 @@ def ingest_nport_dataset_archive(
                 period_end_early = _parse_iso_date(sub.get("REPORT_DATE")) or _parse_iso_date(
                     sub.get("REPORT_ENDING_PERIOD")
                 )
-                if period_end_early is not None and period_end_early < retention_cutoff:
+                # #1433 — reject a NULL or out-of-[1900,2100) period_end
+                # BEFORE the retention gate and the unresolved-CUSIP buffer,
+                # so a junk year-6016 with an unresolved CUSIP never leaks
+                # into unresolved markers, and a pre-1900 date is counted as
+                # bad_data rather than masked as retention (mirrors the #1218
+                # XBRL guard; shared bound via period_end_within_bounds).
+                # period_end_early == the staged period_end (same
+                # REPORT_DATE / REPORT_ENDING_PERIOD expression below).
+                if not period_end_within_bounds(period_end_early):
+                    result.rows_skipped_bad_data += 1
+                    continue
+                if period_end_early < retention_cutoff:
                     result.rows_skipped_retention += 1
                     continue
 
@@ -671,7 +682,8 @@ def ingest_nport_dataset_archive(
                 instrument_id = cusip_map.get(cusip)
                 if instrument_id is None:
                     filer_cik_raw_buf = (reg.get("CIK") or "").strip()
-                    if filer_cik_raw_buf and period_end_early is not None:
+                    # period_end_early guaranteed non-None by the #1433 guard.
+                    if filer_cik_raw_buf:
                         filer_cik_buf = filer_cik_raw_buf.zfill(10)
                         unresolved_buffer.append((cusip, filer_cik_buf, period_end_early))
                     # #1340 — recoverable miss: hold this accession back from
@@ -695,8 +707,12 @@ def ingest_nport_dataset_archive(
                 filer_cik = filer_cik_raw.zfill(10)
 
                 filed_at = _parse_filing_date(sub.get("FILING_DATE"))
-                period_end = _parse_iso_date(sub.get("REPORT_DATE")) or _parse_iso_date(sub.get("REPORT_ENDING_PERIOD"))
-                if filed_at is None or period_end is None:
+                # period_end == period_end_early (same REPORT_DATE /
+                # REPORT_ENDING_PERIOD), already validated in-window by the
+                # #1433 guard above — reuse it (non-None) and only null-check
+                # filed_at here.
+                period_end = period_end_early
+                if filed_at is None:
                     result.rows_skipped_bad_data += 1
                     continue
 

--- a/tests/test_period_end_bounds.py
+++ b/tests/test_period_end_bounds.py
@@ -1,0 +1,39 @@
+"""#1433 — the shared ownership period_end sanity window.
+
+``period_end_within_bounds`` is the single source both the 13F and N-PORT
+bulk ingesters use to reject a NULL or out-of-[1900, 2100) period_end before
+it lands in the DEFAULT partition (mirrors the #1218 XBRL guard).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.ownership_observations import (
+    OWNERSHIP_PERIOD_END_MAX,
+    OWNERSHIP_PERIOD_END_MIN,
+    period_end_within_bounds,
+)
+
+
+def test_bounds_constants() -> None:
+    assert OWNERSHIP_PERIOD_END_MIN == date(1900, 1, 1)
+    assert OWNERSHIP_PERIOD_END_MAX == date(2100, 1, 1)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, False),
+        (date(1899, 12, 31), False),  # below MIN
+        (date(1900, 1, 1), True),  # inclusive MIN
+        (date(2025, 9, 30), True),  # typical quarter-end
+        (date(2099, 12, 31), True),  # below MAX
+        (date(2100, 1, 1), False),  # exclusive MAX
+        (date(6016, 9, 30), False),  # parser-bug junk (#1218 in-the-wild shape)
+    ],
+)
+def test_period_end_within_bounds(value: date | None, expected: bool) -> None:
+    assert period_end_within_bounds(value) is expected

--- a/tests/test_sec_13f_dataset_ingest.py
+++ b/tests/test_sec_13f_dataset_ingest.py
@@ -400,6 +400,91 @@ class TestRealArchiveEdgeCases:
         assert result.rows_written == 0
         assert result.rows_skipped_bad_data == 1
 
+    @pytest.mark.parametrize("bad_shares", ["0", "0.0", "-5", "-100000", ""])
+    def test_non_positive_or_null_shares_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+        bad_shares: str,
+    ) -> None:
+        # #1433 — an SH-type holding with NULL / 0 / negative SSHPRNAMT is
+        # malformed and must not be summed into the ownership rollup.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {"ACCESSION_NUMBER": "0001234567-25-000001", "CIK": "1", "FILING_DATE": "2025-11-14"},
+            ],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILINGMANAGER_NAME": "Mgr",
+                    "REPORTCALENDARORQUARTER": "2025-09-30",
+                },
+            ],
+            infotable=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CUSIP": "037833100",
+                    "VALUE": "1000",
+                    "SSHPRNAMT": bad_shares,
+                    "SSHPRNAMTTYPE": "SH",
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+        assert result.rows_written == 0
+        assert result.rows_skipped_bad_data == 1
+
+    @pytest.mark.parametrize("bad_period", ["6016-09-30", "1899-12-31", "2100-01-01"])
+    def test_out_of_window_period_end_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+        bad_period: str,
+    ) -> None:
+        # #1433 — a period_end outside [1900, 2100) (parser-bug year-6016,
+        # pre-1900, or the exclusive 2100 ceiling) must be skipped before it
+        # reaches the DEFAULT partition.
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {"ACCESSION_NUMBER": "0001234567-25-000001", "CIK": "1", "FILING_DATE": "2025-11-14"},
+            ],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILINGMANAGER_NAME": "Mgr",
+                    "REPORTCALENDARORQUARTER": bad_period,
+                },
+            ],
+            infotable=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CUSIP": "037833100",
+                    "VALUE": "1000",
+                    "SSHPRNAMT": "100000",
+                    "SSHPRNAMTTYPE": "SH",
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+        result = ingest_13f_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+        assert result.rows_written == 0
+        assert result.rows_skipped_bad_data == 1
+
     def test_value_pre_2023_cutover_multiplied_by_thousands(
         self,
         ebull_test_conn: psycopg.Connection[tuple],

--- a/tests/test_sec_nport_dataset_ingest.py
+++ b/tests/test_sec_nport_dataset_ingest.py
@@ -215,12 +215,10 @@ class TestIngestNPortDatasetArchive:
         ebull_test_conn.commit()
         # The real invariant: an out-of-window period_end is never written.
         assert result.rows_written == 0
-        # Future dates (6016 / the exclusive 2100 ceiling) are caught by the
-        # #1433 bad_data guard; a pre-1900 date is caught a step earlier by
-        # the §4.6 retention gate — either way it is skipped, not persisted.
-        assert result.rows_skipped_bad_data + result.rows_skipped_retention >= 1
-        if bad_report_date >= "2100":
-            assert result.rows_skipped_bad_data >= 1
+        # The #1433 bounds guard runs BEFORE the §4.6 retention gate, so every
+        # out-of-window date — future (6016 / the exclusive 2100 ceiling) and
+        # pre-1900 alike — is routed to rows_skipped_bad_data, not retention.
+        assert result.rows_skipped_bad_data >= 1
 
     def test_resolved_cusip_deletes_bulk_marker(
         self,

--- a/tests/test_sec_nport_dataset_ingest.py
+++ b/tests/test_sec_nport_dataset_ingest.py
@@ -165,6 +165,63 @@ class TestIngestNPortDatasetArchive:
             assert period.isoformat() == "2025-09-30"
             assert source == "nport"
 
+    @pytest.mark.parametrize("bad_report_date", ["6016-09-30", "1899-12-31", "2100-01-01"])
+    def test_out_of_window_period_end_skipped(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+        bad_report_date: str,
+    ) -> None:
+        # #1433 — a REPORT_DATE outside [1900, 2100) is rejected at the
+        # submission level before any holding is processed, so it cannot
+        # reach the DEFAULT partition (mirrors the #1218 XBRL guard).
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        archive_bytes = _build_dataset_zip(
+            submissions=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILING_DATE": "2025-11-30",
+                    "SUB_TYPE": "NPORT-P",
+                    "REPORT_DATE": bad_report_date,
+                },
+            ],
+            registrants=[
+                {"ACCESSION_NUMBER": "0001234567-25-000001", "CIK": "1234567", "REGISTRANT_NAME": "Big Fund Trust"},
+            ],
+            fund_info=[
+                {"ACCESSION_NUMBER": "0001234567-25-000001", "SERIES_ID": "S000004310", "SERIES_NAME": "S"},
+            ],
+            holdings=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "HOLDING_ID": "1",
+                    "ISSUER_CUSIP": "037833100",
+                    "BALANCE": "500000",
+                    "UNIT": "NS",
+                    "CURRENCY_CODE": "USD",
+                    "CURRENCY_VALUE": "75000000",
+                    "PAYOFF_PROFILE": "Long",
+                    "ASSET_CAT": "EC",
+                },
+            ],
+        )
+        archive_path = tmp_path / "nport.zip"
+        archive_path.write_bytes(archive_bytes)
+        result = ingest_nport_dataset_archive(
+            conn=ebull_test_conn,
+            archive_path=archive_path,
+            ingest_run_id=uuid4(),
+        )
+        ebull_test_conn.commit()
+        # The real invariant: an out-of-window period_end is never written.
+        assert result.rows_written == 0
+        # Future dates (6016 / the exclusive 2100 ceiling) are caught by the
+        # #1433 bad_data guard; a pre-1900 date is caught a step earlier by
+        # the §4.6 retention gate — either way it is skipped, not persisted.
+        assert result.rows_skipped_bad_data + result.rows_skipped_retention >= 1
+        if bad_report_date >= "2100":
+            assert result.rows_skipped_bad_data >= 1
+
     def test_resolved_cusip_deletes_bulk_marker(
         self,
         ebull_test_conn: psycopg.Connection[tuple],


### PR DESCRIPTION
## What
Two of the three #1433 ingest-correctness guards. **Item 3 (manifest CIK/accession regex) is deferred to #1460** — it must be SEC-source-scoped (an unconditional regex would reject legitimate FINRA synthetic accessions like `FINRA_SI_20260430` / `cik="FINRA_SI"` written via `record_manifest_entry`), and it needs broad test-fixture realism work. Production manifest is already 100% format-clean (2.3M rows, 0 violations), so it is preventive — distinct from the two guards here, which stop actual in-the-wild bad data.

1. **13F shares positivity** — the bulk Form 13F ingester skips an SH-type holding with NULL / 0 / negative `SSHPRNAMT` at parse (schema column nullable, sql/114). Such a row would otherwise sum into the institutional ownership rollup as a phantom position.
2. **Ownership `period_end` window `[1900, 2100)`** — both the 13F and N-PORT bulk ingesters reject a NULL or out-of-window `period_end` before it reaches the partitioned observation tables, mirroring the #1218 XBRL guard (a parser-bug year-6016 / pre-1900 value would land in the DEFAULT partition and skew every period-bounded rollup). Single source: new `period_end_within_bounds` `TypeGuard[date]` + `OWNERSHIP_PERIOD_END_MIN/MAX` in `ownership_observations.py`.

## Why
Codex review of the bulk ingest found these land unguarded. The period_end guard reuses the exact #1218 rationale/bound; the shares guard prevents 0/negative-share phantom positions.

## Key correctness detail (Codex checkpoint-2)
N-PORT: the bounds guard runs **immediately after `period_end_early` is parsed, before the §4.6 retention gate and the unresolved-CUSIP buffer**. Earlier placement was too late — a junk period with an unresolved CUSIP would leak into unresolved markers, and a pre-1900 date would be miscounted as retention. Now downstream `period_end` reuses the already-validated `period_end_early` (single parse). 13F: the guard also keeps a no-cover-period row out of the unresolved buffer; the now-redundant downstream None-checks are simplified.

## Test plan
- `tests/test_period_end_bounds.py` — bound matrix (None / 1899 / 1900 / 2099 / 2100 / 6016).
- `tests/test_sec_13f_dataset_ingest.py` — non-positive/NULL shares (parametrised `0/0.0/-5/-100000/""`) + out-of-window period_end (`6016/1899/2100`).
- `tests/test_sec_nport_dataset_ingest.py` — out-of-window period_end (parametrised; asserts never-written + skipped by some guard, future dates hit the bad_data counter).
- 40 passed; `ruff` + `pyright` clean.

Refs #1433. Deferred sub-item tracked in #1460.