### PR TITLE
fix(#1687): guard future-dated insider txn_date (Rule 16a-3(a)) + flag existing typos

### DIFF
--- a/app/services/holder_name_resolver.py
+++ b/app/services/holder_name_resolver.py
@@ -130,6 +130,7 @@ def resolve_holder_to_filer(
             FROM insider_transactions
             WHERE instrument_id = %(iid)s
               AND post_transaction_shares IS NOT NULL
+              AND NOT txn_date_invalid  -- #1687 — a future-dated typo must not win the latest balance
             ORDER BY COALESCE(filer_cik, ''), filer_name,
                      txn_date DESC NULLS LAST, id DESC
             """,

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -40,7 +40,7 @@ import json
 import logging
 import re
 import xml.etree.ElementTree as ET  # noqa: S405 — Form 4 source is SEC EDGAR, trusted.
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any, Protocol
@@ -261,6 +261,54 @@ class ParsedTransaction:
     underlying_shares: Decimal | None
     underlying_value: Decimal | None
     footnote_refs: tuple[ParsedFootnoteRef, ...] = ()
+    # #1687 — TRUE when txn_date postdates the SEC filing date, which is
+    # impossible per Rule 16a-3(a) for a non-early filing (a filer source
+    # typo). Set in :func:`upsert_filing` once filed_at is resolved; the raw
+    # txn_date is retained for audit and operator-visible readers exclude
+    # flagged rows.
+    txn_date_invalid: bool = False
+
+
+def evaluate_insider_date_validity(
+    txn_date: date,
+    deemed_execution_date: date | None,
+    filed_at: datetime | None,
+    transaction_timeliness: str | None,
+) -> tuple[bool, date | None]:
+    """Apply the Rule 16a-3(a) execution-date invariant to one transaction.
+
+    A Form 4 is due before the end of the 2nd business day *following* the
+    reportable transaction (Securities Exchange Act §16(a) / Rule 16a-3(a)),
+    so the execution date precedes or equals the filing date. A ``txn_date``
+    / ``deemed_execution_date`` that postdates ``filed_at`` is therefore
+    impossible — a filer source typo (#1687).
+
+    Returns ``(txn_date_invalid, deemed_execution_date)``:
+
+    - ``txn_date_invalid`` is True when ``txn_date > filed_at`` (the row is
+      flagged; the raw value is kept since ``txn_date`` is NOT NULL).
+    - ``deemed_execution_date`` is dropped to ``None`` when it postdates
+      ``filed_at`` (nullable ⇒ quarantine, never invent a value).
+
+    Exemptions (return inert ``(False, deemed unchanged)``):
+
+    - ``filed_at is None`` — no authoritative anchor (mirrors the
+      ``upsert_filing`` filed_at fallback semantics).
+    - ``transaction_timeliness == 'E'`` — an early filing (EDGAR ownership
+      XML ``transactionTimeliness``; see ``sql/057``) may legitimately
+      report a transaction dated after the filing.
+    """
+    if filed_at is None or transaction_timeliness == "E":
+        return (False, deemed_execution_date)
+    # Anchor on the UTC calendar date (the SEC filing date is a UTC-stamped
+    # acceptance date) so the boundary is session-timezone independent and
+    # matches the migration's ``(filed_at AT TIME ZONE 'UTC')::date``.
+    filed_date = filed_at.astimezone(UTC).date()
+    txn_date_invalid = txn_date > filed_date
+    deemed_out = (
+        None if deemed_execution_date is not None and deemed_execution_date > filed_date else deemed_execution_date
+    )
+    return (txn_date_invalid, deemed_out)
 
 
 @dataclass(frozen=True)
@@ -1167,6 +1215,22 @@ def upsert_filing(
     historical ``txn_date @ midnight UTC``, logged."""
     if filed_at is None:
         filed_at = lookup_sec_filed_at(conn, accession_number)
+
+    # #1687 — apply the Rule 16a-3(a) execution-date guard once filed_at is
+    # resolved. Sanitise the parsed transactions BEFORE both the DB insert
+    # loop and the ownership write-through below: a future-dated typo must
+    # neither surface in the insider list nor win the latest-per-group
+    # ownership observation.
+    sanitised: list[ParsedTransaction] = []
+    for txn in parsed.transactions:
+        invalid, deemed = evaluate_insider_date_validity(
+            txn.txn_date, txn.deemed_execution_date, filed_at, txn.transaction_timeliness
+        )
+        if invalid != txn.txn_date_invalid or deemed != txn.deemed_execution_date:
+            txn = replace(txn, txn_date_invalid=invalid, deemed_execution_date=deemed)
+        sanitised.append(txn)
+    parsed = replace(parsed, transactions=tuple(sanitised))
+
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -1310,7 +1374,7 @@ def upsert_filing(
                     exercise_date, expiration_date,
                     underlying_security_title,
                     underlying_shares, underlying_value,
-                    footnote_refs
+                    footnote_refs, txn_date_invalid
                 ) VALUES (
                     %s, %s, %s,
                     %s, %s, %s,
@@ -1325,7 +1389,7 @@ def upsert_filing(
                     %s, %s,
                     %s,
                     %s, %s,
-                    %s
+                    %s, %s
                 )
                 ON CONFLICT (accession_number, txn_row_num) DO UPDATE SET
                     filer_cik                 = EXCLUDED.filer_cik,
@@ -1350,7 +1414,8 @@ def upsert_filing(
                     underlying_security_title = EXCLUDED.underlying_security_title,
                     underlying_shares         = EXCLUDED.underlying_shares,
                     underlying_value          = EXCLUDED.underlying_value,
-                    footnote_refs             = EXCLUDED.footnote_refs
+                    footnote_refs             = EXCLUDED.footnote_refs,
+                    txn_date_invalid          = EXCLUDED.txn_date_invalid
                 """,
                 (
                     instrument_id,
@@ -1379,6 +1444,7 @@ def upsert_filing(
                     txn.underlying_shares,
                     txn.underlying_value,
                     footnote_refs_json,
+                    txn.txn_date_invalid,
                 ),
             )
 
@@ -1452,6 +1518,11 @@ def _record_form4_observations_for_filing(
         if txn.post_transaction_shares is None:
             continue
         if txn.txn_date is None:
+            continue
+        # #1687 — a future-dated typo must not win the latest-per-group
+        # holding (it would write a future period_end and the wrong share
+        # balance into ownership_insiders_current).
+        if txn.txn_date_invalid:
             continue
         key = (txn.filer_cik, txn.direct_indirect)
         prior = latest.get(key)
@@ -2198,6 +2269,7 @@ def get_insider_summary(
                AND f.is_tombstone = FALSE
             WHERE it.instrument_id = %s
               AND it.is_derivative = FALSE
+              AND NOT it.txn_date_invalid  -- #1687 — exclude future-dated typos
               AND it.txn_date >= CURRENT_DATE - INTERVAL '90 days'
             """,
             (instrument_id,),
@@ -2319,6 +2391,7 @@ def list_insider_transactions(
                 ON f.accession_number = it.accession_number
                AND f.is_tombstone = FALSE
             WHERE it.instrument_id = %s
+              AND NOT it.txn_date_invalid  -- #1687 — exclude future-dated typos
             ORDER BY it.txn_date DESC, it.id DESC
             LIMIT %s
             """,

--- a/app/services/ownership_observations_sync.py
+++ b/app/services/ownership_observations_sync.py
@@ -194,7 +194,9 @@ def sync_insiders(
         form5_retention_cutoff,
     )
 
-    where = "WHERE it.post_transaction_shares IS NOT NULL AND it.is_derivative = FALSE"
+    # #1687 — exclude future-dated txn_date typos so the latest-per-group
+    # re-derivation never picks an impossible date as the current holding.
+    where = "WHERE it.post_transaction_shares IS NOT NULL AND it.is_derivative = FALSE AND NOT it.txn_date_invalid"
     params: dict[str, Any] = {
         "form4_cutoff": form4_retention_cutoff(),
         "form5_cutoff": form5_retention_cutoff(),

--- a/docs/specs/ingest/2026-06-23-insider-future-dated-txn-date.md
+++ b/docs/specs/ingest/2026-06-23-insider-future-dated-txn-date.md
@@ -1,0 +1,205 @@
+# #1687 — Insider DQ: future-dated `insider_transactions.txn_date`
+
+## Problem
+
+`insider_transactions` rows carry impossible `txn_date` values (e.g. LQDT
+`2035-01-10`, TMUS `2026-06-17`). Operator-visible symptoms:
+
+- **Insider list** (`list_insider_transactions`, `ORDER BY txn_date DESC`)
+  pins the impossible row to the top.
+- **Insider summary** (`get_insider_summary`, `MAX(txn_date)` + a
+  `txn_date >= CURRENT_DATE - 90d` window) reports it as the "latest"
+  activity and folds future rows into the 90d net/buy/sell aggregates.
+- **Ownership rollup** — the Form 4 write-through
+  (`_record_form4_observations_for_filing`) picks the *latest* txn per
+  `(filer, nature)` by `txn_date DESC` and writes `period_end = txn_date`,
+  so a future typo (a) becomes the group winner with the wrong share
+  balance and (b) wins `ownership_insiders_current`
+  (`refresh_insiders_current` orders `period_end DESC`). 126 current
+  observations carry `period_end > filed_at` today.
+
+## Source rule
+
+Securities Exchange Act **§16(a)** + **Rule 16a-3(a) (17 CFR 240.16a-3(a))**
++ **Form 4 General Instructions (Instr. 1)**: a Form 4 is due before the end
+of the **2nd business day following the day the reportable transaction is
+executed** ⇒ the execution date normally precedes/equals the filing date.
+
+**Exception — early filing.** SEC permits *early* reporting; the **EDGAR
+Ownership XML Technical Specification** (`sec.gov/info/edgar/ownershipxmltechspec.htm`)
+defines `transactionTimeliness/value`: `'E'` = early, `'L'` = late
+(optional). When a filer voluntarily reports **early**, the reported
+transaction date may legitimately *postdate* the filing date. Repo's
+settled treatment: `sql/057_insider_transactions_richness.sql:262-265` —
+"`E` = filed early (before the event), `L` = filed late".
+
+**Source for the date-column semantics** — the **Form 4** itself
+(`sec.gov/files/form4.pdf`, General Instructions + table headers):
+Table I col. 3 "Transaction Date" and col. 3a "Deemed Execution Date, if
+any" are *execution* dates (governed by the Rule 16a-3(a) 2-business-day
+rule ⇒ `≤ filed_at`); Table II "Date Exercisable" (`exercise_date`) and
+"Expiration Date" (`expiration_date`) are *future* derivative milestones
+and are therefore exempt.
+
+Invariant:
+
+```
+txn_date              <= filed_at   UNLESS transaction_timeliness = 'E'
+deemed_execution_date <= filed_at   UNLESS transaction_timeliness = 'E'
+```
+
+**Exempt date columns (legitimately future):** `exercise_date` (Table II
+"Date Exercisable") and `expiration_date` (option expiry) describe future
+derivative milestones, not the reported transaction. The guard MUST NOT
+touch them.
+
+Anchor = `filed_at` (SEC-stamped acceptance date, `sec_filing_manifest.filed_at`,
+#1233 — authoritative, not filer-typed). Threshold is strict `>` (same-day
+filing is valid). No hand-waved "slack".
+
+## Finding: FILER SOURCE TYPO, not parser mis-parse
+
+Raw `form4_xml` carries the impossible date verbatim in
+`<transactionDate><value>` while the same filing's `periodOfReport` /
+`signatureDate` are correct. **Full-population check (not a sample):** of
+the 80 non-`E` `txn_date` violators, all **75 with a retained raw payload
+have the stored date present verbatim** as `<value>…</value>` in the source
+XML; **0** parser-invented dates. The 5 remainder are retention-swept (same
+blank-timeliness class). ⇒ **Re-ingest cannot fix it.** We do not invent a
+corrected date (`periodOfReport` ≠ this txn's date on multi-txn forms —
+that would be a heuristic).
+
+## Full-population verification (dev DB, 1,016,755 rows)
+
+| Date column | rows `> filed_at` | of which `timeliness='E'` | treatment |
+|---|---|---|---|
+| `txn_date` | 92 | **12 (all code-J, gap 14–18 d — LEGIT early)** | flag the **80 non-E** rows |
+| `deemed_execution_date` | 19 | 0 (all blank) | NULL the **19** |
+| `exercise_date` | 14,851 | — | **LEGIT — exempt** |
+| `expiration_date` | 92,663 | — | **LEGIT — exempt** |
+
+The 12 `E` rows are tightly clustered (one filing agent, code J, 14–18 day
+gaps) — deliberate early reports of near-future transactions, **not**
+typos. The 80 non-E violators span gaps of 1–3651 days; 0 are unjoined to
+the manifest. `txn_date_invalid` flags only the 80.
+
+Contaminated observations (`source='form4'`, `period_end > filed_at`,
+`known_to IS NULL`): **126** = 92 derived from a flaggable non-E txn + 24
+derived from a legit `E` txn (**must NOT clean**) + 10 unmatched-on-join
+(`period_end > filed_at`, not E — also contaminated). Cleanup keys off the
+flag / non-E predicate so the 24 `E`-derived observations are preserved.
+
+## Design
+
+Row-level treatment (a typo'd txn coexists with valid sibling txns under
+the same accession), not filing-level tombstone.
+
+1. **Schema (`sql/205`)** — add
+   `insider_transactions.txn_date_invalid BOOLEAN NOT NULL DEFAULT FALSE`.
+   `txn_date` is NOT NULL ⇒ keep the raw (bad) value for audit + flag the
+   row. `deemed_execution_date` is nullable ⇒ a violation is quarantined to
+   NULL (no invent). Same migration backfills existing rows (idempotent
+   UPDATEs):
+   - `txn_date_invalid = TRUE` where `txn_date > filed_at`
+     AND `transaction_timeliness IS DISTINCT FROM 'E'` (join
+     `sec_filing_manifest`).
+   - `deemed_execution_date = NULL` where `deemed_execution_date > filed_at`
+     AND `transaction_timeliness IS DISTINCT FROM 'E'`.
+
+2. **Parse-time guard** — pure helper
+   `evaluate_insider_date_validity(txn_date, deemed_execution_date, filed_at,
+   transaction_timeliness) -> (txn_date_invalid: bool,
+   deemed_execution_date: date | None)`:
+   - `filed_at is None` (no anchor) ⇒ `(False, deemed unchanged)`.
+   - `transaction_timeliness == 'E'` ⇒ `(False, deemed unchanged)` (early).
+   - `txn_date > filed_at.date()` ⇒ `txn_date_invalid = True`.
+   - `deemed_execution_date > filed_at.date()` ⇒ drop to `None`.
+
+   Add `txn_date_invalid: bool = False` to `ParsedTransaction`. In
+   `upsert_filing` (the persist chokepoint that resolves `filed_at`),
+   sanitize `parsed.transactions` through the helper **before** both the DB
+   insert loop **and** `_record_form4_observations_for_filing`. The DB loop
+   writes the flag (INSERT + `ON CONFLICT DO UPDATE` so rewash re-applies);
+   the observation builder skips `txn.txn_date_invalid` in its
+   latest-per-group selection so the real latest valid txn wins and
+   `period_end` is correct.
+
+3. **Readers** — exclude flagged rows:
+   - `get_insider_summary` — `AND NOT it.txn_date_invalid` (fixes
+     `MAX(txn_date)` + the 90d window).
+   - `list_insider_transactions` — `AND NOT it.txn_date_invalid` (fixes
+     `ORDER BY txn_date DESC`).
+   - `ownership_observations_sync.sync_insiders` — `AND NOT it.txn_date_invalid`
+     in the insider select so the periodic / rebuild re-derivation also
+     excludes invalid txns.
+
+   **Not filtered** (deliberate): `insider_form3_ingest` "did this filer
+   transact?" EXISTS and `ownership_drillthrough` reconciliation COUNT both
+   want the row present (it is a real transaction, only its date is wrong).
+
+4. **No `_PARSER_VERSION` bump** — cleanup is a targeted SQL UPDATE; the bad
+   rows' other fields are correct. Not bumping avoids a mass re-ingest;
+   future filings get the guard via INSERT, rewash re-applies via ON
+   CONFLICT. ⇒ **no `sec_rebuild` needed.**
+
+## Cleanup of existing contaminated ownership observations (backfill)
+
+`refresh_insiders_current` picks the winner by `period_end DESC` among
+`known_to IS NULL` obs, and the corrected re-derivation writes a *different*
+`period_end` (different natural key) — so re-running the sync alone leaves
+the future-`period_end` obs winning. Cleanup must explicitly supersede it:
+
+1. (migration) flag txns + NULL deemed (above).
+2. (backfill, post-window) supersede contaminated form4 observations,
+   anchored on the **manifest** `filed_at` (the obs's own `filed_at` may
+   carry the legacy `txn_date`-midnight fallback) with obs-`filed_at` only
+   as a last resort when no manifest row exists, and preserving the legit
+   `E` cohort by a positively-keyed `(accession, period_end)` match:
+
+   ```sql
+   UPDATE ownership_insiders_observations o
+   SET known_to = now()
+   FROM ... -- LEFT JOIN sec_filing_manifest m ON m.accession_number = o.source_accession
+   WHERE o.source = 'form4' AND o.known_to IS NULL
+     AND o.period_end > COALESCE(m.filed_at, o.filed_at)::date
+     AND NOT EXISTS (
+       SELECT 1 FROM insider_transactions it
+       WHERE it.accession_number = o.source_accession
+         AND it.txn_date = o.period_end
+         AND it.transaction_timeliness = 'E');
+   ```
+
+   Verified cohort (dev): **102 superseded** (101 manifest-anchored + 1
+   fallback) / **24 `E`-derived preserved**.
+3. (backfill) re-run `sync_insiders` (now excludes flagged txns → records
+   the correct winner obs) + `refresh_insiders_current` for affected
+   instruments → `ownership_insiders_current` re-picks the real latest.
+
+This is an observation re-derivation, **not** `sec_rebuild` (no SEC fetch).
+
+## Tests
+
+Pure-logic table test of `evaluate_insider_date_validity`: txn after /
+equal / before filed; deemed after / equal / before / NULL; `filed_at`
+None; `transaction_timeliness='E'` exempts both txn and deemed; same-day
+boundary. One DB test: seed a non-E future txn + an E future txn + a same-day
+txn; assert the migration/guard flags only the non-E future row and leaves
+the E row + same-day row alone.
+
+## DoD (clauses 8-12) — executed post-#1710-window
+
+- Apply `sql/205` on dev; verify the source-rule invariant
+  `txn_date > sec_filing_manifest.filed_at::date AND transaction_timeliness
+  IS DISTINCT FROM 'E' AND NOT txn_date_invalid` → **0** (this catches the
+  past-but-future-at-filing rows the `> CURRENT_DATE` check misses).
+  Secondary operator-visible check: `txn_date > CURRENT_DATE AND NOT
+  txn_date_invalid` → **0**. Raw bad `txn_date` retained for audit; the 12
+  `E` rows untouched.
+- Run the observation backfill; verify
+  `ownership_insiders_observations` with `period_end > filed_at AND known_to
+  IS NULL AND <non-E>` → **0**; the 24 `E`-derived obs remain.
+- Smoke panel AAPL/GME/MSFT/JPM/HD insider endpoints render.
+- Cross-source: SEC EDGAR direct on one of the 21 accessions (raw
+  `<transactionDate>` already pulled — confirms typo).
+- Hit `/{symbol}/insider_transactions` + `/ownership-rollup` for an affected
+  instrument; confirm the future row no longer surfaces.

--- a/sql/205_insider_txn_date_invalid.sql
+++ b/sql/205_insider_txn_date_invalid.sql
@@ -1,0 +1,48 @@
+-- #1687 — guard against future-dated insider transaction dates.
+--
+-- Source rule: Securities Exchange Act §16(a) + Rule 16a-3(a)
+-- (17 CFR 240.16a-3(a)) + Form 4 General Instructions — a Form 4 is due
+-- before the end of the 2nd business day following the day the reportable
+-- transaction is executed, so the execution date precedes/equals the filing
+-- date. EXCEPTION: an early filing (EDGAR ownership XML
+-- transactionTimeliness='E'; see sql/057:262-265) may legitimately report a
+-- transaction dated after the filing. exercise_date / expiration_date are
+-- Table II derivative milestones that are legitimately future and are NOT
+-- touched.
+--
+-- Finding (#1687): the impossible txn_date is a FILER SOURCE TYPO carried
+-- verbatim in the raw <transactionDate><value> (75/75 retained payloads
+-- among the 80 non-E violators) — re-ingest cannot fix it, so we flag the
+-- row (txn_date stays NOT NULL, raw value retained for audit) and the
+-- operator-visible readers exclude flagged rows. deemed_execution_date is
+-- nullable, so a violation is quarantined to NULL (never invent).
+
+ALTER TABLE insider_transactions
+    ADD COLUMN IF NOT EXISTS txn_date_invalid BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN insider_transactions.txn_date_invalid IS
+    '#1687 — TRUE when txn_date postdates the SEC filing date (filed_at), '
+    'which Rule 16a-3(a) makes impossible for a non-early filing (a filer '
+    'source typo). The raw (impossible) txn_date is retained for audit; '
+    'operator-visible readers exclude flagged rows. An early filing '
+    '(transaction_timeliness=''E'') is exempt — its txn_date may legitimately '
+    'postdate the filing.';
+
+-- One-off cleanup: flag existing non-early future-dated rows. Anchored on
+-- the manifest filed_at (#1233 canonical); manifest-only is sufficient —
+-- 0 of the violators are unjoined to sec_filing_manifest (#1687 full-pop).
+UPDATE insider_transactions it
+SET txn_date_invalid = TRUE
+FROM sec_filing_manifest m
+WHERE m.accession_number = it.accession_number
+  AND it.txn_date > (m.filed_at AT TIME ZONE 'UTC')::date
+  AND it.transaction_timeliness IS DISTINCT FROM 'E'
+  AND it.txn_date_invalid = FALSE;
+
+-- One-off cleanup: quarantine impossible deemed_execution_date to NULL.
+UPDATE insider_transactions it
+SET deemed_execution_date = NULL
+FROM sec_filing_manifest m
+WHERE m.accession_number = it.accession_number
+  AND it.deemed_execution_date > (m.filed_at AT TIME ZONE 'UTC')::date
+  AND it.transaction_timeliness IS DISTINCT FROM 'E';

--- a/tests/test_insider_transactions.py
+++ b/tests/test_insider_transactions.py
@@ -11,7 +11,7 @@ covering both the happy and the ``None`` / missing paths.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 
 import pytest
@@ -21,6 +21,7 @@ from app.services.insider_transactions import (
     ParsedFiling,
     ParsedTransaction,
     _canonical_form_4_url,
+    evaluate_insider_date_validity,
     filer_role_string,
     parse_form_4_xml,
     parse_form_5_xml,
@@ -780,3 +781,57 @@ class TestParseForm5Xml:
         parsed = parse_form_5_xml(xml)
         assert parsed is not None
         assert parsed.document_type == "5"
+
+
+class TestEvaluateInsiderDateValidity:
+    """#1687 — Rule 16a-3(a) execution-date guard.
+
+    A Form 4 is due <= 2 business days after the transaction, so txn_date /
+    deemed_execution_date cannot postdate filed_at — except an early filing
+    (transaction_timeliness='E'), which may legitimately report a
+    future-dated transaction.
+    """
+
+    _FILED = datetime(2026, 6, 16, 20, 7, tzinfo=UTC)  # filed_at: 2026-06-16
+
+    @pytest.mark.parametrize(
+        ("txn_date", "expected_invalid"),
+        [
+            (date(2026, 6, 17), True),  # day after filing -> impossible
+            (date(2035, 1, 10), True),  # decade typo
+            (date(2026, 6, 16), False),  # same-day filing is valid
+            (date(2026, 6, 15), False),  # before filing
+            (date(2020, 1, 1), False),  # long before
+        ],
+    )
+    def test_txn_date_flagged_only_when_after_filed(self, txn_date, expected_invalid):
+        invalid, deemed = evaluate_insider_date_validity(txn_date, None, self._FILED, None)
+        assert invalid is expected_invalid
+        assert deemed is None
+
+    def test_early_filing_exempts_future_txn_date(self):
+        # transaction_timeliness='E' (early) -> future txn_date is legit.
+        invalid, deemed = evaluate_insider_date_validity(date(2026, 7, 1), date(2026, 7, 1), self._FILED, "E")
+        assert invalid is False
+        assert deemed == date(2026, 7, 1)
+
+    def test_no_filed_at_anchor_is_inert(self):
+        # No authoritative anchor -> never flag, never null.
+        invalid, deemed = evaluate_insider_date_validity(date(2035, 1, 10), date(2035, 1, 10), None, None)
+        assert invalid is False
+        assert deemed == date(2035, 1, 10)
+
+    @pytest.mark.parametrize(
+        ("deemed_in", "expected_out"),
+        [
+            (date(2026, 6, 17), None),  # after filing -> quarantine to NULL
+            (date(2026, 6, 16), date(2026, 6, 16)),  # same-day -> kept
+            (date(2026, 6, 15), date(2026, 6, 15)),  # before -> kept
+            (None, None),  # absent -> stays None
+        ],
+    )
+    def test_deemed_execution_date_nulled_only_when_after_filed(self, deemed_in, expected_out):
+        # txn_date itself is valid here; only the deemed column is assessed.
+        invalid, deemed = evaluate_insider_date_validity(date(2026, 6, 15), deemed_in, self._FILED, None)
+        assert invalid is False
+        assert deemed == expected_out

--- a/tests/test_insider_transactions_ingest.py
+++ b/tests/test_insider_transactions_ingest.py
@@ -29,11 +29,15 @@ import psycopg
 import pytest
 
 from app.services.insider_transactions import (
+    ParsedFiler,
+    ParsedFiling,
+    ParsedTransaction,
     get_insider_summary,
     ingest_insider_transactions,
     ingest_insider_transactions_backfill,
     ingest_insider_transactions_for_instrument,
     list_insider_transactions,
+    upsert_filing,
 )
 
 pytestmark = pytest.mark.integration
@@ -1238,3 +1242,156 @@ def test_fixture_imports_ok(ebull_test_conn: psycopg.Connection[tuple]) -> None:
             "insider_transaction_footnotes",
             "insider_transactions",
         ]
+
+
+# ---------------------------------------------------------------------
+# #1687 — future-dated txn_date guard (parse-time) + reader exclusion
+# ---------------------------------------------------------------------
+
+
+def _filer_1687() -> ParsedFiler:
+    return ParsedFiler(
+        filer_cik="0001000099",
+        filer_name="Jane Smith",
+        street1=None,
+        street2=None,
+        city=None,
+        state=None,
+        zip_code=None,
+        state_description=None,
+        is_director=True,
+        is_officer=False,
+        officer_title=None,
+        is_ten_percent_owner=False,
+        is_other=False,
+        other_text=None,
+    )
+
+
+def _txn_1687(
+    row_num: int,
+    txn_date: date,
+    *,
+    post: Decimal,
+    timeliness: str | None = None,
+    deemed: date | None = None,
+) -> ParsedTransaction:
+    return ParsedTransaction(
+        txn_row_num=row_num,
+        is_derivative=False,
+        filer_cik="0001000099",
+        security_title="Common Stock",
+        txn_date=txn_date,
+        deemed_execution_date=deemed,
+        txn_code="P",
+        equity_swap_involved=None,
+        transaction_timeliness=timeliness,
+        shares=Decimal("10"),
+        price=Decimal("5"),
+        acquired_disposed_code="A",
+        post_transaction_shares=post,
+        direct_indirect="D",
+        nature_of_ownership=None,
+        conversion_exercise_price=None,
+        exercise_date=None,
+        expiration_date=None,
+        underlying_security_title=None,
+        underlying_shares=None,
+        underlying_value=None,
+    )
+
+
+def _filing_1687(txns: tuple[ParsedTransaction, ...]) -> ParsedFiling:
+    return ParsedFiling(
+        document_type="4",
+        period_of_report=date(2026, 6, 15),
+        date_of_original_submission=None,
+        not_subject_to_section_16=None,
+        form3_holdings_reported=None,
+        form4_transactions_reported=None,
+        # Empty issuer_cik -> upsert_filing skips sibling resolution and
+        # records observations for the passed instrument_id only.
+        issuer_cik="",
+        issuer_name="Liquidity Services",
+        issuer_trading_symbol="LQDT",
+        remarks=None,
+        signature_name=None,
+        signature_date=None,
+        filers=(_filer_1687(),),
+        footnotes=(),
+        transactions=txns,
+    )
+
+
+class TestFutureDatedTxnDateGuard:
+    """#1687 — a txn_date that postdates filed_at (Rule 16a-3(a) makes this
+    impossible for a non-early filing) is flagged at parse time, excluded
+    from the operator list, and never wins the current ownership holding."""
+
+    _FILED = datetime(2026, 6, 16, 20, 7, tzinfo=UTC)
+    _ACC = "0001000099-26-000001"
+
+    def test_future_txn_flagged_excluded_and_loses_ownership(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        iid = _seed_instrument(ebull_test_conn, iid=1687, symbol="LQDT")
+        valid = _txn_1687(0, date(2026, 6, 15), post=Decimal("1000"))
+        future = _txn_1687(1, date(2035, 1, 10), post=Decimal("9999"))
+        upsert_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession_number=self._ACC,
+            primary_document_url="https://sec.gov/lqdt-form4.xml",
+            parsed=_filing_1687((valid, future)),
+            filed_at=self._FILED,
+        )
+        ebull_test_conn.commit()
+
+        # Both rows persist; only the impossible-date row is flagged.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT txn_date, txn_date_invalid FROM insider_transactions "
+                "WHERE accession_number = %s ORDER BY txn_row_num",
+                (self._ACC,),
+            )
+            rows = cur.fetchall()
+        assert rows == [
+            (date(2026, 6, 15), False),
+            (date(2035, 1, 10), True),
+        ]
+
+        # Operator list excludes the flagged row.
+        listed = list_insider_transactions(ebull_test_conn, instrument_id=iid)
+        assert [d.txn_date for d in listed] == [date(2026, 6, 15)]
+
+        # Current ownership winner is the valid txn, not the future typo.
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT shares, period_end FROM ownership_insiders_current WHERE instrument_id = %s",
+                (iid,),
+            )
+            current = cur.fetchall()
+        assert current == [(Decimal("1000"), date(2026, 6, 15))]
+
+    def test_early_filing_future_txn_is_kept(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        # transaction_timeliness='E' (early) -> a future txn_date is legit
+        # and must NOT be flagged or hidden.
+        iid = _seed_instrument(ebull_test_conn, iid=1688, symbol="EARLY")
+        early = _txn_1687(0, date(2026, 7, 1), post=Decimal("500"), timeliness="E")
+        upsert_filing(
+            ebull_test_conn,
+            instrument_id=iid,
+            accession_number="0001000099-26-000002",
+            primary_document_url="https://sec.gov/early-form4.xml",
+            parsed=_filing_1687((early,)),
+            filed_at=self._FILED,
+        )
+        ebull_test_conn.commit()
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT txn_date_invalid FROM insider_transactions WHERE accession_number = %s",
+                ("0001000099-26-000002",),
+            )
+            rows = cur.fetchall()
+        assert rows == [(False,)]
+        listed = list_insider_transactions(ebull_test_conn, instrument_id=iid)
+        assert [d.txn_date for d in listed] == [date(2026, 7, 1)]


### PR DESCRIPTION
## What

Future-dated `insider_transactions.txn_date` rows (e.g. LQDT `2035-01-10`, TMUS `2026-06-17`) are filer source typos. Adds a parse-time guard so they can never surface again + a one-off cleanup of existing rows. Closes #1687.

## Source rule

Securities Exchange Act **§16(a)** + **Rule 16a-3(a) (17 CFR 240.16a-3(a))** + **Form 4 General Instructions**: a Form 4 is due before the end of the 2nd business day *following* the reportable transaction ⇒ `txn_date <= filed_at` (same for `deemed_execution_date`).

**Exception — early filing.** EDGAR Ownership XML `transactionTimeliness='E'` (early; repo's settled treatment `sql/057:262-265`) may legitimately report a future-dated transaction. Exempt. `exercise_date`/`expiration_date` are Table II derivative milestones (legitimately future) — exempt.

Anchor = `sec_filing_manifest.filed_at` (SEC-stamped, #1233), UTC-anchored, strict `>` (same-day filing valid).

## Finding: filer typo, not parser bug (full-population)

The impossible date is carried **verbatim** in the raw `<transactionDate><value>` while the same filing's `periodOfReport`/`signatureDate` are correct. Full-pop check: of the 80 non-`E` `txn_date` violators, **75/75 with a retained payload** have the stored date present verbatim in the source XML; **0** parser-invented dates. Re-ingest cannot fix it → flag + cleanup (no invented value).

## Full-population verification (dev, 1,016,755 rows)

| Date column | `> filed_at` | of which `E` | treatment |
| --- | --- | --- | --- |
| `txn_date` | 92 | 12 (code-J, 14–18d gaps — LEGIT early) | flag the 80 non-E |
| `deemed_execution_date` | 19 | 0 | NULL the 19 |
| `exercise_date` | 14,851 | — | exempt (legit future) |
| `expiration_date` | 92,663 | — | exempt (legit future) |

## Change

- **`sql/205`** — add `insider_transactions.txn_date_invalid BOOLEAN NOT NULL DEFAULT FALSE` (`txn_date` is NOT NULL ⇒ flag + retain raw for audit). One-off backfill flags the 80 non-E rows and NULLs the 19 impossible `deemed_execution_date` values.
- **`evaluate_insider_date_validity()`** (pure) applies the invariant; wired into `upsert_filing` to sanitise parsed txns once `filed_at` is resolved, **before** the DB insert **and** the ownership write-through.
- **Ownership write-through** (`_record_form4_observations_for_filing`) skips flagged txns so a typo cannot win the latest-per-group holding (`period_end = txn_date`, `period_end DESC`) or write a future `period_end` into `ownership_insiders_current`.
- **Readers exclude flagged rows:** `get_insider_summary` (MAX + 90d window), `list_insider_transactions` (ORDER BY txn_date DESC), `sync_insiders`, `holder_name_resolver.resolve_holder_to_filer` (DEF14A-drift / ownership-rollup latest-balance match).

## Security / data model

No auth surface change. Data-treatment is conservative: the raw bad `txn_date` is **retained** (audit), never invented or clamped; `deemed_execution_date` (nullable) is quarantined to NULL. No `_PARSER_VERSION` bump (cleanup is targeted SQL; no mass re-ingest, no `sec_rebuild`). Existing daemon (pre-restart) keeps writing via the column DEFAULT — no break.

## Tradeoff

This PR fixes the txn-level data + all live read/write paths. Already-written contaminated **ownership observations** (126 `period_end > filed_at`, of which 24 are legit-`E`) are corrected by a post-merge backfill (supersede the 102 non-E contaminated obs + re-run `sync_insiders`/`refresh_insiders_current`), per the spec — not `sec_rebuild`. Sequenced after the in-flight #1710 scheduler-window proof (no daemon restart before then).

## Verification (clauses 8-12)

- Gates @ `3cae6571`: `ruff check`/`ruff format`/`pyright` clean; `pytest -m "not db"` 4436 passed; `tests/smoke` 129 passed; affected DB tests (guard + ownership sync + holder resolver + rollup) green.
- Dev migration applied (via smoke): **80 flagged**, **12 `E` untouched**, source-rule invariant `txn_date > filed_at AND ≠ 'E' AND NOT txn_date_invalid` = **0**, operator-visible `txn_date > CURRENT_DATE AND NOT txn_date_invalid` = **0**.
- Cross-source: SEC EDGAR direct on accession `0000950170-25-004920` — raw `<transactionDate><value>2035-01-10` vs `periodOfReport 2025-01-10` (typo confirmed).
- **Pending post-#1710-window:** daemon restart onto merge commit, observation supersede+refresh backfill, smoke-panel AAPL/GME/MSFT/JPM/HD insider + ownership-rollup endpoints. Will record SHAs on completion.

## Tests

- Pure table-test of `evaluate_insider_date_validity` (after/equal/before filed, deemed null, None filed_at, `E` exemption, same-day boundary).
- DB test: future + valid + early txns through `upsert_filing` → asserts flag write, list exclusion, and that the valid txn (not the future typo) wins `ownership_insiders_current`.
