### PR TITLE
perf(#1729): reuse stored infotable_13f on re-drain (extend #1591 PR1 to 13F-HR)

### DIFF
--- a/.claude/skills/data-engineer/SKILL.md
+++ b/.claude/skills/data-engineer/SKILL.md
@@ -1554,6 +1554,33 @@ Only the `read_raw` / `iter_raw` payload paths (driven by `registered_specs`) co
 
 **Promotion rule:** registering a rewash parser for a kind currently in `KEPT_NEGLIGIBLE_DOCUMENT_KINDS` (e.g. the planned Form 5 parser hinted at `insider_345.py:563-565`) MUST remove it from that map in the same change — the pairwise-disjoint test fails if it lands in two buckets. Settled decision: `docs/settled-decisions.md` "Raw-payload retention (#1617)".
 
+### 13.G Manifest-parser reuse-on-redrain + the prefetch-hook-mirrors-the-gate rule (#1591/#1729)
+
+A `sec_rebuild` re-drain (parser-version bump → manifest rows reset to `pending` → manifest worker re-runs the parser) re-fetches the upstream body unconditionally — even when it is already in `filing_raw_documents`. #1591 added a **manifest-parser reuse fast path** so a re-drain re-parses the stored body instead of re-downloading at 10 req/s.
+
+**This is a SECOND payload reader on a REWASH kind, distinct from the `rewash_filings` bulk spec.** A retained kind in `rewash_filings.registered_specs()` (form4/form3/def14a/13dg/infotable_13f) already has the `scripts/rewash.py` CLI re-parser; #1591/#1729 added an *independent* in-parser reuse branch. Both read the same retained payload; adding the manifest-parser branch needs NO retention-bucket change (the kind is already REWASH). Promoting a KEPT_NEGLIGIBLE kind to reuse DOES require the §13.F bucket move (register a `rewash_filings` spec) so the classification test stays green — that is the form5/nport (#1731) cost, not the infotable (#1729) cost.
+
+**The reuse-branch shape (mirror PR1 exactly):**
+
+```python
+body = stored_body(conn, accession_number=acc, document_kind="<kind>")
+if body is None:                       # first ingest, or SWEPT → rehydrate
+    <existing fetch via provider.fetch_document_text(...)>
+    if not body: <existing empty-body tombstone, raw_status="stored">
+    <existing store_raw(...)>          # fetch path only
+# parse(body) — unchanged; reuse joins the flow here
+```
+
+Invariants (all verified at #1591 ckpt-1, re-audited per parser):
+- The reuse branch wraps ONLY the fetch + empty-guard + store_raw. It must sit BELOW every pre-fetch gate (instrument_id / url / filed_at / retention / def14a cap / 13F post-primary retention) — reuse replaces the fetch, never a gate.
+- EVERY post-body outcome (success, parse-failure, tombstone, transient-upsert-fail, deterministic-upsert-tombstone) must already return `raw_status="stored"` — the reuse path joins at the parse step, so a reuse-hit failure with a stale manifest `raw_status='absent'` must still repair `effective_raw_status` (#938 audit). Audit this before wiring reuse.
+- `fetched_at` is NOT churned on reuse (no re-store) — preserves the operator-visible last-published timestamp.
+- `stored_body` returns `None` for a SWEPT kind (payload NULL), so a born-compacted kind (primary_doc) falls through to the fetch path automatically — reuse is safe to call unconditionally.
+
+**The prefetch-hook-mirrors-the-gate rule (prevention-log #1956).** A `fetch_url`/`expand_urls` prefetch hook front-runs the serial parser to overlap fetches against the shared throttle. It MUST mirror EVERY pre-fetch gate the parser applies — including the #1591 reuse gate — or it burns the rate budget it exists to save (it would prefetch a body the parser then reuses-not-fetches). Mirror via the SAME chokepoint predicates the parser calls, placed AFTER the cheap row-local gates so a gated-out row never pays the DB read. Hooks run savepoint-wrapped in `_prefetch_bodies` (prevention-log #1963), so the `stored_body` read is safe on the shared conn. For a hook shared across forms (Form 3/4/5 share `_insider_fetch_url`), map `row.source` → the EXACT stored kind via an explicit dict and **fail closed** — a source NOT in the dict prefetches as before (a shared `form4_xml` check would wrongly skip Form 3/5 rows).
+
+**Mirror ONLY the kinds the hook actually prefetches.** The rule is conditional on the hook prefetching the reused kind. 13F-HR (#1729) is the worked counter-example: its infotable is reused, but `_thirteen_f_expand` deliberately prefetches `primary_doc.xml` ONLY (the infotable's retention gate is post-primary-parse, so prefetching the often-large infotable for a row that tombstones would itself violate the mirror contract). Because no hook prefetches the infotable, its reuse gate has NO hook to mirror — and adding one would be wrong (it would first require prefetching the infotable). So: a reused kind that is never prefetched needs no hook change. Document the asymmetry in the hook's docstring so a future reader doesn't "fix" it.
+
 ## 14. Postgres crash-recovery fsync tax — diagnosis runbook (#1444, 2026-06-02)
 
 **Symptom:** dev PG stuck in `the database system is in recovery mode` for tens of minutes to HOURS, rejecting every connection. Blocks bootstrap, live verification, DB-backed tests.

--- a/app/services/manifest_parsers/sec_13f_hr.py
+++ b/app/services/manifest_parsers/sec_13f_hr.py
@@ -78,7 +78,7 @@ from app.services.manifest_parsers._classify import (
     is_transient_upsert_error,
 )
 from app.services.ownership_observations import refresh_institutions_current_batch
-from app.services.raw_filings import store_raw
+from app.services.raw_filings import store_raw, stored_body
 from app.services.thirteen_f_normalise import (
     merge_resolved_by_instrument,
     normalise_13f_holdings,
@@ -358,58 +358,71 @@ def _parse_13f_hr(
             error="retention floor",
         )
 
-    # Step 3: fetch infotable.xml + store_raw inside savepoint.
-    try:
-        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-            infotable_xml = provider.fetch_document_text(infotable_url)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "13F-HR manifest parser: infotable fetch raised accession=%s: %s",
-            accession,
-            exc,
-        )
-        return _failed_outcome(f"fetch error: {exc}", raw_status="stored")
+    # Step 3: reuse the stored infotable on a re-drain (#1729), else fetch + store.
+    # SEC Form 13F has exactly ONE Information Table per accession and the EDGAR
+    # archive is immutable once filed (an amendment is a NEW accession), so a
+    # present ``infotable_13f`` body is always the right one to re-parse — keyed
+    # by (accession, kind), no source_url re-check, matching the PR1 single-primary
+    # kinds (#1591). ``primary_doc`` stays SWEPT (re-fetched + re-parsed above for
+    # period_of_report / filer info); only this — the largest attachment (avg
+    # ~199 KB) — is reused, so a re-drain of a parsed 13F-HR drops from 3 HTTP to 2.
+    # The body parser ``parse_infotable`` still runs on reuse, so a parser-version
+    # bump is picked up; only the structurally-deterministic attachment selection
+    # (``parse_archive_index``) is skipped. On reuse, fetch + empty-guard + store_raw
+    # are all skipped (fetched_at preserved); the flow joins below at parse_infotable.
+    infotable_xml = stored_body(conn, accession_number=accession, document_kind="infotable_13f")
+    if infotable_xml is None:
+        try:
+            with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+                infotable_xml = provider.fetch_document_text(infotable_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "13F-HR manifest parser: infotable fetch raised accession=%s: %s",
+                accession,
+                exc,
+            )
+            return _failed_outcome(f"fetch error: {exc}", raw_status="stored")
 
-    if not infotable_xml:
+        if not infotable_xml:
+            try:
+                with conn.transaction():
+                    _record_ingest_attempt(
+                        conn,
+                        filer_cik=filer_cik,
+                        accession_number=accession,
+                        period_of_report=info.period_of_report,
+                        status="tombstoned",
+                        error="infotable.xml fetch failed",
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "13F-HR manifest parser: ingest-log INSERT failed accession=%s",
+                    accession,
+                )
+                return _failed_outcome(f"log error: {exc}", raw_status="stored")
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_13F_HR,
+                raw_status="stored",
+                error="infotable.xml fetch failed",
+            )
+
         try:
             with conn.transaction():
-                _record_ingest_attempt(
+                store_raw(
                     conn,
-                    filer_cik=filer_cik,
                     accession_number=accession,
-                    period_of_report=info.period_of_report,
-                    status="tombstoned",
-                    error="infotable.xml fetch failed",
+                    document_kind="infotable_13f",
+                    payload=infotable_xml,
+                    parser_version=_PARSER_VERSION_13F_INFOTABLE,
+                    source_url=infotable_url,
                 )
         except Exception as exc:  # noqa: BLE001
             logger.exception(
-                "13F-HR manifest parser: ingest-log INSERT failed accession=%s",
+                "13F-HR manifest parser: infotable store_raw failed accession=%s",
                 accession,
             )
-            return _failed_outcome(f"log error: {exc}", raw_status="stored")
-        return ParseOutcome(
-            status="tombstoned",
-            parser_version=_PARSER_VERSION_13F_HR,
-            raw_status="stored",
-            error="infotable.xml fetch failed",
-        )
-
-    try:
-        with conn.transaction():
-            store_raw(
-                conn,
-                accession_number=accession,
-                document_kind="infotable_13f",
-                payload=infotable_xml,
-                parser_version=_PARSER_VERSION_13F_INFOTABLE,
-                source_url=infotable_url,
-            )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "13F-HR manifest parser: infotable store_raw failed accession=%s",
-            accession,
-        )
-        return _failed_outcome(f"store_raw error: {exc}", raw_status="stored")
+            return _failed_outcome(f"store_raw error: {exc}", raw_status="stored")
 
     try:
         holdings: list[ThirteenFHolding] = parse_infotable(infotable_xml)
@@ -651,6 +664,16 @@ def _thirteen_f_expand(index_body: str, row: Any) -> list[str]:  # row: Manifest
     None or infotable_name is None`) BEFORE fetching the primary, so an index
     with a primary but no infotable (the ~55k pre-2013 missing-infotable
     backlog) must NOT prefetch the primary (Codex ckpt-2 P2 — no wasted request).
+
+    #1729 — the parser now REUSES a stored ``infotable_13f`` body on re-drain
+    (skips its fetch). The prefetch-hook-mirrors-the-gate rule (prevention-log
+    #1956) does NOT apply to that reuse here, because this expander does not
+    prefetch the infotable in the first place (only ``primary_doc.xml``, which is
+    SWEPT and always re-fetched). Adding an infotable-reuse gate here would be
+    WRONG — it would first require prefetching the infotable, re-introducing the
+    very fetch-for-a-row-that-tombstones bug this expander avoids (the retention
+    gate is post-primary-parse). The reuse gate lives only at the serial fetch
+    site. Do NOT "fix" this asymmetry.
     """
     primary_name, infotable_name = parse_archive_index(index_body)
     if primary_name is None or infotable_name is None:

--- a/docs/specs/etl/2026-06-26-1729-infotable-13f-reuse.md
+++ b/docs/specs/etl/2026-06-26-1729-infotable-13f-reuse.md
@@ -1,0 +1,171 @@
+# #1729 — Reuse stored infotable_13f on re-drain (extend #1591 PR1 to 13F-HR)
+
+Status: spec (live). Branch `feature/1729-reuse-infotable-13f-redrain`.
+Follow-up to #1591 PR1 (`86d42e5c`, #1727) which wired stored-body reuse into the
+4 single-primary retained parsers (def14a/form4/form3/13dg). 13F-HR was deferred
+because it is multi-doc.
+
+## Problem
+
+`_parse_13f_hr` (`app/services/manifest_parsers/sec_13f_hr.py`) fetches, per accession:
+1. `index.json` (not stored — directory listing)
+2. `primary_doc.xml` → kind `primary_doc`, **SWEPT/born-compacted** (#1617) → always re-fetched
+3. `infotable.xml` → kind `infotable_13f`, **RETAINED**, the largest doc (avg 199 KB)
+
+On a re-drain (`sec_rebuild` resets the manifest row to `pending` → manifest worker
+re-runs the parser) the parser refetches the infotable even though the body is
+already stored. The infotable is the dominant per-row byte cost.
+
+## Source rule
+
+- **One Information Table per 13F-HR accession** (SEC Form 13F General
+  Instruction; the EDGAR `<informationTable>` XML attachment, mandated 2013).
+  `parse_archive_index` resolves exactly one `infotable_name`, and `store_raw`
+  UPSERTs it under `(accession, "infotable_13f")` — so the key
+  `(accession, "infotable_13f")` uniquely + permanently identifies that one
+  attachment. There is no second infotable candidate to disambiguate, so reuse by
+  `(accession, kind)` cannot select the wrong document (Codex ckpt-1 HIGH #1).
+  This matches the PR1 reuse contract exactly — form4/form3/def14a/13dg all reuse
+  by `(accession, kind)` with no `source_url` re-validation; adding one here would
+  diverge from `stored_body`'s settled helper contract for zero benefit (the
+  attachment is structurally singular). The body parser `parse_infotable`
+  (versioned `_PARSER_VERSION_13F_INFOTABLE`) still runs on every reuse, so a
+  body-parser change IS picked up; only the structurally-deterministic attachment
+  *selection* (`parse_archive_index`) is skipped, which is safe because the
+  archive is frozen (next bullet).
+- **A stored body never goes stale for a fixed accession** — this is the settled
+  **#1591-family internal invariant** (already stated verbatim in
+  `raw_filings.stored_body`'s docstring + the #1591 proposal), resting on the
+  EDGAR mechanism that an amendment is filed as a *new* accession (13F-HR/A) with
+  its own accession number while the original accession's archive directory is
+  immutable. "Present" == "reusable", no freshness check. (Codex ckpt-1 HIGH #2:
+  cited as an internal invariant + named the EDGAR amendment mechanism, not
+  inferred from first principles.)
+- **Raw-payload retention is partitioned by #1617** (settled-decisions, data-eng
+  §13.F). `infotable_13f` is already in the **REWASH** bucket
+  (`rewash_filings.registered_specs()` → `_apply_13f_infotable`, since #836), so a
+  stored-body reader is already sanctioned for it — adding a second reader (the
+  manifest-parser fast path) needs NO bucket change and keeps
+  `tests/test_raw_payload_retention.py` green. `primary_doc` stays SWEPT
+  (re-fetched); only `infotable_13f` is reused.
+
+## Full-population verification (dev DB, 2026-06-26)
+
+Two populations, both full (not samples):
+
+**(a) `filing_raw_documents` — are stored infotable bodies reusable?**
+
+| document_kind | rows | with_payload | swept | avg_bytes | reusable? |
+|---|---:|---:|---:|---:|---|
+| infotable_13f | 18,131 | 18,131 | 0 | 199 K | ✅ 100% |
+| primary_doc | 113,393 | 38,413 | 74,980 | 74 K | ❌ 66% swept → re-fetch |
+
+**(b) rebuild candidates — `sec_filing_manifest` source=`sec_13f_hr` LEFT JOIN the
+infotable raw row (Codex ckpt-1 MED #3 — the reuse-hit denominator is manifest
+rows, not raw rows):**
+
+| ingest_status | manifest rows | with stored infotable | reuse-hit |
+|---|---:|---:|---|
+| parsed | 17,396 | 17,396 | **100%** |
+| pending | 50,445 | 749 | partial (mid-drain) |
+| tombstoned | 254,965 | 0 | n/a — tombstoned pre-infotable, re-fetch index + re-tombstone (no infotable fetch wasted) |
+| failed | 14 | 0 | n/a |
+
+Every **parsed** 13F-HR accession (the re-drain reuse target — store-before-parse
+#938 guarantees a parsed row has a stored infotable) reuses on re-drain: 17,396 /
+17,396 = 100%. Tombstoned rows have no infotable to reuse and never fetched one, so
+reuse is correctly inert for them.
+
+## Change
+
+`_parse_13f_hr` Step 3 (the infotable fetch site, AFTER the index-walk + primary
+fetch/store/parse + `thirteen_f_within_retention` gate — reuse replaces ONLY the
+fetch, never a gate):
+
+```python
+infotable_xml = stored_body(conn, accession_number=accession, document_kind="infotable_13f")
+if infotable_xml is None:                 # first ingest, or absent → fetch + store
+    <existing fetch via provider.fetch_document_text(infotable_url)>
+    if not infotable_xml: <existing empty-body tombstone, raw_status="stored">
+    <existing store_raw(... document_kind="infotable_13f" ...)>
+# parse_infotable(infotable_xml) — unchanged; reuse joins the flow here
+```
+
+Import `stored_body` from `app.services.raw_filings` (alongside the existing
+`store_raw` import).
+
+Invariants preserved (identical to PR1):
+- **#938 store-before-parse**: on reuse the row already exists with a payload, so
+  `effective_raw_status='stored'`; no `store_raw` call needed.
+- **fetched_at not churned** on reuse (no re-store) — preserves the
+  operator-visible last-published timestamp.
+- **raw_status="stored"** on EVERY post-infotable outcome — already true today:
+  parse-failure (`:439`), upsert-transient (`:549`), upsert-deterministic
+  (`:577`/`:581`), success (`:584`), and the empty-body / store_raw-failure
+  tombstones all return `raw_status="stored"`. The reuse branch joins at
+  `parse_infotable`, so these returns hold for the reuse path identically (the
+  Codex ckpt-1 #2 audit from PR1 — verified, none slipped).
+- Empty-body guard + store_raw run on the fetch path only; stored bodies are
+  non-empty by construction (`store_raw` rejects empty).
+
+## Prefetch-hook mirror (prevention-log #1956) — verify-only, NO code change
+
+The rule: a prefetch hook that front-runs a gated consumer must mirror EVERY
+pre-fetch gate (reuse included) or it burns the budget it exists to save. Applied
+to 13F-HR's two hooks:
+
+- `_thirteen_f_index_url` (pass 1) prefetches `index.json` — never stored, never
+  reused. Nothing to mirror.
+- `_thirteen_f_expand` (pass 2) prefetches **`primary_doc.xml` ONLY** — which is
+  SWEPT (always re-fetched), never reused; AND it deliberately does NOT prefetch
+  the infotable (the `thirteen_f_within_retention` gate is post-primary-parse, so
+  prefetching the often-large infotable for a row the parser tombstones would
+  itself violate the mirror contract — Codex ckpt-1 HIGH on #1700; pinned by
+  `test_two_phase_prefetch_out_of_retention_never_fetches_infotable`).
+
+Because **no hook prefetches the infotable**, the new infotable reuse gate has no
+hook to mirror — adding one would be wrong (it would re-introduce the
+prefetch-the-infotable-for-a-row-that-tombstones bug). Document the reasoning in
+`_thirteen_f_expand`'s docstring so a future reader doesn't "fix" the asymmetry.
+
+## Tests (DB-tier — mirror existing `test_manifest_parser_sec_13f_hr.py` harness)
+
+The 13F parser is DB-coupled (filer/holdings/observations upserts); the existing
+suite is integration/db tier via `ebull_test_conn` + `_patch_fetch_map`'s `calls`
+list. Add:
+
+- **reuse SUCCESS**: pre-seed `filing_raw_documents` with the `infotable_13f`
+  body; run the worker; assert (a) `base+"infotable.xml" NOT in calls` (no fetch),
+  (b) `base+"primary_doc.xml" IN calls` (primary still SWEPT-fetched), (c) row
+  reaches `parsed` + `raw_status="stored"`, (d) holdings upserted identically.
+- **reuse FAILURE**: pre-seed a stored infotable whose `parse_infotable` raises
+  (monkeypatch) → returns `failed`/`raw_status="stored"` (proves the reuse path
+  repairs `effective_raw_status` even on a parse crash).
+- **MISS**: no stored infotable → fetches + stores (existing happy-path behaviour
+  unchanged — already covered by `test_happy_path_*`; add an explicit assert that
+  `filing_raw_documents` has the infotable row after).
+
+## Dev-verify (ETL DoD 8-12)
+
+Scoped `POST /jobs/sec_rebuild/run` `{"source":"sec_13f_hr","instrument_id":...}`
+on a known 13F filer's accession already on file: assert the infotable URL is NOT
+re-fetched (0-HTTP for the infotable on re-drain) and the parsed holdings are
+byte-identical to the pre-drain rows (parity ⇒ no data change). Smoke
+`/instruments/AAPL/ownership-rollup` institutions slice unchanged. No `sec_rebuild`
+backfill needed for correctness (output row-identical). Restart the jobs daemon
+onto new main post-merge (parser-touching).
+
+## Skill ownership
+
+Document the **"manifest-parser reuse-on-redrain + prefetch-hook-mirrors-the-gate"**
+pattern in `.claude/skills/data-engineer/SKILL.md` in this PR (operator directive):
+the manifest-parser `stored_body` fast path is a SECOND reader on a REWASH kind
+(distinct from the `rewash_filings` bulk spec); a prefetch hook must mirror every
+pre-fetch gate including reuse, BUT only for kinds the hook actually prefetches —
+13F's infotable is reused yet never prefetched, so its reuse gate has no hook
+mirror.
+
+## Non-goals
+
+`primary_doc` reuse (#1617 SWEPT); 10-K XBRL prefetch (#1730); form5/nport reuse
+(#1731).

--- a/tests/test_manifest_parser_sec_13f_hr.py
+++ b/tests/test_manifest_parser_sec_13f_hr.py
@@ -386,6 +386,121 @@ def test_infotable_empty_body_tombstones_preserving_stored_raw(
         assert cur.fetchone() is not None
 
 
+def test_redrain_reuses_stored_infotable_no_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1729 — on a re-drain the parser REUSES the stored ``infotable_13f``
+    body (skips its fetch). primary_doc stays SWEPT (re-fetched). Seed the
+    infotable raw row directly, serve index + primary only, and assert the
+    infotable URL is never fetched yet the row parses end-to-end."""
+    from app.services.raw_filings import store_raw
+
+    iid = 8790100
+    cusip = "037833100"  # AAPL
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL")
+    _seed_cusip_mapping(ebull_test_conn, instrument_id=iid, cusip=cusip)
+    accession = "0001067983-25-000100"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    infotable_url = base + "infotable.xml"  # resolved name from _index_json() default
+    # Pre-seed the stored infotable body — the re-drain reuse target.
+    store_raw(
+        ebull_test_conn,
+        accession_number=accession,
+        document_kind="infotable_13f",
+        payload=_infotable_xml(holdings=[{"cusip": cusip}]),
+        parser_version="13f-infotable-v1",
+        source_url=infotable_url,
+    )
+    ebull_test_conn.commit()
+
+    # Fetch map deliberately OMITS infotable.xml — if the parser fetched it the
+    # call would be recorded (and return None → tombstone), so the assertions
+    # below catch any regression that bypasses reuse.
+    calls = _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+        },
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None and row.ingest_status == "parsed" and row.raw_status == "stored"
+
+    # Reuse: infotable URL never fetched; primary (SWEPT) still fetched.
+    assert infotable_url not in calls
+    assert base + "primary_doc.xml" in calls
+
+    # Holdings upserted from the reused body — identical to the fetch path.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT instrument_id FROM institutional_holdings WHERE accession_number = %s",
+            (accession,),
+        )
+        holdings = cur.fetchall()
+    assert len(holdings) == 1 and holdings[0][0] == iid
+
+
+def test_redrain_reuse_parse_failure_preserves_stored_raw(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1729 — a parse crash on the REUSE path still returns
+    ``raw_status='stored'`` (the body is on disk; the manifest must reflect it so
+    the retry sees the stored body, no re-fetch). Mirrors the PR1 ckpt-1 #2
+    invariant audit applied to the reuse branch."""
+    from app.services.manifest_parsers import sec_13f_hr as parser_module
+    from app.services.raw_filings import store_raw
+
+    accession = "0001067983-25-000101"
+    filer_cik = "0001067983"
+    _seed_pending_13f_hr(ebull_test_conn, accession=accession, filer_cik=filer_cik)
+
+    base = f"https://www.sec.gov/Archives/edgar/data/{int(filer_cik)}/{accession.replace('-', '')}/"
+    infotable_url = base + "infotable.xml"
+    store_raw(
+        ebull_test_conn,
+        accession_number=accession,
+        document_kind="infotable_13f",
+        payload=_infotable_xml(holdings=[{"cusip": "037833100"}]),
+        parser_version="13f-infotable-v1",
+        source_url=infotable_url,
+    )
+    ebull_test_conn.commit()
+
+    calls = _patch_fetch_map(
+        monkeypatch,
+        {
+            base + "index.json": _index_json(),
+            base + "primary_doc.xml": _FAKE_PRIMARY_XML,
+        },
+    )
+
+    def _raising_infotable(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthetic infotable parse crash on reuse")
+
+    monkeypatch.setattr(parser_module, "parse_infotable", _raising_infotable)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_13f_hr", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.failed == 1
+    row = get_manifest_row(ebull_test_conn, accession)
+    assert row is not None
+    assert row.ingest_status == "failed"
+    assert row.raw_status == "stored"
+    # Crash came from the reused body, not a fetch — infotable never requested.
+    assert infotable_url not in calls
+
+
 def test_fetch_exception_marks_failed_with_backoff(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #1729. Follow-up to #1591 PR1 (`86d42e5c`, #1727) which wired stored-body reuse into the 4 single-primary retained parsers (def14a/form4/form3/13dg); 13F-HR was deferred as multi-doc.

## What changed
`_parse_13f_hr` ([app/services/manifest_parsers/sec_13f_hr.py](app/services/manifest_parsers/sec_13f_hr.py)) now reuses the stored `infotable_13f` body on a re-drain (parser-version bump → `sec_rebuild` resets the manifest row to `pending` → manifest worker re-runs the parser) instead of re-downloading it.

- `stored_body(conn, accession, "infotable_13f")` gate wraps the fetch + empty-guard + `store_raw`; on a hit the flow joins at `parse_infotable`. Sits **below** every pre-fetch gate (index walk / primary fetch+parse / `thirteen_f_within_retention`) — reuse replaces only the fetch, never a gate. `fetched_at` is preserved on reuse.
- `primary_doc` stays **SWEPT** (#1617): re-fetched + re-parsed every drain for `period_of_report`/filer info. Only the largest attachment (~199 KB infotable) is reused, so a re-drain of a parsed 13F-HR drops from **3 HTTP → 2**.

## Security model
No auth/authz surface. Read path unchanged. The reuse path reads only `filing_raw_documents` (already-stored, immutable per-accession SEC bytes) on the worker's own connection. No new SQL interpolation; `stored_body` uses the existing parameterised `read_raw`.

## Source rule
- **One Information Table per 13F-HR accession** (SEC Form 13F General Instruction; the EDGAR `<informationTable>` XML attachment). `parse_archive_index` resolves exactly one name; `store_raw` UPSERTs under `(accession, "infotable_13f")` → the key uniquely + permanently identifies that one attachment. No `source_url` re-check needed (matches PR1; the attachment is structurally singular). The body parser `parse_infotable` still runs on reuse, so a body-parser bump IS picked up; only the deterministic attachment *selection* is skipped (archive is immutable).
- **infotable_13f already in the REWASH bucket** (`rewash_filings.registered_specs()` → `_apply_13f_infotable`, since #836) → adding a second reader (the manifest-parser fast path) needs **no** retention-bucket change; `tests/test_raw_payload_retention.py` stays green.

## Full-population verification (dev DB, 2026-06-26)
| population | figure |
|---|---|
| `filing_raw_documents.infotable_13f` | 18,131 rows, 100% with payload, **0 swept**, avg 199 KB → reusable |
| `sec_filing_manifest` source=`sec_13f_hr`, status=`parsed` | 17,396 rows, **17,396 (100%)** have a stored infotable → every re-drain of a parsed row reuses |
| tombstoned (254,965) | 0 stored — tombstone pre-infotable, re-fetch index + re-tombstone (no infotable fetch wasted) |

(`primary_doc`: 113,393 rows, 74,980 swept → correctly excluded, re-fetched.)

## Prefetch-hook mirror (prevention-log #1956) — verify-only, NO code change
No hook prefetches the infotable: `_thirteen_f_index_url` prefetches `index.json`, `_thirteen_f_expand` prefetches `primary_doc.xml` ONLY (the infotable's retention gate is post-primary-parse, so prefetching it for a row that tombstones would itself violate the mirror contract — pinned by `test_two_phase_prefetch_out_of_retention_never_fetches_infotable`). Because no hook prefetches the infotable, the new reuse gate has **no hook to mirror**; adding one would be wrong. Documented the asymmetry in `_thirteen_f_expand`'s docstring.

## Tests (DB-tier, mirror existing harness) — 20/20 pass
- `test_redrain_reuses_stored_infotable_no_fetch`: infotable URL never fetched, primary (SWEPT) still fetched, holdings upserted identically, `raw_status='stored'`.
- `test_redrain_reuse_parse_failure_preserves_stored_raw`: a parse crash on the reuse path still returns `failed`/`raw_status='stored'`.

## Skill ownership
Documented the **"manifest-parser reuse-on-redrain + prefetch-hook-mirrors-the-gate"** pattern in [data-engineer SKILL §13.G](.claude/skills/data-engineer/SKILL.md) (operator directive).

## Conscious tradeoffs
- No `source_url` re-validation on reuse (structurally singular attachment + immutable archive; matches PR1). 
- 13F re-drain saves 1 of 3 fetches (not 0) — primary_doc must stay SWEPT.

## DoD 8-12 (dev-verify) — pending post-merge
Spec records the plan: scoped `POST /jobs/sec_rebuild/run {"source":"sec_13f_hr","instrument_id":...}`, assert infotable 0-HTTP on re-drain + byte-identical holdings parity, smoke `/instruments/AAPL/ownership-rollup`. No `sec_rebuild` backfill needed (output row-identical). Daemon restart onto new main post-merge.

Codex ckpt-1 (spec — 5 findings addressed: structural source-rule cite, candidate-scoped full-pop, robust test assertion) + ckpt-2 (branch — clean).

Spec: [docs/specs/etl/2026-06-26-1729-infotable-13f-reuse.md](docs/specs/etl/2026-06-26-1729-infotable-13f-reuse.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #1591 (parent epic — the rewash/drain-efficiency thread this extends).
