### PR TITLE
fix(#1266): timeline detail line tones by stage status — deliberate skip is not an error

### DIFF
--- a/frontend/src/pages/ProcessDetailPage.test.tsx
+++ b/frontend/src/pages/ProcessDetailPage.test.tsx
@@ -627,6 +627,35 @@ describe("ProcessDetailPage — Timeline tab (bootstrap)", () => {
     expect(chip.getAttribute("title")).toContain("fundamentals_raw_seeded");
   });
 
+  // #1266 — a deliberate skip (slow-connection fallback) must render its
+  // reason in neutral slate, not error red; a genuine error stays red.
+  it("tones the detail line neutral for a skipped stage and red for an error stage", async () => {
+    mockedDetail.mockResolvedValueOnce(
+      makeProcessRow({ process_id: "bootstrap", display_name: "First-install bootstrap" }),
+    );
+    mockedRuns.mockResolvedValueOnce([]);
+    const payload = makeTimelinePayload();
+    payload.stages[0]!.status = "skipped";
+    payload.stages[0]!.last_error =
+      "skipped: slow-connection fallback (mbps=9.514); fallback manifest written, bulk archives bypassed";
+    payload.stages[1]!.status = "error";
+    payload.stages[1]!.last_error = "TimeoutError: archive fetch timed out";
+    mockedTimeline.mockResolvedValueOnce(payload);
+    renderBootstrap();
+    fireEvent.click(await screen.findByRole("tab", { name: "Timeline" }));
+    const details = await screen.findAllByTestId("stage-detail-text");
+    expect(details.length).toBe(2);
+    const skippedDetail = details.find((d) =>
+      d.textContent?.includes("slow-connection fallback"),
+    )!;
+    const errorDetail = details.find((d) =>
+      d.textContent?.includes("TimeoutError"),
+    )!;
+    expect(skippedDetail.className).toContain("text-slate-500");
+    expect(skippedDetail.className).not.toContain("text-red");
+    expect(errorDetail.className).toContain("text-red-700");
+  });
+
   // #1409 P5 — live signals on a running stage: rate + heartbeat age.
   it("renders rate and heartbeat age on a running stage", async () => {
     mockedDetail.mockResolvedValueOnce(

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -1027,6 +1027,19 @@ const STAGE_STATUS_TONE: Record<string, string> = {
     "border-slate-400 bg-slate-100 text-slate-700 dark:border-slate-600 dark:bg-slate-800/60 dark:text-slate-300 italic",
 };
 
+// #1266 — `last_error` doubles as the skip/cancel REASON for deliberate
+// non-error terminal states (`mark_stage_skipped` / `mark_stage_cancelled`
+// write their reason into the same column). Red text on an intended
+// bypass (e.g. the slow-connection fallback) reads as a failure to the
+// operator, so the detail line tones by stage status: neutral for
+// deliberate skips/cancels, amber for blocked (upstream failure forced
+// the skip — matches its badge), red only for genuine errors.
+const STAGE_DETAIL_TONE: Record<string, string> = {
+  skipped: "text-slate-500 dark:text-slate-400",
+  cancelled: "text-slate-500 dark:text-slate-400",
+  blocked: "text-amber-700 dark:text-amber-300",
+};
+
 const ARCHIVE_TONE: Record<string, string> = {
   // Archive squares mirror their stage's status by default; once we have
   // a per-archive status surface (see #1064 follow-up) the tone can
@@ -1352,8 +1365,12 @@ function TimelineStageRow({
           ) : null}
           {stage.last_error ? (
             <div
-              className="mt-1 truncate text-xs text-red-700 dark:text-red-300"
+              className={`mt-1 truncate text-xs ${
+                STAGE_DETAIL_TONE[stage.status] ??
+                "text-red-700 dark:text-red-300"
+              }`}
               title={stage.last_error}
+              data-testid="stage-detail-text"
             >
               {stage.last_error}
             </div>


### PR DESCRIPTION
Closes #1266.

## What

Bootstrap Timeline stage rows rendered `stage.last_error` in red for EVERY status. But `mark_stage_skipped` / `mark_stage_cancelled` (`app/services/bootstrap_state.py`) write their *reason* into the same `bootstrap_stages.last_error` column — so the deliberate slow-connection fallback ("skipped: slow-connection fallback (mbps=…)") read as a failure. Operator flagged it 2026-05-22.

Fix: `STAGE_DETAIL_TONE` map in `ProcessDetailPage.tsx` tones the detail line by stage status:

- `skipped` / `cancelled` → neutral slate (deliberate, not an error)
- `blocked` → amber (upstream failure forced the skip — matches its existing amber badge)
- everything else (i.e. `error`) → red, unchanged

Plus `data-testid="stage-detail-text"` for testability.

## Acceptance mapping

- Neutral badge: the `skipped` badge was ALREADY slate via `STAGE_STATUS_TONE` (issue screenshot predates that); kept as the literal status word "skipped" rather than relabelling "INFO" — the status is information, renaming it loses it.
- Neutral body text: this PR.
- Other deliberate skip paths audited: `cancelled` (operator cancel reason — now slate), `blocked` (prereq-not-met — amber, matching badge), DAG-tab layer table already neutral (`layer.skip_reason` renders slate).

## Security model

FE-only, display tone of an existing string. No data path, auth, or API change.

## Verification

- New test: skipped stage reason renders `text-slate-500` (not red), error stage stays `text-red-700`. `ProcessDetailPage.test.tsx` 33/33.
- Full suite 921/921; typecheck + dark:check clean.
- Codex ckpt-2: "No real bugs found" (independently ran the test file: 33 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)