### PR TITLE
fix(#1320): stop seeding PRE 14A into sec_def14a manifest + repair polluted freshness

### DIFF
--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -164,3 +164,16 @@ A test that claims to prove a "Postgres unreachable → 503" path must make the 
 - Cover BOTH `/system/*` flavors when both exist (self-connect handler + `Depends(get_conn)` handler) — they fail through different code paths. Unit-test `get_conn`'s own error→503 mapping separately.
 
 Origin: PR #1394 review (#1325/#1217). A bearer-path 503 test that only patched the service-layer `psycopg.connect` was flagged as potentially passing for the wrong reason; the first fix (mutating `app.state.db_pool`) then leaked across tests — `dependency_overrides` is the leak-free seam.
+
+## Migration-behaviour tests: strip the BEGIN/COMMIT wrapper before inline execution
+
+A migration-behaviour test (seed pre-state → run the migration SQL inline → assert post-state) must NOT `cur.execute()` the raw migration file when that file carries its own `BEGIN; … COMMIT;` wrapper. The embedded `COMMIT` commits out from under the test's transaction control; the trailing `conn.commit()` then flushes an empty implicit transaction, and whether that raises depends on the test connection's autocommit mode — the test passes by accident.
+
+- Strip the standalone `BEGIN;`/`COMMIT;` lines and execute the body inside the fixture's transaction, letting the test commit once:
+  ```python
+  _BODY = "\n".join(l for l in _MIGRATION_SQL.splitlines() if l.strip() not in ("BEGIN;", "COMMIT;"))
+  ```
+- Or run the file via a dedicated `autocommit=True` connection. Either way the wrapper must not be executed inline through the regular fixture cursor.
+- Migrations with NO embedded transaction (e.g. `sql/111`) are fine to execute directly — the issue is only the embedded `BEGIN/COMMIT`.
+
+Origin: PR #1467 (#1320) review WARNING — `test_migration_182_pre14a_purge.py` executed `sql/182` (which wraps in `BEGIN;…COMMIT;`) inline then called `conn.commit()` again. EXTRACTED here rather than as a grep lint: the failure mode is narrow (migration tests only) and the fix is a one-liner at the call site.

--- a/app/services/sec_manifest.py
+++ b/app/services/sec_manifest.py
@@ -933,7 +933,16 @@ _FORM_TO_SOURCE: dict[str, ManifestSource] = {
     "DEFA14A": "sec_def14a",
     "DEFM14A": "sec_def14a",
     "DEFR14A": "sec_def14a",
-    "PRE 14A": "sec_def14a",
+    # ``PRE 14A`` (preliminary proxy) is deliberately NOT mapped (#1320).
+    # It is a pre-finalisation draft, classified metadata-only
+    # (test_filings_form_allowlist), whose ownership figures we never
+    # historically counted — the definitive DEF 14A that follows is what we
+    # ingest. Mapping it routed 6k+ drafts into the sec_def14a manifest
+    # namespace, which the parser then tombstoned pre-fetch (wasted worker
+    # cycles + polluted coverage). Skipping it at discovery (None → skip) is
+    # strictly better than seed-then-tombstone. The parser PRE-14A tombstone
+    # branch (manifest_parsers/def14a.py) stays as defense-in-depth for any
+    # PRE row that reaches the worker via a legacy/manual seed.
     # Fund (Phase 3). SEC EDGAR submissions API uses both ``NPORT-P`` /
     # ``NPORT-P/A`` (current spelling, no internal dash, "-P" suffix
     # marking the public-quarterly version) and ``N-PORT`` / ``N-PORT/A``

--- a/docs/etl/sources/sec_def14a.md
+++ b/docs/etl/sources/sec_def14a.md
@@ -24,6 +24,8 @@ Stage 17 `sec_def14a_bootstrap` (`app/services/bootstrap_orchestrator.py:1108`).
 ## 6. Manifest insert
 `sec_filing_manifest.source = 'sec_def14a'`. `subject_type='issuer'`, `subject_id=<issuer_cik_zero_padded>`, `instrument_id=<primary_share_class_iid>`. Option C `filed_at` gate at `record_manifest_entry`. Pre-cap accessions can still discover (no early gate); cap enforced post-parse so audit trail captures the supersession.
 
+**Form scope (`_FORM_TO_SOURCE`).** `DEF 14A` (definitive) + `DEFA14A` (additional definitive) + `DEFM14A` (merger) + `DEFR14A` (revised definitive) map to `sec_def14a`. **`PRE 14A` is deliberately excluded (#1320)** — preliminary proxies are pre-finalisation drafts, classified metadata-only; the definitive DEF 14A that follows is what we ingest. Mapping PRE 14A routed 6k+ drafts into this manifest namespace which the parser tombstoned pre-fetch (§7) — wasted worker cycles + polluted `WHERE source='sec_def14a'` reads. It is now skipped at discovery (`map_form_to_source('PRE 14A') is None`). The parser's PRE-14A tombstone branch stays as defense-in-depth for any PRE row that reaches the worker via a legacy/manual seed. Existing mis-seeded rows purged by `sql/182_purge_pre14a_manifest_rows.sql`.
+
 ## 7. Parser
 `app/services/manifest_parsers/def14a.py::_parse_def14a`. Version `_PARSER_VERSION_DEF14A` (`def14a_ingest.py:66`). Registered with `requires_raw_payload=True` — HTML body saved to `filing_raw_documents` BEFORE parse.
 

--- a/sql/182_purge_pre14a_manifest_rows.sql
+++ b/sql/182_purge_pre14a_manifest_rows.sql
@@ -1,0 +1,103 @@
+-- 182_purge_pre14a_manifest_rows.sql
+--
+-- #1320: purge PRE 14A (preliminary proxy) rows mis-seeded into the
+-- sec_def14a manifest namespace, and repair the freshness index they
+-- polluted.
+--
+-- WHY
+-- ---
+--   `app/services/sec_manifest._FORM_TO_SOURCE` previously mapped
+--   ``PRE 14A`` -> ``sec_def14a``. PRE 14A is a pre-finalisation draft,
+--   classified metadata-only — its ownership figures were never counted;
+--   the definitive DEF 14A that follows is what we ingest. The mapping
+--   routed 6k+ drafts into the sec_def14a manifest, which the parser
+--   (manifest_parsers/def14a.py) then tombstoned PRE-FETCH. No raw doc, no
+--   ingest-log row, no observation is ever written for a PRE 14A accession.
+--
+--   But `data_freshness.seed_freshness_for_manifest_row` advances
+--   `data_freshness_index.last_known_filed_at` from EVERY seeded manifest row
+--   by max(filed_at) — including PRE rows. So a PRE draft filed after the
+--   latest real DEF 14A left the subject's freshness pointer aimed at a
+--   preliminary draft. `watermarks.py` reports the operator-facing sec_def14a
+--   watermark as `MAX(last_known_filed_at)` across subjects, so a single PRE
+--   pointer inflates it (Codex #1320 review).
+--
+--   The `_FORM_TO_SOURCE` entry was removed in the same change, so discovery
+--   no longer re-seeds PRE 14A. This migration cleans up the rows + freshness
+--   pointers already on disk.
+--
+-- WHAT IT DOES
+-- -----------
+--   1. DELETE every sec_def14a manifest row with a PRE 14A form. Nothing
+--      downstream references them (parser tombstones before any write).
+--   2+3 only touch the freshness rows that are PROVABLY PRE-polluted: those
+--      whose `last_known_filing_id` no longer resolves to any manifest row
+--      after step 1 (it pointed at a now-deleted PRE accession). A freshness
+--      row whose pointer is NULL or still resolves is left untouched — it was
+--      not advanced by the draft we deleted, so it may be a legitimately
+--      watched issuer with no PRE involvement.
+--   2. RECOMPUTE last_known_*/expected_next_at for dangling rows whose subject
+--      STILL has a sec_def14a manifest row — from the latest remaining row,
+--      mirroring `seed_scheduler_from_manifest` (DISTINCT ON max filed_at).
+--      Cadence 365d = `data_freshness.cadence_for('sec_def14a')`.
+--   3. CLEAR last_known_* (-> NULL, state='unknown') for dangling rows whose
+--      subject has NO remaining sec_def14a manifest row: the pointer aimed
+--      solely at a draft, so there is no known real filing. The row is kept so
+--      the subject stays watched; the poll path re-derives state. NULL
+--      last_known_filed_at drops out of the `MAX()` operator watermark.
+--
+-- Idempotent: a no-op once clean (mapping removal stops re-seeding; both
+-- freshness predicates self-restrict to dangling pointers).
+-- TRIM guards the unlikely whitespace variant SEC sometimes emits.
+
+BEGIN;
+
+-- 1. Purge the PRE 14A manifest rows.
+DELETE FROM sec_filing_manifest
+WHERE source = 'sec_def14a'
+  AND TRIM(form) = 'PRE 14A';
+
+-- 2. Recompute dangling-pointer freshness rows that still have a manifest row.
+UPDATE data_freshness_index dfi
+SET last_known_filing_id = latest.accession_number,
+    last_known_filed_at  = latest.filed_at,
+    expected_next_at     = latest.filed_at + INTERVAL '365 days',
+    updated_at           = NOW()
+FROM (
+    SELECT DISTINCT ON (subject_type, subject_id)
+        subject_type, subject_id, accession_number, filed_at
+    FROM sec_filing_manifest
+    WHERE source = 'sec_def14a'
+    ORDER BY subject_type, subject_id, filed_at DESC NULLS LAST
+) latest
+WHERE dfi.source = 'sec_def14a'
+  AND dfi.subject_type = latest.subject_type
+  AND dfi.subject_id = latest.subject_id
+  AND dfi.last_known_filing_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM sec_filing_manifest m
+      WHERE m.accession_number = dfi.last_known_filing_id
+  );
+
+-- 3. Clear dangling-pointer freshness rows with no remaining manifest row.
+UPDATE data_freshness_index dfi
+SET last_known_filing_id = NULL,
+    last_known_filed_at  = NULL,
+    expected_next_at     = NULL,
+    state                = 'unknown',
+    state_reason         = 'pre14a_pointer_cleared_1320',
+    updated_at           = NOW()
+WHERE dfi.source = 'sec_def14a'
+  AND dfi.last_known_filing_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM sec_filing_manifest m
+      WHERE m.accession_number = dfi.last_known_filing_id
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM sec_filing_manifest m2
+      WHERE m2.source = 'sec_def14a'
+        AND m2.subject_type = dfi.subject_type
+        AND m2.subject_id = dfi.subject_id
+  );
+
+COMMIT;

--- a/tests/test_manifest_parser_def14a.py
+++ b/tests/test_manifest_parser_def14a.py
@@ -402,11 +402,12 @@ def test_parse_phase_exception_preserves_stored_raw_status(
 def test_pre_14a_tombstones_to_match_legacy(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
 ) -> None:
-    """PRE 14A (preliminary proxy) routes to sec_def14a in the
-    manifest but the legacy ingester excludes it. The parser
-    tombstones PRE 14A to keep dual-path accounting consistent
-    during cutover — no body fetch, no holdings write. (Codex
-    pre-push P1.)"""
+    """PRE 14A (preliminary proxy) is no longer mapped to sec_def14a
+    at discovery (#1320 removed the `_FORM_TO_SOURCE` entry). This
+    test seeds a PRE 14A manifest row directly to verify the parser's
+    PRE-14A tombstone branch remains as defense-in-depth: any PRE row
+    that reaches the worker via a legacy/manual seed is tombstoned
+    pre-fetch — no body fetch, no holdings write. (Codex pre-push P1.)"""
     import app.services.manifest_parsers  # noqa: F401 — register
 
     iid = 8740006

--- a/tests/test_migration_182_pre14a_purge.py
+++ b/tests/test_migration_182_pre14a_purge.py
@@ -76,9 +76,18 @@ def _seed_pre_migration_state(conn: psycopg.Connection[tuple]) -> None:
     conn.commit()
 
 
+# Strip the migration's own BEGIN;/COMMIT; wrapper before inline execution:
+# the test drives transaction control via the ebull_test_conn fixture, so an
+# embedded COMMIT inside the executed string would commit out from under it and
+# leave the trailing conn.commit() flushing an empty implicit transaction
+# (behaviour then depends on the fixture's autocommit mode). Run the migration
+# body inside the fixture's transaction and let the test commit once.
+_MIGRATION_BODY = "\n".join(line for line in _MIGRATION_SQL.splitlines() if line.strip() not in ("BEGIN;", "COMMIT;"))
+
+
 def _run_migration(conn: psycopg.Connection[tuple]) -> None:
     with psycopg.ClientCursor(conn) as cur:
-        cur.execute(_MIGRATION_SQL)  # type: ignore[call-overload]
+        cur.execute(_MIGRATION_BODY)  # type: ignore[call-overload]
     conn.commit()
 
 

--- a/tests/test_migration_182_pre14a_purge.py
+++ b/tests/test_migration_182_pre14a_purge.py
@@ -1,0 +1,154 @@
+"""Behaviour test for migration 182 — #1320 PRE 14A purge + freshness repair.
+
+Seeds the exact pre-migration pollution (PRE 14A manifest rows that advanced
+`data_freshness_index.last_known_*`), runs the migration SQL inline, asserts:
+  - PRE 14A manifest rows are deleted.
+  - A subject with a real DEF 14A has its freshness pointer recomputed to the
+    DEF accession (dangling PRE pointer repaired).
+  - A PRE-only subject has its freshness pointer cleared to NULL / 'unknown'.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from app.services.sec_manifest import record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+_MIGRATION_SQL = (Path(__file__).resolve().parents[1] / "sql" / "182_purge_pre14a_manifest_rows.sql").read_text()
+
+_IID_BOTH = 8_820_001  # subject with both DEF 14A and a (newer) PRE 14A
+_IID_PRE_ONLY = 8_820_002  # subject with only a PRE 14A
+
+_DEF_ACC = "0000820001-26-000001"
+_PRE_ACC_BOTH = "0000820001-26-000002"
+_PRE_ACC_ONLY = "0000820002-26-000001"
+
+_DEF_FILED = datetime(2026, 1, 15, tzinfo=UTC)
+_PRE_FILED = datetime(2026, 5, 1, tzinfo=UTC)  # newer than DEF → advances freshness
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_manifest(
+    conn: psycopg.Connection[tuple], *, accession: str, iid: int, cik: str, form: str, filed_at: datetime
+) -> None:
+    # record_manifest_entry seeds data_freshness_index inline (latest-row
+    # semantics), so a newer PRE 14A advances last_known_* to the draft —
+    # exactly the production pollution #1320 fixes.
+    record_manifest_entry(
+        conn,
+        accession,
+        cik=cik,
+        form=form,
+        source="sec_def14a",
+        subject_type="issuer",
+        subject_id=cik,
+        instrument_id=iid,
+        filed_at=filed_at,
+        primary_document_url=f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{accession.replace('-', '')}/d.htm",
+    )
+
+
+def _seed_pre_migration_state(conn: psycopg.Connection[tuple]) -> None:
+    _seed_instrument(conn, _IID_BOTH, "BOTH")
+    _seed_instrument(conn, _IID_PRE_ONLY, "PREO")
+    _seed_manifest(conn, accession=_DEF_ACC, iid=_IID_BOTH, cik="0000820001", form="DEF 14A", filed_at=_DEF_FILED)
+    _seed_manifest(conn, accession=_PRE_ACC_BOTH, iid=_IID_BOTH, cik="0000820001", form="PRE 14A", filed_at=_PRE_FILED)
+    _seed_manifest(
+        conn, accession=_PRE_ACC_ONLY, iid=_IID_PRE_ONLY, cik="0000820002", form="PRE 14A", filed_at=_PRE_FILED
+    )
+    conn.commit()
+
+
+def _run_migration(conn: psycopg.Connection[tuple]) -> None:
+    with psycopg.ClientCursor(conn) as cur:
+        cur.execute(_MIGRATION_SQL)  # type: ignore[call-overload]
+    conn.commit()
+
+
+def test_pre_migration_state_has_pre_polluted_freshness(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Sanity: before the migration, both subjects' freshness pointer aims at
+    the PRE 14A draft (newest filed_at)."""
+    conn = ebull_test_conn
+    _seed_pre_migration_state(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT subject_id, last_known_filing_id FROM data_freshness_index "
+            "WHERE source='sec_def14a' ORDER BY subject_id"
+        )
+        rows = dict(cur.fetchall())
+    assert rows["0000820001"] == _PRE_ACC_BOTH
+    assert rows["0000820002"] == _PRE_ACC_ONLY
+
+
+def test_migration_182_deletes_pre_manifest_rows(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_pre_migration_state(conn)
+    _run_migration(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM sec_filing_manifest WHERE source='sec_def14a' AND TRIM(form)='PRE 14A'")
+        result = cur.fetchone()
+    assert result is not None and result[0] == 0
+
+
+def test_migration_182_recomputes_freshness_for_subject_with_def(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Subject with a real DEF 14A: dangling PRE pointer is recomputed back to
+    the DEF accession + its filed_at + expected_next_at = filed_at + 365d."""
+    conn = ebull_test_conn
+    _seed_pre_migration_state(conn)
+    _run_migration(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_known_filing_id, last_known_filed_at, expected_next_at, state "
+            "FROM data_freshness_index WHERE source='sec_def14a' AND subject_id='0000820001'"
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == _DEF_ACC
+    assert row[1] == _DEF_FILED
+    assert row[2] == _DEF_FILED.replace(year=2027)  # +365d (non-leap 2026)
+    assert row[3] == "current"
+
+
+def test_migration_182_clears_freshness_for_pre_only_subject(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """PRE-only subject: pointer aimed solely at a draft → cleared to NULL /
+    'unknown' so it drops out of the MAX() watermark, row kept (still watched)."""
+    conn = ebull_test_conn
+    _seed_pre_migration_state(conn)
+    _run_migration(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_known_filing_id, last_known_filed_at, expected_next_at, state, state_reason "
+            "FROM data_freshness_index WHERE source='sec_def14a' AND subject_id='0000820002'"
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] is None
+    assert row[1] is None
+    assert row[2] is None
+    assert row[3] == "unknown"
+    assert row[4] == "pre14a_pointer_cleared_1320"

--- a/tests/test_sec_manifest.py
+++ b/tests/test_sec_manifest.py
@@ -672,6 +672,16 @@ class TestFormMapping:
         assert map_form_to_source("CORRESP") is None
         assert map_form_to_source("") is None
 
+    def test_pre_14a_is_not_mapped(self) -> None:
+        """#1320: PRE 14A (preliminary proxy) is a metadata-only draft — it
+        must NOT route to sec_def14a. Mapping it seeded 6k+ preliminary
+        drafts into the sec_def14a manifest namespace which the parser then
+        tombstoned pre-fetch (wasted worker cycles + polluted coverage). It
+        is now skipped at discovery, consistent with its metadata-only
+        classification (test_filings_form_allowlist). The definitive DEF 14A
+        that follows is what we ingest."""
+        assert map_form_to_source("PRE 14A") is None
+
     def test_whitespace_tolerant(self) -> None:
         assert map_form_to_source("13F-HR  ") == "sec_13f_hr"
         assert map_form_to_source("  4  ") == "sec_form4"


### PR DESCRIPTION
PRE 14A (preliminary proxy) is a metadata-only draft whose ownership figures were never counted — the definitive DEF 14A that follows is what we ingest.

## What
`app/services/sec_manifest._FORM_TO_SOURCE` mapped `PRE 14A -> sec_def14a`, seeding 6,051 drafts into the sec_def14a manifest namespace. The parser already tombstones PRE 14A **pre-fetch** (no HTTP / no holdings / no observations), so the output-table acceptance criterion was already met — but:
- the rows cost manifest-worker cycles + polluted `WHERE source='sec_def14a'` coverage reads;
- `seed_freshness_for_manifest_row` advances `data_freshness_index.last_known_*` by `max(filed_at)` over **every** seeded row including PRE, so a PRE draft filed after the latest real DEF left the subject's freshness pointer aimed at a draft — inflating the operator watermark (`watermarks.py` reports `MAX(last_known_filed_at)` per source).

## Fix
- **Remove the `PRE 14A` entry** from `_FORM_TO_SOURCE` → discovery skips it (`map_form_to_source(PRE 14A) is None`), consistent with its metadata-only classification (`test_filings_form_allowlist`). Strictly better than seed-then-tombstone. The parser PRE-14A tombstone branch stays as **defense-in-depth** for any PRE row reaching the worker via a legacy/manual seed.
- **`sql/182`** — purge the mis-seeded PRE manifest rows; **recompute** dangling freshness pointers from the latest remaining sec_def14a manifest row (cadence 365d, matching `cadence_for(sec_def14a)`); **clear** PRE-only-subject pointers to `NULL`/`state=unknown` so they drop out of `MAX()` (row kept = still watched). Both freshness predicates restrict to **dangling** pointers — a `NULL` or still-resolving pointer is never touched (no over-reach).

## Security / correctness model
Pure data-namespace + freshness-watermark correctness. No ingest path is loosened: PRE was already non-counted (parser tombstone + legacy `_DEF14A_FORM_TYPES` excludes it). The freshness repair only removes PRE-derived `last_known_*` values; it does not invent or advance any real-filing watermark.

## Test plan
- `tests/test_sec_manifest.py::TestFormMapping::test_pre_14a_is_not_mapped` — `map_form_to_source(PRE 14A) is None`.
- `tests/test_migration_182_pre14a_purge.py` (4 tests) — full migration behaviour on a faithful fixture seeded via the real `record_manifest_entry` freshness path: PRE manifest deleted; DEF-subject freshness recomputed to the DEF accession + `filed_at + 365d`; PRE-only subject cleared to `NULL`/`unknown`/reason.
- `tests/test_manifest_parser_def14a.py::test_pre_14a_tombstones_to_match_legacy` — parser defense-in-depth still tombstones a directly-seeded PRE row.
- `ruff check` / `ruff format --check` / `pyright` / 20 related tests green.
- Empirical (dev DB, read-only): 6,051 PRE rows under sec_def14a; 32 freshness rows point at a PRE accession (29 recompute, 3 clear); dry-run predicate counts match the migration steps.
- Codex checkpoint-2 (2 rounds): caught the freshness-orphan watermark pollution; final pass No findings.

## DoD note
The 6,051 live dev-DB rows could **not** be purged this session — the live jobs/manifest worker holds row locks on `sec_filing_manifest` (`LockNotAvailable`). `sql/182` applies cleanly at the next jobs-process boot (no worker contention), per the operator runbook. The code change stops all future PRE seeding immediately.

Closes #1320. Refs #1233.