### PR TITLE
fix(#1735): per-accession commit in the manifest worker — release advisory locks at the row boundary

### DIFF
--- a/app/jobs/sec_manifest_worker.py
+++ b/app/jobs/sec_manifest_worker.py
@@ -628,6 +628,17 @@ def _dispatch_rows(
     #938 raw-payload audit invariant fires here (payload-backed
     parsers cannot transition ``parsed + raw_status='absent'``).
 
+    #1735 — commits PER ROW, not per batch. A ``conn.commit()`` before
+    the loop closes the row-selection read-tx (so each parser's
+    ``with conn.transaction()`` is top-level, not a savepoint nested in
+    the batch txn), and a ``conn.commit()`` after each row's terminal
+    ``transition_status`` releases that accession's per-accession
+    advisory xact lock (#817 / #1542) + per-instrument
+    ``refresh_*_current`` locks at the row boundary. Each accession is
+    independent (no cross-row dependency), so per-row commit is safe and
+    strictly more granular than the prior whole-tick commit at
+    ``app/workers/scheduler.py``.
+
     Returns a :class:`WorkerStats` summary; the caller has already
     decided WHICH rows to dispatch (fairness allocation or per-source
     rebuild).
@@ -639,6 +650,21 @@ def _dispatch_rows(
     raw_violations = 0
     skipped_by_source: dict[ManifestSource, int] = defaultdict(int)
     processed_by_source: dict[ManifestSource, int] = defaultdict(int)
+
+    # #1735: close the implicit read-transaction opened by the
+    # row-selection SELECTs (``iter_pending`` / ``iter_retryable`` /
+    # ``iter_pending_topup`` in ``run_manifest_worker``) and the
+    # ``_prefetch_then_dispatch`` savepoints, so the FIRST per-row
+    # ``transition_status``'s ``with conn.transaction()`` opens a
+    # TOP-LEVEL transaction (BEGIN), not a SAVEPOINT nested in the batch
+    # txn. Same ``conn.commit()`` + rationale as the stale-failed sweep
+    # (``app/services/sec_manifest.py``, PR #1132). Without it every
+    # per-row tx is a savepoint inside the one batch txn (committed at
+    # ``app/workers/scheduler.py`` ``sec_manifest_worker`` tick), so each
+    # accession's per-accession advisory xact lock (#817 / #1542) and
+    # per-instrument ``refresh_*_current`` locks are held until the batch
+    # commit instead of releasing at the accession's row boundary.
+    conn.commit()
 
     for row in rows:
         spec = _PARSERS.get(row.source)
@@ -659,83 +685,112 @@ def _dispatch_rows(
         # (which writes both ``failed += 1`` and ``raw_violations += 1``).
         processed_by_source[row.source] += 1
 
+        # #1735: per-row robustness mirrors the stale-failed sweep
+        # (``app/services/sec_manifest.py`` ``tombstone_stale_failed_upserts``).
+        # Each accession now commits at its row boundary, so an
+        # unexpected failure on ONE row (a deadlock victim aborted
+        # mid-transition, a commit-time DB error) rolls back only that
+        # row's uncommitted work and continues — the row keeps its prior
+        # status and re-drains next tick rather than aborting the whole
+        # tick (already-committed prior rows stay durable; pre-#1735 the
+        # raise rolled the whole batch back). The outer ``except`` logs
+        # with a full traceback — the illegal-transition signal the #879
+        # contract guards is NOT silently swallowed.
         try:
-            outcome = spec.fn(conn, row)
-        except Exception as exc:  # parser-internal failure — fail loudly
+            try:
+                outcome = spec.fn(conn, row)
+            except Exception as exc:  # parser-internal failure — fail loudly
+                logger.exception(
+                    "manifest worker: parser raised for source=%s accession=%s",
+                    row.source,
+                    row.accession_number,
+                )
+                transition_status(
+                    conn,
+                    row.accession_number,
+                    ingest_status="failed",
+                    error=f"{type(exc).__name__}: {exc}"[:500],
+                    next_retry_at=now + _backoff_for(0),
+                )
+                conn.commit()  # #1735: release this accession's locks at its row boundary
+                failed += 1
+                continue
+
+            # #938 audit invariant: payload-backed parsers cannot transition
+            # to ``parsed`` while the row's effective raw_status is
+            # ``absent``. Convert to a ``failed`` transition with a
+            # descriptive error so the row remains visible to the operator
+            # + retry path. Silent ``parsed + absent`` would leave an
+            # unauditable row in the manifest forever.
+            #
+            # Effective raw_status falls back to the row's existing value
+            # when the parser doesn't restamp (``outcome.raw_status is
+            # None``). This matches ``transition_status`` semantics — a
+            # ``parsed`` transition with ``raw_status=None`` preserves the
+            # row's existing column — so a rebuild/retry flow where raw
+            # evidence already exists on disk doesn't get misclassified
+            # as a violation. (Codex pre-push catch.)
+            effective_raw_status = outcome.raw_status or row.raw_status
+            if (
+                outcome.status == "parsed"
+                and spec.requires_raw_payload
+                and effective_raw_status not in ("stored", "compacted")
+            ):
+                logger.error(
+                    "manifest worker: source=%s accession=%s parser returned parsed but "
+                    "effective raw_status=%r — payload-backed parsers must persist evidence; "
+                    "transitioning to failed for retry",
+                    row.source,
+                    row.accession_number,
+                    effective_raw_status,
+                )
+                transition_status(
+                    conn,
+                    row.accession_number,
+                    ingest_status="failed",
+                    error=(
+                        "raw payload missing: parser returned parsed without storing "
+                        f"the upstream body (effective raw_status={effective_raw_status!r}). "
+                        "Payload-backed parsers must persist evidence (#938)."
+                    ),
+                    next_retry_at=now + _backoff_for(0),
+                )
+                conn.commit()  # #1735
+                failed += 1
+                raw_violations += 1
+                continue
+
+            target_status: IngestStatus = outcome.status
+            transition_status(
+                conn,
+                row.accession_number,
+                ingest_status=target_status,
+                parser_version=outcome.parser_version,
+                raw_status=outcome.raw_status,
+                error=outcome.error,
+                next_retry_at=outcome.next_retry_at if outcome.status == "failed" else None,
+            )
+            conn.commit()  # #1735
+            if outcome.status == "parsed":
+                parsed += 1
+            elif outcome.status == "tombstoned":
+                tombstoned += 1
+            else:
+                failed += 1
+        except Exception:  # noqa: BLE001 — a per-row failure must not abort the tick
+            # Reached only when ``transition_status`` / ``conn.commit()``
+            # itself raised (illegal state transition, deadlock victim
+            # aborted at the ``FOR UPDATE``, commit-time DB error). Roll
+            # back the aborted txn so the next row runs on a clean
+            # connection; the row keeps its prior status and re-drains.
+            # Logged with full traceback — NOT silent.
             logger.exception(
-                "manifest worker: parser raised for source=%s accession=%s",
+                "manifest worker: row dispatch failed; rolling back and continuing (source=%s accession=%s)",
                 row.source,
                 row.accession_number,
             )
-            transition_status(
-                conn,
-                row.accession_number,
-                ingest_status="failed",
-                error=f"{type(exc).__name__}: {exc}"[:500],
-                next_retry_at=now + _backoff_for(0),
-            )
-            failed += 1
+            conn.rollback()
             continue
-
-        # #938 audit invariant: payload-backed parsers cannot transition
-        # to ``parsed`` while the row's effective raw_status is
-        # ``absent``. Convert to a ``failed`` transition with a
-        # descriptive error so the row remains visible to the operator
-        # + retry path. Silent ``parsed + absent`` would leave an
-        # unauditable row in the manifest forever.
-        #
-        # Effective raw_status falls back to the row's existing value
-        # when the parser doesn't restamp (``outcome.raw_status is
-        # None``). This matches ``transition_status`` semantics — a
-        # ``parsed`` transition with ``raw_status=None`` preserves the
-        # row's existing column — so a rebuild/retry flow where raw
-        # evidence already exists on disk doesn't get misclassified
-        # as a violation. (Codex pre-push catch.)
-        effective_raw_status = outcome.raw_status or row.raw_status
-        if (
-            outcome.status == "parsed"
-            and spec.requires_raw_payload
-            and effective_raw_status not in ("stored", "compacted")
-        ):
-            logger.error(
-                "manifest worker: source=%s accession=%s parser returned parsed but "
-                "effective raw_status=%r — payload-backed parsers must persist evidence; "
-                "transitioning to failed for retry",
-                row.source,
-                row.accession_number,
-                effective_raw_status,
-            )
-            transition_status(
-                conn,
-                row.accession_number,
-                ingest_status="failed",
-                error=(
-                    "raw payload missing: parser returned parsed without storing "
-                    f"the upstream body (effective raw_status={effective_raw_status!r}). "
-                    "Payload-backed parsers must persist evidence (#938)."
-                ),
-                next_retry_at=now + _backoff_for(0),
-            )
-            failed += 1
-            raw_violations += 1
-            continue
-
-        target_status: IngestStatus = outcome.status
-        transition_status(
-            conn,
-            row.accession_number,
-            ingest_status=target_status,
-            parser_version=outcome.parser_version,
-            raw_status=outcome.raw_status,
-            error=outcome.error,
-            next_retry_at=outcome.next_retry_at if outcome.status == "failed" else None,
-        )
-        if outcome.status == "parsed":
-            parsed += 1
-        elif outcome.status == "tombstoned":
-            tombstoned += 1
-        else:
-            failed += 1
 
     # #940: surface no-parser drops at WARNING level with per-source
     # breakdown. Per-row debug logs above let operators dig in if

--- a/app/services/insider_transactions.py
+++ b/app/services/insider_transactions.py
@@ -1234,10 +1234,10 @@ def upsert_filing(
     # #817 — the single once-per-accession chokepoint for Form 4/5 typed-table
     # writes (live manifest drain, rewash, legacy ingest all funnel here).
     # Serialise concurrent writers of this accession's rows before the first
-    # mutation (no SEC fetch happens in this function — safe to hold). Rewash +
-    # legacy commit per accession (xact lock auto-releases there); on the
-    # manifest-worker path the surrounding batch txn holds it until batch commit
-    # (#1735, same property as the #1542 13F lock) — coarse but correct.
+    # mutation (no SEC fetch happens in this function — safe to hold). Every
+    # caller commits per accession now: rewash + legacy commit per accession, and
+    # the manifest worker commits per row (#1735, ``_dispatch_rows``), so the xact
+    # lock auto-releases at each accession's row boundary on all paths.
     raw_filings.acquire_filing_accession_write_lock(conn, accession_number)
 
     with conn.cursor() as cur:

--- a/app/services/manifest_parsers/def14a.py
+++ b/app/services/manifest_parsers/def14a.py
@@ -363,13 +363,12 @@ def _parse_def14a(
             # writes against a concurrent rewash DELETE+INSERT (same lock key).
             # First statement in the txn, after the body fetch above (no SEC
             # fetch inside this block).
-            # NB: this ``with conn.transaction()`` is a SAVEPOINT (the manifest
-            # worker runs the whole batch under one autocommit=False txn, commit
-            # at scheduler.py:4843), so this xact lock is held until BATCH commit,
-            # not per accession — the same coarse-but-correct property the #1542
-            # 13F lock has. Mutual exclusion is preserved; a rare rewash-vs-live
-            # deadlock self-heals (Postgres aborts+retries, no corruption).
-            # Root-cause (per-accession commit) tracked in #1735.
+            # #1735: the manifest worker now commits per row (``_dispatch_rows``
+            # commits the implicit read-tx before the loop), so this
+            # ``with conn.transaction()`` is a TOP-LEVEL txn and this xact lock
+            # releases at the accession's row boundary, same as the rewash +
+            # legacy per-accession callers. Mutual exclusion preserved; the
+            # pre-#1735 batch-txn rewash-vs-live deadlock no longer arises.
             acquire_filing_accession_write_lock(conn, accession)
             siblings = _resolve_siblings(conn, instrument_id=instrument_id, issuer_cik=issuer_cik)
             for sibling_iid in siblings:

--- a/app/services/manifest_parsers/sec_13dg.py
+++ b/app/services/manifest_parsers/sec_13dg.py
@@ -333,11 +333,11 @@ def _parse_13dg(
             # against a concurrent rewash DELETE+INSERT (same lock key). First
             # statement in the txn, after the stored-body read above (no SEC
             # fetch inside this block).
-            # NB: SAVEPOINT, not a top-level txn (the manifest worker batches the
-            # whole tick under one autocommit=False txn) → this xact lock is held
-            # until BATCH commit, matching the #1542 13F lock. Correct mutual
-            # exclusion; rare rewash-vs-live deadlock self-heals. Root-cause
-            # (per-accession commit) tracked in #1735.
+            # #1735: the manifest worker now commits per row, so this
+            # ``with conn.transaction()`` is a TOP-LEVEL txn and the xact lock
+            # releases at the accession's row boundary (same as the rewash +
+            # legacy per-accession callers). Mutual exclusion preserved; the
+            # pre-#1735 batch-txn rewash-vs-live deadlock no longer arises.
             acquire_filing_accession_write_lock(conn, accession)
             # Resolve the subject company to an instrument (#1628). CUSIP
             # is the security-precise key (disambiguates share-class

--- a/app/services/raw_filings.py
+++ b/app/services/raw_filings.py
@@ -183,16 +183,16 @@ def acquire_filing_accession_write_lock(conn: psycopg.Connection[Any], accession
     across network I/O), and BEFORE any count/gate read that feeds a DELETE and
     BEFORE any per-instrument refresh lock (per-accession then per-instrument).
 
-    Release granularity follows the CALLER's commit boundary. Rewash + legacy
-    commit per accession, so the lock releases per accession there. The live
-    manifest worker batches the whole tick under one ``autocommit=False`` txn
-    (commit at ``scheduler.py``), so a ``with conn.transaction()`` inside a
-    parser is a SAVEPOINT and this lock is absorbed by the batch txn and held
-    until BATCH commit — the same coarse-but-correct property the #1542 13F lock
-    has. Mutual exclusion still holds; the uniform-order acyclic argument holds
-    strictly only for the per-accession-commit callers — under the batch txn a
-    rare rewash-vs-live overlap can deadlock and Postgres aborts+retries one side
-    (no corruption). Root-cause (per-accession commit in the worker) → #1735.
+    Release granularity follows the CALLER's commit boundary, and ALL callers
+    now commit per accession: rewash + legacy commit per accession, and the live
+    manifest worker commits per row in ``_dispatch_rows`` (#1735) — it commits the
+    implicit read-tx before the dispatch loop so each parser's
+    ``with conn.transaction()`` is a TOP-LEVEL txn, then commits after each row's
+    terminal ``transition_status``. So this lock releases at each accession's row
+    boundary on every path. Mutual exclusion holds and the uniform-order acyclic
+    argument (per-accession lock then per-instrument refresh lock, one accession
+    in flight at a time) holds for all callers, so the pre-#1735 rare
+    rewash-vs-live batch-txn deadlock no longer arises.
 
     Own namespace (``ingest_filing_accession``) — distinct from the 13F helper's
     ``ingest_13f_accession``; 13F filings carry their own kinds and keep their

--- a/tests/test_manifest_worker_dispatch_commit.py
+++ b/tests/test_manifest_worker_dispatch_commit.py
@@ -1,0 +1,183 @@
+"""Pure-logic tests for the #1735 per-row commit contract in ``_dispatch_rows``.
+
+No DB: a counting fake connection + monkeypatched ``transition_status`` let us
+assert the commit/rollback cadence directly. The state-machine semantics of
+``transition_status`` itself (the ``parsed -> parsed`` / ``tombstoned ->
+tombstoned`` no-ops + the illegal-transition raise) are covered separately in
+``tests/test_sec_manifest.py``; here we only pin that ``_dispatch_rows`` commits
+once before the loop + once per dispatched row, and that a row-level failure
+rolls back and continues instead of aborting the tick.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+import app.jobs.sec_manifest_worker as worker
+from app.jobs.sec_manifest_worker import (
+    ParseOutcome,
+    _dispatch_rows,
+    clear_registered_parsers,
+    register_parser,
+)
+from app.services.sec_manifest import ManifestRow
+
+_NOW = datetime(2026, 6, 26, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> Any:
+    """Clear the module-global parser registry before each test and RESTORE the
+    real registry after, so fake registrations can't leak into an xdist-colocated
+    test (mirrors ``test_manifest_worker_prefetch``)."""
+    clear_registered_parsers()
+    yield
+    clear_registered_parsers()
+    from app.services.manifest_parsers import register_all_parsers
+
+    register_all_parsers()
+
+
+class _CountingConn:
+    """Minimal stand-in for ``psycopg.Connection`` — counts commit/rollback.
+
+    ``_dispatch_rows`` only touches ``commit`` / ``rollback`` directly (the
+    parser fakes ignore the conn and ``transition_status`` is monkeypatched), so
+    nothing else is needed."""
+
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def _row(accession: str, *, source: str = "sec_form4", raw_status: str = "stored") -> ManifestRow:
+    return ManifestRow(
+        accession_number=accession,
+        cik="0000000001",
+        form="4",
+        source=source,  # type: ignore[arg-type]
+        subject_type="issuer",
+        subject_id="1",
+        instrument_id=1,
+        filed_at=datetime(2026, 1, 1, tzinfo=UTC),
+        accepted_at=None,
+        primary_document_url=None,
+        is_amendment=False,
+        amends_accession=None,
+        ingest_status="pending",
+        parser_version=None,
+        raw_status=raw_status,  # type: ignore[arg-type]
+        last_attempted_at=None,
+        next_retry_at=None,
+        error=None,
+    )
+
+
+def _stub_transition(monkeypatch: pytest.MonkeyPatch, fn: Any) -> None:
+    """Replace the module-level ``transition_status`` reference the worker
+    imported (``app/jobs/sec_manifest_worker.py``) so no DB is touched."""
+    monkeypatch.setattr(worker, "transition_status", fn)
+
+
+def test_commits_once_before_loop_plus_once_per_dispatched_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    register_parser("sec_form4", lambda _c, _r: ParseOutcome(status="parsed", raw_status="stored"))
+    _stub_transition(monkeypatch, lambda *_a, **_k: None)
+    conn = _CountingConn()
+    rows = [_row(f"0000000001-26-00000{i}") for i in range(1, 4)]
+
+    stats = _dispatch_rows(conn, rows, now=_NOW)  # type: ignore[arg-type]
+
+    # 1 pre-loop read-tx close + 1 per dispatched row.
+    assert conn.commits == 1 + len(rows)
+    assert conn.rollbacks == 0
+    assert stats.parsed == 3
+
+
+def test_skipped_rows_do_not_commit(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No parser registered for the row's source → skipped before any transition.
+    _stub_transition(monkeypatch, lambda *_a, **_k: None)
+    conn = _CountingConn()
+    rows = [_row("0000000001-26-000001", source="sec_form4")]
+
+    stats = _dispatch_rows(conn, rows, now=_NOW)  # type: ignore[arg-type]
+
+    # Only the pre-loop commit fires; a skipped row takes no lock, commits nothing.
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+    assert stats.skipped_no_parser == 1
+
+
+def test_parser_exception_commits_the_failed_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(_c: Any, _r: ManifestRow) -> ParseOutcome:
+        raise RuntimeError("parser blew up")
+
+    register_parser("sec_form4", _boom)
+    _stub_transition(monkeypatch, lambda *_a, **_k: None)
+    conn = _CountingConn()
+    rows = [_row("0000000001-26-000001")]
+
+    stats = _dispatch_rows(conn, rows, now=_NOW)  # type: ignore[arg-type]
+
+    # pre-loop + the failed-transition commit (so the row's locks release at its
+    # boundary even on the failure path).
+    assert conn.commits == 1 + 1
+    assert conn.rollbacks == 0
+    assert stats.failed == 1
+
+
+def test_raw_payload_violation_commits_the_failed_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Payload-backed parser returns parsed but raw_status='absent' → #938 turns
+    # it into a failed transition, which must still commit per-row (#1735).
+    register_parser(
+        "sec_form4",
+        lambda _c, _r: ParseOutcome(status="parsed", raw_status="absent"),
+        requires_raw_payload=True,
+    )
+    _stub_transition(monkeypatch, lambda *_a, **_k: None)
+    conn = _CountingConn()
+    rows = [_row("0000000001-26-000001", raw_status="absent")]
+
+    stats = _dispatch_rows(conn, rows, now=_NOW)  # type: ignore[arg-type]
+
+    assert conn.commits == 1 + 1
+    assert stats.failed == 1
+    assert stats.raw_payload_violations == 1
+
+
+def test_transition_failure_rolls_back_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A transition raising on ONE row (e.g. illegal transition / deadlock victim)
+    # must roll back only that row and continue the tick, not abort it.
+    poison = "0000000001-26-000002"
+
+    def _transition(_conn: Any, accession: str, **_k: Any) -> None:
+        if accession == poison:
+            raise ValueError("illegal transition")
+
+    register_parser("sec_form4", lambda _c, _r: ParseOutcome(status="parsed", raw_status="stored"))
+    _stub_transition(monkeypatch, _transition)
+    conn = _CountingConn()
+    rows = [_row(f"0000000001-26-00000{i}") for i in range(1, 4)]
+
+    stats = _dispatch_rows(conn, rows, now=_NOW)  # type: ignore[arg-type]
+
+    # rows 1 + 3 commit (pre-loop + 2); row 2 rolls back; tick completes.
+    assert conn.commits == 1 + 2
+    assert conn.rollbacks == 1
+    assert stats.parsed == 2


### PR DESCRIPTION
## What

`app/jobs/sec_manifest_worker.py::_dispatch_rows` now commits **per row** instead of once per batch.

## Why

The worker drained the whole tick under one `autocommit=False` transaction (commit at `app/workers/scheduler.py`, the `sec_manifest_worker` tick). The row-selection `SELECT`s (`iter_pending` / `iter_retryable` / `iter_pending_topup`) opened an implicit read-tx, so each parser's `with conn.transaction()` degraded to a **SAVEPOINT** nested in the batch txn. `pg_advisory_xact_lock` releases only on the **top-level COMMIT** — so the #817 per-accession write lock (and the #1542 13F lock, and per-instrument `refresh_*_current` locks) were held until the batch commit. All ~200 accessions' locks accumulated for the whole tick (the coarse-but-correct property #817/#1542 inherited; the rare rewash-vs-live deadlock the docstrings warned about). #817 filed this as the root-cause follow-up.

## Fix

Mirrors the in-repo precedent — the stale-failed sweep `app/services/sec_manifest.py::tombstone_stale_failed_upserts` (PR #1132):

1. `conn.commit()` **before** the dispatch loop → closes the implicit read-tx so the first parser's `with conn.transaction()` opens a **TOP-LEVEL** tx (BEGIN), not a savepoint.
2. `conn.commit()` **after each row's terminal `transition_status`** → that accession's advisory xact lock + per-instrument refresh locks release at its row boundary.
3. Per-row `try/except`: an unexpected failure (deadlock victim aborted at `FOR UPDATE`, commit-time DB error) rolls back only that row and continues — the row keeps its prior status and re-drains next tick instead of aborting the whole tick. Logged with a full traceback, so the #879 illegal-transition signal is **not** silently swallowed.

Each accession is independent (no cross-row dependency), so per-row commit is safe and strictly more granular than the prior whole-tick commit. **Output-identical** — a pure commit-boundary/serialization change, no change to what rows or typed-table data are written.

Drops the now-stale "held until BATCH commit / coarse-but-correct / rare deadlock self-heals" caveat from the four lock docstrings (`raw_filings.acquire_filing_accession_write_lock`, `manifest_parsers/def14a.py`, `manifest_parsers/sec_13dg.py`, `insider_transactions.upsert_filing`). The 13F helper `institutional_holdings.acquire_13f_accession_write_lock` had no such caveat (verified) — left unchanged.

## Concurrency / safety model

- **Mutual exclusion preserved.** Every writer of a guarded accession (live drain, rewash, legacy ingest, sibling fan-out) still funnels through the same `acquire_filing_accession_write_lock` with the identical key; the lock still serialises them. The change only makes the live-drain path release the lock *sooner* (per row), matching what rewash + legacy already did.
- **Deadlock eliminated for the live path.** With at most one accession's locks held at a time, in a fixed order (per-accession lock → per-instrument refresh lock), the uniform-order acyclic argument now holds for the live drain too — the pre-#1735 batch-txn rewash-vs-live deadlock window no longer arises.
- **psycopg3 semantics** (verified against installed `psycopg` 3 source + Codex): `commit()` raises only if called *inside* a `conn.transaction()` block (`_num_transactions > 0`); all commits here run after `transition_status` returns (depth 0). `commit()` no-ops cleanly when the connection is already IDLE. No caller wraps `run_manifest_worker`/`_dispatch_rows` in `conn.transaction()`.
- **Crash durability** is strictly improved: a mid-tick crash now keeps already-processed rows committed (was: whole-batch rollback).

## Tradeoffs

- Whole-tick atomicity is intentionally dropped. No consumer relied on it (no cross-row dependency); per-row commit is the correct granularity for independent accessions.

## Verification (DoD clauses 8–12)

- **Pure-logic test** `tests/test_manifest_worker_dispatch_commit.py` (no DB): commit count == rows + 1 (pre-loop + per row); parser-exception still commits its failed transition; raw-payload-violation still commits; a transition raising on one row rolls back + continues (other rows commit, tick completes). **5/5.**
- **Gates:** ruff check + format + pyright clean; fast tier **4487 passed**; smoke **129 passed**.
- **DB-backed integration (real Postgres):** manifest-worker `tests/test_sec_manifest_worker.py` **37 passed**; parser integration insider/def14a/13dg **50 passed** (proves output parity end-to-end through the lock + per-row commit).
- **Deterministic dev-DB lock-release proof** (two real connections + the real `acquire_filing_accession_write_lock`): a 2nd writer of the same accession is **blocked while the worker's tx is open**, and **acquires immediately after the per-row `conn.commit()`** — directly proving the lock releases at the row boundary. (Replaces the "watch `pg_locks` during a `sec_rebuild`" check from the assessment, which would be meaningless here: the dev jobs daemon runs pre-#1735 code, so a live rebuild would be drained by the old path. The 2-connection proof is timing-independent and tests *this* code.)
- **Operator-visible figure (clause 11):** `/instruments/{AAPL,GME,MSFT,JPM,HD}/ownership-rollup` all HTTP 200 with real figures (AAPL 14.69B / MSFT 7.43B / JPM 2.68B shares + treasury) — output-identical data path.
- **No `sec_rebuild` needed:** pure serialization, output-identical (same posture as parent #817).
- **Codex checkpoint 2:** NO FINDINGS.

Closes #1735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)