### PR TITLE
feat(#1510): liveness watchdog acts — re-enqueue stalled jobs + wire stall into status/verdict (T4 of #1508)

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -435,6 +435,10 @@ def _convert_row(row: ProcessRow) -> ProcessRowResponse:
         watermark_is_fresh=row.source_watermark_fresh,
         retry_in_flight=retry_in_flight,
         retry_at_display=retry_at_display,
+        # #1510 / T4 — a fresh liveness-watchdog re-enqueue reads the stalled
+        # row as Self-healing "re-enqueued, recovering" (a genuine wedge still
+        # outranks). Set by scheduled_adapter; other adapters leave it False.
+        liveness_kick_in_flight=row.liveness_kick_in_flight,
     )
     return ProcessRowResponse(
         process_id=row.process_id,

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -243,12 +243,14 @@ def _derive_overall_status(
     layers: list[LayerHealth],
     jobs: list[JobHealth],
     kill_switch_active: bool,
+    stalled_job_names: set[str] | None = None,
 ) -> OverallStatus:
     """Worst-of(components).
 
     - kill switch active   → "down"  (system is intentionally halted)
     - any layer "error"    → "down"  (infra fault)
     - any job "failure"    → "down"
+    - any job stalled (silently stopped firing) → "degraded"  (#1510 / T4)
     - any layer "stale"/"empty" → "degraded"
     - any job currently "running" → "degraded"
     - otherwise → "ok"
@@ -260,6 +262,15 @@ def _derive_overall_status(
     can see exactly what is missing. A fresh deploy will still report
     "degraded" via the empty data layers, which is the more meaningful
     signal anyway.
+
+    A *stall* is different from "no runs ever": the job HAS fired before but has
+    recorded zero rows over K cadence cycles, so its latest terminal is an OLD
+    ``success`` and ``last_status='success'`` would otherwise keep the headline
+    ``ok`` while the job silently stopped (#1510). It is ``degraded`` not ``down``
+    — recoverable, and the watchdog may already be re-enqueuing it.
+    ``stalled_job_names`` is computed by the caller via ``find_stalled_jobs`` over
+    the SAME orchestrator-excluded registry the watchdog uses (self-tracked
+    orchestrator jobs write ``sync_runs`` not ``job_runs`` and would false-stall).
     """
     if kill_switch_active:
         return "down"
@@ -267,11 +278,33 @@ def _derive_overall_status(
         return "down"
     if any(job.last_status == "failure" for job in jobs):
         return "down"
+    if stalled_job_names:
+        return "degraded"
     if any(layer.status in ("stale", "empty") for layer in layers):
         return "degraded"
     if any(job.last_status == "running" for job in jobs):
         return "degraded"
     return "ok"
+
+
+def _stalled_job_names(conn: psycopg.Connection[object], now: datetime) -> set[str]:
+    """Names of scheduled jobs that have silently stopped firing (#1510 / T4).
+
+    Best-effort: any failure (DB hiccup mid-build) returns an empty set so the
+    stall signal degrades gracefully rather than 503-ing ``/system/status`` — the
+    headline degradation is a nice-to-have, not load-bearing for the page. Uses
+    the SAME orchestrator exclusion as the watchdog: ``orchestrator_*`` jobs write
+    ``sync_runs`` not ``job_runs`` and would otherwise false-stall.
+    """
+    try:
+        from app.services.job_liveness import find_stalled_jobs
+
+        excluded = {JOB_ORCHESTRATOR_FULL_SYNC, JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC}
+        jobs = [(j.name, j.cadence) for j in SCHEDULED_JOBS if j.name not in excluded]
+        return {s.job_name for s in find_stalled_jobs(conn, jobs, now)}
+    except Exception:
+        logger.warning("get_system_status: stall probe failed; headline stall signal omitted", exc_info=True)
+        return set()
 
 
 def _utcnow() -> datetime:
@@ -398,7 +431,14 @@ def get_system_status(
         logger.exception("get_system_status: failed to build report")
         raise HTTPException(status_code=503, detail="system status unavailable") from exc
 
-    overall = _derive_overall_status(layers, jobs, bool(ks["is_active"]))
+    # #1510 / T4 — surface a silently-stopped job in the headline. Best-effort:
+    # a stall-probe failure must NOT 503 the whole status page, so it is scoped
+    # to its own guard and defaults to "no stall". Same orchestrator exclusion as
+    # the watchdog (self-tracked sync jobs write sync_runs not job_runs and would
+    # false-stall).
+    stalled_job_names = _stalled_job_names(conn, now)
+
+    overall = _derive_overall_status(layers, jobs, bool(ks["is_active"]), stalled_job_names)
 
     return SystemStatusResponse(
         checked_at=now,

--- a/app/services/job_liveness_act.py
+++ b/app/services/job_liveness_act.py
@@ -1,0 +1,227 @@
+"""Liveness watchdog actuator (#1510 / T4 of epic #1508).
+
+Re-fires **stalled** scheduled jobs — those :func:`app.services.job_liveness.find_stalled_jobs`
+flagged (zero ``job_runs`` rows over K cadence cycles despite firing before, not
+running) — through the **audited manual-queue path**, the same mechanism
+``job_retry`` (#1509) and ``post_bootstrap_activation`` (#1511) use. The
+``jobs_liveness_watchdog`` (#1507) only LOGGED stalls; this turns a detected
+stall into one bounded, audited re-enqueue.
+
+Spec: ``docs/specs/ops/2026-06-07-liveness-watchdog-acts.md``.
+
+Why a stalled job is safe to kick (cause-awareness, load-bearing): the detector
+counts ANY ``job_runs`` status as a fire, so a job blocked by the bootstrap gate
+or a per-job prerequisite writes a ``skipped`` row every scheduled fire and is
+NEVER in the stalled set. A job that IS stalled has genuinely stopped firing —
+re-enqueue is the right remedy, not a re-entry into a held limit (#1484). The
+kick itself flows through the universal bootstrap-state gate (prevention-log
+1341), so a kick that should not run is rejected downstream — the issue's
+"blocked by gate -> Needs-attention, not a retry storm" path, for free.
+
+Storm bound (two guards, both mirrored from ``job_retry``):
+
+  * **In-tx stall recheck + in-flight dedup.** Detection runs before this loop,
+    so a natural fire could land in the gap; inside each candidate's transaction
+    we re-assert the stall AND skip if a live request / running row already
+    exists. Two watchdog fires cannot double-dispatch.
+  * **Cooldown via ``decision_audit``.** A ``liveness_kick`` audit newer than
+    ``max(cadence_period, 6h)`` means the prior kick did not take (gate-rejected
+    / dead scheduler) — do NOT re-kick; the row stays attention. Bounds
+    re-dispatch to once per cadence/6h, not once per 15-min watchdog fire.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+from app.services.job_liveness import cadence_period, find_stalled_jobs
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from app.services.job_liveness import StalledJob
+    from app.workers.scheduler import Cadence
+
+logger = logging.getLogger(__name__)
+
+_REQUESTED_BY = "system:liveness_kick"
+
+# Floor on the per-job cooldown between re-kicks. A daily job's cadence (24h)
+# already self-bounds; a 5-min job's cadence does not, so this floor stops a
+# wedged high-frequency job from being kicked every 15-min watchdog tick.
+_COOLDOWN_FLOOR = timedelta(hours=6)
+
+
+@dataclass(frozen=True)
+class ActResult:
+    """Outcome of one actuator pass."""
+
+    kicked: list[str]
+    blocked: list[str]
+
+
+def act_on_stalled_jobs(
+    conn: psycopg.Connection[Any],
+    *,
+    stalled: Sequence[StalledJob],
+    eligible: Mapping[str, Cadence],
+    now: datetime,
+) -> ActResult:
+    """Re-enqueue each eligible stalled job once. Returns names kicked / blocked.
+
+    ``conn`` MUST be autocommit so each candidate's ``conn.transaction()`` issues
+    a real ``BEGIN``/``COMMIT`` (the audited-manual-queue contract), not a
+    savepoint. ``eligible`` is ``{job_name: cadence}`` for ``SCHEDULED_JOBS``
+    minus the sync-runs-tracked orchestrator jobs — the cadence drives the
+    cooldown floor and the in-tx stall recheck.
+    """
+    assert conn.autocommit, "act_on_stalled_jobs requires an autocommit connection"
+    kicked: list[str] = []
+    blocked: list[str] = []
+    for job in stalled:
+        cadence = eligible.get(job.job_name)
+        if cadence is None:
+            # Not eligible (orchestrator_* / unregistered) — never dispatch.
+            continue
+        try:
+            outcome = _act_one(conn, job_name=job.job_name, cadence=cadence, now=now)
+        except Exception:
+            logger.exception(
+                "jobs_liveness_watchdog: re-enqueue failed for %r — leaving stalled for next pass",
+                job.job_name,
+            )
+            continue
+        if outcome == "kicked":
+            kicked.append(job.job_name)
+        elif outcome == "blocked":
+            blocked.append(job.job_name)
+    if kicked:
+        logger.info(
+            "jobs_liveness_watchdog: re-enqueued %d stalled job(s) via audited manual queue: %s",
+            len(kicked),
+            ", ".join(kicked),
+        )
+    if blocked:
+        logger.warning(
+            "jobs_liveness_watchdog: %d stalled job(s) blocked (kick did not take within cooldown): %s",
+            len(blocked),
+            ", ".join(blocked),
+        )
+    return ActResult(kicked=kicked, blocked=blocked)
+
+
+def _act_one(
+    conn: psycopg.Connection[Any],
+    *,
+    job_name: str,
+    cadence: Cadence,
+    now: datetime,
+) -> str:
+    """Recheck + re-enqueue one candidate atomically.
+
+    Returns ``"kicked"`` / ``"blocked"`` / ``"skip"``.
+    """
+    from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
+
+    with conn.transaction():
+        # Per-job xact advisory lock (Codex ckpt-2): unlike job_retry there is no
+        # durable failed row to lock FOR UPDATE, so without this two concurrent
+        # actors (a second watchdog run, an operator kick, the retry sweeper)
+        # could both pass the recheck + dedup before either INSERT commits and
+        # double-enqueue. Process-level single-instancing is not DB isolation
+        # (prevention-log 410). Namespaced key so it cannot collide with the
+        # process_stop prelude lock that keys on the bare process_id.
+        conn.execute(
+            "SELECT pg_advisory_xact_lock(hashtext(%s)::bigint)",
+            (f"liveness_kick:{job_name}",),
+        )
+        # In-tx stall recheck (Codex ckpt-1 #3): a natural fire may have landed
+        # between find_stalled_jobs and here. Re-run the exact same predicate for
+        # this one job; if it fired, it is no longer stalled -> skip.
+        if not find_stalled_jobs(conn, [(job_name, cadence)], now):
+            return "skip"
+        # In-flight dedup: a live request / running row will produce a fresh
+        # terminal -> defer without acting.
+        if _has_running_run(conn, job_name) or _has_active_request(conn, job_name):
+            return "skip"
+        # Cooldown: a recent kick that did not clear the stall means the kick is
+        # not taking (gate-rejected / dead scheduler). Do not storm — surface
+        # blocked so the operator sees a genuinely-stuck job.
+        cooldown_start = now - max(cadence_period(cadence), _COOLDOWN_FLOOR)
+        if _kicked_since(conn, job_name, cooldown_start):
+            return "blocked"
+        publish_manual_job_request_with_conn(
+            conn,
+            job_name,
+            requested_by=_REQUESTED_BY,
+            process_id=job_name,
+            mode="iterate",
+        )
+        _write_liveness_audit(conn, job_name=job_name, now=now)
+        return "kicked"
+
+
+def _has_running_run(conn: psycopg.Connection[Any], job_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM job_runs WHERE job_name = %(job)s AND status = 'running' LIMIT 1",
+        {"job": job_name},
+    ).fetchone()
+    return row is not None
+
+
+def _has_active_request(conn: psycopg.Connection[Any], job_name: str) -> bool:
+    """True when a manual_job request for ``job_name`` is already in flight."""
+    row = conn.execute(
+        """
+        SELECT 1
+          FROM pending_job_requests
+         WHERE job_name = %(job_name)s
+           AND request_kind = 'manual_job'
+           AND status IN ('pending', 'claimed', 'dispatched')
+         LIMIT 1
+        """,
+        {"job_name": job_name},
+    ).fetchone()
+    return row is not None
+
+
+def _kicked_since(conn: psycopg.Connection[Any], job_name: str, since: datetime) -> bool:
+    """True if a ``liveness_kick`` audit for ``job_name`` exists at/after ``since``."""
+    row = conn.execute(
+        """
+        SELECT 1
+          FROM decision_audit
+         WHERE stage = 'liveness_kick'
+           AND decision_time >= %(since)s
+           AND evidence_json ->> 'job_name' = %(job)s
+         LIMIT 1
+        """,
+        {"since": since, "job": job_name},
+    ).fetchone()
+    return row is not None
+
+
+def _write_liveness_audit(conn: psycopg.Connection[Any], *, job_name: str, now: datetime) -> None:
+    """Record the audited re-enqueue in ``decision_audit`` (mirrors the retry audit)."""
+    explanation = f"liveness: re-enqueued stalled job {job_name!r} (no fires in K cadence cycles)"
+    conn.execute(
+        """
+        INSERT INTO decision_audit
+            (decision_time, stage, pass_fail, explanation, evidence_json)
+        VALUES
+            (NOW(), 'liveness_kick', 'KICK', %(expl)s, %(evidence)s)
+        """,
+        {
+            "expl": explanation,
+            "evidence": Jsonb({"job_name": job_name}),
+        },
+    )
+
+
+__all__ = ["ActResult", "act_on_stalled_jobs"]

--- a/app/services/processes/__init__.py
+++ b/app/services/processes/__init__.py
@@ -216,6 +216,14 @@ class ProcessRow:
     # from it for ``compute_verdict`` so a transiently-failed row reads
     # Self-healing "will retry HH:MM" instead of red. None = no retry pending.
     next_retry_at: datetime | None = None
+    # #1510 / T4 — True when a FRESH ``manual_job`` re-enqueue placed by the
+    # liveness watchdog (``requested_by='system:liveness_kick'``) is in flight
+    # for this job. Set by scheduled_adapter via a dedicated EXISTS probe
+    # bounded to ``requested_at >= now - 30m`` (a kick aged past that window is
+    # itself wedged and must not keep painting the row green). Fed to
+    # ``compute_verdict(liveness_kick_in_flight=...)`` so a watchdog-re-enqueued
+    # stalled job reads Self-healing "re-enqueued, recovering" instead of red.
+    liveness_kick_in_flight: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/services/processes/health_verdict.py
+++ b/app/services/processes/health_verdict.py
@@ -25,16 +25,16 @@ queue_stuck`` would render blue "working" while a worker is wedged, and
 dispatched request is stuck — re-introducing the masking the verdict
 exists to kill.
 
-**v1 scope:** T5's watermark look-through is wired here (the
-``watermark_is_fresh`` input promotes a ``pending_first_run`` job on a
-bootstrap-covered, still-fresh source to Current — #1511). T3
-(retry/``next_retry_at``) and T4 (watchdog re-enqueue) are not yet
-landed, so the only ``self_healing`` source remains the existing
-``pending_retry`` status. An overdue row with no recovery mechanism
-reads **attention** — honest, because it currently IS stuck. When T3/T4
-land they extend this function (add ``next_retry_at`` / liveness inputs)
-to reclassify *covered* overdue rows from ``attention`` to
-``self_healing`` with a "will retry HH:MM" reason.
+**Scope:** all three recovery look-throughs are now wired —
+``watermark_is_fresh`` promotes a bootstrap-covered, still-fresh
+``pending_first_run`` job to Current (#1511 / T5); ``retry_in_flight`` +
+``retry_at_display`` read a transiently-failed row as Self-healing
+"will retry HH:MM" (#1509 / T3); and ``liveness_kick_in_flight`` reads a
+watchdog-re-enqueued *stalled* job as Self-healing "re-enqueued,
+recovering" (#1510 / T4). An overdue row with NO recovery mechanism in
+flight still reads **attention** — honest, because it currently IS stuck.
+In every case a genuine wedge (``queue_stuck`` / ``mid_flight_stuck`` /
+``watermark_gap``) outranks the recovery signal and stays attention.
 """
 
 from __future__ import annotations
@@ -75,6 +75,7 @@ def compute_verdict(
     watermark_is_fresh: bool = False,
     retry_in_flight: bool = False,
     retry_at_display: str = "",
+    liveness_kick_in_flight: bool = False,
 ) -> tuple[HealthVerdict, bool, str]:
     """Collapse ``status`` + ``stale_reasons`` into one verdict.
 
@@ -105,6 +106,23 @@ def compute_verdict(
     if retry_in_flight:
         actionable = [r for r in actionable if r != "schedule_missed"]
 
+    # T4 (#1510): a liveness-watchdog re-enqueue IS the fix for a job that
+    # silently stopped firing (the ``schedule_missed`` it surfaces as), so an
+    # in-flight kick suppresses ONLY ``schedule_missed`` — exactly like a retry.
+    # Genuine wedges (``queue_stuck`` / ``mid_flight_stuck`` / ``watermark_gap``)
+    # are NOT dropped, so the actionable block below still returns attention for
+    # them (ckpt-1 invariant: an actionable wedge is never masked — a kick into a
+    # stuck queue does not make the queue un-stuck).
+    #
+    # ``kick_is_recovering`` gates the self_healing branch below on the stall
+    # ACTUALLY being present (Codex ckpt-2): a kick request can linger
+    # ``pending``/``claimed`` after a natural fire already cleared the stall, and
+    # a recovered row (no ``schedule_missed``) must read its honest status, not be
+    # repainted "re-enqueued, recovering".
+    kick_is_recovering = liveness_kick_in_flight and "schedule_missed" in stale_reasons
+    if liveness_kick_in_flight:
+        actionable = [r for r in actionable if r != "schedule_missed"]
+
     # 1. Kill switch — global, deliberate, outranks everything (incl. a
     #    stale reason that may still compute on a halted job).
     if status == "disabled":
@@ -121,6 +139,18 @@ def compute_verdict(
         else:
             reason = _REASON_LABEL[actionable[0]]
         return ("attention", False, reason)
+
+    # T4 (#1510): a fresh liveness-watchdog re-enqueue is in flight FOR A ROW THAT
+    # IS STILL STALLED (``schedule_missed`` present — see ``kick_is_recovering``)
+    # and no genuine wedge outranks it (the actionable block above already
+    # returned for ``queue_stuck`` / ``mid_flight_stuck`` / ``watermark_gap``).
+    # The system detected the silent stall and is auto-recovering it —
+    # Self-healing, no operator action. Placed before the status-only branches
+    # because a kick does NOT flip the adapter status to ``running`` unless the
+    # last terminal was a failure (scheduled_adapter:211), so a stalled ``ok`` /
+    # ``idle`` row would otherwise fall through to Current and hide the recovery.
+    if kick_is_recovering:
+        return ("self_healing", True, "re-enqueued, recovering")
 
     # 3-9. Status-only (no actionable stale).
     if status == "running":

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -408,6 +408,37 @@ def _has_inflight_manual_request(conn: psycopg.Connection[Any], *, job_name: str
         return cur.fetchone() is not None
 
 
+# #1510 / T4 — a liveness-kick request older than this is itself wedged (queue
+# not draining / scheduler dead) and must NOT keep painting the row self-healing;
+# past the window the probe returns False and the row falls back to its honest
+# schedule_missed / queue_stuck → attention surface. 30 min = 2× the 15-min
+# watchdog interval. Process-wide death stays owned by supervisor/heartbeat (#719).
+_LIVENESS_KICK_FRESH_WINDOW = timedelta(minutes=30)
+
+
+def _has_inflight_liveness_kick(conn: psycopg.Connection[Any], *, job_name: str, now: datetime) -> bool:
+    """True if a FRESH watchdog re-enqueue (``requested_by='system:liveness_kick'``)
+    is live for this job. Dedicated EXISTS probe — not an unordered LIMIT 1 read of
+    the requester (Codex ckpt-1 #4: multiple live manual requests can coexist)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                  FROM pending_job_requests
+                 WHERE request_kind = 'manual_job'
+                   AND job_name     = %(name)s
+                   AND requested_by = 'system:liveness_kick'
+                   AND status       IN ('pending', 'claimed', 'dispatched')
+                   AND requested_at >= %(fresh_floor)s
+            )
+            """,
+            {"name": job_name, "fresh_floor": now - _LIVENESS_KICK_FRESH_WINDOW},
+        )
+        row = cur.fetchone()
+        return bool(row[0]) if row is not None else False
+
+
 def _has_data_freshness_gap(
     conn: psycopg.Connection[Any],
     *,
@@ -814,6 +845,12 @@ def _build_row(
         and _source_watermark_fresh(conn, source=freshness_source, now=now)
     )
 
+    # #1510 / T4 — verdict signal: a fresh watchdog re-enqueue is in flight, so
+    # ``compute_verdict`` reads this re-enqueued stall as Self-healing rather than
+    # the red schedule_missed it would otherwise show (a genuine wedge still
+    # outranks). Probe is cheap (single EXISTS) and bounded to the 30-min window.
+    liveness_kick_in_flight = _has_inflight_liveness_kick(conn, job_name=job.name, now=now)
+
     can_cancel = (
         active_run is not None and active_run.run_id is not None and process_status == "running"
         # short-runners (heartbeat etc.) are not worth cooperative-cancel;
@@ -858,6 +895,8 @@ def _build_row(
         # (``.get`` so the sync_runs-shaped row, which has no such column,
         # yields None — those jobs never schedule a retry anyway).
         next_retry_at=terminal_row.get("next_retry_at") if terminal_row is not None else None,
+        # #1510 / T4 — fresh watchdog re-enqueue in flight (see compute_verdict).
+        liveness_kick_in_flight=liveness_kick_in_flight,
     )
 
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4269,16 +4269,23 @@ def jobs_liveness_watchdog() -> None:
     from datetime import UTC, datetime
 
     from app.services.job_liveness import evaluate_liveness
+    from app.services.job_liveness_act import act_on_stalled_jobs
 
     # Self-tracked jobs write ``sync_runs`` not ``job_runs`` — excluding
     # them avoids a permanent false-stall (Codex ckpt-1).
     excluded = {JOB_ORCHESTRATOR_FULL_SYNC, JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC}
-    jobs = [(j.name, j.cadence) for j in SCHEDULED_JOBS if j.name not in excluded]
+    eligible = {j.name: j.cadence for j in SCHEDULED_JOBS if j.name not in excluded}
+    jobs = list(eligible.items())
 
     with _tracked_job(JOB_LIVENESS_WATCHDOG) as tracker:
         now = datetime.now(UTC)
         with psycopg.connect(settings.database_url, autocommit=True) as conn:
             stalled, active = evaluate_liveness(conn, jobs, now)
+            # T4 (#1510): act — re-enqueue each stalled job once via the audited
+            # manual queue (bounded by in-tx stall recheck + in-flight dedup +
+            # cooldown). Same autocommit conn so each candidate tx is a real
+            # BEGIN/COMMIT.
+            act_on_stalled_jobs(conn, stalled=stalled, eligible=eligible, now=now)
         tracker.row_count = len(stalled)
         for job in stalled:
             logger.warning(

--- a/docs/specs/ops/2026-06-07-liveness-watchdog-acts.md
+++ b/docs/specs/ops/2026-06-07-liveness-watchdog-acts.md
@@ -1,0 +1,216 @@
+# Liveness watchdog acts — re-enqueue stalled jobs + wire stall into status/verdict
+
+Issue: #1510 (T4 of epic #1508). Extends #1500/#1507 (`job_liveness`), builds #649.
+Relates #1484 (rate-limit backoff), prevention-log 1217 (terminal-state) + 1341 (universal gate).
+
+## Problem
+
+`jobs_liveness_watchdog` (#1507) DETECTS stalled jobs — zero `job_runs` rows over
+K=3 cadence cycles despite ≥1 lifetime row and not running — but only **logs**
+them. Two gaps remain:
+
+1. **No action.** A silently-stopped scheduled job stays stopped until an operator
+   notices. We have the audited manual-queue path (`publish_manual_job_request_with_conn`)
+   used by `job_retry` (#1509) and `post_bootstrap_activation` (#1511) — wire it in.
+2. **Invisible at the top line.** `app/api/system.py::_derive_overall_status` rolls
+   up `failure` → `down` and `running`/stale-layer → `degraded`, but a stalled job's
+   latest terminal row is an OLD `success`, so `last_status='success'` → `overall_status`
+   stays `ok`. The standalone `/system/job-liveness` shows the stall; the headline does not.
+
+The per-row Processes verdict (#1512) already paints a stalled job `attention` via the
+`schedule_missed` stale reason — honest. This spec makes that row read `self_healing`
+once the watchdog has re-enqueued it.
+
+## Why a stalled job is safe to kick (cause-awareness, load-bearing)
+
+The detector counts **any** `job_runs` status as a fire (#1507 design note). A job
+blocked by the bootstrap gate or a per-job prerequisite writes a `skipped` row on every
+scheduled fire (`record_job_skip`) → `recent > 0` → it is **never in the stalled set**.
+Therefore a job that IS stalled has genuinely stopped firing (scheduler wedge, crash-loop,
+mis-schedule) — re-enqueuing is the correct remedy, not a re-entry into a held limit.
+
+The kick itself flows through the **universal bootstrap-state gate** that runs before
+every dispatch path (prevention-log 1341). If the system is mid-bootstrap or the job's
+prereq is unmet, the dispatcher rejects the request (`bootstrap_not_complete` etc.) — so
+a kick that should not run does not run. That is the issue's "blocked by gate →
+Needs-attention, not a retry storm" path, handled downstream for free.
+
+## Storm bound (#1484)
+
+Two guards, both mirrored from `job_retry`:
+
+* **In-flight dedup + in-tx stall recheck.** Skip a candidate that already has a live
+  `manual_job` `pending_job_requests` row or a `running` `job_runs` row. Detection
+  (`find_stalled_jobs`) runs BEFORE the act loop, so a natural cadence fire could complete
+  in the gap and the dedup probes would still be false at kick time (Codex ckpt-1 #3) —
+  therefore, inside the per-candidate transaction, **re-assert the stall predicate**
+  (`find_stalled_jobs` for this one job, or an inline "zero rows in the K-window") before
+  publish. A job that fired in the gap is no longer stalled → skip. This closes the
+  detect→act race; two watchdog fires (15 min apart) cannot double-dispatch.
+* **Cooldown via `decision_audit`.** Before kicking, check for a `liveness_kick` audit
+  row for this job newer than `max(cadence_period, COOLDOWN_FLOOR=6h)`. If one exists and
+  the job is STILL stalled, the previous kick did not take (rejected by gate, or the
+  scheduler is dead) → **do not re-kick**; the row stays `schedule_missed → attention`,
+  (any kick request has aged past the §D freshness window so it no longer paints
+  self-healing) — the honest "blocked" surface. This bounds re-dispatch to once per
+  cadence/6h, not once per 15-min watchdog fire.
+
+  Rationale for the floor: a daily job's cadence (24h) already self-bounds; a 5-min job's
+  cadence does not, so the 6h floor prevents a wedged high-frequency job from being kicked
+  every watchdog tick. (A genuinely-recovered kick writes a row → leaves the stalled set →
+  the cooldown is moot.)
+
+## Design
+
+### A. Act service — `app/services/job_liveness_act.py`
+
+Mirrors `app/services/job_retry.py::sweep_due_retries`. Autocommit conn; one
+`conn.transaction()` per candidate (psycopg3 abort-safety — prevention `psycopg3_savepoint_commit`).
+
+```python
+def act_on_stalled_jobs(conn, *, stalled, eligible, now) -> ActResult:
+    # stalled: Sequence[StalledJob] from find_stalled_jobs
+    # eligible: Mapping[str, Cadence]  (SCHEDULED_JOBS minus orchestrator_*) —
+    #           the cadence is needed for the per-job cooldown floor + in-tx recheck
+    # returns ActResult(kicked: list[str], blocked: list[str])
+    for job in stalled:
+        cadence = eligible.get(job.job_name)
+        if cadence is None:                           # not eligible (orchestrator_* / unknown)
+            continue
+        with conn.transaction():
+            # In-tx stall recheck (Codex ckpt-1 #3): a natural fire may have landed
+            # between detect and here. Re-assert zero rows in the K-window for THIS job;
+            # if it fired, it is no longer stalled → skip.
+            if not _still_stalled(conn, job.job_name, cadence, now):
+                continue
+            if _has_running_run(conn, job.job_name) or _has_active_request(conn, job.job_name):
+                continue                              # in-flight dedup — defer
+            if _kicked_within_cooldown(conn, job.job_name, cadence, now):
+                blocked.append(job.job_name); continue  # already tried, still stalled ⇒ blocked
+            publish_manual_job_request_with_conn(
+                conn, job.job_name, requested_by='system:liveness_kick',
+                process_id=job.job_name, mode='iterate')
+            _write_liveness_audit(conn, job)          # decision_audit stage='liveness_kick'
+            kicked.append(job.job_name)
+    return ActResult(kicked, blocked)
+```
+
+`_still_stalled` reuses `job_liveness.window_start_for` + the same count query
+`find_stalled_jobs` runs (lifetime≥1, recent==0, not running) for a single job — keep it a
+thin wrapper so detection and recheck share the exact predicate (no drift).
+
+`_kicked_within_cooldown` reads `decision_audit WHERE stage='liveness_kick' AND
+evidence_json->>'job_name'=:name AND decision_time >= :cooldown_start`. `cooldown_start =
+now - max(cadence_period(cadence), 6h)`; cadence looked up per job (passed in with each
+`StalledJob` or via the eligible registry map).
+
+**Decision (Codex):** duplicate `_has_running_run` / `_has_active_request` (the 4-line
+queries) into `job_liveness_act` rather than extracting a shared module — they are tiny
+local predicates and extraction creates coupling without enough shared behaviour.
+
+### B. Watchdog body — `app/workers/scheduler.py::jobs_liveness_watchdog`
+
+After `evaluate_liveness`, call `act_on_stalled_jobs` with the same eligible set the
+retry sweeper builds (`SCHEDULED_JOBS` minus the two orchestrator names). Log
+`kicked` / `blocked`. `tracker.row_count = len(stalled)` unchanged.
+
+### C. overall_status — `app/api/system.py::_derive_overall_status`
+
+Add param `stalled_job_names: set[str]`. New rule, between the `failure→down` and
+`stale-layer→degraded` checks:
+
+```python
+if stalled_job_names: return "degraded"   # a job silently stopped firing
+```
+
+A stall is `degraded`, never `down` (it is recoverable + may already be self-healing).
+The `/system/status` handler computes the stalled set by calling `find_stalled_jobs(conn,
+jobs, now)` where `jobs` is the **orchestrator-excluded** registry — the SAME
+`{JOB_ORCHESTRATOR_FULL_SYNC, JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC}` exclusion the watchdog
+uses (Codex ckpt-1 #2). Without it, sync-runs-tracked jobs (which never write `job_runs`)
+would false-stall and permanently degrade the headline.
+
+**Decision (Codex):** call `find_stalled_jobs` directly, not a cached watchdog result —
+caching would make the headline stale and add invalidation semantics. One extra count query
+per eligible job on the status endpoint, served by `idx_job_runs_name_started`
+(`sql/014_ops_monitor.sql:18`); acceptable for an operator endpoint that already does N
+`check_job_health` round-trips.
+
+### D. verdict — `compute_verdict` + `ProcessRow` + adapter + `_convert_row`
+
+Codex ckpt-1 #1: a live `manual_job` request only flips status→`running` when the latest
+terminal was a `failure` (`scheduled_adapter.py:211-214`). A stalled job's latest terminal
+is an old `success`(→`ok`) or `skipped`(→`idle`), so a kick does NOT make it `running` —
+relying on a `status=="running"` branch would fail acceptance #1. Instead **mirror the
+existing T3 `retry_in_flight` pattern**: a liveness kick IS the fix for a missed schedule,
+so it suppresses `schedule_missed` exactly like a retry does, then a dedicated branch
+returns `self_healing`. No adapter status machine change.
+
+* `ProcessRow` gains `liveness_kick_in_flight: bool = False`.
+* `scheduled_adapter` sets it via a **dedicated EXISTS probe** (Codex ckpt-1 #4 — do not
+  reuse an unordered `LIMIT 1` requester read; multiple live manual requests can coexist):
+
+  ```sql
+  SELECT EXISTS (
+      SELECT 1 FROM pending_job_requests
+       WHERE request_kind = 'manual_job' AND job_name = %(name)s
+         AND requested_by = 'system:liveness_kick'
+         AND status IN ('pending','claimed','dispatched')
+         AND created_at >= %(fresh_floor)s )      -- freshness bound, Codex ckpt-1 #5
+  ```
+
+  `fresh_floor = now - _LIVENESS_KICK_FRESH_WINDOW` (30 min = 2× watchdog interval). A kick
+  request that has sat `pending`/`claimed` beyond the window is itself wedged (queue not
+  draining / scheduler dead) → the probe returns False → the row falls back to its honest
+  `schedule_missed`/`queue_stuck` → `attention` surface rather than masking as
+  self-healing forever (Codex ckpt-1 #5). Process-wide death remains owned by
+  `supervisor.py`/heartbeat (#719); this age-bound just stops a stuck kick from painting
+  green indefinitely.
+
+* `compute_verdict` gains `liveness_kick_in_flight: bool = False`:
+  * In the suppression block (next to `retry_in_flight`): drop `schedule_missed` from
+    `actionable` when `liveness_kick_in_flight` — the kick is the in-flight fix. Genuine
+    wedges (`queue_stuck` / `mid_flight_stuck` / `watermark_gap`) are NOT dropped, so the
+    actionable block still returns `attention` for them (ckpt-1 invariant preserved).
+  * A dedicated branch AFTER the actionable block, BEFORE the status-only branches:
+
+    ```python
+    if liveness_kick_in_flight:
+        return ("self_healing", True, "re-enqueued, recovering")
+    ```
+
+  A blocked stall (cooldown active, no fresh in-flight kick) keeps `schedule_missed` →
+  `attention` — the honest surface, no new branch.
+
+`_convert_row` passes `row.liveness_kick_in_flight` through.
+
+## Out of scope
+
+* Scheduler-process-wide death (a watchdog cannot report its own stall — owned by
+  `supervisor.py` / heartbeat, #719).
+* Changing K, the cadence-window math, or `find_stalled_jobs` (T4 only consumes it).
+* `/system/job-liveness` response shape — it already lists stalled jobs; optionally add
+  `kicked`/`blocked` to its body (nice-to-have, not required by acceptance).
+
+## Acceptance (from #1510)
+
+1. Stalled job, eligible, no in-flight request, outside cooldown → one audited kick →
+   row reads `self_healing` "re-enqueued, recovering"; `decision_audit` stage
+   `liveness_kick` row written. ✅ A/B/D
+2. Stalled job kicked-and-still-stalled (gate-rejected / dead scheduler), inside
+   cooldown → NOT re-kicked → stays `attention` (`schedule_missed`). ✅ storm-bound
+3. `overall_status` returns `degraded` when ≥1 job is stalled. ✅ C
+
+## Tests (lean — pure where possible)
+
+* **Pure** `test_health_verdict`: `liveness_kick_in_flight=True` + `status='running'` →
+  `self_healing`; + an actionable wedge (`queue_stuck`) → still `attention` (invariant).
+* **Pure** `test_derive_overall_status`: non-empty stalled set → `degraded`; empty → unchanged.
+* **Pure/seam** `act_on_stalled_jobs`: with a fake/seamed conn — eligibility filter,
+  in-flight dedup, cooldown bound, audit written. Prefer table-tested decision helpers
+  (`_kicked_within_cooldown` boundary) over a full DB harness; ONE `-m db` integration
+  test exercising publish + audit end-to-end.
+* **Dev-verify**: trigger the watchdog on dev (`POST /jobs/jobs_liveness_watchdog/run` is
+  unauth in dev — run via the in-process path used for the finra backfill), confirm a
+  genuinely-stalled job gets one `liveness_kick` audit row + the Processes row flips to
+  self_healing; confirm `/system/status` `overall_status` reflects any stall.

--- a/tests/services/processes/test_health_verdict.py
+++ b/tests/services/processes/test_health_verdict.py
@@ -268,3 +268,60 @@ def test_total_and_single_valued_with_retry(status: ProcessStatus, reasons: tupl
     )
     assert verdict in _VALID_VERDICTS
     assert self_healing == (verdict == "self_healing")
+
+
+# ----------------------------------------------------------------------
+# #1510 / T4 — liveness_kick_in_flight (watchdog re-enqueue look-through)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["ok", "idle", "pending_first_run"])
+def test_liveness_kick_on_stalled_reads_self_healing(status: ProcessStatus) -> None:
+    """A stalled job (overdue ``ok``/``idle``/``pending_first_run`` +
+    schedule_missed) that the watchdog has re-enqueued reads Self-healing —
+    crucially even though a kick does NOT flip the adapter status to running."""
+    v, sh, reason = compute_verdict(status=status, stale_reasons=("schedule_missed",), liveness_kick_in_flight=True)
+    assert v == "self_healing"
+    assert sh is True
+    assert reason == "re-enqueued, recovering"
+
+
+def test_liveness_kick_suppresses_schedule_missed() -> None:
+    """The kick IS the fix for a missed schedule — it suppresses that reason."""
+    v, _, _ = compute_verdict(status="ok", stale_reasons=("schedule_missed",), liveness_kick_in_flight=True)
+    assert v == "self_healing"
+
+
+@pytest.mark.parametrize("wedge", ["queue_stuck", "mid_flight_stuck", "watermark_gap"])
+def test_liveness_kick_never_masks_genuine_wedge(wedge: StaleReason) -> None:
+    """Codex ckpt-1 invariant: a kick must NOT paint a genuinely-wedged row
+    self-healing — a kick into a stuck queue does not un-stick it."""
+    v, sh, _ = compute_verdict(status="running", stale_reasons=(wedge,), liveness_kick_in_flight=True)
+    assert v == "attention"
+    assert sh is False
+
+
+def test_liveness_kick_on_recovered_row_reads_honest_status() -> None:
+    """Codex ckpt-2: a kick request can linger pending/claimed after a natural
+    fire already cleared the stall (no schedule_missed). The recovered row must
+    read its honest status (current), NOT be repainted 're-enqueued, recovering'."""
+    v, sh, reason = compute_verdict(status="ok", stale_reasons=(), liveness_kick_in_flight=True)
+    assert v == "current"
+    assert sh is False
+    assert reason == ""
+
+
+def test_disabled_outranks_liveness_kick() -> None:
+    """Kill switch still wins over an in-flight kick."""
+    v, sh, reason = compute_verdict(status="disabled", stale_reasons=("schedule_missed",), liveness_kick_in_flight=True)
+    assert v == "attention"
+    assert reason == "kill switch active"
+
+
+@pytest.mark.parametrize("status", _ALL_STATUSES)
+@pytest.mark.parametrize("reasons", _all_reason_subsets())
+def test_total_and_single_valued_with_liveness_kick(status: ProcessStatus, reasons: tuple[StaleReason, ...]) -> None:
+    """Totality holds with the liveness-kick flag set, too."""
+    verdict, self_healing, _ = compute_verdict(status=status, stale_reasons=reasons, liveness_kick_in_flight=True)
+    assert verdict in _VALID_VERDICTS
+    assert self_healing == (verdict == "self_healing")

--- a/tests/services/test_job_liveness_act.py
+++ b/tests/services/test_job_liveness_act.py
@@ -1,0 +1,161 @@
+"""Liveness watchdog actuator (#1510 / T4 of epic #1508).
+
+DB-backed tests pin: a stalled job → one audited manual-queue kick
+(``requested_by='system:liveness_kick'`` + ``decision_audit`` row); an in-flight
+request / running row defers (no double-dispatch); a natural fire between detect
+and act drops the candidate (in-tx stall recheck); a recent kick within the
+cooldown surfaces ``blocked`` instead of re-storming; an ineligible job is never
+dispatched.
+
+Spec: ``docs/specs/ops/2026-06-07-liveness-watchdog-acts.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+from app.services.job_liveness import StalledJob
+from app.services.job_liveness_act import act_on_stalled_jobs
+from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
+from app.workers.scheduler import JOB_CUSIP_EXTID_SWEEP, Cadence
+
+JOB = JOB_CUSIP_EXTID_SWEEP
+CADENCE = Cadence.daily(hour=3, minute=0)
+ELIGIBLE = {JOB: CADENCE}
+_NOW = datetime(2026, 6, 7, 12, 0, tzinfo=UTC)
+
+
+def _stalled(job: str = JOB) -> StalledJob:
+    return StalledJob(job_name=job, window_seconds=3 * 86400.0, last_fire_at=_NOW - timedelta(days=10))
+
+
+def _seed_old_terminal(conn: psycopg.Connection[tuple], *, job: str = JOB, age_days: int = 10) -> None:
+    """A lifetime terminal row OLD enough to sit outside the K=3 daily window —
+    so find_stalled_jobs sees lifetime>=1, recent==0, not running ⇒ stalled."""
+    at = _NOW - timedelta(days=age_days)
+    conn.execute(
+        "INSERT INTO job_runs (job_name, started_at, finished_at, status) VALUES (%s, %s, %s, 'success')",
+        (job, at, at),
+    )
+
+
+def _request_count(conn: psycopg.Connection[tuple], job: str = JOB) -> int:
+    row = conn.execute(
+        "SELECT COUNT(*) FROM pending_job_requests WHERE job_name = %s AND request_kind = 'manual_job'",
+        (job,),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _seed_kick_audit(conn: psycopg.Connection[tuple], *, job: str = JOB, when: datetime) -> None:
+    conn.execute(
+        """
+        INSERT INTO decision_audit (decision_time, stage, pass_fail, explanation, evidence_json)
+        VALUES (%s, 'liveness_kick', 'KICK', 'seeded', %s)
+        """,
+        (when, Jsonb({"job_name": job})),
+    )
+
+
+def test_stalled_job_kicked_audited(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    conn.autocommit = True
+    _seed_old_terminal(conn)
+
+    result = act_on_stalled_jobs(conn, stalled=[_stalled()], eligible=ELIGIBLE, now=_NOW)
+    assert result.kicked == [JOB]
+    assert result.blocked == []
+
+    req = conn.execute(
+        "SELECT requested_by, process_id, mode FROM pending_job_requests "
+        "WHERE job_name = %s AND request_kind = 'manual_job'",
+        (JOB,),
+    ).fetchall()
+    assert req == [("system:liveness_kick", JOB, "iterate")]
+
+    audit = conn.execute(
+        "SELECT pass_fail, evidence_json->>'job_name' FROM decision_audit WHERE stage = 'liveness_kick'"
+    ).fetchall()
+    assert audit == [("KICK", JOB)]
+
+
+def test_in_flight_request_defers(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    conn.autocommit = True
+    _seed_old_terminal(conn)
+    publish_manual_job_request_with_conn(conn, JOB, requested_by="operator-test")
+
+    result = act_on_stalled_jobs(conn, stalled=[_stalled()], eligible=ELIGIBLE, now=_NOW)
+    assert result.kicked == []
+    assert _request_count(conn) == 1  # no duplicate
+
+
+def test_running_row_defers(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    conn.autocommit = True
+    _seed_old_terminal(conn)
+    conn.execute("INSERT INTO job_runs (job_name, started_at, status) VALUES (%s, %s, 'running')", (JOB, _NOW))
+
+    result = act_on_stalled_jobs(conn, stalled=[_stalled()], eligible=ELIGIBLE, now=_NOW)
+    # A live running row means the job is NOT actually stalled (the in-tx recheck
+    # sees has_active_running) — defer, never kick.
+    assert result.kicked == []
+    assert _request_count(conn) == 0
+
+
+def test_recent_fire_drops_candidate(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """Detect→act race (Codex ckpt-1 #3): a natural fire landed in the gap, so the
+    in-tx recheck finds a recent row and the stale kick is not dispatched."""
+    conn = ebull_test_conn
+    conn.autocommit = True
+    _seed_old_terminal(conn)
+    # A fresh terminal inside the K-window — the job fired again after detection.
+    fresh = _NOW - timedelta(hours=1)
+    conn.execute(
+        "INSERT INTO job_runs (job_name, started_at, finished_at, status) VALUES (%s, %s, %s, 'success')",
+        (JOB, fresh, fresh),
+    )
+
+    result = act_on_stalled_jobs(conn, stalled=[_stalled()], eligible=ELIGIBLE, now=_NOW)
+    assert result.kicked == []
+    assert _request_count(conn) == 0
+
+
+def test_cooldown_blocks_second_kick(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """A prior liveness_kick within max(cadence, 6h) means the kick did not take
+    (gate-rejected / dead scheduler) → blocked, not re-stormed."""
+    conn = ebull_test_conn
+    conn.autocommit = True
+    _seed_old_terminal(conn)
+    _seed_kick_audit(conn, when=_NOW - timedelta(hours=1))  # within the 24h daily cooldown
+
+    result = act_on_stalled_jobs(conn, stalled=[_stalled()], eligible=ELIGIBLE, now=_NOW)
+    assert result.kicked == []
+    assert result.blocked == [JOB]
+    assert _request_count(conn) == 0  # no new request
+
+
+def test_kick_outside_cooldown_redispatches(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    conn.autocommit = True
+    _seed_old_terminal(conn)
+    _seed_kick_audit(conn, when=_NOW - timedelta(days=2))  # older than the 24h daily cooldown
+
+    result = act_on_stalled_jobs(conn, stalled=[_stalled()], eligible=ELIGIBLE, now=_NOW)
+    assert result.kicked == [JOB]
+    assert _request_count(conn) == 1
+
+
+def test_ineligible_job_never_dispatched(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    conn.autocommit = True
+    _seed_old_terminal(conn, job="some_orchestrator_job")
+
+    result = act_on_stalled_jobs(conn, stalled=[_stalled("some_orchestrator_job")], eligible=ELIGIBLE, now=_NOW)
+    assert result.kicked == []
+    assert result.blocked == []
+    assert _request_count(conn, "some_orchestrator_job") == 0

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -360,6 +360,35 @@ class TestSystemStatus:
         assert resp.status_code == 200
         assert resp.json()["overall_status"] == "degraded"
 
+    def test_stalled_job_degrades_overall(self) -> None:
+        """#1510 / T4: a silently-stopped job (its latest terminal is an OLD
+        success, so last_status='success' alone would keep the headline ``ok``)
+        degrades ``overall_status``. The stall set is computed by
+        ``_stalled_job_names``; patch it so the unit test stays DB-free."""
+        _override_conn(_mock_conn())
+
+        with (
+            patch("app.api.system.check_all_layers", return_value=_all_ok_layers()),
+            patch(
+                "app.api.system.check_job_health",
+                side_effect=lambda _conn, name: _success_job_health(name),
+            ),
+            patch("app.api.system._stalled_job_names", return_value={"daily_news_refresh"}),
+            patch(
+                "app.api.system.get_kill_switch_status",
+                return_value={
+                    "is_active": False,
+                    "activated_at": None,
+                    "activated_by": None,
+                    "reason": None,
+                },
+            ),
+        ):
+            resp = client.get("/system/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["overall_status"] == "degraded"
+
     def test_jobs_boot_error_null_when_no_breadcrumb(self) -> None:
         """Stream A PR-A T1.8 (#1233): /system/status surfaces NULL
         ``jobs_boot_error`` when bootstrap_state row has neither column
@@ -679,3 +708,46 @@ class TestJobLiveness:
         assert resp.status_code == 503
         assert resp.json()["detail"] == "job liveness unavailable"
         assert secret_marker not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# #1510 / T4 — _derive_overall_status stall precedence (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_derive_overall_status_stall_is_degraded() -> None:
+    from app.api.system import _derive_overall_status
+
+    layers = [_ok_layer("market_data")]
+    jobs = [_success_job_health("x")]
+    assert _derive_overall_status(layers, jobs, False, {"daily_news_refresh"}) == "degraded"
+
+
+def test_derive_overall_status_no_stall_stays_ok() -> None:
+    from app.api.system import _derive_overall_status
+
+    layers = [_ok_layer("market_data")]
+    jobs = [_success_job_health("x")]
+    assert _derive_overall_status(layers, jobs, False, set()) == "ok"
+    # Default arg (None) is also "no stall".
+    assert _derive_overall_status(layers, jobs, False) == "ok"
+
+
+def test_derive_overall_status_failure_outranks_stall() -> None:
+    """A genuine failure is ``down`` and must win over a (degraded) stall."""
+    from app.api.system import _derive_overall_status
+
+    failed = JobHealth(
+        job_name="x",
+        last_status="failure",
+        last_started_at=_NOW,
+        last_finished_at=_NOW,
+        detail="x: failed",
+    )
+    assert _derive_overall_status([_ok_layer("m")], [failed], False, {"y"}) == "down"
+
+
+def test_derive_overall_status_killswitch_outranks_stall() -> None:
+    from app.api.system import _derive_overall_status
+
+    assert _derive_overall_status([_ok_layer("m")], [_success_job_health("x")], True, {"y"}) == "down"

--- a/tests/test_processes_envelope.py
+++ b/tests/test_processes_envelope.py
@@ -59,11 +59,11 @@ def test_process_row_carries_all_envelope_fields() -> None:
     """The handler converts ProcessRow → ProcessRowResponse field-for-field;
     a missing field on the dataclass would silently lose data on the wire.
 
-    ``source_watermark_fresh`` (#1511) and ``next_retry_at`` (#1509) are the
-    intentional exceptions: internal verdict INPUTS consumed by
-    ``compute_verdict`` at ``_convert_row``, not mapped onto the wire response
-    (the FE receives ``health_verdict`` / ``verdict_reason``, derived from
-    them). Pinned here so a future field still trips the guard."""
+    ``source_watermark_fresh`` (#1511), ``next_retry_at`` (#1509) and
+    ``liveness_kick_in_flight`` (#1510) are the intentional exceptions: internal
+    verdict INPUTS consumed by ``compute_verdict`` at ``_convert_row``, not mapped
+    onto the wire response (the FE receives ``health_verdict`` / ``verdict_reason``,
+    derived from them). Pinned here so a future field still trips the guard."""
     row = _make_row()
     expected = {
         "process_id",
@@ -86,6 +86,7 @@ def test_process_row_carries_all_envelope_fields() -> None:
         "description",
         "source_watermark_fresh",
         "next_retry_at",
+        "liveness_kick_in_flight",
     }
     assert set(row.__slots__) == expected
 


### PR DESCRIPTION
## What
`jobs_liveness_watchdog` (#1507) only **logged** stalled scheduled jobs — zero `job_runs` rows over K=3 cadence cycles despite firing before, not running. A silently-stopped job was invisible on `/system/status` (its latest terminal is an OLD `success`, so `last_status='success'` kept the headline `ok`) and read red `attention` on the Processes page with no recovery. T4 makes the watchdog **act**, makes the stall visible at the headline, and reads a re-enqueued stall as Self-healing.

### A. Act — `app/services/job_liveness_act.py` (mirrors `job_retry.py`)
Re-enqueue each eligible stalled job once via the audited manual queue (`publish_manual_job_request_with_conn` `requested_by='system:liveness_kick'` + `decision_audit` `stage='liveness_kick'`). Cause-aware + storm-bound:
- **Per-job xact advisory lock** (`pg_advisory_xact_lock`) serialises recheck+dedup+publish — no durable failed row to `FOR UPDATE` (unlike `job_retry`), so without it two concurrent actors could double-enqueue. _(Codex ckpt-2)_
- **In-tx stall recheck** before publish closes the detect→act race. _(Codex ckpt-1)_
- **In-flight dedup** (live request / running row) defers.
- **Cooldown** via `decision_audit` (`max(cadence_period, 6h)`): a kick that did not take (gate-rejected / dead scheduler) surfaces `blocked`, not a re-storm.

Cause-awareness is load-bearing but free: a stalled job is *never* gate-skipped (skips write rows that count as fires → not in the stalled set), and the kick flows through the universal bootstrap gate, so a kick that shouldn't run is rejected downstream → "blocked → Needs-attention" with no extra logic.

### B. overall_status — `app/api/system.py`
A stall → `degraded` (recoverable; never `down`). Computed by `_stalled_job_names` (best-effort — a probe failure never 503s the page) over the same orchestrator-excluded registry the watchdog uses (self-tracked sync jobs write `sync_runs` not `job_runs` and would false-stall — Codex ckpt-1).

### C. verdict — `compute_verdict` + `ProcessRow` + `scheduled_adapter` + `_convert_row`
A kick is the fix for `schedule_missed` (suppressed like `retry_in_flight`), then reads `self_healing` "re-enqueued, recovering" — but **only while `schedule_missed` is still present** (`kick_is_recovering`), so a row a natural fire already recovered reads its honest status even if a stale kick request lingers (Codex ckpt-2). A genuine wedge (`queue_stuck`/`mid_flight_stuck`/`watermark_gap`) still outranks (ckpt-1 invariant). The adapter sets the flag via a dedicated `EXISTS` probe bounded to `requested_at >= now-30m` (Codex ckpt-1 #4/#5), so a kick aged past the window stops painting the row green.

## Why this shape
Spec `docs/specs/ops/2026-06-07-liveness-watchdog-acts.md`. Codex ckpt-1 (spec) fixed 5 findings: detect→act race recheck, orchestrator exclusion on `/system/status`, `EXISTS` probe vs unordered `LIMIT 1` requester, freshness bound, and suppress-not-force verdict (a kick does NOT flip adapter status to `running` for a non-failure terminal). Codex ckpt-2 (branch) fixed 2: the advisory lock + the recovered-row verdict gate.

## Test
- **Pure** `test_health_verdict`: self_healing on stalled+kick across `ok`/`idle`/`pending_first_run`; recovered-row reads honest `current`; wedge still `attention` (invariant); suppression; disabled outranks; totality with the flag.
- **Pure** `test_api_system`: `_derive_overall_status` stall→degraded, failure/killswitch outrank, no-stall→ok; plus a TestClient `/system/status` degraded case (patched `_stalled_job_names`).
- **DB** `test_job_liveness_act`: kick+audit, in-flight/running dedup, detect→act recheck race, cooldown block + outside-cooldown redispatch, ineligible never dispatched.
- `ProcessRow.__slots__` pin updated.

## Dev verification, at commit $(git rev-parse --short HEAD)
Ran the watchdog detect+act in-process against dev: **4 genuinely-stalled jobs detected and kicked** (`monitor_positions`, `ownership_observations_sync`, `cusip_extid_sweep`, `jobs_retry_sweeper`), all 4 `decision_audit` `liveness_kick` rows written. Downstream outcome confirms both paths: 2 requests **completed** (ran → recovered), 2 **rejected** by the gate/prereq (the "blocked → attention, no re-storm" path — cooldown holds for 6h). `/system/status` is bearer-auth-gated in dev (token unset → 401), so its code path is covered by the smoke test + the TestClient unit test rather than curl.

## Gates
ruff ✓ · pyright ✓ · `pytest -m "not db"` 3574 passed ✓ · smoke 129 passed ✓ · `test_job_liveness_act -m db` 7 passed ✓ · Codex ckpt-1 + ckpt-2 clean after fixes.

Part of #1508. Extends #1507/#1500, builds #649. Relates #1484.

Closes #1510