### PR TITLE
fix(#1226): wait out transient JobLock contention in bootstrap stages instead of erroring

### DIFF
--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -1401,6 +1402,124 @@ def _resolve_stage_rows(
     return None
 
 
+# #1226 — bootstrap stages race standalone cron / manual triggers for the
+# source-level ``JobLock``. The universal bootstrap-state gate (#1064) blocks
+# most scheduled jobs during a bootstrap, so contention is only with the short
+# carve-out jobs (#1181: sec_daily_index_reconcile, orchestrator_high_frequency_
+# _sync — seconds of work) or an operator's gate-override manual trigger. Such
+# holds clear quickly, so the stage waits the holder out with a bounded
+# acquire-retry instead of erroring on the first miss (the prior behaviour
+# surfaced six scary "another instance holds the advisory lock" stage errors in
+# run_id=3, each needing a manual retry click). ~30s window: comfortably longer
+# than a carve-out job's hold, short enough that a stuck genuine-deadlock case
+# still surfaces promptly.
+_LOCK_BUSY_RETRY_BACKOFF: Final[tuple[float, ...]] = (1.0, 2.0, 4.0, 8.0, 15.0)
+
+
+def _bootstrap_run_cancelled(database_url: str, run_id: int) -> bool:
+    """True iff the bootstrap run is no longer ``running`` (cancelled / finalised).
+
+    Authoritative cancel signal for the acquire-retry wait (#1226 / Codex
+    ckpt-2). ``bootstrap_cancel_requested()`` is NOT sufficient here: the
+    dispatcher's cancel path completes the ``process_stop_requests`` row (which
+    ``is_stop_requested`` then filters out) and sweeps the run via
+    ``mark_run_cancelled`` (``bootstrap_runs.status='cancelled'``). Reading the
+    run status directly survives that completion, so a future sleeping between
+    failed lock acquires cannot wake up and start the body after the run was
+    swept cancelled. Errors are treated as "not cancelled" — a transient DB
+    blip must not abort an otherwise-valid stage; worst case the existing
+    between-stage checkpoint catches the cancel.
+    """
+    try:
+        with psycopg.connect(database_url, autocommit=True) as conn:
+            row = conn.execute(
+                "SELECT status FROM bootstrap_runs WHERE id = %(run_id)s",
+                {"run_id": run_id},
+            ).fetchone()
+        return row is not None and row[0] != "running"
+    except Exception as exc:  # noqa: BLE001 — cancel probe must not crash the stage
+        logger.warning("bootstrap stage cancel-probe failed for run %s: %s", run_id, exc)
+        return False
+
+
+def _run_stage_under_lock_with_retry(
+    *,
+    database_url: str,
+    job_name: str,
+    run_id: int,
+    stage_key: str,
+    run: Callable[[], None],
+    backoff: tuple[float, ...] = _LOCK_BUSY_RETRY_BACKOFF,
+    sleep: Callable[[float], None] = time.sleep,
+    cancel_check: Callable[[], bool] | None = None,
+) -> None:
+    """Acquire the source-level ``JobLock`` and invoke ``run()`` under it,
+    retrying ONLY a failed lock ACQUIRE on transient contention (#1226).
+
+    Mirrors the scheduled-fire ``_fire_scheduled_with_lane_retry`` (#1538)
+    invariant: ``JobAlreadyRunning`` raised by ``JobLock.__enter__`` (acquire)
+    is retried with ``backoff``; the SAME exception raised from inside ``run``
+    (body-origin) is RE-RAISED, never replayed — the body may have partially
+    executed. The ``acquired`` flag distinguishes them.
+
+    Cancel-awareness (Codex ckpt-2): the up-to-~30s pre-body wait widened the
+    window in which the dispatcher could cancel the run while this future
+    sleeps. Before each sleep AND before invoking after a successful acquire,
+    ``cancel_check`` (default: authoritative ``bootstrap_runs.status`` read) is
+    consulted; if the run was cancelled, ``BootstrapStageCancelled`` is raised
+    so the body does not start post-cancel and the caller tones the stage gray.
+    Best-effort by design: ``_bootstrap_run_cancelled`` returns False on a probe
+    error (a transient DB blip must not false-cancel a valid stage), so the
+    invoker's own in-body ``bootstrap_cancel_requested`` checkpoints remain the
+    backstop for the rare probe-failed-during-cancel case.
+
+    On success returns normally (``run`` ran under the lock). If the lock stays
+    held through the whole retry window, re-raises ``JobAlreadyRunning`` — now a
+    genuine-contention/deadlock signal the caller records as a stage error.
+    ``active_bootstrap_run`` is scoped per attempt, so the cancel contextvar is
+    set only while the invoker actually runs.
+    """
+    from app.services.bootstrap_state import BootstrapStageCancelled
+    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
+    if cancel_check is None:
+        cancel_check = lambda: _bootstrap_run_cancelled(database_url, run_id)  # noqa: E731
+
+    for attempt in range(len(backoff) + 1):
+        acquired = False
+        try:
+            with JobLock(database_url, job_name), active_bootstrap_run(run_id, stage_key):
+                acquired = True
+                # Do NOT start the body if the run was cancelled while we waited
+                # for the lock — bail cooperatively (caller marks stage cancelled).
+                if cancel_check():
+                    raise BootstrapStageCancelled("run cancelled during lock-acquire wait")
+                run()
+            return
+        except JobAlreadyRunning:
+            if acquired:
+                # Body-origin (an invoker sub-call hit its own JobLock) — not a
+                # lane-acquire skip; re-raise so a partial stage is never replayed.
+                raise
+            if attempt < len(backoff):
+                # Don't burn the rest of the window if the run is already gone.
+                if cancel_check():
+                    raise BootstrapStageCancelled("run cancelled during lock-acquire wait") from None
+                delay = backoff[attempt]
+                logger.info(
+                    "bootstrap stage %s: %r lock busy (cron/manual contention); retrying acquire %d/%d after %.1fs",
+                    stage_key,
+                    job_name,
+                    attempt + 1,
+                    len(backoff),
+                    delay,
+                )
+                sleep(delay)
+                continue
+            # Held through the whole window → genuine contention.
+            raise
+
+
 def _run_one_stage(
     *,
     run_id: int,
@@ -1460,40 +1579,53 @@ def _run_one_stage(
     # context manager scopes the contextvar so scheduled / manual
     # triggers of the same job (outside bootstrap) see no signal.
     from app.services.bootstrap_state import BootstrapStageCancelled, mark_stage_cancelled
-    from app.services.processes.bootstrap_cancel_signal import active_bootstrap_run
+
+    def _invoke_under_lock() -> None:
+        # Body run while holding ``JobLock`` (and the cancel contextvar).
+        nonlocal job_runs_id_after
+        snap_token = _params_snapshot_var.set(effective_params)
+        try:
+            invoker(effective_params)
+        finally:
+            _params_snapshot_var.reset(snap_token)
+        # #1140 Task C — capture the upper bound while still
+        # holding ``JobLock``. Any job_runs row created here must
+        # belong to our invocation; same-source serialisation
+        # prevents a parallel same-job_name fire from sneaking in.
+        #
+        # Wrapped in try/except so a snapshot failure (transient DB
+        # blip, pool exhausted) does NOT mark a successful invoker
+        # as error (Codex pre-push round 2 WARNING). The resolver
+        # falls back to ``job_runs_id_before`` window (which is the
+        # same value as ``job_runs_id_after`` initialised above) →
+        # an empty window → ``rows_processed = None``. The stage
+        # still records ``success``; cap-eval handles the None per
+        # the strict-gate rule.
+        try:
+            with psycopg.connect(database_url) as snap_conn:
+                job_runs_id_after = _snapshot_job_runs_max_id(snap_conn, job_name=job_name)
+        except Exception as snap_exc:  # noqa: BLE001 — snapshot is best-effort
+            logger.warning(
+                "bootstrap stage %s: failed to capture job_runs_id_after: %s",
+                stage_key,
+                snap_exc,
+            )
 
     try:
-        with JobLock(database_url, job_name), active_bootstrap_run(run_id, stage_key):
-            snap_token = _params_snapshot_var.set(effective_params)
-            try:
-                invoker(effective_params)
-            finally:
-                _params_snapshot_var.reset(snap_token)
-            # #1140 Task C — capture the upper bound while still
-            # holding ``JobLock``. Any job_runs row created here must
-            # belong to our invocation; same-source serialisation
-            # prevents a parallel same-job_name fire from sneaking in.
-            #
-            # Wrapped in try/except so a snapshot failure (transient DB
-            # blip, pool exhausted) does NOT mark a successful invoker
-            # as error (Codex pre-push round 2 WARNING). The resolver
-            # falls back to ``job_runs_id_before`` window (which is the
-            # same value as ``job_runs_id_after`` initialised above) →
-            # an empty window → ``rows_processed = None``. The stage
-            # still records ``success``; cap-eval handles the None per
-            # the strict-gate rule.
-            try:
-                with psycopg.connect(database_url) as snap_conn:
-                    job_runs_id_after = _snapshot_job_runs_max_id(snap_conn, job_name=job_name)
-            except Exception as snap_exc:  # noqa: BLE001 — snapshot is best-effort
-                logger.warning(
-                    "bootstrap stage %s: failed to capture job_runs_id_after: %s",
-                    stage_key,
-                    snap_exc,
-                )
+        # #1226 — bounded acquire-retry: wait out a standalone cron / manual
+        # trigger holding the source JobLock instead of erroring on the first
+        # miss. Only a persistent hold through the window surfaces as an error.
+        _run_stage_under_lock_with_retry(
+            database_url=database_url,
+            job_name=job_name,
+            run_id=run_id,
+            stage_key=stage_key,
+            run=_invoke_under_lock,
+        )
     except JobAlreadyRunning:
         message = (
-            f"another instance of {job_name!r} holds the advisory lock; "
+            f"another instance of {job_name!r} held the advisory lock through the "
+            f"~{sum(_LOCK_BUSY_RETRY_BACKOFF):.0f}s retry window; "
             "retry from the bootstrap panel after the other run completes"
         )
         with psycopg.connect(database_url) as conn:

--- a/tests/test_bootstrap_lock_retry.py
+++ b/tests/test_bootstrap_lock_retry.py
@@ -1,0 +1,174 @@
+"""#1226 — ``_run_stage_under_lock_with_retry`` bounded acquire-retry.
+
+Pure unit tests (no DB, no real sleeping): a fake ``JobLock`` controls whether
+the *acquire* succeeds, the body is an injected callable, and ``sleep`` is a
+recorder. A bootstrap stage that races a standalone cron / manual trigger for
+the source ``JobLock`` waits the holder out instead of erroring on the first
+miss (#1226). Mirrors the #1538 invariant: retry ONLY the acquire; a
+body-raised ``JobAlreadyRunning`` is propagated, never replayed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.jobs.locks import JobAlreadyRunning
+from app.services import bootstrap_orchestrator as orch
+from app.services.bootstrap_state import BootstrapStageCancelled
+
+_BACKOFF = (0.25, 0.5, 1.0)  # 3 retries; shape matches prod, values arbitrary for tests
+
+
+def _fake_joblock_factory(state: dict[str, int]):
+    """JobLock stand-in. ``__enter__`` raises ``JobAlreadyRunning`` for the first
+    ``state['fail_n']`` calls (acquire failures), then succeeds."""
+
+    class _FakeLock:
+        def __init__(self, _database_url: str, _job_name: str) -> None:
+            pass
+
+        def __enter__(self) -> _FakeLock:
+            state["enter"] += 1
+            if state["enter"] <= state["fail_n"]:
+                raise JobAlreadyRunning("fake")
+            return self
+
+        def __exit__(self, *_exc: object) -> bool:
+            return False
+
+    return _FakeLock
+
+
+def _call(**kw):
+    # Default cancel_check to a no-op so the pure tests never touch a DB; the
+    # cancel-during-retry tests override it.
+    kw.setdefault("cancel_check", lambda: False)
+    return orch._run_stage_under_lock_with_retry(
+        database_url="db://x",
+        job_name="sec_business_summary_bootstrap",
+        run_id=3,
+        stage_key="sec_business_summary_bootstrap",
+        **kw,
+    )
+
+
+def test_lock_free_runs_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {"enter": 0, "fail_n": 0}
+    monkeypatch.setattr(orch, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    ran: list[int] = []
+
+    _call(run=lambda: ran.append(1), backoff=_BACKOFF, sleep=sleeps.append)
+
+    assert ran == [1]
+    assert state["enter"] == 1  # one acquire, no retry
+    assert sleeps == []  # never slept on a free lock
+
+
+def test_busy_then_free_waits_out_the_holder(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The reported symptom: a cron holds the lock for the first 2 acquires,
+    # releases, and the stage then runs — no error, no manual retry click.
+    state = {"enter": 0, "fail_n": 2}
+    monkeypatch.setattr(orch, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    ran: list[int] = []
+
+    _call(run=lambda: ran.append(1), backoff=_BACKOFF, sleep=sleeps.append)
+
+    assert ran == [1]  # body ran exactly once after the holder released
+    assert state["enter"] == 3  # 2 failed acquires + 1 success
+    assert sleeps == [0.25, 0.5]  # slept before each retry, not after success
+
+
+def test_persistent_contention_raises_after_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Lock held through the whole window → genuine contention/deadlock: re-raise
+    # so the caller records a stage error (the prompt operator signal).
+    state = {"enter": 0, "fail_n": 99}
+    monkeypatch.setattr(orch, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    ran: list[int] = []
+
+    with pytest.raises(JobAlreadyRunning):
+        _call(run=lambda: ran.append(1), backoff=_BACKOFF, sleep=sleeps.append)
+
+    assert ran == []  # never ran
+    assert state["enter"] == len(_BACKOFF) + 1  # initial + 3 retries
+    assert sleeps == list(_BACKOFF)  # slept between each, then gave up
+
+
+def test_body_raised_job_already_running_is_not_replayed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # acquire succeeds, the body itself raises JobAlreadyRunning (an invoker
+    # sub-call hit its own JobLock). acquired=True → propagate, never replay.
+    state = {"enter": 0, "fail_n": 0}
+    monkeypatch.setattr(orch, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    body_calls: list[int] = []
+
+    def _body() -> None:
+        body_calls.append(1)
+        raise JobAlreadyRunning("body-origin")
+
+    with pytest.raises(JobAlreadyRunning):
+        _call(run=_body, backoff=_BACKOFF, sleep=sleeps.append)
+
+    assert body_calls == [1]  # ran once, NOT replayed
+    assert state["enter"] == 1  # exactly one acquire
+    assert sleeps == []  # never slept
+
+
+def test_body_other_exception_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A non-JobAlreadyRunning body error propagates unchanged (the caller's
+    # broad `except Exception` records it as a stage error).
+    state = {"enter": 0, "fail_n": 1}
+    monkeypatch.setattr(orch, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+
+    def _body() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        _call(run=_body, backoff=_BACKOFF, sleep=sleeps.append)
+
+    assert state["enter"] == 2  # one failed acquire + the acquire whose body raised
+    assert sleeps == [0.25]  # slept once before the retry that acquired
+
+
+def test_cancel_after_acquire_does_not_run_the_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The dispatcher swept the run cancelled while we waited for the lock. The
+    # lock then frees; we acquire — but must NOT run the body post-cancel.
+    state = {"enter": 0, "fail_n": 0}  # acquire succeeds immediately
+    monkeypatch.setattr(orch, "JobLock", _fake_joblock_factory(state))
+    ran: list[int] = []
+
+    with pytest.raises(BootstrapStageCancelled):
+        _call(run=lambda: ran.append(1), backoff=_BACKOFF, sleep=lambda _s: None, cancel_check=lambda: True)
+
+    assert ran == []  # body never ran after cancel
+    assert state["enter"] == 1  # acquired once, then bailed before run()
+
+
+def test_cancel_during_backoff_aborts_without_finishing_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Lock stays busy; the run is cancelled mid-wait → bail cooperatively instead
+    # of burning the whole ~30s window then erroring.
+    state = {"enter": 0, "fail_n": 99}  # always busy
+    monkeypatch.setattr(orch, "JobLock", _fake_joblock_factory(state))
+    sleeps: list[float] = []
+    checks = {"n": 0}
+
+    def _cancel() -> bool:
+        # Not cancelled on the first check (so one sleep happens), cancelled after.
+        checks["n"] += 1
+        return checks["n"] > 1
+
+    with pytest.raises(BootstrapStageCancelled):
+        _call(run=lambda: None, backoff=_BACKOFF, sleep=sleeps.append, cancel_check=_cancel)
+
+    assert sleeps == [0.25]  # only the first retry slept; then cancel aborted the wait
+    assert state["enter"] == 2  # initial acquire-fail + one retry acquire-fail
+
+
+def test_prod_window_outlasts_a_carveout_job_hold() -> None:
+    """The default window must comfortably exceed a short carve-out job's hold
+    so the common contention case auto-resolves rather than erroring."""
+    assert sum(orch._LOCK_BUSY_RETRY_BACKOFF) >= 25.0
+    assert len(orch._LOCK_BUSY_RETRY_BACKOFF) >= 4


### PR DESCRIPTION
## What + why

A bootstrap stage that races a standalone cron / manual trigger for the source-level `JobLock` previously **errored on the first miss** ("another instance of '…' holds the advisory lock; retry from the bootstrap panel"), painting the run `partial_error` (red) and forcing a manual "Re-run failed" click per affected stage (run_id=3, 2026-05-17: 6 such errors on stages 17-20 + 22).

The lock is **correct** (settled #1064 universal gate + #1181 carve-out prevent double-dispatch) — only the *classification* was alarming. Product-test: during a live bootstrap the operator should not see scary red stage errors for a benign, self-resolving race.

## Fix

Bounded **acquire-retry** in the stage runner (`app/services/bootstrap_orchestrator.py`). The universal bootstrap gate blocks most scheduled jobs during a bootstrap, so contention is only with the short carve-out jobs (`sec_daily_index_reconcile`, `orchestrator_high_frequency_sync` — seconds) or a gate-override manual trigger. The stage now **waits the holder out** (~30s window: `(1,2,4,8,15)`) and runs normally — no error, no click. Only a persistent hold *through the whole window* surfaces as a stage error (now a genuine deadlock signal).

- Extracted `_run_stage_under_lock_with_retry` — a testable seam (injectable `sleep`, fakeable `JobLock`, `cancel_check`) mirroring the scheduled-fire `_fire_scheduled_with_lane_retry` (#1538) invariant: **retry ONLY the acquire**; a `JobAlreadyRunning` raised from inside the invoker (body-origin) is re-raised, never replayed.
- **Cancel-aware** (Codex ckpt-2 caught a regression): the ~30s pre-body wait widened the window in which the dispatcher could sweep the run `cancelled` while this future sleeps — then wake, acquire, and run the body post-cancel. `bootstrap_cancel_requested()` can't see it (the dispatcher completes the `process_stop_requests` row, which `is_stop_requested` filters). Fix: `_bootstrap_run_cancelled` reads `bootstrap_runs.status` directly (authoritative, survives stop-request completion); checked before each sleep AND before invoking after acquire → raises `BootstrapStageCancelled` so the body doesn't start post-cancel (stage tones gray). Best-effort by design (probe error → False, never false-cancels a valid stage; invoker's own in-body checkpoints are the backstop).

No status-machine change, **lock semantics not weakened** (settled #1064 / #1181 preserved).

## Settled decisions / prevention-log
- #1064 universal bootstrap gate + #1181 carve-out — preserved (lock still acquired, just waited-for; no gate bypass).
- #1064 Cancel UX (cooperative) — strengthened, not weakened (cancel now observed during the acquire wait, not only at the next stage boundary).

## Verification
- `tests/test_bootstrap_lock_retry.py` — 8 pure-logic tests (fast tier, DB-free): free lock, busy-then-free (the reported symptom auto-resolves), persistent-contention-raises, body-origin not-replayed, other body exception propagates, **cancel-after-acquire skips body**, **cancel-during-backoff aborts the wait**, prod-window guard.
- Existing `tests/test_bootstrap_cancel.py` + `tests/test_orchestrator_cancel.py` (30 DB tests) pass.
- ruff / ruff format / pyright clean. Codex ckpt-2: regression found + fixed + re-reviewed (remaining note is a best-effort-probe precision point, consistent with existing `bootstrap_cancel_requested` semantics).

### ⚠ Pre-existing red-on-main (NOT from this PR)
`tests/test_bootstrap_orchestrator.py::{test_orchestrator_happy_path_completes, test_stage_catalogue_has_twenty_one_stages, test_stage_catalogue_lane_composition}` fail on **clean main** (stage-catalogue count drift: catalogue grew but the count assertions weren't updated). Confirmed by checking out main and re-running. Unrelated to #1226 (this change adds no stage) — flagging for a separate fix.

Closes #1226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)