### PR TITLE
perf(#1591): concurrent prefetch on per-source re-drain + 10-K/8-K fetch_url hooks (Part 2)

### DIFF
--- a/app/jobs/sec_manifest_worker.py
+++ b/app/jobs/sec_manifest_worker.py
@@ -295,11 +295,17 @@ def run_manifest_worker(
         now = datetime.now(tz=UTC)
 
     if source is not None:
-        # Per-source rebuild path — unchanged shape.
+        # Per-source rebuild path (sec_rebuild, scoped operator re-drain).
         rows: list[ManifestRow] = list(iter_pending(conn, source=source, limit=max_rows))
         if len(rows) < max_rows:
             rows.extend(iter_retryable(conn, source=source, limit=max_rows - len(rows)))
-        return _dispatch_rows(conn, rows, now=now)
+        # #1591 Part 2 — prefetch this batch's bodies concurrently against the
+        # shared SEC throttle before the serial dispatch, same as the fairness
+        # path. The dominant re-drain cost is the per-row SEC fetch
+        # (~4.7s/row, ~1 req/s observed in the #554 backlog); overlapping the
+        # fetches saturates the 10 req/s floor. No-op for sources without a
+        # ``fetch_url`` hook (empty cache → identical to the old serial path).
+        return _prefetch_then_dispatch(conn, rows, now=now)
 
     # Fairness path (#1179) — Phase R recent-first slice (#1685) +
     # Phase A per-source oldest slice + Phase B global oldest top-up.
@@ -505,11 +511,37 @@ def _prefetch_then_dispatch(
     """#1686 Phase 2 — prefetch single-doc bodies concurrently, bind the
     tick-scoped cache, then run the serial per-row :func:`_dispatch_rows`.
 
-    Used ONLY by the steady-state fairness path (``source is None``) — that
-    is the every-5-min cron + boot catch-up that drains the backlog, the
-    target of #1686. The per-source rebuild path (``sec_rebuild``, operator-
-    triggered + scoped) stays serial via a direct :func:`_dispatch_rows`
-    call — small, operator-paced, no concurrency win needed.
+    Used by BOTH worker paths: the steady-state fairness path (``source is
+    None`` — the every-5-min cron + boot catch-up, the original #1686 target)
+    AND, since #1591 Part 2, the per-source rebuild path (``sec_rebuild``,
+    scoped operator re-drain). The re-drain's dominant cost is the per-row SEC
+    fetch (#554: ~4.7s/row, ~1 req/s against a 10 req/s floor); overlapping
+    the batch's fetches saturates the floor. Born-compacted sources (10-K/8-K)
+    benefit most — their body cannot be reused (#1591 PR1) so it must be
+    (re-)fetched, and concurrency is their only lever.
+
+    Accepted tradeoff (Codex ckpt-1 #5 + ckpt-2): prefetching the whole batch
+    up front widens the window between row-select and the parser's transition,
+    so if another drainer finalises a row in that window this worker re-parses
+    the stale row (rate-budget + redundant-write cost; the writes are
+    idempotent via the filed_at gate / replace-then-insert). The manifest
+    transition that follows:
+      * same-status collision (drainer B also parses → ``parsed -> parsed``,
+        the common case) is absorbed by an idempotent no-op
+        (``sec_manifest.transition_status``, #1591 Part 2, mirroring the #1686
+        ``tombstoned -> tombstoned`` no-op) — no raise.
+      * cross-terminal collision (B's redundant re-parse returns
+        failed/tombstoned where A committed parsed — needs a TRANSIENT fetch
+        discrepancy in the window) still raises ``illegal transition``. It is
+        NOT made a no-op on purpose: that would have to allow ``parsed ->
+        failed``, masking the single-drainer bug ``test_illegal_transition_
+        raises`` guards. This path is caught by the standalone drain's
+        broad-except rollback-retry (``scripts/drain_554_sec10k.py``) — the
+        only context that creates concurrent drainers.
+    Production runs a SINGLETON fairness tick (``scheduler.py`` max-instances
+    =1) and the per-source path has no scheduled caller, so production never
+    races; any non-finalised row simply stays pending and re-drains. No path
+    corrupts data.
 
     The cache is ALWAYS bound (even when empty, so a prior tick's value can
     never leak across ticks on the apscheduler threadpool) and reset in

--- a/app/services/manifest_parsers/eight_k.py
+++ b/app/services/manifest_parsers/eight_k.py
@@ -445,6 +445,23 @@ def _parse_eight_k(
     )
 
 
+def _eight_k_fetch_url(conn: Any, row: Any) -> str | None:  # conn unused; row: ManifestRow
+    """#1591 Part 2 prefetch hook — the SINGLE primary-document URL the 8-K
+    parser GETs, returned ONLY when the parser would actually fetch it.
+    Mirrors :func:`_parse_eight_k`'s pre-fetch tombstone gates (missing
+    ``primary_document_url`` / missing ``instrument_id``); both are row-local
+    so ``conn`` is unused (part of the shared #1700 hook contract). The 8-K is
+    single-doc (no XBRL dimensional step) so this URL is the whole fetch. An
+    over-broad ``None`` is always safe (serial fallback reaches the identical
+    fetch/tombstone). ``primary_doc`` is born-compacted (SWEPT #1617) → no
+    stored body → the 8-K always (re-)fetches, no reuse gate to mirror.
+    """
+    url = row.primary_document_url
+    if not url or row.instrument_id is None:
+        return None
+    return url
+
+
 def register() -> None:
     """Register the 8-K parser with the manifest worker.
 
@@ -455,4 +472,4 @@ def register() -> None:
     """
     from app.jobs.sec_manifest_worker import register_parser
 
-    register_parser("sec_8k", _parse_eight_k, requires_raw_payload=True)
+    register_parser("sec_8k", _parse_eight_k, requires_raw_payload=True, fetch_url=_eight_k_fetch_url)

--- a/app/services/manifest_parsers/sec_10k.py
+++ b/app/services/manifest_parsers/sec_10k.py
@@ -568,6 +568,33 @@ def _parse_sec_10k(
     )
 
 
+def _sec10k_fetch_url(conn: Any, row: Any) -> str | None:  # conn unused; row: ManifestRow
+    """#1591 Part 2 prefetch hook — the SINGLE primary-document URL the 10-K
+    parser GETs (the business-summary HTML), returned ONLY when the parser
+    would actually fetch it. Mirrors :func:`_parse_sec_10k`'s pre-fetch
+    tombstone gates (missing ``primary_document_url`` / missing
+    ``instrument_id``); both are row-local so ``conn`` is unused (part of the
+    shared #1700 hook contract).
+
+    Scope is the PRIMARY doc only. The 10-K also fetches XBRL linkbase
+    artifacts (``index.json`` + instance + label/def) via a SEPARATE provider
+    in :func:`_fetch_dimensional_facts` after an independent index discovery
+    — those are NOT prefetched here (no clean single next-URL; a 13F-style
+    ``expand_urls`` keyed off the primary HTML wouldn't reach them). So on a
+    re-drain the primary docs overlap across rows while the XBRL stays serial;
+    full XBRL overlap is a documented follow-up. An over-broad ``None`` is
+    always safe (serial fallback reaches the identical fetch/tombstone).
+
+    ``primary_doc`` is born-compacted (SWEPT #1617) so there is no stored body
+    to mirror a #1591-PR1 reuse gate against — the 10-K always (re-)fetches /
+    rehydrates from source.
+    """
+    url = row.primary_document_url
+    if not url or row.instrument_id is None:
+        return None
+    return url
+
+
 def register() -> None:
     """Register the 10-K parser with the manifest worker.
 
@@ -578,4 +605,4 @@ def register() -> None:
     """
     from app.jobs.sec_manifest_worker import register_parser
 
-    register_parser("sec_10k", _parse_sec_10k, requires_raw_payload=True)
+    register_parser("sec_10k", _parse_sec_10k, requires_raw_payload=True, fetch_url=_sec10k_fetch_url)

--- a/app/services/sec_manifest.py
+++ b/app/services/sec_manifest.py
@@ -425,6 +425,21 @@ def transition_status(
         # failure mode the rule guards against).
         if current_status == "tombstoned" and ingest_status == "tombstoned":
             return
+        # #1591 Part 2 — idempotent parsed-on-parsed no-op for the SAME
+        # concurrent-drainer race, now reachable because the prefetch
+        # (``_prefetch_then_dispatch``, extended to the per-source rebuild +
+        # 10-K/8-K) widens the window between row-select and transition.
+        # Drainer A commits ``pending -> parsed``; drainer B, which read the
+        # row as pending before A committed, finishes its (idempotent) parse
+        # and calls here with ``current='parsed'``. ``parsed`` is otherwise
+        # terminal (``_ALLOWED_TRANSITIONS['parsed']={pending}`` — re-parses
+        # must go through pending), so without this the redundant transition
+        # raises and aborts B's whole tick. Benign NO-OP: writes nothing (same
+        # #879-safe property as the tombstoned case above) and cannot mask a
+        # single-drainer bug — that path always goes ``pending -> parsed``, so
+        # ``parsed -> parsed`` is unreachable without a concurrent writer.
+        if current_status == "parsed" and ingest_status == "parsed":
+            return
         # Claude bot review on PR #879 (WARNING): same-status no-op
         # was previously short-circuited unconditionally; that masked
         # double-error writes (e.g. worker calls failed->failed twice

--- a/tests/test_insider_transactions_retention_cap.py
+++ b/tests/test_insider_transactions_retention_cap.py
@@ -518,7 +518,12 @@ class TestManifestWorkerGate:
         run_manifest_worker(ebull_test_conn, source="sec_form4", max_rows=10)
         ebull_test_conn.commit()
 
-        assert len(call_log) == 1  # fetched once
+        # In-cap row → the retention gate did NOT fire → fetch was reached.
+        # (Since #1591 Part 2 the per-source rebuild prefetches; this
+        # cache-bypassing spy records both the prefetch and the parser call,
+        # so assert "fetched" rather than an exact count — in production the
+        # parser's call is a prefetch-cache hit → one real HTTP.)
+        assert call_log
 
     def test_filed_at_none_tombstones_per_existing_pattern(
         self,
@@ -641,7 +646,11 @@ class TestForm5ManifestWorkerGate:
         run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
         ebull_test_conn.commit()
 
-        assert len(call_log) == 1  # gate did NOT fire; fetch reached.
+        # Gate did NOT fire (within 18mo) → fetch reached. Asserting "fetched"
+        # rather than an exact count: the #1591-Part-2 per-source prefetch +
+        # the serial parser both call this cache-bypassing spy (production: one
+        # real HTTP via the prefetch-cache hit).
+        assert call_log
 
     def test_form5_filed_at_none_tombstones(
         self,

--- a/tests/test_manifest_parser_insider_345.py
+++ b/tests/test_manifest_parser_insider_345.py
@@ -755,9 +755,15 @@ def test_xsl_url_canonicalised_before_fetch(
     ebull_test_conn.commit()
 
     assert stats.parsed == 1
-    # Confirm canonicalisation actually stripped the XSL segment.
-    assert len(fetched_urls) == 1
-    assert "/xslF345X05/" not in fetched_urls[0]
+    # Canonicalisation strips the XSL segment BEFORE every fetch. Since #1591
+    # Part 2 the per-source rebuild prefetches concurrently (_insider_fetch_url
+    # returns the canonical URL) and the serial parser then reads it; both
+    # canonicalise, so the cache-bypassing spy here records two canonical
+    # calls (in production the parser's call is a prefetch-cache hit → one real
+    # HTTP — proven by tests/test_manifest_worker_prefetch.py). The invariant
+    # under test is that NO fetch ever sees the XSL-rendered URL.
+    assert fetched_urls
+    assert all("/xslF345X05/" not in u for u in fetched_urls)
 
 
 def test_form5_happy_path(

--- a/tests/test_manifest_worker_prefetch.py
+++ b/tests/test_manifest_worker_prefetch.py
@@ -502,3 +502,61 @@ def test_thirteen_f_index_url_and_expander(monkeypatch: pytest.MonkeyPatch) -> N
         lambda _body: ("primary_doc.xml", None),
     )
     assert _thirteen_f_expand("<index/>", ok) == []
+
+
+# --- #1591 Part 2 — 10-K / 8-K prefetch hooks + per-source rebuild routing ---
+
+
+def test_sec10k_fetch_url_mirrors_gates() -> None:
+    """`_sec10k_fetch_url` returns the primary URL only when `_parse_sec_10k`
+    would fetch it — i.e. url + instrument_id present (no retention gate). The
+    10-K parser GETs `row.primary_document_url` verbatim (no canonicalisation),
+    so the hook returns it unchanged."""
+    from app.services.manifest_parsers.sec_10k import _sec10k_fetch_url
+
+    base = "https://www.sec.gov/Archives/edgar/data/1/000/10k.htm"
+    recent = datetime(2026, 1, 1, tzinfo=UTC)
+    assert _sec10k_fetch_url(None, _mk(source="sec_10k", url=base, filed_at=recent, iid=1)) == base
+    assert _sec10k_fetch_url(None, _mk(source="sec_10k", url=None, filed_at=recent, iid=1)) is None
+    assert _sec10k_fetch_url(None, _mk(source="sec_10k", url=base, filed_at=recent, iid=None)) is None
+
+
+def test_eight_k_fetch_url_mirrors_gates() -> None:
+    """`_eight_k_fetch_url` mirrors `_parse_eight_k`'s pre-fetch gates (url +
+    instrument_id); single-doc, so the URL is the whole fetch."""
+    from app.services.manifest_parsers.eight_k import _eight_k_fetch_url
+
+    base = "https://www.sec.gov/Archives/edgar/data/1/000/8k.htm"
+    recent = datetime(2026, 1, 1, tzinfo=UTC)
+    assert _eight_k_fetch_url(None, _mk(source="sec_8k", url=base, filed_at=recent, iid=1)) == base
+    assert _eight_k_fetch_url(None, _mk(source="sec_8k", url=None, filed_at=recent, iid=1)) is None
+    assert _eight_k_fetch_url(None, _mk(source="sec_8k", url=base, filed_at=recent, iid=None)) is None
+
+
+def test_per_source_rebuild_routes_through_prefetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1591 Part 2 — the per-source rebuild path (`source is not None`, what
+    `sec_rebuild` drains into) now prefetches concurrently via
+    `_prefetch_then_dispatch` instead of the old direct `_dispatch_rows` serial
+    call. Pure-logic: iter_pending/iter_retryable + the prefetch entry point are
+    monkeypatched so no DB is touched."""
+    import app.jobs.sec_manifest_worker as w
+
+    monkeypatch.setattr(w, "iter_pending", lambda conn, *, source, limit: [])
+    monkeypatch.setattr(w, "iter_retryable", lambda conn, *, source, limit: [])
+    routed = {"prefetch": False, "serial": False}
+
+    def _spy_prefetch(conn: Any, rows: Any, *, now: Any) -> Any:
+        routed["prefetch"] = True
+        return w.WorkerStats(rows_processed=0, parsed=0, tombstoned=0, failed=0, skipped_no_parser=0)
+
+    def _spy_serial(conn: Any, rows: Any, *, now: Any) -> Any:
+        routed["serial"] = True
+        return w.WorkerStats(rows_processed=0, parsed=0, tombstoned=0, failed=0, skipped_no_parser=0)
+
+    monkeypatch.setattr(w, "_prefetch_then_dispatch", _spy_prefetch)
+    monkeypatch.setattr(w, "_dispatch_rows", _spy_serial)
+
+    w.run_manifest_worker(None, source="sec_10k", max_rows=10)  # type: ignore[arg-type]  # faked iter_* ignore conn
+
+    assert routed["prefetch"] is True
+    assert routed["serial"] is False  # not the old direct-serial path

--- a/tests/test_sec_manifest.py
+++ b/tests/test_sec_manifest.py
@@ -525,6 +525,32 @@ class TestTransitionStatus:
         assert after.error == "retention floor"  # unchanged — no re-stamp
         assert after.last_attempted_at == first.last_attempted_at
 
+    def test_parsed_to_parsed_is_idempotent_noop(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        # #1591 Part 2 — the concurrent-drainer race the prefetch widens:
+        # drainer A commits pending->parsed; drainer B (which read the row as
+        # pending before A committed) finishes its idempotent parse and calls
+        # transition_status parsed again. ``parsed`` is otherwise terminal
+        # (only ->pending, so re-parses go through the explicit rewash gate),
+        # so this must be a NO-OP rather than the tick-aborting ``illegal
+        # transition`` ValueError.
+        accession = self._seed(ebull_test_conn)
+        transition_status(ebull_test_conn, accession, ingest_status="fetched", raw_status="stored")
+        transition_status(ebull_test_conn, accession, ingest_status="parsed", parser_version="v1")
+        first = get_manifest_row(ebull_test_conn, accession)
+        assert first is not None and first.ingest_status == "parsed"
+
+        # Redundant parsed with a DIFFERENT parser_version — must not raise
+        # and must NOT re-stamp (the first writer's state is preserved).
+        transition_status(ebull_test_conn, accession, ingest_status="parsed", parser_version="v2")
+        after = get_manifest_row(ebull_test_conn, accession)
+        assert after is not None
+        assert after.ingest_status == "parsed"
+        assert after.parser_version == "v1"  # unchanged — no re-stamp
+        assert after.last_attempted_at == first.last_attempted_at
+
     def test_rebuild_path_parsed_to_pending(
         self,
         ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811


### PR DESCRIPTION
**Closes #1591** — Part 2 of 2 (Part 1 = #1727, merged `86d42e5c`).

## What
The serial per-source rebuild path in `run_manifest_worker` (`source is not None` — what `sec_rebuild` + standalone drains feed) now routes through `_prefetch_then_dispatch`, so a re-drain's bodies are fetched CONCURRENTLY against the shared 10 req/s SEC throttle instead of one-at-a-time. New `_sec10k_fetch_url` + `_eight_k_fetch_url` prefetch hooks (mirror the parsers' `url` + `instrument_id` pre-fetch gates) register `fetch_url=`, so 10-K/8-K are prefetchable on BOTH worker paths (fairness tick + per-source rebuild).

## Why
#554 observed the standalone 10-K drain at ~4.7s/row, ~1 req/s against a 10 req/s throttle — fully serial. Born-compacted `primary_doc` (10-K/8-K, SWEPT #1617) can't be reused (PR1's lever), so overlapping the unavoidable (re-)fetches is their only lever. The fairness tick already prefetched (#1686/#1700) but 10-K/8-K had no `fetch_url` hook → never prefetched; this PR adds them + extends prefetch to the per-source path.

## Concurrent-drainer race (Codex ckpt-2)
The prefetch widens the window between row-select and the parser's transition, so a concurrent drainer can finalise a row mid-window:
- **Same-status** (`parsed -> parsed`, the common case): `transition_status` now no-ops it idempotently — mirrors the existing #1686 `tombstoned -> tombstoned` no-op. `parsed` is terminal (`_ALLOWED_TRANSITIONS['parsed'] = {pending}`), so `parsed -> parsed` is unreachable in a single-drainer flow (re-parses go through `pending`) → cannot mask a bug; writes nothing (same #879 property).
- **Cross-terminal** (`parsed -> failed/tombstoned`; needs a transient fetch discrepancy in the window): still raises — NOT a no-op on purpose (that would allow `parsed -> failed`, masking the single-drainer bug `test_illegal_transition_raises` guards). Caught by the standalone drain's broad-except rollback-retry (`scripts/drain_554_sec10k.py`).
- Production runs a SINGLETON fairness tick (`scheduler.py` max-instances=1) + the per-source path has no scheduled caller → production never races. No path corrupts data.

## Scope / non-goals
10-K XBRL linkbase fetches (`index.json` + instance + label/def, via a separate provider after independent index discovery) stay serial — no clean single next-URL; documented follow-up. No multi-process (per-process throttle; aggregate would exceed SEC fair-access).

## Security model
No auth/authz surface. Hooks are pure row-local gate mirrors (no SQL). Reuses the proven #1686 `concurrent_fetch` machinery (shared in-process rate gate, single per-process budget — concurrency overlaps wait, never bypasses the 10 req/s floor).

## Tests — green (ruff, pyright 0, fast tier, smoke, manifest+worker db tier)
- `_sec10k_fetch_url` / `_eight_k_fetch_url`: primary URL when url+instrument_id present, `None` otherwise.
- `test_per_source_rebuild_routes_through_prefetch`: the `source != None` path now calls `_prefetch_then_dispatch`, not the old direct `_dispatch_rows`.
- `test_parsed_to_parsed_is_idempotent_noop`: the race no-op (no raise, no re-stamp).
- Updated 3 existing tests whose cache-bypassing fetch spies now see prefetch+parser both call them (XSL canonicalisation + 2 retention "proceeds to fetch") — assert the invariant (canonical / fetch-reached) rather than an exact count; in production the parser's call is a prefetch-cache hit → one real HTTP.

## Dev-verify (ETL DoD 8-12) @ 01428cd3
- Hooks return the primary URL for **3/3** real dev `sec_10k` + **3/3** real `sec_8k` manifest rows (prefetch has work).
- Serial vs concurrent on **6 real dev 10-K primary docs: 2.24s → 0.61s = 3.7×**, bodies identical 6/6 (scales toward the throttle ceiling on larger batches).

## Codex
ckpt-2: found the `parsed->parsed` race-abort → fixed (no-op). Re-review: no-op safe + doesn't mask bugs (findings 1-2 clear); finding 3 (cross-terminal residual) rebutted above (caller-handled + production-singleton + can't generalise without masking the `parsed->failed` invariant).

Spec: `docs/proposals/etl/2026-06-26-1591-rewash-reuse-and-drain-concurrency.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
