### PR TITLE
fix(#1712): wrap bootstrap_validation + fundamentals_sync_bootstrap reach-prelude invokers

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -402,8 +402,18 @@ _INVOKERS[_scheduler.JOB_SEC_N_CSR_BOOTSTRAP_DRAIN] = _scheduler.sec_n_csr_boots
 # Wraps a no-arg derivation function; discards the params dict.
 from app.services.fundamentals import bootstrap as _fundamentals_bootstrap  # noqa: E402
 
-_INVOKERS[_fundamentals_bootstrap.JOB_FUNDAMENTALS_SYNC_BOOTSTRAP] = (
-    _fundamentals_bootstrap.fundamentals_sync_bootstrap_invoker
+# #1712 — wrap in ``_tracked_job`` so a manual "Run now" finalises the
+# prelude's ``running`` ``job_runs`` row instead of orphaning it (#1573 class).
+# The invoker accepts zero args (``_params`` defaults to None), so
+# ``_tracked_zero_arg`` calls it directly — no adapter needed. The NULL
+# ``row_count`` row is inert to the bootstrap cap-eval: ``_resolve_stage_rows``
+# resolves S25 ``rows_processed`` from the ``__job__`` archive row (Source 2,
+# ``normalize_periods_canonical_upserted``) when >0, and Source 3 returns None
+# both before (no row) and after (NULL ``row_count`` → ``row[0] is None``) when
+# ==0 — see ``bootstrap_orchestrator._resolve_stage_rows``.
+_INVOKERS[_fundamentals_bootstrap.JOB_FUNDAMENTALS_SYNC_BOOTSTRAP] = _tracked_zero_arg(
+    _fundamentals_bootstrap.JOB_FUNDAMENTALS_SYNC_BOOTSTRAP,
+    _fundamentals_bootstrap.fundamentals_sync_bootstrap_invoker,
 )
 
 # #1233 PR-1b — OpenFIGI CUSIP resolver post-bulk sweep (Phase D, S13).
@@ -430,8 +440,13 @@ _INVOKERS[_scheduler.JOB_SEC_MASTER_IDX_GAP_CLOSE] = _adapt_zero_arg(_scheduler.
 # hard-floor breach so the stage errors → finalize_run → partial_error.
 from app.services import bootstrap_validation as _bootstrap_validation  # noqa: E402
 
-_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_VALIDATION] = _adapt_zero_arg(
-    _bootstrap_validation.run_bootstrap_validation
+# #1712 — wrap in ``_tracked_job`` so a manual dispatch finalises the prelude's
+# ``running`` ``job_runs`` row (#1573 class). Bootstrap-only and "provides
+# nothing" (status-only validation gate), so there is no ``rows_processed``
+# path to perturb; the NULL ``row_count`` row is purely the prelude finaliser.
+_INVOKERS[_bootstrap_orchestrator.JOB_BOOTSTRAP_VALIDATION] = _tracked_zero_arg(
+    _bootstrap_orchestrator.JOB_BOOTSTRAP_VALIDATION,
+    _bootstrap_validation.run_bootstrap_validation,
 )
 _INVOKERS[_scheduler.JOB_SEC_REBUILD] = _scheduler.sec_rebuild  # params-taking, no _adapt_zero_arg
 # #1013 — one-shot skip-tier filing_events cleanup. Manual-trigger-only

--- a/tests/test_bootstrap_rows_processed_gates.py
+++ b/tests/test_bootstrap_rows_processed_gates.py
@@ -353,6 +353,66 @@ def test_resolver_falls_back_to_job_runs_or_none(
     assert resolved_empty is None
 
 
+def test_resolver_null_row_count_job_run_is_inert(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1712 — wrapping ``fundamentals_sync_bootstrap`` in ``_tracked_zero_arg``
+    writes a NULL-``row_count`` ``success`` ``job_runs`` row on the bootstrap
+    path. The Source-3 query picks the latest success row but guards
+    ``row[0] is not None``, so a NULL ``row_count`` resolves to ``None`` —
+    byte-identical to the pre-#1712 no-job_runs-row case. This pins that the
+    finalisation row does NOT perturb bootstrap ``rows_processed`` cap-eval.
+
+    Shape mirrors the real fundamentals_sync_bootstrap stage: a ``__job__``
+    archive row with ``rows_written=0`` (Source 1 empty, Source 2 falls through)
+    that, pre-#1712, resolved via an empty Source-3 window → ``None``.
+    """
+    _wipe_bootstrap_state(ebull_test_conn)
+    run_id = _insert_run(ebull_test_conn, run_status="running")
+    stage_key = "fundamentals_sync"
+    job_name = "fundamentals_sync_bootstrap"
+    _insert_stage(
+        ebull_test_conn,
+        run_id=run_id,
+        stage_key=stage_key,
+        stage_order=25,
+        lane="db_fundamentals_raw",
+        job_name=job_name,
+        status="running",
+    )
+    # Source 2: __job__ row with rows_written=0 (zero canonical_upserted) →
+    # falls through to Source 3, exactly as the live invoker's audit row does
+    # when no periods normalise.
+    record_archive_result(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key=stage_key,
+        archive_name="__job__",
+        rows_written=0,
+    )
+    ebull_test_conn.commit()
+
+    before = _snapshot_job_runs_max_id(ebull_test_conn, job_name=job_name)
+    # The #1712 _tracked_job finaliser: success, NULL row_count (no count stamped).
+    ebull_test_conn.execute(
+        "INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count) "
+        "VALUES (%s, now(), now(), 'success', NULL)",
+        (job_name,),
+    )
+    ebull_test_conn.commit()
+    after = _snapshot_job_runs_max_id(ebull_test_conn, job_name=job_name)
+
+    resolved = _resolve_stage_rows(
+        ebull_test_conn,
+        bootstrap_run_id=run_id,
+        stage_key=stage_key,
+        job_name=job_name,
+        job_runs_id_before=before,
+        job_runs_id_after=after,
+    )
+    assert resolved is None
+
+
 # ---------------------------------------------------------------------------
 # record_archive_result_if_absent vs record_archive_result
 # ---------------------------------------------------------------------------

--- a/tests/test_layer_123_wiring.py
+++ b/tests/test_layer_123_wiring.py
@@ -475,17 +475,12 @@ class TestEveryReachPreludeInvokerFinalises:
     pins the whole class so a future bare reach-prelude registration fails at
     test time, not in production."""
 
-    # Known bare reach-prelude invokers, deferred to #1712. Both are
-    # bootstrap-only by design (manual exposure is doubly-latent); wrapping
-    # ``fundamentals_sync_bootstrap`` additionally needs its own bootstrap
-    # cap-eval verification (it feeds rows_processed via the job_runs path).
-    # Shrink-only, exactly like ``_KNOWN_UNRESOLVABLE``.
-    _KNOWN_NON_FINALISING: frozenset[str] = frozenset(
-        {
-            "bootstrap_validation",
-            "fundamentals_sync_bootstrap",
-        }
-    )
+    # Known bare reach-prelude invokers. #1712 wrapped the last two
+    # (``bootstrap_validation`` + ``fundamentals_sync_bootstrap``) in
+    # ``_tracked_zero_arg``, so the allow-list is now empty: EVERY reach-prelude
+    # invoker must finalise its prelude ``job_runs`` row. Shrink-only, exactly
+    # like ``_KNOWN_UNRESOLVABLE`` — a new bare registration fails at test time.
+    _KNOWN_NON_FINALISING: frozenset[str] = frozenset()
 
     def _reach_prelude_jobs(self) -> list[str]:
         jobs = []


### PR DESCRIPTION
## What

Wraps the last two bare reach-prelude invokers (deferred from #1573) in `_tracked_zero_arg` so a manual dispatch finalises the prelude's `running` `job_runs` row instead of orphaning it.

- `bootstrap_validation` — #1419 terminal load-time validation gate. Status-only ("provides nothing"); no `rows_processed` path to perturb.
- `fundamentals_sync_bootstrap` — Stream A PR-C2 bootstrap-only fundamentals derivation. Its invoker accepts zero args (`_params` defaults to `None`), so `_tracked_zero_arg` takes it directly — no adapter needed.

Shrinks `TestEveryReachPreludeInvokerFinalises._KNOWN_NON_FINALISING` to empty: every reach-prelude invoker now finalises; a future bare registration fails at test time.

## Why

Bare reach-prelude invoker = a manual "Run now" routes through `run_with_prelude` (opens a `running` `job_runs` row, hands `run_id` to a ContextVar) but the bare body never calls `consume_prelude_run_id`, so the row is left `running` forever (admin Processes shows it wedged; only the #1510 boot reaper later marks it `failure`). Same defect class as #1573's 9 bulk jobs; these two were deferred because they are bootstrap-orchestration (not bulk-dataset ingest) and one needed its own cap-eval verification.

## Cap-eval inertness (KEY verification)

Unlike the bulk ingesters (rows_processed from `bootstrap_archive_results`, Sources 1/2), `fundamentals_sync_bootstrap` can resolve via the `job_runs` window (Source 3) in `bootstrap_orchestrator._resolve_stage_rows`. Adding a `_tracked_job` row on the bootstrap path writes a **NULL `row_count`** success `job_runs` row. Proven inert:

- The live invoker writes a `__job__` archive row with `rows_written = normalize_periods_canonical_upserted` (`app/services/fundamentals/bootstrap.py:228`).
- **canonical_upserted > 0** → Source 2 (`__job__`, >0) returns it; **Source 3 never reached**.
- **canonical_upserted == 0** → Source 2 returns 0 → falls to Source 3. Source 3 SQL picks the latest `status='success'` row then guards `row[0] is not None`; a NULL `row_count` → returns **None** — byte-identical to the pre-#1712 no-job_runs-row case.

→ rows_processed / `fundamentals_raw_seeded` / S25 cap-eval unchanged in both branches.

Pinned by new DB test `tests/test_bootstrap_rows_processed_gates.py::test_resolver_null_row_count_job_run_is_inert` (mirrors the real stage: `__job__` `rows_written=0` + NULL-row_count success `job_runs` row in window → resolver returns `None`).

## Prevention-log cross-check

- L812/816 (record_job_skip must be OUTSIDE `_tracked_job`): both bodies verified to have **no** `record_job_skip` call. `bootstrap_validation` either returns `None` or re-raises `BootstrapValidationError` (→ `_tracked_job` marks `failure`, correct terminalisation). Clear.
- L177 (NULL `row_count` ambiguity): the documented `_tracked_zero_arg` bootstrap-safe choice — bodies return `None`, no count to stamp; `_tracked_job` spike check is gated on `row_count is not None` so it stays inert.

## Verification

- ruff check / ruff format --check / pyright: clean
- `pytest -m "not db"`: 4425 passed, 10 skipped
- `pytest tests/smoke`: 129 passed
- `pytest tests/test_layer_123_wiring.py`: 59 passed (baseline was 3 passed with both in the allow-list; post-fix both read as finalising)
- `pytest tests/test_bootstrap_rows_processed_gates.py -m db`: 9 passed (incl new inertness test)
- Codex checkpoint-2: no correctness findings; independently confirmed the Source-3 invariant.

## Conscious tradeoffs

- Live manual-dispatch dev-verify deferred to the post-merge daemon restart: the running daemon is on old main, and `fundamentals_sync_bootstrap`'s body runs the real (heavy) derivation against dev DB, so an ad-hoc trigger is inappropriate. The finalisation mechanism is the **identical** `_tracked_zero_arg` already dev-proven in #1573 (orphan run 22297 vs finalised 22341); the new risk (cap-eval) is proven by the DB test + code reading above.

Closes #1712