### PR TITLE
fix(#1442): make layer-init guard fail-closed on a transient init-check DB error

### DIFF
--- a/app/services/sync_orchestrator/executor.py
+++ b/app/services/sync_orchestrator/executor.py
@@ -601,11 +601,20 @@ def _layer_initialization_blocks(layer: LayerPlan) -> str | None:
                     if row is None or not row[0]:
                         return f"layer {dep_name} not yet initialized"
     except Exception:
+        # #1442 — fail CLOSED. A transient DB error during the init-check must
+        # not let the layer run before its FK dependency is proven visible —
+        # that is the entire point of ``requires_layer_initialized``. Treat the
+        # failed check as "not yet initialized" → PREREQ_SKIP; the layer retries
+        # on the next dispatch once the DB recovers. Previously this returned
+        # None (fail-open), which #1435 made reachable during bootstrap (the
+        # high-frequency-sync carve-out runs ``portfolio_sync`` gated only by
+        # this check) — a transient error could let it run before ``universe``
+        # is visible and FK-violate the adapter.
         logger.exception(
-            "init-check gate: DB lookup failed for layer %s; not blocking",
+            "init-check gate: DB lookup failed for layer %s; failing CLOSED (skipping the layer)",
             layer.name,
         )
-        return None
+        return f"init-check DB error for layer {layer.name}"
 
     return None
 

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -575,8 +575,10 @@ allow-list + invariant assertions):**
   `job_runs`, so the job_runs-based boot catch-up always treats it as
   never-run — `catch_up_on_boot=True` therefore fires it on every
   controller boot (intended for motivation b: populate dashboard at boot;
-  bounded cost). The layer-init guard is fail-open on a transient
-  init-check DB error (pre-existing; fail-closing tracked separately).
+  bounded cost). The layer-init guard fails CLOSED on a transient
+  init-check DB error (#1442): a DB failure during the check treats the
+  layer as not-yet-initialized → `PREREQ_SKIP`, so it never runs before
+  its FK dependency is proven visible; it retries on the next dispatch.
 
 **Adding a new carve-out requires:**
 

--- a/tests/test_sync_orchestrator_credential_gate.py
+++ b/tests/test_sync_orchestrator_credential_gate.py
@@ -289,6 +289,28 @@ class TestLayerInitializationBlocks:
         result = _layer_initialization_blocks(plan)
         assert result is None
 
+    def test_db_error_during_init_check_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#1442: a transient DB error during the init-check must FAIL CLOSED —
+        return a skip reason (→ PREREQ_SKIP) rather than None (which would let
+        the layer run before its FK dependency is proven visible). Previously
+        fail-open."""
+
+        def _raise(*_args: object, **_kwargs: object) -> object:
+            raise psycopg.OperationalError("connection refused (transient)")
+
+        monkeypatch.setattr(
+            "app.services.sync_orchestrator.executor.psycopg.connect",
+            _raise,
+        )
+        plan = _make_plan("portfolio_sync", ("portfolio_sync",))
+        result = _layer_initialization_blocks(plan)
+        assert result is not None
+        assert "init-check DB error" in result
+        assert "portfolio_sync" in result
+
 
 # ---------------------------------------------------------------------------
 # AUTH_EXPIRED suppression in failure-history queries


### PR DESCRIPTION
`app/services/sync_orchestrator/executor.py::_layer_initialization_blocks` — the FK-safety gate behind `requires_layer_initialized` — was **fail-open**: a transient DB error during the init-check was logged and the layer ran anyway (`return None`).

## Why it matters
#1435 exempts `orchestrator_high_frequency_sync` from the universal bootstrap gate so `portfolio_sync` runs during bootstrap, gated **only** by this layer-init check (`requires_layer_initialized=("universe",)`). That makes the fail-open path reachable during bootstrap: a transient DB failure at the init-check could let `portfolio_sync` run before `universe` is visible → the adapter FK-violates — against the stated FK-safety argument.

## Fix
Fail **closed**: on an init-check DB error, return a skip reason (`"init-check DB error for layer <name>"`) instead of `None`. The executor records `LayerOutcome.PREREQ_SKIP` and the layer retries on the next dispatch once the DB recovers — it never runs before its FK dependency is proven visible.

- **Blast radius:** `portfolio_sync` is the **only** layer using `requires_layer_initialized` (verified — `registry.py:171`), so the change affects exactly one layer: skipped-and-retried on a transient blip, strictly safer than FK-violating. No layer relied on the fail-open behaviour.
- Settled-decisions note (#1181 carve-out section, the `orchestrator_high_frequency_sync` bullet) updated from "fail-open … tracked separately" to the new fail-closed behaviour.

## Test plan
- `tests/test_sync_orchestrator_credential_gate.py::test_db_error_during_init_check_fails_closed` — patch `executor.psycopg.connect` to raise → `_layer_initialization_blocks` returns a skip reason (not None). Existing init-block tests (no-dep passes / uninitialized blocks / initialized unblocks) still green.
- `ruff` / `pyright` / smoke green; 64 orchestrator/executor tests pass.
- Codex checkpoint-2: No findings (fail-closed return handled as PREREQ_SKIP, retry-safe, no deadlock, note accurate).

Closes #1442. Refs #1435, #1181.