### PR TITLE
feat(#735): project DEI EntityPublicFloat into financial_periods.public_float_usd

### DIFF
--- a/app/services/fundamentals/__init__.py
+++ b/app/services/fundamentals/__init__.py
@@ -774,6 +774,11 @@ for _col_name, _tags in TRACKED_CONCEPTS.items():
     for _idx, _tag in enumerate(_tags):
         _TAG_TO_COLUMN[_tag] = (_col_name, _idx)
 
+# DEI cover-page public-float concept (#735). Deliberately NOT in
+# _TAG_TO_COLUMN — it is projected by an FY-only overlay so its
+# cover-page period_end (issuer Q2-end) never lifts the FY anchor (#558).
+_DEI_PUBLIC_FLOAT_CONCEPT = "EntityPublicFloat"
+
 # Financial columns that are flow items (income/CF -- get summed in TTM).
 # Balance sheet items are point-in-time (latest value used in TTM).
 _FLOW_COLUMNS: frozenset[str] = frozenset(
@@ -908,6 +913,11 @@ class PeriodRow:
     shares_authorized: Decimal | None = None
     shares_issued: Decimal | None = None
     retained_earnings: Decimal | None = None
+
+    # DEI cover-page public float (#735). Annual-only — projected by an
+    # FY-only overlay in _derive_periods_from_facts, NEVER via _TAG_TO_COLUMN
+    # (its period_end is the issuer Q2-end, not the FY anchor — see #558).
+    public_float_usd: Decimal | None = None
 
     # Tier 1 + Tier 2 allowlist expansion (#732). Working-capital,
     # liquidity, comprehensive income, intangible amortisation,
@@ -1069,6 +1079,29 @@ def _derive_periods_from_facts(
             setattr(row, col_name, fact.val)
             col_priority[col_name] = priority
 
+        # #735 — DEI public-float overlay (FY only). EntityPublicFloat is a
+        # 10-K cover-page fact stamped (fiscal_year, 'FY') but with
+        # period_end = issuer Q2-end, so it is NOT in ``mapped_facts``
+        # (kept out of _TAG_TO_COLUMN to avoid lifting the FY anchor, #558)
+        # and would be dropped by the ``canonical_facts`` period_end filter.
+        # Pull it from the full ``period_facts`` set instead: current float =
+        # max(period_end) then latest filed_date (guards comparative
+        # re-stamps, #682). Value-only overlay — provenance columns
+        # (source_ref / filed_date / form_type) intentionally stay tied to
+        # the canonical fiscal-period facts; the float fact's accession is
+        # NOT appended to source_ref (that is the raw-upsert key). USD-only
+        # guard so a malformed/future non-USD float never lands in a USD
+        # column.
+        if period_type == "FY":
+            float_facts = [
+                f
+                for f in period_facts
+                if f.concept == _DEI_PUBLIC_FLOAT_CONCEPT and f.unit == "USD" and f.val is not None
+            ]
+            if float_facts:
+                chosen = max(float_facts, key=lambda f: (f.period_end, f.filed_date, f.accession_number))
+                row.public_float_usd = chosen.val
+
         periods.append(row)
 
     # Q4 derivation: if FY exists but Q4 does not, derive Q4 = FY - Q1 - Q2 - Q3
@@ -1167,6 +1200,7 @@ def _upsert_period_raw(
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
             treasury_shares, shares_authorized, shares_issued, retained_earnings,
+            public_float_usd,
             assets_current, liabilities_current, cash_restricted,
             comprehensive_income, intangible_amortization,
             deferred_income_tax, other_nonoperating_income,
@@ -1188,6 +1222,7 @@ def _upsert_period_raw(
             %(operating_cf)s, %(investing_cf)s, %(financing_cf)s, %(capex)s,
             %(dividends_paid)s, %(dps_declared)s, %(buyback_spend)s,
             %(treasury_shares)s, %(shares_authorized)s, %(shares_issued)s, %(retained_earnings)s,
+            %(public_float_usd)s,
             %(assets_current)s, %(liabilities_current)s, %(cash_restricted)s,
             %(comprehensive_income)s, %(intangible_amortization)s,
             %(deferred_income_tax)s, %(other_nonoperating_income)s,
@@ -1237,6 +1272,7 @@ def _upsert_period_raw(
             shares_authorized = EXCLUDED.shares_authorized,
             shares_issued = EXCLUDED.shares_issued,
             retained_earnings = EXCLUDED.retained_earnings,
+            public_float_usd = EXCLUDED.public_float_usd,
             assets_current = EXCLUDED.assets_current,
             liabilities_current = EXCLUDED.liabilities_current,
             cash_restricted = EXCLUDED.cash_restricted,
@@ -1300,6 +1336,7 @@ def _upsert_period_raw(
             "shares_authorized": period.shares_authorized,
             "shares_issued": period.shares_issued,
             "retained_earnings": period.retained_earnings,
+            "public_float_usd": period.public_float_usd,
             "assets_current": period.assets_current,
             "liabilities_current": period.liabilities_current,
             "cash_restricted": period.cash_restricted,
@@ -1466,6 +1503,7 @@ def _canonical_merge_instrument(
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
             treasury_shares, shares_authorized, shares_issued, retained_earnings,
+            public_float_usd,
             assets_current, liabilities_current, cash_restricted,
             comprehensive_income, intangible_amortization,
             deferred_income_tax, other_nonoperating_income,
@@ -1488,6 +1526,7 @@ def _canonical_merge_instrument(
             operating_cf, investing_cf, financing_cf, capex,
             dividends_paid, dps_declared, buyback_spend,
             treasury_shares, shares_authorized, shares_issued, retained_earnings,
+            public_float_usd,
             assets_current, liabilities_current, cash_restricted,
             comprehensive_income, intangible_amortization,
             deferred_income_tax, other_nonoperating_income,
@@ -1542,6 +1581,7 @@ def _canonical_merge_instrument(
             shares_authorized = EXCLUDED.shares_authorized,
             shares_issued = EXCLUDED.shares_issued,
             retained_earnings = EXCLUDED.retained_earnings,
+            public_float_usd = EXCLUDED.public_float_usd,
             assets_current = EXCLUDED.assets_current,
             liabilities_current = EXCLUDED.liabilities_current,
             cash_restricted = EXCLUDED.cash_restricted,

--- a/docs/specs/etl/2026-06-14-735-dei-public-float-projection.md
+++ b/docs/specs/etl/2026-06-14-735-dei-public-float-projection.md
@@ -1,0 +1,74 @@
+# #735 — project EntityPublicFloat (DEI cover-page) into financial_periods
+
+Closes #735. Split out from #731; `sql/088` line 14 reserved `public_float_usd` for this ticket.
+
+## Problem
+
+`EntityPublicFloat` (DEI cover-page fact, 10-K only) is already ingested into
+`financial_facts_raw` (43,117 rows / 4,096 instruments on dev; AAPL FY2025 =
+$3,253,431,000,000) but never reaches `financial_periods` because:
+
+- It is a **DEI** fact, deliberately **not** in `_TAG_TO_COLUMN`, so it is
+  excluded from `mapped_facts` (correct — including it would lift the FY anchor
+  to the cover-page date, #558).
+- Its `period_end` is the issuer's **most-recent-Q2-end** (SEC-prescribed
+  public-float "as of"), NOT fiscal-year-end. AAPL FY2025: float period_end
+  2025-03-28 vs FY anchor 2025-09-27. The `canonical_facts` filter
+  (`f.period_end == period_end`, line 1017) drops any fact whose period_end ≠
+  the FY anchor.
+
+Empirically confirmed: EntityPublicFloat is stamped `(fiscal_year=Y,
+fiscal_period='FY')` per its 10-K context, so it lands in the `(Y, 'FY')` group
+in `period_facts` — available to an overlay even though excluded from
+`mapped_facts`/`canonical_facts`. DEI facts are already loaded into the derive
+input (the #558 comment relies on it).
+
+## Fix — option 1 (issue default: separate DEI overlay, no new table)
+
+### Schema — `sql/197_public_float_usd.sql`
+`ADD COLUMN IF NOT EXISTS public_float_usd NUMERIC(24,2)` to **both**
+`financial_periods_raw` and `financial_periods` (mirrors `sql/088`
+treasury_shares, idempotent). USD dollars; AAPL ~3.25e12 → 13 digits, fits.
+
+### `app/services/fundamentals/__init__.py`
+- `PeriodRow`: add `public_float_usd: Decimal | None = None`.
+- `_derive_periods_from_facts`: after the `canonical_facts` value-application
+  loop, for **FY rows only** (`period_type == "FY"`), overlay:
+  - `pf = [f for f in period_facts if f.concept == "EntityPublicFloat"]`
+  - pick the current float: `max(period_end)` then latest `filed_date` (guards
+    against any comparative re-stamp under the same fy).
+  - `row.public_float_usd = pf_pick.val`.
+  - NOT added to `_TAG_TO_COLUMN`, `_BALANCE_SHEET_COLUMNS`, `_FLOW_COLUMNS`, or
+    the Q4-derivation copy loops — annual-only, never carried to a quarter and
+    never anchor-bearing. The Q4 row therefore has `public_float_usd = NULL`
+    (correct — public float is a 10-K annual disclosure).
+- `_upsert_period_raw`: add `public_float_usd` to the INSERT column list, the
+  `%(public_float_usd)s` VALUES, the `DO UPDATE SET`, and the params dict.
+- Projection merge into `financial_periods` (the `best_source` SELECT): add
+  `public_float_usd` to the INSERT columns, the SELECT projection, and the
+  `DO UPDATE SET`.
+
+Concept name `"EntityPublicFloat"` referenced via a module constant
+`_DEI_PUBLIC_FLOAT_CONCEPT` (no magic string; mirrors `DEI_TRACKED_CONCEPTS`).
+
+## Out of scope
+Surfacing on the ownership card / rollup API (renderer changes land in the #729
+follow-up per #755). This PR only populates the column.
+
+## Tests
+- Pure (`tests/test_fundamentals_*` or new): `_derive_periods_from_facts` with a
+  fixture of FY us-gaap facts (anchor = FY-end) + an EntityPublicFloat fact
+  (period_end = Q2-end, fiscal_period='FY') → FY row gets `public_float_usd`,
+  the FY anchor/period_end is unchanged (no #558 regression), quarters and the
+  derived Q4 have `public_float_usd = None`, latest-filed wins on duplicates.
+- DB (`-m db`): upsert a PeriodRow with public_float_usd → projection carries it
+  to `financial_periods`.
+
+## DoD (ETL clauses 8–12)
+- Backfill: re-derive `financial_periods` for the panel (AAPL/MSFT/GME/JPM/HD)
+  on dev via the fundamentals re-derive path; record `COUNT(*) WHERE
+  public_float_usd IS NOT NULL` non-zero.
+- Cross-source: AAPL FY2025 public_float vs SEC EDGAR 10-K cover page
+  ($3,253,431,000,000 in `financial_facts_raw`, frame CY2025Q1I).
+- Acceptance (#735): `SELECT COUNT(*) FROM financial_periods WHERE
+  public_float_usd IS NOT NULL` non-zero across covered FY rows.

--- a/sql/197_public_float_usd.sql
+++ b/sql/197_public_float_usd.sql
@@ -1,0 +1,30 @@
+-- 197_public_float_usd.sql
+--
+-- Issue #735 — project DEI EntityPublicFloat into financial_periods as
+-- public_float_usd. Reserved by sql/088 (#731), which shipped the four
+-- us-gaap ownership columns and split this one out:
+--
+--   "public_float_usd (DEI EntityPublicFloat) is split out to #735 — its
+--    cover-page period_end (issuer Q2-end) does not match the FY anchor,
+--    so the existing _derive_periods_from_facts canonical-end filter
+--    silently drops it."
+--
+-- EntityPublicFloat is a 10-K cover-page DEI fact. Its period_end is the
+-- issuer's most-recent-Q2-end (the SEC-prescribed public-float "as of"
+-- date), NOT fiscal year-end (AAPL FY2025: float period_end 2025-03-28 vs
+-- FY anchor 2025-09-27). The matching service change adds an FY-only
+-- overlay pass in _derive_periods_from_facts that pulls EntityPublicFloat
+-- from the (fiscal_year, 'FY') group's facts AFTER the canonical-end value
+-- application, so it never lifts the FY anchor (#558) and never enters the
+-- Q4-derivation copy loops.
+--
+-- Purely additive nullable column on both the raw + canonical tables;
+-- existing rows stay NULL until the next normalisation run, which re-reads
+-- facts_raw and rewrites the canonical row via the ON CONFLICT update path.
+-- USD dollars; AAPL ~3.25e12 → 13 digits, well within NUMERIC(24,2).
+
+ALTER TABLE financial_periods_raw
+    ADD COLUMN IF NOT EXISTS public_float_usd NUMERIC(24,2);
+
+ALTER TABLE financial_periods
+    ADD COLUMN IF NOT EXISTS public_float_usd NUMERIC(24,2);

--- a/tests/test_canonical_merge_ownership_columns_731.py
+++ b/tests/test_canonical_merge_ownership_columns_731.py
@@ -58,6 +58,7 @@ def _seed_raw_with_ownership(
     shares_authorized: Decimal,
     shares_issued: Decimal,
     retained_earnings: Decimal,
+    public_float_usd: Decimal | None = None,
 ) -> None:
     conn.execute(
         """
@@ -65,10 +66,12 @@ def _seed_raw_with_ownership(
             instrument_id, period_end_date, period_type,
             fiscal_year, fiscal_quarter, revenue,
             treasury_shares, shares_authorized, shares_issued, retained_earnings,
+            public_float_usd,
             source, source_ref, reported_currency, filed_date
         ) VALUES (
             %s, %s, 'FY', %s, NULL, 1000,
             %s, %s, %s, %s,
+            %s,
             'sec_edgar', %s, 'USD', %s
         )
         """,
@@ -80,6 +83,7 @@ def _seed_raw_with_ownership(
             shares_authorized,
             shares_issued,
             retained_earnings,
+            public_float_usd,
             source_ref,
             filed_date,
         ),
@@ -94,7 +98,7 @@ def _canonical_ownership_row(
         cur.execute(
             """
             SELECT period_end_date, treasury_shares, shares_authorized,
-                   shares_issued, retained_earnings, source_ref
+                   shares_issued, retained_earnings, public_float_usd, source_ref
             FROM financial_periods
             WHERE instrument_id = %s
             """,
@@ -125,6 +129,7 @@ class TestCanonicalMergeOwnershipColumns:
             shares_authorized=Decimal("5000000000"),
             shares_issued=Decimal("1750000000"),
             retained_earnings=Decimal("180000000000"),
+            public_float_usd=Decimal("3253431000000.00"),  # #735
         )
         conn.commit()
 
@@ -136,6 +141,7 @@ class TestCanonicalMergeOwnershipColumns:
         assert row["shares_authorized"] == Decimal("5000000000")
         assert row["shares_issued"] == Decimal("1750000000")
         assert row["retained_earnings"] == Decimal("180000000000")
+        assert row["public_float_usd"] == Decimal("3253431000000.00")  # #735 projects too
 
     def test_on_conflict_update_path_replaces_ownership_columns(
         self,

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -1463,3 +1463,96 @@ class TestTier1Tier2AllowlistProjection:
         assert q4.assets_current == Decimal("450000000")
         assert q4.liabilities_current == Decimal("320000000")
         assert q4.additional_paid_in_capital == Decimal("250000000")
+
+
+class TestPublicFloatOverlay735:
+    """#735 — DEI EntityPublicFloat (10-K cover-page, period_end = issuer
+    Q2-end, stamped fiscal_period='FY') is projected onto the FY row via an
+    overlay, WITHOUT lifting the FY anchor (#558) and only on FY rows."""
+
+    def _fy_gaap(self) -> FactRow:
+        # us-gaap FY anchor fact (AAPL FY2025 ends 2025-09-27).
+        return _fact(
+            concept="Revenues",
+            val=Decimal("391035000000"),
+            period_start="2024-09-29",
+            period_end="2025-09-27",
+            frame="CY2025",
+            form_type="10-K",
+            fiscal_year=2025,
+            fiscal_period="FY",
+            accession_number="0000320193-25-000079",
+            filed_date="2025-11-01",
+        )
+
+    def _float(
+        self,
+        *,
+        val: Decimal = Decimal("3253431000000"),
+        period_end: str = "2025-03-28",  # issuer Q2-end, NOT the FY anchor
+        filed_date: str = "2025-11-01",
+        accession_number: str = "0000320193-25-000079",
+        unit: str = "USD",
+    ) -> FactRow:
+        return _fact(
+            concept="EntityPublicFloat",
+            val=val,
+            period_start=None,  # instant
+            period_end=period_end,
+            frame="CY2025Q1I",
+            form_type="10-K",
+            fiscal_year=2025,
+            fiscal_period="FY",
+            accession_number=accession_number,
+            filed_date=filed_date,
+            unit=unit,
+        )
+
+    def test_float_overlaid_on_fy_row_without_lifting_anchor(self) -> None:
+        periods = _derive_periods_from_facts([self._fy_gaap(), self._float()], reported_currency="USD")
+        fy = next(p for p in periods if p.period_type == "FY")
+        assert fy.public_float_usd == Decimal("3253431000000")
+        # Anchor stays the real FY-end, NOT the float's Q2-end (#558).
+        assert fy.period_end_date == date(2025, 9, 27)
+        assert fy.revenue == Decimal("391035000000")
+
+    def test_float_not_applied_to_quarter_rows(self) -> None:
+        q1_gaap = _fact(
+            concept="Revenues",
+            val=Decimal("95000000000"),
+            period_start="2024-09-29",
+            period_end="2024-12-28",
+            frame="CY2024Q4",
+            fiscal_year=2025,
+            fiscal_period="Q1",
+            accession_number="q1",
+            filed_date="2025-02-01",
+        )
+        periods = _derive_periods_from_facts([self._fy_gaap(), self._float(), q1_gaap], reported_currency="USD")
+        fy = next(p for p in periods if p.period_type == "FY")
+        q1 = next(p for p in periods if p.period_type == "Q1")
+        assert fy.public_float_usd == Decimal("3253431000000")
+        assert q1.public_float_usd is None
+
+    def test_float_picks_current_over_comparative(self) -> None:
+        # A comparative-year float re-stamped under the same fy must lose to
+        # the current float (max period_end), and a later amendment wins on
+        # filed_date at equal period_end.
+        comparative = self._float(val=Decimal("2628553000000"), period_end="2024-03-29")
+        current = self._float(val=Decimal("3253431000000"), period_end="2025-03-28", filed_date="2025-11-01")
+        amendment = self._float(
+            val=Decimal("3253431999999"),
+            period_end="2025-03-28",
+            filed_date="2025-12-15",
+            accession_number="0000320193-25-000079-a",
+        )
+        periods = _derive_periods_from_facts(
+            [self._fy_gaap(), comparative, current, amendment], reported_currency="USD"
+        )
+        fy = next(p for p in periods if p.period_type == "FY")
+        assert fy.public_float_usd == Decimal("3253431999999")  # newest period_end, latest filed
+
+    def test_non_usd_float_ignored(self) -> None:
+        periods = _derive_periods_from_facts([self._fy_gaap(), self._float(unit="shares")], reported_currency="USD")
+        fy = next(p for p in periods if p.period_type == "FY")
+        assert fy.public_float_usd is None


### PR DESCRIPTION
Closes #735.

## Problem

`EntityPublicFloat` (10-K cover-page DEI fact) is already ingested into `financial_facts_raw` (43,117 rows / 4,096 instruments on dev; AAPL FY2025 = $3,253,431,000,000) but never reached `financial_periods`:

- It is a **DEI** fact, deliberately **not** in `_TAG_TO_COLUMN`, so it is excluded from `mapped_facts` (correct — including it would lift the FY anchor to the cover-page date, #558).
- Its `period_end` is the issuer's **most-recent-Q2-end** (SEC-prescribed public-float "as of"), NOT fiscal-year-end (AAPL FY2025: float 2025-03-28 vs FY anchor 2025-09-27). The `canonical_facts` filter (`f.period_end == period_end`) drops it.

`sql/088` (#731) explicitly reserved `public_float_usd` for this ticket. Confirmed empirically: EntityPublicFloat is stamped `(fiscal_year, 'FY')`, so it lands in the `(Y,'FY')` group's `period_facts` — reachable by an overlay even though excluded from `mapped_facts`.

## Fix (option 1 — issue default: FY-only overlay, no new table)

- **`sql/197`**: additive nullable `public_float_usd NUMERIC(24,2)` on both `financial_periods_raw` and `financial_periods`. Idempotent (`ADD COLUMN IF NOT EXISTS`).
- **`_derive_periods_from_facts`**: after the canonical value-application loop, for **FY rows only**, pull `EntityPublicFloat` (USD-only) from `period_facts`, pick the current float via `max(period_end, filed_date, accession_number)`, set `row.public_float_usd`. Kept OUT of `_TAG_TO_COLUMN` / balance-sheet / Q4-derivation → FY anchor preserved (#558), quarters + derived-Q4 carry NULL.
- **`_upsert_period_raw` + canonical projection**: `public_float_usd` added to INSERT / VALUES / DO UPDATE / params and the `best_source` SELECT.

Value-only overlay: provenance (`source_ref` / `filed_date` / `form_type`) intentionally stays tied to the canonical fiscal-period facts — the float's accession is NOT appended to `source_ref` (that is the raw-upsert key).

## Security / data model

No auth surface. Additive nullable column. All SQL parameterised. Re-derive is idempotent (ON CONFLICT DO UPDATE restamps).

## Tradeoffs

- USD-only guard (Codex ckpt-1): a malformed/future non-USD EntityPublicFloat is ignored rather than populating a USD column.
- FY-only: EntityPublicFloat is a 10-K annual cover-page disclosure; quarters intentionally NULL.

## Tests

- `tests/test_financial_normalization.py::TestPublicFloatOverlay735` (pure): overlay on FY row without lifting anchor; not on quarters; current-over-comparative + latest-filed pick; non-USD ignored.
- `tests/test_canonical_merge_ownership_columns_731.py`: extended to assert `public_float_usd` projects through `_canonical_merge_instrument` (db).

## Local gates (commit e691f0d1)

`ruff check` ✓ · `ruff format --check` ✓ · `pyright` 0 errors ✓ · fast tier ✓ · smoke ✓ · #735 + #731 tests ✓. Codex ckpt-1 (spec, 3 findings folded) + ckpt-2 (branch, fundamentals/ETL lenses — **no correctness bugs**).

## DoD ETL clauses 8–12 (dev, commit e691f0d1)

- **8 (panel re-derive):** `normalize_financial_periods` on AAPL/MSFT/GME/JPM/HD → **84** `financial_periods.public_float_usd` non-null rows.
- **9 (cross-source):** AAPL FY2025 `public_float_usd = 3,253,431,000,000` vs SEC 10-K cover page (`financial_facts_raw` frame CY2025Q1I). ✓
- **10 (backfill executed):** `sql/197` applied to dev (`run_migrations`); panel re-derived.
- **11 (operator-visible figure):** AAPL FY2025 row carries the float on `period_end 2025-09-27` (FY anchor intact — overlay did not lift it to the Q2-end). ✓
- **12:** verification recorded here at commit e691f0d1.

Operator follow-up to populate the full universe: `normalize_financial_periods(conn)` (no scope) on dev re-derives every instrument with facts. Out of scope: surfacing on the ownership card / rollup API (renderer change lands in the #729 follow-up per #755).

Spec: `docs/specs/etl/2026-06-14-735-dei-public-float-projection.md`.