### PR TITLE
feat(#921): per-wedge SEC click-through — leaf wedges open the winning EDGAR filing, keyboard Enter support

### DIFF
--- a/docs/specs/ui/2026-06-11-ownership-wedge-clickthrough.md
+++ b/docs/specs/ui/2026-06-11-ownership-wedge-clickthrough.md
@@ -1,0 +1,114 @@
+# Per-wedge SEC click-through (#921)
+
+Status: live spec for #921 (second of 4 split tickets under closed parent #846).
+Scope: `OwnershipSunburst.tsx`, `ownershipRings.ts`, `OwnershipPanel.tsx`,
+`OwnershipPage.tsx` + tests. No backend change (`winning_edgar_url` already in the
+rollup payload from #840 P1).
+
+## Stale-premise resolution (operator decision 2026-06-11)
+
+The issue says "current chart has no click handler at all" — stale. Wedge click
+has navigated to the in-app L2 ownership page since #746 (2026-05-01, predates the
+issue). Operator chose the **split** model via AskUserQuestion:
+
+- **Leaf (outer-ring per-filer) wedge** with a known `source_url` → opens the SEC
+  archive index in a new tab (the issue's audit motivation: "wedge looks
+  suspicious → drill straight to the source filing").
+- **Category wedge + center** → keep the existing in-app navigate (L1 panel →
+  L2 page; L2 page → in-page query-param drill).
+- **Leaf without a URL** (aggregated "Other" tail, treasury, defensive-null
+  accessions, all L2-page-fed holders for now) → falls back to the existing
+  in-app drill. Never a dead wedge. This supersedes issue acceptance item 3
+  ("no click handler" on URL-less wedges), which was written on the stale
+  premise.
+
+## Design decisions
+
+### D1 — `source_url` threads through the data model as an optional field
+
+`SunburstHolder.source_url?: string | null` → `SunburstLeaf.source_url:
+string | null` → `WedgeClick` leaf variant gains `readonly source_url: string |
+null`. Optional on the input so the five L2-page holder builders
+(`filerToHolder`, `aggregateInsiderHoldersForSunburst`, `baselineToInsiderHolders`,
+`blockholdersToHolders`) compile unchanged and yield `null` (= in-page drill
+fallback, today's exact behaviour). Only `rollupToSunburstInputs` (L1 panel) maps
+`holder.winning_edgar_url`. Threading the four L2 endpoints is a follow-up ticket
+if the operator wants EDGAR-from-chart on L2 — the URLs are not in those payloads
+today.
+
+"Other" tail leaves and the treasury pseudo-leaf get `source_url: null` by
+construction (an aggregate has no single source filing).
+
+### D2 — shared `openWedgeSource(target)` helper owns the new-tab dispatch
+
+Exported from `OwnershipSunburst.tsx`: returns `false` unless `target` is a leaf
+with non-null `source_url` that passes the fail-closed host guard (URL must start
+with `https://www.sec.gov/` — backend builds these from accession numbers, but a
+2-line prefix check means a corrupted payload degrades to the in-app drill
+instead of opening an arbitrary URL; Codex ckpt-1 Low). Otherwise
+`window.open(url, "_blank", "noopener,noreferrer")`; returns `window.open(...)
+!== null`, so a popup-blocked open (`null` return) also falls back to the in-app
+navigate rather than swallowing the click (Codex ckpt-1 Medium). Both pages'
+`handleWedgeClick` call it first and fall through to their existing
+navigate/param logic on `false`.
+
+### D3 — keyboard: Enter triggers the focused sector's click
+
+Recharts 2.15 native keyboard model (read from `node_modules`): pie root Layer is
+Tab-reachable (`rootTabIndex` default 0), ArrowLeft/Right move DOM focus across
+sector `<g>` refs, Escape blurs — but **no Enter handling**, and sector
+`tabIndex: -1` is hardcoded after the props spread (not overridable per Cell).
+
+Sector → datum mapping does NOT rely on DOM order (Codex ckpt-1 High). Every
+`Cell` carries `data-ring="middle"|"outer"` + `data-idx={i}`; the wrapper-div
+`onKeyDown` Enter handler reads the focused sector's child
+`path[data-ring]` dataset and resolves `middleData[idx]` / `outerData[idx]`
+directly (helper `focusedSectorDatum(activeEl, middleData, outerData)`). Then it
+dispatches through the same `handleClick` path as mouse. Gap/residual sectors
+resolve to `target: null` → no-op, same as mouse.
+
+**Tab order (Codex ckpt-1 Medium):** the decorative inner pie gets
+`rootTabIndex={-1}` — it is a solid band whose click ("show L2 view") duplicates
+page-level navigation, so it stays mouse-only. Keyboard flow = two Tab stops
+(middle ring, outer ring), ArrowLeft/Right cycles sectors within the focused
+ring, Enter activates, Escape blurs. Recharts' per-pie keyboard handlers make a
+single combined stop impossible without reimplementing focus management.
+
+**AT semantics (Codex ckpt-1 High):** wrapper `role="img"` is wrong once the
+chart is interactive — replaced with `role="group"` + the existing aria-label.
+Known-wedge `Cell`s gain `aria-label` (`"{name}: {shares} shares, {pct} of
+outstanding"`) so arrow-focused sectors announce; recharts spreads unknown Cell
+props onto the sector `<path>` (same passthrough as `data-*`, verified for
+`data-*` in #920 ckpt-2).
+
+### D4 — no new cursor work
+
+`cursor: pointer` already applies to every `data-known='true'` sector; leaf
+wedges remain clickable in both branches (EDGAR or fallback drill), so the
+existing affordance is already correct. Residual/gap sectors stay
+non-interactive for click (#920 carve-out unchanged).
+
+## Acceptance mapping (issue → repo reality)
+
+No Playwright in repo (see #920 spec). Translated:
+
+1. Vitest: `openWedgeSource` — leaf + sec.gov URL opens exact URL with
+   `noopener,noreferrer` (spy), returns true; leaf+null / non-sec.gov URL /
+   category / center return false; popup-blocked (`window.open` → null)
+   returns false.
+2. Vitest: `rollupToSunburstInputs` threads `winning_edgar_url` →
+   `holders[].source_url`; rings thread holder → leaf `source_url`; "Other"
+   tail + treasury leaves get `null`; `buildSunburstChartData` leaf targets
+   carry `source_url`.
+3. Vitest: `focusedSectorDatum` maps `data-ring`/`data-idx` skeleton DOM to
+   the right datum; returns null for non-sector focus / missing dataset.
+4. Vitest **rendered** keyboard test (Codex ckpt-1 Medium): mock
+   `ResponsiveContainer` to a fixed-size passthrough (recharts computes sector
+   geometry mathematically, so real sectors render in jsdom), focus a real
+   sector path's Layer, press Enter on the wrapper, assert the wedge action
+   fires (window.open spy for a leaf with URL).
+5. Type-ripple sweep (Codex ckpt-1 Low): grep every constructor of leaf-kind
+   `WedgeClick` (tests + fixtures) and update for the required `source_url`.
+6. `typecheck` + `test:unit` + `dark:check` green.
+7. Dev-verify (operator): AAPL largest institutional wedge click → SEC archive
+   index new tab; Tab → Arrow → Enter does the same.

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -338,3 +338,44 @@ describe("rollupToSunburstInputs — def14a_unmatched fold (Codex review fix)", 
     expect(inputs!.insiders_total).toBeNull();
   });
 });
+
+describe("rollupToSunburstInputs — source_url threading (#921)", () => {
+  it("maps winning_edgar_url onto the holder's source_url", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({
+        shares_outstanding: "1000000000",
+        slices: [
+          {
+            category: "institutions",
+            label: "Institutions",
+            total_shares: "120000000",
+            pct_outstanding: "0.12",
+            filer_count: 1,
+            dominant_source: "13f",
+            holders: [
+              {
+                filer_cik: "0001000010",
+                filer_name: "BlackRock",
+                shares: "120000000",
+                pct_outstanding: "0.12",
+                winning_source: "13f",
+                winning_accession: "13F-010",
+                winning_edgar_url:
+                  "https://www.sec.gov/Archives/edgar/data/1000010/000100001026000010-index.html",
+                as_of_date: "2025-12-31",
+                filer_type: "INV",
+                dropped_sources: [],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(inputs!.holders).toHaveLength(1);
+    expect(inputs!.holders[0]).toMatchObject({
+      key: "0001000010",
+      source_url:
+        "https://www.sec.gov/Archives/edgar/data/1000010/000100001026000010-index.html",
+    });
+  });
+});

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -47,6 +47,7 @@ import { HistoricalSymbolCallout } from "@/components/instrument/HistoricalSymbo
 import {
   OwnershipLegend,
   OwnershipSunburst,
+  openWedgeSource,
 } from "@/components/instrument/OwnershipSunburst";
 import type { WedgeClick } from "@/components/instrument/OwnershipSunburst";
 import { Pane } from "@/components/instrument/Pane";
@@ -76,6 +77,12 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
   const navigate = useNavigate();
   const handleWedgeClick = useCallback(
     (target: WedgeClick) => {
+      // #921 split model (operator decision 2026-06-11): a per-filer
+      // leaf wedge with a known source filing opens SEC EDGAR in a
+      // new tab; everything else (categories, center, URL-less
+      // leaves, popup-blocked opens) falls through to the in-app L2
+      // drill below.
+      if (openWedgeSource(target)) return;
       const params = new URLSearchParams();
       if (target.kind === "category") params.set("category", target.category_key);
       if (target.kind === "leaf") {
@@ -165,7 +172,13 @@ export function rollupToSunburstInputs(
       const shares = parseShareCount(h.shares);
       if (shares === null || shares <= 0) continue;
       const key = h.filer_cik ?? `name:${h.filer_name}`;
-      out.push({ key, label: h.filer_name, shares, category: target });
+      out.push({
+        key,
+        label: h.filer_name,
+        shares,
+        category: target,
+        source_url: h.winning_edgar_url,
+      });
     }
     return out;
   };

--- a/frontend/src/components/instrument/OwnershipSunburst.test.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.test.tsx
@@ -13,8 +13,9 @@
  * are asserted directly.
  */
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactElement, cloneElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { lightTheme } from "@/lib/chartTheme";
 
@@ -25,8 +26,35 @@ import {
   RESIDUAL_LABEL,
   buildSunburstChartData,
   buildSunburstRings,
+  focusedSectorDatum,
+  openWedgeSource,
   residualTooltipText,
 } from "./OwnershipSunburst";
+
+// jsdom gives ResponsiveContainer a zero-size box, so the real
+// component renders no sectors. Recharts computes sector geometry
+// mathematically (no layout engine needed) — pinning a fixed size on
+// the child chart makes real sector paths render in jsdom, which the
+// keyboard test below needs (#921, Codex ckpt-1: a hand-built DOM
+// skeleton alone could pass while real Recharts markup breaks).
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactElement }) =>
+      cloneElement(children, { width: 360, height: 360 }),
+  };
+});
+
+// vitest 4 reuses spy instances across tests in a file — restore
+// per-test or window.open call history leaks (prevention-log:
+// "Frontend spy call-history leaks across tests").
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const EDGAR_URL =
+  "https://www.sec.gov/Archives/edgar/data/102909/000010290926000123-index.html";
 
 /** 1B outstanding; institutions report 600M with one 400M named
  *  filer → 200M within-category gap; 400M residual. */
@@ -39,6 +67,7 @@ function baseInputs(overrides: Partial<SunburstInputs> = {}): SunburstInputs {
         label: "Vanguard Group",
         shares: 400_000_000,
         category: "institutions",
+        source_url: EDGAR_URL,
       },
     ],
     institutions_total: 600_000_000,
@@ -91,6 +120,18 @@ describe("buildSunburstChartData", () => {
 
     const known = middleData.find((d) => d.id === "cat-institutions");
     expect(known).toMatchObject({ is_gap: false, is_residual: false });
+  });
+
+  it("threads source_url onto the leaf wedge's click target (#921)", () => {
+    const rings = buildSunburstRings(baseInputs());
+    const { outerData } = buildSunburstChartData(rings!, lightTheme);
+    const leaf = outerData.find((d) => d.id === "leaf-institutions-0000102909");
+    expect(leaf?.target).toEqual({
+      kind: "leaf",
+      category_key: "institutions",
+      leaf_key: "0000102909",
+      source_url: EDGAR_URL,
+    });
   });
 
   it("emits no residual datums when categories cover the denominator", () => {
@@ -155,5 +196,131 @@ describe("OwnershipLegend residual row", () => {
     );
     render(<OwnershipLegend rings={rings!} />);
     expect(screen.queryByText(RESIDUAL_LABEL)).toBeNull();
+  });
+});
+
+describe("openWedgeSource (#921)", () => {
+  it("opens a leaf's sec.gov URL in a new tab and returns true", () => {
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue({} as Window);
+    const opened = openWedgeSource({
+      kind: "leaf",
+      category_key: "institutions",
+      leaf_key: "0000102909",
+      source_url: EDGAR_URL,
+    });
+    expect(opened).toBe(true);
+    expect(openSpy).toHaveBeenCalledExactlyOnceWith(
+      EDGAR_URL,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("returns false when the popup is blocked (window.open → null)", () => {
+    vi.spyOn(window, "open").mockReturnValue(null);
+    expect(
+      openWedgeSource({
+        kind: "leaf",
+        category_key: "institutions",
+        leaf_key: "x",
+        source_url: EDGAR_URL,
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed on null, non-sec.gov, category, and center targets", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue({} as Window);
+    expect(
+      openWedgeSource({
+        kind: "leaf",
+        category_key: "etfs",
+        leaf_key: "x",
+        source_url: null,
+      }),
+    ).toBe(false);
+    expect(
+      openWedgeSource({
+        kind: "leaf",
+        category_key: "etfs",
+        leaf_key: "x",
+        source_url: "https://evil.example/sec.gov/index.html",
+      }),
+    ).toBe(false);
+    expect(
+      openWedgeSource({ kind: "category", category_key: "institutions" }),
+    ).toBe(false);
+    expect(openWedgeSource({ kind: "center" })).toBe(false);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("focusedSectorDatum (#921)", () => {
+  const rings = buildSunburstRings(baseInputs())!;
+  const { middleData, outerData } = buildSunburstChartData(rings, lightTheme);
+
+  function sectorPath(ring: string, idx: string): Element {
+    const root = document.createElement("div");
+    root.innerHTML = `<g class="recharts-pie-sector"><path data-ring="${ring}" data-idx="${idx}"></path></g>`;
+    return root.querySelector("path")!;
+  }
+
+  it("resolves middle and outer sectors by data attributes", () => {
+    expect(focusedSectorDatum(sectorPath("middle", "0"), middleData, outerData)).toBe(
+      middleData[0],
+    );
+    expect(focusedSectorDatum(sectorPath("outer", "1"), middleData, outerData)).toBe(
+      outerData[1],
+    );
+  });
+
+  it("returns null for non-sectors, unknown rings, and bad indices", () => {
+    expect(focusedSectorDatum(null, middleData, outerData)).toBeNull();
+    expect(
+      focusedSectorDatum(document.createElement("div"), middleData, outerData),
+    ).toBeNull();
+    expect(focusedSectorDatum(sectorPath("inner", "0"), middleData, outerData)).toBeNull();
+    expect(focusedSectorDatum(sectorPath("middle", ""), middleData, outerData)).toBeNull();
+    expect(
+      focusedSectorDatum(sectorPath("outer", "999"), middleData, outerData),
+    ).toBeNull();
+  });
+});
+
+describe("keyboard Enter on a real rendered sector (#921)", () => {
+  it("fires the wedge action end-to-end: Enter → leaf target → window.open", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue({} as Window);
+    const { container } = render(
+      <OwnershipSunburst
+        inputs={baseInputs()}
+        onWedgeClick={(target) => {
+          openWedgeSource(target);
+        }}
+      />,
+    );
+    // Real Recharts markup (fixed-size ResponsiveContainer mock):
+    // outer ring idx 0 = Vanguard, the only named leaf.
+    const path = container.querySelector('path[data-ring="outer"][data-idx="0"]');
+    expect(path).not.toBeNull();
+    fireEvent.keyDown(path!, { key: "Enter" });
+    expect(openSpy).toHaveBeenCalledExactlyOnceWith(
+      EDGAR_URL,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("ignores Enter on gap sectors and non-Enter keys", () => {
+    const handler = vi.fn();
+    const { container } = render(
+      <OwnershipSunburst inputs={baseInputs()} onWedgeClick={handler} />,
+    );
+    const gap = container.querySelector('path[data-residual="true"]');
+    expect(gap).not.toBeNull();
+    fireEvent.keyDown(gap!, { key: "Enter" });
+    const known = container.querySelector('path[data-ring="outer"][data-idx="0"]');
+    fireEvent.keyDown(known!, { key: "a" });
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/instrument/OwnershipSunburst.test.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.test.tsx
@@ -200,10 +200,13 @@ describe("OwnershipLegend residual row", () => {
 });
 
 describe("openWedgeSource (#921)", () => {
-  it("opens a leaf's sec.gov URL in a new tab and returns true", () => {
-    const openSpy = vi
-      .spyOn(window, "open")
-      .mockReturnValue({} as Window);
+  it("opens a leaf's sec.gov URL in a new tab, severs opener, returns true", () => {
+    // Not the ``noopener`` feature string: per spec that makes
+    // window.open return null even on SUCCESS, which would fire the
+    // caller's in-app fallback after every successful open (double
+    // action — Codex ckpt-2 High). Opener is severed on the handle.
+    const handle = { opener: "sentinel" } as unknown as Window;
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(handle);
     const opened = openWedgeSource({
       kind: "leaf",
       category_key: "institutions",
@@ -211,11 +214,8 @@ describe("openWedgeSource (#921)", () => {
       source_url: EDGAR_URL,
     });
     expect(opened).toBe(true);
-    expect(openSpy).toHaveBeenCalledExactlyOnceWith(
-      EDGAR_URL,
-      "_blank",
-      "noopener,noreferrer",
-    );
+    expect(openSpy).toHaveBeenCalledExactlyOnceWith(EDGAR_URL, "_blank");
+    expect(handle.opener).toBeNull();
   });
 
   it("returns false when the popup is blocked (window.open → null)", () => {
@@ -231,7 +231,9 @@ describe("openWedgeSource (#921)", () => {
   });
 
   it("fails closed on null, non-sec.gov, category, and center targets", () => {
-    const openSpy = vi.spyOn(window, "open").mockReturnValue({} as Window);
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue({ opener: null } as unknown as Window);
     expect(
       openWedgeSource({
         kind: "leaf",
@@ -290,7 +292,9 @@ describe("focusedSectorDatum (#921)", () => {
 
 describe("keyboard Enter on a real rendered sector (#921)", () => {
   it("fires the wedge action end-to-end: Enter → leaf target → window.open", () => {
-    const openSpy = vi.spyOn(window, "open").mockReturnValue({} as Window);
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue({ opener: null } as unknown as Window);
     const { container } = render(
       <OwnershipSunburst
         inputs={baseInputs()}
@@ -304,11 +308,43 @@ describe("keyboard Enter on a real rendered sector (#921)", () => {
     const path = container.querySelector('path[data-ring="outer"][data-idx="0"]');
     expect(path).not.toBeNull();
     fireEvent.keyDown(path!, { key: "Enter" });
-    expect(openSpy).toHaveBeenCalledExactlyOnceWith(
-      EDGAR_URL,
-      "_blank",
-      "noopener,noreferrer",
+    expect(openSpy).toHaveBeenCalledExactlyOnceWith(EDGAR_URL, "_blank");
+  });
+
+  it("recharts' own Arrow navigation focuses a sector that Enter then activates", () => {
+    // Drives the REAL focus chain (Codex ckpt-2 Low): focus the outer
+    // pie root, ArrowLeft via recharts' native onkeydown handler
+    // moves DOM focus onto a sector <g>, then Enter on it activates
+    // the wedge. Proves the wrapper handler composes with recharts'
+    // focus management, not just with hand-picked event targets.
+    const handler = vi.fn();
+    const { container } = render(
+      <OwnershipSunburst inputs={baseInputs()} onWedgeClick={handler} />,
     );
+    const outerLeafPath = container.querySelector(
+      'path[data-ring="outer"][data-idx="0"]',
+    );
+    // The outer pie root = the .recharts-pie ancestor of an outer cell.
+    const outerPieRoot = outerLeafPath!.closest(".recharts-pie");
+    expect(outerPieRoot).not.toBeNull();
+    // Recharts pre-increments its focus index from 0, so the outer
+    // ring's three sectors (leaf, within-category gap, residual)
+    // focus in order 1 → 2 → 0; three presses wrap to the leaf.
+    // Subsequent presses fire on the focused sector — keydown
+    // bubbles to the pie root where recharts attaches its handler,
+    // exactly as in a browser.
+    fireEvent.keyDown(outerPieRoot!, { key: "ArrowLeft" });
+    fireEvent.keyDown(document.activeElement!, { key: "ArrowLeft" });
+    fireEvent.keyDown(document.activeElement!, { key: "ArrowLeft" });
+    const focused = document.activeElement;
+    expect(focused?.classList.contains("recharts-pie-sector")).toBe(true);
+    fireEvent.keyDown(focused!, { key: "Enter" });
+    expect(handler).toHaveBeenCalledExactlyOnceWith({
+      kind: "leaf",
+      category_key: "institutions",
+      leaf_key: "0000102909",
+      source_url: EDGAR_URL,
+    });
   });
 
   it("ignores Enter on gap sectors and non-Enter keys", () => {

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -30,7 +30,7 @@
  * ``<Pie>`` components at increasing ``innerRadius`` / ``outerRadius``.
  */
 
-import { useId, useMemo } from "react";
+import { type KeyboardEvent, useId, useMemo } from "react";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
 import { formatPct, formatShares } from "@/components/instrument/ownershipMetrics";
@@ -62,7 +62,30 @@ export type WedgeClick =
       readonly kind: "leaf";
       readonly category_key: CategoryKey;
       readonly leaf_key: string;
+      /** SEC archive index URL for the holder's winning accession
+       *  (#921). ``null`` = no click-through target (aggregated
+       *  "Other" tail, treasury, feeds without URLs) — consumers
+       *  fall back to the in-app drill. */
+      readonly source_url: string | null;
     };
+
+/** Fail-closed host guard for wedge click-through (#921). The backend
+ *  builds these URLs from accession numbers, but a corrupted payload
+ *  should degrade to the in-app drill, not open an arbitrary URL. */
+const _EDGAR_URL_PREFIX = "https://www.sec.gov/";
+
+/**
+ * Open the SEC source filing for a leaf wedge in a new tab (#921).
+ * Returns ``true`` only when the tab actually opened — callers fall
+ * back to their in-app navigate/drill on ``false`` (no URL, non-SEC
+ * URL, category/center wedge, or popup-blocked ``window.open`` →
+ * ``null``), so a wedge click is never swallowed.
+ */
+export function openWedgeSource(target: WedgeClick): boolean {
+  if (target.kind !== "leaf" || target.source_url === null) return false;
+  if (!target.source_url.startsWith(_EDGAR_URL_PREFIX)) return false;
+  return window.open(target.source_url, "_blank", "noopener,noreferrer") !== null;
+}
 
 /** Index into ``ChartTheme.accent`` for each category's color. */
 export const CATEGORY_FILL_INDEX: Record<CategoryKey, number> = {
@@ -250,6 +273,23 @@ export function OwnershipSunburst({
     onWedgeClick?.(datum.target);
   };
 
+  // Keyboard activation (#921). Recharts' own keyboard layer makes the
+  // pie root Tab-reachable and moves focus across sectors on
+  // ArrowLeft/Right, but has NO Enter handling (verified in
+  // node_modules Pie.js). Keydown bubbles from the focused sector
+  // <g> to this wrapper; ``e.target`` is the focused sector.
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key !== "Enter") return;
+    const datum = focusedSectorDatum(
+      e.target instanceof Element ? e.target : null,
+      middleData,
+      outerData,
+    );
+    if (datum === null) return;
+    e.preventDefault();
+    handleClick(datum);
+  };
+
   const wedgeStroke = theme.gridLine;
 
   // ``middleData`` and ``outerData`` are always non-empty when
@@ -262,8 +302,11 @@ export function OwnershipSunburst({
     <div
       className="ownership-sunburst relative"
       style={{ width: size, height: size }}
-      role="img"
+      // ``group``, not ``img`` (#921): an atomic image role would hide
+      // the keyboard-interactive sectors from assistive tech.
+      role="group"
       aria-label={`Ownership breakdown: ${formatShares(denom)} total shares.`}
+      onKeyDown={handleKeyDown}
     >
       <style>{SUNBURST_STYLES}</style>
       {/* Hatch paint-server for the residual wedges (#920). Recharts
@@ -297,6 +340,10 @@ export function OwnershipSunburst({
             stroke={wedgeStroke}
             isAnimationActive={false}
             onClick={() => onWedgeClick?.({ kind: "center" })}
+            // Decorative band — its click ("show L2 view") duplicates
+            // page-level navigation, so it stays out of the Tab order
+            // (#921, Codex ckpt-1). Keyboard stops = middle + outer.
+            rootTabIndex={-1}
           >
             <Cell fill={theme.borderColor} fillOpacity={0.6} stroke={wedgeStroke} />
           </Pie>
@@ -309,13 +356,16 @@ export function OwnershipSunburst({
             isAnimationActive={false}
             onClick={(_, idx) => handleClick(middleData[idx])}
           >
-            {middleData.map((d) => (
+            {middleData.map((d, i) => (
               <Cell
                 key={d.id}
                 fill={d.is_residual ? `url(#${patternId})` : d.fill}
                 stroke={d.is_gap ? "transparent" : wedgeStroke}
                 data-known={d.is_gap ? "false" : "true"}
                 data-residual={d.is_residual ? "true" : "false"}
+                data-ring="middle"
+                data-idx={i}
+                aria-label={cellAriaLabel(d)}
               />
             ))}
           </Pie>
@@ -328,13 +378,16 @@ export function OwnershipSunburst({
             isAnimationActive={false}
             onClick={(_, idx) => handleClick(outerData[idx])}
           >
-            {outerData.map((d) => (
+            {outerData.map((d, i) => (
               <Cell
                 key={d.id}
                 fill={d.is_residual ? `url(#${patternId})` : d.fill}
                 stroke={d.is_gap ? "transparent" : wedgeStroke}
                 data-known={d.is_gap ? "false" : "true"}
                 data-residual={d.is_residual ? "true" : "false"}
+                data-ring="outer"
+                data-idx={i}
+                aria-label={cellAriaLabel(d)}
               />
             ))}
           </Pie>
@@ -386,8 +439,46 @@ function toLeafDatum(
     fill: baseFill,
     is_gap: false,
     is_residual: false,
-    target: { kind: "leaf", category_key, leaf_key: leaf.key },
+    target: {
+      kind: "leaf",
+      category_key,
+      leaf_key: leaf.key,
+      source_url: leaf.source_url,
+    },
   };
+}
+
+/**
+ * Resolve a keyboard event's target sector to its chart datum (#921).
+ * Reads the ``data-ring`` / ``data-idx`` attributes stamped on each
+ * Cell path — deliberately NOT positional DOM-order mapping, so a
+ * Recharts render-order change cannot silently remap Enter presses to
+ * the wrong wedge (Codex ckpt-1 High). Returns ``null`` for the inner
+ * decorative ring, labels, or anything that is not a sector.
+ */
+export function focusedSectorDatum(
+  eventTarget: Element | null,
+  middleData: readonly ChartDatum[],
+  outerData: readonly ChartDatum[],
+): ChartDatum | null {
+  if (eventTarget === null) return null;
+  const sector = eventTarget.closest(".recharts-pie-sector");
+  if (sector === null) return null;
+  const path = sector.querySelector("path[data-ring]");
+  if (path === null) return null;
+  const ring = path.getAttribute("data-ring");
+  const idx = Number.parseInt(path.getAttribute("data-idx") ?? "", 10);
+  if (!Number.isInteger(idx) || idx < 0) return null;
+  if (ring === "middle") return middleData[idx] ?? null;
+  if (ring === "outer") return outerData[idx] ?? null;
+  return null;
+}
+
+/** Accessible name for an arrow-focused sector (#921). Recharts
+ *  spreads unknown Cell props onto the sector ``<path>`` (same
+ *  passthrough as the ``data-*`` attributes). */
+function cellAriaLabel(d: ChartDatum): string {
+  return `${d.name}: ${formatShares(d.shares)} shares, ${formatPct(d.pct)} of outstanding`;
 }
 
 function makeGapDatum(

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -78,13 +78,22 @@ const _EDGAR_URL_PREFIX = "https://www.sec.gov/";
  * Open the SEC source filing for a leaf wedge in a new tab (#921).
  * Returns ``true`` only when the tab actually opened — callers fall
  * back to their in-app navigate/drill on ``false`` (no URL, non-SEC
- * URL, category/center wedge, or popup-blocked ``window.open`` →
- * ``null``), so a wedge click is never swallowed.
+ * URL, category/center wedge, or popup-blocked open), so a wedge
+ * click is never swallowed.
+ *
+ * Opener isolation is done by nulling ``opener`` on the returned
+ * handle, NOT via the ``noopener`` feature string: per spec,
+ * ``noopener`` makes ``window.open`` return ``null`` even on
+ * SUCCESS, which would make every successful open also fire the
+ * caller's in-app fallback (double action — Codex ckpt-2 High).
  */
 export function openWedgeSource(target: WedgeClick): boolean {
   if (target.kind !== "leaf" || target.source_url === null) return false;
   if (!target.source_url.startsWith(_EDGAR_URL_PREFIX)) return false;
-  return window.open(target.source_url, "_blank", "noopener,noreferrer") !== null;
+  const opened = window.open(target.source_url, "_blank");
+  if (opened === null) return false; // popup blocked → in-app fallback
+  opened.opener = null;
+  return true;
 }
 
 /** Index into ``ChartTheme.accent`` for each category's color. */

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -306,3 +306,42 @@ describe("buildSunburstRings — outer-ring threshold grouping", () => {
     expect(other?.shares).toBe(8_000);
   });
 });
+
+describe("buildSunburstRings — source_url threading (#921)", () => {
+  it("carries holder source_url onto its leaf; aggregates get null", () => {
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      total_shares: 1_000_000,
+      institutions_total: 58_000,
+      treasury_shares: 25_000,
+      holders: [
+        {
+          ...holder("alice", 50_000, "institutions"),
+          source_url:
+            "https://www.sec.gov/Archives/edgar/data/1/000000000126000001-index.html",
+        },
+        // Sub-threshold → folds into the "Other" tail.
+        { ...holder("bob", 8_000, "institutions"), source_url: "https://www.sec.gov/x" },
+      ],
+    });
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.leaves.find((l) => l.key === "alice")!.source_url).toBe(
+      "https://www.sec.gov/Archives/edgar/data/1/000000000126000001-index.html",
+    );
+    // An aggregate has no single source filing.
+    expect(inst.leaves.find((l) => l.is_other)!.source_url).toBeNull();
+    const treasury = r!.categories.find((c) => c.key === "treasury")!;
+    expect(treasury.leaves[0]!.source_url).toBeNull();
+  });
+
+  it("defaults to null when the holder feed carries no URL (L2 builders)", () => {
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      total_shares: 1_000_000,
+      institutions_total: 50_000,
+      holders: [holder("alice", 50_000, "institutions")],
+    });
+    const inst = r!.categories.find((c) => c.key === "institutions")!;
+    expect(inst.leaves.find((l) => l.key === "alice")!.source_url).toBeNull();
+  });
+});

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -69,6 +69,13 @@ export interface SunburstHolder {
     | "insiders"
     | "treasury"
     | "blockholders";
+  /** SEC archive index URL for the holder's winning accession (#921).
+   *  Optional so pre-existing call sites (the L2 page's per-endpoint
+   *  holder builders, whose payloads carry no URL today) compile
+   *  unchanged — absent/null means the wedge click falls back to the
+   *  in-app drill. The rollup-fed L1 panel supplies
+   *  ``winning_edgar_url``. */
+  readonly source_url?: string | null;
 }
 
 export interface SunburstInputs {
@@ -132,6 +139,10 @@ export interface SunburstLeaf {
   readonly shares: number;
   /** True for the aggregated tail wedge from threshold grouping. */
   readonly is_other: boolean;
+  /** Click-through target — SEC archive index URL for the holder's
+   *  winning accession (#921). ``null`` for aggregates ("Other" tail,
+   *  treasury) and holders whose feed carries no URL. */
+  readonly source_url: string | null;
   readonly tail_meta?: SunburstTailMeta;
 }
 
@@ -295,6 +306,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
           label: "Treasury",
           shares: input.treasury_shares,
           is_other: false,
+          source_url: null,
         },
       ],
       within_category_gap: 0,
@@ -358,6 +370,7 @@ function buildCategoryFromTotal(
         label: h.label,
         shares: h.shares,
         is_other: false,
+        source_url: h.source_url ?? null,
       });
     } else {
       tail.push(h);
@@ -373,6 +386,8 @@ function buildCategoryFromTotal(
       label: `Other ${CATEGORY_LABEL[key].toLowerCase()}`,
       shares: aggregate_shares,
       is_other: true,
+      // An aggregate has no single source filing to click through to.
+      source_url: null,
       tail_meta: {
         count: tail.length,
         aggregate_shares,

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -43,6 +43,7 @@ import {
 import {
   OwnershipLegend,
   OwnershipSunburst,
+  openWedgeSource,
 } from "@/components/instrument/OwnershipSunburst";
 import type { WedgeClick } from "@/components/instrument/OwnershipSunburst";
 import {
@@ -135,6 +136,11 @@ export function OwnershipPage(): JSX.Element {
 
   const handleWedgeClick = useCallback(
     (target: WedgeClick) => {
+      // #921 split model: leaf wedge with a source filing → SEC EDGAR
+      // new tab. The L2 holder builders carry no URLs today, so this
+      // only fires once those feeds thread source_url — until then
+      // every leaf falls through to the in-page drill below.
+      if (openWedgeSource(target)) return;
       const next = new URLSearchParams(searchParams);
       if (target.kind === "category") {
         next.set("category", target.category_key);


### PR DESCRIPTION
Closes #921.

## What

Second of the 4 split tickets under closed parent #846. Per-filer (outer-ring) wedges in the ownership sunburst now open the holder's winning SEC EDGAR archive-index URL in a new tab. Keyboard parity: recharts' native ArrowLeft/Right sector focus + a new Enter handler activate the same action.

## Stale-premise resolution (operator decision, this session)

The issue says "current chart has no click handler at all" — stale: wedge click has navigated to the in-app L2 ownership page since #746 (2026-05-01, predates the issue). The operator chose the **split model** via an explicit prompt:

- **Leaf wedge with a known `source_url`** → SEC EDGAR new tab (the issue's audit motivation).
- **Category wedges + center** → existing in-app navigate (L1 panel → L2 page; L2 page → in-page query-param drill).
- **Leaf without a URL** (aggregated "Other" tail, treasury, all L2-page-fed holders today, popup-blocked opens) → falls back to the in-app drill. Never a dead wedge. This supersedes issue acceptance item 3 ("no click handler" on URL-less wedges), which was written on the stale premise.

## How

- `WedgeClick` leaf targets carry `source_url`; threaded `rollup.holders[].winning_edgar_url` → `SunburstHolder.source_url` (optional — the L2 page's four per-endpoint holder builders carry no URLs today and compile unchanged) → `SunburstLeaf` → leaf target. "Other"/treasury aggregates get `null` by construction.
- Shared `openWedgeSource(target)`: fail-closed `https://www.sec.gov/` prefix guard (corrupted payload degrades to in-app drill, never opens an arbitrary URL); opens without a feature string and **severs `opener` on the returned handle** — the `noopener` feature makes `window.open` return `null` even on success per spec, which would have double-fired the in-app fallback after every successful open (Codex ckpt-2 High, caught pre-push); `null` return = popup blocked = in-app fallback.
- Keyboard (#921 acceptance 2): recharts 2.15 moves sector DOM focus on ArrowLeft/Right but has **no Enter handling** (verified in node_modules). Wrapper `onKeyDown` resolves the focused sector via `data-ring`/`data-idx` Cell attributes — deliberately not positional DOM-order mapping (Codex ckpt-1 High) — and dispatches the same click path. Decorative inner pie gets `rootTabIndex={-1}`; two Tab stops (middle, outer ring).
- AT: wrapper `role` `img` → `group` (atomic image role would hide interactive sectors), per-Cell `aria-label` (`"{name}: {shares} shares, {pct} of outstanding"`).
- Cursor affordance already correct: `cursor: pointer` applies to every known wedge, and every known wedge remains clickable in both branches.

Spec with full rationale: `docs/specs/ui/2026-06-11-ownership-wedge-clickthrough.md`.

## Security model

- New-tab URLs come from the backend rollup (`winning_edgar_url`, built server-side from accession numbers). Defense-in-depth: client-side `https://www.sec.gov/` prefix guard fails closed to the in-app drill.
- Reverse-tabnabbing: `opener` severed on the handle (see above for why not the `noopener` feature string). Referrer to sec.gov is not sensitive.
- No user input reaches `window.open`; no SQL; no auth surface change.

## Verification

- `pnpm --dir frontend typecheck` ✅ · `test:unit` ✅ 941 passed (12 new) · `dark:check` ✅
- Pre-push hook (backend fast tier + smoke) ✅
- No Playwright in repo — issue's "Playwright click test" translated: `window.open` spy suite (exact URL, popup-block, host-guard, category/center no-ops) + a **rendered-Recharts** end-to-end keyboard test (fixed-size `ResponsiveContainer` mock; recharts computes sector geometry mathematically so real sector paths render in jsdom): ArrowLeft drives recharts' own focus chain across sectors, Enter fires the wedge action with the exact EDGAR URL.
- Codex ckpt-1 (spec): 7 findings incorporated (data-attr mapping, AT role, tab order, rendered test, popup-block semantics, type-ripple sweep, host guard).
- Codex ckpt-2 (diff): 1 High (noopener/null — fixed b87fc86) + 1 Low (focus-chain test — added b87fc86); re-verified locally after fix.
- Dev-verify (operator follow-up): AAPL largest institutional wedge click → SEC archive index new tab; Tab → Arrow → Enter same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)