### PR TITLE
perf(#1703): batch the 13F _current refresh across all writers (the real max_rows wall)

### DIFF
--- a/app/services/institutional_holdings.py
+++ b/app/services/institutional_holdings.py
@@ -60,7 +60,7 @@ from app.services.bootstrap_state import (
 from app.services.fundamentals import finish_ingestion_run, start_ingestion_run
 from app.services.ownership_observations import (
     record_institution_observation,
-    refresh_institutions_current,
+    refresh_institutions_current_batch,
     resolve_filer_cik_or_raise,
 )
 from app.services.thirteen_f_normalise import (
@@ -1660,12 +1660,16 @@ def _ingest_single_accession(
             filed_at=filed_at,
             resolved_holdings=resolved_holdings,
         )
-        # Dedupe touched instruments → one refresh per unique
-        # instrument. A single 13F can carry 1000+ holdings; refreshing
-        # per-row would be O(N²). The set collapses to the count of
-        # distinct issuers held.
-        for unique_instrument_id in {iid for iid, _ in resolved_holdings}:
-            refresh_institutions_current(conn, instrument_id=unique_instrument_id)
+        # Dedupe touched instruments → ONE batched refresh for the whole
+        # filing. A single 13F can carry 1000+ holdings; the per-instrument
+        # loop ran one advisory-lock + MERGE PER holding (#1703). The batch
+        # helper takes every held instrument's advisory lock in one
+        # hash-sorted query (the canonical deadlock-safe order shared by
+        # every 13F writer) + a single scoped MERGE.
+        refresh_institutions_current_batch(
+            conn,
+            instrument_ids=sorted({iid for iid, _ in resolved_holdings}),
+        )
 
     # Promote to 'partial' when at least one holding was dropped due
     # to an unresolved CUSIP. The accession itself is recorded so

--- a/app/services/manifest_parsers/sec_13f_hr.py
+++ b/app/services/manifest_parsers/sec_13f_hr.py
@@ -77,7 +77,7 @@ from app.services.manifest_parsers._classify import (
     format_upsert_error,
     is_transient_upsert_error,
 )
-from app.services.ownership_observations import refresh_institutions_current
+from app.services.ownership_observations import refresh_institutions_current_batch
 from app.services.raw_filings import store_raw
 from app.services.thirteen_f_normalise import (
     merge_resolved_by_instrument,
@@ -463,9 +463,10 @@ def _parse_13f_hr(
             # (alongside live ingest and rewash). Acquire the per-accession advisory
             # lock FIRST (inside the transaction, after all SEC fetches) so the
             # DELETE+INSERT rewash cannot race this upsert. Lock order: per-accession
-            # (ingest_13f_accession key space) THEN per-instrument
-            # (refresh_institutions_current, acquired inside refresh_institutions_current
-            # below) — matches the other two paths; no deadlock risk.
+            # (ingest_13f_accession key space) THEN per-instrument (the
+            # refresh_institutions_current_batch call below acquires every held
+            # instrument's advisory lock in one hash-sorted, deadlock-safe query)
+            # — matches the other two paths; no deadlock risk.
             acquire_13f_accession_write_lock(conn, accession)
 
             filer_id = _upsert_filer(conn, info)
@@ -507,8 +508,19 @@ def _parse_13f_hr(
                     filed_at=filed_at,
                     resolved_holdings=resolved_holdings,
                 )
-                for unique_instrument_id in {iid for iid, _ in resolved_holdings}:
-                    refresh_institutions_current(conn, instrument_id=unique_instrument_id)
+                # #1703 — ONE batched MERGE for every held instrument, not a
+                # per-holding loop. A 13F carries hundreds–thousands of holdings;
+                # the old per-instrument `refresh_institutions_current` loop ran
+                # one advisory-lock + MERGE PER holding, which dev-verify showed
+                # is the dominant per-tick cost (the serial wall that blocked
+                # raising the manifest worker's max_rows — NOT the infotable
+                # fetch). The batch helper acquires all per-instrument advisory
+                # locks in one hash-sorted query (deadlock-safe) + a single
+                # scoped MERGE — identical semantics, O(1) statements per filing.
+                refresh_institutions_current_batch(
+                    conn,
+                    instrument_ids=sorted({iid for iid, _ in resolved_holdings}),
+                )
 
             total_skipped = skipped_no_cusip + skipped_non_sh
             status = "partial" if total_skipped > 0 else "success"

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -1109,7 +1109,7 @@ def _apply_13f_infotable(
     # log "rewashed accession=..." while leaving every ownership rollup
     # query showing zero institutional shares (#945).
     from app.services.institutional_holdings import _record_13f_observations_for_filing
-    from app.services.ownership_observations import refresh_institutions_current
+    from app.services.ownership_observations import refresh_institutions_current_batch
 
     if resolved:
         # ``filed_at`` from the SELECT above is a tuple-row Decimal/None
@@ -1132,8 +1132,13 @@ def _apply_13f_infotable(
     # provably non-empty here today (empty parse and unresolved-CUSIP
     # paths return earlier), but if a refactor ever changes that, the
     # deleted prior observations must still propagate to _current.
-    for unique_instrument_id in prior_instrument_ids | {iid for iid, _ in resolved}:
-        refresh_institutions_current(conn, instrument_id=unique_instrument_id)
+    # ONE batched refresh over the UNION of prior + new instruments (#1703;
+    # batch helper = the canonical hash-sorted, deadlock-safe lock order shared
+    # by every 13F writer). Empty union → no-op (preserves the #953 semantic).
+    refresh_institutions_current_batch(
+        conn,
+        instrument_ids=sorted(prior_instrument_ids | {iid for iid, _ in resolved}),
+    )
 
     # Log full success.
     with conn.cursor() as cur:

--- a/tests/test_manifest_parser_sec_13f_hr.py
+++ b/tests/test_manifest_parser_sec_13f_hr.py
@@ -1047,8 +1047,8 @@ def test_two_phase_prefetch_out_of_retention_never_fetches_infotable(
     assert row is not None and row.ingest_status == "tombstoned"
 
 
-def test_parser_uses_batched_current_refresh_not_per_holding_loop() -> None:
-    """#1703 regression pin (perf — invisible to the correctness tests above).
+def test_all_13f_current_writers_use_batched_refresh_not_per_holding_loop() -> None:
+    """#1703 regression pin (perf + deadlock — invisible to the correctness tests).
 
     A 13F carries hundreds–thousands of holdings; the ``ownership_institutions_
     current`` refresh MUST be ONE batched MERGE
@@ -1056,15 +1056,29 @@ def test_parser_uses_batched_current_refresh_not_per_holding_loop() -> None:
     ``refresh_institutions_current`` loop. The loop ran one advisory-lock +
     MERGE PER holding and was the dominant per-tick cost (dev-verify: the serial
     wall that blocked raising the manifest worker's max_rows — NOT the infotable
-    fetch the issue assumed). Both forms are functionally identical, so only a
-    source-level assertion catches a revert. Comment mentions of the old name
-    are allowed (a comment documents why the loop was removed)."""
+    fetch the issue assumed).
+
+    Pin EVERY 13F ``_current`` writer (Codex/bot review #1706): once one path
+    batches (hash-sorted lock order) and another loops (set-iteration order),
+    two filings with overlapping instruments can take the same advisory locks in
+    opposite orders and DEADLOCK. Safety now requires ALL writers to share the
+    one canonical batch order — a revert of ANY re-introduces both the wall and
+    the deadlock. Both forms are functionally identical, so only a source-level
+    assertion catches a revert. Comment mentions of the old name are allowed.
+
+    The bulk orchestrator (``sec_bulk_orchestrator_jobs``) already batched
+    pre-#1703 and is covered by its own writer-pattern guards."""
     import inspect
 
+    from app.services import institutional_holdings, rewash_filings
     from app.services.manifest_parsers import sec_13f_hr
 
-    code = "\n".join(ln for ln in inspect.getsource(sec_13f_hr).splitlines() if not ln.lstrip().startswith("#"))
-    assert "refresh_institutions_current_batch(" in code, "13F refresh must use the batch helper"
-    assert "refresh_institutions_current(" not in code, (
-        "per-holding refresh_institutions_current(...) loop reintroduced — use the batch helper (#1703)"
-    )
+    for module in (sec_13f_hr, institutional_holdings, rewash_filings):
+        code = "\n".join(ln for ln in inspect.getsource(module).splitlines() if not ln.lstrip().startswith("#"))
+        assert "refresh_institutions_current_batch(" in code, (
+            f"{module.__name__} must batch the institutions _current refresh (#1703)"
+        )
+        assert "refresh_institutions_current(" not in code, (
+            f"{module.__name__} reintroduced the per-instrument refresh loop — "
+            "use refresh_institutions_current_batch (one global lock order = deadlock-safe, #1703)"
+        )

--- a/tests/test_manifest_parser_sec_13f_hr.py
+++ b/tests/test_manifest_parser_sec_13f_hr.py
@@ -1045,3 +1045,26 @@ def test_two_phase_prefetch_out_of_retention_never_fetches_infotable(
     assert misses == []
     row = get_manifest_row(ebull_test_conn, accession)
     assert row is not None and row.ingest_status == "tombstoned"
+
+
+def test_parser_uses_batched_current_refresh_not_per_holding_loop() -> None:
+    """#1703 regression pin (perf — invisible to the correctness tests above).
+
+    A 13F carries hundreds–thousands of holdings; the ``ownership_institutions_
+    current`` refresh MUST be ONE batched MERGE
+    (``refresh_institutions_current_batch``), never a per-instrument
+    ``refresh_institutions_current`` loop. The loop ran one advisory-lock +
+    MERGE PER holding and was the dominant per-tick cost (dev-verify: the serial
+    wall that blocked raising the manifest worker's max_rows — NOT the infotable
+    fetch the issue assumed). Both forms are functionally identical, so only a
+    source-level assertion catches a revert. Comment mentions of the old name
+    are allowed (a comment documents why the loop was removed)."""
+    import inspect
+
+    from app.services.manifest_parsers import sec_13f_hr
+
+    code = "\n".join(ln for ln in inspect.getsource(sec_13f_hr).splitlines() if not ln.lstrip().startswith("#"))
+    assert "refresh_institutions_current_batch(" in code, "13F refresh must use the batch helper"
+    assert "refresh_institutions_current(" not in code, (
+        "per-holding refresh_institutions_current(...) loop reintroduced — use the batch helper (#1703)"
+    )


### PR DESCRIPTION
## Summary

**#1703 PR2.** This session's dev-verify falsified the issue's premise (and #1700's). The manifest worker's per-tick wall — the thing that blocked raising `max_rows` above 100 — is **not** the 13F `infotable.xml` fetch (3-phase concurrent prefetch, the issue's plan). It is the parser's **per-holding `ownership_institutions_current` refresh**.

`_parse_13f_hr` (and the live-ingest + rewash paths) called `refresh_institutions_current` **once per held instrument** in a loop — a 13F with N holdings = **N advisory-lock + MERGE statements**. The oldest in-retention 13Fs (big managers, thousands of holdings each) → thousands of MERGEs per filing → minutes per filing. A forced `max_rows=150` tick ran **>20 min**, with the per-instrument MERGE the lone active query in `pg_stat_activity`. Raising `max_rows` pulls more (and bigger) such filings into the per-source slice → the tick blows past the 300s cadence. That is the wall.

**Fix:** one batched `refresh_institutions_current_batch(instrument_ids=…)` per filing (N MERGEs → 1). The batch helper already exists, is production-proven (the bulk orchestrator uses it), and is documented in the data-engineer skill (§2.10) as the canonical post-ingest hot-path refresh: it takes every held instrument's advisory lock in one **hash-sorted, deadlock-safe** query + a single scoped MERGE. Identical per-instrument semantics.

`max_rows` **stays 100** in this PR — the raise itself is a separate follow-up needing multi-day worst-slice dev-verify (the #1700 process lesson: don't merge a throughput value before verifying it over time). 3-phase prefetch is **dropped** (the wall is not fetch). Per-source budgeting is held in reserve (decide after the batched daemon bakes).

## Premise falsification chain
1. #1703 issue: "infotable fetch is the wall" → 3-phase prefetch.
2. #1703 PR1 (the sweep, merged `de443459`): out-of-retention 13F were ~96% of dispatched 13F (fetch-to-tombstone storm). After the sweep, dispatch is all in-retention.
3. **This PR:** with the sweep done, the all-in-retention regime exposed the *true* wall — the per-holding refresh MERGE loop (DB write-amplification), not fetch.

## Change
- `app/services/manifest_parsers/sec_13f_hr.py` — manifest parser: loop → batch.
- `app/services/institutional_holdings.py` — live-ingest path: loop → batch.
- `app/services/rewash_filings.py` — rewash path: loop → batch (union of prior + new instruments preserved).
- Regression pin test (the perf choice is invisible to correctness tests — both forms are functionally identical).

After this, **every** 13F `_current` writer (manifest, bulk orchestrator, live-ingest, rewash) uses the one canonical batch helper.

## Security / correctness model
- **Codex ckpt-2 caught a real deadlock (P2), fixed in `99dd1e78`:** batching *only* the manifest path would have left live-ingest + rewash on the set-iteration loop order. The batch helper sorts locks by hash; a Python-set loop does not. Two filings with overlapping instruments running concurrently could acquire the same advisory locks in opposite orders → deadlock. Converting **all** writers to the batch helper gives one global lock order → deadlock-safe (the loops also carried this latent risk among themselves — the reason the batch helper sorts by hash). Re-ran ckpt-2 on the full diff: **clean, no correctness regressions.**
- `#1542` per-accession write-lock order preserved (accession lock FIRST, then the batch's per-instrument locks).
- No schema change, no parser-retention change (`scripts/check_13f_hr_retention.sh` green — the post-parse period gate is untouched). No `parser_version` bump → no re-ingest needed.
- Pure refresh-mechanics change: the `_current` content produced is identical; only the statement count + lock ordering change.

## Verification
- `pytest`: **86 passed** across `test_manifest_parser_sec_13f_hr.py` (incl. the new pin) + `test_rewash_filings.py` + `test_institutional_holdings_ingester.py`.
- Gates: ruff + format + pyright (0 errors) + fast tier `-m "not db"` + smoke + `check_13f_hr_retention.sh` all green.
- Diagnosis evidence: the forced `max_rows=150` tick ran >20 min with the per-instrument MERGE the sole active query; a loop-vs-batch micro-probe measured the batch **3–162× faster** (absolute numbers contention-noisy, direction unambiguous).
- **Deferred to post-merge daemon observation:** the clean end-to-end tick-speedup number + the `max_rows` raise. The in-session live tick measurement over-drove SEC (429s — my error, repeated heavy ad-hoc ticks on top of the daemon), so the authoritative timing moves to the restarted daemon at normal cadence once SEC's rate-limit window clears. The raise is its own PR with the multi-day `<250s` worst-slice bar.

## Follow-up (separate PR, #1703 core remainder)
`max_rows` raise (100 → N), calibrated + dev-verified over a full day on the batched daemon; add per-source 13F budgeting if giant-filing ticks still approach the cadence.

Refs #1703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)