### PR TITLE
feat(#1615): born-compact write-only primary_doc payload at source

### DIFF
--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -77,6 +77,16 @@ DocumentKind = Literal[
 # accession number — they belong in their own per-CIK store, not in
 # this per-filing table. Claude PR 808 review (BLOCKING) caught the
 # prior overload that smuggled CIKs into the accession_number column.
+
+# Kinds whose payload is WRITE-ONLY — no rewash parser reads them and
+# the manifest rebuild re-fetches from EDGAR unconditionally (sql/190).
+# ``store_raw`` persists these **born-compacted** (#1615): payload NULL +
+# payload_sha256 + payload_swept_at, the same state the #1014 sweep
+# produces, so ~22 GB of primary_doc bytes are never stored. MUST stay
+# disjoint from the rewash registry (a rewash parser reads stored bodies,
+# which a born-compacted row lacks). Canonical here (single source of
+# truth); ``raw_payload_retention`` imports it.
+SWEPT_DOCUMENT_KINDS: frozenset[DocumentKind] = frozenset({"primary_doc"})
 # Future PR adds a sibling ``cik_raw_documents`` table for those.
 
 
@@ -125,11 +135,58 @@ def store_raw(
     ``parser_version`` + ``source_url``. The new body is treated as
     authoritative — re-fetches from SEC are exactly when
     overwriting is correct (the document may have been amended).
+
+    ``SWEPT_DOCUMENT_KINDS`` (write-only kinds) are stored
+    **born-compacted** (#1615): the ``payload`` is hashed server-side
+    and the column is written ``NULL`` so the bytes are never persisted.
+    Such a row is identical to a #1014-swept row (payload NULL +
+    payload_sha256 + payload_swept_at) and is rehydratable from
+    ``source_url`` — which is therefore REQUIRED for these kinds.
     """
     if not accession_number:
         raise ValueError("accession_number is required")
     if not payload:
-        raise ValueError("payload is required (empty payload would defeat re-wash)")
+        raise ValueError("payload is required (empty payload would defeat re-wash / leave no hash)")
+
+    if document_kind in SWEPT_DOCUMENT_KINDS:
+        # Born-compacted: hash the bytes server-side (byte-identical to the
+        # #1014 sweep + the rehydrate verifier, sql/190), store NULL
+        # payload. source_url is the ONLY recovery path for a payload-less
+        # row, so it is mandatory — the guard below makes EXCLUDED.source_url
+        # non-NULL on every conflict, so it can never regress to NULL.
+        if not source_url:
+            raise ValueError(
+                f"source_url is required for write-only kind {document_kind!r} "
+                "(born-compacted rows are rehydrated from source_url)"
+            )
+        conn.execute(
+            """
+            INSERT INTO filing_raw_documents (
+                accession_number, document_kind, payload, payload_sha256,
+                payload_swept_at, parser_version, source_url, fetched_at
+            ) VALUES (
+                %(acc)s, %(kind)s, NULL,
+                encode(sha256(convert_to(%(payload)s, 'UTF8')), 'hex'),
+                NOW(), %(pv)s, %(url)s, NOW()
+            )
+            ON CONFLICT (accession_number, document_kind) DO UPDATE SET
+                payload = NULL,
+                payload_sha256 = encode(sha256(convert_to(%(payload)s, 'UTF8')), 'hex'),
+                payload_swept_at = NOW(),
+                parser_version = EXCLUDED.parser_version,
+                source_url = EXCLUDED.source_url,
+                fetched_at = NOW()
+            """,
+            {
+                "acc": accession_number,
+                "kind": document_kind,
+                "payload": payload,
+                "pv": parser_version,
+                "url": source_url,
+            },
+        )
+        return
+
     conn.execute(
         """
         INSERT INTO filing_raw_documents (

--- a/app/services/raw_payload_retention.py
+++ b/app/services/raw_payload_retention.py
@@ -42,7 +42,7 @@ import psycopg
 import psycopg.rows
 
 from app.config import settings
-from app.services.raw_filings import DocumentKind
+from app.services.raw_filings import SWEPT_DOCUMENT_KINDS, DocumentKind
 
 logger = logging.getLogger(__name__)
 
@@ -50,10 +50,12 @@ DEFAULT_BATCH_SIZE = 100
 """Bounds per-tx detoast cost (10-K avg ~3.5 MB -> ~350 MB worst-case
 detoast per batch for the server-side hash) and the WAL burst."""
 
-# The document kinds the sweep may destroy payloads for. MUST stay
-# disjoint from the rewash registry (structural test) — a registered
-# rewash parser reads stored bodies, which a sweep would null.
-SWEPT_DOCUMENT_KINDS: frozenset[DocumentKind] = frozenset({"primary_doc"})
+# ``SWEPT_DOCUMENT_KINDS`` is canonical in ``raw_filings`` (#1615) — the
+# same set ``store_raw`` born-compacts at ingest, so this retroactive
+# sweep and the source-side born-compaction can never diverge. Re-export
+# kept so existing importers (and the retention-classification test)
+# resolve it here too.
+__all__ = ["SWEPT_DOCUMENT_KINDS", "sweep_raw_payloads", "rehydrate_raw_document"]
 
 # Manifest sources whose parsed accessions are sweep-eligible. Keyed on
 # ``sec_filing_manifest.source`` (CHECK-constrained enum, collapses

--- a/docs/specs/etl/2026-06-13-primary-doc-born-compacted.md
+++ b/docs/specs/etl/2026-06-13-primary-doc-born-compacted.md
@@ -1,0 +1,155 @@
+# Stop persisting write-only primary_doc payload at source (born-compacted)
+
+Issue: #1615. Area: filings ETL / data-engineering. Follows A1 (sweep +
+VACUUM reclaim, dev 44→21 GB this session). A3 (durable guard) is a
+separate follow-up PR.
+
+## Problem
+
+`filing_raw_documents.primary_doc` payload is **write-only** — no rewash
+parser reads it (pinned by `tests/test_raw_payload_retention.py`), and
+manifest rebuild re-fetches from EDGAR unconditionally (sql/190). It was
+~22 GB / 52 % of dev DB. The #1014 sweep nulls it retroactively but it
+regrows (742 MB → 23 GB in 3 days) because steady-state ingest re-stores
+the payload. Fix it at the **source**: never persist the bytes.
+
+## Write sites (7, not 3)
+
+`document_kind="primary_doc"` with payload:
+- Services (lazy / API path): `eight_k_events.py:727`,
+  `business_summary.py:1194`, `institutional_holdings.py:1466`.
+- **Manifest parsers (steady-state bulk drain — the regrowth engine):**
+  `manifest_parsers/sec_10k.py:307` + `:448`, `manifest_parsers/sec_13f_hr.py:294`,
+  `manifest_parsers/eight_k.py:293`.
+
+## Design — centralize born-compaction in `store_raw`
+
+All 7 sites call `raw_filings.store_raw(... payload=...)`. Rather than
+edit 7 call sites (miss-prone; a future writer forgets), branch **once**
+in `store_raw`:
+
+- `document_kind ∈ SWEPT_DOCUMENT_KINDS` (= `{"primary_doc"}`): write the
+  row **born-compacted** — `payload = NULL`, `payload_sha256 =
+  encode(sha256(convert_to(%(payload)s,'UTF8')),'hex')` (server-side,
+  byte-identical to the #1014 sweep + the rehydrate verifier per
+  sql/190), `payload_swept_at = NOW()`, plus `source_url`,
+  `parser_version`, `fetched_at = NOW()`. The payload param is sent only
+  to be hashed server-side; it is never stored in the column. `ON
+  CONFLICT` updates the same shape (re-using the `%(payload)s` named
+  param in both the INSERT and the UPDATE SET).
+- All other kinds: unchanged (store payload, clear sweep state).
+
+This is exactly the post-sweep / rehydratable state, so:
+- `chk_swept_rows_carry_hash` (payload NULL ⇒ sha + swept_at) is satisfied.
+- `byte_count` (GENERATED from `octet_length(payload)`) is NULL — the
+  operator storage chip reports live payload bytes only (correct: 0).
+- The #938 raw-before-parsed invariant holds (the row exists; only the
+  bytes are absent).
+- `rehydrate_raw_document` still works (sha + source_url present): any
+  future need re-fetches from EDGAR and hash-verifies.
+- The #1014 sweep skips these rows (its batch requires `payload IS NOT
+  NULL`) — it becomes a no-op for primary_doc, defense-in-depth only.
+
+The `if not payload: raise` guard stays: callers must still pass the
+bytes (we hash them), and an empty payload is still a bug.
+
+### `SWEPT_DOCUMENT_KINDS` single source of truth
+
+Move the canonical `SWEPT_DOCUMENT_KINDS` frozenset from
+`raw_payload_retention.py` into `raw_filings.py` (next to `DocumentKind`
++ `store_raw`); `raw_payload_retention` imports it from there. Avoids a
+circular import (retention already imports `DocumentKind` from
+raw_filings) and gives A3's retention-classification test one set to key
+on.
+
+### source_url is load-bearing for swept kinds (Codex ckpt-1 #1)
+
+A born-compacted row's only recovery path is `rehydrate_raw_document`,
+which needs `source_url`. All 7 current sites pass a non-empty
+`source_url`, but `store_raw`'s signature allows `None` and the existing
+`ON CONFLICT` would overwrite a good URL with `NULL` → an unrecoverable
+`payload NULL + sha + no URL` row. So:
+- For `SWEPT_DOCUMENT_KINDS`, `store_raw` **raises** if `source_url` is
+  empty (a born-compacted row MUST be rehydratable — fail loud at write).
+  The guard makes `EXCLUDED.source_url` non-NULL on every conflict, so
+  `ON CONFLICT … source_url = EXCLUDED.source_url` can never regress a
+  stored URL to NULL (no COALESCE needed).
+
+### raw_status semantics — redefined, not "cosmetic" (Codex ckpt-1 #2/#4)
+
+The 7 callers flip manifest `raw_status='stored'` after `store_raw`, and
+sql/118 documents `raw_status` as "filing_raw_documents has the body".
+Born-compaction makes that literally false for primary_doc, and existing
+tests assert body presence (`test_institutional_holdings_ingester.py::
+test_raw_payload_persisted_for_primary_doc_and_infotable` via
+`require_payload()`; `test_etl_source_to_sink.py` `byte_count > 0`;
+`test_manifest_parser_sec_10k.py`). This is a **conscious model change**,
+not cosmetic:
+
+- Redefine `raw_status` semantics via a new `sql/195` `COMMENT ON
+  COLUMN` migration (sql/118 is an applied migration — the #1333
+  content-drift guard forbids editing it): "a raw evidence row exists
+  for this accession; whether the **bytes** are present is given by
+  `filing_raw_documents.payload_swept_at IS NULL` / `byte_count`".
+  `payload_swept_at` (not `raw_status`) is the authoritative "is the body
+  actually here" signal — already true for #1014-swept rows.
+- Keep `raw_status='stored'` on born-compacted rows (avoids editing 7
+  callers; the chokepoint stays in `store_raw`). Consequence: a
+  payload-less primary_doc may read `'stored'` (born-compacted) or
+  `'compacted'` (#1014-swept). The two are indistinguishable by
+  `raw_status` alone — acceptable, because no consumer distinguishes
+  them: both are payload-less + carry sha + URL and rehydrate identically.
+  Verified no constraint/check enforces `stored ⇒ payload present`;
+  rewash keys on `document_kind` + `require_payload()` (raises on NULL),
+  rehydrate keys on `payload IS NULL` + sha, the sweep batch keys on
+  `payload IS NOT NULL`.
+- Update every test asserting primary_doc body/`byte_count` presence to
+  the new contract (payload NULL, sha present, source_url present). These
+  are listed in the test section.
+
+### Rehydrate of a born-compacted 13F primary_doc (Codex ckpt-1 #3)
+
+The #1014 sweep targets only `sec_10k`/`sec_8k`, so a 13F `primary_doc`
+that is *rehydrated* (payload restored) is not re-compacted by the
+backstop sweep. In practice nothing in production calls
+`rehydrate_raw_document` for `primary_doc` (it is the manual operator
+recovery path), so this is theoretical. Documented: rehydrate is allowed
+to create a transient live 13F primary_doc payload until the next ingest
+overwrites it (which, post-fix, born-compacts it again). A3 may widen
+sweep eligibility if this ever matters.
+
+## Tests (pure-logic + one DB integration)
+
+- `store_raw(primary_doc, payload=…)` → row: `payload IS NULL`,
+  `payload_sha256` = the server-side hash of the input, `payload_swept_at`
+  set, `byte_count IS NULL`, `source_url` kept. (DB integration — one new
+  mechanism.)
+- `store_raw(form4_xml, payload=…)` → payload **stored**, sha NULL
+  (regression guard: re-wash kinds unaffected).
+- Idempotent re-call of `store_raw(primary_doc)` stays born-compacted (no
+  payload resurrected).
+- The recorded `payload_sha256` equals
+  `hashlib.sha256(payload.encode("utf-8")).hexdigest()` (rehydrate-verify
+  consistency).
+- `SWEPT_DOCUMENT_KINDS` import-from-raw_filings round-trips
+  (raw_payload_retention still references the same set).
+
+## Dev verification (CLAUDE.md clauses 8-12)
+
+- Panel: trigger a re-ingest of a known 10-K (e.g. AAPL) + an 8-K + a 13F
+  primary_doc on dev; confirm each new `filing_raw_documents` primary_doc
+  row is born `payload IS NULL` + `payload_sha256` present.
+- Confirm `pg_total_relation_size('filing_raw_documents')` stays flat
+  across a manifest-drain tick (no payload regrowth) vs the pre-fix
+  regrowth.
+- Cross-source: rehydrate one born-compacted primary_doc and confirm the
+  live EDGAR re-fetch hash-matches the recorded sha (proves the recorded
+  hash is the real document's).
+- Record commit SHA + figures in the PR.
+
+## Out of scope (→ A3)
+
+Scheduling the sweep as a backstop, the retention-classification CI
+test, per-table size alarm, docs/settled-decisions + data-engineer skill
+§13.D. The 13F `infotable_13f` second store (institutional_holdings:1531)
+is a re-wash kind — untouched.

--- a/sql/195_raw_status_semantics_born_compacted.sql
+++ b/sql/195_raw_status_semantics_born_compacted.sql
@@ -1,0 +1,24 @@
+-- 195_raw_status_semantics_born_compacted.sql
+--
+-- #1615 — redefine sec_filing_manifest.raw_status semantics on live DBs.
+--
+-- store_raw now writes write-only kinds (primary_doc) BORN-COMPACTED:
+-- payload NULL + payload_sha256 + payload_swept_at, so the bytes are
+-- never persisted. The callers still flip raw_status='stored' (the
+-- born-compaction is centralized in store_raw, not the 7 manifest
+-- writers). So raw_status='stored' no longer implies the payload bytes
+-- are present.
+--
+-- This is a COMMENT-only migration: it carries the redefined meaning to
+-- \d+ / catalog introspection. No data or constraint change. The
+-- authoritative "are the bytes here" predicate is
+-- filing_raw_documents.payload_swept_at IS NULL (NULL = bytes present).
+
+COMMENT ON COLUMN sec_filing_manifest.raw_status IS
+    'Whether a filing_raw_documents raw-evidence ROW exists for this '
+    'accession — NOT whether the payload bytes are present. '
+    'stored = a raw row exists (bytes may be present, #1014-swept, or '
+    'born-compacted for write-only kinds like primary_doc, #1615). '
+    'compacted = the #1014 retention sweep nulled a previously-stored '
+    'payload. absent = no raw row. The authoritative "bytes present" '
+    'signal is filing_raw_documents.payload_swept_at IS NULL / byte_count.';

--- a/tests/test_institutional_holdings_ingester.py
+++ b/tests/test_institutional_holdings_ingester.py
@@ -359,14 +359,16 @@ class TestIngestFiler13F:
         assert rows[0]["market_value_usd"] == Decimal("69900000")
         assert rows[0]["voting_authority"] == "SOLE"
 
-    def test_raw_payload_persisted_for_primary_doc_and_infotable(
+    def test_raw_evidence_persisted_for_primary_doc_and_infotable(
         self,
         _setup: psycopg.Connection[tuple],
     ) -> None:
-        """13F ingester must persist BOTH the primary_doc.xml and
-        the infotable.xml bodies to ``filing_raw_documents`` before
-        parsing — operator audit 2026-05-03 + PR #808 contract.
-        Re-wash workflows depend on these rows."""
+        """13F ingester must persist a raw-evidence row for BOTH the
+        primary_doc.xml and the infotable.xml — operator audit 2026-05-03
+        + PR #808 contract. Since #1615 primary_doc is a write-only kind:
+        its row is BORN-COMPACTED (payload NULL + sha + source_url,
+        rehydratable) — the bytes are never stored. infotable_13f is a
+        re-wash kind and keeps its body."""
         from app.services import raw_filings
 
         conn = _setup
@@ -384,7 +386,10 @@ class TestIngestFiler13F:
             document_kind="primary_doc",
         )
         assert primary is not None
-        assert "BERKSHIRE" in primary.require_payload().upper() or "<edgarSubmission" in primary.require_payload()
+        # Born-compacted: no bytes, but a verifiable hash + recovery URL.
+        assert primary.payload is None and primary.byte_count is None
+        with pytest.raises(RuntimeError, match="swept"):
+            primary.require_payload()
         assert primary.parser_version == "13f-primary-v1"
         assert primary.source_url is not None
         assert primary.source_url.endswith("primary_doc.xml")

--- a/tests/test_manifest_parser_eight_k.py
+++ b/tests/test_manifest_parser_eight_k.py
@@ -177,18 +177,24 @@ def test_happy_path_parses_and_stores_raw(
     assert row8k[1] == "8-K"
     assert row8k[2] is False
 
-    # filing_raw_documents has the body so a future re-wash can reparse.
+    # filing_raw_documents has a BORN-COMPACTED primary_doc row (#1615):
+    # 8-K primary_doc is write-only, so the row carries sha + swept_at +
+    # source_url (rehydratable) but the bytes are never stored.
     with ebull_test_conn.cursor() as cur:
         cur.execute(
             """
-            SELECT byte_count FROM filing_raw_documents
+            SELECT payload, byte_count, payload_sha256, payload_swept_at, source_url
+            FROM filing_raw_documents
             WHERE accession_number = '0000320193-26-000001'
               AND document_kind = 'primary_doc'
             """
         )
         raw = cur.fetchone()
     assert raw is not None
-    assert raw[0] > 0
+    payload, byte_count, sha, swept_at, source_url = raw
+    assert payload is None and byte_count is None
+    assert sha is not None and len(sha) == 64 and swept_at is not None
+    assert source_url
 
 
 def test_empty_fetch_tombstones(

--- a/tests/test_manifest_parser_sec_10k.py
+++ b/tests/test_manifest_parser_sec_10k.py
@@ -259,14 +259,22 @@ def test_happy_path_parses_and_stores_raw(
     assert body_row[1] == "0000999991-26-000001"
     assert body_row[2] is not None  # filed_at populated
 
-    # Raw stored under primary_doc.
+    # Raw evidence row stored under primary_doc — BORN-COMPACTED (#1615):
+    # a write-only kind, so the payload bytes are never persisted. The row
+    # exists with a recorded sha + swept_at + source_url (rehydratable),
+    # payload + byte_count NULL.
     with ebull_test_conn.cursor() as cur:
         cur.execute(
-            "SELECT byte_count FROM filing_raw_documents "
+            "SELECT payload, byte_count, payload_sha256, payload_swept_at, source_url "
+            "FROM filing_raw_documents "
             "WHERE accession_number = '0000999991-26-000001' AND document_kind = 'primary_doc'"
         )
         raw = cur.fetchone()
-    assert raw is not None and raw[0] > 0
+    assert raw is not None
+    payload, byte_count, sha, swept_at, source_url = raw
+    assert payload is None and byte_count is None
+    assert sha is not None and len(sha) == 64 and swept_at is not None
+    assert source_url  # mandatory recovery path for born-compacted rows
 
 
 def test_happy_path_fans_out_to_share_class_siblings(

--- a/tests/test_raw_filings.py
+++ b/tests/test_raw_filings.py
@@ -7,6 +7,8 @@ CHECK constraint.
 
 from __future__ import annotations
 
+import hashlib
+
 import psycopg
 import pytest
 
@@ -135,6 +137,95 @@ def test_empty_payload_rejected_at_helper(
             document_kind="form4_xml",
             payload="",
         )
+
+
+_SAMPLE_PRIMARY_DOC = "<edgarSubmission><headerData>primary doc body</headerData></edgarSubmission>"
+_PRIMARY_URL = "https://www.sec.gov/Archives/edgar/data/1/000/primary_doc.html"
+
+
+def test_store_primary_doc_is_born_compacted(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """#1615 — write-only kinds (primary_doc) are stored BORN-COMPACTED:
+    payload NULL + recorded sha + swept_at, the bytes never persisted.
+    The row still exists (#938 raw-before-parsed invariant) and is
+    rehydratable from source_url. The recorded hash is byte-identical to
+    the Python rehydrate verifier."""
+    conn = ebull_test_conn
+    accession = "0001767470-26-001615"
+    raw_filings.store_raw(
+        conn,
+        accession_number=accession,
+        document_kind="primary_doc",
+        payload=_SAMPLE_PRIMARY_DOC,
+        parser_version="primary-v1",
+        source_url=_PRIMARY_URL,
+    )
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT payload, byte_count, payload_sha256, payload_swept_at, source_url, parser_version "
+            "FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'primary_doc'",
+            (accession,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    payload, byte_count, sha, swept_at, source_url, parser_version = row
+    assert payload is None and byte_count is None
+    assert swept_at is not None
+    assert sha == hashlib.sha256(_SAMPLE_PRIMARY_DOC.encode("utf-8")).hexdigest()
+    assert source_url == _PRIMARY_URL
+    assert parser_version == "primary-v1"
+    # read_raw surfaces it as a swept row — require_payload fails loud.
+    doc = raw_filings.read_raw(conn, accession_number=accession, document_kind="primary_doc")
+    assert doc is not None and doc.payload is None and doc.byte_count is None
+    with pytest.raises(RuntimeError, match="swept"):
+        doc.require_payload()
+
+
+def test_store_primary_doc_requires_source_url(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A born-compacted row's only recovery path is source_url, so a
+    write-only kind stored without one is rejected at the helper —
+    never persist an unrecoverable payload-less row."""
+    conn = ebull_test_conn
+    with pytest.raises(ValueError, match="source_url is required"):
+        raw_filings.store_raw(
+            conn,
+            accession_number="0001767470-26-001616",
+            document_kind="primary_doc",
+            payload=_SAMPLE_PRIMARY_DOC,
+        )
+
+
+def test_store_primary_doc_idempotent_stays_compacted(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Re-storing an amended primary_doc keeps it born-compacted (the
+    bytes are never resurrected), one row, sha refreshed to the new body."""
+    conn = ebull_test_conn
+    accession = "0001767470-26-001617"
+    amended = "<v2>amended</v2>"
+    raw_filings.store_raw(
+        conn, accession_number=accession, document_kind="primary_doc", payload="<v1/>", source_url=_PRIMARY_URL
+    )
+    conn.commit()
+    raw_filings.store_raw(
+        conn, accession_number=accession, document_kind="primary_doc", payload=amended, source_url=_PRIMARY_URL
+    )
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*), bool_and(payload IS NULL), max(payload_sha256) "
+            "FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'primary_doc'",
+            (accession,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    n, all_null, sha = row
+    assert n == 1 and all_null is True
+    assert sha == hashlib.sha256(amended.encode("utf-8")).hexdigest()
 
 
 def test_iter_raw_filters_by_kind_and_parser_version(

--- a/tests/test_raw_payload_retention_db.py
+++ b/tests/test_raw_payload_retention_db.py
@@ -251,25 +251,30 @@ def test_rehydrate_and_store_raw_interleavings_over_a_swept_row(
     assert _manifest_raw_status(conn, accession="swp-r") == "stored"
 
     # Re-sweep the restored row, then store_raw over it (amended
-    # fetch): terminal state must be the live shape with BOTH sweep
-    # columns cleared — a stale hash must never linger against new
-    # bytes (prevention §ON CONFLICT covers all columns).
+    # fetch, e.g. a manifest rebuild). Since #1615 store_raw BORN-COMPACTS
+    # primary_doc (a write-only kind): the bytes are never resurrected —
+    # the new body is hashed server-side and the payload stays NULL.
+    # source_url is mandatory for the rehydratable row.
     summary = sweep_raw_payloads(database_url=test_database_url(), dry_run=False)
     assert summary.rows_swept == 1
     conn.commit()
+    amended = "<html>amended body</html>"
     store_raw(
         conn,
         accession_number="swp-r",
         document_kind="primary_doc",
-        payload="<html>amended body</html>",
+        payload=amended,
+        source_url="https://www.sec.gov/Archives/edgar/data/1/primary_doc.html",
     )
     conn.commit()
-    payload, sha, swept_at, _ = _raw_row(conn, accession="swp-r", kind="primary_doc")
-    assert payload == "<html>amended body</html>"
-    assert sha is None and swept_at is None
-    # Manifest stays 'compacted' until a parser outcome writes
-    # 'stored' — and the 'compacted'-eligible predicate means the row
-    # re-sweeps cleanly:
+    payload, sha, swept_at, byte_count = _raw_row(conn, accession="swp-r", kind="primary_doc")
+    # Born-compacted, NOT resurrected: payload stays NULL, sha = the new
+    # body's hash, swept_at set (chk_swept_rows_carry_hash holds).
+    assert payload is None and byte_count is None
+    assert sha == hashlib.sha256(amended.encode("utf-8")).hexdigest()
+    assert swept_at is not None
     assert _manifest_raw_status(conn, accession="swp-r") == "compacted"
+    # The row now has payload NULL, so the backstop sweep skips it
+    # (nothing left to reclaim).
     final = sweep_raw_payloads(database_url=test_database_url(), dry_run=False)
-    assert final.rows_swept == 1
+    assert final.rows_swept == 0


### PR DESCRIPTION
## Problem
`filing_raw_documents.primary_doc` payload is **write-only** — no rewash parser reads it (pinned by `tests/test_raw_payload_retention.py`), manifest rebuild re-fetches from EDGAR unconditionally (sql/190). ~22 GB / 52 % of dev DB. The #1014 `raw_payload_retention_sweep` nulls it retroactively but it **regrew 742 MB → 23 GB in 3 days** under steady-state ingest. A1 (this session) reclaimed it (44→21 GB); this fixes the source so it never regrows.

## Scope correction: 7 write sites, not 3
The original investigation found 3 (services). It missed the **4 manifest parsers** — `sec_10k.py` (×2), `sec_13f_hr.py`, `eight_k.py` — which are the **steady-state bulk-drain** writers (the actual regrowth engine).

## Fix — born-compaction centralized in `store_raw`
For `document_kind ∈ SWEPT_DOCUMENT_KINDS` (= {primary_doc}), `store_raw` writes the row **born-compacted**: `payload = NULL`, `payload_sha256` (server-side, byte-identical to the #1014 sweep + rehydrate verifier per sql/190), `payload_swept_at = NOW()`, `source_url`, `parser_version`. The bytes are sent only to be hashed, never stored. One chokepoint covers all 7 writers + any future one. Re-wash kinds (form4_xml/def14a_body/…/infotable_13f) keep storing payload, unchanged.

This is exactly the post-sweep state, so it satisfies `chk_swept_rows_carry_hash` (payload NULL ⇒ sha + swept_at), keeps the **#938 raw-before-parsed** invariant (the row exists), the audit sha, and rehydrate-from-EDGAR. The #1014 sweep becomes a no-op for primary_doc (defense-in-depth backstop, A3).

`SWEPT_DOCUMENT_KINDS` moved canonical to `raw_filings.py` (single source of truth — source-side born-compaction + retroactive sweep can never diverge); `raw_payload_retention` imports it.

## Security / invariant model
No auth surface; read-only outbound SEC GETs + a local INSERT. **source_url is mandatory** for swept kinds (the sole recovery path for a payload-less row) — `store_raw` raises if missing, so `ON CONFLICT` can never regress it to NULL (Codex ckpt-1 #1). **raw_status redefined** (Codex ckpt-1 #2): sql/195 `COMMENT ON COLUMN` — `'stored'` now means "a raw evidence ROW exists", NOT that bytes are present; the authoritative "bytes present" signal is `payload_swept_at IS NULL` / `byte_count`. The 7 callers keep `raw_status='stored'` (centralization); verified **nothing enforces `stored ⇒ payload present`** and no consumer gates correctness on it (rewash keys on document_kind + `require_payload()` which raises on NULL; rehydrate on `payload IS NULL`+sha; sweep on `payload IS NOT NULL`). sql/118 left unedited (the #1333 content-drift guard forbids editing applied migrations).

## Tests / verification (commit 77b3d0bb)
- New `store_raw` cases: born-compacted shape, source_url-required, idempotent-stays-compacted (recorded sha == `hashlib.sha256(payload)`).
- Updated 4 existing tests that asserted primary_doc body presence to the new contract: `test_manifest_parser_sec_10k`, `test_manifest_parser_eight_k`, `test_institutional_holdings_ingester` (13F), `test_raw_payload_retention_db` (rehydrate/store_raw interleave).
- Gates: ruff ✓, ruff format ✓, pyright 0 errors, fast tier `-m "not db"` **3941 passed**, affected db-tier **108 passed**.
- **Dev-verified (clauses 8-9):** a real **671 KB** EDGAR 10-K primary doc through `store_raw` on the dev schema (rolled back, 0 pollution) → `payload/byte_count NULL`, `swept_at` set, recorded **sha MATCHES the live EDGAR re-fetch**, source_url preserved.
- Pre-existing **#1562** (`test_def14a_latest_n_cap … PFG-OLD malformed accession`) fails identically on stashed clean main — **unrelated**, not a regression.
- Codex ckpt-1 (folded source_url guard + raw_status model + test fallout; rebutted the `-m db` marker finding — it's applied dynamically in `conftest.py:319`) + ckpt-2 (clean).

## Follow-up (A3, separate PR)
Schedule `raw_payload_retention_sweep` as a backstop; retention-classification CI test (every `document_kind` ∈ rewash-registry OR `SWEPT_DOCUMENT_KINDS`); per-table size alarm; docs/settled-decisions + data-engineer skill §13.D.

Closes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)