### PR TITLE
feat(#920): ownership sunburst static polish — residual hatching + tooltip + known-coverage center line

### DIFF
--- a/docs/specs/ui/2026-06-11-ownership-chart-static-polish.md
+++ b/docs/specs/ui/2026-06-11-ownership-chart-static-polish.md
@@ -1,0 +1,115 @@
+# Ownership chart static polish (#920)
+
+Status: live spec for #920 (first of 4 split tickets under closed parent #846).
+Scope: `frontend/src/components/instrument/OwnershipSunburst.tsx` only. No backend, no API, no new state.
+
+## What ships
+
+1. **Residual hatching.** The `Public / unattributed` residual wedges (middle-ring
+   `middle-residual` + outer-ring `outer-residual` gap datums) render with a subtle
+   diagonal hatch instead of fully transparent. Within-category gap wedges
+   (`{cat}-gap`, "unresolved filers") stay transparent and inert — out of scope per
+   the issue.
+2. **Residual hover tooltip un-suppressed.** Copy:
+   `Public / unattributed: X% of outstanding — N shares not attributed to any disclosed filer.`
+   ("not **attributed to**", not the issue's "not held by": the residual can include
+   positions of filers outside our seeded coverage cohort — the backend residual
+   tooltip says exactly this — so "not held by any disclosed filer" overclaims.
+   Attribution is a statement about *our* data, which is what the wedge shows.
+   Codex ckpt-1 High.)
+3. **Center label third line:** `X% known coverage` under the existing
+   `TOTAL SHARES <N>` block.
+4. **Legend row rename** `Unaccounted` → `Public / unattributed` + hatched swatch,
+   consistent with the wedge. (No references to "Unaccounted" exist outside the
+   component — verified by grep.)
+
+## Design decisions
+
+### D1 — `is_residual` flag on `ChartDatum`
+
+Gap wedges split into two kinds: residual (hatched, hover-tooltip, never clickable)
+vs within-category gap (transparent, fully inert). `makeGapDatum` gains an
+`is_residual` parameter. `target` stays `null` for both — no click semantics change.
+
+### D2 — hatch pattern via hidden sibling `<svg>` + `useId`
+
+Recharts filters unknown children of `<PieChart>`, so a `<defs>` child is not
+reliable. Instead a zero-size `aria-hidden` `<svg>` sibling inside the component
+root carries `<defs><pattern id={patternId}>`. Pattern pinned (Codex ckpt-1 Low):
+6×6 px tile, one diagonal line, stroke `#94a3b8` (slate-400 — same token the focus
+outline already uses; reads on white and slate-950), `strokeOpacity 0.45`,
+`strokeWidth 1.2`. Residual `Cell fill` = `url(#patternId)`. `useId()` keeps the
+pattern id unique if two charts mount on one page. Same-document `url(#…)`
+paint-server references resolve across SVG elements. Manual acceptance: dev-verify
+AAPL in light + dark mode (`dark:check` only audits class pairing, not SVG).
+
+### D3 — pointer-events: residual hoverable, not clickable
+
+Current CSS disables hit-testing on every `data-known='false'` sector, so
+un-suppressing the tooltip alone would be dead code (the spec'd hover could never
+fire). New attribute `data-residual` on each gap `Cell`:
+
+- `data-known='false'` + `data-residual='false'` → `pointer-events: none` (unchanged behaviour).
+- `data-known='false'` + `data-residual='true'` → hit-testing ON so the Recharts
+  tooltip fires; **no** `cursor: pointer`, **no** hover brightness — read-only data
+  must not look clickable (operator-ui-conventions).
+
+### D4 — tooltip copy says "of outstanding", not "of float"
+
+Issue text says "X% of float". The chart denominator is `shares_outstanding`
+(rings' effective `total_shares`), and float ≠ outstanding (float excludes
+insiders/restricted). Mislabeling the denominator on an auditability-first surface
+is worse than a verbatim match, so the copy reads `X% of outstanding`. Conscious
+deviation, recorded here + in the PR description.
+
+The percent/shares values come from the residual datum the rings produced
+(`category_residual / total_shares`) — same numbers the wedge is drawn from.
+
+### D5 — coverage line derives from rings, not the rollup payload
+
+`known coverage = (total_shares − category_residual) / total_shares`. Computed from
+the same `buildSunburstRings` output the wedges render from, so label and chart
+cannot diverge (the rollup's `concentration.pct_outstanding_known` uses the
+*reported* denominator and would drift under the oversubscription bump).
+
+**Oversubscribed edge (Codex ckpt-1 Medium):** when category totals oversubscribe
+the reported outstanding, `buildSunburstRings` bumps the denominator to `sum_known`
+→ `category_residual = 0` → the label honestly reads `100% known coverage` against
+the bumped denominator. That is geometrically consistent with the wedges; the
+oversubscription itself is surfaced by the existing panel-level
+`OversubscribedWarning` (`rollup.residual.oversubscribed`), not by this label.
+Covered by an explicit test.
+
+### D6 — chart-datum construction extracted as pure function
+
+`buildSunburstChartData(rings, theme)` (exported) produces `{middleData,
+outerData}` so tests assert the `is_residual` / `is_gap` flag placement directly —
+jsdom + `ResponsiveContainer` renders a zero-size chart, so sector-level DOM
+assertions are not viable (Codex ckpt-1 Low, satisfied at the data layer).
+`residualTooltipText(shares, pct)` exported likewise (pct = the fraction already on
+the chart datum); the tooltip renders it, the test asserts the exact copy
+(test-quality skill: prefer pure policy).
+
+### D7 — legend hatched swatch via CSS gradient
+
+The legend swatch is an HTML `<span>` — `backgroundColor` cannot reference an SVG
+paint server (Codex ckpt-1 Medium). Swatch uses inline
+`background: repeating-linear-gradient(45deg, transparent 0 3px, rgba(148,163,184,0.6) 3px 4px)`
+and keeps the existing dashed border.
+
+## Acceptance mapping (issue → repo reality)
+
+Issue asks for Playwright snapshots — **no Playwright harness exists in this repo**
+(verified: no playwright dep/config; FE tests = vitest + testing-library + jsdom).
+Translated acceptance:
+
+1. Vitest: center label renders `X% known coverage` (plain HTML outside
+   ResponsiveContainer — testable in jsdom), incl. the oversubscribed → `100%` case.
+2. Vitest: `residualTooltipText` produces the exact spec'd copy.
+3. Vitest: `buildSunburstChartData` marks `middle-residual` / `outer-residual` as
+   `is_residual=true` and `{cat}-gap` as `is_residual=false`.
+4. Vitest: hatch `<pattern>` def present in DOM; legend residual row labelled
+   `Public / unattributed` with hatched swatch.
+5. `pnpm --dir frontend typecheck` + `test:unit` + `dark:check` clean.
+6. Dev-verify: AAPL ownership panel, light + dark, hatch visible + tooltip fires on
+   residual hover.

--- a/frontend/src/components/instrument/OwnershipSunburst.test.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for the #920 static-polish layer of the ownership
+ * sunburst: residual hatching, residual tooltip copy, center
+ * known-coverage line, and the legend's residual row.
+ *
+ * Sector-level DOM (the actual pie arcs) is NOT asserted here —
+ * jsdom gives ResponsiveContainer a zero-size box so Recharts
+ * renders no sectors. The gap/residual flag placement is covered at
+ * the data layer via the exported pure ``buildSunburstChartData``;
+ * the copy via the exported pure ``residualTooltipText``. The parts
+ * of the component that live OUTSIDE ResponsiveContainer (center
+ * label, hatch ``<pattern>`` def, legend) render fine in jsdom and
+ * are asserted directly.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { lightTheme } from "@/lib/chartTheme";
+
+import type { SunburstInputs } from "./ownershipRings";
+import {
+  OwnershipLegend,
+  OwnershipSunburst,
+  RESIDUAL_LABEL,
+  buildSunburstChartData,
+  buildSunburstRings,
+  residualTooltipText,
+} from "./OwnershipSunburst";
+
+/** 1B outstanding; institutions report 600M with one 400M named
+ *  filer → 200M within-category gap; 400M residual. */
+function baseInputs(overrides: Partial<SunburstInputs> = {}): SunburstInputs {
+  return {
+    total_shares: 1_000_000_000,
+    holders: [
+      {
+        key: "0000102909",
+        label: "Vanguard Group",
+        shares: 400_000_000,
+        category: "institutions",
+      },
+    ],
+    institutions_total: 600_000_000,
+    etfs_total: null,
+    insiders_total: null,
+    blockholders_total: null,
+    treasury_shares: null,
+    ...overrides,
+  };
+}
+
+describe("residualTooltipText", () => {
+  it("renders the exact spec'd copy", () => {
+    expect(residualTooltipText(400_000_000, 0.4)).toBe(
+      "Public / unattributed: 40.00% of outstanding — 400,000,000 shares not attributed to any disclosed filer.",
+    );
+  });
+});
+
+describe("buildSunburstChartData", () => {
+  it("marks residual wedges is_residual and within-category gaps not", () => {
+    const rings = buildSunburstRings(baseInputs());
+    expect(rings).not.toBeNull();
+    const { middleData, outerData } = buildSunburstChartData(rings!, lightTheme);
+
+    const middleResidual = middleData.find((d) => d.id === "middle-residual");
+    expect(middleResidual).toMatchObject({
+      name: RESIDUAL_LABEL,
+      shares: 400_000_000,
+      is_gap: true,
+      is_residual: true,
+      target: null,
+    });
+
+    const outerResidual = outerData.find((d) => d.id === "outer-residual");
+    expect(outerResidual).toMatchObject({
+      name: RESIDUAL_LABEL,
+      is_gap: true,
+      is_residual: true,
+      target: null,
+    });
+
+    const categoryGap = outerData.find((d) => d.id === "institutions-gap");
+    expect(categoryGap).toMatchObject({
+      shares: 200_000_000,
+      is_gap: true,
+      is_residual: false,
+      target: null,
+    });
+
+    const known = middleData.find((d) => d.id === "cat-institutions");
+    expect(known).toMatchObject({ is_gap: false, is_residual: false });
+  });
+
+  it("emits no residual datums when categories cover the denominator", () => {
+    const rings = buildSunburstRings(
+      baseInputs({ institutions_total: 1_000_000_000 }),
+    );
+    const { middleData, outerData } = buildSunburstChartData(rings!, lightTheme);
+    expect(middleData.find((d) => d.id === "middle-residual")).toBeUndefined();
+    expect(outerData.find((d) => d.id === "outer-residual")).toBeUndefined();
+  });
+});
+
+describe("OwnershipSunburst center label", () => {
+  it("shows the known-coverage line under the share count", () => {
+    render(<OwnershipSunburst inputs={baseInputs()} />);
+    expect(screen.getByText("Total shares")).toBeInTheDocument();
+    expect(screen.getByText("1,000,000,000")).toBeInTheDocument();
+    // 600M known of 1B outstanding.
+    expect(screen.getByText("60.00% known coverage")).toBeInTheDocument();
+  });
+
+  it("reads 100% against the bumped denominator when oversubscribed", () => {
+    // Category totals (1.5B) oversubscribe reported outstanding (1B):
+    // buildSunburstRings bumps the denominator to sum_known, residual
+    // clamps to 0, and the label honestly reads 100% — the
+    // panel-level OversubscribedWarning carries the diagnostic
+    // (spec D5 / Codex ckpt-1 Medium).
+    render(
+      <OwnershipSunburst
+        inputs={baseInputs({ institutions_total: 1_500_000_000 })}
+      />,
+    );
+    expect(screen.getByText("1,500,000,000")).toBeInTheDocument();
+    expect(screen.getByText("100.00% known coverage")).toBeInTheDocument();
+  });
+
+  it("renders the hatch pattern def", () => {
+    const { container } = render(<OwnershipSunburst inputs={baseInputs()} />);
+    const pattern = container.querySelector("pattern");
+    expect(pattern).not.toBeNull();
+    expect(pattern!.id).toMatch(/^residual-hatch-/);
+  });
+});
+
+describe("OwnershipLegend residual row", () => {
+  it("labels the residual row and hatches its swatch", () => {
+    const rings = buildSunburstRings(baseInputs());
+    const { container } = render(<OwnershipLegend rings={rings!} />);
+    expect(screen.getByText(RESIDUAL_LABEL)).toBeInTheDocument();
+    const swatches = container.querySelectorAll("li span[aria-hidden]");
+    const hatched = Array.from(swatches).filter(
+      (s) =>
+        s instanceof HTMLElement &&
+        s.style.background.includes("repeating-linear-gradient"),
+    );
+    expect(hatched).toHaveLength(1);
+  });
+
+  it("omits the residual row at full coverage", () => {
+    const rings = buildSunburstRings(
+      baseInputs({ institutions_total: 1_000_000_000 }),
+    );
+    render(<OwnershipLegend rings={rings!} />);
+    expect(screen.queryByText(RESIDUAL_LABEL)).toBeNull();
+  });
+});

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -11,20 +11,26 @@
  *   ring 1 (inner)  — single solid band, decorative; denominator
  *                     label sits in the center hole.
  *   ring 2 (middle) — per-category wedges (Institutions / ETFs /
- *                     Insiders / Treasury) plus a transparent wedge
- *                     for the unaccounted residual.
+ *                     Insiders / Treasury) plus a hatched wedge for
+ *                     the ``Public / unattributed`` residual (#920).
  *   ring 3 (outer)  — per-filer / per-officer wedges within each
  *                     category, plus a transparent wedge for any
  *                     within-category gap (filer detail incomplete)
- *                     and a transparent wedge for the same outer
+ *                     and a hatched wedge for the same outer
  *                     residual so ring 3 reaches the same
  *                     circumference as ring 2.
+ *
+ * Residual vs within-category gap (#920): the residual is hatched
+ * (subtle diagonal lines) and hover shows a tooltip, so the operator
+ * SEES the coverage gap instead of reading it as a chart bug. It is
+ * never clickable. Within-category gaps stay fully transparent and
+ * inert — they have no identity to describe.
  *
  * Recharts has no native sunburst primitive — built from three nested
  * ``<Pie>`` components at increasing ``innerRadius`` / ``outerRadius``.
  */
 
-import { useMemo } from "react";
+import { useId, useMemo } from "react";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
 import { formatPct, formatShares } from "@/components/instrument/ownershipMetrics";
@@ -76,16 +82,94 @@ export function categoryFill(theme: ChartTheme, key: CategoryKey): string {
   return theme.accent[idx % theme.accent.length] ?? theme.accent[0]!;
 }
 
-interface ChartDatum {
+export interface ChartDatum {
   readonly id: string;
   readonly name: string;
   readonly shares: number;
   readonly pct: number;
   readonly fill: string;
-  /** True for transparent wedges — they are non-interactive and
-   *  the tooltip / hover affordances suppress on them. */
+  /** True for gap wedges (residual + within-category) — they are
+   *  never clickable. */
   readonly is_gap: boolean;
+  /** True only for the ``Public / unattributed`` residual wedges
+   *  (#920) — hatched fill + hover tooltip. Within-category gaps
+   *  stay transparent and inert. */
+  readonly is_residual: boolean;
   readonly target: WedgeClick | null;
+}
+
+/** Display label for the residual wedge — matches the backend
+ *  rollup's ``residual.label`` so chart, legend, and payload agree. */
+export const RESIDUAL_LABEL = "Public / unattributed";
+
+/**
+ * Tooltip copy for the residual wedge (#920). ``pct`` is the fraction
+ * already carried on the chart datum (``shares / effective
+ * denominator``). Says "of outstanding" (the chart's denominator is
+ * shares_outstanding) and "not attributed to" (the residual can
+ * include filers outside our seeded coverage cohort — "not held by
+ * any disclosed filer" would overclaim). Spec D4 / Codex ckpt-1.
+ */
+export function residualTooltipText(shares: number, pct: number): string {
+  return `${RESIDUAL_LABEL}: ${formatPct(pct)} of outstanding — ${formatShares(shares)} shares not attributed to any disclosed filer.`;
+}
+
+export interface SunburstChartData {
+  readonly middleData: ChartDatum[];
+  readonly outerData: ChartDatum[];
+}
+
+/**
+ * Pure chart-datum construction — extracted from the component so the
+ * gap/residual flag placement is unit-testable (jsdom renders a
+ * zero-size ResponsiveContainer, so sector-level DOM assertions are
+ * not viable).
+ */
+export function buildSunburstChartData(
+  rings: SunburstRings,
+  theme: ChartTheme,
+): SunburstChartData {
+  const denom = rings.total_shares;
+  const fillFor = (key: CategoryKey): string => categoryFill(theme, key);
+
+  // Middle ring — per-category wedges + hatched residual.
+  const middleData: ChartDatum[] = rings.categories.map((cat) =>
+    toCategoryDatum(cat, fillFor(cat.key), denom),
+  );
+  if (rings.category_residual > 0) {
+    middleData.push(
+      makeGapDatum("middle-residual", RESIDUAL_LABEL, rings.category_residual, denom, true),
+    );
+  }
+
+  // Outer ring — leaves under each visible category, then the
+  // category's within_category_gap (transparent), then the same
+  // residual so ring 3 closes flush with ring 2.
+  const outerData: ChartDatum[] = [];
+  for (const cat of rings.categories) {
+    const baseFill = fillFor(cat.key);
+    for (const leaf of cat.leaves) {
+      outerData.push(toLeafDatum(leaf, cat.key, baseFill, denom));
+    }
+    if (cat.within_category_gap > 0) {
+      outerData.push(
+        makeGapDatum(
+          `${cat.key}-gap`,
+          `${cat.label} — unresolved filers`,
+          cat.within_category_gap,
+          denom,
+          false,
+        ),
+      );
+    }
+  }
+  if (rings.category_residual > 0) {
+    outerData.push(
+      makeGapDatum("outer-residual", RESIDUAL_LABEL, rings.category_residual, denom, true),
+    );
+  }
+
+  return { middleData, outerData };
 }
 
 /**
@@ -108,8 +192,11 @@ const SUNBURST_STYLES = [
   // tests on the wrapper for any sector whose Cell carries
   // ``data-known='false'`` so transparent gap wedges don't absorb
   // clicks/hover at all (instead of relying on the JS click filter
-  // to no-op them after the fact).
-  ".ownership-sunburst .recharts-pie-sector:has(path[data-known='false']) {",
+  // to no-op them after the fact). Residual wedges (#920) are the
+  // exception: they keep hit-testing ON so the hover tooltip fires,
+  // but get no cursor / hover affordance — informational, never
+  // clickable.
+  ".ownership-sunburst .recharts-pie-sector:has(path[data-known='false'][data-residual='false']) {",
   "  pointer-events: none;",
   "}",
   ".ownership-sunburst .recharts-pie-sector:has(path[data-known='true']) path {",
@@ -137,43 +224,20 @@ export function OwnershipSunburst({
 }: OwnershipSunburstProps): JSX.Element | null {
   const rings = useMemo(() => buildSunburstRings(inputs), [inputs]);
   const theme = useChartTheme();
+  // ``useId`` emits colon-delimited ids (":r1:") that break ``url(#…)``
+  // fragment references in some engines — strip them.
+  const patternId = `residual-hatch-${useId().replace(/:/g, "")}`;
 
   if (rings === null) return null;
 
   const denom = rings.total_shares;
-  const fillFor = (key: CategoryKey): string => categoryFill(theme, key);
-
-  // Middle ring — per-category wedges + transparent residual.
-  const middleData: ChartDatum[] = rings.categories.map((cat) =>
-    toCategoryDatum(cat, fillFor(cat.key), denom),
-  );
-  if (rings.category_residual > 0) {
-    middleData.push(makeGapDatum("middle-residual", "Unaccounted", rings.category_residual, denom));
-  }
-
-  // Outer ring — leaves under each visible category, then the
-  // category's within_category_gap (transparent), then the same
-  // outer residual so ring 3 closes flush with ring 2.
-  const outerData: ChartDatum[] = [];
-  for (const cat of rings.categories) {
-    const baseFill = fillFor(cat.key);
-    for (const leaf of cat.leaves) {
-      outerData.push(toLeafDatum(leaf, cat.key, baseFill, denom));
-    }
-    if (cat.within_category_gap > 0) {
-      outerData.push(
-        makeGapDatum(
-          `${cat.key}-gap`,
-          `${cat.label} — unresolved filers`,
-          cat.within_category_gap,
-          denom,
-        ),
-      );
-    }
-  }
-  if (rings.category_residual > 0) {
-    outerData.push(makeGapDatum("outer-residual", "Unaccounted", rings.category_residual, denom));
-  }
+  const { middleData, outerData } = buildSunburstChartData(rings, theme);
+  // Known coverage derives from the SAME rings the wedges render
+  // from, so label and chart cannot diverge. Under the
+  // oversubscription bump this honestly reads 100% against the
+  // bumped denominator — the panel-level OversubscribedWarning
+  // carries the diagnostic (spec D5).
+  const coveragePct = (denom - rings.category_residual) / denom;
 
   const totalRadius = size / 2;
   const innerInner = totalRadius * 0.25;
@@ -202,6 +266,24 @@ export function OwnershipSunburst({
       aria-label={`Ownership breakdown: ${formatShares(denom)} total shares.`}
     >
       <style>{SUNBURST_STYLES}</style>
+      {/* Hatch paint-server for the residual wedges (#920). Recharts
+          filters unknown children of <PieChart>, so the <defs> lives
+          in a zero-size sibling svg — same-document url(#…) references
+          resolve across SVG elements. slate-400 stroke reads on both
+          light and dark backgrounds. */}
+      <svg aria-hidden focusable="false" width={0} height={0} className="absolute">
+        <defs>
+          <pattern
+            id={patternId}
+            width={6}
+            height={6}
+            patternUnits="userSpaceOnUse"
+            patternTransform="rotate(45)"
+          >
+            <line x1={0} y1={0} x2={0} y2={6} stroke="#94a3b8" strokeOpacity={0.45} strokeWidth={1.2} />
+          </pattern>
+        </defs>
+      </svg>
       <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Tooltip content={<SunburstTooltip />} />
@@ -230,9 +312,10 @@ export function OwnershipSunburst({
             {middleData.map((d) => (
               <Cell
                 key={d.id}
-                fill={d.fill}
+                fill={d.is_residual ? `url(#${patternId})` : d.fill}
                 stroke={d.is_gap ? "transparent" : wedgeStroke}
                 data-known={d.is_gap ? "false" : "true"}
+                data-residual={d.is_residual ? "true" : "false"}
               />
             ))}
           </Pie>
@@ -248,9 +331,10 @@ export function OwnershipSunburst({
             {outerData.map((d) => (
               <Cell
                 key={d.id}
-                fill={d.fill}
+                fill={d.is_residual ? `url(#${patternId})` : d.fill}
                 stroke={d.is_gap ? "transparent" : wedgeStroke}
                 data-known={d.is_gap ? "false" : "true"}
+                data-residual={d.is_residual ? "true" : "false"}
               />
             ))}
           </Pie>
@@ -262,6 +346,9 @@ export function OwnershipSunburst({
         </span>
         <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
           {formatShares(denom)}
+        </span>
+        <span className="text-xs text-slate-500 dark:text-slate-400">
+          {formatPct(coveragePct)} known coverage
         </span>
       </div>
     </div>
@@ -280,6 +367,7 @@ function toCategoryDatum(
     pct: denom > 0 ? cat.shares / denom : 0,
     fill: baseFill,
     is_gap: false,
+    is_residual: false,
     target: { kind: "category", category_key: cat.key },
   };
 }
@@ -297,18 +385,29 @@ function toLeafDatum(
     pct: denom > 0 ? leaf.shares / denom : 0,
     fill: baseFill,
     is_gap: false,
+    is_residual: false,
     target: { kind: "leaf", category_key, leaf_key: leaf.key },
   };
 }
 
-function makeGapDatum(id: string, name: string, shares: number, denom: number): ChartDatum {
+function makeGapDatum(
+  id: string,
+  name: string,
+  shares: number,
+  denom: number,
+  is_residual: boolean,
+): ChartDatum {
   return {
     id,
     name,
     shares,
     pct: denom > 0 ? shares / denom : 0,
+    // Residual cells override fill with the hatch paint-server at
+    // render time (the pattern id is per-mount, so it cannot live in
+    // this pure datum).
     fill: "transparent",
     is_gap: true,
+    is_residual,
     target: null,
   };
 }
@@ -325,7 +424,19 @@ interface RechartsTooltipProps {
 function SunburstTooltip(props: RechartsTooltipProps): JSX.Element | null {
   if (!props.active || props.payload === undefined || props.payload.length === 0) return null;
   const datum = props.payload[0]?.payload;
-  if (datum === undefined || datum.is_gap) return null;
+  if (datum === undefined) return null;
+  // Within-category gaps stay suppressed; the residual gets its own
+  // single-line copy (#920).
+  if (datum.is_gap && !datum.is_residual) return null;
+  if (datum.is_residual) {
+    return (
+      <div className="max-w-[18rem] rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
+        <div className="text-slate-700 dark:text-slate-300">
+          {residualTooltipText(datum.shares, datum.pct)}
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
       <div className="font-medium text-slate-900 dark:text-slate-100">{datum.name}</div>
@@ -349,7 +460,8 @@ export interface OwnershipLegendProps {
 
 /**
  * Color legend for the sunburst. Renders one row per category that
- * actually rendered, plus an "Unaccounted" row for the residual. Each
+ * actually rendered, plus a "Public / unattributed" row for the
+ * residual (hatched swatch, mirroring the wedge — #920). Each
  * row shows the swatch, label, share count, and % of outstanding so
  * the operator can read the ring at a glance without hovering.
  */
@@ -377,8 +489,8 @@ export function OwnershipLegend({ rings }: OwnershipLegendProps): JSX.Element | 
   }));
   if (rings.category_residual > 0) {
     rows.push({
-      key: "unaccounted",
-      label: "Unaccounted",
+      key: "residual",
+      label: RESIDUAL_LABEL,
       shares: rings.category_residual,
       pct: rings.category_residual / denom,
       swatch_fill: "transparent",
@@ -398,7 +510,15 @@ export function OwnershipLegend({ rings }: OwnershipLegendProps): JSX.Element | 
                 ? "border border-dashed border-slate-400 dark:border-slate-500"
                 : ""
             }`}
-            style={{ backgroundColor: row.swatch_fill }}
+            // The residual swatch mirrors the wedge hatch. An HTML
+            // span cannot reference the SVG paint-server, so the
+            // hatch is a CSS gradient (spec D7). rgba(148,163,184,…)
+            // = slate-400, same token as the wedge pattern stroke.
+            style={{
+              background: row.swatch_outline
+                ? "repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(148, 163, 184, 0.6) 3px, rgba(148, 163, 184, 0.6) 4px)"
+                : row.swatch_fill,
+            }}
           />
           <span className="text-slate-700 dark:text-slate-200">{row.label}</span>
           <span className="font-mono text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
Closes #920.

## What

First of the 4 split tickets under closed parent #846 (Phase 7 of #788). Static visual polish on the ownership sunburst — single component file + tests + spec. No backend, no API surface, no new state.

1. **Residual hatching** — the `Public / unattributed` residual wedges (middle + outer ring) render a subtle diagonal SVG hatch (slate-400 `#94a3b8`, opacity 0.45, 6×6 tile) instead of fully transparent. Pattern `<defs>` lives in a zero-size sibling `<svg>` because Recharts filters unknown `<PieChart>` children; pattern id is `useId()`-derived (colon-stripped for `url(#…)` safety) so two charts can mount on one page.
2. **Residual hover tooltip un-suppressed** — copy: `Public / unattributed: X% of outstanding — N shares not attributed to any disclosed filer.` The pre-existing CSS disabled hit-testing on ALL gap sectors, so un-suppressing the tooltip alone would have been dead code; a new `data-residual` Cell attribute carves residual sectors out of the `pointer-events: none` rule while keeping them cursor-neutral and non-clickable (within-category gaps stay fully inert).
3. **Center label** — third line `X% known coverage`, derived from the same `buildSunburstRings` output the wedges render from so label and chart cannot diverge.
4. **Legend** — residual row renamed `Unaccounted` → `Public / unattributed` (matches backend `residual.label`), swatch hatched via CSS `repeating-linear-gradient` (HTML span cannot reference an SVG paint server).

Spec with full design rationale: `docs/specs/ui/2026-06-11-ownership-chart-static-polish.md`.

## Conscious deviations from the issue text

- **"of outstanding", not "of float"** — the chart denominator is `shares_outstanding` (rings' effective `total_shares`); float excludes insiders/restricted, so "of float" would mislabel the denominator on an auditability-first surface.
- **"not attributed to", not "not held by" any disclosed filer** — the residual can include positions of filers outside our seeded coverage cohort (the backend residual tooltip says exactly this); "not held by" overclaims. Caught as Codex ckpt-1 High.
- **No Playwright snapshots** — no Playwright harness exists in this repo (FE tests = vitest + testing-library + jsdom). Acceptance translated to 7 vitest unit tests: exact tooltip copy (pure helper), residual/gap flag placement (pure `buildSunburstChartData`, extracted because jsdom renders a zero-size `ResponsiveContainer` — no sectors to assert on), center coverage line incl. the oversubscribed→100% edge, hatch `<pattern>` def presence, legend row + hatched swatch, full-coverage omission.

## Edge cases

- **Oversubscribed totals** (category sum > reported outstanding): `buildSunburstRings` bumps the denominator, residual clamps to 0 → label honestly reads `100.00% known coverage` against the bumped denominator; the existing panel-level `OversubscribedWarning` carries the diagnostic. Explicit test.
- **Zero residual**: no residual datums, no legend row, no hatch wedge — tests cover both.

## Security model

No auth surface, no user input, no SQL, no external calls. Pure presentational change inside an already-authenticated operator page. Tooltip/legend copy is composed from numeric rollup data only — no payload strings interpolated into the DOM beyond the existing `name` fields.

## Verification

- `pnpm --dir frontend typecheck` ✅
- `pnpm --dir frontend test:unit` ✅ 929 passed (88 files; 7 new)
- `pnpm --dir frontend dark:check` ✅ 184 files, no violations
- Pre-push hook (backend ruff/pyright/pytest fast tier + smoke) ✅ green on push
- Codex ckpt-1 (spec): 5 findings, all incorporated (copy precision, oversubscribed edge test, gradient swatch, data-layer flag tests, pinned hatch params)
- Codex ckpt-2 (branch diff): "No real bugs found" — independently verified Recharts 2.15.4 passes `data-*` Cell props to sector paths, `:has()` selector matches rendered structure, ran tsc + vitest itself
- Dev-verify (post-merge operator step): AAPL ownership panel, light + dark — hatch visible, tooltip fires on residual hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)