### PR TITLE
fix(#813): populate_canonical_redirects untriggerable — missing source-registry entry + registry-parity invariant

### DIFF
--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -356,6 +356,16 @@ MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
     # params in MANUAL_TRIGGER_JOB_METADATA (empty); invoker in
     # app/jobs/runtime.py::_INVOKERS.
     "filing_events_skip_tier_cleanup": "db",
+    # populate_canonical_redirects — #819 .RTH operational-duplicate
+    # redirect binder. Operator triggers after a universe sync
+    # introduces new ``.RTH``-style variants. Pure DB operation
+    # (instruments self-join + UPDATE, no HTTP), short-running →
+    # ``db`` lane. Invoker landed with #819 but this registry entry
+    # was missed, so every manual trigger was rejected at
+    # ``source_for()`` (found 2026-06-11, S6 audit: 561/561 RTH rows
+    # unbound, zero job_runs ever). Companion params in
+    # MANUAL_TRIGGER_JOB_METADATA (empty).
+    "populate_canonical_redirects": "db",
     # raw_payload_retention_sweep — #1014 payload-null sweep. Pure DB
     # operation but LONG-running (minutes over ~12k rows) → own lane,
     # NOT the catch-all ``db`` (would starve the every-5-min

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -231,6 +231,13 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
     # fallback, which would also yield empty) and completes the
     # manual-only triangle (source + metadata + invoker).
     "filing_events_skip_tier_cleanup": (),
+    # populate_canonical_redirects — #819 .RTH redirect binder. No
+    # operator-tunable params (match rule is fixed by the settled
+    # decision; multi-primary ambiguity is skip-with-warning). Empty
+    # tuple completes the manual-only triangle (source + metadata +
+    # invoker) — the missing sources.py half made the job
+    # untriggerable from #819's merge until 2026-06-11.
+    "populate_canonical_redirects": (),
     # raw_payload_retention_sweep — #1014 payload-null sweep.
     # ``batch_size`` stays internal (implementation knob, same call as
     # #1013); ``dry_run`` is operator-facing and DEFAULTS TRUE so a

--- a/tests/test_layer_123_wiring.py
+++ b/tests/test_layer_123_wiring.py
@@ -23,6 +23,9 @@ import pytest
 
 from app.jobs.runtime import VALID_JOB_NAMES
 from app.jobs.sources import MANUAL_TRIGGER_JOB_SOURCES, source_for
+from app.services.canonical_instrument_redirects import (
+    JOB_POPULATE_CANONICAL_REDIRECTS,
+)
 from app.services.processes.param_metadata import (
     MANUAL_TRIGGER_JOB_METADATA,
     ParamValidationError,
@@ -202,6 +205,88 @@ class TestFilingEventsSkipTierCleanupRegistry:
                 {"batch_size": 100},
                 allow_internal_keys=False,
             )
+
+
+class TestPopulateCanonicalRedirectsRegistry:
+    """#819/#813 — the .RTH redirect binder is manual-trigger-only:
+    operator fires it after a universe sync introduces new variants.
+    The sources.py half of the triangle was missed at #819's merge,
+    so every manual trigger was rejected at ``source_for()`` — this
+    class pins the full triangle (invoker + metadata + source)."""
+
+    def test_in_valid_job_names(self) -> None:
+        assert JOB_POPULATE_CANONICAL_REDIRECTS in VALID_JOB_NAMES
+
+    def test_not_in_scheduled_jobs(self) -> None:
+        assert _job_by_name(JOB_POPULATE_CANONICAL_REDIRECTS) is None
+
+    def test_in_manual_trigger_metadata_with_no_params(self) -> None:
+        assert JOB_POPULATE_CANONICAL_REDIRECTS in MANUAL_TRIGGER_JOB_METADATA
+        assert MANUAL_TRIGGER_JOB_METADATA[JOB_POPULATE_CANONICAL_REDIRECTS] == ()
+
+    def test_in_manual_trigger_sources(self) -> None:
+        assert MANUAL_TRIGGER_JOB_SOURCES[JOB_POPULATE_CANONICAL_REDIRECTS] == "db"
+
+    def test_source_for_resolves(self) -> None:
+        assert source_for(JOB_POPULATE_CANONICAL_REDIRECTS) == "db"
+
+    def test_zero_param_validation_contract(self) -> None:
+        """POST /jobs/populate_canonical_redirects/run takes no params:
+        an empty body validates; any supplied key is rejected."""
+        metadata = _lookup_metadata(JOB_POPULATE_CANONICAL_REDIRECTS)
+        assert metadata == ()
+        validate_job_params(JOB_POPULATE_CANONICAL_REDIRECTS, {}, allow_internal_keys=False)
+        with pytest.raises(ParamValidationError):
+            validate_job_params(
+                JOB_POPULATE_CANONICAL_REDIRECTS,
+                {"suffix": ".W"},
+                allow_internal_keys=False,
+            )
+
+
+class TestEveryInvokerJobResolvesASource:
+    """Generic registry-parity invariant (Codex review of the
+    populate_canonical_redirects fix): every job the API will accept
+    (``VALID_JOB_NAMES`` = ``_INVOKERS`` keys) must resolve a lane via
+    ``source_for()``, or manual dispatch dies with a rejected queue row
+    the operator must reconcile. populate_canonical_redirects shipped
+    with only the invoker half and was silently untriggerable for a
+    month — this pins the whole class, not just that one job."""
+
+    # Jobs ALREADY in this broken state on main when the invariant
+    # landed (S6 audit 2026-06-11). Each needs per-job triage — right
+    # lane vs delete-the-invoker-as-dead-code — tracked in #1571.
+    # Adding a NEW name here is never the fix; complete the triangle
+    # instead.
+    _KNOWN_UNRESOLVABLE: frozenset[str] = frozenset(
+        {
+            "attribution_summary",
+            "daily_financial_facts",
+            "daily_tax_reconciliation",
+            "sec_def14a_ingest",
+            "sec_insider_transactions_ingest",
+        }
+    )
+
+    def test_all_valid_job_names_resolve(self) -> None:
+        unresolvable = []
+        for name in sorted(VALID_JOB_NAMES):
+            try:
+                source_for(name)
+            except KeyError:
+                unresolvable.append(name)
+        new_breaks = sorted(set(unresolvable) - self._KNOWN_UNRESOLVABLE)
+        assert new_breaks == [], (
+            f"jobs wired in _INVOKERS but missing from every source registry (untriggerable): {new_breaks}"
+        )
+
+    def test_known_unresolvable_list_shrinks_only(self) -> None:
+        """When a follow-up fixes one of the known-broken jobs, its
+        name must leave _KNOWN_UNRESOLVABLE — a stale entry would let
+        the regression silently reopen."""
+        for name in sorted(self._KNOWN_UNRESOLVABLE):
+            with pytest.raises(KeyError):
+                source_for(name)
 
 
 class TestLookupMetadataFallback:


### PR DESCRIPTION
## What

`populate_canonical_redirects` (#819, the `.RTH` operational-duplicate redirect binder) shipped 2026-05-11 with its `_INVOKERS` wiring but **without** the `MANUAL_TRIGGER_JOB_SOURCES` / `MANUAL_TRIGGER_JOB_METADATA` halves of the manual-only triangle. `JobLock` resolves its lane via `source_for()`, which raises `KeyError` for any job missing from the source registry — so every manual trigger was rejected at dispatch. The job is manual-only by design (operator fires it after a universe sync), so it has been **mechanically untriggerable since merge**: S6 audit found 561/561 RTH variants unbound (`canonical_instrument_id IS NULL`), zero `job_runs` rows ever, and a live `rejected` queue row (request_id 33) reproducing the failure.

## Changes

- `app/jobs/sources.py` — `"populate_canonical_redirects": "db"`. Pure-DB instruments self-join + UPDATE over ~561 rows, short-running; same shape as `filing_events_skip_tier_cleanup`. Not the #1526/#1527 starvation shape (manual-only, not a recurring co-fire).
- `app/services/processes/param_metadata.py` — empty params tuple (match rule is fixed by the #819 settled decision; no operator knobs).
- `tests/test_layer_123_wiring.py` —
  - `TestPopulateCanonicalRedirectsRegistry`: pins the full triangle (VALID_JOB_NAMES / not-in-SCHEDULED_JOBS / metadata / source / zero-param contract), mirroring the #1013 class.
  - `TestEveryInvokerJobResolvesASource` (Codex ckpt-2 suggestion): generic invariant — every `VALID_JOB_NAMES` entry must resolve via `source_for()`. **Immediately caught 5 more jobs in the same broken state on main**: `attribution_summary`, `daily_financial_facts`, `daily_tax_reconciliation`, `sec_def14a_ingest`, `sec_insider_transactions_ingest`. Pinned in a shrink-only `_KNOWN_UNRESOLVABLE` allow-list (companion test fails on stale entries); per-job triage filed as #1571.

## Security model

No auth/authz surface changes. The job was already reachable only through `POST /jobs/{name}/run` behind `require_session_or_service_token`; this PR changes only whether dispatch succeeds after that gate. No SQL changes, no new inputs.

## Tradeoffs

- The 5 pre-existing breaks are allow-listed rather than fixed here: each needs a deliberate lane choice (#1534 lesson — lane extraction can expose write races) or invoker deletion as dead code. Bundling 5 lane decisions into a registry fix would be scope creep with real risk. Tracked in #1571.
- `db` catch-all lane (not a dedicated lane): justified because the job is manual-only and sub-second-to-seconds over 561 rows; Codex ckpt-2 concurred.

## Verification

- `uv run ruff check .` / `ruff format --check` — clean
- `uv run pyright` — 0 errors
- `uv run pytest -m "not db"` — 3825 passed
- `uv run pytest tests/smoke` — 129 passed
- Codex ckpt-2 review: no blocking findings; its one suggestion (generic invariant) implemented.
- Dev-verify of the operator-visible outcome (trigger job → 561 RTH rows bound → `BRK.B.RTH` redirects to `BRK.B`) happens post-merge after the jobs-process restart picks up this commit; will be recorded on #813.

Part of S6 (#740/#790/#813 coverage). Contributes to #813 (suffix/RTH sub-task); does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Part of #813. Refs #1571.
