### PR TITLE
fix(#1406,#1464): tech-debt sweep — secrets-key env alias + drop dead instrument_type column

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,6 @@
 import os
 
-from pydantic import field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Minimum service-token length. 32 chars of base64/hex is ~192 bits of
@@ -153,7 +153,21 @@ class Settings(BaseSettings):
     #
     # Generate with:
     #     python -c "import os, base64; print(base64.b64encode(os.urandom(32)).decode())"
-    secrets_key: str | None = None
+    # #1406 — the docs, .env.example, and master_key/secrets_crypto
+    # docstrings all name this **EBULL_SECRETS_KEY**, but ``Settings`` has no
+    # ``env_prefix`` so without an alias the field would only read the bare
+    # ``SECRETS_KEY`` and silently drop a documented ``EBULL_SECRETS_KEY``.
+    # AliasChoices honours the documented name AND keeps the legacy bare name
+    # working (back-compat). Currently the value is empty everywhere, so this
+    # changes nothing at runtime; it only un-breaks the documented variable.
+    # NOTE (ADR-0003 §9): if an operator later sets a REAL key while
+    # ciphertext already exists under the file-derived key, env-key mode
+    # activates and the server fail-loud refuses to start until the documented
+    # key-rotation flow is followed.
+    secrets_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("EBULL_SECRETS_KEY", "SECRETS_KEY"),
+    )
 
     # --- Local secret bootstrap data dir (issue #114 / ADR-0003) --------
     # Directory holding the persisted root secret file. When unset we

--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -349,7 +349,6 @@ def _normalise_instrument(item: Mapping[str, object]) -> InstrumentRecord | None
         industry=None,  # secondary lookup deferred
         country=None,  # not available in instruments endpoint
         is_tradable=True,  # only tradable instruments are returned by the API
-        instrument_type=_str_or_none(item.get("instrumentTypeName")),
         instrument_type_id=_int_or_none(item.get("instrumentTypeID")),
     )
 

--- a/app/providers/market_data.py
+++ b/app/providers/market_data.py
@@ -25,11 +25,6 @@ class InstrumentRecord:
     industry: str | None
     country: str | None
     is_tradable: bool
-    # eToro instrumentTypeName ("Stock", "Crypto", "ETF", "Index",
-    # "Currency", "Commodity", …). Cross-validated against
-    # exchanges.asset_class downstream — a stock-typed instrument on a
-    # crypto-classified exchange is a data-integrity flag (#503 PR 4).
-    instrument_type: str | None = None
     # eToro instrumentTypeID — the numeric foreign key into
     # ``etoro_instrument_types`` so the frontend can render the
     # description label by joining on a stable id rather than a

--- a/app/services/universe.py
+++ b/app/services/universe.py
@@ -89,7 +89,7 @@ def sync_universe(
                 """
                 INSERT INTO instruments (
                     instrument_id, symbol, company_name, exchange, currency,
-                    sector, industry, country, is_tradable, instrument_type,
+                    sector, industry, country, is_tradable,
                     instrument_type_id,
                     first_seen_at, last_seen_at
                 )
@@ -99,7 +99,7 @@ def sync_universe(
                     %(sector)s, %(industry)s,
                     (SELECT country FROM exchanges WHERE exchange_id = %(exchange)s),
                     %(is_tradable)s,
-                    %(instrument_type)s, %(instrument_type_id)s, NOW(), NOW()
+                    %(instrument_type_id)s, NOW(), NOW()
                 )
                 ON CONFLICT (instrument_id) DO UPDATE SET
                     symbol             = EXCLUDED.symbol,
@@ -138,13 +138,13 @@ def sync_universe(
                         ELSE instruments.country
                     END,
                     is_tradable        = EXCLUDED.is_tradable,
-                    -- COALESCE preserves a previously-known type when a
-                    -- transient eToro response omits ``instrumentTypeName``
-                    -- / ``instrumentTypeID``. Otherwise a single empty-
-                    -- field response would erase the cross-validation
-                    -- signal we need against ``exchanges.asset_class``
-                    -- (#503 PR 4).
-                    instrument_type    = COALESCE(EXCLUDED.instrument_type, instruments.instrument_type),
+                    -- COALESCE preserves a previously-known id when a
+                    -- transient eToro response omits ``instrumentTypeID``,
+                    -- rather than wiping it to NULL. (#1464 dropped the
+                    -- companion ``instrument_type`` TEXT column — it was
+                    -- always NULL because the instruments endpoint never
+                    -- returns ``instrumentTypeName``; the label is derivable
+                    -- via ``instrument_type_id -> etoro_instrument_types``.)
                     instrument_type_id = COALESCE(EXCLUDED.instrument_type_id, instruments.instrument_type_id),
                     last_seen_at       = NOW()
                 WHERE (
@@ -164,8 +164,6 @@ def sync_universe(
                     instruments.industry           IS DISTINCT FROM EXCLUDED.industry           OR
                     instruments.country            IS DISTINCT FROM EXCLUDED.country            OR
                     instruments.is_tradable        IS DISTINCT FROM EXCLUDED.is_tradable        OR
-                    (EXCLUDED.instrument_type IS NOT NULL AND
-                     instruments.instrument_type IS DISTINCT FROM EXCLUDED.instrument_type)     OR
                     (EXCLUDED.instrument_type_id IS NOT NULL AND
                      instruments.instrument_type_id IS DISTINCT FROM EXCLUDED.instrument_type_id)
                 )
@@ -178,7 +176,6 @@ def sync_universe(
                     "sector": rec.sector,
                     "industry": rec.industry,
                     "is_tradable": rec.is_tradable,
-                    "instrument_type": rec.instrument_type,
                     "instrument_type_id": rec.instrument_type_id,
                 },
             )

--- a/sql/188_drop_instruments_instrument_type.sql
+++ b/sql/188_drop_instruments_instrument_type.sql
@@ -1,0 +1,20 @@
+-- 188_drop_instruments_instrument_type.sql
+--
+-- #1464 — drop the dead ``instruments.instrument_type`` TEXT column.
+--
+-- sql/068 (#503 PR 4) added this column + index for an exchange-vs-instrument
+-- integrity cross-check ("a stock-typed instrument on a crypto-classified
+-- exchange is a data-integrity flag"). But the eToro ``/market-data/instruments``
+-- endpoint returns ``instrumentTypeID`` (-> ``instrument_type_id``), NOT
+-- ``instrumentTypeName``, so the universe upsert wrote NULL for every row:
+--   SELECT count(*), count(instrument_type) FROM instruments  ->  (12530, 0)
+-- The cross-validation it was added for never ran. The human label is fully
+-- derivable via ``instrument_type_id -> etoro_instrument_types.description``
+-- (the FE already joins for display), so if the integrity check is ever
+-- revived it should key on ``instrument_type_id`` directly.
+--
+-- Idempotent + safe: the column is all-NULL, so DROP COLUMN loses no data.
+
+DROP INDEX IF EXISTS idx_instruments_instrument_type;
+
+ALTER TABLE instruments DROP COLUMN IF EXISTS instrument_type;

--- a/tests/test_migration_068_exchanges_classify.py
+++ b/tests/test_migration_068_exchanges_classify.py
@@ -156,22 +156,22 @@ def _cleanup(conn: psycopg.Connection[tuple], ids: list[str]) -> None:
     conn.commit()
 
 
-def test_instrument_type_column_exists(ebull_test_conn) -> None:  # noqa: F811
-    """Schema-level pin: the column the universe upsert writes to
-    must exist with TEXT type, and the lookup index for operator
-    audit queries must be present."""
+def test_instrument_type_column_dropped(ebull_test_conn) -> None:  # noqa: F811
+    """Schema-level pin (post-#1464): sql/068 added ``instruments.instrument_type``
+    + ``idx_instruments_instrument_type`` for a cross-validation that never ran
+    (the column was always NULL — the eToro instruments endpoint returns
+    ``instrumentTypeID``, not ``instrumentTypeName``). sql/188 (#1464) DROPPED
+    both. Confirm they are absent so the dead column cannot silently return."""
     with ebull_test_conn.cursor() as cur:
         cur.execute(
             """
-            SELECT data_type
+            SELECT 1
               FROM information_schema.columns
              WHERE table_name = 'instruments'
                AND column_name = 'instrument_type'
             """,
         )
-        row = cur.fetchone()
-    assert row is not None, "instruments.instrument_type column missing"
-    assert row[0] == "text"
+        assert cur.fetchone() is None, "instruments.instrument_type should be dropped (sql/188 #1464)"
 
     with ebull_test_conn.cursor() as cur:
         cur.execute(
@@ -182,7 +182,7 @@ def test_instrument_type_column_exists(ebull_test_conn) -> None:  # noqa: F811
                AND indexname = 'idx_instruments_instrument_type'
             """,
         )
-        assert cur.fetchone() is not None, "idx_instruments_instrument_type index missing"
+        assert cur.fetchone() is None, "idx_instruments_instrument_type should be dropped (sql/188 #1464)"
 
 
 def test_classifier_uk_suffix(ebull_test_conn) -> None:  # noqa: F811

--- a/tests/test_settings_secrets_key_alias.py
+++ b/tests/test_settings_secrets_key_alias.py
@@ -8,7 +8,9 @@ in #1406). The ``AliasChoices`` fix honours the documented name while keeping
 the legacy bare name working.
 
 ``_env_file=None`` disables the repo ``.env`` so its (possibly-present, empty)
-``EBULL_SECRETS_KEY=`` cannot mask the env var under test.
+``EBULL_SECRETS_KEY=`` cannot mask the env var under test. It is a runtime
+``BaseSettings`` init param not present in the generated typed signature, hence
+the ``type: ignore[call-arg]``.
 """
 
 from __future__ import annotations
@@ -19,16 +21,19 @@ from app.config import Settings
 def test_secrets_key_honours_documented_ebull_name(monkeypatch) -> None:
     monkeypatch.delenv("SECRETS_KEY", raising=False)
     monkeypatch.setenv("EBULL_SECRETS_KEY", "via-documented-name")
-    assert Settings(_env_file=None).secrets_key == "via-documented-name"
+    settings = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert settings.secrets_key == "via-documented-name"
 
 
 def test_secrets_key_legacy_bare_name_still_works(monkeypatch) -> None:
     monkeypatch.delenv("EBULL_SECRETS_KEY", raising=False)
     monkeypatch.setenv("SECRETS_KEY", "via-legacy-name")
-    assert Settings(_env_file=None).secrets_key == "via-legacy-name"
+    settings = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert settings.secrets_key == "via-legacy-name"
 
 
 def test_secrets_key_defaults_none_when_unset(monkeypatch) -> None:
     monkeypatch.delenv("EBULL_SECRETS_KEY", raising=False)
     monkeypatch.delenv("SECRETS_KEY", raising=False)
-    assert Settings(_env_file=None).secrets_key is None
+    settings = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert settings.secrets_key is None

--- a/tests/test_settings_secrets_key_alias.py
+++ b/tests/test_settings_secrets_key_alias.py
@@ -1,0 +1,34 @@
+"""#1406 — Settings.secrets_key must honour the DOCUMENTED env name.
+
+The docs / .env.example / master_key+secrets_crypto docstrings all name the
+AES env-key variable ``EBULL_SECRETS_KEY``, but ``Settings`` has no
+``env_prefix``. Without an alias the field would read only the bare
+``SECRETS_KEY`` and silently drop a documented ``EBULL_SECRETS_KEY`` (verified
+in #1406). The ``AliasChoices`` fix honours the documented name while keeping
+the legacy bare name working.
+
+``_env_file=None`` disables the repo ``.env`` so its (possibly-present, empty)
+``EBULL_SECRETS_KEY=`` cannot mask the env var under test.
+"""
+
+from __future__ import annotations
+
+from app.config import Settings
+
+
+def test_secrets_key_honours_documented_ebull_name(monkeypatch) -> None:
+    monkeypatch.delenv("SECRETS_KEY", raising=False)
+    monkeypatch.setenv("EBULL_SECRETS_KEY", "via-documented-name")
+    assert Settings(_env_file=None).secrets_key == "via-documented-name"
+
+
+def test_secrets_key_legacy_bare_name_still_works(monkeypatch) -> None:
+    monkeypatch.delenv("EBULL_SECRETS_KEY", raising=False)
+    monkeypatch.setenv("SECRETS_KEY", "via-legacy-name")
+    assert Settings(_env_file=None).secrets_key == "via-legacy-name"
+
+
+def test_secrets_key_defaults_none_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("EBULL_SECRETS_KEY", raising=False)
+    monkeypatch.delenv("SECRETS_KEY", raising=False)
+    assert Settings(_env_file=None).secrets_key is None

--- a/tests/test_sync_orchestrator_credential_gate.py
+++ b/tests/test_sync_orchestrator_credential_gate.py
@@ -279,8 +279,8 @@ class TestLayerInitializationBlocks:
                 cur.execute(
                     """
                     INSERT INTO instruments
-                        (instrument_id, symbol, company_name, is_tradable, currency, instrument_type)
-                    VALUES (1, 'AAPL', 'Apple Inc.', TRUE, 'USD', 'stock')
+                        (instrument_id, symbol, company_name, is_tradable, currency)
+                    VALUES (1, 'AAPL', 'Apple Inc.', TRUE, 'USD')
                     """
                 )
             conn.commit()

--- a/tests/test_thirteen_f_retention_cap.py
+++ b/tests/test_thirteen_f_retention_cap.py
@@ -458,10 +458,10 @@ def _seed_instrument_and_cusip(
     conn.execute(
         """
         INSERT INTO instruments (
-            instrument_id, symbol, company_name, instrument_type,
+            instrument_id, symbol, company_name,
             currency, is_tradable, country
         ) VALUES (
-            %(iid)s, %(sym)s, %(name)s, 'STOCK', 'USD', TRUE, 'US'
+            %(iid)s, %(sym)s, %(name)s, 'USD', TRUE, 'US'
         )
         ON CONFLICT (instrument_id) DO NOTHING
         """,

--- a/tests/test_universe_normaliser.py
+++ b/tests/test_universe_normaliser.py
@@ -97,26 +97,9 @@ class TestNormaliseInstrument:
         assert record.sector is None
         assert record.industry is None
         assert record.country is None
-        assert record.instrument_type is None
-
-    def test_instrument_type_captured(self) -> None:
-        """instrumentTypeName flows through so the universe upsert
-        can persist eToro's classification (Stock / Crypto / ETF / …)
-        for the cross-validation against exchanges.asset_class
-        added in migration 068."""
-        record = _normalise_instrument(FIXTURE_INSTRUMENT)
-        assert record is not None
-        assert record.instrument_type == "Stock"
-
-    def test_instrument_type_empty_string_normalises_to_none(self) -> None:
-        """Empty strings from eToro are treated as missing — the
-        downstream upsert distinguishes 'unknown' from '' so a
-        blank value would create a useless distinct row in
-        ``instruments.instrument_type``."""
-        item = {**FIXTURE_INSTRUMENT, "instrumentTypeName": ""}
-        record = _normalise_instrument(item)
-        assert record is not None
-        assert record.instrument_type is None
+        # #1464 dropped the instrument_type column + dataclass field (always
+        # NULL — eToro's instruments endpoint never returns instrumentTypeName;
+        # the type is captured as instrument_type_id instead).
 
     def test_internal_instrument_skipped(self) -> None:
         assert _normalise_instrument(FIXTURE_INSTRUMENT_INTERNAL) is None
@@ -196,7 +179,8 @@ class TestSyncSummary:
 
 
 # ---------------------------------------------------------------------------
-# sync_universe — instrument_type COALESCE contract (#503 PR 4)
+# sync_universe — instrument_type_id COALESCE contract (#503 PR 4; the
+# companion instrument_type TEXT column was dropped in #1464)
 # ---------------------------------------------------------------------------
 
 
@@ -204,7 +188,6 @@ def _make_record(
     *,
     provider_id: str,
     symbol: str,
-    instrument_type: str | None,
     instrument_type_id: int | None = None,
 ) -> InstrumentRecord:
     return InstrumentRecord(
@@ -217,20 +200,8 @@ def _make_record(
         industry=None,
         country=None,
         is_tradable=True,
-        instrument_type=instrument_type,
         instrument_type_id=instrument_type_id,
     )
-
-
-def _read_instrument_type(conn: psycopg.Connection[tuple], instrument_id: int) -> str | None:
-    with conn.cursor() as cur:
-        cur.execute(
-            "SELECT instrument_type FROM instruments WHERE instrument_id = %s",
-            (instrument_id,),
-        )
-        row = cur.fetchone()
-    assert row is not None
-    return row[0]
 
 
 def _read_instrument_type_id(conn: psycopg.Connection[tuple], instrument_id: int) -> int | None:
@@ -246,57 +217,11 @@ def _read_instrument_type_id(conn: psycopg.Connection[tuple], instrument_id: int
 
 @pytest.mark.integration
 class TestUniverseInstrumentTypeUpsert:
-    """Pins the COALESCE behaviour of the ``sync_universe`` upsert
-    against a real DB. The Codex round-1 WARNING fix: a refresh that
-    omits ``instrument_type`` for an existing row must NOT overwrite
-    the previously-known value with NULL."""
-
-    def test_initial_insert_persists_instrument_type(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
-        provider = MagicMock()
-        provider.get_tradable_instruments.return_value = [
-            _make_record(provider_id="950001", symbol="ZZZ1", instrument_type="Stock"),
-        ]
-        sync_universe(provider, ebull_test_conn)
-        ebull_test_conn.commit()
-        assert _read_instrument_type(ebull_test_conn, 950001) == "Stock"
-
-    def test_subsequent_null_does_not_clobber(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
-        """First sync writes 'Stock'; a follow-up sync that omits
-        ``instrument_type`` must leave 'Stock' in place."""
-        provider = MagicMock()
-        provider.get_tradable_instruments.return_value = [
-            _make_record(provider_id="950002", symbol="ZZZ2", instrument_type="Crypto"),
-        ]
-        sync_universe(provider, ebull_test_conn)
-        ebull_test_conn.commit()
-        assert _read_instrument_type(ebull_test_conn, 950002) == "Crypto"
-
-        # Second refresh — no instrument_type from provider.
-        provider.get_tradable_instruments.return_value = [
-            _make_record(provider_id="950002", symbol="ZZZ2", instrument_type=None),
-        ]
-        sync_universe(provider, ebull_test_conn)
-        ebull_test_conn.commit()
-
-        assert _read_instrument_type(ebull_test_conn, 950002) == "Crypto"
-
-    def test_subsequent_value_change_overwrites(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
-        """eToro reclassifying ``Stock`` → ``ETF`` must propagate.
-        COALESCE only protects against NULL — a real change still wins."""
-        provider = MagicMock()
-        provider.get_tradable_instruments.return_value = [
-            _make_record(provider_id="950003", symbol="ZZZ3", instrument_type="Stock"),
-        ]
-        sync_universe(provider, ebull_test_conn)
-        ebull_test_conn.commit()
-
-        provider.get_tradable_instruments.return_value = [
-            _make_record(provider_id="950003", symbol="ZZZ3", instrument_type="ETF"),
-        ]
-        sync_universe(provider, ebull_test_conn)
-        ebull_test_conn.commit()
-
-        assert _read_instrument_type(ebull_test_conn, 950003) == "ETF"
+    """Pins the COALESCE behaviour of the ``sync_universe`` upsert against a
+    real DB: a refresh that omits ``instrument_type_id`` for an existing row
+    must NOT overwrite the previously-known value with NULL. (#1464 dropped the
+    companion ``instrument_type`` TEXT column — always NULL — so only the
+    ``instrument_type_id`` COALESCE remains.)"""
 
     def test_initial_insert_persists_instrument_type_id(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         """instrument_type_id ships alongside the text label so the
@@ -306,7 +231,6 @@ class TestUniverseInstrumentTypeUpsert:
             _make_record(
                 provider_id="950010",
                 symbol="ZZZ10",
-                instrument_type="Stocks",
                 instrument_type_id=5,
             ),
         ]
@@ -315,15 +239,13 @@ class TestUniverseInstrumentTypeUpsert:
         assert _read_instrument_type_id(ebull_test_conn, 950010) == 5
 
     def test_subsequent_null_id_does_not_clobber(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
-        """COALESCE protects instrument_type_id the same way it
-        protects instrument_type — a transient response without
-        instrumentTypeID must NOT erase a previously-known value."""
+        """COALESCE protects instrument_type_id — a transient response
+        without instrumentTypeID must NOT erase a previously-known value."""
         provider = MagicMock()
         provider.get_tradable_instruments.return_value = [
             _make_record(
                 provider_id="950011",
                 symbol="ZZZ11",
-                instrument_type="Crypto",
                 instrument_type_id=10,
             ),
         ]
@@ -335,7 +257,6 @@ class TestUniverseInstrumentTypeUpsert:
             _make_record(
                 provider_id="950011",
                 symbol="ZZZ11",
-                instrument_type=None,
                 instrument_type_id=None,
             ),
         ]
@@ -351,7 +272,6 @@ class TestUniverseInstrumentTypeUpsert:
             _make_record(
                 provider_id="950012",
                 symbol="ZZZ12",
-                instrument_type="Stocks",
                 instrument_type_id=5,
             ),
         ]
@@ -362,7 +282,6 @@ class TestUniverseInstrumentTypeUpsert:
             _make_record(
                 provider_id="950012",
                 symbol="ZZZ12",
-                instrument_type="ETF",
                 instrument_type_id=6,
             ),
         ]
@@ -415,7 +334,6 @@ def _make_record_with_exchange(
         industry=None,
         country=None,  # provider does not supply country (#1233 §6.1)
         is_tradable=True,
-        instrument_type=None,
         instrument_type_id=None,
     )
 


### PR DESCRIPTION
Tech-debt sweep. Two independent, self-contained fixes. (#1417 was in this batch but **pulled** — it needs a vite 5→6 major toolchain upgrade, not a one-line bump; documented on the issue.)

## #1406 — `Settings.secrets_key` honours the documented `EBULL_SECRETS_KEY`
`Settings` has no `env_prefix`, so `secrets_key` read only the bare `SECRETS_KEY` — a documented `EBULL_SECRETS_KEY` (docs / `.env.example` / `master_key`+`secrets_crypto` docstrings) was **silently dropped** (`extra="ignore"`). An operator following the docs would get `secrets_key=None` and fall onto the file-secret path with no error.

**Fix:** `validation_alias=AliasChoices("EBULL_SECRETS_KEY", "SECRETS_KEY")` — the documented name works AND the legacy bare name still works (back-compat; stronger than the issue's bare-alias suggestion). Empirically verified both names read. Value is empty everywhere today → **no runtime change**, just un-breaks the documented variable. ADR-0003 §9 rotation caveat noted in-code. +3 invariant tests.

## #1464 — drop the all-NULL `instruments.instrument_type` column
`SELECT count(*), count(instrument_type) FROM instruments → (12530, 0)`. The eToro `/market-data/instruments` endpoint returns `instrumentTypeID` (→ `instrument_type_id`), **not** `instrumentTypeName`, so the universe upsert wrote NULL for every row and the exchange-vs-instrument cross-validation `sql/068` (#503 PR4) added it for **never ran**. The label is derivable via `instrument_type_id → etoro_instrument_types`; if the check is revived it should key on `instrument_type_id`.

**Fix:** `sql/188` (`DROP INDEX` + `DROP COLUMN`, both `IF EXISTS` → idempotent, all-NULL so no data loss); remove from the `universe.py` upsert (keep `instrument_type_id` + its COALESCE); drop the dead `InstrumentRecord.instrument_type` field + etoro assignment; update 5 test files (delete 3 column-persistence DB tests + 2 normaliser capture tests + helper; strip 2 fixture INSERTs; invert `test_migration_068` to assert the column is now DROPPED).

## Security model
- #1406 touches the master-key secret source. The change only widens which env var name is *read* (adds the documented one); it does not change key handling. The fail-loud ADR-0003 §9 invariant (refuse start on key/ciphertext mismatch) is unchanged.
- #1464 is additive-removal of an all-NULL column; no auth/data-exposure surface.

## Testing / dev-verify
- ruff ✓ · ruff format ✓ · pyright **0 errors** ✓ · fast tier **3784 passed** ✓ · smoke **129 passed** ✓.
- #1464 DB tier: **74 affected DB tests pass** (`test_universe_normaliser`, `test_migration_068`, `test_sync_orchestrator_credential_gate`, `test_thirteen_f_retention_cap`).
- **Dev-verified** (`sql/188` applied to dev): column + index gone, **12530 instruments rows intact**, panel `AAPL/GME/MSFT/JPM/HD` all present with `instrument_type_id`.
- Codex checkpoint-2: CLEAN (AliasChoices correct, upsert still valid, no remaining runtime reader of the dropped column, migration ordered + idempotent).

Closes #1406. Closes #1464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)