### PR TITLE
feat(#1675): real-sector peer-grouping (consume #1634 gics_sector, not opaque 1-9)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -69,7 +69,7 @@ from app.services.risk_metrics import (
     ols_beta,
     simple_returns,
 )
-from app.services.sector_classification import resolve_sector_spdr
+from app.services.sector_classification import resolve_sector_spdr, sector_spdr_case_sql
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +140,13 @@ class InstrumentListItem(BaseModel):
     exchange: str | None
     currency: str | None
     sector: str | None
+    # #1675: real GICS sector + its sector-SPDR, resolved on-read from the SEC
+    # SIC (same crosswalk as the identity payload). NULL for ETFs / non-filers /
+    # unmapped SIC — never a guessed sector. The opaque ``sector`` 1-9 code above
+    # is retained for back-compat but is no longer the operator-facing grouping
+    # dimension. Required-nullable to mirror the TS ``string | null`` exactly.
+    gics_sector: str | None
+    sector_spdr: str | None
     is_tradable: bool
     coverage_tier: int | None
     latest_quote: QuoteSnapshot | None
@@ -413,6 +420,7 @@ def list_instruments(
     conn: psycopg.Connection[object] = Depends(get_conn),
     search: str | None = Query(default=None, max_length=100),
     sector: str | None = Query(default=None),
+    sector_spdr: str | None = Query(default=None),
     coverage_tier: int | None = Query(default=None, ge=1, le=3),
     exchange: str | None = Query(default=None),
     has_dividend: bool | None = Query(default=None),
@@ -424,7 +432,11 @@ def list_instruments(
     Filters:
       - search: prefix match on symbol or case-insensitive substring on
         instrument_display_name (company_name)
-      - sector: exact match on instruments.sector
+      - sector_spdr: exact match on the real GICS sector-SPDR resolved from the
+        SEC SIC (#1675; e.g. ``XLK``). The operator-facing sector dimension.
+      - sector: DEPRECATED — exact match on the opaque ``instruments.sector``
+        1-9 code (no GICS meaning; SPY/XLF/JPM all share ``4``). Retained for
+        back-compat; use ``sector_spdr`` instead.
       - coverage_tier: exact match (1/2/3); untiered instruments excluded
       - exchange: exact match on instruments.exchange
       - has_dividend: True matches instruments with a positive TTM dividend
@@ -447,6 +459,12 @@ def list_instruments(
     if sector is not None:
         where_clauses.append("i.sector = %(sector)s")
         filter_params["sector"] = sector
+    if sector_spdr is not None:
+        # SQL-side resolve (faithful mirror of resolve_sector_spdr) so the
+        # filter paginates correctly. The items query already joins p; the
+        # COUNT join is added below when this filter is active.
+        where_clauses.append(f"({sector_spdr_case_sql()}) = %(sector_spdr)s")
+        filter_params["sector_spdr"] = sector_spdr
     if coverage_tier is not None:
         where_clauses.append("c.coverage_tier = %(coverage_tier)s")
         filter_params["coverage_tier"] = coverage_tier
@@ -470,8 +488,11 @@ def list_instruments(
     count_dividend_join = (
         "LEFT JOIN instrument_dividend_summary ds USING (instrument_id)" if count_needs_dividend else ""
     )
+    # The sector_spdr filter's WHERE references p.sic, so the COUNT must join the
+    # SEC profile when that filter is active (the items query always joins it).
+    count_sec_join = "LEFT JOIN instrument_sec_profile p USING (instrument_id)" if sector_spdr is not None else ""
     count_sql = (  # noqa: S608  — hardcoded fragments only
-        f"SELECT COUNT(*) AS cnt FROM instruments i {count_join} {count_dividend_join}{where_sql}"
+        f"SELECT COUNT(*) AS cnt FROM instruments i {count_join} {count_dividend_join} {count_sec_join}{where_sql}"
     )
 
     # -- Items query -------------------------------------------------------
@@ -480,13 +501,17 @@ def list_instruments(
     # unrelated query (e.g. a plain ``/instruments`` call) is pure overhead.
     items_dividend_join = count_dividend_join
     items_params: dict[str, object] = {**filter_params, "limit": limit, "offset": offset}
+    # Always join the SEC profile + select p.sic so every row can resolve its
+    # real GICS sector for display (#1675), independent of whether the
+    # sector_spdr filter is active. PK join — trivial cost.
     items_sql = f"""SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
-               i.currency, i.sector, i.is_tradable,
+               i.currency, i.sector, p.sic, i.is_tradable,
                c.coverage_tier,
                q.bid, q.ask, q.last, q.spread_pct, q.quoted_at
         FROM instruments i
         LEFT JOIN quotes q USING (instrument_id)
         LEFT JOIN coverage c USING (instrument_id)
+        LEFT JOIN instrument_sec_profile p USING (instrument_id)
         {items_dividend_join}
         {where_sql}
         ORDER BY i.symbol, i.instrument_id
@@ -500,20 +525,24 @@ def list_instruments(
         cur.execute(items_sql, items_params)  # type: ignore[arg-type]  # SQL built from hardcoded fragments
         rows = cur.fetchall()
 
-    items = [
-        InstrumentListItem(
-            instrument_id=r["instrument_id"],  # type: ignore[arg-type]
-            symbol=r["symbol"],  # type: ignore[arg-type]
-            company_name=r["company_name"],  # type: ignore[arg-type]
-            exchange=r["exchange"],  # type: ignore[arg-type]
-            currency=r["currency"],  # type: ignore[arg-type]
-            sector=r["sector"],  # type: ignore[arg-type]
-            is_tradable=r["is_tradable"],  # type: ignore[arg-type]
-            coverage_tier=r["coverage_tier"],  # type: ignore[arg-type]
-            latest_quote=_parse_quote(r),
+    items: list[InstrumentListItem] = []
+    for r in rows:
+        sc = resolve_sector_spdr(r.get("sic"))  # type: ignore[arg-type]
+        items.append(
+            InstrumentListItem(
+                instrument_id=r["instrument_id"],  # type: ignore[arg-type]
+                symbol=r["symbol"],  # type: ignore[arg-type]
+                company_name=r["company_name"],  # type: ignore[arg-type]
+                exchange=r["exchange"],  # type: ignore[arg-type]
+                currency=r["currency"],  # type: ignore[arg-type]
+                sector=r["sector"],  # type: ignore[arg-type]
+                gics_sector=sc.gics_sector if sc is not None else None,
+                sector_spdr=sc.spdr_symbol if sc is not None else None,
+                is_tradable=r["is_tradable"],  # type: ignore[arg-type]
+                coverage_tier=r["coverage_tier"],  # type: ignore[arg-type]
+                latest_quote=_parse_quote(r),
+            )
         )
-        for r in rows
-    ]
 
     return InstrumentListResponse(items=items, total=total, offset=offset, limit=limit)
 

--- a/app/api/scores.py
+++ b/app/api/scores.py
@@ -32,6 +32,7 @@ from app.db import get_conn
 # read endpoints must default to the same version the scoring pass writes, or the
 # rankings page shows stale rows of a version no longer produced.
 from app.services.scoring import _DEFAULT_MODEL_VERSION
+from app.services.sector_classification import resolve_sector_spdr, sector_spdr_case_sql
 
 router = APIRouter(prefix="/rankings", tags=["rankings"])
 
@@ -51,6 +52,10 @@ class RankingItem(BaseModel):
     symbol: str
     company_name: str
     sector: str | None
+    # #1675: real GICS sector resolved on-read from the SEC SIC (same crosswalk
+    # as the instrument identity payload). NULL for ETFs / non-filers / unmapped
+    # SIC. The opaque ``sector`` 1-9 code above is retained for back-compat.
+    gics_sector: str | None
     coverage_tier: int | None
     rank: int | None
     rank_delta: int | None
@@ -128,6 +133,7 @@ def _parse_ranking_item(row: dict[str, object]) -> RankingItem:
         symbol=row["symbol"],  # type: ignore[arg-type]
         company_name=row["company_name"],  # type: ignore[arg-type]
         sector=row["sector"],  # type: ignore[arg-type]
+        gics_sector=(_sc.gics_sector if (_sc := resolve_sector_spdr(row.get("sic"))) is not None else None),  # type: ignore[arg-type]
         coverage_tier=_parse_optional_int(row, "coverage_tier"),
         rank=_parse_optional_int(row, "rank"),
         rank_delta=_parse_optional_int(row, "rank_delta"),
@@ -176,6 +182,7 @@ def list_rankings(
     model_version: str = Query(default=_DEFAULT_MODEL_VERSION),
     coverage_tier: int | None = Query(default=None, ge=1, le=3),
     sector: str | None = Query(default=None),
+    sector_spdr: str | None = Query(default=None),
     stance: Stance | None = Query(default=None),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=50, ge=1, le=MAX_PAGE_LIMIT),
@@ -190,7 +197,10 @@ def list_rankings(
 
     Filters:
       - coverage_tier: exact match (1/2/3); untiered instruments excluded
-      - sector: exact match on instruments.sector
+      - sector_spdr: exact match on the real GICS sector-SPDR resolved from the
+        SEC SIC (#1675; e.g. ``XLF``). The operator-facing peer dimension.
+      - sector: DEPRECATED — exact match on the opaque ``instruments.sector``
+        1-9 code (no GICS meaning). Retained for back-compat; use ``sector_spdr``.
       - stance: latest thesis stance for each instrument (adds LATERAL join only when used)
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -229,7 +239,10 @@ def list_rankings(
             "scored_at": latest_scored_at,
         }
 
-        extra_joins: list[str] = []
+        # Always join the SEC profile so every ranking row can resolve its real
+        # GICS sector for display (#1675) and the sector_spdr filter can resolve
+        # p.sic SQL-side. PK join — trivial cost; shared by COUNT + items.
+        extra_joins: list[str] = ["LEFT JOIN instrument_sec_profile p USING (instrument_id)"]
 
         if coverage_tier is not None:
             where_clauses.append("c.coverage_tier = %(coverage_tier)s")
@@ -238,6 +251,10 @@ def list_rankings(
         if sector is not None:
             where_clauses.append("i.sector = %(sector)s")
             filter_params["sector"] = sector
+
+        if sector_spdr is not None:
+            where_clauses.append(f"({sector_spdr_case_sql()}) = %(sector_spdr)s")
+            filter_params["sector_spdr"] = sector_spdr
 
         # Stance filter: LATERAL join to latest thesis only when needed.
         if stance is not None:
@@ -274,7 +291,7 @@ def list_rankings(
             "limit": limit,
             "offset": offset,
         }
-        items_sql = f"""SELECT s.instrument_id, i.symbol, i.company_name, i.sector,
+        items_sql = f"""SELECT s.instrument_id, i.symbol, i.company_name, i.sector, p.sic,
                    c.coverage_tier,
                    s.rank, s.rank_delta,
                    s.total_score, s.raw_total,

--- a/app/services/sector_classification.py
+++ b/app/services/sector_classification.py
@@ -160,3 +160,33 @@ def resolve_sector_spdr(sic: str | int | None) -> SectorClassification | None:
         if lo <= code <= hi:
             return SectorClassification(gics_sector=SPDR_SECTORS[spdr], spdr_symbol=spdr)
     return None
+
+
+def sector_spdr_case_sql() -> str:
+    """SQL ``CASE`` that resolves ``instrument_sec_profile.sic`` (aliased ``p.sic``)
+    to its sector-SPDR symbol, or ``NULL`` when unmappable — the SQL-side mirror of
+    :func:`resolve_sector_spdr` used by the ``sector_spdr`` filter (#1675).
+
+    Generated from ``_CROSSWALK`` in first-match order so the SQL projection cannot
+    drift from the Python resolver (a DB-backed parity test asserts equivalence over
+    the full SIC domain). The outer regex guard fires the ``::int`` cast only for
+    digit strings (SEC SIC is a bare 4-digit code; leading zeros parse fine, e.g.
+    ``'0100'::int = 100`` matching Python ``int('0100')``).
+
+    Safe to inline into SQL: embeds only module constants — the range bounds are
+    ``int``-formatted and every SPDR literal is asserted ∈ :data:`SPDR_SECTORS`. No
+    caller input. Callers MUST alias ``instrument_sec_profile`` AS ``p``.
+    """
+    branches: list[str] = []
+    for lo, hi, spdr in _CROSSWALK:
+        assert spdr in SPDR_SECTORS, f"crosswalk SPDR {spdr!r} not in SPDR_SECTORS"
+        branches.append(f"WHEN (btrim(p.sic))::int BETWEEN {int(lo)} AND {int(hi)} THEN '{spdr}'")
+    inner = "\n        ".join(branches)
+    return (
+        "CASE WHEN btrim(p.sic) ~ '^[0-9]+$' THEN (\n"
+        "      CASE\n"
+        f"        {inner}\n"
+        "        ELSE NULL\n"
+        "      END\n"
+        "    ) ELSE NULL END"
+    )

--- a/docs/specs/metrics/2026-06-19-sector-peer-grouping.md
+++ b/docs/specs/metrics/2026-06-19-sector-peer-grouping.md
@@ -1,0 +1,102 @@
+# Sector peer-grouping — consume #1634 GICS sector as the filter/peer dimension (#1675)
+
+## Problem
+`instruments.sector` is an opaque 1–9 code with no GICS/SPDR meaning. SPY/XLE/XLF/XLK
+(ETFs, no SIC) and JPM all sit in code `4`; AAPL in `3`. Every surface that groups or
+filters on `i.sector` therefore produces garbage peer sets. #1634 shipped the real
+SIC→GICS-sector→SPDR crosswalk (`resolve_sector_spdr`) but display-only. This switches
+the **filter / peer-grouping dimension** to that crosswalk.
+
+## Source rule
+Sector classification is fixed by the #1634 crosswalk
+(`docs/specs/metrics/2026-06-18-sic-gics-spdr-crosswalk.md`): SEC 4-digit SIC
+(`instrument_sec_profile.sic`) → one of 11 GICS sectors → its State-Street sector SPDR.
+`resolve_sector_spdr` is the single source of truth; this ticket adds a SQL projection of
+the SAME `_CROSSWALK` (generated, not hand-duplicated) so backend filtering matches the
+Python resolver byte-for-byte. No new classification logic, no new source.
+
+## Full-population verification (dev, 12,547 instruments)
+- `instrument_sec_profile.sic` is `text`, all values pure 4-digit numeric (incl. leading
+  zeros e.g. `0100`→100, matches Python `int('0100')`). SQL `btrim(sic)` + `~ '^[0-9]+$'`
+  guard + `::int` is a faithful mirror of `int(str(sic).strip())`.
+- Crosswalk resolves 5,250 / 12,547 (41.8%); the rest are ETFs / foreign non-filers with
+  no SIC → `None` (no peer set), by #1634 design. GICS dist sane: XLV 995, XLF 899,
+  XLI 846, XLK 758, XLY 536, XLB 359, XLRE 242, XLP 167, XLC 161, XLE 159, XLU 128.
+- Opaque-code garbage confirmed: SPY/XLE/XLF/XLK→opaque `4` (sic None→`None`), JPM opaque
+  `4` sic 6021→**XLF**, AAPL opaque `3` sic 3571→**XLK**, XOM opaque `1` sic 2911→**XLE**.
+
+## Premise falsified: NO stored/indexed column needed
+At 12.5k instruments a `LEFT JOIN instrument_sec_profile` + a CASE-range resolve is a
+sub-ms seq scan. Live SQL resolve keeps #1634's deliberate persist-nothing posture (no
+migration, no backfill, no drift-on-SIC-change, no re-sync). A materialized column would
+buy nothing and reintroduce drift.
+
+## Two-path resolve (Codex ckpt-1 #2/#3)
+- **Display** (`gics_sector` on every list/ranking row): the items query ALWAYS
+  `LEFT JOIN instrument_sec_profile p` and selects `p.sic`; the Python row-builder calls
+  `resolve_sector_spdr(row["sic"])` (same pattern as the detail endpoint, instruments.py
+  ~3391). Pure-Python per row — no SQL CASE involved. Unconditional join (PK join, trivial).
+- **Filter** (`?sector_spdr=XLK`): SQL-side resolution required for correct pagination, so
+  the WHERE predicate uses the generated CASE `<case> = %(sector_spdr)s` over `p.sic`.
+  Both display and filter read the SAME `_CROSSWALK`.
+
+## SQL guard ≠ Python int() leniency — documented bounded divergence (Codex ckpt-1 #5)
+Python `int(str(sic).strip())` also accepts `+0100` / `1_000`; SQL `btrim(sic) ~ '^[0-9]+$'`
+rejects them. This divergence is unreachable: SEC SIC is canonically a bare 4-digit code
+(EDGAR `assigned-sic`), never signed/separated — dev pop is 100% pure 4-digit. `^[0-9]+$`
+is the correct SIC domain; the parity test asserts SQL≡Python over digit-string inputs
+(where they agree exactly) plus null/blank/non-numeric (both → no match).
+
+## API contract decision
+**Add a new `sector_spdr` query param** (value = SPDR symbol, e.g. `XLK`) to `/instruments`
+and the rankings endpoint (`/rankings`, served by `app/api/scores.py`). Leave the legacy
+opaque `sector` param accepted (non-breaking) but mark it deprecated in the docstring; the
+FE stops using it. Rationale: opaque `sector` has zero operator value; a clean explicit
+dimension beats overloading the old param. The opaque `sector` field stays in responses
+(SummaryStrip falls back to it when GICS is null).
+
+## Changes
+
+### Backend
+1. `app/services/sector_classification.py` — `sector_spdr_case_sql(sic_col: str) -> str`
+   generating a SQL `CASE` from `_CROSSWALK` in first-match order, safe text→int cast.
+   Inputs are module constants (range ints + SPDR keys validated ∈ `SPDR_SECTORS`); the
+   returned fragment embeds no user input. Pure helper, table-tested against
+   `resolve_sector_spdr` over the full 0–9999 SIC space.
+2. `app/api/instruments.py` `list_instruments` — add `sector_spdr` param; when set, join
+   `instrument_sec_profile p` + WHERE `<case(p.sic)> = %(sector_spdr)s` on BOTH count and
+   items (conditional join, mirroring the existing dividend/coverage pattern). Surface
+   `gics_sector` + `sector_spdr` on `InstrumentListItem` for display (cheap — already
+   joined when filtering; resolve in Python from the row's sic otherwise).
+3. `app/api/scores.py` `list_rankings` — same `sector_spdr` param + conditional join +
+   predicate. Add `gics_sector` to the ranking item so the table column shows the GICS
+   label, not the opaque code.
+
+### Frontend
+4. `src/api/types.ts` — `RankingItem` + instrument list item gain `gics_sector`
+   (+`sector_spdr` on list item), nullable to mirror backend.
+5. `src/api/rankings.ts` / `src/api/instruments.ts` — query types gain `sector_spdr`;
+   fetchers set the `sector_spdr` param.
+6. shared FE const `SECTOR_SPDRS` (SPDR symbol → GICS label) mirroring `SPDR_SECTORS`,
+   for the fixed 11-option dropdowns.
+7. `src/components/rankings/RankingsFilters.tsx` + `src/pages/InstrumentsPage.tsx` — Sector
+   dropdown becomes a fixed 11-option GICS list (label=GICS name, value=SPDR symbol) bound
+   to the `sector_spdr` filter; drop the data-derived opaque-code dropdown.
+8. `src/components/rankings/RankingsTable.tsx` — sector cell renders `gics_sector ?? "—"`.
+9. `src/components/instrument/RightRail.tsx` — `PeerSnapshot` takes `sectorSpdr` (filter)
+   + `sectorLabel` (GICS, for the title); fetches `/scores?sector_spdr=`.
+10. `src/pages/InstrumentPage.tsx` — pass `identity.sector_spdr` + `identity.gics_sector`
+    to RightRail.
+
+## Tests
+- Pure-logic: `sector_spdr_case_sql` SQL CASE evaluated (via the resolver's expected
+  output) matches `resolve_sector_spdr` across all SIC 0–9999 — the generated SQL and the
+  Python resolver cannot drift. (Eval the CASE semantics in Python by reusing `_CROSSWALK`,
+  OR a DB-backed test inserting fixture sics and asserting the filter returns the right set.)
+- FE: RightRail passes `sector_spdr`; dropdowns offer 11 fixed options.
+
+## DoD / dev-verify
+- Filter `/instruments?sector_spdr=XLK` and `/scores?sector_spdr=XLF` return only
+  XLK/XLF-resolved instruments (spot-check JPM∈XLF, AAPL∈XLK, SPY∉any).
+- RightRail on AAPL shows "Peer snapshot · Information Technology" with real XLK peers.
+- No backend metric/job change → no jobs-proc restart, no backfill, no sec_rebuild.

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -14,7 +14,9 @@ import type {
 
 export interface InstrumentsQuery {
   search: string | null;
-  sector: string | null;
+  // #1675: real GICS sector-SPDR symbol (e.g. "XLK"); replaces the opaque
+  // instruments.sector code as the operator-facing filter dimension.
+  sector_spdr: string | null;
   coverage_tier: number | null;
   exchange: string | null;
   has_dividend: boolean | null;
@@ -29,7 +31,7 @@ export function fetchInstruments(
 ): Promise<InstrumentListResponse> {
   const params = new URLSearchParams();
   if (query.search !== null) params.set("search", query.search);
-  if (query.sector !== null) params.set("sector", query.sector);
+  if (query.sector_spdr !== null) params.set("sector_spdr", query.sector_spdr);
   if (query.coverage_tier !== null)
     params.set("coverage_tier", String(query.coverage_tier));
   if (query.exchange !== null) params.set("exchange", query.exchange);

--- a/frontend/src/api/rankings.ts
+++ b/frontend/src/api/rankings.ts
@@ -14,7 +14,9 @@ import type { RankingsListResponse } from "@/api/types";
  */
 export interface RankingsQuery {
   coverage_tier: number | null;
-  sector: string | null;
+  // #1675: real GICS sector-SPDR symbol (e.g. "XLF"); replaces the opaque
+  // instruments.sector code as the peer-grouping dimension.
+  sector_spdr: string | null;
   stance: "buy" | "hold" | "watch" | "avoid" | null;
 }
 
@@ -33,8 +35,8 @@ export async function fetchRankings(
   if (query.coverage_tier !== null) {
     params.set("coverage_tier", String(query.coverage_tier));
   }
-  if (query.sector !== null) {
-    params.set("sector", query.sector);
+  if (query.sector_spdr !== null) {
+    params.set("sector_spdr", query.sector_spdr);
   }
   if (query.stance !== null) {
     params.set("stance", query.stance);

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -225,6 +225,11 @@ export interface InstrumentListItem {
   exchange: string | null;
   currency: string | null;
   sector: string | null;
+  // #1675: real GICS sector + sector-SPDR resolved on-read from the SEC SIC.
+  // null for ETFs / non-filers / unmapped SIC. `sector` above is the deprecated
+  // opaque 1-9 code.
+  gics_sector: string | null;
+  sector_spdr: string | null;
   is_tradable: boolean;
   coverage_tier: number | null;
   latest_quote: QuoteSnapshot | null;
@@ -885,6 +890,9 @@ export interface RankingItem {
   symbol: string;
   company_name: string;
   sector: string | null;
+  // #1675: real GICS sector resolved on-read from the SEC SIC (null for
+  // ETFs / non-filers / unmapped SIC). `sector` is the deprecated opaque code.
+  gics_sector: string | null;
   coverage_tier: number | null;
   rank: number | null;
   rank_delta: number | null;

--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -112,6 +112,7 @@ function rankingsWith(currentSymbol: string): RankingsListResponse {
         symbol: currentSymbol, // the current instrument appears in its own sector list
         company_name: `${currentSymbol} Inc.`,
         sector: "Technology",
+        gics_sector: "Information Technology",
         coverage_tier: 1,
         rank: 1,
         rank_delta: null,
@@ -133,6 +134,7 @@ function rankingsWith(currentSymbol: string): RankingsListResponse {
         symbol: "MSFT",
         company_name: "Microsoft Corp.",
         sector: "Technology",
+        gics_sector: "Information Technology",
         coverage_tier: 1,
         rank: 2,
         rank_delta: null,
@@ -179,19 +181,22 @@ beforeEach(() => {
 
 function renderRail(props: {
   instrumentId?: number;
-  sector?: string | null;
+  sectorSpdr?: string | null;
+  sectorLabel?: string | null;
   currentSymbol?: string;
 } = {}) {
   const {
     instrumentId = 42,
-    sector = "Technology",
+    sectorSpdr = "XLK",
+    sectorLabel = "Information Technology",
     currentSymbol = "AAPL",
   } = props;
   return render(
     <MemoryRouter>
       <RightRail
         instrumentId={instrumentId}
-        sector={sector}
+        sectorSpdr={sectorSpdr}
+        sectorLabel={sectorLabel}
         currentSymbol={currentSymbol}
         filingsActive={true}
       />
@@ -220,7 +225,7 @@ describe("RightRail", () => {
   });
 
   it("short-circuits peer fetch when sector is null", async () => {
-    renderRail({ sector: null });
+    renderRail({ sectorSpdr: null });
     await waitFor(() => {
       expect(
         screen.getByText(/Sector unknown — no peer set available/i),
@@ -260,6 +265,7 @@ describe("RightRail", () => {
           symbol: "AAPL",
           company_name: "Apple Inc.",
           sector: "Technology",
+          gics_sector: "Information Technology",
           coverage_tier: 1,
           rank: 1,
           rank_delta: null,
@@ -291,14 +297,14 @@ describe("RightRail", () => {
     });
   });
 
-  it("passes sector + limit=6 to fetchRankings", async () => {
+  it("passes sector_spdr + limit=6 to fetchRankings", async () => {
     mockedRankings.mockResolvedValue(rankingsEmpty());
-    renderRail({ sector: "Healthcare" });
+    renderRail({ sectorSpdr: "XLV" });
     await waitFor(() => {
       expect(mockedRankings).toHaveBeenCalledTimes(1);
     });
     const [query, limit] = mockedRankings.mock.calls[0]!;
-    expect(query).toMatchObject({ sector: "Healthcare" });
+    expect(query).toMatchObject({ sector_spdr: "XLV" });
     expect(limit).toBe(6);
   });
 });

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -29,7 +29,11 @@ import { useAsync } from "@/lib/useAsync";
 
 export interface RightRailProps {
   instrumentId: number;
-  sector: string | null;
+  /** #1675: real GICS sector-SPDR symbol (e.g. "XLK") — the peer-grouping
+   *  filter value. null for ETFs / non-filers / unmapped SIC. */
+  sectorSpdr: string | null;
+  /** GICS sector name for the section heading (e.g. "Information Technology"). */
+  sectorLabel: string | null;
   currentSymbol: string;
   /** True when at least one filings provider has rows for this
    *  instrument — derived upstream from
@@ -42,21 +46,23 @@ export interface RightRailProps {
 
 export function RightRail({
   instrumentId,
-  sector,
+  sectorSpdr,
+  sectorLabel,
   currentSymbol,
   filingsActive,
 }: RightRailProps): JSX.Element {
   return (
     <aside className="space-y-4">
       {filingsActive ? <RecentFilings instrumentId={instrumentId} /> : null}
-      {/* `key={sector}` forces a full remount when the sector changes
+      {/* `key={sectorSpdr}` forces a full remount when the sector changes
           so `useAsync` re-initialises with `loading=true, data=null`
           on the first render for the new sector — otherwise one frame
           would show the prior sector's peers under the new sector's
           heading (Codex slice-2 round-2 stale-data finding). */}
       <PeerSnapshot
-        key={sector ?? "__no_sector__"}
-        sector={sector}
+        key={sectorSpdr ?? "__no_sector__"}
+        sectorSpdr={sectorSpdr}
+        sectorLabel={sectorLabel}
         currentSymbol={currentSymbol}
       />
       <CopyExposure instrumentId={instrumentId} />
@@ -121,26 +127,28 @@ function FilingRow({ f }: { f: FilingItem }) {
 // ---------------------------------------------------------------------------
 
 function PeerSnapshot({
-  sector,
+  sectorSpdr,
+  sectorLabel,
   currentSymbol,
 }: {
-  sector: string | null;
+  sectorSpdr: string | null;
+  sectorLabel: string | null;
   currentSymbol: string;
 }) {
-  // `sector=null` short-circuits the fetch to avoid a pointless 200-row
+  // `sectorSpdr=null` short-circuits the fetch to avoid a pointless 200-row
   // rankings call on unknown-sector instruments.
   const { data, error, loading, refetch } = useAsync(
     async () => {
-      if (sector === null) return null;
+      if (sectorSpdr === null) return null;
       return await fetchRankings(
-        { coverage_tier: null, sector, stance: null },
+        { coverage_tier: null, sector_spdr: sectorSpdr, stance: null },
         6, // top 5 + room to filter out the current instrument
       );
     },
-    [sector],
+    [sectorSpdr],
   );
 
-  if (sector === null) {
+  if (sectorSpdr === null) {
     return (
       <Section title="Peer snapshot">
         <div className="text-xs text-slate-500">
@@ -161,7 +169,7 @@ function PeerSnapshot({
       : data.items.filter((r) => r.symbol !== currentSymbol).slice(0, 5);
 
   return (
-    <Section title={`Peer snapshot · ${sector}`}>
+    <Section title={`Peer snapshot · ${sectorLabel ?? sectorSpdr}`}>
       {loading && <SectionSkeleton rows={3} />}
       {error !== null && <SectionError onRetry={refetch} />}
       {!loading && error === null && peers !== null && peers.length === 0 && (

--- a/frontend/src/components/rankings/RankingsFilters.tsx
+++ b/frontend/src/components/rankings/RankingsFilters.tsx
@@ -1,11 +1,12 @@
 import type { RankingsQuery } from "@/api/rankings";
+import { SECTOR_OPTIONS } from "@/lib/sectors";
 
 /**
  * Filter bar for the rankings page.
  *
  * Server-side filters (sent to /rankings as query params):
  *   - coverage_tier (1 / 2 / 3)
- *   - sector
+ *   - sector_spdr (real GICS sector, #1675)
  *   - stance (buy / hold / watch / avoid)
  *
  * Client-side filter (applied to the in-memory result set):
@@ -13,10 +14,9 @@ import type { RankingsQuery } from "@/api/rankings";
  *
  * Sort is also client-side and lives on the table component, not here.
  *
- * Sector options are derived from rows the page has *seen so far*.  Once
- * the user selects a sector the API only returns rows for that sector, so
- * a naive "derive from current items" would shrink the dropdown to a
- * single option.  The page passes a monotonically-growing set instead.
+ * Sector options are the fixed 11 GICS sectors (#1675, SECTOR_OPTIONS) — value
+ * is the SPDR symbol sent to the API, label is the GICS name. No longer derived
+ * from data: the opaque 1-9 code it replaced had no operator meaning.
  */
 
 export const STANCE_OPTIONS = ["buy", "hold", "watch", "avoid"] as const;
@@ -29,7 +29,6 @@ export interface RankingsFiltersProps {
   onQueryChange: (next: RankingsQuery) => void;
   scoreThreshold: number | null;
   onScoreThresholdChange: (next: number | null) => void;
-  knownSectors: ReadonlyArray<string>;
   onClearAll: () => void;
   filtersDirty: boolean;
 }
@@ -39,7 +38,6 @@ export function RankingsFilters({
   onQueryChange,
   scoreThreshold,
   onScoreThresholdChange,
-  knownSectors,
   onClearAll,
   filtersDirty,
 }: RankingsFiltersProps) {
@@ -75,16 +73,16 @@ export function RankingsFilters({
         <select
           id="rk-sector"
           className={fieldClass}
-          value={query.sector ?? ""}
+          value={query.sector_spdr ?? ""}
           onChange={(e) => {
             const v = e.target.value;
-            onQueryChange({ ...query, sector: v === "" ? null : v });
+            onQueryChange({ ...query, sector_spdr: v === "" ? null : v });
           }}
         >
           <option value="">All</option>
-          {knownSectors.map((s) => (
-            <option key={s} value={s}>
-              {s}
+          {SECTOR_OPTIONS.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
             </option>
           ))}
         </select>

--- a/frontend/src/components/rankings/RankingsTable.tsx
+++ b/frontend/src/components/rankings/RankingsTable.tsx
@@ -25,7 +25,7 @@ import { RankDeltaCell } from "@/components/rankings/RankDeltaCell";
 type SortKey =
   | "rank"
   | "symbol"
-  | "sector"
+  | "gics_sector"
   | "coverage_tier"
   | "total_score"
   | "quality_score"
@@ -49,7 +49,7 @@ const COLUMNS: ReadonlyArray<ColumnDef> = [
   { key: "rank", label: "Rank", align: "right", defaultDir: "asc" },
   { key: "rank_delta", label: "Δ", align: "right", defaultDir: "asc" },
   { key: "symbol", label: "Symbol", align: "left", defaultDir: "asc" },
-  { key: "sector", label: "Sector", align: "left", defaultDir: "asc" },
+  { key: "gics_sector", label: "Sector", align: "left", defaultDir: "asc" },
   { key: "coverage_tier", label: "Tier", align: "right", defaultDir: "asc" },
   { key: "total_score", label: "Total", align: "right", defaultDir: "desc" },
   { key: "quality_score", label: "Quality", align: "right", defaultDir: "desc" },
@@ -206,7 +206,7 @@ function RankingRow({ item }: { item: RankingItem }) {
           {item.symbol}
         </Link>
       </td>
-      <td className="px-2 py-2 text-slate-700">{item.sector ?? "—"}</td>
+      <td className="px-2 py-2 text-slate-700">{item.gics_sector ?? "—"}</td>
       <td className="px-2 py-2 text-right tabular-nums">
         {item.coverage_tier === null ? "—" : item.coverage_tier}
       </td>

--- a/frontend/src/lib/sectors.ts
+++ b/frontend/src/lib/sectors.ts
@@ -1,0 +1,28 @@
+/**
+ * GICS sector-SPDR options for the operator-facing sector filter (#1675).
+ *
+ * Mirror of `app/services/sector_classification.py::SPDR_SECTORS` (the backend
+ * single source of truth). The filter value is the SPDR symbol (e.g. `XLK`);
+ * the label is the GICS sector name. Kept in sync by hand — the set is the 11
+ * fixed GICS sectors and does not change.
+ */
+export interface SectorOption {
+  /** SPDR symbol — the `sector_spdr` filter value sent to the API. */
+  value: string;
+  /** GICS sector name — the human-readable dropdown label. */
+  label: string;
+}
+
+export const SECTOR_OPTIONS: readonly SectorOption[] = [
+  { value: "XLC", label: "Communication Services" },
+  { value: "XLY", label: "Consumer Discretionary" },
+  { value: "XLP", label: "Consumer Staples" },
+  { value: "XLE", label: "Energy" },
+  { value: "XLF", label: "Financials" },
+  { value: "XLV", label: "Health Care" },
+  { value: "XLI", label: "Industrials" },
+  { value: "XLK", label: "Information Technology" },
+  { value: "XLB", label: "Materials" },
+  { value: "XLRE", label: "Real Estate" },
+  { value: "XLU", label: "Utilities" },
+] as const;

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -731,7 +731,8 @@ function InstrumentPageBody({
           <div className="lg:col-span-4">
             <RightRail
               instrumentId={summary.instrument_id}
-              sector={summary.identity.sector}
+              sectorSpdr={summary.identity.sector_spdr}
+              sectorLabel={summary.identity.gics_sector}
               currentSymbol={summary.identity.symbol}
               filingsActive={hasActiveCapability(summary, "filings")}
             />

--- a/frontend/src/pages/InstrumentsPage.test.tsx
+++ b/frontend/src/pages/InstrumentsPage.test.tsx
@@ -41,6 +41,8 @@ function makeResponse(
         exchange: "NASDAQ",
         currency: "USD",
         sector: "Technology",
+        gics_sector: "Information Technology",
+        sector_spdr: "XLK",
         is_tradable: true,
         coverage_tier: 1,
         latest_quote: {
@@ -58,6 +60,8 @@ function makeResponse(
         exchange: "NASDAQ",
         currency: "USD",
         sector: "Technology",
+        gics_sector: "Information Technology",
+        sector_spdr: "XLK",
         is_tradable: true,
         coverage_tier: 2,
         latest_quote: {
@@ -75,6 +79,8 @@ function makeResponse(
         exchange: "NYSE",
         currency: "USD",
         sector: "Financial Services",
+        gics_sector: "Financials",
+        sector_spdr: "XLF",
         is_tradable: true,
         coverage_tier: null,
         latest_quote: null,

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -21,6 +21,7 @@ import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/S
 import { EmptyState } from "@/components/states/EmptyState";
 import { Pagination } from "@/components/ui/Pagination";
 import { formatMoney } from "@/lib/format";
+import { SECTOR_OPTIONS } from "@/lib/sectors";
 import { useAsync } from "@/lib/useAsync";
 
 // ---------------------------------------------------------------------------
@@ -29,7 +30,9 @@ import { useAsync } from "@/lib/useAsync";
 
 interface Filters {
   search: string;
-  sector: string | null;
+  // #1675: real GICS sector-SPDR symbol (e.g. "XLK"); replaces the opaque
+  // instruments.sector code as the filter dimension.
+  sector_spdr: string | null;
   exchange: string | null;
   coverage_tier: number | null;
   has_dividend: boolean | null;
@@ -37,7 +40,7 @@ interface Filters {
 
 const INITIAL_FILTERS: Filters = {
   search: "",
-  sector: null,
+  sector_spdr: null,
   exchange: null,
   coverage_tier: null,
   has_dividend: null,
@@ -47,7 +50,7 @@ const INITIAL_FILTERS: Filters = {
 // Sort state (client-side within the fetched page)
 // ---------------------------------------------------------------------------
 
-type SortKey = "symbol" | "sector" | "exchange" | "coverage_tier" | "last";
+type SortKey = "symbol" | "gics_sector" | "exchange" | "coverage_tier" | "last";
 type SortDir = "asc" | "desc";
 
 function compare(a: unknown, b: unknown, dir: SortDir): number {
@@ -68,8 +71,8 @@ function sortValue(item: InstrumentListItem, key: SortKey): unknown {
   switch (key) {
     case "symbol":
       return item.symbol;
-    case "sector":
-      return item.sector;
+    case "gics_sector":
+      return item.gics_sector;
     case "exchange":
       return item.exchange;
     case "coverage_tier":
@@ -128,7 +131,7 @@ export function InstrumentsPage() {
   const query: InstrumentsQuery = useMemo(
     () => ({
       search: filters.search || null,
-      sector: filters.sector,
+      sector_spdr: filters.sector_spdr,
       exchange: filters.exchange,
       coverage_tier: filters.coverage_tier,
       has_dividend: filters.has_dividend,
@@ -141,28 +144,19 @@ export function InstrumentsPage() {
   // useAsync captures fn via a ref — fresh arrow per render is fine.
   const result = useAsync(() => fetchInstruments(query), [query]);
 
-  // Extract distinct sectors and exchanges from data for filter dropdowns.
-  // This gives us a good-enough set from the current page; a full enum
+  // Sector dropdown uses the fixed 11 GICS sectors (#1675, SECTOR_OPTIONS), so
+  // only exchange is still derived from the current page's data. A full enum
   // endpoint would be better but is not in scope.
-  const [knownSectors, setKnownSectors] = useState<string[]>([]);
   const [knownExchanges, setKnownExchanges] = useState<string[]>([]);
 
-  // Reset accumulated filter options when filters change (prevents stale
-  // options from prior queries lingering in the dropdowns).
+  // Reset accumulated exchange options when filters change (prevents stale
+  // options from prior queries lingering in the dropdown).
   useEffect(() => {
-    setKnownSectors([]);
     setKnownExchanges([]);
   }, [filters]);
 
   useEffect(() => {
     if (!result.data) return;
-    setKnownSectors((prev) => {
-      const next = new Set(prev);
-      for (const item of result.data!.items) {
-        if (item.sector) next.add(item.sector);
-      }
-      return Array.from(next).sort();
-    });
     setKnownExchanges((prev) => {
       const next = new Set(prev);
       for (const item of result.data!.items) {
@@ -231,12 +225,25 @@ export function InstrumentsPage() {
           />
         </div>
 
-        <FilterSelect
-          label="Sector"
-          value={filters.sector ?? ""}
-          options={knownSectors}
-          onChange={(v) => handleFilterChange("sector", v)}
-        />
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            Sector
+          </label>
+          <select
+            value={filters.sector_spdr ?? ""}
+            onChange={(e) =>
+              handleFilterChange("sector_spdr", e.target.value || null)
+            }
+            className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+          >
+            <option value="">All</option>
+            {SECTOR_OPTIONS.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </div>
         <FilterSelect
           label="Exchange"
           value={filters.exchange ?? ""}
@@ -298,7 +305,7 @@ export function InstrumentsPage() {
             title="No instruments found"
             description={
               filters.search ||
-              filters.sector ||
+              filters.sector_spdr ||
               filters.exchange ||
               filters.coverage_tier !== null ||
               filters.has_dividend !== null
@@ -368,7 +375,7 @@ function FilterSelect({
 
 const COLUMNS: { key: SortKey; label: string; align?: "right" }[] = [
   { key: "symbol", label: "Instrument" },
-  { key: "sector", label: "Sector" },
+  { key: "gics_sector", label: "Sector" },
   { key: "exchange", label: "Exchange" },
   { key: "coverage_tier", label: "Tier" },
   { key: "last", label: "Last price", align: "right" },
@@ -435,7 +442,7 @@ function InstrumentsTable({
                 <div className="text-xs text-slate-500">{item.company_name}</div>
               </td>
               <td className="py-2 pr-4 text-xs text-slate-600">
-                {item.sector ?? "—"}
+                {item.gics_sector ?? "—"}
               </td>
               <td className="py-2 pr-4 text-xs text-slate-600">
                 {item.exchange ?? "—"}

--- a/frontend/src/pages/RankingsPage.test.tsx
+++ b/frontend/src/pages/RankingsPage.test.tsx
@@ -12,6 +12,7 @@ function _item(overrides: Partial<RankingItem>): RankingItem {
     symbol: "AAA",
     company_name: "Alpha Co",
     sector: "Tech",
+    gics_sector: "Information Technology",
     coverage_tier: 1,
     rank: 1,
     rank_delta: 0,

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -16,9 +16,9 @@ import type { RankingItem, RankingsListResponse } from "@/api/types";
  * this page does NOT call /instruments — calling it would be a redundant
  * round-trip for data already in hand.
  *
- * Server-side filters: coverage_tier, sector, stance — included in the
- * query string and therefore in the useAsync deps so a refetch fires when
- * they change.
+ * Server-side filters: coverage_tier, sector_spdr (real GICS sector, #1675),
+ * stance — included in the query string and therefore in the useAsync deps so
+ * a refetch fires when they change.
  *
  * Client-side filters / controls: minimum total_score, column sort. These
  * never trigger a refetch.
@@ -32,7 +32,7 @@ import type { RankingItem, RankingsListResponse } from "@/api/types";
 export function RankingsPage() {
   const [query, setQuery] = useState<RankingsQuery>({
     coverage_tier: null,
-    sector: null,
+    sector_spdr: null,
     stance: null,
   });
   const [scoreThreshold, setScoreThreshold] = useState<number | null>(null);
@@ -46,42 +46,15 @@ export function RankingsPage() {
     return () => clearTimeout(timer);
   }, [searchInput]);
 
-  // Sector dropdown options must be derived from data the page has seen,
-  // not from the *current* response. Once a sector filter is applied the
-  // response only contains rows for that sector, which would otherwise
-  // collapse the dropdown to one option. Cache grows monotonically.
-  const [knownSectors, setKnownSectors] = useState<ReadonlyArray<string>>([]);
-
   // useAsync captures fn via a ref — fresh arrow per render is fine.
   const rankings = useAsync(
     () => fetchRankings(query),
-    [query.coverage_tier, query.sector, query.stance],
+    [query.coverage_tier, query.sector_spdr, query.stance],
   );
-
-  // Functional setState reads the freshest `prev` snapshot from React,
-  // not the closure-captured `knownSectors` from the render in which this
-  // effect was registered. Without this, two rapid data updates landing
-  // in the same tick could re-seed from a stale snapshot and silently
-  // drop sectors added in the first update.
-  useEffect(() => {
-    const data = rankings.data;
-    if (data === null) return;
-    setKnownSectors((prev) => {
-      const next = new Set(prev);
-      let added = false;
-      for (const item of data.items) {
-        if (item.sector !== null && !next.has(item.sector)) {
-          next.add(item.sector);
-          added = true;
-        }
-      }
-      return added ? Array.from(next).sort() : prev;
-    });
-  }, [rankings.data]);
 
   const filtersDirty =
     query.coverage_tier !== null ||
-    query.sector !== null ||
+    query.sector_spdr !== null ||
     query.stance !== null ||
     scoreThreshold !== null ||
     // Use the un-debounced searchInput so Clear All shows immediately
@@ -115,7 +88,7 @@ export function RankingsPage() {
   }, [rankings.data]);
 
   const onClearAll = () => {
-    setQuery({ coverage_tier: null, sector: null, stance: null });
+    setQuery({ coverage_tier: null, sector_spdr: null, stance: null });
     setScoreThreshold(null);
     setSearchInput("");
     setSearch("");
@@ -177,7 +150,6 @@ export function RankingsPage() {
           onQueryChange={setQuery}
           scoreThreshold={scoreThreshold}
           onScoreThresholdChange={setScoreThreshold}
-          knownSectors={knownSectors}
           onClearAll={onClearAll}
           filtersDirty={filtersDirty}
         />

--- a/tests/test_sector_classification.py
+++ b/tests/test_sector_classification.py
@@ -7,12 +7,14 @@ the override-before-major-group ordering, and the SPDR/SPDR_SECTORS invariants.
 
 from __future__ import annotations
 
+import psycopg
 import pytest
 
 from app.services.sector_classification import (
     _CROSSWALK,
     SPDR_SECTORS,
     resolve_sector_spdr,
+    sector_spdr_case_sql,
 )
 from app.workers.scheduler import BENCHMARK_SYMBOLS
 
@@ -104,3 +106,47 @@ class TestInvariants:
         out = resolve_sector_spdr("3841")
         assert out is not None
         assert out.gics_sector == SPDR_SECTORS[out.spdr_symbol] == "Health Care"
+
+
+class TestSqlCaseParity:
+    """The generated SQL CASE (#1675 sector_spdr filter) must resolve a SIC
+    identically to the Python ``resolve_sector_spdr``. Executed against real
+    Postgres — a Python-only re-eval could pass while the emitted SQL was
+    syntactically broken, mis-ordered, or cast/guarded wrong (Codex ckpt-1)."""
+
+    def test_full_domain_parity(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # Sweep every SIC 0..9999 through the emitted CASE (column aliased p.sic
+        # to match the hardcoded reference) and compare to the Python resolver.
+        case = sector_spdr_case_sql()
+        sql = (
+            f"SELECT p.sic, ({case}) AS spdr "  # noqa: S608 — module-constant fragment
+            "FROM (SELECT g::text AS sic FROM generate_series(0, 9999) g) p"
+        )
+        rows = ebull_test_conn.execute(sql).fetchall()  # type: ignore[arg-type]  # SQL built from module-constant fragment
+        assert len(rows) == 10_000
+        mismatches = [
+            (sic, sql_spdr, resolve_sector_spdr(sic))
+            for sic, sql_spdr in rows
+            if sql_spdr != (lambda r: r.spdr_symbol if r else None)(resolve_sector_spdr(sic))
+        ]
+        assert mismatches == []
+
+    @pytest.mark.parametrize(
+        "sic",
+        ["0100", " 0100 ", "abc", "", "05", "6021", "3571", "9999", "0"],
+    )
+    def test_edge_case_parity(self, ebull_test_conn: psycopg.Connection[tuple], sic: str) -> None:
+        # Leading zeros, whitespace, non-numeric, empty, out-of-range — the SQL
+        # guard + cast must agree with Python over the realistic SIC domain.
+        sql = f"SELECT ({sector_spdr_case_sql()}) FROM (VALUES (%s)) AS p(sic)"  # noqa: S608 — module-constant fragment
+        row = ebull_test_conn.execute(sql, (sic,)).fetchone()  # type: ignore[arg-type]
+        assert row is not None
+        py = resolve_sector_spdr(sic)
+        assert row[0] == (py.spdr_symbol if py is not None else None)
+
+    def test_null_sic_parity(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        sql = f"SELECT ({sector_spdr_case_sql()}) FROM (VALUES (CAST(NULL AS text))) AS p(sic)"  # noqa: S608
+        row = ebull_test_conn.execute(sql).fetchone()  # type: ignore[arg-type]
+        assert row is not None
+        assert row[0] is None
+        assert resolve_sector_spdr(None) is None


### PR DESCRIPTION
Closes #1675. Refs #1634.

## Problem
`instruments.sector` is an opaque 1–9 code with no GICS/SPDR meaning — SPY/XLE/XLF/XLK (ETFs, no SIC) **and** JPM all sit in code `4`, AAPL in `3`. Every surface that filtered or grouped on `i.sector` produced garbage peer sets. #1634 shipped the real SIC→GICS-sector→SPDR crosswalk (`resolve_sector_spdr`) but display-only; this switches the **filter / peer-grouping dimension** onto it.

## Source rule
Classification is fixed by the #1634 crosswalk (`docs/specs/metrics/2026-06-18-sic-gics-spdr-crosswalk.md`): SEC 4-digit SIC (`instrument_sec_profile.sic`) → 11 GICS sectors → sector SPDR. `resolve_sector_spdr` is the single source of truth. No new classification logic.

## Premise falsified — no stored/indexed column needed
Full-pop dev scan: 12,547 instruments, `sic` is `text`/pure-4-digit. A `LEFT JOIN instrument_sec_profile` + CASE-range resolve is a sub-ms seq scan at this scale. Live SQL resolve keeps #1634's deliberate persist-nothing posture (no migration, no backfill, no drift-on-SIC-change). Resolves 5,250/12,547 (41.8%); the rest are ETFs/non-filers with no SIC → `None` (no peer set), by design. GICS dist sane: XLV 995, XLF 899, XLI 846, XLK 758, …

## Design — two-path resolve
- **Display** (`gics_sector` on every list/ranking row): items query always `LEFT JOIN instrument_sec_profile p` + selects `p.sic`; Python row-builder calls `resolve_sector_spdr(row["sic"])` (same pattern as the detail endpoint). PK join, trivial.
- **Filter** (`?sector_spdr=XLK`): SQL-side resolution (needed for correct pagination) via new `sector_spdr_case_sql()` — a `CASE` generated from `_CROSSWALK` in first-match order so it **cannot drift** from the Python resolver. Outer `btrim(p.sic) ~ '^[0-9]+$'` guard fences the `::int` cast (short-circuits on NULL/non-digit). Embeds only module constants (range ints + SPDR keys asserted ∈ `SPDR_SECTORS`) — no caller input; safe to inline.

## API contract
Adds `sector_spdr` query param (value = SPDR symbol) to `/instruments` and `/rankings`. The legacy opaque `sector` param stays accepted (non-breaking) but is marked deprecated; the FE no longer uses it. The opaque `sector` field stays in responses (SummaryStrip falls back to it when GICS is null).

## Changes
**Backend**
- `app/services/sector_classification.py`: `sector_spdr_case_sql()` + normalized `except (TypeError, ValueError)`.
- `app/api/instruments.py`: `sector_spdr` param; always-join sec_profile + `p.sic`; conditional COUNT join; per-row GICS resolve; `gics_sector`/`sector_spdr` on `InstrumentListItem`.
- `app/api/scores.py`: same `sector_spdr` param + always-join + `gics_sector` on `RankingItem`.

**Frontend**
- `src/lib/sectors.ts`: fixed 11-option `SECTOR_OPTIONS` (mirror of backend `SPDR_SECTORS`).
- query types + fetchers (`instruments.ts`, `rankings.ts`) → `sector_spdr`; `types.ts` mirrors.
- `RankingsFilters` + `InstrumentsPage` sector dropdowns → fixed GICS options (drop data-derived opaque-code lists).
- `RankingsTable` + `InstrumentsPage` sector column → `gics_sector` (sort key aligned).
- `RightRail` peer snapshot → `sectorSpdr` (filter) + `sectorLabel` (title); `InstrumentPage` feeds `identity.sector_spdr`/`gics_sector`.

## Security model
SQL filter built from module-constant fragments only (no user input in the CASE; bounds `int`-formatted, SPDR literals asserted ∈ constant). `sector_spdr` filter value is a bound parameter. No new auth surface. Read-path only — no migration/schema/backfill/jobs-restart/sec_rebuild.

## Verification
- **Full-population SQL↔Python parity**: DB-backed test sweeps the emitted CASE over SIC 0–9999 + edge cases (leading-zero, whitespace, non-numeric, empty, NULL) and asserts equivalence with `resolve_sector_spdr`. 0 mismatches.
- **Live dev (HEAD pre-merge)**: `/instruments?sector_spdr=XLK` → 758 rows (== full-pop XLK count), all IT, AAPL present; `/rankings?sector_spdr=XLF` → 641 Financials; JPM sic 6021→XLF, AAPL 3571→XLK.
- Gates: ruff/format/pyright clean; `pytest -m "not db"` 4422 passed; `tests/test_sector_classification.py` 57 passed (incl DB parity); smoke 129 passed; FE typecheck clean + `test:unit` 1060 passed.
- Codex ckpt-1 (7 findings folded into spec: endpoint name, always-join for display, parity test rigor, guard-vs-int() divergence, injection surface) + ckpt-2 (no findings).

Commit: ab46f23b