### PR TITLE
fix(#1573,#1571): finalise orphaned bulk-job_runs rows + wire 3 untriggerable ops jobs

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -229,6 +229,54 @@ def _adapt_zero_arg(fn: Callable[[], None]) -> JobInvoker:
     return _adapted
 
 
+def _tracked_zero_arg(job_name: str, fn: Callable[[], object]) -> JobInvoker:
+    """Adapt a bare zero-arg invoker like :func:`_adapt_zero_arg` BUT run the
+    body inside ``_tracked_job`` so the manual-dispatch prelude's ``running``
+    ``job_runs`` row is finalised (#1573).
+
+    Without this, a bare bulk-dataset invoker returns without adopting the
+    prelude's pre-allocated ``run_id`` (it never calls
+    ``consume_prelude_run_id``), so ``run_with_prelude`` leaves the row
+    ``running`` forever — admin Processes shows it wedged; only the #1510
+    aged-running boot reaper later marks it ``failure`` ("orphaned: reaped
+    at boot"). Reproduced on dev: a no-op manual ``sec_submissions_ingest``
+    left ``job_runs`` stuck ``running`` while the queue row showed
+    ``completed``.
+
+    This mirrors the ``populate_canonical_redirects`` fix (a scheduler-side
+    ``_tracked_job`` wrapper), collapsed into one registration-boundary
+    helper because the 9 bulk wrappers would otherwise be byte-identical.
+
+    ``row_count`` is intentionally NOT stamped (the bodies return ``None`` —
+    there is no count to report; the operator-facing per-archive figures
+    live in the job logs + ``bootstrap_archive_results``). This is also the
+    bootstrap-safe choice: these jobs are ALSO bootstrap stages, and
+    ``bootstrap_orchestrator._resolve_stage_rows`` resolves ``rows_processed``
+    from ``bootstrap_archive_results`` (Sources 1/2) BEFORE the ``job_runs``
+    window (Source 3), where a NULL-``row_count`` row is skipped — so the new
+    row keeps bootstrap ``rows_processed`` byte-identical. ``_tracked_job``'s
+    spike check is gated on ``row_count is not None`` so it stays inert too.
+    """
+
+    def _adapted(params: Mapping[str, Any]) -> None:
+        del params  # bulk bodies are zero-arg; params are not consumed.
+        # Lazy import: app.workers.scheduler imports this module's contextvars
+        # at module load, so the reverse import has to be at call time.
+        from app.workers.scheduler import _tracked_job
+
+        with _tracked_job(job_name):
+            fn()
+
+    _adapted.__wrapped__ = fn  # type: ignore[attr-defined]
+    # Explicit finalisation marker. ``inspect.getsource`` follows
+    # ``__wrapped__`` (→ the bare body, which has no ``_tracked_job``), so a
+    # source-grep cannot see the wrapper here. The #1573 regression-guard
+    # invariant (``tests/test_layer_123_wiring.py``) reads this marker to
+    # confirm a reach-prelude invoker finalises its prelude ``job_runs`` row.
+    _adapted.__finalises_prelude_row__ = True  # type: ignore[attr-defined]
+    return _adapted
+
+
 _INVOKERS: Final[dict[str, JobInvoker]] = {
     JOB_NIGHTLY_UNIVERSE_SYNC: _adapt_zero_arg(nightly_universe_sync),
     JOB_DAILY_CANDLE_REFRESH: _adapt_zero_arg(daily_candle_refresh),
@@ -309,11 +357,12 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
 # transitively (the orchestrator imports from this module via
 # ``from app.jobs.runtime import _INVOKERS`` at call time).
 from app.services import bootstrap_orchestrator as _bootstrap_orchestrator  # noqa: E402
-from app.services import sec_bulk_download as _sec_bulk_download  # noqa: E402
 
 # #1021 — bulk-archive download stage A3 of the bulk-datasets-first
-# bootstrap (#1020). Registered so the orchestrator can dispatch it.
-_INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _adapt_zero_arg(_sec_bulk_download.sec_bulk_download_job)
+# bootstrap (#1020). ``sec_bulk_download`` is now registered (tracked) in the
+# consolidated Phase A3/C bulk block below; the duplicate bare registration
+# that used to sit here was removed (#1573 — it would have shadowed the
+# tracked one with a row-orphaning bare invoker depending on import order).
 _INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_ORCHESTRATOR] = _adapt_zero_arg(
     _bootstrap_orchestrator.run_bootstrap_orchestrator
 )
@@ -429,20 +478,43 @@ from app.services import sec_bulk_download as _sec_bulk_download  # noqa: E402
 from app.services import sec_bulk_orchestrator_jobs as _bulk_jobs  # noqa: E402
 from app.services import sec_submissions_files_walk as _files_walk  # noqa: E402
 
-# Phase A3 — bulk archive download (#1021 / #1020). Registered here
-# so PR7 is self-consistent if PR #1029 has not yet landed; the
-# duplicate dict-key assignment when both PRs are merged is a no-op.
-_INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _adapt_zero_arg(_sec_bulk_download.sec_bulk_download_job)
-_INVOKERS[_bulk_jobs.JOB_SEC_SUBMISSIONS_INGEST] = _adapt_zero_arg(_bulk_jobs.sec_submissions_ingest_job)
-_INVOKERS[_bulk_jobs.JOB_SEC_COMPANYFACTS_INGEST] = _adapt_zero_arg(_bulk_jobs.sec_companyfacts_ingest_job)
-_INVOKERS[_bulk_jobs.JOB_SEC_13F_INGEST_FROM_DATASET] = _adapt_zero_arg(_bulk_jobs.sec_13f_ingest_from_dataset_job)
-_INVOKERS[_bulk_jobs.JOB_SEC_INSIDER_INGEST_FROM_DATASET] = _adapt_zero_arg(
-    _bulk_jobs.sec_insider_ingest_from_dataset_job
+# Phase A3 bulk download + Phase C bulk-dataset ingesters. All registered
+# via ``_tracked_zero_arg`` (NOT ``_adapt_zero_arg``): each is a bare
+# zero-arg body that, on manual dispatch ("Run now" / POST /jobs/{name}/run),
+# would otherwise orphan the prelude's ``running`` job_runs row forever
+# (#1573 — the populate_canonical_redirects defect class). The ``_tracked_job``
+# wrapper finalises the row. This is the SOLE registration of
+# ``sec_bulk_download`` (a prior duplicate near the bootstrap-orchestrator
+# block was removed — #1573). row_count is left unstamped (bodies return
+# ``None``); bootstrap ``rows_processed`` is unaffected — see
+# ``_tracked_zero_arg``.
+_INVOKERS[_sec_bulk_download.JOB_SEC_BULK_DOWNLOAD] = _tracked_zero_arg(
+    _sec_bulk_download.JOB_SEC_BULK_DOWNLOAD, _sec_bulk_download.sec_bulk_download_job
 )
-_INVOKERS[_bulk_jobs.JOB_SEC_NPORT_INGEST_FROM_DATASET] = _adapt_zero_arg(_bulk_jobs.sec_nport_ingest_from_dataset_job)
-_INVOKERS[_bulk_jobs.JOB_SEC_FSDS_CLASS_SHARES_INGEST] = _adapt_zero_arg(_bulk_jobs.sec_fsds_class_shares_ingest_job)
-_INVOKERS[_bulk_jobs.JOB_SEC_FSDS_DIMENSIONAL_INGEST] = _adapt_zero_arg(_bulk_jobs.sec_fsds_dimensional_ingest_job)
-_INVOKERS[_files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK] = _adapt_zero_arg(_files_walk.sec_submissions_files_walk_job)
+_INVOKERS[_bulk_jobs.JOB_SEC_SUBMISSIONS_INGEST] = _tracked_zero_arg(
+    _bulk_jobs.JOB_SEC_SUBMISSIONS_INGEST, _bulk_jobs.sec_submissions_ingest_job
+)
+_INVOKERS[_bulk_jobs.JOB_SEC_COMPANYFACTS_INGEST] = _tracked_zero_arg(
+    _bulk_jobs.JOB_SEC_COMPANYFACTS_INGEST, _bulk_jobs.sec_companyfacts_ingest_job
+)
+_INVOKERS[_bulk_jobs.JOB_SEC_13F_INGEST_FROM_DATASET] = _tracked_zero_arg(
+    _bulk_jobs.JOB_SEC_13F_INGEST_FROM_DATASET, _bulk_jobs.sec_13f_ingest_from_dataset_job
+)
+_INVOKERS[_bulk_jobs.JOB_SEC_INSIDER_INGEST_FROM_DATASET] = _tracked_zero_arg(
+    _bulk_jobs.JOB_SEC_INSIDER_INGEST_FROM_DATASET, _bulk_jobs.sec_insider_ingest_from_dataset_job
+)
+_INVOKERS[_bulk_jobs.JOB_SEC_NPORT_INGEST_FROM_DATASET] = _tracked_zero_arg(
+    _bulk_jobs.JOB_SEC_NPORT_INGEST_FROM_DATASET, _bulk_jobs.sec_nport_ingest_from_dataset_job
+)
+_INVOKERS[_bulk_jobs.JOB_SEC_FSDS_CLASS_SHARES_INGEST] = _tracked_zero_arg(
+    _bulk_jobs.JOB_SEC_FSDS_CLASS_SHARES_INGEST, _bulk_jobs.sec_fsds_class_shares_ingest_job
+)
+_INVOKERS[_bulk_jobs.JOB_SEC_FSDS_DIMENSIONAL_INGEST] = _tracked_zero_arg(
+    _bulk_jobs.JOB_SEC_FSDS_DIMENSIONAL_INGEST, _bulk_jobs.sec_fsds_dimensional_ingest_job
+)
+_INVOKERS[_files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK] = _tracked_zero_arg(
+    _files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK, _files_walk.sec_submissions_files_walk_job
+)
 
 # #819 — canonical-instrument redirect populate. Idempotent one-shot
 # the operator triggers after a universe sync introduces new

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -483,6 +483,38 @@ MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
     # Lane — module-global throttle clock shared with bimonthly so the
     # in-process FINRA budget never exceeds 1 req/s combined.
     "finra_regsho_daily_refresh": "finra",
+    # --- #1571 outside-DAG ops jobs wired for manual trigger. Each is in
+    # ``_INVOKERS`` (VALID_JOB_NAMES) but was retired from SCHEDULED_JOBS and
+    # is only a DASHBOARD member of the orchestrator (``JOB_TO_LAYERS`` empty
+    # tuple = "Background tasks" panel — display, not dispatch). Without a
+    # source entry ``source_for`` KeyErrored and every manual trigger landed
+    # ``rejected`` (the populate_canonical_redirects / #1413 trap). All three
+    # already finalise via ``_tracked_job`` + ``connect_job``; zero-param
+    # (empty MANUAL_TRIGGER_JOB_METADATA). Triage #1571 = wire as
+    # manual-trigger-only (the steady-state freshness path moved to the
+    # manifest worker / fundamentals derivation).
+    #
+    # attribution_summary — pure-DB; sole writer of the attribution-summary
+    # store (``app/services/return_attribution.py``). Catch-all ``db`` lane.
+    "attribution_summary": "db",
+    # daily_financial_facts — incremental SEC XBRL facts refresh (SEC HTTP via
+    # SecFilings/SecFundamentals providers). Lane ``sec_rate`` — a SEC
+    # producer that shares the per-IP rate budget, the same lane as its
+    # sibling ``daily_research_refresh``; ``db`` would be wrong (it would hold
+    # a DB lane across slow SEC HTTP and block db-lane jobs, the #1478 class).
+    # NOT a sole writer of ``financial_facts_raw`` — ``fundamentals_sync`` (db)
+    # calls it internally (``scheduler.py`` phase 1) and Stage 9
+    # ``sec_companyfacts_ingest`` also writes it — but the cross-lane overlap
+    # is benign for correctness: the writer ``upsert_facts_for_instrument`` is
+    # keyed last-write-wins/idempotent ("data-layer writes are last-write-wins
+    # UPSERTs so the race is benign for correctness, only telemetry-confusing"
+    # — ``docs/etl/sources/sec_xbrl_facts.md``). So the lane need not serialise
+    # the write.
+    "daily_financial_facts": "sec_rate",
+    # daily_tax_reconciliation — pure-DB tax-lot ingest + disposal matching;
+    # sole writer of ``tax_lots`` / ``disposal_matches``
+    # (``app/services/tax_ledger.py``). Catch-all ``db`` lane.
+    "daily_tax_reconciliation": "db",
     # --- #1413 bulk-only bootstrap — per-CIK SEC jobs dropped from
     # ``_BOOTSTRAP_STAGE_SPECS`` but KEPT in ``_INVOKERS`` as on-demand
     # (steady-state safety-net + sec_rebuild + Admin "Run now"). Their

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -257,6 +257,14 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
     # invoker) — the missing sources.py half made the job
     # untriggerable from #819's merge until 2026-06-11.
     "populate_canonical_redirects": (),
+    # --- #1571 outside-DAG ops jobs wired for manual trigger. All three are
+    # zero-arg bodies (no operator-tunable params); the explicit empty tuples
+    # complete the manual-only triangle (source in MANUAL_TRIGGER_JOB_SOURCES +
+    # metadata here + invoker in _INVOKERS) so the manual API validator accepts
+    # a zero-param trigger instead of rejecting it.
+    "attribution_summary": (),
+    "daily_financial_facts": (),
+    "daily_tax_reconciliation": (),
     # sec_manifest_tombstone_stale — #1614. The drained #1131
     # stale-failed-upsert backfill, retired from SCHEDULED_JOBS to
     # manual-only. No operator-tunable params (it scans + promotes

--- a/tests/test_bulk_invoker_tracked_job_wiring.py
+++ b/tests/test_bulk_invoker_tracked_job_wiring.py
@@ -1,0 +1,135 @@
+"""#1573 — bulk-dataset invoker job-runs telemetry wiring.
+
+Manual dispatch ("Run now" / POST /jobs/{name}/run) of a bare bulk-dataset
+invoker reaches ``run_with_prelude``, which writes a ``running`` ``job_runs``
+row and stashes its ``run_id`` in a ContextVar. A bare body never adopts it
+(it never calls ``consume_prelude_run_id``), so the row orphans ``running``
+forever — only the #1510 boot reaper later marks it ``failure``. Reproduced
+on dev (2026-06-23): a no-op manual ``sec_submissions_ingest`` left
+``job_runs`` stuck ``running`` while the queue row showed ``completed``.
+
+These tests pin the ``_tracked_zero_arg`` fix: the 9 affected invokers run
+their body inside ``_tracked_job`` so the prelude row finalises.
+
+Pure-logic tier — ``_tracked_job`` and the bodies are stubbed; no DB.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+from app.jobs.runtime import _INVOKERS, _tracked_zero_arg
+from app.workers import scheduler as scheduler_module
+
+# The 9 bulk-dataset invokers wrapped by #1573 (issue's 7 + 2 FSDS siblings).
+BULK_JOBS = (
+    "sec_submissions_ingest",
+    "sec_companyfacts_ingest",
+    "sec_13f_ingest_from_dataset",
+    "sec_insider_ingest_from_dataset",
+    "sec_nport_ingest_from_dataset",
+    "sec_fsds_class_shares_ingest",
+    "sec_fsds_dimensional_ingest",
+    "sec_submissions_files_walk",
+    "sec_bulk_download",
+)
+
+
+class TestTrackedZeroArgHelper:
+    def test_runs_body_inside_tracked_job(self, monkeypatch: Any) -> None:
+        entered: list[str] = []
+        order: list[str] = []
+
+        @contextmanager
+        def _fake_tracked_job(job_name: str):
+            entered.append(job_name)
+            order.append("enter")
+            yield type("T", (), {"row_count": None})()
+            order.append("exit")
+
+        monkeypatch.setattr(scheduler_module, "_tracked_job", _fake_tracked_job)
+
+        def _body() -> None:
+            order.append("body")
+
+        invoker = _tracked_zero_arg("job_x", _body)
+        invoker({})
+
+        assert entered == ["job_x"]
+        # Body must run strictly between enter and exit (inside the tracking
+        # scope) so _tracked_job owns the success/failure of the row.
+        assert order == ["enter", "body", "exit"]
+
+    def test_body_exception_propagates_inside_tracking(self, monkeypatch: Any) -> None:
+        """A body failure surfaces INSIDE the tracking scope so ``_tracked_job``
+        records the failed run rather than leaving an orphaned ``running`` row."""
+        exited: list[bool] = []
+
+        @contextmanager
+        def _fake_tracked_job(job_name: str):
+            try:
+                yield type("T", (), {"row_count": None})()
+            finally:
+                exited.append(True)
+
+        monkeypatch.setattr(scheduler_module, "_tracked_job", _fake_tracked_job)
+
+        def _boom() -> None:
+            raise RuntimeError("ingest failed")
+
+        invoker = _tracked_zero_arg("job_x", _boom)
+
+        with pytest.raises(RuntimeError, match="ingest failed"):
+            invoker({})
+        assert exited == [True]
+
+    def test_marker_and_wrapped_set(self) -> None:
+        def _body() -> None: ...
+
+        invoker = _tracked_zero_arg("job_x", _body)
+        # Explicit finalisation marker (inspect.getsource follows __wrapped__
+        # to the bare body, so the regression-guard invariant reads the marker).
+        assert getattr(invoker, "__finalises_prelude_row__", False) is True
+        assert getattr(invoker, "__wrapped__", None) is _body
+
+    def test_params_discarded(self, monkeypatch: Any) -> None:
+        """The bulk bodies are zero-arg; the params dict must be discarded."""
+        seen: list[int] = []
+
+        @contextmanager
+        def _fake_tracked_job(job_name: str):
+            yield type("T", (), {"row_count": None})()
+
+        monkeypatch.setattr(scheduler_module, "_tracked_job", _fake_tracked_job)
+        invoker = _tracked_zero_arg("job_x", lambda: seen.append(1))
+        invoker({"ignored": "value"})
+        assert seen == [1]
+
+
+class TestBulkInvokerRegistration:
+    """Every #1573 bulk invoker in ``_INVOKERS`` must enter ``_tracked_job``
+    with its own job_name when dispatched."""
+
+    @pytest.mark.parametrize("job_name", BULK_JOBS)
+    def test_invoker_enters_tracked_job(self, job_name: str, monkeypatch: Any) -> None:
+        entered: list[str] = []
+
+        class _Sentinel(Exception):
+            pass
+
+        @contextmanager
+        def _fake_tracked_job(name: str):
+            entered.append(name)
+            # Raise on entry so the real body never runs (bodies do real
+            # DB/SEC work). The recorded name proves the wrapper fired.
+            raise _Sentinel
+            yield  # pragma: no cover - unreachable, keeps this a generator
+
+        monkeypatch.setattr(scheduler_module, "_tracked_job", _fake_tracked_job)
+
+        with pytest.raises(_Sentinel):
+            _INVOKERS[job_name]({})
+        assert entered == [job_name]

--- a/tests/test_layer_123_wiring.py
+++ b/tests/test_layer_123_wiring.py
@@ -19,9 +19,11 @@ Verifies:
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
-from app.jobs.runtime import VALID_JOB_NAMES
+from app.jobs.runtime import _INVOKERS, _PRELUDE_OPT_OUT_JOBS, VALID_JOB_NAMES
 from app.jobs.sources import MANUAL_TRIGGER_JOB_SOURCES, source_for
 from app.services.canonical_instrument_redirects import (
     JOB_POPULATE_CANONICAL_REDIRECTS,
@@ -360,20 +362,26 @@ class TestEveryInvokerJobResolvesASource:
     with only the invoker half and was silently untriggerable for a
     month — this pins the whole class, not just that one job."""
 
-    # Jobs ALREADY in this broken state on main when the invariant
-    # landed (S6 audit 2026-06-11). Each needs per-job triage — right
-    # lane vs delete-the-invoker-as-dead-code — tracked in #1571.
-    # Adding a NEW name here is never the fix; complete the triangle
-    # instead.
+    # Jobs intentionally left unresolvable (manual trigger rejects cleanly,
+    # not a crash). Adding a NEW name here is never the fix; complete the
+    # triangle (MANUAL_TRIGGER_JOB_SOURCES + _METADATA + _INVOKERS) instead.
+    #
+    # #1571 wired attribution_summary / daily_financial_facts /
+    # daily_tax_reconciliation (each had a real body + _tracked_job, only the
+    # source registry was missing) — they LEFT this set and now resolve.
+    # sec_insider_transactions_ingest left earlier (re-instated to
+    # SCHEDULED_JOBS 2026-06-20, resolves the sec_insider_ingest lane).
     _KNOWN_UNRESOLVABLE: frozenset[str] = frozenset(
         {
-            "attribution_summary",
-            "daily_financial_facts",
-            "daily_tax_reconciliation",
+            # sec_def14a_ingest — manifest-driven post-#1155 (the manifest
+            # worker owns DEF 14A discovery + parse; there is no standalone
+            # ingest lane to dispatch). DELIBERATELY absent from every source
+            # registry so a manual "Run now" rejects cleanly via source_for's
+            # KeyError (POST → 202 → audit row status='rejected'; no 500, no
+            # orphaned job_runs row — it is rejected BEFORE the prelude). Do
+            # NOT wire it: that would imply a standalone trigger path the
+            # manifest model does not have.
             "sec_def14a_ingest",
-            # sec_insider_transactions_ingest RE-INSTATED to SCHEDULED_JOBS
-            # 2026-06-20 — now resolves the sec_insider_ingest lane (no longer
-            # an unresolvable invoker-only orphan).
         }
     )
 
@@ -396,6 +404,130 @@ class TestEveryInvokerJobResolvesASource:
         for name in sorted(self._KNOWN_UNRESOLVABLE):
             with pytest.raises(KeyError):
                 source_for(name)
+
+
+class TestOpsJobsWired:
+    """#1571 — three outside-DAG ops jobs were in ``_INVOKERS`` but missing
+    from every source registry, so every manual trigger landed ``rejected``.
+    Each had a real ``_tracked_job`` body; only the source-registry half was
+    missing. Pins the completed triangle (source + metadata + invoker)."""
+
+    _WIRED: dict[str, str] = {
+        "attribution_summary": "db",
+        "daily_financial_facts": "sec_rate",
+        "daily_tax_reconciliation": "db",
+    }
+
+    def test_source_for_resolves_to_expected_lane(self) -> None:
+        for name, lane in self._WIRED.items():
+            assert source_for(name) == lane
+
+    def test_in_invokers(self) -> None:
+        for name in self._WIRED:
+            assert name in VALID_JOB_NAMES
+
+    def test_zero_param_metadata(self) -> None:
+        for name in self._WIRED:
+            assert MANUAL_TRIGGER_JOB_METADATA[name] == ()
+
+    def test_zero_param_validation_contract(self) -> None:
+        """Empty body validates; any supplied key is rejected (zero-arg jobs)."""
+        for name in self._WIRED:
+            validate_job_params(name, {}, allow_internal_keys=False)
+            with pytest.raises(ParamValidationError):
+                validate_job_params(name, {"unexpected": 1}, allow_internal_keys=False)
+
+    def test_left_known_unresolvable(self) -> None:
+        """The three wired jobs must NOT linger in the unresolvable allow-list."""
+        assert self._WIRED.keys().isdisjoint(TestEveryInvokerJobResolvesASource._KNOWN_UNRESOLVABLE)
+
+
+def _invoker_finalises_prelude_row(invoker: object) -> bool:
+    """True iff ``invoker`` adopts + finalises the manual-dispatch prelude's
+    ``running`` ``job_runs`` row (#1573).
+
+    Two finalising shapes:
+    * ``_tracked_zero_arg`` outputs carry the explicit
+      ``__finalises_prelude_row__`` marker (``inspect.getsource`` follows
+      ``__wrapped__`` to the BARE body, so a source-grep cannot see the
+      wrapper for this shape).
+    * Every other finalising invoker (native ``_tracked_job`` body,
+      ``_adapt_zero_arg`` of a scheduler-side tracked wrapper) references
+      ``_tracked_job`` in the source that ``getsource`` resolves to.
+    """
+    if getattr(invoker, "__finalises_prelude_row__", False):
+        return True
+    try:
+        return "_tracked_job" in inspect.getsource(invoker)  # type: ignore[arg-type]
+    except OSError, TypeError:
+        return False
+
+
+class TestEveryReachPreludeInvokerFinalises:
+    """#1573 regression guard (sibling of ``TestEveryInvokerJobResolvesASource``).
+
+    Manual dispatch of any job that resolves a source and is NOT prelude-opt-out
+    routes through ``run_with_prelude``, which opens a ``running`` ``job_runs``
+    row and hands its ``run_id`` to a ContextVar. ONLY an invoker that runs its
+    body inside ``_tracked_job`` (→ ``consume_prelude_run_id``) adopts + closes
+    that row. A bare invoker leaves it ``running`` forever (admin Processes
+    shows it wedged; only the boot reaper later marks it ``failure``). This
+    pins the whole class so a future bare reach-prelude registration fails at
+    test time, not in production."""
+
+    # Known bare reach-prelude invokers, deferred to #1712. Both are
+    # bootstrap-only by design (manual exposure is doubly-latent); wrapping
+    # ``fundamentals_sync_bootstrap`` additionally needs its own bootstrap
+    # cap-eval verification (it feeds rows_processed via the job_runs path).
+    # Shrink-only, exactly like ``_KNOWN_UNRESOLVABLE``.
+    _KNOWN_NON_FINALISING: frozenset[str] = frozenset(
+        {
+            "bootstrap_validation",
+            "fundamentals_sync_bootstrap",
+        }
+    )
+
+    def _reach_prelude_jobs(self) -> list[str]:
+        jobs = []
+        for name in sorted(VALID_JOB_NAMES):
+            if name in _PRELUDE_OPT_OUT_JOBS:
+                continue
+            try:
+                source_for(name)
+            except KeyError:
+                continue
+            jobs.append(name)
+        return jobs
+
+    def test_no_bare_reach_prelude_invoker(self) -> None:
+        bare = [name for name in self._reach_prelude_jobs() if not _invoker_finalises_prelude_row(_INVOKERS[name])]
+        new_bare = sorted(set(bare) - self._KNOWN_NON_FINALISING)
+        assert new_bare == [], (
+            "reach-prelude invokers that do not finalise their prelude job_runs row "
+            f"(orphan 'running' on manual dispatch — wrap in _tracked_job): {new_bare}"
+        )
+
+    def test_known_non_finalising_shrinks_only(self) -> None:
+        """A deferred job that gets wrapped must leave the allow-list."""
+        for name in sorted(self._KNOWN_NON_FINALISING):
+            assert not _invoker_finalises_prelude_row(_INVOKERS[name]), (
+                f"{name} now finalises — remove it from _KNOWN_NON_FINALISING"
+            )
+
+    def test_wired_bulk_jobs_finalise(self) -> None:
+        """The 9 #1573 bulk-dataset jobs must read as finalising."""
+        for name in (
+            "sec_submissions_ingest",
+            "sec_companyfacts_ingest",
+            "sec_13f_ingest_from_dataset",
+            "sec_insider_ingest_from_dataset",
+            "sec_nport_ingest_from_dataset",
+            "sec_fsds_class_shares_ingest",
+            "sec_fsds_dimensional_ingest",
+            "sec_submissions_files_walk",
+            "sec_bulk_download",
+        ):
+            assert _invoker_finalises_prelude_row(_INVOKERS[name]), name
 
 
 class TestLookupMetadataFallback:


### PR DESCRIPTION
Closes #1573. Closes #1571.

Two halves of the same "manual-trigger reach is incomplete" theme — one PR.

## Premise falsification (on dev DB @ base 08874328)

- **#1573 orphan CONFIRMED.** Manual dispatch of a bare bulk invoker reaches `run_with_prelude`, which writes a `running` `job_runs` row + stashes its `run_id` in a ContextVar; a bare body never adopts it (never calls `consume_prelude_run_id`), so the row orphans `running` forever — only the #1510 boot reaper closes it (→ `failure` "orphaned: reaped at boot"). Reproduced: renamed `submissions.zip` aside, `POST /jobs/sec_submissions_ingest/run` → req 103 `completed`, but `job_runs` 22297 stuck `running`/NULL. Historical proof: 3 `sec_companyfacts_ingest` rows are all reaped-orphans (one sat `running` ~13h). Artifact row deleted; archive restored.
- **#1571 unresolvable set is 4, NOT 5.** `sec_insider_transactions_ingest` already left `_KNOWN_UNRESOLVABLE` (re-instated to `SCHEDULED_JOBS` 2026-06-20). Re-adding it would FAIL `test_known_unresolvable_list_shrinks_only`. Live set: `attribution_summary`, `daily_financial_facts`, `daily_tax_reconciliation`, `sec_def14a_ingest`.
- **Full-population scan: 11 bare reach-prelude invokers, not the issue's 7.** Issue under-enumerates. The same `sec_bulk_orchestrator_jobs.py` module has 2 more (`sec_fsds_class_shares_ingest`, `sec_fsds_dimensional_ingest`); plus 2 bootstrap-only jobs (`bootstrap_validation`, `fundamentals_sync_bootstrap`).

## #1573 — finalise the prelude row (9 bulk-dataset jobs)

New registration-boundary helper `_tracked_zero_arg(job_name, fn)` in `app/jobs/runtime.py` (next to `_adapt_zero_arg`): runs the body inside `_tracked_job` so the prelude row finalises. Repoints 9 `_INVOKERS` entries (issue's 7 + the 2 FSDS siblings) and dedupes a byte-identical duplicate `sec_bulk_download` registration.

- **Helper, not 9 named scheduler.py wrappers** (the `populate_canonical_redirects` precedent): the wrappers would be byte-identical (`with _tracked_job(JOB): body()`) — captured once (KISS/DRY), same `_tracked_job` mechanism.
- **`row_count` left None (not 0)** — bodies return `None` (no count to stamp). **Bootstrap-safe**: these are also bootstrap stages, and `bootstrap_orchestrator._resolve_stage_rows` resolves `rows_processed` from `bootstrap_archive_results` (Sources 1/2) BEFORE the `job_runs` window (Source 3), where a NULL-`row_count` row is skipped — so bootstrap `rows_processed` is **byte-identical**. Verified against the `_resolve_stage_rows` 3-source priority + the #1225 audit docstring. (Already-promoted stages `sec_13f_quarterly_sweep`/`sec_n_port_ingest` set the precedent: `_tracked_job` + run as bootstrap stages.)
- No body calls `record_job_skip` (grep-verified) → no PREREQ_SKIP double-write (prevention-log L812).
- **Considered + rejected: a generic backstop in `run_with_prelude`** (finalise if the ContextVar `run_id` is unconsumed after `invoker()`). Fixes the whole class in one place but touches the core dispatch primitive (every scheduled+manual fire) and must duplicate `_tracked_job`'s success/failure/spike logic + handle the exception path. The helper + the new invariant test gets class-level protection at the registration boundary with zero blast radius on the hot path.

## #1571 — wire 3 dormant ops jobs (complete the triangle)

All 3 already finalise (real `_tracked_job`+`connect_job` bodies); they were untriggerable only because `source_for` KeyErrored. Not in `SCHEDULED_JOBS`; only **dashboard** members of the orchestrator (`JOB_TO_LAYERS` empty tuple = "Background tasks" panel, display-only — not a dispatcher). Triage = wire as manual-trigger-only.

| job | lane | rationale (#1534 — writes safe vs concurrent lanemates) |
|---|---|---|
| `attribution_summary` | `db` | pure-DB; sole writer of attribution summaries (`return_attribution.py`) |
| `daily_financial_facts` | `sec_rate` | SEC producer (HTTP rate budget; sibling of `daily_research_refresh`). NOT a sole writer of `financial_facts_raw` — `fundamentals_sync` (db) calls it internally + `sec_companyfacts_ingest` writes it too — but the writer `upsert_facts_for_instrument` is last-write-wins/idempotent per `docs/etl/sources/sec_xbrl_facts.md`, so cross-lane overlap is benign. `db` would be wrong (holds a DB lane across slow SEC HTTP). |
| `daily_tax_reconciliation` | `db` | pure-DB; sole writer of `tax_lots`/`disposal_matches` (`tax_ledger.py`) |

Dropped the 3 from `_KNOWN_UNRESOLVABLE` → `{sec_def14a_ingest}` only (manifest-driven post-#1155; verified it rejects cleanly: `POST → 202 → audit row status='rejected'`, no 500, no orphan — it is rejected *before* the prelude).

## Deferred (tracked, not silent) → #1712

`bootstrap_validation` + `fundamentals_sync_bootstrap` — same orphan bug, different family (bootstrap-only). `fundamentals_sync_bootstrap` feeds a bootstrap cap via the job_runs Source-3 path, so wrapping it needs its own cap-eval verification. Allow-listed in the new invariant test (shrink-only) so no NEW bare invoker can slip in.

## Security / safety model

No auth/authz change. No schema change. No parser/observations-data change. The 3 newly-triggerable jobs run only via the existing authenticated `POST /jobs/{name}/run` path (service token), through the same queue listener + `JobLock` source-lock as every other job. Lane choices are write-safe (sole-writer or idempotent last-write-wins per the cited source doc). `sec_def14a_ingest` stays deliberately unresolvable so a manual trigger rejects cleanly rather than running a path the manifest model doesn't have.

## Tests + gates

New: per-job source/metadata for the 3 wired jobs; `_tracked_zero_arg` behaviour (enters `_tracked_job`, body exception propagates inside tracking, params discarded) + all 9 bulk invokers enter tracking; `TestEveryReachPreludeInvokerFinalises` invariant (no bare reach-prelude invoker; shrink-only allow-list for the 2 deferred). Gates: `ruff` clean, `pyright` 0 errors, fast tier 4425 passed, smoke 129 passed, 168 jobs/registry/bootstrap regression tests pass. Codex ckpt1 (plan) + ckpt2 (pre-push) both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
