### PR TITLE
fix(#1303): schedule the orphaned N-CEN filer classifier (annual)

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -61,6 +61,7 @@ from app.services.ops_monitor import (
 )
 from app.workers.scheduler import (
     SCHEDULED_JOBS,
+    CadenceKind,
     ScheduledJob,
     compute_next_run,
 )
@@ -165,7 +166,10 @@ class JobOverviewResponse(BaseModel):
     display_name: str | None
     description: str
     cadence: str
-    cadence_kind: Literal["every_n_minutes", "hourly", "daily", "weekly", "monthly"]
+    # Reuse the scheduler's CadenceKind so a new cadence kind (e.g. 'yearly',
+    # #1303) can never drift this DTO out of sync — adding a kind there is a
+    # one-place change, not a hunt for every mirrored Literal.
+    cadence_kind: CadenceKind
     next_run_time: datetime
     # `next_run_time_source` retained for frontend compat; always
     # "declared" since #719 — the API no longer hosts APScheduler so

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -83,6 +83,7 @@ from app.workers.scheduler import (
     JOB_MONITOR_POSITIONS,
     JOB_MONTHLY_REPORT,
     JOB_MORNING_CANDIDATE_REVIEW,
+    JOB_NCEN_CLASSIFIER,
     JOB_NIGHTLY_UNIVERSE_SYNC,
     JOB_ORCHESTRATOR_FULL_SYNC,
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
@@ -129,6 +130,7 @@ from app.workers.scheduler import (
     monitor_positions_job,
     monthly_report,
     morning_candidate_review,
+    ncen_classifier_yearly,
     nightly_universe_sync,
     orchestrator_full_sync,
     orchestrator_high_frequency_sync,
@@ -250,6 +252,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # ``min_period_of_report`` + ``source_label`` via StageSpec.params.
     JOB_SEC_13F_QUARTERLY_SWEEP: sec_13f_quarterly_sweep,
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC: _adapt_zero_arg(sec_nport_filer_directory_sync),
+    JOB_NCEN_CLASSIFIER: _adapt_zero_arg(ncen_classifier_yearly),
     # PR7 #1233 §4.6 — sec_n_port_ingest migrated to native JobInvoker
     # (params-aware). Bootstrap stage 22 passes ``min_last_seen_filed_at``
     # via StageSpec.params; daily / Admin path dispatches with an empty
@@ -842,6 +845,14 @@ def _trigger_for(cadence: Cadence) -> CronTrigger:
         )
     if cadence.kind == "monthly":
         return CronTrigger(
+            day=cadence.day,
+            hour=cadence.hour,
+            minute=cadence.minute,
+            timezone="UTC",
+        )
+    if cadence.kind == "yearly":
+        return CronTrigger(
+            month=cadence.month,
             day=cadence.day,
             hour=cadence.hour,
             minute=cadence.minute,

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -101,6 +101,7 @@ _LANE_BY_JOB: dict[str, ProcessLane] = {
     "sec_13f_quarterly_sweep": "ownership",
     "sec_nport_filer_directory_sync": "ownership",
     "sec_n_port_ingest": "ownership",
+    "ncen_classifier_yearly": "ownership",
     # Fundamentals
     "fundamentals_sync": "fundamentals",
     "sec_business_summary_bootstrap": "fundamentals",
@@ -152,6 +153,8 @@ def _cron_for(cadence: Cadence) -> str:
         return f"{cadence.minute} {cadence.hour} * * {cron_dow}"
     if cadence.kind == "monthly":
         return f"{cadence.minute} {cadence.hour} {cadence.day} * *"
+    if cadence.kind == "yearly":
+        return f"{cadence.minute} {cadence.hour} {cadence.day} {cadence.month} *"
     # Cadence.kind is a Literal — every value is enumerated above. The
     # fallthrough is a safety net for a future-added kind that forgets
     # to extend this function.

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -106,7 +106,7 @@ logger = logging.getLogger(__name__)
 # next-fire-time from APScheduler; ``compute_next_run`` is retained as
 # a pure utility for catch-up-on-boot and tests.
 
-CadenceKind = Literal["every_n_minutes", "hourly", "daily", "weekly", "monthly"]
+CadenceKind = Literal["every_n_minutes", "hourly", "daily", "weekly", "monthly", "yearly"]
 
 
 @dataclass(frozen=True)
@@ -122,7 +122,8 @@ class Cadence:
     minute: int = 0
     hour: int = 0
     weekday: int = 0  # 0=Mon (matches datetime.weekday())
-    day: int = 0  # 1..28 for monthly cadence
+    day: int = 0  # 1..28 for monthly + yearly cadence
+    month: int = 0  # 1..12 for yearly cadence
     interval_minutes: int = 0  # every_n_minutes cadence (e.g. 5 for every 5 min)
 
     @classmethod
@@ -169,6 +170,21 @@ class Cadence:
             raise ValueError(f"monthly minute must be 0..59, got {minute}")
         return cls(kind="monthly", day=day, hour=hour, minute=minute)
 
+    @classmethod
+    def yearly(cls, *, month: int, day: int, hour: int, minute: int = 0) -> Cadence:
+        """Annual cadence — fires once a year on ``month``/``day`` at
+        ``hour``:``minute`` UTC. ``day`` capped at 28 so the fire date
+        exists in every month (no Feb-29 / 30-vs-31 ambiguity)."""
+        if not 1 <= month <= 12:
+            raise ValueError(f"yearly month must be 1..12, got {month}")
+        if not 1 <= day <= 28:
+            raise ValueError(f"yearly day must be 1..28, got {day}")
+        if not 0 <= hour <= 23:
+            raise ValueError(f"yearly hour must be 0..23, got {hour}")
+        if not 0 <= minute <= 59:
+            raise ValueError(f"yearly minute must be 0..59, got {minute}")
+        return cls(kind="yearly", month=month, day=day, hour=hour, minute=minute)
+
     @property
     def label(self) -> str:
         """Human-readable label for API responses."""
@@ -181,6 +197,22 @@ class Cadence:
         if self.kind == "weekly":
             weekday_names = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
             return f"weekly on {weekday_names[self.weekday]} at {self.hour:02d}:{self.minute:02d} UTC"
+        if self.kind == "yearly":
+            month_names = [
+                "Jan",
+                "Feb",
+                "Mar",
+                "Apr",
+                "May",
+                "Jun",
+                "Jul",
+                "Aug",
+                "Sep",
+                "Oct",
+                "Nov",
+                "Dec",
+            ]
+            return f"yearly on {month_names[self.month - 1]} {self.day} at {self.hour:02d}:{self.minute:02d} UTC"
         # monthly
         return f"monthly on day {self.day} at {self.hour:02d}:{self.minute:02d} UTC"
 
@@ -295,6 +327,7 @@ JOB_SEC_13F_FILER_DIRECTORY_SYNC = "sec_13f_filer_directory_sync"
 JOB_SEC_13F_QUARTERLY_SWEEP = "sec_13f_quarterly_sweep"
 JOB_SEC_NPORT_FILER_DIRECTORY_SYNC = "sec_nport_filer_directory_sync"
 JOB_SEC_N_PORT_INGEST = "sec_n_port_ingest"
+JOB_NCEN_CLASSIFIER = "ncen_classifier_yearly"
 JOB_CUSIP_UNIVERSE_BACKFILL = "cusip_universe_backfill"
 JOB_EXCHANGES_METADATA_REFRESH = "exchanges_metadata_refresh"
 JOB_ETORO_LOOKUPS_REFRESH = "etoro_lookups_refresh"
@@ -1027,6 +1060,46 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # benefit from firing on every dev restart.
         catch_up_on_boot=False,
     ),
+    ScheduledJob(
+        name=JOB_NCEN_CLASSIFIER,
+        display_name="N-CEN filer classifier (annual)",
+        source="sec_rate",
+        description=(
+            "Annual sweep that classifies every active institutional filer "
+            "(broker-dealer / investment-manager / fund) from its latest "
+            "N-CEN census filing (#782), populating "
+            "``ncen_filer_classifications`` — the table "
+            "``ncen_classifier.compose_filer_type`` reads to resolve "
+            "``institutional_filers.filer_type`` (#1303). Walks active "
+            "``institutional_filer_seeds``; per filer fetches submissions.json "
+            "+ the latest N-CEN primary doc via the shared sec_rate budget "
+            "(10 req/s). Empty seeds = natural no-op. Without this schedule "
+            "the classification table only refreshed on an ad-hoc operator "
+            "trigger, so new filers stayed unclassified for a year+ (drift). "
+            "Cadence: yearly Apr 1 05:00 UTC — most N-CEN filings (75 days "
+            "after fiscal-year-end; Dec-FYE funds dominate) have landed by "
+            "end of Q1. Idempotent (latest-only UPSERT per CIK, #1245)."
+        ),
+        cadence=Cadence.yearly(month=4, day=1, hour=5, minute=0),
+        # Annual cadence: a missed Apr-1 fire cannot roll forward cheaply
+        # (a weekly job's missed window costs 7 days; this one costs a YEAR
+        # of classification drift). catch_up_on_boot=True re-fires only when
+        # genuinely overdue (last success > 1y ago, or never run) — after a
+        # successful run next_fire is ~12 months out so a routine restart
+        # does NOT re-trigger the heavy sweep.
+        #
+        # NOT exempt from the universal bootstrap gate, and it CANNOT be: the
+        # carve-out (#1181) requires bounded single-digit-MB cost, but this is
+        # a heavy per-filer SEC sweep. Consequence (the boot-time catch_up
+        # evaluation trap): if the jobs process boots mid-bootstrap, the
+        # catch-up is skipped with ``bootstrap_not_complete`` and does NOT
+        # auto-re-fire when bootstrap later flips complete — it waits for the
+        # next jobs-process restart (catch-up re-evaluates, now unblocked) or
+        # the next Apr 1. Acceptable for an annual classifier: compose_filer_type
+        # degrades to the 'INV' default until then, and the operator can
+        # manually trigger it post-bootstrap (it is in _INVOKERS).
+        catch_up_on_boot=True,
+    ),
     # `sec_n_port_ingest` retired from SCHEDULED_JOBS post-#1155:
     # Layer 1/2/3 + sec_manifest_worker + manifest_parsers/sec_n_port.py
     # (#1133) carry every NPORT-P write to ownership_funds_observations
@@ -1383,6 +1456,19 @@ def compute_next_run(cadence: Cadence, now: datetime) -> datetime:
         candidate += timedelta(days=days_ahead)
         if candidate <= now_utc:
             candidate += timedelta(days=7)
+        return candidate
+
+    if cadence.kind == "yearly":
+        candidate = now_utc.replace(
+            month=cadence.month,
+            day=cadence.day,
+            hour=cadence.hour,
+            minute=cadence.minute,
+            second=0,
+            microsecond=0,
+        )
+        if candidate <= now_utc:
+            candidate = candidate.replace(year=candidate.year + 1)
         return candidate
 
     # monthly
@@ -5636,6 +5722,42 @@ def sec_nport_filer_directory_sync() -> None:
             result.filers_inserted,
             result.filers_refreshed,
             result.skipped_empty_name,
+        )
+
+
+def ncen_classifier_yearly() -> None:
+    """Annual N-CEN filer-classification sweep (#1303).
+
+    Classifies every active institutional filer from its latest N-CEN
+    census filing into ``ncen_filer_classifications``, the table
+    :func:`app.services.ncen_classifier.compose_filer_type` reads to
+    resolve ``institutional_filers.filer_type``. Previously orphaned —
+    the classifier existed but had no ``ScheduledJob``, so the
+    classification table only refreshed on an ad-hoc operator trigger.
+
+    Empty filer-seed list = natural no-op (the classifier logs and
+    returns early), so this is safe to fire post-bootstrap on a
+    partially-populated directory.
+    """
+    from app.services.ncen_classifier import classify_filers_via_ncen
+
+    with _tracked_job(JOB_NCEN_CLASSIFIER) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            psycopg.connect(settings.database_url) as conn,
+        ):
+            report = classify_filers_via_ncen(conn, sec)
+
+        tracker.row_count = report.classifications_written
+        logger.info(
+            "ncen_classifier_yearly: filers_seen=%d classifications_written=%d "
+            "no_ncen_found=%d parse_failures=%d fetch_failures=%d crash_failures=%d",
+            report.filers_seen,
+            report.classifications_written,
+            report.no_ncen_found,
+            report.parse_failures,
+            report.fetch_failures,
+            report.crash_failures,
         )
 
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -55,6 +55,8 @@ export type CadenceKind =
   | "hourly"
   | "daily"
   | "weekly"
+  | "monthly"
+  | "yearly"
   | "every_n_minutes";
 
 export interface LayerHealthResponse {

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -494,6 +494,7 @@ class TestSystemJobs:
                 "daily",
                 "weekly",
                 "monthly",
+                "yearly",
             )
             assert job["next_run_time"]
             assert job["next_run_time_source"] == "declared"

--- a/tests/test_workers_scheduler_registry.py
+++ b/tests/test_workers_scheduler_registry.py
@@ -211,6 +211,19 @@ class TestCadenceValidators:
         # weekday=0 is Monday
         assert Cadence.weekly(weekday=0, hour=5).label == "weekly on Mon at 05:00 UTC"
 
+    @pytest.mark.parametrize("month", [0, 13])
+    def test_yearly_invalid_month_raises(self, month: int) -> None:
+        with pytest.raises(ValueError, match="yearly month"):
+            Cadence.yearly(month=month, day=1, hour=5)
+
+    @pytest.mark.parametrize("day", [0, 29])
+    def test_yearly_invalid_day_raises(self, day: int) -> None:
+        with pytest.raises(ValueError, match="yearly day"):
+            Cadence.yearly(month=4, day=day, hour=5)
+
+    def test_label_yearly(self) -> None:
+        assert Cadence.yearly(month=4, day=1, hour=5).label == "yearly on Apr 1 at 05:00 UTC"
+
 
 # ---------------------------------------------------------------------------
 # compute_next_run
@@ -288,3 +301,77 @@ class TestComputeNextRun:
         plus_one = _NOW.astimezone(tz=__import__("datetime").timezone(timedelta(hours=1)))
         result = compute_next_run(Cadence.daily(hour=18), plus_one)
         assert result == datetime(2026, 4, 7, 18, 0, 0, tzinfo=UTC)
+
+    # ---------- yearly (#1303) ----------
+
+    def test_yearly_this_year_already_passed_rolls_to_next_year(self) -> None:
+        # _NOW is 2026-04-07; Apr 1 has passed → 2027-04-01.
+        result = compute_next_run(Cadence.yearly(month=4, day=1, hour=5), _NOW)
+        assert result == datetime(2027, 4, 1, 5, 0, 0, tzinfo=UTC)
+
+    def test_yearly_later_this_year(self) -> None:
+        # _NOW is 2026-04-07; Jun 15 is still ahead this year.
+        result = compute_next_run(Cadence.yearly(month=6, day=15, hour=5), _NOW)
+        assert result == datetime(2026, 6, 15, 5, 0, 0, tzinfo=UTC)
+
+    def test_yearly_strictly_after_now_on_boundary(self) -> None:
+        on_boundary = datetime(2026, 4, 1, 5, 0, 0, tzinfo=UTC)
+        result = compute_next_run(Cadence.yearly(month=4, day=1, hour=5), on_boundary)
+        assert result == datetime(2027, 4, 1, 5, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# N-CEN classifier annual schedule (#1303)
+# ---------------------------------------------------------------------------
+
+
+class TestNcenClassifierSchedule:
+    def test_registered_in_scheduled_jobs(self) -> None:
+        names = {job.name for job in SCHEDULED_JOBS}
+        assert "ncen_classifier_yearly" in names
+
+    def test_cadence_yearly_apr_1_05_00(self) -> None:
+        job = next(j for j in SCHEDULED_JOBS if j.name == "ncen_classifier_yearly")
+        assert job.cadence.kind == "yearly"
+        assert job.cadence.month == 4
+        assert job.cadence.day == 1
+        assert job.cadence.hour == 5
+        assert job.cadence.minute == 0
+
+    def test_runs_on_sec_rate_lane(self) -> None:
+        job = next(j for j in SCHEDULED_JOBS if j.name == "ncen_classifier_yearly")
+        assert job.source == "sec_rate"
+
+    def test_catches_up_on_boot(self) -> None:
+        # Annual cadence: a missed Apr-1 fire costs a year of classification
+        # drift, so catch up when genuinely overdue (#1303).
+        job = next(j for j in SCHEDULED_JOBS if j.name == "ncen_classifier_yearly")
+        assert job.catch_up_on_boot is True
+
+    def test_not_exempt_from_bootstrap_gate(self) -> None:
+        # Heavy SEC sweep — must wait for bootstrap to complete.
+        job = next(j for j in SCHEDULED_JOBS if j.name == "ncen_classifier_yearly")
+        assert job.exempt_from_universal_bootstrap_gate is False
+
+    def test_invokable_via_invokers(self) -> None:
+        from app.jobs.runtime import _INVOKERS
+
+        assert "ncen_classifier_yearly" in _INVOKERS
+
+    def test_admin_process_lane_is_ownership(self) -> None:
+        # Classifies institutional filers → ownership domain, like the
+        # adjacent 13F/N-PORT filer jobs. Without the explicit mapping it
+        # would default to 'ops' (Codex #1303 review).
+        from app.services.processes.scheduled_adapter import _lane_for
+
+        assert _lane_for("ncen_classifier_yearly") == "ownership"
+
+    def test_trigger_for_yearly_sets_month(self) -> None:
+        from app.jobs.runtime import _trigger_for
+
+        trigger = _trigger_for(Cadence.yearly(month=4, day=1, hour=5))
+        # APScheduler CronTrigger stringifies its fields; month=4 + day=1 pin it.
+        rendered = str(trigger)
+        assert "month='4'" in rendered
+        assert "day='1'" in rendered
+        assert "hour='5'" in rendered


### PR DESCRIPTION
The N-CEN classifier (`compose_filer_type`s data source) existed but had **no `ScheduledJob`** — `classify_filers_via_ncen` had zero production callers. So `ncen_filer_classifications` only refreshed on an ad-hoc operator trigger and new institutional filers drifted unclassified for a year+.

## What
Adds a **yearly `ScheduledJob`** (`ncen_classifier_yearly`, Apr 1 05:00 UTC, `sec_rate` lane, `catch_up_on_boot=True`). Most N-CEN filings (due 75 days after fiscal-year-end; Dec-FYE funds dominate) have landed by end of Q1.

This required a **new `yearly` Cadence kind**, threaded through everything that switches on cadence kind — the source of the only real risk here:
- `compute_next_run`, `runtime._trigger_for`, **and** `scheduled_adapter._cron_for` (all three cadence-kind switches) + `Cadence.label` + a `Cadence.yearly` validator.
- `app/api/system.py::JobOverviewResponse.cadence_kind` was a **hand-mirrored `Literal`** that would have made `/system/jobs` return **503** on the new kind (caught by tests) — now **reuses the scheduler `CadenceKind`** so it can never drift again.
- Frontend `CadenceKind` type extended (and given the `monthly` it was already missing).
- `_LANE_BY_JOB` → `ownership` (Admin process row), matching the adjacent 13F/N-PORT filer jobs (Codex caught the default-to-`ops` miss).

The invoker constructs `SecFilingsProvider(user_agent=settings.sec_user_agent)` and calls `classify_filers_via_ncen`; empty filer-seeds = natural no-op.

## Settled-decisions
- **#719** (process topology): `ScheduledJob` runs in the jobs process. ✓
- **#1064 / #1181** (bootstrap gate + carve-out): NOT exempt — a heavy per-filer SEC sweep fails the bounded-cost carve-out criterion, so it correctly waits for bootstrap. The boot-time `catch_up` evaluation trap (wont auto-re-fire when bootstrap later completes; waits for next restart or next Apr 1) is documented at the declaration; the operator manual-trigger (`_INVOKERS`) is the post-first-bootstrap path. `compose_filer_type` degrades to the `INV` default meanwhile.

## Test plan
- `tests/test_workers_scheduler_registry.py`: yearly `compute_next_run` (this-year / roll-to-next-year / strict boundary), `Cadence.yearly` validators + label, `_trigger_for` month-pinning, and full job registration (cadence kind/month/day/hour, `source=sec_rate`, `catch_up_on_boot=True`, not-exempt, in `_INVOKERS`, Admin lane=`ownership`).
- `ruff` / `pyright` / smoke / `pnpm typecheck` / `pnpm test:unit` (890) green.
- `tests/test_api_system.py` + `tests/test_scheduled_adapter.py` pass (the DTO/`_cron_for` drifts the new kind exposed, now fixed).
- Codex checkpoint-2: 2 findings folded (catch_up comment accuracy + `_LANE_BY_JOB`), re-review clean.

No DB/data backfill (scheduler wiring only). First classifier sweep fires at the next overdue evaluation (operator manual-trigger post-bootstrap, or Apr 1).

Closes #1303. Refs #1233, #782, #1181.