### PR TITLE
feat(#1685): recent-first manifest drain slice (all sources)

### DIFF
--- a/app/jobs/sec_manifest_worker.py
+++ b/app/jobs/sec_manifest_worker.py
@@ -48,6 +48,7 @@ from app.services.sec_manifest import (
     ManifestRow,
     ManifestSource,
     iter_pending,
+    iter_pending_recent,
     iter_pending_topup,
     iter_retryable,
     iter_retryable_topup,
@@ -55,6 +56,15 @@ from app.services.sec_manifest import (
 )
 
 logger = logging.getLogger(__name__)
+
+# #1685 — recent-first slice budget. Of each ``max_rows`` fairness tick, up to
+# this many rows are reserved for the NEWEST pending filings (filed within
+# ``RECENT_WINDOW``) per source, so recent events (8-K-class, 13D/G, DEF 14A,
+# …) stay fresh regardless of the oldest-first historical backlog the main
+# drain works through. The worker caps it at ``max_rows // 2`` so the backlog
+# drain is never starved to zero.
+RECENT_SLICE_ROWS = 30
+RECENT_WINDOW = timedelta(days=90)
 
 
 # Tick counter for Phase A `lead` rotation (#1179). Module-global
@@ -231,8 +241,8 @@ def run_manifest_worker(
             rows.extend(iter_retryable(conn, source=source, limit=max_rows - len(rows)))
         return _dispatch_rows(conn, rows, now=now)
 
-    # Fairness path (#1179) — Phase A per-source slice + Phase B
-    # top-up across the global oldest tail.
+    # Fairness path (#1179) — Phase R recent-first slice (#1685) +
+    # Phase A per-source oldest slice + Phase B global oldest top-up.
     sources = sorted(registered_parser_sources())
     n = len(sources)
     if n == 0:
@@ -246,24 +256,50 @@ def run_manifest_worker(
 
     if tick_id is None:
         tick_id = next(_TICK_COUNTER)
-    quotas = compute_quotas(sources, max_rows, tick_id)
 
-    rows = []
+    rows: list[ManifestRow] = []
+    seen: set[str] = set()
 
-    # Phase A — per-source quota slice (pending first, retryable
-    # within the same per-source budget).
+    # Phase R (#1685) — recent-first slice. Reserve a bounded budget for the
+    # NEWEST pending filings (within RECENT_WINDOW) per source, allocated with
+    # the same #1179 rotation, newest first. ``max_rows // 2`` guarantees the
+    # backlog budget below stays > 0 even for a small ``max_rows`` (Codex
+    # ckpt-1: a base-zero backlog would collapse the fairness rotation).
+    recent_budget = min(RECENT_SLICE_ROWS, max_rows // 2)
+    if recent_budget > 0:
+        recent_cutoff = now - RECENT_WINDOW
+        recent_quotas = compute_quotas(sources, recent_budget, tick_id)
+        for s in sources:
+            q = recent_quotas[s]
+            if q == 0:
+                continue
+            recent = list(iter_pending_recent(conn, source=s, since=recent_cutoff, limit=q))
+            rows.extend(recent)
+            seen.update(r.accession_number for r in recent)
+
+    # Phase A — per-source oldest-first slice over whatever budget Phase R did
+    # NOT consume (unused recent budget rolls into the backlog). The pending
+    # pick is filtered against ``seen`` so a tiny all-recent source cannot have
+    # a row dispatched twice in one tick (Codex ckpt-1: the only overlap case —
+    # for a large backlog Phase R's newest prefix and Phase A's oldest prefix
+    # are disjoint). Retryable rows are ``failed`` so can never collide with the
+    # ``pending`` Phase R picks — no filter needed there.
+    backlog_budget = max_rows - len(rows)
+    quotas = compute_quotas(sources, backlog_budget, tick_id)
     for s in sources:
         q = quotas[s]
         if q == 0:
             continue
-        per_source: list[ManifestRow] = list(iter_pending(conn, source=s, limit=q))
+        per_source: list[ManifestRow] = [
+            r for r in iter_pending(conn, source=s, limit=q) if r.accession_number not in seen
+        ]
         if len(per_source) < q:
             per_source.extend(iter_retryable(conn, source=s, limit=q - len(per_source)))
         rows.extend(per_source)
+        seen.update(r.accession_number for r in per_source)
 
     # Phase B — top-up pending, then retryable, both scoped to
-    # registered sources, excluding Phase A picks.
-    seen: set[str] = {r.accession_number for r in rows}
+    # registered sources, excluding everything already picked.
     remaining = max_rows - len(rows)
     if remaining > 0:
         topup_pending = list(

--- a/app/services/sec_manifest.py
+++ b/app/services/sec_manifest.py
@@ -610,6 +610,43 @@ def iter_pending(
             yield ManifestRow(**row)
 
 
+def iter_pending_recent(
+    conn: psycopg.Connection[Any],
+    *,
+    source: ManifestSource,
+    since: datetime,
+    limit: int = 30,
+) -> Iterator[ManifestRow]:
+    """Yield the NEWEST pending rows for one source filed on/after ``since``.
+
+    #1685 — the recent-first slice. ``filed_at DESC`` (newest first), floored at
+    ``since`` (the worker passes a 90-day window), so every source keeps its
+    recent filings fresh regardless of the oldest-first historical backlog the
+    main drain (``iter_pending``) works through. Served by the partial index
+    ``idx_manifest_recent (source, filed_at DESC, accession_number DESC) WHERE
+    ingest_status='pending'`` (sql/204) so a tick does not scan the ~1.46M-row
+    pending backlog. Source-scoped only — the worker allocates a per-source
+    recent quota via ``compute_quotas``."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT accession_number, cik, form, source,
+                   subject_type, subject_id, instrument_id,
+                   filed_at, accepted_at, primary_document_url,
+                   is_amendment, amends_accession,
+                   ingest_status, parser_version, raw_status,
+                   last_attempted_at, next_retry_at, error
+            FROM sec_filing_manifest
+            WHERE ingest_status = 'pending' AND source = %s AND filed_at >= %s
+            ORDER BY filed_at DESC, accession_number DESC
+            LIMIT %s
+            """,
+            (source, since, limit),
+        )
+        for row in cur.fetchall():
+            yield ManifestRow(**row)
+
+
 def iter_retryable(
     conn: psycopg.Connection[Any],
     *,

--- a/docs/specs/ingest/2026-06-20-manifest-recent-first-slice.md
+++ b/docs/specs/ingest/2026-06-20-manifest-recent-first-slice.md
@@ -1,0 +1,70 @@
+# Manifest worker: recent-first drain slice (#1685)
+
+**Status:** spec • **Issue:** #1685 • **Date:** 2026-06-20
+
+## Problem (full-population verified, dev DB)
+
+`run_manifest_worker` drains `filed_at ASC` (oldest-first) at `max_rows=100`/tick every 5 min against a **1,460,312-row** pending backlog. Every source has `newest_pending` at 2026-06-18/19 but `oldest_pending` years back — recents are discovered then never parsed:
+
+| source | pending | oldest | newest |
+|---|---|---|---|
+| sec_form4 | 1,065,611 | 2018-02-23 | 2026-06-19 |
+| sec_13f_hr | 199,650 | 2018-04-16 | 2026-06-18 |
+| sec_10q | 61,931 | 2020-08-07 | 2026-06-18 |
+| sec_form3 | 52,331 | 2021-03-25 | 2026-06-18 |
+| sec_def14a | 33,117 | 2022-04-28 | 2026-06-18 |
+| sec_13g | 32,123 | 2025-02-12 | 2026-06-18 |
+| sec_13d | 15,549 | 2021-03-08 | 2026-06-19 |
+
+Form 4 (73% of backlog) already has a dedicated newest-first lane (#1684); 13F/10Q/Form3/DEF14A/13G/13D have none → their recent events (8-K-class dividend/13D blockholder/DEF14A) stay months stale. Same starvation class as the Form 4 insider bug.
+
+## Source rule
+SEC imposes no ingest order; recency is our operational freshness strategy (recent filings carry the operator-relevant events). The #1684 spec (`docs/specs/ingest/2026-06-20-insider-recent-first-drain.md` L84-85) already prescribes the systemic fix: "a recent-first slice in `run_manifest_worker` — a `filed_at DESC` top-up alongside the oldest-first fairness path." **Full-population check:** the table above is the entire pending population (7 sources), not a sample.
+
+## Settled-decisions / prevention-log applied
+- **#1179 fairness** (`compute_quotas`): the recent slice REUSES `compute_quotas` for per-source fairness; no parallel allocator.
+- **L1337**: the fairness test computes expected quotas via `compute_quotas(sorted(registered_parser_sources()), ...)` — new tests mirror that exact call, and seed rows with controlled `filed_at` so Phase R is deterministic.
+- **L1712-1715 (lane-split monotonic regression): N/A** — Phase R runs INSIDE the same worker tick / same `sec_manifest` lane / same connection. No new concurrency, no new writer interleave.
+
+## Design — Phase R (recent-first), then the unchanged backlog drain
+
+In `run_manifest_worker` (fairness path, `source is None`), before Phase A:
+
+- `RECENT_SLICE_ROWS = 30` (of `max_rows`), `RECENT_WINDOW = timedelta(days=90)`, `recent_cutoff = now - RECENT_WINDOW`.
+- `recent_budget = min(RECENT_SLICE_ROWS, max_rows // 2)` — the `// 2` floor guarantees Phase A's `backlog_budget` stays `> 0` even when `max_rows` is small (Codex ckpt-1: a base-zero backlog would collapse the #1179 fairness rotation). The production scheduled tick is always `max_rows=100` → recent=30, backlog≥70.
+- **Phase R**: `recent_quotas = compute_quotas(sources, recent_budget, tick_id)`; per source, `iter_pending_recent(conn, source=s, since=recent_cutoff, limit=q)` (`filed_at DESC`, floored at cutoff). Collect → `rows`, seed `seen`.
+- `backlog_budget = max_rows - len(rows)` — **unused recent budget rolls into the backlog** (a source with no recent pending costs nothing).
+- **Phase A** (oldest-first): `compute_quotas(sources, backlog_budget, tick_id)`; per source `iter_pending(source, q)` then `iter_retryable`, each **filtered `accession_number not in seen`** (dedup — only bites a tiny source whose entire pending set is recent; overlap is otherwise impossible since Phase R takes newest, Phase A oldest). Update `seen`.
+- **Phase B**: unchanged (already `exclude_accessions=sorted(seen)`).
+
+`source is not None` (per-source rebuild) path: **unchanged** — it is a targeted drain, not the steady-state freshness keeper.
+
+### New iterator
+`iter_pending_recent(conn, *, source: ManifestSource, since: datetime, limit: int)` — clone of `iter_pending`'s source-filtered branch with `AND filed_at >= %(since)s` and `ORDER BY filed_at DESC, accession_number DESC`. Same column list → `ManifestRow(**row)`.
+
+### Migration 204 (index)
+The per-source `WHERE ingest_status='pending' AND source=? AND filed_at>=? ORDER BY filed_at DESC` query must not scan 1M+ pending rows/tick. Add a partial index:
+```sql
+-- runner: autocommit
+DROP INDEX CONCURRENTLY IF EXISTS idx_manifest_recent;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_manifest_recent
+  ON sec_filing_manifest (source, filed_at DESC, accession_number DESC)
+  WHERE ingest_status = 'pending';
+```
+`CONCURRENTLY` (no worker lock during the ~1.46M-row build) is why the file uses the `-- runner: autocommit` directive (`app/db/migrations.py` — CONCURRENTLY cannot run inside a tx block). The leading `DROP INDEX CONCURRENTLY IF EXISTS` clears any **invalid** index left by a prior interrupted concurrent build (Codex ckpt-1: bare `CREATE ... IF NOT EXISTS` would skip an invalid leftover, leaving it unused) before the rebuild; both statements are idempotent. `accession_number DESC` makes the documented tie-break fully index-ordered.
+
+## Tradeoffs
+- 30/100 rows/tick now chase recents → the historical backlog drains ~30% slower. Acceptable: backlog drain is the #1686 capacity concern (more workers / bigger tick), while recent-freshness is the operator-visible win. The split is a named constant, tunable.
+- Phase R double-counts Form 4 with #1684's lane — harmless (idempotent `transition_status`; dedup is per-tick, the lane and worker don't overlap-write a single accession because `transition_status` is atomic per row).
+
+## Tests
+- `compute_quotas` unchanged (existing tests pass).
+- New worker tests (seed with controlled `filed_at`, inject `tick_id` + `now`): Phase R selects the NEWEST per-source within window; a row older than `RECENT_WINDOW` is NOT picked by Phase R (still drained oldest-first); recent picks are de-duplicated from Phase A (no row dispatched twice); a source with zero recent pending yields its full budget to the backlog. Mirror L1337's `sorted(registered_parser_sources())`.
+- **Backlog floor** (Codex ckpt-1): a fairness-path call with `max_rows < RECENT_SLICE_ROWS` (e.g. 4) still leaves `backlog_budget > 0` (the `// 2` cap) — Phase A is not starved to zero; assert backlog rows still selected.
+- `iter_pending_recent`: one `db` test — DESC order + `since` floor + source filter.
+
+## DoD (ETL clauses 8-12)
+- **Migration applied** (dev): `idx_manifest_recent` exists; `run_migrations` clean.
+- **Operator-visible freshness**: after wiring + a few ticks on dev, confirm a recent pending DEF14A/13D/13G (filed within 90d) transitions `pending→parsed` while the historical backlog is untouched at the tail. Record the accession + before/after `ingest_status`.
+- **No data-treatment change**: #1685 reorders WHICH rows parse first; it does not change parser output, so no instrument-figure cross-source check applies (clauses 9/11 N/A — record why). Smoke panel (clause 8): N/A — no parser/schema change to ownership/fundamentals; the change is ingest-ordering only.
+- Records commit SHA + the freshness observation.

--- a/sql/204_manifest_recent_index.sql
+++ b/sql/204_manifest_recent_index.sql
@@ -1,0 +1,13 @@
+-- runner: autocommit
+-- #1685 — partial index for the recent-first manifest slice. Serves the
+-- per-source recent query (`WHERE ingest_status='pending' AND source=? AND
+-- filed_at>=? ORDER BY filed_at DESC, accession_number DESC`) so a worker tick
+-- does not scan the ~1.46M-row pending backlog. Built CONCURRENTLY (no worker
+-- lock) — hence the autocommit directive (CONCURRENTLY cannot run in a tx
+-- block). The leading DROP CONCURRENTLY IF EXISTS clears any INVALID index a
+-- prior interrupted concurrent build may have left under this name (a bare
+-- CREATE ... IF NOT EXISTS would skip it). Both statements are idempotent.
+DROP INDEX CONCURRENTLY IF EXISTS idx_manifest_recent;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_manifest_recent
+  ON sec_filing_manifest (source, filed_at DESC, accession_number DESC)
+  WHERE ingest_status = 'pending';

--- a/tests/test_sec_manifest_worker.py
+++ b/tests/test_sec_manifest_worker.py
@@ -14,7 +14,7 @@ Covers:
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import psycopg
@@ -29,6 +29,7 @@ from app.jobs.sec_manifest_worker import (
 from app.services.sec_manifest import (
     ManifestRow,
     get_manifest_row,
+    iter_pending_recent,
     record_manifest_entry,
 )
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
@@ -1052,3 +1053,130 @@ class TestFairness:
         )
         assert len(retryable_rows) == 1
         assert retryable_rows[0].accession_number == accessions[0]
+
+
+class TestRecentFirstSlice:
+    """#1685 — Phase R recent-first slice keeps every source's recent filings
+    fresh regardless of the oldest-first historical backlog."""
+
+    _NOW = datetime(2026, 6, 20, 12, 0, tzinfo=UTC)
+
+    def test_recent_picked_despite_old_backlog(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # 120 OLD def14a would fill a max_rows=100 oldest-first tick entirely;
+        # the 5 RECENT (within 90d) would never surface without Phase R.
+        captures: list[tuple[str, ManifestSource]] = []
+        register_parser("sec_def14a", _make_capturing_parser(captures))
+        _seed_pending_n(
+            ebull_test_conn,
+            source="sec_def14a",
+            n=120,
+            base_filed_at=datetime(2020, 1, 1, tzinfo=UTC),
+            iid=1,
+            cik="0000000001",
+        )
+        recent = _seed_pending_n(
+            ebull_test_conn,
+            source="sec_def14a",
+            n=5,
+            base_filed_at=self._NOW - timedelta(days=10),
+            iid=2,
+            cik="0000000002",
+        )
+        ebull_test_conn.commit()
+        run_manifest_worker(ebull_test_conn, source=None, max_rows=100, tick_id=0, now=self._NOW)
+        ebull_test_conn.commit()
+        dispatched = {a for a, _ in captures}
+        assert set(recent) <= dispatched, "Phase R must surface recent filings despite the old backlog"
+
+    def test_no_double_dispatch_when_source_is_all_recent(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # A source whose entire (small) pending set is recent: Phase R + Phase A
+        # both reach for it — the seen-dedup must prevent a double dispatch.
+        captures: list[tuple[str, ManifestSource]] = []
+        register_parser("sec_13d", _make_capturing_parser(captures))
+        accs = _seed_pending_n(
+            ebull_test_conn,
+            source="sec_13d",
+            n=3,
+            base_filed_at=self._NOW - timedelta(days=5),
+            iid=3,
+            cik="0000000003",
+        )
+        ebull_test_conn.commit()
+        run_manifest_worker(ebull_test_conn, source=None, max_rows=100, tick_id=0, now=self._NOW)
+        ebull_test_conn.commit()
+        dispatched = [a for a, _ in captures]
+        assert sorted(dispatched) == sorted(accs)
+        assert len(dispatched) == len(set(dispatched)), "no accession dispatched twice in a tick"
+
+    def test_backlog_not_starved_at_small_max_rows(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # max_rows < RECENT_SLICE_ROWS: the `// 2` floor must leave backlog
+        # budget > 0 so the oldest-first drain is not starved to zero.
+        captures: list[tuple[str, ManifestSource]] = []
+        register_parser("sec_form4", _make_capturing_parser(captures))
+        old = _seed_pending_n(
+            ebull_test_conn,
+            source="sec_form4",
+            n=10,
+            base_filed_at=datetime(2019, 1, 1, tzinfo=UTC),
+            iid=4,
+            cik="0000000004",
+        )
+        _seed_pending_n(
+            ebull_test_conn,
+            source="sec_form4",
+            n=10,
+            base_filed_at=self._NOW - timedelta(days=3),
+            iid=5,
+            cik="0000000005",
+        )
+        ebull_test_conn.commit()
+        run_manifest_worker(ebull_test_conn, source=None, max_rows=4, tick_id=0, now=self._NOW)
+        ebull_test_conn.commit()
+        dispatched = {a for a, _ in captures}
+        assert any(a in dispatched for a in old), "backlog must not be starved to zero at small max_rows"
+
+    def test_iter_pending_recent_desc_floor_and_source_scope(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # Old (outside 90d) excluded; other-source excluded; recent returned DESC.
+        _seed_pending_n(
+            ebull_test_conn,
+            source="sec_13g",
+            n=2,
+            base_filed_at=self._NOW - timedelta(days=120),
+            iid=6,
+            cik="0000000006",
+        )
+        recent = _seed_pending_n(
+            ebull_test_conn,
+            source="sec_13g",
+            n=3,
+            base_filed_at=self._NOW - timedelta(days=10),
+            iid=7,
+            cik="0000000007",
+        )
+        _seed_pending_n(
+            ebull_test_conn,
+            source="sec_13d",
+            n=2,
+            base_filed_at=self._NOW - timedelta(days=5),
+            iid=8,
+            cik="0000000008",
+        )
+        ebull_test_conn.commit()
+        cutoff = self._NOW - timedelta(days=90)
+        rows = list(iter_pending_recent(ebull_test_conn, source="sec_13g", since=cutoff, limit=10))
+        got = [r.accession_number for r in rows]
+        assert set(got) == set(recent), "only this source's pending rows within the window"
+        # Same filed_at across the recent rows → accession DESC tie-break.
+        assert got == sorted(recent, reverse=True), "newest-first (filed_at DESC, accession DESC)"


### PR DESCRIPTION
Closes #1685. Refs #1684 (Form 4 lane it generalizes), #1686 (backlog capacity).

## Problem (full-population verified, dev DB)
`run_manifest_worker` drains `filed_at ASC` (oldest-first) at `max_rows=100`/tick against a **1,460,312-row** pending backlog. Every source has `newest_pending` at 2026-06-18/19 but `oldest_pending` years back, so recents are discovered then never parsed:

| source | pending | oldest | newest |
|---|---|---|---|
| sec_form4 | 1,065,611 | 2018-02-23 | 2026-06-19 |
| sec_13f_hr | 199,650 | 2018-04-16 | 2026-06-18 |
| sec_10q | 61,931 | 2020-08-07 | 2026-06-18 |
| sec_form3 | 52,331 | 2021-03-25 | 2026-06-18 |
| sec_def14a | 33,117 | 2022-04-28 | 2026-06-18 |
| sec_13g | 32,123 | 2025-02-12 | 2026-06-18 |
| sec_13d | 15,549 | 2021-03-08 | 2026-06-19 |

Form 4 (73% of backlog) already has a dedicated newest-first lane (#1684); the other six have none → their recent events stay months stale. Same starvation class as the Form 4 insider bug.

## Change — Phase R (recent-first), then the unchanged backlog drain
- In `run_manifest_worker`'s fairness path, before Phase A: `recent_budget = min(RECENT_SLICE_ROWS=30, max_rows // 2)` rows reserved for the NEWEST pending filings (within `RECENT_WINDOW=90d`) per source, allocated with the **same** `compute_quotas` #1179 rotation. Unused recent budget rolls into the backlog drain; a `seen` set dedups the (tiny) all-recent overlap. Phase B unchanged.
- `iter_pending_recent(source, since, limit)` — `filed_at DESC`, 90d floor.
- `sql/204` — partial index `idx_manifest_recent (source, filed_at DESC, accession_number DESC) WHERE ingest_status='pending'`, built `CONCURRENTLY` (no worker lock; autocommit migration; `DROP INDEX CONCURRENTLY IF EXISTS` first to clear any invalid leftover from an interrupted prior build).
- The `// 2` floor guarantees the backlog drain is never starved to zero (Codex ckpt-1).
- The per-source rebuild path (`source != None`) is **unchanged** — it is a targeted drain, not the steady-state freshness keeper.

## Security model
Ingest-ordering change only — no auth surface, no user input, no parser/data-treatment change (the parsers and what they write are untouched; only WHICH pending rows are dispatched first changes). The migration adds a partial index (no data mutation). Per-source rebuild path unchanged.

## Tradeoff
~30/100 rows/tick now chase recents → the historical backlog drains ~30% slower. Acceptable: backlog throughput is the #1686 capacity concern; recent-freshness is the operator-visible win. Constants (`RECENT_SLICE_ROWS`, `RECENT_WINDOW`) are tunable.

## DoD (ETL clauses)
- **Migration applied (dev):** `idx_manifest_recent` built **valid** (`indisvalid=true`); `run_migrations` clean.
- **Dev-verified on real data (non-mutating selection proof):** per source, oldest-first picks 2020–2025 backlog rows while `iter_pending_recent` surfaces 2026-06-17/18/19 (within 90d, `filed_at DESC`) — exactly the recents the oldest-first drain would never reach. Index serves the query.
- **Clauses 9/10/11 N/A (recorded):** #1685 reorders which rows parse first; it does not change parser output, so there is no instrument-figure cross-source check and no backfill/reprocess (the slice just reorders future ticks). The steady-state parse outcome lands when the jobs daemon next runs this code (not force-restarted — operator anti-churn).
- Gates: ruff/format/pyright0/fast-tier/smoke + new Phase R + existing manifest-worker integration tests pass.

## Tests
`TestRecentFirstSlice`: recent picked despite a 120-row old backlog; no double-dispatch when a source is all-recent (seen-dedup); backlog not starved at `max_rows < RECENT_SLICE_ROWS` (the `// 2` floor); `iter_pending_recent` DESC + 90d floor + source scope. Existing `TestFairness`/parser/retry tests unchanged (default seed date is >90d old → Phase R empty → no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)