### PR TITLE
fix(#1548): expected WS disconnects log one INFO line, not a traceback

### DIFF
--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -42,6 +42,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import ssl
 import threading
 import uuid
 from collections.abc import Callable
@@ -779,6 +780,13 @@ class EtoroWebSocketSubscriber:
                 await self._connect_and_listen()
             except asyncio.CancelledError:
                 raise
+            except ssl.SSLError:
+                # SSLError is an OSError subclass but signals TLS/cert
+                # config trouble, not idle churn — keep the traceback.
+                logger.warning(
+                    "EtoroWebSocketSubscriber: connection error — backoff then reconnect",
+                    exc_info=True,
+                )
             except (ConnectionClosed, OSError, TimeoutError) as exc:
                 # Expected churn (#1548): idle WS reaped by an LB, TCP
                 # reset, auth-envelope timeout. Handled by reconnect —

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -55,6 +55,7 @@ import psycopg
 import psycopg_pool
 import websockets
 from websockets.asyncio.client import ClientConnection
+from websockets.exceptions import ConnectionClosed
 
 from app.services.credential_health_cache import CredentialHealthCache
 from app.services.quote_stream import QuoteBus
@@ -778,6 +779,15 @@ class EtoroWebSocketSubscriber:
                 await self._connect_and_listen()
             except asyncio.CancelledError:
                 raise
+            except (ConnectionClosed, OSError, TimeoutError) as exc:
+                # Expected churn (#1548): idle WS reaped by an LB, TCP
+                # reset, auth-envelope timeout. Handled by reconnect —
+                # no traceback, or real bugs drown in the noise.
+                logger.info(
+                    "EtoroWebSocketSubscriber: connection closed (%s) — reconnecting in %.0fs",
+                    type(exc).__name__,
+                    self._current_backoff(),
+                )
             except Exception:
                 logger.warning(
                     "EtoroWebSocketSubscriber: connection error — backoff then reconnect",

--- a/tests/test_etoro_websocket_credential_aware.py
+++ b/tests/test_etoro_websocket_credential_aware.py
@@ -19,12 +19,15 @@ state-machine and gate logic in isolation.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from psycopg_pool import ConnectionPool
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 from app.services.credential_health import CredentialHealth
 from app.services.credential_health_cache import CredentialHealthCache
@@ -221,3 +224,83 @@ class TestCounterReset:
         sub = _make_subscriber(fake_pool=fake_pool)
         sub._consecutive_auth_failures = 3
         assert sub._consecutive_auth_failures == 3
+
+
+# ---------------------------------------------------------------------------
+# _run loop error logging (#1548) — expected disconnects are calm INFO,
+# unexpected errors keep the WARNING + traceback
+# ---------------------------------------------------------------------------
+
+
+async def _drive_run_once(sub: EtoroWebSocketSubscriber, exc: BaseException) -> None:
+    """Run one _run iteration: _connect_and_listen raises `exc`, then the
+    stop event is already set so the backoff wait exits immediately."""
+
+    async def fake_connect() -> None:
+        sub._stop_event.set()
+        raise exc
+
+    with patch.object(sub, "_connect_and_listen", side_effect=fake_connect):
+        await sub._run()
+
+
+class TestRunLoopErrorLogging:
+    async def test_expected_close_logs_single_info_line_no_traceback(
+        self, fake_pool: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ConnectionClosedError (idle WS reaped, no close frame) is an
+        EXPECTED event — one INFO line, no traceback (#1548)."""
+        sub = _make_subscriber(fake_pool=fake_pool)
+        with caplog.at_level(logging.INFO, logger="app.services.etoro_websocket"):
+            await _drive_run_once(sub, ConnectionClosedError(None, None))
+
+        records = [r for r in caplog.records if "connection closed" in r.message]
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.levelno == logging.INFO
+        assert rec.exc_info is None
+        # Operator sees the concrete type without needing a traceback.
+        assert "ConnectionClosedError" in rec.getMessage()
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ConnectionClosedOK(None, None),
+            OSError("connection reset by peer"),
+            TimeoutError("auth envelope timeout"),
+        ],
+        ids=["closed_ok", "os_error", "timeout"],
+    )
+    async def test_other_expected_errors_log_info(
+        self, fake_pool: Any, caplog: pytest.LogCaptureFixture, exc: BaseException
+    ) -> None:
+        sub = _make_subscriber(fake_pool=fake_pool)
+        with caplog.at_level(logging.INFO, logger="app.services.etoro_websocket"):
+            await _drive_run_once(sub, exc)
+
+        records = [r for r in caplog.records if "connection closed" in r.message]
+        assert len(records) == 1
+        assert records[0].levelno == logging.INFO
+        assert records[0].exc_info is None
+
+    async def test_unexpected_error_keeps_warning_with_traceback(
+        self, fake_pool: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A genuine bug (e.g. ValueError in frame handling) still dumps
+        the full traceback at WARNING."""
+        sub = _make_subscriber(fake_pool=fake_pool)
+        with caplog.at_level(logging.INFO, logger="app.services.etoro_websocket"):
+            await _drive_run_once(sub, ValueError("boom"))
+
+        records = [r for r in caplog.records if "connection error" in r.message]
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.levelno == logging.WARNING
+        assert rec.exc_info is not None
+        assert rec.exc_info[0] is ValueError
+
+    async def test_cancelled_error_propagates(self, fake_pool: Any) -> None:
+        """CancelledError must NOT be swallowed by either catch arm."""
+        sub = _make_subscriber(fake_pool=fake_pool)
+        with pytest.raises(asyncio.CancelledError):
+            await _drive_run_once(sub, asyncio.CancelledError())

--- a/tests/test_etoro_websocket_credential_aware.py
+++ b/tests/test_etoro_websocket_credential_aware.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import ssl
 from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -283,21 +284,34 @@ class TestRunLoopErrorLogging:
         assert records[0].levelno == logging.INFO
         assert records[0].exc_info is None
 
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ValueError("boom"),
+            # SSLError is an OSError subclass but means TLS/cert config
+            # trouble, not idle churn — must keep the traceback (Codex
+            # checkpoint-2 finding on #1548).
+            ssl.SSLError(1, "certificate verify failed"),
+        ],
+        ids=["value_error", "ssl_error"],
+    )
     async def test_unexpected_error_keeps_warning_with_traceback(
-        self, fake_pool: Any, caplog: pytest.LogCaptureFixture
+        self, fake_pool: Any, caplog: pytest.LogCaptureFixture, exc: BaseException
     ) -> None:
-        """A genuine bug (e.g. ValueError in frame handling) still dumps
-        the full traceback at WARNING."""
+        """A genuine bug (frame-handling ValueError, TLS failure) still
+        dumps the full traceback at WARNING."""
         sub = _make_subscriber(fake_pool=fake_pool)
         with caplog.at_level(logging.INFO, logger="app.services.etoro_websocket"):
-            await _drive_run_once(sub, ValueError("boom"))
+            await _drive_run_once(sub, exc)
 
         records = [r for r in caplog.records if "connection error" in r.message]
         assert len(records) == 1
         rec = records[0]
         assert rec.levelno == logging.WARNING
         assert rec.exc_info is not None
-        assert rec.exc_info[0] is ValueError
+        assert rec.exc_info[0] is type(exc)
+        # And no calm INFO line was emitted for it.
+        assert not [r for r in caplog.records if "connection closed" in r.message]
 
     async def test_cancelled_error_propagates(self, fake_pool: Any) -> None:
         """CancelledError must NOT be swallowed by either catch arm."""


### PR DESCRIPTION
## What

`EtoroWebSocketSubscriber._run` reconnect loop caught every connection error with a blanket `except Exception ... exc_info=True` WARNING. A routine idle-drop (`ConnectionClosedError: no close frame received or sent` — LB reaping an idle WS) printed a 40-line traceback that reads as an unhandled crash, immediately followed by a successful reconnect. Alarm fatigue; real errors hide in the noise.

## Fix

Split the catch site in `app/services/etoro_websocket.py::_run` (was lines 781-785):

1. `except asyncio.CancelledError: raise` — unchanged.
2. **NEW** `except ssl.SSLError` → WARNING + `exc_info=True`. `SSLError` is an `OSError` subclass (verified empirically on py3.14), so without this arm TLS/cert config failures would be silenced into the calm INFO path. Found by Codex checkpoint-2 (MED).
3. **NEW** `except (ConnectionClosed, OSError, TimeoutError)` → one-line INFO `connection closed (<type>) — reconnecting in Ns`, no traceback. `ConnectionClosed` (`websockets.exceptions`) is the base of both `ConnectionClosedError` and `ConnectionClosedOK` (verified on websockets 16.0). `TimeoutError` (py3.11+ == `asyncio.TimeoutError`) covers the 10s auth-envelope wait; `OSError` covers TCP resets. (`TimeoutError` is technically an `OSError` subclass — kept explicit for readability.)
4. `except Exception` → unchanged WARNING + `exc_info=True` for genuinely unexpected errors. websockets handshake classes (`InvalidStatus`, `InvalidHandshake`) intentionally land here — they signal config/protocol trouble, not churn.

The INFO line reads the same backoff value (`_current_backoff()`) the loop sleeps with — pure read, nothing mutates the failure counter between catch and sleep.

## Security model

No auth/authz surface. Pure logging-level change inside an internal reconnect loop; no user input, no SQL, no new dependencies. Failure handling semantics unchanged — every arm still falls through to the same backoff + reconnect.

## Tests

`tests/test_etoro_websocket_credential_aware.py::TestRunLoopErrorLogging` (fast tier, no DB) — drives `_run` with an injected raising `_connect_and_listen`:
- `ConnectionClosedError(None, None)` → exactly one INFO record, `exc_info is None`, type name in message.
- Parametrized `ConnectionClosedOK` / `OSError` / `TimeoutError` → same.
- Parametrized `ValueError` / `ssl.SSLError` → WARNING with `exc_info`, and asserts NO calm INFO line was emitted (pins the SSLError-before-OSError arm ordering).
- `CancelledError` propagates (not swallowed by either arm).

## Verification (issue's verify clause)

Forced idle-drop + injected unexpected error exercised via the injected-exception tests above — same code path as a live drop (`_connect_and_listen` raise → catch arm). No live proc restart performed (operator-owned, tty-attached jobs proc).

## Local gates (at 2da114d)

ruff check ✓ · ruff format --check ✓ · pyright 0 errors ✓ · `pytest -m "not db"` 3791 passed ✓ · `pytest tests/smoke` 129 passed ✓ · full pre-push hook green on push.

Codex checkpoint-2: ran on the branch diff; MED finding (SSLError swallowed into INFO) fixed in 2da114d with a pinning test. Codex confirmed `ConnectionClosed` is the right websockets-16 umbrella.

## Tradeoffs

- The `ssl.SSLError` arm duplicates the generic WARNING call body (4 lines) rather than restructuring into an isinstance check — clearest at the catch site, keeps each arm independently greppable.
- Issue's optional follow-up (lazy WS connect at refcount 0) NOT in scope — file separately if the WARNING turns out to be a tight ~5s loop.

Closes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)