### PR TITLE
fix(#1514): label Processes next-fire time honestly as "expected" (T7 of #1508)

### DIFF
--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -409,6 +409,20 @@ describe("ProcessRow", () => {
     expect(container.textContent).toContain("every 5m");
   });
 
+  it("#1514: labels the next-fire time honestly as expected, not live", () => {
+    const { container } = renderRow({
+      row: makeProcessRow({
+        process_id: "daily_cik_refresh",
+        mechanism: "scheduled_job",
+        cadence_human: "every 5m",
+        next_fire_at: "2026-05-10T14:00:00+00:00",
+      }),
+    });
+    // Cadence-derived, not a live scheduler confirmation (#719 / #1514).
+    expect(container.textContent).toContain("next (expected):");
+    expect(container.textContent).not.toContain("next: ");
+  });
+
   // ---------------------------------------------------------------------
   // PR4 #1082 — ⓘ tooltip rendering description
   // ---------------------------------------------------------------------

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -19,6 +19,7 @@ import type { ProcessRowResponse } from "@/api/types";
 import { formatDateTime } from "@/lib/format";
 
 import {
+  NEXT_RUN_EXPECTED_TOOLTIP,
   REASON_TOOLTIP,
   VERDICT_VISUAL,
   reasonTooltip,
@@ -219,8 +220,11 @@ function ProcessRowImpl({
           <>
             <div>{row.cadence_human}</div>
             {row.next_fire_at ? (
-              <div className="text-slate-500 dark:text-slate-500">
-                next: {formatDateTime(row.next_fire_at)}
+              <div
+                className="text-slate-500 dark:text-slate-500"
+                title={NEXT_RUN_EXPECTED_TOOLTIP}
+              >
+                next (expected): {formatDateTime(row.next_fire_at)}
               </div>
             ) : null}
           </>

--- a/frontend/src/components/admin/processStatus.ts
+++ b/frontend/src/components/admin/processStatus.ts
@@ -185,3 +185,17 @@ export const VERDICT_SORT_PRIORITY: Record<HealthVerdict, number> = {
   working: 2,
   current: 3,
 };
+
+/**
+ * #1514 — honest framing for the displayed next-fire time. It is computed
+ * from the declared cadence (`compute_next_run`), NOT read from the live
+ * scheduler: since #719 the scheduler runs in a separate process the API
+ * does not query, so this is the *expected* next slot, not a confirmation
+ * it will fire. A scheduler that has actually stopped firing surfaces as
+ * "needs attention" via the liveness stall detection (#1510), so the
+ * "expected" label plus the verdict together keep the page honest.
+ */
+export const NEXT_RUN_EXPECTED_TOOLTIP =
+  "Expected next fire, computed from the declared cadence — not a live " +
+  "scheduler confirmation (the scheduler runs in a separate process). " +
+  "A job that has actually stopped firing is flagged as needs-attention.";

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -33,6 +33,7 @@ import { CollapsibleSection } from "@/components/admin/CollapsibleSection";
 import { FundDataRow } from "@/components/admin/FundDataRow";
 import { ProblemsPanel } from "@/components/admin/ProblemsPanel";
 import { ProcessesTable } from "@/components/admin/ProcessesTable";
+import { NEXT_RUN_EXPECTED_TOOLTIP } from "@/components/admin/processStatus";
 import {
   SectionError,
   SectionSkeleton,
@@ -362,7 +363,9 @@ function JobsTable({
           <tr>
             <th className="py-2 pr-4">Job</th>
             <th className="py-2 pr-4">Cadence</th>
-            <th className="py-2 pr-4">Next run (declared)</th>
+            <th className="py-2 pr-4" title={NEXT_RUN_EXPECTED_TOOLTIP}>
+              Next run (expected)
+            </th>
             <th className="py-2 pr-4">Last result</th>
             <th className="py-2 pr-4">Last finished</th>
             <th className="py-2 pr-4 text-right">Action</th>
@@ -379,7 +382,10 @@ function JobsTable({
                   <div className="text-xs text-slate-500">{job.description}</div>
                 </td>
                 <td className="py-2 pr-4 text-xs text-slate-600">{job.cadence}</td>
-                <td className="py-2 pr-4 text-xs text-slate-600">
+                <td
+                  className="py-2 pr-4 text-xs text-slate-600"
+                  title={NEXT_RUN_EXPECTED_TOOLTIP}
+                >
                   {formatDateTime(job.next_run_time)}
                 </td>
                 <td className="py-2 pr-4 text-xs">


### PR DESCRIPTION
## What
The Processes row rendered `next: <time>` and the jobs overview header said `Next run (declared)`, presenting a **cadence-derived** time as if it were the live scheduler's committed fire. Since #719 the API does not host APScheduler (it runs in a separate process), so the displayed time is always `compute_next_run(cadence)` — the *expected* next slot, not a confirmation it will fire. A paused/wedged scheduler made the time pure fiction (the tech-debt #1514 flags).

- **ProcessRow**: `next:` → `next (expected):` with a tooltip explaining it is cadence-derived, not a live confirmation.
- **AdminPage JobsTable**: header `Next run (declared)` → `Next run (expected)` + the same tooltip on header and cell.
- Shared `NEXT_RUN_EXPECTED_TOOLTIP` in `processStatus.ts` (single source of truth for the copy).

## Why labelling, not reconciling
The issue offers reconcile-with-live-scheduler **or** honest-label. Reconcile would need new cross-process plumbing — the jobs process computes live next-run (`get_next_run_times`) but only logs it, never persists it. Honest labelling is the KISS resolution, and the genuinely-wedged-scheduler case is **already covered by #1510**: a job that has actually stopped firing is flagged needs-attention via the liveness stall detection, so the "expected" label + the verdict together close the trust gap.

The backend already emits `next_run_time_source="declared"` correctly (`_build_jobs_overview`) — this is purely the FE presentation catching up.

## Test
- `ProcessRow`: new assertion that a scheduled row renders `next (expected):` and not the old `next: ` label.
- typecheck ✓ · full `pnpm test` **909 passed**.
- Codex ckpt-2: no issues (verified backend already honest, assertions sound).

Part of #1508. Last actionable child of the epic (#1515 T6 push-notification is explicitly deferred).

Closes #1514