### PR TITLE
fix(#1462): tradable-aware instruments floor in bootstrap validation

### DIFF
--- a/app/services/bootstrap_validation.py
+++ b/app/services/bootstrap_validation.py
@@ -90,14 +90,12 @@ class BootstrapValidationError(RuntimeError):
 #   ownership_institutions_current    1,151,745 →    575,000
 #   ownership_funds_current             695,750 →    340,000
 #
-# ``instruments`` is deliberately NOT floored here (#1462): the generic
-# ``_check_row_floors`` does ``COUNT(*)``, but ``sync_universe`` marks delisted
-# instruments ``is_tradable = FALSE`` rather than deleting them, so the total
-# row count never shrinks after one good sync — a later partial eToro response
-# leaves ``COUNT(*) >= floor`` and the degraded-universe shape goes undetected.
-# A correct instruments floor needs a ``WHERE is_tradable = TRUE`` count (or a
-# run-local provider-return count), which is a check-mechanism change, not a
-# value tweak — tracked in #1462.
+# ``instruments`` is floored TRADABLE-AWARE via ``_PREDICATE_FLOORS`` (#1462),
+# not here: ``sync_universe`` marks delisted instruments ``is_tradable = FALSE``
+# rather than deleting them, so ``COUNT(*)`` never shrinks after one good sync —
+# a later partial eToro response would leave ``COUNT(*) >= floor`` and the
+# degraded-universe shape undetected. ``COUNT(*) WHERE is_tradable = TRUE``
+# shrinks with the live universe and catches it.
 #
 # Scope rules (which tables are SAFE to hard-floor):
 #  * The three observation tables + filing_events + financial_facts_raw are
@@ -123,6 +121,17 @@ _ROW_FLOORS: Final[dict[str, int]] = {
     "ownership_insiders_current": 30_000,
     "ownership_institutions_current": 575_000,
     "ownership_funds_current": 340_000,
+}
+
+# Predicate-scoped floors (#1462): {table: (floor, where)}. Same calibration
+# policy as _ROW_FLOORS (~50% of the clean-run baseline, raise-never-lower).
+# The ``where`` text is a TRUSTED literal from this dict — same trust posture
+# as the table names — rendered verbatim into the bounded-count subquery.
+#
+# Measured baseline → floor (2026-06-04 dev):
+#   instruments WHERE is_tradable = TRUE   12,530 → 6,000
+_PREDICATE_FLOORS: Final[dict[str, tuple[int, str]]] = {
+    "instruments": (6_000, "is_tradable = TRUE"),
 }
 
 # --- Check 2: panel render -------------------------------------------------
@@ -203,9 +212,19 @@ def _check_row_floors(conn: psycopg.Connection[Any]) -> None:
                 f"row-count floor breach: {table} has {got} row(s), want >= {floor}",
             )
         logger.info("bootstrap_validation: row floor OK — %s >= %d", table, floor)
+    for table, (floor, where) in _PREDICATE_FLOORS.items():
+        met, got = _count_at_least(conn, table, floor, where=where)
+        if not met:
+            raise BootstrapValidationError(
+                "row_floor",
+                f"row-count floor breach: {table} has {got} row(s) WHERE {where}, want >= {floor}",
+            )
+        logger.info("bootstrap_validation: row floor OK — %s WHERE %s >= %d", table, where, floor)
 
 
-def _count_at_least(conn: psycopg.Connection[Any], table: str, floor: int) -> tuple[bool, int]:
+def _count_at_least(
+    conn: psycopg.Connection[Any], table: str, floor: int, *, where: str | None = None
+) -> tuple[bool, int]:
     """Return ``(met, bounded_count)`` for ``table`` against ``floor``.
 
     Uses a LIMIT-bounded subquery so the scan stops at ``floor`` rows — a >0
@@ -213,10 +232,16 @@ def _count_at_least(conn: psycopg.Connection[Any], table: str, floor: int) -> tu
     mechanism still answers "are there >= floor rows?" exactly for any calibrated
     floor. ``bounded_count == min(floor, total)``, so on a FAILURE
     (``total < floor``) it equals the true total — the error message reports the
-    real shortfall. ``table`` comes only from the trusted ``_ROW_FLOORS`` keys;
-    rendered via ``sql.Identifier`` (never string-interpolated) regardless.
+    real shortfall. ``table`` comes only from the trusted ``_ROW_FLOORS`` /
+    ``_PREDICATE_FLOORS`` keys; rendered via ``sql.Identifier`` (never
+    string-interpolated) regardless. ``where`` (#1462) is likewise a trusted
+    literal from ``_PREDICATE_FLOORS`` values only — never caller-supplied
+    free text.
     """
-    query = sql.SQL("SELECT count(*) FROM (SELECT 1 FROM {} LIMIT %(lim)s) AS _bounded").format(sql.Identifier(table))
+    where_clause = sql.SQL("") if where is None else sql.SQL(" WHERE {}").format(sql.SQL(where))  # type: ignore[arg-type]
+    query = sql.SQL("SELECT count(*) FROM (SELECT 1 FROM {}{} LIMIT %(lim)s) AS _bounded").format(
+        sql.Identifier(table), where_clause
+    )
     with conn.cursor() as cur:
         cur.execute(query, {"lim": floor})
         row = cur.fetchone()

--- a/tests/test_bootstrap_validation.py
+++ b/tests/test_bootstrap_validation.py
@@ -87,6 +87,22 @@ def test_count_at_least_bounded_and_accurate_shortfall(ebull_test_conn: psycopg.
     assert bv._count_at_least(conn, "_vt_count", 1) == (False, 0)
 
 
+def test_count_at_least_with_predicate(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """#1462 — the predicate-aware count must floor only the rows matching
+    ``where``, not COUNT(*)."""
+    conn = ebull_test_conn
+    conn.execute("CREATE TEMP TABLE _vt_pred (x int, is_tradable boolean)")
+    conn.execute("INSERT INTO _vt_pred VALUES (1, TRUE), (2, TRUE), (3, FALSE)")
+
+    # Predicate count: 2 tradable rows of 3 total.
+    assert bv._count_at_least(conn, "_vt_pred", 2, where="is_tradable = TRUE") == (True, 2)
+    # Floor above the predicate count fails even though COUNT(*)=3 >= 3 —
+    # the exact degraded-universe shape #1462 exists to catch.
+    assert bv._count_at_least(conn, "_vt_pred", 3, where="is_tradable = TRUE") == (False, 2)
+    # No predicate keeps the old COUNT(*) behaviour.
+    assert bv._count_at_least(conn, "_vt_pred", 3) == (True, 3)
+
+
 # ---------------------------------------------------------------------------
 # _check_row_floors
 # ---------------------------------------------------------------------------
@@ -112,10 +128,48 @@ def test_row_floors_are_calibrated_not_placeholders() -> None:
         "ownership_institutions_current",
         "ownership_funds_current",
     }, sorted(bv._ROW_FLOORS)
-    # instruments stays OUT (correct floor needs a tradable-aware count,
-    # #1462); the deferred treasury / blockholders / def14a slices stay OUT
-    # too — both enforced by the exact-set assertion above.
+    # instruments stays OUT of the COUNT(*) floors (sync_universe marks
+    # delisted rows is_tradable=FALSE, so COUNT(*) never shrinks); it is
+    # floored tradable-aware via _PREDICATE_FLOORS instead (#1462). The
+    # deferred treasury / blockholders / def14a slices stay OUT of both —
+    # enforced by the exact-set assertions.
     assert "instruments" not in bv._ROW_FLOORS
+    assert set(bv._PREDICATE_FLOORS) == {"instruments"}, sorted(bv._PREDICATE_FLOORS)
+    floor, where = bv._PREDICATE_FLOORS["instruments"]
+    # ~50% of the 2026-06-04 dev baseline (12,530 tradable), same margin
+    # policy as _ROW_FLOORS — calibrated, not a non-empty sentinel.
+    assert floor == 6_000
+    assert where == "is_tradable = TRUE"
+
+
+def test_check_row_floors_catches_degraded_universe_shape(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1462 — total rows >= floor but tradable rows < floor must FAIL.
+    This is exactly the partial-eToro-sync shape COUNT(*) cannot see."""
+    conn = ebull_test_conn
+    conn.execute("CREATE TEMP TABLE _vt_uni (x int, is_tradable boolean)")
+    conn.execute("INSERT INTO _vt_uni VALUES (1, TRUE), (2, FALSE), (3, FALSE)")
+    monkeypatch.setattr(bv, "_ROW_FLOORS", {})
+    monkeypatch.setattr(bv, "_PREDICATE_FLOORS", {"_vt_uni": (2, "is_tradable = TRUE")})
+
+    with pytest.raises(BootstrapValidationError) as exc_info:
+        bv._check_row_floors(conn)
+    assert exc_info.value.check_id == "row_floor"
+    assert "_vt_uni" in str(exc_info.value)
+    assert "is_tradable = TRUE" in str(exc_info.value)
+
+
+def test_check_row_floors_predicate_floor_passes_when_met(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    conn.execute("CREATE TEMP TABLE _vt_uni2 (x int, is_tradable boolean)")
+    conn.execute("INSERT INTO _vt_uni2 VALUES (1, TRUE), (2, TRUE), (3, FALSE)")
+    monkeypatch.setattr(bv, "_ROW_FLOORS", {})
+    monkeypatch.setattr(bv, "_PREDICATE_FLOORS", {"_vt_uni2": (2, "is_tradable = TRUE")})
+
+    bv._check_row_floors(conn)  # no raise
 
 
 def test_check_row_floors_raises_when_table_empty(
@@ -138,6 +192,7 @@ def test_check_row_floors_passes_when_floor_met(
     conn.execute("CREATE TEMP TABLE _vt_floor (x int)")
     conn.execute("INSERT INTO _vt_floor VALUES (1)")
     monkeypatch.setattr(bv, "_ROW_FLOORS", {"_vt_floor": 1})
+    monkeypatch.setattr(bv, "_PREDICATE_FLOORS", {})
 
     bv._check_row_floors(conn)  # no raise
 


### PR DESCRIPTION
## What

Bootstrap validation deliberately had NO `instruments` row floor: `sync_universe` (`app/services/universe.py`) marks instruments absent from the eToro feed `is_tradable = FALSE` rather than deleting them, so `COUNT(*)` never shrinks after one good sync — a later partial eToro response (the most-upstream DEGRADED bootstrap shape) would pass any `COUNT(*)` floor undetected (Codex catch on #1434; deferred to #1462 as a check-mechanism change).

## Fix (issue Option A)

- New `_PREDICATE_FLOORS: {table: (floor, where)}` alongside `_ROW_FLOORS` in `app/services/bootstrap_validation.py`, seeded with `{"instruments": (6_000, "is_tradable = TRUE")}`.
- `_count_at_least` grows an optional `where=` keyword, rendered into the existing LIMIT-bounded subquery. The bounded-scan property is preserved: the scan still stops at `floor` matching rows.
- `_check_row_floors` loops both dicts; a predicate breach message includes the predicate (`instruments has N row(s) WHERE is_tradable = TRUE, want >= 6000`), check_id stays `row_floor`.

## Calibration

`COUNT(*) WHERE is_tradable = TRUE` = **12,530** on dev (2026-06-04 baseline, re-confirmed at HEAD) → floor **6,000** (~50%), the same margin policy as the #1434 floors. Raise-never-lower per the existing comment contract.

## Security model

The `where` text is rendered as raw SQL (`sql.SQL(where)`) — by design it must come ONLY from the trusted `_PREDICATE_FLOORS` literal, same trust posture as the table names (already rendered via `sql.Identifier` from trusted keys). Never caller-supplied. Documented in the docstring; Codex checkpoint-2 reviewed the injection posture and confirmed acceptable under that invariant. No user input reaches this path (bootstrap-internal check). Schema: `instruments.is_tradable` is `BOOLEAN NOT NULL DEFAULT TRUE` (sql/001_init.sql) — no NULL-semantics gap in the predicate (Codex-verified).

## Tests

`tests/test_bootstrap_validation.py`:
- `test_count_at_least_with_predicate` — predicate count; **the degraded shape**: `COUNT(*)=3 >= 3` but tradable `2 < 3` → fails; no-predicate path unchanged.
- `test_check_row_floors_catches_degraded_universe_shape` — end-to-end breach raises `row_floor` with the predicate in the message.
- `test_check_row_floors_predicate_floor_passes_when_met`.
- Calibration-pin test extended: exact `_PREDICATE_FLOORS` set, floor value 6,000, predicate string pinned; `instruments` still asserted OUT of `_ROW_FLOORS`.
- Pre-existing pass-case test now patches `_PREDICATE_FLOORS` too (it was hitting the real instruments floor on the near-empty test DB).

## Verification

- Targeted db tier: `tests/test_bootstrap_validation.py` 19 passed.
- Full local gates at HEAD: ruff ✓ format ✓ pyright 0 errors ✓ fast tier 3802 passed ✓ smoke 129 passed ✓ (pre-push hook green on push).
- Dev-verify against live dev DB via the real code path: `_count_at_least(conn, "instruments", 6000, where="is_tradable = TRUE")` → `met=True, bounded_got=6000` (total=12,530, tradable=12,530).
- No backfill: validation-gate logic only, no schema/parser/data change.
- Codex checkpoint-2: **no findings** (injection posture, caller sweep, NULL semantics, test quality all checked).

## Tradeoffs

- Option A (DB predicate count) over Option B (run-local provider-return count): the predicate count survives process restarts and needs no new plumbing between the universe stage and the validation stage; it measures the same thing the panel reads.
- `_PREDICATE_FLOORS` kept as a separate dict rather than widening `_ROW_FLOORS` values — preserves the exact-set calibration test and the plain `{table: int}` knob untouched.

Closes #1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)