### PR TITLE
fix(#1628): extract 13D/G issuer CUSIP from unified mandate schema → blockholders populate

### DIFF
--- a/app/providers/implementations/sec_13dg.py
+++ b/app/providers/implementations/sec_13dg.py
@@ -181,6 +181,26 @@ class BlockholderFiling:
     reporting_persons: list[BlockholderReportingPerson]
 
 
+@dataclass(frozen=True)
+class IssuerIdentity:
+    """Issuer identity read from a 13D/G ``primary_doc.xml`` (#1628).
+
+    Read from the post-2024-12-18 unified mandate-schema tags
+    (``<issuerCik>`` + ``<issuerCusips>/<issuerCusipNumber>``) — the
+    single source of truth for the modern shape. edgartools 5.30.2 and
+    the legacy in-house extractors read the stale flat ``<issuerCUSIP>``
+    element and so return an empty CUSIP for every modern filing, which
+    silently broke CUSIP→instrument resolution (blockholders never
+    populated). Each field is normalised; ``None`` when absent or
+    malformed.
+    """
+
+    cik: str | None
+    cusip: str | None
+    name: str | None
+    class_title: str | None
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -228,6 +248,69 @@ def _child_text(parent: ET.Element | None, name: str) -> str | None:
             if text:
                 return text
     return None
+
+
+def _normalise_cusip(raw: str | None) -> str | None:
+    """``strip().upper()``; return None unless exactly 9 alphanumeric
+    chars. CUSIP (and foreign CINS, which lead with a letter) are 9
+    alphanumeric characters — anything else is malformed and would only
+    poison the resolution lookup / logs, so it maps to None (#1628,
+    Codex ckpt-1)."""
+    if raw is None:
+        return None
+    cusip = raw.strip().upper()
+    return cusip if (len(cusip) == 9 and cusip.isalnum()) else None
+
+
+def _issuer_identity_from_root(root: ET.Element) -> IssuerIdentity:
+    """Extract :class:`IssuerIdentity` from a parsed primary_doc root.
+
+    Reads the unified mandate-schema tags first
+    (``issuerCik`` + ``issuerCusips/issuerCusipNumber``) with the legacy
+    flat tags (``issuerCIK`` / ``issuerCusip`` / ``issuerCUSIP``) as
+    fall-throughs so a pre-unified fixture still resolves. CIK is
+    zero-padded to 10 digits (None if non-numeric); CUSIP is normalised
+    via :func:`_normalise_cusip`.
+    """
+    issuer_info = _find_descendant(root, "issuerInfo")
+    cik_raw = _child_text(issuer_info, "issuerCik") or _child_text(issuer_info, "issuerCIK")
+    cusip_raw = (
+        _child_text(issuer_info, "issuerCusipNumber")  # unified schema (nested)
+        or _child_text(issuer_info, "issuerCusip")  # legacy 13G flat
+        or _child_text(issuer_info, "issuerCUSIP")  # legacy 13D flat
+    )
+    name = _child_text(issuer_info, "issuerName")
+    cover = _find_descendant(root, "coverPageHeader")
+    class_title = _child_text(cover, "securitiesClassTitle")
+
+    cik: str | None = None
+    if cik_raw is not None:
+        cik_stripped = cik_raw.strip()
+        if cik_stripped.isdigit():
+            cik = cik_stripped.zfill(10)
+
+    return IssuerIdentity(
+        cik=cik,
+        cusip=_normalise_cusip(cusip_raw),
+        name=name,
+        class_title=class_title,
+    )
+
+
+def extract_issuer_identity_from_primary_doc(xml: str) -> IssuerIdentity:
+    """Parse ``xml`` and extract the issuer identity (#1628).
+
+    Single source of truth for the modern 13D/G issuer block, used by
+    the edgartools adapter (manifest + rewash drains) to backfill the
+    CUSIP edgartools fails to read. Never raises on a missing tag or an
+    unparseable (e.g. pre-mandate HTML) body — returns all-None so the
+    caller falls back to its other source / leaves the field empty.
+    """
+    try:
+        root = ET.fromstring(xml)  # noqa: S314 — SEC EDGAR is the trusted source for 13D/G XML.
+    except ET.ParseError:
+        return IssuerIdentity(cik=None, cusip=None, name=None, class_title=None)
+    return _issuer_identity_from_root(root)
 
 
 def _decimal_or_none(text: str | None) -> Decimal | None:
@@ -329,20 +412,19 @@ def _extract_13d(root: ET.Element) -> tuple[str, str, str, str | None, date | No
     Returns ``(issuer_cik, issuer_cusip, issuer_name,
     securities_class_title, date_of_event, reporting_persons)``.
     """
-    issuer_info = _find_descendant(root, "issuerInfo")
-    issuer_cik_text = _child_text(issuer_info, "issuerCIK")
-    issuer_cusip = _child_text(issuer_info, "issuerCUSIP")
-    issuer_name = _child_text(issuer_info, "issuerName")
-
-    if issuer_cik_text is None:
-        raise ValueError("13D primary_doc.xml is missing <issuerCIK>")
-    if issuer_cusip is None:
-        raise ValueError("13D primary_doc.xml is missing <issuerCUSIP>")
-    if issuer_name is None:
+    # #1628: issuer identity via the shared correct-tag extractor (the
+    # unified mandate schema nests the CUSIP as
+    # <issuerCusips>/<issuerCusipNumber>; the old flat <issuerCUSIP>
+    # read returned None and raised here, breaking the legacy path too).
+    # CUSIP is no longer required — an absent/odd one is left empty and
+    # resolution falls back to the single-class CIK path.
+    ident = _issuer_identity_from_root(root)
+    if ident.cik is None:
+        raise ValueError("13D primary_doc.xml is missing a valid <issuerCik>")
+    if ident.name is None:
         raise ValueError("13D primary_doc.xml is missing <issuerName>")
 
     cover = _find_descendant(root, "coverPageHeader")
-    securities_class_title = _child_text(cover, "securitiesClassTitle")
     date_of_event = _parse_date_loose(_child_text(cover, "dateOfEvent"))
 
     reporters_root = _find_descendant(root, "reportingPersons")
@@ -355,10 +437,10 @@ def _extract_13d(root: ET.Element) -> tuple[str, str, str, str | None, date | No
     reporters = [_parse_13d_reporting_person(n) for n in reporter_nodes]
 
     return (
-        _zero_pad_cik(issuer_cik_text),
-        issuer_cusip,
-        issuer_name,
-        securities_class_title,
+        ident.cik,
+        ident.cusip or "",
+        ident.name,
+        ident.class_title,
         date_of_event,
         reporters,
     )
@@ -415,20 +497,16 @@ def _parse_13g_reporting_person(node: ET.Element) -> BlockholderReportingPerson:
 
 def _extract_13g(root: ET.Element) -> tuple[str, str, str, str | None, date | None, list[BlockholderReportingPerson]]:
     """Extract the 13G-shaped subset of cover-page + reporter data."""
-    issuer_info = _find_descendant(root, "issuerInfo")
-    issuer_cik_text = _child_text(issuer_info, "issuerCik") or _child_text(issuer_info, "issuerCIK")
-    issuer_cusip = _child_text(issuer_info, "issuerCusip") or _child_text(issuer_info, "issuerCUSIP")
-    issuer_name = _child_text(issuer_info, "issuerName")
-
-    if issuer_cik_text is None:
-        raise ValueError("13G primary_doc.xml is missing <issuerCik>")
-    if issuer_cusip is None:
-        raise ValueError("13G primary_doc.xml is missing <issuerCusip>")
-    if issuer_name is None:
+    # #1628: issuer identity via the shared correct-tag extractor (see
+    # _extract_13d). CUSIP no longer required — resolution falls back to
+    # the single-class CIK path when it is absent.
+    ident = _issuer_identity_from_root(root)
+    if ident.cik is None:
+        raise ValueError("13G primary_doc.xml is missing a valid <issuerCik>")
+    if ident.name is None:
         raise ValueError("13G primary_doc.xml is missing <issuerName>")
 
     cover = _find_descendant(root, "coverPageHeader")
-    securities_class_title = _child_text(cover, "securitiesClassTitle")
     date_of_event = _parse_date_loose(_child_text(cover, "eventDateRequiresFilingThisStatement"))
 
     reporter_nodes = _find_descendants(root, "coverPageHeaderReportingPersonDetails")
@@ -438,10 +516,10 @@ def _extract_13g(root: ET.Element) -> tuple[str, str, str, str | None, date | No
     reporters = [_parse_13g_reporting_person(n) for n in reporter_nodes]
 
     return (
-        _zero_pad_cik(issuer_cik_text),
-        issuer_cusip,
-        issuer_name,
-        securities_class_title,
+        ident.cik,
+        ident.cusip or "",
+        ident.name,
+        ident.class_title,
         date_of_event,
         reporters,
     )

--- a/app/services/blockholders.py
+++ b/app/services/blockholders.py
@@ -65,8 +65,15 @@ from app.services.ownership_observations import (
     record_blockholder_observation,
     refresh_blockholders_current,
 )
+from app.services.sec_identity import siblings_for_issuer_cik
 
-_PARSER_VERSION_13DG = "13dg-primary-v1"
+# v2 (#1628): issuer CUSIP is now extracted from the unified mandate
+# schema (``<issuerCusips>/<issuerCusipNumber>``) — edgartools 5.30.2 +
+# the legacy extractors read the stale flat ``<issuerCUSIP>`` and
+# returned an empty CUSIP, so CUSIP-only resolution never resolved and
+# blockholders never populated. The bump flips sec_13d/sec_13g manifest
+# rows back to ``pending`` so they re-drain through the fixed extractor.
+_PARSER_VERSION_13DG = "13dg-primary-v2"
 
 logger = logging.getLogger(__name__)
 
@@ -448,6 +455,59 @@ def _resolve_cusip_to_instrument_id(
     return int(row[0]) if row is not None else None
 
 
+def _resolve_issuer_to_instrument_id(
+    conn: psycopg.Connection[tuple],
+    *,
+    cusip: str | None,
+    cik: str | None,
+) -> int | None:
+    """Resolve a 13D/G subject company to an instrument_id (#1628).
+
+    CUSIP is the security-precise key — it disambiguates share-class
+    siblings (GOOG/GOOGL share an issuer CIK but not a CUSIP; settled
+    "CIK = entity, CUSIP = security" #1102). CIK is a single-class-only
+    fallback for the coverage gap (we hold more ``(sec, cik)`` mappings
+    than ``(sec, cusip)`` ones). Order:
+
+      1. CUSIP -> ``external_identifiers`` (provider ``sec`` | ``openfigi``,
+         ``sec`` canonical first via the CASE-ordered tiebreak). Precise;
+         safe for multi-class issuers.
+      2. else, if CIK maps to EXACTLY ONE instrument -> that instrument
+         (single-class issuer — safe + broader coverage). A multi-class
+         CIK (or zero siblings, or a malformed CIK) with an unresolved
+         CUSIP stays ``None``: we never guess the share class and never
+         fan out (a 5%+ holder owns ONE class). The caller still writes
+         the ``blockholder_filings`` audit row with ``instrument_id``
+         NULL (status ``partial``).
+    """
+    if cusip:
+        cur = conn.execute(
+            """
+            SELECT instrument_id
+            FROM external_identifiers
+            WHERE provider IN ('sec', 'openfigi')
+              AND identifier_type = 'cusip'
+              AND identifier_value = %(cusip)s
+            ORDER BY CASE provider WHEN 'sec' THEN 0 ELSE 1 END,
+                     is_primary DESC,
+                     external_identifier_id ASC
+            LIMIT 1
+            """,
+            {"cusip": cusip.strip().upper()},
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return int(row[0])
+    if cik:
+        try:
+            siblings = siblings_for_issuer_cik(conn, cik)
+        except ValueError:
+            return None  # malformed CIK — leave unresolved (audit row still written)
+        if len(siblings) == 1:
+            return siblings[0]
+    return None
+
+
 def _upsert_filer(
     conn: psycopg.Connection[tuple],
     *,
@@ -665,7 +725,7 @@ def _ingest_single_accession(
             submission_type=None,
         )
 
-    instrument_id = _resolve_cusip_to_instrument_id(conn, filing.issuer_cusip)
+    instrument_id = _resolve_issuer_to_instrument_id(conn, cusip=filing.issuer_cusip, cik=filing.issuer_cik)
     skipped_no_cusip = 0 if instrument_id is not None else len(filing.reporting_persons)
 
     # Resolve the *filer's* canonical name. ``filing.issuer_name`` is

--- a/app/services/manifest_parsers/_schedule13_adapter.py
+++ b/app/services/manifest_parsers/_schedule13_adapter.py
@@ -49,6 +49,7 @@ from app.providers.implementations.sec_13dg import (
     BlockholderReportingPerson,
     Status,
     SubmissionType,
+    extract_issuer_identity_from_primary_doc,
 )
 from app.services.blockholders import _zero_pad_cik
 
@@ -138,6 +139,7 @@ def build_filing_from_edgartools_dict(
     source: Literal["sec_13d", "sec_13g"],
     manifest_form: str,
     manifest_filer_cik: str,
+    raw_xml: str | None = None,
 ) -> BlockholderFiling:
     """Convert an edgartools ``parse_xml`` dict into a repo-internal
     ``BlockholderFiling``.
@@ -212,12 +214,25 @@ def build_filing_from_edgartools_dict(
             )
         )
 
+    # edgartools 5.30.2 reads the stale flat ``<issuerCUSIP>`` tag, so it
+    # returns an empty issuer CUSIP for every modern (post-2024-12-18)
+    # 13D/G — which silently broke CUSIP→instrument resolution and left
+    # blockholders empty (#1628). Backfill the issuer identity from the
+    # unified mandate schema (``<issuerCusips>/<issuerCusipNumber>`` +
+    # ``<issuerCik>``) via the canonical extractor when the raw body is
+    # available. Prefer the helper; fall back to edgartools' value when
+    # the helper returns None (e.g. a pre-mandate/odd shape) so a valid
+    # parsed identity is never nulled out (Codex ckpt-1).
+    helper = extract_issuer_identity_from_primary_doc(raw_xml) if raw_xml else None
+    issuer_cik = (helper.cik if helper and helper.cik else None) or issuer_info.cik
+    issuer_cusip = (helper.cusip if helper and helper.cusip else None) or security_info.cusip
+
     return BlockholderFiling(
         submission_type=submission_type,
         status=status,
         primary_filer_cik=_zero_pad_cik(manifest_filer_cik),
-        issuer_cik=issuer_info.cik,
-        issuer_cusip=security_info.cusip,
+        issuer_cik=issuer_cik,
+        issuer_cusip=issuer_cusip,
         issuer_name=issuer_info.name,
         securities_class_title=security_info.title or None,
         date_of_event=date_of_event,

--- a/app/services/manifest_parsers/sec_13dg.py
+++ b/app/services/manifest_parsers/sec_13dg.py
@@ -61,7 +61,7 @@ from app.services.blockholders import (
     _archive_file_url,
     _record_13dg_observation_for_filing,
     _record_ingest_attempt,
-    _resolve_cusip_to_instrument_id,
+    _resolve_issuer_to_instrument_id,
     _upsert_filer,
     _upsert_filing_row,
     blockholders_within_retention,
@@ -264,6 +264,7 @@ def _parse_13dg(
             source=row.source,
             manifest_form=row.form,
             manifest_filer_cik=filer_cik,
+            raw_xml=primary_xml,
         )
     except Exception as exc:  # noqa: BLE001 — broad catch + audit-log write
         # Tag the error string by exception class so operators reading
@@ -317,23 +318,22 @@ def _parse_13dg(
     inserted = 0
     try:
         with conn.transaction():
-            # PR11 v8 empirical pivot 2026-05-21: CUSIP-only resolution.
-            # The earlier 5-case CUSIP-vs-hint cross-validation branch
-            # depended on the ``sec_13dg_discovery_issuer_hint`` side
-            # table seeded by the universe-issuer-CIK discovery layer.
-            # Operator smoke against AAPL/GME/MSFT/JPM/HD revealed that
-            # ``efts.sec.gov/LATEST/search-index`` post-2024-12-18 does
-            # NOT index SC 13D/G by SUBJECT CIK, only by FILER CIK —
-            # the hint table would never get populated by the discovery
-            # path, so the cross-validation branches collapse to CASE E
-            # (legacy daily-index path; no hints, CUSIP-only). The hint
-            # table + discovery module + 5-case branch are therefore
-            # all retired (sql/162 drops the table). The legacy daily-
-            # index path remains the discovery mechanism and already
-            # ships 575k SC 13D/G manifest rows in dev DB.
-            instrument_id = _resolve_cusip_to_instrument_id(conn, filing.issuer_cusip)
+            # Resolve the subject company to an instrument (#1628). CUSIP
+            # is the security-precise key (disambiguates share-class
+            # siblings; settled "CIK = entity, CUSIP = security" #1102),
+            # with a single-class-only CIK fallback for the coverage gap.
+            # Pre-#1628 this was CUSIP-only AND edgartools returned an
+            # empty CUSIP for every modern filing (stale <issuerCUSIP>
+            # tag) → 0 resolutions → blockholders never populated; the
+            # adapter now backfills the CUSIP from the unified mandate
+            # schema. (Discovery stays the legacy daily-index path —
+            # efts.sec.gov does not index SC 13D/G by subject CIK; PR11
+            # v8 2026-05-21.)
+            instrument_id = _resolve_issuer_to_instrument_id(conn, cusip=filing.issuer_cusip, cik=filing.issuer_cik)
             log_error: str | None = (
-                None if instrument_id is not None else f"cusip_unresolved (cusip={filing.issuer_cusip!r})"
+                None
+                if instrument_id is not None
+                else f"issuer_unresolved (cusip={filing.issuer_cusip!r} cik={filing.issuer_cik!r})"
             )
 
             skipped_no_cusip = 0 if instrument_id is not None else len(filing.reporting_persons)

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -622,7 +622,7 @@ def _apply_blockholders(
     from edgar.beneficial_ownership.schedule13 import Schedule13D, Schedule13G
 
     from app.services.blockholders import (
-        _resolve_cusip_to_instrument_id,
+        _resolve_issuer_to_instrument_id,
         _upsert_filer,
         _upsert_filing_row,
         blockholders_within_retention,
@@ -708,10 +708,11 @@ def _apply_blockholders(
     # silent default. The sec_filing_manifest.source column is
     # CHECK-constrained to {'sec_13d','sec_13g'} per sql/118.
     try:
+        primary_xml = raw_doc.require_payload()
         if manifest_source == "sec_13g":
-            parsed_dict = Schedule13G.parse_xml(raw_doc.require_payload())
+            parsed_dict = Schedule13G.parse_xml(primary_xml)
         else:
-            parsed_dict = Schedule13D.parse_xml(raw_doc.require_payload())
+            parsed_dict = Schedule13D.parse_xml(primary_xml)
         # Adapter requires the manifest form label (SC 13D / SC 13G /
         # /A variants — dual-spelled per the post-PR1251 form-name
         # normalisation in _SUBMISSION_TYPE_FOR_FORM) for the closed
@@ -726,6 +727,7 @@ def _apply_blockholders(
             source=source_for_adapter,
             manifest_form=form_for_adapter,
             manifest_filer_cik=manifest_filer_cik,
+            raw_xml=primary_xml,
         )
     except Exception as exc:
         raise RewashParseError(
@@ -752,7 +754,7 @@ def _apply_blockholders(
     # different issuer_cusip produces an internally-inconsistent
     # row that silently joins to the wrong instrument. Codex
     # pre-push review caught the prior reuse-of-stale-value bug.
-    instrument_id = _resolve_cusip_to_instrument_id(conn, filing.issuer_cusip)
+    instrument_id = _resolve_issuer_to_instrument_id(conn, cusip=filing.issuer_cusip, cik=filing.issuer_cik)
 
     # Resolve canonical filer name + filer_id (preserved across
     # re-wash via ON CONFLICT (cik) DO UPDATE in _upsert_filer).

--- a/docs/specs/etl/2026-06-14-13dg-cusip-extraction.md
+++ b/docs/specs/etl/2026-06-14-13dg-cusip-extraction.md
@@ -1,0 +1,83 @@
+# 13D/G issuer-CUSIP extraction + resolution (#1628)
+
+Blockholders (13D/G) never populate: `ownership_blockholders_current` = 0 despite ~150k filings + a working parser. Root cause is a parser tag bug, NOT a CIK-vs-CUSIP design decision.
+
+## Root cause (empirically proven, acc 0001274173-26-000157 = CLRB)
+
+The modern SEC Schedule 13 mandate XML (post-2024-12-18) carries the issuer CUSIP as:
+
+```xml
+<issuerInfo>
+  <issuerCik>0001279704</issuerCik>
+  <issuerCusips><issuerCusipNumber>15117F880</issuerCusipNumber></issuerCusips>
+</issuerInfo>
+```
+
+Both parsers read STALE tag names:
+- edgartools 5.30.2 `schedule13.py:191`: `child_text(issuer_el, 'issuerCUSIP')` → `''` (the documented edgartools drift cliff, #932/G15). CIK happens to extract OK.
+- in-house `app/providers/implementations/sec_13dg.py::_extract_issuer` (`:333-334`): reads `issuerCIK` / `issuerCUSIP` — both wrong for the unified mandate schema (`issuerCik` / `issuerCusips/issuerCusipNumber`).
+
+So `filing.issuer_cusip = ''` for every modern 13D/G → CUSIP-only resolution (`_parse_13dg:334`) returns None → observation write skipped → blockholders permanently empty.
+
+Proof: direct XML parse gives `issuerCusipNumber=15117F880` → `external_identifiers` resolves to instrument 1049521; issuer CIK 0001279704 → same instrument.
+
+## Why CUSIP, not "just use CIK" (settled #1102)
+
+CUSIP = security (per-share-class); CIK = entity (settled-decisions "CIK = entity, CUSIP = security" #1102). 56 issuer CIKs in dev map to >1 instrument (GOOG/GOOGL-style share-class siblings). A 13D against GOOGL carries GOOGL's CUSIP; CIK-only resolution is ambiguous for those and would re-break the PR11 Codex-1b BLOCKING (routing GOOG-A 13D onto GOOGL-C). So CUSIP is the precise key; CIK is a single-class-only fallback.
+
+## Fix
+
+### 1. Correct-tag issuer extractor (pure)
+New helper in `app/services/blockholders.py`:
+`extract_issuer_identity_from_primary_doc(xml) -> IssuerIdentity(cik, cusip, name, class_title)` — namespace-agnostic walk reading the REAL tags `issuerCik`, `issuerCusipNumber`, `issuerName`, `securitiesClassTitle`. Single source of truth for the modern schema. Returns Nones for an absent/old-HTML body (defensive).
+
+### 2. Backfill the manifest path (the drain)
+`build_filing_from_edgartools_dict` gains a `raw_xml` arg; when edgartools returns empty `security_info.cusip` (always, today), backfill `issuer_cusip` from the helper. Issuer CIK also taken from the helper (zero-padded) so the filing's issuer identity no longer depends on edgartools' buggy issuer parse. edgartools still supplies reporting-persons + class title (those work).
+
+### 3. Fix the rewash path
+`_extract_issuer` (in-house parser, used by `rewash._apply_blockholders`) routes through the same helper.
+
+### 4. Correct resolution: CUSIP-primary + single-class CIK fallback
+Replace `_resolve_cusip_to_instrument_id(conn, cusip)` with
+`_resolve_issuer_to_instrument_id(conn, *, cusip, cik) -> int | None`:
+1. CUSIP → `external_identifiers WHERE provider IN ('sec','openfigi') AND identifier_type='cusip'`, ORDER BY is_primary DESC, external_identifier_id ASC (mirrors `_load_cusip_map` precedence + the approved OpenFIGI fallback, settled 2026-05-22). Precise, share-class-correct.
+2. If unresolved AND `cik` present: `siblings = siblings_for_issuer_cik(conn, cik)`. If `len(siblings) == 1` → that instrument (single-class issuer — safe, broader coverage: 5,327 CIK mappings vs 2,927 sec CUSIP). If `len != 1` → None (multi-class with no resolvable CUSIP is genuinely ambiguous on share class — leave unresolved; never fabricate an attribution, never fan out: a holder owns ONE class).
+
+Wire into all three callers: `_parse_13dg` (manifest), legacy `blockholders.py` ingest (`:668`), rewash `_apply_blockholders`.
+
+### 5. parser_version bump → re-drain
+Bump `_PARSER_VERSION_13DG` so the manifest flips `sec_13d`/`sec_13g` rows back to `pending` for re-parse through the fixed extractor (standard rewash trigger).
+
+## Invariants preserved
+- #1102 CUSIP=security / CIK=entity; multi-class needs CUSIP (don't re-break PR11).
+- No fuzzy name/class matching (sec-edgar skill). securities_class_title is NOT used to guess a sibling.
+- Manifest CHECK `subject_type='blockholder_filer' ⇒ instrument_id IS NULL` (prevention-log #1508) — unchanged; resolution stays at parse-time on the observation/`blockholder_filings` row, not the manifest row.
+- ETF trust-CIK explosion (settled #1577) is N/A — ETFs hold no `(sec,cik)` row, so `siblings_for_issuer_cik` never returns a trust fan-out.
+- Audit trail: CUSIP-unresolved-and-multi-class accessions still write `blockholder_filings` rows with `instrument_id=NULL` (status `partial`), as today.
+
+## Tests
+- Pure: `extract_issuer_identity_from_primary_doc` on a real-shape `<issuerCusips><issuerCusipNumber>` fixture → correct cik+cusip; on legacy `<issuerCUSIP>`/absent → Nones.
+- Pure: `_resolve_issuer_to_instrument_id` — CUSIP resolves (precise); CUSIP-miss + single-class CIK → CIK instrument; CUSIP-miss + multi-class CIK → None; CUSIP-miss + no CIK → None. (DB-backed, minimal.)
+- Adapter: edgartools-empty-cusip + raw_xml → filing carries the backfilled CUSIP.
+
+## DoD (ETL clauses 8-12)
+- Backfill: `POST /jobs/sec_rebuild/run {"source":"sec_13d"}` + `{"source":"sec_13g"}` on dev (parser_version bump auto-flips rows pending; re-drain through fixed extractor).
+- Verify: `ownership_blockholders_current` > 0; `/instruments/{sym}/ownership-rollup` shows a blockholders wedge (deduped vs 13F by CIK, priority form4>form3>13d/g>def14a>13f). Panel incl. a known activist target.
+- Cross-source: spot-check one issuer's 13D holder vs SEC EDGAR direct (e.g. the filing's reported % of class).
+- Record commit SHA + figures per clause 12.
+
+## Codex ckpt-1 — findings + resolutions (supersede above where noted)
+
+- **HIGH — three parse paths, two extractors (corrects §2/§3).** Verified: (1) manifest `_parse_13dg` AND (3) rewash `_apply_blockholders` (rewash_filings.py:622-631) BOTH use edgartools + `build_filing_from_edgartools_dict`; (2) legacy `blockholders.py::_ingest_single_accession` (:646) uses in-house `parse_primary_doc`. So: fix the **adapter** (backfill from helper, given raw_xml) → covers manifest + rewash; fix the **in-house `_extract_13d`/`_extract_13g`** (via helper) → covers legacy ingest only. Rewash passes its stored body (`raw_doc` payload) into the adapter as `raw_xml`.
+- **HIGH — deterministic provider precedence.** CLRB's `sec` CUSIP row is `is_primary=FALSE`, so `is_primary DESC` alone can let an `openfigi` row win on `external_identifier_id` tiebreak. Resolution ORDER BY = `CASE provider WHEN 'sec' THEN 0 ELSE 1 END, is_primary DESC, external_identifier_id ASC` (sec canonical).
+- **MED — scope, don't replace.** Keep `blockholders._resolve_cusip_to_instrument_id` (cusip-only building block; other non-13D/G caller at blockholders.py:1001 untouched). ADD `_resolve_issuer_to_instrument_id(conn, *, cusip, cik)` and switch only the 3 13D/G callers (manifest :334, legacy :668, rewash :755).
+- **MED — preserve non-empty edgartools identity.** Adapter: `issuer_cusip = helper_cusip or edgartools_cusip`; `issuer_cik = helper_cik or edgartools_cik` (helper preferred; edgartools retained when helper returns None on an old/odd shape — never NULL a valid parsed value).
+- **MED — helper normalization.** CIK → strip + zero-pad-10 (None if non-numeric); CUSIP → `strip().upper()`, return None unless exactly 9 alphanumeric chars (CINS allowed — leading letter is alnum). Malformed → None (not poisoned logs / failed lookups).
+- **MED — audit covers all unresolved.** `instrument_id=NULL` + log `partial` for EVERY unresolved case (CUSIP-miss + multi-class, + no-CIK, + zero-siblings) — not just multi-class. (Existing code already writes the row regardless; preserved.)
+- **LOW — regression tests added:** provider precedence sec>openfigi; lowercase/whitespace CUSIP normalization; adapter `raw_xml=None`/helper-None preserves non-empty edgartools fields; manifest does NOT write `sec_filing_manifest.instrument_id` for `blockholder_filer` rows.
+- **LOW — re-drain acceptance.** `sec_rebuild` flips parser-version-stale rows to `pending`; the manifest worker RE-FETCHES primary_doc.xml + re-parses (parse uses freshly-fetched XML, not the stored raw); `_record_ingest_attempt` upserts so old `partial` logs are overwritten with `success`.
+
+## Out of scope
+- Pre-2024-12-18 HTML 13D/G (retention floor; edgartools returns None — unchanged).
+- Reporting-person field correctness in the in-house parser (rewash) beyond issuer identity — separate if needed.
+- `blockholders.py:1001` (`holding.cusip`) non-13D/G resolver caller — untouched.

--- a/tests/test_13dg_issuer_resolution.py
+++ b/tests/test_13dg_issuer_resolution.py
@@ -1,0 +1,173 @@
+"""13D/G issuer-identity extraction + adapter backfill (#1628) — pure.
+
+The modern (post-2024-12-18 mandate) Schedule 13D/G XML nests the issuer
+CUSIP as ``<issuerCusips>/<issuerCusipNumber>``. edgartools 5.30.2 and
+the legacy in-house extractors read the stale flat ``<issuerCUSIP>``
+element and returned an empty CUSIP for every modern filing, so
+CUSIP-only resolution never resolved and blockholders never populated.
+
+These tests pin the correct-tag extractor + CUSIP normalisation and the
+adapter's helper-backfill / edgartools-preserve behaviour. They are pure
+(no DB) so they run on the fast push gate. The DB-backed resolver matrix
+lives in ``tests/test_13dg_resolver_db.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.providers.implementations.sec_13dg import (
+    IssuerIdentity,
+    _normalise_cusip,
+    extract_issuer_identity_from_primary_doc,
+)
+from app.services.manifest_parsers._schedule13_adapter import (
+    build_filing_from_edgartools_dict,
+)
+
+# ---------------------------------------------------------------------------
+# _normalise_cusip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("15117f880", "15117F880"),  # upper-cased
+        ("  15117F880  ", "15117F880"),  # stripped
+        ("15117F880", "15117F880"),
+        ("G0R21F121", "G0R21F121"),  # CINS (foreign) — leading letter is alnum
+        (None, None),
+        ("", None),
+        ("123", None),  # too short
+        ("1234567890", None),  # too long (10)
+        ("15117F88!", None),  # non-alphanumeric
+    ],
+)
+def test_normalise_cusip(raw: str | None, expected: str | None) -> None:
+    assert _normalise_cusip(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# extract_issuer_identity_from_primary_doc
+# ---------------------------------------------------------------------------
+
+
+def _doc(issuer_inner: str, cover_inner: str = "") -> str:
+    return (
+        "<edgarSubmission><formData>"
+        f"<issuerInfo>{issuer_inner}</issuerInfo>"
+        f"<coverPageHeader>{cover_inner}</coverPageHeader>"
+        "</formData></edgarSubmission>"
+    )
+
+
+def test_extract_reads_unified_mandate_schema() -> None:
+    xml = _doc(
+        "<issuerCik>0001279704</issuerCik>"
+        "<issuerCusips><issuerCusipNumber>15117F880</issuerCusipNumber></issuerCusips>"
+        "<issuerName>CELLECTAR BIOSCIENCES, INC.</issuerName>",
+        "<securitiesClassTitle>Common Stock</securitiesClassTitle>",
+    )
+    assert extract_issuer_identity_from_primary_doc(xml) == IssuerIdentity(
+        cik="0001279704",
+        cusip="15117F880",
+        name="CELLECTAR BIOSCIENCES, INC.",
+        class_title="Common Stock",
+    )
+
+
+def test_extract_legacy_flat_tag_fallback_and_cik_zero_pad() -> None:
+    # Pre-unified fixtures used the flat <issuerCIK>/<issuerCUSIP> tags.
+    xml = _doc("<issuerCIK>37912</issuerCIK><issuerCUSIP>518439104</issuerCUSIP>")
+    ident = extract_issuer_identity_from_primary_doc(xml)
+    assert ident.cik == "0000037912"  # zero-padded to 10
+    assert ident.cusip == "518439104"
+
+
+def test_extract_missing_cusip_is_none_cik_preserved() -> None:
+    ident = extract_issuer_identity_from_primary_doc(_doc("<issuerCik>0000037912</issuerCik>"))
+    assert ident.cik == "0000037912"
+    assert ident.cusip is None
+
+
+def test_extract_malformed_cusip_normalised_to_none() -> None:
+    xml = _doc(
+        "<issuerCik>0000037912</issuerCik><issuerCusips><issuerCusipNumber>abc</issuerCusipNumber></issuerCusips>"
+    )
+    assert extract_issuer_identity_from_primary_doc(xml).cusip is None
+
+
+def test_extract_non_numeric_cik_is_none() -> None:
+    assert extract_issuer_identity_from_primary_doc(_doc("<issuerCik>x12</issuerCik>")).cik is None
+
+
+def test_extract_unparseable_xml_returns_all_none() -> None:
+    assert extract_issuer_identity_from_primary_doc("<not-closed") == IssuerIdentity(None, None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Adapter backfill (SimpleNamespace fakes the edgartools parse dict)
+# ---------------------------------------------------------------------------
+
+_UNIFIED_XML = _doc(
+    "<issuerCik>0000037912</issuerCik>"
+    "<issuerCusips><issuerCusipNumber>518439104</issuerCusipNumber></issuerCusips>"
+    "<issuerName>ACME INC</issuerName>"
+)
+
+
+def _fake_parsed(*, edgartools_cusip: str = "") -> dict:
+    person = SimpleNamespace(
+        name="Holder LP",
+        cik="0000123456",
+        no_cik=False,
+        member_of_group="b",
+        type_of_reporting_person="IN",
+        citizenship="DE",
+        sole_voting_power=1000,
+        shared_voting_power=0,
+        sole_dispositive_power=1000,
+        shared_dispositive_power=0,
+        aggregate_amount=1000,
+        percent_of_class=5,
+    )
+    return {
+        "issuer_info": SimpleNamespace(cik="0000037912", name="ACME INC", cusip=""),
+        "security_info": SimpleNamespace(cusip=edgartools_cusip, title="Common Stock"),
+        "reporting_persons": [person],
+        "date_of_event": "2026-01-15",
+    }
+
+
+def _build(parsed: dict, raw_xml: str | None):
+    return build_filing_from_edgartools_dict(
+        parsed,
+        source="sec_13d",
+        manifest_form="SC 13D",
+        manifest_filer_cik="0000999999",
+        raw_xml=raw_xml,
+    )
+
+
+def test_adapter_backfills_cusip_from_raw_xml() -> None:
+    # edgartools returns an empty CUSIP (the bug); the adapter backfills
+    # it from the unified mandate schema in the raw body.
+    filing = _build(_fake_parsed(edgartools_cusip=""), _UNIFIED_XML)
+    assert filing.issuer_cusip == "518439104"
+    assert filing.issuer_cik == "0000037912"
+
+
+def test_adapter_preserves_edgartools_cusip_when_no_raw_xml() -> None:
+    filing = _build(_fake_parsed(edgartools_cusip="999999999"), None)
+    assert filing.issuer_cusip == "999999999"  # helper not run — edgartools value kept
+
+
+def test_adapter_helper_none_preserves_edgartools_cusip() -> None:
+    # raw_xml present but carries no issuer CUSIP -> helper.cusip is None
+    # -> the non-empty edgartools value is preserved (never nulled out).
+    bare = _doc("<issuerCik>0000037912</issuerCik>")
+    filing = _build(_fake_parsed(edgartools_cusip="888888888"), bare)
+    assert filing.issuer_cusip == "888888888"

--- a/tests/test_13dg_resolver_db.py
+++ b/tests/test_13dg_resolver_db.py
@@ -1,0 +1,71 @@
+"""DB-backed matrix for ``_resolve_issuer_to_instrument_id`` (#1628).
+
+CUSIP-primary resolution (security-precise, settled #1102), deterministic
+``sec`` > ``openfigi`` provider precedence, and the single-class-only CIK
+fallback (multi-class / no-CIK / malformed-CIK → None — never guess the
+share class, never fan out). Auto-marked ``db`` (pulls ``ebull_test_conn``).
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from app.services.blockholders import _resolve_issuer_to_instrument_id
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, country, is_tradable)
+        VALUES (%s, %s, %s, '4', 'USD', 'US', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+
+
+def _seed_extid(
+    conn: psycopg.Connection[tuple],
+    iid: int,
+    provider: str,
+    id_type: str,
+    value: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, %s, %s, %s, FALSE)
+        ON CONFLICT DO NOTHING
+        """,
+        (iid, provider, id_type, value),
+    )
+
+
+def test_resolve_issuer_to_instrument_id(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    for iid, sym in [(900001, "AAA"), (900002, "BBB"), (900003, "CCC"), (900004, "DDD")]:
+        _seed_instrument(conn, iid, sym)
+
+    # 1. CUSIP-primary (+ normalisation: lowercase/whitespace still resolves).
+    _seed_extid(conn, 900001, "sec", "cusip", "111111111")
+    assert _resolve_issuer_to_instrument_id(conn, cusip="111111111", cik=None) == 900001
+    assert _resolve_issuer_to_instrument_id(conn, cusip="  111111111  ", cik=None) == 900001
+
+    # 2. Provider precedence: same CUSIP under BOTH openfigi + sec -> sec wins.
+    _seed_extid(conn, 900002, "openfigi", "cusip", "222222222")
+    _seed_extid(conn, 900003, "sec", "cusip", "222222222")
+    assert _resolve_issuer_to_instrument_id(conn, cusip="222222222", cik=None) == 900003
+
+    # 3. Single-class CIK fallback when the CUSIP is absent / unresolved.
+    _seed_extid(conn, 900004, "sec", "cik", "0000900004")
+    assert _resolve_issuer_to_instrument_id(conn, cusip="", cik="0000900004") == 900004
+    assert _resolve_issuer_to_instrument_id(conn, cusip="ZZZZZZZZZ", cik="0000900004") == 900004
+
+    # 4. Multi-class CIK (2 instruments) -> None (never guess the class / fan out).
+    _seed_extid(conn, 900001, "sec", "cik", "0000900099")
+    _seed_extid(conn, 900002, "sec", "cik", "0000900099")
+    assert _resolve_issuer_to_instrument_id(conn, cusip="", cik="0000900099") is None
+
+    # 5. No CUSIP + no CIK -> None. Malformed CIK -> None (caught, not a crash).
+    assert _resolve_issuer_to_instrument_id(conn, cusip="", cik=None) is None
+    assert _resolve_issuer_to_instrument_id(conn, cusip="", cik="not-a-cik") is None

--- a/tests/test_sec_13dg_parser.py
+++ b/tests/test_sec_13dg_parser.py
@@ -264,10 +264,30 @@ def test_parse_13d_no_reporters_raises() -> None:
         parse_primary_doc(_13d_xml(reporters_xml=""))
 
 
-def test_parse_13d_missing_issuer_cusip_raises() -> None:
+def test_parse_13d_missing_issuer_cusip_does_not_raise() -> None:
+    # #1628: the issuer CUSIP is no longer required — an absent one
+    # leaves ``issuer_cusip`` empty and resolution falls back to the
+    # single-class CIK path. (Previously a missing <issuerCUSIP> raised
+    # ValueError, which — combined with the stale-tag read — tombstoned
+    # every modern filing.)
     xml = _13d_xml().replace("<issuerCUSIP>518439104</issuerCUSIP>", "")
-    with pytest.raises(ValueError, match="<issuerCUSIP>"):
-        parse_primary_doc(xml)
+    parsed = parse_primary_doc(xml)
+    assert parsed.issuer_cusip == ""
+    assert parsed.issuer_cik  # CIK is still required + present
+
+
+def test_parse_13d_reads_unified_mandate_cusip_tag() -> None:
+    # #1628: the post-2024-12-18 mandate XML nests the CUSIP as
+    # <issuerCusips><issuerCusipNumber>; the stale flat <issuerCUSIP>
+    # read (edgartools + the legacy in-house extractor) returned empty.
+    # The shared extractor reads the nested tag first, so a modern
+    # filing resolves a real CUSIP.
+    xml = _13d_xml().replace(
+        "<issuerCUSIP>518439104</issuerCUSIP>",
+        "<issuerCusips><issuerCusipNumber>518439104</issuerCusipNumber></issuerCusips>",
+    )
+    parsed = parse_primary_doc(xml)
+    assert parsed.issuer_cusip == "518439104"
 
 
 def test_parse_13d_missing_reporter_name_raises() -> None:


### PR DESCRIPTION
## Summary

Blockholders (13D/G) never populated — `ownership_blockholders_current` = **0 rows ever** despite ~150k filings on file and a registered, working parser. The ownership panel's blockholders wedge could never render. Root cause is a parser **tag bug**, not a CIK-vs-CUSIP design choice.

Closes #1628.

## Root cause (empirically proven — acc `0001274173-26-000157`, CLRB)

The post-2024-12-18 SEC Schedule 13 mandate XML nests the issuer CUSIP as:

```xml
<issuerInfo>
  <issuerCik>0001279704</issuerCik>
  <issuerCusips><issuerCusipNumber>15117F880</issuerCusipNumber></issuerCusips>
</issuerInfo>
```

Both parsers read the **stale flat `<issuerCUSIP>`** tag:
- edgartools 5.30.2 (`schedule13.py:191`) — the documented edgartools drift cliff (#932/G15). CIK extracts fine.
- in-house `_extract_13d`/`_extract_13g` (`providers/implementations/sec_13dg.py`).

So `filing.issuer_cusip = ''` for every modern 13D/G → the CUSIP-only resolver returned `None` → the observation write was skipped → blockholders stayed empty. Direct XML parse gives `issuerCusipNumber=15117F880` → resolves to instrument 1049521; issuer CIK 0001279704 → same.

## Why CUSIP, not "just use CIK" (settled #1102)

CUSIP = security (per-share-class); CIK = entity. 56 issuer CIKs in dev map to >1 instrument (GOOG/GOOGL-style siblings). A 13D against GOOGL carries GOOGL's CUSIP; CIK-only resolution is ambiguous for those and would re-break the PR11 Codex-1b BLOCKING (routing GOOG-A 13D onto GOOGL-C). CUSIP is the precise key; CIK is a single-class-only fallback.

## Change

- **Correct-tag extractor** `extract_issuer_identity_from_primary_doc` (+ `_issuer_identity_from_root`) reads `<issuerCusips>/<issuerCusipNumber>` + `<issuerCik>` (legacy flat tags kept as fall-throughs), normalises (CUSIP `strip().upper()` + 9-alnum-or-None; CIK zero-pad-or-None). Single source of truth for the modern shape.
- **Adapter backfill** (`build_filing_from_edgartools_dict`, +`raw_xml` arg): when edgartools returns an empty CUSIP, backfill from the helper — helper-preferred, edgartools-value preserved when the helper returns None. Covers the **manifest drain + rewash** (both use the adapter).
- **In-house parser** `_extract_13d`/`_extract_13g` route through the shared helper; no longer raise on a missing CUSIP (resolution falls back to CIK). Covers the **legacy ingest** path.
- **New resolver** `_resolve_issuer_to_instrument_id(cusip, cik)`: CUSIP → `external_identifiers WHERE provider IN ('sec','openfigi')` with deterministic `CASE provider WHEN 'sec' THEN 0 ELSE 1 END, is_primary DESC, external_identifier_id ASC` (sec canonical). If unresolved + CIK maps to **exactly one** instrument → that instrument; multi-class / zero / malformed CIK → `None` (never guess share class, never fan out). Wired into all three 13D/G callers (manifest `:334`, legacy `:668`, rewash `:755`).
- `_PARSER_VERSION_13DG` v1→v2 flips `sec_13d`/`sec_13g` manifest rows to `pending` for re-drain.

`_resolve_cusip_to_instrument_id` (cusip-only) is kept as a building block — its remaining callers are 13F/N-PORT, untouched (confirmed by Codex).

## Security model

No new data exposure. 13D/G XML is fetched server-side from sec.gov and persisted to `filing_raw_documents`; parsing uses stdlib `ElementTree` consistent with every other SEC parser in the repo (documented `# noqa` trusted-source convention; defusedxml is used nowhere). The resolver is parameterised SQL. Manifest CHECK `subject_type='blockholder_filer' ⇒ instrument_id IS NULL` is unchanged — resolution stays at parse-time on the observation/`blockholder_filings` row.

## Tradeoffs / invariants

- Multi-class issuer with an unresolved CUSIP is left **unresolved** (truthful — we can't determine the share class). No fuzzy class-title matching (settled).
- ETF trust-CIK fan-out (settled #1577) is N/A — ETFs hold no `(sec,cik)` row, so the CIK fallback never returns a trust explosion.
- Pre-2024-12-18 HTML 13D/G stays out of scope (retention floor; edgartools returns None — unchanged).

## Verification (DoD 8-12)

- Gates @ `e7c34ebd`: fast tier **4053 passed**, smoke **129 passed**, pyright 0 errors, ruff clean. 18 pure extractor/adapter/normalise tests (fast tier) + 1 db resolver matrix (CUSIP-primary, provider precedence sec>openfigi, single-class CIK fallback, multi-class→None) + 2 parser tests.
- **Dev-verify (operator-visible figure):** drove the fixed path for the CLRB sample → `ownership_blockholders_current` **0 → 1**: CLRB ← **Janus Henderson Group PLC, 798,382 shares, 9.99% of class (SCHEDULE 13G)**.
- **Cross-source (clause 9):** 9.99% is the `classPercent` from the real SEC 13G cover page (passive filer just under the 10% threshold) — cross-sourceable to EDGAR direct.
- Codex ckpt-1 on the spec (8 findings folded: provider precedence, rewash-uses-edgartools, scope-don't-replace, preserve-edgartools, normalisation, audit, tests, re-drain acceptance) + adversarial fresh-agent review on the diff (**no findings**).

## Operator follow-up (full re-drain)

This commit fixes the data path; the existing 150k `sec_13d`/`sec_13g` manifest rows re-drain through the fixed parser once the jobs process is restarted onto this commit, then `POST /jobs/sec_rebuild/run {"source":"sec_13d"}` + `{"source":"sec_13g"}`. Same merge-then-operator-backfill pattern as the rest of R3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
