### PR TITLE
fix(#953,#954): 13F rewash — layer-consistent dedupe + stale observation sweep

### DIFF
--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -108,6 +108,22 @@ assert rec.rationale == "No action trigger met; score=0.600 rank=2"
 assert rec.rationale == _hold_rationale(score_row, quote_is_fallback=False)
 ```
 
+## Scope the deliberate DB-tier run to the diff — NEVER bare `pytest -m db` locally
+
+Bare full-suite `uv run pytest -m db` on the dev Mac has wedged twice (2026-06-09:
+froze at startup, zero workers; 2026-06-10: ran 2h02m to 98% then froze with all
+xdist workers dead — a moving progress bar does not mean it will finish). Even when
+it moves, ~4,300 db tests × 1-3s fixture overhead ≈ an hour+ of wall-clock for
+milliseconds of test logic; suite-shape fix tracked in #1568.
+
+Operator decision: never block a small PR on the full tier. The "run the DB tier
+deliberately" rule is satisfied by running the test files for the touched modules +
+immediate neighbours (e.g. a 2-file rewash change → 4 files / 105 tests / ~60s).
+For broad surface (migrations touching many tables, conftest/fixture changes,
+schema-wide refactors) run the tier in file-scoped batches, not bare `-m db`. A run
+with 0% CPU and no `gw*` workers is wedged: `kill -9` it, then reap leaked test DBs
+with `uv run python -m tests.fixtures.cleanup_test_dbs`.
+
 ## DB write + return value consistency
 
 If a function both writes to the DB and returns a result object, there must be a test verifying the returned object matches what was written. Silent divergence between in-memory and persisted state is a real bug class.

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -978,14 +978,24 @@ def _apply_13f_infotable(
     # the existing rows were silently destroyed with no replacement
     # and no path to repair (return False prevented the bump but
     # the typed table was already empty).
-    resolved: list[tuple[int, Any]] = []  # (instrument_id, holding)
+    # #954 — mirror the first-ingest dedupe (``resolved_by_key`` in
+    # ``institutional_holdings._ingest_single_accession``): collapse
+    # duplicate XML rows by (instrument_id, exposure) keeping the FIRST,
+    # matching the typed table's ON CONFLICT DO NOTHING collapse on
+    # (accession, instrument, COALESCE(is_put_call, 'EQUITY')). Without
+    # this, the observations UPSERT (ON CONFLICT DO UPDATE) keeps the
+    # LAST duplicate while the typed table keeps the first — the two
+    # layers diverge on shares/value for the same holding.
+    resolved_by_key: dict[tuple[int, str], tuple[int, Any]] = {}
     skipped_no_cusip = 0
     for holding in holdings:
         instrument_id = _resolve_cusip_to_instrument_id(conn, holding.cusip)
         if instrument_id is None:
             skipped_no_cusip += 1
             continue
-        resolved.append((instrument_id, holding))
+        exposure_key = holding.put_call if holding.put_call in ("PUT", "CALL") else "EQUITY"
+        resolved_by_key.setdefault((instrument_id, exposure_key), (instrument_id, holding))
+    resolved: list[tuple[int, Any]] = list(resolved_by_key.values())  # (instrument_id, holding)
 
     # ANY unresolved CUSIP defers the rewash — neither full replace
     # nor partial replace is safe:
@@ -1044,6 +1054,31 @@ def _apply_13f_infotable(
             (raw_doc.accession_number,),
         )
 
+    # #953 — mirror the typed-table DELETE on the observations layer.
+    # A parser fix that drops/changes a CUSIP would otherwise leave the
+    # dropped instrument's observation row live (known_to IS NULL) with
+    # stale shares, and its ownership_institutions_current never
+    # re-MERGEd. RETURNING captures the prior instrument set in the
+    # same statement (no SELECT-then-DELETE race) so dropped
+    # instruments get refreshed below — the MERGE's NOT MATCHED BY
+    # SOURCE arm removes their stale _current row. DELETE rather than
+    # known_to-tombstone: record_institution_observation's ON CONFLICT
+    # DO UPDATE never clears known_to, so a tombstoned row re-asserted
+    # by a later rewash would stay invisible to the _current MERGE
+    # (WHERE known_to IS NULL) forever. Same tx + same accession lock
+    # as the typed-table replace — no visibility gap. '13f' matches the
+    # source literal _record_13f_observations_for_filing writes.
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM ownership_institutions_observations
+            WHERE source = '13f' AND source_document_id = %s
+            RETURNING instrument_id
+            """,
+            (raw_doc.accession_number,),
+        )
+        prior_instrument_ids = {int(r[0]) for r in cur.fetchall()}
+
     inserted = 0
     for instrument_id, holding in resolved:
         _upsert_holding(
@@ -1059,15 +1094,15 @@ def _apply_13f_infotable(
 
     # Write-through to observations + refresh ownership_institutions_current
     # so the rollup (#905 read-path cutover) reflects the recovered
-    # holdings on the same transaction. Mirrors the first-ingest path
-    # in app/services/institutional_holdings.py:1260-1274. Without this,
+    # holdings on the same transaction. Mirrors the first-ingest
+    # write-through in ``_ingest_single_accession``. Without this,
     # ``cusip_resolver.sweep_resolvable_unresolved_cusips`` would happily
     # log "rewashed accession=..." while leaving every ownership rollup
     # query showing zero institutional shares (#945).
-    if resolved:
-        from app.services.institutional_holdings import _record_13f_observations_for_filing
-        from app.services.ownership_observations import refresh_institutions_current
+    from app.services.institutional_holdings import _record_13f_observations_for_filing
+    from app.services.ownership_observations import refresh_institutions_current
 
+    if resolved:
         # ``filed_at`` from the SELECT above is a tuple-row Decimal/None
         # type (psycopg returned timestamptz) — record_institution_observation
         # expects a datetime. The first-ingest path threads the same
@@ -1081,8 +1116,15 @@ def _apply_13f_infotable(
             filed_at=filed_at,
             resolved_holdings=resolved,
         )
-        for unique_instrument_id in {iid for iid, _ in resolved}:
-            refresh_institutions_current(conn, instrument_id=unique_instrument_id)
+    # #953 — refresh over the UNION of prior + new instruments, not just
+    # new: an instrument the re-parse dropped needs its _current row
+    # re-MERGEd (to nothing) now that its observation rows are deleted.
+    # Outside the ``if resolved`` guard deliberately — resolved is
+    # provably non-empty here today (empty parse and unresolved-CUSIP
+    # paths return earlier), but if a refactor ever changes that, the
+    # deleted prior observations must still propagate to _current.
+    for unique_instrument_id in prior_instrument_ids | {iid for iid, _ in resolved}:
+        refresh_institutions_current(conn, instrument_id=unique_instrument_id)
 
     # Log full success.
     with conn.cursor() as cur:

--- a/docs/proposals/etl/2026-06-10-13f-rewash-observations-consistency.md
+++ b/docs/proposals/etl/2026-06-10-13f-rewash-observations-consistency.md
@@ -1,0 +1,81 @@
+# 13F rewash ↔ observations consistency (#953 + #954)
+
+Status: plan for review. Both bugs live in `app/services/rewash_filings.py::_apply_13f_infotable`; latent today (CUSIP sweep recovers identical CUSIPs), fire on any parser fix that changes/drops a CUSIP or on duplicate XML rows.
+
+## #954 — dedupe mismatch
+
+Rewash builds `resolved: list[(instrument_id, holding)]` without collapsing duplicate
+`(instrument_id, exposure_kind)` rows. Typed table keeps FIRST dup
+(`_upsert_holding` ON CONFLICT DO NOTHING on partial unique index
+`(accession, instrument, COALESCE(is_put_call,'EQUITY'))`); observations recorder
+(`record_institution_observation` ON CONFLICT DO UPDATE) keeps LAST. First ingest
+already dedupes at `institutional_holdings.py:1597-1633` (`resolved_by_key.setdefault`).
+
+Fix: mirror the first-ingest dedupe in the rewash resolution loop —
+`resolved_by_key: dict[tuple[int, str], tuple[int, ThirteenFHolding]]`, key
+`(instrument_id, put_call if in ("PUT","CALL") else "EQUITY")`, `setdefault` keep-first,
+`resolved = list(resolved_by_key.values())`. Side effect: `inserted` count becomes exact
+(prevention-log "ON CONFLICT DO NOTHING counter overcount").
+
+## #953 — stale observations on CUSIP change
+
+Rewash DELETEs+reinserts `institutional_holdings` for the accession, but write-through
+only records observations for the NEW resolved set and refreshes
+`ownership_institutions_current` only for NEW instruments. If a parser fix drops
+instrument A: A's `ownership_institutions_observations` row for the accession stays
+live (`known_to IS NULL`) and A's `_current` is never re-MERGEd → rollup keeps stale figure.
+
+Fix (DELETE, not tombstone): inside the existing `acquire_13f_accession_write_lock`
+window, next to the typed-table DELETE:
+
+1. `SELECT DISTINCT instrument_id FROM ownership_institutions_observations
+   WHERE source = '13f' AND source_document_id = %(accession)s` → `prior_instrument_ids`.
+2. `DELETE FROM ownership_institutions_observations
+   WHERE source = '13f' AND source_document_id = %(accession)s` — mirrors the typed-table
+   DELETE; same tx so no visibility gap.
+3. Write-through re-records the new set (unchanged recorder).
+4. Refresh `_current` over `prior_instrument_ids | {new instrument ids}` — dropped
+   instruments get re-MERGEd; their stale `_current` row falls out via the
+   `WHEN NOT MATCHED BY SOURCE ... DELETE` arm.
+
+Why DELETE not `known_to` tombstone: `record_institution_observation`'s ON CONFLICT
+DO UPDATE never clears `known_to`; a tombstoned row re-asserted by a later rewash would
+stay invisible to the `_current` MERGE (`WHERE known_to IS NULL`) forever — silent data
+loss. DELETE keeps both layers symmetric (typed table already does DELETE+INSERT).
+
+Identity note: within one accession, observation identity
+`(instrument_id, filer_cik, ownership_nature, period_end, source_document_id, exposure_kind)`
+reduces to `(instrument_id, exposure_kind)` — filer_cik/nature('economic')/period_end are
+constant. The accession-scoped DELETE also sweeps any historical drift rows (e.g. obs
+written under an older period_end for the same accession).
+
+## Out of scope (note in PR)
+
+Live re-ingest path (`_ingest_single_accession`) has the symmetric staleness for
+operator-forced re-ingest — but its typed table is ON CONFLICT DO NOTHING (no DELETE),
+so typed + obs stay consistent with each other there. #953 is scoped to rewash.
+
+## Tests (DB tier, `tests/test_rewash_filings.py`, existing fixture patterns)
+
+1. `test_13f_infotable_rewash_dedupes_duplicate_xml_rows` (#954 Done): parser emits two
+   rows for same (instrument, EQUITY) with different shares → exactly one row in
+   `institutional_holdings` AND one in `ownership_institutions_observations`, both
+   carrying the FIRST row's shares/value.
+2. `test_13f_infotable_rewash_clears_stale_observations_for_dropped_instrument`
+   (#953 Done, sharpened per Codex ckpt-1): seed typed holding + observation (via
+   `record_institution_observation`) + `_current` (via `refresh_institutions_current`)
+   under instrument A, PLUS a period-drifted obs row for the same accession (older
+   `period_end` — distinct conflict identity, so the upsert alone would never clear it);
+   rewash parser emits only instrument B → A's obs rows for the accession gone (both
+   period_ends), A's `_current` empty, B present in obs AND `_current` (pins both the
+   refresh-union fan-out and the MERGE delete arm).
+
+## Gates
+
+ruff / pyright / fast tier / smoke + `pytest -m db` (DB/SQL change) + targeted
+`pytest tests/test_rewash_filings.py`. Codex ckpt-2 pre-push with financial-plumbing /
+data-engineer / data-scientist / adversarial lenses (pre-pr-fresh-agent-review).
+
+Dev-verify: no schema change, no backfill needed (latent bug — current dev data has no
+divergence by construction; verify with a divergence probe query: accessions where obs
+rows exist without matching typed rows). Record probe result in PR.

--- a/docs/proposals/etl/2026-06-10-13f-rewash-observations-consistency.md
+++ b/docs/proposals/etl/2026-06-10-13f-rewash-observations-consistency.md
@@ -76,6 +76,22 @@ ruff / pyright / fast tier / smoke + `pytest -m db` (DB/SQL change) + targeted
 `pytest tests/test_rewash_filings.py`. Codex ckpt-2 pre-push with financial-plumbing /
 data-engineer / data-scientist / adversarial lenses (pre-pr-fresh-agent-review).
 
-Dev-verify: no schema change, no backfill needed (latent bug — current dev data has no
-divergence by construction; verify with a divergence probe query: accessions where obs
-rows exist without matching typed rows). Record probe result in PR.
+Dev-verify: no schema change, no backfill needed. Divergence probe ran 2026-06-10
+(dev DB): 2,856,833 obs rows / 24,734 accessions exist with NO typed rows — ALL
+classified `accession_absent_from_typed` (bulk dataset path `sec_13f_dataset_ingest.py`
+writes observations only, by design — #807 bulk-first). Instrument-level drift
+(`accession_in_typed_diff_instruments`, the #953 damage class): **zero rows** — bug
+confirmed latent, nothing to repair.
+
+Codex ckpt-2 (2026-06-10): no correctness bugs in diff. Pre-existing touched-path gap
+(rewash + legacy ingest lack PRN filter + pre-2023 VALUE ×1000 that the manifest parser
+applies) → DEFERRED #1566, including the post-#953 interplay (rewash re-record can
+re-insert PRN rows bulk seeding excluded).
+
+Cross-source (2026-06-10, SEC EDGAR direct): Vanguard Q4-2025 AAPL — dev obs
+1,279,051,701 shares traces EXACTLY to the SOLE-discretion infotable row in accession
+0000102909-26-000031 (data path validated). But the filing carries 7 AAPL rows
+(sub-manager splits) summing 1,426,283,914 — the settled keep-first dedupe drops the
+other 6 (10.3% undercount on AAPL's largest holder). Filed #1567 (systematic, affects
+all multi-sub-manager filers, all ingest paths). #954 deliberately preserves keep-first
+for layer consistency; the semantic fix is #1567's.

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -18,13 +18,20 @@ Pins the contract:
 from __future__ import annotations
 
 from collections.abc import Iterator
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from typing import Literal
+from uuid import uuid4
 
 import psycopg
 import pytest
 
+from app.providers.implementations.sec_13f import ThirteenFHolding
 from app.services import raw_filings, rewash_filings
+from app.services.ownership_observations import (
+    record_institution_observation,
+    refresh_institutions_current,
+)
 from app.services.raw_filings import RawFilingDocument
 from app.services.rewash_filings import (
     ParserSpec,
@@ -1541,6 +1548,222 @@ def test_13f_infotable_apply_replaces_holdings_with_re_resolved_instrument(
         )
         rows = cur.fetchall()
     assert [r[0] for r in rows] == [new_iid]
+
+
+def _mk_13f_holding(
+    *, cusip: str, shares: str, value: str, put_call: Literal["PUT", "CALL"] | None = None
+) -> ThirteenFHolding:
+    return ThirteenFHolding(
+        cusip=cusip,
+        name_of_issuer="Issuer",
+        title_of_class="COM",
+        value_usd=Decimal(value),
+        shares_or_principal=Decimal(shares),
+        shares_or_principal_type="SH",
+        put_call=put_call,
+        investment_discretion=None,
+        voting_sole=Decimal(shares),
+        voting_shared=Decimal("0"),
+        voting_none=Decimal("0"),
+    )
+
+
+def _seed_13f_typed_row(conn: psycopg.Connection[tuple], *, accession: str, instrument_id: int) -> int:
+    """Seed filer cik 0000111000 + one typed holding; returns filer_id."""
+    conn.execute(
+        "INSERT INTO institutional_filers (cik, name) VALUES ('0000111000', 'Test') ON CONFLICT (cik) DO NOTHING",
+    )
+    with conn.cursor() as cur:
+        cur.execute("SELECT filer_id FROM institutional_filers WHERE cik = '0000111000'")
+        row = cur.fetchone()
+    assert row is not None
+    filer_id = int(row[0])
+    conn.execute(
+        """
+        INSERT INTO institutional_holdings (
+            filer_id, instrument_id, accession_number, period_of_report,
+            shares, market_value_usd, voting_authority, filed_at
+        ) VALUES (%s, %s, %s, '2025-09-30', 100, 1000, 'SOLE', '2025-11-01')
+        """,
+        (filer_id, instrument_id, accession),
+    )
+    return filer_id
+
+
+def test_13f_infotable_rewash_dedupes_duplicate_xml_rows(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """#954 — duplicate XML rows for the same (instrument, exposure_kind)
+    must collapse keep-FIRST in BOTH the typed table and the observations
+    table. Pre-fix the typed table kept the first (ON CONFLICT DO NOTHING)
+    while the observations UPSERT kept the last — layers diverged."""
+    conn = ebull_test_conn
+    iid = 950_090
+    accession = "0001234567-26-000954"
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, 'DUP13F', 'Dup', '4', 'USD', TRUE) ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid,),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cusip', 'DUP13FCSP', FALSE)
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
+        """,
+        (iid,),
+    )
+    _seed_13f_typed_row(conn, accession=accession, instrument_id=iid)
+    _seed_raw(conn, accession=accession, kind="infotable_13f", parser_version="13f-infotable-v0")
+    conn.commit()
+
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_13f.parse_infotable",
+        lambda _xml: [
+            _mk_13f_holding(cusip="DUP13FCSP", shares="100", value="1000"),
+            _mk_13f_holding(cusip="DUP13FCSP", shares="999", value="9990"),
+        ],
+    )
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="infotable_13f",
+            current_version="13f-infotable-v1",
+            apply_fn=rewash_filings._apply_13f_infotable,
+        )
+    )
+
+    result = run_rewash(conn, document_kind="infotable_13f")
+    assert result.rows_reparsed == 1
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT shares FROM institutional_holdings WHERE accession_number = %s",
+            (accession,),
+        )
+        typed = cur.fetchall()
+        cur.execute(
+            "SELECT shares FROM ownership_institutions_observations WHERE source = '13f' AND source_document_id = %s",
+            (accession,),
+        )
+        obs = cur.fetchall()
+    # Exactly one row per layer, both carrying the FIRST duplicate's shares.
+    assert [r[0] for r in typed] == [Decimal("100")]
+    assert [r[0] for r in obs] == [Decimal("100")]
+
+
+def test_13f_infotable_rewash_clears_stale_observations_for_dropped_instrument(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """#953 — a rewash whose re-parse drops instrument A must delete A's
+    accession-scoped observation rows (including period-drifted ones the
+    UPSERT identity would never touch) and re-MERGE A's _current to empty,
+    while instrument B lands in both layers."""
+    conn = ebull_test_conn
+    old_iid = 950_091
+    new_iid = 950_092
+    accession = "0001234567-26-000953"
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, 'OLDOBS', 'Old', '4', 'USD', TRUE), (%s, 'NEWOBS', 'New', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (old_iid, new_iid),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cusip', 'OLDOBSCSP', FALSE), (%s, 'sec', 'cusip', 'NEWOBSCSP', FALSE)
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
+        """,
+        (old_iid, new_iid),
+    )
+    _seed_13f_typed_row(conn, accession=accession, instrument_id=old_iid)
+    _seed_raw(conn, accession=accession, kind="infotable_13f", parser_version="13f-infotable-v0")
+    # Observation rows under A for this accession: the current-period row
+    # the first ingest would have written, plus a period-drifted row whose
+    # conflict identity (period_end differs) the re-record UPSERT can never
+    # reach — only the accession-scoped DELETE clears it.
+    for period_end in (date(2025, 9, 30), date(2025, 6, 30)):
+        record_institution_observation(
+            conn,
+            instrument_id=old_iid,
+            filer_cik="0000111000",
+            filer_name="Test",
+            filer_type=None,
+            ownership_nature="economic",
+            source="13f",
+            source_document_id=accession,
+            source_accession=accession,
+            source_field=None,
+            source_url=None,
+            filed_at=datetime(2025, 11, 1, tzinfo=UTC),
+            period_start=None,
+            period_end=period_end,
+            ingest_run_id=uuid4(),
+            shares=Decimal("100"),
+            market_value_usd=Decimal("1000"),
+            voting_authority="SOLE",
+            exposure_kind="EQUITY",
+        )
+    refresh_institutions_current(conn, instrument_id=old_iid)
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM ownership_institutions_current WHERE instrument_id = %s",
+            (old_iid,),
+        )
+        row = cur.fetchone()
+    assert row is not None and int(row[0]) >= 1  # stale state seeded
+
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_13f.parse_infotable",
+        lambda _xml: [_mk_13f_holding(cusip="NEWOBSCSP", shares="200", value="2000")],
+    )
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="infotable_13f",
+            current_version="13f-infotable-v1",
+            apply_fn=rewash_filings._apply_13f_infotable,
+        )
+    )
+
+    result = run_rewash(conn, document_kind="infotable_13f")
+    assert result.rows_reparsed == 1
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT instrument_id, shares FROM ownership_institutions_observations "
+            "WHERE source = '13f' AND source_document_id = %s",
+            (accession,),
+        )
+        obs = cur.fetchall()
+        cur.execute(
+            "SELECT COUNT(*) FROM ownership_institutions_current WHERE instrument_id = %s",
+            (old_iid,),
+        )
+        old_current = cur.fetchone()
+        cur.execute(
+            "SELECT shares FROM ownership_institutions_current WHERE instrument_id = %s",
+            (new_iid,),
+        )
+        new_current = cur.fetchall()
+    # A's rows (both period_ends) swept; only B remains for the accession.
+    assert [(r[0], r[1]) for r in obs] == [(new_iid, Decimal("200"))]
+    assert old_current is not None and int(old_current[0]) == 0  # MERGE delete arm fired
+    assert [r[0] for r in new_current] == [Decimal("200")]
 
 
 def test_13f_infotable_apply_returns_false_when_cusip_unresolved(


### PR DESCRIPTION
Closes #953. Closes #954.

## What

Two consistency bugs in `app/services/rewash_filings.py::_apply_13f_infotable` (the 13F rewash used by the CUSIP extid sweep), both latent today, both firing the moment a parser fix changes/drops a CUSIP or a filing carries duplicate XML rows:

- **#954 dedupe mismatch:** rewash passed the full `resolved` list to the observations recorder. Typed table keeps the FIRST duplicate (`_upsert_holding` ON CONFLICT DO NOTHING on the partial unique index `(accession, instrument, COALESCE(is_put_call,'EQUITY'))`); the observations UPSERT (ON CONFLICT DO UPDATE) kept the LAST — layers diverged on shares/value. Fix: mirror the first-ingest `resolved_by_key.setdefault` dedupe (keep-first by `(instrument_id, exposure)`), identical to `institutional_holdings._ingest_single_accession` and the manifest parser.
- **#953 stale observations:** rewash DELETE+INSERTed `institutional_holdings` for the accession but never removed prior `ownership_institutions_observations` rows, and refreshed `ownership_institutions_current` only over the NEW instrument set. A dropped instrument kept a live (`known_to IS NULL`) observation with stale shares and a stale `_current` row forever. Fix: accession-scoped `DELETE ... RETURNING instrument_id` on the observations table (inside the existing #1542 per-accession advisory lock, same transaction as the typed-table replace), then refresh `_current` over the **union** of prior + new instruments — the dropped instrument's `_current` row falls out via the MERGE `WHEN NOT MATCHED BY SOURCE ... DELETE` arm.

## Security model

No new external input. The rewash path parses raw payloads already persisted in `filing_raw_documents`; all SQL parameterised; the new DELETE is scoped by `source = '13f' AND source_document_id = <accession>` and serialised against live ingest by the pre-existing `acquire_13f_accession_write_lock`. No auth surface touched.

## Conscious tradeoffs

- **DELETE, not `known_to` tombstone** (issue offered both): `record_institution_observation`'s ON CONFLICT DO UPDATE never clears `known_to`, so a tombstoned row re-asserted by a later rewash would stay invisible to the `_current` MERGE (`WHERE known_to IS NULL`) forever — silent data loss. DELETE keeps the observations layer symmetric with the typed table's existing DELETE+INSERT, in one transaction.
- **Keep-first dedupe preserved, not SUM:** #954's contract is layer consistency with the settled first-ingest pattern (#889). Cross-source verification exposed that keep-first systematically undercounts multi-sub-manager filings (see #1567) — that is a shared-semantics fix across all four ingest paths, out of scope here.
- **Refresh fan-out is per-instrument** (mirrors first-ingest); union at most doubles the loop on a rewash, which is rare by construction.
- Live re-ingest (`_ingest_single_accession`) has no symmetric staleness risk: its typed-table path is ON CONFLICT DO NOTHING (no DELETE), so layers stay mutually consistent there.

## Plan + Codex checkpoints

- Plan doc: `docs/proposals/etl/2026-06-10-13f-rewash-observations-consistency.md` (in this PR).
- Codex ckpt-1 (plan): design confirmed (DELETE-not-tombstone, dedupe parity); 2 Medium test-shape findings folded in (assert B's `_current` inserted; period-drift row sweep).
- Codex ckpt-2 (branch, fresh-agent lenses): "No correctness bugs found in the #953/#954 diff." One pre-existing touched-path gap (PRN filter + pre-2023 VALUE ×1000 missing from rewash + legacy ingest; manifest parser has both) → **DEFERRED #1566**.

## Tests

`tests/test_rewash_filings.py` (DB tier, existing fixture patterns):

- `test_13f_infotable_rewash_dedupes_duplicate_xml_rows` (#954 Done criterion): two XML rows for same (instrument, EQUITY) → exactly one row in BOTH `institutional_holdings` and `ownership_institutions_observations`, both carrying the FIRST duplicate's shares.
- `test_13f_infotable_rewash_clears_stale_observations_for_dropped_instrument` (#953 Done criterion): seeds typed row + two observation rows under instrument A (one period-drifted — unreachable by the re-record UPSERT identity) + A's `_current`; rewash emits only instrument B → A's obs rows gone (both period_ends), A's `_current` empty (MERGE delete arm), B present in obs + `_current`.

## Local gates (all green)

- `uv run ruff check .` + `ruff format --check .` — pass
- `uv run pyright` — 0 errors
- `uv run pytest -m "not db"` — 3817 passed
- `uv run pytest tests/smoke` — 129 passed
- `uv run pytest -m db` (deliberate full integration tier, DB/SQL change) — result recorded below
- Targeted: `tests/test_rewash_filings.py tests/test_cusip_resolver.py tests/test_thirteen_f_retention_cap.py tests/test_ownership_observations.py` — 105 passed

## DoD ETL clauses 8–12

- **(8) Panel smoke (dev):** `/instruments/{symbol}/ownership-rollup` HTTP 200 with populated institutions slice for all five: AAPL 4,716,896,953 sh / 32.12% / 6,297 filers · GME 58,713,959 / 13.09% / 437 · MSFT 2,976,878,523 / 40.07% / 6,518 · JPM 856,588,145 / 31.97% / 5,343 · HD 313,506,012 / 31.44% / 4,554.
- **(9) Cross-source (SEC EDGAR direct):** dev observation for Vanguard/AAPL Q4-2025 = 1,279,051,701 shares — traces EXACTLY to the SOLE-discretion infotable row of accession 0000102909-26-000031 (data path validated). The filing's 7 AAPL sub-manager rows sum to 1,426,283,914; the keep-first undercount is the settled shared semantic, now tracked as **#1567** (out of scope here, deliberately preserved for layer consistency).
- **(10) Backfill:** not applicable — divergence probe on dev classified ALL 2,856,833 typed-absent obs rows (24,734 accessions) as `accession_absent_from_typed` = bulk-dataset-path observations (obs-only by design, #807). The #953 damage class (`accession_in_typed_diff_instruments`) returned **zero rows** — bug latent, nothing to repair, no rebuild triggered.
- **(11) Operator-visible figure:** panel figures above rendered post-change from the live dev endpoint (rewash path changed only; read path untouched).
- **(12)** All verification above executed at commit `e425b46` (+ any follow-ups recorded in comments).

## Follow-ups filed

- #1566 — PRN filter + pre-2023 VALUE ×1000 missing from rewash + legacy ingest (Codex ckpt-2 finding) + post-#953 interplay (rewash re-record can re-insert PRN rows the bulk path excluded).
- #1567 — keep-first dedupe drops sub-manager split rows (10.3% AAPL/Vanguard undercount, EDGAR-confirmed); systematic across all multi-manager filers + all ingest paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
