### PR TITLE
fix(#1480): stop Processes control-hub flicker on poll

### DIFF
--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -4,7 +4,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "@/api/client";
 import { makeProcessRow, makeError } from "@/components/admin/__fixtures__/processes";
-import { ProcessRow } from "@/components/admin/ProcessRow";
+import { ProcessRow, processRowSignature } from "@/components/admin/ProcessRow";
+import type { ProcessRowResponse } from "@/api/types";
 
 function renderRow(props: Partial<Parameters<typeof ProcessRow>[0]> = {}) {
   const row = props.row ?? makeProcessRow();
@@ -14,6 +15,7 @@ function renderRow(props: Partial<Parameters<typeof ProcessRow>[0]> = {}) {
         <tbody>
           <ProcessRow
             row={row}
+            signature={processRowSignature(row)}
             triggerError={undefined}
             cancelError={undefined}
             busy={false}
@@ -25,6 +27,37 @@ function renderRow(props: Partial<Parameters<typeof ProcessRow>[0]> = {}) {
         </tbody>
       </table>
     </MemoryRouter>,
+  );
+}
+
+// Stable handler refs shared across rerenders — the memo comparator
+// reference-compares the callbacks, so fresh `vi.fn()`s per render would
+// (correctly) force a repaint and mask the signature-gating behaviour
+// under test.
+const STABLE_HANDLERS = {
+  onIterate: vi.fn(),
+  onFullWash: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+function rowMarkup(row: ProcessRowResponse, signature: string) {
+  return (
+    <MemoryRouter>
+      <table>
+        <tbody>
+          <ProcessRow
+            row={row}
+            signature={signature}
+            triggerError={undefined}
+            cancelError={undefined}
+            busy={false}
+            onIterate={STABLE_HANDLERS.onIterate}
+            onFullWash={STABLE_HANDLERS.onFullWash}
+            onCancel={STABLE_HANDLERS.onCancel}
+          />
+        </tbody>
+      </table>
+    </MemoryRouter>
   );
 }
 
@@ -495,5 +528,96 @@ describe("ProcessRow", () => {
     expect(
       screen.queryByTestId("process-description-tooltip"),
     ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------
+// #1480 — content signature + React.memo anti-flicker contract.
+// ---------------------------------------------------------------------
+
+describe("processRowSignature", () => {
+  it("is identical for a deep-cloned row — the unchanged-poll case", () => {
+    const a = makeProcessRow({ status: "ok" });
+    // A real poll returns a fresh JSON parse: new object identity at
+    // every level (nested last_run / watermark too), same content. The
+    // signature must collapse that back to equality so memo skips.
+    const b: ProcessRowResponse = JSON.parse(JSON.stringify(a));
+    expect(a).not.toBe(b);
+    expect(a.last_run).not.toBe(b.last_run);
+    expect(processRowSignature(a)).toBe(processRowSignature(b));
+  });
+
+  it("changes when a rendered field changes", () => {
+    const base = makeProcessRow({ status: "ok" });
+    const changed: ProcessRowResponse = { ...base, status: "failed" };
+    expect(processRowSignature(base)).not.toBe(processRowSignature(changed));
+  });
+
+  // The stuck-row elapsed suffix is the one part of the signature NOT
+  // already implied by JSON.stringify(row): last_progress_at is frozen
+  // while a process is wedged, so without a wall-clock term the chip
+  // ("no progress Nm") would freeze too and the operator loses the
+  // wedge signal (#1474 / #1478). These two tests prove the suffix
+  // earns its place — comparing stuck-vs-non-stuck would NOT, since
+  // stale_reasons already lands in the JSON.
+  it("advances a stuck row's signature as wall-clock elapses, with frozen data", () => {
+    const frozen = "2026-05-08T13:00:00+00:00";
+    const stuck = makeProcessRow({
+      status: "running",
+      stale_reasons: ["mid_flight_stuck"],
+      active_run: {
+        run_id: 99,
+        started_at: frozen,
+        rows_processed_so_far: 0,
+        progress_units_done: null,
+        progress_units_total: null,
+        last_progress_at: frozen, // never moves — the process is wedged
+        is_cancelling: false,
+      },
+    });
+    const base = Date.parse(frozen);
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValue(base + 60_000); // 1m wedged
+    const at1m = processRowSignature(stuck);
+    nowSpy.mockReturnValue(base + 10 * 60_000); // 10m wedged, same row data
+    const at10m = processRowSignature(stuck);
+
+    expect(at1m).not.toBe(at10m);
+    nowSpy.mockRestore();
+  });
+
+  it("does not add a time term for quiescent rows — stable across wall-clock", () => {
+    const ok = makeProcessRow({ status: "ok", stale_reasons: [] });
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValue(1_000_000);
+    const early = processRowSignature(ok);
+    nowSpy.mockReturnValue(500_000_000);
+    const late = processRowSignature(ok);
+
+    // A healthy row must never repaint merely because time passed.
+    expect(early).toBe(late);
+    nowSpy.mockRestore();
+  });
+});
+
+describe("ProcessRow memoisation (#1480)", () => {
+  it("skips repaint when the signature is unchanged despite a new row object", () => {
+    const a = makeProcessRow({ display_name: "Alpha" });
+    const { rerender } = render(rowMarkup(a, "SIG-1"));
+    expect(screen.getByRole("link", { name: "Alpha" })).toBeTruthy();
+
+    // New row object, DIFFERENT content, but SAME signature → memo must
+    // skip the repaint and keep showing the prior content. This is the
+    // unchanged-poll case: snapshot identity churns, content does not.
+    const b = makeProcessRow({ display_name: "Beta" });
+    rerender(rowMarkup(b, "SIG-1"));
+    expect(screen.queryByRole("link", { name: "Beta" })).toBeNull();
+    expect(screen.getByRole("link", { name: "Alpha" })).toBeTruthy();
+
+    // Signature changes → memo lets the repaint through.
+    rerender(rowMarkup(b, "SIG-2"));
+    expect(screen.getByRole("link", { name: "Beta" })).toBeTruthy();
   });
 });

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -12,7 +12,7 @@
  * `prefers-reduced-motion` setting.
  */
 
-import { useEffect, useId, useRef, useState } from "react";
+import { memo, useEffect, useId, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 import type { ProcessRowResponse, StaleReason } from "@/api/types";
@@ -27,6 +27,18 @@ import {
 
 export interface ProcessRowProps {
   readonly row: ProcessRowResponse;
+  // Content signature computed by the parent (`processRowSignature`).
+  // Drives the `React.memo` skip decision (#1480): each poll hands the
+  // table a fresh JSON snapshot, so every `row` object has a new
+  // identity even when nothing changed. A reference compare would
+  // repaint all 40 rows every tick (visible flicker + reflow over
+  // RDP). The signature lets memo repaint only the rows whose rendered
+  // content actually changed. It MUST be a prop (computed at the
+  // parent's render time and stored by React), not recomputed inside
+  // the comparator — the comparator sees `prev`/`next` at the same
+  // instant, so any `Date.now()`-derived term computed there cancels
+  // out and the stuck-process elapsed chip would never advance.
+  readonly signature: string;
   readonly triggerError: unknown;
   readonly cancelError: unknown;
   readonly busy: boolean;
@@ -35,10 +47,46 @@ export interface ProcessRowProps {
   readonly onCancel: (row: ProcessRowResponse) => void;
 }
 
+/**
+ * Stable content signature for a process row (#1480).
+ *
+ * Conservative by design: serialise the whole envelope so any field
+ * change forces a repaint, plus the live elapsed-since-heartbeat label
+ * for stuck rows so the `no progress Nm` chip keeps advancing (it is
+ * the operator's wedge signal — #1474 / #1478) while every quiescent
+ * row stays frozen between polls. Cheap for ~40 small objects per tick.
+ */
+export function processRowSignature(row: ProcessRowResponse): string {
+  const heartbeatBase =
+    row.active_run?.last_progress_at ?? row.active_run?.started_at ?? null;
+  const elapsed =
+    row.stale_reasons.includes("mid_flight_stuck") && heartbeatBase !== null
+      ? formatElapsedSince(heartbeatBase)
+      : "";
+  return `${JSON.stringify(row)}|${elapsed}`;
+}
+
+function arePropsEqual(prev: ProcessRowProps, next: ProcessRowProps): boolean {
+  // `onIterate` / `onFullWash` / `onCancel` are stable refs from the
+  // parent (useCallback / useState setters) — compared by reference so
+  // a future regression that passes an inline arrow re-renders rather
+  // than silently going stale. `triggerError` / `cancelError` are
+  // mutation-only (unchanged across polls) — reference compare is right.
+  return (
+    prev.signature === next.signature &&
+    prev.busy === next.busy &&
+    prev.triggerError === next.triggerError &&
+    prev.cancelError === next.cancelError &&
+    prev.onIterate === next.onIterate &&
+    prev.onFullWash === next.onFullWash &&
+    prev.onCancel === next.onCancel
+  );
+}
+
 const PENDING_RETRY_TOOLTIP =
   "hiding prior errors during retry — re-shown if retry also fails or fails to reattempt failed subjects.";
 
-export function ProcessRow({
+function ProcessRowImpl({
   row,
   triggerError,
   cancelError,
@@ -226,6 +274,14 @@ export function ProcessRow({
     </tr>
   );
 }
+
+/**
+ * Memoised row. Repaints only when `arePropsEqual` returns false —
+ * i.e. when the content signature, busy flag, or an error ref changes.
+ * Polls that return an unchanged snapshot are a no-op at the DOM layer,
+ * which is what kills the per-tick flicker + reflow (#1480).
+ */
+export const ProcessRow = memo(ProcessRowImpl, arePropsEqual);
 
 function StaleChips({ row }: { row: ProcessRowResponse }) {
   // Stale-reason chips (PR8 / #1083). One subtle pill per reason;

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -28,7 +28,7 @@ import type {
 import { Modal } from "@/components/ui/Modal";
 
 import { LaneFilter } from "@/components/admin/LaneFilter";
-import { ProcessRow } from "@/components/admin/ProcessRow";
+import { ProcessRow, processRowSignature } from "@/components/admin/ProcessRow";
 import { StaleBanner } from "@/components/admin/StaleBanner";
 import {
   STATUS_SORT_PRIORITY,
@@ -272,12 +272,21 @@ export function ProcessesTable({
                 <ProcessRow
                   key={row.process_id}
                   row={row}
+                  // Content hash computed here (parent render time) so
+                  // React.memo can skip unchanged rows on every poll
+                  // (#1480). Must be a prop, not recomputed in the
+                  // comparator — see ProcessRow `processRowSignature`.
+                  signature={processRowSignature(row)}
                   triggerError={rowErrors[row.process_id]?.trigger}
                   cancelError={rowErrors[row.process_id]?.cancel}
                   busy={busyId === row.process_id}
                   onIterate={handleIterate}
-                  onFullWash={(r) => setFullWashTarget(r)}
-                  onCancel={(r) => setCancelTarget(r)}
+                  // Pass the state setters directly — they are stable
+                  // across renders, so memo's reference compare holds.
+                  // An inline `(r) => setFullWashTarget(r)` would mint a
+                  // fresh fn each render and defeat the memo (#1480).
+                  onFullWash={setFullWashTarget}
+                  onCancel={setCancelTarget}
                 />
               ))}
             </tbody>

--- a/frontend/src/components/admin/a11y.test.tsx
+++ b/frontend/src/components/admin/a11y.test.tsx
@@ -35,7 +35,7 @@ import {
   makeProcessList,
   makeProcessRow,
 } from "@/components/admin/__fixtures__/processes";
-import { ProcessRow } from "@/components/admin/ProcessRow";
+import { ProcessRow, processRowSignature } from "@/components/admin/ProcessRow";
 import { ProcessesTable } from "@/components/admin/ProcessesTable";
 import { StaleBanner } from "@/components/admin/StaleBanner";
 
@@ -71,6 +71,7 @@ function renderRow(props: Partial<Parameters<typeof ProcessRow>[0]> = {}) {
         <tbody>
           <ProcessRow
             row={row}
+            signature={processRowSignature(row)}
             triggerError={undefined}
             cancelError={undefined}
             busy={false}

--- a/frontend/src/lib/useProcesses.test.ts
+++ b/frontend/src/lib/useProcesses.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -6,6 +6,8 @@ import { fetchProcesses } from "@/api/processes";
 import {
   POLL_INTERVAL_IDLE_MS,
   POLL_INTERVAL_RUNNING_MS,
+  SLOW_LINK_BACKOFF,
+  SLOW_LINK_THRESHOLD_MS,
   useProcesses,
 } from "@/lib/useProcesses";
 import {
@@ -33,7 +35,16 @@ beforeEach(() => {
 
 afterEach(() => {
   setIntervalSpy.mockRestore();
+  setDocumentHidden(false);
+  vi.restoreAllMocks();
 });
+
+function setDocumentHidden(hidden: boolean): void {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+}
 
 function setIntervalCalledWith(delay: number): boolean {
   // testing-library's `waitFor` also calls setInterval at 50ms; filter
@@ -91,6 +102,65 @@ describe("useProcesses cadence", () => {
     );
     await waitFor(() =>
       expect(setIntervalCalledWith(POLL_INTERVAL_IDLE_MS)).toBe(true),
+    );
+  });
+});
+
+describe("useProcesses visibility pause (#1480)", () => {
+  it("does not arm a poll timer while the document is hidden", async () => {
+    setDocumentHidden(true);
+    mockedFetch.mockResolvedValue(
+      makeProcessList([makeProcessRow({ status: "ok" })]),
+    );
+    const { result } = renderHook(() => useProcesses());
+    // The initial mount fetch still runs; only the recurring timer is
+    // suppressed while hidden.
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(setIntervalCalledWith(POLL_INTERVAL_IDLE_MS)).toBe(false);
+    expect(setIntervalCalledWith(POLL_INTERVAL_RUNNING_MS)).toBe(false);
+  });
+
+  it("resumes and fires a catch-up refetch when the tab becomes visible", async () => {
+    setDocumentHidden(true);
+    mockedFetch.mockResolvedValue(
+      makeProcessList([makeProcessRow({ status: "ok" })]),
+    );
+    const { result } = renderHook(() => useProcesses());
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    const callsWhileHidden = mockedFetch.mock.calls.length;
+
+    setDocumentHidden(false);
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() =>
+      expect(setIntervalCalledWith(POLL_INTERVAL_IDLE_MS)).toBe(true),
+    );
+    // Becoming visible triggers an immediate catch-up fetch so the
+    // operator does not stare at a stale frame on return.
+    expect(mockedFetch.mock.calls.length).toBeGreaterThan(callsWhileHidden);
+  });
+});
+
+describe("useProcesses slow-link backoff (#1480)", () => {
+  it("multiplies the cadence after a fetch exceeds the slow-link threshold", async () => {
+    // Drive a deterministic clock: each fetch advances it past the
+    // threshold so the measured round-trip reads as slow.
+    let clock = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => clock);
+    mockedFetch.mockImplementation(async () => {
+      clock += SLOW_LINK_THRESHOLD_MS + 1;
+      return makeProcessList([makeProcessRow({ status: "ok" })]);
+    });
+
+    const { result } = renderHook(() => useProcesses());
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+
+    await waitFor(() =>
+      expect(
+        setIntervalCalledWith(POLL_INTERVAL_IDLE_MS * SLOW_LINK_BACKOFF),
+      ).toBe(true),
     );
   });
 });

--- a/frontend/src/lib/useProcesses.ts
+++ b/frontend/src/lib/useProcesses.ts
@@ -3,7 +3,11 @@
  *
  * Cadence:
  *   - 5s while ANY row is `running` (operator wants near-live progress).
- *   - 30s otherwise (cheap background poll).
+ *   - 60s otherwise (cheap background poll).
+ *   - ×3 on a degraded link (see SLOW_LINK_BACKOFF) so a high-latency
+ *     RDP / VPN session does not queue overlapping polls.
+ *   - paused entirely while the tab/window is hidden; resumed with an
+ *     immediate catch-up refetch on return (#1480).
  *
  * The cadence flip is derived from `data.rows.some(r => r.status === "running")`.
  * On a status transition (running → ok, etc.) the interval resets to the
@@ -11,10 +15,12 @@
  * `AdminPage.tsx` so a flip mid-cycle does not double-fire or drop ticks.
  *
  * Stale-while-revalidate via `useAsync({ preserveOnRefetch: true })` —
- * polling does not flicker the table to a skeleton.
+ * polling does not flicker the table to a skeleton. Row-level repaint is
+ * gated separately by `React.memo` on a content signature (#1480) so an
+ * unchanged poll is a no-op at the DOM layer.
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchProcesses } from "@/api/processes";
 import type { AsyncState } from "@/lib/useAsync";
@@ -22,31 +28,86 @@ import { useAsync } from "@/lib/useAsync";
 import type { ProcessListResponse } from "@/api/types";
 
 export const POLL_INTERVAL_RUNNING_MS = 5_000;
-export const POLL_INTERVAL_IDLE_MS = 30_000;
+export const POLL_INTERVAL_IDLE_MS = 60_000;
+
+// A round-trip slower than this marks the link as degraded; the poll
+// cadence is multiplied by SLOW_LINK_BACKOFF until a fast fetch clears
+// the flag. Stops a high-latency session from arming a 5s timer it can
+// never keep up with (#1480).
+export const SLOW_LINK_THRESHOLD_MS = 2_000;
+export const SLOW_LINK_BACKOFF = 3;
 
 export type UseProcessesResult = AsyncState<ProcessListResponse>;
 
+function isDocumentHidden(): boolean {
+  return typeof document !== "undefined" && document.hidden;
+}
+
 export function useProcesses(): UseProcessesResult {
-  const state = useAsync(fetchProcesses, [], { preserveOnRefetch: true });
+  const [slowLink, setSlowLink] = useState(false);
+
+  // Measure round-trip latency around each fetch. `setSlowLink` is a
+  // no-op when the boolean is unchanged (React bails on identical
+  // state), so this only triggers a re-render when the link crosses the
+  // threshold — not on every poll.
+  //
+  // `useAsync` does not abort an in-flight request when a newer refetch
+  // fires (it only ignores the stale *data* via its cancelled flag), so
+  // requests can overlap. Guard the latency side effect with a sequence
+  // counter — only the most-recently-STARTED request may update the
+  // flag, so a slow stale request finishing after a fast newer one
+  // cannot back off the cadence on obsolete timing (Codex ckpt-2).
+  const fetchSeqRef = useRef(0);
+  const measuredFetch = useCallback(async () => {
+    const seq = ++fetchSeqRef.current;
+    const startedAt = performance.now();
+    try {
+      return await fetchProcesses();
+    } finally {
+      if (seq === fetchSeqRef.current) {
+        setSlowLink(performance.now() - startedAt > SLOW_LINK_THRESHOLD_MS);
+      }
+    }
+  }, []);
+
+  const state = useAsync(measuredFetch, [], { preserveOnRefetch: true });
 
   const anyRunning =
     state.data?.rows.some((r) => r.status === "running") ?? false;
-  const interval = anyRunning
+  const baseInterval = anyRunning
     ? POLL_INTERVAL_RUNNING_MS
     : POLL_INTERVAL_IDLE_MS;
+  const interval = slowLink ? baseInterval * SLOW_LINK_BACKOFF : baseInterval;
 
-  // Keep `refetch` in a ref so the timer does not re-arm on every
-  // render — only when the cadence itself changes (running ↔ idle
-  // transition). Mirrors AdminPage.tsx's ref-based interval pattern.
+  // Keep `refetch` in a ref so the timer + visibility listener do not
+  // re-arm on every render — only when the cadence itself changes
+  // (running ↔ idle, slow ↔ fast, hidden ↔ visible).
   const refetchRef = useRef(state.refetch);
   useEffect(() => {
     refetchRef.current = state.refetch;
   }, [state.refetch]);
 
+  // Pause polling while the tab/window is hidden; resume + catch up on
+  // return. No point spending fetches (or repainting) a surface the
+  // operator cannot see, and the catch-up refetch means the first thing
+  // they see on return is fresh, not a stale frame (#1480).
+  const [visible, setVisible] = useState(() => !isDocumentHidden());
   useEffect(() => {
+    function onVisibilityChange() {
+      const nowVisible = !isDocumentHidden();
+      setVisible(nowVisible);
+      if (nowVisible) refetchRef.current();
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return; // hidden — do not arm a timer
     const id = window.setInterval(() => refetchRef.current(), interval);
     return () => window.clearInterval(id);
-  }, [interval]);
+  }, [interval, visible]);
 
   return state;
 }


### PR DESCRIPTION
## What
Fixes #1480 — the Admin **Processes / control hub** flickered on every poll (whole-list repaint + minor layout shift, bad over RDP / high-latency links).

## Why
`useProcesses` self-polls and `useAsync` replaces the whole snapshot each tick. `useAsync({ preserveOnRefetch: true })` already avoids the skeleton flash, but the churn was at the **row level**: each poll is a fresh JSON parse, so every `row` object has a new identity → all ~40 `<ProcessRow>` repaint every tick. Two inline-arrow callbacks (`onFullWash`/`onCancel`) would also defeat any `React.memo`.

## Changes
- **ProcessRow** wrapped in `React.memo` gated on a parent-computed content signature (`processRowSignature`) plus `busy` / error refs. An unchanged poll is now a DOM no-op.
  - Signature is **conservative** (serialises the row) and includes the **live elapsed label for `mid_flight_stuck` rows**, so the wedge indicator (#1474 / #1478) keeps advancing while every quiescent row stays frozen.
  - Signature is a **prop** (computed at parent render time, stored by React), not recomputed in the comparator — the comparator sees `prev`/`next` at the same instant, so a `Date.now()`-derived term there would cancel and the stuck-clock would never advance.
- **ProcessesTable** passes `signature`; replaces inline `onFullWash`/`onCancel` arrows with the stable `useState` setters (inline arrows mint a fresh fn each render and defeat the memo).
- **useProcesses** cadence hardening:
  - **Pause** polling while the tab/window is hidden; **resume + one catch-up refetch** on return.
  - **Slow-link backoff ×3** once a round-trip exceeds 2s; self-healing on the next fast fetch. Latency side effect guarded by a fetch-sequence counter so an overlapping stale request can't back off on obsolete timing.
  - Idle cadence 30s → 60s (slower default); running stays 5s (near-live progress + drives the stuck clock).

Layout shift: the pulsing left border already reserves 4px (`border-l-4 border-l-transparent` when idle), so no per-poll width shift. With memo, unchanged rows produce zero DOM mutation per tick — the reflow source is gone. Chips mount/unmount only on a genuine stale transition, not on every poll.

## Security model
No security surface. Frontend-only, read + operator-trigger plumbing unchanged. No auth/token handling touched. No backend / API / response-model changes (`types.ts` untouched).

## Test
- `pnpm --dir frontend typecheck` — clean.
- `pnpm --dir frontend test:unit` — 897 passing (86 files).
- `pnpm --dir frontend dark:check` — no violations.
- New tests: `processRowSignature` determinism + field-sensitivity + stuck-row elapsed term; `React.memo` skips repaint on equal signature despite new row object and repaints on signature change; visibility pause (no timer while hidden) + catch-up refetch on resume; slow-link backoff multiplies cadence.

## Codex
Checkpoint-2 (pre-push) flagged the slow-link side effect landing out of order across overlapping `useAsync` requests — fixed with the fetch-sequence guard (latest-started wins) before first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
