### PR TITLE
fix(#1545): count 429s on async/bulk SEC paths (#1484 follow-up)

### DIFF
--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -50,6 +50,7 @@ from typing import Any, Final, Literal
 
 import httpx
 
+from app.providers.sec_throttle_metrics import incr_sec_429
 from app.services.bootstrap_preconditions import BootstrapPhaseSkipped
 
 logger = logging.getLogger(__name__)
@@ -435,6 +436,8 @@ async def _head_etag(
     if rate_limiter is not None:
         await rate_limiter.acquire()
     response = await client.head(url)
+    if response.status_code == 429:
+        incr_sec_429()
     if response.status_code != 200:
         logger.info(
             "preflight HEAD non-200 for %s: status=%d — will re-download",
@@ -711,6 +714,8 @@ async def measure_bandwidth_mbps(
     started = time.monotonic()
     response = await client.get(probe_url, headers=headers)
     elapsed = time.monotonic() - started
+    if response.status_code == 429:
+        incr_sec_429()
     if response.status_code not in (200, 206):
         raise RuntimeError(f"bandwidth probe failed: status={response.status_code} url={probe_url}")
     bytes_read = len(response.content)
@@ -775,6 +780,8 @@ async def _head_size_and_type(
     if rate_limiter is not None:
         await rate_limiter.acquire()
     response = await client.head(url)
+    if response.status_code == 429:
+        incr_sec_429()
     if response.status_code != 200:
         raise RuntimeError(f"HEAD failed: status={response.status_code} url={url}")
     length = response.headers.get("content-length")
@@ -1010,6 +1017,8 @@ async def _download_one(
         if rate_limiter is not None:
             await rate_limiter.acquire()
         async with client.stream("GET", archive.url, headers=headers) as response:
+            if response.status_code == 429:
+                incr_sec_429()
             if resume_from and response.status_code != 206:
                 # Server ignored Range; restart from zero.
                 await response.aclose()
@@ -1019,6 +1028,8 @@ async def _download_one(
                 if rate_limiter is not None:
                     await rate_limiter.acquire()
                 async with client.stream("GET", archive.url) as fresh:
+                    if fresh.status_code == 429:
+                        incr_sec_429()
                     if fresh.status_code != 200:
                         return ArchiveDownloadResult(
                             name=archive.name,

--- a/app/services/sec_bulk_refresh.py
+++ b/app/services/sec_bulk_refresh.py
@@ -102,6 +102,7 @@ import httpx
 import psycopg
 
 from app.config import settings
+from app.providers.sec_throttle_metrics import incr_sec_429
 from app.security.master_key import resolve_data_dir
 from app.services.sec_bulk_download import (
     BulkArchive,
@@ -325,6 +326,8 @@ async def _refresh_one_async(
                 skipped_reason=f"head_transport_error: {type(exc).__name__}",
             )
 
+        if head.status_code == 429:
+            incr_sec_429()
         if head.status_code in _TRANSIENT_HTTP_STATUSES:
             logger.warning(
                 "sec_bulk_refresh HEAD got %d for %s — skipping (will retry next fire)",
@@ -471,6 +474,8 @@ async def _refresh_one_async(
         get_etag: str | None = None
         try:
             async with client.stream("GET", archive.url) as response:
+                if response.status_code == 429:
+                    incr_sec_429()
                 if response.status_code in _TRANSIENT_HTTP_STATUSES:
                     logger.warning(
                         "sec_bulk_refresh GET got %d for %s — skipping (local file untouched)",

--- a/app/services/sec_pipelined_fetcher.py
+++ b/app/services/sec_pipelined_fetcher.py
@@ -35,6 +35,7 @@ import httpx
 from app.providers.implementations.sec_edgar import (
     SubmissionsPageResult,
 )
+from app.providers.sec_throttle_metrics import incr_sec_429
 
 if TYPE_CHECKING:
     from app.providers.rate_gate import RateGate
@@ -216,6 +217,10 @@ class PipelinedSecFetcher:
             await self._rate_limiter.acquire()
             try:
                 response = await self._client.get(task.url, headers=task.headers)
+                if response.status_code == 429:
+                    # Chokepoint for every pipelined SEC request (#1545):
+                    # one increment here covers all fetch_many callers.
+                    incr_sec_429()
                 return FetchResult(key=task.key, response=response)
             except (httpx.HTTPError, OSError) as exc:
                 return FetchResult(key=task.key, response=None, error=str(exc))

--- a/tests/test_sec_bulk_download.py
+++ b/tests/test_sec_bulk_download.py
@@ -609,3 +609,112 @@ class TestDownloadBulkArchives:
         assert all(r.error is None for r in result.archives)
         assert (tmp_path / "archive_a.zip").exists()
         assert (tmp_path / "archive_b.zip").exists()
+
+
+# ---------------------------------------------------------------------------
+# SEC 429 counter (#1545) — async download paths increment sec_throttle_429_total
+# ---------------------------------------------------------------------------
+
+
+class TestSec429Counter:
+    """One test per 429-detection site. Delta-based assertions per the
+    prevention log — the counter is process-global, never assert
+    exact totals."""
+
+    @pytest.mark.asyncio
+    async def test_preflight_head_etag_429_increments(self) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+        from app.services.sec_bulk_download import _head_etag
+
+        transport = httpx.MockTransport(lambda r: httpx.Response(429))
+        before = sec_throttle_429_total()
+        async with httpx.AsyncClient(transport=transport) as client:
+            etag = await _head_etag(client, "https://example.test/archive.zip")
+        assert etag is None
+        assert sec_throttle_429_total() - before == 1
+
+    @pytest.mark.asyncio
+    async def test_bandwidth_probe_429_increments(self) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        transport = httpx.MockTransport(lambda r: httpx.Response(429))
+        before = sec_throttle_429_total()
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(RuntimeError):
+                await measure_bandwidth_mbps(client, probe_url="https://example.test/probe.zip")
+        assert sec_throttle_429_total() - before == 1
+
+    @pytest.mark.asyncio
+    async def test_head_size_and_type_429_increments(self) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+        from app.services.sec_bulk_download import _head_size_and_type
+
+        transport = httpx.MockTransport(lambda r: httpx.Response(429))
+        before = sec_throttle_429_total()
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(RuntimeError):
+                await _head_size_and_type(client, "https://example.test/archive.zip")
+        assert sec_throttle_429_total() - before == 1
+
+    @pytest.mark.asyncio
+    async def test_download_stream_429_increments(self, tmp_path: Path) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        body = _build_zip_bytes()
+        url = "https://example.test/archive.zip"
+        archive = BulkArchive(name="archive.zip", url=url)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "HEAD":
+                return httpx.Response(
+                    200,
+                    headers={
+                        "content-length": str(len(body)),
+                        "content-type": "application/zip",
+                    },
+                )
+            return httpx.Response(429)
+
+        before = sec_throttle_429_total()
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            result = await _download_one(client, archive, tmp_path)
+        assert result.error is not None and "429" in result.error
+        assert sec_throttle_429_total() - before == 1
+
+    @pytest.mark.asyncio
+    async def test_download_resume_fresh_stream_429_increments(self, tmp_path: Path) -> None:
+        """Resume path: Range GET answered with 200-but-then-429 on the
+        fresh retry — the fresh stream's 429 must count too."""
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        body = _build_zip_bytes()
+        url = "https://example.test/archive.zip"
+        archive = BulkArchive(name="archive.zip", url=url)
+
+        # Pre-seed a partial so the resume branch fires.
+        (tmp_path / "archive.zip.partial").write_bytes(body[: len(body) // 2])
+
+        get_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal get_count
+            if request.method == "HEAD":
+                return httpx.Response(
+                    200,
+                    headers={
+                        "content-length": str(len(body)),
+                        "content-type": "application/zip",
+                    },
+                )
+            get_count += 1
+            # First GET (Range) ignored with a 200-shaped non-206 → fresh
+            # retry; fresh GET answers 429.
+            if get_count == 1:
+                return httpx.Response(200, content=b"")
+            return httpx.Response(429)
+
+        before = sec_throttle_429_total()
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            result = await _download_one(client, archive, tmp_path)
+        assert result.error is not None
+        assert sec_throttle_429_total() - before == 1

--- a/tests/test_sec_bulk_refresh.py
+++ b/tests/test_sec_bulk_refresh.py
@@ -859,3 +859,72 @@ class TestSchedulerRegistration:
         # All entries should be real archives.
         for name in qtr:
             assert _archive_for_name(name) is not None
+
+
+# ---------------------------------------------------------------------------
+# SEC 429 counter (#1545) — async refresh paths increment sec_throttle_429_total
+# ---------------------------------------------------------------------------
+
+
+class TestSec429Counter:
+    """Delta-based assertions per the prevention log — the counter is
+    process-global, never assert exact totals."""
+
+    @pytest.mark.asyncio
+    async def test_head_429_increments_counter(self, tmp_path: Path) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        handler = _make_handler(archive_url=url, archive_body=_zip_bytes(), etag='"unused"', head_status=429)
+
+        before = sec_throttle_429_total()
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+        assert result.skipped_reason == "head_status_429"
+        assert sec_throttle_429_total() - before == 1
+
+    @pytest.mark.asyncio
+    async def test_get_429_increments_counter(self, tmp_path: Path) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+
+        # Old archive present; new ETag advertised so the GET fires; GET 429s.
+        archive_path = tmp_path / _SUBMISSIONS_NAME
+        archive_path.write_bytes(_zip_bytes(payload=b'{"old": true}'))
+        _atomic_write_text(_etag_sidecar_path(archive_path), '"old-etag"')
+
+        handler = _make_handler(archive_url=url, archive_body=_zip_bytes(), etag='"new-etag"', get_status=429)
+
+        before = sec_throttle_429_total()
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            result = await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+        assert result.skipped_reason == "get_status_429"
+        assert sec_throttle_429_total() - before == 1
+
+    @pytest.mark.asyncio
+    async def test_head_503_does_not_increment(self, tmp_path: Path) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        url = "https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip"
+        archive = BulkArchive(name=_SUBMISSIONS_NAME, url=url)
+        handler = _make_handler(archive_url=url, archive_body=_zip_bytes(), etag='"unused"', head_status=503)
+
+        before = sec_throttle_429_total()
+        async with _patched_make_client(httpx.MockTransport(handler)):
+            await _refresh_one_async(
+                archive=archive,
+                target_dir=tmp_path,
+                user_agent="ebull/test (admin@example.com)",
+            )
+        assert sec_throttle_429_total() - before == 0

--- a/tests/test_sec_pipelined_fetcher.py
+++ b/tests/test_sec_pipelined_fetcher.py
@@ -574,3 +574,62 @@ class TestCachedSubmissionsPageFetcher:
         assert calls == [("page", "ims")]
         assert wrapped.cache_misses == 1
         assert wrapped.cache_hits == 0
+
+
+# ---------------------------------------------------------------------------
+# SEC 429 counter (#1545) — async paths must increment sec_throttle_429_total
+# ---------------------------------------------------------------------------
+
+
+class TestSec429Counter:
+    """fetch_one is the chokepoint: every pipelined SEC request flows
+    through it, so one increment there covers prefetch_document_texts
+    AND prefetch_submissions_pages_conditional.
+
+    Delta-based assertions per the prevention log — the counter is
+    process-global, never assert exact totals."""
+
+    async def test_fetch_one_429_increments_counter(self) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        clock, lock = _isolated_budget()
+        transport = httpx.MockTransport(lambda r: httpx.Response(429))
+        async with httpx.AsyncClient(transport=transport) as client:
+            fetcher = PipelinedSecFetcher(
+                client=client, target_rps=1000, concurrency=1, shared_clock=clock, shared_lock=lock
+            )
+            before = sec_throttle_429_total()
+            result = await fetcher.fetch_one(FetchTask(key="k", url="https://example.test/doc", headers={}))
+        assert result.response is not None
+        assert result.response.status_code == 429
+        assert sec_throttle_429_total() - before == 1
+
+    async def test_fetch_one_200_does_not_increment(self) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        clock, lock = _isolated_budget()
+        transport = httpx.MockTransport(lambda r: httpx.Response(200))
+        async with httpx.AsyncClient(transport=transport) as client:
+            fetcher = PipelinedSecFetcher(
+                client=client, target_rps=1000, concurrency=1, shared_clock=clock, shared_lock=lock
+            )
+            before = sec_throttle_429_total()
+            await fetcher.fetch_one(FetchTask(key="k", url="https://example.test/doc", headers={}))
+        assert sec_throttle_429_total() - before == 0
+
+    async def test_fetch_one_transport_error_does_not_increment(self) -> None:
+        from app.providers.sec_throttle_metrics import sec_throttle_429_total
+
+        clock, lock = _isolated_budget()
+
+        def boom(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("refused")
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(boom)) as client:
+            fetcher = PipelinedSecFetcher(
+                client=client, target_rps=1000, concurrency=1, shared_clock=clock, shared_lock=lock
+            )
+            before = sec_throttle_429_total()
+            result = await fetcher.fetch_one(FetchTask(key="k", url="https://example.test/doc", headers={}))
+        assert result.error is not None
+        assert sec_throttle_429_total() - before == 0


### PR DESCRIPTION
## What

#1484 added the process-global SEC 429 counter (`app/providers/sec_throttle_metrics.py::sec_throttle_429_total`, surfaced on `/system/postgres-health`) wired only into the **sync** `ResilientClient.on_429` path. The async/bulk SEC paths use raw `httpx.AsyncClient`, so their 429s never incremented the counter — the operator could see `sec_throttle_429_total = 0` while bulk/pipelined SEC traffic was being throttled. Observability-completeness gap only; the cross-process gate already prevents the breach.

## Fix

Guarded `if status_code == 429: incr_sec_429()` at every async 429-detection site:

| File | Site |
|---|---|
| `sec_pipelined_fetcher.py` | `PipelinedSecFetcher.fetch_one` — **single chokepoint**: every pipelined request (both `prefetch_document_texts` and `prefetch_submissions_pages_conditional`, plus any future `fetch_many` caller) flows through it. One increment instead of the issue's two scattered ones. |
| `sec_bulk_refresh.py` | HEAD probe (`head_status_*` skip path) + streaming GET (`get_status_*` skip path) |
| `sec_bulk_download.py` | `_head_etag` preflight · bandwidth probe · `_head_size_and_type` · download stream — both the Range response and the fresh-retry stream |

No double-counting: `fetch_one` callers only inspect cached results; the resume-path Range 429 and fresh-retry 429 are distinct HTTP responses (each correctly counts). Fallback to the sync `ResilientClient` counts a *later, separate* request via `on_429`. Confirmed by Codex checkpoint-2.

Thread-safety: `incr_sec_429` uses a `threading.Lock`; called from async contexts the critical section is a single int increment with no await — negligible event-loop hold (Codex-confirmed).

## Security model

No auth/authz surface, no SQL, no user input, no new dependencies. Pure in-process metrics increment on already-existing status-code branches; control flow at every site unchanged.

## Tests

Delta-based assertions throughout (prevention-log rule: process-global counter ⇒ never exact-equality):
- `tests/test_sec_pipelined_fetcher.py::TestSec429Counter` — fetch_one 429 → +1; 200 → +0; transport error → +0.
- `tests/test_sec_bulk_refresh.py::TestSec429Counter` — HEAD 429 → +1 (`head_status_429`); GET 429 → +1 (`get_status_429`); HEAD 503 → +0.
- `tests/test_sec_bulk_download.py::TestSec429Counter` — `_head_etag` 429 → +1; bandwidth probe 429 → +1 (still raises); `_head_size_and_type` 429 → +1 (still raises); download stream 429 → +1; resume fresh-retry 429 → +1.

All fast tier (no DB).

## Verification

This is a counters-only observability change — no ETL/parser/schema surface, so the dev-backfill clauses don't apply. End-to-end counter visibility on `/system/postgres-health` was dev-verified in #1484 (PR #1546); this PR extends the same counter the endpoint already reads.

## Local gates (at c39241d)

ruff check ✓ · ruff format --check ✓ · pyright 0 errors ✓ · `pytest -m "not db"` 3795 passed ✓ · `pytest tests/smoke` 129 passed ✓ · full pre-push hook green on push.

Codex checkpoint-2 on the branch diff: **no findings** — coverage complete across the three files, no double-counting, lock safe from async, tests adequate.

## Tradeoffs

- Increments placed at status-detection sites (not a shared httpx event-hook) — keeps each site greppable and avoids touching client construction in three differently-shaped modules. ~7 two-line additions.
- 429s inside `_TRANSIENT_HTTP_STATUSES` branches count but are otherwise handled exactly as before (skip + retry next fire).

Closes #1545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #1484 (observability follow-up; #1484 itself closed via PR #1546)
