### PR TITLE
feat(#794): live symbol-change ingester — reconcile_symbol_history at the universe-sync chokepoint

### DIFF
--- a/.claude/skills/engineering/python-hygiene.md
+++ b/.claude/skills/engineering/python-hygiene.md
@@ -200,3 +200,16 @@ if self._held:
 Origin: PR #1543 (#1542) review WARNING on `app/jobs/locks.py::JobLock.__exit__` sec_rate release block.
 
 Applies to any cleanup path with an ownership/held flag: `__exit__`, `close()`, manual teardown helpers. The principle is the same as never resetting `committed = True` before `conn.commit()` returns.
+
+## psycopg Connection typing — never `type: ignore[arg-type]` the conn
+
+A `Connection[tuple]` vs `Connection[Any]`/unparameterised mismatch at a
+call site is a real signal: the callee's fetches assume a row shape the
+caller's row factory may not deliver (`int(r[0])` KeyErrors under
+dict_row). Silencing it with `# type: ignore[arg-type]` converts a
+compile-time error into a latent runtime one (PR #1583 review WARNING).
+
+Rule: widen the callee to `Connection[Any]`, and if it reads row values
+(not just `rowcount`), open its own cursor with an explicit
+`row_factory=psycopg.rows.tuple_row` / `dict_row` so the row shape is
+locally guaranteed.

--- a/app/services/instrument_history.py
+++ b/app/services/instrument_history.py
@@ -194,6 +194,10 @@ def backfill_current_history(conn: psycopg.Connection[tuple]) -> tuple[int, int]
 
 
 def _backfill_cik_history(conn: psycopg.Connection[tuple]) -> int:
+    # NOT EXISTS on the instrument for the same reason as the symbol
+    # twin below: once a chain has a closed row, an ON CONFLICT-guarded
+    # re-insert lands on a different PK and trips the EXCLUDE
+    # no-overlap constraint instead of no-op'ing.
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -208,13 +212,22 @@ def _backfill_cik_history(conn: psycopg.Connection[tuple]) -> int:
             FROM instruments i
             JOIN instrument_sec_profile p ON p.instrument_id = i.instrument_id
             WHERE p.cik IS NOT NULL
-            ON CONFLICT DO NOTHING
+              AND NOT EXISTS (
+                  SELECT 1 FROM instrument_cik_history h
+                  WHERE h.instrument_id = i.instrument_id
+              )
             """,
         )
         return cur.rowcount if cur.rowcount is not None and cur.rowcount >= 0 else 0
 
 
 def _backfill_symbol_history(conn: psycopg.Connection[tuple]) -> int:
+    # NOT EXISTS on the instrument (not ON CONFLICT on the PK): after a
+    # rename the open row is (NEWSYM, today) — an ON CONFLICT-guarded
+    # re-insert of (NEWSYM, first_seen) has a DIFFERENT PK, so it would
+    # reach the EXCLUDE no-overlap constraint and blow up the re-run.
+    # Seeding only instruments with no history at all is the idempotent
+    # form once rename chains exist (#794 Batch 7).
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -228,7 +241,112 @@ def _backfill_symbol_history(conn: psycopg.Connection[tuple]) -> int:
                    'imported'
             FROM instruments i
             WHERE i.symbol IS NOT NULL
-            ON CONFLICT DO NOTHING
+              AND NOT EXISTS (
+                  SELECT 1 FROM instrument_symbol_history h
+                  WHERE h.instrument_id = i.instrument_id
+              )
             """,
         )
         return cur.rowcount if cur.rowcount is not None and cur.rowcount >= 0 else 0
+
+
+@dataclass(frozen=True)
+class SymbolReconcileStats:
+    """Outcome of one :func:`reconcile_symbol_history` pass."""
+
+    seeded: int
+    renamed: int
+    corrected_same_day: int
+
+
+def reconcile_symbol_history(conn: psycopg.Connection[tuple]) -> SymbolReconcileStats:
+    """Bring ``instrument_symbol_history`` in line with ``instruments.symbol``
+    (#794 Batch 7 — the live symbol-change ingester).
+
+    eToro's instrument_id is stable across ticker changes, so a rename
+    (FB → META) or delist-rename (BBBY → BBBYQ / ``X.delisted``) arrives
+    at ``sync_universe`` as a plain ``symbol`` UPDATE on the existing
+    row. This reconcile runs inside the same sync transaction and is a
+    pure function of current table state, so it also self-heals any
+    drift introduced outside the sync path (manual fixes, older data).
+
+    Three passes, ordered:
+
+    1. **Seed** — instruments with no history rows get one ``imported``
+       current row (delegates to the backfill insert).
+    2. **Same-day correction** — an open row opened TODAY whose symbol
+       already differs is updated in place. Closing it would need
+       ``effective_to = effective_from``, which the ordered-ranges
+       CHECK rejects (zero-duration range); a same-day flip is treated
+       as a correction of today's observation, not a new chain link.
+    3. **Rename** — open rows opened before today whose symbol differs
+       are closed at ``CURRENT_DATE`` and a new current row opens at
+       ``CURRENT_DATE``. ``source_event`` is ``delisting`` when the new
+       symbol carries eToro's dead-ticker suffix (``.delisted`` /
+       ``.old``), else ``rebrand``. Close and open are two statements,
+       NOT one data-modifying CTE — sibling CTE effects are not
+       reliably visible to each other's constraint checks, so the
+       EXCLUDE no-overlap probe could non-deterministically see the
+       still-open row.
+
+    Caller owns the transaction (``sync_universe`` wraps the whole
+    sync; tests commit explicitly).
+    """
+    seeded = _backfill_symbol_history(conn)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE instrument_symbol_history h
+            SET symbol = i.symbol
+            FROM instruments i
+            WHERE i.instrument_id = h.instrument_id
+              AND h.effective_to IS NULL
+              AND h.effective_from = CURRENT_DATE
+              AND h.symbol IS DISTINCT FROM i.symbol
+            """,
+        )
+        corrected = cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+
+        cur.execute(
+            """
+            SELECT h.instrument_id
+            FROM instrument_symbol_history h
+            JOIN instruments i ON i.instrument_id = h.instrument_id
+            WHERE h.effective_to IS NULL
+              AND h.effective_from < CURRENT_DATE
+              AND h.symbol IS DISTINCT FROM i.symbol
+            """,
+        )
+        changed_ids = [int(r[0]) for r in cur.fetchall()]
+        if not changed_ids:
+            return SymbolReconcileStats(seeded=seeded, renamed=0, corrected_same_day=corrected)
+
+        cur.execute(
+            """
+            UPDATE instrument_symbol_history
+            SET effective_to = CURRENT_DATE
+            WHERE instrument_id = ANY(%s)
+              AND effective_to IS NULL
+            """,
+            (changed_ids,),
+        )
+        cur.execute(
+            r"""
+            INSERT INTO instrument_symbol_history (
+                instrument_id, symbol, effective_from, effective_to, source_event
+            )
+            SELECT i.instrument_id,
+                   i.symbol,
+                   CURRENT_DATE,
+                   NULL,
+                   CASE WHEN i.symbol ~* '\.(delisted|old)$'
+                        THEN 'delisting' ELSE 'rebrand' END
+            FROM instruments i
+            WHERE i.instrument_id = ANY(%s)
+            """,
+            (changed_ids,),
+        )
+        renamed = cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+
+    return SymbolReconcileStats(seeded=seeded, renamed=renamed, corrected_same_day=corrected)

--- a/app/services/instrument_history.py
+++ b/app/services/instrument_history.py
@@ -257,6 +257,7 @@ class SymbolReconcileStats:
     seeded: int
     renamed: int
     corrected_same_day: int
+    reverted_same_day: int = 0
 
 
 def reconcile_symbol_history(conn: psycopg.Connection[tuple]) -> SymbolReconcileStats:
@@ -270,24 +271,36 @@ def reconcile_symbol_history(conn: psycopg.Connection[tuple]) -> SymbolReconcile
     pure function of current table state, so it also self-heals any
     drift introduced outside the sync path (manual fixes, older data).
 
-    Three passes, ordered:
+    Four passes, ordered:
 
     1. **Seed** — instruments with no history rows get one ``imported``
        current row (delegates to the backfill insert).
-    2. **Same-day correction** — an open row opened TODAY whose symbol
-       already differs is updated in place. Closing it would need
+    2. **Same-day revert** — the open row was opened TODAY by an
+       earlier rename and the feed has flipped BACK to the symbol of
+       the row closed today (provider flip-flop / stale response,
+       Codex ckpt-2 HIGH). Updating in place would leave a corrupt
+       "X renamed to X" chain and erase the transient; instead the
+       same-day link is deleted and the closed-today row reopens —
+       fully undoing the flip-flop. Delete and reopen are two
+       statements (same sibling-CTE caveat as pass 4: the partial
+       UNIQUE one-current probe must not race the delete).
+    3. **Same-day correction** — any remaining open row opened TODAY
+       whose symbol differs is updated in place. Closing it would need
        ``effective_to = effective_from``, which the ordered-ranges
        CHECK rejects (zero-duration range); a same-day flip is treated
        as a correction of today's observation, not a new chain link.
-    3. **Rename** — open rows opened before today whose symbol differs
+    4. **Rename** — open rows opened before today whose symbol differs
        are closed at ``CURRENT_DATE`` and a new current row opens at
-       ``CURRENT_DATE``. ``source_event`` is ``delisting`` when the new
-       symbol carries eToro's dead-ticker suffix (``.delisted`` /
-       ``.old``), else ``rebrand``. Close and open are two statements,
-       NOT one data-modifying CTE — sibling CTE effects are not
-       reliably visible to each other's constraint checks, so the
-       EXCLUDE no-overlap probe could non-deterministically see the
-       still-open row.
+       ``CURRENT_DATE``, only for rows the close actually claimed
+       (``RETURNING`` — a concurrent reconcile's loser must not insert
+       from a stale candidate list, Codex ckpt-2 MEDIUM).
+       ``source_event`` is ``delisting`` when the new symbol carries
+       eToro's dead-ticker suffix (``.delisted`` / ``.old``), else
+       ``rebrand``. Close and open are two statements, NOT one
+       data-modifying CTE — sibling CTE effects are not reliably
+       visible to each other's constraint checks, so the EXCLUDE
+       no-overlap probe could non-deterministically see the still-open
+       row.
 
     Caller owns the transaction (``sync_universe`` wraps the whole
     sync; tests commit explicitly).
@@ -295,6 +308,34 @@ def reconcile_symbol_history(conn: psycopg.Connection[tuple]) -> SymbolReconcile
     seeded = _backfill_symbol_history(conn)
 
     with conn.cursor() as cur:
+        # Pass 2 — same-day revert (flip-flop undo).
+        cur.execute(
+            """
+            DELETE FROM instrument_symbol_history h
+            USING instruments i, instrument_symbol_history closed
+            WHERE i.instrument_id = h.instrument_id
+              AND h.effective_to IS NULL
+              AND h.effective_from = CURRENT_DATE
+              AND h.symbol IS DISTINCT FROM i.symbol
+              AND closed.instrument_id = h.instrument_id
+              AND closed.effective_to = CURRENT_DATE
+              AND closed.symbol = i.symbol
+            RETURNING h.instrument_id
+            """,
+        )
+        reverted_ids = [int(r[0]) for r in cur.fetchall()]
+        if reverted_ids:
+            cur.execute(
+                """
+                UPDATE instrument_symbol_history
+                SET effective_to = NULL
+                WHERE instrument_id = ANY(%s)
+                  AND effective_to = CURRENT_DATE
+                """,
+                (reverted_ids,),
+            )
+
+        # Pass 3 — same-day in-place correction.
         cur.execute(
             """
             UPDATE instrument_symbol_history h
@@ -308,29 +349,28 @@ def reconcile_symbol_history(conn: psycopg.Connection[tuple]) -> SymbolReconcile
         )
         corrected = cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
 
+        # Pass 4 — rename: close, then open only what the close claimed.
         cur.execute(
             """
-            SELECT h.instrument_id
-            FROM instrument_symbol_history h
-            JOIN instruments i ON i.instrument_id = h.instrument_id
-            WHERE h.effective_to IS NULL
+            UPDATE instrument_symbol_history h
+            SET effective_to = CURRENT_DATE
+            FROM instruments i
+            WHERE i.instrument_id = h.instrument_id
+              AND h.effective_to IS NULL
               AND h.effective_from < CURRENT_DATE
               AND h.symbol IS DISTINCT FROM i.symbol
+            RETURNING h.instrument_id
             """,
         )
-        changed_ids = [int(r[0]) for r in cur.fetchall()]
-        if not changed_ids:
-            return SymbolReconcileStats(seeded=seeded, renamed=0, corrected_same_day=corrected)
+        closed_ids = [int(r[0]) for r in cur.fetchall()]
+        if not closed_ids:
+            return SymbolReconcileStats(
+                seeded=seeded,
+                renamed=0,
+                corrected_same_day=corrected,
+                reverted_same_day=len(reverted_ids),
+            )
 
-        cur.execute(
-            """
-            UPDATE instrument_symbol_history
-            SET effective_to = CURRENT_DATE
-            WHERE instrument_id = ANY(%s)
-              AND effective_to IS NULL
-            """,
-            (changed_ids,),
-        )
         cur.execute(
             r"""
             INSERT INTO instrument_symbol_history (
@@ -345,8 +385,13 @@ def reconcile_symbol_history(conn: psycopg.Connection[tuple]) -> SymbolReconcile
             FROM instruments i
             WHERE i.instrument_id = ANY(%s)
             """,
-            (changed_ids,),
+            (closed_ids,),
         )
         renamed = cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
 
-    return SymbolReconcileStats(seeded=seeded, renamed=renamed, corrected_same_day=corrected)
+    return SymbolReconcileStats(
+        seeded=seeded,
+        renamed=renamed,
+        corrected_same_day=corrected,
+        reverted_same_day=len(reverted_ids),
+    )

--- a/app/services/instrument_history.py
+++ b/app/services/instrument_history.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
+from typing import Any
 
 import psycopg
 import psycopg.rows
@@ -260,7 +261,7 @@ class SymbolReconcileStats:
     reverted_same_day: int = 0
 
 
-def reconcile_symbol_history(conn: psycopg.Connection[tuple]) -> SymbolReconcileStats:
+def reconcile_symbol_history(conn: psycopg.Connection[Any]) -> SymbolReconcileStats:
     """Bring ``instrument_symbol_history`` in line with ``instruments.symbol``
     (#794 Batch 7 — the live symbol-change ingester).
 
@@ -307,7 +308,10 @@ def reconcile_symbol_history(conn: psycopg.Connection[tuple]) -> SymbolReconcile
     """
     seeded = _backfill_symbol_history(conn)
 
-    with conn.cursor() as cur:
+    # Explicit tuple_row: the caller's connection may carry any row
+    # factory (sync_universe's is unparameterised); the ``int(r[0])``
+    # fetches below must not depend on it (review WARNING, PR #1583).
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
         # Pass 2 — same-day revert (flip-flop undo).
         cur.execute(
             """

--- a/app/services/universe.py
+++ b/app/services/universe.py
@@ -199,7 +199,7 @@ def sync_universe(
         # BBBY → X.delisted) lands above as a plain symbol UPDATE; this
         # reconcile closes the prior instrument_symbol_history chain
         # link and opens the new one inside the same transaction.
-        history = reconcile_symbol_history(conn)  # type: ignore[arg-type]
+        history = reconcile_symbol_history(conn)
         if history.seeded or history.renamed or history.corrected_same_day or history.reverted_same_day:
             logger.info(
                 "Universe sync: symbol history seeded=%d renamed=%d corrected_same_day=%d reverted_same_day=%d",

--- a/app/services/universe.py
+++ b/app/services/universe.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 import psycopg
 
 from app.providers.market_data import InstrumentRecord, MarketDataProvider
+from app.services.instrument_history import reconcile_symbol_history
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +193,20 @@ def sync_universe(
             {"provider_ids": list(provider_ids)},
         )
         deactivated = rows.rowcount
+
+        # #794 Batch 7 — symbol-change ingest. eToro's instrument_id is
+        # stable across renames, so a ticker change (FB → META,
+        # BBBY → X.delisted) lands above as a plain symbol UPDATE; this
+        # reconcile closes the prior instrument_symbol_history chain
+        # link and opens the new one inside the same transaction.
+        history = reconcile_symbol_history(conn)  # type: ignore[arg-type]
+        if history.seeded or history.renamed or history.corrected_same_day:
+            logger.info(
+                "Universe sync: symbol history seeded=%d renamed=%d corrected_same_day=%d",
+                history.seeded,
+                history.renamed,
+                history.corrected_same_day,
+            )
 
     # Re-query to get accurate inserted/updated counts.
     # ON CONFLICT DO UPDATE doesn't distinguish insert vs update via rowcount;

--- a/app/services/universe.py
+++ b/app/services/universe.py
@@ -200,12 +200,13 @@ def sync_universe(
         # reconcile closes the prior instrument_symbol_history chain
         # link and opens the new one inside the same transaction.
         history = reconcile_symbol_history(conn)  # type: ignore[arg-type]
-        if history.seeded or history.renamed or history.corrected_same_day:
+        if history.seeded or history.renamed or history.corrected_same_day or history.reverted_same_day:
             logger.info(
-                "Universe sync: symbol history seeded=%d renamed=%d corrected_same_day=%d",
+                "Universe sync: symbol history seeded=%d renamed=%d corrected_same_day=%d reverted_same_day=%d",
                 history.seeded,
                 history.renamed,
                 history.corrected_same_day,
+                history.reverted_same_day,
             )
 
     # Re-query to get accurate inserted/updated counts.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1737,3 +1737,11 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: vitest 4 returns the SAME spy when `vi.spyOn` re-targets an already-spied method, so call history accumulates across tests in a file. Under vitest 2 the suite was green only because spy semantics masked the missing isolation — the tests were latently order-dependent. Repo-wide config keeps `clearMocks`/`restoreMocks` OFF, so isolation is each file's job.
 - Prevention: any test file asserting on spy call history (`mock.calls[...]`, `not.toHaveBeenCalled()`, `toHaveBeenCalledTimes(n)`) for a `vi.spyOn` target must register a module-scope `afterEach(() => { vi.restoreAllMocks(); })`. Grep on adding such assertions: `grep -L "restoreAllMocks" $(grep -rl "mock.calls\|toHaveBeenCalledTimes\|not.toHaveBeenCalled" frontend/src --include="*.test.tsx")`.
 - Enforced in: this prevention log; `.claude/skills/engineering/test-quality.md` (Mock discipline § frontend `vi.spyOn`); `frontend/src/components/instrument/FilingsPane.test.tsx`, `frontend/src/pages/EightKListPage.test.tsx`.
+
+---
+
+### `type: ignore[arg-type]` masking a psycopg Connection row-factory mismatch
+- First seen in: PR #1583
+- Symptom: `reconcile_symbol_history(conn)  # type: ignore[arg-type]` silenced a `Connection[tuple]` vs unparameterised-connection mismatch. With a dict_row caller, the function's `int(r[0])` fetches would KeyError at runtime — the ignore traded a compile-time error for a latent runtime one.
+- Prevention: never `type: ignore[arg-type]` a psycopg Connection argument. Either the function genuinely depends on the row shape — then open its own cursor with an explicit `row_factory=psycopg.rows.tuple_row` (or `dict_row`) and widen the signature to `Connection[Any]` — or it only uses `rowcount`/`execute`, in which case `Connection[Any]` alone is honest.
+- Enforced in: `.claude/skills/engineering/python-hygiene.md` (psycopg typing section)

--- a/tests/test_instrument_history.py
+++ b/tests/test_instrument_history.py
@@ -225,3 +225,170 @@ class TestBackfill:
 
         assert instrument_history.instrument_id_for_historical_cik(conn, "0000099003") == 794_022
         assert instrument_history.instrument_id_for_historical_cik(conn, "0000099999") is None
+
+
+class TestReconcileSymbolHistory:
+    """#794 Batch 7 — the live symbol-change ingester."""
+
+    def _seed_with_history(
+        self,
+        conn: psycopg.Connection[tuple],
+        *,
+        iid: int,
+        symbol: str,
+        opened_days_ago: int,
+    ) -> None:
+        """Instrument + an open history row opened ``opened_days_ago``."""
+        _seed_instrument(conn, iid=iid, symbol=symbol)
+        conn.execute(
+            """
+            INSERT INTO instrument_symbol_history (
+                instrument_id, symbol, effective_from, effective_to, source_event
+            ) VALUES (%s, %s, CURRENT_DATE - %s, NULL, 'imported')
+            """,
+            (iid, symbol, opened_days_ago),
+        )
+
+    def _chain(self, conn: psycopg.Connection[tuple], iid: int) -> list[tuple]:
+        return conn.execute(
+            """
+            SELECT symbol, effective_from, effective_to, source_event
+            FROM instrument_symbol_history
+            WHERE instrument_id = %s
+            ORDER BY effective_from
+            """,
+            (iid,),
+        ).fetchall()
+
+    def test_rename_closes_prior_and_opens_new(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        self._seed_with_history(conn, iid=794001, symbol="FB", opened_days_ago=30)
+        conn.execute("UPDATE instruments SET symbol = 'META' WHERE instrument_id = 794001")
+
+        stats = instrument_history.reconcile_symbol_history(conn)
+        conn.commit()
+
+        assert stats.renamed == 1
+        chain = self._chain(conn, 794001)
+        assert len(chain) == 2
+        assert chain[0][0] == "FB"
+        assert chain[0][2] == date.today()  # closed at rename date
+        assert chain[1][0] == "META"
+        assert chain[1][2] is None  # current
+        assert chain[1][3] == "rebrand"
+
+    def test_delisted_suffix_classified_as_delisting(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        self._seed_with_history(conn, iid=794002, symbol="BBBY", opened_days_ago=30)
+        conn.execute("UPDATE instruments SET symbol = 'BBBY.delisted' WHERE instrument_id = 794002")
+
+        stats = instrument_history.reconcile_symbol_history(conn)
+        conn.commit()
+
+        assert stats.renamed == 1
+        chain = self._chain(conn, 794002)
+        assert chain[-1][0] == "BBBY.delisted"
+        assert chain[-1][3] == "delisting"
+
+    def test_same_day_flip_updates_in_place(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A flip on the open row's own effective_from day cannot close
+        it (zero-duration range fails the ordered-ranges CHECK) — it is
+        corrected in place instead."""
+        conn = ebull_test_conn
+        self._seed_with_history(conn, iid=794003, symbol="TYPO", opened_days_ago=0)
+        conn.execute("UPDATE instruments SET symbol = 'FIXED' WHERE instrument_id = 794003")
+
+        stats = instrument_history.reconcile_symbol_history(conn)
+        conn.commit()
+
+        assert stats.corrected_same_day == 1
+        assert stats.renamed == 0
+        chain = self._chain(conn, 794003)
+        assert len(chain) == 1
+        assert chain[0][0] == "FIXED"
+        assert chain[0][2] is None
+
+    def test_reconcile_is_idempotent(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        self._seed_with_history(conn, iid=794004, symbol="FB", opened_days_ago=30)
+        conn.execute("UPDATE instruments SET symbol = 'META' WHERE instrument_id = 794004")
+
+        instrument_history.reconcile_symbol_history(conn)
+        second = instrument_history.reconcile_symbol_history(conn)
+        conn.commit()
+
+        assert second.renamed == 0
+        assert second.corrected_same_day == 0
+        assert len(self._chain(conn, 794004)) == 2
+
+    def test_seed_pass_covers_history_less_instrument(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=794005, symbol="NEW")
+
+        stats = instrument_history.reconcile_symbol_history(conn)
+        conn.commit()
+
+        assert stats.seeded >= 1
+        chain = self._chain(conn, 794005)
+        assert len(chain) == 1
+        assert chain[0][0] == "NEW"
+        assert chain[0][3] == "imported"
+
+    def test_backfill_rerun_after_rename_does_not_violate_exclude(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Regression: the old ON CONFLICT DO NOTHING backfill re-insert
+        landed on a different PK after a rename and tripped the EXCLUDE
+        no-overlap constraint. NOT EXISTS skips chained instruments."""
+        conn = ebull_test_conn
+        self._seed_with_history(conn, iid=794006, symbol="FB", opened_days_ago=30)
+        conn.execute("UPDATE instruments SET symbol = 'META' WHERE instrument_id = 794006")
+        instrument_history.reconcile_symbol_history(conn)
+
+        cik_rows, sym_rows = instrument_history.backfill_current_history(conn)
+        conn.commit()
+
+        chain = self._chain(conn, 794006)
+        assert len(chain) == 2  # backfill added nothing to the chained instrument
+
+    def test_reused_symbol_chains_stay_separate(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """#794 AC4 — a symbol abandoned by one instrument and later
+        assigned to another must produce two unlinked chains."""
+        conn = ebull_test_conn
+        self._seed_with_history(conn, iid=794007, symbol="DEAD", opened_days_ago=30)
+        conn.execute("UPDATE instruments SET symbol = 'ALIVE' WHERE instrument_id = 794007")
+        instrument_history.reconcile_symbol_history(conn)
+        # New issuer picks up the abandoned ticker.
+        _seed_instrument(conn, iid=794008, symbol="DEAD")
+        instrument_history.reconcile_symbol_history(conn)
+        conn.commit()
+
+        a = self._chain(conn, 794007)
+        b = self._chain(conn, 794008)
+        assert [r[0] for r in a] == ["DEAD", "ALIVE"]
+        assert [r[0] for r in b] == ["DEAD"]
+        # The two DEAD rows are keyed to different instruments — no join.
+        owners = conn.execute(
+            "SELECT DISTINCT instrument_id FROM instrument_symbol_history "
+            "WHERE symbol = 'DEAD' AND instrument_id IN (794007, 794008)"
+        ).fetchall()
+        assert len(owners) == 2

--- a/tests/test_instrument_history.py
+++ b/tests/test_instrument_history.py
@@ -392,3 +392,29 @@ class TestReconcileSymbolHistory:
             "WHERE symbol = 'DEAD' AND instrument_id IN (794007, 794008)"
         ).fetchall()
         assert len(owners) == 2
+
+    def test_same_day_flip_flop_reverts_cleanly(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Codex ckpt-2 HIGH — rename FB→META then a later same-day sync
+        observing FB again must fully undo the flip-flop (delete the
+        same-day META link, reopen the FB row), NOT leave a corrupt
+        'FB renamed to FB' chain."""
+        conn = ebull_test_conn
+        self._seed_with_history(conn, iid=794009, symbol="FB", opened_days_ago=30)
+        conn.execute("UPDATE instruments SET symbol = 'META' WHERE instrument_id = 794009")
+        instrument_history.reconcile_symbol_history(conn)
+        # Provider flip-flops back the same day.
+        conn.execute("UPDATE instruments SET symbol = 'FB' WHERE instrument_id = 794009")
+
+        stats = instrument_history.reconcile_symbol_history(conn)
+        conn.commit()
+
+        assert stats.reverted_same_day == 1
+        assert stats.renamed == 0
+        assert stats.corrected_same_day == 0
+        chain = self._chain(conn, 794009)
+        assert len(chain) == 1  # META transient erased entirely
+        assert chain[0][0] == "FB"
+        assert chain[0][2] is None  # FB reopened as current


### PR DESCRIPTION
## What

The missing "Batch 7" half of #794. Schema (sql/102/103), service helpers, API surface, and `HistoricalSymbolCallout` shipped in the tier-0 batch; the live ingester that actually writes symbol-change chains never did. This PR:

1. **`reconcile_symbol_history`** (`app/services/instrument_history.py`) — set-based, four ordered passes: seed missing chains (imported) → same-day flip-flop revert (delete link + reopen closed-today row) → same-day in-place correction → rename close-at-`CURRENT_DATE` + open-new. `source_event='delisting'` for eToro dead-ticker suffixes (`.delisted`/`.old`), else `'rebrand'`. Wired into `sync_universe`'s transaction — eToro's instrument_id is stable across renames, so FB→META arrives as a plain symbol UPDATE at that chokepoint. Pure function of table state → self-heals drift from any source, idempotent.
2. **Latent backfill bug fixed** (both history tables): `ON CONFLICT DO NOTHING` re-insert lands on a *different* PK once a chain has a closed row (PK includes `effective_from`) and trips the EXCLUDE no-overlap constraint instead of no-op'ing. Now `NOT EXISTS` per instrument. Regression-pinned.

## Why the shape

- **Same-day flips update in place**: closing a row opened today needs `effective_to = effective_from`, rejected by the ordered-ranges CHECK (zero-duration).
- **Flip-flop revert** (Codex ckpt-2 HIGH): rename A→B then same-day stale-feed B→A would otherwise corrupt the chain into "A renamed to A" and erase B; the revert pass deletes the transient link and reopens the original row.
- **Close/open are separate statements**, and the rename insert derives from the close's `RETURNING` set (Codex ckpt-2 MEDIUM): data-modifying sibling CTEs aren't reliably visible to each other's constraint checks, and a concurrent reconcile's loser must not insert from a stale candidate list.
- **CIK-side reconcile deliberately out of scope**: `instrument_sec_profile.cik` changes are resolution fixes, not reorg events, and the `source_event` CHECK has no honest value for them; readers already join everything on `instrument_id` with CIK stable across renames.

## Security model

No new input surface. Symbols come from the already-trusted eToro provider feed via the existing `sync_universe` path (provider payloads validated at the provider boundary); all reconcile SQL is static with array parameters. No authz changes; nothing user-facing writes here. DB-level invariants (ordered-ranges CHECK, partial UNIQUE one-current, GIST EXCLUDE no-overlap — sql/102/103, outside this diff) remain the hard backstop: any reconcile bug fails loud, not silently.

## Conscious tradeoffs

- `rebrand` vs `delisting` classification is a suffix heuristic; `manual` exists for operator corrections.
- Same-day granularity: at most one chain link per instrument per day; intraday transients collapse (the revert pass makes this total).
- Dev backfill (`scripts/backfill_instrument_history.py` — exists but was never run; history tables are 0 rows on dev) + verification will be recorded on this PR before merge.

## Verification so far (at HEAD)

- `tests/test_instrument_history.py` 16 passed (8 new: rename close+open, delisting classification, same-day flip, flip-flop revert, idempotency, seed pass, backfill-rerun EXCLUDE regression, reused-symbol chain separation = #794 AC4).
- ruff + format + pyright 0 errors; fast tier 3828 passed; smoke 129 passed.
- Codex ckpt-2 run; HIGH + MEDIUM findings fixed (commits reference them).

Part of #794.

🤖 Generated with [Claude Code](https://claude.com/claude-code)