### PR TITLE
fix(#1700): revert manifest max_rows 150 → 100 — dev-verify falsified the raise

### DIFF
--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4808,24 +4808,28 @@ def jobs_retry_sweeper() -> None:
 def sec_manifest_worker_tick() -> None:
     """#873 — One drain pass over ``sec_filing_manifest``.
 
-    Reads up to 150 pending / retryable rows (across all sources),
+    Reads up to 100 pending / retryable rows (across all sources),
     dispatches the registered parser for each row's source, and lets
     the worker handle the manifest state transitions. Sources with
     no parser are debug-skipped and surface in
     ``GET /coverage/manifest-parsers``.
 
-    Bounded at ``max_rows=150`` per tick (#1700, raised from 100). The
-    Phase 2 concurrent body prefetch overlaps the index+primary fetch
-    latency for every fetch-bound source (Form 3/4/5 + 13D/G + DEF 14A
-    single-doc, 13F index+primary via the 2-phase expander) — but 13F's
-    ``infotable.xml`` stays SERIAL (it sits behind a post-primary
-    retention gate), and 13F dominates the global-oldest top-up
-    (~57% of the slice on dev), so the tick wall-clock scales with the
-    13F in-retention infotable fetches. Dev-verified: max_rows=200 ran
-    ~293s (grazing the 300s cadence ceiling under boot contention), so
-    150 is the conservative steady-state value that keeps comfortable
-    margin under the every-5-min cadence declared in ``SCHEDULED_JOBS``.
-    Raising further is gated on making 13F's infotable concurrent too.
+    Bounded at ``max_rows=100`` per tick. #1700 added the Phase 2
+    concurrent body prefetch (index+primary for every fetch-bound source;
+    13F index+primary via the 2-phase expander) — a pure latency win that
+    makes light slices fast (dev: ~52s). It ALSO tried raising max_rows,
+    but dev-verify FALSIFIED that: 13F's ``infotable.xml`` stays SERIAL
+    (it sits behind a post-primary retention gate) and 13F dominates the
+    global-oldest top-up (~56% of the slice), and the infotable fetch+
+    parse cost is large + HIGHLY VARIABLE per slice (a 13F filing can hold
+    thousands of holdings). At max_rows=150 heavy slices ran 439s / 461s →
+    OVERRAN the 300s cadence → the next tick was skipped (singleton lane)
+    → LOWER effective throughput than clean 100-row ticks (150/10min <
+    100/5min) plus operator-visible amber. So max_rows stays at 100 until
+    13F's infotable is made concurrent (3-phase prefetch) and/or per-source
+    row budgeting bounds the heavy 13F slice — tracked as the prerequisite
+    for any raise. The prefetch itself is retained (it lowers tick latency
+    and fully overlaps the out-of-retention 13F backlog).
     """
     from app.jobs.sec_manifest_worker import run_manifest_worker
 
@@ -4834,7 +4838,7 @@ def sec_manifest_worker_tick() -> None:
             # tick_id=None → run_manifest_worker pulls next value from
             # the module-global _TICK_COUNTER (per-process +1-per-tick
             # rotation). Tests inject explicitly via the helper signature.
-            stats = run_manifest_worker(conn, source=None, max_rows=150, tick_id=None)
+            stats = run_manifest_worker(conn, source=None, max_rows=100, tick_id=None)
             conn.commit()
 
         tracker.row_count = stats.parsed + stats.tombstoned + stats.failed

--- a/docs/specs/ingest/2026-06-21-manifest-phase2-prefetch-extend.md
+++ b/docs/specs/ingest/2026-06-21-manifest-phase2-prefetch-extend.md
@@ -70,8 +70,16 @@ Both passes use `concurrent_fetch.fetch_document_texts` (None dropped). `_prefet
 
 Each hook reuses the SAME predicate functions the parser calls (no duplicated date/rank math). An over-broad `None`/URL is safe (cache miss → serial, never wrong data); over-broad fetch only wastes one request, which the mirrored gates prevent.
 
-### 3. Raise max_rows 100 → 150 (empirically tuned)
-`scheduler.py::sec_manifest_worker_tick` literal `max_rows=100` → **`150`** + comment. Initially set to 200; **dev-verify falsified 200**: the first post-restart tick ran **293s** (13f=114/200, `processed=200 parsed=70 tombstoned=130 failed=0`, no 429s) — grazing the 300s cadence ceiling (worsened by boot-job contention). 13f's `infotable.xml` stays serial behind its post-primary retention gate AND 13f dominates the global-oldest top-up (~57%), so the tick wall-clock scales with 13f in-retention infotable fetches faster than the prefetch saves. **150 is the conservative steady-state value** that keeps margin under the cadence; raising further is gated on making 13f's infotable concurrent too (follow-up).
+### 3. Raise max_rows — ATTEMPTED, FALSIFIED by dev-verify → stays 100
+Tried `max_rows=100` → 200 → 150. **Dev-verify (mandatory, ETL DoD clause 11) killed the raise.** Measured tick durations:
+
+| max_rows | tick durations (post-boot) | outcome |
+|---|---|---|
+| 200 | 293s | grazes 300s ceiling |
+| 150 | 439s, skip, 461s, skip, 52s | heavy 13f slices OVERRUN → next tick skipped |
+| 100 (revert) | 49–299s historically; prefetch now lowers heavy slices | safe |
+
+Root cause: 13F's `infotable.xml` stays SERIAL (post-primary retention gate, can't prefetch — §source-rule), 13F is ~56% of every slice (global-oldest top-up), and the infotable fetch+parse is large + HIGHLY VARIABLE (a 13F can hold thousands of holdings). So raising max_rows scales the variable heavy-13F cost and the worst slice blows past the 300s cadence → the singleton lane SKIPS the next tick → **lower effective throughput than clean 100-row ticks** (150/10min < 100/5min) + operator-visible amber. `max_rows` stays **100**. The prefetch is retained — it is a pure latency win (light slices ~52s) and fully overlaps the out-of-retention 13F backlog. **Raising max_rows is gated on a prerequisite** (filed follow-up): make 13F infotable concurrent (3-phase prefetch) and/or per-source row budgeting to bound the heavy 13F slice. No 429s at any tested value — the wall is serial infotable work, not the rate budget.
 
 ## Tests
 - **Pure-logic** (`tests/test_sec_manifest_worker.py` + per-parser): each new hook returns the URL when gates pass and `None` when each gate fails (table-test per gate). 13f `expand_urls` returns `[primary_url]` (primary only) on a valid index.json, `[]` on a missing-`primary_name` index. Pass-2 only runs for rows with a pass-1 cache hit.


### PR DESCRIPTION
Follow-up to #1701/#1702. The mandated dev-verify (ETL DoD clause 11) falsified the `max_rows` raise.

## Measured (dev, daemon on the merge SHA, post-boot)
| max_rows | tick durations | outcome |
|---|---|---|
| 200 | 293s | grazes 300s cadence |
| 150 | 439s, skip, 461s, skip, 52s | heavy 13F slices overrun → next tick skipped |
| 100 | 49–299s | safe |

A 150-row heavy slice runs 439–461s, overrunning the 5-min cadence → the singleton lane skips the next tick → **lower effective throughput than clean 100-row ticks** (150/10min < 100/5min) plus operator-visible amber. No 429s at any value.

## Root cause
13F's `infotable.xml` stays SERIAL (post-primary `thirteen_f_within_retention` gate → not prefetchable in the two-pass model), 13F is ~56% of every slice (global-oldest top-up), and its infotable fetch+parse is large + HIGHLY VARIABLE (thousands of holdings per filing). Raising `max_rows` scales that variable heavy cost; the worst slice blows the cadence.

## Change
`max_rows` 150 → **100** (one literal + docstring + spec table). The Phase-2 prefetch from #1701 is **retained** — pure latency win (light slices ~52s), fully overlaps the out-of-retention 13F backlog. Raising `max_rows` is gated on the prerequisite filed as **#1703** (3-phase 13F infotable concurrency and/or per-source row budgeting).

## Verification
ruff + pyright clean; one literal + docs, no logic. Dev-verify of the 100-row tick staying clean to be recorded on merge.

Refs #1700, #1703.