### PR TITLE
feat(#1593): trade_events ledger — eToro trade-history ingest, closed-position archive, Activity groundwork (PR-1)

### DIFF
--- a/app/api/orders.py
+++ b/app/api/orders.py
@@ -35,6 +35,7 @@ from app.providers.broker import BrokerOrderResult
 from app.services.ops_monitor import get_kill_switch_status
 from app.services.quote_marks import positive_decimal_or_none
 from app.services.runtime_config import get_runtime_config
+from app.services.trade_events import enqueue_post_trade_sync
 
 logger = logging.getLogger(__name__)
 
@@ -477,6 +478,12 @@ def _persist_order_and_fill(
                 "ev": Jsonb({"order_id": order_id, "raw_payload": broker_result.raw_payload}),
             },
         )
+
+        # 7. Filled trade → queue an immediate portfolio sync so the
+        # broker-observed event lands in trade_events within seconds
+        # (#1593). Same transaction: NOTIFY fires only at commit.
+        if passed:
+            enqueue_post_trade_sync(conn, requested_by="orders_api")
 
     return order_id
 

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -142,6 +142,38 @@ class BrokerPortfolio:
     mirrors: Sequence[BrokerMirror] = ()
 
 
+@dataclass(frozen=True)
+class BrokerClosedTrade:
+    """One closed-position slice from the broker's trade history.
+
+    eToro returns one row per closed slice carrying BOTH legs
+    (open + close). Partial closes reduce the same positionId, so a
+    position may appear in several rows (#1593 spec §4).
+
+    Money fields (net_profit, fees, investment, initial_investment)
+    are in the account currency (USD). Rates are in the instrument's
+    native currency.
+    """
+
+    position_id: int
+    instrument_id: int
+    is_buy: bool
+    units: Decimal
+    open_rate: Decimal | None
+    open_timestamp: datetime
+    close_rate: Decimal | None
+    close_timestamp: datetime
+    net_profit: Decimal | None
+    fees: Decimal | None
+    investment: Decimal | None
+    initial_investment: Decimal | None
+    leverage: int
+    order_id: int | None
+    social_trade_id: int | None
+    parent_position_id: int | None
+    raw_payload: dict[str, Any]
+
+
 class BrokerProvider(ABC):
     """
     Interface for broker operations.
@@ -194,3 +226,13 @@ class BrokerProvider(ABC):
 
         Returns all open positions and available cash.
         """
+
+    def get_trade_history(self, min_date: datetime, page_size: int = 200) -> Sequence[BrokerClosedTrade]:
+        """
+        Fetch closed-trade history rows with close timestamp >= min_date.
+
+        Non-abstract with a NotImplementedError default so existing test
+        fakes that implement only the abstract surface keep working;
+        the eToro implementation overrides it.
+        """
+        raise NotImplementedError

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -467,7 +467,10 @@ class EtoroBrokerProvider(BrokerProvider):
                 headers=self._request_headers(),
             )
             response.raise_for_status()
-            rows = response.json()
+            try:
+                rows = response.json()
+            except ValueError as exc:  # 200 with a non-JSON body
+                raise TradeHistoryParseError(f"trade history page {page}: response body is not JSON: {exc}") from exc
             if not isinstance(rows, list):
                 raise TradeHistoryParseError(
                     f"trade history page {page}: expected a JSON array, got {type(rows).__name__}"

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import decimal
 import logging
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 from types import TracebackType
 from typing import Any
@@ -23,6 +23,7 @@ import httpx
 
 from app.config import settings
 from app.providers.broker import (
+    BrokerClosedTrade,
     BrokerMirror,
     BrokerMirrorPosition,
     BrokerOrderResult,
@@ -72,6 +73,15 @@ class PortfolioParseError(Exception):
 
     See spec §2.2.1 for the hierarchy rationale and §2.3.3 for the
     strict-raise sync contract that depends on it.
+    """
+
+
+class TradeHistoryParseError(Exception):
+    """Raised when a trade-history row cannot be parsed safely.
+
+    Same design as PortfolioParseError: directly subclasses Exception
+    so it is never swallowed by the incidental-exception handlers
+    inside the parse loop.
     """
 
 
@@ -427,6 +437,54 @@ class EtoroBrokerProvider(BrokerProvider):
             mirrors=tuple(_parse_mirrors_payload(raw_mirrors)),
         )
 
+    def get_trade_history(self, min_date: datetime, page_size: int = 200) -> Sequence[BrokerClosedTrade]:
+        """Fetch all closed-trade rows with closeTimestamp >= min_date.
+
+        The endpoint filters on the CLOSE timestamp (empirically probed,
+        #1593 spec §0) and paginates offset-style; we loop while pages
+        come back full, collecting everything before returning so the
+        service layer can group slices per position.
+
+        Env segment placement differs from the other info endpoints:
+        /api/v1/trading/info/trade/demo/history (demo) vs
+        /api/v1/trading/info/trade/history (real).
+
+        Raises on HTTP or network errors (caller should handle).
+        """
+        env_segment = "/demo" if self._env == "demo" else ""
+        path = f"/api/v1/trading/info/trade{env_segment}/history"
+
+        trades: list[BrokerClosedTrade] = []
+        page = 1
+        while True:
+            response = self._http_read.get(
+                path,
+                params={
+                    "minDate": min_date.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "page": str(page),
+                    "pageSize": str(page_size),
+                },
+                headers=self._request_headers(),
+            )
+            response.raise_for_status()
+            rows = response.json()
+            if not isinstance(rows, list):
+                raise TradeHistoryParseError(
+                    f"trade history page {page}: expected a JSON array, got {type(rows).__name__}"
+                )
+            for idx, row in enumerate(rows):
+                if not isinstance(row, dict):
+                    raise TradeHistoryParseError(f"trade history page {page} row {idx}: expected an object")
+                try:
+                    trades.append(_parse_closed_trade(row))
+                except (KeyError, ValueError, TypeError, decimal.DecimalException) as exc:
+                    raise TradeHistoryParseError(
+                        f"trade history page {page} row {idx} (position {row.get('positionId')}): {exc}"
+                    ) from exc
+            if len(rows) < page_size:
+                return trades
+            page += 1
+
 
 # ------------------------------------------------------------------
 # Normalisers — pure functions, no I/O
@@ -517,6 +575,51 @@ def _parse_direct_position(payload: dict[str, Any]) -> BrokerPosition:
         leverage=int(payload.get("leverage", 1)),
         is_tsl_enabled=bool(payload.get("isTslEnabled", False)),
         total_fees=Decimal(str(payload.get("totalFees", 0))),
+    )
+
+
+def _parse_closed_trade(payload: dict[str, Any]) -> BrokerClosedTrade:
+    """Parse one trade-history row into BrokerClosedTrade.
+
+    Pure normaliser — no I/O, no instance state. Required fields
+    (positionId, instrumentId, units, openTimestamp, closeTimestamp)
+    raise KeyError on absence; numerics go through Decimal(str(value)).
+    Optional ids: eToro uses 0 as the "none" sentinel for
+    socialTradeId / parentPositionId / orderId — preserved as-is here
+    (the service layer decides sentinel semantics; raw_payload keeps
+    the evidence either way).
+    """
+
+    def _opt_decimal(key: str) -> Decimal | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        return Decimal(str(value))
+
+    def _opt_int(key: str) -> int | None:
+        value = payload.get(key)
+        if value is None:
+            return None
+        return int(value)
+
+    return BrokerClosedTrade(
+        position_id=int(payload["positionId"]),
+        instrument_id=int(payload["instrumentId"]),
+        is_buy=bool(payload.get("isBuy", True)),
+        units=Decimal(str(payload["units"])),
+        open_rate=_opt_decimal("openRate"),
+        open_timestamp=_parse_iso_datetime(payload["openTimestamp"]),
+        close_rate=_opt_decimal("closeRate"),
+        close_timestamp=_parse_iso_datetime(payload["closeTimestamp"]),
+        net_profit=_opt_decimal("netProfit"),
+        fees=_opt_decimal("fees"),
+        investment=_opt_decimal("investment"),
+        initial_investment=_opt_decimal("initialInvestment"),
+        leverage=int(payload.get("leverage", 1)),
+        order_id=_opt_int("orderId"),
+        social_trade_id=_opt_int("socialTradeId"),
+        parent_position_id=_opt_int("parentPositionId"),
+        raw_payload=payload,
     )
 
 

--- a/app/runbooks/trade_events_reresolve_instruments.py
+++ b/app/runbooks/trade_events_reresolve_instruments.py
@@ -1,0 +1,70 @@
+"""Re-resolve unresolved instruments on trade_events rows (#1593 spec §17).
+
+``trade_events.instrument_id`` is NULL when the eToro instrument id was
+absent from the ``instruments`` universe at ingest time (delisted /
+removed instruments in deep history). After a universe sync introduces
+the missing rows, this runbook stamps the FK from the always-kept
+``etoro_instrument_id`` — instruments.instrument_id IS the eToro id, so
+resolution is a pure existence join. No fetch, no delete.
+
+Operator usage::
+
+    uv run python -m app.runbooks.trade_events_reresolve_instruments [--apply]
+
+Default mode is dry-run (prints the resolvable rows; no DB writes).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import psycopg
+import psycopg.rows
+
+from app.config import settings
+
+_CANDIDATES_SQL = """
+    SELECT te.event_id, te.position_id, te.event_kind, te.etoro_instrument_id,
+           i.symbol
+    FROM trade_events te
+    JOIN instruments i ON i.instrument_id = te.etoro_instrument_id
+    WHERE te.instrument_id IS NULL
+    ORDER BY te.event_id
+"""
+
+_APPLY_SQL = """
+    UPDATE trade_events te
+    SET instrument_id = te.etoro_instrument_id
+    FROM instruments i
+    WHERE te.instrument_id IS NULL
+      AND i.instrument_id = te.etoro_instrument_id
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="write the resolved ids (default: dry-run)")
+    args = parser.parse_args()
+
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            rows = cur.execute(_CANDIDATES_SQL).fetchall()
+        if not rows:
+            print("nothing to resolve — no trade_events rows with NULL instrument_id matching the universe")
+            return 0
+        for row in rows:
+            print(
+                f"event {row['event_id']} (position {row['position_id']} {row['event_kind']}): "
+                f"etoro_instrument_id {row['etoro_instrument_id']} -> {row['symbol']}"
+            )
+        if not args.apply:
+            print(f"dry-run: {len(rows)} row(s) resolvable — re-run with --apply to write")
+            return 0
+        result = conn.execute(_APPLY_SQL)
+        conn.commit()
+        print(f"applied: {result.rowcount} row(s) resolved")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/services/etoro_websocket.py
+++ b/app/services/etoro_websocket.py
@@ -595,6 +595,12 @@ class EtoroWebSocketSubscriber:
         # WS-only test path doesn't need).
         from app.providers.implementations.etoro_broker import EtoroBrokerProvider
         from app.services.portfolio_sync import sync_portfolio
+        from app.services.trade_events import compute_history_min_date, fetch_trade_history_safely
+
+        # Watermark read on a briefly-held pool conn BEFORE the provider
+        # session — never hold a pooled conn across HTTP (#1472 class).
+        with self._pool.connection() as conn:
+            history_min_date = compute_history_min_date(conn)
 
         with EtoroBrokerProvider(
             api_key=self._api_key,
@@ -602,12 +608,13 @@ class EtoroWebSocketSubscriber:
             env=self._env,
         ) as broker:
             portfolio = broker.get_portfolio()
+            trade_history = fetch_trade_history_safely(broker, history_min_date)
 
         with self._pool.connection() as conn:
             # ``ConnectionPool.connection()`` already commits on clean
             # exit / rolls back on error via ``with conn:`` — no
             # explicit commit needed here.
-            sync_portfolio(conn, portfolio)
+            sync_portfolio(conn, portfolio, trade_history=trade_history)
 
     def _sync_upsert(self, update: QuoteUpdate) -> None:
         """Sync helper offloaded to a worker thread per tick so the

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -36,6 +36,7 @@ from app.providers.broker import BrokerOrderResult, BrokerProvider, OrderParams
 from app.services.quote_marks import positive_decimal_or_none
 from app.services.return_attribution import compute_attribution, persist_attribution
 from app.services.runtime_config import get_runtime_config
+from app.services.trade_events import enqueue_post_trade_sync
 from app.services.transaction_cost import (
     estimate_cost,
     get_transaction_cost_config,
@@ -1140,6 +1141,12 @@ def execute_order(
             raw_payload=broker_result.raw_payload,
             now=now,
         )
+
+        # Filled trade → queue an immediate portfolio sync so the
+        # broker-observed event lands in trade_events within seconds
+        # (#1593). Same transaction: NOTIFY fires only at commit.
+        if fill_id is not None:
+            enqueue_post_trade_sync(conn, requested_by="execute_order")
 
     # --- Build explanation ---
     if order_status == "filled" and fill_id is not None:

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -35,10 +35,12 @@ import psycopg.rows
 import psycopg.types.json
 
 from app.providers.broker import (
+    BrokerClosedTrade,
     BrokerMirror,
     BrokerPortfolio,
     BrokerPosition,
 )
+from app.services.trade_events import record_trade_events
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +223,33 @@ def _upsert_broker_positions(
     # `!= ALL('{}'::bigint[])` predicate matches all rows, which is
     # the correct behaviour: if the broker reports nothing, nothing
     # should remain in broker_positions.
+    # Archive real-id rows before the sweep (#1593 spec §1.4): evidence
+    # copy of the last-seen broker state for externally-closed positions.
+    # Synthetic negative ids (#227) are handoff artefacts, not closes —
+    # excluded by the position_id >= 0 filter.
+    conn.execute(
+        """
+        INSERT INTO broker_positions_closed
+            (position_id, instrument_id, is_buy, units, initial_units,
+             amount, initial_amount_in_dollars, open_rate,
+             open_conversion_rate, open_date_time, stop_loss_rate,
+             take_profit_rate, is_no_stop_loss, is_no_take_profit,
+             leverage, is_tsl_enabled, total_fees, source, raw_payload,
+             updated_at, closed_detected_at)
+        SELECT position_id, instrument_id, is_buy, units, initial_units,
+               amount, initial_amount_in_dollars, open_rate,
+               open_conversion_rate, open_date_time, stop_loss_rate,
+               take_profit_rate, is_no_stop_loss, is_no_take_profit,
+               leverage, is_tsl_enabled, total_fees, source, raw_payload,
+               updated_at, %(now)s
+        FROM broker_positions
+        WHERE position_id >= 0
+          AND position_id != ALL(%(ids)s::bigint[])
+        ON CONFLICT (position_id, closed_detected_at) DO NOTHING
+        """,
+        {"ids": broker_position_ids, "now": now},
+    )
+
     deleted = 0
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
@@ -522,11 +551,19 @@ def sync_portfolio(
     conn: psycopg.Connection[Any],
     portfolio: BrokerPortfolio,
     now: datetime | None = None,
+    trade_history: Sequence[BrokerClosedTrade] | None = None,
 ) -> PortfolioSyncResult:
     """Reconcile local state against a broker portfolio snapshot.
 
     Must be called inside a transaction (autocommit=False, the default).
     The caller is responsible for committing.
+
+    ``trade_history``: closed-trade rows the caller fetched alongside the
+    portfolio (same provider session). When provided, close events are
+    ingested into the ``trade_events`` ledger; open events are ingested
+    from the portfolio payload on every call regardless (idempotent).
+    Pass None when the history fetch failed — positions still sync and
+    the next run's watermark re-covers the gap (#1593 spec §7).
     """
     if now is None:
         now = datetime.now(UTC)
@@ -690,6 +727,13 @@ def sync_portfolio(
         portfolio.positions,
         now,
     )
+
+    # Trade-events ledger (#1593): opens from the payload (idempotent
+    # re-emit, DO NOTHING dedupes), closes from the supplied history
+    # rows. Pure DB writes — all HTTP happened in the caller's provider
+    # session before this transaction.
+    ledger_counters = record_trade_events(conn, portfolio.positions, trade_history)
+    logger.info("trade_events ingest: %s", ledger_counters.log_line())
 
     for row in local_rows:
         iid = row["instrument_id"]

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -47,6 +47,11 @@ logger = logging.getLogger(__name__)
 # Cash deltas smaller than this are considered rounding noise.
 _CASH_SYNC_TOLERANCE = Decimal("0.01")
 
+# Advisory-lock key serializing sync_portfolio across its two callers
+# (scheduler job + WS reconcile). ASCII "eBull_PS" as int64, same
+# convention as JOBS_PROCESS_LOCK_KEY in app/jobs/locks.py.
+_SYNC_PORTFOLIO_XACT_LOCK_KEY = 0x6562756C6C5F5053
+
 
 @dataclass
 class PortfolioSyncResult:
@@ -567,6 +572,14 @@ def sync_portfolio(
     """
     if now is None:
         now = datetime.now(UTC)
+
+    # Serialize concurrent reconciles (scheduler tick + WS reconcile
+    # runner). Without this, two callers holding portfolio snapshots
+    # taken at different instants can interleave the archive/DELETE
+    # sweep against each other's upserts — archiving a live position as
+    # "closed externally" on stale evidence (#1593 Codex ckpt-2 HIGH).
+    # Transaction-scoped: released at the caller's commit/rollback.
+    conn.execute("SELECT pg_advisory_xact_lock(%s)", [_SYNC_PORTFOLIO_XACT_LOCK_KEY])
 
     updated = 0
     opened_externally = 0

--- a/app/services/trade_events.py
+++ b/app/services/trade_events.py
@@ -507,7 +507,10 @@ def record_trade_events(
     """Single entry point used by sync_portfolio."""
     counters = TradeEventCounters()
     opens = open_events_from_positions(positions, counters)
-    if trade_history:
+    # None = fetch failed (skip history ingest); [] = fetch succeeded
+    # with no rows. Identical output today, but the distinction is the
+    # §7 contract — keep it explicit.
+    if trade_history is not None:
         merged = merge_events(opens, events_from_history(trade_history, counters))
     else:
         merged = opens

--- a/app/services/trade_events.py
+++ b/app/services/trade_events.py
@@ -107,12 +107,14 @@ def _side(kind: EventKind, is_buy: bool) -> EventSide:
     return "sell" if is_buy else "buy"
 
 
-def _positive_or_none(value: Decimal | None, counters: TradeEventCounters) -> Decimal | None:
-    """Sentinel guard: a non-positive rate is NOT a valid mark (prevention log)."""
-    if value is None:
-        return None
-    if value <= 0:
-        counters.null_price += 1
+def _positive_or_none(value: Decimal | None) -> Decimal | None:
+    """Sentinel guard: a non-positive rate is NOT a valid mark (prevention log).
+
+    Pure mapping — the ``null_price`` counter is incremented at INGEST
+    time for rows that actually land, so merge-dropped duplicates never
+    inflate it (Codex ckpt-2 MED).
+    """
+    if value is None or value <= 0:
         return None
     return value
 
@@ -155,7 +157,7 @@ def open_events_from_positions(
                 event_kind="open",
                 side=_side("open", bp.is_buy),
                 units=units,
-                price=_positive_or_none(bp.open_price, counters),
+                price=_positive_or_none(bp.open_price),
                 executed_at=bp.open_date_time,
                 source="etoro_sync",
                 raw_payload=bp.raw_payload,
@@ -199,7 +201,7 @@ def events_from_history(
                     event_kind="open",
                     side=_side("open", earliest.is_buy),
                     units=total_units,
-                    price=_positive_or_none(earliest.open_rate, counters),
+                    price=_positive_or_none(earliest.open_rate),
                     executed_at=earliest.open_timestamp,
                     source="etoro_history",
                     raw_payload=earliest.raw_payload,
@@ -221,7 +223,7 @@ def events_from_history(
                     event_kind="close",
                     side=_side("close", t.is_buy),
                     units=t.units,
-                    price=_positive_or_none(t.close_rate, counters),
+                    price=_positive_or_none(t.close_rate),
                     executed_at=t.close_timestamp,
                     source="etoro_history",
                     raw_payload=t.raw_payload,
@@ -352,6 +354,11 @@ def ingest_trade_events(
         result = conn.execute(sql, params)
         if result.rowcount == 1:
             counters.inserted += 1
+            if event.price is None:
+                # Landed with NULL price (absent or sentinel rate) —
+                # counted here, not at transform time, so merge-dropped
+                # duplicates never inflate the figure (spec §15).
+                counters.null_price += 1
             touched_positions.add(event.position_id)
             continue
         # Conflict: expected duplicate unless the stored row disagrees

--- a/app/services/trade_events.py
+++ b/app/services/trade_events.py
@@ -1,0 +1,507 @@
+"""Trade-events ledger ingest (#1593).
+
+Append-only ``trade_events`` ledger of broker-observed position opens
+and closes. Spec: docs/proposals/etl/2026-06-13-etoro-trade-ledger.md.
+
+Writer topology: ``sync_portfolio`` is the ONLY writer — open events
+from the portfolio-payload positions, open+close events from the
+trade-history rows its callers fetch and pass in. The eBull order path
+never writes here (its broker_positions rows carry synthetic negative
+position ids, #227); it enqueues an immediate sync instead.
+
+Units contract (spec §1.7): an open event's ``units`` is the position's
+ORIGINAL opened size; each close event's ``units`` is that slice's
+delta. eToro partial closes reduce the same positionId, so a position
+may carry one open and N closes. ``conflict_anomaly`` counts every
+observation that violates this model — loud, never silently merged.
+
+Rows are immutable: conflicts are ``ON CONFLICT DO NOTHING`` against
+the two partial unique indexes (sql/194); first observation wins.
+Portfolio-sourced opens are preferred within a batch because they carry
+``initialUnits`` (history-derived opens are best-effort Σ-of-slices).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any, Literal
+
+import httpx
+import psycopg
+import psycopg.rows
+from psycopg.types.json import Jsonb
+
+from app.providers.broker import BrokerClosedTrade, BrokerPosition, BrokerProvider
+from app.providers.implementations.etoro_broker import TradeHistoryParseError
+from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
+
+logger = logging.getLogger(__name__)
+
+EventKind = Literal["open", "close"]
+EventSide = Literal["buy", "sell"]
+EventSource = Literal["etoro_sync", "etoro_history"]
+
+# Pre-dates any eToro retail account we could hold; the deep-backfill
+# minDate for an empty ledger.
+HISTORY_EPOCH = datetime(2017, 1, 1, tzinfo=UTC)
+
+# Re-fetch window behind the watermark — absorbs clock skew and
+# late-arriving rows; the unique indexes make the overlap idempotent.
+_WATERMARK_OVERLAP = timedelta(days=7)
+
+
+@dataclass(frozen=True)
+class TradeEvent:
+    """One broker-observed open or close, ready for insertion."""
+
+    position_id: int
+    etoro_instrument_id: int
+    event_kind: EventKind
+    side: EventSide
+    units: Decimal
+    price: Decimal | None
+    executed_at: datetime
+    source: EventSource
+    raw_payload: dict[str, Any]
+    fees_usd: Decimal | None = None
+    realized_pnl_usd: Decimal | None = None
+    investment_usd: Decimal | None = None
+    order_id: int | None = None
+    social_trade_id: int | None = None
+    parent_position_id: int | None = None
+
+
+@dataclass
+class TradeEventCounters:
+    """Closed-set ingest counters (spec §15). Logged by sync_portfolio."""
+
+    inserted: int = 0
+    duplicate: int = 0
+    unresolved_instrument: int = 0
+    null_price: int = 0
+    conflict_anomaly: int = 0
+    skipped_other: int = 0
+    skip_reasons: list[str] = field(default_factory=list)
+
+    def log_line(self) -> str:
+        line = (
+            f"inserted={self.inserted} duplicate={self.duplicate} "
+            f"unresolved_instrument={self.unresolved_instrument} "
+            f"null_price={self.null_price} "
+            f"conflict_anomaly={self.conflict_anomaly} "
+            f"other={self.skipped_other}"
+        )
+        if self.skip_reasons:
+            line += f" reasons={self.skip_reasons}"
+        return line
+
+
+def _side(kind: EventKind, is_buy: bool) -> EventSide:
+    """Open leg of a long is a buy and its close a sell; shorts invert."""
+    if kind == "open":
+        return "buy" if is_buy else "sell"
+    return "sell" if is_buy else "buy"
+
+
+def _positive_or_none(value: Decimal | None, counters: TradeEventCounters) -> Decimal | None:
+    """Sentinel guard: a non-positive rate is NOT a valid mark (prevention log)."""
+    if value is None:
+        return None
+    if value <= 0:
+        counters.null_price += 1
+        return None
+    return value
+
+
+def open_events_from_positions(
+    positions: Sequence[BrokerPosition],
+    counters: TradeEventCounters,
+) -> list[TradeEvent]:
+    """Open events for every real-id position in the portfolio payload.
+
+    Idempotent against the ledger (DO NOTHING on the per-position open
+    key), so every sync re-emits all opens rather than diffing —
+    simpler, and heals any gap. Synthetic negative ids (#227) and
+    id-less legacy rows are excluded by construction.
+
+    Fees are NOT stamped on open events: the position's ``totalFees``
+    accumulates over its whole life and the authoritative per-trade fee
+    arrives on the history close row — stamping both would double-count
+    for consumers. The raw payload keeps the running figure.
+    """
+    events: list[TradeEvent] = []
+    for bp in positions:
+        if bp.position_id is None or bp.position_id < 0:
+            continue
+        if bp.open_date_time is None:
+            # Cannot fabricate an executed_at (external timestamps must
+            # come from the API response, never now() — prevention log).
+            counters.skipped_other += 1
+            counters.skip_reasons.append(f"open_event position {bp.position_id}: no openDateTime in payload")
+            continue
+        units = bp.initial_units if bp.initial_units is not None and bp.initial_units > 0 else bp.units
+        if units <= 0:
+            counters.skipped_other += 1
+            counters.skip_reasons.append(f"open_event position {bp.position_id}: non-positive units")
+            continue
+        events.append(
+            TradeEvent(
+                position_id=bp.position_id,
+                etoro_instrument_id=bp.instrument_id,
+                event_kind="open",
+                side=_side("open", bp.is_buy),
+                units=units,
+                price=_positive_or_none(bp.open_price, counters),
+                executed_at=bp.open_date_time,
+                source="etoro_sync",
+                raw_payload=bp.raw_payload,
+                investment_usd=bp.initial_amount_in_dollars if bp.initial_amount_in_dollars > 0 else None,
+            )
+        )
+    return events
+
+
+def events_from_history(
+    trades: Sequence[BrokerClosedTrade],
+    counters: TradeEventCounters,
+) -> list[TradeEvent]:
+    """Transform history rows into events: one close per slice plus one
+    synthesized open per position (Σ slice units, earliest open leg).
+
+    The synthesized open is only a fallback for positions the ledger
+    never saw open in a portfolio payload — merge_events() prefers a
+    portfolio-sourced open, and the DB open key keeps whichever landed
+    first thereafter.
+    """
+    by_position: dict[int, list[BrokerClosedTrade]] = {}
+    for t in trades:
+        if t.position_id < 0:
+            # Never observed in probes; guard matches the ledger CHECK.
+            counters.skipped_other += 1
+            counters.skip_reasons.append(f"history row position {t.position_id}: negative id")
+            continue
+        by_position.setdefault(t.position_id, []).append(t)
+
+    events: list[TradeEvent] = []
+    for position_id, rows in by_position.items():
+        rows.sort(key=lambda t: t.open_timestamp)
+        earliest = rows[0]
+        total_units = sum((t.units for t in rows), Decimal("0"))
+        if total_units > 0:
+            events.append(
+                TradeEvent(
+                    position_id=position_id,
+                    etoro_instrument_id=earliest.instrument_id,
+                    event_kind="open",
+                    side=_side("open", earliest.is_buy),
+                    units=total_units,
+                    price=_positive_or_none(earliest.open_rate, counters),
+                    executed_at=earliest.open_timestamp,
+                    source="etoro_history",
+                    raw_payload=earliest.raw_payload,
+                    investment_usd=earliest.initial_investment,
+                    order_id=earliest.order_id,
+                    social_trade_id=earliest.social_trade_id,
+                    parent_position_id=earliest.parent_position_id,
+                )
+            )
+        for t in rows:
+            if t.units <= 0:
+                counters.skipped_other += 1
+                counters.skip_reasons.append(f"history row position {position_id}: non-positive units")
+                continue
+            events.append(
+                TradeEvent(
+                    position_id=position_id,
+                    etoro_instrument_id=t.instrument_id,
+                    event_kind="close",
+                    side=_side("close", t.is_buy),
+                    units=t.units,
+                    price=_positive_or_none(t.close_rate, counters),
+                    executed_at=t.close_timestamp,
+                    source="etoro_history",
+                    raw_payload=t.raw_payload,
+                    fees_usd=t.fees,
+                    realized_pnl_usd=t.net_profit,
+                    investment_usd=t.investment,
+                    order_id=t.order_id,
+                    social_trade_id=t.social_trade_id,
+                    parent_position_id=t.parent_position_id,
+                )
+            )
+    return events
+
+
+def merge_events(
+    portfolio_opens: Sequence[TradeEvent],
+    history_events: Sequence[TradeEvent],
+) -> list[TradeEvent]:
+    """Combine the two streams, preferring a portfolio-sourced open for
+    any position present in both (it carries initialUnits; the
+    history-derived open is Σ-of-slices best-effort)."""
+    open_positions_covered = {e.position_id for e in portfolio_opens}
+    merged = list(portfolio_opens)
+    for e in history_events:
+        if e.event_kind == "open" and e.position_id in open_positions_covered:
+            continue
+        merged.append(e)
+    return merged
+
+
+def compute_history_min_date(conn: psycopg.Connection[Any]) -> datetime:
+    """minDate for the next trade-history fetch.
+
+    The endpoint filters on closeTimestamp (probed, spec §0), so the
+    max ingested close is the correct watermark; the overlap re-walks a
+    window the unique indexes dedupe. Empty ledger → deep backfill.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        row = cur.execute(
+            """
+            SELECT MAX(executed_at) AS watermark
+            FROM trade_events
+            WHERE event_kind = 'close' AND source = 'etoro_history'
+            """
+        ).fetchone()
+    watermark = row["watermark"] if row else None
+    if watermark is None:
+        return HISTORY_EPOCH
+    return watermark - _WATERMARK_OVERLAP
+
+
+_INSERT_OPEN_SQL = """
+    INSERT INTO trade_events
+        (position_id, etoro_instrument_id, instrument_id, event_kind, side,
+         units, price, executed_at, fees_usd, realized_pnl_usd,
+         investment_usd, order_id, social_trade_id, parent_position_id,
+         source, raw_payload)
+    VALUES
+        (%(position_id)s, %(etoro_instrument_id)s, %(instrument_id)s,
+         %(event_kind)s, %(side)s, %(units)s, %(price)s, %(executed_at)s,
+         %(fees_usd)s, %(realized_pnl_usd)s, %(investment_usd)s,
+         %(order_id)s, %(social_trade_id)s, %(parent_position_id)s,
+         %(source)s, %(raw_payload)s)
+    ON CONFLICT (position_id) WHERE event_kind = 'open' DO NOTHING
+"""
+
+_INSERT_CLOSE_SQL = """
+    INSERT INTO trade_events
+        (position_id, etoro_instrument_id, instrument_id, event_kind, side,
+         units, price, executed_at, fees_usd, realized_pnl_usd,
+         investment_usd, order_id, social_trade_id, parent_position_id,
+         source, raw_payload)
+    VALUES
+        (%(position_id)s, %(etoro_instrument_id)s, %(instrument_id)s,
+         %(event_kind)s, %(side)s, %(units)s, %(price)s, %(executed_at)s,
+         %(fees_usd)s, %(realized_pnl_usd)s, %(investment_usd)s,
+         %(order_id)s, %(social_trade_id)s, %(parent_position_id)s,
+         %(source)s, %(raw_payload)s)
+    ON CONFLICT (position_id, executed_at) WHERE event_kind = 'close' DO NOTHING
+"""
+
+
+def ingest_trade_events(
+    conn: psycopg.Connection[Any],
+    events: Sequence[TradeEvent],
+    counters: TradeEventCounters,
+) -> TradeEventCounters:
+    """Insert events; immutable semantics (DO NOTHING + loud anomalies).
+
+    Runs on the caller's transaction — never commits (sync_portfolio's
+    contract). All I/O happened before this call; pure DB writes here.
+    """
+    if not events:
+        return counters
+
+    distinct_ids = sorted({e.etoro_instrument_id for e in events})
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        rows = cur.execute(
+            "SELECT instrument_id FROM instruments WHERE instrument_id = ANY(%s)",
+            [distinct_ids],
+        ).fetchall()
+    known_instruments = {row["instrument_id"] for row in rows}
+
+    touched_positions: set[int] = set()
+    for event in events:
+        resolved = event.etoro_instrument_id if event.etoro_instrument_id in known_instruments else None
+        if resolved is None:
+            counters.unresolved_instrument += 1
+        params = {
+            "position_id": event.position_id,
+            "etoro_instrument_id": event.etoro_instrument_id,
+            "instrument_id": resolved,
+            "event_kind": event.event_kind,
+            "side": event.side,
+            "units": event.units,
+            "price": event.price,
+            "executed_at": event.executed_at,
+            "fees_usd": event.fees_usd,
+            "realized_pnl_usd": event.realized_pnl_usd,
+            "investment_usd": event.investment_usd,
+            "order_id": event.order_id,
+            "social_trade_id": event.social_trade_id,
+            "parent_position_id": event.parent_position_id,
+            "source": event.source,
+            "raw_payload": Jsonb(event.raw_payload),
+        }
+        sql = _INSERT_OPEN_SQL if event.event_kind == "open" else _INSERT_CLOSE_SQL
+        result = conn.execute(sql, params)
+        if result.rowcount == 1:
+            counters.inserted += 1
+            touched_positions.add(event.position_id)
+            continue
+        # Conflict: expected duplicate unless the stored row disagrees
+        # on the financial figures — that is an anomaly worth shouting
+        # about (advisory check; race-tolerant, logging only).
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            existing = cur.execute(
+                """
+                SELECT units, realized_pnl_usd
+                FROM trade_events
+                WHERE position_id = %(pid)s AND event_kind = %(kind)s
+                  AND (%(kind)s = 'open' OR executed_at = %(executed_at)s)
+                ORDER BY event_id
+                LIMIT 1
+                """,
+                {"pid": event.position_id, "kind": event.event_kind, "executed_at": event.executed_at},
+            ).fetchone()
+        if existing is None:
+            # Row vanished between INSERT and SELECT — impossible for an
+            # append-only table outside test truncation; count loudly.
+            counters.conflict_anomaly += 1
+            logger.warning(
+                "trade_events: conflict with no existing row (position %d %s) — investigate",
+                event.position_id,
+                event.event_kind,
+            )
+            continue
+        same_units = Decimal(str(existing["units"])) == event.units
+        same_pnl = (existing["realized_pnl_usd"] is None and event.realized_pnl_usd is None) or (
+            existing["realized_pnl_usd"] is not None
+            and event.realized_pnl_usd is not None
+            and Decimal(str(existing["realized_pnl_usd"])) == event.realized_pnl_usd
+        )
+        if same_units and (event.event_kind == "open" or same_pnl):
+            counters.duplicate += 1
+        else:
+            counters.conflict_anomaly += 1
+            logger.warning(
+                "trade_events: %s event for position %d conflicts with stored figures "
+                "(stored units=%s pnl=%s, incoming units=%s pnl=%s) — first observation kept; "
+                "incoming payload: %s",
+                event.event_kind,
+                event.position_id,
+                existing["units"],
+                existing["realized_pnl_usd"],
+                event.units,
+                event.realized_pnl_usd,
+                event.raw_payload,
+            )
+
+    _check_close_sum_invariant(conn, touched_positions, counters)
+    return counters
+
+
+def _check_close_sum_invariant(
+    conn: psycopg.Connection[Any],
+    position_ids: set[int],
+    counters: TradeEventCounters,
+) -> None:
+    """Σ(close units) must not exceed the open's units (spec §4)."""
+    if not position_ids:
+        return
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        rows = cur.execute(
+            """
+            SELECT o.position_id, o.units AS open_units,
+                   SUM(c.units) AS closed_units
+            FROM trade_events o
+            JOIN trade_events c
+              ON c.position_id = o.position_id AND c.event_kind = 'close'
+            WHERE o.event_kind = 'open'
+              AND o.position_id = ANY(%s)
+            GROUP BY o.position_id, o.units
+            HAVING SUM(c.units) > o.units
+            """,
+            [sorted(position_ids)],
+        ).fetchall()
+    for row in rows:
+        counters.conflict_anomaly += 1
+        logger.warning(
+            "trade_events: position %d closes sum to %s > open units %s — "
+            "partial-close model violation, investigate (spec §22.1)",
+            row["position_id"],
+            row["closed_units"],
+            row["open_units"],
+        )
+
+
+# Must equal scheduler.JOB_DAILY_PORTFOLIO_SYNC — duplicated here because
+# importing the scheduler would be circular (it imports this module).
+# Pinned by tests/test_trade_events.py::test_post_trade_sync_job_name.
+POST_TRADE_SYNC_JOB = "daily_portfolio_sync"
+
+
+def enqueue_post_trade_sync(conn: psycopg.Connection[Any], *, requested_by: str) -> None:
+    """Queue an immediate portfolio sync after a successful fill so the
+    trade lands in the ledger within seconds instead of the next 5-min
+    tick (#1593 spec §1.3). Runs on the caller's transaction — NOTIFY
+    fires at commit, so the jobs process wakes only once the fill row
+    is durable. If the enqueue is lost, the scheduled tick covers it.
+    """
+    publish_manual_job_request_with_conn(conn, POST_TRADE_SYNC_JOB, requested_by=requested_by)
+
+
+def fetch_trade_history_safely(
+    broker: BrokerProvider,
+    min_date: datetime,
+) -> Sequence[BrokerClosedTrade] | None:
+    """Fetch history with the spec §7 error posture; None = skip ingest.
+
+    A failed fetch must never block the position sync: 4xx request-shape
+    or permission regressions are loud ERRORs (deterministic — fix code
+    or key scopes); transient network/429/5xx are WARNINGs. Either way
+    the watermark is untouched, so the next sync re-covers the window.
+    """
+    try:
+        return broker.get_trade_history(min_date)
+    except httpx.HTTPStatusError as exc:
+        log = logger.error if exc.response.status_code in (400, 403) else logger.warning
+        log(
+            "trade history fetch failed (HTTP %d) — positions still sync, watermark unchanged",
+            exc.response.status_code,
+            exc_info=True,
+        )
+        return None
+    except httpx.HTTPError:
+        logger.warning(
+            "trade history fetch failed (network) — positions still sync, watermark unchanged",
+            exc_info=True,
+        )
+        return None
+    except TradeHistoryParseError:
+        logger.error(
+            "trade history response failed to parse — deterministic, fix the parser; "
+            "positions still sync, watermark unchanged",
+            exc_info=True,
+        )
+        return None
+
+
+def record_trade_events(
+    conn: psycopg.Connection[Any],
+    positions: Sequence[BrokerPosition],
+    trade_history: Sequence[BrokerClosedTrade] | None,
+) -> TradeEventCounters:
+    """Single entry point used by sync_portfolio."""
+    counters = TradeEventCounters()
+    opens = open_events_from_positions(positions, counters)
+    if trade_history:
+        merged = merge_events(opens, events_from_history(trade_history, counters))
+    else:
+        merged = opens
+    return ingest_trade_events(conn, merged, counters)

--- a/app/services/trade_events.py
+++ b/app/services/trade_events.py
@@ -497,6 +497,17 @@ def fetch_trade_history_safely(
             exc_info=True,
         )
         return None
+    except NotImplementedError:
+        # BrokerProvider ships a non-abstract default that raises — a
+        # provider without an override must degrade to history-skip,
+        # never break the position sync (review round-3 WARNING).
+        logger.error(
+            "broker provider %s does not implement get_trade_history — "
+            "positions still sync, ledger gets no history from this provider",
+            type(broker).__name__,
+            exc_info=True,
+        )
+        return None
 
 
 def record_trade_events(

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -81,6 +81,7 @@ from app.services.sync_orchestrator.progress import report_progress
 from app.services.sync_orchestrator.row_count_spikes import check_row_count_spike
 from app.services.tax_ledger import ingest_tax_events, run_disposal_matching
 from app.services.thesis import find_stale_instruments, generate_thesis
+from app.services.trade_events import compute_history_min_date, fetch_trade_history_safely
 from app.services.universe import sync_universe
 from app.services.watermarks import get_watermark, set_watermark
 
@@ -2892,15 +2893,23 @@ def daily_portfolio_sync() -> None:
 
     api_key, user_key = creds
     with _tracked_job(JOB_DAILY_PORTFOLIO_SYNC) as tracker:
+        # Watermark read on its own short-lived conn BEFORE the provider
+        # session — no DB conn held across HTTP (#1593 spec PR-1 plan).
+        with psycopg.connect(settings.database_url) as wm_conn:
+            history_min_date = compute_history_min_date(wm_conn)
+
         with EtoroBrokerProvider(
             api_key=api_key,
             user_key=user_key,
             env=settings.etoro_env,
         ) as broker:
             portfolio = broker.get_portfolio()
+            # None on fetch failure — positions still sync; the
+            # unmoved watermark re-covers the window next tick.
+            trade_history = fetch_trade_history_safely(broker, history_min_date)
 
         with psycopg.connect(settings.database_url) as conn:
-            result = sync_portfolio(conn, portfolio)
+            result = sync_portfolio(conn, portfolio, trade_history=trade_history)
 
             # Auto-promote held instruments to Tier 1 so market data,
             # FX rates, and downstream jobs fire for them. Without this,

--- a/docs/proposals/etl/2026-06-13-etoro-trade-ledger.md
+++ b/docs/proposals/etl/2026-06-13-etoro-trade-ledger.md
@@ -1,0 +1,302 @@
+# eToro trade ledger — `trade_events` + Activity surface (#1593, folds #393)
+
+Status: PROPOSAL v3 (Codex ckpt-1 rounds 1-2 folded) — awaiting operator sign-off.
+Consumers: #1594 (portfolio value-over-time v2 `units_at_day`), reports epic (period activity).
+
+## §0 Grep proof
+
+> Generated 2026-06-13 against branch main @ b3a9cd89. Line numbers exact.
+
+### Migration numbering
+
+```text
+$ ls sql/ | sort -t_ -k1 -n | tail -1
+193_instrument_dimensional_facts.sql        → this spec takes sql/194
+```
+
+### Sink shape — broker_positions (read + archived by this spec)
+
+```text
+$ grep -n "PRIMARY KEY\|REFERENCES\|initial_units" sql/024_broker_positions.sql
+15:    position_id              BIGINT PRIMARY KEY,                   -- eToro positionID
+16:    instrument_id            BIGINT NOT NULL REFERENCES instruments(instrument_id),
+19:    initial_units            NUMERIC(20, 8),                       -- detect partial closes (isPartiallyAltered)
+```
+
+Line 19's comment is load-bearing for §4: eToro's partial-close model is
+same-id reduction — positionId persists, `units` shrinks, `initialUnits`
+keeps the original, `isPartiallyAltered` flags it.
+
+### Writers + sweep + callers
+
+```text
+$ grep -rn "INSERT INTO broker_positions" app/ --include="*.py"
+app/api/orders.py:285
+app/services/order_client.py:583
+app/services/portfolio_sync.py:150        (inside _upsert_broker_positions, def at :121)
+
+$ grep -n "DELETE FROM broker_positions" app/services/portfolio_sync.py
+228:            DELETE FROM broker_positions          (disappeared-sweep; called from sync_portfolio at :688)
+
+$ grep -n -- "-order_id" app/api/orders.py app/services/order_client.py
+app/api/orders.py:282:        synthetic_position_id = -order_id     (#227 — negative synthetic namespace)
+app/services/order_client.py:565 (docstring) + :607 ("pid": -order_id)
+
+$ grep -n "sync_portfolio" app/services/etoro_websocket.py | grep -v "^#"
+587: (docstring) _default_reconcile_runner runs ``sync_portfolio`` against a fresh DB connection
+→ sync_portfolio has TWO callers: app/workers/scheduler.py:2903 (daily_portfolio_sync,
+  the only scheduled site) and the WS reconcile runner.
+
+$ grep -rn "trade_events" app/ sql/        (no hits — name free)
+```
+
+### Empirical probes (2026-06-13, demo creds; raw captures /tmp/etoro_probe/*.json → fixture in PR-1)
+
+```text
+GET /api/v1/trading/info/trade/demo/history?minDate=2020-01-01T00:00:00Z&page=1&pageSize=50
+→ HTTP 200, list[1]: {positionId: 3308442654, instrumentId: 4077 (ILMN), isBuy: true,
+   openTimestamp: 2025-08-12T16:47:12.643Z, openRate: 97.3,
+   closeTimestamp: 2025-11-14T19:24:35.307Z, closeRate: 120.56,
+   units: 82.135523, netProfit: 1910.47, fees: 0.0, investment: 7991.79,
+   initialInvestment: 7991.79, leverage: 1, orderId: 272136682, socialTradeId: 0,
+   parentPositionId: 0, stopLossRate: 0.0001, takeProfitRate: 200.0, trailingStopLoss: false}
+
+minDate filter-field probe (ILMN open 2025-08-12, close 2025-11-14):
+  minDate=2025-10-01 (between legs)  → list[1]   — open-date filtering REFUTED
+  minDate=2025-12-01 (after close)   → list[0]
+  ⇒ filter ≡ closeTimestamp >= minDate (an "either-leg" filter is mathematically
+    equivalent since close > open). Watermark on max(close) is the correct field.
+
+pageSize=500 → 200 (no cap error observed); minDate date-only form → 200.
+Rate headers on every response: ratelimit-limit: 60, ratelimit-policy: 60;w=60.
+
+GET /api/v1/balances/history → 403 {"errorCode":"InsufficientPermissions"};
+GET /api/v1/balances → 403 (same) — current demo API key lacks balances scope.
+
+OpenAPI v1.244.0 (fetched 2026-06-13): balances/history = EOD snapshots, 12-month
+lookback, 365d max/request. trade/demo/history params = exactly
+{x-request-id, x-api-key, x-user-key, minDate(required), page, pageSize};
+no ETag/If-Modified-Since/304 on it (ETag exists only on aggregate-portfolio +
+agent-portfolio endpoints).
+```
+
+## §1 Decisions
+
+1. New append-only `trade_events` table (sql/194): one row per broker-observed position **open** or **close** event. Immutable — no UPDATE path, conflict = DO NOTHING.
+2. **Demo trade history is ingestible**: `GET /api/v1/trading/info/trade/demo/history` works on the demo account (probed; §0). One row per closed slice carrying both legs. Backfill = first fetch with deep `minDate`; steady-state = same fetch every `portfolio_sync` tick with a watermark-derived `minDate` (filter field empirically validated, §0).
+3. **Single writer service**: `sync_portfolio` itself is the only `trade_events` writer. Its signature gains an optional `trade_history: Sequence[ClosedTradeRow] | None = None` parameter — open events from the portfolio-payload position diff (always), open+close events from the supplied history rows (when provided). BOTH callers are updated explicitly in PR-1: `scheduler.py::daily_portfolio_sync` and the WS `_default_reconcile_runner` (§0) each fetch all history pages inside their own provider session and pass them in — no caller silently skips the ledger. Writes are idempotent under concurrent callers (atomic `ON CONFLICT DO NOTHING`; the mismatch WARNING is advisory logging, race-tolerant). Our own order/close path does NOT write the ledger directly (deviation from the issue sketch): its `broker_positions` rows use synthetic negative position ids (#227, both writers — §0) that are replaced by real ids at next sync, so order-path events would orphan. **NEW in PR-1**: after a successful broker call, the order path enqueues an immediate manual run of the registered job `daily_portfolio_sync` (manual-queue dispatch is by JOB NAME — `JOB_DAILY_PORTFOLIO_SYNC`, scheduler.py:307 — via the `publish_manual_job_request_with_conn` precedent); no such enqueue exists today (orders.py persists and stops); if the enqueue fails, freshness degrades to the next 5-min scheduled tick. Intent-side audit already lives in `orders`/`fills`/`decision_audit`.
+4. Externally-closed positions are **archived, not just deleted**: the disappeared-DELETE sweep copies rows to `broker_positions_closed` before deleting. **Every ledger/archive read from `broker_positions` filters `position_id >= 0`** — synthetic negative rows are handoff artefacts: never archived, never diffed into open events (the open-event diff additionally keys on broker-payload ids, which are real by construction).
+5. `cash_ledger` is NOT written by this path — cash truth stays with the existing broker_sync reconcile (no double-count).
+6. #393 closes with: equity-over-time exists in the API (`/api/v1/balances/history`) but returns 403 InsufficientPermissions on our demo key; 12-month lookback cap anyway. Our own EOD persistence (#1594) is the equity-history source; revisit only if the operator regenerates keys with balances scope. (Findings posted on #393.)
+7. **Units contract** (consumed by #1594): an open event's `units` = the position's ORIGINAL opened units; each close event's `units` = the closed slice delta. Invariant: Σ(close units) ≤ open units per position_id; net-open at time t = open − Σ(closes ≤ t), clamped ≥ 0 by consumers. See §4.
+8. Operator sees: `GET /portfolio/activity` + Activity tab on PortfolioPage (PR-2) — when bought/sold, price, fees, holding period, realised P&L per closed trade.
+
+## §2 Identifiers + identity-drift
+
+- `position_id` (eToro positionID, int64) — event identity anchor. Stable for a position's lifetime including partial closes (same-id reduction model, §0/§4). Synthetic negative ids never enter `trade_events`: open-event diff keys on broker-payload position ids (real by construction); history rows carry real ids; the `position_id >= 0` CHECK is the backstop.
+- `instrumentId` (eToro int) — numerically equal to our `instruments.instrument_id` (verified: 4077 = ILMN on dev). Historical closed trades may reference instruments no longer in the universe → two columns: `etoro_instrument_id BIGINT NOT NULL` (raw, always set) + `instrument_id BIGINT NULL REFERENCES instruments` (set when resolvable at ingest). No silent drops: unresolved rows still land, `instrument_id IS NULL`, surfaced in the Activity UI as `#<etoro_id>`. A runbook re-resolve exists for later universe additions (§17).
+- `orderId`, `socialTradeId`, `parentPositionId` — carried as columns; `social_trade_id != 0` marks mirror-originated trades (FE default-filters them, consistent with value-history excluding mirrors). `orderId` provenance (open-order vs close-order id) is unverified — kept as data, NOT used in conflict keys (§21).
+- Symbol changes are non-events (id-keyed). Instrument-id reuse by eToro: not observed; raw payload preserves the evidence if it ever happens.
+
+## §3 Endpoint surface
+
+| url | method | body_schema_version | sample_response_fixture_path |
+|---|---|---|---|
+| `/api/v1/trading/info/trade{/demo}/history?minDate=&page=&pageSize=` | GET | OpenAPI v1.244.0 | `tests/fixtures/etoro/trade_history_demo.json` (added in PR-1 from the probe capture) |
+
+- Env segment placement: `/trade/demo/history` (demo) vs `/trade/history` (real) — differs from the `/info{/demo}/portfolio` convention; provider builds it explicitly.
+- `minDate` REQUIRED; filters on `closeTimestamp >= minDate` (probed, §0). `page` (1-based) + `pageSize` optional; loop while `len(rows) == pageSize`, collect ALL pages before transform (per-position grouping needs the full batch, §4). Empty result = `[]` (HTTP 200).
+- Response row schema: §0 probe. Money fields = USD account-currency floats; `units` float (6dp observed); timestamps ISO-8601 UTC with ms.
+- Closed-slices only: every row has both legs. Open events for still-open positions come from the `/trading/info{/demo}/portfolio` payload already fetched by `sync_portfolio` — no extra endpoint.
+
+## §4 Schema
+
+```sql
+-- sql/194_trade_events.sql
+CREATE TABLE trade_events (
+    event_id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    position_id         BIGINT NOT NULL CHECK (position_id >= 0),
+    etoro_instrument_id BIGINT NOT NULL,
+    instrument_id       BIGINT REFERENCES instruments(instrument_id),
+    event_kind          TEXT NOT NULL CHECK (event_kind IN ('open', 'close')),
+    side                TEXT NOT NULL CHECK (side IN ('buy', 'sell')),
+    units               NUMERIC(20, 8) NOT NULL CHECK (units > 0),
+    price               NUMERIC(20, 8) CHECK (price > 0),
+    executed_at         TIMESTAMPTZ NOT NULL,
+    fees_usd            NUMERIC(20, 4),
+    realized_pnl_usd    NUMERIC(20, 4) CHECK (event_kind = 'close' OR realized_pnl_usd IS NULL),
+    investment_usd      NUMERIC(20, 4),
+    order_id            BIGINT,
+    social_trade_id     BIGINT,
+    parent_position_id  BIGINT,
+    source              TEXT NOT NULL CHECK (source IN ('etoro_sync', 'etoro_history')),
+    raw_payload         JSONB NOT NULL,
+    recorded_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX uq_trade_events_open
+    ON trade_events (position_id) WHERE event_kind = 'open';
+CREATE UNIQUE INDEX uq_trade_events_close
+    ON trade_events (position_id, executed_at) WHERE event_kind = 'close';
+CREATE INDEX ix_trade_events_instrument_time
+    ON trade_events (instrument_id, executed_at);
+
+-- archive for externally-closed broker rows (evidence; not a ledger consumer input)
+CREATE TABLE broker_positions_closed (
+    LIKE broker_positions INCLUDING DEFAULTS,
+    closed_detected_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (position_id, closed_detected_at)
+);
+```
+
+- Index Budget: `trade_events` = PK + 3 = 4, at cap, none to spare (declared). `broker_positions_closed` = PK only.
+- **Units semantics under the partial-close model** (same-id reduction, §0 sql/024:19):
+  - Open event from the portfolio diff: `units = initialUnits` from the payload (fall back to `units` when absent) — the ORIGINAL size, immune to later partial closes.
+  - Open event synthesized from history (position fully closed before the ledger ever saw it): the transform groups the fetched batch by `positionId` and emits ONE open with `units = Σ slice units`, `executed_at = min(openTimestamp)`. Correctness: a never-observed position only enters via the deep-backfill window, which spans the account lifetime, so ALL its slices are in the batch. A position observed open during our watch gets its open from the portfolio diff (initialUnits) before any close arrives — first write wins, later history opens are expected duplicates.
+  - Close events: one per history row, `units` = that slice's delta.
+  - Monitored invariant: at ingest, if Σ(close units) would exceed the stored open's units for a position, count `conflict_anomaly` (§15) and WARN with both payloads — loud, never silent, no overwrite.
+- `side` stamped at ingest: open → `buy` if `isBuy` else `sell`; close → the opposite. `isBuy` stays in `raw_payload` (no denormalised twin to drift).
+- Encoding/precision: floats parsed `Decimal(str(x))` (prevention-log: never `Decimal(float)`); units/price NUMERIC(20,8), USD money NUMERIC(20,4) (precedent: sql/184).
+- `price` nullable + `> 0` CHECK: eToro sentinel zeros (e.g. `stopLossRate: 0.0001`) must not become marks (prevention-log: non-positive price ≠ valid mark). Zero/absent rate → NULL price, row still lands, counted (§15).
+- TIMESTAMPTZ everywhere; `executed_at` ALWAYS from the API payload (`openTimestamp`/`closeTimestamp`/`openDateTime`), never `now()` (prevention-log).
+- No `ON DELETE CASCADE` anywhere (audit-grade table).
+
+## §5 Fetch strategy + rate-limit composition
+
+- `per_resource_http`, but the "resource" is the single account: 1 GET per sync tick (+pagination pages, expected 1 for years yet).
+- Budget: eToro 60 GET/min per user key (header-confirmed). Each 5-min `orchestrator_high_frequency_sync` tick currently spends ~2 GETs (portfolio, fx); this adds 1 → ~3 per 5 min. No new lane: runs inside the existing `portfolio_sync` execution slot. WS-reconcile-triggered runs add at most a handful more — still two orders of magnitude under budget.
+
+## §6 Conditional-GET semantics
+
+N/A on this endpoint — OpenAPI v1.244.0 declares no ETag/If-Modified-Since/304 for trade history (§0; ETag exists only on aggregate-portfolio + agent-portfolio endpoints). `minDate` watermark is the delta mechanism.
+
+## §7 Retry posture per error-class
+
+| status | posture |
+|---|---|
+| 429 / 5xx / timeout | Skip history ingest this tick, log WARNING; watermark unmoved so next tick (≤5 min) re-fetches. Position upsert/diff is unaffected (history ingest runs as a separate step after the position transaction commits). |
+| 403 | Loud ERROR (permission regression — observed on balances, §0; must not be silent on trade history). |
+| 400 | Loud ERROR (request-shape bug — deterministic, fix code). |
+
+No retry-storm risk: nothing re-fires faster than the sync cadence.
+
+## §8 Multi-writer sink registry
+
+`trade_events` is a NEW sink with ONE writer function (`sync_portfolio`, history rows supplied via its new optional parameter — §1.3), reached from two call sites (scheduled `daily_portfolio_sync`, WS `_default_reconcile_runner` — §0; both updated in PR-1 to fetch and pass history). Concurrency safety: conflict keys = the two partial unique indexes (§4); conflict action = `ON CONFLICT DO NOTHING` (atomic, first observation wins). Disagreement detection (same key, different figures) is a post-insert advisory SELECT + WARNING — logging only, race-tolerant by construction.
+
+`broker_positions_closed`: one writer (the archive step inside `_upsert_broker_positions`' delete sweep), filtered `position_id >= 0` (§1.4).
+
+This spec adds NO writer to any existing multi-writer sink (`cash_ledger` untouched — §1.5).
+
+## §9 Watermark + retry-budget
+
+- `minDate = COALESCE(MAX(executed_at) FILTER (WHERE event_kind='close' AND source='etoro_history'), '2017-01-01') - interval '7 days'`. The endpoint filters on `closeTimestamp` (probed, §0), so max-close is the correct watermark field — a position opened years ago and closed yesterday has `closeTimestamp` inside any recent window and cannot be missed. Derived from the sink itself — no separate watermark row to drift. 7-day overlap absorbs skew; unique indexes make re-ingest idempotent.
+- Empty ledger → deep backfill happens automatically on first sync after migration (bootstrap = steady-state with a wider window; satisfies the bulk-first-load rule with ~1-3 HTTP calls).
+- Retry budget: none beyond §7 (cadence-bounded).
+
+## §10 Encoding / precision / NULL / timezone
+
+Covered in §4: `Decimal(str(...))` parsing, NUMERIC precisions, TIMESTAMPTZ UTC from payload, JSONB raw payload stored as received. SQL NULL (not JSON null) for absent optionals.
+
+## §11 Backfill horizon + retention
+
+- Horizon: account lifetime (`minDate` 2017-01-01 pre-dates the demo account; 2020 probe accepted). Volume: single account, long-horizon strategy → O(10²) rows/year. Storage negligible.
+- Retention: forever. Append-only audit ledger; no sweep. `broker_positions_closed` likewise.
+
+## §12 Partition strategy + extension deadline
+
+N/A — O(hundreds) rows/year for one account; partitioning is pure overhead. No static window, no extension alarm.
+
+## §13 Bootstrap vs steady-state mode
+
+- Same code path both modes (§9): first run = deep `minDate`, steady-state = watermark. Expected HTTP per fire: 1 + extra pages; bootstrap ≤3 calls on any realistic account.
+- Runs inside `portfolio_sync` (carve-out member `orchestrator_high_frequency_sync`, motivation b) — already creds-gated and `PREREQ_SKIP`-safe pre-universe. History ingest with an unresolvable instrument stores `instrument_id NULL` (§2), so a pre-universe fire cannot FK-fail.
+- No new `ScheduledJob`, no new bootstrap stage, no gate questions.
+
+## §14 Tombstones + soft-delete
+
+N/A for `trade_events` — executed trades have no amendment/supersession concept; append-only, never deleted. `broker_positions` rows ARE hard-deleted by the existing sweep (pre-existing semantic), now with the archive copy (§1.4) preserving the evidence for real ids.
+
+## §15 `rows_skipped` closed-set
+
+Per ingest run, counters logged in the sync summary:
+
+- `duplicate` — ON CONFLICT no-op (expected steady-state bulk).
+- `unresolved_instrument` — row landed with `instrument_id NULL` (counted, not dropped).
+- `null_price` — landed with NULL price after sentinel/absent rate (counted, not dropped).
+- `conflict_anomaly` — close-slice sum would exceed the open's units, or a key-collision with differing figures (§4/§8). Landed/skipped per the DO-NOTHING outcome, WARN with payloads.
+- `other` — anything else, with `partial_data_reason` free-text in the log line.
+
+No row is ever silently dropped; "skip" means degraded-land, except `duplicate`.
+
+## §16 Schema-evolution migration path
+
+New table — no dual-parser window. If eToro adds/renames response fields, `raw_payload` already holds them; promoting a field = additive migration + one-shot backfill from raw_payload. No parser_version in v1 (single trivial mapping; revisit if a second transform version ever exists — §21).
+
+## §17 Operator runbooks
+
+- `app/runbooks/trade_events_reresolve_instruments.py` — re-resolve `instrument_id IS NULL` rows against the current universe (`--dry-run` default, `--apply` to write). PR-1 deliverable.
+- Re-ingest after a bug: delete nothing; fix code — the watermark overlap + DO NOTHING re-walks recent rows. Deep re-walk: one-off runbook if ever needed; declared out of scope for v1.
+
+## §18 Smoke matrix
+
+Account-scoped source (not issuer-keyed) — panel = the dev demo account state:
+
+1. ILMN (4077) closed trade → exactly 1 open + 1 close event, `realized_pnl_usd = 1910.47`, open units = close units = 82.135523, holding period 2025-08-12 → 2025-11-14.
+2. The 7 currently-open broker positions → 7 open events (units = initialUnits), 0 close events.
+3. Mirror positions → ZERO open events from the portfolio diff (mirrors parse into `copy_mirror_positions`, not `broker_positions`); any history row with `social_trade_id != 0` lands flagged.
+4. Synthetic-id check: `SELECT count(*) FROM trade_events WHERE position_id < 0` = 0 and `broker_positions_closed` contains no negative ids after an eBull-originated order cycle.
+
+PR description records the observed counts + the ILMN figures.
+
+## §19 Cross-source verification
+
+ILMN closed trade vs the eToro web UI portfolio→history view on the demo account: net profit $1,910.47, units 82.135523, open 2025-08-12 @ 97.30, close 2025-11-14 @ 120.56. Recorded in the PR description with operator confirmation.
+
+## §20 Test placement
+
+- Pure-logic (no DB): payload→event transform table tests (closed-slice grouping → one open + N closes; Σ-units open synthesis; sentinel rates → NULL price; mirror flag; side derivation; Decimal parsing; synthetic-id exclusion in the diff) — the bulk.
+- ONE `db`-marked integration test: unique-index dedup (re-ingest same fixture twice → no new rows) — the one genuinely-new SQL mechanism.
+- Order-path enqueue: unit test that a successful place/close publishes a manual request for job `daily_portfolio_sync` (by registered job name — §1.3 NEW work).
+- Smoke: existing `tests/smoke/test_app_boots.py` covers migration 194; activity endpoint smoke in PR-2.
+- Dev-verify (DoD clauses 8-11): run sync on dev, check §18 figures, hit `/portfolio/activity` after PR-2.
+
+## §21 Rationale log
+
+**Decision:** event-grained ledger (open/close rows), not closed-trade-grained.
+**Rejected:** mirroring eToro's one-row-per-closed-slice shape — #1594 `units_at_day` needs a units timeline; closed-trade grain forces every consumer to re-split legs.
+
+**Decision:** single writer service at the sync chokepoint; order path enqueues an immediate sync (new PR-1 work) instead of writing events.
+**Rejected:** issue-sketch direct writes from `orders.py`/`order_client.py` — synthetic negative position ids (#227, both writers per §0) would orphan open events when the real id arrives at next sync; mutating ids breaks immutability. Intent audit already exists (`orders`, `fills`, `decision_audit`).
+
+**Decision:** two instrument columns (`etoro_instrument_id` NOT NULL raw + nullable FK `instrument_id`).
+**Rejected:** single FK NOT NULL column — delisted instruments in deep history would FK-fail and force dropping trades; single un-FK'd column — loses referential integrity for the resolvable majority.
+
+**Decision:** `ON CONFLICT DO NOTHING` + advisory mismatch WARNING.
+**Rejected:** DO UPDATE all financial columns (the usual prevention-log default) — this table is immutable evidence; first-observed wins and disagreement is a loud anomaly, not a merge.
+
+**Decision:** close conflict key `(position_id, executed_at)` + `conflict_anomaly` monitoring.
+**Rejected:** including `order_id` in the key — its provenance (open-order vs close-order id) is unverified (§2); a constant-per-position order_id would silently weaken the key. Same-ms multi-slice closes are pathological; if they ever occur the anomaly counter fires loudly and the key is relaxed by an additive migration.
+
+**Decision:** open-event units = ORIGINAL units (initialUnits / Σ-slices), closes = deltas.
+**Rejected:** current remaining units on the open event — wrong pre-partial-close history for `units_at_day`, and unfixable later under an immutable open row.
+
+**Decision:** fetch history on EVERY sync tick.
+**Rejected:** disappearance-triggered + daily sweep — needs fetch-state storage, misses nothing always-fetch misses, saves only ~288 trivially-cheap GETs/day against a 60/min budget.
+
+**Decision:** archive table `broker_positions_closed` (real ids only) rather than a `closed_at` soft-close column.
+**Rejected:** soft-close column — every existing reader of `broker_positions` assumes table = open positions; one missed filter creates phantom holdings in valuation. Separate table keeps the invariant by construction.
+
+**Decision:** no `parser_version` in v1.
+**Rejected:** carrying the SEC-manifest pattern — single trivial mapping with raw_payload fallback; rewash = re-read raw, no supersession machinery to version against.
+
+## §22 Open questions
+
+1. **Partial-close history row shape**: the same-id reduction model is established (sql/024:19 `isPartiallyAltered`), but whether each slice emits its own history row with the same positionId — and whether slice timestamps are guaranteed distinct — is unverified (the dev account has one single-slice close). The §4 units contract + §15 `conflict_anomaly` counter make either answer safe and loud. Optional: operator authorises a one-off demo partial-close experiment to settle it empirically.
+2. **`pageSize` ceiling**: 500 accepted with a 1-row account; true cap unverifiable until more history exists. Loop-while-full-page is correct under any cap.
+3. **Balances scope**: would regenerating the demo API key with wider scopes unlock `/api/v1/balances/history`? Operator action at eToro portal key management; if yes, #1594 gains a cross-check source (12-month window only).
+
+## Implementation plan
+
+- **PR-1 (backend):** sql/194 + provider `get_trade_history()` (thin adapter, explicit demo path segment) + `app/services/trade_events.py` ingest (batch-grouping transform + upserts + skip counters; exposes `compute_history_min_date(conn)` for callers) + `sync_portfolio(conn, portfolio, trade_history=None)` signature change with ingest inside (position-diff open events from broker-payload ids; history events when rows supplied) + BOTH callers updated: `scheduler.py::daily_portfolio_sync` (~2895: provider context closes before `sync_portfolio` — read watermark on a short-lived conn first, fetch portfolio + ALL history pages in the same provider session, pass both in) and WS `_default_reconcile_runner` (same fetch-and-pass inside its own provider session) + archive-before-delete (`position_id >= 0`) inside `_upsert_broker_positions`' sweep + **NEW** order-path post-trade enqueue of job `daily_portfolio_sync` (by job name, manual queue) + fixture + tests + runbook. Dev-verified per §18/§19.
+- **PR-2 (API+FE):** `GET /portfolio/activity` (paged, joined to instruments, holding period + realised P&L) + PortfolioPage Activity tab (mirror filter default-on, unresolved-instrument fallback rendering). FE skills re-read at implementation time.
+- #393 closed when PR-1 merges (findings already posted).

--- a/docs/proposals/etl/2026-06-13-etoro-trade-ledger.md
+++ b/docs/proposals/etl/2026-06-13-etoro-trade-ledger.md
@@ -181,7 +181,7 @@ No retry-storm risk: nothing re-fires faster than the sync cadence.
 
 ## §8 Multi-writer sink registry
 
-`trade_events` is a NEW sink with ONE writer function (`sync_portfolio`, history rows supplied via its new optional parameter — §1.3), reached from two call sites (scheduled `daily_portfolio_sync`, WS `_default_reconcile_runner` — §0; both updated in PR-1 to fetch and pass history). Concurrency safety: conflict keys = the two partial unique indexes (§4); conflict action = `ON CONFLICT DO NOTHING` (atomic, first observation wins). Disagreement detection (same key, different figures) is a post-insert advisory SELECT + WARNING — logging only, race-tolerant by construction.
+`trade_events` is a NEW sink with ONE writer function (`sync_portfolio`, history rows supplied via its new optional parameter — §1.3), reached from two call sites (scheduled `daily_portfolio_sync`, WS `_default_reconcile_runner` — §0; both updated in PR-1 to fetch and pass history). Concurrency safety: `sync_portfolio` takes `pg_advisory_xact_lock` at entry so concurrent reconciles serialize — without it, two callers holding snapshots from different instants could interleave the archive/DELETE sweep against each other's upserts and archive a live position on stale evidence (Codex ckpt-2 HIGH). Ledger conflict keys = the two partial unique indexes (§4); conflict action = `ON CONFLICT DO NOTHING` (atomic, first observation wins). Disagreement detection (same key, different figures) is a post-insert advisory SELECT + WARNING — logging only.
 
 `broker_positions_closed`: one writer (the archive step inside `_upsert_broker_positions`' delete sweep), filtered `position_id >= 0` (§1.4).
 

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -1759,3 +1759,12 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: the ownership chart + L2 filer table fold `def14a_unmatched` into the `insiders` category (`rollupToSunburstInputs` / `rollupToFilerRows`), but the CSV export endpoint filtered `?category=insiders` by exact slice match — a drilled `?category=insiders&view=raw` export silently dropped DEF 14A rows the filtered table visibly showed. The fold lived in the FE transform; the backend consumer keyed on the raw category never learned about it.
 - Prevention: when a surface folds category A into category B for display, grep every consumer keyed on category (`?category=` filters, CSV/export endpoints, deep-link params, history filters) and apply the same fold — or route them all through one shared fold function. Self-review prompt: for each new `SLICE_TO_*` / fold map, list the category-keyed entry points (`grep -rn "category" app/api frontend/src/api` scoped to the feature) and confirm each either folds identically or is exact-by-design with a comment.
 - Enforced in: this prevention log; `app/api/instruments.py::rollup_csv_slice_filter` (pure helper + table test in `tests/test_ownership_rollup_csv.py`).
+
+---
+
+### Non-abstract ABC default methods that raise must be caught by every safety wrapper around the call
+
+- First seen in: PR #1610 (#1593 review round 3 WARNING).
+- Symptom: `BrokerProvider.get_trade_history` ships a non-abstract default that raises `NotImplementedError` (kept non-abstract so existing test fakes don't break). The degrade-gracefully wrapper `fetch_trade_history_safely` caught `httpx` errors + parse errors but not `NotImplementedError` — a future provider without an override would escape the wrapper and fail the whole position sync, the exact outcome the wrapper exists to prevent.
+- Prevention: when an interface method's default implementation raises (NotImplementedError or otherwise), every "this call is allowed to fail" wrapper around it must include that exception class in its catch set, with a loud log naming the provider class. Self-review prompt: for each `except (...)` wrapper around a provider/interface call, read the BASE class implementation — if it can raise something the wrapper misses, add it.
+- Enforced in: `app/services/trade_events.py::fetch_trade_history_safely` (`except NotImplementedError` branch) + the parametrized error-posture table in `tests/test_trade_events.py`.

--- a/sql/194_trade_events.sql
+++ b/sql/194_trade_events.sql
@@ -29,7 +29,7 @@
 BEGIN;
 
 CREATE TABLE IF NOT EXISTS trade_events (
-    event_id            BIGSERIAL PRIMARY KEY,
+    event_id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     position_id         BIGINT NOT NULL CHECK (position_id >= 0),
     etoro_instrument_id BIGINT NOT NULL,
     instrument_id       BIGINT REFERENCES instruments(instrument_id),

--- a/sql/194_trade_events.sql
+++ b/sql/194_trade_events.sql
@@ -1,0 +1,77 @@
+-- 194_trade_events.sql
+--
+-- #1593 (spec docs/proposals/etl/2026-06-13-etoro-trade-ledger.md §4)
+-- — append-only broker-observed trade ledger + closed-position archive.
+--
+-- trade_events: one row per position OPEN or CLOSE event, written only
+-- by sync_portfolio (open events from the portfolio-payload diff,
+-- open+close events from the eToro trade-history fetch). Immutable —
+-- no UPDATE path; conflicts are ON CONFLICT DO NOTHING (first
+-- observation wins, disagreement logged loudly by the ingest service).
+--
+-- Units contract (spec §1.7): open.units = the position's ORIGINAL
+-- opened units (initialUnits / Σ history slices); each close.units =
+-- that slice's delta. eToro partial closes reduce the SAME positionId
+-- (sql/024:19 isPartiallyAltered), so a position may carry one open
+-- and N closes.
+--
+-- position_id >= 0: eBull-originated orders write synthetic NEGATIVE
+-- broker_positions ids (-order_id, #227) that are replaced by the real
+-- broker id at next sync — synthetic ids must never enter the ledger.
+--
+-- instrument_id is nullable on purpose: deep-history trades can
+-- reference instruments absent from the current universe; the raw
+-- etoro_instrument_id is always kept and a runbook re-resolves later
+-- (no silent drops).
+--
+-- Not partitioned: single account, O(hundreds) rows/year.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS trade_events (
+    event_id            BIGSERIAL PRIMARY KEY,
+    position_id         BIGINT NOT NULL CHECK (position_id >= 0),
+    etoro_instrument_id BIGINT NOT NULL,
+    instrument_id       BIGINT REFERENCES instruments(instrument_id),
+    event_kind          TEXT NOT NULL CHECK (event_kind IN ('open', 'close')),
+    side                TEXT NOT NULL CHECK (side IN ('buy', 'sell')),
+    units               NUMERIC(20, 8) NOT NULL CHECK (units > 0),
+    price               NUMERIC(20, 8) CHECK (price > 0),
+    executed_at         TIMESTAMPTZ NOT NULL,
+    fees_usd            NUMERIC(20, 4),
+    realized_pnl_usd    NUMERIC(20, 4) CHECK (event_kind = 'close' OR realized_pnl_usd IS NULL),
+    investment_usd      NUMERIC(20, 4),
+    order_id            BIGINT,
+    social_trade_id     BIGINT,
+    parent_position_id  BIGINT,
+    source              TEXT NOT NULL CHECK (source IN ('etoro_sync', 'etoro_history')),
+    raw_payload         JSONB NOT NULL,
+    recorded_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One open per position (first observation wins; portfolio-diff opens
+-- carry initialUnits and beat later history-derived opens).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_trade_events_open
+    ON trade_events (position_id) WHERE event_kind = 'open';
+
+-- One close per (position, close timestamp) — partial closes land as
+-- distinct rows; a same-ms collision is counted as conflict_anomaly by
+-- the ingest service (spec §15), never silently merged.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_trade_events_close
+    ON trade_events (position_id, executed_at) WHERE event_kind = 'close';
+
+CREATE INDEX IF NOT EXISTS idx_trade_events_instrument_time
+    ON trade_events (instrument_id, executed_at);
+
+-- Archive for broker positions that disappeared from the broker payload
+-- (closed externally: eToro UI, SL/TP trigger). Evidence copy of the
+-- last-seen row, written immediately before the disappeared-DELETE
+-- sweep in _upsert_broker_positions. Real ids only (position_id >= 0);
+-- synthetic eBull handoff rows are not archived.
+CREATE TABLE IF NOT EXISTS broker_positions_closed (
+    LIKE broker_positions INCLUDING DEFAULTS,
+    closed_detected_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (position_id, closed_detected_at)
+);
+
+COMMIT;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -150,6 +150,9 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "coverage",
     "position_alerts",
     "watchlist",
+    # #1593 — trade ledger + closed-position archive (FK → instruments).
+    "trade_events",
+    "broker_positions_closed",
     "broker_positions",
     "positions",
     "quotes",

--- a/tests/fixtures/etoro/trade_history_demo.json
+++ b/tests/fixtures/etoro/trade_history_demo.json
@@ -1,0 +1,35 @@
+{
+  "_meta": {
+    "captured": "2026-06-13",
+    "endpoint": "GET /api/v1/trading/info/trade/demo/history",
+    "params": {
+      "minDate": "2020-01-01T00:00:00Z",
+      "page": "1",
+      "pageSize": "50"
+    },
+    "note": "#1593 probe capture \u2014 dev demo account, single closed trade (ILMN). Body is the verbatim API response array."
+  },
+  "body": [
+    {
+      "netProfit": 1910.47,
+      "closeRate": 120.56,
+      "closeTimestamp": "2025-11-14T19:24:35.307Z",
+      "positionId": 3308442654,
+      "instrumentId": 4077,
+      "isBuy": true,
+      "leverage": 1,
+      "openRate": 97.3,
+      "openTimestamp": "2025-08-12T16:47:12.643Z",
+      "stopLossRate": 0.0001,
+      "takeProfitRate": 200.0,
+      "trailingStopLoss": false,
+      "orderId": 272136682,
+      "socialTradeId": 0,
+      "parentPositionId": 0,
+      "investment": 7991.79,
+      "initialInvestment": 7991.79,
+      "fees": 0.0,
+      "units": 82.135523
+    }
+  ]
+}

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -46,6 +46,7 @@ cost-recording fallback path (between steps 6 and 7).
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -111,6 +112,15 @@ def _patch_runtime_config(monkeypatch: pytest.MonkeyPatch) -> None:
         "app.services.order_client.get_runtime_config",
         lambda _conn: _RUNTIME_DEMO,
     )
+
+
+@pytest.fixture(autouse=True)
+def _stub_post_trade_enqueue() -> Iterator[MagicMock]:
+    """#1593: enqueue_post_trade_sync opens its own cursor, which would
+    exhaust the sequenced mock conns here. Patched at point of use;
+    the enqueue contract is asserted in TestPostTradeEnqueue."""
+    with patch("app.services.order_client.enqueue_post_trade_sync") as stub:
+        yield stub
 
 
 def _make_cursor(rows: list[dict[str, Any]]) -> MagicMock:
@@ -835,6 +845,43 @@ class TestExecuteOrderDemoMode:
 # ---------------------------------------------------------------------------
 # TestExecuteOrderLiveMode
 # ---------------------------------------------------------------------------
+
+
+class TestPostTradeEnqueue:
+    """#1593: a persisted fill queues an immediate daily_portfolio_sync
+    so the broker-observed trade lands in trade_events within seconds."""
+
+    @patch("app.services.order_client._utcnow", return_value=_NOW)
+    def test_filled_demo_buy_enqueues_portfolio_sync(
+        self, _mock_now: MagicMock, _stub_post_trade_enqueue: MagicMock
+    ) -> None:
+        cursors = [
+            _rec_cursor(action="BUY", target_entry=100.0, suggested_size_pct=0.05),
+            _cash_cursor(balance=10_000.0),
+            _quote_cursor(last=100.0, spread_pct=0.20),
+            _order_returning_cursor(order_id=7),
+            _cost_config_cursor(),
+            _cost_model_cursor(),
+            _cost_record_write_cursor(),
+            _fill_returning_cursor(fill_id=3),
+        ]
+        result = execute_order(_make_conn(cursors), recommendation_id=42, decision_id=10)
+        assert result.outcome == "filled"
+        _stub_post_trade_enqueue.assert_called_once()
+        assert _stub_post_trade_enqueue.call_args.kwargs["requested_by"] == "execute_order"
+
+    @patch("app.services.order_client._utcnow", return_value=_NOW)
+    def test_failed_order_does_not_enqueue(self, _mock_now: MagicMock, _stub_post_trade_enqueue: MagicMock) -> None:
+        # Demo EXIT with no quote fails closed: no fill → no enqueue.
+        cursors = [
+            _rec_cursor(action="EXIT", target_entry=None, suggested_size_pct=None),
+            _position_cursor(current_units=5.0),
+            _make_cursor([]),  # no quote
+            _order_returning_cursor(order_id=11),
+        ]
+        result = execute_order(_make_conn(cursors), recommendation_id=42, decision_id=10)
+        assert result.outcome == "failed"
+        _stub_post_trade_enqueue.assert_not_called()
 
 
 class TestExecuteOrderLiveMode:

--- a/tests/test_orders_api.py
+++ b/tests/test_orders_api.py
@@ -20,6 +20,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.db import get_conn
@@ -108,6 +109,15 @@ def _fallback_conn() -> Iterator[MagicMock]:
 app.dependency_overrides.setdefault(get_conn, _fallback_conn)
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _stub_post_trade_enqueue() -> Iterator[MagicMock]:
+    """#1593: enqueue_post_trade_sync consumes a cursor result the
+    sequenced mock conns here don't budget for. Patched at point of
+    use; the enqueue contract is asserted in TestPostTradeEnqueue."""
+    with patch("app.api.orders.enqueue_post_trade_sync") as stub:
+        yield stub
 
 
 # ---------------------------------------------------------------------------
@@ -547,3 +557,45 @@ class TestClosePosition:
         resp = client.post("/portfolio/positions/500/close")
         assert resp.status_code == 409
         assert "positions row" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# TestPostTradeEnqueue (#1593)
+# ---------------------------------------------------------------------------
+
+
+class TestPostTradeEnqueue:
+    """A filled manual order queues an immediate daily_portfolio_sync."""
+
+    def setup_method(self) -> None:
+        self._patch_config = patch(
+            "app.api.orders.get_runtime_config",
+            return_value=_DEFAULT_CONFIG,
+        )
+        self._patch_config.start()
+
+    def teardown_method(self) -> None:
+        self._patch_config.stop()
+        _cleanup()
+
+    def test_filled_buy_enqueues_portfolio_sync(self, _stub_post_trade_enqueue: MagicMock) -> None:
+        order_row = [{"order_id": 42}]
+        fill_row = [{"fill_id": 7}]
+        _with_conn([_KILL_SWITCH_OFF, _QUOTE_ROW, order_row, fill_row])
+
+        resp = client.post(
+            "/portfolio/orders",
+            json={"instrument_id": 1, "action": "BUY", "amount": 300},
+        )
+        assert resp.status_code == 200
+        _stub_post_trade_enqueue.assert_called_once()
+        assert _stub_post_trade_enqueue.call_args.kwargs["requested_by"] == "orders_api"
+
+    def test_kill_switch_block_does_not_enqueue(self, _stub_post_trade_enqueue: MagicMock) -> None:
+        _with_conn([_KILL_SWITCH_ON])
+        resp = client.post(
+            "/portfolio/orders",
+            json={"instrument_id": 1, "action": "BUY", "amount": 100},
+        )
+        assert resp.status_code == 403
+        _stub_post_trade_enqueue.assert_not_called()

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -698,7 +698,9 @@ def _is_broker_positions_upsert(sql_arg: Any) -> bool:
     if not isinstance(sql_arg, str):
         return False
     normalised = re.sub(r"\s+", " ", sql_arg)
-    return "INSERT INTO broker_positions" in normalised
+    # "(" excludes the broker_positions_closed archive INSERT (#1593),
+    # which contains "INSERT INTO broker_positions" as a substring.
+    return "INSERT INTO broker_positions (" in normalised
 
 
 def _is_broker_positions_delete(sql_arg: Any) -> bool:
@@ -769,8 +771,12 @@ class TestUpsertBrokerPositions:
 
         assert upserted == 0
         assert deleted == 0
-        # No UPSERT should have been issued
-        assert conn.execute.call_args_list == []
+        # No UPSERT issued — the only conn.execute is the archive copy
+        # (#1593), which mirrors the DELETE's empty exclusion list.
+        assert len(conn.execute.call_args_list) == 1
+        archive_sql = conn.execute.call_args_list[0].args[0]
+        assert "INSERT INTO broker_positions_closed" in archive_sql
+        assert not _is_broker_positions_upsert(archive_sql)
         # DELETE was still issued (via cursor) with empty exclusion list
         assert mock_cursor.execute.call_count == 1
         sql = mock_cursor.execute.call_args.args[0]

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -285,7 +285,10 @@ class TestEmptyBrokerGuard:
 
         # Zero writes must have occurred. Stronger than "no zero-out
         # updates" — catches any write attempted before the raise.
-        assert conn.execute.call_args_list == []
+        # The only allowed conn.execute before the guard is the
+        # read-only pg_advisory_xact_lock serializer (#1593).
+        non_lock_calls = [c for c in conn.execute.call_args_list if "pg_advisory_xact_lock" not in str(c.args[0])]
+        assert non_lock_calls == []
 
     def test_empty_broker_with_empty_local_does_not_raise(self) -> None:
         """Boundary: fully empty on both sides is a valid no-op."""

--- a/tests/test_trade_events.py
+++ b/tests/test_trade_events.py
@@ -1,0 +1,250 @@
+"""Pure-logic tests for the trade-events ledger transforms (#1593).
+
+No DB — the one genuinely-new SQL mechanism (partial-unique dedup) is
+covered by tests/test_trade_events_db.py.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from app.providers.broker import BrokerClosedTrade, BrokerPosition
+from app.providers.implementations.etoro_broker import (
+    TradeHistoryParseError,
+    _parse_closed_trade,
+)
+from app.services.trade_events import (
+    POST_TRADE_SYNC_JOB,
+    TradeEventCounters,
+    _side,
+    events_from_history,
+    fetch_trade_history_safely,
+    merge_events,
+    open_events_from_positions,
+)
+from app.workers.scheduler import JOB_DAILY_PORTFOLIO_SYNC
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "etoro" / "trade_history_demo.json"
+
+
+def _fixture_rows() -> list[dict[str, Any]]:
+    return json.loads(_FIXTURE.read_text())["body"]
+
+
+def _closed_trade(**overrides: Any) -> BrokerClosedTrade:
+    base: dict[str, Any] = {
+        "position_id": 100,
+        "instrument_id": 4077,
+        "is_buy": True,
+        "units": Decimal("10"),
+        "open_rate": Decimal("97.3"),
+        "open_timestamp": datetime(2025, 8, 12, 16, 47, tzinfo=UTC),
+        "close_rate": Decimal("120.56"),
+        "close_timestamp": datetime(2025, 11, 14, 19, 24, tzinfo=UTC),
+        "net_profit": Decimal("100.5"),
+        "fees": Decimal("0"),
+        "investment": Decimal("973"),
+        "initial_investment": Decimal("973"),
+        "leverage": 1,
+        "order_id": 1,
+        "social_trade_id": 0,
+        "parent_position_id": 0,
+        "raw_payload": {"positionId": 100},
+    }
+    base.update(overrides)
+    return BrokerClosedTrade(**base)
+
+
+def _broker_position(**overrides: Any) -> BrokerPosition:
+    base: dict[str, Any] = {
+        "instrument_id": 4077,
+        "units": Decimal("5"),
+        "open_price": Decimal("97.3"),
+        "current_price": Decimal("97.3"),
+        "raw_payload": {"positionID": 200},
+        "position_id": 200,
+        "is_buy": True,
+        "initial_units": Decimal("8"),
+        "initial_amount_in_dollars": Decimal("778.4"),
+        "open_date_time": datetime(2025, 8, 12, tzinfo=UTC),
+    }
+    base.update(overrides)
+    return BrokerPosition(**base)
+
+
+class TestParseClosedTrade:
+    def test_fixture_row_parses_to_exact_ilmn_figures(self) -> None:
+        trade = _parse_closed_trade(_fixture_rows()[0])
+        assert trade.position_id == 3308442654
+        assert trade.instrument_id == 4077
+        assert trade.is_buy is True
+        assert trade.units == Decimal("82.135523")
+        assert trade.open_rate == Decimal("97.3")
+        assert trade.close_rate == Decimal("120.56")
+        assert trade.net_profit == Decimal("1910.47")
+        assert trade.fees == Decimal("0.0")
+        assert trade.investment == Decimal("7991.79")
+        assert trade.open_timestamp == datetime(2025, 8, 12, 16, 47, 12, 643000, tzinfo=UTC)
+        assert trade.close_timestamp == datetime(2025, 11, 14, 19, 24, 35, 307000, tzinfo=UTC)
+        assert trade.order_id == 272136682
+        assert trade.social_trade_id == 0
+
+    def test_missing_required_field_raises_key_error(self) -> None:
+        row = dict(_fixture_rows()[0])
+        del row["closeTimestamp"]
+        with pytest.raises(KeyError):
+            _parse_closed_trade(row)
+
+
+class TestSideDerivation:
+    @pytest.mark.parametrize(
+        ("kind", "is_buy", "expected"),
+        [
+            ("open", True, "buy"),
+            ("close", True, "sell"),
+            ("open", False, "sell"),
+            ("close", False, "buy"),
+        ],
+    )
+    def test_side_table(self, kind: str, is_buy: bool, expected: str) -> None:
+        assert _side(kind, is_buy) == expected  # type: ignore[arg-type]
+
+
+class TestOpenEventsFromPositions:
+    def test_emits_open_with_initial_units_not_current(self) -> None:
+        counters = TradeEventCounters()
+        events = open_events_from_positions([_broker_position()], counters)
+        assert len(events) == 1
+        assert events[0].event_kind == "open"
+        assert events[0].units == Decimal("8")  # initialUnits, not the partial-close-reduced 5
+        assert events[0].source == "etoro_sync"
+        assert events[0].executed_at == datetime(2025, 8, 12, tzinfo=UTC)
+
+    def test_synthetic_negative_id_excluded(self) -> None:
+        counters = TradeEventCounters()
+        events = open_events_from_positions([_broker_position(position_id=-42)], counters)
+        assert events == []
+        assert counters.skipped_other == 0  # silent by design: handoff artefact, not data loss
+
+    def test_missing_position_id_excluded(self) -> None:
+        counters = TradeEventCounters()
+        assert open_events_from_positions([_broker_position(position_id=None)], counters) == []
+
+    def test_missing_open_date_skipped_and_counted(self) -> None:
+        counters = TradeEventCounters()
+        events = open_events_from_positions([_broker_position(open_date_time=None)], counters)
+        assert events == []
+        assert counters.skipped_other == 1
+        assert "no openDateTime" in counters.skip_reasons[0]
+
+    def test_sentinel_open_price_lands_as_none_and_counted(self) -> None:
+        counters = TradeEventCounters()
+        events = open_events_from_positions([_broker_position(open_price=Decimal("0"))], counters)
+        assert events[0].price is None
+        assert counters.null_price == 1
+
+    def test_fees_not_stamped_on_open_events(self) -> None:
+        counters = TradeEventCounters()
+        events = open_events_from_positions([_broker_position(total_fees=Decimal("3.5"))], counters)
+        assert events[0].fees_usd is None
+
+
+class TestEventsFromHistory:
+    def test_single_trade_yields_open_and_close(self) -> None:
+        counters = TradeEventCounters()
+        events = events_from_history([_closed_trade()], counters)
+        kinds = sorted(e.event_kind for e in events)
+        assert kinds == ["close", "open"]
+        close = next(e for e in events if e.event_kind == "close")
+        opened = next(e for e in events if e.event_kind == "open")
+        assert opened.units == Decimal("10")
+        assert opened.realized_pnl_usd is None
+        assert close.units == Decimal("10")
+        assert close.realized_pnl_usd == Decimal("100.5")
+        assert close.executed_at == datetime(2025, 11, 14, 19, 24, tzinfo=UTC)
+        assert close.side == "sell"
+
+    def test_partial_slices_group_to_one_open_with_summed_units(self) -> None:
+        counters = TradeEventCounters()
+        slice_a = _closed_trade(units=Decimal("4"), close_timestamp=datetime(2025, 9, 1, tzinfo=UTC))
+        slice_b = _closed_trade(units=Decimal("6"), close_timestamp=datetime(2025, 10, 1, tzinfo=UTC))
+        events = events_from_history([slice_a, slice_b], counters)
+        opens = [e for e in events if e.event_kind == "open"]
+        closes = [e for e in events if e.event_kind == "close"]
+        assert len(opens) == 1
+        assert opens[0].units == Decimal("10")
+        assert sorted(c.units for c in closes) == [Decimal("4"), Decimal("6")]
+
+    def test_short_position_open_is_sell(self) -> None:
+        counters = TradeEventCounters()
+        events = events_from_history([_closed_trade(is_buy=False)], counters)
+        opened = next(e for e in events if e.event_kind == "open")
+        close = next(e for e in events if e.event_kind == "close")
+        assert opened.side == "sell"
+        assert close.side == "buy"
+
+    def test_mirror_trade_carries_social_trade_id(self) -> None:
+        counters = TradeEventCounters()
+        events = events_from_history([_closed_trade(social_trade_id=98765)], counters)
+        assert all(e.social_trade_id == 98765 for e in events)
+
+
+class TestMergeEvents:
+    def test_portfolio_open_beats_history_open_for_same_position(self) -> None:
+        counters = TradeEventCounters()
+        portfolio_opens = open_events_from_positions([_broker_position(position_id=100)], counters)
+        history = events_from_history([_closed_trade(position_id=100)], counters)
+        merged = merge_events(portfolio_opens, history)
+        opens = [e for e in merged if e.event_kind == "open"]
+        assert len(opens) == 1
+        assert opens[0].source == "etoro_sync"
+        # The history close survives the merge.
+        assert any(e.event_kind == "close" for e in merged)
+
+    def test_history_only_position_keeps_its_synthesized_open(self) -> None:
+        counters = TradeEventCounters()
+        merged = merge_events([], events_from_history([_closed_trade()], counters))
+        assert any(e.event_kind == "open" and e.source == "etoro_history" for e in merged)
+
+
+class _RaisingBroker:
+    """Minimal BrokerProvider stand-in for the fetch error-posture table."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def get_trade_history(self, min_date: datetime, page_size: int = 200) -> list[BrokerClosedTrade]:
+        raise self._exc
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://example.invalid")
+    return httpx.HTTPStatusError("boom", request=request, response=httpx.Response(status, request=request))
+
+
+class TestFetchTradeHistorySafely:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _http_status_error(403),
+            _http_status_error(429),
+            _http_status_error(500),
+            httpx.ConnectError("network down"),
+            TradeHistoryParseError("bad row"),
+        ],
+    )
+    def test_failures_return_none_so_positions_still_sync(self, exc: Exception) -> None:
+        assert fetch_trade_history_safely(_RaisingBroker(exc), datetime(2020, 1, 1, tzinfo=UTC)) is None  # type: ignore[arg-type]
+
+
+def test_post_trade_sync_job_name_matches_scheduler_constant() -> None:
+    """POST_TRADE_SYNC_JOB is duplicated to avoid a circular import —
+    this pin is the drift guard (#1593 spec §1.3)."""
+    assert POST_TRADE_SYNC_JOB == JOB_DAILY_PORTFOLIO_SYNC

--- a/tests/test_trade_events.py
+++ b/tests/test_trade_events.py
@@ -240,6 +240,7 @@ class TestFetchTradeHistorySafely:
             _http_status_error(500),
             httpx.ConnectError("network down"),
             TradeHistoryParseError("bad row"),
+            NotImplementedError(),  # provider without an override (ABC default)
         ],
     )
     def test_failures_return_none_so_positions_still_sync(self, exc: Exception) -> None:

--- a/tests/test_trade_events.py
+++ b/tests/test_trade_events.py
@@ -144,11 +144,13 @@ class TestOpenEventsFromPositions:
         assert counters.skipped_other == 1
         assert "no openDateTime" in counters.skip_reasons[0]
 
-    def test_sentinel_open_price_lands_as_none_and_counted(self) -> None:
+    def test_sentinel_open_price_lands_as_none(self) -> None:
+        # null_price is counted at INGEST time (landed rows only), so the
+        # transform just maps the sentinel to None — see test_trade_events_db.
         counters = TradeEventCounters()
         events = open_events_from_positions([_broker_position(open_price=Decimal("0"))], counters)
         assert events[0].price is None
-        assert counters.null_price == 1
+        assert counters.null_price == 0
 
     def test_fees_not_stamped_on_open_events(self) -> None:
         counters = TradeEventCounters()

--- a/tests/test_trade_events_db.py
+++ b/tests/test_trade_events_db.py
@@ -108,5 +108,17 @@ def test_reingest_is_idempotent_and_anomaly_is_loud(
         ).fetchone()
     assert row is not None and row[0] is None and row[1] == 999999991
 
+    # null_price counts LANDED rows only (ingest-time, spec §15): a
+    # sentinel close rate lands as NULL price and is counted once.
+    sentinel = [replace(_trade(900003, "2", close_at), close_rate=Decimal("0"))]
+    fifth = ingest_trade_events(conn, events_from_history(sentinel, TradeEventCounters()), TradeEventCounters())
+    assert fifth.inserted == 2
+    assert fifth.null_price == 1  # close landed NULL; the open kept its valid rate
+    with conn.cursor() as cur:
+        row = cur.execute(
+            "SELECT price FROM trade_events WHERE position_id = 900003 AND event_kind = 'close'"
+        ).fetchone()
+    assert row is not None and row[0] is None
+
     # Watermark derives from the ingested closes.
     assert compute_history_min_date(conn) == close_at - timedelta(days=7)

--- a/tests/test_trade_events_db.py
+++ b/tests/test_trade_events_db.py
@@ -1,0 +1,112 @@
+"""DB integration test for the trade_events partial-unique dedup (#1593).
+
+ONE test file for the one genuinely-new SQL mechanism: the two partial
+unique indexes + ON CONFLICT DO NOTHING idempotency, and the anomaly
+counter on a conflicting re-observation. Everything else is pure-logic
+in tests/test_trade_events.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.providers.broker import BrokerClosedTrade
+from app.services.trade_events import (
+    TradeEventCounters,
+    compute_history_min_date,
+    events_from_history,
+    ingest_trade_events,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401  (fixture)
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[Any], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _trade(position_id: int, units: str, close_at: datetime) -> BrokerClosedTrade:
+    return BrokerClosedTrade(
+        position_id=position_id,
+        instrument_id=4077,
+        is_buy=True,
+        units=Decimal(units),
+        open_rate=Decimal("97.3"),
+        open_timestamp=datetime(2025, 8, 12, 16, 47, tzinfo=UTC),
+        close_rate=Decimal("120.56"),
+        close_timestamp=close_at,
+        net_profit=Decimal("100"),
+        fees=Decimal("0"),
+        investment=Decimal("973"),
+        initial_investment=Decimal("973"),
+        leverage=1,
+        order_id=1,
+        social_trade_id=0,
+        parent_position_id=0,
+        raw_payload={"positionId": position_id},
+    )
+
+
+def test_reingest_is_idempotent_and_anomaly_is_loud(
+    ebull_test_conn: psycopg.Connection[Any],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, 4077, "ILMN")
+    close_at = datetime(2025, 11, 14, 19, 24, 35, tzinfo=UTC)
+    trades = [_trade(900001, "82.135523", close_at)]
+
+    # First ingest: open + close land, instrument resolved.
+    first = ingest_trade_events(conn, events_from_history(trades, TradeEventCounters()), TradeEventCounters())
+    assert first.inserted == 2
+    assert first.duplicate == 0
+    assert first.unresolved_instrument == 0
+
+    # Second ingest of the SAME rows: pure no-op via the partial uniques.
+    second = ingest_trade_events(conn, events_from_history(trades, TradeEventCounters()), TradeEventCounters())
+    assert second.inserted == 0
+    assert second.duplicate == 2
+    assert second.conflict_anomaly == 0
+    with conn.cursor() as cur:
+        count = cur.execute("SELECT COUNT(*) FROM trade_events WHERE position_id = 900001").fetchone()
+    assert count is not None and count[0] == 2
+
+    # Conflicting re-observation (same keys, different units): first
+    # observation kept, anomaly counted — never silently merged.
+    conflicting = [_trade(900001, "50", close_at)]
+    third = ingest_trade_events(conn, events_from_history(conflicting, TradeEventCounters()), TradeEventCounters())
+    assert third.inserted == 0
+    assert third.conflict_anomaly >= 1
+    with conn.cursor() as cur:
+        row = cur.execute(
+            "SELECT units FROM trade_events WHERE position_id = 900001 AND event_kind = 'close'"
+        ).fetchone()
+    assert row is not None and Decimal(str(row[0])) == Decimal("82.135523")
+
+    # Unresolved instrument: row still lands with NULL FK (no silent drops).
+    ghost = [replace(_trade(900002, "1", close_at), instrument_id=999999991)]
+    fourth = ingest_trade_events(conn, events_from_history(ghost, TradeEventCounters()), TradeEventCounters())
+    assert fourth.inserted == 2
+    assert fourth.unresolved_instrument == 2
+    with conn.cursor() as cur:
+        row = cur.execute(
+            "SELECT instrument_id, etoro_instrument_id FROM trade_events "
+            "WHERE position_id = 900002 AND event_kind = 'close'"
+        ).fetchone()
+    assert row is not None and row[0] is None and row[1] == 999999991
+
+    # Watermark derives from the ingested closes.
+    assert compute_history_min_date(conn) == close_at - timedelta(days=7)


### PR DESCRIPTION
Part of #1593 (PR-1, backend slice — the epic stays open; PR-2 adds the activity API + FE tab). Closes #393 (capability findings posted on the ticket; balances endpoint 403 + 12-month cap → fills/ledger path adopted).

Spec: `docs/proposals/etl/2026-06-13-etoro-trade-ledger.md` (committed in this PR; operator-signed 2026-06-13; Codex ckpt-1 ran 3 rounds — 3 BLOCKING/3 HIGH/2 MED found+folded, final verdict SOUND).

## What changed

- **sql/194**: `trade_events` — append-only broker-observed ledger, one row per position open/close event. Partial unique keys: `(position_id) WHERE open`, `(position_id, executed_at) WHERE close`. `CHECK (position_id >= 0)`, price `> 0` or NULL, `realized_pnl_usd` close-only. Two instrument columns: `etoro_instrument_id NOT NULL` (raw) + nullable FK `instrument_id` (deep-history delistings must land, not drop). Plus `broker_positions_closed` archive (LIKE broker_positions + `closed_detected_at`, PK (position_id, closed_detected_at)).
- **Provider** (`etoro_broker.py`): `get_trade_history(min_date, page_size)` — paged GET `/api/v1/trading/info/trade{/demo}/history` (note the env segment sits between `trade` and `history`, unlike the other info endpoints), `_parse_closed_trade` pure normaliser, `TradeHistoryParseError`. `BrokerClosedTrade` dataclass in `app/providers/broker.py`.
- **Service** (`app/services/trade_events.py`): transform (units contract below), `merge_events` (portfolio-sourced open beats history-derived), `ingest_trade_events` (ON CONFLICT DO NOTHING + closed-set counters + `conflict_anomaly` invariant check), sink-derived watermark (`max(close executed_at) − 7d`, deep epoch 2017-01-01 on empty ledger), `fetch_trade_history_safely` (spec §7 error posture), `enqueue_post_trade_sync`.
- **Chokepoint** (`portfolio_sync.py`): `sync_portfolio(conn, portfolio, trade_history=None)` is the ONLY ledger writer. Takes `pg_advisory_xact_lock` at entry (serializes its two callers). Archive-INSERT before the disappeared-DELETE sweep, real ids only.
- **Callers**: `scheduler.py::daily_portfolio_sync` + WS `_default_reconcile_runner` both read the watermark on a short-lived conn, fetch portfolio + all history pages in one provider session, and pass rows in. History-fetch failure → `None` → positions still sync, watermark unmoved.
- **Order paths** (`orders.py`, `order_client.py`): a persisted fill enqueues an immediate manual `daily_portfolio_sync` (same transaction — NOTIFY at commit).
- Fixture from the live demo probe, pure-logic test suite, ONE db-marked dedup/anomaly/null-price integration test, re-resolve runbook (`app/runbooks/trade_events_reresolve_instruments.py`, dry-run default).

## Why

Closed positions vanished at sync (DELETE sweep) and eToro-side history was never ingested — no auditable trade record, and #1594 (value-over-time v2) needs an exact units timeline. Probe (2026-06-13) proved the demo account exposes full closed-trade history and that `minDate` filters on closeTimestamp, so a sink-derived watermark is loss-proof.

**Deviation from the issue sketch (spec §21):** the order path does NOT write the ledger directly. Its `broker_positions` rows use synthetic negative position ids (#227, both writers) that the next sync replaces with real ids — direct writes would orphan open events. Intent-side audit already exists (`orders`/`fills`/`decision_audit`); the ledger records broker-observed reality, and the post-fill enqueue closes the latency gap to seconds.

**Units contract (spec §1.7):** open event units = ORIGINAL position size (`initialUnits`, or Σ slices for positions only ever seen in history); close event units = slice deltas. eToro partial closes reduce the same positionId (sql/024:19 `isPartiallyAltered`), so Σ(closes) ≤ open is a monitored invariant (`conflict_anomaly`), never a silent merge.

## Security model

No new auth surface. The ledger writer runs in the jobs process / WS reconcile with existing credentials handling (`_load_etoro_credentials`, audited decrypt). The order-path enqueue runs behind the existing operator session / service-token gate on `/portfolio/orders` and the guard-approved `execute_order` path. Raw API payloads land in JSONB as received (no secrets in trade-history bodies). The runbook is read-only by default (`--apply` to write, FK-existence join only).

## Schema / migration impact

sql/194 (new tables only, no rewrites). Applied to dev via the smoke-test boot. Test-fixture TRUNCATE list extended (`trade_events`, `broker_positions_closed`).

## Invariants checked

- Append-only, immutable: no UPDATE path, DO NOTHING conflicts, first observation wins; disagreement = loud WARNING + `conflict_anomaly`.
- ON CONFLICT predicates attached to both partial unique indexes (settled-decisions: partial-unique inference needs the predicate).
- No HTTP inside transactions: history rows fetched in the caller's provider session, passed as data.
- External timestamps only from API payloads (`openDateTime`/`openTimestamp`/`closeTimestamp`), never `now()`.
- `Decimal(str(x))` for every third-party float; NUMERIC(20,8) units/rates, NUMERIC(20,4) USD.
- Non-positive rates are not marks → NULL price + landed-only `null_price` counter.
- Synthetic negative ids (#227) excluded from ledger AND archive by filter + CHECK.
- cash_ledger untouched (broker_sync reconcile stays the cash truth — no double-count).
- Concurrent reconciles serialized (`pg_advisory_xact_lock`, xact-scoped).
- No ON DELETE CASCADE on the audit-grade tables.

## Failure paths considered

- History fetch 429/5xx/network → WARNING, sync proceeds, unmoved watermark re-covers next tick. 403/400/non-JSON 200 body → loud ERROR, same degrade (`fetch_trade_history_safely` + `TradeHistoryParseError` wrap).
- Empty ledger → deep backfill (bootstrap = steady-state with wide window, 1-3 HTTP calls).
- Unresolvable instrument (delisted) → row lands with NULL FK, counted, runbook re-resolves later.
- Missing `openDateTime` / non-positive units → degraded-skip with reason, counted, never fabricated.
- Order-path enqueue lost → next 5-min scheduled tick covers.

## Codex second opinion (ckpt-2, pre-push)

1 HIGH + 3 MED, all FIXED in 4fc1a97: reconcile serialization (advisory xact lock); `response.json()` ValueError wrapped as parse error; `null_price` counted at ingest on landed rows only (×2 findings).

## Verification (DoD clauses 8–12, at 4fc1a97)

- **Smoke (§18 panel = dev demo account, account-scoped source):** ran the real `daily_portfolio_sync` twice against dev DB. First run: `inserted=9` — 7 open events from live positions (VOO, QQQ, IEP×2, GME×2, BBBY; units = initialUnits; source `etoro_sync`) + ILMN open+close from history. Second run: `inserted=0 duplicate=9` (idempotency). `position_id < 0` count = 0; archive rows = 0 (nothing disappeared).
- **Cross-source (§19):** ILMN closed trade — ledger `realized_pnl_usd=1910.4700`, units `82.135523`, open 2025-08-12 @ 97.30 → close 2025-11-14 @ 120.56 — exactly matches the eToro API trade-history row captured in the probe (`tests/fixtures/etoro/trade_history_demo.json`); operator can eyeball the same figures on the eToro web UI history view.
- **Backfill (§10):** executed — the first dev sync above IS the deep backfill (empty-ledger watermark → 2017 epoch fetch).
- **Operator-visible figure (§11):** SQL-level verification this PR (figures above); the browser surface is PR-2's `GET /portfolio/activity` + Activity tab — recorded as the epic's next slice, not silently skipped.
- Local gates at HEAD: ruff ✓ format ✓ pyright 0 ✓ `-m "not db"` 3911 ✓ smoke 129 ✓ scoped db tier (trade_events_db, portfolio_sync ×2, order suites ×4) ✓.

## Conscious tradeoffs

- Always-fetch history every sync tick (1 GET/5min) vs disappearance-triggered: stateless simplicity, 60/min budget barely dented (spec §21).
- `POST_TRADE_SYNC_JOB` name duplicated in `trade_events.py` (scheduler import would be circular) — pinned by `test_post_trade_sync_job_name_matches_scheduler_constant`.
- History-derived opens are Σ-of-slices best-effort; correct for backfill (window spans account lifetime) and superseded by portfolio-sourced opens for watched positions. §22.1 partial-close row shape stays an open question with a loud anomaly counter watching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
