### PR TITLE
feat(#1604): portfolio value-over-time — hybrid units basis, dark-mode theming, buy/sell markers

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -937,15 +937,32 @@ def get_value_history(
                 GROUP BY d.d, fs.instrument_id
                 HAVING SUM(fs.units) > 0
             ),
+            fills_open_now AS (
+                -- Instruments whose fills replay nets OPEN units today.
+                -- Only these suppress the position basis below: an
+                -- instrument with old fills that net to zero (closed
+                -- via our order path) and a CURRENT broker-synced
+                -- position row is a broker re-open — the position
+                -- basis must price it or the holding goes invisible
+                -- (Codex ckpt-2 finding). Overlap between a closed
+                -- fills lifecycle and a position whose open_date
+                -- predates the fills close would double-count that
+                -- span; that requires contradictory data and resolves
+                -- properly with the #1593 ledger.
+                SELECT instrument_id
+                FROM fills_signed
+                GROUP BY instrument_id
+                HAVING SUM(units) > 0
+            ),
             position_units AS (
                 -- Broker-synced holdings have no fills rows: back-fill
                 -- units from each open position's open_date at TODAY's
                 -- units (#1594 hybrid basis; see endpoint docstring for
-                -- the documented approximations). Instruments with any
-                -- fills are excluded here — the fills replay above is
-                -- their exact source, and double-counting would
-                -- inflate NAV. NULL open_date contributes from the
-                -- window start (held since before we tracked it).
+                -- the documented approximations). NULL open_date
+                -- contributes from the window start (held since before
+                -- we tracked it) — note these holdings get NO buy
+                -- marker in `events` (an unknowable date pinned to the
+                -- window start would shift with the selected range).
                 SELECT
                     d.d,
                     p.instrument_id,
@@ -954,11 +971,7 @@ def get_value_history(
                 JOIN positions p
                   ON COALESCE(p.open_date, '-infinity'::date) <= d.d
                 WHERE p.current_units > 0
-                  AND NOT EXISTS (
-                      SELECT 1 FROM fills f2
-                      JOIN orders o2 ON o2.order_id = f2.order_id
-                      WHERE o2.instrument_id = p.instrument_id
-                  )
+                  AND p.instrument_id NOT IN (SELECT instrument_id FROM fills_open_now)
                 GROUP BY d.d, p.instrument_id
                 HAVING SUM(p.current_units) > 0
             ),
@@ -1017,9 +1030,12 @@ def get_value_history(
         cash_rows = cur.fetchall()
 
     # 3. Buy/sell events for chart markers (#1594). Mirrors the hybrid
-    #    units basis exactly: fills rows are exact events; no-fills
-    #    broker positions contribute their open as a BUY so every step
-    #    in the curve has a marker explaining it.
+    #    units basis for positions with KNOWN open dates: fills rows
+    #    are exact events; no-open-fills broker positions contribute
+    #    their open as a BUY. NULL-open holdings price into the curve
+    #    but get no marker (no knowable date to pin it to), and the
+    #    position-basis suppression keys on fills that net OPEN today
+    #    — same rule as `fills_open_now` above.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
@@ -1044,10 +1060,15 @@ def get_value_history(
             WHERE p.current_units > 0
               AND p.open_date IS NOT NULL
               AND p.open_date >= %(start)s
-              AND NOT EXISTS (
-                  SELECT 1 FROM fills f2
+              AND p.instrument_id NOT IN (
+                  SELECT o2.instrument_id
+                  FROM fills f2
                   JOIN orders o2 ON o2.order_id = f2.order_id
-                  WHERE o2.instrument_id = p.instrument_id
+                  WHERE o2.action IN ('BUY', 'ADD', 'SELL', 'EXIT')
+                  GROUP BY o2.instrument_id
+                  HAVING SUM(
+                      CASE WHEN o2.action IN ('BUY', 'ADD') THEN f2.units ELSE -f2.units END
+                  ) > 0
               )
             ORDER BY event_date, symbol
             """,

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -773,6 +773,23 @@ class ValueHistoryPoint(BaseModel):
     value: float
 
 
+class ValueHistoryEvent(BaseModel):
+    """A buy/sell visible on the value-history chart (#1594 markers).
+
+    `source="fill"` rows are exact (our own order path).
+    `source="position_open"` rows are broker-synced position opens —
+    units are TODAY's units back-dated to the open (same approximation
+    as the hybrid units basis). Broker-side sells are unrecorded until
+    the #1593 ledger, so SELL events only ever come from fills.
+    """
+
+    date: date
+    symbol: str
+    side: Literal["BUY", "SELL"]
+    units: float
+    source: Literal["fill", "position_open"]
+
+
 ValueHistoryRange = Literal["1m", "3m", "6m", "1y", "5y", "max"]
 
 
@@ -793,6 +810,8 @@ class ValueHistoryResponse(BaseModel):
     # (instruments × days).
     fx_skipped: int = 0
     points: list[ValueHistoryPoint]
+    # Buy/sell chart markers, ascending by date (#1594).
+    events: list[ValueHistoryEvent] = []
 
 
 @router.get("/value-history", response_model=ValueHistoryResponse)
@@ -997,7 +1016,57 @@ def get_value_history(
         )
         cash_rows = cur.fetchall()
 
-    # 3. Aggregate into one value per day in display currency.
+    # 3. Buy/sell events for chart markers (#1594). Mirrors the hybrid
+    #    units basis exactly: fills rows are exact events; no-fills
+    #    broker positions contribute their open as a BUY so every step
+    #    in the curve has a marker explaining it.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT f.filled_at::date AS event_date,
+                   i.symbol,
+                   CASE WHEN o.action IN ('BUY', 'ADD') THEN 'BUY' ELSE 'SELL' END AS side,
+                   f.units,
+                   'fill' AS source
+            FROM fills f
+            JOIN orders o ON o.order_id = f.order_id
+            JOIN instruments i ON i.instrument_id = o.instrument_id
+            WHERE o.action IN ('BUY', 'ADD', 'SELL', 'EXIT')
+              AND f.filled_at::date >= %(start)s
+            UNION ALL
+            SELECT p.open_date AS event_date,
+                   i.symbol,
+                   'BUY' AS side,
+                   p.current_units AS units,
+                   'position_open' AS source
+            FROM positions p
+            JOIN instruments i ON i.instrument_id = p.instrument_id
+            WHERE p.current_units > 0
+              AND p.open_date IS NOT NULL
+              AND p.open_date >= %(start)s
+              AND NOT EXISTS (
+                  SELECT 1 FROM fills f2
+                  JOIN orders o2 ON o2.order_id = f2.order_id
+                  WHERE o2.instrument_id = p.instrument_id
+              )
+            ORDER BY event_date, symbol
+            """,
+            {"start": start_date},
+        )
+        event_rows = cur.fetchall()
+
+    events = [
+        ValueHistoryEvent(
+            date=row["event_date"],
+            symbol=str(row["symbol"]),
+            side=row["side"],
+            units=float(row["units"]),
+            source=row["source"],
+        )
+        for row in event_rows
+    ]
+
+    # 4. Aggregate into one value per day in display currency.
     # cash_ledger semantics: every INSERT site (orders.py, order_client.py,
     # portfolio_sync.py) writes a *delta* row, never an absolute snapshot.
     # SUM(amount) is therefore the running balance — correct per-call-site
@@ -1087,4 +1156,5 @@ def get_value_history(
         days=effective_days,
         fx_skipped=len(fx_missing_pairs),
         points=points,
+        events=events,
     )

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -808,11 +808,24 @@ def get_value_history(
         plus sum over each currency:
             net_cash_ledger_at_D                       (converted to display ccy)
 
-    Signed units replay the fills ledger by order action (BUY/ADD add,
-    SELL/EXIT subtract). If a position had no `price_daily` close on
-    or before D (e.g. new listing with stale local store), that bar
-    is skipped for that day — conservatively under-states value
-    rather than inventing a zero.
+    units_at_D is a hybrid (#1594 v1, pre-trade-ledger):
+
+    - Instruments with `fills` rows replay the fills ledger by order
+      action (BUY/ADD add, SELL/EXIT subtract) — exact through our own
+      opens AND closes.
+    - Broker-synced holdings carry no fills; each open position
+      contributes its CURRENT units from its `open_date` forward.
+      Known approximations until the #1593 ledger: partial adds/trims
+      before today are backdated to open_date, and closed broker
+      positions drop out of history entirely (the sync never recorded
+      them).
+    - Mirror/copy-portfolio equity is EXCLUDED — there is no history
+      source for it; the dashboard headline includes it, so this
+      series reads below `total_aum` by the live mirror equity.
+
+    If a position had no `price_daily` close on or before D (e.g. new
+    listing with stale local store), that bar is skipped for that day —
+    conservatively under-states value rather than inventing a zero.
 
     FX conversion uses the **live** snapshot only (`live_fx_rates`).
     Historical daily FX is only populated on tax-event dates today, so
@@ -839,7 +852,10 @@ def get_value_history(
                 SELECT COALESCE(
                     LEAST(
                         (SELECT MIN(filled_at::date) FROM fills),
-                        (SELECT MIN(event_time::date) FROM cash_ledger)
+                        (SELECT MIN(event_time::date) FROM cash_ledger),
+                        -- Broker-synced holdings start history at their
+                        -- position open_date (#1594 hybrid basis).
+                        (SELECT MIN(open_date) FROM positions WHERE current_units > 0)
                     ),
                     CURRENT_DATE
                 ) AS start_date
@@ -886,7 +902,7 @@ def get_value_history(
                 JOIN orders o ON o.order_id = f.order_id
                 WHERE o.action IN ('BUY', 'ADD', 'SELL', 'EXIT')
             ),
-            units_per_day AS (
+            fills_units AS (
                 -- Long-only invariant (CLAUDE.md, eBull non-negotiables
                 -- "Long only in v1. No shorting."). We intentionally
                 -- drop zero and negative net-units: zero = fully
@@ -901,6 +917,36 @@ def get_value_history(
                 JOIN fills_signed fs ON fs.fill_date <= d.d
                 GROUP BY d.d, fs.instrument_id
                 HAVING SUM(fs.units) > 0
+            ),
+            position_units AS (
+                -- Broker-synced holdings have no fills rows: back-fill
+                -- units from each open position's open_date at TODAY's
+                -- units (#1594 hybrid basis; see endpoint docstring for
+                -- the documented approximations). Instruments with any
+                -- fills are excluded here — the fills replay above is
+                -- their exact source, and double-counting would
+                -- inflate NAV. NULL open_date contributes from the
+                -- window start (held since before we tracked it).
+                SELECT
+                    d.d,
+                    p.instrument_id,
+                    SUM(p.current_units) AS units_at_date
+                FROM dates d
+                JOIN positions p
+                  ON COALESCE(p.open_date, '-infinity'::date) <= d.d
+                WHERE p.current_units > 0
+                  AND NOT EXISTS (
+                      SELECT 1 FROM fills f2
+                      JOIN orders o2 ON o2.order_id = f2.order_id
+                      WHERE o2.instrument_id = p.instrument_id
+                  )
+                GROUP BY d.d, p.instrument_id
+                HAVING SUM(p.current_units) > 0
+            ),
+            units_per_day AS (
+                SELECT d, instrument_id, units_at_date FROM fills_units
+                UNION ALL
+                SELECT d, instrument_id, units_at_date FROM position_units
             )
             SELECT
                 u.d AS point_date,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -547,6 +547,17 @@ export interface ValueHistoryPoint {
   value: number;
 }
 
+// Buy/sell chart marker (#1594). source="position_open" = broker-synced
+// open back-dated at today's units; SELL only ever comes from fills
+// (broker-side sells unrecorded until the #1593 ledger).
+export interface ValueHistoryEvent {
+  date: string; // YYYY-MM-DD
+  symbol: string;
+  side: "BUY" | "SELL";
+  units: number;
+  source: "fill" | "position_open";
+}
+
 export interface ValueHistoryResponse {
   display_currency: string;
   range: ValueHistoryRange;
@@ -554,6 +565,7 @@ export interface ValueHistoryResponse {
   fx_mode: string; // "live" in v1 — flags whether historical FX was used
   fx_skipped: number; // rows dropped due to missing live FX pair
   points: ValueHistoryPoint[];
+  events: ValueHistoryEvent[];
 }
 
 // /portfolio/instruments/:instrumentId — native currency drill-through

--- a/frontend/src/components/dashboard/PortfolioValueChart.test.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.test.tsx
@@ -16,9 +16,10 @@ const libState = vi.hoisted(() => ({
 }));
 
 vi.mock("lightweight-charts", () => {
-  const series = { setData: libState.setData };
+  const series = { setData: libState.setData, applyOptions: vi.fn() };
   const chart = {
     addSeries: vi.fn(() => series),
+    applyOptions: vi.fn(),
     priceScale: vi.fn(() => ({ applyOptions: vi.fn() })),
     timeScale: vi.fn(() => ({ fitContent: libState.fitContent })),
     subscribeCrosshairMove: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock("lightweight-charts", () => {
   };
   return {
     createChart: vi.fn(() => chart),
+    createSeriesMarkers: vi.fn(() => ({ detach: vi.fn(), setMarkers: vi.fn() })),
     AreaSeries: "__area__",
   };
 });
@@ -50,6 +52,7 @@ function resp(
     fx_mode: "live",
     fx_skipped: 0,
     points,
+    events: [],
     ...overrides,
   };
 }

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -131,7 +131,7 @@ export function PortfolioValueChart(): JSX.Element | null {
               caption would just duplicate. */}
           {data?.fx_mode === "live" && hasMovement && fxSkipped === 0 ? (
             <span className="text-[10px] text-slate-400 dark:text-slate-500">
-              historical converted at today's FX
+              historical converted at today's FX · excludes copy-portfolio equity
             </span>
           ) : null}
           {/* Keep the FX-missing signal even when the chart has

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -17,18 +17,21 @@ import { useSearchParams } from "react-router-dom";
 import {
   AreaSeries,
   createChart,
+  createSeriesMarkers,
   type IChartApi,
   type ISeriesApi,
+  type SeriesMarker,
   type Time,
   type UTCTimestamp,
 } from "lightweight-charts";
 
 import { fetchValueHistory } from "@/api/portfolio";
-import type { ValueHistoryPoint, ValueHistoryRange } from "@/api/types";
+import type { ValueHistoryEvent, ValueHistoryPoint, ValueHistoryRange } from "@/api/types";
 import { SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { formatMoney } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
+import { useChartTheme } from "@/lib/useChartTheme";
 
 const RANGES: { id: ValueHistoryRange; label: string }[] = [
   { id: "1m", label: "1M" },
@@ -65,6 +68,7 @@ function dateToTime(date: string): UTCTimestamp | null {
 interface HoverState {
   date: string;
   value: number;
+  trades: ValueHistoryEvent[];
 }
 
 export function PortfolioValueChart(): JSX.Element | null {
@@ -178,7 +182,7 @@ export function PortfolioValueChart(): JSX.Element | null {
         // guard share the same view of the series. The canvas would
         // still re-filter internally, but passing `points` raw means
         // two different "what counts as a row" rules in the same file.
-        <ValueCanvas points={validPoints} currency={data.display_currency} />
+        <ValueCanvas points={validPoints} events={data.events} currency={data.display_currency} />
       ) : null}
     </div>
   );
@@ -186,43 +190,55 @@ export function PortfolioValueChart(): JSX.Element | null {
 
 function ValueCanvas({
   points,
+  events,
   currency,
 }: {
   points: ValueHistoryPoint[];
+  events: ValueHistoryEvent[];
   currency: string;
 }): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const seriesRef = useRef<ISeriesApi<"Area"> | null>(null);
+  const markersRef = useRef<ReturnType<typeof createSeriesMarkers<Time>> | null>(null);
+  // The crosshair callback reads events through a ref so the run-once
+  // construction effect never closes over a stale array (the
+  // subscription outlives every refetch).
+  const eventsRef = useRef<ValueHistoryEvent[]>(events);
+  eventsRef.current = events;
   const [hover, setHover] = useState<HoverState | null>(null);
+  const theme = useChartTheme();
 
   useEffect(() => {
     const container = containerRef.current;
     if (container === null) return;
 
+    // Theme values here are construction-time only; the applyOptions
+    // effect below re-applies them on light/dark toggle (PriceChart
+    // pattern — recreating the chart would drop pan/zoom).
     const chart = createChart(container, {
       autoSize: true,
       layout: {
-        background: { color: "#ffffff" },
-        textColor: "#64748b",
+        background: { color: theme.bg },
+        textColor: theme.textSecondary,
         fontSize: 11,
       },
       grid: {
-        vertLines: { color: "#f1f5f9" },
-        horzLines: { color: "#f1f5f9" },
+        vertLines: { color: theme.gridLine },
+        horzLines: { color: theme.gridLine },
       },
-      rightPriceScale: { borderColor: "#e2e8f0" },
-      timeScale: { borderColor: "#e2e8f0" },
+      rightPriceScale: { borderColor: theme.borderColor },
+      timeScale: { borderColor: theme.borderColor },
       crosshair: {
-        vertLine: { width: 1, color: "#94a3b8", style: 3 },
-        horzLine: { width: 1, color: "#94a3b8", style: 3 },
+        vertLine: { width: 1, color: theme.crosshair, style: 3 },
+        horzLine: { width: 1, color: theme.crosshair, style: 3 },
       },
     });
 
     const series = chart.addSeries(AreaSeries, {
-      lineColor: "#2563eb",
-      topColor: "rgba(37,99,235,0.25)",
-      bottomColor: "rgba(37,99,235,0.02)",
+      lineColor: theme.accent[1],
+      topColor: theme.areaTopAlpha,
+      bottomColor: theme.areaBottomAlpha,
       lineWidth: 2,
     });
 
@@ -244,15 +260,47 @@ function ValueCanvas({
         return;
       }
       const date = new Date(param.time * 1000).toISOString().slice(0, 10);
-      setHover({ date, value: (pt as { value: number }).value });
+      setHover({
+        date,
+        value: (pt as { value: number }).value,
+        trades: eventsRef.current.filter((e) => e.date === date),
+      });
     });
 
     return () => {
+      markersRef.current?.detach();
+      markersRef.current = null;
       chart.remove();
       chartRef.current = null;
       seriesRef.current = null;
     };
   }, []);
+
+  // Re-apply theme-driven options on light/dark toggle (PriceChart /
+  // InsiderPriceMarkers pattern — applyOptions, never recreate).
+  useEffect(() => {
+    const chart = chartRef.current;
+    const series = seriesRef.current;
+    if (!chart || !series) return;
+    chart.applyOptions({
+      layout: { background: { color: theme.bg }, textColor: theme.textSecondary },
+      grid: {
+        vertLines: { color: theme.gridLine },
+        horzLines: { color: theme.gridLine },
+      },
+      rightPriceScale: { borderColor: theme.borderColor },
+      timeScale: { borderColor: theme.borderColor },
+      crosshair: {
+        vertLine: { color: theme.crosshair },
+        horzLine: { color: theme.crosshair },
+      },
+    });
+    series.applyOptions({
+      lineColor: theme.accent[1],
+      topColor: theme.areaTopAlpha,
+      bottomColor: theme.areaBottomAlpha,
+    });
+  }, [theme]);
 
   useEffect(() => {
     const series = seriesRef.current;
@@ -268,14 +316,71 @@ function ValueCanvas({
     chart.timeScale().fitContent();
   }, [points]);
 
+  // Buy/sell bubbles (#1594): one marker per (day, side) — BUY below
+  // the bar in `up` green, SELL above in `down` red. The symbol ×
+  // units detail lives in the hover overlay, not marker text — 60+
+  // position opens as permanent labels would bury the line. detach +
+  // re-attach so marker state never accumulates (InsiderPriceMarkers
+  // pattern).
+  useEffect(() => {
+    const series = seriesRef.current;
+    if (!series) return;
+    const byDay = new Map<string, { buys: boolean; sells: boolean }>();
+    for (const e of events) {
+      const entry = byDay.get(e.date) ?? { buys: false, sells: false };
+      if (e.side === "BUY") entry.buys = true;
+      else entry.sells = true;
+      byDay.set(e.date, entry);
+    }
+    const markers: SeriesMarker<Time>[] = [];
+    for (const [date, { buys, sells }] of byDay) {
+      const time = dateToTime(date);
+      if (time === null) continue;
+      if (buys) {
+        markers.push({ time: time as Time, position: "belowBar", color: theme.up, shape: "circle", size: 1 });
+      }
+      if (sells) {
+        markers.push({ time: time as Time, position: "aboveBar", color: theme.down, shape: "circle", size: 1 });
+      }
+    }
+    markers.sort((a, b) => (a.time as number) - (b.time as number));
+    markersRef.current?.detach();
+    markersRef.current = createSeriesMarkers(series, markers);
+    // `theme` intentionally NOT in deps: marker colours are theme.up /
+    // theme.down, identical across light and dark (saturated palette).
+  }, [events]);
+
   return (
     <div className="relative mt-2">
       {hover !== null ? (
-        <div className="absolute right-2 top-2 z-10 rounded bg-white/90 px-2 py-1 text-xs tabular-nums shadow-sm">
-          <span className="text-slate-400 dark:text-slate-500">{hover.date}</span>
-          <span className="ml-2 font-medium text-slate-700">
-            {formatMoney(hover.value, currency)}
-          </span>
+        <div className="absolute right-2 top-2 z-10 rounded border border-slate-200 bg-white/90 px-2 py-1 text-xs tabular-nums shadow-sm dark:border-slate-700 dark:bg-slate-900/90">
+          <div>
+            <span className="text-slate-400 dark:text-slate-500">{hover.date}</span>
+            <span className="ml-2 font-medium text-slate-700 dark:text-slate-200">
+              {formatMoney(hover.value, currency)}
+            </span>
+          </div>
+          {hover.trades.length > 0 ? (
+            <ul className="mt-1 space-y-0.5 border-t border-slate-100 pt-1 dark:border-slate-800">
+              {hover.trades.map((t, i) => (
+                <li key={`${t.symbol}-${t.side}-${i}`} className="flex items-baseline gap-1.5">
+                  <span
+                    className={
+                      t.side === "BUY"
+                        ? "font-medium text-emerald-600 dark:text-emerald-400"
+                        : "font-medium text-red-600 dark:text-red-400"
+                    }
+                  >
+                    {t.side}
+                  </span>
+                  <span className="text-slate-700 dark:text-slate-200">{t.symbol}</span>
+                  <span className="text-slate-500 dark:text-slate-400">
+                    {t.units.toLocaleString("en-GB", { maximumFractionDigits: 4 })} units
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
         </div>
       ) : null}
       <div

--- a/frontend/src/lib/chartTheme.ts
+++ b/frontend/src/lib/chartTheme.ts
@@ -9,6 +9,7 @@
  *   - lightweight-charts options in `PriceChart`, `ChartWorkspaceCanvas`,
  *     and `InsiderPriceMarkers`
  *   - recharts components in fundamentals / dividends / insider drill pages
+ *   - lightweight-charts options in `PortfolioValueChart` (dashboard)
  *   - `Sparkline` (default stroke remains `currentColor` so callers retain
  *     Tailwind `text-*`-driven coloring)
  *
@@ -76,6 +77,14 @@ export interface ChartTheme {
 
   /** Primary normalized line in compare mode. */
   readonly primaryLine: string;
+
+  /**
+   * Translucent fills under an `accent[1]`-coloured area line
+   * (dashboard portfolio-value chart; reusable by any single-series
+   * area chart that wants the blue identity).
+   */
+  readonly areaTopAlpha: string;
+  readonly areaBottomAlpha: string;
 }
 
 export const lightTheme: ChartTheme = {
@@ -123,6 +132,9 @@ export const lightTheme: ChartTheme = {
   channelLow: "#ef4444",
 
   primaryLine: "#1e293b", // slate-800
+
+  areaTopAlpha: "rgba(59,130,246,0.25)", // blue-500 (matches accent[1])
+  areaBottomAlpha: "rgba(59,130,246,0.02)",
 };
 
 /**
@@ -163,4 +175,7 @@ export const darkTheme: ChartTheme = {
   channelLow: lightTheme.channelLow,
 
   primaryLine: "#f1f5f9", // slate-100 — keeps reading-order weight in dark
+
+  areaTopAlpha: lightTheme.areaTopAlpha,
+  areaBottomAlpha: lightTheme.areaBottomAlpha,
 };

--- a/tests/test_api_portfolio_value_history.py
+++ b/tests/test_api_portfolio_value_history.py
@@ -28,13 +28,15 @@ def _make_conn(
 ) -> MagicMock:
     """Conn with one cursor per `conn.cursor()` call.
 
-    The value-history endpoint opens three cursors in sequence:
+    The value-history endpoint opens four cursors in sequence:
         1. start-date resolution (`cur.fetchone()` returns a dict
            with `start_date`)
         2. positions query (`cur.fetchall()` returns position rows)
         3. cash query (`cur.fetchall()` returns cash rows)
+        4. events query (`cur.fetchall()` returns buy/sell marker rows;
+           defaults to [] when the caller passes only two lists)
 
-    `fetchall_per_cursor` holds rows for cursors 2 and 3; the first
+    `fetchall_per_cursor` holds rows for cursors 2+; the first
     cursor's fetchone uses `start_date_row` or a sane default that
     predates every fixture in this file."""
     start_row = start_date_row or _DEFAULT_START
@@ -48,7 +50,7 @@ def _make_conn(
         if cursor_idx[0] == 0:
             cur.fetchone.return_value = start_row
         else:
-            cur.fetchall.return_value = next(fetchalls)
+            cur.fetchall.return_value = next(fetchalls, [])
         cursor_idx[0] += 1
         return cur
 

--- a/tests/test_value_history_db.py
+++ b/tests/test_value_history_db.py
@@ -1,0 +1,122 @@
+"""DB-backed test for the value-history hybrid units basis (#1594 v1).
+
+One integration test per genuinely-new SQL mechanism (test-tiering
+decision 2026-06-07): the hybrid `units_per_day` CTE — fills replay
+for instruments with fills, positions.open_date basis for
+broker-synced holdings — cannot be exercised by the mocked-cursor
+tests in test_api_portfolio_value_history.py.
+
+Calls the endpoint function directly with a real connection (no HTTP /
+auth layer — the SQL is the subject under test).
+
+NOTE: ``cash_ledger`` / ``fills`` are not in the worker-DB truncate
+list (#1602), so this test cleans up its own rows in ``finally`` to
+avoid leaking state into colocated tests.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import psycopg
+
+from app.api.portfolio import get_value_history
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+
+_IID_BROKER = 789901  # broker-synced: position row, NO fills
+_IID_FILLS = 789902  # ebull-path: fills + position row (must not double-count)
+
+
+def _seed(conn: psycopg.Connection[tuple], today: date) -> None:
+    conn.execute("UPDATE runtime_config SET display_currency = 'USD' WHERE id = TRUE")
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%(a)s, 'VHDB1', 'Broker Co', '4', 'USD', TRUE),
+               (%(b)s, 'VHDB2', 'Fills Co', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        {"a": _IID_BROKER, "b": _IID_FILLS},
+    )
+    # Broker position: 10 units, opened 4 days ago, no fills anywhere.
+    conn.execute(
+        """
+        INSERT INTO positions (instrument_id, open_date, avg_cost, current_units,
+                               cost_basis, realized_pnl, unrealized_pnl, source)
+        VALUES (%(a)s, %(open)s, 100, 10, 1000, 0, 0, 'broker_sync'),
+               (%(b)s, %(open)s, 50, 5, 250, 0, 0, 'ebull')
+        ON CONFLICT (instrument_id) DO UPDATE SET
+            open_date = EXCLUDED.open_date,
+            current_units = EXCLUDED.current_units
+        """,
+        {"a": _IID_BROKER, "b": _IID_FILLS, "open": today - timedelta(days=4)},
+    )
+    # Fills-path instrument: BUY 5 units 4 days ago. Its positions row
+    # above must be IGNORED by the hybrid basis (fills replay wins).
+    conn.execute(
+        """
+        INSERT INTO orders (order_id, instrument_id, action, order_type, requested_units, status, created_at)
+        VALUES (889901, %(b)s, 'BUY', 'market', 5, 'filled', %(t)s)
+        ON CONFLICT (order_id) DO NOTHING
+        """,
+        {"b": _IID_FILLS, "t": today - timedelta(days=4)},
+    )
+    conn.execute(
+        """
+        INSERT INTO fills (order_id, units, price, gross_amount, fees, filled_at)
+        VALUES (889901, 5, 50, 250, 0, %(t)s)
+        """,
+        {"t": today - timedelta(days=4)},
+    )
+    # Daily closes: broker instrument 100 → 120; fills instrument flat 50.
+    for offset, close_a in ((4, 100), (2, 110), (0, 120)):
+        conn.execute(
+            """
+            INSERT INTO price_daily (instrument_id, price_date, close)
+            VALUES (%(a)s, %(d)s, %(ca)s), (%(b)s, %(d)s, 50)
+            ON CONFLICT (instrument_id, price_date) DO UPDATE SET close = EXCLUDED.close
+            """,
+            {"a": _IID_BROKER, "b": _IID_FILLS, "d": today - timedelta(days=offset), "ca": close_a},
+        )
+    conn.commit()
+
+
+def _cleanup(conn: psycopg.Connection[tuple]) -> None:
+    conn.rollback()
+    conn.execute("DELETE FROM fills WHERE order_id = 889901")
+    conn.execute("DELETE FROM orders WHERE order_id = 889901")
+    conn.execute(
+        "DELETE FROM price_daily WHERE instrument_id IN (%(a)s, %(b)s)",
+        {"a": _IID_BROKER, "b": _IID_FILLS},
+    )
+    conn.commit()
+
+
+def test_hybrid_units_basis_prices_broker_positions_and_avoids_double_count(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    today = date.today()
+    _seed(conn, today)
+    try:
+        resp = get_value_history(range="1m", conn=conn)
+
+        by_date = {p.date: p.value for p in resp.points}
+
+        # Day of open (4 days ago): broker 10×100 + fills 5×50 = 1250.
+        # Pre-#1594 the broker leg was invisible (fills-only replay)
+        # and this read 250.
+        assert by_date[today - timedelta(days=4)] == 1250.0
+
+        # Carry-forward close between price rows (3 days ago): same.
+        assert by_date[today - timedelta(days=3)] == 1250.0
+
+        # Today: broker 10×120 + fills 5×50 = 1450. A double-counted
+        # fills instrument (fills replay + position row) would add
+        # another 250.
+        assert by_date[today] == 1450.0
+
+        # No points before the broker open_date (no cash seeded).
+        assert (today - timedelta(days=5)) not in by_date
+    finally:
+        _cleanup(conn)

--- a/tests/test_value_history_db.py
+++ b/tests/test_value_history_db.py
@@ -23,6 +23,19 @@ import psycopg
 from app.api.portfolio import get_value_history
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
 
+
+def _db_today(conn: psycopg.Connection[tuple]) -> date:
+    """The endpoint's date series ends at Postgres CURRENT_DATE — anchor
+    the fixtures on the DB clock, not date.today(). Around midnight the
+    two disagree (local BST vs cluster UTC) and `by_date[today]` keys
+    miss (prevention log: datetime.now vs DB now() in freshness
+    windows)."""
+    cur = conn.execute("SELECT CURRENT_DATE")
+    row = cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
 _IID_BROKER = 789901  # broker-synced: position row, NO fills
 _IID_FILLS = 789902  # ebull-path: fills + position row (must not double-count)
 
@@ -82,13 +95,26 @@ def _seed(conn: psycopg.Connection[tuple], today: date) -> None:
 
 
 def _cleanup(conn: psycopg.Connection[tuple]) -> None:
+    """Remove every seeded row + restore mutated singletons. positions
+    is in the worker truncate list but fills/orders/instruments rows
+    and the runtime_config mutation would otherwise leak into
+    colocated tests (#1602; Codex ckpt-2 finding)."""
     conn.rollback()
-    conn.execute("DELETE FROM fills WHERE order_id = 889901")
-    conn.execute("DELETE FROM orders WHERE order_id = 889901")
+    conn.execute("DELETE FROM fills WHERE order_id IN (889901, 889902, 889903)")
+    conn.execute("DELETE FROM orders WHERE order_id IN (889901, 889902, 889903)")
     conn.execute(
         "DELETE FROM price_daily WHERE instrument_id IN (%(a)s, %(b)s)",
         {"a": _IID_BROKER, "b": _IID_FILLS},
     )
+    conn.execute(
+        "DELETE FROM positions WHERE instrument_id IN (%(a)s, %(b)s)",
+        {"a": _IID_BROKER, "b": _IID_FILLS},
+    )
+    conn.execute(
+        "DELETE FROM instruments WHERE instrument_id IN (%(a)s, %(b)s)",
+        {"a": _IID_BROKER, "b": _IID_FILLS},
+    )
+    conn.execute("UPDATE runtime_config SET display_currency = 'GBP' WHERE id = TRUE")
     conn.commit()
 
 
@@ -96,7 +122,7 @@ def test_hybrid_units_basis_prices_broker_positions_and_avoids_double_count(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
 ) -> None:
     conn = ebull_test_conn
-    today = date.today()
+    today = _db_today(conn)
     _seed(conn, today)
     try:
         resp = get_value_history(range="1m", conn=conn)
@@ -127,5 +153,53 @@ def test_hybrid_units_basis_prices_broker_positions_and_avoids_double_count(
         assert ("VHDB1", "BUY", 10.0, "position_open") in events
         assert ("VHDB2", "BUY", 5.0, "fill") in events
         assert len([e for e in events if e[0] == "VHDB2"]) == 1
+    finally:
+        _cleanup(conn)
+
+
+def test_broker_reopen_after_closed_fills_lifecycle_stays_priced(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """An instrument with OLD fills that net to zero (bought + fully
+    closed via our order path) and a CURRENT broker-synced position is
+    a broker re-open: the position basis must price it. An
+    any-fills-ever suppression rule made the holding invisible (Codex
+    ckpt-2 finding)."""
+    conn = ebull_test_conn
+    today = _db_today(conn)
+    _seed(conn, today)
+    try:
+        # Closed fills lifecycle on the BROKER instrument: BUY 3 then
+        # EXIT 3, both before the current position's open_date.
+        conn.execute(
+            """
+            INSERT INTO orders (order_id, instrument_id, action, order_type, requested_units, status, created_at)
+            VALUES (889902, %(a)s, 'BUY', 'market', 3, 'filled', %(t1)s),
+                   (889903, %(a)s, 'EXIT', 'market', 3, 'filled', %(t2)s)
+            ON CONFLICT (order_id) DO NOTHING
+            """,
+            {"a": _IID_BROKER, "t1": today - timedelta(days=30), "t2": today - timedelta(days=20)},
+        )
+        conn.execute(
+            """
+            INSERT INTO fills (order_id, units, price, gross_amount, fees, filled_at)
+            VALUES (889902, 3, 90, 270, 0, %(t1)s),
+                   (889903, 3, 95, 285, 0, %(t2)s)
+            """,
+            {"t1": today - timedelta(days=30), "t2": today - timedelta(days=20)},
+        )
+        conn.commit()
+
+        resp = get_value_history(range="3m", conn=conn)
+        by_date = {p.date: p.value for p in resp.points}
+
+        # Today still prices the re-opened broker position: 10×120 +
+        # fills instrument 5×50 = 1450. Suppressed-position bug would
+        # read 250.
+        assert by_date[today] == 1450.0
+
+        # The re-open keeps its BUY marker too.
+        events = [(e.symbol, e.side, e.source) for e in resp.events]
+        assert ("VHDB1", "BUY", "position_open") in events
     finally:
         _cleanup(conn)

--- a/tests/test_value_history_db.py
+++ b/tests/test_value_history_db.py
@@ -118,5 +118,14 @@ def test_hybrid_units_basis_prices_broker_positions_and_avoids_double_count(
 
         # No points before the broker open_date (no cash seeded).
         assert (today - timedelta(days=5)) not in by_date
+
+        # Marker events mirror the units basis (#1594): the broker
+        # open surfaces as a position_open BUY, the fill as a fill
+        # BUY — and the fills instrument must NOT also emit a
+        # position_open event.
+        events = [(e.symbol, e.side, e.units, e.source) for e in resp.events]
+        assert ("VHDB1", "BUY", 10.0, "position_open") in events
+        assert ("VHDB2", "BUY", 5.0, "fill") in events
+        assert len([e for e in events if e[0] == "VHDB2"]) == 1
     finally:
         _cleanup(conn)


### PR DESCRIPTION
## What

Slice A of #1594 (operator-requested 2026-06-12/13), three changes to the dashboard portfolio-value chart. Closes #1604.

**1. Hybrid units basis** (`app/api/portfolio.py::get_value_history`): the daily reconstruction replayed the `fills` ledger only — the dev account's holdings are broker-synced (0 fills), so the series was a flat cash-only line, and `PortfolioValueChart` hides itself on movement-free series. The operator-visible symptom was "no value-over-time chart anywhere". Now: fills replay for instruments whose fills net open units today (exact through our own opens AND closes), `positions.open_date` basis (current units back-dated to open) for everything else. `range=max` start extends to the earliest position open date.

**2. Dark-mode theming** (`PortfolioValueChart.tsx`): the chart predated the #690 theme system and hardcoded the light palette — unreadable on dark. Now consumes `useChartTheme` at construction + re-applies on toggle via `applyOptions` (PriceChart/InsiderPriceMarkers pattern, pan/zoom preserved). Two new `ChartTheme` slots (`areaTopAlpha`/`areaBottomAlpha`, both palettes) keep the blue area identity with no inline hex. Hover overlay made dark-safe.

**3. Buy/sell markers with hover detail** (operator request): the endpoint emits `events` — exact BUY/SELL rows from fills plus one `position_open` BUY per broker-synced holding at its open date, mirroring the curve's basis so every step has a marker. Green circles below the line (buys), red above (sells); hovering a day lists `SIDE SYMBOL N units` in the overlay. Marker text deliberately not used — N position opens as permanent labels would bury the line.

## Honest limits (documented in code + chart caption)

- Broker-side **sells are unrecorded** until the #1593 trade ledger — closed broker positions drop out of history; SELL markers only ever come from our own order path.
- Partial adds/trims before today are back-dated to the open (current units).
- **Mirror/copy-portfolio equity excluded** (no history source) — the curve reads below the dashboard headline by live mirror equity (~£31k on dev); captioned.
- NULL `open_date` holdings price from the window start and get no marker (no knowable date to pin).
- FX remains today's-rate-for-all-days (pre-existing, `fx_mode` flagged) — per-day FX is the next #1594 slice.

## Settled decisions

AUM basis (mark-to-market first, cost-basis fallback) preserved — close-at-or-before-day with conservative skip on missing closes (pre-existing). Long-only invariant kept (negative net units dropped). No provider/process-topology surface touched.

## Security model

No new auth surface; same authenticated endpoint, no user input in SQL (typed params only; `range` is a validated Literal). FE/BE types updated in the same diff (`ValueHistoryEvent` in `types.ts`).

## Codex checkpoint 2

(One run died overnight to the background-stdin trap; rerun with corrected redirect produced the review.) 3 findings, all **FIXED 333cbb7**:
- NULL-open basis inconsistency between curve/events/max-start → semantics made explicit (curve prices from window start; no marker; comments no longer over-claim parity).
- `NOT EXISTS (any fills ever)` hid a broker re-open after a closed fills lifecycle → suppression now keys on fills netting open TODAY (`fills_open_now`); regression test added.
- db-test hygiene → full row cleanup + `runtime_config` restore + dates anchored on Postgres `CURRENT_DATE` (caught live: the test failed at the BST/UTC midnight boundary exactly as the prevention-log entry predicts).
React lifecycle/timezone audit: clean per Codex.

## Tests + verification

- `ruff` / `format` / `pyright` ✓ · fast tier 3885 ✓ · smoke 129 ✓ · FE typecheck + 1012 tests + dark-gate ✓.
- Targeted db tier: `tests/test_value_history_db.py` (2 tests — hybrid basis arithmetic + events parity; broker re-open regression) + mocked-cursor suite (8) ✓.
- Dev-probed (read-only, real DB): 3m = 91 points £48.2k→£51.4k; max = 305 points from 2025-08-12; 28ms worst-case latency; 5 events (5 direct positions: GME/IEP/QQQ/VOO/BBBY) — was a flat £1,271 line with zero markers.

## Post-merge

API process restart + browser refresh to see the live chart (operator-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)