### PR TITLE
fix(#1534): extract sec_per_cik_poll to own lane + guard freshness watermark regression

### DIFF
--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -64,6 +64,7 @@ Lane = Literal[
     "etoro",
     "sec_rate",
     "sec_manifest",
+    "sec_per_cik",
     "sec_bulk_download",
     "db",
     "db_filings",
@@ -95,16 +96,35 @@ the rate — it does not.
 * ``etoro`` — eToro REST budget. ``execute_approved_orders`` +
   ``daily_candle_refresh`` + ``etoro_lookups_refresh`` +
   ``exchanges_metadata_refresh`` serialise.
-* ``sec_rate`` — the SEC discovery/producer jobs (per-CIK + per-accession
-  fetchers). They serialise under one ``JobLock`` to bound job overlap, NOT
-  request rate (the HTTP floor above bounds rate). #1478 extracted the heavy
-  ``sec_manifest_worker`` drainer out of this lane so it stops starving the
-  lighter producers.
+* ``sec_rate`` — the SEC discovery/producer jobs (per-accession fetchers +
+  per-issuer ingest). They serialise under one ``JobLock`` to bound job
+  overlap, NOT request rate (the HTTP floor above bounds rate). #1478
+  extracted the heavy ``sec_manifest_worker`` drainer; #1534 extracted the
+  hourly ``sec_per_cik_poll`` producer (see ``sec_per_cik`` below) — both
+  for the same reason: a member that holds the shared lane (a long drainer,
+  or any member running at the exact ``:00`` slot the hourly poll fires)
+  deterministically starves the others.
 * ``sec_manifest`` — ``sec_manifest_worker`` only (#1478). The manifest drainer
   spends most of its run on DB tombstoning, not SEC calls; keeping it in
   ``sec_rate`` made it hold the producers' lane for 20-37s and starve them
   (7/7 vs 0/7). Its own lane lets it run concurrently with the producers while
   its single-instance self-lock + the shared HTTP floor still hold.
+* ``sec_per_cik`` — ``sec_per_cik_poll`` only (#1534). The hourly @ :00 Layer-3
+  poll shares the ``:00`` slot with every other ``sec_rate`` member that fires
+  on the hour (and, during bootstrap, with the near-constant heavy drainers).
+  Its fire uses a non-blocking ``pg_try_advisory_lock`` — so on contention it
+  does NOT queue, it skips the whole hour. It lost the race for 17h+ on dev
+  (last fire 2026-06-07 18:49) and the #1510 watchdog's re-enqueue kick hit the
+  same locked lane and no-opped. Its own lane removes the contention. Write
+  disjointness (a lane bounds overlap, not rate): its only shared write target
+  is ``sec_filing_manifest`` via ``record_manifest_entry`` (idempotent
+  ``ON CONFLICT`` upsert keyed by accession) — already written concurrently by
+  ``sec_manifest_worker`` from its own lane since #1478, so concurrent manifest
+  discovery is a proven-safe pattern; ``record_poll_outcome`` (per-CIK poll
+  scheduler rows) and ``set_watermark`` (the per_cik-exclusive
+  ``sec.last_modified.per_cik_poll`` namespace) have no other lane writer.
+  Scheduled-only, so NOT added to the ``bootstrap_stages.lane`` CHECK (like
+  ``sec_manifest`` / ``db_liveness`` / ``db_retry``).
 * ``sec_bulk_download`` — fixed-URL SEC archive downloads. Disjoint
   from ``sec_rate`` — large fixed downloads, no per-issuer iteration.
 * ``db`` — DB-bound stages NOT owned by a finer family lane — Phase E

--- a/app/services/data_freshness.py
+++ b/app/services/data_freshness.py
@@ -429,19 +429,48 @@ def record_poll_outcome(
                 instrument_id = COALESCE(
                     EXCLUDED.instrument_id, data_freshness_index.instrument_id
                 ),
-                last_known_filing_id = COALESCE(
-                    EXCLUDED.last_known_filing_id, data_freshness_index.last_known_filing_id
-                ),
-                last_known_filed_at = COALESCE(
-                    EXCLUDED.last_known_filed_at, data_freshness_index.last_known_filed_at
-                ),
+                -- #1534 — monotonic watermark guard (mirrors the discovery
+                -- seed path above). Before per_cik_poll got its own lane it
+                -- serialised with the other sec_rate discovery producers
+                -- (sec_atom_fast_lane / daily-index), so its read-snapshot →
+                -- fetch → write-back could not race their freshness writes.
+                -- Now that it runs concurrently, a poll that saw no newer
+                -- filing must NOT regress a watermark a concurrent producer
+                -- just advanced: gate last_known_filing_id + last_known_filed_at
+                -- on filed_at so a stale snapshot leaves the newer value
+                -- intact. expected_next_at deliberately stays EXCLUDED (the
+                -- poll owns its own re-poll cadence — line ~394 — and must
+                -- advance even on a no-new-data poll, unlike the seed path).
+                last_known_filing_id = CASE
+                    WHEN data_freshness_index.last_known_filed_at IS NULL
+                      OR EXCLUDED.last_known_filed_at > data_freshness_index.last_known_filed_at
+                    THEN EXCLUDED.last_known_filing_id
+                    ELSE data_freshness_index.last_known_filing_id
+                END,
+                last_known_filed_at = CASE
+                    WHEN data_freshness_index.last_known_filed_at IS NULL
+                      OR EXCLUDED.last_known_filed_at > data_freshness_index.last_known_filed_at
+                    THEN EXCLUDED.last_known_filed_at
+                    ELSE data_freshness_index.last_known_filed_at
+                END,
                 last_polled_at = EXCLUDED.last_polled_at,
                 last_polled_outcome = EXCLUDED.last_polled_outcome,
                 new_filings_since = data_freshness_index.new_filings_since
                     + EXCLUDED.new_filings_since,
-                expected_next_at = COALESCE(
-                    EXCLUDED.expected_next_at, data_freshness_index.expected_next_at
-                ),
+                -- #1534 — tie expected_next_at to the winning watermark so a
+                -- STRICTLY-stale poll cannot leave the row too-soon-due while
+                -- a newer watermark is preserved above. Uses ``>=`` (not the
+                -- watermark's strict ``>``) on purpose: the common no-new-data
+                -- re-poll arrives with EXCLUDED.filed_at == existing and MUST
+                -- still advance its own next-poll cadence (line ~394) — only a
+                -- strictly-older incoming filed_at keeps the existing value.
+                expected_next_at = CASE
+                    WHEN data_freshness_index.last_known_filed_at IS NULL
+                      OR EXCLUDED.last_known_filed_at IS NULL
+                      OR EXCLUDED.last_known_filed_at >= data_freshness_index.last_known_filed_at
+                    THEN EXCLUDED.expected_next_at
+                    ELSE data_freshness_index.expected_next_at
+                END,
                 next_recheck_at = EXCLUDED.next_recheck_at,
                 state = EXCLUDED.state,
                 state_reason = EXCLUDED.state_reason

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1335,7 +1335,16 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_SEC_PER_CIK_POLL,
         display_name="SEC per-CIK poll (Layer 3)",
-        source="sec_rate",
+        # #1534 — own single-job lane. On ``sec_rate`` (shared by 25 jobs)
+        # the hourly @ :00 fire lost the non-blocking advisory-lock race to
+        # whichever sibling held the lane at :00 and skipped the whole hour
+        # (starved 17h+ on dev; the #1510 watchdog kick hit the same lock and
+        # no-opped). The SEC 10 req/s cap is the HTTP floor, not the lane, so
+        # extraction is rate-safe. Disjointness: its only shared write target
+        # (``sec_filing_manifest`` via idempotent ON CONFLICT upsert) is already
+        # written concurrently by ``sec_manifest_worker`` from its own lane
+        # since #1478. See app/jobs/sources.py ``sec_per_cik`` docstring.
+        source="sec_per_cik",
         description=(
             "#1155 — Layer 3 of the #863-#873 freshness redesign. "
             "Hourly per-CIK reconcile reads data_freshness_index for "

--- a/tests/test_data_freshness.py
+++ b/tests/test_data_freshness.py
@@ -357,6 +357,55 @@ class TestRecordPollOutcome:
         # cadence = 30d for form4
         assert row.expected_next_at == datetime(2026, 3, 31, tzinfo=UTC)
 
+    def test_stale_poll_does_not_regress_watermark(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # #1534 — sec_per_cik_poll now runs on its own lane, concurrently
+        # with the sec_rate discovery producers (sec_atom_fast_lane /
+        # daily-index) that also write this freshness row. A per-CIK poll
+        # that snapshotted an OLD watermark, fetched, and saw no newer
+        # filing must NOT clobber a newer watermark a concurrent producer
+        # advanced in the meantime. Models: producer advanced to ACC-NEW;
+        # the in-flight poll then writes back its stale ACC-OLD snapshot.
+        _seed_instrument(ebull_test_conn, iid=1, symbol="X", cik="0000000001")
+        record_poll_outcome(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            outcome="new_data",
+            last_known_filing_id="ACC-NEW",
+            last_known_filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+            new_filings_since=1,
+            cik="0000000001",
+            instrument_id=1,
+        )
+        # Stale poll: older snapshot, no new filings seen.
+        record_poll_outcome(
+            ebull_test_conn,
+            subject_type="issuer",
+            subject_id="1",
+            source="sec_form4",
+            outcome="current",
+            last_known_filing_id="ACC-OLD",
+            last_known_filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+            new_filings_since=0,
+            cik="0000000001",
+            instrument_id=1,
+        )
+        ebull_test_conn.commit()
+
+        row = get_freshness_row(ebull_test_conn, subject_type="issuer", subject_id="1", source="sec_form4")
+        assert row is not None
+        # Watermark did NOT regress to the stale snapshot.
+        assert row.last_known_filing_id == "ACC-NEW"
+        assert row.last_known_filed_at == datetime(2026, 2, 1, tzinfo=UTC)
+        # expected_next_at stays anchored on the preserved (newer) watermark
+        # 2026-02-01 + 30d form4 cadence — NOT the stale 2026-01-01 anchor,
+        # which would leave the row spuriously too-soon-due.
+        assert row.expected_next_at == datetime(2026, 3, 3, tzinfo=UTC)
+
     def test_error_outcome_sets_error_state(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -44,6 +44,13 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # is a job-overlap bucket, not a rate gate (the HTTP throttle bounds
         # the 10 req/s budget); see app/jobs/sources.py::Lane.
         "sec_manifest",
+        # #1534 — sec_per_cik_poll extracted from sec_rate into its own
+        # single-job lane. The hourly @ :00 producer lost the non-blocking
+        # advisory-lock race to whichever sec_rate sibling held the lane at
+        # :00 and skipped the whole hour (starved 17h+ on dev; the #1510
+        # watchdog kick hit the same lock and no-opped). Same shape as the
+        # #1478 sec_manifest split. See app/jobs/sources.py::Lane.
+        "sec_per_cik",
         "sec_bulk_download",
         "db",
         # #1141 — Phase C bulk-ingest family sources. Bootstrap-only
@@ -720,6 +727,36 @@ class TestSecManifestLaneExtraction:
             assert source_for(producer) != worker_lane, (
                 f"{producer} shares lane {worker_lane!r} with sec_manifest_worker — "
                 "the #1478 starvation extraction has regressed"
+            )
+
+
+class TestSecPerCikLaneExtraction:
+    """#1534 — ``sec_per_cik_poll`` lives in its OWN lane, distinct from the
+    ``sec_rate`` siblings that starved its hourly @ :00 fire (non-blocking
+    advisory-lock race → skipped the whole hour, 17h+ on dev; the #1510
+    watchdog kick hit the same lock and no-opped). DB-free always-on gate,
+    same rationale as ``TestSecManifestLaneExtraction``.
+    """
+
+    def test_sec_per_cik_poll_has_own_lane(self) -> None:
+        assert source_for("sec_per_cik_poll") == "sec_per_cik"
+
+    def test_sec_per_cik_lane_differs_from_every_sec_rate_sibling(self) -> None:
+        """The whole point: the hourly poll no longer shares a lane with the
+        ``sec_rate`` members that hold the lane at :00. If a future change
+        re-collapses it onto ``sec_rate``, this re-breaks."""
+        poll_lane = source_for("sec_per_cik_poll")
+        assert poll_lane != "sec_rate"
+        for sibling in (
+            "sec_atom_fast_lane",
+            "sec_daily_index_reconcile",
+            "sec_filing_documents_ingest",
+            "sec_form3_ingest",
+            "sec_insider_transactions_backfill",
+        ):
+            assert source_for(sibling) != poll_lane, (
+                f"{sibling} shares lane {poll_lane!r} with sec_per_cik_poll — "
+                "the #1534 starvation extraction has regressed"
             )
 
 

--- a/tests/test_layer_123_wiring.py
+++ b/tests/test_layer_123_wiring.py
@@ -83,7 +83,10 @@ class TestLayer123Registry:
         assert job.cadence == Cadence.hourly(minute=0)
         assert job.catch_up_on_boot is False
         assert job.prerequisite is not None
-        assert job.source == "sec_rate"
+        # #1534 — extracted from the over-subscribed sec_rate lane to its own
+        # single-job lane (the hourly @ :00 fire lost the non-blocking
+        # advisory-lock race to sec_rate siblings and skipped the whole hour).
+        assert job.source == "sec_per_cik"
 
     def test_layer4_master_idx_quarterly_sweep_registered(self) -> None:
         """G12 — cross-quarter discovery walker. Weekly Sun 05:15 UTC.


### PR DESCRIPTION
Fixes #1534.

## Problem

`sec_per_cik_poll` (hourly @ :00, Layer 3) showed red **NEEDS ATTENTION / schedule missed** despite `Last run · success`. Verified on dev: last actual fire `2026-06-07 18:49 UTC`, zero `job_runs` rows since, no failures, no skips, bootstrap `complete` (not gated). The #1510 watchdog detected the stall and re-enqueued, but the kick `no-opped: advisory lock held by another runner` — self-heal firing but unable to take.

**Root cause:** `sec_per_cik_poll` shared the `sec_rate` lane (one non-blocking source-level `JobLock`) with 25 jobs, including `sec_atom_fast_lane` (every 5 min) and heavy drainers. Its `:00` fire uses a non-blocking `pg_try_advisory_lock` — on contention it does not queue, it skips the whole hour. With bootstrap draining 266k filings the heavy `sec_rate` jobs run near-constantly, so per_cik lost every race. The log shows other `sec_rate` jobs skipping identically. Same class as #1478 (sec_manifest split) / #1526 / #1527 (db-lane).

## Change

1. **Extract `sec_per_cik_poll` to its own single-job lane `sec_per_cik`** (`Lane` Literal + `ScheduledJob.source`). Mirrors #1478/#1527. Scheduled-only → NOT added to the `bootstrap_stages.lane` CHECK (no migration). The SEC 10 req/s cap is the HTTP floor (`concurrent_fetch.py` / ResilientClient), **not** the lane — so extraction is rate-safe.

2. **Freshness watermark regression guard** (Codex checkpoint-2 finding). Once per_cik runs concurrently with the `sec_rate` discovery producers (`sec_atom_fast_lane` / daily-index) that also write `data_freshness_index`, `record_poll_outcome`'s blind `COALESCE(EXCLUDED, existing)` could regress a watermark a concurrent producer just advanced (per_cik snapshots an old watermark → fetches → writes back stale). Fix:
   - `last_known_filing_id` / `last_known_filed_at` → monotonic `CASE` guard (mirrors the discovery seed-path guard in the same file) — strictly-older incoming filed_at leaves the newer value intact.
   - `expected_next_at` → tied to the winning watermark with `>=` (Codex follow-up finding): a strictly-stale poll keeps the existing value (no spurious too-soon-due), but the common no-new-data re-poll (`==`) still advances its own cadence per the existing line-394 anti-storm rule.
   - `record_poll_outcome` is called **only** by `sec_per_cik_poll`, so the guard's blast radius is exactly the extracted job.

## Security model

No auth surface. JobLock advisory keys are derived from the in-memory source registry; the new lane is a distinct key. No user-controlled input; all SQL parameterised. No schema/migration.

## Tradeoffs / notes

- Codex flagged a residual same-`filed_at` edge (equality keeps existing filing id). `data_freshness_index.last_known_filed_at` is `timestamptz` (timestamp-precise), so distinct filings advance via strict `>`; an exact-timestamp tie is harmless (manifest has both via ON CONFLICT). This matches the existing seed-path guard exactly — consciously consistent, not a new divergence.
- The #1510 watchdog cannot heal a *lane-starvation* stall (its re-enqueue lands in the same contended lane). Out of scope here (per_cik on its own lane no longer stalls); filed as a follow-up tech-debt.

## Verification

- `ruff check` / `ruff format --check` / `pyright`: clean.
- Fast tier `pytest -m "not db"`: **3739 passed**. Smoke: **129 passed**.
- `db` tier (the SQL change): `test_data_freshness.py` + `test_sec_per_cik_poll.py` + conditional-GET: **42 passed**, incl. new `test_stale_poll_does_not_regress_watermark` (asserts neither `last_known_*` nor `expected_next_at` regress).
- New DB-free regression gate: `TestSecPerCikLaneExtraction` (own lane + disjoint from every `sec_rate` sibling).
- **Post-merge dev verify (pending):** restart jobs proc onto the fix, trigger `sec_per_cik_poll` (now on its own free lane → runs), confirm `job_runs` success + Processes verdict `sec_per_cik_poll` → current, and watermark non-regression across a live `sec_atom_fast_lane` tick. Will record the commit SHA + figures.