### PR TITLE
fix(#1638): 13D/G blockholder reporter_cik = reporting person, not issuer

### DIFF
--- a/app/providers/implementations/sec_13dg.py
+++ b/app/providers/implementations/sec_13dg.py
@@ -144,7 +144,17 @@ class BlockholderFiling:
         is what the ``blockholder_filer_seeds`` table keys on. Note
         that this is sometimes the same as the first reporting
         person, sometimes a service company (e.g. a transfer-agent
-        filing on behalf of a family trust).
+        filing on behalf of a family trust). NOTE: on the edgartools
+        manifest-drain path the adapter feeds this the manifest
+        archive-owner CIK (the subject/issuer post-#1628); for the
+        reporter identity used downstream prefer ``document_filer_cik``.
+      * ``document_filer_cik`` — the ``<filerCredentials><cik>`` read
+        directly from the primary_doc.xml: the entity that submitted the
+        filing on EDGAR. Always the document's own filer of record (both
+        the in-house parser and the edgartools adapter source it from the
+        body), so it is the fallback reporter identity for 13G accessions
+        whose cover omits a per-reporter ``<reportingPersonCIK>`` (#1638).
+        ``None`` only when the body is unparseable / pre-mandate.
       * ``issuer_cik`` — the issuing company's CIK. Joins to the
         eBull ``instruments`` table via
         ``instrument_sec_profile.cik``.
@@ -172,6 +182,7 @@ class BlockholderFiling:
     submission_type: SubmissionType
     status: Status
     primary_filer_cik: str
+    document_filer_cik: str | None
     issuer_cik: str
     issuer_cusip: str
     issuer_name: str
@@ -311,6 +322,28 @@ def extract_issuer_identity_from_primary_doc(xml: str) -> IssuerIdentity:
     except ET.ParseError:
         return IssuerIdentity(cik=None, cusip=None, name=None, class_title=None)
     return _issuer_identity_from_root(root)
+
+
+def extract_filer_cik_from_primary_doc(xml: str) -> str | None:
+    """Read ``<filerCredentials><cik>`` (the EDGAR submitter / filer of
+    record) from a 13D/G primary_doc.xml (#1638).
+
+    Used by the edgartools adapter as the observation ``reporter_cik``
+    fallback when a 13G cover omits per-reporter ``<reportingPersonCIK>``
+    — there the filer of record IS the beneficial owner. Never raises:
+    returns ``None`` on a missing tag, a non-numeric CIK, or an
+    unparseable (pre-mandate HTML) body so the caller can fall back."""
+    try:
+        root = ET.fromstring(xml)  # noqa: S314 — SEC EDGAR is the trusted source for 13D/G XML.
+    except ET.ParseError:
+        return None
+    text = _child_text(_find_descendant(root, "filerCredentials"), "cik")
+    if not text or not text.strip():
+        return None
+    try:
+        return _zero_pad_cik(text)
+    except ValueError:
+        return None
 
 
 def _decimal_or_none(text: str | None) -> Decimal | None:
@@ -574,6 +607,9 @@ def parse_primary_doc(xml: str) -> BlockholderFiling:
         submission_type=submission_type,
         status=status,
         primary_filer_cik=primary_filer_cik,
+        # In-house parser: primary_filer_cik IS the document filer of
+        # record, so document_filer_cik mirrors it (#1638).
+        document_filer_cik=primary_filer_cik,
         issuer_cik=issuer_cik,
         issuer_cusip=issuer_cusip,
         issuer_name=issuer_name,

--- a/app/services/blockholders.py
+++ b/app/services/blockholders.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 import json
 import logging
 import xml.etree.ElementTree as ET  # noqa: S405 — only used to catch ET.ParseError; no untrusted input parsed here.
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from decimal import Decimal
@@ -73,7 +73,7 @@ from app.services.sec_identity import siblings_for_issuer_cik
 # returned an empty CUSIP, so CUSIP-only resolution never resolved and
 # blockholders never populated. The bump flips sec_13d/sec_13g manifest
 # rows back to ``pending`` so they re-drain through the fixed extractor.
-_PARSER_VERSION_13DG = "13dg-primary-v2"
+_PARSER_VERSION_13DG = "13dg-primary-v3"
 
 logger = logging.getLogger(__name__)
 
@@ -795,7 +795,6 @@ def _ingest_single_accession(
         accession_number=ref.accession_number,
         primary_document_url=primary_url,
         filing=filing,
-        filer_name=filer_name,
         ref=ref,
         run_id=batch_run_id,
     )
@@ -810,6 +809,60 @@ def _ingest_single_accession(
     )
 
 
+@dataclass(frozen=True)
+class BlockholderReporterIdentity:
+    """The single observation-row identity resolved from one 13D/G
+    accession's reporting persons (#1638)."""
+
+    reporter_cik: str
+    reporter_name: str
+    aggregate_amount_owned: Decimal
+    percent_of_class: Decimal | None
+
+
+def resolve_blockholder_reporter_identity(
+    reporting_persons: Sequence[BlockholderReportingPerson],
+    *,
+    document_filer_cik: str | None,
+) -> BlockholderReporterIdentity | None:
+    """Resolve the one observation-row identity for a 13D/G accession.
+
+    Collapses joint filers to ONE observation (#837): the reporting
+    person with the largest ``aggregate_amount_owned``. ``reporter_cik``
+    is that person's own per-reporter CIK when the XML carries it
+    (modern 13D), else the document ``<filerCredentials><cik>`` filer of
+    record (modern 13G omits per-reporter CIK; and the rare multi-party
+    13D whose largest reporter is a natural person with no CIK — the
+    filer of record is the group's stable, joinable identity, never the
+    issuer/subject). NEVER the manifest/subject CIK (#1638).
+
+    Returns ``None`` (skip the observation) when there are no reporting
+    persons, the chosen person has no aggregate (mirrors the write-side
+    ``aggregate_amount_owned IS NOT NULL`` guard), or no joinable CIK is
+    available at all.
+    """
+    if not reporting_persons:
+        return None
+    # Match the legacy DISTINCT ON ... ORDER BY aggregate_amount_owned
+    # DESC NULLS LAST: the tuple sentinel floats NULL aggregates to the
+    # bottom so ``max`` never compares against ``None``.
+    chosen = max(
+        reporting_persons,
+        key=lambda p: (p.aggregate_amount_owned is not None, p.aggregate_amount_owned or Decimal(0)),
+    )
+    if chosen.aggregate_amount_owned is None:
+        return None
+    reporter_cik = (chosen.cik or "").strip() or (document_filer_cik or "").strip()
+    if not reporter_cik:
+        return None
+    return BlockholderReporterIdentity(
+        reporter_cik=reporter_cik,
+        reporter_name=chosen.name,
+        aggregate_amount_owned=chosen.aggregate_amount_owned,
+        percent_of_class=chosen.percent_of_class,
+    )
+
+
 def _record_13dg_observation_for_filing(
     conn: psycopg.Connection[Any],
     *,
@@ -817,51 +870,37 @@ def _record_13dg_observation_for_filing(
     accession_number: str,
     primary_document_url: str,
     filing: BlockholderFiling,
-    filer_name: str,
     ref: AccessionRef,
     run_id: Any,
 ) -> None:
     """Record one ``ownership_blockholders_observations`` row for one
     13D/G accession.
 
-    Mirrors the legacy batch-sync rule in
-    ``ownership_observations_sync.sync_blockholders``:
-
-      - Identity: PRIMARY filer's CIK (``filing.primary_filer_cik``),
-        NEVER the per-row reporter_cik. Joint reporters on the same
-        accession collapse to one observation per the SEC convention
-        that joint filers claim the same beneficial figure on the
-        cover page (#837 lesson).
-      - Picks the reporting_persons row with the highest
-        ``aggregate_amount_owned`` (DESC NULLS LAST) — matches the
-        legacy ``DISTINCT ON (accession, filer_id) ORDER BY ...``.
-      - Source enum: ``'13d'`` for SCHEDULE 13D family, ``'13g'`` for
-        SCHEDULE 13G.
-      - Filter: ``aggregate_amount_owned IS NOT NULL`` AND
-        ``filed_at IS NOT NULL`` — both required by the observation
-        contract.
+    Identity is resolved by :func:`resolve_blockholder_reporter_identity`
+    — the largest-aggregate reporting person, keyed to that person's own
+    per-reporter CIK when present (modern 13D), else the document filer
+    of record (``filing.document_filer_cik``; modern 13G omits the
+    per-reporter CIK). NEVER the manifest/subject CIK (#1638 — the prior
+    ``filing.primary_filer_cik`` became the issuer CIK on the drain path
+    post-#1628). Joint reporters still collapse to one observation per
+    accession (#837). ``filed_at`` is required by the observation
+    contract; a missing aggregate / no joinable CIK skips the row.
     """
-    if not filing.reporting_persons:
-        return
     filed_at = filing.filed_at or ref.filed_at
     if filed_at is None:
         return
-    # Match legacy DISTINCT ON ... ORDER BY aggregate_amount_owned
-    # DESC NULLS LAST. ``key=lambda`` with ``-Decimal`` would crash on
-    # NULL; use a sentinel that floats NULLs to the bottom.
-    chosen = max(
-        filing.reporting_persons,
-        key=lambda p: (p.aggregate_amount_owned is not None, p.aggregate_amount_owned or Decimal(0)),
+    identity = resolve_blockholder_reporter_identity(
+        filing.reporting_persons, document_filer_cik=filing.document_filer_cik
     )
-    if chosen.aggregate_amount_owned is None:
+    if identity is None:
         return
     stype = filing.submission_type
     source = "13d" if stype.startswith("SCHEDULE 13D") else "13g"
     record_blockholder_observation(
         conn,
         instrument_id=instrument_id,
-        reporter_cik=filing.primary_filer_cik,
-        reporter_name=filer_name,
+        reporter_cik=identity.reporter_cik,
+        reporter_name=identity.reporter_name,
         ownership_nature="beneficial",
         submission_type=stype,
         status_flag=filing.status,
@@ -874,8 +913,8 @@ def _record_13dg_observation_for_filing(
         period_start=None,
         period_end=filed_at.date(),
         ingest_run_id=run_id,
-        aggregate_amount_owned=chosen.aggregate_amount_owned,
-        percent_of_class=chosen.percent_of_class,
+        aggregate_amount_owned=identity.aggregate_amount_owned,
+        percent_of_class=identity.percent_of_class,
     )
 
 

--- a/app/services/manifest_parsers/_schedule13_adapter.py
+++ b/app/services/manifest_parsers/_schedule13_adapter.py
@@ -49,6 +49,7 @@ from app.providers.implementations.sec_13dg import (
     BlockholderReportingPerson,
     Status,
     SubmissionType,
+    extract_filer_cik_from_primary_doc,
     extract_issuer_identity_from_primary_doc,
 )
 from app.services.blockholders import _zero_pad_cik
@@ -227,10 +228,18 @@ def build_filing_from_edgartools_dict(
     issuer_cik = (helper.cik if helper and helper.cik else None) or issuer_info.cik
     issuer_cusip = (helper.cusip if helper and helper.cusip else None) or security_info.cusip
 
+    # edgartools does NOT expose <filerCredentials><cik>; read it from the
+    # raw body so the observation reporter_cik can fall back to the true
+    # filer of record for 13G covers that omit per-reporter CIKs (#1638).
+    # Distinct from primary_filer_cik, which post-#1628 is the manifest
+    # archive-owner (subject/issuer) on this drain path.
+    document_filer_cik = extract_filer_cik_from_primary_doc(raw_xml) if raw_xml else None
+
     return BlockholderFiling(
         submission_type=submission_type,
         status=status,
         primary_filer_cik=_zero_pad_cik(manifest_filer_cik),
+        document_filer_cik=document_filer_cik,
         issuer_cik=issuer_cik,
         issuer_cusip=issuer_cusip,
         issuer_name=issuer_info.name,

--- a/app/services/manifest_parsers/sec_13dg.py
+++ b/app/services/manifest_parsers/sec_13dg.py
@@ -362,7 +362,6 @@ def _parse_13dg(
                     accession_number=accession,
                     primary_document_url=primary_url,
                     filing=filing,
-                    filer_name=filer_name,
                     ref=ref,
                     run_id=uuid4(),  # one-shot per accession; no batch run_id concept on manifest path
                 )

--- a/app/services/ownership_observations.py
+++ b/app/services/ownership_observations.py
@@ -646,12 +646,14 @@ def record_blockholder_observation(
     """Append one 13D/G blockholder observation. Idempotent on the
     natural key.
 
-    Identity (per #837 lesson): ``reporter_cik`` here is the PRIMARY
-    filer (``blockholder_filers.cik``), NOT the per-row joint
-    reporter. Backfill / write-through MUST resolve the primary
-    filer first; joint reporters on the same accession collapse to
-    one observation row per the SEC convention that joint filers
-    claim the same beneficial ownership."""
+    ``reporter_cik`` is the resolved beneficial-owner identity for the
+    accession (see
+    :func:`app.services.blockholders.resolve_blockholder_reporter_identity`):
+    the largest-aggregate reporting person's own per-reporter CIK, else
+    the document filer of record. NEVER the manifest/subject CIK
+    (#1638). Joint reporters on the same accession still collapse to one
+    observation per the SEC convention that joint filers claim the same
+    beneficial figure (#837)."""
     if reporter_cik is None or not reporter_cik.strip():
         raise ValueError("record_blockholder_observation: reporter_cik is required")
     with conn.cursor() as cur:

--- a/app/services/ownership_observations_sync.py
+++ b/app/services/ownership_observations_sync.py
@@ -490,15 +490,23 @@ def sync_blockholders(
     since: date | None = None,
     limit: int | None = None,
 ) -> SyncSummary:
-    """Mirror ``blockholder_filings`` (joined to ``blockholder_filers``
-    for primary cik) into ``ownership_blockholders_observations`` and
-    refresh ``_current``.
+    """Mirror ``blockholder_filings`` into
+    ``ownership_blockholders_observations`` and refresh ``_current``.
 
-    Per #837 lesson + Codex plan review: identity is the PRIMARY filer
-    (filer_id → cik), never the per-row reporter_cik. Joint reporters
-    on the same accession collapse via ``DISTINCT ON (accession_number,
-    filer_id)`` so each accession contributes one observation per
-    primary filer.
+    Identity is the per-row ``reporter_cik`` of the largest-aggregate
+    reporting person (the disclosing person's own CIK), NOT
+    ``blockholder_filers.cik`` — post-#1628 that filer row carries the
+    subject/issuer CIK on the drain path (#1638). Joint reporters on the
+    same accession collapse via ``DISTINCT ON (accession_number)``
+    ordered by aggregate so each accession contributes one observation
+    (#837). Rows whose ``reporter_cik`` is NULL (13G covers omit
+    per-reporter CIKs; the rare multi-party 13D whose largest reporter is
+    CIK-less) are SKIPPED here — the canonical write-through path
+    (``_record_13dg_observation_for_filing``) populates them with the
+    document filer-of-record fallback, which the typed tables cannot
+    reconstruct. This legacy mirror runs only via the manual one-shot
+    ``ownership_observations_backfill``; the daily job is the repair
+    sweep.
 
     PR11 #1233 §3.2 chokepoint C — the 3y retention cap is enforced as
     a SQL predicate on the raw chain's own ``bf.filed_at`` column so
@@ -535,22 +543,32 @@ def sync_blockholders(
         params["lim"] = limit
     limit_sql = "LIMIT %(lim)s" if limit is not None else ""
 
-    # DISTINCT ON keeps one row per (accession, primary filer) — joint
-    # reporter dimension collapses per the SEC convention that joint
-    # filers claim the same beneficial figure on the cover page.
+    # DISTINCT ON keeps the largest-aggregate reporting person per
+    # accession — joint reporters collapse to one observation per the SEC
+    # convention that joint filers claim the same beneficial figure (#837).
+    # Identity is the per-row ``reporter_cik`` (the disclosing person's
+    # own CIK), NOT ``blockholder_filers.cik`` which post-#1628 is the
+    # subject/issuer on the drain path (#1638).
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             f"""
-            SELECT DISTINCT ON (bf.accession_number, bf.filer_id)
+            SELECT DISTINCT ON (bf.accession_number)
                    bf.instrument_id, bf.accession_number,
                    bf.submission_type, bf.status, bf.filed_at,
                    bf.aggregate_amount_owned, bf.percent_of_class,
-                   f.cik, f.name AS filer_name
+                   bf.reporter_cik, bf.reporter_name
             FROM blockholder_filings bf
-            JOIN blockholder_filers f ON f.filer_id = bf.filer_id
             {where}
-            ORDER BY bf.accession_number, bf.filer_id,
-                     bf.aggregate_amount_owned DESC NULLS LAST
+            ORDER BY bf.accession_number,
+                     bf.aggregate_amount_owned DESC NULLS LAST,
+                     -- Deterministic tie-breaker matching the write-through
+                     -- resolver, whose max() returns the FIRST equal-aggregate
+                     -- reporter in XML order. _upsert_filing_row inserts
+                     -- reporters in XML order, so the lowest filing_id is the
+                     -- first XML reporter — both paths pick the same CIK on a
+                     -- tie, so no second observation under a different natural
+                     -- key (Codex ckpt-2).
+                     bf.filing_id ASC
             {limit_sql}
             """,
             params,
@@ -559,9 +577,15 @@ def sync_blockholders(
 
     for row in rows:
         summary.rows_scanned += 1
-        cik = str(row["cik"] or "").strip()
-        if not cik or row["instrument_id"] is None:
-            summary.orphans.append(f"blockholder_filings accession={row['accession_number']} (blank cik or instrument)")
+        reporter_cik = str(row["reporter_cik"] or "").strip()
+        if not reporter_cik or row["instrument_id"] is None:
+            # NULL per-reporter CIK = a 13G cover (or the rare multi-party
+            # 13D whose largest reporter is CIK-less). The typed tables
+            # carry no filer-of-record fallback, so defer to the canonical
+            # write-through populator rather than write a wrong CIK (#1638).
+            summary.orphans.append(
+                f"blockholder_filings accession={row['accession_number']} (no per-reporter cik or instrument)"
+            )
             continue
         # Map submission_type to source tag.
         stype = str(row["submission_type"])
@@ -570,8 +594,8 @@ def sync_blockholders(
             record_blockholder_observation(
                 conn,
                 instrument_id=int(row["instrument_id"]),
-                reporter_cik=cik,
-                reporter_name=str(row["filer_name"]),
+                reporter_cik=reporter_cik,
+                reporter_name=str(row["reporter_name"]),
                 ownership_nature="beneficial",
                 submission_type=stype,
                 status_flag=str(row["status"]) if row["status"] else None,

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -821,7 +821,6 @@ def _apply_blockholders(
             accession_number=raw_doc.accession_number,
             primary_document_url="",
             filing=filing,
-            filer_name=filer_name,
             ref=ref,
             run_id=uuid4(),
         )

--- a/docs/specs/etl/2026-06-15-blockholder-reporter-cik.md
+++ b/docs/specs/etl/2026-06-15-blockholder-reporter-cik.md
@@ -1,0 +1,163 @@
+# 13D/G blockholder `reporter_cik` — source from the document, not the manifest
+
+Issue: #1638 (part of #788 — ownership card trustworthy). Live spec. **PR1 of 2**
+(PR2 = concentration cross-slice dedup; see "Bug A" below — operator-scoped 2026-06-15).
+
+## Problem
+
+`ownership_blockholders_current.reporter_cik` carries the **subject company's own
+issuer CIK** for 733/800 dev rows (≈93%), with the correct reporting-person **name**.
+GME: `reporter_name='Cohen Ryan'`, `reporter_cik='0001326380'` — but `0001326380`
+is GameStop's issuer CIK.
+
+### Root cause (cross-layer, verified)
+
+`#1628` flipped the 13D/G manifest from *filer*-keyed to *issuer*-keyed so
+subject→instrument resolution works via issuer-CUSIP. But the edgartools adapter
+still feeds `manifest.cik` into `BlockholderFiling.primary_filer_cik`
+(`_schedule13_adapter.py:233`), whose documented meaning is "the EDGAR submitter" —
+so post-#1628 that field silently became the **issuer CIK** on the drain path. The
+observation writer copies it verbatim (`blockholders.py:863`).
+
+The correct identity is in the document and **already parsed/stored**:
+- per-reporter `<reportingPersonCIK>` → `BlockholderReportingPerson.cik` and
+  `blockholder_filings.reporter_cik` (Cohen `0001767470`). Present on modern 13D;
+  **absent on modern 13G** (443/443 dev rows null — mandate 13G omits it).
+- `<filerCredentials><cik>` → the EDGAR submitter (the filer of record). Present on
+  every successfully-parsed filing; never the issuer (verified Vanguard `0000102909`,
+  Janus `0001274173`, BlackRock `0002012383`, all ≠ their issuers).
+
+Empirical survey of all 800 stored accessions (edgartools `Schedule13{D,G}.parse_xml`
++ adapter): 13D = 342/369 carry a non-null chosen-reporter CIK; 13G = 443/443 null;
+chosen-reporter CIK is **never** the issuer CIK (0 rows).
+
+## Fix — resolve reporter identity from the document (two write paths)
+
+There are **two** writers into `ownership_blockholders_observations` for 13D/G — both
+must stop writing the issuer CIK:
+
+1. **Write-through drain** (`_record_13dg_observation_for_filing`, the canonical path
+   per #873.C) — the 733 bad rows came from here.
+2. **Legacy mirror** (`sync_blockholders`, run only by the manual one-shot
+   `ownership_observations_backfill`; the *daily* `ownership_observations_sync` job is
+   the repair sweep, not this) — writes `reporter_cik = blockholder_filers.cik` =
+   issuer post-#1628 → a manual reintroduction vector (Codex ckpt-1 HIGH).
+
+### Resolution rule (pure function, table-tested)
+
+`resolve_blockholder_reporter_identity(reporting_persons, *, document_filer_cik)`:
+
+1. `chosen = max(reporting_persons, key=aggregate_amount_owned DESC NULLS LAST)` —
+   the existing selection; one observation per accession (preserves #837 joint-filer
+   collapse).
+2. `reporter_cik = chosen.cik or document_filer_cik`:
+   - per-reporter CIK when the XML carries it (modern 13D — the disclosing person's
+     own CIK, e.g. Cohen `0001767470`);
+   - else the document `<filerCredentials><cik>` (modern 13G — the filer IS the
+     beneficial owner; and the 27 multi-party 13D where the largest-aggregate reporter
+     is a natural person with no CIK — the filer-of-record is the group's stable,
+     joinable identity, never the issuer, never an agent for 13D/G per sec-edgar §3.7).
+3. `reporter_name = chosen.name`, `aggregate/percent = chosen.*` (the largest disclosed
+   beneficial position — most operator-useful label).
+4. Return `None` (skip the observation) when: no reporting persons; chosen has no
+   aggregate (mirrors the existing `aggregate_amount_owned IS NOT NULL` write-side
+   guard, prevention-log "mirror write-time guards"); or both CIKs null (unjoinable).
+
+**Group-filing caveat:** for a multi-party 13D whose largest-aggregate reporter has no
+CIK, `reporter_name` (largest reporter) and `reporter_cik` (filer-of-record) may name
+different members of the same filing group. This is inherent to the #837 one-row-per-
+accession collapse; the filer-of-record CIK is the correct joinable group identity.
+Affects 27/800 dev rows. Strictly better than the issuer-CIK bug (always wrong) or
+skipping (hides a real large position).
+
+### Path 1 — write-through
+`_record_13dg_observation_for_filing` calls the resolver with
+`document_filer_cik=filing.document_filer_cik`. New in-memory field
+`BlockholderFiling.document_filer_cik` (NO DB column):
+- **edgartools adapter** sets it via `extract_filer_cik_from_primary_doc(raw_xml)`
+  (new helper reading `<filerCredentials><cik>`, zero-padded; `None` on absent/malformed).
+- **in-house `parse_primary_doc`** sets it `= primary_filer_cik` (there it already IS
+  the document filerCredentials).
+`primary_filer_cik` is left as-is (still the `blockholder_filers` PK / ingest-log key).
+
+### Path 2 — legacy mirror
+`sync_blockholders` reads the per-row `blockholder_filings.reporter_cik` (already the
+correct per-person CIK, written by `_upsert_filing_row(person.cik)`), `DISTINCT ON
+(accession) ORDER BY aggregate_amount_owned DESC NULLS LAST`, and writes
+`reporter_cik = bf.reporter_cik`, `reporter_name = bf.reporter_name`. When
+`bf.reporter_cik IS NULL` (all 13G + the 27 multi-party 13D) it **skips** (orphan-log)
+— the write-through is the canonical populator for those rows; the mirror must never
+write the filer/issuer CIK as the reporter. (The typed tables carry no
+filerCredentials column, so the mirror cannot reproduce the document-filer fallback;
+deferring those rows to write-through is correct, not a coverage loss.)
+
+### Other
+- Bump `_PARSER_VERSION_13DG` `"13dg-primary-v2"` → `"13dg-primary-v3"`
+  (`blockholders.py:76`) to force `sec_rebuild` re-drain.
+- Update `record_blockholder_observation` docstring (#837 note: identity is the chosen
+  reporting person / document-filer fallback, NOT the primary filer).
+
+## Out of scope (noted, not fixed here)
+
+- `primary_filer_cik` / `blockholder_filers.cik` are the issuer CIK on the drain path
+  (typed-table mis-keying). Not operator-visible (rollup reads `_current` ←
+  observations, which this fix corrects). Latent follow-up, not #1638.
+- **Bug A — concentration double-count (#1640, PR2).** The rollup *deliberately* keeps 13D/G
+  (beneficial) and Form 4 (direct) in separate pie-wedge slices and `_compute_concentration`
+  **sums** them (`ownership_rollup.py:1386`, #837/#788-P0b) — so Cohen's insider 38.3M +
+  blockholder 36.8M both count regardless of `reporter_cik`. Correct identity (this PR)
+  is the **prerequisite**; PR2 adds a concentration-level cross-slice dedup-by-CIK
+  (keeps the "show both slices" display, de-dups only the sum) → GME ≈40%.
+
+## Backfill (the append-only trap) — Codex ckpt-1 HIGH/MED fixes folded
+
+The observation natural key includes `reporter_cik`. Re-draining with a corrected CIK
+**INSERTs** a new row; the stale issuer-CIK row stays valid (`known_to IS NULL`). The
+`_current` MERGE is `DISTINCT ON (reporter_cik, ownership_nature)` — it would keep
+**both** → a fix that worsens the double-count. Blockholder observations have **no
+known_to supersession wired** (verified), so re-drain alone does not retire stale rows.
+
+`scripts/backfill_1638_retire_issuer_cik_blockholders.py` (run on dev; idempotent):
+
+1. Retire stale rows in one statement, capturing affected instruments:
+   ```sql
+   UPDATE ownership_blockholders_observations o
+   SET known_to = clock_timestamp(), ingested_at = clock_timestamp()  -- bump ingested_at so
+   -- the refresh/repair watermark (MAX(ingested_at)) advances past the expiry (Codex HIGH-3)
+   FROM external_identifiers ei
+   WHERE o.known_to IS NULL
+     AND o.source IN ('13d','13g')
+     AND ei.instrument_id = o.instrument_id
+     AND ei.provider = 'sec' AND ei.identifier_type = 'cik'
+     AND lpad(ei.identifier_value, 10, '0') = lpad(o.reporter_cik, 10, '0')
+   RETURNING o.instrument_id;
+   ```
+   Exact bug signature; 0 legitimate self-filings (a 13D/G is never filed by the issuer
+   on itself — confirmed chosen.cik never == issuer).
+2. **Immediately** `refresh_blockholders_current` for each RETURNING instrument →
+   MERGE `WHEN NOT MATCHED BY SOURCE THEN DELETE` drops the stale `_current` rows now
+   (no window where `_current` holds both; Codex MED-3).
+3. `POST /jobs/sec_rebuild/run {"source":"sec_13d"}` + `{"source":"sec_13g"}` →
+   re-drain re-parses stored raw (no SEC re-fetch) → correct observations + per-accession
+   refresh.
+
+## Tests
+
+- **Pure** `tests/test_blockholder_reporter_identity.py` (no DB): 13D chosen-with-CIK →
+  Cohen `0001767470`; 13G null-cik → `document_filer_cik`; multi-party 13D null-chosen-cik
+  → `document_filer_cik`; all-null aggregate → None; empty → None; both CIKs null → None;
+  tie → list order.
+- **Adapter** `tests/test_manifest_parser_sec_13dg.py`: `build_filing_from_edgartools_dict`
+  populates `document_filer_cik` from `raw_xml`; None when `raw_xml=None`.
+- **(db) invariant** `tests/test_blockholders_ingester.py`: after the drain on a GME-shape
+  fixture, no active observation has `reporter_cik == issuer_cik`; mirror skips 13G.
+
+## DoD
+
+8. Panel AAPL/GME/MSFT/JPM/HD: `_current.reporter_cik` ≠ issuer CIK after backfill.
+9. Cross-source: GME Cohen `reporter_cik → 0001767470` (his Form 4 CIK); Vanguard 13G →
+   `0000102909`.
+10. Backfill run on dev (retire + refresh + sec_rebuild) — record counts.
+11. `/instruments/GME/ownership-rollup`: blockholder Cohen row shows `0001767470`.
+    (Concentration stays 48.37% until PR2 — by design.)
+12. PR records each + commit SHA.

--- a/scripts/backfill_1638_retire_issuer_cik_blockholders.py
+++ b/scripts/backfill_1638_retire_issuer_cik_blockholders.py
@@ -1,0 +1,158 @@
+"""One-shot retirement of issuer-CIK blockholder observations (#1638).
+
+Pre-#1638 the 13D/G write-through + legacy mirror stamped
+``ownership_blockholders_observations.reporter_cik`` with the subject
+company's own issuer CIK (post-#1628 the manifest/filer key became the
+issuer). #1638 corrects the write paths to use the reporting person's
+own CIK (or the document filer of record). But the observation natural
+key includes ``reporter_cik``, so a corrected re-drain INSERTs a NEW row
+and leaves the stale issuer-CIK row valid (``known_to IS NULL``). The
+``_current`` MERGE is ``DISTINCT ON (reporter_cik, ownership_nature)`` —
+it would then keep BOTH → a fix that doubles the row. Blockholder
+observations have no ``known_to`` supersession wired, so re-drain alone
+does not retire the stale rows.
+
+This script retires exactly the bug signature — an active 13D/G
+observation whose ``reporter_cik`` equals the instrument's own issuer
+``(sec, cik)`` — and immediately refreshes ``_current`` for the affected
+instruments so the stale current rows are deleted
+(``WHEN NOT MATCHED BY SOURCE THEN DELETE``). A 13D/G is never filed by
+the issuer on itself, so this predicate cannot retire a legitimate row.
+
+Run from repo root (dry-run first):
+
+    uv run python -m scripts.backfill_1638_retire_issuer_cik_blockholders
+    uv run python -m scripts.backfill_1638_retire_issuer_cik_blockholders --apply
+
+After ``--apply``, trigger the re-drain so the corrected parser
+repopulates the observations under the bumped parser_version:
+
+    POST /jobs/sec_rebuild/run  {"params": {"source": "sec_13d"}}
+    POST /jobs/sec_rebuild/run  {"params": {"source": "sec_13g"}}
+
+Idempotent: re-running after a clean re-drain retires 0 rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.services.ownership_observations import refresh_blockholders_current
+
+logger = logging.getLogger("backfill_1638")
+
+# An active 13D/G observation whose reporter_cik == the instrument's own
+# issuer (sec, cik). lpad both sides so a stored unpadded CIK still matches.
+_STALE_PREDICATE = """
+    o.known_to IS NULL
+    AND o.source IN ('13d', '13g')
+    AND ei.provider = 'sec'
+    AND ei.identifier_type = 'cik'
+    AND lpad(ei.identifier_value, 10, '0') = lpad(o.reporter_cik, 10, '0')
+"""
+
+
+def _count_stale(conn: psycopg.Connection[tuple]) -> tuple[int, int]:
+    row = conn.execute(
+        f"""
+        SELECT count(*) AS rows, count(DISTINCT o.instrument_id) AS instruments
+        FROM ownership_blockholders_observations o
+        JOIN external_identifiers ei ON ei.instrument_id = o.instrument_id
+        WHERE {_STALE_PREDICATE}
+        """
+    ).fetchone()
+    assert row is not None
+    return int(row[0]), int(row[1])
+
+
+def _retire(conn: psycopg.Connection[tuple]) -> list[int]:
+    """Soft-delete the stale rows (set known_to) and bump ingested_at so
+    the refresh / repair-sweep watermark (MAX(ingested_at)) advances past
+    the expiry. Returns the distinct affected instrument_ids."""
+    rows = conn.execute(
+        f"""
+        UPDATE ownership_blockholders_observations o
+        SET known_to = clock_timestamp(),
+            ingested_at = clock_timestamp()
+        FROM external_identifiers ei
+        WHERE ei.instrument_id = o.instrument_id
+          AND {_STALE_PREDICATE}
+        RETURNING o.instrument_id
+        """
+    ).fetchall()
+    return sorted({int(r[0]) for r in rows})
+
+
+def _stale_current_instruments(conn: psycopg.Connection[tuple]) -> list[int]:
+    """Instruments whose ``ownership_blockholders_current`` still holds an
+    issuer-CIK blockholder row. On a clean run this equals the retired set;
+    after a partial run (observations retired but a refresh failed) it
+    surfaces the un-refreshed remainder so a rerun still drops them even
+    though there are no observations left to retire — makes the script
+    idempotent under partial failure (Codex ckpt-2)."""
+    rows = conn.execute(
+        """
+        SELECT DISTINCT bc.instrument_id
+        FROM ownership_blockholders_current bc
+        JOIN external_identifiers ei ON ei.instrument_id = bc.instrument_id
+        WHERE ei.provider = 'sec'
+          AND ei.identifier_type = 'cik'
+          AND bc.source IN ('13d', '13g')
+          AND lpad(ei.identifier_value, 10, '0') = lpad(bc.reporter_cik, 10, '0')
+        """
+    ).fetchall()
+    return sorted({int(r[0]) for r in rows})
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Retire the stale rows + refresh _current. Without it, dry-run counts only.",
+    )
+    args = parser.parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        n_rows, n_instruments = _count_stale(conn)
+        stale_current = _stale_current_instruments(conn)
+        logger.info(
+            "backfill_1638: %d stale issuer-CIK observations across %d instruments; "
+            "%d instruments still hold a stale _current row",
+            n_rows,
+            n_instruments,
+            len(stale_current),
+        )
+        if not args.apply:
+            logger.info("backfill_1638: DRY-RUN — pass --apply to retire + refresh")
+            return 0
+        if n_rows == 0 and not stale_current:
+            logger.info("backfill_1638: nothing to retire or refresh")
+            return 0
+
+        # Retire the stale observations, then refresh the UNION of the
+        # instruments whose observations we just retired AND any instrument
+        # still carrying a stale _current row (heals a prior partial run).
+        retired = _retire(conn) if n_rows else []
+        conn.commit()
+        affected = sorted(set(retired) | set(stale_current))
+        logger.info("backfill_1638: retired %d rows; refreshing _current for %d instruments", n_rows, len(affected))
+        for instrument_id in affected:
+            refresh_blockholders_current(conn, instrument_id=instrument_id)
+        logger.info(
+            "backfill_1638: DONE — %d rows retired, %d instruments refreshed. "
+            "Now trigger sec_rebuild {source: sec_13d} + {source: sec_13g} to repopulate.",
+            n_rows,
+            len(affected),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_blockholder_reporter_identity.py
+++ b/tests/test_blockholder_reporter_identity.py
@@ -1,0 +1,119 @@
+"""Pure-logic tests for the 13D/G blockholder reporter-identity resolver
+(#1638). No DB. The resolver picks the one observation-row identity for a
+13D/G accession: reporter_cik = chosen (max-aggregate) reporter's own CIK,
+else the document filer-of-record CIK; reporter_name = chosen reporter.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.providers.implementations.sec_13dg import BlockholderReportingPerson
+from app.services.blockholders import (
+    BlockholderReporterIdentity,
+    resolve_blockholder_reporter_identity,
+)
+
+
+def _person(
+    name: str,
+    cik: str | None,
+    aggregate: str | None,
+    percent: str | None = None,
+) -> BlockholderReportingPerson:
+    return BlockholderReportingPerson(
+        cik=cik,
+        no_cik=cik is None,
+        name=name,
+        member_of_group=None,
+        type_of_reporting_person=None,
+        citizenship=None,
+        sole_voting_power=None,
+        shared_voting_power=None,
+        sole_dispositive_power=None,
+        shared_dispositive_power=None,
+        aggregate_amount_owned=Decimal(aggregate) if aggregate is not None else None,
+        percent_of_class=Decimal(percent) if percent is not None else None,
+    )
+
+
+def test_13d_uses_chosen_per_reporter_cik() -> None:
+    # GME 0000921895-25-000190: Cohen (largest aggregate) carries his own
+    # CIK; RC Ventures is the filer of record but reports 0.
+    persons = [
+        _person("Cohen Ryan", "0001767470", "36847842", "8.2"),
+        _person("RC Ventures LLC", "0001822844", "0"),
+    ]
+    out = resolve_blockholder_reporter_identity(persons, document_filer_cik="0001822844")
+    assert out == BlockholderReporterIdentity(
+        reporter_cik="0001767470",
+        reporter_name="Cohen Ryan",
+        aggregate_amount_owned=Decimal("36847842"),
+        percent_of_class=Decimal("8.2"),
+    )
+
+
+def test_13g_null_reporter_cik_falls_back_to_document_filer() -> None:
+    # Modern 13G omits per-reporter CIK; the filer of record IS the
+    # beneficial owner (e.g. Vanguard).
+    persons = [_person("The Vanguard Group", None, "100", "9.3")]
+    out = resolve_blockholder_reporter_identity(persons, document_filer_cik="0000102909")
+    assert out is not None
+    assert out.reporter_cik == "0000102909"
+    assert out.reporter_name == "The Vanguard Group"
+    assert out.aggregate_amount_owned == Decimal("100")
+
+
+def test_multiparty_13d_null_chosen_cik_uses_filer_of_record() -> None:
+    # Group 13D where the largest-aggregate reporter is a natural person
+    # with no CIK; a smaller member carries the filer-of-record CIK.
+    persons = [
+        _person("Mark Getty", None, "500"),
+        _person("Getty Investments L.L.C.", "0001056213", "100"),
+    ]
+    out = resolve_blockholder_reporter_identity(persons, document_filer_cik="0001056213")
+    assert out is not None
+    assert out.reporter_cik == "0001056213"  # filer of record (joinable)
+    assert out.reporter_name == "Mark Getty"  # largest disclosed position
+    assert out.aggregate_amount_owned == Decimal("500")
+
+
+def test_chosen_cik_present_ignores_document_filer() -> None:
+    persons = [_person("Acme Fund", "0001234567", "100")]
+    out = resolve_blockholder_reporter_identity(persons, document_filer_cik="0009999999")
+    assert out is not None
+    assert out.reporter_cik == "0001234567"
+
+
+def test_tie_aggregate_picks_first_in_list() -> None:
+    persons = [
+        _person("First Filer", "0000000001", "100"),
+        _person("Second Filer", "0000000002", "100"),
+    ]
+    out = resolve_blockholder_reporter_identity(persons, document_filer_cik=None)
+    assert out is not None
+    assert out.reporter_cik == "0000000001"
+    assert out.reporter_name == "First Filer"
+
+
+def test_empty_string_cik_treated_as_null() -> None:
+    persons = [_person("Edge Filer", "", "100")]
+    out = resolve_blockholder_reporter_identity(persons, document_filer_cik="0000102909")
+    assert out is not None
+    assert out.reporter_cik == "0000102909"
+
+
+def test_no_persons_returns_none() -> None:
+    assert resolve_blockholder_reporter_identity([], document_filer_cik="0000102909") is None
+
+
+def test_chosen_aggregate_none_returns_none() -> None:
+    # Defer-to-prior-cover amendment: no aggregate → skip (mirrors the
+    # write-side aggregate_amount_owned IS NOT NULL guard).
+    persons = [_person("No Aggregate", "0001767470", None)]
+    assert resolve_blockholder_reporter_identity(persons, document_filer_cik="0001767470") is None
+
+
+def test_both_ciks_null_returns_none() -> None:
+    persons = [_person("Unjoinable", None, "100")]
+    assert resolve_blockholder_reporter_identity(persons, document_filer_cik=None) is None

--- a/tests/test_manifest_parser_sec_13dg.py
+++ b/tests/test_manifest_parser_sec_13dg.py
@@ -22,6 +22,7 @@ without touching SEC.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import psycopg
 import pytest
@@ -130,6 +131,75 @@ _FAKE_13G_XML = f"""<?xml version="1.0" encoding="UTF-8"?>
       <signaturePerson>
         <signatureDetails>
           <date>10/15/2025</date>
+        </signatureDetails>
+      </signaturePerson>
+    </signatureInfo>
+  </formData>
+</edgarSubmission>
+"""
+
+
+# GME-shape 13D — the #1638 regression case. The manifest CIK is the
+# ISSUER (post-#1628 issuer-keyed discovery), the filer of record
+# (filerCredentials) is RC Ventures, and the largest-aggregate reporting
+# person (Cohen) carries his OWN distinct CIK. The observation reporter_cik
+# MUST be Cohen's CIK, never the issuer/manifest CIK.
+_GME_SHAPE_13D_XML = f"""<?xml version="1.0" encoding="UTF-8"?>
+<edgarSubmission xmlns="{_NS_13D}">
+  <headerData>
+    <submissionType>SCHEDULE 13D</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <cik>0001822844</cik>
+        </filerCredentials>
+      </filer>
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPageHeader>
+      <securitiesClassTitle>Class A Common Stock</securitiesClassTitle>
+      <dateOfEvent>01/29/2025</dateOfEvent>
+      <issuerInfo>
+        <issuerCIK>0001326380</issuerCIK>
+        <issuerCUSIP>36467W109</issuerCUSIP>
+        <issuerName>GameStop Corp.</issuerName>
+      </issuerInfo>
+    </coverPageHeader>
+    <reportingPersons>
+      <reportingPersonInfo>
+        <reportingPersonCIK>0001767470</reportingPersonCIK>
+        <reportingPersonNoCIK>N</reportingPersonNoCIK>
+        <reportingPersonName>Cohen Ryan</reportingPersonName>
+        <memberOfGroup>b</memberOfGroup>
+        <citizenshipOrOrganization>NY</citizenshipOrOrganization>
+        <soleVotingPower>36847842</soleVotingPower>
+        <sharedVotingPower>0</sharedVotingPower>
+        <soleDispositivePower>36847842</soleDispositivePower>
+        <sharedDispositivePower>0</sharedDispositivePower>
+        <aggregateAmountOwned>36847842</aggregateAmountOwned>
+        <percentOfClass>8.2</percentOfClass>
+        <typeOfReportingPerson>IN</typeOfReportingPerson>
+      </reportingPersonInfo>
+      <reportingPersonInfo>
+        <reportingPersonCIK>0001822844</reportingPersonCIK>
+        <reportingPersonNoCIK>N</reportingPersonNoCIK>
+        <reportingPersonName>RC Ventures LLC</reportingPersonName>
+        <memberOfGroup>b</memberOfGroup>
+        <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+        <soleVotingPower>0</soleVotingPower>
+        <sharedVotingPower>0</sharedVotingPower>
+        <soleDispositivePower>0</soleDispositivePower>
+        <sharedDispositivePower>0</sharedDispositivePower>
+        <aggregateAmountOwned>0</aggregateAmountOwned>
+        <percentOfClass>0</percentOfClass>
+        <typeOfReportingPerson>OO</typeOfReportingPerson>
+      </reportingPersonInfo>
+    </reportingPersons>
+    <signatureInfo>
+      <signaturePerson>
+        <signatureDetails>
+          <date>01/30/2025</date>
         </signatureDetails>
       </signaturePerson>
     </signatureInfo>
@@ -290,6 +360,98 @@ def test_13g_happy_path(
         cur.execute("SELECT submission_type FROM blockholder_filings WHERE accession_number = '0000950103-25-014355'")
         bf = cur.fetchone()
     assert bf is not None and bf[0] == "SCHEDULE 13G"
+
+
+def test_13d_observation_reporter_cik_is_reporting_person_not_issuer(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1638: with the manifest CIK = the issuer (post-#1628), the
+    observation reporter_cik MUST be the largest-aggregate reporting
+    person's own CIK (Cohen 0001767470), NEVER the issuer/manifest CIK."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    _seed_instrument_with_cusip(ebull_test_conn, iid=8750009, symbol="GME", cusip="36467W109")
+    ebull_test_conn.execute(
+        "INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary) "
+        "VALUES (8750009, 'sec', 'cik', '0001326380', TRUE) ON CONFLICT DO NOTHING"
+    )
+    _seed_pending_13dg(
+        ebull_test_conn,
+        accession="0000921895-25-000190",
+        filer_cik="0001326380",  # issuer-keyed manifest (post-#1628)
+        source="sec_13d",
+        form="SC 13D",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _GME_SHAPE_13D_XML,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13d", max_rows=10)
+    ebull_test_conn.commit()
+    assert stats.parsed == 1
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT reporter_cik, reporter_name, aggregate_amount_owned "
+            "FROM ownership_blockholders_current WHERE instrument_id = 8750009"
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    reporter_cik, reporter_name, agg = rows[0]
+    assert reporter_cik == "0001767470"  # Cohen's own CIK
+    assert reporter_cik != "0001326380"  # NOT the issuer / manifest CIK
+    assert reporter_name == "Cohen Ryan"
+    assert agg == Decimal("36847842")
+
+
+def test_13g_observation_reporter_cik_falls_back_to_document_filer(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1638: a modern 13G cover omits per-reporter CIK, so the
+    observation reporter_cik falls back to the document filer of record
+    (<filerCredentials> 0002083532), NEVER the issuer/manifest CIK."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    _seed_instrument_with_cusip(ebull_test_conn, iid=8750010, symbol="AURA", cusip="G06973112")
+    ebull_test_conn.execute(
+        "INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary) "
+        "VALUES (8750010, 'sec', 'cik', '0001468642', TRUE) ON CONFLICT DO NOTHING"
+    )
+    _seed_pending_13dg(
+        ebull_test_conn,
+        accession="0000950103-25-014999",
+        filer_cik="0001468642",  # issuer-keyed manifest (post-#1628)
+        source="sec_13g",
+        form="SC 13G",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _FAKE_13G_XML,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13g", max_rows=10)
+    ebull_test_conn.commit()
+    assert stats.parsed == 1
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT reporter_cik FROM ownership_blockholders_current WHERE instrument_id = 8750010")
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "0002083532"  # document filer of record
+    assert rows[0][0] != "0001468642"  # NOT the issuer / manifest CIK
 
 
 def test_cusip_unresolved_returns_parsed_with_partial_log(

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -1126,6 +1126,7 @@ def test_blockholders_apply_re_resolves_instrument_from_fresh_cusip(
         submission_type="SCHEDULE 13G",
         status="passive",
         primary_filer_cik="0000111000",
+        document_filer_cik="0000111000",
         issuer_cik="0000999000",
         issuer_cusip="NEWCUSP1",  # parser fix
         issuer_name="New Issuer",
@@ -1243,6 +1244,7 @@ def test_blockholders_apply_raises_on_empty_reporting_persons(
         submission_type="SCHEDULE 13G",
         status="passive",
         primary_filer_cik="0000111000",
+        document_filer_cik="0000111000",
         issuer_cik="0000999000",
         issuer_cusip="CSP12345",
         issuer_name="Issuer",

--- a/tests/test_schedule13_adapter.py
+++ b/tests/test_schedule13_adapter.py
@@ -98,6 +98,39 @@ def test_adapter_returns_blockholder_filing_for_13d_dict() -> None:
     assert filing.filed_at is None
 
 
+# Minimal primary_doc.xml carrying only <filerCredentials><cik> — the
+# document filer of record the adapter reads for document_filer_cik (#1638).
+_RAW_WITH_FILER_CREDENTIALS = (
+    '<?xml version="1.0"?><edgarSubmission xmlns="http://www.sec.gov/edgar/schedule13D">'
+    "<headerData><filerInfo><filer><filerCredentials><cik>0009999999</cik>"
+    "</filerCredentials></filer></filerInfo></headerData></edgarSubmission>"
+)
+
+
+def test_adapter_extracts_document_filer_cik_from_raw_xml() -> None:
+    filing = build_filing_from_edgartools_dict(
+        _parsed_13d(),
+        source="sec_13d",
+        manifest_form="SC 13D",
+        manifest_filer_cik="2093607",
+        raw_xml=_RAW_WITH_FILER_CREDENTIALS,
+    )
+    # document_filer_cik comes from the raw doc's <filerCredentials>, NOT
+    # the manifest CIK (which is the subject/issuer post-#1628).
+    assert filing.document_filer_cik == "0009999999"
+    assert filing.primary_filer_cik == "0002093607"  # still the manifest arg
+
+
+def test_adapter_document_filer_cik_none_when_no_raw_xml() -> None:
+    filing = build_filing_from_edgartools_dict(
+        _parsed_13d(),
+        source="sec_13d",
+        manifest_form="SC 13D",
+        manifest_filer_cik="2093607",
+    )
+    assert filing.document_filer_cik is None
+
+
 def test_adapter_maps_reporting_persons_with_decimal_typing() -> None:
     """Per-reporter mapping preserves Decimal typing on share-power +
     aggregate + percent fields (matches NUMERIC schema)."""

--- a/tests/test_sec_13dg_parser.py
+++ b/tests/test_sec_13dg_parser.py
@@ -30,6 +30,7 @@ import pytest
 
 from app.providers.implementations.sec_13dg import (
     BlockholderFiling,
+    extract_filer_cik_from_primary_doc,
     parse_primary_doc,
 )
 
@@ -199,6 +200,21 @@ def _13g_xml(
 # ---------------------------------------------------------------------------
 # 13D parsing
 # ---------------------------------------------------------------------------
+
+
+def test_extract_filer_cik_from_primary_doc_reads_filer_credentials() -> None:
+    assert extract_filer_cik_from_primary_doc(_13d_xml(primary_filer_cik="2093607")) == "0002093607"
+
+
+def test_extract_filer_cik_returns_none_for_malformed_or_missing() -> None:
+    assert extract_filer_cik_from_primary_doc("<not-xml") is None
+    assert extract_filer_cik_from_primary_doc("<edgarSubmission></edgarSubmission>") is None
+
+
+def test_parse_13d_sets_document_filer_cik_from_filer_credentials() -> None:
+    parsed = parse_primary_doc(_13d_xml())
+    assert parsed.document_filer_cik == "0002093607"
+    assert parsed.document_filer_cik == parsed.primary_filer_cik
 
 
 def test_parse_13d_returns_active_status_and_zero_padded_ciks() -> None:


### PR DESCRIPTION
## What

`ownership_blockholders_current.reporter_cik` carried the **subject company's own
issuer CIK** for 733/800 dev rows (≈93%), with the correct reporting-person name.
GME: `reporter_name='Cohen Ryan'`, `reporter_cik='0001326380'` — but `0001326380`
is GameStop's issuer CIK; Ryan Cohen's is `0001767470`.

Part of #788 (ownership card trustworthy). Spec:
`docs/specs/etl/2026-06-15-blockholder-reporter-cik.md`.

## Root cause (cross-layer)

#1628 flipped the 13D/G manifest from *filer*-keyed to *issuer*-keyed so
subject→instrument resolution works via issuer-CUSIP. But the observation writer
still used `BlockholderFiling.primary_filer_cik`, which the edgartools adapter
feeds from the manifest CIK — now the **issuer** on the drain path. A correct
change in #1628 silently invalidated a load-bearing assumption in the observation
writer two layers away.

## Fix — resolve reporter identity from the document

A pure resolver `resolve_blockholder_reporter_identity(reporting_persons, *,
document_filer_cik)` picks the largest-aggregate reporting person (one observation
per accession — preserves the #837 joint-filer collapse) and sets
`reporter_cik = chosen.cik or document_filer_cik`:

- the disclosing person's own per-reporter `<reportingPersonCIK>` (modern 13D —
  e.g. Cohen `0001767470`);
- else the document `<filerCredentials><cik>` filer of record (modern **13G** omits
  per-reporter CIK 443/443 dev rows; the filer IS the beneficial owner — Vanguard
  `0000102909`, etc.). Never the manifest/subject CIK.

Both write paths corrected:

- **Write-through drain** (`_record_13dg_observation_for_filing`) → resolver.
- **Legacy mirror** (`sync_blockholders`, run only by the manual one-shot
  `ownership_observations_backfill`; the daily job is the repair sweep) → reads the
  per-row `blockholder_filings.reporter_cik` (`DISTINCT ON (accession)` max
  aggregate) and **skips** rows whose `reporter_cik` is NULL (13G — write-through is
  the canonical populator) rather than writing `blockholder_filers.cik` (= issuer
  post-#1628). Closes a manual reintroduction vector.

New in-memory field `BlockholderFiling.document_filer_cik` +
`extract_filer_cik_from_primary_doc()` — **no schema migration**; `primary_filer_cik`
(the `blockholder_filers` PK) is untouched. `_PARSER_VERSION_13DG` `v2 → v3` forces
the re-drain.

### Group-filing caveat (27/800 dev rows)

A multi-party 13D whose largest-aggregate reporter is a natural person with no CIK
keys to the filer-of-record CIK with the largest reporter's name — inherent to the
one-row-per-accession collapse; the filer-of-record is the group's stable, joinable
identity, never the issuer, never a filing agent for 13D/G (sec-edgar §3.7). Strictly
better than the issuer-CIK bug or dropping the filing.

## Out of scope — Bug A (deferred follow-up, operator-scoped)

Correct `reporter_cik` is the **prerequisite** for, but does NOT by itself fix, the
GME concentration double-count: the rollup *deliberately* keeps 13D/G (beneficial)
and Form 4 (direct) in separate pie-wedge slices and `_compute_concentration` sums
them (`ownership_rollup.py:1386`, #837/#788-P0b), so Cohen's 38.3M insider + 36.8M
blockholder both count regardless of CIK. The cross-slice dedup-by-CIK that drops
GME to ≈40% is a separate PR (rollup-math, distinct review lens). GME concentration
stays 48.37% until then — by design for this PR. Tracked in **#1640**.

`primary_filer_cik` / `blockholder_filers.cik` being the issuer on the drain path is
a non-operator-visible latent follow-up (the rollup reads `_current` ← observations,
which this PR corrects).

## Tests

- **Pure** `tests/test_blockholder_reporter_identity.py` (9 cases, no DB): 13D
  chosen-with-CIK → Cohen; 13G null-cik → document filer; multi-party 13D
  null-chosen-cik → filer of record; tie → list order; empty / no-aggregate /
  both-null → None.
- **Adapter** `document_filer_cik` from `raw_xml`; None when absent.
- **(db) end-to-end regression** in `test_manifest_parser_sec_13dg.py`: GME-shape 13D
  (manifest CIK = issuer) → observation `reporter_cik = 0001767470` (Cohen), `≠
  0001326380` (issuer); 13G → falls back to `<filerCredentials>`, `≠` issuer.

## Codex review

- **ckpt-1 (spec) ×2:** caught that Bug A is NOT downstream of Bug B (rollup splits
  13D/G out of dedup) and that the legacy `sync_blockholders` mirror is a second write
  path — both folded into the design before coding. Re-review of the revised spec: no
  findings.
- **ckpt-2 (diff):** 2 findings, both FIXED — (1) mirror `DISTINCT ON (accession)`
  lacked a tie-breaker matching the write-through `max()` first-maximal pick → added
  `bf.filing_id ASC` (insert/XML order); (2) backfill was not failure-idempotent →
  now refreshes the union of retired-observation instruments + instruments still
  holding a stale `_current` row, so a rerun heals a partial failure.

## DoD (ETL clauses)

- **Local gates:** `ruff check` ✓, `ruff format --check` ✓, `pyright` 0 errors,
  `pytest -m "not db"` 4139 passed, `pytest tests/smoke` 129 passed, touched `-m db`
  tier 133 passed (re-run 27 after ckpt-2 fixes).
- **Pre-merge dev-verify (8/9) on REAL dev data:** GME stored 13D XML (acc
  `0000921895-25-000190`) parsed through the production adapter+resolver yields
  `reporter_cik=0001767470` = Cohen's Form 4 `holder_cik` (cross-source: matches
  `ownership_insiders_current`). **Full-population check:** of 905 current blockholder
  rows, **812 carry the issuer CIK today → the new resolver produces the issuer CIK
  for 0 rows**, 0 skips; 13G rows resolve to the real filer of record (North Star
  `0001342857`, Victory Capital `0001040188`, …), never the issuer.
- **Backfill (10):** `scripts/backfill_1638_retire_issuer_cik_blockholders.py`
  dry-run on dev ≈ 1200 stale issuer-CIK observations across ≈816 instruments (grows
  as the live drain adds rows). **Operator follow-up (I own the dev jobs proc):**
  restart jobs onto merged main → `--apply` retire+refresh → `sec_rebuild
  {source:sec_13d}` + `{sec_13g}` re-drain → verify GME `/ownership-rollup` blockholder
  Cohen row shows `0001767470`. Recorded on merge.


Closes #1638
