### PR TITLE
perf(#1436): stream whole-file TSV loads + chunk unresolved_cusip buffers in 13F/N-PORT bulk ingest

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -522,6 +522,28 @@ cur.execute("""
 
 **Cancel observation cost**: per-row INSERT used to checkpoint operator-cancel at sub-second latency. COPY drains atomically per archive (10-60s on multi-million-row archives). Operator cancel is observed at the archive boundary; the trade-off is documented in spec §7 and accepted (the throughput gain is ~30× for first-install bootstrap, which is the dominant cost driver).
 
+**A live `cur.copy()` owns the connection protocol — you cannot interleave other SQL mid-COPY (#1436).** While a `cur.copy(...)` context is open, the connection is in PG `COPY_IN` state: any other `execute` (including a savepoint-wrapped flush on the *same* connection) corrupts the protocol. So a Python-side buffer that must be drained *during* the row stream (e.g. the `unresolved_buffer` of `(cusip, filer, period)` triples — millions deep on a full quarter) cannot be flushed inside the COPY loop. To bound its RAM, flush in chunks by **tearing down + reopening** the COPY context at each chunk boundary:
+
+```python
+rows = _iter_tsv(zf, "INFOTABLE.tsv")          # ONE generator, consumed across segments
+while True:
+    chunk_full = False
+    with conn.cursor() as cur, cur.copy(copy_sql) as copy:
+        for row in rows:                        # resumes where the prior segment broke
+            ...
+            buffer.append(triple)
+            if len(buffer) >= _CHUNK:
+                chunk_full = True
+                break                           # leave COPY → connection exits COPY_IN
+    if buffer:                                  # now safe to run other SQL
+        _flush_unresolved_buffer(conn, buffer=buffer, ...)
+        buffer.clear()
+    if not chunk_full:
+        break                                   # generator exhausted → done
+```
+
+Multiple `cur.copy()` appends to the same `ON COMMIT DROP` TEMP table within one archive tx are valid (the temp table is tx-scoped, not cursor-scoped). **Parity precondition:** chunked == single-batch ONLY if the flush helper's aggregation is a commutative monoid — `cusip_resolver.flush_unresolved_cusips_bulk` is (`COUNT/MIN/MAX` grouped by key; `ON CONFLICT` does `count +=`, `LEAST`/`GREATEST`, `NOW()` which is tx-constant). If a helper instead did `last = EXCLUDED.last` (overwrite, not `GREATEST`), chunk *order* would change the result and chunking would break parity. Verify the helper's conflict clause before chunking a buffer. Same rule for `_open_tsv`-style whole-file `list(csv.DictReader)` loads feeding an accession-keyed dict: stream straight into the dict (`_index_tsv_by_accession`) — keep the *last* row per key and count *every* row to preserve `*_seen` parity — instead of materialising the list first (O(rows)+O(accessions) → O(accessions); measured −82% peak Python heap on a 3.36M-row 13F quarter).
+
 **Companyfacts is NOT on this pattern** — `sec_companyfacts_ingest.py` reads XBRL JSON not TSV and already uses multi-row INSERT chunked at `_UPSERT_PAGE_SIZE=1000` via `upsert_facts_for_instrument`. The per-CIK savepoint there is intentional (one savepoint per CIK-payload, NOT per-row); it stays.
 
 Spec: `docs/_archive/2026-05/superseded-bootstrap-etl-optimisation-v2.md` §7. Tests: `tests/test_pr3_copy_refactor.py` (throughput floor, ON_ERROR skip, commit-boundary preservation, idempotency, touched-instrument set).

--- a/app/services/sec_13f_dataset_ingest.py
+++ b/app/services/sec_13f_dataset_ingest.py
@@ -48,7 +48,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Final, Literal
 from uuid import UUID, uuid4
 
 import psycopg
@@ -68,6 +68,23 @@ from app.services.ownership_observations import period_end_within_bounds
 from app.services.thirteen_f_normalise import VALUE_DOLLARS_CUTOVER as _VALUE_DOLLARS_CUTOVER
 
 logger = logging.getLogger(__name__)
+
+
+# #1436 — flush the unresolved-CUSIP buffer in bounded chunks rather than
+# accumulating millions of ``(cusip, filer_cik, period_end)`` triples in one
+# Python list before a single end-of-archive flush. Parity: the flush helper
+# (:func:`cusip_resolver.flush_unresolved_cusips_bulk`) aggregates
+# ``COUNT(*) / MIN / MAX`` grouped by ``(cusip, source)`` and on conflict does
+# ``observation_count += EXCLUDED``, ``first = LEAST(...)``, ``last =
+# GREATEST(...)``, ``last_observed_at = NOW()`` — a commutative monoid with a
+# tx-constant timestamp, so N chunked flushes within one archive transaction
+# land byte-identical final rows to one batch flush. The flush MUST run with
+# the connection OUT of COPY mode (a live ``cur.copy()`` owns the connection
+# protocol), so the row loop tears down + reopens the staging COPY at each
+# chunk boundary — a handful of times per multi-million-row archive, negligible
+# cost. Multiple COPY appends to the same ``ON COMMIT DROP`` TEMP table are
+# valid within the per-archive transaction.
+_UNRESOLVED_FLUSH_CHUNK: Final = 100_000
 
 
 @dataclass
@@ -243,23 +260,32 @@ def _read_voting_components(row: dict[str, str]) -> tuple[Decimal, Decimal, Deci
     )
 
 
-def _open_tsv(zf: zipfile.ZipFile, name: str) -> list[dict[str, str]]:
-    """Read a TSV from the archive into a list of dicts.
+def _index_tsv_by_accession(zf: zipfile.ZipFile, name: str) -> tuple[dict[str, dict[str, str]], int]:
+    """Stream a TSV and index its rows by ``ACCESSION_NUMBER`` (#1436).
 
-    The 13F datasets are typically <100 MB so loading SUBMISSION.tsv
-    + COVERPAGE.tsv into memory is acceptable. INFOTABLE can be 30M+
-    rows so the caller iterates that one streamingly.
+    Replaces the prior ``_open_tsv`` (whole-file ``list(csv.DictReader)``)
+    + dict-comprehension. SUBMISSION/COVERPAGE were materialised into a
+    transient ``list[dict]`` held in worker RAM alongside the
+    accession-keyed dict the caller actually used — O(rows) + O(accessions)
+    peak. Streaming builds only the dict — O(accessions).
+
+    Returns ``(index, total_rows)``. ``index`` keeps the LAST row per
+    accession, identical to the overwriting dict-comprehension
+    ``{r["ACCESSION_NUMBER"]: r for r in rows if "ACCESSION_NUMBER" in r}``
+    it replaces. ``total_rows`` counts EVERY data row — including
+    duplicates and rows missing ``ACCESSION_NUMBER`` — so the ``*_seen``
+    telemetry stays byte-identical to the old ``len(list(...))``.
     """
-    if name not in zf.namelist():
-        # Some archives bundle CSVs at top-level and others nest under
-        # a directory. Try to fall back.
-        candidates = [n for n in zf.namelist() if n.endswith("/" + name) or n == name]
-        if not candidates:
-            return []
-        name = candidates[0]
-    with zf.open(name) as fh:
-        text = io.TextIOWrapper(fh, encoding="utf-8", newline="")
-        return list(csv.DictReader(text, delimiter="\t"))
+    index: dict[str, dict[str, str]] = {}
+    total = 0
+    for row in _iter_tsv(zf, name):
+        total += 1
+        # Same predicate as the dict-comprehension it replaces — a short
+        # row missing the column (DictReader restval=None) is excluded
+        # by ``in``, matching the prior behaviour exactly.
+        if "ACCESSION_NUMBER" in row:
+            index[row["ACCESSION_NUMBER"]] = row
+    return index, total
 
 
 def _iter_tsv(zf: zipfile.ZipFile, name: str) -> Iterator[dict[str, str]]:
@@ -589,13 +615,12 @@ def ingest_13f_dataset_archive(
     figi_to_instrument: dict[str, int] = {}
 
     with zipfile.ZipFile(archive_path) as zf:
-        submissions = _open_tsv(zf, "SUBMISSION.tsv")
-        coverpages = _open_tsv(zf, "COVERPAGE.tsv")
-        result.submissions_seen = len(submissions)
-        result.coverpage_seen = len(coverpages)
-
-        sub_by_accession = {row["ACCESSION_NUMBER"]: row for row in submissions if "ACCESSION_NUMBER" in row}
-        cover_by_accession = {row["ACCESSION_NUMBER"]: row for row in coverpages if "ACCESSION_NUMBER" in row}
+        # #1436 — stream-index SUBMISSION/COVERPAGE straight into the
+        # accession-keyed dicts the loop joins against; never materialise
+        # the whole TSV as a transient list first. ``*_seen`` counts every
+        # row (parity with the old ``len(list(...))``).
+        sub_by_accession, result.submissions_seen = _index_tsv_by_accession(zf, "SUBMISSION.tsv")
+        cover_by_accession, result.coverpage_seen = _index_tsv_by_accession(zf, "COVERPAGE.tsv")
 
         # Stream INFOTABLE → pre-validate → COPY into _stg_13f. Single
         # cursor.copy() context spans every validated row in the
@@ -608,168 +633,187 @@ def ingest_13f_dataset_archive(
             + ") FROM STDIN WITH (FORMAT text, ON_ERROR ignore, LOG_VERBOSITY verbose)"
         )
         copy_attempted = 0
-        with conn.cursor() as cur, cur.copy(copy_sql) as copy:
-            for row in _iter_tsv(zf, "INFOTABLE.tsv"):
-                result.infotable_seen += 1
-                accession = row.get("ACCESSION_NUMBER", "").strip()
-                if not accession:
-                    result.rows_skipped_orphan_accession += 1
-                    continue
-                sub = sub_by_accession.get(accession)
-                cover = cover_by_accession.get(accession)
-                if sub is None or cover is None:
-                    result.rows_skipped_orphan_accession += 1
-                    continue
+        # #1436 — one shared INFOTABLE generator consumed across COPY
+        # segments. When the unresolved-CUSIP buffer reaches a chunk
+        # boundary the COPY context closes (so the connection leaves COPY
+        # mode), the buffer flushes, then a fresh COPY context reopens and
+        # the SAME generator resumes at the next row. Multiple COPY appends
+        # to the ON COMMIT DROP _stg_13f are valid within the per-archive
+        # tx. Generator exhaustion (the ``for`` ends without break) leaves
+        # ``chunk_full`` False → the outer loop flushes the remainder and
+        # breaks.
+        infotable = _iter_tsv(zf, "INFOTABLE.tsv")
+        while True:
+            chunk_full = False
+            with conn.cursor() as cur, cur.copy(copy_sql) as copy:
+                for row in infotable:
+                    result.infotable_seen += 1
+                    accession = row.get("ACCESSION_NUMBER", "").strip()
+                    if not accession:
+                        result.rows_skipped_orphan_accession += 1
+                        continue
+                    sub = sub_by_accession.get(accession)
+                    cover = cover_by_accession.get(accession)
+                    if sub is None or cover is None:
+                        result.rows_skipped_orphan_accession += 1
+                        continue
 
-                cusip = (row.get("CUSIP") or "").strip().upper()
-                if not cusip:
-                    result.rows_skipped_bad_data += 1
-                    continue
+                    cusip = (row.get("CUSIP") or "").strip().upper()
+                    if not cusip:
+                        result.rows_skipped_bad_data += 1
+                        continue
 
-                filer_cik_raw = str(sub.get("CIK") or "").strip()
-                if not filer_cik_raw:
-                    result.rows_skipped_bad_data += 1
-                    continue
-                filer_cik = filer_cik_raw.zfill(10)
+                    filer_cik_raw = str(sub.get("CIK") or "").strip()
+                    if not filer_cik_raw:
+                        result.rows_skipped_bad_data += 1
+                        continue
+                    filer_cik = filer_cik_raw.zfill(10)
 
-                period_end = _parse_period_end(cover.get("REPORTCALENDARORQUARTER"))
-                # #1433 — reject a NULL or out-of-[1900,2100) period_end
-                # before it reaches the partitioned table. Mirrors the
-                # #1218 XBRL guard: a year-6016 / pre-1900 value would land
-                # in the DEFAULT partition and silently skew every
-                # period-bounded institutional rollup. A 13F-HR with no
-                # parseable cover period has nothing to rewash either, so
-                # this also keeps it out of the unresolved-CUSIP buffer.
-                if not period_end_within_bounds(period_end):
-                    result.rows_skipped_bad_data += 1
-                    continue
-                filed_at = _parse_filing_date(sub.get("FILING_DATE") or sub.get("DATE_FILED"))
+                    period_end = _parse_period_end(cover.get("REPORTCALENDARORQUARTER"))
+                    # #1433 — reject a NULL or out-of-[1900,2100) period_end
+                    # before it reaches the partitioned table. Mirrors the
+                    # #1218 XBRL guard: a year-6016 / pre-1900 value would land
+                    # in the DEFAULT partition and silently skew every
+                    # period-bounded institutional rollup. A 13F-HR with no
+                    # parseable cover period has nothing to rewash either, so
+                    # this also keeps it out of the unresolved-CUSIP buffer.
+                    if not period_end_within_bounds(period_end):
+                        result.rows_skipped_bad_data += 1
+                        continue
+                    filed_at = _parse_filing_date(sub.get("FILING_DATE") or sub.get("DATE_FILED"))
 
-                instrument_id = cusip_map.get(cusip)
-                if instrument_id is None:
-                    result.rows_skipped_unresolved_cusip += 1
-                    # PR-1a — record (cusip, filer, period) so the
-                    # PR-1b OpenFIGI sweep can rewash. period_end is
-                    # guaranteed in-window (non-None) by the #1433 guard
-                    # above, so the bulk-path index always has a period.
-                    unresolved_buffer.append((cusip, filer_cik, period_end))
-                    continue
+                    instrument_id = cusip_map.get(cusip)
+                    if instrument_id is None:
+                        result.rows_skipped_unresolved_cusip += 1
+                        # PR-1a — record (cusip, filer, period) so the
+                        # PR-1b OpenFIGI sweep can rewash. period_end is
+                        # guaranteed in-window (non-None) by the #1433 guard
+                        # above, so the bulk-path index always has a period.
+                        unresolved_buffer.append((cusip, filer_cik, period_end))
+                        # #1436 — bounded-chunk flush: break out to drain
+                        # this chunk (outside COPY mode) then resume.
+                        if len(unresolved_buffer) >= _UNRESOLVED_FLUSH_CHUNK:
+                            chunk_full = True
+                            break
+                        continue
 
-                # #1302 — capture the security's FIGI (12-char OpenFIGI id,
-                # new INFOTABLE column 2023-01-03) against the instrument it
-                # resolved to. Collected before the share/retention gates
-                # below: the FIGI<->instrument identity holds regardless of
-                # whether THIS holding row is a valid current position.
-                figi = (row.get("FIGI") or "").strip().upper()
-                if figi and _FIGI_RE.match(figi):
-                    figi_to_instrument.setdefault(figi, instrument_id)
+                    # #1302 — capture the security's FIGI (12-char OpenFIGI id,
+                    # new INFOTABLE column 2023-01-03) against the instrument it
+                    # resolved to. Collected before the share/retention gates
+                    # below: the FIGI<->instrument identity holds regardless of
+                    # whether THIS holding row is a valid current position.
+                    figi = (row.get("FIGI") or "").strip().upper()
+                    if figi and _FIGI_RE.match(figi):
+                        figi_to_instrument.setdefault(figi, instrument_id)
 
-                filer_name = (cover.get("FILINGMANAGER_NAME") or "").strip()
-                if not filer_name:
-                    # Schema requires NOT NULL filer_name; fall back to
-                    # the CIK to keep the row instead of dropping it.
-                    filer_name = f"CIK{filer_cik}"
+                    filer_name = (cover.get("FILINGMANAGER_NAME") or "").strip()
+                    if not filer_name:
+                        # Schema requires NOT NULL filer_name; fall back to
+                        # the CIK to keep the row instead of dropping it.
+                        filer_name = f"CIK{filer_cik}"
 
-                # period_end already validated in-window above (#1433); only
-                # filed_at remains to null-check here.
-                if filed_at is None:
-                    result.rows_skipped_bad_data += 1
-                    continue
+                    # period_end already validated in-window above (#1433); only
+                    # filed_at remains to null-check here.
+                    if filed_at is None:
+                        result.rows_skipped_bad_data += 1
+                        continue
 
-                # PR6 #1233 §4.5 — per-row retention gate. Bulk dataset
-                # archives can span 30+ years; the per-row check honours
-                # the calendar-quarter cap regardless of the archive's
-                # nominal coverage window.
-                if period_end < retention_cutoff:
-                    result.rows_skipped_retention += 1
-                    continue
+                    # PR6 #1233 §4.5 — per-row retention gate. Bulk dataset
+                    # archives can span 30+ years; the per-row check honours
+                    # the calendar-quarter cap regardless of the archive's
+                    # nominal coverage window.
+                    if period_end < retention_cutoff:
+                        result.rows_skipped_retention += 1
+                        continue
 
-                # SSHPRNAMT carries shares OR principal-amount depending on
-                # SSHPRNAMTTYPE (SH | PRN). PRN rows hold bond principal in
-                # dollars, NOT shares — must skip to avoid silent
-                # corruption (PR #1054 finding: 20k PRN rows in 2026Q1).
-                shprn_type = (row.get("SSHPRNAMTTYPE") or "").strip().upper()
-                if shprn_type and shprn_type != "SH":
-                    result.rows_skipped_bad_data += 1
-                    continue
-                shares = _parse_decimal(row.get("SSHPRNAMT"))
-                # #1433 — an SH-type 13F holding must carry a positive share
-                # count. NULL / 0 / negative SSHPRNAMT is malformed (the
-                # schema column is nullable, sql/114, so the guard lives
-                # here at parse) and would otherwise be summed into the
-                # institutional ownership rollup as a phantom position.
-                if shares is None or shares <= 0:
-                    result.rows_skipped_bad_data += 1
-                    continue
-                # VALUE column unit changed 2023-01-03 — pre-cutover it
-                # was reported in $thousands, post-cutover in $dollars.
-                # See _VALUE_DOLLARS_CUTOVER constant at module top.
-                # Discriminate on FILED_AT (when the filer reported), NOT
-                # period_end — a 2022Q4 restatement filed in March 2023
-                # reports in dollars even though period_end is pre-cutover.
-                value_raw = _parse_decimal(row.get("VALUE"))
-                if value_raw is None:
-                    market_value_usd = None
-                elif filed_at.date() >= _VALUE_DOLLARS_CUTOVER:
-                    market_value_usd = value_raw
-                else:
-                    market_value_usd = value_raw * Decimal("1000")
+                    # SSHPRNAMT carries shares OR principal-amount depending on
+                    # SSHPRNAMTTYPE (SH | PRN). PRN rows hold bond principal in
+                    # dollars, NOT shares — must skip to avoid silent
+                    # corruption (PR #1054 finding: 20k PRN rows in 2026Q1).
+                    shprn_type = (row.get("SSHPRNAMTTYPE") or "").strip().upper()
+                    if shprn_type and shprn_type != "SH":
+                        result.rows_skipped_bad_data += 1
+                        continue
+                    shares = _parse_decimal(row.get("SSHPRNAMT"))
+                    # #1433 — an SH-type 13F holding must carry a positive share
+                    # count. NULL / 0 / negative SSHPRNAMT is malformed (the
+                    # schema column is nullable, sql/114, so the guard lives
+                    # here at parse) and would otherwise be summed into the
+                    # institutional ownership rollup as a phantom position.
+                    if shares is None or shares <= 0:
+                        result.rows_skipped_bad_data += 1
+                        continue
+                    # VALUE column unit changed 2023-01-03 — pre-cutover it
+                    # was reported in $thousands, post-cutover in $dollars.
+                    # See _VALUE_DOLLARS_CUTOVER constant at module top.
+                    # Discriminate on FILED_AT (when the filer reported), NOT
+                    # period_end — a 2022Q4 restatement filed in March 2023
+                    # reports in dollars even though period_end is pre-cutover.
+                    value_raw = _parse_decimal(row.get("VALUE"))
+                    if value_raw is None:
+                        market_value_usd = None
+                    elif filed_at.date() >= _VALUE_DOLLARS_CUTOVER:
+                        market_value_usd = value_raw
+                    else:
+                        market_value_usd = value_raw * Decimal("1000")
 
-                voting_sole, voting_shared, voting_none = _read_voting_components(row)
-                exposure_kind = _map_putcall(row.get("PUTCALL"))
+                    voting_sole, voting_shared, voting_none = _read_voting_components(row)
+                    exposure_kind = _map_putcall(row.get("PUTCALL"))
 
-                accession_no_dashes = accession.replace("-", "")
-                source_url = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession_no_dashes}/"
+                    accession_no_dashes = accession.replace("-", "")
+                    source_url = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession_no_dashes}/"
 
-                copy.write_row(
-                    _build_copy_row(
-                        instrument_id=instrument_id,
-                        filer_cik=filer_cik,
-                        filer_name=filer_name,
-                        # Spec maps 13F filers to ``filer_type='INV'``
-                        # (investment manager) by default. The schema
-                        # CHECK accepts ETF/INV/INS/BD/OTHER. INV is
-                        # the right default for typical 13F-HR filers.
-                        filer_type="INV",
-                        # ``ownership_nature`` for 13F-HR: pass
-                        # ``'economic'`` for the full reported
-                        # position. Mapping pinned in
-                        # ``record_institution_observation`` docstring.
-                        ownership_nature="economic",
-                        source="13f",
-                        source_document_id=accession,
-                        source_accession=accession,
-                        source_field=None,
-                        source_url=source_url,
-                        filed_at=filed_at,
-                        period_start=None,
-                        period_end=period_end,
-                        ingest_run_id=ingest_run_id,
-                        shares=shares,
-                        market_value_usd=market_value_usd,
-                        voting_sole=voting_sole,
-                        voting_shared=voting_shared,
-                        voting_none=voting_none,
-                        exposure_kind=exposure_kind,
+                    copy.write_row(
+                        _build_copy_row(
+                            instrument_id=instrument_id,
+                            filer_cik=filer_cik,
+                            filer_name=filer_name,
+                            # Spec maps 13F filers to ``filer_type='INV'``
+                            # (investment manager) by default. The schema
+                            # CHECK accepts ETF/INV/INS/BD/OTHER. INV is
+                            # the right default for typical 13F-HR filers.
+                            filer_type="INV",
+                            # ``ownership_nature`` for 13F-HR: pass
+                            # ``'economic'`` for the full reported
+                            # position. Mapping pinned in
+                            # ``record_institution_observation`` docstring.
+                            ownership_nature="economic",
+                            source="13f",
+                            source_document_id=accession,
+                            source_accession=accession,
+                            source_field=None,
+                            source_url=source_url,
+                            filed_at=filed_at,
+                            period_start=None,
+                            period_end=period_end,
+                            ingest_run_id=ingest_run_id,
+                            shares=shares,
+                            market_value_usd=market_value_usd,
+                            voting_sole=voting_sole,
+                            voting_shared=voting_shared,
+                            voting_none=voting_none,
+                            exposure_kind=exposure_kind,
+                        )
                     )
-                )
-                copy_attempted += 1
-                result.touched_instrument_ids.add(instrument_id)
+                    copy_attempted += 1
+                    result.touched_instrument_ids.add(instrument_id)
 
-    # Flush accumulated unresolved CUSIPs after the COPY context
-    # closes (a COPY context exclusively owns the cursor so we cannot
-    # interleave normal statements; flushing post-stream is the
-    # simplest correct shape). #1295: a single COPY pass handles
-    # millions of triples — no per-chunk loop needed.
-    if unresolved_buffer:
-        _flush_unresolved_buffer(
-            conn,
-            buffer=unresolved_buffer,
-            source="bulk_13f_dataset",
-            cutoff=retention_cutoff,
-            result=result,
-        )
-        unresolved_buffer.clear()
+            # COPY context closed → connection is out of COPY mode. Flush
+            # this chunk of unresolved CUSIPs (#1436). A partial flush at
+            # the generator's end drains the remainder; the helper's
+            # aggregation is order-independent so chunked == single-batch.
+            if unresolved_buffer:
+                _flush_unresolved_buffer(
+                    conn,
+                    buffer=unresolved_buffer,
+                    source="bulk_13f_dataset",
+                    cutoff=retention_cutoff,
+                    result=result,
+                )
+                unresolved_buffer.clear()
+
+            if not chunk_full:
+                break
 
     # Drain staging into the partitioned observations table.
     #

--- a/app/services/sec_nport_dataset_ingest.py
+++ b/app/services/sec_nport_dataset_ingest.py
@@ -66,6 +66,21 @@ logger = logging.getLogger(__name__)
 _BALANCE_QUANTUM: Final = Decimal("0.0001")
 
 
+# #1436 — flush the unresolved-CUSIP buffer in bounded chunks rather than
+# accumulating millions of ``(cusip, filer_cik, period_end)`` triples in one
+# Python list before a single end-of-archive flush. Parity: the flush helper
+# (:func:`cusip_resolver.flush_unresolved_cusips_bulk`) aggregates
+# ``COUNT(*) / MIN / MAX`` grouped by ``(cusip, source)`` and on conflict sums
+# count + takes ``LEAST``/``GREATEST`` of the periods (``NOW()`` tx-constant) —
+# a commutative monoid, so N chunked flushes within one archive transaction
+# land byte-identical final rows to one batch flush. The flush MUST run with
+# the connection OUT of COPY mode, so the holding loop tears down + reopens the
+# staging COPY at each chunk boundary (a handful of times per multi-million-row
+# archive). Multiple COPY appends to the ON COMMIT DROP _stg_nport are valid
+# within the per-archive transaction.
+_UNRESOLVED_FLUSH_CHUNK: Final = 100_000
+
+
 @dataclass
 class NPortIngestResult:
     """Per-archive ingest outcome."""
@@ -167,21 +182,28 @@ def _parse_decimal(value: str | None) -> Decimal | None:
         return None
 
 
-def _open_tsv(zf: zipfile.ZipFile, *candidate_names: str) -> list[dict[str, str]]:
-    """Open the first matching TSV from a list of candidate filenames."""
-    available = zf.namelist()
-    for name in candidate_names:
-        if name in available:
-            with zf.open(name) as fh:
-                text = io.TextIOWrapper(fh, encoding="utf-8", newline="")
-                return list(csv.DictReader(text, delimiter="\t"))
-    for name in candidate_names:
-        nested = [n for n in available if n.endswith("/" + name)]
-        if nested:
-            with zf.open(nested[0]) as fh:
-                text = io.TextIOWrapper(fh, encoding="utf-8", newline="")
-                return list(csv.DictReader(text, delimiter="\t"))
-    return []
+def _index_tsv_by_accession(zf: zipfile.ZipFile, *candidate_names: str) -> tuple[dict[str, dict[str, str]], int]:
+    """Stream the first matching TSV and index its rows by accession (#1436).
+
+    Replaces the prior ``_open_tsv`` (whole-file ``list(csv.DictReader)``)
+    + dict-comprehension for the per-accession lookup tables
+    (SUBMISSION/REGISTRANT/FUND_REPORTED_INFO). The list materialisation
+    held every row in worker RAM transiently alongside the accession-keyed
+    dict the caller used. Streaming builds only the dict — O(accessions).
+
+    Returns ``(index, total_rows)``. ``index`` keeps the LAST row per
+    accession, identical to the overwriting
+    ``{r["ACCESSION_NUMBER"]: r for r in rows if "ACCESSION_NUMBER" in r}``
+    it replaces. ``total_rows`` counts EVERY data row so the
+    ``submissions_seen`` telemetry stays byte-identical to ``len(list(...))``.
+    """
+    index: dict[str, dict[str, str]] = {}
+    total = 0
+    for row in _iter_tsv(zf, *candidate_names):
+        total += 1
+        if "ACCESSION_NUMBER" in row:
+            index[row["ACCESSION_NUMBER"]] = row
+    return index, total
 
 
 def _iter_tsv(zf: zipfile.ZipFile, *candidate_names: str) -> Iterator[dict[str, str]]:
@@ -469,20 +491,14 @@ def ingest_nport_dataset_archive(
         cur.execute(_CREATE_STG_SQL)
 
     with zipfile.ZipFile(archive_path) as zf:
-        submissions = _open_tsv(zf, "SUBMISSION.tsv")
-        registrants = _open_tsv(zf, "REGISTRANT.tsv")
-        fund_info = _open_tsv(zf, "FUND_REPORTED_INFO.tsv")
-        result.submissions_seen = len(submissions)
-
-        sub_by_accn: dict[str, dict[str, str]] = {
-            r["ACCESSION_NUMBER"]: r for r in submissions if "ACCESSION_NUMBER" in r
-        }
-        reg_by_accn: dict[str, dict[str, str]] = {
-            r["ACCESSION_NUMBER"]: r for r in registrants if "ACCESSION_NUMBER" in r
-        }
-        fund_by_accn: dict[str, dict[str, str]] = {
-            r["ACCESSION_NUMBER"]: r for r in fund_info if "ACCESSION_NUMBER" in r
-        }
+        # #1436 — stream-index the per-accession lookup tables straight into
+        # the dicts the holding loop joins against; never materialise the
+        # whole TSV as a transient list first. ``submissions_seen`` counts
+        # every row (parity with the old ``len(list(...))``); the registrant
+        # / fund counts are not surfaced so their totals are discarded.
+        sub_by_accn, result.submissions_seen = _index_tsv_by_accession(zf, "SUBMISSION.tsv")
+        reg_by_accn, _ = _index_tsv_by_accession(zf, "REGISTRANT.tsv")
+        fund_by_accn, _ = _index_tsv_by_accession(zf, "FUND_REPORTED_INFO.tsv")
 
         # PR7 #1233 §4.6 — 8-quarter (24-month) retention cap. Cutoff
         # resolved ONCE per archive to avoid date-rollover during a
@@ -524,184 +540,221 @@ def ingest_nport_dataset_archive(
             + ") FROM STDIN WITH (FORMAT text, ON_ERROR ignore, LOG_VERBOSITY verbose)"
         )
         copy_attempted = 0
-        with conn.cursor() as cur, cur.copy(copy_sql) as copy:
-            for holding in _iter_tsv(zf, "FUND_REPORTED_HOLDING.tsv"):
-                result.holdings_seen += 1
-                accn = holding.get("ACCESSION_NUMBER", "").strip()
-                if not accn:
-                    result.rows_skipped_orphan_accession += 1
-                    continue
-                sub = sub_by_accn.get(accn)
-                if sub is None:
-                    result.rows_skipped_orphan_accession += 1
-                    continue
+        # #1436 — one shared FUND_REPORTED_HOLDING generator consumed across
+        # COPY segments. When the unresolved-CUSIP buffer reaches a chunk
+        # boundary the COPY context closes (connection leaves COPY mode), the
+        # buffer flushes, and a fresh COPY context reopens to resume the SAME
+        # generator. Multiple COPY appends to the ON COMMIT DROP _stg_nport are
+        # valid within the per-archive tx. Ordering note: the chunked flush now
+        # runs DURING the holding loop, i.e. BEFORE the staging drain — same as
+        # the 13F sibling. Failure isolation is unchanged: the flush's
+        # ``with conn.transaction()`` savepoint rolls back only its own writes
+        # on error, never the staged observations (independent of order).
+        holdings = _iter_tsv(zf, "FUND_REPORTED_HOLDING.tsv")
+        while True:
+            chunk_full = False
+            with conn.cursor() as cur, cur.copy(copy_sql) as copy:
+                for holding in holdings:
+                    result.holdings_seen += 1
+                    accn = holding.get("ACCESSION_NUMBER", "").strip()
+                    if not accn:
+                        result.rows_skipped_orphan_accession += 1
+                        continue
+                    sub = sub_by_accn.get(accn)
+                    if sub is None:
+                        result.rows_skipped_orphan_accession += 1
+                        continue
 
-                # PR7 §4.6 retention gate (EARLY) — same shape as
-                # legacy.
-                period_end_early = _parse_iso_date(sub.get("REPORT_DATE")) or _parse_iso_date(
-                    sub.get("REPORT_ENDING_PERIOD")
-                )
-                # #1433 — reject a NULL or out-of-[1900,2100) period_end
-                # BEFORE the retention gate and the unresolved-CUSIP buffer,
-                # so a junk year-6016 with an unresolved CUSIP never leaks
-                # into unresolved markers, and a pre-1900 date is counted as
-                # bad_data rather than masked as retention (mirrors the #1218
-                # XBRL guard; shared bound via period_end_within_bounds).
-                # period_end_early == the staged period_end (same
-                # REPORT_DATE / REPORT_ENDING_PERIOD expression below).
-                if not period_end_within_bounds(period_end_early):
-                    result.rows_skipped_bad_data += 1
-                    continue
-                if period_end_early < retention_cutoff:
-                    result.rows_skipped_retention += 1
-                    continue
+                    # PR7 §4.6 retention gate (EARLY) — same shape as
+                    # legacy.
+                    period_end_early = _parse_iso_date(sub.get("REPORT_DATE")) or _parse_iso_date(
+                        sub.get("REPORT_ENDING_PERIOD")
+                    )
+                    # #1433 — reject a NULL or out-of-[1900,2100) period_end
+                    # BEFORE the retention gate and the unresolved-CUSIP buffer,
+                    # so a junk year-6016 with an unresolved CUSIP never leaks
+                    # into unresolved markers, and a pre-1900 date is counted as
+                    # bad_data rather than masked as retention (mirrors the #1218
+                    # XBRL guard; shared bound via period_end_within_bounds).
+                    # period_end_early == the staged period_end (same
+                    # REPORT_DATE / REPORT_ENDING_PERIOD expression below).
+                    if not period_end_within_bounds(period_end_early):
+                        result.rows_skipped_bad_data += 1
+                        continue
+                    if period_end_early < retention_cutoff:
+                        result.rows_skipped_retention += 1
+                        continue
 
-                reg = reg_by_accn.get(accn)
-                fund = fund_by_accn.get(accn)
-                if reg is None or fund is None:
-                    result.rows_skipped_orphan_accession += 1
-                    continue
+                    reg = reg_by_accn.get(accn)
+                    fund = fund_by_accn.get(accn)
+                    if reg is None or fund is None:
+                        result.rows_skipped_orphan_accession += 1
+                        continue
 
-                # ─── filter at write boundary ───────────────────────
-                asset_cat = (holding.get("ASSET_CAT") or "").strip()
-                if asset_cat != "EC":
-                    result.rows_skipped_non_equity += 1
-                    continue
-                payoff = (holding.get("PAYOFF_PROFILE") or "").strip()
-                if payoff != "Long":
-                    result.rows_skipped_non_long += 1
-                    continue
-                unit = (holding.get("UNIT") or "").strip().upper()
-                if unit != "NS":
-                    result.rows_skipped_non_share_units += 1
-                    continue
-                balance = _parse_decimal(holding.get("BALANCE"))
-                if balance is None or balance <= 0:
-                    result.rows_skipped_non_positive_shares += 1
-                    continue
-                # PR-3 regression guard: ``ownership_funds_observations.shares``
-                # is NUMERIC(24, 4) with a strict ``CHECK (shares > 0)``
-                # (sql/123:84). A fractional-share holding like 0.00005
-                # passes the ``> 0`` predicate above but quantises to
-                # 0.0000 on COPY into staging, then trips the CHECK on
-                # the INSERT...SELECT drain — aborting the entire archive.
-                # Pre-PR-3 per-row INSERT path masked this via per-row
-                # SAVEPOINT (counted as bad_data, loop continued); the
-                # COPY-batched path cannot. Quantise here at the same
-                # precision the column will store, and reject the row
-                # if it underflows to zero.
-                # ROUND_HALF_EVEN matches Postgres NUMERIC coercion
-                # semantics exactly — what PG would do on INSERT, we do
-                # here so the pre-validation outcome lines up with the
-                # CHECK constraint outcome. ``0.00005 → 0.0000`` (tie
-                # to even, reject); ``0.00006 → 0.0001`` (accept);
-                # ``0.00004 → 0.0000`` (reject). Codex 2 finding on
-                # the fix branch — implicit rounding mode was a
-                # forensic gap.
-                balance_q = balance.quantize(_BALANCE_QUANTUM, rounding=ROUND_HALF_EVEN)
-                if balance_q <= 0:
-                    result.rows_skipped_non_positive_shares += 1
-                    continue
-                balance = balance_q
+                    # ─── filter at write boundary ───────────────────────
+                    asset_cat = (holding.get("ASSET_CAT") or "").strip()
+                    if asset_cat != "EC":
+                        result.rows_skipped_non_equity += 1
+                        continue
+                    payoff = (holding.get("PAYOFF_PROFILE") or "").strip()
+                    if payoff != "Long":
+                        result.rows_skipped_non_long += 1
+                        continue
+                    unit = (holding.get("UNIT") or "").strip().upper()
+                    if unit != "NS":
+                        result.rows_skipped_non_share_units += 1
+                        continue
+                    balance = _parse_decimal(holding.get("BALANCE"))
+                    if balance is None or balance <= 0:
+                        result.rows_skipped_non_positive_shares += 1
+                        continue
+                    # PR-3 regression guard: ``ownership_funds_observations.shares``
+                    # is NUMERIC(24, 4) with a strict ``CHECK (shares > 0)``
+                    # (sql/123:84). A fractional-share holding like 0.00005
+                    # passes the ``> 0`` predicate above but quantises to
+                    # 0.0000 on COPY into staging, then trips the CHECK on
+                    # the INSERT...SELECT drain — aborting the entire archive.
+                    # Pre-PR-3 per-row INSERT path masked this via per-row
+                    # SAVEPOINT (counted as bad_data, loop continued); the
+                    # COPY-batched path cannot. Quantise here at the same
+                    # precision the column will store, and reject the row
+                    # if it underflows to zero.
+                    # ROUND_HALF_EVEN matches Postgres NUMERIC coercion
+                    # semantics exactly — what PG would do on INSERT, we do
+                    # here so the pre-validation outcome lines up with the
+                    # CHECK constraint outcome. ``0.00005 → 0.0000`` (tie
+                    # to even, reject); ``0.00006 → 0.0001`` (accept);
+                    # ``0.00004 → 0.0000`` (reject). Codex 2 finding on
+                    # the fix branch — implicit rounding mode was a
+                    # forensic gap.
+                    balance_q = balance.quantize(_BALANCE_QUANTUM, rounding=ROUND_HALF_EVEN)
+                    if balance_q <= 0:
+                        result.rows_skipped_non_positive_shares += 1
+                        continue
+                    balance = balance_q
 
-                cusip = (holding.get("ISSUER_CUSIP") or "").strip().upper()
-                if not cusip:
-                    result.rows_skipped_unresolved_cusip += 1
-                    continue
-                instrument_id = cusip_map.get(cusip)
-                if instrument_id is None:
-                    filer_cik_raw_buf = (reg.get("CIK") or "").strip()
-                    # period_end_early guaranteed non-None by the #1433 guard.
-                    if filer_cik_raw_buf:
-                        filer_cik_buf = filer_cik_raw_buf.zfill(10)
-                        unresolved_buffer.append((cusip, filer_cik_buf, period_end_early))
-                    # #1340 — recoverable miss: hold this accession back from
-                    # the n_port_ingest_log seed so S23 can re-fetch it after
-                    # the CUSIP resolves.
-                    unresolved_accns.add(accn)
-                    result.rows_skipped_unresolved_cusip += 1
-                    continue
+                    cusip = (holding.get("ISSUER_CUSIP") or "").strip().upper()
+                    if not cusip:
+                        result.rows_skipped_unresolved_cusip += 1
+                        continue
+                    instrument_id = cusip_map.get(cusip)
+                    if instrument_id is None:
+                        filer_cik_raw_buf = (reg.get("CIK") or "").strip()
+                        # period_end_early guaranteed non-None by the #1433 guard.
+                        if filer_cik_raw_buf:
+                            filer_cik_buf = filer_cik_raw_buf.zfill(10)
+                            unresolved_buffer.append((cusip, filer_cik_buf, period_end_early))
+                            # #1436 — bounded-chunk flush boundary.
+                            if len(unresolved_buffer) >= _UNRESOLVED_FLUSH_CHUNK:
+                                chunk_full = True
+                        # #1340 — recoverable miss: hold this accession back from
+                        # the n_port_ingest_log seed so S23 can re-fetch it after
+                        # the CUSIP resolves.
+                        unresolved_accns.add(accn)
+                        result.rows_skipped_unresolved_cusip += 1
+                        # #1436 — break out to drain this chunk (outside COPY
+                        # mode) then resume the generator.
+                        if chunk_full:
+                            break
+                        continue
 
-                # ─── series identity ────────────────────────────────
-                series_id = (fund.get("SERIES_ID") or "").strip()
-                series_name = (fund.get("SERIES_NAME") or "").strip()
-                if not series_id:
-                    result.rows_skipped_missing_series += 1
-                    continue
+                    # ─── series identity ────────────────────────────────
+                    series_id = (fund.get("SERIES_ID") or "").strip()
+                    series_name = (fund.get("SERIES_NAME") or "").strip()
+                    if not series_id:
+                        result.rows_skipped_missing_series += 1
+                        continue
 
-                filer_cik_raw = (reg.get("CIK") or "").strip()
-                if not filer_cik_raw:
-                    result.rows_skipped_bad_data += 1
-                    continue
-                filer_cik = filer_cik_raw.zfill(10)
+                    filer_cik_raw = (reg.get("CIK") or "").strip()
+                    if not filer_cik_raw:
+                        result.rows_skipped_bad_data += 1
+                        continue
+                    filer_cik = filer_cik_raw.zfill(10)
 
-                filed_at = _parse_filing_date(sub.get("FILING_DATE"))
-                # period_end == period_end_early (same REPORT_DATE /
-                # REPORT_ENDING_PERIOD), already validated in-window by the
-                # #1433 guard above — reuse it (non-None) and only null-check
-                # filed_at here.
-                period_end = period_end_early
-                if filed_at is None:
-                    result.rows_skipped_bad_data += 1
-                    continue
+                    filed_at = _parse_filing_date(sub.get("FILING_DATE"))
+                    # period_end == period_end_early (same REPORT_DATE /
+                    # REPORT_ENDING_PERIOD), already validated in-window by the
+                    # #1433 guard above — reuse it (non-None) and only null-check
+                    # filed_at here.
+                    period_end = period_end_early
+                    if filed_at is None:
+                        result.rows_skipped_bad_data += 1
+                        continue
 
-                # Series upsert is deferred to post-COPY. Buffer this
-                # (accn, series_id) tuple iff this is the first
-                # qualifying holding for the pair. Legacy semantic:
-                # one upsert per (accn, series_id) — re-encountering
-                # the same series under a different accession in the
-                # same archive STILL upserts so ``GREATEST(...)``
-                # advances ``last_seen_period_end``.
-                series_key = (accn, series_id)
-                if series_key not in seen_series:
-                    seen_series.add(series_key)
-                    series_upsert_buffer.append(
+                    # Series upsert is deferred to post-COPY. Buffer this
+                    # (accn, series_id) tuple iff this is the first
+                    # qualifying holding for the pair. Legacy semantic:
+                    # one upsert per (accn, series_id) — re-encountering
+                    # the same series under a different accession in the
+                    # same archive STILL upserts so ``GREATEST(...)``
+                    # advances ``last_seen_period_end``.
+                    series_key = (accn, series_id)
+                    if series_key not in seen_series:
+                        seen_series.add(series_key)
+                        series_upsert_buffer.append(
+                            (
+                                accn,
+                                series_id,
+                                series_name or f"Series {series_id}",
+                                filer_cik,
+                                period_end,
+                            )
+                        )
+
+                    holding_id = (holding.get("HOLDING_ID") or "0").strip() or "0"
+                    source_document_id = f"{accn}:{holding_id}"
+                    accession_no_dashes = accn.replace("-", "")
+                    source_url = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession_no_dashes}/"
+
+                    # CURRENCY_VALUE in local currency; only treat USD
+                    # as canonical USD per legacy posture.
+                    currency_code = (holding.get("CURRENCY_CODE") or "").strip().upper()
+                    if currency_code == "USD":
+                        market_value_usd = _parse_decimal(holding.get("CURRENCY_VALUE"))
+                    else:
+                        market_value_usd = None
+
+                    copy.write_row(
                         (
-                            accn,
+                            instrument_id,
                             series_id,
                             series_name or f"Series {series_id}",
                             filer_cik,
+                            "economic",
+                            "nport",
+                            source_document_id,
+                            accn,
+                            holding_id,
+                            source_url,
+                            filed_at,
+                            None,
                             period_end,
+                            str(ingest_run_id),
+                            balance,
+                            market_value_usd,
+                            payoff,
+                            asset_cat,
                         )
                     )
+                    copy_attempted += 1
+                    result.touched_instrument_ids.add(instrument_id)
 
-                holding_id = (holding.get("HOLDING_ID") or "0").strip() or "0"
-                source_document_id = f"{accn}:{holding_id}"
-                accession_no_dashes = accn.replace("-", "")
-                source_url = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession_no_dashes}/"
-
-                # CURRENCY_VALUE in local currency; only treat USD
-                # as canonical USD per legacy posture.
-                currency_code = (holding.get("CURRENCY_CODE") or "").strip().upper()
-                if currency_code == "USD":
-                    market_value_usd = _parse_decimal(holding.get("CURRENCY_VALUE"))
-                else:
-                    market_value_usd = None
-
-                copy.write_row(
-                    (
-                        instrument_id,
-                        series_id,
-                        series_name or f"Series {series_id}",
-                        filer_cik,
-                        "economic",
-                        "nport",
-                        source_document_id,
-                        accn,
-                        holding_id,
-                        source_url,
-                        filed_at,
-                        None,
-                        period_end,
-                        str(ingest_run_id),
-                        balance,
-                        market_value_usd,
-                        payoff,
-                        asset_cat,
-                    )
+            # COPY context closed → connection is out of COPY mode. Flush this
+            # chunk of unresolved CUSIPs (#1436). A partial flush at the
+            # generator's end drains the remainder; the helper's aggregation
+            # is order-independent so chunked == single-batch.
+            if unresolved_buffer:
+                _flush_unresolved_buffer(
+                    conn,
+                    unresolved_buffer,
+                    source="bulk_nport_dataset",
+                    cutoff=retention_cutoff,
+                    result=result,
                 )
-                copy_attempted += 1
-                result.touched_instrument_ids.add(instrument_id)
+                unresolved_buffer.clear()
+
+            if not chunk_full:
+                break
 
     # Drain staging into the partitioned observations table FIRST,
     # before the series upsert + unresolved-CUSIP flushes. Rationale:
@@ -765,18 +818,11 @@ def ingest_nport_dataset_archive(
 
     series_upsert_buffer.clear()
 
-    # Flush accumulated unresolved CUSIPs AFTER the staging drain so
-    # a flush failure cannot roll it back. #1295: single COPY pass
-    # handles the whole buffer; no per-chunk loop needed.
-    if unresolved_buffer:
-        _flush_unresolved_buffer(
-            conn,
-            unresolved_buffer,
-            source="bulk_nport_dataset",
-            cutoff=retention_cutoff,
-            result=result,
-        )
-        unresolved_buffer.clear()
+    # #1436 — the unresolved-CUSIP buffer is flushed in bounded chunks INSIDE
+    # the holding loop (above), so by here it is already drained and empty; no
+    # end-of-archive flush remains. ``unresolved_accns`` (the seed-log hold-back
+    # set, not the triple buffer) was intentionally NOT cleared and was consumed
+    # by the n_port_ingest_log seed above.
 
     # #1349 — the #1399 inline marker-delete that used to follow here is
     # gone: with per-(cusip, source) marker grain, mapped-CUSIP hygiene

--- a/tests/test_sec_13f_dataset_ingest.py
+++ b/tests/test_sec_13f_dataset_ingest.py
@@ -783,3 +783,102 @@ class TestIngest13FFigiCapture:
 
         assert result.figi_identifiers_seen == 0
         assert result.figi_identifiers_written == 0
+
+
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestUnresolvedChunkedFlushParity:
+    """#1436 — the unresolved-CUSIP buffer flushes in bounded chunks
+    inside the INFOTABLE loop instead of one end-of-archive flush.
+
+    Parity bar: the flush helper aggregates COUNT/MIN/MAX grouped by
+    (cusip, source) with an ON CONFLICT that sums count + LEAST/GREATEST
+    of the periods, so N chunked flushes within one archive transaction
+    land byte-identical final rows to a single batch flush. This test
+    drives a SMALL chunk size so the buffer flushes multiple times —
+    including a (cusip) whose two holdings straddle a chunk boundary —
+    and asserts the per-(cusip) aggregate is exactly what a single flush
+    would produce.
+    """
+
+    def test_chunked_flush_matches_single_batch_aggregate(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.services import sec_13f_dataset_ingest as ingest_mod
+
+        # Seed nothing in the universe for these CUSIPs → every INFOTABLE
+        # row is unresolved and lands in the buffer.
+        flush_calls = {"n": 0}
+        real_flush = ingest_mod._flush_unresolved_buffer
+
+        def _counting_flush(*args: object, **kwargs: object) -> None:
+            flush_calls["n"] += 1
+            real_flush(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(ingest_mod, "_flush_unresolved_buffer", _counting_flush)
+        # Chunk of 2 → buffer flushes at sizes 2, 2, then the remainder.
+        monkeypatch.setattr(ingest_mod, "_UNRESOLVED_FLUSH_CHUNK", 2)
+
+        # Two accessions; 5 unresolved holdings across 4 distinct CUSIPs.
+        # Order is chosen so CHUNK0033's two holdings straddle a chunk
+        # boundary (rows 1 + 3) — proving cross-chunk COUNT summing via
+        # ON CONFLICT, not just within-chunk aggregation.
+        subs = [
+            {"ACCESSION_NUMBER": "0009990000-25-000001", "CIK": "9990000", "FILING_DATE": "2025-11-14"},
+            {"ACCESSION_NUMBER": "0009990000-25-000002", "CIK": "9990000", "FILING_DATE": "2025-11-14"},
+        ]
+        covers = [
+            {
+                "ACCESSION_NUMBER": "0009990000-25-000001",
+                "FILINGMANAGER_NAME": "Chunk Fund",
+                "REPORTCALENDARORQUARTER": "2025-09-30",
+            },
+            {
+                "ACCESSION_NUMBER": "0009990000-25-000002",
+                "FILINGMANAGER_NAME": "Chunk Fund",
+                "REPORTCALENDARORQUARTER": "2025-09-30",
+            },
+        ]
+        infotable = [
+            {"ACCESSION_NUMBER": "0009990000-25-000001", "CUSIP": "CHUNK0033", "VALUE": "1", "SSHPRNAMT": "1"},
+            {"ACCESSION_NUMBER": "0009990000-25-000001", "CUSIP": "CHUNK0011", "VALUE": "1", "SSHPRNAMT": "1"},
+            {"ACCESSION_NUMBER": "0009990000-25-000001", "CUSIP": "CHUNK0033", "VALUE": "1", "SSHPRNAMT": "1"},
+            {"ACCESSION_NUMBER": "0009990000-25-000002", "CUSIP": "CHUNK0022", "VALUE": "1", "SSHPRNAMT": "1"},
+            {"ACCESSION_NUMBER": "0009990000-25-000002", "CUSIP": "CHUNK0044", "VALUE": "1", "SSHPRNAMT": "1"},
+        ]
+        archive_bytes = _build_dataset_zip(submissions=subs, coverpages=covers, infotable=infotable)
+        archive_path = tmp_path / "form13f_chunk.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_13f_dataset_archive(conn=ebull_test_conn, archive_path=archive_path, ingest_run_id=uuid4())
+        ebull_test_conn.commit()
+
+        # 5 unresolved holdings counted; nothing written (no universe match).
+        assert result.rows_written == 0
+        assert result.rows_skipped_unresolved_cusip == 5
+        # Chunking actually fired: flushes at 2, 2, remainder 1 = 3 calls.
+        assert flush_calls["n"] == 3
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT cusip, observation_count, first_period_end, last_period_end
+                FROM unresolved_13f_cusips
+                WHERE source = 'bulk_13f_dataset' AND cusip LIKE 'CHUNK00%'
+                ORDER BY cusip
+                """
+            )
+            rows = cur.fetchall()
+
+        # Exactly the single-batch aggregate: one row per distinct CUSIP,
+        # CHUNK0033 count=2 (summed ACROSS two separate chunk flushes).
+        from datetime import date as _date
+
+        assert rows == [
+            ("CHUNK0011", 1, _date(2025, 9, 30), _date(2025, 9, 30)),
+            ("CHUNK0022", 1, _date(2025, 9, 30), _date(2025, 9, 30)),
+            ("CHUNK0033", 2, _date(2025, 9, 30), _date(2025, 9, 30)),
+            ("CHUNK0044", 1, _date(2025, 9, 30), _date(2025, 9, 30)),
+        ]

--- a/tests/test_sec_nport_dataset_ingest.py
+++ b/tests/test_sec_nport_dataset_ingest.py
@@ -595,3 +595,112 @@ class TestIngestNPortDatasetArchive:
 
         assert result.rows_written == 0
         assert result.rows_skipped_missing_series == 1
+
+
+@pytest.mark.skipif(not _test_db_available(), reason="ebull_test DB unavailable")
+class TestUnresolvedChunkedFlushParity:
+    """#1436 — N-PORT unresolved-CUSIP buffer flushes in bounded chunks
+    inside the holding loop (before the staging drain, matching the 13F
+    sibling) instead of one end-of-archive flush. Same parity bar: the
+    flush helper's (cusip, source) aggregation is a commutative monoid,
+    so chunked flushes land byte-identical final rows to a single batch.
+    """
+
+    def test_chunked_flush_matches_single_batch_aggregate(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from datetime import date as _date
+
+        from app.services import sec_nport_dataset_ingest as ingest_mod
+
+        flush_calls = {"n": 0}
+        real_flush = ingest_mod._flush_unresolved_buffer
+
+        def _counting_flush(*args: object, **kwargs: object) -> None:
+            flush_calls["n"] += 1
+            real_flush(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(ingest_mod, "_flush_unresolved_buffer", _counting_flush)
+        monkeypatch.setattr(ingest_mod, "_UNRESOLVED_FLUSH_CHUNK", 2)
+
+        accn1 = "0009990000-25-000001"
+        accn2 = "0009990000-25-000002"
+        subs = [
+            {
+                "ACCESSION_NUMBER": accn1,
+                "FILING_DATE": "2025-11-30",
+                "SUB_TYPE": "NPORT-P",
+                "REPORT_DATE": "2025-09-30",
+            },
+            {
+                "ACCESSION_NUMBER": accn2,
+                "FILING_DATE": "2025-11-30",
+                "SUB_TYPE": "NPORT-P",
+                "REPORT_DATE": "2025-09-30",
+            },
+        ]
+        regs = [
+            {"ACCESSION_NUMBER": accn1, "CIK": "9990000", "REGISTRANT_NAME": "Chunk Trust"},
+            {"ACCESSION_NUMBER": accn2, "CIK": "9990000", "REGISTRANT_NAME": "Chunk Trust"},
+        ]
+        funds = [
+            {"ACCESSION_NUMBER": accn1, "SERIES_ID": "S000099000", "SERIES_NAME": "Chunk Series"},
+            {"ACCESSION_NUMBER": accn2, "SERIES_ID": "S000099000", "SERIES_NAME": "Chunk Series"},
+        ]
+
+        def _holding(accn: str, hid: str, cusip: str) -> dict[str, str]:
+            # Valid EC / Long / NS / positive-balance holding with an
+            # UNMAPPED cusip → lands in the unresolved buffer.
+            return {
+                "ACCESSION_NUMBER": accn,
+                "HOLDING_ID": hid,
+                "ISSUER_CUSIP": cusip,
+                "BALANCE": "500000",
+                "UNIT": "NS",
+                "CURRENCY_CODE": "USD",
+                "CURRENCY_VALUE": "1000000",
+                "PAYOFF_PROFILE": "Long",
+                "ASSET_CAT": "EC",
+            }
+
+        # CHUNK0033 straddles a chunk boundary (rows 1 + 3) → cross-chunk
+        # COUNT summing via ON CONFLICT.
+        holdings = [
+            _holding(accn1, "1", "CHUNK0033"),
+            _holding(accn1, "2", "CHUNK0011"),
+            _holding(accn1, "3", "CHUNK0033"),
+            _holding(accn2, "4", "CHUNK0022"),
+            _holding(accn2, "5", "CHUNK0044"),
+        ]
+        archive_bytes = _build_dataset_zip(submissions=subs, registrants=regs, fund_info=funds, holdings=holdings)
+        archive_path = tmp_path / "nport_chunk.zip"
+        archive_path.write_bytes(archive_bytes)
+
+        result = ingest_nport_dataset_archive(conn=ebull_test_conn, archive_path=archive_path, ingest_run_id=uuid4())
+        ebull_test_conn.commit()
+
+        assert result.rows_written == 0
+        assert result.rows_skipped_unresolved_cusip == 5
+        # Flushes at 2, 2, remainder 1 = 3 calls.
+        assert flush_calls["n"] == 3
+
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT cusip, observation_count, first_period_end, last_period_end
+                FROM unresolved_13f_cusips
+                WHERE source = 'bulk_nport_dataset' AND cusip LIKE 'CHUNK00%'
+                ORDER BY cusip
+                """
+            )
+            rows = cur.fetchall()
+
+        assert rows == [
+            ("CHUNK0011", 1, _date(2025, 9, 30), _date(2025, 9, 30)),
+            ("CHUNK0022", 1, _date(2025, 9, 30), _date(2025, 9, 30)),
+            ("CHUNK0033", 2, _date(2025, 9, 30), _date(2025, 9, 30)),
+            ("CHUNK0044", 1, _date(2025, 9, 30), _date(2025, 9, 30)),
+        ]


### PR DESCRIPTION
Closes #1436.

## What
Worker-RAM efficiency for the two bulk dataset ingesters. **No behaviour change — parity is the bar.** Two independent targets, both isolation-testable.

**Target 1 — `_open_tsv` whole-file `list[dict]` → streaming accession indexer.**
`SUBMISSION`/`COVERPAGE` (13F) and `SUBMISSION`/`REGISTRANT`/`FUND_REPORTED_INFO` (N-PORT) were materialised into a transient `list[dict]` held in worker RAM *alongside* the accession-keyed dict the caller actually used (O(rows)+O(accessions) peak). New `_index_tsv_by_accession` streams via the existing `_iter_tsv` and builds only the dict — O(accessions).
Parity: keeps the **last** row per accession (same as the overwriting dict-comprehension) and counts **every** row incl. duplicates / missing-key (same as `len(list(...))`) so the `*_seen` telemetry is byte-identical.

**Target 2 — `unresolved_buffer` one-shot flush → bounded 100k chunks.**
The buffer accumulated millions of `(cusip, filer_cik, period_end)` triples before a single end-of-archive flush. Now flushes at a 100k boundary **inside** the row loop. A live `cur.copy()` owns the connection protocol (cannot interleave other SQL mid-COPY), so the loop tears down + reopens the staging COPY at each chunk boundary — multiple COPY appends to one `ON COMMIT DROP` temp table are valid within the per-archive tx; reopened a handful of times per multi-million-row archive (negligible).

## Why chunked flush is byte-identical (parity proof)
`cusip_resolver.flush_unresolved_cusips_bulk` aggregates `COUNT(*)/MIN/MAX` grouped by `(cusip, source)`, and on conflict does `observation_count += EXCLUDED`, `first = LEAST(...)`, `last = GREATEST(...)`, `last_observed_at = NOW()` (tx-constant). That's a **commutative monoid** — N chunked flushes within one archive transaction land byte-identical final rows to a single batch flush, independent of how the buffer is split.

N-PORT note: the chunked flush now runs **during** the holding loop (before the staging drain), matching the 13F sibling. Failure isolation is unchanged — the flush's `with conn.transaction()` savepoint rolls back only its own writes on error, never the staged observations, independent of order. `unresolved_accns` (the seed-log hold-back set, not the triple buffer) is intentionally left intact and still consumed by the `n_port_ingest_log` seed.

Distinct from #1276 (per-row INSERT ceiling) and the prior PG OOM.

## Security model
No auth/authz surface. Pure in-process refactor of two internal ingest services driven by the manifest worker; no new external input, no SQL string-building from user data (parameterised throughout, unchanged). Both files remain on the `check_bulk_ingest_copy_pattern.sh` whitelist and still satisfy invariants A/B/C/D (no `with conn.transaction()` re-introduced inside a COPY body).

## Tests
- New pure-DB chunked-flush parity test per ingester (`TestUnresolvedChunkedFlushParity`): small chunk size, a CUSIP whose two holdings **straddle a chunk boundary** → exercises cross-chunk `COUNT` summing via `ON CONFLICT`; asserts the exact single-batch aggregate + the flush-call count.
- COPY-pattern lint guard green; ruff/ruff-format/pyright(0 errors)/fast-tier/smoke all green; targeted DB tier `-k "13f or nport or dataset_ingest"` exit 0.

## ETL DoD — parity + RAM proof on a real quarter (dev)
Ran a real archive (`form13f_01jun2025-31aug2025.zip`, 3.36M INFOTABLE rows, 1.10M unresolved CUSIPs) through the ingester in a **rolled-back** tx (no dev mutation) on `main` vs this branch, commit `710e5a6a`:

| | BEFORE (main) | AFTER (this PR) |
|---|---|---|
| rows_written | 1,478,876 | 1,478,876 ✓ |
| infotable_seen | 3,360,306 | 3,360,306 ✓ |
| unresolved | 1,101,668 | 1,101,668 ✓ |
| observation-row md5 | `56845a27…` | `56845a27…` ✓ |
| unresolved-marker md5 | `8e945743…` | `8e945743…` ✓ |
| **peak Python heap** (tracemalloc) | **188.8 MB** | **33.2 MB** (−82%, 5.7×) |
| peak RSS | 598.3 MB | 203.0 MB (−66%) |

Byte-identical writes (both checksums match), measured RAM win. N-PORT shares the identical two mechanisms (covered by its own parity test).

## Operator follow-up after merge
- Restart the jobs daemon onto new `main` (it runs this ingest code).
- **No `sec_rebuild` needed** — no parser_version bump, no output change. The before/after checksums are identical, so re-ingesting would reproduce the same rows; this is a pure RAM-streaming refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)