### PR TITLE
feat(#923): coverage banner v2 — OwnershipCoverageBanner extraction + per-state glyphs on the settled 5-state machine

### DIFF
--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -691,6 +691,28 @@ trust-CIK rows.
 
 ---
 
+## Ownership coverage banner = 5-state server-driven machine (#840, reaffirmed #923 2026-06-11)
+
+The coverage banner renders the backend's 5-state machine — `no_data` /
+`red` / `unknown_universe` / `amber` / `green`
+(`app/services/ownership_rollup.py::CoverageState`) — with headline,
+body, and color variant all SERVER-owned (`_banner_for_state`) and
+rendered verbatim by `OwnershipCoverageBanner.tsx`. The frontend adds
+only a per-state glyph (disambiguates `no_data` vs `red`, which share
+`variant="error"`).
+
+The Phase-1 6-state vocabulary (`partial_identifier_coverage`,
+`stale_category`, `issuer_does_not_disclose`,
+`complete_source_universe`) that issue #923 cited is **superseded** —
+it was never implemented; #840 shipped this machine instead, and its
+Codex review separately pinned the coverage-vs-concentration split.
+Do not re-litigate from the old spec. Adding a coverage state is a
+backend change first (new spec + ticket), never an FE-only remap.
+
+**Spec:** `docs/specs/ui/2026-06-11-ownership-coverage-banner-v2.md`.
+
+---
+
 ## Maintenance rule
 
 When a new repo-level decision is agreed and is likely to affect future implementation:

--- a/docs/specs/ui/2026-06-11-ownership-coverage-banner-v2.md
+++ b/docs/specs/ui/2026-06-11-ownership-coverage-banner-v2.md
@@ -1,0 +1,67 @@
+# Ownership coverage banner v2 (#923, rescoped)
+
+Status: live spec for #923 as RESCOPED by operator decision 2026-06-11.
+Scope: frontend only — extract + polish the existing banner on the shipped
+5-state machine. No backend change.
+
+## Rescope rationale (operator decision 2026-06-11)
+
+The issue asks for a 6-state machine (`no_data`, `unknown_universe`,
+`partial_identifier_coverage`, `stale_category`, `issuer_does_not_disclose`,
+`complete_source_universe`) and claims "backend already emits coverage.state
+from #840 P1 — backend payload satisfies all 6 states". **False**: the backend
+ships a 5-state machine (`no_data` / `red` / `unknown_universe` / `amber` /
+`green`, `CoverageState` in `app/services/ownership_rollup.py`) with per-state
+headline/body/variant already server-rendered (`_banner_for_state`). The
+Phase-1 6-state vocabulary was superseded by #840's implementation (whose
+Codex review separately pinned the coverage-vs-concentration split). The
+issue's own out-of-scope forbids backend changes, so the literal 6-state ask
+is unimplementable as written. Operator chose: **rescope to the shipped
+5-state machine** (over close-as-shipped and over a backend redesign).
+
+Recorded in `docs/settled-decisions.md` (same PR).
+
+## What ships
+
+1. **Extract** the `Banner` function + `_BANNER_VARIANT_CLASS` out of
+   `OwnershipPanel.tsx` into `frontend/src/components/instrument/
+   OwnershipCoverageBanner.tsx` (the component file the issue names), exported
+   as `OwnershipCoverageBanner`. The L2 `OwnershipPage` does not render a
+   banner today — unchanged (the rollup payload feeds L1 only).
+2. **Glyph keyed by STATE; color keyed by server VARIANT** (Codex ckpt-1 MED
+   ×2). Today `no_data` and `red` are visually identical (both
+   `variant="error"`); the glyph disambiguates them. Division of ownership:
+   - Glyph map is an **exhaustive** `Record<OwnershipCoverageState, string>` —
+     a future backend/type state fails the FE typecheck instead of silently
+     rendering glyph-less: `no_data ⊘ · red ✕ · unknown_universe ? ·
+     amber ▲ · green ✓`.
+   - Color renders the server `banner.variant` **verbatim** via the existing
+     `Record<OwnershipBannerVariant, string>` class map — the FE does not
+     re-derive variant from state, and the current green→success
+     special-case is removed (state↔variant consistency is backend-owned;
+     a mismatched-but-typed payload like `{state:"green",
+     variant:"warning"}` renders warning colors + ✓ glyph, test-pinned).
+   - Layout stays state-driven only for the compact green single-line form.
+3. **A11y, exactly** (Codex ckpt-1 LOW): glyph is `<span aria-hidden="true">`,
+   no `role="img"`, no `title` — headline/body remain the entire accessible
+   content of the `role="status"` region; test-pinned.
+4. **Per-state unit tests** in `OwnershipCoverageBanner.test.tsx`: glyph,
+   variant class, `data-banner-state`, server headline/body verbatim (copy
+   stays server-owned per #840 — FE must not fork copy), plus the
+   mismatch-payload case. The stale "per-state assertions below" comment in
+   `OwnershipPanel.test.ts` (they never existed there) is corrected to point
+   here (Codex ckpt-1 LOW).
+5. **Extraction cleanup** (Codex ckpt-1 LOW): no external `Banner` importers
+   exist; `OwnershipPanel.tsx` drops the class map + now-unused
+   `OwnershipBannerVariant` import and renders `<OwnershipCoverageBanner>` at
+   its three call sites.
+6. **Settled-decisions entry (required, non-code)**: "Ownership coverage
+   banner = 5-state server-driven machine (#840, reaffirmed #923
+   2026-06-11)" — the 6-state Phase-1 design is recorded as superseded so the
+   next reader does not re-litigate it.
+
+## Out of scope
+
+- Backend state machine changes (any new state = new spec + new ticket).
+- Storybook (not wired in this repo).
+- Playwright snapshots (no Playwright harness — vitest as in #920-#922).

--- a/frontend/src/components/instrument/OwnershipCoverageBanner.test.tsx
+++ b/frontend/src/components/instrument/OwnershipCoverageBanner.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Per-state rendering tests for the coverage banner (#923).
+ *
+ * Contract: copy (headline/body) and color (variant) are SERVER-owned
+ * and rendered verbatim; the FE adds only the per-state glyph (which
+ * disambiguates no_data vs red — both ship variant="error") and the
+ * data-banner-state hook. One fixture per state of the shipped
+ * 5-state machine (#840; the 6-state design the #923 issue cites was
+ * superseded — see settled-decisions).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  OwnershipBannerVariant,
+  OwnershipCoverageState,
+} from "@/api/ownership";
+
+import {
+  BANNER_STATE_GLYPH,
+  OwnershipCoverageBanner,
+} from "./OwnershipCoverageBanner";
+
+interface Fixture {
+  readonly state: OwnershipCoverageState;
+  readonly variant: OwnershipBannerVariant;
+  readonly colorToken: string;
+}
+
+// Variants mirror app/services/ownership_rollup.py::_banner_for_state.
+const FIXTURES: readonly Fixture[] = [
+  { state: "no_data", variant: "error", colorToken: "border-red-200" },
+  { state: "red", variant: "error", colorToken: "border-red-200" },
+  { state: "unknown_universe", variant: "warning", colorToken: "border-amber-200" },
+  { state: "amber", variant: "warning", colorToken: "border-amber-200" },
+  { state: "green", variant: "success", colorToken: "border-emerald-200" },
+];
+
+function bannerProp(state: OwnershipCoverageState, variant: OwnershipBannerVariant) {
+  return {
+    state,
+    variant,
+    headline: `Headline for ${state}`,
+    body: `Body copy for ${state}.`,
+  };
+}
+
+describe("OwnershipCoverageBanner per state", () => {
+  it.each(FIXTURES)(
+    "$state renders its glyph, server variant color, and verbatim copy",
+    ({ state, variant, colorToken }) => {
+      const { container } = render(
+        <OwnershipCoverageBanner banner={bannerProp(state, variant)} />,
+      );
+      const region = container.querySelector('[role="status"]');
+      expect(region).not.toBeNull();
+      expect(region!.getAttribute("data-banner-state")).toBe(state);
+      expect(region!.className).toContain(colorToken);
+      // Server copy verbatim — FE must not fork it.
+      expect(screen.getByText(`Headline for ${state}`)).toBeInTheDocument();
+      expect(screen.getByText(`Body copy for ${state}.`)).toBeInTheDocument();
+      // Glyph present but aria-hidden: not part of the accessible name.
+      const glyph = container.querySelector('span[aria-hidden="true"]');
+      expect(glyph?.textContent).toBe(BANNER_STATE_GLYPH[state]);
+      expect(glyph?.getAttribute("role")).toBeNull();
+      expect(glyph?.getAttribute("title")).toBeNull();
+    },
+  );
+
+  it("disambiguates no_data from red despite identical variant", () => {
+    expect(BANNER_STATE_GLYPH.no_data).not.toBe(BANNER_STATE_GLYPH.red);
+  });
+
+  it("renders a mismatched-but-typed payload's variant verbatim (backend-owned invariant)", () => {
+    const { container } = render(
+      <OwnershipCoverageBanner banner={bannerProp("green", "warning")} />,
+    );
+    const region = container.querySelector('[role="status"]');
+    // Color follows the server variant, glyph follows the state — the
+    // FE does not normalize; state↔variant consistency is the
+    // backend's contract.
+    expect(region!.className).toContain("border-amber-200");
+    expect(container.querySelector('span[aria-hidden="true"]')?.textContent).toBe("✓");
+  });
+});

--- a/frontend/src/components/instrument/OwnershipCoverageBanner.tsx
+++ b/frontend/src/components/instrument/OwnershipCoverageBanner.tsx
@@ -1,0 +1,86 @@
+/**
+ * Ownership coverage banner (#923, extracted from OwnershipPanel).
+ *
+ * Renders the SERVER-driven 5-state coverage machine (#840:
+ * ``no_data`` / ``red`` / ``unknown_universe`` / ``amber`` /
+ * ``green``). Copy (headline/body) and color (``variant``) are
+ * backend-owned and rendered verbatim — the FE must not fork copy or
+ * re-derive variant from state. The 6-state Phase-1 vocabulary the
+ * #923 issue cites was superseded by #840; see
+ * ``docs/specs/ui/2026-06-11-ownership-coverage-banner-v2.md`` and
+ * the settled-decisions entry.
+ *
+ * What the FE adds: a per-STATE glyph, because ``no_data`` and
+ * ``red`` share ``variant="error"`` and were visually identical —
+ * the operator must tell "nothing on file" from "coverage
+ * dangerously incomplete" at a glance.
+ */
+
+import type {
+  OwnershipBannerVariant,
+  OwnershipCoverageState,
+  OwnershipRollupResponse,
+} from "@/api/ownership";
+
+const BANNER_VARIANT_CLASS: Record<OwnershipBannerVariant, string> = {
+  error:
+    "border-red-200 bg-red-50 text-red-900 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200",
+  warning:
+    "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200",
+  info: "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200",
+  success:
+    "border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-900/20 dark:text-emerald-200",
+};
+
+/** Exhaustive by construction — a new backend/type state fails the
+ *  typecheck here instead of silently rendering glyph-less. */
+export const BANNER_STATE_GLYPH: Record<OwnershipCoverageState, string> = {
+  no_data: "⊘",
+  red: "✕",
+  unknown_universe: "?",
+  amber: "▲",
+  green: "✓",
+};
+
+export interface OwnershipCoverageBannerProps {
+  readonly banner: OwnershipRollupResponse["banner"];
+}
+
+export function OwnershipCoverageBanner({
+  banner,
+}: OwnershipCoverageBannerProps): JSX.Element {
+  const glyph = (
+    // aria-hidden glyph only — headline/body remain the entire
+    // accessible content of the role="status" region.
+    <span aria-hidden="true" className="mr-1.5 font-semibold">
+      {BANNER_STATE_GLYPH[banner.state]}
+    </span>
+  );
+  if (banner.state === "green") {
+    // Compact single-line form for the healthy state.
+    return (
+      <div
+        className={`rounded-md border px-3 py-2 text-xs ${BANNER_VARIANT_CLASS[banner.variant]}`}
+        role="status"
+        data-banner-state={banner.state}
+      >
+        {glyph}
+        <span className="font-medium">{banner.headline}</span>
+        <span className="ml-1.5">{banner.body}</span>
+      </div>
+    );
+  }
+  return (
+    <div
+      className={`rounded-md border px-3 py-2 text-xs ${BANNER_VARIANT_CLASS[banner.variant]}`}
+      role="status"
+      data-banner-state={banner.state}
+    >
+      <p className="font-medium">
+        {glyph}
+        {banner.headline}
+      </p>
+      <p className="mt-0.5">{banner.body}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -14,9 +14,9 @@
  *   * Per-category totals + holder lists round-trip from the rollup
  *     into the SunburstInputs shape with no double-counting.
  *
- * The banner state machine + oversubscription warning are tested
- * against the response shape directly (they are simple enum-keyed
- * renders) — see the per-state assertions below.
+ * Banner rendering (per-state glyph / variant / copy) is covered in
+ * ``OwnershipCoverageBanner.test.tsx`` since the #923 extraction —
+ * this file only exercises the rollup→SunburstInputs transform.
  */
 
 import { describe, expect, it } from "vitest";

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -37,13 +37,12 @@ import { useNavigate } from "react-router-dom";
 
 import { fetchOwnershipRollup } from "@/api/ownership";
 import type {
-  OwnershipBannerVariant,
-  OwnershipCoverageState,
   OwnershipRollupResponse,
   OwnershipSliceCategory,
 } from "@/api/ownership";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { HistoricalSymbolCallout } from "@/components/instrument/HistoricalSymbolCallout";
+import { OwnershipCoverageBanner } from "@/components/instrument/OwnershipCoverageBanner";
 import {
   OwnershipLegend,
   OwnershipSunburst,
@@ -230,16 +229,6 @@ export function rollupToSunburstInputs(
   };
 }
 
-const _BANNER_VARIANT_CLASS: Record<OwnershipBannerVariant, string> = {
-  error:
-    "border-red-200 bg-red-50 text-red-900 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-200",
-  warning:
-    "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-200",
-  info: "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200",
-  success:
-    "border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-900/20 dark:text-emerald-200",
-};
-
 interface PanelBodyProps {
   readonly rollup: OwnershipRollupResponse;
   readonly onWedgeClick: (target: WedgeClick) => void;
@@ -250,7 +239,7 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
   if (rollup.banner.state === "no_data" || inputs === null) {
     return (
       <div className="flex flex-col gap-3">
-        <Banner banner={rollup.banner} />
+        <OwnershipCoverageBanner banner={rollup.banner} />
         <HistoricalSymbolCallout
           currentSymbol={rollup.symbol}
           historicalSymbols={rollup.historical_symbols}
@@ -266,7 +255,7 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
   if (rings === null) {
     return (
       <div className="flex flex-col gap-3">
-        <Banner banner={rollup.banner} />
+        <OwnershipCoverageBanner banner={rollup.banner} />
         <HistoricalSymbolCallout
           currentSymbol={rollup.symbol}
           historicalSymbols={rollup.historical_symbols}
@@ -281,7 +270,7 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
 
   return (
     <div className="flex flex-col gap-3">
-      <Banner banner={rollup.banner} />
+      <OwnershipCoverageBanner banner={rollup.banner} />
       <HistoricalSymbolCallout
         currentSymbol={rollup.symbol}
         historicalSymbols={rollup.historical_symbols}
@@ -329,35 +318,6 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
           </p>
         </div>
       </div>
-    </div>
-  );
-}
-
-interface BannerProps {
-  readonly banner: OwnershipRollupResponse["banner"];
-}
-
-function Banner({ banner }: BannerProps): JSX.Element | null {
-  if (banner.state === "green") {
-    return (
-      <div
-        className={`rounded-md border px-3 py-2 text-xs ${_BANNER_VARIANT_CLASS.success}`}
-        role="status"
-        data-banner-state={banner.state}
-      >
-        <span className="font-medium">{banner.headline}</span>
-        <span className="ml-1.5">{banner.body}</span>
-      </div>
-    );
-  }
-  return (
-    <div
-      className={`rounded-md border px-3 py-2 text-xs ${_BANNER_VARIANT_CLASS[banner.variant]}`}
-      role="status"
-      data-banner-state={banner.state}
-    >
-      <p className="font-medium">{banner.headline}</p>
-      <p className="mt-0.5">{banner.body}</p>
     </div>
   );
 }
@@ -520,9 +480,3 @@ function FundsMemoOverlay({ slice }: FundsMemoOverlayProps): JSX.Element {
     </div>
   );
 }
-
-// Internal banner-state union exported solely so the test file can
-// drive snapshot fixtures without re-importing from the api module
-// (keeps the test imports tight). Codex caught a similar pattern on
-// #767's freshness chip extraction.
-export type _BannerStateForTest = OwnershipCoverageState;


### PR DESCRIPTION
Closes #923.

## What

Fourth and last of the #846 split tickets. **Rescoped by operator decision (this session):** the issue asks for a 6-state machine and claims the backend already emits it — false. The backend ships a 5-state machine (`no_data`/`red`/`unknown_universe`/`amber`/`green`, `CoverageState` in `app/services/ownership_rollup.py`) with per-state headline/body/variant already server-rendered; the Phase-1 6-state vocabulary was superseded by #840 (whose Codex review pinned the coverage-vs-concentration split), and the issue's own out-of-scope forbids backend changes. Operator chose rescope-to-shipped-machine over close-as-shipped and over a backend redesign. Recorded as a new settled-decisions entry so it isn't re-litigated.

## Changes

- **Extract** `Banner` + variant class map from `OwnershipPanel.tsx` → `OwnershipCoverageBanner.tsx` (the component file the issue names). Three call sites swapped; no external importers existed.
- **Per-state glyph** (`⊘ ✕ ? ▲ ✓`) via an exhaustive `Record<OwnershipCoverageState, string>` — a future state fails the typecheck instead of rendering glyph-less. This is the real operator win: `no_data` and `red` were visually identical (both `variant="error"`).
- **Color renders the server `banner.variant` verbatim** — the previous green→success hard-code is removed; state↔variant consistency is backend-owned, and a mismatched-but-typed payload (`{state:"green", variant:"warning"}`) is test-pinned to render the server variant + state glyph.
- **A11y:** glyph is `<span aria-hidden="true">` with no role/title — headline/body remain the entire accessible content of the `role="status"` region (test-pinned).
- Removed the dead `_BannerStateForTest` export; fixed the stale "per-state assertions below" comment in `OwnershipPanel.test.ts` (those assertions never existed there — they now exist in `OwnershipCoverageBanner.test.tsx`).
- `docs/settled-decisions.md`: new entry "Ownership coverage banner = 5-state server-driven machine".

Spec with the full rescope rationale + 6 Codex ckpt-1 resolutions: `docs/specs/ui/2026-06-11-ownership-coverage-banner-v2.md`.

## Security model

Presentational extraction inside the authenticated operator page; server copy rendered as React text nodes (no HTML injection path); no API/auth/SQL surface.

## Verification

- `typecheck` ✅ · `test:unit` 969 pass (7 new per-state tests) ✅ · `dark:check` 188 files ✅ · pre-push hook ✅
- Codex ckpt-1 (spec): 6 findings incorporated (exhaustive glyph map, variant-source clarity, extraction cleanup, exact a11y, mismatch-payload contract, settled-decisions as required deliverable).
- Codex ckpt-2 (diff): "No findings" — independently ran vitest + tsc + diff check.
- No Playwright in repo (issues' snapshot acceptance translated to vitest, as in #920-#922).
- Operator follow-up: visual pass on dev UI (glyphs in light+dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)