### PR TITLE
docs(#1321): operator FAQ for forms NOT ingested by the manifest + doc↔code pin

### DIFF
--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -201,6 +201,13 @@ SEC_PARSE_AND_RAW: frozenset[str] = frozenset(
 # Tier 2 — metadata-only. No parser, no raw body. filing_events row
 # costs ~200 bytes; cheap insurance for future parsers + ad-hoc
 # operator queries. See spec for per-form rationale (Codex round 1).
+#
+# Scope: this is the ``filing_events`` (refresh_filings) tier classification
+# ONLY — independent of the manifest worker's ``_FORM_TO_SOURCE`` ingest map
+# (sec_manifest.py). A form may be metadata-only HERE yet still be ingested by
+# the manifest worker: ``5`` / ``5/A`` are listed below AND mapped to
+# ``sec_form5`` (parsed via manifest_parsers/insider_345). Do not treat the two
+# sets as disjoint. Operator FAQ on unmapped forms: docs/etl/sources/README.md.
 SEC_METADATA_ONLY: frozenset[str] = frozenset(
     {
         # Late-filing red flags — restatement / auditor-change signal.

--- a/app/services/sec_manifest.py
+++ b/app/services/sec_manifest.py
@@ -1055,7 +1055,18 @@ def map_form_to_source(form: str) -> ManifestSource | None:
     Returns ``None`` for unsupported forms (e.g. ``S-1``, ``424B5``,
     ``CORRESP``) — the discovery paths skip these. Matching is exact;
     callers must canonicalise spacing first (SEC sometimes emits
-    ``13F-HR`` and sometimes ``13F-HR  `` with trailing whitespace)."""
+    ``13F-HR`` and sometimes ``13F-HR  `` with trailing whitespace).
+
+    The intentionally-unmapped forms and the rationale for each (operator
+    FAQ: "where is 6-K?") live in ``docs/etl/sources/README.md`` §"Forms NOT
+    ingested by the manifest + why". Most are recorded as a metadata-only
+    ``filing_events`` row — see ``SEC_METADATA_ONLY`` in
+    ``app/services/filings.py`` — which is a SEPARATE taxonomy from this map
+    (a form can be in both: ``5``/``5/A`` are metadata-only at the
+    ``filing_events`` tier yet mapped here to ``sec_form5``). ``13F-NT`` is
+    deliberately unmapped (notice-only, no holdings) — see
+    ``docs/review-prevention-log.md`` for the stale-parent double-count gap
+    that drop creates."""
     return _FORM_TO_SOURCE.get(form.strip())
 
 

--- a/docs/etl/sources/README.md
+++ b/docs/etl/sources/README.md
@@ -41,6 +41,38 @@ CI gate: `scripts/check_etl_source_docs.sh` enforces.
 
 ---
 
+## Forms NOT ingested by the manifest + why
+
+`map_form_to_source` (`app/services/sec_manifest.py`) returns `None` for any
+form absent from `_FORM_TO_SOURCE`, and the discovery paths skip it. That is
+intentional for the forms below. "Where instead" names the pipeline that *does*
+recognise the form, if any — most are recorded as a metadata-only
+`filing_events` row (`SEC_METADATA_ONLY` in `app/services/filings.py`), which is
+a **different taxonomy** from the manifest source map: a form can be
+metadata-only at the `filing_events` tier yet still be ingested by the manifest
+worker (Form 5 is — see note).
+
+| Form(s) | Why no manifest source | Where instead |
+|---|---|---|
+| `6-K`, `6-K/A` | Foreign private issuer interim report — no manifest parser, and deliberately excluded from fundamentals (typically lacks structured XBRL, so companyfacts yields no new rows — `FUNDAMENTALS_FORMS` in `app/services/fundamentals/__init__.py`). | `filing_events` metadata-only. |
+| `20-F`, `20-F/A`, `40-F`, `40-F/A` | Foreign private issuer annual — no manifest ownership/insider parser. **Fundamentals ARE ingested** for these, but via the companyfacts (`sec_xbrl_facts`) path keyed by CIK (`FUNDAMENTALS_FORMS`), not by form→source discovery. | Fundamentals: companyfacts / XBRL; `filing_events` metadata-only otherwise. |
+| `S-1`, `S-3`, `S-4`, `F-1/3/4`, `424B2/3/4/5/7/8` | Registration / prospectus capital-action filings — no ownership, fundamentals, or insider payload to parse. | New-instrument discovery is via `company_tickers`, not form discovery; `filing_events` metadata-only. |
+| `PRE 14A`, `PRER14A` | Preliminary proxy **drafts** (#1320) — the definitive `DEF 14A` that follows is what we ingest; mapping the draft seeded 6k+ rows the parser then tombstoned. | `filing_events` metadata-only; the `DEF 14A` → `sec_def14a`. |
+| `13F-NT`, `13F-NT/A` | Institutional **notice-only** (manager reports nothing this quarter) — no holdings table. | `filing_events` metadata-only, used for institutional-filer classification. **Note:** dropping NT at discovery is the known gap behind stale-parent 13F double-counts — see `docs/review-prevention-log.md` (Vanguard/AAPL). |
+| `144` | Proposed restricted-share sale notice — intent, not an executed transaction. | `filing_events` metadata-only (insider-overhang signal). |
+| `11-K` | Employee stock-purchase-plan annual report — no instrument-level ownership. | `filing_events` metadata-only. |
+| `25`, `25-NSE`, `15-12B/12G/15D`, `15F*` | Delisting / deregistration — terminal-state signal, no recurring data. | `filing_events` metadata-only. |
+| `CORRESP` | SEC ↔ filer correspondence — free text, no structured data. | `filing_events` metadata-only (rare red-flag signal). |
+| `D`, `D/A` | Private-placement notice (Reg D) — irrelevant to public-equity investing. | Dropped entirely (not even `filing_events`). |
+
+> **Form 5 is the exception that proves the two-taxonomy split:** `5` / `5/A`
+> are `SEC_METADATA_ONLY` at the `filing_events` tier **and** mapped in
+> `_FORM_TO_SOURCE` → `sec_form5` (the manifest worker parses them via
+> `manifest_parsers/insider_345._parse_form5`). The two sets are independent
+> axes; do not assume disjointness.
+
+---
+
 ## Template — required sections per source file
 
 ```markdown

--- a/tests/test_sec_manifest.py
+++ b/tests/test_sec_manifest.py
@@ -829,7 +829,7 @@ class TestFormMapping:
             "11-K",
             "25",
             "25-NSE",
-            "15F",
+            "15F-12B",
             "CORRESP",
             "D",
             "D/A",

--- a/tests/test_sec_manifest.py
+++ b/tests/test_sec_manifest.py
@@ -799,6 +799,45 @@ class TestFormMapping:
         assert map_form_to_source("CORRESP") is None
         assert map_form_to_source("") is None
 
+    def test_documented_unmapped_forms_stay_none(self) -> None:
+        """#1321: representative forms the operator FAQ documents as
+        intentionally NOT ingested (docs/etl/sources/README.md §"Forms NOT
+        ingested by the manifest + why") must return None. Pins the doc↔code
+        contract so a future accidental ``_FORM_TO_SOURCE`` addition trips this
+        test instead of silently contradicting the README. Uses real SEC form
+        codes (e.g. ``D``, not the colloquial "Form D")."""
+        documented_unmapped = [
+            "6-K",
+            "6-K/A",
+            "20-F",
+            "20-F/A",
+            "40-F",
+            "40-F/A",
+            "S-1",
+            "S-3",
+            "S-4",
+            "F-1",
+            "F-3",
+            "F-4",
+            "424B3",
+            "424B5",
+            "PRE 14A",
+            "PRER14A",
+            "13F-NT",
+            "13F-NT/A",
+            "144",
+            "11-K",
+            "25",
+            "25-NSE",
+            "15F",
+            "CORRESP",
+            "D",
+            "D/A",
+        ]
+        mapped = {f: map_form_to_source(f) for f in documented_unmapped}
+        offenders = {f: src for f, src in mapped.items() if src is not None}
+        assert offenders == {}, f"forms documented as unmapped in README now map to a source: {offenders}"
+
     def test_pre_14a_is_not_mapped(self) -> None:
         """#1320: PRE 14A (preliminary proxy) is a metadata-only draft — it
         must NOT route to sec_def14a. Mapping it seeded 6k+ preliminary


### PR DESCRIPTION
## What

`map_form_to_source` returns `None` for any SEC form absent from `_FORM_TO_SOURCE`, and discovery silently skips it. The per-form rationale ("operator asks: where is 6-K?") lived nowhere operator-facing. This adds it.

- **`docs/etl/sources/README.md`** — new **"Forms NOT ingested by the manifest + why"** table. Each row: the form(s), why there's no manifest source, and where the form IS handled instead (mostly `filing_events` metadata-only). Covers 6-K/20-F/40-F, S-/F-/424B*, PRE 14A, 13F-NT, 144, 11-K, delisting (25/15) family, CORRESP, D.
- **`app/services/sec_manifest.py`** — `map_form_to_source` docstring now points to the README + `SEC_METADATA_ONLY` + the 13F-NT double-count prevention-log entry.
- **`app/services/filings.py`** — clarify `SEC_METADATA_ONLY` is the `filing_events`-tier taxonomy, **independent** of `_FORM_TO_SOURCE` (Form 5 is in both: events-metadata yet manifest-parsed). Prevents the "these two sets contradict!" misread.
- **`tests/test_sec_manifest.py`** — doc↔code pin: representative documented-unmapped forms must return `None`, so a future accidental `_FORM_TO_SOURCE` addition trips the test instead of silently contradicting the README.

## Why this shape (rebuttals of the issue's literal asks)

The issue (committee Data Engineer IMP-3) proposed a new `_INTENTIONALLY_UNSUPPORTED_FORMS` frozenset, a `map_form_to_source` short-circuit, and (by implication) a disjointness invariant. All three rejected with grounds:

1. **New frozenset → REBUTTED.** The forms are already enumerated in `SEC_METADATA_ONLY` (`filings.py`). A second hand-maintained list is a third source of truth — violates the global "single source of truth for constants" rule.
2. **Short-circuit `map_form_to_source` "faster + traceable" → REBUTTED.** `_FORM_TO_SOURCE.get(form.strip())` already returns `None` in O(1). A pre-check adds zero speed and a dual-truth drift hazard.
3. **Disjointness invariant (`SEC_METADATA_ONLY ∩ _FORM_TO_SOURCE.keys() = ∅`) → REBUTTED as unsound.** Verified full-population: `5`/`5/A` are legitimately in **both** — events-tier metadata-only AND manifest-parsed (`manifest_parsers/insider_345._parse_form5`, 12,883 rows on dev). The two constants measure independent axes.

## Security model
None affected — docs, docstrings, one comment, one pure-logic test. No auth/SQL/data path.

## Codex checkpoint-2
Rebuttals confirmed sound. 3 minor findings fixed before push:
- `20-F`/`40-F` ARE in `FUNDAMENTALS_FORMS` (companyfacts ingests them) — narrowed the README claim; only `6-K` is fundamentals-inert.
- Real SEC code is `D`/`D/A`, not colloquial "Form D" — fixed README + test pin (was vacuous).
- Softened test docstring "every" → "representative".

## Verification
- `uv run ruff check` / `ruff format --check` / `pyright` — clean.
- Fast tier `-m "not db"`: 4438 passed (unchanged — the new test is in the `db`-marked module with its `map_form_to_source` siblings).
- `tests/smoke`: 129 passed.
- New pin test: 1 passed (all 26 representative forms incl `D`/`D/A` confirmed `None`).
- ETL DoD clauses 8-12 (smoke-3-instruments / backfill / rollup endpoint) **N/A** — no parser/schema/data-path change.

Closes #1321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)