### PR TITLE
feat(#1647): ownership machine-trust envelope — as-of coherence + sanity invariants + is_estimate

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -35,7 +35,7 @@ import psycopg
 import psycopg.rows
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import PlainTextResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.api._helpers import resolve_quote_price
 from app.api.auth import require_session_or_service_token
@@ -4229,6 +4229,13 @@ class _SliceModel(BaseModel):
     # Frontend filters on this to decide whether to render in the pie
     # vs as a memo panel below the pie.
     denominator_basis: Literal["pie_wedge", "institution_subset"] = "pie_wedge"
+    # As-of coherence envelope (#1647 part 1). The as-of span of this slice's
+    # deduped holders (incl. collapsed-family members) so a machine consumer
+    # sees the figure sums across quarters. NULL-as_of-only slice → None/0/False.
+    as_of_min: date | None = None
+    as_of_max: date | None = None
+    distinct_quarters: int = 0
+    mixed_period: bool = False
 
 
 class _ResidualModel(BaseModel):
@@ -4244,6 +4251,11 @@ class _CategoryCoverageModel(BaseModel):
     estimated_universe: int | None
     pct_universe: Decimal | None
     state: Literal["no_data", "red", "unknown_universe", "amber", "green"]
+    # Honest machine completeness flag (#1647 part 2). True ⇔ no real
+    # filer-universe estimate for this category (figure is a floor). Real
+    # coverage_ratio gate DEFERRED #790. Default True (back-compat with
+    # pre-envelope payloads, which were all unknown-universe).
+    is_estimate: bool = True
 
 
 class _CoverageModel(BaseModel):
@@ -4288,6 +4300,19 @@ class _DualClassDenominatorModel(BaseModel):
     note: str
 
 
+class _SanityChecksModel(BaseModel):
+    """Raw plausibility facts over the pie-wedge slices (#1647 part 4). NOT
+    pass/fail — measurements a decision agent can reason over to catch the next
+    silent inflation (the existing ``residual.oversubscribed`` guard cannot).
+    Memo-overlay slices excluded. ``shares_outstanding <= 0`` → zeroed."""
+
+    max_distinct_quarters: int = 0
+    institutions_pct: Decimal = Decimal(0)
+    institutions_over_100pct: bool = False
+    largest_single_holder_pct: Decimal = Decimal(0)
+    any_pie_slice_over_100pct: bool = False
+
+
 class OwnershipRollupResponse(BaseModel):
     """Cross-channel deduped ownership snapshot (#789).
 
@@ -4328,6 +4353,10 @@ class OwnershipRollupResponse(BaseModel):
     # and the no_data path. When set, the FE renders the caveat callout and every
     # percentage should be read as a combined-basis lower bound.
     dual_class_denominator: _DualClassDenominatorModel | None
+    # Sanity-invariant facts over the pie-wedge slices (#1647 part 4). Always
+    # present; zeroed on the no_data path. Default so older callers/tests need
+    # no change.
+    sanity: _SanityChecksModel = Field(default_factory=_SanityChecksModel)
     computed_at: datetime
 
 
@@ -4356,6 +4385,10 @@ def _rollup_to_response(
                 filer_count=s.filer_count,
                 dominant_source=s.dominant_source,
                 denominator_basis=s.denominator_basis,
+                as_of_min=s.as_of_min,
+                as_of_max=s.as_of_max,
+                distinct_quarters=s.distinct_quarters,
+                mixed_period=s.mixed_period,
                 holders=[
                     _HolderModel(
                         filer_cik=h.filer_cik,
@@ -4414,6 +4447,7 @@ def _rollup_to_response(
                     estimated_universe=c.estimated_universe,
                     pct_universe=c.pct_universe,
                     state=c.state,
+                    is_estimate=c.is_estimate,
                 )
                 for k, c in rollup.coverage.categories.items()
             },
@@ -4459,6 +4493,13 @@ def _rollup_to_response(
             )
             if rollup.dual_class_denominator is not None
             else None
+        ),
+        sanity=_SanityChecksModel(
+            max_distinct_quarters=rollup.sanity.max_distinct_quarters,
+            institutions_pct=rollup.sanity.institutions_pct,
+            institutions_over_100pct=rollup.sanity.institutions_over_100pct,
+            largest_single_holder_pct=rollup.sanity.largest_single_holder_pct,
+            any_pie_slice_over_100pct=rollup.sanity.any_pie_slice_over_100pct,
         ),
         computed_at=rollup.computed_at,
     )

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any, Final, Literal
@@ -209,6 +209,19 @@ class OwnershipSlice:
     dominant_source: SourceTag | None
     holders: tuple[Holder, ...]
     denominator_basis: DenominatorBasis = "pie_wedge"
+    # As-of coherence envelope (#1647 part 1). The as-of span of this slice's
+    # deduped holders, so a machine consumer can see the figure sums across
+    # quarters (98.2% of dev instruments mix ≥2 13F quarters in the
+    # institutions slice). Computed in :func:`_build_slice` from each holder's
+    # ``as_of_date`` PLUS its ``family_members`` as-of dates — a collapsed
+    # family is one Holder whose own ``as_of_date`` is ``min(member dates)``,
+    # so looking only at the holder would hide an intra-family quarter spread
+    # (Codex ckpt-1). NULL-as_of holders are ignored; an all-NULL slice keeps
+    # the defaults (None / 0 / False).
+    as_of_min: date | None = None
+    as_of_max: date | None = None
+    distinct_quarters: int = 0
+    mixed_period: bool = False
 
 
 @dataclass(frozen=True)
@@ -231,6 +244,14 @@ class CategoryCoverage:
     estimated_universe: int | None
     pct_universe: Decimal | None
     state: CoverageState
+    # Honest machine completeness flag (#1647 part 2, shippable half).
+    # ``True`` ⇔ no real filer-universe estimate exists for this category
+    # (``estimated_universe is None``) → the figure is a floor, not a measured
+    # share of a known universe. A real seeded ``estimate == 0`` (vacuously-
+    # green, "we know the SEC universe here is empty") is NOT an estimate.
+    # The real ``coverage_ratio`` gate is blocked on the per-instrument 13F
+    # universe-count ingest → DEFERRED #790. Derived in :func:`_compute_coverage`.
+    is_estimate: bool = True
 
 
 @dataclass(frozen=True)
@@ -248,6 +269,46 @@ class ConcentrationInfo:
 
     pct_outstanding_known: Decimal
     info_chip: str
+
+
+@dataclass(frozen=True)
+class SanityChecks:
+    """Raw plausibility facts over the pie-wedge slices (#1647 part 4).
+
+    NOT pass/fail thresholds — measurable facts a decision agent or operator
+    can reason over to catch the NEXT silent inflation bug. The only guard
+    today (``residual.oversubscribed``) cannot express sub-residual
+    granularity, so it never trips on a sub-100% inflation like #1639 (AAPL
+    44.4%). Memo-overlay slices (``denominator_basis != "pie_wedge"``) are
+    excluded everywhere — they are already-counted detail.
+
+      * ``max_distinct_quarters`` — worst per-slice as-of spread; >1 means at
+        least one slice sums filings from different quarters.
+      * ``institutions_pct`` — Σ pie-wedge institutions+etfs / outstanding.
+      * ``institutions_over_100pct`` — institutions own >100% (impossible).
+      * ``largest_single_holder_pct`` — biggest single deduped pie-wedge
+        holder / outstanding (a collapsed family is one holder, so this is
+        the committee's "single-family plausibility").
+      * ``any_pie_slice_over_100pct`` — any single slice exceeds 100%.
+
+    ``outstanding <= 0`` → all pct ``Decimal(0)``, both booleans ``False``."""
+
+    max_distinct_quarters: int
+    institutions_pct: Decimal
+    institutions_over_100pct: bool
+    largest_single_holder_pct: Decimal
+    any_pie_slice_over_100pct: bool
+
+    @classmethod
+    def empty(cls) -> SanityChecks:
+        """Zeroed checks for the ``no_data`` path (no slices to measure)."""
+        return cls(
+            max_distinct_quarters=0,
+            institutions_pct=Decimal(0),
+            institutions_over_100pct=False,
+            largest_single_holder_pct=Decimal(0),
+            any_pie_slice_over_100pct=False,
+        )
 
 
 @dataclass(frozen=True)
@@ -331,6 +392,11 @@ class OwnershipRollup:
     # combined-basis lower bound. None for single-class issuers and the no_data
     # path. Last field with a default so existing constructors need no change.
     dual_class_denominator: DualClassDenominator | None = None
+    # Sanity-invariant facts over the pie-wedge slices (#1647 part 4). Raw
+    # plausibility measurements (not pass/fail) so a machine consumer can
+    # catch the next silent inflation. Zeroed on the no_data path. Last field
+    # with a default so existing constructors need no change.
+    sanity: SanityChecks = field(default_factory=SanityChecks.empty)
 
     @classmethod
     def no_data(
@@ -1623,6 +1689,40 @@ def _bucket_into_slices(
     return slices
 
 
+def _calendar_quarter(d: date) -> tuple[int, int]:
+    """``(year, quarter)`` with quarter in ``1..4`` (human convention).
+
+    13F quarter-ends (03-31/06-30/09-30/12-31) map cleanly to Q1..Q4."""
+    return (d.year, (d.month - 1) // 3 + 1)
+
+
+def _slice_coherence(holders: Sequence[Holder]) -> tuple[date | None, date | None, int, bool]:
+    """As-of span of a slice's holders (#1647 part 1).
+
+    Gathers, per holder, ``holder.as_of_date`` PLUS every
+    ``family_member.as_of_date`` — a collapsed family is one synthetic Holder
+    whose own ``as_of_date`` is ``min(member dates)``, so looking only at the
+    holder would hide an intra-family quarter spread (Codex ckpt-1). Dropped
+    sources are NOT gathered — a dedup loser is not part of the counted
+    figure's span.
+
+    NULL as-of dates are ignored. Returns
+    ``(as_of_min, as_of_max, distinct_quarters, mixed_period)``; an all-NULL
+    (or empty) slice → ``(None, None, 0, False)``."""
+    dates: list[date] = []
+    for h in holders:
+        if h.as_of_date is not None:
+            dates.append(h.as_of_date)
+        for m in h.family_members:
+            if m.as_of_date is not None:
+                dates.append(m.as_of_date)
+    if not dates:
+        return (None, None, 0, False)
+    quarters = {_calendar_quarter(d) for d in dates}
+    distinct = len(quarters)
+    return (min(dates), max(dates), distinct, distinct > 1)
+
+
 def _build_slice(
     category: SliceCategory,
     holders: list[Holder],
@@ -1659,6 +1759,7 @@ def _build_slice(
     # the underlying filers), not as one row, so coverage % is not deflated by the
     # collapse (#1644/#1649). Ordinary holders (no members) count as 1.
     filer_count = sum(len(h.family_members) or 1 for h in holders)
+    as_of_min, as_of_max, distinct_quarters, mixed_period = _slice_coherence(enriched_holders)
     return OwnershipSlice(
         category=category,
         label=_SLICE_LABELS[category],
@@ -1668,6 +1769,10 @@ def _build_slice(
         dominant_source=dominant,
         holders=enriched_holders,
         denominator_basis=denominator_basis,
+        as_of_min=as_of_min,
+        as_of_max=as_of_max,
+        distinct_quarters=distinct_quarters,
+        mixed_period=mixed_period,
     )
 
 
@@ -1729,6 +1834,49 @@ _CATEGORY_ORDER: tuple[SliceCategory, ...] = (
 )
 
 
+_INSTITUTIONAL_CATEGORIES: frozenset[SliceCategory] = frozenset({"institutions", "etfs"})
+
+
+def _compute_sanity(slices: Sequence[OwnershipSlice], outstanding: Decimal) -> SanityChecks:
+    """Raw plausibility facts over the pie-wedge slices (#1647 part 4).
+
+    Measurements, not pass/fail. Memo-overlay slices are excluded — they are
+    already-counted detail. ``outstanding <= 0`` → zeroed pct / False booleans.
+    See :class:`SanityChecks`."""
+    pie = [s for s in slices if s.denominator_basis == "pie_wedge"]
+    max_distinct_quarters = max((s.distinct_quarters for s in pie), default=0)
+    if outstanding <= 0:
+        return SanityChecks(
+            max_distinct_quarters=max_distinct_quarters,
+            institutions_pct=Decimal(0),
+            institutions_over_100pct=False,
+            largest_single_holder_pct=Decimal(0),
+            any_pie_slice_over_100pct=False,
+        )
+    inst_shares = sum(
+        (s.total_shares for s in pie if s.category in _INSTITUTIONAL_CATEGORIES),
+        Decimal(0),
+    )
+    institutions_pct = inst_shares / outstanding
+    largest_holder_shares = max(
+        (h.shares for s in pie for h in s.holders),
+        default=Decimal(0),
+    )
+    largest_single_holder_pct = largest_holder_shares / outstanding
+    # Recompute from this function's ``outstanding`` arg (not the slice's
+    # precomputed ``pct_outstanding``) so all four facts share one denominator
+    # and cannot disagree if a slice were ever built against a different one
+    # (Codex ckpt-2). ``outstanding > 0`` guaranteed by the early return above.
+    any_pie_slice_over_100pct = any(s.total_shares / outstanding > 1 for s in pie)
+    return SanityChecks(
+        max_distinct_quarters=max_distinct_quarters,
+        institutions_pct=institutions_pct,
+        institutions_over_100pct=institutions_pct > 1,
+        largest_single_holder_pct=largest_single_holder_pct,
+        any_pie_slice_over_100pct=any_pie_slice_over_100pct,
+    )
+
+
 def _compute_coverage(
     slices: Sequence[OwnershipSlice],
     estimates: dict[str, int | None],
@@ -1757,6 +1905,9 @@ def _compute_coverage(
             estimated_universe=estimate,
             pct_universe=pct_universe,
             state=per_state,
+            # Honest machine flag (#1647): no real universe estimate ⇒ the
+            # figure is a floor. A real seeded estimate==0 is NOT an estimate.
+            is_estimate=estimate is None,
         )
     fold_state = _worst_of(cats[c].state for c in _CATEGORY_ORDER)
     return CoverageReport(state=fold_state, categories=cats)
@@ -2272,6 +2423,7 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     )
     residual = _compute_residual(outstanding, slices, treasury)
     concentration = _compute_concentration(outstanding, slices)
+    sanity = _compute_sanity(slices, outstanding)
     estimates = _read_universe_estimates(conn, instrument_id)
     coverage = _compute_coverage(slices, estimates)
     banner = _banner_for_state(coverage.state, coverage, concentration.pct_outstanding_known)
@@ -2305,6 +2457,7 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
         dual_class_denominator=_detect_dual_class_denominator(
             conn, instrument_id, denominator_concept=outstanding_source.concept
         ),
+        sanity=sanity,
         computed_at=datetime.now(tz=UTC),
     )
 

--- a/docs/specs/etl/2026-06-16-ownership-machine-trust-envelope.md
+++ b/docs/specs/etl/2026-06-16-ownership-machine-trust-envelope.md
@@ -1,0 +1,141 @@
+# Ownership machine-trust envelope (#1647 PR-A)
+
+Epic #788 / machine-trust contract #1647. PURE READ-PATH. No schema, no
+migration, no parser, no backfill, no `sec_rebuild`, no jobs-proc restart.
+
+## Scope (operator decision 2026-06-16: "Envelope now, ratio→#790")
+
+Ships the fully-feasible half of the #1647 contract on
+`GET /instruments/{symbol}/ownership-rollup`:
+
+1. **Part 1 — per-slice as-of coherence.** Each slice exposes the as-of
+   span of its deduped holders so a consumer can see it is summing across
+   quarters (98.2% of dev instruments mix ≥2 13F quarters in the
+   institutions slice).
+2. **Part 4 — sanity invariants.** Top-level raw facts a consumer/agent
+   can reason over to catch the *next* silent inflation bug. No hard
+   pass/fail thresholds — facts only.
+3. **Part 2 (shippable half) — honest `is_estimate` machine flag.** Per
+   category. `true` when there is no real universe estimate (current Tier-0
+   state: every category NULL → `unknown_universe`). The real
+   `coverage_ratio` stays blocked on the per-instrument 13F universe-count
+   ingest → **DEFERRED #790**.
+
+Already shipped, NOT in scope: Part 3 structured `corrections_applied[]`
+(#1639 first producer). Part 5 cross-source validation = lower priority,
+deferred.
+
+## Guardrail (settled-decisions.md:702-720)
+
+The 5-state coverage banner is server-driven; adding a *state* needs a new
+spec+ticket. This PR adds only **additive contract fields** — no new banner
+state, no FE-only remap. `is_estimate` is derived from the existing
+`unknown_universe`/`no_data` states, not a new state.
+
+## Definitions
+
+`as_of_date` = financial statement period end (settled-decisions.md:104).
+For 13F holders this is the quarter-end (`periodOfReport`); for Form 4 the
+transaction date; for 13D/G the event date.
+
+Calendar quarter: `_calendar_quarter(d) = (d.year, (d.month - 1) // 3 + 1)`
+→ quarter `1..4` (human convention). 13F quarter-ends
+(03-31/06-30/09-30/12-31) map cleanly to Q1..Q4.
+
+## Contract additions
+
+### Per slice (`OwnershipSlice`, computed in `_build_slice` from holders)
+
+```
+as_of_min: date | None        # min non-null holder as_of_date
+as_of_max: date | None        # max non-null holder as_of_date
+distinct_quarters: int        # count distinct calendar quarters over non-null as_of
+mixed_period: bool            # distinct_quarters > 1
+```
+
+Holders with NULL `as_of_date` are ignored for all four (a slice of only
+NULL-as_of holders → min/max None, distinct_quarters 0, mixed_period
+False). All four are intrinsic to the slice's holders — computed once in
+`_build_slice`, so every slice (pie-wedge + memo overlays) carries them.
+
+**Family blind-spot fix (Codex ckpt-1 High).** A collapsed institutional
+family (#1644/#1649) is one synthetic `Holder` whose `as_of_date =
+min(member dates)`, but its `family_members` may span quarters. So
+`_slice_coherence` gathers, per holder, `holder.as_of_date` **plus every
+`family_member.as_of_date`** — otherwise a Vanguard family spanning Q2+Q3
+would falsely read single-quarter. The dedup `dropped_sources` are NOT
+gathered (a dropped loser is not part of the counted figure's as-of span).
+
+### Per category (`CategoryCoverage`)
+
+```
+is_estimate: bool             # estimated_universe is None
+```
+
+Honest machine flag: `true` means "no real filer-universe estimate exists
+for this category, treat the figure as a floor not a measured share."
+Derived in `_compute_coverage` as `estimated_universe is None` (Codex
+ckpt-1 High). This is equivalent to `state in {unknown_universe}` for the
+normal path but avoids coupling to a state and correctly treats a real
+seeded `estimate == 0` as NOT an estimate (`is_estimate=False`,
+vacuously-green). The `no_data` rollup path bypasses `_compute_coverage`
+and ships `coverage.categories = {}` (no per-category flags) — unchanged;
+the top-level `coverage.state == "no_data"` already signals untrustable.
+
+### Top-level (`OwnershipRollup.sanity: SanityChecks`)
+
+Raw facts over pie-wedge slices only (memo overlays excluded — they are
+already-counted detail). No thresholds.
+
+```
+max_distinct_quarters: int        # max slice.distinct_quarters over pie-wedge slices
+institutions_pct: Decimal         # Σ pie-wedge slices in {institutions, etfs} total / outstanding
+institutions_over_100pct: bool    # institutions_pct > 1
+largest_single_holder_pct: Decimal# biggest single deduped pie-wedge holder / outstanding
+any_pie_slice_over_100pct: bool   # any pie-wedge slice pct_outstanding > 1
+```
+
+`institutions_pct` explicitly filters `denominator_basis == "pie_wedge"`
+(Codex ckpt-1 Medium) so a future memo overlay tagged institutions/etfs
+cannot leak into the bound. `outstanding <= 0` → all pct fields `Decimal(0)`,
+both booleans `False`.
+
+`largest_single_holder_pct` covers the committee's "single-family
+plausibility": a collapsed Vanguard/BlackRock family is one `Holder`
+(#1644/#1649), so an implausibly large family shows here. `institutions_pct`
++ the two `over_100pct` booleans are the impossibility checks the existing
+`residual.oversubscribed` guard cannot express at sub-residual granularity.
+
+`no_data` rollups get a zeroed `SanityChecks` (all 0 / False).
+
+## API + FE
+
+- `app/api/instruments.py`: add the fields to `_SliceModel`,
+  `_CategoryCoverageModel`, and a new `_SanityChecksModel` on
+  `OwnershipRollupResponse`; map in `_rollup_to_response`
+  (`app/api/instruments.py:4332`).
+- `frontend/src/api/ownership.ts`: mirror the types (optional fields with
+  back-compat defaults, matching the existing `denominator_basis?` pattern).
+- No new FE rendering required for PR-A (contract-only). The existing panel
+  ignores unknown fields. A follow-up may surface a "mixed-quarter" chip.
+- CSV export (`build_rollup_csv`): add a trailing `__as_of_coherence__`
+  memo row per pie-wedge slice? → NO. Keep CSV unchanged; the envelope is a
+  JSON-contract concern, and the CSV already carries per-holder `as_of_date`
+  for manual span checks. (Documented non-change.)
+
+## Tests (pure-logic, no DB)
+
+Table-test the new pure helpers:
+- `_calendar_quarter` boundary months.
+- `_slice_coherence(holders)` — empty / all-NULL-as_of / single-quarter /
+  multi-quarter / unsorted dates.
+- `_compute_sanity(slices, outstanding)` — over/under 100%, memo-overlay
+  exclusion, largest-holder pick, zero-outstanding guard.
+- `is_estimate` derivation across all 5 coverage states.
+
+## DoD
+
+Pure read-path → clauses 8-12 (ETL smoke/backfill) N/A; record that. Live
+endpoint verified on dev panel (AAPL/GME/MSFT/JPM/HD) showing the envelope
+fields populate (AAPL institutions `mixed_period=true`, `distinct_quarters`
+≥2). Codex ckpt-1 (spec) + ckpt-2 (pre-push diff).

--- a/frontend/src/api/ownership.ts
+++ b/frontend/src/api/ownership.ts
@@ -133,6 +133,16 @@ export interface OwnershipSlice {
    *  overlays. Defaults to ``pie_wedge`` when absent for backwards
    *  compatibility with older payloads. */
   readonly denominator_basis?: OwnershipDenominatorBasis;
+  /** As-of coherence envelope (#1647 part 1). The as-of span of this slice's
+   *  deduped holders (incl. collapsed-family members) — lets a consumer see the
+   *  figure sums filings across quarters. ``mixed_period`` is
+   *  ``distinct_quarters > 1``. A slice whose holders all have null as-of →
+   *  ``as_of_min``/``as_of_max`` null, ``distinct_quarters`` 0, ``mixed_period``
+   *  false. Optional for back-compat with pre-envelope payloads. */
+  readonly as_of_min?: string | null;
+  readonly as_of_max?: string | null;
+  readonly distinct_quarters?: number;
+  readonly mixed_period?: boolean;
 }
 
 export interface OwnershipResidual {
@@ -152,6 +162,12 @@ export interface OwnershipCategoryCoverage {
   readonly estimated_universe: number | null;
   readonly pct_universe: string | null;
   readonly state: OwnershipCoverageState;
+  /** Honest machine completeness flag (#1647 part 2). ``true`` ⇔ no real
+   *  filer-universe estimate exists for this category, so the figure is a
+   *  floor, not a measured share of a known universe. The real
+   *  ``coverage_ratio`` gate is deferred to #790. Optional for back-compat;
+   *  treat absent as ``true`` (the pre-envelope state was all-unknown). */
+  readonly is_estimate?: boolean;
 }
 
 export interface OwnershipCoverage {
@@ -244,6 +260,23 @@ export interface OwnershipDualClassDenominator {
   readonly note: string;
 }
 
+/** Raw plausibility facts over the pie-wedge slices (#1647 part 4). NOT
+ *  pass/fail — measurements a machine consumer can reason over to catch the
+ *  next silent inflation (the existing ``residual.oversubscribed`` guard
+ *  cannot). Memo-overlay slices excluded; zeroed on the ``no_data`` path. All
+ *  optional for back-compat with pre-envelope payloads. */
+export interface OwnershipSanityChecks {
+  /** Worst per-slice as-of spread; >1 ⇒ a slice sums different quarters. */
+  readonly max_distinct_quarters?: number;
+  /** Decimal-as-string fraction: Σ pie-wedge institutions+etfs / outstanding. */
+  readonly institutions_pct?: string;
+  readonly institutions_over_100pct?: boolean;
+  /** Decimal-as-string: biggest single deduped pie-wedge holder / outstanding
+   *  (a collapsed family is one holder). */
+  readonly largest_single_holder_pct?: string;
+  readonly any_pie_slice_over_100pct?: boolean;
+}
+
 export interface OwnershipRollupResponse {
   readonly symbol: string;
   readonly instrument_id: number;
@@ -268,6 +301,9 @@ export interface OwnershipRollupResponse {
   /** Non-null only for one share class of a multi-class issuer; when set, every
    *  percentage in this rollup is a combined-basis lower bound (#1646). */
   readonly dual_class_denominator: OwnershipDualClassDenominator | null;
+  /** Raw plausibility facts over the pie-wedge slices (#1647 part 4). Optional
+   *  for back-compat with pre-envelope payloads. */
+  readonly sanity?: OwnershipSanityChecks;
   readonly computed_at: string;
 }
 

--- a/tests/test_ownership_machine_trust_envelope.py
+++ b/tests/test_ownership_machine_trust_envelope.py
@@ -1,0 +1,269 @@
+"""Pure-logic tests for the ownership machine-trust envelope (#1647 PR-A).
+
+Covers the three additive-contract helpers — all pure, no DB:
+  * ``_calendar_quarter`` — (year, 1..4) bucketing.
+  * ``_slice_coherence`` — per-slice as-of span incl. collapsed-family members.
+  * ``_compute_sanity`` — raw plausibility facts over pie-wedge slices.
+  * ``is_estimate`` derivation via ``_per_category_state`` / ``_compute_coverage``.
+
+See docs/specs/etl/2026-06-16-ownership-machine-trust-envelope.md.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.ownership_rollup import (
+    FamilyMember,
+    Holder,
+    OwnershipSlice,
+    SliceCategory,
+    SourceTag,
+    _build_slice,
+    _calendar_quarter,
+    _compute_coverage,
+    _compute_sanity,
+    _slice_coherence,
+)
+
+
+def _h(
+    shares: str,
+    *,
+    as_of: date | None,
+    source: SourceTag = "13f",
+    family: tuple[FamilyMember, ...] = (),
+    name: str = "Holder",
+) -> Holder:
+    return Holder(
+        filer_cik="0000000001",
+        filer_name=name,
+        shares=Decimal(shares),
+        pct_outstanding=Decimal(0),
+        winning_source=source,
+        winning_accession="acc-1",
+        winning_edgar_url=None,
+        as_of_date=as_of,
+        filer_type=None,
+        dropped_sources=(),
+        family_members=family,
+    )
+
+
+def _fm(shares: str, *, as_of: date | None) -> FamilyMember:
+    return FamilyMember(
+        filer_cik="0000000002",
+        filer_name="Sub",
+        shares=Decimal(shares),
+        source="13f",
+        accession_number="acc-2",
+        edgar_url=None,
+        as_of_date=as_of,
+    )
+
+
+def _slice(
+    category: SliceCategory,
+    holders: list[Holder],
+    *,
+    outstanding: str = "1000",
+    basis: str = "pie_wedge",
+) -> OwnershipSlice:
+    return _build_slice(category, holders, Decimal(outstanding), denominator_basis=basis)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _calendar_quarter
+# ---------------------------------------------------------------------------
+
+
+def test_calendar_quarter_boundaries() -> None:
+    assert _calendar_quarter(date(2025, 1, 1)) == (2025, 1)
+    assert _calendar_quarter(date(2025, 3, 31)) == (2025, 1)
+    assert _calendar_quarter(date(2025, 4, 1)) == (2025, 2)
+    assert _calendar_quarter(date(2025, 6, 30)) == (2025, 2)
+    assert _calendar_quarter(date(2025, 9, 30)) == (2025, 3)
+    assert _calendar_quarter(date(2025, 10, 1)) == (2025, 4)
+    assert _calendar_quarter(date(2025, 12, 31)) == (2025, 4)
+
+
+def test_calendar_quarter_year_distinguished() -> None:
+    # Same quarter index, different year → distinct buckets.
+    assert _calendar_quarter(date(2024, 3, 31)) != _calendar_quarter(date(2025, 3, 31))
+
+
+# ---------------------------------------------------------------------------
+# _slice_coherence
+# ---------------------------------------------------------------------------
+
+
+def test_coherence_empty() -> None:
+    assert _slice_coherence([]) == (None, None, 0, False)
+
+
+def test_coherence_all_null_as_of() -> None:
+    holders = [_h("100", as_of=None), _h("50", as_of=None)]
+    assert _slice_coherence(holders) == (None, None, 0, False)
+
+
+def test_coherence_single_quarter() -> None:
+    holders = [_h("100", as_of=date(2025, 3, 31)), _h("50", as_of=date(2025, 1, 15))]
+    lo, hi, distinct, mixed = _slice_coherence(holders)
+    assert lo == date(2025, 1, 15)
+    assert hi == date(2025, 3, 31)
+    assert distinct == 1
+    assert mixed is False
+
+
+def test_coherence_multi_quarter() -> None:
+    holders = [
+        _h("100", as_of=date(2025, 3, 31)),  # Q1
+        _h("50", as_of=date(2025, 6, 30)),  # Q2
+        _h("25", as_of=date(2024, 12, 31)),  # 2024 Q4
+    ]
+    lo, hi, distinct, mixed = _slice_coherence(holders)
+    assert lo == date(2024, 12, 31)
+    assert hi == date(2025, 6, 30)
+    assert distinct == 3
+    assert mixed is True
+
+
+def test_coherence_unsorted_dates() -> None:
+    holders = [_h("1", as_of=date(2025, 6, 30)), _h("2", as_of=date(2025, 1, 1))]
+    lo, hi, _distinct, _mixed = _slice_coherence(holders)
+    assert lo == date(2025, 1, 1)
+    assert hi == date(2025, 6, 30)
+
+
+def test_coherence_looks_through_family_members() -> None:
+    # Collapsed family: holder.as_of = min(members) = Q2, but a member is in Q3.
+    # Looking only at the holder would falsely read single-quarter.
+    family = (_fm("60", as_of=date(2025, 4, 1)), _fm("40", as_of=date(2025, 9, 30)))
+    holders = [_h("100", as_of=date(2025, 4, 1), family=family)]
+    lo, hi, distinct, mixed = _slice_coherence(holders)
+    assert lo == date(2025, 4, 1)
+    assert hi == date(2025, 9, 30)
+    assert distinct == 2
+    assert mixed is True
+
+
+def test_coherence_family_member_null_ignored() -> None:
+    family = (_fm("60", as_of=date(2025, 4, 1)), _fm("40", as_of=None))
+    holders = [_h("100", as_of=date(2025, 4, 1), family=family)]
+    lo, hi, distinct, mixed = _slice_coherence(holders)
+    assert lo == hi == date(2025, 4, 1)
+    assert distinct == 1
+    assert mixed is False
+
+
+def test_build_slice_populates_coherence_fields() -> None:
+    slc = _slice("institutions", [_h("100", as_of=date(2025, 3, 31)), _h("50", as_of=date(2025, 6, 30))])
+    assert slc.as_of_min == date(2025, 3, 31)
+    assert slc.as_of_max == date(2025, 6, 30)
+    assert slc.distinct_quarters == 2
+    assert slc.mixed_period is True
+
+
+# ---------------------------------------------------------------------------
+# _compute_sanity
+# ---------------------------------------------------------------------------
+
+
+def test_sanity_empty_slices() -> None:
+    s = _compute_sanity([], Decimal("1000"))
+    assert s.max_distinct_quarters == 0
+    assert s.institutions_pct == Decimal(0)
+    assert s.institutions_over_100pct is False
+    assert s.largest_single_holder_pct == Decimal(0)
+    assert s.any_pie_slice_over_100pct is False
+
+
+def test_sanity_zero_outstanding_zeroes_pct_but_keeps_quarters() -> None:
+    slc = _slice(
+        "institutions", [_h("100", as_of=date(2025, 3, 31)), _h("50", as_of=date(2025, 6, 30))], outstanding="1"
+    )
+    # Re-measure against a 0 denominator: quarters survive, pct collapse to 0.
+    s = _compute_sanity([slc], Decimal(0))
+    assert s.max_distinct_quarters == 2
+    assert s.institutions_pct == Decimal(0)
+    assert s.institutions_over_100pct is False
+    assert s.largest_single_holder_pct == Decimal(0)
+    assert s.any_pie_slice_over_100pct is False
+
+
+def test_sanity_institutions_and_etfs_summed() -> None:
+    inst = _slice("institutions", [_h("400", as_of=date(2025, 3, 31))], outstanding="1000")
+    etf = _slice("etfs", [_h("300", as_of=date(2025, 3, 31))], outstanding="1000")
+    s = _compute_sanity([inst, etf], Decimal("1000"))
+    assert s.institutions_pct == Decimal("0.7")
+    assert s.institutions_over_100pct is False
+
+
+def test_sanity_institutions_over_100pct() -> None:
+    inst = _slice("institutions", [_h("700", as_of=date(2025, 3, 31))], outstanding="1000")
+    etf = _slice("etfs", [_h("400", as_of=date(2025, 3, 31))], outstanding="1000")
+    s = _compute_sanity([inst, etf], Decimal("1000"))
+    assert s.institutions_pct == Decimal("1.1")
+    assert s.institutions_over_100pct is True
+
+
+def test_sanity_memo_overlay_excluded() -> None:
+    # A funds memo-overlay slice tagged institution_subset must NOT leak into
+    # institutions_pct, the largest-holder pick, or max_distinct_quarters.
+    inst = _slice("institutions", [_h("400", as_of=date(2025, 3, 31))], outstanding="1000")
+    funds = _slice(
+        "funds",
+        [_h("9999", as_of=date(2024, 1, 1)), _h("1", as_of=date(2025, 12, 31))],
+        outstanding="1000",
+        basis="institution_subset",
+    )
+    s = _compute_sanity([inst, funds], Decimal("1000"))
+    assert s.institutions_pct == Decimal("0.4")  # funds excluded
+    assert s.largest_single_holder_pct == Decimal("0.4")  # 400/1000, not 9999
+    assert s.max_distinct_quarters == 1  # funds' 2-quarter spread excluded
+    assert s.any_pie_slice_over_100pct is False
+
+
+def test_sanity_largest_single_holder_across_slices() -> None:
+    inst = _slice(
+        "institutions", [_h("200", as_of=date(2025, 3, 31)), _h("100", as_of=date(2025, 3, 31))], outstanding="1000"
+    )
+    block = _slice("blockholders", [_h("350", as_of=date(2025, 3, 31), source="13d")], outstanding="1000")
+    s = _compute_sanity([inst, block], Decimal("1000"))
+    assert s.largest_single_holder_pct == Decimal("0.35")  # the 350 blockholder
+
+
+def test_sanity_any_slice_over_100pct() -> None:
+    block = _slice("blockholders", [_h("1200", as_of=date(2025, 3, 31), source="13d")], outstanding="1000")
+    s = _compute_sanity([block], Decimal("1000"))
+    assert s.any_pie_slice_over_100pct is True
+
+
+# ---------------------------------------------------------------------------
+# is_estimate derivation
+# ---------------------------------------------------------------------------
+
+
+def test_is_estimate_true_when_no_universe_estimate() -> None:
+    # Tier-0 default: every category NULL estimate → is_estimate True.
+    slc = _slice("institutions", [_h("400", as_of=date(2025, 3, 31))])
+    coverage = _compute_coverage([slc], {"insiders": None, "blockholders": None, "institutions": None, "etfs": None})
+    assert all(c.is_estimate for c in coverage.categories.values())
+    assert coverage.categories["institutions"].state == "unknown_universe"
+
+
+def test_is_estimate_false_when_estimate_seeded() -> None:
+    slc = _slice("institutions", [_h("400", as_of=date(2025, 3, 31))])
+    coverage = _compute_coverage([slc], {"insiders": None, "blockholders": None, "institutions": 10, "etfs": None})
+    assert coverage.categories["institutions"].is_estimate is False
+    assert coverage.categories["insiders"].is_estimate is True
+
+
+def test_is_estimate_false_for_real_zero_estimate() -> None:
+    # estimate==0 is a real seeded value ("universe is empty here"), vacuously
+    # green — NOT an estimate.
+    slc = _slice("institutions", [_h("0", as_of=date(2025, 3, 31))])
+    coverage = _compute_coverage([slc], {"insiders": 0, "blockholders": None, "institutions": None, "etfs": None})
+    assert coverage.categories["insiders"].is_estimate is False
+    assert coverage.categories["insiders"].state == "green"


### PR DESCRIPTION
## What & why

PR-A of epic **#1647** (the data-trust committee's convergent meta-finding: ownership data is display-only with no machine-readable trust envelope). Operator scope decision 2026-06-16: **"Envelope now, ratio→#790"** — ship the fully-feasible half of the contract; defer the real `coverage_ratio` (blocked on per-instrument 13F universe-count ingest) to #790.

**PURE READ-PATH.** No schema, migration, parser, backfill, `sec_rebuild`, or jobs-proc restart. Additive contract fields on `GET /instruments/{symbol}/ownership-rollup` only.

## Contract additions

| Part | What | Where |
|------|------|-------|
| **1 — as-of coherence** (per slice) | `as_of_min`, `as_of_max`, `distinct_quarters`, `mixed_period` | `_slice_coherence` → `_build_slice` |
| **4 — sanity invariants** (top-level) | `SanityChecks`: `max_distinct_quarters`, `institutions_pct`, `institutions_over_100pct`, `largest_single_holder_pct`, `any_pie_slice_over_100pct` | `_compute_sanity` |
| **2 — completeness flag** (per category, shippable half) | `is_estimate` (`estimated_universe is None`) | `_compute_coverage` |

- **Part 3** (structured `corrections_applied[]`) already shipped via #1639+. Not in scope.
- **Part 5** (cross-source validation) — lower priority, deferred.
- Real **`coverage_ratio`** gate → **DEFERRED #790** (universe estimates are NULL on every category today; `_read_universe_estimates` returns `{None,…}` until #790 lands).

## Design notes

- **As-of coherence looks *through* collapsed institutional families.** A #1644/#1649 family is one synthetic `Holder` whose own `as_of_date` is `min(member dates)`; `_slice_coherence` also gathers each `family_member.as_of_date`, else a Vanguard family spanning Q2+Q3 would falsely read single-quarter (Codex ckpt-1).
- **Sanity facts, not thresholds.** Raw measurements a decision agent reasons over — the existing `residual.oversubscribed` guard can't express sub-residual granularity, so it never trips on a sub-100% inflation like #1639 (AAPL 44.4%). All four percentage facts share the one `outstanding` denominator (Codex ckpt-2).
- **Memo-overlay slices excluded** from all sanity facts (already-counted detail, e.g. N-PORT funds inside the 13F aggregate).
- `is_estimate` is derived from `estimated_universe is None`, not coupled to a banner state — a real seeded `estimate == 0` (vacuously-green) is correctly NOT an estimate.

## Settled-decision guardrail

The 5-state coverage banner stays server-driven; this PR adds **only additive contract fields**, no new banner state, no FE-only remap (settled-decisions.md:702-720).

## Tests & verification

- **20 pure-logic tests** (no DB): `tests/test_ownership_machine_trust_envelope.py` — quarter bucketing, coherence (empty/all-null/single/multi/unsorted/family-lookthrough), sanity (over/under-100%, memo exclusion, largest-holder, zero-outstanding), `is_estimate` across all 5 coverage states.
- **Gates green**: ruff check + format, pyright (0 errors), fast tier (4251 passed), smoke (129 passed), FE typecheck, FE unit (1036 passed).
- **Dev-verified** (DoD clause 11) on panel AAPL/GME/MSFT/JPM/HD via the service against the dev DB:
  - AAPL institutions `mixed_period=true distinct_q=6` (Dec'24..Mar'26) — confirms the committee's 98.2% multi-quarter finding.
  - AAPL `sanity`: inst_pct=41.73%, `institutions_over_100pct=false`, largest holder 9.78%, `any_pie_slice_over_100pct=false`.
  - `is_estimate=true` for all categories (Tier-0 NULL universe → honest floor flag).
  - `funds` (institution_subset) correctly excluded from sanity `max_distinct_quarters`.

DoD ETL clauses 8-10 (smoke/cross-source/backfill) **N/A — pure read-path, no migration/backfill**.

## Conscious tradeoffs

- FE `sanity?` and its fields are typed **optional** to match this client's established additive-field back-compat convention (`denominator_basis?`, `family_members?`, `is_estimate?`). The API model `_SanityChecksModel` (defaults, always serialized) is the authoritative "always present" contract; FE optionality only guards transitional/cached payloads. (Codex ckpt-2 Low — REBUTTED on this basis.)

## Codex

- ckpt-1 (spec): 5 findings, all fixed before coding (is_estimate no-data semantics, family blind-spot, quarter numbering, pie-wedge filter, fn-name drift).
- ckpt-2 (diff): 1 Medium fixed (denominator consistency on `any_pie_slice_over_100pct`); 1 Low rebutted (above).

Spec: `docs/specs/etl/2026-06-16-ownership-machine-trust-envelope.md`

Part of #788. Refs #1647 (epic stays open: `coverage_ratio` → #790, cross-source → part 5). Next per sequence: #1648.
