### PR TITLE
fix(#1434): calibrate bootstrap load-time validation row-count floors from clean baseline

### DIFF
--- a/app/services/bootstrap_validation.py
+++ b/app/services/bootstrap_validation.py
@@ -69,10 +69,35 @@ class BootstrapValidationError(RuntimeError):
 
 # --- Check 1: absolute row-count floors ------------------------------------
 #
-# PLACEHOLDER floors: every bulk-backed table must be non-empty (>0) after a
-# successful bulk-only bootstrap. P6 (clean-bootstrap drive) replaces these with
-# the first clean run's measured baselines (#1419 / plan Phase 6). Keep this a
-# plain {table: int} knob — no hardcoded ratios.
+# Calibrated absolute floors (#1434). Each is ~50% of the first clean-run
+# baseline measured on the dev DB 2026-06-04 (the run-3 baseline #1426 asked
+# for), rounded down to a clean figure. The half-baseline margin catches a
+# DEGRADED bootstrap — a bulk stage that errored mid-run and silently wrote a
+# fraction of expected (e.g. the 13F sweep dying after 2 of 11 cohorts) — while
+# leaving wide headroom against legitimate variance. SEC data only accumulates
+# and the bootstrap horizons are bounded (13F ~12mo, N-PORT 1yr, insider 2yr),
+# so these absolute minimums stay valid as future baselines grow; raise them
+# (never lower) when a later clean run measures a materially higher floor.
+# Plain {table: int} knob — no hardcoded ratios.
+#
+# Measured baseline → floor (2026-06-04):
+#   filing_events                     2,706,453 →  1,300,000
+#   financial_facts_raw              16,552,616 →  8,000,000
+#   ownership_insiders_observations     606,500 →    300,000
+#   ownership_institutions_observations 2,856,833 → 1,400,000
+#   ownership_funds_observations      2,247,669 →  1,100,000
+#   ownership_insiders_current           61,188 →     30,000
+#   ownership_institutions_current    1,151,745 →    575,000
+#   ownership_funds_current             695,750 →    340,000
+#
+# ``instruments`` is deliberately NOT floored here (#1462): the generic
+# ``_check_row_floors`` does ``COUNT(*)``, but ``sync_universe`` marks delisted
+# instruments ``is_tradable = FALSE`` rather than deleting them, so the total
+# row count never shrinks after one good sync — a later partial eToro response
+# leaves ``COUNT(*) >= floor`` and the degraded-universe shape goes undetected.
+# A correct instruments floor needs a ``WHERE is_tradable = TRUE`` count (or a
+# run-local provider-return count), which is a check-mechanism change, not a
+# value tweak — tracked in #1462.
 #
 # Scope rules (which tables are SAFE to hard-floor):
 #  * The three observation tables + filing_events + financial_facts_raw are
@@ -85,19 +110,19 @@ class BootstrapValidationError(RuntimeError):
 #    but S24 runs before/parallel to S25 (no cap between them), so treasury
 #    _current can be empty/stale at completion even on a healthy run. The panel
 #    render check still exercises treasury as a rollup slice; a hard floor here
-#    would false-fail. P6 re-scopes once treasury refresh is ordered after S25.
+#    would false-fail. Re-scope once treasury refresh is ordered after S25.
 #  * ``ownership_blockholders_current`` / ``ownership_def14a_current`` are
 #    deferred (manifest-worker / lazy-on-view) slices, legitimately empty at
 #    completion (spec §4.4) — never floored.
 _ROW_FLOORS: Final[dict[str, int]] = {
-    "filing_events": 1,
-    "financial_facts_raw": 1,
-    "ownership_insiders_observations": 1,
-    "ownership_institutions_observations": 1,
-    "ownership_funds_observations": 1,
-    "ownership_insiders_current": 1,
-    "ownership_institutions_current": 1,
-    "ownership_funds_current": 1,
+    "filing_events": 1_300_000,
+    "financial_facts_raw": 8_000_000,
+    "ownership_insiders_observations": 300_000,
+    "ownership_institutions_observations": 1_400_000,
+    "ownership_funds_observations": 1_100_000,
+    "ownership_insiders_current": 30_000,
+    "ownership_institutions_current": 575_000,
+    "ownership_funds_current": 340_000,
 }
 
 # --- Check 2: panel render -------------------------------------------------

--- a/tests/test_bootstrap_validation.py
+++ b/tests/test_bootstrap_validation.py
@@ -92,6 +92,34 @@ def test_count_at_least_bounded_and_accurate_shortfall(ebull_test_conn: psycopg.
 # ---------------------------------------------------------------------------
 
 
+def test_row_floors_are_calibrated_not_placeholders() -> None:
+    """#1434 — the floors were calibrated off the run-3 clean baseline. Guard
+    against an accidental revert to the old ``1`` placeholders (which only
+    caught a totally empty table, not a DEGRADED fractional-fill)."""
+    # No leftover placeholder: every floor is a calibrated absolute minimum,
+    # not the old non-empty sentinel.
+    assert all(floor >= 10_000 for floor in bv._ROW_FLOORS.values()), bv._ROW_FLOORS
+    # instruments is NOT floored here — a correct floor needs a tradable-aware
+    # count (sync_universe soft-deletes via is_tradable=FALSE), tracked in #1462.
+    assert "instruments" not in bv._ROW_FLOORS
+    # The bulk-backed observation/current tables stay floored.
+    for table in (
+        "filing_events",
+        "financial_facts_raw",
+        "ownership_institutions_current",
+        "ownership_funds_current",
+        "ownership_insiders_current",
+    ):
+        assert bv._ROW_FLOORS.get(table, 0) > 1, table
+    # Deferred / cross-stage-ambiguous slices stay UNfloored (scope rules).
+    for table in (
+        "ownership_treasury_current",
+        "ownership_blockholders_current",
+        "ownership_def14a_current",
+    ):
+        assert table not in bv._ROW_FLOORS, table
+
+
 def test_check_row_floors_raises_when_table_empty(
     ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_bootstrap_validation.py
+++ b/tests/test_bootstrap_validation.py
@@ -99,25 +99,23 @@ def test_row_floors_are_calibrated_not_placeholders() -> None:
     # No leftover placeholder: every floor is a calibrated absolute minimum,
     # not the old non-empty sentinel.
     assert all(floor >= 10_000 for floor in bv._ROW_FLOORS.values()), bv._ROW_FLOORS
-    # instruments is NOT floored here — a correct floor needs a tradable-aware
-    # count (sync_universe soft-deletes via is_tradable=FALSE), tracked in #1462.
-    assert "instruments" not in bv._ROW_FLOORS
-    # The bulk-backed observation/current tables stay floored.
-    for table in (
+    # Exact floored-table set (per the scope rules): asserting the whole set —
+    # not a subset loop — so DROPPING a key (e.g. silently losing an
+    # ownership_*_observations table) fails the test, not just bad values.
+    assert set(bv._ROW_FLOORS) == {
         "filing_events",
         "financial_facts_raw",
+        "ownership_insiders_observations",
+        "ownership_institutions_observations",
+        "ownership_funds_observations",
+        "ownership_insiders_current",
         "ownership_institutions_current",
         "ownership_funds_current",
-        "ownership_insiders_current",
-    ):
-        assert bv._ROW_FLOORS.get(table, 0) > 1, table
-    # Deferred / cross-stage-ambiguous slices stay UNfloored (scope rules).
-    for table in (
-        "ownership_treasury_current",
-        "ownership_blockholders_current",
-        "ownership_def14a_current",
-    ):
-        assert table not in bv._ROW_FLOORS, table
+    }, sorted(bv._ROW_FLOORS)
+    # instruments stays OUT (correct floor needs a tradable-aware count,
+    # #1462); the deferred treasury / blockholders / def14a slices stay OUT
+    # too — both enforced by the exact-set assertion above.
+    assert "instruments" not in bv._ROW_FLOORS
 
 
 def test_check_row_floors_raises_when_table_empty(


### PR DESCRIPTION
## What
The P4 load-time validation floors (#1419) shipped placeholder `1`s — catching only a totally empty table, not a DEGRADED bootstrap where a bulk stage errors mid-run and silently writes a fraction of expected (e.g. the 13F sweep dying after 2 of 11 cohorts).

Calibrate each floored table to ~50% of the first clean-run baseline measured on dev 2026-06-04 (the run-3 baseline #1426 asked for), rounded to a clean figure:

| table | baseline | floor |
|---|--:|--:|
| filing_events | 2,706,453 | 1,300,000 |
| financial_facts_raw | 16,552,616 | 8,000,000 |
| ownership_insiders_observations | 606,500 | 300,000 |
| ownership_institutions_observations | 2,856,833 | 1,400,000 |
| ownership_funds_observations | 2,247,669 | 1,100,000 |
| ownership_insiders_current | 61,188 | 30,000 |
| ownership_institutions_current | 1,151,745 | 575,000 |
| ownership_funds_current | 695,750 | 340,000 |

## Why ~50%
The half-baseline margin catches fractional-fill degradation with wide headroom against legitimate variance. SEC data only accumulates and the bootstrap horizons are bounded (13F ~12mo, N-PORT 1yr, insider 2yr), so these absolute minimums stay valid as future baselines grow — raise (never lower) when a later clean run measures materially higher.

## instruments deferred → #1462
`instruments` is **not** floored here. The generic `_check_row_floors` does `COUNT(*)`, but `sync_universe` soft-deletes (marks `is_tradable=FALSE`) rather than deleting, so `COUNT(*)` never shrinks after one good sync — a degraded partial-universe goes undetected. A correct floor needs a tradable-aware count (a check-mechanism change), tracked in #1462 (Codex checkpoint-2 catch).

## Test plan
- Empirically verified: `_check_row_floors` PASSES against the live dev baseline with every floor at ~50% margin (all `actual >= floor`).
- `test_row_floors_are_calibrated_not_placeholders` pins the calibration (no leftover `1`s; deferred slices `treasury`/`blockholders`/`def14a` stay unfloored; instruments stays out pending #1462).
- 16 passed; `ruff` + `pyright` clean.

Closes #1434