### PR TITLE
feat(#591): risk-metrics evidence layer + endpoint (PR-B)

### DIFF
--- a/.claude/skills/market-data/SKILL.md
+++ b/.claude/skills/market-data/SKILL.md
@@ -29,3 +29,17 @@ Return:
 - summary
 - structured fields
 - confidence / uncertainty note where relevant
+
+## Risk-metrics conventions (#591, `app/services/risk_metrics.py`, `risk_v1`)
+
+Price-derived risk stats are computed from the `price_daily.close` chain (instrument + SPY benchmark). Pinned conventions — keep identical across any future risk math:
+
+- **Returns: SIMPLE** (`close[i]/close[i-1] - 1`) between consecutive *surviving* rows. A close is valid iff finite AND `> 0`; an invalid row **breaks the chain** (no gap-spanning synthetic return); the return is keyed to the later close's date.
+- **Volatility: annualized realized** = sample std (n−1) of daily returns × `sqrt(TRADING_DAYS)`, `TRADING_DAYS = 252` (a fixed constant — never derived from observed row count). This realized vol is **NOT** the scorer's TA "volatility-regime" term (Bollinger/ATR) — distinct figure, distinct purpose.
+- **CAGR: calendar-time** `(final/first)^(365/calendar_days) - 1`, NOT `(252/n_returns)` (the trading-day form silently inflates the figure when the survivor chain has gaps). Calmar's numerator uses the SAME annualizer.
+- **Calmar** = `annualized_return / abs(max_drawdown)` (Calmar, NOT Sharpe — eBull has no risk-free-rate series, so an honest Sharpe is impossible; never label it Sharpe). `abs(max_dd)` near 0 → null.
+- **Beta vs SPY: OLS on DATE-ALIGNED returns** — pair only dates where BOTH series have a return (intersection of date keys; NEVER positional-zip — holiday gaps differ between an instrument and SPY and a positional zip silently mis-pairs them). `beta = cov/var_m`, `r2 = corr²`; `var_m=0` → beta null; `var_i=0 or var_m=0` → r2 null. No `alpha` in v1.
+- **var_5 (empirical VaR)** = type-7 linear-interpolation 5th percentile of daily returns, **signed** (a loss is negative — stored as-is, never abs'd). skew/excess-kurtosis use biased ÷n central moments (Fisher: `kurtosis − 3`); flagged low-sample below ~250 obs.
+- **Float island:** skew / excess-kurtosis / percentile computed in float (numpy) then quantized to Decimal at the persistence boundary; everything else (returns/vol/drawdown/beta/CAGR/Calmar) end-to-end Decimal.
+- **Windows** 1y/3y/full: standalone metrics use the instrument's valid history *within the window*; benchmark metrics (beta, excess) use the aligned-overlap window. Min-obs: vol/beta need ≥60 returns; annualized figures flag `partial_window` below ~252 returns.
+- v1 is **price return, not total return** (dividend-adjusted TR is a filed follow-up). Persisted in the two-layer `instrument_risk_metrics_*` tables; served by `GET /instruments/{symbol}/risk-metrics`.

--- a/.claude/skills/metrics-analyst/SKILL.md
+++ b/.claude/skills/metrics-analyst/SKILL.md
@@ -22,7 +22,8 @@
 | AUM | Risk + portfolio | positions × quotes × cash_ledger | `/portfolio` |
 | Available for deployment | Risk + portfolio | `budget_config` + computed | `/budget` |
 | Backfill / SEC manifest pending count | Pipeline | `sec_filing_manifest`, `data_freshness_index` | `/system/jobs`, `/system/bootstrap/status` |
-| Beta vs SPY | Market data | (deferred) | — |
+| Beta vs SPY | Risk metrics | `instrument_risk_metrics_current.beta` | `/instruments/{symbol}/risk-metrics` |
+| Risk drill (vol / drawdown / Calmar / VaR / trailing-vs-SPY) | Risk metrics | `instrument_risk_metrics_current` (`risk_v1`) | `/instruments/{symbol}/risk-metrics` |
 | Blockholder ownership % | Ownership | `ownership_blockholders_current` | `/instruments/{symbol}/ownership-rollup` |
 | Bollinger bands (20, 2σ) | Market data | `price_daily.bb_upper / bb_lower` | (TA scoring) |
 | Bootstrap stage final row count | Pipeline | `bootstrap_stages.rows_processed` | `/processes/bootstrap/overview` |
@@ -311,8 +312,21 @@ All US fundamentals come from SEC XBRL via Company Facts API (settled in `docs/s
 - Today: `price_daily.volume` per day; live-tick volume not aggregated.
 - Planned: rolling intraday volume against running average.
 
-### VWAP / Realised volatility / Beta vs SPY
-- All **deferred**. eToro candles do not include intraday VWAP. ATR-14 stored at `price_daily.atr_14` (sql/025) consumed by scoring as proxy.
+### VWAP
+- **Deferred.** eToro candles do not include intraday VWAP.
+
+### Risk metrics — risk drill (#591, `risk_v1`)
+- **Definition:** versioned (`metric_version="risk_v1"`), windowed (`window_key ∈ 1y/3y/full`), quality-flagged risk scalars per instrument: CAGR + excess-vs-SPY, max/current drawdown (+ peak/trough dates), annualized realized vol, OLS beta vs SPY (+ r2, n_obs), return distribution (skew, excess-kurtosis, signed empirical var_5, worst/best day), Calmar, trailing 1m/3m/6m/1y (+ excess vs SPY).
+- **Formula / conventions:** see `.claude/skills/market-data/SKILL.md` §"Risk-metrics conventions" (simple-return valid-close chain; vol ×√252; calendar-time CAGR; date-aligned beta; type-7 signed var_5; float island for moments; window slicing).
+- **Source data:** `price_daily.close` chain (instrument + SPY benchmark, ingested by PR-A `daily_candle_refresh`).
+- **Transform:** `app/services/risk_metrics.py::compute_and_store_risk_metrics` (pure compute + persist). Each metric carries a per-metric `*_status` ∈ {ok, insufficient_history, partial_window, benchmark_missing, benchmark_insufficient_history, invalid_price_chain, stale}.
+- **Storage (two-layer):** `instrument_risk_metrics_observations` (append-only, partitioned quarterly by `as_of_date`, PK incl `computed_at` — the audit log; `price_daily` is mutable via ON CONFLICT DO UPDATE so past metrics are NOT reconstructable, hence the immutable observation row) + `instrument_risk_metrics_current` (latest write-through, fast reads) — `sql/198`.
+- **Service / job:** `risk_metrics_refresh` (DB-only) — orchestrator DAG layer `risk_metrics` (`dependencies=("candles",)`, weekly cadence, `is_blocking=False`); also manually triggerable (`risk_metrics` JobLock lane). NOT a standalone cron.
+- **Endpoint:** `GET /instruments/{symbol}/risk-metrics` — persisted scalars + per-metric statuses + on-read display series (drawdown curve, rolling-vol line, return histogram, beta scatter) cut at the persisted `as_of_date`.
+- **Chart:** `RiskPage.tsx` (PR-C, planned).
+- **Cadence:** weekly (annualized ≥1y-window stats move negligibly day-to-day; `as_of_date` surfaced so staleness is honest).
+- **Caveats:** v1 is **price return, not total return** (TR follow-up). **Calmar, NOT Sharpe** (no risk-free-rate series). Realized vol here is **distinct** from the scorer's TA "volatility-regime" term (Bollinger/ATR) — risk context, NOT a v1.1 score input. Sector-relative views cut (no GICS/SPDR crosswalk — follow-up). Thesis/ranking consumption are filed follow-ups (#1632/#1633).
+- **Validation:** cross-source one beta or vol vs a public source (e.g. AAPL ~1y vol/beta); confirm `/instruments/AAPL/risk-metrics` renders sane scalars + statuses after a dev `risk_metrics_refresh`.
 
 ### Total return windows
 - 1d / 1w / 1m: dashboard via `/portfolio/rolling-pnl` ([app/api/portfolio.py:710](../../../app/api/portfolio.py#L710)). Anchor uses each position's `latest_close` `price_date` — never wall-clock — so stale candle doesn't collapse the bucket (Codex #387 phase 2 finding).

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -57,6 +57,14 @@ from app.services.operators import (
     NoOperatorError,
     sole_operator_id,
 )
+from app.services.risk_metrics import (
+    RISK_METRICS_VERSION,
+    annualized_vol,
+    drawdown_curve,
+    load_close_series,
+    ols_beta,
+    simple_returns,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -4666,4 +4674,361 @@ def get_instrument_ownership_rollup_csv(
         headers={
             "Content-Disposition": f'attachment; filename="{symbol_clean}_ownership_rollup.csv"',
         },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Risk metrics (#591 PR-B, Task B6) — read-through of the persisted two-layer
+# risk-metrics tables plus on-read display series.
+# ---------------------------------------------------------------------------
+
+
+class RiskWindowMetrics(BaseModel):
+    """All persisted risk scalars + per-metric statuses for ONE window.
+
+    Every numeric field is a FRACTION (0.10 == 10%) or dimensionless, and
+    nullable — a thin / invalid history yields NULL plus a flagging status,
+    never a fabricated zero. Statuses pass through verbatim from the persisted
+    columns.
+    """
+
+    window_key: str
+    cagr: Decimal | None
+    excess_cagr_vs_spy: Decimal | None
+    max_drawdown: Decimal | None
+    current_drawdown: Decimal | None
+    vol_annualized: Decimal | None
+    beta: Decimal | None
+    beta_r2: Decimal | None
+    calmar: Decimal | None
+    skew: Decimal | None
+    excess_kurtosis: Decimal | None
+    var_5: Decimal | None
+    worst_day: Decimal | None
+    best_day: Decimal | None
+    trailing_1m: Decimal | None
+    trailing_3m: Decimal | None
+    trailing_6m: Decimal | None
+    trailing_1y: Decimal | None
+    excess_trailing_1m: Decimal | None
+    excess_trailing_3m: Decimal | None
+    excess_trailing_6m: Decimal | None
+    excess_trailing_1y: Decimal | None
+    n_returns: int | None
+    beta_n_obs: int | None
+    window_days: int | None
+    cagr_status: str | None
+    vol_status: str | None
+    beta_status: str | None
+    drawdown_status: str | None
+    distribution_status: str | None
+    calmar_status: str | None
+    trailing_status: str | None
+    excess_cagr_status: str | None
+
+
+class DrawdownPoint(BaseModel):
+    """One point on the running-peak underwater curve (dd ≤ 0)."""
+
+    date: date
+    drawdown: Decimal
+
+
+class RollingVolPoint(BaseModel):
+    """One point on the trailing rolling-volatility line (annualized fraction)."""
+
+    date: date
+    vol: Decimal
+
+
+class HistogramBin(BaseModel):
+    """One bin of the daily-return distribution histogram."""
+
+    lower: Decimal
+    upper: Decimal
+    count: int
+
+
+class BetaScatterPoint(BaseModel):
+    """One date-aligned (SPY return, instrument return) pair for the beta scatter."""
+
+    spy_return: Decimal
+    inst_return: Decimal
+
+
+class RiskSeries(BaseModel):
+    """On-read display series for the risk drill charts.
+
+    Computed at request time from the price series cut at the persisted
+    ``as_of_date`` (NOT persisted) — purely presentational. ``beta`` /
+    ``beta_r2`` here are the FULL-series fit shown alongside the scatter; the
+    per-window betas live on :class:`RiskWindowMetrics`. Beta fields are null and
+    ``beta_scatter`` empty when no benchmark series is available.
+    """
+
+    drawdown_curve: list[DrawdownPoint]
+    rolling_vol: list[RollingVolPoint]
+    return_histogram: list[HistogramBin]
+    beta_scatter: list[BetaScatterPoint]
+    beta: Decimal | None
+    beta_r2: Decimal | None
+
+
+class InstrumentRiskMetrics(BaseModel):
+    """Response shape for GET /instruments/{symbol}/risk-metrics.
+
+    ``windows`` is empty and ``series``/``as_of_date`` null when the instrument
+    has no persisted risk rows (never computed). ``benchmark_symbol`` is null
+    when no benchmark was resolved at compute time.
+    """
+
+    symbol: str
+    as_of_date: date | None
+    benchmark_symbol: str | None
+    metric_version: str
+    windows: list[RiskWindowMetrics]
+    series: RiskSeries | None
+
+
+# Display-series tuning. The rolling-vol window is in RETURNS (≈ trading days).
+_ROLLING_VOL_WINDOW = 30
+_HISTOGRAM_BINS = 30
+# Windows surfaced shortest → full.
+_RISK_WINDOW_ORDER: dict[str, int] = {"1y": 0, "3y": 1, "full": 2}
+
+
+def _rolling_vol_series(
+    inst_returns: list[tuple[date, Decimal]],
+    window: int = _ROLLING_VOL_WINDOW,
+) -> list[RollingVolPoint]:
+    """Trailing annualized-vol line: ``annualized_vol`` over the last ``window`` returns.
+
+    Keyed to the latest return's date in each trailing window. Empty until at
+    least ``window`` returns exist. Reuses the service ``annualized_vol`` so the
+    line and the scalar use identical math.
+    """
+    out: list[RollingVolPoint] = []
+    if len(inst_returns) < window:
+        return out
+    for i in range(window - 1, len(inst_returns)):
+        slice_vals = [r for _, r in inst_returns[i - window + 1 : i + 1]]
+        vol = annualized_vol(slice_vals)
+        if vol is not None:
+            out.append(RollingVolPoint(date=inst_returns[i][0], vol=vol))
+    return out
+
+
+def _return_histogram(
+    inst_returns: list[tuple[date, Decimal]],
+    bins: int = _HISTOGRAM_BINS,
+) -> list[HistogramBin]:
+    """Equal-width histogram of daily returns over [min, max].
+
+    A degenerate (constant) series collapses to a single unit-width bin around
+    the value so the chart still renders. Returns empty when there are no
+    returns.
+    """
+    vals = [r for _, r in inst_returns]
+    if not vals:
+        return []
+    lo = min(vals)
+    hi = max(vals)
+    if hi <= lo:
+        # Constant series — one bin centred on the value.
+        return [HistogramBin(lower=lo - Decimal("0.5"), upper=lo + Decimal("0.5"), count=len(vals))]
+    span = hi - lo
+    width = span / Decimal(bins)
+    counts = [0] * bins
+    for v in vals:
+        idx = int((v - lo) / width)
+        if idx >= bins:
+            idx = bins - 1  # the max value lands in the last bin
+        if idx < 0:
+            idx = 0
+        counts[idx] += 1
+    return [
+        HistogramBin(lower=lo + width * Decimal(i), upper=lo + width * Decimal(i + 1), count=counts[i])
+        for i in range(bins)
+    ]
+
+
+def _beta_scatter(
+    inst_returns: list[tuple[date, Decimal]],
+    spy_returns: list[tuple[date, Decimal]],
+) -> list[BetaScatterPoint]:
+    """Date-aligned (spy, inst) return pairs over the sorted date intersection.
+
+    Mirrors :func:`ols_beta`'s alignment (intersection, never positional-zip).
+    Empty when either side is empty.
+    """
+    inst_map = dict(inst_returns)
+    spy_map = dict(spy_returns)
+    shared = sorted(set(inst_map) & set(spy_map))
+    return [BetaScatterPoint(spy_return=spy_map[d], inst_return=inst_map[d]) for d in shared]
+
+
+@router.get("/{symbol}/risk-metrics", response_model=InstrumentRiskMetrics)
+def get_instrument_risk_metrics(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> InstrumentRiskMetrics:
+    """Persisted risk metrics + on-read display series for ``symbol``.
+
+    Reads ``instrument_risk_metrics_current`` (latest write-through, one row per
+    window). The honest-status contract is preserved end-to-end: every scalar
+    and its status pass through verbatim — NULLs are never coerced to zero, and
+    a flagging status (insufficient_history / partial_window / benchmark_*) is
+    surfaced as-is.
+
+    404 for an unknown symbol. 200 with empty ``windows`` / null ``as_of_date``
+    / null ``series`` when the instrument exists but has no persisted risk rows
+    (never computed). Otherwise the display series are recomputed at request
+    time from the price series cut at the persisted ``as_of_date``.
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+    out_symbol = str(inst_row["symbol"])  # type: ignore[arg-type]
+
+    with snapshot_read(conn):
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT
+                    window_key, as_of_date, benchmark_instrument_id,
+                    cagr, excess_cagr_vs_spy, max_drawdown, current_drawdown,
+                    vol_annualized, beta, beta_r2, calmar,
+                    skew, excess_kurtosis, var_5, worst_day, best_day,
+                    trailing_1m, trailing_3m, trailing_6m, trailing_1y,
+                    excess_trailing_1m, excess_trailing_3m,
+                    excess_trailing_6m, excess_trailing_1y,
+                    n_returns, beta_n_obs, window_days,
+                    cagr_status, vol_status, beta_status, drawdown_status,
+                    distribution_status, calmar_status, trailing_status,
+                    excess_cagr_status
+                FROM instrument_risk_metrics_current
+                WHERE instrument_id = %(iid)s
+                  AND metric_version = %(ver)s
+                """,
+                {"iid": instrument_id, "ver": RISK_METRICS_VERSION},
+            )
+            risk_rows = cur.fetchall()
+
+        if not risk_rows:
+            # Never computed — honest empty payload, not a 404.
+            return InstrumentRiskMetrics(
+                symbol=out_symbol,
+                as_of_date=None,
+                benchmark_symbol=None,
+                metric_version=RISK_METRICS_VERSION,
+                windows=[],
+                series=None,
+            )
+
+        # All windows share one as_of_date (the rebuild writes them together).
+        as_of_date: date = risk_rows[0]["as_of_date"]  # type: ignore[assignment]
+
+        # Resolve the benchmark symbol from the persisted benchmark_instrument_id.
+        benchmark_symbol: str | None = None
+        bench_id: int | None = None
+        for r in risk_rows:
+            if r["benchmark_instrument_id"] is not None:
+                bench_id = int(r["benchmark_instrument_id"])  # type: ignore[arg-type]
+                break
+        if bench_id is not None:
+            with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                cur.execute(
+                    "SELECT symbol FROM instruments WHERE instrument_id = %(id)s",
+                    {"id": bench_id},
+                )
+                bench_row = cur.fetchone()
+            if bench_row is not None:
+                benchmark_symbol = str(bench_row["symbol"])  # type: ignore[arg-type]
+
+        # Load the price series cut at the persisted as_of_date for the series.
+        inst_closes = load_close_series(conn, instrument_id, as_of_date)
+        spy_closes = load_close_series(conn, bench_id, as_of_date) if bench_id is not None else []
+
+    windows = [
+        RiskWindowMetrics(
+            window_key=str(r["window_key"]),
+            cagr=r["cagr"],
+            excess_cagr_vs_spy=r["excess_cagr_vs_spy"],
+            max_drawdown=r["max_drawdown"],
+            current_drawdown=r["current_drawdown"],
+            vol_annualized=r["vol_annualized"],
+            beta=r["beta"],
+            beta_r2=r["beta_r2"],
+            calmar=r["calmar"],
+            skew=r["skew"],
+            excess_kurtosis=r["excess_kurtosis"],
+            var_5=r["var_5"],
+            worst_day=r["worst_day"],
+            best_day=r["best_day"],
+            trailing_1m=r["trailing_1m"],
+            trailing_3m=r["trailing_3m"],
+            trailing_6m=r["trailing_6m"],
+            trailing_1y=r["trailing_1y"],
+            excess_trailing_1m=r["excess_trailing_1m"],
+            excess_trailing_3m=r["excess_trailing_3m"],
+            excess_trailing_6m=r["excess_trailing_6m"],
+            excess_trailing_1y=r["excess_trailing_1y"],
+            n_returns=r["n_returns"],
+            beta_n_obs=r["beta_n_obs"],
+            window_days=r["window_days"],
+            cagr_status=r["cagr_status"],
+            vol_status=r["vol_status"],
+            beta_status=r["beta_status"],
+            drawdown_status=r["drawdown_status"],
+            distribution_status=r["distribution_status"],
+            calmar_status=r["calmar_status"],
+            trailing_status=r["trailing_status"],
+            excess_cagr_status=r["excess_cagr_status"],
+        )
+        for r in risk_rows
+    ]
+    windows.sort(key=lambda w: _RISK_WINDOW_ORDER.get(w.window_key, 99))
+
+    # On-read display series over the full series (cut at as_of_date).
+    inst_returns = simple_returns(inst_closes)
+    spy_returns = simple_returns(spy_closes)
+    dd_points = [DrawdownPoint(date=d, drawdown=dd) for d, dd in drawdown_curve(inst_closes)]
+    rolling = _rolling_vol_series(inst_returns)
+    histogram = _return_histogram(inst_returns)
+    scatter = _beta_scatter(inst_returns, spy_returns)
+    fit = ols_beta(inst_returns, spy_returns) if spy_returns else None
+
+    series = RiskSeries(
+        drawdown_curve=dd_points,
+        rolling_vol=rolling,
+        return_histogram=histogram,
+        beta_scatter=scatter,
+        beta=fit.beta if fit is not None else None,
+        beta_r2=fit.r2 if fit is not None else None,
+    )
+
+    return InstrumentRiskMetrics(
+        symbol=out_symbol,
+        as_of_date=as_of_date,
+        benchmark_symbol=benchmark_symbol,
+        metric_version=RISK_METRICS_VERSION,
+        windows=windows,
+        series=series,
     )

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4889,25 +4889,30 @@ def get_instrument_risk_metrics(
     if not symbol_clean:
         raise HTTPException(status_code=400, detail="symbol is required")
 
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT instrument_id, symbol FROM instruments
-            WHERE UPPER(symbol) = %(s)s
-            ORDER BY is_primary_listing DESC, instrument_id ASC
-            LIMIT 1
-            """,
-            {"s": symbol_clean},
-        )
-        inst_row = cur.fetchone()
-
-    if inst_row is None:
-        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
-
-    instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
-    out_symbol = str(inst_row["symbol"])  # type: ignore[arg-type]
-
+    # All reads — symbol→id resolution, current rows, benchmark lookup, and the
+    # price series — run inside ONE snapshot so a concurrent universe /
+    # primary-listing change cannot mix two committed views (Codex ckpt-2 LOW;
+    # snapshot_read commits the pending txn on entry, so a pre-block lookup would
+    # be a different snapshot — prevention-log §snapshot_read).
     with snapshot_read(conn):
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT instrument_id, symbol FROM instruments
+                WHERE UPPER(symbol) = %(s)s
+                ORDER BY is_primary_listing DESC, instrument_id ASC
+                LIMIT 1
+                """,
+                {"s": symbol_clean},
+            )
+            inst_row = cur.fetchone()
+
+        if inst_row is None:
+            raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+        instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+        out_symbol = str(inst_row["symbol"])  # type: ignore[arg-type]
+
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
                 """

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -103,6 +103,7 @@ from app.workers.scheduler import (
     JOB_RAW_DATA_RETENTION_SWEEP,
     JOB_RETRY_DEFERRED,
     JOB_RETRY_SWEEPER,
+    JOB_RISK_METRICS_REFRESH,
     JOB_SEC_8K_EVENTS_INGEST,
     JOB_SEC_13F_FILER_DIRECTORY_SYNC,
     JOB_SEC_13F_QUARTERLY_SWEEP,
@@ -154,6 +155,7 @@ from app.workers.scheduler import (
     portfolio_eod_snapshot_job,
     raw_data_retention_sweep,
     retry_deferred_recommendations_job,
+    risk_metrics_refresh,
     sec_8k_events_ingest,
     sec_13f_filer_directory_sync,
     sec_13f_quarterly_sweep,
@@ -240,6 +242,12 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     JOB_MONITOR_POSITIONS: _adapt_zero_arg(monitor_positions_job),
     JOB_PORTFOLIO_EOD_SNAPSHOT: _adapt_zero_arg(portfolio_eod_snapshot_job),
     JOB_FX_HISTORY_BACKFILL: _adapt_zero_arg(fx_history_backfill_job),
+    # #591 PR-B — risk-metrics recompute. Orchestrator-driven (DAG layer
+    # "risk_metrics") + manual-trigger-only; NOT in SCHEDULED_JOBS (the
+    # layer cadence/freshness gate the DAG walk — a scheduled row would
+    # double-fire). Source-lock "risk_metrics" in MANUAL_TRIGGER_JOB_SOURCES;
+    # empty params in MANUAL_TRIGGER_JOB_METADATA.
+    JOB_RISK_METRICS_REFRESH: _adapt_zero_arg(risk_metrics_refresh),
     JOB_ATTRIBUTION_SUMMARY: _adapt_zero_arg(attribution_summary_job),
     JOB_SEED_COST_MODELS: _adapt_zero_arg(seed_cost_models),
     JOB_WEEKLY_REPORT: _adapt_zero_arg(weekly_report),

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -81,6 +81,7 @@ Lane = Literal[
     "db_cusip",
     "db_ownership_obs",
     "db_raw_sweep",
+    "risk_metrics",
     "bootstrap",
     "finra",
     "openfigi",
@@ -249,6 +250,17 @@ when one overruns). Scheduled-only, so NOT added to the
   schedules are staggered (backfill 03:00, sweep 03:30) so they never
   co-fire in practice.
 
+* ``risk_metrics`` — ``risk_metrics_refresh`` (#591 PR-B) only. The
+  orchestrator-driven weekly risk-metric recompute. DB-only producer (no
+  external host), so the lane is purely a write-overlap bucket, not a
+  rate limiter. Its own lane keeps it write-disjoint: it is the sole
+  writer of the risk-metrics store and reads ``price_daily`` MVCC-safe
+  against any concurrent candle writer. Reachable via the orchestrator
+  adapter inner-JobLock AND the operator manual-trigger path. NOT in
+  SCHEDULED_JOBS (the DAG layer's cadence/freshness gate the run; a
+  scheduled row would double-fire), so NOT added to the
+  ``bootstrap_stages.lane`` CHECK.
+
 The final lane is bootstrap-only:
 
 * ``bootstrap`` — ``bootstrap_orchestrator`` (G14). Deliberately
@@ -395,6 +407,14 @@ MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
     # idempotent upsert; invoker in app/jobs/runtime.py::_INVOKERS, empty
     # params in MANUAL_TRIGGER_JOB_METADATA.
     "fx_history_backfill": "db_eod_snapshot",
+    # risk_metrics_refresh — #591 PR-B weekly risk-metric recompute.
+    # Own write-disjoint lane (sole writer of the risk-metrics store; reads
+    # price_daily MVCC-safe). Orchestrator-driven (DAG layer "risk_metrics")
+    # + manual-trigger-only; NOT in SCHEDULED_JOBS (the layer cadence gates
+    # the DAG walk — a scheduled row would double-fire). Companion empty
+    # params in MANUAL_TRIGGER_JOB_METADATA; invoker in
+    # app/jobs/runtime.py::_INVOKERS.
+    "risk_metrics_refresh": "risk_metrics",
     # sec_rebuild — operator manual triage (#1155). Per-CIK
     # check_freshness probes against SEC submissions.json; shares the
     # 10 req/s SEC fair-use budget with every other sec_rate consumer.

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -230,6 +230,12 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
     # supported display currencies). Empty tuple completes the manual-only
     # triangle (source + metadata + invoker).
     "fx_history_backfill": (),
+    # risk_metrics_refresh — #591 PR-B weekly risk-metric recompute. No
+    # operator-tunable params (windows + benchmark set are fixed by the
+    # service). Empty tuple completes the manual-only triangle (source +
+    # metadata + invoker) so the manual API validator accepts a zero-param
+    # trigger.
+    "risk_metrics_refresh": (),
     # filing_events_skip_tier_cleanup — one-shot retroactive delete
     # (#1013). No operator-tunable params: ``batch_size`` is an
     # implementation knob (§6.5.7 item 2), kept internal. The explicit

--- a/app/services/risk_metrics.py
+++ b/app/services/risk_metrics.py
@@ -35,9 +35,14 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Literal, get_args
+from typing import Any, Literal, get_args
 
 import numpy as np
+import psycopg
+from psycopg import sql
+
+from app.db.snapshot import snapshot_read
+from app.workers.scheduler import BENCHMARK_SYMBOLS
 
 # ---------------------------------------------------------------------------
 # Public constants
@@ -56,6 +61,13 @@ MIN_OBS_MOMENTS = 250
 CALMAR_DD_EPSILON = Decimal("1e-9")
 
 WINDOW_KEYS: tuple[str, ...] = ("1y", "3y", "full")
+
+# The benchmark for beta / excess metrics. Resolved to an instrument_id at run
+# time (primary-listing tiebreak) the same way the candle-refresh scope does.
+SPY_SYMBOL = "SPY"
+
+# Chunk size for the batched current-table rebuild (~15k total rows / run).
+_REBUILD_BATCH = 500
 
 RiskStatus = Literal[
     "ok",
@@ -747,3 +759,428 @@ def compute_instrument_risk(
         distribution_status=dist_st,
         trailing_status=trailing_st,
     )
+
+
+# ---------------------------------------------------------------------------
+# DB persist layer (#591 PR-B, Task B3)
+# ---------------------------------------------------------------------------
+#
+# READ phase under snapshot_read (REPEATABLE READ): one consistent snapshot so
+# a concurrent candle refresh / correction cannot let two instruments see
+# different price states. COMPUTE phase in memory (pure). WRITE phase in a
+# separate READ COMMITTED transaction: content-dedup append into the
+# append-only observations log, then a deterministic rebuild of the _current
+# write-through from the winning observation.
+#
+# CRITICAL (prevention-log "Diff-aware writers" variant A): refreshed_at /
+# computed_at are mutate-on-every-call timestamps. They go in the UPDATE SET
+# clause ONLY — NEVER inside the IS DISTINCT FROM tuple (else now() always
+# differs → every MATCHED row re-fires → bloat). The (as_of_date, computed_at)
+# tuple comparison is what advances a fresh / corrected snapshot even when the
+# rounded business values are unchanged.
+
+# Business columns shared by the INSERT, the dedup compare, and the _current
+# upsert IS DISTINCT FROM tuple. Single source of truth — ORDER IS LOAD-BEARING
+# (it drives the param order below and the EXCLUDED tuple). Excludes the keys
+# (instrument_id, as_of_date, metric_version, window_key) and the mutate-on-
+# write timestamps (computed_at, refreshed_at).
+_RISK_BUSINESS_COLS: tuple[str, ...] = (
+    "cagr",
+    "excess_cagr_vs_spy",
+    "max_drawdown",
+    "max_dd_peak_date",
+    "max_dd_trough_date",
+    "current_drawdown",
+    "vol_annualized",
+    "beta",
+    "beta_r2",
+    "skew",
+    "excess_kurtosis",
+    "var_5",
+    "worst_day",
+    "best_day",
+    "calmar",
+    "trailing_1m",
+    "trailing_3m",
+    "trailing_6m",
+    "trailing_1y",
+    "excess_trailing_1m",
+    "excess_trailing_3m",
+    "excess_trailing_6m",
+    "excess_trailing_1y",
+    "n_returns",
+    "beta_n_obs",
+    "benchmark_instrument_id",
+    "window_days",
+    "cagr_status",
+    "vol_status",
+    "beta_status",
+    "drawdown_status",
+    "distribution_status",
+    "calmar_status",
+    "trailing_status",
+    "excess_cagr_status",
+)
+
+
+def load_close_series(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    end_date: date,
+) -> list[tuple[date, Decimal | None]]:
+    """Load ``(price_date, close)`` for an instrument up to and including ``end_date``.
+
+    Closes are returned ASC with NULL closes KEPT in the list — the
+    return-chain / status logic in :func:`compute_instrument_risk` must see the
+    invalid rows (a NULL breaks the chain and feeds the ``invalid_price_chain``
+    signal). Do NOT pre-filter. Non-null closes are coerced ``Decimal(str(...))``.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT price_date, close
+            FROM price_daily
+            WHERE instrument_id = %(iid)s
+              AND price_date <= %(end)s
+            ORDER BY price_date ASC
+            """,
+            {"iid": instrument_id, "end": end_date},
+        )
+        rows = cur.fetchall()
+    out: list[tuple[date, Decimal | None]] = []
+    for price_date, close in rows:
+        out.append((price_date, None if close is None else Decimal(str(close))))
+    return out
+
+
+def _resolve_benchmark_instrument_ids(conn: psycopg.Connection[Any]) -> dict[str, int]:
+    """Resolve the benchmark symbols to instrument_ids (primary-listing tiebreak).
+
+    Mirrors the candle-refresh scope query (``daily_candle_refresh``): tradable
+    rows only, one id per symbol, ``is_primary_listing DESC, instrument_id``.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (symbol) symbol, instrument_id
+            FROM instruments
+            WHERE symbol = ANY(%(symbols)s)
+              AND is_tradable = TRUE
+            ORDER BY symbol, is_primary_listing DESC, instrument_id
+            """,
+            {"symbols": sorted(BENCHMARK_SYMBOLS)},
+        )
+        return {str(symbol): int(iid) for symbol, iid in cur.fetchall()}
+
+
+def _latest_valid_close_date(closes: Sequence[tuple[date, Decimal | None]]) -> date | None:
+    """The date of the latest VALID (finite & > 0) close, else None.
+
+    closes are ASC; the last valid one wins. This — NOT raw MAX(price_date) —
+    is the ``as_of_date`` so a trailing NULL / bad bar does not advance the
+    snapshot date past the last good price.
+    """
+    latest: date | None = None
+    for d, raw in closes:
+        if _valid_close(raw) is not None:
+            latest = d
+    return latest
+
+
+def _count_valid_closes(closes: Sequence[tuple[date, Decimal | None]]) -> int:
+    """Count rows whose close is valid (finite & > 0)."""
+    return sum(1 for _, raw in closes if _valid_close(raw) is not None)
+
+
+def _window_days(closes: Sequence[tuple[date, Decimal | None]]) -> int | None:
+    """Calendar span (days) of the valid close sub-chain, else None for < 2 valid."""
+    valid = [d for d, raw in closes if _valid_close(raw) is not None]
+    if len(valid) < 2:
+        return None
+    return (valid[-1] - valid[0]).days
+
+
+def _metrics_row_values(
+    metrics: WindowMetrics,
+    inst_closes: Sequence[tuple[date, Decimal | None]],
+    spy_closes: Sequence[tuple[date, Decimal | None]],
+    as_of_date: date,
+    benchmark_instrument_id: int | None,
+) -> dict[str, object]:
+    """Build the business-column value dict for one (instrument, window) row.
+
+    Trailing returns are absolute-lookback (1m/3m/6m/1y) and computed here from
+    the same as_of_date / close series — they are window-independent but
+    persisted on every window row.
+    """
+    dist = metrics.distribution
+    # peak/trough dates are not on WindowMetrics; recompute off the same chain.
+    dd = drawdown(inst_closes)
+    trailing: dict[str, Decimal | None] = {}
+    excess_trailing: dict[str, Decimal | None] = {}
+    for key, lookback in TRAILING_LOOKBACK_DAYS.items():
+        trailing[key] = trailing_return(inst_closes, as_of_date, lookback)
+        xs_val, _ = excess_trailing_return(inst_closes, spy_closes, as_of_date, lookback)
+        excess_trailing[key] = xs_val
+
+    return {
+        "cagr": metrics.cagr,
+        "excess_cagr_vs_spy": metrics.excess_cagr,
+        "max_drawdown": metrics.max_drawdown,
+        "max_dd_peak_date": dd.peak_date,
+        "max_dd_trough_date": dd.trough_date,
+        "current_drawdown": metrics.current_drawdown,
+        "vol_annualized": metrics.annualized_vol,
+        "beta": metrics.beta,
+        "beta_r2": metrics.r2,
+        "skew": dist.skew if dist else None,
+        "excess_kurtosis": dist.excess_kurtosis if dist else None,
+        "var_5": dist.var_5 if dist else None,
+        "worst_day": dist.worst_day if dist else None,
+        "best_day": dist.best_day if dist else None,
+        "calmar": metrics.calmar,
+        "trailing_1m": trailing["1m"],
+        "trailing_3m": trailing["3m"],
+        "trailing_6m": trailing["6m"],
+        "trailing_1y": trailing["1y"],
+        "excess_trailing_1m": excess_trailing["1m"],
+        "excess_trailing_3m": excess_trailing["3m"],
+        "excess_trailing_6m": excess_trailing["6m"],
+        "excess_trailing_1y": excess_trailing["1y"],
+        "n_returns": metrics.n_returns,
+        "beta_n_obs": metrics.beta_n_obs,
+        "benchmark_instrument_id": benchmark_instrument_id,
+        "window_days": _window_days(inst_closes),
+        "cagr_status": metrics.cagr_status,
+        "vol_status": metrics.vol_status,
+        "beta_status": metrics.beta_status,
+        "drawdown_status": metrics.drawdown_status,
+        "distribution_status": metrics.distribution_status,
+        "calmar_status": metrics.calmar_status,
+        "trailing_status": metrics.trailing_status,
+        "excess_cagr_status": metrics.excess_cagr_status,
+    }
+
+
+def _coerce_db_value(value: object) -> object:
+    """Coerce a business value to its DB boundary form. Decimal stays Decimal."""
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, str, date)):
+        return value
+    # Any stray numeric (e.g. float island that slipped through) -> Decimal.
+    return Decimal(str(value))
+
+
+@dataclass(frozen=True)
+class _PendingRow:
+    """One computed (instrument, as_of, window) row awaiting write."""
+
+    instrument_id: int
+    as_of_date: date
+    window_key: str
+    values: dict[str, object]
+
+
+def compute_and_store_risk_metrics(conn: psycopg.Connection[Any]) -> int:
+    """Compute + persist risk metrics for the scoped instrument universe.
+
+    Scope = instruments with >= 2 valid closes (>= 1 return computable) UNION
+    the resolved benchmark instrument_ids. For each, all WINDOW_KEYS are
+    computed against the SPY series and written:
+
+      1. content-dedup APPEND into instrument_risk_metrics_observations
+         (insert a new row only if none exists for the key, or the business
+         columns differ from the latest existing row);
+      2. deterministic REBUILD of instrument_risk_metrics_current from the
+         winning observation (latest as_of_date, then latest computed_at).
+
+    Returns the number of observation rows written this run.
+    """
+    # ---- READ PHASE (REPEATABLE READ snapshot; no writes inside) ----------
+    with snapshot_read(conn):
+        benchmark_ids = _resolve_benchmark_instrument_ids(conn)
+        spy_instrument_id = benchmark_ids.get(SPY_SYMBOL)
+
+        with conn.cursor() as cur:
+            # Instruments with >= 2 valid (finite & > 0) closes. Pre-filter in
+            # SQL on the close-validity predicate so scope is bounded; the
+            # Python validity check is the source of truth but this avoids
+            # loading the whole universe.
+            cur.execute(
+                """
+                SELECT instrument_id
+                FROM price_daily
+                WHERE close IS NOT NULL
+                  AND close > 0
+                GROUP BY instrument_id
+                HAVING COUNT(*) >= 2
+                """
+            )
+            scoped_ids = {int(r[0]) for r in cur.fetchall()}
+        scoped_ids |= set(benchmark_ids.values())
+
+        # End date for every series load: today (UTC date via Postgres).
+        with conn.cursor() as cur:
+            cur.execute("SELECT CURRENT_DATE")
+            current_date_row = cur.fetchone()
+        assert current_date_row is not None
+        current_date: date = current_date_row[0]
+
+        spy_closes: list[tuple[date, Decimal | None]] = (
+            load_close_series(conn, spy_instrument_id, current_date) if spy_instrument_id is not None else []
+        )
+
+        inst_series: dict[int, list[tuple[date, Decimal | None]]] = {}
+        for iid in sorted(scoped_ids):
+            inst_series[iid] = load_close_series(conn, iid, current_date)
+
+    # ---- COMPUTE PHASE (in memory; pure) ----------------------------------
+    pending: list[_PendingRow] = []
+    for iid in sorted(scoped_ids):
+        closes = inst_series.get(iid, [])
+        # A benchmark with thin / no own history can still be in scope via the
+        # UNION; skip it if it cannot produce even one return.
+        if _count_valid_closes(closes) < 2:
+            continue
+        as_of_date = _latest_valid_close_date(closes)
+        if as_of_date is None:
+            continue
+        # Guard: never let a future-dated bar advance the snapshot past today.
+        if as_of_date > current_date:
+            as_of_date = current_date
+        for window_key in WINDOW_KEYS:
+            metrics = compute_instrument_risk(closes, spy_closes, window_key, as_of_date)
+            values = _metrics_row_values(metrics, closes, spy_closes, as_of_date, spy_instrument_id)
+            pending.append(
+                _PendingRow(
+                    instrument_id=iid,
+                    as_of_date=as_of_date,
+                    window_key=window_key,
+                    values=values,
+                )
+            )
+
+    if not pending:
+        return 0
+
+    # ---- WRITE PHASE (separate READ COMMITTED transaction) ----------------
+    written = 0
+    touched_ids: list[int] = sorted({p.instrument_id for p in pending})
+    with conn.transaction():
+        for row in pending:
+            if _append_observation_if_changed(conn, row):
+                written += 1
+        # Rebuild _current for the touched instruments, batched.
+        for start in range(0, len(touched_ids), _REBUILD_BATCH):
+            batch = touched_ids[start : start + _REBUILD_BATCH]
+            _rebuild_current_for_batch(conn, batch)
+    return written
+
+
+def _append_observation_if_changed(conn: psycopg.Connection[Any], row: _PendingRow) -> bool:
+    """Insert a new observation row iff it is new or its business columns differ.
+
+    Reads the latest existing row for (instrument, as_of, version, window) and
+    compares ONLY the business columns (never computed_at). Returns True if a
+    row was inserted.
+    """
+    col_idents = sql.SQL(", ").join(sql.Identifier(c) for c in _RISK_BUSINESS_COLS)
+    select_q = sql.SQL(
+        """
+        SELECT {cols}
+        FROM instrument_risk_metrics_observations
+        WHERE instrument_id = %(iid)s
+          AND as_of_date = %(asof)s
+          AND metric_version = %(ver)s
+          AND window_key = %(win)s
+        ORDER BY computed_at DESC
+        LIMIT 1
+        """
+    ).format(cols=col_idents)
+    key_params: dict[str, object] = {
+        "iid": row.instrument_id,
+        "asof": row.as_of_date,
+        "ver": RISK_METRICS_VERSION,
+        "win": row.window_key,
+    }
+    with conn.cursor() as cur:
+        cur.execute(select_q, key_params)
+        latest = cur.fetchone()
+
+    new_vals = [_coerce_db_value(row.values[c]) for c in _RISK_BUSINESS_COLS]
+    if latest is not None:
+        # Compare business columns. The SELECT returns DB-native types
+        # (Decimal / int / date / str / None) which match the coerced new
+        # values exactly, so equality is a faithful content compare.
+        if list(latest) == new_vals:
+            return False
+
+    placeholders = sql.SQL(", ").join(sql.Placeholder(c) for c in _RISK_BUSINESS_COLS)
+    insert_q = sql.SQL(
+        """
+        INSERT INTO instrument_risk_metrics_observations (
+            instrument_id, as_of_date, metric_version, window_key, {cols}
+        ) VALUES (
+            %(iid)s, %(asof)s, %(ver)s, %(win)s, {vals}
+        )
+        """
+    ).format(cols=col_idents, vals=placeholders)
+    params: dict[str, object] = dict(key_params)
+    for c in _RISK_BUSINESS_COLS:
+        params[c] = _coerce_db_value(row.values[c])
+    with conn.cursor() as cur:
+        cur.execute(insert_q, params)
+    return True
+
+
+def _rebuild_current_for_batch(conn: psycopg.Connection[Any], instrument_ids: Sequence[int]) -> None:
+    """Rebuild instrument_risk_metrics_current from the winning observation.
+
+    DISTINCT ON picks the latest (as_of_date, computed_at) per
+    (instrument, version, window). On conflict the row advances when the
+    winning observation is newer ((as_of_date, computed_at) tuple) OR the
+    business columns differ — refreshed_at / computed_at are SET only, never in
+    the IS DISTINCT FROM tuple (prevention-log MERGE-bloat variant A).
+    """
+    col_idents = sql.SQL(", ").join(sql.Identifier(c) for c in _RISK_BUSINESS_COLS)
+    set_clause = sql.SQL(", ").join(
+        sql.SQL("{c} = EXCLUDED.{c}").format(c=sql.Identifier(c)) for c in _RISK_BUSINESS_COLS
+    )
+    business_lhs = sql.SQL(", ").join(
+        sql.SQL("instrument_risk_metrics_current.{c}").format(c=sql.Identifier(c)) for c in _RISK_BUSINESS_COLS
+    )
+    business_rhs = sql.SQL(", ").join(sql.SQL("EXCLUDED.{c}").format(c=sql.Identifier(c)) for c in _RISK_BUSINESS_COLS)
+    rebuild_q = sql.SQL(
+        """
+        INSERT INTO instrument_risk_metrics_current (
+            instrument_id, metric_version, window_key,
+            {cols}, as_of_date, computed_at, refreshed_at
+        )
+        SELECT DISTINCT ON (instrument_id, metric_version, window_key)
+            instrument_id, metric_version, window_key,
+            {cols}, as_of_date, computed_at, NOW() AS refreshed_at
+        FROM instrument_risk_metrics_observations
+        WHERE instrument_id = ANY(%(ids)s)
+          AND metric_version = %(ver)s
+        ORDER BY instrument_id, metric_version, window_key,
+                 as_of_date DESC, computed_at DESC
+        ON CONFLICT (instrument_id, metric_version, window_key) DO UPDATE SET
+            {set_clause},
+            as_of_date = EXCLUDED.as_of_date,
+            computed_at = EXCLUDED.computed_at,
+            refreshed_at = NOW()
+        WHERE (EXCLUDED.as_of_date, EXCLUDED.computed_at)
+              > (instrument_risk_metrics_current.as_of_date, instrument_risk_metrics_current.computed_at)
+           OR ({business_lhs}) IS DISTINCT FROM ({business_rhs})
+        """
+    ).format(
+        cols=col_idents,
+        set_clause=set_clause,
+        business_lhs=business_lhs,
+        business_rhs=business_rhs,
+    )
+    with conn.cursor() as cur:
+        cur.execute(rebuild_q, {"ids": list(instrument_ids), "ver": RISK_METRICS_VERSION})

--- a/app/services/risk_metrics.py
+++ b/app/services/risk_metrics.py
@@ -133,6 +133,7 @@ class WindowMetrics:
     cagr_status: RiskStatus
     max_drawdown: Decimal | None
     current_drawdown: Decimal | None
+    drawdown_status: RiskStatus
     calmar: Decimal | None
     calmar_status: RiskStatus
     beta: Decimal | None
@@ -142,6 +143,8 @@ class WindowMetrics:
     excess_cagr: Decimal | None
     excess_cagr_status: RiskStatus
     distribution: DistributionResult | None
+    distribution_status: RiskStatus
+    trailing_status: RiskStatus
 
 
 # ---------------------------------------------------------------------------
@@ -601,6 +604,72 @@ def beta_status(
     return "ok"
 
 
+def drawdown_status(valid_closes: int, invalids_dropped: int = 0) -> RiskStatus:
+    """Status for drawdown given the count of valid closes in the chain.
+
+    A drawdown is computable from ≥ 2 valid closes. It is NOT annualized
+    (never ``partial_window``) and NOT benchmark-relative (never ``benchmark_*``).
+
+    Trigger rule (mirrors :func:`vol_beta_status`'s invalids signal):
+      - ``valid_closes >= 2`` → ``ok``.
+      - below 2 AND ``invalids_dropped > 0`` → ``invalid_price_chain``
+        (invalids dropped the usable chain below 2).
+      - below 2 AND no invalids → ``insufficient_history``.
+    """
+    if valid_closes >= 2:
+        return "ok"
+    if invalids_dropped > 0:
+        return "invalid_price_chain"
+    return "insufficient_history"
+
+
+def distribution_status(n_returns: int, invalids_dropped: int = 0) -> RiskStatus:
+    """Status for the return-distribution moments given the valid-return count.
+
+    The moments (skew / excess kurtosis / var_5) need ≥ 2 returns to exist and
+    ≥ ``MIN_OBS_MOMENTS`` (250) returns to be reliable (the persisted form of
+    :attr:`DistributionResult.low_sample`).
+
+    Trigger rule:
+      - ``n_returns >= MIN_OBS_MOMENTS`` → ``ok``.
+      - ``2 <= n_returns < MIN_OBS_MOMENTS`` → ``partial_window`` (low-sample,
+        unreliable moments).
+      - ``n_returns < 2`` AND ``invalids_dropped > 0`` → ``invalid_price_chain``.
+      - ``n_returns < 2`` AND no invalids → ``insufficient_history``.
+    """
+    if n_returns >= MIN_OBS_MOMENTS:
+        return "ok"
+    if n_returns >= 2:
+        return "partial_window"
+    if invalids_dropped > 0:
+        return "invalid_price_chain"
+    return "insufficient_history"
+
+
+def trailing_status(
+    inst_closes: Sequence[PricePoint],
+    as_of: date,
+    invalids_dropped: int = 0,
+) -> RiskStatus:
+    """Rollup status for trailing returns: is the SHORTEST horizon computable?
+
+    Per-window null trailing values already encode which individual horizons are
+    missing; this status is the rollup over the shortest (1m) window — if not
+    even 1m is computable there is no trailing history at all.
+
+    Trigger rule:
+      - shortest (1m) trailing return computable → ``ok``.
+      - not computable AND ``invalids_dropped > 0`` → ``invalid_price_chain``.
+      - not computable AND no invalids → ``insufficient_history``.
+    """
+    shortest_lookback = TRAILING_LOOKBACK_DAYS["1m"]
+    if trailing_return(inst_closes, as_of, shortest_lookback) is not None:
+        return "ok"
+    if invalids_dropped > 0:
+        return "invalid_price_chain"
+    return "insufficient_history"
+
+
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
@@ -610,7 +679,7 @@ def compute_instrument_risk(
     inst_closes: Sequence[PricePoint],
     spy_closes: Sequence[PricePoint],
     window_key: str,
-    as_of_date: date,  # noqa: ARG001 — reserved for staleness checks at the persistence layer
+    as_of_date: date,
 ) -> WindowMetrics:
     """Compute all risk metrics for ONE instrument over ONE window.
 
@@ -632,6 +701,10 @@ def compute_instrument_risk(
     cagr_st = annualized_status(n_returns, invalids_dropped)
 
     dd = drawdown(inst_closes)
+    # Drawdown is computed off the VALID close sub-chain (≥ 2 needed). The total
+    # raw rows minus invalids gives the usable chain length.
+    valid_closes = len(inst_closes) - invalids_dropped
+    dd_st = drawdown_status(valid_closes, invalids_dropped)
 
     calmar_val: Decimal | None = None
     if inst_cagr is not None and dd.max_drawdown is not None:
@@ -641,6 +714,9 @@ def compute_instrument_risk(
     calmar_st = annualized_status(n_returns, invalids_dropped)
 
     dist = distribution(inst_ret_vals) if inst_ret_vals else None
+    dist_st = distribution_status(n_returns, invalids_dropped)
+
+    trailing_st = trailing_status(inst_closes, as_of_date, invalids_dropped)
 
     spy_present = bool(spy_closes)
     spy_rets = simple_returns(spy_closes)
@@ -658,6 +734,7 @@ def compute_instrument_risk(
         cagr_status=cagr_st,
         max_drawdown=dd.max_drawdown,
         current_drawdown=dd.current_drawdown,
+        drawdown_status=dd_st,
         calmar=calmar_val,
         calmar_status=calmar_st,
         beta=beta_res.beta,
@@ -667,4 +744,6 @@ def compute_instrument_risk(
         excess_cagr=xs_cagr,
         excess_cagr_status=xs_cagr_st,
         distribution=dist,
+        distribution_status=dist_st,
+        trailing_status=trailing_st,
     )

--- a/app/services/risk_metrics.py
+++ b/app/services/risk_metrics.py
@@ -338,6 +338,34 @@ def drawdown(closes: Sequence[PricePoint]) -> DrawdownResult:
     )
 
 
+def drawdown_curve(closes: Sequence[PricePoint]) -> list[tuple[date, Decimal]]:
+    """Running-peak underwater curve: ``(date, dd)`` for each valid close.
+
+    ``dd[i] = close[i]/peak[i] - 1`` (always ≤ 0), keyed to the close's date,
+    over the SAME valid sub-chain :func:`drawdown` uses (a close survives iff it
+    is finite and > 0). Returns an empty list when there is no valid close.
+
+    This is the display companion to :func:`drawdown`'s scalar summary — the API
+    layer renders this as the underwater chart so it never re-implements the
+    peak/dd math.
+    """
+    valid: list[tuple[date, Decimal]] = []
+    for d, raw in closes:
+        c = _valid_close(raw)
+        if c is not None:
+            valid.append((d, c))
+    if not valid:
+        return []
+
+    peak_close = valid[0][1]
+    out: list[tuple[date, Decimal]] = []
+    for d, c in valid:
+        if c > peak_close:
+            peak_close = c
+        out.append((d, c / peak_close - Decimal(1)))
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Calmar
 # ---------------------------------------------------------------------------

--- a/app/services/risk_metrics.py
+++ b/app/services/risk_metrics.py
@@ -1,0 +1,631 @@
+"""
+Risk-metrics pure-compute service (``risk_v1``).
+
+Computes long-horizon risk metrics for ONE instrument over ONE window from a
+price series, plus benchmark-relative metrics against SPY.
+
+Design (mirrors ``app/services/return_attribution.py``):
+  - Pure math. No DB, no I/O, no connection. The caller loads price series and
+    persists results.
+  - ``Decimal(str(x))`` coercion at every numeric boundary; ``ZERO = Decimal("0")``.
+  - Frozen dataclasses for results. Module-level version/window constants.
+  - One sanctioned FLOAT ISLAND: skew, excess kurtosis, and the var_5 percentile
+    are computed in ``float`` via numpy (no scipy) and re-quantized to Decimal at
+    the boundary with ``Decimal(str(round(v, 8)))``. Everything else stays
+    end-to-end Decimal.
+
+Math contracts:
+  - Returns are SIMPLE: ``r = close[i]/close[i-1] - 1`` between *consecutive
+    surviving* rows. A close is valid iff finite AND ``> 0``. An invalid row
+    breaks the chain — NO gap-spanning synthetic return. The return is keyed to
+    the LATER close's date.
+  - Volatility annualizes the sample (n-1) std by ``sqrt(252)``.
+  - CAGR is CALENDAR-time: ``(final/first)^(365/calendar_days) - 1``.
+  - Drawdown uses a running peak: ``dd[i] = close[i]/peak[i] - 1`` (≤ 0).
+  - Beta INTERSECTS dates between the instrument and SPY return series — never
+    positional-zip (that mis-pairs across holiday gaps).
+  - ``var_5`` is SIGNED (a loss is negative) — persisted as-is.
+
+Issue #591 PR-B, Task B1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Literal, get_args
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+RISK_METRICS_VERSION = "risk_v1"
+TRADING_DAYS = 252
+ZERO = Decimal("0")
+
+# Boundaries are counted in RETURNS, not closes.
+MIN_RETURNS_VOL_BETA = 60
+MIN_RETURNS_ANNUALIZED = 252
+MIN_OBS_MOMENTS = 250
+
+# Calmar guard: a max-drawdown magnitude below this is treated as "no drawdown".
+CALMAR_DD_EPSILON = Decimal("1e-9")
+
+WINDOW_KEYS: tuple[str, ...] = ("1y", "3y", "full")
+
+RiskStatus = Literal[
+    "ok",
+    "insufficient_history",
+    "partial_window",
+    "benchmark_missing",
+    "benchmark_insufficient_history",
+    "invalid_price_chain",
+    "stale",
+]
+RISK_STATUSES: frozenset[str] = frozenset(get_args(RiskStatus))
+
+# Trailing-return lookback windows, in calendar days.
+TRAILING_LOOKBACK_DAYS: dict[str, int] = {
+    "1m": 30,
+    "3m": 91,
+    "6m": 182,
+    "1y": 365,
+}
+
+# A (date, close) pair. close may be any numeric / float (NaN allowed upstream).
+PricePoint = tuple[date, object]
+# A (date, return) pair — return is always a Decimal.
+ReturnPoint = tuple[date, Decimal]
+
+_SQRT_TRADING_DAYS = Decimal(TRADING_DAYS).sqrt()
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DrawdownResult:
+    """Running-peak drawdown over a close series."""
+
+    max_drawdown: Decimal | None
+    current_drawdown: Decimal | None
+    peak_date: date | None
+    trough_date: date | None
+
+
+@dataclass(frozen=True)
+class BetaResult:
+    """OLS regression of instrument returns on benchmark returns (single regressor)."""
+
+    beta: Decimal | None
+    r2: Decimal | None
+    n_obs: int
+
+
+@dataclass(frozen=True)
+class DistributionResult:
+    """Return-distribution moments and tail stats (float island, quantized to Decimal)."""
+
+    skew: Decimal | None
+    excess_kurtosis: Decimal | None
+    var_5: Decimal | None
+    worst_day: Decimal | None
+    best_day: Decimal | None
+    n_obs: int
+    low_sample: bool
+
+
+@dataclass(frozen=True)
+class WindowMetrics:
+    """All risk metrics for ONE instrument over ONE window."""
+
+    window_key: str
+    n_returns: int
+    annualized_vol: Decimal | None
+    vol_status: RiskStatus
+    cagr: Decimal | None
+    cagr_status: RiskStatus
+    max_drawdown: Decimal | None
+    current_drawdown: Decimal | None
+    calmar: Decimal | None
+    calmar_status: RiskStatus
+    beta: Decimal | None
+    r2: Decimal | None
+    beta_n_obs: int
+    beta_status: RiskStatus
+    excess_cagr: Decimal | None
+    excess_cagr_status: RiskStatus
+    distribution: DistributionResult | None
+
+
+# ---------------------------------------------------------------------------
+# Validity + returns
+# ---------------------------------------------------------------------------
+
+
+def _valid_close(value: object) -> Decimal | None:
+    """Return a positive finite close as Decimal, else None.
+
+    A close is valid iff it is finite AND strictly greater than zero.
+    NaN / inf / zero / negative are all invalid (and break the return chain).
+    """
+    if value is None:
+        return None
+    try:
+        d = Decimal(str(value))
+    except ArithmeticError, ValueError, TypeError:
+        return None
+    if not d.is_finite():
+        return None
+    if d <= ZERO:
+        return None
+    return d
+
+
+def simple_returns(closes: Sequence[PricePoint]) -> list[ReturnPoint]:
+    """Simple returns between *consecutive surviving* closes.
+
+    ``r = close[i]/close[i-1] - 1`` only when BOTH the current and the
+    immediately-preceding row are valid. An invalid row breaks the chain — no
+    synthetic return spans the gap. The return is keyed to the LATER close's
+    date.
+    """
+    out: list[ReturnPoint] = []
+    prev: Decimal | None = None
+    for d, raw in closes:
+        cur = _valid_close(raw)
+        if cur is None:
+            prev = None  # break the chain; no gap-spanning return
+            continue
+        if prev is not None:
+            out.append((d, cur / prev - Decimal(1)))
+        prev = cur
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Volatility (shared sample std)
+# ---------------------------------------------------------------------------
+
+
+def _sample_std(returns: Sequence[Decimal]) -> Decimal | None:
+    """Sample standard deviation (n-1 denominator). None for n < 2.
+
+    SHARED by ``annualized_vol`` and ``distribution`` so the std is identical.
+    """
+    n = len(returns)
+    if n < 2:
+        return None
+    mean = sum(returns, ZERO) / Decimal(n)
+    sse = sum(((r - mean) ** 2 for r in returns), ZERO)
+    variance = sse / Decimal(n - 1)
+    return variance.sqrt()
+
+
+def annualized_vol(returns: Sequence[Decimal]) -> Decimal | None:
+    """Annualized volatility: sample std × sqrt(252). None for < 2 returns."""
+    std = _sample_std(returns)
+    if std is None:
+        return None
+    return std * _SQRT_TRADING_DAYS
+
+
+# ---------------------------------------------------------------------------
+# CAGR (calendar-time)
+# ---------------------------------------------------------------------------
+
+
+def cagr(closes: Sequence[PricePoint]) -> Decimal | None:
+    """CALENDAR-time CAGR over the valid sub-chain of a close series.
+
+    ``(final/first)^(365/calendar_days) - 1`` where
+    ``calendar_days = (last_valid_date - first_valid_date).days``.
+
+    Uses Decimal ``.ln()``/``.exp()`` for the fractional power. Returns None
+    when there are fewer than two valid closes, when first close is non-positive,
+    or when ``calendar_days == 0``.
+    """
+    valid: list[tuple[date, Decimal]] = []
+    for d, raw in closes:
+        c = _valid_close(raw)
+        if c is not None:
+            valid.append((d, c))
+    if len(valid) < 2:
+        return None
+    first_date, first_close = valid[0]
+    last_date, last_close = valid[-1]
+    calendar_days = (last_date - first_date).days
+    if calendar_days == 0:
+        return None
+    ratio = last_close / first_close
+    exponent = Decimal(365) / Decimal(calendar_days)
+    # ratio ** exponent via exp(exponent * ln(ratio)); ratio > 0 guaranteed.
+    return (exponent * ratio.ln()).exp() - Decimal(1)
+
+
+# ---------------------------------------------------------------------------
+# Drawdown
+# ---------------------------------------------------------------------------
+
+
+def drawdown(closes: Sequence[PricePoint]) -> DrawdownResult:
+    """Running-peak drawdown over the valid sub-chain.
+
+    ``dd[i] = close[i]/peak[i] - 1`` (always ≤ 0). ``max_drawdown`` is the
+    minimum (most negative) dd; ``current_drawdown`` is the last dd. Reports the
+    peak date in effect at the trough and the trough date.
+    """
+    valid: list[tuple[date, Decimal]] = []
+    for d, raw in closes:
+        c = _valid_close(raw)
+        if c is not None:
+            valid.append((d, c))
+    if not valid:
+        return DrawdownResult(None, None, None, None)
+
+    peak_close = valid[0][1]
+    peak_date = valid[0][0]
+    max_dd = ZERO
+    max_dd_peak_date = valid[0][0]
+    trough_date = valid[0][0]
+    last_dd = ZERO
+
+    for d, c in valid:
+        if c > peak_close:
+            peak_close = c
+            peak_date = d
+        dd = c / peak_close - Decimal(1)
+        last_dd = dd
+        if dd < max_dd:
+            max_dd = dd
+            max_dd_peak_date = peak_date
+            trough_date = d
+
+    return DrawdownResult(
+        max_drawdown=max_dd,
+        current_drawdown=last_dd,
+        peak_date=max_dd_peak_date,
+        trough_date=trough_date,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Calmar
+# ---------------------------------------------------------------------------
+
+
+def calmar(annualized_return: Decimal, max_drawdown: Decimal) -> Decimal | None:
+    """``annualized_return / abs(max_drawdown)``.
+
+    None when ``abs(max_drawdown) < CALMAR_DD_EPSILON`` (avoids div-by-near-zero).
+    """
+    dd_mag = abs(max_drawdown)
+    if dd_mag < CALMAR_DD_EPSILON:
+        return None
+    return annualized_return / dd_mag
+
+
+# ---------------------------------------------------------------------------
+# OLS beta (date-intersection)
+# ---------------------------------------------------------------------------
+
+
+def ols_beta(
+    inst_returns: Sequence[ReturnPoint],
+    bench_returns: Sequence[ReturnPoint],
+) -> BetaResult:
+    """OLS beta of instrument returns on benchmark returns, single regressor.
+
+    Builds ``{date: return}`` for both and regresses on the sorted INTERSECTION
+    of dates (never positional-zip — that silently mis-pairs across holiday
+    gaps). The aligned window therefore starts at ``max(first inst return date,
+    first bench return date)`` implicitly.
+
+    ``beta = cov(i, m) / var(m)``; ``r2 = corr(i, m)^2`` (closed form). Both
+    covariance and variance use n-1 denominators (they cancel in beta but must
+    match). Guards:
+      - fewer than 2 aligned pairs → beta None, r2 None
+      - ``var(m) == 0`` → beta None
+      - ``var(i) == 0 or var(m) == 0`` → r2 None
+    """
+    inst_map = dict(inst_returns)
+    bench_map = dict(bench_returns)
+    shared = sorted(set(inst_map) & set(bench_map))
+    n = len(shared)
+    if n < 2:
+        return BetaResult(beta=None, r2=None, n_obs=n)
+
+    i_vals = [inst_map[d] for d in shared]
+    m_vals = [bench_map[d] for d in shared]
+    nd = Decimal(n)
+    i_mean = sum(i_vals, ZERO) / nd
+    m_mean = sum(m_vals, ZERO) / nd
+
+    denom = Decimal(n - 1)
+    cov = sum(((i - i_mean) * (m - m_mean) for i, m in zip(i_vals, m_vals, strict=True)), ZERO) / denom
+    var_m = sum(((m - m_mean) ** 2 for m in m_vals), ZERO) / denom
+    var_i = sum(((i - i_mean) ** 2 for i in i_vals), ZERO) / denom
+
+    beta: Decimal | None = None if var_m == ZERO else cov / var_m
+
+    r2: Decimal | None
+    if var_i == ZERO or var_m == ZERO:
+        r2 = None
+    else:
+        corr = cov / (var_i.sqrt() * var_m.sqrt())
+        r2 = corr * corr
+
+    return BetaResult(beta=beta, r2=r2, n_obs=n)
+
+
+# ---------------------------------------------------------------------------
+# Distribution (FLOAT ISLAND)
+# ---------------------------------------------------------------------------
+
+
+def _quantize8(value: float) -> Decimal:
+    """Quantize a float-island scalar to 8dp Decimal at the persistence boundary."""
+    return Decimal(str(round(value, 8)))
+
+
+def distribution(returns: Sequence[Decimal]) -> DistributionResult:
+    """Return-distribution moments + tail stats.
+
+    FLOAT ISLAND: skew, excess kurtosis and the var_5 percentile are computed in
+    float via numpy (two-pass: mean first, then central moments), then quantized
+    to 8dp Decimal at the boundary. ``worst_day``/``best_day`` stay Decimal.
+
+    - ``skew``: biased moment form ``m3 / m2^1.5``.
+    - ``excess_kurtosis``: Fisher, biased moment form ``m4 / m2^2 - 3``.
+    - ``var_5``: type-7 linear-interpolation 5th percentile (``h = 0.05*(n-1)``),
+      SIGNED (a left-tail loss is negative — persisted as-is).
+    - constant series (variance 0) → skew / kurt None (no div-by-zero).
+    - ``low_sample`` True when ``n_obs < MIN_OBS_MOMENTS``.
+    """
+    n = len(returns)
+    if n == 0:
+        return DistributionResult(None, None, None, None, None, 0, True)
+
+    worst = min(returns)
+    best = max(returns)
+    low_sample = n < MIN_OBS_MOMENTS
+
+    arr = np.array([float(r) for r in returns], dtype=np.float64)
+
+    # type-7 5th percentile (numpy default method='linear' == type-7). SIGNED.
+    var_5_f = float(np.percentile(arr, 5.0, method="linear"))
+
+    skew: Decimal | None = None
+    excess_kurt: Decimal | None = None
+    # Detect a constant series EXACTLY in the Decimal domain (the source of
+    # truth). Float central moments suffer roundoff (a constant series yields
+    # m2 ~1e-36, not 0) and would produce nonsense skew/kurt. When variance is
+    # exactly zero the moments are undefined → None (no div-by-zero).
+    if n >= 2 and worst != best:
+        mean = float(arr.mean())
+        centered = arr - mean
+        m2 = float(np.mean(centered**2))
+        if m2 > 0.0:
+            m3 = float(np.mean(centered**3))
+            m4 = float(np.mean(centered**4))
+            skew = _quantize8(m3 / (m2**1.5))
+            excess_kurt = _quantize8(m4 / (m2**2) - 3.0)
+
+    return DistributionResult(
+        skew=skew,
+        excess_kurtosis=excess_kurt,
+        var_5=_quantize8(var_5_f),
+        worst_day=worst,
+        best_day=best,
+        n_obs=n,
+        low_sample=low_sample,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trailing returns
+# ---------------------------------------------------------------------------
+
+
+def _close_at(closes: Sequence[PricePoint], as_of: date) -> Decimal | None:
+    """Valid close exactly at ``as_of`` if present, else the nearest valid close before it."""
+    best: Decimal | None = None
+    for d, raw in closes:
+        if d > as_of:
+            continue
+        c = _valid_close(raw)
+        if c is not None:
+            best = c  # closes assumed ascending; last ≤ as_of wins
+    return best
+
+
+def trailing_return(
+    closes: Sequence[PricePoint],
+    as_of: date,
+    lookback_days: int,
+) -> Decimal | None:
+    """``close[as_of] / close[nearest valid ≤ as_of - lookback_days] - 1``.
+
+    None if there is no valid close at/after ``as_of`` or no valid close at or
+    before ``as_of - lookback_days``.
+    """
+    end = _close_at(closes, as_of)
+    if end is None:
+        return None
+    start_cutoff = as_of - timedelta(days=lookback_days)
+    start = _close_at(closes, start_cutoff)
+    if start is None or start == ZERO:
+        return None
+    return end / start - Decimal(1)
+
+
+def excess_trailing_return(
+    inst_closes: Sequence[PricePoint],
+    spy_closes: Sequence[PricePoint],
+    as_of: date,
+    lookback_days: int,
+) -> tuple[Decimal | None, RiskStatus]:
+    """Instrument trailing return minus SPY trailing return over the same window.
+
+    ``benchmark_missing`` when there is no SPY series at all. Otherwise computes
+    the difference; None value if either side lacks far-enough history.
+    """
+    if not spy_closes:
+        return None, "benchmark_missing"
+    inst = trailing_return(inst_closes, as_of, lookback_days)
+    spy = trailing_return(spy_closes, as_of, lookback_days)
+    if inst is None:
+        return None, "insufficient_history"
+    if spy is None:
+        return None, "benchmark_insufficient_history"
+    return inst - spy, "ok"
+
+
+# ---------------------------------------------------------------------------
+# Excess CAGR (first-class)
+# ---------------------------------------------------------------------------
+
+
+def _aligned_window(
+    inst_closes: Sequence[PricePoint],
+    spy_closes: Sequence[PricePoint],
+) -> tuple[list[PricePoint], list[PricePoint]]:
+    """Restrict both series to the overlapping date span (intersection of extents).
+
+    Window starts at ``max(first valid inst date, first valid spy date)`` and
+    ends at ``min(last valid inst date, last valid spy date)``.
+    """
+    inst_valid = [(d, raw) for d, raw in inst_closes if _valid_close(raw) is not None]
+    spy_valid = [(d, raw) for d, raw in spy_closes if _valid_close(raw) is not None]
+    if not inst_valid or not spy_valid:
+        return [], []
+    start = max(inst_valid[0][0], spy_valid[0][0])
+    end = min(inst_valid[-1][0], spy_valid[-1][0])
+    if start > end:
+        return [], []
+    inst_w = [(d, raw) for d, raw in inst_valid if start <= d <= end]
+    spy_w = [(d, raw) for d, raw in spy_valid if start <= d <= end]
+    return inst_w, spy_w
+
+
+def excess_cagr(
+    inst_closes: Sequence[PricePoint],
+    spy_closes: Sequence[PricePoint],
+    window: str,  # noqa: ARG001 — window kept for caller symmetry / future per-window slicing
+) -> tuple[Decimal | None, RiskStatus]:
+    """``cagr(inst over aligned window) - cagr(SPY over aligned window)``.
+
+    ``benchmark_missing`` when SPY is absent; ``benchmark_insufficient_history``
+    when the aligned overlap is too short to compute either CAGR.
+    """
+    if not spy_closes:
+        return None, "benchmark_missing"
+    inst_w, spy_w = _aligned_window(inst_closes, spy_closes)
+    if not inst_w or not spy_w:
+        return None, "benchmark_insufficient_history"
+    inst_cagr = cagr(inst_w)
+    spy_cagr = cagr(spy_w)
+    if inst_cagr is None:
+        return None, "insufficient_history"
+    if spy_cagr is None:
+        return None, "benchmark_insufficient_history"
+    return inst_cagr - spy_cagr, "ok"
+
+
+# ---------------------------------------------------------------------------
+# Per-metric status helpers
+# ---------------------------------------------------------------------------
+
+
+def vol_beta_status(n_returns: int) -> RiskStatus:
+    """``ok`` when ≥ MIN_RETURNS_VOL_BETA returns, else ``insufficient_history``."""
+    return "ok" if n_returns >= MIN_RETURNS_VOL_BETA else "insufficient_history"
+
+
+def annualized_status(n_returns: int) -> RiskStatus:
+    """``ok`` when ≥ MIN_RETURNS_ANNUALIZED returns, else ``partial_window``."""
+    return "ok" if n_returns >= MIN_RETURNS_ANNUALIZED else "partial_window"
+
+
+def beta_status(
+    aligned_n: int,
+    spy_present: bool,
+) -> RiskStatus:
+    """Status for beta given aligned-pair count and benchmark presence."""
+    if not spy_present:
+        return "benchmark_missing"
+    if aligned_n < MIN_RETURNS_VOL_BETA:
+        return "benchmark_insufficient_history"
+    return "ok"
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def compute_instrument_risk(
+    inst_closes: Sequence[PricePoint],
+    spy_closes: Sequence[PricePoint],
+    window_key: str,
+    as_of_date: date,  # noqa: ARG001 — reserved for staleness checks at the persistence layer
+) -> WindowMetrics:
+    """Compute all risk metrics for ONE instrument over ONE window.
+
+    Standalone metrics (vol, cagr, drawdown, calmar, distribution) use the
+    instrument's full valid history within the window. Benchmark metrics (beta,
+    excess_cagr) use the aligned-overlap window with SPY.
+    """
+    inst_rets = simple_returns(inst_closes)
+    inst_ret_vals = [r for _, r in inst_rets]
+    n_returns = len(inst_ret_vals)
+
+    vol = annualized_vol(inst_ret_vals)
+    vol_st = vol_beta_status(n_returns)
+
+    inst_cagr = cagr(inst_closes)
+    cagr_st = annualized_status(n_returns)
+
+    dd = drawdown(inst_closes)
+
+    calmar_val: Decimal | None = None
+    calmar_st: RiskStatus = "ok"
+    if inst_cagr is not None and dd.max_drawdown is not None:
+        calmar_val = calmar(inst_cagr, dd.max_drawdown)
+    if n_returns < MIN_RETURNS_ANNUALIZED:
+        calmar_st = "partial_window"
+
+    dist = distribution(inst_ret_vals) if inst_ret_vals else None
+
+    spy_present = bool(spy_closes)
+    spy_rets = simple_returns(spy_closes)
+    beta_res = ols_beta(inst_rets, spy_rets)
+    beta_st = beta_status(beta_res.n_obs, spy_present)
+
+    xs_cagr, xs_cagr_st = excess_cagr(inst_closes, spy_closes, window_key)
+
+    return WindowMetrics(
+        window_key=window_key,
+        n_returns=n_returns,
+        annualized_vol=vol,
+        vol_status=vol_st,
+        cagr=inst_cagr,
+        cagr_status=cagr_st,
+        max_drawdown=dd.max_drawdown,
+        current_drawdown=dd.current_drawdown,
+        calmar=calmar_val,
+        calmar_status=calmar_st,
+        beta=beta_res.beta,
+        r2=beta_res.r2,
+        beta_n_obs=beta_res.n_obs,
+        beta_status=beta_st,
+        excess_cagr=xs_cagr,
+        excess_cagr_status=xs_cagr_st,
+        distribution=dist,
+    )

--- a/app/services/risk_metrics.py
+++ b/app/services/risk_metrics.py
@@ -168,6 +168,18 @@ def _valid_close(value: object) -> Decimal | None:
     return d
 
 
+def _count_invalid_closes(closes: Sequence[PricePoint]) -> int:
+    """Count raw rows whose close is invalid (None / non-finite / ≤ 0).
+
+    A single invalid close breaks the return chain (no gap-spanning return) and
+    therefore costs up to two returns (the one into it and the one out of it).
+    The caller uses this count to distinguish *invalid-driven* shortfalls
+    (``invalid_price_chain``) from genuinely-short clean history
+    (``insufficient_history`` / ``partial_window``).
+    """
+    return sum(1 for _, raw in closes if _valid_close(raw) is None)
+
+
 def simple_returns(closes: Sequence[PricePoint]) -> list[ReturnPoint]:
     """Simple returns between *consecutive surviving* closes.
 
@@ -543,14 +555,38 @@ def excess_cagr(
 # ---------------------------------------------------------------------------
 
 
-def vol_beta_status(n_returns: int) -> RiskStatus:
-    """``ok`` when ≥ MIN_RETURNS_VOL_BETA returns, else ``insufficient_history``."""
-    return "ok" if n_returns >= MIN_RETURNS_VOL_BETA else "insufficient_history"
+def vol_beta_status(n_returns: int, invalids_dropped: int = 0) -> RiskStatus:
+    """Status for vol/beta given valid-return count and invalids dropped upstream.
+
+    Trigger rule:
+      - ``n_returns >= MIN_RETURNS_VOL_BETA`` → ``ok`` (a single chain break with
+        enough valid returns remaining is fine, even if some invalids were
+        dropped earlier).
+      - ``n_returns < MIN_RETURNS_VOL_BETA`` AND ``invalids_dropped > 0`` →
+        ``invalid_price_chain`` (invalids contributed to the shortfall).
+      - ``n_returns < MIN_RETURNS_VOL_BETA`` AND no invalids → genuinely-short
+        clean history → ``insufficient_history``.
+    """
+    if n_returns >= MIN_RETURNS_VOL_BETA:
+        return "ok"
+    if invalids_dropped > 0:
+        return "invalid_price_chain"
+    return "insufficient_history"
 
 
-def annualized_status(n_returns: int) -> RiskStatus:
-    """``ok`` when ≥ MIN_RETURNS_ANNUALIZED returns, else ``partial_window``."""
-    return "ok" if n_returns >= MIN_RETURNS_ANNUALIZED else "partial_window"
+def annualized_status(n_returns: int, invalids_dropped: int = 0) -> RiskStatus:
+    """Status for annualized metrics given valid-return count and invalids dropped.
+
+    Trigger rule (mirrors :func:`vol_beta_status` against ``MIN_RETURNS_ANNUALIZED``):
+      - ``n_returns >= MIN_RETURNS_ANNUALIZED`` → ``ok``.
+      - below threshold AND ``invalids_dropped > 0`` → ``invalid_price_chain``.
+      - below threshold AND no invalids → ``partial_window``.
+    """
+    if n_returns >= MIN_RETURNS_ANNUALIZED:
+        return "ok"
+    if invalids_dropped > 0:
+        return "invalid_price_chain"
+    return "partial_window"
 
 
 def beta_status(
@@ -585,21 +621,24 @@ def compute_instrument_risk(
     inst_rets = simple_returns(inst_closes)
     inst_ret_vals = [r for _, r in inst_rets]
     n_returns = len(inst_ret_vals)
+    # Invalid closes break the return chain; track how many were dropped so a
+    # sub-threshold metric can report invalid_price_chain (vs short-but-clean).
+    invalids_dropped = _count_invalid_closes(inst_closes)
 
     vol = annualized_vol(inst_ret_vals)
-    vol_st = vol_beta_status(n_returns)
+    vol_st = vol_beta_status(n_returns, invalids_dropped)
 
     inst_cagr = cagr(inst_closes)
-    cagr_st = annualized_status(n_returns)
+    cagr_st = annualized_status(n_returns, invalids_dropped)
 
     dd = drawdown(inst_closes)
 
     calmar_val: Decimal | None = None
-    calmar_st: RiskStatus = "ok"
     if inst_cagr is not None and dd.max_drawdown is not None:
         calmar_val = calmar(inst_cagr, dd.max_drawdown)
-    if n_returns < MIN_RETURNS_ANNUALIZED:
-        calmar_st = "partial_window"
+    # Calmar shares the annualized min-obs threshold → reuse annualized_status so
+    # invalid-driven shortfalls surface as invalid_price_chain there too.
+    calmar_st = annualized_status(n_returns, invalids_dropped)
 
     dist = distribution(inst_ret_vals) if inst_ret_vals else None
 

--- a/app/services/risk_metrics.py
+++ b/app/services/risk_metrics.py
@@ -62,6 +62,11 @@ CALMAR_DD_EPSILON = Decimal("1e-9")
 
 WINDOW_KEYS: tuple[str, ...] = ("1y", "3y", "full")
 
+# Calendar-day lookback per window. ``full`` has NO lower bound (all closes).
+# A close survives the slice iff its date is within ``lookback`` days of the
+# as_of_date (and ≤ as_of_date, which the loaded series already guarantees).
+WINDOW_LOOKBACK_DAYS: dict[str, int | None] = {"1y": 365, "3y": 1095, "full": None}
+
 # The benchmark for beta / excess metrics. Resolved to an instrument_id at run
 # time (primary-listing tiebreak) the same way the candle-refresh scope does.
 SPY_SYMBOL = "SPY"
@@ -156,6 +161,17 @@ class WindowMetrics:
     excess_cagr_status: RiskStatus
     distribution: DistributionResult | None
     distribution_status: RiskStatus
+    # Trailing-return scalars (calendar-lookback from as_of_date). These are
+    # window-INDEPENDENT — identical across the 1y/3y/full rows — and computed
+    # on the FULL series, NOT the window slice. excess_* are null without SPY.
+    trailing_1m: Decimal | None
+    trailing_3m: Decimal | None
+    trailing_6m: Decimal | None
+    trailing_1y: Decimal | None
+    excess_trailing_1m: Decimal | None
+    excess_trailing_3m: Decimal | None
+    excess_trailing_6m: Decimal | None
+    excess_trailing_1y: Decimal | None
     trailing_status: RiskStatus
 
 
@@ -544,9 +560,14 @@ def _aligned_window(
 def excess_cagr(
     inst_closes: Sequence[PricePoint],
     spy_closes: Sequence[PricePoint],
-    window: str,  # noqa: ARG001 — window kept for caller symmetry / future per-window slicing
+    window: str,  # noqa: ARG001 — label only; the caller pre-slices both series to the window
 ) -> tuple[Decimal | None, RiskStatus]:
     """``cagr(inst over aligned window) - cagr(SPY over aligned window)``.
+
+    Window slicing happens UPSTREAM: :func:`compute_instrument_risk` slices both
+    series to ``window_key`` before calling this, so the inst/spy passed here are
+    already window-bounded and this just intersects their date extents. ``window``
+    is retained as a label for caller symmetry.
 
     ``benchmark_missing`` when SPY is absent; ``benchmark_insufficient_history``
     when the aligned overlap is too short to compute either CAGR.
@@ -683,6 +704,31 @@ def trailing_status(
 
 
 # ---------------------------------------------------------------------------
+# Window slicing
+# ---------------------------------------------------------------------------
+
+
+def _slice_window(
+    closes: Sequence[PricePoint],
+    as_of_date: date,
+    window_key: str,
+) -> list[PricePoint]:
+    """Keep the closes that fall inside the ``window_key`` calendar lookback.
+
+    A row survives iff ``as_of_date - lookback <= date <= as_of_date`` where
+    ``lookback = WINDOW_LOOKBACK_DAYS[window_key]``. ``full`` has no lower bound
+    (every close at/before ``as_of_date`` is kept). The loaded series is already
+    ≤ as_of_date, but the upper bound is enforced here too so a stray future bar
+    cannot leak into a window. Row order is preserved (callers assume ascending).
+    """
+    lookback = WINDOW_LOOKBACK_DAYS[window_key]
+    if lookback is None:
+        return [(d, raw) for d, raw in closes if d <= as_of_date]
+    cutoff = as_of_date - timedelta(days=lookback)
+    return [(d, raw) for d, raw in closes if cutoff <= d <= as_of_date]
+
+
+# ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
 
@@ -695,27 +741,41 @@ def compute_instrument_risk(
 ) -> WindowMetrics:
     """Compute all risk metrics for ONE instrument over ONE window.
 
-    Standalone metrics (vol, cagr, drawdown, calmar, distribution) use the
-    instrument's full valid history within the window. Benchmark metrics (beta,
-    excess_cagr) use the aligned-overlap window with SPY.
+    The instrument and SPY series are FIRST sliced to ``window_key``'s calendar
+    lookback (1y / 3y / full) via :func:`_slice_window`. Every standalone metric
+    (vol, cagr, drawdown, calmar, distribution) is then computed on the sliced
+    instrument series, and the benchmark metrics (beta, excess_cagr) on the
+    sliced+aligned overlap with SPY. ``n_returns`` and ``window_days`` reflect
+    the sliced window, so the three windows produce distinct metrics.
+
+    EXCEPTION — trailing returns. ``trailing_*`` / ``excess_trailing_*`` are
+    calendar-lookback from ``as_of_date`` and therefore window-INDEPENDENT; they
+    are computed on the FULL (unsliced) series and are intentionally identical
+    across the 1y/3y/full rows. ``trailing_status`` is likewise the full-series
+    rollup. excess_trailing is null when SPY is absent.
     """
-    inst_rets = simple_returns(inst_closes)
+    # Slice BOTH series to the window first; all window metrics derive from these.
+    inst_w = _slice_window(inst_closes, as_of_date, window_key)
+    spy_w = _slice_window(spy_closes, as_of_date, window_key)
+
+    inst_rets = simple_returns(inst_w)
     inst_ret_vals = [r for _, r in inst_rets]
     n_returns = len(inst_ret_vals)
     # Invalid closes break the return chain; track how many were dropped so a
     # sub-threshold metric can report invalid_price_chain (vs short-but-clean).
-    invalids_dropped = _count_invalid_closes(inst_closes)
+    # Scoped to the window — an invalid bar outside the window is irrelevant here.
+    invalids_dropped = _count_invalid_closes(inst_w)
 
     vol = annualized_vol(inst_ret_vals)
     vol_st = vol_beta_status(n_returns, invalids_dropped)
 
-    inst_cagr = cagr(inst_closes)
+    inst_cagr = cagr(inst_w)
     cagr_st = annualized_status(n_returns, invalids_dropped)
 
-    dd = drawdown(inst_closes)
+    dd = drawdown(inst_w)
     # Drawdown is computed off the VALID close sub-chain (≥ 2 needed). The total
-    # raw rows minus invalids gives the usable chain length.
-    valid_closes = len(inst_closes) - invalids_dropped
+    # windowed rows minus invalids gives the usable chain length.
+    valid_closes = len(inst_w) - invalids_dropped
     dd_st = drawdown_status(valid_closes, invalids_dropped)
 
     calmar_val: Decimal | None = None
@@ -728,14 +788,32 @@ def compute_instrument_risk(
     dist = distribution(inst_ret_vals) if inst_ret_vals else None
     dist_st = distribution_status(n_returns, invalids_dropped)
 
-    trailing_st = trailing_status(inst_closes, as_of_date, invalids_dropped)
-
     spy_present = bool(spy_closes)
-    spy_rets = simple_returns(spy_closes)
+    spy_rets = simple_returns(spy_w)
     beta_res = ols_beta(inst_rets, spy_rets)
     beta_st = beta_status(beta_res.n_obs, spy_present)
 
-    xs_cagr, xs_cagr_st = excess_cagr(inst_closes, spy_closes, window_key)
+    # excess_cagr over the window-sliced aligned overlap. SPY presence is GLOBAL:
+    # if SPY exists overall but has no rows inside this window, the shortfall is
+    # benchmark_insufficient_history (not benchmark_missing). Pass spy_w (already
+    # sliced) but force the missing-vs-insufficient distinction off the global
+    # series so an empty window slice doesn't masquerade as "no benchmark".
+    if not spy_present:
+        xs_cagr, xs_cagr_st = None, "benchmark_missing"
+    else:
+        xs_cagr, xs_cagr_st = excess_cagr(inst_w, spy_w, window_key)
+        if xs_cagr_st == "benchmark_missing":
+            # spy_w empty within the window though SPY exists globally.
+            xs_cagr_st = "benchmark_insufficient_history"
+
+    # Trailing returns are window-INDEPENDENT: computed on the FULL series.
+    trailing: dict[str, Decimal | None] = {}
+    excess_trailing: dict[str, Decimal | None] = {}
+    for key, lookback in TRAILING_LOOKBACK_DAYS.items():
+        trailing[key] = trailing_return(inst_closes, as_of_date, lookback)
+        xs_val, _ = excess_trailing_return(inst_closes, spy_closes, as_of_date, lookback)
+        excess_trailing[key] = xs_val
+    trailing_st = trailing_status(inst_closes, as_of_date, _count_invalid_closes(inst_closes))
 
     return WindowMetrics(
         window_key=window_key,
@@ -757,6 +835,14 @@ def compute_instrument_risk(
         excess_cagr_status=xs_cagr_st,
         distribution=dist,
         distribution_status=dist_st,
+        trailing_1m=trailing["1m"],
+        trailing_3m=trailing["3m"],
+        trailing_6m=trailing["6m"],
+        trailing_1y=trailing["1y"],
+        excess_trailing_1m=excess_trailing["1m"],
+        excess_trailing_3m=excess_trailing["3m"],
+        excess_trailing_6m=excess_trailing["6m"],
+        excess_trailing_1y=excess_trailing["1y"],
         trailing_status=trailing_st,
     )
 
@@ -892,7 +978,7 @@ def _count_valid_closes(closes: Sequence[tuple[date, Decimal | None]]) -> int:
     return sum(1 for _, raw in closes if _valid_close(raw) is not None)
 
 
-def _window_days(closes: Sequence[tuple[date, Decimal | None]]) -> int | None:
+def _window_days(closes: Sequence[PricePoint]) -> int | None:
     """Calendar span (days) of the valid close sub-chain, else None for < 2 valid."""
     valid = [d for d, raw in closes if _valid_close(raw) is not None]
     if len(valid) < 2:
@@ -903,25 +989,24 @@ def _window_days(closes: Sequence[tuple[date, Decimal | None]]) -> int | None:
 def _metrics_row_values(
     metrics: WindowMetrics,
     inst_closes: Sequence[tuple[date, Decimal | None]],
-    spy_closes: Sequence[tuple[date, Decimal | None]],
+    spy_closes: Sequence[tuple[date, Decimal | None]],  # noqa: ARG001 — kept for caller symmetry
     as_of_date: date,
     benchmark_instrument_id: int | None,
 ) -> dict[str, object]:
     """Build the business-column value dict for one (instrument, window) row.
 
-    Trailing returns are absolute-lookback (1m/3m/6m/1y) and computed here from
-    the same as_of_date / close series — they are window-independent but
-    persisted on every window row.
+    Window-DEPENDENT evidence (peak/trough dates, window_days) is recomputed off
+    the SAME window slice the metrics used (``metrics.window_key``), so it stays
+    consistent with the now-sliced vol/cagr/drawdown. Trailing returns are taken
+    directly from the window-INDEPENDENT WindowMetrics scalars (computed on the
+    full series) — they are identical across window rows.
     """
     dist = metrics.distribution
-    # peak/trough dates are not on WindowMetrics; recompute off the same chain.
-    dd = drawdown(inst_closes)
-    trailing: dict[str, Decimal | None] = {}
-    excess_trailing: dict[str, Decimal | None] = {}
-    for key, lookback in TRAILING_LOOKBACK_DAYS.items():
-        trailing[key] = trailing_return(inst_closes, as_of_date, lookback)
-        xs_val, _ = excess_trailing_return(inst_closes, spy_closes, as_of_date, lookback)
-        excess_trailing[key] = xs_val
+    # peak/trough dates are not on WindowMetrics; recompute off the same window
+    # slice the drawdown metric used (NOT the full series — that would make the
+    # peak/trough disagree with the sliced max_drawdown).
+    inst_w = _slice_window(inst_closes, as_of_date, metrics.window_key)
+    dd = drawdown(inst_w)
 
     return {
         "cagr": metrics.cagr,
@@ -939,18 +1024,18 @@ def _metrics_row_values(
         "worst_day": dist.worst_day if dist else None,
         "best_day": dist.best_day if dist else None,
         "calmar": metrics.calmar,
-        "trailing_1m": trailing["1m"],
-        "trailing_3m": trailing["3m"],
-        "trailing_6m": trailing["6m"],
-        "trailing_1y": trailing["1y"],
-        "excess_trailing_1m": excess_trailing["1m"],
-        "excess_trailing_3m": excess_trailing["3m"],
-        "excess_trailing_6m": excess_trailing["6m"],
-        "excess_trailing_1y": excess_trailing["1y"],
+        "trailing_1m": metrics.trailing_1m,
+        "trailing_3m": metrics.trailing_3m,
+        "trailing_6m": metrics.trailing_6m,
+        "trailing_1y": metrics.trailing_1y,
+        "excess_trailing_1m": metrics.excess_trailing_1m,
+        "excess_trailing_3m": metrics.excess_trailing_3m,
+        "excess_trailing_6m": metrics.excess_trailing_6m,
+        "excess_trailing_1y": metrics.excess_trailing_1y,
         "n_returns": metrics.n_returns,
         "beta_n_obs": metrics.beta_n_obs,
         "benchmark_instrument_id": benchmark_instrument_id,
-        "window_days": _window_days(inst_closes),
+        "window_days": _window_days(inst_w),
         "cagr_status": metrics.cagr_status,
         "vol_status": metrics.vol_status,
         "beta_status": metrics.beta_status,

--- a/app/services/sync_orchestrator/adapters.py
+++ b/app/services/sync_orchestrator/adapters.py
@@ -294,6 +294,22 @@ def refresh_monthly_reports(
     )
 
 
+def refresh_risk_metrics(
+    *,
+    sync_run_id: int,
+    progress: ProgressCallback,
+    upstream_outcomes: Mapping[str, LayerOutcome],
+) -> Sequence[tuple[str, RefreshResult]]:
+    from app.workers.scheduler import risk_metrics_refresh
+
+    return _wrap_single(
+        job_name="risk_metrics_refresh",
+        layer_name="risk_metrics",
+        legacy_fn=risk_metrics_refresh,
+        progress=progress,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Composite adapters (spec §2.3.1)
 # ---------------------------------------------------------------------------

--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -265,6 +265,13 @@ def cost_models_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
     return _fresh_by_audit(conn, "seed_cost_models", timedelta(hours=24))
 
 
+def risk_metrics_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
+    # Weekly cadence (#591): risk metrics are recomputed from price
+    # history, which only meaningfully shifts on a weekly horizon. A
+    # 7-day audit window matches the layer cadence.
+    return _fresh_by_audit(conn, "risk_metrics_refresh", timedelta(days=7))
+
+
 def weekly_reports_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
     return _fresh_by_audit(conn, "weekly_report", timedelta(days=7))
 

--- a/app/services/sync_orchestrator/registry.py
+++ b/app/services/sync_orchestrator/registry.py
@@ -21,6 +21,7 @@ from app.services.sync_orchestrator.adapters import (
     refresh_fx_rates,
     refresh_monthly_reports,
     refresh_portfolio_sync,
+    refresh_risk_metrics,
     refresh_scoring_and_recommendations,
     refresh_universe,
     refresh_weekly_reports,
@@ -37,6 +38,7 @@ from app.services.sync_orchestrator.freshness import (
     monthly_reports_is_fresh,
     portfolio_sync_is_fresh,
     recommendations_is_fresh,
+    risk_metrics_is_fresh,
     scoring_is_fresh,
     universe_is_fresh,
     weekly_reports_is_fresh,
@@ -93,6 +95,10 @@ class DataLayer:
 # tests/test_sync_orchestrator_credential_gate.py.
 INIT_CHECKS: dict[str, str] = {
     "universe": "SELECT EXISTS (SELECT 1 FROM instruments WHERE is_tradable = true)",
+    # risk_metrics declares ``requires_layer_initialized=("candles",)`` — the
+    # pre-flight gate raises if a named dep has no INIT_CHECKS entry, so the
+    # candles initialization predicate must exist (#591 / Codex ckpt-1 HIGH).
+    "candles": "SELECT EXISTS (SELECT 1 FROM price_daily)",
 }
 
 
@@ -196,6 +202,23 @@ LAYERS: dict[str, DataLayer] = {
         dependencies=("universe",),
         plain_language_sla="Re-seeded nightly.",
     ),
+    "risk_metrics": DataLayer(
+        name="risk_metrics",
+        display_name="Risk Metrics",
+        # Tier 2 — one below candles (tier 1), which it derives from.
+        tier=2,
+        cadence=Cadence(interval=timedelta(days=7)),
+        is_fresh=risk_metrics_is_fresh,
+        refresh=refresh_risk_metrics,
+        dependencies=("candles",),
+        # Layer-initialization gate: candles must have at least one
+        # price_daily row before risk metrics can compute. Stricter than
+        # the per-tick ``dependencies`` so a fresh install doesn't compute
+        # on an empty price table. INIT_CHECKS["candles"] backs this.
+        requires_layer_initialized=("candles",),
+        is_blocking=False,
+        plain_language_sla="Recomputed weekly from price history.",
+    ),
     "weekly_reports": DataLayer(
         name="weekly_reports",
         display_name="Weekly Performance Report",
@@ -240,6 +263,7 @@ JOB_TO_LAYERS: dict[str, tuple[str, ...]] = {
     "weekly_report": ("weekly_reports",),
     "monthly_report": ("monthly_reports",),
     "fx_rates_refresh": ("fx_rates",),
+    "risk_metrics_refresh": ("risk_metrics",),
     # Outside-DAG (6 entries, empty tuples):
     "execute_approved_orders": (),
     "fundamentals_sync": (),

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -315,6 +315,11 @@ JOB_PORTFOLIO_EOD_SNAPSHOT = "portfolio_eod_snapshot"
 # historical FX backfill into fx_rates_daily. Not in SCHEDULED_JOBS — the
 # eod-snapshot job self-backfills on first run; this is the operator re-run.
 JOB_FX_HISTORY_BACKFILL = "fx_history_backfill"
+# Risk metrics (#591 PR-B). Orchestrator-driven (DAG layer "risk_metrics",
+# dependency on candles) + manual-trigger-only — deliberately NOT in
+# SCHEDULED_JOBS (the layer's own weekly cadence + freshness gate the DAG
+# walk; a ScheduledJob row would double-fire alongside the orchestrator).
+JOB_RISK_METRICS_REFRESH = "risk_metrics_refresh"
 JOB_ATTRIBUTION_SUMMARY = "attribution_summary"
 JOB_WEEKLY_REPORT = "weekly_report"
 # JOB_WEEKLY_COVERAGE_AUDIT + JOB_WEEKLY_COVERAGE_REVIEW retired in Chunk 2 of
@@ -4042,6 +4047,24 @@ def fx_history_backfill_job() -> None:
             written = ensure_fx_history(conn, until=today)
             conn.commit()
         tracker.row_count = written
+
+
+def risk_metrics_refresh() -> None:
+    """Recompute + persist per-instrument risk metrics from price history (#591).
+
+    DB-only producer (no external I/O): reads ``price_daily`` (+ benchmark
+    candles), computes the windowed risk-metric set (CAGR, vol, drawdown,
+    Calmar, beta, …), and write-throughs to the risk-metrics store.
+    Orchestrator-driven via the ``risk_metrics`` DAG layer (weekly cadence,
+    depends on ``candles``) and operator-triggerable via the
+    ``risk_metrics`` manual lane. Mirrors ``portfolio_eod_snapshot_job``'s
+    ``_tracked_job`` + own-connection + ``tracker.row_count`` shape.
+    """
+    from app.services.risk_metrics import compute_and_store_risk_metrics
+
+    with _tracked_job(JOB_RISK_METRICS_REFRESH) as tracker:
+        with psycopg.connect(settings.database_url) as conn:
+            tracker.row_count = compute_and_store_risk_metrics(conn)
 
 
 def exchanges_metadata_refresh() -> None:

--- a/docs/superpowers/plans/2026-06-14-instrument-risk-drill-pr-b.md
+++ b/docs/superpowers/plans/2026-06-14-instrument-risk-drill-pr-b.md
@@ -1,0 +1,156 @@
+# #591 PR-B — risk-metrics service + endpoint (bite-sized TDD plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]` checkboxes. TDD throughout: failing test → run-fail → implement → run-pass → commit.
+
+**Branch:** `feature/591-risk-metrics-service` (off main `3f7966ec`).
+**Parent:** epic #591, roadmap R4. **Spec:** `docs/superpowers/specs/2026-06-14-instrument-risk-drill-design.md` (§PR-B authoritative). PR-A merged (PR #1631).
+
+**Goal:** A versioned (`risk_v1`), windowed (1y/3y/full), quality-flagged backend risk-metrics evidence layer computed from `price_daily.close` (instrument + SPY), persisted in the repo's two-layer pattern (append-only partitioned observations + write-through current), refreshed by the orchestrator DAG, served by `GET /instruments/{symbol}/risk-metrics`. Page (PR-C) renders it; thesis/ranking consumption are filed follow-ups (#1632/#1633).
+
+> **Plan rev 2** — Codex ckpt-1 (2026-06-14) rejected a current-only simplification (BLOCKER): `price_daily` is mutable (`market_data.py:321 ON CONFLICT … DO UPDATE` — vendor corrections rewrite OHLCV), so risk metrics are NOT reconstructable and the append-only observation history captures real, otherwise-lost state. Reverted to the spec's append-only design via the repo's two-layer pattern. Also folded Codex's 4 wiring fixes (orchestrator-driven not standalone-cron; INIT_CHECKS["candles"]; per-instrument as_of_date; current-table as_of advance) + math pins.
+
+---
+
+## Storage — two-layer (data-engineer recipe + spec append-only)
+
+Mirrors the canonical ownership two-layer pattern (`sql/114_ownership_institutions_observations.sql`, partition horizon `sql/177`):
+
+**`instrument_risk_metrics_observations`** — append-only audit log, `PARTITION BY RANGE (as_of_date)`, **quarterly** partitions (mirror `sql/177` template; real lower bound `2010-01-01`, never MINVALUE) + a `_default` catch-all.
+- PK `(instrument_id, as_of_date, metric_version, window_key, computed_at)` (window_key in PK — else 1y/3y/full collide; **`computed_at` in PK** — Codex rev2 BLOCKER: a vendor correction to a historical bar that does NOT advance the latest close date produces different metrics on the same `(instrument_id, as_of_date, version, window_key)` — without `computed_at` the recompute collides and is silently dropped, defeating the whole append-only-because-mutable rationale). `as_of_date` is the partition key and is in the PK ✓ (Postgres requires partition key ⊆ unique key).
+- **Content-dedup append:** INSERT a new observation only when the computed content **differs** from the most recent existing row for `(instrument_id, as_of_date, metric_version, window_key)` (look up `ORDER BY computed_at DESC LIMIT 1`, compare scalars+statuses). Identical re-run (e.g. intra-day manual re-trigger, no new data) → skip. Correction (same as_of, changed content) → new `computed_at` row. Normal weekly advance (new as_of) → new key → always insert. Never UPDATE in place (audit history is immutable).
+- `as_of_date DATE NOT NULL` = the date of the **instrument's own latest VALID close** actually used by the compute (Codex rev2 MED: NOT raw `MAX(price_date)` — `close` is nullable and invalids are excluded/break the chain; stamping a date whose close wasn't used would lie). If the latest raw row is invalid/null, as_of = the prior valid date.
+- Columns (all returns stored as **FRACTIONS**, 0.10 = 10%; column names carry NO `_pct` suffix — the suffix would lie; the API/FE multiplies ×100 for display): `cagr`, `excess_cagr_vs_spy`, `max_drawdown`, `max_dd_peak_date DATE`, `max_dd_trough_date DATE`, `current_drawdown`, `vol_annualized`, `beta`, `beta_r2`, `skew`, `excess_kurtosis`, `var_5` (signed), `worst_day`, `best_day`, `calmar`, `trailing_1m`/`3m`/`6m`/`1y`, `excess_trailing_1m`/`3m`/`6m`/`1y` (all `NUMERIC`).
+- Evidence: `n_returns INT` (instrument own chain length — floors vol/dist/cagr/trailing), `beta_n_obs INT` (aligned-pair count — floors beta/excess), `benchmark_instrument_id BIGINT` (stored + validated at write; **no DB FK** — observation log must survive instrument churn, per data-engineer), `window_days INT`, `computed_at TIMESTAMPTZ NOT NULL DEFAULT now()`.
+- Per-metric **discrete CHECK status columns** (NOT a `quality` JSONB — zero JSONB-status precedent; closed enum; indexable): `cagr_status`, `vol_status`, `beta_status`, `drawdown_status`, `distribution_status`, `calmar_status`, `trailing_status`, each `TEXT CHECK (… IN ('ok','insufficient_history','partial_window','benchmark_missing','benchmark_insufficient_history','invalid_price_chain','stale'))`. Per-metric grain so an instrument with good prices but no SPY overlap reads `vol_status='ok'`, `beta_status='benchmark_missing'`.
+- `window_key TEXT CHECK (window_key IN ('1y','3y','full'))` (extendable by a one-line later migration if 6m added).
+- `metric_version TEXT NOT NULL` (in PK so `risk_v2` coexists).
+- **Write-boundary guard:** reject `as_of_date > current_date` (DEFAULT-partition alarm is a lagging indicator otherwise — prevention-log §DEFAULT). Test `_default` is empty post-backfill.
+- Index `(instrument_id, as_of_date DESC)` — the `_current` rebuild source + operator "as of date X" query.
+
+**`instrument_risk_metrics_current`** — latest-only write-through for fast reads.
+- PK `(instrument_id, metric_version, window_key)`. Same scalar/status/evidence columns + `as_of_date DATE NOT NULL` + `computed_at TIMESTAMPTZ` (carried from the winning observation, for the tuple tiebreak) + `refreshed_at TIMESTAMPTZ` (this table's own write time, SET-only).
+- Populated from observations: `INSERT … SELECT DISTINCT ON (instrument_id, metric_version, window_key) … ORDER BY instrument_id, metric_version, window_key, as_of_date DESC, computed_at DESC ON CONFLICT (instrument_id, metric_version, window_key) DO UPDATE SET <all cols incl as_of_date, refreshed_at> WHERE (excluded.as_of_date, excluded.computed_at) > (instrument_risk_metrics_current.as_of_date, instrument_risk_metrics_current.computed_at) OR (<business scalar+status cols>) IS DISTINCT FROM (<excluded …>)`. The `(as_of_date, computed_at) >` tuple advances `_current` to a newer snapshot OR a same-as_of correction (Codex rev2: deterministic tiebreak once same-as_of observations exist). The `as_of_date >` clause makes a fresh snapshot advance `as_of_date` even when rounded values are unchanged (Codex HIGH — SET-only would freeze the page's data date); `refreshed_at`/`computed_at` are in the SET only, **never** in the IS DISTINCT FROM tuple (prevention-log §MERGE bloat variant-A). Churn = ~15k rows/week max, trivial.
+- Index `(window_key, metric_version)` for the ranking "all instruments at 3y" scan (#1633).
+
+**Retention:** none shipped — the observations table IS the audit log and is kept. Justified in the migration header: at the 7-day cadence growth is ~5,138 subjects × 3 windows × 52 ≈ 800k rows/yr (~150 MB/yr), quarterly-partitioned, crosses 1M rows in ~15mo and 1GB in ~6yr — bounded; `DROP PARTITION` is available if a horizon is ever wanted; retention would defeat the audit purpose. File a tracking follow-up (#TBD risk-metrics retention-when-needed). This is the data-engineer's "OR justify in the migration comment" escape from the mega-table NOT-MERGEABLE clause.
+
+**Mega-table compliance:** partitioned at design-time ✓ (>1M rows within 15mo); real lower bound + DEFAULT-empty test ✓; bloat-safe upsert ✓.
+
+---
+
+## Orchestrator wiring — DAG-driven, NOT a standalone cron (Codex HIGH)
+
+`daily_candle_refresh` is **not** in `SCHEDULED_JOBS`; the candles layer is fired by `orchestrator_full_sync` (daily 03:00 UTC walks the DAG, calls each layer's `refresh` adapter, gated by the layer's own `cadence` + `is_fresh`). Registering risk_metrics as BOTH a DAG node and a `ScheduledJob` would double-fire. So:
+- **DAG node only** in `registry.LAYERS` with `cadence=Cadence(interval=timedelta(days=7))` — the orchestrator refreshes it weekly (skips while fresh).
+- `_INVOKERS` entry + a `MANUAL_TRIGGER_JOB_SOURCES` lane entry → operator can `POST /jobs/risk_metrics_refresh/run` on demand; gives it a JobLock lane.
+- **NO `ScheduledJob` entry.**
+- `requires_layer_initialized=("candles",)` REQUIRES adding `INIT_CHECKS["candles"]` (Codex HIGH — only `universe` exists today); else the preflight gate raises "no INIT_CHECKS entry".
+
+---
+
+## Math contracts (quant wash — each becomes a unit test)
+
+- **Returns:** SIMPLE, `r = close[i]/close[i-1] - 1` between **consecutive surviving** rows. Valid close iff finite & `> 0`. Invalid row **breaks the chain** — no gap-spanning synthetic return; r keyed to the **later** close's date.
+- **Decimal everywhere EXCEPT one sanctioned float island:** skew, excess_kurtosis, var_5 percentile in `float` (numpy 2.4.4, already a dep; two-pass — mean then central moments) → quantized at the persistence boundary via `Decimal(str(round(v, 8)))` (note: rounding, pinned by test — not bit-exact quantize). Reason: Decimal has no fractional power for `m3/m2**1.5`; cubing tiny deviations in Decimal is numerically worse. Returns/vol/drawdown/beta/CAGR/Calmar stay end-to-end Decimal. `Decimal(str(x))` at every DB-numeric boundary (prevention-log #925).
+- **vol:** sample std (n−1) × `Decimal(252).sqrt()`. `TRADING_DAYS=252` constant. ≥2 returns else null.
+- **CAGR:** **calendar-time** `(final/first)^(Decimal(365)/Decimal(calendar_days)) - 1` (`calendar_days=(last-first).days`); NOT `(252/n_returns)` (inflates on gaps). Calmar numerator uses the SAME fn. `calendar_days==0` → null.
+- **Calmar:** `annualized_return / abs(max_drawdown)`; `abs(max_dd) < Decimal("1e-9")` → null; inherits `partial_window`.
+- **drawdown:** running peak; `dd[i]=close[i]/peak[i]-1` (≤0); `max_drawdown=min(dd)`, `current_drawdown=dd[-1]`, peak/trough dates.
+- **beta (OLS):** date-aligned only — `{date:return}` both, **intersect keys**, regress on intersection. `beta=cov/var_m`, `r2=corr²` (closed form). n−1 denominators (match). Guards: `var_m==0`→beta null; `var_i==0 or var_m==0`→r2 null; `<2` pairs→both null + n_obs. **NEVER positional-zip.** No alpha.
+- **distribution:** shared `_sample_std` (n−1, same as vol). `skew`, `excess_kurtosis=m4/m2²-3` (Fisher, biased moment form), `var_5`=type-7 linear-interpolation 5th percentile (`h=0.05·(n-1)`), **signed** (persist as-is), `worst_day=min`, `best_day=max`, `n_obs`. Low-sample flag `n_obs<250`.
+- **trailing returns (1m/3m/6m/1y):** RECOMPUTED here (NOT `price_daily.return_*` latest-row-only cols). Window semantics: calendar lookback (1m=30d,3m=91d,6m=182d,1y=365d) from as_of; return = `close[as_of]/close[nearest valid close ≤ as_of−lookback] - 1`; null + status if no close ≥ lookback ago. `excess_trailing_* = instrument − SPY same calendar window` (uses beta-alignment dates; status `benchmark_missing` if no SPY). Floors on `n_returns`/`beta_n_obs`.
+- **excess_cagr_vs_spy:** first-class — `cagr(instrument over aligned window) − cagr(SPY over aligned window)`; status mirrors beta (benchmark_missing / benchmark_insufficient_history). Own test.
+- **windows:** standalone metrics (drawdown/CAGR/vol/dist/trailing) use instrument full valid history in window. **Benchmark metrics (beta, excess_cagr, excess_trailing)** use the aligned-overlap window from `max(first valid instrument return date, first valid SPY return date)`.
+- **boundaries:** count **returns** not closes — vol/beta need ≥60 returns (≥61 consecutive closes; 61 closes with one mid-gap = 59 returns → fails). annualized partial_window threshold = <252 returns.
+- **`invalid_price_chain` trigger:** invalids always break the chain (no synthetic return). A metric emits `invalid_price_chain` ONLY when invalids are why its valid sub-chain fell below its min-obs; otherwise compute normally on the valid sub-chain (a single break with enough remaining obs is `ok`/`partial_window`).
+
+---
+
+## File structure
+
+Create: `app/services/risk_metrics.py`, `sql/198_instrument_risk_metrics.sql`, `tests/test_risk_metrics.py`, `tests/test_risk_metrics_wiring.py`, `tests/test_api_risk_metrics.py`.
+Modify: `app/workers/scheduler.py` (const + job fn, **no ScheduledJob**), `app/jobs/runtime.py` (`_INVOKERS`), `app/jobs/sources.py` (`risk_metrics` Lane + `MANUAL_TRIGGER_JOB_SOURCES`), `app/services/sync_orchestrator/registry.py` (LAYERS node + `JOB_TO_LAYERS` + `INIT_CHECKS["candles"]`), `adapters.py` (`refresh_risk_metrics`), `freshness.py` (`risk_metrics_is_fresh`), `app/api/instruments.py` (models + endpoint), `.claude/skills/market-data/SKILL.md` + `.claude/skills/metrics-analyst/SKILL.md`.
+
+---
+
+## Task B1 — `risk_metrics.py` pure compute (TDD, no DB)
+
+Constants: `RISK_METRICS_VERSION="risk_v1"`, `TRADING_DAYS=252`, `ZERO=Decimal("0")`, `MIN_RETURNS_VOL_BETA=60`, `MIN_RETURNS_ANNUALIZED=252`, `MIN_OBS_MOMENTS=250`, `CALMAR_DD_EPSILON=Decimal("1e-9")`, `WINDOW_KEYS=("1y","3y","full")`, status `Literal` + `RiskStatus` set, trailing lookback-day map.
+
+Pure fns, each TDD'd (failing test → run-fail → implement → run-pass → commit per group):
+- [ ] `daily_returns(rows) -> list[(date, Decimal)]` — valid-close chain. Tests: `[100,110,121]`→`[0.10,0.10]`; mid-series NaN/0/negative (each a case) → break, no gap return, correct date keys both sides; <2 valid → empty.
+- [ ] `_sample_std(returns) -> Decimal|None` — n−1, None<2.
+- [ ] `annualized_vol(returns)` — `_sample_std×Decimal(252).sqrt()`. Tests: hand std×√252; 1 return→None; equals distribution std.
+- [ ] `drawdown(closes) -> DrawdownResult`. Tests: monotonic→0/0; V `[100,120,60,90]`→max=−0.5(trough@60),current=−0.25,peak@120; open dd→current==max.
+- [ ] `ols_beta(inst, bench) -> BetaResult`. Tests: `r_i=2·r_m`→beta=2,r2=1,n_obs; `0.5·r_m+noise` hand value; flat bench→null; **date-misalign**→date-join beta=2 ≠ positional-zip; <2 pairs→null+n_obs; aligned start=max(first dates) excludes earlier inst-only history.
+- [ ] `distribution(returns) -> DistributionResult` — float island. Tests: var_5 sign<0 + exact type-7 on fixed 20-array; symmetric skew~0; right-skew>0; heavy-tail kurt>0, normal~0; constant→variance0→null (no div0); n<250→low_sample; worst==min,best==max; persisted type is Decimal.
+- [ ] `cagr(closes)` — calendar-time. Tests: 2× over 365d→1.0; **same total_return diff gap counts→SAME cagr** (anti-regression for 252/n_returns); calendar_days=0→null.
+- [ ] `calmar(ann_ret, max_dd)`. Tests: known fixture; abs(max_dd)<1e-9→null; partial_window inherit.
+- [ ] `trailing_return(closes, as_of, lookback_days)` + `excess`. Tests: nearest-prior-close pick; no close ≥lookback→null+status.
+- [ ] `excess_cagr(inst, spy, window)` — first-class. Tests: aligned diff; no SPY→benchmark_missing.
+- [ ] status helpers — (n_returns, aligned n, window coverage, benchmark presence, snapshot staleness, invalid-chain)→per-metric status. Tests: 60→ok/59→insufficient; <252→partial_window (251 vs 252); SPY absent→beta benchmark_missing while vol ok; SPY short overlap→benchmark_insufficient_history; invalids dropping below min→invalid_price_chain.
+- [ ] `compute_instrument_risk(inst_closes, spy_closes, window_key, as_of_date) -> WindowMetrics` — orchestrates per window; window slice + benchmark alignment. Tests: slicing; full-window benchmark alignment with different starts.
+
+Result types: frozen dataclasses carrying scalars + per-metric status + n_obs.
+
+## Task B2 — `sql/198_instrument_risk_metrics.sql`
+
+- [ ] `instrument_risk_metrics_observations` partitioned quarterly (mirror `sql/114`+`sql/177` DO-loop, lower bound `2010-01-01`, `_default`) + indexes, per Storage section. PK incl as_of_date+window_key. Per-metric CHECK status cols. No FK.
+- [ ] `instrument_risk_metrics_current` (PK without as_of_date) + `(window_key, metric_version)` index.
+- [ ] Header: provenance (#591 PR-B rev2), append-only-because-price_daily-mutable rationale, retention-none justification, spec link. Idempotent (`IF NOT EXISTS`, per-col `ADD COLUMN IF NOT EXISTS`). **198 is next free; never edit after applied (prevention-log #1333) — fixes go in 199.**
+- [ ] db-tier test: `_default` empty post-insert; partition routing for a current-quarter as_of.
+
+## Task B3 — persist layer in `risk_metrics.py`
+
+- [ ] `load_close_series(conn, instrument_id, end_date)` — mirror `return_attribution._load_price_series` (`SELECT price_date, close FROM price_daily WHERE instrument_id=%s AND close IS NOT NULL AND price_date<=%s ORDER BY price_date ASC`), `Decimal(str(...))`.
+- [ ] `compute_and_store_risk_metrics(conn) -> int`:
+  - **Read phase under `snapshot_read(conn)`** (Codex rev2 HIGH — a plain `conn.transaction()` is READ COMMITTED; concurrent candle refresh/correction would let different instruments see different candle states). Resolve scope = instruments with **≥2 valid closes** (≥1 return computable) + `BENCHMARK_SYMBOLS`; load SPY close series once; load each scoped instrument's close series. Build all results in memory. (snapshot_read commits the pending txn on entry — do all reads here, no writes.)
+  - **Compute:** per instrument, `as_of_date = date of the latest VALID close in its chain` (not raw MAX(price_date)); compute all windows (thin-history instruments get null metrics + per-metric `insufficient_history`/`partial_window` statuses — Codex rev2 HIGH: persist the flagged row, do NOT exclude, so the endpoint contract "insufficient-history returns flagged not absence" holds). Guard `as_of_date ≤ current_date`.
+  - **Write phase (separate txn):** for each (instrument, as_of, version, window), content-dedup append into observations — read latest row for the key (`ORDER BY computed_at DESC LIMIT 1`), INSERT only if scalars+statuses differ (or none exists); then rebuild `_current` from observations via the `(as_of_date, computed_at) >`-gated upsert (Storage section). Return observation rows written.
+  - Instruments with **0–1 valid closes** → no row (endpoint 404/no-data for those).
+- [ ] db-tier tests: (a) synthetic candles 1 instrument + SPY → observation + current row, sane scalars+statuses; (b) re-run unchanged → no new observation (content-dedup), current unchanged (no churn); (c) **correction same as_of, changed historical close → new observation row (new computed_at) + current advances** (the rev2 BLOCKER scenario); (d) thin-history instrument (<60 returns) → persisted row with flagged statuses, not absent.
+
+## Task B4 — orchestrator wiring
+
+- [ ] `freshness.py`: `risk_metrics_is_fresh(conn)` = `_fresh_by_audit(conn, "risk_metrics_refresh", timedelta(days=7) × grace)`.
+- [ ] `registry.py`: `INIT_CHECKS["candles"] = "SELECT EXISTS (SELECT 1 FROM price_daily)"` (Codex HIGH). `LAYERS["risk_metrics"] = DataLayer(name="risk_metrics", display_name="Risk Metrics", tier=2, cadence=Cadence(interval=timedelta(days=7)), is_fresh=risk_metrics_is_fresh, refresh=refresh_risk_metrics, dependencies=("candles",), requires_layer_initialized=("candles",), is_blocking=False, plain_language_sla="Recomputed weekly from price history.")`. `JOB_TO_LAYERS["risk_metrics_refresh"]=("risk_metrics",)`.
+- [ ] `adapters.py`: `refresh_risk_metrics(*, sync_run_id, progress, upstream_outcomes)` → `_wrap_single(job_name="risk_metrics_refresh", layer_name="risk_metrics", legacy_fn=risk_metrics_refresh, progress=progress)`.
+- Wiring tests: node present, depends candles, is_blocking False, INIT_CHECKS["candles"] present, JOB_TO_LAYERS maps, adapter callable.
+
+## Task B5 — job fn + invoker + lane (NO ScheduledJob)
+
+- [ ] `scheduler.py`: `JOB_RISK_METRICS_REFRESH="risk_metrics_refresh"`; `def risk_metrics_refresh() -> None` (mirror `portfolio_eod_snapshot_job`: `_tracked_job` + `psycopg.connect`; `tracker.row_count=compute_and_store_risk_metrics(conn)`). **No `ScheduledJob` entry** — orchestrator drives cadence.
+- [ ] `sources.py`: add `"risk_metrics"` to `Lane` Literal; `MANUAL_TRIGGER_JOB_SOURCES["risk_metrics_refresh"]="risk_metrics"` (own write-disjoint lane, #1527 class). Extend starvation regression test for the new lane.
+- [ ] `runtime.py`: import + `_INVOKERS[JOB_RISK_METRICS_REFRESH]=_adapt_zero_arg(risk_metrics_refresh)`.
+- Wiring tests (mirror `tests/test_finra_regsho_daily_scheduler_wiring.py` minus the ScheduledJob asserts): constant, invoker `__wrapped__`, `source_for(...)=="risk_metrics"`, `MANUAL_TRIGGER_JOB_SOURCES` entry. Assert it is NOT in SCHEDULED_JOBS.
+
+## Task B6 — endpoint `GET /instruments/{symbol}/risk-metrics`
+
+- [ ] Pydantic models: `RiskWindowMetrics` (scalars as fractions + per-metric status + n_obs + window_key), `RiskSeries` (drawdown curve, rolling-vol line, histogram bins, beta-scatter points), `InstrumentRiskMetrics` (symbol, as_of_date, benchmark_symbol, windows: list, series). `Decimal|None` fields.
+- [ ] `@router.get("/{symbol}/risk-metrics")` — resolve symbol→instrument_id (standard primary-listing tiebreak), 404 absent. `with snapshot_read(conn):` read `_current` scalars + compute on-read series via the SAME service fns **cut at the row's `as_of_date`**; any config read inside the block. Thin-history/missing-benchmark → honest status passthrough, never zeros (ZERO-fallback ban). Snapshot older than SLA → `stale`.
+- [ ] db-tier test: data symbol → scalars+series+statuses; insufficient-history → flagged (not zeros); missing-benchmark → `beta_status='benchmark_missing'`.
+
+## Task B7 — skill updates (same PR, skill-ownership rule)
+
+- [ ] `market-data/SKILL.md`: TRADING_DAYS=252, vol×√252, calendar-CAGR, var_5 type-7, simple-return valid-close chain.
+- [ ] `metrics-analyst/SKILL.md`: risk-metrics row (source→transform→table→endpoint→chart) + caveats (price not total return; Calmar not Sharpe; realized vol ≠ scorer TA vol-regime; mutable price_daily ⇒ observations is the audit record).
+
+## Task B8 — dev backfill + DoD (operator step; I own the dev jobs proc)
+
+After merge → restart dev jobs proc onto main → `POST /jobs/risk_metrics_refresh/run`. Record: `instrument_risk_metrics_current` populated for AAPL/GME/MSFT/JPM/HD (+SPY); cross-source ONE beta or vol vs a public source; `GET /instruments/AAPL/risk-metrics` sane scalars+statuses+as_of_date. SHA + figures in PR (ETL DoD 8–12).
+
+---
+
+## Process
+1. Codex ckpt-1 re-confirm on THIS rev2 (deviation reverted; verify wiring fixes land) → fold.
+2. subagent-driven-development per task (implementer + spec-review + code-quality-review).
+3. `uv run pytest -m "not db"` + smoke; `-m db` for B2/B3/B6.
+4. Codex ckpt-2 on branch before push.
+5. Push, PR "Part of #591" (closing/ref verb in BODY); Claude review APPROVE + CI green; squash-merge.
+6. B8 backfill + DoD; then PR-C.
+
+## Self-review
+- **Spec coverage:** all §PR-B metrics+statuses+windows+endpoint; append-only two-layer honors the spec (rev2 reverted the deviation).
+- **Codex ckpt-1 folded:** BLOCKER (price_daily mutable → keep append-only) ✓; HIGH upsert as_of advance ✓; HIGH orchestrator-driven not standalone-cron ✓; HIGH INIT_CHECKS["candles"] ✓; HIGH per-instrument as_of ✓; MED units(fractions)/trailing-semantics/excess_cagr-first-class/invalid_price_chain-trigger/quantize-note ✓; MED n_obs grain (n_returns+beta_n_obs rule) ✓.
+- **Personas folded:** quant math contracts → B1 tests; data-engineer (two-layer, quarterly partition, discrete CHECK status, bloat-safe upsert, no-FK, own lane, retention justification) → B2/B3/B5; consumers (per-metric status grain, n_obs per metric, TEXT window_key, 3y window) → B2/B6.
+- **Prevention-log:** ZERO-fallback ban, `Decimal(str(x))`, snapshot_read, applied-migration immutability, ON-CONFLICT bloat predicate, mega-table partition-at-design-time.

--- a/sql/198_instrument_risk_metrics.sql
+++ b/sql/198_instrument_risk_metrics.sql
@@ -1,0 +1,261 @@
+-- 198_instrument_risk_metrics.sql
+--
+-- #591 PR-B, Task B2 — two-layer risk-metrics persistence for the
+-- instrument risk drill. Spec:
+--   docs/superpowers/specs/2026-06-14-instrument-risk-drill-design.md
+--
+-- TWO-LAYER RATIONALE (mirrors the ownership observations/_current model,
+-- sql/114-116):
+--   - instrument_risk_metrics_observations is APPEND-ONLY. price_daily is a
+--     MUTABLE table (ingest writes ON CONFLICT DO UPDATE) — a corrected or
+--     re-fetched bar overwrites the prior close in place. That means a past
+--     metric computation is NOT reconstructable from current price_daily: the
+--     observation row IS the audit record of "what we computed, from what data,
+--     when". Never UPDATE/DELETE an observation; a recompute appends a new row.
+--   - instrument_risk_metrics_current is the latest write-through snapshot, one
+--     row per (instrument, metric_version, window_key), rebuilt deterministically
+--     by B3's upsert from the winning observation.
+--
+-- WHY computed_at IS IN THE OBSERVATIONS PK:
+--   A vendor correction to a historical bar that does NOT advance the latest
+--   close date produces DIFFERENT metrics for the same
+--   (instrument_id, as_of_date, metric_version, window_key). Without computed_at
+--   in the key the corrected recompute would collide with — and silently
+--   overwrite — the prior row, defeating the audit purpose. computed_at
+--   disambiguates the two computations. as_of_date (the partition key) is in the
+--   PK as Postgres requires the partition column to be part of any PK.
+--
+-- UNITS: all returns/ratios are stored as FRACTIONS (0.10 == 10%). No _pct
+-- suffix. Skew / excess_kurtosis / beta / r2 are dimensionless.
+--
+-- COLUMN ALIGNMENT (B3 dataclass -> column), app/services/risk_metrics.py:
+--   WindowMetrics.annualized_vol  -> vol_annualized
+--   WindowMetrics.r2 / BetaResult.r2 -> beta_r2
+--   WindowMetrics.excess_cagr     -> excess_cagr_vs_spy
+--   WindowMetrics.excess_cagr_status -> excess_cagr_status
+--   DrawdownResult.peak_date      -> max_dd_peak_date
+--   DrawdownResult.trough_date    -> max_dd_trough_date
+--   DistributionResult.{skew,excess_kurtosis,var_5,worst_day,best_day} -> same
+--   DistributionResult.n_obs      -> (folded into distribution evidence; n_returns is the window count)
+-- The trailing_* / excess_trailing_* columns are populated by B3 from
+-- risk_metrics.trailing_return / excess_trailing_return per-window.
+--
+-- RETENTION = NONE (no sweep). At weekly cadence over the tradable universe
+-- this is ~800k rows/yr, quarterly-partitioned and bounded. A retention sweep
+-- would DELETE exactly the historical audit trail this table exists to keep.
+-- If size ever bites, DROP whole old PARTITIONs (cheap, metadata-only) rather
+-- than row-level retention.
+--
+-- Idempotent: every CREATE uses IF NOT EXISTS; re-applying is a no-op.
+--
+-- NEVER edit this file after it is applied — fixes go in sql/199
+-- (prevention-log #1333: schema_migrations content_sha256 drift guard).
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Table 1: instrument_risk_metrics_observations (append-only audit log)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS instrument_risk_metrics_observations (
+    instrument_id             BIGINT NOT NULL,
+    as_of_date                DATE NOT NULL,
+    metric_version            TEXT NOT NULL,
+    window_key                TEXT NOT NULL
+        CHECK (window_key IN ('1y', '3y', 'full')),
+    computed_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Scalar metrics (FRACTIONS; nullable — thin history -> NULL + status flag).
+    cagr                      NUMERIC,
+    excess_cagr_vs_spy        NUMERIC,
+    max_drawdown              NUMERIC,
+    max_dd_peak_date          DATE,
+    max_dd_trough_date        DATE,
+    current_drawdown          NUMERIC,
+    vol_annualized            NUMERIC,
+    beta                      NUMERIC,
+    beta_r2                   NUMERIC,
+    skew                      NUMERIC,
+    excess_kurtosis           NUMERIC,
+    var_5                     NUMERIC,
+    worst_day                 NUMERIC,
+    best_day                  NUMERIC,
+    calmar                    NUMERIC,
+    trailing_1m               NUMERIC,
+    trailing_3m               NUMERIC,
+    trailing_6m               NUMERIC,
+    trailing_1y               NUMERIC,
+    excess_trailing_1m        NUMERIC,
+    excess_trailing_3m        NUMERIC,
+    excess_trailing_6m        NUMERIC,
+    excess_trailing_1y        NUMERIC,
+
+    -- Evidence. NO foreign key on instrument_id / benchmark_instrument_id: an
+    -- append-only audit log must survive instrument churn (delisting / merge /
+    -- re-id), matching the ownership observations which also do NOT FK
+    -- instrument_id.
+    n_returns                 INT,
+    beta_n_obs                INT,
+    benchmark_instrument_id   BIGINT,
+    window_days               INT,
+
+    -- Per-metric discrete status (NOT a JSONB — queryable, CHECK-guarded).
+    -- Values mirror risk_metrics.RiskStatus.
+    cagr_status               TEXT
+        CHECK (cagr_status IS NULL OR cagr_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    vol_status                TEXT
+        CHECK (vol_status IS NULL OR vol_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    beta_status               TEXT
+        CHECK (beta_status IS NULL OR beta_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    drawdown_status           TEXT
+        CHECK (drawdown_status IS NULL OR drawdown_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    distribution_status       TEXT
+        CHECK (distribution_status IS NULL OR distribution_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    calmar_status             TEXT
+        CHECK (calmar_status IS NULL OR calmar_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    trailing_status           TEXT
+        CHECK (trailing_status IS NULL OR trailing_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    excess_cagr_status        TEXT
+        CHECK (excess_cagr_status IS NULL OR excess_cagr_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+
+    PRIMARY KEY (instrument_id, as_of_date, metric_version, window_key, computed_at)
+) PARTITION BY RANGE (as_of_date);
+
+COMMENT ON TABLE instrument_risk_metrics_observations IS
+    'Append-only per-(instrument, as_of, version, window) risk-metric audit log. price_daily is mutable so past computations are not reconstructable — the observation IS the audit record. Rebuild source for instrument_risk_metrics_current. Spec: docs/superpowers/specs/2026-06-14-instrument-risk-drill-design.md (#591 PR-B).';
+
+-- Quarterly partitions 2010-Q1 .. 2040-Q4 (real lower bound 2010-01-01,
+-- NEVER MINVALUE — a stray pre-2010 as_of_date routes to _default, visible).
+DO $$
+DECLARE
+    yr     INT;
+    qtr    INT;
+    qstart DATE;
+    qend   DATE;
+    pname  TEXT;
+BEGIN
+    FOR yr IN 2010..2040 LOOP
+        FOR qtr IN 1..4 LOOP
+            qstart := MAKE_DATE(yr, (qtr - 1) * 3 + 1, 1);
+            qend := qstart + INTERVAL '3 months';
+            pname := FORMAT('instrument_risk_metrics_observations_%sq%s', yr, qtr);
+            EXECUTE FORMAT(
+                'CREATE TABLE IF NOT EXISTS %I PARTITION OF instrument_risk_metrics_observations FOR VALUES FROM (%L) TO (%L)',
+                pname, qstart, qend
+            );
+        END LOOP;
+    END LOOP;
+END $$;
+
+CREATE TABLE IF NOT EXISTS instrument_risk_metrics_observations_default
+    PARTITION OF instrument_risk_metrics_observations DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_risk_obs_instrument_asof
+    ON instrument_risk_metrics_observations (instrument_id, as_of_date DESC);
+
+-- ---------------------------------------------------------------------------
+-- Table 2: instrument_risk_metrics_current (latest write-through)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS instrument_risk_metrics_current (
+    instrument_id             BIGINT NOT NULL,
+    metric_version            TEXT NOT NULL,
+    window_key                TEXT NOT NULL
+        CHECK (window_key IN ('1y', '3y', 'full')),
+    as_of_date                DATE NOT NULL,
+    -- Carried from the winning observation (B3's upsert tiebreak: latest
+    -- as_of_date, then latest computed_at).
+    computed_at               TIMESTAMPTZ,
+    -- This table's own write time (distinct from the observation's computed_at).
+    refreshed_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Scalar metrics (FRACTIONS), same as observations.
+    cagr                      NUMERIC,
+    excess_cagr_vs_spy        NUMERIC,
+    max_drawdown              NUMERIC,
+    max_dd_peak_date          DATE,
+    max_dd_trough_date        DATE,
+    current_drawdown          NUMERIC,
+    vol_annualized            NUMERIC,
+    beta                      NUMERIC,
+    beta_r2                   NUMERIC,
+    skew                      NUMERIC,
+    excess_kurtosis           NUMERIC,
+    var_5                     NUMERIC,
+    worst_day                 NUMERIC,
+    best_day                  NUMERIC,
+    calmar                    NUMERIC,
+    trailing_1m               NUMERIC,
+    trailing_3m               NUMERIC,
+    trailing_6m               NUMERIC,
+    trailing_1y               NUMERIC,
+    excess_trailing_1m        NUMERIC,
+    excess_trailing_3m        NUMERIC,
+    excess_trailing_6m        NUMERIC,
+    excess_trailing_1y        NUMERIC,
+
+    -- Evidence (no FK — same churn rationale as observations).
+    n_returns                 INT,
+    beta_n_obs                INT,
+    benchmark_instrument_id   BIGINT,
+    window_days               INT,
+
+    -- Per-metric discrete status, same domain as observations.
+    cagr_status               TEXT
+        CHECK (cagr_status IS NULL OR cagr_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    vol_status                TEXT
+        CHECK (vol_status IS NULL OR vol_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    beta_status               TEXT
+        CHECK (beta_status IS NULL OR beta_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    drawdown_status           TEXT
+        CHECK (drawdown_status IS NULL OR drawdown_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    distribution_status       TEXT
+        CHECK (distribution_status IS NULL OR distribution_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    calmar_status             TEXT
+        CHECK (calmar_status IS NULL OR calmar_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    trailing_status           TEXT
+        CHECK (trailing_status IS NULL OR trailing_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+    excess_cagr_status        TEXT
+        CHECK (excess_cagr_status IS NULL OR excess_cagr_status IN (
+            'ok', 'insufficient_history', 'partial_window', 'benchmark_missing',
+            'benchmark_insufficient_history', 'invalid_price_chain', 'stale')),
+
+    PRIMARY KEY (instrument_id, metric_version, window_key)
+);
+
+COMMENT ON TABLE instrument_risk_metrics_current IS
+    'Materialised latest-per-(instrument, version, window) risk-metric snapshot. Rebuilt deterministically by B3 from the winning observation (latest as_of_date, then latest computed_at). Spec: docs/superpowers/specs/2026-06-14-instrument-risk-drill-design.md (#591 PR-B).';
+
+-- For the future ranking "all instruments at window 3y / version risk_v1" scan.
+CREATE INDEX IF NOT EXISTS idx_risk_current_window_version
+    ON instrument_risk_metrics_current (window_key, metric_version);
+
+COMMIT;

--- a/tests/test_api_risk_metrics.py
+++ b/tests/test_api_risk_metrics.py
@@ -1,0 +1,233 @@
+"""DB-tier tests for GET /instruments/{symbol}/risk-metrics (#591 PR-B, Task B6).
+
+Seeds synthetic price_daily for a subject instrument + a fake SPY, runs
+``compute_and_store_risk_metrics`` to persist the two-layer tables, then drives
+the endpoint via a TestClient whose ``get_conn`` yields the test connection.
+
+Asserts the honest-status contract: populated windows + non-empty series for a
+long clean series; FLAGGED (not zeroed) statuses for thin history; null beta +
+``benchmark_missing`` when SPY is absent; 404 for an unknown symbol.
+
+Auto-marked ``db`` (pulls ``ebull_test_conn`` + TestClient).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date, timedelta
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_conn
+from app.main import app
+from app.services.risk_metrics import (
+    RISK_METRICS_VERSION,
+    compute_and_store_risk_metrics,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+# Fixed synthetic ids well outside any real-data range.
+_SPY_ID = 991001
+_SUBJECT_ID = 991002
+_THIN_ID = 991003
+_NOBENCH_ID = 991004
+
+# Anchor the series ~5 days in the past so trailing windows resolve and
+# CURRENT_DATE is always after the last bar.
+_END = date.today() - timedelta(days=5)
+
+
+@pytest.fixture
+def client(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> Iterator[TestClient]:
+    """TestClient with get_conn overridden to yield the test connection."""
+
+    def _dep() -> Iterator[psycopg.Connection[tuple]]:
+        yield ebull_test_conn
+
+    app.dependency_overrides[get_conn] = _dep
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_conn, None)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, currency, country, is_tradable)
+        VALUES (%s, %s, %s, 'USD', 'US', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+
+
+def _seed_series(
+    conn: psycopg.Connection[tuple],
+    iid: int,
+    closes: list[float | None],
+    end: date = _END,
+) -> None:
+    """Insert ``closes`` ending at ``end`` (one calendar day apart, ASC)."""
+    n = len(closes)
+    for i, close in enumerate(closes):
+        d = end - timedelta(days=(n - 1 - i))
+        conn.execute(
+            """
+            INSERT INTO price_daily (instrument_id, price_date, close)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (instrument_id, price_date) DO UPDATE SET close = EXCLUDED.close
+            """,
+            (iid, d, close),
+        )
+
+
+def _clean_series(n: int, start: float = 100.0, step: float = 0.5) -> list[float | None]:
+    """A monotone-up clean series of ``n`` closes (no NULLs, all > 0)."""
+    return [start + step * i for i in range(n)]
+
+
+def _window(body: dict[str, object], key: str) -> dict[str, object]:
+    for w in body["windows"]:  # type: ignore[union-attr]
+        if w["window_key"] == key:  # type: ignore[index]
+            return w  # type: ignore[return-value]
+    raise AssertionError(f"window {key!r} not present in {[w['window_key'] for w in body['windows']]}")  # type: ignore[index,union-attr]
+
+
+def test_data_symbol_returns_populated_windows_and_series(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Long clean series w/ SPY → 200, windows populated, statuses ok, series non-empty."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _SUBJECT_ID, "FAKE")
+    _seed_series(conn, _SPY_ID, _clean_series(400, start=400.0, step=0.3))
+    _seed_series(conn, _SUBJECT_ID, _clean_series(400, start=100.0, step=0.5))
+    conn.commit()
+    compute_and_store_risk_metrics(conn)
+    conn.commit()
+
+    resp = client.get("/instruments/FAKE/risk-metrics")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert body["symbol"] == "FAKE"
+    assert body["metric_version"] == RISK_METRICS_VERSION
+    assert body["benchmark_symbol"] == "SPY"
+    assert body["as_of_date"] == _END.isoformat()
+    assert {w["window_key"] for w in body["windows"]} == {"1y", "3y", "full"}
+    # Windows are ordered shortest → full.
+    assert [w["window_key"] for w in body["windows"]] == ["1y", "3y", "full"]
+
+    full = _window(body, "full")
+    assert full["cagr"] is not None
+    assert full["vol_annualized"] is not None
+    assert full["max_drawdown"] is not None
+    # 400-row clean series clears every "ok" threshold.
+    assert full["cagr_status"] == "ok"
+    assert full["vol_status"] == "ok"
+    assert full["drawdown_status"] == "ok"
+    assert full["distribution_status"] == "ok"
+    assert full["beta_status"] == "ok"
+    # No metric coerced to zero — they are real fractions.
+
+    series = body["series"]
+    assert series is not None
+    assert len(series["drawdown_curve"]) > 0
+    assert len(series["rolling_vol"]) > 0
+    assert len(series["return_histogram"]) > 0
+    assert len(series["beta_scatter"]) > 0
+    assert series["beta"] is not None
+    # Beta scatter pairs are aligned (spy, inst).
+    pt = series["beta_scatter"][0]
+    assert "spy_return" in pt and "inst_return" in pt
+
+
+def test_insufficient_history_flags_status_not_zero(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Thin (10-close) history → 200, windows present, FLAGGED statuses, not zeros."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _THIN_ID, "THIN")
+    _seed_series(conn, _SPY_ID, _clean_series(400, start=400.0, step=0.3))
+    _seed_series(conn, _THIN_ID, _clean_series(10, start=50.0, step=0.2))
+    conn.commit()
+    compute_and_store_risk_metrics(conn)
+    conn.commit()
+
+    resp = client.get("/instruments/THIN/risk-metrics")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert {w["window_key"] for w in body["windows"]} == {"1y", "3y", "full"}
+
+    full = _window(body, "full")
+    # 9 returns < thresholds → flagged, NOT 'ok', NOT fabricated zeros.
+    assert full["vol_status"] == "insufficient_history"
+    assert full["cagr_status"] == "partial_window"
+    assert full["distribution_status"] == "partial_window"
+    assert full["beta_status"] == "benchmark_insufficient_history"
+    # Monotone-up → zero drawdown → calmar mathematically null (not zero).
+    assert full["calmar"] is None
+
+
+def test_missing_benchmark_beta_null_status_flagged(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """No SPY rows at all → beta null + beta_status flagged benchmark_missing, not 0."""
+    conn = ebull_test_conn
+    # Deliberately do NOT seed SPY.
+    _seed_instrument(conn, _NOBENCH_ID, "NOBENCH")
+    _seed_series(conn, _NOBENCH_ID, _clean_series(400, start=100.0, step=0.5))
+    conn.commit()
+    compute_and_store_risk_metrics(conn)
+    conn.commit()
+
+    resp = client.get("/instruments/NOBENCH/risk-metrics")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # No benchmark resolved.
+    assert body["benchmark_symbol"] is None
+    full = _window(body, "full")
+    assert full["beta"] is None
+    assert full["beta_status"] == "benchmark_missing"
+    assert full["excess_cagr_vs_spy"] is None
+    assert full["excess_cagr_status"] == "benchmark_missing"
+    # Series still computes the instrument-only curves; beta fit is null.
+    series = body["series"]
+    assert series is not None
+    assert len(series["drawdown_curve"]) > 0
+    assert series["beta"] is None
+    assert series["beta_scatter"] == []
+
+
+def test_unknown_symbol_returns_404(client: TestClient) -> None:
+    resp = client.get("/instruments/NOTREAL/risk-metrics")
+    assert resp.status_code == 404
+
+
+def test_never_computed_instrument_returns_empty_payload(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Instrument exists but has no persisted risk rows → 200, empty windows, null as_of."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, 991009, "EMPTY")
+    conn.commit()
+
+    resp = client.get("/instruments/EMPTY/risk-metrics")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["symbol"] == "EMPTY"
+    assert body["as_of_date"] is None
+    assert body["windows"] == []
+    assert body["series"] is None
+    assert body["metric_version"] == RISK_METRICS_VERSION

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -530,6 +530,14 @@ class TestProductionInvokerRegistry:
             # pre-#1131 row; source-lock "db" + empty param metadata
             # complete the manual-only triangle.
             "sec_manifest_tombstone_stale",
+            # #591 PR-B — risk_metrics_refresh. Orchestrator-driven (DAG
+            # layer "risk_metrics") + manual-trigger-only. Stays in
+            # _INVOKERS for the orchestrator adapter inner-JobLock + Admin
+            # "Run now"; intentionally NOT in SCHEDULED_JOBS (the layer
+            # cadence/freshness gate the DAG walk — a scheduled row would
+            # double-fire). Source-lock "risk_metrics" + empty param
+            # metadata complete the manual-only triangle.
+            "risk_metrics_refresh",
         }
         assert on_demand == expected_on_demand, (
             f"Unexpected on-demand invokers (update this test if intentional): "

--- a/tests/test_risk_metrics.py
+++ b/tests/test_risk_metrics.py
@@ -500,6 +500,96 @@ def test_compute_short_clean_series_is_insufficient_history():  # case (c)
 
 
 # ===========================================================================
+# Group 14 — drawdown_status / distribution_status / trailing_status
+# (every persisted status column has a compute-layer source)
+# ===========================================================================
+
+
+def test_drawdown_status_ok_two_valid_closes():
+    # ≥ 2 valid closes => a drawdown is computable => ok.
+    assert rm.drawdown_status(2) == "ok"
+    closes = _closes([100.0, 90.0])
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.drawdown_status == "ok"
+
+
+def test_drawdown_status_insufficient_below_two_closes():
+    # < 2 valid closes, no invalids => insufficient_history.
+    assert rm.drawdown_status(1) == "insufficient_history"
+    closes = _closes([100.0])  # one clean close, no invalids
+    assert rm._count_invalid_closes(closes) == 0
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.drawdown_status == "insufficient_history"
+
+
+def test_drawdown_status_invalid_price_chain():
+    # invalids dropped the usable chain below 2 => invalid_price_chain.
+    assert rm.drawdown_status(1, invalids_dropped=2) == "invalid_price_chain"
+    # one valid close + two invalids => valid chain = 1 (< 2), invalids present.
+    closes = _closes([100.0, float("nan"), 0])
+    assert rm._count_invalid_closes(closes) == 2
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.drawdown_status == "invalid_price_chain"
+
+
+def test_distribution_status_ok_at_min_obs():
+    # >= MIN_OBS_MOMENTS (250) returns => ok.
+    assert rm.distribution_status(rm.MIN_OBS_MOMENTS) == "ok"
+    closes = _closes([100.0 + k for k in range(rm.MIN_OBS_MOMENTS + 1)])  # 250 returns
+    rets = rm.simple_returns(closes)
+    assert len(rets) == rm.MIN_OBS_MOMENTS
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.distribution_status == "ok"
+    assert wm.distribution is not None and wm.distribution.low_sample is False
+
+
+def test_distribution_status_partial_window_low_sample():
+    # 2 <= n < 250 returns => partial_window (mirrors low_sample flag).
+    assert rm.distribution_status(2) == "partial_window"
+    assert rm.distribution_status(rm.MIN_OBS_MOMENTS - 1) == "partial_window"
+    closes = _closes([100.0 + k for k in range(50)])  # 49 returns
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.distribution_status == "partial_window"
+    assert wm.distribution is not None and wm.distribution.low_sample is True
+
+
+def test_distribution_status_insufficient_below_two_returns():
+    # < 2 returns, no invalids => insufficient_history.
+    assert rm.distribution_status(1) == "insufficient_history"
+    closes = _closes([100.0, 110.0])  # exactly 1 return
+    assert rm._count_invalid_closes(closes) == 0
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.distribution_status == "insufficient_history"
+    # invalid-driven path: < 2 returns AND invalids => invalid_price_chain.
+    assert rm.distribution_status(1, invalids_dropped=3) == "invalid_price_chain"
+
+
+def test_trailing_status_ok_when_shortest_window_computable():
+    base = date(2024, 6, 1)
+    closes = [
+        (base - timedelta(days=40), 100.0),
+        (base, 130.0),
+    ]
+    # a close ≥ 30 calendar days back exists => 1m trailing computable => ok.
+    assert rm.trailing_status(closes, base) == "ok"
+    wm = rm.compute_instrument_risk(closes, [], "full", base)
+    assert wm.trailing_status == "ok"
+
+
+def test_trailing_status_insufficient_when_series_shorter_than_30d():
+    base = date(2024, 6, 1)
+    closes = [
+        (base - timedelta(days=5), 100.0),
+        (base, 110.0),
+    ]
+    # no close ≥ 30 days back => not even 1m computable => insufficient_history.
+    assert rm.trailing_return(closes, base, 30) is None
+    assert rm.trailing_status(closes, base) == "insufficient_history"
+    wm = rm.compute_instrument_risk(closes, [], "full", base)
+    assert wm.trailing_status == "insufficient_history"
+
+
+# ===========================================================================
 # Group 11 — float island doesn't leak
 # ===========================================================================
 

--- a/tests/test_risk_metrics.py
+++ b/tests/test_risk_metrics.py
@@ -436,6 +436,70 @@ def test_vol_beta_boundary_60_vs_59_and_midgap():  # case 27
 
 
 # ===========================================================================
+# Group 13 — invalid_price_chain status (invalids caused the shortfall)
+# ===========================================================================
+
+
+def test_count_invalid_closes():
+    # 5 rows, two invalid (nan and 0); rest valid.
+    closes = _closes([100.0, float("nan"), 110.0, 0, 121.0])
+    assert rm._count_invalid_closes(closes) == 2
+    # None entries also count as invalid
+    assert rm._count_invalid_closes([(date(2024, 1, 1), None), (date(2024, 1, 2), 100.0)]) == 1
+    # all-clean => 0
+    assert rm._count_invalid_closes(_closes([100.0, 101.0, 102.0])) == 0
+
+
+def test_status_helpers_invalid_price_chain_trigger():
+    # below min-obs AND invalids dropped => invalid_price_chain
+    assert rm.vol_beta_status(59, invalids_dropped=3) == "invalid_price_chain"
+    assert rm.annualized_status(251, invalids_dropped=5) == "invalid_price_chain"
+    # below min-obs but NO invalids => genuine short history
+    assert rm.vol_beta_status(59, invalids_dropped=0) == "insufficient_history"
+    assert rm.annualized_status(251, invalids_dropped=0) == "partial_window"
+    # meets min-obs even with invalids dropped earlier => ok (single break is fine)
+    assert rm.vol_beta_status(60, invalids_dropped=10) == "ok"
+    assert rm.annualized_status(252, invalids_dropped=10) == "ok"
+    # default invalids_dropped=0 preserves the old single-arg call shape
+    assert rm.vol_beta_status(60) == "ok"
+    assert rm.annualized_status(252) == "ok"
+
+
+def test_compute_invalid_price_chain_drops_vol_below_threshold():  # case (a)
+    # 70 dated rows; sprinkle enough invalids that valid returns < 60.
+    # Each invalid close breaks the chain and costs 2 returns (in + out).
+    vals = [100.0 + k for k in range(70)]
+    # 6 invalids at spaced positions => removes ~12 returns from the clean 69.
+    for idx in (10, 20, 30, 40, 50, 60):
+        vals[idx] = float("nan")
+    closes = _closes(vals)
+    rets = rm.simple_returns(closes)
+    assert len(rets) < rm.MIN_RETURNS_VOL_BETA  # invalids drove it under threshold
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.vol_status == "invalid_price_chain"
+
+
+def test_compute_single_invalid_with_enough_remaining_is_ok():  # case (b)
+    # 70 dated rows, one mid-chain invalid. Even with the 2-return cost,
+    # >= 60 valid returns remain => vol_status stays ok despite an invalid present.
+    vals = [100.0 + k for k in range(70)]
+    vals[35] = float("nan")
+    closes = _closes(vals)
+    rets = rm.simple_returns(closes)
+    assert len(rets) >= rm.MIN_RETURNS_VOL_BETA
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.vol_status == "ok"
+
+
+def test_compute_short_clean_series_is_insufficient_history():  # case (c)
+    # genuinely-short clean series (< 60 returns, no invalids) => insufficient_history.
+    closes = _closes([100.0 + k for k in range(40)])  # 39 returns, all valid
+    assert rm._count_invalid_closes(closes) == 0
+    wm = rm.compute_instrument_risk(closes, [], "full", closes[-1][0])
+    assert wm.vol_status == "insufficient_history"
+
+
+# ===========================================================================
 # Group 11 — float island doesn't leak
 # ===========================================================================
 

--- a/tests/test_risk_metrics.py
+++ b/tests/test_risk_metrics.py
@@ -639,3 +639,172 @@ def test_compute_instrument_risk_full_window():
     assert wm.max_drawdown is not None
     assert wm.beta is not None
     assert wm.distribution is not None
+
+
+# ===========================================================================
+# Group 15 — BUG A: window_key actually slices the series
+# ===========================================================================
+
+
+def _three_year_series():
+    """~3y daily series whose LAST 1y has a DIFFERENT mean/vol than the whole.
+
+    First ~2 years: tiny low-vol uptrend. Last ~1 year: large high-vol swings.
+    The 1y sub-window therefore has materially different vol/cagr than 3y/full.
+    """
+    import random
+
+    rng = random.Random(1234)
+    start = date(2021, 1, 1)
+    closes: list = []
+    price = 100.0
+    # 730 days of low-vol drift
+    for i in range(730):
+        price *= 1.0 + rng.uniform(-0.001, 0.0015)
+        closes.append((start + timedelta(days=i), price))
+    # 365 days of high-vol, sharply different regime
+    for i in range(730, 1095):
+        price *= 1.0 + rng.uniform(-0.05, 0.06)
+        closes.append((start + timedelta(days=i), price))
+    return closes
+
+
+def test_slice_window_keeps_only_lookback_span():
+    closes = _three_year_series()
+    as_of = closes[-1][0]
+    full = rm._slice_window(closes, as_of, "full")
+    one_y = rm._slice_window(closes, as_of, "1y")
+    three_y = rm._slice_window(closes, as_of, "3y")
+    # full keeps everything
+    assert len(full) == len(closes)
+    # 1y is a strict subset and shorter than 3y/full
+    assert len(one_y) < len(three_y) <= len(full)
+    # every 1y row is within 365 calendar days of as_of
+    cutoff = as_of - timedelta(days=365)
+    assert all(d >= cutoff for d, _ in one_y)
+    assert all(d <= as_of for d, _ in one_y)
+    # the earliest full row predates the 1y cutoff (proves slicing dropped rows)
+    assert full[0][0] < cutoff
+
+
+def test_window_key_changes_vol_and_cagr():  # BUG A core
+    closes = _three_year_series()
+    spy = _closes([400.0 + 0.2 * k for k in range(len(closes))], start=closes[0][0])
+    as_of = closes[-1][0]
+    wm_1y = rm.compute_instrument_risk(closes, spy, "1y", as_of)
+    wm_3y = rm.compute_instrument_risk(closes, spy, "3y", as_of)
+    wm_full = rm.compute_instrument_risk(closes, spy, "full", as_of)
+
+    # vol of the high-vol last year must differ from the 3y/full blend.
+    assert wm_1y.annualized_vol is not None
+    assert wm_3y.annualized_vol is not None
+    assert wm_full.annualized_vol is not None
+    assert wm_1y.annualized_vol != wm_3y.annualized_vol
+    assert wm_1y.annualized_vol != wm_full.annualized_vol
+    # cagr likewise differs across windows.
+    assert wm_1y.cagr is not None and wm_3y.cagr is not None and wm_full.cagr is not None
+    assert wm_1y.cagr != wm_3y.cagr
+    assert wm_1y.cagr != wm_full.cagr
+    # n_returns reflects the sliced window (1y has far fewer returns than full).
+    assert wm_1y.n_returns < wm_full.n_returns
+
+
+def test_full_window_uses_all_closes():
+    closes = _three_year_series()
+    as_of = closes[-1][0]
+    wm_full = rm.compute_instrument_risk(closes, [], "full", as_of)
+    # full == compute on the whole series directly (no lower bound).
+    all_rets = rm.simple_returns(closes)
+    assert wm_full.n_returns == len(all_rets)
+    assert wm_full.annualized_vol == rm.annualized_vol([r for _, r in all_rets])
+    assert wm_full.cagr == rm.cagr(closes)
+
+
+def test_window_slice_below_min_returns_flags():
+    # A 1y window holding < MIN_RETURNS_VOL_BETA (60) clean returns flags
+    # insufficient_history on vol even when the full series is long.
+    start = date(2021, 1, 1)
+    closes: list = []
+    # 800 daily closes for ~2y of dense history (full window is long)...
+    for i in range(800):
+        closes.append((start + timedelta(days=i), 100.0 + 0.1 * i))
+    # ...then sparse monthly closes for the last year so the 1y slice is thin.
+    last = closes[-1][0]
+    sparse: list = []
+    for k in range(1, 12):
+        sparse.append((last + timedelta(days=30 * k), 200.0 + k))
+    closes = closes + sparse
+    as_of = closes[-1][0]
+    wm_1y = rm.compute_instrument_risk(closes, [], "1y", as_of)
+    wm_full = rm.compute_instrument_risk(closes, [], "full", as_of)
+    assert wm_1y.n_returns < rm.MIN_RETURNS_VOL_BETA
+    assert wm_1y.vol_status == "insufficient_history"
+    # full window has plenty of returns → ok.
+    assert wm_full.n_returns >= rm.MIN_RETURNS_VOL_BETA
+    assert wm_full.vol_status == "ok"
+
+
+def test_excess_cagr_and_beta_reflect_window():
+    closes = _three_year_series()
+    # SPY tracks inst loosely; use a distinct shape so beta differs by window.
+    spy_vals = [400.0 * (1.0 + 0.0005 * k) for k in range(len(closes))]
+    spy = [(d, v) for (d, _), v in zip(closes, spy_vals, strict=True)]
+    as_of = closes[-1][0]
+    wm_1y = rm.compute_instrument_risk(closes, spy, "1y", as_of)
+    wm_full = rm.compute_instrument_risk(closes, spy, "full", as_of)
+    # excess_cagr is window-relative: the high-vol last year vs the blended full.
+    assert wm_1y.excess_cagr is not None and wm_full.excess_cagr is not None
+    assert wm_1y.excess_cagr != wm_full.excess_cagr
+    # beta over the volatile 1y differs from the full-history beta.
+    assert wm_1y.beta is not None and wm_full.beta is not None
+    assert wm_1y.beta != wm_full.beta
+
+
+# ===========================================================================
+# Group 16 — BUG B: trailing-return scalars are emitted on WindowMetrics
+# ===========================================================================
+
+
+def test_trailing_scalars_populated_and_match_helper():
+    base = date(2024, 6, 1)
+    # dense enough that all four lookbacks resolve.
+    closes = [(base - timedelta(days=400 - k), 100.0 + 0.2 * k) for k in range(401)]
+    spy = [(base - timedelta(days=400 - k), 400.0 + 0.1 * k) for k in range(401)]
+    wm = rm.compute_instrument_risk(closes, spy, "1y", base)
+    for key, lookback in rm.TRAILING_LOOKBACK_DAYS.items():
+        expected = rm.trailing_return(closes, base, lookback)
+        got = getattr(wm, f"trailing_{key}")
+        assert got is not None
+        assert got == expected
+        # excess trailing == inst trailing minus spy trailing.
+        xs_expected, _ = rm.excess_trailing_return(closes, spy, base, lookback)
+        xs_got = getattr(wm, f"excess_trailing_{key}")
+        assert xs_got == xs_expected
+
+
+def test_excess_trailing_null_when_no_spy():
+    base = date(2024, 6, 1)
+    closes = [(base - timedelta(days=400 - k), 100.0 + 0.2 * k) for k in range(401)]
+    wm = rm.compute_instrument_risk(closes, [], "full", base)
+    # inst trailing still populated...
+    assert wm.trailing_1m is not None
+    # ...but excess trailing is null with no benchmark.
+    assert wm.excess_trailing_1m is None
+    assert wm.excess_trailing_3m is None
+    assert wm.excess_trailing_6m is None
+    assert wm.excess_trailing_1y is None
+
+
+def test_trailing_scalars_window_independent():
+    # Trailing returns are calendar-lookback from as_of → identical across
+    # 1y / 3y / full window rows (intentional redundancy).
+    closes = _three_year_series()
+    as_of = closes[-1][0]
+    wm_1y = rm.compute_instrument_risk(closes, [], "1y", as_of)
+    wm_3y = rm.compute_instrument_risk(closes, [], "3y", as_of)
+    wm_full = rm.compute_instrument_risk(closes, [], "full", as_of)
+    for key in rm.TRAILING_LOOKBACK_DAYS:
+        v1 = getattr(wm_1y, f"trailing_{key}")
+        v3 = getattr(wm_3y, f"trailing_{key}")
+        vf = getattr(wm_full, f"trailing_{key}")
+        assert v1 == v3 == vf

--- a/tests/test_risk_metrics.py
+++ b/tests/test_risk_metrics.py
@@ -1,0 +1,487 @@
+"""Pure-math tests for app.services.risk_metrics (risk_v1).
+
+NO DB. Every test encodes a math contract from the #591 quant review.
+Numbered references in comments map to the required-test-cases list.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services import risk_metrics as rm
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _closes(values, start=date(2024, 1, 1)):
+    """Build a list of (date, close) with consecutive calendar days."""
+    return [(start + timedelta(days=i), v) for i, v in enumerate(values)]
+
+
+def _D(x) -> Decimal:
+    return Decimal(str(x))
+
+
+# ===========================================================================
+# Group 1 — simple returns + chain breaking
+# ===========================================================================
+
+
+def test_clean_returns_exact_decimal():  # case 1
+    closes = _closes([100, 110, 121])
+    rets = rm.simple_returns(closes)
+    assert [r for _, r in rets] == [Decimal("0.10"), Decimal("0.10")]
+    # keyed to the LATER close's date
+    assert [d for d, _ in rets] == [date(2024, 1, 2), date(2024, 1, 3)]
+
+
+@pytest.mark.parametrize("bad", [float("nan"), 0, -5])
+def test_mid_series_invalid_breaks_chain(bad):  # case 2
+    # close[2] invalid -> no return into it AND no return out of it (gap span)
+    closes = _closes([100, 110, bad, 121, 133.1])
+    rets = rm.simple_returns(closes)
+    # surviving consecutive pairs: (d1->d2)=0.10, then (d4->d5)=0.10
+    # NO synthetic 110->121 across the invalid row.
+    dates = [d for d, _ in rets]
+    vals = [r for _, r in rets]
+    assert dates == [date(2024, 1, 2), date(2024, 1, 5)]
+    assert vals == [Decimal("0.10"), Decimal("0.10")]
+
+
+def test_fewer_than_two_valid_returns_empty():  # case 3
+    assert rm.simple_returns(_closes([100])) == []
+    assert rm.simple_returns(_closes([float("nan"), 100])) == []
+    assert rm.simple_returns([]) == []
+
+
+# ===========================================================================
+# Group 2 — sample std + annualized vol
+# ===========================================================================
+
+
+def test_sample_std_n_minus_1():
+    # returns [0.1, 0.1] -> std = 0
+    rets = [Decimal("0.1"), Decimal("0.1")]
+    assert rm._sample_std(rets) == Decimal("0")
+
+
+def test_sample_std_none_below_2():
+    assert rm._sample_std([Decimal("0.1")]) is None
+    assert rm._sample_std([]) is None
+
+
+def test_vol_equals_hand_std_times_sqrt252():  # case 4
+    rets = [Decimal("0.01"), Decimal("-0.01"), Decimal("0.02"), Decimal("-0.02")]
+    # hand sample std (n-1):
+    fl = [0.01, -0.01, 0.02, -0.02]
+    mean = sum(fl) / len(fl)
+    var = sum((x - mean) ** 2 for x in fl) / (len(fl) - 1)
+    expected = Decimal(str(math.sqrt(var))) * Decimal(252).sqrt()
+    got = rm.annualized_vol(rets)
+    assert got is not None
+    assert abs(got - expected) < Decimal("1e-12")
+
+
+def test_vol_one_return_none():  # case 5
+    assert rm.annualized_vol([Decimal("0.01")]) is None
+
+
+def test_vol_std_matches_distribution_std():  # case 6
+    rets = [Decimal("0.01"), Decimal("-0.02"), Decimal("0.03"), Decimal("-0.01"), Decimal("0.02")]
+    std_helper = rm._sample_std(rets)
+    vol = rm.annualized_vol(rets)
+    assert vol is not None and std_helper is not None
+    # vol = std * sqrt(252); divide back out and compare
+    assert abs(vol / Decimal(252).sqrt() - std_helper) < Decimal("1e-15")
+
+
+# ===========================================================================
+# Group 3 — drawdown
+# ===========================================================================
+
+
+def test_drawdown_monotonic_up():  # case 7
+    res = rm.drawdown(_closes([100, 110, 120, 130]))
+    assert res.max_drawdown == Decimal("0")
+    assert res.current_drawdown == Decimal("0")
+
+
+def test_drawdown_v_shape():  # case 8
+    closes = _closes([100, 120, 60, 90])
+    res = rm.drawdown(closes)
+    assert res.max_drawdown == Decimal("-0.5")  # 60/120 - 1
+    assert res.current_drawdown == Decimal("-0.25")  # 90/120 - 1
+    assert res.peak_date == date(2024, 1, 2)  # the 120
+    assert res.trough_date == date(2024, 1, 3)  # the 60
+
+
+def test_drawdown_open_current_equals_max():  # case 9
+    closes = _closes([100, 120, 60])
+    res = rm.drawdown(closes)
+    assert res.current_drawdown == res.max_drawdown == Decimal("-0.5")
+
+
+# ===========================================================================
+# Group 4 — OLS beta (date-intersection)
+# ===========================================================================
+
+
+def test_beta_exact_2x():  # case 10
+    # bench returns vary; inst = 2 * bench, same dates
+    bench = _closes([100, 110, 121, 108.9])  # rets: .1, .1, -.1
+    inst = _closes([100, 120, 144, 115.2])  # rets: .2, .2, -.2
+    res = rm.ols_beta(rm.simple_returns(inst), rm.simple_returns(bench))
+    assert res.beta is not None and abs(res.beta - Decimal("2")) < Decimal("1e-9")
+    assert res.r2 is not None and abs(res.r2 - Decimal("1")) < Decimal("1e-9")
+    assert res.n_obs == 3
+
+
+def test_beta_half_with_hand_value():  # case 11
+    # inst = 0.5*bench + noise; pick noise so it's hand-checkable
+    # bench rets: m = [0.10, -0.10, 0.20, -0.20]
+    # inst rets : i = [0.06, -0.04, 0.11, -0.09]  (0.5*m + [0.01,0.01,0.01,0.01])
+    m = [0.10, -0.10, 0.20, -0.20]
+    i = [0.5 * x + 0.01 for x in m]
+    mb = sum(m) / len(m)
+    ib = sum(i) / len(i)
+    cov = sum((a - ib) * (b - mb) for a, b in zip(i, m, strict=True)) / (len(m) - 1)
+    varm = sum((b - mb) ** 2 for b in m) / (len(m) - 1)
+    expected_beta = cov / varm  # = 0.5 exactly
+    dates = [date(2024, 2, 1) + timedelta(days=k) for k in range(4)]
+    inst_rets = list(zip(dates, [_D(x) for x in i], strict=True))
+    bench_rets = list(zip(dates, [_D(x) for x in m], strict=True))
+    res = rm.ols_beta(inst_rets, bench_rets)
+    assert res.beta is not None
+    assert abs(res.beta - _D(expected_beta)) < Decimal("1e-9")
+    assert abs(res.beta - Decimal("0.5")) < Decimal("1e-9")
+
+
+def test_beta_flat_bench_none():  # case 12
+    dates = [date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)]
+    bench_rets = list(zip(dates, [Decimal("0"), Decimal("0"), Decimal("0")], strict=True))
+    inst_rets = list(zip(dates, [Decimal("0.1"), Decimal("-0.1"), Decimal("0.2")], strict=True))
+    res = rm.ols_beta(inst_rets, bench_rets)
+    assert res.beta is None
+    assert res.r2 is None
+
+
+def test_beta_date_misalignment_join_vs_zip():  # case 13
+    # inst is missing the mid day that bench has.
+    # bench rets keyed: d2:0.1, d3:-0.1, d4:0.2
+    bd = [date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)]
+    bench_rets = list(zip(bd, [Decimal("0.1"), Decimal("-0.1"), Decimal("0.2")], strict=True))
+    # inst has rets only on d2 and d4 (missing d3): inst = 2*bench on shared days
+    inst_rets = [(date(2024, 1, 2), Decimal("0.2")), (date(2024, 1, 4), Decimal("0.4"))]
+    res = rm.ols_beta(inst_rets, bench_rets)
+    # date-join pairs: (0.2,0.1) and (0.4,0.2) -> perfect beta 2.0
+    assert res.beta is not None and abs(res.beta - Decimal("2")) < Decimal("1e-9")
+    assert res.n_obs == 2
+    # positional-zip would have paired inst[1]=0.4 with bench[1]=-0.1 -> different.
+    zip_pairs_m = [0.1, -0.1]
+    zip_pairs_i = [0.2, 0.4]
+    mb = sum(zip_pairs_m) / 2
+    ib = sum(zip_pairs_i) / 2
+    cov = sum((a - ib) * (b - mb) for a, b in zip(zip_pairs_i, zip_pairs_m, strict=True))
+    varm = sum((b - mb) ** 2 for b in zip_pairs_m)
+    zip_beta = cov / varm
+    assert abs(_D(zip_beta) - Decimal("2")) > Decimal("0.1")  # proves they differ
+
+
+def test_beta_fewer_than_two_pairs():  # case 14
+    inst_rets = [(date(2024, 1, 2), Decimal("0.1"))]
+    bench_rets = [(date(2024, 1, 2), Decimal("0.05"))]
+    res = rm.ols_beta(inst_rets, bench_rets)
+    assert res.beta is None
+    assert res.r2 is None
+    assert res.n_obs == 1
+
+
+def test_beta_aligned_start_excludes_inst_only_history():  # case 15
+    # inst has extra early returns bench lacks; aligned window = intersection.
+    inst_rets = [
+        (date(2024, 1, 2), Decimal("99")),  # inst-only, must be excluded
+        (date(2024, 1, 3), Decimal("0.2")),
+        (date(2024, 1, 4), Decimal("0.4")),
+    ]
+    bench_rets = [
+        (date(2024, 1, 3), Decimal("0.1")),
+        (date(2024, 1, 4), Decimal("0.2")),
+    ]
+    res = rm.ols_beta(inst_rets, bench_rets)
+    assert res.n_obs == 2  # only the 2 shared dates
+    assert res.beta is not None and abs(res.beta - Decimal("2")) < Decimal("1e-9")
+
+
+# ===========================================================================
+# Group 5 — distribution (float island)
+# ===========================================================================
+
+
+def test_var5_exact_type7_on_fixed_array():  # case 16
+    # 20-element array, hand-compute type-7 5th percentile.
+    arr = [
+        -0.10,
+        -0.08,
+        -0.06,
+        -0.05,
+        -0.04,
+        -0.03,
+        -0.02,
+        -0.01,
+        0.00,
+        0.01,
+        0.02,
+        0.03,
+        0.04,
+        0.05,
+        0.06,
+        0.07,
+        0.08,
+        0.09,
+        0.10,
+        0.12,
+    ]
+    rets = [_D(x) for x in arr]
+    res = rm.distribution(rets)
+    # type-7: h = 0.05*(n-1) = 0.05*19 = 0.95; sorted asc.
+    s = sorted(arr)
+    h = 0.05 * (len(s) - 1)
+    lo = math.floor(h)
+    expected = s[lo] + (h - lo) * (s[lo + 1] - s[lo])
+    assert res.var_5 is not None
+    assert abs(res.var_5 - Decimal(str(round(expected, 8)))) < Decimal("1e-8")
+    # SIGNED: left-tail loss must be negative
+    assert res.var_5 < Decimal("0")
+
+
+def test_skew_symmetric_near_zero_and_right_skew_positive():  # case 17
+    sym = [_D(x) for x in [-0.02, -0.01, 0.0, 0.01, 0.02]]
+    res_sym = rm.distribution(sym)
+    assert res_sym.skew is not None and abs(res_sym.skew) < Decimal("1e-6")
+    right = [_D(x) for x in [-0.01, -0.01, -0.01, -0.01, 0.10]]
+    res_right = rm.distribution(right)
+    assert res_right.skew is not None and res_right.skew > Decimal("0")
+
+
+def test_kurtosis_heavy_normal_and_constant():  # case 18
+    heavy = [_D(x) for x in ([0.0] * 8 + [-0.5, 0.5])]
+    res_heavy = rm.distribution(heavy)
+    assert res_heavy.excess_kurtosis is not None and res_heavy.excess_kurtosis > Decimal("0")
+    constant = [_D("0.01")] * 10
+    res_const = rm.distribution(constant)
+    assert res_const.skew is None
+    assert res_const.excess_kurtosis is None
+
+
+def test_low_sample_flag_boundary():  # case 19
+    n_low = [_D("0.0") if k % 2 else _D("0.01") for k in range(249)]
+    assert rm.distribution(n_low).low_sample is True
+    n_ok = [_D("0.0") if k % 2 else _D("0.01") for k in range(250)]
+    assert rm.distribution(n_ok).low_sample is False
+
+
+def test_worst_best_day():  # case 20
+    rets = [_D("0.03"), _D("-0.05"), _D("0.01"), _D("0.07"), _D("-0.02")]
+    res = rm.distribution(rets)
+    assert res.worst_day == Decimal("-0.05")
+    assert res.best_day == Decimal("0.07")
+    assert res.n_obs == 5
+
+
+# ===========================================================================
+# Group 6 — cagr (calendar-time)
+# ===========================================================================
+
+
+def test_cagr_double_over_365_days():  # case 21
+    closes = [(date(2024, 1, 1), 100.0), (date(2024, 12, 31), 200.0)]
+    # calendar_days = 365 -> (200/100)^(365/365) - 1 = 1.0
+    got = rm.cagr(closes)
+    assert got is not None and abs(got - Decimal("1")) < Decimal("1e-9")
+
+
+def test_cagr_same_total_return_diff_gap_counts_same():  # case 22 anti-regression
+    # both: 100 -> 150 over the SAME calendar span, different #observations.
+    span_days = 200
+    sparse = [(date(2024, 1, 1), 100.0), (date(2024, 1, 1) + timedelta(days=span_days), 150.0)]
+    dense = [
+        (date(2024, 1, 1), 100.0),
+        (date(2024, 1, 1) + timedelta(days=50), 120.0),
+        (date(2024, 1, 1) + timedelta(days=120), 110.0),
+        (date(2024, 1, 1) + timedelta(days=span_days), 150.0),
+    ]
+    a = rm.cagr(sparse)
+    b = rm.cagr(dense)
+    assert a is not None and b is not None
+    assert abs(a - b) < Decimal("1e-9")  # proves calendar-time, not 252/n_returns
+
+
+def test_cagr_calendar_days_zero_none():  # case 26
+    closes = [(date(2024, 1, 1), 100.0), (date(2024, 1, 1), 200.0)]
+    assert rm.cagr(closes) is None
+
+
+# ===========================================================================
+# Group 7 — calmar
+# ===========================================================================
+
+
+def test_calmar_known_fixture():  # case 23
+    got = rm.calmar(Decimal("0.30"), Decimal("-0.15"))
+    assert got is not None and got == Decimal("2")
+
+
+def test_calmar_tiny_dd_none():  # case 24
+    assert rm.calmar(Decimal("0.30"), Decimal("-1e-12")) is None
+    assert rm.calmar(Decimal("0.30"), Decimal("0")) is None
+
+
+# ===========================================================================
+# Group 8 — trailing return + excess
+# ===========================================================================
+
+
+def test_trailing_return_basic():
+    base = date(2024, 6, 1)
+    closes = [
+        (base - timedelta(days=40), 100.0),
+        (base - timedelta(days=35), 105.0),
+        (base, 130.0),
+    ]
+    # lookback 30d: as_of - 30 = base-30; nearest valid <= that is base-35 (105)
+    got = rm.trailing_return(closes, base, 30)
+    assert got is not None and abs(got - (Decimal("130") / Decimal("105") - 1)) < Decimal("1e-12")
+
+
+def test_trailing_return_none_when_no_history():
+    base = date(2024, 6, 1)
+    closes = [(base - timedelta(days=5), 100.0), (base, 110.0)]
+    assert rm.trailing_return(closes, base, 365) is None
+
+
+def test_excess_trailing_benchmark_missing():
+    base = date(2024, 6, 1)
+    closes = [(base - timedelta(days=40), 100.0), (base, 130.0)]
+    val, status = rm.excess_trailing_return(closes, [], base, 30)
+    assert val is None
+    assert status == "benchmark_missing"
+
+
+# ===========================================================================
+# Group 9 — excess cagr
+# ===========================================================================
+
+
+def test_excess_cagr_first_class():
+    inst = [(date(2024, 1, 1), 100.0), (date(2024, 12, 31), 200.0)]  # cagr 1.0
+    spy = [(date(2024, 1, 1), 100.0), (date(2024, 12, 31), 150.0)]  # cagr 0.5
+    val, status = rm.excess_cagr(inst, spy, "1y")
+    assert status == "ok"
+    assert val is not None and abs(val - Decimal("0.5")) < Decimal("1e-9")
+
+
+def test_excess_cagr_benchmark_missing():
+    inst = [(date(2024, 1, 1), 100.0), (date(2024, 12, 31), 200.0)]
+    val, status = rm.excess_cagr(inst, [], "1y")
+    assert val is None
+    assert status == "benchmark_missing"
+
+
+# ===========================================================================
+# Group 10 — boundaries / status
+# ===========================================================================
+
+
+def test_partial_window_cagr_boundary_251_vs_252():  # case 25
+    # 252 returns => not partial; 251 => partial.
+    closes_252 = _closes([100.0 + k for k in range(253)])  # 252 returns
+    closes_251 = _closes([100.0 + k for k in range(252)])  # 251 returns
+    assert rm.annualized_status(252) == "ok"
+    assert rm.annualized_status(251) == "partial_window"
+    # plumbed through compute
+    wm252 = rm.compute_instrument_risk(closes_252, [], "full", closes_252[-1][0])
+    wm251 = rm.compute_instrument_risk(closes_251, [], "full", closes_251[-1][0])
+    assert wm252.cagr_status == "ok"
+    assert wm251.cagr_status == "partial_window"
+
+
+def test_vol_beta_boundary_60_vs_59_and_midgap():  # case 27
+    # exactly 60 returns => pass; 59 => fail.
+    closes_61 = _closes([100.0 + k for k in range(61)])  # 60 returns
+    assert rm.vol_beta_status(60) == "ok"
+    assert rm.vol_beta_status(59) == "insufficient_history"
+    # 61 calendar days with one missing-date row => 60 rows => 59 returns => fails.
+    # (A missing-date gap drops exactly one return; an invalid-close gap breaks
+    #  the chain and drops two — that case is covered by
+    #  test_mid_series_invalid_breaks_chain.)
+    full = _closes([100.0 + k for k in range(61)])  # 61 dated rows, 60 returns
+    closes_gap = full[:30] + full[31:]  # drop the row at index 30
+    rets_gap = rm.simple_returns(closes_gap)
+    assert len(rets_gap) == 59
+    assert rm.vol_beta_status(len(rets_gap)) == "insufficient_history"
+    # sanity: clean 60-return chain
+    assert len(rm.simple_returns(closes_61)) == 60
+    # and an invalid-close mid-gap breaks the chain => 58 returns (also fails)
+    vals = [100.0 + k for k in range(61)]
+    vals[30] = float("nan")
+    rets_broken = rm.simple_returns(_closes(vals))
+    assert len(rets_broken) == 58
+    assert rm.vol_beta_status(len(rets_broken)) == "insufficient_history"
+
+
+# ===========================================================================
+# Group 11 — float island doesn't leak
+# ===========================================================================
+
+
+def test_persisted_distribution_scalars_are_decimal():  # case 28
+    arr = [
+        -0.10,
+        -0.08,
+        -0.06,
+        -0.05,
+        -0.04,
+        -0.03,
+        -0.02,
+        -0.01,
+        0.00,
+        0.01,
+        0.02,
+        0.03,
+        0.04,
+        0.05,
+        0.06,
+        0.07,
+        0.08,
+        0.09,
+        0.10,
+        0.12,
+    ]
+    res = rm.distribution([_D(x) for x in arr])
+    for v in (res.skew, res.excess_kurtosis, res.var_5):
+        assert isinstance(v, Decimal)
+        # equals Decimal(str(round(float, 8))) form — 8dp quantization
+        assert v == Decimal(str(round(float(v), 8)))
+
+
+# ===========================================================================
+# Group 12 — orchestration smoke
+# ===========================================================================
+
+
+def test_compute_instrument_risk_full_window():
+    closes = _closes([100.0 + k for k in range(300)])
+    spy = _closes([100.0 + 0.5 * k for k in range(300)])
+    wm = rm.compute_instrument_risk(closes, spy, "full", closes[-1][0])
+    assert wm.window_key == "full"
+    assert wm.annualized_vol is not None
+    assert wm.cagr is not None
+    assert wm.max_drawdown is not None
+    assert wm.beta is not None
+    assert wm.distribution is not None

--- a/tests/test_risk_metrics_migration.py
+++ b/tests/test_risk_metrics_migration.py
@@ -1,0 +1,132 @@
+"""Schema test for migration 198 — #591 PR-B Task B2 two-layer risk metrics.
+
+The ``ebull_test_conn`` fixture applies all migrations (incl. sql/198) to the
+template DB, so both tables already exist. Asserts:
+  - both tables exist;
+  - observations is RANGE-partitioned on as_of_date;
+  - the _default partition exists and stays EMPTY after a current-quarter
+    as_of_date insert (the row routes to a quarterly leaf, not _default);
+  - a window_key='1y' row inserts into both tables;
+  - an invalid window_key is rejected by the CHECK;
+  - an invalid status value is rejected by the CHECK.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.db
+
+_IID = 591_000_001
+_VERSION = "risk_v1"
+
+
+def test_both_tables_exist(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    conn = ebull_test_conn
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT to_regclass('instrument_risk_metrics_observations'), "
+            "       to_regclass('instrument_risk_metrics_current')"
+        )
+        obs, cur_tbl = cur.fetchone()
+    assert obs is not None
+    assert cur_tbl is not None
+
+
+def test_observations_is_range_partitioned(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT partstrat FROM pg_partitioned_table "
+            "WHERE partrelid = 'instrument_risk_metrics_observations'::regclass"
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "r"  # RANGE
+
+
+def test_current_quarter_row_routes_to_leaf_not_default(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    today = date.today()
+    conn.execute(
+        """
+        INSERT INTO instrument_risk_metrics_observations
+            (instrument_id, as_of_date, metric_version, window_key, computed_at,
+             cagr, vol_annualized, n_returns, cagr_status, vol_status)
+        VALUES (%s, %s, %s, '1y', %s, 0.1234, 0.2200, 251, 'ok', 'ok')
+        """,
+        (_IID, today, _VERSION, datetime.now(UTC)),
+    )
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM instrument_risk_metrics_observations_default")
+        default_count = cur.fetchone()[0]
+        cur.execute(
+            "SELECT COUNT(*) FROM instrument_risk_metrics_observations "
+            "WHERE instrument_id = %s",
+            (_IID,),
+        )
+        total = cur.fetchone()[0]
+    assert default_count == 0  # routed to a quarterly leaf
+    assert total == 1
+
+
+def test_current_row_inserts(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    conn = ebull_test_conn
+    conn.execute(
+        """
+        INSERT INTO instrument_risk_metrics_current
+            (instrument_id, metric_version, window_key, as_of_date, computed_at,
+             cagr, vol_annualized, beta, beta_r2, n_returns, cagr_status)
+        VALUES (%s, %s, '1y', %s, %s, 0.1, 0.2, 1.05, 0.88, 251, 'ok')
+        """,
+        (_IID, _VERSION, date.today(), datetime.now(UTC)),
+    )
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT window_key FROM instrument_risk_metrics_current WHERE instrument_id = %s",
+            (_IID,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] == "1y"
+
+
+def test_invalid_window_key_rejected(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    with pytest.raises(psycopg.errors.CheckViolation):
+        conn.execute(
+            """
+            INSERT INTO instrument_risk_metrics_observations
+                (instrument_id, as_of_date, metric_version, window_key)
+            VALUES (%s, %s, %s, '5y')
+            """,
+            (_IID, date.today(), _VERSION),
+        )
+    conn.rollback()
+
+
+def test_invalid_status_rejected(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    conn = ebull_test_conn
+    with pytest.raises(psycopg.errors.CheckViolation):
+        conn.execute(
+            """
+            INSERT INTO instrument_risk_metrics_observations
+                (instrument_id, as_of_date, metric_version, window_key, cagr_status)
+            VALUES (%s, %s, %s, '1y', 'totally_bogus')
+            """,
+            (_IID, date.today(), _VERSION),
+        )
+    conn.rollback()

--- a/tests/test_risk_metrics_migration.py
+++ b/tests/test_risk_metrics_migration.py
@@ -33,7 +33,9 @@ def test_both_tables_exist(ebull_test_conn: psycopg.Connection[tuple]) -> None: 
             "SELECT to_regclass('instrument_risk_metrics_observations'), "
             "       to_regclass('instrument_risk_metrics_current')"
         )
-        obs, cur_tbl = cur.fetchone()
+        row = cur.fetchone()
+    assert row is not None
+    obs, cur_tbl = row
     assert obs is not None
     assert cur_tbl is not None
 
@@ -69,12 +71,16 @@ def test_current_quarter_row_routes_to_leaf_not_default(
     conn.commit()
     with conn.cursor() as cur:
         cur.execute("SELECT COUNT(*) FROM instrument_risk_metrics_observations_default")
-        default_count = cur.fetchone()[0]
+        default_row = cur.fetchone()
+        assert default_row is not None
+        default_count = default_row[0]
         cur.execute(
             "SELECT COUNT(*) FROM instrument_risk_metrics_observations WHERE instrument_id = %s",
             (_IID,),
         )
-        total = cur.fetchone()[0]
+        total_row = cur.fetchone()
+        assert total_row is not None
+        total = total_row[0]
     assert default_count == 0  # routed to a quarterly leaf
     assert total == 1
 

--- a/tests/test_risk_metrics_migration.py
+++ b/tests/test_risk_metrics_migration.py
@@ -71,8 +71,7 @@ def test_current_quarter_row_routes_to_leaf_not_default(
         cur.execute("SELECT COUNT(*) FROM instrument_risk_metrics_observations_default")
         default_count = cur.fetchone()[0]
         cur.execute(
-            "SELECT COUNT(*) FROM instrument_risk_metrics_observations "
-            "WHERE instrument_id = %s",
+            "SELECT COUNT(*) FROM instrument_risk_metrics_observations WHERE instrument_id = %s",
             (_IID,),
         )
         total = cur.fetchone()[0]

--- a/tests/test_risk_metrics_persist.py
+++ b/tests/test_risk_metrics_persist.py
@@ -244,6 +244,78 @@ def test_thin_history_persists_flagged_not_absent(ebull_test_conn: psycopg.Conne
     assert cur["calmar_status"] == "partial_window"
 
 
+def test_trailing_columns_non_null_for_long_series(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """(f) BUG B: trailing_* and excess_trailing_* persist non-null for a long
+    series with SPY (the columns previously always wrote NULL)."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _SUBJECT_ID, "FAKE")
+    _seed_series(conn, _SPY_ID, _clean_series(400, start=400.0, step=0.3))
+    _seed_series(conn, _SUBJECT_ID, _clean_series(400, start=100.0, step=0.5))
+    conn.commit()
+
+    compute_and_store_risk_metrics(conn)
+
+    cur = _current_row(conn, _SUBJECT_ID, "full")
+    assert cur is not None
+    for col in ("trailing_1m", "trailing_3m", "trailing_6m", "trailing_1y"):
+        assert cur[col] is not None, f"{col} should be populated"
+    for col in (
+        "excess_trailing_1m",
+        "excess_trailing_3m",
+        "excess_trailing_6m",
+        "excess_trailing_1y",
+    ):
+        assert cur[col] is not None, f"{col} should be populated (SPY present)"
+
+    # Trailing scalars are window-INDEPENDENT → identical across window rows.
+    one_y = _current_row(conn, _SUBJECT_ID, "1y")
+    assert one_y is not None
+    assert one_y["trailing_1m"] == cur["trailing_1m"]
+    assert one_y["trailing_1y"] == cur["trailing_1y"]
+
+
+def test_window_rows_differ_in_db(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """(g) BUG A: the 1y and full rows in instrument_risk_metrics_current have
+    DIFFERENT vol/cagr (they were identical before the window-slice fix).
+
+    The series has a quiet first ~2 years and a volatile last year so the 1y
+    slice is materially different from the full series.
+    """
+    import random
+
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _SUBJECT_ID, "FAKE")
+    _seed_series(conn, _SPY_ID, _clean_series(1100, start=400.0, step=0.1))
+
+    rng = random.Random(99)
+    price = 100.0
+    subject: list[float | None] = []
+    for i in range(1100):
+        if i < 735:
+            price *= 1.0 + rng.uniform(-0.001, 0.0015)  # quiet
+        else:
+            price *= 1.0 + rng.uniform(-0.05, 0.06)  # volatile last ~1y
+        subject.append(price)
+    _seed_series(conn, _SUBJECT_ID, subject)
+    conn.commit()
+
+    compute_and_store_risk_metrics(conn)
+
+    one_y = _current_row(conn, _SUBJECT_ID, "1y")
+    full = _current_row(conn, _SUBJECT_ID, "full")
+    assert one_y is not None and full is not None
+    assert one_y["vol_annualized"] is not None and full["vol_annualized"] is not None
+    assert one_y["vol_annualized"] != full["vol_annualized"]
+    assert one_y["cagr"] is not None and full["cagr"] is not None
+    assert one_y["cagr"] != full["cagr"]
+    # n_returns / window_days evidence reflects the slice too.
+    assert one_y["n_returns"] < full["n_returns"]
+    assert one_y["window_days"] is not None and full["window_days"] is not None
+    assert one_y["window_days"] < full["window_days"]
+
+
 def test_fewer_than_two_valid_closes_no_row(ebull_test_conn: psycopg.Connection[tuple]) -> None:
     """(e) Instrument with < 2 valid closes → no row at all."""
     conn = ebull_test_conn

--- a/tests/test_risk_metrics_persist.py
+++ b/tests/test_risk_metrics_persist.py
@@ -311,9 +311,12 @@ def test_window_rows_differ_in_db(ebull_test_conn: psycopg.Connection[tuple]) ->
     assert one_y["cagr"] is not None and full["cagr"] is not None
     assert one_y["cagr"] != full["cagr"]
     # n_returns / window_days evidence reflects the slice too.
-    assert int(one_y["n_returns"]) < int(full["n_returns"])
-    assert one_y["window_days"] is not None and full["window_days"] is not None
-    assert int(one_y["window_days"]) < int(full["window_days"])
+    oy_n, fl_n = one_y["n_returns"], full["n_returns"]
+    oy_wd, fl_wd = one_y["window_days"], full["window_days"]
+    assert isinstance(oy_n, int) and isinstance(fl_n, int)
+    assert isinstance(oy_wd, int) and isinstance(fl_wd, int)
+    assert oy_n < fl_n
+    assert oy_wd < fl_wd
 
 
 def test_fewer_than_two_valid_closes_no_row(ebull_test_conn: psycopg.Connection[tuple]) -> None:

--- a/tests/test_risk_metrics_persist.py
+++ b/tests/test_risk_metrics_persist.py
@@ -1,0 +1,260 @@
+"""DB-tier tests for the risk-metrics persist layer (#591 PR-B, Task B3).
+
+Exercises ``compute_and_store_risk_metrics`` against a real Postgres:
+content-dedup append into the append-only observations log, deterministic
+rebuild of the _current write-through, and the correction-advances-current
+audit path (the rev2 BLOCKER scenario). Auto-marked ``db`` (pulls
+``ebull_test_conn``).
+
+Synthetic instruments only — a fake subject + a fake SPY (resolved by symbol
+the same way the candle-refresh scope resolves benchmarks).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import psycopg
+import psycopg.rows
+
+from app.services.risk_metrics import (
+    RISK_METRICS_VERSION,
+    WINDOW_KEYS,
+    compute_and_store_risk_metrics,
+)
+
+# Fixed synthetic ids well outside any real-data range.
+_SPY_ID = 990001
+_SUBJECT_ID = 990002
+_THIN_ID = 990003
+_ONE_CLOSE_ID = 990004
+
+# Anchor the series in the recent past so trailing windows resolve but the
+# data is deterministic. End ~5 days ago so CURRENT_DATE is always after it.
+_END = date.today() - timedelta(days=5)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, currency, country, is_tradable)
+        VALUES (%s, %s, %s, 'USD', 'US', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} co"),
+    )
+
+
+def _seed_series(
+    conn: psycopg.Connection[tuple],
+    iid: int,
+    closes: list[float | None],
+    end: date = _END,
+) -> None:
+    """Insert ``closes`` ending at ``end`` (one calendar day apart, ASC)."""
+    n = len(closes)
+    for i, close in enumerate(closes):
+        d = end - timedelta(days=(n - 1 - i))
+        conn.execute(
+            """
+            INSERT INTO price_daily (instrument_id, price_date, close)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (instrument_id, price_date) DO UPDATE SET close = EXCLUDED.close
+            """,
+            (iid, d, close),
+        )
+
+
+def _clean_series(n: int, start: float = 100.0, step: float = 0.5) -> list[float | None]:
+    """A monotone-up clean series of ``n`` closes (no NULLs, all > 0)."""
+    return [start + step * i for i in range(n)]
+
+
+def _count_obs(conn: psycopg.Connection[tuple], iid: int, window: str = "1y") -> int:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) FROM instrument_risk_metrics_observations
+        WHERE instrument_id = %s AND metric_version = %s AND window_key = %s
+        """,
+        (iid, RISK_METRICS_VERSION, window),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _current_row(conn: psycopg.Connection[tuple], iid: int, window: str = "1y") -> dict[str, object] | None:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT * FROM instrument_risk_metrics_current
+            WHERE instrument_id = %s AND metric_version = %s AND window_key = %s
+            """,
+            (iid, RISK_METRICS_VERSION, window),
+        )
+        return cur.fetchone()
+
+
+def test_long_clean_series_persists_ok_status(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """(a) A long clean series → observation + current rows with non-null
+    scalars and *_status='ok'."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _SUBJECT_ID, "FAKE")
+    # 400 closes → > MIN_RETURNS_ANNUALIZED (252) and > MIN_OBS_MOMENTS (250).
+    _seed_series(conn, _SPY_ID, _clean_series(400, start=400.0, step=0.3))
+    _seed_series(conn, _SUBJECT_ID, _clean_series(400, start=100.0, step=0.5))
+    conn.commit()
+
+    written = compute_and_store_risk_metrics(conn)
+    assert written > 0
+
+    # One observation row per window for the subject.
+    for window in WINDOW_KEYS:
+        assert _count_obs(conn, _SUBJECT_ID, window) == 1
+
+    cur = _current_row(conn, _SUBJECT_ID, "full")
+    assert cur is not None
+    assert cur["cagr"] is not None
+    assert cur["vol_annualized"] is not None
+    assert cur["max_drawdown"] is not None
+    # 400-row clean series clears every "ok" threshold.
+    assert cur["cagr_status"] == "ok"
+    assert cur["vol_status"] == "ok"
+    assert cur["drawdown_status"] == "ok"
+    assert cur["distribution_status"] == "ok"
+    assert cur["beta_status"] == "ok"
+    # Beta is computed against SPY → benchmark_instrument_id carried.
+    assert cur["benchmark_instrument_id"] == _SPY_ID
+    assert cur["as_of_date"] == _END
+
+
+def test_rerun_identical_data_no_new_observation(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """(b) Re-run with identical data → NO new observation row (content-dedup);
+    current unchanged."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _SUBJECT_ID, "FAKE")
+    _seed_series(conn, _SPY_ID, _clean_series(400, start=400.0, step=0.3))
+    _seed_series(conn, _SUBJECT_ID, _clean_series(400, start=100.0, step=0.5))
+    conn.commit()
+
+    compute_and_store_risk_metrics(conn)
+    before = _count_obs(conn, _SUBJECT_ID, "1y")
+    cur_before = _current_row(conn, _SUBJECT_ID, "1y")
+    assert cur_before is not None
+    refreshed_before = cur_before["refreshed_at"]
+
+    # Identical re-run.
+    compute_and_store_risk_metrics(conn)
+    after = _count_obs(conn, _SUBJECT_ID, "1y")
+    assert after == before  # no new observation
+
+    cur_after = _current_row(conn, _SUBJECT_ID, "1y")
+    assert cur_after is not None
+    # No-op rebuild must not churn refreshed_at (prevention-log MERGE-bloat).
+    assert cur_after["refreshed_at"] == refreshed_before
+
+
+def test_correction_appends_new_observation_and_advances_current(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """(c) Correct a HISTORICAL close (latest date unchanged) + re-run →
+    a NEW observation row for the same as_of_date AND current advances to it.
+
+    This is the rev2 BLOCKER scenario: a vendor correction to a past bar that
+    does not move the latest close date still produces different metrics; the
+    append-only log must record it and _current must advance.
+    """
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _SUBJECT_ID, "FAKE")
+    _seed_series(conn, _SPY_ID, _clean_series(400, start=400.0, step=0.3))
+    subject = _clean_series(400, start=100.0, step=0.5)
+    _seed_series(conn, _SUBJECT_ID, subject)
+    conn.commit()
+
+    compute_and_store_risk_metrics(conn)
+    obs_before = _count_obs(conn, _SUBJECT_ID, "full")
+    cur_before = _current_row(conn, _SUBJECT_ID, "full")
+    assert cur_before is not None
+    vol_before = cur_before["vol_annualized"]
+    computed_at_before = cur_before["computed_at"]
+    as_of_before = cur_before["as_of_date"]
+
+    # Correct a HISTORICAL bar (index 100) — a big spike injects volatility but
+    # leaves the LATEST close (index 399) and therefore as_of_date unchanged.
+    corrected = list(subject)
+    corrected[100] = 100.0 + 0.5 * 100 + 75.0  # large upward correction
+    _seed_series(conn, _SUBJECT_ID, corrected)
+    conn.commit()
+
+    compute_and_store_risk_metrics(conn)
+    obs_after = _count_obs(conn, _SUBJECT_ID, "full")
+    # A NEW observation row appended for the SAME as_of_date.
+    assert obs_after == obs_before + 1
+
+    cur_after = _current_row(conn, _SUBJECT_ID, "full")
+    assert cur_after is not None
+    # as_of_date unchanged (correction did not move the latest close).
+    assert cur_after["as_of_date"] == as_of_before
+    # current advanced to the corrected computation: new computed_at, new vol.
+    assert cur_after["computed_at"] != computed_at_before
+    assert cur_after["vol_annualized"] != vol_before
+
+
+def test_thin_history_persists_flagged_not_absent(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """(d) Thin-history instrument (10 closes) → row PERSISTED with FLAGGED
+    statuses, not absent.
+
+    Contract note: the compute layer computes a scalar whenever it is
+    mathematically possible (cagr/vol from >= 2 valid closes) and flags
+    *reliability* via the per-metric status — it does NOT null the scalar just
+    because the window is short. The endpoint therefore gets a flagged-not-
+    absent row, which is the required behaviour. We assert the row exists and
+    the short-history statuses are flagged (not 'ok'); a genuinely-null scalar
+    only appears when a metric is mathematically uncomputable (e.g. calmar with
+    a zero drawdown on a monotone-up series).
+    """
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _THIN_ID, "THIN")
+    _seed_series(conn, _SPY_ID, _clean_series(400, start=400.0, step=0.3))
+    _seed_series(conn, _THIN_ID, _clean_series(10, start=50.0, step=0.2))
+    conn.commit()
+
+    compute_and_store_risk_metrics(conn)
+
+    # Row EXISTS (flagged-not-absent) for every window.
+    for window in WINDOW_KEYS:
+        assert _count_obs(conn, _THIN_ID, window) == 1
+
+    cur = _current_row(conn, _THIN_ID, "full")
+    assert cur is not None
+    # 9 returns < MIN_RETURNS_ANNUALIZED (252) → cagr flagged partial_window.
+    assert cur["cagr_status"] == "partial_window"
+    # 9 returns < MIN_RETURNS_VOL_BETA (60) → vol flagged insufficient_history.
+    assert cur["vol_status"] == "insufficient_history"
+    # Aligned overlap with SPY too short → beta flagged.
+    assert cur["beta_status"] == "benchmark_insufficient_history"
+    # 9 returns < MIN_OBS_MOMENTS (250) → distribution flagged partial_window.
+    assert cur["distribution_status"] == "partial_window"
+    # Monotone-up series → zero drawdown → calmar mathematically null (epsilon
+    # guard), flagged via calmar_status. This is the genuinely-null metric.
+    assert cur["calmar"] is None
+    assert cur["calmar_status"] == "partial_window"
+
+
+def test_fewer_than_two_valid_closes_no_row(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """(e) Instrument with < 2 valid closes → no row at all."""
+    conn = ebull_test_conn
+    _seed_instrument(conn, _SPY_ID, "SPY")
+    _seed_instrument(conn, _ONE_CLOSE_ID, "ONE")
+    _seed_series(conn, _SPY_ID, _clean_series(400, start=400.0, step=0.3))
+    # A single valid close (1 < 2) → out of scope.
+    _seed_series(conn, _ONE_CLOSE_ID, [123.45])
+    conn.commit()
+
+    compute_and_store_risk_metrics(conn)
+
+    assert _count_obs(conn, _ONE_CLOSE_ID, "1y") == 0
+    assert _current_row(conn, _ONE_CLOSE_ID, "1y") is None

--- a/tests/test_risk_metrics_persist.py
+++ b/tests/test_risk_metrics_persist.py
@@ -311,9 +311,9 @@ def test_window_rows_differ_in_db(ebull_test_conn: psycopg.Connection[tuple]) ->
     assert one_y["cagr"] is not None and full["cagr"] is not None
     assert one_y["cagr"] != full["cagr"]
     # n_returns / window_days evidence reflects the slice too.
-    assert one_y["n_returns"] < full["n_returns"]
+    assert int(one_y["n_returns"]) < int(full["n_returns"])
     assert one_y["window_days"] is not None and full["window_days"] is not None
-    assert one_y["window_days"] < full["window_days"]
+    assert int(one_y["window_days"]) < int(full["window_days"])
 
 
 def test_fewer_than_two_valid_closes_no_row(ebull_test_conn: psycopg.Connection[tuple]) -> None:

--- a/tests/test_risk_metrics_wiring.py
+++ b/tests/test_risk_metrics_wiring.py
@@ -1,0 +1,71 @@
+"""Wiring invariants for the risk-metrics orchestrator layer + manual job
+(#591 PR-B, Tasks B4+B5).
+
+Mirrors tests/test_finra_regsho_daily_scheduler_wiring.py, but risk_metrics
+is orchestrator-driven, NOT a standalone cron — so this file asserts the
+ABSENCE of a SCHEDULED_JOBS entry (a ScheduledJob row would double-fire
+alongside the orchestrator DAG walk) and the PRESENCE of the DAG layer +
+JOB_TO_LAYERS mapping + manual-trigger lane.
+"""
+
+from __future__ import annotations
+
+from app.jobs.runtime import _INVOKERS
+from app.jobs.sources import MANUAL_TRIGGER_JOB_SOURCES, source_for
+from app.services.sync_orchestrator.adapters import refresh_risk_metrics
+from app.services.sync_orchestrator.registry import (
+    INIT_CHECKS,
+    JOB_TO_LAYERS,
+    LAYERS,
+)
+from app.workers.scheduler import (
+    JOB_RISK_METRICS_REFRESH,
+    SCHEDULED_JOBS,
+    risk_metrics_refresh,
+)
+
+
+def test_job_name_constant_exported() -> None:
+    assert JOB_RISK_METRICS_REFRESH == "risk_metrics_refresh"
+
+
+def test_invoker_registered_in_runtime() -> None:
+    invoker = _INVOKERS[JOB_RISK_METRICS_REFRESH]
+    assert callable(invoker)
+    assert invoker.__wrapped__ is risk_metrics_refresh  # type: ignore[attr-defined]
+
+
+def test_source_for_job_name_resolves_to_risk_metrics() -> None:
+    assert source_for(JOB_RISK_METRICS_REFRESH) == "risk_metrics"
+
+
+def test_manual_trigger_sources_entry_present() -> None:
+    assert MANUAL_TRIGGER_JOB_SOURCES[JOB_RISK_METRICS_REFRESH] == "risk_metrics"
+
+
+def test_layer_present_with_candles_dependency() -> None:
+    layer = LAYERS["risk_metrics"]
+    assert layer.dependencies == ("candles",)
+    assert layer.requires_layer_initialized == ("candles",)
+    assert layer.is_blocking is False
+
+
+def test_candles_init_check_present() -> None:
+    # risk_metrics declares requires_layer_initialized=("candles",); the
+    # pre-flight gate raises if a named dep has no INIT_CHECKS entry.
+    assert "candles" in INIT_CHECKS
+
+
+def test_job_to_layers_mapping() -> None:
+    assert JOB_TO_LAYERS["risk_metrics_refresh"] == ("risk_metrics",)
+
+
+def test_refresh_adapter_callable() -> None:
+    assert callable(refresh_risk_metrics)
+
+
+def test_not_in_scheduled_jobs() -> None:
+    """Orchestrator-driven, NOT a standalone cron — a ScheduledJob row would
+    double-fire alongside the DAG walk (Codex ckpt-1 design constraint)."""
+    scheduled_names = {job.name for job in SCHEDULED_JOBS}
+    assert JOB_RISK_METRICS_REFRESH not in scheduled_names

--- a/tests/test_sync_orchestrator_planner.py
+++ b/tests/test_sync_orchestrator_planner.py
@@ -93,13 +93,16 @@ class TestBuildExecutionPlanFull:
         _make_conn_with_freshness(set(LAYERS.keys()))
         plan = build_execution_plan(MagicMock(), SyncScope.full())
         assert plan.layers_to_refresh == ()
-        assert len(plan.layers_skipped) == 10
+        # 11 in-DAG layers (risk_metrics added #591 PR-B).
+        assert len(plan.layers_skipped) == 11
 
     def test_all_stale_yields_every_in_dag_layer(self) -> None:
         _make_conn_with_freshness(set())
         plan = build_execution_plan(MagicMock(), SyncScope.full())
-        # 11 in-DAG jobs → 11 LayerPlan entries.
-        assert len(plan.layers_to_refresh) == 9
+        # 11 in-DAG layers, but scoring + recommendations collapse into one
+        # producing job (morning_candidate_review) → 10 LayerPlan entries.
+        # risk_metrics added its own job in #591 PR-B (9 → 10).
+        assert len(plan.layers_to_refresh) == 10
 
     def test_topological_order_roots_first(self) -> None:
         _make_conn_with_freshness(set())

--- a/tests/test_sync_orchestrator_registry.py
+++ b/tests/test_sync_orchestrator_registry.py
@@ -7,10 +7,11 @@ from app.services.sync_orchestrator.registry import JOB_TO_LAYERS, LAYERS
 
 
 class TestLayerRegistry:
-    def test_all_10_layers_present(self) -> None:
+    def test_all_layers_present(self) -> None:
         # news + thesis retired in Phase 1.2 of the 2026-04-19 research-tool
         # refocus; both are now on-demand (POST /instruments/{symbol}/thesis)
-        # instead of scheduled orchestrator layers.
+        # instead of scheduled orchestrator layers. risk_metrics added in
+        # #591 PR-B (orchestrator-driven, depends on candles).
         expected = {
             "universe",
             "candles",
@@ -20,6 +21,7 @@ class TestLayerRegistry:
             "portfolio_sync",
             "fx_rates",
             "cost_models",
+            "risk_metrics",
             "weekly_reports",
             "monthly_reports",
         }
@@ -31,6 +33,7 @@ class TestLayerRegistry:
         non_blocking = {
             "portfolio_sync",
             "fx_rates",
+            "risk_metrics",
             "weekly_reports",
             "monthly_reports",
         }


### PR DESCRIPTION
Part of #591 (R4 risk drill, #585 cluster). PR-B of three (PR-A benchmark ingest merged #1631; PR-C = the frontend page).

## What this ships
A versioned, auditable backend **risk-metrics evidence layer** computed from `price_daily.close` (instrument + SPY), persisted in the repo's two-layer pattern, refreshed by the orchestrator DAG, served by a new endpoint. This is the operator-locked **Option B** (backend evidence layer feeding the page + future thesis/ranking) — not a frontend-only computation.

- **`app/services/risk_metrics.py`** — pure compute (`RISK_METRICS_VERSION="risk_v1"`, Decimal) + persist. Metrics per window (1y/3y/full): CAGR + excess-vs-SPY, max/current drawdown (+ peak/trough dates), annualized realized vol, OLS beta vs SPY (+ r², n_obs), return distribution (skew, excess-kurtosis, signed empirical `var_5`, worst/best day), Calmar, trailing 1m/3m/6m/1y (+ excess). Each metric carries a per-metric `*_status` ∈ {ok, insufficient_history, partial_window, benchmark_missing, benchmark_insufficient_history, invalid_price_chain, stale}.
- **`sql/198_instrument_risk_metrics.sql`** — two-layer: `instrument_risk_metrics_observations` (append-only audit log, quarterly RANGE partitions on `as_of_date`, PK incl `computed_at`) + `instrument_risk_metrics_current` (latest write-through). Discrete CHECK status columns (no JSONB). ~800k rows/yr at weekly cadence; bounded; `DROP PARTITION` available if a horizon is ever wanted.
- **Orchestrator wiring** — `risk_metrics` DAG layer (`dependencies=("candles",)`, `requires_layer_initialized=("candles",)` + new `INIT_CHECKS["candles"]`, weekly cadence, `is_blocking=False`). NOT a standalone `ScheduledJob` (the candles layer isn't either — `orchestrator_full_sync` drives it; a cron entry would double-fire). Own write-disjoint `risk_metrics` JobLock lane + manual-trigger triangle.
- **`GET /instruments/{symbol}/risk-metrics`** — persisted scalars + per-metric statuses + on-read display series (drawdown curve, rolling-vol line, return histogram, beta scatter) recomputed by the SAME service fns, cut at the persisted `as_of_date` (chart and table agree). 404 unknown symbol; 200 + empty windows for a never-computed instrument; honest status passthrough, never null→0.

## Key design decisions (Codex ckpt-1 ×2 + 3-persona wash folded)
- **Append-only observations is load-bearing because `price_daily` is mutable** (`market_data.py:321 ON CONFLICT … DO UPDATE` — vendor corrections rewrite history). So past metrics are NOT reconstructable from price history; the immutable observation row IS the audit record. A same-`as_of_date` correction appends a new `computed_at` row and advances `_current` (the PK includes `computed_at`).
- **Bloat-safe upsert** — `ON CONFLICT DO UPDATE … WHERE (business cols) IS DISTINCT FROM (excluded)`; `computed_at`/`refreshed_at` in the SET clause only, never in the diff predicate (prevention-log §MERGE bloat). The `(as_of_date, computed_at) >` tuple advances a fresh/corrected snapshot even when rounded values are unchanged.
- **Math contracts:** SIMPLE returns on the valid-close chain (finite & >0; invalid breaks the chain, no gap-spanning); calendar-time CAGR `(end/first)^(365/calendar_days)-1` (NOT 252/n_returns); date-ALIGNED OLS beta (never positional-zip); vol ×√252; type-7 signed `var_5`; one sanctioned float island for skew/kurtosis/percentile (numpy), quantized to Decimal at the boundary, everything else end-to-end Decimal; window slicing genuinely differs across 1y/3y/full.
- **Honest labels:** price return (not total return); **Calmar, not Sharpe** (no risk-free-rate series); this realized vol is distinct from the scorer's TA "volatility-regime" term — risk context, not a v1.1 score input.

## Security / safety model
- Read endpoint resolves `symbol→instrument_id` and does all reads inside one `snapshot_read` (REPEATABLE READ) so a concurrent universe change can't mix views (Codex ckpt-2). No user input reaches raw SQL — dynamic upsert SQL is built with `psycopg.sql` identifier/placeholder composition, values parameterised.
- Job is DB-only (no broker credential), gated by the universal bootstrap gate + candle-layer-init.
- No new dependency (numpy already present).

## Tradeoffs (conscious)
- Weekly cadence: annualized ≥1y-window stats move negligibly day-to-day; `as_of_date` surfaced so staleness is honest. A daily ranker (#1633) reading ≤7d-stale scalars is acceptable for structural risk; #1633 reassesses.
- Sector-relative views cut (no GICS/SPDR crosswalk) — follow-up. Thesis-evidence ingestion (#1632) + ranking risk-adjustment (#1633) are filed follow-ups, not built here.
- A redundant drawdown recompute in the persist layer (peak/trough dates) — efficiency nit on a weekly job, flagged by code review, left for a follow-up.

## Tests
- `tests/test_risk_metrics.py` (59 pure): every math contract incl. date-misalignment-vs-positional-zip beta, exact type-7 `var_5`, same-total-return-different-gaps→same-CAGR anti-regression, 60/59 & 252/251 boundaries counting returns, float-no-leak.
- `tests/test_risk_metrics_migration.py` (6 db), `tests/test_risk_metrics_persist.py` (7 db, incl. the same-`as_of` correction → new observation + current advances), `tests/test_api_risk_metrics.py` (5 db), `tests/test_risk_metrics_wiring.py` (9).
- Gates green: ruff, ruff format, pyright, fast tier (4125 passed), smoke (129).

## DoD (ETL clauses 8–12)
Dev backfill + panel figures (AAPL/GME/MSFT/JPM/HD + SPY) + a cross-source beta/vol check are being run on the dev DB; figures + SHA will be added as a PR comment. The live-endpoint check follows post-merge (the dev API reloads on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
