### PR TITLE
fix(#1516): widen finra short-interest ratio cols to NUMERIC(20,4)

### DIFF
--- a/sql/184_finra_short_interest_widen_ratio_cols.sql
+++ b/sql/184_finra_short_interest_widen_ratio_cols.sql
@@ -53,26 +53,32 @@
 -- an inline COMMIT would split them (prevention-log: tx-bound migrations).
 
 DO $$
+DECLARE
+    rec RECORD;
 BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'finra_short_interest_observations'
-          AND column_name = 'days_to_cover'
-          AND numeric_precision = 10
-    ) THEN
-        ALTER TABLE finra_short_interest_observations
-            ALTER COLUMN days_to_cover  TYPE NUMERIC(20, 4),
-            ALTER COLUMN change_percent TYPE NUMERIC(20, 4);
-    END IF;
-
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'finra_short_interest_current'
-          AND column_name = 'days_to_cover'
-          AND numeric_precision = 10
-    ) THEN
-        ALTER TABLE finra_short_interest_current
-            ALTER COLUMN days_to_cover  TYPE NUMERIC(20, 4),
-            ALTER COLUMN change_percent TYPE NUMERIC(20, 4);
-    END IF;
+    -- Guard EACH (table, column) independently so a partial prior state
+    -- (one column already widened, its sibling not) still widens the
+    -- narrow one. The shape check fires per column, never coupling
+    -- change_percent's widening to days_to_cover's precision.
+    FOR rec IN
+        SELECT v.tbl, v.col
+        FROM (VALUES
+            ('finra_short_interest_observations', 'days_to_cover'),
+            ('finra_short_interest_observations', 'change_percent'),
+            ('finra_short_interest_current',      'days_to_cover'),
+            ('finra_short_interest_current',      'change_percent')
+        ) AS v(tbl, col)
+    LOOP
+        IF EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = rec.tbl
+              AND column_name = rec.col
+              AND numeric_precision = 10
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE %I ALTER COLUMN %I TYPE NUMERIC(20, 4)',
+                rec.tbl, rec.col
+            );
+        END IF;
+    END LOOP;
 END$$;

--- a/sql/184_finra_short_interest_widen_ratio_cols.sql
+++ b/sql/184_finra_short_interest_widen_ratio_cols.sql
@@ -1,0 +1,78 @@
+-- 184_finra_short_interest_widen_ratio_cols.sql
+--
+-- Issue: #1516 (surfaced while diagnosing epic #1508).
+--
+-- ## Why
+--
+-- finra_short_interest_refresh aborts every settlement file that contains an
+-- edge instrument whose FINRA-supplied days_to_cover or change_percent is
+-- >= 10^6: both columns are NUMERIC(10,4) (max 999,999.9999) in
+-- finra_short_interest_observations AND finra_short_interest_current
+-- (sql/152_finra_short_interest.sql:34-35,115-116). FINRA publishes such
+-- values legitimately — near-zero ADV yields a huge days-to-cover, near-zero
+-- prior short interest yields a huge percent change. The whole-file COPY/UPSERT
+-- aborts with:
+--
+--     NumericValueOutOfRange: numeric field overflow
+--     DETAIL: A field with precision 10, scale 4 must round to an absolute
+--             value less than 10^6.
+--
+-- Three dev settlement files fail repeatedly: 2025-09-15, 2025-11-28,
+-- 2026-04-15. The values are valid FINRA data, just wider than the column —
+-- so the fix is to widen, not to clamp/parse. Shares columns are already
+-- NUMERIC(20,0) (correct); only the two ratio columns are too narrow.
+--
+-- Widen days_to_cover + change_percent to NUMERIC(20,4) on both tables.
+-- finra_short_interest_observations is partitioned by settlement_date —
+-- ALTER COLUMN ... TYPE on the partitioned parent propagates to every
+-- partition (PG14+).
+--
+-- ## Lock impact
+--
+-- Verified empirically on PG17 (dev): widening NUMERIC(10,4) -> NUMERIC(20,4)
+-- keeps the same precision-class storage and does NOT rewrite the table
+-- (pg_relation_filenode unchanged across the ALTER). Metadata-only, sub-second.
+-- It still takes a brief ACCESS EXCLUSIVE lock on the parent + each partition +
+-- the current table while it runs, but with no rewrite the lock is held only for
+-- the catalog update — negligible for these tables.
+--
+-- ## Idempotency
+--
+-- The migration runner records each file once in schema_migrations, so this
+-- runs once. The DO-block shape guards (numeric_precision check on the parent
+-- tables) make a manual re-run a no-op anyway, matching the issue's request.
+--
+-- ## ETL clauses
+--
+-- CLAUDE.md ETL clauses 8-11: this is a column-width fix, not a parser/identity
+-- change — no re-parse needed. The DoD backfill (re-run the 3 failed settlement
+-- dates and confirm they upsert) is recorded in the PR body (clause 12).
+--
+-- No explicit BEGIN/COMMIT: the migration runner wraps the body + the
+-- schema_migrations INSERT in one transaction (app/db/migrations.run_migrations);
+-- an inline COMMIT would split them (prevention-log: tx-bound migrations).
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'finra_short_interest_observations'
+          AND column_name = 'days_to_cover'
+          AND numeric_precision = 10
+    ) THEN
+        ALTER TABLE finra_short_interest_observations
+            ALTER COLUMN days_to_cover  TYPE NUMERIC(20, 4),
+            ALTER COLUMN change_percent TYPE NUMERIC(20, 4);
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'finra_short_interest_current'
+          AND column_name = 'days_to_cover'
+          AND numeric_precision = 10
+    ) THEN
+        ALTER TABLE finra_short_interest_current
+            ALTER COLUMN days_to_cover  TYPE NUMERIC(20, 4),
+            ALTER COLUMN change_percent TYPE NUMERIC(20, 4);
+    END IF;
+END$$;

--- a/tests/fixtures/finra/shrt20260430_overflow.csv
+++ b/tests/fixtures/finra/shrt20260430_overflow.csv
@@ -1,0 +1,2 @@
+accountingYearMonthNumber|symbolCode|issueName|issuerServicesGroupExchangeCode|marketClassCode|currentShortPositionQuantity|previousShortPositionQuantity|stockSplitFlag|averageDailyVolumeQuantity|daysToCoverQuantity|revisionFlag|changePercent|changePreviousNumber|settlementDate
+20260430|AAPL|Apple Inc. Common Stock|R|NNM|134675274|2||1|1234567.8900||9876543.2100|134675272|2026-04-30

--- a/tests/test_finra_short_interest_ingest.py
+++ b/tests/test_finra_short_interest_ingest.py
@@ -247,63 +247,6 @@ def test_ingest_skips_defect_rows(
 
 
 # ----------------------------------------------------------------------
-# 5 — Wide ratio columns (#1516): days_to_cover / change_percent >= 10^6
-#     persist rather than aborting the whole file. Regression for the
-#     NUMERIC(10,4) overflow widened to NUMERIC(20,4) in sql/184.
-# ----------------------------------------------------------------------
-
-
-def test_ingest_persists_ratio_values_over_one_million(
-    ebull_test_conn: psycopg.Connection[tuple],
-) -> None:
-    """A FINRA row with days_to_cover=1234567.89 and change_percent=9876543.21
-    (both >= 10^6, both valid FINRA edge-instrument values) must upsert. Before
-    sql/184 these overflowed NUMERIC(10,4) and aborted the whole settlement
-    file (#1516)."""
-    _seed_instrument(ebull_test_conn, instrument_id=1001, symbol="AAPL")
-    resolver = build_preloaded_symbol_resolver(ebull_test_conn)
-    raw = _OVERFLOW.read_bytes()
-    ingest_run_id = uuid4()
-
-    with ebull_test_conn.transaction():
-        stats = ingest_settlement_file(
-            ebull_test_conn,
-            date(2026, 4, 30),
-            raw,
-            resolver,
-            ingest_run_id,
-        )
-
-    assert stats.rows_parsed == 1
-    assert stats.rows_resolved == 1
-    assert stats.rows_upserted == 1
-    assert stats.skipped_invalid_row == 0
-
-    with ebull_test_conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT days_to_cover, change_percent
-            FROM finra_short_interest_observations
-            WHERE instrument_id = %s AND settlement_date = %s
-            """,
-            (1001, date(2026, 4, 30)),
-        )
-        obs = cur.fetchone()
-        assert obs is not None
-        assert obs[0] == Decimal("1234567.8900")
-        assert obs[1] == Decimal("9876543.2100")
-
-        cur.execute(
-            "SELECT days_to_cover, change_percent FROM finra_short_interest_current WHERE instrument_id = %s",
-            (1001,),
-        )
-        current = cur.fetchone()
-        assert current is not None
-        assert current[0] == Decimal("1234567.8900")
-        assert current[1] == Decimal("9876543.2100")
-
-
-# ----------------------------------------------------------------------
 # 5 — Header corruption raises HeaderCorruptionError
 # ----------------------------------------------------------------------
 
@@ -549,3 +492,60 @@ def test_filed_at_anchored_at_settlement_midnight_utc(
         row = cur.fetchone()
         assert row is not None
         assert row[0] == expected
+
+
+# ----------------------------------------------------------------------
+# 10 — Wide ratio columns (#1516): days_to_cover / change_percent >= 10^6
+#      persist rather than aborting the whole file. Regression for the
+#      NUMERIC(10,4) overflow widened to NUMERIC(20,4) in sql/184.
+# ----------------------------------------------------------------------
+
+
+def test_ingest_persists_ratio_values_over_one_million(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A FINRA row with days_to_cover=1234567.89 and change_percent=9876543.21
+    (both >= 10^6, both valid FINRA edge-instrument values) must upsert. Before
+    sql/184 these overflowed NUMERIC(10,4) and aborted the whole settlement
+    file (#1516)."""
+    _seed_instrument(ebull_test_conn, instrument_id=1001, symbol="AAPL")
+    resolver = build_preloaded_symbol_resolver(ebull_test_conn)
+    raw = _OVERFLOW.read_bytes()
+    ingest_run_id = uuid4()
+
+    with ebull_test_conn.transaction():
+        stats = ingest_settlement_file(
+            ebull_test_conn,
+            date(2026, 4, 30),
+            raw,
+            resolver,
+            ingest_run_id,
+        )
+
+    assert stats.rows_parsed == 1
+    assert stats.rows_resolved == 1
+    assert stats.rows_upserted == 1
+    assert stats.skipped_invalid_row == 0
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT days_to_cover, change_percent
+            FROM finra_short_interest_observations
+            WHERE instrument_id = %s AND settlement_date = %s
+            """,
+            (1001, date(2026, 4, 30)),
+        )
+        obs = cur.fetchone()
+        assert obs is not None
+        assert obs[0] == Decimal("1234567.8900")
+        assert obs[1] == Decimal("9876543.2100")
+
+        cur.execute(
+            "SELECT days_to_cover, change_percent FROM finra_short_interest_current WHERE instrument_id = %s",
+            (1001,),
+        )
+        current = cur.fetchone()
+        assert current is not None
+        assert current[0] == Decimal("1234567.8900")
+        assert current[1] == Decimal("9876543.2100")

--- a/tests/test_finra_short_interest_ingest.py
+++ b/tests/test_finra_short_interest_ingest.py
@@ -21,6 +21,7 @@ Spec: docs/superpowers/specs/2026-05-18-finra-bimonthly-short-interest.md.
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
+from decimal import Decimal
 from pathlib import Path
 from uuid import uuid4
 
@@ -37,6 +38,7 @@ from app.services.finra_short_interest_ingest import (
 
 _PRISTINE = Path("tests/fixtures/finra/shrt20260430_sample.csv")
 _DEFECTS = Path("tests/fixtures/finra/shrt20260430_defects.csv")
+_OVERFLOW = Path("tests/fixtures/finra/shrt20260430_overflow.csv")
 
 
 # ----------------------------------------------------------------------
@@ -242,6 +244,63 @@ def test_ingest_skips_defect_rows(
     assert stats.skipped_no_instrument_match == 1
     # blank-symbol + truncated + malformed-int all bucket as invalid.
     assert stats.skipped_invalid_row == 3
+
+
+# ----------------------------------------------------------------------
+# 5 — Wide ratio columns (#1516): days_to_cover / change_percent >= 10^6
+#     persist rather than aborting the whole file. Regression for the
+#     NUMERIC(10,4) overflow widened to NUMERIC(20,4) in sql/184.
+# ----------------------------------------------------------------------
+
+
+def test_ingest_persists_ratio_values_over_one_million(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A FINRA row with days_to_cover=1234567.89 and change_percent=9876543.21
+    (both >= 10^6, both valid FINRA edge-instrument values) must upsert. Before
+    sql/184 these overflowed NUMERIC(10,4) and aborted the whole settlement
+    file (#1516)."""
+    _seed_instrument(ebull_test_conn, instrument_id=1001, symbol="AAPL")
+    resolver = build_preloaded_symbol_resolver(ebull_test_conn)
+    raw = _OVERFLOW.read_bytes()
+    ingest_run_id = uuid4()
+
+    with ebull_test_conn.transaction():
+        stats = ingest_settlement_file(
+            ebull_test_conn,
+            date(2026, 4, 30),
+            raw,
+            resolver,
+            ingest_run_id,
+        )
+
+    assert stats.rows_parsed == 1
+    assert stats.rows_resolved == 1
+    assert stats.rows_upserted == 1
+    assert stats.skipped_invalid_row == 0
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT days_to_cover, change_percent
+            FROM finra_short_interest_observations
+            WHERE instrument_id = %s AND settlement_date = %s
+            """,
+            (1001, date(2026, 4, 30)),
+        )
+        obs = cur.fetchone()
+        assert obs is not None
+        assert obs[0] == Decimal("1234567.8900")
+        assert obs[1] == Decimal("9876543.2100")
+
+        cur.execute(
+            "SELECT days_to_cover, change_percent FROM finra_short_interest_current WHERE instrument_id = %s",
+            (1001,),
+        )
+        current = cur.fetchone()
+        assert current is not None
+        assert current[0] == Decimal("1234567.8900")
+        assert current[1] == Decimal("9876543.2100")
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## What
`days_to_cover` + `change_percent` were `NUMERIC(10,4)` (max 999,999.9999) in both `finra_short_interest_observations` and `finra_short_interest_current` (`sql/152_finra_short_interest.sql:34-35,115-116`). FINRA legitimately publishes values ≥ 10^6 for edge instruments (near-zero ADV → huge days-to-cover; near-zero prior short interest → huge % change), so `finra_short_interest_refresh` aborted the whole settlement file with `NumericValueOutOfRange` — failing every day on dev and turning `/system/status` red (the one red Processes row, surfaced while diagnosing #1508).

`sql/184` widens both ratio columns to `NUMERIC(20,4)` on both tables. No parser change — the values are valid, just wider than the column. Shares columns are already `NUMERIC(20,0)` (correct); only the two ratio cols were too narrow.

## Why this shape
- **Idempotent**: DO-block shape guard (`numeric_precision = 10` check per table) makes a manual re-run a no-op; the runner records the file once anyway.
- **Partition propagation**: `ALTER COLUMN ... TYPE` on the partitioned `observations` parent propagates to every partition (PG14+); verified all partitions now `p20`.
- **Lock/rewrite**: verified empirically on PG17 — widening `NUMERIC(10,4)→(20,4)` is metadata-only, no table rewrite (`pg_relation_filenode` unchanged across the ALTER). Brief `ACCESS EXCLUSIVE` lock for the catalog update only.
- **No inline COMMIT**: the migration runner wraps body + `schema_migrations` insert in one tx (prevention-log: tx-bound migrations).

## Test
- New `tests/fixtures/finra/shrt20260430_overflow.csv` + `test_ingest_persists_ratio_values_over_one_million`: a row with `days_to_cover=1234567.89` and `change_percent=9876543.21` (both ≥ 10^6) must upsert into observations + current rather than abort the file. DB-tier (`-m db`).

## Dev verification (DoD), at commit ef305f5
- **Migration applied on dev** (`scripts/migrate.py`) — all 4 cols + every partition now `NUMERIC(20,4)`.
- **Backfill executed**: re-ran `run_finra_short_interest_refresh` on dev. The 3 previously-failing settlement dates now upsert, `failed_files=0`:
  - 2025-09-15 → 5490 rows
  - 2025-11-28 → 5576 rows
  - 2026-04-15 → 5620 rows
- **Operator-visible figure**: rows whose ratio cols exceed the old 10^6 ceiling now persist, e.g. `change_percent=171206000.0000` (i=15534, 2026-04-15) and `57598300.0000` (i=1051020, 2025-09-15) — the exact values that aborted the file pre-184.
- **Cross-source order-of-magnitude sane** vs public FINRA/marketbeat: GME 57.9M shares short / dtc 4.16, AAPL 138.8M / 2.74, MSFT 77.3M / 2.34 (settle 2026-05-15).

## Gates
ruff check ✓ · ruff format ✓ · pyright ✓ · `pytest -m "not db"` 3437 passed ✓ · smoke 129 passed ✓ · finra db tier 18 passed ✓ · Codex ckpt-2 no findings.

## Note
#1509's permanent-failure classification (DB_CONSTRAINT → no retry) already stopped the retry-storm; this removes the underlying daily failure so the row goes green.

Closes #1516