### PR TITLE
fix(#1102): dot→dash share-class CIK ticker fallback + audit bucket + PR-B docs un-stale

### DIFF
--- a/app/services/cik_coverage_audit.py
+++ b/app/services/cik_coverage_audit.py
@@ -18,10 +18,17 @@ operator can ignore the noise and focus on real gaps:
     ``ABT.US``, ``ACLX.CVR``). These are operational duplicates;
     once #819 lands the canonical-redirect mechanism, they should
     NOT have their own CIK row — the canonical row carries it.
-    Legitimate share-class siblings like ``BRK.B`` DO have CIK rows
-    (post-#1102) so they don't show here.
   * ``other`` — everything else. ETFs, funds, merger CVRs, and any
     genuine gap. Operator must triage one by one.
+
+Share-class exception (#1102): a dotted symbol ending in a single
+uppercase class letter (``BRK.B``, ``CWEN.A`` — ``\\.[A-Z]$``) is a
+distinct security expected to carry its own CIK, not an operational
+variant. Those bucket as ``other`` so a residual miss (SEC's ticker
+file lacking the dashed form) stays operator-visible instead of
+hiding in the ignorable bucket. Multi-letter class suffixes
+(``AXIA.PC``) are rare enough that they stay in ``suffix_variants``
+— triage via the sample list if coverage stalls.
 
 The bridge itself (ticker → CIK via SEC's ``company_tickers.json``)
 already ships in ``daily_cik_refresh`` (#475); this audit surface is
@@ -39,6 +46,13 @@ from typing import Any
 import psycopg
 
 logger = logging.getLogger(__name__)
+
+# True for dotted symbols that are operational variants (AAPL.RTH,
+# DOW.OLD) — false for bare tickers and for share-class dots
+# (BRK.B, CWEN.A: ``\.[A-Z]$``), which are expected CIK-bearing
+# securities post-#1102. Static SQL fragment, single source for the
+# three queries below.
+_SUFFIX_VARIANT_SQL = r"(i.symbol LIKE '%%.%%' AND i.symbol !~ '\.[A-Z]$')"
 
 
 @dataclass(frozen=True)
@@ -116,10 +130,10 @@ def compute_cik_gap_report(
         # streaming the full unmapped set just to bucket them. The
         # sample query below caps payload size.
         cur.execute(
-            """
+            f"""
             SELECT
-              COUNT(*) FILTER (WHERE i.symbol LIKE '%%.%%') AS suffix_variants,
-              COUNT(*) FILTER (WHERE i.symbol NOT LIKE '%%.%%') AS other
+              COUNT(*) FILTER (WHERE {_SUFFIX_VARIANT_SQL}) AS suffix_variants,
+              COUNT(*) FILTER (WHERE NOT {_SUFFIX_VARIANT_SQL}) AS other
               FROM instruments i
               JOIN exchanges e ON e.exchange_id = i.exchange
               LEFT JOIN external_identifiers ei
@@ -145,9 +159,9 @@ def compute_cik_gap_report(
         # operator sees the genuinely interesting gaps first. Cap at
         # sample_limit to keep the JSON response bounded.
         cur.execute(
-            """
+            f"""
             SELECT i.instrument_id, i.symbol, i.company_name,
-                   CASE WHEN i.symbol LIKE '%%.%%' THEN 'suffix_variant'
+                   CASE WHEN {_SUFFIX_VARIANT_SQL} THEN 'suffix_variant'
                         ELSE 'other' END AS category
               FROM instruments i
               JOIN exchanges e ON e.exchange_id = i.exchange
@@ -159,7 +173,7 @@ def compute_cik_gap_report(
              WHERE i.is_tradable = TRUE
                AND e.asset_class = 'us_equity'
                AND ei.identifier_value IS NULL
-             ORDER BY CASE WHEN i.symbol LIKE '%%.%%' THEN 1 ELSE 0 END,
+             ORDER BY CASE WHEN {_SUFFIX_VARIANT_SQL} THEN 1 ELSE 0 END,
                       i.symbol
              LIMIT %s
             """,

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -517,6 +517,13 @@ def upsert_cik_mapping(
                 # ``asset_class='us_equity'`` cohort filter keeps the
                 # crypto siblings out of this loop entirely (#475).
                 cik = mapping.get(symbol_upper[: -len(".US")])
+            if not cik and "." in symbol_upper:
+                # #1102 — share-class separators differ: eToro uses a
+                # dot (BRK.B, BF.A), SEC's ticker files use a dash
+                # (BRK-B, BF-A). Operational-variant suffixes (.RTH,
+                # .OLD, .CVR, ...) translate to dashed strings SEC
+                # never lists, so they miss here and stay skips.
+                cik = mapping.get(symbol_upper.replace(".", "-"))
             if not cik:
                 logger.debug("CIK mapping: no CIK found for symbol %s", symbol)
                 continue

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -507,23 +507,28 @@ def upsert_cik_mapping(
     with conn.transaction():
         for symbol, instrument_id in instrument_symbols:
             symbol_upper = symbol.upper()
+            # Fallback chain: exact → .US strip → dot→dash on the
+            # stripped base. Exact match always wins.
+            base = symbol_upper[: -len(".US")] if symbol_upper.endswith(".US") else symbol_upper
             cik = mapping.get(symbol_upper)
-            if not cik and symbol_upper.endswith(".US"):
+            if not cik and base != symbol_upper:
                 # #813 — eToro suffixes some US listings ``.US`` to
                 # disambiguate from same-ticker crypto rows (M.US =
                 # Macy's, M = crypto). SEC's ticker files carry the
                 # bare ticker, so PETS.US / BTG.US etc. never matched.
-                # Exact match wins when both exist; the caller's
-                # ``asset_class='us_equity'`` cohort filter keeps the
-                # crypto siblings out of this loop entirely (#475).
-                cik = mapping.get(symbol_upper[: -len(".US")])
-            if not cik and "." in symbol_upper:
+                # The caller's ``asset_class='us_equity'`` cohort filter
+                # keeps the crypto siblings out of this loop entirely
+                # (#475).
+                cik = mapping.get(base)
+            if not cik and "." in base:
                 # #1102 — share-class separators differ: eToro uses a
                 # dot (BRK.B, BF.A), SEC's ticker files use a dash
-                # (BRK-B, BF-A). Operational-variant suffixes (.RTH,
-                # .OLD, .CVR, ...) translate to dashed strings SEC
-                # never lists, so they miss here and stay skips.
-                cik = mapping.get(symbol_upper.replace(".", "-"))
+                # (BRK-B, BF-A). Translating the .US-stripped base also
+                # covers a hypothetical BRK.B.US → BRK-B. Operational
+                # variant suffixes (.RTH, .OLD, .CVR, ...) translate to
+                # dashed strings SEC never lists, so they miss here and
+                # stay skips.
+                cik = mapping.get(base.replace(".", "-"))
             if not cik:
                 logger.debug("CIK mapping: no CIK found for symbol %s", symbol)
                 continue

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -437,12 +437,15 @@ below for the operational-duplicate redirect semantics.
 - **PR-A:** sql/143 migration + filings.py upsert + ON CONFLICT predicate
   sweep across ~25 production + test sites + `tests/test_upsert_cik_mapping.py`
   flips.
-- **PR-B (deferred):** fan-out CIK→instrument multimap in
-  `sec_companyfacts_ingest.py`, `sec_submissions_ingest.py`,
+- **PR-B (landed 65660911, PR #1118):** fan-out CIK→instrument multimap
+  in `sec_companyfacts_ingest.py`, `sec_submissions_ingest.py`,
   `sec_insider_dataset_ingest.py` so share-class siblings BOTH receive
-  bulk-ingest data. Until PR-B lands, only one of two siblings has
-  fundamentals / submissions / insider data — but the binding is stable
-  rather than flapping (strict improvement).
+  bulk-ingest data. Per-filing manifest parsers fan out via
+  `app/services/manifest_parsers/_siblings.py::resolve_siblings` /
+  `app/services/sec_identity.py::siblings_for_issuer_cik` (PR #1152
+  onward). Data ingested BEFORE PR-B stays single-sibling until a
+  scoped `sec_rebuild` re-ingest — re-run it when a sibling shows
+  missing per-source data despite a bound CIK.
 
 **Spec:** `docs/proposals/etl/share-class-cik-uniqueness.md`.
 

--- a/tests/test_cik_coverage_audit.py
+++ b/tests/test_cik_coverage_audit.py
@@ -174,3 +174,28 @@ def test_sample_limit_caps_payload(
 
     assert report.unmapped == 7  # AAPL.RTH + AAXJ + 5 EXTRA.RTH
     assert len(report.sample) == 2
+
+
+def test_share_class_dot_buckets_as_other(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """#1102 — an unmapped single-letter share class (CWEN.A) is an
+    expected CIK-bearing security, not an operational variant. It must
+    bucket as ``other`` so the miss stays operator-visible."""
+    conn = ebull_test_conn
+    _seed_universe(conn)
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671020, 'CWEN.A', 'Clearway Energy A', 'audit_us', 'USD', TRUE)
+        """,
+    )
+    conn.commit()
+
+    report = compute_cik_gap_report(conn, sample_limit=10)
+
+    assert report.unmapped_suffix_variants == 1  # AAPL.RTH only
+    assert report.unmapped_other == 2  # AAXJ + CWEN.A
+    by_symbol = {r.symbol: r.category for r in report.sample}
+    assert by_symbol["CWEN.A"] == "other"
+    assert by_symbol["AAPL.RTH"] == "suffix_variant"

--- a/tests/test_upsert_cik_mapping.py
+++ b/tests/test_upsert_cik_mapping.py
@@ -310,6 +310,19 @@ def test_share_class_exact_match_wins_over_dash(ebull_test_conn: psycopg.Connect
     assert _primary_cik(conn, 1) == "0009999999"
 
 
+def test_share_class_dot_us_chains_to_dash(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """Hypothetical BRK.B.US — the dash translation applies to the
+    .US-stripped base, so the chain reaches BRK-B. Also pins that the
+    nonsense BRK-B-US form is never probed (mapping omits it)."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="BRK.B.US")
+
+    upserted = upsert_cik_mapping(conn, {"BRK-B": "0001067983"}, [("BRK.B.US", "1")])
+
+    assert upserted == 1
+    assert _primary_cik(conn, 1) == "0001067983"
+
+
 def test_variant_suffix_dash_translation_stays_a_skip(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_upsert_cik_mapping.py
+++ b/tests/test_upsert_cik_mapping.py
@@ -280,3 +280,46 @@ def test_non_dot_us_suffix_is_not_stripped(ebull_test_conn: psycopg.Connection[t
 
     assert upserted == 0
     assert _primary_cik(conn, 1) is None
+
+
+def test_share_class_dot_falls_back_to_dash(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """#1102 — eToro writes share classes with a dot (BRK.B), SEC's
+    ticker files with a dash (BRK-B). The dashed fallback must bind."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="BRK.B")
+
+    upserted = upsert_cik_mapping(conn, {"BRK-B": "0001067983"}, [("BRK.B", "1")])
+
+    assert upserted == 1
+    assert _primary_cik(conn, 1) == "0001067983"
+
+
+def test_share_class_exact_match_wins_over_dash(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """If SEC ever lists a literal dotted ticker, the exact match must
+    win — the dash translation is a fallback, never a rewrite."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="BRK.B")
+
+    upserted = upsert_cik_mapping(
+        conn,
+        {"BRK.B": "0009999999", "BRK-B": "0001067983"},
+        [("BRK.B", "1")],
+    )
+
+    assert upserted == 1
+    assert _primary_cik(conn, 1) == "0009999999"
+
+
+def test_variant_suffix_dash_translation_stays_a_skip(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Operational variants (AAPL.RTH → AAPL-RTH) translate to dashed
+    strings SEC never lists — the fallback must not bind them to the
+    base ticker's CIK."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, instrument_id=1, symbol="DOW.OLD")
+
+    upserted = upsert_cik_mapping(conn, {"DOW": "0001751788"}, [("DOW.OLD", "1")])
+
+    assert upserted == 0
+    assert _primary_cik(conn, 1) is None


### PR DESCRIPTION
## What

Close-out PR for #1102 (share-class CIK uniqueness). Three changes:

1. **`upsert_cik_mapping` dot→dash fallback** (`app/services/filings.py`): SEC's `company_tickers.json` writes share classes with a dash (`BRK-B`, `BF-A`, `MOG-A` — verified live 2026-06-11); eToro symbols use a dot (`BRK.B`, `BF.A`). The exact-match lookup never bound a CIK to any dotted share class. Fallback chain is now **exact → `.US` strip (#813) → dot→dash on the stripped base**; exact match always wins. Sized on dev: **11 tradable instruments bind** (BRK.B, BF.A, HEI.A, LEN.B, MOG.A, CRD.A, GEF.B, GTN.A, UHAL.B, PBR.A, AXIA.PC), all verified entity-correct against the live SEC file.
2. **`cik_coverage_audit` share-class bucket** (Codex ckpt-2 finding): the audit bucketed every dotted symbol as ignorable `suffix_variant`. Post-#1102, a single-letter share class (`\.[A-Z]$`) is an expected CIK-bearing security — residual misses (e.g. `CWEN.A`, whose dashed form SEC does not list) now bucket as `other` so they stay operator-visible. Predicate single-sourced as `_SUFFIX_VARIANT_SQL`.
3. **`docs/settled-decisions.md` maintenance edit**: the "CIK = entity" entry still claimed PR-B (sibling fan-out) was deferred — it landed 2026-05-10 as 65660911 (PR #1118), with manifest-parser fan-out via `_siblings.py`/`sec_identity.py` since PR #1152. Text corrected; adds the operator note that pre-PR-B data needs a scoped `sec_rebuild` re-ingest.

## Why

S7 identity batch. #1102's schema (PR-A `8e6766f9`) and fan-out (PR-B `65660911`) merged a month ago but the issue stayed open: dev audit (2026-06-11) showed BRK.B CIK-less (dash/dot mismatch), GOOGL with 0 insider rows (pre-PR-B ingest), and stale docs claiming fan-out was still deferred.

## Security model

No new input surface. `mapping` values come from SEC's `company_tickers.json` via the existing provider path; symbols come from our own `instruments` table. The dash translation only changes which dict key is probed — it cannot bind a CIK that SEC's file doesn't carry. Operational-variant suffixes (`.RTH`, `.OLD`, `.CVR`) translate to dashed strings SEC never lists, so they remain skips (pinned by test). `_SUFFIX_VARIANT_SQL` is a static module constant, not interpolated user input. Authz unchanged: audit endpoint sits behind the existing operator auth.

## Conscious tradeoffs

- Multi-letter class suffixes (`AXIA.PC`) stay in the audit's `suffix_variant` bucket — the `\.[A-Z]$` heuristic favours precision; documented in the module docstring. (AXIA.PC itself binds via the new fallback, so it leaves the unmapped set anyway.)
- No normalisation at `_parse_cik_mapping` (provider side) — translation lives at the single consumer chokepoint, mirroring the `.US` precedent from #1578.

## Verification (ETL DoD 8-12 — in progress, recorded before merge)

- Targeted DB tier: `tests/test_upsert_cik_mapping.py` 15 passed, `tests/test_cik_coverage_audit.py` 5 passed.
- Fast tier 3828 passed; smoke 129 passed; ruff + format + pyright clean.
- Codex ckpt-2 run on cd25c44; both findings fixed in bbb1bd9.
- Dev backfill + panel verification (GOOG/GOOGL/BRK.B/AAPL rollups, cross-source revenue) to be recorded on this PR before merge.

Part of #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)