### PR TITLE
fix(#1293): disambiguate candle_refresh candles=0 outcome (fresh vs failed vs empty)

### DIFF
--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -46,6 +46,17 @@ class MarketRefreshSummary:
     quotes_updated: int
     quotes_skipped: int
     spread_flags_set: int
+    # #1293 — disambiguate a candle_rows_upserted=0 outcome. ``candles_skipped``
+    # counts instruments skipped because their candles were already fresh
+    # (legitimate no-op). ``candles_failed`` counts instruments whose refresh
+    # raised — that wraps the WHOLE per-instrument transaction (provider
+    # fetch + ``_upsert_candles`` + feature compute), so a DB/write error
+    # counts too, not only an eToro fetch/session failure; callers must phrase
+    # the cause accordingly. Without these the caller cannot tell a healthy
+    # "everything already fresh" run from a broken "every fetch failed" run;
+    # both report 0 candles written.
+    candles_skipped: int = 0
+    candles_failed: int = 0
 
 
 def refresh_market_data(
@@ -86,6 +97,7 @@ def refresh_market_data(
 
     today = date.today()
     candles_skipped = 0
+    candles_failed = 0
 
     # --- Candles: per-instrument (with freshness skip + two-mode fetch) ---
     # Two-mode fetch (#271):
@@ -114,15 +126,23 @@ def refresh_market_data(
             fetch_count = lookback_days
         else:
             fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days, today=today)
+        upserted = 0
+        computed = 0
         try:
             with conn.transaction():
                 bars = provider.get_daily_candles(instrument_id, fetch_count)
                 if bars:
                     upserted = _upsert_candles(conn, instrument_id, bars)
-                    candle_rows_upserted += upserted
                     computed = _compute_and_store_features(conn, instrument_id)
-                    features_computed += computed
+            # Accumulate the running totals ONLY after the transaction has
+            # committed cleanly (#1293 / Codex): incrementing inside the
+            # ``with`` block would over-report rows for an instrument whose
+            # feature-compute or commit later raised and rolled the write back
+            # — and that same instrument is also counted in ``candles_failed``.
+            candle_rows_upserted += upserted
+            features_computed += computed
         except Exception:
+            candles_failed += 1
             logger.warning("Failed to refresh candles for %s (id=%d), skipping", symbol, instrument_id, exc_info=True)
         report_progress(idx, total)
 
@@ -178,6 +198,8 @@ def refresh_market_data(
         quotes_updated=quotes_updated,
         quotes_skipped=quotes_skipped,
         spread_flags_set=spread_flags_set,
+        candles_skipped=candles_skipped,
+        candles_failed=candles_failed,
     )
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1873,7 +1873,16 @@ def daily_candle_refresh() -> None:
                 ordered.append((iid, str(row[1])))
 
             if not ordered:
-                logger.info("daily_candle_refresh: no instruments to refresh, skipping")
+                # #1293 — S2 is gated on ``universe_seeded`` (cap requirement),
+                # and the daily job normally has held + T1/T2 + T3 scope, so an
+                # empty refresh set is anomalous (empty universe / coverage not
+                # seeded). Surface as a WARNING, not a silent info, so a
+                # bootstrap S2 that completes with rows=0 because the scope was
+                # empty is distinguishable from a healthy run in the log.
+                logger.warning(
+                    "daily_candle_refresh: refresh scope is EMPTY (0 held + 0 T1/T2 + 0 T3) — "
+                    "nothing to fetch; universe/coverage may not be seeded"
+                )
                 tracker.row_count = 0
                 return
 
@@ -1893,14 +1902,56 @@ def daily_candle_refresh() -> None:
         tracker.row_count = summary.candle_rows_upserted
 
     logger.info(
-        "Market refresh complete: instruments=%d candles=%d features=%d quotes=%d quotes_skipped=%d spread_flags=%d",
+        "Market refresh complete: instruments=%d candles=%d features=%d quotes=%d "
+        "quotes_skipped=%d spread_flags=%d candles_fresh_skipped=%d candles_failed=%d",
         summary.instruments_refreshed,
         summary.candle_rows_upserted,
         summary.features_computed,
         summary.quotes_updated,
         summary.quotes_skipped,
         summary.spread_flags_set,
+        summary.candles_skipped,
+        summary.candles_failed,
     )
+
+    # #1293 — disambiguate the outcome. Run #6 completed S2 in 9s with
+    # rows_processed=0; without this a healthy "all fresh" run and a broken
+    # "every refresh failed" run both look like a clean SUCCESS.
+    if summary.candles_failed > 0:
+        # Any refresh failures — partial OR total. The per-instrument
+        # transaction wraps fetch + upsert + feature compute, so the cause is
+        # an eToro session lapse / API outage OR a DB write error; do not
+        # over-attribute. NOT a healthy no-op: the candles for the failed
+        # instruments were not written.
+        logger.warning(
+            "daily_candle_refresh: %d/%d instrument refreshes FAILED "
+            "(eToro session lapse / API outage or a DB write error) — "
+            "%d candles written, %d already fresh. Investigate; the expected "
+            "candles for the failed instruments are missing.",
+            summary.candles_failed,
+            len(instruments),
+            summary.candle_rows_upserted,
+            summary.candles_skipped,
+        )
+    elif summary.candle_rows_upserted == 0 and len(instruments) > 0:
+        if summary.candles_skipped == len(instruments):
+            # Every instrument's candles were already fresh — a legitimate
+            # no-op (e.g. S2 re-run shortly after a prior run).
+            logger.info(
+                "daily_candle_refresh: 0 candles written — all %d instruments already fresh (no fetch needed)",
+                len(instruments),
+            )
+        else:
+            # Non-empty scope, no failures, not all fresh → instruments were
+            # fetched successfully but returned no new bars (benign: no new
+            # trading data since the last run). Surfaced so it is not mistaken
+            # for the failure case above.
+            logger.info(
+                "daily_candle_refresh: 0 candles written — %d instrument(s) returned no new bars, "
+                "%d already fresh, 0 failed",
+                len(instruments) - summary.candles_skipped,
+                summary.candles_skipped,
+            )
 
 
 def _cik_destination_is_empty(conn: psycopg.Connection) -> bool:  # type: ignore[type-arg]

--- a/tests/test_daily_candle_refresh.py
+++ b/tests/test_daily_candle_refresh.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.workers.scheduler import _T3_BOOTSTRAP_BATCH_SIZE, daily_candle_refresh
 
 
@@ -76,6 +78,10 @@ class TestDailyCandleRefreshT3Bootstrap:
         mock_summary.quotes_updated = 0
         mock_summary.quotes_skipped = 0
         mock_summary.spread_flags_set = 0
+        # #1293 — must be real ints; the disambiguation branch compares them
+        # (`> 0`), and a bare MagicMock attribute raises on comparison.
+        mock_summary.candles_failed = 0
+        mock_summary.candles_skipped = 0
 
         with (
             patch(_PATCHES["creds"], return_value=("key", "ukey")),
@@ -149,6 +155,8 @@ class TestDailyCandleRefreshT3Bootstrap:
         mock_tracker.__exit__ = MagicMock(return_value=False)
         mock_summary = MagicMock()
         mock_summary.candle_rows_upserted = 1
+        mock_summary.candles_failed = 0
+        mock_summary.candles_skipped = 0
 
         with (
             patch(_PATCHES["creds"], return_value=("key", "ukey")),
@@ -170,3 +178,115 @@ class TestDailyCandleRefreshT3Bootstrap:
     def test_bootstrap_batch_size_is_200(self) -> None:
         """Sanity check the constant value."""
         assert _T3_BOOTSTRAP_BATCH_SIZE == 200
+
+
+# ---------------------------------------------------------------------------
+# #1293 — empty-fetch / candles=0 disambiguation
+# ---------------------------------------------------------------------------
+
+
+class TestDailyCandleRefreshEmptyFetchDisambiguation:
+    """S2 run #6 completed in 9s with rows_processed=0. Without structured
+    logging a healthy 'all already fresh' run and a broken 'every fetch
+    failed' run both look like a clean SUCCESS. These tests pin the three
+    cases to distinct log levels (#1293)."""
+
+    def _run_with_summary(
+        self,
+        *,
+        tier12_rows: list[tuple[int, str]],
+        candle_rows_upserted: int,
+        candles_failed: int,
+        candles_skipped: int,
+    ) -> None:
+        mock_conn = _make_mock_conn(tier12_rows, [], None)
+        mock_provider = MagicMock()
+        mock_provider.__enter__ = MagicMock(return_value=mock_provider)
+        mock_provider.__exit__ = MagicMock(return_value=False)
+        mock_tracker = MagicMock()
+        mock_tracker.__enter__ = MagicMock(return_value=mock_tracker)
+        mock_tracker.__exit__ = MagicMock(return_value=False)
+        mock_summary = MagicMock()
+        mock_summary.candle_rows_upserted = candle_rows_upserted
+        mock_summary.instruments_refreshed = len(tier12_rows)
+        mock_summary.features_computed = 0
+        mock_summary.quotes_updated = 0
+        mock_summary.quotes_skipped = 0
+        mock_summary.spread_flags_set = 0
+        mock_summary.candles_failed = candles_failed
+        mock_summary.candles_skipped = candles_skipped
+        with (
+            patch(_PATCHES["creds"], return_value=("key", "ukey")),
+            patch(_PATCHES["tracked"], return_value=mock_tracker),
+            patch(_PATCHES["provider_cls"], return_value=mock_provider),
+            patch(_PATCHES["connect"], return_value=mock_conn),
+            patch(_PATCHES["refresh"], return_value=mock_summary),
+        ):
+            daily_candle_refresh()
+
+    def test_empty_scope_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Empty held + T1/T2 + T3 → refresh never called; WARNING surfaced.
+        mock_conn = _make_mock_conn([], [], None)
+        mock_provider = MagicMock()
+        mock_provider.__enter__ = MagicMock(return_value=mock_provider)
+        mock_provider.__exit__ = MagicMock(return_value=False)
+        mock_tracker = MagicMock()
+        mock_tracker.__enter__ = MagicMock(return_value=mock_tracker)
+        mock_tracker.__exit__ = MagicMock(return_value=False)
+        with (
+            patch(_PATCHES["creds"], return_value=("key", "ukey")),
+            patch(_PATCHES["tracked"], return_value=mock_tracker),
+            patch(_PATCHES["provider_cls"], return_value=mock_provider),
+            patch(_PATCHES["connect"], return_value=mock_conn),
+            caplog.at_level("WARNING", logger="app.workers.scheduler"),
+        ):
+            daily_candle_refresh()
+        assert any("refresh scope is EMPTY" in r.message for r in caplog.records)
+
+    def test_all_fetches_failed_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING", logger="app.workers.scheduler"):
+            self._run_with_summary(
+                tier12_rows=[(1, "AAPL"), (2, "MSFT"), (3, "GME")],
+                candle_rows_upserted=0,
+                candles_failed=3,
+                candles_skipped=0,
+            )
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("refreshes FAILED" in r.message and "Investigate" in r.message for r in warnings)
+
+    def test_all_fresh_logs_info_not_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("INFO", logger="app.workers.scheduler"):
+            self._run_with_summary(
+                tier12_rows=[(1, "AAPL"), (2, "MSFT")],
+                candle_rows_upserted=0,
+                candles_failed=0,
+                candles_skipped=2,
+            )
+        assert any("already fresh" in r.message for r in caplog.records if r.levelname == "INFO")
+        # The healthy no-op must NOT raise a failure warning.
+        assert not any(r.levelname == "WARNING" and "FAILED" in r.message for r in caplog.records)
+
+    def test_partial_failure_with_some_writes_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        # #1293 (Codex): candles>0 AND failed>0 must still WARN — a partial
+        # failure is not a clean success.
+        with caplog.at_level("WARNING", logger="app.workers.scheduler"):
+            self._run_with_summary(
+                tier12_rows=[(1, "AAPL"), (2, "MSFT"), (3, "GME")],
+                candle_rows_upserted=20,
+                candles_failed=1,
+                candles_skipped=0,
+            )
+        assert any("refreshes FAILED" in r.message for r in caplog.records if r.levelname == "WARNING")
+
+    def test_zero_writes_no_failures_not_all_fresh_logs_no_new_bars(self, caplog: pytest.LogCaptureFixture) -> None:
+        # #1293 (Codex): non-empty scope, 0 written, 0 failed, not-all-fresh →
+        # instruments returned no new bars (benign), logged at INFO, no WARNING.
+        with caplog.at_level("INFO", logger="app.workers.scheduler"):
+            self._run_with_summary(
+                tier12_rows=[(1, "AAPL"), (2, "MSFT")],
+                candle_rows_upserted=0,
+                candles_failed=0,
+                candles_skipped=1,  # 1 fresh, 1 fetched-but-no-bars
+            )
+        assert any("no new bars" in r.message for r in caplog.records if r.levelname == "INFO")
+        assert not any(r.levelname == "WARNING" and "FAILED" in r.message for r in caplog.records)

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1034,3 +1034,70 @@ class TestRefreshMarketDataForceBackfill:
         # force_backfill bypasses both freshness skip AND incremental
         # fetch-count logic — provider gets the full lookback verbatim.
         provider.get_daily_candles.assert_called_once_with(42, 1000)
+
+    def test_fresh_instrument_counted_in_candles_skipped(self) -> None:
+        """#1293: a freshness-skipped instrument increments candles_skipped
+        so the caller can tell 'all fresh' from 'all failed'."""
+        from app.services.market_data import refresh_market_data
+
+        provider = MagicMock()
+        provider.get_daily_candles.return_value = []
+        conn = self._mock_conn_fresh()
+        summary = refresh_market_data(provider, conn, instruments=[(42, "AAPL")], skip_quotes=True)
+        assert summary.candles_skipped == 1
+        assert summary.candles_failed == 0
+        assert summary.candle_rows_upserted == 0
+
+    def test_fetch_exception_counted_in_candles_failed(self) -> None:
+        """#1293: a candle fetch that raises increments candles_failed (the
+        silent-failure signal — eToro session lapse / API outage)."""
+        from app.services.market_data import refresh_market_data
+
+        # conn whose _candles_are_fresh returns False (old latest date) so the
+        # fetch is attempted, then the provider raises.
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (date(2020, 1, 1),)
+        conn.execute.return_value = cursor
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.transaction.return_value = ctx
+
+        provider = MagicMock()
+        provider.get_daily_candles.side_effect = RuntimeError("eToro 401 session expired")
+
+        summary = refresh_market_data(provider, conn, instruments=[(42, "AAPL")], skip_quotes=True)
+        assert summary.candles_failed == 1
+        assert summary.candles_skipped == 0
+        assert summary.candle_rows_upserted == 0
+
+    def test_rollback_after_upsert_does_not_count_rows(self) -> None:
+        """#1293 (Codex): if the upsert succeeds but feature-compute (still
+        inside the transaction) raises, the write rolls back — candle_rows_upserted
+        must NOT count it, and the instrument is counted as failed."""
+        from unittest.mock import patch as _patch
+
+        from app.services import market_data
+        from app.services.market_data import refresh_market_data
+
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (date(2020, 1, 1),)  # not fresh → attempt fetch
+        conn.execute.return_value = cursor
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.transaction.return_value = ctx
+
+        provider = MagicMock()
+        provider.get_daily_candles.return_value = [MagicMock()]  # non-empty bars
+
+        with (
+            _patch.object(market_data, "_upsert_candles", return_value=5),
+            _patch.object(market_data, "_compute_and_store_features", side_effect=RuntimeError("feature boom")),
+        ):
+            summary = refresh_market_data(provider, conn, instruments=[(42, "AAPL")], skip_quotes=True)
+
+        assert summary.candle_rows_upserted == 0  # the 5 rolled back — not counted
+        assert summary.candles_failed == 1


### PR DESCRIPTION
Bootstrap run #6 S2 `candle_refresh` completed in 9s with `rows_processed=0`. A healthy "all already fresh" run and a broken "every fetch failed" run both looked like a clean SUCCESS — no way to tell which from the log.

## What
- **`MarketRefreshSummary`** gains `candles_skipped` (freshness no-ops) + `candles_failed` (per-instrument refresh exceptions), counted in `refresh_market_data` and logged on the "Market refresh complete" line.
- **`daily_candle_refresh`** now disambiguates:
  - `candles_failed > 0` (partial OR total) → **WARNING** (eToro session lapse / API outage OR a DB write error — phrased to not over-attribute, since the per-instrument `try` wraps fetch + upsert + feature compute).
  - 0 written, 0 failed, all fresh → **INFO** "already fresh" (benign no-op — the run-#6 case if cause was freshness).
  - 0 written, 0 failed, not all fresh → **INFO** "no new bars" (benign).
  - empty refresh scope → **WARNING** (anomalous: S2 is gated on `universe_seeded`).
- **Counter accuracy** (Codex): `candle_rows_upserted` / `features_computed` now accumulate **only after** the per-instrument transaction commits. They were incremented inside the `with conn.transaction()` block, so a post-upsert feature-compute / commit rollback over-reported writes for an instrument that was *also* counted as failed.

## Security model
Logging + telemetry only; no execution/trade path. No behaviour change to what candles are written — only how a zero-write outcome is surfaced + counter accuracy on rollback.

## Test plan
- `tests/test_market_data.py`: `refresh_market_data` counters — fresh→`candles_skipped`, fetch-raise→`candles_failed`, **post-upsert feature-compute rollback → `candle_rows_upserted==0` + `candles_failed==1`** (the Codex accuracy fix).
- `tests/test_daily_candle_refresh.py`: log levels for all five cases (empty scope / all-failed / partial-failed / all-fresh / no-new-bars), via `caplog`.
- `ruff` / `pyright` / smoke green. 106 candle/market tests pass.
- Codex checkpoint-2: 4 findings folded over 2 rounds (partial-failure warning, residual no-bars case, cause-attribution wording, post-commit accumulation); final pass clean.

No DB/data change. The original run-#6 root cause (which of the three) is now diagnosable directly from the structured log next time.

Closes #1293. Refs #1233.