### PR TITLE
feat(#1617): durable raw-payload retention classification guard

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -1451,6 +1451,31 @@ Every metric is nullable + every breach flag is nullable; a failed probe (e.g. `
 
 When adding a new storage discipline rule (retention, sweep, partition retrofit), wire its operator-visible signal into this endpoint AND into `.githooks/pre-push` if it's a push-time concern. The two surfaces share a single threshold constant (`DB_SIZE_WARN_BYTES` is the working example) so an operator never sees one surface clean while the other is breached.
 
+### 13.F Raw-payload retention classification — every `DocumentKind` is bucketed (#1617)
+
+The operator rule: **a stored raw filing payload is kept only if it is re-read OR housekept-and-negligible.** Made concrete as a three-bucket partition over `raw_filings.DocumentKind`, with each member in exactly one bucket:
+
+| Bucket | Canonical home | Meaning | Payload on disk? |
+|---|---|---|---|
+| **REWASH** | `rewash_filings.registered_specs()` keys | a rewash parser reads the stored body | yes (full) |
+| **SWEPT** | `raw_filings.SWEPT_DOCUMENT_KINDS` | born-compacted at source (#1615) — payload NULL + `payload_sha256` + `payload_swept_at`, rehydratable from `source_url` | no (hash only) |
+| **KEPT_NEGLIGIBLE** | `raw_filings.KEPT_NEGLIGIBLE_DOCUMENT_KINDS` (kind → justification) | small, write-only, no payload reader; kept uncompacted with an explicit reason | yes (small) |
+
+The partition is CI-enforced by `tests/test_raw_payload_retention.py::test_every_document_kind_is_classified` + `::test_retention_buckets_are_pairwise_disjoint`. A new write-only kind fails CI until deliberately bucketed.
+
+**The careful part when bucketing a new kind — grep the payload readers FIRST.** "Re-read" means the *payload bytes* are read back, not the row. The existence-only `COUNT(DISTINCT accession_number)` diagnostics in `ownership_drillthrough.py` / `app/api/instruments.py` are satisfied by the row alone — they do NOT make a kind REWASH (a born-compacted or kept row still has the row). At #1617 this distinction is what kept `form5_xml` out of REWASH: it appears in `ownership_drillthrough.py:350` but only in a `COUNT(*)`. The grep:
+
+```bash
+# payload readers: read_raw / iter_raw call sites carrying the kind
+grep -rn "read_raw(\|iter_raw(" app/ --include="*.py"
+# every textual reference to the kind (writers + diagnostics + readers)
+grep -rn "\"<kind>\"\|'<kind>'" app/ --include="*.py"
+```
+
+Only the `read_raw` / `iter_raw` payload paths (driven by `registered_specs`) count as re-reads. If the only references are writers + `COUNT(*)` diagnostics, the kind is write-only → SWEPT (if large enough to bother compacting) or KEPT_NEGLIGIBLE (if small, with a justification).
+
+**Promotion rule:** registering a rewash parser for a kind currently in `KEPT_NEGLIGIBLE_DOCUMENT_KINDS` (e.g. the planned Form 5 parser hinted at `insider_345.py:563-565`) MUST remove it from that map in the same change — the pairwise-disjoint test fails if it lands in two buckets. Settled decision: `docs/settled-decisions.md` "Raw-payload retention (#1617)".
+
 ## 14. Postgres crash-recovery fsync tax — diagnosis runbook (#1444, 2026-06-02)
 
 **Symptom:** dev PG stuck in `the database system is in recovery mode` for tens of minutes to HOURS, rejecting every connection. Blocks bootstrap, live verification, DB-backed tests.

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -89,6 +89,39 @@ DocumentKind = Literal[
 SWEPT_DOCUMENT_KINDS: frozenset[DocumentKind] = frozenset({"primary_doc"})
 # Future PR adds a sibling ``cik_raw_documents`` table for those.
 
+# Write-only kinds we deliberately KEEP uncompacted because they are
+# small enough that born-compaction (#1615) would buy nothing, yet they
+# are NOT re-read by any rewash parser either. The operator retention
+# rule (#1617, settled-decisions "Raw-payload retention"): a raw-store
+# path is legitimate only if its payload is (a) re-read — REWASH, in
+# ``rewash_filings.registered_specs()`` — OR (b) housekept-and-negligible
+# — SWEPT, ``SWEPT_DOCUMENT_KINDS`` — OR (c) kept-and-negligible with an
+# explicit justification, this map. Every ``DocumentKind`` MUST land in
+# exactly one of those three buckets; a new unclassified kind fails the
+# partition test in ``tests/test_raw_payload_retention.py``. The
+# justification per kind was grep-verified at #1617: each was confirmed
+# to have NO payload reader (the existence-only ``COUNT(*)`` diagnostics
+# in ``ownership_drillthrough`` / ``instruments`` are satisfied by the
+# row, not the bytes).
+KEPT_NEGLIGIBLE_DOCUMENT_KINDS: dict[DocumentKind, str] = {
+    # Parsed in-memory at ingest; ownership_drillthrough COUNT(*)s the row
+    # but never reads the body. ~11 MB (dev). Retained for a planned Form 5
+    # rewash parser (insider_345.py:563-565) — promote to REWASH when that
+    # spec is registered; the partition test forces the move (it would
+    # otherwise be in two buckets).
+    "form5_xml": "write-only ~11MB; held for a future Form 5 rewash parser",
+    # Parsed in-memory at ingest; rewash re-fetches from EDGAR rather than
+    # re-reading the stored body (n_port_ingest.py:82). ~6 MB (dev).
+    "nport_xml": "write-only ~6MB; rewash re-fetches from EDGAR, no payload reader",
+    # Parsed in-memory at ingest; the bimonthly job re-fetches fresh from
+    # FINRA each cadence (finra_short_interest_refresh.py), never from the
+    # store. Part of ~92 MB FINRA raw (dev).
+    "finra_short_interest_csv": "write-only; steady-state re-fetches from FINRA, no payload reader",
+    # Parsed in-memory at ingest; the daily job re-fetches fresh from FINRA
+    # (finra_regsho_daily_refresh.py), never from the store.
+    "finra_regsho_daily_txt": "write-only; steady-state re-fetches from FINRA, no payload reader",
+}
+
 
 @dataclass(frozen=True)
 class RawFilingDocument:

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -105,6 +105,14 @@ Before designing or coding for an issue:
 - it does not mean fetch time
 - when combining TTM + balance-sheet values, use the balance-sheet period end as the canonical snapshot date in v1
 
+### Raw-payload retention (#1617, settled 2026-06-13)
+- A stored raw filing payload (`filing_raw_documents.payload`) is legitimate only if its retention is justified by exactly one of three classes:
+  - **re-read** — a rewash parser reads the stored body. Registered in `rewash_filings.registered_specs()`.
+  - **housekept-and-negligible** — born-compacted at source (payload NULL + `payload_sha256` + `payload_swept_at`, rehydratable from `source_url`). Listed in `raw_filings.SWEPT_DOCUMENT_KINDS` (#1615).
+  - **kept-and-negligible** — small, write-only, no payload reader; kept uncompacted with an explicit justification. Listed in `raw_filings.KEPT_NEGLIGIBLE_DOCUMENT_KINDS` (kind → reason).
+- Every `raw_filings.DocumentKind` member MUST fall into exactly one class. The partition is CI-enforced by `tests/test_raw_payload_retention.py::test_every_document_kind_is_classified` — a new write-only kind fails CI until an operator deliberately buckets it (grep its payload readers first; existence-only `COUNT(*)` diagnostics do not count as a re-read).
+- Adding a rewash parser for a kind currently in `KEPT_NEGLIGIBLE_DOCUMENT_KINDS` (e.g. a future Form 5 parser) MUST remove it from that map in the same change — the pairwise-disjoint test fails if it lands in two classes.
+
 ---
 
 ## News and sentiment

--- a/tests/test_raw_payload_retention.py
+++ b/tests/test_raw_payload_retention.py
@@ -19,7 +19,11 @@ from typing import Any, get_args
 import pytest
 
 from app.services import rewash_filings
-from app.services.raw_filings import DocumentKind, _row_to_document
+from app.services.raw_filings import (
+    KEPT_NEGLIGIBLE_DOCUMENT_KINDS,
+    DocumentKind,
+    _row_to_document,
+)
 from app.services.raw_payload_retention import (
     SWEPT_DOCUMENT_KINDS,
     SWEPT_MANIFEST_SOURCES,
@@ -57,6 +61,48 @@ def test_swept_sources_are_the_approved_drop_list() -> None:
     the new source's payload consumers must be audited first (see the
     def14a_body exclusion rationale in the spec)."""
     assert SWEPT_MANIFEST_SOURCES == frozenset({"sec_10k", "sec_8k"})
+
+
+def test_kept_negligible_kinds_are_valid_document_kinds() -> None:
+    assert set(KEPT_NEGLIGIBLE_DOCUMENT_KINDS) <= set(get_args(DocumentKind))
+
+
+def test_kept_negligible_entries_carry_a_justification() -> None:
+    """The bucket is an explicit allow-list, not a dumping ground —
+    each kept-but-not-swept-not-rewashed kind records WHY it is kept
+    (the operator rule's 'negligible-kept justification')."""
+    for kind, reason in KEPT_NEGLIGIBLE_DOCUMENT_KINDS.items():
+        assert reason.strip(), f"{kind} has no retention justification"
+
+
+def test_retention_buckets_are_pairwise_disjoint() -> None:
+    """A kind in two buckets is a contradiction: e.g. a kind both
+    re-read (REWASH) and born-compacted (SWEPT) would lose the bytes a
+    parser needs. Registering a ``form5_xml`` rewash parser, say, must
+    REMOVE it from KEPT_NEGLIGIBLE in the same change — this test fails
+    loud if it lands in both."""
+    rewash = set(rewash_filings.registered_specs())
+    swept = set(SWEPT_DOCUMENT_KINDS)
+    kept = set(KEPT_NEGLIGIBLE_DOCUMENT_KINDS)
+    assert rewash.isdisjoint(swept), rewash & swept
+    assert rewash.isdisjoint(kept), rewash & kept
+    assert swept.isdisjoint(kept), swept & kept
+
+
+def test_every_document_kind_is_classified() -> None:
+    """The durable #1617 guard: every ``raw_filings.DocumentKind`` MUST
+    be classified into exactly one retention bucket — re-read (REWASH,
+    ``registered_specs``), housekept (SWEPT, ``SWEPT_DOCUMENT_KINDS``),
+    or kept-and-negligible (``KEPT_NEGLIGIBLE_DOCUMENT_KINDS``). A new
+    write-only kind that silently bloats the table fails CI here until an
+    operator deliberately buckets it — grep its payload readers first."""
+    all_kinds = set(get_args(DocumentKind))
+    classified = (
+        set(rewash_filings.registered_specs()) | set(SWEPT_DOCUMENT_KINDS) | set(KEPT_NEGLIGIBLE_DOCUMENT_KINDS)
+    )
+    assert classified == all_kinds, (
+        f"unclassified DocumentKind(s): {all_kinds - classified}; unknown classified kind(s): {classified - all_kinds}"
+    )
 
 
 def test_batch_size_must_be_positive() -> None:


### PR DESCRIPTION
Closes #1617. Follow-up to #1615 (A2 born-compaction, b0658970) / #1014 (A1 sweep).

## What
A durable lifecycle guard so a **future** write-only `DocumentKind` can't silently bloat `filing_raw_documents` the way `primary_doc` did (742MB→23GB in 3 days pre-#1615).

### (a) Classification CI test
`tests/test_raw_payload_retention.py` — every `raw_filings.DocumentKind` member MUST partition into exactly one retention bucket:

| Bucket | Canonical home | Meaning |
|---|---|---|
| REWASH | `rewash_filings.registered_specs()` keys | payload re-read by a rewash parser |
| SWEPT | `raw_filings.SWEPT_DOCUMENT_KINDS` | born-compacted at source (#1615) |
| KEPT_NEGLIGIBLE | `raw_filings.KEPT_NEGLIGIBLE_DOCUMENT_KINDS` (new; kind→justification) | small, write-only, no payload reader |

- `test_every_document_kind_is_classified` — fails CI on a new unbucketed kind (proven to bite).
- `test_retention_buckets_are_pairwise_disjoint` — fails if a kind is in two buckets, forcing cleanup when a rewash parser is later registered for a currently-kept kind.
- `test_kept_negligible_entries_carry_a_justification` — the allow-list is justified, not a dumping ground.

### Bucketing the 4 previously-unclassified kinds
Each **grep-verified to have NO stored-payload reader** before bucketing. The careful distinction: existence-only `COUNT(DISTINCT accession_number)` diagnostics (`ownership_drillthrough.py:350`, `app/api/instruments.py`) are satisfied by the *row*, not the *bytes* — they are **not** a re-read. Only `read_raw`/`iter_raw` payload paths (driven by `registered_specs`) count.

| Kind | Reader check | Verdict |
|---|---|---|
| `form5_xml` | writer + `COUNT(*)` diagnostic only; held for a planned Form 5 rewash parser (insider_345.py:563-565) | KEPT_NEGLIGIBLE (~11MB) |
| `nport_xml` | writer only; rewash re-fetches from EDGAR | KEPT_NEGLIGIBLE (~6MB) |
| `finra_short_interest_csv` | writer only; steady-state re-fetches fresh from FINRA | KEPT_NEGLIGIBLE |
| `finra_regsho_daily_txt` | writer only; steady-state re-fetches fresh from FINRA | KEPT_NEGLIGIBLE |

### (b) Sweep backstop — DEFERRED
No-op post-#1615 (`primary_doc` born-compacted at source; zero live rows accumulate). Part (a) guards the same risk at CI time. Per issue: "skip/defer the sweep backstop — it's a no-op post-#1615."

### (c) Docs
- `docs/settled-decisions.md` → new "Raw-payload retention (#1617)" decision under Filing storage.
- `.claude/skills/data-engineer/SKILL.md` §13.F → the three-bucket rule + grep-the-payload-readers-first discipline + the promotion rule.

### (d) Per-table alarm — SKIPPED
Gold-plating per the issue; DB-size alarm already exists (`/system/postgres-health` + pre-push).

## Security model
No new code path, no SQL, no input handling. Pure module constant + pure-logic test + docs. No authn/authz surface touched.

## DoD ETL clauses 8-12 — N/A
No schema migration, no parser change, no ingest/data-path change. No operator-visible figure changes. The guard is CI + constant + docs only, so panel smoke / cross-source / backfill / rollup-endpoint verification do not apply.

## Verification
- `uv run pytest tests/test_raw_payload_retention.py` → 18 passed (14 prior + 4 new).
- Negative case proven: injecting a fake unbucketed kind trips `test_every_document_kind_is_classified`.
- Fast tier `pytest -m "not db"` → 3945 passed; smoke → 129 passed; ruff check/format clean; pyright clean on changed files.
- Codex ckpt-2: findings none — independently confirmed all 4 kinds are write-only and the partition invariant is correctly enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)