### PR TITLE
feat(#1751): peer-comparison data layer (sector medians + peer set + revenue_growth_yoy)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -58,6 +58,13 @@ from app.services.operators import (
     NoOperatorError,
     sole_operator_id,
 )
+from app.services.peer_comparison import (
+    DEV_LIMITED_FACTORS,
+    FACTOR_BETTER_WHEN,
+    FACTOR_KEYS,
+    FACTOR_LABELS,
+    compute_peer_comparison,
+)
 from app.services.portfolio_risk import (
     PortfolioRiskStatus,
     compute_portfolio_relative_risk,
@@ -265,6 +272,37 @@ class FcfYieldSeries(BaseModel):
     # #1662, or cross-currency FCF/price); ``points`` is then empty.
     suppressed_reason: Literal["multiclass", "currency_mismatch"] | None
     points: list[FcfYieldPoint]
+
+
+class PeerFactor(BaseModel):
+    """One radar factor: the instrument's value vs its sector median (#1751)."""
+
+    key: str
+    label: str
+    instrument_value: float | None
+    sector_median: float | None
+    sector_n: int  # # sector members with a non-null value for this factor
+    dev_limited: bool  # True for price-gated factors (P/E) — thin on dev
+    better_when: Literal["higher", "lower"]
+
+
+class PeerInstrument(BaseModel):
+    """A sector peer with its factor row (for the #594 heatmap)."""
+
+    instrument_id: int
+    symbol: str
+    company_name: str | None
+    size_proxy: float | None  # total_assets (peer-proximity ranking key)
+    factors: dict[str, float | None]
+
+
+class PeerComparison(BaseModel):
+    symbol: str
+    instrument_id: int
+    sector: str  # raw code "1".."9" (instruments.sector is TEXT; no lookup table)
+    sector_member_count: int  # complete-TTM members in the sector (median base)
+    factors: list[PeerFactor]
+    peers: list[PeerInstrument]
 
 
 class CandleBar(BaseModel):
@@ -872,6 +910,76 @@ def get_instrument_fcf_yield(
                 price_as_of=row.price_as_of,
             )
             for row in result.rows
+        ],
+    )
+
+
+@router.get("/{symbol}/peer-comparison", response_model=PeerComparison)
+def get_instrument_peer_comparison(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> PeerComparison:
+    """Peer-comparison data for the #594 radar + sector heatmap (#1751).
+
+    Per instrument: the radar factors (P/E, ROE, revenue growth YoY, operating
+    margin, debt/equity, net margin), their sector medians, and a size-proximity
+    peer set — all derived server-side from existing fundamentals (no new
+    ingest). P/E is ``dev_limited`` (price-gated). 404 when the instrument has no
+    sector classification or no complete-TTM fundamentals. Policy lives in
+    app/services/peer_comparison.py.
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id FROM instruments
+            WHERE UPPER(symbol) = %(s)s
+            ORDER BY is_primary_listing DESC, instrument_id ASC
+            LIMIT 1
+            """,
+            {"s": symbol_clean},
+        )
+        inst_row = cur.fetchone()
+
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+
+    result = compute_peer_comparison(conn, instrument_id=int(inst_row["instrument_id"]))  # type: ignore[arg-type]
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No peer-comparison data for {symbol} (no sector classification or no complete-TTM fundamentals)",
+        )
+
+    return PeerComparison(
+        symbol=result.symbol,
+        instrument_id=result.instrument_id,
+        sector=result.sector,
+        sector_member_count=result.sector_member_count,
+        factors=[
+            PeerFactor(
+                key=key,
+                label=FACTOR_LABELS[key],
+                instrument_value=result.self_factors.get(key),
+                sector_median=result.medians[key].median,
+                sector_n=result.medians[key].n,
+                dev_limited=key in DEV_LIMITED_FACTORS,
+                better_when=FACTOR_BETTER_WHEN[key],  # type: ignore[arg-type]
+            )
+            for key in FACTOR_KEYS
+        ],
+        peers=[
+            PeerInstrument(
+                instrument_id=p.instrument_id,
+                symbol=p.symbol,
+                company_name=p.company_name,
+                size_proxy=p.total_assets,
+                factors=p.factors,
+            )
+            for p in result.peers
         ],
     )
 

--- a/app/services/peer_comparison.py
+++ b/app/services/peer_comparison.py
@@ -1,0 +1,253 @@
+"""
+Peer-comparison data layer (#1751) — unblocks #594.
+
+Derives, per instrument, the radar factors (P/E, ROE, revenue growth YoY,
+operating margin, debt/equity, net margin), their sector medians, and a peer
+set — entirely from EXISTING tables (no new ingest):
+
+  * price-free factors from ``financial_periods_ttm`` (is_complete_ttm),
+  * ``pe_ratio`` from the ``instrument_valuation`` view (price-gated → thin on
+    dev; flagged ``dev_limited`` by the caller),
+  * ``revenue_growth_yoy`` from the two most recent canonical FY rows in
+    ``financial_periods``, with a consecutive-year day-gap guard,
+  * sector medians via ``percentile_cont`` over the sector's complete-TTM set,
+  * peer set = same sector, nearest by size proximity (``total_assets``;
+    market cap is price-gated so unusable broadly).
+
+Factor formulas MIRROR ``instrument_valuation`` (sql/201) — do not re-derive.
+The view's ~32-row ceiling is its live-price join; bypassed here by reading
+``financial_periods_ttm`` directly for the price-free factors.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import psycopg
+from psycopg.rows import dict_row
+
+_PEER_LIMIT = 8
+
+# Factor keys in #594 radar order. Each: (key, label, better_when).
+FACTOR_KEYS: tuple[str, ...] = (
+    "pe_ratio",
+    "roe",
+    "revenue_growth_yoy",
+    "operating_margin",
+    "debt_equity_ratio",
+    "net_margin",
+)
+FACTOR_LABELS: dict[str, str] = {
+    "pe_ratio": "P/E (TTM)",
+    "roe": "ROE",
+    "revenue_growth_yoy": "Revenue growth YoY",
+    "operating_margin": "Operating margin",
+    "debt_equity_ratio": "Debt / equity",
+    "net_margin": "Net margin",
+}
+# "higher" = a larger value is better for a long investor; "lower" = smaller is
+# better (cheaper / less levered).
+FACTOR_BETTER_WHEN: dict[str, str] = {
+    "pe_ratio": "lower",
+    "roe": "higher",
+    "revenue_growth_yoy": "higher",
+    "operating_margin": "higher",
+    "debt_equity_ratio": "lower",
+    "net_margin": "higher",
+}
+# pe_ratio is price-gated (instrument_valuation live-price join) → dev-limited.
+DEV_LIMITED_FACTORS: frozenset[str] = frozenset({"pe_ratio"})
+
+# Per-instrument factor CTE, parameterised by ``%(sector)s``. Mirrors the
+# instrument_valuation formulas (sql/201) for the price-free factors; LEFT JOINs
+# instrument_valuation for pe_ratio and the YoY CTE for revenue growth.
+_FACTORS_CTE = """
+WITH yoy AS (
+    SELECT instrument_id,
+           (cur_rev - prev_rev) / prev_rev AS revenue_growth_yoy
+    FROM (
+        SELECT instrument_id,
+               revenue AS cur_rev,
+               period_end_date AS cur_end,
+               LEAD(revenue) OVER w AS prev_rev,
+               LEAD(period_end_date) OVER w AS prev_end,
+               ROW_NUMBER() OVER w AS rn
+        FROM financial_periods
+        WHERE period_type = 'FY'
+          AND revenue > 0
+          AND superseded_at IS NULL
+          AND normalization_status = 'normalized'
+        WINDOW w AS (PARTITION BY instrument_id ORDER BY period_end_date DESC)
+    ) s
+    WHERE rn = 1
+      AND prev_rev IS NOT NULL
+      AND prev_rev > 0
+      -- consecutive-year guard: the two most recent FY ends must be ~12mo
+      -- apart, else the "YoY" spans a multi-year gap (e.g. GME: FY2025/FY2020).
+      AND (cur_end - prev_end) BETWEEN 300 AND 430
+),
+factors AS (
+    SELECT
+        t.instrument_id,
+        i.symbol,
+        i.company_name,
+        t.total_assets,
+        CASE WHEN t.revenue_ttm > 0
+             THEN t.operating_income_ttm / t.revenue_ttm END AS operating_margin,
+        CASE WHEN t.revenue_ttm > 0
+             THEN t.net_income_ttm / t.revenue_ttm END AS net_margin,
+        CASE WHEN t.shareholders_equity > 0
+             THEN t.net_income_ttm / t.shareholders_equity END AS roe,
+        CASE WHEN t.shareholders_equity > 0
+             THEN (COALESCE(t.long_term_debt, 0) + COALESCE(t.short_term_debt, 0))
+                  / t.shareholders_equity END AS debt_equity_ratio,
+        v.pe_ratio,
+        y.revenue_growth_yoy
+    FROM financial_periods_ttm t
+    JOIN instruments i USING (instrument_id)
+    LEFT JOIN instrument_valuation v USING (instrument_id)
+    LEFT JOIN yoy y ON y.instrument_id = t.instrument_id
+    WHERE t.is_complete_ttm = TRUE
+      AND i.sector = %(sector)s
+)
+"""
+
+
+@dataclass(frozen=True)
+class PeerRow:
+    instrument_id: int
+    symbol: str
+    company_name: str | None
+    total_assets: float | None
+    factors: dict[str, float | None]
+
+
+@dataclass(frozen=True)
+class FactorMedian:
+    median: float | None
+    n: int
+
+
+@dataclass(frozen=True)
+class PeerComparisonResult:
+    instrument_id: int
+    symbol: str
+    sector: str
+    sector_member_count: int
+    self_factors: dict[str, float | None]
+    medians: dict[str, FactorMedian]
+    peers: list[PeerRow]
+
+
+def _row_factors(row: dict[str, object]) -> dict[str, float | None]:
+    out: dict[str, float | None] = {}
+    for key in FACTOR_KEYS:
+        val = row.get(key)
+        out[key] = float(val) if val is not None else None  # type: ignore[arg-type]
+    return out
+
+
+def _rank_peers(
+    rows: list[dict[str, object]],
+    *,
+    self_id: int,
+    self_total_assets: float,
+    limit: int,
+) -> list[PeerRow]:
+    """
+    Pick the ``limit`` nearest same-sector peers by log-size proximity.
+
+    Pure (no I/O): excludes self, drops rows with non-positive ``total_assets``,
+    orders by ``|ln(peer.total_assets) - ln(self_total_assets)|``. Ties break on
+    instrument_id for determinism.
+    """
+    candidates = [
+        r
+        for r in rows
+        if int(r["instrument_id"]) != self_id  # type: ignore[arg-type]
+        and r["total_assets"] is not None
+        and float(r["total_assets"]) > 0  # type: ignore[arg-type]
+    ]
+    target = math.log(self_total_assets)
+    candidates.sort(
+        key=lambda r: (abs(math.log(float(r["total_assets"])) - target), int(r["instrument_id"]))  # type: ignore[arg-type]
+    )
+    return [
+        PeerRow(
+            instrument_id=int(r["instrument_id"]),  # type: ignore[arg-type]
+            symbol=str(r["symbol"]),
+            company_name=(str(r["company_name"]) if r["company_name"] is not None else None),
+            total_assets=float(r["total_assets"]),  # type: ignore[arg-type]
+            factors=_row_factors(r),
+        )
+        for r in candidates[:limit]
+    ]
+
+
+def compute_peer_comparison(
+    conn: psycopg.Connection[object],
+    instrument_id: int,
+) -> PeerComparisonResult | None:
+    """
+    Build the peer-comparison payload, or ``None`` when the instrument has no
+    sector classification or no complete-TTM fundamentals (caller 404s).
+    """
+    with conn.cursor(row_factory=dict_row) as cur:
+        # 1. sector (TEXT code "1".."9"); None → no classification.
+        cur.execute(
+            "SELECT sector FROM instruments WHERE instrument_id = %(id)s",
+            {"id": instrument_id},
+        )
+        srow = cur.fetchone()
+        if srow is None or srow["sector"] is None:
+            return None
+        sector = str(srow["sector"])
+
+        # 2. all complete-TTM factor rows in the sector (self + candidates).
+        cur.execute(
+            _FACTORS_CTE + "SELECT instrument_id, symbol, company_name, total_assets, "
+            "operating_margin, net_margin, roe, debt_equity_ratio, pe_ratio, revenue_growth_yoy "
+            "FROM factors",
+            {"sector": sector},
+        )
+        rows = cur.fetchall()
+        by_id = {int(r["instrument_id"]): r for r in rows}
+        self_raw = by_id.get(instrument_id)
+        # Self must have a complete-TTM row with positive total_assets (factor
+        # anchor + peer-proximity reference). Else: no fundamentals.
+        if self_raw is None or self_raw["total_assets"] is None or float(self_raw["total_assets"]) <= 0:
+            return None
+        self_ta = float(self_raw["total_assets"])
+
+        # 3. sector medians + non-null counts, one pass over the factors CTE.
+        median_select = ", ".join(
+            f"percentile_cont(0.5) WITHIN GROUP (ORDER BY {k}) AS {k}_med, count({k}) AS {k}_n" for k in FACTOR_KEYS
+        )
+        # median_select is built only from the frozen FACTOR_KEYS constant — no
+        # user input — so the dynamic SELECT is injection-safe.
+        cur.execute(_FACTORS_CTE + f"SELECT {median_select} FROM factors", {"sector": sector})  # type: ignore[arg-type]
+        mrow = cur.fetchone() or {}
+
+    medians = {
+        k: FactorMedian(
+            median=(float(mrow[f"{k}_med"]) if mrow.get(f"{k}_med") is not None else None),
+            n=int(mrow.get(f"{k}_n") or 0),
+        )
+        for k in FACTOR_KEYS
+    }
+
+    # 4. peer set: same sector, exclude self, total_assets>0, nearest by
+    #    log-size proximity. Ranking in Python over the already-fetched sector
+    #    rows (hundreds at most) — no extra query.
+    peers = _rank_peers(list(by_id.values()), self_id=instrument_id, self_total_assets=self_ta, limit=_PEER_LIMIT)
+
+    return PeerComparisonResult(
+        instrument_id=instrument_id,
+        symbol=str(self_raw["symbol"]),
+        sector=sector,
+        sector_member_count=len(rows),
+        self_factors=_row_factors(self_raw),
+        medians=medians,
+        peers=peers,
+    )

--- a/docs/specs/metrics/2026-06-27-1751-peer-comparison-data.md
+++ b/docs/specs/metrics/2026-06-27-1751-peer-comparison-data.md
@@ -1,0 +1,132 @@
+# #1751 — peer-comparison data layer (unblocks #594)
+
+## Problem
+
+#594 (peer-comparison radar + sector heatmap) needs, per instrument: (a) a
+peer set, (b) sector-median aggregates across the radar factors (P/E, ROE,
+revenue growth YoY, operating margin, debt/equity). The issue framed this as
+an *ingest* gap ("no peer-set table, no sector medians").
+
+## Premise falsified (full-population, dev DB)
+
+It is **not an ingest gap** — the inputs already exist:
+
+- `instruments.sector` populated 9256/12565 (custom int code 1–9; **no lookup
+  table** — `resolve_sector_spdr` #1634 maps code→SPDR). `instrument_sec_profile.sic` present.
+- `financial_periods_ttm`: **4062** `is_complete_ttm=TRUE` rows; per-sector
+  computable (revenue>0 AND equity>0) is in the **hundreds** (sector 3:747,
+  4:380, 6:325, 8:320, 7:252, 1:117, 9:109, 5:62; sector 2 thin:7).
+- `financial_periods` FY revenue → YoY computable for **2600** instruments
+  (per-sector hundreds).
+
+So sector medians + peer sets are a **server-side derivation** from existing
+data. The pre-existing `instrument_valuation` view only emits ~32 rows because
+of its live-price join — bypassed here by reading `financial_periods_ttm`
+directly for the price-free factors.
+
+## Source rule (factor formulas — MIRROR `instrument_valuation`, sql/201)
+
+Do not re-derive; mirror the settled per-instrument formulas (all guard denom>0):
+
+- `roe = net_income_ttm / shareholders_equity` (when `shareholders_equity > 0`)
+- `operating_margin = operating_income_ttm / revenue_ttm` (when `revenue_ttm > 0`)
+- `debt_equity_ratio = (COALESCE(long_term_debt,0) + COALESCE(short_term_debt,0)) / shareholders_equity`
+  (when `shareholders_equity > 0`) — **COALESCE both debt legs** (Codex: view
+  does this; a NULL leg must not NULL the ratio).
+- `net_margin = net_income_ttm / revenue_ttm` (when `revenue_ttm > 0`; extra)
+- `pe_ratio = price / eps_diluted_ttm` — **price-gated** → only ~32 on dev.
+  Marked `dev_limited` so the FE can grey it out; sector median computed from
+  `instrument_valuation` (thin on dev, correct in prod).
+- `revenue_growth_yoy` — two most recent FY rows per instrument from
+  `financial_periods` WHERE `period_type='FY' AND revenue > 0 AND superseded_at
+  IS NULL AND normalization_status='normalized'` (Codex: mirror the
+  `financial_periods_ttm` canonical filter — sql/032:218 — so a superseded/raw
+  FY row cannot win the pair); `(cur-prev)/prev`. **Consecutive-year guard**
+  (real-data catch: GME has only FY2025 + FY2020): require
+  `cur.period_end_date - prev.period_end_date BETWEEN 300 AND 430` days, else NULL.
+
+## Design
+
+### Service — `app/services/peer_comparison.py`
+
+`compute_peer_comparison(conn, instrument_id) -> PeerComparison | None`:
+
+1. Resolve the instrument's `sector` (TEXT column — code "1".."9"). If NULL →
+   return `None` (caller 404s "no sector classification").
+2. **Self must have a complete-TTM row** with `total_assets > 0` (needed both as
+   the factor anchor and the peer-proximity reference). If absent → return
+   `None` (404 "no fundamentals"). The legacy `fundamentals_snapshot` valuation
+   path is intentionally ignored — the radar requires the TTM factor set.
+3. **Per-instrument factor CTE** (`instrument_factors`): from
+   `financial_periods_ttm` WHERE `is_complete_ttm`, compute roe / operating_margin /
+   debt_equity_ratio / net_margin (price-free) per the formulas above. LEFT JOIN
+   a `revenue_growth_yoy` CTE (the FY-pair calc with the canonical filter +
+   day-gap guard). LEFT JOIN `instrument_valuation` for `pe_ratio` (price-gated).
+4. **Sector medians**: `percentile_cont(0.5) WITHIN GROUP (ORDER BY <factor>)`
+   (ordered-set agg skips NULLs) over `instrument_factors` joined to
+   `instruments.sector`, GROUP BY sector; plus `count(*) FILTER (WHERE <factor>
+   IS NOT NULL)` per factor for `sector_n` (a thin/empty sector then reads
+   median=NULL, sector_n=0). P/E median computed separately over the priced set.
+5. **Peer set**: same `sector`, exclude self, require peer `total_assets > 0`,
+   rank by **size proximity** `ABS(ln(peer.total_assets) - ln(self.total_assets))`
+   (keyless, broad — market cap is price-gated), nearest `_PEER_LIMIT=8`. Each
+   peer carries its factor row (for the #594 heatmap). Self `total_assets > 0` is
+   already guaranteed by step 2, so `ln(self...)` is safe.
+6. Assemble the instrument's own factor values + sector medians + peers.
+
+All pure SQL + a thin assembler; no external calls, no new dependency.
+
+### Endpoint — `app/api/instruments.py`
+
+`GET /instruments/{symbol}/peer-comparison` → `PeerComparison` (Pydantic),
+mirroring the sibling symbol-keyed endpoints (resolve symbol→instrument_id,
+`conn = Depends(get_conn)`, 404 when no sector / no fundamentals).
+
+Response model:
+
+```
+PeerFactor:      key, label, instrument_value: float|None, sector_median: float|None,
+                 sector_n: int, dev_limited: bool, better_when: "higher"|"lower"
+PeerInstrument:  instrument_id, symbol, company_name, size_proxy: float|None,
+                 factors: dict[str, float|None]   # the 6 factor keys
+PeerComparison:  symbol, instrument_id, sector: str, sector_member_count: int,
+                 factors: list[PeerFactor], peers: list[PeerInstrument]
+                 # sector is the raw code string ("1".."9"); instruments.sector
+                 # is TEXT (sql/001:7). No int cast — no lookup table exists.
+```
+
+Factor set (radar order, #594): pe_ratio, roe, revenue_growth_yoy,
+operating_margin, debt_equity_ratio (+ net_margin). `better_when`:
+roe/operating_margin/net_margin/revenue_growth_yoy = higher; debt_equity_ratio
+= lower; pe_ratio = lower (cheaper).
+
+### Scope boundary
+
+- **In**: factors + sector medians + peer set (data for radar + heatmap).
+- **Out**: #594.2 peer-return scatter — that needs `price_daily` return series;
+  the endpoint returns peer `instrument_id`s so the FE fetches returns via the
+  existing candles/returns path. No new price work here.
+- **Out**: the #594 FE itself (separate ticket, unblocked by this).
+
+## Tests (pure-logic where possible)
+
+- `revenue_growth_yoy` day-gap guard: consecutive FY → value; 5-year-gap (GME
+  shape) → NULL. (DB-backed, one fixture.)
+- factor formula parity vs `instrument_valuation` for a priced instrument.
+- peer selection: same-sector only, self excluded, ordered by size proximity,
+  capped at 8.
+- endpoint: 200 shape for a covered instrument; 404 for no-sector.
+
+## Dev-verify
+
+- `GET /instruments/GME/peer-comparison` → 200; sector medians non-null for the
+  price-free factors; `pe_ratio.dev_limited=true`; peers populated; assert the
+  instrument's roe matches `instrument_valuation.roe` (if priced) / the manual
+  TTM calc.
+- Spot a second sector (e.g. a sector-3 name) for non-empty peers.
+
+## Files
+
+- NEW `app/services/peer_comparison.py`
+- `app/api/instruments.py` (+ endpoint + Pydantic models, or a models module)
+- NEW `tests/test_peer_comparison.py`

--- a/tests/test_peer_comparison.py
+++ b/tests/test_peer_comparison.py
@@ -1,0 +1,146 @@
+"""Peer-comparison data layer (#1751): DB integration — factor formulas,
+sector medians, and the YoY consecutive-year guard. Pure ranking tests live in
+test_peer_comparison_ranking.py (kept DB-free so they run in the fast tier)."""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.services.peer_comparison import compute_peer_comparison
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 (fixture re-export)
+
+__all__ = ["ebull_test_conn"]
+
+
+# financial_periods_ttm is a VIEW summing the latest 4 quarters (sql/032:209);
+# stock items (equity/assets/debt) come from the most recent quarter. So a
+# "complete TTM" is seeded by inserting 4 quarterly rows.
+_Q_ENDS = ("2024-03-31", "2024-06-30", "2024-09-30", "2024-12-31")
+_Q_TYPES = ("Q1", "Q2", "Q3", "Q4")
+
+
+def _seed_quarters(
+    conn: psycopg.Connection[tuple],
+    iid: int,
+    *,
+    revenue_q: float,
+    op_income_q: float,
+    net_income_q: float,
+    equity: float,
+    total_assets: float,
+    long_term_debt: float = 0,
+    short_term_debt: float = 0,
+) -> None:
+    """Insert 4 quarters → a complete TTM. Flow items sum; stock items are read
+    from the latest quarter (2024-12-31), so set them only there."""
+    for i, (end, qt) in enumerate(zip(_Q_ENDS, _Q_TYPES, strict=True)):
+        latest = end == "2024-12-31"
+        conn.execute(
+            """
+            INSERT INTO financial_periods
+              (instrument_id, period_end_date, period_type, fiscal_year, source, source_ref,
+               reported_currency, revenue, operating_income, net_income,
+               total_assets, shareholders_equity, long_term_debt, short_term_debt,
+               superseded_at, normalization_status)
+            VALUES (%s, %s, %s, 2024, 'test', %s, 'USD', %s, %s, %s, %s, %s, %s, %s, NULL, 'normalized')
+            """,
+            (
+                iid,
+                end,
+                qt,
+                f"q{iid}{i}",
+                revenue_q,
+                op_income_q,
+                net_income_q,
+                total_assets if latest else None,
+                equity if latest else None,
+                long_term_debt if latest else None,
+                short_term_debt if latest else None,
+            ),
+        )
+
+
+def _seed(conn: psycopg.Connection[tuple]) -> None:
+    # instruments: self + 2 same-sector peers + 1 other-sector + 1 no-sector.
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, sector, is_tradable)
+        VALUES
+          (9001, 'PCSELF', 'Self Co',   '99', TRUE),
+          (9002, 'PCNEAR', 'Near Peer', '99', TRUE),
+          (9003, 'PCFAR',  'Far Peer',  '99', TRUE),
+          (9004, 'PCOTHER','Other Sec', '88', TRUE),
+          (9005, 'PCNOSEC','No Sector', NULL, TRUE)
+        """
+    )
+    # self: ttm rev 1000, op 100, ni 80; equity 800, ta 1000, no debt.
+    _seed_quarters(conn, 9001, revenue_q=250, op_income_q=25, net_income_q=20, equity=800, total_assets=1000)
+    # near peer (ta 1100): ttm rev 500, op 50, ni 25; equity 250.
+    _seed_quarters(
+        conn,
+        9002,
+        revenue_q=125,
+        op_income_q=12.5,
+        net_income_q=6.25,
+        equity=250,
+        total_assets=1100,
+        long_term_debt=50,
+        short_term_debt=50,
+    )
+    # far peer (ta 9e8): excluded from nearest only by distance, still a peer.
+    _seed_quarters(conn, 9003, revenue_q=100, op_income_q=5, net_income_q=2.5, equity=100, total_assets=9.0e8)
+    # other sector — must NOT appear as a peer.
+    _seed_quarters(conn, 9004, revenue_q=225, op_income_q=22.5, net_income_q=17.5, equity=700, total_assets=1050)
+    # no-sector — None path.
+    _seed_quarters(conn, 9005, revenue_q=225, op_income_q=22.5, net_income_q=17.5, equity=700, total_assets=1050)
+    # FY revenue rows for YoY. self: consecutive (366d) → computable.
+    # near peer: 5-year gap → guard rejects → None.
+    conn.execute(
+        """
+        INSERT INTO financial_periods
+          (instrument_id, period_end_date, period_type, fiscal_year, source, source_ref,
+           reported_currency, revenue, superseded_at, normalization_status)
+        VALUES
+          (9001, DATE '2024-12-31', 'FY', 2024, 'test', 'fy1', 'USD', 1100, NULL, 'normalized'),
+          (9001, DATE '2023-12-31', 'FY', 2023, 'test', 'fy2', 'USD', 1000, NULL, 'normalized'),
+          (9002, DATE '2024-12-31', 'FY', 2024, 'test', 'fy3', 'USD',  600, NULL, 'normalized'),
+          (9002, DATE '2019-12-31', 'FY', 2019, 'test', 'fy4', 'USD',  500, NULL, 'normalized')
+        """
+    )
+    conn.commit()
+
+
+@pytest.mark.db
+def test_compute_peer_comparison_db(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    _seed(ebull_test_conn)
+    result = compute_peer_comparison(ebull_test_conn, instrument_id=9001)
+    assert result is not None
+    assert result.sector == "99"
+    assert result.sector_member_count == 3  # 9001/9002/9003 (same sector, complete TTM)
+
+    sf = result.self_factors
+    assert sf["operating_margin"] == pytest.approx(0.1)  # 100/1000
+    assert sf["net_margin"] == pytest.approx(0.08)  # 80/1000
+    assert sf["roe"] == pytest.approx(0.1)  # 80/800
+    assert sf["debt_equity_ratio"] == pytest.approx(0.0)  # no debt
+    assert sf["revenue_growth_yoy"] == pytest.approx(0.1)  # (1100-1000)/1000, consecutive FY
+    assert sf["pe_ratio"] is None  # no price → instrument_valuation excludes it
+
+    # peer order: 9002 (ta 1100, near) before 9003 (ta 9e8, far); 9004/9005 excluded.
+    assert [p.instrument_id for p in result.peers] == [9002, 9003]
+    near = result.peers[0]
+    assert near.factors["revenue_growth_yoy"] is None  # 5-year gap → guard rejects
+
+    # median of revenue_growth_yoy: only self has a value → median 0.1, n=1.
+    assert result.medians["revenue_growth_yoy"].n == 1
+    assert result.medians["revenue_growth_yoy"].median == pytest.approx(0.1)
+
+
+@pytest.mark.db
+def test_compute_peer_comparison_none_paths(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    _seed(ebull_test_conn)
+    # No sector classification → None.
+    assert compute_peer_comparison(ebull_test_conn, instrument_id=9005) is None
+    # Unknown instrument → None.
+    assert compute_peer_comparison(ebull_test_conn, instrument_id=999999) is None

--- a/tests/test_peer_comparison_ranking.py
+++ b/tests/test_peer_comparison_ranking.py
@@ -1,0 +1,45 @@
+"""Pure-logic tests for peer ranking + factor mapping (#1751). No DB."""
+
+from __future__ import annotations
+
+from app.services.peer_comparison import FACTOR_KEYS, _rank_peers, _row_factors
+
+
+def _row(iid: int, ta: float | None, **factors: float | None) -> dict[str, object]:
+    base: dict[str, object] = {
+        "instrument_id": iid,
+        "symbol": f"S{iid}",
+        "company_name": f"C{iid}",
+        "total_assets": ta,
+    }
+    for k in FACTOR_KEYS:
+        base.setdefault(k, None)
+    base.update(factors)
+    return base
+
+
+def test_rank_peers_excludes_self_and_orders_by_proximity() -> None:
+    rows = [_row(1, 100.0), _row(2, 110.0), _row(3, 1000.0), _row(4, 95.0)]
+    peers = _rank_peers(rows, self_id=1, self_total_assets=100.0, limit=8)
+    # self excluded; nearest log-size first: 95 (0.051), 110 (0.095), 1000 (2.30)
+    assert [p.instrument_id for p in peers] == [4, 2, 3]
+
+
+def test_rank_peers_drops_nonpositive_total_assets() -> None:
+    rows = [_row(1, 100.0), _row(2, None), _row(3, 0.0), _row(4, 120.0)]
+    peers = _rank_peers(rows, self_id=1, self_total_assets=100.0, limit=8)
+    assert [p.instrument_id for p in peers] == [4]
+
+
+def test_rank_peers_caps_at_limit() -> None:
+    rows = [_row(i, 100.0 + i) for i in range(1, 20)]
+    peers = _rank_peers(rows, self_id=1, self_total_assets=100.0, limit=8)
+    assert len(peers) == 8
+
+
+def test_row_factors_maps_all_keys() -> None:
+    f = _row_factors(_row(1, 100.0, roe=0.1, pe_ratio=15.0))
+    assert set(f) == set(FACTOR_KEYS)
+    assert f["roe"] == 0.1
+    assert f["pe_ratio"] == 15.0
+    assert f["net_margin"] is None


### PR DESCRIPTION
## What & why
The #594 peer drill (radar + sector heatmap) needs, per instrument, the radar factors vs their **sector median** and a **peer set**. The issue framed this as an *ingest* gap.

**Premise falsified on the full population** — the inputs already exist, so this is a server-side **derivation, not an ingest**:
- `instruments.sector` populated 9256/12565 (custom code "1".."9"; no lookup table — `resolve_sector_spdr` #1634 maps it).
- `financial_periods_ttm`: 4062 `is_complete_ttm` rows; per-sector computable in the **hundreds** (sector 3:747, 4:380, 6:325…; sector 2 thin:7).
- `financial_periods` FY revenue → YoY computable for 2600 instruments.

The pre-existing `instrument_valuation` view emits only ~32 rows because of its live-price join — bypassed here by reading `financial_periods_ttm` directly for the price-free factors.

## Changes
- **NEW** `app/services/peer_comparison.py` — `compute_peer_comparison(conn, instrument_id)`:
  - Per-instrument factors **mirroring `instrument_valuation` (sql/201)**: `roe`, `operating_margin`, `debt_equity_ratio` (COALESCE'd debt legs), `net_margin` from `financial_periods_ttm`; `pe_ratio` LEFT JOIN `instrument_valuation` (price-gated → `dev_limited`); `revenue_growth_yoy` from the two most recent canonical FY rows with a **consecutive-year day-gap guard (300–430d)** that rejects multi-year gaps (e.g. GME FY2025/FY2020).
  - Sector medians via `percentile_cont(0.5)` + non-null counts; peer set = same sector, nearest by `log(total_assets)` proximity (market cap is price-gated, so unusable broadly).
- **NEW** `GET /instruments/{symbol}/peer-comparison` → `PeerComparison` (factors: value vs `sector_median`, `sector_n`, `dev_limited`, `better_when`; + peers with their factor rows for the heatmap). 404 on no sector / no complete-TTM fundamentals.
- Tests: 4 pure (peer ranking, factor mapping) + 2 DB (factor-formula parity, YoY guard, sector grouping, peer order, None paths).

No new ingest, no schema change, no new dependency.

## Source rule
Factor formulas cite `instrument_valuation` (sql/201). The FY canonical filter mirrors `financial_periods_ttm` (sql/032:218 — `superseded_at IS NULL AND normalization_status='normalized'`) so a superseded/raw FY row cannot win the YoY pair. Verified on the full population.

## Security model
Endpoint resolves symbol via parameterized `WHERE UPPER(symbol)=%(s)s` (no dynamic SQL from input); only the resolved `instrument_id` flows into the service as a bound param. The one dynamic SELECT (median columns) is built solely from the frozen `FACTOR_KEYS` constant — no user input — and Codex confirmed injection-safe.

## Codex
ckpt-1 (spec) folded 6 findings: COALESCE debt legs, canonical FY filter, self-`total_assets>0` guard, `sector` as str (column is TEXT), no-TTM→404, `sector_n` via FILTER. ckpt-2 (pre-push): no real bugs found; ran the 6 tests (pass).

## Verification
- ruff/format/pyright clean; 4 pure + 2 DB tests pass.
- **Dev-verify**: `GET /instruments/GME/peer-comparison` → **HTTP 200**; sector 7, 317 members; roe 0.080 vs median 0.043 (n=245), operating_margin 0.095 vs 0.045 (n=277), **P/E `dev_limited` (n=6)**, **`revenue_growth_yoy=null`** (GME's FY gap → the consecutive-year guard fired), 8 size-proximate peers. 404 verified for unknown symbol.

## Scope boundary
Out: #594.2 peer-return scatter (needs `price_daily` return series; the endpoint returns peer `instrument_id`s so the FE fetches returns via the existing candles path) and the #594 FE itself (separate ticket, unblocked by this).

Closes #1751.