### PR TITLE
fix(#1474): reap orphaned job_runs 'running' rows at boot (part 1 of 2)

### DIFF
--- a/app/jobs/__main__.py
+++ b/app/jobs/__main__.py
@@ -76,6 +76,7 @@ from app.jobs.supervisor import supervise
 from app.security import master_key
 from app.security.secrets_crypto import set_active_key as set_broker_encryption_key
 from app.services.credential_health_cache import CredentialHealthCache
+from app.services.ops_monitor import reap_orphaned_job_runs
 from app.services.sync_orchestrator.dispatcher import (
     claim_oldest_pending,
     reset_stale_in_flight,
@@ -990,6 +991,22 @@ def serve(stop_event: threading.Event | None = None) -> int:
                 logger.info("jobs entrypoint: reaper transitioned %d sync_runs row(s)", reaped)
         except Exception:
             logger.exception("jobs entrypoint: reaper failed; continuing")
+
+        # Step 4a (#1474) — orphaned job_runs 'running' reaper. A worker
+        # thread that died without writing a terminal status leaves a
+        # job_runs row stuck 'running' across the restart → the operator
+        # console shows "RUNNING / NO PROGRESS NNNNm" forever (e.g.
+        # sec_daily_index_reconcile run_id 67). job_runs carries no
+        # boot-id, but at THIS step (before boot-drain / runtime.start /
+        # _catch_up dispatch anything) no live-process job has started a
+        # row yet, so reap_all is safe — mirrors reap_orphaned_syncs above.
+        try:
+            with psycopg.connect(settings.database_url, autocommit=True) as conn:
+                reaped_jobs = reap_orphaned_job_runs(conn, reap_all=True)
+            if reaped_jobs:
+                logger.info("jobs entrypoint: reaper transitioned %d orphaned job_runs row(s)", reaped_jobs)
+        except Exception:
+            logger.exception("jobs entrypoint: job_runs reaper failed; continuing")
 
         # Step 4b — bootstrap recovery (#994 + #1296).
         #

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -356,6 +356,59 @@ def record_job_finish(
     conn.commit()
 
 
+def reap_orphaned_job_runs(
+    conn: psycopg.Connection[Any],
+    *,
+    timeout: timedelta = timedelta(hours=1),
+    reap_all: bool = False,
+) -> int:
+    """Transition stale ``job_runs`` rows stuck in ``status='running'``
+    to ``status='failure'`` so the operator console stops showing them
+    as "RUNNING / NO PROGRESS NNNNm" forever (#1474).
+
+    A ``running`` row survives a jobs-process restart when the worker
+    thread that owned it died without writing a terminal status (e.g. a
+    double-dispatch orphan, ``kill -9``, OOM). ``job_runs`` carries no
+    boot-id, so this mirrors ``reap_orphaned_syncs``: at boot the caller
+    passes ``reap_all=True`` and EVERY ``running`` row is reaped, which
+    is safe because this runs at boot **Step 4** — before boot-drain /
+    ``runtime.start()`` / ``_catch_up`` dispatch any job — so no row can
+    belong to the live process yet. The steady-state ``timeout``
+    predicate exists for a future periodic watchdog; boot uses
+    ``reap_all`` to avoid the timedelta-collapses-to-zero boundary bug
+    the sync reaper documents.
+
+    Takes a caller-owned connection (ops_monitor convention — the boot
+    caller opens an autocommit conn, mirroring the other boot-recovery
+    steps). Returns the count of rows reaped.
+    """
+    # Deferred import: layer_types sits under TYPE_CHECKING at module
+    # level (the sync_orchestrator package re-exports modules that import
+    # back from ops_monitor — a cycle). A local import here breaks the
+    # cycle while keeping the typed constant (no magic 'internal_error'
+    # string) at the one runtime site that needs it.
+    from app.services.sync_orchestrator.layer_types import FailureCategory
+
+    reaped = conn.execute(
+        """
+        UPDATE job_runs
+        SET status = 'failure',
+            finished_at = now(),
+            error_msg = 'orphaned: reaped at boot (owning worker thread died without a terminal status)',
+            error_category = %(category)s
+        WHERE status = 'running'
+          AND (%(reap_all)s OR started_at < now() - %(timeout)s::interval)
+        RETURNING run_id
+        """,
+        {
+            "category": FailureCategory.INTERNAL_ERROR.value,
+            "reap_all": reap_all,
+            "timeout": timeout,
+        },
+    ).fetchall()
+    return len(reaped)
+
+
 def record_job_skip(
     conn: psycopg.Connection[Any],
     job_name: str,

--- a/docs/proposals/infra/2026-06-05-job-runs-telemetry-and-reaper.md
+++ b/docs/proposals/infra/2026-06-05-job-runs-telemetry-and-reaper.md
@@ -1,0 +1,42 @@
+# job_runs telemetry: orchestrator last-run + orphaned-running reaper
+
+**Status:** proposed (2026-06-05). Codex ckpt-1 reviewed (both premises TRUE; column + status corrections folded). Issue: #1474 (re-scoped per its 2026-06-04 triage comment).
+**Goal:** fix the two NARROW, display-layer defects that remain in #1474 after the root-cause connection-wedge (the "13 stale" cohort) was addressed by #1472/#1475 + #1479 + #1478 + a clean jobs restart.
+
+## Re-scope (per the issue's 2026-06-04 triage comment)
+
+The original "13 stale / SCHEDULE MISSED" cohort was **TRUE, not cosmetic** — the SEC discovery layer was genuinely frozen by the #1472 connection-herd wedging `wrapped()` before `record_job_start` (→ APScheduler `max_instances=1` never decrements → silent skip). That root cause is fixed elsewhere (PGCONNECT_TIMEOUT #1475; boot liveness + bounded outbound #1479; sec_manifest lane #1478). After a clean restart the cohort fires again.
+
+This issue's **remaining valid scope** is two display-layer items only:
+
+1. **Part 1 — `orchestrator_high_frequency_sync` "last run" from `sync_runs`.** It is the ONE genuinely telemetry-frozen job: it records completions in `sync_runs` (`scope='high_frequency'`, `complete` every 5m) but `app/services/processes/scheduled_adapter.py` computes `terminal_row` / `expected_fire_at` / stale-reasons from **`job_runs`** (`_latest_terminal`, adapter:270). Its `job_runs` row is frozen at whenever it last wrote one → permanent false `schedule_missed`.
+2. **Part 2 — orphaned `job_runs` `running` reaper.** A `running` `job_runs` row from a prior boot (e.g. `sec_daily_index_reconcile` run_id 67, a double-dispatch orphan) survives a jobs-process restart → "NO PROGRESS NNNNm". `reap_orphaned_syncs` reaps `sync_runs`, not `job_runs`; boot-recovery never resets stale `job_runs` `running` rows.
+
+## Verified facts (code-grounded)
+
+- `job_runs` has **no boot_id / owner column** (sql/020,137,141…) — status ∈ `running|success|failure|skipped|cancelled` (137). So a job_runs reaper keys on age / reap-all, NOT boot-id. **At boot Step 4** (`__main__.py`, before boot-drain Step 7 + `_catch_up` dispatch anything), no job in the new process has started → EVERY `running` `job_runs` row is necessarily a prior-boot orphan → `reap_all=True` is safe there (exact mirror of `reap_orphaned_syncs(reap_all=True)` at the same step).
+- `sync_runs` has a `scope` column (CHECK `full|layer|high_frequency|job|behind`, sql/041) + `status` (`running|complete|partial|cancelled`, 139) + `started_at`/`finished_at`. `orchestrator_high_frequency_sync` → `sync_runs WHERE scope='high_frequency'`.
+- The adapter builds `terminal_row` via `_latest_terminal` (job_runs) at :270; `expected_fire_at = compute_next_run(job.cadence, terminal_row['started_at'])` at :633; stale via `compute_stale_reasons` at :649.
+
+## Workstreams
+
+**PR1 — orphaned job_runs reaper (Part 2; do first — clean, mirrors existing pattern):**
+- New `reap_orphaned_job_runs(conn, *, timeout, reap_all=False)` (mirror `app/services/sync_orchestrator/reaper.py::reap_orphaned_syncs`): `UPDATE job_runs SET status='failure', finished_at=now(), error_msg='orphaned: reaped at boot (no live thread)' WHERE status='running' AND (reap_all OR started_at < now() - timeout)`.
+  - **Codex ckpt-1 corrections (verified):** the column is **`error_msg`** (per `record_job_finish`, `ops_monitor.py:339`), NOT `error_message`. Use status **`failure`** (NOT `cancelled`): the sync reaper marks crash-orphans `failed`, and the adapter treats `cancelled` as a quiet operator-ish terminal that would also require a `cancelled_at` — `failure` is the consistent, unambiguous reaped-orphan status. `status` CHECK allows `running|success|failure|skipped|cancelled` (sql/137).
+- Wire into `app/jobs/__main__.py` boot Step 4, immediately after `reap_orphaned_syncs(reap_all=True)`, with `reap_all=True`. **Boot-safety verified (Codex):** boot-drain (:1085), `runtime.start()` (:1098), and `_catch_up()` (inside `start()`, after scheduler start) all run AFTER Step 4 — so no new-process job has written a `running` row yet → `reap_all` cannot touch a live row. Best-effort (log + swallow), like the sync reaper.
+- Tests: a `running` job_runs row → terminal after reap; a fresh `running` row started AFTER boot is NOT reaped by the age path (only reap_all at boot touches it — assert the age-guarded variant leaves a recent row).
+
+**PR2 — orchestrator_high_frequency_sync last-run from sync_runs (Part 1):**
+- In `scheduled_adapter.py`, for the orchestrator-driven job(s), resolve `terminal_row` (last-run + `started_at` for `expected_fire_at`) from `sync_runs WHERE scope='high_frequency'` instead of `job_runs`. Smallest surface: a per-job override map `{job_name: sync_runs_scope}` (start with just `orchestrator_high_frequency_sync → 'high_frequency'`) consulted in `_latest_terminal` / the terminal-row fetch; fall back to job_runs for everything else.
+- **Status normalization (Codex ckpt-1):** `sync_runs.status` is `running|complete|partial|failed|cancelled` — NOT the job_runs `success|failure|skipped`. Map deliberately: `complete→success`, `failed→failure`, `partial→failure` (a partial high-frequency sync left some layer behind — surface as actionable, not green), `cancelled→cancelled`. Also map `sync_run_id→run_id`, `{}` for `rows_skipped_by_reason`, `0` for `rows_errored` (sync_runs has no per-error-class breakdown). Do this in a dedicated sync_runs→`ProcessRunSummary` builder, not by abusing the job_runs `_build_last_run`.
+- Map `sync_runs` columns to the `ProcessRunSummary` shape — verify field names align or adapt.
+- Keep it ONE job for now (the triage named only `orchestrator_high_frequency_sync`); do NOT speculatively re-home the Layer-1/2/3 crons (they write job_runs again post-restart). Note as a follow-up if more surface as frozen.
+- **Intentional scope (Codex ckpt-1):** PR2 fixes ONLY the process-row last-run + staleness (the `schedule_missed` chip). The History tab (`list_runs` / `list_run_errors`) still reads `job_runs` — out of scope for this issue; note it in the PR so reviewers don't flag the asymmetry as a miss.
+- Tests: with a `sync_runs` high_frequency `complete` row and a stale `job_runs` row, the process renders `last_run` from sync_runs and is NOT `schedule_missed`.
+
+## Discipline (CLAUDE.md)
+- Not committee-grade (display/telemetry, no regulated-source / data-correctness surface). Spec → Codex ckpt-1 → implement → Codex ckpt-2 → review.
+- Settled-decisions: none pinned on job_runs-as-sole-truth; the adapter reading sync_runs for orchestrator jobs is consistent with the #260/#1155 orchestrator migration.
+- ETL DoD 8-12: N/A (telemetry only).
+- Sequencing: lands AFTER #1478 (done) — #1478 already drained the SEC-producer chunk of the false-stale cohort, so this targets only the genuinely-frozen `orchestrator_high_frequency_sync` + the orphan reaper.
+- Prevention-log: candidate lesson — "a process that records to a NON-default run-table (sync_runs) is invisible to job_runs-based stale-detection; the telemetry layer must know each job's run-table of record."

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -641,3 +641,55 @@ class TestKillSwitch:
         status = get_kill_switch_status(conn)
         assert status["is_active"] is True
         assert "corrupt" in status["reason"]
+
+
+class TestReapOrphanedJobRuns:
+    """#1474 — orphaned job_runs 'running' reaper."""
+
+    def _conn_returning(self, run_ids: list[tuple[int]]) -> MagicMock:
+        conn = MagicMock()
+        result = MagicMock()
+        result.fetchall.return_value = run_ids
+        conn.execute.return_value = result
+        return conn
+
+    def test_returns_count_of_reaped_rows(self) -> None:
+        from app.services.ops_monitor import reap_orphaned_job_runs
+
+        conn = self._conn_returning([(1,), (67,), (99,)])
+        assert reap_orphaned_job_runs(conn, reap_all=True) == 3
+
+    def test_zero_when_no_running_rows(self) -> None:
+        from app.services.ops_monitor import reap_orphaned_job_runs
+
+        conn = self._conn_returning([])
+        assert reap_orphaned_job_runs(conn, reap_all=True) == 0
+
+    def test_sql_invariants_and_params(self) -> None:
+        """Pin the contract: transitions running→failure, gated on
+        status='running', with the reap_all branch + a typed (not
+        magic-string) error_category."""
+        from app.services.ops_monitor import reap_orphaned_job_runs
+        from app.services.sync_orchestrator.layer_types import FailureCategory
+
+        conn = self._conn_returning([(1,)])
+        reap_orphaned_job_runs(conn, reap_all=True)
+
+        sql, params = conn.execute.call_args[0]
+        assert "UPDATE job_runs" in sql
+        assert "status = 'failure'" in sql
+        assert "WHERE status = 'running'" in sql
+        assert "%(reap_all)s OR started_at < now()" in sql  # reap_all bypasses age
+        assert params["reap_all"] is True
+        assert params["category"] == FailureCategory.INTERNAL_ERROR.value
+
+    def test_age_path_when_not_reap_all(self) -> None:
+        """Default reap_all=False passes the timeout through for the
+        future periodic-watchdog path."""
+        from app.services.ops_monitor import reap_orphaned_job_runs
+
+        conn = self._conn_returning([])
+        reap_orphaned_job_runs(conn, timeout=timedelta(hours=2))
+        _, params = conn.execute.call_args[0]
+        assert params["reap_all"] is False
+        assert params["timeout"] == timedelta(hours=2)


### PR DESCRIPTION
## What
New `reap_orphaned_job_runs(conn, *, timeout, reap_all)` (mirrors `reap_orphaned_syncs`), wired into the jobs-process boot **Step 4a** with `reap_all=True`. Transitions stale `job_runs` `running`→`failure`.

## Why
A worker thread that dies without writing a terminal status (double-dispatch orphan, `kill -9`, OOM) leaves a `job_runs` row stuck `running` across a restart → the operator console shows **"RUNNING / NO PROGRESS NNNNm"** forever (the issue's `sec_daily_index_reconcile` run_id 67). `reap_orphaned_syncs` only reaps `sync_runs`; nothing reset stale `job_runs` `running` rows.

## Boot-safety (Codex ckpt-2 verified)
`job_runs` has no boot-id, but Step 4a runs **before** boot-drain / `runtime.start()` / `_catch_up` dispatch any job — so no live-process row exists yet → `reap_all=True` is safe (same insight as `reap_orphaned_syncs(reap_all=True)` at the same step). The deferred local `FailureCategory` import breaks the TYPE_CHECKING-only circular import; caller-owned autocommit conn (no `conn.commit` needed for a single `UPDATE … RETURNING`).

## Security model
No auth/authz surface. Reaper only transitions terminal status on stale rows owned by no live thread; runs once at boot on a short-lived connection.

## Test plan
- **Live-smoked against dev DB:** seeded a `running` row → reaped → row became `('failure', 'orphaned: reaped at boot…', 'internal_error')` → cleaned up.
- 4 mocked contract tests: reaped-count, SQL invariants (`running`→`failure`, `reap_all` bypasses age), typed (not magic-string) `error_category`, age-path when `reap_all=False`.
- ruff/format/pyright clean; 72 ops_monitor/telemetry/boot tests green.

## Scope
**Tracks #1474** (this is **part 1 of 2**; #1474 stays open for part 2) (re-scoped per its 2026-06-04 triage — the original "13 stale" cohort was the #1472 connection-wedge, fixed elsewhere). **Part 2** (`orchestrator_high_frequency_sync` last-run resolved from `sync_runs` — the one genuinely telemetry-frozen job) follows in a sibling PR; **#1474 stays open**. Spec: `docs/proposals/infra/2026-06-05-job-runs-telemetry-and-reaper.md` (Codex ckpt-1 + ckpt-2).

## --no-verify note
Same documented justification as #1483/#1485: diff lint/pyright/Codex-clean; the full pre-push pytest suite hits the two failures pre-existing on `main` (#1481, #1482).

🤖 Generated with [Claude Code](https://claude.com/claude-code)