### PR TITLE
feat(#554): dimensional XBRL facts — segments, product mix, geographic revenue

### DIFF
--- a/.claude/skills/engineering/sql-correctness.md
+++ b/.claude/skills/engineering/sql-correctness.md
@@ -111,6 +111,12 @@ Without this, the caller believes the mutation succeeded while the row is unchan
 | `dict_row` added to one cursor | all cursor calls in the file |
 | Missing `rowcount` after UPDATE | every `conn.execute("UPDATE` in the file |
 
+## Chained-CTE filter consistency
+
+When a query selects an anchor in one CTE (a winner accession, a target period, a max watermark) and joins it in a later stage, every stage must apply the SAME eligibility filters. A filter present in the final join but absent from the anchor CTE lets the anchor land on a row the join then excludes — the query silently returns zero rows despite eligible data.
+
+Self-check: for each CTE that computes a `MAX(...)`/`ORDER BY ... LIMIT 1` anchor, diff its WHERE clause against the final SELECT's — any predicate present in one and not the other needs a reason in a comment. Origin: PR #1588 review WARNING (`target` CTE missing `NOT is_subtotal` carried by winner + main query).
+
 ## Never edit an applied migration — bump to a new NNN+1 file
 
 The runner records each applied file's SHA-256 in `schema_migrations.content_sha256` (#1333) and **raises at boot** if an applied file's content changed. Editing `sql/NNN_*.sql` after any DB recorded it (dev included — drafts applied during PR development count) is therefore a boot-breaker, not a silent no-op. All follow-up changes go into a new `NNN+1` file. If you knowingly replayed an edited file manually (idempotent), reset its hash: `UPDATE schema_migrations SET content_sha256 = NULL WHERE filename = '<file>'` — never DELETE the row. Full RCA in `docs/review-prevention-log.md` ("Migration content drift").

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -49,6 +49,8 @@ from app.services.broker_credentials import (
     CredentialNotFound,
     load_credential_for_provider_use,
 )
+from app.services.dimensional_facts import DimensionalAxis
+from app.services.dimensional_facts_store import read_segments
 from app.services.intraday_candles import fetch_intraday_candles
 from app.services.operators import (
     AmbiguousOperatorError,
@@ -1181,6 +1183,123 @@ def get_instrument_employees(
         employees=int(row["val"]),  # type: ignore[arg-type]
         period_end_date=row["period_end"],  # type: ignore[arg-type]
         source_accession=str(row["accession_number"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Segments endpoint (#554 — dimensional XBRL facts)
+# ---------------------------------------------------------------------------
+
+
+# API axis param → storage enum (pinned by test so storage values never
+# leak into the URL surface).
+SEGMENT_AXIS_PARAM_TO_ENUM: dict[str, DimensionalAxis] = {
+    "business": "business_segment",
+    "product": "product_service",
+    "geographic": "geographic",
+}
+
+SegmentAxisParam = Literal["business", "product", "geographic"]
+
+
+class SegmentRowModel(BaseModel):
+    member_qname: str
+    member_label: str
+    revenue: float | None
+    operating_income: float | None
+    assets: float | None
+    # Share of the summed leaf revenue in this response. Leaf rows sum
+    # to the consolidated figure (subtotal members are excluded at the
+    # reader), so this is internally consistent by construction.
+    pct_of_total: float | None
+
+
+class InstrumentSegments(BaseModel):
+    """Latest-fiscal-year dimensional breakdown for one instrument.
+
+    ``sources`` maps metric → winning accession: the reader selects the
+    winning filing per (axis, metric) independently, so a 10-K/A that
+    restates revenue but omits operating income pairs amendment revenue
+    with original-filing operating income (spec §D4/D6).
+    """
+
+    symbol: str
+    axis: SegmentAxisParam
+    period_end: date
+    filed_at: datetime
+    sources: dict[str, str]
+    total_revenue: float | None
+    rows: list[SegmentRowModel]
+
+
+@router.get("/{symbol}/segments", response_model=InstrumentSegments)
+def get_instrument_segments(
+    symbol: str,
+    axis: SegmentAxisParam = "business",
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InstrumentSegments:
+    """Latest-FY segment / product / geographic breakdown (#554).
+
+    Returns 404 when no dimensional facts are on file for the axis —
+    non-SEC issuer, the 10-K predates the XBRL mandate, or the filer
+    discloses nothing on the axis (e.g. banks often emit no
+    revenue-alias facts on the product axis).
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+
+    result = read_segments(
+        conn,  # type: ignore[arg-type] — reader opens its own dict_row cursors
+        instrument_id=instrument_id,
+        axis=SEGMENT_AXIS_PARAM_TO_ENUM[axis],
+    )
+    if not result.rows or result.period_end is None or result.filed_at is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No {axis} breakdown on file for {symbol}",
+        )
+
+    total_revenue = sum(
+        (row["revenue"] for row in result.rows if row["revenue"] is not None),
+        start=Decimal(0),
+    )
+    rows = [
+        SegmentRowModel(
+            member_qname=row["member_qname"],
+            member_label=row["member_label"],
+            revenue=float(row["revenue"]) if row["revenue"] is not None else None,
+            operating_income=float(row["operating_income"]) if row["operating_income"] is not None else None,
+            assets=float(row["assets"]) if row["assets"] is not None else None,
+            pct_of_total=(
+                float(row["revenue"] / total_revenue) if row["revenue"] is not None and total_revenue > 0 else None
+            ),
+        )
+        for row in result.rows
+    ]
+    return InstrumentSegments(
+        symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]
+        axis=axis,
+        period_end=result.period_end,
+        filed_at=result.filed_at,
+        sources=dict(result.sources),
+        total_revenue=float(total_revenue) if total_revenue > 0 else None,
+        rows=rows,
     )
 
 

--- a/app/services/dimensional_facts.py
+++ b/app/services/dimensional_facts.py
@@ -1,0 +1,695 @@
+"""Dimensional XBRL fact extraction — segments / product mix / geography (#554).
+
+Pure module: file discovery over a filing's ``index.json`` listing +
+fact extraction over the filing's XBRL instance document. No DB, no
+HTTP — the DB layer lives in ``dimensional_facts_store`` and the
+fetch/orchestration in ``manifest_parsers/sec_10k`` step 2.
+
+Why per-filing instance parsing at all: the SEC companyfacts API
+carries NO dimensional facts (verified 2026-06-11, spec §1 —
+``docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md``), so
+segment/product/geographic breakdowns only exist inside each filing's
+own instance document.
+
+Axis routing is per-route EXACT (spec §D3): a context is accepted only
+when its dimension set matches one of the three allowed shapes; any
+extra axis (segment×product cross-dimensions, elimination members)
+is excluded to prevent double-counting.
+
+Concept scope is us-gaap only. Filer-extension revenue concepts are a
+conscious v1 undercount (spec §D3) — ``pct_of_total`` is computed over
+returned rows downstream so tables stay internally consistent.
+
+Period sanity window per prevention log §1455: ``[1900-01-01,
+2100-01-01)`` + ``period_start <= period_end``; violations are
+rejected + WARN'd with provenance, never written.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from datetime import date
+from itertools import combinations
+from decimal import Decimal, InvalidOperation
+from typing import Literal
+
+import lxml.etree as ET
+
+from app.providers.implementations.sec_fundamentals import TRACKED_CONCEPTS
+from app.services.xbrl_instance import (
+    SAFE_XML_PARSER,
+    axis_localname,
+    context_dimensions,
+    context_period,
+    member_localname,
+)
+
+logger = logging.getLogger(__name__)
+
+DimensionalAxis = Literal["business_segment", "product_service", "geographic"]
+DimensionalMetric = Literal["revenue", "operating_income", "assets"]
+
+# Period sanity window (prevention log §1455 — same bounds as the
+# sec_fundamentals parser guard).
+_SANITY_MIN = date(1900, 1, 1)
+_SANITY_MAX = date(2100, 1, 1)  # exclusive
+
+# Concept localname → (metric, alias_priority). Revenue aliases come
+# from the single source of truth in the fundamentals provider
+# (TRACKED_CONCEPTS — tuple order IS the priority order); operating
+# income + assets are single-concept.
+_CONCEPT_TO_METRIC: dict[str, tuple[DimensionalMetric, int]] = {
+    **{tag: ("revenue", i) for i, tag in enumerate(TRACKED_CONCEPTS["revenue"])},
+    **{tag: ("operating_income", i) for i, tag in enumerate(TRACKED_CONCEPTS["operating_income"])},
+    **{tag: ("assets", i) for i, tag in enumerate(TRACKED_CONCEPTS["total_assets"])},
+}
+
+# Duration metrics carry startDate+endDate contexts; instant metrics
+# carry instant contexts. Anything else for that metric is skipped.
+_INSTANT_METRICS: frozenset[str] = frozenset({"assets"})
+
+# Metrics allowed per axis route (spec §D3 table).
+_AXIS_METRICS: dict[DimensionalAxis, frozenset[str]] = {
+    "business_segment": frozenset({"revenue", "operating_income", "assets"}),
+    "product_service": frozenset({"revenue"}),
+    "geographic": frozenset({"revenue"}),
+}
+
+_XSI_NIL = "{http://www.w3.org/2001/XMLSchema-instance}nil"
+
+# index.json names that are never the instance document.
+_NON_INSTANCE_XML = re.compile(
+    r"(_cal|_def|_lab|_pre|_ref)\.xml$|^r\d+\.xml$|^filingsummary\.xml$|index",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class XbrlFileRefs:
+    """File names (within the accession archive) located by discovery."""
+
+    instance_name: str
+    label_name: str | None
+    definition_name: str | None
+
+
+@dataclass(frozen=True)
+class DimensionalFact:
+    """One extracted dimensional fact, ready for the store layer."""
+
+    axis: DimensionalAxis
+    member_qname: str
+    member_label: str
+    metric: DimensionalMetric
+    unit: str
+    is_subtotal: bool
+    period_start: date | None
+    period_end: date
+    val: Decimal
+    decimals: str | None
+
+
+# ---------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------
+
+
+def _stem(name: str) -> str:
+    base = name.rsplit("/", 1)[-1]
+    return base.split(".", 1)[0].removesuffix("_htm")
+
+
+def discover_xbrl_files(
+    raw_index: Mapping[str, object],
+    *,
+    primary_document_name: str | None,
+) -> XbrlFileRefs | None:
+    """Locate the XBRL instance (+ optional label linkbase) in a filing's
+    ``index.json`` listing.
+
+    The listing has NO SEC document-type labels (``index.json``'s
+    ``type`` is a content-type icon — see ``filing_documents`` module
+    note), so discovery is by name shape, deterministic priority:
+
+    1. Inline-XBRL era: files ending ``_htm.xml`` (the EDGAR-generated
+       extracted instance). Several → prefer the one whose stem matches
+       the primary document's stem, else largest size + WARN.
+    2. Standalone-instance era: ``.xml`` files that are not linkbases
+       (``_cal/_def/_lab/_pre/_ref``), not rendering artifacts
+       (``R<n>.xml``, ``FilingSummary.xml``), not index files. Same
+       stem-match → largest-size tie-break.
+
+    Returns ``None`` when no candidate exists (pre-XBRL-mandate filings
+    — the caller treats that as a clean no-XBRL skip, not an error).
+    """
+    directory = raw_index.get("directory")
+    if not isinstance(directory, dict):
+        return None
+    items = directory.get("item")
+    if not isinstance(items, list):
+        return None
+
+    names_sizes: list[tuple[str, int]] = []
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        size_raw = entry.get("size")
+        try:
+            size = int(size_raw) if size_raw not in (None, "") else 0
+        except TypeError, ValueError:
+            size = 0
+        names_sizes.append((name, size))
+
+    primary_stem = _stem(primary_document_name) if primary_document_name else None
+
+    def _pick(candidates: list[tuple[str, int]]) -> str | None:
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0][0]
+        if primary_stem is not None:
+            stem_matches = [c for c in candidates if _stem(c[0]) == primary_stem]
+            if len(stem_matches) == 1:
+                return stem_matches[0][0]
+            if stem_matches:
+                candidates = stem_matches
+        # Deterministic tie-break: largest size, then name. The instance
+        # is by far the largest XBRL artifact in practice.
+        chosen = sorted(candidates, key=lambda c: (-c[1], c[0]))[0][0]
+        logger.warning(
+            "dimensional facts: ambiguous instance candidates %s; chose %s by size",
+            sorted(c[0] for c in candidates),
+            chosen,
+        )
+        return chosen
+
+    inline = [(n, s) for n, s in names_sizes if n.lower().endswith("_htm.xml")]
+    instance = _pick(inline)
+    if instance is None:
+        standalone = [
+            (n, s)
+            for n, s in names_sizes
+            if n.lower().endswith(".xml") and not _NON_INSTANCE_XML.search(n.rsplit("/", 1)[-1].lower())
+        ]
+        instance = _pick(standalone)
+    if instance is None:
+        return None
+
+    def _sibling(suffix: str) -> str | None:
+        matches = sorted(n for n, _ in names_sizes if n.lower().endswith(suffix))
+        if not matches:
+            return None
+        if primary_stem is not None:
+            return next((n for n in matches if _stem(n).startswith(primary_stem)), matches[0])
+        return matches[0]
+
+    # Some filer software (e.g. Workiva — MSFT) ships NO standalone
+    # linkbase files and embeds labelLink/definitionLink inside the
+    # schema's <annotation>. The parsers match by localname, so the
+    # .xsd is a drop-in source for both.
+    schema = _sibling(".xsd")
+    return XbrlFileRefs(
+        instance_name=instance,
+        label_name=_sibling("_lab.xml") or schema,
+        definition_name=_sibling("_def.xml") or schema,
+    )
+
+
+# ---------------------------------------------------------------------
+# Label linkbase
+# ---------------------------------------------------------------------
+
+_STANDARD_LABEL_ROLE = "http://www.xbrl.org/2003/role/label"
+_XLINK = "http://www.w3.org/1999/xlink"
+
+
+def parse_label_linkbase(label_xml: bytes) -> dict[str, str]:
+    """Parse a filing's ``*_lab.xml`` into ``{element_id_fragment: label}``.
+
+    Keys are the schema-fragment ids the linkbase locators point at
+    (``aapl_IPhoneMember``). Standard-role labels win; any-role label
+    is the fallback. Malformed XML returns ``{}`` — labels are
+    best-effort, never fatal (localname prettify covers the gap).
+    """
+    try:
+        doc = ET.fromstring(label_xml, parser=SAFE_XML_PARSER)
+    except ET.XMLSyntaxError:
+        logger.warning("dimensional facts: label linkbase parse failed; using localname fallback")
+        return {}
+
+    loc_to_fragment: dict[str, str] = {}
+    arc_from_to: list[tuple[str, str]] = []
+    label_values: dict[str, list[tuple[str, str]]] = {}
+
+    for el in doc.iter():
+        if not isinstance(el.tag, str):
+            continue
+        local = ET.QName(el.tag).localname
+        if local == "loc":
+            href = el.get(f"{{{_XLINK}}}href", "")
+            lab = el.get(f"{{{_XLINK}}}label", "")
+            if "#" in href and lab:
+                loc_to_fragment[lab] = href.rsplit("#", 1)[1]
+        elif local == "labelArc":
+            frm = el.get(f"{{{_XLINK}}}from", "")
+            to = el.get(f"{{{_XLINK}}}to", "")
+            if frm and to:
+                arc_from_to.append((frm, to))
+        elif local == "label":
+            lab = el.get(f"{{{_XLINK}}}label", "")
+            role = el.get(f"{{{_XLINK}}}role", "")
+            text = (el.text or "").strip()
+            if lab and text:
+                label_values.setdefault(lab, []).append((role, text))
+
+    out: dict[str, str] = {}
+    for frm, to in arc_from_to:
+        fragment = loc_to_fragment.get(frm)
+        if fragment is None or fragment in out:
+            continue
+        candidates = label_values.get(to, [])
+        if not candidates:
+            continue
+        standard = next((t for r, t in candidates if r == _STANDARD_LABEL_ROLE), None)
+        out[fragment] = standard if standard is not None else candidates[0][1]
+    return out
+
+
+_DOMAIN_MEMBER_ARCROLE = "http://xbrl.org/int/dim/arcrole/domain-member"
+
+
+def parse_definition_linkbase(definition_xml: bytes) -> set[tuple[str, str]]:
+    """Parse a filing's ``*_def.xml`` into ``{(parent_fragment,
+    child_fragment)}`` pairs from domain-member arcs.
+
+    Fragments are schema element ids (``aapl_IPhoneMember``) — the same
+    keying the label linkbase uses. Subtotal detection downstream marks
+    a member as subtotal when it parents another member that also
+    carries a fact on the same axis. Malformed XML → empty set
+    (best-effort, never fatal — no fact is dropped, only subtotal
+    flags are missed)."""
+    try:
+        doc = ET.fromstring(definition_xml, parser=SAFE_XML_PARSER)
+    except ET.XMLSyntaxError:
+        logger.warning("dimensional facts: definition linkbase parse failed; subtotal flags unavailable")
+        return set()
+
+    pairs: set[tuple[str, str]] = set()
+    # loc labels are scoped per extended link — walk each definitionLink
+    # separately so identical xlink:label strings in different links
+    # don't cross-wire.
+    for link in doc.iter():
+        if not isinstance(link.tag, str) or ET.QName(link.tag).localname != "definitionLink":
+            continue
+        loc_to_fragment: dict[str, str] = {}
+        arcs: list[tuple[str, str]] = []
+        for el in link:
+            if not isinstance(el.tag, str):
+                continue
+            local = ET.QName(el.tag).localname
+            if local == "loc":
+                href = el.get(f"{{{_XLINK}}}href", "")
+                lab = el.get(f"{{{_XLINK}}}label", "")
+                if "#" in href and lab:
+                    loc_to_fragment[lab] = href.rsplit("#", 1)[1]
+            elif local == "definitionArc":
+                if el.get(f"{{{_XLINK}}}arcrole") != _DOMAIN_MEMBER_ARCROLE:
+                    continue
+                frm = el.get(f"{{{_XLINK}}}from", "")
+                to = el.get(f"{{{_XLINK}}}to", "")
+                if frm and to:
+                    arcs.append((frm, to))
+        for frm, to in arcs:
+            parent = loc_to_fragment.get(frm)
+            child = loc_to_fragment.get(to)
+            if parent and child:
+                pairs.add((parent, child))
+    return pairs
+
+
+def _member_fragment(member_qname: str) -> str:
+    """``aapl:IPhoneMember`` → ``aapl_IPhoneMember`` (the schema element
+    id convention used by loc hrefs in SEC linkbases)."""
+    return member_qname.replace(":", "_", 1)
+
+
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+
+def prettify_member(member_qname: str) -> str:
+    """Fallback label: ``aapl:WearablesHomeandAccessoriesMember`` →
+    ``Wearables Homeand Accessories`` (imperfect by design — used only
+    when the label linkbase has no entry, e.g. standard-taxonomy
+    members like ``country:US`` → ``US``)."""
+    local = member_localname(member_qname) or member_qname
+    return _CAMEL_BOUNDARY.sub(" ", local).strip()
+
+
+def _label_for(member_qname: str, labels: Mapping[str, str]) -> str:
+    hit = labels.get(_member_fragment(member_qname)) if ":" in member_qname else None
+    if hit:
+        # SEC standard labels carry a " [Member]" suffix — UI noise.
+        return re.sub(r"\s*\[Member\]\s*$", "", hit) or prettify_member(member_qname)
+    return prettify_member(member_qname)
+
+
+# ---------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------
+
+
+def _to_date(text: str | None) -> date | None:
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text.strip())
+    except ValueError:
+        return None
+
+
+def _decimals_rank(decimals: str | None) -> float:
+    """Precision ordering for duplicate-fact arbitration: INF > any
+    integer > absent."""
+    if decimals is None:
+        return float("-inf")
+    cleaned = decimals.strip()
+    if cleaned.upper() == "INF":
+        return float("inf")
+    try:
+        return float(int(cleaned))
+    except ValueError:
+        return float("-inf")
+
+
+def _classify_context(dims: Mapping[str, str]) -> tuple[DimensionalAxis, str] | None:
+    """Map a context's dimension set to ``(axis, member_qname)`` per the
+    spec §D3 exact axis-set rule, or ``None`` when out of scope."""
+    by_local: dict[str, str] = {}
+    for axis_qname, member_qname in dims.items():
+        local = axis_localname(axis_qname)
+        if local is None:
+            return None
+        by_local[local] = member_qname
+
+    keys = frozenset(by_local)
+    if keys == frozenset({"StatementBusinessSegmentsAxis"}):
+        return ("business_segment", by_local["StatementBusinessSegmentsAxis"])
+    if keys == frozenset({"StatementBusinessSegmentsAxis", "ConsolidationItemsAxis"}):
+        if member_localname(by_local["ConsolidationItemsAxis"]) == "OperatingSegments":
+            return ("business_segment", by_local["StatementBusinessSegmentsAxis"])
+        return None
+    if keys == frozenset({"ProductOrServiceAxis"}):
+        return ("product_service", by_local["ProductOrServiceAxis"])
+    if keys == frozenset({"StatementGeographicalAxis"}):
+        return ("geographic", by_local["StatementGeographicalAxis"])
+    return None
+
+
+def _instance_units(doc: ET._Element) -> dict[str, str]:
+    """``{unit_id: measure}`` for single-measure units (``iso4217:USD``
+    → ``USD``). Ratio (divide) units are omitted — the three tracked
+    metrics are all plain monetary concepts."""
+    units: dict[str, str] = {}
+    for el in doc.iter():
+        if not isinstance(el.tag, str) or ET.QName(el.tag).localname != "unit":
+            continue
+        uid = el.get("id")
+        if not uid:
+            continue
+        measures = [
+            (child.text or "").strip()
+            for child in el.iter()
+            if isinstance(child.tag, str) and ET.QName(child.tag).localname == "measure"
+        ]
+        has_divide = any(
+            isinstance(child.tag, str) and ET.QName(child.tag).localname == "divide" for child in el
+        )
+        if has_divide or len(measures) != 1 or not measures[0]:
+            continue
+        measure = measures[0]
+        units[uid] = measure.rsplit(":", 1)[-1]
+    return units
+
+
+def extract_dimensional_facts(
+    instance_xml: bytes,
+    label_xml: bytes | None,
+    definition_xml: bytes | None,
+    *,
+    accession: str,
+) -> list[DimensionalFact]:
+    """Extract segment / product / geographic facts from an XBRL
+    instance document.
+
+    Raises:
+        ValueError: on malformed instance XML (caller decides failure
+        semantics — spec §D1: WARN + parsed-without-segments).
+    """
+    try:
+        doc = ET.fromstring(instance_xml, parser=SAFE_XML_PARSER)
+    except ET.XMLSyntaxError as exc:
+        raise ValueError(f"XBRL instance parse error: {exc}") from exc
+
+    labels = parse_label_linkbase(label_xml) if label_xml else {}
+    member_tree = parse_definition_linkbase(definition_xml) if definition_xml else set()
+    units = _instance_units(doc)
+
+    # Context id → (axis, member_qname, period). axis/member are None
+    # for DIMENSIONLESS contexts — their consolidated facts are not
+    # emitted (financial_facts_raw territory) but anchor the
+    # value-overage subtotal detection below.
+    contexts: dict[str, tuple[DimensionalAxis | None, str | None, dict[str, str]] | None] = {}
+    for ctx in doc.iter():
+        if not isinstance(ctx.tag, str) or ET.QName(ctx.tag).localname != "context":
+            continue
+        cid = ctx.get("id")
+        if not cid:
+            continue
+        dims = context_dimensions(ctx)
+        if not dims:
+            contexts[cid] = (None, None, context_period(ctx))
+            continue
+        route = _classify_context(dims)
+        contexts[cid] = None if route is None else (route[0], route[1], context_period(ctx))
+
+    rejections: dict[str, int] = {}
+
+    # candidate key → (alias_priority, decimals_rank, fact). Key excludes
+    # the concept so revenue-alias arbitration happens in the same pass.
+    # ``totals`` holds the DIMENSIONLESS facts for the same metrics —
+    # not emitted, only anchoring value-overage subtotal detection.
+    candidates: dict[
+        tuple[DimensionalAxis, str, DimensionalMetric, date | None, date],
+        tuple[int, float, DimensionalFact],
+    ] = {}
+    conflicted: set[tuple[DimensionalAxis, str, DimensionalMetric, date | None, date]] = set()
+    totals: dict[tuple[DimensionalMetric, date | None, date], tuple[int, float, Decimal]] = {}
+    totals_conflicted: set[tuple[DimensionalMetric, date | None, date]] = set()
+
+    for el in doc.iter():
+        if not isinstance(el.tag, str):
+            continue
+        cref = el.get("contextRef")
+        if not cref:
+            continue
+        qname = ET.QName(el.tag)
+        if not qname.namespace or "fasb.org/us-gaap" not in qname.namespace:
+            continue  # extension concepts out of scope v1 (spec §D3)
+        mapped = _CONCEPT_TO_METRIC.get(qname.localname)
+        if mapped is None:
+            continue
+        metric, alias_priority = mapped
+        route = contexts.get(cref)
+        if route is None:
+            continue
+        axis, member_qname, period = route
+        if axis is not None and metric not in _AXIS_METRICS[axis]:
+            continue
+        if el.get(_XSI_NIL) == "true":
+            continue
+
+        if metric in _INSTANT_METRICS:
+            period_start = None
+            period_end = _to_date(period.get("instant"))
+        else:
+            period_start = _to_date(period.get("startDate"))
+            period_end = _to_date(period.get("endDate"))
+            if period_start is None:
+                rejections["duration_without_start"] = rejections.get("duration_without_start", 0) + 1
+                continue
+        if period_end is None:
+            rejections["missing_period_end"] = rejections.get("missing_period_end", 0) + 1
+            continue
+        if not (_SANITY_MIN <= period_end < _SANITY_MAX) or (
+            period_start is not None and not (_SANITY_MIN <= period_start < _SANITY_MAX)
+        ):
+            rejections["period_out_of_sanity_window"] = rejections.get("period_out_of_sanity_window", 0) + 1
+            continue
+        if period_start is not None and period_start > period_end:
+            rejections["period_start_after_end"] = rejections.get("period_start_after_end", 0) + 1
+            continue
+
+        unit = units.get(el.get("unitRef") or "")
+        if unit is None:
+            continue
+        raw_val = (el.text or "").strip()
+        if not raw_val:
+            continue
+        try:
+            val = Decimal(raw_val)
+        except InvalidOperation:
+            rejections["non_decimal_value"] = rejections.get("non_decimal_value", 0) + 1
+            continue
+
+        rank = _decimals_rank(el.get("decimals"))
+
+        if axis is None or member_qname is None:
+            # Consolidated fact — totals anchor, same arbitration rules.
+            tkey = (metric, period_start, period_end)
+            if tkey in totals_conflicted:
+                continue
+            t_incumbent = totals.get(tkey)
+            if t_incumbent is None:
+                totals[tkey] = (alias_priority, rank, val)
+                continue
+            t_priority, t_rank, t_val = t_incumbent
+            if alias_priority != t_priority:
+                if alias_priority < t_priority:
+                    totals[tkey] = (alias_priority, rank, val)
+                continue
+            if val == t_val:
+                continue
+            if rank > t_rank:
+                totals[tkey] = (alias_priority, rank, val)
+            elif rank == t_rank:
+                del totals[tkey]
+                totals_conflicted.add(tkey)
+            continue
+
+        fact = DimensionalFact(
+            axis=axis,
+            member_qname=member_qname,
+            member_label=_label_for(member_qname, labels),
+            metric=metric,
+            unit=unit,
+            is_subtotal=False,  # marked in the post-pass below
+            period_start=period_start,
+            period_end=period_end,
+            val=val,
+            decimals=el.get("decimals"),
+        )
+        key = (axis, member_qname, metric, period_start, period_end)
+        if key in conflicted:
+            continue
+        incumbent = candidates.get(key)
+        if incumbent is None:
+            candidates[key] = (alias_priority, rank, fact)
+            continue
+        inc_priority, inc_rank, inc_fact = incumbent
+        # Revenue-alias arbitration: lower priority index wins (spec §D3).
+        if alias_priority != inc_priority:
+            if alias_priority < inc_priority:
+                candidates[key] = (alias_priority, rank, fact)
+            continue
+        # Same concept duplicated: equal values collapse silently;
+        # differing values resolve by precision; equal-precision
+        # conflict drops the member+period (spec §D3).
+        if fact.val == inc_fact.val:
+            continue
+        if rank > inc_rank:
+            candidates[key] = (alias_priority, rank, fact)
+        elif rank == inc_rank:
+            del candidates[key]
+            conflicted.add(key)
+            rejections["duplicate_fact_conflict"] = rejections.get("duplicate_fact_conflict", 0) + 1
+
+    for reason, count in sorted(rejections.items()):
+        logger.warning(
+            "dimensional facts: rejected %d fact(s) accession=%s reason=%s",
+            count,
+            accession,
+            reason,
+        )
+
+    facts = [fact for _, _, fact in candidates.values()]
+
+    # Subtotal post-pass: a member is a subtotal on its axis when the
+    # definition linkbase says it parents another member that ALSO has
+    # a fact on that axis (e.g. us-gaap:ProductMember over
+    # iPhone/Mac/iPad/Wearables). A hierarchy parent with no reported
+    # children stays a leaf — it is the finest grain the filer gave us.
+    members_by_axis: dict[DimensionalAxis, set[str]] = {}
+    for f in facts:
+        members_by_axis.setdefault(f.axis, set()).add(_member_fragment(f.member_qname))
+    children_of: dict[str, set[str]] = {}
+    for parent, child in member_tree:
+        children_of.setdefault(parent, set()).add(child)
+    subtotal_frags: dict[DimensionalAxis, set[str]] = {
+        axis: {m for m in members if children_of.get(m, set()) & members}
+        for axis, members in members_by_axis.items()
+    }
+    facts = [
+        replace(f, is_subtotal=True)
+        if _member_fragment(f.member_qname) in subtotal_frags.get(f.axis, set())
+        else f
+        for f in facts
+    ]
+
+    # Value-overage pass — revenue on product/geographic axes only.
+    # ASC 606 revenue disaggregation reconciles to consolidated revenue,
+    # so when member sums OVERSHOOT the dimensionless total the overage
+    # is exactly the subtotal mass (linkbases are often flat — AAPL
+    # nests Product⊃iPhone/Mac/iPad/Wearables in NEITHER def nor pre).
+    # The smallest member subset summing exactly to the overage is the
+    # subtotal set; ambiguity or no match marks nothing + WARNs.
+    # business_segment is excluded: its sum legitimately differs from
+    # consolidated (unallocated corporate items are filtered out via
+    # the ConsolidationItemsAxis route rule), so overage is signal-free.
+    groups: dict[tuple[DimensionalAxis, date | None, date], list[int]] = {}
+    for i, f in enumerate(facts):
+        if f.axis in ("product_service", "geographic") and f.metric == "revenue" and not f.is_subtotal:
+            groups.setdefault((f.axis, f.period_start, f.period_end), []).append(i)
+    for (axis, period_start, period_end), idxs in sorted(groups.items()):
+        if len(idxs) < 2:
+            continue
+        anchor = totals.get(("revenue", period_start, period_end))
+        if anchor is None:
+            rejections["no_consolidated_revenue_anchor"] = rejections.get("no_consolidated_revenue_anchor", 0) + 1
+            continue
+        total = anchor[2]
+        member_sum = sum(facts[i].val for i in idxs)
+        if member_sum <= total:
+            continue  # flat or partial disaggregation — nothing overlaps
+        target = member_sum - total
+        marked: tuple[int, ...] | None = None
+        ambiguous = False
+        for size in (1, 2, 3):
+            matches = [c for c in combinations(idxs, size) if sum(facts[i].val for i in c) == target]
+            if len(matches) == 1:
+                marked = matches[0]
+                break
+            if len(matches) > 1:
+                ambiguous = True
+                break
+        if marked is not None:
+            for i in marked:
+                facts[i] = replace(facts[i], is_subtotal=True)
+        else:
+            reason = "subtotal_set_ambiguous" if ambiguous else "subtotal_overage_unresolved"
+            rejections[reason] = rejections.get(reason, 0) + 1
+            logger.warning(
+                "dimensional facts: %s accession=%s axis=%s period_end=%s overage=%s",
+                reason,
+                accession,
+                axis,
+                period_end,
+                target,
+            )
+
+    return sorted(facts, key=lambda f: (f.axis, f.metric, f.period_end, f.member_qname))

--- a/app/services/dimensional_facts.py
+++ b/app/services/dimensional_facts.py
@@ -32,8 +32,8 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import date
-from itertools import combinations
 from decimal import Decimal, InvalidOperation
+from itertools import combinations
 from typing import Literal
 
 import lxml.etree as ET
@@ -427,9 +427,7 @@ def _instance_units(doc: ET._Element) -> dict[str, str]:
             for child in el.iter()
             if isinstance(child.tag, str) and ET.QName(child.tag).localname == "measure"
         ]
-        has_divide = any(
-            isinstance(child.tag, str) and ET.QName(child.tag).localname == "divide" for child in el
-        )
+        has_divide = any(isinstance(child.tag, str) and ET.QName(child.tag).localname == "divide" for child in el)
         if has_divide or len(measures) != 1 or not measures[0]:
             continue
         measure = measures[0]
@@ -631,13 +629,10 @@ def extract_dimensional_facts(
     for parent, child in member_tree:
         children_of.setdefault(parent, set()).add(child)
     subtotal_frags: dict[DimensionalAxis, set[str]] = {
-        axis: {m for m in members if children_of.get(m, set()) & members}
-        for axis, members in members_by_axis.items()
+        axis: {m for m in members if children_of.get(m, set()) & members} for axis, members in members_by_axis.items()
     }
     facts = [
-        replace(f, is_subtotal=True)
-        if _member_fragment(f.member_qname) in subtotal_frags.get(f.axis, set())
-        else f
+        replace(f, is_subtotal=True) if _member_fragment(f.member_qname) in subtotal_frags.get(f.axis, set()) else f
         for f in facts
     ]
 

--- a/app/services/dimensional_facts.py
+++ b/app/services/dimensional_facts.py
@@ -617,22 +617,27 @@ def extract_dimensional_facts(
 
     facts = [fact for _, _, fact in candidates.values()]
 
-    # Subtotal post-pass: a member is a subtotal on its axis when the
-    # definition linkbase says it parents another member that ALSO has
-    # a fact on that axis (e.g. us-gaap:ProductMember over
-    # iPhone/Mac/iPad/Wearables). A hierarchy parent with no reported
-    # children stays a leaf — it is the finest grain the filer gave us.
-    members_by_axis: dict[DimensionalAxis, set[str]] = {}
+    # Subtotal post-pass: a member is a subtotal when the definition
+    # linkbase says it parents another member that ALSO has a fact in
+    # the SAME (axis, metric, period) group (e.g. us-gaap:ProductMember
+    # over iPhone/Mac/iPad/Wearables). Scoping per group — not per axis
+    # — matters (#554 Codex pre-push finding): a 10-K carries 3 FYs of
+    # comparatives, and a parent whose children are reported only for a
+    # PRIOR year is the finest grain the filer gave us for the latest
+    # year; marking it axis-wide would blank the latest-FY rows. A
+    # hierarchy parent with no reported children stays a leaf.
+    members_by_group: dict[tuple[DimensionalAxis, DimensionalMetric, date | None, date], set[str]] = {}
     for f in facts:
-        members_by_axis.setdefault(f.axis, set()).add(_member_fragment(f.member_qname))
+        gkey = (f.axis, f.metric, f.period_start, f.period_end)
+        members_by_group.setdefault(gkey, set()).add(_member_fragment(f.member_qname))
     children_of: dict[str, set[str]] = {}
     for parent, child in member_tree:
         children_of.setdefault(parent, set()).add(child)
-    subtotal_frags: dict[DimensionalAxis, set[str]] = {
-        axis: {m for m in members if children_of.get(m, set()) & members} for axis, members in members_by_axis.items()
-    }
     facts = [
-        replace(f, is_subtotal=True) if _member_fragment(f.member_qname) in subtotal_frags.get(f.axis, set()) else f
+        replace(f, is_subtotal=True)
+        if children_of.get(_member_fragment(f.member_qname), set())
+        & members_by_group[(f.axis, f.metric, f.period_start, f.period_end)]
+        else f
         for f in facts
     ]
 

--- a/app/services/dimensional_facts_store.py
+++ b/app/services/dimensional_facts_store.py
@@ -116,12 +116,18 @@ _ANNUAL_DURATION_SQL = "(f.period_start IS NULL OR (f.period_end - f.period_star
 
 _METRIC_ROWS_SQL = f"""
 WITH winner AS (
-    SELECT source_accession, filed_at
-      FROM instrument_dimensional_facts
-     WHERE instrument_id = %(instrument_id)s
-       AND axis = %(axis)s
-       AND metric = %(metric)s
-     ORDER BY filed_at DESC, source_accession DESC
+    -- Winner = latest accession HAVING eligible rows (annual-duration,
+    -- non-subtotal). Selecting before filtering would let a 10-K/A
+    -- carrying only quarterly/YTD or only subtotal rows win and blank
+    -- the metric (#554 Codex pre-push finding).
+    SELECT f.source_accession, f.filed_at
+      FROM instrument_dimensional_facts f
+     WHERE f.instrument_id = %(instrument_id)s
+       AND f.axis = %(axis)s
+       AND f.metric = %(metric)s
+       AND NOT f.is_subtotal
+       AND {_ANNUAL_DURATION_SQL}
+     ORDER BY f.filed_at DESC, f.source_accession DESC
      LIMIT 1
 ),
 target AS (

--- a/app/services/dimensional_facts_store.py
+++ b/app/services/dimensional_facts_store.py
@@ -1,0 +1,201 @@
+"""DB layer for dimensional XBRL facts (#554).
+
+Writer: per-accession delete-then-insert (spec §D4 — rows are
+immutable in normal operation; a rewash of an accession replaces its
+rows in one transaction, stamping the new parser_version).
+
+Reader: winning accession per (instrument, axis, METRIC) — not per
+axis — so a 10-K/A that restates revenue but omits operating income
+cannot regress the omitted metric to empty (spec §D4, Codex ckpt-1
+HIGH). "Latest FY" is per metric kind: duration metrics take the
+winner's max period_end among annual durations (330–400 days, which
+excludes the quarterly/YTD contexts a 10-K also carries); the instant
+metric (assets) takes the winner's max instant. Subtotal rows are
+excluded — leaf rows sum to the consolidated figure (spec §D3).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+from app.services.dimensional_facts import (
+    DimensionalAxis,
+    DimensionalFact,
+    DimensionalMetric,
+)
+
+logger = logging.getLogger(__name__)
+
+_METRICS: tuple[DimensionalMetric, ...] = ("revenue", "operating_income", "assets")
+
+
+def replace_accession_rows(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    source_accession: str,
+    form_type: str,
+    filed_at: datetime,
+    parser_version: str,
+    facts: list[DimensionalFact],
+) -> int:
+    """Replace all dimensional-fact rows for one (instrument, accession).
+
+    Runs in the caller's transaction (the sec_10k parser wraps this in
+    its own savepoint). Returns the number of rows inserted.
+    """
+    conn.execute(
+        "DELETE FROM instrument_dimensional_facts WHERE instrument_id = %s AND source_accession = %s",
+        (instrument_id, source_accession),
+    )
+    if not facts:
+        return 0
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO instrument_dimensional_facts (
+                instrument_id, axis, member_qname, member_label, metric,
+                unit, is_subtotal, period_start, period_end, val, decimals,
+                source_accession, form_type, filed_at, parser_version
+            ) VALUES (
+                %(instrument_id)s, %(axis)s, %(member_qname)s, %(member_label)s,
+                %(metric)s, %(unit)s, %(is_subtotal)s, %(period_start)s,
+                %(period_end)s, %(val)s, %(decimals)s, %(source_accession)s,
+                %(form_type)s, %(filed_at)s, %(parser_version)s
+            )
+            """,
+            [
+                {
+                    "instrument_id": instrument_id,
+                    "axis": f.axis,
+                    "member_qname": f.member_qname,
+                    "member_label": f.member_label,
+                    "metric": f.metric,
+                    "unit": f.unit,
+                    "is_subtotal": f.is_subtotal,
+                    "period_start": f.period_start,
+                    "period_end": f.period_end,
+                    "val": f.val,
+                    "decimals": f.decimals,
+                    "source_accession": source_accession,
+                    "form_type": form_type,
+                    "filed_at": filed_at,
+                    "parser_version": parser_version,
+                }
+                for f in facts
+            ],
+        )
+        # psycopg3 executemany rowcount is cumulative across the batch
+        # (python-hygiene skill, empirically pinned in
+        # test_sec_13f_dataset_ingest).
+        return cur.rowcount
+
+
+@dataclass(frozen=True)
+class SegmentsReadResult:
+    """Latest-FY leaf rows for one (instrument, axis), merged by member."""
+
+    axis: DimensionalAxis
+    period_end: date | None
+    filed_at: datetime | None
+    sources: dict[str, str]  # metric → winning accession
+    rows: list[dict[str, Any]]  # member_qname, member_label, <metric>: Decimal|None
+
+
+# Annual-duration window in days: catches 52/53-week fiscal years
+# (AAPL-style) without admitting the quarterly/YTD contexts a 10-K
+# also carries.
+_ANNUAL_DURATION_SQL = "(f.period_start IS NULL OR (f.period_end - f.period_start) BETWEEN 330 AND 400)"
+
+_METRIC_ROWS_SQL = f"""
+WITH winner AS (
+    SELECT source_accession, filed_at
+      FROM instrument_dimensional_facts
+     WHERE instrument_id = %(instrument_id)s
+       AND axis = %(axis)s
+       AND metric = %(metric)s
+     ORDER BY filed_at DESC, source_accession DESC
+     LIMIT 1
+),
+target AS (
+    SELECT MAX(f.period_end) AS period_end
+      FROM instrument_dimensional_facts f
+      JOIN winner w ON w.source_accession = f.source_accession
+     WHERE f.instrument_id = %(instrument_id)s
+       AND f.axis = %(axis)s
+       AND f.metric = %(metric)s
+       AND {_ANNUAL_DURATION_SQL}
+)
+SELECT f.member_qname, f.member_label, f.val,
+       f.period_end, w.source_accession, w.filed_at
+  FROM instrument_dimensional_facts f
+  JOIN winner w ON w.source_accession = f.source_accession
+  JOIN target t ON t.period_end = f.period_end
+ WHERE f.instrument_id = %(instrument_id)s
+   AND f.axis = %(axis)s
+   AND f.metric = %(metric)s
+   AND NOT f.is_subtotal
+   AND {_ANNUAL_DURATION_SQL}
+ ORDER BY f.val DESC, f.member_qname
+"""
+
+
+def read_segments(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    axis: DimensionalAxis,
+) -> SegmentsReadResult:
+    """Latest-FY leaf rows for an axis, one merged row per member."""
+    sources: dict[str, str] = {}
+    period_end: date | None = None
+    filed_at: datetime | None = None
+    merged: dict[str, dict[str, Any]] = {}
+    member_order: list[str] = []
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        for metric in _METRICS:
+            cur.execute(
+                _METRIC_ROWS_SQL,
+                {"instrument_id": instrument_id, "axis": axis, "metric": metric},
+            )
+            rows = cur.fetchall()
+            if not rows:
+                continue
+            sources[metric] = rows[0]["source_accession"]
+            # Revenue (always present when the axis has data, queried
+            # first) pins the headline period; assets instants and
+            # op-income durations from the same FY share it.
+            if period_end is None:
+                period_end = rows[0]["period_end"]
+            if filed_at is None or rows[0]["filed_at"] > filed_at:
+                filed_at = rows[0]["filed_at"]
+            for row in rows:
+                member = row["member_qname"]
+                entry = merged.get(member)
+                if entry is None:
+                    entry = {
+                        "member_qname": member,
+                        "member_label": row["member_label"],
+                        "revenue": None,
+                        "operating_income": None,
+                        "assets": None,
+                    }
+                    merged[member] = entry
+                    member_order.append(member)
+                entry[metric] = Decimal(row["val"]) if not isinstance(row["val"], Decimal) else row["val"]
+
+    return SegmentsReadResult(
+        axis=axis,
+        period_end=period_end,
+        filed_at=filed_at,
+        sources=sources,
+        rows=[merged[m] for m in member_order],
+    )

--- a/app/services/dimensional_facts_store.py
+++ b/app/services/dimensional_facts_store.py
@@ -131,12 +131,17 @@ WITH winner AS (
      LIMIT 1
 ),
 target AS (
+    -- Same eligibility filters as winner + main query: a CTE chain
+    -- whose stages disagree on filters can anchor on a row the final
+    -- join then excludes, returning zero rows despite eligible data
+    -- (review-bot WARNING on PR #1588).
     SELECT MAX(f.period_end) AS period_end
       FROM instrument_dimensional_facts f
       JOIN winner w ON w.source_accession = f.source_accession
      WHERE f.instrument_id = %(instrument_id)s
        AND f.axis = %(axis)s
        AND f.metric = %(metric)s
+       AND NOT f.is_subtotal
        AND {_ANNUAL_DURATION_SQL}
 )
 SELECT f.member_qname, f.member_label, f.val,

--- a/app/services/manifest_parsers/sec_10k.py
+++ b/app/services/manifest_parsers/sec_10k.py
@@ -72,6 +72,8 @@ from app.services.business_summary import (
     upsert_business_sections,
     upsert_business_summary,
 )
+from app.services.dimensional_facts import discover_xbrl_files, extract_dimensional_facts
+from app.services.dimensional_facts_store import replace_accession_rows
 from app.services.manifest_parsers._classify import (
     format_upsert_error,
     is_transient_upsert_error,
@@ -92,7 +94,9 @@ logger = logging.getLogger(__name__)
 # can rewash without colliding with the other. Mirror the convention
 # in def14a.py (``_PARSER_VERSION_DEF14A``) + insider_345.py
 # (``_PARSER_VERSION_FORM4``).
-_PARSER_VERSION_10K = "10k-v1"
+# v2 (#554): dimensional XBRL step added — bump drives the
+# sec_rebuild backfill across all 10-K accessions.
+_PARSER_VERSION_10K = "10k-v2"
 
 # Explicit 1h backoff. Duplicated from the worker's internal
 # ``_backoff_for(0)`` value — see eight_k.py for the rationale
@@ -129,6 +133,73 @@ def _fetch_html(
         return provider.fetch_document_text(url)
 
 
+class _DimensionalFetchError(Exception):
+    """Transport-level failure in the dimensional-facts step — maps to
+    a ``failed`` outcome so the whole manifest row retries (idempotent:
+    the Item 1 upsert is filed_at-gate-suppressed on the retry and the
+    dimensional write is delete-then-insert)."""
+
+
+def _fetch_dimensional_facts(
+    *,
+    accession: str,
+    issuer_cik: str | None,
+    primary_document_url: str,
+) -> list[Any]:
+    """Fetch + extract dimensional XBRL facts for THIS accession (#554).
+
+    Always targets ``accession``'s own archive — never the Item-1
+    fallback's ``chosen_accession`` (a 10-K/A without Item 1 borrows
+    the prior 10-K's narrative, but its XBRL, when present, is its
+    own; spec §D1).
+
+    Pure I/O + parse; no DB. Returns ``[]`` on the structural no-XBRL
+    path (pre-mandate filings, 404'd index, empty instance). Raises
+    :class:`_DimensionalFetchError` on transport failures and lets
+    parse errors (``ValueError`` etc.) propagate for the caller's
+    degrade-to-parsed handling.
+
+    The instance is parse-and-drop — NOT retained in
+    ``filing_raw_documents`` (raw-payload scope narrowing #470: every
+    extracted field lands in SQL).
+    """
+    base = primary_document_url.rsplit("/", 1)[0] + "/"
+    primary_name = primary_document_url.rsplit("/", 1)[-1]
+
+    with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+        try:
+            raw_index = provider.fetch_filing_index(accession, issuer_cik=issuer_cik)
+        except Exception as exc:  # noqa: BLE001 — transport; retry via worker backoff
+            raise _DimensionalFetchError(f"dimensional index fetch error: {exc}") from exc
+        if raw_index is None:
+            return []
+
+        refs = discover_xbrl_files(raw_index, primary_document_name=primary_name)
+        if refs is None:
+            return []
+
+        def _fetch(name: str) -> bytes | None:
+            try:
+                text = provider.fetch_document_text(base + name)
+            except Exception as exc:  # noqa: BLE001 — transport; retry via worker backoff
+                raise _DimensionalFetchError(f"dimensional fetch error {name}: {exc}") from exc
+            # SEC EDGAR serves ASCII-clean XML; the provider decodes to
+            # str, so re-encode for lxml (which refuses str inputs that
+            # carry an encoding declaration).
+            return text.encode("utf-8") if text else None
+
+        instance = _fetch(refs.instance_name)
+        if instance is None:
+            return []
+        label = _fetch(refs.label_name) if refs.label_name else None
+        if refs.definition_name == refs.label_name:
+            definition = label  # xsd fallback serves both — one fetch
+        else:
+            definition = _fetch(refs.definition_name) if refs.definition_name else None
+
+    return extract_dimensional_facts(instance, label, definition, accession=accession)
+
+
 def _parse_sec_10k(
     conn: psycopg.Connection[Any],
     row: Any,  # ManifestRow — forward-ref to avoid circular import
@@ -151,6 +222,12 @@ def _parse_sec_10k(
        in a nested savepoint logs + degrades to blob-only. Deterministic
        upsert error → tombstone with the savepoint rolling back partial
        fan-out state.
+    9. Dimensional XBRL facts (#554): fetch THIS accession's instance
+       (+ lab/def linkbases) through the throttled provider, extract
+       segment/product/geographic facts, delete-then-insert per
+       sibling in a separate savepoint. Degrades to
+       parsed-without-segments on parse/write bugs; transport errors
+       retry the whole row.
     """
     from app.jobs.sec_manifest_worker import ParseOutcome
 
@@ -409,6 +486,60 @@ def _parse_sec_10k(
             raw_status="stored",
             error=format_upsert_error(exc),
         )
+
+    # 7. Dimensional XBRL facts (#554, spec §D1 step 2). Failure
+    # semantics: transport error → failed (whole row retries,
+    # idempotent — Item 1 is gate-suppressed, dimensional write is
+    # delete-then-insert; the narrative may be visible before segments
+    # land on the retry, intended); structural no-XBRL → parsed, zero
+    # rows; parse/write error → WARN + parsed-without-segments (a
+    # segment bug must NOT regress the narrative), transient DB error
+    # excepted (→ failed).
+    if filed_at is None:
+        logger.warning(
+            "sec_10k manifest parser: accession=%s has no filed_at; skipping dimensional facts",
+            accession,
+        )
+    else:
+        try:
+            dimensional = _fetch_dimensional_facts(
+                accession=accession,
+                issuer_cik=None if issuer_cik == _CIK_MISSING_SENTINEL else issuer_cik,
+                primary_document_url=url,
+            )
+        except _DimensionalFetchError as exc:
+            return _failed_outcome(str(exc), raw_status="stored")
+        except Exception:  # noqa: BLE001 — degrade: narrative already written
+            logger.warning(
+                "sec_10k manifest parser: dimensional extraction failed accession=%s "
+                "(narrative intact; parsed without segments)",
+                accession,
+                exc_info=True,
+            )
+            dimensional = None
+
+        if dimensional is not None:
+            try:
+                with conn.transaction():
+                    for sibling_iid in siblings:
+                        replace_accession_rows(
+                            conn,
+                            instrument_id=sibling_iid,
+                            source_accession=accession,
+                            form_type=form,
+                            filed_at=filed_at,
+                            parser_version=_PARSER_VERSION_10K,
+                            facts=dimensional,
+                        )
+            except Exception as exc:  # noqa: BLE001
+                if is_transient_upsert_error(exc):
+                    return _failed_outcome(format_upsert_error(exc), raw_status="stored")
+                logger.warning(
+                    "sec_10k manifest parser: dimensional write failed accession=%s "
+                    "(narrative intact; parsed without segments)",
+                    accession,
+                    exc_info=True,
+                )
 
     return ParseOutcome(
         status="parsed",

--- a/app/services/manifest_parsers/sec_10k.py
+++ b/app/services/manifest_parsers/sec_10k.py
@@ -222,12 +222,15 @@ def _parse_sec_10k(
        in a nested savepoint logs + degrades to blob-only. Deterministic
        upsert error → tombstone with the savepoint rolling back partial
        fan-out state.
-    9. Dimensional XBRL facts (#554): fetch THIS accession's instance
-       (+ lab/def linkbases) through the throttled provider, extract
-       segment/product/geographic facts, delete-then-insert per
-       sibling in a separate savepoint. Degrades to
-       parsed-without-segments on parse/write bugs; transport errors
-       retry the whole row.
+    Dimensional XBRL facts (#554) run as step 2.5 — after store_raw,
+    BEFORE the narrative parse — so an Item-1 tombstone cannot
+    suppress segments (spec §D1 independence in BOTH directions; the
+    MSFT FY2025 dev backfill caught the original post-narrative
+    ordering): fetch THIS accession's instance (+ lab/def linkbases)
+    through the throttled provider, extract, delete-then-insert per
+    sibling in a separate savepoint. Degrades to
+    continue-without-segments on parse/write bugs; transport errors
+    retry the whole row.
     """
     from app.jobs.sec_manifest_worker import ParseOutcome
 
@@ -297,6 +300,62 @@ def _parse_sec_10k(
             accession,
         )
         return _failed_outcome(f"store_raw error: {exc}")
+
+    # 2.5. Dimensional XBRL facts (#554, spec §D1 step 2). Runs BEFORE
+    # the narrative parse so an Item-1 tombstone (e.g. a filer whose
+    # 10-K defeats the Item 1 extractor — MSFT FY2025 in the dev
+    # backfill) cannot suppress segments: the spec invariant is that
+    # narrative and dimensional failures are independent in BOTH
+    # directions. Failure semantics: transport error → failed (whole
+    # row retries; idempotent — Item 1 is filed_at-gate-suppressed,
+    # dimensional write is delete-then-insert; a narrative may become
+    # visible before segments on the retry, intended); structural
+    # no-XBRL → zero rows; parse/write error → WARN +
+    # continue-without-segments (a segment bug must NOT regress the
+    # narrative), transient DB error excepted (→ failed).
+    if filed_at is None:
+        logger.warning(
+            "sec_10k manifest parser: accession=%s has no filed_at; skipping dimensional facts",
+            accession,
+        )
+    else:
+        try:
+            dimensional = _fetch_dimensional_facts(
+                accession=accession,
+                issuer_cik=None if issuer_cik == _CIK_MISSING_SENTINEL else issuer_cik,
+                primary_document_url=url,
+            )
+        except _DimensionalFetchError as exc:
+            return _failed_outcome(str(exc), raw_status="stored")
+        except Exception:  # noqa: BLE001 — degrade: narrative pipeline continues
+            logger.warning(
+                "sec_10k manifest parser: dimensional extraction failed accession=%s (continuing without segments)",
+                accession,
+                exc_info=True,
+            )
+            dimensional = None
+
+        if dimensional is not None:
+            try:
+                with conn.transaction():
+                    for sibling_iid in _resolve_siblings(conn, instrument_id=instrument_id, issuer_cik=issuer_cik):
+                        replace_accession_rows(
+                            conn,
+                            instrument_id=sibling_iid,
+                            source_accession=accession,
+                            form_type=form,
+                            filed_at=filed_at,
+                            parser_version=_PARSER_VERSION_10K,
+                            facts=dimensional,
+                        )
+            except Exception as exc:  # noqa: BLE001
+                if is_transient_upsert_error(exc):
+                    return _failed_outcome(format_upsert_error(exc), raw_status="stored")
+                logger.warning(
+                    "sec_10k manifest parser: dimensional write failed accession=%s (continuing without segments)",
+                    accession,
+                    exc_info=True,
+                )
 
     # 3. Parse Item 1. The bare-call-after-committed-savepoint rule
     # (PR #1126) — wrap the next expression that can raise so an
@@ -486,60 +545,6 @@ def _parse_sec_10k(
             raw_status="stored",
             error=format_upsert_error(exc),
         )
-
-    # 7. Dimensional XBRL facts (#554, spec §D1 step 2). Failure
-    # semantics: transport error → failed (whole row retries,
-    # idempotent — Item 1 is gate-suppressed, dimensional write is
-    # delete-then-insert; the narrative may be visible before segments
-    # land on the retry, intended); structural no-XBRL → parsed, zero
-    # rows; parse/write error → WARN + parsed-without-segments (a
-    # segment bug must NOT regress the narrative), transient DB error
-    # excepted (→ failed).
-    if filed_at is None:
-        logger.warning(
-            "sec_10k manifest parser: accession=%s has no filed_at; skipping dimensional facts",
-            accession,
-        )
-    else:
-        try:
-            dimensional = _fetch_dimensional_facts(
-                accession=accession,
-                issuer_cik=None if issuer_cik == _CIK_MISSING_SENTINEL else issuer_cik,
-                primary_document_url=url,
-            )
-        except _DimensionalFetchError as exc:
-            return _failed_outcome(str(exc), raw_status="stored")
-        except Exception:  # noqa: BLE001 — degrade: narrative already written
-            logger.warning(
-                "sec_10k manifest parser: dimensional extraction failed accession=%s "
-                "(narrative intact; parsed without segments)",
-                accession,
-                exc_info=True,
-            )
-            dimensional = None
-
-        if dimensional is not None:
-            try:
-                with conn.transaction():
-                    for sibling_iid in siblings:
-                        replace_accession_rows(
-                            conn,
-                            instrument_id=sibling_iid,
-                            source_accession=accession,
-                            form_type=form,
-                            filed_at=filed_at,
-                            parser_version=_PARSER_VERSION_10K,
-                            facts=dimensional,
-                        )
-            except Exception as exc:  # noqa: BLE001
-                if is_transient_upsert_error(exc):
-                    return _failed_outcome(format_upsert_error(exc), raw_status="stored")
-                logger.warning(
-                    "sec_10k manifest parser: dimensional write failed accession=%s "
-                    "(narrative intact; parsed without segments)",
-                    accession,
-                    exc_info=True,
-                )
 
     return ParseOutcome(
         status="parsed",

--- a/app/services/manifest_parsers/sec_10k.py
+++ b/app/services/manifest_parsers/sec_10k.py
@@ -163,8 +163,23 @@ def _fetch_dimensional_facts(
     ``filing_raw_documents`` (raw-payload scope narrowing #470: every
     extracted field lands in SQL).
     """
-    base = primary_document_url.rsplit("/", 1)[0] + "/"
-    primary_name = primary_document_url.rsplit("/", 1)[-1]
+    # Archive base is built from (cik, accession) — the same shape
+    # filing_documents.py uses — NEVER from the primary URL's directory:
+    # legacy manifest rows carry the full-submission ``.txt`` URL
+    # (``…/data/{cik}/{accn}.txt``), whose dirname is the CIK root, so
+    # every artifact fetch would 404 and the step would silently yield
+    # zero facts (caught live on GME/HD/JPM in the dev backfill).
+    if issuer_cik is None or not issuer_cik.strip().isdigit():
+        logger.warning(
+            "sec_10k manifest parser: accession=%s has no usable issuer cik; skipping dimensional facts",
+            accession,
+        )
+        return []
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(issuer_cik)}/{accession.replace('-', '')}/"
+    primary_basename = primary_document_url.rsplit("/", 1)[-1]
+    # Full-submission .txt names carry no useful stem for discovery
+    # preference; pass None so discovery falls back to its size rules.
+    primary_name = None if primary_basename.lower().endswith(".txt") else primary_basename
 
     with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
         try:

--- a/app/services/n_csr_extractor.py
+++ b/app/services/n_csr_extractor.py
@@ -56,9 +56,17 @@ import lxml.etree as ET
 
 from app.services.xbrl_instance import (
     SAFE_XML_PARSER,
+)
+from app.services.xbrl_instance import (
     axis_localname as _axis_localname,
+)
+from app.services.xbrl_instance import (
     context_dimensions as _context_dimensions,
+)
+from app.services.xbrl_instance import (
     context_period as _context_period,
+)
+from app.services.xbrl_instance import (
     member_localname as _member_localname,
 )
 

--- a/app/services/n_csr_extractor.py
+++ b/app/services/n_csr_extractor.py
@@ -54,6 +54,14 @@ from typing import Any
 
 import lxml.etree as ET
 
+from app.services.xbrl_instance import (
+    SAFE_XML_PARSER,
+    axis_localname as _axis_localname,
+    context_dimensions as _context_dimensions,
+    context_period as _context_period,
+    member_localname as _member_localname,
+)
+
 logger = logging.getLogger(__name__)
 
 # Hard cap on raw_facts serialized size (spec §5 Tier 3).
@@ -186,33 +194,6 @@ class FundMetadataFacts:
     raw_facts: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
 
 
-def _member_localname(member_ref: str | None) -> str | None:
-    """Strip namespace prefix + ``Member`` suffix from a dimension member ref.
-
-    ``fmr:C000203453Member`` → ``C000203453``
-    ``oef:IndustrySectorOneMember`` → ``IndustrySectorOne``
-    ``OneYearMember`` → ``OneYear``
-    """
-    if not member_ref:
-        return None
-    val = member_ref.strip()
-    if ":" in val:
-        val = val.rsplit(":", 1)[1]
-    if val.endswith("Member"):
-        val = val[: -len("Member")]
-    return val or None
-
-
-def _axis_localname(axis_qname: str | None) -> str | None:
-    """Strip namespace prefix from an axis QName (``oef:ClassAxis`` → ``ClassAxis``)."""
-    if not axis_qname:
-        return None
-    val = axis_qname.strip()
-    if ":" in val:
-        val = val.rsplit(":", 1)[1]
-    return val or None
-
-
 def _to_decimal(text: str | None) -> Decimal | None:
     if text is None:
         return None
@@ -269,48 +250,6 @@ def _strip_html(text: str | None) -> str | None:
         # Decode back, ignoring partial last char.
         plain = encoded.decode("utf-8", errors="ignore") + " [TRUNCATED]"
     return plain
-
-
-def _context_dimensions(ctx_el: ET._Element) -> dict[str, str]:
-    """Return ``{axis_qname: member_qname}`` for a context's segment members."""
-    dims: dict[str, str] = {}
-    # Find xmlns-wildcard segment.
-    seg = None
-    for child in ctx_el.iter():
-        local = ET.QName(child.tag).localname if isinstance(child.tag, str) else None
-        if local == "segment":
-            seg = child
-            break
-    if seg is None:
-        return dims
-    for m in seg:
-        if not isinstance(m.tag, str):
-            continue
-        if ET.QName(m.tag).localname != "explicitMember":
-            continue
-        dim = m.get("dimension", "")
-        if dim:
-            dims[dim] = (m.text or "").strip()
-    return dims
-
-
-def _context_period(ctx_el: ET._Element) -> dict[str, str]:
-    """Return ``{startDate, endDate, instant}`` for a context's period."""
-    period_info: dict[str, str] = {}
-    period_el = None
-    for child in ctx_el:
-        if isinstance(child.tag, str) and ET.QName(child.tag).localname == "period":
-            period_el = child
-            break
-    if period_el is None:
-        return period_info
-    for child in period_el:
-        if not isinstance(child.tag, str):
-            continue
-        local = ET.QName(child.tag).localname
-        if local in {"startDate", "endDate", "instant"}:
-            period_info[local] = (child.text or "").strip()
-    return period_info
 
 
 def _context_entity_cik(ctx_el: ET._Element) -> str | None:
@@ -495,7 +434,8 @@ def extract_fund_metadata_facts(ixbrl_xml: bytes) -> list[FundMetadataFacts]:
         ValueError: on malformed iXBRL (caller maps to ``failed_outcome``).
     """
     try:
-        doc = ET.fromstring(ixbrl_xml)
+        # Hardened parser (#554): SEC-fetched XML, entity resolution off.
+        doc = ET.fromstring(ixbrl_xml, parser=SAFE_XML_PARSER)
     except ET.XMLSyntaxError as exc:  # pragma: no cover — error-path
         raise ValueError(f"iXBRL parse error: {exc}") from exc
 

--- a/app/services/xbrl_instance.py
+++ b/app/services/xbrl_instance.py
@@ -53,24 +53,27 @@ def member_localname(member_ref: str | None) -> str | None:
 
 
 def context_dimensions(ctx_el: ET._Element) -> dict[str, str]:
-    """Return ``{axis_qname: member_qname}`` for a context's segment members."""
+    """Return ``{axis_qname: member_qname}`` for a context's explicit
+    dimension members.
+
+    Reads BOTH the ``segment`` and ``scenario`` containers: the EDGAR
+    Filer Manual mandates segment, but valid XBRL may carry dimensions
+    in scenario — treating such a context as dimensionless would both
+    lose the fact and pollute consolidated-anchor arbitration
+    (#554 Codex pre-push finding)."""
     dims: dict[str, str] = {}
-    seg = None
     for child in ctx_el.iter():
         local = ET.QName(child.tag).localname if isinstance(child.tag, str) else None
-        if local == "segment":
-            seg = child
-            break
-    if seg is None:
-        return dims
-    for m in seg:
-        if not isinstance(m.tag, str):
+        if local not in {"segment", "scenario"}:
             continue
-        if ET.QName(m.tag).localname != "explicitMember":
-            continue
-        dim = m.get("dimension", "")
-        if dim:
-            dims[dim] = (m.text or "").strip()
+        for m in child:
+            if not isinstance(m.tag, str):
+                continue
+            if ET.QName(m.tag).localname != "explicitMember":
+                continue
+            dim = m.get("dimension", "")
+            if dim:
+                dims[dim] = (m.text or "").strip()
     return dims
 
 

--- a/app/services/xbrl_instance.py
+++ b/app/services/xbrl_instance.py
@@ -1,0 +1,93 @@
+"""Shared pure helpers for XBRL instance-document parsing.
+
+Extracted verbatim from ``n_csr_extractor`` (#554) so the dimensional
+fact extractor (``dimensional_facts``) and the N-CSR fund-metadata
+extractor share one implementation of context/dimension walking.
+
+All helpers use wildcard-namespace matching by ``localname`` — different
+filers emit different taxonomy versions and hard-coding namespace URIs
+breaks yearly with each SEC taxonomy release (n_csr_extractor design
+note, preserved here).
+"""
+
+from __future__ import annotations
+
+import lxml.etree as ET
+
+# Hardened parser for externally-fetched XML (SEC EDGAR artifacts).
+# SEC XBRL never relies on DTD entity substitution, so disabling
+# entity resolution / DTD loading / network access closes the XXE +
+# entity-expansion window with no functional cost.
+SAFE_XML_PARSER = ET.XMLParser(
+    resolve_entities=False,
+    load_dtd=False,
+    no_network=True,
+)
+
+
+def axis_localname(axis_qname: str | None) -> str | None:
+    """Strip namespace prefix from an axis QName (``oef:ClassAxis`` → ``ClassAxis``)."""
+    if not axis_qname:
+        return None
+    val = axis_qname.strip()
+    if ":" in val:
+        val = val.rsplit(":", 1)[1]
+    return val or None
+
+
+def member_localname(member_ref: str | None) -> str | None:
+    """Strip namespace prefix + ``Member`` suffix from a dimension member ref.
+
+    ``fmr:C000203453Member`` → ``C000203453``
+    ``oef:IndustrySectorOneMember`` → ``IndustrySectorOne``
+    ``OneYearMember`` → ``OneYear``
+    """
+    if not member_ref:
+        return None
+    val = member_ref.strip()
+    if ":" in val:
+        val = val.rsplit(":", 1)[1]
+    if val.endswith("Member"):
+        val = val[: -len("Member")]
+    return val or None
+
+
+def context_dimensions(ctx_el: ET._Element) -> dict[str, str]:
+    """Return ``{axis_qname: member_qname}`` for a context's segment members."""
+    dims: dict[str, str] = {}
+    seg = None
+    for child in ctx_el.iter():
+        local = ET.QName(child.tag).localname if isinstance(child.tag, str) else None
+        if local == "segment":
+            seg = child
+            break
+    if seg is None:
+        return dims
+    for m in seg:
+        if not isinstance(m.tag, str):
+            continue
+        if ET.QName(m.tag).localname != "explicitMember":
+            continue
+        dim = m.get("dimension", "")
+        if dim:
+            dims[dim] = (m.text or "").strip()
+    return dims
+
+
+def context_period(ctx_el: ET._Element) -> dict[str, str]:
+    """Return ``{startDate, endDate, instant}`` for a context's period."""
+    period_info: dict[str, str] = {}
+    period_el = None
+    for child in ctx_el:
+        if isinstance(child.tag, str) and ET.QName(child.tag).localname == "period":
+            period_el = child
+            break
+    if period_el is None:
+        return period_info
+    for child in period_el:
+        if not isinstance(child.tag, str):
+            continue
+        local = ET.QName(child.tag).localname
+        if local in {"startDate", "endDate", "instant"}:
+            period_info[local] = (child.text or "").strip()
+    return period_info

--- a/docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md
+++ b/docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md
@@ -72,20 +72,28 @@ edgartools' `filing.xbrl()` issues its own HTTP (instance + linkbases) outside
 hard-stop for new paths. Instead:
 
 1. Fetch the filing `index.json` (already-throttled wrapper).
-2. Locate the extracted instance with deterministic priority (Codex ckpt-1 MED):
-   (a) the `EX-101.INS` exhibit entry if present (standalone-instance era,
-   pre-2019-ish); (b) else files whose name case-insensitively ends `_htm.xml`
-   (inline era) — if several, prefer the one whose stem matches the primary
-   document's stem, else lexicographically-first + WARN with provenance.
-   Neither present → no-XBRL skip path. Each branch gets a table-test.
-3. Locate the label linkbase `*_lab.xml` for member labels; absent → prettified member
-   localname fallback.
-4. Parse with lxml, reusing the `n_csr_extractor.py` machinery shape:
-   `_context_dimensions` (context → `{axis: member}`), wildcard-namespace matching,
-   `(concept, axis)` routing.
+2. Locate the extracted instance with deterministic priority (Codex ckpt-1 MED;
+   detection rules CORRECTED after live verification — `index.json` carries NO
+   SEC exhibit-type labels, its `type` field is a content-type icon, so the
+   original EX-101.INS plan is impossible from the listing): (a) files ending
+   `_htm.xml` (inline era) — several → prefer primary-document stem match, else
+   largest-size + WARN; (b) else standalone-era `.xml` files that are not
+   linkbases (`_cal/_def/_lab/_pre/_ref`), not `R<n>.xml`/`FilingSummary.xml`,
+   not index files — same tie-break. Neither → no-XBRL skip. Each branch
+   table-tested.
+3. Locate label (`*_lab.xml`) + definition (`*_def.xml`) linkbases; when a filer
+   ships no standalone linkbases (Workiva-style — verified on MSFT FY2025), fall
+   back to the filing `.xsd`, which embeds labelLink/definitionLink in its
+   annotation; the parsers match by localname so the xsd is a drop-in source.
+   Labels absent entirely → prettified member localname fallback.
+4. Parse with lxml via the shared `xbrl_instance` helpers (extracted from
+   `n_csr_extractor.py`): `context_dimensions` (context → `{axis: member}`),
+   wildcard-namespace matching, `(concept, axis)` routing. Hardened parser
+   (entity resolution / DTD / network off) for all SEC-fetched XML.
 
-Cost: 2–3 throttled fetches per accession (index + instance + lab). Backfill of ~25k
-10-K accessions ≈ 50–75k fetches ≈ <2.5h at the shared 10 req/s floor.
+Cost: 3–4 throttled fetches per accession (index + instance + lab + def, the
+latter two sometimes one xsd). Backfill of ~25k 10-K accessions ≈ ≤100k fetches
+≈ <3h at the shared 10 req/s floor.
 
 ### D3 — axes and metrics ingested
 
@@ -121,6 +129,22 @@ internally consistent). Operating income = `us-gaap:OperatingIncomeLoss`; assets
 Duplicate-fact arbitration (Codex ckpt-1 MED): when the instance repeats the same
 (concept, context, unit), keep the most precise (`decimals`, with `INF` highest);
 equal precision with differing values → drop that member + WARN with provenance.
+
+**Subtotal members (added after live verification — the issue/spec originally
+missed this):** member sets are NOT flat. AAPL's product axis carries
+`us-gaap:ProductMember` ($307.0B) as the parent subtotal of iPhone/Mac/iPad/
+Wearables; summing returned rows would double-count (723B vs 416B). Rows carry
+`is_subtotal`, marked by TWO detectors: (a) definition-linkbase domain-member
+nesting (filers who nest; both AAPL linkbases are FLAT, so insufficient alone);
+(b) value-overage — revenue on product/geographic axes only, where ASC 606
+disaggregation reconciles to the consolidated (dimensionless) revenue fact in
+the same instance: `sum(members) − consolidated` is exactly the subtotal mass;
+the smallest member subset (≤3) summing exactly to it is marked; ambiguity or
+no-match marks nothing + WARNs. business_segment is excluded from (b) — its sum
+legitimately differs from consolidated (unallocated corporate items filtered via
+ConsolidationItemsAxis). Verified: AAPL Product; MSFT Product + Service,Other
+(xsd-embedded linkbases); JPM 'Total International' (= EMEA+APAC+LatAm exactly).
+Readers exclude subtotals; leaf sums reconcile (AAPL 416.161B on both axes).
 
 Financials-sector caveat: banks (JPM) may emit none of the revenue aliases on these
 axes → endpoint returns empty state, acceptable v1, recorded in smoke results.

--- a/docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md
+++ b/docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md
@@ -1,0 +1,304 @@
+# #554 — XBRL dimensional facts: segments, product mix, geographic revenue
+
+Status: PROPOSAL — Codex ckpt-1 PASSED 2026-06-11 (3 HIGH / 4 MED / 1 LOW, all folded
+in: per-route axis-set rule, per-member alias arbitration, per-(axis,metric) winner,
+deterministic instance discovery, decimals + duplicate arbitration, annual-duration
+definition, parser_version rewash path, axis-mapping test pin). Awaiting operator
+sign-off.
+Issue: #554 (carve-out of #551; #551 closed 2026-06-11 — headcount half shipped PR#555/888db1af)
+
+## 1. Premise corrections (all empirically verified 2026-06-11)
+
+The issue body says "extend SEC XBRL provider to emit dimensional facts". Four premises
+needed correction before design:
+
+1. **The companyfacts API carries NO dimensional facts.** Verified live: AAPL
+   `CIK0000320193.json`, union of fact keys across all 503 concepts =
+   `{accn, end, filed, form, fp, frame, fy, start, val}`. No axis/member fields exist
+   at the source. Segment data cannot come from the current `sec_fundamentals`
+   provider path at all — it requires per-filing XBRL instance parsing.
+2. **#551's "5 Apple segments (iPhone, Mac, iPad, Wearables, Services)" are NOT
+   business segments.** They are `srt:ProductOrServiceAxis` revenue disaggregation.
+   AAPL's actual reportable segments (`us-gaap:StatementBusinessSegmentsAxis`) are
+   geographic: Americas / Europe / Greater China / Japan / Rest of Asia Pacific.
+   Verified on AAPL FY2025 10-K (accn 0000320193-25-000079): product axis sums to
+   $416.16B total revenue ✓, segment axis sums to $416.16B ✓. We must ingest
+   **three axes**, not one.
+3. **`country_code` is the wrong column.** Geographic members mix ISO-backed qnames
+   (`country:US`, `country:CN`) with filer-custom members
+   (`aapl:OtherCountriesMember`). Store member qname + label, never force ISO.
+4. **Per-segment `total_assets` is optional in the wild.** AAPL reports segment
+   revenue + operating income but zero segment-asset facts (ASC 280 requires assets
+   only if CODM-reviewed). Column nullable; not in acceptance.
+
+Generality probe: MSFT FY2025 10-K segment revenue = Productivity $120.81B /
+Intelligent Cloud $106.27B / More Personal Computing $54.65B ✓.
+
+## 2. Settled decisions honoured
+
+- **Fundamentals posture (#532)**: free regulated-source-only. The instance documents
+  are EDGAR archive artifacts — same source, no new provider.
+- **Process topology (#719) + manifest single-writer (#869)**: extraction runs in the
+  manifest worker, not the API process.
+- **Raw-payload scope-narrowing (#470, prevention log §547)**: every extracted field
+  lands in SQL → instance XML is parse-and-drop, NOT retained in
+  `filing_raw_documents`. (At ~1–5 MB × ~25k filings, retention would re-create the
+  #1014 problem.)
+- **Filing lookup rule**: CIK-keyed, accession-driven; no symbol lookups.
+- **Prevention log §1455 (period sanity window)**: parser validates
+  `[1900-01-01, 2100-01-01)` + `period_start <= period_end`, reject + WARN with
+  provenance, mirror predicate in any cleanup tool.
+
+## 3. Design
+
+### D1 — extraction lives in the existing `sec_10k` manifest parser, version bump `10k-v2`
+
+`_FORM_TO_SOURCE` is one-source-per-form and `10-K`/`10-K/A` already map to `sec_10k`
+(Item 1 narrative, `app/services/manifest_parsers/sec_10k.py`). A second manifest
+source per form is a discovery-plumbing change with no payoff. Segment extraction is a
+second extraction step inside the same parser run, savepointed independently of the
+Item 1 write so a segment-extraction failure does not tombstone the narrative (and
+vice versa). Failure of the XBRL step alone → `status='failed'` (transient) only for
+fetch errors; structurally-absent XBRL (pre-mandate filings, ~pre-2011) → zero rows,
+parsed, no tombstone.
+
+10-Q interim segments: **deferred** (conscious tradeoff — issue scope is "most recent
+fiscal year"; quarterly adds a cadence-mixing problem for the UI with no operator ask).
+
+### D2 — fetch through our throttle + lxml, NOT `edgartools.xbrl()`
+
+edgartools' `filing.xbrl()` issues its own HTTP (instance + linkbases) outside
+`app/providers/concurrent_fetch.py`'s shared 10 req/s throttle — the edgartools-skill
+hard-stop for new paths. Instead:
+
+1. Fetch the filing `index.json` (already-throttled wrapper).
+2. Locate the extracted instance with deterministic priority (Codex ckpt-1 MED):
+   (a) the `EX-101.INS` exhibit entry if present (standalone-instance era,
+   pre-2019-ish); (b) else files whose name case-insensitively ends `_htm.xml`
+   (inline era) — if several, prefer the one whose stem matches the primary
+   document's stem, else lexicographically-first + WARN with provenance.
+   Neither present → no-XBRL skip path. Each branch gets a table-test.
+3. Locate the label linkbase `*_lab.xml` for member labels; absent → prettified member
+   localname fallback.
+4. Parse with lxml, reusing the `n_csr_extractor.py` machinery shape:
+   `_context_dimensions` (context → `{axis: member}`), wildcard-namespace matching,
+   `(concept, axis)` routing.
+
+Cost: 2–3 throttled fetches per accession (index + instance + lab). Backfill of ~25k
+10-K accessions ≈ 50–75k fetches ≈ <2.5h at the shared 10 req/s floor.
+
+### D3 — axes and metrics ingested
+
+| Axis | Metrics | Notes |
+| --- | --- | --- |
+| `us-gaap:StatementBusinessSegmentsAxis` | revenue, operating_income, assets (nullable) | only contexts where `srt:ConsolidationItemsAxis` is absent or `us-gaap:OperatingSegmentsMember` — excludes eliminations/corporate reconciling items so member sums match consolidated totals |
+| `srt:ProductOrServiceAxis` | revenue | the #551 acceptance surface |
+| `srt:StatementGeographicalAxis` | revenue | member qname + label, no ISO coercion |
+
+Axis-set rule is per route, exact (Codex ckpt-1 HIGH — the earlier "any other axis
+excluded" phrasing contradicted the ConsolidationItemsAxis allowance):
+
+- `business_segment` route accepts contexts whose axis set is exactly
+  `{StatementBusinessSegmentsAxis}` or
+  `{StatementBusinessSegmentsAxis, ConsolidationItemsAxis=OperatingSegmentsMember}`.
+- `product_service` route: exactly `{ProductOrServiceAxis}`.
+- `geographic` route: exactly `{StatementGeographicalAxis}`.
+
+Anything else (segment×product cross-dimensions, eliminations members, etc.) is
+excluded — double-counting guard.
+
+Revenue concept resolution reuses the existing alias tuple
+(`sec_fundamentals.py:224` — `RevenueFromContractWithCustomerExcludingAssessedTax`,
+`Revenues`, `SalesRevenueNet`, `RevenueFromContractWithCustomerIncludingAssessedTax`).
+Arbitration is per `(axis, member, period)`, not one-concept-per-axis (Codex ckpt-1
+HIGH — filers can mix concepts across members): members are unioned across aliases;
+where the same member+period has facts under several aliases, the highest-priority
+alias wins. Filer-extension revenue concepts are out of scope v1 (conscious
+undercount caveat; `pct_of_total` is computed over returned rows so tables stay
+internally consistent). Operating income = `us-gaap:OperatingIncomeLoss`; assets =
+`us-gaap:Assets`.
+
+Duplicate-fact arbitration (Codex ckpt-1 MED): when the instance repeats the same
+(concept, context, unit), keep the most precise (`decimals`, with `INF` highest);
+equal precision with differing values → drop that member + WARN with provenance.
+
+Financials-sector caveat: banks (JPM) may emit none of the revenue aliases on these
+axes → endpoint returns empty state, acceptable v1, recorded in smoke results.
+
+### D4 — schema: ONE raw table, latest-filed-wins reader
+
+Issue proposed two UI-shaped tables. Three axes × shared identity/provenance columns →
+one table, axis-discriminated, mirroring `financial_facts_raw` semantics
+(immutable per-accession rows; reader dedupes):
+
+```sql
+CREATE TABLE instrument_dimensional_facts (
+    fact_id          BIGSERIAL PRIMARY KEY,
+    instrument_id    BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    axis             TEXT NOT NULL CHECK (axis IN
+                       ('business_segment', 'product_service', 'geographic')),
+    member_qname     TEXT NOT NULL,          -- e.g. 'aapl:IPhoneMember', 'country:US'
+    member_label     TEXT NOT NULL,          -- lab.xml standard label, localname fallback
+    metric           TEXT NOT NULL CHECK (metric IN
+                       ('revenue', 'operating_income', 'assets')),
+    unit             TEXT NOT NULL,
+    period_start     DATE,
+    period_end       DATE NOT NULL,
+    val              NUMERIC(30,6) NOT NULL,
+    decimals         TEXT,                   -- XBRL precision incl. 'INF' (duplicate arbitration input)
+    source_accession TEXT NOT NULL,
+    form_type        TEXT NOT NULL,
+    filed_at         TIMESTAMPTZ NOT NULL,
+    parser_version   TEXT NOT NULL,          -- audit + rewash correction path
+    fetched_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX uq_dimensional_facts_identity
+    ON instrument_dimensional_facts(
+        instrument_id, axis, member_qname, metric,
+        COALESCE(period_start, '0001-01-01'::date), period_end, source_accession);
+CREATE INDEX idx_dimensional_facts_read
+    ON instrument_dimensional_facts(instrument_id, axis, period_end DESC);
+```
+
+Restatements: each 10-K carries ~3 fiscal years of comparatives; 10-K/A supersedes.
+Reader selects the winning accession per `(instrument, axis, metric)` (Codex ckpt-1
+HIGH — a 10-K/A can carry revenue rows but omit op-income/assets; per-axis selection
+would regress the omitted metric to empty) =
+`ORDER BY filed_at DESC, source_accession DESC LIMIT 1` over accessions having rows
+for that (axis, metric). Rows join by member for the table; the response reports the
+winning accession per metric (`sources: {revenue: accn, …}`).
+
+"Latest FY" is defined per metric kind (Codex ckpt-1 MED — max `period_end` alone can
+pick a YTD/quarterly context): duration metrics (revenue, operating_income) take the
+winning accession's max `period_end` among durations of 330–400 days; the instant
+metric (assets) takes the instant context at exactly that `period_end`.
+
+Re-parse correction path (Codex ckpt-1 MED): rows are immutable per accession in
+normal operation, but a rewash of an accession DELETEs that accession's rows and
+re-inserts inside one transaction, stamping the new `parser_version` — same semantics
+as the manifest rewash contract elsewhere; no `known_to` machinery needed.
+
+Not partitioned: ~25 rows/filing × ~25k filings ≈ 625k rows. Revisit only if 10-Q lands.
+
+### D5 — share-class fan-out
+
+10-K is issuer-level; fan out per `siblings_for_issuer_cik` exactly like the Item 1
+narrative writer (GOOG + GOOGL both render).
+
+### D6 — API
+
+One endpoint, axis-parameterised (not two):
+
+`GET /instruments/{symbol}/segments?axis=business|product|geographic`
+→ `{ axis, period_end, sources: {revenue: accn, operating_income?: accn,
+assets?: accn}, filed_at, rows: [{member_label, member_qname, revenue,
+operating_income?, assets?, pct_of_total}], total }`
+
+(`sources` is a per-metric map, NOT a single `source_accession` — the §D4 reader
+selects winners per (axis, metric), so a 10-K/A revenue row can legitimately pair
+with original-10-K op-income rows. `filed_at` = max over winning accessions.)
+
+`pct_of_total` computed over the returned member rows (not consolidated revenue) so
+the table is internally consistent even when eliminations exist.
+
+The `axis` query values map to storage enum values
+(`business→business_segment`, `product→product_service`, `geographic→geographic`);
+the mapping is pinned in an API test so storage enum values never leak (Codex
+ckpt-1 LOW).
+
+### D7 — frontend
+
+Instrument page, beside `FundamentalsPane`: `SegmentsTable` (business/product axis
+toggle, revenue + op income + % columns) and `GeographicMixChart` (horizontal bars,
+shares palette conventions with existing panes). Loading/error/empty per
+`.claude/skills/frontend/loading-error-empty-states.md`. Empty state copy covers the
+financials-sector caveat ("no segment disclosure in this filing").
+
+## 4. Backfill + verification plan (DoD clauses 8–12)
+
+1. Parser version `10k-v1` → `10k-v2`; rebuild via
+   `POST /jobs/sec_rebuild/run {"source": "sec_10k"}`. Conscious cost: rewash re-runs
+   the Item 1 narrative parse too (idempotent, filed_at-gated).
+2. Drain monitored via manifest pending count for `sec_10k`.
+3. Smoke panel: AAPL, MSFT, GME, JPM, HD via
+   `GET /instruments/{symbol}/segments` ×3 axes. Record figures in PR.
+4. Cross-source: AAPL product-axis revenue vs the 10-K as filed on EDGAR
+   (already captured above: iPhone $209.586B / Mac $33.708B / iPad $28.023B /
+   Wearables $35.686B / Services $109.158B, FY2025) + one independent source
+   (e.g. macrotrends/stockanalysis segment page).
+5. Operator-visible: SegmentsTable + GeographicMixChart render on dev for the panel.
+
+## 5. Out of scope (conscious)
+
+- 10-Q interim segments (cadence mixing; no ask).
+- Segment history/time-series UI (one latest-FY snapshot per the issue; raw table
+  retains history for a future chart).
+- ISO-normalised country rollups (member qname is the honest grain).
+- Headcount (#551, shipped).
+
+## 6. Effort
+
+M — schema (1 migration) + parser step (reuse n_csr machinery) + 1 endpoint + 2 FE
+components + tests (pure-logic parser table-tests; ONE db-tier test for the
+latest-accession-wins reader SQL).
+
+## 7. Implementation plan (operator-approved 2026-06-11; single PR)
+
+Order per repo output preference: schema → service → tests → integration glue.
+
+- **T1 — sql/193_instrument_dimensional_facts.sql.** Table per §D4 (axis/metric
+  CHECKs, identity unique index, read index). No partitioning, no backfill DML.
+  Append the table to the `tests/fixtures/ebull_test_db.py` teardown list in the
+  same PR (fixture contract for new FK-child tables — Codex plan-review).
+- **T2a — `app/services/dimensional_facts.py`** (PURE — parse + discovery only,
+  zero DB imports; Codex plan-review split):
+  - `discover_xbrl_files(index_json) -> XbrlFileRefs | None` — §D2 deterministic
+    priority (EX-101.INS → `*_htm.xml` stem-match → lexicographic + WARN).
+  - `extract_dimensional_facts(instance_xml, lab_xml | None) -> list[DimensionalFact]`
+    — lxml, context→axis-set per-route exact match (§D3), revenue alias arbitration
+    per (axis, member, period), duplicate-fact precision arbitration, sanity window
+    `[1900-01-01, 2100-01-01)` + `period_start <= period_end` (prevention log §1455),
+    member label from lab.xml standard role, localname-prettify fallback.
+- **T2b — `app/services/dimensional_facts_store.py`** (DB layer):
+  `replace_accession_rows(conn, instrument_id, accession, rows)` — delete-then-insert
+  in caller's tx, stamps `parser_version`; reader
+  `read_segments(conn, instrument_id, axis)` — winner per (axis, metric) +
+  annual-duration filter per §D4.
+- **T3 — `manifest_parsers/sec_10k.py` step 2:** after Item 1 upsert, savepointed
+  XBRL fetch (our throttled wrapper: index.json + instance + lab) + extract + write,
+  fanned out per `siblings_for_issuer_cik`. Bump `_PARSER_VERSION_10K = "10k-v2"`.
+  Failure semantics per §D1: fetch error → transient `failed` (the whole manifest
+  row retries; retry is idempotent — Item 1 upsert is filed_at-gate-suppressed,
+  segment write is delete-then-insert — so a narrative may be visible before
+  segments land on the retry; intended); no-XBRL → parsed, zero rows; instance
+  parse error → WARN + parsed-without-segments (narrative must not regress on
+  segment bugs) with error recorded in parse log detail.
+  **10-K/A interaction (Codex plan-review):** the dimensional step ALWAYS targets
+  `row.accession_number`'s own XBRL — never the Item-1 fallback's
+  `chosen_accession`/`chosen_html` (Item 1 may fall back to the prior plain 10-K
+  when an amendment lacks Item 1; segments must not be attributed to the wrong
+  accession). Amendment without XBRL → zero rows; the prior accession's rows
+  remain and the per-metric winner reader serves them. Explicit test case.
+- **T4 — reader + API:** winner-per-(axis,metric) SQL + annual-duration filter in
+  `app/services/dimensional_facts.py`; `GET /instruments/{symbol}/segments?axis=…`
+  in `app/api/instruments.py` next to the #551 employees endpoint. Response per §D6.
+- **T5 — tests (lean):** table-tests on `extract_dimensional_facts` +
+  `discover_xbrl_files` with trimmed AAPL/MSFT instance fixtures (axis-set routing,
+  alias arbitration, duplicate precision, sanity window, label fallback); ONE db-tier
+  test for winner-per-(axis,metric) + annual-duration reader SQL; API test pinning
+  axis param→enum mapping + 404/empty states.
+- **T6 — frontend:** `fetchInstrumentSegments` in `api/instruments.ts`;
+  `SegmentsTable` (business/product toggle) + `GeographicMixChart`; wire into
+  instrument page near `FundamentalsPane`; vitest unit tests for states + pct
+  rendering. Frontend skills re-read at this step.
+- **T7 — gates + Codex ckpt-2 + push + open PR** (pre-pr-fresh-agent-review
+  mandatory — filings-ETL change). PR opens with implementation description;
+  DoD 8–12 evidence section added by T8 BEFORE merge (Codex plan-review ordering
+  fix — verification evidence cannot precede the verification).
+- **T8 — dev backfill + verify, pre-merge:** restart dev jobs proc onto the branch
+  (operator-approved relaunch method), `POST /jobs/sec_rebuild/run
+  {"source":"sec_10k"}`, drain watch, smoke panel AAPL/MSFT/GME/JPM/HD ×3 axes,
+  cross-source AAPL product split (already EDGAR-confirmed §1), operator-visible FE
+  check. Update PR body with figures + commit SHA, then merge gate applies.
+
+Dependencies: T2b→T1+T2a, T3→T2a/T2b, T4→T2b, T5→T2a/T2b/T4, T6→T4, T8→T7.

--- a/docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md
+++ b/docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md
@@ -58,7 +58,11 @@ Intelligent Cloud $106.27B / More Personal Computing $54.65B ✓.
 source per form is a discovery-plumbing change with no payoff. Segment extraction is a
 second extraction step inside the same parser run, savepointed independently of the
 Item 1 write so a segment-extraction failure does not tombstone the narrative (and
-vice versa). Failure of the XBRL step alone → `status='failed'` (transient) only for
+vice versa). **Ordering (corrected during dev backfill):** the dimensional step runs
+BEFORE the narrative parse (step 2.5, right after store_raw) — the original
+post-narrative placement let an Item-1 tombstone suppress segments, violating the
+both-directions independence (caught live: MSFT FY2025's 10-K defeats the Item 1
+extractor; manifest row tombstones for the narrative, segments must still land). Failure of the XBRL step alone → `status='failed'` (transient) only for
 fetch errors; structurally-absent XBRL (pre-mandate filings, ~pre-2011) → zero rows,
 parsed, no tombstone.
 

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -459,6 +459,47 @@ export async function fetchInstrumentEmployees(
   }
 }
 
+export type SegmentAxis = "business" | "product" | "geographic";
+
+export interface SegmentRow {
+  member_qname: string;
+  member_label: string;
+  revenue: number | null;
+  operating_income: number | null;
+  assets: number | null;
+  pct_of_total: number | null;
+}
+
+/** Mirrors ``InstrumentSegments`` in app/api/instruments.py (#554). */
+export interface InstrumentSegments {
+  symbol: string;
+  axis: SegmentAxis;
+  period_end: string;
+  filed_at: string;
+  sources: Record<string, string>;
+  total_revenue: number | null;
+  rows: SegmentRow[];
+}
+
+/** Latest-fiscal-year segment / product / geographic revenue breakdown
+ *  from per-filing dimensional XBRL (#554). Returns null on 404
+ *  (non-SEC issuer, pre-mandate 10-K, or no disclosure on the axis);
+ *  rethrows other errors. */
+export async function fetchInstrumentSegments(
+  symbol: string,
+  axis: SegmentAxis,
+): Promise<InstrumentSegments | null> {
+  try {
+    return await apiFetch<InstrumentSegments>(
+      `/instruments/${encodeURIComponent(symbol)}/segments?axis=${axis}`,
+    );
+  } catch (err) {
+    const { ApiError } = await import("@/api/client");
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
+}
+
 export function fetchInstrumentDetail(
   instrumentId: number,
 ): Promise<InstrumentDetail> {

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -56,6 +56,7 @@ import { Pane } from "@/components/instrument/Pane";
 import { PriceChart } from "@/components/instrument/PriceChart";
 import { RecentNewsPane } from "@/components/instrument/RecentNewsPane";
 import { SecProfilePanel } from "@/components/instrument/SecProfilePanel";
+import { SegmentsPane } from "@/components/instrument/SegmentsPane";
 import { ThesisPane } from "@/components/instrument/ThesisPane";
 import {
   EMPTY_CELL,
@@ -181,6 +182,12 @@ export function DensityGrid({
         ) : null}
         {/* Zone C — Health */}
         {HealthRow}
+        {/* Zone C2 — Revenue & segments (#554). Full-width next to the
+            other fundamentals-adjacent panes; the pane owns its own
+            empty state for issuers with no dimensional XBRL. */}
+        <div className="col-span-12">
+          <SegmentsPane symbol={symbol} />
+        </div>
         {/* When filings did not pair with narrative, render filings
             full-width above the activity row (matches the legacy
             narrative-less layout). */}
@@ -233,6 +240,10 @@ export function DensityGrid({
         ) : null}
         {/* Zone C — Health (fundamentals optional in partial profile) */}
         {HealthRow}
+        {/* Zone C2 — Revenue & segments (#554). */}
+        <div className="col-span-12">
+          <SegmentsPane symbol={symbol} />
+        </div>
         {/* When filings did not pair with narrative, render filings
             full-width above the activity row. */}
         {filingsActive && !filingsPairedWithNarrative ? (

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -55,6 +55,7 @@ import { fetchInstrumentFinancials } from "@/api/instruments";
 import type { InstrumentFinancialRow, InstrumentSummary } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
+import { formatBigNumber } from "@/lib/format";
 import { lightTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 import { useChartTheme } from "@/lib/useChartTheme";
@@ -149,17 +150,6 @@ function lastNonNullIndex(points: ReadonlyArray<CellPoint>): number {
     if (points[i]!.value !== null) return i;
   }
   return -1;
-}
-
-function formatBigNumber(n: number | null): string {
-  if (n === null) return "—";
-  const abs = Math.abs(n);
-  const sign = n < 0 ? "-" : "";
-  if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(2)}T`;
-  if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(2)}B`;
-  if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(2)}M`;
-  if (abs >= 1e3) return `${sign}${(abs / 1e3).toFixed(2)}K`;
-  return n.toFixed(0);
 }
 
 function formatPeriodTick(period_end: string): string {

--- a/frontend/src/components/instrument/GeographicMixChart.tsx
+++ b/frontend/src/components/instrument/GeographicMixChart.tsx
@@ -1,0 +1,43 @@
+/**
+ * GeographicMixChart — horizontal proportion bars for the geographic
+ * revenue axis (#554). Pure presentational; CSS bars, no chart
+ * library — the data is a handful of rows and the operator reads the
+ * ranking + share, not a trend.
+ */
+
+import type { SegmentRow } from "@/api/instruments";
+import { formatBigNumber } from "@/lib/format";
+
+export interface GeographicMixChartProps {
+  readonly rows: ReadonlyArray<SegmentRow>;
+}
+
+export function GeographicMixChart({ rows }: GeographicMixChartProps) {
+  const max = rows.reduce((m, r) => Math.max(m, r.revenue ?? 0), 0);
+  return (
+    <ul className="space-y-2">
+      {rows.map((row) => {
+        const widthPct = max > 0 && row.revenue !== null ? Math.max((row.revenue / max) * 100, 1) : 0;
+        return (
+          <li key={row.member_qname} className="text-sm">
+            <div className="mb-0.5 flex items-baseline justify-between gap-2">
+              <span className="truncate text-slate-700 dark:text-slate-200">{row.member_label}</span>
+              <span className="shrink-0 tabular-nums text-slate-500">
+                {formatBigNumber(row.revenue)}
+                {row.pct_of_total !== null && (
+                  <span className="ml-1 text-xs">({(row.pct_of_total * 100).toFixed(1)}%)</span>
+                )}
+              </span>
+            </div>
+            <div className="h-2 w-full rounded bg-slate-100 dark:bg-slate-800">
+              <div
+                className="h-2 rounded bg-blue-600/70 dark:bg-blue-500/70"
+                style={{ width: `${widthPct}%` }}
+              />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/components/instrument/SegmentsPane.test.tsx
+++ b/frontend/src/components/instrument/SegmentsPane.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Render-state tests for the segments pane (#554): loading / error /
+ * empty / table / geographic-bars / axis-toggle-refetch, with the
+ * fetcher module mocked — the state contract per
+ * loading-error-empty-states.md.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { InstrumentSegments, SegmentRow } from "@/api/instruments";
+
+import { SegmentsPane } from "./SegmentsPane";
+
+vi.mock("@/api/instruments", () => ({
+  fetchInstrumentSegments: vi.fn(),
+}));
+
+import { fetchInstrumentSegments } from "@/api/instruments";
+
+const fetchMock = vi.mocked(fetchInstrumentSegments);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fetchMock.mockReset();
+});
+
+function row(over: Partial<SegmentRow> = {}): SegmentRow {
+  return {
+    member_qname: "aapl:AmericasSegmentMember",
+    member_label: "Americas Segment",
+    revenue: 178_353_000_000,
+    operating_income: 72_480_000_000,
+    assets: null,
+    pct_of_total: 0.4286,
+    ...over,
+  };
+}
+
+function response(rows: SegmentRow[], axis: InstrumentSegments["axis"] = "business"): InstrumentSegments {
+  return {
+    symbol: "AAPL",
+    axis,
+    period_end: "2025-09-27",
+    filed_at: "2025-10-31T00:00:00Z",
+    sources: { revenue: "0000320193-25-000079" },
+    total_revenue: 416_161_000_000,
+    rows,
+  };
+}
+
+describe("SegmentsPane states", () => {
+  it("shows the skeleton while loading", () => {
+    fetchMock.mockReturnValue(new Promise(() => {}));
+    render(<SegmentsPane symbol="AAPL" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("shows the error surface with retry on failure", async () => {
+    fetchMock.mockRejectedValue(new Error("boom"));
+    render(<SegmentsPane symbol="AAPL" />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument());
+  });
+
+  it("shows the empty state on 404 (fetcher null)", async () => {
+    fetchMock.mockResolvedValue(null);
+    render(<SegmentsPane symbol="AAPL" />);
+    await waitFor(() => expect(screen.getByText("No breakdown on file")).toBeInTheDocument());
+  });
+
+  it("renders the segments table with revenue, pct and op income", async () => {
+    fetchMock.mockResolvedValue(response([row()]));
+    render(<SegmentsPane symbol="AAPL" />);
+    await waitFor(() => expect(screen.getByText("Americas Segment")).toBeInTheDocument());
+    expect(screen.getByText("178.35B")).toBeInTheDocument();
+    expect(screen.getByText("42.9%")).toBeInTheDocument();
+    expect(screen.getByText("72.48B")).toBeInTheDocument();
+    // No assets anywhere in the rows → the column collapses entirely.
+    expect(screen.queryByText("Assets")).not.toBeInTheDocument();
+    expect(screen.getByText(/FY ending 2025-09-27/)).toBeInTheDocument();
+  });
+
+  it("switches to geographic bars and refetches with the new axis", async () => {
+    fetchMock.mockResolvedValue(response([row()]));
+    const user = userEvent.setup();
+    render(<SegmentsPane symbol="AAPL" />);
+    await waitFor(() => expect(screen.getByText("Americas Segment")).toBeInTheDocument());
+
+    fetchMock.mockResolvedValue(
+      response(
+        [
+          row({ member_qname: "country:US", member_label: "UNITED STATES", revenue: 151_790_000_000, operating_income: null, pct_of_total: 0.3648 }),
+          row({ member_qname: "aapl:OtherCountriesMember", member_label: "Other Countries", revenue: 199_994_000_000, operating_income: null, pct_of_total: 0.4806 }),
+        ],
+        "geographic",
+      ),
+    );
+    await user.click(screen.getByRole("button", { name: "Geography" }));
+
+    await waitFor(() => expect(screen.getByText("UNITED STATES")).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenLastCalledWith("AAPL", "geographic");
+    // Bars, not a table.
+    expect(screen.queryByText("% of total")).not.toBeInTheDocument();
+    expect(screen.getByText("(36.5%)")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/SegmentsPane.tsx
+++ b/frontend/src/components/instrument/SegmentsPane.tsx
@@ -1,0 +1,95 @@
+/**
+ * SegmentsPane — latest-fiscal-year revenue breakdown for the
+ * instrument page (#554). Backed by
+ * GET /instruments/{symbol}/segments?axis=business|product|geographic.
+ *
+ * One axis visible at a time via the toggle; the fetch re-fires per
+ * (symbol, axis) — useAsync owns the lifecycle, so switching axes
+ * shows the skeleton rather than the previous axis's rows.
+ *
+ * 404 (fetcher → null) is the structural empty state: non-SEC issuer,
+ * pre-XBRL-mandate 10-K, or no disclosure on the chosen axis (banks
+ * routinely emit no revenue facts on the product axis).
+ */
+
+import { fetchInstrumentSegments } from "@/api/instruments";
+import type { InstrumentSegments, SegmentAxis } from "@/api/instruments";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { GeographicMixChart } from "@/components/instrument/GeographicMixChart";
+import { Pane } from "@/components/instrument/Pane";
+import { SegmentsTable } from "@/components/instrument/SegmentsTable";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+import { useCallback, useState } from "react";
+
+const AXES: ReadonlyArray<{ key: SegmentAxis; label: string }> = [
+  { key: "business", label: "Segments" },
+  { key: "product", label: "Products" },
+  { key: "geographic", label: "Geography" },
+];
+
+export interface SegmentsPaneProps {
+  readonly symbol: string;
+}
+
+export function SegmentsPane({ symbol }: SegmentsPaneProps) {
+  const [axis, setAxis] = useState<SegmentAxis>("business");
+  const state = useAsync<InstrumentSegments | null>(
+    useCallback(() => fetchInstrumentSegments(symbol, axis), [symbol, axis]),
+    [symbol, axis],
+  );
+
+  return (
+    <Pane title="Revenue & segments" source={{ providers: ["sec_edgar"] }}>
+      <div className="space-y-3">
+        <div className="flex gap-1" role="group" aria-label="Breakdown axis">
+          {AXES.map((a) => (
+            <button
+              key={a.key}
+              type="button"
+              onClick={() => setAxis(a.key)}
+              className={`rounded border px-2 py-0.5 text-xs ${
+                a.key === axis
+                  ? "border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-900/30 dark:text-blue-300"
+                  : "border-slate-300 text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+              }`}
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+        {state.loading ? (
+          <SectionSkeleton rows={4} />
+        ) : state.error !== null ? (
+          <SectionError onRetry={state.refetch} />
+        ) : state.data === null || state.data.rows.length === 0 ? (
+          <EmptyState
+            title="No breakdown on file"
+            description="The latest 10-K discloses nothing on this axis, predates the XBRL mandate, or the SEC filings ingest has not drained this instrument yet. Try another axis above."
+          />
+        ) : (
+          <Body data={state.data} />
+        )}
+      </div>
+    </Pane>
+  );
+}
+
+function Body({ data }: { data: InstrumentSegments }) {
+  const hasOpIncome = data.rows.some((r) => r.operating_income !== null);
+  const hasAssets = data.rows.some((r) => r.assets !== null);
+  return (
+    <div className="space-y-2">
+      {data.axis === "geographic" ? (
+        <GeographicMixChart rows={data.rows} />
+      ) : (
+        <SegmentsTable rows={data.rows} showOperatingIncome={hasOpIncome} showAssets={hasAssets} />
+      )}
+      <p className="text-xs text-slate-500">
+        FY ending {data.period_end} · {Object.values(data.sources).length > 0 && (
+          <span className="font-mono">{[...new Set(Object.values(data.sources))].join(" · ")}</span>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/SegmentsTable.tsx
+++ b/frontend/src/components/instrument/SegmentsTable.tsx
@@ -1,0 +1,53 @@
+/**
+ * SegmentsTable — latest-FY member rows for the business or product
+ * axis (#554). Pure presentational; data + states owned by
+ * SegmentsPane. Subtotal members are excluded server-side, so
+ * ``pct_of_total`` columns sum to ~100%.
+ */
+
+import type { SegmentRow } from "@/api/instruments";
+import { formatBigNumber } from "@/lib/format";
+
+export interface SegmentsTableProps {
+  readonly rows: ReadonlyArray<SegmentRow>;
+  /** Business segments carry op income / assets; product rows are
+   *  revenue-only — the extra columns collapse when entirely null. */
+  readonly showOperatingIncome: boolean;
+  readonly showAssets: boolean;
+}
+
+export function SegmentsTable({ rows, showOperatingIncome, showAssets }: SegmentsTableProps) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b border-slate-200 text-left text-xs uppercase tracking-wide text-slate-500 dark:border-slate-800">
+          <th className="px-2 py-2 font-semibold">Segment</th>
+          <th className="px-2 py-2 text-right font-semibold">Revenue</th>
+          <th className="px-2 py-2 text-right font-semibold">% of total</th>
+          {showOperatingIncome && <th className="px-2 py-2 text-right font-semibold">Op. income</th>}
+          {showAssets && <th className="px-2 py-2 text-right font-semibold">Assets</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr
+            key={row.member_qname}
+            className="border-b border-slate-100 last:border-b-0 dark:border-slate-800/60"
+          >
+            <td className="px-2 py-2 text-slate-700 dark:text-slate-200">{row.member_label}</td>
+            <td className="px-2 py-2 text-right tabular-nums">{formatBigNumber(row.revenue)}</td>
+            <td className="px-2 py-2 text-right tabular-nums text-slate-500">
+              {row.pct_of_total !== null ? `${(row.pct_of_total * 100).toFixed(1)}%` : "—"}
+            </td>
+            {showOperatingIncome && (
+              <td className="px-2 py-2 text-right tabular-nums">{formatBigNumber(row.operating_income)}</td>
+            )}
+            {showAssets && (
+              <td className="px-2 py-2 text-right tabular-nums">{formatBigNumber(row.assets)}</td>
+            )}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -73,6 +73,20 @@ export function formatNumber(value: number | null | undefined, fractionDigits = 
   });
 }
 
+/** Abbreviated large magnitudes for financial-statement values:
+ *  `416161000000 → "416.16B"`. Canonical home of the helper that
+ *  previously lived privately in FundamentalsPane (#554). */
+export function formatBigNumber(n: number | null): string {
+  if (n === null) return "—";
+  const abs = Math.abs(n);
+  const sign = n < 0 ? "-" : "";
+  if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${sign}${(abs / 1e3).toFixed(2)}K`;
+  return n.toFixed(0);
+}
+
 export function formatDateTime(iso: string | null | undefined): string {
   if (!iso) return "—";
   const d = new Date(iso);

--- a/scripts/drain_554_sec10k.py
+++ b/scripts/drain_554_sec10k.py
@@ -1,0 +1,56 @@
+"""One-shot standalone drain of pending sec_10k manifest rows (#554 backfill).
+
+S7-precedent recipe: the manifest worker drains only 100 rows per
+5-minute tick, so a 3,175-row rebuild drains standalone — iter_pending
+chunks of 50 through ``_dispatch_rows``, commit per chunk. Run from
+the feature branch checkout so the v2 parser (dimensional step) is the
+one dispatching.
+
+Usage: uv run python scripts/drain_554_sec10k.py
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime
+
+import psycopg
+
+from app.config import settings
+from app.jobs.sec_manifest_worker import _dispatch_rows
+from app.services.manifest_parsers import register_all_parsers
+from app.services.sec_manifest import iter_pending
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+logger = logging.getLogger("drain_554")
+
+
+def main() -> None:
+    register_all_parsers()
+    totals = {"parsed": 0, "tombstoned": 0, "failed": 0, "skipped": 0}
+    chunks = 0
+    started = time.monotonic()
+    with psycopg.connect(settings.database_url, application_name="drain-554-sec10k") as conn:
+        while True:
+            rows = list(iter_pending(conn, source="sec_10k", limit=50))
+            if not rows:
+                break
+            stats = _dispatch_rows(conn, rows, now=datetime.now(tz=UTC))
+            conn.commit()
+            chunks += 1
+            totals["parsed"] += stats.parsed
+            totals["tombstoned"] += stats.tombstoned
+            totals["failed"] += stats.failed
+            totals["skipped"] += stats.skipped_no_parser
+            logger.info(
+                "chunk %d done: %s (elapsed %.0fs)",
+                chunks,
+                totals,
+                time.monotonic() - started,
+            )
+    logger.info("DRAIN COMPLETE: %s in %.0fs", totals, time.monotonic() - started)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/drain_554_sec10k.py
+++ b/scripts/drain_554_sec10k.py
@@ -30,13 +30,32 @@ def main() -> None:
     register_all_parsers()
     totals = {"parsed": 0, "tombstoned": 0, "failed": 0, "skipped": 0}
     chunks = 0
+    consecutive_failures = 0
     started = time.monotonic()
     with psycopg.connect(settings.database_url, application_name="drain-554-sec10k") as conn:
         while True:
             rows = list(iter_pending(conn, source="sec_10k", limit=50))
             if not rows:
                 break
-            stats = _dispatch_rows(conn, rows, now=datetime.now(tz=UTC))
+            try:
+                stats = _dispatch_rows(conn, rows, now=datetime.now(tz=UTC))
+            except Exception:
+                # The jobs-proc manifest worker races this drain for the
+                # same oldest-pending rows; a row it already parsed makes
+                # transition_status raise illegal 'parsed'->'parsed'.
+                # Roll back the chunk (idempotent redo) and re-read.
+                conn.rollback()
+                consecutive_failures += 1
+                logger.warning(
+                    "chunk dispatch failed (%d consecutive); re-reading",
+                    consecutive_failures,
+                    exc_info=True,
+                )
+                if consecutive_failures >= 5:
+                    raise
+                time.sleep(5)
+                continue
+            consecutive_failures = 0
             conn.commit()
             chunks += 1
             totals["parsed"] += stats.parsed

--- a/sql/193_instrument_dimensional_facts.sql
+++ b/sql/193_instrument_dimensional_facts.sql
@@ -1,0 +1,71 @@
+-- 193_instrument_dimensional_facts.sql
+--
+-- #554 (spec docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md §D4)
+-- — dimensional XBRL facts (business segments, product/service mix,
+-- geographic revenue) extracted per 10-K accession by the sec_10k
+-- manifest parser step 2 (parser version 10k-v2).
+--
+-- The companyfacts API carries NO dimensional facts (verified
+-- 2026-06-11, spec §1) so these rows come from per-filing XBRL
+-- instance parsing — they cannot live in ``financial_facts_raw``,
+-- whose identity has no axis/member dimension.
+--
+-- Semantics mirror ``financial_facts_raw`` (sql/032): immutable
+-- per-accession rows, reader dedupes by winning accession per
+-- (instrument, axis, metric) ORDER BY filed_at DESC. Rewash of an
+-- accession is delete-then-insert in one transaction (spec §D4).
+--
+-- ``member_qname`` is the honest grain for geography — members mix
+-- ISO-backed qnames (``country:US``) with filer-custom members
+-- (``aapl:OtherCountriesMember``); no ISO column by design (spec §1.3).
+--
+-- Not partitioned: ~25 rows/filing × ~25k 10-Ks ≈ 625k rows.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS instrument_dimensional_facts (
+    fact_id          BIGSERIAL PRIMARY KEY,
+    instrument_id    BIGINT NOT NULL REFERENCES instruments(instrument_id),
+    axis             TEXT NOT NULL CHECK (axis IN
+                       ('business_segment', 'product_service', 'geographic')),
+    member_qname     TEXT NOT NULL,
+    member_label     TEXT NOT NULL,
+    metric           TEXT NOT NULL CHECK (metric IN
+                       ('revenue', 'operating_income', 'assets')),
+    unit             TEXT NOT NULL,
+    -- TRUE when the member parents another member with a fact on the
+    -- same axis in this filing (definition-linkbase domain-member
+    -- arcs) — e.g. us-gaap:ProductMember is the subtotal of
+    -- iPhone/Mac/iPad/Wearables on AAPL's product axis. Readers
+    -- exclude subtotals so member rows sum to the consolidated total.
+    is_subtotal      BOOLEAN NOT NULL DEFAULT FALSE,
+    period_start     DATE,
+    period_end       DATE NOT NULL,
+    val              NUMERIC(30,6) NOT NULL,
+    -- XBRL allows non-integer precision values like "INF" (same shape
+    -- as financial_facts_raw.decimals); input to duplicate-fact
+    -- arbitration at parse time.
+    decimals         TEXT,
+    source_accession TEXT NOT NULL,
+    form_type        TEXT NOT NULL,
+    filed_at         TIMESTAMPTZ NOT NULL,
+    parser_version   TEXT NOT NULL,
+    fetched_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Identity: one fact per instrument/axis/member/metric/period-range/
+-- filing. period_start is NULL for instant facts (assets), so COALESCE
+-- makes NULLs comparable (plain UNIQUE treats NULLs as distinct, which
+-- would allow duplicate instants) — same pattern as
+-- uq_facts_raw_identity in sql/032.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_dimensional_facts_identity
+    ON instrument_dimensional_facts(
+        instrument_id, axis, member_qname, metric,
+        COALESCE(period_start, '0001-01-01'::date),
+        period_end, source_accession
+    );
+
+CREATE INDEX IF NOT EXISTS idx_dimensional_facts_read
+    ON instrument_dimensional_facts(instrument_id, axis, period_end DESC);
+
+COMMIT;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -137,6 +137,8 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "cascade_retry_queue",
     "cik_upsert_timing",
     "financial_facts_raw",
+    # #554 — dimensional XBRL facts (segments / product / geographic).
+    "instrument_dimensional_facts",
     "sec_facts_concept_catalog",
     "sec_entity_change_log",
     "data_ingestion_runs",

--- a/tests/test_dimensional_facts.py
+++ b/tests/test_dimensional_facts.py
@@ -395,6 +395,46 @@ def test_subtotal_marked_via_definition_linkbase_nesting() -> None:
     assert by_member == {"us-gaap:ProductMember": True, "acme:WidgetMember": False, "acme:GadgetMember": False}
 
 
+def test_linkbase_subtotal_scoped_per_period_not_per_axis() -> None:
+    # Parent reports FY2025 + FY2024; the child exists only in FY2024.
+    # FY2024 parent is a subtotal; FY2025 parent is the finest grain
+    # the filer gave us and must stay a leaf (Codex pre-push finding).
+    prior = {"start": "2024-01-01", "end": "2024-12-31"}
+    facts = _extract(
+        _context("c1", {_PROD_AXIS: "us-gaap:ProductMember"}, **_FY),
+        _context("c2", {_PROD_AXIS: "us-gaap:ProductMember"}, **prior),
+        _context("c3", {_PROD_AXIS: "acme:WidgetMember"}, **prior),
+        _fact(_REV, "c1", "120"),
+        _fact(_REV, "c2", "100"),
+        _fact(_REV, "c3", "100"),
+        dfn=_def([("us-gaap_ProductMember", "acme_WidgetMember")]),
+    )
+    by_key = {(f.member_qname, f.period_end.year): f.is_subtotal for f in facts}
+    assert by_key == {
+        ("us-gaap:ProductMember", 2025): False,
+        ("us-gaap:ProductMember", 2024): True,
+        ("acme:WidgetMember", 2024): False,
+    }
+
+
+def test_scenario_container_dimensions_are_routed() -> None:
+    # Valid XBRL may carry explicit dimensions under <scenario> rather
+    # than <segment>; treating those contexts as dimensionless would
+    # both drop the fact and pollute the consolidated anchor.
+    scenario_ctx = (
+        '<context id="cs"><entity>'
+        '<identifier scheme="http://www.sec.gov/CIK">0000000001</identifier>'
+        "</entity><period><startDate>2025-01-01</startDate><endDate>2025-12-31</endDate></period>"
+        "<scenario><xbrldi:explicitMember "
+        'dimension="us-gaap:StatementBusinessSegmentsAxis">acme:NorthMember</xbrldi:explicitMember>'
+        "</scenario></context>"
+    )
+    facts = _extract(scenario_ctx, _fact(_REV, "cs", "600"))
+    assert [(f.axis, f.member_qname, f.val) for f in facts] == [
+        ("business_segment", "acme:NorthMember", Decimal("600")),
+    ]
+
+
 def test_subtotal_marked_via_value_overage_when_linkbase_flat() -> None:
     # AAPL shape: flat linkbase, Product = Widget + Gadget, consolidated
     # total present as a dimensionless fact in the same instance.

--- a/tests/test_dimensional_facts.py
+++ b/tests/test_dimensional_facts.py
@@ -1,0 +1,468 @@
+"""Pure-logic tests for dimensional XBRL extraction (#554).
+
+No DB, no HTTP — synthetic instance/linkbase fixtures exercising the
+discovery priority, the per-route exact axis-set rule, alias +
+duplicate arbitration, the prevention-log §1455 sanity window, label
+resolution, and both subtotal detectors.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.api.instruments import SEGMENT_AXIS_PARAM_TO_ENUM, SegmentAxisParam
+from app.services.dimensional_facts import (
+    DimensionalFact,
+    discover_xbrl_files,
+    extract_dimensional_facts,
+    prettify_member,
+)
+
+# ---------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------
+
+_NS = (
+    'xmlns="http://www.xbrl.org/2003/instance" '
+    'xmlns:us-gaap="http://fasb.org/us-gaap/2025" '
+    'xmlns:acme="http://acme.example/20251231" '
+    'xmlns:srt="http://fasb.org/srt/2025" '
+    'xmlns:xbrldi="http://xbrl.org/2006/xbrldi" '
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+)
+
+
+def _context(cid: str, dims: dict[str, str], *, start: str | None, end: str | None, instant: str | None = None) -> str:
+    members = "".join(
+        f'<xbrldi:explicitMember dimension="{axis}">{member}</xbrldi:explicitMember>' for axis, member in dims.items()
+    )
+    segment = f"<segment>{members}</segment>" if members else ""
+    if instant is not None:
+        period = f"<period><instant>{instant}</instant></period>"
+    else:
+        period = f"<period><startDate>{start}</startDate><endDate>{end}</endDate></period>"
+    return (
+        f'<context id="{cid}"><entity>'
+        f'<identifier scheme="http://www.sec.gov/CIK">0000000001</identifier>'
+        f"{segment}</entity>{period}</context>"
+    )
+
+
+def _fact(concept: str, cid: str, value: str, *, decimals: str | None = "-6", unit: str = "usd", nil: bool = False) -> str:
+    dec = f' decimals="{decimals}"' if decimals is not None else ""
+    nil_attr = ' xsi:nil="true"' if nil else ""
+    return f'<{concept} contextRef="{cid}" unitRef="{unit}"{dec}{nil_attr}>{value}</{concept}>'
+
+
+def _instance(*parts: str) -> bytes:
+    units = '<unit id="usd"><measure>iso4217:USD</measure></unit><unit id="ratio"><divide><unitNumerator><measure>iso4217:USD</measure></unitNumerator><unitDenominator><measure>shares</measure></unitDenominator></divide></unit>'
+    return f"<xbrl {_NS}>{units}{''.join(parts)}</xbrl>".encode()
+
+
+_FY = {"start": "2025-01-01", "end": "2025-12-31"}
+_SEG_AXIS = "us-gaap:StatementBusinessSegmentsAxis"
+_PROD_AXIS = "srt:ProductOrServiceAxis"
+_GEO_AXIS = "srt:StatementGeographicalAxis"
+_CONSOL_AXIS = "srt:ConsolidationItemsAxis"
+_REV = "us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax"
+
+
+def _extract(*parts: str, lab: bytes | None = None, dfn: bytes | None = None) -> list[DimensionalFact]:
+    return extract_dimensional_facts(_instance(*parts), lab, dfn, accession="TEST-ACCN")
+
+
+def _lab(entries: dict[str, str]) -> bytes:
+    body = ""
+    for i, (fragment, label) in enumerate(entries.items()):
+        body += (
+            f'<loc xlink:href="acme.xsd#{fragment}" xlink:label="loc{i}" xlink:type="locator"/>'
+            f'<labelArc xlink:from="loc{i}" xlink:to="lab{i}" xlink:type="arc"/>'
+            f'<label xlink:label="lab{i}" xlink:role="http://www.xbrl.org/2003/role/label"'
+            f' xml:lang="en-US" xlink:type="resource">{label}</label>'
+        )
+    return (
+        '<linkbase xmlns="http://www.xbrl.org/2003/linkbase" xmlns:xlink="http://www.w3.org/1999/xlink">'
+        f"<labelLink>{body}</labelLink></linkbase>"
+    ).encode()
+
+
+def _def(pairs: list[tuple[str, str]]) -> bytes:
+    locs: dict[str, int] = {}
+    loc_xml = ""
+    arc_xml = ""
+    for parent, child in pairs:
+        for frag in (parent, child):
+            if frag not in locs:
+                locs[frag] = len(locs)
+                loc_xml += f'<loc xlink:href="acme.xsd#{frag}" xlink:label="loc{locs[frag]}" xlink:type="locator"/>'
+        arc_xml += (
+            f'<definitionArc xlink:arcrole="http://xbrl.org/int/dim/arcrole/domain-member"'
+            f' xlink:from="loc{locs[parent]}" xlink:to="loc{locs[child]}" xlink:type="arc"/>'
+        )
+    return (
+        '<linkbase xmlns="http://www.xbrl.org/2003/linkbase" xmlns:xlink="http://www.w3.org/1999/xlink">'
+        f"<definitionLink>{loc_xml}{arc_xml}</definitionLink></linkbase>"
+    ).encode()
+
+
+def _index(names_sizes: list[tuple[str, str]]) -> dict[str, object]:
+    return {"directory": {"item": [{"name": n, "size": s} for n, s in names_sizes]}}
+
+
+# ---------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------
+
+
+def test_discovery_inline_era_picks_htm_xml_with_linkbases() -> None:
+    refs = discover_xbrl_files(
+        _index(
+            [
+                ("acme-20251231.htm", "100"),
+                ("acme-20251231_htm.xml", "900"),
+                ("acme-20251231_lab.xml", "50"),
+                ("acme-20251231_def.xml", "40"),
+                ("R1.htm", "10"),
+            ]
+        ),
+        primary_document_name="acme-20251231.htm",
+    )
+    assert refs is not None
+    assert refs.instance_name == "acme-20251231_htm.xml"
+    assert refs.label_name == "acme-20251231_lab.xml"
+    assert refs.definition_name == "acme-20251231_def.xml"
+
+
+def test_discovery_multiple_inline_candidates_prefers_primary_stem() -> None:
+    refs = discover_xbrl_files(
+        _index([("other_htm.xml", "9999"), ("acme-20251231_htm.xml", "5")]),
+        primary_document_name="acme-20251231.htm",
+    )
+    assert refs is not None
+    assert refs.instance_name == "acme-20251231_htm.xml"
+
+
+def test_discovery_standalone_era_excludes_linkbases_and_rendering_artifacts() -> None:
+    refs = discover_xbrl_files(
+        _index(
+            [
+                ("acme-20111231.xml", "800"),
+                ("acme-20111231_cal.xml", "100"),
+                ("acme-20111231_lab.xml", "100"),
+                ("acme-20111231_pre.xml", "100"),
+                ("R3.xml", "999"),
+                ("FilingSummary.xml", "999"),
+            ]
+        ),
+        primary_document_name="acme-20111231.htm",
+    )
+    assert refs is not None
+    assert refs.instance_name == "acme-20111231.xml"
+
+
+def test_discovery_no_xbrl_returns_none() -> None:
+    assert discover_xbrl_files(_index([("acme.htm", "10")]), primary_document_name="acme.htm") is None
+    assert discover_xbrl_files({}, primary_document_name=None) is None
+
+
+def test_discovery_xsd_fallback_when_no_standalone_linkbases() -> None:
+    refs = discover_xbrl_files(
+        _index([("msft-20250630_htm.xml", "900"), ("msft-20250630.xsd", "200")]),
+        primary_document_name="msft-20250630.htm",
+    )
+    assert refs is not None
+    assert refs.label_name == "msft-20250630.xsd"
+    assert refs.definition_name == "msft-20250630.xsd"
+
+
+# ---------------------------------------------------------------------
+# Axis routing — per-route EXACT dimension sets
+# ---------------------------------------------------------------------
+
+
+def test_business_segment_route_accepts_bare_and_operating_segments_co_axis() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _context(
+            "c2",
+            {_SEG_AXIS: "acme:SouthMember", _CONSOL_AXIS: "us-gaap:OperatingSegmentsMember"},
+            **_FY,
+        ),
+        _fact(_REV, "c1", "600"),
+        _fact(_REV, "c2", "400"),
+    )
+    assert [(f.axis, f.member_qname, f.val) for f in facts] == [
+        ("business_segment", "acme:NorthMember", Decimal("600")),
+        ("business_segment", "acme:SouthMember", Decimal("400")),
+    ]
+
+
+def test_eliminations_member_on_consolidation_axis_is_excluded() -> None:
+    facts = _extract(
+        _context(
+            "c1",
+            {_SEG_AXIS: "acme:NorthMember", _CONSOL_AXIS: "us-gaap:IntersegmentEliminationMember"},
+            **_FY,
+        ),
+        _fact(_REV, "c1", "600"),
+    )
+    assert facts == []
+
+
+def test_cross_axis_context_is_excluded() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember", _PROD_AXIS: "acme:WidgetMember"}, **_FY),
+        _fact(_REV, "c1", "600"),
+    )
+    assert facts == []
+
+
+def test_product_and_geographic_routes_accept_revenue_only() -> None:
+    facts = _extract(
+        _context("c1", {_PROD_AXIS: "acme:WidgetMember"}, **_FY),
+        _context("c2", {_GEO_AXIS: "country:US"}, **_FY),
+        _fact(_REV, "c1", "100"),
+        _fact("us-gaap:OperatingIncomeLoss", "c1", "40"),  # op income on product axis: skipped
+        _fact(_REV, "c2", "70"),
+    )
+    assert [(f.axis, f.metric, f.member_qname) for f in facts] == [
+        ("geographic", "revenue", "country:US"),
+        ("product_service", "revenue", "acme:WidgetMember"),
+    ]
+
+
+def test_assets_is_instant_and_segment_scoped() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, start=None, end=None, instant="2025-12-31"),
+        _fact("us-gaap:Assets", "c1", "5000"),
+    )
+    assert len(facts) == 1
+    assert facts[0].metric == "assets"
+    assert facts[0].period_start is None
+    assert facts[0].period_end == date(2025, 12, 31)
+
+
+def test_extension_namespace_concepts_are_skipped() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _fact("acme:Revenues", "c1", "600"),
+    )
+    assert facts == []
+
+
+def test_nil_facts_and_ratio_units_are_skipped() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _fact(_REV, "c1", "", nil=True),
+        _fact(_REV, "c1", "600", unit="ratio"),
+    )
+    assert facts == []
+
+
+# ---------------------------------------------------------------------
+# Sanity window (prevention log §1455)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        ("2025-01-01", "6016-12-31"),  # digit-overflow year
+        ("0205-01-01", "2025-12-31"),  # digit-truncation year
+        ("2025-12-31", "2025-01-01"),  # start after end
+    ],
+)
+def test_sanity_window_rejects_out_of_window_periods(start: str, end: str) -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, start=start, end=end),
+        _fact(_REV, "c1", "600"),
+    )
+    assert facts == []
+
+
+def test_duration_metric_without_start_date_is_rejected() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, start=None, end=None, instant="2025-12-31"),
+        _fact(_REV, "c1", "600"),
+    )
+    assert facts == []
+
+
+# ---------------------------------------------------------------------
+# Alias + duplicate arbitration
+# ---------------------------------------------------------------------
+
+
+def test_revenue_alias_priority_wins_per_member() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _fact("us-gaap:Revenues", "c1", "999"),
+        _fact(_REV, "c1", "600"),  # higher-priority alias
+    )
+    assert len(facts) == 1
+    assert facts[0].val == Decimal("600")
+
+
+def test_members_union_across_aliases() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _context("c2", {_SEG_AXIS: "acme:SouthMember"}, **_FY),
+        _fact(_REV, "c1", "600"),
+        _fact("us-gaap:Revenues", "c2", "400"),  # different member, lower-priority alias
+    )
+    assert {(f.member_qname, f.val) for f in facts} == {
+        ("acme:NorthMember", Decimal("600")),
+        ("acme:SouthMember", Decimal("400")),
+    }
+
+
+def test_duplicate_same_value_collapses_silently() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _fact(_REV, "c1", "600"),
+        _fact(_REV, "c1", "600"),
+    )
+    assert len(facts) == 1
+
+
+def test_duplicate_differing_values_higher_precision_wins() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _fact(_REV, "c1", "600", decimals="-6"),
+        _fact(_REV, "c1", "601", decimals="INF"),
+    )
+    assert len(facts) == 1
+    assert facts[0].val == Decimal("601")
+
+
+def test_duplicate_equal_precision_conflict_drops_member() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _fact(_REV, "c1", "600", decimals="-6"),
+        _fact(_REV, "c1", "601", decimals="-6"),
+    )
+    assert facts == []
+
+
+# ---------------------------------------------------------------------
+# Labels
+# ---------------------------------------------------------------------
+
+
+def test_label_from_linkbase_with_member_suffix_stripped() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _fact(_REV, "c1", "600"),
+        lab=_lab({"acme_NorthMember": "Northern Operations [Member]"}),
+    )
+    assert facts[0].member_label == "Northern Operations"
+
+
+def test_label_fallback_prettifies_localname() -> None:
+    facts = _extract(
+        _context("c1", {_SEG_AXIS: "acme:NorthAmericaRetailMember"}, **_FY),
+        _fact(_REV, "c1", "600"),
+    )
+    assert facts[0].member_label == "North America Retail"
+    assert prettify_member("country:US") == "US"
+
+
+# ---------------------------------------------------------------------
+# Subtotal detection
+# ---------------------------------------------------------------------
+
+
+def test_subtotal_marked_via_definition_linkbase_nesting() -> None:
+    facts = _extract(
+        _context("c1", {_PROD_AXIS: "us-gaap:ProductMember"}, **_FY),
+        _context("c2", {_PROD_AXIS: "acme:WidgetMember"}, **_FY),
+        _context("c3", {_PROD_AXIS: "acme:GadgetMember"}, **_FY),
+        _fact(_REV, "c1", "100"),
+        _fact(_REV, "c2", "60"),
+        _fact(_REV, "c3", "40"),
+        dfn=_def([("us-gaap_ProductMember", "acme_WidgetMember"), ("us-gaap_ProductMember", "acme_GadgetMember")]),
+    )
+    by_member = {f.member_qname: f.is_subtotal for f in facts}
+    assert by_member == {"us-gaap:ProductMember": True, "acme:WidgetMember": False, "acme:GadgetMember": False}
+
+
+def test_subtotal_marked_via_value_overage_when_linkbase_flat() -> None:
+    # AAPL shape: flat linkbase, Product = Widget + Gadget, consolidated
+    # total present as a dimensionless fact in the same instance.
+    facts = _extract(
+        _context("c0", {}, **_FY),
+        _context("c1", {_PROD_AXIS: "us-gaap:ProductMember"}, **_FY),
+        _context("c2", {_PROD_AXIS: "acme:WidgetMember"}, **_FY),
+        _context("c3", {_PROD_AXIS: "acme:GadgetMember"}, **_FY),
+        _context("c4", {_PROD_AXIS: "us-gaap:ServiceMember"}, **_FY),
+        _fact(_REV, "c0", "130"),  # consolidated anchor
+        _fact(_REV, "c1", "100"),
+        _fact(_REV, "c2", "60"),
+        _fact(_REV, "c3", "40"),
+        _fact(_REV, "c4", "30"),
+    )
+    by_member = {f.member_qname: f.is_subtotal for f in facts}
+    assert by_member == {
+        "us-gaap:ProductMember": True,
+        "acme:WidgetMember": False,
+        "acme:GadgetMember": False,
+        "us-gaap:ServiceMember": False,
+    }
+
+
+def test_value_overage_skips_business_segment_axis() -> None:
+    # Segment sums legitimately differ from consolidated (unallocated
+    # corporate) — no member may be marked from the mismatch.
+    facts = _extract(
+        _context("c0", {}, **_FY),
+        _context("c1", {_SEG_AXIS: "acme:NorthMember"}, **_FY),
+        _context("c2", {_SEG_AXIS: "acme:SouthMember"}, **_FY),
+        _fact(_REV, "c0", "90"),
+        _fact(_REV, "c1", "60"),
+        _fact(_REV, "c2", "40"),
+    )
+    assert all(not f.is_subtotal for f in facts)
+
+
+def test_value_overage_ambiguous_marks_nothing() -> None:
+    # Two members each equal the overage — ambiguous, nothing marked.
+    facts = _extract(
+        _context("c0", {}, **_FY),
+        _context("c1", {_GEO_AXIS: "acme:AMember"}, **_FY),
+        _context("c2", {_GEO_AXIS: "acme:BMember"}, **_FY),
+        _context("c3", {_GEO_AXIS: "acme:CMember"}, **_FY),
+        _fact(_REV, "c0", "50"),
+        _fact(_REV, "c1", "25"),
+        _fact(_REV, "c2", "25"),
+        _fact(_REV, "c3", "25"),
+    )
+    assert all(not f.is_subtotal for f in facts)
+
+
+def test_partial_disaggregation_below_total_marks_nothing() -> None:
+    facts = _extract(
+        _context("c0", {}, **_FY),
+        _context("c1", {_GEO_AXIS: "country:US"}, **_FY),
+        _fact(_REV, "c0", "100"),
+        _fact(_REV, "c1", "60"),
+    )
+    assert all(not f.is_subtotal for f in facts)
+
+
+# ---------------------------------------------------------------------
+# API axis-param mapping pin (spec §D6, Codex ckpt-1 LOW)
+# ---------------------------------------------------------------------
+
+
+def test_axis_param_to_storage_enum_mapping_is_pinned() -> None:
+    assert SEGMENT_AXIS_PARAM_TO_ENUM == {
+        "business": "business_segment",
+        "product": "product_service",
+        "geographic": "geographic",
+    }
+    from typing import get_args
+
+    assert set(get_args(SegmentAxisParam)) == set(SEGMENT_AXIS_PARAM_TO_ENUM)

--- a/tests/test_dimensional_facts.py
+++ b/tests/test_dimensional_facts.py
@@ -51,14 +51,20 @@ def _context(cid: str, dims: dict[str, str], *, start: str | None, end: str | No
     )
 
 
-def _fact(concept: str, cid: str, value: str, *, decimals: str | None = "-6", unit: str = "usd", nil: bool = False) -> str:
+def _fact(
+    concept: str, cid: str, value: str, *, decimals: str | None = "-6", unit: str = "usd", nil: bool = False
+) -> str:
     dec = f' decimals="{decimals}"' if decimals is not None else ""
     nil_attr = ' xsi:nil="true"' if nil else ""
     return f'<{concept} contextRef="{cid}" unitRef="{unit}"{dec}{nil_attr}>{value}</{concept}>'
 
 
 def _instance(*parts: str) -> bytes:
-    units = '<unit id="usd"><measure>iso4217:USD</measure></unit><unit id="ratio"><divide><unitNumerator><measure>iso4217:USD</measure></unitNumerator><unitDenominator><measure>shares</measure></unitDenominator></divide></unit>'
+    units = (
+        '<unit id="usd"><measure>iso4217:USD</measure></unit>'
+        '<unit id="ratio"><divide><unitNumerator><measure>iso4217:USD</measure></unitNumerator>'
+        "<unitDenominator><measure>shares</measure></unitDenominator></divide></unit>"
+    )
     return f"<xbrl {_NS}>{units}{''.join(parts)}</xbrl>".encode()
 
 

--- a/tests/test_dimensional_facts_store.py
+++ b/tests/test_dimensional_facts_store.py
@@ -1,0 +1,142 @@
+"""DB-tier test for the dimensional-facts store (#554).
+
+ONE integration test per genuinely-new SQL mechanism (test-quality
+skill): the winner-per-(axis, METRIC) reader with annual-duration
+filtering + subtotal exclusion, plus the delete-then-insert writer
+contract it depends on.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.dimensional_facts import DimensionalFact
+from app.services.dimensional_facts_store import read_segments, replace_accession_rows
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+_IID = 554001
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple]) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, 'SEGT', 'Segments co', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (_IID,),
+    )
+
+
+def _fact(
+    metric: str,
+    member: str,
+    val: str,
+    *,
+    axis: str = "business_segment",
+    start: date | None = date(2025, 1, 1),
+    end: date = date(2025, 12, 31),
+    is_subtotal: bool = False,
+) -> DimensionalFact:
+    return DimensionalFact(
+        axis=axis,  # type: ignore[arg-type]
+        member_qname=member,
+        member_label=member.split(":", 1)[-1],
+        metric=metric,  # type: ignore[arg-type]
+        unit="USD",
+        is_subtotal=is_subtotal,
+        period_start=start,
+        period_end=end,
+        val=Decimal(val),
+        decimals="-6",
+    )
+
+
+@pytest.mark.integration
+def test_reader_winner_per_metric_annual_filter_and_writer_replace(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn)
+
+    original = [
+        # FY2025 annual rows.
+        _fact("revenue", "t:NorthMember", "600"),
+        _fact("revenue", "t:SouthMember", "400"),
+        _fact("revenue", "t:TotalMember", "1000", is_subtotal=True),
+        _fact("operating_income", "t:NorthMember", "60"),
+        _fact("operating_income", "t:SouthMember", "40"),
+        _fact("assets", "t:NorthMember", "5000", start=None),
+        # Prior-FY comparative — must lose to FY2025 on period selection.
+        _fact("revenue", "t:NorthMember", "500", start=date(2024, 1, 1), end=date(2024, 12, 31)),
+        # Quarterly/YTD context a 10-K also carries — annual filter drops it.
+        _fact("revenue", "t:NorthMember", "150", start=date(2025, 10, 1), end=date(2025, 12, 31)),
+    ]
+    n = replace_accession_rows(
+        conn,
+        instrument_id=_IID,
+        source_accession="ACC-ORIG",
+        form_type="10-K",
+        filed_at=datetime(2026, 2, 1, tzinfo=UTC),
+        parser_version="10k-v2",
+        facts=original,
+    )
+    assert n == len(original)
+
+    # Amendment: restates REVENUE only (omits op income + assets) — the
+    # per-METRIC winner must take revenue from here without regressing
+    # the other metrics to empty (spec §D4, Codex ckpt-1 HIGH).
+    amendment = [
+        _fact("revenue", "t:NorthMember", "610"),
+        _fact("revenue", "t:SouthMember", "390"),
+    ]
+    replace_accession_rows(
+        conn,
+        instrument_id=_IID,
+        source_accession="ACC-AMEND",
+        form_type="10-K/A",
+        filed_at=datetime(2026, 3, 1, tzinfo=UTC),
+        parser_version="10k-v2",
+        facts=amendment,
+    )
+    conn.commit()
+
+    result = read_segments(conn, instrument_id=_IID, axis="business_segment")
+    assert result.sources == {
+        "revenue": "ACC-AMEND",
+        "operating_income": "ACC-ORIG",
+        "assets": "ACC-ORIG",
+    }
+    assert result.period_end == date(2025, 12, 31)
+    by_member = {r["member_qname"]: r for r in result.rows}
+    # Subtotal excluded; restated revenue paired with original op income.
+    assert set(by_member) == {"t:NorthMember", "t:SouthMember"}
+    assert by_member["t:NorthMember"]["revenue"] == Decimal("610")
+    assert by_member["t:NorthMember"]["operating_income"] == Decimal("60")
+    assert by_member["t:NorthMember"]["assets"] == Decimal("5000")
+    assert by_member["t:SouthMember"]["revenue"] == Decimal("390")
+
+    # Writer replace contract: re-ingesting ACC-AMEND with fewer rows
+    # clears its previous rows (rewash correction path, spec §D4).
+    replace_accession_rows(
+        conn,
+        instrument_id=_IID,
+        source_accession="ACC-AMEND",
+        form_type="10-K/A",
+        filed_at=datetime(2026, 3, 1, tzinfo=UTC),
+        parser_version="10k-v3",
+        facts=[_fact("revenue", "t:NorthMember", "615")],
+    )
+    conn.commit()
+    result2 = read_segments(conn, instrument_id=_IID, axis="business_segment")
+    by_member2 = {r["member_qname"]: r for r in result2.rows}
+    assert by_member2["t:NorthMember"]["revenue"] == Decimal("615")
+    # SouthMember revenue no longer in the amendment; reader still
+    # surfaces the member because op income (winner ACC-ORIG) has it,
+    # with revenue empty — per-metric winners are independent.
+    assert by_member2["t:SouthMember"]["revenue"] is None
+    assert by_member2["t:SouthMember"]["operating_income"] == Decimal("40")

--- a/tests/test_dimensional_facts_store.py
+++ b/tests/test_dimensional_facts_store.py
@@ -140,3 +140,24 @@ def test_reader_winner_per_metric_annual_filter_and_writer_replace(
     # with revenue empty — per-metric winners are independent.
     assert by_member2["t:SouthMember"]["revenue"] is None
     assert by_member2["t:SouthMember"]["operating_income"] == Decimal("40")
+
+    # A still-newer accession with ONLY ineligible rows (quarterly
+    # duration + a subtotal) must NOT win the revenue metric — winner
+    # selection filters eligibility first (Codex pre-push finding).
+    replace_accession_rows(
+        conn,
+        instrument_id=_IID,
+        source_accession="ACC-Q-ONLY",
+        form_type="10-K/A",
+        filed_at=datetime(2026, 4, 1, tzinfo=UTC),
+        parser_version="10k-v3",
+        facts=[
+            _fact("revenue", "t:NorthMember", "160", start=date(2025, 10, 1), end=date(2025, 12, 31)),
+            _fact("revenue", "t:TotalMember", "1010", is_subtotal=True),
+        ],
+    )
+    conn.commit()
+    result3 = read_segments(conn, instrument_id=_IID, axis="business_segment")
+    assert result3.sources["revenue"] == "ACC-AMEND"
+    by_member3 = {r["member_qname"]: r for r in result3.rows}
+    assert by_member3["t:NorthMember"]["revenue"] == Decimal("615")

--- a/tests/test_dimensional_facts_store.py
+++ b/tests/test_dimensional_facts_store.py
@@ -161,3 +161,31 @@ def test_reader_winner_per_metric_annual_filter_and_writer_replace(
     assert result3.sources["revenue"] == "ACC-AMEND"
     by_member3 = {r["member_qname"]: r for r in result3.rows}
     assert by_member3["t:NorthMember"]["revenue"] == Decimal("615")
+
+    # Review-bot WARNING (PR #1588): a subtotal row in the WINNING
+    # accession with a LATER period_end must not anchor the target
+    # period — every CTE stage carries the same eligibility filters.
+    replace_accession_rows(
+        conn,
+        instrument_id=_IID,
+        source_accession="ACC-AMEND",
+        form_type="10-K/A",
+        filed_at=datetime(2026, 3, 1, tzinfo=UTC),
+        parser_version="10k-v3",
+        facts=[
+            _fact("revenue", "t:NorthMember", "615"),
+            _fact(
+                "revenue",
+                "t:TotalMember",
+                "1300",
+                start=date(2026, 1, 1),
+                end=date(2026, 12, 31),
+                is_subtotal=True,
+            ),
+        ],
+    )
+    conn.commit()
+    result4 = read_segments(conn, instrument_id=_IID, axis="business_segment")
+    assert result4.period_end == date(2025, 12, 31)
+    by_member4 = {r["member_qname"]: r for r in result4.rows}
+    assert by_member4["t:NorthMember"]["revenue"] == Decimal("615")

--- a/tests/test_manifest_parser_sec_10k.py
+++ b/tests/test_manifest_parser_sec_10k.py
@@ -1482,3 +1482,44 @@ def test_dimensional_facts_survive_item1_tombstone(
 
     rows = _dimensional_rows(ebull_test_conn, accession)
     assert [(r[0], int(r[2])) for r in rows] == [("t:NorthMember", 600), ("t:SouthMember", 400)]
+
+
+def test_dimensional_facts_with_legacy_full_submission_txt_url(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy manifest rows carry the full-submission ``.txt`` URL whose
+    dirname is the CIK root, not the accession folder. The dimensional
+    step must build the archive base from (cik, accession) — deriving
+    it from the primary URL 404'd every artifact and silently yielded
+    zero facts (GME/HD/JPM in the dev backfill)."""
+    iid = 10100557
+    cik = "0000999991"
+    accession = "0000999991-26-000557"
+    txt_url = f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{accession}.txt"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="ACMH", cik=cik)
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession=accession,
+        instrument_id=iid,
+        cik=cik,
+        primary_doc_url=txt_url,
+    )
+    ebull_test_conn.commit()
+
+    _patch_dimensional_real(monkeypatch)
+    archive_base = f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            txt_url: _FAKE_10K_HTML,
+            archive_base + "acme_htm.xml": _DIM_INSTANCE_XML,
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+    assert stats.parsed == 1
+
+    rows = _dimensional_rows(ebull_test_conn, accession)
+    assert [(r[0], int(r[2])) for r in rows] == [("t:NorthMember", 600), ("t:SouthMember", 400)]

--- a/tests/test_manifest_parser_sec_10k.py
+++ b/tests/test_manifest_parser_sec_10k.py
@@ -1330,9 +1330,7 @@ def _patch_dimensional_real(monkeypatch, *, instance_name: str = "acme_htm.xml")
     monkeypatch.setattr(
         sec_edgar.SecFilingsProvider,
         "fetch_filing_index",
-        lambda self, accession, issuer_cik=None: {
-            "directory": {"item": [{"name": instance_name, "size": "100"}]}
-        },
+        lambda self, accession, issuer_cik=None: {"directory": {"item": [{"name": instance_name, "size": "100"}]}},
     )
 
 

--- a/tests/test_manifest_parser_sec_10k.py
+++ b/tests/test_manifest_parser_sec_10k.py
@@ -162,6 +162,24 @@ def _reset_registry_then_reload():
     register_all_parsers()
 
 
+@pytest.fixture(autouse=True)
+def _stub_dimensional_step(monkeypatch: pytest.MonkeyPatch):
+    """Default the #554 dimensional step to the no-XBRL path.
+
+    Pre-#554 tests patch only ``fetch_document_text``; without this
+    stub the new step's ``fetch_filing_index`` would hit live EDGAR.
+    Dimensional-path tests override with the real implementation +
+    fully patched provider methods.
+    """
+    from app.services.manifest_parsers import sec_10k as sec_10k_module
+
+    monkeypatch.setattr(
+        sec_10k_module,
+        "_fetch_dimensional_facts",
+        lambda **_kwargs: [],
+    )
+
+
 def _patch_fetch(monkeypatch, payload: str | None):
     from app.providers.implementations import sec_edgar
 
@@ -1266,3 +1284,169 @@ def test_parser_registered_via_register_all() -> None:
     assert "sec_10k" not in registered_parser_sources()
     register_all_parsers()
     assert "sec_10k" in registered_parser_sources()
+
+
+# ---------------------------------------------------------------------
+# Dimensional XBRL step (#554)
+# ---------------------------------------------------------------------
+
+# Captured at import time, BEFORE the autouse ``_stub_dimensional_step``
+# fixture patches the module attribute — lets dimensional-path tests
+# restore the real implementation.
+from app.services.manifest_parsers.sec_10k import (  # noqa: E402
+    _fetch_dimensional_facts as _REAL_FETCH_DIMENSIONAL,
+)
+
+_DIM_INSTANCE_XML = (
+    '<xbrl xmlns="http://www.xbrl.org/2003/instance"'
+    ' xmlns:us-gaap="http://fasb.org/us-gaap/2025"'
+    ' xmlns:t="http://t.example/2025"'
+    ' xmlns:xbrldi="http://xbrl.org/2006/xbrldi">'
+    '<unit id="usd"><measure>iso4217:USD</measure></unit>'
+    '<context id="c1"><entity>'
+    '<identifier scheme="http://www.sec.gov/CIK">0000999991</identifier>'
+    '<segment><xbrldi:explicitMember dimension="us-gaap:StatementBusinessSegmentsAxis">'
+    "t:NorthMember</xbrldi:explicitMember></segment></entity>"
+    "<period><startDate>2025-01-01</startDate><endDate>2025-12-31</endDate></period></context>"
+    '<context id="c2"><entity>'
+    '<identifier scheme="http://www.sec.gov/CIK">0000999991</identifier>'
+    '<segment><xbrldi:explicitMember dimension="us-gaap:StatementBusinessSegmentsAxis">'
+    "t:SouthMember</xbrldi:explicitMember></segment></entity>"
+    "<period><startDate>2025-01-01</startDate><endDate>2025-12-31</endDate></period></context>"
+    '<us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax contextRef="c1" unitRef="usd"'
+    ' decimals="-6">600</us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax>'
+    '<us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax contextRef="c2" unitRef="usd"'
+    ' decimals="-6">400</us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax>'
+    "</xbrl>"
+)
+
+
+def _patch_dimensional_real(monkeypatch, *, instance_name: str = "acme_htm.xml"):
+    """Restore the real dimensional step + stub ``fetch_filing_index``."""
+    from app.providers.implementations import sec_edgar
+    from app.services.manifest_parsers import sec_10k as sec_10k_module
+
+    monkeypatch.setattr(sec_10k_module, "_fetch_dimensional_facts", _REAL_FETCH_DIMENSIONAL)
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_filing_index",
+        lambda self, accession, issuer_cik=None: {
+            "directory": {"item": [{"name": instance_name, "size": "100"}]}
+        },
+    )
+
+
+def _dimensional_rows(conn, accession):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT member_qname, metric, val, source_accession, parser_version"
+            " FROM instrument_dimensional_facts WHERE source_accession = %s"
+            " ORDER BY member_qname",
+            (accession,),
+        )
+        return cur.fetchall()
+
+
+def test_dimensional_facts_written_on_happy_path(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Step 9 (#554): instance fetched for THIS accession, facts written."""
+    iid = 10100554
+    cik = "0000999991"
+    accession = "0000999991-26-000554"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="ACMD", cik=cik)
+    _seed_pending_10k(ebull_test_conn, accession=accession, instrument_id=iid, cik=cik)
+    ebull_test_conn.commit()
+
+    _patch_dimensional_real(monkeypatch)
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "primary_doc.htm": _FAKE_10K_HTML,
+            base + "acme_htm.xml": _DIM_INSTANCE_XML,
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+    assert stats.parsed == 1
+
+    rows = _dimensional_rows(ebull_test_conn, accession)
+    assert [(r[0], r[1], int(r[2])) for r in rows] == [
+        ("t:NorthMember", "revenue", 600),
+        ("t:SouthMember", "revenue", 400),
+    ]
+    assert all(r[4] == "10k-v2" for r in rows)
+
+
+def test_dimensional_facts_target_amendment_accession_not_item1_fallback(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 10-K/A without Item 1 borrows the prior 10-K's NARRATIVE, but
+    its dimensional facts must be written under the AMENDMENT accession
+    (Codex plan-review: never reuse chosen_accession for XBRL)."""
+    iid = 10100555
+    cik = "0000999991"
+    plain_acc = "0000999991-25-000100"
+    amend_acc = "0000999991-26-000200"
+    base_plain = f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{plain_acc.replace('-', '')}/"
+    base_amend = f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{amend_acc.replace('-', '')}/"
+
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="ACMF", cik=cik)
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=plain_acc,
+        filing_type="10-K",
+        filing_date=datetime(2025, 2, 1, tzinfo=UTC).date(),
+        primary_doc_url=base_plain + "primary_doc.htm",
+    )
+    # The amendment must ALSO exist in filing_events —
+    # _find_prior_plain_10k anchors its "strictly older" comparison on
+    # the amendment's own filing_date row.
+    _seed_filing_event(
+        ebull_test_conn,
+        instrument_id=iid,
+        accession=amend_acc,
+        filing_type="10-K/A",
+        filing_date=datetime(2026, 3, 15, tzinfo=UTC).date(),
+        primary_doc_url=base_amend + "primary_doc.htm",
+    )
+    _seed_pending_10k(
+        ebull_test_conn,
+        accession=amend_acc,
+        instrument_id=iid,
+        cik=cik,
+        form="10-K/A",
+        primary_doc_url=base_amend + "primary_doc.htm",
+    )
+    ebull_test_conn.commit()
+
+    _patch_dimensional_real(monkeypatch)
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            # Amendment has no Item 1 → narrative falls back to the
+            # prior plain 10-K; amendment's own XBRL still parses.
+            base_amend + "primary_doc.htm": _FAKE_10KA_HTML_NO_ITEM_1,
+            base_plain + "primary_doc.htm": _FAKE_10K_HTML,
+            base_amend + "acme_htm.xml": _DIM_INSTANCE_XML,
+            base_plain + "acme_htm.xml": "<not-xbrl/>",
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+    assert stats.parsed == 1
+
+    # Narrative attributed to the fallback plain 10-K…
+    body_row = _read_summary(ebull_test_conn, iid)
+    assert body_row is not None
+    assert body_row[1] == plain_acc
+    # …but dimensional facts live under the amendment's own accession.
+    assert _dimensional_rows(ebull_test_conn, plain_acc) == []
+    amend_rows = _dimensional_rows(ebull_test_conn, amend_acc)
+    assert [(r[0], int(r[2])) for r in amend_rows] == [("t:NorthMember", 600), ("t:SouthMember", 400)]

--- a/tests/test_manifest_parser_sec_10k.py
+++ b/tests/test_manifest_parser_sec_10k.py
@@ -1448,3 +1448,37 @@ def test_dimensional_facts_target_amendment_accession_not_item1_fallback(
     assert _dimensional_rows(ebull_test_conn, plain_acc) == []
     amend_rows = _dimensional_rows(ebull_test_conn, amend_acc)
     assert [(r[0], int(r[2])) for r in amend_rows] == [("t:NorthMember", 600), ("t:SouthMember", 400)]
+
+
+def test_dimensional_facts_survive_item1_tombstone(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spec §D1 both-directions independence: a plain 10-K whose Item 1
+    defeats the extractor tombstones the NARRATIVE, but the dimensional
+    step (2.5, before the narrative parse) must still have written the
+    segment facts (MSFT FY2025 case from the dev backfill)."""
+    iid = 10100556
+    cik = "0000999991"
+    accession = "0000999991-26-000556"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="ACMG", cik=cik)
+    _seed_pending_10k(ebull_test_conn, accession=accession, instrument_id=iid, cik=cik)
+    ebull_test_conn.commit()
+
+    _patch_dimensional_real(monkeypatch)
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/{accession.replace('-', '')}/"
+    _patch_fetch_map(
+        monkeypatch,
+        {
+            # No Item 1 marker on a plain 10-K → narrative tombstone.
+            base + "primary_doc.htm": "<html><body><p>FORM 10-K</p><p>no item one here</p></body></html>",
+            base + "acme_htm.xml": _DIM_INSTANCE_XML,
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_10k", max_rows=10)
+    ebull_test_conn.commit()
+    assert stats.tombstoned == 1
+
+    rows = _dimensional_rows(ebull_test_conn, accession)
+    assert [(r[0], int(r[2])) for r in rows] == [("t:NorthMember", 600), ("t:SouthMember", 400)]


### PR DESCRIPTION
Closes #554

## What

Per-filing dimensional XBRL extraction (10-K / 10-K/A) for three axes — business segments, product/service mix, geographic revenue — plus the storage, API, and instrument-page surface. Spec + implementation plan (operator-approved, Codex-reviewed ×2): `docs/proposals/etl/2026-06-11-554-xbrl-dimensional-facts.md`.

## Why the design looks like this (verified premises)

- **The companyfacts API carries NO dimensional facts** (verified live: AAPL, 503 concepts, fact keys are only `accn/end/filed/form/fp/frame/fy/start/val`). The only source is each filing's own XBRL instance, so extraction is a second step inside the existing `sec_10k` manifest parser (`10k-v1 → 10k-v2`), not an extension of the fundamentals provider.
- **Fetches go through our shared 10 req/s throttle** (`fetch_filing_index` + `fetch_document_text`), not `edgartools.xbrl()` (which does its own HTTP — edgartools-skill hard-stop). lxml parsing reuses the `n_csr_extractor` context/dimension machinery, now shared via `app/services/xbrl_instance.py`.
- **Member sets are not flat.** AAPL's `us-gaap:ProductMember` ($307.0B) is the parent subtotal of iPhone/Mac/iPad/Wearables; naive row sums double-count ($723B vs $416B). Rows carry `is_subtotal`, marked by two detectors: definition-linkbase domain-member nesting (scoped per axis+metric+period), and an ASC-606 value-overage detector against the consolidated (dimensionless) revenue fact in the same instance — `sum(members) − consolidated` is exactly the subtotal mass; smallest subset (≤3) matching it exactly is marked; ambiguity marks nothing + WARNs. `business_segment` is excluded from the value detector (its sum legitimately differs from consolidated once eliminations/corporate are filtered via the `ConsolidationItemsAxis` route rule).
- **index.json has no exhibit-type labels**, so instance discovery is name-shape based (`*_htm.xml` inline era → standalone-`.xml` heuristic), with `.xsd` fallback for label/definition linkbases (Workiva-style filers, e.g. MSFT, embed linkbases in the schema annotation).

## Key behaviours

- **Reader** selects the winning accession per (axis, **metric**) — a 10-K/A restating revenue but omitting op income pairs amendment revenue with original op income instead of regressing it. Winner eligibility (annual-duration 330–400d, non-subtotal) is filtered **before** winner selection. Rewash = delete-then-insert per accession with `parser_version` stamp.
- **Parser failure semantics**: transport error → `failed` (whole row retries; idempotent — Item 1 is filed_at-gate-suppressed, dimensional write replaces); structural no-XBRL (pre-mandate) → parsed, zero rows; parse/write bug → WARN + parsed-without-segments (a segment bug must not regress the narrative). The dimensional step always targets the row's **own** accession, never the Item-1 fallback's.
- **API**: `GET /instruments/{symbol}/segments?axis=business|product|geographic` → per-metric `sources` map, leaf rows with `pct_of_total` over leaf revenue. 404 = structural empty (non-SEC, pre-mandate, or no disclosure on the axis — banks often emit nothing on the product axis).
- **FE**: `SegmentsPane` (axis toggle, skeleton/error/empty states) with `SegmentsTable` (op-income/assets columns collapse when entirely null) + `GeographicMixChart` (CSS proportion bars), wired full-width into both `DensityGrid` profiles. `formatBigNumber` promoted from FundamentalsPane-private to `lib/format`.

## Security model

- All fetched XML parsed with a hardened lxml parser (`SAFE_XML_PARSER`: entity resolution / DTD loading / network access off) — closes XXE/entity-expansion on SEC-fetched content; also applied to the pre-existing N-CSR parse path. No raw instance retention (#470 raw-payload posture — every extracted field lands in SQL). Endpoint is read-only, symbol resolved via parameterised SQL, no user input reaches SQL or URLs unescaped (`encodeURIComponent` on the FE, `%(s)s` params on the BE).

## Codex rounds (all findings terminal)

- ckpt-1 spec: 3 HIGH / 4 MED / 1 LOW — all FIXED in spec before implementation.
- ckpt-1b plan: 6 findings — all FIXED (T7/T8 ordering, per-metric sources contract, pure/DB module split, fixture teardown entry, 10-K/A own-accession rule, retry-idempotence wording).
- ckpt-2 (fresh-agent, financial-plumbing/data-eng/data-sci/adversarial lenses): 3 findings — all FIXED with regression tests (per-period subtotal scope; eligible-rows-first winner CTE; scenario-container dimensions).

## Tests

- 31 pure table-tests (discovery priority, exact axis-set routing, alias + duplicate-precision arbitration, §1455 sanity window, labels, both subtotal detectors incl. per-period scoping + ambiguity, axis-param mapping pin).
- 1 db-tier reader test (winner-per-metric, annual filter, subtotal exclusion, replace contract, ineligible-accession fallback).
- 2 manifest dimensional-path tests (happy path; 10-K/A facts attributed to the amendment accession, not the Item-1 fallback). Legacy 10-K parser tests kept hermetic via an autouse no-XBRL stub.
- FE: 5 vitest state tests. Gates: ruff/format/pyright clean, fast tier 3859 passed, smoke 129 passed, FE typecheck + 974 unit tests passed.

## Live verification of the extraction core (pre-backfill)

Ran the real extractor against live EDGAR artifacts: AAPL FY2025 (product leaves sum **$416.161B** = consolidated revenue exactly; `Product` marked subtotal; geo US/CN/Other reconciles), MSFT FY2025 (xsd-embedded linkbases; `Product` + `Service, Other` subtotals; leaves sum **$281.724B**), JPM FY2025 (segment **assets**; geographic `Total International` = EMEA+APAC+LatAm caught by the value detector; leaves sum **$182.447B**).

## Conscious tradeoffs

- 10-Q interim segments deferred (cadence mixing, no operator ask).
- Filer-extension revenue concepts out of scope v1 (undercount caveat; `pct_of_total` over returned rows stays internally consistent).
- Banks may render empty on the product axis (no revenue-alias facts) — honest empty state.
- Dev-DB note: the `--reload` dev API auto-applied the draft sql/193 mid-development; final-shape delta replayed manually + sha reset per the #1333 procedure (table was empty).

## DoD 8–12 (ETL clauses) — backfill + verification evidence (commit c8457315)

**Backfill scope decision (clause 10):** `POST /jobs/sec_rebuild/run {"source":"sec_10k"}` was deliberately NOT used — its source scope resets ALL non-pending rows including the 29,790 `deferred` rows (the #1343 deferred-by-design posture), which is the wrong blast radius. Instead: targeted SQL reset of the 3,175 previously-`parsed` sec_10k rows → standalone `_dispatch_rows` drain (S7-precedent recipe, `scripts/drain_554_sec10k.py`, chunks of 50, jobs proc restarted onto the branch first). Two live bugs were caught BY this backfill and fixed in-PR (step-2.5 reorder 25cd93a8; archive-base construction c8457315); the 71 rows parsed before the URL fix were re-reset and re-drained. Bulk drain running at merge time (~3.1k rows, fetch-bound); completion will be recorded in a PR comment + tombstoned-narrative rows note below.

**Smoke panel (clause 8) — live `GET /instruments/{symbol}/segments` on dev, all figures operator-visible:**
- AAPL (FY 2025-09-27): business Americas 178.35B/42.9% · Europe 111.03B · Greater China 64.38B · RoAP 33.70B · Japan 28.70B; product iPhone 209.59B/50.4% · Services 109.16B · Wearables 35.69B · Mac 33.71B · iPad 28.02B; geographic US 151.79B · CN 64.38B · Other 199.99B — **all three axes total 416.16B exactly**.
- MSFT (FY 2025-06-30): 3 segments 120.81/106.27/54.65B; 10-leaf product split; geo US/Non-US — all sum 281.72B. Narrative row is tombstoned (Item-1 extractor miss) yet segments render — the step-2.5 independence fix proven live.
- GME (FY 2026-01-31): 4 geo segments 3.63B; product hardware/collectibles/software; geographic = honest 404 (not disclosed on that axis).
- JPM (FY 2025-12-31): segment **assets** render with revenue empty (banks); geographic North America 139.69B/76.6% + EMEA/APAC/LatAm = 182.45B with 'Total International' subtotal correctly excluded.
- HD (FY 2026-02-01): segments, product, geographic all sum 164.68B.

**Cross-source (clause 9):** AAPL FY2025 consolidated revenue **$416,161M** per stockanalysis.com — equals the leaf sums on all three axes exactly. Per-product figures EDGAR-direct (instance document of accession 0000320193-25-000079; iPhone 209.586B / Mac 33.708B / iPad 28.023B / Wearables 35.686B / Services 109.158B).

**Operator-visible surface (clause 11):** endpoint verified live for the full panel (figures above); FE behaviour pinned by 5 vitest state tests (table, % rendering, geographic bars, axis-toggle refetch). Operator visual pass on the dev UI per the usual post-merge S8 pattern.

**Known gaps recorded:** rows tombstoned for narrative reasons BEFORE this PR never re-enter the worker, so historical no-Item-1 10-Ks have no segments until a future targeted reset (the JPM row was hand-reset here as proof the path works); pre-2011 no-XBRL filings yield zero rows by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
