### PR TITLE
fix(#819): populate_canonical_redirects orphans its job_runs row — add _tracked_job wrapper

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -417,11 +417,15 @@ _INVOKERS[_files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK] = _adapt_zero_arg(_files_w
 
 # #819 — canonical-instrument redirect populate. Idempotent one-shot
 # the operator triggers after a universe sync introduces new
-# ``.RTH``-style variants. The job opens its own connection + commits.
+# ``.RTH``-style variants. Registered via the SCHEDULER tracked
+# wrapper, not the bare service function: manual dispatch runs the
+# lock+fence prelude which writes a ``running`` job_runs row that only
+# the invoker's ``_tracked_job`` finalises — the bare service body
+# orphaned that row forever (run 6994, 2026-06-11).
 from app.services import canonical_instrument_redirects as _canonical_redirects  # noqa: E402
 
 _INVOKERS[_canonical_redirects.JOB_POPULATE_CANONICAL_REDIRECTS] = _adapt_zero_arg(
-    _canonical_redirects.populate_canonical_redirects_job
+    _scheduler.populate_canonical_redirects
 )
 
 

--- a/app/services/canonical_instrument_redirects.py
+++ b/app/services/canonical_instrument_redirects.py
@@ -272,12 +272,16 @@ def populate_canonical_redirects(
 JOB_POPULATE_CANONICAL_REDIRECTS = "populate_canonical_redirects"
 
 
-def populate_canonical_redirects_job() -> None:
-    """Zero-arg job invoker — opens a connection and runs the populate.
+def populate_canonical_redirects_job() -> RedirectPopulationStats:
+    """Zero-arg job body — opens a connection and runs the populate.
 
-    Registered in ``app/jobs/runtime.py``. The operator triggers it
-    after a universe sync that may have introduced new ``.RTH``-style
-    variants. Idempotent — safe to re-run any time.
+    Dispatched via the ``app/workers/scheduler.py`` tracked wrapper
+    (which owns job-runs telemetry — the manual-dispatch prelude's
+    ``running`` job_runs row is finalised by ``_tracked_job`` there).
+    The operator triggers it after a universe sync that may have
+    introduced new ``.RTH``-style variants. Idempotent — safe to
+    re-run any time. Returns the run stats so the wrapper can stamp
+    ``row_count``.
     """
     from app.config import settings
 
@@ -287,3 +291,4 @@ def populate_canonical_redirects_job() -> None:
         # the job wrapper that owns the connection commits explicitly.
         conn.commit()
         logger.info("populate_canonical_redirects_job: %s", stats)
+    return stats

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -40,6 +40,7 @@ from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
 from app.services.anthropic_client import make_anthropic_client
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
+from app.services.canonical_instrument_redirects import JOB_POPULATE_CANONICAL_REDIRECTS
 from app.services.coverage import bootstrap_missing_coverage_rows, review_coverage, seed_coverage
 from app.services.deferred_retry import retry_deferred_recommendations
 from app.services.entry_timing import evaluate_entry_conditions
@@ -4320,6 +4321,29 @@ def filing_events_skip_tier_cleanup() -> None:
             summary.batches,
             dict(sorted(summary.by_form_type.items(), key=lambda kv: kv[1], reverse=True)),
         )
+
+
+def populate_canonical_redirects() -> None:
+    """Bind ``.RTH`` operational-duplicate variants to their canonical
+    base instrument (#819). Manual-trigger-only.
+
+    Thin scheduler-side wrapper around
+    :func:`app.services.canonical_instrument_redirects.populate_canonical_redirects_job`.
+    The service owns the connection + commit; this wrapper only adds
+    job-runs telemetry. Without it the manual-dispatch prelude's
+    ``running`` job_runs row has no finaliser and orphans forever
+    (found 2026-06-11 on the job's first-ever successful trigger:
+    run 6994 stuck ``running`` after the body completed in <1s).
+    ``row_count`` = redirects newly set this run (idempotent re-run
+    reports 0 with the bindings counted as already-correct).
+    """
+    from app.services.canonical_instrument_redirects import (
+        populate_canonical_redirects_job,
+    )
+
+    with _tracked_job(JOB_POPULATE_CANONICAL_REDIRECTS) as tracker:
+        stats = populate_canonical_redirects_job()
+        tracker.row_count = stats.redirects_set
 
 
 def raw_payload_retention_sweep(params: Mapping[str, Any]) -> None:

--- a/tests/test_populate_canonical_redirects_wiring.py
+++ b/tests/test_populate_canonical_redirects_wiring.py
@@ -1,0 +1,105 @@
+"""#819 — populate_canonical_redirects job-runs telemetry wiring.
+
+The job's first-ever successful manual dispatch (2026-06-11) orphaned
+its prelude-written ``running`` job_runs row: the bare service body
+never adopted the row via ``_tracked_job``. These tests pin the fix:
+
+* ``_INVOKERS`` registers the SCHEDULER tracked wrapper, not the bare
+  service function.
+* The wrapper runs the body inside ``_tracked_job`` and stamps
+  ``row_count = redirects_set``.
+
+Pure-logic tier — the service body and the tracking context manager
+are both stubbed; no DB.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+from app.jobs.runtime import _INVOKERS
+from app.services.canonical_instrument_redirects import (
+    JOB_POPULATE_CANONICAL_REDIRECTS,
+    RedirectPopulationStats,
+)
+from app.workers import scheduler as scheduler_module
+
+
+class TestInvokerRegistration:
+    def test_invoker_wraps_scheduler_tracked_wrapper(self) -> None:
+        """The registered invoker must be the scheduler-side wrapper.
+
+        Registering the bare service function reintroduces the
+        orphaned-``running``-row defect — the prelude row would have
+        no finaliser.
+        """
+        invoker = _INVOKERS[JOB_POPULATE_CANONICAL_REDIRECTS]
+        wrapped = getattr(invoker, "__wrapped__", None)
+        assert wrapped is scheduler_module.populate_canonical_redirects
+
+
+class TestTrackedWrapper:
+    def test_wrapper_tracks_and_stamps_row_count(self, monkeypatch: Any) -> None:
+        stats = RedirectPopulationStats(
+            variants_scanned=561,
+            redirects_set=540,
+            redirects_already_correct=0,
+            redirects_skipped_no_base=21,
+            redirects_skipped_ambiguous=0,
+        )
+
+        class _Tracker:
+            row_count: int | None = None
+
+        tracker = _Tracker()
+        entered: list[str] = []
+
+        @contextmanager
+        def _fake_tracked_job(job_name: str):
+            entered.append(job_name)
+            yield tracker
+
+        monkeypatch.setattr(scheduler_module, "_tracked_job", _fake_tracked_job)
+        monkeypatch.setattr(
+            "app.services.canonical_instrument_redirects.populate_canonical_redirects_job",
+            lambda: stats,
+        )
+
+        scheduler_module.populate_canonical_redirects()
+
+        assert entered == [JOB_POPULATE_CANONICAL_REDIRECTS]
+        assert tracker.row_count == 540
+
+    def test_body_exception_propagates_inside_tracking(self, monkeypatch: Any) -> None:
+        """A body failure must surface INSIDE the tracking scope so
+        ``_tracked_job`` records the failed run (not an orphaned row)."""
+        entered: list[str] = []
+        exited: list[bool] = []
+
+        @contextmanager
+        def _fake_tracked_job(job_name: str):
+            entered.append(job_name)
+            try:
+                yield type("T", (), {"row_count": None})()
+            finally:
+                exited.append(True)
+
+        def _boom() -> RedirectPopulationStats:
+            raise RuntimeError("populate failed")
+
+        monkeypatch.setattr(scheduler_module, "_tracked_job", _fake_tracked_job)
+        monkeypatch.setattr(
+            "app.services.canonical_instrument_redirects.populate_canonical_redirects_job",
+            _boom,
+        )
+
+        try:
+            scheduler_module.populate_canonical_redirects()
+        except RuntimeError:
+            pass
+        else:  # pragma: no cover - assertion guard
+            raise AssertionError("body exception was swallowed")
+
+        assert entered == [JOB_POPULATE_CANONICAL_REDIRECTS]
+        assert exited == [True]


### PR DESCRIPTION
## What

Follow-up defect exposed by PR #1572 (which made `populate_canonical_redirects` dispatchable for the first time). Manual dispatch routes through `run_with_prelude` (`app/jobs/runtime.py:882`), which writes a `running` job_runs row that only the invoker's `_tracked_job` finalises — and the registered invoker was the **bare service function** with no tracking. First-ever successful trigger on dev: body completed in <1s (scanned=561, set=540, skipped_no_base=21), but run 6994 stayed `running` forever — reads as a wedged job on admin Processes and trips the #1510 aged-running surface.

## Changes

- `app/workers/scheduler.py` — `populate_canonical_redirects()` tracked wrapper (same shape as the #1013 `filing_events_skip_tier_cleanup` precedent); `tracker.row_count = stats.redirects_set`.
- `app/services/canonical_instrument_redirects.py` — `populate_canonical_redirects_job` returns `RedirectPopulationStats` (was `None`) so the wrapper stamps row_count. No other callers (verified by grep + Codex).
- `app/jobs/runtime.py` — `_INVOKERS` entry points at the scheduler wrapper.
- `tests/test_populate_canonical_redirects_wiring.py` — pure-tier pins: invoker identity (re-registering the bare service fn reintroduces the orphan), `_tracked_job` scope + row_count stamping, body-exception-propagates-inside-tracking.

## Security model

No auth/authz/input changes. Telemetry-only path behind the existing `require_session_or_service_token` job-trigger gate.

## Tradeoffs

- Same latent exposure exists for the 7 bulk-dataset invokers (bare service fns, zero job_runs rows ever — they only run as bootstrap stages). Deliberately NOT bundled: each needs its own stats-return plumbing. Filed as #1573.
- The orphaned dev row 6994 is left for the jobs-process boot-recovery sweep at the next restart (which is also needed to load this code) rather than a hand `UPDATE`.

## Verification

- `uv run ruff check .` / `format --check` — clean; `uv run pyright` — 0 errors
- `uv run pytest -m "not db"` — 3828 passed; `tests/smoke` — 129 passed
- Codex ckpt-2: **no findings**; explicitly confirmed `_tracked_job` adopts the prelude row via `consume_prelude_run_id` (no double-write) and the signature change has no other callers.
- Post-merge dev-verify (recorded on #813/#819 trail): restart jobs proc onto the merge, re-trigger the job, confirm job_runs row reaches `success` with `row_count=0` (idempotent re-run — 540 bindings already correct) and boot recovery swept run 6994.

Part of #813. Refs #819. Refs #1573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)