### PR TITLE
feat(#1593): GET /portfolio/activity + Activity tab (PR-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 .testmondata-*
 dist/
 build/
+# pnpm content-addressable store — regenerated at repo root by pnpm runs;
+# machine-local, never check in (leaked once, cleaned up in e92658d8).
+.pnpm-store/
 .DS_Store
 .claude/settings.local.json
 data/

--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -30,7 +30,7 @@ from typing import Any, Literal
 
 import psycopg
 import psycopg.rows
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.api._helpers import parse_optional_float, resolve_quote_price
@@ -1179,3 +1179,114 @@ def get_value_history(
         points=points,
         events=events,
     )
+
+
+# ---------------------------------------------------------------------------
+# GET /portfolio/activity — broker-observed trade ledger (#1593 PR-2)
+# ---------------------------------------------------------------------------
+
+
+class ActivityEventItem(BaseModel):
+    """One trade_events row, render-ready.
+
+    Money fields (fees_usd, realized_pnl_usd) are USD account-currency;
+    price is in the instrument's native currency. ``symbol`` is None
+    when the instrument is absent from the current universe (deep
+    history) — the FE falls back to ``#<etoro_instrument_id>``.
+    """
+
+    event_id: int
+    position_id: int
+    event_kind: Literal["open", "close"]
+    side: Literal["buy", "sell"]
+    symbol: str | None
+    etoro_instrument_id: int
+    units: float
+    price: float | None
+    executed_at: datetime
+    fees_usd: float | None
+    realized_pnl_usd: float | None
+    # Close events only: days between this position's open event and
+    # the close (fractional). None for opens or when no open is on file.
+    holding_period_days: float | None
+    source: Literal["etoro_sync", "etoro_history"]
+    is_mirror: bool
+
+
+class ActivityResponse(BaseModel):
+    events: list[ActivityEventItem]
+    # Total rows matching the filter (events is capped at `limit`).
+    total: int
+    include_mirrors: bool
+
+
+@router.get("/activity", response_model=ActivityResponse)
+def get_activity(
+    limit: int = Query(default=100, ge=1, le=500),
+    include_mirrors: bool = False,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ActivityResponse:
+    """Trade ledger feed, newest first.
+
+    Mirror-originated rows (``social_trade_id != 0``) are excluded by
+    default, consistent with the value-history chart's own-portfolio
+    basis; ``include_mirrors=true`` widens the filter.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        total_row = cur.execute(
+            """
+            SELECT COUNT(*) AS total
+            FROM trade_events
+            WHERE %(include_mirrors)s OR COALESCE(social_trade_id, 0) = 0
+            """,
+            {"include_mirrors": include_mirrors},
+        ).fetchone()
+        total = int(total_row["total"]) if total_row else 0
+
+        rows = cur.execute(
+            """
+            SELECT te.event_id, te.position_id, te.event_kind, te.side,
+                   te.units, te.price, te.executed_at, te.fees_usd,
+                   te.realized_pnl_usd, te.source, te.etoro_instrument_id,
+                   te.social_trade_id, i.symbol,
+                   CASE
+                       WHEN te.event_kind = 'close' AND o.opened_at IS NOT NULL
+                       THEN GREATEST(
+                           0,
+                           EXTRACT(EPOCH FROM te.executed_at - o.opened_at) / 86400.0
+                       )
+                   END AS holding_period_days
+            FROM trade_events te
+            LEFT JOIN instruments i ON i.instrument_id = te.instrument_id
+            LEFT JOIN (
+                SELECT position_id, executed_at AS opened_at
+                FROM trade_events
+                WHERE event_kind = 'open'
+            ) o ON o.position_id = te.position_id AND te.event_kind = 'close'
+            WHERE %(include_mirrors)s OR COALESCE(te.social_trade_id, 0) = 0
+            ORDER BY te.executed_at DESC, te.event_id DESC
+            LIMIT %(limit)s
+            """,
+            {"include_mirrors": include_mirrors, "limit": limit},
+        ).fetchall()
+
+    events = [
+        ActivityEventItem(
+            event_id=row["event_id"],
+            position_id=row["position_id"],
+            event_kind=row["event_kind"],
+            side=row["side"],
+            symbol=row["symbol"],
+            etoro_instrument_id=row["etoro_instrument_id"],
+            units=float(row["units"]),
+            price=parse_optional_float(row, "price"),
+            executed_at=row["executed_at"],
+            fees_usd=parse_optional_float(row, "fees_usd"),
+            realized_pnl_usd=parse_optional_float(row, "realized_pnl_usd"),
+            holding_period_days=parse_optional_float(row, "holding_period_days"),
+            source=row["source"],
+            is_mirror=bool(row["social_trade_id"]),
+        )
+        for row in rows
+    ]
+    return ActivityResponse(events=events, total=total, include_mirrors=include_mirrors)

--- a/frontend/src/api/portfolio.ts
+++ b/frontend/src/api/portfolio.ts
@@ -1,5 +1,6 @@
 import { apiFetch } from "@/api/client";
 import type {
+  ActivityResponse,
   InstrumentPositionDetail,
   PortfolioResponse,
   RollingPnlResponse,
@@ -25,4 +26,9 @@ export function fetchValueHistory(
   return apiFetch<ValueHistoryResponse>(
     `/portfolio/value-history?range=${encodeURIComponent(range)}`,
   );
+}
+
+export function fetchActivity(includeMirrors: boolean): Promise<ActivityResponse> {
+  const params = new URLSearchParams({ include_mirrors: String(includeMirrors) });
+  return apiFetch<ActivityResponse>(`/portfolio/activity?${params}`);
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -568,6 +568,33 @@ export interface ValueHistoryResponse {
   events: ValueHistoryEvent[];
 }
 
+// /portfolio/activity — broker-observed trade ledger (#1593 PR-2).
+// fees_usd / realized_pnl_usd are USD account-currency; price is in the
+// instrument's NATIVE currency. symbol null = instrument absent from the
+// current universe (deep history) — render `#${etoro_instrument_id}`.
+export interface ActivityEventItem {
+  event_id: number;
+  position_id: number;
+  event_kind: "open" | "close";
+  side: "buy" | "sell";
+  symbol: string | null;
+  etoro_instrument_id: number;
+  units: number;
+  price: number | null;
+  executed_at: string;
+  fees_usd: number | null;
+  realized_pnl_usd: number | null;
+  holding_period_days: number | null; // closes only; fractional days
+  source: "etoro_sync" | "etoro_history";
+  is_mirror: boolean;
+}
+
+export interface ActivityResponse {
+  events: ActivityEventItem[];
+  total: number; // rows matching the filter; events capped at `limit`
+  include_mirrors: boolean;
+}
+
 // /portfolio/instruments/:instrumentId — native currency drill-through
 export interface NativeTradeItem {
   position_id: number;

--- a/frontend/src/components/portfolio/ActivitySection.test.tsx
+++ b/frontend/src/components/portfolio/ActivitySection.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Render-state tests for the Activity tab (#1593 PR-2): loading / error /
+ * empty / table, mirror-toggle refetch param, symbol fallback, and the
+ * USD money + holding-period rendering — the state contract per
+ * loading-error-empty-states.md.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ActivityEventItem, ActivityResponse } from "@/api/types";
+
+import { ActivitySection } from "./ActivitySection";
+
+vi.mock("@/api/portfolio", () => ({
+  fetchActivity: vi.fn(),
+}));
+
+import { fetchActivity } from "@/api/portfolio";
+
+const fetchMock = vi.mocked(fetchActivity);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fetchMock.mockReset();
+});
+
+function event(over: Partial<ActivityEventItem> = {}): ActivityEventItem {
+  return {
+    event_id: 9,
+    position_id: 3308442654,
+    event_kind: "close",
+    side: "sell",
+    symbol: "ILMN",
+    etoro_instrument_id: 4077,
+    units: 82.135523,
+    price: 120.56,
+    executed_at: "2025-11-14T19:24:35.307Z",
+    fees_usd: 0,
+    realized_pnl_usd: 1910.47,
+    holding_period_days: 94.1,
+    source: "etoro_history",
+    is_mirror: false,
+    ...over,
+  };
+}
+
+function response(events: ActivityEventItem[], total?: number): ActivityResponse {
+  return { events, total: total ?? events.length, include_mirrors: false };
+}
+
+describe("ActivitySection states", () => {
+  it("shows the skeleton while loading", () => {
+    fetchMock.mockReturnValue(new Promise(() => {}));
+    render(<ActivitySection />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("shows the error surface with retry on failure", async () => {
+    fetchMock.mockRejectedValue(new Error("boom"));
+    render(<ActivitySection />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    });
+    // Fixed phrase only — never exception text in the DOM.
+    expect(screen.queryByText(/boom/)).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state with the next-action hint", async () => {
+    fetchMock.mockResolvedValue(response([]));
+    render(<ActivitySection />);
+    await waitFor(() => {
+      expect(screen.getByText("No trade activity yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/portfolio sync/)).toBeInTheDocument();
+  });
+
+  it("renders a close row with USD P&L, side pill and holding period", async () => {
+    fetchMock.mockResolvedValue(response([event()]));
+    render(<ActivitySection />);
+    await waitFor(() => {
+      expect(screen.getByText("ILMN")).toBeInTheDocument();
+    });
+    expect(screen.getByText("SELL")).toBeInTheDocument();
+    // en-GB locale renders USD as "US$…"
+    expect(screen.getByText("US$1,910.47")).toBeInTheDocument();
+    expect(screen.getByText("94 d")).toBeInTheDocument();
+  });
+
+  it("falls back to #etoro_id when the symbol is unresolved", async () => {
+    fetchMock.mockResolvedValue(response([event({ symbol: null })]));
+    render(<ActivitySection />);
+    await waitFor(() => {
+      expect(screen.getByText("#4077")).toBeInTheDocument();
+    });
+  });
+
+  it("defaults to own activity and refetches with mirrors on toggle", async () => {
+    fetchMock.mockResolvedValue(response([event()]));
+    render(<ActivitySection />);
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(false);
+    });
+    await userEvent.click(screen.getByLabelText(/include copy-trading/i));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it("flags mirror rows and shows the capped-count note", async () => {
+    fetchMock.mockResolvedValue(response([event({ is_mirror: true })], 250));
+    render(<ActivitySection />);
+    await waitFor(() => {
+      expect(screen.getByText("mirror")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/showing 1 of 250/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/portfolio/ActivitySection.tsx
+++ b/frontend/src/components/portfolio/ActivitySection.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { fetchActivity } from "@/api/portfolio";
+import type { ActivityEventItem } from "@/api/types";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { formatDateTime, formatMoney, formatNumber } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+/**
+ * Activity tab — the broker-observed trade ledger (#1593 PR-2).
+ *
+ * One row per `trade_events` open/close. Mirror (copy-trading) rows are
+ * excluded by default, consistent with the value-history chart's
+ * own-portfolio basis; the toggle widens the server-side filter.
+ *
+ * Money columns (fees, realised P&L) are USD account-currency; price is
+ * the instrument's native-currency rate, so it renders as a plain
+ * number, not money.
+ */
+export function ActivitySection() {
+  const [includeMirrors, setIncludeMirrors] = useState(false);
+  // Filter-driven refetch: prior payload is semantically wrong for the
+  // new filter, so default clear-on-refetch is correct here.
+  const activity = useAsync(() => fetchActivity(includeMirrors), [includeMirrors]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+          <input
+            type="checkbox"
+            checked={includeMirrors}
+            onChange={(e) => setIncludeMirrors(e.target.checked)}
+            className="rounded border-slate-300 dark:border-slate-700"
+          />
+          Include copy-trading activity
+        </label>
+        {activity.data !== null && activity.data.events.length < activity.data.total ? (
+          <span className="text-xs text-slate-400">
+            showing {activity.data.events.length} of {activity.data.total}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="overflow-hidden rounded-md border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+        {activity.error !== null ? (
+          <SectionError onRetry={activity.refetch} />
+        ) : activity.loading || activity.data === null ? (
+          <SectionSkeleton rows={6} />
+        ) : activity.data.events.length === 0 ? (
+          <EmptyState
+            title="No trade activity yet"
+            description="Events appear once the portfolio sync observes a position open or close — place an order or wait for the next sync."
+          />
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs uppercase tracking-wide text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                <th className="px-3 py-2 font-medium">When</th>
+                <th className="px-3 py-2 font-medium">Action</th>
+                <th className="px-3 py-2 font-medium">Symbol</th>
+                <th className="px-3 py-2 text-right font-medium">Units</th>
+                <th className="px-3 py-2 text-right font-medium">Price</th>
+                <th className="px-3 py-2 text-right font-medium">Fees</th>
+                <th className="px-3 py-2 text-right font-medium">Realised P&amp;L</th>
+                <th className="px-3 py-2 text-right font-medium">Held</th>
+              </tr>
+            </thead>
+            <tbody>
+              {activity.data.events.map((e) => (
+                <ActivityRow key={e.event_id} event={e} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ActivityRow({ event }: { event: ActivityEventItem }) {
+  const sideLabel = event.side === "buy" ? "BUY" : "SELL";
+  const sidePill =
+    event.side === "buy"
+      ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
+      : "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+  const pnl = event.realized_pnl_usd;
+  const pnlClass =
+    pnl === null
+      ? "text-slate-400"
+      : pnl >= 0
+        ? "text-emerald-600 dark:text-emerald-400"
+        : "text-red-600 dark:text-red-400";
+
+  return (
+    <tr className="border-b border-slate-100 last:border-0 dark:border-slate-800/60">
+      <td className="whitespace-nowrap px-3 py-2 text-slate-600 dark:text-slate-400">
+        {formatDateTime(event.executed_at)}
+      </td>
+      <td className="px-3 py-2">
+        <span className={`rounded px-1.5 py-0.5 text-xs font-semibold ${sidePill}`}>
+          {sideLabel}
+        </span>
+        {event.is_mirror ? (
+          <span className="ml-1 rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+            mirror
+          </span>
+        ) : null}
+      </td>
+      <td className="px-3 py-2 font-medium text-slate-800 dark:text-slate-100">
+        {event.symbol ?? `#${event.etoro_instrument_id}`}
+      </td>
+      <td className="px-3 py-2 text-right tabular-nums text-slate-700 dark:text-slate-300">
+        {formatNumber(event.units, 4)}
+      </td>
+      <td className="px-3 py-2 text-right tabular-nums text-slate-700 dark:text-slate-300">
+        {formatNumber(event.price, 2)}
+      </td>
+      <td className="px-3 py-2 text-right tabular-nums text-slate-500 dark:text-slate-400">
+        {formatMoney(event.fees_usd, "USD")}
+      </td>
+      <td className={`px-3 py-2 text-right tabular-nums font-medium ${pnlClass}`}>
+        {formatMoney(pnl, "USD")}
+      </td>
+      <td className="px-3 py-2 text-right tabular-nums text-slate-500 dark:text-slate-400">
+        {event.holding_period_days === null ? "—" : `${Math.round(event.holding_period_days)} d`}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -26,14 +26,20 @@ import type {
 vi.mock("@/api/portfolio", () => ({
   fetchPortfolio: vi.fn(),
   fetchInstrumentPositions: vi.fn(),
+  fetchActivity: vi.fn(),
 }));
 vi.mock("@/api/orders", () => ({ placeOrder: vi.fn(), closePosition: vi.fn() }));
 
 import { TestConfigProvider } from "@/lib/ConfigContext";
-import { fetchPortfolio, fetchInstrumentPositions } from "@/api/portfolio";
+import {
+  fetchPortfolio,
+  fetchInstrumentPositions,
+  fetchActivity,
+} from "@/api/portfolio";
 
 const mockedFetchPortfolio = vi.mocked(fetchPortfolio);
 const mockedFetchInstrumentPositions = vi.mocked(fetchInstrumentPositions);
+const mockedFetchActivity = vi.mocked(fetchActivity);
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -369,6 +375,26 @@ describe("PortfolioPage — keyboard", () => {
     await screen.findByTestId("position-row-1");
 
     await user.keyboard("{Control>}{Enter}{/Control}");
+    expect(screen.getByTestId("location").textContent).toBe("/portfolio");
+  });
+
+  it("Activity tab suppresses positions shortcuts — Enter does not drill a hidden row", async () => {
+    // pageRowsRef still holds the positions page after the table
+    // unmounts, so an un-gated Enter on the Activity tab would navigate
+    // into a hidden row. Regression guard for the Codex #1593 finding.
+    mockedFetchActivity.mockResolvedValue({
+      events: [],
+      total: 0,
+      include_mirrors: false,
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId("position-row-1"); // positions loaded → ref populated
+
+    await user.click(screen.getByRole("tab", { name: "Activity" }));
+    await screen.findByText(/No trade activity yet/); // ActivitySection mounted
+
+    await user.keyboard("{Enter}"); // would drill row 0 (AAA) without the tab gate
     expect(screen.getByTestId("location").textContent).toBe("/portfolio");
   });
 });

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -15,6 +15,7 @@ import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
+import { ActivitySection } from "@/components/portfolio/ActivitySection";
 import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import { LivePriceCell } from "@/components/quotes/LivePriceCell";
 import type {
@@ -58,6 +59,7 @@ export function PortfolioPage() {
   const currency = useDisplayCurrency();
   const navigate = useNavigate();
 
+  const [tab, setTab] = useState<"positions" | "activity">("positions");
   const [search, setSearch] = useState("");
   const [focusedIdx, setFocusedIdx] = useState<number>(0);
   const [page, setPage] = useState<number>(1);
@@ -169,6 +171,10 @@ export function PortfolioPage() {
     }
 
     function onKey(e: KeyboardEvent) {
+      // Positions-tab shortcuts only. On the Activity tab the table is
+      // unmounted but `pageRowsRef` still holds the last positions page,
+      // so an un-gated Enter would drill into a hidden row (Codex #1593).
+      if (tab !== "positions") return;
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       if (addFor !== null || closeFor !== null) return;
 
@@ -219,7 +225,7 @@ export function PortfolioPage() {
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [addFor, closeFor, drillInto]);
+  }, [tab, addFor, closeFor, drillInto]);
 
   return (
     <div className="space-y-4 pt-6">
@@ -227,7 +233,36 @@ export function PortfolioPage() {
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Portfolio</h1>
       </div>
 
-      {portfolio.error !== null ? (
+      <div role="tablist" className="flex gap-1 border-b border-slate-200 dark:border-slate-800">
+        {(
+          [
+            { key: "positions", label: "Positions" },
+            { key: "activity", label: "Activity" },
+          ] as const
+        ).map((t) => {
+          const active = tab === t.key;
+          return (
+            <button
+              key={t.key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setTab(t.key)}
+              className={`-mb-px rounded-t border border-b-0 px-3 py-1 text-sm font-medium ${
+                active
+                  ? "border-slate-300 bg-white text-slate-800 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                  : "border-transparent bg-transparent text-slate-500 hover:bg-slate-50 dark:text-slate-400 dark:hover:bg-slate-800/40"
+              }`}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {tab === "activity" ? (
+        <ActivitySection />
+      ) : portfolio.error !== null ? (
         <SectionError onRetry={portfolio.refetch} />
       ) : portfolio.loading || portfolio.data === null ? (
         <SectionSkeleton rows={8} />


### PR DESCRIPTION
## What & why

Operator brief (#1593): *"We can't see when items were bought and sold."* PR-1 (#1610) landed the `trade_events` ledger (schema + eToro sync/history ingest + closed-position archive). This PR is scope item 4 — the **read surface**: a `GET /portfolio/activity` endpoint and an **Activity** tab on PortfolioPage.

**Part of #1593** (epic stays open for value-over-time v2 + the reports section, which consume this ledger).

## Changes

**Backend** — `app/api/portfolio.py`
- `GET /portfolio/activity` — `trade_events` feed, newest-first (`executed_at DESC, event_id DESC`).
- `holding_period_days` computed server-side: `LEFT JOIN` each `close` event to its position's `open` row, `EXTRACT(EPOCH …)/86400`, `GREATEST(0, …)` clamp. `null` for opens / no open on file.
- Mirror (copy-trading) rows excluded by default (`COALESCE(social_trade_id,0)=0`), matching the value-history chart's own-portfolio basis; `include_mirrors=true` widens.
- `limit` bounded 1–500 (`Query(ge=1, le=500)`); `total` returned for the "showing N of M" note.

**Frontend**
- `PortfolioPage.tsx` — `Positions | Activity` tab bar (ProcessDetailPage idiom).
- `ActivitySection.tsx` — own `useAsync` keyed on the mirror toggle (filter-driven clear-on-refetch); loading / error / empty states per `loading-error-empty-states.md`. Fees & realised P&L are USD columns; price is native-ccy (plain number, not money); `#<etoro_instrument_id>` fallback when `symbol` is null (deep history, instrument absent from universe).
- `types.ts` + `portfolio.ts` fetcher updated same-PR per `api-shape-and-types.md` (FE↔BE field/type parity verified).

## Security model
- **AuthN**: inherited router-level — the portfolio router declares `dependencies=[Depends(require_session_or_service_token)]` (`app/api/auth.py`), so `/activity` requires a browser session cookie **or** bearer service token. Verified: `401 Unauthorized` without a token.
- **AuthZ**: single-operator system; `trade_events` is the operator's own broker ledger — no multi-tenant resource-ownership gate applies, consistent with sibling reads (`/portfolio`, `/portfolio/value-history`).
- **SQLi**: every query fully parameterized (`%(name)s` dict params); `limit`/`include_mirrors` are typed, bounded query params bound as parameters — never interpolated.
- **Read-only**: GET, no writes.
- **Out-of-diff invariant**: the holding-period join is single-valued because `sql/194_trade_events.sql` defines `uq_trade_events_open` — a **partial unique index on `(position_id) WHERE event_kind='open'`** — so each close matches exactly one open; `total` (a separate `COUNT(*)`) and the list stay consistent.

## Tradeoffs
- `holding_period_days` is fractional days; the FE rounds to whole days for display. Raw value shipped so consumers can reuse it.
- Default page cap 500; the "showing N of M" note signals truncation. No cursor pagination yet — current ledger is small (9 rows on dev); revisit when it grows.
- Mirror rows default-excluded (matches the chart). Toggle is server-side, not a client filter, so `total` reflects the active filter.

## Verification (commit `cc4f4c9`)
- **Codex ckpt-2** (pre-push) flagged one real [P2]: the positions-table window `keydown` handler stayed live on the Activity tab — `pageRowsRef` survives the table unmount, so an un-gated **Enter drilled into a hidden row**. Fixed by gating the handler on `tab === "positions"` (+`tab` in deps). Regression test added and **proven red without the fix** (`expected '/instrument/AAA' to be '/portfolio'`).
- **Live dev probe** (`:8000`, bearer auth):
  - 9 events, newest-first ordering confirmed.
  - ILMN close (`position 3308442654`): realised P&L **$1910.47**, `holding_period_days` **94.1093** — independently validated against the open row (open `2025-08-12T16:47:12Z` → close `2025-11-14T19:24:35Z` = 94.1093 d, exact match).
  - Opens correctly `null` for realised P&L / holding period.
  - `limit=0` → 422, `limit=501` → 422 (bounds enforced).
  - `include_mirrors` toggles cleanly (total 9 both ways — dev has no mirror `trade_events` yet; filter logic unit-tested).
- **Gates green**: ruff check/format, pyright 0 errors, pytest fast tier 3912 passed / smoke 129 passed; FE `tsc` clean, `test:unit` 1020 passed (incl. new guard). Pre-push hook green.
- No schema / parser / migration in this PR (reads PR-1's `trade_events`) — DoD ETL clauses 8–12 N/A.

Spec: `docs/proposals/etl/2026-06-13-etoro-trade-ledger.md`. Follows PR-1 #1610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
