### PR TITLE
fix: set optimizeDeps esbuild target to es2022 (dev server crash on fresh start)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,13 @@ export default defineConfig({
   // single-operator dashboard on a current browser — raising the
   // build target is free; lowering it back requires esbuild <0.28.
   build: { target: "es2022" },
+  // Dev dep pre-bundling (optimizeDeps) runs esbuild too, and it does NOT
+  // inherit build.target — left unset it falls back to vite 6's legacy default
+  // (chrome87/safari14/es2020). esbuild >=0.28 (the #1606 GHSA pin) dropped the
+  // down-transforms for those targets, so `vite` (dev) crashes optimizing deps
+  // that ship modern syntax (e.g. @remix-run/router destructuring). Mirror the
+  // build target so dev and build agree.
+  optimizeDeps: { esbuildOptions: { target: "es2022" } },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Problem

A fresh `pnpm --dir frontend dev` crashes immediately:

```
ERROR: Transforming destructuring to the configured target environment
("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
is not supported yet
  node_modules/.pnpm/@remix-run+router@1.23.2/.../router.js
```

## Root cause

#1606 (PR#1607) raised `build.target` to `es2022` because esbuild ≥0.28 (pinned via `pnpm.overrides` for the GHSA on esbuild <0.28.1) dropped the down-transforms to vite 6's legacy default targets (chrome87/safari14/es2020). But it only set the **build** target — the dev **dep pre-bundle** (`optimizeDeps`) runs esbuild too and does **not** inherit `build.target`. Left unset it falls back to vite 6's legacy default, so `vite` (dev) crashes optimizing any dependency shipping modern syntax (here `@remix-run/router`'s destructuring).

Latent since the #1606 bump — it only surfaces on a clean dev start. The previously-running instance was a stale in-memory vite that was never restarted since (noted in the #1417/#1606 session memory: "5173 still vite-5-in-memory"); when the dev server died and was restarted fresh, the gap surfaced.

## Fix

Mirror `build.target` in `optimizeDeps.esbuildOptions.target` so dev and build agree.

## Verification

- `pnpm --dir frontend dev` → `VITE v6.4.3 ready`, listening on :5173, root serves HTTP 200, dep-optimize no longer crashes.
- `pnpm --dir frontend typecheck` clean.
- `pnpm --dir frontend test:unit` → 97 files / 1040 tests passed.

Refs #1606, #1417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)