### PR TITLE
test(#1331): pin multixact stub surface to psycopg ABC + probe-drift guard

### DIFF
--- a/tests/runbooks/test_safety_multixact.py
+++ b/tests/runbooks/test_safety_multixact.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+import psycopg
 import pytest
 
 from app.runbooks.safety import RunbookRefused, assert_no_multixact_wraparound
@@ -52,6 +53,22 @@ class _StubCursor:
 
 class _StubConn:
     """Minimal psycopg.Connection stub for unit-testing safety probes.
+
+    Surface contract (#1331): this stub implements ONLY the connection
+    surface ``assert_no_multixact_wraparound`` actually uses
+    (``conn.execute(...)`` -> ``.fetchone()`` / ``.fetchall()``). It is
+    deliberately NOT a full ``psycopg.Connection`` — the call sites pass
+    it with ``# type: ignore[arg-type]``, an intentional stub
+    substitution rather than a masked row-factory bug (cf.
+    review-prevention-log "type: ignore[arg-type] masking a psycopg
+    Connection row-factory mismatch": the stub returns tuple rows, so
+    nothing is masked). The two ``test_stub_*`` guards below pin this
+    surface so a future probe that drifts to an unstubbed surface (e.g.
+    ``conn.cursor()``) fails loudly instead of silently passing, and so
+    the stub can never claim a method ``psycopg`` does not have. Per
+    settled-decisions "do not shape production APIs around test
+    convenience", the probe signature stays ``psycopg.Connection`` — we
+    pin the stub to that surface, not the reverse.
 
     Each .execute() pops the next canned response from a queue. Tests
     set up the queue to mirror the exact sequence of cursors returned
@@ -161,3 +178,56 @@ def test_refuses_lists_multiple_breaching_tables() -> None:
     msg = exc_info.value.msg
     assert "job_runtime_heartbeat" in msg
     assert "broker_credentials" in msg
+
+
+# ---------------------------------------------------------------------------
+# Stub-surface guards (#1331): keep the stub honest against the real probe
+# and the real ``psycopg`` ABC, so the four ``# type: ignore[arg-type]``
+# substitutions above can never silently mask probe/API drift.
+# ---------------------------------------------------------------------------
+
+
+def test_probe_drifting_to_unstubbed_surface_fails_loud() -> None:
+    """A probe reaching for a connection surface the stub does not
+    implement (e.g. ``conn.cursor()``) must FAIL loudly, never silently
+    pass.
+
+    The current ``assert_no_multixact_wraparound`` uses only
+    ``conn.execute(...)``. If a future revision drifts to
+    ``conn.cursor().execute(...).fetchmany(...)``, the stub — which has
+    no ``cursor`` attribute — raises ``AttributeError`` and the suite
+    breaks, forcing the stub to be consciously extended (which in turn
+    re-trips this guard). This is the #1331 acceptance criterion and a
+    tripwire against a future too-permissive stub (e.g. a blanket
+    ``__getattr__`` returning a mock) that would let drift pass green.
+    """
+
+    def _drifted_probe(conn: Any) -> None:
+        cur = conn.cursor()  # surface the stub deliberately does not provide
+        cur.execute("SELECT 1")
+        cur.fetchmany(5)
+
+    conn = _StubConn([(1,)])
+    with pytest.raises(AttributeError):
+        _drifted_probe(conn)
+
+
+def test_stub_surface_is_subset_of_real_psycopg_abc() -> None:
+    """Every public method the stubs implement must exist on the real
+    ``psycopg`` class they stand in for.
+
+    The stubs may implement FEWER methods than ``psycopg.Connection`` /
+    ``psycopg.Cursor`` (they only need the probe's surface), but never a
+    method ``psycopg`` lacks — otherwise the suite would pin the probe
+    against a contract a live Postgres connection cannot honour, and the
+    ``# type: ignore[arg-type]`` would be hiding a genuine API mismatch
+    rather than a benign substitution.
+    """
+    conn_surface = {name for name in vars(_StubConn) if not name.startswith("_")}
+    cursor_surface = {name for name in vars(_StubCursor) if not name.startswith("_")}
+
+    conn_extra = conn_surface - set(dir(psycopg.Connection))
+    cursor_extra = cursor_surface - set(dir(psycopg.Cursor))
+
+    assert not conn_extra, f"_StubConn methods absent from psycopg.Connection: {conn_extra}"
+    assert not cursor_extra, f"_StubCursor methods absent from psycopg.Cursor: {cursor_extra}"


### PR DESCRIPTION
## What
`tests/runbooks/test_safety_multixact.py`'s `_StubConn` / `_StubCursor` duck-type **only** the surface `assert_no_multixact_wraparound` currently uses (`conn.execute(...)` → `.fetchone()` / `.fetchall()`), passed at the call sites with `# type: ignore[arg-type]`. A future probe revision that drifts to an unstubbed surface (e.g. `conn.cursor().execute(...).fetchmany(...)`), or a future too-permissive stub (e.g. a blanket `__getattr__`), could pass these tests **silently** while breaking against a live Postgres connection (committee Test Engineer lens IM-2, 2026-05-25).

Adds two pure-logic guard tests — no production change:

- **`test_probe_drifting_to_unstubbed_surface_fails_loud`** — a synthetic probe using `conn.cursor()` raises `AttributeError` against the stub. This is the issue's acceptance criterion, and a tripwire: extending the stub's surface later re-trips it, forcing a conscious update.
- **`test_stub_surface_is_subset_of_real_psycopg_abc`** — every public method the stubs define must exist on `psycopg.Connection` / `psycopg.Cursor`, so the stub can never pin the probe to a method live PG lacks.

Plus a `_StubConn` docstring note documenting the deliberate `# type: ignore[arg-type]` substitution and these guards.

## Why test-only (the 1759 vs settled-decision call)
- **prevention-log "`type: ignore[arg-type]` masking a psycopg Connection row-factory mismatch" (#1583)** says never `type: ignore[arg-type]` a psycopg Connection arg. That rule targets **production** code where a real `dict_row` connection would `KeyError` at runtime. Here the stub returns **tuple** rows the probe reads positionally — nothing is masked; it's a deliberate, visible test substitution.
- **settled-decisions "do not shape production APIs around test convenience"** — narrowing the probe signature to a `Protocol` solely so a stub satisfies it would reshape prod typing for the test. Rejected.
- Resolution: keep `assert_no_multixact_wraparound(conn: psycopg.Connection[object])` (1 prod caller, passes a real connection), retain the localized `# type: ignore`, and **pin the stub surface with runtime guards** instead. Codex ckpt-2 independently agreed.

## Verification (commit f87bd98b)
- `tests/runbooks/test_safety_multixact.py`: **6 passed** (4 existing + 2 new).
- Guards proven **non-vacuous**: a planted non-psycopg method (`frobnicate`) is flagged by guard 2; `_StubConn` genuinely lacks `cursor` so guard 1's drift raises for the right reason.
- Pure-logic (fast tier, not db-marked). Gates: ruff ✓, ruff format ✓, **pyright 0 errors**, fast tier **4438 passed**, smoke **129 passed**.
- Codex ckpt-2: no real findings.

## Security model
None affected — test-only, no production code, no schema, no runtime path.

## Tradeoffs
- Guards pin **method-name** surface, not signature/semantic parity for same-named methods (a same-named-but-wrong-shape stub method would slip) — out of scope for this guard's purpose and not a correctness blocker (Codex-confirmed). The existing behavioural tests already pin call semantics.

Closes #1331.