### PR TITLE
perf(#1731): reuse stored form5_xml on re-drain (promote out of KEPT_NEGLIGIBLE) + nport determination

### DIFF
--- a/app/services/manifest_parsers/insider_345.py
+++ b/app/services/manifest_parsers/insider_345.py
@@ -637,56 +637,64 @@ def _parse_form5(
     # ``/xslF345Xnn/`` prefixes used by Forms 3/4/5 (shared XSL).
     canonical_url = _canonical_form_4_url(url)
 
-    try:
-        with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
-            xml = provider.fetch_document_text(canonical_url)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "form5 manifest parser: fetch raised accession=%s url=%s: %s",
-            accession,
-            canonical_url,
-            exc,
-        )
-        return _failed_outcome(f"fetch error: {exc}", parser_version=_PARSER_VERSION_FORM5)
+    # #1731 — reuse the stored form5_xml body on a re-drain instead of
+    # re-downloading (SEC filings immutable per accession; same contract as
+    # _parse_form4/_parse_form3). Fetch + store only on a miss; reuse skips both
+    # so fetched_at is preserved. form5_xml is promoted out of KEPT_NEGLIGIBLE
+    # into the REWASH bucket in this change (rewash_filings registers a Form 5
+    # apply_fn) so the #1617 partition test stays green.
+    xml = stored_body(conn, accession_number=accession, document_kind="form5_xml")
+    if xml is None:
+        try:
+            with SecFilingsProvider(user_agent=settings.sec_user_agent) as provider:
+                xml = provider.fetch_document_text(canonical_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "form5 manifest parser: fetch raised accession=%s url=%s: %s",
+                accession,
+                canonical_url,
+                exc,
+            )
+            return _failed_outcome(f"fetch error: {exc}", parser_version=_PARSER_VERSION_FORM5)
 
-    if not xml:
+        if not xml:
+            try:
+                with conn.transaction():
+                    _write_tombstone(
+                        conn,
+                        instrument_id=instrument_id,
+                        accession_number=accession,
+                        primary_document_url=canonical_url,
+                        document_type="5",
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "form5 manifest parser: tombstone INSERT failed accession=%s",
+                    accession,
+                )
+                return _failed_outcome(f"tombstone error: {exc}", parser_version=_PARSER_VERSION_FORM5)
+            return ParseOutcome(
+                status="tombstoned",
+                parser_version=_PARSER_VERSION_FORM5,
+                error="empty or non-200 fetch",
+            )
+
         try:
             with conn.transaction():
-                _write_tombstone(
+                store_raw(
                     conn,
-                    instrument_id=instrument_id,
                     accession_number=accession,
-                    primary_document_url=canonical_url,
-                    document_type="5",
+                    document_kind="form5_xml",
+                    payload=xml,
+                    parser_version=_PARSER_VERSION_FORM5,
+                    source_url=canonical_url,
                 )
         except Exception as exc:  # noqa: BLE001
             logger.exception(
-                "form5 manifest parser: tombstone INSERT failed accession=%s",
+                "form5 manifest parser: store_raw failed accession=%s",
                 accession,
             )
-            return _failed_outcome(f"tombstone error: {exc}", parser_version=_PARSER_VERSION_FORM5)
-        return ParseOutcome(
-            status="tombstoned",
-            parser_version=_PARSER_VERSION_FORM5,
-            error="empty or non-200 fetch",
-        )
-
-    try:
-        with conn.transaction():
-            store_raw(
-                conn,
-                accession_number=accession,
-                document_kind="form5_xml",
-                payload=xml,
-                parser_version=_PARSER_VERSION_FORM5,
-                source_url=canonical_url,
-            )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "form5 manifest parser: store_raw failed accession=%s",
-            accession,
-        )
-        return _failed_outcome(f"store_raw error: {exc}", parser_version=_PARSER_VERSION_FORM5)
+            return _failed_outcome(f"store_raw error: {exc}", parser_version=_PARSER_VERSION_FORM5)
 
     try:
         parsed = parse_form_5_xml(xml)
@@ -823,12 +831,17 @@ def _insider_fetch_url(conn: Any, row: Any) -> str | None:  # conn: Connection, 
         return None
     if row.source == "sec_form5" and not form5_within_retention(filed):
         return None
-    # Map source → the EXACT stored kind; fail closed (Codex ckpt-1 #4).
-    # ``sec_form5`` is deliberately absent — _parse_form5 does NOT reuse
-    # (form5_xml stays KEPT_NEGLIGIBLE per #1617), so it falls through and
-    # prefetches as before. A shared form4_xml check would wrongly skip
-    # Form 3/5 rows whose form4_xml body happens to exist.
-    reuse_kind: dict[str, DocumentKind] = {"sec_form3": "form3_xml", "sec_form4": "form4_xml"}
+    # Map source → the EXACT stored kind; fail closed (Codex ckpt-1 #4). All
+    # three insider forms now reuse their stored body on re-drain (Form 5 joined
+    # in #1731 — promoted out of KEPT_NEGLIGIBLE into REWASH). The per-source map
+    # (vs a shared form4_xml check) keeps a stored form4_xml body from wrongly
+    # skipping a Form 3/5 prefetch; a source NOT in the map falls through and
+    # prefetches as before.
+    reuse_kind: dict[str, DocumentKind] = {
+        "sec_form3": "form3_xml",
+        "sec_form4": "form4_xml",
+        "sec_form5": "form5_xml",
+    }
     kind = reuse_kind.get(row.source)
     if kind is not None and stored_body(conn, accession_number=row.accession_number, document_kind=kind) is not None:
         return None

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -104,15 +104,20 @@ SWEPT_DOCUMENT_KINDS: frozenset[DocumentKind] = frozenset({"primary_doc"})
 # in ``ownership_drillthrough`` / ``instruments`` are satisfied by the
 # row, not the bytes).
 KEPT_NEGLIGIBLE_DOCUMENT_KINDS: dict[DocumentKind, str] = {
-    # Parsed in-memory at ingest; ownership_drillthrough COUNT(*)s the row
-    # but never reads the body. ~11 MB (dev). Retained for a planned Form 5
-    # rewash parser (insider_345.py:563-565) — promote to REWASH when that
-    # spec is registered; the partition test forces the move (it would
-    # otherwise be in two buckets).
-    "form5_xml": "write-only ~11MB; held for a future Form 5 rewash parser",
-    # Parsed in-memory at ingest; rewash re-fetches from EDGAR rather than
-    # re-reading the stored body (n_port_ingest.py:82). ~6 MB (dev).
-    "nport_xml": "write-only ~6MB; rewash re-fetches from EDGAR, no payload reader",
+    # form5_xml PROMOTED to REWASH in #1731 — _parse_form5 now reuses the stored
+    # body on re-drain + rewash_filings registers a Form 5 apply_fn, so it is a
+    # payload reader and lives in registered_specs(), not here (the partition
+    # test would fail if it stayed).
+    # n_port: VERIFIED 2026-06-26 (#1731) — the "rewash re-fetches from EDGAR"
+    # behaviour is DESCRIPTIVE (no payload reader wired), NOT a hard design
+    # constraint: nport_xml is stored + retained, the filing is immutable per
+    # accession, and parse_n_port_payload would produce identical output from the
+    # stored bytes. Reuse is DEFERRED (not forbidden): 151 dev rows (~12× smaller
+    # than Form 5's already-negligible 1,586) don't justify promoting — promotion
+    # needs a full _apply_nport rewash spec (the series + per-holding equity-filter
+    # + fund-observation ladder, far heavier than Form 5's upsert_filing mirror).
+    # Revisit if the manifest-adapter nport population grows materially.
+    "nport_xml": "write-only ~6MB; rewash re-fetches from EDGAR, no payload reader (reuse deferred by volume #1731)",
     # Parsed in-memory at ingest; the bimonthly job re-fetches fresh from
     # FINRA each cadence (finra_short_interest_refresh.py), never from the
     # store. Part of ~92 MB FINRA raw (dev).

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -471,9 +471,10 @@ def _apply_form5(
     return True
 
 
-# Form 5 parser version is "form5-v{N}" — see _PARSER_VERSION_FORM5 in
-# insider_transactions.py. Bump both in lockstep when the parser semantics
-# change in a way that affects what lands in typed tables.
+# Form 5 parser version is "form5-v{N}" — defined as _PARSER_VERSION_FORM5 in
+# insider_transactions.py (imported by manifest_parsers/insider_345.py, not
+# redefined there). Bump both in lockstep when the parser semantics change in a
+# way that affects what lands in typed tables.
 register_parser(
     ParserSpec(
         document_kind="form5_xml",

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -415,6 +415,75 @@ register_parser(
 
 
 # ---------------------------------------------------------------------------
+# Form 5 wiring (#1731 — promotes form5_xml out of KEPT_NEGLIGIBLE)
+# ---------------------------------------------------------------------------
+
+
+def _apply_form5(
+    conn: psycopg.Connection[Any],
+    raw_doc: RawFilingDocument,
+) -> bool:
+    """Re-parse the Form 5 XML body and re-apply the typed-table upsert.
+
+    Same shape as :func:`_apply_form4` — Form 5 (annual statement of changes,
+    Rule 16a-3(f)) shares the Form 4 ownership XML schema and persists through
+    the SAME ``insider_filings`` (``document_type='5'``) + ``insider_transactions``
+    path via ``upsert_filing``; only the parser differs (``parse_form_5_xml``).
+    The parsed object carries the document_type, so no extra kwarg is needed
+    (mirrors the live ``insider_345._parse_form5`` call).
+
+    Returns ``False`` when no existing ``insider_filings`` row is found (re-wash
+    is not a first-time ingester). Raises :class:`RewashParseError` on parser
+    regression — for Form 5 that includes the holdings-only / wrong-document_type
+    filings ``parse_form_5_xml`` returns ``None`` for, so the failure surfaces in
+    ``rows_failed`` rather than silently in ``rows_skipped``."""
+    from app.services.insider_transactions import parse_form_5_xml, upsert_filing
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, primary_document_url
+            FROM insider_filings
+            WHERE accession_number = %s
+            """,
+            (raw_doc.accession_number,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return False
+    instrument_id, primary_document_url = row
+
+    body = raw_doc.require_payload()
+    parsed = parse_form_5_xml(body)
+    if parsed is None:
+        raise RewashParseError(
+            f"parse_form_5_xml returned None for accession={raw_doc.accession_number} body_size={len(body)}"
+        )
+
+    upsert_filing(
+        conn,
+        instrument_id=int(instrument_id),
+        accession_number=raw_doc.accession_number,
+        primary_document_url=str(primary_document_url) if primary_document_url else "",
+        parsed=parsed,
+        is_rewash=True,
+    )
+    return True
+
+
+# Form 5 parser version is "form5-v{N}" — see _PARSER_VERSION_FORM5 in
+# insider_transactions.py. Bump both in lockstep when the parser semantics
+# change in a way that affects what lands in typed tables.
+register_parser(
+    ParserSpec(
+        document_kind="form5_xml",
+        current_version="form5-v1",
+        apply_fn=_apply_form5,
+    )
+)
+
+
+# ---------------------------------------------------------------------------
 # DEF 14A proxy beneficial-ownership table wiring
 # ---------------------------------------------------------------------------
 

--- a/tests/test_manifest_parser_insider_345.py
+++ b/tests/test_manifest_parser_insider_345.py
@@ -1275,3 +1275,57 @@ def test_form3_reuse_stored_body_skips_fetch(
     assert stats.parsed == 1
     row = get_manifest_row(ebull_test_conn, acc)
     assert row is not None and row.ingest_status == "parsed" and row.raw_status == "stored"
+
+
+def test_form5_reuse_stored_body_skips_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1731 — Form 5 reuses its stored form5_xml body on re-drain (no SEC fetch,
+    fetched_at preserved), the same branch as Form 4/3. form5_xml is promoted out
+    of KEPT_NEGLIGIBLE into REWASH in this change."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+    from app.services.raw_filings import store_raw
+
+    iid = 8760053
+    acc = "0000320193-26-000053"
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="AAPL5R")
+    _seed_pending(ebull_test_conn, accession=acc, instrument_id=iid, source="sec_form5", form="5")
+    store_raw(
+        ebull_test_conn,
+        accession_number=acc,
+        document_kind="form5_xml",
+        payload=_FAKE_FORM_5_XML,
+        parser_version="form5-v1",
+        source_url="https://www.sec.gov/Archives/edgar/data/320193/000032019326000053/primary_doc.xml",
+    )
+    ebull_test_conn.commit()
+
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT fetched_at FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'form5_xml'",
+            (acc,),
+        )
+        before_row = cur.fetchone()
+    assert before_row is not None
+    fetched_at_before = before_row[0]
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(sec_edgar.SecFilingsProvider, "fetch_document_text", _no_fetch)
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_form5", max_rows=10)
+    ebull_test_conn.commit()
+
+    assert stats.parsed == 1
+    row = get_manifest_row(ebull_test_conn, acc)
+    assert row is not None and row.ingest_status == "parsed" and row.raw_status == "stored"
+
+    # Reuse must NOT re-store → fetched_at unchanged.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            "SELECT fetched_at FROM filing_raw_documents WHERE accession_number = %s AND document_kind = 'form5_xml'",
+            (acc,),
+        )
+        after_row = cur.fetchone()
+    assert after_row is not None and after_row[0] == fetched_at_before

--- a/tests/test_manifest_worker_prefetch.py
+++ b/tests/test_manifest_worker_prefetch.py
@@ -241,10 +241,13 @@ def test_insider_fetch_url_mirrors_prefetch_gates(monkeypatch: pytest.MonkeyPatc
     # #1591 — body already stored → skip prefetch (parser reuses it from the DB).
     monkeypatch.setattr(ins, "stored_body", _fake_stored_body((_MK_ACCESSION, "form4_xml")))
     assert _insider_fetch_url(None, _mk(source="sec_form4", url=base, filed_at=recent, iid=1)) is None
-    # Fail-closed map (Codex ckpt-1 #4): Form 5 is NOT reused by _parse_form5,
-    # so its source is absent from the reuse map — a stored form5_xml body must
-    # NOT skip the prefetch (the parser will fetch it).
+    # #1731 — Form 5 now reuses its stored body too (promoted out of
+    # KEPT_NEGLIGIBLE into REWASH). A stored form5_xml body skips the prefetch.
     monkeypatch.setattr(ins, "stored_body", _fake_stored_body((_MK_ACCESSION, "form5_xml")))
+    assert _insider_fetch_url(None, _mk(source="sec_form5", url=base, filed_at=recent, iid=1)) is None
+    # Fail-closed map still holds: a stored form4_xml body must NOT skip a Form 5
+    # prefetch (per-source map, not a shared kind check).
+    monkeypatch.setattr(ins, "stored_body", _fake_stored_body((_MK_ACCESSION, "form4_xml")))
     assert _insider_fetch_url(None, _mk(source="sec_form5", url=base, filed_at=recent, iid=1)) is not None
 
 


### PR DESCRIPTION
Closes #1731. Refs #1591 (parent epic — the rewash/drain-efficiency thread this extends). Follow-up small-kind cleanup after #1729 (PR #1732) + #1730 (PR #1733).

## form5_xml — promoted out of KEPT_NEGLIGIBLE into REWASH
- `_parse_form5` ([insider_345.py](app/services/manifest_parsers/insider_345.py)) now reuses the stored `form5_xml` body on a re-drain (skip fetch + store, `fetched_at` preserved) — same branch as `_parse_form4`/`_parse_form3` (#1591 PR1).
- `rewash_filings` registers a Form 5 `_apply_form5` (mirrors `_apply_form4` with `parse_form_5_xml`; Form 5 shares `insider_filings`/`insider_transactions` via `upsert_filing(is_rewash=True)`) → `form5_xml` lands in `registered_specs()`.
- `_insider_fetch_url` adds `sec_form5 → form5_xml` to the fail-closed reuse map (the prefetch hook now mirrors the reuse gate for all three insider forms).
- **Removed `form5_xml` from `KEPT_NEGLIGIBLE_DOCUMENT_KINDS` in the SAME change** so the #1617 pairwise-disjoint + every-kind-classified partition tests stay green — a payload reader can't also be "no payload reader". The settled-decision ("adding a rewash parser for a KEPT_NEGLIGIBLE kind MUST remove it in the same change") + the old `form5_xml` comment both anticipated exactly this.

## Security model
No auth/authz surface. Reuse reads only the already-stored, immutable-per-accession `form5_xml` body on the worker's own connection (no SQL interpolation; `stored_body` uses the existing parameterised `read_raw`). `_apply_form5` is the existing rewash framework's local-reparse path (no SEC re-fetch). No retention/storage change — `form5_xml` was already retained uncompacted (KEPT_NEGLIGIBLE → REWASH is a classification move, not a sweep change).

## Source rule
- **SEC filings immutable per accession** (#1591-family invariant; amendment = new accession) → a present `form5_xml` body is reusable, no freshness check. Form 5 (Rule 16a-3(f)) shares the Form 4 ownership XML schema + persistence path, so reuse + `_apply_form5` are direct mirrors of the dev-verified Form 4 path.
- **#1617 retention partition** (settled-decisions §"Raw-payload retention"; data-eng §13.F): every `DocumentKind` in exactly one bucket. Adding a payload reader forces `form5_xml` REWASH; removing it from KEPT_NEGLIGIBLE keeps the partition disjoint.

## Full-population verification (dev DB, 2026-06-26)
`form5_xml`: 1,586 rows, 100% with payload, **0 swept**, avg 7 KB → every re-drain of a parsed Form 5 reuses. (Negligible volume — this is consistency + clearing the "held for a future Form 5 rewash parser" debt, not a large rate-budget win.)

## nport_xml — VERIFIED design intent, reuse DEFERRED (no code change)
The issue flagged nport as "may be intentionally re-fetched — check first". Determination: the `"rewash re-fetches from EDGAR"` justification is **descriptive** (no reader wired), **NOT a hard design constraint** — `nport_xml` is stored + retained, the filing is immutable per accession, and `parse_n_port_payload` would produce identical output from the stored bytes. Reuse is **deferred, not forbidden**: 151 dev rows (~12× smaller than Form 5's already-negligible 1,586) don't justify promoting, because promotion needs a full `_apply_nport` rewash spec (the series + per-holding equity-filter + fund-observation ladder — far heavier than Form 5's `upsert_filing` mirror). Recorded in the `KEPT_NEGLIGIBLE` justification comment; revisit if the manifest-adapter nport population grows materially.

## Tests
- `test_form5_reuse_stored_body_skips_fetch`: stored body reused, no SEC fetch, `fetched_at` preserved, holdings written, `raw_status='stored'`.
- `_insider_fetch_url` form5 assertion **flipped**: a stored `form5_xml` body now skips the prefetch (was "not reused"); the fail-closed map still prevents a `form4_xml` body from suppressing a Form 5 prefetch.
- #1617 partition tests (`test_raw_payload_retention.py`) auto-cover the bucket move (form5_xml ∈ REWASH, ∉ KEPT_NEGLIGIBLE). 98 affected + 4482 fast-tier pass.

## Conscious tradeoffs
- form5 reuse is negligible-volume (consistency, not a perf win) — chosen because the operator asked + it clears tech-debt + the partition test forced the bucket decision either way.
- `_apply_form5` is not unit-tested with a real body in `test_rewash_filings.py` (which only tests the framework with synthetic apply_fns); it mirrors the dev-verified `_apply_form4` exactly and is dev-verified end-to-end via `run_rewash --kind form5_xml`.

## DoD 8-12 (dev-verify) — pending post-merge
Single-accession Form 5 re-drain: assert 0-HTTP reuse + byte-identical insider rows (parity), like #1729. `_apply_form5`: `run_rewash --kind form5_xml --dry-run` then a scoped real run on the panel. No `sec_rebuild` backfill needed (output identical). Daemon restart onto new main post-merge.

Codex ckpt-2 (branch — clean: bucket partition valid, reuse preserves `raw_status='stored'`, `_apply_form5` correct, fail-closed map intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)