### PR TITLE
fix(#815): document the cik_raw_documents cache-race invariant (re-scope, no lock)

### DIFF
--- a/app/services/filer_seed_verification.py
+++ b/app/services/filer_seed_verification.py
@@ -210,6 +210,17 @@ def _fetch_submissions(
     if cached is not None:
         return cached
 
+    # #815 — see ``reconciliation._fetch_companyfacts_payload``: this
+    # read-miss -> fetch -> write window is deliberately UNLOCKED. A
+    # concurrent same-(cik, 'submissions_json') caller redundantly
+    # fetches at worst once; ``_write_cache`` is idempotent via
+    # ``store_cik_raw`` (``ON CONFLICT (cik, document_kind) DO UPDATE``),
+    # so last-writer-wins with no clobber. The only callers are operator
+    # CLIs (``scripts/verify_filer_seeds.py``); a lock across the 30s
+    # ``urlopen`` would strand an idle conn (#719 / #1129) for zero gain.
+    # Add the ``pg_try_advisory_lock`` fast-skip only when a
+    # ScheduledJob/API route calls the seed verifier, OR a 2nd concurrent
+    # same-(cik, document_kind) consumer lands (#815).
     req = urllib.request.Request(
         _submissions_url(cik_padded),
         headers={"User-Agent": settings.sec_user_agent},

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -313,9 +313,9 @@ def _fetch_companyfacts_payload(
     # (cik, 'companyfacts') that also misses will redundantly fetch SEC
     # and write; worst case is ONE duplicate ~30s fetch. There is no
     # clobber/corruption: ``_write_cache`` goes through
-    # ``store_cik_raw`` (``ON CONFLICT (cik, document_kind) DO UPDATE``,
-    # ``cik_raw_filings.py:121``), so the second writer restamps the
-    # same row, last-writer-wins. A lock here would have to span the 30s
+    # ``store_cik_raw``, whose ``ON CONFLICT (cik, document_kind) DO
+    # UPDATE`` means the second writer restamps the same row,
+    # last-writer-wins. A lock here would have to span the 30s
     # ``urlopen`` — the stranded-idle-connection failure mode
     # (#719 / #1129) — for zero gain, because the only callers are
     # operator CLIs (``scripts/run_reconciliation.py``,

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -308,6 +308,23 @@ def _fetch_companyfacts_payload(
     if cached is not None:
         return cached
 
+    # #815 — the read-miss -> fetch -> write window below is
+    # deliberately UNLOCKED. A concurrent caller for the same
+    # (cik, 'companyfacts') that also misses will redundantly fetch SEC
+    # and write; worst case is ONE duplicate ~30s fetch. There is no
+    # clobber/corruption: ``_write_cache`` goes through
+    # ``store_cik_raw`` (``ON CONFLICT (cik, document_kind) DO UPDATE``,
+    # ``cik_raw_filings.py:121``), so the second writer restamps the
+    # same row, last-writer-wins. A lock here would have to span the 30s
+    # ``urlopen`` — the stranded-idle-connection failure mode
+    # (#719 / #1129) — for zero gain, because the only callers are
+    # operator CLIs (``scripts/run_reconciliation.py``,
+    # ``scripts/seed_top_13f_filers.py``), never a scheduler/API route.
+    # Build the ``pg_try_advisory_lock`` fast-skip (loser dup-fetches;
+    # winner re-checks the cache then fetches; session lock released in
+    # ``finally``; ``%s::text`` key, never int4) ONLY when that changes:
+    # a ScheduledJob/API route calls ``run_spot_check``, OR a 2nd
+    # concurrent same-(cik, document_kind) consumer lands (#815).
     req = urllib.request.Request(
         _companyfacts_url(cik_padded),
         headers={"User-Agent": settings.sec_user_agent},


### PR DESCRIPTION
## What

Re-scopes #815 from "add a lock" to "document the invariant + the trigger to build the lock", at the two cache-fetch sites. **Comment-only — no behaviour change.**

## Why (re-triage)

#815 flagged a read-miss → fetch → write race in the `cik_raw_documents` write-through cache. The race is **real but benign**:

- Worst case under concurrency = **ONE duplicate ~30s SEC fetch**.
- No clobber/corruption: `_write_cache` → `store_cik_raw` (`ON CONFLICT (cik, document_kind) DO UPDATE`, `cik_raw_filings.py:121`) → last-writer-wins on the same row.
- The only callers are operator CLIs (`run_reconciliation.py`, `seed_top_13f_filers.py`, `verify_filer_seeds.py`) — **no scheduler/API route**. A lock spanning the 30s `urlopen` would re-introduce the stranded-idle-connection class (#719 / #1129) for **zero gain**.

## Change

Invariant comments at:
- `app/services/reconciliation.py::_fetch_companyfacts_payload`
- `app/services/filer_seed_verification.py::_fetch_submissions`

Each documents: the window is deliberately unlocked, why it's benign (idempotent `store_cik_raw`), why no lock (CLI-only callers + the #719/#1129 stranded-conn trap), and the **trigger** to actually build the `pg_try_advisory_lock` fast-skip:

> a ScheduledJob/API route calls `run_spot_check` or the seed verifier, **OR** a 2nd concurrent same-`(cik, document_kind)` consumer lands.

This relocates the tripwire **into the code a future caller would touch**, so the dangling tech-debt issue can close without losing the knowledge.

## Verification

ruff check + ruff format + pyright clean on both files. Comment-only diff — no logic, no test change.

Closes #815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)