### PR TITLE
fix(#1526): extract liveness watchdog + retry sweeper to own joblock lanes

### DIFF
--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -71,6 +71,8 @@ Lane = Literal[
     "db_ownership_inst",
     "db_ownership_insider",
     "db_ownership_funds",
+    "db_liveness",
+    "db_retry",
     "bootstrap",
     "finra",
     "openfigi",
@@ -125,6 +127,29 @@ PR1c #1064 collapsed everything onto a single ``db`` source.
   writes ``insider_transactions`` + ``form3_holdings_initial``.
 * ``db_ownership_funds`` — ``sec_nport_ingest_from_dataset``;
   writes ``n_port_*`` + ``sec_fund_series``.
+
+The next two are scheduled-only infra lanes, each owning exactly ONE
+job (#1526 — same "extract the loser out of the contended lane" shape
+as the #1478 ``sec_manifest`` split):
+
+* ``db_liveness`` — ``jobs_liveness_watchdog`` (#1507/#1510) only.
+* ``db_retry`` — ``jobs_retry_sweeper`` (#1509) only.
+
+  Both were on the catch-all ``db`` lane and fired on the same 5-min
+  grid as ``orchestrator_high_frequency_sync`` (every_5min, ``db``),
+  which holds ``job_source:db`` re-entrantly through its ingest
+  (~0.6s/run). The cross-thread scheduled fire of these light infra
+  jobs lost the lane race every tick and starved (proven via
+  ``pg_locks`` tick-poll + log correlation, 2026-06-07). They only read
+  ``job_runs`` and write ``decision_audit`` / ``pending_job_requests``
+  (each already guarded by its own ``pg_advisory_xact_lock``), so they
+  are safe to run concurrently with orchestrator ingest. SEPARATE
+  lanes, not one shared ``db_infra`` — a shared lane would re-create the
+  same starvation between the 15-min watchdog and the 5-min sweeper at
+  the :00/:15/:30/:45 ticks they co-fire. Scheduled-only, so NOT added
+  to the ``bootstrap_stages.lane`` CHECK (like ``sec_manifest`` /
+  ``finra`` / ``bootstrap``). See #1527 for the daily/hourly db jobs
+  that collide on the same grid but may need true ingest serialisation.
 
 The final lane is bootstrap-only:
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -947,7 +947,14 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_LIVENESS_WATCHDOG,
         display_name="Jobs liveness watchdog",
-        source="db",
+        # Own single-job lane (#1526). On the catch-all ``db`` lane this
+        # 15-min watchdog lost the ``job_source:db`` advisory-lock race to
+        # orchestrator_high_frequency_sync (every_5min, ``db``) at every
+        # :00/:15/:30/:45 tick and never ran on schedule (#1508 self-healing
+        # infra was itself starved). ``db_liveness`` is disjoint, so it runs
+        # concurrently with orchestrator ingest; its per-job
+        # pg_advisory_xact_lock (job_liveness_act) still bounds double-kicks.
+        source="db_liveness",
         description=(
             "#1500 (GAP-D) — per-job stall detector. Every 15m, flags any "
             "scheduled job that has recorded ZERO job_runs rows over K=3 "
@@ -971,7 +978,13 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_RETRY_SWEEPER,
         display_name="Jobs retry sweeper",
-        source="db",
+        # Own single-job lane (#1526). On the catch-all ``db`` lane this
+        # every_5min sweeper co-fired orchestrator_high_frequency_sync
+        # (every_5min, ``db``) on the SAME grid every tick and lost the lane
+        # race → never ran on schedule. ``db_retry`` is disjoint from
+        # orchestrator ingest; the manual-queue dispatch it issues is itself
+        # idempotent + advisory-locked, so concurrency with ingest is safe.
+        source="db_retry",
         description=(
             "#1509 (T3 of #1508) — re-fires transiently-failed jobs. Every "
             "5m, scans job_runs for due next_retry_at (set by "

--- a/tests/test_db_lane_infra_starvation.py
+++ b/tests/test_db_lane_infra_starvation.py
@@ -1,0 +1,54 @@
+"""Regression: jobs_liveness_watchdog + jobs_retry_sweeper own single-job lanes (#1526).
+
+Both infra jobs were on the catch-all ``db`` lane, where they lost the
+``job_source:db`` advisory-lock race to ``orchestrator_high_frequency_sync``
+(every_5min, ``db``) at every shared tick and never ran on schedule — the
+#1508 self-healing infra was itself starved (root cause proven via a
+``pg_locks`` tick-poll + jobs-log correlation, 2026-06-07). Each now owns a
+disjoint single-job lane (``db_liveness`` / ``db_retry``).
+
+Pure registry assertions (no DB) so the invariant gates every push: if a
+future edit reverts either ``source`` to ``db`` — or collapses both onto one
+shared lane — this fails in the fast tier. The distinct-source -> concurrent-
+acquire property itself is already proven by
+``tests/test_db_lane_family_split.py``.
+"""
+
+from __future__ import annotations
+
+from app.jobs.sources import get_job_name_to_source, source_for
+
+# (job_name, expected own lane). Pinned so a future re-merge updates in lockstep.
+_INFRA_LANES: tuple[tuple[str, str], ...] = (
+    ("jobs_liveness_watchdog", "db_liveness"),
+    ("jobs_retry_sweeper", "db_retry"),
+)
+
+
+def test_each_infra_job_resolves_to_its_own_lane() -> None:
+    for job_name, expected in _INFRA_LANES:
+        assert source_for(job_name) == expected
+
+
+def test_infra_lanes_disjoint_from_db_catchall_and_each_other() -> None:
+    # The starvation was contention with orchestrator_high_frequency_sync on the
+    # catch-all ``db`` lane; the orchestrator stays on ``db`` while the infra
+    # jobs leave it, so the cross-thread scheduled fire no longer collides.
+    assert source_for("orchestrator_high_frequency_sync") == "db"
+    liveness = source_for("jobs_liveness_watchdog")
+    retry = source_for("jobs_retry_sweeper")
+    assert liveness != "db"
+    assert retry != "db"
+    # SEPARATE lanes, not one shared ``db_infra`` — a shared lane would
+    # re-create the starvation between the 15-min watchdog and the 5-min
+    # sweeper at the :00/:15/:30/:45 ticks they co-fire.
+    assert liveness != retry
+
+
+def test_each_infra_lane_owned_by_exactly_one_job() -> None:
+    # Catches a future job being assigned db_liveness/db_retry, which would
+    # re-introduce the same-lane contention the split removes.
+    registry = get_job_name_to_source()
+    for job_name, lane in _INFRA_LANES:
+        holders = {name for name, src in registry.items() if src == lane}
+        assert holders == {job_name}, f"lane {lane!r} owned by {sorted(holders)!r}, expected [{job_name!r}]"

--- a/tests/test_db_lane_infra_starvation.py
+++ b/tests/test_db_lane_infra_starvation.py
@@ -17,11 +17,15 @@ acquire property itself is already proven by
 from __future__ import annotations
 
 from app.jobs.sources import get_job_name_to_source, source_for
+from app.workers.scheduler import JOB_LIVENESS_WATCHDOG, JOB_RETRY_SWEEPER
 
-# (job_name, expected own lane). Pinned so a future re-merge updates in lockstep.
+# (job_name, expected own lane). Job names via the scheduler constants so a
+# rename cannot silently pass against a stale literal (review NITPICK PR #1528);
+# the lane values are the canonical ``Lane`` literals. Pinned so a future
+# re-merge updates in lockstep.
 _INFRA_LANES: tuple[tuple[str, str], ...] = (
-    ("jobs_liveness_watchdog", "db_liveness"),
-    ("jobs_retry_sweeper", "db_retry"),
+    (JOB_LIVENESS_WATCHDOG, "db_liveness"),
+    (JOB_RETRY_SWEEPER, "db_retry"),
 )
 
 

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -59,6 +59,15 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # Lane disjoint from sec_rate (CDN serves both endpoints with
         # one shared throttle).
         "finra",
+        # #1526 — jobs_liveness_watchdog + jobs_retry_sweeper extracted from the
+        # catch-all ``db`` lane into their own single-job lanes. On ``db`` they
+        # lost the ``job_source:db`` advisory-lock race to
+        # orchestrator_high_frequency_sync every tick and never ran on schedule
+        # (the #1508 self-healing infra was itself starved). Separate lanes (not
+        # one shared infra lane) so the 15-min watchdog and 5-min sweeper do not
+        # re-starve each other. See app/jobs/sources.py::Lane.
+        "db_liveness",
+        "db_retry",
     }
 )
 


### PR DESCRIPTION
Closes #1526.

## What
`jobs_liveness_watchdog` and `jobs_retry_sweeper` move from the catch-all `db` joblock lane to their own single-job lanes `db_liveness` / `db_retry`.

## Why
Both shared `job_source:db` with `orchestrator_high_frequency_sync` (every_5min, source=db), which holds that advisory lock **re-entrantly** through its ownership/insider ingest (~0.6s/run). The infra jobs fire on the same 5-min grid (sweeper every_5min; watchdog every_15min at :00/:15/:30/:45), lose the cross-thread lane race every tick, skip, and write no `job_runs` row — so the #1508 self-healing infra never actually ran on its own schedule on dev.

Proven (2026-06-07): a `pg_locks` tick-poll @150ms caught `job_source:db` (objid 925006522) held by the orchestrator's conn at 19:20:00.058, while the jobs log shows `jobs_retry_sweeper skipped` @19:20:00.047 and `orchestrator_high_frequency_sync complete sync_run_id=1168` @19:20:00.617. Between ticks the lock is free — why naive `pg_locks` snapshots miss it.

## Design
- **Separate** lanes, not one shared `db_infra` — a shared lane would re-create the starvation between the 15-min watchdog and the 5-min sweeper at the ticks they co-fire.
- Safe to run concurrently with orchestrator ingest: each infra job only reads `job_runs` and writes `decision_audit`/`pending_job_requests`, each already guarded by its own `pg_advisory_xact_lock` (retry: `FOR UPDATE` on candidate rows; liveness: per-job xact lock + cooldown). Orchestrator HF writes `sync_runs`/ingest tables — not a conflicting writer (Codex ckpt-2 confirmed).
- Scheduled-only lanes → no `bootstrap_stages.lane` CHECK migration (matches existing `sec_manifest` / `finra` / `bootstrap`).

## Security model
No auth/authz surface. Advisory-lock lane assignment only — no new SQL, no schema change, no new endpoint. The admin-page display `ProcessLane` is keyed by job **name** in `scheduled_adapter.py::_LANE_BY_JOB`, independent of `source`, so the Processes page is unaffected.

## Test
- New `tests/test_db_lane_infra_starvation.py` (pure, fast tier): each job resolves to its own lane; disjoint from `db` and from each other; one-job-per-lane.
- `_ALLOWED_SOURCES` in `test_job_registry.py` updated in lockstep (`test_every_source_is_valid_lane` enforces it).
- Local: ruff ✓, ruff format ✓, pyright 0 errors ✓, fast tier (`-m "not db"`) green, smoke 129 passed / 3 skipped.

## Out of scope
#1527 — daily/hourly db jobs (`cusip_extid_sweep` @:50, `ownership_observations_sync` @:30, `monitor_positions` @:15) collide on the same 5-min grid; same root cause, may need true ingest serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)