### PR TITLE
feat(#1577): ETF identity = series/class by design — settled decision + fund_series_covered audit bucket

### DIFF
--- a/app/api/coverage.py
+++ b/app/api/coverage.py
@@ -93,17 +93,20 @@ class CikGapRowResponse(BaseModel):
     instrument_id: int
     symbol: str
     company_name: str | None
-    category: str  # "suffix_variant" | "other"
+    category: str  # "fund_series_covered" | "suffix_variant" | "other"
 
 
 class CikCoverageGapResponse(BaseModel):
     """Aggregate counters + capped sample for the CIK gap report.
 
     Cohort is the us_equity tradable producer cohort (matches
-    ``daily_cik_refresh``'s scope). ``unmapped_suffix_variants``
-    rows are operational-duplicate variants (``.RTH``, ``.US`` etc)
-    that legitimately lack their own CIK row; ``unmapped_other`` is
-    the real gap signal — typically ETFs, funds, merger CVRs, or
+    ``daily_cik_refresh``'s scope). ``unmapped_fund_series_covered``
+    rows are ETFs/funds whose identity flows through the series/class
+    mechanism by design (#1577 — trust CIK never stamped on
+    instruments); ``unmapped_suffix_variants`` rows are
+    operational-duplicate variants (``.RTH``, ``.US`` etc) that
+    legitimately lack their own CIK row; ``unmapped_other`` is the
+    real gap signal — funds without class bindings, merger CVRs, or
     a genuine missing mapping.
     """
 
@@ -111,6 +114,7 @@ class CikCoverageGapResponse(BaseModel):
     cohort_total: int
     mapped: int
     unmapped: int
+    unmapped_fund_series_covered: int
     unmapped_suffix_variants: int
     unmapped_other: int
     sample: list[CikGapRowResponse]
@@ -277,12 +281,14 @@ def get_cik_gap(
     so the ``mapped`` + ``unmapped`` split correlates with the
     bridge's hit / miss rate. Unmapped rows are bucketed:
 
+    * ``fund_series_covered`` — ETF/fund identity flows through
+      series/class by design (#1577); the missing CIK is not a gap.
     * ``suffix_variants`` — symbol contains ``.`` (operational
       duplicates like ``AAPL.RTH``). Pre-#819 these would render
       empty pages; post-#819 the canonical-redirect mechanism
       ensures they don't need their own CIK.
-    * ``other`` — ETFs, funds, merger CVRs, and any genuine gap
-      worth operator triage.
+    * ``other`` — funds without class bindings, merger CVRs, and
+      any genuine gap worth operator triage.
 
     See ``docs/wiki/runbooks/runbook-diagnosing-missing-cik.md`` for
     the runbook that interprets this report.
@@ -295,6 +301,7 @@ def get_cik_gap(
         cohort_total=report.cohort_total,
         mapped=report.mapped,
         unmapped=report.unmapped,
+        unmapped_fund_series_covered=report.unmapped_fund_series_covered,
         unmapped_suffix_variants=report.unmapped_suffix_variants,
         unmapped_other=report.unmapped_other,
         sample=[

--- a/app/services/cik_coverage_audit.py
+++ b/app/services/cik_coverage_audit.py
@@ -62,11 +62,23 @@ logger = logging.getLogger(__name__)
 # three queries below.
 _SUFFIX_VARIANT_SQL = r"(i.symbol LIKE '%%.%%' AND i.symbol !~ '\.[A-Z]$')"
 
+# cik_refresh_mf_directory has observed-ever semantics — daily_cik_refresh
+# upserts bump last_seen daily for classes still in company_tickers_mf.json,
+# so a row whose last_seen stops advancing is a class SEC has dropped.
+# 30 days tolerates refresh outages while still catching drops (Codex
+# ckpt-2: without this, a dropped class would hide a real CIK gap in
+# the by-design bucket forever).
+_MF_DIRECTORY_FRESHNESS_DAYS = 30
+
 # True when the instrument's fund identity flows through the
 # series/class mechanism (#1577): a PRIMARY (sec, class_id) row whose
-# class_id the mf directory still knows. Both predicates are
-# load-bearing (Codex spec review): a demoted class_id or one SEC has
-# dropped from the directory must not hide a real CIK gap.
+# class_id the mf directory has seen RECENTLY. All three predicates
+# are load-bearing (Codex spec + ckpt-2 reviews): a demoted class_id,
+# or one SEC has dropped from the directory, must not hide a real
+# CIK gap. Freshness arrives as the ``mf_fresh_days`` query param —
+# parameterising (vs interpolating the constant) keeps the composed
+# query a LiteralString for pyright, per repo convention
+# (def14a_drift.py / coverage.py precedents).
 _FUND_SERIES_COVERED_SQL = """EXISTS (
   SELECT 1 FROM external_identifiers cl
   JOIN cik_refresh_mf_directory mf ON mf.class_id = cl.identifier_value
@@ -74,6 +86,7 @@ _FUND_SERIES_COVERED_SQL = """EXISTS (
     AND cl.provider = 'sec'
     AND cl.identifier_type = 'class_id'
     AND cl.is_primary = TRUE
+    AND mf.last_seen >= NOW() - make_interval(days => %(mf_fresh_days)s)
 )"""
 
 
@@ -171,6 +184,7 @@ def compute_cik_gap_report(
                AND e.asset_class = 'us_equity'
                AND ei.identifier_value IS NULL
             """,
+            {"mf_fresh_days": _MF_DIRECTORY_FRESHNESS_DAYS},
         )
         row = cur.fetchone()
         if row is None:
@@ -207,9 +221,12 @@ def compute_cik_gap_report(
                            WHEN {_SUFFIX_VARIANT_SQL} THEN 1
                            ELSE 0 END,
                       i.symbol
-             LIMIT %s
+             LIMIT %(sample_limit)s
             """,
-            (sample_limit,),
+            {
+                "mf_fresh_days": _MF_DIRECTORY_FRESHNESS_DAYS,
+                "sample_limit": sample_limit,
+            },
         )
         sample = [
             CikGapRow(

--- a/app/services/cik_coverage_audit.py
+++ b/app/services/cik_coverage_audit.py
@@ -11,15 +11,23 @@ missing a primary SEC CIK in ``external_identifiers``. Useful when:
   * Diagnosing why an instrument's chart / ownership / fundamentals
     render empty: no CIK = no SEC filings ingest.
 
-The audit splits unmapped instruments into two buckets so the
+The audit splits unmapped instruments into three buckets so the
 operator can ignore the noise and focus on real gaps:
 
+  * ``fund_series_covered`` — instrument holds a primary ``(sec,
+    class_id)`` row whose class_id is known to
+    ``cik_refresh_mf_directory``. ETF/fund identity flows through
+    series/class by design (#1577 — trust CIK is deliberately never
+    stamped on instruments), so the missing CIK row is not a gap.
+    The directory join is load-bearing: a stale/orphaned class_id
+    must NOT hide a real CIK gap.
   * ``suffix_variants`` — symbol contains ``.`` (e.g. ``AAPL.RTH``,
     ``ABT.US``, ``ACLX.CVR``). These are operational duplicates;
     once #819 lands the canonical-redirect mechanism, they should
     NOT have their own CIK row — the canonical row carries it.
-  * ``other`` — everything else. ETFs, funds, merger CVRs, and any
-    genuine gap. Operator must triage one by one.
+  * ``other`` — everything else. Funds without class bindings,
+    merger CVRs, and any genuine gap. Operator must triage one by
+    one.
 
 Share-class exception (#1102): a dotted symbol ending in a single
 uppercase class letter (``BRK.B``, ``CWEN.A`` — ``\\.[A-Z]$``) is a
@@ -54,6 +62,20 @@ logger = logging.getLogger(__name__)
 # three queries below.
 _SUFFIX_VARIANT_SQL = r"(i.symbol LIKE '%%.%%' AND i.symbol !~ '\.[A-Z]$')"
 
+# True when the instrument's fund identity flows through the
+# series/class mechanism (#1577): a PRIMARY (sec, class_id) row whose
+# class_id the mf directory still knows. Both predicates are
+# load-bearing (Codex spec review): a demoted class_id or one SEC has
+# dropped from the directory must not hide a real CIK gap.
+_FUND_SERIES_COVERED_SQL = """EXISTS (
+  SELECT 1 FROM external_identifiers cl
+  JOIN cik_refresh_mf_directory mf ON mf.class_id = cl.identifier_value
+  WHERE cl.instrument_id = i.instrument_id
+    AND cl.provider = 'sec'
+    AND cl.identifier_type = 'class_id'
+    AND cl.is_primary = TRUE
+)"""
+
 
 @dataclass(frozen=True)
 class CikGapRow:
@@ -62,7 +84,7 @@ class CikGapRow:
     instrument_id: int
     symbol: str
     company_name: str | None
-    category: str  # "suffix_variant" | "other"
+    category: str  # "fund_series_covered" | "suffix_variant" | "other"
 
 
 @dataclass(frozen=True)
@@ -72,6 +94,7 @@ class CikCoverageGapReport:
     cohort_total: int
     mapped: int
     unmapped: int
+    unmapped_fund_series_covered: int
     unmapped_suffix_variants: int
     unmapped_other: int
     sample: list[CikGapRow]  # capped at sample_limit
@@ -132,8 +155,11 @@ def compute_cik_gap_report(
         cur.execute(
             f"""
             SELECT
-              COUNT(*) FILTER (WHERE {_SUFFIX_VARIANT_SQL}) AS suffix_variants,
-              COUNT(*) FILTER (WHERE NOT {_SUFFIX_VARIANT_SQL}) AS other
+              COUNT(*) FILTER (WHERE {_FUND_SERIES_COVERED_SQL}) AS fund_series_covered,
+              COUNT(*) FILTER (WHERE NOT {_FUND_SERIES_COVERED_SQL}
+                               AND {_SUFFIX_VARIANT_SQL}) AS suffix_variants,
+              COUNT(*) FILTER (WHERE NOT {_FUND_SERIES_COVERED_SQL}
+                               AND NOT {_SUFFIX_VARIANT_SQL}) AS other
               FROM instruments i
               JOIN exchanges e ON e.exchange_id = i.exchange
               LEFT JOIN external_identifiers ei
@@ -148,20 +174,24 @@ def compute_cik_gap_report(
         )
         row = cur.fetchone()
         if row is None:
+            unmapped_fund_series_covered = 0
             unmapped_suffix_variants = 0
             unmapped_other = 0
         else:
-            unmapped_suffix_variants = int(row[0] or 0)
-            unmapped_other = int(row[1] or 0)
-        unmapped = unmapped_suffix_variants + unmapped_other
+            unmapped_fund_series_covered = int(row[0] or 0)
+            unmapped_suffix_variants = int(row[1] or 0)
+            unmapped_other = int(row[2] or 0)
+        unmapped = unmapped_fund_series_covered + unmapped_suffix_variants + unmapped_other
 
-        # Sample: prioritise "other" rows over suffix variants so the
+        # Sample: prioritise "other" rows, then suffix variants, then
+        # fund_series_covered (by-design, least interesting) so the
         # operator sees the genuinely interesting gaps first. Cap at
         # sample_limit to keep the JSON response bounded.
         cur.execute(
             f"""
             SELECT i.instrument_id, i.symbol, i.company_name,
-                   CASE WHEN {_SUFFIX_VARIANT_SQL} THEN 'suffix_variant'
+                   CASE WHEN {_FUND_SERIES_COVERED_SQL} THEN 'fund_series_covered'
+                        WHEN {_SUFFIX_VARIANT_SQL} THEN 'suffix_variant'
                         ELSE 'other' END AS category
               FROM instruments i
               JOIN exchanges e ON e.exchange_id = i.exchange
@@ -173,7 +203,9 @@ def compute_cik_gap_report(
              WHERE i.is_tradable = TRUE
                AND e.asset_class = 'us_equity'
                AND ei.identifier_value IS NULL
-             ORDER BY CASE WHEN {_SUFFIX_VARIANT_SQL} THEN 1 ELSE 0 END,
+             ORDER BY CASE WHEN {_FUND_SERIES_COVERED_SQL} THEN 2
+                           WHEN {_SUFFIX_VARIANT_SQL} THEN 1
+                           ELSE 0 END,
                       i.symbol
              LIMIT %s
             """,
@@ -190,10 +222,12 @@ def compute_cik_gap_report(
         ]
 
     logger.info(
-        "cik_coverage_audit: cohort=%d mapped=%d unmapped=%d (suffix_variants=%d other=%d) sample=%d",
+        "cik_coverage_audit: cohort=%d mapped=%d unmapped=%d "
+        "(fund_series_covered=%d suffix_variants=%d other=%d) sample=%d",
         cohort_total,
         mapped,
         unmapped,
+        unmapped_fund_series_covered,
         unmapped_suffix_variants,
         unmapped_other,
         len(sample),
@@ -202,6 +236,7 @@ def compute_cik_gap_report(
         cohort_total=cohort_total,
         mapped=mapped,
         unmapped=unmapped,
+        unmapped_fund_series_covered=unmapped_fund_series_covered,
         unmapped_suffix_variants=unmapped_suffix_variants,
         unmapped_other=unmapped_other,
         sample=sample,

--- a/docs/proposals/etl/2026-06-11-etf-trust-cik-design.md
+++ b/docs/proposals/etl/2026-06-11-etf-trust-cik-design.md
@@ -1,0 +1,63 @@
+# ETF trust CIKs — design decision (#1577)
+
+**Status:** draft for Codex ckpt-1 + operator sign-off.
+**Scope:** decide where ETF trust CIKs live in the identity model. No code in this doc's PR; implementation tickets follow the decision.
+
+## Problem
+
+~457 US-listed tradable ETFs carry no `(sec, cik)` row. Their tickers live in SEC's `company_tickers_mf.json`, keyed to the **trust** CIK: iShares Trust `0001100663` alone covers ~300 of our ETF instruments. Stamping trust CIKs through the #1102 shared-CIK mechanism would:
+
+1. Blow the settled-decision threshold — the per-instrument shared-CIK indexes were sized for ~10 share-class siblings with an explicit "50+ → entities layer" tripwire. Dev is at **46 multi-bound CIKs** today; one trust adds ~300.
+2. Explode parse-time fan-out — CIK→instrument fan-out consumers (issuer manifest parsers via `_siblings.py::resolve_siblings`, the three bulk ingesters' multimaps) fan per-filing writes across all siblings of the filing's CIK. A trust-level filing (N-CEN, 485BPOS) would denormalise ×300. (N-CSR is NOT in this class — it fans out by class_id, deliberately.)
+3. Mis-route subject resolution — `sec_atom_fast_lane.py::default_subject_resolver` resolves CIK→instrument with `LIMIT 1`; trust filings would land on an arbitrary sibling ETF.
+
+## Evidence (dev DB, 2026-06-11)
+
+- 1,869 us_equity tradable instruments lack a CIK; **440 of them hold a `(sec, class_id)` row AND appear in `cik_refresh_mf_directory`** — the ETF series/class population (close to the 457 estimate; remainder = delisted/operational variants).
+- `cik_refresh_mf_directory` (sql/149) already stores **`trust_cik` per class row** — 28,379 classes across 1,169 trusts; biggest trusts 339-587 classes each. Trust CIK is queryable today without touching instrument identity. Caveat: the directory has observed-ever semantics (no tombstoning on SEC dropping a class); any future trust-CIK consumer JOINing through it needs a freshness predicate (`last_seen`).
+- Fund data already flows without instrument-level trust CIKs, via two distinct paths: N-PORT holdings keyed by `fund_series_id` (#1171); N-CSR/fund-metadata resolved per class via `_fund_class_resolver.resolve_class_id_to_instrument` — N-CSR **already walks trust CIKs** from the directory and lands per-instrument fund metadata through class_id fan-out.
+- Berkshire counter-lesson (PR #1579): CIK 0001067983 was unbound until 2026-06-11; its historical manifest rows resolved `subject_type='institutional_filer', instrument_id=NULL` and stay mis-subjected — **no re-resolution sweep exists for late-arriving bindings**. Any option must not make late trust-CIK arrival worse.
+
+## What instrument-level data would a trust CIK even deliver?
+
+| Data class | ETF source | Needs trust CIK on instrument? |
+| --- | --- | --- |
+| Holdings | N-PORT keyed by `fund_series_id` | No (wired, #1171) |
+| Fund metadata (expense, objective) | N-CSR via trust-CIK walk → class_id resolution | No (wired — consumes the directory, not instrument CIK rows) |
+| Fundamentals (10-K/Q facts) | ETFs file none | No |
+| Insider (Form 3/4/5) | None for ETFs | No |
+| Proxy (DEF 14A) | Trust-level, fund-board ops | Marginal |
+| N-CEN / 485 (fees, ops) | Trust-level | Only consumer that would |
+| Prices / AUM | Market data providers | No |
+
+No current consumer needs trust CIK **stamped on instruments** — N-CSR proves trust-CIK-keyed ingest works fine through the directory + class-resolution path. No eBull surface consumes N-CEN/485 content today.
+
+## Options
+
+### (a) Entities layer (#1102 Option B)
+
+`entities(cik PK, kind, name)` + `instruments.entity_id FK`; entity-level data keyed by entity; readers join. Honest model, kills denormalisation, survives 300-sibling trusts.
+**Cost:** large migration touching every CIK-keyed reader (fundamentals, submissions, insider, capabilities, manifest subject resolution) + the two-layer ownership model. Weeks, not days. Pays rent only when a consumer needs trust-level data.
+
+### (b) Non-primary trust-CIK rows + audited consumer contract
+
+Stamp `(sec, cik, trust_cik_value, is_primary=FALSE)` on ETF instruments; audit every CIK→instrument consumer to filter `is_primary` or cap fan-out.
+**Cost:** the audit is the hard part — every future consumer must remember the filter; one miss re-creates the ×300 explosion silently. The partial unique indexes (sql/143) also key on `(provider, type, value, instrument_id)` regardless of primacy, so 46→346 multi-bound CIKs immediately, deep in tripwire territory. Fragile.
+
+### (c) By-design: series/class is the ETF identity path — RECOMMENDED
+
+Trust CIK is **deliberately not stamped** on instruments. ETF fund-side data flows via `class_id`/`mf_directory` (which already carries `trust_cik` for any future consumer to JOIN through). The instrument-level CIK gap for ETFs is by-design, not a coverage failure.
+
+Implementation (one small PR):
+1. `docs/settled-decisions.md` entry: "ETF identity = series/class; trust CIK lives in `cik_refresh_mf_directory`, never on `external_identifiers`."
+2. `cik_coverage_audit`: new bucket `fund_series_covered` — unmapped instrument with a **primary** `(sec, class_id)` row whose class_id still exists in `cik_refresh_mf_directory` (the directory join guards against stale/demoted class_ids hiding a real CIK gap). The 440 ETFs stop polluting the actionable `other` bucket and the audit stays honest.
+3. Revisit-tripwire in the settled-decision, narrowly drawn: file option (a) when a trust-CIK-keyed consumer **cannot resolve to series/class before instrument writes** (the N-CSR pattern stops fitting), or when a durable entity-level trust page/join is needed. Trust-level content per se is NOT the tripwire — N-CSR already renders trust-filed data per-ETF through class resolution. No half-step through (b).
+
+### Out of scope (follow-ups filed separately)
+
+- Manifest subject re-resolution sweep for late-arriving CIK bindings (Berkshire case, PR #1579 evidence).
+- The handful of operating companies absent from all three SEC ticker files (AL, DHIL, FBMS, VRNA, CVAC) — manual-override endpoint, re-homed from #813.
+
+## Decision rationale
+
+Trust CIK is already captured as fund-directory/filer identity; instrument identity for funds is class_id/series_id. Stamping trust CIK into issuer-style `external_identifiers (sec, cik)` rows would violate the current fan-out and subject-resolution invariants — that, not cost alone, is the core argument. (c) keeps the #1102 mechanism honest at its designed scale (~10 share-class siblings), keeps the entities-layer powder dry behind a narrow tripwire, and nothing is thrown away by deferring: the data a future consumer would want is already captured (`trust_cik` per class, sql/149).

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -654,6 +654,43 @@ so `assert_archive_belongs_to_run` still gates Phase C on current
 
 ---
 
+## ETF identity = series/class; trust CIK never stamped (#1577, settled 2026-06-11)
+
+ETF/mutual-fund instruments do NOT get a `(sec, cik)` row in
+`external_identifiers` — their SEC tickers live in
+`company_tickers_mf.json` keyed to the **trust** CIK (iShares Trust
+`0001100663` alone covers ~300 of our ETFs), and stamping that
+through the #1102 shared-CIK mechanism would explode parse-time
+sibling fan-out ×300 and mis-route subject resolution (single-winner
+`default_subject_resolver`). The #1102 indexes were sized for ~10
+share-class siblings.
+
+Instead, ETF identity flows through the **series/class mechanism**:
+`(sec, class_id)` rows in `external_identifiers` +
+`cik_refresh_mf_directory` (sql/149), which stores `trust_cik` per
+class row for any consumer that needs it. N-CSR proves the pattern:
+it walks trust CIKs from the directory and resolves
+class_id → instrument before any instrument write. N-PORT keys
+holdings by `fund_series_id`. The instrument-level CIK gap for ETFs
+is **by-design** — `cik_coverage_audit` buckets them
+`fund_series_covered` (primary class_id + directory join, both
+load-bearing) so they don't pollute the actionable gap list.
+
+Caveat: `cik_refresh_mf_directory` has observed-ever semantics —
+future trust-CIK consumers must apply a freshness predicate
+(`last_seen`).
+
+**Tripwire for the entities layer (#1102 Option B):** file it when a
+trust-CIK-keyed consumer cannot resolve to series/class before
+instrument writes (the N-CSR pattern stops fitting), or when a
+durable entity-level trust page/join is needed. Trust-level content
+per se is NOT the tripwire. No half-step through non-primary
+trust-CIK rows.
+
+**Spec:** `docs/proposals/etl/2026-06-11-etf-trust-cik-design.md`.
+
+---
+
 ## Maintenance rule
 
 When a new repo-level decision is agreed and is likely to affect future implementation:

--- a/tests/test_cik_coverage_audit.py
+++ b/tests/test_cik_coverage_audit.py
@@ -276,3 +276,43 @@ def test_stale_class_id_without_directory_row_stays_other(
     assert report.unmapped_fund_series_covered == 0
     by_symbol = {r.symbol: r.category for r in report.sample}
     assert by_symbol["DEADETF"] == "other"
+
+
+def test_dropped_directory_class_falls_out_of_covered_bucket(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """cik_refresh_mf_directory is observed-ever; a class whose
+    last_seen stopped advancing (SEC dropped it) must NOT keep the
+    instrument in the by-design bucket."""
+    conn = ebull_test_conn
+    _seed_universe(conn)
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671032, 'GONEETF', 'Dropped ETF', 'audit_us', 'USD', TRUE)
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers
+          (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (90671032, 'sec', 'class_id', 'C000088888', TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO cik_refresh_mf_directory (class_id, series_id, symbol, trust_cik, last_seen)
+        VALUES ('C000088888', 'S000008888', 'GONEETF', '0001100663', NOW() - INTERVAL '60 days')
+        ON CONFLICT (class_id) DO NOTHING
+        """,
+    )
+    conn.commit()
+
+    report = compute_cik_gap_report(conn, sample_limit=10)
+
+    assert report.unmapped_fund_series_covered == 0
+    by_symbol = {r.symbol: r.category for r in report.sample}
+    assert by_symbol["GONEETF"] == "other"

--- a/tests/test_cik_coverage_audit.py
+++ b/tests/test_cik_coverage_audit.py
@@ -199,3 +199,80 @@ def test_share_class_dot_buckets_as_other(
     by_symbol = {r.symbol: r.category for r in report.sample}
     assert by_symbol["CWEN.A"] == "other"
     assert by_symbol["AAPL.RTH"] == "suffix_variant"
+
+
+def test_fund_series_covered_buckets_separately(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """#1577 — an unmapped ETF with a primary (sec, class_id) row known
+    to cik_refresh_mf_directory is covered by-design: it buckets as
+    ``fund_series_covered``, not ``other``, and samples last."""
+    conn = ebull_test_conn
+    _seed_universe(conn)
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671030, 'IVV', 'iShares Core S&P 500 ETF', 'audit_us', 'USD', TRUE)
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers
+          (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (90671030, 'sec', 'class_id', 'C000012345', TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO cik_refresh_mf_directory (class_id, series_id, symbol, trust_cik)
+        VALUES ('C000012345', 'S000004310', 'IVV', '0001100663')
+        ON CONFLICT (class_id) DO NOTHING
+        """,
+    )
+    conn.commit()
+
+    report = compute_cik_gap_report(conn, sample_limit=10)
+
+    assert report.unmapped_fund_series_covered == 1  # IVV
+    assert report.unmapped_suffix_variants == 1  # AAPL.RTH
+    assert report.unmapped_other == 1  # AAXJ (no class binding)
+    assert report.unmapped == 3
+    by_symbol = {r.symbol: r.category for r in report.sample}
+    assert by_symbol["IVV"] == "fund_series_covered"
+    assert by_symbol["AAXJ"] == "other"
+    assert report.sample[-1].symbol == "IVV"  # by-design rows sample last
+
+
+def test_stale_class_id_without_directory_row_stays_other(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """The directory join is load-bearing: a class_id SEC no longer
+    lists must NOT hide a real CIK gap in the by-design bucket."""
+    conn = ebull_test_conn
+    _seed_universe(conn)
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (90671031, 'DEADETF', 'Delisted ETF', 'audit_us', 'USD', TRUE)
+        """,
+    )
+    conn.execute(
+        """
+        INSERT INTO external_identifiers
+          (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (90671031, 'sec', 'class_id', 'C000099999', TRUE)
+        ON CONFLICT (provider, identifier_type, identifier_value)
+            WHERE NOT (provider = 'sec' AND identifier_type = 'cik')
+        DO NOTHING
+        """,
+    )
+    conn.commit()
+
+    report = compute_cik_gap_report(conn, sample_limit=10)
+
+    assert report.unmapped_fund_series_covered == 0
+    by_symbol = {r.symbol: r.category for r in report.sample}
+    assert by_symbol["DEADETF"] == "other"


### PR DESCRIPTION
## What

Lands the #1577 design decision (operator-approved option c) + its one code consequence:

1. **Settled decision** (`docs/settled-decisions.md`): ETF/fund instruments deliberately never get a `(sec, cik)` row. Identity flows through `(sec, class_id)` + `cik_refresh_mf_directory` (sql/149, stores `trust_cik` per class). Narrow entities-layer tripwire: a trust-CIK-keyed consumer that cannot resolve to series/class before instrument writes. Spec with full options analysis at `docs/proposals/etl/2026-06-11-etf-trust-cik-design.md` (Codex ckpt-1: option c sound; all 7 corrections applied).
2. **`cik_coverage_audit` third bucket** `fund_series_covered`: unmapped instrument with a primary `(sec, class_id)` row whose class_id the directory has seen within 30 days. All three predicates load-bearing — demoted class_id, unknown class_id, or SEC-dropped class (observed-ever directory, Codex ckpt-2 catch) must not hide a real CIK gap. Freshness passed as a query param to keep the composed SQL a `LiteralString` (pyright; repo convention).
3. **`/coverage/cik-gap`**: additive `unmapped_fund_series_covered` counter + `fund_series_covered` sample category (samples last; `other` still first). No FE consumer of the counters today.

## Why

457-ish US ETFs showed as CIK gaps. Stamping trust CIKs would explode #1102's sibling fan-out ×300 per trust (iShares Trust alone ≈ 300 of our ETFs), mis-route single-winner subject resolution, and blow the 50-sibling entities-layer tripwire (dev already at 46 multi-bound CIKs). N-CSR proves trust-CIK-keyed ingest already works through directory walk + class resolution — nothing needs the stamp.

## Security model

No new input surface or authz change. The bucket predicate is static SQL over our own tables; the only new parameters are an int day-count module constant and the existing sample_limit, both server-side. `/coverage/cik-gap` remains behind the existing operator auth (`app/api/coverage.py` router deps, unchanged, outside this diff).

## Conscious tradeoffs

- 30-day freshness window is a constant, not config — single-symbol edit if cadence changes.
- Multi-letter share-class suffixes (`AXIA.PC`) remain in `suffix_variants` (pre-existing heuristic from PR #1579, documented).
- No FE rendering of the new bucket — counters are API-visible; FE chip can ride a reporting-track ticket if wanted.

## Verification (dev DB, 2026-06-11, at HEAD)

- `compute_cik_gap_report` from tree: cohort 7,190 / mapped 5,321 / unmapped 1,869 = **fund_series_covered 440 + suffix 652 + other 777** (exact partition; 440 matches the predicted ETF population). Top `other` samples now genuinely actionable (AABA, AAN, AAWW, ABMD — delisted/acquired operating companies).
- `tests/test_cik_coverage_audit.py` 8 passed (covered bucket, stale class_id → other, dropped-directory-row → other, sample ordering).
- ruff + format + pyright 0 errors; fast tier 3828 passed; smoke 129 passed.
- Codex ckpt-1 (spec) + ckpt-2 (diff) both run; all findings fixed (freshness predicate = ckpt-2's one finding).

Closes #1577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)