### PR TITLE
feat(#671): FCF yield trend on the fundamentals drill page

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -51,6 +51,7 @@ from app.services.broker_credentials import (
 )
 from app.services.dimensional_facts import DimensionalAxis
 from app.services.dimensional_facts_store import read_segments
+from app.services.fcf_yield import fcf_yield_series
 from app.services.intraday_candles import fetch_intraday_candles
 from app.services.operators import (
     AmbiguousOperatorError,
@@ -246,6 +247,24 @@ class InstrumentFinancials(BaseModel):
     currency: str | None
     source: str  # "financial_periods" (local SEC XBRL) | "unavailable"
     rows: list[InstrumentFinancialRow]
+
+
+class FcfYieldPoint(BaseModel):
+    period_end: date
+    period_type: str  # Q1/Q2/Q3/Q4 (quarterly) | FY (annual)
+    fcf_ttm: Decimal | None  # trailing-4Q (quarterly) or FY (annual); ABS(SUM capex)
+    market_cap: Decimal | None  # period_end shares × period_end close
+    fcf_yield_pct: Decimal | None  # fcf_ttm / market_cap × 100; negative preserved
+    price: Decimal | None  # close at/before period_end
+    price_as_of: date | None
+
+
+class FcfYieldSeries(BaseModel):
+    symbol: str
+    # Set → instrument is fail-closed suppressed (multi-class cap distortion
+    # #1662, or cross-currency FCF/price); ``points`` is then empty.
+    suppressed_reason: Literal["multiclass", "currency_mismatch"] | None
+    points: list[FcfYieldPoint]
 
 
 class CandleBar(BaseModel):
@@ -764,6 +783,62 @@ def get_instrument_financials(
         currency=None,
         source="unavailable",
         rows=[],
+    )
+
+
+@router.get("/{symbol}/fcf-yield", response_model=FcfYieldSeries)
+def get_instrument_fcf_yield(
+    symbol: str,
+    period: Literal["quarterly", "annual"] = Query(default="quarterly"),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> FcfYieldSeries:
+    """Per-period FCF-yield series for the fundamentals drill overlay (#671).
+
+    Single-class, currency-coherent issuers get the TTM-FCF / period-end-cap
+    trend. Multi-class issuers (the retired dual-class distortion #1662) and
+    cross-currency issuers (no FX normaliser) are fail-closed SUPPRESSED
+    (``suppressed_reason`` set, ``points`` empty); the FE keeps the absolute
+    FCF line + a caveat. Policy lives in app/services/fcf_yield.py.
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, symbol FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    result = fcf_yield_series(
+        conn,
+        instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
+        period=period,
+    )
+    return FcfYieldSeries(
+        symbol=str(inst_row["symbol"]),  # type: ignore[index]
+        suppressed_reason=result.suppressed_reason,
+        points=[
+            FcfYieldPoint(
+                period_end=row.period_end,
+                period_type=row.period_type,
+                fcf_ttm=row.fcf_ttm,
+                market_cap=row.market_cap,
+                fcf_yield_pct=row.fcf_yield_pct,
+                price=row.price,
+                price_as_of=row.price_as_of,
+            )
+            for row in result.rows
+        ],
     )
 
 

--- a/app/services/fcf_yield.py
+++ b/app/services/fcf_yield.py
@@ -1,0 +1,196 @@
+"""Per-period FCF-yield series for the fundamentals drill page (#671).
+
+FCF yield = TTM free cash flow / period-end market cap, rendered as a trend
+overlay on the absolute-FCF line (`/instrument/:symbol/fundamentals`).
+
+This module owns the fail-closed market-cap policy the frontend cannot
+reproduce (data-eng I20 / prevention-log #1664):
+
+  * **Multi-class issuers** — `close × combined_shares` is the structurally-wrong
+    figure #1662 retired. v1 does no per-period per-class reconstruction, so any
+    curated multi-class issuer (``resolve_market_cap_basis().basis !=
+    "not_multiclass"``) is SUPPRESSED, not approximated.
+  * **Cross-currency** — FCF is in ``financial_periods.reported_currency``; price
+    is the instrument's eToro trading currency (``instruments.currency``). With no
+    FX normaliser (sql/024 caveat), a proven mismatch is SUPPRESSED.
+
+Single-class, currency-coherent issuers get the per-period TTM yield:
+``fcf_ttm = SUM(operating_cf) − ABS(SUM(capex))`` over 4 consecutive normalized
+quarters (mirrors ``financial_periods_ttm`` sql/032:209 + the ABS(SUM) form at
+sql/080:78), divided by ``period_end_shares × period_end_close``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+import psycopg.rows
+
+from app.services.xbrl_derived_stats import resolve_market_cap_basis
+
+FcfYieldSuppression = Literal["multiclass", "currency_mismatch"]
+FinancialsPeriod = Literal["quarterly", "annual"]
+
+
+@dataclass(frozen=True)
+class FcfYieldRow:
+    period_end: date
+    period_type: str
+    fcf_ttm: Decimal | None
+    market_cap: Decimal | None
+    fcf_yield_pct: Decimal | None
+    price: Decimal | None
+    price_as_of: date | None
+
+
+@dataclass(frozen=True)
+class FcfYieldComputation:
+    suppressed_reason: FcfYieldSuppression | None
+    rows: list[FcfYieldRow]
+
+
+def fcf_yield_pct(fcf_ttm: Decimal | None, market_cap: Decimal | None) -> Decimal | None:
+    """FCF yield % = ``fcf_ttm / market_cap × 100``.
+
+    None when either input is absent or ``market_cap <= 0``. A NEGATIVE
+    ``fcf_ttm`` is preserved (a real negative yield — cash-burning issuer), never
+    clamped to zero: the operator needs to see it.
+    """
+    if fcf_ttm is None or market_cap is None or market_cap <= 0:
+        return None
+    return fcf_ttm / market_cap * 100
+
+
+# Per-period TTM over 4 consecutive normalized quarters. Mirrors
+# financial_periods_ttm (sql/032:209) but PER PERIOD via a trailing-row window;
+# adds a span guard financial_periods_ttm lacks, so a MISSING quarter (4 rows
+# spanning >~11 months) yields NULL rather than a silently-wrong 15-month "TTM".
+_QUARTERLY_SQL = """
+    WITH q AS (
+        SELECT
+            period_end_date, period_type, shares_outstanding,
+            SUM(operating_cf)    OVER w AS ocf_ttm,
+            SUM(capex)           OVER w AS capex_ttm,
+            COUNT(*)             OVER w AS n_q,
+            MIN(period_end_date) OVER w AS ttm_start
+        FROM financial_periods
+        WHERE instrument_id = %(iid)s
+          AND superseded_at IS NULL
+          AND normalization_status = 'normalized'
+          AND period_type IN ('Q1','Q2','Q3','Q4')
+        WINDOW w AS (ORDER BY period_end_date ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
+    )
+    SELECT
+        q.period_end_date, q.period_type, q.shares_outstanding,
+        CASE
+            WHEN q.n_q = 4 AND (q.period_end_date - q.ttm_start) <= 330
+            THEN q.ocf_ttm - ABS(COALESCE(q.capex_ttm, 0))
+            ELSE NULL
+        END AS fcf_ttm,
+        pd.close AS price, pd.price_date AS price_as_of
+    FROM q
+    LEFT JOIN LATERAL (
+        SELECT close, price_date FROM price_daily
+        WHERE instrument_id = %(iid)s
+          AND price_date <= q.period_end_date
+          AND close IS NOT NULL
+        ORDER BY price_date DESC
+        LIMIT 1
+    ) pd ON TRUE
+    ORDER BY q.period_end_date DESC
+    LIMIT 20
+"""
+
+# Annual: a FY row is already 12 months, so fcf = that row's own ocf − |capex|.
+_ANNUAL_SQL = """
+    SELECT
+        fp.period_end_date, fp.period_type, fp.shares_outstanding,
+        fp.operating_cf - ABS(COALESCE(fp.capex, 0)) AS fcf_ttm,
+        pd.close AS price, pd.price_date AS price_as_of
+    FROM financial_periods fp
+    LEFT JOIN LATERAL (
+        SELECT close, price_date FROM price_daily
+        WHERE instrument_id = %(iid)s
+          AND price_date <= fp.period_end_date
+          AND close IS NOT NULL
+        ORDER BY price_date DESC
+        LIMIT 1
+    ) pd ON TRUE
+    WHERE fp.instrument_id = %(iid)s
+      AND fp.superseded_at IS NULL
+      AND fp.normalization_status = 'normalized'
+      AND fp.period_type = 'FY'
+    ORDER BY fp.period_end_date DESC
+    LIMIT 20
+"""
+
+
+def _currency_mismatch(conn: psycopg.Connection[Any], instrument_id: int) -> bool:
+    """True only on a PROVEN mismatch — both currencies known and different.
+
+    A NULL trading currency (data gap) is NOT treated as a mismatch: over-
+    suppressing US instruments is worse for the operator than a rare undetected
+    foreign mismatch. The full-population verification (spec) reports the
+    mismatch count; reported_currency is NOT NULL (sql/032:121).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT i.currency AS trading_ccy,
+                   (SELECT reported_currency
+                    FROM financial_periods
+                    WHERE instrument_id = %(iid)s AND superseded_at IS NULL
+                      AND normalization_status = 'normalized'
+                    ORDER BY period_end_date DESC, filed_date DESC NULLS LAST
+                    LIMIT 1) AS reported_ccy
+            FROM instruments i
+            WHERE i.instrument_id = %(iid)s
+            """,
+            {"iid": instrument_id},
+        )
+        row = cur.fetchone()
+    if row is None:
+        return False
+    trading_ccy, reported_ccy = row
+    return trading_ccy is not None and reported_ccy is not None and trading_ccy != reported_ccy
+
+
+def fcf_yield_series(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    period: FinancialsPeriod,
+) -> FcfYieldComputation:
+    """Per-period FCF-yield series, or a suppression reason (empty rows)."""
+    if resolve_market_cap_basis(conn, instrument_id=instrument_id).basis != "not_multiclass":
+        return FcfYieldComputation(suppressed_reason="multiclass", rows=[])
+    if _currency_mismatch(conn, instrument_id):
+        return FcfYieldComputation(suppressed_reason="currency_mismatch", rows=[])
+
+    sql = _QUARTERLY_SQL if period == "quarterly" else _ANNUAL_SQL
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, {"iid": instrument_id})
+        db_rows = cur.fetchall()
+
+    rows: list[FcfYieldRow] = []
+    for r in db_rows:
+        shares = r["shares_outstanding"]
+        price = r["price"]
+        fcf_ttm = r["fcf_ttm"]
+        market_cap = shares * price if shares is not None and price is not None else None
+        rows.append(
+            FcfYieldRow(
+                period_end=r["period_end_date"],
+                period_type=str(r["period_type"]),
+                fcf_ttm=fcf_ttm,
+                market_cap=market_cap,
+                fcf_yield_pct=fcf_yield_pct(fcf_ttm, market_cap),
+                price=price,
+                price_as_of=r["price_as_of"],
+            )
+        )
+    return FcfYieldComputation(suppressed_reason=None, rows=rows)

--- a/app/services/fcf_yield.py
+++ b/app/services/fcf_yield.py
@@ -65,10 +65,18 @@ def fcf_yield_pct(fcf_ttm: Decimal | None, market_cap: Decimal | None) -> Decima
     return fcf_ttm / market_cap * 100
 
 
-# Per-period TTM over 4 consecutive normalized quarters. Mirrors
-# financial_periods_ttm (sql/032:209) but PER PERIOD via a trailing-row window;
-# adds a span guard financial_periods_ttm lacks, so a MISSING quarter (4 rows
-# spanning >~11 months) yields NULL rather than a silently-wrong 15-month "TTM".
+# Per-period TTM over 4 CONSECUTIVE normalized quarters. Mirrors
+# financial_periods_ttm (sql/032:209) but PER PERIOD via a trailing-row window,
+# plus a span guard financial_periods_ttm lacks.
+#
+# Span guard = 330 days. The (newest_end - oldest_end) span of 4 *consecutive*
+# quarter-ends is ~273-275 days (3 inter-quarter gaps; <=~280d even on 53-week
+# fiscal calendars — empirically max 275d across AAPL/MSFT/JPM/HD/GME on dev). A
+# MISSING quarter pulls a 4th quarter from the prior year, pushing the 4-row
+# window to ~364-365d. 330 cleanly separates the two: keeps every consecutive
+# window (>=50d margin) and NULLs the gap windows (a silently-wrong cross-year
+# "TTM"). A looser bound (e.g. 400) would ADMIT the 365d gap windows. Keep this
+# `330` in sync with the spec (docs/specs/fundamentals/2026-06-26-fcf-yield-trend.md).
 _QUARTERLY_SQL = """
     WITH q AS (
         SELECT

--- a/docs/specs/fundamentals/2026-06-26-fcf-yield-trend.md
+++ b/docs/specs/fundamentals/2026-06-26-fcf-yield-trend.md
@@ -1,0 +1,196 @@
+# FCF yield trend on the fundamentals drill page (#671)
+
+Parent epic: #585. Predecessor: #589 (shipped the absolute FCF line).
+Spec reviewed by Codex ckpt-1 (2026-06-26); 5 findings incorporated (currency
+guard, abs-capex breadth, TTM continuity, Decimal wire type, full-pop verify).
+
+## Goal
+
+Overlay an **FCF yield** trend on the existing absolute-FCF line on
+`/instrument/:symbol/fundamentals`. Operator reads "is this getting cheaper on
+cash flow?" at a glance. Tooltip shows both the quarterly FCF and the TTM yield.
+
+## Source rule
+
+1. **FCF = `operating_cf − |capex|`.** capex sign convention varies between
+   filers (prev-log "XBRL CapEx sign convention varies", #177) → `abs`. The TTM
+   view uses `ABS(SUM(capex))` (`sql/080:78-85`); the FE per-period builders do
+   raw subtraction (`fundamentalsMetrics.ts:246` FCF-YoY, `:454` buildFcf;
+   `dividendsMetrics.ts:153` payout FCF) — **fix all three** (prev:596 "apply to
+   both latest- and historical-snapshot builders").
+2. **Market cap = total-company basis, not `price × combined_shares`.**
+   Dual-class `close × combined_shares` is the figure #1662 retired (prev-log
+   "A SQL view cannot reproduce a fail-closed multi-step policy", #1664; data-eng
+   I20; `resolve_market_cap_basis` `app/services/xbrl_derived_stats.py:426`).
+   Fail-closed Python policy → cannot be reproduced client-side (issue's
+   "option A client-side join" rejected). Single-class (`not_multiclass`):
+   `period_end_close × period_end_shares` IS correct.
+3. **Yield is TTM.** Settled metric is TTM (`instrument_valuation.fcf_yield`).
+   Issue left quarterly semantics open → source-rule picks **trailing-4Q
+   consecutive** (mirrors `financial_periods_ttm` `sql/032:209-228`:
+   4 normalized quarters, `is_complete_ttm = COUNT(*)=4`). Annual periods use FY
+   FCF directly.
+4. **Currency: FCF and price must share a currency.** `financial_periods.
+   reported_currency` (sql/032:121, reporting currency) vs `instruments.currency`
+   (sql/001:6, eToro trading currency) — `sql/024:27-30` warns they differ for
+   non-US issuers and "must add explicit currency normalisation before
+   cross-currency comparison." v1 has no FX normaliser → **fail-closed suppress
+   on mismatch** (same posture as dual-class).
+
+## Scope (operator-approved 2026-06-26): single-class + USD-coherent now; suppress the rest
+
+Suppress the yield overlay (keep the absolute FCF line + a caveat) when EITHER:
+- `resolve_market_cap_basis().basis != "not_multiclass"` (any curated multi-class
+  issuer — incl. `total_company`, since v1 does **no** per-period per-class price
+  reconstruction, so its naive `combined_shares × this-class close` per-period
+  cap would be the retired distortion); OR
+- `reported_currency != instruments.currency` (cross-currency FCF/price).
+
+**Out of scope → follow-up ticket (filed at impl):** per-period dual-class
+reconstruction (Σ sibling `price_daily` × per-class FSDS shares + residual
+imputation + per-period guards) AND cross-currency FX normalisation.
+
+## Backend
+
+### Endpoint
+
+`GET /instruments/{symbol}/fcf-yield?period=quarterly|annual`
+(`app/api/instruments.py`, sibling of `/financials` `:698`). Read-only; no
+migration; reads existing `financial_periods` + `price_daily`.
+
+```python
+class FcfYieldPoint(BaseModel):
+    period_end: date
+    period_type: str               # Q1/Q2/Q3/Q4 (quarterly) | FY (annual)
+    fcf_ttm: Decimal | None        # trailing-4Q (quarterly) or FY (annual); ABS(SUM capex); null if continuity-incomplete
+    market_cap: Decimal | None     # period_end_shares × period_end_close; null if either missing
+    fcf_yield_pct: Decimal | None  # fcf_ttm / market_cap × 100; null if fcf_ttm null OR market_cap null/≤0
+    price: Decimal | None          # close at/before period_end
+    price_as_of: date | None       # the price_daily.price_date actually used
+
+class FcfYieldSeries(BaseModel):
+    symbol: str
+    suppressed_reason: Literal["multiclass", "currency_mismatch"] | None
+    points: list[FcfYieldPoint]    # [] when suppressed_reason is not None
+```
+
+### Service (`app/services/xbrl_derived_stats.py`, new `fcf_yield_series` helper)
+
+1. Resolve `instrument_id` from `symbol` (same path `/financials` uses).
+2. `resolve_market_cap_basis(conn, instrument_id=iid)`; if
+   `basis != "not_multiclass"` → `suppressed_reason="multiclass", points=[]`.
+3. Currency gate: latest `financial_periods.reported_currency` (per the
+   `MAX(...) FILTER (rn=1)` pattern, sql/032:267) vs `instruments.currency`;
+   mismatch → `suppressed_reason="currency_mismatch", points=[]`.
+4. **Quarterly** — single window query over `financial_periods` mirroring
+   `financial_periods_ttm` semantics, but per-period:
+
+```sql
+WITH q AS (
+    SELECT instrument_id, period_end_date, period_type, shares_outstanding,
+           operating_cf, capex,
+           SUM(operating_cf) OVER w  AS ocf_ttm,
+           SUM(capex)        OVER w  AS capex_ttm,
+           COUNT(*)          OVER w  AS n_q,
+           MIN(period_end_date) OVER w AS ttm_start
+    FROM financial_periods
+    WHERE instrument_id = %(iid)s AND superseded_at IS NULL
+      AND normalization_status = 'normalized'
+      AND period_type IN ('Q1','Q2','Q3','Q4')
+    WINDOW w AS (PARTITION BY instrument_id ORDER BY period_end_date
+                 ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
+)
+SELECT q.period_end_date, q.period_type, q.shares_outstanding,
+       CASE WHEN q.n_q = 4                                  -- 4 consecutive quarters present
+             AND q.period_end_date - q.ttm_start <= 400     -- ~12-month span guard (no gap)
+            THEN q.ocf_ttm - ABS(COALESCE(q.capex_ttm, 0))  -- mirror sql/080:78 ABS(SUM)
+            ELSE NULL END AS fcf_ttm,
+       pd.close AS price, pd.price_date AS price_as_of
+FROM q
+LEFT JOIN LATERAL (
+    SELECT close, price_date FROM price_daily
+    WHERE instrument_id = q.instrument_id
+      AND price_date <= q.period_end_date AND close IS NOT NULL
+    ORDER BY price_date DESC LIMIT 1
+) pd ON TRUE
+ORDER BY q.period_end_date DESC
+LIMIT 20
+```
+
+   **Annual** — same but `period_type='FY'`, `fcf_ttm = operating_cf -
+   ABS(COALESCE(capex,0))` per row (FY is already 12 months; no window).
+5. Per row: `market_cap = shares_outstanding × price` when both present else
+   null; `fcf_yield_pct = fcf_ttm / market_cap × 100` when `fcf_ttm` not null and
+   `market_cap > 0` else null. Extract this final arithmetic into a **pure
+   function** `_fcf_yield_pct(fcf_ttm, market_cap)` for table-testing (test-quality
+   skill: prefer pure policy).
+
+## Frontend
+
+### abs(capex) fix (prev:596) — 3 sites
+
+`fundamentalsMetrics.ts:246` (FCF-YoY), `:454` (buildFcf), `dividendsMetrics.ts:153`
+(payout FCF): `operating_cf - capex` → `operating_cf - Math.abs(capex)`. Update
+each comment. (Line/YoY/payout correctness; the yield's TTM FCF is server-side.)
+
+### Types + fetcher (api-shape-and-types skill)
+
+- `types.ts`: `FcfYieldPoint` + `FcfYieldSeries`. **Decimal → `string | null`**
+  on the wire (`fcf_ttm`, `market_cap`, `fcf_yield_pct`, `price`), per the repo
+  contract (types.ts:469 "Decimal|None → JSON string|null, never coerce to number
+  until the chart boundary"). `suppressed_reason: "multiclass" |
+  "currency_mismatch" | null`.
+- `instruments.ts`: `fetchFcfYield(symbol, {period})`.
+
+### Chart + page
+
+- `fundamentalsCharts.tsx:504` `FcfChart` → dual-axis `ComposedChart` (template
+  `DebtStructureChart:379-410`): absolute quarterly FCF on left Y (currency,
+  existing `buildFcf` line), `fcf_yield_pct` on right Y (%). Coerce the wire
+  `string` → number at this chart boundary only. Yield line `theme.accent[*]`
+  via `useChartTheme()` (never `lightTheme`, prev:1671). Shared `ChartTooltip`
+  (#1601): period, **FCF (quarter)**, **FCF yield (TTM)** — labelled distinctly
+  so the quarterly line and TTM yield don't read as the same number.
+- `FundamentalsPage.tsx:272` (comment already flags #671): 4th `useAsync`
+  (`fetchFcfYield`, independent lifecycle per async-data-loading skill), join
+  `fcf_yield_pct` by `period_end` into the chart series.
+- `suppressed_reason != null` → FCF line only + caveat
+  (`"FCF yield unavailable for multi-class issuers"` /
+  `"...when reporting and trading currencies differ"`). Loading/empty/error per
+  loading-error-empty-states skill (each `useAsync` owns one surface).
+
+### Tests
+
+- **pytest (pure):** `_fcf_yield_pct(fcf_ttm, market_cap)` table test — positive,
+  negative-FCF (negative yield renders, not clamped), null/zero/negative
+  market_cap → null.
+- **vitest:** the abs(capex) fix in all 3 builders; the server-points →
+  chart-series `period_end` join; suppression caveat rendering; empty-state gap
+  on null `fcf_yield_pct`.
+
+## Full-population verification (not a sample)
+
+Suppression safety is verified on the FULL population, not the smoke panel:
+
+- `SELECT DISTINCT source_cik FROM instrument_class_shares_outstanding` → for
+  every mapped instrument, assert the endpoint returns
+  `suppressed_reason="multiclass"` (no curated multi-class issuer ever emits a
+  naive yield).
+- `SELECT instrument_id FROM financial_periods fp JOIN instruments i USING
+  (instrument_id) WHERE fp.reported_currency <> i.currency` (latest period) →
+  assert `suppressed_reason="currency_mismatch"` for each.
+- Single-class sample (AAPL, MSFT, JPM, HD): yield renders; **GOOGL**:
+  suppressed+caveat. Cross-source one: AAPL latest TTM yield vs gurufocus +
+  `instrument_valuation.fcf_yield` (same order; small drift expected — ours uses
+  period-end close not live quote).
+- **Dev-verify** live `/instrument/AAPL/fundamentals` (overlay + tooltip both
+  figures) + `/instrument/GOOGL/fundamentals` (suppressed+caveat), light + dark.
+- No backfill/rebuild (read-only over existing tables).
+
+## Note on scope creep
+
+Issue #671 was filed as "the simplest drill (single metric)". The source-rule pass
+revealed it carries the most correctness weight in the cluster (dual-class cap +
+currency + TTM-continuity + capex-sign). The v1 fail-closed posture
+(suppress-on-uncertainty) keeps the **shipped operator surface** simple while
+staying correct; the deferred reconstruction work is isolated to the follow-up.

--- a/docs/specs/fundamentals/2026-06-26-fcf-yield-trend.md
+++ b/docs/specs/fundamentals/2026-06-26-fcf-yield-trend.md
@@ -102,7 +102,7 @@ WITH q AS (
 )
 SELECT q.period_end_date, q.period_type, q.shares_outstanding,
        CASE WHEN q.n_q = 4                                  -- 4 consecutive quarters present
-             AND q.period_end_date - q.ttm_start <= 400     -- ~12-month span guard (no gap)
+             AND q.period_end_date - q.ttm_start <= 330     -- gap guard: consecutive ~275d, missing-quarter ~365d
             THEN q.ocf_ttm - ABS(COALESCE(q.capex_ttm, 0))  -- mirror sql/080:78 ABS(SUM)
             ELSE NULL END AS fcf_ttm,
        pd.close AS price, pd.price_date AS price_as_of

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -1,6 +1,7 @@
 import { apiFetch } from "@/api/client";
 import type {
   CandleRange,
+  FcfYieldSeries,
   InstrumentCandles,
   InstrumentDetail,
   InstrumentFinancials,
@@ -484,6 +485,16 @@ export function fetchInstrumentFinancials(
   });
   return apiFetch<InstrumentFinancials>(
     `/instruments/${encodeURIComponent(symbol)}/financials?${params.toString()}`,
+  );
+}
+
+export function fetchFcfYield(
+  symbol: string,
+  query: { period: "quarterly" | "annual" },
+): Promise<FcfYieldSeries> {
+  const params = new URLSearchParams({ period: query.period });
+  return apiFetch<FcfYieldSeries>(
+    `/instruments/${encodeURIComponent(symbol)}/fcf-yield?${params.toString()}`,
   );
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -614,6 +614,25 @@ export interface InstrumentFinancials {
   rows: InstrumentFinancialRow[];
 }
 
+// FCF yield trend (#671). Decimals → string | null on the wire (coerce at the
+// chart boundary). `suppressed_reason` set → fail-closed (multi-class cap
+// distortion #1662 / cross-currency FCF↔price); `points` is then empty.
+export interface FcfYieldPoint {
+  period_end: string;
+  period_type: string;
+  fcf_ttm: string | null;
+  market_cap: string | null;
+  fcf_yield_pct: string | null;
+  price: string | null;
+  price_as_of: string | null;
+}
+
+export interface FcfYieldSeries {
+  symbol: string;
+  suppressed_reason: "multiclass" | "currency_mismatch" | null;
+  points: FcfYieldPoint[];
+}
+
 // ---------------------------------------------------------------------------
 // /portfolio (app/api/portfolio.py)
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/fundamentals/fundamentalsCharts.tsx
+++ b/frontend/src/components/fundamentals/fundamentalsCharts.tsx
@@ -30,6 +30,8 @@ import {
   YAxis,
 } from "recharts";
 
+import type { FcfYieldSeries } from "@/api/types";
+import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { type ChartTheme, lightTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import {
@@ -501,25 +503,109 @@ export function RoicChart({ periods }: PnlChartProps): JSX.Element {
 // 9. Free cash flow trend
 // ---------------------------------------------------------------------------
 
-export function FcfChart({ periods }: PnlChartProps): JSX.Element {
+interface FcfChartRow {
+  readonly period_end: string;
+  readonly fcf: number | null;
+  readonly fcf_yield_pct: number | null;
+}
+
+interface FcfTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload?: FcfChartRow }>;
+}
+
+function FcfTooltip({ active, payload }: FcfTooltipProps): JSX.Element | null {
+  if (active !== true || !payload || payload.length === 0) return null;
+  const row = payload[0]?.payload;
+  if (!row) return null;
+  return (
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">{formatPeriod(row.period_end)}</div>
+      <div className="tabular-nums text-slate-600 dark:text-slate-300">
+        FCF (quarter) {row.fcf !== null ? formatBigNumber(row.fcf) : "—"}
+      </div>
+      {row.fcf_yield_pct !== null ? (
+        <div className="tabular-nums text-slate-500 dark:text-slate-400">
+          FCF yield (TTM) {row.fcf_yield_pct.toFixed(2)}%
+        </div>
+      ) : null}
+    </ChartTooltip>
+  );
+}
+
+/**
+ * FCF (absolute, quarterly bars) + FCF yield (TTM, %) overlay (#671). The
+ * yield denominator (market cap) is a fail-closed server policy
+ * (`/instruments/{symbol}/fcf-yield`): multi-class (the retired dual-class
+ * distortion #1662) and cross-currency issuers come back `suppressed`, so the
+ * absolute line shows alone with a caveat. `yieldSeries` null = yield fetch in
+ * flight / errored — the absolute line still renders (supplementary signal,
+ * never blocks the FCF line).
+ */
+export function FcfChart({
+  periods,
+  yieldSeries,
+}: {
+  readonly periods: ReadonlyArray<JoinedPeriod>;
+  readonly yieldSeries: FcfYieldSeries | null;
+}): JSX.Element {
   const theme = useChartTheme();
   const f = buildFcf(periods);
   const hasData = f.some((r) => r.fcf !== null);
   if (!hasData) {
     return <NoData message="FCF needs operating cash flow and capex on the cash-flow statement." />;
   }
+  // Decimal arrives as a string on the wire (#671 / types.ts) — coerce to
+  // number at this chart boundary only.
+  const yieldByPeriod = new Map<string, number | null>();
+  for (const p of yieldSeries?.points ?? []) {
+    yieldByPeriod.set(p.period_end, p.fcf_yield_pct === null ? null : Number(p.fcf_yield_pct));
+  }
+  const data: FcfChartRow[] = f.map((r) => ({
+    period_end: r.period_end,
+    fcf: r.fcf,
+    fcf_yield_pct: yieldByPeriod.get(r.period_end) ?? null,
+  }));
+  const suppressed = yieldSeries?.suppressed_reason ?? null;
+  const hasYield = suppressed === null && data.some((r) => r.fcf_yield_pct !== null);
+  const caveat =
+    suppressed === "multiclass"
+      ? "FCF yield unavailable for multi-class issuers."
+      : suppressed === "currency_mismatch"
+        ? "FCF yield unavailable when reporting and trading currencies differ."
+        : null;
   return (
-    <div style={{ height: CHART_HEIGHT }} className="w-full">
-      <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={f} margin={{ top: 8, right: 8, left: 8, bottom: 4 }}>
-          <SharedGrid theme={theme} />
-          <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
-          <YAxis tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...sharedAxis(theme)} />
-          <ReferenceLine y={0} stroke={theme.borderColor} />
-          <Tooltip formatter={(value: number) => formatBigNumber(value)} labelFormatter={formatPeriod} contentStyle={{ fontSize: "11px" }} />
-          <Line type="monotone" dataKey="fcf" name="FCF" stroke={lightTheme.accent[1]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
-        </LineChart>
-      </ResponsiveContainer>
+    <div className="space-y-1">
+      <div style={{ height: CHART_HEIGHT }} className="w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={data} margin={{ top: 8, right: hasYield ? 32 : 8, left: 8, bottom: 4 }}>
+            <SharedGrid theme={theme} />
+            <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
+            <YAxis yAxisId="fcf" tickFormatter={(v: number) => formatBigNumber(v)} width={60} {...sharedAxis(theme)} />
+            {hasYield ? (
+              <YAxis yAxisId="yield" orientation="right" tickFormatter={(v: number) => `${v.toFixed(1)}%`} width={48} {...sharedAxis(theme)} />
+            ) : null}
+            <ReferenceLine yAxisId="fcf" y={0} stroke={theme.borderColor} />
+            <Tooltip content={<FcfTooltip />} cursor={{ stroke: theme.crosshair }} />
+            <Line yAxisId="fcf" type="monotone" dataKey="fcf" name="FCF" stroke={theme.accent[1]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
+            {hasYield ? (
+              <Line
+                yAxisId="yield"
+                type="monotone"
+                dataKey="fcf_yield_pct"
+                name="FCF yield (TTM)"
+                stroke={theme.accent[0]}
+                strokeWidth={1.5}
+                strokeDasharray="4 3"
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+              />
+            ) : null}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+      {caveat ? <p className="text-xs text-slate-500">{caveat}</p> : null}
     </div>
   );
 }

--- a/frontend/src/lib/dividendsMetrics.ts
+++ b/frontend/src/lib/dividendsMetrics.ts
@@ -152,7 +152,9 @@ function joinCashflow(
     .map((r) => {
       const op = num(r.values["operating_cf"]);
       const cx = num(r.values["capex"]);
-      const fcf = op !== null && cx !== null ? op - cx : null;
+      // capex sign convention varies between filers (prevention-log #596) —
+      // abs() to normalise, matching buildFcf + the TTM view (sql/080:78).
+      const fcf = op !== null && cx !== null ? op - Math.abs(cx) : null;
       const div = num(r.values["dividends_paid"]);
       // SEC XBRL `PaymentsOfDividends` is a positive outflow. Some
       // issuers under-report by emitting it as a negative number;

--- a/frontend/src/lib/fundamentalsMetrics.test.ts
+++ b/frontend/src/lib/fundamentalsMetrics.test.ts
@@ -387,4 +387,15 @@ describe("buildFcf", () => {
     );
     expect(buildFcf(periods)[0]!.fcf).toBeNull();
   });
+
+  it("normalises capex sign — abs() before subtracting (prevention-log #596)", () => {
+    const periods = joinStatements(
+      [],
+      [],
+      [row("2026", { operating_cf: "150", capex: "-40" }, "annual")],
+    );
+    // A filer reporting capex as a negative outflow must not INFLATE FCF:
+    // 150 - abs(-40) = 110, never 150 - (-40) = 190.
+    expect(buildFcf(periods)[0]!.fcf).toBe(110);
+  });
 });

--- a/frontend/src/lib/fundamentalsMetrics.ts
+++ b/frontend/src/lib/fundamentalsMetrics.ts
@@ -245,9 +245,10 @@ export function buildYoyGrowth(
     const prior = i >= lag ? periods[i - lag] : undefined;
     const fcf = (cur: JoinedPeriod): number | null => {
       if (cur.operating_cf === null || cur.capex === null) return null;
-      // capex is reported as a positive outflow in XBRL `us-gaap:
-      // PaymentsToAcquirePropertyPlantAndEquipment`. FCF subtracts it.
-      return cur.operating_cf - cur.capex;
+      // capex is XBRL `us-gaap:PaymentsToAcquirePropertyPlantAndEquipment`,
+      // normally a positive outflow — but the sign convention varies between
+      // filers (prevention-log #596), so abs() before subtracting.
+      return cur.operating_cf - Math.abs(cur.capex);
     };
     return {
       period_end: p.period_end,
@@ -442,9 +443,10 @@ export function buildRoic(periods: ReadonlyArray<JoinedPeriod>): RoicRow[] {
 
 export interface FcfRow {
   readonly period_end: string;
-  /** Free cash flow = operating_cf - capex. Both are absolute values
-   *  in the source statement; capex is XBRL `PaymentsToAcquirePPE`
-   *  reported as a positive outflow, so subtraction is correct. */
+  /** Free cash flow = operating_cf - |capex|. capex is XBRL
+   *  `PaymentsToAcquirePPE`, normally a positive outflow, but the sign
+   *  convention varies between filers (prevention-log #596) — abs() to
+   *  normalise, matching the TTM view (sql/080:78). */
   readonly fcf: number | null;
 }
 
@@ -453,7 +455,7 @@ export function buildFcf(periods: ReadonlyArray<JoinedPeriod>): FcfRow[] {
     period_end: p.period_end,
     fcf:
       p.operating_cf !== null && p.capex !== null
-        ? p.operating_cf - p.capex
+        ? p.operating_cf - Math.abs(p.capex)
         : null,
   }));
 }

--- a/frontend/src/pages/FundamentalsPage.tsx
+++ b/frontend/src/pages/FundamentalsPage.tsx
@@ -32,8 +32,8 @@
 import { useCallback, useMemo } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
-import { fetchInstrumentFinancials } from "@/api/instruments";
-import type { InstrumentFinancials } from "@/api/types";
+import { fetchFcfYield, fetchInstrumentFinancials } from "@/api/instruments";
+import type { FcfYieldSeries, InstrumentFinancials } from "@/api/types";
 import {
   SectionError,
   SectionSkeleton,
@@ -100,6 +100,14 @@ export function FundamentalsPage(): JSX.Element {
     ),
     [symbol, period],
   );
+  // Supplementary: the FCF-yield overlay (#671). Independent lifecycle — never
+  // gates the page or the absolute FCF line. Multi-class / cross-currency
+  // issuers come back `suppressed`; a fetch error just leaves the FCF line
+  // intact (the chart reads `yieldSeries` defensively).
+  const fcfYield = useAsync<FcfYieldSeries>(
+    useCallback(() => fetchFcfYield(symbol, { period }), [symbol, period]),
+    [symbol, period],
+  );
 
   const periods = useMemo(() => {
     if (income.data === null || balance.data === null || cashflow.data === null) {
@@ -135,6 +143,7 @@ export function FundamentalsPage(): JSX.Element {
     income.refetch();
     balance.refetch();
     cashflow.refetch();
+    fcfYield.refetch();
   }
 
   return (
@@ -269,11 +278,7 @@ export function FundamentalsPage(): JSX.Element {
             scope={periodScope(period)}
             source={{ providers: ["sec_xbrl"] }}
           >
-            {/* Spec calls for FCF *yield* (FCF / market cap) over time.
-                Yield needs price + shares-outstanding joined per
-                period; tracked at #671. The absolute FCF line ships
-                here so the trend is visible from day one. */}
-            <FcfChart periods={periods} />
+            <FcfChart periods={periods} yieldSeries={fcfYield.data} />
           </Pane>
         </div>
       )}

--- a/tests/services/test_fcf_yield.py
+++ b/tests/services/test_fcf_yield.py
@@ -1,0 +1,32 @@
+"""Pure-logic tests for the FCF-yield formula (#671).
+
+The yield arithmetic is the only branch-bearing pure policy in the FCF-yield
+path (the SQL window + suppression are exercised by dev-verify + the
+full-population check in the PR). Table-test it here (no DB, fast tier).
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.fcf_yield import fcf_yield_pct
+
+
+@pytest.mark.parametrize(
+    ("fcf_ttm", "market_cap", "expected"),
+    [
+        (Decimal("100"), Decimal("2000"), Decimal("5")),  # 100 / 2000 → 5%
+        (Decimal("-50"), Decimal("1000"), Decimal("-5")),  # negative FCF → negative yield, NOT clamped
+        (Decimal("0"), Decimal("1000"), Decimal("0")),  # zero FCF → 0%
+        (None, Decimal("1000"), None),  # missing FCF → None
+        (Decimal("100"), None, None),  # missing market cap → None
+        (Decimal("100"), Decimal("0"), None),  # zero market cap → None (no ZeroDivision)
+        (Decimal("100"), Decimal("-5"), None),  # negative market cap → None (fail-closed)
+    ],
+)
+def test_fcf_yield_pct(fcf_ttm: Decimal | None, market_cap: Decimal | None, expected: Decimal | None) -> None:
+    result = fcf_yield_pct(fcf_ttm, market_cap)
+    if expected is None:
+        assert result is None
+    else:
+        assert result == expected


### PR DESCRIPTION
## What

Per-period **FCF yield** overlay on the existing absolute-FCF line at `/instrument/:symbol/fundamentals`. New server endpoint `GET /instruments/{symbol}/fcf-yield?period=quarterly|annual` computes per-period TTM FCF ÷ period-end market cap; the FE renders it as a dual-axis overlay (FCF $ left, yield % right) with the shared `ChartTooltip` (#1601) showing both figures.

## Source rule (not reasoned from first principles)

- **FCF = `operating_cf − |capex|`** — capex sign convention varies between filers (prev-log #596). Fixed all 3 FE FCF builders (`buildFcf`, FCF-YoY, dividend payout); the yield's TTM FCF is server-side and abs-correct (mirrors `sql/080:78`).
- **Market cap = total-company basis, not `price × combined_shares`** — the dual-class distortion #1662 retired (data-eng I20, prev-log #1664). That fail-closed policy is a multi-step Python helper (`resolve_market_cap_basis`) that *cannot* be reproduced client-side, so the issue's recommended client-side `/candles` join was **rejected** for a server endpoint.
- **Yield is TTM** — trailing-4-consecutive-quarters (mirrors `financial_periods_ttm` `sql/032:209`, plus a span guard it lacks); annual periods use FY FCF.

## Scope (operator-approved) + fail-closed

v1 ships the yield for single-class, currency-coherent issuers and **suppresses** (absolute FCF line + caveat, `suppressed_reason` set, empty points) for:
- **multi-class** issuers (`basis != "not_multiclass"`) — v1 does no per-period per-class reconstruction, so the naive `combined_shares × this-class close` per-period cap would be the retired distortion;
- **cross-currency** issuers (`reported_currency != instruments.currency`) — no FX normaliser yet (sql/024 caveat).

Full reconstruction (per-period dual-class cap + FX) deferred → **#1745**.

## Premise correction

The issue recommended a client-side `FCF / (close × shares_outstanding)` join ("cheapest to ship"). Source-rule research falsified it: that reproduces the dual-class market-cap distortion (#1662) and the capex sign bug (#596). The correct figure needs the server-side fail-closed market-cap policy. Hence the server endpoint.

## Security model

No auth/authz surface — read-only endpoint over existing `financial_periods` + `price_daily`, **parameterised queries only** (no user input interpolated into SQL; `symbol` resolved via the same path `/financials` uses). No writes, no migration, no parser/schema change. The only "policy" is the fail-closed market-cap suppression, owned server-side (the FE cannot emit a naive cap).

## Files

- **Backend**: `app/services/fcf_yield.py` (pure `fcf_yield_pct` + trailing-4Q window query + suppression), `FcfYieldSeries`/`FcfYieldPoint` models + endpoint in `app/api/instruments.py`, `tests/services/test_fcf_yield.py`.
- **FE**: dual-axis `FcfChart` (`fundamentalsCharts.tsx`, shared `ChartTooltip` + `theme` tokens not `lightTheme`), `fetchFcfYield` + types (`Decimal → string|null`, coerced at the chart boundary), `FundamentalsPage` 4th independent `useAsync` (yield never blocks the FCF line), abs(capex) fixes in `fundamentalsMetrics.ts` + `dividendsMetrics.ts`.
- **Spec**: `docs/specs/fundamentals/2026-06-26-fcf-yield-trend.md`.

## Verification (CLAUDE.md clauses 8-12) — at `fc222bd0`

- **Gates**: ruff/format/pyright 0 errors; `pytest tests/services/test_fcf_yield.py` 7 passed; FE typecheck + `test:unit` 1077 passed + `dark:check` 0 violations. Pre-push hook green.
- **Smoke panel** (single-class): AAPL / MSFT / JPM / HD → 20 points each, yield renders.
- **Cross-source**: AAPL TTM FCF yield **1.41%** (FCF $51.55B / cap $3.65T, period-end close $248.78) — matches public ~1.4%.
- **FULL-POPULATION suppression** (not a sample): all 6 curated multi-class instruments (GOOG, GOOGL, HEI, HEI.A, METC, METCB) → `suppressed_reason=multiclass`, 0 points; 0 currency-mismatch instruments on dev (guard is a forward safety net).
- **Dev-verify live**: `/instrument/AAPL/fundamentals` — dual-axis overlay renders (right `%` axis 0–1.6%, FCF + yield lines). `/instrument/GOOGL/fundamentals` — FCF line only + caveat (dual axis correctly dropped to single line, verified via DOM). No backfill/rebuild (read-only endpoint).
- **Codex**: ckpt-1 (5 findings — currency guard, abs breadth, TTM continuity, Decimal wire type, full-pop verify — all fixed) + ckpt-2 (currency-gate normalized-row + caveat copy — both fixed).

Closes #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
