### PR TITLE
fix(#1700): dial manifest max_rows 200 → 150 after dev-verify

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4808,19 +4808,24 @@ def jobs_retry_sweeper() -> None:
 def sec_manifest_worker_tick() -> None:
     """#873 — One drain pass over ``sec_filing_manifest``.
 
-    Reads up to 200 pending / retryable rows (across all sources),
+    Reads up to 150 pending / retryable rows (across all sources),
     dispatches the registered parser for each row's source, and lets
     the worker handle the manifest state transitions. Sources with
     no parser are debug-skipped and surface in
     ``GET /coverage/manifest-parsers``.
 
-    Bounded at ``max_rows=200`` per tick (#1700, raised from 100). With
-    the Phase 2 concurrent body prefetch now covering every fetch-bound
-    source (Form 3/4/5 + 13D/G + DEF 14A single-doc, 13F index+primary
-    via the 2-phase expander), the per-tick fetch latency overlaps to the
-    ≤10 req/s ceiling instead of serialising, so doubling the row budget
-    keeps each fire well inside the every-5-min cadence declared in
-    ``SCHEDULED_JOBS`` (dev-verified tick duration < 300s).
+    Bounded at ``max_rows=150`` per tick (#1700, raised from 100). The
+    Phase 2 concurrent body prefetch overlaps the index+primary fetch
+    latency for every fetch-bound source (Form 3/4/5 + 13D/G + DEF 14A
+    single-doc, 13F index+primary via the 2-phase expander) — but 13F's
+    ``infotable.xml`` stays SERIAL (it sits behind a post-primary
+    retention gate), and 13F dominates the global-oldest top-up
+    (~57% of the slice on dev), so the tick wall-clock scales with the
+    13F in-retention infotable fetches. Dev-verified: max_rows=200 ran
+    ~293s (grazing the 300s cadence ceiling under boot contention), so
+    150 is the conservative steady-state value that keeps comfortable
+    margin under the every-5-min cadence declared in ``SCHEDULED_JOBS``.
+    Raising further is gated on making 13F's infotable concurrent too.
     """
     from app.jobs.sec_manifest_worker import run_manifest_worker
 
@@ -4829,7 +4834,7 @@ def sec_manifest_worker_tick() -> None:
             # tick_id=None → run_manifest_worker pulls next value from
             # the module-global _TICK_COUNTER (per-process +1-per-tick
             # rotation). Tests inject explicitly via the helper signature.
-            stats = run_manifest_worker(conn, source=None, max_rows=200, tick_id=None)
+            stats = run_manifest_worker(conn, source=None, max_rows=150, tick_id=None)
             conn.commit()
 
         tracker.row_count = stats.parsed + stats.tombstoned + stats.failed

--- a/docs/specs/ingest/2026-06-21-manifest-phase2-prefetch-extend.md
+++ b/docs/specs/ingest/2026-06-21-manifest-phase2-prefetch-extend.md
@@ -70,8 +70,8 @@ Both passes use `concurrent_fetch.fetch_document_texts` (None dropped). `_prefet
 
 Each hook reuses the SAME predicate functions the parser calls (no duplicated date/rank math). An over-broad `None`/URL is safe (cache miss → serial, never wrong data); over-broad fetch only wastes one request, which the mirrored gates prevent.
 
-### 3. Raise max_rows 100 → 200
-`scheduler.py::sec_manifest_worker_tick` literal `max_rows=100` → `200` + comment. With 13f fully concurrent and the single-doc sources concurrent, the per-tick fetch phase overlaps to the ≤10 req/s ceiling (~30–40s of saturated fetch) and the serial remainder is parse-only. **Verify empirically on dev** (tick duration < ~120s with margin under the 300s cadence; no sustained 429 storm beyond the #1698-tolerated burst) before finalising; dial to 150 if ticks approach 300s.
+### 3. Raise max_rows 100 → 150 (empirically tuned)
+`scheduler.py::sec_manifest_worker_tick` literal `max_rows=100` → **`150`** + comment. Initially set to 200; **dev-verify falsified 200**: the first post-restart tick ran **293s** (13f=114/200, `processed=200 parsed=70 tombstoned=130 failed=0`, no 429s) — grazing the 300s cadence ceiling (worsened by boot-job contention). 13f's `infotable.xml` stays serial behind its post-primary retention gate AND 13f dominates the global-oldest top-up (~57%), so the tick wall-clock scales with 13f in-retention infotable fetches faster than the prefetch saves. **150 is the conservative steady-state value** that keeps margin under the cadence; raising further is gated on making 13f's infotable concurrent too (follow-up).
 
 ## Tests
 - **Pure-logic** (`tests/test_sec_manifest_worker.py` + per-parser): each new hook returns the URL when gates pass and `None` when each gate fails (table-test per gate). 13f `expand_urls` returns `[primary_url]` (primary only) on a valid index.json, `[]` on a missing-`primary_name` index. Pass-2 only runs for rows with a pass-1 cache hit.


### PR DESCRIPTION
Follow-up to #1701 (merged fe703d81). One-line value change driven by the mandated dev-verify.

## Why
#1701 set `sec_manifest_worker` `max_rows=200`. Restarting the daemon on the merge SHA and watching the first tick measured **293s** (`processed=200 parsed=70 tombstoned=130 failed=0`, `13f_hr=114/200`, no 429s) — essentially at the 300s every-5-min cadence ceiling (boot-job contention inflated it). A tick that overruns the cadence makes the singleton lane skip the next fire — a throughput LOSS, the opposite of #1686's goal.

Root cause of the super-linear cost: 13F's `infotable.xml` stays **serial** (it sits behind a post-primary-parse retention gate, so it can't be safely prefetched — see #1701), and 13F dominates the global-oldest top-up (~57% of the slice). So raising the row budget mostly adds 13F in-retention infotable fetches, which the index+primary prefetch doesn't cover.

## Change
`max_rows` 200 → **150** (still +50% over the prior 100), with comfortable margin under the 300s cadence. Spec updated with the empirical falsification of 200. Raising further is gated on a follow-up that makes 13F's infotable concurrent.

## Verification
ruff + pyright clean. Single literal + docstring/spec change; no logic touched. Dev-verify of the 150 tick duration to be recorded on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #1700, #1701.
