### PR TITLE
test(#1486): guard bootstrap-stage lane vocab across all 4 definitions

### DIFF
--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -61,12 +61,17 @@ Lane = Literal[
     "db_ownership_inst",
     "db_ownership_insider",
     "db_ownership_funds",
+    "openfigi",
 ]
 """Row-shape Literal for ``bootstrap_stages.lane`` reads. Mirrors
 ``app/jobs/sources.py::Lane`` plus the legacy ``"sec"`` catch-all
 preserved for pre-#1020 rows. New family lanes added by #1141 /
 Task E of #1136 audit (see
-``docs/superpowers/specs/2026-05-13-db-lane-family-split.md``)."""
+``docs/superpowers/specs/2026-05-13-db-lane-family-split.md``).
+``"openfigi"`` added by #1233 PR-1b (S13 CUSIP resolver sweep lane) —
+mirrored here from ``sources.py::Lane`` + ``LaneApi`` + sql/165; the
+#1486 guard (``tests/test_bootstrap_lane_consistency.py``) keeps this
+Literal a superset of every writable bootstrap-stage lane."""
 
 
 class BootstrapAlreadyRunning(RuntimeError):

--- a/tests/test_bootstrap_lane_consistency.py
+++ b/tests/test_bootstrap_lane_consistency.py
@@ -1,0 +1,149 @@
+"""#1486 — guard the four parallel bootstrap-stage lane vocabularies.
+
+Four independent definitions describe ``bootstrap_stages.lane`` and can
+silently drift:
+
+* ``app/jobs/sources.py::Lane`` — the full lane vocabulary (superset).
+* ``app/api/bootstrap.py::LaneApi`` — API row-shape Literal.
+* ``app/services/bootstrap_state.py::Lane`` — read row-shape Literal.
+* the ``bootstrap_stages_lane_check`` CHECK constraint (sql/NNN).
+
+``LaneApi`` and ``bootstrap_state.Lane`` are deliberately NOT equal to
+``Lane``: they carry a legacy ``"sec"`` catch-all and omit
+non-bootstrap scheduled lanes (``finra``, ``bootstrap``, ``sec_manifest``,
+the per-CIK / insider lanes). So a naive ``set(LaneApi.__args__) ==
+set(Lane.__args__)`` test is WRONG (false-fails today).
+
+The *correct* invariant (issue #1486): every lane that can be WRITTEN to
+``bootstrap_stages.lane`` — i.e. every ``_effective_lane`` of a stage in
+``_BOOTSTRAP_STAGE_SPECS`` (consulting ``_STAGE_LANE_OVERRIDES``) — MUST
+be a member of all three downstream definitions. A new bootstrap-stage
+lane added to ``sources.py::Lane`` + overrides but forgotten in a
+row-shape Literal or the CHECK allow-list would surface as a runtime
+CHECK violation (not caught at boot). ``"openfigi"`` (#1233 PR-1b S13)
+was exactly such a miss in ``bootstrap_state.Lane`` until this guard.
+
+DB-free: the CHECK allow-list is parsed from the migration files on
+disk (last-defining migration wins, mirroring apply order), so no
+Postgres connection is required.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import get_args
+
+from app.api.bootstrap import LaneApi
+from app.db.migrations import MIGRATIONS_DIR
+from app.jobs.sources import Lane as SourcesLane
+from app.services.bootstrap_state import Lane as StateLane
+
+_LANE_CHECK_CONSTRAINT = "bootstrap_stages_lane_check"
+
+
+def _effective_bootstrap_lanes() -> frozenset[str]:
+    """The lanes actually writable to ``bootstrap_stages.lane`` — the
+    source of truth every downstream definition must cover.
+
+    Imports are lazy: ``app.services.bootstrap_orchestrator`` sits behind a
+    ``insider_transactions`` <-> ``manifest_parsers`` import cycle that only
+    resolves once ``manifest_parsers`` is imported first (repo idiom — see
+    ``tests/test_manifest_parser_eight_k.py``). A module-level import would
+    fail collection in isolation."""
+    import app.services.manifest_parsers  # noqa: F401  # break the import cycle first
+    from app.services.bootstrap_orchestrator import (
+        _BOOTSTRAP_STAGE_SPECS,
+        _effective_lane,
+    )
+
+    return frozenset(_effective_lane(s.stage_key, s.lane) for s in _BOOTSTRAP_STAGE_SPECS)
+
+
+def _sql_lane_check_allow_list() -> frozenset[str]:
+    """Parse the ``bootstrap_stages_lane_check`` allow-list from the
+    last migration that (re)defines it. Migrations apply in lexicographic
+    filename order, so the highest-numbered defining file is the live
+    constraint — same resolution the runtime DB ends up with.
+
+    Guards against a stale parse: if any migration AFTER the last
+    ``ADD CONSTRAINT`` drops the constraint without re-adding it, the
+    runtime DB has no allow-list to check against, so this helper must
+    fail loudly rather than return the obsolete set (Codex #1486)."""
+    files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    add_re = re.compile(r"ADD\s+CONSTRAINT\s+" + _LANE_CHECK_CONSTRAINT)
+    drop_re = re.compile(r"DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?" + _LANE_CHECK_CONSTRAINT)
+
+    last_add_idx = next(
+        (i for i in range(len(files) - 1, -1, -1) if add_re.search(files[i].read_text(encoding="utf-8"))),
+        None,
+    )
+    assert last_add_idx is not None, (
+        f"no migration defines CONSTRAINT {_LANE_CHECK_CONSTRAINT} in {MIGRATIONS_DIR} — "
+        "the parser would otherwise vacuously pass; check the constraint name / migration layout"
+    )
+    last = files[last_add_idx]
+    orphaning_drops = [
+        files[i].name
+        for i in range(last_add_idx + 1, len(files))
+        if drop_re.search(files[i].read_text(encoding="utf-8"))
+    ]
+    assert not orphaning_drops, (
+        f"CONSTRAINT {_LANE_CHECK_CONSTRAINT} is DROPped after its last ADD "
+        f"(in {last.name}) by {orphaning_drops} with no re-add — the live DB has no "
+        "lane allow-list, so this guard cannot verify the SQL side; re-add the "
+        "constraint or update the guard."
+    )
+    block = re.search(
+        r"ADD\s+CONSTRAINT\s+" + _LANE_CHECK_CONSTRAINT + r"\s+CHECK\s*\(\s*lane\s+IN\s*\((.*?)\)\s*\)",
+        last.read_text(encoding="utf-8"),
+        re.S,
+    )
+    assert block is not None, f"could not parse the lane IN (...) allow-list from {last.name}"
+    tokens = frozenset(re.findall(r"'([^']+)'", block.group(1)))
+    assert tokens, f"lane CHECK allow-list parsed empty from {last.name}"
+    return tokens
+
+
+def test_effective_lane_set_is_nonempty() -> None:
+    """Non-vacuity guard: the subset assertions below are meaningless if
+    no stage resolves a lane."""
+    assert _effective_bootstrap_lanes(), "_BOOTSTRAP_STAGE_SPECS resolved zero effective lanes"
+
+
+def test_every_writable_lane_is_in_sources_lane_literal() -> None:
+    """``Lane`` is the full vocabulary — it must contain every effective
+    bootstrap-stage lane (else ``JobLock`` source resolution KeyErrors)."""
+    missing = _effective_bootstrap_lanes() - set(get_args(SourcesLane))
+    assert not missing, f"effective bootstrap-stage lanes missing from sources.py::Lane: {sorted(missing)}"
+
+
+def test_every_writable_lane_is_in_lane_api_literal() -> None:
+    missing = _effective_bootstrap_lanes() - set(get_args(LaneApi))
+    assert not missing, f"effective bootstrap-stage lanes missing from bootstrap.py::LaneApi: {sorted(missing)}"
+
+
+def test_every_writable_lane_is_in_bootstrap_state_lane_literal() -> None:
+    missing = _effective_bootstrap_lanes() - set(get_args(StateLane))
+    assert not missing, (
+        f"effective bootstrap-stage lanes missing from bootstrap_state.py::Lane: {sorted(missing)} "
+        "(this was the #1486 'openfigi' gap)"
+    )
+
+
+def test_every_writable_lane_is_in_sql_check_allow_list() -> None:
+    missing = _effective_bootstrap_lanes() - _sql_lane_check_allow_list()
+    assert not missing, (
+        f"effective bootstrap-stage lanes missing from the bootstrap_stages_lane_check "
+        f"CHECK allow-list: {sorted(missing)} — a persist would raise a runtime CHECK violation"
+    )
+
+
+def test_openfigi_is_an_effective_lane_and_covered_everywhere() -> None:
+    """Regression pin for the #1486 gap: ``openfigi`` (S13 CUSIP sweep)
+    is a real writable lane and must be present in all four definitions.
+    Guards against a future edit silently dropping it from any one."""
+    assert "openfigi" in _effective_bootstrap_lanes()
+    assert "openfigi" in set(get_args(SourcesLane))
+    assert "openfigi" in set(get_args(LaneApi))
+    assert "openfigi" in set(get_args(StateLane))
+    assert "openfigi" in _sql_lane_check_allow_list()

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -878,7 +878,13 @@ def _make_fake_conn(
 
 
 class TestComputeScore:
-    def test_full_fixture_produces_valid_result(self) -> None:
+    def test_full_fixture_produces_valid_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # compute_score reads wall-clock via scoring._utcnow(); pin it to
+        # the fixture's anchor so thesis-age math is deterministic. Without
+        # this the _RECENT (=_NOW-10d) thesis crosses the 90-day stale
+        # threshold once real time passes _NOW+80d, flipping penalties to a
+        # one-item list (date-bomb #1720).
+        monkeypatch.setattr("app.services.scoring._utcnow", lambda: _NOW)
         conn = _make_fake_conn(
             fund_rows=[
                 _fund_row(0.18, 0.55, 200_000.0, -50_000.0, 100_000.0, 1_100_000.0, 10_000_000.0),


### PR DESCRIPTION
## What
DB-free guard pinning the four parallel definitions of `bootstrap_stages.lane` so they can't silently drift, plus the one real gap it surfaced.

The four vocabularies:
- `app/jobs/sources.py::Lane` — full lane vocabulary (superset)
- `app/api/bootstrap.py::LaneApi` — API row-shape Literal
- `app/services/bootstrap_state.py::Lane` — read row-shape Literal
- `bootstrap_stages_lane_check` CHECK constraint (sql/165, last-defining)

## Invariant (per #1486)
Every lane **writable** to `bootstrap_stages.lane` — i.e. every `_effective_lane(stage)` for a stage in `_BOOTSTRAP_STAGE_SPECS` (consulting `_STAGE_LANE_OVERRIDES`) — MUST be a member of all three downstream defs **and** the CHECK allow-list.

**Subset, not equality.** `LaneApi` / `bootstrap_state.Lane` deliberately carry a legacy `sec` catch-all and omit non-bootstrap scheduled lanes (`finra`, `bootstrap`, `sec_manifest`, per-CIK/insider). A naive `set(LaneApi.__args__) == set(Lane.__args__)` test false-fails today — the issue called this out and this guard avoids it.

## Real gap fixed
Full-population enumeration (the 11 current effective lanes) found `openfigi` (#1233 PR-1b, S13 CUSIP resolver sweep) present in `sources.py::Lane` + `LaneApi` + sql/165 but **MISSING from `bootstrap_state.Lane`**. Added it.

- Pure typing change: `bootstrap_state.Lane` is annotation-only (`lane: Lane` at lines 156/180 of `bootstrap_state.py`) — **no runtime membership check**, so byte-identical runtime behaviour.
- **No daemon restart / no backfill** — does not touch parsing or storage of any ownership/filings data. (ETL/schema DoD clauses 8-12 N/A.)

## Guard design
- Source of truth derived from `_effective_lane` over `_BOOTSTRAP_STAGE_SPECS` (not a hand-pinned list) → can't drift from the stage catalogue.
- CHECK allow-list parsed from the **last-defining migration** (lexicographic = apply order), so a future widening is picked up automatically — not pinned to sql/165.
- Non-vacuity guards: fails loudly if zero effective lanes resolve, if no migration defines the constraint, or if the allow-list parses empty.
- **Codex ckpt-2 finding addressed**: guard now fails loudly if a migration DROPs the constraint after its last ADD without re-adding (false-green risk). Proved non-vacuous against a synthetic later-drop migration.
- DB-free → stays in fast tier (not `db`-marked). Import cycle (`insider_transactions` ↔ `manifest_parsers`) handled via lazy import per repo idiom.

## Bundled: #1720 (red-on-main date-bomb)
The fast-tier gate was already red on main: `test_scoring::test_full_fixture_produces_valid_result` omits a `now=` injection, so its `_NOW-10d` thesis crossed the 90-day `stale_thesis` threshold on 2026-06-24. Pinned `scoring._utcnow` to `_NOW` in that test. Filed as #1720; folded here because the hook blocked all pushes until green. Closes #1720.

## Verification
- `tests/test_bootstrap_lane_consistency.py`: 6 passed; mutation-tested (stripping `openfigi` from `bootstrap_state.Lane` → 2 fail as expected; synthetic later-drop migration → orphan-drop guard fires).
- Fast tier: 4444 passed, 10 skipped. Smoke: 129 passed. ruff/format/pyright clean.

Refs #1486, #1485 (review PREVENTION). Closes #1486, closes #1720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)