### PR TITLE
docs(#608): eToro WS carries no per-tick volume — defer live volume

### DIFF
--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -419,7 +419,20 @@ Response: `{"success": true/false, "errorCode": "...", "errorMessage": "..."}`
 }
 ```
 
-Rate message fields: `Ask`, `Bid`, `LastExecution`, `Date` (ISO 8601), `PriceRateID`
+Rate message fields: `Ask`, `Bid`, `LastExecution`, `Date` (ISO 8601),
+`PriceRateID`, plus margin-derived prices (`NewUnitMargin`, `UnitMarginAsk`,
+`UnitMarginBid`, `BidDiscounted`, `AskDiscounted`,
+`UnitMarginBidDiscounted`, `UnitMarginAskDiscounted`).
+
+**No volume / size / quantity field exists on any WS topic** (#608, verified
+2026-06-27 against both api-portal `/websocket/topics` and
+`websocket-doc.html`). eToro's WS has exactly two topics — `instrument:<id>`
+(rate) and `private` (order/position) — and neither carries per-trade or
+per-tick volume. There is **no** `Trading.Instrument.Trade` topic. The only
+volume eToro exposes is the **per-bar** `volume` field on the REST candles
+endpoint (cumulative for the in-progress bar). Live intraday volume on the
+chart would therefore require polling candles, not the WS — out of #608 scope,
+deferred.
 
 ### Subscribe to private channel (order/position updates)
 
@@ -443,9 +456,12 @@ with fields: `OrderID`, `StatusID`, `InstrumentID`, `ExecutedUnits`,
 
 ### eBull WebSocket status
 
-Not yet implemented. Planned for live price streaming (alternative to polling
-`/instruments/rates`). Would eliminate the 1.1s throttle overhead for
-real-time dashboard updates.
+Implemented (`app/services/etoro_websocket.py`, #274). Live price streaming via
+`instrument:<id>` (rate fan-out to SSE `/sse/quotes`) + `private` (debounced
+portfolio reconcile), with a 5s REST `/instruments/rates` poll as a freshness
+floor. Live in-progress-bar OHLC rides this stream (#602); **volume stays
+static** because the WS push carries no volume (#607/#608 — see rate-fields
+note above).
 
 ---
 


### PR DESCRIPTION
## What
Bounded investigation for #608 (parent epic #585). Records the finding + corrects a stale status note. **Docs-only, zero code.**

## Finding — premise falsified
#608 hypothesised a WS `Trading.Instrument.Trade` (or equivalent) topic carrying per-tick volume. Verified against the **source contract**:
- api-portal `/api-reference/websocket/topics`
- `websocket-doc.html`
- repo `docs/etoro-api-reference.md` + project memory

All agree: eToro's WS exposes **exactly two topics** — `instrument:<id>` (`Trading.Instrument.Rate`) and `private` — and **neither carries volume / size / quantity**. There is **no** `Trading.Instrument.Trade` topic. Full rate field set is Ask/Bid/LastExecution/Date/PriceRateID + margin-derived prices; none is volume.

## Consequence
The #607 limitation stands: the chart's in-progress bar keeps **static** volume. The WS cannot drive a live volume bar. The only volume eToro exposes is the **per-bar** `volume` on the REST candles endpoint (cumulative for the in-progress bar) — live intraday volume would require **polling candles**, a different and larger mechanism, out of #608's WS scope. Deferred; that REST-candles path is the reopening condition.

## Changes
- `docs/etoro-api-reference.md`: full WS rate field list + explicit "no volume on any WS topic (#608)" note; corrected the stale "WebSocket: not yet implemented" status (shipped in #274).

## Verification
No code path touched. Finding cross-checked against two independent official eToro doc URLs (quoted in the doc diff).

Closes #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)