### PR TITLE
feat(#1513): Processes clean-bill-of-health header + collapse non-actionable rows (T2 of #1508)

### DIFF
--- a/frontend/src/components/admin/ProcessesTable.test.tsx
+++ b/frontend/src/components/admin/ProcessesTable.test.tsx
@@ -34,7 +34,7 @@ function renderTable(
   partial = false,
   onMutationSuccess = vi.fn(),
 ) {
-  return render(
+  const result = render(
     <MemoryRouter>
       <ProcessesTable
         snapshot={makeProcessList(rows, partial)}
@@ -42,6 +42,14 @@ function renderTable(
       />
     </MemoryRouter>,
   );
+  // #1513 — non-actionable rows collapse by default. Expand so the
+  // existing row-level assertions (actions, sort, filter) see every row;
+  // the default-collapsed behaviour has dedicated tests below.
+  const toggle = screen
+    .queryByTestId("collapsed-disclosure")
+    ?.querySelector("button");
+  if (toggle) fireEvent.click(toggle);
+  return result;
 }
 
 describe("ProcessesTable", () => {
@@ -71,7 +79,15 @@ describe("ProcessesTable", () => {
   it("filters by selected lane", () => {
     renderTable([
       makeProcessRow({ process_id: "x", lane: "sec", display_name: "X_sec" }),
-      makeProcessRow({ process_id: "y", lane: "ownership", display_name: "Y_own" }),
+      // Pinned verdict (attention) so the row stays visible after the lane
+      // switch re-collapses the default-quiet rows (#1513) — this test is
+      // about lane filtering, not the collapse.
+      makeProcessRow({
+        process_id: "y",
+        lane: "ownership",
+        display_name: "Y_own",
+        stale_reasons: ["queue_stuck"],
+      }),
     ]);
     fireEvent.click(screen.getByRole("button", { name: /^Ownership/ }));
     expect(screen.queryByRole("link", { name: "X_sec" })).toBeNull();
@@ -201,17 +217,18 @@ describe("ProcessesTable", () => {
   });
 
   // ---------------------------------------------------------------------
-  // PR8 (#1083) — stale banner integration. Banner unit-behaviour lives
-  // in StaleBanner.test.tsx; here we just confirm the table mounts it
-  // when at least one row is stale and hides it otherwise.
+  // #1513 — clean-bill health header integration. Header unit-behaviour
+  // lives in StaleBanner.test.tsx; here we just confirm the table mounts it
+  // with the positive all-clear when healthy and the summary otherwise.
   // ---------------------------------------------------------------------
 
-  it("does NOT render stale banner when all rows have empty stale_reasons", () => {
+  it("renders the all-clear header when all rows are healthy", () => {
     renderTable([makeProcessRow({ stale_reasons: [] })]);
-    expect(screen.queryByTestId("stale-banner")).toBeNull();
+    const header = screen.getByTestId("health-header");
+    expect(header.textContent).toContain("All systems current");
   });
 
-  it("renders stale banner when at least one row has stale_reasons", () => {
+  it("renders the attention summary header when at least one row needs attention", () => {
     renderTable([
       makeProcessRow({ process_id: "a", stale_reasons: [] }),
       makeProcessRow({
@@ -219,7 +236,9 @@ describe("ProcessesTable", () => {
         stale_reasons: ["watermark_gap"],
       }),
     ]);
-    expect(screen.getByTestId("stale-banner")).toBeTruthy();
+    expect(screen.getByTestId("health-header").textContent).toContain(
+      "need attention",
+    );
   });
 
   it("sorts stale rows above non-stale ok rows (status='ok' + stale_reasons populated)", () => {
@@ -340,7 +359,7 @@ describe("ProcessesTable", () => {
       | "partial_error"
       | null,
   ) {
-    return render(
+    const result = render(
       <MemoryRouter>
         <ProcessesTable
           snapshot={makeProcessList(rows, false)}
@@ -349,6 +368,13 @@ describe("ProcessesTable", () => {
         />
       </MemoryRouter>,
     );
+    // #1513 — expand the steady-state collapse so non-attention rows are
+    // assertable (no-op in bootstrap-only mode, where collapse is disabled).
+    const toggle = screen
+      .queryByTestId("collapsed-disclosure")
+      ?.querySelector("button");
+    if (toggle) fireEvent.click(toggle);
+    return result;
   }
 
   it("hides non-bootstrap rows + lane filter when bootstrap is partial_error", () => {
@@ -543,5 +569,62 @@ describe("ProcessesTable", () => {
       screen.getByRole("link", { name: "First-install bootstrap" }),
     ).toBeTruthy();
     expect(screen.getByRole("link", { name: "CIK refresh" })).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------
+  // #1513 — non-actionable rows collapse by default behind an inline
+  // disclosure; needs-attention rows are always visible.
+  // ---------------------------------------------------------------------
+
+  // Raw render (the shared renderTable auto-expands; here we want the
+  // default-collapsed state).
+  function renderTableRaw(rows: ReturnType<typeof makeProcessRow>[]) {
+    return render(
+      <MemoryRouter>
+        <ProcessesTable
+          snapshot={makeProcessList(rows, false)}
+          onMutationSuccess={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("collapses current/self-healing rows but pins attention and working rows", () => {
+    renderTableRaw([
+      makeProcessRow({ process_id: "att", display_name: "Attn", stale_reasons: ["queue_stuck"] }),
+      makeProcessRow({ process_id: "run", display_name: "Runn", status: "running", stale_reasons: [] }),
+      makeProcessRow({ process_id: "cur", display_name: "Curr", status: "ok", stale_reasons: [] }),
+      makeProcessRow({ process_id: "heal", display_name: "Heal", status: "pending_retry", stale_reasons: [] }),
+    ]);
+    // Attention + working (live run, exposes Cancel) stay pinned.
+    expect(screen.getByRole("link", { name: "Attn" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Runn" })).toBeTruthy();
+    // current + self-healing hide behind the disclosure.
+    expect(screen.queryByRole("link", { name: "Curr" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Heal" })).toBeNull();
+    const disclosure = screen.getByTestId("collapsed-disclosure");
+    expect(disclosure.textContent).toContain("1 current");
+    expect(disclosure.textContent).toContain("1 self-healing");
+  });
+
+  it("reveals the collapsed rows when the disclosure is clicked", () => {
+    renderTableRaw([
+      makeProcessRow({ process_id: "cur", display_name: "Curr", status: "ok", stale_reasons: [] }),
+    ]);
+    expect(screen.queryByRole("link", { name: "Curr" })).toBeNull();
+    fireEvent.click(
+      screen.getByTestId("collapsed-disclosure").querySelector("button")!,
+    );
+    expect(screen.getByRole("link", { name: "Curr" })).toBeTruthy();
+  });
+
+  it("renders no disclosure when every row needs attention", () => {
+    renderTableRaw([
+      makeProcessRow({ process_id: "a", display_name: "A", stale_reasons: ["queue_stuck"] }),
+      makeProcessRow({ process_id: "b", display_name: "B", status: "failed", stale_reasons: [] }),
+    ]);
+    expect(screen.queryByTestId("collapsed-disclosure")).toBeNull();
+    expect(screen.getByRole("link", { name: "A" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "B" })).toBeTruthy();
   });
 });

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -386,9 +386,10 @@ function isCollapsible(verdict: ProcessRowResponse["health_verdict"]): boolean {
   return verdict === "current" || verdict === "self_healing";
 }
 
-/** Disclosure label for the collapsed non-actionable rows (#1513), e.g.
- *  "12 current · 3 self-healing". `working` rows count as "current" for the
- *  summary (both are non-actionable in-progress/fresh states). */
+/** Disclosure label for the collapsed rows (#1513), e.g.
+ *  "12 current · 3 self-healing". Only `current` and `self_healing` are
+ *  collapsible (see isCollapsible); `current` here is the count of collapsed
+ *  `current`-verdict rows. */
 function collapsedLabel(current: number, selfHealing: number): string {
   const parts: string[] = [];
   if (current > 0) parts.push(`${current} current`);

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -16,7 +16,7 @@
  * failed" (loading-error-empty-states.md rule).
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ApiError } from "@/api/client";
 import { cancelProcess, triggerProcess } from "@/api/processes";
@@ -52,6 +52,10 @@ export interface ProcessesTableProps {
     | "complete"
     | "partial_error"
     | null;
+  // #1513 — client-side completion time of the last successful poll,
+  // rendered as the header's "checked HH:MM" freshness anchor. Optional;
+  // omitted (null) before the first poll lands.
+  readonly checkedAt?: Date | null;
 }
 
 interface RowErrorState {
@@ -63,6 +67,7 @@ export function ProcessesTable({
   snapshot,
   onMutationSuccess,
   bootstrapStatus = null,
+  checkedAt = null,
 }: ProcessesTableProps) {
   const [selectedLane, setSelectedLane] = useState<ProcessLane | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -115,6 +120,40 @@ export function ProcessesTable({
         : baseRows.filter((r) => r.lane === selectedLane);
     return [...rows].sort(compareRows);
   }, [baseRows, selectedLane]);
+
+  // #1513 — collapse the quiet rows by default. Pinned (always visible):
+  // `attention` (operator must act) AND `working` (a live run — the 5s
+  // poll exists to watch it, and it exposes Cancel, so it must not hide).
+  // Collapsed behind one inline disclosure: `current` (steady, fresh) and
+  // `self_healing` (auto-recovering, no action). compareRows already floats
+  // attention to the top, so the split preserves order within each group.
+  // Disabled in bootstrap-only mode: there the single bootstrap row IS the
+  // primary action surface and must never be tucked behind a disclosure.
+  const pinnedRows = useMemo(
+    () =>
+      bootstrapOnly
+        ? visibleRows
+        : visibleRows.filter((r) => !isCollapsible(r.health_verdict)),
+    [visibleRows, bootstrapOnly],
+  );
+  const collapsedRows = useMemo(
+    () =>
+      bootstrapOnly
+        ? []
+        : visibleRows.filter((r) => isCollapsible(r.health_verdict)),
+    [visibleRows, bootstrapOnly],
+  );
+  const collapsedSelfHealing = collapsedRows.filter(
+    (r) => r.health_verdict === "self_healing",
+  ).length;
+  const collapsedCurrent = collapsedRows.length - collapsedSelfHealing;
+  const [showCollapsed, setShowCollapsed] = useState(false);
+  // Reset to the default-collapsed state whenever the lane filter changes,
+  // so switching lanes never carries another lane's expanded state over
+  // (Codex ckpt-2) — each lane re-collapses its own quiet rows.
+  useEffect(() => {
+    setShowCollapsed(false);
+  }, [selectedLane]);
 
   const setRowError = useCallback(
     (processId: string, patch: RowErrorState) => {
@@ -201,6 +240,24 @@ export function ProcessesTable({
     [clearRowError, onMutationSuccess, setRowError],
   );
 
+  // Shared row renderer so the attention group and the (collapsible)
+  // non-actionable group emit identical ProcessRow markup. The signature
+  // prop keeps React.memo skipping unchanged rows on every poll (#1480).
+  const renderRow = (row: ProcessRowResponse) => (
+    <ProcessRow
+      key={row.process_id}
+      row={row}
+      signature={processRowSignature(row)}
+      triggerError={rowErrors[row.process_id]?.trigger}
+      cancelError={rowErrors[row.process_id]?.cancel}
+      busy={busyId === row.process_id}
+      onIterate={handleIterate}
+      // Stable setters passed directly so memo's reference compare holds.
+      onFullWash={setFullWashTarget}
+      onCancel={setCancelTarget}
+    />
+  );
+
   return (
     <div className="space-y-3">
       {/* In bootstrap-only mode the lane chips would offer one option
@@ -245,7 +302,7 @@ export function ProcessesTable({
         </div>
       )}
 
-      <StaleBanner rows={baseRows} />
+      <StaleBanner rows={baseRows} checkedAt={checkedAt} />
 
       {snapshot.partial ? (
         <div
@@ -275,27 +332,27 @@ export function ProcessesTable({
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-              {visibleRows.map((row) => (
-                <ProcessRow
-                  key={row.process_id}
-                  row={row}
-                  // Content hash computed here (parent render time) so
-                  // React.memo can skip unchanged rows on every poll
-                  // (#1480). Must be a prop, not recomputed in the
-                  // comparator — see ProcessRow `processRowSignature`.
-                  signature={processRowSignature(row)}
-                  triggerError={rowErrors[row.process_id]?.trigger}
-                  cancelError={rowErrors[row.process_id]?.cancel}
-                  busy={busyId === row.process_id}
-                  onIterate={handleIterate}
-                  // Pass the state setters directly — they are stable
-                  // across renders, so memo's reference compare holds.
-                  // An inline `(r) => setFullWashTarget(r)` would mint a
-                  // fresh fn each render and defeat the memo (#1480).
-                  onFullWash={setFullWashTarget}
-                  onCancel={setCancelTarget}
-                />
-              ))}
+              {pinnedRows.map(renderRow)}
+              {collapsedRows.length > 0 ? (
+                <tr data-testid="collapsed-disclosure">
+                  <td colSpan={6} className="px-2 py-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowCollapsed((v) => !v)}
+                      aria-expanded={showCollapsed}
+                      className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+                    >
+                      <span aria-hidden="true">
+                        {showCollapsed ? "▾ " : "▸ "}
+                      </span>
+                      {collapsedLabel(collapsedCurrent, collapsedSelfHealing)}
+                      {" — "}
+                      {showCollapsed ? "hide" : "show"}
+                    </button>
+                  </td>
+                </tr>
+              ) : null}
+              {showCollapsed ? collapsedRows.map(renderRow) : null}
             </tbody>
           </table>
         </div>
@@ -320,6 +377,23 @@ export function ProcessesTable({
       ) : null}
     </div>
   );
+}
+
+/** Verdicts that fold into the #1513 disclosure: steady-fresh `current` and
+ *  auto-recovering `self_healing`. `attention` (act) and `working` (a live
+ *  run — watch / cancel) stay pinned. */
+function isCollapsible(verdict: ProcessRowResponse["health_verdict"]): boolean {
+  return verdict === "current" || verdict === "self_healing";
+}
+
+/** Disclosure label for the collapsed non-actionable rows (#1513), e.g.
+ *  "12 current · 3 self-healing". `working` rows count as "current" for the
+ *  summary (both are non-actionable in-progress/fresh states). */
+function collapsedLabel(current: number, selfHealing: number): string {
+  const parts: string[] = [];
+  if (current > 0) parts.push(`${current} current`);
+  if (selfHealing > 0) parts.push(`${selfHealing} self-healing`);
+  return parts.join(" · ");
 }
 
 function compareRows(a: ProcessRowResponse, b: ProcessRowResponse): number {

--- a/frontend/src/components/admin/StaleBanner.test.tsx
+++ b/frontend/src/components/admin/StaleBanner.test.tsx
@@ -5,29 +5,38 @@ import { describe, expect, it } from "vitest";
 import { makeProcessRow } from "@/components/admin/__fixtures__/processes";
 import { StaleBanner } from "@/components/admin/StaleBanner";
 
-function renderBanner(rows: ReturnType<typeof makeProcessRow>[]) {
+function renderBanner(
+  rows: ReturnType<typeof makeProcessRow>[],
+  checkedAt?: Date | null,
+) {
   return render(
     <MemoryRouter>
-      <StaleBanner rows={rows} />
+      <StaleBanner rows={rows} checkedAt={checkedAt ?? null} />
     </MemoryRouter>,
   );
 }
 
-describe("StaleBanner (#1512 verdict-driven)", () => {
-  it("renders nothing when every row is current/working", () => {
-    const { container } = renderBanner([
+describe("StaleBanner (#1513 clean-bill header)", () => {
+  it("renders the positive all-clear when every row is current/working", () => {
+    renderBanner([
       makeProcessRow({ status: "ok", stale_reasons: [] }),
       makeProcessRow({ process_id: "b", status: "running", stale_reasons: [] }),
     ]);
-    expect(container.querySelector("[data-testid='stale-banner']")).toBeNull();
+    const text = screen.getByTestId("health-header").textContent ?? "";
+    expect(text).toContain("All systems current");
+    expect(text).not.toContain("need attention");
+    expect(text).not.toContain("self-healing");
   });
 
-  it("renders when at least one row needs attention", () => {
+  it("renders the attention summary when at least one row needs attention", () => {
     renderBanner([
       makeProcessRow({ process_id: "a", status: "ok", stale_reasons: [] }),
       makeProcessRow({ process_id: "b", stale_reasons: ["watermark_gap"] }),
     ]);
-    expect(screen.getByTestId("stale-banner")).toBeTruthy();
+    expect(screen.getByTestId("health-header")).toBeTruthy();
+    expect(screen.getByTestId("health-header").textContent).toContain(
+      "need attention",
+    );
   });
 
   it("names up to 3 attention process_ids and adds +N more for the rest", () => {
@@ -38,7 +47,7 @@ describe("StaleBanner (#1512 verdict-driven)", () => {
       makeProcessRow({ process_id: "p4", stale_reasons: ["watermark_gap"] }),
       makeProcessRow({ process_id: "p5", stale_reasons: ["watermark_gap"] }),
     ]);
-    const text = screen.getByTestId("stale-banner").textContent ?? "";
+    const text = screen.getByTestId("health-header").textContent ?? "";
     expect(text).toContain("5 need attention");
     expect(text).toContain("p1");
     expect(text).toContain("p2");
@@ -52,19 +61,20 @@ describe("StaleBanner (#1512 verdict-driven)", () => {
       makeProcessRow({ process_id: "a", stale_reasons: ["queue_stuck"] }),
       makeProcessRow({ process_id: "b", status: "pending_retry", stale_reasons: [] }),
     ]);
-    const text = screen.getByTestId("stale-banner").textContent ?? "";
+    const text = screen.getByTestId("health-header").textContent ?? "";
     expect(text).toContain("1 need attention");
     expect(text).toContain("1 self-healing");
   });
 
-  it("renders for a self-healing-only snapshot (no attention rows)", () => {
+  it("shows the summary (not all-clear) for a self-healing-only snapshot", () => {
     renderBanner([
       makeProcessRow({ process_id: "a", status: "ok", stale_reasons: [] }),
       makeProcessRow({ process_id: "b", status: "pending_retry", stale_reasons: [] }),
     ]);
-    const text = screen.getByTestId("stale-banner").textContent ?? "";
+    const text = screen.getByTestId("health-header").textContent ?? "";
     expect(text).toContain("1 self-healing");
     expect(text).not.toContain("need attention");
+    expect(text).not.toContain("All systems current");
   });
 
   it("View link points to the first attention row's drill-in route", () => {
@@ -74,5 +84,18 @@ describe("StaleBanner (#1512 verdict-driven)", () => {
     ]);
     const link = screen.getByRole("link", { name: /View/ });
     expect(link.getAttribute("href")).toBe("/admin/processes/attn_one");
+  });
+
+  it("renders the checked HH:MM freshness anchor when checkedAt is given", () => {
+    const checkedAt = new Date("2026-06-07T14:32:00Z");
+    renderBanner([makeProcessRow({ status: "ok", stale_reasons: [] })], checkedAt);
+    expect(screen.getByTestId("health-header").textContent).toContain("checked");
+  });
+
+  it("omits the checked anchor when checkedAt is null", () => {
+    renderBanner([makeProcessRow({ status: "ok", stale_reasons: [] })], null);
+    expect(screen.getByTestId("health-header").textContent).not.toContain(
+      "checked",
+    );
   });
 });

--- a/frontend/src/components/admin/StaleBanner.tsx
+++ b/frontend/src/components/admin/StaleBanner.tsx
@@ -1,31 +1,55 @@
 /**
- * StaleBanner — at-a-glance health summary above the ProcessesTable.
+ * StaleBanner — page-level clean-bill-of-health header above the
+ * ProcessesTable.
  *
  * Originally (PR8 / #1083) driven by `stale_reasons`. Rewired in #1512
  * to the single computed `health_verdict` so the banner language matches
- * the row pills (no "stale" vocabulary that no longer appears on rows).
+ * the row pills. #1513 turns it into the always-present header: a positive
+ * "All systems current" all-clear when every row is `current` / `working`,
+ * and the "N need attention · M self-healing" summary otherwise — a
+ * deliberate, scoped reversal of admin-triage's "no 'No problems!' banner"
+ * rule, limited to this header (never a toast).
  *
- * Renders only when at least one row needs attention or is self-healing.
- * When every row is `current` / `working` it returns `null` (no layout
- * shift). #1513 expands this into the positive "All systems current"
- * clean-bill header; #1512 only keeps it consistent with the
- * single-axis model.
+ * `checkedAt` is the client-side completion time of the last successful
+ * poll (from `useProcesses`), rendered as the "checked HH:MM" freshness
+ * anchor so the operator can trust the all-clear is live.
  */
 
 import { Link } from "react-router-dom";
 
 import type { ProcessRowResponse } from "@/api/types";
+import { formatTime } from "@/lib/format";
 
 const MAX_NAMED_PROCESSES = 3;
 
 export interface StaleBannerProps {
   readonly rows: readonly ProcessRowResponse[];
+  readonly checkedAt?: Date | null;
 }
 
-export function StaleBanner({ rows }: StaleBannerProps) {
+export function StaleBanner({ rows, checkedAt = null }: StaleBannerProps) {
   const attention = rows.filter((r) => r.health_verdict === "attention");
   const selfHealing = rows.filter((r) => r.health_verdict === "self_healing");
-  if (attention.length === 0 && selfHealing.length === 0) return null;
+  const checkedSuffix =
+    checkedAt !== null ? ` · checked ${formatTime(checkedAt)}` : "";
+
+  // Healthy: nothing needs attention and nothing is mid-recovery. The
+  // positive all-clear (#1513) — emerald, the OK colour (operator-ui
+  // conventions). Rendered (not null) so the operator gets an explicit
+  // "trust the page" signal without inspecting rows.
+  if (attention.length === 0 && selfHealing.length === 0) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid="health-header"
+        className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200"
+      >
+        <span aria-hidden="true">✓ </span>
+        All systems current{checkedSuffix}.
+      </div>
+    );
+  }
 
   // Link target: the first attention row if any, else the first
   // self-healing row (so "View" always points somewhere useful).
@@ -34,11 +58,12 @@ export function StaleBanner({ rows }: StaleBannerProps) {
     <div
       role="status"
       aria-live="polite"
-      data-testid="stale-banner"
+      data-testid="health-header"
       className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
     >
       <span aria-hidden="true">⚠ </span>
-      {formatSummary(attention, selfHealing)}{" "}
+      {formatSummary(attention, selfHealing)}
+      {checkedSuffix}{" "}
       {target ? (
         <Link
           to={`/admin/processes/${encodeURIComponent(target.process_id)}`}
@@ -67,5 +92,5 @@ function formatSummary(
   if (selfHealing.length > 0) {
     parts.push(`${selfHealing.length} self-healing`);
   }
-  return `${parts.join(" · ")}.`;
+  return parts.join(" · ");
 }

--- a/frontend/src/components/admin/a11y.test.tsx
+++ b/frontend/src/components/admin/a11y.test.tsx
@@ -53,7 +53,7 @@ const AXE_OPTIONS = {
 } as const;
 
 function renderTable(rows = [makeProcessRow()], partial = false) {
-  return render(
+  const result = render(
     <MemoryRouter>
       <ProcessesTable
         snapshot={makeProcessList(rows, partial)}
@@ -61,6 +61,13 @@ function renderTable(rows = [makeProcessRow()], partial = false) {
       />
     </MemoryRouter>,
   );
+  // #1513 — expand the steady-state collapse so row actions (Full-wash /
+  // Cancel) are reachable for the modal a11y checks.
+  const toggle = screen
+    .queryByTestId("collapsed-disclosure")
+    ?.querySelector("button");
+  if (toggle) fireEvent.click(toggle);
+  return result;
 }
 
 function renderRow(props: Partial<Parameters<typeof ProcessRow>[0]> = {}) {

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -4,7 +4,26 @@ import {
   formatHeartbeatAge,
   formatRate,
   formatRelativeTime,
+  formatTime,
 } from "@/lib/format";
+
+describe("formatTime", () => {
+  it("renders HH:MM (24h) for a Date", () => {
+    // 14:32 UTC — assert the minutes part survives regardless of viewer TZ.
+    expect(formatTime(new Date("2026-06-07T14:32:00Z"))).toMatch(/\d{2}:32/);
+  });
+
+  it("accepts an ISO string", () => {
+    expect(formatTime("2026-06-07T09:05:00Z")).toMatch(/\d{2}:05/);
+  });
+
+  it("renders em-dash for null / undefined / empty / invalid", () => {
+    expect(formatTime(null)).toBe("—");
+    expect(formatTime(undefined)).toBe("—");
+    expect(formatTime("")).toBe("—");
+    expect(formatTime("not-a-date")).toBe("—");
+  });
+});
 
 describe("formatRelativeTime", () => {
   const NOW = new Date("2026-04-21T12:00:00Z");

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -80,6 +80,20 @@ export function formatDateTime(iso: string | null | undefined): string {
   return DATE.format(d);
 }
 
+const TIME = new Intl.DateTimeFormat("en-GB", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+/** Time-only (HH:MM, en-GB 24h) for "checked HH:MM"-style freshness labels
+ *  (#1513). Accepts a Date (client poll-completion time) or an ISO string. */
+export function formatTime(value: Date | string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "—";
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return TIME.format(d);
+}
+
 /** Format a YYYY-MM-DD date-only value (pydantic `date` serialisation).
  *  Unlike formatDateTime, does NOT render hours/minutes. */
 export function formatDate(iso: string | null | undefined): string {

--- a/frontend/src/lib/useProcesses.ts
+++ b/frontend/src/lib/useProcesses.ts
@@ -37,7 +37,12 @@ export const POLL_INTERVAL_IDLE_MS = 60_000;
 export const SLOW_LINK_THRESHOLD_MS = 2_000;
 export const SLOW_LINK_BACKOFF = 3;
 
-export type UseProcessesResult = AsyncState<ProcessListResponse>;
+export interface UseProcessesResult extends AsyncState<ProcessListResponse> {
+  /** Client-side completion time of the most recent successful fetch —
+   *  the honest "checked HH:MM" freshness anchor for the Processes header
+   *  (#1513). `null` until the first successful poll. */
+  readonly checkedAt: Date | null;
+}
 
 function isDocumentHidden(): boolean {
   return typeof document !== "undefined" && document.hidden;
@@ -58,11 +63,17 @@ export function useProcesses(): UseProcessesResult {
   // flag, so a slow stale request finishing after a fast newer one
   // cannot back off the cadence on obsolete timing (Codex ckpt-2).
   const fetchSeqRef = useRef(0);
+  const [checkedAt, setCheckedAt] = useState<Date | null>(null);
   const measuredFetch = useCallback(async () => {
     const seq = ++fetchSeqRef.current;
     const startedAt = performance.now();
     try {
-      return await fetchProcesses();
+      const result = await fetchProcesses();
+      // Stamp freshness only for the most-recently-STARTED request so a
+      // slow stale fetch landing after a newer one cannot back-date the
+      // "checked" label (same seq guard as the slow-link flag below).
+      if (seq === fetchSeqRef.current) setCheckedAt(new Date());
+      return result;
     } finally {
       if (seq === fetchSeqRef.current) {
         setSlowLink(performance.now() - startedAt > SLOW_LINK_THRESHOLD_MS);
@@ -109,5 +120,5 @@ export function useProcesses(): UseProcessesResult {
     return () => window.clearInterval(id);
   }, [interval, visible]);
 
-  return state;
+  return { ...state, checkedAt };
 }

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -227,6 +227,7 @@ export function AdminPage() {
               refetchBootstrap();
             }}
             bootstrapStatus={bootstrap.data?.status ?? null}
+            checkedAt={processes.checkedAt}
           />
         ) : null}
       </CollapsibleSection>


### PR DESCRIPTION
## What
The Processes page had no positive all-clear — a healthy page rendered no banner (`StaleBanner` returned `null`), so the operator had to scan every row to trust the page. #1513 adds the page-level header and folds the quiet rows away so a healthy page reads as one line.

- **`StaleBanner` → always-present health header.** Healthy (no attention, no self-healing) → emerald `✓ All systems current · checked HH:MM`; otherwise the amber `N need attention · M self-healing · checked HH:MM` summary + `View` link. A deliberate, **scoped reversal** of admin-triage's "no 'No problems!' banner" rule — limited to this header, never a toast.
- **`ProcessesTable` → inline disclosure collapse.** `current` (steady, fresh) + `self_healing` (auto-recovering) rows fold into one `▸ N current · M self-healing — show` disclosure. **`attention` (act) and `working` (a live run — the 5s poll exists to watch it, and it exposes `Cancel`) stay pinned.** Disabled in bootstrap-only mode (the bootstrap row is the primary action surface).
- **`useProcesses` exposes `checkedAt`** — client completion time of the last successful poll (seq-guarded exactly like the slow-link flag so a stale fetch can't back-date it) → the honest "checked HH:MM" freshness anchor. `AdminPage` threads it through.
- **`format.ts` gains `formatTime`** (HH:MM, en-GB 24h) — the canonical time-only formatter (operator-ui: all formatting via `format.ts`).

## Design choice
Operator picked the **banner + inline disclosure** layout (one table, attention rows pinned, the rest behind a single disclosure row) over grouped sections.

## Why this shape
Codex ckpt-2 fixed two real issues: (1) `working`/running rows were being collapsed — they're the live-progress case and expose `Cancel`, so they now stay pinned alongside `attention`; (2) `showCollapsed` persisted across lane changes — it now resets on `selectedLane` change so each lane re-collapses its own quiet rows.

## Test
- `StaleBanner`: all-clear when healthy; attention/self-healing summary; checked-anchor present/absent; View link target.
- `ProcessesTable`: default collapse pins `attention`+`working` / hides `current`+`self_healing`; reveal on click; no disclosure when nothing is collapsible. The shared `renderTable` helper auto-expands so the existing row/action/sort/filter tests are unchanged.
- `formatTime` unit tests; a11y modal tests expand the disclosure to reach the row actions.
- typecheck ✓ · full `pnpm test` **908 passed** (87 files, incl. SetupPage integration).

Part of #1508. Depends on the verdict (T1 / #1512), now shipped.

Closes #1513