### PR TITLE
feat(#1627): surface def14a as own wedge + funds top-N overlay

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4558,19 +4558,18 @@ _ROLLUP_CSV_CATEGORIES: frozenset[str] = _ROLLUP_CSV_SLICE_CATEGORIES | {"treasu
 def rollup_csv_slice_filter(category: str) -> frozenset[str]:
     """Slice categories a ``?category=`` CSV filter keeps.
 
-    ``treasury`` keeps no slices (memo + residual rows only).
-    ``insiders`` includes ``def14a_unmatched`` — the chart and the L2
-    filer table both fold proxy-only DEF 14A holders into the insiders
-    category (``rollupToSunburstInputs`` / ``rollupToFilerRows``), and
-    the CSV's contract is to match the chart 1:1; exporting the raw
-    slice alone would drop rows the filtered table visibly shows
-    (#1589 Codex ckpt-2). ``def14a_unmatched`` stays addressable on
-    its own.
+    ``treasury`` keeps no slices (memo + residual rows only). Every
+    other category maps to its own slice — including
+    ``def14a_unmatched``, which is its own wedge + L2 filer category
+    since #1627 (un-folded from insiders). The CSV must match the
+    un-folded chart/table 1:1: ``?category=insiders&view=raw`` now
+    carries insiders only, and ``?category=def14a_unmatched`` carries
+    the proxy-only holders. (Pre-#1627 the chart/table folded DEF 14A
+    into insiders and this filter mirrored that fold — prevention-log
+    #1767; un-folding one surface requires un-folding all three.)
     """
     if category == "treasury":
         return frozenset()
-    if category == "insiders":
-        return frozenset({"insiders", "def14a_unmatched"})
     return frozenset({category})
 
 

--- a/docs/specs/ui/2026-06-14-ownership-surface-categories.md
+++ b/docs/specs/ui/2026-06-14-ownership-surface-categories.md
@@ -1,0 +1,122 @@
+# Ownership panel — surface buried categories (#1627)
+
+Renderer-only round-out of the ownership panel. NO change to
+`app/services/ownership_rollup.py` dedup/denominator/math. Parent epic #788.
+
+## Problem (verified live on dev, panel AAPL/GME/MSFT/JPM/HD)
+
+1. **def14a folded into Insiders.** `rollupToSunburstInputs` (L1) and
+   `SLICE_TO_TABLE_CATEGORY` (L2) both map `def14a_unmatched → insiders`. On
+   AAPL the chart "Insiders" wedge is 99.6% unmatched proxy holders (2.48B
+   shares vs 10.3M real insiders). `def14a_unmatched` carries
+   `denominator_basis=pie_wedge` (additive — already in server residual /
+   concentration), so it is a real wedge, not a sub-set of insiders.
+2. **funds overlay shows one aggregate row.** `FundsMemoOverlay` renders the
+   slice total only; the 2106 per-fund series for AAPL are surfaced nowhere
+   (L2 excludes funds too).
+3. **blockholders** wedge code path exists but `ownership_blockholders_current`
+   = 0 (13D/G drain mid-flight) → absent live. Verify-on-data.
+
+## Invariants preserved
+
+- `denominator_basis` is the authoritative additive-vs-overlay signal:
+  `pie_wedge` → counts toward the pie + server residual; `institution_subset`
+  → memo overlay, never summed into the pie. (data-engineer I4/I5.)
+- Denominator stays `shares_outstanding` only (treasury additive on top).
+- Wedge ↔ L2 row key parity: a chart click sets `?filer=<key>`; the L2 table
+  resolves rows by the same `filer_cik ?? name:` key under the same category.
+- One server snapshot drives chart + table + residual; the renderer must not
+  introduce a figure the server didn't compute.
+
+## Decisions (operator, 2026-06-14)
+
+- **def14a → own pie wedge** (un-fold; stays additive `pie_wedge`).
+- **funds → top-N fund series + aggregate** inside the overlay.
+
+## Changes
+
+### 1. `ownershipRings.ts`
+- `SunburstHolder.category` union + `CategoryKey` union: add `"def14a"`.
+- `CATEGORY_LABEL`: `def14a: "DEF 14A"`.
+- `SunburstInputs`: add `def14a_total: number | null` + `def14a_as_of?: string | null`.
+- `buildSunburstRings`: filter `def14a` holders; push a category via
+  `buildCategoryFromTotal("def14a", input.def14a_total, def14a_holders,
+  threshold, /*bypass*/ true, input.def14a_as_of ?? null)` after insiders.
+  **bypass=true** (like blockholders): DEF 14A holders are 5%+ beneficial
+  owners — every one surfaces as its own leaf, no "Other DEF 14A" tail, so
+  wedge↔row parity holds for every L2 row (Codex ckpt-1 Medium).
+
+### 2. `OwnershipSunburst.tsx`
+- `CATEGORY_FILL_INDEX`: `def14a: 5` (accent[5] = lime-500, the last free
+  accent slot; chart is the documented exception to the no-new-color rule).
+
+### 3. `OwnershipPanel.tsx`
+- `rollupToSunburstInputs`: drop the def14a→insiders fold. `insiders_total`
+  / `insiders_as_of` = insiders slice only. Add `def14a_total` /
+  `def14a_as_of` from `def14a_unmatched`. Push `flattenHolders(
+  "def14a_unmatched", "def14a")` into `holders`.
+- Table/overlay split driven off `denominator_basis`: overlay slices =
+  `slices.filter(s => (s.denominator_basis ?? "pie_wedge") === "institution_subset")`;
+  pie-wedge slices keep the explicit ordered list. (Correct-by-construction
+  for funds + any future `institution_subset` overlay.)
+- Overlay renders top-N (8) holders by shares + aggregate total + "+N more"
+  when truncated. Holder selection extracted to a pure helper
+  `topHoldersByShares(holders, n)` in `ownershipMetrics.ts` (table-tested).
+
+### 4. `OwnershipPage.tsx`
+- `SLICE_TO_TABLE_CATEGORY`: `def14a_unmatched: "def14a"` (was `"insiders"`).
+- `CATEGORY_LABELS`: `def14a: "DEF 14A"`. `_CATEGORY_ORDER`: insert `def14a`.
+
+### 5. Tests
+- `OwnershipPanel.test.ts`: rewrite the def14a-fold block → def14a is its own
+  category (`insiders_total` = insiders only; `def14a_total` separate; holder
+  `category === "def14a"`).
+- `OwnershipPage.test.ts`: def14a maps to `def14a` category/label; wedge↔row
+  parity still holds.
+- `ownershipRings.test.ts`: def14a total renders its own category.
+- `OwnershipSunburst.test.tsx`: `CATEGORY_FILL_INDEX` includes def14a.
+- `ownershipMetrics.test.ts`: `topHoldersByShares` ordering + truncation.
+
+## Out of scope
+- `etfs` (empty — filer-classification gap, needs `etf_filer_cik_seeds`; separate ticket).
+- Any backend `denominator_basis` reclassification.
+
+## Codex ckpt-1 — findings + resolutions (supersede above where noted)
+
+- **High — CSV `?category=def14a` would break / drift.** `rollup_csv_slice_filter`
+  (`app/api/instruments.py:4558`) mirrors the fold server-side: `"insiders" →
+  {"insiders","def14a_unmatched"}`. Un-folding the FE without this re-introduces
+  prevention-log #1767 in reverse (Insiders-drill CSV would carry def14a the
+  table no longer shows). Resolution (ONE backend hunk — the CSV category map,
+  NOT rollup math): `rollup_csv_slice_filter("insiders") → {"insiders"}`;
+  `"def14a_unmatched"` is already self-addressable. FE export href maps the
+  chart key `def14a → "def14a_unmatched"` for `?category=`. Update
+  `tests/test_ownership_rollup_csv.py::test_rollup_csv_slice_filter_folds_def14a_into_insiders`
+  → un-fold assertion.
+- **High — pie_wedge slice could be dropped from the table while server residual
+  counts it.** Resolution: the L1 `SliceTable` renders EVERY `pie_wedge` slice
+  (ordered by the known list, any unknown pie_wedge appended) — basis-driven,
+  not a hardcoded allow-list. Test: a pie_wedge slice always appears in the table.
+- **Medium — generic overlay vs funds-only.** Resolution: overlay selection is
+  `denominator_basis === "institution_subset"`; rendering is per-slice using the
+  slice's own `label`. The 13F-double-count memo line is funds-specific (only
+  `institution_subset` member today); a generic "non-additive overlay — not in
+  pie/residual" line covers any future overlay.
+- **Medium — bypass=false → Other-tail parity gap.** Resolution: def14a uses
+  **bypass=true** (above). Parity invariant scoped to rendered leaves.
+- **Medium — no residual-reconciliation test.** Resolution: add a fixture with a
+  large funds slice; assert funds NEVER enters `inputs.holders` / any `*_total`
+  (non-additive), and that un-folding leaves `insiders_total` + `def14a_total`
+  summing to the old combined value (residual math unchanged).
+- **Low — stale `SunburstInputs` denominator comment** ("callers compute
+  shares_outstanding + treasury"). Resolution: fix the comment.
+- **Low — duplicate holder key across categories.** Resolution: scope the L2
+  `filerLabel` lookup by `key && category` so a `name:` collision across
+  insiders/def14a can't pick the wrong label.
+
+## Verification (DoD clauses 8/11/12)
+- `pnpm --dir frontend typecheck` + `test:unit` green.
+- Dev panel AAPL/GME/MSFT/JPM/HD: def14a renders as its own wedge (not folded);
+  Insiders wedge reads honest (~0.07% AAPL); funds overlay lists top funds;
+  pie + residual still reconcile (residual unchanged — additive math untouched).
+- blockholders: re-check AAPL/GME after the 13D/G drain lands `>0` rows.

--- a/frontend/src/components/instrument/OwnershipFreshnessChips.test.tsx
+++ b/frontend/src/components/instrument/OwnershipFreshnessChips.test.tsx
@@ -15,6 +15,7 @@ function category(
     institutions: "Institutions",
     etfs: "ETFs",
     insiders: "Insiders",
+    def14a: "DEF 14A",
     treasury: "Treasury",
     blockholders: "Blockholders",
   };

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -254,14 +254,15 @@ describe("rollupToSunburstInputs — empty / no-data cases", () => {
   });
 });
 
-describe("rollupToSunburstInputs — def14a_unmatched fold (Codex review fix)", () => {
+describe("rollupToSunburstInputs — def14a_unmatched is its own wedge (#1627)", () => {
   /**
-   * Codex pre-push review (Batch 1 of #788) caught this: the prior
-   * version dropped ``def14a_unmatched`` slices from the chart
-   * entirely. Folding into the insiders bucket keeps the chart
-   * totals reconciled with the slice table.
+   * #1627 un-folds ``def14a_unmatched`` from the insiders wedge. It
+   * carries ``denominator_basis=pie_wedge`` (additive, already in the
+   * server residual), and on large caps the unmatched proxy 5%+ holders
+   * dwarf the real insiders, so folding mislabelled the majority of the
+   * insiders wedge. It now renders as its own ``def14a`` category.
    */
-  it("folds def14a_unmatched holders into the insiders bucket", () => {
+  it("surfaces def14a_unmatched as its own category, not folded into insiders", () => {
     const inputs = rollupToSunburstInputs(
       _baseRollup({
         shares_outstanding: "100000000",
@@ -298,7 +299,7 @@ describe("rollupToSunburstInputs — def14a_unmatched fold (Codex review fix)", 
             holders: [
               {
                 filer_cik: null,
-                filer_name: "Officer B (proxy-only)",
+                filer_name: "Big Proxy Holder",
                 shares: "500000",
                 pct_outstanding: "0.005",
                 winning_source: "def14a",
@@ -314,28 +315,95 @@ describe("rollupToSunburstInputs — def14a_unmatched fold (Codex review fix)", 
       }),
     );
     expect(inputs).not.toBeNull();
-    // Combined insiders total = 1M + 500k.
-    expect(inputs!.insiders_total).toBe(1_500_000);
-    // Both holders surface in the holders list under the insiders
-    // category.
-    const insiderHolders = inputs!.holders.filter((h) => h.category === "insiders");
-    expect(insiderHolders).toHaveLength(2);
-    expect(insiderHolders.map((h) => h.label).sort()).toEqual([
+    // Insiders is ONLY insiders now — no def14a fold.
+    expect(inputs!.insiders_total).toBe(1_000_000);
+    expect(inputs!.insiders_as_of).toBe("2026-01-01");
+    // def14a is its own category total + as_of.
+    expect(inputs!.def14a_total).toBe(500_000);
+    expect(inputs!.def14a_as_of).toBe("2026-03-01");
+    // Each holder surfaces under its own chart category.
+    expect(inputs!.holders.filter((h) => h.category === "insiders").map((h) => h.label)).toEqual([
       "Officer A",
-      "Officer B (proxy-only)",
     ]);
-    // Combined as_of takes the latest of the two.
-    expect(inputs!.insiders_as_of).toBe("2026-03-01");
+    expect(inputs!.holders.filter((h) => h.category === "def14a").map((h) => h.label)).toEqual([
+      "Big Proxy Holder",
+    ]);
   });
 
-  it("returns null insiders_total when both insiders and def14a_unmatched are absent", () => {
+  it("returns null insiders_total AND def14a_total when both slices are absent", () => {
+    const inputs = rollupToSunburstInputs(
+      _baseRollup({ shares_outstanding: "100000000", slices: [] }),
+    );
+    expect(inputs!.insiders_total).toBeNull();
+    expect(inputs!.def14a_total).toBeNull();
+  });
+});
+
+describe("rollupToSunburstInputs — funds overlay is non-additive (#1627)", () => {
+  /**
+   * funds is the only ``institution_subset`` slice. Its shares are
+   * fund-level N-PORT detail already inside the 13F-HR institutional
+   * aggregate, so it must NEVER enter the chart — additive accounting
+   * would double-count and visibly oversubscribe the pie. Here funds
+   * (80M) is larger than institutions (30M), so a leak would be obvious.
+   */
+  it("never flattens funds holders into the chart or any category total", () => {
     const inputs = rollupToSunburstInputs(
       _baseRollup({
         shares_outstanding: "100000000",
-        slices: [],
+        slices: [
+          {
+            category: "institutions",
+            label: "Institutions",
+            total_shares: "30000000",
+            pct_outstanding: "0.3",
+            filer_count: 1,
+            dominant_source: "13f",
+            holders: [
+              {
+                filer_cik: "0001000010",
+                filer_name: "BlackRock",
+                shares: "30000000",
+                pct_outstanding: "0.3",
+                winning_source: "13f",
+                winning_accession: "13F-010",
+                winning_edgar_url: null,
+                as_of_date: "2025-12-31",
+                filer_type: "INV",
+                dropped_sources: [],
+              },
+            ],
+          },
+          {
+            category: "funds",
+            label: "Mutual funds (N-PORT)",
+            total_shares: "80000000",
+            pct_outstanding: "0.8",
+            filer_count: 1,
+            dominant_source: "nport",
+            denominator_basis: "institution_subset",
+            holders: [
+              {
+                filer_cik: "0000036405",
+                filer_name: "Big Fund",
+                shares: "80000000",
+                pct_outstanding: "0.8",
+                winning_source: "nport",
+                winning_accession: "NPORT-1",
+                winning_edgar_url: null,
+                as_of_date: "2026-03-31",
+                filer_type: null,
+                dropped_sources: [],
+              },
+            ],
+          },
+        ],
       }),
     );
-    expect(inputs!.insiders_total).toBeNull();
+    expect(inputs).not.toBeNull();
+    expect(inputs!.holders.some((h) => h.label === "Big Fund")).toBe(false);
+    expect(inputs!.holders).toHaveLength(1);
+    expect(inputs!.institutions_total).toBe(30_000_000);
   });
 });
 

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -39,6 +39,7 @@ import { useNavigate } from "react-router-dom";
 import { fetchOwnershipRollup } from "@/api/ownership";
 import type {
   OwnershipRollupResponse,
+  OwnershipSlice,
   OwnershipSliceCategory,
 } from "@/api/ownership";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
@@ -56,6 +57,7 @@ import {
   formatShares,
   ownershipStaleDenominatorCopy,
   parseShareCount,
+  topHoldersByShares,
 } from "@/components/instrument/ownershipMetrics";
 import type {
   SunburstHolder,
@@ -135,13 +137,14 @@ export function OwnershipPanel({ symbol }: OwnershipPanelProps): JSX.Element {
  * denominator (treasury-on-top model); per-slice totals come from
  * the deduped rollup; per-filer holders feed the outer ring.
  *
- * ``def14a_unmatched`` rows fold into the ``insiders`` chart category
- * (they are by definition named officers in the proxy with no Form 4
- * filing on record). The slice table keeps them as a separate
- * category for transparency, but the chart treats them as insiders so
- * the sunburst doesn't need a fifth named category and the chart-vs-
- * table totals stay reconciled. Codex pre-push review (Batch 1 of
- * #788) caught the prior version that dropped them from the chart.
+ * ``def14a_unmatched`` is its own wedge (#1627). It carries
+ * ``denominator_basis=pie_wedge`` (additive — already in the server
+ * residual), and on large caps the unmatched proxy 5%+ holders dwarf
+ * the real insiders (AAPL: 2.48B vs 10.3M), so folding them into the
+ * insiders wedge mislabelled the majority of it. ``funds`` is the only
+ * ``institution_subset`` overlay and is deliberately NOT flattened
+ * here — it is a memo (N-PORT detail already inside the 13F-HR
+ * institutional aggregate), never a wedge.
  */
 export function rollupToSunburstInputs(
   rollup: OwnershipRollupResponse,
@@ -186,27 +189,6 @@ export function rollupToSunburstInputs(
 
   const treasury = parseShareCount(rollup.treasury_shares);
 
-  // Insiders bucket folds in def14a_unmatched holders. Both totals
-  // and as_of dates take the max across the two slices so the chart
-  // category sums match the slice table's insiders + def14a_unmatched
-  // rows.
-  const insiders_slice_total = sliceTotal("insiders");
-  const def14a_unmatched_total = sliceTotal("def14a_unmatched");
-  const combined_insiders_total =
-    insiders_slice_total === null && def14a_unmatched_total === null
-      ? null
-      : (insiders_slice_total ?? 0) + (def14a_unmatched_total ?? 0);
-  // Latest as_of across {insiders, def14a_unmatched}. Sort surfaces
-  // the most recent date last; ``at(-1)`` returns it; ``?? null``
-  // handles the both-empty case. Claude PR review (PR 798) round 2
-  // pinned this idiom over nested ternaries — extends cleanly when a
-  // third source enters the fold.
-  const combined_insiders_as_of =
-    [sliceAsOf("insiders"), sliceAsOf("def14a_unmatched")]
-      .filter((d): d is string => d !== null)
-      .sort()
-      .at(-1) ?? null;
-
   return {
     // Canonical denominator: shares_outstanding only. Treasury is
     // additive on top, NOT part of the denominator.
@@ -215,17 +197,22 @@ export function rollupToSunburstInputs(
       ...flattenHolders("institutions", "institutions"),
       ...flattenHolders("etfs", "etfs"),
       ...flattenHolders("insiders", "insiders"),
-      ...flattenHolders("def14a_unmatched", "insiders"),
+      // def14a_unmatched is its own wedge now (#1627), not folded into
+      // insiders. funds is an institution_subset overlay — never a
+      // wedge — so it is deliberately absent from this list.
+      ...flattenHolders("def14a_unmatched", "def14a"),
       ...flattenHolders("blockholders", "blockholders"),
     ],
     institutions_total: sliceTotal("institutions"),
     etfs_total: sliceTotal("etfs"),
-    insiders_total: combined_insiders_total,
+    insiders_total: sliceTotal("insiders"),
+    def14a_total: sliceTotal("def14a_unmatched"),
     blockholders_total: sliceTotal("blockholders"),
     treasury_shares: treasury,
     institutions_as_of: sliceAsOf("institutions"),
     etfs_as_of: sliceAsOf("etfs"),
-    insiders_as_of: combined_insiders_as_of,
+    insiders_as_of: sliceAsOf("insiders"),
+    def14a_as_of: sliceAsOf("def14a_unmatched"),
     treasury_as_of: rollup.treasury_as_of,
     blockholders_as_of: sliceAsOf("blockholders"),
   };
@@ -371,9 +358,14 @@ interface SliceTableProps {
   readonly rollup: OwnershipRollupResponse;
 }
 
-// Pie-wedge categories — render in the main slice table and contribute
-// to the chart. Funds slice (#919) renders separately as a memo overlay
-// so its share counts don't visually compete with the pie totals.
+// Known pie-wedge categories, in render order. Pie-wedge slices
+// (``denominator_basis="pie_wedge"``) sum to ≤ shares_outstanding and
+// feed the chart + server residual; ``institution_subset`` slices
+// (funds) render below as a non-additive memo overlay. The table is
+// driven off ``denominator_basis`` (NOT this list alone) so a future
+// additive category is never silently dropped while the residual still
+// subtracts it — this list only fixes the ORDER of the categories we
+// already know (Codex ckpt-1).
 const _CATEGORY_ORDER_TABLE: readonly OwnershipSliceCategory[] = [
   "insiders",
   "blockholders",
@@ -382,11 +374,26 @@ const _CATEGORY_ORDER_TABLE: readonly OwnershipSliceCategory[] = [
   "def14a_unmatched",
 ];
 
+function _denominatorBasis(slice: OwnershipSlice) {
+  return slice.denominator_basis ?? "pie_wedge";
+}
+
 function SliceTable({ rollup }: SliceTableProps): JSX.Element {
-  const slicesByCategory = new Map(rollup.slices.map((s) => [s.category, s]));
-  const visible = _CATEGORY_ORDER_TABLE.filter((cat) => slicesByCategory.has(cat));
-  const fundsSlice = slicesByCategory.get("funds");
-  if (visible.length === 0 && fundsSlice === undefined) {
+  const pieSlices = rollup.slices.filter((s) => _denominatorBasis(s) === "pie_wedge");
+  const overlaySlices = rollup.slices.filter(
+    (s) => _denominatorBasis(s) === "institution_subset",
+  );
+  // Order the known categories, then append any unknown pie-wedge slice
+  // the FE has no explicit slot for — so a new additive category can't
+  // vanish from the table while the server residual still counts it.
+  const orderedPie: OwnershipSlice[] = [
+    ..._CATEGORY_ORDER_TABLE.map((cat) =>
+      pieSlices.find((s) => s.category === cat),
+    ).filter((s): s is OwnershipSlice => s !== undefined),
+    ...pieSlices.filter((s) => !_CATEGORY_ORDER_TABLE.includes(s.category)),
+  ];
+
+  if (orderedPie.length === 0 && overlaySlices.length === 0) {
     return (
       <p className="text-xs text-slate-500 dark:text-slate-400">
         No filings ingested yet.
@@ -395,95 +402,146 @@ function SliceTable({ rollup }: SliceTableProps): JSX.Element {
   }
   return (
     <>
-      <table className="w-full text-sm">
-        <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-          <tr>
-            <th className="pb-1 text-left">Category</th>
-            <th className="pb-1 text-right">Shares</th>
-            <th className="pb-1 text-right">% of outstanding</th>
-            <th className="pb-1 text-right">Filers</th>
-          </tr>
-        </thead>
-        <tbody>
-          {visible.map((cat) => {
-            const slc = slicesByCategory.get(cat)!;
-            const shares = parseShareCount(slc.total_shares) ?? 0;
-            const pct = parseShareCount(slc.pct_outstanding) ?? 0;
-            return (
-              <tr key={cat} className="border-t border-t-slate-100 dark:border-t-slate-800">
-                <td className="py-1.5 text-slate-700 dark:text-slate-200">
-                  {slc.label}
-                </td>
-                <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
-                  {formatShares(shares)}
-                </td>
-                <td className="py-1.5 text-right font-mono text-slate-900 dark:text-slate-100">
-                  {formatPct(pct)}
-                </td>
-                <td className="py-1.5 text-right font-mono text-slate-500 dark:text-slate-400">
-                  {slc.filer_count}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-      {fundsSlice !== undefined && <FundsMemoOverlay slice={fundsSlice} />}
+      {orderedPie.length > 0 && (
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <tr>
+              <th className="pb-1 text-left">Category</th>
+              <th className="pb-1 text-right">Shares</th>
+              <th className="pb-1 text-right">% of outstanding</th>
+              <th className="pb-1 text-right">Filers</th>
+            </tr>
+          </thead>
+          <tbody>
+            {orderedPie.map((slc) => {
+              const shares = parseShareCount(slc.total_shares) ?? 0;
+              const pct = parseShareCount(slc.pct_outstanding) ?? 0;
+              return (
+                <tr
+                  key={slc.category}
+                  className="border-t border-t-slate-100 dark:border-t-slate-800"
+                >
+                  <td className="py-1.5 text-slate-700 dark:text-slate-200">
+                    {slc.label}
+                  </td>
+                  <td className="py-1.5 text-right font-mono text-slate-700 dark:text-slate-200">
+                    {formatShares(shares)}
+                  </td>
+                  <td className="py-1.5 text-right font-mono text-slate-900 dark:text-slate-100">
+                    {formatPct(pct)}
+                  </td>
+                  <td className="py-1.5 text-right font-mono text-slate-500 dark:text-slate-400">
+                    {slc.filer_count}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+      {overlaySlices.map((slc) => (
+        <OverlaySection key={slc.category} slice={slc} />
+      ))}
     </>
   );
 }
 
-interface FundsMemoOverlayProps {
-  readonly slice: OwnershipRollupResponse["slices"][number];
+interface OverlaySectionProps {
+  readonly slice: OwnershipSlice;
 }
 
+const _OVERLAY_TOP_N = 8;
+
 /**
- * Memo overlay for the funds slice (#919). N-PORT mutual-fund holdings
- * are fund-level detail INSIDE the 13F-HR institutional aggregate; we
- * render them in a separate panel so the operator can see the per-fund
- * breakdown without the share counts visually adding to the pie totals
- * (additive accounting would double-count). Distinct visual treatment
- * — italic label, muted styling, explicit memo footnote — signals the
- * non-additive semantic.
+ * Memo overlay for an ``institution_subset`` slice — funds today (#919),
+ * with top-N per-holder detail (#1627). These holdings are NON-additive
+ * (fund-level N-PORT detail already counted inside the 13F-HR
+ * institutional aggregate), so they render in a separate, visually
+ * distinct panel and never sum into the pie or residual. Italic memo +
+ * muted styling signal the non-additive semantic. Shows the top
+ * ``_OVERLAY_TOP_N`` holders by shares, a "+N more" line, and the
+ * aggregate total. Overlay selection is basis-driven, so a future
+ * ``institution_subset`` slice surfaces here automatically; only the
+ * funds-specific double-count copy is keyed on the category.
  */
-function FundsMemoOverlay({ slice }: FundsMemoOverlayProps): JSX.Element {
-  const shares = parseShareCount(slice.total_shares) ?? 0;
-  const pct = parseShareCount(slice.pct_outstanding) ?? 0;
+function OverlaySection({ slice }: OverlaySectionProps): JSX.Element {
+  const total = parseShareCount(slice.total_shares) ?? 0;
+  const totalPct = parseShareCount(slice.pct_outstanding) ?? 0;
+  const { shown, remaining } = topHoldersByShares(slice.holders, _OVERLAY_TOP_N);
+  const isFunds = slice.category === "funds";
+  const unit = isFunds ? "fund series" : "holders";
   return (
     <div
       className="mt-3 rounded-md border border-slate-200 bg-slate-50 p-2 text-xs dark:border-slate-800 dark:bg-slate-900/40"
-      data-test="funds-memo-overlay"
+      data-test="ownership-overlay"
     >
       <p className="mb-1 italic text-slate-600 dark:text-slate-300">
-        Memo: mutual funds (N-PORT) — fund-level detail of positions
-        already counted in Institutions via 13F-HR. Does not contribute
-        to the pie or residual math.
+        Memo: {slice.label} —{" "}
+        {isFunds
+          ? "fund-level detail of positions already counted in Institutions via 13F-HR. "
+          : "non-additive overlay. "}
+        Does not contribute to the pie or residual math.
       </p>
       <table className="w-full">
         <thead className="text-[0.625rem] uppercase tracking-wide text-slate-500 dark:text-slate-400">
           <tr>
-            <th className="pb-1 text-left">Fund series (N-PORT)</th>
-            <th className="pb-1 text-right">Shares (sum)</th>
+            <th className="pb-1 text-left">
+              {isFunds ? "Fund series (N-PORT)" : "Holder"}
+            </th>
+            <th className="pb-1 text-right">Shares</th>
             <th className="pb-1 text-right">% of outstanding</th>
-            <th className="pb-1 text-right">Series</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td className="py-1 italic text-slate-600 dark:text-slate-300">
-              {slice.label}
+          {shown.map((h) => {
+            const hShares = parseShareCount(h.shares) ?? 0;
+            const hPct = parseShareCount(h.pct_outstanding) ?? 0;
+            return (
+              <tr key={h.filer_cik ?? `name:${h.filer_name}`}>
+                <td className="py-1 text-slate-600 dark:text-slate-300">
+                  {h.winning_edgar_url !== null ? (
+                    <a
+                      className="underline decoration-dotted hover:text-slate-800 dark:hover:text-slate-100"
+                      href={h.winning_edgar_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {h.filer_name}
+                    </a>
+                  ) : (
+                    h.filer_name
+                  )}
+                </td>
+                <td className="py-1 text-right font-mono text-slate-600 dark:text-slate-300">
+                  {formatShares(hShares)}
+                </td>
+                <td className="py-1 text-right font-mono text-slate-700 dark:text-slate-200">
+                  {formatPct(hPct)}
+                </td>
+              </tr>
+            );
+          })}
+          {remaining > 0 && (
+            <tr>
+              <td colSpan={3} className="py-1 italic text-slate-500 dark:text-slate-400">
+                + {formatShares(remaining)} more {unit}
+              </td>
+            </tr>
+          )}
+        </tbody>
+        <tfoot>
+          <tr className="border-t border-t-slate-200 dark:border-t-slate-700">
+            <td className="py-1 font-medium text-slate-700 dark:text-slate-200">
+              Total · {slice.filer_count} {unit}
             </td>
-            <td className="py-1 text-right font-mono text-slate-600 dark:text-slate-300">
-              {formatShares(shares)}
+            <td className="py-1 text-right font-mono font-medium text-slate-700 dark:text-slate-200">
+              {formatShares(total)}
             </td>
-            <td className="py-1 text-right font-mono text-slate-700 dark:text-slate-200">
-              {formatPct(pct)}
-            </td>
-            <td className="py-1 text-right font-mono text-slate-500 dark:text-slate-400">
-              {slice.filer_count}
+            <td className="py-1 text-right font-mono font-medium text-slate-700 dark:text-slate-200">
+              {formatPct(totalPct)}
             </td>
           </tr>
-        </tbody>
+        </tfoot>
       </table>
     </div>
   );

--- a/frontend/src/components/instrument/OwnershipSunburst.test.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.test.tsx
@@ -74,6 +74,7 @@ function baseInputs(overrides: Partial<SunburstInputs> = {}): SunburstInputs {
     etfs_total: null,
     insiders_total: null,
     blockholders_total: null,
+    def14a_total: null,
     treasury_shares: null,
     ...overrides,
   };

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -101,6 +101,9 @@ export const CATEGORY_FILL_INDEX: Record<CategoryKey, number> = {
   institutions: 0, // cyan-500
   etfs: 1, // blue-500
   insiders: 2, // purple-500
+  def14a: 5, // lime-500 — DEF 14A proxy-only holders (#1627); the last
+  //                       free accent so the un-folded wedge reads as
+  //                       its own category, distinct from insiders.
   treasury: 3, // amber-500
   blockholders: 4, // rose-500 — distinct from the other four; activist
   //                            holds usually warrant a high-contrast

--- a/frontend/src/components/instrument/ownershipFreshness.ts
+++ b/frontend/src/components/instrument/ownershipFreshness.ts
@@ -42,6 +42,11 @@ export const CADENCE: Record<CategoryKey, CadenceThresholds> = {
   institutions: { aging_days: 135, stale_days: 270 },
   etfs: { aging_days: 135, stale_days: 270 },
   insiders: { aging_days: 30, stale_days: 90 },
+  // DEF 14A proxy statements (#1627) are annual — one per proxy season.
+  // The unmatched 5%+ holder table refreshes once a year, so a figure
+  // ~9 months old is normal; stale only past the ~400-day sec_def14a
+  // freshness horizon. Aging > 270d, stale > 400d.
+  def14a: { aging_days: 270, stale_days: 400 },
   treasury: { aging_days: 100, stale_days: 200 },
   // Blockholders (13D / 13G #766) are event-driven, not periodic —
   // a reporter only re-files when their position changes materially

--- a/frontend/src/components/instrument/ownershipMetrics.test.ts
+++ b/frontend/src/components/instrument/ownershipMetrics.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import type { OwnershipHolder } from "@/api/ownership";
+
 import {
   aggregateInsiderHoldings,
   computeOwnership,
@@ -7,7 +9,62 @@ import {
   formatShares,
   ownershipStaleDenominatorCopy,
   parseShareCount,
+  topHoldersByShares,
 } from "./ownershipMetrics";
+
+describe("topHoldersByShares (#1627 funds overlay)", () => {
+  function _h(name: string, shares: string, cik: string | null = null): OwnershipHolder {
+    return {
+      filer_cik: cik,
+      filer_name: name,
+      shares,
+      pct_outstanding: "0.01",
+      winning_source: "nport",
+      winning_accession: "0000000000-26-000001",
+      winning_edgar_url: null,
+      as_of_date: "2026-03-31",
+      filer_type: null,
+      dropped_sources: [],
+    };
+  }
+
+  it("returns the top n by shares, largest-first, with the remainder count", () => {
+    const { shown, remaining } = topHoldersByShares(
+      [_h("Small", "100"), _h("Biggest", "900"), _h("Middle", "500")],
+      2,
+    );
+    expect(shown.map((h) => h.filer_name)).toEqual(["Biggest", "Middle"]);
+    expect(remaining).toBe(1);
+  });
+
+  it("drops null / zero / unparseable share counts before ranking", () => {
+    const { shown, remaining } = topHoldersByShares(
+      [_h("Good", "300"), _h("Zero", "0"), _h("Bad", "not-a-number")],
+      8,
+    );
+    expect(shown.map((h) => h.filer_name)).toEqual(["Good"]);
+    expect(remaining).toBe(0);
+  });
+
+  it("returns remaining 0 when n covers every positive holder", () => {
+    const { shown, remaining } = topHoldersByShares([_h("A", "10"), _h("B", "20")], 8);
+    expect(shown).toHaveLength(2);
+    expect(remaining).toBe(0);
+  });
+
+  it("does not mutate the input array", () => {
+    const holders = [_h("A", "10"), _h("B", "20")];
+    const before = holders.map((h) => h.filer_name);
+    topHoldersByShares(holders, 1);
+    expect(holders.map((h) => h.filer_name)).toEqual(before);
+  });
+
+  it("handles an empty array", () => {
+    const { shown, remaining } = topHoldersByShares([], 8);
+    expect(shown).toHaveLength(0);
+    expect(remaining).toBe(0);
+  });
+});
 
 describe("parseShareCount", () => {
   it("returns null for null / undefined / blank", () => {

--- a/frontend/src/components/instrument/ownershipMetrics.ts
+++ b/frontend/src/components/instrument/ownershipMetrics.ts
@@ -25,7 +25,7 @@
  * returns NUMERICs as strings); :func:`parseShareCount` normalises.
  */
 
-import type { OwnershipCoverageState } from "@/api/ownership";
+import type { OwnershipCoverageState, OwnershipHolder } from "@/api/ownership";
 
 export interface OwnershipSliceInput {
   /** Sum of long-equity shares for this slice. ``null`` = no data. */
@@ -199,6 +199,37 @@ export function formatPct(pct: number | null): string {
 export function formatShares(shares: number | null): string {
   if (shares === null || !Number.isFinite(shares)) return "—";
   return shares.toLocaleString("en-US", { maximumFractionDigits: 0 });
+}
+
+export interface TopHolders {
+  /** Top ``n`` holders by parsed share count, largest-first. */
+  readonly shown: readonly OwnershipHolder[];
+  /** Count of positive-share holders beyond the top ``n`` (drives the
+   *  "+N more" affordance). Never negative. */
+  readonly remaining: number;
+}
+
+/**
+ * Select the top ``n`` holders by share count for a memo overlay
+ * (#1627 funds overlay). Holders with null / non-positive / unparseable
+ * share counts are dropped first (same skip predicate the chart uses),
+ * then the rest are sorted largest-first. Pure + table-tested — the
+ * overlay renders ``shown`` as rows and ``remaining`` as a "+N more"
+ * line. Does NOT mutate the input array.
+ */
+export function topHoldersByShares(
+  holders: readonly OwnershipHolder[],
+  n: number,
+): TopHolders {
+  const positive = holders.filter((h) => {
+    const shares = parseShareCount(h.shares);
+    return shares !== null && shares > 0;
+  });
+  const sorted = [...positive].sort(
+    (a, b) => (parseShareCount(b.shares) ?? 0) - (parseShareCount(a.shares) ?? 0),
+  );
+  const shown = sorted.slice(0, Math.max(0, n));
+  return { shown, remaining: sorted.length - shown.length };
 }
 
 /**

--- a/frontend/src/components/instrument/ownershipRings.test.ts
+++ b/frontend/src/components/instrument/ownershipRings.test.ts
@@ -10,6 +10,7 @@ const DEFAULT_INPUT: SunburstInputs = {
   etfs_total: null,
   insiders_total: null,
   blockholders_total: null,
+  def14a_total: null,
   treasury_shares: null,
 };
 
@@ -97,6 +98,22 @@ describe("buildSunburstRings — category sizing", () => {
     expect(treasury.shares).toBe(50_000_000);
     expect(treasury.leaves).toHaveLength(1);
     expect(treasury.within_category_gap).toBe(0);
+  });
+
+  it("renders def14a as its own category with every holder surfaced (#1627 bypass)", () => {
+    const r = buildSunburstRings({
+      ...DEFAULT_INPUT,
+      def14a_total: 100_000_000,
+      holders: [
+        holder("vanguard-proxy", 60_000_000, "def14a"),
+        holder("blackrock-proxy", 40_000_000, "def14a"),
+      ],
+    });
+    const d = r!.categories.find((c) => c.key === "def14a")!;
+    expect(d.shares).toBe(100_000_000);
+    // bypass=true → every 5%+ proxy holder is its own leaf, no "Other".
+    expect(d.leaves).toHaveLength(2);
+    expect(d.leaves.every((l) => !l.is_other)).toBe(true);
   });
 });
 

--- a/frontend/src/components/instrument/ownershipRings.ts
+++ b/frontend/src/components/instrument/ownershipRings.ts
@@ -67,6 +67,7 @@ export interface SunburstHolder {
     | "institutions"
     | "etfs"
     | "insiders"
+    | "def14a"
     | "treasury"
     | "blockholders";
   /** SEC archive index URL for the holder's winning accession (#921).
@@ -80,8 +81,11 @@ export interface SunburstHolder {
 
 export interface SunburstInputs {
   /** Denominator. Every category + leaf is sized as a proportion of
-   *  this number; the visible arcs sum to ≤100%. Callers typically
-   *  compute this as ``shares_outstanding + (treasury_shares ?? 0)``. */
+   *  this number; the visible arcs sum to ≤100%. This is
+   *  ``shares_outstanding`` ONLY — treasury renders as an additive
+   *  wedge on top, never folded into the denominator (the #789
+   *  ship-blocker that wedged every category down by the treasury
+   *  fraction). */
   readonly total_shares: number;
 
   /** Per-filer detail for institutional / ETF / insider categories.
@@ -102,6 +106,13 @@ export interface SunburstInputs {
    *  count does NOT double-count co-reporters of the same filing).
    *  Null = no 13D/G blocks on file. */
   readonly blockholders_total: number | null;
+
+  /** DEF 14A proxy-statement beneficial holders that did NOT resolve
+   *  to a Form 4 / Form 3 / 13F filer (the ``def14a_unmatched`` slice;
+   *  ``denominator_basis=pie_wedge`` — additive, already in the server
+   *  residual). Surfaced as its own wedge (#1627), no longer folded
+   *  into insiders. Null = none on file. */
+  readonly def14a_total: number | null;
 
   /** Treasury (issuer-held) shares from XBRL. ``null`` = not on
    *  file; treasury wedge does not render. Counted in the
@@ -124,12 +135,16 @@ export interface SunburstInputs {
   /** Blockholders as_of_date — latest filed_at across the included
    *  blocks (the reader endpoint returns this directly). */
   readonly blockholders_as_of?: string | null;
+  /** DEF 14A as_of_date — latest as_of across the unmatched proxy
+   *  holders. Optional, mirrors the other ``_as_of`` fields. */
+  readonly def14a_as_of?: string | null;
 }
 
 export type CategoryKey =
   | "institutions"
   | "etfs"
   | "insiders"
+  | "def14a"
   | "treasury"
   | "blockholders";
 
@@ -214,6 +229,7 @@ const CATEGORY_LABEL: Record<CategoryKey, string> = {
   institutions: "Institutions",
   etfs: "ETFs",
   insiders: "Insiders",
+  def14a: "DEF 14A",
   treasury: "Treasury",
   blockholders: "Blockholders",
 };
@@ -229,6 +245,7 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
   const inst_holders = input.holders.filter((h) => h.category === "institutions");
   const etf_holders = input.holders.filter((h) => h.category === "etfs");
   const insider_holders = input.holders.filter((h) => h.category === "insiders");
+  const def14a_holders = input.holders.filter((h) => h.category === "def14a");
   const blockholder_holders = input.holders.filter(
     (h) => h.category === "blockholders",
   );
@@ -278,6 +295,18 @@ export function buildSunburstRings(input: SunburstInputs): SunburstRings | null 
         threshold,
         true, // bypass threshold — every officer surfaces
         input.insiders_as_of ?? null,
+      ),
+    );
+  }
+  if (input.def14a_total !== null && input.def14a_total > 0) {
+    categories.push(
+      buildCategoryFromTotal(
+        "def14a",
+        input.def14a_total,
+        def14a_holders,
+        threshold,
+        true, // bypass threshold — DEF 14A holders are 5%+ beneficial owners; every one surfaces
+        input.def14a_as_of ?? null,
       ),
     );
   }

--- a/frontend/src/pages/OwnershipPage.test.ts
+++ b/frontend/src/pages/OwnershipPage.test.ts
@@ -145,12 +145,12 @@ describe("rollupToFilerRows — row shape and category mapping", () => {
     });
   });
 
-  it("folds def14a_unmatched into the insiders category", () => {
+  it("maps def14a_unmatched to its own def14a category (#1627 un-fold)", () => {
     const rollup = _baseRollup({
       slices: [
         _slice({
           category: "def14a_unmatched",
-          label: "Named officers (DEF 14A)",
+          label: "Proxy-only (DEF 14A)",
           holders: [
             _holder({
               filer_cik: null,
@@ -164,8 +164,43 @@ describe("rollupToFilerRows — row shape and category mapping", () => {
     });
     const rows = rollupToFilerRows(rollup);
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.category).toBe("insiders");
-    expect(rows[0]!.category_label).toBe("Insiders");
+    expect(rows[0]!.category).toBe("def14a");
+    expect(rows[0]!.category_label).toBe("DEF 14A");
+  });
+
+  it("keeps a same-name holder in insiders and def14a as two distinct rows (#1627)", () => {
+    // A CIK-null ``name:`` key can collide across categories. The rows
+    // must stay separate (category + key) so the L2 filer-label lookup
+    // can be scoped by category to resolve the right one.
+    const rollup = _baseRollup({
+      slices: [
+        _slice({
+          category: "insiders",
+          holders: [
+            _holder({
+              filer_cik: null,
+              filer_name: "PAT SMITH",
+              shares: "100",
+              winning_source: "form4",
+            }),
+          ],
+        }),
+        _slice({
+          category: "def14a_unmatched",
+          holders: [
+            _holder({
+              filer_cik: null,
+              filer_name: "PAT SMITH",
+              shares: "200",
+              winning_source: "def14a",
+            }),
+          ],
+        }),
+      ],
+    });
+    const rows = rollupToFilerRows(rollup).filter((r) => r.key === "name:PAT SMITH");
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.category))).toEqual(new Set(["insiders", "def14a"]));
   });
 
   it("excludes the funds memo slice (N-PORT, non-additive)", () => {
@@ -238,6 +273,35 @@ describe("rollupToFilerRows — row shape and category mapping", () => {
     });
     const rows = rollupToFilerRows(rollup);
     expect(rows.map((r) => r.key)).toEqual(["4", "3", "2", "1", "treasury"]);
+  });
+
+  it("sorts def14a rows after insiders and before treasury (#1627)", () => {
+    // Regression for the Codex ckpt-2 catch: def14a must be in
+    // _CATEGORY_ORDER, else indexOf returns -1 and DEF 14A rows sort
+    // before every known category.
+    const rollup = _baseRollup({
+      treasury_shares: "1000",
+      slices: [
+        _slice({
+          category: "insiders",
+          holders: [_holder({ filer_cik: "ins", shares: "100", winning_source: "form4" })],
+        }),
+        _slice({
+          category: "def14a_unmatched",
+          holders: [_holder({ filer_cik: "d14", shares: "200", winning_source: "def14a" })],
+        }),
+        _slice({
+          category: "institutions",
+          holders: [_holder({ filer_cik: "inst", shares: "300" })],
+        }),
+      ],
+    });
+    expect(rollupToFilerRows(rollup).map((r) => r.category)).toEqual([
+      "institutions",
+      "insiders",
+      "def14a",
+      "treasury",
+    ]);
   });
 });
 

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -14,7 +14,7 @@
  *
  * Operator-side controls:
  *
- *   * ``?category=institutions|etfs|insiders|blockholders|treasury``
+ *   * ``?category=institutions|etfs|insiders|def14a|blockholders|treasury``
  *     — filter the table to that category. Set by L1 / L2
  *     middle-ring clicks.
  *   * ``?filer=<cik|name-fallback>`` — scroll to + highlight a
@@ -76,15 +76,16 @@ const CATEGORY_LABELS: Record<CategoryKey, string> = {
   institutions: "Institutions",
   etfs: "ETFs",
   insiders: "Insiders",
+  def14a: "DEF 14A",
   treasury: "Treasury",
   blockholders: "Blockholders",
 };
 
 /** Rollup slice category → chart/table category. ``def14a_unmatched``
- *  folds into insiders (same fold as ``rollupToSunburstInputs`` so
- *  the table rows match the wedges 1:1); ``funds`` is a non-additive
- *  N-PORT memo overlay (#919) and is excluded from the filer table
- *  entirely. */
+ *  is its own ``def14a`` category (#1627 — un-folded from insiders so
+ *  the L2 filer rows match the un-folded wedges 1:1); ``funds`` is a
+ *  non-additive N-PORT memo overlay (#919) and is excluded from the
+ *  filer table entirely. */
 const SLICE_TO_TABLE_CATEGORY: Record<
   OwnershipSliceCategory,
   CategoryKey | null
@@ -93,7 +94,7 @@ const SLICE_TO_TABLE_CATEGORY: Record<
   etfs: "etfs",
   insiders: "insiders",
   blockholders: "blockholders",
-  def14a_unmatched: "insiders",
+  def14a_unmatched: "def14a",
   funds: null,
 };
 
@@ -218,7 +219,7 @@ function OwnershipBody({
 }: OwnershipBodyProps): JSX.Element {
   // Same mapping the L1 panel uses — single source of truth for the
   // rollup → rings transform (denominator = shares_outstanding only;
-  // treasury additive on top; def14a_unmatched folded into insiders).
+  // treasury additive on top; def14a_unmatched is its own wedge #1627).
   const inputs = useMemo(() => rollupToSunburstInputs(rollup), [rollup]);
   const rings = useMemo(
     () => (inputs === null ? null : buildSunburstRings(inputs)),
@@ -268,10 +269,17 @@ function OwnershipBody({
     // exports only that slice. Codex pre-push review (Chain 2.8
     // follow-up) caught the regression when the filter wasn't
     // forwarded.
+    // The chart category key in ``?category=`` matches the backend's
+    // CSV slice-filter param for every category EXCEPT ``def14a``,
+    // whose backend slice category is ``def14a_unmatched`` (#1627). Map
+    // it so a drilled DEF 14A export hits the right slice instead of
+    // 400ing on an unknown category.
+    const exportCategory =
+      categoryFilter === "def14a" ? "def14a_unmatched" : categoryFilter;
     const exportPath = `/api/instruments/${encodeURIComponent(symbol)}/ownership-rollup/export.csv`;
     const exportHref =
-      categoryFilter !== null
-        ? `${exportPath}?category=${encodeURIComponent(categoryFilter)}`
+      exportCategory !== null
+        ? `${exportPath}?category=${encodeURIComponent(exportCategory)}`
         : exportPath;
     return (
       <div className="space-y-3">
@@ -374,7 +382,11 @@ function OwnershipBody({
             filerFilter={filerFilter}
             filerLabel={
               filerFilter !== null
-                ? (allRows.find((r) => r.key === filerFilter)?.label ?? null)
+                ? (allRows.find(
+                    (r) =>
+                      r.key === filerFilter &&
+                      (categoryFilter === null || r.category === categoryFilter),
+                  )?.label ?? null)
                 : null
             }
             outstanding={outstanding}
@@ -537,6 +549,7 @@ const _CATEGORY_ORDER: readonly CategoryKey[] = [
   "etfs",
   "blockholders",
   "insiders",
+  "def14a",
   "treasury",
 ];
 

--- a/tests/test_ownership_rollup_csv.py
+++ b/tests/test_ownership_rollup_csv.py
@@ -529,18 +529,19 @@ def test_build_csv_supports_post_filter_via_dataclass_replace() -> None:
     assert "Public / unattributed" in csv_filt
 
 
-def test_rollup_csv_slice_filter_folds_def14a_into_insiders() -> None:
-    """``?category=insiders`` keeps the ``def14a_unmatched`` slice.
+def test_rollup_csv_slice_filter_def14a_addressable_on_its_own() -> None:
+    """``?category=`` maps each category to its own slice (#1627 un-fold).
 
-    The chart and the L2 filer table fold proxy-only DEF 14A holders
-    into the insiders category; the CSV must match the chart 1:1 or
-    a drilled ``?category=insiders&view=raw`` export silently drops
-    rows the table shows (#1589 Codex ckpt-2). Every other filter
-    value stays exact; ``treasury`` keeps no slices.
+    Pre-#1627 the chart + L2 table folded proxy-only DEF 14A holders into
+    insiders and this filter mirrored that fold. #1627 surfaces
+    ``def14a_unmatched`` as its own wedge + L2 category, so the filter
+    must un-fold too — otherwise a drilled ``?category=insiders&view=raw``
+    export would carry DEF 14A rows the un-folded table no longer shows
+    (prevention-log #1767 in reverse). ``treasury`` keeps no slices.
     """
     from app.api.instruments import rollup_csv_slice_filter
 
-    assert rollup_csv_slice_filter("insiders") == frozenset({"insiders", "def14a_unmatched"})
+    assert rollup_csv_slice_filter("insiders") == frozenset({"insiders"})
     assert rollup_csv_slice_filter("def14a_unmatched") == frozenset({"def14a_unmatched"})
     assert rollup_csv_slice_filter("treasury") == frozenset()
     for exact in ("blockholders", "institutions", "etfs", "funds"):


### PR DESCRIPTION
## Summary

Renderer-only round-out of the ownership panel (child of epic #788). Surfaces the buried ownership categories so a viewer sees every populated one clearly, with overlays kept distinct from the 100% pie. Verified live on dev against AAPL/GME/MSFT/JPM/HD.

Closes #1627.

## Problem (verified live)

- **def14a folded into Insiders.** The L1 sunburst (`rollupToSunburstInputs`), the L2 filer table (`SLICE_TO_TABLE_CATEGORY`), and the CSV export filter (`rollup_csv_slice_filter`) all folded `def14a_unmatched` into the `insiders` category. But `def14a_unmatched` carries `denominator_basis=pie_wedge` (additive — already in the server residual/concentration), and on large caps the unmatched proxy 5%+ holders dwarf real insiders: on AAPL the "Insiders" wedge was **2.48B shares (16.9%), of which only 10.3M (0.07%) were real insiders** — 99.6% of the wedge was mislabelled proxy holders.
- **funds overlay was one aggregate row.** The N-PORT memo overlay rendered only the slice total; the per-fund series (2106 for AAPL) appeared nowhere — the L2 drill excludes funds too.
- **blockholders** wedge code path exists but `ownership_blockholders_current` is mid-backfill (0 rows live); verify-on-data.

## Change

Renderer-only. **No change to `app/services/ownership_rollup.py` dedup/denominator/math** — the rollup payload, residual, and concentration are untouched.

- **def14a → own wedge.** New `def14a` chart/table category (lime-500, the last free accent slot). Un-folded on all three surfaces: L1 chart, L2 filer table, and the CSV export filter. Stays `pie_wedge` (additive), so the visible pie still reconciles with the unchanged server residual exactly. On AAPL the Insiders wedge now reads an honest ~0.07%.
- **funds overlay → top-N.** Generic `OverlaySection` (basis-driven: any `institution_subset` slice) lists the top 8 holders by shares + a "+N more" line + the aggregate total, with per-fund EDGAR links. Kept visually distinct (italic memo, muted) and explicitly non-additive.
- **basis-driven table.** The L1 slice table renders every `pie_wedge` slice (ordered by the known list, any unknown pie_wedge appended) so a future additive category can't silently vanish while the residual still subtracts it.
- **one backend hunk (flagged).** `rollup_csv_slice_filter("insiders")` returned `{insiders, def14a_unmatched}` — the fold mirrored server-side. Un-folding the FE without this re-introduces prevention-log **#1767 in reverse** (an Insiders-drill CSV would carry def14a the table no longer shows). Now `insiders → {insiders}`; `def14a_unmatched` was already self-addressable. This is the CSV category map, **not** rollup math. The FE export-href maps chart key `def14a → def14a_unmatched`.

## Security model

No new data exposure. Both the rollup and CSV export endpoints are already behind `require_session_or_service_token` (router-level) — unchanged. The renderer reads the same single server `snapshot_read`; no new figure is computed client-side. The funds overlay's per-fund EDGAR links open `sec.gov` URLs the backend already supplies (`winning_edgar_url`), with `rel="noopener noreferrer"`.

## Tradeoffs / notes

- `OverlaySection` selection is basis-driven (future overlays surface automatically), but the 13F-double-count memo copy is funds-specific (the only `institution_subset` member today). A generic "non-additive overlay" line covers any future member.
- def14a uses chart `bypass_threshold=true` (every 5%+ proxy holder is its own leaf, no "Other DEF 14A") so wedge↔L2-row parity holds for every row.
- The overlay "+N more" count derives from the holders array; the footer total uses `slice.filer_count` (the authoritative aggregate). They agree for funds (no truncation).
- `etfs` is out of scope (empty — filer-classification gap, needs `etf_filer_cik_seeds` curation; separate ticket).

## Verification (DoD 8/11/12)

- Gates @ `ccfc8452`: FE `typecheck` clean, `test:unit` **1034 passed**, `pyright` 0 errors, fast-tier **4034 passed**, smoke **129 passed**, ruff clean.
- Dev panel (AAPL/GME/MSFT/JPM/HD) rollup payloads inspected: funds present everywhere (basis `institution_subset`), `def14a_unmatched` on AAPL/MSFT/HD (basis `pie_wedge`), blockholders absent (backfill mid-flight).
- Cross-surface CSV (clause 11), AAPL: `?category=insiders` → 20 insiders rows, **zero def14a**; `?category=def14a_unmatched` → 17 def14a rows. Confirms the un-fold is consistent end-to-end.
- **FE visual pass pending operator** (vite :5173 / API refresh) for the chart pixels (def14a wedge colour, overlay layout); all data→render logic is covered by the pure-function unit tests.

## Codex

- ckpt-1 (spec): CSV `?category=def14a` drift, basis-driven table to prevent dropped pie_wedge slices, `bypass=true` for parity, residual-reconciliation + key-collision tests — all folded in.
- ckpt-2 (diff): caught `_CATEGORY_ORDER` omitting `def14a` (would sort def14a rows first via `indexOf=-1`) — fixed + pinned with a row-order test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
