### PR TITLE
feat(#593): news-analytics drill — sentiment trend + weekly volume + source pie

### DIFF
--- a/.claude/skills/engineering/pre-flight-review.md
+++ b/.claude/skills/engineering/pre-flight-review.md
@@ -141,6 +141,11 @@ If the diff touches `frontend/`, also read and apply these before pushing:
 - `.claude/skills/frontend/api-shape-and-types.md` — `types.ts` mirrors Pydantic `response_model` in the same PR; `apiFetch` path contract; auth stays in the client
 - `.claude/skills/frontend/operator-ui-conventions.md` — formatters, color semantics, density, status pill vocabulary
 
+- **encoding-comment vs test:** a comment that states a numeric encoding (gradient
+  offset, sign convention, index→meaning) must match the sign-regime tests in the
+  same file. After writing one, read the test that pins it. (PR #1758: an inverted
+  `splitOffset` JSDoc claimed `1 = full red` when the tests prove `1 = full emerald`.)
+
 For frontend pages, also grep:
 
 ```bash

--- a/docs/proposals/ui/2026-06-27-593-news-analytics-drill.md
+++ b/docs/proposals/ui/2026-06-27-593-news-analytics-drill.md
@@ -1,0 +1,85 @@
+# #593 — News analytics drill (`/instrument/:symbol/news-analysis`)
+
+Phase 3 of #585. FE recharts drill over the now-populated `GET /news/{instrument_id}`
+(#1750 RSS provider). Sibling of the #592 filings-analytics drill — mirrors its
+structure exactly (page shell, pure `lib/` transforms, theme-driven charts).
+
+## Source rule / endpoint contract (verified 2026-06-27 vs live :8000)
+
+`GET /news/{instrument_id}` (`app/api/news.py:89`) → `NewsListResponse`:
+- Items: `{news_event_id, instrument_id, event_time (tstz ISO), source, headline,
+  category, sentiment_score (signed numeric|null), importance_score, snippet, url}`.
+- **Defaults to last 30 days** unless `since` passed; `limit` default 50, cap **200**;
+  ordered `event_time DESC`; **404 on unknown instrument**.
+- Endpoint is `instrument_id`-keyed → resolve `:symbol → id` via `fetchInstrumentSummary`
+  first (same one-lifecycle pattern as `FilingsAnalyticsPage.tsx:29`).
+- Sentiment is a signed numeric score (settled-decisions §News/Sentiment) — emerald >0 /
+  red <0 fill is the correct encoding.
+
+## Dev-data reality (full-population check, NOT a sample)
+
+`news_events` on dev: 4 instruments only — **GME 20, TPR 18, BBBY 12, ATEX 2** (not AAPL).
+Span **2026-06-22 → 06-27 = 1 ISO week**, **single source** "Yahoo Finance", categories
+general/analyst_note/earnings. So on dev: source-pie = 1 slice, weekly-volume = 1 bar,
+7d-rolling-mean ≈ raw mean. This is RSS recency, not a bug.
+
+**Posture (mirrors the operator-mandated `dev_limited`/`sector_n` honesty for #594):** build
+all three charts spec-faithful for production correctness; render honestly-sparse on dev with
+a low-history caption. Do NOT dumb charts down to current dev sparsity (transient state).
+Fetch window = 365d (`since`) so the trend fills as news accrues; 200-row cap is ample
+(max 20 rows/instrument today). Dev fixture for verification: **GME**.
+
+## Charts (spec §News, lines 143-147)
+
+Pure transforms in `frontend/src/lib/newsAnalytics.ts` (table-tested, no DB/render — the
+"pure policy over real DB" prevention-log lesson). All series colors from `useChartTheme()`
+`theme.*`, never `lightTheme.*` (prevention-log 1917 — #591 risk-drill regression).
+
+1. **Sentiment trend** (AreaChart) — daily mean `sentiment_score` + 7-day rolling mean.
+   Bicolor-by-sign via the canonical recharts **gradient-offset** technique (NOT a pos/neg
+   null-split — that gaps at zero crossings): single `<Area dataKey="rolling" baseValue={0}
+   fill="url(#sentSplit)" stroke="url(#sentSplit)">` + a `<linearGradient>` with a hard stop
+   at `offset = maxV/(maxV-minV)` (fraction of value-domain above 0) — emerald above the stop,
+   red below. `baseValue={0}` anchors fill to the zero line; emerald fills line→0 above, red
+   fills 0→line below. `YAxis domain` forced to include 0 (`[min(0,minV), max(0,maxV)]` padded)
+   + `<ReferenceLine y={0}>`. Rolling mean = trailing 7-day window with **minPeriods=1**
+   (partial window early, so 6-day dev data renders, not all-null). Days with no item, or items
+   with null `sentiment_score`, excluded from the daily mean (no fabricated zeros).
+2. **News volume** (BarChart) — count per **ISO week** (ISO week-*year* key `YYYY-Www`, UTC
+   date math — not `getFullYear`/local, which mis-bucket at year/midnight boundaries),
+   `theme.accent[1]`. "Spot bursts."
+3. **Source breakdown** (PieChart) — count by `source` (null/blank coalesced to "Unknown"
+   before grouping), `theme.accent` rotation. 1-slice on dev is honest; correct once multi-source.
+
+### Codex ckpt-1 resolutions (2026-06-27)
+
+1. **200-row cap vs 365d** — `fetchNews` paginates (bounded loop, `offset+items >= total`,
+   hard stop ~10 pages/2000 rows) so a hot name isn't silently truncated to newest-200; caption
+   if the cap is hit. 2-4. **Area baseline / null-gap / partial window** — resolved by the
+   gradient-offset + `baseValue={0}` + `minPeriods=1` design above. 5. **ISO week-year + UTC** —
+   pure helper keys on ISO week-year in UTC. 6. **Nullable source** — coalesced to "Unknown".
+
+Chart components in `frontend/src/components/news/newsAnalyticsCharts.tsx`; each carries its
+own empty guard (mirror `NoFilings`). Custom tooltips wrap `<ChartTooltip>`.
+
+## Page + wiring
+
+- `frontend/src/pages/NewsAnalysisPage.tsx` — mirror `FilingsAnalyticsPage`: `useParams`,
+  back-link, header + subtitle, `useAsync` (symbol→id→news), loading/error/empty states,
+  three `<Section>` wrappers. Low-history caption when span < 2 weeks or sources < 2.
+- `frontend/src/App.tsx` — static import + route `instrument/:symbol/news-analysis`
+  (drills are static-imported in this codebase, not lazy — spec's lazy note is stale).
+- `frontend/src/api/news.ts` — add optional `since` to `fetchNews` (back-compat default).
+- Header "Analytics →" link from the existing news pane (`RecentNewsPane`) to the drill.
+  Existing pane stays (L1 unchanged).
+- `frontend/src/lib/newsAnalytics.test.ts` — unit-test the 3 transforms (fast `test:unit`).
+
+## Out of scope
+
+Multi-source ingest (data-layer), importance-weighted sentiment, per-category split. No
+backend change. No daemon restart (FE-only).
+
+## Gates
+
+`pnpm --dir frontend typecheck && test:unit && dark:check`. Codex ckpt-1 (this spec) +
+ckpt-2 (staged diff pre-push). In-browser render verify on GME via chrome-devtools.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { DividendsPage } from "@/pages/DividendsPage";
 import { FundamentalsPage } from "@/pages/FundamentalsPage";
 import { InsiderPage } from "@/pages/InsiderPage";
 import { OwnershipPage } from "@/pages/OwnershipPage";
+import { NewsAnalysisPage } from "@/pages/NewsAnalysisPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
 import { AdminPage } from "@/pages/AdminPage";
@@ -116,6 +117,10 @@ export function App() {
           <Route
             path="instrument/:symbol/risk"
             element={<RiskPage />}
+          />
+          <Route
+            path="instrument/:symbol/news-analysis"
+            element={<NewsAnalysisPage />}
           />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />

--- a/frontend/src/api/news.ts
+++ b/frontend/src/api/news.ts
@@ -1,16 +1,58 @@
 import { apiFetch } from "@/api/client";
-import type { NewsListResponse } from "@/api/types";
+import type { NewsItem, NewsListResponse } from "@/api/types";
 
 export function fetchNews(
   instrumentId: number,
   offset = 0,
   limit = 10,
+  since?: string,
 ): Promise<NewsListResponse> {
   const params = new URLSearchParams({
     offset: String(offset),
     limit: String(limit),
   });
+  if (since !== undefined) params.set("since", since);
   return apiFetch<NewsListResponse>(
     `/news/${instrumentId}?${params.toString()}`,
   );
+}
+
+// Endpoint page cap (`app/api/news.py` MAX_PAGE_LIMIT) + a hard page bound so
+// a hot name can't spin an unbounded loop. 10 × 200 = 2000 rows max.
+const PAGE_LIMIT = 200;
+const MAX_PAGES = 10;
+const DAY_MS = 86_400_000;
+
+export interface AllNews {
+  readonly items: NewsItem[];
+  readonly total: number;
+  readonly symbol: string | null;
+  /** True when MAX_PAGES was hit before draining `total` — the charts then
+   *  show the newest `items.length` of `total` and the page captions it. */
+  readonly capped: boolean;
+}
+
+/**
+ * Fetch the full news window for the analytics drill, paginating the
+ * 200-row-capped endpoint until drained (Codex ckpt-1 #1 — a single fetch
+ * would silently truncate a high-volume name to its newest 200 rows).
+ */
+export async function fetchAllNews(
+  instrumentId: number,
+  sinceDays = 365,
+): Promise<AllNews> {
+  const since = new Date(Date.now() - sinceDays * DAY_MS).toISOString();
+  const items: NewsItem[] = [];
+  let total = 0;
+  let symbol: string | null = null;
+  let capped = false;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const res = await fetchNews(instrumentId, page * PAGE_LIMIT, PAGE_LIMIT, since);
+    total = res.total;
+    symbol = res.symbol;
+    items.push(...res.items);
+    if (items.length >= res.total || res.items.length === 0) break;
+    if (page === MAX_PAGES - 1) capped = items.length < res.total;
+  }
+  return { items, total, symbol, capped };
 }

--- a/frontend/src/components/instrument/RecentNewsPane.tsx
+++ b/frontend/src/components/instrument/RecentNewsPane.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import { fetchNews } from "@/api/news";
 import type { NewsListResponse } from "@/api/types";
@@ -70,6 +70,14 @@ export function RecentNewsPane({
           </li>
         ))}
       </ul>
+      <div className="mt-2 border-t border-slate-100 dark:border-slate-800 pt-2 text-right">
+        <Link
+          to={`/instrument/${encodeURIComponent(symbol)}/news-analysis`}
+          className="text-[11px] text-sky-700 hover:underline"
+        >
+          News analytics →
+        </Link>
+      </div>
     </Pane>
   );
 }

--- a/frontend/src/components/news/newsAnalyticsCharts.test.tsx
+++ b/frontend/src/components/news/newsAnalyticsCharts.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Render tests for the news-analytics charts (#593). The pure shaping is
+ * exercised in `lib/newsAnalytics.test.ts`; these pin the empty-state
+ * guards inside the chart components (where a bug shows as a blank recharts
+ * frame, not an error) and confirm the populated branch mounts the chart.
+ *
+ * jsdom stubs ResizeObserver as a noop (test/setup.ts) so ResponsiveContainer
+ * measures 0px and never renders the inner series — hence we assert the
+ * guard hints + the container element, not chart internals (the recharts
+ * props are validated by typecheck).
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  NewsVolumeChart,
+  SentimentTrendChart,
+  SourceBreakdownPie,
+} from "@/components/news/newsAnalyticsCharts";
+import {
+  buildSentimentSeries,
+  buildSourceBreakdown,
+  buildWeeklyVolume,
+} from "@/lib/newsAnalytics";
+import type { NewsItem } from "@/api/types";
+
+let seq = 0;
+function n(event_time: string, sentiment_score: number | null, source = "Yahoo Finance"): NewsItem {
+  seq += 1;
+  return {
+    news_event_id: seq,
+    instrument_id: 1,
+    event_time,
+    source,
+    headline: `h${seq}`,
+    category: "general",
+    sentiment_score,
+    importance_score: null,
+    snippet: null,
+    url: null,
+  };
+}
+
+describe("SentimentTrendChart", () => {
+  it("renders the no-signal hint when no item is scored", () => {
+    render(<SentimentTrendChart series={buildSentimentSeries([n("2026-06-22T10:00:00Z", null)])} />);
+    expect(screen.getByText(/No scored sentiment/i)).toBeInTheDocument();
+  });
+
+  it("renders the no-signal hint on an empty series", () => {
+    render(<SentimentTrendChart series={buildSentimentSeries([])} />);
+    expect(screen.getByText(/No scored sentiment/i)).toBeInTheDocument();
+  });
+
+  it("mounts the chart (not the hint) when scored data is present", () => {
+    const { container } = render(
+      <SentimentTrendChart
+        series={buildSentimentSeries([
+          n("2026-06-22T10:00:00Z", 0.3),
+          n("2026-06-23T10:00:00Z", -0.4),
+        ])}
+      />,
+    );
+    expect(screen.queryByText(/No scored sentiment/i)).not.toBeInTheDocument();
+    expect(container.querySelector(".recharts-responsive-container")).not.toBeNull();
+  });
+});
+
+describe("NewsVolumeChart", () => {
+  it("renders the no-news hint on empty data", () => {
+    render(<NewsVolumeChart data={buildWeeklyVolume([])} />);
+    expect(screen.getByText(/No news in the window/i)).toBeInTheDocument();
+  });
+
+  it("mounts the chart when there is news", () => {
+    const { container } = render(
+      <NewsVolumeChart data={buildWeeklyVolume([n("2026-06-22T10:00:00Z", 0.1)])} />,
+    );
+    expect(screen.queryByText(/No news in the window/i)).not.toBeInTheDocument();
+    expect(container.querySelector(".recharts-responsive-container")).not.toBeNull();
+  });
+});
+
+describe("SourceBreakdownPie", () => {
+  it("renders the no-sources hint on empty data", () => {
+    render(<SourceBreakdownPie slices={buildSourceBreakdown([])} />);
+    expect(screen.getByText(/No sources in the window/i)).toBeInTheDocument();
+  });
+
+  it("mounts the donut when sources are present", () => {
+    const { container } = render(
+      <SourceBreakdownPie
+        slices={buildSourceBreakdown([
+          n("2026-06-22T10:00:00Z", 0.1, "Yahoo Finance"),
+          n("2026-06-22T11:00:00Z", 0.1, "Reuters"),
+        ])}
+      />,
+    );
+    expect(screen.queryByText(/No sources in the window/i)).not.toBeInTheDocument();
+    expect(container.querySelector(".recharts-responsive-container")).not.toBeNull();
+  });
+});

--- a/frontend/src/components/news/newsAnalyticsCharts.tsx
+++ b/frontend/src/components/news/newsAnalyticsCharts.tsx
@@ -1,0 +1,244 @@
+/**
+ * Charts for the news-analytics drill (#593): a bicolor sentiment trend, a
+ * weekly news-volume bar, and a source-breakdown donut. All read the pure
+ * shapes from `@/lib/newsAnalytics` and take every colour from
+ * `useChartTheme()` `theme.*` — never `lightTheme.*` (prevention-log 1917,
+ * the #591 risk-drill regression).
+ */
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { ChartTooltip } from "@/components/charts/ChartTooltip";
+import { type ChartTheme } from "@/lib/chartTheme";
+import {
+  type SentimentSeries,
+  type SourceSlice,
+  type WeeklyVolumePoint,
+} from "@/lib/newsAnalytics";
+import { useChartTheme } from "@/lib/useChartTheme";
+
+const CHART_HEIGHT = 280;
+
+function NoNews({ message }: { message: string }): JSX.Element {
+  return <p className="px-2 py-6 text-xs text-slate-500">{message}</p>;
+}
+
+/** `2026-06-22` → `06-22` for a compact daily tick. */
+function dayTick(date: string): string {
+  return date.slice(5);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Sentiment trend — 7-day rolling mean, emerald above 0 / red below 0
+// ---------------------------------------------------------------------------
+
+interface SentimentTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload?: { date: string; rolling: number | null; mean: number | null; count: number } }>;
+}
+
+function SentimentTooltip({ active, payload }: SentimentTooltipProps): JSX.Element | null {
+  if (active !== true || !payload || payload.length === 0) return null;
+  const row = payload[0]?.payload;
+  if (!row) return null;
+  return (
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">{row.date}</div>
+      <div className="tabular-nums text-slate-600 dark:text-slate-300">
+        7d sentiment {row.rolling === null ? "—" : row.rolling.toFixed(3)}
+      </div>
+      <div className="tabular-nums text-slate-500 dark:text-slate-400">
+        day mean {row.mean === null ? "—" : row.mean.toFixed(3)} · {row.count} item
+        {row.count === 1 ? "" : "s"}
+      </div>
+    </ChartTooltip>
+  );
+}
+
+export function SentimentTrendChart({ series }: { series: SentimentSeries }): JSX.Element {
+  const theme = useChartTheme();
+  const hasSignal = series.points.some((p) => p.rolling !== null);
+  if (series.points.length === 0 || !hasSignal) {
+    return <NoNews message="No scored sentiment in the window." />;
+  }
+  // Axis domain MUST equal the fill bbox [min(0,min) .. max(0,max)] (no
+  // padding) so the axis-positioned zero line coincides with the gradient's
+  // emerald/red boundary — see lib/newsAnalytics splitOffset note.
+  const domLo = Math.min(0, series.min);
+  const domHi = Math.max(0, series.max);
+  return (
+    <div style={{ height: CHART_HEIGHT }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={[...series.points]} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+          <defs>
+            <linearGradient id="newsSentFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset={series.splitOffset} stopColor={theme.up} stopOpacity={0.45} />
+              <stop offset={series.splitOffset} stopColor={theme.down} stopOpacity={0.45} />
+            </linearGradient>
+            <linearGradient id="newsSentStroke" x1="0" y1="0" x2="0" y2="1">
+              <stop offset={series.splitOffset} stopColor={theme.up} />
+              <stop offset={series.splitOffset} stopColor={theme.down} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid stroke={theme.gridLine} vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={dayTick}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            interval="preserveStartEnd"
+            minTickGap={20}
+          />
+          <YAxis
+            domain={[domLo, domHi]}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            width={40}
+            tickFormatter={(v: number) => v.toFixed(2)}
+          />
+          <ReferenceLine y={0} stroke={theme.borderColor} />
+          <Tooltip content={<SentimentTooltip />} cursor={{ stroke: theme.gridLine }} />
+          <Area
+            type="monotone"
+            dataKey="rolling"
+            baseValue={0}
+            stroke="url(#newsSentStroke)"
+            strokeWidth={1.5}
+            fill="url(#newsSentFill)"
+            connectNulls
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. News volume — count per ISO week
+// ---------------------------------------------------------------------------
+
+interface VolumeTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload?: WeeklyVolumePoint }>;
+}
+
+function VolumeTooltip({ active, payload }: VolumeTooltipProps): JSX.Element | null {
+  if (active !== true || !payload || payload.length === 0) return null;
+  const row = payload[0]?.payload;
+  if (!row) return null;
+  return (
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">{row.week}</div>
+      <div className="tabular-nums text-slate-600 dark:text-slate-300">
+        {row.count} item{row.count === 1 ? "" : "s"}
+      </div>
+    </ChartTooltip>
+  );
+}
+
+export function NewsVolumeChart({ data }: { data: readonly WeeklyVolumePoint[] }): JSX.Element {
+  const theme = useChartTheme();
+  if (data.length === 0) {
+    return <NoNews message="No news in the window." />;
+  }
+  return (
+    <div style={{ height: CHART_HEIGHT }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={[...data]} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+          <CartesianGrid stroke={theme.gridLine} vertical={false} />
+          <XAxis
+            dataKey="week"
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            interval="preserveStartEnd"
+            minTickGap={16}
+          />
+          <YAxis
+            allowDecimals={false}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            width={32}
+          />
+          <Tooltip content={<VolumeTooltip />} cursor={{ fill: theme.gridLine }} />
+          <Bar dataKey="count" name="news" fill={theme.accent[1]} isAnimationActive={false} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Source breakdown — donut by source
+// ---------------------------------------------------------------------------
+
+interface SourceTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload?: SourceSlice; percent?: number }>;
+}
+
+function SourceTooltip({ active, payload }: SourceTooltipProps): JSX.Element | null {
+  if (active !== true || !payload || payload.length === 0) return null;
+  const slice = payload[0]?.payload;
+  if (!slice) return null;
+  const pct = payload[0]?.percent;
+  return (
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">{slice.source}</div>
+      <div className="tabular-nums text-slate-600 dark:text-slate-300">
+        {slice.count} item{slice.count === 1 ? "" : "s"}
+        {pct !== undefined ? ` · ${(pct * 100).toFixed(0)}%` : ""}
+      </div>
+    </ChartTooltip>
+  );
+}
+
+function sliceColor(theme: ChartTheme, i: number): string {
+  return theme.accent[i % theme.accent.length] ?? theme.primaryLine;
+}
+
+export function SourceBreakdownPie({ slices }: { slices: readonly SourceSlice[] }): JSX.Element {
+  const theme = useChartTheme();
+  if (slices.length === 0) {
+    return <NoNews message="No sources in the window." />;
+  }
+  return (
+    <div style={{ height: CHART_HEIGHT }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={[...slices]}
+            dataKey="count"
+            nameKey="source"
+            cx="50%"
+            cy="50%"
+            innerRadius={50}
+            outerRadius={95}
+            paddingAngle={1}
+            isAnimationActive={false}
+          >
+            {slices.map((s, i) => (
+              <Cell key={s.source} fill={sliceColor(theme, i)} />
+            ))}
+          </Pie>
+          <Tooltip content={<SourceTooltip />} />
+          <Legend wrapperStyle={{ fontSize: "11px" }} />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/lib/newsAnalytics.test.ts
+++ b/frontend/src/lib/newsAnalytics.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSentimentSeries,
+  buildSourceBreakdown,
+  buildWeeklyVolume,
+  isoWeek,
+  newsCoverage,
+  UNKNOWN_SOURCE,
+} from "@/lib/newsAnalytics";
+import type { NewsItem } from "@/api/types";
+
+let seq = 0;
+function n(
+  event_time: string,
+  sentiment_score: number | null,
+  source: string | null = "Yahoo Finance",
+): NewsItem {
+  seq += 1;
+  return {
+    news_event_id: seq,
+    instrument_id: 1,
+    event_time,
+    source,
+    headline: `h${seq}`,
+    category: "general",
+    sentiment_score,
+    importance_score: null,
+    snippet: null,
+    url: null,
+  };
+}
+
+describe("isoWeek (ISO-8601 week-year, UTC — year-boundary correctness)", () => {
+  const cases: ReadonlyArray<[string, number, number]> = [
+    ["2020-12-31T12:00:00Z", 2020, 53], // Thu — last week of 2020
+    ["2021-01-01T12:00:00Z", 2020, 53], // Fri — still ISO 2020-W53
+    ["2021-01-04T12:00:00Z", 2021, 1], // Mon — first week of 2021
+    ["2019-12-30T12:00:00Z", 2020, 1], // Mon — owned by ISO 2020-W01
+    ["2016-01-01T12:00:00Z", 2015, 53], // Fri — owned by ISO 2015-W53
+  ];
+  it.each(cases)("%s → %i-W%i", (iso, year, week) => {
+    expect(isoWeek(new Date(iso))).toEqual({ year, week });
+  });
+
+  it("buckets a near-midnight event by UTC, not local time", () => {
+    // 23:30Z Sunday is still that ISO week in UTC regardless of viewer tz.
+    expect(isoWeek(new Date("2026-06-21T23:30:00Z"))).toEqual({ year: 2026, week: 25 });
+    expect(isoWeek(new Date("2026-06-22T00:30:00Z"))).toEqual({ year: 2026, week: 26 });
+  });
+});
+
+describe("buildSentimentSeries", () => {
+  it("daily mean averages scored items, excludes null scores, counts all", () => {
+    const s = buildSentimentSeries([
+      n("2026-06-22T10:00:00Z", 0.2),
+      n("2026-06-22T14:00:00Z", 0.4),
+      n("2026-06-22T15:00:00Z", null), // counts toward volume, not mean
+    ]);
+    expect(s.points).toHaveLength(1);
+    expect(s.points[0]!.mean).toBeCloseTo(0.3, 6);
+    expect(s.points[0]!.count).toBe(3);
+  });
+
+  it("builds a gap-free UTC day axis and advances the rolling window over quiet days", () => {
+    const s = buildSentimentSeries([
+      n("2026-06-22T10:00:00Z", 1),
+      n("2026-06-25T10:00:00Z", -1), // 3-day gap
+    ]);
+    // 22,23,24,25 inclusive
+    expect(s.points.map((p) => p.date)).toEqual([
+      "2026-06-22",
+      "2026-06-23",
+      "2026-06-24",
+      "2026-06-25",
+    ]);
+    // Quiet days carry null daily mean but a non-null rolling (trailing window).
+    expect(s.points[1]!.mean).toBeNull();
+    expect(s.points[1]!.rolling).toBeCloseTo(1, 6); // only the 22's item in window
+    // Day 25: rolling over 19..25 window covers both items → mean(1,-1)=0
+    expect(s.points[3]!.rolling).toBeCloseTo(0, 6);
+  });
+
+  it("rolling mean uses minPeriods=1 (first day is non-null)", () => {
+    const s = buildSentimentSeries([n("2026-06-22T10:00:00Z", 0.5)]);
+    expect(s.points[0]!.rolling).toBeCloseTo(0.5, 6);
+  });
+
+  it("splitOffset = 1 (all emerald) when every value is non-negative", () => {
+    const s = buildSentimentSeries([
+      n("2026-06-22T10:00:00Z", 0.2),
+      n("2026-06-23T10:00:00Z", 0.5),
+    ]);
+    expect(s.splitOffset).toBeCloseTo(1, 6);
+  });
+
+  it("splitOffset = 0 (all red) when every value is negative", () => {
+    const s = buildSentimentSeries([
+      n("2026-06-22T10:00:00Z", -0.2),
+      n("2026-06-23T10:00:00Z", -0.5),
+    ]);
+    expect(s.splitOffset).toBeCloseTo(0, 6);
+  });
+
+  it("splitOffset = fraction of domain above zero for mixed-sign data", () => {
+    // rolling values: day1 = -0.2 ; day2 = mean(-0.2, 0.6) over 7d window = 0.2.
+    // To make the test deterministic, isolate days >7d apart so each day's
+    // rolling == its own daily mean.
+    const s = buildSentimentSeries([
+      n("2026-06-01T10:00:00Z", -0.2),
+      n("2026-07-01T10:00:00Z", 0.6),
+    ]);
+    expect(s.min).toBeCloseTo(-0.2, 6);
+    expect(s.max).toBeCloseTo(0.6, 6);
+    // domain [-0.2, 0.6], span 0.8, zero sits 0.6/0.8 = 0.75 from top.
+    expect(s.splitOffset).toBeCloseTo(0.75, 6);
+  });
+
+  it("handles empty + all-null-score input without throwing", () => {
+    expect(buildSentimentSeries([]).points).toEqual([]);
+    const allNull = buildSentimentSeries([n("2026-06-22T10:00:00Z", null)]);
+    expect(allNull.points).toHaveLength(1);
+    expect(allNull.points[0]!.rolling).toBeNull();
+    expect(allNull.splitOffset).toBe(1);
+  });
+});
+
+describe("buildWeeklyVolume", () => {
+  it("counts per ISO week over a gap-free weekly axis", () => {
+    const v = buildWeeklyVolume([
+      n("2026-06-22T10:00:00Z", 0.1), // W26
+      n("2026-06-24T10:00:00Z", 0.1), // W26
+      n("2026-07-06T10:00:00Z", 0.1), // W28 (skips W27)
+    ]);
+    expect(v).toEqual([
+      { week: "2026-W26", count: 2 },
+      { week: "2026-W27", count: 0 }, // quiet week renders as a 0 bar
+      { week: "2026-W28", count: 1 },
+    ]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(buildWeeklyVolume([])).toEqual([]);
+  });
+});
+
+describe("buildSourceBreakdown", () => {
+  it("counts by source, coalesces null/blank to Unknown, sorts count-desc", () => {
+    const slices = buildSourceBreakdown([
+      n("2026-06-22T10:00:00Z", 0.1, "Yahoo Finance"),
+      n("2026-06-22T11:00:00Z", 0.1, "Yahoo Finance"),
+      n("2026-06-22T12:00:00Z", 0.1, "Reuters"),
+      n("2026-06-22T13:00:00Z", 0.1, null),
+      n("2026-06-22T14:00:00Z", 0.1, "   "),
+    ]);
+    // Equal counts tie-break alphabetically: "Unknown" (U) before "Yahoo …" (Y).
+    expect(slices).toEqual([
+      { source: UNKNOWN_SOURCE, count: 2 },
+      { source: "Yahoo Finance", count: 2 },
+      { source: "Reuters", count: 1 },
+    ]);
+  });
+});
+
+describe("newsCoverage", () => {
+  it("flags limited when < 2 weeks or < 2 sources (the dev reality)", () => {
+    const dev = newsCoverage([
+      n("2026-06-22T10:00:00Z", 0.1, "Yahoo Finance"),
+      n("2026-06-24T10:00:00Z", 0.1, "Yahoo Finance"),
+    ]);
+    expect(dev).toEqual({ weeks: 1, sources: 1, limited: true });
+  });
+
+  it("not limited with ≥ 2 weeks and ≥ 2 sources", () => {
+    const ok = newsCoverage([
+      n("2026-06-22T10:00:00Z", 0.1, "Yahoo Finance"),
+      n("2026-07-06T10:00:00Z", 0.1, "Reuters"),
+    ]);
+    expect(ok.limited).toBe(false);
+  });
+});

--- a/frontend/src/lib/newsAnalytics.ts
+++ b/frontend/src/lib/newsAnalytics.ts
@@ -56,8 +56,9 @@ export interface SentimentSeries {
   /**
    * Gradient stop offset for the bicolor split, as a fraction from the
    * TOP of the y-domain `[min(0,min) .. max(0,max)]`. Emerald above the
-   * stop (≥0), red below (<0). 1 = all-negative (full red), 0 =
-   * all-positive (full emerald). Drives `<stop offset={splitOffset}>`.
+   * stop (≥0), red below (<0). 1 = all-non-negative (full emerald), 0 =
+   * all-negative (full red) — verified by the sign-regime tests in
+   * newsAnalytics.test.ts. Drives `<stop offset={splitOffset}>`.
    */
   readonly splitOffset: number;
 }

--- a/frontend/src/lib/newsAnalytics.ts
+++ b/frontend/src/lib/newsAnalytics.ts
@@ -1,0 +1,263 @@
+/**
+ * Pure aggregation for the news-analytics drill (#593). Consumes the
+ * `/news/{instrument_id}` items (`NewsItem[]`) and shapes them for three
+ * charts: a bicolor sentiment trend, weekly news volume, and a source
+ * breakdown. No DB, no render — table-tested in `newsAnalytics.test.ts`
+ * (the "pure policy over real DB" prevention-log lesson).
+ *
+ * All date math is UTC (`getUTC*`): `event_time` is a tz-aware ISO string
+ * whose serialized offset we must not let leak into calendar bucketing —
+ * a near-midnight event must bucket identically regardless of the
+ * viewer's timezone (Codex ckpt-1 #5).
+ */
+import type { NewsItem } from "@/api/types";
+
+const DAY_MS = 86_400_000;
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** UTC calendar day key `YYYY-MM-DD` for a tz-aware ISO timestamp. */
+function utcDayKey(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+}
+
+/** UTC midnight epoch-ms for a `YYYY-MM-DD` key. */
+function dayKeyToMs(key: string): number {
+  const p = key.split("-");
+  return Date.UTC(Number(p[0]), Number(p[1]) - 1, Number(p[2]));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Sentiment trend — daily mean + 7-day trailing rolling mean (minPeriods=1)
+// ---------------------------------------------------------------------------
+
+const ROLLING_WINDOW_DAYS = 7;
+
+export interface SentimentPoint {
+  /** UTC calendar day `YYYY-MM-DD`. */
+  readonly date: string;
+  /** Mean `sentiment_score` of scored items that day; null if none. */
+  readonly mean: number | null;
+  /** 7-day trailing rolling mean of scored items (minPeriods=1); null if
+   *  no scored item in the trailing window. This is the plotted series. */
+  readonly rolling: number | null;
+  /** Item count that day (all items, scored or not) — tooltip context. */
+  readonly count: number;
+}
+
+export interface SentimentSeries {
+  readonly points: readonly SentimentPoint[];
+  /** Min / max of the non-null `rolling` values (0 / 0 when empty). */
+  readonly min: number;
+  readonly max: number;
+  /**
+   * Gradient stop offset for the bicolor split, as a fraction from the
+   * TOP of the y-domain `[min(0,min) .. max(0,max)]`. Emerald above the
+   * stop (≥0), red below (<0). 1 = all-negative (full red), 0 =
+   * all-positive (full emerald). Drives `<stop offset={splitOffset}>`.
+   */
+  readonly splitOffset: number;
+}
+
+interface DayBucket {
+  scoredSum: number;
+  scoredN: number;
+  count: number;
+}
+
+/**
+ * Build the daily sentiment series over a gap-free UTC day axis (earliest
+ * → latest item day inclusive), so quiet days still advance the rolling
+ * window rather than being skipped. Items with a null `sentiment_score`
+ * count toward volume but not the mean (no fabricated zeros).
+ */
+export function buildSentimentSeries(items: readonly NewsItem[]): SentimentSeries {
+  const buckets = new Map<string, DayBucket>();
+  for (const it of items) {
+    if (it.event_time === null || it.event_time === undefined) continue;
+    const key = utcDayKey(it.event_time);
+    const b = buckets.get(key) ?? { scoredSum: 0, scoredN: 0, count: 0 };
+    b.count += 1;
+    if (it.sentiment_score !== null && it.sentiment_score !== undefined) {
+      b.scoredSum += it.sentiment_score;
+      b.scoredN += 1;
+    }
+    buckets.set(key, b);
+  }
+  if (buckets.size === 0) {
+    return { points: [], min: 0, max: 0, splitOffset: 1 };
+  }
+
+  const keys = [...buckets.keys()].sort();
+  const loMs = dayKeyToMs(keys[0] ?? "");
+  const hiMs = dayKeyToMs(keys[keys.length - 1] ?? "");
+
+  // Gap-free axis: one {date, bucket} per UTC day from first to last.
+  const days: { readonly date: string; readonly bucket: DayBucket | undefined }[] = [];
+  for (let ms = loMs; ms <= hiMs; ms += DAY_MS) {
+    const d = new Date(ms);
+    const date = `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+    days.push({ date, bucket: buckets.get(date) });
+  }
+
+  const points: SentimentPoint[] = [];
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < days.length; i++) {
+    const day = days[i];
+    if (day === undefined) continue; // in-bounds; guards strict index access
+    const b = day.bucket;
+    const mean = b && b.scoredN > 0 ? b.scoredSum / b.scoredN : null;
+
+    // Trailing 7-day rolling mean over scored items (minPeriods=1).
+    let rollSum = 0;
+    let rollN = 0;
+    for (let j = Math.max(0, i - (ROLLING_WINDOW_DAYS - 1)); j <= i; j++) {
+      const bj = days[j]?.bucket;
+      if (bj && bj.scoredN > 0) {
+        rollSum += bj.scoredSum;
+        rollN += bj.scoredN;
+      }
+    }
+    const rolling = rollN > 0 ? rollSum / rollN : null;
+    if (rolling !== null) {
+      if (rolling < min) min = rolling;
+      if (rolling > max) max = rolling;
+    }
+    points.push({ date: day.date, mean, rolling, count: b?.count ?? 0 });
+  }
+
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    // No scored items at all → flat empty domain.
+    return { points, min: 0, max: 0, splitOffset: 1 };
+  }
+
+  // y-domain spans zero so the bicolor split sits on the real zero line.
+  const domLo = Math.min(0, min);
+  const domHi = Math.max(0, max);
+  const span = domHi - domLo;
+  // Offset of the zero line from the TOP of the domain (0..1). span===0
+  // (all values exactly 0) → treat as fully non-negative (emerald = 1).
+  const splitOffset = span === 0 ? 1 : domHi / span;
+  return { points, min, max, splitOffset };
+}
+
+// ---------------------------------------------------------------------------
+// 2. News volume — count per ISO week (ISO week-year, UTC)
+// ---------------------------------------------------------------------------
+
+export interface WeeklyVolumePoint {
+  /** ISO week-year label `YYYY-Www` (e.g. `2026-W26`). */
+  readonly week: string;
+  readonly count: number;
+}
+
+/** ISO-8601 week + week-year (UTC) for a date. Jan 1 may fall in the prior
+ *  ISO year; Dec 29-31 may fall in the next (Codex ckpt-1 #5). */
+export function isoWeek(d: Date): { year: number; week: number } {
+  // Shift to the Thursday of this week — ISO weeks are owned by their Thursday.
+  const t = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dayNum = (t.getUTCDay() + 6) % 7; // Mon=0 .. Sun=6
+  t.setUTCDate(t.getUTCDate() - dayNum + 3);
+  const isoYear = t.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+  const firstDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDayNum + 3);
+  const week = 1 + Math.round((t.getTime() - firstThursday.getTime()) / (7 * DAY_MS));
+  return { year: isoYear, week };
+}
+
+function isoWeekKey(iso: string): string {
+  const { year, week } = isoWeek(new Date(iso));
+  return `${year}-W${pad2(week)}`;
+}
+
+/** Monday (UTC) of the ISO week containing `iso`, as epoch-ms. */
+function isoWeekMondayMs(iso: string): number {
+  const d = new Date(iso);
+  const t = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  const dayNum = (new Date(t).getUTCDay() + 6) % 7; // Mon=0
+  return t - dayNum * DAY_MS;
+}
+
+/**
+ * Count per ISO week over a gap-free weekly axis (first → last present
+ * week), so a quiet week renders as a 0 bar and a burst reads true.
+ * Iterates by Monday + 7d to stay correct across year boundaries.
+ */
+export function buildWeeklyVolume(items: readonly NewsItem[]): WeeklyVolumePoint[] {
+  const counts = new Map<string, number>();
+  let minMonday = Infinity;
+  let maxMonday = -Infinity;
+  for (const it of items) {
+    if (it.event_time === null || it.event_time === undefined) continue;
+    const key = isoWeekKey(it.event_time);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    const mon = isoWeekMondayMs(it.event_time);
+    if (mon < minMonday) minMonday = mon;
+    if (mon > maxMonday) maxMonday = mon;
+  }
+  if (counts.size === 0) return [];
+
+  const out: WeeklyVolumePoint[] = [];
+  for (let ms = minMonday; ms <= maxMonday; ms += 7 * DAY_MS) {
+    const key = isoWeekKey(new Date(ms).toISOString());
+    out.push({ week: key, count: counts.get(key) ?? 0 });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Source breakdown — count by source (null/blank → "Unknown")
+// ---------------------------------------------------------------------------
+
+export interface SourceSlice {
+  readonly source: string;
+  readonly count: number;
+}
+
+export const UNKNOWN_SOURCE = "Unknown";
+
+/** Count by `source`, coalescing null/blank to "Unknown" (Codex ckpt-1 #6).
+ *  Sorted count-desc, then name-asc for a stable legend/pie order. */
+export function buildSourceBreakdown(items: readonly NewsItem[]): SourceSlice[] {
+  const counts = new Map<string, number>();
+  for (const it of items) {
+    const raw = (it.source ?? "").trim();
+    const source = raw === "" ? UNKNOWN_SOURCE : raw;
+    counts.set(source, (counts.get(source) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([source, count]) => ({ source, count }))
+    .sort((a, b) => b.count - a.count || a.source.localeCompare(b.source));
+}
+
+// ---------------------------------------------------------------------------
+// Low-history affordance — honest dev-sparsity caption (mirrors #594's
+// dev_limited posture: build the real chart, annotate the limitation).
+// ---------------------------------------------------------------------------
+
+export interface NewsCoverage {
+  readonly weeks: number;
+  readonly sources: number;
+  /** True when the data is too thin for the charts to be representative. */
+  readonly limited: boolean;
+}
+
+export function newsCoverage(items: readonly NewsItem[]): NewsCoverage {
+  const weeks = new Set<string>();
+  const sources = new Set<string>();
+  for (const it of items) {
+    if (it.event_time !== null && it.event_time !== undefined) weeks.add(isoWeekKey(it.event_time));
+    const raw = (it.source ?? "").trim();
+    sources.add(raw === "" ? UNKNOWN_SOURCE : raw);
+  }
+  return {
+    weeks: weeks.size,
+    sources: sources.size,
+    limited: weeks.size < 2 || sources.size < 2,
+  };
+}

--- a/frontend/src/pages/NewsAnalysisPage.tsx
+++ b/frontend/src/pages/NewsAnalysisPage.tsx
@@ -1,0 +1,122 @@
+/**
+ * /instrument/:symbol/news-analysis — news-analytics drill (#593).
+ *
+ * Three charts over `/news/{instrument_id}` (#1750 RSS provider): a 7-day
+ * rolling-mean sentiment trend (emerald > 0 / red < 0), weekly news volume,
+ * and a source breakdown. Mirrors the #592 filings-analytics drill shell.
+ *
+ * News on dev is RSS-recent (single source, ~1 week) so the charts render
+ * honestly-sparse with a low-history caption — the same "build the real
+ * chart, annotate the limitation" posture as the #594 peer drill's
+ * dev_limited flags. The charts fill as news accrues in production.
+ */
+import { useCallback } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { fetchAllNews, type AllNews } from "@/api/news";
+import { fetchInstrumentSummary } from "@/api/instruments";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import {
+  NewsVolumeChart,
+  SentimentTrendChart,
+  SourceBreakdownPie,
+} from "@/components/news/newsAnalyticsCharts";
+import { EmptyState } from "@/components/states/EmptyState";
+import {
+  buildSentimentSeries,
+  buildSourceBreakdown,
+  buildWeeklyVolume,
+  newsCoverage,
+} from "@/lib/newsAnalytics";
+import { useAsync } from "@/lib/useAsync";
+
+export function NewsAnalysisPage(): JSX.Element {
+  const { symbol = "" } = useParams<{ symbol: string }>();
+  const backHref = `/instrument/${encodeURIComponent(symbol)}`;
+
+  // /news is instrument_id-keyed; resolve :symbol → id via the summary, then
+  // drain the paginated window — one lifecycle, one error surface (mirrors
+  // FilingsAnalyticsPage).
+  const news = useAsync<AllNews>(
+    useCallback(
+      () => fetchInstrumentSummary(symbol).then((s) => fetchAllNews(s.instrument_id)),
+      [symbol],
+    ),
+    [symbol],
+  );
+
+  const items = news.data?.items ?? [];
+  const isEmpty = news.data !== null && items.length === 0;
+
+  return (
+    <div className="mx-auto max-w-screen-xl space-y-4 p-4">
+      <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
+        <Link to={backHref} className="text-xs text-sky-700 hover:underline">
+          ← Back to {symbol}
+        </Link>
+        <div className="mt-1 flex flex-wrap items-baseline justify-between gap-2">
+          <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            News analytics — {symbol}
+          </h1>
+        </div>
+        <p className="mt-1 text-xs text-slate-500">
+          Sentiment direction, news cadence, and source mix over the last 12 months. Sentiment
+          is a signed score smoothed to a 7-day rolling mean (emerald above zero, red below).
+        </p>
+      </header>
+
+      {news.loading ? (
+        <SectionSkeleton rows={6} />
+      ) : news.error !== null ? (
+        <SectionError onRetry={news.refetch} />
+      ) : news.data === null || isEmpty ? (
+        <EmptyState
+          title="No news on record"
+          description="No news events for this instrument in the last 12 months. News coverage is currently limited to a recently-enabled RSS set — most instruments have none yet."
+        >
+          <Link to={backHref} className="text-sm text-sky-700 hover:underline">
+            ← Back to {symbol}
+          </Link>
+        </EmptyState>
+      ) : (
+        <NewsAnalyticsBody items={items} capped={news.data.capped} total={news.data.total} />
+      )}
+    </div>
+  );
+}
+
+function NewsAnalyticsBody({
+  items,
+  capped,
+  total,
+}: {
+  items: AllNews["items"];
+  capped: boolean;
+  total: number;
+}): JSX.Element {
+  const sentiment = buildSentimentSeries(items);
+  const volume = buildWeeklyVolume(items);
+  const sources = buildSourceBreakdown(items);
+  const coverage = newsCoverage(items);
+
+  return (
+    <>
+      {(coverage.limited || capped) && (
+        <p className="text-[11px] text-amber-700 dark:text-amber-500">
+          {capped
+            ? `Showing the newest ${items.length.toLocaleString()} of ${total.toLocaleString()} news items.`
+            : `Limited history — ${coverage.weeks} week${coverage.weeks === 1 ? "" : "s"} of news from ${coverage.sources} source${coverage.sources === 1 ? "" : "s"}. Trends fill out as coverage grows.`}
+        </p>
+      )}
+      <Section title="Sentiment trend — 7-day rolling mean">
+        <SentimentTrendChart series={sentiment} />
+      </Section>
+      <Section title="News volume — items per ISO week">
+        <NewsVolumeChart data={volume} />
+      </Section>
+      <Section title="Source breakdown">
+        <SourceBreakdownPie slices={sources} />
+      </Section>
+    </>
+  );
+}


### PR DESCRIPTION
## What

New `/instrument/:symbol/news-analysis` drill (Phase 3 of #585) over the now-populated `GET /news/{instrument_id}` (#1750 RSS provider). Mirrors the #592 filings-analytics drill shell exactly.

Three charts, pure transforms in `lib/newsAnalytics.ts` (table-tested), all colors from `useChartTheme()` `theme.*` (never `lightTheme.*` — prevention-log 1917):

1. **Sentiment trend** — 7-day rolling mean (minPeriods=1), bicolor by sign via the recharts **gradient-offset** technique: single `<Area baseValue={0}>` + a `<linearGradient>` with a hard stop at the zero-offset, `YAxis` domain forced to span zero. Emerald above 0, red below, meeting exactly on the zero line.
2. **News volume** — count per ISO week (ISO **week-year**, UTC date math — correct at year/midnight boundaries).
3. **Source breakdown** — donut by `source` (null/blank → "Unknown").

Plus: a "News analytics →" link from `RecentNewsPane` (existing pane unchanged, L1 stays); `fetchAllNews` paginates the 200-row-capped endpoint (bounded 10 pages) so a high-volume name isn't silently truncated to its newest 200.

## Premise falsification (vs live `:8000`, full population)

The issue listed the endpoint as `/instruments/{id}/news` — it is actually `/news/{instrument_id}`, defaults to a 30-day window, caps `limit` at 200, and 404s unknown instruments. Dev `news_events`: **4 instruments** (GME 20, TPR 18, BBBY 12, ATEX 2 — not AAPL), **1 ISO week** of span, **single source** ("Yahoo Finance"). So on dev: source pie = 1 slice, weekly volume = 1 bar, rolling mean ≈ raw mean. This is RSS recency, not a bug.

**Posture:** build all three charts spec-faithful for production correctness; render honestly-sparse on dev with a low-history caption — the same "build the real chart, annotate the limitation" approach as #594's `dev_limited`/`sector_n`. Charts fill as news accrues. Dev fixture: GME.

## Security model

FE-only. No new endpoint, no SQL, no auth/authz change. Reads the existing operator-gated `/news` endpoint through the established cookie-auth `apiFetch` path. The `since` window is a client-computed ISO string (not user input); pagination is hard-bounded (`MAX_PAGES=10`). No daemon restart (no ingest/parser/scheduler touch).

## Verification

- `pnpm typecheck` ✓ · `pnpm test:unit` 1115 pass (**+25 new**: 18 transform incl. ISO-week year-boundary + splitOffset sign-regime cases, 7 render incl. empty-guard branches) ✓ · `pnpm dark:check` 219 files, 0 violations ✓.
- Live endpoint shape confirmed via `curl` against GME (1699) — payload matches the transforms' inputs (incl. a `0.0` sentiment and single source).
- Codex ckpt-1 (spec) surfaced 6 edge cases (200-row truncation, area baseline, null-gap at sign crossings, partial rolling window, ISO week-year, nullable source) — all folded in before coding. Codex ckpt-2 (staged diff): clean.

## Conscious tradeoffs

- **No live in-browser screenshot.** FE auth is an HttpOnly session cookie; the isolated chrome-devtools browser has no operator session and I hold only the API bearer (which the FE doesn't use). Render is covered deterministically by the render tests (empty-guard + populated-mount) + typecheck-validated recharts props — the repo's actual chart-verification path (`FundamentalsPage.test`, `dividendsCharts.test`).
- **Weekly (not daily) volume buckets** per spec — on dev that's a thin chart, but it's correct at production scale; the low-history caption flags it.

Closes #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)