### PR TITLE
refactor(#1601): adopt shared ChartTooltip across insider/ownership tooltips

### DIFF
--- a/frontend/src/components/insider/InsiderByOfficer.tsx
+++ b/frontend/src/components/insider/InsiderByOfficer.tsx
@@ -21,6 +21,7 @@ import {
 } from "recharts";
 
 import type { InsiderTransactionDetail } from "@/api/instruments";
+import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { lightTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import {
@@ -141,21 +142,21 @@ function OfficerTooltip({ active, payload }: TooltipProps) {
   if (!bucket) return null;
   const colorClass =
     bucket.net > 0
-      ? "text-emerald-700"
+      ? "text-emerald-700 dark:text-emerald-400"
       : bucket.net < 0
-        ? "text-red-700"
-        : "text-slate-600";
+        ? "text-red-700 dark:text-red-400"
+        : "text-slate-600 dark:text-slate-400";
   return (
-    <div className="rounded border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-2 py-1 text-xs shadow-md">
-      <div className="font-medium text-slate-700">{bucket.officer}</div>
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">{bucket.officer}</div>
       <div className={`font-mono tabular-nums ${colorClass}`}>
         {bucket.net > 0 ? "+" : ""}
         {formatShares(bucket.net)} sh
       </div>
-      <div className="text-[10px] text-slate-500">
+      <div className="text-[10px] text-slate-500 dark:text-slate-400">
         {bucket.txnCount} txn{bucket.txnCount === 1 ? "" : "s"}
       </div>
-    </div>
+    </ChartTooltip>
   );
 }
 

--- a/frontend/src/components/insider/InsiderNetByMonth.tsx
+++ b/frontend/src/components/insider/InsiderNetByMonth.tsx
@@ -21,6 +21,7 @@ import {
 } from "recharts";
 
 import type { InsiderTransactionDetail } from "@/api/instruments";
+import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { lightTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import { directionOf, signedShares } from "@/lib/insiderClassify";
@@ -131,20 +132,20 @@ function NetTooltip({ active, payload }: TooltipProps) {
   if (!bucket) return null;
   const colorClass =
     bucket.net > 0
-      ? "text-emerald-700"
+      ? "text-emerald-700 dark:text-emerald-400"
       : bucket.net < 0
-        ? "text-red-700"
-        : "text-slate-700";
+        ? "text-red-700 dark:text-red-400"
+        : "text-slate-700 dark:text-slate-300";
   return (
-    <div className="rounded border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-2 py-1 text-xs shadow-md">
-      <div className="font-medium text-slate-700">
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">
         {shortMonthLabel(bucket.month)}
       </div>
       <div className={`font-mono tabular-nums ${colorClass}`}>
         {bucket.net > 0 ? "+" : ""}
         {formatShares(bucket.net)} sh
       </div>
-    </div>
+    </ChartTooltip>
   );
 }
 

--- a/frontend/src/components/instrument/OwnershipHistoryChart.tsx
+++ b/frontend/src/components/instrument/OwnershipHistoryChart.tsx
@@ -26,6 +26,7 @@ import {
   YAxis,
 } from "recharts";
 
+import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { type AggregateCoverage, fetchOwnershipHistory } from "@/api/ownershipHistory";
 import {
@@ -342,7 +343,7 @@ function HistoryTooltip(props: HistoryTooltipProps): JSX.Element | null {
   if (!props.active || props.payload === undefined || props.payload.length === 0) return null;
   const period = props.label ?? "";
   return (
-    <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
+    <ChartTooltip>
       <div className="font-medium text-slate-900 dark:text-slate-100">{period}</div>
       {props.payload.map((entry) => {
         const shares = typeof entry.value === "number" ? entry.value : null;
@@ -358,6 +359,6 @@ function HistoryTooltip(props: HistoryTooltipProps): JSX.Element | null {
           </div>
         );
       })}
-    </div>
+    </ChartTooltip>
   );
 }

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -33,6 +33,7 @@
 import { type KeyboardEvent, useId, useMemo } from "react";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
+import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { formatPct, formatShares } from "@/components/instrument/ownershipMetrics";
 import {
   type CategoryKey,
@@ -533,15 +534,15 @@ function SunburstTooltip(props: RechartsTooltipProps): JSX.Element | null {
   if (datum.is_gap && !datum.is_residual) return null;
   if (datum.is_residual) {
     return (
-      <div className="max-w-[18rem] rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
-        <div className="text-slate-700 dark:text-slate-300">
+      <ChartTooltip>
+        <div className="max-w-[18rem] text-slate-700 dark:text-slate-300">
           {residualTooltipText(datum.shares, datum.pct)}
         </div>
-      </div>
+      </ChartTooltip>
     );
   }
   return (
-    <div className="rounded border border-slate-300 bg-white px-3 py-2 text-xs shadow-md dark:border-slate-700 dark:bg-slate-900">
+    <ChartTooltip>
       <div className="font-medium text-slate-900 dark:text-slate-100">{datum.name}</div>
       <div className="text-slate-600 dark:text-slate-400">
         {formatShares(datum.shares)} shares
@@ -549,7 +550,7 @@ function SunburstTooltip(props: RechartsTooltipProps): JSX.Element | null {
       <div className="text-slate-600 dark:text-slate-400">
         {formatPct(datum.pct)} of total shares
       </div>
-    </div>
+    </ChartTooltip>
   );
 }
 


### PR DESCRIPTION
## What

Migrate the remaining hand-rolled recharts custom-tooltip containers onto the shared `ChartTooltip` (`frontend/src/components/charts/ChartTooltip.tsx`, extracted in #1592). 4 components, 5 containers:

- `InsiderByOfficer` (OfficerTooltip)
- `InsiderNetByMonth` (NetTooltip)
- `OwnershipHistoryChart` (HistoryTooltip)
- `OwnershipSunburst` (SunburstTooltip — both residual + normal branches)

Each previously hand-rolled a `rounded border … shadow-md dark:…` div identical-in-spirit to `ChartTooltip`. They now compose `<ChartTooltip>` and own only their rows — the same pattern as the reference `PerformanceChart` / `AttributionChart` tooltips.

## Premise correction

The issue text expected the hand-rolls on the "fundamentals / dividends" pages. They aren't there — those charts use recharts' **default** tooltip (`contentStyle`-only). The actual hand-rolled containers (the issue's own grep signature `rounded border` + `shadow-md` near `Tooltip content=`) live in **insider + ownership**. Scoped to those.

## Bonus dark-mode bugfix

While migrating, found the two insider tooltips' inner rows used `text-slate-700` / `text-slate-500` / `text-emerald-700` / `text-red-700` with **no `dark:` partner** — dark-grey text on the `dark:bg-slate-900` surface = unreadable in dark mode today. (`dark:check` doesn't catch this — it gates `border-` / `hover:bg-`, not `text-slate-*`.) Added partners matching the reference impls. The ownership tooltips already had correct partners.

## StatTile half: no-op

Surveyed the 15 hairline-chrome consumers. `SummaryCards` already consumes `StatTile`; `RollingPnlStrip` (3-up strip, `text-lg`, tone-coloured subtext) and `KeyStatsPane` (`<dl>` key-value) are deliberate distinct shapes — forcing `StatTile` would change their visuals. No remaining ad-hoc tile to migrate.

## Out of scope → #1743

The ~17 recharts **default** tooltips in dividends/fundamentals/risk render white-card in dark mode (inline style; Tailwind `dark:` can't reach it). That's a separate theming fix — a visual change, not a `ChartTooltip` adoption — filed as #1743.

## Security model

N/A — pure presentational refactor. No auth, no authorization, no data path, no API, no SQL, no user input. Touches only chart-tooltip container JSX + Tailwind classes.

## Verification

- `pnpm typecheck` ✓ · `pnpm test:unit` ✓ (100 files, 1076 tests) · `pnpm dark:check` ✓ (214 files, 0 violations)
- **Dev-verified live** on `/instrument/AAPL/insider` + `/instrument/AAPL/ownership`, light **and** dark (at `3eb4e975`):
  - NetTooltip in dark: computed container `background-color: rgb(15,23,42)` (slate-900) — not the old white card; label `color: rgb(226,232,240)` (slate-200) — legible. Pre-fix the label resolved to slate-700 (dark-on-dark).
  - SunburstTooltip: normal + residual branches both render `ChartTooltip`; residual inner div carries `max-w-[18rem]` (wrap preserved).
- Codex ckpt-2: no issues.

Closes #1601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
