### PR TITLE
feat(#1634): curated SIC→GICS-sector→SPDR crosswalk (substrate + display)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -65,6 +65,7 @@ from app.services.risk_metrics import (
     ols_beta,
     simple_returns,
 )
+from app.services.sector_classification import resolve_sector_spdr
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +153,13 @@ class InstrumentIdentity(BaseModel):
     display_name: str | None
     sector: str | None
     industry: str | None
+    # #1634: real GICS sector + its sector-SPDR, resolved on-read from the SEC
+    # SIC code (instruments.sector is an opaque 1-9 code). NULL when the
+    # instrument has no SIC (ETFs / non-filers) or its SIC has no confident
+    # mapping — never a guessed sector. Required-nullable (no default) to mirror
+    # the TS `string | null` exactly (Codex ckpt-2).
+    gics_sector: str | None
+    sector_spdr: str | None
     exchange: str | None
     country: str | None
     currency: str | None
@@ -3335,10 +3343,12 @@ def get_instrument_summary(
                    i.currency, i.sector, i.industry, i.country,
                    i.is_tradable, c.coverage_tier,
                    q.bid, q.ask, q.last,
+                   p.sic,
                    canonical.symbol AS canonical_symbol
             FROM instruments i
             LEFT JOIN coverage c USING (instrument_id)
             LEFT JOIN quotes q USING (instrument_id)
+            LEFT JOIN instrument_sec_profile p USING (instrument_id)
             LEFT JOIN instruments canonical
               ON canonical.instrument_id = i.canonical_instrument_id
             WHERE i.instrument_id = %(id)s AND UPPER(i.symbol) = %(symbol)s
@@ -3350,10 +3360,12 @@ def get_instrument_summary(
                    i.currency, i.sector, i.industry, i.country,
                    i.is_tradable, c.coverage_tier,
                    q.bid, q.ask, q.last,
+                   p.sic,
                    canonical.symbol AS canonical_symbol
             FROM instruments i
             LEFT JOIN coverage c USING (instrument_id)
             LEFT JOIN quotes q USING (instrument_id)
+            LEFT JOIN instrument_sec_profile p USING (instrument_id)
             LEFT JOIN instruments canonical
               ON canonical.instrument_id = i.canonical_instrument_id
             WHERE UPPER(i.symbol) = %(symbol)s
@@ -3370,11 +3382,16 @@ def get_instrument_summary(
 
     # Identity: local DB only. Fields the operator's universe sync
     # left null stay null — no third-party fill-in.
+    # #1634: resolve the real GICS sector + sector-SPDR from the SEC SIC
+    # (fail-closed None when no SIC / no confident mapping).
+    sector_cls = resolve_sector_spdr(row.get("sic"))  # type: ignore[arg-type]
     identity = InstrumentIdentity(
         symbol=row["symbol"],  # type: ignore[arg-type]
         display_name=row["company_name"] or None,  # type: ignore[arg-type]
         sector=row["sector"],  # type: ignore[arg-type]
         industry=row["industry"],  # type: ignore[arg-type]
+        gics_sector=sector_cls.gics_sector if sector_cls is not None else None,
+        sector_spdr=sector_cls.spdr_symbol if sector_cls is not None else None,
         exchange=row["exchange"],  # type: ignore[arg-type]
         country=row["country"],  # type: ignore[arg-type]
         currency=row["currency"],  # type: ignore[arg-type]

--- a/app/services/sector_classification.py
+++ b/app/services/sector_classification.py
@@ -1,0 +1,162 @@
+"""SIC → GICS-sector → sector-SPDR crosswalk (#1634).
+
+`instruments.sector` is an opaque 1–9 code with no GICS/SPDR meaning. The SEC's
+own SIC taxonomy (`instrument_sec_profile.sic`, 4-digit) is the real industry
+classification for operating filers. This module maps a SIC to one of the 11
+GICS sectors and its State-Street sector SPDR ETF (the benchmarks #591 PR-A
+ingested), re-enabling sector-relative views.
+
+Honest limitation: GICS is proprietary (MSCI/S&P) and NOT 1:1 with SIC, so this
+is a documented best-effort SIC→GICS approximation — never authoritative GICS.
+A SIC with no confident mapping, or an instrument with no SIC (ETFs, foreign
+non-filers), resolves to ``None`` (no sector view), never a guessed sector.
+
+Pure module — no DB, no I/O. The crosswalk is verified against the full SIC
+population in `tests/` + the dev scan recorded on the PR.
+
+Source: SEC SIC code list (4-digit division/major-group structure); SPDR/GICS
+11-sector definitions. Spec: docs/specs/metrics/2026-06-18-sic-gics-spdr-crosswalk.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The 11 sector SPDRs → their GICS sector name. Single source of truth; the
+# symbols are a subset of app.workers.scheduler.BENCHMARK_SYMBOLS (cross-checked
+# in tests, not imported here to keep this module dependency-free / cycle-free).
+SPDR_SECTORS: dict[str, str] = {
+    "XLB": "Materials",
+    "XLC": "Communication Services",
+    "XLE": "Energy",
+    "XLF": "Financials",
+    "XLI": "Industrials",
+    "XLK": "Information Technology",
+    "XLP": "Consumer Staples",
+    "XLRE": "Real Estate",
+    "XLU": "Utilities",
+    "XLV": "Health Care",
+    "XLY": "Consumer Discretionary",
+}
+
+
+@dataclass(frozen=True)
+class SectorClassification:
+    """A resolved sector for an instrument. ``gics_sector`` is the human label;
+    ``spdr_symbol`` is the sector-SPDR ETF benchmark."""
+
+    gics_sector: str
+    spdr_symbol: str
+
+
+# Ordered (lo, hi, spdr) SIC ranges, inclusive. **Override ranges first**, then
+# the enclosing major-group ranges — the resolver returns the FIRST match, so a
+# carve-out (e.g. 2834 pharma out of 28xx chemicals) must precede its parent.
+# Covers SIC 0100–8799; the bounds are GICS-driven (see the spec table). The
+# gics_sector label is derived from SPDR_SECTORS so the two never drift.
+#
+# Carve-outs are population-backed (the 389-SIC dev scan, full list in the spec)
+# — every range below corresponds to SIC codes actually present that the parent
+# major group would mis-route. Carve-outs MUST precede their enclosing major
+# group (first-match wins).
+_CROSSWALK: tuple[tuple[int, int, str], ...] = (
+    # --- GICS-driven carve-outs (most-specific first) ---
+    (2833, 2836, "XLV"),  # drugs / pharma / biologicals (out of 28xx chemicals)
+    (3570, 3579, "XLK"),  # computers & peripherals (out of 35xx machinery)
+    (3630, 3639, "XLY"),  # household appliances (out of 36xx electrical → cons. durables)
+    (3650, 3659, "XLY"),  # household audio/video equipment (out of 36xx)
+    (3660, 3679, "XLK"),  # comms equipment + semiconductors/components (out of 36xx)
+    (3710, 3716, "XLY"),  # autos & parts (out of 37xx transport equipment)
+    (3812, 3812, "XLI"),  # search/detection/nav/guidance = defense electronics (out of 38xx)
+    (3826, 3826, "XLV"),  # laboratory analytical instruments = life-sciences tools (out of 38xx)
+    (3840, 3851, "XLV"),  # surgical/medical/dental/x-ray/electromedical/ophthalmic devices
+    (3873, 3873, "XLY"),  # watches & clocks = consumer durables (out of 38xx)
+    (4950, 4959, "XLI"),  # sanitary / refuse / hazardous-waste services (out of 49xx utilities)
+    (5010, 5019, "XLY"),  # motor-vehicle wholesale (out of 50xx) → autos
+    (5045, 5045, "XLK"),  # computer & software wholesale (out of 50xx)
+    (5047, 5047, "XLV"),  # medical/dental/hospital-equipment wholesale (out of 50xx)
+    (5065, 5065, "XLK"),  # electronic-parts wholesale (out of 50xx)
+    (5122, 5122, "XLV"),  # drug wholesale (out of 51xx)
+    (5160, 5169, "XLB"),  # chemicals wholesale (out of 51xx)
+    (5171, 5172, "XLE"),  # petroleum wholesale (out of 51xx)
+    (5400, 5499, "XLP"),  # food & grocery retail (out of 52–59xx retail)
+    (6324, 6324, "XLV"),  # hospital/medical service plans = managed care (out of 63xx insurance)
+    (6500, 6599, "XLRE"),  # real estate
+    (6792, 6792, "XLE"),  # oil royalty traders (out of 67xx) → energy
+    (6795, 6795, "XLB"),  # mineral royalty traders (out of 67xx) → materials
+    (6798, 6798, "XLRE"),  # REITs (out of 67xx holding offices)
+    (7310, 7319, "XLC"),  # advertising (out of 73xx services)
+    (7370, 7379, "XLK"),  # software / data processing (out of 73xx services)
+    (8731, 8731, "XLV"),  # commercial biological research (out of 87xx)
+    # --- major groups ---
+    (100, 999, "XLP"),  # agriculture / fishing
+    (1000, 1099, "XLB"),  # metal mining
+    (1200, 1299, "XLE"),  # coal
+    (1300, 1399, "XLE"),  # oil & gas
+    (1400, 1499, "XLB"),  # nonmetallic mineral mining
+    (1500, 1799, "XLI"),  # construction
+    (2000, 2099, "XLP"),  # food
+    (2100, 2199, "XLP"),  # tobacco
+    (2200, 2399, "XLY"),  # textiles & apparel
+    (2400, 2499, "XLB"),  # lumber & wood
+    (2500, 2599, "XLY"),  # furniture
+    (2600, 2699, "XLB"),  # paper
+    (2700, 2799, "XLC"),  # printing & publishing (media)
+    (2800, 2899, "XLB"),  # chemicals (non-pharma)
+    (2900, 2999, "XLE"),  # petroleum refining
+    (3000, 3099, "XLB"),  # rubber & plastics
+    (3100, 3199, "XLY"),  # leather & footwear
+    (3200, 3399, "XLB"),  # stone/clay/glass, primary metal
+    (3400, 3499, "XLI"),  # fabricated metal
+    (3500, 3599, "XLI"),  # industrial machinery (non-computer)
+    (3600, 3699, "XLI"),  # electrical equipment (transformers/motors/lighting/misc) → Industrials
+    (3700, 3799, "XLI"),  # aerospace & other transport equip (autos carved out)
+    (3800, 3899, "XLK"),  # electronic/measuring instruments (medical carved to XLV above)
+    (3900, 3999, "XLY"),  # misc manufacturing
+    (4000, 4499, "XLI"),  # rail / transit / trucking / water transport
+    (4500, 4599, "XLI"),  # air transport
+    (4600, 4699, "XLE"),  # pipelines
+    (4700, 4799, "XLI"),  # transportation services
+    (4800, 4899, "XLC"),  # telephone / cable / broadcasting
+    (4900, 4999, "XLU"),  # electric / gas / water utilities (waste carved out)
+    (5000, 5099, "XLI"),  # durable-goods wholesale (distributors)
+    (5100, 5199, "XLP"),  # nondurable wholesale (food/drug plurality)
+    (5200, 5999, "XLY"),  # retail (food retail 54xx carved out above)
+    (6000, 6199, "XLF"),  # banks & credit
+    (6200, 6299, "XLF"),  # brokers / investment advice
+    (6300, 6399, "XLF"),  # insurance (managed-care 6324 carved out)
+    (6400, 6499, "XLF"),  # insurance agents
+    (6700, 6799, "XLF"),  # holding/investment offices (REIT/royalty carved out)
+    (7000, 7099, "XLY"),  # hotels
+    (7200, 7299, "XLY"),  # personal services
+    (7300, 7399, "XLI"),  # business services (software/advertising carved out)
+    (7500, 7699, "XLI"),  # auto repair/rental, repair services
+    (7800, 7899, "XLC"),  # motion pictures
+    (7900, 7999, "XLY"),  # amusement & recreation (leisure)
+    (8000, 8099, "XLV"),  # health services
+    (8100, 8199, "XLI"),  # legal services
+    (8200, 8299, "XLY"),  # educational services
+    (8300, 8399, "XLY"),  # social/child-care services
+    (8700, 8799, "XLI"),  # engineering / consulting (bio research 8731 carved out)
+)
+
+
+def resolve_sector_spdr(sic: str | int | None) -> SectorClassification | None:
+    """Map a 4-digit SIC to its sector SPDR, or ``None`` when unmappable.
+
+    Fail-closed: a missing / non-numeric / out-of-range SIC returns ``None``
+    (the instrument simply has no sector-relative view — never a guessed
+    sector). The first matching range wins, so carve-outs precede major groups.
+    """
+    if sic is None:
+        return None
+    try:
+        code = int(str(sic).strip())
+    except TypeError, ValueError:
+        return None
+    if code <= 0:
+        return None
+    for lo, hi, spdr in _CROSSWALK:
+        if lo <= code <= hi:
+            return SectorClassification(gics_sector=SPDR_SECTORS[spdr], spdr_symbol=spdr)
+    return None

--- a/docs/specs/metrics/2026-06-18-sic-gics-spdr-crosswalk.md
+++ b/docs/specs/metrics/2026-06-18-sic-gics-spdr-crosswalk.md
@@ -1,0 +1,185 @@
+# #1634 — curated SIC → GICS-sector → SPDR crosswalk (substrate + display)
+
+Status: spec. Follows #591 (cut sector-relative views: `instruments.sector` is an
+opaque 1–9 code). Operator scope (2026-06-18): **substrate + display**, pure
+read-path. Sector-relative beta in `risk_metrics` and real-sector peer-grouping
+are filed follow-ups (the former touches the shipped versioned evidence layer +
+needs a backfill).
+
+## Source rule
+
+- **`instruments.sector` (1–9) is unusable** — verified: SPY/XLE/XLF/XLK/JPM all
+  `4`, AAPL `3`, MSFT `8`; 3293 of 12546 tradable are NULL; `industry` is 100%
+  NULL. Not a GICS/SPDR crosswalk.
+- **The real classification is SEC SIC** on `instrument_sec_profile.sic` (+
+  `sic_description`). SIC is the SEC's own industry taxonomy assigned to every
+  operating filer (5249/12546 tradable have one; 389 distinct codes). SIC's
+  4-digit division/major-group structure is the documented, public mapping basis
+  (SEC SIC code list). ETFs/SPDRs and non-filers have **no SIC** (SPY/XLK/XLF
+  return NULL) — they are the sector *targets*, mapped by known ticker.
+- **The 11 sector SPDRs are GICS-based**, already ingested by #591 PR-A
+  (`BENCHMARK_SYMBOLS`): XLB Materials, XLC Communication Services, XLE Energy,
+  XLF Financials, XLI Industrials, XLK Information Technology, XLP Consumer
+  Staples, XLRE Real Estate, XLU Utilities, XLV Health Care, XLY Consumer
+  Discretionary.
+- **Honest limitation (caveat, not fabrication):** GICS is proprietary
+  (MSCI/S&P) and **not 1:1 with SIC** — the crosswalk is a documented best-effort
+  SIC→GICS-sector approximation, labelled as such, never presented as
+  authoritative GICS. Marginal groups (misc-electrical 369x, wholesale 50–51xx)
+  are assigned to their plurality GICS sector. A SIC with no confident mapping,
+  or an instrument with no SIC, resolves to **None** (no sector view — honest
+  gap, mirrors the #591 degrade), never a guessed sector.
+
+## Approach — deterministic SIC-range crosswalk (curated, fail-closed)
+
+`app/services/sector_classification.py`: an **ordered** list of SIC integer
+ranges → `(gics_sector, spdr_symbol)`, most-specific override ranges first, then
+major-group ranges. `resolve_sector_spdr(sic: str | None) -> SectorClassification
+| None` parses the 4-digit SIC, walks the ranges, returns the first match (or
+None). Pure, no DB. The SPDR symbols are referenced from a single constant set
+(no magic strings; cross-checked against `BENCHMARK_SYMBOLS`).
+
+### Codex ckpt-1 resolutions (population-backed, 2026-06-18)
+
+The first cut's major-group ranges swallowed SICs that belong to other GICS
+sectors. Refined against the full 389-SIC dev population — every flagged code now
+verified (re-scan: 0 unmapped, 26/26 flagged-code checks pass). The authoritative
+crosswalk is `_CROSSWALK` in `app/services/sector_classification.py`; the table
+below is the human summary. Carve-outs added:
+
+- **36xx** base → **XLI** (electrical equipment: transformers/motors/lighting/
+  misc are Industrials, not IT); carve 363x/365x → XLY (appliances / consumer
+  audio-video), 366x–367x → XLK (comms equipment, semis, components).
+- **38xx** base → **XLK** (electronic/measuring instruments); carve 3812 → XLI
+  (defense electronics), 3826 → XLV (life-sciences tools), 3840–3851 → XLV
+  (medical devices), 3873 → XLY (watches).
+- **49xx**: carve 4950–4959 → XLI (sanitary/refuse/hazardous-waste = Industrials).
+- **63xx**: narrowed the health carve-out to **6324 only** (managed care); 6321
+  accident/health insurance stays XLF.
+- **67xx**: carve 6792 → XLE (oil royalty) and 6795 → XLB (mineral royalty); 6770
+  blank-check/SPAC stays XLF.
+- **50–51xx wholesale**: carve product-specific distributors present in the
+  population — 5010–5019 → XLY (motor vehicle), 5045/5065 → XLK (computer/
+  electronic), 5047/5122 → XLV (medical/drug), 5160–5169 → XLB (chemicals),
+  5171–5172 → XLE (petroleum); durable base → XLI, nondurable base → XLP.
+- **Ordering**: 5400–5499 (grocery) is in the carve-out block ahead of the
+  5200–5999 retail major group (resolver is first-match; an order test pins it).
+- **LEFT JOIN**: the summary read LEFT-JOINs `instrument_sec_profile` so a no-SIC
+  instrument yields `gics_sector=None, sector_spdr=None`, never a dropped row.
+- **PR artifact**: the full `sic → spdr → count → description` table for all 389
+  codes is recorded as the verification record (not "operator eyeball" alone).
+
+Crosswalk summary (major group → SPDR; *override ranges resolve first*):
+
+| SIC range | GICS sector | SPDR | Note |
+|---|---|---|---|
+| 2833–2836 | Health Care | XLV | drugs/pharma/biologicals (carved out of 28xx chemicals) |
+| 3570–3579 | Information Technology | XLK | computers & peripherals (carved out of 35xx machinery) |
+| 3670–3679 | Information Technology | XLK | semiconductors & electronic components |
+| 3660–3669 | Information Technology | XLK | communications equipment |
+| 3710–3716 | Consumer Discretionary | XLY | autos & parts (carved out of 37xx transport equip) |
+| 6320–6329 | Health Care | XLV | hospital/medical service plans (health insurers — GICS) |
+| 6798 | Real Estate | XLRE | REITs (carved out of 67xx holding offices) |
+| 6500–6599 | Real Estate | XLRE | real estate |
+| 7370–7379 | Information Technology | XLK | software / data processing (carved out of 73xx services) |
+| 7310–7319 | Communication Services | XLC | advertising |
+| 8731 | Health Care | XLV | commercial biological research (carved out of 87xx) |
+| 0100–0999 | Consumer Staples | XLP | agriculture / fishing |
+| 1000–1099 | Materials | XLB | metal mining |
+| 1200–1299 | Energy | XLE | coal |
+| 1300–1399 | Energy | XLE | oil & gas |
+| 1400–1499 | Materials | XLB | nonmetallic mineral mining |
+| 1500–1799 | Industrials | XLI | construction |
+| 2000–2099 | Consumer Staples | XLP | food |
+| 2100–2199 | Consumer Staples | XLP | tobacco |
+| 2200–2399 | Consumer Discretionary | XLY | textiles & apparel |
+| 2400–2499 | Materials | XLB | lumber & wood |
+| 2500–2599 | Consumer Discretionary | XLY | furniture |
+| 2600–2699 | Materials | XLB | paper |
+| 2700–2799 | Communication Services | XLC | printing & publishing (media) |
+| 2800–2899 | Materials | XLB | chemicals (non-pharma) |
+| 2900–2999 | Energy | XLE | petroleum refining |
+| 3000–3099 | Materials | XLB | rubber & plastics |
+| 3100–3199 | Consumer Discretionary | XLY | leather & footwear |
+| 3200–3399 | Materials | XLB | stone/clay/glass, primary metal |
+| 3400–3499 | Industrials | XLI | fabricated metal |
+| 3500–3599 | Industrials | XLI | industrial machinery (non-computer) |
+| 3600–3699 | Information Technology | XLK | electronics (semis dominate; 369x misc-electrical accepted) |
+| 3700–3799 | Industrials | XLI | aerospace & other transport equip (autos overridden above) |
+| 3800–3899 | Health Care | XLV | instruments (medical devices dominate our pop.) |
+| 3900–3999 | Consumer Discretionary | XLY | misc manufacturing (sporting goods, toys) |
+| 4000–4499 | Industrials | XLI | rail / transit / trucking / water transport |
+| 4500–4599 | Industrials | XLI | air transport |
+| 4600–4699 | Energy | XLE | pipelines |
+| 4700–4799 | Industrials | XLI | transportation services |
+| 4800–4899 | Communication Services | XLC | telephone / cable / broadcasting |
+| 4900–4999 | Utilities | XLU | electric / gas / water utilities |
+| 5000–5099 | Industrials | XLI | durable-goods wholesale (distributors) |
+| 5100–5199 | Consumer Staples | XLP | nondurable wholesale (food/drug plurality) |
+| 5200–5999 | Consumer Discretionary | XLY | retail (food retail 54xx overridden below) |
+| 5400–5499 | Consumer Staples | XLP | food & grocery retail |
+| 6000–6199 | Financials | XLF | banks & credit |
+| 6200–6299 | Financials | XLF | brokers / investment advice |
+| 6300–6399 | Financials | XLF | insurance (health plans 632x overridden above) |
+| 6400–6499 | Financials | XLF | insurance agents |
+| 6700–6799 | Financials | XLF | holding/investment offices (REIT 6798 overridden above) |
+| 7000–7099 | Consumer Discretionary | XLY | hotels |
+| 7200–7299 | Consumer Discretionary | XLY | personal services |
+| 7300–7399 | Industrials | XLI | business services (software 737x / advertising 731x overridden above) |
+| 7500–7699 | Industrials | XLI | auto repair/rental, repair services |
+| 7800–7899 | Communication Services | XLC | motion pictures |
+| 7900–7999 | Consumer Discretionary | XLY | amusement & recreation (leisure) |
+| 8000–8099 | Health Care | XLV | health services |
+| 8100–8199 | Industrials | XLI | legal services |
+| 8200–8299 | Consumer Discretionary | XLY | educational services |
+| 8300–8399 | Consumer Discretionary | XLY | social/child-care services |
+| 8700–8799 | Industrials | XLI | engineering / consulting (bio research 8731 overridden above) |
+
+Note: `5400–5499` and the autos/REIT/pharma/software/advertising/health-plan
+overrides must be matched **before** their enclosing major-group range — the
+resolver tries override ranges first. The 5200–5999 retail range and the 5400
+carve-out coexist via order.
+
+**Full-population verification (mandatory):** a one-shot scan resolves every one
+of the 389 distinct SICs in the dev DB and prints `sic → spdr` for operator
+eyeball; the PR records that 100% of SIC-bearing tradable instruments resolve to
+exactly one SPDR (or an explicit, justified None), and spot-checks the panel
+(AAPL 3571→XLK, MSFT 7372→XLK, JPM 6021→XLF, a REIT 6798→XLRE, pharma 2834→XLV,
+an oil name 1311→XLE).
+
+## Exposure (display consumer — avoids dead code)
+
+`app/api/instruments.py` summary endpoint (`InstrumentIdentity` / the summary
+read): add `gics_sector: str | None` and `sector_spdr: str | None`, resolved
+on-read by joining `instrument_sec_profile.sic` through
+`resolve_sector_spdr`. Pure read-path — no migration, no stored column, no
+backfill. `instruments.sector` (the 1–9 code) is left untouched (peer-grouping
+still uses it; real-sector peer-grouping is a filed follow-up).
+
+Frontend: render the real `gics_sector` (+ a small "sector: XLK" affordance) on
+the instrument page where the opaque code is shown today
+(`summary.identity.sector` → show `gics_sector` when present, fall back to the
+code). `types.ts` mirrors the two new fields.
+
+## Tests
+
+`tests/test_sector_classification.py` (pure): panel mappings; each of the
+override carve-outs (pharma/computers/semis/autos/REIT/software/advertising/
+health-plan/bio-research); None for no-SIC and for an out-of-range/blank SIC;
+every SPDR returned is in the SPDR constant set; a representative SIC from each
+major group resolves to the spec's sector.
+
+## Dev-verify
+
+Run the full-population scan (389 SICs) on dev; hit
+`/instruments/{AAPL,JPM,O,XOM,PFE}/summary` and confirm `gics_sector` +
+`sector_spdr` render (XLK/XLF/XLRE/XLE/XLV). Record in the PR.
+
+## Out of scope (filed follow-ups)
+
+- Sector-relative beta/excess in `instrument_risk_metrics` (2nd benchmark →
+  columns + metric_version + backfill).
+- Real-sector peer-grouping (rankings / RightRail / instruments filter currently
+  group on the 1–9 code).
+- A `sector_spdr` from a true GICS feed (would need a licensed vendor — out of
+  the eToro+SEC posture, same class as #1635's dividend-source decision).

--- a/docs/specs/metrics/2026-06-18-sic-gics-spdr-crosswalk.md
+++ b/docs/specs/metrics/2026-06-18-sic-gics-spdr-crosswalk.md
@@ -34,7 +34,7 @@ needs a backfill).
 
 `app/services/sector_classification.py`: an **ordered** list of SIC integer
 ranges → `(gics_sector, spdr_symbol)`, most-specific override ranges first, then
-major-group ranges. `resolve_sector_spdr(sic: str | None) -> SectorClassification
+major-group ranges. `resolve_sector_spdr(sic: str | int | None) -> SectorClassification
 | None` parses the 4-digit SIC, walks the ranges, returns the first match (or
 None). Pure, no DB. The SPDR symbols are referenced from a single constant set
 (no magic strings; cross-checked against `BENCHMARK_SYMBOLS`).
@@ -71,74 +71,19 @@ below is the human summary. Carve-outs added:
 
 Crosswalk summary (major group → SPDR; *override ranges resolve first*):
 
-| SIC range | GICS sector | SPDR | Note |
-|---|---|---|---|
-| 2833–2836 | Health Care | XLV | drugs/pharma/biologicals (carved out of 28xx chemicals) |
-| 3570–3579 | Information Technology | XLK | computers & peripherals (carved out of 35xx machinery) |
-| 3670–3679 | Information Technology | XLK | semiconductors & electronic components |
-| 3660–3669 | Information Technology | XLK | communications equipment |
-| 3710–3716 | Consumer Discretionary | XLY | autos & parts (carved out of 37xx transport equip) |
-| 6320–6329 | Health Care | XLV | hospital/medical service plans (health insurers — GICS) |
-| 6798 | Real Estate | XLRE | REITs (carved out of 67xx holding offices) |
-| 6500–6599 | Real Estate | XLRE | real estate |
-| 7370–7379 | Information Technology | XLK | software / data processing (carved out of 73xx services) |
-| 7310–7319 | Communication Services | XLC | advertising |
-| 8731 | Health Care | XLV | commercial biological research (carved out of 87xx) |
-| 0100–0999 | Consumer Staples | XLP | agriculture / fishing |
-| 1000–1099 | Materials | XLB | metal mining |
-| 1200–1299 | Energy | XLE | coal |
-| 1300–1399 | Energy | XLE | oil & gas |
-| 1400–1499 | Materials | XLB | nonmetallic mineral mining |
-| 1500–1799 | Industrials | XLI | construction |
-| 2000–2099 | Consumer Staples | XLP | food |
-| 2100–2199 | Consumer Staples | XLP | tobacco |
-| 2200–2399 | Consumer Discretionary | XLY | textiles & apparel |
-| 2400–2499 | Materials | XLB | lumber & wood |
-| 2500–2599 | Consumer Discretionary | XLY | furniture |
-| 2600–2699 | Materials | XLB | paper |
-| 2700–2799 | Communication Services | XLC | printing & publishing (media) |
-| 2800–2899 | Materials | XLB | chemicals (non-pharma) |
-| 2900–2999 | Energy | XLE | petroleum refining |
-| 3000–3099 | Materials | XLB | rubber & plastics |
-| 3100–3199 | Consumer Discretionary | XLY | leather & footwear |
-| 3200–3399 | Materials | XLB | stone/clay/glass, primary metal |
-| 3400–3499 | Industrials | XLI | fabricated metal |
-| 3500–3599 | Industrials | XLI | industrial machinery (non-computer) |
-| 3600–3699 | Information Technology | XLK | electronics (semis dominate; 369x misc-electrical accepted) |
-| 3700–3799 | Industrials | XLI | aerospace & other transport equip (autos overridden above) |
-| 3800–3899 | Health Care | XLV | instruments (medical devices dominate our pop.) |
-| 3900–3999 | Consumer Discretionary | XLY | misc manufacturing (sporting goods, toys) |
-| 4000–4499 | Industrials | XLI | rail / transit / trucking / water transport |
-| 4500–4599 | Industrials | XLI | air transport |
-| 4600–4699 | Energy | XLE | pipelines |
-| 4700–4799 | Industrials | XLI | transportation services |
-| 4800–4899 | Communication Services | XLC | telephone / cable / broadcasting |
-| 4900–4999 | Utilities | XLU | electric / gas / water utilities |
-| 5000–5099 | Industrials | XLI | durable-goods wholesale (distributors) |
-| 5100–5199 | Consumer Staples | XLP | nondurable wholesale (food/drug plurality) |
-| 5200–5999 | Consumer Discretionary | XLY | retail (food retail 54xx overridden below) |
-| 5400–5499 | Consumer Staples | XLP | food & grocery retail |
-| 6000–6199 | Financials | XLF | banks & credit |
-| 6200–6299 | Financials | XLF | brokers / investment advice |
-| 6300–6399 | Financials | XLF | insurance (health plans 632x overridden above) |
-| 6400–6499 | Financials | XLF | insurance agents |
-| 6700–6799 | Financials | XLF | holding/investment offices (REIT 6798 overridden above) |
-| 7000–7099 | Consumer Discretionary | XLY | hotels |
-| 7200–7299 | Consumer Discretionary | XLY | personal services |
-| 7300–7399 | Industrials | XLI | business services (software 737x / advertising 731x overridden above) |
-| 7500–7699 | Industrials | XLI | auto repair/rental, repair services |
-| 7800–7899 | Communication Services | XLC | motion pictures |
-| 7900–7999 | Consumer Discretionary | XLY | amusement & recreation (leisure) |
-| 8000–8099 | Health Care | XLV | health services |
-| 8100–8199 | Industrials | XLI | legal services |
-| 8200–8299 | Consumer Discretionary | XLY | educational services |
-| 8300–8399 | Consumer Discretionary | XLY | social/child-care services |
-| 8700–8799 | Industrials | XLI | engineering / consulting (bio research 8731 overridden above) |
-
-Note: `5400–5499` and the autos/REIT/pharma/software/advertising/health-plan
-overrides must be matched **before** their enclosing major-group range — the
-resolver tries override ranges first. The 5200–5999 retail range and the 5400
-carve-out coexist via order.
+**The code `_CROSSWALK` in `app/services/sector_classification.py` is
+authoritative — this doc is not a second copy of it** (avoids spec-vs-code
+drift; review WARNING). The carve-out summary in "Codex ckpt-1 resolutions"
+above describes the GICS-driven overrides; the major-group bases are: agriculture
+0xx→XLP, mining/metals/chemicals/paper→XLB, oil&gas/coal/petroleum/pipelines→XLE,
+construction/machinery/**electrical-equipment 36xx**/transport-equip/fabricated-
+metal/transport-services→XLI, **electronic & measuring instruments 38xx→XLK**
+(medical devices carved to XLV), food/tobacco→XLP, textiles/apparel/furniture/
+leather/retail/hotels/leisure/education→XLY, publishing/telecom/broadcast/motion-
+pictures→XLC, utilities 49xx→XLU, banks/brokers/**insurance 63xx→XLF** (managed-
+care 6324 carved to XLV), real-estate 65xx + REIT 6798→XLRE, health-services
+80xx→XLV. Every range and its order is in `_CROSSWALK`; carve-outs precede their
+major group (first match wins), pinned by `tests/test_sector_classification.py`.
 
 **Full-population verification (mandatory):** a one-shot scan resolves every one
 of the 389 distinct SICs in the dev DB and prints `sic → spdr` for operator

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -260,6 +260,11 @@ export interface InstrumentIdentity {
   display_name: string | null;
   sector: string | null;
   industry: string | null;
+  /** #1634: real GICS sector + its sector-SPDR, resolved from the SEC SIC
+   * (the bare `sector` is an opaque 1-9 code). null when the instrument has
+   * no SIC (ETFs / non-filers) or no confident mapping. */
+  gics_sector: string | null;
+  sector_spdr: string | null;
   exchange: string | null;
   country: string | null;
   currency: string | null;

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -28,6 +28,8 @@ function summary(overrides: Partial<InstrumentSummary> = {}): InstrumentSummary 
       display_name: "Apple Inc.",
       sector: "Technology",
       industry: "Consumer Electronics",
+      gics_sector: null,
+      sector_spdr: null,
       exchange: "NMS",
       country: "United States",
       currency: "USD",
@@ -149,6 +151,29 @@ describe("SummaryStrip — action gating", () => {
     expect(screen.getByText("AAPL")).toBeInTheDocument();
     expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
     expect(screen.getByText(/Technology/)).toBeInTheDocument();
+  });
+
+  it("prefers the real GICS sector + SPDR over the opaque sector code (#1634)", () => {
+    render(
+      <SummaryStrip
+        summary={summary({
+          identity: {
+            ...summary().identity,
+            sector: "3",
+            gics_sector: "Information Technology",
+            sector_spdr: "XLK",
+          },
+        })}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(
+      screen.getByText(/Information Technology \(XLK\)/),
+    ).toBeInTheDocument();
+    // The opaque code is not surfaced when a real sector resolves.
+    expect(screen.queryByText(/^3 ·/)).not.toBeInTheDocument();
   });
 
   it("hides Close when not held", () => {

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -178,9 +178,13 @@ export function SummaryStrip({
         ) : null}
       </div>
 
-      {/* Row 2: sector strip */}
+      {/* Row 2: sector strip. Prefer the real GICS sector (#1634, resolved from
+          the SEC SIC) over the opaque 1-9 `sector` code; show its sector-SPDR. */}
       <div className="mt-1 text-xs text-slate-500">
-        {identity.sector ?? "—"}
+        {identity.gics_sector ?? identity.sector ?? "—"}
+        {identity.gics_sector && identity.sector_spdr
+          ? ` (${identity.sector_spdr})`
+          : ""}
         {identity.industry ? ` · ${identity.industry}` : ""}
         {identity.exchange ? ` · ${identity.exchange}` : ""}
         {identity.country ? ` · ${identity.country}` : ""}

--- a/tests/test_sector_classification.py
+++ b/tests/test_sector_classification.py
@@ -1,0 +1,106 @@
+"""Pure tests for the SIC → GICS-sector → SPDR crosswalk (#1634).
+
+No DB. The full 389-SIC dev population is verified out-of-band (recorded on the
+PR); here we pin the panel, every GICS-driven carve-out, fail-closed handling,
+the override-before-major-group ordering, and the SPDR/SPDR_SECTORS invariants.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.sector_classification import (
+    _CROSSWALK,
+    SPDR_SECTORS,
+    resolve_sector_spdr,
+)
+from app.workers.scheduler import BENCHMARK_SYMBOLS
+
+
+def _spdr(sic: str) -> str | None:
+    out = resolve_sector_spdr(sic)
+    return out.spdr_symbol if out is not None else None
+
+
+class TestPanel:
+    @pytest.mark.parametrize(
+        ("sic", "spdr"),
+        [
+            ("3571", "XLK"),  # AAPL — electronic computers
+            ("7372", "XLK"),  # MSFT — prepackaged software
+            ("6021", "XLF"),  # JPM — national commercial banks
+            ("6798", "XLRE"),  # a REIT (Realty Income)
+            ("2834", "XLV"),  # PFE — pharmaceutical preparations
+            ("1311", "XLE"),  # XOM-like — crude petroleum & natural gas
+            ("4911", "XLU"),  # an electric utility
+        ],
+    )
+    def test_panel(self, sic: str, spdr: str) -> None:
+        assert _spdr(sic) == spdr
+
+
+class TestCarveOuts:
+    """Every GICS-driven carve-out must beat its enclosing major group."""
+
+    @pytest.mark.parametrize(
+        ("sic", "spdr"),
+        [
+            ("2834", "XLV"),  # pharma out of 28xx chemicals (chemicals→XLB)
+            ("3571", "XLK"),  # computers out of 35xx machinery (→XLI)
+            ("3674", "XLK"),  # semiconductors out of 36xx (base→XLI)
+            ("3634", "XLY"),  # household appliances out of 36xx → cons. disc.
+            ("3651", "XLY"),  # consumer audio/video out of 36xx
+            ("3690", "XLI"),  # misc electrical machinery stays Industrials
+            ("3711", "XLY"),  # autos out of 37xx (aerospace→XLI)
+            ("3721", "XLI"),  # aircraft stays Industrials
+            ("3812", "XLI"),  # defense electronics out of 38xx (base→XLK)
+            ("3826", "XLV"),  # life-sciences tools out of 38xx
+            ("3841", "XLV"),  # surgical/medical devices
+            ("3873", "XLY"),  # watches out of 38xx
+            ("4953", "XLI"),  # refuse/waste out of 49xx utilities (→XLU)
+            ("6324", "XLV"),  # managed care out of 63xx insurance (→XLF)
+            ("6321", "XLF"),  # accident/health insurance stays Financials
+            ("6792", "XLE"),  # oil royalty out of 67xx (→XLF)
+            ("6795", "XLB"),  # mineral royalty out of 67xx
+            ("6770", "XLF"),  # blank-check/SPAC stays Financials
+            ("5045", "XLK"),  # computer wholesale out of 50xx (→XLI)
+            ("5122", "XLV"),  # drug wholesale out of 51xx (→XLP)
+            ("5172", "XLE"),  # petroleum wholesale out of 51xx
+            ("5411", "XLP"),  # grocery retail out of 52-59xx retail (→XLY)
+            ("5961", "XLY"),  # catalog retail stays Consumer Discretionary
+            ("7372", "XLK"),  # software out of 73xx services (→XLI)
+            ("7311", "XLC"),  # advertising out of 73xx
+            ("8731", "XLV"),  # commercial biological research out of 87xx (→XLI)
+        ],
+    )
+    def test_carve_out(self, sic: str, spdr: str) -> None:
+        assert _spdr(sic) == spdr
+
+
+class TestFailClosed:
+    @pytest.mark.parametrize("sic", [None, "", "  ", "abc", "0", "0000", "9999", "9100"])
+    def test_unmappable_is_none(self, sic: str | None) -> None:
+        # No SIC, blank, non-numeric, or out-of-mapped-range → None (never guessed).
+        assert resolve_sector_spdr(sic) is None
+
+    def test_int_input_accepted(self) -> None:
+        assert _spdr("2834") == _spdr(2834) == "XLV"  # type: ignore[arg-type]
+
+
+class TestInvariants:
+    def test_every_spdr_in_benchmark_universe(self) -> None:
+        # The 11 sector SPDRs we map to must be the candle-ingested benchmarks.
+        assert set(SPDR_SECTORS) <= BENCHMARK_SYMBOLS
+
+    def test_crosswalk_spdrs_are_known(self) -> None:
+        for _lo, _hi, spdr in _CROSSWALK:
+            assert spdr in SPDR_SECTORS
+
+    def test_ranges_are_well_formed(self) -> None:
+        for lo, hi, _spdr_ in _CROSSWALK:
+            assert lo <= hi
+
+    def test_resolved_gics_label_matches_spdr(self) -> None:
+        out = resolve_sector_spdr("3841")
+        assert out is not None
+        assert out.gics_sector == SPDR_SECTORS[out.spdr_symbol] == "Health Care"


### PR DESCRIPTION
Closes #1634. Follows #591 (which cut sector-relative views because `instruments.sector` is an opaque 1–9 code). Operator scope (2026-06-18): **substrate + display**, pure read-path.

## What
`instruments.sector` is junk (SPY/XLE/XLF/XLK/JPM all `4`; AAPL `3`, MSFT `8`). The real classification is **SEC SIC** (`instrument_sec_profile.sic`). This adds a deterministic, fail-closed **SIC-range → GICS-sector → sector-SPDR** crosswalk and exposes the real sector on the instrument summary. **No migration, no backfill, no job** — the SIC is resolved on-read.

- **`app/services/sector_classification.py`** — `_CROSSWALK` (ordered SIC ranges; carve-outs resolve before their major group) + `resolve_sector_spdr()`; `SPDR_SECTORS` is the single source of truth and a subset of `BENCHMARK_SYMBOLS` (#591 PR-A). Population-backed carve-outs (every SIC the parent major group would mis-route): pharma 283x→XLV, computers 357x→XLK, semis/components 366x-367x→XLK, appliances 363x / audio 365x→XLY, autos 371x→XLY, defense 3812→XLI, life-sciences-tools 3826 + medical-devices 384x→XLV, watches 3873→XLY, waste 495x→XLI, managed-care **6324**→XLV (6321 accident/health stays XLF), oil/mineral royalty 6792→XLE / 6795→XLB, REIT 6798→XLRE, product-specific wholesale (5045/5065→XLK, 5047/5122→XLV, 516x→XLB, 517x→XLE, 501x→XLY), software 737x→XLK / advertising 731x→XLC, grocery 54xx→XLP, bio-research 8731→XLV.
- **`app/api/instruments.py`** — `InstrumentIdentity` gains `gics_sector` + `sector_spdr`, resolved via `LEFT JOIN instrument_sec_profile` (fail-closed `None` for no-SIC ETFs/non-filers). Required-nullable to mirror the TS exactly.
- **Frontend** — `SummaryStrip` prefers the real GICS sector `"Information Technology (XLK)"` over the opaque code; `types.ts` mirror. (Peer-grouping still uses the code — real-sector peer-grouping is a filed follow-up.)

## Source rule / honest limitation
SIC is the SEC's own taxonomy (the only structured industry data we hold; yfinance/FMP retired). GICS is proprietary (MSCI/S&P) and **not 1:1 with SIC**, so this is a documented best-effort SIC→GICS approximation — never authoritative GICS; an unmappable SIC or a no-SIC instrument resolves to `None`, never a guessed sector.

## Codex
- **ckpt-1** (spec): 9 findings folded — the first-cut major-group ranges swallowed SICs belonging to other sectors; refined with **population-backed carve-outs** for 36xx/38xx/49xx/63xx/67xx/50-51xx, narrowed the health carve to 6324-only, LEFT JOIN, override ordering, full-artifact requirement.
- **ckpt-2** (branch): 1 finding — `gics_sector`/`sector_spdr` had `= None` defaults (optional in OpenAPI) vs the required-nullable TS mirror; dropped the defaults.

## Verification — full population, not a sample
- **Full 389-SIC dev scan: 0 unmapped** (every SIC-bearing tradable instrument resolves to exactly one SPDR); **26/26 previously-flagged codes verified** (6321→XLF vs 6324→XLV, 3690→XLI, 3826→XLV, 6792→XLE, 4953→XLI, …). By-SPDR distribution (SICs / instruments): XLV 25/995, XLF 27/898, XLI 108/846, XLK 32/758, XLY 64/536, XLB 53/359, XLRE 8/242, XLP 31/167, XLC 20/161, XLE 12/159, XLU 9/128.
- 46 pure tests (panel, every carve-out, fail-closed, ordering, SPDR⊆BENCHMARK_SYMBOLS invariant) · fast tier **4393** + smoke **129** + FE **1058** + dark-gate green.
- **Dev summary endpoint:** AAPL→IT/XLK, JPM→Financials/XLF, **O→Real Estate/XLRE** (JPM and O both had the junk code `4`), XOM→Energy/XLE, PFE→Health Care/XLV, SPY(ETF)→None/None.

Spec: `docs/specs/metrics/2026-06-18-sic-gics-spdr-crosswalk.md`.

## Follow-ups (filed separately, out of scope)
- Sector-relative beta/excess in `instrument_risk_metrics` (2nd benchmark → columns + metric_version + backfill).
- Real-sector peer-grouping (rankings / RightRail / instruments filter currently group on the 1–9 code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)