### PR TITLE
feat(#1665): per-class float value as a separate labelled stat

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -175,6 +175,14 @@ class InstrumentIdentity(BaseModel):
     country: str | None
     currency: str | None
     market_cap: Decimal | None
+    # #1665: per-class FLOAT value of THIS instrument's own share class — its
+    # FSDS shares × its price (GOOGL Class A ≈ $2.15T), a SEPARATE stat from
+    # ``market_cap`` (the whole company, ≈ $4.45T, identical across siblings).
+    # Non-null ONLY for a curated dual-class issuer where this instrument is a
+    # priced per-class leg; null for single-class issuers (``market_cap`` already
+    # IS the sole class value) and where no clean per-class leg exists.
+    # Required-nullable (no default) to mirror the TS ``string | null`` exactly.
+    class_market_value: Decimal | None
     # #819: when set, this instrument is an operational duplicate
     # (e.g. ``AAPL.RTH``) of the named canonical symbol
     # (``AAPL``). The frontend should redirect to the canonical
@@ -3429,6 +3437,7 @@ def get_instrument_summary(
         country=row["country"],  # type: ignore[arg-type]
         currency=row["currency"],  # type: ignore[arg-type]
         market_cap=None,
+        class_market_value=None,
         canonical_symbol=row.get("canonical_symbol"),  # type: ignore[arg-type]
     )
 
@@ -3485,11 +3494,21 @@ def get_instrument_summary(
         else:
             single_cap = compute_market_cap(conn, instrument_id=instrument_id_int)
             computed_cap_value = single_cap.value if single_cap is not None else None
+        # #1665: per-class float value of THIS instrument's own share class.
+        # Travels on the same resolution (no extra query); set only on the
+        # total_company basis, so it is null for single-class issuers.
+        class_market_value: Decimal | None = cap_resolution.class_market_value
     except Exception:
         logger.warning("compute_market_cap failed", exc_info=True)
         computed_cap_value = None
+        class_market_value = None
+    identity_update: dict[str, Decimal | None] = {}
     if computed_cap_value is not None:
-        identity = identity.model_copy(update={"market_cap": computed_cap_value})
+        identity_update["market_cap"] = computed_cap_value
+    if class_market_value is not None:
+        identity_update["class_market_value"] = class_market_value
+    if identity_update:
+        identity = identity.model_copy(update=identity_update)
 
     # Dividend yield: SEC dividend summary (#426). Empty when the
     # instrument has never paid a dividend; key stats path falls

--- a/app/services/xbrl_derived_stats.py
+++ b/app/services/xbrl_derived_stats.py
@@ -173,6 +173,13 @@ class TotalCompanyMarketCap:
     residual_shares: Decimal
     imputed_residual: bool
     leg_count: int
+    # The priced traded legs that summed into ``value`` — one per share-class
+    # sibling instrument (the imputed untraded residual class is NOT a leg: it has
+    # no instrument). Carried so a caller can surface a single sibling's per-class
+    # FLOAT value (its ``shares × price``) — the tradable-class market value, a
+    # SEPARATE stat from this total-company ``value`` (#1665). Σ over ``legs`` =
+    # ``value - residual_shares × <largest-leg price>``.
+    legs: tuple[_ClassLeg, ...]
 
 
 MarketCapBasis = Literal["total_company", "multiclass_unavailable", "not_multiclass"]
@@ -192,6 +199,14 @@ class MarketCapResolution:
 
     basis: MarketCapBasis
     total: TotalCompanyMarketCap | None = None
+    # Per-class FLOAT value of the VIEWED instrument's own share class — its leg's
+    # ``shares × price`` (#1665). A SEPARATE stat from ``total.value`` (the whole
+    # company): GOOGL Class A ≈ $2.15T vs Alphabet total ≈ $4.45T. Set only for
+    # ``total_company`` basis, and only when the viewed instrument is itself a
+    # priced leg (``None`` for a same-CIK sibling with no FSDS class row, and for
+    # ``not_multiclass`` / ``multiclass_unavailable`` — which scopes the stat to
+    # curated dual-class issuers).
+    class_market_value: Decimal | None = None
 
 
 def _sum_class_caps(legs: list[_ClassLeg], residual_shares: Decimal, impute_price: Decimal) -> Decimal:
@@ -203,6 +218,20 @@ def _sum_class_caps(legs: list[_ClassLeg], residual_shares: Decimal, impute_pric
     if residual_shares > 0:
         total += residual_shares * impute_price
     return total
+
+
+def _leg_market_value(total: TotalCompanyMarketCap, instrument_id: int) -> Decimal | None:
+    """Per-class FLOAT value of ``instrument_id``'s own leg within ``total`` — its
+    ``shares × price`` (#1665). The FSDS table PK is ``(instrument_id, period_end)``
+    and ``_build_total_company_cap`` reads a single ``period_end``, so AT MOST ONE
+    leg can match a given instrument — this returns the first match (defensive: a
+    hypothetical duplicate-ID leg list must not double-count). ``None`` when the
+    viewed instrument is not itself a priced leg (e.g. a same-CIK ``.US`` listing
+    with no FSDS class row). Pure — table-tested without a DB."""
+    for leg in total.legs:
+        if leg.instrument_id == instrument_id:
+            return leg.shares * leg.price
+    return None
 
 
 def _latest_price(conn: psycopg.Connection[Any], instrument_id: int) -> Decimal | None:
@@ -329,6 +358,7 @@ def _assemble_total_company_cap(
         residual_shares=residual_shares,
         imputed_residual=residual_shares > 0,
         leg_count=len(legs),
+        legs=tuple(legs),
     )
 
 
@@ -439,7 +469,14 @@ def resolve_market_cap_basis(
 
     total = _build_total_company_cap(conn, instrument_id, cik)
     if total is not None:
-        return MarketCapResolution(basis="total_company", total=total)
+        # Also surface the viewed instrument's OWN per-class float value (#1665) —
+        # a SEPARATE stat from the total-company ``value``. None when this sibling
+        # is not itself a priced leg.
+        return MarketCapResolution(
+            basis="total_company",
+            total=total,
+            class_market_value=_leg_market_value(total, instrument_id),
+        )
     # Curated dual-class issuer but no clean total → suppress, do not publish the
     # structurally-wrong combined×price for a known dual-class issuer.
     return MarketCapResolution(basis="multiclass_unavailable")

--- a/docs/specs/etl/2026-06-19-per-class-float-stat.md
+++ b/docs/specs/etl/2026-06-19-per-class-float-stat.md
@@ -1,0 +1,128 @@
+# Per-class float value as a separate labelled stat (#1665)
+
+Follow-up to #1662 (PR #1666). Refs #1662, #1664.
+
+## Problem
+
+Issue #1662 made `identity.market_cap` the **total company** capitalization
+(Σ class×price, identical across GOOG/GOOGL). The per-class **float value**
+(GOOGL Class A shares × Class A price ≈ $2.16T) is a genuinely distinct,
+meaningful number — the tradable-class market value, what a this-ticker view
+wants — but it is NOT "market cap" and must stay clearly separated from it
+(conflating them is exactly the #1662 bug). Today that per-leg figure is
+computed inside `_assemble_total_company_cap` and then **discarded** (only the
+aggregate `value` survives on `TotalCompanyMarketCap`).
+
+## Source rule
+
+No SEC reg governs a *display* label. The data-treatment rule IS #1662 /
+data-engineer invariant **I20** (`.claude/skills/data-engineer/SKILL.md`) /
+prevention-log §"Market cap of a multi-class issuer is the total company …"
+(`docs/review-prevention-log.md:1863`): "per-class float is a separate,
+separately-labelled stat." This ticket implements the second half of that
+settled sentence. Per-class shares are the curated #1623 FSDS table
+`instrument_class_shares_outstanding`; price is the same `quotes` mark hierarchy
+`compute_market_cap` / `_latest_price` use.
+
+## Full-population verification (dev DB, 2026-06-19)
+
+Curated dual-class universe = 3 issuers / 6 instruments (every CIK in
+`instrument_class_shares_outstanding`):
+
+| symbol | class member | shares | price | class market value |
+|---|---|---|---|---|
+| GOOGL | CommonClassA | 5.835B | 369.20 | **$2.1543T** |
+| GOOG  | CapitalClassC | 5.515B | 357.23 | **$1.9701T** |
+| HEI / HEI.A | — | 55.0M / 83.9M | none | — (no price → null) |
+| METC / METCB | — | 43.8M / 9.5M | none | — (no price → null) |
+
+GOOGL $2.1543T matches the issue's ≈$2.16T. Per-class value is **per-leg**
+(NOT identical across siblings — the whole point): GOOGL $2.15T vs GOOG $1.97T,
+while `market_cap` (total) is $4.4476T on both. HEICO/Ramaco have no quote on
+file → their total fails closed today and the per-class value is honestly null.
+
+The dev DB IS the operational population here (demo-first, single-operator; no
+separate prod corpus — settled "Risk posture: Demo-first"). The curated set the
+safety rests on is the #1623 CIK→class map in
+`instrument_class_shares_outstanding`, which is environment-independent: any
+deployment reads the same curated table, so this full-pop scan generalizes.
+
+## Design — PURE READ-PATH
+
+The per-class float for the viewed instrument = its OWN leg's `shares × price`.
+That leg is already built inside `_assemble_total_company_cap`; carry it out and
+let `resolve_market_cap_basis` (which knows `instrument_id`) pick the matching
+leg. Reusing the assembled leg guarantees the displayed per-class value is the
+EXACT leg the total summed — identical shares, identical price, identical
+`class_shares_usable` filter — so the class value can never disagree with its own
+contribution to `market_cap`. (It does NOT guarantee cross-class quote-timestamp
+coherence: `_latest_price` reads each sibling's newest quote independently, same
+as today's total. That is acceptable — both figures already inherit it.) A
+separate re-read of shares+price for the per-class value, by contrast, could pick
+a different tick or a row the total's usability filter rejected, publishing a
+class value incoherent with the total it sits beside.
+
+1. `TotalCompanyMarketCap`: add `legs: tuple[_ClassLeg, ...]` (the priced traded
+   legs; the imputed residual class has no instrument and is excluded).
+2. `_assemble_total_company_cap`: set `legs=tuple(legs)` on the return. No logic
+   change — the legs already exist at that point.
+3. `MarketCapResolution`: add `class_market_value: Decimal | None = None`.
+4. `resolve_market_cap_basis`: when `basis == "total_company"`, select the leg
+   whose `instrument_id == instrument_id` → `class_market_value = shares × price`.
+   The FSDS table PK is `(instrument_id, period_end)`
+   (`sql/200_instrument_class_shares_outstanding.sql:47`) and `_build_total_company_cap`
+   reads a single `period_end`, so **at most one** leg can match a given
+   instrument — the pick is exactly-one-or-none, not a sum. Defensive: iterate and
+   take the first match (a duplicate-ID pure test locks that a hypothetical
+   double-ID `legs_raw` does not double-count). `None` when the viewed instrument
+   is not a priced leg (e.g. a same-CIK `.US` listing with no FSDS class row).
+   Naturally null for `not_multiclass` (single-class: `market_cap` already IS the
+   sole class value) and `multiclass_unavailable` → scopes the new stat to curated
+   dual-class only.
+5. API `_build_instrument_summary` (instruments.py ~3480): set
+   `identity.class_market_value = cap_resolution.class_market_value`.
+6. `InstrumentIdentity` (py + TS `types.ts`): add `class_market_value: Decimal |
+   None` / `string | null` — required-nullable, mirroring `market_cap`.
+7. FE `KeyStatsPane.tsx`: add a row right after "Market cap", labelled
+   `{symbol} market value` (e.g. "GOOGL market value"), formatted by the existing
+   `formatMarketCap`. `makeRow` returns null when the value is null → the row
+   simply doesn't appear for single-class issuers.
+
+### Label tradeoff
+
+Label by the viewed **symbol** ("GOOGL market value"), not a parsed class name
+("Class A"). The viewed ticker IS the share class, so the symbol is an
+unambiguous anchor and needs zero FSDS-token humanization (the member tokens —
+`CommonClassA`, `CapitalClassC`, `HeicoCommonStock` — are not a controlled
+vocabulary; a humanizer is a new failure surface for marginal gain). A
+"Class A" label is a future polish with a controlled map, not this ticket.
+
+## Out of scope
+
+- No schema / migration / backfill / job change (pure read-path).
+- No new "is dual-class?" predicate — `total_company` basis already encodes it.
+- Ranking view (#1664) is unaffected — float value is display-only, never a
+  scoring input.
+
+## Tests
+
+- Pure: `_assemble_total_company_cap` returns legs; a 2-leg fixture exposes each
+  leg's `shares × price`; residual leg excluded from `legs`.
+- Pure coherence invariants on the returned legs: each leg value `> 0`; Σ leg
+  values `== total.value - residual_shares × impute_price` (residual excluded);
+  a picked class value equals exactly one leg's `shares × price` and is
+  `<= total.value`.
+- Pure: leg-pick — duplicate-ID `legs_raw` takes the first match (no
+  double-count); viewed-instrument-absent → None.
+- Service (DB-backed, `-m db`): `resolve_market_cap_basis` for a GOOGL-shaped
+  fixture sets `class_market_value` to that sibling's leg; a single-class
+  instrument leaves it None. Mirrors the existing `resolve_market_cap_basis` tests.
+- FE: `KeyStatsPane.test.tsx` — row renders when `class_market_value` set, absent
+  when null.
+
+## DoD
+
+Pure read-path display change (no ownership/observations data treatment, no
+parser/schema). Smoke the panel via the live endpoint: GOOGL/GOOG show both
+`market_cap` (4.4476T) and `class_market_value` (2.15T / 1.97T); AAPL (single
+class) shows market cap only, no per-class row.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -274,6 +274,12 @@ export interface InstrumentIdentity {
   country: string | null;
   currency: string | null;
   market_cap: string | null;
+  /** #1665: per-class FLOAT value of THIS instrument's own share class — its
+   * FSDS shares × price (GOOGL Class A ≈ $2.15T), a SEPARATE stat from
+   * `market_cap` (the whole company, ≈ $4.45T, identical across siblings).
+   * Non-null only on curated dual-class issuers where this instrument is a
+   * priced per-class leg; null for single-class issuers. */
+  class_market_value: string | null;
   /** #819: when set, this instrument is an operational duplicate
    * (e.g. ``AAPL.RTH``) of the named canonical symbol (``AAPL``).
    * The frontend redirects to the canonical symbol's page so

--- a/frontend/src/components/instrument/KeyStatsPane.test.tsx
+++ b/frontend/src/components/instrument/KeyStatsPane.test.tsx
@@ -47,4 +47,24 @@ describe("KeyStatsPane", () => {
     render(<KeyStatsPane summary={fixture(null)} />);
     expect(screen.getByText(/No key stats/i)).toBeInTheDocument();
   });
+
+  it("renders a per-class float row labelled by symbol when class_market_value is set (#1665)", () => {
+    const base = fixture({});
+    const dualClass = {
+      ...base,
+      identity: { ...base.identity, symbol: "GOOGL", class_market_value: "2154300000000" },
+    } as InstrumentSummary;
+    render(<KeyStatsPane summary={dualClass} />);
+    // Both the total-company "Market cap" and the per-class value are shown,
+    // clearly disambiguated by the symbol-anchored label.
+    expect(screen.getByText("Market cap")).toBeInTheDocument();
+    expect(screen.getByText("GOOGL market value")).toBeInTheDocument();
+    expect(screen.getByText("2.15T")).toBeInTheDocument();
+  });
+
+  it("omits the per-class float row for a single-class issuer (class_market_value null)", () => {
+    // The default fixture leaves class_market_value unset → row absent.
+    render(<KeyStatsPane summary={fixture({})} />);
+    expect(screen.queryByText(/market value$/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/instrument/KeyStatsPane.tsx
+++ b/frontend/src/components/instrument/KeyStatsPane.tsx
@@ -75,6 +75,14 @@ function buildRows(summary: InstrumentSummary): Row[] {
   const fs = stats.field_source ?? {};
   const candidates: Array<Row | null> = [
     makeRow(formatMarketCap(summary.identity.market_cap), "Market cap", undefined),
+    // #1665: per-class FLOAT value (this share class's shares × price), a separate
+    // stat from total-company "Market cap". Labelled by the viewed symbol — the
+    // ticker IS the class. Null (row absent) for single-class issuers.
+    makeRow(
+      formatMarketCap(summary.identity.class_market_value),
+      `${summary.identity.symbol} market value`,
+      undefined,
+    ),
     makeRow(formatDecimal(stats.pe_ratio), "P/E ratio", fs["pe_ratio"]),
     makeRow(formatDecimal(stats.pb_ratio), "P/B ratio", fs["pb_ratio"]),
     makeRow(formatDecimal(stats.dividend_yield, { percent: true }), "Dividend yield", fs["dividend_yield"]),

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -34,6 +34,7 @@ function summary(overrides: Partial<InstrumentSummary> = {}): InstrumentSummary 
       country: "United States",
       currency: "USD",
       market_cap: "3000000000000",
+      class_market_value: null,
       canonical_symbol: null,
     },
     price: {

--- a/tests/test_per_class_market_cap.py
+++ b/tests/test_per_class_market_cap.py
@@ -15,6 +15,7 @@ from app.services.xbrl_derived_stats import (
     TotalCompanyMarketCap,
     _assemble_total_company_cap,
     _ClassLeg,
+    _leg_market_value,
     _sum_class_caps,
 )
 
@@ -267,3 +268,75 @@ def test_residual_too_large_fails_closed() -> None:
         )
         is None
     )
+
+
+# --- per-class float legs (#1665) -----------------------------------------------
+
+
+def _alphabet_total() -> TotalCompanyMarketCap:
+    got = _assemble_total_company_cap(
+        period_end=_FRESH,
+        today=_TODAY,
+        legs_raw=_alphabet_legs(),
+        combined_shares=_D("12116000000"),
+        combined_as_of=_FRESH,
+    )
+    assert got is not None
+    return got
+
+
+def test_legs_carried_and_residual_excluded() -> None:
+    # The two PRICED traded legs survive on the return; the imputed untraded
+    # residual (Class B, 766M) is NOT a leg — it has no instrument.
+    got = _alphabet_total()
+    assert {leg.instrument_id for leg in got.legs} == {6434, 1002}
+    assert len(got.legs) == got.leg_count == 2
+    by_id = {leg.instrument_id: leg for leg in got.legs}
+    assert by_id[6434].shares == _D("5835000000") and by_id[6434].price == _D("369.20")
+    assert by_id[1002].shares == _D("5515000000") and by_id[1002].price == _D("358.20")
+
+
+def test_legs_reconcile_to_value_minus_residual() -> None:
+    # Σ(leg shares × price) == total.value - residual valued at the largest leg's
+    # price (the imputation). Each leg value is strictly positive and ≤ the total.
+    got = _alphabet_total()
+    impute_price = max(got.legs, key=lambda leg: leg.shares).price
+    sum_legs = sum((leg.shares * leg.price for leg in got.legs), Decimal(0))
+    assert sum_legs == got.value - got.residual_shares * impute_price
+    for leg in got.legs:
+        assert leg.shares * leg.price > 0
+        assert leg.shares * leg.price <= got.value
+
+
+def test_leg_market_value_picks_viewed_instrument() -> None:
+    # Per-class float = the VIEWED sibling's own leg, NOT identical across siblings.
+    got = _alphabet_total()
+    googl = _leg_market_value(got, 6434)
+    goog = _leg_market_value(got, 1002)
+    assert googl == _D("5835000000") * _D("369.20")  # GOOGL Class A
+    assert goog == _D("5515000000") * _D("358.20")  # GOOG Class C
+    # …and each is a strict subset of (less than) the whole-company value.
+    assert googl is not None and googl < got.value
+
+
+def test_leg_market_value_absent_instrument_is_none() -> None:
+    # A same-CIK sibling that is not itself a priced leg (e.g. a .US listing with
+    # no FSDS class row) has no per-class float → honest None.
+    assert _leg_market_value(_alphabet_total(), 99999) is None
+
+
+def test_leg_market_value_duplicate_id_takes_first_no_double_count() -> None:
+    # The FSDS PK (instrument_id, period_end) + a single period_end make a
+    # duplicate ID impossible in practice; defensively the pick takes the FIRST
+    # match and never sums two legs into a doubled value.
+    total = TotalCompanyMarketCap(
+        value=_D("3000"),
+        period_end=_FRESH,
+        combined_shares=_D("300"),
+        sum_mapped_shares=_D("300"),
+        residual_shares=Decimal(0),
+        imputed_residual=False,
+        leg_count=2,
+        legs=(_ClassLeg(7, _D("100"), _D("10")), _ClassLeg(7, _D("50"), _D("20"))),
+    )
+    assert _leg_market_value(total, 7) == _D("1000")  # first leg only (100×10), not 2000

--- a/tests/test_scoring_market_cap_basis.py
+++ b/tests/test_scoring_market_cap_basis.py
@@ -14,7 +14,7 @@ from datetime import date
 from decimal import Decimal
 
 from app.services.scoring import _apply_market_cap_basis
-from app.services.xbrl_derived_stats import MarketCapResolution, TotalCompanyMarketCap
+from app.services.xbrl_derived_stats import MarketCapResolution, TotalCompanyMarketCap, _ClassLeg
 
 # The eight shares-distorted columns (each carries a price × combined-shares term)
 # the view must NULL for a curated dual-class issuer; and the clean ones it must
@@ -63,6 +63,10 @@ def _total(value: str) -> TotalCompanyMarketCap:
         residual_shares=Decimal("861000000"),
         imputed_residual=True,
         leg_count=2,
+        legs=(
+            _ClassLeg(1, Decimal("5835000000"), Decimal("369.20")),
+            _ClassLeg(2, Decimal("5515000000"), Decimal("358.20")),
+        ),
     )
 
 

--- a/tests/test_xbrl_derived_stats.py
+++ b/tests/test_xbrl_derived_stats.py
@@ -189,6 +189,9 @@ class TestResolveMarketCapBasis:
         res = resolve_market_cap_basis(ebull_test_conn, instrument_id=iid)
         assert res.basis == "not_multiclass"
         assert res.total is None
+        # No per-class float stat for a single-class issuer — market cap already
+        # IS the sole class value (#1665).
+        assert res.class_market_value is None
 
     def test_dual_class_total_company_cap(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         # Two siblings sharing a CIK, each with a curated FSDS class row at a fresh
@@ -215,6 +218,12 @@ class TestResolveMarketCapBasis:
         # Identical regardless of which sibling the page renders.
         assert res_c.basis == "total_company" and res_c.total is not None
         assert res_c.total.value == res_a.total.value
+        # #1665: per-class float = the VIEWED sibling's OWN leg (shares × price),
+        # a separate stat from the (identical) total — and strictly less than it.
+        assert res_a.class_market_value == Decimal("6000")  # A: 600 × 10
+        assert res_c.class_market_value == Decimal("6000")  # C: 300 × 20 (per-sibling, not the total)
+        cmv_a = res_a.class_market_value
+        assert cmv_a is not None and cmv_a < res_a.total.value
 
     def test_dual_class_unpriced_sibling_suppressed(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
         # Curated dual-class but one class has no quote → fail closed (suppress),
@@ -232,3 +241,5 @@ class TestResolveMarketCapBasis:
         res = resolve_market_cap_basis(ebull_test_conn, instrument_id=a)
         assert res.basis == "multiclass_unavailable"
         assert res.total is None
+        # No clean total → no per-class float either (#1665).
+        assert res.class_market_value is None


### PR DESCRIPTION
Closes #1665. Refs #1662, #1664.

## What

Surfaces a dual-class issuer's **per-class float value** — the viewed
instrument's own share-class market value (GOOGL Class A shares × Class A
price ≈ \$2.15T) — as a **separate, clearly-labelled stat**, distinct from
`market_cap`.

#1662 (PR #1666) made `identity.market_cap` the **total-company**
capitalization (Σ class×price, **identical** across GOOG/GOOGL). The per-class
float is a genuinely different number — the tradable-class market value — and
must never be conflated with market cap (that conflation was the #1662 bug).
This ships the second half of the settled data-engineer **I20** sentence
("per-class float is a separate, separately-labelled stat").

## How — PURE READ-PATH

The per-class float = the viewed instrument's OWN leg's `shares × price`. That
leg is **already** built inside `_assemble_total_company_cap` and was being
discarded (only the aggregate `value` survived).

1. `TotalCompanyMarketCap.legs` — carry the priced traded legs (the imputed
   untraded residual class is excluded; it has no instrument).
2. `_leg_market_value(total, instrument_id)` — pure pick of the viewed leg.
   FSDS PK `(instrument_id, period_end)` + single `period_end` ⇒ at most one
   match; takes the first defensively (a duplicate-ID list never double-counts).
3. `resolve_market_cap_basis` sets `MarketCapResolution.class_market_value`,
   non-null **only** on `total_company` basis → naturally scoped to curated
   dual-class issuers. Null for single-class (`market_cap` already IS the sole
   class value) and where no clean per-class leg exists.
4. API `get_instrument_summary` copies it onto `identity.class_market_value`.
5. FE `KeyStatsPane` renders a `{symbol} market value` row right after
   "Market cap"; `makeRow` returns null when the value is null → the row is
   simply absent for single-class issuers.

Reusing the assembled leg (vs. a separate re-read) guarantees the displayed
class value is the EXACT leg the total summed — same shares, same price tick,
same `class_shares_usable` filter — so it can never disagree with its own
contribution to `market_cap`.

### Label tradeoff
Labelled by the viewed **symbol** ("GOOGL market value"), not a parsed class
name ("Class A"). The viewed ticker IS the share class, so the symbol is an
unambiguous anchor needing zero FSDS-token humanization (the member tokens —
`CommonClassA`, `CapitalClassC`, `HeicoCommonStock` — are not a controlled
vocabulary). A "Class A" label is a future polish with a controlled map.

## Security / data model

No new data, no SQL, no migration, no parser, no job. Read-path only:
`class_market_value` is computed from the existing #1623 curated FSDS table
`instrument_class_shares_outstanding` (CIK→class map, the same oracle #1662
uses) × the existing `quotes` mark. No user input reaches any query. The new
field is required-nullable on both the Pydantic model and the TS mirror.
Ranking/scoring is untouched — the float value is display-only, never a
scoring input (#1664's view path is unaffected).

## Full-population verification (dev DB)

Curated dual-class universe = 3 issuers / 6 instruments (every CIK in
`instrument_class_shares_outstanding`). Live `/instruments/{s}/summary`:

| symbol | market_cap (total) | class_market_value (per-leg) |
|---|---|---|
| GOOGL | \$4.442T | **\$2.154T** (Class A) |
| GOOG | \$4.442T (identical) | **\$1.970T** (Class C) |
| AAPL (single class) | \$4.366T | **null** (no per-class row) |

Per-class is per-leg (NOT identical across siblings — the point); the total IS
identical. HEICO / Ramaco (no quote on file) → total fails closed, per-class
honestly null.

## Tests

- Pure (`tests/test_per_class_market_cap.py`): legs carried + residual
  excluded; coherence (each leg > 0, ≤ total, Σ legs == `value −
  residual×impute_price`); leg-pick present → value, absent → None,
  duplicate-ID → first only (no double-count).
- DB (`tests/test_xbrl_derived_stats.py`, `-m db`): resolver sets
  `class_market_value` to the viewed sibling's leg; null for single-class and
  `multiclass_unavailable`.
- FE (`KeyStatsPane.test.tsx`): row renders + disambiguates when set; absent
  when null.

## Checks

ruff ✅ · ruff format ✅ · pyright 0 errors ✅ · `pytest -m "not db"` 4381 ✅ ·
smoke 129 ✅ · `pytest -m db` (resolver) 9 ✅ · FE typecheck ✅ · FE unit 1062 ✅.
Codex ckpt-1 (5 spec findings folded) + ckpt-2 (no findings). Live endpoint
verified at the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)