### PR TITLE
docs(#1304): Form 144 + SC 13E — delete retention rows, document metadata-only (wire-or-delete → delete)

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -1484,8 +1484,8 @@ eBull doesn't keep every historical filing forever. Each source has a backfill h
 | 10-K | last 3 annual | atom + daily-index | 3 filings |
 | 10-Q | last 8 quarterly | atom + daily-index | 8 filings |
 | FINRA short interest | last 2 years | bi-monthly per FINRA cadence | ~48 bi-monthly rows |
-| Form 144 | rolling 90 days (effective ≤ 90d post-filing) | atom | ephemeral |
-| SC 13E | last 2 years | atom + daily-index | rare event filings |
+
+> **Coverage scope (#1304):** Form 144 + SC 13E are **metadata-only** `filing_events` (`SEC_METADATA_ONLY` in [app/services/filings.py](../../../app/services/filings.py)) — no `ManifestSource` / parser / observation table, so they are deliberately off this structured-ingest table. No decision-path consumer reads insider sell-intent (not even Form 4's *executed* sells). Full source-rule rationale + re-open condition: [`sec-edgar.md` §11.2](../data-sources/sec-edgar.md) "Coverage scope".
 
 ### 13.A Backfill horizon enforcement
 

--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -742,8 +742,11 @@ Bootstrap drains the horizon. Steady-state refresh fetches only new accessions d
 | 10-K | last 3 annual | atom + daily-index |
 | 10-Q | last 8 quarterly | atom + daily-index |
 | FINRA short interest | last 2 years | bi-monthly per FINRA cadence |
-| Form 144 | rolling 90 days (filing → effective ≤ 90d) | atom |
-| SC 13E | last 2 years | atom + daily-index |
+
+**Coverage scope — Form 144 / SC 13E are metadata-only, NOT structurally parsed (#1304).** Both are captured as lightweight `filing_events` rows (`SEC_METADATA_ONLY`, [app/services/filings.py](../../../app/services/filings.py)) — visible in the filings feed but with **no `ManifestSource`, no `manifest_parsers/` parser, no observation table** (absent from `_FORM_TO_SOURCE`). They are deliberately off this structured-ingest table; their prior presence here over-claimed coverage.
+- **Source rule.** Form 144 (Rule 144) = *"Notice of Proposed Sale of Securities"* — insider *intent* to sell restricted/control shares (>5,000 sh or >$50k), filed *before* a sale that may never occur; the *executed* sale is **Form 4** (filed ≤2 business days), which eBull already ingests. Structured Form 144 XML exists only since the 2023-04-13 e-filing mandate (paper before). SC 13E (Rule 13e-3) = going-private / issuer-tender disclosure — a rare terminal corporate event.
+- **Why not wired.** No decision-path consumer reads insider sell-intent: `scoring` / `thesis` / `entry_timing` / `portfolio` / `execution_guard` carry zero insider references — eBull does not consume even Form 4's *executed* sells (insider data is display/audit-only: the ownership-rollup pie wedge + instrument page). A Form 144 observation surface would have no reader; SC 13E has no long-only use.
+- **Re-open condition.** Build an insider-sell decision signal off the already-ingested **Form 4** executed-sale data first; only then weigh whether Form 144's leading-indicator delta (intent ahead of execution) earns a dedicated ingest. Cross-ref `docs/specs/etl/retention-rubric.md` §4.14 (metadata-only forms).
 
 **Why per-source rather than uniform:** Form 4 has tens of millions of accessions in a 2-year window but is small per filing (~10 KB XML); the cost is well within bounds. 13F has fewer but heavier filings — limiting to 4 quarters keeps disk + parse cost bounded. Per-filing-size × per-source-cadence determines retention; arbitrary cutoffs cost storage without informing decisions.
 


### PR DESCRIPTION
## What

Wire-or-delete decision for SEC **Form 144** + **SC 13E**, which `sec-edgar.md §11.2` and `data-engineer/SKILL.md §13` listed in their **per-source backfill-horizon (structured-ingest) tables** but which are not built. Resolved by research → **delete both rows**; document them as the metadata-only forms they actually are.

Docs-only. Two skill files; no code, schema, parser, or data change.

## Decision: delete both (research-backed)

**Premise (confirmed + sharpened).** Neither form has a `ManifestSource` member ([`sec_manifest.py:107-122`](app/services/sec_manifest.py#L107-L122)), a `manifest_parsers/` parser, or a bootstrap stage. **But** both are already captured **metadata-only** as `filing_events` rows — `144` and `DEF 13E-3` live in `SEC_METADATA_ONLY` ([`filings.py:211-275`](app/services/filings.py#L211-L275): "No parser, no raw body… cheap insurance"). They appear in the filings feed; they are intentionally not parsed into observations. The retention-table rows wrongly implied **structured** ingest (they sat beside Form 4 / 13F / DEF 14A, all structurally parsed) — that was the false claim.

**Source rule (verified on SEC, not memory).**
- **Form 144** (Rule 144, Securities Act 1933) = *"Notice of Proposed Sale of Securities"* — insider **intent** to sell restricted/control shares (>5,000 sh or >$50k), filed **before** a sale that may never occur. The **executed** sale is **Form 4** (≤2 business days), which eBull **already ingests**. Structured Form 144 XML exists only since the **2023-04-13** e-filing mandate (paper before → thin history). (The issue's "dilution" framing is imprecise: Form 144 is affiliate distribution of *existing* restricted shares = selling pressure, not new-issuance dilution.)
- **SC 13E** (Rule 13e-3, Exchange Act) = going-private / issuer-tender disclosure — a rare terminal corporate event.

**Decisive — empty consumer surface.** No decision-path consumer reads insider sell-intent: `scoring.py`, `thesis.py`, `entry_timing.py`, `portfolio.py`, `execution_guard.py`, `app/api/scores.py` each carry **zero** `insider` references; no `recommendations`/`ranking` module exists. Every insider reader is display/audit/ingest (instrument page, ownership rollup/history/drillthrough, write-side). eBull does not consume even Form 4's *executed* sells — a strictly stronger signal than Form 144's intent. Wiring Form 144 ⇒ a new ManifestSource + parser + observation schema + bootstrap stage + backfill for a signal **nothing reads** (anti-KISS; violates "new data surface ships with a consumer"). SC 13E has no long-only use.

**Re-open condition** (recorded in the note): if an insider-sell decision signal is built, consume the already-ingested **Form 4** executed-sale data first; only then weigh whether Form 144's leading-indicator delta (intent ahead of execution) earns a dedicated ingest.

## Changes

- [`sec-edgar.md §11.2`](.claude/skills/data-sources/sec-edgar.md): remove the Form 144 + SC 13E rows from the backfill-horizon table; add a **Coverage scope** note (metadata-only status, full source rule, no-consumer reason, re-open condition).
- [`data-engineer/SKILL.md §13`](.claude/skills/data-engineer/SKILL.md): remove the mirror rows; add a short coverage-scope pointer to the §11.2 note (single source of truth — avoids drift).

Other docs already describe these forms correctly and are untouched: `retention.md`, `retention-rubric.md §4.14`, `sec-bulk-archives.md` (all say metadata-only / not consumed / future-ticket-gated); `edgartools.md` (library-capability matrix, not an eBull-coverage claim).

## Security model

N/A — documentation only. No endpoint, query, auth, or data path changes.

## ETL DoD (clauses 8-12)

**N/A — no data-path change.** No ManifestSource, parser, schema migration, or backfill. No `sec_rebuild`, no jobs-daemon restart. The forms' metadata-only `filing_events` capture is unchanged.

## Verification

- `git grep` sweep: the false structured-ingest claim existed only in the two retention tables; both trimmed. No other doc/skill relocates it.
- Relative links in the new notes resolve (`../../../app/services/filings.py`, `../data-sources/sec-edgar.md`) — match the files' existing link convention.
- Pre-push gate (ruff / format / pyright / shellcheck / chokepoint-lint / fast-tier pytest / smoke) is unaffected — no `.py`/`.sh` touched.

Closes #1304.
