### PR TITLE
feat(#1636): position-vs-portfolio risk — marginal risk contribution

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -57,6 +57,10 @@ from app.services.operators import (
     NoOperatorError,
     sole_operator_id,
 )
+from app.services.portfolio_risk import (
+    PortfolioRiskStatus,
+    compute_portfolio_relative_risk,
+)
 from app.services.risk_metrics import (
     RISK_METRICS_VERSION,
     annualized_vol,
@@ -5091,6 +5095,38 @@ class InstrumentRiskMetrics(BaseModel):
     series: RiskSeries | None
 
 
+class PortfolioRelativeRiskResponse(BaseModel):
+    """Response shape for GET /instruments/{symbol}/portfolio-risk (#1636).
+
+    The candidate's risk relative to the operator's CURRENT book — a
+    current-exposure covariance estimate (today's weights over past returns), NOT
+    realized book history. Every scalar is nullable; ``status`` carries the
+    degraded cases (``empty_book`` / ``book_history_unavailable`` /
+    ``single_holding_is_candidate`` / ``insufficient_history``). NULLs are never
+    coerced to 0.
+
+    - ``portfolio_beta`` = cov(candidate, book) / var(book): >1 amplifies book
+      risk, <1 dampens, <0 hedges.
+    - ``marginal_risk_contribution`` = portfolio_beta × portfolio_vol: the
+      candidate's annualized risk per unit weight at the margin (a small add
+      funded pro-rata from the book reduces per-unit risk iff this < portfolio_vol).
+    All return/vol figures are fractions; vols are annualized.
+    """
+
+    symbol: str
+    as_of_date: date | None
+    status: PortfolioRiskStatus
+    holdings_count: int
+    already_held: bool
+    current_weight: Decimal | None
+    portfolio_beta: Decimal | None
+    correlation: Decimal | None
+    candidate_vol: Decimal | None
+    portfolio_vol: Decimal | None
+    marginal_risk_contribution: Decimal | None
+    n_obs: int
+
+
 # Display-series tuning. The rolling-vol window is in RETURNS (≈ trading days).
 _ROLLING_VOL_WINDOW = 30
 _HISTOGRAM_BINS = 30
@@ -5337,4 +5373,57 @@ def get_instrument_risk_metrics(
         metric_version=RISK_METRICS_VERSION,
         windows=windows,
         series=series,
+    )
+
+
+@router.get("/{symbol}/portfolio-risk", response_model=PortfolioRelativeRiskResponse)
+def get_instrument_portfolio_risk(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> PortfolioRelativeRiskResponse:
+    """Candidate-vs-current-book risk (#1636) — marginal risk contribution.
+
+    How much the candidate moves the operator's existing book's risk: portfolio
+    beta / correlation / marginal-risk-contribution vs the current holdings.
+    ON-READ (the book is dynamic) — a current-exposure covariance estimate, not
+    realized book history. 404 for an unknown symbol; 200 with
+    ``status="empty_book"`` when the operator holds nothing.
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    result = compute_portfolio_relative_risk(
+        conn,
+        int(row["instrument_id"]),  # type: ignore[arg-type]
+        str(row["symbol"]),  # type: ignore[arg-type]
+        date.today(),
+    )
+    return PortfolioRelativeRiskResponse(
+        symbol=result.symbol,
+        as_of_date=result.as_of_date,
+        status=result.status,
+        holdings_count=result.holdings_count,
+        already_held=result.already_held,
+        current_weight=result.current_weight,
+        portfolio_beta=result.portfolio_beta,
+        correlation=result.correlation,
+        candidate_vol=result.candidate_vol,
+        portfolio_vol=result.portfolio_vol,
+        marginal_risk_contribution=result.marginal_risk_contribution,
+        n_obs=result.n_obs,
     )

--- a/app/services/portfolio_risk.py
+++ b/app/services/portfolio_risk.py
@@ -1,0 +1,243 @@
+"""Position-vs-portfolio risk — marginal risk contribution (#1636).
+
+The single-instrument risk layer (#591) measures a name in isolation (β vs SPY).
+This answers the PM's sizing question instead: *how much does a candidate move my
+existing book's risk?* — covariance vs the current holdings.
+
+ON-READ, NOT persisted: the book is dynamic (weights change with every fill), so
+a versioned evidence row would be stale immediately. Reuses the risk_metrics
+primitives (no new estimator math).
+
+**Convention (read the caveat):** the portfolio return series is **today's
+market-value weights applied to past returns** — a *current-exposure covariance
+estimate*, NOT the book's realized historical return. MCR's marginal
+interpretation assumes a small add funded pro-rata from the book.
+
+Source: Markowitz portfolio risk; standard MCR/component decomposition
+(`∂σ_p/∂w_i = (Σw)_i/σ_p`). Spec:
+docs/specs/metrics/2026-06-18-position-vs-portfolio-risk.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+
+from app.db.snapshot import snapshot_read
+from app.services.portfolio import _load_positions
+from app.services.risk_metrics import (
+    MIN_RETURNS_VOL_BETA,
+    ReturnPoint,
+    annualized_vol,
+    load_close_series,
+    ols_beta,
+    simple_returns,
+)
+
+_ZERO = Decimal("0")
+_ONE = Decimal("1")
+
+PortfolioRiskStatus = Literal[
+    "ok",
+    "empty_book",
+    "book_history_unavailable",
+    "insufficient_history",
+    "single_holding_is_candidate",
+]
+
+
+@dataclass(frozen=True)
+class PortfolioRelativeRisk:
+    """Candidate-vs-current-book risk. Every scalar is nullable + status-flagged;
+    a degraded book yields a flagging status, never a fabricated zero."""
+
+    symbol: str
+    as_of_date: date | None
+    status: PortfolioRiskStatus
+    holdings_count: int
+    already_held: bool
+    current_weight: Decimal | None
+    portfolio_beta: Decimal | None
+    correlation: Decimal | None
+    candidate_vol: Decimal | None
+    portfolio_vol: Decimal | None
+    marginal_risk_contribution: Decimal | None
+    n_obs: int
+
+
+# ---------------------------------------------------------------------------
+# Pure math (no DB — table-tested against synthetic series)
+# ---------------------------------------------------------------------------
+
+
+def build_portfolio_returns(
+    holdings: list[tuple[Decimal, dict[date, Decimal]]],
+) -> list[ReturnPoint]:
+    """Current-weight portfolio return series over the date window where ALL
+    holdings have a return (the common intersection — so the weighted sum always
+    spans the same asset set). ``holdings`` = ``(market_value, {date: return})``;
+    weights are normalised by total market value. Empty when there are no
+    holdings, total weight is 0, or the histories don't overlap.
+    """
+    if not holdings:
+        return []
+    total_w = sum((w for w, _ in holdings), _ZERO)
+    if total_w <= _ZERO:
+        return []
+    date_sets = [set(m) for _, m in holdings]
+    common = sorted(set.intersection(*date_sets)) if date_sets else []
+    out: list[ReturnPoint] = []
+    for d in common:
+        r = sum((w / total_w * m[d] for w, m in holdings), _ZERO)
+        out.append((d, r))
+    return out
+
+
+@dataclass(frozen=True)
+class _RelMetrics:
+    beta: Decimal | None
+    correlation: Decimal | None
+    candidate_vol: Decimal | None
+    portfolio_vol: Decimal | None
+    n_obs: int
+    last_date: date | None
+
+
+def relative_risk_metrics(
+    candidate_returns: list[ReturnPoint],
+    portfolio_returns: list[ReturnPoint],
+) -> _RelMetrics:
+    """β / correlation / vols over the SHARED candidate∩portfolio date window.
+
+    σ_p, σ_c and β all use the same intersection so ``MCR = β·σ_p`` is
+    self-consistent (Codex ckpt-1). correlation = ``sign(β)·√r²`` — ``None`` (never
+    0) when β / r² is null.
+    """
+    c_map = dict(candidate_returns)
+    p_map = dict(portfolio_returns)
+    shared = sorted(set(c_map) & set(p_map))
+    n = len(shared)
+    last = shared[-1] if shared else None
+    if n < 2:
+        return _RelMetrics(None, None, None, None, n, last)
+    aligned_c = [(d, c_map[d]) for d in shared]
+    aligned_p = [(d, p_map[d]) for d in shared]
+    fit = ols_beta(aligned_c, aligned_p)
+    corr: Decimal | None = None
+    if fit.beta is not None and fit.r2 is not None:
+        corr = (_ONE if fit.beta >= _ZERO else -_ONE) * fit.r2.sqrt()
+    cvol = annualized_vol([c_map[d] for d in shared])
+    pvol = annualized_vol([p_map[d] for d in shared])
+    return _RelMetrics(fit.beta, corr, cvol, pvol, n, last)
+
+
+def marginal_risk_contribution(beta: Decimal | None, portfolio_vol: Decimal | None) -> Decimal | None:
+    """MCR = β·σ_p (annualized). None when either input is null — never 0."""
+    if beta is None or portfolio_vol is None:
+        return None
+    return beta * portfolio_vol
+
+
+# ---------------------------------------------------------------------------
+# DB orchestration
+# ---------------------------------------------------------------------------
+
+
+def compute_portfolio_relative_risk(
+    conn: psycopg.Connection[Any],
+    candidate_instrument_id: int,
+    symbol: str,
+    end_date: date,
+) -> PortfolioRelativeRisk:
+    """Compute the candidate's risk relative to the current book. Always returns
+    a payload — the status field carries the degraded cases (empty book, no book
+    history, single-holding-is-candidate, thin overlap)."""
+
+    def _degraded(
+        status: PortfolioRiskStatus,
+        holdings_count: int,
+        held: bool,
+        weight: Decimal | None = None,
+    ) -> PortfolioRelativeRisk:
+        return PortfolioRelativeRisk(
+            symbol=symbol,
+            as_of_date=None,
+            status=status,
+            holdings_count=holdings_count,
+            already_held=held,
+            current_weight=weight,
+            portfolio_beta=None,
+            correlation=None,
+            candidate_vol=None,
+            portfolio_vol=None,
+            marginal_risk_contribution=None,
+            n_obs=0,
+        )
+
+    with snapshot_read(conn):
+        positions = _load_positions(conn)
+        holdings_count = len(positions)
+        if holdings_count == 0:
+            return _degraded("empty_book", 0, held=False)
+
+        total_mv = sum((Decimal(str(p.market_value)) for p in positions.values()), _ZERO)
+        held = candidate_instrument_id in positions
+        current_weight: Decimal | None = None
+        if held and total_mv > _ZERO:
+            current_weight = Decimal(str(positions[candidate_instrument_id].market_value)) / total_mv
+
+        # A book that is ONLY the candidate yields a trivial β=1 — flag it.
+        if holdings_count == 1 and held:
+            return _degraded("single_holding_is_candidate", 1, held=True, weight=current_weight)
+
+        # Include EVERY holding, even one with no usable returns: an empty return
+        # map forces an empty common-date intersection in build_portfolio_returns
+        # → book_history_unavailable, rather than silently computing risk on a
+        # renormalized subset of the book (Codex ckpt-2 P1).
+        holdings: list[tuple[Decimal, dict[date, Decimal]]] = [
+            (
+                Decimal(str(pos.market_value)),
+                dict(simple_returns(load_close_series(conn, iid, end_date))),
+            )
+            for iid, pos in positions.items()
+        ]
+
+        portfolio_returns = build_portfolio_returns(holdings)
+        if not portfolio_returns:
+            return PortfolioRelativeRisk(
+                symbol=symbol,
+                as_of_date=None,
+                status="book_history_unavailable",
+                holdings_count=holdings_count,
+                already_held=held,
+                current_weight=current_weight,
+                portfolio_beta=None,
+                correlation=None,
+                candidate_vol=None,
+                portfolio_vol=None,
+                marginal_risk_contribution=None,
+                n_obs=0,
+            )
+
+        candidate_returns = simple_returns(load_close_series(conn, candidate_instrument_id, end_date))
+
+    m = relative_risk_metrics(candidate_returns, portfolio_returns)
+    status: PortfolioRiskStatus = "ok" if m.n_obs >= MIN_RETURNS_VOL_BETA else "insufficient_history"
+    return PortfolioRelativeRisk(
+        symbol=symbol,
+        as_of_date=m.last_date,
+        status=status,
+        holdings_count=holdings_count,
+        already_held=held,
+        current_weight=current_weight,
+        portfolio_beta=m.beta,
+        correlation=m.correlation,
+        candidate_vol=m.candidate_vol,
+        portfolio_vol=m.portfolio_vol,
+        marginal_risk_contribution=marginal_risk_contribution(m.beta, m.portfolio_vol),
+        n_obs=m.n_obs,
+    )

--- a/docs/specs/metrics/2026-06-18-position-vs-portfolio-risk.md
+++ b/docs/specs/metrics/2026-06-18-position-vs-portfolio-risk.md
@@ -1,0 +1,138 @@
+# #1636 — position-vs-portfolio risk (marginal risk contribution)
+
+Status: spec. Follows #591 (PM committee). The risk layer is single-instrument
+standalone (β vs SPY). This adds the **true sizing metric**: how much a candidate
+moves the *existing book's* risk — covariance vs current holdings. **On-read, not
+persisted** (the book is dynamic — current weights change with every trade; a
+versioned evidence row like `instrument_risk_metrics` would be stale on the next
+fill). Reuses the `risk_metrics.py` primitives (`simple_returns`, `ols_beta`,
+`annualized_vol`); no new estimator math.
+
+## Source rule (portfolio theory — cited, not first-principles)
+
+Markowitz portfolio risk. For a book with weights `w` and return covariance `Σ`,
+portfolio variance is `σ_p² = wᵀΣw`. The contribution of an asset is governed by
+its covariance with the *portfolio*:
+
+- **Portfolio beta** of a candidate `c`: `β_{c,p} = cov(r_c, r_p) / var(r_p)` —
+  how the candidate co-moves with the book. `β > 1` amplifies book risk, `β < 1`
+  dampens, `β < 0` hedges. (This is exactly `ols_beta(r_c, r_p)` with the
+  portfolio series as the regressor — same closed form already shipped.)
+- **Correlation** `ρ_{c,p}` (= `sign(β)·√r²` from the same fit) — the
+  diversification signal independent of magnitude: low/negative ρ diversifies.
+- **Marginal contribution to risk** (MCR) of adding `c` at the margin:
+  `MCR_c = β_{c,p} · σ_p = cov(r_c, r_p)/σ_p` (annualized). This is the standard
+  Euler/risk-decomposition marginal term: to first order, adding a small weight
+  `δw` of `c` (funded pro-rata from the book) changes portfolio vol by
+  `δσ_p ≈ δw · (MCR_c − σ_p)`. So `MCR_c < σ_p` (equivalently `β_{c,p} < 1`) means
+  the candidate is **risk-reducing per unit weight** at the current book; `> σ_p`
+  means risk-adding. (Refs: Markowitz 1952; standard MCR/CCR decomposition,
+  `∂σ_p/∂w_i = (Σw)_i/σ_p`.)
+
+This is the candidate-vs-book metric. (Component contribution to risk of each
+*held* position — `CCR_i = w_i·β_{i,p}·σ_p`, `Σ CCR = σ_p` — is a natural
+extension but out of scope here; the issue asks for the candidate sizing metric.)
+
+## Weighting convention (documented)
+
+**Current market-value weights applied to historical returns.** `w_i = mv_i / Σ
+mv` where `mv_i` is the mark-to-market value from
+`portfolio.py::_load_positions` (the canonical portfolio-page source: quote
+`last>0` → `cost_basis` fallback, #1428) — chosen explicitly so weights match
+the portfolio UI/AUM (Codex ckpt-1: do NOT mix in `valuation.py`'s
+quote→close→cost ladder). **This is a current-exposure covariance estimate, NOT
+the book's realized historical return** — today's weights over past returns. The
+docstring + endpoint + UI copy must say so; nobody should read `r_p` as a
+backtest of the actual book. We do not reconstruct time-varying historical
+weights (not cleanly available; the operator's decision is about *today's*
+sizing). MCR's `δσ_p ≈ δw·(MCR−σ_p)` assumes the add is funded **pro-rata from
+the existing book** (normalized weights `w' = (1−δw)w + δw·e_c`), not cash-funded
+expansion — stated in the endpoint/UI.
+
+## Compute (`app/services/portfolio_risk.py`)
+
+`compute_portfolio_relative_risk(conn, candidate_instrument_id) -> PortfolioRelativeRisk | None`:
+
+1. Load open positions + mark-to-market weights (`current_units > 0`).
+2. For each holding, `load_close_series` → `simple_returns` → `{date: ret}`.
+3. **Portfolio return series** `r_p`: over the dates where **all** holdings have a
+   return (the common window — so the weighted sum always spans the same asset
+   set), `r_p[t] = Σ_i w_i · r_i[t]`. (Decimal throughout, matching risk_metrics.)
+4. Candidate: `load_close_series` → `simple_returns`.
+5. `ols_beta(candidate_returns, r_p)` → `β_{c,p}`, `r²`, `n_obs` (aligned
+   intersection of candidate ∩ portfolio dates — the helper already does this).
+   `correlation = sign(β)·√r²`. `σ_c`, `σ_p = annualized_vol(...)` on the aligned
+   window. `MCR = β·σ_p` (None when β or σ_p is None).
+6. `already_held` + `current_weight` when the candidate is in the book.
+
+## Quality flags — own `PortfolioRiskStatus` Literal (Codex ckpt-1)
+
+NOT `RiskStatus` (closed; lacks these). A dedicated
+`PortfolioRiskStatus = Literal["ok", "empty_book", "book_history_unavailable",
+"insufficient_history", "single_holding_is_candidate"]`:
+
+- `empty_book` → no open positions (metric undefined; nulls, `holdings_count=0`).
+- `book_history_unavailable` → the portfolio return series is empty: no holding
+  has a usable price series, or the holdings' histories don't overlap into a
+  common window (distinct from the *candidate's* `insufficient_history` — the
+  book itself couldn't be constructed; Codex ckpt-1).
+- `single_holding_is_candidate` → the only holding IS the candidate (β to itself
+  is trivially 1).
+- `insufficient_history` → fewer than `MIN_RETURNS_VOL_BETA = 60` aligned
+  candidate∩portfolio obs.
+- `ok` otherwise. NULLs never coerced to 0; `correlation`/`portfolio_beta`/`MCR`
+  are `None` (not 0) when β / r² / var(r_p) is null (#1581 honest-status).
+
+The service **always returns a payload** (status carries the degraded cases);
+`None` is not part of its contract — the endpoint owns the 404 for an unknown
+symbol (Codex ckpt-1).
+
+## Window consistency (Codex ckpt-1, load-bearing)
+
+`σ_p`, `σ_c`, and `β` are all computed over the **same** candidate∩portfolio
+date intersection — `σ_p` is NOT the vol of the full `r_p` series. Otherwise
+`MCR = β·σ_p` mixes two windows and is inconsistent. A test pins this.
+
+## Endpoint (`app/api/instruments.py` or `portfolio.py`)
+
+`GET /instruments/{symbol}/portfolio-risk` → `PortfolioRelativeRisk`:
+`{symbol, as_of_date, status, holdings_count, already_held, current_weight,
+portfolio_beta, correlation, candidate_vol, portfolio_vol,
+marginal_risk_contribution, n_obs}`. On-read (no persistence). `snapshot_read`
+so positions + all price series come from one committed view. 404 unknown
+symbol; 200 with `status="empty_book"` when the book is empty.
+
+## Frontend (thin card on the risk page)
+
+A "vs your portfolio" card on `RiskPage` (2nd `useAsync` to `/portfolio-risk`):
+plain-language verdict — `portfolio_beta < 1` ⇒ "dampens your book's swings",
+`> 1` ⇒ "amplifies", `< 0` ⇒ "hedges"; correlation as a diversification line;
+MCR vs portfolio_vol. Per-card empty/flag state keyed on `status` (`empty_book` →
+"You hold no positions yet"). Avoids shipping a dead endpoint. types.ts mirror +
+fetcher.
+
+## Tests
+
+- `portfolio_risk.py` pure-ish: portfolio-return weighting (weighted sum on the
+  common date window), β/corr/MCR wiring vs a constructed 2-3 holding book,
+  `empty_book` / `single_holding_is_candidate` / `insufficient_history` flags,
+  NULL passthrough. Extract the weighting + assembly into pure helpers fed
+  synthetic series (no DB), per the repo's pure-test preference.
+- Endpoint: one integration test (book with holdings → sane payload; empty book →
+  `empty_book` not zeros).
+- `RiskPage.test.tsx`: renders the card; empty-book state; verdict mapping.
+
+## Dev-verify
+
+Dev book = 5 holdings (GME 48.6% / QQQ 18.8% / VOO 17.4% / BBBY 11.6% / IEP 3.5%).
+Run `compute_portfolio_relative_risk` for a candidate (e.g. AAPL, and a held one
+GME) on dev; confirm `portfolio_beta` / correlation / MCR are sane (GME β≈1+ as
+the dominant holding; a diversifier < 1). Hit `/instruments/AAPL/portfolio-risk`.
+Record figures + SHA.
+
+## Out of scope (note)
+
+- Component contribution to risk (CCR) per held position + a book-risk
+  decomposition view (extension).
+- Wiring MCR into the portfolio-manager sizing / scoring path (a model change —
+  same gate class as #1633).

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -9,6 +9,7 @@ import type {
   InstrumentRiskMetrics,
   InstrumentSummary,
   IntradayInterval,
+  PortfolioRelativeRisk,
 } from "@/api/types";
 
 export interface InstrumentsQuery {
@@ -515,5 +516,14 @@ export function fetchInstrumentRiskMetrics(
 ): Promise<InstrumentRiskMetrics> {
   return apiFetch<InstrumentRiskMetrics>(
     `/instruments/${encodeURIComponent(symbol)}/risk-metrics`,
+  );
+}
+
+// #1636 — candidate-vs-current-book risk (marginal risk contribution).
+export function fetchInstrumentPortfolioRisk(
+  symbol: string,
+): Promise<PortfolioRelativeRisk> {
+  return apiFetch<PortfolioRelativeRisk>(
+    `/instruments/${encodeURIComponent(symbol)}/portfolio-risk`,
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -523,6 +523,32 @@ export interface InstrumentRiskMetrics {
   series: RiskSeries | null;
 }
 
+/** Candidate-vs-current-book risk (#1636). Mirrors PortfolioRelativeRiskResponse
+ *  in app/api/instruments.py. Decimals → string | null; figures are fractions,
+ *  vols annualized. A current-exposure covariance estimate (today's weights over
+ *  past returns), NOT realized book history. */
+export type PortfolioRiskStatus =
+  | "ok"
+  | "empty_book"
+  | "book_history_unavailable"
+  | "insufficient_history"
+  | "single_holding_is_candidate";
+
+export interface PortfolioRelativeRisk {
+  symbol: string;
+  as_of_date: string | null;
+  status: PortfolioRiskStatus;
+  holdings_count: number;
+  already_held: boolean;
+  current_weight: string | null;
+  portfolio_beta: string | null;
+  correlation: string | null;
+  candidate_vol: string | null;
+  portfolio_vol: string | null;
+  marginal_risk_contribution: string | null;
+  n_obs: number;
+}
+
 // #601 — chart UI range token (the union the chart buttons render).
 // Translates to either a daily range (existing endpoint) or an
 // intraday (interval, count) pair via CHART_RANGE_PLAN. The API

--- a/frontend/src/pages/RiskPage.test.tsx
+++ b/frontend/src/pages/RiskPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 import type { InstrumentRiskMetrics, RiskWindowMetrics } from "@/api/types";
@@ -11,7 +11,11 @@ vi.mock("@/api/instruments", async () => {
     await vi.importActual<typeof import("@/api/instruments")>(
       "@/api/instruments",
     );
-  return { ...actual, fetchInstrumentRiskMetrics: vi.fn() };
+  return {
+    ...actual,
+    fetchInstrumentRiskMetrics: vi.fn(),
+    fetchInstrumentPortfolioRisk: vi.fn(),
+  };
 });
 
 // Recharts needs a real layout pipeline jsdom lacks; the chart internals are
@@ -40,11 +44,42 @@ vi.mock("@/components/risk/riskCharts", () => ({
   ),
 }));
 
-import { fetchInstrumentRiskMetrics } from "@/api/instruments";
+import {
+  fetchInstrumentPortfolioRisk,
+  fetchInstrumentRiskMetrics,
+} from "@/api/instruments";
+import type { PortfolioRelativeRisk } from "@/api/types";
 
 const mockRisk = vi.mocked(fetchInstrumentRiskMetrics);
+const mockPortfolioRisk = vi.mocked(fetchInstrumentPortfolioRisk);
+
+function makePortfolioRisk(
+  overrides: Partial<PortfolioRelativeRisk> = {},
+): PortfolioRelativeRisk {
+  return {
+    symbol: "AAPL",
+    as_of_date: "2026-06-12",
+    status: "ok",
+    holdings_count: 5,
+    already_held: false,
+    current_weight: null,
+    portfolio_beta: "0.18",
+    correlation: "0.34",
+    candidate_vol: "0.28",
+    portfolio_vol: "0.53",
+    marginal_risk_contribution: "0.095",
+    n_obs: 997,
+    ...overrides,
+  };
+}
 
 afterEach(() => vi.clearAllMocks());
+
+// Default the supplementary #1636 fetch so every test resolves it; card-specific
+// tests override. Without a default, useAsync calls fn().then on undefined.
+beforeEach(() => {
+  mockPortfolioRisk.mockResolvedValue(makePortfolioRisk());
+});
 
 function makeWindow(
   key: string,
@@ -214,5 +249,38 @@ describe("RiskPage", () => {
     await screen.findByTestId("mock-underwater");
     const backLinks = screen.getAllByRole("link", { name: /Back to AAPL/i });
     expect(backLinks[0]).toHaveAttribute("href", "/instrument/AAPL");
+  });
+
+  it("renders the vs-portfolio card with a diversification verdict (#1636)", async () => {
+    mockRisk.mockResolvedValue(makePayload());
+    mockPortfolioRisk.mockResolvedValue(makePortfolioRisk({ portfolio_beta: "0.18" }));
+    renderPage();
+
+    await screen.findByTestId("mock-underwater");
+    expect(
+      await screen.findByText(/Dampens your book's swings/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Portfolio beta/i)).toBeInTheDocument();
+  });
+
+  it("shows the empty-book message on the vs-portfolio card when nothing is held", async () => {
+    mockRisk.mockResolvedValue(makePayload());
+    mockPortfolioRisk.mockResolvedValue(
+      makePortfolioRisk({
+        status: "empty_book",
+        holdings_count: 0,
+        portfolio_beta: null,
+        correlation: null,
+        portfolio_vol: null,
+        marginal_risk_contribution: null,
+        n_obs: 0,
+      }),
+    );
+    renderPage();
+
+    await screen.findByTestId("mock-underwater");
+    expect(
+      await screen.findByText(/You hold no positions yet/i),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/RiskPage.tsx
+++ b/frontend/src/pages/RiskPage.tsx
@@ -15,8 +15,15 @@
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
-import { fetchInstrumentRiskMetrics } from "@/api/instruments";
-import type { InstrumentRiskMetrics, RiskWindowMetrics } from "@/api/types";
+import {
+  fetchInstrumentPortfolioRisk,
+  fetchInstrumentRiskMetrics,
+} from "@/api/instruments";
+import type {
+  InstrumentRiskMetrics,
+  PortfolioRelativeRisk,
+  RiskWindowMetrics,
+} from "@/api/types";
 import {
   SectionError,
   SectionSkeleton,
@@ -190,6 +197,93 @@ function RiskCard({
 }
 
 // ---------------------------------------------------------------------------
+// Vs-your-portfolio card (#1636) — marginal risk contribution
+// ---------------------------------------------------------------------------
+
+function portfolioRiskCopy(status: string): string | null {
+  switch (status) {
+    case "empty_book":
+      return "You hold no positions yet — add holdings to see how this name fits your book.";
+    case "book_history_unavailable":
+      return "Not enough price history across your holdings yet.";
+    case "single_holding_is_candidate":
+      return "This is your only holding — there's nothing else in the book to compare it against.";
+    default:
+      return null;
+  }
+}
+
+function PortfolioRiskCard({
+  state,
+}: {
+  readonly state: ReturnType<typeof useAsync<PortfolioRelativeRisk>>;
+}): JSX.Element | null {
+  if (state.loading) {
+    return (
+      <Pane title="Vs your portfolio" scope="marginal risk contribution">
+        <SectionSkeleton rows={2} />
+      </Pane>
+    );
+  }
+  if (state.error !== null || !state.data) {
+    // Degrade quietly — this card is supplementary to the standalone risk view.
+    return null;
+  }
+  const d = state.data;
+  const degraded = portfolioRiskCopy(d.status);
+  if (degraded !== null) {
+    return (
+      <Pane title="Vs your portfolio" scope="marginal risk contribution">
+        <p className="px-2 py-3 text-xs text-slate-500">{degraded}</p>
+      </Pane>
+    );
+  }
+  const beta = parseDecimal(d.portfolio_beta);
+  const pvol = parseDecimal(d.portfolio_vol);
+  const mcr = parseDecimal(d.marginal_risk_contribution);
+  const weight = parseDecimal(d.current_weight);
+  const verdict =
+    beta === null
+      ? "—"
+      : beta < 0
+        ? "Hedges your book (moves opposite)."
+        : beta < 1
+          ? "Dampens your book's swings (less than your current mix)."
+          : "Amplifies your book's swings (more than your current mix).";
+  const provisional = d.status === "insufficient_history";
+  return (
+    <Pane title="Vs your portfolio" scope="marginal risk contribution">
+      {provisional ? (
+        <p className="px-2 pb-1 text-[11px] text-amber-700 dark:text-amber-500">
+          Short overlap with your book — figure is provisional.
+        </p>
+      ) : null}
+      <p className="px-2 pb-1 text-sm text-slate-700 dark:text-slate-300">
+        {verdict}
+        {d.already_held
+          ? ` You already hold this${
+              weight !== null ? ` (${formatUnsignedPct(weight)} of your book)` : ""
+            } — figures show an incremental tilt funded from the rest.`
+          : ""}
+      </p>
+      <div className="grid grid-cols-2 gap-x-4 sm:grid-cols-3">
+        <StatTile label="Portfolio beta" value={formatNumber(beta, 2)} />
+        <StatTile
+          label="Correlation"
+          value={formatNumber(parseDecimal(d.correlation), 2)}
+          hint="to your book's returns"
+        />
+        <StatTile
+          label="Marginal risk"
+          value={formatUnsignedPct(mcr)}
+          hint={`vs book vol ${formatUnsignedPct(pvol)}`}
+        />
+      </div>
+    </Pane>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -200,6 +294,12 @@ export function RiskPage(): JSX.Element {
   // useAsync captures fn via a ref — fresh arrow per render is fine.
   const risk = useAsync<InstrumentRiskMetrics>(
     () => fetchInstrumentRiskMetrics(symbol),
+    [symbol],
+  );
+  // #1636 — independent fetch; the card owns its own loading/empty/error and
+  // degrades to nothing if the endpoint fails (supplementary to the standalone view).
+  const portfolioRisk = useAsync<PortfolioRelativeRisk>(
+    () => fetchInstrumentPortfolioRisk(symbol),
     [symbol],
   );
 
@@ -265,6 +365,8 @@ export function RiskPage(): JSX.Element {
       ) : (
         <div className="space-y-4">
           <ScalarSummary win={selectedWindow} />
+
+          <PortfolioRiskCard state={portfolioRisk} />
 
           <RiskCard
             title="Drawdown (underwater)"

--- a/tests/test_portfolio_risk.py
+++ b/tests/test_portfolio_risk.py
@@ -1,0 +1,95 @@
+"""Pure tests for position-vs-portfolio risk math (#1636). No DB."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from app.services.portfolio_risk import (
+    build_portfolio_returns,
+    marginal_risk_contribution,
+    relative_risk_metrics,
+)
+
+D = Decimal
+_BASE = date(2026, 1, 1)
+
+
+def _d(n: int) -> date:
+    return _BASE + timedelta(days=n)
+
+
+class TestBuildPortfolioReturns:
+    def test_market_value_weighted_sum_on_common_dates(self) -> None:
+        # 75/25 value split → r_p = 0.75*a + 0.25*b on shared dates.
+        a = {_d(1): D("0.10"), _d(2): D("0.20")}
+        b = {_d(1): D("0.00"), _d(2): D("0.40")}
+        out = dict(build_portfolio_returns([(D("75"), a), (D("25"), b)]))
+        assert out[_d(1)] == D("0.075")
+        assert out[_d(2)] == D("0.25")  # 0.75*0.2 + 0.25*0.4
+
+    def test_intersection_only(self) -> None:
+        # b is missing d2 → portfolio series has only the common date d1.
+        a = {_d(1): D("0.1"), _d(2): D("0.2")}
+        b = {_d(1): D("0.1")}
+        out = build_portfolio_returns([(D("1"), a), (D("1"), b)])
+        assert [d for d, _ in out] == [_d(1)]
+
+    def test_empty_and_zero_weight(self) -> None:
+        assert build_portfolio_returns([]) == []
+        assert build_portfolio_returns([(D("0"), {_d(1): D("0.1")})]) == []
+
+    def test_disjoint_histories_yield_empty(self) -> None:
+        a = {_d(1): D("0.1")}
+        b = {_d(2): D("0.1")}
+        assert build_portfolio_returns([(D("1"), a), (D("1"), b)]) == []
+
+    def test_holding_with_no_returns_forces_empty(self) -> None:
+        # A holding with an empty return map empties the common intersection —
+        # the book can't be fully constructed (→ book_history_unavailable), NOT
+        # a renormalized subset of the holdings that do have history (Codex P1).
+        a = {_d(1): D("0.1"), _d(2): D("0.2")}
+        assert build_portfolio_returns([(D("90"), a), (D("10"), {})]) == []
+
+
+class TestRelativeRiskMetrics:
+    def test_perfect_positive_gives_beta_and_corr(self) -> None:
+        # candidate == 2× portfolio → β=2, corr=+1.
+        p = [(_d(i), D(str(0.01 * (i % 5 - 2)))) for i in range(1, 40)]
+        c = [(d, r * 2) for d, r in p]
+        m = relative_risk_metrics(c, p)
+        assert m.n_obs == len(p)
+        assert m.beta is not None and abs(m.beta - D("2")) < D("0.0001")
+        assert m.correlation is not None and abs(m.correlation - D("1")) < D("0.0001")
+        assert m.last_date == p[-1][0]
+
+    def test_negative_relationship_gives_negative_corr(self) -> None:
+        p = [(_d(i), D(str(0.01 * (i % 5 - 2)))) for i in range(1, 40)]
+        c = [(d, -r) for d, r in p]
+        m = relative_risk_metrics(c, p)
+        assert m.beta is not None and m.beta < 0
+        assert m.correlation is not None and m.correlation < 0
+
+    def test_window_is_the_intersection_not_full_series(self) -> None:
+        # portfolio has an extra early date the candidate lacks; σ_p must be
+        # computed over the SHARED window only (Codex ckpt-1 consistency).
+        p = [(_d(i), D("0.01")) for i in range(1, 10)]
+        c = [(_d(i), D("0.02")) for i in range(4, 10)]  # starts at d4
+        m = relative_risk_metrics(c, p)
+        assert m.n_obs == 6  # d4..d9, not 9
+        assert m.last_date == _d(9)
+
+    def test_under_two_obs_is_none(self) -> None:
+        m = relative_risk_metrics([(_d(1), D("0.1"))], [(_d(1), D("0.1"))])
+        assert m.beta is None and m.correlation is None
+        assert m.candidate_vol is None and m.portfolio_vol is None
+        assert m.n_obs == 1
+
+
+class TestMarginalRiskContribution:
+    def test_beta_times_portfolio_vol(self) -> None:
+        assert marginal_risk_contribution(D("1.5"), D("0.20")) == D("0.30")
+
+    def test_none_inputs_stay_none(self) -> None:
+        assert marginal_risk_contribution(None, D("0.2")) is None
+        assert marginal_risk_contribution(D("1.5"), None) is None


### PR DESCRIPTION
Closes #1636. Follows #591 (PM committee). Last ticket of the risk-drill follow-up batch.

## What
The risk layer was single-instrument (β vs SPY). This adds the **PM sizing metric**: *how much does a candidate move my existing book's risk?* — covariance vs current holdings. **On-read** (the book is dynamic; a versioned evidence row would be stale on the next fill), reusing the `risk_metrics.py` primitives — no new estimator math.

- **`app/services/portfolio_risk.py`**
  - `build_portfolio_returns` — current market-value-weighted return series over the date window where **all** holdings have a return (the common intersection, so the weighted sum always spans the same asset set). A holding with no history forces an empty intersection → `book_history_unavailable`, never a renormalized subset (Codex ckpt-2 P1).
  - `relative_risk_metrics` — β / correlation / σ_c / σ_p all over the **same** candidate∩portfolio window so `MCR = β·σ_p` is self-consistent (Codex ckpt-1).
  - `marginal_risk_contribution` = β·σ_p. Own `PortfolioRiskStatus` (`ok | empty_book | book_history_unavailable | single_holding_is_candidate | insufficient_history`); honest passthrough (NULL never 0; correlation None not 0).
- **`GET /instruments/{symbol}/portfolio-risk`** — on-read; 404 unknown symbol; `empty_book` when nothing held. `snapshot_read` so positions + all price series are one committed view.
- **Frontend** — "vs your portfolio" card on `RiskPage` (independent `useAsync`, degrades to nothing on error): verdict (hedges / dampens / amplifies), β / correlation / marginal-risk vs book vol, and already-held "incremental tilt" copy. `types.ts` mirror (closed-set status) + fetcher.

## Source rule / convention
Markowitz portfolio risk; standard MCR/component decomposition (`∂σ_p/∂w_i = (Σw)_i/σ_p`). `β_{c,p} = cov(r_c,r_p)/var(r_p)`; `MCR = β·σ_p`. Weights = current market value via `portfolio.py::_load_positions` (matches the portfolio UI). **Documented caveat:** the portfolio series is today's weights over past returns — a *current-exposure covariance estimate*, NOT realized book history; the MCR marginal interpretation assumes a small add funded pro-rata from the book.

## Codex
- **ckpt-1** (spec): 9 findings folded — own status Literal (not `RiskStatus`), `book_history_unavailable`, σ_p on the aligned window, explicit mark source, current-weights-not-history label.
- **ckpt-2** (branch): P1 — skipping no-history holdings computed risk on a renormalized subset → now forces `book_history_unavailable`; P2 — closed-set status type on both FE and BE.

## Verification
- 11 pure tests (weighting / intersection / window consistency / β·σ_p / honest None / no-history-forces-empty) · fast tier **4403** + smoke **129** + FE **1060** + dark-gate green.
- **Dev endpoint** (book = GME 48.6% / QQQ 18.8% / VOO 17.4% / BBBY 11.6% / IEP 3.5%): GME (held, dominant) β **1.75** / corr **0.97** → amplifies; **AAPL β 0.18 / XOM 0.05 / JNJ 0.0009** → diversify (MCR ≪ book vol 0.53). Economically correct.
- **FE card dev-rendered** (authed, dark mode): "Dampens your book's swings", Portfolio beta 0.18 / Correlation 0.34 / Marginal risk 9.47% vs book vol 52.89%; no console errors.

Spec: `docs/specs/metrics/2026-06-18-position-vs-portfolio-risk.md`.

## Out of scope (noted)
- Component contribution to risk (CCR) per held position + book-risk decomposition.
- Wiring MCR into the portfolio-manager sizing / scoring path (a model change — gate class of #1633).

🤖 Generated with [Claude Code](https://claude.com/claude-code)