### PR TITLE
fix: move admin fund-stats band to a top header (was buried below Processes)

### DIFF
--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -3,9 +3,11 @@
  *
  * Post-PR9 (#1085) AdminPage shape:
  *   1. ProblemsPanel — failing layers + failing jobs + coverage anomalies.
- *   2. Processes table — unified mechanism rows; bootstrap row + DAG drill-in
+ *   2. FundDataRow — at-a-glance fund stats header (moved above Processes
+ *      so it reads as the page header, not a footer buried under 40 rows).
+ *   3. Processes table — unified mechanism rows; bootstrap row + DAG drill-in
  *      + Timeline drill-in routes live under /admin/processes/:id.
- *   3. FundDataRow + Background tasks + Filings coverage.
+ *   4. Background tasks + Filings coverage.
  *
  * Decommissioned in PR6 (no longer covered here):
  *   - Sync-now button (top-level)

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -195,6 +195,13 @@ export function AdminPage() {
         onOpenOrchestrator={openOrchestratorFor}
       />
 
+      <FundDataRow
+        coverage={coverage.data}
+        coverageError={coverage.error !== null}
+        recommendations={recs.data}
+        recommendationsError={recs.error !== null}
+      />
+
       <CollapsibleSection
         title="Processes"
         summary="control hub"
@@ -223,13 +230,6 @@ export function AdminPage() {
           />
         ) : null}
       </CollapsibleSection>
-
-      <FundDataRow
-        coverage={coverage.data}
-        coverageError={coverage.error !== null}
-        recommendations={recs.data}
-        recommendationsError={recs.error !== null}
-      />
 
       <CollapsibleSection
         title="Background tasks"


### PR DESCRIPTION
## What
Move the `FundDataRow` at-a-glance stats band from **below** the Processes table to directly under `<ProblemsPanel>`, **above** Processes.

## Why
The band (tradable universe / analysable / needs review / latest recommendation / tier / score / thesis) is styled like a page header but was rendered after the 40-row process list, so the operator had to scroll past everything to reach it. It now lands at the top as the at-a-glance header it reads as.

## Test plan
- Pure JSX reorder — no logic, props, or component change.
- `pnpm --dir frontend typecheck` → clean.
- `pnpm --dir frontend test:unit` → **890 passed** (incl. AdminPage's 15: "renders the fund-data row…").
- Updated the `AdminPage.test.tsx` layout-description comment to match the new order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
