### PR TITLE
feat(#1596): snapshot v2 data contract — flow-adjusted cover, shared valuation, statement sections

### DIFF
--- a/.claude/skills/engineering/sql-correctness.md
+++ b/.claude/skills/engineering/sql-correctness.md
@@ -137,3 +137,20 @@ Worked example (Codex 2 catch, 2026-05-27 PR phase-0-new-b-c-bundle):
 * A seeder that grepped only the CREATE TABLE saw "NOT NULL TEXT" and emitted `SYN00000000` → COPY aborted on first row.
 
 The lesson lives in `feedback_grep_alter_constraints` (memory) and `docs/review-prevention-log.md`.
+
+## Inclusive day-upper-bounds on timestamp columns: `< %(end)s::date + 1`
+
+For "rows up to and including day X" against a TIMESTAMPTZ column, the
+repo convention is the half-open form:
+
+```sql
+WHERE ts_col >= %(start)s
+  AND ts_col <  %(end)s::date + 1
+```
+
+Do NOT "simplify" to `ts_col <= %(end)s::date` — comparing a timestamp
+to a date coerces the date to midnight, silently dropping every
+intraday row on the last day. (PR #1597 review suggested exactly that
+rewrite; it would have excluded the whole final day of each report
+period.) `reporting.py` uses the half-open form at every period-bounded
+query — keep new queries consistent with it.

--- a/app/api/_helpers.py
+++ b/app/api/_helpers.py
@@ -1,37 +1,16 @@
-"""Shared helpers for API route modules."""
+"""Shared helpers for API route modules.
+
+``parse_optional_float`` and ``resolve_quote_price`` moved to
+``app/services/valuation.py`` with #1596 — the shared valuation
+helper needs them and the service layer must not import from the API
+layer. Re-exported here so existing API-module imports keep working.
+"""
 
 from __future__ import annotations
 
+from app.services.valuation import parse_optional_float, resolve_quote_price
 
-def parse_optional_float(row: dict[str, object], key: str) -> float | None:
-    """Safely cast a nullable numeric DB column to float."""
-    val = row.get(key)
-    if val is None:
-        return None
-    return float(val)  # type: ignore[arg-type]
-
-
-def resolve_quote_price(
-    last: float | None,
-    bid: float | None,
-    ask: float | None,
-) -> float | None:
-    """Return a usable live-quote price, or ``None`` if none is available.
-
-    Rule: a usable mark is the trade ``last`` when strictly positive; else
-    the bid/ask mid when the book is two-sided and both sides are positive.
-
-    A non-positive ``last`` is treated as missing. eToro persists
-    ``quotes.last = 0.00`` for instruments not freshly traded (bid/ask
-    present, no recent trade). Using 0 as the mark values a position at 0 →
-    fake −100% P&L (#1428). Callers supply their own downstream fallback
-    (daily_close → cost basis / open_rate) when this returns ``None``.
-    """
-    if last is not None and last > 0:
-        return last
-    if bid is not None and bid > 0 and ask is not None and ask > 0:
-        return (bid + ask) / 2.0
-    return None
+__all__ = ["parse_optional_float", "parse_optional_int", "resolve_quote_price"]
 
 
 def parse_optional_int(row: dict[str, object], key: str) -> int | None:

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -38,8 +38,8 @@ from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.domain.positions import PositionSource
 from app.services.fx import FxRateNotFound, convert, load_live_fx_rates_with_metadata
-from app.services.portfolio import load_mirror_breakdowns
 from app.services.runtime_config import get_runtime_config
+from app.services.valuation import HoldingValuation, compute_portfolio_valuation
 
 logger = logging.getLogger(__name__)
 
@@ -190,75 +190,27 @@ def _convert_value(
         return value
 
 
-def _parse_position(
-    row: dict[str, object],
-    display_currency: str,
-    rates: dict[tuple[str, str], Decimal],
-) -> PositionItem:
-    cost_basis = float(row["cost_basis"])  # type: ignore[arg-type]
-    current_units = float(row["current_units"])  # type: ignore[arg-type]
-    native_currency: str = str(row.get("currency") or "USD")  # fallback for un-enriched
+def _position_item(h: HoldingValuation) -> PositionItem:
+    """API shape for one valued holding.
 
-    # Mark-to-market hierarchy: live quote (last>0 → bid/ask mid) →
-    # price_daily.close → cost_basis. A non-positive last/close is not a
-    # valid mark (#1428). valuation_source tells the dashboard which tier
-    # produced the value.
-    quote_price = resolve_quote_price(
-        parse_optional_float(row, "last"),
-        parse_optional_float(row, "bid"),
-        parse_optional_float(row, "ask"),
-    )
-    daily_close = parse_optional_float(row, "daily_close")
-
-    if quote_price is not None:
-        current_price: float | None = quote_price
-        market_value = current_units * quote_price
-        unrealized_pnl = market_value - cost_basis
-        valuation_source = "quote"
-    elif daily_close is not None and daily_close > 0:
-        current_price = daily_close
-        market_value = current_units * daily_close
-        unrealized_pnl = market_value - cost_basis
-        valuation_source = "daily_close"
-    else:
-        current_price = None
-        market_value = cost_basis
-        unrealized_pnl = 0.0
-        valuation_source = "cost_basis"
-
-    # Convert all monetary values to display currency in a single block
-    # so they either all convert or all stay in native currency.
-    avg_cost = parse_optional_float(row, "avg_cost")
-    if native_currency != display_currency:
-        try:
-            market_value = float(convert(Decimal(str(market_value)), native_currency, display_currency, rates))
-            cost_basis = float(convert(Decimal(str(cost_basis)), native_currency, display_currency, rates))
-            unrealized_pnl = float(convert(Decimal(str(unrealized_pnl)), native_currency, display_currency, rates))
-            if current_price is not None:
-                current_price = float(convert(Decimal(str(current_price)), native_currency, display_currency, rates))
-            if avg_cost is not None:
-                avg_cost = float(convert(Decimal(str(avg_cost)), native_currency, display_currency, rates))
-        except FxRateNotFound:
-            logger.warning(
-                "FX rate %s→%s not found; skipping conversion for position",
-                native_currency,
-                display_currency,
-            )
-
+    All marking + FX math lives in
+    `app.services.valuation.compute_portfolio_valuation` (#1596) — this
+    is a pure field mapping.
+    """
     return PositionItem(
-        instrument_id=row["instrument_id"],  # type: ignore[arg-type]
-        symbol=row["symbol"],  # type: ignore[arg-type]
-        company_name=row["company_name"],  # type: ignore[arg-type]
-        open_date=row["open_date"],  # type: ignore[arg-type]
-        avg_cost=avg_cost,
-        current_price=current_price,
-        current_units=current_units,
-        cost_basis=cost_basis,
-        market_value=market_value,
-        unrealized_pnl=unrealized_pnl,
-        valuation_source=valuation_source,
-        source=row["source"],  # type: ignore[arg-type]
-        updated_at=row["updated_at"],  # type: ignore[arg-type]
+        instrument_id=h.instrument_id,
+        symbol=h.symbol,
+        company_name=h.company_name,
+        open_date=h.open_date,
+        avg_cost=h.avg_cost,
+        current_price=h.current_price,
+        current_units=h.current_units,
+        cost_basis=h.cost_basis,
+        market_value=h.market_value,
+        unrealized_pnl=h.unrealized_pnl,
+        valuation_source=h.valuation_source,
+        source=h.source,
+        updated_at=h.updated_at,
     )
 
 
@@ -334,55 +286,15 @@ def get_portfolio(
     If cash_balance is unknown (empty cash_ledger), AUM uses positions only
     and cash_balance is null. mirror_equity is always a float (default 0.0).
     """
-    # -- Load display currency and FX rates ----------------------------------
-    config = get_runtime_config(conn)
-    display_currency = config.display_currency
-    rates_meta = load_live_fx_rates_with_metadata(conn)
-    rates: dict[tuple[str, str], Decimal] = {k: v["rate"] for k, v in rates_meta.items()}
-
-    # -- Positions query ---------------------------------------------------
-    # quotes is 1:1 keyed by instrument_id (PRIMARY KEY) — LEFT JOIN is fan-out-safe.
-    # Zero-unit positions are excluded: fully liquidated positions should not
-    # appear in the portfolio view or inflate AUM.
-    # i.currency: the instrument's native currency for FX conversion.
-    # LEFT JOIN quotes (1:1 by PK) and latest price_daily (DISTINCT ON
-    # avoids fan-out — one row per instrument, most recent date).
-    positions_sql = """
-        SELECT p.instrument_id, i.symbol, i.company_name, i.currency,
-               p.open_date, p.avg_cost, p.current_units, p.cost_basis,
-               p.source, p.updated_at,
-               q.last, q.bid, q.ask,
-               pd.close AS daily_close
-        FROM positions p
-        JOIN instruments i USING (instrument_id)
-        LEFT JOIN quotes q USING (instrument_id)
-        LEFT JOIN LATERAL (
-            SELECT close
-            FROM price_daily
-            WHERE instrument_id = p.instrument_id
-              AND close IS NOT NULL
-            ORDER BY price_date DESC
-            LIMIT 1
-        ) pd ON true
-        WHERE p.current_units > 0
-        ORDER BY p.cost_basis DESC, p.instrument_id ASC
-    """
-
-    # -- Cash query --------------------------------------------------------
-    # SUM on empty table returns NULL (one row, NULL value) — not zero rows.
-    cash_sql = "SELECT SUM(amount) AS cash_balance FROM cash_ledger"
-
-    # Use separate cursors for logically independent queries to avoid
-    # relying on psycopg v3 cursor reuse semantics after fetchall().
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(positions_sql)
-        pos_rows = cur.fetchall()
-
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(cash_sql)
-        cash_row = cur.fetchone()
-        # SUM() always returns exactly one row; the value is None when the table is empty.
-        raw_cash = cash_row["cash_balance"] if cash_row else None  # type: ignore[index]
+    # -- Shared valuation (#1596) -------------------------------------------
+    # Positions mark-to-market, cash, mirror equity, and total_aum all come
+    # from compute_portfolio_valuation — the same helper the report
+    # builders use, so the report cover and this headline cannot drift.
+    val = compute_portfolio_valuation(conn)
+    display_currency = val.display_currency
+    rates = val.rates
+    rates_meta = val.rates_meta
+    pos_rows = list(val.raw_rows)
 
     # -- Broker positions (individual trades per instrument) ----------------
     broker_sql = """
@@ -489,24 +401,17 @@ def get_portfolio(
             )
         )
 
-    positions = [_parse_position(r, display_currency, rates) for r in pos_rows]
+    positions = [_position_item(h) for h in val.holdings]
 
     # Attach individual trades to their parent position.
     for pos in positions:
         pos.trades = trades_by_instrument.get(pos.instrument_id, [])
 
-    cash_balance = float(raw_cash) if raw_cash is not None else None  # type: ignore[arg-type]
+    cash_balance = val.cash_balance
 
-    # Convert cash_balance — always USD for eToro.
-    if cash_balance is not None:
-        cash_balance = _convert_value(cash_balance, "USD", display_currency, rates)
-
-    # AUM: sum of position market_values + cash (if known) + mirror_equity.
-    total_market = sum(p.market_value for p in positions)
-
-    # Per-mirror breakdowns — derive total mirror_equity from these so we
-    # load mirror data once instead of running two separate queries.
-    mirror_breakdowns = load_mirror_breakdowns(conn)
+    # Per-mirror breakdowns — loaded once inside the valuation helper;
+    # the per-mirror display rows still convert each figure here.
+    mirror_breakdowns = val.mirror_breakdowns
     raw_mirror_equity = sum(mb.mirror_equity_usd for mb in mirror_breakdowns)
 
     # Convert each mirror's monetary values from USD to display currency.
@@ -525,17 +430,15 @@ def get_portfolio(
             )
         )
 
-    # Convert total mirror_equity — always USD for eToro.
-    mirror_equity = _convert_value(raw_mirror_equity, "USD", display_currency, rates)
-
-    total_aum = total_market + (cash_balance if cash_balance is not None else 0.0) + mirror_equity
+    mirror_equity = val.mirror_equity
+    total_aum = val.total_aum
 
     # Re-sort by market_value DESC (computed value, not a DB column) with stable tiebreak.
     positions.sort(key=lambda p: (-p.market_value, p.instrument_id))
 
     # Build fx_rates_used from source currencies actually consumed.
     fx_rates_used = _build_fx_rates_used(
-        pos_rows, raw_cash is not None, raw_mirror_equity, display_currency, rates_meta
+        pos_rows, cash_balance is not None, raw_mirror_equity, display_currency, rates_meta
     )
 
     # Union of every instrument_id the page should subscribe to live

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -790,6 +790,11 @@ def _compute_contributors(
             return Decimal("0")
         now_row = realized_now.get(iid)
         if now_row is None:
+            # positions rows persist after close (current_units = 0) and
+            # are never deleted, so a prior-snapshot instrument always
+            # has a realized_now entry; this guard covers test doubles /
+            # hypothetical row deletion, where 0 (no realised movement)
+            # is the conservative answer (PR #1597 review nitpick).
             return Decimal("0")
         return Decimal(now_row["realized_pnl"]) - prior_realized
 
@@ -1290,7 +1295,8 @@ def _holdings_section(
                 "valuation_source": h.valuation_source,
             }
         )
-    rows.sort(key=lambda r: Decimal(r["market_value"] or "0"), reverse=True)
+    # `market_value` is `_dec_f` over a non-optional float — never None.
+    rows.sort(key=lambda r: Decimal(r["market_value"]), reverse=True)
     return rows
 
 

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -23,15 +23,32 @@ import psycopg.rows
 from psycopg.types.json import Jsonb
 
 from app.services.budget import FxRateUnavailable, compute_budget_state
+from app.services.fx import FxRateNotFound, convert
+from app.services.valuation import PortfolioValuation, compute_portfolio_valuation
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Type aliases
+# Type aliases / constants
 # ---------------------------------------------------------------------------
 
 WeeklyReport = dict[str, Any]
 MonthlyReport = dict[str, Any]
+
+# Snapshot schema version (#1596, spec docs/proposals/ui/2026-06-12-report-ia.md).
+# v1 snapshots have no `schema_version` key; the FE branches on it.
+SCHEMA_VERSION = 2
+
+# Benchmark resolved BY SYMBOL at generation time (spec §7 — no hardcoded
+# instrument_id; dev-data availability is not a repo invariant). Builder
+# constant in v1, not operator config.
+BENCHMARK_SYMBOL = "SPX500"
+BENCHMARK_LABEL = "S&P 500 (price index)"
+
+# Volatility / drawdown need a minimum observation count or they print
+# noise (spec §4.9): below this the risk section reports
+# insufficient_history instead of figures.
+_MIN_RISK_OBSERVATIONS = 6
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -41,6 +58,42 @@ MonthlyReport = dict[str, Any]
 def _dec(v: Decimal | None) -> str | None:
     """Decimal → str for JSON serialisation, preserving None."""
     return str(v) if v is not None else None
+
+
+_MONEY_Q = Decimal("0.000001")
+
+
+def _dec_f(v: float | None) -> str | None:
+    """float → Decimal-string (6 dp, matching NUMERIC(18,6)), None-safe.
+
+    Valuation figures arrive as floats (market-data pipeline); quantizing
+    keeps float repr noise (0.30000000000000004) out of the snapshot.
+    """
+    if v is None:
+        return None
+    return str(Decimal(str(v)).quantize(_MONEY_Q))
+
+
+def _parse_dec(v: Any) -> Decimal | None:
+    """Lenient str/number → Decimal for reading values back out of a
+    prior snapshot's JSON. None / unparseable → None."""
+    if v is None:
+        return None
+    try:
+        return Decimal(str(v))
+    except ArithmeticError:
+        return None
+
+
+def _dec_q(v: Decimal | None) -> str | None:
+    """Decimal → 6-dp string for v2 snapshot figures, None-safe.
+
+    Division/sqrt produce 28-significant-digit Decimals and
+    float-derived Decimals carry repr noise — one quantum at the
+    serialisation boundary keeps the stored JSON canonical."""
+    if v is None:
+        return None
+    return str(v.quantize(_MONEY_Q))
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +192,7 @@ def _positions_opened_closed(
                        tr.rationale,
                        f.price,
                        f.units,
+                       f.fees,
                        f.filled_at
                 FROM fills f
                 JOIN orders o USING (order_id)
@@ -161,6 +215,7 @@ def _positions_opened_closed(
                 "rationale": r["rationale"],
                 "price": _dec(r["price"]),
                 "units": _dec(r["units"]),
+                "fees": _dec(r["fees"]),
                 "filled_at": r["filled_at"].isoformat() if r["filled_at"] is not None else None,
             }
             for r in raw
@@ -319,6 +374,9 @@ def _win_rate_and_holding(
             "losers": 0,
             "win_rate_pct": None,
             "avg_holding_days": None,
+            "avg_win_pct": None,
+            "avg_loss_pct": None,
+            "payoff_ratio": None,
         }
 
     winners = sum(1 for r in rows if r["gross_return_pct"] is not None and r["gross_return_pct"] > 0)
@@ -326,12 +384,24 @@ def _win_rate_and_holding(
     win_rate = f"{100 * winners / total:.2f}"
     hold_days_vals = [float(r["hold_days"]) for r in rows if r["hold_days"] is not None]
     avg_holding = sum(hold_days_vals) / len(hold_days_vals) if hold_days_vals else None
+    # Payoff ratio (avg win % / |avg loss %|) — win rate alone is the
+    # classic misleading stat (90% win rate + one −50% loser = losing
+    # book). Spec §4.9.
+    returns: list[Decimal] = [r["gross_return_pct"] for r in rows if r["gross_return_pct"] is not None]
+    win_returns = [r for r in returns if r > 0]
+    loss_returns = [r for r in returns if r < 0]
+    avg_win: Decimal | None = sum(win_returns, Decimal(0)) / len(win_returns) if win_returns else None
+    avg_loss: Decimal | None = sum(loss_returns, Decimal(0)) / len(loss_returns) if loss_returns else None
+    payoff = (avg_win / abs(avg_loss)) if avg_win is not None and avg_loss is not None and avg_loss != 0 else None
     return {
         "total_closed": total,
         "winners": winners,
         "losers": losers,
         "win_rate_pct": win_rate,
         "avg_holding_days": avg_holding,
+        "avg_win_pct": _dec(avg_win),
+        "avg_loss_pct": _dec(avg_loss),
+        "payoff_ratio": _dec(payoff),
     }
 
 
@@ -388,7 +458,10 @@ def _period_attribution(
             SELECT COUNT(*) AS positions_attributed,
                    AVG(gross_return_pct)   AS avg_gross,
                    AVG(market_return_pct)  AS avg_market,
-                   AVG(model_alpha_pct)    AS avg_alpha
+                   AVG(sector_return_pct)  AS avg_sector,
+                   AVG(model_alpha_pct)    AS avg_alpha,
+                   AVG(timing_alpha_pct)   AS avg_timing,
+                   AVG(cost_drag_pct)      AS avg_cost_drag
             FROM return_attribution
             WHERE hold_end >= %(start)s
               AND hold_end <= %(end)s
@@ -402,13 +475,27 @@ def _period_attribution(
             "positions_attributed": 0,
             "avg_gross_return_pct": None,
             "avg_market_return_pct": None,
+            "avg_sector_return_pct": None,
             "avg_model_alpha_pct": None,
+            "avg_timing_alpha_pct": None,
+            "avg_cost_drag_pct": None,
+            "weighting": "equal",
         }
     return {
         "positions_attributed": row["positions_attributed"],
         "avg_gross_return_pct": _dec(row["avg_gross"]),
         "avg_market_return_pct": _dec(row["avg_market"]),
+        # Full decomposition (spec §4.10): gross = market + sector +
+        # model alpha + timing alpha − cost drag. timing/cost-drag were
+        # stored in return_attribution all along but silently dropped
+        # here — cost drag is the figure that teaches why churn loses.
+        "avg_sector_return_pct": _dec(row["avg_sector"]),
         "avg_model_alpha_pct": _dec(row["avg_alpha"]),
+        "avg_timing_alpha_pct": _dec(row["avg_timing"]),
+        "avg_cost_drag_pct": _dec(row["avg_cost_drag"]),
+        # Equal-weighted across closed trades — a $50 close weighs the
+        # same as a $5,000 one. Labelled so the FE can say it.
+        "weighting": "equal",
     }
 
 
@@ -562,7 +649,9 @@ def _positions_snapshot(conn: psycopg.Connection[Any]) -> list[dict[str, Any]]:
                    i.symbol,
                    i.company_name,
                    p.unrealized_pnl,
-                   p.cost_basis
+                   p.cost_basis,
+                   p.realized_pnl,
+                   p.current_units
             FROM positions p
             JOIN instruments i USING (instrument_id)
             WHERE p.current_units > 0
@@ -577,9 +666,34 @@ def _positions_snapshot(conn: psycopg.Connection[Any]) -> list[dict[str, Any]]:
             "company_name": r["company_name"],
             "unrealized_pnl": _dec(r["unrealized_pnl"]),
             "cost_basis": _dec(r["cost_basis"]),
+            # realized_pnl + current_units added by #1596 so the NEXT
+            # snapshot can fold realised deltas into period
+            # contribution (spec §4.4). Additive — v1 readers ignore.
+            "realized_pnl": _dec(r["realized_pnl"]),
+            "current_units": _dec(r["current_units"]),
         }
         for r in rows
     ]
+
+
+def _realized_by_instrument(conn: psycopg.Connection[Any]) -> dict[int, dict[str, Any]]:
+    """Lifetime realised P&L per instrument across ALL positions rows,
+    including fully-closed ones (current_units = 0). Used to fold
+    realised deltas into period contribution — a position closed
+    mid-period vanishes from the open-positions snapshot but its
+    realised P&L still moved this period (#1596, spec §4.4)."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT p.instrument_id, i.symbol, p.realized_pnl
+            FROM positions p
+            JOIN instruments i USING (instrument_id)
+            """
+        )
+        rows = cur.fetchall()
+    return {
+        r["instrument_id"]: {"symbol": r["symbol"], "realized_pnl": r["realized_pnl"] or Decimal("0")} for r in rows
+    }
 
 
 def _load_prior_snapshot(
@@ -628,21 +742,30 @@ def _compute_contributors(
     prior: list[dict[str, Any]] | None,
     *,
     top_n: int = 5,
+    realized_now: dict[int, dict[str, Any]] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
-    """Diff per-instrument unrealised P&L between two position snapshots.
+    """Diff per-instrument period P&L between two position snapshots.
 
     Returns `{contributors: [...top_n gainers...], drags: [...top_n losers...]}`
     where each row is `{instrument_id, symbol, pnl_delta, pnl_pct}`.
 
-    - `pnl_delta` = current unrealized_pnl - prior unrealized_pnl (Decimal → str).
+    - `pnl_delta` = (current unrealized_pnl − prior unrealized_pnl)
+      PLUS, when `realized_now` is supplied and the prior row carries a
+      `realized_pnl` key (v2 snapshots, #1596 spec §4.4), the realised
+      delta (current lifetime realised − prior lifetime realised). The
+      pre-#1596 unrealised-only diff made a position closed mid-period
+      vanish and a trim read as a phantom loss.
+    - Closed positions (in `prior`, absent from `current`): with
+      `realized_now`, the close itself contributes
+      `(realised delta − prior unrealised)` — the open P&L converts to
+      realised and the net move lands in the chart. Without
+      `realized_now` (legacy callers/tests), closed positions are
+      skipped as before.
     - `pnl_pct`   = pnl_delta / prior_cost_basis (None if no prior row or
       prior cost_basis is zero — avoids div/0 and the misleading "∞%"
       for a brand-new position).
     - New positions (in `current`, absent from `prior`) surface with
       their full unrealized_pnl as the delta and `pnl_pct = null`.
-    - Closed positions (in `prior`, absent from `current`) are NOT
-      reported here — their contribution lives in the realised-P&L
-      aggregate, which the existing `pnl` section already covers.
     - When `prior is None` (first snapshot, or backfilled historical
       snapshots with no `positions` key), both lists are empty so the
       UI gracefully degrades.
@@ -651,16 +774,31 @@ def _compute_contributors(
         return {"contributors": [], "drags": []}
 
     prior_by_id = {p["instrument_id"]: p for p in prior}
+
+    def _realized_delta(iid: int, prior_row: dict[str, Any] | None) -> Decimal:
+        """Realised P&L movement this period; 0 unless both sides know it."""
+        if realized_now is None or prior_row is None:
+            return Decimal("0")
+        prior_realized = _parse_dec(prior_row.get("realized_pnl"))
+        if prior_realized is None:  # v1 prior snapshot — no realised baseline
+            return Decimal("0")
+        now_row = realized_now.get(iid)
+        if now_row is None:
+            return Decimal("0")
+        return Decimal(now_row["realized_pnl"]) - prior_realized
+
     # Keep the raw Decimal delta alongside the serialised string so
     # sort + filter never round-trip through `Decimal(str)` re-parsing
     # (Codex slice-4 round-2 note).
     entries: list[tuple[Decimal, dict[str, Any]]] = []
+    seen_current: set[int] = set()
     for curr in current:
         iid = curr["instrument_id"]
+        seen_current.add(iid)
         prior_row = prior_by_id.get(iid)
         curr_pnl = Decimal(curr["unrealized_pnl"] or "0")
         prior_pnl = Decimal(prior_row["unrealized_pnl"] or "0") if prior_row is not None else Decimal("0")
-        delta = curr_pnl - prior_pnl
+        delta = curr_pnl - prior_pnl + _realized_delta(iid, prior_row)
         if delta == 0:
             continue
         prior_cost = Decimal(prior_row["cost_basis"] or "0") if prior_row is not None else Decimal("0")
@@ -676,6 +814,33 @@ def _compute_contributors(
                 },
             )
         )
+
+    # Positions closed during the period: prior row exists, no current
+    # row. Net contribution = realised movement − the unrealised P&L
+    # that was on the books at period start (it converted to realised).
+    if realized_now is not None:
+        for iid, prior_row in prior_by_id.items():
+            if iid in seen_current:
+                continue
+            if _parse_dec(prior_row.get("realized_pnl")) is None:
+                continue  # v1 prior snapshot — no realised baseline
+            prior_pnl = Decimal(prior_row["unrealized_pnl"] or "0")
+            delta = _realized_delta(iid, prior_row) - prior_pnl
+            if delta == 0:
+                continue
+            prior_cost = Decimal(prior_row["cost_basis"] or "0")
+            closed_pct: Decimal | None = delta / prior_cost if prior_cost > 0 else None
+            entries.append(
+                (
+                    delta,
+                    {
+                        "instrument_id": iid,
+                        "symbol": prior_row["symbol"],
+                        "pnl_delta": _dec(delta),
+                        "pnl_pct": _dec(closed_pct),
+                    },
+                )
+            )
 
     # Contributors: positive deltas, descending (biggest gainer first).
     # Drags: negative deltas, ascending (most-negative first). Both
@@ -744,6 +909,612 @@ def load_report_snapshots(
 
 
 # ---------------------------------------------------------------------------
+# v2 sections (#1596 — spec docs/proposals/ui/2026-06-12-report-ia.md)
+# ---------------------------------------------------------------------------
+
+
+def _benchmark_closes(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> dict[str, Any]:
+    """Benchmark closes around the period, resolved BY SYMBOL.
+
+    Baseline = latest close STRICTLY BEFORE period_start (the value the
+    period grew from); end = latest close at-or-before period_end.
+    Returns nulls when the benchmark instrument or its closes are
+    missing (spec §7: dev-data availability is not a repo invariant) —
+    the FE renders portfolio-only with a notice.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id FROM instruments
+            WHERE UPPER(symbol) = %(sym)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"sym": BENCHMARK_SYMBOL},
+        )
+        inst = cur.fetchone()
+    if inst is None:
+        return {
+            "symbol": BENCHMARK_SYMBOL,
+            "label": BENCHMARK_LABEL,
+            "close_start": None,
+            "close_end": None,
+            "return_pct": None,
+        }
+
+    def _close(on_or_before: date, *, strict_before: bool) -> Decimal | None:
+        op = "<" if strict_before else "<="
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                f"""
+                SELECT close FROM price_daily
+                WHERE instrument_id = %(iid)s
+                  AND close IS NOT NULL
+                  AND price_date {op} %(day)s
+                ORDER BY price_date DESC
+                LIMIT 1
+                """,  # noqa: S608 — `op` is a literal chosen above, not user input
+                {"iid": inst["instrument_id"], "day": on_or_before},
+            )
+            row = cur.fetchone()
+        return row["close"] if row else None
+
+    close_start = _close(period_start, strict_before=True)
+    close_end = _close(period_end, strict_before=False)
+    return_pct: Decimal | None = None
+    if close_start is not None and close_end is not None and close_start > 0:
+        return_pct = close_end / close_start - 1
+    return {
+        "symbol": BENCHMARK_SYMBOL,
+        "label": BENCHMARK_LABEL,
+        "close_start": _dec(close_start),
+        "close_end": _dec(close_end),
+        "return_pct": _dec_q(return_pct),
+    }
+
+
+def _external_flows(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+    display_currency: str,
+    rates: dict[tuple[str, str], Decimal],
+) -> list[tuple[date, Decimal]]:
+    """External capital flows in the period, signed, display currency.
+
+    `capital_events.amount` is always positive; `event_type` carries
+    direction (sql/027 CHECK). Only `injection` (+) / `withdrawal` (−)
+    are EXTERNAL flows — `tax_provision` / `tax_release` are internal
+    earmarks; the cash never leaves the account (spec §3.4).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT event_time::date AS flow_date, event_type, amount, currency
+            FROM capital_events
+            WHERE event_type IN ('injection', 'withdrawal')
+              AND event_time >= %(start)s
+              AND event_time < %(end)s::date + 1
+            ORDER BY event_time
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        rows = cur.fetchall()
+
+    flows: list[tuple[date, Decimal]] = []
+    for r in rows:
+        amount: Decimal = r["amount"]
+        ccy = str(r["currency"] or "USD")
+        if ccy != display_currency:
+            try:
+                amount = convert(amount, ccy, display_currency, rates)
+            except FxRateNotFound:
+                logger.warning(
+                    "capital_events flow %s→%s rate missing; flow used in native currency",
+                    ccy,
+                    display_currency,
+                )
+        signed = amount if r["event_type"] == "injection" else -amount
+        flows.append((r["flow_date"], signed))
+    return flows
+
+
+def _modified_dietz(
+    v_start: Decimal | None,
+    v_end: Decimal,
+    flows: list[tuple[date, Decimal]],
+    period_start: date,
+    period_end: date,
+) -> Decimal | None:
+    """Flow-adjusted period return (spec §3.4).
+
+    `(V_end − V_start − ΣF) / (V_start + Σ(F × w))` with F signed
+    (injection +, withdrawal −) and w = fraction of the period
+    remaining after the flow lands. Degenerates to the simple ratio in
+    flow-free periods. None when there is no opening value or the
+    denominator is non-positive (e.g. account funded entirely
+    mid-period — a return number would be meaningless).
+    """
+    if v_start is None:
+        return None
+    period_len = (period_end - period_start).days + 1
+    if period_len <= 0:
+        return None
+    flow_sum = sum((f for _, f in flows), Decimal(0))
+    weighted = Decimal(0)
+    for flow_date, f in flows:
+        remaining = (period_end - flow_date).days + 1
+        w = Decimal(max(0, min(remaining, period_len))) / Decimal(period_len)
+        weighted += f * w
+    denominator = v_start + weighted
+    if denominator <= 0:
+        return None
+    return (v_end - v_start - flow_sum) / denominator
+
+
+def _chain_link(returns: list[Decimal]) -> Decimal | None:
+    """Geometric chain of period returns: Π(1+r) − 1. None on empty."""
+    if not returns:
+        return None
+    acc = Decimal(1)
+    for r in returns:
+        acc *= Decimal(1) + r
+    return acc - 1
+
+
+def _prior_v2_chain(
+    conn: psycopg.Connection[Any],
+    *,
+    report_type: str,
+    period_start: date,
+) -> list[dict[str, Any]]:
+    """Ordered (oldest→newest) prior v2 snapshots' chained figures.
+
+    One row per prior snapshot with `schema_version >= 2`:
+    `{period_start, period_return (Decimal|None), display_currency}`.
+    Feeds YTD / since-inception chaining and the risk section's
+    return series. v1 snapshots carry no return — excluded.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT period_start,
+                   snapshot_json -> 'cover' ->> 'period_return' AS period_return,
+                   snapshot_json -> 'cover' ->> 'display_currency' AS display_currency
+            FROM report_snapshots
+            WHERE report_type = %(report_type)s
+              AND period_start < %(period_start)s
+              AND (snapshot_json ->> 'schema_version')::int >= 2
+            ORDER BY period_start ASC
+            """,
+            {"report_type": report_type, "period_start": period_start},
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "period_start": r["period_start"],
+            "period_return": _parse_dec(r["period_return"]),
+            "display_currency": r["display_currency"],
+        }
+        for r in rows
+    ]
+
+
+def _cover_and_performance(
+    conn: psycopg.Connection[Any],
+    *,
+    valuation: PortfolioValuation,
+    prior: dict[str, Any] | None,
+    chain: list[dict[str, Any]],
+    period_start: date,
+    period_end: date,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Account-summary cover + the single-period performance point.
+
+    Closing value comes from the SHARED valuation helper — the same
+    code path as the dashboard headline (spec §3.3), so the two cannot
+    drift. Opening value = prior v2 snapshot's closing value; None on
+    the first v2 snapshot (or after a display-currency change, where
+    mixing bases would be dishonest) → period_return null, FE labels
+    "(since inception)".
+    """
+    closing = Decimal(str(valuation.total_aum))
+    opening: Decimal | None = None
+    prior_cover = prior.get("cover") if isinstance(prior, dict) else None
+    if isinstance(prior_cover, dict):
+        if prior_cover.get("display_currency") == valuation.display_currency:
+            opening = _parse_dec(prior_cover.get("closing_value"))
+        else:
+            logger.warning(
+                "prior snapshot display currency %s != current %s; period return suppressed",
+                prior_cover.get("display_currency"),
+                valuation.display_currency,
+            )
+
+    flows = _external_flows(conn, period_start, period_end, valuation.display_currency, valuation.rates)
+    net_flows = sum((f for _, f in flows), Decimal(0))
+    period_return = _modified_dietz(opening, closing, flows, period_start, period_end)
+    benchmark = _benchmark_closes(conn, period_start, period_end)
+    benchmark_return = _parse_dec(benchmark["return_pct"])
+    excess = period_return - benchmark_return if period_return is not None and benchmark_return is not None else None
+
+    # Lifetime P&L aggregates → period deltas vs the prior snapshot's
+    # stored aggregates (`pnl` key — present on v1 priors too).
+    pnl_now = _pnl_snapshot(conn)
+    realized_now = _parse_dec(pnl_now["realized_pnl"]) or Decimal(0)
+    unrealized_now = _parse_dec(pnl_now["unrealized_pnl"]) or Decimal(0)
+    realized_delta: Decimal | None = None
+    unrealized_delta: Decimal | None = None
+    prior_pnl = prior.get("pnl") if isinstance(prior, dict) else None
+    if isinstance(prior_pnl, dict):
+        prior_realized = _parse_dec(prior_pnl.get("realized_pnl"))
+        prior_unrealized = _parse_dec(prior_pnl.get("unrealized_pnl"))
+        if prior_realized is not None:
+            realized_delta = realized_now - prior_realized
+        if prior_unrealized is not None:
+            unrealized_delta = unrealized_now - prior_unrealized
+
+    # Value bridge (spec §4.1): opening + external flows + realised +
+    # change in unrealised + residual = closing. The residual absorbs
+    # everything the ledger can't itemise yet — broker_sync deltas
+    # (dividends, fees, sync corrections) and valuation-basis drift.
+    # Honest line, labelled "Broker adjustments (unitemised)".
+    residual: Decimal | None = None
+    if opening is not None and realized_delta is not None and unrealized_delta is not None:
+        residual = closing - opening - net_flows - realized_delta - unrealized_delta
+
+    # YTD / since-inception: chain-link prior v2 period returns with
+    # this period's. Only chains in the SAME display currency count.
+    chain_returns = [
+        c["period_return"]
+        for c in chain
+        if c["period_return"] is not None and c["display_currency"] == valuation.display_currency
+    ]
+    current_returns = [period_return] if period_return is not None else []
+    si_return = _chain_link(chain_returns + current_returns)
+    ytd_chain = [
+        c["period_return"]
+        for c in chain
+        if c["period_return"] is not None
+        and c["display_currency"] == valuation.display_currency
+        and c["period_start"].year == period_end.year
+    ]
+    ytd_return = _chain_link(ytd_chain + current_returns)
+
+    # Benchmark over the same spans, from closes (cheap, [NOW]).
+    si_start = chain[0]["period_start"] if chain else period_start
+    benchmark_si = _benchmark_closes(conn, si_start, period_end)
+    ytd_start = date(period_end.year, 1, 1)
+    benchmark_ytd = _benchmark_closes(conn, ytd_start, period_end)
+
+    cover = {
+        "display_currency": valuation.display_currency,
+        "closing_value": _dec_q(closing),
+        "opening_value": _dec_q(opening),
+        "cash": _dec_f(valuation.cash_balance),
+        "mirror_equity": _dec_f(valuation.mirror_equity),
+        "period_return": _dec_q(period_return),
+        "benchmark_return": benchmark["return_pct"],
+        "excess_return": _dec_q(excess),
+        "ytd_return": _dec_q(ytd_return),
+        "si_return": _dec_q(si_return),
+        "benchmark_ytd_return": benchmark_ytd["return_pct"],
+        "benchmark_si_return": benchmark_si["return_pct"],
+        "realized_delta": _dec_q(realized_delta),
+        "unrealized_delta": _dec_q(unrealized_delta),
+        "bridge": {
+            "opening_value": _dec_q(opening),
+            "net_external_flows": _dec_q(net_flows),
+            "realized_delta": _dec_q(realized_delta),
+            "unrealized_delta": _dec_q(unrealized_delta),
+            "broker_adjustments_residual": _dec_q(residual),
+            "closing_value": _dec_q(closing),
+        },
+        "return_method": "modified_dietz_v1",
+    }
+    performance = {
+        "portfolio_value": _dec_q(closing),
+        "period_return": _dec_q(period_return),
+        "benchmark": benchmark,
+        "fx_mode": "generation_date",
+        "method": "modified_dietz_v1",
+        "observations": len(chain_returns) + len(current_returns),
+    }
+    return cover, performance
+
+
+def _holdings_section(
+    valuation: PortfolioValuation,
+    prior_positions: list[dict[str, Any]] | None,
+    realized_now: dict[int, dict[str, Any]],
+    opening_value: Decimal | None,
+) -> list[dict[str, Any]]:
+    """Holdings-at-generation table rows (spec §4.5).
+
+    Weight is vs total_aum (the whole account, cash + mirrors
+    included). Period contribution folds realised + unrealised deltas
+    vs the prior snapshot's per-instrument rows; bps vs opening value.
+    """
+    prior_by_id = {p["instrument_id"]: p for p in prior_positions or []}
+    total_aum = Decimal(str(valuation.total_aum))
+    rows: list[dict[str, Any]] = []
+    for h in valuation.holdings:
+        mv = Decimal(str(h.market_value))
+        cost = Decimal(str(h.cost_basis))
+        weight = mv / total_aum if total_aum > 0 else None
+        since_entry = (mv - cost) / cost if cost > 0 else None
+
+        contribution: Decimal | None = None
+        contribution_bps: Decimal | None = None
+        prior_row = prior_by_id.get(h.instrument_id)
+        if prior_row is not None:
+            prior_unreal = _parse_dec(prior_row.get("unrealized_pnl")) or Decimal(0)
+            delta = Decimal(str(h.unrealized_pnl)) - prior_unreal
+            prior_real = _parse_dec(prior_row.get("realized_pnl"))
+            now_real = realized_now.get(h.instrument_id)
+            if prior_real is not None and now_real is not None:
+                delta += Decimal(now_real["realized_pnl"]) - prior_real
+            contribution = delta
+            if opening_value is not None and opening_value > 0:
+                contribution_bps = delta / opening_value * 10000
+
+        rows.append(
+            {
+                "instrument_id": h.instrument_id,
+                "symbol": h.symbol,
+                "company_name": h.company_name,
+                "sector": h.sector,
+                "units": _dec_f(h.current_units),
+                "price": _dec_f(h.current_price),
+                "market_value": _dec_f(h.market_value),
+                "cost_basis": _dec_f(h.cost_basis),
+                "weight_pct": _dec_q(weight),
+                "since_entry_return_pct": _dec_q(since_entry),
+                "unrealized_pnl": _dec_f(h.unrealized_pnl),
+                "period_contribution": _dec_q(contribution),
+                "period_contribution_bps": _dec_q(contribution_bps),
+                "valuation_source": h.valuation_source,
+            }
+        )
+    rows.sort(key=lambda r: Decimal(r["market_value"] or "0"), reverse=True)
+    return rows
+
+
+def _income_section(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> dict[str, Any]:
+    """Estimated dividend income: declarations with ex-date in the
+    period × CURRENT units (period-end proxy — spec §4.7 names the
+    approximation; exact units-at-ex-date needs the #1593 ledger).
+    Estimates only — not confirmed received."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT de.instrument_id,
+                   i.symbol,
+                   de.ex_date,
+                   de.pay_date,
+                   de.dps_declared,
+                   de.currency,
+                   p.current_units
+            FROM dividend_events de
+            JOIN instruments i USING (instrument_id)
+            JOIN positions p USING (instrument_id)
+            WHERE p.current_units > 0
+              AND de.ex_date >= %(start)s
+              AND de.ex_date <= %(end)s
+              AND de.dps_declared IS NOT NULL
+            ORDER BY de.ex_date, i.symbol
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        rows = cur.fetchall()
+
+    items: list[dict[str, Any]] = []
+    totals_by_ccy: dict[str, Decimal] = {}
+    for r in rows:
+        amount = r["dps_declared"] * r["current_units"]
+        ccy = str(r["currency"] or "USD")
+        totals_by_ccy[ccy] = totals_by_ccy.get(ccy, Decimal(0)) + amount
+        items.append(
+            {
+                "instrument_id": r["instrument_id"],
+                "symbol": r["symbol"],
+                "ex_date": r["ex_date"].isoformat() if r["ex_date"] is not None else None,
+                "pay_date": r["pay_date"].isoformat() if r["pay_date"] is not None else None,
+                "dps_declared": _dec(r["dps_declared"]),
+                "currency": ccy,
+                "units": _dec(r["current_units"]),
+                "estimated_amount": _dec(amount),
+            }
+        )
+    return {
+        "items": items,
+        "estimated_totals": {ccy: _dec(total) for ccy, total in sorted(totals_by_ccy.items())},
+        "basis": "declared_dps_x_current_units",
+    }
+
+
+def _costs_section(
+    conn: psycopg.Connection[Any],
+    period_start: date,
+    period_end: date,
+) -> dict[str, Any]:
+    """Own-platform fees in the period. Broker-side fees are invisible
+    until #1593 (they arrive folded into broker_sync cash deltas)."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) AS fill_count,
+                   COALESCE(SUM(f.fees), 0) AS fees_total
+            FROM fills f
+            WHERE f.filled_at >= %(start)s
+              AND f.filled_at < %(end)s::date + 1
+            """,
+            {"start": period_start, "end": period_end},
+        )
+        row = cur.fetchone()
+    fill_count = row["fill_count"] if row else 0
+    fees_total: Decimal = row["fees_total"] if row else Decimal(0)
+    return {
+        "fees_total": _dec(fees_total),
+        "fill_count": fill_count,
+        "scope": "own_platform_orders_only",
+    }
+
+
+def _risk_section(
+    valuation: PortfolioValuation,
+    chain: list[dict[str, Any]],
+    current_period_return: Decimal | None,
+    *,
+    observation_label: str,
+) -> dict[str, Any]:
+    """Concentration + sector exposure (point-in-time, always
+    computable) and volatility / max drawdown over the FULL snapshot
+    return history — never the single period (spec §4.9: n≤13 windows
+    whipsaw). Below `_MIN_RISK_OBSERVATIONS` the series stats render
+    as insufficient history. Explicitly NO Sharpe/Sortino/IR — not
+    honestly computable before #1593 daily series."""
+    total_aum = Decimal(str(valuation.total_aum))
+    mvs = sorted((Decimal(str(h.market_value)) for h in valuation.holdings), reverse=True)
+    top5 = sum(mvs[:5], Decimal(0))
+    concentration_top5 = top5 / total_aum if total_aum > 0 else None
+
+    sector_weights: dict[str, Decimal] = {}
+    for h in valuation.holdings:
+        sector = h.sector or "Unknown"
+        sector_weights[sector] = sector_weights.get(sector, Decimal(0)) + Decimal(str(h.market_value))
+    sector_exposure = (
+        {s: _dec_q(w / total_aum) for s, w in sorted(sector_weights.items(), key=lambda kv: kv[1], reverse=True)}
+        if total_aum > 0
+        else {}
+    )
+
+    returns = [
+        c["period_return"]
+        for c in chain
+        if c["period_return"] is not None and c["display_currency"] == valuation.display_currency
+    ]
+    if current_period_return is not None:
+        returns = [*returns, current_period_return]
+
+    n = len(returns)
+    volatility: Decimal | None = None
+    max_drawdown: Decimal | None = None
+    if n >= _MIN_RISK_OBSERVATIONS:
+        mean = sum(returns, Decimal(0)) / n
+        variance = sum(((r - mean) ** 2 for r in returns), Decimal(0)) / (n - 1)
+        volatility = variance.sqrt()
+        # Max drawdown on the chained return index.
+        index = Decimal(1)
+        peak = Decimal(1)
+        worst = Decimal(0)
+        for r in returns:
+            index *= Decimal(1) + r
+            peak = max(peak, index)
+            drawdown = index / peak - 1
+            worst = min(worst, drawdown)
+        max_drawdown = worst
+
+    return {
+        "holding_count": len(valuation.holdings),
+        "concentration_top5_pct": _dec_q(concentration_top5),
+        "sector_exposure": sector_exposure,
+        "volatility": _dec_q(volatility),
+        "max_drawdown": _dec_q(max_drawdown),
+        "observations": n,
+        "observation_label": observation_label,
+        "insufficient_history": n < _MIN_RISK_OBSERVATIONS,
+    }
+
+
+_ROLLING_WINDOWS: dict[str, int | None] = {"1m": 1, "3m": 3, "6m": 6, "1y": 12, "si": None}
+
+
+def _rolling_returns(
+    conn: psycopg.Connection[Any],
+    chain: list[dict[str, Any]],
+    current_period_return: Decimal | None,
+    display_currency: str,
+    period_start: date,
+    period_end: date,
+) -> dict[str, Any]:
+    """Rolling-returns table (monthly statement, spec §4.3): portfolio
+    chained over the last N monthly periods vs benchmark over the same
+    span. Portfolio cells null until snapshot depth exists."""
+    chained = [c for c in chain if c["period_return"] is not None and c["display_currency"] == display_currency]
+    out: dict[str, Any] = {}
+    for label, months in _ROLLING_WINDOWS.items():
+        if months is None:
+            window = chained
+        else:
+            window = chained[-(months - 1) :] if months > 1 else []
+        window_returns = [c["period_return"] for c in window]
+        if current_period_return is not None:
+            window_returns = [*window_returns, current_period_return]
+        # A window is only honest when it is FULL (or si): chaining 2
+        # months and calling it "6m" overstates history.
+        portfolio: Decimal | None
+        if months is None:
+            portfolio = _chain_link(window_returns)
+            span_start = window[0]["period_start"] if window else period_start
+        elif len(window_returns) == months:
+            portfolio = _chain_link(window_returns)
+            span_start = window[0]["period_start"] if window else period_start
+        else:
+            portfolio = None
+            span_start = None
+        benchmark: Decimal | None = None
+        if span_start is not None:
+            benchmark = _parse_dec(_benchmark_closes(conn, span_start, period_end)["return_pct"])
+        excess = portfolio - benchmark if portfolio is not None and benchmark is not None else None
+        out[label] = {
+            "portfolio": _dec_q(portfolio),
+            "benchmark": _dec_q(benchmark),
+            "excess": _dec_q(excess),
+        }
+    return out
+
+
+def _thesis_summary(thesis_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate hit/miss/not-evaluable buckets over the per-trade
+    thesis_accuracy rows (spec §4.10 — hit rates without a
+    not-yet-evaluable bucket are unfalsifiable). Hit = exit at or
+    above the base target."""
+    evaluated = [r for r in thesis_rows if r.get("target_hit") is not None]
+    not_evaluable = len(thesis_rows) - len(evaluated)
+    hits = [r for r in evaluated if r["target_hit"] in ("bull", "base")]
+    misses = [r for r in evaluated if r["target_hit"] not in ("bull", "base")]
+
+    def _rate(stance: str) -> dict[str, Any]:
+        stance_rows = [r for r in evaluated if r.get("stance") == stance]
+        stance_hits = sum(1 for r in stance_rows if r["target_hit"] in ("bull", "base"))
+        n = len(stance_rows)
+        return {
+            "n": n,
+            "hits": stance_hits,
+            "hit_rate_pct": f"{100 * stance_hits / n:.2f}" if n > 0 else None,
+        }
+
+    return {
+        "total": len(thesis_rows),
+        "evaluated": len(evaluated),
+        "hits": len(hits),
+        "misses": len(misses),
+        "not_evaluable": not_evaluable,
+        "buy": _rate("buy"),
+        "avoid": _rate("avoid"),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Main entry points
 # ---------------------------------------------------------------------------
 
@@ -779,13 +1550,37 @@ def generate_weekly_report(
     # here would treat every current holding as a brand-new
     # contributor. Codex slice-4 finding.
     prior_positions = prior.get("positions") if isinstance(prior, dict) and "positions" in prior else None
-    period_contribution = _compute_contributors(positions_now, prior_positions)
+    realized_now = _realized_by_instrument(conn)
+    period_contribution = _compute_contributors(positions_now, prior_positions, realized_now=realized_now)
+
+    # v2 sections (#1596) — shared valuation = same code path as the
+    # dashboard headline (spec §3.3).
+    valuation = compute_portfolio_valuation(conn)
+    chain = _prior_v2_chain(conn, report_type="weekly", period_start=period_start)
+    cover, performance = _cover_and_performance(
+        conn,
+        valuation=valuation,
+        prior=prior,
+        chain=chain,
+        period_start=period_start,
+        period_end=period_end,
+    )
+    holdings = _holdings_section(
+        valuation,
+        prior_positions,
+        realized_now,
+        _parse_dec(cover["opening_value"]),
+    )
 
     return {
+        "schema_version": SCHEMA_VERSION,
         "report_type": "weekly",
         "period_start": period_start.isoformat(),
         "period_end": period_end.isoformat(),
         "generated_at": datetime.now(tz=UTC).isoformat(),
+        "cover": cover,
+        "performance": performance,
+        "holdings": holdings,
         "pnl": pnl,
         "top_performers": top_performers,
         "bottom_performers": bottom_performers,
@@ -827,6 +1622,10 @@ def generate_monthly_report(
     thesis_accuracy = _thesis_accuracy(conn, period_start, period_end)
     tax_provision = _tax_provision_snapshot(conn)
     positions_now = _positions_snapshot(conn)
+    # Rank movers were weekly-only pre-#1596 (committee finding: the
+    # monthly model-review section cited a key the monthly builder
+    # never wrote).
+    score_changes = _score_changes(conn, period_start, period_end)
     prior = _load_prior_snapshot(conn, report_type="monthly", period_start=period_start)
     # When `prior` is absent OR lacks the `positions` key (pre-feature
     # snapshots from before Slice 4), pass `None` so
@@ -834,17 +1633,68 @@ def generate_monthly_report(
     # here would treat every current holding as a brand-new
     # contributor. Codex slice-4 finding.
     prior_positions = prior.get("positions") if isinstance(prior, dict) and "positions" in prior else None
-    period_contribution = _compute_contributors(positions_now, prior_positions)
+    realized_now = _realized_by_instrument(conn)
+    period_contribution = _compute_contributors(positions_now, prior_positions, realized_now=realized_now)
+
+    # v2 sections (#1596) — shared valuation = same code path as the
+    # dashboard headline (spec §3.3).
+    valuation = compute_portfolio_valuation(conn)
+    chain = _prior_v2_chain(conn, report_type="monthly", period_start=period_start)
+    cover, performance = _cover_and_performance(
+        conn,
+        valuation=valuation,
+        prior=prior,
+        chain=chain,
+        period_start=period_start,
+        period_end=period_end,
+    )
+    holdings = _holdings_section(
+        valuation,
+        prior_positions,
+        realized_now,
+        _parse_dec(cover["opening_value"]),
+    )
+    current_period_return = _parse_dec(cover["period_return"])
+    risk = _risk_section(
+        valuation,
+        chain,
+        current_period_return,
+        observation_label="since inception, monthly observations",
+    )
+    rolling_returns = _rolling_returns(
+        conn,
+        chain,
+        current_period_return,
+        valuation.display_currency,
+        period_start,
+        period_end,
+    )
+    income = _income_section(conn, period_start, period_end)
+    costs = _costs_section(conn, period_start, period_end)
+    thesis_summary = _thesis_summary(thesis_accuracy)
 
     return {
+        "schema_version": SCHEMA_VERSION,
         "report_type": "monthly",
         "period_start": period_start.isoformat(),
         "period_end": period_end.isoformat(),
         "generated_at": datetime.now(tz=UTC).isoformat(),
+        "cover": cover,
+        "performance": performance,
+        "holdings": holdings,
+        "rolling_returns": rolling_returns,
+        "income": income,
+        "costs": costs,
+        "risk": risk,
+        "thesis_summary": thesis_summary,
+        "score_changes": score_changes,
         "pnl": pnl,
         "position_pnl": position_pnl,
         "win_rate": win_rate_data["win_rate_pct"],
         "avg_holding_days": win_rate_data["avg_holding_days"],
+        # Full closed-trade review incl. payoff ratio (spec §4.9) —
+        # `win_rate`/`avg_holding_days` stay as legacy top-level keys.
+        "trade_stats": win_rate_data,
         "best_trade": best_trade,
         "worst_trade": worst_trade,
         "attribution_summary": attribution_summary,

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -769,6 +769,12 @@ def _compute_contributors(
     - When `prior is None` (first snapshot, or backfilled historical
       snapshots with no `positions` key), both lists are empty so the
       UI gracefully degrades.
+    - Known limit (Codex ckpt-2): a position opened AND fully closed
+      within one period has no snapshot row on either side, so it
+      cannot appear per-instrument here (its realised P&L still lands
+      in the cover's aggregate `realized_delta`). Likewise a
+      same-period open+trim shows its unrealised delta only. Exact
+      per-instrument intra-period attribution needs the #1593 ledger.
     """
     if prior is None:
         return {"contributors": [], "drags": []}
@@ -990,6 +996,13 @@ def _external_flows(
     direction (sql/027 CHECK). Only `injection` (+) / `withdrawal` (−)
     are EXTERNAL flows — `tax_provision` / `tax_release` are internal
     earmarks; the cash never leaves the account (spec §3.4).
+
+    Timing caveat (Codex ckpt-2): flows count when RECORDED in
+    `capital_events`; the cash itself reaches valuation via the
+    broker-sync cash ledger. If a recording and its broker sync land
+    on opposite sides of a period boundary, that period's return is
+    under/overstated and the next one symmetrically corrects — the
+    mismatch is visible as a non-zero bridge residual, never silent.
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
@@ -1169,24 +1182,21 @@ def _cover_and_performance(
 
     # YTD / since-inception: chain-link prior v2 period returns with
     # this period's. Only chains in the SAME display currency count.
-    chain_returns = [
-        c["period_return"]
-        for c in chain
-        if c["period_return"] is not None and c["display_currency"] == valuation.display_currency
+    chained_rows = [
+        c for c in chain if c["period_return"] is not None and c["display_currency"] == valuation.display_currency
     ]
+    chain_returns = [c["period_return"] for c in chained_rows]
     current_returns = [period_return] if period_return is not None else []
     si_return = _chain_link(chain_returns + current_returns)
-    ytd_chain = [
-        c["period_return"]
-        for c in chain
-        if c["period_return"] is not None
-        and c["display_currency"] == valuation.display_currency
-        and c["period_start"].year == period_end.year
-    ]
+    ytd_chain = [c["period_return"] for c in chained_rows if c["period_start"].year == period_end.year]
     ytd_return = _chain_link(ytd_chain + current_returns)
 
-    # Benchmark over the same spans, from closes (cheap, [NOW]).
-    si_start = chain[0]["period_start"] if chain else period_start
+    # Benchmark over the same spans, from closes (cheap, [NOW]). The SI
+    # span starts at the first chain row that SURVIVES the currency
+    # filter — starting at chain[0] regardless would compare a
+    # later-inception portfolio chain against an older benchmark span
+    # (Codex ckpt-2).
+    si_start = chained_rows[0]["period_start"] if chained_rows else period_start
     benchmark_si = _benchmark_closes(conn, si_start, period_end)
     ytd_start = date(period_end.year, 1, 1)
     benchmark_ytd = _benchmark_closes(conn, ytd_start, period_end)
@@ -1438,6 +1448,25 @@ def _risk_section(
 _ROLLING_WINDOWS: dict[str, int | None] = {"1m": 1, "3m": 3, "6m": 6, "1y": 12, "si": None}
 
 
+def _add_month(d: date) -> date:
+    """First-of-next-month for a first-of-month date."""
+    return date(d.year + 1, 1, 1) if d.month == 12 else date(d.year, d.month + 1, 1)
+
+
+def _is_contiguous_monthly(window: list[dict[str, Any]], current_period_start: date) -> bool:
+    """True when the window's monthly periods run back-to-back and the
+    newest one immediately precedes the current period. Count alone is
+    not enough: with gaps (missed/backfilled months), N stale returns
+    would masquerade as an N-month window (Codex ckpt-2)."""
+    expected = current_period_start
+    for row in reversed(window):
+        prev = row["period_start"].replace(day=1)
+        if _add_month(prev) != expected:
+            return False
+        expected = prev
+    return True
+
+
 def _rolling_returns(
     conn: psycopg.Connection[Any],
     chain: list[dict[str, Any]],
@@ -1460,12 +1489,14 @@ def _rolling_returns(
         if current_period_return is not None:
             window_returns = [*window_returns, current_period_return]
         # A window is only honest when it is FULL (or si): chaining 2
-        # months and calling it "6m" overstates history.
+        # months and calling it "6m" overstates history. Fullness is
+        # count AND calendar contiguity — with gaps, N stale returns
+        # would masquerade as an N-month window (Codex ckpt-2).
         portfolio: Decimal | None
         if months is None:
             portfolio = _chain_link(window_returns)
             span_start = window[0]["period_start"] if window else period_start
-        elif len(window_returns) == months:
+        elif len(window_returns) == months and _is_contiguous_monthly(window, period_start):
             portfolio = _chain_link(window_returns)
             span_start = window[0]["period_start"] if window else period_start
         else:

--- a/app/services/valuation.py
+++ b/app/services/valuation.py
@@ -1,0 +1,275 @@
+"""Shared portfolio valuation — the single source of the AUM figure.
+
+`compute_portfolio_valuation` is consumed by BOTH the dashboard
+endpoint (`app/api/portfolio.py::get_portfolio`) and the report
+builders (`app/services/reporting.py`), so the report cover and the
+dashboard headline cannot drift — they are one code path (#1596,
+spec §3.3 of docs/proposals/ui/2026-06-12-report-ia.md).
+
+Valuation basis (unchanged from the pre-#1596 endpoint):
+
+    total_aum = Σ position market_value + cash_balance + mirror_equity
+
+Mark-to-market hierarchy per position: live quote (``last`` > 0 →
+bid/ask mid) → latest positive ``price_daily.close`` → cost basis
+(#1428: a non-positive mark is not a valid price). All monetary
+values convert to the operator's display currency; a missing FX rate
+leaves the native value in place (same degrade as the dashboard).
+
+``resolve_quote_price`` / ``parse_optional_float`` moved here from
+``app/api/_helpers`` (which re-exports them) so the service layer
+does not import from the API layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.domain.positions import PositionSource
+from app.services.fx import FxRateNotFound, convert, load_live_fx_rates_with_metadata
+from app.services.portfolio import MirrorBreakdown, load_mirror_breakdowns
+from app.services.runtime_config import get_runtime_config
+
+logger = logging.getLogger(__name__)
+
+
+def parse_optional_float(row: dict[str, object], key: str) -> float | None:
+    """Safely cast a nullable numeric DB column to float."""
+    val = row.get(key)
+    if val is None:
+        return None
+    return float(val)  # type: ignore[arg-type]
+
+
+def resolve_quote_price(
+    last: float | None,
+    bid: float | None,
+    ask: float | None,
+) -> float | None:
+    """Return a usable live-quote price, or ``None`` if none is available.
+
+    Rule: a usable mark is the trade ``last`` when strictly positive; else
+    the bid/ask mid when the book is two-sided and both sides are positive.
+
+    A non-positive ``last`` is treated as missing. eToro persists
+    ``quotes.last = 0.00`` for instruments not freshly traded (bid/ask
+    present, no recent trade). Using 0 as the mark values a position at 0 →
+    fake −100% P&L (#1428). Callers supply their own downstream fallback
+    (daily_close → cost basis / open_rate) when this returns ``None``.
+    """
+    if last is not None and last > 0:
+        return last
+    if bid is not None and bid > 0 and ask is not None and ask > 0:
+        return (bid + ask) / 2.0
+    return None
+
+
+@dataclass(frozen=True)
+class HoldingValuation:
+    """One open position, marked and converted to display currency."""
+
+    instrument_id: int
+    symbol: str
+    company_name: str
+    sector: str | None
+    native_currency: str
+    open_date: date | None
+    source: PositionSource  # positions.source is NOT NULL + CHECK-constrained
+    updated_at: datetime  # positions.updated_at is NOT NULL
+    avg_cost: float | None
+    current_units: float
+    cost_basis: float
+    current_price: float | None
+    market_value: float
+    unrealized_pnl: float
+    valuation_source: str  # "quote" | "daily_close" | "cost_basis"
+
+
+@dataclass(frozen=True)
+class PortfolioValuation:
+    """Aggregate valuation + the per-holding detail it was built from."""
+
+    display_currency: str
+    holdings: tuple[HoldingValuation, ...]
+    total_market: float
+    cash_balance: float | None  # None = empty cash_ledger (unknown)
+    mirror_equity: float
+    total_aum: float
+    # Raw position rows (dict_row) in the same order as `holdings`, for
+    # callers that need columns beyond the valuation (the dashboard's
+    # broker-trade price lookup + fx_rates_used derivation).
+    raw_rows: tuple[dict[str, Any], ...]
+    # FX metadata loaded once; shared so callers don't re-query.
+    rates: dict[tuple[str, str], Decimal]
+    rates_meta: dict[tuple[str, str], dict[str, Any]]
+    # Mirror breakdowns loaded once (dashboard renders per-mirror rows).
+    mirror_breakdowns: tuple[MirrorBreakdown, ...]
+
+
+_POSITIONS_SQL = """
+    SELECT p.instrument_id, i.symbol, i.company_name, i.currency, i.sector,
+           p.open_date, p.avg_cost, p.current_units, p.cost_basis,
+           p.source, p.updated_at,
+           q.last, q.bid, q.ask,
+           pd.close AS daily_close
+    FROM positions p
+    JOIN instruments i USING (instrument_id)
+    LEFT JOIN quotes q USING (instrument_id)
+    LEFT JOIN LATERAL (
+        SELECT close
+        FROM price_daily
+        WHERE instrument_id = p.instrument_id
+          AND close IS NOT NULL
+        ORDER BY price_date DESC
+        LIMIT 1
+    ) pd ON true
+    WHERE p.current_units > 0
+    ORDER BY p.cost_basis DESC, p.instrument_id ASC
+"""
+
+# SUM on empty table returns NULL (one row, NULL value) — not zero rows.
+_CASH_SQL = "SELECT SUM(amount) AS cash_balance FROM cash_ledger"
+
+
+def _convert_value(
+    value: float,
+    from_ccy: str,
+    to_ccy: str,
+    rates: dict[tuple[str, str], Decimal],
+) -> float:
+    """Float convenience wrapper over fx.convert; missing rate → unchanged."""
+    if from_ccy == to_ccy:
+        return value
+    try:
+        return float(convert(Decimal(str(value)), from_ccy, to_ccy, rates))
+    except FxRateNotFound:
+        logger.warning("FX rate %s→%s not found; value left in native currency", from_ccy, to_ccy)
+        return value
+
+
+def _holding_from_row(
+    row: dict[str, Any],
+    display_currency: str,
+    rates: dict[tuple[str, str], Decimal],
+) -> HoldingValuation:
+    cost_basis = float(row["cost_basis"])
+    current_units = float(row["current_units"])
+    native_currency = str(row.get("currency") or "USD")
+
+    quote_price = resolve_quote_price(
+        parse_optional_float(row, "last"),
+        parse_optional_float(row, "bid"),
+        parse_optional_float(row, "ask"),
+    )
+    daily_close = parse_optional_float(row, "daily_close")
+
+    if quote_price is not None:
+        current_price: float | None = quote_price
+        market_value = current_units * quote_price
+        unrealized_pnl = market_value - cost_basis
+        valuation_source = "quote"
+    elif daily_close is not None and daily_close > 0:
+        current_price = daily_close
+        market_value = current_units * daily_close
+        unrealized_pnl = market_value - cost_basis
+        valuation_source = "daily_close"
+    else:
+        current_price = None
+        market_value = cost_basis
+        unrealized_pnl = 0.0
+        valuation_source = "cost_basis"
+
+    # Convert all monetary values to display currency in a single block
+    # so they either all convert or all stay in native currency.
+    avg_cost = parse_optional_float(row, "avg_cost")
+    if native_currency != display_currency:
+        try:
+            market_value = float(convert(Decimal(str(market_value)), native_currency, display_currency, rates))
+            cost_basis = float(convert(Decimal(str(cost_basis)), native_currency, display_currency, rates))
+            unrealized_pnl = float(convert(Decimal(str(unrealized_pnl)), native_currency, display_currency, rates))
+            if current_price is not None:
+                current_price = float(convert(Decimal(str(current_price)), native_currency, display_currency, rates))
+            if avg_cost is not None:
+                avg_cost = float(convert(Decimal(str(avg_cost)), native_currency, display_currency, rates))
+        except FxRateNotFound:
+            logger.warning(
+                "FX rate %s→%s not found; skipping conversion for position",
+                native_currency,
+                display_currency,
+            )
+
+    return HoldingValuation(
+        instrument_id=row["instrument_id"],
+        symbol=row["symbol"],
+        company_name=row["company_name"],
+        sector=row.get("sector"),
+        native_currency=native_currency,
+        open_date=row["open_date"],
+        source=row["source"],
+        updated_at=row["updated_at"],
+        avg_cost=avg_cost,
+        current_units=current_units,
+        cost_basis=cost_basis,
+        current_price=current_price,
+        market_value=market_value,
+        unrealized_pnl=unrealized_pnl,
+        valuation_source=valuation_source,
+    )
+
+
+def compute_portfolio_valuation(conn: psycopg.Connection[Any]) -> PortfolioValuation:
+    """Mark-to-market valuation of the whole account, display currency.
+
+    One snapshot of: open positions (marked per the #1428 hierarchy),
+    cash (signed sum of `cash_ledger`), and mirror equity. The
+    dashboard endpoint and the report builders both call this — see
+    module docstring.
+    """
+    config = get_runtime_config(conn)
+    display_currency = config.display_currency
+    rates_meta = load_live_fx_rates_with_metadata(conn)
+    rates: dict[tuple[str, str], Decimal] = {k: v["rate"] for k, v in rates_meta.items()}
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_POSITIONS_SQL)
+        pos_rows = cur.fetchall()
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_CASH_SQL)
+        cash_row = cur.fetchone()
+        # SUM() always returns exactly one row; value is None on empty table.
+        raw_cash = cash_row["cash_balance"] if cash_row else None
+
+    holdings = tuple(_holding_from_row(r, display_currency, rates) for r in pos_rows)
+    total_market = sum(h.market_value for h in holdings)
+
+    cash_balance = float(raw_cash) if raw_cash is not None else None
+    # Cash is always USD for eToro.
+    if cash_balance is not None:
+        cash_balance = _convert_value(cash_balance, "USD", display_currency, rates)
+
+    mirror_breakdowns = tuple(load_mirror_breakdowns(conn))
+    raw_mirror_equity = sum(mb.mirror_equity_usd for mb in mirror_breakdowns)
+    mirror_equity = _convert_value(raw_mirror_equity, "USD", display_currency, rates)
+
+    total_aum = total_market + (cash_balance if cash_balance is not None else 0.0) + mirror_equity
+
+    return PortfolioValuation(
+        display_currency=display_currency,
+        holdings=holdings,
+        total_market=total_market,
+        cash_balance=cash_balance,
+        mirror_equity=mirror_equity,
+        total_aum=total_aum,
+        raw_rows=tuple(pos_rows),
+        rates=rates,
+        rates_meta=rates_meta,
+        mirror_breakdowns=mirror_breakdowns,
+    )

--- a/docs/proposals/ui/2026-06-12-report-ia.md
+++ b/docs/proposals/ui/2026-06-12-report-ia.md
@@ -1,0 +1,309 @@
+# Report IA v2 — period statements: skeleton, naming, visual system (#1592 child 1)
+
+Status: PROPOSAL v2 — operator sign-off required before children 2–3 start.
+Scope: information architecture only. No code in this child.
+
+v2 provenance: v1 passed Codex ckpt-1 (×2, 8 findings folded), then a
+5-lens committee round (quant analyst, broker-report designer, UI/chart
+designer, adversarial grounding, Codex CTO) per the operator's 2026-06-12
+brief. Raw memos + consolidated findings in session memory
+(`project_report_ia_review_*`, `project_report_ia_consolidated_findings`).
+All load-bearing claims below grep/DB-verified at write time.
+
+## 1. Problem
+
+Operator brief (2026-06-11): "Our reports are a bit disjointed, doesn't feel
+intuitive, naming and graphs don't look great, doesn't feel like a detailed
+financial report."
+
+`ReportsPage.tsx` renders disconnected stat blocks in arbitrary order, with no
+charts, no benchmark, no holdings view, and a tab+list navigation that buries
+the latest report. Labels don't match what a financial statement calls things.
+
+## 2. Current state (audited 2026-06-12)
+
+- **Surface:** `frontend/src/pages/ReportsPage.tsx` — two tabs (weekly /
+  monthly) over `GET /reports/weekly` / `GET /reports/monthly`
+  (`app/api/reports.py`; `limit` param default 10, max 100), rows from
+  `report_snapshots` (`sql/030_report_snapshots.sql`: immutable JSONB per
+  `(report_type, period_start)` unique index).
+- **Builders:** `app/services/reporting.py::generate_weekly_report` /
+  `generate_monthly_report`. Job function bodies in
+  `app/workers/scheduler.py::weekly_report/monthly_report`; registered in
+  `_INVOKERS` (`app/jobs/runtime.py:223`), NOT in `SCHEDULED_JOBS` —
+  on-demand only.
+- **Weekly snapshot keys:** `pnl` (current-state, key literally carries
+  `note: "current-state snapshot, not period delta"`), `top_performers`,
+  `bottom_performers`, `positions_opened`, `positions_closed`,
+  `upcoming_earnings` (always `[]`, retired #539), `score_changes`,
+  `budget`, `positions`, `period_contribution`.
+- **Monthly adds:** `position_pnl`, `win_rate`, `avg_holding_days`,
+  `best_trade`, `worst_trade`, `attribution_summary`, `thesis_accuracy`,
+  `tax_provision`.
+- **Live bugs found during audit (one prevention class — "API response
+  shapes invented at the type boundary"; `snapshot_json` is
+  `Record<string, unknown>` so TS never caught any of them):**
+  1. P&L block reads `pnl["realised_pnl"]` / `pnl["unrealised_pnl"]` /
+     `pnl["portfolio_value"]` / `pnl["cash"]` (`ReportsPage.tsx:138-144`);
+     builder writes `realized_pnl` / `unrealized_pnl` / `total_pnl` only
+     (`reporting.py::_pnl_snapshot`). All four tiles render empty.
+  2. Top/bottom performers + best/worst trade read `return_pct`
+     (`ReportsPage.tsx:194,225`); builders write `unrealized_pnl`
+     (`_top_bottom_performers`) and `gross_return_pct`
+     (`_best_worst_trade`). Values render empty.
+  3. Thesis accuracy reads `buy_hit_rate_pct` / `avoid_hit_rate_pct` as
+     dict keys; builder `_thesis_accuracy` returns a per-trade LIST of
+     rows (`stance`, `gross_return_pct`, `target_hit`, …) — no aggregate
+     hit-rate keys exist anywhere.
+- **Dev data:** 3 snapshots (2 weekly, 1 monthly); `fills` has 0 rows (no
+  trades yet on demo account).
+
+## 3. Core rules
+
+1. **A report is a record.** Every figure renders from `snapshot_json`.
+   Nothing is recomputed live at view time — each snapshot's own figures
+   are stamped at generation. The one cross-period view (the §4.2
+   trailing line) is ASSEMBLED client-side from the fetched list of
+   immutable snapshots — assembly of stamped points is not
+   recomputation; no point's value can differ from its snapshot. Regenerating a period (re-running the job)
+   replaces the snapshot via the `(report_type, period_start)` unique
+   index — that is the only way a report changes; the snapshot's
+   `generated_at` (already emitted by both builders) renders in the
+   statement footer so a regenerated historical report is visibly
+   re-dated, not silently rewritten.
+2. **Schema versioning.** New top-level key `schema_version: 2`. FE
+   branches on it: v2 renders the statement; v1 snapshots (no
+   `schema_version` key) render a **corrected** legacy block layout — key
+   reads fixed (`realized_pnl`, `unrealized_pnl`, `gross_return_pct` —
+   §2 bugs), dead sections dropped. Legacy branch has an explicit exit
+   condition: renders old snapshots only, no new features ever land in
+   it, and it is pinned by one v1 weekly + one v1 monthly fixture test.
+3. **Valuation parity with the dashboard.** The dashboard's headline is
+   `total_aum = total_market + cash_balance + mirror_equity`
+   (`app/api/portfolio.py:531`). The snapshot's `cover.portfolio_value`
+   MUST be produced by a shared, named backend valuation helper used by
+   both paths (child 3 extracts it from the portfolio endpoint logic) —
+   not a parallel formula. A smoke test asserts a freshly generated
+   report's cover value equals the dashboard valuation on the same
+   connection/rates. Without this the report and the dashboard drift.
+4. **Returns are flow-adjusted.** External capital flows are already
+   recorded in `capital_events` (`sql/027_budget_capital.sql`:
+   `injection` / `withdrawal` / `tax_provision` / `tax_release`).
+   Period return = **Modified Dietz**:
+   `(V_end − V_start − ΣF) / (V_start + Σ(F × w))`, where F is each
+   external flow SIGNED (injection +, withdrawal −) and w is the
+   fraction of the period remaining after the flow lands
+   (`(period_end − flow_date) / period_length`); degenerates to the
+   simple ratio in flow-free periods. A naive `V_end/V_start − 1` prints
+   every deposit as performance — the one error a financial report must
+   never make. Note: time-weighted return needs **external** flow timing,
+   which exists today — #1593 gates daily valuation *granularity*, not
+   flow-awareness. Internal buys/sells never touch portfolio-level
+   returns. Unitemised broker-side cash movements (`broker_sync` deltas)
+   that exceed a small epsilon are surfaced on the bridge (§4.2) and
+   footnoted on the return figure ("includes net unclassified broker
+   movements of £X").
+
+## 4. Statement structure
+
+**Cadence split (committee + CTO convergence): monthly = full statement;
+weekly = slim digest.** Same schema primitives, different density. Weekly
+renders sections 1, 2, 4, 5, 6 + 11-12 below; monthly renders all. A slim
+weekly that is always full reads better than a 9-section weekly of nil
+lines.
+
+**Chrome (every statement):**
+
+- **Masthead:** "eToro demo account · Reporting currency GBP · Statement
+  period 2–8 Jun 2026 · Data as at 8 Jun 2026 close". Account label +
+  currency are constants; period from the row; the demo designation is
+  non-negotiable honesty.
+- **Footer:** "Generated {generated_at} · Prices: period-end close · FX:
+  generation date · Benchmark: S&P 500 price index". Timestamps exist in
+  the snapshot today (`generated_at`, `computed_at`).
+- **Footnote system:** methodology caveats carry superscript markers
+  resolving to §11 Notes & disclosures. Inline caveat lines are reserved
+  for materially-dangerous misreads only (§4.6, §4.9 scope).
+
+| # | Section | Cadence | Contents | Data | v1 state |
+| --- | --- | --- | --- | --- | --- |
+| 1 | **Account summary** | W+M | Stat tiles: closing value, period return % (flow-adjusted, §3.4), benchmark return % + excess, net realised gains (period), change in net unrealised appreciation (period), cash. Below tiles: **value bridge** — opening value + net external flows + trading P&L ± charges + "broker adjustments (unitemised)" residual = closing value. Rows for YTD and since-inception return (portfolio vs benchmark) — "—" until history exists | child 3: `cover` key (values via §3.3 shared helper; bridge from prior snapshot + `capital_events` + `fills`; residual absorbs `broker_sync`); benchmark period return from `price_daily` closes [NOW] | NEW |
+| 2 | **Performance vs benchmark** | W+M | Indexed line chart: portfolio vs benchmark, both = 100 at window start, over trailing window (13 weekly / 12 monthly points). Portfolio = chain-linked flow-adjusted sub-period returns (§3.4), NOT raw value. Benchmark **sampled at snapshot dates** — the daily intraperiod line (both series) is #1593-gated (daily valuation = a declared #1593 consumer) | child 3: each snapshot stamps its own `performance` point (portfolio_value, period_return, benchmark_close, benchmark_return); the trailing line is assembled client-side from the fetched snapshot list — each snapshot stays an immutable single-period record, no cross-snapshot series duplication | NEW |
+| 3 | **Rolling returns** | M | Table: 1m / 3m / 6m / 1y / SI — portfolio, benchmark, excess. Portfolio cells render "—" until snapshot depth exists; benchmark side computable from `price_daily` [NOW] | child 3: derived from stored snapshot chain + benchmark closes at generation | NEW |
+| 4 | **Attribution** | W+M | Horizontal diverging bar: top 5 contributors / top 5 detractors by **period P&L delta including realised** — child 3 folds `positions.realized_pnl` snapshot-diff into `_compute_contributors` (today it diffs unrealised P&L of OPEN positions only, `reporting.py:626` — closed positions vanish, trims read as phantom losses). Until folded, the chart is labelled "Change in unrealised P&L — open positions only" | exists (`period_contribution`) + child 3 realised fold | RENDERABLE NOW under the honest label |
+| 5 | **Holdings & exposure** | W+M | Table at period end: symbol, name, units, price, market value, weight % (inline bar), since-entry return % [NOW: market value vs `cost_basis`], period contribution (currency + bps of opening value). Below: concentration line (phrased for small n: "Top 5 = 100% (only 4 holdings)") + sector exposure bars | child 3: `holdings` key (snapshot `positions` key omits units/price/value by builder choice — `_positions_snapshot` selects symbol/name/pnl/cost-basis only; the SQL table has `current_units`) | NEW shape; v1 renders current `positions` key reduced |
+| 6 | **Period activity** | W+M | Trades in period: date, side, symbol, units, price, fees, realised P&L on close | partial: `positions_opened`/`positions_closed` (own order path only; fees = child-3 addition — `fills.fees` exists but `_positions_opened_closed` doesn't select it) | **#1593-gated** for broker-side completeness; permanent inline caveat: "Own-platform orders only — broker-side trade history lands with the trade ledger (#1593)" |
+| 7 | **Dividends & income** | M | Declared dividends with ex-date in period: instrument, ex-date, DPS, units (period-end proxy), estimated amount; total line labelled "Estimated income" | child 3: `income` key — `dividend_events` (`sql/054`) × period-end units. Footnote: estimated from declarations, not confirmed received; units-at-ex-date approximated by period-end units (a position opened after ex-date shows phantom income) until #1593 | NEW |
+| 8 | **Charges** | M | Fees paid in period (own-path `fills.fees`); `fx_unavailable` degraded-state badge when set | partial; child 3: `costs` key | NEW; broker-side fees invisible until #1593 (footnote) |
+| 9 | **Risk & trade statistics** | M | Drawdown + volatility computed over the **full snapshot history** ("since inception, N weekly observations"), min-n gate (n<6 → "Insufficient history (N periods)"); explicitly NO Sharpe/Sortino/IR (not honestly computable pre-#1593 — out of scope, do not add). **Closed-trade review:** win rate with denominator ("3 of 4 closed trades", % suppressed below n=5), payoff ratio (avg win % / avg loss % from `return_attribution.gross_return_pct` [NOW]), average holding period ("12 days (6 trades)"), best & worst closed trades (gross), turnover = reserved line "(requires trade ledger, #1593)" | exists (`win_rate`, `avg_holding_days`, `best_trade`, `worst_trade`) + child 3: `risk` key + payoff ratio | partial NOW |
+| 10 | **Model & thesis review** | M | Attribution decomposition: gross = market + sector + model alpha + timing alpha − cost drag, equal-weighted, "n=K closed trades" label (current `_period_attribution` silently drops `timing_alpha_pct` + `cost_drag_pct` — both stored in `return_attribution`, `sql/029`; child 3 surfaces all components). Thesis outcomes bucketed hit / miss / **not yet evaluable** (younger than horizon) with n per bucket; per-trade list below. Rank movers (`score_changes` — weekly-only today; child 3 adds to monthly builder) | partial; child 3: `thesis_summary` + builder additions | partial NOW |
+| 11 | **Notes & disclosures** | W+M | Numbered footnotes: benchmark basis ("S&P 500 price index — excludes dividends; understates total return by ~1.3–2%/yr, comparisons flattered by about that much"), FX basis (each snapshot at its generation-date rates), income estimation basis, return methodology (Modified Dietz), small-n caveat, #1593 scope notes | constants + per-snapshot values | NEW (presentation) |
+| 12 | **Appendix: snapshot data** | W+M | Collapsed `<details>` raw JSON — operator debug | exists | keep (needs `dark:` styling pass) |
+
+Dropped sections: **Upcoming earnings** (retired #539, always empty),
+**Top/bottom performers** (current-state `unrealized_pnl` duplicates §4.4 +
+§4.5's since-entry column).
+
+Empty sections render **nil lines** ("No transactions during this period",
+"No dividends declared this period") — statement convention — NOT
+`EmptyState` cards. `EmptyState` is reserved for genuinely missing data
+(absent key, no snapshot at all). With dev's 0 fills this single decision
+determines whether v1 feels like a statement or a skeleton.
+
+## 5. Naming pass
+
+| Current label | New label | Why |
+| --- | --- | --- |
+| "Weekly + monthly performance snapshots from the report jobs" (subtitle) | "Period statements" | operator-facing, not plumbing-facing |
+| Tabs "Weekly" / "Monthly" + 10-row list | Segmented "Weekly \| Monthly" + stepper "‹ 2–8 Jun 2026 ›"; period label clickable → period picker over the fetched list | latest first; archive stays reachable; statements name the period SPAN, not "Week of" |
+| "P&L" | "Account summary" | it carries value, flows, cash — not just P&L |
+| "Realised" / "Unrealised" | "Net realised gains (period)" / "Change in net unrealised appreciation (period)" | fund-statement convention; "change in" prevents level-vs-delta misread; v1 (pre-deltas) says "(since inception)" |
+| "Top contributors" / "Top drags" | "Top contributors" / "Top detractors" | standard term |
+| "Top performers" / "Bottom performers" | (dropped) | redundant |
+| "Trade stats" | "Closed-trade review" (inside "Risk & trade statistics") | win rate alone misleads; framing is the review of closed trades |
+| "Avg holding (days)" | "Average holding period" — "12 days (6 trades)" | denominator always visible |
+| "Best / worst trade" | "Best & worst closed trades" + "gross return" qualifier | `gross_return_pct` is gross |
+| "Thesis accuracy" | "Model & thesis review" / "Buy hit rate" / "Avoid hit rate" + "not yet evaluable" bucket | unfalsifiable without maturity bucketing |
+| "Upcoming earnings" | (dropped) | retired #539 |
+| (new) | "Period activity" | statement term for the blotter |
+| (new) | "Dividends & income" / total = "Estimated income" | never implies cash received |
+| "Fees & FX" | "Charges" | FX methodology is a disclosure (§11), not a charge |
+| `SPX500` in legends | "S&P 500 (price index)" | internal tickers in legends are a plumbing tell |
+
+Period-sensitive labels rule (prevention log): every label naming a
+granularity derives from the active `report_type`, none hardcoded.
+
+## 6. Visual system (binds child 2)
+
+1. **Charts: recharts + `useChartTheme()`**
+   (`frontend/src/lib/useChartTheme.ts`; palettes in
+   `frontend/src/lib/chartTheme.ts`, #690). Every chart: real axes, tick
+   labels, legend, tooltip. Tooltip + legend MUST be theme-aware custom
+   content — the recharts defaults are white-card/black-text and break
+   dark mode (`slate-950` surfaces); every existing consumer hand-rolls
+   one. Child 2 extracts a shared dark-safe **`ChartTooltip`** container
+   (bg/border/text from the theme) — adopted on this page only;
+   migrating the other recharts consumers is a separate follow-up ticket.
+2. **Stat tiles:** extract **`StatTile`** from the existing
+   `SummaryCards.tsx` `Card` (small-caps label, `text-2xl tabular-nums`
+   value, tone, `hint` slot for the benchmark delta). It keeps its
+   hairline top — that is the established tile chrome. Per-tile
+   sparklines only when ≥4 periods exist (`Sparkline.tsx` precedent);
+   omit below that, don't reserve dead space.
+3. **Chart encodings:** §4.2 indexed LINE (portfolio = `primaryLine`,
+   benchmark = `accent[1]` dashed) + `ReferenceLine y=100` + always-on
+   point markers (`dot={{r:3}}`) + muted "N periods" count in the
+   `Section` action slot — sparse series (2-5 points is the common case
+   for months) must read as stated fact, not rendering failure. Suppress
+   the benchmark legend entry when `benchmark = null`. §4.4 diverging
+   horizontal bars per the `InsiderByOfficer` idiom (`layout="vertical"`,
+   per-Cell `up`/`down` fill); symbols rendered as link-styled axis ticks
+   (`text-blue-600 hover:underline`, keyboard Enter per #921) — bar rects
+   are NOT silently clickable (read-only-vs-interactive convention).
+   §4.5 sector bars: ONE neutral fill (`accent[1]`) — accent rotation is
+   for series identity, not categories. No pie charts. No waterfall for
+   attribution (top-5 truncation breaks its additive promise).
+4. **Loading/error model: ONE fetch, page-level states.** The whole
+   statement renders from one snapshot row — one page-level skeleton
+   structurally mirroring the layout (tile row + section stubs), one
+   page-level `ErrorBanner` with retry (the single source IS "all
+   sources"). NO per-section skeletons/retries. Per-section `EmptyState`
+   only for missing v2 keys (v1 snapshot under v2 skeleton); nil lines
+   per §4.
+5. **Page rhythm:** charts + holdings full-width; small sections paired
+   two-up at `md:` (`grid gap-4 md:grid-cols-2`): Dividends & income +
+   Charges; Risk & trade statistics + Model & thesis review. Period
+   header row (segmented control + stepper + period label) is
+   `sticky top-0` with page background — flip periods without scrolling
+   back. Layout stays linear single-column in DOCUMENT ORDER so a later
+   `@media print` pass is possible; child 2 must not adopt layouts that
+   preclude printing.
+6. **Period navigation:** stepper ends disabled (opacity +
+   `cursor-not-allowed`, never hidden); ArrowLeft/Right when focused;
+   URL `push` (not replace — back-button walks periods); type-switch
+   resets to latest period; deep-link `?type=weekly&period=2026-06-01`;
+   FE fetches `limit=100` (param exists, `le=100`); periods beyond 100
+   are out of v1 scope — stated, not implied reachable.
+7. **Caveat two-tier rule:** scope/methodology caveats = muted slate
+   caption or §11 footnote — a caveat is NOT a warning. Amber is
+   reserved for genuine degraded states (`fx_unavailable` badge).
+8. **Tables:** holdings NEVER truncated (a statement that hides positions
+   isn't a record); activity capped ~20 rows + "show all (N)" in the
+   Section action slot; numeric cells `text-right tabular-nums`; weight
+   bars need a dark-aware track (`bg-slate-100 dark:bg-slate-800`).
+9. **Type contract:** `SnapshotV2` percent fields are **fraction-basis
+   Decimal-strings** parsed once at the boundary (`formatPct` takes
+   fractions) — stated explicitly so the §2 phantom-key class doesn't
+   recur as a ×100 class.
+
+## 7. Honest-caveat register (v1)
+
+- **Period P&L:** `_pnl_snapshot` is lifetime current-state. Until child 3
+  computes period deltas, cover tiles are labelled "(since inception)".
+- **Activity completeness:** `fills` only records eBull-placed orders;
+  broker-side trades + backfill are #1593. §4.6/§4.9 inline caveat
+  permanent until then.
+- **Income:** `cash_ledger.event_type` vocabulary is `order_buy` /
+  `order_sell` / `broker_sync` (verified: the only three write sites —
+  `app/api/orders.py`, `app/services/order_client.py`,
+  `app/services/portfolio_sync.py`). Broker dividends/fees arrive folded
+  into undifferentiated `broker_sync` deltas. §4.7 is estimates from
+  declarations; actuals need eToro account-activity ingest (#1593
+  investigation decides feasibility).
+- **Benchmark availability:** default benchmark symbol `SPX500`. Daily
+  closes observed on the dev DB (2022-07→present in `price_daily`) — a
+  dev-data observation, not a repo invariant. Child 3 resolves the
+  benchmark **by symbol at generation time** (no hardcoded instrument_id)
+  and stamps `performance.benchmark = null` when missing; FE renders
+  portfolio-only with a notice. Benchmark symbol is a builder constant in
+  v1, not operator config.
+- **Benchmark basis:** S&P 500 **price index** vs flow-adjusted portfolio
+  returns. Quantified footnote (§11): excludes dividends, understates
+  total return ~1.3–2%/yr — comparisons flattered by about that much.
+- **FX:** each snapshot's values are stamped at generation-date FX (same
+  basis as the dashboard). Points on the trailing line therefore mix
+  each report's generation-date rates; chart legend carries
+  "GBP-converted at each report's generation date".
+  `performance.fx_mode: "generation_date"`.
+- **Sparse early series:** trailing line from consecutive snapshots —
+  fresh install renders 2 points. §6.3 treatment (markers + baseline +
+  "N periods") makes that intentional; 1 point = dot + notice; 0 = nil.
+- **Small-n statistics:** risk metrics min-n gated; win-rate % suppressed
+  below 5 closed trades; concentration phrased as portfolio size.
+
+## 8. Execution plan (order FLIPPED from v1 — committee/CTO)
+
+- **Step 1 — child 3 (data contract) first, minimal slice:** both
+  builders emit `schema_version: 2` + `cover` (incl. bridge +
+  Modified-Dietz return via §3.3 shared valuation helper + §3.4 flow
+  math), `performance` (single-period point + benchmark close),
+  `holdings`, `income`, `costs`, `risk`, `thesis_summary`;
+  `score_changes` added to monthly; `fees` added to
+  `_positions_opened_closed`; `_compute_contributors` folds realised
+  deltas; `_period_attribution` surfaces timing alpha + cost drag. All
+  derived inside the generation transaction; Decimals as strings
+  (existing `_dec` convention). No new tables, no migration. Regenerate
+  current week + month on dev. **Deliverable includes a backend-emitted
+  v2 fixture** (from a builder test, never handwritten) + the §3.3
+  valuation parity smoke.
+- **Step 2 — child 2 (FE statement):** rebuild ReportsPage per §§4-6
+  against a typed `SnapshotV2` interface mirroring the builder
+  field-for-field, type-tested against the backend-emitted fixture.
+  Corrected legacy branch (§3.2) retires all three §2 phantom-key bugs.
+  Extracts `StatTile` + `ChartTooltip` (page-local adoption).
+- **Out of scope:** trade ledger (#1593); benchmark selection UI; PDF
+  export (layout reserves it, §6.6); scheduling the report jobs (stay
+  on-demand); backfilling v2 keys into historical snapshots; Sharpe/
+  Sortino/IR (§4.9 — explicitly rejected until daily series exist);
+  migrating the other recharts consumers onto `ChartTooltip`/`StatTile`
+  (file as follow-up ticket at child-2 merge).
+
+## 9. Dependencies
+
+- **#1593 (trade ledger epic):** §4.6 completeness, §4.7 income actuals,
+  §4.9 turnover + daily-resolution risk stats, §4.2 daily intraperiod
+  lines. Statement ships v1-honest without it; sections upgrade in place.
+- **#690 chart theme / #691 section chrome:** consumed, not modified.
+- **Follow-up tickets to file at child-2 merge:** chart-tooltip/stat-tile
+  adoption across existing recharts consumers; legacy per-source
+  ownership endpoints retirement (from #1589, unrelated but queued).

--- a/docs/proposals/ui/2026-06-12-report-ia.md
+++ b/docs/proposals/ui/2026-06-12-report-ia.md
@@ -270,6 +270,15 @@ granularity derives from the active `report_type`, none hardcoded.
   "N periods") makes that intentional; 1 point = dot + notice; 0 = nil.
 - **Small-n statistics:** risk metrics min-n gated; win-rate % suppressed
   below 5 closed trades; concentration phrased as portfolio size.
+- **Flow-recording skew:** flows count when recorded in
+  `capital_events`; the cash reaches valuation via broker sync. A
+  recording and its sync landing on opposite sides of a period boundary
+  under/overstates that period's return and symmetrically corrects the
+  next — visible as a non-zero bridge residual, never silent.
+- **Intra-period round trips:** a position opened AND fully closed
+  within one period has no snapshot baseline on either side — its
+  realised P&L lands in the cover aggregate but not in the
+  per-instrument attribution chart until the #1593 ledger.
 
 ## 8. Execution plan (order FLIPPED from v1 — committee/CTO)
 

--- a/tests/fixtures/report_snapshot_v2/monthly.json
+++ b/tests/fixtures/report_snapshot_v2/monthly.json
@@ -1,0 +1,183 @@
+{
+  "attribution_summary": {
+    "avg_cost_drag_pct": null,
+    "avg_gross_return_pct": null,
+    "avg_market_return_pct": null,
+    "avg_model_alpha_pct": null,
+    "avg_sector_return_pct": null,
+    "avg_timing_alpha_pct": null,
+    "positions_attributed": 0,
+    "weighting": "equal"
+  },
+  "avg_holding_days": null,
+  "best_trade": null,
+  "costs": {
+    "fees_total": "0",
+    "fill_count": 0,
+    "scope": "own_platform_orders_only"
+  },
+  "cover": {
+    "benchmark_return": null,
+    "benchmark_si_return": null,
+    "benchmark_ytd_return": null,
+    "bridge": {
+      "broker_adjustments_residual": null,
+      "closing_value": "2100.000000",
+      "net_external_flows": "0.000000",
+      "opening_value": null,
+      "realized_delta": null,
+      "unrealized_delta": null
+    },
+    "cash": "1000.000000",
+    "closing_value": "2100.000000",
+    "display_currency": "USD",
+    "excess_return": null,
+    "mirror_equity": "0.000000",
+    "opening_value": null,
+    "period_return": null,
+    "realized_delta": null,
+    "return_method": "modified_dietz_v1",
+    "si_return": null,
+    "unrealized_delta": null,
+    "ytd_return": null
+  },
+  "generated_at": "2026-06-12T10:49:45.667501+00:00",
+  "holdings": [
+    {
+      "company_name": "Report Co",
+      "cost_basis": "1000.000000",
+      "instrument_id": 789801,
+      "market_value": "1100.000000",
+      "period_contribution": null,
+      "period_contribution_bps": null,
+      "price": "110.000000",
+      "sector": "Technology",
+      "since_entry_return_pct": "0.100000",
+      "symbol": "RPTV2A",
+      "units": "10.000000",
+      "unrealized_pnl": "100.000000",
+      "valuation_source": "quote",
+      "weight_pct": "0.523810"
+    }
+  ],
+  "income": {
+    "basis": "declared_dps_x_current_units",
+    "estimated_totals": {},
+    "items": []
+  },
+  "performance": {
+    "benchmark": {
+      "close_end": null,
+      "close_start": null,
+      "label": "S&P 500 (price index)",
+      "return_pct": null,
+      "symbol": "SPX500"
+    },
+    "fx_mode": "generation_date",
+    "method": "modified_dietz_v1",
+    "observations": 0,
+    "period_return": null,
+    "portfolio_value": "2100.000000"
+  },
+  "period_contribution": {
+    "contributors": [],
+    "drags": []
+  },
+  "period_end": "2026-05-31",
+  "period_start": "2026-05-01",
+  "pnl": {
+    "note": "current-state snapshot, not period delta",
+    "realized_pnl": "0.000000",
+    "total_pnl": "100.000000",
+    "unrealized_pnl": "100.000000"
+  },
+  "position_pnl": [],
+  "positions": [
+    {
+      "company_name": "Report Co",
+      "cost_basis": "1000.000000",
+      "current_units": "10.000000",
+      "instrument_id": 789801,
+      "realized_pnl": "0.000000",
+      "symbol": "RPTV2A",
+      "unrealized_pnl": "100.000000"
+    }
+  ],
+  "report_type": "monthly",
+  "risk": {
+    "concentration_top5_pct": "0.523810",
+    "holding_count": 1,
+    "insufficient_history": true,
+    "max_drawdown": null,
+    "observation_label": "since inception, monthly observations",
+    "observations": 0,
+    "sector_exposure": {
+      "Technology": "0.523810"
+    },
+    "volatility": null
+  },
+  "rolling_returns": {
+    "1m": {
+      "benchmark": null,
+      "excess": null,
+      "portfolio": null
+    },
+    "1y": {
+      "benchmark": null,
+      "excess": null,
+      "portfolio": null
+    },
+    "3m": {
+      "benchmark": null,
+      "excess": null,
+      "portfolio": null
+    },
+    "6m": {
+      "benchmark": null,
+      "excess": null,
+      "portfolio": null
+    },
+    "si": {
+      "benchmark": null,
+      "excess": null,
+      "portfolio": null
+    }
+  },
+  "schema_version": 2,
+  "score_changes": [],
+  "tax_provision": {
+    "estimated_tax_gbp": "0",
+    "estimated_tax_usd": "0",
+    "tax_year": "2026/27"
+  },
+  "thesis_accuracy": [],
+  "thesis_summary": {
+    "avoid": {
+      "hit_rate_pct": null,
+      "hits": 0,
+      "n": 0
+    },
+    "buy": {
+      "hit_rate_pct": null,
+      "hits": 0,
+      "n": 0
+    },
+    "evaluated": 0,
+    "hits": 0,
+    "misses": 0,
+    "not_evaluable": 0,
+    "total": 0
+  },
+  "trade_stats": {
+    "avg_holding_days": null,
+    "avg_loss_pct": null,
+    "avg_win_pct": null,
+    "losers": 0,
+    "payoff_ratio": null,
+    "total_closed": 0,
+    "win_rate_pct": null,
+    "winners": 0
+  },
+  "win_rate": null,
+  "worst_trade": null
+}

--- a/tests/fixtures/report_snapshot_v2/weekly.json
+++ b/tests/fixtures/report_snapshot_v2/weekly.json
@@ -1,0 +1,104 @@
+{
+  "bottom_performers": [],
+  "budget": {
+    "available_for_deployment": "900.0000000000",
+    "cash_balance": "1000.000000",
+    "deployed_capital": "1000.000000",
+    "estimated_tax_usd": "0"
+  },
+  "cover": {
+    "benchmark_return": null,
+    "benchmark_si_return": null,
+    "benchmark_ytd_return": null,
+    "bridge": {
+      "broker_adjustments_residual": null,
+      "closing_value": "2100.000000",
+      "net_external_flows": "0.000000",
+      "opening_value": null,
+      "realized_delta": null,
+      "unrealized_delta": null
+    },
+    "cash": "1000.000000",
+    "closing_value": "2100.000000",
+    "display_currency": "USD",
+    "excess_return": null,
+    "mirror_equity": "0.000000",
+    "opening_value": null,
+    "period_return": null,
+    "realized_delta": null,
+    "return_method": "modified_dietz_v1",
+    "si_return": null,
+    "unrealized_delta": null,
+    "ytd_return": null
+  },
+  "generated_at": "2026-06-12T10:49:45.644780+00:00",
+  "holdings": [
+    {
+      "company_name": "Report Co",
+      "cost_basis": "1000.000000",
+      "instrument_id": 789801,
+      "market_value": "1100.000000",
+      "period_contribution": null,
+      "period_contribution_bps": null,
+      "price": "110.000000",
+      "sector": "Technology",
+      "since_entry_return_pct": "0.100000",
+      "symbol": "RPTV2A",
+      "units": "10.000000",
+      "unrealized_pnl": "100.000000",
+      "valuation_source": "quote",
+      "weight_pct": "0.523810"
+    }
+  ],
+  "performance": {
+    "benchmark": {
+      "close_end": null,
+      "close_start": null,
+      "label": "S&P 500 (price index)",
+      "return_pct": null,
+      "symbol": "SPX500"
+    },
+    "fx_mode": "generation_date",
+    "method": "modified_dietz_v1",
+    "observations": 0,
+    "period_return": null,
+    "portfolio_value": "2100.000000"
+  },
+  "period_contribution": {
+    "contributors": [],
+    "drags": []
+  },
+  "period_end": "2026-05-31",
+  "period_start": "2026-05-25",
+  "pnl": {
+    "note": "current-state snapshot, not period delta",
+    "realized_pnl": "0.000000",
+    "total_pnl": "100.000000",
+    "unrealized_pnl": "100.000000"
+  },
+  "positions": [
+    {
+      "company_name": "Report Co",
+      "cost_basis": "1000.000000",
+      "current_units": "10.000000",
+      "instrument_id": 789801,
+      "realized_pnl": "0.000000",
+      "symbol": "RPTV2A",
+      "unrealized_pnl": "100.000000"
+    }
+  ],
+  "positions_closed": [],
+  "positions_opened": [],
+  "report_type": "weekly",
+  "schema_version": 2,
+  "score_changes": [],
+  "top_performers": [
+    {
+      "company_name": "Report Co",
+      "instrument_id": 789801,
+      "symbol": "RPTV2A",
+      "unrealized_pnl": "100.000000"
+    }
+  ],
+  "upcoming_earnings": []
+}

--- a/tests/test_api_portfolio.py
+++ b/tests/test_api_portfolio.py
@@ -122,14 +122,20 @@ def _mock_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
 
 
 def _with_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
-    # The endpoint runs five DB queries in order:
+    # Callers supply results in the legacy logical order:
     #   1. positions  2. cash  3. broker_positions  4. mirror_breakdowns
     #   5. mirror underlying instrument_ids (#502 PR follow-up)
     # Existing callers supply [positions, cash] only — pad with empty
     # broker_positions, mirror_breakdowns, and mirror-underlying results.
+    #
+    # Since #1596 the EXECUTION order differs: compute_portfolio_valuation
+    # runs positions, cash, then mirror_breakdowns (inside the shared
+    # valuation helper), and the endpoint's broker query runs after.
+    # Remap so call sites keep the legacy convention.
     padded = list(cursor_results)
     while len(padded) < 5:
         padded.append([])
+    padded = [padded[0], padded[1], padded[3], padded[2], padded[4]]
     conn = _mock_conn(padded)
 
     def _override() -> Iterator[MagicMock]:
@@ -174,11 +180,11 @@ class TestGetPortfolio:
     def setup_method(self) -> None:
         # Patch FX/config service functions so existing tests (all USD) pass unchanged.
         self._patch_config = patch(
-            "app.api.portfolio.get_runtime_config",
+            "app.services.valuation.get_runtime_config",
             return_value=_DEFAULT_CONFIG,
         )
         self._patch_fx_meta = patch(
-            "app.api.portfolio.load_live_fx_rates_with_metadata",
+            "app.services.valuation.load_live_fx_rates_with_metadata",
             return_value={},
         )
         self._patch_config.start()
@@ -459,11 +465,11 @@ class TestPortfolioFxConversion:
             reason="test",
         )
         self._patch_config = patch(
-            "app.api.portfolio.get_runtime_config",
+            "app.services.valuation.get_runtime_config",
             return_value=gbp_config,
         )
         self._patch_fx_meta = patch(
-            "app.api.portfolio.load_live_fx_rates_with_metadata",
+            "app.services.valuation.load_live_fx_rates_with_metadata",
             return_value={
                 ("USD", "GBP"): {
                     "rate": Decimal("0.78"),
@@ -654,11 +660,11 @@ class TestPortfolioMirrors:
 
     def setup_method(self) -> None:
         self._patch_config = patch(
-            "app.api.portfolio.get_runtime_config",
+            "app.services.valuation.get_runtime_config",
             return_value=_DEFAULT_CONFIG,
         )
         self._patch_fx_meta = patch(
-            "app.api.portfolio.load_live_fx_rates_with_metadata",
+            "app.services.valuation.load_live_fx_rates_with_metadata",
             return_value={},
         )
         self._patch_config.start()

--- a/tests/test_portfolio_valuation.py
+++ b/tests/test_portfolio_valuation.py
@@ -1,4 +1,8 @@
-"""Tests for portfolio valuation hierarchy: quote → daily_close → cost_basis."""
+"""Tests for portfolio valuation hierarchy: quote → daily_close → cost_basis.
+
+The mark-resolution logic moved from `app.api.portfolio._parse_position`
+to `app.services.valuation._holding_from_row` with #1596 (shared
+valuation helper) — same hierarchy, same field names."""
 
 from __future__ import annotations
 
@@ -7,7 +11,7 @@ from decimal import Decimal
 
 import pytest
 
-from app.api.portfolio import _parse_position
+from app.services.valuation import _holding_from_row
 
 
 def _row(
@@ -48,7 +52,7 @@ class TestValuationHierarchy:
         """When quote.last exists, use it regardless of daily_close."""
         row = _row(current_units=10.0, cost_basis=1500.0, last=160.0, daily_close=155.0)
         rates: dict[tuple[str, str], Decimal] = {}
-        pos = _parse_position(row, "USD", rates)
+        pos = _holding_from_row(row, "USD", rates)
 
         assert pos.valuation_source == "quote"
         assert pos.current_price == 160.0
@@ -59,7 +63,7 @@ class TestValuationHierarchy:
         """When no quote but daily_close exists, use daily_close."""
         row = _row(current_units=10.0, cost_basis=1500.0, last=None, daily_close=155.0)
         rates: dict[tuple[str, str], Decimal] = {}
-        pos = _parse_position(row, "USD", rates)
+        pos = _holding_from_row(row, "USD", rates)
 
         assert pos.valuation_source == "daily_close"
         assert pos.current_price == 155.0
@@ -70,7 +74,7 @@ class TestValuationHierarchy:
         """When neither quote nor daily_close exists, fall back to cost_basis."""
         row = _row(current_units=10.0, cost_basis=1500.0, last=None, daily_close=None)
         rates: dict[tuple[str, str], Decimal] = {}
-        pos = _parse_position(row, "USD", rates)
+        pos = _holding_from_row(row, "USD", rates)
 
         assert pos.valuation_source == "cost_basis"
         assert pos.current_price is None
@@ -81,7 +85,7 @@ class TestValuationHierarchy:
         """Daily close values are converted to display currency."""
         row = _row(currency="USD", current_units=10.0, cost_basis=1500.0, daily_close=155.0)
         rates = {("USD", "GBP"): Decimal("0.78")}
-        pos = _parse_position(row, "GBP", rates)
+        pos = _holding_from_row(row, "GBP", rates)
 
         assert pos.valuation_source == "daily_close"
         # current_price = 155 * 0.78 = 120.9
@@ -100,7 +104,7 @@ class TestValuationHierarchy:
         """
         row = _row(current_units=100.0, cost_basis=500.0, last=0.0, daily_close=5.0)
         rates: dict[tuple[str, str], Decimal] = {}
-        pos = _parse_position(row, "USD", rates)
+        pos = _holding_from_row(row, "USD", rates)
 
         assert pos.valuation_source == "daily_close"
         assert pos.market_value == 500.0  # 100 * 5.0, NOT 0
@@ -111,7 +115,7 @@ class TestValuationHierarchy:
         row["bid"] = 697.16
         row["ask"] = 697.22
         rates: dict[tuple[str, str], Decimal] = {}
-        pos = _parse_position(row, "USD", rates)
+        pos = _holding_from_row(row, "USD", rates)
 
         assert pos.valuation_source == "quote"
         assert pos.market_value == pytest.approx(6971.9)  # 10 * 697.19 mid

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -968,3 +968,43 @@ class TestHoldingsSection:
         assert rows[0]["since_entry_return_pct"] is None
         assert rows[0]["weight_pct"] is None
         assert rows[0]["period_contribution"] is None
+
+
+class TestRollingWindowContiguity:
+    """Count alone must not satisfy a rolling window — calendar gaps
+    would let stale returns masquerade as an N-month window."""
+
+    def test_contiguous_months_pass(self) -> None:
+        from app.services.reporting import _is_contiguous_monthly
+
+        window = [
+            {"period_start": date(2026, 3, 1)},
+            {"period_start": date(2026, 4, 1)},
+        ]
+        assert _is_contiguous_monthly(window, date(2026, 5, 1)) is True
+
+    def test_gap_before_current_fails(self) -> None:
+        from app.services.reporting import _is_contiguous_monthly
+
+        window = [{"period_start": date(2026, 2, 1)}]
+        assert _is_contiguous_monthly(window, date(2026, 5, 1)) is False
+
+    def test_gap_inside_window_fails(self) -> None:
+        from app.services.reporting import _is_contiguous_monthly
+
+        window = [
+            {"period_start": date(2026, 1, 1)},
+            {"period_start": date(2026, 4, 1)},
+        ]
+        assert _is_contiguous_monthly(window, date(2026, 5, 1)) is False
+
+    def test_december_january_wrap(self) -> None:
+        from app.services.reporting import _is_contiguous_monthly
+
+        window = [{"period_start": date(2025, 12, 1)}]
+        assert _is_contiguous_monthly(window, date(2026, 1, 1)) is True
+
+    def test_empty_window_is_trivially_contiguous(self) -> None:
+        from app.services.reporting import _is_contiguous_monthly
+
+        assert _is_contiguous_monthly([], date(2026, 5, 1)) is True

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -92,6 +92,35 @@ from app.services.reporting import generate_weekly_report  # noqa: E402
 _REPORTING = "app.services.reporting"
 
 
+def _fake_valuation() -> Any:
+    """Minimal PortfolioValuation for builder tests — the heavy
+    market-data/FX path is exercised separately; builder tests patch
+    `compute_portfolio_valuation` at the boundary (#1596)."""
+    from app.services.valuation import PortfolioValuation
+
+    return PortfolioValuation(
+        display_currency="USD",
+        holdings=(),
+        total_market=0.0,
+        cash_balance=10000.0,
+        mirror_equity=0.0,
+        total_aum=10000.0,
+        raw_rows=(),
+        rates={},
+        rates_meta={},
+        mirror_breakdowns=(),
+    )
+
+
+_NULL_BENCHMARK = {
+    "symbol": "SPX500",
+    "label": "S&P 500 (price index)",
+    "close_start": None,
+    "close_end": None,
+    "return_pct": None,
+}
+
+
 class TestGenerateWeeklyReport:
     def test_returns_weekly_report_structure(self) -> None:
         """Weekly report should contain all expected sections."""
@@ -102,7 +131,11 @@ class TestGenerateWeeklyReport:
         cursor.fetchall.return_value = []
         cursor.fetchone.return_value = {"realized": Decimal("0"), "unrealized": Decimal("0")}
 
-        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+        with (
+            patch(f"{_REPORTING}.compute_budget_state") as mock_budget,
+            patch(f"{_REPORTING}.compute_portfolio_valuation", return_value=_fake_valuation()),
+            patch(f"{_REPORTING}._benchmark_closes", return_value=dict(_NULL_BENCHMARK)),
+        ):
             mock_budget.return_value = MagicMock(
                 cash_balance=Decimal("10000"),
                 deployed_capital=Decimal("5000"),
@@ -118,6 +151,7 @@ class TestGenerateWeeklyReport:
         assert report["report_type"] == "weekly"
         assert report["period_start"] == "2026-04-06"
         assert report["period_end"] == "2026-04-12"
+        assert report["schema_version"] == 2
         assert "pnl" in report
         assert report["pnl"]["note"] == "current-state snapshot, not period delta"
         assert "top_performers" in report
@@ -127,6 +161,15 @@ class TestGenerateWeeklyReport:
         assert "upcoming_earnings" in report
         assert "score_changes" in report
         assert "budget" in report
+        # v2 sections (#1596)
+        assert report["cover"]["closing_value"] == "10000.000000"
+        assert report["cover"]["display_currency"] == "USD"
+        # First v2 snapshot: no prior → no opening value → no return.
+        assert report["cover"]["opening_value"] is None
+        assert report["cover"]["period_return"] is None
+        assert report["performance"]["portfolio_value"] == "10000.000000"
+        assert report["performance"]["fx_mode"] == "generation_date"
+        assert report["holdings"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -150,10 +193,19 @@ class TestGenerateMonthlyReport:
             "positions_attributed": 0,
             "avg_gross": None,
             "avg_market": None,
+            "avg_sector": None,
             "avg_alpha": None,
+            "avg_timing": None,
+            "avg_cost_drag": None,
+            "fill_count": 0,
+            "fees_total": Decimal("0"),
         }
 
-        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+        with (
+            patch(f"{_REPORTING}.compute_budget_state") as mock_budget,
+            patch(f"{_REPORTING}.compute_portfolio_valuation", return_value=_fake_valuation()),
+            patch(f"{_REPORTING}._benchmark_closes", return_value=dict(_NULL_BENCHMARK)),
+        ):
             mock_budget.return_value = MagicMock(
                 cash_balance=Decimal("10000"),
                 deployed_capital=Decimal("5000"),
@@ -171,6 +223,7 @@ class TestGenerateMonthlyReport:
         assert report["report_type"] == "monthly"
         assert report["period_start"] == "2026-03-01"
         assert report["period_end"] == "2026-03-31"
+        assert report["schema_version"] == 2
         assert "position_pnl" in report
         assert "win_rate" in report
         assert "avg_holding_days" in report
@@ -179,6 +232,19 @@ class TestGenerateMonthlyReport:
         assert "attribution_summary" in report
         assert "thesis_accuracy" in report
         assert "tax_provision" in report
+        # v2 sections (#1596)
+        assert "cover" in report
+        assert "performance" in report
+        assert "holdings" in report
+        assert "rolling_returns" in report
+        assert set(report["rolling_returns"].keys()) == {"1m", "3m", "6m", "1y", "si"}
+        assert report["income"]["items"] == []
+        assert report["costs"]["fill_count"] == 0
+        assert report["risk"]["insufficient_history"] is True
+        assert report["thesis_summary"]["total"] == 0
+        # score_changes was weekly-only pre-#1596 (committee finding).
+        assert "score_changes" in report
+        assert report["trade_stats"]["payoff_ratio"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +452,11 @@ class TestJsonSerializability:
         cursor.fetchall.return_value = []
         cursor.fetchone.return_value = {"realized": Decimal("0"), "unrealized": Decimal("0")}
 
-        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+        with (
+            patch(f"{_REPORTING}.compute_budget_state") as mock_budget,
+            patch(f"{_REPORTING}.compute_portfolio_valuation", return_value=_fake_valuation()),
+            patch(f"{_REPORTING}._benchmark_closes", return_value=dict(_NULL_BENCHMARK)),
+        ):
             mock_budget.return_value = MagicMock(
                 cash_balance=Decimal("10000"),
                 deployed_capital=Decimal("5000"),
@@ -417,10 +487,19 @@ class TestJsonSerializability:
             "positions_attributed": 0,
             "avg_gross": None,
             "avg_market": None,
+            "avg_sector": None,
             "avg_alpha": None,
+            "avg_timing": None,
+            "avg_cost_drag": None,
+            "fill_count": 0,
+            "fees_total": Decimal("0"),
         }
 
-        with patch(f"{_REPORTING}.compute_budget_state") as mock_budget:
+        with (
+            patch(f"{_REPORTING}.compute_budget_state") as mock_budget,
+            patch(f"{_REPORTING}.compute_portfolio_valuation", return_value=_fake_valuation()),
+            patch(f"{_REPORTING}._benchmark_closes", return_value=dict(_NULL_BENCHMARK)),
+        ):
             mock_budget.return_value = MagicMock(
                 cash_balance=Decimal("10000"),
                 deployed_capital=Decimal("5000"),
@@ -593,3 +672,299 @@ class TestComputeContributors:
         assert [r["symbol"] for r in result["contributors"]] == ["S10", "S8", "S6"]
         # Drags sorted ascending by delta — most-negative first.
         assert [r["symbol"] for r in result["drags"]] == ["S9", "S7", "S5"]
+
+
+# ---------------------------------------------------------------------------
+# v2 sections (#1596 — spec docs/proposals/ui/2026-06-12-report-ia.md)
+# ---------------------------------------------------------------------------
+
+from app.services.reporting import (  # noqa: E402
+    _chain_link,
+    _holdings_section,
+    _modified_dietz,
+    _risk_section,
+    _thesis_summary,
+)
+from app.services.valuation import HoldingValuation, PortfolioValuation  # noqa: E402
+
+
+def _holding(
+    *,
+    instrument_id: int = 1,
+    symbol: str = "AAPL",
+    sector: str | None = "Technology",
+    cost_basis: float = 1000.0,
+    market_value: float = 1100.0,
+    units: float = 10.0,
+) -> HoldingValuation:
+    return HoldingValuation(
+        instrument_id=instrument_id,
+        symbol=symbol,
+        company_name=f"{symbol} Inc",
+        sector=sector,
+        native_currency="USD",
+        open_date=date(2026, 1, 5),
+        source="ebull",
+        updated_at=datetime(2026, 6, 1, tzinfo=UTC),
+        avg_cost=cost_basis / units if units else None,
+        current_units=units,
+        cost_basis=cost_basis,
+        current_price=market_value / units if units else None,
+        market_value=market_value,
+        unrealized_pnl=market_value - cost_basis,
+        valuation_source="quote",
+    )
+
+
+def _valuation_with(holdings: tuple[HoldingValuation, ...], *, cash: float = 500.0) -> PortfolioValuation:
+    total_market = sum(h.market_value for h in holdings)
+    return PortfolioValuation(
+        display_currency="USD",
+        holdings=holdings,
+        total_market=total_market,
+        cash_balance=cash,
+        mirror_equity=0.0,
+        total_aum=total_market + cash,
+        raw_rows=(),
+        rates={},
+        rates_meta={},
+        mirror_breakdowns=(),
+    )
+
+
+class TestModifiedDietz:
+    """Flow-adjusted period return (spec §3.4). The business boundary:
+    a deposit must NEVER print as performance."""
+
+    START = date(2026, 6, 1)
+    END = date(2026, 6, 30)
+
+    def test_no_flows_degenerates_to_simple_ratio(self) -> None:
+        r = _modified_dietz(Decimal("1000"), Decimal("1100"), [], self.START, self.END)
+        assert r == Decimal("0.1")
+
+    def test_deposit_is_not_performance(self) -> None:
+        """1000 → 2000 purely via a 1000 injection = 0% return, not 100%."""
+        flows = [(date(2026, 6, 1), Decimal("1000"))]
+        r = _modified_dietz(Decimal("1000"), Decimal("2000"), flows, self.START, self.END)
+        assert r == Decimal("0")
+
+    def test_withdrawal_is_not_a_loss(self) -> None:
+        """1000 → 500 purely via a 500 withdrawal = 0% return, not −50%."""
+        flows = [(date(2026, 6, 30), Decimal("-500"))]
+        r = _modified_dietz(Decimal("1000"), Decimal("500"), flows, self.START, self.END)
+        assert r == Decimal("0")
+
+    def test_mid_period_flow_is_time_weighted(self) -> None:
+        """A flow landing mid-period only counts for the remaining
+        fraction of the period in the denominator."""
+        # 30-day June: flow on the 16th → 15 days remain → w = 0.5.
+        flows = [(date(2026, 6, 16), Decimal("1000"))]
+        r = _modified_dietz(Decimal("1000"), Decimal("2100"), flows, self.START, self.END)
+        # (2100 − 1000 − 1000) / (1000 + 1000×0.5) = 100 / 1500
+        assert r == Decimal("100") / Decimal("1500")
+
+    def test_none_opening_value_returns_none(self) -> None:
+        assert _modified_dietz(None, Decimal("1000"), [], self.START, self.END) is None
+
+    def test_non_positive_denominator_returns_none(self) -> None:
+        """Account funded entirely mid-period: opening 0 → denominator
+        can be ≤ 0 → a return figure would be meaningless."""
+        flows = [(date(2026, 6, 30), Decimal("-2000"))]
+        r = _modified_dietz(Decimal("0"), Decimal("100"), flows, self.START, self.END)
+        assert r is None
+
+
+class TestChainLink:
+    def test_empty_returns_none(self) -> None:
+        assert _chain_link([]) is None
+
+    def test_single_return_round_trips(self) -> None:
+        assert _chain_link([Decimal("0.1")]) == Decimal("0.1")
+
+    def test_geometric_not_additive(self) -> None:
+        # (1.1 × 0.9) − 1 = −0.01, NOT 0.
+        r = _chain_link([Decimal("0.1"), Decimal("-0.1")])
+        assert r == Decimal("-0.01")
+
+
+class TestThesisSummary:
+    def test_empty_rows(self) -> None:
+        s = _thesis_summary([])
+        assert s["total"] == 0
+        assert s["buy"]["hit_rate_pct"] is None
+
+    def test_buckets_and_not_evaluable(self) -> None:
+        rows = [
+            {"stance": "buy", "target_hit": "bull"},
+            {"stance": "buy", "target_hit": "base"},
+            {"stance": "buy", "target_hit": "between_bear_and_base"},
+            {"stance": "buy", "target_hit": None},  # not yet evaluable
+            {"stance": "avoid", "target_hit": "bear"},
+        ]
+        s = _thesis_summary(rows)
+        assert s["total"] == 5
+        assert s["evaluated"] == 4
+        assert s["not_evaluable"] == 1
+        assert s["hits"] == 2
+        assert s["misses"] == 2
+        assert s["buy"] == {"n": 3, "hits": 2, "hit_rate_pct": "66.67"}
+        assert s["avoid"]["n"] == 1
+
+
+class TestRiskSection:
+    def test_insufficient_history_below_min_observations(self) -> None:
+        val = _valuation_with((_holding(),))
+        risk = _risk_section(val, [], Decimal("0.05"), observation_label="test")
+        assert risk["insufficient_history"] is True
+        assert risk["volatility"] is None
+        assert risk["max_drawdown"] is None
+        assert risk["observations"] == 1
+
+    def test_concentration_and_sector_always_computable(self) -> None:
+        holdings = (
+            _holding(instrument_id=1, symbol="AAPL", market_value=600.0, sector="Technology"),
+            _holding(instrument_id=2, symbol="JPM", market_value=300.0, sector="Financials"),
+            _holding(instrument_id=3, symbol="XOM", market_value=100.0, sector=None),
+        )
+        val = _valuation_with(holdings, cash=0.0)
+        risk = _risk_section(val, [], None, observation_label="test")
+        assert risk["holding_count"] == 3
+        # 3 holdings → top-5 = everything = 100%.
+        assert Decimal(risk["concentration_top5_pct"]) == Decimal("1")
+        assert Decimal(risk["sector_exposure"]["Technology"]) == Decimal("0.6")
+        assert "Unknown" in risk["sector_exposure"]
+
+    def test_drawdown_and_volatility_over_full_chain(self) -> None:
+        chain = [
+            {"period_start": date(2026, 1, 1), "period_return": Decimal(v), "display_currency": "USD"}
+            for v in ("0.10", "-0.20", "0.05", "0.05", "0.05")
+        ]
+        val = _valuation_with((_holding(),))
+        risk = _risk_section(val, chain, Decimal("0.05"), observation_label="test")
+        assert risk["observations"] == 6
+        assert risk["insufficient_history"] is False
+        # Max drawdown: peak after +10% = 1.1, trough after −20% = 0.88
+        # → 0.88/1.1 − 1 = −0.2.
+        assert Decimal(risk["max_drawdown"]) == Decimal("-0.2")
+        assert risk["volatility"] is not None
+
+    def test_chain_rows_in_other_display_currency_excluded(self) -> None:
+        chain = [
+            {"period_start": date(2026, 1, 1), "period_return": Decimal("0.1"), "display_currency": "GBP"}
+            for _ in range(10)
+        ]
+        val = _valuation_with((_holding(),))
+        risk = _risk_section(val, chain, None, observation_label="test")
+        assert risk["observations"] == 0
+        assert risk["insufficient_history"] is True
+
+
+class TestComputeContributorsRealizedFold:
+    """#1596 spec §4.4: realised deltas fold into period contribution.
+    Pre-#1596 the chart was unrealised-open-only — a position closed
+    mid-period vanished; a trim read as a phantom loss."""
+
+    def test_trim_with_realised_gain_is_not_a_phantom_drag(self) -> None:
+        """Sell half at a profit: unrealised drops 50, realised rises 60
+        → net +10 contributor, not a −50 drag."""
+        prior = [
+            {
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "unrealized_pnl": "100",
+                "cost_basis": "1000",
+                "realized_pnl": "0",
+            }
+        ]
+        current = [
+            {
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "unrealized_pnl": "50",
+                "cost_basis": "500",
+                "realized_pnl": "60",
+            }
+        ]
+        realized_now = {1: {"symbol": "AAPL", "realized_pnl": Decimal("60")}}
+        result = _compute_contributors(current, prior, realized_now=realized_now)
+        assert len(result["contributors"]) == 1
+        assert result["contributors"][0]["pnl_delta"] == "10"
+        assert result["drags"] == []
+
+    def test_position_closed_in_period_still_contributes(self) -> None:
+        """Closed position: prior unrealised 100 converts to realised
+        120 → net +20 contributor despite being absent from current."""
+        prior = [
+            {
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "unrealized_pnl": "100",
+                "cost_basis": "1000",
+                "realized_pnl": "0",
+            }
+        ]
+        realized_now = {1: {"symbol": "AAPL", "realized_pnl": Decimal("120")}}
+        result = _compute_contributors([], prior, realized_now=realized_now)
+        assert len(result["contributors"]) == 1
+        assert result["contributors"][0]["symbol"] == "AAPL"
+        assert result["contributors"][0]["pnl_delta"] == "20"
+
+    def test_v1_prior_without_realized_keeps_legacy_behavior(self) -> None:
+        """Prior snapshot rows without `realized_pnl` (v1) must not
+        invent realised deltas — unrealised-only diff, closed
+        positions skipped."""
+        prior = [
+            {"instrument_id": 1, "symbol": "AAPL", "unrealized_pnl": "100", "cost_basis": "1000"},
+            {"instrument_id": 2, "symbol": "MSFT", "unrealized_pnl": "50", "cost_basis": "500"},
+        ]
+        current = [
+            {"instrument_id": 1, "symbol": "AAPL", "unrealized_pnl": "150", "cost_basis": "1000"},
+        ]
+        realized_now = {
+            1: {"symbol": "AAPL", "realized_pnl": Decimal("999")},
+            2: {"symbol": "MSFT", "realized_pnl": Decimal("999")},
+        }
+        result = _compute_contributors(current, prior, realized_now=realized_now)
+        assert len(result["contributors"]) == 1
+        assert result["contributors"][0]["pnl_delta"] == "50"
+        # MSFT closed but prior row is v1 (no realised baseline) → skipped.
+        assert result["drags"] == []
+
+
+class TestHoldingsSection:
+    def test_weights_since_entry_and_contribution(self) -> None:
+        holdings = (
+            _holding(instrument_id=1, symbol="AAPL", cost_basis=800.0, market_value=900.0),
+            _holding(instrument_id=2, symbol="JPM", cost_basis=100.0, market_value=100.0),
+        )
+        val = _valuation_with(holdings, cash=0.0)
+        prior_positions = [
+            {
+                "instrument_id": 1,
+                "symbol": "AAPL",
+                "unrealized_pnl": "60",
+                "cost_basis": "800",
+                "realized_pnl": "0",
+            }
+        ]
+        realized_now = {1: {"symbol": "AAPL", "realized_pnl": Decimal("0")}}
+        rows = _holdings_section(val, prior_positions, realized_now, Decimal("1000"))
+        assert [r["symbol"] for r in rows] == ["AAPL", "JPM"]
+        aapl = rows[0]
+        assert aapl["weight_pct"] == "0.900000"
+        assert aapl["since_entry_return_pct"] == "0.125000"
+        # Unrealised now 100 vs prior 60 → +40 period contribution.
+        assert aapl["period_contribution"] == "40.000000"
+        # 40 / 1000 opening value = 400 bps.
+        assert aapl["period_contribution_bps"] == "400.000000"
+        # New position this period: no prior row → null contribution.
+        assert rows[1]["period_contribution"] is None
+
+    def test_no_prior_and_zero_cost_are_null_safe(self) -> None:
+        holdings = (_holding(cost_basis=0.0, market_value=0.0, units=0.0),)
+        val = _valuation_with(holdings, cash=0.0)
+        rows = _holdings_section(val, None, {}, None)
+        assert rows[0]["since_entry_return_pct"] is None
+        assert rows[0]["weight_pct"] is None
+        assert rows[0]["period_contribution"] is None

--- a/tests/test_reporting_v2_db.py
+++ b/tests/test_reporting_v2_db.py
@@ -1,0 +1,213 @@
+"""DB-backed contract tests for the v2 report snapshot (#1596).
+
+Pins the three things the pure-logic tests cannot:
+
+1. **Valuation parity** (spec §3.3): the report cover's closing value
+   equals `compute_portfolio_valuation().total_aum` on the same
+   connection — by construction, since the builder calls the same
+   helper as the dashboard endpoint, but this test guards against the
+   paths re-forking.
+2. **Flow-adjusted return end-to-end** (spec §3.4): a `capital_events`
+   injection between two snapshots does NOT print as performance.
+3. **The v2 fixture** consumed by child 2's `SnapshotV2` type test is
+   backend-emitted, never handwritten: run with
+   ``REPORT_FIXTURE_WRITE=1`` to regenerate
+   ``tests/fixtures/report_snapshot_v2/*.json``; by default the test
+   asserts the checked-in fixtures' key structure still matches what
+   the builders emit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import psycopg
+
+from app.services.reporting import (
+    generate_monthly_report,
+    generate_weekly_report,
+    persist_report_snapshot,
+)
+from app.services.valuation import compute_portfolio_valuation
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "report_snapshot_v2"
+
+_PERIOD_A = (date(2026, 5, 25), date(2026, 5, 31))
+_PERIOD_B = (date(2026, 6, 1), date(2026, 6, 7))
+_MONTH = (date(2026, 5, 1), date(2026, 5, 31))
+
+
+def _seed_portfolio(conn: psycopg.Connection[tuple]) -> None:
+    """One USD instrument, 10 units @ 100 cost, marked 110 via quote,
+    1000 cash. total_aum = 10×110 + 1000 = 2100 (display ccy pinned
+    to USD so no FX conversion enters the arithmetic)."""
+    conn.execute("UPDATE runtime_config SET display_currency = 'USD' WHERE id = TRUE")
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, sector, is_tradable)
+        VALUES (789801, 'RPTV2A', 'Report Co', '4', 'USD', 'Technology', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO positions (instrument_id, open_date, avg_cost, current_units,
+                               cost_basis, realized_pnl, unrealized_pnl, source)
+        VALUES (789801, '2026-05-01', 100, 10, 1000, 0, 100, 'ebull')
+        ON CONFLICT (instrument_id) DO UPDATE
+        SET current_units = EXCLUDED.current_units,
+            cost_basis = EXCLUDED.cost_basis,
+            realized_pnl = EXCLUDED.realized_pnl,
+            unrealized_pnl = EXCLUDED.unrealized_pnl
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO quotes (instrument_id, last, bid, ask, quoted_at)
+        VALUES (789801, 110, 109.9, 110.1, NOW())
+        ON CONFLICT (instrument_id) DO UPDATE SET last = EXCLUDED.last
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO cash_ledger (event_time, event_type, amount, currency, note)
+        VALUES ('2026-05-01T00:00:00Z', 'broker_sync', 1000, 'USD', 'test seed')
+        """
+    )
+    conn.commit()
+
+
+def test_weekly_v2_first_snapshot_parity(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    conn = ebull_test_conn
+    _seed_portfolio(conn)
+
+    report = generate_weekly_report(conn, period_start=_PERIOD_A[0], period_end=_PERIOD_A[1])
+    val = compute_portfolio_valuation(conn)
+
+    assert report["schema_version"] == 2
+    # Parity: cover closing value == the dashboard's valuation basis.
+    assert Decimal(report["cover"]["closing_value"]) == Decimal(str(val.total_aum))
+    assert Decimal(report["cover"]["closing_value"]) == Decimal("2100")
+    assert report["cover"]["display_currency"] == "USD"
+    # First v2 snapshot: no opening value, no return — never a fake 0%.
+    assert report["cover"]["opening_value"] is None
+    assert report["cover"]["period_return"] is None
+    # Benchmark instrument not seeded → null-safe (spec §7).
+    assert report["performance"]["benchmark"]["return_pct"] is None
+    # Holdings row reflects the seeded mark.
+    (holding,) = report["holdings"]
+    assert holding["symbol"] == "RPTV2A"
+    assert Decimal(holding["market_value"]) == Decimal("1100")
+    assert Decimal(holding["since_entry_return_pct"]) == Decimal("0.1")
+    assert holding["valuation_source"] == "quote"
+
+
+def test_weekly_v2_flow_adjusted_return(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    """A deposit between snapshots is NOT performance: value moves
+    2100 → 3150 where 1000 is an injection on the first day of the
+    period and 50 is genuine price P&L. Modified Dietz:
+    (3150 − 2100 − 1000) / (2100 + 1000×1.0) = 50/3100."""
+    conn = ebull_test_conn
+    _seed_portfolio(conn)
+
+    snap_a = generate_weekly_report(conn, period_start=_PERIOD_A[0], period_end=_PERIOD_A[1])
+    persist_report_snapshot(
+        conn,
+        report_type="weekly",
+        period_start=_PERIOD_A[0],
+        period_end=_PERIOD_A[1],
+        snapshot=snap_a,
+    )
+    conn.commit()
+
+    # Period B: 1000 injection lands day 1 (w = 1.0), price 110 → 115
+    # (+50 unrealised), cash +1000.
+    conn.execute(
+        """
+        INSERT INTO capital_events (event_time, event_type, amount, currency, source, note)
+        VALUES ('2026-06-01T09:00:00Z', 'injection', 1000, 'USD', 'operator', 'test')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO cash_ledger (event_time, event_type, amount, currency, note)
+        VALUES ('2026-06-01T09:00:00Z', 'broker_sync', 1000, 'USD', 'mirror of injection')
+        """
+    )
+    conn.execute("UPDATE quotes SET last = 115, bid = 114.9, ask = 115.1 WHERE instrument_id = 789801")
+    conn.execute("UPDATE positions SET unrealized_pnl = 150 WHERE instrument_id = 789801")
+    conn.commit()
+
+    report = generate_weekly_report(conn, period_start=_PERIOD_B[0], period_end=_PERIOD_B[1])
+
+    assert Decimal(report["cover"]["opening_value"]) == Decimal("2100")
+    assert Decimal(report["cover"]["closing_value"]) == Decimal("3150")
+    assert Decimal(report["cover"]["bridge"]["net_external_flows"]) == Decimal("1000")
+    # (3150 − 2100 − 1000) / (2100 + 1000) = 50 / 3100 ≈ 0.016129 —
+    # NOT (3150/2100 − 1) = 50%.
+    assert Decimal(report["cover"]["period_return"]) == (Decimal("50") / Decimal("3100")).quantize(Decimal("0.000001"))
+    # Bridge closes: unrealised moved +50, realised 0, residual 0
+    # (the injection's cash twin is classified as a flow, not P&L).
+    assert Decimal(report["cover"]["bridge"]["unrealized_delta"]) == Decimal("50")
+    assert Decimal(report["cover"]["bridge"]["realized_delta"]) == Decimal("0")
+    assert Decimal(report["cover"]["bridge"]["broker_adjustments_residual"]) == Decimal("0")
+
+
+def test_benchmark_resolved_by_symbol(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    """Benchmark closes resolve by symbol at generation; period return
+    uses the last close strictly before period_start as baseline."""
+    conn = ebull_test_conn
+    _seed_portfolio(conn)
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (789802, 'SPX500', 'S&P 500 Index', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO price_daily (instrument_id, price_date, close)
+        VALUES (789802, '2026-05-29', 5000), (789802, '2026-06-05', 5100)
+        ON CONFLICT (instrument_id, price_date) DO UPDATE SET close = EXCLUDED.close
+        """
+    )
+    conn.commit()
+
+    report = generate_weekly_report(conn, period_start=_PERIOD_B[0], period_end=_PERIOD_B[1])
+    benchmark = report["performance"]["benchmark"]
+    assert benchmark["symbol"] == "SPX500"
+    assert Decimal(benchmark["close_start"]) == Decimal("5000")
+    assert Decimal(benchmark["close_end"]) == Decimal("5100")
+    # 5100/5000 − 1 = 0.02
+    assert Decimal(benchmark["return_pct"]) == Decimal("0.02")
+
+
+def test_v2_fixture_is_backend_emitted(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    """The SnapshotV2 fixture for child 2's FE type test is generated
+    by the real builders. ``REPORT_FIXTURE_WRITE=1`` regenerates the
+    files; the default run asserts the checked-in fixtures still carry
+    exactly the keys the builders emit (drift = this test fails before
+    the FE types rot)."""
+    conn = ebull_test_conn
+    _seed_portfolio(conn)
+
+    weekly = generate_weekly_report(conn, period_start=_PERIOD_A[0], period_end=_PERIOD_A[1])
+    monthly = generate_monthly_report(conn, period_start=_MONTH[0], period_end=_MONTH[1])
+
+    if os.environ.get("REPORT_FIXTURE_WRITE") == "1":
+        _FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+        (_FIXTURE_DIR / "weekly.json").write_text(json.dumps(weekly, indent=2, sort_keys=True) + "\n")
+        (_FIXTURE_DIR / "monthly.json").write_text(json.dumps(monthly, indent=2, sort_keys=True) + "\n")
+
+    for name, generated in (("weekly", weekly), ("monthly", monthly)):
+        fixture = json.loads((_FIXTURE_DIR / f"{name}.json").read_text())
+        assert set(fixture.keys()) == set(generated.keys()), name
+        assert set(fixture["cover"].keys()) == set(generated["cover"].keys()), name
+        assert set(fixture["performance"].keys()) == set(generated["performance"].keys()), name
+        assert set(fixture["cover"]["bridge"].keys()) == set(generated["cover"]["bridge"].keys()), name


### PR DESCRIPTION
## What

Child 3 of the reports-overhaul epic #1592, implementing the **operator-signed-off spec** [docs/proposals/ui/2026-06-12-report-ia.md](docs/proposals/ui/2026-06-12-report-ia.md) (v2, post 5-lens committee round — quant, broker-report, UI, grounding, Codex CTO; raw memos in session memory). Data contract ships **before** the FE child per spec §8 so child 2 renders real builder JSON. Closes #1596.

### Shared valuation (spec §3.3 — dashboard/report parity by construction)

New `app/services/valuation.py::compute_portfolio_valuation` owns the whole-account valuation: per-position mark-to-market (quote → daily close → cost basis, #1428 hierarchy preserved verbatim), cash, **mirror equity**, `total_aum`. `get_portfolio` now consumes it (the endpoint keeps broker-trade detail, per-mirror rows, `fx_rates_used` — all driven off the helper's raw rows), and the report builders call the same function — the report cover and the dashboard headline are one code path. `resolve_quote_price`/`parse_optional_float` moved into the service layer; `app/api/_helpers` re-exports so 8 API modules keep their imports.

### Snapshot v2 keys (both builders, `schema_version: 2`)

- **`cover`**: closing/opening value, **Modified Dietz flow-adjusted period return** over `capital_events` injections/withdrawals (spec §3.4 — a deposit must never print as performance; `tax_provision`/`tax_release` are internal earmarks, excluded), benchmark/excess/YTD/since-inception returns, value bridge (opening + flows + realised Δ + unrealised Δ + "broker adjustments (unitemised)" residual = closing). Display-currency change between periods suppresses the return instead of mixing bases.
- **`performance`**: single-period point — portfolio value, period return, benchmark close/return **resolved by symbol** (`SPX500`), null-safe when missing; `fx_mode: generation_date`. The trailing chart is an FE assembly of immutable per-period points (spec §3.1).
- **`holdings`**: units/price/market value/weight (vs total_aum)/since-entry return/period contribution (realised + unrealised) + bps vs opening value/valuation source.
- **Monthly only**: `income` (declared DPS × period-end units — estimated, basis stamped), `costs` (own-path `fills.fees`), `risk` (volatility + max drawdown over the FULL snapshot-return chain with an n≥6 gate — never single-period noise; concentration; sector exposure; explicitly NO Sharpe/Sortino per spec §4.9), `rolling_returns` (1m/3m/6m/1y/si — full-window AND calendar-contiguous only), `thesis_summary` (hit/miss/**not-evaluable** buckets + per-stance rates), `trade_stats` (payoff ratio, win/loss averages, denominators), `score_changes` (was weekly-only — committee finding).

### Committee/Codex findings fixed in the legacy sections

- `_compute_contributors` folds **realised deltas**: a trim is no longer a phantom drag; a position closed mid-period still contributes (prior unrealised converts to realised). v1 priors (no realised baseline) keep the old behaviour — no invented deltas.
- `_period_attribution` surfaces `timing_alpha_pct` + `cost_drag_pct` (stored in `return_attribution` all along, silently dropped) + `weighting: equal` label.
- `_positions_opened_closed` rows carry `fees`; positions snapshot rows carry `realized_pnl`/`current_units` for next-period diffs (additive — v1 readers unaffected).

## Security model

No auth changes; no new endpoints. Builders are read-only over existing tables (`positions`, `fills`, `capital_events`, `price_daily`, `dividend_events`, `return_attribution`, `report_snapshots`); the only write path is the pre-existing `persist_report_snapshot` upsert. All SQL parameterised; the one f-string in `_benchmark_closes` interpolates a two-value comparison-operator literal chosen in code (commented, `noqa: S608`). The `get_portfolio` refactor moves code between layers without changing its query shapes or auth dependency.

## Conscious tradeoffs (documented in code + spec §7)

- **Flow-recording skew** (Codex ckpt-2 HIGH, accepted as documented behaviour): flows count when recorded in `capital_events`; cash reaches valuation via broker sync. A boundary-straddling pair under/overstates one period and symmetrically corrects the next — and it is loud, not silent: it shows as a non-zero bridge residual. In normal operation the ledgers are in sync.
- **Intra-period round trips**: open+close within one period has no snapshot baseline on either side → cover aggregate only, per-instrument attribution waits for the #1593 ledger.
- **Benchmark span vs chain** + **rolling-window contiguity**: both Codex ckpt-2 MEDs fixed in code (currency-filtered SI span; `_is_contiguous_monthly` gate with Dec→Jan wrap test).
- `_benchmark_closes` is called several times per generation (cover + SI + YTD + rolling spans) — repeated instrument resolution; acceptable for an on-demand monthly job, noted for the record.

## Verification

- `uv run ruff check .` / `format --check` — clean; `uv run pyright` — 0 errors
- `uv run pytest -m "not db"` — **3884 passed** (new: Dietz table tests incl. deposit≠performance + withdrawal≠loss + mid-period weighting; chain-link; risk min-n/currency-exclusion/drawdown math; thesis buckets; contributors realised-fold incl. closed-position + v1-back-compat; holdings null-safety; rolling contiguity incl. Dec→Jan)
- `uv run pytest tests/smoke` — 129 passed
- Deliberate db-tier runs: `tests/test_reporting_v2_db.py` (4 — **valuation parity**, end-to-end flow-adjusted return 50/3100 with bridge closure, benchmark-by-symbol, fixture shape) + `tests/test_api_portfolio.py` (37) + mirror/guard/valuation files (23)
- **Backend-emitted SnapshotV2 fixtures** at `tests/fixtures/report_snapshot_v2/` (regenerate: `REPORT_FIXTURE_WRITE=1`) — child 2's FE type test consumes these, never handwritten samples
- `tests/test_api_portfolio.py` mocks re-pointed to `app.services.valuation` (patch-at-point-of-use) with the post-refactor query-order remap documented in `_with_conn`
- Codex ckpt-2: 1 HIGH + 3 MED — 2 fixed in code, 2 documented (above); post-merge dev verify (regenerate current week + month, check parity on live endpoint) to follow in PR comments

Part of #1592. Closes #1596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)