### PR TITLE
feat(#813): .US-suffix fallback in the CIK ticker match

### DIFF
--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -506,7 +506,17 @@ def upsert_cik_mapping(
     upserted = 0
     with conn.transaction():
         for symbol, instrument_id in instrument_symbols:
-            cik = mapping.get(symbol.upper())
+            symbol_upper = symbol.upper()
+            cik = mapping.get(symbol_upper)
+            if not cik and symbol_upper.endswith(".US"):
+                # #813 — eToro suffixes some US listings ``.US`` to
+                # disambiguate from same-ticker crypto rows (M.US =
+                # Macy's, M = crypto). SEC's ticker files carry the
+                # bare ticker, so PETS.US / BTG.US etc. never matched.
+                # Exact match wins when both exist; the caller's
+                # ``asset_class='us_equity'`` cohort filter keeps the
+                # crypto siblings out of this loop entirely (#475).
+                cik = mapping.get(symbol_upper[: -len(".US")])
             if not cik:
                 logger.debug("CIK mapping: no CIK found for symbol %s", symbol)
                 continue

--- a/tests/test_upsert_cik_mapping.py
+++ b/tests/test_upsert_cik_mapping.py
@@ -238,3 +238,45 @@ def test_symbol_missing_from_mapping_is_skipped(ebull_test_conn: psycopg.Connect
 
     assert upserted == 0
     assert _primary_cik(conn, 1) is None
+
+
+def test_dot_us_suffix_falls_back_to_bare_ticker(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """#813 — eToro's ``.US`` stock-vs-crypto disambiguation suffix.
+    SEC's ticker files carry the bare ticker (PETS), so PETS.US must
+    match via the stripped fallback."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="PETS.US")
+
+    upserted = upsert_cik_mapping(conn, {"PETS": "0001040130"}, [("PETS.US", "1")])
+
+    assert upserted == 1
+    assert _primary_cik(conn, 1) == "0001040130"
+
+
+def test_dot_us_exact_match_wins_over_stripped(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """If SEC ever lists a literal ``X.US`` ticker, the exact match
+    must win — the strip is a fallback, never a rewrite."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="PETS.US")
+
+    upserted = upsert_cik_mapping(
+        conn,
+        {"PETS.US": "0009999999", "PETS": "0001040130"},
+        [("PETS.US", "1")],
+    )
+
+    assert upserted == 1
+    assert _primary_cik(conn, 1) == "0009999999"
+
+
+def test_non_dot_us_suffix_is_not_stripped(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """Only the literal ``.US`` suffix participates — ``.RTH`` variants
+    are the canonical-redirect mechanism's territory (#819), and a
+    bare-miss must stay a skip."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="AAPL.RTH")
+
+    upserted = upsert_cik_mapping(conn, {"AAPL": "0000320193"}, [("AAPL.RTH", "1")])
+
+    assert upserted == 0
+    assert _primary_cik(conn, 1) is None


### PR DESCRIPTION
## What

223 tradable `.US`-suffixed stocks (PETS.US, BTG.US, …) had no SEC CIK, leaving their filings/fundamentals dark. eToro suffixes some US listings `.US` to disambiguate from same-ticker **crypto** rows (M.US = Macy's, M = crypto; verified on dev — most `.US` bare-siblings sit on the Digital Currency exchange). SEC's `company_tickers.json` carries the bare ticker, so the exact-match lookup in `upsert_cik_mapping` could never bind them.

## Change

`app/services/filings.py::upsert_cik_mapping` — on an exact-match miss for a symbol ending `.US`, retry with the suffix stripped. One fallback, single chokepoint (the daily `daily_cik_refresh` stage-5 path is the only production caller).

Safety:
- **Exact match always wins** — the strip is a fallback, never a rewrite (test-pinned).
- **No crypto mis-stamping**: the caller's cohort filter (`exchanges.asset_class='us_equity'`, #475/#503) keeps crypto siblings out of the loop entirely; the suffix logic never touches them.
- `.RTH` variants don't participate (canonical-redirect territory per the #819 settled decision; test-pinned).
- Edge cases (Codex ckpt-2, no findings): literal `".US"` symbol → empty-key miss; case folded before compare; `BRK.B.US` would strip to `BRK.B` correctly.

## Tests

`tests/test_upsert_cik_mapping.py`: fallback hit, exact-match precedence over strip, `.RTH` non-participation. 11 passed (db tier, deliberate run). Gates: ruff/format clean, pyright 0, fast tier 3,828, smoke 129.

## Scope note — #813 ETF half re-homed

Empirics invalidated the issue's premise: `company_tickers_exchange.json` does NOT carry ETFs (same curated set as the canonical file). ETF tickers live in `company_tickers_mf.json` keyed to **trust** CIKs (iShares Trust 0001100663 ≈ 300 of our ETFs), which trips the #1102 settled-decision 50+ shared-CIK threshold and a CIK→instrument fan-out misrouting risk. Re-homed to **#1577** (entities-layer design decision) per operator decision 2026-06-11. ADR resolver / manual-override endpoint / report page were already rescoped out (see #813 comment trail).

## Verification (dev, post-merge plan)

This is identity resolution feeding ownership/fundamentals surfaces, so the ETL DoD applies: after merge, trigger `daily_cik_refresh` on dev, record the `.US` CIK-gain count + spot PETS.US/BTG.US bindings (cross-source: SEC company_tickers.json carries PETS→0001040130, BTG→0001429937 — probed 2026-06-11), and confirm `/coverage/cik-gap` drops. Will be recorded as a PR comment before merge.

Closes #813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)