### PR TITLE
chore(#1437): tech-debt sweep — dead sentinel machinery, unconsumed ordering caps, CUSIP-map dedup, stale comments

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -1,9 +1,12 @@
 """First-install bootstrap orchestrator.
 
-Runs the 26-stage end-to-end first-install backfill described in
+Runs the end-to-end first-install backfill described in
 ``docs/superpowers/specs/2026-05-08-bootstrap-etl-orchestration.md``
-(supersedes the original 17-stage shape in
+(supersedes the original shape in
 ``docs/superpowers/specs/2026-05-07-first-install-bootstrap.md``).
+The stage list is ``_BOOTSTRAP_STAGE_SPECS`` below — the count has
+drifted with every redesign (26 → 21 as of #1413), so it is not
+restated here.
 
 Phases (S-numbers match the runbook stage list):
 
@@ -53,7 +56,7 @@ import json
 import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import UTC, date, datetime, time, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final, Literal
 
@@ -125,23 +128,6 @@ JOB_CUSIP_RESOLVER_POST_BULK_SWEEP = "cusip_resolver_post_bulk_sweep"
 # run to ``partial_error`` (the universal gate stays closed). See
 # ``app/services/bootstrap_validation.py``.
 JOB_BOOTSTRAP_VALIDATION = "bootstrap_validation"
-# PR1c #1064 — bootstrap-bounded 13F sweep recency cut-off. Used to
-# live as a constant inside the deleted ``bootstrap_sec_13f_recent_sweep_job``
-# wrapper. 4 quarters (~380 days) = current + 3 prior periods, matches
-# the rolling ownership-card window. Older 13Fs add no value to
-# current-quarter ranking and pre-2013 ones don't have machine-readable
-# holdings (#1008).
-_BOOTSTRAP_13F_QUARTERS_BACK = 4
-_BOOTSTRAP_13F_RECENCY_DAYS = _BOOTSTRAP_13F_QUARTERS_BACK * 95
-
-# PR7 #1233 §4.6 — N-PORT cohort recency window. Aliases to the 13F
-# 380d window today (#1010 precedent) but lives in its own constant
-# so a future 13F-only tuning of ``_BOOTSTRAP_13F_RECENCY_DAYS``
-# doesn't silently drift the N-PORT cohort cutoff. Bot review on PR
-# #1243 WARNING — keep the two namespaced even when their numerical
-# value is identical.
-_BOOTSTRAP_NPORT_RECENCY_DAYS = _BOOTSTRAP_13F_RECENCY_DAYS
-
 # PR1c #1064 — filings_history_seed bootstrap default form-type
 # allow-list. Imported once at module load so the StageSpec.params
 # dict is plain data; the underlying constant lives in the canonical
@@ -151,70 +137,6 @@ _BOOTSTRAP_NPORT_RECENCY_DAYS = _BOOTSTRAP_13F_RECENCY_DAYS
 from app.services.filings import SEC_INGEST_KEEP_FORMS  # noqa: E402
 
 _FILINGS_HISTORY_KEEP_FORMS_TUPLE: tuple[str, ...] = tuple(sorted(SEC_INGEST_KEEP_FORMS))
-
-
-# Sentinel for params values that depend on dispatch-time state
-# (e.g. ``date.today()``). Module-load evaluation would freeze the
-# value into ``_BOOTSTRAP_STAGE_SPECS`` for the lifetime of the jobs
-# process; a long-lived process would dispatch stage 22 with a stale
-# cutoff. ``_resolve_dynamic_params`` materialises the absolute value
-# at dispatch time. The sentinel string is namespaced so it never
-# collides with a legitimate operator value.
-_PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF = "<dynamic:bootstrap_13f_cutoff>"
-# #1010 — sibling sentinel for the HR-recency cohort cutoff on stage
-# 22. Filters ``institutional_filers.last_13f_hr_at >= cutoff`` so the
-# sweep iterates only currently-active HR filers.
-_PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF = "<dynamic:bootstrap_13f_hr_cutoff>"
-# #1233 PR7 (mirror of #1010 for N-PORT) — recency cohort cutoff for
-# stage 23 sec_n_port_ingest. Filters
-# ``sec_nport_filer_directory.last_seen_filed_at >= cutoff`` so the
-# bootstrap sweep iterates only currently-active fund-trust filers.
-# Daily / Admin / manual paths dispatch with empty params → full
-# cohort (#1010 precedent — safety-net for re-emerging filers).
-_PARAM_DYNAMIC_BOOTSTRAP_NPORT_CUTOFF = "<dynamic:bootstrap_nport_cutoff>"
-
-
-def _resolve_dynamic_params(params: Mapping[str, Any]) -> dict[str, Any]:
-    """Materialise dispatch-time dynamic values in a stage params dict.
-
-    Today the dynamic values are the bootstrap-13F recency cutoffs
-    (one for ``min_period_of_report``, one for ``min_last_13f_hr_at``).
-    The helper is structured for forward extensibility (additional
-    sentinels can be added without touching call sites).
-
-    The dispatcher calls this immediately before invoking the
-    underlying ``JobInvoker`` so the absolute value is what flows
-    into ``job_runs.params_snapshot`` and the invoker body.
-    """
-    resolved: dict[str, Any] = dict(params)
-    if resolved.get("min_period_of_report") == _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF:
-        resolved["min_period_of_report"] = date.today() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS)
-    if resolved.get("min_last_13f_hr_at") == _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF:
-        # UTC start-of-day so the boundary is inclusive against
-        # ``form.idx`` dates which are stored at midnight UTC. Two
-        # subtle pitfalls avoided here:
-        #   (1) using the full timestamp (no ``.date()`` truncation)
-        #       would drift the cutoff during the day and exclude
-        #       filings whose form.idx date is exactly ``today() -
-        #       380d`` (Codex 1a B-3); (2) ``date.today()`` returns
-        #       *local* time — on a non-UTC dev host around the
-        #       local/UTC date boundary it would shift the cutoff by
-        #       ±1 day and silently exclude an exact-boundary UTC
-        #       filer (Codex 2 MEDIUM). Take the UTC date explicitly.
-        cutoff_date = datetime.now(tz=UTC).date() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS)
-        resolved["min_last_13f_hr_at"] = datetime.combine(cutoff_date, time(0, 0), tzinfo=UTC)
-    if resolved.get("min_last_seen_filed_at") == _PARAM_DYNAMIC_BOOTSTRAP_NPORT_CUTOFF:
-        # PR7 #1233 §4.6 — mirror of the 13F HR-cutoff resolution.
-        # UTC start-of-day so the boundary is inclusive against
-        # ``sec_nport_filer_directory.last_seen_filed_at`` (stored at
-        # midnight UTC by ``sec_nport_filer_directory_sync``). The
-        # 380d window aliases the 13F figure today but lives behind
-        # the dedicated ``_BOOTSTRAP_NPORT_RECENCY_DAYS`` constant so
-        # a future 13F-only tuning doesn't silently drift the N-PORT
-        # cohort cutoff (PR #1243 bot review WARNING).
-        nport_cutoff_date = datetime.now(tz=UTC).date() - timedelta(days=_BOOTSTRAP_NPORT_RECENCY_DAYS)
-        resolved["min_last_seen_filed_at"] = datetime.combine(nport_cutoff_date, time(0, 0), tzinfo=UTC)
-    return resolved
 
 
 def _spec(
@@ -364,40 +286,14 @@ Capability = Literal[
     # skipped → S8 cascade-skipped) still flows into S15 as the
     # legacy chain owner of ``filing_events_seeded``.
     "submissions_processed",
-    # #1233 — extension of the PR-1292 cap-ordering pattern to the
-    # other bulk/legacy pairs flagged by the 2026-05-23 lock-contention
-    # audit. Same shape:
-    #
-    #   * ``insider_dataset_processed`` — S11 sec_insider_ingest_from_dataset
-    #     and S19 sec_insider_transactions_backfill + S20 sec_form3_ingest
-    #     all write ``ownership_insiders_observations``. Without an
-    #     ordering cap, PR-2 ``as_completed`` parallelism would let the
-    #     bulk path and the legacy backfills run concurrently against
-    #     overlapping (instrument_id, holder, observed_at) rows —
-    #     identical row-lock storm shape as the S8↔S15 case PR-1292
-    #     fixed.
-    #
-    #   * ``institutional_dataset_processed`` — S10 sec_13f_ingest_from_dataset
-    #     and S22 sec_13f_recent_sweep both write
-    #     ``ownership_institutions_observations``. Same pattern;
-    #     largest write fanout of any audited pair (institutional 13F
-    #     rows during a full bootstrap can total tens of millions).
-    #
-    #   * ``nport_dataset_processed`` (#1340) — S12 sec_nport_ingest_from_dataset
-    #     and S23 sec_n_port_ingest both write ``ownership_funds_observations``.
-    #     They run on different lanes (db vs sec_rate) so PR-2 ``as_completed``
-    #     parallelism would let them write concurrently. Same row-lock shape;
-    #     ALSO required for correctness — S23 reads the ``n_port_ingest_log``
-    #     rows S12 seeds (#1340) to skip bulk-loaded accessions, so S23 must
-    #     run after S12 commits.
-    #
-    # All caps are PROVIDED on SUCCESS by their respective bulk
-    # ingester and ON SKIP for cascade-skip parity. Required by the
-    # legacy stages downstream so they serialise after the bulk
-    # ingester terminalises.
-    "insider_dataset_processed",
-    "institutional_dataset_processed",
-    "nport_dataset_processed",
+    # #1437 — the ``insider_dataset_processed`` / ``institutional_dataset_processed``
+    # / ``nport_dataset_processed`` ordering caps (#1233's extension of the
+    # PR-1292 pattern to the other bulk/legacy pairs) were removed: the
+    # legacy per-CIK stages that consumed them (S19/S20/S22/S23) were
+    # dropped by #1413, leaving the caps provided-but-unconsumed. If a
+    # legacy stage that writes ``ownership_*_observations`` ever returns
+    # to the bootstrap graph, reintroduce an ordering cap from the bulk
+    # ingester (see the PR-1292 ``submissions_processed`` shape above).
     # #1419 (P4) — S24 ``ownership_observations_backfill`` refreshed the
     # ``ownership_*_current`` tables the rollup reads. Provided ONLY by S24
     # (terminal db-lane stage that otherwise advertised nothing), required by
@@ -445,25 +341,17 @@ _STAGE_PROVIDES: Final[dict[str, tuple[Capability, ...]]] = {
     "sec_submissions_ingest": ("filing_events_seeded", "submissions_processed"),
     "sec_companyfacts_ingest": ("fundamentals_raw_seeded",),
     # Bulk ownership ingester covers both insider transactions + Form 3.
-    # #1233 lock-contention cap-gates: bulk ingesters advertise an
-    # ordering cap on top of their content caps. Required by S19/S20
-    # (insider) and S22 (institutional) so the legacy backfills wait
-    # for the bulk path to terminalise. See ``insider_dataset_processed``
-    # / ``institutional_dataset_processed`` docstrings.
     # #1413 — bulk insider dataset ingest writes ownership_insiders_observations
     # for BOTH Form 4 transactions AND Form 3 initial-holdings (NONDERIV_HOLDING
     # path), so it carries the insider content cap directly. ``form3_inputs_seeded``
     # removed entirely (the legacy per-CIK S20 that owned it is dropped; S24 no
     # longer requires a form3-specific gate — bulk S11 covers form3 observations).
-    "sec_insider_ingest_from_dataset": (
-        "insider_inputs_seeded",
-        "insider_dataset_processed",
-    ),
-    "sec_13f_ingest_from_dataset": (
-        "institutional_inputs_seeded",
-        "institutional_dataset_processed",
-    ),
-    "sec_nport_ingest_from_dataset": ("nport_inputs_seeded", "nport_dataset_processed"),
+    # #1437 — the ``*_dataset_processed`` ordering caps these three used to
+    # advertise on top of the content caps were removed (consumers dropped
+    # by #1413; see the Capability Literal comment).
+    "sec_insider_ingest_from_dataset": ("insider_inputs_seeded",),
+    "sec_13f_ingest_from_dataset": ("institutional_inputs_seeded",),
+    "sec_nport_ingest_from_dataset": ("nport_inputs_seeded",),
     # #1413 — S14 sec_submissions_files_walk + S15 filings_history_seed
     # dropped; ``filing_events_seeded`` re-homed to S8 (success) + S16.
     # S16 sec_first_install_drain seeds filing_events from bulk. Step 2.3
@@ -505,21 +393,9 @@ _STAGE_PROVIDES_ON_SKIP: Final[dict[str, tuple[Capability, ...]]] = {
     # as success" — the cap is purely an ordering constraint on S15,
     # not a content-validity signal.
     "sec_submissions_ingest": ("submissions_processed",),
-    # #1233 lock-contention cap-gates: same cascade-skip parity as
-    # ``sec_submissions_ingest``. If S7 sec_bulk_download is skipped
-    # on slow-connection fallback (#1041), S10/S11 cascade-skip too —
-    # but the ordering cap still flows so the legacy ingesters
-    # proceed without waiting on a bulk run that will never happen.
-    # The cap is purely an ordering constraint; the cap-on-skip does
-    # NOT masquerade as "content was ingested", same as the existing
-    # ``submissions_processed`` cascade-skip entry.
-    "sec_insider_ingest_from_dataset": ("insider_dataset_processed",),
-    "sec_13f_ingest_from_dataset": ("institutional_dataset_processed",),
-    # #1340 — S12 NPORT bulk ingester. Cascade-skip parity: if S7 is
-    # skipped on slow-connection fallback, S12 cascade-skips but the
-    # ordering cap still flows so S23 proceeds (it falls back to the
-    # full HTTP enumeration path with an empty n_port_ingest_log).
-    "sec_nport_ingest_from_dataset": ("nport_dataset_processed",),
+    # #1437 — the ``*_dataset_processed`` cascade-skip parity entries for
+    # S10/S11/S12 were removed with the caps themselves (consumers dropped
+    # by #1413).
 }
 
 
@@ -606,12 +482,11 @@ _STRICT_CAP_PROVIDER_EXCLUSIONS: Final[dict[Capability, frozenset[str]]] = {}
 # etc.) deliberately stay non-ordering: they must observe actual
 # content writes to be satisfied. Ordering caps only need the
 # upstream stage to be done.
+# (#1437 — the three ``*_dataset_processed`` ordering caps were removed
+# from this set with the caps themselves.)
 _ORDERING_ONLY_CAPS: Final[frozenset[Capability]] = frozenset(
     {
         "submissions_processed",
-        "insider_dataset_processed",
-        "institutional_dataset_processed",
-        "nport_dataset_processed",
     }
 )
 
@@ -672,9 +547,8 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
     # ``filing_events_seeded`` (the ``submissions_secondary_pages_walked``
     # requirement is dropped: S16 no longer provides it, and recent
     # deep-history bodies are lazy-on-view per #1343). The
-    # ``*_dataset_processed`` ordering caps now have no consumers (the legacy
-    # stages that required them are gone) — they remain provided-but-
-    # unconsumed (harmless; cleanup later).
+    # ``*_dataset_processed`` ordering caps lost their consumers here and
+    # were removed end-to-end by #1437.
     "sec_business_summary_bootstrap": CapRequirement(all_of=("filing_events_seeded",)),
     "sec_8k_events_ingest": CapRequirement(all_of=("filing_events_seeded",)),
     # #1174 — dedicated MF directory refresh (bounded mf.json fetch).
@@ -1179,8 +1053,10 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # in <10 min on a fast connection; the C-stages below ingest
     # locally with no rate-budget cost.
     _spec("sec_bulk_download", 7, "sec_bulk_download", JOB_SEC_BULK_DOWNLOAD),
-    # Phase C — DB-bound bulk ingesters (#1020). Parallel within db
-    # lane (max_concurrency=5).
+    # Phase C — DB-bound bulk ingesters (#1020). Parallel CROSS-lane:
+    # ``_STAGE_LANE_OVERRIDES`` re-homes each onto its own per-family
+    # lane (#1141), bounded by ``_HEAVY_INGEST_MAX_CONCURRENCY`` = 2
+    # (#1426 memory guard).
     _spec("sec_submissions_ingest", 8, "db", JOB_SEC_SUBMISSIONS_INGEST),
     _spec("sec_companyfacts_ingest", 9, "db", JOB_SEC_COMPANYFACTS_INGEST),
     _spec("sec_13f_ingest_from_dataset", 10, "db", JOB_SEC_13F_INGEST_FROM_DATASET),
@@ -1193,7 +1069,7 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # joins on the resolved CUSIP map. The sweep promotes each
     # OpenFIGI-resolved CUSIP into ``external_identifiers`` with
     # provider='openfigi', then leaves the unresolved row in place
-    # (a subsequent ``_load_cusip_map`` read picks the new mapping up
+    # (a subsequent ``load_bulk_cusip_map`` read picks the new mapping up
     # via the WHERE provider IN ('sec', 'openfigi') filter).
     #
     # Lane=``openfigi`` so it is disjoint from every SEC budget — the
@@ -1273,8 +1149,8 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # The operator-visible ownership rollup renders from the bulk
     # observation tables; the legacy per-CIK sweeps remain as steady-state
     # scheduled jobs (post-complete) for the recency-window delta + the
-    # legacy ``institutional_holdings`` table. The dynamic recency sentinels
-    # (_PARAM_DYNAMIC_BOOTSTRAP_*) are now unused by the bootstrap path.
+    # legacy ``institutional_holdings`` table. (#1437 — the dynamic recency
+    # sentinel machinery the dropped stages used was removed outright.)
     _spec("ownership_observations_backfill", 24, "db", "ownership_observations_backfill"),
     # Stream A PR-C2 T1.2 (#1233): S25 dispatches the bootstrap-only
     # ``fundamentals_sync_bootstrap`` invoker (NOT the steady-state
@@ -2247,19 +2123,19 @@ def _phase_batched_dispatch(
                 if not _heavy_ingest_admits(heavy_in_flight_keys, stage.stage_key):
                     continue  # heavy-ingest at cap; leave pending
 
-                # PR1c #1064: resolve dispatch-time dynamic values
-                # (e.g. _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF →
-                # ``today() - 380d``) and validate via the canonical
-                # registry validator with allow_internal_keys=True
-                # so audit-only keys (``source_label``) pass through.
-                # Validation failure is a programmer error in the
-                # stage spec — fail-fast, dispatch surfaces it as a
-                # stage error.
-                resolved = _resolve_dynamic_params(stage.params)
+                # PR1c #1064: validate via the canonical registry
+                # validator with allow_internal_keys=True so audit-only
+                # keys (``source_label``) pass through. Validation
+                # failure is a programmer error in the stage spec —
+                # fail-fast, dispatch surfaces it as a stage error.
+                # (#1437 — the dispatch-time dynamic-sentinel resolution
+                # step that used to precede this was removed: the per-CIK
+                # stages that carried ``<dynamic:...>`` params were
+                # dropped by #1413 and no current spec sets one.)
                 try:
                     validated_params = validate_job_params(
                         stage.job_name,
-                        resolved,
+                        dict(stage.params),
                         allow_internal_keys=True,
                     )
                 except ParamValidationError as exc:

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -2934,8 +2934,9 @@ def run_bootstrap_orchestrator() -> None:
 # lifted into params-aware ``JobInvoker`` bodies in
 # ``app/workers/scheduler.py`` (``filings_history_seed``,
 # ``sec_first_install_drain``, extended ``sec_13f_quarterly_sweep``).
-# Bootstrap stages 14, 15, 21 dispatch the promoted bodies via
-# ``StageSpec.params``; the deleted JOB_* constants are gone too,
+# (#1413 later dropped the filings_history_seed / 13F-sweep stages from
+# the bootstrap graph; S16 ``sec_first_install_drain`` is the surviving
+# params-carrying stage.) The deleted JOB_* constants are gone too,
 # so any straggling reference fails fast on import.
 
 

--- a/app/services/cusip_resolver.py
+++ b/app/services/cusip_resolver.py
@@ -1412,7 +1412,7 @@ def _tombstone_bulk_rows_for_cusip(
     (different filer × period). A successful OpenFIGI resolution
     means the CUSIP→instrument_id mapping is now in
     ``external_identifiers``; the next bulk ingest pass will load
-    the mapping via ``_load_cusip_map`` and write into typed tables
+    the mapping via ``load_bulk_cusip_map`` and write into typed tables
     directly, so the unresolved rows have served their purpose.
 
     Scoped to ``source IS NOT NULL`` so the legacy partition is

--- a/app/services/cusip_resolver.py
+++ b/app/services/cusip_resolver.py
@@ -225,6 +225,49 @@ class _Match:
 BulkCusipSource = Literal["bulk_13f_dataset", "bulk_nport_dataset"]
 
 
+def load_bulk_cusip_map(conn: psycopg.Connection[Any]) -> dict[str, int]:
+    """Preload all CUSIP → instrument_id mappings (SEC + OpenFIGI) into a dict.
+
+    Shared by the 13F and N-PORT bulk dataset ingesters (#1437 — was
+    duplicated lock-step in both modules). INFOTABLE rows can number in
+    the millions per archive; doing one indexed DB query per row is the
+    dominant cost of the bulk ingest. Loading the entire map once at the
+    top of ``ingest_*_dataset_archive`` collapses millions of round
+    trips into one SELECT. CUSIP universe is bounded (~13k SEC Form 13F
+    securities list rows + ~1500 universe instruments + OpenFIGI
+    promotions), so the dict fits comfortably in memory.
+
+    Provider widening (#1233 PR-1b): the WHERE filter reads
+    ``provider IN ('sec', 'openfigi')`` so post-bulk-sweep OpenFIGI
+    promotions become visible to the next bulk ingest pass without
+    a schema-level UNION view. The SEC-curated mappings remain
+    authoritative — ``ORDER BY is_primary DESC, external_identifier_id ASC``
+    means a SEC ``is_primary=TRUE`` row wins over an OpenFIGI
+    ``is_primary=FALSE`` row when both exist for the same CUSIP
+    (the OpenFIGI sweep deliberately writes ``is_primary=FALSE``;
+    see ``_promote_openfigi_mapping``). The CUSIP-uniqueness constraint
+    (``uq_external_identifiers_provider_value`` on
+    ``(provider, identifier_type, identifier_value)``) means at most
+    one row per (provider, cusip), so the dedup happens at the row
+    level — ``setdefault`` keeps the first-seen mapping per CUSIP
+    after the ORDER BY.
+    """
+    out: dict[str, int] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT identifier_value, instrument_id
+            FROM external_identifiers
+            WHERE provider IN ('sec', 'openfigi') AND identifier_type = 'cusip'
+            ORDER BY is_primary DESC, external_identifier_id ASC
+            """,
+        )
+        for row in cur.fetchall():
+            cusip, instrument_id = row
+            out.setdefault(str(cusip).strip().upper(), int(instrument_id))
+    return out
+
+
 def record_unresolved_cusip_from_bulk(
     conn: psycopg.Connection[Any],
     *,

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -57,6 +57,7 @@ from app.services.cusip_resolver import (
     delete_resolved_bulk_markers,
     flush_unresolved_cusips_bulk,
     in_window_bulk_markers_exist,
+    load_bulk_cusip_map,
     reconcile_survived_markers,
 )
 from app.services.institutional_holdings import thirteen_f_retention_cutoff
@@ -140,57 +141,6 @@ def _persist_figi_external_identifiers(
         cur.executemany(_FIGI_UPSERT_SQL, params)
         if cur.rowcount and cur.rowcount > 0:
             result.figi_identifiers_written += cur.rowcount
-
-
-def _load_cusip_map(conn: psycopg.Connection[Any]) -> dict[str, int]:
-    """Preload all CUSIP → instrument_id mappings (SEC + OpenFIGI) into a dict.
-
-    13F + N-PORT INFOTABLE rows can number in the millions per
-    archive; doing one indexed DB query per row is the dominant
-    cost of the bulk ingest. Loading the entire map once at the
-    top of ingest_*_dataset_archive collapses millions of round
-    trips into one SELECT. CUSIP universe is bounded (~13k SEC
-    Form 13F securities list rows + ~1500 universe instruments +
-    OpenFIGI promotions), so the dict fits comfortably in memory.
-
-    Codex sweep BLOCKING for #1020.
-
-    Provider widening (#1233 PR-1b): the WHERE filter now reads
-    ``provider IN ('sec', 'openfigi')`` so post-bulk-sweep OpenFIGI
-    promotions become visible to the next bulk ingest pass without
-    a schema-level UNION view. The SEC-curated mappings remain
-    authoritative — ``ORDER BY is_primary DESC, external_identifier_id ASC``
-    means a SEC ``is_primary=TRUE`` row wins over an OpenFIGI
-    ``is_primary=FALSE`` row when both exist for the same CUSIP
-    (the OpenFIGI sweep deliberately writes ``is_primary=FALSE``;
-    see ``app/services/cusip_resolver.py::_promote_openfigi_mapping``).
-    The CUSIP-uniqueness constraint
-    (``uq_external_identifiers_provider_value`` on
-    ``(provider, identifier_type, identifier_value)``) means at most
-    one row per (provider, cusip), so the dedup happens at the row
-    level — ``setdefault`` keeps the first-seen mapping per CUSIP
-    after the ORDER BY.
-    """
-    out: dict[str, int] = {}
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT identifier_value, instrument_id
-            FROM external_identifiers
-            WHERE provider IN ('sec', 'openfigi') AND identifier_type = 'cusip'
-            ORDER BY is_primary DESC, external_identifier_id ASC
-            """,
-        )
-        for row in cur.fetchall():
-            cusip, instrument_id = row
-            key = str(cusip).strip().upper()
-            # First (highest priority) wins per (CUSIP) — match the
-            # `ORDER BY is_primary DESC` shape of the per-row query
-            # this replaces. SEC primary > SEC non-primary > OpenFIGI
-            # non-primary by construction (OpenFIGI sweep never writes
-            # is_primary=TRUE).
-            out.setdefault(key, int(instrument_id))
-    return out
 
 
 def _parse_filing_date(value: str | None) -> datetime | None:
@@ -619,7 +569,7 @@ def ingest_13f_dataset_archive(
     # Preload CUSIP → instrument map once. Per-row DB lookup would
     # otherwise dominate cost on multi-million-row INFOTABLE.tsv
     # (Codex sweep BLOCKING).
-    cusip_map = _load_cusip_map(conn)
+    cusip_map = load_bulk_cusip_map(conn)
 
     # PR6 #1233 §4.5 — archive-level retention cutoff. Resolve once
     # OUTSIDE the per-row INFOTABLE loop so a multi-million-row drain

--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -50,6 +50,7 @@ from app.services.cusip_resolver import (
     delete_resolved_bulk_markers,
     flush_unresolved_cusips_bulk,
     in_window_bulk_markers_exist,
+    load_bulk_cusip_map,
     reconcile_survived_markers,
 )
 from app.services.n_port_ingest import n_port_retention_cutoff
@@ -168,31 +169,6 @@ def _parse_decimal(value: str | None) -> Decimal | None:
     except (InvalidOperation, ValueError) as _exc:
         del _exc
         return None
-
-
-def _load_cusip_map(conn: psycopg.Connection[Any]) -> dict[str, int]:
-    """Preload all CUSIP → instrument_id mappings (SEC + OpenFIGI).
-
-    See ``sec_13f_dataset_ingest._load_cusip_map`` for rationale and
-    the provider-widening note (#1233 PR-1b) — same pattern duplicated
-    here to keep ingester modules independent. The two readers MUST
-    stay in lock-step: a future curated mapping that only one sees
-    silently mis-aligns row counts between 13F and N-PORT.
-    """
-    out: dict[str, int] = {}
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT identifier_value, instrument_id
-            FROM external_identifiers
-            WHERE provider IN ('sec', 'openfigi') AND identifier_type = 'cusip'
-            ORDER BY is_primary DESC, external_identifier_id ASC
-            """,
-        )
-        for row in cur.fetchall():
-            cusip, instrument_id = row
-            out.setdefault(str(cusip).strip().upper(), int(instrument_id))
-    return out
 
 
 def _open_tsv(zf: zipfile.ZipFile, *candidate_names: str) -> list[dict[str, str]]:
@@ -502,7 +478,7 @@ def ingest_nport_dataset_archive(
     if ingest_run_id is None:
         ingest_run_id = uuid4()
     result = NPortIngestResult()
-    cusip_map = _load_cusip_map(conn)
+    cusip_map = load_bulk_cusip_map(conn)
 
     # #1233 PR-1a — buffer of (cusip, filer_cik, period_end) triples
     # for every unresolved-CUSIP holding. Mirrors the 13F path.

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -6076,12 +6076,13 @@ def sec_n_port_ingest(params: Mapping[str, Any]) -> None:
     PR7 #1233 §4.6 — params-aware (mirror of #1064 PR1c lift for
     ``sec_13f_quarterly_sweep``). Accepts:
 
-      * ``min_last_seen_filed_at`` — bootstrap stage 22 passes
-        ``today - 380d`` (UTC midnight) via the
-        ``_PARAM_DYNAMIC_BOOTSTRAP_NPORT_CUTOFF`` sentinel; daily /
-        Admin "Run now" / manual sweep paths pass an empty dict, which
-        resolves to ``None`` here → full cohort (safety-net for
-        previously-inactive trusts re-emerging — #1010 precedent).
+      * ``min_last_seen_filed_at`` — optional recency cutoff. The
+        bootstrap stage that used to pass ``today - 380d`` via a
+        dispatch-time sentinel was dropped by #1413 (and the sentinel
+        machinery removed by #1437); daily / Admin "Run now" / manual
+        sweep paths pass an empty dict, which resolves to ``None``
+        here → full cohort (safety-net for previously-inactive trusts
+        re-emerging — #1010 precedent).
       * ``use_bulk_zip`` (bool, bootstrap-only via JOB_INTERNAL_KEYS) —
         route the PRIMARY per-CIK ``submissions/CIK<10>.json`` reads
         (the S23 enumeration long-pole) through the local

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -917,30 +917,11 @@ def test_submissions_processed_provided_by_s8_on_success_and_skip() -> None:
 
 
 # ---------------------------------------------------------------------------
-# #1233 extended lock-contention cap-gates — same pattern as PR-1292
-# for the other bulk/legacy pairs flagged by the 2026-05-23 audit.
+# #1233 extended lock-contention cap-gates — PR-1292 pattern. #1437: the
+# three ``*_dataset_processed`` ordering caps were removed (their legacy
+# consumers were dropped by #1413), so only ``submissions_processed``
+# remains; its provider/skip invariants are pinned below.
 # ---------------------------------------------------------------------------
-
-
-def test_dataset_processed_caps_provided_by_bulk_ingesters_on_success_and_skip() -> None:
-    """Companion invariant to the requires-side tests. Each new
-    ordering cap is advertised by its bulk ingester on BOTH success
-    AND skip — the skip entry preserves cascade-skip parity (S7
-    skipped → S10/S11 cascade-skipped → legacy chain still gets the
-    ordering cap satisfied so it does not deadlock).
-    """
-    from app.services.bootstrap_orchestrator import (
-        _STAGE_PROVIDES,
-        _STAGE_PROVIDES_ON_SKIP,
-    )
-
-    assert "insider_dataset_processed" in _STAGE_PROVIDES["sec_insider_ingest_from_dataset"]
-    assert "insider_dataset_processed" in _STAGE_PROVIDES_ON_SKIP["sec_insider_ingest_from_dataset"]
-    assert "institutional_dataset_processed" in _STAGE_PROVIDES["sec_13f_ingest_from_dataset"]
-    assert "institutional_dataset_processed" in _STAGE_PROVIDES_ON_SKIP["sec_13f_ingest_from_dataset"]
-    # #1340 — NPORT family: S12 bulk provides on success + skip.
-    assert "nport_dataset_processed" in _STAGE_PROVIDES["sec_nport_ingest_from_dataset"]
-    assert "nport_dataset_processed" in _STAGE_PROVIDES_ON_SKIP["sec_nport_ingest_from_dataset"]
 
 
 def test_ordering_only_caps_disjoint_from_strict_gate_caps() -> None:
@@ -960,9 +941,6 @@ def test_ordering_only_caps_disjoint_from_strict_gate_caps() -> None:
     assert _ORDERING_ONLY_CAPS == frozenset(
         {
             "submissions_processed",
-            "insider_dataset_processed",
-            "institutional_dataset_processed",
-            "nport_dataset_processed",
         }
     ), (
         "_ORDERING_ONLY_CAPS membership changed without updating the test. "
@@ -982,38 +960,32 @@ def test_ordering_only_caps_disjoint_from_strict_gate_caps() -> None:
 def test_ordering_caps_satisfied_on_terminal_failure_but_content_caps_are_not() -> None:
     """Codex 2 LOW on #1233 cap-gates: prove the terminal-failure
     escape hatch in ``_satisfied_capabilities`` works as documented.
-    An ordering cap (``insider_dataset_processed``) advertised by
-    ``sec_insider_ingest_from_dataset`` (S11) MUST be satisfied
-    whenever S11 reaches blocked / error / cancelled. The adjacent
-    content cap (``insider_inputs_seeded``) advertised by the same
-    stage MUST NOT — content caps stay dead on terminal failure so
-    downstream content consumers correctly block.
+    The ordering cap (``submissions_processed``) MUST be satisfied
+    whenever its provider reaches blocked / error / cancelled; content
+    caps advertised by terminal-failed stages MUST NOT — they stay dead
+    so downstream content consumers correctly block.
 
-    Tests the exact bug pattern Codex caught on
-    ``test_partial_bulk_failure_legacy_recovers`` regression: ordering
-    cap must flow through to legacy chain, content cap must not.
+    (#1437 — the ``*_dataset_processed`` legs were removed with the
+    caps; the content-cap-stays-dead half is preserved on the bulk
+    ingesters below.)
     """
     from app.services.bootstrap_orchestrator import _satisfied_capabilities
 
+    # Content caps stay dead on terminal failure of the bulk ingesters.
     for terminal_status in ("blocked", "error", "cancelled"):
         caps = _satisfied_capabilities(
-            statuses={"sec_insider_ingest_from_dataset": terminal_status},
-            rows_processed={"sec_insider_ingest_from_dataset": None},
-        )
-        assert "insider_dataset_processed" in caps, (
-            f"ordering cap missing on status={terminal_status!r} — legacy recovery chain would falsely block"
+            statuses={
+                "sec_insider_ingest_from_dataset": terminal_status,
+                "sec_13f_ingest_from_dataset": terminal_status,
+            },
+            rows_processed={
+                "sec_insider_ingest_from_dataset": None,
+                "sec_13f_ingest_from_dataset": None,
+            },
         )
         assert "insider_inputs_seeded" not in caps, (
             f"content cap leaked on status={terminal_status!r} — downstream consumer would falsely proceed"
         )
-
-    # Same shape for institutional pair.
-    for terminal_status in ("blocked", "error", "cancelled"):
-        caps = _satisfied_capabilities(
-            statuses={"sec_13f_ingest_from_dataset": terminal_status},
-            rows_processed={"sec_13f_ingest_from_dataset": None},
-        )
-        assert "institutional_dataset_processed" in caps
         assert "institutional_inputs_seeded" not in caps
 
     # Bot WARNING on PR #1299: ``submissions_processed`` is also a

--- a/tests/test_cusip_resolver_openfigi.py
+++ b/tests/test_cusip_resolver_openfigi.py
@@ -478,11 +478,11 @@ class TestProviderWidening:
         assert coverage.cohort >= 1
 
     def test_load_cusip_map_reads_openfigi_rows(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
-        """The 13F + N-PORT ingest preload (``_load_cusip_map``) must
-        return OpenFIGI promotions. Without this, the post-sweep bulk
-        re-ingest pass would still record the same CUSIP as unresolved."""
-        from app.services.sec_13f_dataset_ingest import _load_cusip_map as load_13f
-        from app.services.sec_nport_dataset_ingest import _load_cusip_map as load_nport
+        """The 13F + N-PORT ingest preload (``load_bulk_cusip_map``,
+        shared since #1437) must return OpenFIGI promotions. Without
+        this, the post-sweep bulk re-ingest pass would still record the
+        same CUSIP as unresolved."""
+        from app.services.cusip_resolver import load_bulk_cusip_map
 
         _seed_instrument(ebull_test_conn, instrument_id=70200, symbol="LMAP", company_name="Load Map Inc")
         cusip = "LMAPCUSIP"
@@ -500,11 +500,7 @@ class TestProviderWidening:
             )
         ebull_test_conn.commit()
 
-        m13f = load_13f(ebull_test_conn)
-        mnport = load_nport(ebull_test_conn)
-
-        assert m13f.get(cusip) == 70200
-        assert mnport.get(cusip) == 70200
+        assert load_bulk_cusip_map(ebull_test_conn).get(cusip) == 70200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cusip_resolver_openfigi.py
+++ b/tests/test_cusip_resolver_openfigi.py
@@ -428,7 +428,7 @@ class TestSweepSelection:
 
 
 # ---------------------------------------------------------------------------
-# Coverage floor — _load_cusip_map + compute_cusip_coverage widening
+# Coverage floor — load_bulk_cusip_map + compute_cusip_coverage widening
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -135,26 +135,19 @@ class TestStageSpecParamsField:
             assert hasattr(stage, "params"), f"stage {stage.stage_key} missing params"
 
     def test_only_bootstrap_lifted_stages_have_params(self) -> None:
-        """PR1c populated stages 14, 15, 21 (the bespoke-wrapper lift targets);
-        every other stage stays with the empty default until a future
-        ParamMetadata expansion lands."""
-        # PR1c #1064 — lifted bespoke wrappers. The job registry audit
-        # §4 enumerates these three; any addition must update the audit
-        # and this assertion in lockstep.
+        """PR1c populated the bespoke-wrapper lift targets; every other
+        stage stays with the empty default until a future ParamMetadata
+        expansion lands."""
+        # PR1c #1064 — lifted bespoke wrappers; any addition must update
+        # the job registry audit §4 and this assertion in lockstep.
+        # #1437 — trimmed to the surviving stage: #1413 dropped
+        # ``filings_history_seed`` / ``sec_13f_recent_sweep`` /
+        # ``sec_n_port_ingest`` from the bootstrap graph (their entries
+        # here were dead — the loop below only checks stages present in
+        # ``_BOOTSTRAP_STAGE_SPECS``), and the dispatch-time dynamic
+        # param sentinels they carried were removed outright.
         lifted_stage_keys = {
-            "filings_history_seed",
             "sec_first_install_drain",
-            "sec_13f_recent_sweep",
-            # PR8 #1233 §4.12 — sec_n_csr_bootstrap_drain previously
-            # carried ``horizon_days=730`` params; the param was
-            # removed when N_CSR_RETENTION_DAYS became the single
-            # source of truth, so the stage now dispatches with
-            # ``params={}`` and is intentionally absent from this set.
-            # PR7 #1233 §4.6 — sec_n_port_ingest dispatches with
-            # ``min_last_seen_filed_at`` resolved at dispatch time to
-            # ``today - 380d`` (UTC midnight). Mirror of the #1010
-            # cohort bound on stage 21's sec_13f_recent_sweep.
-            "sec_n_port_ingest",
         }
         for stage in _BOOTSTRAP_STAGE_SPECS:
             if stage.stage_key in lifted_stage_keys:

--- a/tests/test_pr1c_wrapper_lift.py
+++ b/tests/test_pr1c_wrapper_lift.py
@@ -4,10 +4,10 @@ Three behaviour groups:
 
 1. **Deletion** — the three deleted symbols are gone from
    ``app.services.bootstrap_orchestrator``.
-2. **StageSpec.params** — bootstrap stages 14, 15, 21 carry the
-   exact params dict the deleted wrappers used to hardcode in their
-   bodies. ``_resolve_dynamic_params`` materialises the dispatch-time
-   13F cutoff sentinel.
+2. **StageSpec.params** — surviving bootstrap stages carry the exact
+   params dict the deleted wrappers used to hardcode in their bodies.
+   (#1437 — the ``_resolve_dynamic_params`` sentinel machinery and its
+   tests were removed: no current stage spec sets a dynamic param.)
 3. **Promoted invoker contract** — ``filings_history_seed``,
    ``sec_first_install_drain``, ``sec_13f_quarterly_sweep`` accept the
    widened ``Mapping[str, Any]`` and honour the operator-tunable
@@ -16,17 +16,12 @@ Three behaviour groups:
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date
 from typing import Any
 
 import pytest
 
-from app.services.bootstrap_orchestrator import (
-    _BOOTSTRAP_13F_RECENCY_DAYS,
-    _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF,
-    _resolve_dynamic_params,
-    get_bootstrap_stage_specs,
-)
+from app.services.bootstrap_orchestrator import get_bootstrap_stage_specs
 
 # ---------------------------------------------------------------------------
 # 1. Deletion regression — wrappers + JOB_BOOTSTRAP_* constants gone.
@@ -91,56 +86,6 @@ class TestStageSpecParams:
             "use_bulk_zip": True,
             "follow_pagination": False,
         }
-
-
-class TestResolveDynamicParams:
-    """``_resolve_dynamic_params`` materialises the dispatch-time 13F cutoff."""
-
-    def test_sentinel_resolves_to_today_minus_recency_days(self) -> None:
-        out = _resolve_dynamic_params(
-            {"min_period_of_report": _PARAM_DYNAMIC_BOOTSTRAP_13F_CUTOFF, "source_label": "x"}
-        )
-        assert out["min_period_of_report"] == date.today() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS)
-        # Pass-through of non-sentinel keys.
-        assert out["source_label"] == "x"
-
-    def test_concrete_date_passes_through(self) -> None:
-        fixed = date(2024, 1, 1)
-        out = _resolve_dynamic_params({"min_period_of_report": fixed})
-        assert out["min_period_of_report"] == fixed
-
-    def test_no_min_period_pass_through(self) -> None:
-        out = _resolve_dynamic_params({"days_back": 365})
-        assert out == {"days_back": 365}
-
-    def test_min_last_13f_hr_at_sentinel_resolves_to_utc_midnight(self) -> None:
-        """#1010 — HR-recency cutoff materialises as UTC start-of-day
-        ``today() - 380d``. Exact equality pins the invariant against
-        future time-of-day regressions (Codex 1b)."""
-        from datetime import UTC, datetime, time
-
-        from app.services.bootstrap_orchestrator import (
-            _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF,
-        )
-
-        out = _resolve_dynamic_params({"min_last_13f_hr_at": _PARAM_DYNAMIC_BOOTSTRAP_13F_HR_CUTOFF})
-        # Mirror the resolver: UTC date, not local ``date.today()``.
-        # On a non-UTC dev host around the midnight boundary the two
-        # can differ by one day (Codex 2 MEDIUM).
-        expected = datetime.combine(
-            datetime.now(tz=UTC).date() - timedelta(days=_BOOTSTRAP_13F_RECENCY_DAYS),
-            time(0, 0),
-            tzinfo=UTC,
-        )
-        assert out["min_last_13f_hr_at"] == expected
-
-    def test_min_last_13f_hr_at_concrete_value_passes_through(self) -> None:
-        """Concrete datetime ≠ sentinel → returned unchanged."""
-        from datetime import UTC, datetime
-
-        fixed = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
-        out = _resolve_dynamic_params({"min_last_13f_hr_at": fixed})
-        assert out["min_last_13f_hr_at"] == fixed
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Safe-now cleanup sweep from the Codex tech-debt audit (#1437). Net −247 lines, no behaviour change on any live path. Closes #1437.

### 1. Stale comments fixed
- Orchestrator module docstring no longer hardcodes a stage count (claimed 26; actual is 21 since #1413 — verified by counting `_BOOTSTRAP_STAGE_SPECS` entries). It now points at the spec tuple instead, so the next redesign can't re-stale it.
- Phase C comment claimed "Parallel within db lane (max_concurrency=5)" — reality is per-family lanes (#1141) bounded by `_HEAVY_INGEST_MAX_CONCURRENCY = 2` (#1426). Comment now states that.

### 2. `bootstrap_stages.expected_units` / `units_done` — KEPT (reconciliation decision)
The issue flagged these as dead columns (zero writers — verified: only SELECT-side readers through to the FE types). It also noted the conflict with #1005, which proposes WIRING `units_done` for live mid-stage progress. #1005 is open; dropping the columns now would conflict with it. Decision: keep, #1005 owns the wiring. No code change for this item.

### 3. CUSIP-map loader dedup
`sec_13f_dataset_ingest._load_cusip_map` and `sec_nport_dataset_ingest._load_cusip_map` were lock-step duplicates (the N-PORT copy carried an explicit "MUST stay in lock-step" warning). Extracted to `cusip_resolver.load_bulk_cusip_map` — identical SQL, normalisation, ORDER BY and first-wins `setdefault` semantics (Codex-verified equivalence). The lock-step risk is gone by construction.

### 4. Dead symbols removed
- **Dynamic param sentinels**: `_PARAM_DYNAMIC_BOOTSTRAP_{13F,13F_HR,NPORT}_CUTOFF`, `_resolve_dynamic_params`, the dispatch-time resolution call, and the recency-day constants they consumed. No stage spec sets a dynamic param since #1413 dropped the per-CIK stages, and `bootstrap_stages` has **no params column** (verified against dev schema) so no DB row can carry a sentinel into a re-run either. The steady-state `sec_13f_quarterly_sweep` / `sec_n_port_ingest` job bodies still honour concrete `min_*` params — only the sentinel indirection died.
- **Ordering caps** `insider_dataset_processed` / `institutional_dataset_processed` / `nport_dataset_processed`: their consumers (legacy S19/S20/S22/S23) were dropped by #1413, leaving them provided-but-unconsumed in `_STAGE_PROVIDES`, `_STAGE_PROVIDES_ON_SKIP`, the `Capability` literal and `_ORDERING_ONLY_CAPS`. `submissions_processed` is **kept** — still consumed by `sec_first_install_drain` and `sec_master_idx_gap_close` (verified). A breadcrumb comment in the Capability literal explains how to reintroduce an ordering cap if a legacy observation-writer ever returns.

## Tests
- Sentinel-resolution tests removed with the machinery (`TestResolveDynamicParams`).
- Ordering-cap invariant tests re-pinned to the surviving `submissions_processed`; the content-cap-stays-dead-on-terminal-failure coverage is preserved on the bulk ingesters.
- `test_job_registry` lifted-stage set trimmed to the surviving params-carrying stage (the dropped-stage entries were dead — the assertion loop only checks stages present in the spec tuple).
- Shared-loader OpenFIGI visibility test now imports `load_bulk_cusip_map` once.

## Security model
No auth, SQL-input, or network surface touched. The removed code paths were unreachable (no producer of sentinel values; no consumer of the caps).

## Verification (at 3966025 + hygiene commit)
- `ruff check` / `ruff format --check` / `pyright` (0 errors) — pass
- `pytest -m "not db"` 3802 passed; `pytest tests/smoke` 129 passed
- File-scoped DB tier: `test_bootstrap_orchestrator.py` + `test_pr1c_wrapper_lift.py` 51 passed, `test_cusip_resolver_openfigi.py` 22 passed, `test_sec_13f_dataset_ingest.py` + `test_sec_nport_dataset_ingest.py` 41 passed, `test_job_registry.py` 64 passed
- Codex ckpt-2: no blocking findings; 2 LOW comment-hygiene items fixed in the follow-up commit

## Tradeoffs
- Not an ETL data-path change (no parser/schema/ownership semantics) — the smoke-panel/backfill clauses don't apply; the bootstrap dispatcher change is comment-level plus removal of a no-op call.
- If a legacy per-CIK stage ever returns, its ordering cap must be consciously reintroduced (breadcrumb left in the Capability literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)