### PR TITLE
fix(#1527): extract daily/hourly db jobs to own lanes (db-lane starvation)

### DIFF
--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -73,6 +73,9 @@ Lane = Literal[
     "db_ownership_funds",
     "db_liveness",
     "db_retry",
+    "db_positions",
+    "db_cusip",
+    "db_ownership_obs",
     "bootstrap",
     "finra",
     "openfigi",
@@ -107,8 +110,11 @@ the rate — it does not.
 * ``db`` — DB-bound stages NOT owned by a finer family lane — Phase E
   derivations (``fundamentals_sync``, ``ownership_observations_backfill``)
   + scheduler catch-all (``orchestrator_full_sync``,
-  ``orchestrator_high_frequency_sync``, ``retry_deferred``,
-  ``monitor_positions``, ``ownership_observations_sync``).
+  ``orchestrator_high_frequency_sync``, ``retry_deferred``). The
+  daily/hourly ``monitor_positions`` / ``ownership_observations_sync`` /
+  ``cusip_extid_sweep`` were extracted to their own lanes in #1527 (see
+  below); ``ownership_observations_backfill`` stays here (S24 bootstrap
+  stage — moving it would force a CHECK migration).
 
 The next five are bootstrap Phase C bulk-ingest family lanes
 (#1141 / Task E of audit #1136). Each owns a disjoint write
@@ -148,8 +154,43 @@ as the #1478 ``sec_manifest`` split):
   same starvation between the 15-min watchdog and the 5-min sweeper at
   the :00/:15/:30/:45 ticks they co-fire. Scheduled-only, so NOT added
   to the ``bootstrap_stages.lane`` CHECK (like ``sec_manifest`` /
-  ``finra`` / ``bootstrap``). See #1527 for the daily/hourly db jobs
-  that collide on the same grid but may need true ingest serialisation.
+  ``finra`` / ``bootstrap``).
+
+The next three are steady-state db jobs extracted from the catch-all
+``db`` lane (#1527 — the daily/hourly continuation of #1526). Each fires
+on a 5-minute-aligned slot and so co-fired ``orchestrator_high_frequency_sync``
+(every_5min, ``db``) and lost the ``job_source:db`` cross-thread lane race
+every collision — a once-daily job skips a FULL day per collision. Write-target
+disjointness was verified before extraction (a lane is a job-overlap bucket,
+not a rate limiter): none of the three writes a table the orchestrator's
+portfolio_sync / fx_rates ingest writes, so none needs to serialise against
+it. Each owns a single-job lane (NOT one shared ``db_steady`` lane — the
+#1526 lesson: a shared lane re-creates the starvation between its members
+when one overruns). Scheduled-only, so NOT added to the
+``bootstrap_stages.lane`` CHECK (matches ``db_liveness`` / ``db_retry``).
+
+* ``db_positions`` — ``monitor_positions`` (hourly @ :15) only. Reads
+  ``positions`` (MVCC-safe vs the orchestrator's concurrent portfolio
+  write) and writes only ``position_alerts`` via ``persist_position_alerts``.
+* ``db_cusip`` — ``cusip_extid_sweep`` (daily @ :50) only. Writes
+  ``unresolved_13f_cusips`` (resolve flag) + ``institutional_holdings``
+  (13F rewash). The 13F ingest writers already run on ``sec_rate`` /
+  ``db_ownership_inst`` (never ``db``), so extraction introduces no NEW
+  race — the sweep already ran concurrently with them.
+* ``db_ownership_obs`` — ``ownership_observations_sync`` (daily @ :30)
+  only — the all-7-category ``ownership_*_current`` repair sweep.
+  ``ownership_*_current`` has other writers (the live ingesters + bulk
+  paths), but they run on ``db_ownership_*`` / ``sec_rate`` lanes —
+  already off ``db`` — so the sweep was NEVER lane-serialised against
+  them, and extraction introduces no new race. The only writer the
+  sweep shared the ``db`` lane with is ``ownership_observations_backfill``
+  (S24 bootstrap stage + weekly Sun 03:00), which DELIBERATELY stays on
+  ``db``: it is a ``bootstrap_stages.lane`` entry (moving it would force
+  a CHECK migration). Both serialise the only shared mutation — the
+  ``refresh_*_current`` DELETE-then-INSERT — per-instrument via
+  ``pg_advisory_xact_lock`` (the lane is not the guard), and their
+  schedules are staggered (backfill 03:00, sweep 03:30) so they never
+  co-fire in practice.
 
 The final lane is bootstrap-only:
 

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -662,7 +662,13 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_MONITOR_POSITIONS,
         display_name="Monitor open positions",
-        source="db",
+        # Own single-job lane (#1527). Hourly @ :15 is a 5-min-aligned slot,
+        # so on the catch-all ``db`` lane this lost the ``job_source:db`` race
+        # to orchestrator_high_frequency_sync (every_5min, ``db``) and skipped.
+        # Reads ``positions`` (MVCC-safe vs the orchestrator's portfolio write)
+        # and writes only ``position_alerts`` — disjoint, so ``db_positions``
+        # runs concurrently with orchestrator ingest.
+        source="db_positions",
         description="Check open positions for SL/TP breaches and thesis breaks.",
         cadence=Cadence.hourly(minute=15),
         prerequisite=_has_open_positions,
@@ -800,7 +806,20 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_OWNERSHIP_OBSERVATIONS_SYNC,
         display_name="Ownership repair sweep",
-        source="db",
+        # Own single-job lane (#1527). Daily @ :30 is a 5-min-aligned slot, so
+        # on the catch-all ``db`` lane it lost the ``job_source:db`` race to
+        # orchestrator_high_frequency_sync (every_5min) and skipped a full day
+        # per collision. Refreshes ``ownership_*_current``. That table's other
+        # writers (live ingesters + bulk paths) run on ``db_ownership_*`` /
+        # ``sec_rate`` — already off ``db`` — so the sweep was never lane-
+        # serialised against them; extraction adds no new race. The only
+        # writer it shared the ``db`` lane with is
+        # ``ownership_observations_backfill`` (kept on ``db`` — an S24
+        # bootstrap stage), and both already serialise the only shared write
+        # (``refresh_*_current`` DELETE-then-INSERT) per-instrument via
+        # pg_advisory_xact_lock (schedules staggered too: backfill Sun 03:00,
+        # this sweep 03:30). So ``db_ownership_obs`` is safe.
+        source="db_ownership_obs",
         description=(
             "Self-healing repair sweep for ownership_*_current (#892). "
             "Live ingesters now write observations + refresh _current "
@@ -845,7 +864,15 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_CUSIP_EXTID_SWEEP,
         display_name="CUSIP rewash sweep",
-        source="db",
+        # Own single-job lane (#1527). Daily @ :50 is a 5-min-aligned slot, so
+        # on the catch-all ``db`` lane it lost the ``job_source:db`` race to
+        # orchestrator_high_frequency_sync (every_5min) and skipped a full day
+        # per collision (consistent with it not truly running since 2026-06-03).
+        # Writes ``unresolved_13f_cusips`` + ``institutional_holdings``; the 13F
+        # ingest writers run on ``sec_rate`` / ``db_ownership_inst`` (never
+        # ``db``), so ``db_cusip`` introduces no new race — the sweep already
+        # ran concurrently with them.
+        source="db_cusip",
         description=(
             "Sweep ``unresolved_13f_cusips`` for rows whose CUSIP "
             "already has a matching ``external_identifiers`` row, mark "

--- a/tests/test_db_lane_steady_starvation.py
+++ b/tests/test_db_lane_steady_starvation.py
@@ -1,0 +1,74 @@
+"""Regression: monitor_positions + cusip_extid_sweep + ownership_observations_sync
+own single-job lanes (#1527 — daily/hourly continuation of #1526).
+
+All three fire on a 5-minute-aligned slot (monitor_positions hourly @ :15,
+ownership_observations_sync daily @ :30, cusip_extid_sweep daily @ :50). On the
+catch-all ``db`` lane they co-fired ``orchestrator_high_frequency_sync``
+(every_5min, ``db``), which holds ``job_source:db`` re-entrantly through its
+portfolio/fx ingest, and lost the cross-thread advisory-lock race every
+collision — a once-daily job skips a FULL day per collision (root cause proven
+for the infra jobs in #1526 via a ``pg_locks`` tick-poll). Each now owns a
+disjoint single-job lane; write-target disjointness from the orchestrator's
+ingest was verified before extraction (see app/jobs/sources.py::Lane).
+
+Pure registry assertions (no DB) so the invariant gates every push: if a future
+edit reverts any ``source`` to ``db`` — or collapses these onto one shared lane
+— this fails in the fast tier. The distinct-source -> concurrent-acquire
+property itself is already proven by ``tests/test_db_lane_family_split.py``.
+"""
+
+from __future__ import annotations
+
+from app.jobs.sources import get_job_name_to_source, source_for
+from app.workers.scheduler import (
+    JOB_CUSIP_EXTID_SWEEP,
+    JOB_MONITOR_POSITIONS,
+    JOB_OWNERSHIP_OBSERVATIONS_SYNC,
+)
+
+# (job_name, expected own lane). Job names via the scheduler constants so a
+# rename cannot silently pass against a stale literal; the lane values are the
+# canonical ``Lane`` literals. Pinned so a future re-merge updates in lockstep.
+_STEADY_LANES: tuple[tuple[str, str], ...] = (
+    (JOB_MONITOR_POSITIONS, "db_positions"),
+    (JOB_CUSIP_EXTID_SWEEP, "db_cusip"),
+    (JOB_OWNERSHIP_OBSERVATIONS_SYNC, "db_ownership_obs"),
+)
+
+
+def test_each_steady_job_resolves_to_its_own_lane() -> None:
+    for job_name, expected in _STEADY_LANES:
+        assert source_for(job_name) == expected
+
+
+def test_steady_lanes_disjoint_from_db_catchall_and_each_other() -> None:
+    # The starvation was contention with orchestrator_high_frequency_sync on the
+    # catch-all ``db`` lane; the orchestrator stays on ``db`` while these jobs
+    # leave it, so the cross-thread scheduled fire no longer collides.
+    assert source_for("orchestrator_high_frequency_sync") == "db"
+    lanes = {job_name: source_for(job_name) for job_name, _ in _STEADY_LANES}
+    for lane in lanes.values():
+        assert lane != "db"
+    # Distinct lanes, not one shared ``db_steady`` — a shared lane would
+    # re-create the starvation between members when one overruns (#1526 lesson).
+    assert len(set(lanes.values())) == len(lanes)
+
+
+def test_ownership_backfill_stays_on_db_to_avoid_check_migration() -> None:
+    # ownership_observations_backfill is an S24 bootstrap stage, so its lane
+    # participates in the bootstrap_stages.lane CHECK; it deliberately stays on
+    # ``db``. It is the only *remaining* db-lane writer of ownership_*_current
+    # the daily sweep overlaps (other writers — live ingesters/bulk paths — run
+    # on db_ownership_* / sec_rate, already off db). The one shared mutation,
+    # the refresh_*_current DELETE-then-INSERT, is serialised per-instrument by
+    # pg_advisory_xact_lock (the lane is not the guard), so the split is safe.
+    assert source_for("ownership_observations_backfill") == "db"
+
+
+def test_each_steady_lane_owned_by_exactly_one_job() -> None:
+    # Catches a future job being assigned one of these lanes, which would
+    # re-introduce the same-lane contention the split removes.
+    registry = get_job_name_to_source()
+    for job_name, lane in _STEADY_LANES:
+        holders = {name for name, src in registry.items() if src == lane}
+        assert holders == {job_name}, f"lane {lane!r} owned by {sorted(holders)!r}, expected [{job_name!r}]"

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -68,6 +68,15 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # re-starve each other. See app/jobs/sources.py::Lane.
         "db_liveness",
         "db_retry",
+        # #1527 — daily/hourly continuation of #1526. monitor_positions,
+        # cusip_extid_sweep, ownership_observations_sync each fire on a
+        # 5-min-aligned slot and lost the ``job_source:db`` race to
+        # orchestrator_high_frequency_sync (skipping a full day per collision).
+        # Write-target-disjoint from the orchestrator's portfolio/fx ingest, so
+        # each owns a single-job lane. See app/jobs/sources.py::Lane.
+        "db_positions",
+        "db_cusip",
+        "db_ownership_obs",
     }
 )
 


### PR DESCRIPTION
## What
Extract three steady-state jobs from the catch-all `db` joblock lane into their own single-job lanes:
- `monitor_positions` (hourly @ :15) → `db_positions`
- `ownership_observations_sync` (daily @ :30) → `db_ownership_obs`
- `cusip_extid_sweep` (daily @ :50) → `db_cusip`

Follow-up to #1526 (same root cause, daily/hourly scope). Closes #1527.

## Why
The catch-all `db` lane is one Postgres session advisory lock (`hashtext('job_source:db')`). `orchestrator_high_frequency_sync` (every_5min, `source=db`) holds it re-entrantly through its portfolio/fx ingest (~0.6s/run). The #1184 same-context re-entrancy bypass is a `ContextVar` and does **not** propagate across APScheduler threads, so a *scheduled* fire of another `db` job runs on its own thread, hits the real PG lock, and loses the race deterministically. Every one of these jobs fires on a 5-min-aligned minute → collides with the orchestrator → **skips a full day per collision** (consistent with `cusip_extid_sweep` not truly running since 2026-06-03).

## Decision: own lanes (option 1), not re-phase
Re-phase (option 2) only shifts the collision minute; if the orchestrator ever overruns the offset gap the starvation silently returns. Lane extraction is structural and matches settled precedent (#1478 manifest split, #1150 family split, #1526 infra lanes).

Separate single-job lanes, **not** one shared `db_steady` — the #1526 lesson: a shared lane re-creates the starvation between its members when one overruns.

## Security / safety model — write-target disjointness (verified before extraction)
A lane is a job-overlap bucket, not a rate limiter, so the only question is whether each extracted job shares a write target that the lane was serialising:
- **monitor_positions** — writes only `position_alerts` via `persist_position_alerts`; reads `positions` (MVCC-safe vs the orchestrator's concurrent portfolio write). Disjoint.
- **cusip_extid_sweep** — writes `unresolved_13f_cusips` (resolve flag) + `institutional_holdings` (13F rewash). The 13F ingest writers already run on `sec_rate` / `db_ownership_inst` (never `db`), so the sweep already ran concurrently with them — no NEW race.
- **ownership_observations_sync** — refreshes `ownership_*_current` (all 7 categories). Other writers (live ingesters / bulk paths) run on `db_ownership_*` / `sec_rate`, already off `db`. The only `db`-lane co-writer is `ownership_observations_backfill`, which **deliberately stays on `db`** (it is an S24 `_BOOTSTRAP_STAGE_SPECS` entry → moving it would force a `bootstrap_stages.lane` CHECK migration). Both serialise the one shared mutation — the `refresh_*_current` DELETE-then-INSERT — per-instrument via `pg_advisory_xact_lock` (the lane is not the guard), and their schedules are staggered (backfill Sun 03:00, sweep 03:30).

All three extracted jobs are **scheduled-only** (none is in `_BOOTSTRAP_STAGE_SPECS`), so **no CHECK migration** is needed — exactly the #1526 shape. Display lane (`_LANE_BY_JOB` in `scheduled_adapter.py`) is name-keyed, independent of `source`, so the admin Processes page is unaffected.

## Files
- `app/jobs/sources.py` — 3 new `Lane` literals + docstring (lane → write-target rationale); updated stale `db`-lane member list.
- `app/workers/scheduler.py` — `source=` on the 3 `ScheduledJob` defs + per-job rationale comment.
- `tests/test_db_lane_steady_starvation.py` (new) — own-lane / disjoint-from-db-and-each-other / backfill-stays-on-db / one-job-per-lane (pure registry assertions, fast tier).
- `tests/test_job_registry.py` — `_ALLOWED_SOURCES` lockstep (its `test_every_source_is_valid_lane` is the guard that catches a missing entry).

## Test
- `tests/test_db_lane_steady_starvation.py` + `tests/test_job_registry.py`: 48 passed.
- Fast tier (`pytest -m "not db"`): 3581 passed, 14 skipped.
- Smoke (`tests/smoke`): 17 passed.
- ruff check + format: clean. pyright: 0 errors.
- Codex ckpt-2: no blocking race found vs orchestrator or other db-lane jobs; one LOW wording finding (ownership "only writer" → "only remaining db-lane writer") fixed.

Dev-verify (operator follow-up): a jobs-process restart picks up the new lanes; confirm at the next aligned tick that `monitor_positions` / `ownership_observations_sync` / `cusip_extid_sweep` run concurrently with `orchestrator_high_frequency_sync` instead of skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)