### PR TITLE
feat(#1014): raw-payload retention sweep + SHA-256 reproducibility guard

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -369,6 +369,11 @@ _INVOKERS[_scheduler.JOB_SEC_REBUILD] = _scheduler.sec_rebuild  # params-taking,
 # (not in SCHEDULED_JOBS); zero-param. Source-lock in
 # MANUAL_TRIGGER_JOB_SOURCES; empty params in MANUAL_TRIGGER_JOB_METADATA.
 _INVOKERS[_scheduler.JOB_FILING_EVENTS_SKIP_TIER_CLEANUP] = _adapt_zero_arg(_scheduler.filing_events_skip_tier_cleanup)
+# #1014 — raw-payload retention sweep. Manual-trigger-only triangle;
+# params-taking (dry_run, default true) — no _adapt_zero_arg. Source-lock
+# db_raw_sweep in MANUAL_TRIGGER_JOB_SOURCES; params in
+# MANUAL_TRIGGER_JOB_METADATA.
+_INVOKERS[_scheduler.JOB_RAW_PAYLOAD_RETENTION_SWEEP] = _scheduler.raw_payload_retention_sweep
 # G6/#915 — FINRA bimonthly short interest (daily 12:00 UTC). Zero-param
 # manual surface; extended-window backfill via REPL runbook.
 _INVOKERS[_scheduler.JOB_FINRA_SHORT_INTEREST_REFRESH] = _adapt_zero_arg(_scheduler.finra_short_interest_refresh)

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -79,6 +79,7 @@ Lane = Literal[
     "db_positions",
     "db_cusip",
     "db_ownership_obs",
+    "db_raw_sweep",
     "bootstrap",
     "finra",
     "openfigi",
@@ -223,6 +224,15 @@ when one overruns). Scheduled-only, so NOT added to the
   (13F rewash). The 13F ingest writers already run on ``sec_rate`` /
   ``db_ownership_inst`` (never ``db``), so extraction introduces no NEW
   race — the sweep already ran concurrently with them.
+* ``db_raw_sweep`` — ``raw_payload_retention_sweep`` (#1014,
+  manual-only) only. A full sweep nulls ~12k multi-MB payloads in
+  bounded batches and holds its lane for minutes; on the catch-all
+  ``db`` lane it would starve ``orchestrator_high_frequency_sync``
+  (every-5-min, same lane) — the #1526/#1527 starvation class.
+  Write-safety: sole writer of ``payload_sha256``/``payload_swept_at``;
+  the raw-row UPDATE re-checks ``payload IS NOT NULL`` under its row
+  lock, so concurrent ``store_raw`` upserts (sec_rate / sec_manifest
+  lanes) compose to one of the two legal terminal states either way.
 * ``db_ownership_obs`` — ``ownership_observations_sync`` (daily @ :30)
   only — the all-7-category ``ownership_*_current`` repair sweep.
   ``ownership_*_current`` has other writers (the live ingesters + bulk
@@ -346,6 +356,13 @@ MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
     # params in MANUAL_TRIGGER_JOB_METADATA (empty); invoker in
     # app/jobs/runtime.py::_INVOKERS.
     "filing_events_skip_tier_cleanup": "db",
+    # raw_payload_retention_sweep — #1014 payload-null sweep. Pure DB
+    # operation but LONG-running (minutes over ~12k rows) → own lane,
+    # NOT the catch-all ``db`` (would starve the every-5-min
+    # orchestrator_high_frequency_sync; #1526/#1527 class). Params
+    # (dry_run) in MANUAL_TRIGGER_JOB_METADATA; invoker in
+    # app/jobs/runtime.py::_INVOKERS.
+    "raw_payload_retention_sweep": "db_raw_sweep",
     # sec_rebuild — operator manual triage (#1155). Per-CIK
     # check_freshness probes against SEC submissions.json; shares the
     # 10 req/s SEC fair-use budget with every other sec_rate consumer.

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -231,6 +231,26 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
     # fallback, which would also yield empty) and completes the
     # manual-only triangle (source + metadata + invoker).
     "filing_events_skip_tier_cleanup": (),
+    # raw_payload_retention_sweep — #1014 payload-null sweep.
+    # ``batch_size`` stays internal (implementation knob, same call as
+    # #1013); ``dry_run`` is operator-facing and DEFAULTS TRUE so a
+    # casual trigger destroys nothing — the operator reads the dry-run
+    # figures, then re-triggers with dry_run=false.
+    "raw_payload_retention_sweep": (
+        ParamMetadata(
+            name="dry_run",
+            label="Dry run",
+            help_text=(
+                "If true (default), report eligible row count + byte "
+                "total only — zero writes. Set false to actually null "
+                "the payloads (SHA-256 is recorded per row first; "
+                "re-fetch from EDGAR verifies against it)."
+            ),
+            field_type="bool",
+            default=True,
+            advanced_group=False,
+        ),
+    ),
     # sec_13f_quarterly_sweep — post-#1155 retirement of the weekly
     # scheduled row; bootstrap stage 21 still dispatches it via
     # _INVOKERS, and the sweep-adapter / Admin Run-now paths surface

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -84,11 +84,29 @@ DocumentKind = Literal[
 class RawFilingDocument:
     accession_number: str
     document_kind: DocumentKind
-    payload: str
-    byte_count: int
+    # ``payload`` / ``byte_count`` are None on swept rows (#1014): the
+    # retention sweep nulls the bytes after recording payload_sha256;
+    # byte_count is GENERATED from octet_length(payload) so it follows.
+    payload: str | None
+    byte_count: int | None
     parser_version: str | None
     fetched_at: datetime
     source_url: str | None
+
+    def require_payload(self) -> str:
+        """Return the payload, raising if this row has been swept.
+
+        Rewash apply-fns call this instead of touching ``payload``
+        directly — callers that can tolerate a swept row must check
+        ``payload is None`` BEFORE handing the doc over. Explicit
+        raise (not assert): production invariant."""
+        if self.payload is None:
+            raise RuntimeError(
+                f"raw payload for accession={self.accession_number} "
+                f"kind={self.document_kind} was swept "
+                f"(payload_swept_at set); re-fetch via rehydrate before re-parsing"
+            )
+        return self.payload
 
 
 def store_raw(
@@ -122,7 +140,13 @@ def store_raw(
             payload = EXCLUDED.payload,
             parser_version = EXCLUDED.parser_version,
             source_url = EXCLUDED.source_url,
-            fetched_at = NOW()
+            fetched_at = NOW(),
+            -- #1014: a fresh body invalidates sweep state. The stored
+            -- hash belongs to the bytes that were destroyed; letting it
+            -- linger would fail a future verify against a legitimately
+            -- re-stored (possibly amended) body.
+            payload_sha256 = NULL,
+            payload_swept_at = NULL
         """,
         (accession_number, document_kind, payload, parser_version, source_url),
     )
@@ -150,13 +174,21 @@ def read_raw(
         row = cur.fetchone()
     if row is None:
         return None
+    return _row_to_document(row)
+
+
+def _row_to_document(row: dict[str, Any]) -> RawFilingDocument:
+    """Map a dict_row to the dataclass. ``payload`` / ``byte_count``
+    are NULL on swept rows (#1014) — must map to ``None``, never
+    ``str(None)`` == the literal string ``"None"`` (prevention-log
+    §str(row[N]) coerces SQL NULL)."""
     return RawFilingDocument(
-        accession_number=str(row["accession_number"]),  # type: ignore[arg-type]
-        document_kind=row["document_kind"],  # type: ignore[arg-type]
-        payload=str(row["payload"]),  # type: ignore[arg-type]
-        byte_count=int(row["byte_count"]),  # type: ignore[arg-type]
+        accession_number=str(row["accession_number"]),
+        document_kind=row["document_kind"],
+        payload=(str(row["payload"]) if row.get("payload") is not None else None),
+        byte_count=(int(row["byte_count"]) if row.get("byte_count") is not None else None),
         parser_version=(str(row["parser_version"]) if row.get("parser_version") is not None else None),
-        fetched_at=row["fetched_at"],  # type: ignore[arg-type]
+        fetched_at=row["fetched_at"],
         source_url=(str(row["source_url"]) if row.get("source_url") is not None else None),
     )
 
@@ -202,15 +234,7 @@ def iter_raw(
         cur.itersize = batch_size
         cur.execute(sql, params)  # type: ignore[arg-type]  # f-string composed from closed enum
         for row in cur:
-            yield RawFilingDocument(
-                accession_number=str(row["accession_number"]),  # type: ignore[arg-type]
-                document_kind=row["document_kind"],  # type: ignore[arg-type]
-                payload=str(row["payload"]),  # type: ignore[arg-type]
-                byte_count=int(row["byte_count"]),  # type: ignore[arg-type]
-                parser_version=(str(row["parser_version"]) if row.get("parser_version") is not None else None),
-                fetched_at=row["fetched_at"],  # type: ignore[arg-type]
-                source_url=(str(row["source_url"]) if row.get("source_url") is not None else None),
-            )
+            yield _row_to_document(row)
 
 
 @dataclass(frozen=True)

--- a/app/services/raw_payload_retention.py
+++ b/app/services/raw_payload_retention.py
@@ -1,0 +1,348 @@
+"""Raw-payload retention sweep + SHA-256 reproducibility guard (#1014).
+
+Spec: ``docs/specs/etl/2026-06-10-raw-payload-retention-sweep.md``.
+
+``filing_raw_documents`` ``primary_doc`` payloads (10-K / 8-K primary
+documents, 16 GB raw on dev) are write-only: no rewash parser is
+registered for the kind (pinned by
+``tests/test_raw_payload_retention.py``), and the manifest re-parse
+path re-fetches from EDGAR unconditionally. The sweep nulls the
+payload of PARSED 10-K / 8-K rows after recording a SHA-256 of the
+bytes being destroyed, and flips the manifest ``raw_status`` to
+``'compacted'`` (the value sql/118 reserved for exactly this).
+
+Destruction is opt-in: ``SWEPT_MANIFEST_SOURCES`` is a drop-list —
+anything not listed defaults to keep-always. ``def14a_body`` is
+consciously excluded (it HAS a stored-body rewash consumer).
+
+Connection ownership (prevention-log §"orchestrator-of-N autocommit"):
+the sweep OWNS its connection — opens ``autocommit=True`` and wraps
+each batch in ``with conn.transaction()`` (a real top-level
+BEGIN/COMMIT per batch). Mirror of
+:func:`app.services.filing_events_cleanup.cleanup_skip_tier_filing_events`.
+
+Hash semantics: SHA-256 of the UTF-8 encoding of the TEXT payload as
+stored. Server-side ``encode(sha256(convert_to(payload, 'UTF8')), 'hex')``
+equals Python ``hashlib.sha256(text.encode('utf-8')).hexdigest()``
+(verified on dev PG 17, 2026-06-10) — so the sweep never ships
+multi-MB payloads to the client, and the re-fetch verifier hashes the
+decoded text, immune to transfer-encoding/charset variance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+from app.config import settings
+from app.services.raw_filings import DocumentKind
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 100
+"""Bounds per-tx detoast cost (10-K avg ~3.5 MB -> ~350 MB worst-case
+detoast per batch for the server-side hash) and the WAL burst."""
+
+# The document kinds the sweep may destroy payloads for. MUST stay
+# disjoint from the rewash registry (structural test) — a registered
+# rewash parser reads stored bodies, which a sweep would null.
+SWEPT_DOCUMENT_KINDS: frozenset[DocumentKind] = frozenset({"primary_doc"})
+
+# Manifest sources whose parsed accessions are sweep-eligible. Keyed on
+# ``sec_filing_manifest.source`` (CHECK-constrained enum, collapses
+# amendments: sec_10k covers 10-K + 10-K/A) rather than the free-text
+# ``form`` column. Opt-in destruction: a new source (sec_10q, ...)
+# defaults to keep-always until explicitly added here. 13F-HR
+# primary_doc rows (~33 MB) are excluded — not worth touching, and
+# ``raw_status`` is accession-scoped while a 13F stores two kinds.
+SWEPT_MANIFEST_SOURCES: frozenset[Literal["sec_10k", "sec_8k"]] = frozenset({"sec_10k", "sec_8k"})
+
+
+class RawPayloadIntegrityError(RuntimeError):
+    """Re-fetched bytes do not hash-match the recorded payload_sha256.
+
+    SEC silently changed the document under the same accession — the
+    operator must adjudicate; never auto-overwrite."""
+
+
+@dataclass(frozen=True)
+class RawPayloadSweepSummary:
+    """Outcome of one sweep run."""
+
+    rows_swept: int
+    batches: int
+    bytes_reclaimed: int
+    by_source: dict[str, int] = field(default_factory=dict)
+    dry_run: bool = False
+
+
+# Per-batch statement. Chained data-modifying CTEs, one snapshot, one
+# transaction:
+#   batch   — pick candidates; lock ONLY the raw rows (FOR UPDATE OF r
+#             SKIP LOCKED). The manifest is not locked: a concurrent
+#             sec_rebuild flipping parsed->pending is benign — the
+#             worker re-parse fetches from primary_document_url
+#             unconditionally and store_raw re-populates the payload.
+#   swept   — null the payload; re-checks ``payload IS NOT NULL`` under
+#             the row lock so a store_raw that won the race is never
+#             clobbered with a hash-of-nothing.
+#   flagged — manifest stored->compacted; 'compacted' rows (re-swept
+#             after a store_raw without parser transition) are already
+#             correct, hence the raw_status='stored' guard.
+# RETURNING evaluates the NEW row, so the OLD byte_count comes from the
+# batch CTE, never from the UPDATE.
+# Eligibility requires raw_status IN ('stored','compacted'): a split
+# row (parsed + raw_status='absent' + payload present) is already an
+# invariant violation — excluded, surfaces as a dry-run discrepancy.
+_SWEEP_BATCH_SQL = """
+WITH batch AS (
+    SELECT r.accession_number, r.byte_count, m.source
+    FROM filing_raw_documents r
+    JOIN sec_filing_manifest m ON m.accession_number = r.accession_number
+    WHERE r.document_kind = %(kind)s
+      AND r.payload IS NOT NULL
+      AND m.source = ANY(%(sources)s)
+      AND m.ingest_status = 'parsed'
+      AND m.raw_status IN ('stored', 'compacted')
+    ORDER BY r.accession_number
+    LIMIT %(batch)s
+    FOR UPDATE OF r SKIP LOCKED
+),
+swept AS (
+    UPDATE filing_raw_documents r
+    SET payload_sha256   = encode(sha256(convert_to(r.payload, 'UTF8')), 'hex'),
+        payload_swept_at = NOW(),
+        payload          = NULL
+    FROM batch b
+    WHERE r.accession_number = b.accession_number
+      AND r.document_kind = %(kind)s
+      AND r.payload IS NOT NULL
+    RETURNING r.accession_number
+),
+flagged AS (
+    UPDATE sec_filing_manifest m
+    SET raw_status = 'compacted'
+    FROM swept s
+    WHERE m.accession_number = s.accession_number
+      AND m.raw_status = 'stored'
+    RETURNING m.accession_number
+)
+SELECT b.accession_number, b.source, b.byte_count
+FROM batch b
+JOIN swept s ON s.accession_number = b.accession_number
+"""
+
+_DRY_RUN_SQL = """
+SELECT m.source, COUNT(*) AS rows, COALESCE(SUM(r.byte_count), 0) AS bytes
+FROM filing_raw_documents r
+JOIN sec_filing_manifest m ON m.accession_number = r.accession_number
+WHERE r.document_kind = %(kind)s
+  AND r.payload IS NOT NULL
+  AND m.source = ANY(%(sources)s)
+  AND m.ingest_status = 'parsed'
+  AND m.raw_status IN ('stored', 'compacted')
+GROUP BY m.source
+"""
+
+
+def sweep_raw_payloads(
+    *,
+    database_url: str | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    dry_run: bool = True,
+) -> RawPayloadSweepSummary:
+    """Null the payload of sweep-eligible ``filing_raw_documents`` rows
+    in bounded batches, recording a SHA-256 per row first.
+
+    ``dry_run`` defaults TRUE at this entrypoint too (Codex ckpt-2):
+    a destructive service must be opt-in even for REPL / test callers,
+    not just at the manual-trigger layer.
+
+    Idempotent: the ``payload IS NOT NULL`` predicate means a drained
+    DB sweeps 0. Terminates: the candidate set strictly shrinks per
+    batch (a swept row cannot re-match).
+    """
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+
+    url = database_url or settings.database_url
+    sources = sorted(SWEPT_MANIFEST_SOURCES)
+
+    tally: Counter[str] = Counter()
+    rows_swept = 0
+    bytes_reclaimed = 0
+    batches = 0
+
+    with psycopg.connect(url, autocommit=True) as conn:
+        if dry_run:
+            with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                for kind in sorted(SWEPT_DOCUMENT_KINDS):
+                    cur.execute(_DRY_RUN_SQL, {"kind": kind, "sources": sources})
+                    for row in cur.fetchall():
+                        tally[str(row["source"])] += int(row["rows"])
+                        rows_swept += int(row["rows"])
+                        bytes_reclaimed += int(row["bytes"])
+            logger.info(
+                "raw_payload_retention_sweep dry_run: eligible=%d bytes=%d by_source=%s",
+                rows_swept,
+                bytes_reclaimed,
+                dict(tally),
+            )
+            return RawPayloadSweepSummary(
+                rows_swept=rows_swept,
+                batches=0,
+                bytes_reclaimed=bytes_reclaimed,
+                by_source=dict(tally),
+                dry_run=True,
+            )
+
+        for kind in sorted(SWEPT_DOCUMENT_KINDS):
+            while True:
+                with conn.transaction(), conn.cursor() as cur:
+                    cur.execute(
+                        _SWEEP_BATCH_SQL,
+                        {"kind": kind, "sources": sources, "batch": batch_size},
+                    )
+                    swept = cur.fetchall()
+                if not swept:
+                    break
+                batches += 1
+                rows_swept += len(swept)
+                for _accession, source, byte_count in swept:
+                    tally[str(source)] += 1
+                    bytes_reclaimed += int(byte_count)
+
+    logger.info(
+        "raw_payload_retention_sweep: rows_swept=%d batches=%d bytes_reclaimed=%d by_source=%s",
+        rows_swept,
+        batches,
+        bytes_reclaimed,
+        dict(tally),
+    )
+    return RawPayloadSweepSummary(
+        rows_swept=rows_swept,
+        batches=batches,
+        bytes_reclaimed=bytes_reclaimed,
+        by_source=dict(tally),
+    )
+
+
+@dataclass(frozen=True)
+class RehydrateOutcome:
+    accession_number: str
+    document_kind: DocumentKind
+    status: Literal["already_present", "restored"]
+
+
+def rehydrate_raw_document(
+    conn: psycopg.Connection[Any],
+    *,
+    accession_number: str,
+    document_kind: DocumentKind,
+    fetch_text: Callable[[str], str],
+) -> RehydrateOutcome:
+    """Restore a swept payload from source, verifying byte-identity.
+
+    ``fetch_text`` is injected (production callers pass the
+    SEC-rate-limited provider fetch) so this module owns no HTTP.
+
+    Raises :class:`RawPayloadIntegrityError` when the re-fetched bytes
+    do not hash-match the recorded ``payload_sha256`` — SEC silently
+    changed the document; the operator must adjudicate. Never
+    auto-overwrites on mismatch.
+
+    Caller owns the transaction (service-no-commit rule); all I/O
+    happens BEFORE the writes.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT payload, payload_sha256, source_url
+            FROM filing_raw_documents
+            WHERE accession_number = %s AND document_kind = %s
+            """,
+            (accession_number, document_kind),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"no filing_raw_documents row for accession={accession_number!r} kind={document_kind!r}")
+    if row["payload"] is not None:
+        return RehydrateOutcome(
+            accession_number=accession_number,
+            document_kind=document_kind,
+            status="already_present",
+        )
+    expected_sha = row["payload_sha256"]
+    if expected_sha is None:
+        # chk_swept_rows_carry_hash forbids this shape at the DB layer;
+        # reaching here means the constraint was dropped or bypassed.
+        raise RuntimeError(f"swept row accession={accession_number!r} kind={document_kind!r} carries no payload_sha256")
+    source_url = row["source_url"]
+    if not source_url:
+        raise RuntimeError(f"swept row accession={accession_number!r} kind={document_kind!r} has no source_url")
+
+    # I/O outside the write — fetch + hash before touching any row.
+    text = fetch_text(str(source_url))
+    actual_sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    if actual_sha != expected_sha:
+        logger.warning(
+            "rehydrate hash mismatch accession=%s kind=%s expected=%s actual=%s url=%s",
+            accession_number,
+            document_kind,
+            expected_sha,
+            actual_sha,
+            source_url,
+        )
+        raise RawPayloadIntegrityError(
+            f"re-fetched payload for accession={accession_number!r} kind={document_kind!r} "
+            f"does not match recorded sha256 (expected {expected_sha}, got {actual_sha}); "
+            "SEC may have silently changed the document — operator adjudication required"
+        )
+
+    # Hash matches — restore. payload_sha256 stays (still true);
+    # payload_swept_at clears (row is live again); fetched_at is NOT
+    # refreshed (preserves the original "when did SEC publish this?"
+    # timestamp, mirroring rewash's _bump_parser_version rationale).
+    # The WHERE re-pins payload_sha256 to the hash this fetch was
+    # verified against (Codex ckpt-2): a concurrent store_raw +
+    # re-sweep between our SELECT and this UPDATE can install a NEWER
+    # hash — writing our (stale-verified) bytes under it would pair
+    # bytes with a hash they were never checked against. rowcount==0
+    # then means "row moved on" — report already_present, don't write.
+    result = conn.execute(
+        """
+        UPDATE filing_raw_documents
+        SET payload = %s, payload_swept_at = NULL
+        WHERE accession_number = %s AND document_kind = %s
+          AND payload IS NULL AND payload_sha256 = %s
+        """,
+        (text, accession_number, document_kind, expected_sha),
+    )
+    if result.rowcount == 0:
+        # Lost a race with store_raw / another rehydrate / a re-sweep
+        # under a newer hash — the row has moved on; nothing written.
+        return RehydrateOutcome(
+            accession_number=accession_number,
+            document_kind=document_kind,
+            status="already_present",
+        )
+    conn.execute(
+        """
+        UPDATE sec_filing_manifest
+        SET raw_status = 'stored'
+        WHERE accession_number = %s AND raw_status = 'compacted'
+        """,
+        (accession_number,),
+    )
+    return RehydrateOutcome(
+        accession_number=accession_number,
+        document_kind=document_kind,
+        status="restored",
+    )

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -175,10 +175,14 @@ def run_rewash(
             accession_number=accession,
             document_kind=document_kind,
         )
-        if raw_doc is None:
+        if raw_doc is None or raw_doc.payload is None:
             # Row vanished between cohort scan and read (rare but
-            # possible if a parallel process truncated). Treat as
-            # skipped; the next sweep will see the new state.
+            # possible if a parallel process truncated), OR the
+            # payload was swept by the #1014 retention sweep
+            # (unreachable for registered kinds today — the sweep
+            # only targets kinds with no rewash parser, pinned by
+            # tests/test_raw_payload_retention.py — but cheap
+            # belt-and-braces). Treat as skipped.
             skipped += 1
             continue
 
@@ -307,7 +311,8 @@ def _apply_form4(
         return False
     instrument_id, primary_document_url = row
 
-    parsed = parse_form_4_xml(raw_doc.payload)
+    body = raw_doc.require_payload()
+    parsed = parse_form_4_xml(body)
     if parsed is None:
         # Parser regression — the previous parser presumably
         # produced a typed-table row for this body, but the current
@@ -317,7 +322,7 @@ def _apply_form4(
         # in the failure counter. A parser regression is a real
         # failure that must surface in ``rows_failed``.
         raise RewashParseError(
-            f"parse_form_4_xml returned None for accession={raw_doc.accession_number} body_size={len(raw_doc.payload)}"
+            f"parse_form_4_xml returned None for accession={raw_doc.accession_number} body_size={len(body)}"
         )
 
     upsert_filing(
@@ -378,10 +383,11 @@ def _apply_form3(
         return False
     instrument_id, primary_document_url = row
 
-    parsed = parse_form_3_xml(raw_doc.payload)
+    body = raw_doc.require_payload()
+    parsed = parse_form_3_xml(body)
     if parsed is None:
         raise RewashParseError(
-            f"parse_form_3_xml returned None for accession={raw_doc.accession_number} body_size={len(raw_doc.payload)}"
+            f"parse_form_3_xml returned None for accession={raw_doc.accession_number} body_size={len(body)}"
         )
 
     upsert_form_3_filing(
@@ -495,7 +501,7 @@ def _apply_def14a(
     issuer_cik, instrument_id = row
 
     try:
-        parsed = parse_beneficial_ownership_table(raw_doc.payload)
+        parsed = parse_beneficial_ownership_table(raw_doc.require_payload())
     except Exception as exc:
         raise RewashParseError(
             f"parse_beneficial_ownership_table failed for accession={raw_doc.accession_number}: {exc}"
@@ -703,9 +709,9 @@ def _apply_blockholders(
     # CHECK-constrained to {'sec_13d','sec_13g'} per sql/118.
     try:
         if manifest_source == "sec_13g":
-            parsed_dict = Schedule13G.parse_xml(raw_doc.payload)
+            parsed_dict = Schedule13G.parse_xml(raw_doc.require_payload())
         else:
-            parsed_dict = Schedule13D.parse_xml(raw_doc.payload)
+            parsed_dict = Schedule13D.parse_xml(raw_doc.require_payload())
         # Adapter requires the manifest form label (SC 13D / SC 13G /
         # /A variants — dual-spelled per the post-PR1251 form-name
         # normalisation in _SUBMISSION_TYPE_FOR_FORM) for the closed
@@ -924,7 +930,7 @@ def _apply_13f_infotable(
         return False
 
     try:
-        holdings = parse_infotable(raw_doc.payload)
+        holdings = parse_infotable(raw_doc.require_payload())
     except Exception as exc:
         raise RewashParseError(f"parse_infotable failed for accession={raw_doc.accession_number}: {exc}") from exc
 
@@ -1156,7 +1162,9 @@ def _rewash_13f_accession(
         accession_number=accession_number,
         document_kind="infotable_13f",
     )
-    if raw_doc is None:
+    if raw_doc is None or raw_doc.payload is None:
+        # Absent row OR swept payload (#1014) — same caller contract:
+        # "rewash deferred, body not on hand".
         return False
 
     return spec.apply_fn(conn, raw_doc)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -323,6 +323,10 @@ JOB_FINANCIAL_FACTS_RETENTION_SWEEP = "financial_facts_retention_sweep"
 # never auto-fire. Source-lock binding in MANUAL_TRIGGER_JOB_SOURCES,
 # params (none) in MANUAL_TRIGGER_JOB_METADATA.
 JOB_FILING_EVENTS_SKIP_TIER_CLEANUP = "filing_events_skip_tier_cleanup"
+# #1014 — raw-payload retention sweep (manual-trigger-only triangle,
+# same shape as filing_events_skip_tier_cleanup). dry_run param in
+# MANUAL_TRIGGER_JOB_METADATA; own lane in MANUAL_TRIGGER_JOB_SOURCES.
+JOB_RAW_PAYLOAD_RETENTION_SWEEP = "raw_payload_retention_sweep"
 JOB_ORPHAN_TEST_DB_REAP = "orphan_test_db_reap"
 JOB_LIVENESS_WATCHDOG = "jobs_liveness_watchdog"
 JOB_RETRY_SWEEPER = "jobs_retry_sweeper"
@@ -4315,6 +4319,39 @@ def filing_events_skip_tier_cleanup() -> None:
             summary.total_deleted,
             summary.batches,
             dict(sorted(summary.by_form_type.items(), key=lambda kv: kv[1], reverse=True)),
+        )
+
+
+def raw_payload_retention_sweep(params: Mapping[str, Any]) -> None:
+    """Null parsed 10-K / 8-K ``primary_doc`` payloads after recording
+    SHA-256 (#1014). Manual-trigger-only.
+
+    Thin scheduler-side wrapper around
+    :func:`app.services.raw_payload_retention.sweep_raw_payloads`. The
+    service owns transaction shape (autocommit conn + per-batch
+    ``with conn.transaction()``); this wrapper only adds job-runs
+    telemetry. Idempotent: a drained DB sweeps 0 rows.
+
+    Honoured params (declared in ``MANUAL_TRIGGER_JOB_METADATA``):
+
+    * ``dry_run`` (bool, default TRUE) — count + byte-total only, zero
+      writes. Deliberate safety default for a destructive job: the
+      operator reads the dry-run figures, then re-triggers with
+      ``dry_run=false`` (mirrors the raw_data_retention_sweep posture).
+    """
+    from app.services.raw_payload_retention import sweep_raw_payloads
+
+    dry_run = bool(params.get("dry_run", True))
+    with _tracked_job(JOB_RAW_PAYLOAD_RETENTION_SWEEP) as tracker:
+        summary = sweep_raw_payloads(dry_run=dry_run)
+        tracker.row_count = summary.rows_swept
+        logger.info(
+            "raw_payload_retention_sweep complete: rows_swept=%d batches=%d bytes_reclaimed=%d by_source=%s dry_run=%s",
+            summary.rows_swept,
+            summary.batches,
+            summary.bytes_reclaimed,
+            dict(sorted(summary.by_source.items(), key=lambda kv: kv[1], reverse=True)),
+            summary.dry_run,
         )
 
 

--- a/docs/specs/etl/2026-06-10-raw-payload-retention-sweep.md
+++ b/docs/specs/etl/2026-06-10-raw-payload-retention-sweep.md
@@ -1,0 +1,415 @@
+# Raw-payload retention sweep — `primary_doc` drop-on-success + SHA-256 guard (#1014)
+
+Author: claude (autonomous)
+Date: 2026-06-10
+Status: Draft (post-Codex round 1 — 2 High, 2 Medium, 1 Low all addressed inline)
+Issue: #1014 (re-scoped 2026-06-10) — part of the #1011 retention plan.
+Parent spec: [`retention.md`](retention.md) §"Raw-payload retention policy".
+
+## Problem
+
+`filing_raw_documents` is the #1 table in the dev DB: **5.77 GB on disk
+(TOAST-compressed), 16 GB of raw payload bytes**, DB total 20 GB
+(measured 2026-06-10, `bootstrap_state=complete`). Per-kind split:
+
+| document_kind | rows | raw bytes |
+|---|---|---|
+| `primary_doc` | 28,102 | **16 GB** |
+| `form4_xml` | 102,700 | 719 MB |
+| `def14a_body` | 5,859 | 593 MB |
+| others | ~13k | ~140 MB |
+
+`primary_doc` by manifest form:
+
+| form | rows | raw bytes | avg/doc |
+|---|---|---|---|
+| 10-K (+/A) | 3,776 | 12.3 GB | ~3.5 MB |
+| 8-K (+/A) | 8,997 | 4.4 GB | ~500 KB |
+| 13F-HR (+/A) | 15,329 | 33 MB | ~2 KB |
+
+10-K/8-K primary-document HTML is ~99.8% of the kind's bytes and the
+single largest open-ended growth path in the DB (grew 14 GB → 16 GB
+within one day of ongoing ingest).
+
+## Prior decisions this implements (and two deviations)
+
+The parent spec's policy table already pre-decided:
+
+> (future) 10-K body → **drop-on-success**. (future) 8-K body →
+> **keep-on-fail**.
+
+Sweeping only `ingest_status='parsed'` accessions implements both:
+parsed bodies are dropped; `failed` / `tombstoned` / `pending` rows
+keep their payload for forensics and retry.
+
+Two deviations from the original #1014 issue body (pre-rescope):
+
+1. **Hash at sweep time, not at ingest time.** The original plan added
+   `payload_sha256` at every `store_raw` + a 16 GB backfill migration.
+   Computing the hash server-side inside the sweep's UPDATE gives the
+   identical guard property (hash recorded before bytes destroyed) with
+   zero ingest-path change and no mass backfill. Rows that are never
+   swept don't need a stored hash — it is derivable from the payload at
+   any time.
+2. **No per-row `retention_mode` column.** The policy is per
+   `(document_kind, manifest.source)`, not per row. It lives in one code
+   constant the sweep reads (`SWEPT_MANIFEST_SOURCES`), the same shape
+   as `SEC_PARSE_AND_RAW`. A column would denormalise a global policy
+   into 230k rows.
+
+Settled decisions check: "full raw filing text … separate table, not
+`filing_events`" (holds — this is that table); #719 process topology
+(job lands in the jobs process via the manual-trigger queue); universal
+bootstrap gate (manual-only triangle job, same bypass as
+`filing_events_skip_tier_cleanup` #1013). No settled decision changes.
+
+Prevention-log entries applied: #1013 allow-list-superset lesson
+(§Structural guard below); mega-table sweep shape (autocommit conn +
+per-batch `with conn.transaction()`); `str(row[N])` NULL-coercion
+(§read-path); ON CONFLICT must cover all columns (§store_raw).
+
+## Design
+
+### Safety by construction
+
+A swept payload is recoverable because, for these forms, the re-parse
+path never reads the stored body:
+
+- **No rewash parser exists for `primary_doc`** — the rewash registry
+  (`app/services/rewash_filings.py::_REGISTRY`) covers `form4_xml`,
+  `form3_xml`, `def14a_body`, `primary_doc_13dg`, `infotable_13f` only.
+  `primary_doc` payload is write-only today (verified: the only readers
+  of `filing_raw_documents.payload` are `read_raw`/`iter_raw`, called
+  solely by rewash; all other queries are COUNT-style diagnostics).
+- **The manifest rebuild path re-fetches.** `sec_rebuild` flips
+  `parsed → pending`; the manifest worker re-runs the parser, which
+  fetches from `primary_document_url` and calls `store_raw`
+  unconditionally. A swept row is transparently re-hydrated by any
+  re-parse.
+- **SEC archive is durable** for accepted filings; the SHA-256 guard
+  detects the (theoretically possible) silent-replacement case.
+
+### Scope — opt-in destruction list
+
+Eligible rows = all of:
+
+```
+r.document_kind = 'primary_doc'
+AND r.payload IS NOT NULL
+AND m.accession_number = r.accession_number
+AND m.source IN ('sec_10k', 'sec_8k')          -- SWEPT_MANIFEST_SOURCES
+AND m.ingest_status = 'parsed'
+AND m.raw_status IN ('stored', 'compacted')
+```
+
+The `raw_status` predicate (Codex round 1, High): a split row
+`parsed + raw_status='absent' + payload present` is already an
+invariant violation (raw_status must reflect the table) — the sweep
+must NOT compound it by destroying the payload while the manifest says
+`absent`. Such rows are excluded and surface as a dry-run-vs-total
+discrepancy for operator triage. `'compacted'` is eligible so a row
+re-stored by `store_raw` without a parser transition (manifest still
+`compacted`) re-sweeps cleanly; the manifest flag update below is a
+no-op for it (already correct).
+
+Keyed on `sec_filing_manifest.source` (CHECK-constrained enum that
+collapses amendments: `sec_10k` ⊇ {10-K, 10-K/A}) rather than the
+free-text `form` column. Anything NOT listed is kept — a new form
+(10-Q, etc.) defaults to keep-always until explicitly added here.
+13F-HR `primary_doc` rows (33 MB) are excluded: not worth touching, and
+`raw_status` is accession-scoped so compacting one of a 13F's two kinds
+would make the manifest flag ambiguous.
+
+`def14a_body` (593 MB) is consciously out of scope: it HAS a registered
+rewash parser that reads stored bodies; sweeping it requires a
+re-fetch-capable rewash path first. Revisit if it grows materially
+(parent-spec threshold language stands).
+
+Eligible on dev today: **12,184 rows / ~14.4 GB raw** (3,173 `sec_10k`
++ 9,011 `sec_8k`).
+
+### Schema — `sql/190_filing_raw_documents_sweepable.sql`
+
+```sql
+ALTER TABLE filing_raw_documents
+    ALTER COLUMN payload DROP NOT NULL;
+
+ALTER TABLE filing_raw_documents
+    ADD COLUMN payload_sha256 TEXT
+        CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
+    ADD COLUMN payload_swept_at TIMESTAMPTZ;
+
+ALTER TABLE filing_raw_documents
+    ADD CONSTRAINT chk_swept_rows_carry_hash CHECK (
+        payload IS NOT NULL
+        OR (payload_sha256 IS NOT NULL AND payload_swept_at IS NOT NULL)
+    );
+```
+
+- `payload_sha256` TEXT hex (not BYTEA): greppable, comparable in SQL
+  and Python without encode/decode asymmetry. CHECK pins shape.
+- `chk_swept_rows_carry_hash`: a payload-less row MUST carry hash +
+  sweep timestamp — the DB cannot represent "bytes gone, no proof".
+- `byte_count` is `GENERATED ALWAYS AS (octet_length(payload)) STORED`
+  → becomes NULL on swept rows. This is correct: the operator storage
+  chip (`storage_summary`) then reports live payload bytes. Reclaimed
+  bytes are reported in the sweep job summary instead.
+- No new index: candidates resolve via existing
+  `idx_filing_raw_documents_kind_fetched` + manifest PK join; the sweep
+  is rare + manual, seq-scan acceptable at 28k rows.
+
+Hash semantics: **SHA-256 of the UTF-8 encoding of the TEXT payload as
+stored** — server-side `encode(sha256(convert_to(payload, 'UTF8')), 'hex')`,
+Python-side `hashlib.sha256(text.encode('utf-8')).hexdigest()`.
+Empirically verified identical on dev PG 17 (accession
+`0001291422-13-000007`). Hashing the decoded text (not raw HTTP bytes)
+makes the re-fetch comparison immune to transfer-encoding/charset
+variance.
+
+### Manifest flag — `raw_status = 'compacted'`
+
+`sec_filing_manifest.raw_status` already reserves `'compacted'`
+("future hot-storage eviction path" — sql/118) and the
+`transition_status` guard already treats `('stored','compacted')` as
+sticky-non-absent. The sweep bulk-updates
+`raw_status = 'compacted' WHERE accession IN (batch) AND raw_status = 'stored'`
+in the same per-batch transaction as the payload UPDATE. No CHECK
+migration, no Literal change (`RawStatus` already includes it). A later
+re-parse writes `raw_status='stored'` via the existing parser-outcome
+path — a legal transition.
+
+### Sweep service — `app/services/raw_payload_retention.py`
+
+Mirror of `filing_events_cleanup.py` (#1013) / mega-table prevention
+entry:
+
+- `sweep_raw_payloads(*, database_url=None, batch_size=100, dry_run=True) -> RawPayloadSweepSummary`
+  — `dry_run` defaults TRUE at the service entrypoint too (Codex
+  ckpt-2): a destructive service must be opt-in even for REPL / test
+  callers, not just at the manual-trigger layer.
+- Owns its connection: `psycopg.connect(url, autocommit=True)`; each
+  batch in `with conn.transaction()` (real top-level commit per batch).
+- Per batch, one statement (chained data-modifying CTEs, all in one
+  snapshot + tx):
+
+```sql
+WITH batch AS (
+    SELECT r.accession_number, r.byte_count, m.source
+    FROM filing_raw_documents r
+    JOIN sec_filing_manifest m ON m.accession_number = r.accession_number
+    WHERE r.document_kind = 'primary_doc'
+      AND r.payload IS NOT NULL
+      AND m.source = ANY(%(sources)s)
+      AND m.ingest_status = 'parsed'
+      AND m.raw_status IN ('stored', 'compacted')
+    ORDER BY r.accession_number
+    LIMIT %(batch)s
+    FOR UPDATE OF r SKIP LOCKED
+),
+swept AS (
+    UPDATE filing_raw_documents r
+    SET payload_sha256   = encode(sha256(convert_to(r.payload, 'UTF8')), 'hex'),
+        payload_swept_at = NOW(),
+        payload          = NULL
+    FROM batch b
+    WHERE r.accession_number = b.accession_number
+      AND r.document_kind = 'primary_doc'
+      AND r.payload IS NOT NULL
+    RETURNING r.accession_number
+),
+flagged AS (
+    UPDATE sec_filing_manifest m
+    SET raw_status = 'compacted'
+    FROM swept s
+    WHERE m.accession_number = s.accession_number
+      AND m.raw_status = 'stored'
+    RETURNING m.accession_number
+)
+SELECT b.accession_number, b.source, b.byte_count
+FROM batch b
+JOIN swept s ON s.accession_number = b.accession_number
+```
+
+  Notes pinned for the implementer (Codex round 1):
+  - RETURNING evaluates the NEW row — the OLD `byte_count` must come
+    from the `batch` CTE, never from the UPDATE's RETURNING.
+  - The `swept`/`flagged` CTEs target different tables, so the
+    one-snapshot rule for data-modifying CTEs is safe here.
+  - Lock scope is honest: `FOR UPDATE OF r` locks only the raw row.
+    The manifest is NOT locked; a concurrent `sec_rebuild` can flip
+    `parsed → pending` between snapshot and commit. Consequence is
+    benign by construction: the pending row's worker re-parse fetches
+    from `primary_document_url` unconditionally and `store_raw`
+    re-populates the payload — it never reads the stored body. The
+    raw-row side IS re-checked under lock (`payload IS NOT NULL` in
+    the `swept` UPDATE), so a `store_raw` that won the race is never
+    clobbered by a stale hash-of-nothing.
+- `dry_run=True`: one aggregate SELECT (count + SUM(byte_count)), no
+  writes.
+- Idempotent: `payload IS NOT NULL` predicate → drained DB sweeps 0.
+- Terminates: candidate set strictly shrinks per batch.
+- `batch_size=100` default: bounds per-tx detoast cost (10-K avg
+  3.5 MB → ~350 MB worst-case detoast per batch) and WAL burst.
+- Summary: `rows_swept, batches, bytes_reclaimed, by_source`.
+
+### Re-hydrate helper + hash guard — same module
+
+`rehydrate_raw_document(conn, *, accession_number, document_kind, fetch_text) -> RehydrateOutcome`
+
+1. Read row. `payload IS NOT NULL` → no-op (`already_present`).
+   Missing row → raise (nothing to rehydrate).
+2. `text = fetch_text(source_url)` — injected callable; production
+   caller passes the SEC-rate-limited provider fetch. No new HTTP code.
+3. `hashlib.sha256(text.encode('utf-8')).hexdigest()` vs stored
+   `payload_sha256`. **Mismatch → log warning + raise
+   `RawPayloadIntegrityError`** (SEC silently changed the document —
+   operator must adjudicate; never auto-overwrite).
+4. Match → `UPDATE ... SET payload = %s, payload_swept_at = NULL
+   WHERE ... payload IS NULL AND payload_sha256 = <verified hash>`
+   (keep `payload_sha256` — still true; keep `fetched_at` — original
+   SEC-publication-era timestamp, mirrors `_bump_parser_version`
+   rationale) + manifest `raw_status='stored'` where `'compacted'`.
+   The hash re-pin in the WHERE (Codex ckpt-2): a concurrent
+   `store_raw` + re-sweep during the fetch can install a NEWER hash;
+   writing the stale-verified bytes under it would pair bytes with a
+   hash they were never checked against. `rowcount == 0` → report
+   `already_present`, write nothing.
+
+Helper-only in this PR (operator invokes via Python / future admin
+endpoint). The hot re-parse path doesn't need it — parsers re-fetch +
+`store_raw` regardless.
+
+### `store_raw` change (prevention #732)
+
+A fresh body invalidates sweep state. ON CONFLICT SET gains:
+
+```sql
+payload_sha256 = NULL,
+payload_swept_at = NULL
+```
+
+Fresh-or-amended bytes are authoritative; a stale hash must not linger
+to fail a future verify against a legitimately re-stored body.
+
+Concurrency invariant (Codex round 1): whatever the interleaving of
+sweep and `store_raw` on the same row, the terminal state is one of
+exactly two legal shapes — `payload IS NULL + sha256 + swept_at`
+(sweep won) or `payload IS NOT NULL + both sweep columns NULL`
+(store_raw won). Both writers take the row lock (single-statement
+UPDATE / upsert), the sweep re-checks `payload IS NOT NULL` under the
+lock, and `store_raw` unconditionally clears the sweep columns — so no
+third state is reachable. The DB CHECK `chk_swept_rows_carry_hash`
+forbids the dangerous fourth shape (payload gone, no hash) outright.
+Tested sequentially (both orders) in the DB tier; a two-session lock
+test adds no coverage beyond what the row lock already guarantees.
+
+### Read-path NULL safety (prevention #960)
+
+`RawFilingDocument.payload: str | None`, `byte_count: int | None`;
+`read_raw` / `iter_raw` stop coercing via `str(...)` (which would
+produce the literal string `"None"`). `run_rewash` gains a
+belt-and-braces guard: `raw_doc.payload is None → rows_skipped += 1`
+(unreachable for currently-swept kinds — see structural guard — but
+cheap and future-proof).
+
+### Job triangle — `raw_payload_retention_sweep`
+
+Manual-trigger-only, #1013 shape:
+
+- `app/workers/scheduler.py`: `JOB_RAW_PAYLOAD_RETENTION_SWEEP` +
+  thin `_tracked_job` wrapper (`tracker.row_count = rows_swept`).
+- `app/jobs/runtime.py::_INVOKERS` entry.
+- `app/jobs/sources.py`: **own lane `db_raw_sweep`** — NOT the
+  catch-all `db` lane. A 12k-row sweep holds its lane for minutes;
+  on `db` it would starve `orchestrator_high_frequency_sync`
+  (every-5-min, same lane) — the exact #1526/#1527 starvation class.
+  Manual-only job ⇒ no `ScheduledJob` row, no bootstrap-stage CHECK
+  migration (precedent #1540).
+- `app/services/processes/param_metadata.py`: `dry_run` bool param
+  (mirrors `raw_data_retention_sweep`).
+- NOT in `SCHEDULED_JOBS` — no cadence, no bootstrap gate interplay.
+
+### Structural guard (#1013 lesson, inverted)
+
+The #1013 trap was a keep-list that under-enumerated → delete destroyed
+real data. Here destruction is opt-in (drop-list), so the residual risk
+is different: **a rewash parser registered for a swept kind later**
+would read NULL payloads. Pure-logic test pins the invariant:
+
+```python
+def test_swept_kinds_have_no_rewash_parser():
+    from app.services import rewash_filings
+    from app.services.raw_payload_retention import SWEPT_DOCUMENT_KINDS
+    assert SWEPT_DOCUMENT_KINDS.isdisjoint(rewash_filings.registered_specs())
+```
+
+plus `SWEPT_MANIFEST_SOURCES ⊆` the manifest `source` vocabulary
+(import the Literal/constant from `sec_manifest.py`, not a hand copy).
+Registering a `primary_doc` rewash parser then fails this test until
+the author reconciles it with the sweep (re-fetch-capable rewash or
+de-scoping the kind).
+
+## Storage reclaim mechanics (honesty section)
+
+Nulling TOASTed payloads marks TOAST tuples dead; **plain autovacuum
+makes the space reusable but does not shrink the 5.77 GB file**.
+Operator follow-up on dev: run `VACUUM (ANALYZE) filing_raw_documents`
+after the sweep (space reuse), then a one-time
+`VACUUM FULL filing_raw_documents` (exclusive lock, ~minutes, needs
+~2× transient disk) to actually return ~4 GB to the OS before the
+issue-1556 threshold re-measure. Expected post-sweep steady state: table
+~1.5–1.8 GB on disk (form4/def14a/others remain).
+
+## Tests (lean tier policy)
+
+Pure-logic (fast tier):
+1. Structural: swept kinds ∩ rewash registry = ∅; swept sources ⊆
+   manifest source vocabulary.
+2. `rehydrate` hash guard: fake `fetch_text`; mismatch raises
+   `RawPayloadIntegrityError`, match returns payload restore plan
+   (mock-cursor level).
+3. `read_raw` NULL-payload mapping (no `"None"` literal).
+
+DB tier (`-m db`, two genuinely-new SQL mechanisms):
+4. Sweep integration: seed 3 raw rows (parsed/failed/parsed-other-kind)
+   + manifest rows → sweep with `batch_size=1` → only the parsed
+   `primary_doc` row swept; hash equals `hashlib` reference; manifest
+   `compacted`; `chk_swept_rows_carry_hash` satisfied; re-run sweeps 0;
+   `dry_run` writes nothing.
+5. Rehydrate integration: swept row + matching fake fetch → payload
+   restored, `payload_swept_at` NULL, manifest back to `stored`;
+   `store_raw` over a swept row clears both sweep columns, and
+   sweeping a re-stored row re-sweeps it cleanly (both interleaving
+   orders → one of the two legal terminal states).
+
+## Dev-verify (DoD 8–12)
+
+1. Migration applies (drift-guard hash recorded).
+2. Manual trigger `dry_run=true` → counts match the eligibility query.
+3. Real run → `rows_swept ≈ 12k+`, bytes_reclaimed ≈ 14+ GB raw.
+4. `VACUUM (ANALYZE)`, then `VACUUM FULL` → record
+   `pg_total_relation_size` before/after + `pg_database_size`.
+5. Panel smoke: `/instruments/{AAPL,GME,MSFT,JPM,HD}/ownership-rollup`
+   200 + figures unchanged (sweep touches no typed tables).
+6. Cross-source: pick one swept 10-K accession → fetch
+   `primary_document_url` from SEC EDGAR direct → SHA-256 matches the
+   stored `payload_sha256` (this is the reproducibility guard exercised
+   end-to-end, and the independent-source check in one step).
+7. 8-K page + business-summary endpoint still render (no payload
+   readers on those paths).
+
+## Out of scope / follow-ups
+
+- `def14a_body` sweep (needs re-fetch-capable rewash) — revisit on
+  growth.
+- Admin endpoint / UI for rehydrate — operator-driven Python for now.
+- #1556 threshold rebase lands as its own PR after step 4 measurement.
+
+## Rollback
+
+Migration is additive (two nullable columns + constraints); the sweep
+is the only writer of NULL payloads. Roll back = stop triggering the
+job. Swept payloads are recoverable per-accession via `rehydrate` or
+any manifest re-parse; bulk restore = `sec_rebuild` scope
+`{source: sec_10k|sec_8k}` (re-fetch at 10 req/s shared, ~12k requests
+≈ 20 min of budget).

--- a/scripts/check_13f_hr_retention.sh
+++ b/scripts/check_13f_hr_retention.sh
@@ -32,7 +32,7 @@
 #     ``thirteen_f_within_retention(`` exactly 1 call AND its line
 #     number MUST sit between the rescue-fallback SQL anchor
 #     (``JOIN institutional_filers f ON f.cik = log.filer_cik``) and
-#     the parser call ``parse_infotable(raw_doc.payload)``.
+#     the parser call ``parse_infotable(raw_doc.require_payload())``.
 #  G. ``ownership_observations_sync.sync_institutions`` SQL predicate.
 #     ``thirteen_f_retention_cutoff(`` ≥ 1 call AND SQL fragment
 #     ``ih.period_of_report >= %(retention_cutoff)s`` ≥ 1.
@@ -291,12 +291,12 @@ else
   else
     cap_line=$(first_line_in_function "$FILE_REWASH" "_apply_13f_infotable" "thirteen_f_within_retention(" || true)
     anchor_line=$(first_line_in_function "$FILE_REWASH" "_apply_13f_infotable" "JOIN institutional_filers f ON f.cik = log.filer_cik" || true)
-    parse_line=$(first_line_in_function "$FILE_REWASH" "_apply_13f_infotable" "parse_infotable(raw_doc.payload)" || true)
+    parse_line=$(first_line_in_function "$FILE_REWASH" "_apply_13f_infotable" "parse_infotable(raw_doc.require_payload())" || true)
 
     if [[ -z "$anchor_line" || "$anchor_line" == "0" ]]; then
       fail "$FILE_REWASH: _apply_13f_infotable missing rescue-fallback 'JOIN institutional_filers f ON f.cik = log.filer_cik' anchor."
     elif [[ -z "$parse_line" || "$parse_line" == "0" ]]; then
-      fail "$FILE_REWASH: _apply_13f_infotable missing 'parse_infotable(raw_doc.payload)' anchor."
+      fail "$FILE_REWASH: _apply_13f_infotable missing 'parse_infotable(raw_doc.require_payload())' anchor."
     elif (( cap_line <= anchor_line )); then
       fail "$FILE_REWASH:$cap_line: thirteen_f_within_retention(...) appears at/before the rescue SQL anchor at line $anchor_line — happy-path branch must NOT be capped."
     elif (( cap_line >= parse_line )); then

--- a/sql/190_filing_raw_documents_sweepable.sql
+++ b/sql/190_filing_raw_documents_sweepable.sql
@@ -1,0 +1,63 @@
+-- 190_filing_raw_documents_sweepable.sql
+--
+-- #1014 — raw-payload retention sweep, schema half.
+-- Spec: docs/specs/etl/2026-06-10-raw-payload-retention-sweep.md
+--
+-- Makes ``filing_raw_documents.payload`` sweepable: the retention
+-- sweep nulls the payload of parsed 10-K / 8-K ``primary_doc`` rows
+-- (16 GB raw on dev, ~99.8% of the kind's bytes) after recording a
+-- SHA-256 of the bytes being destroyed. Re-parse is safe by
+-- construction: no rewash parser reads ``primary_doc`` payload, and
+-- the manifest rebuild path re-fetches from EDGAR unconditionally.
+--
+-- Schema decisions:
+--
+--   * ``payload`` DROP NOT NULL — a swept row keeps its identity,
+--     metadata and hash; only the bytes go.
+--   * ``payload_sha256`` TEXT hex (not BYTEA): greppable, comparable
+--     in SQL and Python without encode/decode asymmetry. Shape pinned
+--     by CHECK. Hash semantics: SHA-256 of the UTF-8 encoding of the
+--     TEXT payload as stored — server-side
+--     ``encode(sha256(convert_to(payload, 'UTF8')), 'hex')`` equals
+--     Python ``hashlib.sha256(text.encode('utf-8')).hexdigest()``
+--     (verified on dev PG 17, 2026-06-10).
+--   * ``payload_swept_at`` — when the bytes were destroyed. NULL on
+--     live rows and on rehydrated rows.
+--   * ``chk_swept_rows_carry_hash`` — the DB cannot represent
+--     "bytes gone, no proof": a payload-less row MUST carry hash +
+--     sweep timestamp.
+--   * Hash is computed AT SWEEP TIME, not at ingest — zero ingest-path
+--     change, no 16 GB backfill. Rows never swept don't need a stored
+--     hash (derivable from the payload at any time).
+--   * ``byte_count`` (GENERATED from octet_length(payload)) becomes
+--     NULL on swept rows — intentional: the operator storage chip
+--     reports LIVE payload bytes; reclaimed bytes are reported in the
+--     sweep job summary.
+--   * No new index: the sweep is rare + manual; candidates resolve via
+--     the existing kind index + manifest PK join at ~28k rows.
+
+ALTER TABLE filing_raw_documents
+    ALTER COLUMN payload DROP NOT NULL;
+
+ALTER TABLE filing_raw_documents
+    ADD COLUMN payload_sha256 TEXT
+        CONSTRAINT chk_payload_sha256_shape
+        CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
+    ADD COLUMN payload_swept_at TIMESTAMPTZ;
+
+ALTER TABLE filing_raw_documents
+    ADD CONSTRAINT chk_swept_rows_carry_hash CHECK (
+        payload IS NOT NULL
+        OR (payload_sha256 IS NOT NULL AND payload_swept_at IS NOT NULL)
+    );
+
+COMMENT ON COLUMN filing_raw_documents.payload_sha256 IS
+    'SHA-256 (lowercase hex) of the UTF-8 bytes of payload, recorded '
+    'by the retention sweep immediately before nulling the payload. '
+    'The reproducibility guard: any re-fetch must hash-match or fail '
+    'loud (SEC silently changed the document). NULL on rows the sweep '
+    'has never touched.';
+
+COMMENT ON COLUMN filing_raw_documents.payload_swept_at IS
+    'When the retention sweep nulled this row''s payload. NULL on '
+    'live rows; cleared again on rehydrate / re-store.';

--- a/tests/test_def14a_ingest.py
+++ b/tests/test_def14a_ingest.py
@@ -359,7 +359,7 @@ class TestIngestDef14a:
         assert doc is not None
         assert doc.parser_version == "def14a-v1"
         assert doc.source_url == url
-        assert len(doc.payload) > 0
+        assert len(doc.require_payload()) > 0
 
     def test_re_ingest_promotes_via_upsert_not_insert(
         self,

--- a/tests/test_insider_form3_ingest.py
+++ b/tests/test_insider_form3_ingest.py
@@ -180,7 +180,7 @@ class TestRichHappyPath:
             document_kind="form3_xml",
         )
         assert doc is not None
-        assert "<ownershipDocument>" in doc.payload
+        assert "<ownershipDocument>" in doc.require_payload()
         assert doc.parser_version == "form3-v1"
         assert doc.source_url == url
 

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -327,7 +327,7 @@ class TestIngestInsiderTransactions:
             document_kind="form4_xml",
         )
         assert doc is not None
-        assert "<ownershipDocument>" in doc.payload
+        assert "<ownershipDocument>" in doc.require_payload()
         assert doc.parser_version == "form4-v1"
         assert doc.source_url == "https://www.sec.gov/Archives/form4-raw.xml"
 

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -384,7 +384,7 @@ class TestIngestFiler13F:
             document_kind="primary_doc",
         )
         assert primary is not None
-        assert "BERKSHIRE" in primary.payload.upper() or "<edgarSubmission" in primary.payload
+        assert "BERKSHIRE" in primary.require_payload().upper() or "<edgarSubmission" in primary.require_payload()
         assert primary.parser_version == "13f-primary-v1"
         assert primary.source_url is not None
         assert primary.source_url.endswith("primary_doc.xml")
@@ -395,7 +395,7 @@ class TestIngestFiler13F:
             document_kind="infotable_13f",
         )
         assert infotable is not None
-        assert "037833100" in infotable.payload  # the seeded CUSIP
+        assert "037833100" in infotable.require_payload()  # the seeded CUSIP
         assert infotable.parser_version == "13f-infotable-v1"
         assert infotable.source_url is not None
         assert infotable.source_url.endswith("infotable.xml")

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -472,6 +472,13 @@ class TestProductionInvokerRegistry:
             # Zero params (empty MANUAL_TRIGGER_JOB_METADATA entry);
             # source-lock "db" in MANUAL_TRIGGER_JOB_SOURCES.
             "filing_events_skip_tier_cleanup",
+            # #1014 — raw-payload retention sweep. Registered in _INVOKERS
+            # so POST /jobs/raw_payload_retention_sweep/run works;
+            # intentionally NOT in SCHEDULED_JOBS (a payload-destroying
+            # sweep must never auto-fire). dry_run param (default TRUE)
+            # in MANUAL_TRIGGER_JOB_METADATA; source-lock "db_raw_sweep"
+            # in MANUAL_TRIGGER_JOB_SOURCES.
+            "raw_payload_retention_sweep",
             # #819 — canonical-instrument redirect populate. Idempotent
             # one-shot the operator triggers after a universe sync
             # introduces new .RTH-style variants. Registered in

--- a/tests/test_raw_filings.py
+++ b/tests/test_raw_filings.py
@@ -236,8 +236,8 @@ def test_iter_raw_concurrent_calls_use_unique_cursor_names(
     # the prior static-name implementation.
     a1 = next(iter_a)
     b1 = next(iter_b)
-    assert a1.payload.startswith("<doc-")
-    assert b1.payload.startswith("<doc-")
+    assert a1.require_payload().startswith("<doc-")
+    assert b1.require_payload().startswith("<doc-")
     # Drain both so the server-side cursors close cleanly.
     list(iter_a)
     list(iter_b)

--- a/tests/test_raw_payload_retention.py
+++ b/tests/test_raw_payload_retention.py
@@ -1,0 +1,230 @@
+"""Pure-logic tests for the #1014 raw-payload retention sweep.
+
+Spec: docs/specs/etl/2026-06-10-raw-payload-retention-sweep.md.
+
+The structural tests are the #1013 prevention-log lesson applied: a
+destructive operation keyed on a classification set must be coupled to
+the producing/consuming code's own constants, never a hand-copied list.
+The SQL mechanisms themselves are covered in
+``tests/test_raw_payload_retention_db.py`` (db tier).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any, get_args
+
+import pytest
+
+from app.services import rewash_filings
+from app.services.raw_filings import DocumentKind, _row_to_document
+from app.services.raw_payload_retention import (
+    SWEPT_DOCUMENT_KINDS,
+    SWEPT_MANIFEST_SOURCES,
+    RawPayloadIntegrityError,
+    rehydrate_raw_document,
+    sweep_raw_payloads,
+)
+from app.services.sec_manifest import ManifestSource
+
+# ---------------------------------------------------------------------------
+# Structural guards
+# ---------------------------------------------------------------------------
+
+
+def test_swept_kinds_have_no_rewash_parser() -> None:
+    """A rewash parser reads stored bodies; the sweep nulls them. The
+    two sets MUST stay disjoint — registering a ``primary_doc`` rewash
+    parser requires reconciling it with the sweep first (re-fetch-
+    capable rewash, or de-scoping the kind here)."""
+    assert SWEPT_DOCUMENT_KINDS.isdisjoint(rewash_filings.registered_specs())
+
+
+def test_swept_kinds_are_valid_document_kinds() -> None:
+    assert SWEPT_DOCUMENT_KINDS <= set(get_args(DocumentKind))
+
+
+def test_swept_sources_are_valid_manifest_sources() -> None:
+    """Couple the drop-list to the manifest's own source vocabulary —
+    a renamed/removed source fails here, not as a silent zero-match."""
+    assert set(SWEPT_MANIFEST_SOURCES) <= set(get_args(ManifestSource))
+
+
+def test_swept_sources_are_the_approved_drop_list() -> None:
+    """Destruction is opt-in. Widening this set is a spec change —
+    the new source's payload consumers must be audited first (see the
+    def14a_body exclusion rationale in the spec)."""
+    assert SWEPT_MANIFEST_SOURCES == frozenset({"sec_10k", "sec_8k"})
+
+
+def test_batch_size_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="batch_size"):
+        sweep_raw_payloads(database_url="postgresql://unused/unused", batch_size=0)
+
+
+# ---------------------------------------------------------------------------
+# Row mapping — swept rows carry NULL payload / byte_count
+# ---------------------------------------------------------------------------
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "accession_number": "0000000000-26-000001",
+        "document_kind": "primary_doc",
+        "payload": "<html>body</html>",
+        "byte_count": 18,
+        "parser_version": None,
+        "fetched_at": datetime(2026, 6, 10, tzinfo=UTC),
+        "source_url": "https://www.sec.gov/Archives/x.htm",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_row_to_document_maps_null_payload_to_none_not_the_string_none() -> None:
+    doc = _row_to_document(_row(payload=None, byte_count=None))
+    assert doc.payload is None
+    assert doc.byte_count is None
+
+
+def test_row_to_document_maps_live_payload() -> None:
+    doc = _row_to_document(_row())
+    assert doc.payload == "<html>body</html>"
+    assert doc.byte_count == 18
+
+
+def test_require_payload_raises_on_swept_row() -> None:
+    doc = _row_to_document(_row(payload=None, byte_count=None))
+    with pytest.raises(RuntimeError, match="swept"):
+        doc.require_payload()
+
+
+# ---------------------------------------------------------------------------
+# Rehydrate hash guard — pure interleaving with a fake connection
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, row: dict[str, Any] | None) -> None:
+        self._row = row
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        del sql, params
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self._row
+
+
+class _FakeConn:
+    """Single-read fake: one dict_row SELECT + recorded UPDATEs.
+
+    Deliberately minimal (prevention-log §mock cursor sequences are
+    fragile) — the real SQL paths run in the db-tier test."""
+
+    def __init__(self, row: dict[str, Any] | None) -> None:
+        self._row = row
+        self.executed: list[tuple[str, Any]] = []
+
+    @contextmanager
+    def cursor(self, *, row_factory: Any = None) -> Any:
+        del row_factory
+        yield _FakeCursor(self._row)
+
+    def execute(self, sql: str, params: Any = None) -> Any:
+        self.executed.append((sql, params))
+
+        class _Result:
+            rowcount = 1
+
+        return _Result()
+
+
+_BODY = "<html>10-K body</html>"
+_BODY_SHA = hashlib.sha256(_BODY.encode("utf-8")).hexdigest()
+
+
+def _swept_row(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "payload": None,
+        "payload_sha256": _BODY_SHA,
+        "source_url": "https://www.sec.gov/Archives/a.htm",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_rehydrate_mismatch_fails_loud_and_writes_nothing() -> None:
+    conn = _FakeConn(_swept_row())
+    with pytest.raises(RawPayloadIntegrityError, match="does not match"):
+        rehydrate_raw_document(
+            conn,  # type: ignore[arg-type]
+            accession_number="a",
+            document_kind="primary_doc",
+            fetch_text=lambda _url: "<html>SEC silently changed this</html>",
+        )
+    assert conn.executed == []  # never auto-overwrite on mismatch
+
+
+def test_rehydrate_match_restores_payload() -> None:
+    conn = _FakeConn(_swept_row())
+    outcome = rehydrate_raw_document(
+        conn,  # type: ignore[arg-type]
+        accession_number="a",
+        document_kind="primary_doc",
+        fetch_text=lambda _url: _BODY,
+    )
+    assert outcome.status == "restored"
+    # Two writes: raw-row restore + manifest compacted->stored.
+    assert len(conn.executed) == 2
+    restore_sql, restore_params = conn.executed[0]
+    assert "payload_swept_at = NULL" in restore_sql
+    assert restore_params[0] == _BODY
+    manifest_sql, _ = conn.executed[1]
+    assert "raw_status = 'stored'" in manifest_sql
+
+
+def test_rehydrate_noop_when_payload_present() -> None:
+    conn = _FakeConn(_swept_row(payload="<html>live</html>"))
+    outcome = rehydrate_raw_document(
+        conn,  # type: ignore[arg-type]
+        accession_number="a",
+        document_kind="primary_doc",
+        fetch_text=lambda _url: pytest.fail("must not fetch when payload present"),  # type: ignore[arg-type]
+    )
+    assert outcome.status == "already_present"
+    assert conn.executed == []
+
+
+def test_rehydrate_missing_row_raises() -> None:
+    conn = _FakeConn(None)
+    with pytest.raises(ValueError, match="no filing_raw_documents row"):
+        rehydrate_raw_document(
+            conn,  # type: ignore[arg-type]
+            accession_number="a",
+            document_kind="primary_doc",
+            fetch_text=lambda _url: _BODY,
+        )
+
+
+def test_rehydrate_swept_row_without_hash_raises() -> None:
+    conn = _FakeConn(_swept_row(payload_sha256=None))
+    with pytest.raises(RuntimeError, match="no payload_sha256"):
+        rehydrate_raw_document(
+            conn,  # type: ignore[arg-type]
+            accession_number="a",
+            document_kind="primary_doc",
+            fetch_text=lambda _url: _BODY,
+        )
+
+
+def test_rehydrate_swept_row_without_source_url_raises() -> None:
+    conn = _FakeConn(_swept_row(source_url=None))
+    with pytest.raises(RuntimeError, match="no source_url"):
+        rehydrate_raw_document(
+            conn,  # type: ignore[arg-type]
+            accession_number="a",
+            document_kind="primary_doc",
+            fetch_text=lambda _url: _BODY,
+        )

--- a/tests/test_raw_payload_retention_db.py
+++ b/tests/test_raw_payload_retention_db.py
@@ -1,0 +1,275 @@
+"""DB integration tests for the #1014 raw-payload retention sweep.
+
+Spec: docs/specs/etl/2026-06-10-raw-payload-retention-sweep.md.
+
+Two genuinely-new SQL mechanisms, one test each:
+
+1. the chained-CTE sweep batch (eligibility + server-side SHA-256 +
+   payload NULL + manifest stored->compacted, idempotent, dry-run);
+2. the rehydrate / store_raw interleavings over a swept row (the two
+   legal terminal states).
+
+Structural drop-list coverage is pure-logic in
+``tests/test_raw_payload_retention.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import psycopg
+import pytest
+
+from app.services.raw_filings import store_raw
+from app.services.raw_payload_retention import (
+    RawPayloadIntegrityError,
+    rehydrate_raw_document,
+    sweep_raw_payloads,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn, test_database_url  # noqa: F401
+
+_IID = 561014
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], instrument_id: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+            VALUES (%s, %s, %s, TRUE)
+            ON CONFLICT (instrument_id) DO NOTHING
+            """,
+            (instrument_id, f"SWP{instrument_id}", f"Raw sweep test {instrument_id}"),
+        )
+
+
+def _seed_manifest(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    source: str,
+    form: str,
+    ingest_status: str,
+    raw_status: str,
+    issuer: bool = True,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO sec_filing_manifest
+                (accession_number, cik, form, source, subject_type, subject_id,
+                 instrument_id, filed_at, ingest_status, raw_status)
+            VALUES (%s, '0000561014', %s, %s, %s, %s, %s,
+                    TIMESTAMPTZ '2026-01-01 00:00:00+00', %s, %s)
+            """,
+            (
+                accession,
+                form,
+                source,
+                "issuer" if issuer else "institutional_filer",
+                str(_IID) if issuer else "0000561014",
+                _IID if issuer else None,
+                ingest_status,
+                raw_status,
+            ),
+        )
+
+
+def _seed_raw(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    kind: str,
+    payload: str,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO filing_raw_documents
+                (accession_number, document_kind, payload, source_url)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (accession, kind, payload, f"https://www.sec.gov/Archives/{accession}.htm"),
+        )
+
+
+def _raw_row(conn: psycopg.Connection[tuple], *, accession: str, kind: str) -> tuple:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT payload, payload_sha256, payload_swept_at, byte_count
+            FROM filing_raw_documents
+            WHERE accession_number = %s AND document_kind = %s
+            """,
+            (accession, kind),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        return row
+
+
+def _manifest_raw_status(conn: psycopg.Connection[tuple], *, accession: str) -> str:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT raw_status FROM sec_filing_manifest WHERE accession_number = %s",
+            (accession,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        return row[0]
+
+
+_BODY_10K = "<html>annual report body — swept-eligible</html>"
+_BODY_8K = "<html>8-K body — failed parse, must survive</html>"
+
+
+@pytest.mark.integration
+def test_sweep_nulls_only_parsed_swept_source_primary_docs(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, _IID)
+
+    # A — parsed sec_10k primary_doc: THE sweep target.
+    _seed_manifest(conn, accession="swp-a", source="sec_10k", form="10-K", ingest_status="parsed", raw_status="stored")
+    _seed_raw(conn, accession="swp-a", kind="primary_doc", payload=_BODY_10K)
+    # B — sec_8k but ingest_status='failed': keep-on-fail, payload survives.
+    _seed_manifest(conn, accession="swp-b", source="sec_8k", form="8-K", ingest_status="failed", raw_status="stored")
+    _seed_raw(conn, accession="swp-b", kind="primary_doc", payload=_BODY_8K)
+    # C — parsed sec_def14a def14a_body: kind not swept, survives.
+    _seed_manifest(
+        conn, accession="swp-c", source="sec_def14a", form="DEF 14A", ingest_status="parsed", raw_status="stored"
+    )
+    _seed_raw(conn, accession="swp-c", kind="def14a_body", payload="<html>proxy</html>")
+    # D — parsed sec_13f_hr primary_doc: source not in the drop-list, survives.
+    _seed_manifest(
+        conn,
+        accession="swp-d",
+        source="sec_13f_hr",
+        form="13F-HR",
+        ingest_status="parsed",
+        raw_status="stored",
+        issuer=False,
+    )
+    _seed_raw(conn, accession="swp-d", kind="primary_doc", payload="<xml>13f primary</xml>")
+    # E — split row: parsed sec_10k but raw_status='absent' while payload
+    # exists. Already an invariant violation — the sweep must not
+    # compound it (Codex round 1 High).
+    _seed_manifest(conn, accession="swp-e", source="sec_10k", form="10-K", ingest_status="parsed", raw_status="absent")
+    _seed_raw(conn, accession="swp-e", kind="primary_doc", payload="<html>split row</html>")
+    conn.commit()
+
+    # Dry run first: counts only, zero writes.
+    dry = sweep_raw_payloads(database_url=test_database_url(), dry_run=True)
+    assert dry.dry_run is True
+    assert dry.rows_swept == 1
+    assert dry.by_source == {"sec_10k": 1}
+    assert dry.bytes_reclaimed == len(_BODY_10K.encode("utf-8"))
+    assert dry.batches == 0
+    conn.commit()
+    payload, sha, swept_at, _ = _raw_row(conn, accession="swp-a", kind="primary_doc")
+    assert payload == _BODY_10K and sha is None and swept_at is None
+
+    # Real run; batch_size=1 exercises the batching loop.
+    summary = sweep_raw_payloads(database_url=test_database_url(), batch_size=1, dry_run=False)
+    assert summary.rows_swept == 1
+    assert summary.batches == 1
+    assert summary.by_source == {"sec_10k": 1}
+    assert summary.bytes_reclaimed == len(_BODY_10K.encode("utf-8"))
+
+    conn.commit()  # end the idle tx so reads see the service's commits
+
+    # A swept: payload + generated byte_count NULL, hash matches
+    # hashlib over the same text, manifest compacted.
+    payload, sha, swept_at, byte_count = _raw_row(conn, accession="swp-a", kind="primary_doc")
+    assert payload is None
+    assert byte_count is None
+    assert swept_at is not None
+    assert sha == hashlib.sha256(_BODY_10K.encode("utf-8")).hexdigest()
+    assert _manifest_raw_status(conn, accession="swp-a") == "compacted"
+
+    # B/C/D/E untouched.
+    for accession, kind in (
+        ("swp-b", "primary_doc"),
+        ("swp-c", "def14a_body"),
+        ("swp-d", "primary_doc"),
+        ("swp-e", "primary_doc"),
+    ):
+        payload, sha, swept_at, _ = _raw_row(conn, accession=accession, kind=kind)
+        assert payload is not None, accession
+        assert sha is None and swept_at is None, accession
+    assert _manifest_raw_status(conn, accession="swp-b") == "stored"
+    assert _manifest_raw_status(conn, accession="swp-e") == "absent"
+
+    # Idempotent: a drained DB sweeps 0.
+    again = sweep_raw_payloads(database_url=test_database_url(), dry_run=False)
+    assert again.rows_swept == 0
+    assert again.batches == 0
+
+
+@pytest.mark.integration
+def test_rehydrate_and_store_raw_interleavings_over_a_swept_row(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, _IID)
+    _seed_manifest(conn, accession="swp-r", source="sec_10k", form="10-K", ingest_status="parsed", raw_status="stored")
+    _seed_raw(conn, accession="swp-r", kind="primary_doc", payload=_BODY_10K)
+    conn.commit()
+
+    summary = sweep_raw_payloads(database_url=test_database_url(), dry_run=False)
+    assert summary.rows_swept == 1
+    conn.commit()
+
+    # Mismatching re-fetch fails loud and leaves the row swept.
+    with pytest.raises(RawPayloadIntegrityError):
+        rehydrate_raw_document(
+            conn,
+            accession_number="swp-r",
+            document_kind="primary_doc",
+            fetch_text=lambda _url: "<html>tampered</html>",
+        )
+    conn.rollback()
+    payload, _, swept_at, _ = _raw_row(conn, accession="swp-r", kind="primary_doc")
+    assert payload is None and swept_at is not None
+
+    # Matching re-fetch restores: payload back, swept_at cleared, hash
+    # kept (still true), manifest compacted -> stored.
+    outcome = rehydrate_raw_document(
+        conn,
+        accession_number="swp-r",
+        document_kind="primary_doc",
+        fetch_text=lambda _url: _BODY_10K,
+    )
+    conn.commit()
+    assert outcome.status == "restored"
+    payload, sha, swept_at, byte_count = _raw_row(conn, accession="swp-r", kind="primary_doc")
+    assert payload == _BODY_10K
+    assert swept_at is None
+    assert sha == hashlib.sha256(_BODY_10K.encode("utf-8")).hexdigest()
+    assert byte_count == len(_BODY_10K.encode("utf-8"))
+    assert _manifest_raw_status(conn, accession="swp-r") == "stored"
+
+    # Re-sweep the restored row, then store_raw over it (amended
+    # fetch): terminal state must be the live shape with BOTH sweep
+    # columns cleared — a stale hash must never linger against new
+    # bytes (prevention §ON CONFLICT covers all columns).
+    summary = sweep_raw_payloads(database_url=test_database_url(), dry_run=False)
+    assert summary.rows_swept == 1
+    conn.commit()
+    store_raw(
+        conn,
+        accession_number="swp-r",
+        document_kind="primary_doc",
+        payload="<html>amended body</html>",
+    )
+    conn.commit()
+    payload, sha, swept_at, _ = _raw_row(conn, accession="swp-r", kind="primary_doc")
+    assert payload == "<html>amended body</html>"
+    assert sha is None and swept_at is None
+    # Manifest stays 'compacted' until a parser outcome writes
+    # 'stored' — and the 'compacted'-eligible predicate means the row
+    # re-sweeps cleanly:
+    assert _manifest_raw_status(conn, accession="swp-r") == "compacted"
+    final = sweep_raw_payloads(database_url=test_database_url(), dry_run=False)
+    assert final.rows_swept == 1


### PR DESCRIPTION
Closes #1014.

## What

`filing_raw_documents` is the #1 table in the dev DB (5.77 GB on disk, 16 GB raw payload bytes, DB 20 GB). `primary_doc` is 99.8% of that: 10-K (12.3 GB) + 8-K (4.4 GB) primary-document HTML, growing ~2 GB/day during active ingest. This PR adds a manual-only retention sweep that nulls the payload of **parsed** 10-K/8-K `primary_doc` rows after recording a SHA-256 of the bytes destroyed, plus a hash-verified rehydrate path.

Spec: `docs/specs/etl/2026-06-10-raw-payload-retention-sweep.md` (Codex round 1: 2 High / 2 Medium / 1 Low — all addressed; checkpoint-2 fresh-agent review: 2 findings, both fixed, see below). Implements the parent spec's pre-decided policy (`docs/specs/etl/retention.md`: "(future) 10-K body → drop-on-success; (future) 8-K body → keep-on-fail" — parsed-only eligibility is exactly keep-on-fail).

## Why deletion is safe by construction

- **No rewash parser exists for `primary_doc`** — payload is write-only (the only payload readers are `read_raw`/`iter_raw`, called solely by rewash; everything else is COUNT-style diagnostics). Pinned by a structural test: `SWEPT_DOCUMENT_KINDS` must stay disjoint from the rewash registry.
- **The manifest re-parse path re-fetches.** `sec_rebuild` flips `parsed→pending`; the worker's parser fetches from `primary_document_url` unconditionally and `store_raw` re-populates. A swept row is transparently re-hydrated by any re-parse.
- **SHA-256 guard:** recorded server-side (`encode(sha256(convert_to(payload,'UTF8')),'hex')`, verified byte-identical to Python `hashlib` on dev PG 17) in the same UPDATE that nulls the payload. `rehydrate_raw_document` re-fetches, hash-compares, and **raises `RawPayloadIntegrityError` on mismatch** — never auto-overwrites.

## Design points

- **Opt-in destruction list:** eligibility keys on `sec_filing_manifest.source IN ('sec_10k','sec_8k')` (CHECK-constrained enum; amendments collapse) + `ingest_status='parsed'` + `raw_status IN ('stored','compacted')`. New forms default to keep-always. `def14a_body` consciously excluded (it HAS a stored-body rewash consumer). Split rows (`parsed` + `raw_status='absent'` + payload present) are excluded — already an invariant violation, the sweep must not compound it.
- **Manifest flag:** swept accessions flip `raw_status` `stored→'compacted'` — the value sql/118 explicitly reserved for "a future hot-storage eviction path"; no CHECK migration, `RawStatus` Literal already includes it, transition guard already treats it as sticky-non-absent.
- **Sweep shape:** chained data-modifying CTEs, one statement per batch, autocommit conn + per-batch `with conn.transaction()` (mega-table prevention-log shape). `FOR UPDATE OF r SKIP LOCKED` locks only the raw row; the UPDATE re-checks `payload IS NOT NULL` under the lock so a concurrent `store_raw` is never clobbered with a hash-of-nothing. OLD `byte_count` carried out of the batch CTE (RETURNING evaluates the NEW row).
- **`store_raw` ON CONFLICT clears both sweep columns** — a fresh/amended body invalidates the recorded hash (prevention-log §ON CONFLICT covers all columns).
- **`byte_count` (generated from `octet_length(payload)`) goes NULL on swept rows** — intentional: the operator storage chip reports live bytes; reclaimed bytes are in the job summary.
- **Job triangle** (`#1013` shape): manual-only, `dry_run` param **defaults TRUE** at both the trigger layer and the service entrypoint; own lane `db_raw_sweep` (a minutes-long sweep on the catch-all `db` lane would starve `orchestrator_high_frequency_sync` — #1526/#1527 starvation class).
- **Read-path NULL safety:** `RawFilingDocument.payload/byte_count` are now `str|None`/`int|None`; mapping helper never coerces SQL NULL via `str(...)` (prevention-log §`str(row[N])`); `require_payload()` is the narrowing fence for rewash apply-fns; `run_rewash`/`_rewash_13f_accession` skip swept rows.

## Codex checkpoint-2 findings (both FIXED pre-push)

1. Rehydrate's restore UPDATE now re-pins `payload_sha256 = <verified hash>` in the WHERE — a concurrent store_raw + re-sweep during the fetch could otherwise pair stale-verified bytes with a newer hash. `rowcount==0` → `already_present`, nothing written.
2. `sweep_raw_payloads` service entrypoint defaults `dry_run=True` (destructive must be opt-in for REPL/test callers too, not just the trigger layer).

## Security model

No new HTTP surface. The job is reachable only via the authenticated manual-trigger queue (`POST /jobs/raw_payload_retention_sweep/run`), same auth as every other job. `rehydrate_raw_document` takes an injected `fetch_text` callable — no new outbound HTTP code; production callers pass the SEC-rate-limited provider fetch. No user-controlled input reaches SQL (closed enums + parameterised queries).

## Tradeoffs (conscious)

- Hash computed at sweep time, not ingest time: identical guard property, zero ingest-path change, no 16 GB backfill migration. Never-swept rows carry no hash (derivable from payload).
- No per-row `retention_mode` column (issue's original sketch): policy is per `(kind, source)`, lives in one code constant — a column would denormalise a global policy into 230k rows.
- Rehydrate is helper-only (no admin endpoint yet) — operator-driven Python until a UI need appears.
- On-disk shrink needs VACUUM: nulling TOAST payloads makes space reusable; file shrink requires a one-time `VACUUM FULL` (recorded in dev-verify below).
- `scripts/check_13f_hr_retention.sh` invariant-F anchor updated (`parse_infotable(raw_doc.payload)` → `raw_doc.require_payload()`) — textual anchor tracking the rename, semantics unchanged.

## Local gates

`ruff check` ✓ · `ruff format --check` ✓ · `pyright` 0 errors ✓ · fast tier `-m "not db"` 3817 passed ✓ · smoke 129 passed ✓ · targeted db tier (new tests + raw_filings + rewash + def14a/insider/13F ingester modules + triangle wiring) 186 passed ✓.

## Dev-verify (DoD 8–12)

Will be appended to this PR description before merge: dry-run figures, real sweep summary, `pg_total_relation_size` before/after VACUUM, panel smoke (AAPL/GME/MSFT/JPM/HD ownership-rollup), and the EDGAR-direct re-fetch hash cross-check (independent-source verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Dev-verify record (executed 2026-06-10, commit f1de86447814d321f064e661a2b439a12ebf016b)

- **Migration**: sql/190 applied to dev (drift-guard hash recorded via lifespan run).
- **Dry-run** (service, read-only): eligible **12,277 rows / 14.19 GiB** — `{'sec_10k': 3173, 'sec_8k': 9104}` — matched the independent eligibility query.
- **Real sweep**: **12,284 rows / 15,239,831,430 bytes (14.19 GiB) nulled in 123 batches, 65.7 s**; `by_source={'sec_8k': 9111, 'sec_10k': 3173}` (delta vs dry-run = live ingest between runs). Per-batch top-level commits observed mid-run (10,100 rows visible from a separate conn while running).
- **Integrity**: 0 rows violating `chk_swept_rows_carry_hash` shape; all 12,284 parsed 10-K/8-K manifest rows now `raw_status='compacted'`; no rows deleted (UPDATE-only path).
- **Storage**: `pg_total_relation_size('filing_raw_documents')` **5,926 MB → 742 MB** after one-time `VACUUM FULL` (10.3 s); `pg_database_size('ebull')` **20 GB → 15 GB**. Plain `VACUUM (ANALYZE)` (14.1 s) run first — space reusable but file unshrunk, as documented in the spec.
- **Panel smoke (DoD 8)**: `/instruments/{AAPL,GME,MSFT,JPM,HD}/ownership-rollup` all **200** with shares_outstanding figures rendering — sweep touches no typed tables.
- **Cross-source (DoD 9) + reproducibility guard end-to-end**: AAPL FY2025 10-K `0000320193-25-000079` re-fetched from **SEC EDGAR direct** (`aapl-20250927.htm`, 1,520,208 bytes): fresh-fetch SHA-256 `548ae59778cf08ee0f2ee088e7ece20d947076c3c01f74d2d65db4c2777e436a` == stored `payload_sha256` recorded at sweep time. Byte-identity proven across destroy/re-fetch.
- **Operator-visible render (DoD 11)**: `/instruments/AAPL/eight_k_filings` 200, `/instruments/AAPL/summary` 200 post-sweep.
- **Note**: the `raw_payload_retention_sweep` manual trigger becomes available in the admin UI after the next jobs-process restart onto main (current dev jobs proc predates this branch); the sweep itself was executed via the service entrypoint, which is the same code path the trigger wrapper calls.
