### PR TITLE
fix(#1614): retire drained tombstone backfill to manual-only

### DIFF
--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -366,6 +366,20 @@ MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
     # unbound, zero job_runs ever). Companion params in
     # MANUAL_TRIGGER_JOB_METADATA (empty).
     "populate_canonical_redirects": "db",
+    # sec_manifest_tombstone_stale — #1614. The #1131 stale-failed-upsert
+    # backfill, retired from SCHEDULED_JOBS (was daily 05:30) to
+    # manual-only: it is drained (zero candidates; rows_tombstoned=0 on
+    # every run; the #1131 source fix means the candidate shape cannot
+    # recur), and each zero-candidate no-op lost the db-lane tick-race
+    # vs its siblings (#1526/#1527/#1534 class), surfacing a false-red
+    # "schedule missed" verdict on the admin Processes page. Kept in
+    # _INVOKERS so an operator can still drain a resurfaced pre-#1131 row
+    # via POST /jobs/sec_manifest_tombstone_stale/run. Pure DB scan +
+    # UPDATE, short-running → catch-all ``db`` lane (its prior
+    # ScheduledJob.source). Without this entry ``source_for()`` KeyErrors
+    # and every manual trigger is rejected at JobLock acquisition (the
+    # #1413 / populate_canonical_redirects trap).
+    "sec_manifest_tombstone_stale": "db",
     # raw_payload_retention_sweep — #1014 payload-null sweep. Pure DB
     # operation but LONG-running (minutes over ~12k rows) → own lane,
     # NOT the catch-all ``db`` (would starve the every-5-min

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -238,6 +238,13 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
     # invoker) — the missing sources.py half made the job
     # untriggerable from #819's merge until 2026-06-11.
     "populate_canonical_redirects": (),
+    # sec_manifest_tombstone_stale — #1614. The drained #1131
+    # stale-failed-upsert backfill, retired from SCHEDULED_JOBS to
+    # manual-only. No operator-tunable params (it scans + promotes
+    # pre-#1131 rows by a fixed rule). The explicit empty tuple completes
+    # the manual-only triangle (source + metadata + invoker) and documents
+    # zero-param-by-design (vs the bootstrap-only fallback, also empty).
+    "sec_manifest_tombstone_stale": (),
     # raw_payload_retention_sweep — #1014 payload-null sweep.
     # ``batch_size`` stays internal (implementation knob, same call as
     # #1013); ``dry_run`` is operator-facing and DEFAULTS TRUE so a

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -1558,30 +1558,25 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
     ),
-    ScheduledJob(
-        name=JOB_SEC_MANIFEST_TOMBSTONE_STALE,
-        display_name="Manifest stale-failed sweep",
-        source="db",
-        description=(
-            "#1131 backfill: scan sec_filing_manifest for rows stuck in "
-            "ingest_status='failed' with a pre-#1131-shape "
-            "'upsert error:...' message older than 24h, promote them to "
-            "'tombstoned'. Skips post-#1131 transient-shape rows "
-            "(OperationalError / SerializationFailure / DeadlockDetected) "
-            "so genuine retries are not masked. Stops the legacy retry "
-            "loop where deterministic constraint violations refetched the "
-            "same dead XML from SEC every hour. Cadence: daily 05:30 UTC; "
-            "self-deactivates once the backlog drains (zero candidates = "
-            "no-op). Operator can also trigger via "
-            "POST /jobs/sec_manifest_tombstone_stale/run."
-        ),
-        cadence=Cadence.daily(hour=5, minute=30),
-        catch_up_on_boot=False,
-    ),
     # -- On-demand jobs are NOT listed here.  They stay in _INVOKERS
     # (runtime.py) so "Run now" in the Admin UI works, but they are
     # not registered with APScheduler and do not participate in
-    # catch-up.  Currently on-demand: daily_tax_reconciliation.
+    # catch-up.  Currently on-demand:
+    #   * daily_tax_reconciliation
+    #   * sec_manifest_tombstone_stale (#1614) — the #1131 stale-failed-
+    #     upsert backfill.  Drained: zero candidates, rows_tombstoned=0 on
+    #     every run, and the source bug (#1131 split transient vs
+    #     deterministic) means the candidate shape cannot recur, so the
+    #     job self-deactivates by design.  Retired from the daily 05:30
+    #     cadence because each zero-candidate no-op lost the db-lane
+    #     tick-race against its siblings (#1526/#1527/#1534 class) and
+    #     surfaced a false-red "schedule missed" verdict on the admin
+    #     Processes page.  Kept manual-trigger-only via
+    #     POST /jobs/sec_manifest_tombstone_stale/run for the (unlikely)
+    #     resurfacing of a pre-#1131 row; source-lock ("db") in
+    #     app/jobs/sources.py::MANUAL_TRIGGER_JOB_SOURCES + zero-param
+    #     metadata in param_metadata.py::MANUAL_TRIGGER_JOB_METADATA
+    #     complete the manual-only triangle.
 ]
 
 

--- a/tests/test_bootstrap_state_prerequisite.py
+++ b/tests/test_bootstrap_state_prerequisite.py
@@ -39,7 +39,6 @@ from app.workers.scheduler import (
     JOB_RETRY_SWEEPER,
     JOB_SEC_13F_FILER_DIRECTORY_SYNC,
     JOB_SEC_DAILY_INDEX_RECONCILE,
-    JOB_SEC_MANIFEST_TOMBSTONE_STALE,
     JOB_SEC_MANIFEST_WORKER,
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
     JOB_SEED_COST_MODELS,
@@ -127,12 +126,14 @@ NON_GATED_SCHEDULED: frozenset[str] = frozenset(
         #     would re-enable the crash-loop it exists to prevent.
         #   * sec_manifest_worker — self-gates internally; safe to run during
         #     bootstrap (it drains the manifest the bootstrap seeds).
-        #   * sec_daily_index_reconcile / sec_manifest_tombstone_stale —
-        #     idempotent maintenance, no-op on an empty DB (#1155).
+        #   * sec_daily_index_reconcile — idempotent maintenance, no-op on
+        #     an empty DB (#1155).
+        #   (sec_manifest_tombstone_stale lived here until #1614 retired it
+        #   from SCHEDULED_JOBS to manual-trigger-only — no longer a
+        #   scheduled job, so it cannot appear in this scheduled-job set.)
         JOB_ORPHAN_TEST_DB_REAP,
         JOB_SEC_MANIFEST_WORKER,
         JOB_SEC_DAILY_INDEX_RECONCILE,
-        JOB_SEC_MANIFEST_TOMBSTONE_STALE,
         # #1504 — ncen_classifier_yearly carries NO per-job
         # _bootstrap_complete prereq by design: it is gated by the
         # UNIVERSAL bootstrap gate (#1181), which runs check_bootstrap_state_gate

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -513,6 +513,15 @@ class TestProductionInvokerRegistry:
             # filing-metadata-scoped bootstrap dispatch and the unscoped
             # weekly cron coexist. No cadence → on-demand/bootstrap-only.
             "sec_master_idx_gap_close",
+            # #1614 — sec_manifest_tombstone_stale retired from
+            # SCHEDULED_JOBS to manual-only. The drained #1131 backfill
+            # (zero candidates; rows_tombstoned=0 every run; #1131 source
+            # fix means the shape cannot recur) lost the db-lane tick-race
+            # as a scheduled no-op and read false-red "schedule missed".
+            # Stays in _INVOKERS for operator drain of a resurfaced
+            # pre-#1131 row; source-lock "db" + empty param metadata
+            # complete the manual-only triangle.
+            "sec_manifest_tombstone_stale",
         }
         assert on_demand == expected_on_demand, (
             f"Unexpected on-demand invokers (update this test if intentional): "

--- a/tests/test_layer_123_wiring.py
+++ b/tests/test_layer_123_wiring.py
@@ -38,6 +38,7 @@ from app.workers.scheduler import (
     JOB_FINRA_SHORT_INTEREST_REFRESH,
     JOB_SEC_ATOM_FAST_LANE,
     JOB_SEC_DAILY_INDEX_RECONCILE,
+    JOB_SEC_MANIFEST_TOMBSTONE_STALE,
     JOB_SEC_MASTER_IDX_QUARTERLY_SWEEP,
     JOB_SEC_PER_CIK_POLL,
     JOB_SEC_REBUILD,
@@ -240,6 +241,49 @@ class TestPopulateCanonicalRedirectsRegistry:
             validate_job_params(
                 JOB_POPULATE_CANONICAL_REDIRECTS,
                 {"suffix": ".W"},
+                allow_internal_keys=False,
+            )
+
+
+class TestSecManifestTombstoneStaleRegistry:
+    """#1614 — the #1131 stale-failed-upsert backfill is drained (zero
+    candidates; rows_tombstoned=0 every run; the #1131 source fix means the
+    candidate shape cannot recur) and self-deactivates by design. Retired
+    from SCHEDULED_JOBS to manual-trigger-only because each zero-candidate
+    no-op lost the db-lane tick-race and surfaced a false-red "schedule
+    missed" verdict on the admin Processes page. Kept in _INVOKERS so an
+    operator can still drain a resurfaced pre-#1131 row. Pins the full
+    triangle (invoker + metadata + source) so the manual path resolves
+    JobLock — the #1413 / populate_canonical_redirects trap. (NOT modelled
+    on daily_tax_reconciliation, which is missing its MANUAL_TRIGGER source
+    entry and is itself a latent KeyError-on-trigger bug.)"""
+
+    def test_in_valid_job_names(self) -> None:
+        assert JOB_SEC_MANIFEST_TOMBSTONE_STALE in VALID_JOB_NAMES
+
+    def test_not_in_scheduled_jobs(self) -> None:
+        assert _job_by_name(JOB_SEC_MANIFEST_TOMBSTONE_STALE) is None
+
+    def test_in_manual_trigger_metadata_with_no_params(self) -> None:
+        assert JOB_SEC_MANIFEST_TOMBSTONE_STALE in MANUAL_TRIGGER_JOB_METADATA
+        assert MANUAL_TRIGGER_JOB_METADATA[JOB_SEC_MANIFEST_TOMBSTONE_STALE] == ()
+
+    def test_in_manual_trigger_sources(self) -> None:
+        assert MANUAL_TRIGGER_JOB_SOURCES[JOB_SEC_MANIFEST_TOMBSTONE_STALE] == "db"
+
+    def test_source_for_resolves(self) -> None:
+        assert source_for(JOB_SEC_MANIFEST_TOMBSTONE_STALE) == "db"
+
+    def test_zero_param_validation_contract(self) -> None:
+        """POST /jobs/sec_manifest_tombstone_stale/run takes no params:
+        an empty body validates; any supplied key is rejected."""
+        metadata = _lookup_metadata(JOB_SEC_MANIFEST_TOMBSTONE_STALE)
+        assert metadata == ()
+        validate_job_params(JOB_SEC_MANIFEST_TOMBSTONE_STALE, {}, allow_internal_keys=False)
+        with pytest.raises(ParamValidationError):
+            validate_job_params(
+                JOB_SEC_MANIFEST_TOMBSTONE_STALE,
+                {"max_age_hours": 24},
                 allow_internal_keys=False,
             )
 


### PR DESCRIPTION
## What

Retire `sec_manifest_tombstone_stale` from `SCHEDULED_JOBS` (was daily 05:30 UTC, `source="db"`) to **manual-trigger-only**. Stays in `_INVOKERS` so `POST /jobs/sec_manifest_tombstone_stale/run` still works.

Closes #1614.

## Why

The job is the one-shot #1131 backfill (promote pre-#1131-shape `upsert error:…` failed manifest rows → `tombstoned`). It is **drained**: zero candidates, `rows_tombstoned=0` on every recent run, and the #1131 source fix (split transient vs deterministic upsert errors) means the candidate shape **cannot recur**. It self-deactivates by design — every fire is a no-op.

As a scheduled job its zero-candidate no-op lost the `db`-lane non-blocking `pg_try_advisory_lock` tick-race against its lane-siblings at `:30` (same class as #1526/#1527/#1534), so it missed fires intermittently and surfaced a **false-red `attention` / "schedule missed"** verdict on the admin Processes page. The #1510 watchdog kick hit the same lane contention and could not heal it.

Retiring (vs extracting a dedicated lane per #1527/#1534) is the right call for a dead job: it removes the false-red **and** the db-lane contention with zero behavioural loss, instead of keeping a daily no-op running forever on its own lane.

## The fix — complete the manual-only triangle

Removing a `SCHEDULED_JOBS` entry while keeping the invoker orphans the source-registry path (`_build_job_name_to_source` = `SCHEDULED_JOBS ∪ _BOOTSTRAP_STAGE_SPECS ∪ MANUAL_TRIGGER_JOB_SOURCES`). The manual-trigger path constructs `JobLock` → `source_for()`, which **KeyErrors with no fallback** — every manual trigger would be rejected at the queue (the #1413 / `populate_canonical_redirects` trap, where a missed `sources.py` half left a job silently untriggerable for a month).

So the retire wires the full triangle the 4 working manual-only jobs use (`sec_rebuild`, `filing_events_skip_tier_cleanup`, `populate_canonical_redirects`, `raw_payload_retention_sweep`):

| Layer | Change |
|---|---|
| `app/jobs/sources.py` | `MANUAL_TRIGGER_JOB_SOURCES["sec_manifest_tombstone_stale"] = "db"` (its prior `ScheduledJob.source`) |
| `app/services/processes/param_metadata.py` | `MANUAL_TRIGGER_JOB_METADATA[...] = ()` (zero operator params) |
| `app/workers/scheduler.py` | remove the `ScheduledJob`; document the retire in the on-demand note. Constant + function + `_tracked_job` usage retained (still in `_INVOKERS`) |

### Did NOT mirror `daily_tax_reconciliation`
The issue named `daily_tax_reconciliation` as the on-demand precedent — but it is **itself a latent bug**: triggerable (in `VALID_JOB_NAMES` via `_INVOKERS`) yet `source_for()` KeyErrors because it was never added to `MANUAL_TRIGGER_JOB_SOURCES`. Empirically confirmed, and already tracked: it sits in `_KNOWN_UNRESOLVABLE` (`tests/test_layer_123_wiring.py`), the #1571 triage set. Copying it would have propagated the bug — so tombstone is wired correctly instead. No new issue filed (already #1571).

## Security model
No security surface. Registry-only change in three trusted internal maps. The job is gated by the universal bootstrap gate on the manual-queue dispatch path like any other job; retiring it from `SCHEDULED_JOBS` only removes its cron participation, not any authorization. No SQL, no schema, no user-facing input. Manual trigger remains operator-only behind the existing `/jobs/{name}/run` auth.

## Tests
- `tests/test_jobs_runtime.py` — add `sec_manifest_tombstone_stale` to `expected_on_demand` (`test_every_invoker_is_scheduled_or_on_demand`).
- `tests/test_bootstrap_state_prerequisite.py` — drop it from `NON_GATED_SCHEDULED` (set invariant: "every entry must be in `SCHEDULED_JOBS`") + remove the now-orphaned import.
- `tests/test_layer_123_wiring.py` — new `TestSecManifestTombstoneStaleRegistry` (6 cases) pins the full triangle. The pre-existing `test_all_valid_job_names_resolve` already **fails CI** on a source-less retire — this change keeps it green precisely because the source entry is present.

## Verification (commit 2f3b557b)
- `ruff check .` → All checks passed
- `ruff format --check .` → 861 files already formatted
- `pyright` → 0 errors, 0 warnings
- `pytest -m "not db"` (fast tier) → green (exit 0)
- `pytest tests/smoke` → green (exit 0)
- targeted: `test_layer_123_wiring` + `test_job_registry` + the two invariant tests → green; new class collects 6 tests
- **Codex checkpoint-2** (`codex exec review --base main`) → no blocking regression: "retires … while preserving manual trigger wiring through the source and metadata registries."

## Operator follow-up (post-merge)
Not an ETL / parser / schema-migration change → DoD clauses 8-12 N/A. Operator-visible confirmation needs the **API/jobs process restarted onto this commit**, then `GET /system/processes` should show `sec_manifest_tombstone_stale` as a manual-only row (no "schedule missed" verdict). The current dev API runs pre-branch code, so the false-red persists until restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)