### PR TITLE
chore: rebase dev-DB size warn threshold 30 GB -> 60 GB

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -299,7 +299,7 @@ fi
 # || true on every docker exec so set -euo pipefail (top of file)
 # cannot kill the whole hook if psql is briefly unavailable — same
 # best-effort posture as the orphan-sweep cleanup.
-DB_SIZE_WARN_BYTES=32212254720  # 30 GB — rebased #1556; mirror of app/services/postgres_health.py
+DB_SIZE_WARN_BYTES=64424509440  # 60 GB — rebased #1556 then #1436-followup; mirror of app/services/postgres_health.py
 if command -v docker >/dev/null 2>&1; then
   db_size=$(docker exec ebull-postgres psql -U postgres -d ebull -tAc \
     "SELECT pg_database_size('ebull')" 2>/dev/null | tr -d ' ' || true)
@@ -312,7 +312,7 @@ if command -v docker >/dev/null 2>&1; then
     pretty=$(docker exec ebull-postgres psql -U postgres -d ebull -tAc \
       "SELECT pg_size_pretty(pg_database_size('ebull'))" 2>/dev/null \
       | tr -d ' ' || true)
-    echo '==> WARN: dev DB ebull size = '"${pretty}"' (> 30 GB).'
+    echo '==> WARN: dev DB ebull size = '"${pretty}"' (> 60 GB).'
     echo '==> WARN: investigate via GET /system/postgres-health.'
     echo '==> WARN: non-blocking; push continues.'
   fi

--- a/app/services/postgres_health.py
+++ b/app/services/postgres_health.py
@@ -3,8 +3,9 @@
 Surfaces the five operator signals that Phases 1-3 of #1208 lacked a
 live readout for:
 
-- `pg_database_size('ebull')` against a 30 GB warn threshold (matches
-  the pre-push hook gate at `.githooks/pre-push`; rebased by #1556).
+- `pg_database_size('ebull')` against a 60 GB warn threshold (matches
+  the pre-push hook gate at `.githooks/pre-push`; rebased by #1556 then
+  #1436 follow-up).
 - Leaked `ebull_test_*` DB count + names (Phase 2 enforced zero leaks
   but had no operator surface).
 - WAL: `wal_dir_bytes` (size of pg_wal/ on disk) against a 4 GB
@@ -57,11 +58,24 @@ logger = logging.getLogger(__name__)
 # genuine live data (always-red alarm = operator noise, same failure
 # class as #1221). Measured genuine baseline after the #1349 cusips
 # grain collapse + the #1014 primary_doc payload sweep + VACUUM FULL:
-# 15 GB (2026-06-10). 30 GB = 2x headroom over the swept baseline; the
-# alarm now means "something is growing unexpectedly", not "the DB
-# contains data".
+# 15 GB (2026-06-10).
+#
+# Rebased 30 GB -> 60 GB (2026-06-25, #1436 follow-up): the swept-15 GB
+# baseline no longer holds — the now-fully-ingested SEC ownership corpus
+# is genuine live data at 44 GB. Breakdown (investigated 2026-06-25):
+# filing_raw_documents 18 GB (dominated by ~27 GB-raw def14a_body, which
+# is CONSCIOUSLY retention-excluded in
+# `raw_payload_retention.SWEPT_DOCUMENT_KINDS` because the Item 403
+# ownership rewash consumer re-parses the stored body) + retention-bounded
+# 13F/N-PORT observation partitions (~11 GB). Dead-tuple ratios are low
+# (autovacuum healthy) — NOT bloat. The raw_payload_retention_sweep is
+# current (only ~274 MB eligible). 60 GB ~= 1.4x headroom over the 44 GB
+# real baseline; the alarm again means "growing unexpectedly", not "the
+# DB contains the data we deliberately ingested". A future def14a-body
+# retention/recompression decision (settled-decision change, operator
+# sign-off) is the only material lever to shrink it.
 
-DB_SIZE_WARN_BYTES: int = 30 * 1024 * 1024 * 1024  # 30 GB
+DB_SIZE_WARN_BYTES: int = 60 * 1024 * 1024 * 1024  # 60 GB
 # 4 GB absolute pg_wal disk-bloat alarm. Effective max_wal_size is 1 GB
 # (docker-compose `command:` flag, #1410), so steady-state pg_wal sits
 # well below this even during bootstrap write bursts; crossing 4 GB


### PR DESCRIPTION
## What
Bump the dev-DB `pg_database_size('ebull')` warn threshold `30 GB → 60 GB` in both mirrored sites (`.githooks/pre-push`, `app/services/postgres_health.py`).

## Why
The 30 GB threshold (#1556, rebased off a swept-15 GB baseline) now fires on **genuine live data**, not bloat. Investigated 2026-06-25 (post-#1436):

- DB = **44 GB**, dominated by `filing_raw_documents` 18 GB — of which ~27 GB-raw is `def14a_body`, **consciously retention-excluded** in `raw_payload_retention.SWEPT_DOCUMENT_KINDS` because the Item 403 ownership rewash consumer re-parses the stored body.
- Remaining: retention-bounded 13F/N-PORT observation partitions (~11 GB) + manifest/insider — all real full-population SEC data.
- Dead-tuple ratios low (5–12%, autovacuum healthy) → **no pathological bloat**. `raw_payload_retention_sweep` is current (only ~274 MB eligible; dry-run confirmed).

An always-red alarm is operator noise (same failure class as #1221/#1556). 60 GB ≈ 1.4× headroom over the 44 GB real baseline → the alarm again means "growing unexpectedly".

## Safety / scope
Pure threshold + comment change. No behaviour change to ingest/data. Both mirrors bumped in lockstep; alignment pinned by `tests/test_pre_push_hook_bloat_warn.py::test_pre_push_hook_threshold_matches_db_size_warn` (3 passed locally). Hook bash-syntax + ruff/format green.

## Deferred
The only material shrink lever — `def14a_body` retention/recompression (27 GB) — is a settled-decision change (those bodies feed the ownership rewash path). Deferred to operator sign-off once we've drilled into what data is actually cuttable; not folded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)