### PR TITLE
fix(#899): insider observations filed_at = SEC filing timestamp, coordinated backfill

### DIFF
--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -47,6 +47,7 @@ from app.services.insider_transactions import (
     ParsedForm3,
     ParsedHolding,
     _canonical_form_4_url,
+    lookup_sec_filed_at,
     parse_form_3_xml,
 )
 from app.services.ownership_observations import (
@@ -86,6 +87,7 @@ def upsert_form_3_filing(
     primary_document_url: str,
     parsed: ParsedForm3,
     is_rewash: bool = False,
+    filed_at: datetime | None = None,
 ) -> None:
     """Insert / refresh the Form 3 filing header + filer dim + footnote
     bodies + holding rows for one accession.
@@ -99,7 +101,15 @@ def upsert_form_3_filing(
     ``is_rewash``: when True, the conflict branch preserves the
     original ``fetched_at`` (re-parsing a stored body isn't a fresh
     SEC fetch). Same flag pattern as Form 4 (PR #818).
+
+    ``filed_at`` (#899): SEC filing timestamp for the observation
+    write-through. Manifest callers pass ``row.filed_at``; ``None``
+    resolves at this chokepoint via ``lookup_sec_filed_at`` (same
+    pattern as ``upsert_filing``); final fallback is the historical
+    as-of derivation, logged.
     """
+    if filed_at is None:
+        filed_at = lookup_sec_filed_at(conn, accession_number)
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -341,6 +351,7 @@ def upsert_form_3_filing(
             accession_number=accession_number,
             primary_document_url=primary_document_url,
             parsed=parsed,
+            filed_at=filed_at,
         )
         refresh_insiders_current(conn, instrument_id=sibling_iid)
 
@@ -352,6 +363,7 @@ def _record_form3_observations_for_filing(
     accession_number: str,
     primary_document_url: str,
     parsed: ParsedForm3,
+    filed_at: datetime | None = None,
 ) -> None:
     """Derive one ``ownership_insiders_observations`` row per
     ``(filer_cik, direct_indirect)`` from the parsed Form 3 holdings.
@@ -395,6 +407,15 @@ def _record_form3_observations_for_filing(
     if not latest:
         return
 
+    # #899 — filed_at carries the SEC filing timestamp; the as-of date
+    # is preserved as period_end. Fallback to the historical as-of
+    # derivation only when no manifest / filing_events timestamp exists.
+    if filed_at is None:
+        logger.info(
+            "form3 observations: no SEC filed_at for accession=%s; falling back to as_of",
+            accession_number,
+        )
+
     run_id = uuid4()
     for (filer_cik, direct_indirect), holding in latest.items():
         shares = holding.shares
@@ -415,7 +436,7 @@ def _record_form3_observations_for_filing(
             source_accession=accession_number,
             source_field=None,
             source_url=primary_document_url or None,
-            filed_at=datetime.combine(as_of, datetime.min.time(), tzinfo=UTC),
+            filed_at=filed_at if filed_at is not None else datetime.combine(as_of, datetime.min.time(), tzinfo=UTC),
             period_start=None,
             period_end=as_of,
             ingest_run_id=run_id,

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -1120,7 +1120,7 @@ def lookup_sec_filed_at(conn: psycopg.Connection[Any], accession_number: str) ->
             return row[0]
         cur.execute(
             """
-            SELECT filing_date::timestamptz
+            SELECT filing_date::timestamp AT TIME ZONE 'UTC'
             FROM filing_events
             WHERE provider = 'sec' AND provider_filing_id = %s
             ORDER BY filing_date DESC

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -1101,6 +1101,37 @@ def _parse_one_holding(
 # ---------------------------------------------------------------------
 
 
+def lookup_sec_filed_at(conn: psycopg.Connection[Any], accession_number: str) -> datetime | None:
+    """Resolve an accession's TRUE SEC filing timestamp (#899).
+
+    Priority: ``sec_filing_manifest.filed_at`` (canonical, #1233) →
+    ``filing_events.filing_date`` (legacy cohort with no manifest row) →
+    ``None`` (caller falls back to its event-date derivation, logged).
+    ``filing_events`` can carry one row per share-class sibling for the
+    same accession; the filing_date is identical across them, the ORDER
+    BY just pins determinism."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT filed_at FROM sec_filing_manifest WHERE accession_number = %s",
+            (accession_number,),
+        )
+        row = cur.fetchone()
+        if row is not None and row[0] is not None:
+            return row[0]
+        cur.execute(
+            """
+            SELECT filing_date::timestamptz
+            FROM filing_events
+            WHERE provider = 'sec' AND provider_filing_id = %s
+            ORDER BY filing_date DESC
+            LIMIT 1
+            """,
+            (accession_number,),
+        )
+        row = cur.fetchone()
+        return row[0] if row is not None else None
+
+
 def upsert_filing(
     conn: psycopg.Connection[Any],
     *,
@@ -1109,6 +1140,7 @@ def upsert_filing(
     primary_document_url: str,
     parsed: ParsedFiling,
     is_rewash: bool = False,
+    filed_at: datetime | None = None,
 ) -> None:
     """Insert/refresh the filing header + filer dim + footnote bodies +
     transaction rows for one accession.
@@ -1124,7 +1156,17 @@ def upsert_filing(
     original ``fetched_at`` (re-parsing a stored body isn't a fresh
     SEC fetch and shouldn't claim to be — operator audit / recency
     logic using ``fetched_at`` would otherwise read every re-walked
-    filing as "fetched today")."""
+    filing as "fetched today").
+
+    ``filed_at`` (#899): the SEC filing timestamp stamped onto the
+    observation write-through. Manifest-driven callers pass
+    ``row.filed_at``; when ``None`` (legacy per-CIK ingester, rewash)
+    it is resolved at this chokepoint via :func:`lookup_sec_filed_at`
+    so every caller gets true-filing-time semantics without per-site
+    changes. Final fallback (no manifest row, no filing_event) is the
+    historical ``txn_date @ midnight UTC``, logged."""
+    if filed_at is None:
+        filed_at = lookup_sec_filed_at(conn, accession_number)
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -1369,6 +1411,7 @@ def upsert_filing(
             accession_number=accession_number,
             primary_document_url=primary_document_url,
             parsed=parsed,
+            filed_at=filed_at,
         )
         refresh_insiders_current(conn, instrument_id=sibling_iid)
 
@@ -1380,6 +1423,7 @@ def _record_form4_observations_for_filing(
     accession_number: str,
     primary_document_url: str,
     parsed: ParsedFiling,
+    filed_at: datetime | None = None,
 ) -> None:
     """Derive one ``ownership_insiders_observations`` row per
     ``(filer_cik, direct_indirect)`` from the parsed transactions and
@@ -1421,6 +1465,16 @@ def _record_form4_observations_for_filing(
     if not latest:
         return
 
+    # #899 — filed_at carries the SEC filing timestamp. The trade date
+    # is preserved as period_end (the observation natural key). Fallback
+    # to the historical txn_date derivation only when no manifest /
+    # filing_events timestamp exists for the accession.
+    if filed_at is None:
+        logger.info(
+            "form4 observations: no SEC filed_at for accession=%s; falling back to txn_date",
+            accession_number,
+        )
+
     run_id = uuid4()
     for (filer_cik, direct_indirect), txn in latest.items():
         if txn.txn_date is None or txn.post_transaction_shares is None:
@@ -1442,7 +1496,9 @@ def _record_form4_observations_for_filing(
             source_accession=accession_number,
             source_field=None,
             source_url=primary_document_url or None,
-            filed_at=datetime.combine(txn.txn_date, datetime.min.time(), tzinfo=UTC),
+            filed_at=filed_at
+            if filed_at is not None
+            else datetime.combine(txn.txn_date, datetime.min.time(), tzinfo=UTC),
             period_start=None,
             period_end=txn.txn_date,
             ingest_run_id=run_id,

--- a/app/services/manifest_parsers/insider_345.py
+++ b/app/services/manifest_parsers/insider_345.py
@@ -280,7 +280,8 @@ def _parse_form4(
     # upsert_filing handles siblings fan-out + observation
     # write-through + refresh_insiders_current internally. Single
     # savepoint covers every child write so a mid-batch failure rolls
-    # back atomically across share-class siblings.
+    # back atomically across share-class siblings. filed_at from the
+    # manifest row = SEC filing timestamp for observations (#899).
     try:
         with conn.transaction():
             upsert_filing(
@@ -289,6 +290,7 @@ def _parse_form4(
                 accession_number=accession,
                 primary_document_url=canonical_url,
                 parsed=parsed,
+                filed_at=filed_at,
             )
     except Exception as exc:  # noqa: BLE001
         # PR #1131: transient-vs-deterministic discrimination on the
@@ -361,6 +363,9 @@ def _parse_form3(
     accession = row.accession_number
     instrument_id = row.instrument_id
     url = row.primary_document_url
+    # SEC filing timestamp from the manifest row — threaded into the
+    # observation write-through (#899).
+    filed_at = row.filed_at
 
     if instrument_id is None:
         logger.warning(
@@ -489,6 +494,8 @@ def _parse_form3(
                 accession_number=accession,
                 primary_document_url=canonical_url,
                 parsed=parsed,
+                # SEC filing timestamp from the manifest row (#899).
+                filed_at=filed_at,
             )
     except Exception as exc:  # noqa: BLE001
         # PR #1131: transient (OperationalError) → 1h retry; deterministic
@@ -722,6 +729,8 @@ def _parse_form5(
                 accession_number=accession,
                 primary_document_url=canonical_url,
                 parsed=parsed,
+                # SEC filing timestamp from the manifest row (#899).
+                filed_at=filed_at,
             )
     except Exception as exc:  # noqa: BLE001
         # PR #1131 discrimination: transient ``OperationalError`` →

--- a/app/services/ownership_observations_sync.py
+++ b/app/services/ownership_observations_sync.py
@@ -234,13 +234,16 @@ def sync_insiders(
                 it.instrument_id, it.accession_number,
                 it.filer_cik, it.filer_name, it.direct_indirect,
                 it.txn_date, it.post_transaction_shares,
-                f.primary_document_url
+                f.primary_document_url,
+                COALESCE(m.filed_at, fe.filing_date::timestamptz) AS sec_filed_at
             FROM insider_transactions it
             JOIN insider_filings f USING (accession_number)
             LEFT JOIN filing_events fe
               ON fe.provider_filing_id = it.accession_number
              AND fe.provider = 'sec'
              AND fe.instrument_id = it.instrument_id
+            LEFT JOIN sec_filing_manifest m
+              ON m.accession_number = it.accession_number
             {where}
             ORDER BY it.accession_number, it.filer_cik, it.filer_name, it.direct_indirect,
                      it.txn_date DESC NULLS LAST, it.txn_row_num DESC
@@ -272,7 +275,11 @@ def sync_insiders(
                 source_accession=str(row["accession_number"]),
                 source_field=None,
                 source_url=str(row["primary_document_url"]) if row["primary_document_url"] else None,
-                filed_at=datetime.combine(row["txn_date"], datetime.min.time(), tzinfo=UTC),
+                # #899 — SEC filing timestamp (manifest → filing_events);
+                # txn_date fallback only for rows with neither.
+                filed_at=row["sec_filed_at"]
+                if row["sec_filed_at"] is not None
+                else datetime.combine(row["txn_date"], datetime.min.time(), tzinfo=UTC),
                 period_start=None,
                 period_end=row["txn_date"],
                 ingest_run_id=run_id,
@@ -296,9 +303,16 @@ def sync_insiders(
             SELECT iih.instrument_id, iih.accession_number,
                    iih.filer_cik, iih.filer_name,
                    iih.shares, iih.as_of_date, iih.direct_indirect,
-                   f.primary_document_url
+                   f.primary_document_url,
+                   COALESCE(m.filed_at, fe.filing_date::timestamptz) AS sec_filed_at
             FROM insider_initial_holdings iih
             JOIN insider_filings f USING (accession_number)
+            LEFT JOIN filing_events fe
+              ON fe.provider_filing_id = iih.accession_number
+             AND fe.provider = 'sec'
+             AND fe.instrument_id = iih.instrument_id
+            LEFT JOIN sec_filing_manifest m
+              ON m.accession_number = iih.accession_number
             {where}
             {limit_sql}
             """,
@@ -328,7 +342,11 @@ def sync_insiders(
                 source_accession=str(row["accession_number"]),
                 source_field=None,
                 source_url=str(row["primary_document_url"]) if row["primary_document_url"] else None,
-                filed_at=datetime.combine(row["as_of_date"], datetime.min.time(), tzinfo=UTC),
+                # #899 — SEC filing timestamp (manifest → filing_events);
+                # as_of_date fallback only for rows with neither.
+                filed_at=row["sec_filed_at"]
+                if row["sec_filed_at"] is not None
+                else datetime.combine(row["as_of_date"], datetime.min.time(), tzinfo=UTC),
                 period_start=None,
                 period_end=row["as_of_date"],
                 ingest_run_id=run_id,

--- a/app/services/ownership_observations_sync.py
+++ b/app/services/ownership_observations_sync.py
@@ -202,18 +202,24 @@ def sync_insiders(
     if since is not None:
         where += " AND it.txn_date >= %(since)s"
         params["since"] = since
+    # Retention gates resolve the SEC filing date manifest-first
+    # (#899 Codex ckpt-2): a manifest-only accession (no filing_events
+    # row) is provably in/out of retention via m.filed_at — gating on
+    # fe.filing_date alone wrongly excluded it. Rows with NEITHER
+    # source stay excluded (fail-closed for unattributed legacy rows,
+    # #1247).
     where += (
         " AND ("
         "  f.document_type IN ('3','3/A')"
         "  OR ("
         "    f.document_type IN ('4','4/A')"
-        "    AND fe.filing_date IS NOT NULL"
-        "    AND fe.filing_date >= %(form4_cutoff)s"
+        "    AND COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date) IS NOT NULL"
+        "    AND COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date) >= %(form4_cutoff)s"
         "  )"
         "  OR ("
         "    f.document_type IN ('5','5/A')"
-        "    AND fe.filing_date IS NOT NULL"
-        "    AND fe.filing_date >= %(form5_cutoff)s"
+        "    AND COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date) IS NOT NULL"
+        "    AND COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date) >= %(form5_cutoff)s"
         "  )"
         ")"
     )
@@ -235,7 +241,7 @@ def sync_insiders(
                 it.filer_cik, it.filer_name, it.direct_indirect,
                 it.txn_date, it.post_transaction_shares,
                 f.primary_document_url,
-                COALESCE(m.filed_at, fe.filing_date::timestamptz) AS sec_filed_at
+                COALESCE(m.filed_at, fe.filing_date::timestamp AT TIME ZONE 'UTC') AS sec_filed_at
             FROM insider_transactions it
             JOIN insider_filings f USING (accession_number)
             LEFT JOIN filing_events fe
@@ -304,7 +310,7 @@ def sync_insiders(
                    iih.filer_cik, iih.filer_name,
                    iih.shares, iih.as_of_date, iih.direct_indirect,
                    f.primary_document_url,
-                   COALESCE(m.filed_at, fe.filing_date::timestamptz) AS sec_filed_at
+                   COALESCE(m.filed_at, fe.filing_date::timestamp AT TIME ZONE 'UTC') AS sec_filed_at
             FROM insider_initial_holdings iih
             JOIN insider_filings f USING (accession_number)
             LEFT JOIN filing_events fe

--- a/docs/proposals/etl/2026-06-10-insider-filed-at-semantics.md
+++ b/docs/proposals/etl/2026-06-10-insider-filed-at-semantics.md
@@ -1,6 +1,26 @@
 # Insider observations `filed_at` semantics (#899)
 
-Status: plan for review.
+Status: as-built (implemented 2026-06-10; verification record in the PR).
+
+## As-built deltas + Codex ckpt-2 fixes
+
+- Chokepoint design: `lookup_sec_filed_at` (manifest → filing_events) runs INSIDE
+  `upsert_filing` / `upsert_form_3_filing` when the new `filed_at` param is None —
+  legacy ingest + rewash inherit the fix with zero call-site changes; manifest
+  parsers pass `row.filed_at` explicitly.
+- Codex ckpt-2 bug 1: sync retention gates resolve manifest-first —
+  `COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date)`; manifest-only
+  accessions were wrongly excluded by the fe-only gate. Lint pins updated in
+  `check_form4_retention.sh` + `check_form5_retention.sh` (invariant unchanged).
+- Codex ckpt-2 bug 2: every DATE→timestamptz cast pinned UTC
+  (`::timestamp AT TIME ZONE 'UTC'`, sql/148 precedent); tests tightened to exact
+  UTC-midnight equality.
+- Dev: sql/191 applied + replayed post-fix (hash reset per sql-correctness escape);
+  matched-cohort residual 0 at replay; 2,696 rows unmatched (event-date fallback
+  cohort, honest); `_current` recomputed for 4,548 instruments, 0 failures.
+- Live jobs proc writes event-dated rows until restarted onto this code → operator
+  mop-up after merge: restart jobs proc, then re-run the sql/191 UPDATE body once
+  (idempotent).
 
 ## Problem (verified 2026-06-10)
 

--- a/docs/proposals/etl/2026-06-10-insider-filed-at-semantics.md
+++ b/docs/proposals/etl/2026-06-10-insider-filed-at-semantics.md
@@ -1,0 +1,116 @@
+# Insider observations `filed_at` semantics (#899)
+
+Status: plan for review.
+
+## Problem (verified 2026-06-10)
+
+`ownership_insiders_observations.filed_at` carries MIXED semantics today — worse than
+issue #899 describes:
+
+- Write-through Form 4 (`app/services/insider_transactions.py:1445`):
+  `filed_at = txn_date @ midnight UTC` (trade date).
+- Write-through Form 3 (`app/services/insider_form3_ingest.py:418`):
+  `filed_at = as_of @ midnight UTC`.
+- Legacy batch sync (`app/services/ownership_observations_sync.py:275/331`): same two
+  wrong derivations (reads typed tables, which carry NO filing timestamp — only
+  `txn_date` / `as_of_date` + `accession_number`).
+- Bulk insider dataset (`app/services/sec_insider_dataset_ingest.py:544`):
+  `filed_at = FILING_DATE` from the SEC dataset — the TRUE filing date.
+
+So rows disagree on what the column means depending on which path wrote them.
+Institutions / blockholders / treasury observations all use true filing time —
+insiders are the outlier.
+
+## Decision: fix in place (no new column), coordinated backfill
+
+Issue #899 offers rename-or-add-accepted_at. Neither is needed:
+
+- The trade/as-of date is NOT lost — it is already the natural key's `period_end`
+  (`period_end=txn.txn_date` / `as_of`), and `txn_date` lives on the typed rows.
+- `filed_at` is NOT in the conflict identity
+  `(instrument_id, holder_identity_key, ownership_nature, source, source_document_id, period_end)`
+  (sql/113, recorder `ownership_observations.py:201`) — rewriting it is a pure UPDATE,
+  no identity/current-row drift, which was the #894-era blocker for a write-through-only
+  change. Coordinated backfill is exactly what removes that blocker.
+- Bulk-dataset rows already carry the target semantics.
+
+## Changes
+
+1. **Writers** — thread the true filing timestamp:
+   - Form 4/5 manifest parser (`manifest_parsers/insider_345.py`) already holds
+     `row.filed_at` (manifest, NOT NULL in practice) — pass it through
+     `insider_transactions.py` ingest into `record_insider_observation(filed_at=...)`.
+     Fallback when unavailable: keep `txn_date @ midnight` (defensive, logged).
+   - Form 3 (`insider_form3_ingest.py`): same — use the manifest/submissions-index
+     `filed_at` threaded into the ingest; fallback `as_of @ midnight`.
+   - Legacy sync (`ownership_observations_sync.py`): JOIN
+     `sec_filing_manifest.filed_at` (canonical) by accession with COALESCE fallback to
+     the current derivation. (Sync is the retro/repair path; it must not resurrect
+     trade-date semantics on a manual run.)
+2. **Backfill** — migration `sql/<next>_backfill_insider_observations_filed_at.sql`:
+   `UPDATE ownership_insiders_observations o SET filed_at = m.filed_at FROM
+   sec_filing_manifest m WHERE m.accession_number = o.source_accession AND
+   o.filed_at IS DISTINCT FROM m.filed_at` (scoped `source IN ('form4','form3')`).
+   Dev scale: 707,184 rows (679k form4 / 28k form3) — bounded one-time UPDATE.
+   Rows whose accession is absent from the manifest keep the old value (COALESCE-free
+   inner join = untouched) — logged count in PR via pre/post probe.
+3. **Downstream readers** — no query-shape changes required:
+   - `refresh_insiders_current` MERGE + `ownership_history.py:114` use `filed_at DESC`
+     as tie-break — semantics IMPROVE (true filing order; late-filed amendments now
+     order correctly). `_current` rows refresh via the post-backfill repair sweep /
+     normal drift detection (`ownership_refresh_state` watermark vs `ingested_at` —
+     NOTE: plain UPDATE does not advance `ingested_at`; see Open question 1).
+   - Frontend: verify which surfaces render insider `filed_at`; relabel only if a label
+     says "trade date".
+
+## Codex ckpt-1 resolutions (2026-06-10 — fix-in-place CONFIRMED sound)
+
+1. **_current propagation = recompute, NOT mirror-update** (Codex HIGH): backfilled
+   `filed_at` is the MERGE tie-break (`ownership_observations.py:289`) — it can flip
+   the WINNING observation, not just its timestamp; a mirror UPDATE would leave stale
+   `source_document_id`/`shares` on `_current`. Resolution: post-backfill operator
+   step runs `refresh_insiders_current_batch` over every instrument with a rewritten
+   row (drift sweep alone won't fire — plain UPDATE doesn't advance `ingested_at`).
+2. **Writer chain must carry the param** (Codex HIGH): `filed_at` threads through
+   `upsert_filing(...)` → `_record_form4_observations_for_filing(...)` and
+   `upsert_form_3_filing(...)` → `_record_form3_observations_for_filing(...)`
+   (`insider_345.py:286/486/719`, `insider_transactions.py:1104`,
+   `insider_form3_ingest.py:81`) — manifest adapters hold `row.filed_at` but the
+   observation writers never receive it today.
+3. **Non-manifest callers** (Codex HIGH): legacy schedulers + Form 4/Form 3 rewash
+   (`rewash_filings.py:328/393`, `insider_transactions.py:1803`,
+   `insider_form3_ingest.py:677`) call `upsert_filing`/`upsert_form_3_filing`
+   directly — rewash must look up manifest/filing-event filed time by accession,
+   not fall back to txn/as-of.
+4. **Form 5 routes through Form 4 plumbing** with `source='form4'`
+   (`insider_345.py:543`, `insider_transactions.py:428`) — fixed by the same thread;
+   backfill keys on `source_accession` so Form 5 accessions resolve via their own
+   manifest rows. Intentional + tested.
+5. **Backfill join filters manifest source/form explicitly**; keyed on
+   `o.source_accession` (correct across the bulk path's `accn:NDT:*`/`accn:NDH:*`
+   `source_document_id` shapes — tests cover both).
+6. **Probe invariant** (Codex LOW fix): post-backfill count of
+   `o.filed_at IS DISTINCT FROM m.filed_at` over the joined cohort == 0, plus an
+   honest unmatched-accession count (rows left untouched). NOT a date-inequality
+   heuristic — filing date legitimately follows the trade date.
+
+No `accepted_at` column: `sec_filing_manifest.accepted_at` already exists if acceptance
+precision is ever needed separately from filing date.
+
+## Done criteria (from #899 + this plan)
+
+- All writer paths (manifest Form 4/5 + Form 3, legacy sync, rewash) stamp the SEC
+  filing timestamp; fallbacks logged.
+- Backfill executed on dev; probe per resolution 6 recorded in PR.
+- `_current` recomputed via `refresh_insiders_current_batch` over affected instruments;
+  spot-verified.
+- Tests: writer-level (filed_at == manifest value; fallback branch), backfill
+  migration-behaviour test (seed wrong filed_at → run → assert manifest value; both
+  source_document_id shapes), tie-break regression (late-filed amendment wins
+  `_current` only post-fix).
+
+## Gates
+
+ruff / pyright / fast / smoke + `pytest -m db` + DoD ETL clauses 8-12 (panel smoke,
+cross-source one fixture vs EDGAR acceptance date, backfill executed + probe, rollup
+endpoint verify, SHAs in PR).

--- a/scripts/check_form4_retention.sh
+++ b/scripts/check_form4_retention.sh
@@ -151,15 +151,20 @@ else
 
   # D2. Form 4 branch — three required pins inside the WHERE clause:
   #     - the Form 4 document-type predicate (Form 3 split out)
-  #     - the LEFT-JOIN NULL-guard on fe.filing_date
-  #     - the cutoff predicate on fe.filing_date
+  #     - the NULL-guard on the resolved SEC filing date
+  #     - the cutoff predicate on the resolved SEC filing date
+  # #899 updated the pinned literal: the gate resolves the date
+  # manifest-first — COALESCE((m.filed_at AT TIME ZONE 'UTC')::date,
+  # fe.filing_date) — so a manifest-only accession is provable instead
+  # of wrongly excluded. The #1247 invariant (Form 4 branch gates on
+  # %(form4_cutoff)s; neither-source rows fail closed) is unchanged.
   d2_doctype=$(count_literal "$FILE_SYNC_INSIDERS" "f.document_type IN ('4','4/A')")
-  d2_param=$(count_literal "$FILE_SYNC_INSIDERS" "fe.filing_date >= %(form4_cutoff)s")
+  d2_param=$(count_literal "$FILE_SYNC_INSIDERS" "COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date) >= %(form4_cutoff)s")
   if (( d2_doctype < 1 )); then
     fail "$FILE_SYNC_INSIDERS: missing \"f.document_type IN ('4','4/A')\" branch — #1247 splits Form 4 into its own retention-gated branch."
   fi
   if (( d2_param < 1 )); then
-    fail "$FILE_SYNC_INSIDERS: missing \"fe.filing_date >= %(form4_cutoff)s\" predicate — #1247 requires the Form 4 branch to gate on the cutoff param."
+    fail "$FILE_SYNC_INSIDERS: missing \"COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date) >= %(form4_cutoff)s\" predicate — #1247 requires the Form 4 branch to gate on the cutoff param (resolved manifest-first per #899)."
   fi
 
   # D3. Form 3 stays in the unconditional branch — must NOT be wrapped

--- a/scripts/check_form5_retention.sh
+++ b/scripts/check_form5_retention.sh
@@ -158,7 +158,9 @@ else
   sync_cutoff_calls=$(count_regex "$FILE_SYNC" "form5_retention_cutoff\(")
   left_join_count=$(count_literal "$FILE_SYNC" "LEFT JOIN filing_events fe")
   form5_doctype_count=$(count_literal "$FILE_SYNC" "f.document_type IN ('5','5/A')")
-  cutoff_predicate_count=$(count_literal "$FILE_SYNC" "fe.filing_date >= %(form5_cutoff)s")
+  # #899 — gate resolves the SEC filing date manifest-first (same pin
+  # update as check_form4_retention.sh invariant D2).
+  cutoff_predicate_count=$(count_literal "$FILE_SYNC" "COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date) >= %(form5_cutoff)s")
 
   if (( sync_cutoff_calls < 1 )); then
     fail "$FILE_SYNC: missing form5_retention_cutoff(...) call inside sync_insiders. PR10b sync chokepoint."
@@ -170,7 +172,7 @@ else
     fail "$FILE_SYNC: missing \"f.document_type IN ('5','5/A')\" literal in sync_insiders Form 5 branch."
   fi
   if (( cutoff_predicate_count < 1 )); then
-    fail "$FILE_SYNC: missing 'fe.filing_date >= %(form5_cutoff)s' literal in sync_insiders Form 5 branch."
+    fail "$FILE_SYNC: missing 'COALESCE((m.filed_at AT TIME ZONE 'UTC')::date, fe.filing_date) >= %(form5_cutoff)s' literal in sync_insiders Form 5 branch (resolved manifest-first per #899)."
   fi
 fi
 

--- a/sql/191_backfill_insider_observations_filed_at.sql
+++ b/sql/191_backfill_insider_observations_filed_at.sql
@@ -37,7 +37,10 @@ FROM (
     SELECT m.accession_number, m.filed_at AS sec_filed_at
     FROM sec_filing_manifest m
     UNION ALL
-    SELECT fe.provider_filing_id, MAX(fe.filing_date)::timestamptz
+    -- DATE -> timestamptz pinned to UTC (sql/148 precedent): a bare
+    -- ::timestamptz cast is session-timezone dependent and can shift
+    -- the UTC calendar date.
+    SELECT fe.provider_filing_id, MAX(fe.filing_date)::timestamp AT TIME ZONE 'UTC'
     FROM filing_events fe
     WHERE fe.provider = 'sec'
       AND NOT EXISTS (

--- a/sql/191_backfill_insider_observations_filed_at.sql
+++ b/sql/191_backfill_insider_observations_filed_at.sql
@@ -1,0 +1,52 @@
+-- 191_backfill_insider_observations_filed_at.sql
+--
+-- #899 — insider observations `filed_at` carried event-date semantics
+-- (Form 4: txn_date @ midnight; Form 3: as_of @ midnight) on the
+-- write-through + legacy-sync paths, while the bulk insider dataset
+-- path wrote the TRUE SEC filing date — one column, mixed meanings.
+-- The trade/as-of date is not lost by this rewrite: it is the natural
+-- key's `period_end`. `filed_at` is NOT part of the observation
+-- conflict identity (sql/113), so this is a pure value UPDATE with no
+-- identity drift.
+--
+-- Backfill: stamp the SEC filing timestamp from the canonical
+-- `sec_filing_manifest` (#1233), falling back to
+-- `filing_events.filing_date` for legacy-cohort accessions with no
+-- manifest row. Rows whose accession resolves in NEITHER source are
+-- left untouched (the writer paths keep the event-date fallback for
+-- the same cohort, logged). Scoped to source IN ('form4','form3') —
+-- Form 5 observations are written under source='form4' by design
+-- (manifest_parsers/insider_345.py module docstring) and resolve via
+-- their own accessions in the same join.
+--
+-- `ownership_insiders_current` is NOT touched here: backfilled
+-- filed_at participates in the refresh MERGE's winner tie-break, so
+-- mirrors must be RECOMPUTED (refresh_insiders_current_batch over
+-- affected instruments — operator step recorded in the PR), not
+-- value-copied. A plain UPDATE also does not advance observations
+-- `ingested_at`, deliberately: the drift sweep must not treat a
+-- semantic relabel as fresh ingest data.
+--
+-- No explicit BEGIN/COMMIT: the migration runner wraps the body + the
+-- schema_migrations INSERT in one transaction
+-- (app/db/migrations.run_migrations).
+
+UPDATE ownership_insiders_observations o
+SET filed_at = src.sec_filed_at
+FROM (
+    SELECT m.accession_number, m.filed_at AS sec_filed_at
+    FROM sec_filing_manifest m
+    UNION ALL
+    SELECT fe.provider_filing_id, MAX(fe.filing_date)::timestamptz
+    FROM filing_events fe
+    WHERE fe.provider = 'sec'
+      AND NOT EXISTS (
+          SELECT 1 FROM sec_filing_manifest m2
+          WHERE m2.accession_number = fe.provider_filing_id
+      )
+    GROUP BY fe.provider_filing_id
+) AS src
+WHERE o.source IN ('form4', 'form3')
+  AND o.source_accession = src.accession_number
+  AND src.sec_filed_at IS NOT NULL
+  AND o.filed_at IS DISTINCT FROM src.sec_filed_at;

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -21,7 +21,7 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from typing import cast
 
@@ -456,8 +456,11 @@ class TestIngestInsiderTransactions:
             )
             rows = cur.fetchall()
         assert rows, "observation write-through row expected"
+        # lookup_sec_filed_at pins the DATE to UTC midnight via
+        # `::timestamp AT TIME ZONE 'UTC'` — exact-equality is safe.
+        expected_filed_at = datetime(filing_day.year, filing_day.month, filing_day.day, tzinfo=UTC)
         for filed_at_val, period_end in rows:
-            assert filed_at_val.date() == filing_day
+            assert filed_at_val == expected_filed_at
             assert period_end == txn_day
 
     def test_joint_filing_splits_filers_by_cik(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -21,7 +21,7 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from typing import cast
 
@@ -425,6 +425,40 @@ class TestIngestInsiderTransactions:
             refs = tx[6]  # already parsed from JSONB
             assert isinstance(refs, list)
             assert any(r.get("footnote_id") == "F1" and r.get("field") == "transactionShares" for r in refs)
+
+    def test_observation_filed_at_uses_filing_events_lookup(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """#899 — legacy ingest (no manifest row) resolves the SEC filing
+        timestamp through lookup_sec_filed_at's filing_events fallback;
+        the observation must NOT carry the transaction date. The trade
+        date is preserved as period_end (natural key)."""
+        iid = _seed_instrument(ebull_test_conn)
+        accession = "0000000001-24-000899"
+        txn_day = date.today() - timedelta(days=10)
+        filing_day = date.today() - timedelta(days=7)
+        url = "https://www.sec.gov/Archives/form4-899.xml"
+        _seed_form_4(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession=accession,
+            url=url,
+            filing_date=filing_day.isoformat(),
+        )
+        fetcher = _StubFetcher({url: _FORM_4_RICH_BUY.replace("2024-06-15", txn_day.isoformat())})
+
+        result = ingest_insider_transactions(ebull_test_conn, cast("object", fetcher))  # type: ignore[arg-type]
+        assert result.filings_parsed == 1
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT filed_at, period_end FROM ownership_insiders_observations "
+                "WHERE source = 'form4' AND source_document_id = %s",
+                (accession,),
+            )
+            rows = cur.fetchall()
+        assert rows, "observation write-through row expected"
+        for filed_at_val, period_end in rows:
+            assert filed_at_val.date() == filing_day
+            assert period_end == txn_day
 
     def test_joint_filing_splits_filers_by_cik(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         iid = _seed_instrument(ebull_test_conn)

--- a/tests/test_manifest_parser_insider_345.py
+++ b/tests/test_manifest_parser_insider_345.py
@@ -74,6 +74,9 @@ _FAKE_FORM_4_XML = dedent("""<?xml version="1.0"?>
         <transactionPricePerShare><value>185.42</value></transactionPricePerShare>
         <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
       </transactionAmounts>
+      <postTransactionAmounts>
+        <sharesOwnedFollowingTransaction><value>10250</value></sharesOwnedFollowingTransaction>
+      </postTransactionAmounts>
       <ownershipNature>
         <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
       </ownershipNature>
@@ -274,6 +277,16 @@ def test_form4_happy_path(
         r = cur.fetchone()
     assert r is not None and r[0] > 0
 
+    # #899 — observation write-through stamps the manifest row's SEC
+    # filing timestamp, not the transaction date.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT filed_at FROM ownership_insiders_observations "
+            "WHERE source = 'form4' AND source_document_id = '0000320193-26-000010'"
+        )
+        obs = cur.fetchall()
+    assert [o[0] for o in obs] == [datetime(2026, 5, 11, tzinfo=UTC)]
+
 
 def test_form3_happy_path(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
@@ -327,6 +340,16 @@ def test_form3_happy_path(
             "WHERE accession_number = '0000320193-26-000020' AND document_kind = 'form3_xml'"
         )
         assert cur.fetchone() is not None
+
+    # #899 — Form 3 observation write-through stamps the manifest row's
+    # SEC filing timestamp, not the as-of date.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT filed_at FROM ownership_insiders_observations "
+            "WHERE source = 'form3' AND source_document_id = '0000320193-26-000020'"
+        )
+        obs = cur.fetchall()
+    assert [o[0] for o in obs] == [datetime(2026, 5, 11, tzinfo=UTC)]
 
 
 def test_form4_empty_fetch_tombstones(

--- a/tests/test_migration_191_insider_filed_at.py
+++ b/tests/test_migration_191_insider_filed_at.py
@@ -1,0 +1,127 @@
+"""Behaviour test for migration 191 — #899 insider observations filed_at backfill.
+
+Seeds observation rows carrying the legacy event-date semantics, runs the
+migration SQL inline, asserts:
+  - a row whose accession has a sec_filing_manifest row is restamped to the
+    manifest filed_at (covers the bulk-path source_document_id shape too —
+    the join keys on source_accession);
+  - a row whose accession exists only in filing_events is restamped to the
+    filing_date (legacy cohort fallback arm);
+  - a row whose accession resolves in neither source is left untouched;
+  - a non-insider source row is out of scope.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import psycopg
+import pytest
+
+from app.services.ownership_observations import record_insider_observation
+from app.services.sec_manifest import record_manifest_entry
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+_MIGRATION_SQL = (
+    Path(__file__).resolve().parents[1] / "sql" / "191_backfill_insider_observations_filed_at.sql"
+).read_text()
+
+_IID = 8_910_001
+_ACC_MANIFEST = "0000891001-26-000001"  # has manifest row
+_ACC_EVENTS = "0000891001-26-000002"  # filing_events only
+_ACC_ORPHAN = "0000891001-26-000003"  # neither source
+
+_WRONG_FILED = datetime(2026, 1, 5, tzinfo=UTC)  # legacy txn-date semantics
+_MANIFEST_FILED = datetime(2026, 1, 9, 14, 30, tzinfo=UTC)
+_EVENTS_FILED = date(2026, 1, 12)
+
+
+def _seed_obs(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    source_document_id: str | None = None,
+) -> None:
+    record_insider_observation(
+        conn,
+        instrument_id=_IID,
+        holder_cik="0001000001",
+        holder_name="Test Insider",
+        ownership_nature="direct",
+        source="form4",
+        source_document_id=source_document_id or accession,
+        source_accession=accession,
+        source_field=None,
+        source_url=None,
+        filed_at=_WRONG_FILED,
+        period_start=None,
+        period_end=date(2026, 1, 5),
+        ingest_run_id=uuid4(),
+        shares=Decimal("100"),
+    )
+
+
+def _obs_filed_at(conn: psycopg.Connection[tuple], source_document_id: str) -> datetime:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT filed_at FROM ownership_insiders_observations "
+            "WHERE source = 'form4' AND source_document_id = %s "
+            "ORDER BY filed_at DESC LIMIT 1",
+            (source_document_id,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
+def test_migration_191_backfills_filed_at_from_manifest_then_filing_events(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, 'M191', 'M191 Inc', '4', 'USD', TRUE) ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (_IID,),
+    )
+    record_manifest_entry(
+        conn,
+        _ACC_MANIFEST,
+        cik="0000891001",
+        form="4",
+        source="sec_form4",
+        subject_type="issuer",
+        subject_id=str(_IID),
+        instrument_id=_IID,
+        filed_at=_MANIFEST_FILED,
+        primary_document_url="https://www.sec.gov/Archives/m191.xml",
+    )
+    conn.execute(
+        """
+        INSERT INTO filing_events (instrument_id, filing_date, filing_type, provider, provider_filing_id)
+        VALUES (%s, %s, '4', 'sec', %s)
+        """,
+        (_IID, _EVENTS_FILED, _ACC_EVENTS),
+    )
+    # Manifest-resolved row, seeded under the BULK dataset's
+    # source_document_id shape (accn:NDT:*) — the backfill must key on
+    # source_accession, not source_document_id.
+    _seed_obs(conn, accession=_ACC_MANIFEST, source_document_id=f"{_ACC_MANIFEST}:NDT:1")
+    _seed_obs(conn, accession=_ACC_EVENTS)
+    _seed_obs(conn, accession=_ACC_ORPHAN)
+    conn.commit()
+
+    conn.execute(_MIGRATION_SQL)  # type: ignore[arg-type]  # no embedded BEGIN/COMMIT (runner wraps)
+    conn.commit()
+
+    assert _obs_filed_at(conn, f"{_ACC_MANIFEST}:NDT:1") == _MANIFEST_FILED
+    # filing_events arm: DATE cast to timestamptz at the cluster TZ —
+    # compare the date portion to stay TZ-agnostic.
+    assert _obs_filed_at(conn, _ACC_EVENTS).date() == _EVENTS_FILED
+    assert _obs_filed_at(conn, _ACC_ORPHAN) == _WRONG_FILED  # untouched

--- a/tests/test_migration_191_insider_filed_at.py
+++ b/tests/test_migration_191_insider_filed_at.py
@@ -121,7 +121,9 @@ def test_migration_191_backfills_filed_at_from_manifest_then_filing_events(
     conn.commit()
 
     assert _obs_filed_at(conn, f"{_ACC_MANIFEST}:NDT:1") == _MANIFEST_FILED
-    # filing_events arm: DATE cast to timestamptz at the cluster TZ —
-    # compare the date portion to stay TZ-agnostic.
-    assert _obs_filed_at(conn, _ACC_EVENTS).date() == _EVENTS_FILED
+    # filing_events arm: DATE pinned to UTC midnight by the migration's
+    # `::timestamp AT TIME ZONE 'UTC'` (session-TZ-independent).
+    assert _obs_filed_at(conn, _ACC_EVENTS) == datetime(
+        _EVENTS_FILED.year, _EVENTS_FILED.month, _EVENTS_FILED.day, tzinfo=UTC
+    )
     assert _obs_filed_at(conn, _ACC_ORPHAN) == _WRONG_FILED  # untouched


### PR DESCRIPTION
Closes #899.

## What

`ownership_insiders_observations.filed_at` carried MIXED semantics — write-through Form 4 stamped the trade date, Form 3 the as-of date, the legacy batch sync both of those, while the bulk insider dataset path stamped the TRUE SEC filing date. One column, path-dependent meaning. This PR fixes it in place — no new column:

- The trade/as-of date is NOT lost: it is the natural key's `period_end`.
- `filed_at` is NOT in the observation conflict identity (sql/113), so rewriting is a pure value UPDATE with no identity/current-row drift — the blocker that deferred this at #894 disappears with a coordinated backfill, which this PR ships.

**Writers** — `upsert_filing` / `upsert_form_3_filing` gain a `filed_at` param. Manifest parsers (Form 4/5 + Form 3) pass `row.filed_at`. When the param is `None` (legacy per-CIK ingest, rewash), it is resolved at the chokepoint by the new `lookup_sec_filed_at` (`sec_filing_manifest.filed_at` → `filing_events.filing_date` pinned to UTC) — every caller inherits the fix with zero call-site changes. Final fallback (accession in neither source) keeps the historical event-date derivation, logged. The legacy batch sync resolves the same two sources via SQL JOIN.

**Backfill** — `sql/191` restamps existing form4/form3 observations from manifest-UNION-filing_events keyed on `source_accession` (covers the bulk path's `accn:NDT:*` `source_document_id` shapes). Unmatched accessions left untouched.

**`_current`** — deliberately NOT value-copied by the migration: backfilled `filed_at` is the refresh MERGE's winner tie-break and can flip which observation wins, so mirrors must be recomputed, not patched (Codex ckpt-1 HIGH). Recompute executed on dev (below).

## Security model

No new external input or auth surface. `lookup_sec_filed_at` is two parameterised SELECTs against internal tables; sync JOIN additions are internal reads. Migration is a scoped UPDATE with no user-controlled values.

## Conscious tradeoffs

- **Fix-in-place over `accepted_at` column** (issue offered either): the column already carried mixed semantics (bulk path wrote filing dates), trade dates live in `period_end`, and `sec_filing_manifest.accepted_at` exists if acceptance-precision is ever needed. Codex ckpt-1 endorsed; adding a column would duplicate data without removing the mislabel.
- **Retention-gate tightening** (Codex ckpt-2): sync Form 4/5 gates now resolve the filing date manifest-first — manifest-only accessions were wrongly excluded by the `filing_events`-only gate. Neither-source rows stay excluded (fail-closed, #1247). Lint pins in `check_form4_retention.sh` / `check_form5_retention.sh` updated in this PR, invariant intent unchanged.
- **UTC-pinned casts**: all `DATE → timestamptz` sites use `::timestamp AT TIME ZONE 'UTC'` (sql/148 precedent) — bare `::timestamptz` is session-TZ-dependent (Codex ckpt-2).
- **2,696 unmatched rows** keep event-date `filed_at` (accession absent from both manifest and filing_events) — honest fallback cohort, logged at write time going forward.

## Codex checkpoints

- ckpt-1 (plan, `docs/proposals/etl/2026-06-10-insider-filed-at-semantics.md` — in this PR): fix-in-place confirmed sound; 3 HIGH folded in (recompute-not-mirror for `_current`; thread `filed_at` through the full writer chain; cover rewash + legacy callers — solved via the chokepoint lookup).
- ckpt-2 (branch): 2 real bugs found and FIXED in `efccae0` (manifest-first retention gate; TZ-dependent casts). No other writer-path misses — Codex enumerated all `record_insider_observation` callers.

## Tests

- `tests/test_migration_191_insider_filed_at.py` (new): manifest arm (bulk `accn:NDT:*` doc-id shape), filing_events arm (exact UTC midnight), unmatched row untouched.
- `tests/test_manifest_parser_insider_345.py`: form4 + form3 happy paths now assert obs `filed_at` == manifest timestamp (form4 fixture gained `postTransactionAmounts` so the write-through actually fires — it previously wrote zero observations, masking the assertion).
- `tests/test_insider_transactions_ingest.py` (new test): legacy ingest path resolves via `filing_events` lookup; `filed_at` = filing date (exact UTC midnight), `period_end` = trade date.

## Local gates (all green)

ruff check + format · pyright 0 errors · fast tier 3806 passed · smoke 129 passed · targeted DB tier (migration + manifest-parser + form3/form4 ingest + sync + rewash files): 124 tests passed. Full chokepoint-lint sweep green. (Per #1568 / test-quality.md: targeted files = the deliberate DB-tier run; bare `-m db` wedges on this box.)

## DoD ETL clauses 8–12 (executed at `efccae0`)

- **(8) Panel smoke (dev, post-backfill + recompute):** `/instruments/{symbol}/ownership-rollup` 200×5 — insiders slice: AAPL 9,793,026 sh / 17 filers · GME 39,323,198 / 7 · MSFT 2,635,849 / 24 · JPM 5,369,259 / 26 · HD 507,697 / 18.
- **(9) Cross-source (SEC EDGAR direct):** AAPL / Newstead Jennifer Form 4, accession `0001780525-26-000005` — EDGAR archive date **2026-03-17** == our `filed_at` (2026-03-17 00:00Z); trade date 2026-03-15 preserved as `period_end`. Pre-#899 `filed_at` would have read 2026-03-15.
- **(10) Backfill executed:** sql/191 applied on dev (boot path), then replayed with the ckpt-2-corrected content (idempotent; recorded hash reset per the sql-correctness "Never edit an applied migration" escape). Matched-cohort residual probe = 0 at replay; 2,696 unmatched rows (neither source) untouched by design. `_current` recomputed via `refresh_insiders_current_batch` for **4,548 instruments, 0 failures**.
- **(11) Operator-visible figure:** panel above rendered live post-recompute.
- **(12)** This section.

## Operator follow-up after merge (required)

The dev jobs proc still runs pre-#899 code and stamps event-dated rows until restarted (4 such rows had already accumulated during verification). After merge:
1. Restart the jobs proc onto main (standard detached relaunch).
2. Re-run the sql/191 UPDATE body once (idempotent) to mop up rows written in the gap.
3. Spot-check residual probe = stable 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
