### PR TITLE
fix(#1267): bootstrap nudge banner deep-links to the bootstrap Timeline

### DIFF
--- a/frontend/src/components/dashboard/BootstrapNudgeBanner.tsx
+++ b/frontend/src/components/dashboard/BootstrapNudgeBanner.tsx
@@ -12,7 +12,10 @@
  *    via sessionStorage; reload re-shows it as long as bootstrap is
  *    still incomplete (we never want "dismiss forever" — the actual
  *    fix path is the admin panel).
- *  * Click "Open admin" → navigates to ``/admin``.
+ *  * Click "Open bootstrap" → deep-links to the bootstrap process detail
+ *    page with the Timeline tab preselected (#1267 — the old "/admin"
+ *    target was a no-op when the operator was already on /admin; the
+ *    detail page is always forward motion).
  */
 
 import { Link } from "react-router-dom";
@@ -92,10 +95,10 @@ export function BootstrapNudgeBanner() {
       <span>{STATUS_COPY[data.status]}</span>
       <div className="flex items-center gap-3">
         <Link
-          to="/admin"
+          to="/admin/processes/bootstrap?tab=timeline"
           className="rounded bg-white/60 dark:bg-slate-900/60 px-2 py-1 text-xs font-medium hover:bg-white dark:hover:bg-slate-900"
         >
-          Open admin
+          Open bootstrap
         </Link>
         <button
           type="button"

--- a/frontend/src/pages/ProcessDetailPage.test.tsx
+++ b/frontend/src/pages/ProcessDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -522,9 +522,9 @@ function makeTimelinePayload(): BootstrapTimelineResponse {
   };
 }
 
-function renderBootstrap() {
+function renderBootstrap(path = "/admin/processes/bootstrap") {
   return render(
-    <MemoryRouter initialEntries={["/admin/processes/bootstrap"]}>
+    <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="admin/processes/:id" element={<ProcessDetailPage />} />
       </Routes>
@@ -568,6 +568,40 @@ describe("ProcessDetailPage — Timeline tab (bootstrap)", () => {
       expect(screen.getByRole("tab", { name: "Timeline" })).toBeTruthy(),
     );
     // Fetch is gated on (tab === "timeline") AND bootstrap id.
+    expect(mockedTimeline).not.toHaveBeenCalled();
+  });
+
+  // #1267 — the bootstrap nudge banner deep-links here with ?tab=timeline.
+  it("preselects the Timeline tab and fetches /timeline when deep-linked via ?tab=timeline", async () => {
+    mockedDetail.mockResolvedValueOnce(
+      makeProcessRow({ process_id: "bootstrap", display_name: "First-install bootstrap" }),
+    );
+    mockedRuns.mockResolvedValueOnce([]);
+    mockedTimeline.mockResolvedValueOnce(makeTimelinePayload());
+    renderBootstrap("/admin/processes/bootstrap?tab=timeline");
+    // No tab click — the deep link alone must open Timeline.
+    await waitFor(() => expect(mockedTimeline).toHaveBeenCalledWith("bootstrap"));
+    expect(await screen.findByText("Universe Sync")).toBeTruthy();
+  });
+
+  // #1267 — an unknown ?tab= value must fall back to overview, and a
+  // timeline deep link on a NON-bootstrap process must reset via the
+  // existing per-process guard (restricted endpoint never called).
+  it("falls back to Overview for unknown ?tab= and for ?tab=timeline on a non-bootstrap process", async () => {
+    mockedDetail.mockResolvedValue(
+      makeProcessRow({ process_id: "sec_form4_ingest", display_name: "Form 4 ingest" }),
+    );
+    mockedRuns.mockResolvedValue([]);
+    renderAt("/admin/processes/sec_form4_ingest?tab=bogus");
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Overview" })).toBeTruthy(),
+    );
+    expect(mockedTimeline).not.toHaveBeenCalled();
+    cleanup();
+    renderAt("/admin/processes/sec_form4_ingest?tab=timeline");
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Overview" })).toBeTruthy(),
+    );
     expect(mockedTimeline).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/ProcessDetailPage.tsx
+++ b/frontend/src/pages/ProcessDetailPage.tsx
@@ -13,7 +13,7 @@
 
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import { ApiError } from "@/api/client";
 import { runJob } from "@/api/jobs";
@@ -58,6 +58,19 @@ import {
 
 type TabKey = "overview" | "history" | "errors" | "dag" | "timeline" | "advanced";
 
+// #1267 — valid `?tab=` deep-link targets. Runtime mirror of TabKey so a
+// link like /admin/processes/bootstrap?tab=timeline can preselect a tab;
+// anything unknown falls back to overview, and the existing per-process
+// guards below still reset tabs the process doesn't own.
+const TAB_KEYS: readonly TabKey[] = [
+  "overview",
+  "history",
+  "errors",
+  "dag",
+  "timeline",
+  "advanced",
+];
+
 const ORCHESTRATOR_FULL_SYNC_ID = "orchestrator_full_sync";
 const BOOTSTRAP_PROCESS_ID = "bootstrap";
 
@@ -92,7 +105,16 @@ const BOOTSTRAP_LANE_ORDER = [
 export function ProcessDetailPage() {
   const params = useParams<{ id: string }>();
   const id = params.id ?? "";
-  const [tab, setTab] = useState<TabKey>("overview");
+  // #1267 — initial tab honours a `?tab=` deep link (read once at mount;
+  // tab switches stay local state, the URL is not kept in sync).
+  const [searchParams] = useSearchParams();
+  const [tab, setTab] = useState<TabKey>(() => {
+    const requested = searchParams.get("tab");
+    return requested !== null &&
+      (TAB_KEYS as readonly string[]).includes(requested)
+      ? (requested as TabKey)
+      : "overview";
+  });
   const [busy, setBusy] = useState(false);
   const [triggerError, setTriggerError] = useState<unknown>(null);
   const [cancelError, setCancelError] = useState<unknown>(null);


### PR DESCRIPTION
Closes #1267.

## What

The bootstrap nudge banner's "Open admin" link targeted `/admin` — a no-op when the operator was already on the admin page (operator 2026-05-22: "I'm on the admin page, so where should it take me?"). Implemented the issue's recommended **option B**: the link now deep-links to `/admin/processes/bootstrap?tab=timeline` (bootstrap detail, Timeline preselected) and reads "Open bootstrap" — forward motion from any page.

Supporting change: `ProcessDetailPage` gains `?tab=` deep-link support — the initial tab is read **once at mount** from search params, validated against a `TAB_KEYS` runtime mirror of the `TabKey` union. Unknown values fall back to `overview`. The existing per-process ownership guards are untouched and still win: `?tab=timeline` on a non-bootstrap process resets to overview and the restricted `/timeline` endpoint is never called (tested), same for `dag`/`advanced`.

## Security model

FE-only routing change. The `/jobs/bootstrap/timeline` endpoint keeps its server-side restriction (non-bootstrap ids 404); the client-side guard is UX, not the security boundary.

## Conscious tradeoffs

- Tab switches stay local state; the URL is NOT kept in sync after mount. `InstrumentPage` has a fully URL-driven tab pattern, but porting it would churn every `setTab` caller including the three ownership guards — out of scope for a banner-link fix.
- `?tab=advanced` deep link on a process whose metadata hasn't loaded yet resets to overview (guard fires before detail lands). Not a use case today — the only producer of deep links is the banner, which sends `tab=timeline`.
- Label renamed "Open admin" → "Open bootstrap" to match the new destination.

## Verification (e256636)

- New tests: deep link preselects Timeline + fetches `/timeline` without a click; unknown `?tab=` and `?tab=timeline` on non-bootstrap both fall back to Overview with `/timeline` never called. `ProcessDetailPage.test.tsx` 34/34.
- Full suite 922/922; typecheck + dark:check clean.
- Codex ckpt-2: no findings (independently verified all four router/guard edge cases + ran the test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)