### PR TITLE
fix(#1538): retry scheduled-fire lane acquire on transient cross-job contention (general sec_rate de-starvation)

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -42,6 +42,7 @@ import contextvars
 import logging
 import os
 import threading
+import time
 from collections.abc import Callable, Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -430,6 +431,95 @@ _RECURRING_JOB_ID_PREFIX: Final[str] = "recurring:"
 # running job triggers it too), so the honest label is "an instance is already
 # active"; the operator tells wedge from slow via the running row's age.
 _MAX_INSTANCES_SKIP_REASON: Final[str] = "max_instances_active"
+
+
+# ---------------------------------------------------------------------------
+# Lane-busy retry (#1538)
+# ---------------------------------------------------------------------------
+#
+# ``JobLock`` is ONE advisory lock per lane (``source``), shared by every job on
+# that lane. The acquire is non-blocking, so a scheduled fire that loses the
+# race to a DIFFERENT job on the same lane raised ``JobAlreadyRunning`` and
+# skipped its WHOLE cadence period — e.g. an hourly producer firing at :00 lost
+# to ``sec_atom_fast_lane`` (every 5 min) and read red "schedule missed" with a
+# successful-looking last run, even though nothing was actually wrong. Per-job
+# lane extraction (#1534) fixed that one job at a time; this fixes the mechanism
+# for every lane: retry the ACQUIRE a few times so the loser re-acquires once
+# the peer (typically <1s) releases, and runs the same period.
+_LANE_BUSY_RETRY_BACKOFF: Final[tuple[float, ...]] = (0.25, 0.5, 1.0)  # 3 retries, ~1.75s max
+# Cap concurrent retry-sleepers so the bounded waits can never drain the
+# APScheduler worker pool (executor size 10, misfire_grace_time=1). When all
+# slots are taken a colliding fire skips immediately — exactly the pre-#1538
+# behaviour, never worse.
+_MAX_CONCURRENT_LANE_WAITERS: Final[int] = 3
+_LANE_WAIT_SLOTS: Final[threading.BoundedSemaphore] = threading.BoundedSemaphore(_MAX_CONCURRENT_LANE_WAITERS)
+
+
+def _fire_scheduled_with_lane_retry(
+    database_url: str,
+    job_name: str,
+    run: Callable[[], None],
+    *,
+    backoff: tuple[float, ...] = _LANE_BUSY_RETRY_BACKOFF,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Run a scheduled fire under its source-level ``JobLock``, retrying ONLY a
+    failed lock ACQUIRE on lane contention (#1538).
+
+    On lane-busy the fire re-tries the acquire a few times (``backoff``) so it
+    can run the same cadence period instead of skipping until next cadence.
+
+    Invariants:
+      * Retries ONLY the acquire. ``JobAlreadyRunning`` raised by
+        ``JobLock.__enter__`` (acquire) is retried; the same exception raised
+        from inside ``run`` (the body) is RE-RAISED, never replayed — the body
+        may have partially executed. The ``acquired`` flag distinguishes them.
+      * A module-level ``BoundedSemaphore`` caps concurrent waiters; with no
+        free slot the fire skips immediately (== pre-#1538 behaviour), so retry
+        sleeps cannot starve the scheduler pool.
+      * Worst case (lane held longer than the retry window, or no slot free) is
+        the old skip exactly — no new failure mode.
+
+    Returns normally on a lane-contention skip (after logging). Propagates
+    ``JobAlreadyRunning`` ONLY when ``run`` itself raised it (body-origin), plus
+    any exception ``run`` raises — the caller's existing handlers own those.
+    """
+    slot_held = False
+    try:
+        for attempt in range(len(backoff) + 1):
+            acquired = False
+            try:
+                with JobLock(database_url, job_name):
+                    acquired = True
+                    run()
+                return  # ran this period
+            except JobAlreadyRunning:
+                if acquired:
+                    # Raised from the body, not the acquire — not a lane skip.
+                    raise
+                if attempt == 0:
+                    if not _LANE_WAIT_SLOTS.acquire(blocking=False):
+                        logger.info(
+                            "scheduled fire of %r skipped: its lane is busy and all %d "
+                            "lane-retry slots are in use; will fire next cadence",
+                            job_name,
+                            _MAX_CONCURRENT_LANE_WAITERS,
+                        )
+                        return
+                    slot_held = True
+                if attempt < len(backoff):
+                    sleep(backoff[attempt])
+                    continue
+                logger.info(
+                    "scheduled fire of %r skipped: its lane stayed busy through the "
+                    "~%.2fs retry window; will fire next cadence",
+                    job_name,
+                    sum(backoff),
+                )
+                return
+    finally:
+        if slot_held:
+            _LANE_WAIT_SLOTS.release()
 
 
 # ---------------------------------------------------------------------------
@@ -1766,28 +1856,34 @@ class JobRuntime:
                         exc_info=True,
                     )
 
+            # #1071 — admin control hub PR3: route through the lock+fence
+            # prelude. Scheduled fires never bypass the fence (they are not the
+            # full-wash holder), so the default ``bypass_fence_check=False``
+            # applies. Self-tracked invokers opt out of the prelude.
+            def _run_scheduled_body() -> None:
+                if job_name in _PRELUDE_OPT_OUT_JOBS:
+                    # Set both contextvars so the opt-out invoker's
+                    # ``_tracked_job`` (if any) reuses the snapshot.
+                    snap_token = _params_snapshot_var.set(params)
+                    try:
+                        invoker(params)
+                    finally:
+                        _params_snapshot_var.reset(snap_token)
+                else:
+                    run_with_prelude(database_url, job_name, invoker, params=params)
+
             try:
-                with JobLock(database_url, job_name):
-                    # #1071 — admin control hub PR3: route through the
-                    # lock+fence prelude. Scheduled fires never bypass the
-                    # fence (they are not the full-wash holder), so the
-                    # default ``bypass_fence_check=False`` applies.
-                    # Self-tracked invokers opt out of the prelude.
-                    if job_name in _PRELUDE_OPT_OUT_JOBS:
-                        # Set both contextvars so the opt-out invoker's
-                        # ``_tracked_job`` (if any) reuses the snapshot.
-                        snap_token = _params_snapshot_var.set(params)
-                        try:
-                            invoker(params)
-                        finally:
-                            _params_snapshot_var.reset(snap_token)
-                    else:
-                        run_with_prelude(database_url, job_name, invoker, params=params)
+                # #1538 — retry the source-level lane acquire on transient
+                # cross-job contention so a fire that loses the shared-lane race
+                # runs the SAME period instead of skipping the whole cadence.
+                _fire_scheduled_with_lane_retry(database_url, job_name, _run_scheduled_body)
             except JobAlreadyRunning:
+                # The helper retries the ACQUIRE, so this is reached ONLY when
+                # the body raised it — the same job is already running in this
+                # process (a manual trigger or an overrunning prior fire).
                 logger.info(
-                    "scheduled fire of %r skipped: another instance is "
-                    "already running (lock held by manual trigger or "
-                    "earlier overrunning fire)",
+                    "scheduled fire of %r skipped: the same job is already "
+                    "running in this process; will fire next cadence",
                     job_name,
                 )
             except OrchestratorFenceHeld as exc:

--- a/docs/specs/ops/2026-06-08-lane-busy-retry.md
+++ b/docs/specs/ops/2026-06-08-lane-busy-retry.md
@@ -1,0 +1,159 @@
+# Lane-busy retry — scheduled fires recover transient cross-job lane contention
+
+**Issue:** #1538 · **Relates:** #1534 (per_cik lane extraction), #1536 (watchdog can't heal lane starvation), #1064 (same-source serialise), #1530 (schedule_missed de-noise)
+
+## Problem
+
+A scheduled fire acquires a **source-level** `JobLock` —
+`pg_try_advisory_lock(hashtext('job_source:{lane}'))`, NON-blocking. When the
+lane is already held it raises `JobAlreadyRunning`; the scheduled-fire handler
+(`app/jobs/runtime.py`, the `except JobAlreadyRunning` at the `with JobLock(...)`
+site) logs "skipped" and **waits for the next cadence** — losing the whole
+period.
+
+On an over-subscribed lane this starves periodic producers. `sec_rate` has ~24
+jobs including `sec_atom_fast_lane` (every 5 min, holds the lane <1s) and heavy
+drainers. Any periodic producer whose slot aligns with a lane peer (most do —
+`:00`, `:35`, hourly/daily on 5-min boundaries) loses the race and skips. On dev:
+`sec_per_cik_poll` skipped 17h+ (fixed by #1534 — own lane); `sec_filing_documents_ingest`
+fires ~every 2h instead of hourly; daily_index / 8k / form3 / master_idx are
+exposed identically.
+
+## Root cause
+
+The skip-whole-period on **transient cross-job** lane contention.
+`max_instances=1` (`app/jobs/runtime.py`) already prevents a job overlapping
+*itself*, so the source-level lock serializes only DIFFERENT jobs — the skip is
+a cross-job artifact, not self-overlap protection. Per-job lane extraction
+(#1534) treats one symptom at a time; the mechanism is generic to every lane.
+
+## Design — in-lock bounded retry (extracted helper)
+
+Extract the scheduled-fire run into a small, testable helper
+`_fire_scheduled_with_lane_retry(database_url, job_name, run, *, backoff, sleep=time.sleep)`
+that wraps the existing `with JobLock(...): run()` in a bounded retry. The
+inline `except JobAlreadyRunning` site in `app/jobs/runtime.py` calls the helper.
+
+Two invariants the helper must hold:
+
+1. **Retry ONLY the acquire, never the body.** `JobAlreadyRunning` is raised by
+   `JobLock.__enter__` (acquire) — verified at `app/jobs/locks.py:324` — BEFORE
+   the body runs. But the `except` wraps the whole `with`, so a `JobAlreadyRunning`
+   surfaced from *inside* the invoker/prelude must NOT be retried (the body
+   already partially ran). Guard with an `acquired` flag set as the first
+   statement inside the `with`; on `JobAlreadyRunning` with `acquired=True`, treat
+   as a body error (log + stop), do not retry.
+2. **Bound concurrent waiters** so retry sleeps cannot drain the scheduler pool
+   (see Safety). A module-level `BoundedSemaphore` gates the wait; if no slot is
+   free, skip immediately (== today's behaviour).
+
+```python
+# app/jobs/runtime.py (shape, not final formatting)
+_LANE_BUSY_RETRY_BACKOFF: tuple[float, ...] = (0.25, 0.5, 1.0)   # 3 retries, ~1.75s max
+_MAX_CONCURRENT_LANE_WAITERS = 3
+_LANE_WAIT_SLOTS = threading.BoundedSemaphore(_MAX_CONCURRENT_LANE_WAITERS)
+
+def _fire_scheduled_with_lane_retry(database_url, job_name, run, *, backoff=_LANE_BUSY_RETRY_BACKOFF, sleep=time.sleep):
+    slot = False
+    try:
+        for attempt in range(len(backoff) + 1):
+            acquired = False
+            try:
+                with JobLock(database_url, job_name):
+                    acquired = True
+                    run()
+                return                                  # ran this period
+            except JobAlreadyRunning:
+                if acquired:
+                    raise                               # body raised it — NOT a lane skip; caller logs
+                if attempt == 0 and not _LANE_WAIT_SLOTS.acquire(blocking=False):
+                    logger.info("scheduled fire of %r skipped: lane busy, no retry slot free", job_name)
+                    return                              # too many concurrent waiters — skip now
+                slot = slot or attempt == 0 and True    # (set when slot acquired)
+                if attempt < len(backoff):
+                    sleep(backoff[attempt]); continue
+                logger.info("scheduled fire of %r skipped after %d lane-busy retries: lane held the whole window", job_name, len(backoff))
+                return
+    finally:
+        if slot:
+            _LANE_WAIT_SLOTS.release()
+```
+
+(The `slot` bookkeeping is shown roughly; final code sets it precisely when the
+semaphore is acquired and releases exactly once.) The caller keeps its existing
+`except JobAlreadyRunning` (now only reached if the body raised it),
+`except OrchestratorFenceHeld`, and `except Exception` arms unchanged.
+
+### Why it works
+
+The dominant collision is with `sec_atom_fast_lane` (holds the lane <1s). The
+first acquire at `:35:00` loses; the retry ~0.25–0.5s later finds the lane free
+and **runs the same period**. Recovery is within the first period — far under
+the ~2-cadence `schedule_missed` de-noise threshold (#1530) — so the row never
+goes red. No verdict change required.
+
+### Safety / bounds
+
+- **Worst case = today.** Lane held longer than the ~1.75s window (a ~2-min heavy
+  drainer), OR no waiter slot free → log skip exactly as now. No new failure mode.
+- **Scheduler-pool protection (Codex ckpt-1).** APScheduler runs executor size
+  10, `misfire_grace_time=1`, `coalesce=True`, `max_instances=1`
+  (`app/jobs/runtime.py:956`). Sleeping workers risk delaying *other* due jobs
+  past the 1s misfire grace. Mitigations: (a) short backoff (~1.75s max, vs the
+  job runtimes already on the pool — e.g. filing_documents ~1m44s — so the
+  incremental hold is small); (b) `BoundedSemaphore(3)` caps total concurrent
+  sleepers at 3, so retries can never occupy more than 3 of 10 workers; excess
+  collisions skip immediately. This is a deliberate tradeoff, not a free lunch.
+- **No self-overlap special-casing.** Retrying is safe whether the lane is held
+  by another job (likely frees) or this job's own manual run (retries exhaust →
+  skip). Bounded either way.
+- **#1184 re-entrancy (Codex ckpt-1).** `_HELD_SOURCES` is per-ContextVar and NOT
+  cross-thread (`app/jobs/locks.py`), so a same-context nested same-lane acquire
+  bypasses Postgres entirely (no `JobAlreadyRunning`, never reaches the retry);
+  scheduled/manual sibling workers on different threads still collide at Postgres
+  and ARE the case this retry helps. Retry semantics are unaffected by the bypass.
+- **Manual triggers unchanged.** The manual-trigger path keeps its immediate
+  `JobAlreadyRunning` → 409. Only the scheduled-fire caller wraps with the helper.
+- **`max_instances=1` interaction.** The retry occupies the run slot for ≤~1.75s;
+  for all current scheduled cadences (≥ every-5-min) that is ≪ the period, so a
+  next-cadence fire is not expected to be affected. (Not an absolute guarantee —
+  it holds because cadences ≫ the retry window, not by construction.)
+
+### Not in scope
+
+- No change to lane membership (`sec_rate` keeps its members; per_cik stays on
+  its own lane from #1534).
+- No change to `JobLock` semantics itself (still non-blocking acquire); the retry
+  lives in the scheduled-fire caller so manual/orchestrator acquire paths are
+  untouched.
+- The #1536 watchdog enhancement is separate (this reduces how often a job
+  reaches a true stall, but doesn't replace the watchdog).
+
+## Testing (fast tier, DB-free)
+
+The helper takes an injected `sleep` and runs against a fake `JobLock`, so all
+tests are pure (no DB, no real sleeping).
+
+- **Retry-then-run:** fake `JobLock` raises `JobAlreadyRunning` on the first N
+  `__enter__`s then succeeds; assert the `run` callable fires once and `sleep`
+  was called N times with the expected backoff prefix.
+- **Exhaust-then-skip:** `JobLock.__enter__` always raises; assert `run` never
+  fires, `sleep` called `len(backoff)` times, skip logged once.
+- **Body raises `JobAlreadyRunning` → NOT retried (Codex ckpt-1):** `JobLock`
+  acquires (sets `acquired`), the `run` callable raises `JobAlreadyRunning`;
+  assert exactly one attempt, `sleep` never called, and it surfaces as a body
+  error (not a lane-skip) to the caller.
+- **Waiter-slot exhaustion → immediate skip (Codex ckpt-1):** pre-acquire all
+  `_MAX_CONCURRENT_LANE_WAITERS` slots; a lane-busy fire skips on attempt 0
+  without sleeping; assert `sleep` never called and the slot count is unchanged
+  afterwards (the helper released nothing it didn't take).
+- **Slot released on every exit path:** after retry-then-run, exhaust-then-skip,
+  and body-raises, assert `_LANE_WAIT_SLOTS` is back to full capacity (no leak).
+
+## Rollout / verify
+
+Restart dev jobs proc onto the change. Confirm `sec_filing_documents_ingest`,
+`sec_daily_index_reconcile`, `sec_8k_events_ingest`, `sec_form3_ingest` fire on
+their full cadence (no skipped periods) across an aligned `sec_atom_fast_lane`
+tick; verify their Processes verdicts read current. Spot-check the log for
+"skipped after N lane-busy retries" — should be rare (only genuine long holds).

--- a/tests/test_lane_busy_retry.py
+++ b/tests/test_lane_busy_retry.py
@@ -1,0 +1,172 @@
+"""#1538 — ``_fire_scheduled_with_lane_retry`` bounded-retry behaviour.
+
+Pure unit tests (no DB, no real sleeping): a fake ``JobLock`` controls whether
+the *acquire* succeeds, the body is an injected callable, and ``sleep`` is a
+recorder. Verifies the two invariants Codex flagged at spec checkpoint-1:
+retry ONLY the acquire (body-raised ``JobAlreadyRunning`` is not replayed), and
+the ``BoundedSemaphore`` caps + releases waiter slots without leaking.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from app.jobs import runtime
+from app.jobs.locks import JobAlreadyRunning
+
+_BACKOFF = (0.25, 0.5, 1.0)  # 3 retries; matches the shape, values arbitrary for tests
+
+
+def _fake_joblock_factory(state: dict[str, int]):
+    """Return a JobLock stand-in. ``__enter__`` raises ``JobAlreadyRunning`` for
+    the first ``state['fail_n']`` calls (acquire failures), then succeeds."""
+
+    class _FakeLock:
+        def __init__(self, _database_url: str, _job_name: str) -> None:
+            pass
+
+        def __enter__(self) -> _FakeLock:
+            state["enter"] += 1
+            if state["enter"] <= state["fail_n"]:
+                raise JobAlreadyRunning("fake")
+            return self
+
+        def __exit__(self, *_exc: object) -> bool:
+            return False
+
+    return _FakeLock
+
+
+def _slots_available(sem: threading.BoundedSemaphore) -> int:
+    """Count free slots non-destructively (acquire all, then release them back)."""
+    taken = 0
+    while sem.acquire(blocking=False):
+        taken += 1
+    for _ in range(taken):
+        sem.release()
+    return taken
+
+
+@pytest.fixture
+def fresh_slots(monkeypatch: pytest.MonkeyPatch) -> threading.BoundedSemaphore:
+    sem = threading.BoundedSemaphore(runtime._MAX_CONCURRENT_LANE_WAITERS)
+    monkeypatch.setattr(runtime, "_LANE_WAIT_SLOTS", sem)
+    return sem
+
+
+def test_retry_then_run(monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore) -> None:
+    state = {"enter": 0, "fail_n": 2}
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    ran: list[int] = []
+
+    runtime._fire_scheduled_with_lane_retry(
+        "db://x", "job", lambda: ran.append(1), backoff=_BACKOFF, sleep=sleeps.append
+    )
+
+    assert ran == [1]  # body ran exactly once
+    assert state["enter"] == 3  # 2 failed acquires + 1 success
+    assert sleeps == [0.25, 0.5]  # slept before each retry, not after success
+    assert _slots_available(fresh_slots) == runtime._MAX_CONCURRENT_LANE_WAITERS  # slot released
+
+
+def test_exhaust_then_skip(monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore) -> None:
+    state = {"enter": 0, "fail_n": 99}  # always busy
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    ran: list[int] = []
+
+    runtime._fire_scheduled_with_lane_retry(
+        "db://x", "job", lambda: ran.append(1), backoff=_BACKOFF, sleep=sleeps.append
+    )
+
+    assert ran == []  # never ran
+    assert state["enter"] == len(_BACKOFF) + 1  # initial + 3 retries
+    assert sleeps == list(_BACKOFF)  # slept between each, then gave up
+    assert _slots_available(fresh_slots) == runtime._MAX_CONCURRENT_LANE_WAITERS  # slot released
+
+
+def test_body_raised_job_already_running_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    state = {"enter": 0, "fail_n": 0}  # acquire always succeeds
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+
+    def _body() -> None:
+        raise JobAlreadyRunning("body-origin")
+
+    # Body-origin JobAlreadyRunning propagates to the caller, NOT retried.
+    with pytest.raises(JobAlreadyRunning):
+        runtime._fire_scheduled_with_lane_retry("db://x", "job", _body, backoff=_BACKOFF, sleep=sleeps.append)
+
+    assert state["enter"] == 1  # exactly one acquire, no retry
+    assert sleeps == []  # never slept
+    assert _slots_available(fresh_slots) == runtime._MAX_CONCURRENT_LANE_WAITERS  # no slot taken/leaked
+
+
+def test_no_free_slot_skips_immediately(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    # Drain every waiter slot so the colliding fire cannot retry.
+    for _ in range(runtime._MAX_CONCURRENT_LANE_WAITERS):
+        assert fresh_slots.acquire(blocking=False)
+    state = {"enter": 0, "fail_n": 99}
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    ran: list[int] = []
+
+    runtime._fire_scheduled_with_lane_retry(
+        "db://x", "job", lambda: ran.append(1), backoff=_BACKOFF, sleep=sleeps.append
+    )
+
+    assert ran == []  # skipped
+    assert state["enter"] == 1  # one acquire attempt, then no slot → immediate skip
+    assert sleeps == []  # never slept (no slot to wait in)
+    # The helper took no slot it must release; the 3 we drained are still ours.
+    assert _slots_available(fresh_slots) == 0
+
+
+def test_body_other_exception_after_retry_releases_slot(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    # attempt 0 fails acquire (slot taken) → attempt 1 acquires → body raises a
+    # non-JobAlreadyRunning error. It must propagate AND the slot must be freed.
+    state = {"enter": 0, "fail_n": 1}
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+
+    def _body() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        runtime._fire_scheduled_with_lane_retry("db://x", "job", _body, backoff=_BACKOFF, sleep=sleeps.append)
+
+    assert state["enter"] == 2  # one failed acquire + one success (then body raised)
+    assert sleeps == [0.25]  # slept once before the retry that acquired
+    assert _slots_available(fresh_slots) == runtime._MAX_CONCURRENT_LANE_WAITERS  # slot released in finally
+
+
+def test_body_job_already_running_after_retry_not_replayed(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    # attempt 0 fails acquire (slot taken) → attempt 1 acquires → body raises
+    # JobAlreadyRunning. acquired=True so it is NOT replayed; propagates; slot freed.
+    state = {"enter": 0, "fail_n": 1}
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    body_calls: list[int] = []
+
+    def _body() -> None:
+        body_calls.append(1)
+        raise JobAlreadyRunning("body-origin")
+
+    with pytest.raises(JobAlreadyRunning):
+        runtime._fire_scheduled_with_lane_retry("db://x", "job", _body, backoff=_BACKOFF, sleep=sleeps.append)
+
+    assert body_calls == [1]  # body ran once, NOT replayed after raising
+    assert state["enter"] == 2  # failed acquire + the acquire whose body raised
+    assert sleeps == [0.25]  # only the pre-retry sleep
+    assert _slots_available(fresh_slots) == runtime._MAX_CONCURRENT_LANE_WAITERS  # slot released in finally


### PR DESCRIPTION
Fixes #1538.

## Problem (general, not job-specific)

A scheduled fire acquires a **source-level** `JobLock` — one non-blocking advisory lock per lane (`source`), shared by every job on that lane. Losing the race to a *different* job on the same lane raised `JobAlreadyRunning` → the scheduled-fire handler logged "skipped" and **waited for the next cadence**, losing the whole period. On the over-subscribed `sec_rate` lane (~24 jobs incl. `sec_atom_fast_lane` every 5 min), any periodic producer whose slot aligns with a lane peer skipped repeatedly and read red `schedule_missed` despite a successful-looking last run.

`#1534` moved one job (`sec_per_cik_poll`) to its own lane — whack-a-mole. `sec_filing_documents_ingest`, `sec_daily_index_reconcile`, `sec_8k_events_ingest`, `sec_form3_ingest`, `sec_master_idx_*` have the identical symptom. The disease is **skip-whole-period on transient cross-job lane contention**, generic to every lane. (`max_instances=1` already prevents a job overlapping *itself*, so the lane lock only serializes *different* jobs — the skip is a cross-job artifact.)

## Fix

`_fire_scheduled_with_lane_retry` at the single scheduled-fire chokepoint (`app/jobs/runtime.py`) retries **only a failed acquire** — backoff `(0.25, 0.5, 1.0)s`, ~1.75s max — then skips as before. The dominant collision is with `sec_atom_fast_lane` (holds the lane <1s), so one retry ~0.25s later finds it free and **runs the same period** — recovering well under the ~2-cadence `schedule_missed` de-noise threshold (#1530), so the row never reddens. General: every lane, every job.

### Safety (Codex checkpoint-1 + 2)

- **Retry only the acquire.** An `acquired` flag is set as the first statement inside the `with JobLock`; a `JobAlreadyRunning` raised by the *body* is re-raised, never replayed (the body may have partially executed). Only `__enter__` (acquire) failures retry.
- **Scheduler-pool protection.** `BoundedSemaphore(3)` caps concurrent retry-sleepers, so bounded waits can never drain the APScheduler worker pool (executor 10, `misfire_grace_time=1`). No free slot → skip immediately. Short backoff (~1.75s ≪ the job runtimes already on the pool, e.g. filing_documents ~1m44s).
- **Worst case == today.** Lane held past the window, or no slot → the old skip exactly. No new failure mode.
- **#1184 re-entrancy** unaffected (`_HELD_SOURCES` is per-ContextVar, not cross-thread; same-context nested acquires bypass Postgres and never reach the retry).
- **Manual triggers unchanged** (immediate 409). Only the scheduled-fire caller wraps with the helper.

### Operator-facing (intuitive — the point of this thread)

The happy path leaves the row **green** — operators never see it. The misleading `"another instance is already running (lock held by manual trigger or earlier overrunning fire)"` log (which is what made the original red look like a contradiction) is replaced with messages that state *what* and *next step*: e.g. `"… skipped: its lane stayed busy through the ~1.75s retry window; will fire next cadence"`.

## Security model

No auth surface, no user input, no SQL, no schema. Pure in-process concurrency change at one chokepoint. Lane membership unchanged (per_cik keeps its #1534 lane).

## Verification

- `ruff` / `pyright`: clean. Fast tier `pytest -m "not db"`: **3743 passed**. Smoke: **129 passed**.
- New `tests/test_lane_busy_retry.py`: **6 pure DB-free cases** — retry-then-run, exhaust-then-skip, body-raised `JobAlreadyRunning` not replayed (attempt 0 + post-retry), other body exception releases slot, no-free-slot immediate skip; all assert no semaphore-slot leak.
- Spec `docs/specs/ops/2026-06-08-lane-busy-retry.md` (Codex checkpoint-1: 2 rounds, no findings). Codex checkpoint-2 on the impl: no correctness defects.
- **Post-merge dev verify (pending):** restart jobs proc; confirm `sec_filing_documents_ingest` + the other `sec_rate` periodic producers fire on full cadence across an aligned `sec_atom_fast_lane` tick and their verdicts read current. Will record commit SHA + figures.

Relates #1534, #1536.