### PR TITLE
feat(#1689): derived display verdict on /system/jobs — kill false-red on transient/retrying/reaped/stale-manual

### DIFF
--- a/app/api/processes.py
+++ b/app/api/processes.py
@@ -77,7 +77,7 @@ from app.services.processes import (
     ingest_sweep_adapter,
     scheduled_adapter,
 )
-from app.services.processes.health_verdict import compute_verdict
+from app.services.processes.health_verdict import verdict_for_row
 from app.services.processes.ingest_sweep_adapter import is_sweep
 from app.services.processes.param_metadata import ParamMetadata
 from app.services.processes.stale_thresholds import get_threshold
@@ -196,6 +196,10 @@ class ProcessRowResponse(BaseModel):
     # rows move to the collapsed "Bootstrap & backfill" section. Defaults
     # to ``steady_state`` so an untagged row stays visible.
     role: ProcessRole = "steady_state"
+    # #1689 — latest terminal ``job_runs.attempt`` (consecutive-failure streak
+    # position). The FE renders "attempt N" on a self-healing/retrying row.
+    # None when never failed or for adapters that don't track it.
+    attempt: int | None = None
 
 
 class ProcessListResponse(BaseModel):
@@ -423,39 +427,12 @@ def _convert_error(err: ErrorClassSummary) -> ErrorClassSummaryResponse:
 
 
 def _convert_row(row: ProcessRow) -> ProcessRowResponse:
-    # #1509 / T3 — derive the retry inputs at the choke point (the clock lives
-    # here, not in the pure ``compute_verdict``). ``retry_in_flight`` is True
-    # whenever ``next_retry_at`` is set (past OR future): a due-but-not-yet-swept
-    # retry is still scheduled recovery, so the row must not flicker red in the
-    # ≤5m sweeper gap. The "HH:MM" label (UTC) is shown only while the retry is
-    # still in the future; once due, compute_verdict renders "retrying shortly".
-    retry_in_flight = row.next_retry_at is not None
-    retry_at_display = (
-        row.next_retry_at.strftime("%H:%M")
-        if row.next_retry_at is not None and row.next_retry_at > datetime.now(UTC)
-        else ""
-    )
-    verdict, self_healing, verdict_reason = compute_verdict(
-        status=row.status,
-        stale_reasons=row.stale_reasons,
-        watermark_is_fresh=row.source_watermark_fresh,
-        retry_in_flight=retry_in_flight,
-        retry_at_display=retry_at_display,
-        # #1510 / T4 — a fresh liveness-watchdog re-enqueue reads the stalled
-        # row as Self-healing "re-enqueued, recovering" (a genuine wedge still
-        # outranks). Set by scheduled_adapter; other adapters leave it False.
-        liveness_kick_in_flight=row.liveness_kick_in_flight,
-        # #1508 / C6 — a never-run scheduled job now overdue past its first
-        # expected fire reads attention "never started" instead of forever-green
-        # "first run pending". Set by scheduled_adapter; other adapters leave it
-        # False.
-        never_started=row.never_started,
-        # Task 5 (#1508) — an operator-traceable cancel reads benign Current;
-        # a system/crash cancel stays attention "last run cancelled". Set by
-        # scheduled_adapter via the process_stop_requests join; other adapters
-        # leave it False.
-        cancel_was_operator_initiated=row.cancel_was_operator_initiated,
-    )
+    # #1689 — the retry-input + aged-failure derivation and the verdict call now
+    # live in the shared ``verdict_for_row`` choke point, so the legacy
+    # ``/system/jobs`` overview renders the IDENTICAL computed verdict (single
+    # source of truth) instead of its old raw-``last_status`` red. The clock is
+    # injected once here (``compute_verdict`` itself stays pure).
+    verdict, self_healing, verdict_reason = verdict_for_row(row, now=datetime.now(UTC))
     return ProcessRowResponse(
         process_id=row.process_id,
         display_name=row.display_name,
@@ -481,6 +458,8 @@ def _convert_row(row: ProcessRow) -> ProcessRowResponse:
         # C7 (#1530) — wire the page-scope role through so the FE can
         # partition steady-state keepers from bootstrap / backfill rows.
         role=row.role,
+        # #1689 — latest terminal attempt for the "attempt N" retrying label.
+        attempt=row.attempt,
     )
 
 

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -46,6 +46,7 @@ from pydantic import BaseModel
 from app.api.auth import require_session_or_service_token
 from app.api.bootstrap import BootstrapApiStatus, LaneApi, StageApiStatus
 from app.db import get_conn
+from app.db.snapshot import snapshot_read
 from app.providers.sec_throttle_metrics import sec_throttle_429_total as _sec_throttle_429_total
 from app.services.bootstrap_state import (
     compute_retryable_view,
@@ -60,6 +61,12 @@ from app.services.ops_monitor import (
     check_job_health,
     get_kill_switch_status,
 )
+from app.services.processes import (
+    HealthVerdict,
+    ProcessRole,
+    scheduled_adapter,
+)
+from app.services.processes.health_verdict import verdict_for_row
 from app.workers.scheduler import (
     JOB_ORCHESTRATOR_FULL_SYNC,
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
@@ -191,6 +198,19 @@ class JobOverviewResponse(BaseModel):
     last_started_at: datetime | None
     last_finished_at: datetime | None
     detail: str
+    # #1689 — the single computed verdict (same `compute_verdict` the Processes
+    # Hub renders), so this legacy table stops painting raw `last_status` red on
+    # a transient/retrying/restart-reaped/aged-one-shot run. `last_status` stays
+    # for back-compat (ProblemsPanel); the FE pill now renders `health_verdict`.
+    health_verdict: HealthVerdict = "current"
+    self_healing: bool = False
+    verdict_reason: str = ""
+    # Page-scope role (#1530) so the FE can split bootstrap/backfill into a
+    # collapsed "Manual & backfill" section, and `attempt` / `next_retry_at`
+    # (#1509) for the "attempt N · next HH:MM" retrying label.
+    role: ProcessRole = "steady_state"
+    attempt: int | None = None
+    next_retry_at: datetime | None = None
 
 
 class JobsProcessSubsystemHealth(BaseModel):
@@ -334,17 +354,46 @@ def _build_jobs_overview(
 ) -> list[JobOverviewResponse]:
     """Build the per-job overview view.
 
-    Since #719, next-run-time is always computed from the declared
-    cadence — the API no longer hosts APScheduler, so there is no live
-    fire-time to query. `compute_next_run(cadence, now)` returns the
-    next future occurrence, which is the same value APScheduler would
-    schedule against. The `_source="declared"` discriminator is kept
-    for frontend compat.
+    Legacy fields (``last_status`` / ``last_started_at`` / ``last_finished_at`` /
+    ``detail``) still come from ``check_job_health`` so their semantics are
+    unchanged. #1689 layers on the SAME computed verdict the Processes Hub
+    renders — via ``scheduled_adapter.list_rows`` + the shared
+    ``verdict_for_row`` choke point — so this legacy table stops painting a
+    transient / retrying / restart-reaped / aged-one-shot run red.
+
+    ``next_run_time`` is sourced from the row's ``next_fire_at`` (the same basis
+    as the verdict inputs; falls back to ``compute_next_run`` only when the row
+    is absent or has no next fire), avoiding cross-read drift. Per #719 this is
+    the *declared* cadence slot, not a live APScheduler fire-time — the
+    ``next_run_time_source="declared"`` discriminator is kept for FE compat.
+
+    The verdict rows are read once under a single ``snapshot_read`` snapshot
+    (``list_rows``'s documented caller-MUST) so all rows share one consistent
+    MVCC view. This roughly doubles the admin-poll probe cost vs the old
+    ``check_job_health``-only loop (it now also runs the Hub's per-row probes);
+    acceptable at the current job count and eliminated when the redundant
+    ``JobsTable`` is retired (see spec).
     """
+    with snapshot_read(conn):
+        verdict_rows = {r.process_id: r for r in scheduled_adapter.list_rows(conn)}
     overviews: list[JobOverviewResponse] = []
     for job in registry:
         health = check_job_health(conn, job.name)
-        next_run = compute_next_run(job.cadence, now)
+        row = verdict_rows.get(job.name)
+        if row is not None:
+            verdict, self_healing, verdict_reason = verdict_for_row(row, now=now)
+            role: ProcessRole = row.role
+            attempt = row.attempt
+            next_retry_at = row.next_retry_at
+            next_run = row.next_fire_at or compute_next_run(job.cadence, now)
+        else:
+            # Defensive: ``list_rows`` iterates the same ``SCHEDULED_JOBS``, so a
+            # miss is not expected — fall back to a calm verdict + declared cadence.
+            verdict, self_healing, verdict_reason = "current", False, ""
+            role = job.role
+            attempt = None
+            next_retry_at = None
+            next_run = compute_next_run(job.cadence, now)
         overviews.append(
             JobOverviewResponse(
                 name=job.name,
@@ -358,6 +407,12 @@ def _build_jobs_overview(
                 last_started_at=health.last_started_at,
                 last_finished_at=health.last_finished_at,
                 detail=health.detail,
+                health_verdict=verdict,
+                self_healing=self_healing,
+                verdict_reason=verdict_reason,
+                role=role,
+                attempt=attempt,
+                next_retry_at=next_retry_at,
             )
         )
     return overviews

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -449,7 +449,14 @@ def record_job_finish(
         attempt, next_retry_at = _retry_plan(conn, run_id, error_category, now)
     else:
         attempt, next_retry_at = 1, None
-    conn.execute(
+    # #1689 — ``AND status = 'running'`` makes this a first-writer-wins finalize.
+    # If a boot/orphan reaper (or any future out-of-band terminal writer) already
+    # transitioned this row to a terminal status — and, for a transient category,
+    # already stamped its OWN ``_retry_plan`` (#1688) — a late finalize by the
+    # original worker must NOT clobber that terminal/retry. The guarded UPDATE
+    # no-ops (rowcount 0); we log and return without a secondary write. Mirrors
+    # ``sync_orchestrator.executor._finalize_sync_run``'s guarded UPDATE.
+    cur = conn.execute(
         """
         UPDATE job_runs
         SET finished_at    = %(finished)s,
@@ -460,6 +467,7 @@ def record_job_finish(
             next_retry_at  = %(next_retry_at)s,
             attempt        = %(attempt)s
         WHERE run_id = %(run_id)s
+          AND status = 'running'
         """,
         {
             "finished": now,
@@ -472,6 +480,12 @@ def record_job_finish(
             "run_id": run_id,
         },
     )
+    if cur.rowcount == 0:
+        logger.info(
+            "record_job_finish: run_id=%s already terminal (status != 'running'); "
+            "finalize raced a reaper — skipping, terminal/retry plan preserved",
+            run_id,
+        )
     conn.commit()
 
 

--- a/app/services/processes/__init__.py
+++ b/app/services/processes/__init__.py
@@ -63,7 +63,7 @@ ProcessStatus = Literal[
 # see rendered side-by-side as contradictory chips. Derived (not stored)
 # at the API layer (``app/api/processes.py::_convert_row`` →
 # ``health_verdict.compute_verdict``). The FE renders ONE verdict pill.
-HealthVerdict = Literal["current", "working", "self_healing", "attention"]
+HealthVerdict = Literal["current", "working", "self_healing", "attention", "stale_manual"]
 
 RunStatus = Literal["success", "failure", "partial", "cancelled", "skipped"]
 
@@ -260,6 +260,12 @@ class ProcessRow:
     # ``"bootstrap"``; ingest_sweep_adapter keeps the default
     # ``"steady_state"`` (sweeps keep their source current).
     role: ProcessRole = "steady_state"
+    # #1689 — ``job_runs.attempt`` of the latest terminal run (the
+    # consecutive-failure streak position, 1 = first natural fire). Set by
+    # scheduled_adapter from the terminal row so the FE can render "attempt N"
+    # on a retrying row. None for adapters that don't track it (bootstrap /
+    # ingest_sweep) or jobs that have never failed.
+    attempt: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/services/processes/health_verdict.py
+++ b/app/services/processes/health_verdict.py
@@ -39,13 +39,23 @@ In every case a genuine wedge (``queue_stuck`` / ``mid_flight_stuck`` /
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import Final
 
 from app.services.processes import (
     HealthVerdict,
+    ProcessRow,
     ProcessStatus,
     StaleReason,
 )
+
+# #1689 — a bootstrap/backfill (one-shot, non-steady) job whose latest run
+# failed permanently (no retry in flight) and finished longer ago than this
+# window is aged-out history, not a steady-state alarm: it reads
+# ``stale_manual`` (muted, collapsed) instead of ``attention`` (red). A
+# *recent* failure inside the window still reads attention so the operator
+# sees their triggered job failed.
+STALE_MANUAL_WINDOW: Final[timedelta] = timedelta(hours=24)
 
 # All four stale reasons are actionable in v1 (none auto-recovers yet).
 ACTIONABLE_STALE: Final[frozenset[StaleReason]] = frozenset(
@@ -78,6 +88,7 @@ def compute_verdict(
     liveness_kick_in_flight: bool = False,
     never_started: bool = False,
     cancel_was_operator_initiated: bool = False,
+    manual_aged_exhausted: bool = False,
 ) -> tuple[HealthVerdict, bool, str]:
     """Collapse ``status`` + ``stale_reasons`` into one verdict.
 
@@ -85,7 +96,8 @@ def compute_verdict(
 
     * ``verdict`` — ``current`` (green, fresh) / ``working`` (blue,
       progressing) / ``self_healing`` (amber, auto-recovering, no action
-      needed) / ``attention`` (red, operator must act).
+      needed) / ``attention`` (red, operator must act) / ``stale_manual``
+      (muted, aged one-shot bootstrap/backfill failure — #1689).
     * ``self_healing`` — convenience boolean (``verdict == "self_healing"``
       today; kept distinct so T3/T4 can flag a row that is *both*
       surfaced and recovering).
@@ -168,6 +180,14 @@ def compute_verdict(
         # Cadence-covered fallback: next natural fire reattempts the failed
         # scope, but no explicit ``next_retry_at`` backoff is in flight.
         return ("self_healing", True, "retry scheduled")
+    if status == "failed" and manual_aged_exhausted:
+        # #1689 — an aged, exhausted one-shot (bootstrap/backfill) failure is
+        # history, not a steady-state alarm. Reads muted ``stale_manual`` and
+        # folds into the collapsed Manual & backfill section. Reached only when
+        # NO actionable wedge (block above) and NO retry-in-flight (branch
+        # above) apply, and ``verdict_for_row`` role-gated it to bootstrap/
+        # backfill — so a wedged or steady-state failure still reads attention.
+        return ("stale_manual", False, "aged one-shot failure")
     if status == "failed":
         return ("attention", False, "last run failed")
     if status == "cancelled":
@@ -212,4 +232,50 @@ def compute_verdict(
     return ("attention", False, "unknown state")
 
 
-__all__ = ["ACTIONABLE_STALE", "compute_verdict"]
+def verdict_for_row(row: ProcessRow, *, now: datetime) -> tuple[HealthVerdict, bool, str]:
+    """Derive a row's verdict from a built ``ProcessRow``.
+
+    The single choke point shared by ``/system/processes``
+    (``api/processes.py::_convert_row``) and the legacy ``/system/jobs``
+    overview (``api/system.py``, #1689) — so both surfaces render the SAME
+    computed verdict instead of two drifting status models (the naive
+    ``/system/jobs`` table previously rendered raw ``last_status`` →
+    ``failure`` painted red regardless of retry/reap/role).
+
+    The clock lives here, not in the pure ``compute_verdict``:
+    ``retry_in_flight`` and the aged-failure check both compare
+    ``next_retry_at`` / ``finished_at`` against ``now``. Callers pass one
+    ``now`` so a row's inputs cannot straddle a clock tick.
+    """
+    # #1509 / T3 — a scheduled retry (``next_retry_at`` set, past OR future) is
+    # recovery, not a red alarm. "HH:MM" label only while still in the future;
+    # once due, ``compute_verdict`` renders "retrying shortly".
+    retry_in_flight = row.next_retry_at is not None
+    retry_at_display = (
+        row.next_retry_at.strftime("%H:%M") if row.next_retry_at is not None and row.next_retry_at > now else ""
+    )
+    # #1689 — aged, exhausted one-shot failure → stale_manual. Role-gated to
+    # bootstrap/backfill (a ``steady_state`` failure is a real alarm); requires
+    # a permanent failure (no ``next_retry_at`` retry in flight) whose terminal
+    # run finished longer ago than ``STALE_MANUAL_WINDOW``.
+    manual_aged_exhausted = (
+        row.role in ("bootstrap", "backfill")
+        and row.status == "failed"
+        and row.next_retry_at is None
+        and row.last_run is not None
+        and row.last_run.finished_at < now - STALE_MANUAL_WINDOW
+    )
+    return compute_verdict(
+        status=row.status,
+        stale_reasons=row.stale_reasons,
+        watermark_is_fresh=row.source_watermark_fresh,
+        retry_in_flight=retry_in_flight,
+        retry_at_display=retry_at_display,
+        liveness_kick_in_flight=row.liveness_kick_in_flight,
+        never_started=row.never_started,
+        cancel_was_operator_initiated=row.cancel_was_operator_initiated,
+        manual_aged_exhausted=manual_aged_exhausted,
+    )
+
+
+__all__ = ["ACTIONABLE_STALE", "STALE_MANUAL_WINDOW", "compute_verdict", "verdict_for_row"]

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -280,7 +280,7 @@ def _read_latest_terminal_run(conn: psycopg.Connection[Any], *, job_name: str) -
             """
             SELECT run_id, started_at, finished_at, status, row_count,
                    error_msg, error_classes, rows_skipped_by_reason,
-                   rows_errored, cancelled_at, next_retry_at
+                   rows_errored, cancelled_at, next_retry_at, attempt
               FROM job_runs
              WHERE job_name = %(name)s
                AND status   IN ('success', 'failure', 'skipped', 'cancelled')
@@ -992,6 +992,9 @@ def _build_row(
         # C7 (#1530) — page-scope role straight from the registry entry so
         # the FE can partition steady-state keepers from bootstrap / backfill.
         role=job.role,
+        # #1689 — latest terminal ``attempt`` (``.get`` so a sync_runs-shaped
+        # orchestrator row, which has no such column, yields None).
+        attempt=terminal_row.get("attempt") if terminal_row is not None else None,
     )
 
 

--- a/docs/specs/ops/2026-06-20-jobs-admin-display-honesty.md
+++ b/docs/specs/ops/2026-06-20-jobs-admin-display-honesty.md
@@ -1,0 +1,81 @@
+# Jobs admin display honesty (#1689)
+
+**Status:** spec (Codex ckpt-1 applied) • **Issue:** #1689 • **Follow-up:** #1690 (statement_timeout) • **Date:** 2026-06-20
+
+## Premise falsification (working-order 4b)
+
+Handoff: "the admin page paints transient/retrying/restart-reaped jobs the same red as genuinely-dead ones." **Corrected against the code + full live population (all 38 rendered jobs, not a sample):**
+
+- The **Processes Control Hub** (`/system/processes` → `ProcessRow`) ALREADY renders honestly via `compute_verdict()` (#1512, `health_verdict.py`): reaped-failure+`next_retry_at` → `self_healing`; role-split #1530; wedge-never-masked. **It is not a false-red source.**
+- Only the **Background Jobs table** (`/system/jobs` → `AdminPage::JobsTable`; `system.py:330 _build_jobs_overview`) is naive: it renders raw `last_status` through `STATUS_TONE` (`AdminPage.tsx:51`, `failure`→`text-red-600`). It is a redundant, dumber view of the **same** registry — both `_build_jobs_overview` and `scheduled_adapter.list_rows()` iterate `SCHEDULED_JOBS` (38 jobs).
+- **No job is rendered-red right now** — all 38 `SCHEDULED_JOBS` are `success`/`skipped`/`running`. The false-red is **latent**: it manifests when a steady-state job fails transiently or is restart-reaped (the restart churn of the prior insider-staleness session). The fix is a latent-bug fix, not a visible-today fix.
+- **`sec_rebuild` (and other manual-trigger jobs) are NOT in `SCHEDULED_JOBS`** — they render on neither admin table (they are invoked via the manual queue + tracked in `job_runs` only). The handoff's "sec_rebuild stale red" is a `job_runs` artifact, not a rendered figure. `stale_manual` therefore targets the **rendered** non-steady jobs: the `bootstrap`/`backfill` role entries.
+
+→ Correct fix = **converge the naive surface onto the existing verdict model** (single source of truth), NOT a parallel status enum.
+
+## Settled decisions applied
+- **#719 process topology** (`settled-decisions.md:372`): jobs process owns scheduler/reaper/dispatcher; API serves HTTP only. No runtime/scheduling added to the API. ✅ all changes are read-path (endpoint projection) or in `app.services`.
+- **#1512 single computed verdict** (`health_verdict.py`): the one choke point. Extended, never forked.
+- **#1530 role split**: `ScheduledJob.role ∈ {steady_state, bootstrap, backfill}` (`scheduler.py:295`), surfaced on `ProcessRow.role`.
+- **#1508 C3** (self_healing rendered calm-green): **deliberately superseded** here — operator now wants retrying visible as amber (3-state semaphore). C3 tests/comments updated, not ignored.
+
+## Prevention-log applied
+- L1796 "multi-surface states share one copy source" → reuse `compute_verdict` + `VERDICT_VISUAL`; no second model.
+- L1915-1917 "terminal job-status write outside `record_job_finish` MUST run `_retry_plan`" → no new terminal-write site; the `status='running'` guard only protects the existing path.
+- L1691 "prefer pure policy over real DBs" → verdict logic stays pure-testable; one `db` test for the SQL guard.
+
+## Source rule
+Operator-UI verdict — no SEC reg governs it. Governing invariant = the in-repo settled model `compute_verdict` (#1512) + `REMEDIES.self_heal` (`layer_types.py:60`, single transient-vs-permanent source, already consumed by `_is_transient`). **Full-population check:** verified against all 38 rendered jobs (0 red, all ok) — not a sample.
+
+## Decision 1 — converge `/system/jobs` on the verdict (reconcile)
+
+Operator's explicit ask: derived status *on the jobs-overview endpoint*. Reuse, don't duplicate.
+
+1. **Extract** `verdict_for_row(row: ProcessRow, *, now) -> tuple[HealthVerdict, bool, str]` (new fn in `health_verdict.py`) from `processes.py::_convert_row:432-444` — the `retry_in_flight = row.next_retry_at is not None` / `retry_at_display` derivation + the `compute_verdict(...)` call + the new `manual_aged_exhausted` derivation (Decision 3). `_convert_row` calls it; `/system/jobs` calls it. One source.
+2. **`/system/jobs`** (`system.py` `get_jobs` / `_build_jobs_overview`): wrap the build in `snapshot_read(conn)` **explicitly in the handler path** and call `scheduled_adapter.list_rows(conn)` once inside it (its documented caller-MUST). Map each `ProcessRow` → enriched `JobOverviewResponse`. New fields: `health_verdict`, `self_healing`, `verdict_reason`, `role`, `attempt`, `next_retry_at`. `next_run_time` now sourced from `row.next_fire_at` (same basis as the verdict inputs; fall back to `compute_next_run(job.cadence, now)` only when `next_fire_at is None`) — removes the millisecond/cadence-boundary drift of computing it separately. The per-job `check_job_health` loop is replaced (also kills its N+1).
+   - **Failure mode unchanged:** `get_jobs` keeps its existing 503-on-build-failure (`system.py:673`). Partial-degradation (`partial=True`) is the Hub's contract, not this legacy endpoint's — not expanded here.
+   - **Perf:** `list_rows()` runs per-job probes under a repeatable-read snapshot — materially heavier than the old `check_job_health` loop, and the page polls `/system/jobs` + `/system/processes` together (≈2× probe load). Read-only MVCC, no row-lock concern; acceptable at 38 jobs. The redundant fetch is fully eliminated when `JobsTable` is retired (recommended follow-up note below).
+3. **`ProcessRow`** (`processes/__init__.py:170`) gains `attempt: int | None = None`, sourced in `_build_row` from `terminal_row.get("attempt")` (the latest terminal `job_runs` row already read). DTO `ProcessRowResponse` + wire type mirror it.
+4. **FE `JobsTable`** (`AdminPage.tsx:354`): render the verdict pill via shared `VERDICT_VISUAL` (drop `STATUS_TONE`); role-split `role !== "steady_state"` into a collapsed "Manual & backfill" section (mirror Hub); a retrying row shows `attempt N · next HH:MM` from `attempt`/`next_retry_at`.
+5. **Type** `JobOverviewResponse` (`types.ts:114`) gains the six fields.
+
+> **Non-blocking review note:** with both surfaces now verdict-identical, the naive `JobsTable` is redundant with the Hub. Recommend retiring it in a follow-up; kept here because the operator asked for the endpoint-level fix and deletion is an operator-visible scope call.
+
+## Decision 2 — `self_healing` → amber (supersedes #1508 C3)
+`VERDICT_VISUAL.self_healing` currently renders green `CALM_TONE` (`processStatus.ts`); `compute_verdict`'s own docstring already calls it amber (`health_verdict.py:33,88`). Change it to an amber tone. 3-state semaphore: green=ok/working, amber=self_healing/retrying, red=attention. **Update the C3 assertions** (`processStatus.test.ts:45` "only attention pins" stays valid for *sort*; any color assertion expecting calm-green for self_healing is updated). Shared `VERDICT_VISUAL` ⇒ applies to both surfaces (intended).
+
+## Decision 3 — `stale_manual` aging
+New 5th verdict `stale_manual` (muted/slate). Gate (precomputed in `verdict_for_row`, passed to `compute_verdict` as one bool `manual_aged_exhausted`):
+`role in ("bootstrap", "backfill")` AND `status == "failed"` AND `next_retry_at is None` (exhausted/permanent — no retry in flight) AND `finished_at < now - STALE_MANUAL_WINDOW` (24h).
+- `bootstrap` **intentionally included** — an aged, exhausted one-time install/backfill failure is history, not a steady-state alarm.
+- A *recent* (<24h) bootstrap/backfill failure still reads `attention` so the operator sees their triggered job failed.
+- A `steady_state` failure is never muted (role gate) — stays red.
+- Manual-trigger jobs (`sec_rebuild`) are out of scope (not rendered on these surfaces).
+
+**Precedence (Codex BLOCKING):** the `stale_manual` branch sits in the status-only section **after** the kill-switch check, **after** the actionable-stale block (so `queue_stuck`/`mid_flight_stuck`/`watermark_gap` still outrank → a genuinely-wedged bootstrap job stays red), **after** the retry/kick suppression, and **before** the `status == "failed" → attention` branch:
+```
+if status == "failed" and manual_aged_exhausted:
+    return ("stale_manual", False, "aged one-shot failure")   # ASCII, role-neutral
+if status == "failed":
+    return ("attention", False, "last run failed")
+```
+**Full contract surface (Codex HIGH):** backend `HealthVerdict` Literal (`processes/__init__.py`), FE `HealthVerdict` (`types.ts:1382`), `VERDICT_VISUAL` (muted tone), `VERDICT_SORT_PRIORITY` (`processStatus.ts:204` — sort like `current`, i.e. not pinned, collapsible), the `processStatus.test.ts` priority test, and `compute_verdict` fixtures.
+
+## Decision 4 — hung-job
+**Pick timeout-bounded adapters (root cause); reject the blind periodic reaper** (it can't reclaim a wedged thread → would false-amber a genuinely-stuck job). Active mitigation (per-job `statement_timeout` via a shared `connect_job()`) needs an ~82-site raw-`psycopg.connect` migration → **#1690** (its own reviewed PR).
+
+Ship here (safe, in-scope):
+- **`record_job_finish` status guard** (`ops_monitor.py:452`): `UPDATE job_runs SET ... WHERE run_id = %(run_id)s AND status = 'running'`. Check rowcount; `rowcount == 0` → gate-safe no-op log ("finalize raced — row already terminal, skipping"), **no secondary write**. `_retry_plan` runs before the UPDATE (read-only; harmless on a raced row). First-writer-wins; mirrors `_finalize_sync_run`.
+- **running_too_long: no new code.** A wedged non-heartbeating `running` row is **already** caught — `stale_detection.py:166-172` keys `mid_flight_stuck` on `COALESCE(last_progress_at, started_at)` vs `get_threshold(process_id)`, so an old `running` row with no progress already reads `attention` (red). Add a **test** asserting it; do not add a redundant reason.
+
+## Tests
+- Pure-logic `compute_verdict`: `stale_manual` (aged bootstrap & backfill → stale_manual; recent → attention; steady-state-exhausted → stays attention); wedge (`queue_stuck`) still outranks an aged-exhausted bootstrap → attention; `manual_aged_exhausted` role-gated.
+- `verdict_for_row`: same `ProcessRow` → identical verdict from `_convert_row` and the `/system/jobs` mapper (parity).
+- `mid_flight_stuck` via `started_at` fallback (no heartbeat) → attention (regression assertion).
+- `record_job_finish` guard: one `db` test — finalize a row already flipped to `failure` no-ops (rowcount 0, status unchanged); normal finalize of a `running` row succeeds.
+- FE `processStatus`: amber for self_healing, red for attention, muted for stale_manual; `VERDICT_SORT_PRIORITY` includes stale_manual.
+
+## DoD verification (dev)
+1. `/system/jobs` 200 (authed) carries `health_verdict`/`self_healing`/`role`/`attempt`/`next_retry_at`; live `/admin` `JobsTable` renders pills, no red while all ok.
+2. Synthetic state on a `SCHEDULED_JOB` via crafted `job_runs` row: failure+`next_retry_at` future → amber "retrying attempt N · next HH:MM"; non-self-heal (`auth_expired`, `next_retry_at` NULL) → red attention; aged bootstrap/backfill failure → muted stale_manual in the collapsed section.
+3. Record commit SHA + figures observed. Clauses 8-12 (ownership/parser/schema-ingest) N/A — read-path display change only.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -129,6 +129,18 @@ export interface JobOverviewResponse {
   last_started_at: string | null;
   last_finished_at: string | null;
   detail: string;
+  // #1689 — the single computed verdict (same `compute_verdict` as the
+  // Processes Hub). Render this as the status pill instead of the raw
+  // `last_status` tone, so a transient/retrying/restart-reaped/aged-one-shot
+  // run is never painted red. `last_status` stays for back-compat.
+  health_verdict: HealthVerdict;
+  self_healing: boolean;
+  verdict_reason: string;
+  // Page-scope role (#1530) for the collapsed Manual & backfill split; attempt
+  // + next_retry_at (#1509) drive the "attempt N · next HH:MM" retrying label.
+  role: ProcessRole;
+  attempt: number | null;
+  next_retry_at: string | null;
 }
 
 export interface JobsListResponse {
@@ -1379,7 +1391,14 @@ export type ProcessStatus =
  * contradictory combos ("ok + schedule missed") are impossible. Derived
  * by `app/services/processes/health_verdict.py::compute_verdict`.
  */
-export type HealthVerdict = "current" | "working" | "self_healing" | "attention";
+export type HealthVerdict =
+  | "current"
+  | "working"
+  | "self_healing"
+  | "attention"
+  // #1689 — muted: an aged, exhausted one-shot (bootstrap/backfill) failure.
+  // Folds into the collapsed Manual & backfill section; not a steady-state red.
+  | "stale_manual";
 
 export type ProcessRunStatus =
   | "success"

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -4,11 +4,31 @@ import { MemoryRouter } from "react-router-dom";
 
 import type {
   CoverageSummaryResponse,
+  JobOverviewResponse,
   JobsListResponse,
   SyncLayersV2Response,
 } from "@/api/types";
 
 import { ProblemsPanel } from "./ProblemsPanel";
+
+// #1689 — JobOverviewResponse gained six verdict fields. These fixtures don't
+// exercise them; spread sane defaults so the literals stay type-complete.
+const JOB_VERDICT_DEFAULTS: Pick<
+  JobOverviewResponse,
+  | "health_verdict"
+  | "self_healing"
+  | "verdict_reason"
+  | "role"
+  | "attempt"
+  | "next_retry_at"
+> = {
+  health_verdict: "current",
+  self_healing: false,
+  verdict_reason: "",
+  role: "steady_state",
+  attempt: null,
+  next_retry_at: null,
+};
 
 
 function emptyV2(): SyncLayersV2Response {
@@ -336,6 +356,12 @@ describe("ProblemsPanel", () => {
           last_started_at: null,
           last_finished_at: new Date().toISOString(),
           detail: "",
+          ...JOB_VERDICT_DEFAULTS,
+          // #1689 — a genuinely-failing job reads `attention`; that is what the
+          // ProblemsPanel now keys off (not raw last_status). verdict_reason
+          // carries the inline copy the panel renders.
+          health_verdict: "attention",
+          verdict_reason: "last run failed",
         },
       ],
     };
@@ -362,6 +388,12 @@ describe("ProblemsPanel", () => {
           last_started_at: null,
           last_finished_at: new Date().toISOString(),
           detail: "",
+          ...JOB_VERDICT_DEFAULTS,
+          // #1689 — a genuinely-failing job reads `attention`; that is what the
+          // ProblemsPanel now keys off (not raw last_status). verdict_reason
+          // carries the inline copy the panel renders.
+          health_verdict: "attention",
+          verdict_reason: "last run failed",
         },
       ],
     };
@@ -391,6 +423,12 @@ describe("ProblemsPanel", () => {
           last_started_at: null,
           last_finished_at: new Date().toISOString(),
           detail: "",
+          ...JOB_VERDICT_DEFAULTS,
+          // #1689 — a genuinely-failing job reads `attention`; that is what the
+          // ProblemsPanel now keys off (not raw last_status). verdict_reason
+          // carries the inline copy the panel renders.
+          health_verdict: "attention",
+          verdict_reason: "last run failed",
         },
       ],
     };
@@ -442,6 +480,12 @@ describe("ProblemsPanel", () => {
           last_started_at: null,
           last_finished_at: new Date().toISOString(),
           detail: "",
+          ...JOB_VERDICT_DEFAULTS,
+          // #1689 — a genuinely-failing job reads `attention`; that is what the
+          // ProblemsPanel now keys off (not raw last_status). verdict_reason
+          // carries the inline copy the panel renders.
+          health_verdict: "attention",
+          verdict_reason: "last run failed",
         },
       ],
     };
@@ -598,6 +642,8 @@ describe("ProblemsPanel", () => {
           next_run_time_source: "declared",
           last_status: "failure",
           last_finished_at: new Date().toISOString(),
+          // #1689 — genuine failure → attention is what the panel now counts.
+          health_verdict: "attention",
         } as unknown as JobsListResponse["jobs"][number],
       ],
     };

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -130,7 +130,12 @@ export function ProblemsPanel({
 
   const baseActionNeeded = cache.v2?.action_needed ?? [];
   const secretMissing = cache.v2?.secret_missing ?? [];
-  const failingJobs = (cache.jobs?.jobs ?? []).filter((j) => j.last_status === "failure");
+  // #1689 — a job is a "problem" only when its COMPUTED verdict says the
+  // operator must act (`attention`). A retrying (`self_healing`), aged one-shot
+  // (`stale_manual`), `working`, or `current` job is NOT a problem. Keying off
+  // raw `last_status === "failure"` here re-introduced the exact false-red the
+  // verdict model exists to kill (a transient/reaped failure raised a red banner).
+  const failingJobs = (cache.jobs?.jobs ?? []).filter((j) => j.health_verdict === "attention");
   const coverageNullRows = cache.coverage?.null_rows ?? 0;
 
   // Inject the credential-rejected banner when the operator's aggregate
@@ -205,7 +210,9 @@ export function ProblemsPanel({
               <div className="flex items-start gap-2">
                 <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-red-500" />
                 <div className="flex-1">
-                  <div className="font-medium text-red-800">{label} — last run failed</div>
+                  <div className="font-medium text-red-800">
+                    {label} — {job.verdict_reason || "needs attention"}
+                  </div>
                   {job.last_finished_at !== null ? (
                     <div className="text-xs text-slate-600">Failed at {formatDateTime(job.last_finished_at)}</div>
                   ) : null}

--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -152,9 +152,10 @@ describe("ProcessRow", () => {
     expect(screen.queryByText("ConnectionTimeout")).toBeNull();
   });
 
-  it("renders auto-hide tooltip on the self-healing (pending_retry) pill", () => {
+  it("renders auto-hide tooltip on the retrying (self_healing) pill", () => {
     renderRow({ row: makeProcessRow({ status: "pending_retry", stale_reasons: [] }) });
-    const pill = screen.getByText(/self-healing/i);
+    // #1689 — the self_healing pill label is now "retrying" (amber), not "self-healing".
+    const pill = screen.getByText(/retrying/i);
     expect(pill.getAttribute("title")).toContain("hiding");
     expect(pill.getAttribute("title")).toContain("retry");
   });
@@ -244,12 +245,14 @@ describe("ProcessRow", () => {
     expect(tr.className).toContain("border-l-red-500");
   });
 
-  it("#1508 C3: self_healing verdict is calm — no amber alarm border/pulse", () => {
+  it("#1689: self_healing gets an amber pill but no alarm row-border/pulse", () => {
     const { container } = renderRow({
       row: makeProcessRow({ status: "pending_retry", stale_reasons: [] }),
     });
     const tr = container.querySelector("tr") as HTMLElement;
-    // A scheduled retry is auto-recovery, not an action item → calm.
+    // #1689 — a scheduled retry now reads amber on the PILL (visible recovery),
+    // but is still auto-recovery, not an action item, so the ROW stays calm: no
+    // amber/red left-border, no pulse. Only `attention` wears the red row border.
     expect(tr.className).not.toContain("border-l-amber-500");
     expect(tr.className).not.toContain("animate-pulse");
     expect(tr.className).toContain("border-l-transparent");

--- a/frontend/src/components/admin/processStatus.test.ts
+++ b/frontend/src/components/admin/processStatus.test.ts
@@ -1,9 +1,9 @@
 /**
- * #1508 C3 — two-colour Processes page. `working` and `self_healing`
- * must read as the SAME calm green as `current` (keep distinct label
- * text, drop the blue/amber alarm pulse); only `attention` is the
- * alarming, pinned colour. Sort folds the three calm verdicts into one
- * group so only `attention` floats to the pinned region.
+ * #1689 three-state semaphore (supersedes the #1508 C3 two-colour fold):
+ * green (`current`/`working`) = ok · amber (`self_healing`) = recovering ·
+ * red (`attention`) = act · muted (`stale_manual`) = aged history. `working`
+ * stays calm green; `self_healing` is now its own amber tone (label "retrying")
+ * so a recovering row is visible rather than hidden as calm-green.
  */
 
 import { describe, expect, test } from "vitest";
@@ -14,47 +14,46 @@ import {
   VERDICT_VISUAL,
 } from "./processStatus";
 
-describe("VERDICT_VISUAL — two-colour fold (C3)", () => {
-  test("working and self_healing share the calm (non-attention) tone of current", () => {
-    expect(VERDICT_VISUAL.working.toneClass).toBe(
-      VERDICT_VISUAL.current.toneClass,
-    );
-    expect(VERDICT_VISUAL.self_healing.toneClass).toBe(
-      VERDICT_VISUAL.current.toneClass,
-    );
-    expect(VERDICT_VISUAL.attention.toneClass).not.toBe(
-      VERDICT_VISUAL.current.toneClass,
-    );
+describe("VERDICT_VISUAL — three-state semaphore (#1689)", () => {
+  test("working stays calm-green; self_healing/attention/stale_manual are each distinct", () => {
+    expect(VERDICT_VISUAL.working.toneClass).toBe(VERDICT_VISUAL.current.toneClass);
+    // self_healing is now amber — NOT the calm green it shared under C3.
+    expect(VERDICT_VISUAL.self_healing.toneClass).not.toBe(VERDICT_VISUAL.current.toneClass);
+    expect(VERDICT_VISUAL.self_healing.toneClass).not.toBe(VERDICT_VISUAL.attention.toneClass);
+    expect(VERDICT_VISUAL.attention.toneClass).not.toBe(VERDICT_VISUAL.current.toneClass);
+    // stale_manual is muted — distinct from calm, amber, and red.
+    expect(VERDICT_VISUAL.stale_manual.toneClass).not.toBe(VERDICT_VISUAL.current.toneClass);
+    expect(VERDICT_VISUAL.stale_manual.toneClass).not.toBe(VERDICT_VISUAL.self_healing.toneClass);
+    expect(VERDICT_VISUAL.stale_manual.toneClass).not.toBe(VERDICT_VISUAL.attention.toneClass);
   });
 
-  test("the calm verdicts do not pulse-as-alarm; attention does not pulse either", () => {
+  test("no verdict pulses-as-alarm", () => {
     expect(VERDICT_VISUAL.current.pulse).toBe(false);
     expect(VERDICT_VISUAL.working.pulse).toBe(false);
     expect(VERDICT_VISUAL.self_healing.pulse).toBe(false);
     expect(VERDICT_VISUAL.attention.pulse).toBe(false);
+    expect(VERDICT_VISUAL.stale_manual.pulse).toBe(false);
   });
 
-  test("distinct label text is preserved per verdict", () => {
+  test("distinct label text per verdict", () => {
     expect(VERDICT_VISUAL.current.label).toBe("current");
     expect(VERDICT_VISUAL.working.label).toBe("working");
-    expect(VERDICT_VISUAL.self_healing.label).toBe("self-healing");
+    expect(VERDICT_VISUAL.self_healing.label).toBe("retrying");
     expect(VERDICT_VISUAL.attention.label).toBe("needs attention");
+    expect(VERDICT_VISUAL.stale_manual.label).toBe("stale");
   });
 });
 
-describe("VERDICT_SORT_PRIORITY — only attention pins (C3)", () => {
-  test("only attention sorts to the pinned region", () => {
+describe("VERDICT_SORT_PRIORITY (#1689)", () => {
+  test("only attention pins to the top; calm/recovering share rank 1", () => {
     expect(VERDICT_SORT_PRIORITY.attention).toBe(0);
     expect(VERDICT_SORT_PRIORITY.working).toBe(VERDICT_SORT_PRIORITY.current);
-    expect(VERDICT_SORT_PRIORITY.self_healing).toBe(
-      VERDICT_SORT_PRIORITY.current,
-    );
+    expect(VERDICT_SORT_PRIORITY.self_healing).toBe(VERDICT_SORT_PRIORITY.current);
   });
 
-  test("attention outranks the calm group", () => {
-    expect(VERDICT_SORT_PRIORITY.attention).toBeLessThan(
-      VERDICT_SORT_PRIORITY.current,
-    );
+  test("attention outranks the calm group; stale_manual sinks below it", () => {
+    expect(VERDICT_SORT_PRIORITY.attention).toBeLessThan(VERDICT_SORT_PRIORITY.current);
+    expect(VERDICT_SORT_PRIORITY.stale_manual).toBeGreaterThan(VERDICT_SORT_PRIORITY.current);
   });
 });
 

--- a/frontend/src/components/admin/processStatus.ts
+++ b/frontend/src/components/admin/processStatus.ts
@@ -146,25 +146,28 @@ export const STALE_REASON_LABEL: Record<StaleReason, string> = {
 
 /**
  * Visuals for the single computed health verdict (#1512). The main
- * Processes row renders THIS pill instead of the raw `status` +
- * `stale_reasons` axes, so the operator never sees two cells that
- * disagree.
+ * Processes row AND the legacy Background Jobs table (#1689) both render
+ * THIS pill instead of raw `status` / `last_status`, so the operator
+ * never sees a transient / retrying / restart-reaped run painted red.
  *
- * #1508 C3 — two-colour fold. The page must read as binary: calm green
- * (no action) vs alarming red (act). `working` and `self_healing` are
- * "no action needed" states (a run is in flight / a retry is scheduled
- * — both are the system working AS DESIGNED), so they share `current`'s
- * calm emerald tone and DO NOT pulse-as-alarm. Their distinct LABEL text
- * ("working" / "self-healing") is preserved so the operator still sees
- * *why* a row is calm, but the colour no longer screams. Only `attention`
- * wears the alarming red tone.
- *
- * The calm-green Tailwind tone is hoisted to a single const so the three
- * calm verdicts cannot drift apart on a future dark-mode tweak
- * (single-source-of-truth).
+ * #1689 three-state semaphore (supersedes the #1508 C3 two-colour fold):
+ *   - green  (`current` / `working`)  — ok, system working as designed.
+ *   - amber  (`self_healing`)         — recovering: an auto-scheduled retry
+ *       is in flight. The operator should SEE it healing, not mistake it for
+ *       done (green) or broken (red). This is the deliberate reversal of C3,
+ *       which painted self_healing calm-green; the operator asked for amber.
+ *   - red    (`attention`)            — act: operator must intervene.
+ *   - muted  (`stale_manual`)         — aged history: an exhausted one-shot
+ *       (bootstrap/backfill) failure that is no longer a live alarm (#1689).
+ * Each tone is hoisted to a single const so verdicts cannot drift apart on a
+ * future dark-mode tweak (single-source-of-truth).
  */
 const CALM_TONE =
   "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/60 dark:text-emerald-300";
+const AMBER_TONE =
+  "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-300";
+const MUTED_TONE =
+  "border-slate-300 bg-slate-50 text-slate-500 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-400";
 
 export const VERDICT_VISUAL: Record<HealthVerdict, StatusVisual> = {
   current: {
@@ -180,10 +183,10 @@ export const VERDICT_VISUAL: Record<HealthVerdict, StatusVisual> = {
     pulse: false,
   },
   self_healing: {
-    // Distinct label, calm-green tone: a scheduled retry is auto-recovery,
-    // not an operator action item.
-    label: "self-healing",
-    toneClass: CALM_TONE,
+    // #1689 — amber: a scheduled retry is auto-recovery in progress. Distinct
+    // from green (done) and red (broken) so the operator SEES it healing.
+    label: "retrying",
+    toneClass: AMBER_TONE,
     pulse: false,
   },
   attention: {
@@ -192,20 +195,28 @@ export const VERDICT_VISUAL: Record<HealthVerdict, StatusVisual> = {
       "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/60 dark:text-red-300",
     pulse: false,
   },
+  stale_manual: {
+    // #1689 — muted: an aged, exhausted one-shot (bootstrap/backfill) failure.
+    // No longer a live alarm; sits in the collapsed Manual & backfill section.
+    label: "stale",
+    toneClass: MUTED_TONE,
+    pulse: false,
+  },
 };
 
 /**
- * Sort priority (#1508 C3): only `attention` pins to the top. The three
- * calm verdicts (`current` / `working` / `self_healing`) share one rank
- * so they form a single quiet group that the table can collapse behind
- * one disclosure. Replaces the prior four-rank ordering (#1512) — the
- * page is two-state now, not four.
+ * Sort priority: `attention` pins to the top (rank 0). The calm/recovering
+ * verdicts (`current` / `working` / `self_healing`) share rank 1 — one quiet
+ * group the table collapses behind a disclosure. `stale_manual` (#1689) sinks
+ * to rank 2 so aged one-shot history settles below live jobs. Only `attention`
+ * pins; lower number = higher.
  */
 export const VERDICT_SORT_PRIORITY: Record<HealthVerdict, number> = {
   attention: 0,
   current: 1,
   working: 1,
   self_healing: 1,
+  stale_manual: 2,
 };
 
 /**

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -31,11 +31,31 @@ import { AdminPage } from "@/pages/AdminPage";
 import { ApiError } from "@/api/client";
 import type {
   CoverageSummaryResponse,
+  JobOverviewResponse,
   JobsListResponse,
   RecommendationsListResponse,
   ConfigResponse,
   SyncLayersV2Response,
 } from "@/api/types";
+
+// #1689 — JobOverviewResponse gained six verdict fields. These fixtures don't
+// exercise them; spread sane defaults so the literals stay type-complete.
+const JOB_VERDICT_DEFAULTS: Pick<
+  JobOverviewResponse,
+  | "health_verdict"
+  | "self_healing"
+  | "verdict_reason"
+  | "role"
+  | "attempt"
+  | "next_retry_at"
+> = {
+  health_verdict: "current",
+  self_healing: false,
+  verdict_reason: "",
+  role: "steady_state",
+  attempt: null,
+  next_retry_at: null,
+};
 
 vi.mock("@/api/jobs", () => ({ fetchJobsOverview: vi.fn(), runJob: vi.fn() }));
 vi.mock("@/api/sync", () => ({
@@ -121,6 +141,7 @@ function jobsResponse(): JobsListResponse {
         last_started_at: null,
         last_finished_at: null,
         detail: "",
+        ...JOB_VERDICT_DEFAULTS,
       },
       {
         name: "execute_approved_orders",
@@ -134,6 +155,7 @@ function jobsResponse(): JobsListResponse {
         last_started_at: null,
         last_finished_at: null,
         detail: "",
+        ...JOB_VERDICT_DEFAULTS,
       },
       {
         name: "attribution_summary",
@@ -147,6 +169,11 @@ function jobsResponse(): JobsListResponse {
         last_started_at: null,
         last_finished_at: "2026-04-16T07:00:02Z",
         detail: "provider timeout",
+        ...JOB_VERDICT_DEFAULTS,
+        // #1689 — a genuinely-failed job reads attention; that is what the
+        // ProblemsPanel keys off now (not raw last_status).
+        health_verdict: "attention",
+        verdict_reason: "last run failed",
       },
     ],
   };
@@ -242,6 +269,7 @@ describe("AdminPage — top-level composition", () => {
           last_started_at: null,
           last_finished_at: null,
           detail: "",
+          ...JOB_VERDICT_DEFAULTS,
         },
       ],
     });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -33,7 +33,7 @@ import { CollapsibleSection } from "@/components/admin/CollapsibleSection";
 import { FundDataRow } from "@/components/admin/FundDataRow";
 import { ProblemsPanel } from "@/components/admin/ProblemsPanel";
 import { ProcessesTable } from "@/components/admin/ProcessesTable";
-import { NEXT_RUN_EXPECTED_TOOLTIP } from "@/components/admin/processStatus";
+import { NEXT_RUN_EXPECTED_TOOLTIP, VERDICT_VISUAL } from "@/components/admin/processStatus";
 import {
   SectionError,
   SectionSkeleton,
@@ -47,13 +47,6 @@ type RowState =
   | { kind: "running" }
   | { kind: "error"; message: string }
   | { kind: "queued" };
-
-const STATUS_TONE: Record<string, string> = {
-  success: "text-emerald-600",
-  failure: "text-red-600",
-  running: "text-amber-600",
-  skipped: "text-slate-400",
-};
 
 const ORCHESTRATOR_OWNED = new Set([
   "orchestrator_full_sync",
@@ -351,7 +344,31 @@ function CoverageSummaryCard({
   );
 }
 
-function JobsTable({
+// #1689 — render the single computed verdict pill (the same `VERDICT_VISUAL`
+// the Processes Hub uses) instead of the raw `last_status` tone, plus an
+// "attempt N · <reason>" detail line for a retrying (self_healing) row. So a
+// transient / retrying / restart-reaped run is never painted red here.
+function JobStatusCell({ job }: { job: JobOverviewResponse }) {
+  const visual = VERDICT_VISUAL[job.health_verdict];
+  const detail =
+    job.self_healing && job.attempt != null
+      ? `attempt ${job.attempt}${job.verdict_reason ? ` · ${job.verdict_reason}` : ""}`
+      : job.verdict_reason;
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span
+        data-testid="job-verdict-pill"
+        data-verdict={job.health_verdict}
+        className={`inline-flex w-fit items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${visual.toneClass}`}
+      >
+        {visual.label}
+      </span>
+      {detail ? <span className="text-[10px] text-slate-500">{detail}</span> : null}
+    </div>
+  );
+}
+
+function JobsSubTable({
   items,
   rowState,
   onRun,
@@ -360,9 +377,6 @@ function JobsTable({
   rowState: Record<string, RowState>;
   onRun: (name: string) => void;
 }) {
-  if (items.length === 0) {
-    return <p className="text-sm text-slate-500">No background jobs registered.</p>;
-  }
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-left text-sm">
@@ -373,7 +387,7 @@ function JobsTable({
             <th className="py-2 pr-4" title={NEXT_RUN_EXPECTED_TOOLTIP}>
               Next run (expected)
             </th>
-            <th className="py-2 pr-4">Last result</th>
+            <th className="py-2 pr-4">Status</th>
             <th className="py-2 pr-4">Last finished</th>
             <th className="py-2 pr-4 text-right">Action</th>
           </tr>
@@ -383,7 +397,7 @@ function JobsTable({
             const state = rowState[job.name] ?? { kind: "idle" };
             const label = job.display_name ?? job.name;
             return (
-              <tr key={job.name} className="align-top">
+              <tr key={job.name} className="align-top" data-job-row={job.name}>
                 <td className="py-2 pr-4">
                   <div className="font-medium text-slate-700">{label}</div>
                   <div className="text-xs text-slate-500">{job.description}</div>
@@ -396,13 +410,7 @@ function JobsTable({
                   {formatDateTime(job.next_run_time)}
                 </td>
                 <td className="py-2 pr-4 text-xs">
-                  <span
-                    className={
-                      STATUS_TONE[job.last_status ?? ""] ?? "text-slate-400"
-                    }
-                  >
-                    {job.last_status ?? "never run"}
-                  </span>
+                  <JobStatusCell job={job} />
                 </td>
                 <td className="py-2 pr-4 text-xs text-slate-500">
                   {formatDateTime(job.last_finished_at)}
@@ -421,6 +429,45 @@ function JobsTable({
         </tbody>
       </table>
     </div>
+  );
+}
+
+// #1530 / #1689 — steady-state keepers render inline; one-shot bootstrap /
+// backfill jobs (which legitimately sit idle/failed between runs) move into a
+// collapsed section so an aged one-shot never reads as a steady-state alarm.
+function JobsTable({
+  items,
+  rowState,
+  onRun,
+}: {
+  items: JobOverviewResponse[];
+  rowState: Record<string, RowState>;
+  onRun: (name: string) => void;
+}) {
+  if (items.length === 0) {
+    return <p className="text-sm text-slate-500">No background jobs registered.</p>;
+  }
+  const steady = items.filter((j) => j.role === "steady_state");
+  const manual = items.filter((j) => j.role !== "steady_state");
+  return (
+    <>
+      {steady.length > 0 ? (
+        <JobsSubTable items={steady} rowState={rowState} onRun={onRun} />
+      ) : (
+        <p className="text-sm text-slate-500">No steady-state jobs.</p>
+      )}
+      {manual.length > 0 ? (
+        <details className="mt-3">
+          <summary className="cursor-pointer text-xs font-medium text-slate-500">
+            Manual &amp; backfill ({manual.length}) — one-shot installs and historical
+            catch-ups
+          </summary>
+          <div className="mt-2">
+            <JobsSubTable items={manual} rowState={rowState} onRun={onRun} />
+          </div>
+        </details>
+      ) : null}
+    </>
   );
 }
 

--- a/tests/services/processes/test_health_verdict.py
+++ b/tests/services/processes/test_health_verdict.py
@@ -17,11 +17,24 @@ from __future__ import annotations
 
 import itertools
 import typing
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from app.services.processes import HealthVerdict, ProcessStatus, StaleReason
-from app.services.processes.health_verdict import ACTIONABLE_STALE, compute_verdict
+from app.services.processes import (
+    HealthVerdict,
+    ProcessRole,
+    ProcessRow,
+    ProcessRunSummary,
+    ProcessStatus,
+    StaleReason,
+)
+from app.services.processes.health_verdict import (
+    ACTIONABLE_STALE,
+    STALE_MANUAL_WINDOW,
+    compute_verdict,
+    verdict_for_row,
+)
 
 _ALL_STATUSES: tuple[ProcessStatus, ...] = typing.get_args(ProcessStatus)
 _ALL_REASONS: tuple[StaleReason, ...] = typing.get_args(StaleReason)
@@ -423,3 +436,119 @@ def test_recovery_signal_never_masks_a_wedge(wedge: str, recover: str) -> None:
         kw["retry_at_display"] = "21:20"
     verdict, _, _ = compute_verdict(**kw)  # type: ignore[arg-type]
     assert verdict == "attention", f"{recover} masked {wedge}"
+
+
+# ---------------------------------------------------------------------------
+# #1689 — stale_manual (aged one-shot bootstrap/backfill failure) + the
+# verdict_for_row choke point shared by /system/processes and /system/jobs.
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 6, 20, 12, 0, tzinfo=UTC)
+
+
+def _row(
+    *,
+    role: ProcessRole,
+    status: ProcessStatus,
+    next_retry_at: datetime | None = None,
+    finished_ago: timedelta = timedelta(days=2),
+    stale_reasons: tuple[StaleReason, ...] = (),
+) -> ProcessRow:
+    """Minimal ProcessRow for verdict_for_row tests (most fields default)."""
+    last_run = ProcessRunSummary(
+        run_id=1,
+        started_at=_NOW - finished_ago - timedelta(minutes=5),
+        finished_at=_NOW - finished_ago,
+        duration_seconds=300.0,
+        rows_processed=0,
+        rows_skipped_by_reason={},
+        rows_errored=0,
+        status="failure" if status == "failed" else "success",
+        cancelled_by_operator_id=None,
+    )
+    return ProcessRow(
+        process_id="job_x",
+        display_name="Job X",
+        lane="sec",
+        mechanism="scheduled_job",
+        status=status,
+        last_run=last_run,
+        active_run=None,
+        cadence_human="daily",
+        cadence_cron=None,
+        next_fire_at=None,
+        watermark=None,
+        can_iterate=True,
+        can_full_wash=True,
+        can_cancel=False,
+        last_n_errors=(),
+        stale_reasons=stale_reasons,
+        role=role,
+        next_retry_at=next_retry_at,
+    )
+
+
+def test_compute_verdict_stale_manual_on_aged_one_shot() -> None:
+    verdict, self_healing, reason = compute_verdict(status="failed", stale_reasons=(), manual_aged_exhausted=True)
+    assert verdict == "stale_manual"
+    assert self_healing is False
+    assert reason  # non-empty inline copy
+
+
+@pytest.mark.parametrize("wedge", ["watermark_gap", "queue_stuck", "mid_flight_stuck"])
+def test_stale_manual_never_masks_a_wedge(wedge: StaleReason) -> None:
+    """An actionable wedge outranks the aged-one-shot demotion (precedence)."""
+    verdict, _, _ = compute_verdict(status="failed", stale_reasons=(wedge,), manual_aged_exhausted=True)
+    assert verdict == "attention"
+
+
+def test_failed_without_aged_flag_stays_attention() -> None:
+    verdict, _, _ = compute_verdict(status="failed", stale_reasons=(), manual_aged_exhausted=False)
+    assert verdict == "attention"
+
+
+def test_retry_in_flight_outranks_stale_manual() -> None:
+    """A scheduled retry reads self_healing even if the aged flag is set."""
+    verdict, self_healing, _ = compute_verdict(
+        status="failed", stale_reasons=(), retry_in_flight=True, manual_aged_exhausted=True
+    )
+    assert verdict == "self_healing"
+    assert self_healing is True
+
+
+@pytest.mark.parametrize("role", ["bootstrap", "backfill"])
+def test_verdict_for_row_aged_one_shot_is_stale_manual(role: ProcessRole) -> None:
+    row = _row(role=role, status="failed", finished_ago=STALE_MANUAL_WINDOW + timedelta(hours=1))
+    assert verdict_for_row(row, now=_NOW)[0] == "stale_manual"
+
+
+def test_verdict_for_row_steady_state_failure_never_muted() -> None:
+    """Role gate: a steady_state failure stays red however old — it is a real alarm."""
+    row = _row(role="steady_state", status="failed", finished_ago=STALE_MANUAL_WINDOW + timedelta(days=10))
+    assert verdict_for_row(row, now=_NOW)[0] == "attention"
+
+
+def test_verdict_for_row_recent_one_shot_failure_is_attention() -> None:
+    """Within STALE_MANUAL_WINDOW the operator still sees their triggered job failed (red)."""
+    row = _row(role="backfill", status="failed", finished_ago=timedelta(hours=1))
+    assert verdict_for_row(row, now=_NOW)[0] == "attention"
+
+
+def test_verdict_for_row_one_shot_with_retry_in_flight_is_self_healing() -> None:
+    row = _row(
+        role="backfill",
+        status="failed",
+        next_retry_at=_NOW + timedelta(minutes=10),
+        finished_ago=STALE_MANUAL_WINDOW + timedelta(days=1),
+    )
+    verdict, self_healing, _ = verdict_for_row(row, now=_NOW)
+    assert verdict == "self_healing"
+    assert self_healing is True
+
+
+def test_verdict_for_row_wedged_running_reads_red() -> None:
+    """#1689 running_too_long guarantee: a wedged running row (mid_flight_stuck,
+    keyed on COALESCE(last_progress_at, started_at) in stale_detection) reads
+    attention — a hung non-heartbeating job is never falsely calm."""
+    row = _row(role="steady_state", status="running", stale_reasons=("mid_flight_stuck",))
+    assert verdict_for_row(row, now=_NOW)[0] == "attention"

--- a/tests/services/test_ops_monitor_retry.py
+++ b/tests/services/test_ops_monitor_retry.py
@@ -152,3 +152,41 @@ def test_success_breaks_streak_resets_attempt(ebull_test_conn: psycopg.Connectio
     _, next_retry_at, attempt = _retry_state(ebull_test_conn, run_id)
     assert attempt == 1
     assert next_retry_at == now + timedelta(seconds=300)
+
+
+# --- #1689 — record_job_finish first-writer-wins guard -------------------
+
+
+def test_finalize_guard_preserves_a_reaped_row(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """A late finalize must NOT clobber a row already terminalized out of band
+    (e.g. the boot reaper flipped it to failure + scheduled its own retry).
+    ``WHERE ... AND status='running'`` makes record_job_finish first-writer-wins."""
+    reaped_retry = datetime(2026, 6, 20, 12, 0, tzinfo=UTC)
+    run_id = record_job_start(ebull_test_conn, "guard_jobR")
+    # Mimic reap_orphaned_job_runs: terminalize + stamp its own retry plan.
+    ebull_test_conn.execute(
+        """
+        UPDATE job_runs
+           SET status = 'failure', finished_at = now(),
+               error_category = %s, next_retry_at = %s, attempt = 2
+         WHERE run_id = %s
+        """,
+        (FailureCategory.INTERNAL_ERROR.value, reaped_retry, run_id),
+    )
+    ebull_test_conn.commit()
+    # The original worker now (late) finalizes the same run as success.
+    record_job_finish(ebull_test_conn, run_id, status="success", row_count=5)
+    status, next_retry_at, attempt = _retry_state(ebull_test_conn, run_id)
+    # Guard held: reaper's terminal + retry plan intact, not overwritten.
+    assert status == "failure"
+    assert next_retry_at == reaped_retry
+    assert attempt == 2
+
+
+def test_finalize_succeeds_on_a_running_row(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """The guard does not block the normal path: a still-running row finalizes."""
+    run_id = record_job_start(ebull_test_conn, "guard_jobN")
+    record_job_finish(ebull_test_conn, run_id, status="success", row_count=7)
+    status, next_retry_at, _ = _retry_state(ebull_test_conn, run_id)
+    assert status == "success"
+    assert next_retry_at is None

--- a/tests/test_processes_envelope.py
+++ b/tests/test_processes_envelope.py
@@ -97,6 +97,8 @@ def test_process_row_carries_all_envelope_fields() -> None:
         "never_started",
         "cancel_was_operator_initiated",
         "role",
+        # #1689 — latest terminal job_runs.attempt, for the FE "attempt N" label.
+        "attempt",
     }
     assert set(row.__slots__) == expected
 


### PR DESCRIPTION
Closes #1689. Follow-up: #1690 (statement_timeout active-cancel). Refs #1685/#1686/#1687.

## Problem
The **Background Jobs table** (`/system/jobs` → `AdminPage::JobsTable`) rendered raw `last_status` through `STATUS_TONE` (`failure`→red), so a transient / retrying / restart-reaped / aged-one-shot job painted the same red as a genuinely-dead one. The **Processes Hub** (`/system/processes`, `compute_verdict` #1512) already renders honestly — and `scheduled_adapter.list_rows()` enumerates the **same** `SCHEDULED_JOBS`. So the naive table was a redundant, dumber view.

**Premise correction (verified against the full live population, not a sample):** `sec_rebuild` is manual-trigger-only — NOT in `SCHEDULED_JOBS` — so it renders on neither admin table; the handoff's "sec_rebuild stale red" was a `job_runs` artifact. All 38 rendered jobs are currently non-red; the false-red is **latent** (manifests during failure/retry/restart-reap windows — the recent restart churn). `stale_manual` therefore targets the rendered `bootstrap`/`backfill` role jobs.

## Change — converge on the existing verdict model (single source of truth)
- **`verdict_for_row()`** extracted from `api/processes.py::_convert_row` (the `retry_in_flight`/`retry_at_display` derivation + `compute_verdict` call + the new aged-failure derivation). Both `/system/processes` and `/system/jobs` call it. No parallel status model.
- **`/system/jobs`** (`_build_jobs_overview`) reuses `scheduled_adapter.list_rows()` under one `snapshot_read`, layering `health_verdict`/`self_healing`/`verdict_reason`/`role`/`attempt`/`next_retry_at` onto the unchanged legacy fields. `next_run_time` sourced from `row.next_fire_at` (same basis as verdict inputs → no cross-read drift).
- **New 5th `HealthVerdict` `stale_manual`**: `role in {bootstrap,backfill}` AND `failed` AND no `next_retry_at` AND `finished_at < now − 24h` → muted, collapsed. Role-gated (a `steady_state` failure is never muted); a *recent* one-shot failure still reads attention. An actionable wedge still outranks it (#1512 precedence preserved).
- **`self_healing` pill → amber "retrying"** (supersedes #1508 C3 calm-green; operator asked for amber) with `attempt N · <reason>`. Semaphore: green ok / amber recovering / red act / muted aged.
- **`ProblemsPanel`** keys off `health_verdict === "attention"` (not raw `last_status`), so a retrying/reaped/aged job no longer raises a red problem banner *(Codex ckpt-2 finding — the same false-red on a sibling surface)*.
- **FE `JobsTable`** renders the verdict pill + role-split collapsed "Manual & backfill" section.
- **`record_job_finish`** gains `AND status='running'` — a first-writer-wins guard so a late finalize can't clobber a reaper's terminal/retry plan (#1688). Mirrors `_finalize_sync_run`.

## Hung-job decision (Decision 4)
Picked **timeout-bounded adapters** (root cause); **rejected the blind periodic reaper** — Python can't force-kill a thread, so reaping a wedged job only flips the row + schedules a retry that can't proceed while the wedged thread holds the source advisory lock → it would paint a genuinely-stuck job amber "retrying", violating "red = genuinely-stuck only". `running_too_long` is **already** covered: `stale_detection` keys `mid_flight_stuck` on `COALESCE(last_progress_at, started_at)`, so a wedged non-heartbeating `running` row already reads attention. The active query-cancel (`statement_timeout` via a shared `connect_job()`) needs an ~82-site raw-`psycopg.connect` migration → split to **#1690**.

## Out of scope (own tickets)
#1685 recent-first manifest slice · #1690 statement_timeout · #1686/#1687 referenced.

## Tradeoff
`/system/jobs` now also runs the Hub's per-row probes (≈2× admin-poll probe cost vs the old `check_job_health` loop). Read-only MVCC, fine at 38 jobs; **eliminated when the now-redundant `JobsTable` is retired** — recommended follow-up (kept here because the operator asked for the endpoint-level fix and deleting a surface is an operator-visible scope call).

## Security model
Read-path only — no new auth surface, no SQL on user input, no schema/parser/ownership change. `/system/jobs` keeps its existing `require_session_or_service_token` gate and its 503-on-build-failure. The `record_job_finish` guard tightens (never loosens) a write. No migration, no backfill, no `sec_rebuild`, no jobs-daemon restart required.

## Verification (commit fbed5b2e)
- Gates: `ruff check`/`format` clean, `pyright` 0, fast tier exit 0, smoke pass, FE typecheck + **1062** unit tests pass.
- **Dev-verified on the real path against the dev DB** (`list_rows` + `verdict_for_row`): 38 jobs build (`{attention:4, current:34}` — the 4 attention are genuinely overdue/never-started jobs the Hub already flags; the naive table hid them as green). Synthetic rows on a real job (cleaned up): aged backfill failure → `stale_manual`; backfill failed + future retry → `self_healing` "will retry HH:MM"; steady `auth_expired` no-retry → `attention`.
- Clauses 8-12 (ownership/parser/schema-ingest) N/A — operator-UI display change.

## Tests
`compute_verdict` stale_manual / wedge-outranks / role-gate; `verdict_for_row` aged vs recent vs steady-exhausted vs retry-in-flight; wedged-running→red regression; `record_job_finish` guard (db); FE `processStatus` (amber/muted/sort) + `ProblemsPanel`/`AdminPage`/`ProcessRow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)