### PR TITLE
ops(#1556): rebase DB_SIZE_WARN_BYTES 10 GB -> 30 GB against post-sweep baseline

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -299,7 +299,7 @@ fi
 # || true on every docker exec so set -euo pipefail (top of file)
 # cannot kill the whole hook if psql is briefly unavailable — same
 # best-effort posture as the orphan-sweep cleanup.
-DB_SIZE_WARN_BYTES=10737418240  # 10 GB
+DB_SIZE_WARN_BYTES=32212254720  # 30 GB — rebased #1556; mirror of app/services/postgres_health.py
 if command -v docker >/dev/null 2>&1; then
   db_size=$(docker exec ebull-postgres psql -U postgres -d ebull -tAc \
     "SELECT pg_database_size('ebull')" 2>/dev/null | tr -d ' ' || true)
@@ -312,7 +312,7 @@ if command -v docker >/dev/null 2>&1; then
     pretty=$(docker exec ebull-postgres psql -U postgres -d ebull -tAc \
       "SELECT pg_size_pretty(pg_database_size('ebull'))" 2>/dev/null \
       | tr -d ' ' || true)
-    echo '==> WARN: dev DB ebull size = '"${pretty}"' (> 10 GB).'
+    echo '==> WARN: dev DB ebull size = '"${pretty}"' (> 30 GB).'
     echo '==> WARN: investigate via GET /system/postgres-health.'
     echo '==> WARN: non-blocking; push continues.'
   fi

--- a/app/services/postgres_health.py
+++ b/app/services/postgres_health.py
@@ -3,8 +3,8 @@
 Surfaces the five operator signals that Phases 1-3 of #1208 lacked a
 live readout for:
 
-- `pg_database_size('ebull')` against a 10 GB warn threshold (matches
-  the pre-push hook gate at `.githooks/pre-push`).
+- `pg_database_size('ebull')` against a 30 GB warn threshold (matches
+  the pre-push hook gate at `.githooks/pre-push`; rebased by #1556).
 - Leaked `ebull_test_*` DB count + names (Phase 2 enforced zero leaks
   but had no operator surface).
 - WAL: `wal_dir_bytes` (size of pg_wal/ on disk) against a 4 GB
@@ -51,8 +51,17 @@ logger = logging.getLogger(__name__)
 # DB_SIZE_WARN_BYTES is also pinned in `.githooks/pre-push`. The
 # `tests/test_pre_push_hook_bloat_warn.py::test_pre_push_hook_threshold_matches_db_size_warn`
 # test asserts the two stay aligned by parsing the hook file.
+#
+# Rebased 10 GB -> 30 GB (#1556, 2026-06-10): the 10 GB value predates
+# the bulk-first SEC redesign and had been permanently breached by
+# genuine live data (always-red alarm = operator noise, same failure
+# class as #1221). Measured genuine baseline after the #1349 cusips
+# grain collapse + the #1014 primary_doc payload sweep + VACUUM FULL:
+# 15 GB (2026-06-10). 30 GB = 2x headroom over the swept baseline; the
+# alarm now means "something is growing unexpectedly", not "the DB
+# contains data".
 
-DB_SIZE_WARN_BYTES: int = 10 * 1024 * 1024 * 1024  # 10 GB
+DB_SIZE_WARN_BYTES: int = 30 * 1024 * 1024 * 1024  # 30 GB
 # 4 GB absolute pg_wal disk-bloat alarm. Effective max_wal_size is 1 GB
 # (docker-compose `command:` flag, #1410), so steady-state pg_wal sits
 # well below this even during bootstrap write bursts; crossing 4 GB


### PR DESCRIPTION
Closes #1556.

## What

`DB_SIZE_WARN_BYTES` 10 GB → 30 GB in both threshold sites, in lockstep:
- `app/services/postgres_health.py` constant (+ rationale comment + stale module-docstring prose corrected)
- `.githooks/pre-push` literal `32212254720` (+ its operator-facing WARN message text, which still said "> 10 GB" — Codex checkpoint-2 catch)

Growth-trend stretch (`db_size_growth_7d` informational field) consciously deferred to #1564 — an absolute threshold goes stale as genuine data grows; a bytes/week trend is the durable fix, but the rebase restores the alarm's signal value today.

## Why

The 10 GB value predates the bulk-first SEC redesign; `db_size_breached_warn` has been permanently True on genuine live data — an always-red alarm is operator noise that erodes trust in the health surface (#1221 failure class). Issue #1556 explicitly sequenced this AFTER #1349 (cusips grain, merged 37ac871) and #1014 (primary_doc payload sweep, merged 36084c2) so the new threshold reflects a swept baseline rather than baking bloat in.

**Measured genuine baseline (dev, 2026-06-10, post-#1349 + post-#1014 sweep + one-time VACUUM FULL): 15 GB** (`pg_database_size('ebull')`; was 20 GB pre-sweep). 30 GB = 2× headroom over the swept baseline — the alarm now means "something is growing unexpectedly", not "the DB contains data".

## Security model

No security-relevant surface: a monitoring threshold constant + a local git-hook message. No input handling, no auth paths.

## Verification

- `tests/test_pre_push_hook_bloat_warn.py` (alignment gate parsing the hook literal vs the Python constant) — 3 passed.
- `tests/test_api_postgres_health.py` — 9 passed (threshold injected per-test; no behavior change).
- `ruff check` ✓ `ruff format --check` ✓ `pyright` 0 errors ✓.
- Byte arithmetic: 30 × 1024³ = 32,212,254,720 (Codex-confirmed).
- Repo-wide sweep for further mirrors of the old literal/prose: none remain (`grep -rn "10737418240\|> 10 GB"` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)