### PR TITLE
fix(#1302): capture 13F INFOTABLE FIGI into external_identifiers (it's FIGI, not LEI)

### DIFF
--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -349,9 +349,14 @@ Archive-URL CIK varies by form type:
 - **Form 4 / Form 3 / Form 5** — `/Archives/edgar/data/{ISSUER_CIK}/{acc_no_dashes}/...`. Insider Form 4 filings for AAPL are submitted by various filer-agent CIKs but stored under Apple's CIK 0000320193.
 - **13F-HR / 13G/D / N-PORT-P** — `/Archives/edgar/data/{FILER_CIK}/{acc_no_dashes}/...`. The filing-manager / blockholder / fund-trust IS the filer; there is no separate "issuer" in those forms. eBull's 13F builder uses the filer CIK at [app/services/sec_13f_dataset_ingest.py:334](../../../app/services/sec_13f_dataset_ingest.py#L334).
 
-### 3.4 LEI (Legal Entity Identifier)
+### 3.4 LEI (Legal Entity Identifier) + FIGI
 
-20-character alphanumeric ISO 17442 code. Required on N-PORT, N-CSR, N-MFP, certain swap reports, and (since 2023-01-03) on Form 13F. Resolve via GLEIF API: `https://api.gleif.org/api/v1/lei-records/{lei}`.
+**LEI** — 20-character alphanumeric ISO 17442 code. Present in the **N-PORT** dataset INFOTABLE (`lei`, the issuer of the held security). Resolve via GLEIF API: `https://api.gleif.org/api/v1/lei-records/{lei}`.
+
+**Form 13F has NO LEI** (empirically verified 2026-06-04 against the published `*_form13f.zip` headers — #1302). What the **13F structured dataset** gained on 2023-01-03, alongside the VALUE $thousands→$dollars cutover, is a **`FIGI`** column in `INFOTABLE.tsv`, NOT an LEI. The full post-2023 INFOTABLE header is:
+`ACCESSION_NUMBER, INFOTABLE_SK, NAMEOFISSUER, TITLEOFCLASS, CUSIP, FIGI, VALUE, SSHPRNAMT, SSHPRNAMTTYPE, PUTCALL, INVESTMENTDISCRETION, OTHERMANAGER, VOTING_AUTH_SOLE, VOTING_AUTH_SHARED, VOTING_AUTH_NONE`. No LEI appears in any 13F dataset file (COVERPAGE/SUBMISSION/SUMMARYPAGE/SIGNATURE/OTHERMANAGER checked).
+
+**FIGI** — 12-character uppercase-alphanumeric OpenFIGI/Bloomberg global security identifier (e.g. `BBG000B9XRY4`), per-security (per CUSIP). `sec_13f_dataset_ingest._persist_figi_external_identifiers` (#1302) captures distinct `FIGI → instrument` into `external_identifiers (provider='sec', identifier_type='figi')` at instrument grain. It is the OpenFIGI bridge key (settled-decision: OpenFIGI is the approved CUSIP-resolution fallback).
 
 ### 3.5 Series ID / Class ID — fund hierarchy
 

--- a/.claude/skills/engineering/python-hygiene.md
+++ b/.claude/skills/engineering/python-hygiene.md
@@ -152,3 +152,18 @@ fees = raw.get("Fees") if raw.get("Fees") is not None else raw.get("fees")
 
 For string fields (order ref, status label), `or`-chaining is fine because empty strings are invalid.
 For numeric fields (price, units, fees), use explicit `is not None` checks.
+
+## psycopg3 `executemany` rowcount IS cumulative (verified)
+
+`cursor.rowcount` after a **non-returning** `executemany(...)` reflects the **sum** of affected rows across the whole batch in psycopg 3.3.3 — NOT the last statement only. Empirically verified (2026-06-04):
+
+```python
+cur.executemany("INSERT ... ON CONFLICT DO NOTHING", [3 distinct rows])  # cur.rowcount == 3
+cur.executemany("INSERT ... ON CONFLICT DO NOTHING", [1 conflict, 1 new]) # cur.rowcount == 1
+```
+
+So using `cur.rowcount` as a batch insert/affected total after `executemany` is correct for this driver. Two caveats:
+- It is **driver/version-specific** (DB-API leaves it implementation-defined; some drivers/older psycopg return -1 or the last count). When the total matters across a version bump, **pin it with a regression test** that inserts N distinct rows and asserts the count == N (e.g. `tests/test_sec_13f_dataset_ingest.py::...test_multiple_distinct_figis_counted_cumulatively`), rather than trusting the doc.
+- It does NOT hold for `executemany(..., returning=True)` — that path iterates result sets differently.
+
+Origin: PR #1468 (#1302) review WARNING claimed the FIGI counter "will be at most 1"; rebutted by empirical probe + the pinned regression test.

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import re
 import zipfile
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -86,7 +87,59 @@ class Form13FIngestResult:
     rows_skipped_retention: int = 0  # PR6 #1233 §4.5
     parse_errors: int = 0
     resolved_markers_deleted: int = 0  # #1399 — inline-deleted bulk markers
+    figi_identifiers_seen: int = 0  # #1302 — distinct FIGIs collected this archive
+    figi_identifiers_written: int = 0  # #1302 — newly inserted external_identifiers rows
     touched_instrument_ids: set[int] = field(default_factory=set)
+
+
+# #1302 — the 13F INFOTABLE gained a ``FIGI`` column on 2023-01-03 (NOT
+# ``LEI`` — empirically verified against the published dataset header; there
+# is no LEI anywhere in the 13F structured data). FIGI is the 12-char
+# OpenFIGI/Bloomberg global security identifier; ISO/BBG form is uppercase
+# alphanumeric exactly 12 long. Reject anything else (empty / malformed) so
+# only clean values reach external_identifiers.
+_FIGI_RE = re.compile(r"^[A-Z0-9]{12}$")
+
+
+# Persist the distinct CUSIP-derived FIGI -> instrument mappings at INSTRUMENT
+# grain (NOT per holding-row): FIGI identifies the security, so storing it
+# per (filer, period) observation would denormalise the same value across
+# millions of rows of an already-bloated partitioned table (#1219/#1349). The
+# settled-decisions home for a provider-native security identifier is
+# ``external_identifiers``. Bounded by distinct securities held in the archive
+# (~thousands). ``DO NOTHING`` never clobbers a curated/prior mapping; a FIGI
+# already bound to a DIFFERENT instrument is a data anomaly left for audit,
+# not silently rebound. The ON CONFLICT predicate targets the non-CIK partial
+# unique index ``uq_external_identifiers_provider_value_non_cik`` (#1102).
+_FIGI_UPSERT_SQL = """
+INSERT INTO external_identifiers (
+    instrument_id, provider, identifier_type, identifier_value, is_primary
+) VALUES (%(iid)s, 'sec', 'figi', %(figi)s, FALSE)
+ON CONFLICT (provider, identifier_type, identifier_value)
+    WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+DO NOTHING
+"""
+
+
+def _persist_figi_external_identifiers(
+    conn: psycopg.Connection[Any],
+    figi_to_instrument: dict[str, int],
+    *,
+    result: Form13FIngestResult,
+) -> None:
+    """Batch-upsert collected FIGI -> instrument mappings (#1302).
+
+    Idempotent + clobber-safe (DO NOTHING). Runs in the caller's per-archive
+    transaction so it commits/rolls back atomically with the holdings drain.
+    """
+    if not figi_to_instrument:
+        return
+    result.figi_identifiers_seen += len(figi_to_instrument)
+    params = [{"iid": iid, "figi": figi} for figi, iid in figi_to_instrument.items()]
+    with conn.cursor() as cur:
+        cur.executemany(_FIGI_UPSERT_SQL, params)
+        if cur.rowcount and cur.rowcount > 0:
+            result.figi_identifiers_written += cur.rowcount
 
 
 def _load_cusip_map(conn: psycopg.Connection[Any]) -> dict[str, int]:
@@ -600,6 +653,10 @@ def ingest_13f_dataset_archive(
     # row must not delete a marker for an obs that never landed).
     materialised_markers: set[tuple[str, str, date, int]] = set()
 
+    # #1302 — distinct FIGI -> instrument mappings collected across the
+    # archive; batch-upserted into external_identifiers after the drain.
+    figi_to_instrument: dict[str, int] = {}
+
     with zipfile.ZipFile(archive_path) as zf:
         submissions = _open_tsv(zf, "SUBMISSION.tsv")
         coverpages = _open_tsv(zf, "COVERPAGE.tsv")
@@ -666,6 +723,15 @@ def ingest_13f_dataset_archive(
                     # above, so the bulk-path index always has a period.
                     unresolved_buffer.append((cusip, filer_cik, period_end))
                     continue
+
+                # #1302 — capture the security's FIGI (12-char OpenFIGI id,
+                # new INFOTABLE column 2023-01-03) against the instrument it
+                # resolved to. Collected before the share/retention gates
+                # below: the FIGI<->instrument identity holds regardless of
+                # whether THIS holding row is a valid current position.
+                figi = (row.get("FIGI") or "").strip().upper()
+                if figi and _FIGI_RE.match(figi):
+                    figi_to_instrument.setdefault(figi, instrument_id)
 
                 filer_name = (cover.get("FILINGMANAGER_NAME") or "").strip()
                 if not filer_name:
@@ -809,6 +875,11 @@ def ingest_13f_dataset_archive(
             # Driver couldn't tag the result. Fall back to staged
             # count so the count is a lower bound rather than 0.
             result.rows_written = accepted_via_copy
+
+    # #1302 — persist the archive's distinct FIGI -> instrument mappings.
+    # Same per-archive transaction as the drain, so it commits/rolls back
+    # atomically with the holdings.
+    _persist_figi_external_identifiers(conn, figi_to_instrument, result=result)
 
     # #1399 — delete bulk markers a prior run recorded for CUSIPs that
     # resolved this run. Reconcile against _stg_13f FIRST: only the

--- a/tests/test_sec_13f_dataset_ingest.py
+++ b/tests/test_sec_13f_dataset_ingest.py
@@ -12,12 +12,14 @@ import psycopg
 import pytest
 
 from app.services.sec_13f_dataset_ingest import (
+    _FIGI_RE,
     Form13FIngestResult,
     _map_putcall,
     _map_voting_authority,
     _parse_decimal,
     _parse_filing_date,
     _parse_period_end,
+    _persist_figi_external_identifiers,
     ingest_13f_dataset_archive,
 )
 from tests.fixtures.ebull_test_db import ebull_test_conn
@@ -547,3 +549,156 @@ class TestRealArchiveEdgeCases:
             mv = row[0]
         # 5,000,000 thousands = 5B USD (pre-2023 multiplier applied).
         assert mv == Decimal("5000000000.00")
+
+
+# ---------------------------------------------------------------------------
+# #1302 — FIGI capture (the 13F INFOTABLE column added 2023-01-03; NOT LEI)
+# ---------------------------------------------------------------------------
+
+
+class TestFigiRegex:
+    def test_accepts_valid_12char_figi(self) -> None:
+        assert _FIGI_RE.match("BBG000B9XRY4")
+
+    def test_rejects_wrong_length(self) -> None:
+        assert _FIGI_RE.match("BBG000B9XRY") is None  # 11
+        assert _FIGI_RE.match("BBG000B9XRY44") is None  # 13
+
+    def test_rejects_lowercase_and_symbols(self) -> None:
+        assert _FIGI_RE.match("bbg000b9xry4") is None
+        assert _FIGI_RE.match("BBG000B9-RY4") is None
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestPersistFigiExternalIdentifiers:
+    def _seed_iid(self, conn: psycopg.Connection[tuple], symbol: str, cusip: str) -> int:
+        return _seed_universe_with_cusip(conn, symbol=symbol, cusip=cusip)
+
+    def test_inserts_new_figi_mapping(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = self._seed_iid(ebull_test_conn, "FOO", "111111111")
+        result = Form13FIngestResult()
+        _persist_figi_external_identifiers(ebull_test_conn, {"BBG000B9XRY4": iid}, result=result)
+        ebull_test_conn.commit()
+        assert result.figi_identifiers_seen == 1
+        assert result.figi_identifiers_written == 1
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT instrument_id, is_primary FROM external_identifiers "
+                "WHERE provider='sec' AND identifier_type='figi' AND identifier_value='BBG000B9XRY4'"
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == iid
+        assert row[1] is False  # never claims primary
+
+    def test_do_nothing_on_existing_figi(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A FIGI already mapped (even to a DIFFERENT instrument) is never
+        clobbered — DO NOTHING preserves the existing row."""
+        iid_a = self._seed_iid(ebull_test_conn, "AAA", "222222222")
+        iid_b = self._seed_iid(ebull_test_conn, "BBB", "333333333")
+        r1 = Form13FIngestResult()
+        _persist_figi_external_identifiers(ebull_test_conn, {"BBG00000FIG1": iid_a}, result=r1)
+        ebull_test_conn.commit()
+        # Second persist with the same FIGI pointed at a different instrument.
+        r2 = Form13FIngestResult()
+        _persist_figi_external_identifiers(ebull_test_conn, {"BBG00000FIG1": iid_b}, result=r2)
+        ebull_test_conn.commit()
+        assert r2.figi_identifiers_written == 0
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT instrument_id FROM external_identifiers "
+                "WHERE provider='sec' AND identifier_type='figi' AND identifier_value='BBG00000FIG1'"
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == iid_a  # original mapping preserved
+
+    def test_empty_mapping_is_noop(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        result = Form13FIngestResult()
+        _persist_figi_external_identifiers(ebull_test_conn, {}, result=result)
+        assert result.figi_identifiers_seen == 0
+        assert result.figi_identifiers_written == 0
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestIngest13FFigiCapture:
+    def test_figi_column_captured_during_archive_ingest(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        iid = _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        archive_bytes = _build_dataset_zip(
+            submissions=[{"ACCESSION_NUMBER": "0001234567-25-000001", "CIK": "1234567", "FILING_DATE": "2025-11-14"}],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILINGMANAGER_NAME": "Big Fund LLC",
+                    "REPORTCALENDARORQUARTER": "2025-09-30",
+                }
+            ],
+            infotable=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CUSIP": "037833100",
+                    "FIGI": "BBG000B9XRY4",
+                    "VALUE": "5000000",
+                    "SSHPRNAMT": "100000",
+                    "PUTCALL": "",
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_13f_dataset_archive(conn=ebull_test_conn, archive_path=archive_path, ingest_run_id=uuid4())
+        ebull_test_conn.commit()
+
+        assert result.figi_identifiers_seen == 1
+        assert result.figi_identifiers_written == 1
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT instrument_id FROM external_identifiers "
+                "WHERE provider='sec' AND identifier_type='figi' AND identifier_value='BBG000B9XRY4'"
+            )
+            row = cur.fetchone()
+        assert row is not None and row[0] == iid
+
+    def test_malformed_or_missing_figi_not_captured(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+    ) -> None:
+        _seed_universe_with_cusip(ebull_test_conn, symbol="AAPL", cusip="037833100")
+        archive_bytes = _build_dataset_zip(
+            submissions=[{"ACCESSION_NUMBER": "0001234567-25-000001", "CIK": "1234567", "FILING_DATE": "2025-11-14"}],
+            coverpages=[
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "FILINGMANAGER_NAME": "Big Fund LLC",
+                    "REPORTCALENDARORQUARTER": "2025-09-30",
+                }
+            ],
+            infotable=[
+                # Pre-2023 row shape (no FIGI column) + a malformed FIGI row.
+                {"ACCESSION_NUMBER": "0001234567-25-000001", "CUSIP": "037833100", "VALUE": "100", "SSHPRNAMT": "10"},
+                {
+                    "ACCESSION_NUMBER": "0001234567-25-000001",
+                    "CUSIP": "037833100",
+                    "FIGI": "NOTAFIGI",  # wrong length → rejected
+                    "VALUE": "200",
+                    "SSHPRNAMT": "20",
+                    "PUTCALL": "Put",
+                },
+            ],
+        )
+        archive_path = tmp_path / "form13f.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_13f_dataset_archive(conn=ebull_test_conn, archive_path=archive_path, ingest_run_id=uuid4())
+        ebull_test_conn.commit()
+
+        assert result.figi_identifiers_seen == 0
+        assert result.figi_identifiers_written == 0

--- a/tests/test_sec_13f_dataset_ingest.py
+++ b/tests/test_sec_13f_dataset_ingest.py
@@ -592,6 +592,29 @@ class TestPersistFigiExternalIdentifiers:
         assert row[0] == iid
         assert row[1] is False  # never claims primary
 
+    def test_multiple_distinct_figis_counted_cumulatively(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """``figi_identifiers_written`` is the CUMULATIVE insert count across
+        the whole ``executemany`` batch, not the last statement's rowcount.
+
+        Empirically verified: psycopg 3.3.3 accumulates ``cur.rowcount`` over a
+        non-returning ``executemany`` (3 distinct ON CONFLICT DO NOTHING
+        inserts → rowcount 3; 1 conflict + 1 new → rowcount 1). This test pins
+        that invariant so a driver-version bump that changes the semantic is
+        caught here (rebuts the review WARNING claiming it reflects only the
+        last statement)."""
+        a = self._seed_iid(ebull_test_conn, "MUL1", "444444444")
+        b = self._seed_iid(ebull_test_conn, "MUL2", "555555555")
+        c = self._seed_iid(ebull_test_conn, "MUL3", "666666666")
+        result = Form13FIngestResult()
+        _persist_figi_external_identifiers(
+            ebull_test_conn,
+            {"BBG00000MUL1": a, "BBG00000MUL2": b, "BBG00000MUL3": c},
+            result=result,
+        )
+        ebull_test_conn.commit()
+        assert result.figi_identifiers_seen == 3
+        assert result.figi_identifiers_written == 3  # cumulative, not 1
+
     def test_do_nothing_on_existing_figi(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """A FIGI already mapped (even to a DIFFERENT instrument) is never
         clobbered — DO NOTHING preserves the existing row."""


### PR DESCRIPTION
The 13F bulk dataset INFOTABLE silently dropped the identifier column added 2023-01-03. **Empirically verified: that column is `FIGI`, not `LEI`** — the issue (and skill §3.4) were factually wrong.

## Evidence
Downloaded the live `01dec2025-28feb2026_form13f.zip` (project SEC UA) and dumped headers:
- `INFOTABLE.tsv`: `ACCESSION_NUMBER, INFOTABLE_SK, NAMEOFISSUER, TITLEOFCLASS, CUSIP, **FIGI**, VALUE, SSHPRNAMT, SSHPRNAMTTYPE, PUTCALL, INVESTMENTDISCRETION, OTHERMANAGER, VOTING_AUTH_SOLE/SHARED/NONE`.
- **No LEI** in any 13F file (COVERPAGE/SUBMISSION/SUMMARYPAGE/SIGNATURE/OTHERMANAGER all checked). LEI lives in the **N-PORT** dataset, not 13F.

So the genuine dropped column is FIGI (the 12-char OpenFIGI/Bloomberg global **security** identifier, per-CUSIP).

## What
`sec_13f_dataset_ingest` now collects distinct `FIGI → instrument` during the INFOTABLE stream and batch-upserts into `external_identifiers (provider=sec, identifier_type=figi)` at **instrument grain**.

- **Why external_identifiers, not a per-observation column:** FIGI identifies the security, so a per-`(filer, period)` observation column would denormalise the same value across millions of rows of an already-bloated partitioned table (#1219/#1349). `external_identifiers` is the settled-decisions home for provider-native security identifiers, and FIGI is the OpenFIGI bridge key (OpenFIGI = approved CUSIP-resolution fallback, settled 2026-05-22).
- **Bounded:** collection is keyed by distinct FIGI (~thousands of held securities/archive), not holding rows — no per-row write, COPY pipeline untouched (`_STG_COPY_COLUMNS` unchanged).
- `_FIGI_RE` rejects empty/malformed (only clean 12-char uppercase alnum).
- `ON CONFLICT DO NOTHING` on `uq_external_identifiers_provider_value_non_cik` (#1102 predicate) never clobbers a curated/prior mapping; a FIGI already bound to a different instrument is left for audit. `is_primary=FALSE`. Runs in the per-archive transaction (atomic with the holdings drain).

## Security model
Read-only identifier capture; no execution/trade path. The non-CIK ON CONFLICT predicate is the #1102-mandated one. DO NOTHING means the curated mapping always wins — the ingest can never rebind a security identifier.

## Test plan
- `tests/test_sec_13f_dataset_ingest.py` 27 pass (8 new): `_FIGI_RE` accept/reject; `_persist_figi_external_identifiers` insert / DO-NOTHING-on-existing-(even-different-instrument) / empty no-op; full archive ingest captures FIGI; malformed/missing FIGI not captured.
- `ruff` / `pyright` / `check_bulk_ingest_copy_pattern.sh` green.
- **Real-data smoke:** sampled 200k rows of the live `01dec2025-28feb2026` archive — FIGI present (~29% fill; optional field), every populated value 12-char `BBG…` matching `_FIGI_RE`.
- Codex checkpoint-2: No findings (predicate matches the schema index exactly; perf bounded; executemany rowcount semantics correct; atomic with drain).
- Skill `data-sources/sec-edgar.md §3.4` corrected (LEI-on-13F claim was false; documents the real FIGI column + full header).

## DoD note
`sec_rebuild` backfill of historical archives is operator-deferred (live-worker lock contention on dev DB, same constraint as #1320). Capture is live for the next quarterly bulk ingest immediately. No operator-visible endpoint (FIGI is a bridge identifier, not a displayed figure).

Closes #1302. Refs #1233, #1102.