### PR TITLE
feat(#592): filings-analytics drill — density timeline + form-type heatmap

### DIFF
--- a/app/api/filings.py
+++ b/app/api/filings.py
@@ -69,6 +69,18 @@ class FilingsListResponse(BaseModel):
     limit: int
 
 
+class FilingQuarterCount(BaseModel):
+    quarter: str  # "YYYY-Qn"
+    filing_type: str
+    count: int
+
+
+class FilingQuarterlyCounts(BaseModel):
+    instrument_id: int
+    symbol: str | None
+    counts: list[FilingQuarterCount]
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -170,4 +182,59 @@ def list_filings(
         total=total,
         offset=offset,
         limit=limit,
+    )
+
+
+@router.get("/{instrument_id}/quarterly-counts", response_model=FilingQuarterlyCounts)
+def filing_quarterly_counts(
+    instrument_id: int,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    years: int = Query(default=5, ge=1, le=20),
+) -> FilingQuarterlyCounts:
+    """Per-(quarter, filing_type) filing counts over the last ``years`` years.
+
+    Feeds the filings-analytics drill (#592) — the density timeline + the
+    form-type heatmap. Aggregated server-side so the client never pulls the raw
+    filing rows (an active filer has hundreds of Form 4s alone, past the
+    /filings page cap); the small {quarter, filing_type, count} payload is
+    categorised + bucketed on the FE. ``red_flag_score`` is unpopulated across
+    the corpus, so the red-flag trend chart was deferred to #1748.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT symbol FROM instruments WHERE instrument_id = %(id)s",
+            {"id": instrument_id},
+        )
+        inst_row = cur.fetchone()
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail="Instrument not found")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT to_char(date_trunc('quarter', filing_date), 'YYYY-"Q"Q') AS quarter,
+                   filing_type,
+                   COUNT(*) AS count
+            FROM filing_events
+            WHERE instrument_id = %(id)s
+              AND filing_type IS NOT NULL
+              AND filing_date >= (CURRENT_DATE - make_interval(years => %(years)s))
+            GROUP BY 1, filing_type
+            ORDER BY 1, filing_type
+            """,
+            {"id": instrument_id, "years": years},
+        )
+        rows = cur.fetchall()
+
+    return FilingQuarterlyCounts(
+        instrument_id=instrument_id,
+        symbol=inst_row["symbol"],  # type: ignore[index]
+        counts=[
+            FilingQuarterCount(
+                quarter=str(r["quarter"]),
+                filing_type=str(r["filing_type"]),
+                count=int(r["count"]),
+            )
+            for r in rows
+        ],
     )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { InstrumentDetailRedirect } from "@/pages/InstrumentDetailRedirect";
 import { InstrumentPage } from "@/pages/InstrumentPage";
 import { Tenk10KDrilldownPage } from "@/pages/Tenk10KDrilldownPage";
 import { EightKListPage } from "@/pages/EightKListPage";
+import { FilingsAnalyticsPage } from "@/pages/FilingsAnalyticsPage";
 import { ChartPage } from "@/pages/ChartPage";
 import { RiskPage } from "@/pages/RiskPage";
 import { DividendsPage } from "@/pages/DividendsPage";
@@ -87,6 +88,10 @@ export function App() {
           <Route
             path="instrument/:symbol/filings/8-k"
             element={<EightKListPage />}
+          />
+          <Route
+            path="instrument/:symbol/filings/analytics"
+            element={<FilingsAnalyticsPage />}
           />
           <Route
             path="instrument/:symbol/dividends"

--- a/frontend/src/api/filings.ts
+++ b/frontend/src/api/filings.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "@/api/client";
-import type { FilingsListResponse } from "@/api/types";
+import type { FilingQuarterlyCounts, FilingsListResponse } from "@/api/types";
 
 export interface FetchFilingsOpts {
   readonly filing_type?: string;
@@ -20,5 +20,15 @@ export function fetchFilings(
   }
   return apiFetch<FilingsListResponse>(
     `/filings/${instrumentId}?${params.toString()}`,
+  );
+}
+
+export function fetchFilingQuarterlyCounts(
+  instrumentId: number,
+  years = 5,
+): Promise<FilingQuarterlyCounts> {
+  const params = new URLSearchParams({ years: String(years) });
+  return apiFetch<FilingQuarterlyCounts>(
+    `/filings/${instrumentId}/quarterly-counts?${params.toString()}`,
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1061,6 +1061,19 @@ export interface FilingsListResponse {
   limit: number;
 }
 
+// Per-(quarter, filing_type) counts for the filings-analytics drill (#592).
+export interface FilingQuarterCount {
+  quarter: string; // "YYYY-Qn"
+  filing_type: string;
+  count: number;
+}
+
+export interface FilingQuarterlyCounts {
+  instrument_id: number;
+  symbol: string | null;
+  counts: FilingQuarterCount[];
+}
+
 // ---------------------------------------------------------------------------
 // /news/{instrument_id} (app/api/news.py)
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/filings/filingsAnalyticsCharts.tsx
+++ b/frontend/src/components/filings/filingsAnalyticsCharts.tsx
@@ -1,0 +1,187 @@
+/**
+ * Charts for the filings-analytics drill (#592): a stacked filing-density
+ * timeline + a form-type heatmap. Both read the server's per-(quarter,
+ * filing_type) counts and EXCLUDE insider Forms (3/4/5/144) — routine,
+ * high-volume, and owned by the #588 insider drill.
+ */
+import { Fragment, type CSSProperties } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type { FilingQuarterCount } from "@/api/types";
+import { ChartTooltip } from "@/components/charts/ChartTooltip";
+import {
+  buildDensity,
+  buildHeatmap,
+  DENSITY_CATEGORIES,
+  type DensityCategory,
+  type DensityRow,
+} from "@/lib/filingsAnalytics";
+import { type ChartTheme } from "@/lib/chartTheme";
+import { useChartTheme } from "@/lib/useChartTheme";
+
+const CHART_HEIGHT = 280;
+
+/** Category → its accent slot (6 categories ↔ the 6-tuple `theme.accent`). */
+function categoryColor(theme: ChartTheme, category: DensityCategory): string {
+  const i = DENSITY_CATEGORIES.indexOf(category);
+  return theme.accent[i % theme.accent.length] ?? theme.primaryLine;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.replace("#", "");
+  const n = parseInt(h.length === 3 ? h.replace(/./g, "$&$&") : h, 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function NoFilings({ message }: { message: string }): JSX.Element {
+  return <p className="px-2 py-6 text-xs text-slate-500">{message}</p>;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Filing density timeline — stacked bars, count/quarter by material category
+// ---------------------------------------------------------------------------
+
+interface DensityTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload?: DensityRow }>;
+}
+
+function DensityTooltip({ active, payload }: DensityTooltipProps): JSX.Element | null {
+  if (active !== true || !payload || payload.length === 0) return null;
+  const row = payload[0]?.payload;
+  if (!row || row.total === 0) return null;
+  return (
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">{row.quarter}</div>
+      {DENSITY_CATEGORIES.filter((cat) => row[cat] > 0).map((cat) => (
+        <div key={cat} className="tabular-nums text-slate-600 dark:text-slate-300">
+          {cat} {row[cat]}
+        </div>
+      ))}
+      <div className="mt-0.5 tabular-nums font-medium text-slate-700 dark:text-slate-200">
+        Total {row.total}
+      </div>
+    </ChartTooltip>
+  );
+}
+
+export function FilingDensityChart({
+  counts,
+}: {
+  readonly counts: ReadonlyArray<FilingQuarterCount>;
+}): JSX.Element {
+  const theme = useChartTheme();
+  const data = buildDensity(counts);
+  if (data.length === 0 || data.every((r) => r.total === 0)) {
+    return <NoFilings message="No material company filings in the window." />;
+  }
+  return (
+    <div style={{ height: CHART_HEIGHT }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+          <CartesianGrid stroke={theme.gridLine} vertical={false} />
+          <XAxis
+            dataKey="quarter"
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            interval="preserveStartEnd"
+            minTickGap={16}
+          />
+          <YAxis
+            allowDecimals={false}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            width={32}
+          />
+          <Tooltip content={<DensityTooltip />} cursor={{ fill: theme.gridLine }} />
+          <Legend wrapperStyle={{ fontSize: "11px" }} />
+          {DENSITY_CATEGORIES.map((cat) => (
+            <Bar
+              key={cat}
+              dataKey={cat}
+              name={cat}
+              stackId="filings"
+              fill={categoryColor(theme, cat)}
+              isAnimationActive={false}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Form-type heatmap — categories × quarters, cell intensity by count
+// ---------------------------------------------------------------------------
+
+export function FilingHeatmapChart({
+  counts,
+}: {
+  readonly counts: ReadonlyArray<FilingQuarterCount>;
+}): JSX.Element {
+  const theme = useChartTheme();
+  const h = buildHeatmap(counts);
+  if (h.quarters.length === 0 || h.max === 0) {
+    return <NoFilings message="No material company filings to map." />;
+  }
+  // Per-category hue, opacity scaled by count / global-max so an unusual
+  // cluster (e.g. a hot 8-K quarter) stands out across the whole grid.
+  const cellStyle = (category: DensityCategory, count: number): CSSProperties => {
+    if (count === 0) return { backgroundColor: "transparent" };
+    const { r, g, b } = hexToRgb(categoryColor(theme, category));
+    const alpha = 0.15 + 0.85 * (count / h.max);
+    return { backgroundColor: `rgba(${r}, ${g}, ${b}, ${alpha})` };
+  };
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="grid gap-px"
+        style={{ gridTemplateColumns: `auto repeat(${h.quarters.length}, minmax(20px, 1fr))` }}
+      >
+        {/* header row: corner + quarter labels */}
+        <div />
+        {h.quarters.map((q) => (
+          <div
+            key={q}
+            className="text-center text-[9px] tabular-nums text-slate-500"
+            title={q}
+          >
+            {q.slice(2)}
+          </div>
+        ))}
+        {/* one row per category */}
+        {h.categories.map((cat) => (
+          <Fragment key={cat}>
+            <div className="pr-2 text-right text-[11px] text-slate-600 dark:text-slate-300">
+              {cat}
+            </div>
+            {h.quarters.map((q) => {
+              const n = h.get(cat, q);
+              return (
+                <div
+                  key={`${cat}|${q}`}
+                  className="h-5 rounded-sm border border-slate-100 dark:border-slate-800"
+                  style={cellStyle(cat, n)}
+                  title={`${cat} · ${q}: ${n}`}
+                />
+              );
+            })}
+          </Fragment>
+        ))}
+      </div>
+      <p className="mt-2 text-[10px] text-slate-400">
+        Cell shade ∝ filing count (peak {h.max}). Routine insider Form 3/4/5 excluded.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/FilingsPane.tsx
+++ b/frontend/src/components/instrument/FilingsPane.tsx
@@ -179,6 +179,14 @@ export function FilingsPane({
           })}
         </ul>
       )}
+      <div className="mt-2 border-t border-slate-100 dark:border-slate-800 pt-2 text-right">
+        <Link
+          to={`/instrument/${encodeURIComponent(symbol)}/filings/analytics`}
+          className="text-[11px] text-sky-700 hover:underline"
+        >
+          Filing analytics →
+        </Link>
+      </div>
     </Pane>
   );
 }

--- a/frontend/src/lib/filingsAnalytics.test.ts
+++ b/frontend/src/lib/filingsAnalytics.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDensity,
+  buildHeatmap,
+  categorizeFiling,
+  quarterRange,
+} from "@/lib/filingsAnalytics";
+import type { FilingQuarterCount } from "@/api/types";
+
+function c(quarter: string, filing_type: string, count: number): FilingQuarterCount {
+  return { quarter, filing_type, count };
+}
+
+describe("categorizeFiling", () => {
+  it("maps the real SEC filing_type values to chart categories", () => {
+    expect(categorizeFiling("10-K")).toBe("10-K");
+    expect(categorizeFiling("10-K/A")).toBe("10-K");
+    expect(categorizeFiling("10-Q")).toBe("10-Q");
+    expect(categorizeFiling("8-K")).toBe("8-K");
+    expect(categorizeFiling("8-K/A")).toBe("8-K");
+    expect(categorizeFiling("DEF 14A")).toBe("Proxy");
+    expect(categorizeFiling("DEFA14A")).toBe("Proxy");
+    expect(categorizeFiling("SC 13G/A")).toBe("13D/G");
+    expect(categorizeFiling("SCHEDULE 13D")).toBe("13D/G");
+    expect(categorizeFiling("3")).toBe("Insider");
+    expect(categorizeFiling("4")).toBe("Insider");
+    expect(categorizeFiling("4/A")).toBe("Insider");
+    expect(categorizeFiling("144")).toBe("Insider");
+    expect(categorizeFiling("424B2")).toBe("Other");
+    expect(categorizeFiling("6-K")).toBe("Other");
+  });
+});
+
+describe("quarterRange", () => {
+  it("fills the gap between earliest and latest quarter (inclusive)", () => {
+    expect(quarterRange(["2024-Q4", "2024-Q1"])).toEqual([
+      "2024-Q1",
+      "2024-Q2",
+      "2024-Q3",
+      "2024-Q4",
+    ]);
+  });
+  it("crosses a year boundary", () => {
+    expect(quarterRange(["2023-Q3", "2024-Q1"])).toEqual(["2023-Q3", "2023-Q4", "2024-Q1"]);
+  });
+  it("returns [] for no quarters", () => {
+    expect(quarterRange([])).toEqual([]);
+  });
+});
+
+describe("buildDensity", () => {
+  it("buckets by quarter, excludes insider, fills gaps, totals the shown categories", () => {
+    const rows = buildDensity([
+      c("2024-Q1", "8-K", 3),
+      c("2024-Q1", "10-Q", 1),
+      c("2024-Q1", "4", 9), // insider — excluded from shown counts + total
+      c("2024-Q3", "10-K", 1), // skips Q2 -> gap-filled to 0
+    ]);
+    expect(rows.map((r) => r.quarter)).toEqual(["2024-Q1", "2024-Q2", "2024-Q3"]);
+    const q1 = rows[0]!;
+    expect(q1["8-K"]).toBe(3);
+    expect(q1["10-Q"]).toBe(1);
+    expect(q1.total).toBe(4); // insider's 9 is NOT counted
+    const q2 = rows[1]!;
+    expect(q2.total).toBe(0); // gap-filled empty quarter
+    expect(rows[2]!["10-K"]).toBe(1);
+  });
+});
+
+describe("buildHeatmap", () => {
+  it("exposes per-cell counts + the max, excluding insider", () => {
+    const h = buildHeatmap([
+      c("2024-Q1", "8-K", 5),
+      c("2024-Q1", "4", 99), // insider — excluded, must not become max
+      c("2024-Q2", "8-K", 2),
+    ]);
+    expect(h.quarters).toEqual(["2024-Q1", "2024-Q2"]);
+    expect(h.get("8-K", "2024-Q1")).toBe(5);
+    expect(h.get("8-K", "2024-Q2")).toBe(2);
+    expect(h.get("10-K", "2024-Q1")).toBe(0);
+    expect(h.max).toBe(5); // not 99 (insider excluded)
+  });
+});

--- a/frontend/src/lib/filingsAnalytics.ts
+++ b/frontend/src/lib/filingsAnalytics.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure aggregation for the filings-analytics drill (#592). Consumes the
+ * server's per-(quarter, filing_type) counts (`/filings/{id}/quarterly-counts`)
+ * and shapes them for the density timeline + the form-type heatmap.
+ *
+ * Insider Forms (3/4/5/144) are categorised but EXCLUDED from both charts: they
+ * are routine and high-volume (an active issuer files hundreds of Form 4s,
+ * ~80% of the bar), which buries the material-filing pattern these charts exist
+ * to surface. Insider activity has its own drill (#588). The page shows a caveat.
+ */
+import type { FilingQuarterCount } from "@/api/types";
+
+/** Material-filing categories shown in both charts (insider excluded). */
+export const DENSITY_CATEGORIES = ["10-K", "10-Q", "8-K", "Proxy", "13D/G", "Other"] as const;
+export type DensityCategory = (typeof DENSITY_CATEGORIES)[number];
+export type FilingCategory = DensityCategory | "Insider";
+
+/** Map a raw SEC `filing_type` to a chart category. */
+export function categorizeFiling(filingType: string): FilingCategory {
+  const t = filingType.trim().toUpperCase();
+  if (t.startsWith("10-K")) return "10-K"; // 10-K, 10-K/A, 10-KSB
+  if (t.startsWith("10-Q")) return "10-Q"; // 10-Q, 10-Q/A
+  if (t.startsWith("8-K")) return "8-K"; // 8-K, 8-K/A
+  if (t.includes("14A")) return "Proxy"; // DEF 14A, DEFA14A, PRE 14A
+  if (t.includes("13D") || t.includes("13G")) return "13D/G"; // SC 13D/G, SCHEDULE 13D/G
+  if (t === "144" || /^[345](\/A)?$/.test(t)) return "Insider"; // Forms 3/4/5 (+/A), 144
+  return "Other"; // 424B*, 6-K, 20-F, S-1/S-3, NT, FWP, CORRESP, 11-K, ...
+}
+
+export interface DensityRow {
+  readonly quarter: string;
+  readonly "10-K": number;
+  readonly "10-Q": number;
+  readonly "8-K": number;
+  readonly Proxy: number;
+  readonly "13D/G": number;
+  readonly Other: number;
+  readonly total: number;
+}
+
+// "YYYY-Qn" <-> ordinal, for generating a gap-free quarter axis.
+function quarterOrdinal(q: string): number {
+  const [y, qq] = q.split("-Q");
+  return Number(y) * 4 + (Number(qq) - 1);
+}
+function ordinalToQuarter(o: number): string {
+  return `${Math.floor(o / 4)}-Q${(o % 4) + 1}`;
+}
+
+/** Continuous quarter axis from the earliest to the latest present quarter
+ *  (inclusive), so a quiet/empty quarter renders as a gap, not a skipped
+ *  column — clusters and droughts must read true. */
+export function quarterRange(quarters: ReadonlyArray<string>): string[] {
+  if (quarters.length === 0) return [];
+  const ords = quarters.map(quarterOrdinal);
+  const lo = Math.min(...ords);
+  const hi = Math.max(...ords);
+  const out: string[] = [];
+  for (let o = lo; o <= hi; o++) out.push(ordinalToQuarter(o));
+  return out;
+}
+
+function aggregate(
+  counts: ReadonlyArray<FilingQuarterCount>,
+): { byCell: Map<string, number>; axis: string[]; max: number } {
+  const byCell = new Map<string, number>(); // `${category}|${quarter}` -> count
+  const present = new Set<string>(); // all quarters with ANY filing (incl insider)
+  let max = 0;
+  for (const c of counts) {
+    present.add(c.quarter);
+    const cat = categorizeFiling(c.filing_type);
+    if (cat === "Insider") continue;
+    const key = `${cat}|${c.quarter}`;
+    const v = (byCell.get(key) ?? 0) + c.count;
+    byCell.set(key, v);
+    if (v > max) max = v;
+  }
+  return { byCell, axis: quarterRange([...present]), max };
+}
+
+export function buildDensity(counts: ReadonlyArray<FilingQuarterCount>): DensityRow[] {
+  const { byCell, axis } = aggregate(counts);
+  const at = (cat: DensityCategory, q: string): number => byCell.get(`${cat}|${q}`) ?? 0;
+  return axis.map((q) => {
+    const cells = {
+      "10-K": at("10-K", q),
+      "10-Q": at("10-Q", q),
+      "8-K": at("8-K", q),
+      Proxy: at("Proxy", q),
+      "13D/G": at("13D/G", q),
+      Other: at("Other", q),
+    };
+    const total = Object.values(cells).reduce((a, b) => a + b, 0);
+    return { quarter: q, ...cells, total };
+  });
+}
+
+export interface FilingHeatmap {
+  readonly quarters: string[];
+  readonly categories: readonly DensityCategory[];
+  /** Count for a (category, quarter) cell; 0 if none. */
+  readonly get: (category: DensityCategory, quarter: string) => number;
+  /** Largest single-cell count, for the colour scale (0 when empty). */
+  readonly max: number;
+}
+
+export function buildHeatmap(counts: ReadonlyArray<FilingQuarterCount>): FilingHeatmap {
+  const { byCell, axis, max } = aggregate(counts);
+  return {
+    quarters: axis,
+    categories: DENSITY_CATEGORIES,
+    get: (cat, q) => byCell.get(`${cat}|${q}`) ?? 0,
+    max,
+  };
+}

--- a/frontend/src/pages/FilingsAnalyticsPage.tsx
+++ b/frontend/src/pages/FilingsAnalyticsPage.tsx
@@ -1,0 +1,91 @@
+/**
+ * /instrument/:symbol/filings/analytics — filings-analytics drill (#592).
+ *
+ * Two charts over the server's per-(quarter, filing_type) counts
+ * (`/filings/{id}/quarterly-counts`): a stacked filing-density timeline + a
+ * form-type heatmap. The red-flag-score trend the issue also called for is
+ * deferred to #1748 — `red_flag_score` is unpopulated across the filings corpus.
+ */
+import { useCallback } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { fetchFilingQuarterlyCounts } from "@/api/filings";
+import { fetchInstrumentSummary } from "@/api/instruments";
+import type { FilingQuarterlyCounts } from "@/api/types";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import {
+  FilingDensityChart,
+  FilingHeatmapChart,
+} from "@/components/filings/filingsAnalyticsCharts";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+
+export function FilingsAnalyticsPage(): JSX.Element {
+  const { symbol = "" } = useParams<{ symbol: string }>();
+  const backHref = `/instrument/${encodeURIComponent(symbol)}`;
+
+  // The /filings endpoints are instrument_id-keyed; resolve :symbol → id via the
+  // summary, then pull the aggregated counts — one lifecycle, one error surface.
+  const counts = useAsync<FilingQuarterlyCounts>(
+    useCallback(
+      () =>
+        fetchInstrumentSummary(symbol).then((s) => fetchFilingQuarterlyCounts(s.instrument_id)),
+      [symbol],
+    ),
+    [symbol],
+  );
+
+  const isEmpty = counts.data !== null && counts.data.counts.length === 0;
+
+  return (
+    <div className="mx-auto max-w-screen-xl space-y-4 p-4">
+      <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
+        <Link to={backHref} className="text-xs text-sky-700 hover:underline">
+          ← Back to {symbol}
+        </Link>
+        <div className="mt-1 flex flex-wrap items-baseline justify-between gap-2">
+          <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Filing analytics — {symbol}
+          </h1>
+          <div className="flex items-center gap-2 text-xs">
+            <Link to={`${backHref}/filings/8-k`} className="text-sky-700 hover:underline">
+              8-K list →
+            </Link>
+            <Link to={`${backHref}/filings/10-k`} className="text-sky-700 hover:underline">
+              10-K list →
+            </Link>
+          </div>
+        </div>
+        <p className="mt-1 text-xs text-slate-500">
+          SEC filing cadence over the last 5 years, by quarter and form type. Spot the reporting
+          rhythm (10-K / 10-Q), event clusters (8-K), and ownership activity (13D/G). Routine
+          insider Form 3/4/5 is excluded — see the insider drill.
+        </p>
+      </header>
+
+      {counts.loading ? (
+        <SectionSkeleton rows={6} />
+      ) : counts.error !== null ? (
+        <SectionError onRetry={counts.refetch} />
+      ) : counts.data === null || isEmpty ? (
+        <EmptyState
+          title="No filings on record"
+          description="No SEC filing events for this instrument in the last 5 years — likely a non-US issuer or one without an SEC CIK."
+        >
+          <Link to={backHref} className="text-sm text-sky-700 hover:underline">
+            ← Back to {symbol}
+          </Link>
+        </EmptyState>
+      ) : (
+        <>
+          <Section title="Filing density — count per quarter by form type">
+            <FilingDensityChart counts={counts.data.counts} />
+          </Section>
+          <Section title="Form-type heatmap">
+            <FilingHeatmapChart counts={counts.data.counts} />
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

New drill page `/instrument/:symbol/filings/analytics` (sibling of `/filings/8-k`, `/filings/10-k`) with two charts over a new aggregation endpoint:

1. **Filing density timeline** — stacked bars, filing count per quarter by material form category (10-K, 10-Q, 8-K, Proxy, 13D/G, Other), last 5y.
2. **Form-type heatmap** — categories × quarters, cell shade ∝ count (per-category accent), to spot unusual patterns (e.g. an 8-K cluster).

L1: `FilingsPane` gets a "Filing analytics →" link.

## Premise corrections (the issue's "FE-only / existing endpoint sufficient" was falsified)

Verified on dev:
- **`red_flag_score` is NULL across all 2,716,023 `filing_events`** — never populated (the column, scoring thresholds, and InstrumentPage badge are all aspirational). The issue's 3rd chart (red-flag trend) has no data for any instrument → **dropped**; a real filings risk-scorer + the trend deferred to **#1748**.
- **`/filings` caps at `limit=200`, but AAPL has 365 filings/5y** — and shipping thousands of raw rows (Form 4 alone is 1.2M corpus-wide) to the client just to *count* them is wrong. So a small server-side count-by-quarter aggregation: **`GET /filings/{id}/quarterly-counts`** (GROUP BY quarter, filing_type; bounded `years`; parameterised). Routine insider Form 3/4/5/144 is **excluded** from both charts — high-volume (would be ~80% of every bar) and owned by the #588 insider drill.

## Security model

Read-only aggregation over `filing_events`; **parameterised query only** (`instrument_id`, bounded `years` ∈ [1,20]; no user input interpolated into SQL). No writes/migration/parser change. Symbol→instrument_id resolved via the existing summary fetch.

## Files

- **Backend**: `FilingQuarterCount`/`FilingQuarterlyCounts` + `GET /filings/{id}/quarterly-counts` in `app/api/filings.py`.
- **FE**: pure aggregation `lib/filingsAnalytics.ts` (+ table tests), charts `components/filings/filingsAnalyticsCharts.tsx` (shared `ChartTooltip` #1601 + `useChartTheme`), page `pages/FilingsAnalyticsPage.tsx`, route in `App.tsx`, `FilingsPane` link, `fetchFilingQuarterlyCounts` + types.

## Verification — at this commit

- **Gates**: ruff/format/pyright 0; FE typecheck + `test:unit` 1083 (+6 aggregation tests) + `dark:check` 216/0. Pre-push green.
- **Endpoint live**: AAPL → 105 aggregated rows / 20 quarters (2021-Q3 … 2026-Q2 = exactly 5y).
- **Page live** `/instrument/AAPL/filings/analytics`: density renders 6 stacked categories (legend 10-K/10-Q/8-K/Proxy/13D/G/Other) across 59 data cells; heatmap 120 cells / 59 shaded; "insider excluded" caveat shown; no error boundary.
- **Codex** ckpt-2: no issues (SQL / categorisation / aggregation / useAsync / dark-mode all validated).

Closes #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
