### PR TITLE
fix(#1221): DEFAULT-partition alarm keys on parser-junk rows, not raw count

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -796,6 +796,8 @@ class PostgresHealthResponse(BaseModel):
     last_checkpoint_at: datetime | None
     autovacuum_top10: list[AutovacuumTableLagSchema] | None
     financial_facts_raw_default_rows: int | None
+    # #1221 — parser-junk rows only; the breach flag keys on this count.
+    financial_facts_raw_default_junk_rows: int | None
     financial_facts_raw_default_warn_threshold: int
     financial_facts_raw_default_breached_warn: bool | None
     listener_connections: list[ListenerConnectionCountSchema] | None
@@ -1007,6 +1009,7 @@ def get_postgres_health() -> PostgresHealthResponse:
             ]
         ),
         financial_facts_raw_default_rows=snapshot.financial_facts_raw_default_rows,
+        financial_facts_raw_default_junk_rows=(snapshot.financial_facts_raw_default_junk_rows),
         financial_facts_raw_default_warn_threshold=(snapshot.financial_facts_raw_default_warn_threshold),
         financial_facts_raw_default_breached_warn=(snapshot.financial_facts_raw_default_breached_warn),
         listener_connections=(

--- a/app/services/postgres_health.py
+++ b/app/services/postgres_health.py
@@ -14,12 +14,15 @@ live readout for:
   signal.
 - Autovacuum top-10 by `n_dead_tup` (Phase 3's partition + retention
   motivation).
-- `financial_facts_raw_default` row count against the 5000-row alarm
-  (Phase 3 §4.1.1 — parser-junk growth detector).
+- `financial_facts_raw_default` row count (informational) plus a
+  parser-junk row count against the 5000-row alarm (Phase 3 §4.1.1;
+  #1221 — the breach flag keys on the junk count so legitimate
+  forward-projected XBRL schedule rows past the partition ceiling
+  never false-positive the alarm).
 
 Service-no-commit invariant + autocommit-conn contract: the service
-opens its OWN connection with `autocommit=True` so each of the seven
-metric queries runs in its own implicit tx. Without autocommit, a
+opens its OWN connection with `autocommit=True` so each metric query
+runs in its own implicit tx. Without autocommit, a
 single SQL error (e.g. `pg_monitor` role required for `pg_ls_waldir`
 on a non-superuser DB) puts the entire tx in `ABORTED` state and
 every subsequent query fails with `current transaction is aborted`.
@@ -33,7 +36,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 
 import psycopg
 
@@ -57,6 +60,16 @@ DB_SIZE_WARN_BYTES: int = 10 * 1024 * 1024 * 1024  # 10 GB
 # normal checkpoint pressure.
 WAL_WARN_BYTES: int = 4 * 1024 * 1024 * 1024  # 4 GB
 DEFAULT_PARTITION_WARN_ROWS: int = 5000
+
+# #1221 — sanity window mirrored from the parser-side guard
+# (`app/providers/implementations/sec_fundamentals.py::_PERIOD_MIN/_PERIOD_MAX`,
+# #1218). Duplicated here rather than imported so this service never
+# pulls the provider module; the
+# `tests/test_postgres_health_junk_window.py::test_junk_window_matches_parser_guard`
+# test asserts the two stay aligned (same pattern as DB_SIZE_WARN_BYTES
+# vs the pre-push hook above).
+FACTS_PERIOD_MIN: date = date(1900, 1, 1)
+FACTS_PERIOD_MAX: date = date(2100, 1, 1)
 
 
 # ── Data shapes ──────────────────────────────────────────────────
@@ -107,6 +120,13 @@ class PostgresHealthSnapshot:
     last_checkpoint_at: datetime | None
     autovacuum_top10: list[AutovacuumTableLag] | None
     financial_facts_raw_default_rows: int | None
+    # #1221 — rows in DEFAULT matching the parser-rejection predicate
+    # (out-of-window period_end/period_start, or start > end). Post-#1218
+    # the parser blocks these at ingest, so this stays 0 unless the
+    # guard regresses. The breach flag keys on THIS count, not the raw
+    # row count — legitimate forward-projected schedule rows past the
+    # 2040 partition ceiling (sql/175) sit in DEFAULT without alarming.
+    financial_facts_raw_default_junk_rows: int | None
     financial_facts_raw_default_warn_threshold: int
     financial_facts_raw_default_breached_warn: bool | None
     # #1472 PR3 — per-application_name count of eBull LISTEN connections,
@@ -296,11 +316,33 @@ def _q_listener_connections(conn: psycopg.Connection[tuple]) -> list[ListenerCon
 
 
 def _q_default_partition_rows(conn: psycopg.Connection[tuple]) -> int:
-    # Full seq scan on the DEFAULT partition. Current size ~1055 rows
-    # post-Phase-3; scan stays cheap until the 5000-row alarm fires,
-    # at which point the operator has bigger problems than scan cost.
+    # Full seq scan on the DEFAULT partition. Sits at 0 on dev
+    # post-#1314 cleanup; scan stays cheap until the 5000-row alarm
+    # fires, at which point the operator has bigger problems than scan
+    # cost.
     with conn.cursor() as cur:
         cur.execute("SELECT count(*) FROM financial_facts_raw_default")
+        row = cur.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _q_default_partition_junk_rows(conn: psycopg.Connection[tuple]) -> int:
+    # #1221 — count only rows the parser-side guard
+    # (`_classify_period_rejection`, #1218) would have rejected:
+    # out-of-window dates or start > end. Anything else in DEFAULT is a
+    # legitimate forward-projected row past the partition ceiling.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM financial_facts_raw_default "
+            " WHERE period_end < %(pmin)s "
+            "    OR period_end >= %(pmax)s "
+            "    OR (period_start IS NOT NULL "
+            "        AND (period_start < %(pmin)s "
+            "             OR period_start >= %(pmax)s "
+            "             OR period_start > period_end))",
+            {"pmin": FACTS_PERIOD_MIN, "pmax": FACTS_PERIOD_MAX},
+        )
         row = cur.fetchone()
     assert row is not None
     return int(row[0])
@@ -318,9 +360,9 @@ def collect_postgres_health(
 ) -> PostgresHealthSnapshot:
     """Collect every PG health metric into one snapshot.
 
-    Opens its own `psycopg.connect(url, autocommit=True)` so each of
-    the seven metric queries runs in its own implicit tx — a SQL
-    error on one metric never aborts the others.
+    Opens its own `psycopg.connect(url, autocommit=True)` so each
+    metric query runs in its own implicit tx — a SQL error on one
+    metric never aborts the others.
 
     Thresholds are injectable for tests (above-threshold assertions
     on a small test DB need a low threshold). Production callers pass
@@ -345,6 +387,7 @@ def collect_postgres_health(
     last_ckpt: datetime | None = None
     top10: list[AutovacuumTableLag] | None = None
     default_rows: int | None = None
+    default_junk_rows: int | None = None
     listener_conns: list[ListenerConnectionCount] | None = None
 
     with psycopg.connect(url, autocommit=True) as conn:
@@ -366,11 +409,16 @@ def collect_postgres_health(
         last_ckpt = _safe(conn, "last_checkpoint", _q_last_checkpoint, errors)
         top10 = _safe(conn, "autovacuum_top10", _q_autovacuum_top10, errors)
         default_rows = _safe(conn, "default_partition_rows", _q_default_partition_rows, errors)
+        default_junk_rows = _safe(conn, "default_partition_junk_rows", _q_default_partition_junk_rows, errors)
         listener_conns = _safe(conn, "listener_connections", _q_listener_connections, errors)
 
     db_size_breached: bool | None = None if db_size_bytes is None else db_size_bytes > db_size_warn_threshold_bytes
     wal_breached: bool | None = None if wal_dir_bytes is None else wal_dir_bytes > wal_warn_threshold_bytes
-    default_breached: bool | None = None if default_rows is None else default_rows > default_partition_warn_rows
+    # #1221 — breach keys on the parser-junk count, not the raw row
+    # count; raw count stays informational.
+    default_breached: bool | None = (
+        None if default_junk_rows is None else default_junk_rows > default_partition_warn_rows
+    )
     leaked_count: int | None = None if leaked_names is None else len(leaked_names)
     listener_dup: bool | None = None if listener_conns is None else any(lc.count > 1 for lc in listener_conns)
 
@@ -391,6 +439,7 @@ def collect_postgres_health(
         last_checkpoint_at=last_ckpt,
         autovacuum_top10=top10,
         financial_facts_raw_default_rows=default_rows,
+        financial_facts_raw_default_junk_rows=default_junk_rows,
         financial_facts_raw_default_warn_threshold=default_partition_warn_rows,
         financial_facts_raw_default_breached_warn=default_breached,
         listener_connections=listener_conns,

--- a/app/services/postgres_health.py
+++ b/app/services/postgres_health.py
@@ -328,10 +328,14 @@ def _q_default_partition_rows(conn: psycopg.Connection[tuple]) -> int:
 
 
 def _q_default_partition_junk_rows(conn: psycopg.Connection[tuple]) -> int:
-    # #1221 — count only rows the parser-side guard
-    # (`_classify_period_rejection`, #1218) would have rejected:
-    # out-of-window dates or start > end. Anything else in DEFAULT is a
-    # legitimate forward-projected row past the partition ceiling.
+    # #1221 — count only rows the #1218 data-shape sanity guard
+    # (`_classify_period_rejection`'s window + ordering legs) would have
+    # rejected: out-of-window dates or start > end. The classifier's
+    # retention-cutoff leg is DELIBERATELY not mirrored: retention
+    # rejections are in-window historical dates that route to real
+    # partitions, never to DEFAULT — and they are policy, not junk.
+    # Anything else in DEFAULT is a legitimate forward-projected row
+    # past the partition ceiling.
     with conn.cursor() as cur:
         cur.execute(
             "SELECT count(*) FROM financial_facts_raw_default "

--- a/tests/test_api_postgres_health.py
+++ b/tests/test_api_postgres_health.py
@@ -69,6 +69,7 @@ def _snapshot(**overrides: object) -> PostgresHealthSnapshot:
             )
         ],
         "financial_facts_raw_default_rows": 1055,
+        "financial_facts_raw_default_junk_rows": 0,
         "financial_facts_raw_default_warn_threshold": 5000,
         "financial_facts_raw_default_breached_warn": False,
         "listener_connections": [
@@ -109,6 +110,7 @@ def test_endpoint_returns_200_with_all_fields() -> None:
         "last_checkpoint_at",
         "autovacuum_top10",
         "financial_facts_raw_default_rows",
+        "financial_facts_raw_default_junk_rows",
         "financial_facts_raw_default_warn_threshold",
         "financial_facts_raw_default_breached_warn",
         "listener_connections",
@@ -142,16 +144,21 @@ def test_db_size_breach_flag_above_threshold() -> None:
 
 
 def test_default_partition_warn_flag_above_threshold() -> None:
+    # #1221 — breach keys on the junk count; raw count can sit high
+    # (legit forward-projected rows) without flipping the flag.
     with patch(
         "app.services.postgres_health.collect_postgres_health",
         return_value=_snapshot(
             financial_facts_raw_default_rows=10_000,
+            financial_facts_raw_default_junk_rows=6_000,
             financial_facts_raw_default_breached_warn=True,
         ),
     ):
         resp = client.get("/system/postgres-health")
     assert resp.status_code == 200
-    assert resp.json()["financial_facts_raw_default_breached_warn"] is True
+    body = resp.json()
+    assert body["financial_facts_raw_default_breached_warn"] is True
+    assert body["financial_facts_raw_default_junk_rows"] == 6_000
 
 
 def test_wal_breach_flag_keys_on_dir_not_since_checkpoint() -> None:

--- a/tests/test_postgres_health_junk_window.py
+++ b/tests/test_postgres_health_junk_window.py
@@ -1,0 +1,20 @@
+"""#1221 — pure alignment guard: the postgres_health junk-window
+constants must mirror the parser-side period sanity guard.
+
+`app.services.postgres_health` deliberately duplicates the
+`[_PERIOD_MIN, _PERIOD_MAX)` window from
+`app.providers.implementations.sec_fundamentals` instead of importing
+the provider module at runtime. This test is the single-source-of-truth
+enforcement (same pattern as the DB_SIZE_WARN_BYTES ↔ pre-push-hook
+alignment test in `tests/test_pre_push_hook_bloat_warn.py`).
+"""
+
+from __future__ import annotations
+
+from app.providers.implementations import sec_fundamentals
+from app.services import postgres_health
+
+
+def test_junk_window_matches_parser_guard() -> None:
+    assert postgres_health.FACTS_PERIOD_MIN == sec_fundamentals._PERIOD_MIN
+    assert postgres_health.FACTS_PERIOD_MAX == sec_fundamentals._PERIOD_MAX

--- a/tests/test_postgres_health_service.py
+++ b/tests/test_postgres_health_service.py
@@ -67,6 +67,7 @@ def test_autocommit_isolates_failed_probe_under_real_db(
     #   5. last_checkpoint     (after wal_dir — load-bearing guard)
     #   6. autovacuum_top10    (after wal_dir — load-bearing guard)
     #   7. default_partition_rows (after wal_dir — load-bearing guard)
+    #   8. default_partition_junk_rows (after wal_dir — load-bearing guard)
     assert snapshot.wal_since_checkpoint_bytes is not None, (
         "post-wal_dir probe failed — autocommit=True missing from "
         "psycopg.connect(...) leaves the conn in ABORTED state after "
@@ -75,6 +76,7 @@ def test_autocommit_isolates_failed_probe_under_real_db(
     assert snapshot.last_checkpoint_at is not None
     assert snapshot.autovacuum_top10 is not None
     assert snapshot.financial_facts_raw_default_rows is not None
+    assert snapshot.financial_facts_raw_default_junk_rows is not None
 
 
 @pytest.mark.skipif(not test_db_available(), reason="test DB unavailable")
@@ -92,18 +94,81 @@ def test_safe_wrapper_catches_non_psycopg_exceptions(
     def _bad_probe(_conn: psycopg.Connection[tuple]) -> int:
         raise AssertionError("synthetic: probe internal assertion failed")
 
-    monkeypatch.setattr(postgres_health, "_q_default_partition_rows", _bad_probe)
+    # #1221: the breach flag keys on the JUNK probe, so that is the one
+    # whose failure must null the flag (fail-unknown, not fail-False).
+    monkeypatch.setattr(postgres_health, "_q_default_partition_junk_rows", _bad_probe)
 
     snapshot = collect_postgres_health(database_url=test_database_url())
 
-    assert snapshot.financial_facts_raw_default_rows is None
+    assert snapshot.financial_facts_raw_default_junk_rows is None
     assert snapshot.financial_facts_raw_default_breached_warn is None
-    assert any(e.startswith("default_partition_rows:") for e in snapshot.metric_errors), (
-        f"expected default_partition_rows entry in metric_errors, got {snapshot.metric_errors}"
+    assert any(e.startswith("default_partition_junk_rows:") for e in snapshot.metric_errors), (
+        f"expected default_partition_junk_rows entry in metric_errors, got {snapshot.metric_errors}"
     )
+    # The raw informational count is an independent probe — unaffected.
+    assert snapshot.financial_facts_raw_default_rows is not None
     # Every other metric unaffected.
     assert snapshot.db_size_bytes is not None
     assert snapshot.last_checkpoint_at is not None
+
+
+@pytest.mark.skipif(not test_db_available(), reason="test DB unavailable")
+def test_default_partition_junk_probe_discriminates_legit_forward_rows() -> None:
+    """#1221 — the breach flag keys on parser-junk rows only.
+
+    Seeds the DEFAULT partition with one legitimate forward-projected
+    row (period_end 2045 — past the 2040 ceiling, inside the parser
+    window) and three junk rows (pre-1900, post-2100, start > end).
+    Delta-based assertions (prevention log: never exact-equality on
+    DB-global counters).
+    """
+    url = test_database_url()
+    baseline = collect_postgres_health(database_url=url)
+    assert baseline.financial_facts_raw_default_rows is not None
+    assert baseline.financial_facts_raw_default_junk_rows is not None
+
+    marker = "9999999999-21-001221"  # accession marker for teardown
+    with psycopg.connect(url, autocommit=True) as conn:
+        try:
+            conn.execute(
+                "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+                "VALUES (9902210, 'ZZJUNK', 'Junk Probe Test', 'USD', TRUE)"
+            )
+            for start, end in (
+                (None, "2045-01-01"),  # legit forward-projected (NOT junk)
+                (None, "1850-12-31"),  # junk: pre-window
+                (None, "2105-01-01"),  # junk: post-window
+                ("2046-01-01", "2045-06-30"),  # junk: start > end
+            ):
+                conn.execute(
+                    "INSERT INTO financial_facts_raw "
+                    "  (instrument_id, concept, unit, period_start, period_end, "
+                    "   val, accession_number, form_type, filed_date) "
+                    "VALUES (9902210, 'TestConcept', 'USD', %s, %s, 1, %s, '10-K', '2026-01-01')",
+                    (start, end, marker),
+                )
+
+            snap = collect_postgres_health(database_url=url)
+            assert snap.financial_facts_raw_default_rows is not None
+            assert snap.financial_facts_raw_default_junk_rows is not None
+            assert snap.financial_facts_raw_default_rows - baseline.financial_facts_raw_default_rows == 4
+            assert (snap.financial_facts_raw_default_junk_rows - baseline.financial_facts_raw_default_junk_rows) == 3
+
+            # Breach keys on junk: threshold between junk and raw counts
+            # → no breach despite raw count exceeding it.
+            mid = collect_postgres_health(
+                database_url=url,
+                default_partition_warn_rows=baseline.financial_facts_raw_default_junk_rows + 3,
+            )
+            assert mid.financial_facts_raw_default_breached_warn is False
+            low = collect_postgres_health(
+                database_url=url,
+                default_partition_warn_rows=baseline.financial_facts_raw_default_junk_rows + 2,
+            )
+            assert low.financial_facts_raw_default_breached_warn is True
+        finally:
+            conn.execute("DELETE FROM financial_facts_raw WHERE accession_number = %s", (marker,))
+            conn.execute("DELETE FROM instruments WHERE instrument_id = 9902210")
 
 
 @pytest.mark.skipif(not test_db_available(), reason="test DB unavailable")

--- a/tests/test_postgres_health_service.py
+++ b/tests/test_postgres_health_service.py
@@ -168,7 +168,9 @@ def test_default_partition_junk_probe_discriminates_legit_forward_rows() -> None
             assert low.financial_facts_raw_default_breached_warn is True
         finally:
             conn.execute("DELETE FROM financial_facts_raw WHERE accession_number = %s", (marker,))
-            conn.execute("DELETE FROM instruments WHERE instrument_id = 9902210")
+            # symbol guard: never delete a pre-existing instrument if the
+            # hardcoded id is somehow taken on a shared DB.
+            conn.execute("DELETE FROM instruments WHERE instrument_id = 9902210 AND symbol = 'ZZJUNK'")
 
 
 @pytest.mark.skipif(not test_db_available(), reason="test DB unavailable")


### PR DESCRIPTION
## What

`financial_facts_raw_default_breached_warn` (operator alarm at `GET /system/postgres-health`, threshold 5000 rows) previously keyed on the RAW row count of `financial_facts_raw_default`. Legitimate forward-projected XBRL schedule rows (NOL expiration schedules, ASC 350 amortisation waterfalls) with `period_end` past the 2040 partition ceiling land in DEFAULT and would eventually false-positive the alarm — operator noise that erodes alarm trust (#1221's core complaint).

This PR implements option B from the issue: a new probe `_q_default_partition_junk_rows` counts only rows matching the #1218 parser-rejection data-shape predicate (`period_end`/`period_start` outside `[1900-01-01, 2100-01-01)`, or `period_start > period_end`). The breach flag now keys on this count; the raw count stays as an informational field. Option A (partition extension) already shipped: sql/175 (#1314) extended quarterly partitions to 2040 with deliberate 10y headroom — not re-extended here.

## Why this is the right signal

Post-#1218 the parser rejects junk at ingest, so the junk count sits at 0 unless the guard regresses — the alarm becomes a pure parser-regression detector (exactly the prevention-log "parser bugs silently fill the DEFAULT partition" concern), while legit far-forward rows accumulate in DEFAULT silently until the next partition extension.

The classifier's retention-cutoff leg is deliberately NOT mirrored in the SQL: retention rejections are in-window historical dates that route to real partitions, never DEFAULT — and they are policy, not junk (Codex ckpt-2 MED, resolved by scoping comment).

## Single source of truth

`FACTS_PERIOD_MIN/MAX` are duplicated in `postgres_health.py` rather than importing the provider module at runtime; `tests/test_postgres_health_junk_window.py` asserts alignment with `sec_fundamentals._PERIOD_MIN/_PERIOD_MAX` (same pattern as `DB_SIZE_WARN_BYTES` ↔ pre-push hook).

## Security model

No auth surface changes. The endpoint stays behind the existing operator-auth gate (`tests/test_api_postgres_health.py::TestAuthGate` unchanged). New SQL is parameterised; no user input reaches it.

## Tests

- New DB test seeds 1 legit forward row (period_end 2045) + 3 junk rows (pre-1900, post-2100, start>end) and proves: raw Δ=4, junk Δ=3, and breach flips on the junk count, not the raw count (delta-based per prevention log).
- `_safe`-isolation test rewired: a failing junk probe nulls the breach flag (fail-unknown), raw probe independent.
- Pure alignment test (fast tier) pins the window to the parser constants.
- API shape: `financial_facts_raw_default_junk_rows` added to response model + mock-shape tests.

## Verification

- `ruff check` / `ruff format --check` / `pyright` (0 errors) — pass at 6f5796d
- `pytest -m "not db"` 3803 passed; `pytest tests/smoke` 129 passed
- File-scoped DB tier: `tests/test_postgres_health_service.py` 6 passed, `tests/test_api_postgres_health.py` + junk-window 16 passed
- Dev DB: `financial_facts_raw_default` currently 0 rows (post-#1314 cleanup) — verified directly
- Codex ckpt-2: 1 MED + 1 LOW, both addressed in 6f5796d

## Tradeoffs

- DEFAULT partition has no growth alarm for LEGIT far-forward rows anymore — by design; growth there is bounded by real-world forward-schedule disclosure volume (currently 0 rows on dev) and the partition runway is an operator decision per sql/175.
- Junk window duplicated (not imported) — enforced by alignment test; avoids service→provider import coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1221
