### PR TITLE
fix(#1532): tombstone pre-2013 13F archive-missing filings (stop redding sec_13f_sweep)

### DIFF
--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -218,6 +218,14 @@ class _AccessionOutcome:
       * ``'failed'`` — fetch / parse failure that prevents writing
         a canonical row. The accession is logged so re-runs skip
         it; the operator can clear the log row to force a retry.
+      * ``'tombstoned'`` — deterministically unparseable; re-fetching
+        yields the same gap forever (e.g. pre-2013 13Fs that predate
+        the 2013 infotable-XML mandate, where the archive index has no
+        primary_doc / infotable attachment). Logged as a permanent
+        skip so the operator-visible sweep stays green (#1532) — it is
+        NOT an action item. Mirrors the ``tombstoned`` ParseOutcome the
+        manifest-worker path returns for the same condition
+        (``app/services/manifest_parsers/sec_13f_hr.py``).
     """
 
     status: str
@@ -1060,6 +1068,12 @@ def ingest_filer_13f(
         )
         if outcome.ingested:
             summary.accessions_ingested += 1
+        elif outcome.status == "tombstoned":
+            # Deterministic permanent skip (#1532) — not a failure. Don't
+            # inflate accessions_failed / first_error (which surface in
+            # data_ingestion_runs as operator-facing failure signal); the
+            # tombstoned ingest-log row is the audit trail.
+            pass
         else:
             summary.accessions_failed += 1
             if outcome.error and summary.first_error is None:
@@ -1377,8 +1391,18 @@ def _ingest_single_accession(
             primary_name,
             infotable_name,
         )
+        # Deterministic permanent skip: the archive index has no
+        # primary_doc / infotable attachment, so re-fetching yields the
+        # same gap forever (pre-2013 13Fs predate the 2013 infotable-XML
+        # mandate). Tombstone — not ``failed`` — so the sweep does not red
+        # on a non-actionable condition (#1532). Mirrors the manifest
+        # path's ``tombstoned`` ParseOutcome for the same branch
+        # (``sec_13f_hr.py``). A well-formed modern 13F always carries
+        # both attachments, so this branch is structurally pre-2013-only;
+        # genuinely transient fetch 404s land in the ``failed`` branches
+        # above and stay retryable.
         return _AccessionOutcome(
-            status="failed",
+            status="tombstoned",
             holdings_inserted=0,
             holdings_skipped_no_cusip=0,
             error=(f"archive index missing files (primary={primary_name!r}, infotable={infotable_name!r})"),

--- a/app/services/manifest_parsers/sec_13f_hr.py
+++ b/app/services/manifest_parsers/sec_13f_hr.py
@@ -199,7 +199,7 @@ def _parse_13f_hr(
                     filer_cik=filer_cik,
                     accession_number=accession,
                     period_of_report=None,
-                    status="failed",
+                    status="tombstoned",
                     error="archive index.json fetch failed",
                 )
         except Exception as exc:  # noqa: BLE001
@@ -218,7 +218,12 @@ def _parse_13f_hr(
     if primary_name is None or infotable_name is None:
         # Index found but missing one of the two required attachments.
         # Deterministic — re-fetching the same index yields the same
-        # gap. Tombstone with audit-log entry.
+        # gap (pre-2013 13Fs predate the 2013 infotable-XML mandate).
+        # Tombstone with audit-log entry. The ingest-log row is written
+        # 'tombstoned' (not 'failed') to MIRROR the ParseOutcome below,
+        # so the ingest_sweep_adapter does not red sec_13f_sweep on a
+        # non-actionable permanent skip (#1532). This is the dominant
+        # log-failure class (~55k pre-2013 accessions).
         log_error = f"archive index missing files (primary={primary_name!r}, infotable={infotable_name!r})"
         try:
             with conn.transaction():
@@ -227,7 +232,7 @@ def _parse_13f_hr(
                     filer_cik=filer_cik,
                     accession_number=accession,
                     period_of_report=None,
-                    status="failed",
+                    status="tombstoned",
                     error=log_error,
                 )
         except Exception as exc:  # noqa: BLE001
@@ -265,7 +270,7 @@ def _parse_13f_hr(
                     filer_cik=filer_cik,
                     accession_number=accession,
                     period_of_report=None,
-                    status="failed",
+                    status="tombstoned",
                     error="primary_doc.xml fetch failed",
                 )
         except Exception as exc:  # noqa: BLE001
@@ -348,7 +353,7 @@ def _parse_13f_hr(
                     filer_cik=filer_cik,
                     accession_number=accession,
                     period_of_report=info.period_of_report,
-                    status="failed",
+                    status="tombstoned",
                     error="retention floor",
                 )
         except Exception as exc:  # noqa: BLE001
@@ -384,7 +389,7 @@ def _parse_13f_hr(
                     filer_cik=filer_cik,
                     accession_number=accession,
                     period_of_report=info.period_of_report,
-                    status="failed",
+                    status="tombstoned",
                     error="infotable.xml fetch failed",
                 )
         except Exception as exc:  # noqa: BLE001
@@ -551,8 +556,14 @@ def _parse_13f_hr(
         )
         if is_transient_upsert_error(exc):
             return _failed_outcome(format_upsert_error(exc), raw_status="stored")
-        # Deterministic — write ingest-log 'failed' in a fresh
-        # savepoint then tombstone the manifest.
+        # Deterministic — tombstone the manifest (re-fetch won't fix a
+        # constraint / programming defect) BUT keep the ingest-log row
+        # 'failed', NOT 'tombstoned'. Unlike the pre-2013 archive-missing
+        # skip (expected, non-actionable), an upsert defect is an
+        # actionable code/data bug — the operator must still see it via
+        # the sweep's last-run breadcrumb (#1532, Codex ckpt-2 HIGH).
+        # This deliberate manifest=tombstoned / log=failed divergence
+        # surfaces the defect without re-fetch-storming.
         try:
             with conn.transaction():
                 _record_ingest_attempt(

--- a/app/services/processes/ingest_sweep_adapter.py
+++ b/app/services/processes/ingest_sweep_adapter.py
@@ -315,6 +315,14 @@ def _log_error_summaries(
     ``(accession_number PK, filer_cik, status, error, fetched_at)``
     so the query is uniform. Identifier-injection guard: ``log_table``
     is selected from the static ``_SWEEPS`` registry, not user input.
+
+    #1532: ``status = 'failed'`` deliberately EXCLUDES ``'tombstoned'``
+    rows. A tombstone is a deterministic permanent skip (e.g. pre-2013
+    13Fs with no infotable XML) — not an operator action item — so it
+    must not red the sweep ("red = actionable", #1530). The write paths
+    (``institutional_holdings.py`` / ``manifest_parsers/sec_13f_hr.py``)
+    label those rows ``'tombstoned'``; the equality filter here drops
+    them with no extra predicate needed.
     """
     if log_table not in {"institutional_holdings_ingest_log", "n_port_ingest_log"}:
         # Defence-in-depth: refuse anything not in the allow-list.
@@ -386,6 +394,11 @@ def _has_freshness_errors(conn: psycopg.Connection[Any], *, source: str) -> bool
 
 
 def _has_manifest_failures(conn: psycopg.Connection[Any], *, source: str) -> bool:
+    # ``ingest_status='failed'`` is the actionable-failure predicate.
+    # ``'tombstoned'`` rows (deterministic permanent skips — pre-2013
+    # 13Fs, retention-floor, etc.) are intentionally NOT counted: they
+    # are not operator action items, so they must not red the sweep
+    # ("red = actionable", #1530 / #1532).
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -438,6 +451,10 @@ _LOG_STATUS_TO_RUN: dict[str, RunStatus] = {
     "success": "success",
     "partial": "partial",
     "failed": "failure",
+    # #1532 — a tombstoned accession is a deterministic permanent skip,
+    # not a failure. Map to 'skipped' so a last-run summary whose newest
+    # log row is a tombstone reads honestly (and never as 'failure').
+    "tombstoned": "skipped",
 }
 
 

--- a/sql/186_institutional_holdings_ingest_log_tombstoned.sql
+++ b/sql/186_institutional_holdings_ingest_log_tombstoned.sql
@@ -1,0 +1,41 @@
+-- 186_institutional_holdings_ingest_log_tombstoned.sql
+--
+-- #1532 — pre-2013 13F "archive index missing files" filings are
+-- deterministically unparseable (the infotable-XML mandate started 2013).
+-- The manifest worker (app/services/manifest_parsers/sec_13f_hr.py) already
+-- TOMBSTONES them in sec_filing_manifest, but it ALSO stamped a
+-- `status='failed'` row in institutional_holdings_ingest_log. The
+-- ingest_sweep_adapter reds `sec_13f_sweep` on those 55k+ log `failed`
+-- rows, contradicting #1530's "red = actionable" goal (a tombstone is a
+-- deliberate permanent skip, not an operator action item).
+--
+-- This migration:
+--   1. Widens the log `status` CHECK to admit 'tombstoned' (mirrors
+--      sec_filing_manifest.ingest_status, which already has it).
+--   2. Backfills existing archive-missing `failed` log rows -> 'tombstoned'
+--      so the dev/prod page clears immediately.
+--
+-- Code change lands in the same PR so NEW archive-missing accessions are
+-- written 'tombstoned' from both 13F ingest paths.
+--
+-- Scope of the backfill is matched on the deterministic error string, NOT
+-- on filing year: a transient fetch timeout on a pre-2013 accession (e.g.
+-- the lone manifest `failed` row, 0001085146-09-001941 = "fetch error:
+-- The read operation timed out") is a RETRYABLE failure and must stay
+-- `failed` until it drains to a real archive-missing tombstone.
+--
+-- No explicit BEGIN/COMMIT: the migration runner wraps the body + the
+-- schema_migrations INSERT in one transaction (app/db/migrations.run_migrations);
+-- the wider CHECK must commit-with the UPDATE so the reclassify doesn't
+-- violate the old constraint mid-transaction (DDL is applied before the
+-- DML below, in declaration order, within the same tx).
+ALTER TABLE institutional_holdings_ingest_log
+    DROP CONSTRAINT IF EXISTS institutional_holdings_ingest_log_status_check;
+ALTER TABLE institutional_holdings_ingest_log
+    ADD CONSTRAINT institutional_holdings_ingest_log_status_check
+    CHECK (status IN ('success', 'partial', 'failed', 'tombstoned'));
+
+UPDATE institutional_holdings_ingest_log
+   SET status = 'tombstoned'
+ WHERE status = 'failed'
+   AND error LIKE 'archive index missing files%';

--- a/tests/test_ingest_sweep_adapter.py
+++ b/tests/test_ingest_sweep_adapter.py
@@ -142,6 +142,23 @@ def _insert_n_port_log(
     )
 
 
+def _insert_13f_log(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    status: str,
+    error: str | None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO institutional_holdings_ingest_log (
+            accession_number, filer_cik, status, holdings_inserted, holdings_skipped, error
+        ) VALUES (%s, '0001234567', %s, 0, 0, %s)
+        """,
+        (accession, status, error),
+    )
+
+
 def test_sweep_registry_has_six_canonical_sweeps(ebull_test_conn: psycopg.Connection[tuple]) -> None:
     """Pin the v1 sweep registry shape — adding/removing sweeps is a deliberate change."""
     ids = ingest_sweep_adapter.sweep_process_ids()
@@ -263,6 +280,67 @@ def test_nport_sweep_reads_log_errors_first(
     assert row.status == "failed"
     # log dominates — first error_class is the log's
     assert any("NPortMissingSeriesError" in e.error_class for e in row.last_n_errors)
+
+
+def test_tombstoned_rows_do_not_red_13f_sweep(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1532 — tombstoned manifest + log rows are deterministic permanent
+    skips (pre-2013 13Fs with no infotable XML), NOT operator action items.
+    A sweep whose ONLY non-success rows are tombstoned must read 'ok'
+    ("red = actionable", #1530), and its last-run summary must read
+    'skipped' rather than 'failure'."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    _wipe_test_state(ebull_test_conn)
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="0001085146-09-000001",
+        cik="0000894300",
+        source="sec_13f_hr",
+        form="13F-HR",
+        ingest_status="tombstoned",
+        error="archive index missing files (primary=None, infotable=None)",
+        instrument_id=None,
+    )
+    _insert_13f_log(
+        ebull_test_conn,
+        accession="0001085146-09-000001",
+        status="tombstoned",
+        error="archive index missing files (primary=None, infotable=None)",
+    )
+    ebull_test_conn.commit()
+
+    row = ingest_sweep_adapter.get_row(ebull_test_conn, process_id="sec_13f_sweep")
+    assert row is not None
+    assert row.status == "ok"
+    assert row.last_n_errors == ()
+    assert row.last_run is not None
+    assert row.last_run.status == "skipped"
+
+
+def test_failed_manifest_row_still_reds_13f_sweep(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1532 guard — a genuinely actionable (retryable) manifest failure,
+    e.g. a transient fetch timeout, MUST still red the sweep. The
+    tombstone exclusion is status-scoped, not a blanket 13F mute."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    _wipe_test_state(ebull_test_conn)
+    _insert_manifest_row(
+        ebull_test_conn,
+        accession_number="0001085146-09-001941",
+        cik="0000894300",
+        source="sec_13f_hr",
+        form="13F-HR",
+        ingest_status="failed",
+        error="fetch error: The read operation timed out",
+        instrument_id=None,
+    )
+    ebull_test_conn.commit()
+
+    row = ingest_sweep_adapter.get_row(ebull_test_conn, process_id="sec_13f_sweep")
+    assert row is not None
+    assert row.status == "failed"
 
 
 def test_ok_sweep_when_no_failures_and_no_running(

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -545,6 +545,47 @@ class TestIngestFiler13F:
             assert row is not None
             assert row[0] == 0
 
+    def test_archive_missing_attachments_tombstones_accession(
+        self,
+        _setup: psycopg.Connection[tuple],
+    ) -> None:
+        """Index found but missing primary_doc / infotable — deterministic
+        (pre-2013 13Fs predate the 2013 infotable-XML mandate). Re-fetching
+        yields the same gap forever, so the accession is TOMBSTONED, not
+        'failed' (#1532). A tombstone is a permanent skip, not an operator
+        action item: the ingest-log row reads 'tombstoned' so the
+        sec_13f_sweep stays green, and it does NOT count as accessions_failed.
+        """
+        conn = _setup
+        cik_int = 1067983
+        accession = "0001067983-25-000001"
+        archive_base = f"https://www.sec.gov/Archives/edgar/data/{cik_int}/{accession.replace('-', '')}/"
+        payloads: dict[str, str | None] = {
+            "https://data.sec.gov/submissions/CIK0001067983.json": _submissions_json(
+                accessions=[(accession, "13F-HR", "2025-02-14", "2024-12-31")]
+            ),
+            # Index present but neither attachment resolvable — empty
+            # primary_doc makes parse_archive_index return primary=None.
+            archive_base + "index.json": _archive_index_json(primary_doc="", infotable=""),
+        }
+        fetcher = _InMemoryFetcher(payloads)
+        summary = ingest_filer_13f(conn, fetcher, filer_cik="0001067983")
+        conn.commit()
+        assert summary.accessions_seen == 1
+        assert summary.accessions_ingested == 0
+        # Deterministic permanent skip — NOT a failure.
+        assert summary.accessions_failed == 0
+        assert summary.first_error is None
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT status, error FROM institutional_holdings_ingest_log WHERE accession_number = %s",
+                (accession,),
+            )
+            log = cur.fetchone()
+        assert log is not None
+        assert log[0] == "tombstoned"
+        assert log[1] is not None and "archive index missing files" in log[1]
+
     def test_partial_unique_index_blocks_duplicate_equity_row(
         self,
         _setup: psycopg.Connection[tuple],

--- a/tests/test_manifest_parser_sec_13f_hr.py
+++ b/tests/test_manifest_parser_sec_13f_hr.py
@@ -320,7 +320,9 @@ def test_index_404_tombstones_with_log(
             (accession,),
         )
         log = cur.fetchone()
-    assert log is not None and log[0] == "failed"
+    # #1532 — index.json 404 is a deterministic permanent skip; the log
+    # row mirrors the tombstoned ParseOutcome so the sweep stays green.
+    assert log is not None and log[0] == "tombstoned"
 
 
 def test_index_missing_primary_doc_tombstones(
@@ -328,7 +330,7 @@ def test_index_missing_primary_doc_tombstones(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Index found but primary_doc.xml entry absent — deterministic
-    gap; tombstone the manifest + log 'failed'."""
+    gap; tombstone the manifest + log 'tombstoned' (#1532)."""
     accession = "0001067983-25-000004"
     filer_cik = "0001067983"
     _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
@@ -501,6 +503,10 @@ def test_deterministic_upsert_exception_tombstones_with_log(
         )
         log = cur.fetchone()
     assert log is not None
+    # #1532 — a deterministic UPSERT defect (constraint / programming
+    # bug) tombstones the manifest (re-fetch won't fix it) but stays
+    # log 'failed': it is an actionable code/data bug the operator must
+    # still see, unlike the expected pre-2013 archive-missing skip.
     assert log[0] == "failed"
     assert log[1] is not None and "RuntimeError" in log[1]
 
@@ -858,7 +864,9 @@ def test_pre_cap_period_tombstones_before_infotable_fetch(
         )
         log = cur.fetchone()
     assert log is not None
-    assert log[0] == "failed"
+    # #1532 — retention-floor is a deterministic permanent skip; the log
+    # row mirrors the tombstoned ParseOutcome.
+    assert log[0] == "tombstoned"
     assert log[1] == date_cls(2020, 3, 31)
     assert log[2] == "retention floor"
 


### PR DESCRIPTION
Fixes #1532.

## What
Pre-2013 13Fs predate the 2013 infotable-XML mandate — their archive index has no primary_doc/infotable attachment, so they are deterministically unparseable. The manifest worker already tombstones them in `sec_filing_manifest`, but **both** 13F ingest paths also stamped a `status='failed'` row in `institutional_holdings_ingest_log`. `ingest_sweep_adapter` red `sec_13f_sweep` on those 55k+ log `failed` rows — false-red, contradicting #1530's "red = actionable".

**Part A — classify expected, structural permanent skips as tombstones**
- `institutional_holdings.py`: the archive-missing branch returns a new `_AccessionOutcome` `status='tombstoned'` (was `failed`); the per-filer summary no longer counts it as `accessions_failed`/`first_error`.
- `sec_13f_hr.py`: the ingest-log status now **mirrors the ParseOutcome** for *expected* permanent skips — archive-missing, index/primary/infotable fetch-404, retention-floor → log `tombstoned`. The **deterministic-upsert** branch keeps log `failed` (manifest still tombstones to stop retries): a constraint/programming defect is an *actionable* code/data bug the operator must still see — unlike a non-actionable archive-structure skip (per Codex ckpt-2). The two retryable parse branches keep `failed`.
  - Verified: `sec_edgar.fetch_document_text` returns `None` only on 404/410; other HTTP errors `raise_for_status()` → caught → retryable. So fetch-`None` is genuinely permanent.

**Part B — display**
- `ingest_sweep_adapter` failed-row probes filter the exact literal `failed` / `ingest_status='failed'`, so `tombstoned` is excluded by construction (documented the invariant; no dead `<> 'tombstoned'` predicate).
- Added a `tombstoned -> 'skipped'` RunStatus mapping so a last-run summary whose newest log row is a tombstone reads honestly (not `failure`).

**Migration `sql/186`**
- Widen the log `status` CHECK to admit `tombstoned` (mirrors `sec_filing_manifest.ingest_status`).
- Backfill existing archive-missing `failed` log rows → `tombstoned`, matched on the deterministic error string (**not** filing year) so a transient fetch-timeout on a pre-2013 accession stays retryable.

## Two paths — unify?
The legacy filer-sweep (`institutional_holdings.py`) and the manifest worker (`sec_13f_hr.py`) are substantially duplicated. Unification is a sizeable refactor out of scope for this bug; recommend a follow-up tech-debt issue. This PR makes them classify archive-missing identically.

## Test (dev)
- Gates: ruff + format, pyright 0, fast tier 3737 passed, smoke 129 passed, affected db tier 67 passed.
- Migration applied on dev; backfill reclassified **55,710** archive-missing log rows → `tombstoned` (status CHECK confirmed widened).
- The lone stuck pre-2013 manifest row (`0001085146-09-001941`, a transient `read operation timed out`) was drained through the **fixed** parser via `iter_retryable` + `_dispatch_rows`: it fetched → archive-missing → **tombstoned in both manifest and log** with the new `tombstoned` log status.
- New `ingest_sweep_adapter.get_row(sec_13f_sweep)` against dev then reads `status=ok`, `last_run=skipped`, `0` errors, `0` manifest/log `failed`.
- No 13F holdings exist on dev yet (bootstrap still draining ~266k pending), so there is no ownership figure to cross-source — the operator-visible figure this PR governs is the sweep status (verified green).

## Operator follow-up
The dev **jobs** process is still running the pre-merge code and keeps writing fresh log-`failed` archive-missing rows on each ~5-min tick (old code logs `failed`; manifest still tombstones). The green above is durable only once that process restarts onto this branch — a routine post-merge restart. Not bounced here (per "never restart on own initiative").

🤖 Generated with [Claude Code](https://claude.com/claude-code)