### PR TITLE
perf(#1591): reuse stored body on re-drain in retained-kind SEC parsers (Part 1)

### DIFF
--- a/app/services/manifest_parsers/def14a.py
+++ b/app/services/manifest_parsers/def14a.py
@@ -79,7 +79,7 @@ from app.services.ownership_observations import (
     refresh_def14a_current,
     refresh_esop_current,
 )
-from app.services.raw_filings import store_raw
+from app.services.raw_filings import store_raw, stored_body
 from app.services.sec_identity import siblings_for_issuer_cik
 
 logger = logging.getLogger(__name__)
@@ -215,70 +215,80 @@ def _parse_def14a(
             error="latest-N primary cap",
         )
 
-    try:
-        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-            body = provider.fetch_document_text(url)
-    except Exception as exc:  # noqa: BLE001 — transient fetch errors retry via worker backoff
-        logger.warning(
-            "def14a manifest parser: fetch raised accession=%s url=%s: %s",
-            accession,
-            url,
-            exc,
-        )
-        return _failed_outcome(f"fetch error: {exc}")
-
-    # Resolve issuer CIK once; threaded through every outcome path so
-    # the ingest-log write doesn't re-issue the lookup (same shape as
-    # the legacy ingester's _AccessionOutcome.issuer_cik).
+    # Resolve issuer CIK once; threaded through every outcome path (the
+    # empty-body ingest-log write + the parse/upsert below) so neither
+    # re-issues the lookup. Hoisted above the fetch branch so the #1591
+    # reuse path resolves it too (same shape as the legacy ingester's
+    # _AccessionOutcome.issuer_cik).
     issuer_cik = _resolve_issuer_cik(conn, instrument_id=instrument_id) or _CIK_MISSING_SENTINEL
 
-    if not body:
-        # Non-200 or empty body. Legacy path returned status='failed'
-        # for this case; manifest path treats it as a tombstone so the
-        # row doesn't get retried forever on a persistently-404 doc.
-        # Write the ingest-log row with status='failed' to match legacy
-        # accounting; manifest itself records tombstoned.
+    # #1591 — reuse the stored body on a re-drain (parser-version bump →
+    # sec_rebuild resets the row to pending) instead of re-downloading.
+    # def14a_body is retained (avg ~725KB) and SEC filings are immutable
+    # per accession, so a present body is always safe to re-parse. Fetch +
+    # store only on a miss (first ingest); reuse skips both so fetched_at
+    # is not churned and the rate-limited SEC budget is spared.
+    body = stored_body(conn, accession_number=accession, document_kind="def14a_body")
+    if body is None:
+        try:
+            with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+                body = provider.fetch_document_text(url)
+        except Exception as exc:  # noqa: BLE001 — transient fetch errors retry via worker backoff
+            logger.warning(
+                "def14a manifest parser: fetch raised accession=%s url=%s: %s",
+                accession,
+                url,
+                exc,
+            )
+            return _failed_outcome(f"fetch error: {exc}")
+
+        if not body:
+            # Non-200 or empty body. Legacy path returned status='failed'
+            # for this case; manifest path treats it as a tombstone so the
+            # row doesn't get retried forever on a persistently-404 doc.
+            # Write the ingest-log row with status='failed' to match legacy
+            # accounting; manifest itself records tombstoned.
+            try:
+                with conn.transaction():
+                    _record_ingest_attempt(
+                        conn,
+                        accession_number=accession,
+                        issuer_cik=issuer_cik,
+                        status="failed",
+                        error="primary doc fetch returned empty or non-200",
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "def14a manifest parser: ingest-log INSERT failed accession=%s",
+                    accession,
+                )
+                return _failed_outcome(f"log error: {exc}")
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_DEF14A,
+                error="empty or non-200 fetch",
+            )
+
+        # store_raw in a savepoint so a partial write doesn't abort the
+        # worker's outer transaction. The body lands in
+        # filing_raw_documents BEFORE parse so a downstream re-wash can
+        # reparse without re-fetching from SEC.
         try:
             with conn.transaction():
-                _record_ingest_attempt(
+                store_raw(
                     conn,
                     accession_number=accession,
-                    issuer_cik=issuer_cik,
-                    status="failed",
-                    error="primary doc fetch returned empty or non-200",
+                    document_kind="def14a_body",
+                    payload=body,
+                    parser_version=_PARSER_VERSION_DEF14A,
+                    source_url=url,
                 )
         except Exception as exc:  # noqa: BLE001
             logger.exception(
-                "def14a manifest parser: ingest-log INSERT failed accession=%s",
+                "def14a manifest parser: store_raw failed accession=%s",
                 accession,
             )
-            return _failed_outcome(f"log error: {exc}")
-        return ParseOutcome(
-            status="tombstoned",
-            parser_version=_PARSER_VERSION_DEF14A,
-            error="empty or non-200 fetch",
-        )
-
-    # store_raw in a savepoint so a partial write doesn't abort the
-    # worker's outer transaction. The body lands in
-    # filing_raw_documents BEFORE parse so a downstream re-wash can
-    # reparse without re-fetching from SEC.
-    try:
-        with conn.transaction():
-            store_raw(
-                conn,
-                accession_number=accession,
-                document_kind="def14a_body",
-                payload=body,
-                parser_version=_PARSER_VERSION_DEF14A,
-                source_url=url,
-            )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "def14a manifest parser: store_raw failed accession=%s",
-            accession,
-        )
-        return _failed_outcome(f"store_raw error: {exc}")
+            return _failed_outcome(f"store_raw error: {exc}")
 
     # Parse-phase exceptions must return raw_status='stored' because
     # store_raw already committed inside its savepoint — the manifest
@@ -444,6 +454,9 @@ def _def14a_fetch_url(conn: psycopg.Connection[Any], row: Any) -> str | None:  #
         pre-fetch. This gate needs a DB read (ranks proxies via
         ``filing_events``) — hence the ``conn`` in the #1700 hook contract.
         Calls the SAME helper the parser calls (one rank source of truth).
+      * #1591 — body already stored → the parser REUSES it (no fetch), so
+        skip the prefetch (prevention-log #1956). Checked LAST, after the
+        cheap row-local gates, so a gated-out row never pays the DB read.
     An over-broad ``None`` is always safe (serial fallback reaches the
     identical tombstone).
     """
@@ -455,6 +468,8 @@ def _def14a_fetch_url(conn: psycopg.Connection[Any], row: Any) -> str | None:  #
     if row.instrument_id is None:
         return None
     if not def14a_within_cap(conn, accession_number=row.accession_number, instrument_id=row.instrument_id):
+        return None
+    if stored_body(conn, accession_number=row.accession_number, document_kind="def14a_body") is not None:
         return None
     return url
 

--- a/app/services/manifest_parsers/insider_345.py
+++ b/app/services/manifest_parsers/insider_345.py
@@ -82,7 +82,7 @@ from app.services.manifest_parsers._classify import (
     format_upsert_error,
     is_transient_upsert_error,
 )
-from app.services.raw_filings import store_raw
+from app.services.raw_filings import DocumentKind, store_raw, stored_body
 
 logger = logging.getLogger(__name__)
 
@@ -174,58 +174,66 @@ def _parse_form4(
 
     canonical_url = _canonical_form_4_url(url)
 
-    try:
-        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-            xml = provider.fetch_document_text(canonical_url)
-    except Exception as exc:  # noqa: BLE001 — transient retries via 1h backoff
-        logger.warning(
-            "form4 manifest parser: fetch raised accession=%s url=%s: %s",
-            accession,
-            canonical_url,
-            exc,
-        )
-        return _failed_outcome(f"fetch error: {exc}", parser_version=_PARSER_VERSION_FORM4)
+    # #1591 — reuse the stored body on a re-drain (parser-version bump →
+    # sec_rebuild resets the row to pending) instead of re-downloading.
+    # SEC filings are immutable per accession, so a present form4_xml body
+    # is always safe to re-parse. Fetch + store only on a miss (first
+    # ingest); reuse skips both so fetched_at is not churned and the
+    # rate-limited SEC budget is spared.
+    xml = stored_body(conn, accession_number=accession, document_kind="form4_xml")
+    if xml is None:
+        try:
+            with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+                xml = provider.fetch_document_text(canonical_url)
+        except Exception as exc:  # noqa: BLE001 — transient retries via 1h backoff
+            logger.warning(
+                "form4 manifest parser: fetch raised accession=%s url=%s: %s",
+                accession,
+                canonical_url,
+                exc,
+            )
+            return _failed_outcome(f"fetch error: {exc}", parser_version=_PARSER_VERSION_FORM4)
 
-    if not xml:
-        # Empty / non-200. Legacy tombstones the row in insider_filings;
-        # mirror so dashboard counts match. Savepoint isolates the
-        # tombstone write from the outer worker tx.
+        if not xml:
+            # Empty / non-200. Legacy tombstones the row in insider_filings;
+            # mirror so dashboard counts match. Savepoint isolates the
+            # tombstone write from the outer worker tx.
+            try:
+                with conn.transaction():
+                    _write_tombstone(
+                        conn,
+                        instrument_id=instrument_id,
+                        accession_number=accession,
+                        primary_document_url=canonical_url,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "form4 manifest parser: tombstone INSERT failed accession=%s",
+                    accession,
+                )
+                return _failed_outcome(f"tombstone error: {exc}", parser_version=_PARSER_VERSION_FORM4)
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_FORM4,
+                error="empty or non-200 fetch",
+            )
+
         try:
             with conn.transaction():
-                _write_tombstone(
+                store_raw(
                     conn,
-                    instrument_id=instrument_id,
                     accession_number=accession,
-                    primary_document_url=canonical_url,
+                    document_kind="form4_xml",
+                    payload=xml,
+                    parser_version=_PARSER_VERSION_FORM4,
+                    source_url=canonical_url,
                 )
         except Exception as exc:  # noqa: BLE001
             logger.exception(
-                "form4 manifest parser: tombstone INSERT failed accession=%s",
+                "form4 manifest parser: store_raw failed accession=%s",
                 accession,
             )
-            return _failed_outcome(f"tombstone error: {exc}", parser_version=_PARSER_VERSION_FORM4)
-        return ParseOutcome(
-            status="tombstoned",
-            parser_version=_PARSER_VERSION_FORM4,
-            error="empty or non-200 fetch",
-        )
-
-    try:
-        with conn.transaction():
-            store_raw(
-                conn,
-                accession_number=accession,
-                document_kind="form4_xml",
-                payload=xml,
-                parser_version=_PARSER_VERSION_FORM4,
-                source_url=canonical_url,
-            )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "form4 manifest parser: store_raw failed accession=%s",
-            accession,
-        )
-        return _failed_outcome(f"store_raw error: {exc}", parser_version=_PARSER_VERSION_FORM4)
+            return _failed_outcome(f"store_raw error: {exc}", parser_version=_PARSER_VERSION_FORM4)
 
     # Parse-phase exceptions AFTER store_raw must return
     # raw_status='stored' so the manifest matches filing_raw_documents
@@ -390,55 +398,60 @@ def _parse_form3(
 
     canonical_url = _canonical_form_4_url(url)
 
-    try:
-        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-            xml = provider.fetch_document_text(canonical_url)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "form3 manifest parser: fetch raised accession=%s url=%s: %s",
-            accession,
-            canonical_url,
-            exc,
-        )
-        return _failed_outcome(f"fetch error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
+    # #1591 — reuse the stored body on a re-drain instead of re-downloading
+    # (SEC filings immutable per accession; see _parse_form4). Fetch + store
+    # only on a miss; reuse skips both.
+    xml = stored_body(conn, accession_number=accession, document_kind="form3_xml")
+    if xml is None:
+        try:
+            with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+                xml = provider.fetch_document_text(canonical_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "form3 manifest parser: fetch raised accession=%s url=%s: %s",
+                accession,
+                canonical_url,
+                exc,
+            )
+            return _failed_outcome(f"fetch error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
 
-    if not xml:
+        if not xml:
+            try:
+                with conn.transaction():
+                    _write_form_3_tombstone(
+                        conn,
+                        instrument_id=instrument_id,
+                        accession_number=accession,
+                        primary_document_url=canonical_url,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "form3 manifest parser: tombstone INSERT failed accession=%s",
+                    accession,
+                )
+                return _failed_outcome(f"tombstone error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_FORM3_PARSER_VERSION_STR,
+                error="empty or non-200 fetch",
+            )
+
         try:
             with conn.transaction():
-                _write_form_3_tombstone(
+                store_raw(
                     conn,
-                    instrument_id=instrument_id,
                     accession_number=accession,
-                    primary_document_url=canonical_url,
+                    document_kind="form3_xml",
+                    payload=xml,
+                    parser_version=_FORM3_PARSER_VERSION_STR,
+                    source_url=canonical_url,
                 )
         except Exception as exc:  # noqa: BLE001
             logger.exception(
-                "form3 manifest parser: tombstone INSERT failed accession=%s",
+                "form3 manifest parser: store_raw failed accession=%s",
                 accession,
             )
-            return _failed_outcome(f"tombstone error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
-        return ParseOutcome(
-            status="tombstoned",
-            parser_version=_FORM3_PARSER_VERSION_STR,
-            error="empty or non-200 fetch",
-        )
-
-    try:
-        with conn.transaction():
-            store_raw(
-                conn,
-                accession_number=accession,
-                document_kind="form3_xml",
-                payload=xml,
-                parser_version=_FORM3_PARSER_VERSION_STR,
-                source_url=canonical_url,
-            )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "form3 manifest parser: store_raw failed accession=%s",
-            accession,
-        )
-        return _failed_outcome(f"store_raw error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
+            return _failed_outcome(f"store_raw error: {exc}", parser_version=_FORM3_PARSER_VERSION_STR)
 
     try:
         parsed = parse_form_3_xml(xml)
@@ -779,12 +792,11 @@ def _parse_form5(
     )
 
 
-def _insider_fetch_url(conn: Any, row: Any) -> str | None:  # conn: Connection (unused), row: ManifestRow
+def _insider_fetch_url(conn: Any, row: Any) -> str | None:  # conn: Connection, row: ManifestRow
     """#1686 Phase 2 prefetch hook — the SINGLE canonical ownership-XML URL
     Form 3/4/5 parsers GET, returned ONLY when the parser would actually
-    fetch it. ``conn`` is part of the #1700 hook contract (DEF 14A needs a
-    DB read for its cap gate); the insider gates are all row-local so it is
-    unused here.
+    fetch it. ``conn`` (part of the #1700 hook contract) is used for the
+    #1591 stored-body gate below.
 
     The hook MUST mirror every PRE-FETCH tombstone gate the parser applies,
     or the concurrent prefetch wastes SEC rate budget fetching bodies the
@@ -795,6 +807,11 @@ def _insider_fetch_url(conn: Any, row: Any) -> str | None:  # conn: Connection (
       * Form 4 past the 3y cap (``form4_within_retention``) / Form 5 past the
         18-month cap (``form5_within_retention``) → pre-fetch tombstone.
         Form 3 has NO retention gate, so it is fetched whenever it has a URL.
+      * #1591 — body already stored → the parser REUSES it (no fetch), so
+        skip the prefetch (prevention-log #1956: a prefetch hook must mirror
+        EVERY pre-fetch gate, reuse included, or it burns the budget it
+        exists to save). Checked LAST (after the cheap row-local gates) so a
+        gated-out row never pays the DB read.
     Returning ``None`` here just means "no prefetch" — the parser still runs
     serially and reaches the identical tombstone, so an over-broad ``None``
     is always safe (worst case: no speedup)."""
@@ -805,6 +822,15 @@ def _insider_fetch_url(conn: Any, row: Any) -> str | None:  # conn: Connection (
     if row.source == "sec_form4" and not form4_within_retention(filed):
         return None
     if row.source == "sec_form5" and not form5_within_retention(filed):
+        return None
+    # Map source → the EXACT stored kind; fail closed (Codex ckpt-1 #4).
+    # ``sec_form5`` is deliberately absent — _parse_form5 does NOT reuse
+    # (form5_xml stays KEPT_NEGLIGIBLE per #1617), so it falls through and
+    # prefetches as before. A shared form4_xml check would wrongly skip
+    # Form 3/5 rows whose form4_xml body happens to exist.
+    reuse_kind: dict[str, DocumentKind] = {"sec_form3": "form3_xml", "sec_form4": "form4_xml"}
+    kind = reuse_kind.get(row.source)
+    if kind is not None and stored_body(conn, accession_number=row.accession_number, document_kind=kind) is not None:
         return None
     return _canonical_form_4_url(url)
 

--- a/app/services/manifest_parsers/sec_13dg.py
+++ b/app/services/manifest_parsers/sec_13dg.py
@@ -74,7 +74,7 @@ from app.services.manifest_parsers._schedule13_adapter import (
     build_filing_from_edgartools_dict,
 )
 from app.services.ownership_observations import refresh_blockholders_current
-from app.services.raw_filings import store_raw
+from app.services.raw_filings import store_raw, stored_body
 
 logger = logging.getLogger(__name__)
 
@@ -178,63 +178,70 @@ def _parse_13dg(
     # an HTML wrapper and immediately tombstone-on-parse.
     primary_url = _archive_file_url(filer_cik, accession, "primary_doc.xml")
 
-    try:
-        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-            primary_xml = provider.fetch_document_text(primary_url)
-    except Exception as exc:  # noqa: BLE001 — transient fetch errors retry via backoff
-        logger.warning(
-            "13D/G manifest parser: fetch raised accession=%s url=%s: %s",
-            accession,
-            primary_url,
-            exc,
-        )
-        return _failed_outcome(f"fetch error: {exc}")
+    # #1591 — reuse the stored body on a re-drain (parser-version bump →
+    # sec_rebuild resets the row to pending) instead of re-downloading.
+    # primary_doc_13dg is retained and SEC filings are immutable per
+    # accession, so a present body is always safe to re-parse. Fetch +
+    # store only on a miss (first ingest); reuse skips both.
+    primary_xml = stored_body(conn, accession_number=accession, document_kind="primary_doc_13dg")
+    if primary_xml is None:
+        try:
+            with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+                primary_xml = provider.fetch_document_text(primary_url)
+        except Exception as exc:  # noqa: BLE001 — transient fetch errors retry via backoff
+            logger.warning(
+                "13D/G manifest parser: fetch raised accession=%s url=%s: %s",
+                accession,
+                primary_url,
+                exc,
+            )
+            return _failed_outcome(f"fetch error: {exc}")
 
-    if not primary_xml:
-        # Empty / non-200. Log the attempt with status='failed' to
-        # match legacy accounting; manifest itself tombstones so we
-        # don't spin retry on a persistently-404 doc.
+        if not primary_xml:
+            # Empty / non-200. Log the attempt with status='failed' to
+            # match legacy accounting; manifest itself tombstones so we
+            # don't spin retry on a persistently-404 doc.
+            try:
+                with conn.transaction():
+                    _record_ingest_attempt(
+                        conn,
+                        filer_cik=filer_cik,
+                        accession_number=accession,
+                        submission_type=None,
+                        status="failed",
+                        error="primary_doc.xml fetch returned empty or non-200",
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "13D/G manifest parser: ingest-log INSERT failed accession=%s",
+                    accession,
+                )
+                return _failed_outcome(f"log error: {exc}")
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_13DG,
+                error="empty or non-200 fetch",
+            )
+
+        # store_raw in a savepoint so the worker's outer tx stays clean
+        # on partial failure. Raw body persisted BEFORE parse so #938
+        # invariant holds even when downstream raises.
         try:
             with conn.transaction():
-                _record_ingest_attempt(
+                store_raw(
                     conn,
-                    filer_cik=filer_cik,
                     accession_number=accession,
-                    submission_type=None,
-                    status="failed",
-                    error="primary_doc.xml fetch returned empty or non-200",
+                    document_kind="primary_doc_13dg",
+                    payload=primary_xml,
+                    parser_version=_PARSER_VERSION_13DG,
+                    source_url=primary_url,
                 )
         except Exception as exc:  # noqa: BLE001
             logger.exception(
-                "13D/G manifest parser: ingest-log INSERT failed accession=%s",
+                "13D/G manifest parser: store_raw failed accession=%s",
                 accession,
             )
-            return _failed_outcome(f"log error: {exc}")
-        return ParseOutcome(
-            status="tombstoned",
-            parser_version=_PARSER_VERSION_13DG,
-            error="empty or non-200 fetch",
-        )
-
-    # store_raw in a savepoint so the worker's outer tx stays clean
-    # on partial failure. Raw body persisted BEFORE parse so #938
-    # invariant holds even when downstream raises.
-    try:
-        with conn.transaction():
-            store_raw(
-                conn,
-                accession_number=accession,
-                document_kind="primary_doc_13dg",
-                payload=primary_xml,
-                parser_version=_PARSER_VERSION_13DG,
-                source_url=primary_url,
-            )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "13D/G manifest parser: store_raw failed accession=%s",
-            accession,
-        )
-        return _failed_outcome(f"store_raw error: {exc}")
+            return _failed_outcome(f"store_raw error: {exc}")
 
     # Parse-phase errors AFTER store_raw must return
     # raw_status='stored' so the manifest matches filing_raw_documents.
@@ -429,14 +436,14 @@ def _parse_13dg(
     )
 
 
-def _blockholder_fetch_url(conn: Any, row: Any) -> str | None:  # conn unused; row: ManifestRow
+def _blockholder_fetch_url(conn: Any, row: Any) -> str | None:  # conn: Connection; row: ManifestRow
     """#1700 Phase 2 prefetch hook — the SINGLE canonical primary_doc.xml URL
     the 13D/G parser GETs, returned ONLY when the parser would actually fetch
     it. Mirrors EVERY pre-fetch gate in :func:`_parse_13dg` (in order), so
     prefetch never burns SEC budget on a row the parser tombstones before any
-    HTTP. All gates are row-local — ``conn`` is unused (part of the shared
-    hook contract). An over-broad ``None`` is always safe (serial fallback
-    reaches the identical tombstone).
+    HTTP. ``conn`` (part of the shared hook contract) is used for the #1591
+    stored-body gate below. An over-broad ``None`` is always safe (serial
+    fallback reaches the identical tombstone).
     """
     filer_cik = (row.cik or "").strip()
     if not filer_cik:
@@ -450,6 +457,10 @@ def _blockholder_fetch_url(conn: Any, row: Any) -> str | None:  # conn unused; r
         return None  # parser tombstones pre-fetch: agent CIK
     if not blockholders_within_retention(row.filed_at):
         return None  # parser tombstones pre-fetch: retention floor
+    # #1591 — body already stored → parser reuses it; skip prefetch
+    # (prevention-log #1956). Checked last, after the cheap row-local gates.
+    if stored_body(conn, accession_number=row.accession_number, document_kind="primary_doc_13dg") is not None:
+        return None
     # Same canonical URL the parser builds (sec_13dg.py:_parse_13dg).
     return _archive_file_url(filer_cik, row.accession_number, "primary_doc.xml")
 

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -267,6 +267,37 @@ def read_raw(
     return _row_to_document(row)
 
 
+def stored_body(
+    conn: psycopg.Connection[Any],
+    *,
+    accession_number: str,
+    document_kind: DocumentKind,
+) -> str | None:
+    """Return a stored body to REUSE in place of an upstream re-fetch, or
+    ``None`` when the caller must fetch.
+
+    ``None`` covers two cases the caller handles identically (fetch):
+
+      * no ``filing_raw_documents`` row yet — first ingest.
+      * the row exists but ``payload IS NULL`` — a SWEPT / born-compacted
+        kind (#1014 / #1615). Reuse is impossible; the caller rehydrates
+        from ``source_url`` (i.e. re-fetches).
+
+    A non-``None`` return is always safe to reuse without a freshness
+    check: SEC filings are **immutable once filed** (an amendment is a NEW
+    accession with its own number), so for a fixed ``(accession_number,
+    document_kind)`` a present body never goes stale — "present" ==
+    "fresh". The manifest-worker parsers (#1591) call this BEFORE their
+    fetch so a re-drain (parser-version bump → ``sec_rebuild`` resets rows
+    to pending) re-parses the stored body instead of re-downloading it.
+
+    Only valid for retained kinds (a payload reader on a SWEPT kind is
+    barred by ``tests/test_raw_payload_retention.py``); SWEPT kinds always
+    return ``None`` here and fall through to the fetch path."""
+    doc = read_raw(conn, accession_number=accession_number, document_kind=document_kind)
+    return doc.payload if doc is not None else None
+
+
 def _row_to_document(row: dict[str, Any]) -> RawFilingDocument:
     """Map a dict_row to the dataclass. ``payload`` / ``byte_count``
     are NULL on swept rows (#1014) — must map to ``None``, never

--- a/docs/proposals/etl/2026-06-26-1591-rewash-reuse-and-drain-concurrency.md
+++ b/docs/proposals/etl/2026-06-26-1591-rewash-reuse-and-drain-concurrency.md
@@ -1,0 +1,162 @@
+# #1591 — Rewash/drain efficiency: reuse stored bodies (retained kinds) + drain concurrency
+
+Status: proposal (unshipped). PR1 branch `feature/1591-rewash-reuse-stored-html`; PR2 follows.
+
+## Problem
+
+A `sec_rebuild` re-drain (and the standalone #554 drain) re-runs the manifest-worker
+parsers, which **refetch the upstream body unconditionally** even when it is already in
+`filing_raw_documents`. Observed in the #554 backfill: ~4.7 s/row, ~1 req/s against a
+10 req/s throttle. Two compounding costs → two PRs.
+
+## Source rule
+
+- **SEC filings are immutable once filed.** A given accession's documents never change
+  after acceptance; an amendment is a NEW accession with its own number (sec-edgar skill
+  §filing identity; settled-decisions "Filing dedupe"). So for a fixed `(accession,
+  document_kind)` a stored body is permanently fresh — "present" == "reusable", no decay.
+- **Raw-payload retention is partitioned by settled #1617** (settled-decisions.md,
+  "Raw-payload retention"): every `DocumentKind` is exactly one of re-read (REWASH) /
+  housekept (SWEPT, born-compacted) / kept-negligible. A stored-body READER may be added
+  only for a kind whose payload is retained — adding one for a SWEPT kind fails
+  `tests/test_raw_payload_retention.py::test_swept_kinds_have_no_rewash_parser` +
+  `::test_retention_buckets_are_pairwise_disjoint`.
+
+## Full-population verification (dev DB `filing_raw_documents`, 2026-06-26)
+
+| document_kind | rows | with_payload | swept | avg_bytes | reusable on re-drain? |
+|---|---:|---:|---:|---:|---|
+| form4_xml | 465,150 | 465,150 | 0 | 6.7K | ✅ |
+| **primary_doc** (10-K/8-K/13F-primary) | 111,297 | 38,413 | **72,884** | 73K | ❌ SWEPT #1617 → 100% |
+| form3_xml | 59,916 | 59,916 | 0 | 5.8K | ✅ |
+| def14a_body | 42,137 | 42,137 | 0 | **725K** | ✅ |
+| primary_doc_13dg | 27,743 | 27,743 | 0 | 10K | ✅ |
+| infotable_13f | 16,237 | 16,237 | 0 | 198K | ✅ (multi-doc → follow-up) |
+| form5_xml | 1,586 | 1,586 | 0 | 7.1K | ✅ |
+| nport_xml | 151 | 151 | 0 | 72K | KEPT_NEGLIGIBLE → follow-up |
+
+**Premise correction.** The ticket's flagship `_parse_sec_10k` (`primary_doc`) is the ONE
+kind that is born-compacted (`SWEPT_MANIFEST_SOURCES={sec_10k,sec_8k}`, raw_filings.py:89;
+65 % already swept, trending 100 %). Reuse there is value-dead AND CI-blocked. The real
+reuse win is the retained ownership kinds. Operator decision 2026-06-26: **retarget Part 1
+to the retained kinds; keep Part 2 concurrency for 10-K/8-K** (whose only lever is overlap,
+since their body must be rehydrated). No manifest parser reuses a stored body today.
+
+## PR1 — reuse stored bodies (retained single-primary kinds)
+
+Scope: `_parse_def14a`, `_parse_form4`, `_parse_form3`, `_parse_13dg` (4 parsers).
+Out: `primary_doc` (born-compacted), 13F infotable (multi-doc), n_port + **form5_xml**
+(both KEPT_NEGLIGIBLE — a manifest-parser READER would falsify their #1617 "no payload
+reader" justification; Form 5 is 1,586 rows / 7 KB so the win is negligible anyway →
+follow-up, promote out of `KEPT_NEGLIGIBLE_DOCUMENT_KINDS` if/when reused). Codex ckpt-1.
+
+New helper in `app/services/raw_filings.py` (sibling to `read_raw`, single store home):
+
+```python
+def stored_body(conn, *, accession_number, document_kind) -> str | None:
+    """Stored payload for reuse, or None when absent OR swept (caller must
+    fetch). 'present' == 'fresh' — SEC filings are immutable per accession."""
+    doc = read_raw(conn, accession_number=accession_number, document_kind=document_kind)
+    return doc.payload if doc is not None else None
+```
+
+Each parser, replacing its unconditional fetch+store with a reuse-first branch (all
+existing PRE-FETCH gates — instrument_id / url / filed_at / retention / def14a cap — stay
+ABOVE this; reuse replaces only the fetch, never a gate):
+
+```python
+body = stored_body(conn, accession_number=accession, document_kind="<kind>")
+if body is None:                       # first ingest, or swept → rehydrate
+    <existing fetch via provider.fetch_document_text(...)>
+    if not body: <existing empty-body tombstone>
+    <existing store_raw(...)>          # fetch path only
+# parse(body) — unchanged
+```
+
+Invariants preserved:
+- **#938 store-before-parse** holds on reuse — the row already exists with a payload.
+- **fetched_at not churned** on reuse (no re-store) — matches `_bump_parser_version`'s
+  "preserve operator-visible last-published timestamp" rule.
+- **raw_status="stored"** on the reuse path (the row has a payload) — the worker's #938
+  audit (`effective_raw_status`) passes without a store_raw call.
+- Empty-body guard runs on the fetch path only; stored bodies are non-empty by
+  construction (`store_raw` rejects empty).
+- def14a hoists its `issuer_cik` resolve + insider/13dg hoist `canonical_url`/`primary_url`
+  ABOVE the branch (pure / body-independent; both paths need them downstream).
+
+**Mirror the new pre-fetch gate in the prefetch hooks** (prevention-log #1956 — a hook
+that front-runs a gated consumer must replicate EVERY pre-fetch gate, else it burns the
+budget it exists to save). `_insider_fetch_url`, `_def14a_fetch_url`, `_blockholder_fetch_url`
+return `None` when the body is already stored. Placed AFTER the existing cheap gates so a
+gated-out row never pays the DB read. Hooks run savepoint-wrapped in `_prefetch_bodies`
+(prevention-log #1963), so the read is safe on the shared conn.
+
+- def14a → `def14a_body`; 13d/g → `primary_doc_13dg` (single kind each).
+- `_insider_fetch_url` is shared by Form 3/4/5, so map `row.source` to the EXACT kind via
+  an explicit `{"sec_form3": "form3_xml", "sec_form4": "form4_xml"}` dict and **fail
+  closed** — a source NOT in the dict (notably `sec_form5`, which PR1 does NOT reuse) skips
+  the stored-check and prefetches as today (Codex ckpt-1 #4: a shared `form4_xml` check
+  would wrongly skip Form 3/5 rows). The dict's keys == the set of reused insider sources.
+
+Pre-impl invariant audit: confirm EVERY post-body outcome in each of the 4 parsers
+(success, parse-failure, tombstone, transient-upsert-fail, deterministic-upsert-tombstone)
+already returns `raw_status="stored"`. The reuse branch joins the flow at the parse step,
+so those returns must hold for the reuse path identically (Codex ckpt-1 #2 — else a
+reuse-hit failure with manifest `row.raw_status='absent'` would mis-trip the worker's #938
+audit). They do today (the "8-K Codex round 2 BLOCKING" rule); the audit just verifies none
+slipped.
+
+Tests (pure-logic preferred):
+- `stored_body`: hit → payload; missing row → None; swept (payload None) → None.
+- each parser, stored-hit SUCCESS: reuses (no fetch, no store_raw, parses, outcome
+  `raw_status="stored"`). Fake provider (asserts un-called) + store_raw spy.
+- each parser, stored-hit FAILURE: a parse-raising body on the reuse path still returns
+  `raw_status="stored"` (construct the manifest row with `raw_status="absent"` to prove the
+  outcome repairs `effective_raw_status`). Codex ckpt-1 #2.
+- each parser, MISS: fetches + stores (existing behaviour unchanged).
+- each hook: returns None when stored; returns URL when not stored; `_insider_fetch_url`
+  with `sec_form5` prefetches even when a `form5_xml` body exists (fail-closed mapping);
+  existing gate tests unchanged.
+
+## PR2 — drain concurrency (serial paths + 10-K/8-K hooks)
+
+The fairness tick is already concurrent (#1686/#1700 prefetch cache + hooks). Two gaps:
+
+1. **Serial re-drain paths.** `run_manifest_worker(source=...)` (per-source rebuild, what
+   `sec_rebuild` drains into) and the standalone drain call `_dispatch_rows` directly.
+   Swap the per-source rebuild to the existing `_prefetch_then_dispatch` (binds the #1686
+   cache) so a re-drain overlaps fetches against the shared throttle.
+2. **10-K/8-K have no `fetch_url` hook** → never prefetched. Add `_sec10k_fetch_url` /
+   `_eight_k_fetch_url` mirroring their pre-fetch gates (url present, instrument_id
+   present; no retention gate), returning `primary_document_url`. XBRL linkbase prefetch
+   for 10-K (separate provider + `index.json` discovery) is out of scope, documented.
+
+Throttle: reuses `concurrent_fetch` over the shared `_PROCESS_RATE_LIMIT_*` clock —
+overlaps wait, never exceeds 10 req/s. Single per-process budget; no multi-process
+(ticket non-goal — aggregate would exceed SEC fair-access).
+
+Accepted tradeoff (Codex ckpt-1 #5): prefetching the whole batch up front widens the
+pre-dispatch window, so a row another drainer parses between prefetch and dispatch wastes
+its prefetched fetch. This is a rate-budget cost, never data corruption (the serial parser
+still re-checks/transitions; the standalone drain already rolls back `parsed→parsed`
+races), and is the identical property the fairness tick already ships (#1686). No fresh
+status re-read added — the per-source rebuild scope is normally drained by one worker.
+
+Tests: `_sec10k_fetch_url` / `_eight_k_fetch_url` return None on missing url/instrument_id,
+URL otherwise; per-source rebuild path prefetches (cache bound).
+
+## Dev-verify (ETL DoD 8-12)
+
+- **PR1:** scoped `POST /jobs/sec_rebuild/run` on a known instrument's def14a + form4;
+  assert parse output BYTE-IDENTICAL to a fetch-path run (parity ⇒ no data change) and
+  count HTTP saved (= reused rows). Smoke def14a ownership rollup + form4 insider rows for
+  AAPL/MSFT.
+- **PR2:** scoped sec_10k re-drain; confirm req-rate rises toward the throttle + wall-clock
+  drops; AAPL/MSFT 10-K business-summary + segments unchanged.
+- Parity proven ⇒ no `sec_rebuild` backfill needed for correctness (output row-identical);
+  restart the jobs daemon onto new main post-merge (parser-touching).
+
+## Non-goals
+
+Multi-process drains; un-compacting `primary_doc` (#1617); 13F infotable + n_port reuse
+(follow-up); XBRL linkbase prefetch.

--- a/tests/test_manifest_parser_def14a.py
+++ b/tests/test_manifest_parser_def14a.py
@@ -625,3 +625,117 @@ def test_parser_registered_via_register_all() -> None:
 
     register_all_parsers()
     assert "sec_def14a" in registered_parser_sources()
+
+
+# ---------------------------------------------------------------------------
+# #1591 — reuse the stored body on a re-drain instead of re-fetching from SEC
+# ---------------------------------------------------------------------------
+
+
+def _no_fetch(_self: object, _url: str) -> str:
+    raise AssertionError("stored body must be reused — no SEC fetch on re-drain")
+
+
+def test_def14a_reuse_stored_body_skips_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1591 — when the def14a_body (avg ~725KB) is already stored, the parser
+    REUSES it on a re-drain: no SEC fetch, no re-store (fetched_at preserved),
+    holdings still write from the stored body. The pre-fetch latest-N cap gate
+    still runs above the reuse (it sits before the fetch)."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+    from app.services.raw_filings import store_raw
+
+    iid = 8740050
+    acc = "0000320193-26-000050"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPLR", cik="0000320193")
+    _seed_pending_def14a(ebull_test_conn, accession=acc, instrument_id=iid)
+    store_raw(
+        ebull_test_conn,
+        accession_number=acc,
+        document_kind="def14a_body",
+        payload=_FAKE_DEF14A_HTML,
+        parser_version="def14a-v1",
+        source_url="https://www.sec.gov/Archives/edgar/data/320193/000032019326000050/def14a.htm",
+    )
+    ebull_test_conn.commit()
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT fetched_at FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'def14a_body'",
+            (acc,),
+        )
+        before_row = cur.fetchone()
+    assert before_row is not None
+    fetched_at_before = before_row[0]
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _no_fetch)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, acc)
+    assert row is not None and row.ingest_status == "parsed" and row.raw_status == "stored"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM def14a_beneficial_holdings WHERE accession_number = %s AND instrument_id = %s",
+            (acc, iid),
+        )
+        c = cur.fetchone()
+    assert c is not None and c[0] >= 2
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT fetched_at FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'def14a_body'",
+            (acc,),
+        )
+        after_row = cur.fetchone()
+    assert after_row is not None and after_row[0] == fetched_at_before
+
+
+def test_def14a_reuse_failure_preserves_raw_status_stored(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1591 / Codex ckpt-1 #2 — a post-body failure on the REUSE path returns
+    raw_status='stored'. A notice-only proxy (no beneficial-ownership table)
+    tombstones AFTER the body is in hand; the outcome must repair a fresh
+    pending row's raw_status='absent' to 'stored', identical to the fetch
+    path. Hoisting issuer_cik above the reuse branch keeps the tombstone
+    ingest-log write intact."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+    from app.services.raw_filings import store_raw
+
+    iid = 8740051
+    acc = "0000320193-26-000051"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPLF", cik="0000320193")
+    _seed_pending_def14a(ebull_test_conn, accession=acc, instrument_id=iid)
+    store_raw(
+        ebull_test_conn,
+        accession_number=acc,
+        document_kind="def14a_body",
+        payload=_NOTICE_ONLY_DEF14A_HTML,
+        parser_version="def14a-v1",
+        source_url="https://www.sec.gov/Archives/edgar/data/320193/000032019326000051/def14a.htm",
+    )
+    ebull_test_conn.commit()
+
+    row_before = get_manifest_row(ebull_test_conn, acc)
+    assert row_before is not None and row_before.raw_status == "absent"
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _no_fetch)
+
+    run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, acc)
+    assert row is not None
+    assert row.raw_status == "stored"  # repaired from 'absent'
+    assert row.ingest_status == "tombstoned"

--- a/tests/test_manifest_parser_insider_345.py
+++ b/tests/test_manifest_parser_insider_345.py
@@ -1118,3 +1118,154 @@ def test_parser_registers_form3_form4_form5() -> None:
     assert "sec_form3" in registered_parser_sources()
     assert "sec_form4" in registered_parser_sources()
     assert "sec_form5" in registered_parser_sources()
+
+
+# ---------------------------------------------------------------------------
+# #1591 — reuse the stored body on a re-drain instead of re-fetching from SEC
+# ---------------------------------------------------------------------------
+
+# Well-formed-open but never-closed → the XML parser raises, exercising the
+# post-body parse-failure path on the REUSE branch.
+_MALFORMED_OWNERSHIP_XML = "<ownershipDocument><unclosed>"
+
+
+def _no_fetch(_self: object, _url: str) -> str:
+    raise AssertionError("stored body must be reused — no SEC fetch on re-drain")
+
+
+def test_form4_reuse_stored_body_skips_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1591 — when the form4_xml body is already in filing_raw_documents (a
+    re-drain after a parser-version bump → sec_rebuild resets the row to
+    pending), _parse_form4 REUSES it: no SEC fetch, no re-store (fetched_at
+    preserved), and the typed rows still write from the stored body."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+    from app.services.raw_filings import store_raw
+
+    iid = 8760050
+    acc = "0000320193-26-000050"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPLR")
+    _seed_pending(ebull_test_conn, accession=acc, instrument_id=iid, source="sec_form4", form="4")
+    store_raw(
+        ebull_test_conn,
+        accession_number=acc,
+        document_kind="form4_xml",
+        payload=_FAKE_FORM_4_XML,
+        parser_version="form4-v1",
+        source_url="https://www.sec.gov/Archives/edgar/data/320193/000032019326000050/primary_doc.xml",
+    )
+    ebull_test_conn.commit()
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT fetched_at FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'form4_xml'",
+            (acc,),
+        )
+        before_row = cur.fetchone()
+    assert before_row is not None
+    fetched_at_before = before_row[0]
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _no_fetch)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, acc)
+    assert row is not None and row.ingest_status == "parsed" and row.raw_status == "stored"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM insider_transactions WHERE accession_number = %s", (acc,))
+        c = cur.fetchone()
+    assert c is not None and c[0] >= 1
+
+    # Reuse must NOT re-store → fetched_at unchanged (preserves the
+    # operator-visible "when SEC last published"; matches _bump_parser_version).
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT fetched_at FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'form4_xml'",
+            (acc,),
+        )
+        after_row = cur.fetchone()
+    assert after_row is not None and after_row[0] == fetched_at_before
+
+
+def test_form4_reuse_failure_preserves_raw_status_stored(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1591 / Codex ckpt-1 #2 — a parse failure on the REUSE path must still
+    return raw_status='stored' so the worker's #938 audit sees the body as
+    present, even though a fresh pending row starts raw_status='absent'.
+    Proves effective_raw_status is repaired by the outcome on the reuse
+    branch, identically to the fetch path."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+    from app.services.raw_filings import store_raw
+
+    iid = 8760051
+    acc = "0000320193-26-000051"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPLF")
+    _seed_pending(ebull_test_conn, accession=acc, instrument_id=iid, source="sec_form4", form="4")
+    store_raw(
+        ebull_test_conn,
+        accession_number=acc,
+        document_kind="form4_xml",
+        payload=_MALFORMED_OWNERSHIP_XML,
+        parser_version="form4-v1",
+        source_url="https://www.sec.gov/Archives/edgar/data/320193/000032019326000051/primary_doc.xml",
+    )
+    ebull_test_conn.commit()
+
+    row_before = get_manifest_row(ebull_test_conn, acc)
+    assert row_before is not None and row_before.raw_status == "absent"
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _no_fetch)
+
+    run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
+    ebull_test_conn.commit()
+
+    row = get_manifest_row(ebull_test_conn, acc)
+    assert row is not None
+    assert row.raw_status == "stored"  # repaired from 'absent' on the failure path
+    assert row.ingest_status in ("failed", "tombstoned")
+
+
+def test_form3_reuse_stored_body_skips_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1591 — Form 3 reuses its stored form3_xml body on re-drain. Guards the
+    per-parser document_kind wiring (same branch shape as Form 4)."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+    from app.services.raw_filings import store_raw
+
+    iid = 8760052
+    acc = "0000320193-26-000052"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL3R")
+    _seed_pending(ebull_test_conn, accession=acc, instrument_id=iid, source="sec_form3", form="3")
+    store_raw(
+        ebull_test_conn,
+        accession_number=acc,
+        document_kind="form3_xml",
+        payload=_FAKE_FORM_3_XML,
+        parser_version="form3-v1",
+        source_url="https://www.sec.gov/Archives/edgar/data/320193/000032019326000052/primary_doc.xml",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _no_fetch)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form3", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, acc)
+    assert row is not None and row.ingest_status == "parsed" and row.raw_status == "stored"

--- a/tests/test_manifest_parser_sec_13dg.py
+++ b/tests/test_manifest_parser_sec_13dg.py
@@ -910,3 +910,58 @@ def test_parser_registered_for_both_sources() -> None:
     register_all_parsers()
     assert "sec_13d" in registered_parser_sources()
     assert "sec_13g" in registered_parser_sources()
+
+
+# ---------------------------------------------------------------------------
+# #1591 — reuse the stored body on a re-drain instead of re-fetching from SEC
+# ---------------------------------------------------------------------------
+
+
+def _no_fetch(_self: object, _url: str) -> str:
+    raise AssertionError("stored body must be reused — no SEC fetch on re-drain")
+
+
+def test_13dg_reuse_stored_body_skips_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1591 — when the primary_doc_13dg body is already stored, _parse_13dg
+    REUSES it on a re-drain: no SEC fetch, and the filer/filing rows still
+    write from the stored body (re-resolving the issuer from the parsed
+    CUSIP). Guards the per-parser document_kind wiring."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+    from app.services.raw_filings import store_raw
+
+    acc = "0001140361-25-040863"
+    _seed_instrument_with_cusip(ebull_test_conn, iid=8750050, symbol="ELR", cusip="518439104")
+    _seed_pending_13dg(ebull_test_conn, accession=acc, filer_cik="0002093607", source="sec_13d", form="SC 13D")
+    store_raw(
+        ebull_test_conn,
+        accession_number=acc,
+        document_kind="primary_doc_13dg",
+        payload=_FAKE_13D_XML,
+        parser_version="13dg-primary-v1",
+        source_url="https://www.sec.gov/Archives/edgar/data/2093607/000114036125040863/primary_doc.xml",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _no_fetch)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13d", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, acc)
+    assert row is not None and row.ingest_status == "parsed" and row.raw_status == "stored"
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT submission_type, instrument_id FROM blockholder_filings WHERE accession_number = %s",
+            (acc,),
+        )
+        bf = cur.fetchall()
+    assert len(bf) == 1
+    assert bf[0][0] == "SCHEDULE 13D"
+    assert bf[0][1] == 8750050  # CUSIP re-resolved from the reused body

--- a/tests/test_manifest_worker_prefetch.py
+++ b/tests/test_manifest_worker_prefetch.py
@@ -80,6 +80,18 @@ def _row(*, source: str, url: str | None, accession: str) -> ManifestRow:
     )
 
 
+def _fake_stored_body(*present_kinds: str) -> Any:
+    """A ``stored_body`` stand-in for the pure hook tests: returns a body for
+    the given ``document_kind``s (simulating a re-drain where the payload is
+    already on disk), ``None`` otherwise. Lets the #1591 reuse gate be
+    exercised without a DB cursor."""
+
+    def _f(_conn: Any, *, accession_number: str, document_kind: str) -> str | None:
+        return "<stored/>" if document_kind in present_kinds else None
+
+    return _f
+
+
 # --- fetch chokepoint cache read ------------------------------------------
 
 
@@ -190,16 +202,21 @@ def test_prefetch_empty_when_no_hooks(monkeypatch: pytest.MonkeyPatch) -> None:
 # --- _insider_fetch_url mirrors the parser's pre-fetch gates ---------------
 
 
-def test_insider_fetch_url_mirrors_prefetch_gates() -> None:
+def test_insider_fetch_url_mirrors_prefetch_gates(monkeypatch: pytest.MonkeyPatch) -> None:
     """The hook must NOT return a URL for a row the parser would tombstone
     before fetching — else the prefetch wastes SEC budget (Codex ckpt-2 HIGH)."""
     from datetime import timedelta
 
+    import app.services.manifest_parsers.insider_345 as ins
     from app.services.manifest_parsers.insider_345 import _insider_fetch_url
 
     recent = datetime.now(tz=UTC) - timedelta(days=30)
     old = datetime(2015, 1, 1, tzinfo=UTC)  # past both the 3y + 18mo caps
     base = "https://www.sec.gov/Archives/edgar/data/1/000/primary_doc.xml"
+
+    # Default: nothing stored, so the gate asserts below exercise the
+    # row-local gates only (the #1591 stored-body gate is a no-op here).
+    monkeypatch.setattr(ins, "stored_body", _fake_stored_body())
 
     # In-retention Form 4 with a URL + instrument_id → prefetch (canonical, XSL-free).
     assert _insider_fetch_url(None, _mk(source="sec_form4", url=base, filed_at=recent, iid=1)) is not None
@@ -212,6 +229,15 @@ def test_insider_fetch_url_mirrors_prefetch_gates() -> None:
     assert _insider_fetch_url(None, _mk(source="sec_form5", url=base, filed_at=old, iid=1)) is None
     # Form 3 has NO retention gate — an old Form 3 with a URL is still fetched.
     assert _insider_fetch_url(None, _mk(source="sec_form3", url=base, filed_at=old, iid=1)) is not None
+
+    # #1591 — body already stored → skip prefetch (parser reuses it from the DB).
+    monkeypatch.setattr(ins, "stored_body", _fake_stored_body("form4_xml"))
+    assert _insider_fetch_url(None, _mk(source="sec_form4", url=base, filed_at=recent, iid=1)) is None
+    # Fail-closed map (Codex ckpt-1 #4): Form 5 is NOT reused by _parse_form5,
+    # so its source is absent from the reuse map — a stored form5_xml body must
+    # NOT skip the prefetch (the parser will fetch it).
+    monkeypatch.setattr(ins, "stored_body", _fake_stored_body("form5_xml"))
+    assert _insider_fetch_url(None, _mk(source="sec_form5", url=base, filed_at=recent, iid=1)) is not None
 
 
 def _mk(*, source: str, url: str | None, filed_at: Any, iid: int | None) -> ManifestRow:
@@ -377,10 +403,13 @@ def test_prefetch_no_pass2_when_no_expander(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_blockholder_fetch_url_mirrors_gates(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.services.manifest_parsers.sec_13dg as d13dg
     from app.services.manifest_parsers.sec_13dg import _blockholder_fetch_url
 
     recent = datetime.now(tz=UTC)  # within blockholders retention (post-mandate)
     old = datetime(2010, 1, 1, tzinfo=UTC)  # pre-cutoff → tombstone pre-fetch
+
+    monkeypatch.setattr(d13dg, "stored_body", _fake_stored_body())  # nothing stored
 
     ok = _mk(source="sec_13d", url=None, filed_at=recent, iid=1)
     assert _blockholder_fetch_url(None, ok) is not None  # cik present, not agent, in retention
@@ -392,6 +421,10 @@ def test_blockholder_fetch_url_mirrors_gates(monkeypatch: pytest.MonkeyPatch) ->
 
     no_cik = dataclasses.replace(ok, cik="")
     assert _blockholder_fetch_url(None, no_cik) is None
+    # #1591 — body already stored → skip prefetch (parser reuses it).
+    monkeypatch.setattr(d13dg, "stored_body", _fake_stored_body("primary_doc_13dg"))
+    assert _blockholder_fetch_url(None, ok) is None
+    monkeypatch.setattr(d13dg, "stored_body", _fake_stored_body())  # reset: nothing stored
     # Agent CIK → None.
     monkeypatch.setattr("app.providers.implementations.sec_edgar.KNOWN_FILING_AGENT_CIKS", {"0000000001"})
     assert _blockholder_fetch_url(None, ok) is None
@@ -402,6 +435,7 @@ def test_def14a_fetch_url_mirrors_gates(monkeypatch: pytest.MonkeyPatch) -> None
     from app.services.manifest_parsers.def14a import _def14a_fetch_url
 
     monkeypatch.setattr(d14a, "def14a_within_cap", lambda *a, **k: True)
+    monkeypatch.setattr(d14a, "stored_body", _fake_stored_body())  # nothing stored
     base = "https://www.sec.gov/Archives/edgar/data/1/000/proxy.htm"
     recent = datetime.now(tz=UTC)
     ok = _mk(source="sec_def14a", url=base, filed_at=recent, iid=1)
@@ -416,6 +450,11 @@ def test_def14a_fetch_url_mirrors_gates(monkeypatch: pytest.MonkeyPatch) -> None
     assert _def14a_fetch_url(None, pre) is None  # type: ignore[arg-type]
     # Past the latest-N cap → None (gate needs conn; helper stubbed False).
     monkeypatch.setattr(d14a, "def14a_within_cap", lambda *a, **k: False)
+    assert _def14a_fetch_url(None, ok) is None  # type: ignore[arg-type]
+    # #1591 — body already stored → skip prefetch (parser reuses it). Cap reset
+    # to True so the None below is attributable to the stored-body gate alone.
+    monkeypatch.setattr(d14a, "def14a_within_cap", lambda *a, **k: True)
+    monkeypatch.setattr(d14a, "stored_body", _fake_stored_body("def14a_body"))
     assert _def14a_fetch_url(None, ok) is None  # type: ignore[arg-type]
 
 

--- a/tests/test_manifest_worker_prefetch.py
+++ b/tests/test_manifest_worker_prefetch.py
@@ -80,14 +80,22 @@ def _row(*, source: str, url: str | None, accession: str) -> ManifestRow:
     )
 
 
-def _fake_stored_body(*present_kinds: str) -> Any:
+# Accession `_mk` stamps on every gate-test row (via `_row`); the stored-body
+# stub keys on it so a hook querying the WRONG accession is caught.
+_MK_ACCESSION = "0000000001-26-000001"
+
+
+def _fake_stored_body(*present_pairs: tuple[str, str]) -> Any:
     """A ``stored_body`` stand-in for the pure hook tests: returns a body for
-    the given ``document_kind``s (simulating a re-drain where the payload is
-    already on disk), ``None`` otherwise. Lets the #1591 reuse gate be
-    exercised without a DB cursor."""
+    the given ``(accession_number, document_kind)`` pairs (simulating a re-drain
+    where that exact filing's payload is on disk), ``None`` otherwise. Keying on
+    BOTH accession and kind means a hook that queries the wrong accession (e.g. a
+    hardcoded literal instead of ``row.accession_number``) or the wrong kind is
+    caught — the stub returns None and the hook fails to skip (Claude review
+    NITPICK on #1727). Lets the #1591 reuse gate be exercised without a DB."""
 
     def _f(_conn: Any, *, accession_number: str, document_kind: str) -> str | None:
-        return "<stored/>" if document_kind in present_kinds else None
+        return "<stored/>" if (accession_number, document_kind) in present_pairs else None
 
     return _f
 
@@ -231,12 +239,12 @@ def test_insider_fetch_url_mirrors_prefetch_gates(monkeypatch: pytest.MonkeyPatc
     assert _insider_fetch_url(None, _mk(source="sec_form3", url=base, filed_at=old, iid=1)) is not None
 
     # #1591 — body already stored → skip prefetch (parser reuses it from the DB).
-    monkeypatch.setattr(ins, "stored_body", _fake_stored_body("form4_xml"))
+    monkeypatch.setattr(ins, "stored_body", _fake_stored_body((_MK_ACCESSION, "form4_xml")))
     assert _insider_fetch_url(None, _mk(source="sec_form4", url=base, filed_at=recent, iid=1)) is None
     # Fail-closed map (Codex ckpt-1 #4): Form 5 is NOT reused by _parse_form5,
     # so its source is absent from the reuse map — a stored form5_xml body must
     # NOT skip the prefetch (the parser will fetch it).
-    monkeypatch.setattr(ins, "stored_body", _fake_stored_body("form5_xml"))
+    monkeypatch.setattr(ins, "stored_body", _fake_stored_body((_MK_ACCESSION, "form5_xml")))
     assert _insider_fetch_url(None, _mk(source="sec_form5", url=base, filed_at=recent, iid=1)) is not None
 
 
@@ -422,7 +430,7 @@ def test_blockholder_fetch_url_mirrors_gates(monkeypatch: pytest.MonkeyPatch) ->
     no_cik = dataclasses.replace(ok, cik="")
     assert _blockholder_fetch_url(None, no_cik) is None
     # #1591 — body already stored → skip prefetch (parser reuses it).
-    monkeypatch.setattr(d13dg, "stored_body", _fake_stored_body("primary_doc_13dg"))
+    monkeypatch.setattr(d13dg, "stored_body", _fake_stored_body((_MK_ACCESSION, "primary_doc_13dg")))
     assert _blockholder_fetch_url(None, ok) is None
     monkeypatch.setattr(d13dg, "stored_body", _fake_stored_body())  # reset: nothing stored
     # Agent CIK → None.
@@ -454,7 +462,7 @@ def test_def14a_fetch_url_mirrors_gates(monkeypatch: pytest.MonkeyPatch) -> None
     # #1591 — body already stored → skip prefetch (parser reuses it). Cap reset
     # to True so the None below is attributable to the stored-body gate alone.
     monkeypatch.setattr(d14a, "def14a_within_cap", lambda *a, **k: True)
-    monkeypatch.setattr(d14a, "stored_body", _fake_stored_body("def14a_body"))
+    monkeypatch.setattr(d14a, "stored_body", _fake_stored_body((_MK_ACCESSION, "def14a_body")))
     assert _def14a_fetch_url(None, ok) is None  # type: ignore[arg-type]
 
 

--- a/tests/test_raw_filings.py
+++ b/tests/test_raw_filings.py
@@ -355,3 +355,60 @@ def test_byte_count_generated_from_octet_length(
     )
     assert doc is not None
     assert doc.byte_count == len(b"<short/>")
+
+
+# ---------------------------------------------------------------------------
+# #1591 — stored_body: reuse a present body, else fall through to fetch
+# ---------------------------------------------------------------------------
+
+
+def test_stored_body_returns_payload_on_hit(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A retained kind with a present payload returns the body for reuse."""
+    conn = ebull_test_conn
+    raw_filings.store_raw(
+        conn,
+        accession_number="0001767470-26-000091",
+        document_kind="form4_xml",
+        payload=_SAMPLE_FORM4,
+        parser_version="form4-v1",
+    )
+    conn.commit()
+    assert (
+        raw_filings.stored_body(conn, accession_number="0001767470-26-000091", document_kind="form4_xml")
+        == _SAMPLE_FORM4
+    )
+
+
+def test_stored_body_returns_none_on_missing_row(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """No row → None → the caller fetches (first ingest)."""
+    assert (
+        raw_filings.stored_body(ebull_test_conn, accession_number="9999999999-26-000000", document_kind="form4_xml")
+        is None
+    )
+
+
+def test_stored_body_returns_none_on_swept_payload(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A SWEPT kind (primary_doc) is born-compacted (payload NULL) by
+    store_raw, so stored_body returns None and the caller rehydrates /
+    re-fetches — reuse is impossible for a body that was never stored. This
+    is exactly why #1591 excludes 10-K/8-K from the reuse retarget."""
+    conn = ebull_test_conn
+    raw_filings.store_raw(
+        conn,
+        accession_number="0000000009-26-000001",
+        document_kind="primary_doc",
+        payload="<html>10-K body</html>",
+        parser_version="10k-v2",
+        source_url="https://www.sec.gov/Archives/edgar/data/9/000/primary.htm",
+    )
+    conn.commit()
+    # Sanity: the row exists but its payload was born-compacted to NULL.
+    doc = raw_filings.read_raw(conn, accession_number="0000000009-26-000001", document_kind="primary_doc")
+    assert doc is not None and doc.payload is None
+    assert raw_filings.stored_body(conn, accession_number="0000000009-26-000001", document_kind="primary_doc") is None


### PR DESCRIPTION
**Part of #1591** — Part 1 of 2. Does NOT close #1591 (Part 2 = drain concurrency for 10-K/8-K follows).

## What
SEC manifest-worker parsers `_parse_def14a` / `_parse_form4` / `_parse_form3` / `_parse_13dg` now REUSE the stored `filing_raw_documents` body on a re-drain instead of re-fetching from SEC. New `raw_filings.stored_body(conn, *, accession_number, document_kind) -> str | None` returns the stored payload (or `None` → fetch). Each parser reads it before fetching; on a hit it skips the SEC GET **and** `store_raw` (so `fetched_at` is not churned), then falls through to the unchanged parse/upsert. The three prefetch hooks (`_insider_fetch_url` / `_def14a_fetch_url` / `_blockholder_fetch_url`) mirror the new reuse gate (return `None` when stored) so the fairness-tick prefetch doesn't re-fetch a body the parser reads from the DB (prevention-log #1956).

## Why / premise correction
#1591 as filed targeted `_parse_sec_10k`, but the 10-K body is `document_kind="primary_doc"`, which is **born-compacted/SWEPT** (settled #1617; `SWEPT_MANIFEST_SOURCES={sec_10k,sec_8k}`) — the bytes are deliberately not stored, so there is nothing to reuse, and a stored-body reader on a SWEPT kind fails `tests/test_raw_payload_retention.py` by design. The reuse win is the RETAINED ownership kinds. Operator decision 2026-06-26: retarget Part 1 to those; bring concurrency to 10-K/8-K in Part 2 (their only lever — their body must be rehydrated).

## Source rule
SEC filings are immutable once filed (an amendment is a NEW accession). For a fixed `(accession, document_kind)` a present body never goes stale — "present" == "fresh"; no freshness check needed.

## Full-population verification (dev DB `filing_raw_documents`, 2026-06-26)
| kind | rows | with_payload | swept |
|---|--:|--:|--:|
| form4_xml | 465,150 | 465,150 | 0 |
| primary_doc (10-K/8-K) | 111,297 | 38,413 | 72,884 |
| form3_xml | 59,916 | 59,916 | 0 |
| def14a_body | 42,137 | 42,137 | 0 |
| primary_doc_13dg | 27,743 | 27,743 | 0 |
| infotable_13f | 16,237 | 16,237 | 0 |

Retained kinds = 100% payload (reusable); `primary_doc` = 65%→100% swept (excluded).

## Invariants preserved
- **#938** store-before-parse: holds on reuse — the row already has a payload.
- **raw_status="stored"** on EVERY post-body outcome (success / parse-error / parsed-None tombstone / transient-upsert / deterministic-tombstone): the reuse branch joins the parse step where those returns already hard-code it. `*_reuse_failure_preserves_raw_status_stored` pins it with a manifest row starting `raw_status='absent'`.
- **fetched_at not churned** on reuse (no re-store) — test asserts before == after.
- All pre-fetch gates (instrument_id / url / filed_at / retention / def14a latest-N cap) stay ABOVE the reuse — reuse replaces only the fetch.

## Scope
**In:** def14a, form4, form3, 13dg (single-primary retained kinds). **Out:** `primary_doc` 10-K/8-K (SWEPT — Part 2 instead); `form5_xml` + `nport_xml` (KEPT_NEGLIGIBLE — a reader would falsify their #1617 "no payload reader" justification; deferred); 13F infotable (multi-doc; deferred).

## Security model
No auth/authz surface. Reuse reads the SAME-accession stored body the parser would have fetched; the parse path (and its input validation) is unchanged. `stored_body` parameterises `accession_number` + `document_kind` (no raw-SQL interpolation).

## Tests — all green (ruff, pyright 0, fast tier `-m "not db"`, smoke, db tier on changed files)
- `stored_body`: hit→payload / missing→None / SWEPT `primary_doc`→None.
- per-parser reuse SUCCESS (no fetch, parsed, raw_status stored) for form4/form3/def14a/13dg; form4 + def14a also assert `fetched_at` preserved.
- form4 + def14a reuse-FAILURE → `raw_status='stored'` repaired from `'absent'`.
- 3 prefetch hooks: skip when stored; `_insider_fetch_url` fail-closed (`sec_form5` still prefetches even with a stored `form5_xml` body).

## Dev-verify (ETL DoD 8-12) @ f2f1b61f
- **Clause 8/11 smoke:** `/instruments/{AAPL,MSFT,GME,JPM,HD}/ownership-rollup` → HTTP 200, shape intact (data parity-unchanged).
- **Clause 9 parity / cross-check:** re-parsed **12 REAL dev-DB accessions** (3 each: def14a/form4/form3/13dg) via the reuse path with `SecFilingsProvider.fetch_document_text` patched to RAISE — all returned `parsed` + `raw=stored`, **0 HTTP fetches total** (rolled-back tx; running daemon untouched). Same immutable body → deterministic parser → output identical to the fetch path.
- **Clause 10 backfill:** NOT required — parity-preserving (output byte-identical to the fetch path), so no `sec_rebuild` needed for correctness. Justified-skip.

## Codex
- ckpt-1 (spec): 5 findings, all folded in (form5 excluded; raw_status failure-path tests; fail-closed source→kind map; PR2 pre-dispatch-window tradeoff documented).
- ckpt-2 (branch): **no findings.**

## Non-goals / follow-up
Part 2 (#1591): bounded prefetch on the serial `sec_rebuild` / standalone drain + `fetch_url` hooks for `sec_10k`/`sec_8k`. `form5`/`nport`/13F-infotable reuse: follow-up.

Spec: `docs/proposals/etl/2026-06-26-1591-rewash-reuse-and-drain-concurrency.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
