### PR TITLE
feat: re-instate newest-first Form 4 ingest (fix recent insider staleness)

### DIFF
--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -67,6 +67,7 @@ Lane = Literal[
     "sec_per_cik",
     "sec_filing_docs",
     "sec_insider_backfill",
+    "sec_insider_ingest",
     "sec_bulk_download",
     "db",
     "db_filings",
@@ -144,9 +145,9 @@ the rate — it does not.
   The hourly @ :45 oldest-first Form-4 tail drainer collides with the @ :45
   ``atom`` tick every hour; when it loses to a slow holder it skips the whole
   hour (#1538 retry can't cover the long holds). Own lane removes the
-  contention. Write-ordering-safety (it now runs concurrently with its former
-  lanemate ``sec_insider_transactions_ingest``, which stays on ``sec_rate`` and
-  shares its full write set): typed insider tables + ``ownership_insiders_observations``
+  contention. Write-ordering-safety (it runs concurrently with
+  ``sec_insider_transactions_ingest``, which has its OWN ``sec_insider_ingest``
+  lane @:15 since 2026-06-20, and shares its full write set): typed insider tables + ``ownership_insiders_observations``
   + ``filing_raw_documents`` are row-level ``ON CONFLICT`` idempotent from
   immutable filings; ``ownership_insiders_current`` + ``ownership_refresh_state``
   are written only inside ``refresh_insiders_current``, which holds a

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -775,13 +775,36 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     # + `instrument_business_summary_sections`. The weekly Sunday safety-net
     # bootstrap (`sec_business_summary_bootstrap` below) stays for
     # one-shot drain + operator manual backfill.
-    # `sec_insider_transactions_ingest` retired from SCHEDULED_JOBS
-    # post-#1155: Layer 1/2/3 + sec_manifest_worker + manifest_parsers/
-    # insider_345.py (#1130) carry every Form 4 write to
-    # insider_transactions + insider_filings + insider_filers. The
-    # round-robin `sec_insider_transactions_backfill` cron stays
-    # scheduled for the deep-historical-tail drain. Function body +
-    # _INVOKERS entry preserved for Admin "Run now".
+    # `sec_insider_transactions_ingest` — RE-INSTATED to SCHEDULED_JOBS
+    # (2026-06-20). #1155 retired it on the premise that "Layer 1/2/3 +
+    # sec_manifest_worker" keeps recent Form 4 fresh. FALSIFIED on dev: the
+    # manifest worker drains `filed_at ASC` (oldest-first) against a ~1.46M-row
+    # pending backlog at 10 req/s, so recent Form 4s sit at the back of the queue
+    # and never parse — operator-reported eBay insider sales were ~3 months stale.
+    # This newest-first ingester (reads filing_events newest-first, correct
+    # form4.xml URLs, bounded 500/tick) is the recent keeper; the round-robin
+    # `sec_insider_transactions_backfill` stays for the historical tail. Both run
+    # concurrently + write-safe (per-instrument advisory lock in
+    # refresh_insiders_current; SEC 10 req/s is a process-global clock).
+    # Spec: docs/specs/ingest/2026-06-20-insider-recent-first-drain.md
+    ScheduledJob(
+        name=JOB_SEC_INSIDER_TRANSACTIONS_INGEST,
+        display_name="SEC Form 4 newest-first ingest",
+        # Own single-job lane (#1540 pattern) — runs concurrently with the @:45
+        # backfill on its own lock; the global SEC clock bounds combined req/s.
+        source="sec_insider_ingest",
+        description=(
+            "Universe-wide newest-first Form 4 ingester (#456). Reads "
+            "filing_events newest-first, canonicalises to the raw form4.xml "
+            "URL, parses into insider_transactions / insider_filings / "
+            "insider_filers, bounded 500/tick. The steady-state RECENT keeper "
+            "(the oldest-first manifest worker + backfill cannot keep recent "
+            "fresh against a deep pending backlog). Re-instated 2026-06-20."
+        ),
+        cadence=Cadence.hourly(minute=15),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,  # #996 — gated until first-install bootstrap is complete
+    ),
     ScheduledJob(
         name=JOB_SEC_FILING_DOCUMENTS_INGEST,
         display_name="SEC filing-documents manifest ingest",
@@ -838,8 +861,9 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         role="backfill",
         # #1540 — own lane: this @:45 tail drainer collided with the @:45 atom
         # tick every hour; #1538's retry can't cover the long holds. Write-safe
-        # concurrently with sec_insider_transactions_ingest (stays on sec_rate)
-        # via per-instrument advisory lock in refresh_insiders_current.
+        # concurrently with sec_insider_transactions_ingest (own sec_insider_ingest
+        # lane @:15, re-instated 2026-06-20) via the per-instrument advisory lock
+        # in refresh_insiders_current.
         source="sec_insider_backfill",
         description=(
             "Round-robin backfill of Form 4 filings for instruments "

--- a/docs/etl/sources/sec_form4.md
+++ b/docs/etl/sources/sec_form4.md
@@ -25,7 +25,9 @@ Per-(subject, source) row in `data_freshness_index` keyed on `subject_type='issu
 Steady-state writes after that are 100% manifest-worker driven via the Layer 1/2/3 discovery → `_parse_form4` path. Wall-clock for stage 11: ~10 min cleanly per `project_1233_run2_measurement.md`.
 
 ## 5. Steady-state path
-**No SCHEDULED_JOBS cron for Form 4 hourly ingest** — retired post-#1155 (`scheduler.py:665-671`). Discovery flows: Atom fast-lane (every 5 min) + daily-index reconcile (daily) → `sec_manifest_worker` → `manifest_parsers/insider_345.py::_parse_form4` (one write-path per accession).
+**Two parsers run for Form 4** (2026-06-20):
+1. `sec_insider_transactions_ingest` — **newest-first** universe ingester, RE-INSTATED to `SCHEDULED_JOBS` (own `sec_insider_ingest` lane, hourly @:15). This is the RECENT keeper: it reads `filing_events` newest-first (correct `form4.xml` URLs) → `insider_transactions`/`insider_filings`/`insider_filers`. #1155 retired it on the premise the manifest worker keeps recent fresh; that was FALSIFIED — the worker drains `filed_at ASC` (oldest-first) against a ~1.46M pending backlog so recent Form 4 starved (eBay insider sales ~3mo stale). Spec: `docs/specs/ingest/2026-06-20-insider-recent-first-drain.md`.
+2. Manifest-worker path: Atom fast-lane (every 5 min) + daily-index reconcile (daily) → `sec_manifest_worker` (oldest-first) → `manifest_parsers/insider_345.py::_parse_form4`. Carries discovery + the historical tail; write-safe concurrently with (1) via the per-instrument advisory lock in `refresh_insiders_current`.
 
 Round-robin deep-tail backfill cron still scheduled: `ScheduledJob(name=JOB_SEC_INSIDER_TRANSACTIONS_BACKFILL, source='sec_rate', cadence=hourly(minute=45))` at `scheduler.py:712-728`. Picks the 25 instruments with the largest pending backlog, clears up to 50 oldest-first per instrument per run. Prerequisite `_bootstrap_complete` (gated until first-install bootstrap finishes).
 

--- a/docs/specs/ingest/2026-06-20-insider-recent-first-drain.md
+++ b/docs/specs/ingest/2026-06-20-insider-recent-first-drain.md
@@ -1,0 +1,99 @@
+# Recent-first Form 4 drain — re-introduce the newest-first insider ingest
+
+Fixes universe-wide recent insider-transaction staleness (operator-reported:
+eBay insider sales ~3 months stale despite recent known selling).
+
+## Problem (verified on dev 2026-06-20)
+
+- `sec_insider_transactions_ingest` (newest-first universe Form 4 ingest, reads
+  `filing_events` newest-first, bounded 500/tick) was **retired from
+  `SCHEDULED_JOBS`** post-#1155 on the premise that "Layer 1/2/3 discovery +
+  `sec_manifest_worker`" is "the steady-state keeper for new Form 4s".
+- **That premise is falsified.** The manifest worker drains
+  **`filed_at ASC` (oldest-first)** (`sec_manifest.py::iter_pending`) against a
+  **~1.46M-row pending backlog** (form4 alone: 1.07M pending / 487 parsed) at the
+  shared 10 req/s. Recent Form 4s (correct `form4.xml` URLs) sit at the BACK of
+  the queue and never get parsed. The round-robin backfill is also oldest-first.
+  → Nothing parses recent Form 4 first → recent insider activity is discovered
+  (`filing_events` + manifest `pending`) but never reaches `insider_transactions`.
+- Independent crash bug (already fixed, PR #1683 / `cb33c6ab`): an empty-body 200
+  crashed the backfill tick; that froze the historical drainer but is orthogonal
+  to the recent-first gap.
+
+## Fix
+
+Re-register the **existing, proven** `sec_insider_transactions_ingest` as a
+`ScheduledJob` (function body + `_INVOKERS` entry were preserved at retirement;
+the only change is putting it back on the schedule). It already:
+- selects newest-first from `filing_events` (`ORDER BY filing_date DESC`),
+- canonicalises the URL (`_canonical_form_4_url` strips the XSL segment → raw
+  `form4.xml`), so it uses the correct primary-doc URL (NOT the `-index.htm` the
+  manifest sometimes stores),
+- tombstones on fetch/parse failure (now empty-body-safe after #1683),
+- is documented write-safe concurrently with the backfill via the per-instrument
+  advisory lock in `refresh_insiders_current`.
+
+### Lane + cadence
+
+- **NEW dedicated lane `sec_insider_ingest`** (one job — matches the #1540
+  single-job-lane pattern; the backfill's `sec_insider_backfill` lane is asserted
+  single-job by `test_extracted_lanes_are_single_job`, so it cannot be reused).
+  The newest-first keeper runs CONCURRENTLY with the @:45 backfill (different
+  lanes) — safe because: (a) the SEC 10 req/s budget is a PROCESS-GLOBAL clock
+  (`sec_edgar._PROCESS_RATE_LIMIT_CLOCK`), not per-lane, so concurrency cannot
+  burst SEC; (b) both write the insider tables under the per-instrument advisory
+  lock in `refresh_insiders_current` (documented write-safe); (c) they select
+  different ends (newest-first vs oldest-first) so overlap is minimal and
+  `ON CONFLICT DO UPDATE` makes any overlap idempotent.
+- `cadence = Cadence.hourly(minute=15)`.
+- `role` defaults to `steady_state` (recurring recent-keeper — must show on the
+  Processes page; a hidden keeper is the #1530 footgun). `catch_up_on_boot=False`,
+  `prerequisite=_bootstrap_complete`.
+
+`ScheduledJob.source` supplies the lane for `source_for()` (Codex ckpt-1: no
+`MANUAL_TRIGGER_JOB_SOURCES` entry needed). Bounded 500/tick: ample for
+steady-state inflow; the current recent backlog drains newest→older over
+successive ticks (operator runs it a few times now to unstale immediately).
+
+### Registry/test updates (Codex ckpt-1)
+
+- Add `"sec_insider_ingest"` to the `Lane` literal (`app/jobs/sources.py`).
+- Remove `sec_insider_transactions_ingest` from `expected_on_demand`
+  (`test_jobs_runtime.py`) and `_KNOWN_UNRESOLVABLE` (`test_layer_123_wiring.py`)
+  — it now resolves a lane + is scheduled again.
+- Add single-job-lane + differ-from-`sec_rate` assertions for the new lane in
+  `test_job_registry.py`.
+- Correct the now-stale comments: the #1155 "retired" note (scheduler.py) and the
+  "stays on sec_rate" lanemate note (sources.py / backfill ScheduledJob).
+
+## Coexistence with the manifest worker
+
+Both write the insider tables; the per-instrument advisory lock makes that safe.
+A given accession is processed by whichever reaches it first; the
+`no existing insider_filings row` candidate filter + the manifest
+`ingest_status` bookkeeping prevent double-parse. The newest-first job keeps
+RECENT fresh; the worker + backfill grind the historical tail. (When the worker
+later reaches an accession the newest-first job already parsed, it may
+re-fetch/tombstone the manifest row — harmless bookkeeping; the data is already
+correct in the insider tables.)
+
+## Out of scope (follow-ups)
+
+- The SAME oldest-first starvation affects EVERY manifest source (8-K dividend
+  events, 13D/G blockholders, etc.). The principled systemic fix is a
+  **recent-first slice in `run_manifest_worker`** (a `filed_at DESC` top-up
+  alongside the oldest-first fairness path) so every source keeps recent fresh.
+  Ticket it; this PR fixes the operator-reported insider case with proven code.
+- 69 pending form4 rows + eBay's recent carried the `-index.htm` URL in the
+  manifest (a discovery quirk); the newest-first job sidesteps it (reads
+  `filing_events`). Note for the manifest-discovery URL audit.
+- Historical backlog drain (1.46M pending) — separate capacity question.
+
+## Verify (DoD)
+
+- Smoke: app boots; scheduler registry accepts the re-added job (no
+  source_for KeyError; SCHEDULED_JOBS/`_BOOTSTRAP_STAGE_SPECS` source agreement
+  check at `app/jobs/__main__.py` passes).
+- Run the job on dev → recent Form 4 parses; eBay + a 2nd known recent-filer
+  advance to within days of today.
+- Confirm it coexists with the backfill (no lock errors, no double rows).

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -62,6 +62,11 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # See app/jobs/sources.py::Lane.
         "sec_filing_docs",
         "sec_insider_backfill",
+        # 2026-06-20 — sec_insider_transactions_ingest RE-INSTATED on its own
+        # single-job lane (newest-first Form 4 recent keeper; the oldest-first
+        # manifest worker can't keep recent fresh against the deep backlog).
+        # Concurrent with the @:45 backfill; global SEC clock bounds req/s.
+        "sec_insider_ingest",
         "sec_bulk_download",
         "db",
         # #1141 — Phase C bulk-ingest family sources. Bootstrap-only
@@ -791,6 +796,12 @@ class TestLongHoldSecRateLaneExtraction:
     def test_insider_backfill_has_own_lane(self) -> None:
         assert source_for("sec_insider_transactions_backfill") == "sec_insider_backfill"
 
+    def test_insider_ingest_has_own_lane(self) -> None:
+        # Re-instated 2026-06-20 (recent-first Form 4 keeper) on its own lane so
+        # it runs concurrently with the @:45 backfill (global SEC clock bounds
+        # combined req/s; per-instrument write lock keeps it safe).
+        assert source_for("sec_insider_transactions_ingest") == "sec_insider_ingest"
+
     def test_extracted_lanes_are_single_job(self) -> None:
         """Each new lane holds exactly one job across the FULL registry — the
         whole point of the split is that these heavy holders no longer share a
@@ -809,16 +820,20 @@ class TestLongHoldSecRateLaneExtraction:
 
         assert lane_counts["sec_filing_docs"] == 1, lane_to_jobs.get("sec_filing_docs")
         assert lane_counts["sec_insider_backfill"] == 1, lane_to_jobs.get("sec_insider_backfill")
+        assert lane_counts["sec_insider_ingest"] == 1, lane_to_jobs.get("sec_insider_ingest")
         assert lane_to_jobs["sec_filing_docs"] == ["sec_filing_documents_ingest"]
         assert lane_to_jobs["sec_insider_backfill"] == ["sec_insider_transactions_backfill"]
+        assert lane_to_jobs["sec_insider_ingest"] == ["sec_insider_transactions_ingest"]
 
     def test_extracted_lanes_differ_from_sec_rate(self) -> None:
         """If a future change re-collapses either onto ``sec_rate``, this
         re-breaks the #1540 extraction."""
         assert source_for("sec_filing_documents_ingest") != "sec_rate"
         assert source_for("sec_insider_transactions_backfill") != "sec_rate"
-        # ... and the two do not collapse onto each other.
+        assert source_for("sec_insider_transactions_ingest") != "sec_rate"
+        # ... and the extracted insider lanes do not collapse onto each other.
         assert source_for("sec_filing_documents_ingest") != source_for("sec_insider_transactions_backfill")
+        assert source_for("sec_insider_transactions_ingest") != source_for("sec_insider_transactions_backfill")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -421,7 +421,8 @@ class TestProductionInvokerRegistry:
             "sec_13f_quarterly_sweep",
             "sec_def14a_ingest",
             "sec_form3_ingest",
-            "sec_insider_transactions_ingest",
+            # sec_insider_transactions_ingest RE-INSTATED to SCHEDULED_JOBS
+            # 2026-06-20 (recent-first Form 4 keeper) — no longer on-demand-only.
             "sec_n_port_ingest",
             # #994 (first-install bootstrap orchestrator) — these jobs
             # are dispatched by the bootstrap orchestrator (not SCHEDULED)

--- a/tests/test_layer_123_wiring.py
+++ b/tests/test_layer_123_wiring.py
@@ -371,7 +371,9 @@ class TestEveryInvokerJobResolvesASource:
             "daily_financial_facts",
             "daily_tax_reconciliation",
             "sec_def14a_ingest",
-            "sec_insider_transactions_ingest",
+            # sec_insider_transactions_ingest RE-INSTATED to SCHEDULED_JOBS
+            # 2026-06-20 — now resolves the sec_insider_ingest lane (no longer
+            # an unresolvable invoker-only orphan).
         }
     )
 


### PR DESCRIPTION
## Problem (operator-reported)
Insider sales — eBay and universe-wide — were ~3 months stale despite recent known selling. SEC had 8+ eBay Form 4s dated 2026-06-18; our DB's latest was 2026-03-18.

## Root cause
`sec_insider_transactions_ingest` (the **newest-first** universe Form 4 ingester) was **retired from `SCHEDULED_JOBS`** by #1155, on the premise that "Layer 1/2/3 discovery + `sec_manifest_worker`" is the steady-state keeper for recent Form 4. **That premise is falsified:** the manifest worker drains **`filed_at ASC` (oldest-first)** (`sec_manifest.py::iter_pending`) against a **~1.46M-row pending backlog** at the shared 10 req/s (form4 alone: 1.07M pending / 487 parsed). Recent Form 4s sit at the back of the queue and never parse. The round-robin backfill is also oldest-first. → **Nothing parses recent Form 4 first**, so recent insider activity is discovered (`filing_events` + manifest `pending`) but never reaches `insider_transactions`.

(Separate, already-merged crash fix #1683 / `cb33c6ab` unfroze the backfill; orthogonal to this recent-first gap.)

## Fix
Re-register the **existing, proven** newest-first ingester into `SCHEDULED_JOBS` (its function body + `_INVOKERS` entry were preserved at retirement — the only change is putting it back on the schedule). It reads `filing_events` newest-first, canonicalises to the raw `form4.xml` URL, tombstones on fetch/parse failure (empty-body-safe after #1683), bounded 500/tick.

- **New dedicated single-job lane `sec_insider_ingest`** (matches the #1540 pattern; the backfill's lane is asserted single-job, so it can't be reused). Runs **concurrently** with the @:45 backfill — safe because (a) the SEC 10 req/s budget is a **process-global** clock (`sec_edgar._PROCESS_RATE_LIMIT_CLOCK`), not per-lane; (b) both write insider tables under the per-instrument advisory lock in `refresh_insiders_current`; (c) `ON CONFLICT DO UPDATE` makes any overlap idempotent.
- `cadence = hourly(@:15)`, `role` steady_state, `prerequisite=_bootstrap_complete`.

## Registry/test updates (Codex ckpt-1 + ckpt-2)
- `Lane` literal + test `_ALLOWED_SOURCES`: add `sec_insider_ingest`.
- `test_job_registry`: single-job-lane + differ-from-`sec_rate` assertions for the new lane.
- `test_jobs_runtime`: removed the job from `expected_on_demand`.
- `test_layer_123_wiring`: removed from `_KNOWN_UNRESOLVABLE` (it now resolves a lane).
- Corrected stale comments/docs ("retired post-#1155", "stays on sec_rate") in `sources.py`, `scheduler.py`, `docs/etl/sources/sec_form4.md`.

## Verification (dev, this branch)
- `ruff`/`pyright` clean; `test_job_registry` + `test_jobs_runtime` + `test_layer_123_wiring` (150) pass; smoke (129) passes (full boot registers the job).
- Triggered the re-instated job: **success, 1,157 rows across 186 instruments** in one 73s tick. eBay now current through **2026-06-18** including the insider **sale** (Sweetnam 863 sh @ $109.17). Additional ticks queued to drain the recent backlog.
- Coexists with the @:45 backfill — no lock errors, no double rows (idempotent conflict keys).

## Out of scope (follow-ups)
- The SAME oldest-first starvation affects every manifest source (8-K dividend events, 13D/G). Principled systemic fix = a **recent-first slice in `run_manifest_worker`** (filed_at DESC top-up). Ticket it.
- 1.46M manifest backlog drain (capacity).
- 69 form4 manifest rows carrying `-index.htm` URLs (discovery quirk; this job sidesteps it via `filing_events`).

## Spec
`docs/specs/ingest/2026-06-20-insider-recent-first-drain.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)