### PR TITLE
feat(#922): ownership history pane — category-aggregate endpoint mode + OwnershipHistoryChart

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4225,7 +4225,11 @@ def _rollup_to_response(
 
 
 class OwnershipHistoryPointResponse(BaseModel):
-    """One point on a holder's history series (#840.F)."""
+    """One point on a holder's history series (#840.F).
+
+    ``holder_count`` (#922): filers contributing to an aggregate
+    bucket; ``None`` on per-holder series and issuer-level treasury
+    points."""
 
     period_end: date
     ownership_nature: str
@@ -4233,6 +4237,7 @@ class OwnershipHistoryPointResponse(BaseModel):
     source: str
     source_accession: str | None
     filed_at: datetime | None
+    holder_count: int | None = None
 
 
 class OwnershipHistoryResponse(BaseModel):
@@ -4258,6 +4263,7 @@ def get_instrument_ownership_history(
     symbol: str,
     category: str,
     holder_id: str | None = None,
+    aggregate: bool = False,
     from_date: date | None = None,
     to_date: date | None = None,
     conn: psycopg.Connection[object] = Depends(get_conn),
@@ -4268,6 +4274,13 @@ def get_instrument_ownership_history(
     Operator question this answers: *"how has Vanguard's AAPL
     position shifted over the last 8 quarters?"* — call with
     ``category=institutions, holder_id=0000102909``.
+
+    ``aggregate=true`` (#922) answers the CATEGORY-level question
+    ("how have institutions in total trended?"): per-quarter sums
+    over the per-filer dedup winners. Only ``institutions`` and
+    ``treasury`` aggregate honestly — event-driven categories
+    (insiders / blockholders / def14a) would only count holders who
+    happened to file in each period.
 
     Categories: ``insiders``, ``blockholders``, ``institutions``,
     ``treasury``, ``def14a``. ``holder_id`` semantics depend on
@@ -4281,6 +4294,22 @@ def get_instrument_ownership_history(
         raise HTTPException(status_code=400, detail="symbol is required")
     if category not in ("insiders", "blockholders", "institutions", "treasury", "def14a"):
         raise HTTPException(status_code=400, detail=f"unknown category {category!r}")
+    if aggregate:
+        if holder_id is not None and holder_id.strip():
+            raise HTTPException(
+                status_code=400,
+                detail="aggregate=true and holder_id are mutually exclusive",
+            )
+        if category not in ownership_history.AGGREGATE_CATEGORIES:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"category {category!r} has no honest aggregate series: "
+                    "event-driven filings would only count holders who filed "
+                    "in each period (carry-forward not implemented); query "
+                    "per-holder instead"
+                ),
+            )
     # Codex pre-push review for #840.F: holder-scoped categories
     # MUST be called with a holder_id. Without one, DISTINCT ON
     # ``(period_end, ownership_nature)`` returns one arbitrary
@@ -4288,7 +4317,11 @@ def get_instrument_ownership_history(
     # would mislead the chart consumer. Treasury is issuer-level so
     # holder_id is ignored there.
     holder_scoped = ("insiders", "blockholders", "institutions", "def14a")
-    if category in holder_scoped and (holder_id is None or not holder_id.strip()):
+    if (
+        not aggregate
+        and category in holder_scoped
+        and (holder_id is None or not holder_id.strip())
+    ):
         raise HTTPException(
             status_code=400,
             detail=f"holder_id is required for category {category!r}",
@@ -4308,14 +4341,23 @@ def get_instrument_ownership_history(
             inst_row = cur.fetchone()
         if inst_row is None:
             raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
-        points = ownership_history.get_ownership_history(
-            conn,
-            instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
-            category=category,  # type: ignore[arg-type]
-            holder_id=holder_id,
-            from_date=from_date,
-            to_date=to_date,
-        )
+        if aggregate:
+            points = ownership_history.get_ownership_category_totals(
+                conn,
+                instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
+                category=category,  # type: ignore[arg-type]
+                from_date=from_date,
+                to_date=to_date,
+            )
+        else:
+            points = ownership_history.get_ownership_history(
+                conn,
+                instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
+                category=category,  # type: ignore[arg-type]
+                holder_id=holder_id,
+                from_date=from_date,
+                to_date=to_date,
+            )
     return OwnershipHistoryResponse(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
         instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
@@ -4329,6 +4371,7 @@ def get_instrument_ownership_history(
                 source=p.source,
                 source_accession=p.source_accession,
                 filed_at=p.filed_at,
+                holder_count=p.holder_count,
             )
             for p in points
         ],

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4295,7 +4295,10 @@ def get_instrument_ownership_history(
     if category not in ("insiders", "blockholders", "institutions", "treasury", "def14a"):
         raise HTTPException(status_code=400, detail=f"unknown category {category!r}")
     if aggregate:
-        if holder_id is not None and holder_id.strip():
+        # ANY supplied holder_id (including blank) conflicts — a blank
+        # value slipping through would echo holder_id="" in the
+        # response and mask caller bugs (Codex ckpt-2 S3).
+        if holder_id is not None:
             raise HTTPException(
                 status_code=400,
                 detail="aggregate=true and holder_id are mutually exclusive",
@@ -4317,11 +4320,7 @@ def get_instrument_ownership_history(
     # would mislead the chart consumer. Treasury is issuer-level so
     # holder_id is ignored there.
     holder_scoped = ("insiders", "blockholders", "institutions", "def14a")
-    if (
-        not aggregate
-        and category in holder_scoped
-        and (holder_id is None or not holder_id.strip())
-    ):
+    if not aggregate and category in holder_scoped and (holder_id is None or not holder_id.strip()):
         raise HTTPException(
             status_code=400,
             detail=f"holder_id is required for category {category!r}",

--- a/app/services/ownership_history.py
+++ b/app/services/ownership_history.py
@@ -437,15 +437,11 @@ def get_ownership_category_totals(
     (#922). Only ``AGGREGATE_CATEGORIES`` are supported — see the
     constant's docstring for the cadence rationale."""
     if category == "institutions":
-        return _institutions_aggregate_history(
-            conn, instrument_id=instrument_id, from_date=from_date, to_date=to_date
-        )
+        return _institutions_aggregate_history(conn, instrument_id=instrument_id, from_date=from_date, to_date=to_date)
     if category == "treasury":
         # Treasury is issuer-level: the aggregate IS the existing
         # series, XBRL source/accession provenance untouched.
-        return _treasury_history(
-            conn, instrument_id=instrument_id, from_date=from_date, to_date=to_date
-        )
+        return _treasury_history(conn, instrument_id=instrument_id, from_date=from_date, to_date=to_date)
     raise ValueError(
         f"category {category!r} has no honest aggregate series "
         "(event-driven filings need carry-forward semantics; use per-holder)"

--- a/app/services/ownership_history.py
+++ b/app/services/ownership_history.py
@@ -60,6 +60,9 @@ class OwnershipHistoryPoint:
     source: str
     source_accession: str | None
     filed_at: Any
+    # Filers contributing to an aggregate bucket (#922). ``None`` on
+    # per-holder series and on issuer-level treasury points.
+    holder_count: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -342,6 +345,111 @@ def _def14a_history(
             )
             for row in cur.fetchall()
         ]
+
+
+def _institutions_aggregate_history(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    from_date: date | None = None,
+    to_date: date | None = None,
+) -> list[OwnershipHistoryPoint]:
+    """Per-quarter category total across ALL 13F filers (#922).
+
+    Dedup-before-sum: the inner ``DISTINCT ON (period_end, filer_cik)``
+    picks one winner per filer per quarter (``filed_at DESC,
+    source_document_id ASC`` — same winner rule as the per-holder
+    reader) so amendments cannot double-count. ``ownership_nature``
+    is FILTERED to ``'economic'`` (the only nature 13F rows carry
+    today, verified on dev 2026-06-11) rather than summed across —
+    if other natures ever land they are excluded, not silently
+    mislabelled into an "economic" total.
+
+    NOT comparable 1:1 with the rollup pie's institutions slice: the
+    pie reads the ``*_current`` tables through cross-source survivor
+    logic + an ETF filer_type split. This series is raw-13F-by-quarter
+    (spec D2)."""
+    where_extra = ""
+    params: dict[str, Any] = {"iid": instrument_id}
+    if from_date is not None:
+        where_extra += " AND period_end >= %(from_date)s"
+        params["from_date"] = from_date
+    if to_date is not None:
+        where_extra += " AND period_end <= %(to_date)s"
+        params["to_date"] = to_date
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            f"""
+            SELECT period_end,
+                   SUM(shares) AS shares,
+                   COUNT(DISTINCT filer_cik) AS holder_count,
+                   MAX(filed_at) AS filed_at
+            FROM (
+                SELECT DISTINCT ON (period_end, filer_cik)
+                    period_end, filer_cik, shares, filed_at
+                FROM ownership_institutions_observations
+                WHERE instrument_id = %(iid)s
+                  AND known_to IS NULL
+                  AND shares IS NOT NULL
+                  AND exposure_kind = 'EQUITY'
+                  AND ownership_nature = 'economic'
+                  {where_extra}
+                ORDER BY period_end, filer_cik, filed_at DESC, source_document_id ASC
+            ) winners
+            GROUP BY period_end
+            ORDER BY period_end
+            """,
+            params,
+        )
+        return [
+            OwnershipHistoryPoint(
+                period_end=row["period_end"],
+                ownership_nature="economic",
+                shares=row["shares"],
+                source="13f",
+                # An aggregate has no single accession.
+                source_accession=None,
+                filed_at=row["filed_at"],
+                holder_count=int(row["holder_count"]),  # type: ignore[arg-type]
+            )
+            for row in cur.fetchall()
+        ]
+
+
+#: Categories whose aggregate-by-period series is honest (#922).
+#: 13F is quarterly by construction; treasury is issuer-level.
+#: Event-driven categories (insiders / blockholders / def14a) need
+#: carry-forward-latest-per-holder semantics to aggregate honestly —
+#: out of scope, per-holder drill only.
+AGGREGATE_CATEGORIES: tuple[HistoryCategory, ...] = ("institutions", "treasury")
+
+
+def get_ownership_category_totals(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    category: HistoryCategory,
+    from_date: date | None = None,
+    to_date: date | None = None,
+) -> list[OwnershipHistoryPoint]:
+    """Aggregate (holder-less) history for one instrument × category
+    (#922). Only ``AGGREGATE_CATEGORIES`` are supported — see the
+    constant's docstring for the cadence rationale."""
+    if category == "institutions":
+        return _institutions_aggregate_history(
+            conn, instrument_id=instrument_id, from_date=from_date, to_date=to_date
+        )
+    if category == "treasury":
+        # Treasury is issuer-level: the aggregate IS the existing
+        # series, XBRL source/accession provenance untouched.
+        return _treasury_history(
+            conn, instrument_id=instrument_id, from_date=from_date, to_date=to_date
+        )
+    raise ValueError(
+        f"category {category!r} has no honest aggregate series "
+        "(event-driven filings need carry-forward semantics; use per-holder)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1745,3 +1745,8 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: `reconcile_symbol_history(conn)  # type: ignore[arg-type]` silenced a `Connection[tuple]` vs unparameterised-connection mismatch. With a dict_row caller, the function's `int(r[0])` fetches would KeyError at runtime — the ignore traded a compile-time error for a latent runtime one.
 - Prevention: never `type: ignore[arg-type]` a psycopg Connection argument. Either the function genuinely depends on the row shape — then open its own cursor with an explicit `row_factory=psycopg.rows.tuple_row` (or `dict_row`) and widen the signature to `Connection[Any]` — or it only uses `rowcount`/`execute`, in which case `Connection[Any]` alone is honest.
 - Enforced in: `.claude/skills/engineering/python-hygiene.md` (psycopg typing section)
+
+### `new Date()` / `Date.now()` computed in a render body and fed into async-hook dep arrays
+
+- PR #1586 review WARNING: `windowFromDate(window, new Date())` evaluated every render, result in `useAsync` deps. Benign THERE only because the helper returns a date STRING (value-stable within a day) — the same pattern returning a `Date` object or epoch ms refetches on every parent re-render.
+- Rule: any `new Date()` / `Date.now()` whose result reaches a `useAsync` / `useEffect` / `useCallback` dep array must be wrapped in `useMemo` keyed on the inputs that should drive recomputation. Stability must be explicit, not incidental to a string return type.

--- a/docs/specs/ui/2026-06-11-ownership-history-pane.md
+++ b/docs/specs/ui/2026-06-11-ownership-history-pane.md
@@ -1,0 +1,179 @@
+# Ownership history pane (#922)
+
+Status: live spec for #922 (third of 4 split tickets under closed parent #846).
+Scope: new `OwnershipHistoryChart` on the L2 ownership page + a small, additive
+extension to the existing `/instruments/{symbol}/ownership-history` endpoint
+(aggregate mode). No new endpoint, no schema change, no ingest change.
+
+## Stale-premise resolution
+
+The issue claims the existing endpoint "already returns the data shape" for the
+default category-level view. **It does not**: `holder_id` is REQUIRED for every
+holder-scoped category (`insiders`, `blockholders`, `institutions`, `def14a`) —
+a deliberate guard (Codex review of #840.F) because holder-less `DISTINCT ON
+(period_end, ownership_nature)` would silently return one arbitrary holder per
+period. The issue itself allows "add fields if not" — the gap is closed with an
+explicit `aggregate=true` mode, not by weakening the guard.
+
+## Where the component lives
+
+`OwnershipPage` (L2), below the existing pie + legend. The issue says "below the
+ownership rollup pie"; the L2 page is where holder ROWS exist (the drill-in
+acceptance — "click on Cohen's GME insider row" — needs them) and where the
+`?category=` / `?filer=` selection params already live (set by wedge clicks
+since #746/#921). The chart consumes that same selection state: no new selection
+mechanism, no prop drilling from a second source of truth.
+
+## Backend design
+
+### D1 — aggregate mode is honest only where the data cadence allows it
+
+- **institutions** (13F): quarterly by construction — every filer reports per
+  quarter-end. Aggregate per `period_end` = `SUM` over the per-`(filer_cik,
+  ownership_nature)` deduped winner rows (same `filed_at DESC,
+  source_document_id ASC` winner rule as the per-holder reader — raw SUM would
+  double-count amendments). Dev-verified on AAPL: 5,577–6,069 filers/quarter,
+  sums 3.1–5.8B vs 14.9B outstanding; older quarters visibly partial (backfill
+  still draining) — the chart shows what we have, faithfully.
+- **treasury**: already issuer-level; aggregate == the existing series.
+- **insiders / blockholders / def14a**: event-driven filings (Form 4 on trade,
+  13D/G on threshold). A per-period SUM would only count holders who happened to
+  file that period — misleading. Honest aggregation needs carry-forward-latest-
+  per-holder semantics; **out of scope**, returns 400 with an explicit detail,
+  follow-up issue filed. Drill-in (per-holder) covers these categories, which is
+  also exactly what the issue's GME/Cohen acceptance exercises.
+- No ETF split in v1: `ownership_institutions_observations.filer_type` is 100%
+  `'INV'` on dev (ETF tagging hasn't landed in observations). When it lands, the
+  split is one GROUP BY term. Documented divergence from the pie (which splits
+  ETFs from the 13F **current** snapshot by `filer_type`).
+
+### D2 — pinned aggregate SQL + provenance honesty (Codex ckpt-1 P0/P1)
+
+Pinned shape (institutions):
+
+```sql
+SELECT period_end, SUM(shares) AS shares,
+       COUNT(DISTINCT filer_cik) AS holder_count,
+       MAX(filed_at) AS filed_at
+FROM (
+  SELECT DISTINCT ON (period_end, filer_cik)
+         period_end, filer_cik, shares, filed_at
+  FROM ownership_institutions_observations
+  WHERE instrument_id = … AND known_to IS NULL AND shares IS NOT NULL
+    AND exposure_kind = 'EQUITY' AND ownership_nature = 'economic'
+    [AND period_end >= …] [AND period_end <= …]
+  ORDER BY period_end, filer_cik, filed_at DESC, source_document_id ASC
+) winners
+GROUP BY period_end ORDER BY period_end
+```
+
+- `ownership_nature = 'economic'` is FILTERED, not summed-across: today it is
+  the only nature (verified, 6.25M rows); if other natures ever land they are
+  excluded rather than silently mislabelled into an "economic" total.
+- Dedup-before-sum: the inner `DISTINCT ON` picks one winner per
+  `(period_end, filer_cik)` so amendments cannot double-count.
+- `holder_count = COUNT(DISTINCT filer_cik)` — filers, not filer-nature rows.
+- **NOT claimed to reconcile with the pie** (Codex P0): the pie reads the
+  `*_current` tables through cross-source survivor logic + an ETF filer_type
+  split; this series is raw-13F-by-quarter. Dev-verify is a magnitude
+  sanity-check only; the chart line is labelled "Institutions (13F)".
+
+### D3 — API surface (additive only)
+
+`GET /instruments/{symbol}/ownership-history?category=…&aggregate=true`:
+
+- `aggregate=true` + `holder_id` → 400 (mutually exclusive).
+- `aggregate=true` + category not in `{institutions, treasury}` → 400 with the
+  cadence rationale in `detail`.
+- Existing per-holder contract unchanged, including inclusive date bounds
+  (`from_date > to_date` ⇒ empty list, same as today; test pins it).
+- **Institutions** aggregate points reuse `OwnershipHistoryPointResponse`:
+  `ownership_nature="economic"`, `source="13f"`, `source_accession=null` (an
+  aggregate has no single accession), `filed_at=MAX(filed_at)` in the bucket.
+- **Treasury** aggregate = the EXISTING issuer-level series verbatim — XBRL
+  source/accession provenance untouched (Codex P0: the institutions bullet
+  does not apply to treasury).
+- New OPTIONAL field `holder_count: int | None` on the point response
+  (institutions-aggregate only; `null` in per-holder mode and for treasury).
+  Pydantic + `types.ts` updated in the same PR (api-shape-and-types skill).
+
+## Frontend design
+
+### D4 — selection-driven modes (Codex ckpt-1 P0: `?category=` respected)
+
+Aggregate (no `?filer=`):
+
+- No `?category=` → institutions + treasury lines. Two parallel fetches; either
+  failing alone degrades to the other line + a per-section error note; both
+  failing → `SectionError`.
+- `?category=institutions` → institutions line only; `?category=treasury` →
+  treasury line only.
+- `?category=insiders|blockholders|def14a` → explanatory `EmptyState`: these
+  filings are event-driven, only per-holder series are honest — "click a holder
+  row to chart one filer".
+- `?category=etfs` → same explanatory state; the 13F aggregate line includes
+  ETF filers (no filer_type split in observations yet — see D1).
+
+Per-holder (`?filer=` set) — **per-category key → `holder_id` mapping**
+(verified key shapes; Codex ckpt-1 P1):
+
+| category | leaf/row key shape | holder_id |
+| --- | --- | --- |
+| institutions / etfs | raw `filer_cik` | key as-is, queried as `category=institutions` |
+| insiders (Form 4) | `cik` or `name:{name}` | key if all-digits, else unmappable |
+| insiders (baseline) | `baseline:{cik}:d\|n` | middle segment |
+| blockholders | `block:{cik\|name:…}` | suffix if all-digits, else unmappable |
+
+- Mappable key → per-holder series for the selected category; one line per
+  `ownership_nature` (service doc: beneficial and direct render as TWO lines,
+  never summed).
+- Unmappable key (`name:` fallback anywhere) → `EmptyState`: "No per-holder
+  history: this holder has no resolved CIK."
+- Stale/unknown-but-mappable key → endpoint returns an empty list →
+  `EmptyState` ("no history on file for this holder").
+- `?filer=` without `?category=` → filer ignored, aggregate default renders.
+- `?category=treasury` + `?filer=` → issuer series unchanged (treasury is
+  issuer-level).
+
+### D5 — time windows and axis
+
+- 1Y / 3Y / 5Y / All toggle → `from_date` (UTC today minus window). Local
+  component state, not a URL param (the issue names only `holder_cik` as param
+  state; windows are ephemeral view state).
+- **Y axis = absolute shares, not %.** The issue's "50% → 53%" example implies a
+  percent axis, but a percent of TODAY's `shares_outstanding` applied to old
+  quarters misstates history (buybacks shrink the denominator — AAPL
+  specifically). We have no historical outstanding series wired (#1580 notes
+  stale multi-class dei rows). Tooltip shows shares + "X% of current
+  outstanding" explicitly labelled "current". Conscious deviation, recorded in
+  the PR; percent axis = follow-up when a historical denominator exists.
+
+### D6 — states + conventions
+
+Loading `SectionSkeleton`, error `SectionError onRetry`, empty `EmptyState` with
+next-action copy ("Ownership history appears after the 13F backfill drains for
+this instrument."), all structurally symmetric per
+`loading-error-empty-states.md`. Recharts `LineChart` themed via `useChartTheme`
+accents; formatting via existing `formatShares`/`formatPct`; timestamps via
+`format.ts`.
+
+### D7 — fetcher
+
+New `frontend/src/api/ownershipHistory.ts` thin fetcher +
+`OwnershipHistoryResponse` types in `types.ts` (mirrors the Pydantic model
+field-for-field; `holder_count: number | null`).
+
+## Tests
+
+1. Backend: pure param-validation cases via existing endpoint-test pattern;
+   ONE db-tier integration test for the genuinely-new aggregate SQL (dedup-
+   before-sum proven with an amendment fixture: two accessions same
+   filer×quarter → aggregate counts the winner once). Run targeted (`pytest
+   <file> -m db`), never bare `-m db` (wedge precedent).
+2. Frontend: pure series-builder (points → per-nature recharts series), mode
+   decision (aggregate / holder / name-fallback), window → from_date; render
+   states (loading/error/empty/data) in jsdom with mocked fetchers.
+3. Dev-verify: AAPL / GME / MSFT — aggregate renders; GME insider drill via a
+   known CIK; figures sanity-checked for MAGNITUDE against the pie's
+   institutions slice (not exact reconciliation — different snapshot + dedup
+   semantics, see D2 / Codex ckpt-1 P0).

--- a/frontend/src/api/ownershipHistory.ts
+++ b/frontend/src/api/ownershipHistory.ts
@@ -1,0 +1,60 @@
+/**
+ * Fetcher + response mirror for ``GET
+ * /instruments/{symbol}/ownership-history`` (#840.F, aggregate mode
+ * #922). Mirrors ``OwnershipHistoryResponse`` /
+ * ``OwnershipHistoryPointResponse`` in ``app/api/instruments.py``
+ * field-for-field — update both sides in the same PR.
+ */
+import { apiFetch } from "@/api/client";
+
+export type OwnershipHistoryCategory =
+  | "insiders"
+  | "blockholders"
+  | "institutions"
+  | "treasury"
+  | "def14a";
+
+export interface OwnershipHistoryPoint {
+  /** ISO ``YYYY-MM-DD`` valid-time bucket end. */
+  readonly period_end: string;
+  readonly ownership_nature: string;
+  /** Decimal-as-string. */
+  readonly shares: string | null;
+  readonly source: string;
+  /** ``null`` on aggregate points — a category total has no single
+   *  accession. */
+  readonly source_accession: string | null;
+  readonly filed_at: string | null;
+  /** Filers contributing to an aggregate bucket (#922); ``null`` on
+   *  per-holder series and issuer-level treasury points. */
+  readonly holder_count: number | null;
+}
+
+export interface OwnershipHistoryResponse {
+  readonly symbol: string;
+  readonly instrument_id: number;
+  readonly category: string;
+  readonly holder_id: string | null;
+  readonly points: readonly OwnershipHistoryPoint[];
+}
+
+export interface FetchOwnershipHistoryParams {
+  readonly category: OwnershipHistoryCategory;
+  readonly holderId?: string;
+  readonly aggregate?: boolean;
+  /** Inclusive ``period_end`` lower bound, ISO ``YYYY-MM-DD``. */
+  readonly fromDate?: string;
+}
+
+export function fetchOwnershipHistory(
+  symbol: string,
+  params: FetchOwnershipHistoryParams,
+): Promise<OwnershipHistoryResponse> {
+  const qs = new URLSearchParams({ category: params.category });
+  if (params.holderId !== undefined) qs.set("holder_id", params.holderId);
+  if (params.aggregate === true) qs.set("aggregate", "true");
+  if (params.fromDate !== undefined) qs.set("from_date", params.fromDate);
+  return apiFetch<OwnershipHistoryResponse>(
+    `/instruments/${encodeURIComponent(symbol)}/ownership-history?${qs.toString()}`,
+  );
+}

--- a/frontend/src/components/instrument/OwnershipHistoryChart.test.tsx
+++ b/frontend/src/components/instrument/OwnershipHistoryChart.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Render-state tests for the ownership history pane (#922):
+ * loading / error / empty / data / partial-failure / unsupported
+ * modes, with the fetcher module mocked. Chart internals (recharts
+ * lines) are covered by the pure-series tests; here we assert the
+ * state contract per loading-error-empty-states.md.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { OwnershipHistoryResponse } from "@/api/ownershipHistory";
+
+import { OwnershipHistoryChart } from "./OwnershipHistoryChart";
+
+vi.mock("@/api/ownershipHistory", () => ({
+  fetchOwnershipHistory: vi.fn(),
+}));
+
+import { fetchOwnershipHistory } from "@/api/ownershipHistory";
+
+const fetchMock = vi.mocked(fetchOwnershipHistory);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fetchMock.mockReset();
+});
+
+function response(
+  category: string,
+  points: OwnershipHistoryResponse["points"],
+): OwnershipHistoryResponse {
+  return { symbol: "AAPL", instrument_id: 1, category, holder_id: null, points };
+}
+
+function aggPoint(period_end: string, shares: string) {
+  return {
+    period_end,
+    ownership_nature: "economic",
+    shares,
+    source: "13f",
+    source_accession: null,
+    filed_at: null,
+    holder_count: 6011,
+  };
+}
+
+function renderChart(over: Partial<Parameters<typeof OwnershipHistoryChart>[0]> = {}) {
+  return render(
+    <OwnershipHistoryChart
+      symbol="AAPL"
+      categoryFilter={null}
+      filerFilter={null}
+      filerLabel={null}
+      outstanding={14_900_000_000}
+      {...over}
+    />,
+  );
+}
+
+describe("OwnershipHistoryChart states", () => {
+  it("renders both aggregate lines' legend when fetches succeed", async () => {
+    fetchMock.mockImplementation((_s, p) =>
+      Promise.resolve(
+        p.category === "institutions"
+          ? response("institutions", [aggPoint("2025-12-31", "4645585728"), aggPoint("2026-03-31", "4818120397")])
+          : response("treasury", []),
+      ),
+    );
+    renderChart();
+    await waitFor(() => {
+      expect(screen.getByText("Institutions (13F)")).toBeInTheDocument();
+    });
+    // Treasury series empty → no legend row for it.
+    expect(screen.queryByText("Treasury")).toBeNull();
+  });
+
+  it("degrades to the surviving line + note when one aggregate fetch fails", async () => {
+    fetchMock.mockImplementation((_s, p) =>
+      p.category === "institutions"
+        ? Promise.resolve(response("institutions", [aggPoint("2026-03-31", "100")]))
+        : Promise.reject(new Error("boom")),
+    );
+    renderChart();
+    await waitFor(() => {
+      expect(screen.getByText(/Treasury failed to load/)).toBeInTheDocument();
+    });
+    expect(screen.getByText("Institutions (13F)")).toBeInTheDocument();
+  });
+
+  it("shows the error state when every fetch fails", async () => {
+    fetchMock.mockRejectedValue(new Error("boom"));
+    renderChart();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    });
+  });
+
+  it("shows the no-history empty state for an empty aggregate", async () => {
+    fetchMock.mockImplementation((_s, p) =>
+      Promise.resolve(response(p.category, [])),
+    );
+    renderChart();
+    await waitFor(() => {
+      expect(screen.getByText("No history yet")).toBeInTheDocument();
+    });
+  });
+
+  it("explains per-holder-only categories without fetching", () => {
+    renderChart({ categoryFilter: "insiders" });
+    expect(screen.getByText("Per-holder view only")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("explains the no-CIK case without fetching", () => {
+    renderChart({ categoryFilter: "insiders", filerFilter: "name:Cohen Ryan" });
+    expect(screen.getByText("No per-holder history")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches the per-holder series with the mapped holder id", async () => {
+    fetchMock.mockResolvedValue(
+      response("blockholders", [
+        {
+          period_end: "2026-03-31",
+          ownership_nature: "beneficial",
+          shares: "38347842",
+          source: "13d",
+          source_accession: "0001234500-26-000001",
+          filed_at: null,
+          holder_count: null,
+        },
+      ]),
+    );
+    renderChart({
+      categoryFilter: "blockholders",
+      filerFilter: "block:0001767470",
+      filerLabel: "Cohen Ryan",
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Cohen Ryan")).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith("AAPL", {
+      category: "blockholders",
+      holderId: "0001767470",
+      fromDate: expect.any(String) as string,
+    });
+  });
+});

--- a/frontend/src/components/instrument/OwnershipHistoryChart.tsx
+++ b/frontend/src/components/instrument/OwnershipHistoryChart.tsx
@@ -1,0 +1,335 @@
+/**
+ * Ownership history pane (#922) — trend companion to the rollup pie.
+ * The pie answers "where is the float TODAY"; this answers "where is
+ * it TRENDING".
+ *
+ * Selection-driven (spec D4): consumes the L2 page's existing
+ * ``?category=`` / ``?filer=`` params via props — no second
+ * selection mechanism. Aggregate lines exist only for institutions
+ * (13F quarterly, dedup-before-sum on the backend) and treasury
+ * (issuer-level); event-driven categories chart per-holder only.
+ *
+ * Y axis is ABSOLUTE SHARES, not percent (spec D5): a percent of
+ * TODAY's outstanding applied to old quarters misstates history
+ * (buybacks shrink the denominator). The tooltip shows the percent
+ * explicitly labelled "of current outstanding".
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { fetchOwnershipHistory } from "@/api/ownershipHistory";
+import {
+  HISTORY_WINDOWS,
+  type HistoryLine,
+  type HistoryWindow,
+  buildHistoryRows,
+  historyModeSignature,
+  linesByNature,
+  resolveHistoryMode,
+  windowFromDate,
+} from "@/components/instrument/ownershipHistorySeries";
+import { formatPct, formatShares } from "@/components/instrument/ownershipMetrics";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useChartTheme } from "@/lib/useChartTheme";
+import { useAsync } from "@/lib/useAsync";
+
+export interface OwnershipHistoryChartProps {
+  readonly symbol: string;
+  readonly categoryFilter: string | null;
+  readonly filerFilter: string | null;
+  /** Label for the selected filer (from the table rows); falls back
+   *  to the raw holder id in the line legend. */
+  readonly filerLabel: string | null;
+  /** Current shares outstanding — tooltip percent denominator,
+   *  explicitly labelled "current". */
+  readonly outstanding: number | null;
+}
+
+const AGGREGATE_LABEL: Record<"institutions" | "treasury", string> = {
+  // "(13F)" is load-bearing: this series is raw-13F-by-quarter and
+  // does NOT reconcile 1:1 with the pie's survivor-deduped slice.
+  institutions: "Institutions (13F)",
+  treasury: "Treasury",
+};
+
+interface HistoryFetchResult {
+  readonly lines: readonly HistoryLine[];
+  /** Aggregate categories whose fetch failed while a sibling
+   *  succeeded — rendered as a per-section note (spec D4). */
+  readonly failed: readonly string[];
+}
+
+export function OwnershipHistoryChart({
+  symbol,
+  categoryFilter,
+  filerFilter,
+  filerLabel,
+  outstanding,
+}: OwnershipHistoryChartProps): JSX.Element {
+  const theme = useChartTheme();
+  const [window, setWindow] = useState<HistoryWindow>("3Y");
+
+  const mode = useMemo(
+    () => resolveHistoryMode(categoryFilter, filerFilter),
+    [categoryFilter, filerFilter],
+  );
+  const modeSig = historyModeSignature(mode);
+  const fromDate = windowFromDate(window, new Date());
+
+  const state = useAsync<HistoryFetchResult>(
+    useCallback(async () => {
+      if (mode.kind === "unsupported") return { lines: [], failed: [] };
+      if (mode.kind === "holder") {
+        const resp = await fetchOwnershipHistory(symbol, {
+          category: mode.category,
+          holderId: mode.holder_id,
+          fromDate,
+        });
+        return {
+          lines: linesByNature(resp.points, filerLabel ?? mode.holder_id),
+          failed: [],
+        };
+      }
+      const settled = await Promise.allSettled(
+        mode.categories.map((c) =>
+          fetchOwnershipHistory(symbol, { category: c, aggregate: true, fromDate }),
+        ),
+      );
+      const lines: HistoryLine[] = [];
+      const failed: string[] = [];
+      settled.forEach((result, i) => {
+        const category = mode.categories[i]!;
+        if (result.status === "fulfilled") {
+          lines.push({
+            key: `agg-${category}`,
+            label: AGGREGATE_LABEL[category],
+            points: result.value.points,
+          });
+        } else {
+          console.error(`ownership-history ${category} fetch failed:`, result.reason);
+          failed.push(AGGREGATE_LABEL[category]);
+        }
+      });
+      // All requested series failing = a real error state, not an
+      // empty chart.
+      if (lines.length === 0 && failed.length > 0) {
+        throw new Error("all ownership-history fetches failed");
+      }
+      return { lines, failed };
+      // ``modeSig`` stands in for ``mode`` in the deps — it encodes
+      // the full fetch plan as a stable string.
+    }, [symbol, modeSig, fromDate, filerLabel]),
+    [symbol, modeSig, fromDate, filerLabel],
+  );
+
+  return (
+    <section className="mt-6 rounded border border-slate-200 p-4 dark:border-slate-800">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+          Ownership history
+        </h2>
+        <div className="flex gap-1" role="group" aria-label="History window">
+          {HISTORY_WINDOWS.map((w) => (
+            <button
+              key={w}
+              type="button"
+              onClick={() => setWindow(w)}
+              className={`rounded border px-2 py-0.5 text-xs ${
+                w === window
+                  ? "border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-900/30 dark:text-blue-300"
+                  : "border-slate-300 text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+              }`}
+            >
+              {w === "ALL" ? "All" : w}
+            </button>
+          ))}
+        </div>
+      </div>
+      <HistoryBody
+        mode={mode}
+        state={state}
+        outstanding={outstanding}
+        gridLine={theme.gridLine}
+        textMuted={theme.textMuted}
+        accents={theme.accent}
+      />
+    </section>
+  );
+}
+
+interface HistoryBodyProps {
+  readonly mode: ReturnType<typeof resolveHistoryMode>;
+  readonly state: ReturnType<typeof useAsync<HistoryFetchResult>>;
+  readonly outstanding: number | null;
+  readonly gridLine: string;
+  readonly textMuted: string;
+  readonly accents: readonly string[];
+}
+
+function HistoryBody({
+  mode,
+  state,
+  outstanding,
+  gridLine,
+  textMuted,
+  accents,
+}: HistoryBodyProps): JSX.Element {
+  if (mode.kind === "unsupported") {
+    if (mode.reason === "no_cik") {
+      return (
+        <EmptyState
+          title="No per-holder history"
+          description="This holder has no resolved CIK, so no filing series can be queried. Pick a holder with a CIK from the table."
+        />
+      );
+    }
+    return (
+      <EmptyState
+        title="Per-holder view only"
+        description={
+          mode.reason === "etfs"
+            ? "ETF filers are part of the 13F institutions line (no per-type split in the observations yet). Click a holder row to chart one filer."
+            : "Insider and blockholder filings are event-driven — only a per-holder series is honest. Click a holder row to chart one filer."
+        }
+      />
+    );
+  }
+  if (state.loading) return <SectionSkeleton rows={6} />;
+  if (state.error !== null || state.data === null) {
+    return <SectionError onRetry={state.refetch} />;
+  }
+
+  const { rows, lines } = buildHistoryRows(state.data.lines);
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title="No history yet"
+        description="Ownership history appears after the 13F / XBRL backfill drains for this instrument."
+      />
+    );
+  }
+
+  return (
+    <div>
+      {state.data.failed.length > 0 && (
+        <p className="mb-2 text-xs text-amber-700 dark:text-amber-400">
+          {state.data.failed.join(", ")} failed to load — showing the rest.
+        </p>
+      )}
+      <div style={{ width: "100%", height: 280 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={[...rows]} margin={{ top: 8, right: 16, bottom: 4, left: 8 }}>
+            <CartesianGrid stroke={gridLine} strokeDasharray="3 3" />
+            <XAxis
+              dataKey="period_end"
+              tick={{ fontSize: 11, fill: textMuted }}
+              tickFormatter={formatPeriodTick}
+            />
+            <YAxis
+              tick={{ fontSize: 11, fill: textMuted }}
+              tickFormatter={formatSharesTick}
+              width={56}
+            />
+            <Tooltip
+              content={
+                <HistoryTooltip
+                  outstanding={outstanding}
+                  points={state.data.lines}
+                />
+              }
+            />
+            {lines.map((l, i) => (
+              <Line
+                key={l.key}
+                dataKey={l.key}
+                name={l.label}
+                type="monotone"
+                stroke={accents[i % accents.length]}
+                dot={{ r: 2 }}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        {lines.map((l, i) => (
+          <li key={l.key} className="flex items-center gap-1.5">
+            <span
+              aria-hidden
+              className="inline-block h-0.5 w-4"
+              style={{ backgroundColor: accents[i % accents.length] }}
+            />
+            <span className="text-slate-700 dark:text-slate-200">{l.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** ``2026-03-31`` → ``Q1 '26`` (13F buckets are quarter ends; other
+ *  sources still read sensibly as month-year). */
+function formatPeriodTick(period_end: string): string {
+  const y = period_end.slice(2, 4);
+  const m = Number(period_end.slice(5, 7));
+  if (m === 3) return `Q1 '${y}`;
+  if (m === 6) return `Q2 '${y}`;
+  if (m === 9) return `Q3 '${y}`;
+  if (m === 12) return `Q4 '${y}`;
+  return `${period_end.slice(5, 7)}/${y}`;
+}
+
+function formatSharesTick(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
+  return String(n);
+}
+
+interface HistoryTooltipProps {
+  readonly active?: boolean;
+  readonly label?: string;
+  readonly payload?: readonly {
+    readonly dataKey?: string | number;
+    readonly name?: string | number;
+    readonly value?: number | string;
+  }[];
+  readonly outstanding: number | null;
+  readonly points: readonly HistoryLine[];
+}
+
+function HistoryTooltip(props: HistoryTooltipProps): JSX.Element | null {
+  if (!props.active || props.payload === undefined || props.payload.length === 0) return null;
+  const period = props.label ?? "";
+  return (
+    <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
+      <div className="font-medium text-slate-900 dark:text-slate-100">{period}</div>
+      {props.payload.map((entry) => {
+        const shares = typeof entry.value === "number" ? entry.value : null;
+        const line = props.points.find((l) => l.key === entry.dataKey);
+        const point = line?.points.find((p) => p.period_end === period);
+        return (
+          <div key={String(entry.dataKey)} className="text-slate-600 dark:text-slate-400">
+            {String(entry.name)}: {formatShares(shares)}
+            {props.outstanding !== null && shares !== null && props.outstanding > 0 && (
+              <> · {formatPct(shares / props.outstanding)} of current outstanding</>
+            )}
+            {point?.holder_count != null && <> · {point.holder_count} filers</>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/OwnershipHistoryChart.tsx
+++ b/frontend/src/components/instrument/OwnershipHistoryChart.tsx
@@ -77,14 +77,21 @@ export function OwnershipHistoryChart({
   outstanding,
 }: OwnershipHistoryChartProps): JSX.Element {
   const theme = useChartTheme();
-  const [window, setWindow] = useState<HistoryWindow>("3Y");
+  const [historyWindow, setHistoryWindow] = useState<HistoryWindow>("3Y");
 
   const mode = useMemo(
     () => resolveHistoryMode(categoryFilter, filerFilter),
     [categoryFilter, filerFilter],
   );
   const modeSig = historyModeSignature(mode);
-  const fromDate = windowFromDate(window, new Date());
+  // Memoized so the date string is computed once per window change,
+  // not per render (review WARNING on PR #1586; the value is a
+  // primitive so deps were already value-stable, but the memo makes
+  // the stability explicit instead of incidental).
+  const fromDate = useMemo(
+    () => windowFromDate(historyWindow, new Date()),
+    [historyWindow],
+  );
 
   const state = useAsync<HistoryFetchResult>(
     useCallback(async () => {
@@ -143,9 +150,9 @@ export function OwnershipHistoryChart({
             <button
               key={w}
               type="button"
-              onClick={() => setWindow(w)}
+              onClick={() => setHistoryWindow(w)}
               className={`rounded border px-2 py-0.5 text-xs ${
-                w === window
+                w === historyWindow
                   ? "border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-900/30 dark:text-blue-300"
                   : "border-slate-300 text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
               }`}

--- a/frontend/src/components/instrument/OwnershipHistoryChart.tsx
+++ b/frontend/src/components/instrument/OwnershipHistoryChart.tsx
@@ -210,22 +210,30 @@ function HistoryBody({
   }
 
   const { rows, lines } = buildHistoryRows(state.data.lines);
+  // The partial-failure note must survive the empty branch — an empty
+  // surviving series + a hidden failure would read as a clean empty
+  // dataset (Codex ckpt-2 S3).
+  const failedNote =
+    state.data.failed.length > 0 ? (
+      <p className="mb-2 text-xs text-amber-700 dark:text-amber-400">
+        {state.data.failed.join(", ")} failed to load — showing the rest.
+      </p>
+    ) : null;
   if (rows.length === 0) {
     return (
-      <EmptyState
-        title="No history yet"
-        description="Ownership history appears after the 13F / XBRL backfill drains for this instrument."
-      />
+      <div>
+        {failedNote}
+        <EmptyState
+          title="No history yet"
+          description="Ownership history appears after the 13F / XBRL backfill drains for this instrument."
+        />
+      </div>
     );
   }
 
   return (
     <div>
-      {state.data.failed.length > 0 && (
-        <p className="mb-2 text-xs text-amber-700 dark:text-amber-400">
-          {state.data.failed.join(", ")} failed to load — showing the rest.
-        </p>
-      )}
+      {failedNote}
       <div style={{ width: "100%", height: 280 }}>
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={[...rows]} margin={{ top: 8, right: 16, bottom: 4, left: 8 }}>

--- a/frontend/src/components/instrument/ownershipHistorySeries.test.ts
+++ b/frontend/src/components/instrument/ownershipHistorySeries.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Pure-helper tests for the ownership history pane (#922): mode
+ * resolution, filer-key → holder_id mapping, window arithmetic, and
+ * row building.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { OwnershipHistoryPoint } from "@/api/ownershipHistory";
+
+import {
+  buildHistoryRows,
+  holderIdFromFilerKey,
+  linesByNature,
+  resolveHistoryMode,
+  windowFromDate,
+} from "./ownershipHistorySeries";
+
+function point(overrides: Partial<OwnershipHistoryPoint>): OwnershipHistoryPoint {
+  return {
+    period_end: "2026-03-31",
+    ownership_nature: "economic",
+    shares: "100",
+    source: "13f",
+    source_accession: null,
+    filed_at: null,
+    holder_count: null,
+    ...overrides,
+  };
+}
+
+describe("windowFromDate", () => {
+  const now = new Date(Date.UTC(2026, 5, 11)); // 2026-06-11
+  it("subtracts whole years", () => {
+    expect(windowFromDate("1Y", now)).toBe("2025-06-11");
+    expect(windowFromDate("3Y", now)).toBe("2023-06-11");
+    expect(windowFromDate("5Y", now)).toBe("2021-06-11");
+  });
+  it("ALL has no bound", () => {
+    expect(windowFromDate("ALL", now)).toBeUndefined();
+  });
+});
+
+describe("holderIdFromFilerKey", () => {
+  it("maps per-category key shapes to a CIK", () => {
+    expect(holderIdFromFilerKey("0000102909")).toBe("0000102909");
+    expect(holderIdFromFilerKey("block:0001767470")).toBe("0001767470");
+    expect(holderIdFromFilerKey("baseline:0001214156:d")).toBe("0001214156");
+    expect(holderIdFromFilerKey("baseline:0001214156:n")).toBe("0001214156");
+  });
+  it("rejects name fallbacks anywhere", () => {
+    expect(holderIdFromFilerKey("name:Cohen Ryan")).toBeNull();
+    expect(holderIdFromFilerKey("block:name:Icahn Carl")).toBeNull();
+    expect(holderIdFromFilerKey("")).toBeNull();
+  });
+});
+
+describe("resolveHistoryMode", () => {
+  it("defaults to the institutions + treasury aggregate", () => {
+    expect(resolveHistoryMode(null, null)).toEqual({
+      kind: "aggregate",
+      categories: ["institutions", "treasury"],
+    });
+    // ?filer= without ?category= is ambiguous — filer ignored.
+    expect(resolveHistoryMode(null, "0000102909")).toEqual({
+      kind: "aggregate",
+      categories: ["institutions", "treasury"],
+    });
+  });
+
+  it("scopes the aggregate to a selected aggregable category", () => {
+    expect(resolveHistoryMode("institutions", null)).toEqual({
+      kind: "aggregate",
+      categories: ["institutions"],
+    });
+    expect(resolveHistoryMode("treasury", null)).toEqual({
+      kind: "aggregate",
+      categories: ["treasury"],
+    });
+    // Treasury is issuer-level — filer selection cannot re-scope it.
+    expect(resolveHistoryMode("treasury", "whatever")).toEqual({
+      kind: "aggregate",
+      categories: ["treasury"],
+    });
+  });
+
+  it("marks event-driven and etf categories unsupported without a filer", () => {
+    expect(resolveHistoryMode("insiders", null)).toEqual({
+      kind: "unsupported",
+      reason: "event_driven",
+    });
+    expect(resolveHistoryMode("blockholders", null)).toEqual({
+      kind: "unsupported",
+      reason: "event_driven",
+    });
+    expect(resolveHistoryMode("etfs", null)).toEqual({
+      kind: "unsupported",
+      reason: "etfs",
+    });
+  });
+
+  it("resolves per-holder modes, drilling etfs through institutions", () => {
+    expect(resolveHistoryMode("insiders", "0001767470")).toEqual({
+      kind: "holder",
+      category: "insiders",
+      holder_id: "0001767470",
+    });
+    expect(resolveHistoryMode("blockholders", "block:0001767470")).toEqual({
+      kind: "holder",
+      category: "blockholders",
+      holder_id: "0001767470",
+    });
+    expect(resolveHistoryMode("etfs", "0000036405")).toEqual({
+      kind: "holder",
+      category: "institutions",
+      holder_id: "0000036405",
+    });
+  });
+
+  it("flags no-CIK holders", () => {
+    expect(resolveHistoryMode("insiders", "name:Cohen Ryan")).toEqual({
+      kind: "unsupported",
+      reason: "no_cik",
+    });
+  });
+});
+
+describe("linesByNature", () => {
+  it("splits natures into separate lines, never summing", () => {
+    const lines = linesByNature(
+      [
+        point({ ownership_nature: "direct", shares: "100" }),
+        point({ ownership_nature: "indirect", shares: "50" }),
+        point({ ownership_nature: "direct", shares: "120", period_end: "2026-06-30" }),
+      ],
+      "Cohen Ryan",
+    );
+    expect(lines).toHaveLength(2);
+    const direct = lines.find((l) => l.key === "nature-direct");
+    expect(direct?.label).toBe("Cohen Ryan (direct)");
+    expect(direct?.points).toHaveLength(2);
+  });
+
+  it("omits the nature suffix for single-nature holders", () => {
+    const lines = linesByNature([point({})], "Vanguard");
+    expect(lines[0]?.label).toBe("Vanguard");
+  });
+});
+
+describe("buildHistoryRows", () => {
+  it("joins lines on period_end ascending, leaving gaps absent", () => {
+    const { rows, lines } = buildHistoryRows([
+      {
+        key: "a",
+        label: "A",
+        points: [
+          point({ period_end: "2026-03-31", shares: "10" }),
+          point({ period_end: "2025-12-31", shares: "8" }),
+        ],
+      },
+      { key: "b", label: "B", points: [point({ period_end: "2026-03-31", shares: "5" })] },
+    ]);
+    expect(rows).toEqual([
+      { period_end: "2025-12-31", a: 8 },
+      { period_end: "2026-03-31", a: 10, b: 5 },
+    ]);
+    expect(lines.map((l) => l.key)).toEqual(["a", "b"]);
+  });
+
+  it("drops lines with no parseable points from the legend", () => {
+    const { lines } = buildHistoryRows([
+      { key: "a", label: "A", points: [point({ shares: null })] },
+      { key: "b", label: "B", points: [point({ shares: "5" })] },
+    ]);
+    expect(lines.map((l) => l.key)).toEqual(["b"]);
+  });
+});

--- a/frontend/src/components/instrument/ownershipHistorySeries.test.ts
+++ b/frontend/src/components/instrument/ownershipHistorySeries.test.ts
@@ -123,6 +123,26 @@ describe("resolveHistoryMode", () => {
       reason: "no_cik",
     });
   });
+
+  it("treats unknown/typo categories as no selection, never institutions (Codex ckpt-2 S2)", () => {
+    expect(resolveHistoryMode("garbage", "0000102909")).toEqual({
+      kind: "aggregate",
+      categories: ["institutions", "treasury"],
+    });
+    expect(resolveHistoryMode("garbage", null)).toEqual({
+      kind: "aggregate",
+      categories: ["institutions", "treasury"],
+    });
+    // def14a is event-driven AND name-keyed — never drillable.
+    expect(resolveHistoryMode("def14a", "0000102909")).toEqual({
+      kind: "unsupported",
+      reason: "event_driven",
+    });
+    expect(resolveHistoryMode("def14a", null)).toEqual({
+      kind: "unsupported",
+      reason: "event_driven",
+    });
+  });
 });
 
 describe("linesByNature", () => {

--- a/frontend/src/components/instrument/ownershipHistorySeries.ts
+++ b/frontend/src/components/instrument/ownershipHistorySeries.ts
@@ -1,0 +1,167 @@
+/**
+ * Pure helpers for the ownership history pane (#922): selection →
+ * fetch-mode resolution, filer-key → holder_id mapping, time-window
+ * arithmetic, and point-list → recharts-row building. No fetching,
+ * no React — everything here is table-testable.
+ *
+ * Mode semantics (spec
+ * ``docs/specs/ui/2026-06-11-ownership-history-pane.md`` D4):
+ * aggregate series exist only for ``institutions`` (13F is quarterly
+ * by construction) and ``treasury`` (issuer-level). Event-driven
+ * categories (insiders / blockholders / def14a) chart per-holder
+ * only — a per-period sum would count just the holders who happened
+ * to file that period.
+ */
+
+import type {
+  OwnershipHistoryCategory,
+  OwnershipHistoryPoint,
+} from "@/api/ownershipHistory";
+import { parseShareCount } from "@/components/instrument/ownershipMetrics";
+
+export type HistoryWindow = "1Y" | "3Y" | "5Y" | "ALL";
+
+export const HISTORY_WINDOWS: readonly HistoryWindow[] = ["1Y", "3Y", "5Y", "ALL"];
+
+/** Inclusive ``from_date`` for a window, ISO date; undefined = no bound. */
+export function windowFromDate(window: HistoryWindow, now: Date): string | undefined {
+  if (window === "ALL") return undefined;
+  const years = window === "1Y" ? 1 : window === "3Y" ? 3 : 5;
+  const d = new Date(Date.UTC(now.getUTCFullYear() - years, now.getUTCMonth(), now.getUTCDate()));
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Map a chart/table filer key to the history endpoint's ``holder_id``
+ * (#922). Key shapes are per-category (verified against the
+ * builders in OwnershipPage / rollupToSunburstInputs):
+ *
+ *   institutions / etfs : raw ``filer_cik``
+ *   insiders (Form 4)   : ``cik`` or ``name:{name}``
+ *   insiders (baseline) : ``baseline:{cik}:d|n``
+ *   blockholders        : ``block:{cik|name:…}``
+ *
+ * ``name:`` fallbacks have no CIK → ``null`` (caller renders the
+ * no-CIK empty state).
+ */
+export function holderIdFromFilerKey(key: string): string | null {
+  let raw = key;
+  if (raw.startsWith("block:")) {
+    raw = raw.slice("block:".length);
+  } else if (raw.startsWith("baseline:")) {
+    raw = raw.split(":")[1] ?? "";
+  }
+  return /^\d+$/.test(raw) ? raw : null;
+}
+
+export type HistoryMode =
+  | { readonly kind: "aggregate"; readonly categories: readonly ("institutions" | "treasury")[] }
+  | {
+      readonly kind: "holder";
+      readonly category: OwnershipHistoryCategory;
+      readonly holder_id: string;
+    }
+  | { readonly kind: "unsupported"; readonly reason: "event_driven" | "etfs" | "no_cik" };
+
+/**
+ * Resolve the L2 page's ``?category=`` / ``?filer=`` selection into a
+ * fetch plan. ``?filer=`` without ``?category=`` falls back to the
+ * aggregate default (a filer key alone is ambiguous across
+ * categories). ``etfs`` drills through ``institutions`` — ETF leaves
+ * are 13F filers in the same observations table.
+ */
+export function resolveHistoryMode(
+  categoryFilter: string | null,
+  filerFilter: string | null,
+): HistoryMode {
+  if (filerFilter === null || categoryFilter === null) {
+    if (categoryFilter === null) return { kind: "aggregate", categories: ["institutions", "treasury"] };
+    if (categoryFilter === "institutions") return { kind: "aggregate", categories: ["institutions"] };
+    if (categoryFilter === "treasury") return { kind: "aggregate", categories: ["treasury"] };
+    if (categoryFilter === "etfs") return { kind: "unsupported", reason: "etfs" };
+    return { kind: "unsupported", reason: "event_driven" };
+  }
+  // Treasury is issuer-level — a filer selection cannot re-scope it.
+  if (categoryFilter === "treasury") return { kind: "aggregate", categories: ["treasury"] };
+  const holder_id = holderIdFromFilerKey(filerFilter);
+  if (holder_id === null) return { kind: "unsupported", reason: "no_cik" };
+  const category: OwnershipHistoryCategory =
+    categoryFilter === "etfs"
+      ? "institutions"
+      : categoryFilter === "insiders"
+        ? "insiders"
+        : categoryFilter === "blockholders"
+          ? "blockholders"
+          : "institutions";
+  return { kind: "holder", category, holder_id };
+}
+
+/** Stable signature for useAsync deps — modes are plain objects. */
+export function historyModeSignature(mode: HistoryMode): string {
+  if (mode.kind === "aggregate") return `agg:${mode.categories.join("+")}`;
+  if (mode.kind === "holder") return `holder:${mode.category}:${mode.holder_id}`;
+  return `unsupported:${mode.reason}`;
+}
+
+export interface HistoryLine {
+  /** recharts dataKey — unique per line. */
+  readonly key: string;
+  readonly label: string;
+  readonly points: readonly OwnershipHistoryPoint[];
+}
+
+export interface HistoryRows {
+  /** One row per distinct period_end, ascending; per-line values
+   *  keyed by line key, missing periods absent (recharts leaves a
+   *  gap — connectNulls stays false). */
+  readonly rows: ReadonlyArray<Record<string, number | string>>;
+  readonly lines: ReadonlyArray<{ readonly key: string; readonly label: string }>;
+}
+
+/** Join lines on period_end into recharts rows. */
+export function buildHistoryRows(lines: readonly HistoryLine[]): HistoryRows {
+  const byPeriod = new Map<string, Record<string, number | string>>();
+  for (const line of lines) {
+    for (const p of line.points) {
+      const shares = parseShareCount(p.shares);
+      if (shares === null) continue;
+      let row = byPeriod.get(p.period_end);
+      if (row === undefined) {
+        row = { period_end: p.period_end };
+        byPeriod.set(p.period_end, row);
+      }
+      row[line.key] = shares;
+    }
+  }
+  const rows = [...byPeriod.values()].sort((a, b) =>
+    String(a["period_end"]) < String(b["period_end"]) ? -1 : 1,
+  );
+  return {
+    rows,
+    lines: lines
+      .filter((l) => l.points.some((p) => parseShareCount(p.shares) !== null))
+      .map((l) => ({ key: l.key, label: l.label })),
+  };
+}
+
+/**
+ * Split a per-holder point list into one line per ownership_nature
+ * (service contract: beneficial and direct are distinct series —
+ * never summed).
+ */
+export function linesByNature(
+  points: readonly OwnershipHistoryPoint[],
+  holderLabel: string,
+): HistoryLine[] {
+  const natures = new Map<string, OwnershipHistoryPoint[]>();
+  for (const p of points) {
+    const bucket = natures.get(p.ownership_nature);
+    if (bucket === undefined) natures.set(p.ownership_nature, [p]);
+    else bucket.push(p);
+  }
+  return [...natures.entries()].map(([nature, pts]) => ({
+    key: `nature-${nature}`,
+    label: natures.size > 1 ? `${holderLabel} (${nature})` : holderLabel,
+    points: pts,
+  }));
+}

--- a/frontend/src/components/instrument/ownershipHistorySeries.ts
+++ b/frontend/src/components/instrument/ownershipHistorySeries.ts
@@ -70,30 +70,51 @@ export type HistoryMode =
  * categories). ``etfs`` drills through ``institutions`` — ETF leaves
  * are 13F filers in the same observations table.
  */
+const _EVENT_DRIVEN_CATEGORIES = new Set(["insiders", "blockholders", "def14a"]);
+
+/** Filer-scoped categories the chart can drill: chart category →
+ *  endpoint category. ``etfs`` drills through ``institutions`` (ETF
+ *  leaves are 13F filers in the same table). ``def14a`` is absent on
+ *  purpose — its endpoint holder_id is a holder NAME key, and every
+ *  FE def14a row carries a ``name:`` fallback key anyway. */
+const _DRILLABLE: Record<string, OwnershipHistoryCategory> = {
+  institutions: "institutions",
+  etfs: "institutions",
+  insiders: "insiders",
+  blockholders: "blockholders",
+};
+
 export function resolveHistoryMode(
   categoryFilter: string | null,
   filerFilter: string | null,
 ): HistoryMode {
-  if (filerFilter === null || categoryFilter === null) {
-    if (categoryFilter === null) return { kind: "aggregate", categories: ["institutions", "treasury"] };
-    if (categoryFilter === "institutions") return { kind: "aggregate", categories: ["institutions"] };
-    if (categoryFilter === "treasury") return { kind: "aggregate", categories: ["treasury"] };
-    if (categoryFilter === "etfs") return { kind: "unsupported", reason: "etfs" };
+  // Unknown / typo categories are treated as NO selection — falling
+  // through to a plausible-but-wrong institutions chart would
+  // mislead (Codex ckpt-2 S2).
+  const known =
+    categoryFilter !== null &&
+    (categoryFilter in _DRILLABLE ||
+      categoryFilter === "treasury" ||
+      _EVENT_DRIVEN_CATEGORIES.has(categoryFilter));
+  const category = known ? categoryFilter : null;
+
+  if (filerFilter === null || category === null) {
+    if (category === null) return { kind: "aggregate", categories: ["institutions", "treasury"] };
+    if (category === "institutions") return { kind: "aggregate", categories: ["institutions"] };
+    if (category === "treasury") return { kind: "aggregate", categories: ["treasury"] };
+    if (category === "etfs") return { kind: "unsupported", reason: "etfs" };
     return { kind: "unsupported", reason: "event_driven" };
   }
   // Treasury is issuer-level — a filer selection cannot re-scope it.
-  if (categoryFilter === "treasury") return { kind: "aggregate", categories: ["treasury"] };
+  if (category === "treasury") return { kind: "aggregate", categories: ["treasury"] };
+  const endpoint_category = _DRILLABLE[category];
+  if (endpoint_category === undefined) {
+    // def14a: drillable neither by CIK nor (in the FE) by name.
+    return { kind: "unsupported", reason: "event_driven" };
+  }
   const holder_id = holderIdFromFilerKey(filerFilter);
   if (holder_id === null) return { kind: "unsupported", reason: "no_cik" };
-  const category: OwnershipHistoryCategory =
-    categoryFilter === "etfs"
-      ? "institutions"
-      : categoryFilter === "insiders"
-        ? "insiders"
-        : categoryFilter === "blockholders"
-          ? "blockholders"
-          : "institutions";
-  return { kind: "holder", category, holder_id };
+  return { kind: "holder", category: endpoint_category, holder_id };
 }
 
 /** Stable signature for useAsync deps — modes are plain objects. */

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -40,6 +40,7 @@ import {
   isBaselineHoldingRow,
   isInsiderHoldingRow,
 } from "@/components/instrument/ownershipInsiders";
+import { OwnershipHistoryChart } from "@/components/instrument/OwnershipHistoryChart";
 import {
   OwnershipLegend,
   OwnershipSunburst,
@@ -550,6 +551,21 @@ function OwnershipBody({
           highlightFiler={filerFilter}
           highlightRef={filerRowRef}
           onClearHighlight={onClearFiler}
+        />
+      </div>
+      {/* History pane (#922) — trend companion to the pie. Reads the
+          same ?category=/?filer= selection the pie + table use. */}
+      <div className="col-span-12">
+        <OwnershipHistoryChart
+          symbol={symbol}
+          categoryFilter={categoryFilter}
+          filerFilter={filerFilter}
+          filerLabel={
+            filerFilter !== null
+              ? (allRows.find((r) => r.key === filerFilter)?.label ?? null)
+              : null
+          }
+          outstanding={outstanding}
         />
       </div>
     </div>

--- a/tests/test_ownership_history.py
+++ b/tests/test_ownership_history.py
@@ -21,6 +21,7 @@ from app.services.ownership_history import (
     iter_categories,
 )
 from app.services.ownership_observations import (
+    OwnershipNature,
     record_blockholder_observation,
     record_def14a_observation,
     record_insider_observation,
@@ -496,7 +497,7 @@ class TestInstitutionsAggregate:
         accession: str,
         filed_at: datetime,
         shares: Decimal,
-        nature: str = "economic",
+        nature: OwnershipNature = "economic",
     ) -> None:
         record_institution_observation(
             conn,
@@ -531,29 +532,39 @@ class TestInstitutionsAggregate:
         q = date(2026, 3, 31)
         # Filer A: original then amendment (later filed_at wins).
         self._seed_13f(
-            conn, iid=843_600, filer_cik="0000000001", q_end=q,
-            doc_id="A-orig", accession="0001234599-26-000001",
+            conn,
+            iid=843_600,
+            filer_cik="0000000001",
+            q_end=q,
+            doc_id="A-orig",
+            accession="0001234599-26-000001",
             filed_at=datetime(2026, 5, 1, tzinfo=UTC),
             shares=Decimal("1000000"),
         )
         self._seed_13f(
-            conn, iid=843_600, filer_cik="0000000001", q_end=q,
-            doc_id="A-amend", accession="0001234599-26-000002",
+            conn,
+            iid=843_600,
+            filer_cik="0000000001",
+            q_end=q,
+            doc_id="A-amend",
+            accession="0001234599-26-000002",
             filed_at=datetime(2026, 5, 20, tzinfo=UTC),
             shares=Decimal("1200000"),
         )
         # Filer B: single filing.
         self._seed_13f(
-            conn, iid=843_600, filer_cik="0000000002", q_end=q,
-            doc_id="B-orig", accession="0001234599-26-000003",
+            conn,
+            iid=843_600,
+            filer_cik="0000000002",
+            q_end=q,
+            doc_id="B-orig",
+            accession="0001234599-26-000003",
             filed_at=datetime(2026, 5, 2, tzinfo=UTC),
             shares=Decimal("500000"),
         )
         conn.commit()
 
-        points = get_ownership_category_totals(
-            conn, instrument_id=843_600, category="institutions"
-        )
+        points = get_ownership_category_totals(conn, instrument_id=843_600, category="institutions")
         assert len(points) == 1
         p = points[0]
         # Amendment replaced the original: 1.2M + 0.5M, NOT 1M + 1.2M + 0.5M.
@@ -577,22 +588,29 @@ class TestInstitutionsAggregate:
         conn.commit()
         q = date(2026, 3, 31)
         self._seed_13f(
-            conn, iid=843_601, filer_cik="0000000003", q_end=q,
-            doc_id="C-econ", accession="0001234599-26-000004",
+            conn,
+            iid=843_601,
+            filer_cik="0000000003",
+            q_end=q,
+            doc_id="C-econ",
+            accession="0001234599-26-000004",
             filed_at=datetime(2026, 5, 1, tzinfo=UTC),
             shares=Decimal("100"),
         )
         self._seed_13f(
-            conn, iid=843_601, filer_cik="0000000003", q_end=q,
-            doc_id="C-voting", accession="0001234599-26-000005",
+            conn,
+            iid=843_601,
+            filer_cik="0000000003",
+            q_end=q,
+            doc_id="C-voting",
+            accession="0001234599-26-000005",
             filed_at=datetime(2026, 5, 1, tzinfo=UTC),
-            shares=Decimal("999"), nature="voting",
+            shares=Decimal("999"),
+            nature="voting",
         )
         conn.commit()
 
-        points = get_ownership_category_totals(
-            conn, instrument_id=843_601, category="institutions"
-        )
+        points = get_ownership_category_totals(conn, instrument_id=843_601, category="institutions")
         assert len(points) == 1
         assert points[0].shares == Decimal("100")
 
@@ -603,9 +621,7 @@ class TestInstitutionsAggregate:
         from app.services.ownership_history import get_ownership_category_totals
 
         with pytest.raises(ValueError, match="no honest aggregate"):
-            get_ownership_category_totals(
-                ebull_test_conn, instrument_id=843_600, category="insiders"
-            )
+            get_ownership_category_totals(ebull_test_conn, instrument_id=843_600, category="insiders")
 
     def test_treasury_aggregate_keeps_issuer_provenance(
         self,
@@ -634,9 +650,7 @@ class TestInstitutionsAggregate:
         )
         conn.commit()
 
-        points = get_ownership_category_totals(
-            conn, instrument_id=843_602, category="treasury"
-        )
+        points = get_ownership_category_totals(conn, instrument_id=843_602, category="treasury")
         assert len(points) == 1
         assert points[0].source == "xbrl_dei"
         assert points[0].source_accession == "0000000000-26-000001"

--- a/tests/test_ownership_history.py
+++ b/tests/test_ownership_history.py
@@ -473,3 +473,171 @@ class TestUnknownCategory:
     def test_iter_categories_covers_every_path(self) -> None:
         cats = list(iter_categories())
         assert set(cats) == {"insiders", "blockholders", "institutions", "treasury", "def14a"}
+
+
+# ---------------------------------------------------------------------------
+# Aggregate mode (#922)
+# ---------------------------------------------------------------------------
+
+
+class TestInstitutionsAggregate:
+    """Category-total series (#922). The load-bearing invariant is
+    dedup-BEFORE-sum: an amendment (second accession, same filer ×
+    quarter) must replace, not add."""
+
+    def _seed_13f(
+        self,
+        conn: psycopg.Connection[tuple],
+        *,
+        iid: int,
+        filer_cik: str,
+        q_end: date,
+        doc_id: str,
+        accession: str,
+        filed_at: datetime,
+        shares: Decimal,
+        nature: str = "economic",
+    ) -> None:
+        record_institution_observation(
+            conn,
+            instrument_id=iid,
+            filer_cik=filer_cik,
+            filer_name=f"Filer {filer_cik}",
+            filer_type="INV",
+            ownership_nature=nature,
+            source="13f",
+            source_document_id=doc_id,
+            source_accession=accession,
+            source_field=None,
+            source_url=None,
+            filed_at=filed_at,
+            period_start=None,
+            period_end=q_end,
+            ingest_run_id=uuid4(),
+            shares=shares,
+            market_value_usd=None,
+            voting_authority="SOLE",
+        )
+
+    def test_amendment_dedups_before_sum(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.ownership_history import get_ownership_category_totals
+
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=843_600, symbol="AGGTEST")
+        conn.commit()
+        q = date(2026, 3, 31)
+        # Filer A: original then amendment (later filed_at wins).
+        self._seed_13f(
+            conn, iid=843_600, filer_cik="0000000001", q_end=q,
+            doc_id="A-orig", accession="0001234599-26-000001",
+            filed_at=datetime(2026, 5, 1, tzinfo=UTC),
+            shares=Decimal("1000000"),
+        )
+        self._seed_13f(
+            conn, iid=843_600, filer_cik="0000000001", q_end=q,
+            doc_id="A-amend", accession="0001234599-26-000002",
+            filed_at=datetime(2026, 5, 20, tzinfo=UTC),
+            shares=Decimal("1200000"),
+        )
+        # Filer B: single filing.
+        self._seed_13f(
+            conn, iid=843_600, filer_cik="0000000002", q_end=q,
+            doc_id="B-orig", accession="0001234599-26-000003",
+            filed_at=datetime(2026, 5, 2, tzinfo=UTC),
+            shares=Decimal("500000"),
+        )
+        conn.commit()
+
+        points = get_ownership_category_totals(
+            conn, instrument_id=843_600, category="institutions"
+        )
+        assert len(points) == 1
+        p = points[0]
+        # Amendment replaced the original: 1.2M + 0.5M, NOT 1M + 1.2M + 0.5M.
+        assert p.shares == Decimal("1700000")
+        assert p.holder_count == 2
+        assert p.ownership_nature == "economic"
+        assert p.source == "13f"
+        # An aggregate has no single accession.
+        assert p.source_accession is None
+
+    def test_non_economic_nature_excluded_not_summed(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """A hypothetical second nature must be EXCLUDED (filtered),
+        never silently folded into the "economic" total (spec D2)."""
+        from app.services.ownership_history import get_ownership_category_totals
+
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=843_601, symbol="NATTEST")
+        conn.commit()
+        q = date(2026, 3, 31)
+        self._seed_13f(
+            conn, iid=843_601, filer_cik="0000000003", q_end=q,
+            doc_id="C-econ", accession="0001234599-26-000004",
+            filed_at=datetime(2026, 5, 1, tzinfo=UTC),
+            shares=Decimal("100"),
+        )
+        self._seed_13f(
+            conn, iid=843_601, filer_cik="0000000003", q_end=q,
+            doc_id="C-voting", accession="0001234599-26-000005",
+            filed_at=datetime(2026, 5, 1, tzinfo=UTC),
+            shares=Decimal("999"), nature="voting",
+        )
+        conn.commit()
+
+        points = get_ownership_category_totals(
+            conn, instrument_id=843_601, category="institutions"
+        )
+        assert len(points) == 1
+        assert points[0].shares == Decimal("100")
+
+    def test_event_driven_category_raises(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.ownership_history import get_ownership_category_totals
+
+        with pytest.raises(ValueError, match="no honest aggregate"):
+            get_ownership_category_totals(
+                ebull_test_conn, instrument_id=843_600, category="insiders"
+            )
+
+    def test_treasury_aggregate_keeps_issuer_provenance(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Treasury aggregate IS the existing issuer series — XBRL
+        source/accession untouched, holder_count None (spec D3)."""
+        from app.services.ownership_history import get_ownership_category_totals
+
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=843_602, symbol="TRAGG")
+        conn.commit()
+        record_treasury_observation(
+            conn,
+            instrument_id=843_602,
+            source="xbrl_dei",
+            source_document_id="T-1",
+            source_accession="0000000000-26-000001",
+            source_field="TreasuryStockShares",
+            source_url=None,
+            filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+            period_start=None,
+            period_end=date(2025, 12, 31),
+            ingest_run_id=uuid4(),
+            treasury_shares=Decimal("250000"),
+        )
+        conn.commit()
+
+        points = get_ownership_category_totals(
+            conn, instrument_id=843_602, category="treasury"
+        )
+        assert len(points) == 1
+        assert points[0].source == "xbrl_dei"
+        assert points[0].source_accession == "0000000000-26-000001"
+        assert points[0].holder_count is None


### PR DESCRIPTION
Closes #922.

## What

Third of the 4 split tickets under closed parent #846. New `OwnershipHistoryChart` on the L2 ownership page (trend companion to the rollup pie) + a small additive extension to the existing `/instruments/{symbol}/ownership-history` endpoint. No new endpoint, no schema change.

## Stale-premise resolution

The issue claims the existing endpoint "already returns the data shape" for the default category-level view. It does not: `holder_id` is REQUIRED for every holder-scoped category — a deliberate #840.F guard (holder-less `DISTINCT ON` would return one arbitrary holder per period). Closed with an explicit `aggregate=true` mode per the issue's own "add fields if not" allowance; the guard is untouched for non-aggregate calls.

## Backend

- `get_ownership_category_totals`: per-quarter 13F totals, **dedup-before-sum** (inner `DISTINCT ON (period_end, filer_cik)`, winner `filed_at DESC, source_document_id ASC`) so amendments replace rather than add — on dev AAPL this removes ~1B shares of amendment double-count vs a naive SUM. `ownership_nature='economic'` is FILTERED (the only nature today, 6.25M rows verified), not summed-across — a future second nature is excluded, never mislabelled. `holder_count = COUNT(DISTINCT filer_cik)`.
- Treasury aggregate = the existing issuer-level series verbatim (XBRL provenance untouched).
- Event-driven categories (insiders/blockholders/def14a) have **no honest aggregate** — a per-period sum counts only the holders who happened to file that period; service raises, endpoint 400s with the rationale. Carry-forward semantics = follow-up if wanted.
- `aggregate=true` is mutually exclusive with ANY supplied `holder_id` (including blank — Codex ckpt-2). New optional `holder_count` on the point response, mirrored field-for-field in the new FE types.
- This series is labelled "Institutions (13F)" and deliberately NOT claimed to reconcile 1:1 with the pie (the pie reads `*_current` through cross-source survivor logic + an ETF split).

## Frontend

- Chart consumes the L2 page's existing `?category=`/`?filer=` selection — no second selection mechanism. Default: Institutions (13F) + Treasury lines; per-holder drill via the same selection the wedges/table set, one line per `ownership_nature` (never summed). Per-category filer-key → holder_id mapping (`block:`/`baseline:` prefixes; `name:` fallbacks → no-CIK empty state); `etfs` drills through `institutions` (same 13F table); unknown/typo categories read as no selection (Codex ckpt-2 — falling through to institutions would mislead).
- 1Y/3Y/5Y/All window (local state). **Y axis = absolute shares, not percent** — percent of TODAY's outstanding applied to old quarters misstates history (buybacks); tooltip shows percent explicitly labelled "of current outstanding". Conscious deviation from the issue's "50% → 53%" example; percent axis is a follow-up once a historical outstanding series exists.
- Partial-failure degradation: one aggregate fetch failing renders the surviving line + an amber note (which also survives the empty branch — Codex ckpt-2); all failing → `SectionError`. Loading/empty/error per `loading-error-empty-states.md`.

Spec with full rationale incl. all 15 Codex finding resolutions: `docs/specs/ui/2026-06-11-ownership-history-pane.md`.

## Security model

Read-only endpoint extension behind existing operator auth; `aggregate` is a typed bool, `category` allow-listed, all SQL parameterised (no user input interpolated); FE fetcher builds query strings via `URLSearchParams`.

## Verification

- Backend: `tests/test_ownership_history.py` 16 pass (4 new db-tier: amendment dedup-before-sum, nature exclusion, event-driven raise, treasury provenance), targeted run against the test cluster. ruff + format + pyright green (full pre-push hook).
- Frontend: 962 pass (21 new: pure mode/key/window/row helpers + render-state suite with mocked fetcher). typecheck + dark:check green.
- Codex ckpt-1 (spec): 12 findings incorporated. Codex ckpt-2 (diff): 3 findings (S2 category fallthrough, S3 hidden partial-failure note, S3 blank holder_id) — all fixed + test-pinned; SQL explicitly cleared.
- Dev-verify (service-level, dev DB): AAPL 6 quarters latest 4.82B/6,011 filers; GME 8 quarters 88.1M/356; MSFT 8 quarters 2.93B/6,123; GME insider drill CIK 0001767470 (Cohen) → 3 points. Magnitudes sane vs pie slices.
- Operator follow-up: visual check on the dev UI (chart render + drill + window toggle) — agent has no UI credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)