### PR TITLE
fix(#1707): patient lane backoff for daily syncs — orchestrator_full_sync starved 7/7 days

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -495,6 +495,23 @@ _LANE_BUSY_RETRY_BACKOFF: Final[tuple[float, ...]] = (0.25, 0.5, 1.0)  # 3 retri
 _MAX_CONCURRENT_LANE_WAITERS: Final[int] = 3
 _LANE_WAIT_SLOTS: Final[threading.BoundedSemaphore] = threading.BoundedSemaphore(_MAX_CONCURRENT_LANE_WAITERS)
 
+# Per-job acquire-backoff overrides. The default ~1.75s window suits FREQUENT
+# jobs: a 5-min job that loses the lane race just runs next cadence (5 min
+# later), no harm. It is WRONG for a DAILY job — skipping "next cadence" means
+# skipping a whole DAY. ``orchestrator_full_sync`` (daily 03:00) co-fires with
+# ``orchestrator_high_frequency_sync`` (every 5 min, same 03:00 slot, same sync
+# gate); high-freq holds the gate ~2-5s, so the ~1.75s window always expires
+# first and full-sync was starved 7/7 days (last real run 15 Jun). A daily sync
+# can afford to WAIT out the brief high-freq run (running ~10s late once a day is
+# irrelevant), so give it a longer, "patient" window that outlasts high-freq's
+# hold. Bounded by ``_MAX_CONCURRENT_LANE_WAITERS`` exactly like the default, so
+# it can never drain the scheduler pool. General rule: a job's acquire patience
+# should scale with its cadence — frequent jobs skip cheaply, daily jobs wait.
+_LANE_BACKOFF_DAILY_PATIENT: Final[tuple[float, ...]] = (0.5, 1.0, 2.0, 4.0, 4.0)  # ~11.5s
+_LANE_BACKOFF_OVERRIDES: Final[dict[str, tuple[float, ...]]] = {
+    JOB_ORCHESTRATOR_FULL_SYNC: _LANE_BACKOFF_DAILY_PATIENT,
+}
+
 
 def _fire_scheduled_with_lane_retry(
     database_url: str,
@@ -1917,7 +1934,14 @@ class JobRuntime:
                 # #1538 — retry the source-level lane acquire on transient
                 # cross-job contention so a fire that loses the shared-lane race
                 # runs the SAME period instead of skipping the whole cadence.
-                _fire_scheduled_with_lane_retry(database_url, job_name, _run_scheduled_body)
+                # Daily syncs use a longer "patient" window (_LANE_BACKOFF_OVERRIDES)
+                # so a 5-min peer holding the gate can't starve them for a day.
+                _fire_scheduled_with_lane_retry(
+                    database_url,
+                    job_name,
+                    _run_scheduled_body,
+                    backoff=_LANE_BACKOFF_OVERRIDES.get(job_name, _LANE_BUSY_RETRY_BACKOFF),
+                )
             except JobAlreadyRunning:
                 # The helper retries the ACQUIRE, so this is reached ONLY when
                 # the body raised it — the same job is already running in this

--- a/tests/test_lane_busy_retry.py
+++ b/tests/test_lane_busy_retry.py
@@ -170,3 +170,53 @@ def test_body_job_already_running_after_retry_not_replayed(
     assert state["enter"] == 2  # failed acquire + the acquire whose body raised
     assert sleeps == [0.25]  # only the pre-retry sleep
     assert _slots_available(fresh_slots) == runtime._MAX_CONCURRENT_LANE_WAITERS  # slot released in finally
+
+
+def test_full_sync_gets_a_longer_patient_backoff_than_the_default() -> None:
+    """A DAILY sync (orchestrator_full_sync) must wait out a multi-second
+    high-freq gate hold, not the ~1.75s default (which made it skip a whole DAY,
+    7/7 — last real run 15 Jun). A FREQUENT peer keeps the cheap default."""
+    from app.workers.scheduler import (
+        JOB_ORCHESTRATOR_FULL_SYNC,
+        JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
+    )
+
+    patient = runtime._LANE_BACKOFF_OVERRIDES[JOB_ORCHESTRATOR_FULL_SYNC]
+    assert sum(patient) > sum(runtime._LANE_BUSY_RETRY_BACKOFF)
+    assert len(patient) > len(runtime._LANE_BUSY_RETRY_BACKOFF)
+    # the every-5-min peer that holds the gate keeps the cheap default — skipping
+    # one of its cadences is harmless, and it must never wait long enough to
+    # starve the pool.
+    assert JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC not in runtime._LANE_BACKOFF_OVERRIDES
+
+
+def test_patient_backoff_rides_out_a_hold_the_default_would_skip(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    """The fix, proven on the exact starvation shape: high-freq holds the sync
+    gate for ~5s ≈ 4 failed acquires before releasing. The DEFAULT window (3
+    retries → 4 acquires) exhausts and SKIPS (the day-long starvation). The
+    PATIENT window (5 retries → 6 acquires) rides it out and RUNS."""
+    from app.workers.scheduler import JOB_ORCHESTRATOR_FULL_SYNC
+
+    patient = runtime._LANE_BACKOFF_OVERRIDES[JOB_ORCHESTRATOR_FULL_SYNC]
+
+    # DEFAULT: busy through all 4 acquires → never runs (the bug).
+    default_state = {"enter": 0, "fail_n": 4}
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(default_state))
+    default_ran: list[int] = []
+    runtime._fire_scheduled_with_lane_retry(
+        "db://x", "orchestrator_full_sync", lambda: default_ran.append(1), backoff=_BACKOFF, sleep=lambda _s: None
+    )
+    assert default_ran == []  # default window starves
+
+    # PATIENT: same 4-acquire hold, then the 5th acquire (gate released) succeeds → runs.
+    patient_state = {"enter": 0, "fail_n": 4}
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(patient_state))
+    patient_ran: list[int] = []
+    runtime._fire_scheduled_with_lane_retry(
+        "db://x", "orchestrator_full_sync", lambda: patient_ran.append(1), backoff=patient, sleep=lambda _s: None
+    )
+    assert patient_ran == [1]  # patient window rides out the hold and runs
+    assert patient_state["enter"] == 5  # 4 failed acquires + 1 success
+    assert _slots_available(fresh_slots) == runtime._MAX_CONCURRENT_LANE_WAITERS  # slot released


### PR DESCRIPTION
## Summary
Operator-reported: admin shows "Orchestrator full sync — schedule missed" and `orchestrator_full_sync` last ran 15 Jun (7 days) despite a daily 03:00 UTC cadence + healthy daemon. **Root-caused to a scheduling-starvation bug**, not a display artifact (the display was already made honest in #1689).

## Root cause
`orchestrator_full_sync` (daily 03:00) and `orchestrator_high_frequency_sync` (every 5 min) share the sync orchestrator's single-running gate. 03:00 is on the 5-min grid → they **co-fire**. High-freq grabs the gate and holds it ~2-5s (measured); the daily fire's lane-acquire retry window is only **~1.75s** (`_LANE_BUSY_RETRY_BACKOFF`, #1538), so it expires before high-freq releases and "skips to next cadence" — which for a daily job means **skips a whole day**. Every day → 7/7 starvation.

```
04:00:00 Running job "orchestrator_full_sync" (scheduled at 03:00:00 UTC)
04:00:01 scheduled fire of 'orchestrator_full_sync' skipped: its lane stayed busy through the ~1.75s retry window; will fire next cadence
```

## Fix
The ~1.75s window is right for FREQUENT jobs (a 5-min job skipping one cadence is harmless); it is wrong for a DAILY job. Add a per-job `_LANE_BACKOFF_OVERRIDES` map giving daily syncs a longer "patient" acquire window (~11.5s) that outlasts the brief high-freq hold — running ~10s late once a day is irrelevant. Bounded by `_MAX_CONCURRENT_LANE_WAITERS` exactly like the default, so it can never drain the APScheduler pool. Code comment states the general rule: acquire patience should scale with cadence.

- `app/jobs/runtime.py`: `_LANE_BACKOFF_DAILY_PATIENT` + `_LANE_BACKOFF_OVERRIDES` (keyed on `JOB_ORCHESTRATOR_FULL_SYNC`); the `_fire_scheduled_with_lane_retry` call passes the per-job backoff.

## Verification
- `tests/test_lane_busy_retry.py` (+2): pin the override (daily window > default; the 5-min peer keeps the cheap default) + **prove the patient window RUNS on the exact 4-acquire hold the default SKIPS** (the starvation shape). 8 passed.
- ruff + pyright + fast tier `-m "not db"` + smoke all green.
- Codex ckpt-2: clean — "cleanly applies a longer retry backoff only to the daily full sync path and preserves the existing bounded-wait behavior."
- **Relief already applied (out-of-band):** manual `POST /jobs/orchestrator_full_sync/run` (request 95) → `orchestrator_full_sync: starting` at 10:46 UTC, running now → clears the 7-day staleness + the schedule-missed verdict. The manual-queue path is not subject to the 1.75s scheduled-fire skip; only the scheduled daily fire was starved (what this fixes).

## Not in scope (separate, transient)
The `sec_13f_sweep` / `sec_form4_sweep` "429" attention items: an overnight SEC rate-limit burst (01:00–02:54 UTC) that self-cleared (0 since); the 258/16 failed rows auto-retry (#1698). Monitoring for recurrence.

Closes #1707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)