### PR TITLE
fix(#1598): eToro sector key casing — stocksIndustryID, 0-sentinel, id→name at snapshot generation

### DIFF
--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -345,7 +345,9 @@ def _normalise_instrument(item: Mapping[str, object]) -> InstrumentRecord | None
         # universe.py derives it from the operator-curated exchanges.currency
         # via the exchange join (same as country) — sql/159, #1431.
         currency=None,
-        sector=_str_or_none(item.get("stocksIndustryId")),
+        # Key is capital-ID like every sibling (instrumentID, exchangeID);
+        # 0 is eToro's FX/commodity "no industry" sentinel → None (#1598).
+        sector=_str_or_none(_int_or_none(item.get("stocksIndustryID"))),
         industry=None,  # secondary lookup deferred
         country=None,  # not available in instruments endpoint
         is_tradable=True,  # only tradable instruments are returned by the API

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -1282,7 +1282,10 @@ def _holdings_section(
                 "instrument_id": h.instrument_id,
                 "symbol": h.symbol,
                 "company_name": h.company_name,
-                "sector": h.sector,
+                # Resolved name, not the raw numeric industry id (#1598).
+                # None when the instrument has no sector or the id is
+                # unmapped — the FE renders its nil treatment.
+                "sector": h.sector_name,
                 "units": _dec_f(h.current_units),
                 "price": _dec_f(h.current_price),
                 "market_value": _dec_f(h.market_value),
@@ -1405,7 +1408,17 @@ def _risk_section(
 
     sector_weights: dict[str, Decimal] = {}
     for h in valuation.holdings:
-        sector = h.sector or "Unknown"
+        # instruments.sector stores eToro's numeric industry id; the name
+        # is resolved in the valuation query via etoro_stocks_industries
+        # (#1598). An id with no catalogue row folds into "Unknown" — warn
+        # so catalogue drift surfaces before it skews the exposure table.
+        if h.sector is not None and h.sector_name is None:
+            logger.warning(
+                "sector id %s on %s has no etoro_stocks_industries row; grouped as Unknown",
+                h.sector,
+                h.symbol,
+            )
+        sector = h.sector_name or "Unknown"
         sector_weights[sector] = sector_weights.get(sector, Decimal(0)) + Decimal(str(h.market_value))
     sector_exposure = (
         {s: _dec_q(w / total_aum) for s, w in sorted(sector_weights.items(), key=lambda kv: kv[1], reverse=True)}

--- a/app/services/valuation.py
+++ b/app/services/valuation.py
@@ -78,7 +78,8 @@ class HoldingValuation:
     instrument_id: int
     symbol: str
     company_name: str
-    sector: str | None
+    sector: str | None  # eToro numeric industry id, as text (provider contract)
+    sector_name: str | None  # resolved via etoro_stocks_industries; None if unmapped
     native_currency: str
     open_date: date | None
     source: PositionSource  # positions.source is NOT NULL + CHECK-constrained
@@ -115,12 +116,14 @@ class PortfolioValuation:
 
 _POSITIONS_SQL = """
     SELECT p.instrument_id, i.symbol, i.company_name, i.currency, i.sector,
+           esi.name AS sector_name,
            p.open_date, p.avg_cost, p.current_units, p.cost_basis,
            p.source, p.updated_at,
            q.last, q.bid, q.ask,
            pd.close AS daily_close
     FROM positions p
     JOIN instruments i USING (instrument_id)
+    LEFT JOIN etoro_stocks_industries esi ON esi.industry_id::text = i.sector
     LEFT JOIN quotes q USING (instrument_id)
     LEFT JOIN LATERAL (
         SELECT close
@@ -210,6 +213,7 @@ def _holding_from_row(
         symbol=row["symbol"],
         company_name=row["company_name"],
         sector=row.get("sector"),
+        sector_name=row.get("sector_name"),
         native_currency=native_currency,
         open_date=row["open_date"],
         source=row["source"],

--- a/tests/fixtures/report_snapshot_v2/monthly.json
+++ b/tests/fixtures/report_snapshot_v2/monthly.json
@@ -41,7 +41,7 @@
     "unrealized_delta": null,
     "ytd_return": null
   },
-  "generated_at": "2026-06-12T10:49:45.667501+00:00",
+  "generated_at": "2026-06-12T14:36:07.046550+00:00",
   "holdings": [
     {
       "company_name": "Report Co",

--- a/tests/fixtures/report_snapshot_v2/weekly.json
+++ b/tests/fixtures/report_snapshot_v2/weekly.json
@@ -31,7 +31,7 @@
     "unrealized_delta": null,
     "ytd_return": null
   },
-  "generated_at": "2026-06-12T10:49:45.644780+00:00",
+  "generated_at": "2026-06-12T14:36:07.028063+00:00",
   "holdings": [
     {
       "company_name": "Report Co",

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -47,7 +47,7 @@ FIXTURE_INSTRUMENT = {
     "symbolFull": "AAPL",
     "instrumentDisplayName": "Apple",
     "exchangeID": 10,
-    "stocksIndustryId": 42,
+    "stocksIndustryID": 42,
     "priceSource": "Nasdaq",
     "isInternalInstrument": False,
 }

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
@@ -692,7 +693,8 @@ def _holding(
     *,
     instrument_id: int = 1,
     symbol: str = "AAPL",
-    sector: str | None = "Technology",
+    sector: str | None = "42",
+    sector_name: str | None = "Technology",
     cost_basis: float = 1000.0,
     market_value: float = 1100.0,
     units: float = 10.0,
@@ -702,6 +704,7 @@ def _holding(
         symbol=symbol,
         company_name=f"{symbol} Inc",
         sector=sector,
+        sector_name=sector_name,
         native_currency="USD",
         open_date=date(2026, 1, 5),
         source="ebull",
@@ -823,9 +826,9 @@ class TestRiskSection:
 
     def test_concentration_and_sector_always_computable(self) -> None:
         holdings = (
-            _holding(instrument_id=1, symbol="AAPL", market_value=600.0, sector="Technology"),
-            _holding(instrument_id=2, symbol="JPM", market_value=300.0, sector="Financials"),
-            _holding(instrument_id=3, symbol="XOM", market_value=100.0, sector=None),
+            _holding(instrument_id=1, symbol="AAPL", market_value=600.0, sector_name="Technology"),
+            _holding(instrument_id=2, symbol="JPM", market_value=300.0, sector_name="Financials"),
+            _holding(instrument_id=3, symbol="XOM", market_value=100.0, sector=None, sector_name=None),
         )
         val = _valuation_with(holdings, cash=0.0)
         risk = _risk_section(val, [], None, observation_label="test")
@@ -834,6 +837,16 @@ class TestRiskSection:
         assert Decimal(risk["concentration_top5_pct"]) == Decimal("1")
         assert Decimal(risk["sector_exposure"]["Technology"]) == Decimal("0.6")
         assert "Unknown" in risk["sector_exposure"]
+
+    def test_unmapped_sector_id_groups_unknown_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A populated sector id with no etoro_stocks_industries row folds
+        into "Unknown" and warns (catalogue drift must surface, #1598)."""
+        holdings = (_holding(sector="99", sector_name=None),)
+        val = _valuation_with(holdings, cash=0.0)
+        with caplog.at_level(logging.WARNING, logger="app.services.reporting"):
+            risk = _risk_section(val, [], None, observation_label="test")
+        assert Decimal(risk["sector_exposure"]["Unknown"]) == Decimal("1")
+        assert any("no etoro_stocks_industries row" in r.getMessage() for r in caplog.records)
 
     def test_drawdown_and_volatility_over_full_chain(self) -> None:
         chain = [

--- a/tests/test_reporting_v2_db.py
+++ b/tests/test_reporting_v2_db.py
@@ -215,6 +215,12 @@ def test_v2_fixture_is_backend_emitted(ebull_test_conn: psycopg.Connection[tuple
         (_FIXTURE_DIR / "weekly.json").write_text(json.dumps(weekly, indent=2, sort_keys=True) + "\n")
         (_FIXTURE_DIR / "monthly.json").write_text(json.dumps(monthly, indent=2, sort_keys=True) + "\n")
 
+    # The id→name join must actually resolve (#1598): a broken
+    # etoro_stocks_industries lookup would silently emit sector=None /
+    # group everything as "Unknown" while the key-structure checks pass.
+    assert monthly["holdings"][0]["sector"] == "Technology"
+    assert "Technology" in monthly["risk"]["sector_exposure"]
+
     for name, generated in (("weekly", weekly), ("monthly", monthly)):
         fixture = json.loads((_FIXTURE_DIR / f"{name}.json").read_text())
         assert set(fixture.keys()) == set(generated.keys()), name

--- a/tests/test_reporting_v2_db.py
+++ b/tests/test_reporting_v2_db.py
@@ -47,10 +47,20 @@ def _seed_portfolio(conn: psycopg.Connection[tuple]) -> None:
     1000 cash. total_aum = 10×110 + 1000 = 2100 (display ccy pinned
     to USD so no FX conversion enters the arithmetic)."""
     conn.execute("UPDATE runtime_config SET display_currency = 'USD' WHERE id = TRUE")
+    # instruments.sector stores eToro's NUMERIC industry id (provider
+    # contract); names live in etoro_stocks_industries (#1598). Seed the
+    # production shape so the fixture exercises the id→name join.
+    conn.execute(
+        """
+        INSERT INTO etoro_stocks_industries (industry_id, name)
+        VALUES (42, 'Technology')
+        ON CONFLICT (industry_id) DO UPDATE SET name = EXCLUDED.name
+        """
+    )
     conn.execute(
         """
         INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, sector, is_tradable)
-        VALUES (789801, 'RPTV2A', 'Report Co', '4', 'USD', 'Technology', TRUE)
+        VALUES (789801, 'RPTV2A', 'Report Co', '4', 'USD', '42', TRUE)
         ON CONFLICT (instrument_id) DO NOTHING
         """
     )

--- a/tests/test_universe_normaliser.py
+++ b/tests/test_universe_normaliser.py
@@ -25,7 +25,7 @@ FIXTURE_INSTRUMENT = {
     "symbolFull": "AAPL",
     "instrumentDisplayName": "Apple Inc.",
     "exchangeID": 10,
-    "stocksIndustryId": 42,
+    "stocksIndustryID": 42,
     "priceSource": "Nasdaq",
     "isInternalInstrument": False,
     "instrumentTypeName": "Stock",
@@ -45,7 +45,7 @@ FIXTURE_API_RESPONSE = {
             "symbolFull": "MSFT",
             "instrumentDisplayName": "Microsoft Corporation",
             "exchangeID": 10,
-            "stocksIndustryId": 42,
+            "stocksIndustryID": 42,
             "priceSource": "Nasdaq",
             "isInternalInstrument": False,
         },
@@ -68,6 +68,13 @@ class TestNormaliseInstrument:
         assert record.exchange == "10"
         assert record.sector == "42"
         assert record.is_tradable is True
+
+    def test_sector_zero_sentinel_maps_to_none(self) -> None:
+        """eToro sends stocksIndustryID = 0 for FX/commodities (no
+        industry). 0 must map to None, not the string "0" (#1598)."""
+        record = _normalise_instrument({**FIXTURE_INSTRUMENT, "stocksIndustryID": 0})
+        assert record is not None
+        assert record.sector is None
 
     def test_currency_is_none_from_normaliser(self) -> None:
         """currency is None from the normaliser — the eToro instruments


### PR DESCRIPTION
## What

`instruments.sector` was NULL for all 12,545 instruments because the eToro instruments mapper read `stocksIndustryId`; the live payload key is `stocksIndustryID` (capital ID — probed 2026-06-12, present on 10,894/15,497 items; every sibling key in the item is capital-ID). Closes #1598.

Three changes:

1. **Mapper** (`app/providers/implementations/etoro.py`): read `stocksIndustryID`; compose `_str_or_none(_int_or_none(...))` so eToro's `0` FX/commodity sentinel maps to `None` (`_int_or_none` already documents 0→None), not the string `"0"`.
2. **Consumer half** (`app/services/valuation.py`): `_POSITIONS_SQL` LEFT JOINs `etoro_stocks_industries` (`industry_id::text = i.sector` — cast on the 9-row catalogue side, never throws on non-numeric text); `HoldingValuation` grows `sector_name`. Resolution lives in the shared valuation (#1596) so every snapshot consumer gets names from one place.
3. **Report sections** (`app/services/reporting.py`): `_risk_section` groups exposure by resolved name — `risk.sector_exposure` reads "Technology", not "5"; a populated id with no catalogue row warns (prevention-log "silent .get fallback" analogue) and folds into "Unknown". `_holdings_section` emits the resolved name (None when unmapped → FE nil treatment).

## Settled decisions

- **Providers are thin adapters / domain logic in services**: the provider change is a key read; id→name resolution sits in the service-layer SQL. Preserved.
- **eToro = source of truth for tradable universe**: unchanged; this makes the sync actually carry the field.

## Security model

No new endpoints, no auth surface, no user-controlled SQL — the join key is a DB column populated from the provider mapper; query is static SQL with no interpolation. Files outside the diff: none security-relevant.

## Tradeoffs

- Unmapped numeric id renders as "Unknown" in exposure (with a log warning) rather than echoing the raw id — keeps the statement clean; drift is operator-visible in logs and in the #1599 follow-up surfaces.
- Non-reporting consumers (`instruments`/`scores` sector filter, `watchlist`, portfolio reason strings) still expose the raw id once data lands — deliberately out of scope here, filed as **#1599** (Codex ckpt-2 P2s; pre-fix these were all NULL so nothing regresses).

## Codex checkpoint 2

Run on the branch diff. Findings triage:
- P2 (non-reporting consumers expose ids) → **DEFERRED #1599**.
- P3 (legacy non-numeric sector text would be dropped by name-only emission) → **REBUTTED**: dev DB verified 2026-06-12, `COUNT(sector) = 0` of 12,545 — no legacy text values exist anywhere; the only name-shaped value was the test fixture seed, which this PR fixes to the production shape (numeric id + catalogue row).
- Note (fixture test couldn't catch a broken join) → **FIXED ba89608**: asserts `holdings[0].sector == "Technology"` + `"Technology" in risk.sector_exposure`.

## Tests + verification (DoD ETL clauses)

- New: 0-sentinel test; unmapped-id warns + groups-Unknown test; join-resolution assertions in the v2 fixture test. Fixture key casing corrected to the live payload shape (the wrong-cased fixture is how the bug survived).
- `ruff check` / `ruff format --check` / `pyright` / `pytest -m "not db"` (3885 passed) / `tests/smoke` (129 passed) / targeted db tier `tests/test_reporting_v2_db.py` (5 passed) all green.
- v2 fixtures regenerated via `REPORT_FIXTURE_WRITE=1` — diff is `generated_at` only; sector values byte-identical through the new join.
- Cross-source: live eToro payload probe (issue #1598 diagnosis, 2026-06-12): `stocksIndustryID` on 10,894/15,497 items, `0` on FX/commodities; catalogue parser at `etoro.py:632` reads `industryID` (same casing family).
- **Post-merge backfill (operator runbook)**: re-run `nightly_universe_sync` on dev (upsert overwrites sector in place, `app/services/universe.py:124`); verify `COUNT(sector) > 0`, GME/BBBY carry real industry ids; regenerate the dev monthly snapshot and confirm named sectors in `risk.sector_exposure`. Will be recorded on this PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)