### PR TITLE
fix(#1747): retry-wrap PyPI-fetch CI steps against transient download flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,14 @@ jobs:
 
       - name: Install uv
         # Pinned so CI / local dev / supply-chain audit see the
-        # same resolver behavior across runs.
-        run: pip install "uv==0.5.21"
+        # same resolver behavior across runs. Retry-wrapped (#1747): a
+        # transient PyPI/CDN fetch error otherwise fails the job.
+        run: bash scripts/ci_retry.sh pip install "uv==0.5.21"
 
       - name: Install dependencies
-        run: uv sync --group dev
+        # Retry-wrapped (#1747): uv sync downloads wheels from PyPI; a
+        # broken-pipe/reset mid-download is transient (PR #1744/#1746).
+        run: bash scripts/ci_retry.sh uv sync --group dev
 
       - name: Ruff lint
         run: uv run ruff check .
@@ -226,7 +229,8 @@ jobs:
         # uv pinned for resolver determinism (matches the lint/pytest
         # jobs above); pip-audit floats so we always hit the latest
         # advisory database — pinning that would defeat the gate.
-        run: pip install "uv==0.5.21" pip-audit
+        # Retry-wrapped (#1747): transient PyPI fetch.
+        run: bash scripts/ci_retry.sh pip install "uv==0.5.21" pip-audit
 
       - name: Export Python lockfile to requirements.txt
         # GitHub's default ``bash -e`` does not reliably run process
@@ -291,13 +295,14 @@ jobs:
 
       - name: Install uv
         # Pinned to match the sibling ``lint`` + ``supply-chain`` jobs.
-        run: pip install "uv==0.5.21"
+        # Retry-wrapped (#1747): transient PyPI fetch.
+        run: bash scripts/ci_retry.sh pip install "uv==0.5.21"
 
       - name: Install dependencies
         # ``pyyaml`` (load floors.yaml + manifest.yaml) is already in
         # the dev group via uv.lock; use uv sync for parity with the
-        # local pre-push hook + sibling CI jobs.
-        run: uv sync --group dev
+        # local pre-push hook + sibling CI jobs. Retry-wrapped (#1747).
+        run: bash scripts/ci_retry.sh uv sync --group dev
 
       - name: Perf-claim artifact lint
         # All untrusted PR inputs are bound via env, not interpolated

--- a/scripts/ci_retry.sh
+++ b/scripts/ci_retry.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# #1747 — retry a flaky network command with linear backoff.
+#
+# Why: the CI Python toolchain bootstrap (`pip install uv`, `uv sync`)
+# fetches wheels from PyPI/CDN with no retry. A transient fetch error
+# (broken pipe, connection reset) fails the whole job and needs a manual
+# `gh run rerun --failed`. Observed on PR #1744 (lxml download) and PR
+# #1746 (httptools download) in consecutive sessions. Wrapping the fetch
+# steps in this retry turns a one-in-N CDN hiccup into a non-event.
+#
+# Usage: scripts/ci_retry.sh <command> [args...]
+# Env:
+#   CI_RETRY_ATTEMPTS  total attempts before giving up (default 3)
+#   CI_RETRY_DELAY     base backoff seconds; delay = DELAY * attempt# (default 5)
+#
+# On final failure the original command's exit status is propagated, so
+# the CI step still fails red on a genuine (non-transient) error.
+set -euo pipefail
+
+attempts="${CI_RETRY_ATTEMPTS:-3}"
+delay="${CI_RETRY_DELAY:-5}"
+
+if [[ $# -eq 0 ]]; then
+  echo "::error::ci_retry.sh requires a command to run" >&2
+  exit 2
+fi
+
+# Validate the tunables up front: a non-integer would make the arithmetic
+# below abort under `set -e` with a cryptic message (Codex #1747).
+if ! [[ $attempts =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::CI_RETRY_ATTEMPTS must be a positive integer (got '${attempts}')" >&2
+  exit 2
+fi
+if ! [[ $delay =~ ^[0-9]+$ ]]; then
+  echo "::error::CI_RETRY_DELAY must be a non-negative integer (got '${delay}')" >&2
+  exit 2
+fi
+
+n=1
+while true; do
+  status=0
+  "$@" || status=$?
+  if [[ $status -eq 0 ]]; then
+    exit 0
+  fi
+  if [[ $n -ge $attempts ]]; then
+    echo "::error::command failed after ${attempts} attempts (exit ${status}): $*" >&2
+    exit "$status"
+  fi
+  echo "::warning::attempt ${n}/${attempts} failed (exit ${status}); retrying in $((delay * n))s: $*" >&2
+  sleep "$((delay * n))"
+  n=$((n + 1))
+done


### PR DESCRIPTION
## What
The `lint`, `supply-chain`, and `perf-claim-lint` CI jobs run `pip install uv` / `uv sync` with no retry or cache. A transient PyPI/CDN fetch error fails the whole job and needs a manual `gh run rerun --failed`.

Observed twice this session:
- PR #1744 — `Failed to download lxml==6.1.0 ... broken pipe`
- PR #1746 — `Failed to download httptools==0.7.1 ... connection error / broken pipe`

## Change
- **New** `scripts/ci_retry.sh` — linear-backoff retry wrapper (default 3 attempts, 5s base; `delay = base * attempt#`). Propagates the original command exit on final failure, so a genuine error still fails red. Emits `::warning::`/`::error::` GitHub annotations so flake-vs-real is visible in the run UI. Validates `CI_RETRY_ATTEMPTS` / `CI_RETRY_DELAY` (positive / non-negative integer) up front.
- Wrapped the **5 PyPI-fetch steps** across the 3 jobs (`pip install uv` ×3, `uv sync` ×2).

Chose retry (issue option b) over `actions/cache` (option a): cache still cold-fetches on any `uv.lock` change and would still flake on that run; retry covers cold and warm paths and is a smaller, mechanism-preserving diff (keeps the pinned `uv==0.5.21` determinism comment intact).

## Security model
`ci_retry.sh` takes its command as positional args (`"$@"`) — no shell-string interpolation, no eval. All call sites pass static literals (`pip install "uv==0.5.21"`, `uv sync --group dev`); no untrusted GitHub-event input reaches the wrapper. Annotation messages echo `$*` (the static args only) — no secrets at these call sites.

## Conscious tradeoff
Retries **every** nonzero exit, not only network errors. A deterministic failure (resolver conflict, tool bug) therefore costs ~15s of backoff before going red. Accepted: matching uv's transient error classes by message is brittle, and the wrapper is scoped to bootstrap steps where the only realistic transient is the fetch. Final exit code is always preserved — no red-to-green masking.

## Verification
- `scripts/check_shellcheck.sh` — clean (script is `-S warning` clean).
- `scripts/check_ci_mirrors_prepush.sh` — parity OK (22 lints; `ci_retry` is not a `check_*` lint, outside the mirror set by design).
- `ruff check` / `ruff format --check` — clean.
- Self-tested locally: success passthrough, retry-then-fail exit propagation, transient-then-recover, no-arg guard (exit 2), non-integer tunable guards (exit 2).

No Python/app code touched.

Closes #1747.