### PR TITLE
fix(#1230,#1229): admin trigger-reject reason inline + expandable failed-stage list

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1562,7 +1562,14 @@ export type TriggerConflictReason =
   // job request is rejected because bootstrap_state.status !=
   // 'complete' and no override flag was set. Surfaces to the operator
   // via the rejected pending_job_requests row's error_msg.
-  | "bootstrap_not_complete";
+  | "bootstrap_not_complete"
+  // #1139 — bootstrap "Re-run failed" (iterate) preconditions, raised as
+  // synchronous 409s by app/api/processes.py::_apply_bootstrap_iterate_reset.
+  // `bootstrap_not_resettable`: singleton status not in {partial_error,
+  // cancelled}. `bootstrap_no_failed_stages`: latest run had no failed
+  // stages to iterate (the common "Re-run failed on a clean bootstrap" case).
+  | "bootstrap_not_resettable"
+  | "bootstrap_no_failed_stages";
 
 // ---------------------------------------------------------------------------
 // Orchestrator DAG drill-in (#1078, umbrella #1064 — PR6)

--- a/frontend/src/components/admin/ProcessRow.test.tsx
+++ b/frontend/src/components/admin/ProcessRow.test.tsx
@@ -145,6 +145,42 @@ describe("ProcessRow", () => {
     expect(screen.getByText("MissingCIK")).toBeTruthy();
   });
 
+  it("#1229: '+N more' expands the full failed-stage list, then collapses", () => {
+    // A bootstrap in partial_error surfaces each failed stage as an entry
+    // keyed by stage_key (bootstrap_adapter). With >2, the surplus hides
+    // behind an expandable disclosure instead of a dead-end "+N more".
+    renderRow({
+      row: makeProcessRow({
+        process_id: "bootstrap",
+        mechanism: "bootstrap",
+        status: "failed",
+        last_n_errors: [
+          makeError({ error_class: "sec_def14a_bootstrap", count: 1 }),
+          makeError({ error_class: "sec_business_summary_bootstrap", count: 1 }),
+          makeError({ error_class: "sec_insider_transactions_backfill", count: 1 }),
+          makeError({ error_class: "sec_13f_recent_sweep", count: 1 }),
+        ],
+      }),
+    });
+    // Collapsed: first two shown, last two hidden behind "+2 more".
+    expect(screen.getByText("sec_def14a_bootstrap")).toBeTruthy();
+    expect(screen.getByText("sec_business_summary_bootstrap")).toBeTruthy();
+    expect(screen.queryByText("sec_13f_recent_sweep")).toBeNull();
+    const toggle = screen.getByRole("button", { name: "+2 more" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(toggle);
+    // Expanded: every failed stage visible.
+    expect(screen.getByText("sec_insider_transactions_backfill")).toBeTruthy();
+    expect(screen.getByText("sec_13f_recent_sweep")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "show fewer" }).getAttribute("aria-expanded"),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "show fewer" }));
+    expect(screen.queryByText("sec_13f_recent_sweep")).toBeNull();
+  });
+
   it("does NOT render error preview on status=running (auto-hide-on-retry already empty BE-side)", () => {
     renderRow({
       row: makeProcessRow({ status: "running", last_n_errors: [] }),
@@ -160,21 +196,60 @@ describe("ProcessRow", () => {
     expect(pill.getAttribute("title")).toContain("retry");
   });
 
-  it("renders structured 409 reason tooltip when triggerError is an ApiError", () => {
-    renderRow({
+  it("#1230: surfaces the rejection category inline + full hint in the tooltip", () => {
+    const { getByTestId } = renderRow({
       triggerError: new ApiError(409, "iterate already in flight", {
         reason: "iterate_already_pending",
       }),
     });
-    const note = screen.getByText("trigger rejected");
+    const note = getByTestId("trigger-rejected");
+    // Category is visible without hovering (#1230).
+    expect(note.textContent).toContain("iterate already pending");
+    expect(note.textContent).toContain("trigger rejected");
+    // Full "what to do" sentence still lives on the tooltip.
     expect(note.getAttribute("title")).toContain("already in flight");
   });
 
-  it("falls back to a fixed phrase when error has no known reason", () => {
-    renderRow({
+  it("#1230: kill_switch_active renders its category inline", () => {
+    const { getByTestId } = renderRow({
+      triggerError: new ApiError(409, "blocked", {
+        reason: "kill_switch_active",
+      }),
+    });
+    const note = getByTestId("trigger-rejected");
+    expect(note.textContent).toContain("kill switch active");
+    expect(note.getAttribute("title")).toContain("Kill switch");
+  });
+
+  it("#1230: bootstrap_no_failed_stages (Re-run-failed on a clean bootstrap) shows its category", () => {
+    const { getByTestId } = renderRow({
+      triggerError: new ApiError(409, "no failed stages", {
+        reason: "bootstrap_no_failed_stages",
+      }),
+    });
+    const note = getByTestId("trigger-rejected");
+    expect(note.textContent).toContain("no failed stages");
+    expect(note.getAttribute("title")).toContain("no failed stages");
+  });
+
+  it("#1230: cancel rejection surfaces its own inline category", () => {
+    const { getByTestId } = renderRow({
+      cancelError: new ApiError(409, "nothing to cancel", {
+        reason: "no_active_run",
+      }),
+    });
+    const note = getByTestId("cancel-rejected");
+    expect(note.textContent).toContain("cancel rejected");
+    expect(note.textContent).toContain("no active run");
+  });
+
+  it("#1230: unknown reason shows the generic label with no inline category", () => {
+    const { getByTestId } = renderRow({
       triggerError: new ApiError(500, "Internal Server Error"),
     });
-    const note = screen.getByText("trigger rejected");
+    const note = getByTestId("trigger-rejected");
+    expect(note.textContent).toBe("trigger rejected");
+    expect(note.textContent).not.toContain("—");
     expect(note.getAttribute("title")).toContain("browser console");
   });
 

--- a/frontend/src/components/admin/ProcessRow.tsx
+++ b/frontend/src/components/admin/ProcessRow.tsx
@@ -22,6 +22,7 @@ import {
   NEXT_RUN_EXPECTED_TOOLTIP,
   REASON_TOOLTIP,
   VERDICT_VISUAL,
+  reasonShortLabel,
   reasonTooltip,
 } from "@/components/admin/processStatus";
 
@@ -253,24 +254,8 @@ function ProcessRowImpl({
             />
           )}
         </div>
-        {triggerError ? (
-          <div
-            role="status"
-            className="mt-1 text-right text-[11px] text-red-700 dark:text-red-300"
-            title={reasonTooltip(triggerError)}
-          >
-            trigger rejected
-          </div>
-        ) : null}
-        {cancelError ? (
-          <div
-            role="status"
-            className="mt-1 text-right text-[11px] text-red-700 dark:text-red-300"
-            title={reasonTooltip(cancelError)}
-          >
-            cancel rejected
-          </div>
-        ) : null}
+        <RejectedNote kind="trigger" err={triggerError} />
+        <RejectedNote kind="cancel" err={cancelError} />
       </td>
     </tr>
   );
@@ -357,6 +342,42 @@ function ActionButton({
   );
 }
 
+/**
+ * Inline trigger / cancel rejection note (#1230). Surfaces the specific
+ * reason CATEGORY ("kill switch active", "bootstrap already running", …)
+ * next to the generic "rejected" label so the operator scanning the page
+ * sees what blocks the row without hovering. The full-sentence "what to
+ * do" hint stays on the `title` tooltip. Unknown / unstructured errors
+ * render the generic label alone (no exception text inline — the
+ * loading-error-empty-states fixed-phrase rule).
+ */
+function RejectedNote({
+  kind,
+  err,
+}: {
+  kind: "trigger" | "cancel";
+  err: unknown;
+}) {
+  if (!err) return null;
+  const short = reasonShortLabel(err);
+  return (
+    <div
+      role="status"
+      data-testid={`${kind}-rejected`}
+      className="mt-1 text-right text-[11px] text-red-700 dark:text-red-300"
+      title={reasonTooltip(err)}
+    >
+      {kind} rejected
+      {short !== null ? (
+        <>
+          {" — "}
+          <span className="font-medium">{short}</span>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
 function ErrorPreview({
   errors,
 }: {
@@ -364,13 +385,19 @@ function ErrorPreview({
 }) {
   // Spec §"Error display rules" — inline preview is always visible
   // (no click-to-reveal); drill-in shows the full list on the Errors
-  // tab. Show up to two error classes inline; truncate the rest with
-  // a `+N more` link to the drill-in.
-  const head = errors.slice(0, 2);
-  const remainder = errors.length - head.length;
+  // tab. Show up to two error classes inline; the rest collapse behind
+  // an expandable "+N more" disclosure (#1229 — for a bootstrap in
+  // partial_error each entry is a failed stage_key, so the operator can
+  // see every failed stage inline instead of clicking into the detail
+  // page). The disclosure starts collapsed; plain local state, no
+  // prop-derived initializer (so no reset path needed — prevention-log
+  // "prop-derived useState").
+  const [expanded, setExpanded] = useState(false);
+  const remainder = errors.length - 2;
+  const shown = expanded ? errors : errors.slice(0, 2);
   return (
     <ul className="mt-1 space-y-0.5 text-xs text-red-700 dark:text-red-300">
-      {head.map((e) => (
+      {shown.map((e) => (
         <li key={e.error_class} className="truncate" title={e.sample_message}>
           <span className="font-medium">{e.error_class}</span>{" "}
           <span className="text-slate-500 dark:text-slate-400">
@@ -384,8 +411,15 @@ function ErrorPreview({
         </li>
       ))}
       {remainder > 0 ? (
-        <li className="text-[11px] text-slate-500 dark:text-slate-400">
-          +{remainder} more
+        <li>
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            className="text-[11px] text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+          >
+            {expanded ? "show fewer" : `+${remainder} more`}
+          </button>
         </li>
       ) : null}
     </ul>

--- a/frontend/src/components/admin/ProcessesTable.test.tsx
+++ b/frontend/src/components/admin/ProcessesTable.test.tsx
@@ -124,8 +124,10 @@ describe("ProcessesTable", () => {
     );
     renderTable();
     fireEvent.click(screen.getByRole("button", { name: "Iterate" }));
-    await waitFor(() => expect(screen.getByText("trigger rejected")).toBeTruthy());
-    const note = screen.getByText("trigger rejected");
+    await waitFor(() => expect(screen.getByTestId("trigger-rejected")).toBeTruthy());
+    const note = screen.getByTestId("trigger-rejected");
+    // #1230 — category visible inline; full hint on the tooltip.
+    expect(note.textContent).toContain("iterate already pending");
     expect(note.getAttribute("title")).toContain("already in flight");
   });
 

--- a/frontend/src/components/admin/processStatus.ts
+++ b/frontend/src/components/admin/processStatus.ts
@@ -107,6 +107,36 @@ export const REASON_TOOLTIP: Record<TriggerConflictReason, string> = {
     "Sweeps have no in-flight state — cancel the underlying scheduled job.",
   bootstrap_not_complete:
     "First-install bootstrap is not complete — finish or override before triggering this job.",
+  bootstrap_not_resettable:
+    "Bootstrap is not in a re-runnable state — only a failed or cancelled run can be re-run.",
+  bootstrap_no_failed_stages:
+    "Nothing to re-run — the latest bootstrap run has no failed stages.",
+};
+
+/**
+ * Short inline-visible label for a structured trigger / cancel reason
+ * (#1230). Sibling to REASON_TOOLTIP: the tooltip carries the full
+ * "what to do" sentence (hover), this carries the *category* so the
+ * operator scanning the page sees WHY a row is blocked without hovering.
+ * Keep keys in lock-step with REASON_TOOLTIP.
+ */
+export const REASON_SHORT_LABEL: Record<TriggerConflictReason, string> = {
+  kill_switch_active: "kill switch active",
+  bootstrap_already_running: "bootstrap already running",
+  bootstrap_state_missing: "bootstrap not initialised",
+  bootstrap_not_resumable: "nothing to iterate",
+  iterate_already_pending: "iterate already pending",
+  full_wash_already_pending: "full-wash already pending",
+  active_run_in_progress: "run in progress",
+  shared_source_active_run: "sibling job running",
+  shared_source_full_wash_pending: "sibling full-wash pending",
+  no_active_run: "no active run",
+  stop_already_pending: "cancel already pending",
+  trigger_not_supported: "trigger not supported",
+  cancel_not_supported: "cancel not supported",
+  bootstrap_not_complete: "bootstrap not complete",
+  bootstrap_not_resettable: "bootstrap not re-runnable",
+  bootstrap_no_failed_stages: "no failed stages",
 };
 
 const KNOWN_REASONS = new Set<string>(Object.keys(REASON_TOOLTIP));
@@ -125,6 +155,17 @@ export function reasonTooltip(err: unknown): string {
   const reason = reasonFromError(err);
   if (reason !== null) return REASON_TOOLTIP[reason];
   return "Request rejected. Check the browser console for details.";
+}
+
+/**
+ * Short inline category for a trigger / cancel rejection (#1230), or
+ * null when the reason is unstructured/unknown — the caller then shows
+ * the generic "rejected" label alone (the full hint stays in the
+ * tooltip; we never render exception text inline).
+ */
+export function reasonShortLabel(err: unknown): string | null {
+  const reason = reasonFromError(err);
+  return reason !== null ? REASON_SHORT_LABEL[reason] : null;
 }
 
 /**


### PR DESCRIPTION
## What + why

Two admin/processes operator-UX papercuts from the install/admin honesty cluster (precedent #1689). Product-test: an operator scanning `/admin/processes` during a live run sees *why* a row is blocked and *which* stages failed — without hovering or drilling in.

### #1230 — trigger/cancel rejection reason inline (was hover-only)
Before: a rejected trigger showed a generic red "trigger rejected"; the specific reason (`kill_switch_active`, `bootstrap_already_running`, …) was only in the `title` tooltip — easy to miss (surfaced 2026-05-19 T9-POST drive; operator had to ask Claude to dig into the backend).

After: the reason **category** renders inline next to the label ("trigger rejected — kill switch active"); the full "what to do" sentence stays on the tooltip.

- New `REASON_SHORT_LABEL` map (sibling to `REASON_TOOLTIP`) + `reasonShortLabel()` in `processStatus.ts`.
- Extracted `RejectedNote` so trigger + cancel share one renderer.
- Unknown/unstructured errors render the generic label alone — **no exception text inline** (loading-error-empty-states fixed-phrase rule).
- **Contract gap closed** (Codex ckpt-2): backend raises `bootstrap_not_resettable` + `bootstrap_no_failed_stages` 409s (`app/api/processes.py::_apply_bootstrap_iterate_reset`) that the FE `TriggerConflictReason` enum omitted → generic copy. Added both to the enum + both `Record` maps. The common case — operator clicks **Re-run failed** on a clean bootstrap — now shows "no failed stages" inline.

### #1229 — "+N more" failed-stage label now expandable (was a dead label)
Before: a bootstrap in `partial_error` with >2 failed child stages clipped at 2 + a static "+6 more" with no handler — operator had to open the detail page → Errors tab.

After: "+N more" is an expandable disclosure; click expands the full list inline, "show fewer" collapses. Each entry is a failed `stage_key` (`bootstrap_adapter`). Plain local `useState` (no prop-derived initializer → no reset path needed, per prevention-log).

## Settled decisions / prevention-log
- Cancel UX #1064 (cooperative) — untouched. 5-state coverage banner #840 — N/A.
- Prevention-log "prop-derived `useState` needs reset path" — avoided by using plain `useState(false)`.
- loading-error-empty-states "never render exception text in DOM" — honored (fixed phrases only).

## Out of scope (already shipped — recommend closing)
- **#1271** (timeline auto-refresh) — already shipped by #1272 ([ProcessDetailPage.tsx:183-215](frontend/src/pages/ProcessDetailPage.tsx#L183-L215), `TIMELINE_POLL_MS=5000`).
- **#1005** (mid-stage progress) — FE bar shipped ([ProcessDetailPage.tsx:1318-1379](frontend/src/pages/ProcessDetailPage.tsx#L1318-L1379)); backend instruments 6 stages via #1273 (acceptance = ≥4). Only `daily_candle_refresh` ungauged.

## Verification
- Frontend typecheck ✓, 1076 unit tests ✓ (new #1230 + #1229 coverage), dark:check ✓ (all via pre-push gate).
- Codex ckpt-2: no branch-introduced issues.
- Dev-verify (live :8000): real 409 `{"detail":{"reason":"trigger_not_supported"}}` from `sec_13f_sweep` flows end-to-end through `ApiError.detail` → `reasonShortLabel` → inline label. #1229 >2-entry expansion unit-tested against the real `ErrorPreview` with the live `last_n_errors` shape (bootstrap is `ok` on dev — no live `partial_error` to drive).

Closes #1230. Closes #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)