### PR TITLE
feat(#1632): thesis engine ingests instrument_risk_metrics as risk evidence

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -306,6 +306,65 @@ def _event_reason_for_form(form_type: str) -> StaleReason:
 # ---------------------------------------------------------------------------
 
 
+_RISK_BASIS_NOTE = (
+    "All returns/ratios are fractions (0.10 = 10%, not percent). "
+    "Drawdown, var_5 and worst_day are signed losses (negative is a loss). "
+    "Basis is price-return (no dividend reinvestment; total-return is future "
+    "work), so do not over-read CAGR for high-yield names. A non-'ok' status "
+    "means the metric is NOT a precise number: treat insufficient_history / "
+    "partial_window as provisional, and benchmark_missing beta/excess as "
+    "absent, not zero. Cite a risk figure as {window_key, as_of_date, "
+    "metric_version}."
+)
+
+
+def _shape_risk_metrics(
+    rows: Sequence[Sequence[object]],
+    metric_version: str,
+) -> dict[str, object] | None:
+    """Shape the `instrument_risk_metrics_current` rows into the context block.
+
+    Pure: no DB, no I/O — the row order/column order is fixed by the SELECT in
+    :func:`_assemble_context`. Returns ``None`` when there are no rows (the
+    instrument's metrics were never computed — distinct from a thin-history
+    instrument, which HAS rows carrying flagged statuses that pass through
+    verbatim). NULL scalars stay ``None`` via :func:`_to_float` — never a
+    fabricated zero. ``as_of_date`` rides each window (no constraint enforces
+    one shared snapshot date across windows).
+    """
+    if not rows:
+        return None
+    return {
+        "metric_version": metric_version,
+        "basis_note": _RISK_BASIS_NOTE,
+        "windows": [
+            {
+                "window_key": r[0],
+                "as_of_date": str(r[1]) if r[1] is not None else None,
+                "benchmark_symbol": r[2],
+                "cagr": _to_float(r[3]),
+                "excess_cagr_vs_spy": _to_float(r[4]),
+                "vol_annualized": _to_float(r[5]),
+                "beta": _to_float(r[6]),
+                "beta_r2": _to_float(r[7]),
+                "calmar": _to_float(r[8]),
+                "max_drawdown": _to_float(r[9]),
+                "current_drawdown": _to_float(r[10]),
+                "var_5": _to_float(r[11]),
+                "worst_day": _to_float(r[12]),
+                "cagr_status": r[13],
+                "excess_cagr_status": r[14],
+                "vol_status": r[15],
+                "beta_status": r[16],
+                "drawdown_status": r[17],
+                "distribution_status": r[18],
+                "calmar_status": r[19],
+            }
+            for r in rows
+        ],
+    }
+
+
 def _assemble_context(
     conn: psycopg.Connection[Any],
     instrument_id: int,
@@ -436,6 +495,37 @@ def _assemble_context(
             "currency": inst_row[5],
         }
 
+    # Realized-risk metrics (#1632): persisted, versioned, quality-flagged
+    # risk_v1 scalars per window as structured evidence for the writer + critic.
+    # Lazy import — risk_metrics pulls in app.workers.scheduler, which transitively
+    # imports this module (refresh_cascade); a module-level import would be a cycle.
+    # By call time thesis is fully initialized, so the function-level import is safe
+    # and keeps the version/window constants single-sourced (no magic-string dup).
+    from app.services.risk_metrics import RISK_METRICS_VERSION, WINDOW_KEYS
+
+    # ONE statement (LEFT JOIN for the benchmark symbol) so context assembly does
+    # not add a second snapshot-spanning read. No rows → None (never computed,
+    # like analyst_estimates); a thin-history instrument DOES have rows carrying
+    # flagged statuses, which pass through verbatim — honest-status discipline,
+    # never a fabricated zero (NULL scalars stay None via _to_float).
+    risk_rows = conn.execute(
+        """
+        SELECT c.window_key, c.as_of_date, b.symbol AS benchmark_symbol,
+               c.cagr, c.excess_cagr_vs_spy, c.vol_annualized,
+               c.beta, c.beta_r2, c.calmar,
+               c.max_drawdown, c.current_drawdown, c.var_5, c.worst_day,
+               c.cagr_status, c.excess_cagr_status, c.vol_status, c.beta_status,
+               c.drawdown_status, c.distribution_status, c.calmar_status
+        FROM instrument_risk_metrics_current c
+        LEFT JOIN instruments b ON b.instrument_id = c.benchmark_instrument_id
+        WHERE c.instrument_id = %(id)s
+          AND c.metric_version = %(ver)s
+        ORDER BY array_position(%(worder)s, c.window_key)
+        """,
+        {"id": instrument_id, "ver": RISK_METRICS_VERSION, "worder": list(WINDOW_KEYS)},
+    ).fetchall()
+    risk_metrics = _shape_risk_metrics(risk_rows, RISK_METRICS_VERSION)
+
     # #539: earnings_events + analyst_estimates retired with FMP. The
     # writer prompt's optional contextual fields fall back to None;
     # the writer system prompt already tolerates absent enrichment.
@@ -445,6 +535,7 @@ def _assemble_context(
         "filings": filings,
         "news": news,
         "prior_thesis": prior_thesis,
+        "risk_metrics": risk_metrics,
         "earnings_history": [],
         "analyst_estimates": None,
     }
@@ -463,6 +554,12 @@ You will be given a research context including:
 - recent filing summaries (up to 3)
 - recent news events (up to 10, last 30 days)
 - prior thesis if one exists
+- realized-risk metrics (`risk_metrics`): persisted, versioned, quality-flagged
+  scalars per window (1y/3y/full) — CAGR, annualized vol, beta + R² vs the
+  benchmark, Calmar, max/current drawdown, var_5. All are FRACTIONS (0.10 = 10%,
+  not percent); drawdown / var_5 / worst_day are SIGNED losses (negative). Basis
+  is PRICE-RETURN (no dividends) — do not over-read CAGR for high-yield names.
+  May be null when no metrics are computed.
 
 Produce a JSON object with EXACTLY these fields:
 
@@ -488,6 +585,12 @@ Rules:
 - break_conditions: list of concrete, specific events that would invalidate the thesis
 - memo_markdown: full structured memo covering: business quality, key financials, recent news
   impact, valuation, risks, stance rationale. Min 3 paragraphs.
+- Use `risk_metrics` to ground the risk section: deep max drawdown, high beta,
+  low Calmar, or fat-tail var_5 are downside context that can support or weaken
+  a long. Respect the status flags — do NOT cite a non-`ok` metric as a precise
+  number (a `benchmark_missing` beta is absent, not 0; a `partial_window` CAGR
+  is provisional). When you cite a risk figure, name its {window_key,
+  as_of_date, metric_version} so the claim stays reproducible.
 - Separate facts from judgement. Be explicit about what must go right.
 - Respond with ONLY valid JSON. No explanation outside the JSON object.
 """
@@ -522,6 +625,12 @@ Rules:
 - Fight confirmation bias. Do not restate the bull case.
 - Prefer the strongest realistic objection over generic cautions.
 - Be concrete — cite specific metrics, dates, or events where possible.
+- Mine `risk_metrics` for realized-risk objections the memo glossed over — e.g.
+  a deep peak-to-trough drawdown, a high beta, a weak Calmar, or fat-tail var_5
+  that the bull case ignores. These are FRACTIONS, signed losses are negative,
+  basis is price-return. Respect status flags (a non-`ok` metric is not precise;
+  `benchmark_missing` beta is absent, not 0) and cite {window_key, as_of_date,
+  metric_version}.
 - verdict must be exactly one of: "Strong challenge", "Moderate challenge", "Weak challenge"
 - Respond with ONLY valid JSON. No explanation outside the JSON object.
 """

--- a/docs/specs/thesis/2026-06-18-risk-evidence-ingestion.md
+++ b/docs/specs/thesis/2026-06-18-risk-evidence-ingestion.md
@@ -1,0 +1,115 @@
+# #1632 — thesis engine ingests instrument_risk_metrics as structured risk evidence
+
+Status: spec. Follows #591 (PR-B shipped the `instrument_risk_metrics` two-layer table + `risk_v1`). Read-side only.
+
+## Goal
+
+Feed the persisted, versioned, quality-flagged risk scalars into the thesis
+writer + critic LLM context so a long thesis is grounded in realized risk
+(drawdown / vol / beta / Calmar / tail) and the critic's falsification kit can
+attack it on downside-risk grounds. **No schema / migration / job change** —
+`_assemble_context` gains one more read block, exactly like fundamentals /
+filings / news.
+
+## Source rule (the contract this must honour)
+
+From the #591 design (`docs/superpowers/specs/2026-06-14-instrument-risk-drill-design.md`)
++ data-engineer honest-status discipline + prevention-log "degrade honestly,
+never fabricate":
+
+- The risk row is the **auditable evidence**: a thesis citing "beta 1.3"
+  resolves to `{value, window_key, as_of_date, metric_version, status}`. So the
+  context block MUST carry `metric_version` + `as_of_date` (+ benchmark symbol
+  for beta/excess) alongside the scalars, and the prompts MUST instruct the LLM
+  to cite them.
+- **Honest status passthrough.** Every scalar already carries a per-metric
+  status (`ok | insufficient_history | partial_window | benchmark_missing |
+  benchmark_insufficient_history | invalid_price_chain | stale`). The block
+  passes the status through verbatim next to each metric family; the prompts
+  instruct the LLM to NOT treat a flagged (non-`ok`) metric as a precise number
+  — a thin-history annualized figure is provisional, a `benchmark_missing` beta
+  is absent, not zero. NULLs are never coerced to 0 (mirrors `_to_float`, which
+  returns None).
+- **Two distinct empty states (Codex ckpt-1 HIGH).** A *thin-history* instrument
+  still has `_current` rows — null scalars + flagged statuses
+  (`insufficient_history` / `partial_window`); those pass through verbatim
+  (status carries the signal). Only a *never-computed* instrument (no rows at
+  all — not yet in a refresh scope) yields `risk_metrics = None`, exactly like
+  `analyst_estimates`. Tests assert BOTH: flagged-row passthrough AND
+  None-on-no-rows.
+- **Units / signs (Codex ckpt-1 MED).** All returns/ratios are FRACTIONS
+  (0.10 = 10%, not percent); drawdown / `var_5` / `worst_day` are SIGNED losses
+  (negative); basis is **price-return** (TR deferred #1635). The block carries a
+  `note` stating this and the prompts repeat it so the LLM cannot misread
+  `-0.52` as "-0.52%" or as a gain.
+- Reproducibility: `risk_v1` rows are append-only + version-bumped, so a stored
+  thesis's risk citation stays reproducible. We read `_current` filtered to
+  `RISK_METRICS_VERSION` (imported, no magic string). A risk citation must name
+  `{window_key, as_of_date, metric_version}` — the prompts require all three
+  (Codex ckpt-1 HIGH: version cannot be dropped, else the append-only series
+  can't resolve the cited row).
+
+## Changes
+
+### `app/services/thesis.py`
+
+1. Import `RISK_METRICS_VERSION` from `app.services.risk_metrics`.
+2. `_assemble_context`: add a `risk_metrics` block — **ONE** SELECT (no second
+   statement — Codex ckpt-1 MED snapshot concern) from
+   `instrument_risk_metrics_current c LEFT JOIN instruments b ON b.instrument_id
+   = c.benchmark_instrument_id`, WHERE `c.instrument_id` AND
+   `c.metric_version = RISK_METRICS_VERSION`, ordered by window order
+   (`WINDOW_KEYS` from `risk_metrics.py` via a CASE / `array_position`, NOT the
+   api-layer `_RISK_WINDOW_ORDER`). Per-window subset:
+   `window_key, as_of_date` (**per window** — Codex MED, no constraint enforces
+   sameness), `benchmark_symbol` (= `b.symbol`), `cagr, excess_cagr_vs_spy,
+   vol_annualized, beta, beta_r2, calmar, max_drawdown, current_drawdown, var_5,
+   worst_day` + per-family statuses (`cagr_status, excess_cagr_status,
+   vol_status, beta_status, drawdown_status, distribution_status,
+   calmar_status`). Decimals → `_to_float`; dates → `str`.
+   Block shape: `{"metric_version": RISK_METRICS_VERSION, "basis_note":
+   "<fractions not percent; losses negative; price-return basis, not
+   total-return; non-ok status = do not treat as precise>", "windows": [...]}`.
+   `metric_version` is top-level (filtered, so shared by construction);
+   `as_of_date` rides each window. Returns `None` when **no rows** (never
+   computed — like `analyst_estimates`); thin-history instruments DO have rows
+   (flagged statuses) and pass through.
+3. Add `"risk_metrics": risk_metrics` to the returned context dict.
+
+### Prompts
+
+4. `_WRITER_SYSTEM`: add "recent realized-risk metrics (windowed, versioned,
+   quality-flagged; fractions not percent; losses negative; price-return basis)"
+   to the input list + a rule: use risk to support/contradict the long (deep max
+   drawdown / high beta / low Calmar / fat-tail var_5 = downside context);
+   respect status flags (do not cite a non-`ok` metric as precise;
+   `benchmark_missing` beta is absent, not 0); a CAGR is price-return (no
+   dividends) so don't over-read it for high-yield names; **when citing a risk
+   figure name all of `{window, as_of_date, metric_version}`** (Codex ckpt-1
+   HIGH — version is load-bearing for reproducibility).
+5. `_CRITIC_SYSTEM`: add risk metrics to the falsification kit — the critic
+   should raise realized-risk objections the memo ignored (e.g. "thesis ignores
+   a 52% peak-to-trough drawdown and beta 1.8 — the downside is larger than the
+   memo admits"), respecting the same status-flag + sign + version-citation
+   honesty.
+
+## Tests (`tests/test_thesis.py`)
+
+- `_assemble_context` includes a `risk_metrics` block with `metric_version` +
+  `as_of_date` + windows when `_current` rows exist (db-tier or mocked cursor).
+- Returns `None`/absent when no rows (thin-history instrument) — no fabricated
+  zeros.
+- Honest passthrough: a `partial_window` / `benchmark_missing` row carries its
+  status verbatim into the context.
+
+## Dev-verify
+
+Run `_assemble_context` (or `generate_thesis`) on AAPL on dev; confirm the
+`risk_metrics` block renders with `risk_v1`, an `as_of_date`, three windows, and
+beta_status etc. Record the figure + SHA in the PR.
+
+## Out of scope
+
+No schema/migration/job. No new risk math. No scoring change (#1633 gated). No
+total-return (#1635 deferred). Critic storage unchanged (`critic_json`, per
+settled-decisions).

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -15,7 +15,8 @@ Coverage:
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,6 +25,7 @@ from app.services.thesis import (
     ThesisResult,
     _call_critic,
     _call_writer,
+    _shape_risk_metrics,
     _to_float,
     _validate_critic_output,
     _validate_writer_output,
@@ -583,3 +585,105 @@ class TestGenerateThesis:
         assert result.base_value is None
         assert result.bull_value is None
         assert result.bear_value is None
+
+
+# ---------------------------------------------------------------------------
+# Risk-metrics context block (#1632) — pure row-shaping
+# ---------------------------------------------------------------------------
+
+# Column order mirrors the SELECT in _assemble_context (20 cols).
+#   0 window_key, 1 as_of_date, 2 benchmark_symbol,
+#   3 cagr, 4 excess_cagr_vs_spy, 5 vol_annualized, 6 beta, 7 beta_r2, 8 calmar,
+#   9 max_drawdown, 10 current_drawdown, 11 var_5, 12 worst_day,
+#   13 cagr_status, 14 excess_cagr_status, 15 vol_status, 16 beta_status,
+#   17 drawdown_status, 18 distribution_status, 19 calmar_status
+
+
+def _risk_row(
+    window_key: str = "1y",
+    as_of: date | None = date(2026, 6, 12),
+    *,
+    cagr: object = 0.46,
+    beta: object = 0.81,
+    max_dd: object = -0.14,
+    var_5: object = -0.02,
+    cagr_status: str | None = "ok",
+    beta_status: str | None = "ok",
+) -> tuple[object, ...]:
+    return (
+        window_key,
+        as_of,
+        "SPY",
+        cagr,
+        0.23,
+        0.24,
+        beta,
+        0.19,
+        3.36,
+        max_dd,
+        -0.075,
+        var_5,
+        -0.05,
+        cagr_status,
+        "ok",
+        "ok",
+        beta_status,
+        "ok",
+        "partial_window",
+        "ok",
+    )
+
+
+def _windows(out: dict[str, object] | None) -> list[Any]:
+    """Narrow the object-typed `windows` list for indexable test access."""
+    assert out is not None
+    windows = out["windows"]
+    assert isinstance(windows, list)
+    return windows
+
+
+class TestShapeRiskMetrics:
+    def test_no_rows_returns_none(self) -> None:
+        # Never-computed instrument — None, not an empty block, no fabricated data.
+        assert _shape_risk_metrics([], "risk_v1") is None
+
+    def test_shapes_windows_with_version_and_per_window_as_of(self) -> None:
+        out = _shape_risk_metrics(
+            [_risk_row("1y", date(2026, 6, 12)), _risk_row("3y", date(2026, 6, 11))],
+            "risk_v1",
+        )
+        assert out is not None
+        assert out["metric_version"] == "risk_v1"
+        assert "fractions" in str(out["basis_note"])
+        windows = _windows(out)
+        assert len(windows) == 2
+        # as_of_date rides each window (no shared-date assumption).
+        assert windows[0]["as_of_date"] == "2026-06-12"
+        assert windows[1]["as_of_date"] == "2026-06-11"
+        assert windows[0]["benchmark_symbol"] == "SPY"
+        assert windows[0]["beta"] == pytest.approx(0.81)
+
+    def test_signed_losses_preserved(self) -> None:
+        out = _shape_risk_metrics([_risk_row(max_dd=-0.52, var_5=-0.07)], "risk_v1")
+        w = _windows(out)[0]
+        # Losses stay negative — never abs()'d or flipped.
+        assert w["max_drawdown"] == pytest.approx(-0.52)
+        assert w["var_5"] == pytest.approx(-0.07)
+
+    def test_null_scalar_stays_none_not_zero(self) -> None:
+        # Thin-history: cagr NULL + flagged status. NULL must NOT become 0.
+        out = _shape_risk_metrics([_risk_row(cagr=None, cagr_status="partial_window")], "risk_v1")
+        w = _windows(out)[0]
+        assert w["cagr"] is None
+        assert w["cagr_status"] == "partial_window"
+
+    def test_flagged_status_passthrough(self) -> None:
+        # benchmark_missing beta passes through verbatim (absent, not zero).
+        out = _shape_risk_metrics([_risk_row(beta=None, beta_status="benchmark_missing")], "risk_v1")
+        w = _windows(out)[0]
+        assert w["beta"] is None
+        assert w["beta_status"] == "benchmark_missing"
+
+    def test_as_of_none_tolerated(self) -> None:
+        out = _shape_risk_metrics([_risk_row(as_of=None)], "risk_v1")
+        assert _windows(out)[0]["as_of_date"] is None


### PR DESCRIPTION
Closes #1632. Follows #591 (PR-B shipped the versioned `instrument_risk_metrics` table). Read-side only — no schema / migration / job.

## What
`app/services/thesis.py::_assemble_context` gains a `risk_metrics` block that feeds the persisted, versioned, quality-flagged `risk_v1` scalars into the writer + critic LLM prompts, so a long thesis is grounded in realized risk (drawdown / vol / beta / Calmar / tail) and the critic can attack it on downside-risk grounds.

- **`_shape_risk_metrics`** — pure row→dict helper (no DB; table-tested). One `LEFT JOIN instruments` SELECT of `instrument_risk_metrics_current` filtered to `RISK_METRICS_VERSION`, ordered by `WINDOW_KEYS` via `array_position`. Per-window `as_of_date` (no shared-date assumption — Codex ckpt-1). Honest-status passthrough: NULL scalars stay `None` (never a fabricated 0), flagged statuses (`insufficient_history` / `partial_window` / `benchmark_missing`) pass through verbatim. Returns `None` when no rows (never computed — like `analyst_estimates`); a thin-history instrument HAS rows carrying flags.
- **`basis_note` + prompt rules** — fractions not percent; drawdown / var_5 / worst_day are signed losses; **price-return** basis (TR deferred #1635, so don't over-read CAGR for high-yield names); cite `{window_key, as_of_date, metric_version}` for reproducibility.
- **Writer** uses risk to support/contradict the long; **critic** mines it for realized-risk objections (deep drawdown / high beta / low Calmar / fat-tail var_5) the memo glossed over.
- **Lazy import** of `RISK_METRICS_VERSION` / `WINDOW_KEYS` — `risk_metrics → scheduler → refresh_cascade → thesis` would cycle at module scope; function-level import breaks it and keeps the constants single-sourced (no magic-string dup).

## Source rule
Honest-status discipline + #591 risk-evidence contract (`docs/superpowers/specs/2026-06-14-instrument-risk-drill-design.md`): the risk row is the auditable evidence; a citation resolves to `{value, window_key, as_of_date, metric_version, status}`; never coerce NULL/flagged to a precise number. Settled-decisions preserved: thesis versioning + `critic_json` storage unchanged.

## Codex
- **ckpt-1** (spec): 6 findings folded — two distinct empty-states (no-rows vs thin-history-flagged), `metric_version` in the citation rule, per-window `as_of_date`, single-statement (no snapshot split), units/sign semantics, include excess columns.
- **ckpt-2** (branch): **no findings** (verified SELECT column-order ↔ positional reads, window ordering, lazy-import cycle break, single-statement join, honest passthrough).

## Verification
- `ruff` / `ruff format --check` / `pyright` clean · fast tier **4347 passed** + smoke **129 passed** · 6 pure `TestShapeRiskMetrics` cases (None-on-empty, per-window as_of, signed-loss preservation, NULL≠0, flagged passthrough).
- **Dev-verified** (`_assemble_context` on AAPL, live dev DB): `risk_metrics` renders with `risk_v1`, 3 windows, SPY benchmark, β 0.81 / 1.06 / 1.16 (matching `/risk-metrics`), `partial_window` cagr_status passed through honestly.

Spec: `docs/specs/thesis/2026-06-18-risk-evidence-ingestion.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)