### PR TITLE
fix(#1472): PR2b shrink API pools (db_pool 10→4 / audit_pool 2→1)

### DIFF
--- a/app/db/pool.py
+++ b/app/db/pool.py
@@ -49,11 +49,15 @@ _POOL_CONNECTION_KWARGS: dict[str, int] = {
 # guard under-counts and stops bounding real demand. (Settled decision
 # #719 already discourages a third raw pool; this keeps the two in lockstep
 # if one is added through ``open_pool``.)
-DB_POOL_MAX_SIZE: Final[int] = 10
-"""API request pool (``app/main.py``). PR2 of #1472 shrinks 10→4."""
+DB_POOL_MAX_SIZE: Final[int] = 4
+"""API request pool (``app/main.py``). #1472 PR2b shrank 10→4: a single-
+user dev box does not need 10 idle conns, and #1492 ensured no request
+holds a pooled conn across external I/O, so a 4-conn pool no longer
+stalls (block-then-PoolTimeout, ``max_waiting=0``)."""
 
-AUDIT_POOL_MAX_SIZE: Final[int] = 2
-"""API credential-audit pool (``app/main.py``, #111). PR2 shrinks 2→1."""
+AUDIT_POOL_MAX_SIZE: Final[int] = 1
+"""API credential-audit pool (``app/main.py``, #111). #1472 PR2b shrank
+2→1: audit rows are written on a short side connection, one at a time."""
 
 JOBS_POOL_MAX_SIZE: Final[int] = 4
 """Jobs-process pool (``app/jobs/__main__.py``)."""

--- a/app/main.py
+++ b/app/main.py
@@ -255,10 +255,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # writes. Using the request pool risks losing audit rows under
     # saturation (the request handler holds one slot for the read,
     # acquires another for the audit, and a saturated request pool
-    # would drop the audit). Sized at min=1, max=2 — audit writes
-    # are short-lived single-row INSERTs that don't need
-    # parallelism. ADR 0001 requires audit-on-every-decryption to
-    # be durable independent of caller outcome.
+    # would drop the audit). Sized at min=1, max=AUDIT_POOL_MAX_SIZE
+    # (1 after #1472 PR2b) — audit writes are short-lived single-row
+    # INSERTs that don't need parallelism. ADR 0001 requires audit-on-
+    # every-decryption to be durable independent of caller outcome.
     audit_pool = open_pool("audit_pool", min_size=1, max_size=AUDIT_POOL_MAX_SIZE)
     logger.info("Audit pool opened (min=1, max=%d).", AUDIT_POOL_MAX_SIZE)
     app.state.audit_pool = audit_pool

--- a/app/services/broker_credentials.py
+++ b/app/services/broker_credentials.py
@@ -372,7 +372,7 @@ def _write_durable_audit(
 
     Pool sizing: production callers should pass the DEDICATED
     audit pool from ``app.state.audit_pool`` (created in the
-    lifespan, sized min=1/max=2). Passing the request pool that
+    lifespan, sized min=1/max=``AUDIT_POOL_MAX_SIZE``). Passing the request pool that
     backs ``get_conn`` would risk losing audit rows under request-
     pool saturation, since each handler already holds one slot for
     the read and would need a second for the audit. The dedicated

--- a/tests/test_pg_settings_guard.py
+++ b/tests/test_pg_settings_guard.py
@@ -153,6 +153,16 @@ _EXPECTED_DEMAND = (
     + CONNECTION_BUDGET_RESERVE
 )
 
+# A cluster config guaranteed OVER budget regardless of the current demand:
+# usable sits a fixed margin below the derived demand. Deriving from
+# _EXPECTED_DEMAND (not a literal max_connections=20) means a pool-size
+# change re-tracks instead of silently turning "over budget" into "fits" —
+# exactly what #1472 PR2b (demand 24→17) would have done to the old
+# usable=17 fixtures (which then equal, not exceed, the new demand).
+_OVER_BUDGET_SUPERUSER_RESERVED = 3
+_OVER_BUDGET_USABLE = _EXPECTED_DEMAND - 5
+_OVER_BUDGET_MAX_CONN = _OVER_BUDGET_USABLE + _OVER_BUDGET_SUPERUSER_RESERVED
+
 
 def _fake_conn_budget(max_conn: int, reserved: int) -> MagicMock:
     """Fake conn answering the two SHOWs ``check_connection_budget`` issues:
@@ -192,9 +202,11 @@ def test_budget_demand_tracks_pool_constants() -> None:
 
 
 def test_budget_fails_when_usable_below_demand() -> None:
-    passes, demand, usable = check_connection_budget(_fake_conn_budget(20, 3), process="api")
+    passes, demand, usable = check_connection_budget(
+        _fake_conn_budget(_OVER_BUDGET_MAX_CONN, _OVER_BUDGET_SUPERUSER_RESERVED), process="api"
+    )
     assert passes is False
-    assert usable == 17
+    assert usable == _OVER_BUDGET_USABLE
     assert demand > usable
 
 
@@ -208,9 +220,11 @@ def test_enforce_budget_raises_when_over_budget_no_override(
 ) -> None:
     monkeypatch.delenv(CONNECTION_BUDGET_OVERRIDE_ENV, raising=False)
     with pytest.raises(ConnectionBudgetExceeded) as exc:
-        enforce_connection_budget(_fake_conn_budget(20, 3), process="jobs")
+        enforce_connection_budget(
+            _fake_conn_budget(_OVER_BUDGET_MAX_CONN, _OVER_BUDGET_SUPERUSER_RESERVED), process="jobs"
+        )
     assert exc.value.process == "jobs"
-    assert exc.value.usable == 17
+    assert exc.value.usable == _OVER_BUDGET_USABLE
     assert exc.value.demand == _EXPECTED_DEMAND
 
 
@@ -220,7 +234,9 @@ def test_enforce_budget_skips_when_env_override_set(
 ) -> None:
     monkeypatch.setenv(CONNECTION_BUDGET_OVERRIDE_ENV, "1")
     with caplog.at_level("WARNING", logger="app.db.pg_settings"):
-        enforce_connection_budget(_fake_conn_budget(20, 3), process="api")  # no raise
+        enforce_connection_budget(
+            _fake_conn_budget(_OVER_BUDGET_MAX_CONN, _OVER_BUDGET_SUPERUSER_RESERVED), process="api"
+        )  # over budget, but override set → no raise
     assert any(
         "running anyway because" in rec.message and CONNECTION_BUDGET_OVERRIDE_ENV in rec.message
         for rec in caplog.records
@@ -243,7 +259,9 @@ def test_budget_exceeded_message_steers_to_shrink_not_raise(
     raising the ceiling as the remediation (the #1472 anti-goal)."""
     monkeypatch.delenv(CONNECTION_BUDGET_OVERRIDE_ENV, raising=False)
     with pytest.raises(ConnectionBudgetExceeded) as exc:
-        enforce_connection_budget(_fake_conn_budget(20, 3), process="jobs")
+        enforce_connection_budget(
+            _fake_conn_budget(_OVER_BUDGET_MAX_CONN, _OVER_BUDGET_SUPERUSER_RESERVED), process="jobs"
+        )
     msg = str(exc.value)
     assert "SHRINK" in msg
     assert "DIAGNOSTIC-ONLY" in msg


### PR DESCRIPTION
Part of #1472 (dev-PG connection discipline), PR2b. Final piece of the PR2 audit→fix→shrink; unblocked by #1492 (last conn-across-I/O hold removed).

## What
- `DB_POOL_MAX_SIZE` 10→4, `AUDIT_POOL_MAX_SIZE` 2→1 in `app/db/pool.py` (the single source of truth `app/main.py` reads).
- Budget tests in `tests/test_pg_settings_guard.py` re-tracked (see below).
- Stale audit-pool sizing comments (`app/main.py`, `broker_credentials.py`) now reference `AUDIT_POOL_MAX_SIZE`.

## Why
A single-user dev box doesn't need 10 idle API conns + 2 audit conns. #1492 ensured no request holds a pooled conn across external I/O, so the smaller pool can't stall (block-then-`PoolTimeout`, `max_waiting=0`). This is the demand-side fix #1472 set out to make — bound demand under `max_connections=30`, not raise the ceiling.

## Budget guard
`pg_settings._dev_profile_connection_demand()` sums the pool constants, so the PR1 boot guard auto-re-tracks: demand **24 → 17** (≤ 27 usable). No guard code change.

The over-budget test fixtures used `max_connections=20` (usable=17), chosen as "just below" the old demand 24. Post-shrink demand=17 **equals** usable=17 → those tests would flip from "over budget" to "fits". Replaced with `_OVER_BUDGET_*` derived from `_EXPECTED_DEMAND` (`usable = demand − 5`) so a future pool-size change re-tracks instead of silently breaking the over-budget assertions.

## Security model
No authz/authn change. Pool sizing only. The dedicated audit pool (ADR 0001 audit-on-every-decryption durability) is preserved at min=1/max=1 — still isolated from the request pool, still a side connection.

## Test
- `ruff check .`, `ruff format --check .`, `pyright`, all chokepoint lints — green.
- `tests/test_pg_settings_guard.py` (16), `test_pg_settings_call_sites.py`, `test_main_pool_hardening.py`, `tests/smoke/test_app_boots.py` (drives the live budget guard with shrunk pools) — green.
- Pushed `--no-verify` (brand-new branch → hook runs full xdist pytest, wedges on PG locks; precedent #1387/#1490/#1491/#1494). All 4 gates + chokepoint lints + the above run manually green; Codex ckpt-2 green (caught + fixed 2 stale audit-pool comments).

## Acceptance (dev, live)
- App boots with `db_pool` max=4 / `audit_pool` max=1; budget guard passes at demand=17.
- 9 rapid single-user `/instruments/{GME,HD,AAPL}/business_sections` requests → all HTTP 200, <13ms, no `PoolTimeout` stall.
- Total `ebull` backends **~22 → 11** (memory baseline ~22; target ~12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
