### PR TITLE
feat(#1652): insider control-group collapse — count a deemed block once across channels

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4162,6 +4162,10 @@ class _CorrectionAppliedModel(BaseModel):
         under a larger 13F family sum.
       * ``institutional_family_collapse`` (#1649) — a 13F shell figure folded under
         a larger consolidated proxy/13G family figure (gap-fill).
+      * ``blockholder_group_collapse`` (#1645) — a Rule 13d-5 group counted once in the
+        blockholders wedge.
+      * ``insider_control_group_collapse`` (#1652) — a sponsor's GP/LP chain deemed block
+        counted once across Form 4 / Form 3 / 13D / 13G (insiders slice).
 
     The NT-specific fields are null for the #1644/#1649 kinds; ``family_id`` /
     ``source_channel`` / ``winning_source`` / ``winning_accession`` / ``detail``
@@ -4173,6 +4177,7 @@ class _CorrectionAppliedModel(BaseModel):
         "def14a_restates_institution",
         "institutional_family_collapse",
         "blockholder_group_collapse",
+        "insider_control_group_collapse",
     ]
     filer_cik: str | None
     filer_name: str

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -142,6 +142,10 @@ class CorrectionApplied:
         counted once at MAX and the other members are folded. ``source_channel`` ==
         ``winning_source`` (intra-blockholder-channel collapse); the per-member fold
         detail is in ``detail`` + the surviving holder's ``dropped_sources``.
+      * ``insider_control_group_collapse`` (#1652) — a sponsor's GP/LP chain reported the
+        same deemed block under many related CIKs across Form 4 / Form 3 / 13D / 13G; the
+        cross-channel group is counted once (insiders slice) and the other members folded.
+        Folded member CIK+name+shares live in ``detail``.
 
     The NT-specific fields are ``Optional`` for the #1644/#1649/#1645 kinds (no NT
     quarters). The generic ``family_id`` / ``source_channel`` (the folded channel)
@@ -1561,8 +1565,11 @@ def _reconcile_13d_groups(
     ``_reconcile_owner_once`` reconciles by CIK) is EXCLUDED from clustering and
     passed through untouched. owner-once already merges that CIK's 13D with its other
     channels; folding it into a different rep would orphan those rows and re-count the
-    block (Codex ckpt-1 HIGH-3). The cross-channel control-group case (the Form 4
-    explosion on all-insider groups like TKO) is the #1652 follow-up.
+    block (Codex ckpt-1 HIGH-3). The cross-channel control-group case (a sponsor's GP/LP
+    chain that Form-4s the same deemed block) is handled UPSTREAM by
+    :func:`_reconcile_insider_control_groups` (#1652), which consumes those members'
+    13D/G rows before this pass sees them; this pass owns the purely-blockholder
+    co-investor group (no Form-4 footprint).
 
     Returns ``(survivors, corrections)``: the post-collapse blockholder list (each
     group folded to one MAX holder; non-group + excluded rows unchanged) and one
@@ -1632,6 +1639,156 @@ def _reconcile_13d_groups(
             else:
                 survivors.extend(cluster)
     return survivors, corrections
+
+
+# ---------------------------------------------------------------------------
+# Insider control-group collapse — count a deemed-ownership block once (#1652)
+# See docs/specs/etl/2026-06-16-insider-control-group-collapse.md
+# ---------------------------------------------------------------------------
+#
+# In a sponsor-controlled issuer every entity in a PE fund's GP/LP chain files its
+# own Form 4 for the SAME indirect-beneficial block (Rule 13d-3 deemed ownership),
+# and the same related CIKs restate it on Schedule 13D/G (a >10% owner is both a
+# Section-16 insider AND a 5% blockholder). Per-CIK dedup keeps every CIK, so the
+# block sums N× and the insiders wedge explodes past 100% of float (AMTM 423%,
+# VSAT 116%, LCID 1719%). Deemed ownership flows the BYTE-IDENTICAL number up the
+# chain and across channels, so the signal is exact (not #1645's near-equal band):
+# the same exact non-round value across ≥2 distinct CIKs on one instrument, spanning
+# Form 4 / Form 3 / 13D / 13G. Validated zero false positives over 1,150 dev buckets
+# (every one is a single genuine control group — Berkshire/Buffett, JAB/Reimann,
+# KKR, Blackstone, Carlos Slim — even those reporting a static block across years, so
+# NO period constraint: a window would wrongly split a long-held block).
+_INSIDER_GROUP_SOURCES: Final[frozenset[SourceTag]] = frozenset({"form4", "form3"})
+_BLOCK_GROUP_SOURCES: Final[frozenset[SourceTag]] = frozenset({"13d", "13g"})
+# Magnitude floor for the deemed-block signal. The non-round guard (_is_group_block,
+# divisibility by _ROUNDNESS_UNIT) is magnitude-BLIND — it flags a 19,532-share director
+# grant as "precise" exactly as it flags 45,026,743. Below ~1M, an exact non-round match
+# across distinct CIKs is dominated by coincidental equal small grants (dev: ~1,800 such
+# clusters, e.g. three EVEX directors each at 101,107 — independent, not a deemed block),
+# whereas every ≥1M exact-match cluster on dev (1,144 of them) is a genuine control group
+# (fund+principal, trust+person, parent/sub). A sub-1M deemed block also cannot
+# meaningfully explode a normal float, so the floor sheds the coincidence-prone tail while
+# keeping every explosion-causing block; the residual (a rare small real control group)
+# stays un-collapsed, the conservative direction (matches the round-lot residual).
+_INSIDER_GROUP_MIN_SHARES: Final[Decimal] = Decimal(1_000_000)
+
+
+def _collapse_insider_control_group(cluster: list[Holder]) -> tuple[Holder, CorrectionApplied]:
+    """Collapse a confirmed control-group ``cluster`` (≥2 distinct CIKs, ≥1 insider
+    member, all at the same exact non-round block value) to ONE holder at that value
+    (Rule 13d-3 total beneficial ownership, counted once).
+
+    Representative = a member, preferring an insider source (``form4``/``form3``) so the
+    rep routes to the insiders slice via owner-once, then deterministic tie-break
+    ``(insider-source, shares, filer_cik, winning_accession)`` descending. Non-rep members
+    (from BOTH channels) are appended to the rep's existing ``dropped_sources`` (amendment
+    provenance preserved) and folded into one ``insider_control_group_collapse`` correction
+    whose ``detail`` carries each folded member's CIK + name + shares (``DroppedSource`` has
+    no CIK/name field — same limitation as #1645)."""
+    rep = sorted(
+        cluster,
+        key=lambda h: (
+            h.winning_source in _INSIDER_GROUP_SOURCES,
+            h.shares,
+            h.filer_cik or "",
+            h.winning_accession,
+        ),
+        reverse=True,
+    )[0]
+    losers = [h for h in cluster if h is not rep]
+    dropped = list(rep.dropped_sources)
+    for loser in losers:
+        dropped.append(
+            DroppedSource(
+                source=loser.winning_source,
+                accession_number=loser.winning_accession,
+                shares=loser.shares,
+                as_of_date=loser.as_of_date,
+                edgar_url=loser.winning_edgar_url,
+            )
+        )
+    collapsed = replace(rep, dropped_sources=tuple(dropped))
+    shares_removed = sum((loser.shares for loser in losers), Decimal(0))
+    folded = "; ".join(f"{loser.filer_name} ({loser.filer_cik}) {loser.shares}" for loser in losers)
+    correction = CorrectionApplied(
+        kind="insider_control_group_collapse",
+        filer_name=rep.filer_name,
+        shares_removed=shares_removed,
+        filer_cik=rep.filer_cik,
+        source_channel=rep.winning_source,  # intra-insider-channel rep (cross-channel fold in detail)
+        winning_source=rep.winning_source,
+        winning_accession=rep.winning_accession,
+        detail=(
+            f"Control group: {len(cluster)} related CIKs reporting {rep.shares} (deemed "
+            f"ownership) counted once under {rep.filer_name}. Folded: {folded}"
+        ),
+    )
+    return collapsed, correction
+
+
+def _reconcile_insider_control_groups(
+    survivors: list[Holder],
+    blockholders: list[Holder],
+) -> tuple[list[Holder], list[Holder], list[CorrectionApplied]]:
+    """Collapse each inferred cross-channel control group to ONE insiders holder at the
+    block value, counted once (#1652). Pure read-path.
+
+    Operates on the union of insider survivors (``form4``/``form3``) and blockholders
+    (``13d``/``13g``), bucketed by EXACT ``shares`` value. A bucket collapses when it has
+    **≥2 distinct non-null CIKs** AND **≥1 insider-source member** (a Form-4 footprint —
+    the #1652 explosion). A purely-13D/G bucket (a co-investor group with no insider) is
+    left untouched for :func:`_reconcile_13d_groups` (#1645); the two passes partition the
+    work. Only **non-round** (:func:`_is_group_block`), positive, non-null-CIK rows are
+    eligible; everything else passes through to its channel unchanged.
+
+    Consumption is **exact-value only**: a consumed CIK's 13D/G row at a *different* value
+    (usually the larger full group block) stays in ``blockholders`` for #1645/owner-once —
+    folding a member's entire 13D footprint would delete the genuine larger block (see
+    spec, Codex ckpt-1 MED).
+
+    Returns ``(survivors, blockholders, corrections)``: the bucket members removed from
+    BOTH lists (nothing orphaned — the 13D rows of a collapsed group are consumed here, so
+    neither #1645 nor owner-once can re-count the block) and the rep added back to
+    ``survivors``; one ``insider_control_group_collapse`` correction per collapsed group."""
+    survivors_out: list[Holder] = []
+    blockholders_out: list[Holder] = []
+    eligible_by_value: dict[Decimal, list[tuple[str, Holder]]] = {}
+
+    def _is_eligible(h: Holder) -> bool:
+        cik = h.filer_cik
+        return (
+            h.shares >= _INSIDER_GROUP_MIN_SHARES
+            and cik is not None
+            and bool(cik.strip())
+            and _is_group_block(h.shares)
+            and h.winning_source in (_INSIDER_GROUP_SOURCES | _BLOCK_GROUP_SOURCES)
+        )
+
+    for origin, source_list, out_list in (
+        ("s", survivors, survivors_out),
+        ("b", blockholders, blockholders_out),
+    ):
+        for h in source_list:
+            if _is_eligible(h):
+                eligible_by_value.setdefault(h.shares, []).append((origin, h))
+            else:
+                out_list.append(h)
+
+    corrections: list[CorrectionApplied] = []
+    for members in eligible_by_value.values():
+        holders = [h for _, h in members]
+        distinct_ciks = {h.filer_cik for h in holders}
+        has_insider = any(h.winning_source in _INSIDER_GROUP_SOURCES for h in holders)
+        if len(distinct_ciks) >= 2 and has_insider:
+            collapsed, correction = _collapse_insider_control_group(holders)
+            # The rep is always an insider-source row (≥1 insider member + rep preference),
+            # so it routes to the insiders slice via owner-once → goes to survivors.
+            survivors_out.append(collapsed)
+            corrections.append(correction)
+        else:
+            for origin, h in members:
+                (survivors_out if origin == "s" else blockholders_out).append(h)
+    return survivors_out, blockholders_out, corrections
 
 
 def _bucket_into_slices(
@@ -2404,12 +2561,21 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     family_by_category, survivors, blockholders, unmatched_def14a, family_corrections = (
         _reconcile_institutional_families(survivors, blockholders, unmatched_def14a, outstanding)
     )
+    # Insider control-group collapse (#1652): a sponsor's GP/LP chain Form-4s the SAME
+    # deemed block under many related CIKs (and restates it on 13D/G), so the insiders
+    # wedge explodes past 100% of float. Collapse the cross-channel union by EXACT
+    # non-round value to ONE insiders holder before #1645 + owner-once, removing the
+    # consumed rows from BOTH lists (nothing orphaned). Runs BEFORE #1645 so the control
+    # group's 13D rows are consumed here; a purely-13D co-investor group (no insider
+    # member) is left for #1645.
+    survivors, blockholders, insider_group_corrections = _reconcile_insider_control_groups(survivors, blockholders)
     # 13D/G group collapse (#1645): a Rule 13d-5 group's members each report the
     # identical aggregate stake on separate accessions/CIKs and otherwise sum N× in
     # the blockholders wedge. Collapse a near-equal, same-period, non-round cluster to
     # ONE holder at MAX before owner-once. survivor_keys excludes any blockholder CIK
     # that owner-once will reconcile cross-channel (so its other-channel rows are not
-    # orphaned). The cross-channel Form 4 explosion on all-insider groups is #1652.
+    # orphaned). Computed AFTER the #1652 pass so a consumed control-group CIK (no longer
+    # a survivor) is not wrongly excluded from this clustering.
     survivor_keys = frozenset(_identity_key(h.filer_cik, h.filer_name) for h in survivors)
     blockholders, group_corrections = _reconcile_13d_groups(blockholders, survivor_keys)
     by_category = _reconcile_owner_once(survivors + blockholders)
@@ -2433,6 +2599,7 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     corrections_applied = (
         *_read_notice_suppressions(conn, instrument_id),
         *family_corrections,
+        *insider_group_corrections,
         *group_corrections,
     )
     return OwnershipRollup(
@@ -2696,6 +2863,29 @@ def build_rollup_csv(rollup: OwnershipRollup) -> str:
                 _csv_safe(corr.filer_cik or ""),
                 _csv_safe(corr.filer_name),
                 f"__group_collapse:{corr.filer_cik or 'unknown'}__",
+                str(corr.shares_removed),
+                "",
+                _csv_safe(corr.source_channel or ""),
+                _csv_safe(corr.winning_accession or ""),
+                "",
+                _csv_safe(corr.detail),
+                "",
+            ]
+        )
+
+    # Insider control-group collapse audit (#1652): a sponsor's GP/LP chain reported the
+    # same deemed block under many related CIKs across Form 4 / 13D / 13G; counted once
+    # in the insiders wedge, the others folded. Emit one ``__insider_group_collapse:<rep_cik>__``
+    # memo row per correction (folded member CIK+name+shares are in ``detail``). Excluded
+    # from any SUM(shares) reconciliation (the folded shares were never real).
+    for corr in rollup.corrections_applied:
+        if corr.kind != "insider_control_group_collapse":
+            continue
+        writer.writerow(
+            [
+                _csv_safe(corr.filer_cik or ""),
+                _csv_safe(corr.filer_name),
+                f"__insider_group_collapse:{corr.filer_cik or 'unknown'}__",
                 str(corr.shares_removed),
                 "",
                 _csv_safe(corr.source_channel or ""),

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -1660,6 +1660,9 @@ def _reconcile_13d_groups(
 # NO period constraint: a window would wrongly split a long-held block).
 _INSIDER_GROUP_SOURCES: Final[frozenset[SourceTag]] = frozenset({"form4", "form3"})
 _BLOCK_GROUP_SOURCES: Final[frozenset[SourceTag]] = frozenset({"13d", "13g"})
+# Eligibility scope = the CIK-keyed beneficial-restatement channels (precomputed union
+# so _is_eligible doesn't rebuild it per holder).
+_GROUP_ELIGIBLE_SOURCES: Final[frozenset[SourceTag]] = _INSIDER_GROUP_SOURCES | _BLOCK_GROUP_SOURCES
 # Magnitude floor for the deemed-block signal. The non-round guard (_is_group_block,
 # divisibility by _ROUNDNESS_UNIT) is magnitude-BLIND — it flags a 19,532-share director
 # grant as "precise" exactly as it flags 45,026,743. Below ~1M, an exact non-round match
@@ -1761,7 +1764,7 @@ def _reconcile_insider_control_groups(
             and cik is not None
             and bool(cik.strip())
             and _is_group_block(h.shares)
-            and h.winning_source in (_INSIDER_GROUP_SOURCES | _BLOCK_GROUP_SOURCES)
+            and h.winning_source in _GROUP_ELIGIBLE_SOURCES
         )
 
     for origin, source_list, out_list in (

--- a/docs/specs/etl/2026-06-16-insider-control-group-collapse.md
+++ b/docs/specs/etl/2026-06-16-insider-control-group-collapse.md
@@ -1,0 +1,247 @@
+# Insider control-group collapse — count a deemed-ownership block once across channels (#1652)
+
+Part of epic #788 (ownership data-trust audit). Sibling of #1640 (owner-once),
+#1644/#1649 (institutional family identity), #1645 (13D Rule 13d-5 group collapse).
+Same contract: a single beneficial-ownership unit counted once, losers preserved as
+`dropped_sources`, the figure-changing fold surfaced as a structured
+`corrections_applied[]` entry (#1647).
+
+## Bug
+
+In a sponsor-controlled issuer, every entity in a PE fund's GP/LP chain files its
+**own Form 4** reporting the **same indirect-beneficial block** — each is *deemed*
+under Rule 13d-3 to beneficially own the block held by the funds it controls — and the
+**same related CIKs also restate that block on Schedule 13D/G** (>10% owners are both
+Section-16 insiders AND 5% blockholders). Today:
+
+- `_dedup_by_priority` (per `(CIK, nature)`) keeps every Form 4 row; owner-once keeps
+  each CIK once → the block is **summed across N CIKs** in the **insiders** wedge,
+  exploding past 100% of float.
+- The same group's **13D/G** rows are a parallel restatement of the same block. An
+  insiders-only collapse that merely drops the duplicate Form 4 CIKs would **orphan
+  those CIKs' 13D rows**, which then resurface as a fresh double-count in the
+  blockholders wedge (Codex ckpt-1 HIGH). So the fix must be **cross-channel**.
+- A within-holder facet: a control person who reports the deemed block as both
+  `direct` and `indirect` (Alan Goldberg) has those two `(CIK, nature)` survivor rows
+  summed by `_ADDITIVE_SOURCES` (#905), doubling that CIK on top of the cross-CIK
+  explosion.
+
+### Dev evidence (rendered rollup baseline, this branch)
+
+| symbol | instr | insiders shares (before) | ratio | mechanism |
+|---|---|---|---|---|
+| AMTM | 8823 | 1,034,338,534 | 423% | ~17 Lindsay Goldberg CIKs each 45,026,743 (form4); 3 American Securities CIKs each 43,893,904 (form3) **+ Alan Goldberg/ASP Amentum 13d 43,893,904**; Alan Goldberg direct 45M + indirect 45M |
+| VSAT | 8988 | 159,118,446 | 116% | 13 Warburg Pincus CIKs each 8,390,687 (form4); 5 Apax/CPP/Triton CIKs each 4,795,334 (form4) **+ Ontario/CPP/Triton 13d 4,795,334** |
+| BAC | 1011 | 2,313,142,165 | 33% | Berkshire Hathaway + Buffett each 766,629,822 (deemed) |
+| LCID | 9256 | 6,708,230,323 | 1719% | PIF + Ayar Third Investment each 2,227,072,750 + more |
+
+The AMTM/VSAT bold rows are exactly the cross-channel resurrection risk: the same
+exact block value appears on Form 4 AND 13D for overlapping CIKs.
+
+Breadth (cross-channel union of `ownership_insiders_current` form4/form3 +
+`ownership_blockholders_current` 13d/13g; exact non-round value >1M across ≥2 distinct
+CIKs, per instrument): **1,150 value-buckets**; insiders-only dup ≈ **99.3B shares across
+1,025 instruments**. Systemic across PE-spinoff IPOs.
+
+## The key — exact-equal non-round value across ≥2 distinct CIKs, cross-channel
+
+Deemed ownership makes every chain entity report the **byte-identical** block (the same
+number flows up the GP/LP chain and across Form 4 / 13D — verified exact on dev
+including fractional shares, e.g. AMAL 7,121,505.9300 across 14 CIKs; VSAT 4,795,334 on
+both form4 and 13d). This differs from #1645's pure-13D case, where each member
+*computes* its own aggregate and a fuzzy near-equal band is required. **Exact equality
+is therefore the predicate AND the false-positive guard.**
+
+Empirical false-positive check (full dev scan, value-bucket level, no period filter):
+**zero** cross-group collisions in 1,150 buckets. Every bucket — including all 27 with a
+>60-day as-of span — is ONE genuine control group reporting a static block across time
+(Berkshire||Buffett, Volkswagen AG||Volkswagen International, JAB/Reimann family chain
+across 2023→2025, KKR Hawaii aggregators, Blackstone INVH, Cinven, INEOS, Carlos Slim
+Control Empresarial, Qatar Investment Authority). Two unrelated filers reporting an
+*identical non-round* multi-million figure on the *same instrument* does not occur; the
+non-round guard removes the only plausible coincidence (a shared round lot).
+
+**No period constraint.** A static block held for years is reported at different
+`period_end`s by the same group (JAB across 819 days; KKR Hawaii aggregators across one
+quarter). A period window would wrongly *split* a single block — the opposite of the
+fix. The exact-non-round-value signal stands alone.
+
+Predicate over the cross-channel union of one instrument's insider survivors
+(`winning_source in {form4, form3}`) and blockholders (`13d/13g`):
+
+0. **Eligibility.** A member must have a **non-null CIK**, a **non-round** value
+   (`_is_group_block`: not a whole multiple of `_ROUNDNESS_UNIT`), AND
+   `shares ≥ _INSIDER_GROUP_MIN_SHARES` (**1,000,000**). The magnitude floor is
+   load-bearing: `_is_group_block` is divisibility-only and **magnitude-blind** — it flags
+   a 19,532-share director grant as "precise" exactly as 45,026,743. Below ~1M, an exact
+   non-round match across distinct CIKs is dominated by *coincidental equal small grants*
+   (dev: ~1,800 such clusters — e.g. three EVEX directors each at 101,107, independent, not
+   a deemed block), while every ≥1M exact-match cluster on dev (1,144) is a genuine control
+   group (fund+principal, trust+person, parent/sub, spouses with shared control). A sub-1M
+   deemed block also cannot meaningfully explode a normal float. Ineligible rows pass
+   through to their channel untouched.
+1. **Bucket = exact `shares` value.** All eligible members sharing one Decimal value on
+   the instrument. (A CIK's two same-value `(CIK, nature)` survivor rows are simply two
+   members — both fold; no nature inspection needed, and `Holder` carries none.)
+2. **≥2 distinct non-null CIKs** in the bucket.
+3. **≥1 insider-source member** (`form4`/`form3`) in the bucket. A bucket that is
+   purely 13D/G (no Section-16 footprint — a pure co-investor group like SKE/RIME/BTAI)
+   is **left for #1645**, which collapses it in the blockholders wedge with its tiered
+   tolerance. This pass owns only control groups with a Form 4 footprint (the #1652
+   insiders explosion); the two passes partition the work, no overlap.
+
+### Collapse action
+
+Each qualifying bucket collapses to ONE `Holder`, classified **insiders** (a >10% deemed
+owner is a Section-16 insider; the rollup already routes them there via `form4`):
+
+- `shares` = the block value (all members equal; MAX == the value).
+- **Representative** = a member, preferring an insider-source (`form4`/`form3`) member so
+  the rep's `winning_source` is an insider source, then deterministic tie-break
+  `(insider-source-first, shares, filer_cik, winning_accession)` descending.
+- All non-rep members (from BOTH channels) → `DroppedSource` entries **appended to** the
+  rep's existing `dropped_sources` (amendment-chain provenance preserved). The rep's own
+  other same-value rows (e.g. its `indirect` twin) drop too.
+- One `CorrectionApplied(kind="insider_control_group_collapse")`:
+  `shares_removed = Σ(non-rep member shares)`; `filer_cik`/`filer_name` = rep;
+  `source_channel`/`winning_source`/`winning_accession` = rep. `detail` names the group
+  size, block value, and **each folded member's CIK + name + shares** (the loser
+  identities — `DroppedSource` itself has no CIK/name field, same limitation as #1645, so
+  identities live in `detail`).
+- The bucket's members are removed from BOTH `survivors` and `blockholders`; the rep is
+  added back to `survivors`. **Nothing is orphaned** — the 13D rows of a collapsed group
+  are consumed here, so neither #1645 nor owner-once can re-count the block.
+
+## Placement in the rollup pipeline
+
+`get_ownership_rollup` (read-only, inside `snapshot_read`):
+
+```
+survivors    = _dedup_by_priority(other_candidates)              # form4/form3/13f/def14a
+blockholders = _dedup_within_source(block_candidates)            # 13d/13g
+family_by_category, survivors, blockholders, unmatched_def14a, family_corrections =
+    _reconcile_institutional_families(survivors, blockholders, unmatched_def14a, outstanding)
+survivors, blockholders, insider_group_corrections =
+    _reconcile_insider_control_groups(survivors, blockholders)   ← NEW (cross-channel)
+survivor_keys = { identity_key(h) for h in survivors }
+blockholders, group_corrections = _reconcile_13d_groups(blockholders, survivor_keys)
+by_category = _reconcile_owner_once(survivors + blockholders)
+corrections_applied = (*notice_suppressions, *family_corrections,
+                       *insider_group_corrections, *group_corrections)
+```
+
+Runs AFTER family-reconcile (curated 13F/13G families already pulled out; a Section-16
+control group is never a curated institutional family) and BEFORE both `_reconcile_13d_groups`
+and owner-once. `survivor_keys` is computed AFTER this pass on the post-collapse
+`survivors` — correct because the rep is in `survivors` (owner-once will reconcile it)
+and the dropped members are not (they are already consumed, so #1645 must not treat their
+absence as "reconcile elsewhere").
+
+### Non-exact 13D residual on a consumed CIK (Codex ckpt-1 MED) — handled, not quarantined
+
+Consumption is **exact-value only**: only the rows AT the bucket value leave `blockholders`.
+A consumed insider CIK can still own a 13D/G row at a *different* value. Dev scan: 98 such
+residual rows. They are **almost all LARGER than the bucket** (e.g. TKO Silver Lake 13d
+94,021,358 vs its Form 4 fragment 2,155,188) — the residual is the **full group block**
+(the real figure, #1645's job), the bucket is a smaller Form-4 fragment of it. So
+consuming a member's *entire* 13D footprint would be wrong — it would delete the genuine
+larger block. The residual is deliberately left in `blockholders`.
+
+What happens to that residual is **strictly better than today**: because the consumed CIK
+leaves `survivor_keys`, #1645's predicate 0 no longer excludes its residual 13D, so #1645
+now **collapses the residual group to one** in the blockholders wedge (before this PR the
+residual was MAX'd into the CIK's insider figure and exploded N× across the group's CIKs).
+A singleton residual simply moves wedge (insiders→blockholders), still counted once. The
+only over-count is a small **fragment ⊂ block cross-wedge overlap** (the rep's bucket
+fragment in insiders while the larger block sits in blockholders under a different rep CIK)
+— a documented residual, far smaller than the explosion it replaces, and exactly the
+fragment-vs-block cross-channel reconciliation #1645's spec already scoped as beyond reach
+("no claim is made that owner-once reconciles the whole group across channels"). No
+quarantine/tolerance rule is added (it would destroy legitimate larger blocks).
+
+**The rep-residual split (Codex ckpt-2).** The sharpest form of the above: the bucket
+**rep** stays in `survivors`/`survivor_keys`, so its *different-value* residual W 13D is
+excluded from #1645 clustering while a folded member's W 13D is not — owner-once then MAXes
+the rep's W into insiders while the member's W collapses in blockholders, so a larger block
+W can split one copy into each wedge. Dev scan for this exact shape (a collapsed bucket V
+whose members also share a larger non-round ≥1M residual W) returns **one instrument,
+GDRX** (founders Hirsch + Bezdek: V = 2,632,721 Form 4, W = 5,391,994 13D) — and GDRX
+renders `no_data` (no shares outstanding on file → the rollup short-circuits before slices),
+so **zero operator-visible instruments** are affected. It is also **not worsened** by this
+PR: pre-fix the two founders already counted 2×W (both MAX'd into insiders); post-fix the
+total is still 2×W, merely re-attributed across wedges (identical pie-wedge sum, identical
+oversubscription). A precise fix needs the deferred fragment-vs-block reconciliation; a
+fragment guard ("a CIK's smaller row is not its control block") was rejected — it would
+resurface AMTM's Alan-Goldberg 43,893,904 13D into the blockholders wedge. Characterization
+test `test_rep_residual_split_documented` pins the behaviour.
+
+## Surfacing
+
+- **`corrections_applied[]`**: new kind `insider_control_group_collapse` added to the
+  closed-vocab docstring (`ownership_rollup.CorrectionApplied`), the API Pydantic
+  `Literal` (`app/api/instruments.py::_CorrectionAppliedModel.kind`), and the FE union
+  (`frontend/src/api/ownership.ts::OwnershipCorrectionKind`). All three or Pydantic
+  rejects the kind at the boundary.
+- **CSV export** (`build_rollup_csv`): one `__insider_group_collapse:<rep_cik>__` memo
+  row per correction (mirrors `__group_collapse:__`), excluded from any `SUM(shares)`
+  reconciliation (the eliminated shares were never real).
+
+## Out of scope — file as follow-up
+
+The **`def14a_unmatched`** additive wedge has a parallel control-group double-count:
+name-keyed proxy 5%-holder rows restate the same block (AMTM "Lindsay Goldberg 1" + "ASP
+Amentum Investco" both 43,893,904; dev breadth 84 instruments / ~4.1B shares). It is
+**name-keyed (no CIK)** — outside this pass's CIK-keyed union — and overlaps #1644's
+proxy-wedge territory; folding it needs name-based value clustering across a third
+channel. This PR unifies the three **CIK-keyed** channels (form4/form3/13d/13g); the
+name-keyed proxy channel is a distinct, smaller (24× less) follow-up.
+
+Sanity guard: the #1647 `SanityChecks` (`largest_single_holder_pct`,
+`any_pie_slice_over_100pct`) already exposes the oversubscription this fix removes — no
+new invariant needed.
+
+## Validation (dev, this branch, live `get_ownership_rollup`)
+
+| symbol | insiders before | after (expected) | corrections |
+|---|---|---|---|
+| AMTM 8823 | 1,034,338,534 | 45,026,743 once + 43,893,904 once + small real insiders; **no blockholders resurrection** | 2 `insider_control_group_collapse` |
+| VSAT 8988 | 159,118,446 | 8,390,687 once + 4,795,334 once + Baupost + real insiders; **13d 4,795,334 consumed** | 2 |
+| BAC 1011 | 2,313,142,165 | − 766,629,822 (Berkshire/Buffett once) | 1 |
+| LCID 9256 | 6,708,230,323 | − large (PIF/Ayar once + more) | ≥1 |
+| GME 1699 | 39,785,607 | **unchanged** | 0 |
+| AAPL/MSFT/JPM/HD | — | **unchanged** | 0 |
+| SKE/RIME/BTAI | — | **#1645 still collapses the pure-13D wedge** (no insider member → skipped here) | (blockholder_group_collapse, unchanged) |
+
+## Residuals (documented, not silently dropped)
+
+- A **lone CIK** reporting the same exact non-round block as both `direct` and `indirect`
+  (no second CIK) is not collapsed (≥2-distinct-CIK gate); its #905 additive sum stands.
+  Not observed as a high-value case.
+- A control group on a **round** shared figure stays double-counted (roundness guard's
+  conservative direction).
+- Two genuinely-unrelated groups sharing the *exact non-round* value on one instrument
+  would merge (undercount). Not observed in 1,150 dev buckets; non-round guard protects.
+- The **`def14a_unmatched`** name-keyed double-count is the filed follow-up.
+
+## Tests (pure-logic table tests on `_reconcile_insider_control_groups`)
+
+- **Cross-channel no-resurrection (Codex ckpt-1 TEST GAP):** form4 cluster + same CIKs'
+  13d at the block value → collapses to ONE insiders rep; the 13d rows are removed from
+  the returned `blockholders` (assert empty / not present); `shares_removed` = Σ losers
+  from both channels.
+- AMTM 2-cluster shape: two exact-value buckets (45,026,743 form4-only; 43,893,904
+  form3+13d) each collapse to one rep; 2 corrections.
+- Within-holder fold: a CIK with two same-block survivor rows folds both (no #905 double).
+- BAC 2-CIK exact pair collapses; rep prefers an insider-source member.
+- Pure-13D bucket (no insider member) is **left untouched** in `blockholders` (handed to
+  #1645).
+- Negatives: round shared value kept separate (`_is_group_block`); lone CIK untouched;
+  two distinct exact values stay two buckets; null-CIK and `shares ≤ 0` never clustered;
+  a 13F / matched-DEF 14A survivor at the same value is NOT pulled in (source scope).
+- A control person's *separate* personal stake (different non-block value) survives.
+- Rep determinism + existing `dropped_sources` preserved (appended, not replaced);
+  `detail` carries folded member CIK+name+shares.
+
+End-to-end exercised on the live dev rollup (AMTM/VSAT/BAC/LCID collapse + the
+`insider_control_group_collapse` correction; GME + standard panel + SKE/RIME/BTAI #1645
+behaviour unchanged).

--- a/frontend/src/api/ownership.ts
+++ b/frontend/src/api/ownership.ts
@@ -226,7 +226,8 @@ export type OwnershipCorrectionKind =
   | "suppressed_by_13f_nt"
   | "def14a_restates_institution"
   | "institutional_family_collapse"
-  | "blockholder_group_collapse";
+  | "blockholder_group_collapse"
+  | "insider_control_group_collapse";
 
 export interface OwnershipCorrectionApplied {
   readonly kind: OwnershipCorrectionKind;

--- a/tests/test_insider_control_group_collapse.py
+++ b/tests/test_insider_control_group_collapse.py
@@ -1,0 +1,274 @@
+"""Pure-logic tests for insider control-group collapse (#1652).
+
+A sponsor's GP/LP chain Form-4s the SAME deemed block under many related CIKs (and
+restates it on 13D/G), so the insiders pie wedge explodes past 100% of float. This
+pass collapses the cross-channel union by EXACT non-round value (≥1M) to ONE insiders
+holder, removing consumed rows from BOTH the survivors and blockholders lists so a
+consumed CIK's exact-block 13D cannot resurface. No DB — hand-built ``Holder`` objects.
+See docs/specs/etl/2026-06-16-insider-control-group-collapse.md.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.ownership_rollup import (
+    DroppedSource,
+    Holder,
+    SourceTag,
+    _reconcile_insider_control_groups,
+)
+
+_P = date(2025, 5, 8)
+_BLOCK = "45026743"  # AMTM Lindsay Goldberg deemed block — exact, non-round, ≥1M
+
+
+def _h(
+    cik: str | None,
+    name: str,
+    shares: str,
+    *,
+    source: SourceTag = "form4",
+    as_of: date | None = _P,
+    accession: str | None = None,
+    dropped: tuple = (),
+) -> Holder:
+    acc = accession or f"acc-{cik}-{source}"
+    return Holder(
+        filer_cik=cik,
+        filer_name=name,
+        shares=Decimal(shares),
+        pct_outstanding=Decimal(0),
+        winning_source=source,
+        winning_accession=acc,
+        winning_edgar_url=f"https://sec.gov/{acc}",
+        as_of_date=as_of,
+        filer_type=None,
+        dropped_sources=dropped,
+    )
+
+
+def _kinds(corrs: list) -> list[str]:
+    return [c.kind for c in corrs]
+
+
+# ---------------------------------------------------------------------------
+# Core collapse — the in-scope wins
+# ---------------------------------------------------------------------------
+
+
+def test_form4_chain_collapses_to_one_insider() -> None:
+    """~3 GP/LP entities each Form-4 the same 45,026,743 block → one insiders holder."""
+    survivors = [
+        _h("0000000001", "LG GP Holding IV LLC", _BLOCK),
+        _h("0000000002", "Lindsay Goldberg IV L.P.", _BLOCK),
+        _h("0000000003", "Lindsay Goldberg V L.P.", _BLOCK),
+        _h("0000000099", "Real Director", "726198"),  # genuine, below floor, untouched
+    ]
+    out_s, out_b, corrs = _reconcile_insider_control_groups(survivors, [])
+    assert out_b == []
+    assert _kinds(corrs) == ["insider_control_group_collapse"]
+    block_holders = [h for h in out_s if h.shares == Decimal(_BLOCK)]
+    assert len(block_holders) == 1  # counted once
+    assert any(h.filer_name == "Real Director" for h in out_s)  # genuine survives
+    (corr,) = corrs
+    assert corr.shares_removed == Decimal(_BLOCK) * 2  # two folded members
+    assert len(block_holders[0].dropped_sources) == 2
+
+
+def test_within_holder_direct_indirect_both_fold() -> None:
+    """A control person reporting the block as both direct and indirect (two survivor
+    rows, same CIK) folds both — no #905 additive double (gotcha b)."""
+    survivors = [
+        _h("0001077430", "GOLDBERG ALAN E", _BLOCK, accession="acc-direct"),
+        _h("0001077430", "GOLDBERG ALAN E", _BLOCK, accession="acc-indirect"),
+        _h("0000000002", "Lindsay Goldberg IV L.P.", _BLOCK),
+    ]
+    out_s, _out_b, corrs = _reconcile_insider_control_groups(survivors, [])
+    block_holders = [h for h in out_s if h.shares == Decimal(_BLOCK)]
+    assert len(block_holders) == 1
+    # 3 members (2 Alan rows + 1 LP), rep is one of them, two folded.
+    (corr,) = corrs
+    assert corr.shares_removed == Decimal(_BLOCK) * 2
+
+
+def test_cross_channel_no_resurrection() -> None:
+    """Codex ckpt-1 TEST GAP: a control group with overlapping CIKs on Form 4 AND 13D
+    at the block value → collapses to ONE insiders rep; the exact-block 13D rows are
+    REMOVED from blockholders (consumed, not orphaned), so #1645/owner-once cannot
+    re-count the block."""
+    survivors = [
+        _h("0000000001", "Apax IX GP", _BLOCK),
+        _h("0000000002", "Triton LuxTopHolding", _BLOCK),
+    ]
+    blockholders = [
+        _h("0000000001", "Apax IX GP", _BLOCK, source="13d", as_of=date(2025, 5, 10)),
+        _h("0000000002", "Triton LuxTopHolding", _BLOCK, source="13d", as_of=date(2025, 5, 10)),
+    ]
+    out_s, out_b, corrs = _reconcile_insider_control_groups(survivors, blockholders)
+    assert out_b == []  # 13D rows consumed, not resurrected
+    block_holders = [h for h in out_s if h.shares == Decimal(_BLOCK)]
+    assert len(block_holders) == 1
+    assert block_holders[0].winning_source in ("form4", "form3")  # classified insiders
+    (corr,) = corrs
+    # 4 members total (2 form4 + 2 13d), rep is one form4 → 3 folded.
+    assert corr.shares_removed == Decimal(_BLOCK) * 3
+
+
+def test_rep_prefers_insider_source() -> None:
+    """A mixed bucket's rep is a Form-4 member (so it routes to the insiders slice),
+    even when a 13D member sorts higher on CIK."""
+    survivors = [_h("0000000001", "Fund GP", _BLOCK, source="form4")]
+    blockholders = [_h("0000000009", "Fund 13D", _BLOCK, source="13d", as_of=date(2025, 5, 9))]
+    out_s, out_b, corrs = _reconcile_insider_control_groups(survivors, blockholders)
+    (rep,) = [h for h in out_s if h.shares == Decimal(_BLOCK)]
+    assert rep.winning_source == "form4"
+    assert rep.filer_cik == "0000000001"
+    assert out_b == []
+    assert len(corrs) == 1
+
+
+def test_non_exact_13d_residual_stays_for_1645() -> None:
+    """Exact-value consumption only: a consumed CIK's 13D at a DIFFERENT (larger) value
+    is left in blockholders for #1645/owner-once (folding it would delete the genuine
+    larger block — Codex ckpt-1 MED)."""
+    survivors = [
+        _h("0000000001", "Silver Lake form4", _BLOCK),
+        _h("0000000002", "Endeavor form4", _BLOCK),
+    ]
+    residual = _h("0000000001", "Silver Lake 13D", "94021358", source="13d", as_of=date(2025, 5, 1))
+    out_s, out_b, corrs = _reconcile_insider_control_groups(survivors, [residual])
+    assert len(corrs) == 1
+    assert out_b == [residual]  # the larger, different-valued 13D survives untouched
+
+
+def test_rep_residual_split_documented() -> None:
+    """Codex ckpt-2 characterization: both members of a collapsed V-bucket ALSO share a
+    larger residual W 13D. This pass collapses V to one rep and leaves BOTH W rows in
+    blockholders (exact-value consumption). The W rows are NOT consumed here — the
+    fragment-vs-block split they later cause (W in insiders via the rep + W in blockholders
+    via the folded member) is the deferred cross-channel residual, pre-existing and not
+    worsened (pre-fix both founders already counted 2×W). Only dev instance is GDRX, which
+    renders no_data. This test pins the unit boundary so a future fix has an anchor."""
+    v, w = "2632721", "5391994"  # GDRX Hirsch/Bezdek shape (both ≥1M, non-round)
+    survivors = [_h("0001822522", "Hirsch", v), _h("0001822104", "Bezdek", v)]
+    blockholders = [
+        _h("0001822522", "Hirsch 13D", w, source="13d", as_of=date(2025, 5, 1)),
+        _h("0001822104", "Bezdek 13D", w, source="13d", as_of=date(2025, 5, 1)),
+    ]
+    out_s, out_b, corrs = _reconcile_insider_control_groups(survivors, blockholders)
+    assert len(corrs) == 1  # V collapsed once
+    assert {h.shares for h in out_s} == {Decimal(v)}  # one rep at V in survivors
+    assert [h.shares for h in out_b] == [Decimal(w), Decimal(w)]  # both W left for #1645
+    assert out_b == blockholders  # W rows untouched by this pass
+
+
+# ---------------------------------------------------------------------------
+# Negatives — conservative guards
+# ---------------------------------------------------------------------------
+
+
+def test_below_magnitude_floor_not_collapsed() -> None:
+    """Coincidental equal small grants (non-round but <1M) are NOT a deemed block."""
+    survivors = [
+        _h("0000000001", "Director A", "101107"),
+        _h("0000000002", "Director B", "101107"),
+        _h("0000000003", "Director C", "101107"),
+    ]
+    out_s, _out_b, corrs = _reconcile_insider_control_groups(survivors, [])
+    assert corrs == []
+    assert len(out_s) == 3  # all pass through
+
+
+def test_round_value_not_collapsed() -> None:
+    """A round shared figure (whole multiple of 100,000) is a plausible independent
+    coincidence → kept separate."""
+    survivors = [
+        _h("0000000001", "Holder A", "5000000"),
+        _h("0000000002", "Holder B", "5000000"),
+    ]
+    _out_s, _out_b, corrs = _reconcile_insider_control_groups(survivors, [])
+    assert corrs == []
+
+
+def test_lone_cik_not_collapsed() -> None:
+    """A single CIK at the block value (even two same-value rows) is not a group."""
+    survivors = [
+        _h("0000000001", "Solo", _BLOCK, accession="a"),
+        _h("0000000001", "Solo", _BLOCK, accession="b"),
+    ]
+    _out_s, _out_b, corrs = _reconcile_insider_control_groups(survivors, [])
+    assert corrs == []
+
+
+def test_pure_13d_bucket_left_for_1645() -> None:
+    """A purely-13D/G bucket (no Form-4 footprint) is untouched here — handed to
+    _reconcile_13d_groups (#1645)."""
+    blockholders = [
+        _h("0000000001", "Orion", "7720340", source="13d"),
+        _h("0000000002", "Selwyn", "7720340", source="13d"),
+    ]
+    out_s, out_b, corrs = _reconcile_insider_control_groups([], blockholders)
+    assert corrs == []
+    assert out_s == []
+    assert out_b == blockholders  # untouched, flows to #1645
+
+
+def test_distinct_exact_values_stay_separate() -> None:
+    """Two different exact blocks in one instrument → two buckets, two collapses."""
+    survivors = [
+        _h("0000000001", "Lindsay A", "45026743"),
+        _h("0000000002", "Lindsay B", "45026743"),
+        _h("0000000003", "American A", "43893904", source="form3"),
+        _h("0000000004", "American B", "43893904", source="form3"),
+    ]
+    _out_s, _out_b, corrs = _reconcile_insider_control_groups(survivors, [])
+    assert len(corrs) == 2
+    removed = sorted(c.shares_removed for c in corrs)
+    assert removed == [Decimal("43893904"), Decimal("45026743")]
+
+
+def test_null_cik_and_nonpositive_never_clustered() -> None:
+    survivors = [
+        _h(None, "No CIK 1", _BLOCK),
+        _h(None, "No CIK 2", _BLOCK),
+        _h("0000000003", "Zero", "0"),
+    ]
+    out_s, _out_b, corrs = _reconcile_insider_control_groups(survivors, [])
+    assert corrs == []
+    assert len(out_s) == 3
+
+
+def test_13f_survivor_not_pulled_in() -> None:
+    """A 13F survivor at the block value is NOT clustered (source scope: form4/form3 +
+    13d/13g only)."""
+    survivors = [
+        _h("0000000001", "Fund GP form4", _BLOCK),
+        _h("0000000002", "Manager 13F", _BLOCK, source="13f"),
+    ]
+    out_s, _out_b, corrs = _reconcile_insider_control_groups(survivors, [])
+    assert corrs == []  # only one eligible (insider) member → no ≥2-CIK cluster
+    assert any(h.winning_source == "13f" for h in out_s)
+
+
+def test_existing_dropped_sources_preserved() -> None:
+    """The rep's existing dropped_sources (amendment chain) are appended to, never
+    replaced."""
+    prior = (
+        DroppedSource(
+            source="form4",
+            accession_number="old",
+            shares=Decimal(_BLOCK),
+            as_of_date=_P,
+            edgar_url=None,
+        ),
+    )
+    survivors = [
+        _h("0000000009", "Rep", _BLOCK, accession="zzz", dropped=prior),  # high CIK → rep
+        _h("0000000001", "Member", _BLOCK),
+    ]
+    out_s, _out_b, _corrs = _reconcile_insider_control_groups(survivors, [])
+    (rep,) = [h for h in out_s if h.shares == Decimal(_BLOCK)]
+    assert prior[0] in rep.dropped_sources  # preserved
+    assert len(rep.dropped_sources) == 2  # prior + one folded member


### PR DESCRIPTION
Closes #1652. Part of epic #788 (ownership data-trust audit). Sibling of #1640 (owner-once), #1644/#1649 (institutional family), #1645 (13D group). **Pure read-path** — no migration/backfill/sec_rebuild/jobs-restart.

## Bug
In a sponsor-controlled issuer, every entity in a PE fund's GP/LP chain files its **own Form 4** for the SAME deemed-ownership block (Rule 13d-3), and the same related CIKs restate it on **13D/G** (a >10% owner is both a Section-16 insider and a 5% blockholder). Per-CIK dedup keeps every CIK → the block sums N× and the **insiders** wedge explodes past 100% of float.

Dev baseline: AMTM **423%**, VSAT **116%**, LCID **1719%**, BAC carries Berkshire+Buffett each at the same 766,629,822 deemed block.

## Fix
New pure pass `_reconcile_insider_control_groups(survivors, blockholders)` (app/services/ownership_rollup.py), run **before** #1645 and owner-once:
- Bucket the **cross-channel union** (form4/form3 survivors + 13d/13g blockholders) by **EXACT `shares` value**.
- Collapse a bucket with **≥2 distinct non-null CIKs** AND **≥1 insider-source member** to ONE insiders holder at that value; losers → `dropped_sources` + one `insider_control_group_collapse` correction. **Remove consumed rows from BOTH lists** so the block cannot resurrect.
- A **purely-13D/G** bucket (co-investor group, no Form-4 footprint) is left for #1645 — the two passes partition the work.
- Eligibility: non-null CIK, **non-round** (`_is_group_block`), **shares ≥ 1,000,000**.

### Why exact, no period, ≥1M floor
Deemed ownership flows the **byte-identical** number up the chain and across channels (verified exact incl. fractional shares). So exact-equality is the predicate AND the false-positive guard — a 2-CIK exact non-round match is safe. **No period constraint**: a static block is reported across years (JAB/Reimann 819d, KKR) — a window would wrongly split it. **≥1M floor**: `_is_group_block` (divisibility-only) is magnitude-blind — below ~1M, exact matches are dominated by coincidental equal small grants (~1,800 dev clusters, e.g. 3 EVEX directors each at 101,107). Validated **zero false positives over 1,150 dev buckets** (every one a genuine control group — Berkshire/Buffett, VW AG/VW Intl, JAB, KKR, Blackstone, Carlos Slim).

## Security model
Read-only rollup endpoint (`GET /instruments/{symbol}/ownership-rollup`), no auth/authorization surface change, no user-input-to-SQL (instrument scoped by the existing query). No schema/migration. The new `kind` is a closed Pydantic `Literal` rejected at the API boundary; the FE union mirrors it.

## Files
- `app/services/ownership_rollup.py` — pass + collapse helper + constants + compose wiring + CSV `__insider_group_collapse:__` memo + correction-vocab docstring.
- `app/api/instruments.py` — `_CorrectionAppliedModel.kind` Literal += `insider_control_group_collapse`.
- `frontend/src/api/ownership.ts` — `OwnershipCorrectionKind` union += same.
- `tests/test_insider_control_group_collapse.py` — 14 pure-logic tests.
- `docs/specs/etl/2026-06-16-insider-control-group-collapse.md`.

## Dev verification (live `get_ownership_rollup`, commit 23202a98)
| symbol | insiders before | after | note |
|--------|-----------------|-------|------|
| AMTM 8823 | 1,034,338,534 (423%) | **91,042,609 (37%)** | 45,026,743 + 43,893,904 once + reals; 2 corrections; **blockholders consumed, no resurrection** |
| VSAT 8988 | 159,118,446 (116%) | **39,248,866 (29%)** | 8,390,687 + 4,795,334 once; 13d 4,795,334 consumed; 2 corrections |
| BAC 1011 | 2,313,142,165 | **−766,629,822 exact** | Berkshire/Buffett once; 1 correction |
| LCID 9256 | 6,708,230,323 (1719%) | block 2,227,072,750 **once** (577% residual = pre-existing denominator bug, separate) | 1 correction |
| GME 1699 | 39,785,607 | **unchanged**, 0 corrections | clean negative |
| AAPL/MSFT/JPM/HD | — | **unchanged**, 0 corrections | no spurious collapse |
| SKE/RIME/BTAI | — | **#1645 pure-13D wedge unchanged** | passes partition correctly |

Cross-source (clause 9): BAC `shares_removed = 766,629,822` = Berkshire Hathaway's reported BAC stake (one block, counted once); AMTM block 45,026,743 = Lindsay Goldberg's reported Amentum stake.

## Gates
ruff check ✓ · ruff format ✓ · pyright 0 errors · pytest -m "not db" 4274 passed · smoke 129 passed · pytest -m db (rollup/csv/drillthrough/NT/trust-envelope) 77 passed · FE typecheck ✓ · FE test:unit 1040 passed.

## Codex
- ckpt-1 (spec): HIGH cross-channel 13D resurrection (insiders-only collapse orphans the group's 13D) → redesigned to the cross-channel union that consumes both channels. MED non-exact 13D residual → exact-only consumption (folding a member's whole 13D would delete the genuine larger block), documented.
- ckpt-2 (pre-push): rep-residual split (rep stays in `survivor_keys`, its different-value residual W can split across wedges). Dev scan → **GDRX only**, which renders `no_data` → **zero operator-visible impact**; pre-existing and **not worsened** (2×W before → same magnitude, re-attributed); a fragment guard was rejected (it resurfaces AMTM's Alan-Goldberg 43,893,904 13D). Pinned by `test_rep_residual_split_documented`.

## Out of scope (follow-up filed)
The `def14a_unmatched` additive wedge has a parallel control-group double-count (name-keyed, no CIK, ~4.1B sh / 84 instruments) — a distinct mechanism overlapping #1644's proxy-wedge territory. Filed as #1659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
