### PR TITLE
fix(#817): per-accession advisory write lock for ownership rewash + live ingest

### DIFF
--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -773,6 +773,13 @@ def _ingest_single_accession(
     inserted = 0
     updated = 0
 
+    # #817 — legacy per-accession ingest is a third writer of
+    # def14a_beneficial_holdings (alongside the live manifest drain and rewash).
+    # Acquire the per-accession lock here — AFTER the fetch+parse above (never
+    # held across the SEC fetch at line ~715), BEFORE the write fan-out — so a
+    # concurrent rewash DELETE+INSERT serialises against it.
+    raw_filings.acquire_filing_accession_write_lock(conn, ref.accession_number)
+
     # Per-share-class fan-out (#1117 PR-B). Same DEF 14A document
     # describes the same issuer; each share-class sibling renders
     # its own copy of the per-instrument tables. Bulk path covered

--- a/app/services/insider_form3_ingest.py
+++ b/app/services/insider_form3_ingest.py
@@ -109,6 +109,11 @@ def upsert_form_3_filing(
     pattern as ``upsert_filing``); final fallback is the historical
     as-of derivation, logged.
     """
+    # #817 — the single once-per-accession chokepoint for Form 3 typed-table
+    # writes (live manifest drain, rewash, legacy ingest all funnel here).
+    # Serialise concurrent writers of this accession's rows before the first
+    # read/mutation (no SEC fetch in this function — safe to hold).
+    raw_filings.acquire_filing_accession_write_lock(conn, accession_number)
     if filed_at is None:
         filed_at = lookup_sec_filed_at(conn, accession_number)
     with conn.cursor() as cur:

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -1231,6 +1231,15 @@ def upsert_filing(
         sanitised.append(txn)
     parsed = replace(parsed, transactions=tuple(sanitised))
 
+    # #817 — the single once-per-accession chokepoint for Form 4/5 typed-table
+    # writes (live manifest drain, rewash, legacy ingest all funnel here).
+    # Serialise concurrent writers of this accession's rows before the first
+    # mutation (no SEC fetch happens in this function — safe to hold). Rewash +
+    # legacy commit per accession (xact lock auto-releases there); on the
+    # manifest-worker path the surrounding batch txn holds it until batch commit
+    # (#1735, same property as the #1542 13F lock) — coarse but correct.
+    raw_filings.acquire_filing_accession_write_lock(conn, accession_number)
+
     with conn.cursor() as cur:
         cur.execute(
             """

--- a/app/services/manifest_parsers/def14a.py
+++ b/app/services/manifest_parsers/def14a.py
@@ -79,7 +79,11 @@ from app.services.ownership_observations import (
     refresh_def14a_current,
     refresh_esop_current,
 )
-from app.services.raw_filings import store_raw, stored_body
+from app.services.raw_filings import (
+    acquire_filing_accession_write_lock,
+    store_raw,
+    stored_body,
+)
 from app.services.sec_identity import siblings_for_issuer_cik
 
 logger = logging.getLogger(__name__)
@@ -355,6 +359,18 @@ def _parse_def14a(
 
     try:
         with conn.transaction():
+            # #817 — serialise this accession's def14a_beneficial_holdings
+            # writes against a concurrent rewash DELETE+INSERT (same lock key).
+            # First statement in the txn, after the body fetch above (no SEC
+            # fetch inside this block).
+            # NB: this ``with conn.transaction()`` is a SAVEPOINT (the manifest
+            # worker runs the whole batch under one autocommit=False txn, commit
+            # at scheduler.py:4843), so this xact lock is held until BATCH commit,
+            # not per accession — the same coarse-but-correct property the #1542
+            # 13F lock has. Mutual exclusion is preserved; a rare rewash-vs-live
+            # deadlock self-heals (Postgres aborts+retries, no corruption).
+            # Root-cause (per-accession commit) tracked in #1735.
+            acquire_filing_accession_write_lock(conn, accession)
             siblings = _resolve_siblings(conn, instrument_id=instrument_id, issuer_cik=issuer_cik)
             for sibling_iid in siblings:
                 for holder in parsed.rows:

--- a/app/services/manifest_parsers/sec_13dg.py
+++ b/app/services/manifest_parsers/sec_13dg.py
@@ -74,7 +74,11 @@ from app.services.manifest_parsers._schedule13_adapter import (
     build_filing_from_edgartools_dict,
 )
 from app.services.ownership_observations import refresh_blockholders_current
-from app.services.raw_filings import store_raw, stored_body
+from app.services.raw_filings import (
+    acquire_filing_accession_write_lock,
+    store_raw,
+    stored_body,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -325,6 +329,16 @@ def _parse_13dg(
     inserted = 0
     try:
         with conn.transaction():
+            # #817 — serialise this accession's blockholder_filings writes
+            # against a concurrent rewash DELETE+INSERT (same lock key). First
+            # statement in the txn, after the stored-body read above (no SEC
+            # fetch inside this block).
+            # NB: SAVEPOINT, not a top-level txn (the manifest worker batches the
+            # whole tick under one autocommit=False txn) → this xact lock is held
+            # until BATCH commit, matching the #1542 13F lock. Correct mutual
+            # exclusion; rare rewash-vs-live deadlock self-heals. Root-cause
+            # (per-accession commit) tracked in #1735.
+            acquire_filing_accession_write_lock(conn, accession)
             # Resolve the subject company to an instrument (#1628). CUSIP
             # is the security-precise key (disambiguates share-class
             # siblings; settled "CIK = entity, CUSIP = security" #1102),

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -157,6 +157,53 @@ class RawFilingDocument:
         return self.payload
 
 
+def acquire_filing_accession_write_lock(conn: psycopg.Connection[Any], accession_number: str) -> None:
+    """Serialise concurrent writers of ONE accession's typed ownership rows
+    (#817 — generalises the 13F #1542 lock to Form 3/4/5, DEF 14A and 13D/G
+    blockholders).
+
+    Three writer classes target the same accession's typed tables: the live
+    manifest drain (``manifest_parsers/*``), the operator rewash
+    (``rewash_filings``), and the legacy manual ingesters. After
+    ``POST /jobs/sec_rebuild/run`` requeues a parser-version cohort for the live
+    worker, an operator-triggered ``scripts/rewash.py`` can target the same
+    accession the worker is re-draining; #1274/#1591 also made the live drain
+    concurrent. This transaction-scoped advisory lock makes those mutations
+    mutually exclusive per accession.
+
+    An advisory lock is cooperative: EVERY writer of the guarded rows MUST call
+    this with the identical key (prevention-log "Advisory lock scope vs
+    concurrent writers"). It lives inside the once-per-accession write path so a
+    future caller cannot forget it (prevention-log "lock acquisition belongs
+    inside the function").
+
+    Transaction-scoped (``pg_advisory_xact_lock``): auto-releases on
+    COMMIT/ROLLBACK/connection-close. MUST be called inside the same
+    non-autocommit transaction as the write, AFTER any SEC fetch (never held
+    across network I/O), and BEFORE any count/gate read that feeds a DELETE and
+    BEFORE any per-instrument refresh lock (per-accession then per-instrument).
+
+    Release granularity follows the CALLER's commit boundary. Rewash + legacy
+    commit per accession, so the lock releases per accession there. The live
+    manifest worker batches the whole tick under one ``autocommit=False`` txn
+    (commit at ``scheduler.py``), so a ``with conn.transaction()`` inside a
+    parser is a SAVEPOINT and this lock is absorbed by the batch txn and held
+    until BATCH commit — the same coarse-but-correct property the #1542 13F lock
+    has. Mutual exclusion still holds; the uniform-order acyclic argument holds
+    strictly only for the per-accession-commit callers — under the batch txn a
+    rare rewash-vs-live overlap can deadlock and Postgres aborts+retries one side
+    (no corruption). Root-cause (per-accession commit in the worker) → #1735.
+
+    Own namespace (``ingest_filing_accession``) — distinct from the 13F helper's
+    ``ingest_13f_accession``; 13F filings carry their own kinds and keep their
+    #1542 serialisation domain. Key derivation mirrors
+    :func:`institutional_holdings.acquire_13f_accession_write_lock`."""
+    conn.execute(
+        "SELECT pg_advisory_xact_lock((hashtextextended('ingest_filing_accession', 0) # hashtextextended(%s, 0)))",
+        (accession_number,),
+    )
+
+
 def store_raw(
     conn: psycopg.Connection[Any],
     *,

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -524,6 +524,13 @@ def _apply_def14a(
     #      the old parser_version forever.
     from app.services.def14a_ingest import _upsert_holding, def14a_within_cap
 
+    # #817 — acquire BEFORE the existence/cap-gate reads below: the
+    # def14a_within_cap decision feeds the DELETE+INSERT, so the whole
+    # read→DELETE→insert window must be serialised against a concurrent live
+    # _upsert_holding (prevention-log "SELECT COUNT(*) race when gating a
+    # DELETE"). No SEC fetch in this function — safe to hold.
+    raw_filings.acquire_filing_accession_write_lock(conn, raw_doc.accession_number)
+
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -702,6 +709,13 @@ def _apply_blockholders(
     )
 
     accession = raw_doc.accession_number
+
+    # #817 — acquire BEFORE the COUNT(*)/within_retention gate below: that
+    # decision feeds the DELETE+INSERT, so the read→DELETE→insert window must
+    # be serialised against a concurrent live _upsert_filing_row writer
+    # (prevention-log "SELECT COUNT(*) race when gating a DELETE"). No SEC
+    # fetch in this function — safe to hold.
+    raw_filings.acquire_filing_accession_write_lock(conn, accession)
 
     # Branch-order step 1: count existing typed rows for the accession.
     with conn.cursor() as cur:

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -348,6 +348,14 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 
 ---
 
+### `scripts/rewash.py` must pre-import `manifest_parsers` or a real rewash crashes mid-run on a circular import
+- First seen in: #1731 (noted in memory); fixed in #817
+- Symptom: `scripts/rewash.py --kind form4_xml` (any non-dry-run with a non-empty cohort) crashes on the FIRST insider accession with `ImportError: cannot import name 'ParsedForm3' from partially initialized module 'app.services.insider_transactions'`. The apply-fn (`_apply_form4/5/3`) does a lazy `from app.services.insider_transactions import ...`; if that is the process's first import of `insider_transactions`, the chain `insider_transactions -> manifest_parsers._classify -> insider_345 -> insider_form3_ingest -> insider_transactions` re-enters the module mid-init. The app + test entrypoints import `manifest_parsers` first by side effect, masking it; the standalone CLI did not. Dry-run does NOT reproduce (it skips the apply import). Reproduces on a clean `main` tree — NOT introduced by any single PR.
+- Prevention: the rewash CLI imports `app.services.manifest_parsers` BEFORE `app.services.rewash_filings`. Any new standalone entrypoint that drives ownership apply-fns must do the same (or the deeper fix: make `insider_transactions`'s top-level `manifest_parsers._classify` import lazy). When dev-verifying a rewash, run a REAL (non-dry-run) pass on a forced cohort of 1 — a dry-run will not surface apply-time import or parse failures.
+- Enforced in: this prevention log; `scripts/rewash.py` (pre-import + comment)
+
+---
+
 ### `assert` as a runtime guard in service code
 - First seen in: #109
 - Symptom: A service function used `assert row is not None` after a `RETURNING` INSERT (or after a transaction block) to enforce a DB-contract invariant. `python -O` strips assertions, so the guard vanishes in any optimised build and the next line crashes with a confusing `TypeError: 'NoneType' object is not subscriptable` (or similar) instead of the intended structured error.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -340,6 +340,14 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 
 ---
 
+### `pg_advisory_xact_lock` inside a manifest-worker savepoint is held until BATCH commit, not per accession
+- First seen in: #817 (Codex ckpt-2), generalising the #1542 13F lock
+- Symptom: A per-accession `pg_advisory_xact_lock` was acquired inside a manifest parser's `with conn.transaction()` to serialise that accession's typed-table write. But `sec_manifest_worker_tick` opens `connect_job()` (default `autocommit=False`) and commits ONCE after the whole batch (`scheduler.py`), and `_dispatch_rows` has no per-row commit — so the parser's `with conn.transaction()` is a SAVEPOINT, and `pg_advisory_xact_lock` acquired in a savepoint is absorbed by the parent and held until the TOP-LEVEL (batch) transaction commits. Result: the lock is held across all subsequent rows' SEC fetches, accumulates one lock per accession + per instrument across the batch, and the "one accession lock at a time → deadlock-free" argument breaks (a concurrent per-accession writer can deadlock; Postgres aborts+retries, so no corruption but an availability blip). The #1542 13F lock and every `refresh_*_current` lock share this property.
+- Prevention: `with conn.transaction()` is a SAVEPOINT when the connection is already in a transaction (the default under `autocommit=False`). A `pg_advisory_xact_lock` taken inside it releases at the OUTER transaction's commit, NOT at the `with` block's exit. Before claiming a per-accession (or per-anything) advisory lock releases "per iteration", confirm the enclosing loop actually commits per iteration — grep the worker/driver for a per-row `conn.commit()`. If the driver batches, either (a) commit per row, or (b) use a session lock (`pg_advisory_lock`/`pg_advisory_unlock`) released in a `finally` — but only where the surrounding txn is recoverable on the release (a savepoint write, not direct-on-conn statements that abort the txn). For a coarse-but-correct lock (mutual exclusion preserved, deadlock self-heals) the batch-hold may be acceptable — but document it at the call site and ticket the root cause; do NOT silently imply per-accession granularity.
+- Enforced in: this prevention log; #817 (`manifest_parsers/def14a.py`, `sec_13dg.py`, `insider_transactions.py` call-site comments); root-cause tracked in #1735
+
+---
+
 ### `assert` as a runtime guard in service code
 - First seen in: #109
 - Symptom: A service function used `assert row is not None` after a `RETURNING` INSERT (or after a transaction block) to enforce a DB-contract invariant. `python -O` strips assertions, so the guard vanishes in any optimised build and the next line crashes with a confusing `TypeError: 'NoneType' object is not subscriptable` (or similar) instead of the intended structured error.

--- a/docs/specs/etl/2026-06-26-817-rewash-accession-write-lock.md
+++ b/docs/specs/etl/2026-06-26-817-rewash-accession-write-lock.md
@@ -1,0 +1,302 @@
+# #817 — Per-accession write lock for ownership rewash + live ingest
+
+Status: spec (2026-06-26). Branch `feature/817-rewash-accession-write-lock`.
+Closes #817. Refs #1542 (the 13F precedent this generalises).
+
+## Problem
+
+`rewash_filings.run_rewash` (manual CLI `scripts/rewash.py`) re-parses every
+`filing_raw_documents` row below the current `parser_version` and re-applies
+the typed-table write. The cohort scan (`_fetch_cohort`,
+`rewash_filings.py:250`) is a plain `SELECT` with **no row claim**, and the
+per-kind apply functions do **no per-accession locking** — except 13F, which
+got `acquire_13f_accession_write_lock` in #1542.
+
+So two writers of the **same accession's** typed rows can interleave:
+
+- **rewash vs rewash** — two operators each run `scripts/rewash.py --kind X`.
+- **rewash vs live** — an operator runs `scripts/rewash.py --kind X` while the
+  `sec_manifest_worker` re-drains the same kind (the operator runbook tells
+  operators to `POST /jobs/sec_rebuild/run` after a parser change, which
+  requeues manifest rows for the live worker; `sec_rebuild` preserves
+  `parser_version` — `sec_rebuild.py:131` — so the live drain and a manual
+  rewash can both target the same accession).
+- **live vs live** — #1274 parallelised filer ingest and #1591 added concurrent
+  re-drain prefetch; a re-queue/retry overlap can put two live writers on one
+  accession.
+
+### Premise correction (full-population, dev DB)
+
+The ticket claims "both upserts are idempotent (`ON CONFLICT DO UPDATE`), so no
+corruption — just duplicate parsing work". **This is only true for two of the
+five kinds.** Verified against the actual write code:
+
+| Kind | Per-accession write mechanism | Concurrency hazard |
+|---|---|---|
+| `form4_xml` | `upsert_filing` — pure `ON CONFLICT DO UPDATE` (insider_filings/filers/footnotes/transactions) | benign (idempotent, deterministic by parser_version) — duplicate work only |
+| `form5_xml` | `upsert_filing` (same as form4) | benign |
+| `form3_xml` | `upsert_form_3_filing` — `ON CONFLICT` on `insider_filings`, but **DELETE+INSERT** on `insider_filers`, `insider_transaction_footnotes`, `insider_initial_holdings` | **real** — transient-empty child rows + lost-update window |
+| `def14a_body` | rewash `_apply_def14a`: **`DELETE FROM def14a_beneficial_holdings`** + `_upsert_holding` loop, gated by `def14a_within_cap`. **Live** path (`manifest_parsers/def14a.py`) is `_upsert_holding`-only, **no DELETE** | **real** (rewash side) — DELETE+INSERT + cap-gated DELETE racing a concurrent `_upsert_holding` |
+| `primary_doc_13dg` (blockholders) | `_apply_blockholders`: `blockholders_within_retention` count-gate → **DELETE** → `_upsert_filing_row` (`ON CONFLICT DO NOTHING`) | **real** — matches prevention-log L311 ("SELECT COUNT(*) race when gating a DELETE") |
+
+So the hazard is **non-uniform**: form3 / def14a / blockholders carry a genuine
+**lost-data** race (not merely duplicate work); form4 / form5 are benign.
+
+**Live def14a is correctly upsert-only (not a bug):** a live accession is
+ingested exactly once, so there is no "new parser version" event at live time to
+drop stale holders for — that is precisely what *rewash* exists to do (hence the
+rewash-only DELETE). The lock's job here is to serialise the rare rewash-DELETE
+against a concurrent live `_upsert_holding`, not to add a DELETE to the live
+path.
+
+## Source rule
+
+This is an internal concurrency invariant, not an SEC data-treatment rule, so
+the governing "source rule" is our **own settled pattern**, not a reg:
+
+- **#1542 precedent** (`institutional_holdings.acquire_13f_accession_write_lock`,
+  `institutional_holdings.py:899`): a transaction-scoped
+  `pg_advisory_xact_lock` keyed on the accession serialises the 13F live writer
+  (`sec_13f_hr.py:483`) against the 13F rewash DELETE+INSERT
+  (`rewash_filings.py:1129`). Acquired **inside the transaction, after all SEC
+  fetches**, **first** (before any per-instrument refresh lock) so lock order is
+  consistent and deadlock-free.
+- **Prevention-log L335-338** ("Advisory lock scope vs concurrent writers"): an
+  advisory lock is cooperative — **every** writer of the guarded invariant must
+  take the **same** lock. Locking only the rewash side would not protect against
+  the live writer.
+- **Prevention-log L401-402** ("lock acquisition belongs inside the function,
+  not at every call site") and **L407-410** ("a process lock / defensive SELECT
+  buys no DB isolation; use a real DB boundary keyed to the natural identity").
+- **Prevention-log L311** (count-gated DELETE needs a conflicting lock) — the
+  blockholders / def14a count-gate is exactly this shape.
+
+The invariant to enforce: **at most one transaction at a time writes a given
+accession's typed ownership rows.** Natural identity = `accession_number`. (Not
+globally one-kind-per-accession in general — a 13F filing carries both
+`primary_doc` and `infotable_13f` — but among the five kinds this lock covers
+there are **0** shared accessions, full-pop verified below, so one namespace is
+collision-free for the covered set.)
+
+## Design (smallest change that enforces the invariant)
+
+Generalise the 13F helper to a kind-agnostic, accession-keyed lock and apply it
+symmetrically on **both** writers (rewash apply + live manifest drain) for each
+of the five ownership kinds — exactly the #1542 shape, replicated.
+
+### 1. Shared helper
+
+Add to `app/services/raw_filings.py` (low-level filing primitive, already
+imported by both `rewash_filings` and the manifest parsers — no import cycle):
+
+```python
+_FILING_ACCESSION_LOCK_NS = "ingest_filing_accession"
+
+def acquire_filing_accession_write_lock(conn, accession_number: str) -> None:
+    """Serialise concurrent writers of ONE accession's typed ownership rows
+    (#817; generalises the 13F #1542 lock to all ownership kinds).
+
+    Transaction-scoped (pg_advisory_xact_lock): auto-releases on
+    COMMIT/ROLLBACK. MUST be called inside the same non-autocommit
+    transaction as the typed-table write, AFTER any SEC fetch (never held
+    across network I/O), and BEFORE any per-instrument refresh lock so lock
+    order is uniform across writers (per-accession then per-instrument)."""
+    conn.execute(
+        "SELECT pg_advisory_xact_lock("
+        "(hashtextextended(%s, 0) # hashtextextended(%s, 0)))",
+        (_FILING_ACCESSION_LOCK_NS, accession_number),
+    )
+```
+
+Key derivation mirrors `acquire_13f_accession_write_lock` byte-for-byte except
+the namespace string. 13F keeps its own helper/namespace — 13F accessions never
+collide with the others, so the two namespaces coexist safely; not worth
+churning the proven 13F call sites.
+
+### 2. Lock placement — driven by the full writer census (dev, 2026-06-26)
+
+Census (every writer of the 6 guarded typed tables, with txn granularity):
+
+- **Insider (form3/4/5)** — *all* writers (live manifest drain, rewash, legacy
+  manual ingest) funnel through exactly **two** once-per-accession chokepoints,
+  **zero bypass**: `upsert_filing` (`insider_transactions.py:1183`, form4/5) and
+  `upsert_form_3_filing` (`insider_form3_ingest.py:83`, form3). Each is called
+  once per accession (loops over child rows internally).
+- **def14a** — three per-accession writers, no shared chokepoint (the DELETE is
+  rewash-only; `_upsert_holding` is per-*row*): rewash `_apply_def14a`, live
+  `manifest_parsers/def14a.py:357` txn, legacy
+  `def14a_ingest.py:_ingest_single_accession` (still callable).
+- **blockholders** — two active per-accession writers: rewash
+  `_apply_blockholders`, live `manifest_parsers/sec_13dg.py:327` txn. **Legacy
+  retired** (`blockholders.py` docstring, #1233 PR11 — no active call site).
+
+So:
+
+**Insider → lock inside the two chokepoint functions** (`upsert_filing`,
+`upsert_form_3_filing`), as their first statement. This covers manifest +
+rewash + legacy automatically and is future-proof against new callers
+(prevention-log L401-402: the lock belongs inside the function, not at each
+call site). One line each.
+
+**def14a / blockholders → lock at each per-accession entry** (no chokepoint to
+hide it in; `_upsert_holding`/`_upsert_filing_row` are per-row so the DELETE
+would be unguarded):
+
+| Kind | Sites (lock = first statement, before any gate read / DELETE / upsert) |
+|---|---|
+| def14a | `_apply_def14a` (top, before the `def14a_within_cap` gate read); `manifest_parsers/def14a.py` (inside the `:357` txn, before the `_upsert_holding` loop); `def14a_ingest._ingest_single_accession` (legacy, before its write) |
+| blockholders | `_apply_blockholders` (top, before the `blockholders_within_retention` count-gate); `manifest_parsers/sec_13dg.py` (inside the `:327` txn, before the `_upsert_filer`/`_upsert_filing_row` loop) |
+
+**Count/gate reads must be inside the lock** (prevention-log L311): the
+`def14a_within_cap` and `blockholders_within_retention` decisions feed the
+DELETE, so the lock is acquired **before** those reads, not merely before the
+DELETE.
+
+Lock-order rule (deadlock safety): **per-accession lock FIRST**, then any
+per-instrument refresh lock (`refresh_insiders_current` /
+`refresh_def14a_current` etc.), matching the 13F comment at
+`sec_13f_hr.py:~483`. Every path holds exactly **one** accession lock at a time
+(one accession per txn — census-confirmed for all three writer classes), so the
+accession locks alone can never form a wait-cycle; layering the per-instrument
+locks under a uniform "accession-then-instrument" order keeps the combined graph
+acyclic.
+
+### 2a. Manifest-worker batch-hold (Codex ckpt-2 — known, accepted, ticketed)
+
+`sec_manifest_worker_tick` opens `connect_job()` (default `autocommit=False`)
+and commits **once** after the whole batch (`scheduler.py:4843`); `_dispatch_rows`
+has no per-row commit. So each manifest parser's `with conn.transaction()` is a
+**savepoint**, and a `pg_advisory_xact_lock` acquired inside it is held until the
+**batch** commits — not per accession.
+
+This is accepted for #817 because:
+
+1. **It is exactly the #1542 precedent.** The 13F lock at `sec_13f_hr.py:~483`
+   sits inside the same worker's savepoint with the same batch-hold; so do all
+   the per-instrument `refresh_*_current` xact locks. #817 extends an
+   already-shipped, reviewed pattern — it does not invent a new hazard.
+2. **Correctness is preserved.** The lock still gives mutual exclusion: a
+   concurrent rewash and the live drain cannot interleave writes to one
+   accession. The only costs are *coarseness* (the live path holds the lock
+   batch-long, so a concurrent `scripts/rewash.py` blocks longer) and a
+   *self-healing deadlock* surface (rewash-vs-live on shared accession/instrument
+   keys → Postgres detects + aborts one side → retry, **no data corruption** —
+   the lock converts a silent write-race into a loud, retryable serialisation).
+3. **The realistic contention is rare.** The manifest worker is a per-process
+   singleton (one tick at a time), and `run_rewash` is a manual CLI; the operator
+   runbook drives re-ingest via `sec_rebuild` (the live worker), not concurrent
+   `scripts/rewash.py`.
+
+The root-cause fix (per-accession commit in `_dispatch_rows`, which would release
+every per-accession lock at its natural boundary and also fix #1542 + the
+refresh-lock accumulation) is **out of scope** — it changes the transaction
+granularity of a hot, #1591/#1274-tuned path and needs its own dev-verify.
+Tracked in **#1735**. Rejected alternative: session-scoped locks with explicit
+per-accession release — fragile release on aborted txns, session/xact mixing,
+and would force moving the insider lock off its shared chokepoint.
+
+### 3. Bulk-ingest path excluded — by table-surface, not "bootstrap-only"
+
+The bulk / bootstrap orchestrators do **not** write any of the six guarded typed
+tables at all (census: `grep 'INSERT INTO insider_*|def14a_*|blockholder_*'`
+over `sec_bulk_orchestrator*`, `bootstrap_*` → zero hits). Bulk writes only
+`ownership_observations` / `_current` rollups, which are serialised on their own
+per-instrument refresh locks. So bulk is not a writer of the guarded surface and
+needs no accession lock — and adding one to a **batched** bulk transaction (many
+accessions per txn) would have risked the #1274-class multi-lock ordering
+deadlock. (The earlier "structurally unable to overlap because clean-bootstrap
+gated" rationale is *not* relied upon — bulk jobs are callable outside a running
+bootstrap when cached archives exist; the sound reason is the empty table
+surface.)
+
+### 4. Cohort scan stays a plain SELECT
+
+`_fetch_cohort` does not need `FOR UPDATE SKIP LOCKED`. It reads only
+`(accession, fetched_at)` identifiers (no body, no typed rows), and a row that
+vanishes/changes between scan and apply is already handled (driver
+`rewash_filings.py:178`, "row vanished between cohort scan and read → skipped").
+The serialisation that matters is at the **write**, which the per-accession lock
+provides. Adding row claims to the scan would be the misleading-isolation
+anti-pattern (L410) — it would not protect the typed-table write the cohort scan
+doesn't touch. Run-level single-instance locking (ticket Option C) is likewise
+rejected: it would close rewash-vs-rewash only, leaving the named rewash-vs-live
+race open and the codebase inconsistent with the 13F per-accession choice.
+
+## Full-population verification (dev DB, 2026-06-26)
+
+Registered rewash kinds (`grep document_kind= rewash_filings.py`): `form4_xml`,
+`form3_xml`, `form5_xml`, **`def14a_body`** (def14a), **`primary_doc_13dg`**
+(blockholders), `infotable_13f` (already #1542-locked, separate namespace).
+
+1. **Cohort population** (`filing_raw_documents` rows per kind) — all non-empty,
+   so the lock guards real accessions:
+
+   | kind | rows |
+   |---|---|
+   | form4_xml | 465,464 |
+   | form3_xml | 62,310 |
+   | def14a_body | 42,147 |
+   | primary_doc_13dg | 30,206 |
+   | infotable_13f | 18,325 |
+   | form5_xml | 1,586 |
+
+2. **Single-namespace safety (the assumption that was falsified, then bounded).**
+   `SELECT accession_number ... HAVING count(DISTINCT document_kind) > 1`
+   returned **18,325 accessions spanning >1 kind** — NOT zero. Drill-down: the
+   collisions are **entirely `infotable_13f + primary_doc`** (the 13F cover doc
+   + infotable of the *same* 13F filing). Both are outside the new namespace's
+   five kinds, and `infotable_13f` is on the *separate* `ingest_13f_accession`
+   namespace. Re-run scoped to the five locked kinds
+   (`form3_xml/form4_xml/form5_xml/def14a_body/primary_doc_13dg`):
+   **0 shared accessions.** ⇒ the single `ingest_filing_accession` namespace has
+   **no false-sharing** among the kinds it covers. (Premise note: a naive "one
+   accession ⇒ one kind" claim is false in general — 13F filings carry two
+   kinds — but it holds for the locked set, which is what the namespace needs.)
+
+## Tests
+
+- **Pure-logic**: table-test `acquire_filing_accession_write_lock`'s key
+  derivation is deterministic and (for the sampled accessions) differs from the
+  13F namespace's key for the same accession. This is a *negligible-collision*
+  check matching #1542's own 64-bit `hashtextextended` XOR scheme — NOT a proof
+  of formal disjointness (two distinct 64-bit keyspaces can theoretically
+  alias; the risk is the same advisory-key birthday risk the codebase already
+  accepts everywhere). Assert the SQL text + params shape (no DB needed).
+- **Structural-invariant test (preferred over a flaky interleave)**: a grep/AST
+  guard asserting every `_apply_*` in `rewash_filings.py` and every live
+  ownership manifest-drain write acquires `acquire_filing_accession_write_lock`
+  (or, for 13F, `acquire_13f_accession_write_lock`) before its first typed-table
+  mutation. This is the L337-338 "every writer takes the same lock" check made
+  executable, and it won't rot silently when a sixth kind lands.
+- **One DB-tier interleave** (`-m db`, sparingly): two connections, A holds the
+  lock for accession X inside a txn; B's `acquire_filing_accession_write_lock(X)`
+  blocks until A commits (use `pg_try_advisory_xact_lock` probe or a short
+  `statement_timeout` to assert B is blocked, then released). Proves the lock
+  actually serialises — not a defensive SELECT.
+
+## Tradeoffs
+
+- Two lock namespaces (13F legacy + the new general one) rather than unifying —
+  chosen to avoid churning the proven #1542 13F call sites and risking a
+  key-mismatch regression. The new namespace covers form3/4/5/def14a_body/
+  primary_doc_13dg (0 shared accessions among them, full-pop verified); 13F
+  keeps its own. Cross-namespace aliasing risk is the ordinary 64-bit
+  advisory-key birthday risk #1542 already accepts.
+- form4/form5 get the lock despite being benign-idempotent — for uniformity
+  across the insider family and cheap future-proofing (one line each, same drain
+  function), not because they currently lose data.
+- Bulk excluded by structural invariant, not by a lock — documented at the call
+  sites so a future maintainer who makes bulk concurrent knows to revisit.
+
+## DoD / dev-verify (ETL clauses 8-12)
+
+Output is **unchanged** (this is pure serialisation — same parse, same rows),
+so **no `sec_rebuild` and no parser-version bump**. Dev-verify:
+
+- Run `scripts/rewash.py --kind form3_xml --dry-run` then a real small-scope
+  rewash on dev; confirm parity (same typed rows before/after) and that the lock
+  acquires/releases (no wedge). Roll back any state touched so dev DB is clean.
+- Interleave proof: open two psql sessions, both `pg_advisory_xact_lock` the
+  same key — confirm the second blocks until the first commits.
+- Smoke the panel (AAPL/GME/MSFT/JPM/HD) `/instruments/<symbol>/ownership-rollup`
+  renders unchanged.

--- a/scripts/rewash.py
+++ b/scripts/rewash.py
@@ -26,8 +26,23 @@ from datetime import date
 import psycopg
 
 from app.config import settings
+
+# Pre-import the manifest_parsers package BEFORE rewash_filings so
+# ``app.services.insider_transactions`` finishes initialising before any
+# rewash apply-fn's lazy ``from app.services.insider_transactions import ...``
+# runs. Without this, a real (non-dry-run) rewash crashes on the first insider
+# accession with a partially-initialised ``ParsedForm3`` ImportError: the chain
+# insider_transactions -> manifest_parsers._classify -> insider_345 ->
+# insider_form3_ingest -> insider_transactions re-enters mid-init. The app/test
+# entrypoints import manifest_parsers first by side effect; this CLI did not.
+# Recurring trap — see review-prevention-log + memory (#1731). isort must NOT
+# reorder this block (the ordering is the fix).
+# isort: off
+import app.services.manifest_parsers  # noqa: F401 — side-effect import, must precede rewash_filings
 from app.services.raw_filings import DocumentKind
 from app.services.rewash_filings import registered_specs, run_rewash
+
+# isort: on
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:

--- a/tests/services/test_filing_accession_lock.py
+++ b/tests/services/test_filing_accession_lock.py
@@ -1,0 +1,110 @@
+"""The generalised per-accession ownership write lock (#817).
+
+Mirrors the 13F helper (#1542) for the other ownership kinds — same
+``hashtextextended`` XOR scheme, its own namespace so the lock key is
+distinct from the 13F key space for the same accession string.
+"""
+
+from unittest.mock import MagicMock
+
+import psycopg
+
+from app.services.institutional_holdings import acquire_13f_accession_write_lock
+from app.services.raw_filings import acquire_filing_accession_write_lock
+from tests.fixtures.ebull_test_db import test_database_url
+
+_PROBE_SQL = (
+    "SELECT pg_try_advisory_xact_lock((hashtextextended('ingest_filing_accession', 0) # hashtextextended(%s, 0)))"
+)
+
+
+def test_helper_issues_xact_lock_with_accession_keyed_hash():
+    conn = MagicMock()
+    acquire_filing_accession_write_lock(conn, "0001234567-25-000001")
+    assert conn.execute.call_count == 1
+    sql, params = conn.execute.call_args.args
+    # transaction-scoped advisory lock (auto-released on commit/rollback)
+    assert "pg_advisory_xact_lock" in sql
+    # own namespace, accession-keyed via hashtextextended XOR — every writer
+    # of these kinds must issue the identical key (prevention-log L337-338)
+    assert "hashtextextended('ingest_filing_accession', 0)" in sql
+    assert "hashtextextended(%s, 0)" in sql
+    assert params == ("0001234567-25-000001",)
+
+
+def test_namespace_is_distinct_from_13f_lock():
+    """The new namespace string differs from the 13F one, so the two lock
+    keys for the same accession do not (modulo 64-bit birthday risk) alias —
+    13F filings keep their own #1542 serialisation domain."""
+    conn_a, conn_b = MagicMock(), MagicMock()
+    acquire_filing_accession_write_lock(conn_a, "0001234567-25-000001")
+    acquire_13f_accession_write_lock(conn_b, "0001234567-25-000001")
+    sql_new = conn_a.execute.call_args.args[0]
+    sql_13f = conn_b.execute.call_args.args[0]
+    assert "ingest_filing_accession" in sql_new
+    assert "ingest_13f_accession" in sql_13f
+    assert "ingest_filing_accession" not in sql_13f
+
+
+def test_every_guarded_ownership_writer_acquires_the_lock():
+    """Structural census guard (#817): an advisory lock only protects callers
+    that take it, so EVERY once-per-accession writer of the guarded ownership
+    typed tables must acquire ``acquire_filing_accession_write_lock`` (or, for
+    13F, the #1542 helper). Pins prevention-log "Advisory lock scope vs
+    concurrent writers" so a sixth kind / a new caller can't silently bypass it.
+    """
+    import inspect
+
+    from app.services import def14a_ingest, insider_form3_ingest, insider_transactions, rewash_filings
+    from app.services.manifest_parsers import def14a as mp_def14a
+    from app.services.manifest_parsers import sec_13dg as mp_13dg
+
+    # (function, required-lock-token). All non-13F writers share the new helper;
+    # the 13F rewash apply keeps its #1542 lock.
+    guarded = [
+        # insider form4/5 + form3 chokepoints (cover manifest+rewash+legacy)
+        (insider_transactions.upsert_filing, "acquire_filing_accession_write_lock"),
+        (insider_form3_ingest.upsert_form_3_filing, "acquire_filing_accession_write_lock"),
+        # def14a: rewash, live manifest, legacy
+        (rewash_filings._apply_def14a, "acquire_filing_accession_write_lock"),
+        (mp_def14a._parse_def14a, "acquire_filing_accession_write_lock"),
+        (def14a_ingest._ingest_single_accession, "acquire_filing_accession_write_lock"),
+        # blockholders: rewash, live manifest
+        (rewash_filings._apply_blockholders, "acquire_filing_accession_write_lock"),
+        (mp_13dg._parse_13dg, "acquire_filing_accession_write_lock"),
+        # 13F (#1542) — regression guard that its symmetric lock survives
+        (rewash_filings._apply_13f_infotable, "acquire_13f_accession_write_lock"),
+    ]
+    missing = [fn.__qualname__ for fn, token in guarded if token not in inspect.getsource(fn)]
+    assert not missing, f"writers missing per-accession write lock: {missing}"
+
+
+def test_lock_actually_serialises_two_sessions():
+    """DB-tier interleave: while one session holds the per-accession lock, a
+    second session's ``pg_try_advisory_xact_lock`` on the SAME key fails;
+    once the holder commits, the key is acquirable. Proves real serialisation
+    (not a defensive SELECT) — prevention-log "process lock != DB isolation".
+    """
+    accn = "0001234567-25-000777"
+    test_url = test_database_url()
+
+    holder = psycopg.connect(test_url)
+    holder.autocommit = False
+    try:
+        acquire_filing_accession_write_lock(holder, accn)  # held until txn ends
+
+        with psycopg.connect(test_url) as other:
+            other.autocommit = False
+            row = other.execute(_PROBE_SQL, (accn,)).fetchone()
+            assert row is not None and row[0] is False, "second session acquired a held per-accession lock"
+            other.rollback()
+
+        holder.commit()  # release
+
+        with psycopg.connect(test_url) as other:
+            other.autocommit = False
+            row = other.execute(_PROBE_SQL, (accn,)).fetchone()
+            assert row is not None and row[0] is True, "lock not acquirable after holder committed"
+            other.rollback()
+    finally:
+        holder.close()


### PR DESCRIPTION
## What

Generalises the 13F per-accession advisory write lock (#1542) to the other four
ownership kinds (Form 3/4/5, DEF 14A, 13D/G blockholders) so concurrent writers
of one accession's typed rows are serialised. Closes #817.

New helper `raw_filings.acquire_filing_accession_write_lock(conn, accession)` — a
transaction-scoped `pg_advisory_xact_lock` on `hashtextextended('ingest_filing_accession',0) # hashtextextended(accession,0)`,
mirroring the #1542 13F helper with its own namespace.

Lock sites (every once-per-accession writer of the guarded typed tables takes
the same key — an advisory lock is cooperative):

- **Insider (form3/4/5)** — inside the two universal chokepoints
  `upsert_filing` (`insider_transactions.py`) and `upsert_form_3_filing`
  (`insider_form3_ingest.py`). The census proved live-manifest + rewash + legacy
  all funnel through these two functions with **zero bypass**, so locking inside
  them covers all three writer classes (prevention-log "lock acquisition belongs
  inside the function").
- **DEF 14A** — at all three per-accession entries: rewash `_apply_def14a`
  (before the `def14a_within_cap` gate read), live `manifest_parsers/def14a._parse_def14a`,
  legacy `def14a_ingest._ingest_single_accession` (after its fetch, before the
  write fan-out).
- **13D/G blockholders** — rewash `_apply_blockholders` (before the
  `blockholders_within_retention` count-gate) and live `manifest_parsers/sec_13dg._parse_13dg`.
  (Legacy blockholder ingest retired in #1233 PR11.)

Count/gate reads that feed a DELETE are inside the lock (prevention-log "SELECT
COUNT(*) race when gating a DELETE"). Lock order is uniform per-accession →
per-instrument, and each writer holds exactly one accession lock at a time
(one accession per txn) → no deadlock.

## Why

`run_rewash` (manual `scripts/rewash.py`) re-parses cohorts below the current
`parser_version` and re-applies typed writes with **no per-accession lock**
(only 13F had one, via #1542). After `POST /jobs/sec_rebuild/run` requeues a
parser-version cohort for the live worker (`sec_rebuild` preserves
`parser_version`), an operator-run rewash can target the same accession the live
worker is re-draining; #1274/#1591 also made the live drain concurrent. For the
DELETE+INSERT kinds (form3 child tables, def14a, blockholders — the latter two
with a count-gated DELETE) that interleave is a genuine lost-data window, not
merely duplicate work.

**Premise correction:** the ticket says "both upserts are idempotent ON CONFLICT
DO UPDATE — just duplicate work". Verified false for 3 of 5 kinds: form3 does
DELETE+INSERT on its child tables, def14a/blockholders do count-gated DELETE +
upsert. form4/form5 are genuinely idempotent (locked too, for uniformity).

## Source rule

Internal concurrency invariant — governed by our own settled pattern, not an SEC
reg: #1542's `acquire_13f_accession_write_lock`, and prevention-log entries
"Advisory lock scope vs concurrent writers" (every writer takes the same lock),
"lock acquisition belongs inside the function", "process lock != DB isolation"
(use a real DB boundary keyed to the natural identity — `accession_number`), and
"SELECT COUNT(*) race when gating a DELETE".

## Full-population verification (dev DB, 2026-06-26)

- Cohort populations all non-empty: form4_xml 465,464 / form3_xml 62,310 /
  def14a_body 42,147 / primary_doc_13dg 30,206 / form5_xml 1,586.
- Single-namespace safety: a naive "one accession ⇒ one kind" is **false in
  general** (18,325 accessions span `infotable_13f`+`primary_doc` — the 13F
  cover+infotable, both on the separate 13F namespace). Re-scoped to the five
  kinds this lock covers: **0 shared accessions** → the `ingest_filing_accession`
  namespace has no false-sharing.

## Security model

No auth/authz surface. The lock is a Postgres advisory lock; it changes only
write-serialisation, not what data any caller may read or write. Files outside
the diff that write the guarded tables were enumerated (full writer census) and
all funnel through the locked functions; bulk/bootstrap writes **none** of the
six guarded typed tables (only observations/`_current` rollups), so it needs no
lock and was excluded by table-surface, not by a "bootstrap-only" assumption.

## Manifest-worker batch-hold (Codex ckpt-2, BLOCKING — resolved as documented + ticketed)

`sec_manifest_worker_tick` runs the whole tick under one `autocommit=False` txn
(commit at `scheduler.py:4843`); `_dispatch_rows` has no per-row commit. So a
parser's `with conn.transaction()` is a **savepoint**, and the xact lock acquired
inside it is held until the **batch** commits — not per accession. This is the
**same property #1542's 13F lock already has** (same worker, same savepoint), and
every `refresh_*_current` xact lock. It is **coarse but correct**: mutual
exclusion holds; the only costs are batch-long hold on the live path and a
*self-healing* deadlock surface (rewash-vs-live on shared keys → Postgres
aborts+retries one side → **no data corruption**). The manifest worker is a
per-process singleton and `run_rewash` is a manual CLI, so the contention is
rare. Root-cause fix (per-accession commit in the worker, which also fixes #1542
+ the refresh-lock accumulation) is out of scope and tracked in **#1735**.
Documented at every lock site + the helper docstring + the spec + a prevention-log
entry. Rejected alternative (session locks + manual release) — fragile on aborted
txns, session/xact mixing, forces moving the insider lock off its chokepoint.

## Tradeoffs

- Two lock namespaces (13F legacy + the new one) rather than unifying — avoids
  churning the proven #1542 call sites; cross-namespace aliasing is the ordinary
  64-bit advisory-key birthday risk #1542 already accepts.
- form4/form5 locked despite being idempotent-benign — uniformity + future-proofing.
- def14a/blockholders need the lock at each per-accession entry (no shared
  chokepoint to hide it in); insider gets the cleaner single-chokepoint placement.

## Tests

- `tests/services/test_filing_accession_lock.py`: pure key-derivation + namespace
  distinctness; a **structural census guard** asserting every guarded writer
  acquires the lock (executable "every writer takes the same lock"); a **DB-tier
  interleave** proving a held lock blocks a second session and releases on commit
  (real serialisation, not a defensive SELECT).

## Output parity / DoD

Pure serialisation — same parse, same rows, **no parser-version bump, no
`sec_rebuild`**. Dev-verify: `scripts/rewash.py` parity + two-session interleave
proof + ownership-rollup panel renders unchanged (recorded in follow-up comment).

Spec: `docs/specs/etl/2026-06-26-817-rewash-accession-write-lock.md`.

Closes #817. Refs #1542. Refs #1735.
