### PR TITLE
feat(#1512): collapse Processes row status to one computed health verdict

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -62,6 +62,7 @@ from app.services.process_stop import (
 from app.services.processes import (
     ActiveRunSummary,
     ErrorClassSummary,
+    HealthVerdict,
     ProcessLane,
     ProcessMechanism,
     ProcessRow,
@@ -75,6 +76,7 @@ from app.services.processes import (
     ingest_sweep_adapter,
     scheduled_adapter,
 )
+from app.services.processes.health_verdict import compute_verdict
 from app.services.processes.ingest_sweep_adapter import is_sweep
 from app.services.processes.param_metadata import ParamMetadata
 from app.services.processes.stale_thresholds import get_threshold
@@ -167,6 +169,15 @@ class ProcessRowResponse(BaseModel):
     can_cancel: bool
     last_n_errors: list[ErrorClassSummaryResponse]
     stale_reasons: list[StaleReason]
+    # #1512 — single computed health verdict collapsing the ``status`` +
+    # ``stale_reasons`` axes. The FE main row renders this pill (not the
+    # two raw axes), so contradictory combos ("ok + schedule_missed")
+    # are impossible by construction. ``status`` + ``stale_reasons`` stay
+    # on the payload (non-breaking — drill-in + tests still read them).
+    # ``verdict_reason`` is the inline explanation (folds #1230).
+    health_verdict: HealthVerdict
+    self_healing: bool
+    verdict_reason: str
     # PR2 #1064 — operator-exposable params for the Advanced disclosure
     # tab on /admin/processes/{id}. Empty list for bootstrap +
     # ingest_sweep mechanisms; non-empty only for scheduled jobs that
@@ -406,6 +417,10 @@ def _convert_error(err: ErrorClassSummary) -> ErrorClassSummaryResponse:
 
 
 def _convert_row(row: ProcessRow) -> ProcessRowResponse:
+    verdict, self_healing, verdict_reason = compute_verdict(
+        status=row.status,
+        stale_reasons=row.stale_reasons,
+    )
     return ProcessRowResponse(
         process_id=row.process_id,
         display_name=row.display_name,
@@ -423,6 +438,9 @@ def _convert_row(row: ProcessRow) -> ProcessRowResponse:
         can_cancel=row.can_cancel,
         last_n_errors=[_convert_error(e) for e in row.last_n_errors],
         stale_reasons=list(row.stale_reasons),
+        health_verdict=verdict,
+        self_healing=self_healing,
+        verdict_reason=verdict_reason,
         params_metadata=list(row.params_metadata),
         description=row.description,
     )

--- a/app/services/processes/__init__.py
+++ b/app/services/processes/__init__.py
@@ -44,11 +44,17 @@ ProcessStatus = Literal[
     "running",
     "ok",
     "failed",
-    "stale",
     "pending_retry",
     "cancelled",
     "disabled",
 ]
+
+# #1512 — single computed health verdict that collapses the two
+# orthogonal axes (``status`` + ``stale_reasons``) the operator used to
+# see rendered side-by-side as contradictory chips. Derived (not stored)
+# at the API layer (``app/api/processes.py::_convert_row`` →
+# ``health_verdict.compute_verdict``). The FE renders ONE verdict pill.
+HealthVerdict = Literal["current", "working", "self_healing", "attention"]
 
 RunStatus = Literal["success", "failure", "partial", "cancelled", "skipped"]
 
@@ -216,6 +222,7 @@ class ProcessSnapshot:
 __all__ = [
     "ActiveRunSummary",
     "ErrorClassSummary",
+    "HealthVerdict",
     "ProcessLane",
     "ProcessMechanism",
     "ProcessRow",

--- a/app/services/processes/health_verdict.py
+++ b/app/services/processes/health_verdict.py
@@ -1,0 +1,134 @@
+"""Pure-logic single health verdict for the admin Processes page.
+
+Issue #1512 (umbrella #1508). Spec:
+``docs/specs/ui/2026-06-06-process-health-verdict.md``.
+
+The shipped model rendered two orthogonal axes per row — the
+``ProcessStatus`` pill (*did the last terminal run succeed?*) and the
+``stale_reasons`` chips (*is it overdue / behind right now?*) — and the
+operator saw their product, producing contradictory rows like
+``ok + schedule_missed`` or ``idle + schedule_missed``. This module
+collapses both axes into ONE precedence-ordered verdict so a row can
+never display two cells that disagree (contradiction-free *by
+construction*).
+
+Computed (not stored) at the API layer — see
+``app/api/processes.py::_convert_row`` — which is the single choke point
+all three adapters' rows flow through, so no adapter changes are needed.
+
+**Load-bearing invariant (Codex ckpt-1):** an actionable stale reason
+must NEVER be masked by a status. Only the global kill switch
+(``status == "disabled"``) outranks a stale reason; every other status
+is evaluated *after* the stale check. Without this, ``running +
+queue_stuck`` would render blue "working" while a worker is wedged, and
+``pending_retry + queue_stuck`` would render "self-healing" while a
+dispatched request is stuck — re-introducing the masking the verdict
+exists to kill.
+
+**v1 scope:** T3 (retry/``next_retry_at``), T4 (watchdog re-enqueue) and
+T5 (post-bootstrap seed + watermark look-through) are not yet landed, so
+the only ``self_healing`` source is the existing ``pending_retry``
+status. An overdue row with no recovery mechanism reads **attention** —
+honest, because it currently IS stuck (the bug #1511 fixes). When
+T3/T4/T5 land they extend this function (add ``next_retry_at`` /
+liveness inputs) to reclassify *covered* overdue rows from ``attention``
+to ``self_healing`` with a "will retry HH:MM" reason.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from app.services.processes import (
+    HealthVerdict,
+    ProcessStatus,
+    StaleReason,
+)
+
+# All four stale reasons are actionable in v1 (none auto-recovers yet).
+ACTIONABLE_STALE: Final[frozenset[StaleReason]] = frozenset(
+    {"schedule_missed", "watermark_gap", "queue_stuck", "mid_flight_stuck"}
+)
+
+# Stable order for picking the headline reason when several fire at once.
+_REASON_ORDER: Final[tuple[StaleReason, ...]] = (
+    "schedule_missed",
+    "watermark_gap",
+    "queue_stuck",
+    "mid_flight_stuck",
+)
+
+_REASON_LABEL: Final[dict[StaleReason, str]] = {
+    "schedule_missed": "schedule missed",
+    "watermark_gap": "source has fresh data",
+    "queue_stuck": "queue stuck",
+    "mid_flight_stuck": "no progress",
+}
+
+
+def compute_verdict(
+    *,
+    status: ProcessStatus,
+    stale_reasons: tuple[StaleReason, ...],
+) -> tuple[HealthVerdict, bool, str]:
+    """Collapse ``status`` + ``stale_reasons`` into one verdict.
+
+    Returns ``(verdict, self_healing, verdict_reason)``:
+
+    * ``verdict`` — ``current`` (green, fresh) / ``working`` (blue,
+      progressing) / ``self_healing`` (amber, auto-recovering, no action
+      needed) / ``attention`` (red, operator must act).
+    * ``self_healing`` — convenience boolean (``verdict == "self_healing"``
+      today; kept distinct so T3/T4 can flag a row that is *both*
+      surfaced and recovering).
+    * ``verdict_reason`` — short inline copy (folds #1230). Empty string
+      for ``current`` / plain ``working`` where no explanation helps.
+
+    Precedence (first match wins) — see the spec's mapping table:
+    """
+    # ``_REASON_ORDER`` IS exactly the actionable set (all four reasons),
+    # in fixed display order — so the headline is the first listed reason
+    # that fired.
+    actionable: list[StaleReason] = [r for r in _REASON_ORDER if r in stale_reasons]
+
+    # 1. Kill switch — global, deliberate, outranks everything (incl. a
+    #    stale reason that may still compute on a halted job).
+    if status == "disabled":
+        return ("attention", False, "kill switch active")
+
+    # 2. Any actionable stale reason — surfaced before any non-disabled
+    #    status so it can never be masked. Verdict is attention; only the
+    #    headline reason text varies by usefulness.
+    if actionable:
+        if status == "failed":
+            reason = "last run failed"
+        elif status == "running" and "mid_flight_stuck" in actionable:
+            reason = "running but no progress"
+        else:
+            reason = _REASON_LABEL[actionable[0]]
+        return ("attention", False, reason)
+
+    # 3-9. Status-only (no actionable stale).
+    if status == "running":
+        return ("working", False, "")
+    if status == "pending_retry":
+        return ("self_healing", True, "retry scheduled")
+    if status == "failed":
+        return ("attention", False, "last run failed")
+    if status == "cancelled":
+        return ("attention", False, "last run cancelled")
+    if status == "pending_first_run":
+        return ("working", False, "first run pending")
+    if status == "ok":
+        return ("current", False, "")
+    if status == "idle":
+        # Last terminal run was 'skipped' (prerequisite/gate not met) and
+        # nothing is overdue — benign.
+        return ("current", False, "")
+
+    # Fallback — unreachable given the ProcessStatus Literal; guards
+    # against silent drift if a new status is added without a mapping.
+    return ("attention", False, "unknown state")
+
+
+__all__ = ["ACTIONABLE_STALE", "compute_verdict"]

--- a/docs/specs/ui/2026-06-06-process-health-verdict.md
+++ b/docs/specs/ui/2026-06-06-process-health-verdict.md
@@ -1,0 +1,130 @@
+# #1512 — single health verdict (computed layer over status + stale_reasons)
+
+> **Status:** SPEC v1 2026-06-06. Child of epic #1508. Evolves `docs/proposals/ui/admin-processes-self-healing-health.md` §1. Subsumes #1489; folds #1230.
+
+## 1. Problem
+
+Each Processes row renders **two orthogonal axes** and the operator sees their product:
+
+- `ProcessStatus` pill (`scheduled_adapter._status_for` etc.) — `ok` = *last terminal run succeeded*, independent of staleness.
+- `stale_reasons` chips (`stale_detection.compute`) — *overdue / behind right now*.
+
+Contradictory combos (verified dev 2026-06-06): `ok`+`schedule_missed` (monitor_positions, sec_per_cik_poll), `idle`+`schedule_missed` (ownership_observations_sync, cusip_extid_sweep), `ok`+`watermark_gap` (sec_filing_documents_ingest + 4 sweeps). To the operator: "which is it?"
+
+## 2. Design — one computed verdict, non-breaking
+
+Add a **computed** `health_verdict` + `self_healing` + `verdict_reason` to `ProcessRow`, derived from the existing `status` + `stale_reasons`. **Keep the underlying enums + adapters + tests** (reuse, non-breaking). The FE renders the verdict pill, not the two raw axes.
+
+```
+HealthVerdict = Literal["current", "working", "self_healing", "attention"]
+```
+
+| Verdict | Tone | Means | Operator action |
+|---|---|---|---|
+| **Current** | green | fresh / on-cadence / gated-benign | none |
+| **Working** | blue | actively running, progressing | none |
+| **Self-healing** | amber | failed/overdue **and** auto-recovery in flight | none — "will retry HH:MM" |
+| **Needs attention** | red | won't auto-recover | act |
+
+### 2.1 Pure function
+
+New module `app/services/processes/health_verdict.py`:
+
+```python
+def compute_verdict(
+    *,
+    status: ProcessStatus,
+    stale_reasons: tuple[StaleReason, ...],
+    mechanism: ProcessMechanism,
+) -> tuple[HealthVerdict, bool, str]:
+    """Return (verdict, self_healing, verdict_reason). Pure; table-tested."""
+```
+
+Called once centrally in `app/api/processes.py::_convert_row` (the single choke point all three adapters flow through) so no adapter changes are needed for v1. Inputs available there today: `row.status`, `row.stale_reasons`, `row.mechanism`.
+
+> **First cut scope.** T3 (retry/`next_retry_at`) / T4 (watchdog re-enqueue) / T5 (post-bootstrap seed+kick) are NOT yet landed. So v1 has no `next_retry_at` signal: the only `self_healing` source is the existing `pending_retry` status. When T3/T4/T5 land they extend `compute_verdict` (add `next_retry_at` / liveness inputs) to reclassify *covered* overdue rows from `attention` → `self_healing` with a "will retry HH:MM" reason. v1 is deliberately conservative: an overdue row with no recovery mechanism reads **attention** (honest — it IS currently stuck; that is the bug #1511 fixes).
+
+### 2.2 Verdict mapping (precedence top→bottom, first match wins)
+
+`ACTIONABLE_STALE = {schedule_missed, watermark_gap, queue_stuck, mid_flight_stuck}` (all four actionable in v1).
+
+**Key invariant (Codex ckpt-1 fix):** an actionable stale reason must NEVER be masked by a status. So `disabled` (kill switch, global) is the only thing that beats stale; every other status is evaluated *after* the stale check. This closes the `running+queue_stuck → working` and `pending_retry+queue_stuck → self_healing` masking gaps Codex flagged.
+
+| # | Condition | verdict | self_healing | reason |
+|---|---|---|---|---|
+| 1 | `status == disabled` | attention | F | "kill switch active" |
+| 2 | any reason in `ACTIONABLE_STALE` | attention | F | *headline* (see below) |
+| 3 | `status == running` | working | F | "" |
+| 4 | `status == pending_retry` | self_healing | T | "retry scheduled" |
+| 5 | `status == failed` | attention | F | "last run failed" |
+| 6 | `status == cancelled` | attention | F | "last run cancelled" |
+| 7 | `status == pending_first_run` | working | F | "first run pending" |
+| 8 | `status == ok` | current | F | "" |
+| 9 | `status == idle` | current | F | "" (gated — prerequisite not met) |
+| — | fallback (unreachable) | attention | F | "unknown state" |
+
+**Row 2 headline** (verdict is `attention` regardless; only the reason text differs, picked by usefulness):
+- `status == failed` → "last run failed"
+- `status == running` and `mid_flight_stuck` → "running but no progress"
+- else → label of the first reason in fixed order (`schedule_missed` → `watermark_gap` → `queue_stuck` → `mid_flight_stuck`).
+
+**Reachability (not all 9×16 combos occur — mapping is total/defensive anyway):** `stale_detection.compute` makes `schedule_missed`/`watermark_gap` impossible while `running`; `mid_flight_stuck` only while `running`; bootstrap emits only `queue_stuck`/`mid_flight_stuck`; ingest sweeps emit only `disabled/running/failed/ok` + `watermark_gap`. The table is keyed on status with the stale-set checked as a whole, so unreachable combos cost nothing and the fallback guards drift.
+
+Notes on judgment cells (Codex ckpt-1 confirmed sound):
+
+- **disabled (kill switch)** → `attention`. Global kill-switch is deliberate, but per-row it is the honest "this is not running and won't until you act" signal. #1513 header dedupes it into one banner; the per-row verdict stays honest. *(Alternative: a 5th neutral `paused` verdict — rejected to keep the agreed 4-bucket model.)*
+- **cancelled** → `attention`. A cancelled run left no fresh data and nothing is re-running it; operator chose to cancel, so surfacing it is honest, not noise.
+- **pending_first_run** → `working` (not `current`: it has no data yet; not `attention`: it is expected to fire at its first slot). T5 look-through will flip bootstrap-covered rows whose source watermark is fresh → `current`.
+- **idle** (last terminal = `skipped`/gated) → `current` when no actionable stale. The contradictory `idle`+`schedule_missed` combo is resolved by row 6 (→ attention) *before* row 10 is reached. This is the catch-up-trap surface; #1511 fixes the underlying stuck-ness, after which the row stops being `schedule_missed`.
+
+Contradiction-free **by construction**: every row matches exactly one precedence row → one verdict, one reason.
+
+### 2.3 Remove dead `stale` literal
+
+`ProcessStatus` includes `"stale"` which is **never set** by any adapter (verified: grep shows no `status="stale"` / `return "stale"` assignment). Remove from the `Literal` in `app/services/processes/__init__.py`, the API `ProcessStatus` mirror, FE `STATUS_VISUAL`/`STATUS_SORT_PRIORITY`, and the generated `@/api/types`. Guarded by a grep-based assertion in the table-test.
+
+## 3. API
+
+`app/api/processes.py`:
+- `ProcessRowResponse` gains `health_verdict: HealthVerdict`, `self_healing: bool`, `verdict_reason: str`.
+- `_convert_row` calls `compute_verdict(...)` and sets the three fields.
+- `status` + `stale_reasons` stay on the payload (non-breaking; drill-in / tests still read them; FE main row stops rendering them as pills).
+
+## 4. FE
+
+`frontend/src/api/types.ts` (generated mirror — hand-edit to match BE):
+- Add `HealthVerdict` type + `health_verdict`/`self_healing`/`verdict_reason` to `ProcessRowResponse`.
+- Remove `"stale"` from `ProcessStatus`.
+
+`frontend/src/components/admin/processStatus.ts`:
+- Add `VERDICT_VISUAL: Record<HealthVerdict, StatusVisual>` (label + toneClass + pulse). `working`/`self_healing` pulse; `current`/`attention` static.
+- Add `VERDICT_SORT_PRIORITY: Record<HealthVerdict, number>` (`attention` 0 → `self_healing` 1 → `working` 2 → `current` 3).
+- Remove dead `stale` from `STATUS_VISUAL`; **delete `STATUS_SORT_PRIORITY`** (replaced by verdict sort — its only consumer is `compareRows`). Keep `STATUS_VISUAL` for the drill-in page if it still renders raw status; otherwise prune.
+
+`frontend/src/components/admin/ProcessRow.tsx`:
+- `StatusPill` renders `VERDICT_VISUAL[row.health_verdict]` instead of `STATUS_VISUAL[row.status]`.
+- Replace the `StaleChips` cluster with **one inline `verdict_reason` line** when non-empty (folds #1230 — reason inline, not hover-only). Keep `triggerError`/`cancelError` "trigger rejected" lines but render the reason *category* inline too (#1230 scope).
+- `pulseBorder` keyed off verdict (`self_healing`/`attention`→amber, `working`→sky, else transparent) instead of `stale_reasons.length`.
+- `processRowSignature` serialises the whole row → picks up new fields automatically; keep the `mid_flight_stuck` elapsed term off `active_run`.
+
+`frontend/src/components/admin/ProcessesTable.tsx` (Codex ckpt-1 pt 5 — sequencing):
+- `compareRows` → sort by `VERDICT_SORT_PRIORITY[row.health_verdict]` (drops the `STATUS_SORT_PRIORITY.stale ?? status` two-step that depended on the removed `stale` literal). Tiebreak by `next_fire_at` then `display_name` unchanged.
+
+`frontend/src/components/admin/StaleBanner.tsx` (Codex ckpt-1 pt 6):
+- Rewire off `health_verdict` instead of `stale_reasons`: count `attention` (and, separately, `self_healing`) rows. Banner copy "N need attention · M self-healing", links to the first attention row. Keeps the existing render-nothing-when-clean behaviour. **#1513 expands this into the positive "All systems current" clean-bill header**; #1512 only makes it consistent with the single-axis model (no "stale" language that no longer matches the row pills).
+
+## 5. Tests
+
+- **BE table-test** `tests/services/processes/test_health_verdict.py`: exhaustive over `ProcessStatus × powerset-subset(StaleReason)` asserting (a) exactly one verdict, (b) the mapping table above, (c) no input yields a contradiction, (d) grep-guard that `"stale"` literal is gone.
+- **FE unit** `ProcessRow.test.tsx`: verdict pill renders, inline reason shows, no double-axis pills, sort order.
+- Adapter tests unchanged (enums retained).
+
+## 6. Settled-decision compliance
+
+- Two-axis (control-hub §A1): superseded by computed verdict; underlying enums retained → adapters/tests minimal change.
+- None-vs-skipped (prevention 249): `pending_first_run` stays a distinct verdict input (row 8), not folded into attention.
+- No new universal-gate carve-out (this ticket adds no dispatch path).
+
+## 7. Out of scope
+
+`next_retry_at`-driven self-healing reclassification (#1509/#1510), watermark look-through + post-bootstrap seed (#1511), clean-bill header (#1513). v1 is the contradiction-killing computed layer only.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1172,10 +1172,18 @@ export type ProcessStatus =
   | "running"
   | "ok"
   | "failed"
-  | "stale"
   | "pending_retry"
   | "cancelled"
   | "disabled";
+
+/**
+ * #1512 — single computed health verdict that collapses the two
+ * orthogonal axes (`status` + `stale_reasons`) into one signal. The
+ * main Processes row renders this pill, not the raw axes, so
+ * contradictory combos ("ok + schedule missed") are impossible. Derived
+ * by `app/services/processes/health_verdict.py::compute_verdict`.
+ */
+export type HealthVerdict = "current" | "working" | "self_healing" | "attention";
 
 export type ProcessRunStatus =
   | "success"
@@ -1257,6 +1265,13 @@ export interface ProcessRowResponse {
   can_cancel: boolean;
   last_n_errors: ErrorClassSummaryResponse[];
   stale_reasons: StaleReason[];
+  // #1512 — single computed health verdict + inline reason. The main
+  // row renders `health_verdict`; `status` + `stale_reasons` stay on the
+  // payload for the drill-in. `verdict_reason` is the inline explanation
+  // (folds #1230 — reason visible without hover).
+  health_verdict: HealthVerdict;
+  self_healing: boolean;
+  verdict_reason: string;
   // PR2 #1064 — operator-exposable params for the drill-in Advanced
   // disclosure. Empty list for bootstrap + ingest_sweep mechanisms.
   // Non-empty only for scheduled jobs that declare

--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -151,9 +151,9 @@ describe("ProcessRow", () => {
     expect(screen.queryByText("ConnectionTimeout")).toBeNull();
   });
 
-  it("renders pending_retry tooltip on the status pill", () => {
-    renderRow({ row: makeProcessRow({ status: "pending_retry" }) });
-    const pill = screen.getByText(/pending retry/i);
+  it("renders auto-hide tooltip on the self-healing (pending_retry) pill", () => {
+    renderRow({ row: makeProcessRow({ status: "pending_retry", stale_reasons: [] }) });
+    const pill = screen.getByText(/self-healing/i);
     expect(pill.getAttribute("title")).toContain("hiding");
     expect(pill.getAttribute("title")).toContain("retry");
   });
@@ -177,40 +177,41 @@ describe("ProcessRow", () => {
   });
 
   // ---------------------------------------------------------------------
-  // PR8 (#1083) — four-case stale model chips + pulsing border.
+  // #1512 — single computed verdict pill + one inline reason line.
+  // The two-axis stale chips are gone; an overdue row is one red
+  // "needs attention" pill with an inline reason.
   // ---------------------------------------------------------------------
 
-  it("renders no stale chips when stale_reasons is empty", () => {
+  it("renders no verdict-reason line for a clean (current) row", () => {
     const { container } = renderRow({
       row: makeProcessRow({ status: "ok", stale_reasons: [] }),
     });
-    expect(
-      container.querySelector("[data-testid='stale-chips']"),
-    ).toBeNull();
+    expect(container.querySelector("[data-testid='verdict-reason']")).toBeNull();
+    expect(container.querySelector("[data-testid='stale-chips']")).toBeNull();
   });
 
-  it("renders one chip per stale reason (multiple can fire)", () => {
+  it("renders ONE verdict pill (not two contradictory axes) for ok+overdue", () => {
     const { container } = renderRow({
       row: makeProcessRow({
         status: "ok",
         stale_reasons: ["schedule_missed", "watermark_gap"],
       }),
     });
-    const chips = container.querySelector(
-      "[data-testid='stale-chips']",
+    const pill = container.querySelector(
+      "[data-testid='status-pill']",
     ) as HTMLElement;
-    expect(chips).toBeTruthy();
-    expect(
-      chips.querySelectorAll("[data-stale-reason='schedule_missed']").length,
-    ).toBe(1);
-    expect(
-      chips.querySelectorAll("[data-stale-reason='watermark_gap']").length,
-    ).toBe(1);
-    expect(chips.textContent).toContain("schedule missed");
-    expect(chips.textContent).toContain("source has fresh data");
+    expect(pill.getAttribute("data-verdict")).toBe("attention");
+    expect(pill.textContent?.toLowerCase()).toContain("needs attention");
+    // No second axis — the old stale-chips cluster is gone.
+    expect(container.querySelector("[data-testid='stale-chips']")).toBeNull();
+    const reason = container.querySelector(
+      "[data-testid='verdict-reason']",
+    ) as HTMLElement;
+    // First reason in fixed order wins the headline.
+    expect(reason.textContent).toContain("schedule missed");
   });
 
-  it("mid_flight_stuck chip suffixes elapsed-since-heartbeat", () => {
+  it("mid_flight_stuck verdict-reason suffixes elapsed-since-heartbeat", () => {
     const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
     const { container } = renderRow({
       row: makeProcessRow({
@@ -227,36 +228,37 @@ describe("ProcessRow", () => {
         },
       }),
     });
-    const chip = container.querySelector(
-      "[data-stale-reason='mid_flight_stuck']",
+    const reason = container.querySelector(
+      "[data-testid='verdict-reason']",
     ) as HTMLElement;
-    expect(chip).toBeTruthy();
-    expect(chip.textContent).toMatch(/no progress\s+\d+m/);
+    expect(reason).toBeTruthy();
+    expect(reason.textContent).toMatch(/running but no progress\s+\d+m/);
   });
 
-  it("pulsing amber border applies when stale_reasons non-empty", () => {
+  it("attention verdict paints a red left border", () => {
     const { container } = renderRow({
-      row: makeProcessRow({
-        status: "ok",
-        stale_reasons: ["watermark_gap"],
-      }),
+      row: makeProcessRow({ status: "ok", stale_reasons: ["watermark_gap"] }),
     });
     const tr = container.querySelector("tr") as HTMLElement;
+    expect(tr.className).toContain("border-l-red-500");
+  });
+
+  it("self_healing verdict pulses amber", () => {
+    const { container } = renderRow({
+      row: makeProcessRow({ status: "pending_retry", stale_reasons: [] }),
+    });
+    const tr = container.querySelector("tr") as HTMLElement;
+    expect(tr.className).toContain("border-l-amber-500");
     expect(tr.className).toContain("animate-pulse");
-    expect(tr.className).toContain("motion-reduce:animate-none");
-    expect(tr.className).toContain("border-l-amber-500");
   });
 
-  it("amber stale border outranks sky running border on overlap", () => {
+  it("running (not stuck) pulses sky, not amber", () => {
     const { container } = renderRow({
-      row: makeProcessRow({
-        status: "running",
-        stale_reasons: ["mid_flight_stuck"],
-      }),
+      row: makeProcessRow({ status: "running", stale_reasons: [] }),
     });
     const tr = container.querySelector("tr") as HTMLElement;
-    expect(tr.className).toContain("border-l-amber-500");
-    expect(tr.className).not.toContain("border-l-sky-500");
+    expect(tr.className).toContain("border-l-sky-500");
+    expect(tr.className).not.toContain("border-l-amber-500");
   });
 
   // ---------------------------------------------------------------------
@@ -277,57 +279,14 @@ describe("ProcessRow", () => {
     expect(chip).toHaveAccessibleName("Lane: sec");
   });
 
-  it("status pill's accessible name includes the human label with screen-reader prefix", () => {
+  it("verdict pill's accessible name includes the verdict label with screen-reader prefix", () => {
     const { container } = renderRow({
-      row: makeProcessRow({ status: "running" }),
+      row: makeProcessRow({ status: "running", stale_reasons: [] }),
     });
     const pill = container.querySelector(
       "[data-testid='status-pill']",
     ) as HTMLElement;
-    expect(pill).toHaveAccessibleName("Status: running");
-  });
-
-  it("stale chip's accessible name carries the reason with screen-reader prefix", () => {
-    const { container } = renderRow({
-      row: makeProcessRow({
-        status: "ok",
-        stale_reasons: ["schedule_missed", "queue_stuck"],
-      }),
-    });
-    const scheduleChip = container.querySelector(
-      "[data-stale-reason='schedule_missed']",
-    ) as HTMLElement;
-    const queueChip = container.querySelector(
-      "[data-stale-reason='queue_stuck']",
-    ) as HTMLElement;
-    expect(scheduleChip).toHaveAccessibleName("Stale reason: schedule missed");
-    expect(queueChip).toHaveAccessibleName("Stale reason: queue stuck");
-  });
-
-  it("mid_flight_stuck stale chip's accessible name includes the elapsed suffix", () => {
-    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
-    const { container } = renderRow({
-      row: makeProcessRow({
-        status: "running",
-        stale_reasons: ["mid_flight_stuck"],
-        active_run: {
-          run_id: 99,
-          started_at: fiveMinutesAgo,
-          rows_processed_so_far: 0,
-          progress_units_done: null,
-          progress_units_total: null,
-          last_progress_at: fiveMinutesAgo,
-          is_cancelling: false,
-        },
-      }),
-    });
-    const chip = container.querySelector(
-      "[data-stale-reason='mid_flight_stuck']",
-    ) as HTMLElement;
-    // Visible text is `no progress 5m`; the accessible name layers the
-    // `Stale reason:` prefix on top so a screen reader announces the
-    // full meaning rather than the bare phrase.
-    expect(chip).toHaveAccessibleName(/^Stale reason: no progress\s+\d+m$/);
+    expect(pill).toHaveAccessibleName("Health: working");
   });
 
   // ---------------------------------------------------------------------

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -15,13 +15,12 @@
 import { memo, useEffect, useId, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
-import type { ProcessRowResponse, StaleReason } from "@/api/types";
+import type { ProcessRowResponse } from "@/api/types";
 import { formatDateTime } from "@/lib/format";
 
 import {
   REASON_TOOLTIP,
-  STALE_REASON_LABEL,
-  STATUS_VISUAL,
+  VERDICT_VISUAL,
   reasonTooltip,
 } from "@/components/admin/processStatus";
 
@@ -95,19 +94,20 @@ function ProcessRowImpl({
   onFullWash,
   onCancel,
 }: ProcessRowProps) {
-  const visual = STATUS_VISUAL[row.status];
-  // Pulse precedence (spec §"Visible-motion rules"): stale rows pulse
-  // amber even while running, because mid_flight_stuck overlaps
-  // status="running" by definition. `motion-reduce:animate-none`
-  // keeps the colour but stops the animation for operators with
-  // prefers-reduced-motion (PR8 carve-out from PR9 a11y sweep — avoid
-  // a regression window).
-  const isStale = row.stale_reasons.length > 0;
-  const pulseBorder = isStale
-    ? "border-l-4 border-l-amber-500 animate-pulse motion-reduce:animate-none"
-    : visual.pulse
-      ? "border-l-4 border-l-sky-500 animate-pulse motion-reduce:animate-none"
-      : "border-l-4 border-l-transparent";
+  // Pulse precedence keyed off the single verdict (#1512): self-healing
+  // and attention pulse amber/red (something is recovering or wrong);
+  // working pulses sky (a run is in flight); current is static.
+  // `motion-reduce:animate-none` keeps the colour but stops the
+  // animation for operators with prefers-reduced-motion (PR8 carve-out).
+  const verdict = row.health_verdict;
+  const pulseBorder =
+    verdict === "self_healing"
+      ? "border-l-4 border-l-amber-500 animate-pulse motion-reduce:animate-none"
+      : verdict === "attention"
+        ? "border-l-4 border-l-red-500"
+        : verdict === "working"
+          ? "border-l-4 border-l-sky-500 animate-pulse motion-reduce:animate-none"
+          : "border-l-4 border-l-transparent";
 
   const lastRunLabel = row.last_run
     ? `${formatDateTime(row.last_run.finished_at)} · ${formatDuration(row.last_run.duration_seconds)} · ${
@@ -204,7 +204,7 @@ function ProcessRowImpl({
       </td>
       <td className="px-2 py-2">
         <StatusPill row={row} />
-        {isStale ? <StaleChips row={row} /> : null}
+        <VerdictReason row={row} />
       </td>
       <td className="px-2 py-2 text-xs text-slate-600 dark:text-slate-400">
         {lastRunLabel}
@@ -283,62 +283,40 @@ function ProcessRowImpl({
  */
 export const ProcessRow = memo(ProcessRowImpl, arePropsEqual);
 
-function StaleChips({ row }: { row: ProcessRowResponse }) {
-  // Stale-reason chips (PR8 / #1083). One subtle pill per reason;
-  // mid_flight_stuck includes the elapsed-since-heartbeat suffix
-  // computed from `active_run.last_progress_at` (or `started_at` as
-  // fallback) so the operator sees "no progress 7m" rather than just
-  // "no progress".
+function VerdictReason({ row }: { row: ProcessRowResponse }) {
+  // #1512 — one inline reason line (folds #1230: visible, not hover-only).
+  // For a wedged run we append the live elapsed-since-heartbeat ("running
+  // but no progress 7m") — the operator's wedge signal (#1474 / #1478),
+  // computed client-side from active_run so it keeps advancing between
+  // polls. Empty reason (current / plain working) renders nothing.
+  if (!row.verdict_reason) return null;
   const heartbeatBase =
     row.active_run?.last_progress_at ?? row.active_run?.started_at ?? null;
+  const elapsed =
+    row.stale_reasons.includes("mid_flight_stuck") && heartbeatBase !== null
+      ? ` ${formatElapsedSince(heartbeatBase)}`
+      : "";
   return (
     <div
-      className="mt-1 flex flex-wrap gap-1"
-      data-testid="stale-chips"
+      data-testid="verdict-reason"
+      className="mt-1 text-[11px] text-slate-600 dark:text-slate-400"
     >
-      {row.stale_reasons.map((reason) => (
-        <StaleChip
-          key={reason}
-          reason={reason}
-          heartbeatBase={heartbeatBase}
-        />
-      ))}
+      {row.verdict_reason}
+      {elapsed}
     </div>
   );
 }
 
-function StaleChip({
-  reason,
-  heartbeatBase,
-}: {
-  reason: StaleReason;
-  heartbeatBase: string | null;
-}) {
-  const label = STALE_REASON_LABEL[reason];
-  const text =
-    reason === "mid_flight_stuck" && heartbeatBase !== null
-      ? `${label} ${formatElapsedSince(heartbeatBase)}`
-      : label;
-  return (
-    <span
-      data-stale-reason={reason}
-      aria-label={`Stale reason: ${text}`}
-      className="inline-flex items-center rounded-full border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-200"
-    >
-      {text}
-    </span>
-  );
-}
-
 function StatusPill({ row }: { row: ProcessRowResponse }) {
-  const visual = STATUS_VISUAL[row.status];
-  const tooltip =
-    row.status === "pending_retry" ? PENDING_RETRY_TOOLTIP : undefined;
+  // #1512 — render the single computed verdict, not the raw status.
+  const visual = VERDICT_VISUAL[row.health_verdict];
+  const tooltip = row.self_healing ? PENDING_RETRY_TOOLTIP : undefined;
   return (
     <span
       data-testid="status-pill"
+      data-verdict={row.health_verdict}
       title={tooltip}
-      aria-label={`Status: ${visual.label}`}
+      aria-label={`Health: ${visual.label}`}
       className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${visual.toneClass}`}
     >
       {visual.label}

--- a/frontend/src/components/admin/ProcessesTable.test.tsx
+++ b/frontend/src/components/admin/ProcessesTable.test.tsx
@@ -244,12 +244,16 @@ describe("ProcessesTable", () => {
     expect(links[1]).toBe("A_ok");
   });
 
-  it("failed rows still outrank stale rows", () => {
+  it("#1512: failed and overdue rows are peers (both attention), tie-broken deterministically", () => {
+    // Under the single verdict a failed row and an ok+overdue row both
+    // collapse to `attention` — there is no failed>stale hierarchy any
+    // more. With equal verdict + equal next_fire_at the tiebreak is
+    // display_name, so A_overdue precedes B_failed.
     const { container } = renderTable([
       makeProcessRow({
-        process_id: "stale",
+        process_id: "overdue",
         status: "ok",
-        display_name: "A_stale",
+        display_name: "A_overdue",
         stale_reasons: ["queue_stuck"],
       }),
       makeProcessRow({
@@ -258,11 +262,15 @@ describe("ProcessesTable", () => {
         display_name: "B_failed",
       }),
     ]);
+    const pills = Array.from(
+      container.querySelectorAll("[data-testid='status-pill']"),
+    ).map((p) => p.getAttribute("data-verdict"));
+    expect(pills).toEqual(["attention", "attention"]);
     const links = Array.from(container.querySelectorAll("tbody a")).map(
       (a) => a.textContent ?? "",
     );
-    expect(links[0]).toBe("B_failed");
-    expect(links[1]).toBe("A_stale");
+    expect(links[0]).toBe("A_overdue");
+    expect(links[1]).toBe("B_failed");
   });
 
   // ---------------------------------------------------------------------

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -31,7 +31,7 @@ import { LaneFilter } from "@/components/admin/LaneFilter";
 import { ProcessRow, processRowSignature } from "@/components/admin/ProcessRow";
 import { StaleBanner } from "@/components/admin/StaleBanner";
 import {
-  STATUS_SORT_PRIORITY,
+  VERDICT_SORT_PRIORITY,
   reasonTooltip,
 } from "@/components/admin/processStatus";
 
@@ -323,20 +323,14 @@ export function ProcessesTable({
 }
 
 function compareRows(a: ProcessRowResponse, b: ProcessRowResponse): number {
-  // PR8 (#1083): stale rows float up to just below `failed`. The new
-  // four-case stale model surfaces via `stale_reasons` rather than
-  // flipping `status` to `"stale"`, so the sort must consult the
-  // tuple directly. Codex pre-push WARNING — without this, an `ok` /
-  // `idle` row that goes stale stays buried below `failed` and is
-  // easy to miss despite the chips + banner.
-  const aStale = a.stale_reasons.length > 0;
-  const bStale = b.stale_reasons.length > 0;
-  const sa = aStale
-    ? STATUS_SORT_PRIORITY.stale
-    : (STATUS_SORT_PRIORITY[a.status] ?? 99);
-  const sb = bStale
-    ? STATUS_SORT_PRIORITY.stale
-    : (STATUS_SORT_PRIORITY[b.status] ?? 99);
+  // #1512: sort by the single health verdict — attention floats to the
+  // top, then self-healing, working, current. This replaces the prior
+  // status-based priority + synthetic `stale` rank (the two-axis model
+  // is collapsed into one verdict), so an `ok`/`idle` row that goes
+  // overdue (now verdict=attention) surfaces at the top without a
+  // separate stale-tuple consult.
+  const sa = VERDICT_SORT_PRIORITY[a.health_verdict] ?? 99;
+  const sb = VERDICT_SORT_PRIORITY[b.health_verdict] ?? 99;
   if (sa !== sb) return sa - sb;
   // Failed jobs without a next-fire (one-shot) come after the ones
   // that will actually retry — operator action vs auto-recovery.

--- a/frontend/src/components/admin/StaleBanner.test.tsx
+++ b/frontend/src/components/admin/StaleBanner.test.tsx
@@ -13,24 +13,24 @@ function renderBanner(rows: ReturnType<typeof makeProcessRow>[]) {
   );
 }
 
-describe("StaleBanner", () => {
-  it("renders nothing when no row has stale_reasons", () => {
+describe("StaleBanner (#1512 verdict-driven)", () => {
+  it("renders nothing when every row is current/working", () => {
     const { container } = renderBanner([
-      makeProcessRow({ stale_reasons: [] }),
-      makeProcessRow({ process_id: "b", stale_reasons: [] }),
+      makeProcessRow({ status: "ok", stale_reasons: [] }),
+      makeProcessRow({ process_id: "b", status: "running", stale_reasons: [] }),
     ]);
     expect(container.querySelector("[data-testid='stale-banner']")).toBeNull();
   });
 
-  it("renders when at least one row is stale", () => {
+  it("renders when at least one row needs attention", () => {
     renderBanner([
-      makeProcessRow({ process_id: "a", stale_reasons: [] }),
+      makeProcessRow({ process_id: "a", status: "ok", stale_reasons: [] }),
       makeProcessRow({ process_id: "b", stale_reasons: ["watermark_gap"] }),
     ]);
     expect(screen.getByTestId("stale-banner")).toBeTruthy();
   });
 
-  it("names up to 3 stale process_ids and adds +N more for the rest", () => {
+  it("names up to 3 attention process_ids and adds +N more for the rest", () => {
     renderBanner([
       makeProcessRow({ process_id: "p1", stale_reasons: ["watermark_gap"] }),
       makeProcessRow({ process_id: "p2", stale_reasons: ["watermark_gap"] }),
@@ -38,8 +38,8 @@ describe("StaleBanner", () => {
       makeProcessRow({ process_id: "p4", stale_reasons: ["watermark_gap"] }),
       makeProcessRow({ process_id: "p5", stale_reasons: ["watermark_gap"] }),
     ]);
-    const banner = screen.getByTestId("stale-banner");
-    const text = banner.textContent ?? "";
+    const text = screen.getByTestId("stale-banner").textContent ?? "";
+    expect(text).toContain("5 need attention");
     expect(text).toContain("p1");
     expect(text).toContain("p2");
     expect(text).toContain("p3");
@@ -47,32 +47,32 @@ describe("StaleBanner", () => {
     expect(text).toContain("+2 more");
   });
 
-  it("describes single shared cause when all stale rows share one reason", () => {
+  it("counts self-healing rows separately from attention", () => {
     renderBanner([
       makeProcessRow({ process_id: "a", stale_reasons: ["queue_stuck"] }),
-      makeProcessRow({ process_id: "b", stale_reasons: ["queue_stuck"] }),
+      makeProcessRow({ process_id: "b", status: "pending_retry", stale_reasons: [] }),
     ]);
     const text = screen.getByTestId("stale-banner").textContent ?? "";
-    expect(text).toContain("queue stuck");
+    expect(text).toContain("1 need attention");
+    expect(text).toContain("1 self-healing");
   });
 
-  it("falls back to 'multiple causes' when stale rows have different reasons", () => {
+  it("renders for a self-healing-only snapshot (no attention rows)", () => {
     renderBanner([
-      makeProcessRow({ process_id: "a", stale_reasons: ["watermark_gap"] }),
-      makeProcessRow({ process_id: "b", stale_reasons: ["queue_stuck"] }),
+      makeProcessRow({ process_id: "a", status: "ok", stale_reasons: [] }),
+      makeProcessRow({ process_id: "b", status: "pending_retry", stale_reasons: [] }),
     ]);
     const text = screen.getByTestId("stale-banner").textContent ?? "";
-    expect(text).toContain("multiple causes");
+    expect(text).toContain("1 self-healing");
+    expect(text).not.toContain("need attention");
   });
 
-  it("View link points to the first stale row's drill-in route", () => {
+  it("View link points to the first attention row's drill-in route", () => {
     renderBanner([
-      makeProcessRow({ process_id: "fresh", stale_reasons: [] }),
-      makeProcessRow({ process_id: "stale_one", stale_reasons: ["queue_stuck"] }),
+      makeProcessRow({ process_id: "fresh", status: "ok", stale_reasons: [] }),
+      makeProcessRow({ process_id: "attn_one", stale_reasons: ["queue_stuck"] }),
     ]);
     const link = screen.getByRole("link", { name: /View/ });
-    expect(link.getAttribute("href")).toBe(
-      "/admin/processes/stale_one",
-    );
+    expect(link.getAttribute("href")).toBe("/admin/processes/attn_one");
   });
 });

--- a/frontend/src/components/admin/StaleBanner.tsx
+++ b/frontend/src/components/admin/StaleBanner.tsx
@@ -1,22 +1,20 @@
 /**
- * StaleBanner — at-a-glance stale-process summary above the
- * ProcessesTable (PR8 / #1083, umbrella #1064).
+ * StaleBanner — at-a-glance health summary above the ProcessesTable.
  *
- * Spec: `docs/superpowers/specs/2026-05-08-admin-control-hub-rewrite.md`
- *       §"Stale-detection rule" line 602-604 — banner format pattern;
- *       §A1 four-case stale model (line 11-22) — reason vocabulary.
+ * Originally (PR8 / #1083) driven by `stale_reasons`. Rewired in #1512
+ * to the single computed `health_verdict` so the banner language matches
+ * the row pills (no "stale" vocabulary that no longer appears on rows).
  *
- * The banner is rendered only when at least one row in the snapshot
- * carries non-empty `stale_reasons`. If every row is fresh, the
- * component returns `null` — no layout shift, no empty banner. When
- * all stale rows share one reason, the summary names it; otherwise
- * the copy says "multiple causes".
+ * Renders only when at least one row needs attention or is self-healing.
+ * When every row is `current` / `working` it returns `null` (no layout
+ * shift). #1513 expands this into the positive "All systems current"
+ * clean-bill header; #1512 only keeps it consistent with the
+ * single-axis model.
  */
 
 import { Link } from "react-router-dom";
 
-import type { ProcessRowResponse, StaleReason } from "@/api/types";
-import { STALE_REASON_LABEL } from "@/components/admin/processStatus";
+import type { ProcessRowResponse } from "@/api/types";
 
 const MAX_NAMED_PROCESSES = 3;
 
@@ -25,9 +23,13 @@ export interface StaleBannerProps {
 }
 
 export function StaleBanner({ rows }: StaleBannerProps) {
-  const stale = rows.filter((r) => r.stale_reasons.length > 0);
-  const first = stale[0];
-  if (first === undefined) return null;
+  const attention = rows.filter((r) => r.health_verdict === "attention");
+  const selfHealing = rows.filter((r) => r.health_verdict === "self_healing");
+  if (attention.length === 0 && selfHealing.length === 0) return null;
+
+  // Link target: the first attention row if any, else the first
+  // self-healing row (so "View" always points somewhere useful).
+  const target = attention[0] ?? selfHealing[0];
   return (
     <div
       role="status"
@@ -36,33 +38,34 @@ export function StaleBanner({ rows }: StaleBannerProps) {
       className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
     >
       <span aria-hidden="true">⚠ </span>
-      {formatSummary(stale)}{" "}
-      <Link
-        to={`/admin/processes/${encodeURIComponent(first.process_id)}`}
-        className="ml-1 font-medium underline hover:no-underline"
-      >
-        View
-      </Link>
+      {formatSummary(attention, selfHealing)}{" "}
+      {target ? (
+        <Link
+          to={`/admin/processes/${encodeURIComponent(target.process_id)}`}
+          className="ml-1 font-medium underline hover:no-underline"
+        >
+          View
+        </Link>
+      ) : null}
     </div>
   );
 }
 
-function formatSummary(stale: readonly ProcessRowResponse[]): string {
-  const named = stale.slice(0, MAX_NAMED_PROCESSES).map((r) => r.process_id);
-  const remainder = stale.length - named.length;
-  const suffix = remainder > 0 ? `, +${remainder} more` : "";
-  const cause = describeCause(stale);
-  return `${stale.length} stale (${cause}): ${named.join(", ")}${suffix}.`;
-}
-
-function describeCause(stale: readonly ProcessRowResponse[]): string {
-  const reasons = new Set<StaleReason>();
-  for (const r of stale) {
-    for (const reason of r.stale_reasons) reasons.add(reason);
+function formatSummary(
+  attention: readonly ProcessRowResponse[],
+  selfHealing: readonly ProcessRowResponse[],
+): string {
+  const parts: string[] = [];
+  if (attention.length > 0) {
+    const named = attention
+      .slice(0, MAX_NAMED_PROCESSES)
+      .map((r) => r.process_id);
+    const remainder = attention.length - named.length;
+    const suffix = remainder > 0 ? `, +${remainder} more` : "";
+    parts.push(`${attention.length} need attention: ${named.join(", ")}${suffix}`);
   }
-  if (reasons.size === 1) {
-    const only: StaleReason | undefined = reasons.values().next().value;
-    if (only !== undefined) return STALE_REASON_LABEL[only];
+  if (selfHealing.length > 0) {
+    parts.push(`${selfHealing.length} self-healing`);
   }
-  return "multiple causes";
+  return `${parts.join(" · ")}.`;
 }

--- a/frontend/src/components/admin/__fixtures__/processes.ts
+++ b/frontend/src/components/admin/__fixtures__/processes.ts
@@ -5,14 +5,71 @@
 
 import type {
   ErrorClassSummaryResponse,
+  HealthVerdict,
   ProcessLane,
   ProcessListResponse,
   ProcessRowResponse,
   ProcessStatus,
   ProcessWatermarkResponse,
+  StaleReason,
 } from "@/api/types";
 
 let nextRunId = 1;
+
+const REASON_LABEL: Record<StaleReason, string> = {
+  schedule_missed: "schedule missed",
+  watermark_gap: "source has fresh data",
+  queue_stuck: "queue stuck",
+  mid_flight_stuck: "no progress",
+};
+const REASON_ORDER: StaleReason[] = [
+  "schedule_missed",
+  "watermark_gap",
+  "queue_stuck",
+  "mid_flight_stuck",
+];
+
+/**
+ * Mirror of `app/services/processes/health_verdict.py::compute_verdict`
+ * so fixtures built from `{status, stale_reasons}` carry a coherent
+ * verdict without every test spelling it out. Keep in lock-step with
+ * the BE precedence table (#1512).
+ */
+export function deriveVerdict(
+  status: ProcessStatus,
+  staleReasons: StaleReason[],
+): { health_verdict: HealthVerdict; self_healing: boolean; verdict_reason: string } {
+  const actionable = REASON_ORDER.filter((r) => staleReasons.includes(r));
+  if (status === "disabled")
+    return { health_verdict: "attention", self_healing: false, verdict_reason: "kill switch active" };
+  const headline = actionable[0];
+  if (headline !== undefined) {
+    const reason =
+      status === "failed"
+        ? "last run failed"
+        : status === "running" && actionable.includes("mid_flight_stuck")
+          ? "running but no progress"
+          : REASON_LABEL[headline];
+    return { health_verdict: "attention", self_healing: false, verdict_reason: reason };
+  }
+  switch (status) {
+    case "running":
+      return { health_verdict: "working", self_healing: false, verdict_reason: "" };
+    case "pending_retry":
+      return { health_verdict: "self_healing", self_healing: true, verdict_reason: "retry scheduled" };
+    case "failed":
+      return { health_verdict: "attention", self_healing: false, verdict_reason: "last run failed" };
+    case "cancelled":
+      return { health_verdict: "attention", self_healing: false, verdict_reason: "last run cancelled" };
+    case "pending_first_run":
+      return { health_verdict: "working", self_healing: false, verdict_reason: "first run pending" };
+    case "ok":
+    case "idle":
+      return { health_verdict: "current", self_healing: false, verdict_reason: "" };
+    default:
+      return { health_verdict: "attention", self_healing: false, verdict_reason: "unknown state" };
+  }
+}
 
 export function makeWatermark(
   overrides: Partial<ProcessWatermarkResponse> = {},
@@ -45,6 +102,7 @@ export function makeProcessRow(
 ): ProcessRowResponse {
   const status: ProcessStatus = overrides.status ?? "ok";
   const lane: ProcessLane = overrides.lane ?? "sec";
+  const derived = deriveVerdict(status, overrides.stale_reasons ?? []);
   return {
     process_id: "sec_form4_ingest",
     display_name: "Insider Form 4 ingest",
@@ -72,6 +130,7 @@ export function makeProcessRow(
     can_cancel: false,
     last_n_errors: [],
     stale_reasons: [],
+    ...derived,
     params_metadata: [],
     description: "Operator-facing description for the Insider Form 4 ingest.",
     ...overrides,

--- a/frontend/src/components/admin/processStatus.ts
+++ b/frontend/src/components/admin/processStatus.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  HealthVerdict,
   ProcessStatus,
   StaleReason,
   TriggerConflictReason,
@@ -52,12 +53,6 @@ export const STATUS_VISUAL: Record<ProcessStatus, StatusVisual> = {
     toneClass:
       "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/60 dark:text-red-300",
     pulse: false,
-  },
-  stale: {
-    label: "stale",
-    toneClass:
-      "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-300",
-    pulse: true,
   },
   pending_retry: {
     label: "pending retry",
@@ -146,18 +141,47 @@ export const STALE_REASON_LABEL: Record<StaleReason, string> = {
 };
 
 /**
- * Sort priority: failed/stale first, running next, terminal states by
- * lane order. Spec §"Error display rules" — failed processes float to
- * top so the operator sees them without scrolling.
+ * Visuals for the single computed health verdict (#1512). The main
+ * Processes row renders THIS pill instead of the raw `status` +
+ * `stale_reasons` axes, so the operator never sees two cells that
+ * disagree. `working` / `self_healing` pulse (something is in motion);
+ * `current` / `attention` are static.
  */
-export const STATUS_SORT_PRIORITY: Record<ProcessStatus, number> = {
-  failed: 0,
-  stale: 1,
-  pending_retry: 2,
-  running: 3,
-  cancelled: 4,
-  pending_first_run: 5,
-  idle: 6,
-  ok: 7,
-  disabled: 8,
+export const VERDICT_VISUAL: Record<HealthVerdict, StatusVisual> = {
+  current: {
+    label: "current",
+    toneClass:
+      "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/60 dark:text-emerald-300",
+    pulse: false,
+  },
+  working: {
+    label: "working",
+    toneClass:
+      "border-sky-300 bg-sky-50 text-sky-800 dark:border-sky-800 dark:bg-sky-950/60 dark:text-sky-200",
+    pulse: true,
+  },
+  self_healing: {
+    label: "self-healing",
+    toneClass:
+      "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-300",
+    pulse: true,
+  },
+  attention: {
+    label: "needs attention",
+    toneClass:
+      "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/60 dark:text-red-300",
+    pulse: false,
+  },
+};
+
+/**
+ * Sort priority: attention first so it floats to the top, then
+ * self-healing, working, current last (#1512 — replaces the
+ * status-based STATUS_SORT_PRIORITY + synthetic `stale` priority).
+ */
+export const VERDICT_SORT_PRIORITY: Record<HealthVerdict, number> = {
+  attention: 0,
+  self_healing: 1,
+  working: 2,
+  current: 3,
 };

--- a/tests/services/processes/test_health_verdict.py
+++ b/tests/services/processes/test_health_verdict.py
@@ -1,0 +1,152 @@
+"""Exhaustive table-test for the single health verdict (#1512).
+
+Spec: ``docs/specs/ui/2026-06-06-process-health-verdict.md`` §2.2.
+
+Two guarantees:
+
+1. **Total + contradiction-free.** Over the full ``ProcessStatus`` x
+   every subset of ``StaleReason`` matrix, ``compute_verdict`` returns
+   exactly one verdict from the literal set and never raises — so no
+   input can produce two cells that disagree.
+2. **Mapping correctness.** The precedence table is pinned cell-by-cell,
+   including the Codex-ckpt-1 masking guards (an actionable stale reason
+   is never hidden by ``running`` / ``pending_retry``).
+"""
+
+from __future__ import annotations
+
+import itertools
+import typing
+
+import pytest
+
+from app.services.processes import HealthVerdict, ProcessStatus, StaleReason
+from app.services.processes.health_verdict import ACTIONABLE_STALE, compute_verdict
+
+_ALL_STATUSES: tuple[ProcessStatus, ...] = typing.get_args(ProcessStatus)
+_ALL_REASONS: tuple[StaleReason, ...] = typing.get_args(StaleReason)
+_VALID_VERDICTS: frozenset[HealthVerdict] = frozenset(typing.get_args(HealthVerdict))
+
+
+def _all_reason_subsets() -> list[tuple[StaleReason, ...]]:
+    out: list[tuple[StaleReason, ...]] = []
+    for k in range(len(_ALL_REASONS) + 1):
+        for combo in itertools.combinations(_ALL_REASONS, k):
+            out.append(combo)
+    return out
+
+
+def test_dead_stale_literal_removed() -> None:
+    """The never-set ``stale`` status literal is gone (#1512)."""
+    assert "stale" not in _ALL_STATUSES
+
+
+def test_actionable_stale_is_every_reason() -> None:
+    """v1: all four stale reasons are actionable (none auto-recovers)."""
+    assert ACTIONABLE_STALE == frozenset(_ALL_REASONS)
+
+
+@pytest.mark.parametrize("status", _ALL_STATUSES)
+@pytest.mark.parametrize("reasons", _all_reason_subsets())
+def test_total_and_single_valued(status: ProcessStatus, reasons: tuple[StaleReason, ...]) -> None:
+    """Every (status, reason-subset) yields exactly one valid verdict."""
+    verdict, self_healing, reason = compute_verdict(status=status, stale_reasons=reasons)
+    assert verdict in _VALID_VERDICTS
+    assert isinstance(self_healing, bool)
+    assert isinstance(reason, str)
+    # self_healing is the convenience boolean for the self_healing verdict.
+    assert self_healing == (verdict == "self_healing")
+
+
+@pytest.mark.parametrize("status", _ALL_STATUSES)
+def test_disabled_always_attention(
+    status: ProcessStatus,
+) -> None:
+    """Kill switch (disabled) outranks everything — incl. a stale reason."""
+    if status != "disabled":
+        pytest.skip("only disabled relevant here")
+    for reasons in _all_reason_subsets():
+        verdict, _, reason = compute_verdict(status="disabled", stale_reasons=reasons)
+        assert verdict == "attention"
+        assert reason == "kill switch active"
+
+
+@pytest.mark.parametrize(
+    "status",
+    [s for s in _ALL_STATUSES if s != "disabled"],
+)
+@pytest.mark.parametrize("reason", _ALL_REASONS)
+def test_actionable_stale_never_masked(status: ProcessStatus, reason: StaleReason) -> None:
+    """Codex ckpt-1: any actionable stale reason (on a non-disabled row)
+    forces ``attention`` — never hidden behind ``working`` /
+    ``self_healing`` / ``current``.
+    """
+    verdict, self_healing, _ = compute_verdict(status=status, stale_reasons=(reason,))
+    assert verdict == "attention"
+    assert self_healing is False
+
+
+def test_no_stale_status_mapping() -> None:
+    """Pin the status-only column (no actionable stale reason)."""
+    expected: dict[ProcessStatus, tuple[HealthVerdict, bool]] = {
+        "disabled": ("attention", False),
+        "running": ("working", False),
+        "pending_retry": ("self_healing", True),
+        "failed": ("attention", False),
+        "cancelled": ("attention", False),
+        "pending_first_run": ("working", False),
+        "ok": ("current", False),
+        "idle": ("current", False),
+    }
+    assert set(expected) == set(_ALL_STATUSES)
+    for status, (verdict, self_healing) in expected.items():
+        v, sh, _ = compute_verdict(status=status, stale_reasons=())
+        assert (v, sh) == (verdict, self_healing), status
+
+
+def test_running_with_stuck_headline() -> None:
+    """A running row that is stuck reads 'running but no progress'."""
+    v, _, reason = compute_verdict(status="running", stale_reasons=("mid_flight_stuck",))
+    assert v == "attention"
+    assert reason == "running but no progress"
+
+
+def test_running_with_queue_stuck_not_working() -> None:
+    """The exact masking gap Codex flagged: running + queue_stuck."""
+    v, _, reason = compute_verdict(status="running", stale_reasons=("queue_stuck",))
+    assert v == "attention"
+    assert reason == "queue stuck"
+
+
+def test_pending_retry_with_queue_stuck_not_self_healing() -> None:
+    """Codex gap: pending_retry + queue_stuck must surface, not hide."""
+    v, sh, reason = compute_verdict(status="pending_retry", stale_reasons=("queue_stuck",))
+    assert v == "attention"
+    assert sh is False
+    assert reason == "queue stuck"
+
+
+def test_failed_with_stale_prefers_failure_headline() -> None:
+    """A failed row that is also overdue headlines 'last run failed'."""
+    v, _, reason = compute_verdict(status="failed", stale_reasons=("schedule_missed",))
+    assert v == "attention"
+    assert reason == "last run failed"
+
+
+def test_headline_uses_fixed_reason_order() -> None:
+    """Multiple reasons → first in display order wins the headline."""
+    _, _, reason = compute_verdict(status="ok", stale_reasons=("queue_stuck", "schedule_missed"))
+    assert reason == "schedule missed"
+
+
+def test_ok_overdue_is_attention_not_ok() -> None:
+    """The headline contradiction #1489: ok + schedule_missed → attention."""
+    v, _, reason = compute_verdict(status="ok", stale_reasons=("schedule_missed",))
+    assert v == "attention"
+    assert reason == "schedule missed"
+
+
+def test_idle_overdue_is_attention() -> None:
+    """idle + schedule_missed (catch-up trap surface) → attention."""
+    v, _, _ = compute_verdict(status="idle", stale_reasons=("schedule_missed",))
+    assert v == "attention"


### PR DESCRIPTION
## What
Add a computed, non-breaking **single health verdict** to each admin Processes row, collapsing the two orthogonal axes the operator currently sees side-by-side:
- `ProcessStatus` pill (`ok` = *last terminal run succeeded*)
- `stale_reasons` chips (*overdue / behind right now*)

These render together and contradict — verified live on dev 2026-06-06: `ok`+`schedule_missed`, `idle`+`schedule_missed`, `ok`+`watermark_gap`.

New computed fields on `ProcessRowResponse`: `health_verdict` (`current` | `working` | `self_healing` | `attention`), `self_healing`, `verdict_reason`. The FE renders ONE verdict pill + one inline reason line. Underlying enums + adapters + their tests retained (non-breaking layer); only the central API choke point (`_convert_row`) and the FE rendering change.

## Why
Two axes both painted → rows the operator can't read ("which is it?"). Closes #1489; folds #1230 (reason inline, not hover-only). Part of epic #1508 — make the page a clean bill of health.

## Design
`compute_verdict` (`app/services/processes/health_verdict.py`) is pure + exhaustively table-tested. **Load-bearing invariant (Codex ckpt-1):** only the global kill switch (`disabled`) outranks an actionable stale reason; every other status is evaluated *after* the stale check — so `running`+`queue_stuck` and `pending_retry`+`queue_stuck` can never be masked as `working`/`self_healing`. Contradiction-free by construction: one row → exactly one verdict.

Mapping + reachability table: `docs/specs/ui/2026-06-06-process-health-verdict.md`.

Also: removed the dead `stale` `ProcessStatus` literal (never assigned by any adapter); `compareRows` now sorts by verdict (attention floats to top); `StaleBanner` rewired off `health_verdict` ("N need attention · M self-healing").

**v1 scope:** the contradiction-killing layer only. T3/T4 (#1509/#1510) extend `compute_verdict` with `next_retry_at`/liveness to reclassify *covered* overdue rows → `self_healing` with "will retry HH:MM"; T5 (#1511) adds watermark look-through + post-bootstrap seed. Net effect today: the ~9 genuinely-stuck overdue rows on dev read red `attention` — honest until #1511 lands.

## Test
- `tests/services/processes/test_health_verdict.py` — exhaustive over `ProcessStatus × powerset(StaleReason)` (total + single-valued), the masking-guard cases Codex flagged, full mapping pin. **167 pass.**
- `tests/test_processes_endpoints.py` integration (exercises `_convert_row` → new fields). **35 pass.**
- FE admin suite updated to verdict model. **898 pass.**
- `pnpm typecheck`, `ruff check`, `ruff format --check`, `pyright` clean.
- Codex reviewed at ckpt-1 (spec) and ckpt-2 (diff) — no blocking findings.

## Settled-decision compliance
- Two-axis (control-hub §A1): superseded by computed verdict; enums retained → minimal adapter/test change.
- None-vs-skipped (prevention 249): `pending_first_run` stays a distinct verdict input.
- No new universal-gate carve-out (this PR adds no dispatch path).

Closes #1512.
