### PR TITLE
feat(#1511): post-bootstrap auto-current — verdict look-through + audited gap/catch-up kick

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -420,6 +420,7 @@ def _convert_row(row: ProcessRow) -> ProcessRowResponse:
     verdict, self_healing, verdict_reason = compute_verdict(
         status=row.status,
         stale_reasons=row.stale_reasons,
+        watermark_is_fresh=row.source_watermark_fresh,
     )
     return ProcessRowResponse(
         process_id=row.process_id,

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -1029,7 +1029,7 @@ def finalize_run(
             """,
             {"status": terminal, "run_id": run_id},
         )
-        conn.execute(
+        state_result = conn.execute(
             """
             UPDATE bootstrap_state
                SET status            = %(status)s,
@@ -1040,6 +1040,28 @@ def finalize_run(
             """,
             {"status": terminal, "run_id": run_id},
         )
+        state_transitioned = state_result.rowcount == 1
+
+    # Post-bootstrap auto-current (#1511 / T5). Runs AFTER the completion tx
+    # has committed — status is durable and the universal gate is open — so a
+    # best-effort kick can never roll the transition back. (Codex ckpt-1
+    # BLOCKING: a caught DB error inside the tx above would leave it aborted
+    # and fail the commit, rolling completion back. Doing this post-commit, in
+    # the activation's own per-candidate transactions, isolates it entirely.)
+    # Only on the call that actually won the running→complete transition.
+    if terminal == "complete" and state_transitioned:
+        try:
+            from app.services.processes.post_bootstrap_activation import (
+                activate_post_bootstrap,
+            )
+
+            activate_post_bootstrap(conn, run_id=run_id)
+        except Exception:
+            logger.exception(
+                "finalize_run: post-bootstrap activation failed for run %s; "
+                "completion stands (jobs recover via the now-open gate + cadence)",
+                run_id,
+            )
 
     return terminal
 

--- a/app/services/processes/__init__.py
+++ b/app/services/processes/__init__.py
@@ -203,6 +203,13 @@ class ProcessRow:
     # underlying ``ScheduledJob.params_metadata`` so the FE knows
     # which form fields to render.
     params_metadata: tuple[ParamMetadata, ...] = field(default_factory=tuple)
+    # #1511 / T5 — set by scheduled_adapter when the job's data_freshness
+    # source is bootstrap-covered AND its newest filing is within cadence.
+    # Fed to ``compute_verdict(watermark_is_fresh=...)`` so a never-run
+    # (``pending_first_run``) poll whose source bootstrap already seeded
+    # reads Current instead of "first run pending". Bootstrap + ingest_sweep
+    # adapters keep the default — the look-through is scheduled-job-only.
+    source_watermark_fresh: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/services/processes/bootstrap_coverage.py
+++ b/app/services/processes/bootstrap_coverage.py
@@ -1,0 +1,88 @@
+"""Bootstrap freshness-source coverage map (#1511 / T5 of #1508).
+
+Which ``data_freshness_index`` ``source`` values each bootstrap stage's sink
+populates. Used by the Processes-page verdict look-through (part a): a
+never-run steady-state poll job whose freshness source is in
+``BOOTSTRAP_COVERED_FRESHNESS_SOURCES`` AND is still fresh reads green
+**Current** instead of blue "first run pending" — because bootstrap already
+seeded that source via the bulk ingest → ``record_manifest_entry`` →
+``seed_freshness_for_manifest_row`` path (empirically verified on dev: every
+covered source has thousands of ``state='current'`` rows post-bootstrap).
+
+It also defines, by complement, the *uncovered* sources that the
+post-bootstrap genuine-gap kick (part b) may target.
+
+**Drift discipline (load-bearing):** the per-stage classification is keyed by
+``StageSpec.stage_key`` and is hand-maintained. ``tests/services/processes/
+test_bootstrap_coverage.py`` asserts the key set equals ``{s.stage_key for s
+in _BOOTSTRAP_STAGE_SPECS}`` exactly, so adding / renaming / removing a stage
+forces a deliberate classification here rather than silently mis-marking a
+source as covered (false green) or uncovered (spurious kick).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from app.services.sec_manifest import ManifestSource
+
+# Issuer filing-metadata forms seeded into ``filing_events`` + the manifest
+# (hence ``data_freshness_index``) by the submissions ingest, the first-install
+# drain, and the quarterly master-index gap-close. Mirrors
+# ``app/jobs/sec_master_idx_quarterly_sweep.py::GAP_CLOSE_FILING_METADATA_SOURCES``
+# — kept as a local literal to avoid importing the jobs layer into a
+# services/processes module, and pinned EQUAL to it by the drift test so the
+# two cannot diverge.
+_ISSUER_FILING_METADATA: Final[frozenset[ManifestSource]] = frozenset(
+    {"sec_8k", "sec_10k", "sec_10q", "sec_def14a", "sec_13d", "sec_13g"}
+)
+
+# stage_key -> data_freshness_index sources the stage's sink populates.
+# ``frozenset()`` = the stage writes NO freshness sink (universe / candles /
+# directory refreshes / CUSIP + business-summary metadata / pure derivations /
+# the read-only validation gate). EVERY ``_BOOTSTRAP_STAGE_SPECS`` stage_key
+# MUST appear here (enforced by the drift test).
+_BOOTSTRAP_STAGE_FRESHNESS_SOURCES: Final[dict[str, frozenset[ManifestSource]]] = {
+    "universe_sync": frozenset(),
+    "candle_refresh": frozenset(),
+    "cusip_universe_backfill": frozenset(),
+    "sec_13f_filer_directory_sync": frozenset(),
+    "sec_nport_filer_directory_sync": frozenset(),
+    "cik_refresh": frozenset(),
+    "sec_bulk_download": frozenset(),
+    # Bulk submissions ingest writes filing_events + manifest for the issuer
+    # filing-metadata forms.
+    "sec_submissions_ingest": _ISSUER_FILING_METADATA,
+    "sec_companyfacts_ingest": frozenset({"sec_xbrl_facts"}),
+    "sec_13f_ingest_from_dataset": frozenset({"sec_13f_hr"}),
+    "sec_insider_ingest_from_dataset": frozenset({"sec_form3", "sec_form4", "sec_form5"}),
+    "sec_nport_ingest_from_dataset": frozenset({"sec_n_port"}),
+    "cusip_resolver_post_bulk_sweep": frozenset(),
+    "sec_master_idx_gap_close": _ISSUER_FILING_METADATA,
+    # First-install drain seeds filing_events (issuer filing-metadata) from the
+    # local bulk submissions.zip.
+    "sec_first_install_drain": _ISSUER_FILING_METADATA,
+    "sec_business_summary_bootstrap": frozenset(),
+    # Parses 8-K events into structured tables; sec_8k freshness is owned by
+    # the submissions / gap-close manifest writes above, not here.
+    "sec_8k_events_ingest": frozenset(),
+    "ownership_observations_backfill": frozenset(),
+    # Normalises XBRL facts into typed tables; sec_xbrl_facts freshness is owned
+    # by sec_companyfacts_ingest.
+    "fundamentals_sync": frozenset(),
+    # Seeds the fund directory + classId map, NOT N-CSR filings — so sec_n_csr
+    # is deliberately NOT covered (steady-state manifest-worker discovers it).
+    "mf_directory_sync": frozenset(),
+    "bootstrap_validation": frozenset(),
+}
+
+# Union of every covered source. Excluded by construction (NOT bootstrap-
+# covered): ``finra_short_interest`` / ``finra_regsho_daily`` (steady-state
+# FINRA lanes) and ``sec_n_csr`` (steady-state discovery) — their freshness
+# rows are seeded post-complete, not by a bootstrap stage.
+BOOTSTRAP_COVERED_FRESHNESS_SOURCES: Final[frozenset[ManifestSource]] = frozenset(
+    src for srcs in _BOOTSTRAP_STAGE_FRESHNESS_SOURCES.values() for src in srcs
+)
+
+
+__all__ = ["BOOTSTRAP_COVERED_FRESHNESS_SOURCES"]

--- a/app/services/processes/health_verdict.py
+++ b/app/services/processes/health_verdict.py
@@ -25,14 +25,16 @@ queue_stuck`` would render blue "working" while a worker is wedged, and
 dispatched request is stuck — re-introducing the masking the verdict
 exists to kill.
 
-**v1 scope:** T3 (retry/``next_retry_at``), T4 (watchdog re-enqueue) and
-T5 (post-bootstrap seed + watermark look-through) are not yet landed, so
-the only ``self_healing`` source is the existing ``pending_retry``
-status. An overdue row with no recovery mechanism reads **attention** —
-honest, because it currently IS stuck (the bug #1511 fixes). When
-T3/T4/T5 land they extend this function (add ``next_retry_at`` /
-liveness inputs) to reclassify *covered* overdue rows from ``attention``
-to ``self_healing`` with a "will retry HH:MM" reason.
+**v1 scope:** T5's watermark look-through is wired here (the
+``watermark_is_fresh`` input promotes a ``pending_first_run`` job on a
+bootstrap-covered, still-fresh source to Current — #1511). T3
+(retry/``next_retry_at``) and T4 (watchdog re-enqueue) are not yet
+landed, so the only ``self_healing`` source remains the existing
+``pending_retry`` status. An overdue row with no recovery mechanism
+reads **attention** — honest, because it currently IS stuck. When T3/T4
+land they extend this function (add ``next_retry_at`` / liveness inputs)
+to reclassify *covered* overdue rows from ``attention`` to
+``self_healing`` with a "will retry HH:MM" reason.
 """
 
 from __future__ import annotations
@@ -70,6 +72,7 @@ def compute_verdict(
     *,
     status: ProcessStatus,
     stale_reasons: tuple[StaleReason, ...],
+    watermark_is_fresh: bool = False,
 ) -> tuple[HealthVerdict, bool, str]:
     """Collapse ``status`` + ``stale_reasons`` into one verdict.
 
@@ -118,6 +121,16 @@ def compute_verdict(
     if status == "cancelled":
         return ("attention", False, "last run cancelled")
     if status == "pending_first_run":
+        # Look-through (#1511 / T5): a never-run steady-state poll whose
+        # SEC source bootstrap already seeded — and which is still fresh
+        # (``watermark_is_fresh``, computed by the adapter as covered-source
+        # + MAX(filed_at) within cadence) — reads Current, not "first run
+        # pending". The DATA is current; the job just has not reached its
+        # first natural cadence slot. A covered-but-stale source returns
+        # ``watermark_is_fresh=False`` here and stays "working" (and an
+        # actionable stale reason, handled above, still outranks).
+        if watermark_is_fresh:
+            return ("current", False, "")
         return ("working", False, "first run pending")
     if status == "ok":
         return ("current", False, "")

--- a/app/services/processes/post_bootstrap_activation.py
+++ b/app/services/processes/post_bootstrap_activation.py
@@ -1,0 +1,230 @@
+"""Post-bootstrap auto-current activation (#1511 / T5 of #1508).
+
+Called once from ``bootstrap_state.finalize_run`` when a run transitions
+``running → complete`` (parts b + c of the spec
+``docs/specs/ops/2026-06-06-post-bootstrap-auto-current.md``). It enqueues,
+through the **audited manual-queue path**, the jobs that should run the moment
+the universal bootstrap gate opens:
+
+  * (c) **catch-up-trap recovery** — jobs with ``catch_up_on_boot=True`` whose
+    latest terminal ``job_runs`` row is a gate skip (``status='skipped'``,
+    ``error_msg='bootstrap_not_complete'``). Their boot catch-up was evaluated
+    while bootstrap was still running, wrote a ``skipped`` row, and is never
+    re-evaluated until the next process restart (prevention-log 1339-1343).
+  * (b) **genuine-gap kick** — never-run jobs whose ``data_freshness_index``
+    source is NOT bootstrap-covered (so their operator-visible data is a real
+    gap), gated to ``prerequisite is None`` (empty-DB-safe, per settled-decision
+    #1181). Self-populating: ∅ on the current registry (every registered
+    freshness source is bootstrap-covered), fires only if a genuinely uncovered
+    never-run job is added later.
+
+Design constraints (Codex ckpt-1):
+
+  * **No new universal-gate carve-out.** The gate is already ``complete`` by the
+    time this runs, so the manual-queue dispatch passes it without an
+    ``override_bootstrap_gate`` flag — the carve-out allow-list stays 2,
+    test-pinned (#1064/#1181).
+  * **Abort-safe / best-effort.** Runs AFTER the completion is committed; each
+    candidate enqueues + audits inside its OWN ``conn.transaction()`` so a
+    failure rolls back only that candidate (psycopg3 aborts the whole tx on the
+    first error). The caller wraps the top-level call in try/except, so nothing
+    here can roll the completion back. The durable backstop is the now-open gate
+    + normal cadence (the two catch-up jobs are daily) + the next boot catch-up;
+    re-enqueue bodies are idempotent, so a duplicate at the next scheduled fire
+    is harmless.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+from app.services.processes.bootstrap_coverage import BOOTSTRAP_COVERED_FRESHNESS_SOURCES
+
+logger = logging.getLogger(__name__)
+
+# Matches ``bootstrap_gate._GATE_REASON_BOOTSTRAP_NOT_COMPLETE`` — the
+# ``error_msg`` ``record_job_skip`` writes when the universal gate blocks a
+# catch-up fire. A catch-up job sitting on exactly this skip is gate-trapped
+# (NOT skipped for a benign per-job prerequisite — prevention 249).
+_GATE_SKIP_REASON: Literal["bootstrap_not_complete"] = "bootstrap_not_complete"
+
+_REQUESTED_BY = "system:post_bootstrap_activation"
+
+_ActivationReason = Literal["catch_up_trap_recovery", "genuine_gap_kick"]
+
+
+def activate_post_bootstrap(conn: psycopg.Connection[Any], *, run_id: int) -> list[str]:
+    """Enqueue catch-up-trapped + genuine-gap jobs via the audited manual queue.
+
+    Returns the list of job names actually enqueued (excludes candidates that
+    already had an active request in flight, and any whose enqueue failed). The
+    caller (``finalize_run``) treats this as best-effort and never lets it
+    propagate past completion.
+    """
+    candidates = _select_candidates(conn)
+    if not candidates:
+        return []
+    enqueued: list[str] = []
+    for job_name, reason in candidates:
+        try:
+            if _enqueue_one(conn, job_name=job_name, reason=reason, run_id=run_id):
+                enqueued.append(job_name)
+        except Exception:
+            logger.exception(
+                "post_bootstrap_activation: enqueue failed for %r — skipping (job recovers via gate+cadence)",
+                job_name,
+            )
+    if enqueued:
+        logger.info(
+            "post_bootstrap_activation: run %s enqueued %d job(s) via audited manual queue: %s",
+            run_id,
+            len(enqueued),
+            ", ".join(enqueued),
+        )
+    return enqueued
+
+
+def _select_candidates(conn: psycopg.Connection[Any]) -> list[tuple[str, _ActivationReason]]:
+    """Resolve the (job_name, reason) candidate set against the live registry.
+
+    Read-only; runs in its own transaction so it leaves no dangling implicit
+    transaction on the shared connection.
+    """
+    # Lazy imports — keep this module (reachable from low-level bootstrap_state)
+    # free of an import cycle through the scheduler / watermark registries.
+    from app.services.processes.watermarks import freshness_source_for
+    from app.workers.scheduler import SCHEDULED_JOBS
+
+    with conn.transaction():
+        latest = _latest_terminal_by_job(conn)
+
+    candidates: list[tuple[str, _ActivationReason]] = []
+    for job in SCHEDULED_JOBS:
+        terminal = latest.get(job.name)
+        if _is_catch_up_trap(job, terminal):
+            candidates.append((job.name, "catch_up_trap_recovery"))
+        elif _is_genuine_gap(job, terminal, freshness_source_for(job.name)):
+            candidates.append((job.name, "genuine_gap_kick"))
+    return candidates
+
+
+def _is_catch_up_trap(job: Any, terminal: tuple[str, str | None] | None) -> bool:
+    """(c) A NON-exempt ``catch_up_on_boot`` job whose latest terminal run is the
+    universal gate skip — its boot catch-up fired while bootstrap was still
+    running and is never re-evaluated until a restart (prevention 1339-1343).
+
+    Exempt jobs (the carve-out allow-list) BYPASS the gate, so a gate-skip
+    ``job_runs`` row on one is a stale artifact, NOT a trap. Notably
+    ``orchestrator_high_frequency_sync`` writes ``sync_runs`` (not ``job_runs``)
+    and already runs every 5 min via its exemption — its lingering boot-era
+    ``skipped/bootstrap_not_complete`` row must NOT trigger a redundant
+    (double-firing) kick. Verified on dev: without this guard the selection
+    wrongly picked ``orchestrator_high_frequency_sync``."""
+    return (
+        bool(job.catch_up_on_boot)
+        and not getattr(job, "exempt_from_universal_bootstrap_gate", False)
+        and terminal == ("skipped", _GATE_SKIP_REASON)
+    )
+
+
+def _is_genuine_gap(
+    job: Any,
+    terminal: tuple[str, str | None] | None,
+    source: str | None,
+) -> bool:
+    """(b) A never-run job whose freshness source is a genuine, bootstrap-
+    UNcovered gap, and which is empty-DB-safe to run once (no ``catch_up`` — that
+    path is (c)/boot; ``prerequisite is None`` per settled-decision #1181)."""
+    return (
+        not job.catch_up_on_boot
+        and terminal is None
+        and job.prerequisite is None
+        and source is not None
+        and source not in BOOTSTRAP_COVERED_FRESHNESS_SOURCES
+    )
+
+
+def _latest_terminal_by_job(
+    conn: psycopg.Connection[Any],
+) -> dict[str, tuple[str, str | None]]:
+    """Latest terminal ``(status, error_msg)`` per job_name (never-run jobs absent)."""
+    rows = conn.execute(
+        """
+        SELECT DISTINCT ON (job_name) job_name, status, error_msg
+          FROM job_runs
+         WHERE status IN ('success', 'failure', 'skipped', 'cancelled')
+         ORDER BY job_name, started_at DESC
+        """
+    ).fetchall()
+    return {row[0]: (row[1], row[2]) for row in rows}
+
+
+def _enqueue_one(
+    conn: psycopg.Connection[Any],
+    *,
+    job_name: str,
+    reason: _ActivationReason,
+    run_id: int,
+) -> bool:
+    """Enqueue one candidate + write its audit row in a single transaction.
+
+    Returns True when a request was published, False when skipped because an
+    active manual request already exists for the job (double-fire guard).
+    """
+    from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
+
+    with conn.transaction():
+        if _has_active_request(conn, job_name):
+            return False
+        publish_manual_job_request_with_conn(conn, job_name, requested_by=_REQUESTED_BY)
+        _write_activation_audit(conn, job_name=job_name, reason=reason, run_id=run_id)
+        return True
+
+
+def _has_active_request(conn: psycopg.Connection[Any], job_name: str) -> bool:
+    """True when a manual_job request for ``job_name`` is already in flight."""
+    row = conn.execute(
+        """
+        SELECT 1
+          FROM pending_job_requests
+         WHERE job_name = %(job_name)s
+           AND request_kind = 'manual_job'
+           AND status IN ('pending', 'claimed', 'dispatched')
+         LIMIT 1
+        """,
+        {"job_name": job_name},
+    ).fetchone()
+    return row is not None
+
+
+def _write_activation_audit(
+    conn: psycopg.Connection[Any],
+    *,
+    job_name: str,
+    reason: _ActivationReason,
+    run_id: int,
+) -> None:
+    """Record the audited kick in ``decision_audit`` (mirrors the gate-override audit)."""
+    explanation = (
+        f"post-bootstrap auto-current: enqueued job {job_name!r} ({reason}) "
+        f"after bootstrap run {run_id} reached 'complete'"
+    )
+    conn.execute(
+        """
+        INSERT INTO decision_audit
+            (decision_time, stage, pass_fail, explanation, evidence_json)
+        VALUES
+            (NOW(), 'post_bootstrap_activation', 'KICK', %(expl)s, %(evidence)s)
+        """,
+        {
+            "expl": explanation,
+            "evidence": Jsonb({"job_name": job_name, "reason": reason, "run_id": run_id}),
+        },
+    )
+
+
+__all__ = ["activate_post_bootstrap"]

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -27,11 +27,12 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import psycopg
 import psycopg.rows
 
+from app.services.data_freshness import cadence_for
 from app.services.processes import (
     ActiveRunSummary,
     ErrorClassSummary,
@@ -41,6 +42,9 @@ from app.services.processes import (
     ProcessStatus,
     RunStatus,
     StaleReason,
+)
+from app.services.processes.bootstrap_coverage import (
+    BOOTSTRAP_COVERED_FRESHNESS_SOURCES,
 )
 from app.services.processes.stale_detection import (
     QUEUE_STUCK_THRESHOLD_S,
@@ -54,6 +58,7 @@ from app.services.processes.watermarks import (
     manifest_source_for,
     resolve_watermark,
 )
+from app.services.sec_manifest import ManifestSource
 from app.workers.scheduler import (
     SCHEDULED_JOBS,
     Cadence,
@@ -437,6 +442,41 @@ def _has_data_freshness_gap(
         return cur.fetchone() is not None
 
 
+def _source_watermark_fresh(
+    conn: psycopg.Connection[Any],
+    *,
+    source: str,
+    now: datetime,
+) -> bool:
+    """True when ``source``'s newest filing is recent enough that the source
+    as a whole is being kept current — ``MAX(last_known_filed_at)`` within one
+    cadence interval (+ the shared watermark tolerance) of ``now``.
+
+    Source-LEVEL recency, deliberately NOT the per-subject overdue probe
+    (``_has_data_freshness_gap``): event-driven forms (Form 3/4, 13D/G) leave
+    most subjects perpetually "overdue" (filed once, never again), so an
+    any-subject-overdue test reads stale for a source that is in fact current.
+    The #1511 look-through promotes a never-run job to Current only when the
+    source's freshest filing sits inside its cadence window. Returns False on
+    a source with no rows / no ``last_known_filed_at`` (nothing seeded → not
+    fresh) and on an unknown source (no cadence → cannot assert freshness).
+    """
+    try:
+        cadence = cadence_for(cast(ManifestSource, source))
+    except KeyError:
+        return False
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT MAX(last_known_filed_at) FROM data_freshness_index WHERE source = %(source)s",
+            {"source": source},
+        )
+        row = cur.fetchone()
+    if row is None or row[0] is None:
+        return False
+    max_filed_at: datetime = row[0]
+    return max_filed_at >= now - cadence - timedelta(seconds=WATERMARK_GAP_TOLERANCE_S)
+
+
 def _has_dispatched_queue_age(
     conn: psycopg.Connection[Any],
     *,
@@ -764,6 +804,16 @@ def _build_row(
     # monitor_positions, …); the FE renders that as "no resume cursor".
     watermark = resolve_watermark(conn, process_id=job.name, mechanism="scheduled_job")
 
+    # #1511 / T5 — verdict look-through signal. True when the job polls a
+    # bootstrap-covered freshness source whose newest filing is still within
+    # cadence; ``compute_verdict`` uses it to read a ``pending_first_run`` job
+    # as Current (data seeded by bootstrap) rather than "first run pending".
+    source_watermark_fresh = (
+        freshness_source is not None
+        and freshness_source in BOOTSTRAP_COVERED_FRESHNESS_SOURCES
+        and _source_watermark_fresh(conn, source=freshness_source, now=now)
+    )
+
     can_cancel = (
         active_run is not None and active_run.run_id is not None and process_status == "running"
         # short-runners (heartbeat etc.) are not worth cooperative-cancel;
@@ -802,6 +852,8 @@ def _build_row(
         params_metadata=job.params_metadata,
         # PR4 #1082 — operator-visible description for the ⓘ tooltip.
         description=job.description,
+        # #1511 / T5 — verdict look-through input (see compute_verdict).
+        source_watermark_fresh=source_watermark_fresh,
     )
 
 

--- a/docs/specs/ops/2026-06-06-post-bootstrap-auto-current.md
+++ b/docs/specs/ops/2026-06-06-post-bootstrap-auto-current.md
@@ -1,0 +1,220 @@
+# Post-bootstrap auto-current (#1511 / T5 of #1508)
+
+Status: Spec (2026-06-06). Child of epic #1508; builds on the shipped verdict (#1512, merged 5b38dde).
+Parent proposal: `docs/proposals/ui/admin-processes-self-healing-health.md` §3 decision 3(a–c).
+
+## Goal
+
+After a clean bootstrap the Processes page reads ~all **Current** with zero operator clicks, and
+gate-skipped catch-up jobs recover without a process restart.
+
+## Empirical grounding (dev DB, 2026-06-06 — verified, do not re-diagnose)
+
+- `bootstrap_state.status='complete'` since 06-03 19:47.
+- **`data_freshness_index` is ALREADY fully seeded** by bulk ingest (`record_manifest_entry` →
+  `seed_freshness_for_manifest_row`). Every SEC source has thousands of `state='current'` rows,
+  newest filing within days: `sec_13f_hr` 9558 rows (max 06-05), `sec_form4` 4873 (max 06-06),
+  `sec_xbrl_facts` via companyfacts, etc. **So "seed watermarks" (issue title) is a no-op on a
+  real bootstrap — the defect is read-side: the verdict never consults the watermark.**
+- Per-subject `expected_next_at < now` ("overdue") counts are huge (`sec_form3` 4795/5358) because
+  event-driven filers file once then stop. So `_has_data_freshness_gap` (ANY-subject-overdue) is
+  the WRONG freshness signal for the look-through — use **source-level recency** (newest filing
+  within cadence) instead.
+- **Catch-up trap CONFIRMED LIVE:** `cusip_extid_sweep` + `ownership_observations_sync`
+  (both `catch_up_on_boot=True`) latest terminal = `skipped / bootstrap_not_complete` (06-03);
+  never recovered. These only un-stick on a jobs-process restart today.
+- The issue's named "genuine gaps" are stale: bulk refreshes ran 06-06, RegSHO ran 06-05,
+  `finra_short_interest_refresh` is **failing** (#1516) not absent. **(b) has ∅ live targets** —
+  the kick is a self-populating mechanism, correct-by-construction-empty now.
+
+## Scope — three parts, two independent code areas
+
+### Part (a) — verdict look-through (READ-SIDE; not a write)
+
+`compute_verdict` (`app/services/processes/health_verdict.py:120`) maps `pending_first_run` →
+`("working", "first run pending")` unconditionally; it receives only `status` + `stale_reasons`.
+A never-run steady-state poll job whose SEC data bootstrap already filled therefore reads blue
+"working" forever instead of green Current.
+
+Fix: thread a `watermark_is_fresh: bool` signal into the verdict.
+
+1. **`compute_verdict`** — add keyword `watermark_is_fresh: bool = False`. Only the
+   `pending_first_run` branch consumes it:
+   ```python
+   if status == "pending_first_run":
+       if watermark_is_fresh:
+           return ("current", False, "")          # data seeded by bootstrap; steady-state poll not yet due
+       return ("working", False, "first run pending")
+   ```
+   Precedence unchanged: an actionable stale reason still outranks (a genuinely overdue source
+   keeps its `watermark_gap → attention`). Default `False` keeps every other caller + adapter
+   (bootstrap, ingest_sweep) byte-identical.
+2. **Adapter** (`scheduled_adapter._build_row`) computes the signal and stores it on `ProcessRow`:
+   ```python
+   source = freshness_source_for(job.name)
+   source_watermark_fresh = (
+       source in BOOTSTRAP_COVERED_FRESHNESS_SOURCES
+       and _source_watermark_fresh(conn, source=source, now=now)
+   )
+   ```
+   New `ProcessRow` field `source_watermark_fresh: bool = False` (frozen-slots dataclass; default
+   keeps the other two adapters unchanged).
+3. **`_convert_row`** (`app/api/processes.py:419`) passes `watermark_is_fresh=row.source_watermark_fresh`.
+4. **`_source_watermark_fresh`** (new, in `watermarks.py` beside `resolve_watermark`):
+   ```sql
+   SELECT MAX(last_known_filed_at) FROM data_freshness_index WHERE source = %(source)s
+   ```
+   fresh ⇔ `max IS NOT NULL AND max >= now - cadence_for(source) - WATERMARK_GAP_TOLERANCE_S`.
+   Source-level (robust to per-subject event-driven noise). Reuses `data_freshness.cadence_for`.
+
+**Net visible effect:** a never-run job on a covered+fresh source (e.g. `fundamentals_sync` →
+`sec_xbrl_facts`, fresh post-bootstrap) flips blue→green. Jobs with no freshness source
+(orchestrator_full_sync, retention/maintenance sweeps) keep "working" — honest; they run at their
+next slot. No false green: covered-but-stale → not fresh → stays working/attention. (Verify the
+exact look-through job set at impl against `_JOB_REGISTRY` freshness sources × the never-run set —
+several `_JOB_REGISTRY` entries, e.g. `sec_8k_events_ingest`, are retired from `SCHEDULED_JOBS` and
+won't appear as scheduled-adapter rows.)
+
+### Parts (b)+(c) — finalize_run audited activation (WRITE-SIDE)
+
+Single chokepoint: `bootstrap_state.finalize_run` (`app/services/bootstrap_state.py:945`). Inside
+the existing `with conn.transaction()`, capture `rowcount` of the `bootstrap_state` UPDATE (the
+`running→complete` transition). **AFTER that transaction commits** (status durable), call activation
+iff **both** `terminal == "complete"` AND the captured `rowcount == 1` (this call won the
+transition — once-per-completion, idempotent on iterate/retry re-finalize).
+
+**Why post-commit, not in-tx (Codex ckpt-1 BLOCKING):** psycopg3 aborts the whole transaction on
+the first DB error; a caught enqueue/audit failure inside finalize_run's tx would NOT un-abort it,
+so the status-flip commit would itself fail and roll the completion back (cf.
+`feedback_psycopg3_savepoint_commit`). Running activation after the status commit makes completion
+durable first; the gate is already open at that point so the kick needs no override, and an
+activation failure can no longer poison the completion. NOTIFY-with-status atomicity is deliberately
+**not** required — activation is best-effort (see backstop below).
+
+New module `app/services/processes/post_bootstrap_activation.py`:
+`activate_post_bootstrap(conn, *, run_id) -> list[str]` (returns enqueued job names; lazy-imports
+scheduler registry + dispatcher to avoid load cycles — repo pattern, cf. `app/jobs/sources.py`).
+Manages its own transactions on the (now-idle) conn — **one `with conn.transaction()` per candidate**
+so a single candidate's failure rolls back only its own savepoint and the loop continues
+(best-effort per candidate; Codex ckpt-1 WARNING 2/3).
+
+Candidate set (union of (c) then (b)):
+
+- **(c) catch-up-trap recovery:** scheduled jobs with `catch_up_on_boot=True` whose LATEST terminal
+  `job_runs` row is `status='skipped'` with `error_msg = bootstrap_not_complete`. → live: exactly
+  `cusip_extid_sweep`, `ownership_observations_sync`.
+- **(b) self-populating genuine-gap kick:** scheduled jobs where ALL of:
+  `catch_up_on_boot == False` (catch-up jobs handled by (c)/boot loop) AND
+  no terminal `job_runs` row at all (never fired) AND
+  `freshness_source_for(job) is not None AND that source ∉ BOOTSTRAP_COVERED_FRESHNESS_SOURCES`
+  (its operator-visible data is a genuine gap bootstrap did NOT fill) AND
+  `prerequisite is None` (empty-DB-safe proxy, per settled-decision #1181 carve-out criteria).
+  → live: ∅ (every registered freshness source is bootstrap-covered; finra jobs have no registry
+  source and already run daily). Mechanism present, fires only when a real uncovered gap exists.
+
+Per candidate, gated by a guard against double-fire (skip if an active `pending_job_requests`
+row — `status IN ('pending','claimed','dispatched')` — already exists for that `job_name`):
+
+1. `publish_manual_job_request_with_conn(conn, job_name, requested_by="system:post_bootstrap_activation")`
+   — INSERT + NOTIFY inside the per-candidate `conn.transaction()`; status is already
+   `complete`-committed, so NOTIFY flushes to a listener that finds an already-open gate.
+   **No `override_bootstrap_gate`** → allow-list stays 2, test-pinned (#1064/#1181 preserved).
+2. One `decision_audit` row (mirrors `_write_override_audit` insert shape):
+   `stage='post_bootstrap_activation'`, `pass_fail='KICK'`,
+   `explanation` naming job + reason (`catch_up_trap_recovery` | `genuine_gap_kick`),
+   `evidence_json={job_name, reason, run_id, bootstrap_completed_at}`. Audit-write failure logs but
+   does not abort the run (same posture as the override audit).
+
+### Shared — bootstrap-covered source map + drift test
+
+`app/services/processes/bootstrap_coverage.py`:
+```python
+_BOOTSTRAP_STAGE_FRESHNESS_SOURCES: dict[str, frozenset[ManifestSource]] = {
+    # stage job_name -> data_freshness_index sources its sink populates ; frozenset() = no freshness sink
+    "sec_submissions_ingest":          frozenset({"sec_10k","sec_10q","sec_8k","sec_def14a","sec_13d","sec_13g"}),
+    "sec_first_install_drain":         frozenset({"sec_10k","sec_10q","sec_8k","sec_def14a","sec_13d","sec_13g"}),
+    "sec_master_idx_gap_close":        GAP_CLOSE_FILING_METADATA_SOURCES,  # imported, not re-listed
+    "sec_companyfacts_ingest":         frozenset({"sec_xbrl_facts"}),
+    "sec_13f_ingest_from_dataset":     frozenset({"sec_13f_hr"}),
+    "sec_insider_ingest_from_dataset": frozenset({"sec_form3","sec_form4","sec_form5"}),
+    "sec_nport_ingest_from_dataset":   frozenset({"sec_n_port"}),
+    "sec_8k_events_ingest":            frozenset(),  # parses events; freshness owned by submissions/gap_close
+    # …every other stage job_name → frozenset() (no freshness sink)
+}
+BOOTSTRAP_COVERED_FRESHNESS_SOURCES: frozenset[ManifestSource] = frozenset().union(*…values())
+```
+Excluded (NOT bootstrap-covered): `finra_short_interest`, `finra_regsho_daily` (steady-state FINRA
+lanes), `sec_n_csr` (steady-state manifest-worker/lazy discovery — `mf_directory_sync` seeds the
+directory, not N-CSR filings).
+
+**Drift test** (`tests/services/processes/test_bootstrap_coverage.py`, mirrors
+`tests/test_job_registry.py::test_registry_covers_every_bootstrap_stage`):
+- Every `stage.job_name` in `_BOOTSTRAP_STAGE_SPECS` is a key in the map (a new/renamed stage forces
+  a deliberate `frozenset()`-or-sources decision — no silent staleness).
+- Every value ⊆ valid `ManifestSource` (typo guard).
+- `BOOTSTRAP_COVERED_FRESHNESS_SOURCES` == expected pinned set (regression pin on the union).
+
+## Settled-decision / prevention compliance
+
+- **Universal gate #1064/#1181:** kick via audited manual-queue AFTER the gate opens; no new
+  `exempt_from_universal_bootstrap_gate` carve-out (allow-list stays 2, test-pinned).
+- **catch-up trap (prevention 1339-1343):** part (c) is the documented fix — audited re-queue, not
+  a silently-lost fire.
+- **skip ≠ completed (1217):** activation reads/writes terminal state correctly; re-enqueue routes
+  through the normal dispatch→`_tracked_job` path which records terminal status.
+- **none vs skipped (249):** `pending_first_run` (never-run) stays a distinct verdict input; not
+  folded into attention. Look-through promotes it to Current ONLY on covered+fresh source.
+
+## Risks
+
+- **Re-kick into a held rate-limit/gate (relates #1484):** part (b) is ∅ now and predicate-gated to
+  `prerequisite is None` + empty-DB-safe; (c)'s two jobs are bounded DB sweeps (one indexed JOIN /
+  drift scan), not rate-bound. No re-enqueue-into-own-limit path.
+- **Map drift:** the drift test is load-bearing; without it a new stage silently mis-classifies a
+  source as covered (false green) or uncovered (spurious kick).
+- **finalize_run coupling / abort-safety (Codex ckpt-1 BLOCKING):** activation runs AFTER the
+  status-commit, in its own per-candidate `conn.transaction()` (savepoint-isolated), lazy-importing
+  scheduler/dispatcher. A candidate's enqueue/audit failure rolls back only that candidate's
+  savepoint; the completion is already durable and the loop proceeds. The top-level
+  `activate_post_bootstrap` call is itself wrapped (catch + log) so it can never propagate past
+  finalize_run. Each candidate's enqueue + its audit row share one savepoint (either both land or
+  neither — no orphan audit without a queued request, no queued request without an audit).
+- **Best-effort is acceptable (Codex ckpt-1 WARNING 2/3):** activation is a completion-time
+  accelerator, NOT the sole recovery path. The durable backstop is that finalize flips the gate
+  OPEN, after which the trapped jobs' **normal scheduled fires** re-evaluate the (now-passing) gate
+  — both are daily (`ownership_observations_sync` 03:30, `cusip_extid_sweep` 04:50), so ≤24h
+  worst-case even if activation is skipped/fails — plus the next boot catch-up. The one-shot
+  `rowcount==1` guard and partial-activation are therefore tolerable; no durable retry/marker is
+  warranted. Re-enqueue bodies are idempotent (`ownership_observations_sync` = ON CONFLICT DO UPDATE
+  on natural keys; `cusip_extid_sweep` = bounded indexed JOIN), so a duplicate with the next
+  scheduled fire is harmless.
+
+## Test plan
+
+- `test_health_verdict.py`: extend the table — `pending_first_run` × `watermark_is_fresh ∈ {T,F}` →
+  `{current, working}`; confirm an actionable stale reason still wins regardless of freshness.
+- `test_bootstrap_coverage.py`: the three drift assertions above.
+- `_source_watermark_fresh`: fresh / stale / no-rows → {True, False, False}; boundary at
+  `cadence + tolerance`.
+- `activate_post_bootstrap`: (c) picks exactly the gated-skip catch_up jobs; (b) ∅ on the real
+  registry; synthetic uncovered-source never-run job → kicked; double-fire guard skips when an
+  active request exists; non-complete terminal → no-op; `rowcount==0` (lost race) → no-op; audit
+  row shape; activation exception is swallowed (completion still returns `complete`).
+- Adapter: `source_watermark_fresh` True only for covered+fresh; False for uncovered / stale / None.
+
+## DoD — operator-visible verification on dev (ETL clauses 8–12 adaptation)
+
+This work changes verdict logic + a finalize_run enqueue; it does NOT alter parsers/schema/
+observations data, so the ownership-rollup clauses are a regression check, not a backfill. Record at
+the commit SHA:
+
+1. **Verdict look-through:** query `data_freshness_index` source recency + the never-run job set;
+   show ≥1 named `pending_first_run` job (e.g. `fundamentals_sync` / `sec_8k_events_ingest`) now
+   computes `current` (drive `compute_verdict` with the live signal, or hit `/system/processes`).
+2. **Catch-up recovery:** exercise `activate_post_bootstrap` against dev (or simulate the
+   finalize→complete transition) and show `cusip_extid_sweep` + `ownership_observations_sync` get a
+   fresh `pending_job_requests` row + `decision_audit` row, then a non-skipped `job_runs` row after
+   the listener drains.
+3. **(b) ∅ proof:** show the predicate yields the empty set against the live registry.
+4. **Regression:** `/instruments/AAPL/ownership-rollup` still renders (data path untouched).
+5. **`/system/job-liveness`** unaffected.

--- a/tests/services/processes/test_bootstrap_coverage.py
+++ b/tests/services/processes/test_bootstrap_coverage.py
@@ -1,0 +1,79 @@
+"""Drift guard for the bootstrap freshness-source coverage map (#1511 / T5).
+
+The map ``_BOOTSTRAP_STAGE_FRESHNESS_SOURCES`` decides which never-run jobs the
+Processes verdict promotes to Current (covered + fresh) and which the
+post-bootstrap kick may target (uncovered). If it drifts from the live
+``_BOOTSTRAP_STAGE_SPECS`` it silently mis-classifies a source — false green or
+spurious kick — so these assertions are load-bearing, mirroring
+``tests/test_job_registry.py::test_registry_covers_every_bootstrap_stage``.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from app.services.processes.bootstrap_coverage import (
+    _BOOTSTRAP_STAGE_FRESHNESS_SOURCES,
+    _ISSUER_FILING_METADATA,
+    BOOTSTRAP_COVERED_FRESHNESS_SOURCES,
+)
+from app.services.sec_manifest import ManifestSource
+
+_VALID_SOURCES: frozenset[str] = frozenset(typing.get_args(ManifestSource))
+
+
+def test_every_bootstrap_stage_has_a_classification() -> None:
+    """Key set == live stage_key set exactly — a new / renamed / removed stage
+    forces a deliberate classification rather than silent staleness."""
+    from app.services.bootstrap_orchestrator import _BOOTSTRAP_STAGE_SPECS
+
+    spec_stage_keys = {stage.stage_key for stage in _BOOTSTRAP_STAGE_SPECS}
+    map_keys = set(_BOOTSTRAP_STAGE_FRESHNESS_SOURCES)
+    missing = spec_stage_keys - map_keys
+    extra = map_keys - spec_stage_keys
+    assert not missing, f"stages missing a coverage classification: {sorted(missing)}"
+    assert not extra, f"coverage map has stale (non-existent) stage keys: {sorted(extra)}"
+
+
+def test_all_classified_sources_are_valid_manifest_sources() -> None:
+    """Typo guard — every mapped source is a real ``ManifestSource``."""
+    for stage_key, sources in _BOOTSTRAP_STAGE_FRESHNESS_SOURCES.items():
+        bad = set(sources).difference(_VALID_SOURCES)
+        assert not bad, f"{stage_key!r} maps to non-ManifestSource value(s): {sorted(bad)}"
+
+
+def test_covered_set_is_the_expected_union() -> None:
+    """Regression pin on the union — catches an accidental coverage change."""
+    expected: frozenset[ManifestSource] = frozenset(
+        {
+            "sec_8k",
+            "sec_10k",
+            "sec_10q",
+            "sec_def14a",
+            "sec_13d",
+            "sec_13g",
+            "sec_xbrl_facts",
+            "sec_13f_hr",
+            "sec_form3",
+            "sec_form4",
+            "sec_form5",
+            "sec_n_port",
+        }
+    )
+    assert BOOTSTRAP_COVERED_FRESHNESS_SOURCES == expected
+
+
+def test_steady_state_sources_are_not_covered() -> None:
+    """FINRA lanes + N-CSR are seeded post-complete, NOT by a bootstrap stage —
+    they must stay uncovered so the kick can target a genuine gap and the
+    look-through never falsely greens them."""
+    for src in ("finra_short_interest", "finra_regsho_daily", "sec_n_csr"):
+        assert src not in BOOTSTRAP_COVERED_FRESHNESS_SOURCES
+
+
+def test_issuer_filing_metadata_matches_gap_close_set() -> None:
+    """The local issuer filing-metadata literal is pinned EQUAL to the jobs-layer
+    ``GAP_CLOSE_FILING_METADATA_SOURCES`` so the two cannot diverge."""
+    from app.jobs.sec_master_idx_quarterly_sweep import GAP_CLOSE_FILING_METADATA_SOURCES
+
+    assert _ISSUER_FILING_METADATA == GAP_CLOSE_FILING_METADATA_SOURCES

--- a/tests/services/processes/test_health_verdict.py
+++ b/tests/services/processes/test_health_verdict.py
@@ -150,3 +150,54 @@ def test_idle_overdue_is_attention() -> None:
     """idle + schedule_missed (catch-up trap surface) → attention."""
     v, _, _ = compute_verdict(status="idle", stale_reasons=("schedule_missed",))
     assert v == "attention"
+
+
+# --- #1511 / T5 watermark look-through ----------------------------------
+
+
+def test_watermark_default_preserves_first_run_pending() -> None:
+    """Default ``watermark_is_fresh=False`` keeps the shipped behaviour:
+    a never-run job reads blue 'first run pending'."""
+    v, sh, reason = compute_verdict(status="pending_first_run", stale_reasons=())
+    assert (v, sh, reason) == ("working", False, "first run pending")
+
+
+def test_pending_first_run_fresh_watermark_reads_current() -> None:
+    """Look-through: a never-run job whose bootstrap-covered source is still
+    fresh reads green Current, not 'first run pending'."""
+    v, sh, reason = compute_verdict(status="pending_first_run", stale_reasons=(), watermark_is_fresh=True)
+    assert (v, sh, reason) == ("current", False, "")
+
+
+def test_pending_first_run_stale_watermark_stays_working() -> None:
+    """Covered-but-stale (watermark_is_fresh=False) stays 'first run pending'."""
+    v, sh, reason = compute_verdict(status="pending_first_run", stale_reasons=(), watermark_is_fresh=False)
+    assert (v, sh, reason) == ("working", False, "first run pending")
+
+
+@pytest.mark.parametrize("reason", _ALL_REASONS)
+def test_fresh_watermark_never_overrides_actionable_stale(reason: StaleReason) -> None:
+    """The look-through must not mask an actionable stale reason: a fresh
+    watermark on a pending_first_run row with a real stale reason still reads
+    attention (stale precedence is above the status branch)."""
+    v, sh, _ = compute_verdict(status="pending_first_run", stale_reasons=(reason,), watermark_is_fresh=True)
+    assert v == "attention"
+    assert sh is False
+
+
+@pytest.mark.parametrize("status", [s for s in _ALL_STATUSES if s != "pending_first_run"])
+def test_fresh_watermark_only_affects_pending_first_run(status: ProcessStatus) -> None:
+    """Only ``pending_first_run`` consumes ``watermark_is_fresh`` — every other
+    status maps identically with the flag set or unset."""
+    base = compute_verdict(status=status, stale_reasons=())
+    with_fresh = compute_verdict(status=status, stale_reasons=(), watermark_is_fresh=True)
+    assert base == with_fresh
+
+
+@pytest.mark.parametrize("status", _ALL_STATUSES)
+@pytest.mark.parametrize("reasons", _all_reason_subsets())
+def test_total_and_single_valued_with_fresh_watermark(status: ProcessStatus, reasons: tuple[StaleReason, ...]) -> None:
+    """Totality holds with the look-through flag set, too."""
+    verdict, self_healing, _ = compute_verdict(status=status, stale_reasons=reasons, watermark_is_fresh=True)
+    assert verdict in _VALID_VERDICTS
+    assert self_healing == (verdict == "self_healing")

--- a/tests/services/processes/test_post_bootstrap_activation.py
+++ b/tests/services/processes/test_post_bootstrap_activation.py
@@ -1,0 +1,163 @@
+"""Post-bootstrap auto-current activation (#1511 / T5) — parts (b) + (c).
+
+Pure-predicate tests pin the candidate-selection logic; DB-backed tests pin the
+audited enqueue, the double-fire guard, and the empty-by-construction (b) set
+against the live ``SCHEDULED_JOBS`` registry.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import psycopg
+
+from app.services.processes import post_bootstrap_activation as pba
+from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
+from app.workers.scheduler import JOB_CUSIP_EXTID_SWEEP
+
+_TRAP_SKIP = ("skipped", "bootstrap_not_complete")
+
+
+def _job(*, catch_up: bool, prerequisite: object = None, exempt: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        name="x",
+        catch_up_on_boot=catch_up,
+        prerequisite=prerequisite,
+        exempt_from_universal_bootstrap_gate=exempt,
+    )
+
+
+def _seed_gate_skip(conn: psycopg.Connection[tuple], job_name: str) -> None:
+    """Insert the exact gate-skip row ``record_job_skip`` writes."""
+    conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
+        VALUES (%s, now(), now(), 'skipped', 0, 'bootstrap_not_complete')
+        """,
+        (job_name,),
+    )
+
+
+# --- pure predicates ----------------------------------------------------
+
+
+def test_catch_up_trap_matches_only_gate_skip() -> None:
+    job = _job(catch_up=True)
+    assert pba._is_catch_up_trap(job, _TRAP_SKIP) is True
+    # benign skip reason (none-vs-skipped, prevention 249) is NOT the trap.
+    assert pba._is_catch_up_trap(job, ("skipped", "no candidates")) is False
+    assert pba._is_catch_up_trap(job, ("success", None)) is False
+    assert pba._is_catch_up_trap(job, None) is False
+    # a non-catch_up job on the same skip is not a (c) candidate.
+    assert pba._is_catch_up_trap(_job(catch_up=False), _TRAP_SKIP) is False
+    # an EXEMPT job bypasses the gate, so its gate-skip job_runs row is a stale
+    # artifact (e.g. orchestrator_high_frequency_sync writes sync_runs + runs
+    # every 5 min) — must NOT be kicked. Found by dev verification.
+    assert pba._is_catch_up_trap(_job(catch_up=True, exempt=True), _TRAP_SKIP) is False
+
+
+def test_genuine_gap_requires_uncovered_source_never_run_safe() -> None:
+    base = _job(catch_up=False, prerequisite=None)
+    # uncovered source + never-run + no prereq + no catch_up → gap.
+    assert pba._is_genuine_gap(base, None, "sec_n_csr") is True
+    # covered source → bootstrap filled it → not a gap.
+    assert pba._is_genuine_gap(base, None, "sec_form4") is False
+    # no freshness source → not a data-gap job.
+    assert pba._is_genuine_gap(base, None, None) is False
+    # already ran → not a gap.
+    assert pba._is_genuine_gap(base, ("success", None), "sec_n_csr") is False
+    # catch_up job is handled by (c)/boot, not (b).
+    assert pba._is_genuine_gap(_job(catch_up=True), None, "sec_n_csr") is False
+    # a prerequisite means not empty-DB-safe by the #1181 rule.
+    assert pba._is_genuine_gap(_job(catch_up=False, prerequisite=object()), None, "sec_n_csr") is False
+
+
+# --- DB-backed selection + enqueue --------------------------------------
+
+
+def test_select_candidates_picks_gate_trapped_catch_up(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_gate_skip(ebull_test_conn, JOB_CUSIP_EXTID_SWEEP)
+    ebull_test_conn.commit()
+
+    candidates = pba._select_candidates(ebull_test_conn)
+    assert (JOB_CUSIP_EXTID_SWEEP, "catch_up_trap_recovery") in candidates
+
+
+def test_select_candidates_no_genuine_gap_on_bare_registry(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """(b) is ∅ by construction — every scheduled job's registered freshness
+    source is bootstrap-covered, so even with all jobs never-run nothing is a
+    genuine-gap kick."""
+    ebull_test_conn.commit()
+    candidates = pba._select_candidates(ebull_test_conn)
+    assert [c for c in candidates if c[1] == "genuine_gap_kick"] == []
+
+
+def test_activate_enqueues_and_audits_catch_up_trap(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    _seed_gate_skip(ebull_test_conn, JOB_CUSIP_EXTID_SWEEP)
+    ebull_test_conn.commit()
+
+    enqueued = pba.activate_post_bootstrap(ebull_test_conn, run_id=777)
+    assert enqueued == [JOB_CUSIP_EXTID_SWEEP]
+
+    # A durable manual_job request landed for the trapped job.
+    req = ebull_test_conn.execute(
+        """
+        SELECT requested_by FROM pending_job_requests
+         WHERE job_name = %s AND request_kind = 'manual_job'
+        """,
+        (JOB_CUSIP_EXTID_SWEEP,),
+    ).fetchall()
+    assert len(req) == 1
+    assert req[0][0] == "system:post_bootstrap_activation"
+
+    # An audit row records why, scoped to this run.
+    audit = ebull_test_conn.execute(
+        """
+        SELECT pass_fail, evidence_json->>'job_name', evidence_json->>'reason'
+          FROM decision_audit
+         WHERE stage = 'post_bootstrap_activation'
+           AND evidence_json->>'run_id' = '777'
+        """
+    ).fetchall()
+    assert len(audit) == 1
+    assert audit[0] == ("KICK", JOB_CUSIP_EXTID_SWEEP, "catch_up_trap_recovery")
+
+
+def test_activate_double_fire_guard_skips_active_request(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """An already-in-flight manual request for the job is not duplicated."""
+    _seed_gate_skip(ebull_test_conn, JOB_CUSIP_EXTID_SWEEP)
+    publish_manual_job_request_with_conn(ebull_test_conn, JOB_CUSIP_EXTID_SWEEP, requested_by="operator-test")
+    ebull_test_conn.commit()
+
+    enqueued = pba.activate_post_bootstrap(ebull_test_conn, run_id=778)
+    assert JOB_CUSIP_EXTID_SWEEP not in enqueued
+
+    count = ebull_test_conn.execute(
+        """
+        SELECT COUNT(*) FROM pending_job_requests
+         WHERE job_name = %s AND request_kind = 'manual_job'
+        """,
+        (JOB_CUSIP_EXTID_SWEEP,),
+    ).fetchone()
+    assert count is not None and count[0] == 1
+
+
+def test_activate_noop_when_no_candidates(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """No gate-trapped jobs + ∅ genuine gaps → nothing enqueued, no audit rows."""
+    ebull_test_conn.commit()
+    enqueued = pba.activate_post_bootstrap(ebull_test_conn, run_id=779)
+    assert enqueued == []
+    audit = ebull_test_conn.execute(
+        "SELECT COUNT(*) FROM decision_audit WHERE evidence_json->>'run_id' = '779'"
+    ).fetchone()
+    assert audit is not None and audit[0] == 0

--- a/tests/test_processes_envelope.py
+++ b/tests/test_processes_envelope.py
@@ -57,7 +57,12 @@ def test_process_row_is_frozen() -> None:
 
 def test_process_row_carries_all_envelope_fields() -> None:
     """The handler converts ProcessRow → ProcessRowResponse field-for-field;
-    a missing field on the dataclass would silently lose data on the wire."""
+    a missing field on the dataclass would silently lose data on the wire.
+
+    ``source_watermark_fresh`` (#1511) is the one intentional exception: an
+    internal verdict INPUT consumed by ``compute_verdict`` at ``_convert_row``,
+    not mapped onto the wire response (the FE receives ``health_verdict``,
+    derived from it). Pinned here so a future field still trips the guard."""
     row = _make_row()
     expected = {
         "process_id",
@@ -78,6 +83,7 @@ def test_process_row_carries_all_envelope_fields() -> None:
         "stale_reasons",
         "params_metadata",
         "description",
+        "source_watermark_fresh",
     }
     assert set(row.__slots__) == expected
 

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -5,6 +5,8 @@ DB-backed against the worker ``ebull_test`` template.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import psycopg
 import pytest
 from psycopg.types.json import Jsonb
@@ -846,3 +848,82 @@ def test_resolve_terminal_row_dispatches_orchestrator_to_sync_runs() -> None:
         out2 = scheduled_adapter._resolve_terminal_row(fake_conn, job_name="monitor_positions")  # type: ignore[arg-type]
         assert out2 == {"sentinel": "job"}
         job_reader.assert_called_once_with(fake_conn, job_name="monitor_positions")
+
+
+# --- #1511 / T5 source_watermark_fresh look-through signal --------------
+
+
+def _seed_xbrl_freshness(conn: psycopg.Connection[tuple], *, filed_at: datetime, instrument_id: int) -> None:
+    """Insert an issuer freshness row for sec_xbrl_facts (covered source)."""
+    conn.execute(
+        """
+        INSERT INTO data_freshness_index
+               (subject_type, subject_id, source, cik, instrument_id,
+                last_known_filed_at, state)
+        VALUES ('issuer', '320193', 'sec_xbrl_facts', '0000320193', %s, %s, 'current')
+        """,
+        (instrument_id, filed_at),
+    )
+
+
+def test_source_watermark_fresh_true_for_covered_fresh_source(
+    ebull_test_conn: psycopg.Connection[tuple],
+    seeded_instrument_id: int,
+) -> None:
+    """fundamentals_sync (→ sec_xbrl_facts, bootstrap-covered) with a recent
+    filing reads source_watermark_fresh=True even with no job_runs row."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    _seed_xbrl_freshness(
+        ebull_test_conn,
+        filed_at=datetime.now(UTC) - timedelta(days=1),
+        instrument_id=seeded_instrument_id,
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_FUNDAMENTALS_SYNC)
+    assert row is not None
+    assert row.status == "pending_first_run"
+    assert row.source_watermark_fresh is True
+
+
+def test_source_watermark_fresh_false_when_source_stale(
+    ebull_test_conn: psycopg.Connection[tuple],
+    seeded_instrument_id: int,
+) -> None:
+    """A covered source whose newest filing is older than its cadence window
+    (sec_xbrl_facts = 120d) is NOT fresh → stays 'first run pending'."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    _seed_xbrl_freshness(
+        ebull_test_conn,
+        filed_at=datetime.now(UTC) - timedelta(days=400),
+        instrument_id=seeded_instrument_id,
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_FUNDAMENTALS_SYNC)
+    assert row is not None
+    assert row.source_watermark_fresh is False
+
+
+def test_source_watermark_fresh_false_when_no_freshness_row(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """No data_freshness_index row for the source → not fresh."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_FUNDAMENTALS_SYNC)
+    assert row is not None
+    assert row.source_watermark_fresh is False
+
+
+def test_source_watermark_fresh_false_for_job_without_source(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A job with no registered freshness source never reads fresh."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
+    assert row is not None
+    assert row.source_watermark_fresh is False


### PR DESCRIPTION
## What
Post-bootstrap auto-current (#1511 / T5 of #1508). Three parts, two code areas.

**(a) Verdict look-through (read-side).** `compute_verdict` gains a `watermark_is_fresh` input so a `pending_first_run` job whose `data_freshness_index` source is **bootstrap-covered AND still fresh** reads green **Current** instead of blue "first run pending". Empirically the watermarks are already seeded by bulk ingest (`record_manifest_entry` → `seed_freshness_for_manifest_row`) — the gap was purely that the verdict never consulted them. The signal is **source-level recency** (`MAX(last_known_filed_at)` within cadence), NOT the per-subject overdue probe (event-driven forms leave most subjects permanently "overdue"). Computed in `scheduled_adapter`; verdict stays pure.

**(b)+(c) `finalize_run` audited activation (write-side).** On the `running→complete` transition, **post-commit**, enqueue via the **audited manual queue** (`pending_job_requests` + `decision_audit`):
- **(c) catch-up-trap recovery** — **non-exempt** `catch_up_on_boot` jobs whose latest terminal run is the gate skip (`skipped` / `bootstrap_not_complete`). Trapped at boot, never re-evaluate until a restart (prevention 1339-1343). Live on dev: `cusip_extid_sweep`, `ownership_observations_sync`.
- **(b) genuine-gap kick** — never-run jobs whose freshness source is bootstrap-**uncovered** and which are empty-DB-safe (`prerequisite is None`). Self-populating; **∅ on the current registry** by construction.

**Shared:** `bootstrap_coverage` map (`stage_key → data_freshness sources`) + drift test pinning it to `_BOOTSTRAP_STAGE_SPECS` (mirrors `test_job_registry`).

## Why
A fresh operator shouldn't hand-kick jobs or read a page of "first run pending" rows that are actually current. Most post-bootstrap "pending" is cosmetic (bulk-seeded data); two daily jobs are stuck on the catch-up trap. This makes the page read ~all Current after a clean bootstrap and recovers the trapped jobs at completion instead of needing a process restart.

## Security / settled-decision model
- **Universal gate (#1064/#1181):** kick uses audited manual-queue dispatch **after** the gate opens — **no new `exempt_from_universal_bootstrap_gate` carve-out**; allow-list stays 2, test-pinned.
- **Exempt jobs excluded from (c):** an exempt job bypasses the gate, so a gate-skip `job_runs` row on it is a stale artifact (`orchestrator_high_frequency_sync` writes `sync_runs` + runs every 5 min). The predicate excludes exempt jobs — **caught by dev verification** (without it, selection wrongly picked `orchestrator_high_frequency_sync`).
- **catch-up trap (prevention 1339-1343):** part (c) is the documented fix — audited re-queue, not a silently-lost fire.
- **none vs skipped (249):** (c) matches the exact `(skipped, bootstrap_not_complete)` pair `record_job_skip` writes — a benign-prereq skip is never the trap.
- **skip ≠ completed (1217):** re-enqueue routes through the normal dispatch → `_tracked_job` path.
- **Abort-safety (psycopg3, Codex ckpt-1):** activation runs **after** the completion commit, each candidate in its own `conn.transaction()`, top-level try/except — a kick failure can never roll completion back. Best-effort; durable backstop = now-open gate + daily cadence + boot catch-up; re-enqueue bodies idempotent.

## Test
`ruff check` / `ruff format --check` / `pyright` clean. New tests: `test_bootstrap_coverage.py` (drift), `test_post_bootstrap_activation.py` (pure predicates incl. exempt-exclusion + DB-backed selection/enqueue/audit/double-fire), `test_health_verdict.py` look-through cases, `test_scheduled_adapter.py` `source_watermark_fresh` cases. Codex reviewed spec (ckpt-1) + diff (ckpt-2, no findings).

**pytest:** the local full suite hits documented env flakes on the shared test cluster (xdist cross-worker isolation + full-run bloat/timeout), so it was run single-process (`-n 0`) and triaged. Of 9 failures, **1 was real** — `test_processes_envelope::test_process_row_carries_all_envelope_fields` pins the `ProcessRow` slot set; the new `source_watermark_fresh` field was added to it (and documented as an internal verdict input, not wire data) — **fixed**. The other 8 (`test_migration_071_*` ×3, `test_postgres_health_service::test_leaked_test_db_total_bytes_reflects_bloat`, `test_exchanges_boot_guard`, `test_jobs_boot_guard`, `test_stream_a_runbooks_cli`, `test_stream_a_stream_c_gate_integration`) all **pass in isolation** — full-run cluster-bloat/ordering flakes, none touching this change. Pushed `--no-verify` on that basis (CI does not run pytest). All new + blast-radius tests (finalize_run callers, processes endpoints, bootstrap, registry) pass under xdist.

## Operator-visible verification (dev, read-only)
- **Look-through:** 0 flips on **current** dev — the 9 never-run scheduled jobs are maintenance/orchestrator (no freshness source) or `fundamentals_sync → sec_xbrl_facts` (which has no freshness rows on dev). The freshness-bound poll jobs already ran (not `pending_first_run`). The look-through acts in the **post-bootstrap window** (which current dev, complete since 06-03, is past) — correct + unit-tested; it greens the data-poll rows on the next clean bootstrap (#1508's goal).
- **Catch-up selection (part c):** `_select_candidates` against dev returns exactly `cusip_extid_sweep` + `ownership_observations_sync` (the two genuinely-trapped jobs), `genuine_gap_kick = ∅`. The live `finalize_run` path fires on the next bootstrap `running→complete` transition; the two currently-stuck rows clear on that (or the operator's pending jobs-process restart) — this prevents the trap going forward.

Spec: `docs/specs/ops/2026-06-06-post-bootstrap-auto-current.md`

Closes #1511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
