### PR TITLE
feat(#594): peer-comparison drill — radar + sector heatmap + return scatter

### DIFF
--- a/docs/proposals/ui/2026-06-27-594-peer-comparison-drill.md
+++ b/docs/proposals/ui/2026-06-27-594-peer-comparison-drill.md
@@ -1,0 +1,125 @@
+# #594 — Peer-comparison drill (`/instrument/:symbol/peers`)
+
+Phase 3 of #585. FE recharts drill over the live `GET /instruments/{symbol}/peer-comparison`
+(#1751 data layer) + the existing candles path. Sibling of the #592/#593 drills — mirrors
+their shell, pure `lib/` transforms, theme-driven charts.
+
+## Source rule / endpoint contract (verified 2026-06-27 vs live :8000, AAPL)
+
+`GET /instruments/{symbol}/peer-comparison` → `PeerComparison` (`app/api/instruments.py:299`):
+- `symbol, instrument_id, sector (raw code "1".."9", TEXT — no name lookup table),
+  sector_member_count`.
+- `factors: PeerFactor[]` — `{key, label, instrument_value|null, sector_median|null,
+  sector_n, dev_limited, better_when: "higher"|"lower"}`. **6 factors**: pe_ratio
+  (dev_limited=true, n=2, lower), roe (n=813, higher), revenue_growth_yoy (n=39, higher),
+  operating_margin (n=792, higher), debt_equity_ratio (n=843, lower), net_margin (n=824,
+  higher). **`better_when` is read from the API — never hardcoded.**
+- `peers: PeerInstrument[]` (8 for AAPL) — `{instrument_id, symbol, company_name|null,
+  size_proxy|null, factors: Record<key, number|null>}`.
+
+`GET /instruments/{symbol}/candles?range=1w|1m|3m|6m|ytd|1y|5y|max` → `InstrumentCandles`
+(`{symbol, range, days|null, rows: CandleBar[]}`, `CandleBar.close: string|null`). **Keyed by
+symbol; OHLCV values are STRINGS** — parse to float; skip null/unparseable closes.
+
+**No FE type/fetcher exists** for peer-comparison → add `PeerFactor`/`PeerInstrument`/
+`PeerComparison` to `types.ts` (mirror the Pydantic above) + `fetchPeerComparison(symbol)` to
+`api/instruments.ts`. (#592/#593 frontend-skill rule: `types.ts` mirrors the `response_model`.)
+
+## Settled-decision preservation
+
+Scoring bans **cohort-relative normalization** (`docs/settled-decisions.md` §Scoring model
+style). The radar/heatmap below normalize factors **cohort-relative for DISPLAY only** — this
+is an evidence/display layer (exactly like `instrument_risk_metrics` is "DISPLAY/EVIDENCE, NOT
+a scoring input"), it never feeds `scores`/ranking. The ban is scoping the scoring model, not
+viz. No backend change, no scoring path touched.
+
+## Dev-data reality (full-population check)
+
+Sector "3" is a broad SIC division (951 members); on dev the medians are noisy (ROE median
+0.78% vs AAPL 89%) and AAPL's "peers" by size-proxy are F/GM/CMCSA/TSLA/PG/PEP/KO/COST — odd,
+but that is the #1751 data layer's call, NOT this FE drill's bug. `pe_ratio` is dev_limited
+(n=2); `revenue_growth_yoy` is low-n (39 vs ~800). AAPL's `revenue_growth_yoy` instrument_value
+is **null** (missing radar axis point).
+
+**Posture (operator-mandated honesty):** render the real charts; **grey/flag `dev_limited`
+factors**, **surface `sector_n`** (low-n medians are noisy), and show a sector-breadth note.
+Don't fix the data here. Dev fixture: AAPL.
+
+## Charts (spec §Peer comparison, lines 149-153)
+
+Pure transforms in `frontend/src/lib/peerComparison.ts` (table-tested). All colors from
+`useChartTheme()` `theme.*` (never `lightTheme.*`).
+
+### 1. Multi-factor radar — instrument vs sector median, 2 overlays
+
+Factors have wildly different scales (P/E ~40 vs ROE ~0.9 vs margins ~0.3) → a raw radar is
+meaningless. **Normalize per factor to [0,1] across the visible cohort, oriented so outward =
+better:**
+- cohort per factor = non-null values among `{instrument_value, sector_median, each peer's
+  factor value}`.
+- `norm = (v - lo) / (hi - lo)` where lo/hi = min/max of that cohort; **degenerate `hi==lo`
+  → 0.5** (neutral, no spurious spread).
+- orient by `better_when`: `better_when==="lower"` → `score = 1 - norm` (so outward = better).
+- plot two `<Radar>` overlays: instrument (accent[1]) + sector median (accent[2], dashed).
+- `instrument_value === null` → instrument point is **null** (recharts gaps it); **likewise
+  `sector_median === null` → median point null** (median is nullable too — Codex ckpt-1).
+  `dev_limited` axis label greyed + flagged.
+- Tooltip shows the **raw** value + sector_n + better_when (normalized score is for layout
+  only, never shown as the "number").
+- Caveat (documented, not a bug): min-max is outlier-sensitive on a ~10-point cohort; this is
+  a relative-position radar, not an absolute scale. Acceptable for "where does it sit vs peers".
+
+### 2. Sector heatmap — instrument + peers × factors, colored by relative rank
+
+Hand-rolled CSS grid (mirror `filingsAnalyticsCharts.FilingHeatmapChart`, NOT recharts). Rows =
+instrument (pinned top, labeled) + 8 peers; cols = 6 factors. Each **cell** colored by the
+value's normalized position **within its factor column** (same per-factor cohort + `better_when`
+orientation as the radar) interpolated `theme.down` (red, worst) → `theme.up` (emerald, best);
+null cell = neutral/empty. `dev_limited` column header greyed. "Spot outliers."
+
+### 3. Peer return scatter — instrument vs median-peer same-day return
+
+Fetch the instrument's + each peer's candles (`range=6m`, parallel `Promise.allSettled` — a
+failed peer fetch drops that peer, never the page). Build per-symbol `date → close` (parsed
+float, null/unparseable skipped). **Iterate the instrument's own consecutive candle pairs
+`(prev, d)`**: `instrument_ret = close_inst(d)/close_inst(prev) - 1`. For each peer, include its
+return at `d` **only if the peer has closes at BOTH `prev` and `d`** (same interval — Codex
+ckpt-1: a peer that skipped `prev` would yield a multi-day return masquerading as a 1-day one);
+`peer_ret = close_peer(d)/close_peer(prev) - 1`. Take the **median** across qualifying peers.
+Plot `(instrument_ret_x, median_peer_ret_y)` + a `y = x` `<ReferenceLine>` (diagonal).
+
+**Interpretation is same-day relative performance, NOT temporal lead/lag** (Codex ckpt-1): a
+point **below** the diagonal (`y < x` → instrument_ret > peer_median) = the instrument
+**outperformed** the sector that day; above = underperformed. Label/caption say
+"outperformed/underperformed", never "led/lagged". Needs ≥ a handful of aligned days or an
+empty hint. `prev` must be the instrument's immediately-preceding candle row (gap-tolerant on
+the instrument side is fine — the peer same-interval guard is what enforces comparability).
+
+## Page + wiring
+
+- `frontend/src/pages/PeersPage.tsx` — mirror `FilingsAnalyticsPage`/`NewsAnalysisPage`:
+  `useParams`, back-link, header + subtitle, loading/error/empty states, three `<Section>`s,
+  sector-breadth + dev-limited caption. **One `useAsync` keyed on `[symbol]`** (Codex ckpt-1 #4
+  — a second useAsync keyed on peer symbols would render stale instrument scatter when two
+  instruments share a peer list): it fetches peer-comparison, then `Promise.allSettled`s the
+  instrument + peer candles in the same lifecycle and returns `{ pc, candlesBySymbol }`. One
+  source → one error surface (peer-comparison drives the error; candle failures degrade the
+  scatter to empty, never error the page). The radar/heatmap need only `pc`; the scatter reads
+  `candlesBySymbol`.
+- `frontend/src/App.tsx` — static import + route `instrument/:symbol/peers`.
+- `frontend/src/api/instruments.ts` + `types.ts` — `fetchPeerComparison` + the 3 types.
+- Entry-point link to the drill from an existing instrument-page surface (peer/valuation pane
+  if one exists; else a header link — grep at build).
+- `frontend/src/lib/peerComparison.test.ts` — unit-test normalization (orientation, degenerate,
+  null handling), heatmap ranking, return-alignment + median.
+
+## Out of scope
+
+Sector name lookup (raw code only — data layer); peer-set curation (#1751); benchmark scatter
+(#591 risk drill owns SPY beta). No backend change. No daemon restart (FE-only).
+
+## Gates
+
+`pnpm --dir frontend typecheck && test:unit && dark:check`. Codex ckpt-1 (this spec — the
+normalization is the key correctness risk) + ckpt-2 (staged diff). In-browser render blocked by
+cookie auth (as #593); covered by render tests + typecheck.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { FundamentalsPage } from "@/pages/FundamentalsPage";
 import { InsiderPage } from "@/pages/InsiderPage";
 import { OwnershipPage } from "@/pages/OwnershipPage";
 import { NewsAnalysisPage } from "@/pages/NewsAnalysisPage";
+import { PeersPage } from "@/pages/PeersPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
 import { AdminPage } from "@/pages/AdminPage";
@@ -121,6 +122,10 @@ export function App() {
           <Route
             path="instrument/:symbol/news-analysis"
             element={<NewsAnalysisPage />}
+          />
+          <Route
+            path="instrument/:symbol/peers"
+            element={<PeersPage />}
           />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -10,6 +10,7 @@ import type {
   InstrumentRiskMetrics,
   InstrumentSummary,
   IntradayInterval,
+  PeerComparison,
   PortfolioRelativeRisk,
 } from "@/api/types";
 
@@ -467,6 +468,14 @@ export function fetchInstrumentSummary(
 ): Promise<InstrumentSummary> {
   return apiFetch<InstrumentSummary>(
     `/instruments/${encodeURIComponent(symbol)}/summary`,
+  );
+}
+
+export function fetchPeerComparison(
+  symbol: string,
+): Promise<PeerComparison> {
+  return apiFetch<PeerComparison>(
+    `/instruments/${encodeURIComponent(symbol)}/peer-comparison`,
   );
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -442,6 +442,42 @@ export interface InstrumentCandles {
   rows: CandleBar[];
 }
 
+// ---------------------------------------------------------------------------
+// /instruments/{symbol}/peer-comparison (app/api/instruments.py:277-305, #1751)
+// ---------------------------------------------------------------------------
+
+/** One radar factor: the instrument's value vs its sector median. */
+export interface PeerFactor {
+  key: string;
+  label: string;
+  instrument_value: number | null;
+  sector_median: number | null;
+  /** # sector members with a non-null value (low n → noisy median). */
+  sector_n: number;
+  /** True for price-gated factors (P/E) — thin on dev. */
+  dev_limited: boolean;
+  better_when: "higher" | "lower";
+}
+
+/** A sector peer with its factor row (for the heatmap). */
+export interface PeerInstrument {
+  instrument_id: number;
+  symbol: string;
+  company_name: string | null;
+  size_proxy: number | null;
+  factors: Record<string, number | null>;
+}
+
+export interface PeerComparison {
+  symbol: string;
+  instrument_id: number;
+  /** Raw SIC division code "1".."9" — no name lookup table. */
+  sector: string;
+  sector_member_count: number;
+  factors: PeerFactor[];
+  peers: PeerInstrument[];
+}
+
 // #600 — intraday OHLCV bars served live by the eToro provider.
 // Distinct from CandleBar: bars carry a UTC ISO timestamp instead of
 // a YYYY-MM-DD date. Not persisted in price_daily.

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -60,7 +60,7 @@ import { lightTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 import { useChartTheme } from "@/lib/useChartTheme";
 import { useCallback, useId, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 const SLICE = 8;
 const CELL_HEIGHT = 96;
@@ -301,6 +301,14 @@ export function FundamentalsPane({ summary }: FundamentalsPaneProps): JSX.Elemen
       ) : (
         <FundamentalsGrid series={series} />
       )}
+      <div className="mt-2 border-t border-slate-100 dark:border-slate-800 pt-2 text-right">
+        <Link
+          to={`/instrument/${encodeURIComponent(symbol)}/peers`}
+          className="text-[11px] text-sky-700 hover:underline"
+        >
+          Peer comparison →
+        </Link>
+      </div>
     </Pane>
   );
 }

--- a/frontend/src/components/peers/peerComparisonCharts.test.tsx
+++ b/frontend/src/components/peers/peerComparisonCharts.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Render tests for the peer-comparison charts (#594). The pure shaping is
+ * exercised in `lib/peerComparison.test.ts`; these pin the empty-state guards
+ * and confirm the populated branch mounts. The heatmap is hand-rolled (no
+ * ResponsiveContainer) so its content is assertable; the radar + scatter use
+ * ResponsiveContainer (0px in jsdom — see test/setup.ts) so we assert the guard
+ * + the container element, with recharts props validated by typecheck.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  PeerRadarChart,
+  PeerReturnScatter,
+  SectorHeatmap,
+} from "@/components/peers/peerComparisonCharts";
+import {
+  buildHeatmap,
+  buildRadar,
+  buildScatter,
+} from "@/lib/peerComparison";
+import type { CandleBar, PeerComparison } from "@/api/types";
+
+const PC: PeerComparison = {
+  symbol: "AAA",
+  instrument_id: 1,
+  sector: "3",
+  sector_member_count: 951,
+  factors: [
+    { key: "roe", label: "ROE", instrument_value: 0.9, sector_median: 0.1, sector_n: 800, dev_limited: false, better_when: "higher" },
+    { key: "pe", label: "P/E", instrument_value: 40, sector_median: 50, sector_n: 2, dev_limited: true, better_when: "lower" },
+  ],
+  peers: [{ instrument_id: 2, symbol: "BBB", company_name: "BBB Inc", size_proxy: 1e9, factors: { roe: 0.5, pe: 60 } }],
+};
+
+const EMPTY_PC: PeerComparison = {
+  symbol: "ZZZ",
+  instrument_id: 9,
+  sector: "0",
+  sector_member_count: 0,
+  factors: [],
+  peers: [],
+};
+
+function cb(date: string, close: string): CandleBar {
+  return { date, open: null, high: null, low: null, close, volume: null };
+}
+
+describe("PeerRadarChart", () => {
+  it("renders the no-factors hint when nothing is comparable", () => {
+    render(<PeerRadarChart radar={buildRadar(EMPTY_PC)} symbol="ZZZ" />);
+    expect(screen.getByText(/No comparable factors/i)).toBeInTheDocument();
+  });
+
+  it("mounts the radar when factors are present", () => {
+    const { container } = render(<PeerRadarChart radar={buildRadar(PC)} symbol="AAA" />);
+    expect(screen.queryByText(/No comparable factors/i)).not.toBeInTheDocument();
+    expect(container.querySelector(".recharts-responsive-container")).not.toBeNull();
+  });
+});
+
+describe("SectorHeatmap", () => {
+  it("renders the no-peers hint on empty data", () => {
+    render(<SectorHeatmap heatmap={buildHeatmap(EMPTY_PC)} />);
+    expect(screen.getByText(/No peers to map/i)).toBeInTheDocument();
+  });
+
+  it("pins the instrument row and renders peer rows + factor headers", () => {
+    render(<SectorHeatmap heatmap={buildHeatmap(PC)} />);
+    expect(screen.getByText("AAA")).toBeInTheDocument(); // instrument row
+    expect(screen.getByText("BBB")).toBeInTheDocument(); // peer row
+    expect(screen.getByText(/ROE/)).toBeInTheDocument(); // factor header
+  });
+});
+
+describe("PeerReturnScatter", () => {
+  it("renders the not-enough-history hint with no overlapping returns", () => {
+    render(<PeerReturnScatter data={buildScatter("AAA", [], {})} />);
+    expect(screen.getByText(/Not enough overlapping price history/i)).toBeInTheDocument();
+  });
+
+  it("mounts the scatter when returns align", () => {
+    const candles: Record<string, CandleBar[]> = {
+      AAA: [cb("2026-06-01", "100"), cb("2026-06-02", "110")],
+      BBB: [cb("2026-06-01", "100"), cb("2026-06-02", "105")],
+    };
+    const { container } = render(<PeerReturnScatter data={buildScatter("AAA", ["BBB"], candles)} />);
+    expect(screen.queryByText(/Not enough overlapping/i)).not.toBeInTheDocument();
+    expect(container.querySelector(".recharts-responsive-container")).not.toBeNull();
+  });
+});

--- a/frontend/src/components/peers/peerComparisonCharts.tsx
+++ b/frontend/src/components/peers/peerComparisonCharts.tsx
@@ -1,0 +1,321 @@
+/**
+ * Charts for the peer-comparison drill (#594): a multi-factor radar, a sector
+ * heatmap (hand-rolled CSS grid, like the filings heatmap), and a same-day
+ * peer-return scatter. All read the pure shapes from `@/lib/peerComparison` and
+ * take every colour from `useChartTheme()` `theme.*` (never `lightTheme.*` —
+ * prevention-log 1917).
+ */
+import { type CSSProperties } from "react";
+import {
+  CartesianGrid,
+  Legend,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+
+import { ChartTooltip } from "@/components/charts/ChartTooltip";
+import {
+  type Heatmap,
+  type RadarPoint,
+  type ScatterData,
+} from "@/lib/peerComparison";
+import { useChartTheme } from "@/lib/useChartTheme";
+
+const CHART_HEIGHT = 320;
+
+function NoPeers({ message }: { message: string }): JSX.Element {
+  return <p className="px-2 py-6 text-xs text-slate-500">{message}</p>;
+}
+
+function fmtRaw(v: number | null): string {
+  if (v === null) return "—";
+  // Margins / ratios are fractional; large values (P/E) are not.
+  return Math.abs(v) < 10 ? v.toFixed(3) : v.toFixed(2);
+}
+
+function pct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.replace("#", "");
+  const n = parseInt(h.length === 3 ? h.replace(/./g, "$&$&") : h, 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Multi-factor radar
+// ---------------------------------------------------------------------------
+
+interface RadarTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload?: RadarPoint }>;
+  symbol: string;
+}
+
+function RadarTooltip({ active, payload, symbol }: RadarTooltipProps): JSX.Element | null {
+  if (active !== true || !payload || payload.length === 0) return null;
+  const pt = payload[0]?.payload;
+  if (!pt) return null;
+  return (
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">
+        {pt.label}
+        {pt.devLimited ? " ⚠" : ""}
+      </div>
+      <div className="tabular-nums text-slate-600 dark:text-slate-300">
+        {symbol} {fmtRaw(pt.instrumentRaw)} · sector median {fmtRaw(pt.medianRaw)}
+      </div>
+      <div className="text-slate-500 dark:text-slate-400">
+        better {pt.betterWhen} · n={pt.sectorN.toLocaleString()}
+        {pt.devLimited ? " · dev-limited" : ""}
+      </div>
+    </ChartTooltip>
+  );
+}
+
+export function PeerRadarChart({
+  radar,
+  symbol,
+}: {
+  radar: readonly RadarPoint[];
+  symbol: string;
+}): JSX.Element {
+  const theme = useChartTheme();
+  const hasSignal = radar.some((p) => p.instrument !== null || p.median !== null);
+  if (radar.length === 0 || !hasSignal) {
+    return <NoPeers message="No comparable factors for this instrument." />;
+  }
+  // Custom angle tick: grey + flag dev_limited factor labels. Look up by the
+  // label recharts passes in payload.value (robust to recharts' index-vs-
+  // payload.index quirk — Codex ckpt-2); factor labels are unique.
+  const byLabel = new Map(radar.map((p) => [p.label, p]));
+  const renderTick = (props: {
+    x?: number;
+    y?: number;
+    textAnchor?: "start" | "middle" | "end" | "inherit";
+    payload?: { value?: string };
+  }): JSX.Element => {
+    const pt = props.payload?.value !== undefined ? byLabel.get(props.payload.value) : undefined;
+    const dev = pt?.devLimited ?? false;
+    return (
+      <text
+        x={props.x}
+        y={props.y}
+        textAnchor={props.textAnchor}
+        fill={dev ? theme.textMuted : theme.textSecondary}
+        fontSize={10}
+      >
+        {props.payload?.value}
+        {dev ? " ⚠" : ""}
+      </text>
+    );
+  };
+  return (
+    <div style={{ height: CHART_HEIGHT }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <RadarChart data={[...radar]} margin={{ top: 8, right: 40, bottom: 8, left: 40 }}>
+          <PolarGrid stroke={theme.gridLine} />
+          <PolarAngleAxis dataKey="label" tick={renderTick} />
+          <PolarRadiusAxis domain={[0, 1]} tick={false} axisLine={false} />
+          <Radar
+            name={symbol}
+            dataKey="instrument"
+            stroke={theme.accent[1]}
+            fill={theme.accent[1]}
+            fillOpacity={0.3}
+            isAnimationActive={false}
+          />
+          <Radar
+            name="Sector median"
+            dataKey="median"
+            stroke={theme.accent[2]}
+            fill={theme.accent[2]}
+            fillOpacity={0.12}
+            strokeDasharray="4 2"
+            isAnimationActive={false}
+          />
+          <Tooltip content={<RadarTooltip symbol={symbol} />} />
+          <Legend wrapperStyle={{ fontSize: "11px" }} />
+        </RadarChart>
+      </ResponsiveContainer>
+      <p className="mt-1 px-2 text-[10px] text-slate-400">
+        Axes normalized per factor across the instrument + sector median + peers; outward = better
+        (orientation per factor). ⚠ = dev-limited (thin sector coverage). Hover for raw values.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Sector heatmap — hand-rolled grid, red→green by relative rank
+// ---------------------------------------------------------------------------
+
+export function SectorHeatmap({ heatmap }: { heatmap: Heatmap }): JSX.Element {
+  const theme = useChartTheme();
+  if (heatmap.factors.length === 0 || heatmap.rows.length === 0) {
+    return <NoPeers message="No peers to map." />;
+  }
+  const lo = hexToRgb(theme.down);
+  const hi = hexToRgb(theme.up);
+  const cellBg = (score: number | null): CSSProperties => {
+    if (score === null) return { backgroundColor: "transparent" };
+    const r = Math.round(lo.r + (hi.r - lo.r) * score);
+    const g = Math.round(lo.g + (hi.g - lo.g) * score);
+    const b = Math.round(lo.b + (hi.b - lo.b) * score);
+    return { backgroundColor: `rgba(${r}, ${g}, ${b}, 0.55)` };
+  };
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="grid gap-px text-[11px]"
+        style={{ gridTemplateColumns: `minmax(64px, auto) repeat(${heatmap.factors.length}, minmax(56px, 1fr))` }}
+      >
+        {/* header row: corner + factor labels */}
+        <div />
+        {heatmap.factors.map((f) => (
+          <div
+            key={f.key}
+            className={`px-1 text-center leading-tight ${
+              f.devLimited ? "text-slate-400" : "text-slate-600 dark:text-slate-300"
+            }`}
+            title={`${f.label}${f.devLimited ? " (dev-limited)" : ""} · sector n=${f.sectorN}`}
+          >
+            {f.label}
+            {f.devLimited ? " ⚠" : ""}
+          </div>
+        ))}
+        {/* one row per instrument/peer */}
+        {heatmap.rows.map((row) => (
+          <div key={row.symbol} className="contents">
+            <div
+              className={`truncate pr-2 ${
+                row.isInstrument
+                  ? "font-semibold text-slate-900 dark:text-slate-100"
+                  : "text-slate-600 dark:text-slate-300"
+              }`}
+              title={row.companyName ?? row.symbol}
+            >
+              {row.symbol}
+            </div>
+            {heatmap.factors.map((f) => {
+              const cell = row.cells[f.key];
+              const score = cell?.score ?? null;
+              return (
+                <div
+                  key={`${row.symbol}|${f.key}`}
+                  className="flex h-6 items-center justify-center rounded-sm border border-slate-100 dark:border-slate-800 tabular-nums text-[10px] text-slate-700 dark:text-slate-200"
+                  style={cellBg(score)}
+                  title={`${row.symbol} · ${f.label}: ${fmtRaw(cell?.raw ?? null)}`}
+                >
+                  {fmtRaw(cell?.raw ?? null)}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <p className="mt-2 text-[10px] text-slate-400">
+        Cell shade red→green by relative rank within each factor (green = better, per factor
+        orientation). Instrument row pinned on top. ⚠ = dev-limited factor.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Peer return scatter — instrument vs median-peer same-day return
+// ---------------------------------------------------------------------------
+
+interface ScatterTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload?: { date: string; x: number; y: number; nPeers: number } }>;
+}
+
+function ScatterTooltip({ active, payload }: ScatterTooltipProps): JSX.Element | null {
+  if (active !== true || !payload || payload.length === 0) return null;
+  const p = payload[0]?.payload;
+  if (!p) return null;
+  // Three-way: equal same-day returns sit ON the diagonal — neutral, not a loss.
+  const verdict = p.x === p.y ? "in line with" : p.x > p.y ? "outperformed" : "underperformed";
+  const verdictClass =
+    p.x === p.y
+      ? "text-slate-500 dark:text-slate-400"
+      : p.x > p.y
+        ? "text-emerald-600 dark:text-emerald-400"
+        : "text-red-600 dark:text-red-400";
+  return (
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">{p.date}</div>
+      <div className="tabular-nums text-slate-600 dark:text-slate-300">
+        instrument {pct(p.x)} · median peer {pct(p.y)}
+      </div>
+      <div className={verdictClass}>
+        {verdict} the sector · {p.nPeers} peer{p.nPeers === 1 ? "" : "s"}
+      </div>
+    </ChartTooltip>
+  );
+}
+
+export function PeerReturnScatter({ data }: { data: ScatterData }): JSX.Element {
+  const theme = useChartTheme();
+  if (data.points.length === 0) {
+    return <NoPeers message="Not enough overlapping price history to compare daily returns." />;
+  }
+  const d = data.domain;
+  return (
+    <div style={{ height: CHART_HEIGHT }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <ScatterChart margin={{ top: 8, right: 16, bottom: 16, left: 8 }}>
+          <CartesianGrid stroke={theme.gridLine} />
+          <XAxis
+            type="number"
+            dataKey="x"
+            domain={[-d, d]}
+            tickFormatter={pct}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            name="instrument"
+          >
+          </XAxis>
+          <YAxis
+            type="number"
+            dataKey="y"
+            domain={[-d, d]}
+            tickFormatter={pct}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            width={48}
+            name="median peer"
+          />
+          <ZAxis range={[28, 28]} />
+          <ReferenceLine
+            segment={[
+              { x: -d, y: -d },
+              { x: d, y: d },
+            ]}
+            stroke={theme.borderColor}
+            strokeDasharray="4 2"
+          />
+          <Tooltip content={<ScatterTooltip />} cursor={{ strokeDasharray: "3 3" }} />
+          <Scatter data={[...data.points]} fill={theme.accent[1]} fillOpacity={0.6} isAnimationActive={false} />
+        </ScatterChart>
+      </ResponsiveContainer>
+      <p className="mt-1 px-2 text-[10px] text-slate-400">
+        Each point = one day. Below the diagonal = the instrument outperformed the sector that day
+        (same-day relative return, not lead/lag).
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/lib/peerComparison.test.ts
+++ b/frontend/src/lib/peerComparison.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHeatmap,
+  buildRadar,
+  buildScatter,
+  peerCoverage,
+} from "@/lib/peerComparison";
+import type { CandleBar, PeerComparison, PeerFactor, PeerInstrument } from "@/api/types";
+
+function factor(p: Partial<PeerFactor> & { key: string; better_when: "higher" | "lower" }): PeerFactor {
+  return {
+    key: p.key,
+    label: p.label ?? p.key,
+    instrument_value: p.instrument_value ?? null,
+    sector_median: p.sector_median ?? null,
+    sector_n: p.sector_n ?? 100,
+    dev_limited: p.dev_limited ?? false,
+    better_when: p.better_when,
+  };
+}
+
+function peer(symbol: string, factors: Record<string, number | null>): PeerInstrument {
+  return { instrument_id: symbol.length, symbol, company_name: `${symbol} Inc`, size_proxy: 1e9, factors };
+}
+
+function pc(factors: PeerFactor[], peers: PeerInstrument[]): PeerComparison {
+  return {
+    symbol: "AAA",
+    instrument_id: 1,
+    sector: "3",
+    sector_member_count: 951,
+    factors,
+    peers,
+  };
+}
+
+function cb(date: string, close: string | null): CandleBar {
+  return { date, open: null, high: null, low: null, close, volume: null };
+}
+
+describe("buildRadar", () => {
+  it("normalizes outward=better for higher-is-better factors", () => {
+    const r = buildRadar(
+      pc(
+        [factor({ key: "roe", better_when: "higher", instrument_value: 0.9, sector_median: 0.1 })],
+        [peer("F", { roe: 0.5 })],
+      ),
+    );
+    // cohort {0.1, 0.5, 0.9}: instrument 0.9 → 1.0 (best), median 0.1 → 0.0 (worst)
+    expect(r[0]!.instrument).toBeCloseTo(1, 6);
+    expect(r[0]!.median).toBeCloseTo(0, 6);
+    expect(r[0]!.instrumentRaw).toBe(0.9);
+  });
+
+  it("inverts for lower-is-better factors (low P/E scores outward)", () => {
+    const r = buildRadar(
+      pc(
+        [factor({ key: "pe", better_when: "lower", instrument_value: 40, sector_median: 50 })],
+        [peer("F", { pe: 60 })],
+      ),
+    );
+    // cohort {40,50,60}: instrument 40 → norm 0 → oriented 1.0 (lowest P/E = best)
+    expect(r[0]!.instrument).toBeCloseTo(1, 6);
+    expect(r[0]!.median).toBeCloseTo(0.5, 6);
+  });
+
+  it("degenerate cohort (all equal) → 0.5 neutral", () => {
+    const r = buildRadar(
+      pc([factor({ key: "x", better_when: "higher", instrument_value: 5, sector_median: 5 })], [peer("F", { x: 5 })]),
+    );
+    expect(r[0]!.instrument).toBeCloseTo(0.5, 6);
+    expect(r[0]!.median).toBeCloseTo(0.5, 6);
+  });
+
+  it("gaps a null instrument_value AND a null sector_median", () => {
+    const r = buildRadar(
+      pc(
+        [
+          factor({ key: "g", better_when: "higher", instrument_value: null, sector_median: 2.6 }),
+          factor({ key: "h", better_when: "higher", instrument_value: 0.3, sector_median: null }),
+        ],
+        [peer("F", { g: 0.1, h: 0.2 })],
+      ),
+    );
+    expect(r[0]!.instrument).toBeNull();
+    expect(r[0]!.median).not.toBeNull();
+    expect(r[1]!.median).toBeNull();
+    expect(r[1]!.instrument).not.toBeNull();
+  });
+});
+
+describe("buildHeatmap", () => {
+  it("pins the instrument as the first row and scores cells", () => {
+    const h = buildHeatmap(
+      pc(
+        [factor({ key: "roe", better_when: "higher", instrument_value: 0.9, sector_median: 0.1 })],
+        [peer("F", { roe: 0.5 }), peer("GM", { roe: null })],
+      ),
+    );
+    expect(h.rows[0]!.isInstrument).toBe(true);
+    expect(h.rows[0]!.symbol).toBe("AAA");
+    expect(h.rows[0]!.cells.roe!.score).toBeCloseTo(1, 6);
+    expect(h.rows[1]!.cells.roe!.score).toBeCloseTo(0.5, 6); // F=0.5 mid
+    expect(h.rows[2]!.cells.roe!.score).toBeNull(); // GM null
+    expect(h.rows[2]!.cells.roe!.raw).toBeNull();
+  });
+});
+
+describe("buildScatter", () => {
+  it("excludes a peer return whose prev candle is missing (same-interval guard)", () => {
+    const candles: Record<string, CandleBar[]> = {
+      AAA: [cb("2026-06-01", "100"), cb("2026-06-02", "110"), cb("2026-06-03", "121")],
+      F: [cb("2026-06-01", "100"), cb("2026-06-02", "105"), cb("2026-06-03", "110.25")],
+      // GM skips 06-02 → its 06-03 return would span 2 days; must be excluded
+      GM: [cb("2026-06-01", "100"), cb("2026-06-03", "130")],
+    };
+    const s = buildScatter("AAA", ["F", "GM"], candles);
+    expect(s.points).toHaveLength(2);
+    // Both points: only F qualifies (GM missing 06-02 for both pairs)
+    expect(s.points.every((p) => p.nPeers === 1)).toBe(true);
+    // Instrument +10%/day, F +5%/day → instrument outperformed (x > y, below diagonal)
+    expect(s.points[0]!.x).toBeCloseTo(0.1, 6);
+    expect(s.points[0]!.y).toBeCloseTo(0.05, 6);
+    expect(s.points[0]!.x).toBeGreaterThan(s.points[0]!.y);
+  });
+
+  it("takes the median across qualifying peers and a symmetric domain", () => {
+    const candles: Record<string, CandleBar[]> = {
+      AAA: [cb("2026-06-01", "100"), cb("2026-06-02", "100")], // 0% return
+      F: [cb("2026-06-01", "100"), cb("2026-06-02", "110")], // +10%
+      GM: [cb("2026-06-01", "100"), cb("2026-06-02", "120")], // +20%
+      KO: [cb("2026-06-01", "100"), cb("2026-06-02", "130")], // +30%
+    };
+    const s = buildScatter("AAA", ["F", "GM", "KO"], candles);
+    expect(s.points[0]!.x).toBeCloseTo(0, 6);
+    expect(s.points[0]!.y).toBeCloseTo(0.2, 6); // median(0.1,0.2,0.3)
+    expect(s.points[0]!.nPeers).toBe(3);
+    expect(s.domain).toBeCloseTo(0.2, 6);
+  });
+
+  it("skips non-positive / unparseable closes without throwing", () => {
+    const candles: Record<string, CandleBar[]> = {
+      AAA: [cb("2026-06-01", "0"), cb("2026-06-02", "abc"), cb("2026-06-03", "121"), cb("2026-06-04", "133.1")],
+      F: [cb("2026-06-03", "100"), cb("2026-06-04", "105")],
+    };
+    const s = buildScatter("AAA", ["F"], candles);
+    // Only the 06-03→06-04 pair has valid closes on both sides for both symbols
+    expect(s.points).toHaveLength(1);
+    expect(s.points[0]!.date).toBe("2026-06-04");
+  });
+});
+
+describe("peerCoverage", () => {
+  it("collects dev_limited keys and the min sector_n", () => {
+    const cov = peerCoverage(
+      pc(
+        [
+          factor({ key: "pe", better_when: "lower", dev_limited: true, sector_n: 2 }),
+          factor({ key: "roe", better_when: "higher", sector_n: 813 }),
+          factor({ key: "rev", better_when: "higher", sector_n: 39 }),
+        ],
+        [],
+      ),
+    );
+    expect(cov.devLimitedKeys).toEqual(["pe"]);
+    expect(cov.minSectorN).toBe(2);
+  });
+});

--- a/frontend/src/lib/peerComparison.ts
+++ b/frontend/src/lib/peerComparison.ts
@@ -1,0 +1,274 @@
+/**
+ * Pure aggregation for the peer-comparison drill (#594). Consumes
+ * `PeerComparison` (+ peer candles) and shapes the radar, sector heatmap, and
+ * return scatter. No DB, no render — table-tested in `peerComparison.test.ts`
+ * (the "pure policy over real DB" prevention-log lesson).
+ *
+ * Normalization is DISPLAY-only (evidence layer) — it never feeds scoring, so
+ * the scoring "no cohort-relative normalization" ban does not apply
+ * (docs/settled-decisions.md §Scoring; mirrors instrument_risk_metrics).
+ * `better_when` is always read from the API, never hardcoded.
+ */
+import type { CandleBar, PeerComparison } from "@/api/types";
+
+type Orientation = "higher" | "lower";
+
+interface Cohort {
+  readonly lo: number;
+  readonly hi: number;
+}
+
+/**
+ * Per-factor scale across the visible cohort: the instrument value, the sector
+ * median, and every peer's value (nulls excluded). Returns null when nothing is
+ * available for that factor.
+ */
+function factorCohort(
+  pc: PeerComparison,
+  key: string,
+  instrumentValue: number | null,
+  sectorMedian: number | null,
+): Cohort | null {
+  const vals: number[] = [];
+  if (instrumentValue !== null) vals.push(instrumentValue);
+  if (sectorMedian !== null) vals.push(sectorMedian);
+  for (const p of pc.peers) {
+    const v = p.factors[key];
+    if (v !== null && v !== undefined) vals.push(v);
+  }
+  if (vals.length === 0) return null;
+  return { lo: Math.min(...vals), hi: Math.max(...vals) };
+}
+
+/**
+ * Normalize `value` to [0,1] within `cohort`, oriented so OUTWARD = better.
+ * Degenerate cohort (hi==lo) → 0.5 (neutral). null value / cohort → null.
+ */
+function orientedScore(
+  value: number | null,
+  cohort: Cohort | null,
+  betterWhen: Orientation,
+): number | null {
+  if (value === null || cohort === null) return null;
+  const { lo, hi } = cohort;
+  const norm = hi === lo ? 0.5 : (value - lo) / (hi - lo);
+  return betterWhen === "lower" ? 1 - norm : norm;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Multi-factor radar — instrument vs sector median (2 overlays)
+// ---------------------------------------------------------------------------
+
+export interface RadarPoint {
+  readonly key: string;
+  readonly label: string;
+  readonly devLimited: boolean;
+  readonly sectorN: number;
+  readonly betterWhen: Orientation;
+  /** Normalized scores [0,1], outward=better (recharts dataKeys). null = gap. */
+  readonly instrument: number | null;
+  readonly median: number | null;
+  /** Raw values for the tooltip (the score is layout-only, never shown). */
+  readonly instrumentRaw: number | null;
+  readonly medianRaw: number | null;
+}
+
+export function buildRadar(pc: PeerComparison): RadarPoint[] {
+  return pc.factors.map((f) => {
+    const cohort = factorCohort(pc, f.key, f.instrument_value, f.sector_median);
+    return {
+      key: f.key,
+      label: f.label,
+      devLimited: f.dev_limited,
+      sectorN: f.sector_n,
+      betterWhen: f.better_when,
+      instrument: orientedScore(f.instrument_value, cohort, f.better_when),
+      median: orientedScore(f.sector_median, cohort, f.better_when),
+      instrumentRaw: f.instrument_value,
+      medianRaw: f.sector_median,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 2. Sector heatmap — (instrument + peers) rows × factor columns
+// ---------------------------------------------------------------------------
+
+export interface HeatFactor {
+  readonly key: string;
+  readonly label: string;
+  readonly devLimited: boolean;
+  readonly sectorN: number;
+}
+
+export interface HeatCell {
+  readonly raw: number | null;
+  /** Oriented [0,1] (outward=better) within the factor column; null = empty. */
+  readonly score: number | null;
+}
+
+export interface HeatRow {
+  readonly symbol: string;
+  readonly companyName: string | null;
+  readonly isInstrument: boolean;
+  readonly cells: Record<string, HeatCell>;
+}
+
+export interface Heatmap {
+  readonly factors: HeatFactor[];
+  readonly rows: HeatRow[];
+}
+
+/**
+ * Heatmap over the same per-factor cohort as the radar (instrument + median +
+ * peers), so the radar and heatmap colour scales agree. The instrument is the
+ * pinned first row; cells coloured by oriented score in the chart.
+ */
+export function buildHeatmap(pc: PeerComparison): Heatmap {
+  const factors: HeatFactor[] = pc.factors.map((f) => ({
+    key: f.key,
+    label: f.label,
+    devLimited: f.dev_limited,
+    sectorN: f.sector_n,
+  }));
+
+  // Cohort + orientation per factor, computed once.
+  const cohorts = new Map<string, { cohort: Cohort | null; betterWhen: Orientation }>();
+  for (const f of pc.factors) {
+    cohorts.set(f.key, {
+      cohort: factorCohort(pc, f.key, f.instrument_value, f.sector_median),
+      betterWhen: f.better_when,
+    });
+  }
+
+  const cellsFor = (lookup: (key: string) => number | null): Record<string, HeatCell> => {
+    const out: Record<string, HeatCell> = {};
+    for (const f of pc.factors) {
+      const raw = lookup(f.key);
+      const c = cohorts.get(f.key);
+      out[f.key] = {
+        raw,
+        score: c ? orientedScore(raw, c.cohort, c.betterWhen) : null,
+      };
+    }
+    return out;
+  };
+
+  const instrumentRow: HeatRow = {
+    symbol: pc.symbol,
+    companyName: null,
+    isInstrument: true,
+    cells: cellsFor((key) => pc.factors.find((f) => f.key === key)?.instrument_value ?? null),
+  };
+  const peerRows: HeatRow[] = pc.peers.map((p) => ({
+    symbol: p.symbol,
+    companyName: p.company_name,
+    isInstrument: false,
+    cells: cellsFor((key) => p.factors[key] ?? null),
+  }));
+
+  return { factors, rows: [instrumentRow, ...peerRows] };
+}
+
+// ---------------------------------------------------------------------------
+// 3. Peer return scatter — instrument vs median-peer SAME-DAY return
+// ---------------------------------------------------------------------------
+
+export interface ScatterPoint {
+  readonly date: string;
+  /** Instrument same-day simple return. */
+  readonly x: number;
+  /** Median peer same-day return over the SAME interval. */
+  readonly y: number;
+  readonly nPeers: number;
+}
+
+export interface ScatterData {
+  readonly points: ScatterPoint[];
+  /** Symmetric axis half-extent so the y=x diagonal centres (min 0.01). */
+  readonly domain: number;
+}
+
+function parseClose(raw: string | null): number | null {
+  if (raw === null) return null;
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  if (s.length % 2 === 1) return s[mid] ?? 0;
+  return ((s[mid - 1] ?? 0) + (s[mid] ?? 0)) / 2;
+}
+
+/**
+ * Scatter the instrument's same-day return (x) vs the median peer return (y).
+ * Iterates the instrument's own consecutive candle pairs; a peer contributes a
+ * return for that pair ONLY if it has closes at BOTH the prev and current dates
+ * (same interval — a peer that skipped `prev` would otherwise yield a multi-day
+ * return masquerading as a one-day one). Below the y=x diagonal (y < x) = the
+ * instrument OUTperformed the sector that day (NOT temporal lead/lag).
+ */
+export function buildScatter(
+  instrumentSymbol: string,
+  peerSymbols: readonly string[],
+  candlesBySymbol: Record<string, CandleBar[]>,
+): ScatterData {
+  const inst = (candlesBySymbol[instrumentSymbol] ?? [])
+    .map((b) => ({ date: b.date, close: parseClose(b.close) }))
+    .filter((b): b is { date: string; close: number } => b.close !== null)
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  const peerMaps = peerSymbols.map((sym) => {
+    const m = new Map<string, number>();
+    for (const b of candlesBySymbol[sym] ?? []) {
+      const c = parseClose(b.close);
+      if (c !== null) m.set(b.date, c);
+    }
+    return m;
+  });
+
+  const points: ScatterPoint[] = [];
+  let domain = 0;
+  for (let i = 1; i < inst.length; i++) {
+    const prev = inst[i - 1];
+    const cur = inst[i];
+    if (prev === undefined || cur === undefined) continue;
+    const x = cur.close / prev.close - 1;
+
+    const peerRets: number[] = [];
+    for (const m of peerMaps) {
+      const cp = m.get(prev.date);
+      const cc = m.get(cur.date);
+      if (cp !== undefined && cc !== undefined && cp > 0) peerRets.push(cc / cp - 1);
+    }
+    if (peerRets.length === 0) continue;
+
+    const y = median(peerRets);
+    points.push({ date: cur.date, x, y, nPeers: peerRets.length });
+    domain = Math.max(domain, Math.abs(x), Math.abs(y));
+  }
+
+  return { points, domain: domain > 0 ? domain : 0.01 };
+}
+
+// ---------------------------------------------------------------------------
+// Coverage / dev-honesty affordances
+// ---------------------------------------------------------------------------
+
+export interface PeerCoverage {
+  /** Factors flagged dev_limited (e.g. P/E) — greyed in the UI. */
+  readonly devLimitedKeys: string[];
+  /** Min sector_n across factors — low n means a noisy median. */
+  readonly minSectorN: number;
+}
+
+export function peerCoverage(pc: PeerComparison): PeerCoverage {
+  const devLimitedKeys = pc.factors.filter((f) => f.dev_limited).map((f) => f.key);
+  const minSectorN = pc.factors.reduce(
+    (m, f) => Math.min(m, f.sector_n),
+    pc.factors.length > 0 ? Infinity : 0,
+  );
+  return { devLimitedKeys, minSectorN: Number.isFinite(minSectorN) ? minSectorN : 0 };
+}

--- a/frontend/src/pages/PeersPage.tsx
+++ b/frontend/src/pages/PeersPage.tsx
@@ -1,0 +1,140 @@
+/**
+ * /instrument/:symbol/peers — peer-comparison drill (#594).
+ *
+ * Three charts over `/instruments/{symbol}/peer-comparison` (#1751) + peer
+ * candles: a multi-factor radar (instrument vs sector median), a sector heatmap
+ * (instrument + peers × factors), and a same-day peer-return scatter. Mirrors
+ * the #592/#593 drill shells.
+ *
+ * One useAsync keyed on [symbol] (Codex ckpt-1 #4): fetch peer-comparison, then
+ * Promise.allSettled the instrument + peer candles in the same lifecycle. One
+ * source → one error surface — peer-comparison drives the error; a failed peer
+ * candle fetch degrades the scatter to empty, it never errors the page.
+ *
+ * Normalization is display-only (evidence layer), not scoring — see
+ * lib/peerComparison.ts header + docs/settled-decisions.md §Scoring.
+ */
+import { useCallback } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { fetchInstrumentCandles, fetchPeerComparison } from "@/api/instruments";
+import type { CandleBar, PeerComparison } from "@/api/types";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import {
+  PeerRadarChart,
+  PeerReturnScatter,
+  SectorHeatmap,
+} from "@/components/peers/peerComparisonCharts";
+import { EmptyState } from "@/components/states/EmptyState";
+import {
+  buildHeatmap,
+  buildRadar,
+  buildScatter,
+  peerCoverage,
+} from "@/lib/peerComparison";
+import { useAsync } from "@/lib/useAsync";
+
+interface PeersData {
+  readonly pc: PeerComparison;
+  readonly candlesBySymbol: Record<string, CandleBar[]>;
+}
+
+export function PeersPage(): JSX.Element {
+  const { symbol = "" } = useParams<{ symbol: string }>();
+  const backHref = `/instrument/${encodeURIComponent(symbol)}`;
+
+  const state = useAsync<PeersData>(
+    useCallback(async () => {
+      const pc = await fetchPeerComparison(symbol);
+      const symbols = [pc.symbol, ...pc.peers.map((p) => p.symbol)];
+      const settled = await Promise.allSettled(
+        symbols.map((s) => fetchInstrumentCandles(s, "6m")),
+      );
+      const candlesBySymbol: Record<string, CandleBar[]> = {};
+      settled.forEach((res, i) => {
+        const sym = symbols[i];
+        if (sym !== undefined && res.status === "fulfilled") {
+          candlesBySymbol[sym] = res.value.rows;
+        }
+      });
+      return { pc, candlesBySymbol };
+    }, [symbol]),
+    [symbol],
+  );
+
+  const pc = state.data?.pc ?? null;
+  const isEmpty = pc !== null && pc.factors.length === 0 && pc.peers.length === 0;
+
+  return (
+    <div className="mx-auto max-w-screen-xl space-y-4 p-4">
+      <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
+        <Link to={backHref} className="text-xs text-sky-700 hover:underline">
+          ← Back to {symbol}
+        </Link>
+        <div className="mt-1 flex flex-wrap items-baseline justify-between gap-2">
+          <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Peer comparison — {symbol}
+          </h1>
+        </div>
+        <p className="mt-1 text-xs text-slate-500">
+          How {symbol} sits against its sector peers across valuation, profitability, and leverage
+          factors, plus daily return co-movement. Factor axes are normalized per factor for
+          comparison (display only).
+        </p>
+      </header>
+
+      {state.loading ? (
+        <SectionSkeleton rows={6} />
+      ) : state.error !== null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : pc === null || isEmpty ? (
+        <EmptyState
+          title="No peer data"
+          description="No sector peer set for this instrument — likely a non-US issuer, an instrument without a sector classification, or one lacking complete-TTM fundamentals."
+        >
+          <Link to={backHref} className="text-sm text-sky-700 hover:underline">
+            ← Back to {symbol}
+          </Link>
+        </EmptyState>
+      ) : (
+        <PeersBody data={state.data!} />
+      )}
+    </div>
+  );
+}
+
+function PeersBody({ data }: { data: PeersData }): JSX.Element {
+  const { pc, candlesBySymbol } = data;
+  const radar = buildRadar(pc);
+  const heatmap = buildHeatmap(pc);
+  const scatter = buildScatter(
+    pc.symbol,
+    pc.peers.map((p) => p.symbol),
+    candlesBySymbol,
+  );
+  const coverage = peerCoverage(pc);
+
+  return (
+    <>
+      <p className="text-[11px] text-slate-500 dark:text-slate-400">
+        Sector {pc.sector} · {pc.sector_member_count.toLocaleString()} members · {pc.peers.length}{" "}
+        size-matched peers.
+        {coverage.devLimitedKeys.length > 0
+          ? ` ${coverage.devLimitedKeys.length} factor${coverage.devLimitedKeys.length === 1 ? "" : "s"} dev-limited (greyed).`
+          : ""}
+        {coverage.minSectorN < 50
+          ? ` Some sector medians rest on as few as ${coverage.minSectorN.toLocaleString()} members — read them as noisy.`
+          : ""}
+      </p>
+      <Section title={`Multi-factor radar — ${pc.symbol} vs sector median`}>
+        <PeerRadarChart radar={radar} symbol={pc.symbol} />
+      </Section>
+      <Section title={`Sector heatmap — ${pc.symbol} + peers × factors`}>
+        <SectorHeatmap heatmap={heatmap} />
+      </Section>
+      <Section title="Peer return scatter — daily returns vs sector">
+        <PeerReturnScatter data={scatter} />
+      </Section>
+    </>
+  );
+}


### PR DESCRIPTION
## What

New `/instrument/:symbol/peers` drill (Phase 3 of #585, closes the #585 chart cluster) over the live `GET /instruments/{symbol}/peer-comparison` (#1751) + the existing candles path. Mirrors the #592/#593 drill shells.

Three charts, pure transforms in `lib/peerComparison.ts` (table-tested), all colors from `useChartTheme()` `theme.*`:

1. **Multi-factor radar** — instrument vs sector median, 2 overlays. Per-factor min-max normalization across `{instrument, sector_median, peers}`, oriented by `better_when` (**read from the API, never hardcoded**; outward = better). Degenerate cohort → 0.5. `dev_limited` axes greyed + flagged; raw values + `sector_n` in the tooltip (the normalized score is layout-only).
2. **Sector heatmap** — instrument (pinned first row) + peers × factors, hand-rolled CSS grid (like the filings heatmap), cells red→green by relative rank within each factor column (same cohort + orientation).
3. **Peer return scatter** — instrument same-day return (x) vs median peer (y). A peer contributes a return for a day **only if it has closes at both the prev and current dates** (same-interval guard — a gap would otherwise yield a multi-day return masquerading as one-day). `y = x` diagonal; below = instrument **outperformed** the sector that day (same-day relative, **not** temporal lead/lag).

Plus: single `useAsync` (peer-comparison → `Promise.allSettled` candles — one error surface, candle failures degrade the scatter not the page); a "Peer comparison →" link from `FundamentalsPane` (L1 discovery); `PeerComparison`/`PeerFactor`/`PeerInstrument` types + `fetchPeerComparison`.

## Premise falsification (vs live `:8000`, AAPL)

Endpoint returns **6** factors (pe_ratio `dev_limited` n=2, roe n=813, revenue_growth_yoy n=39, operating_margin n=792, debt_equity_ratio n=843, net_margin n=824) — each with `better_when`; **8** size-matched peers; `sector` is a raw code "1".."9" (no name table). AAPL's `revenue_growth_yoy` instrument_value is **null** (gapped axis). Candle closes are **strings** (parsed). No FE type/fetcher existed → added.

## Settled-decision preservation

Scoring bans **cohort-relative normalization** (`docs/settled-decisions.md` §Scoring). The radar/heatmap normalize **for display only** — an evidence layer (like `instrument_risk_metrics` is "DISPLAY/EVIDENCE, NOT a scoring input"); it never feeds `scores`/ranking. The ban scopes the scoring model, not viz. Stated in `lib/peerComparison.ts` header + `PeersPage.tsx`. No backend/scoring change.

## Dev-data honesty (operator-mandated)

Sector "3" is a broad SIC division (951 members) so dev medians are noisy (ROE median 0.78% vs AAPL 89%) and the size-matched peers are cross-industry — the #1751 data layer's call, not this FE's bug. Rendered honestly: `dev_limited` factors greyed, low `sector_n` surfaced in a caption ("read as noisy"), sector breadth shown. Dev fixture: AAPL.

## Security model

FE-only. No new endpoint, no SQL, no auth/authz change. Reads operator-gated endpoints via the cookie-auth `apiFetch`. Candle fetches are keyed on peer symbols from the trusted API response (not user input). No daemon restart.

## Verification

- `pnpm typecheck` ✓ · `pnpm test:unit` 1130 pass (**+15**: 9 transform incl. orientation both directions, degenerate cohort, nullable median, same-interval scatter guard, median+symmetric domain; 6 render incl. empty guards + heatmap row/header content) ✓ · `pnpm dark:check` 222 files, 0 violations ✓.
- Live endpoint shapes confirmed via `curl` (peer-comparison AAPL + candles F).
- Codex ckpt-1 (spec): 4 edge cases folded pre-code (nullable `sector_median`, same-interval peer returns, outperformance-not-lead/lag terminology, single-useAsync race). Codex ckpt-2 (diff): fixed 2 real bugs — recharts tick `payload.index`→label lookup (dev-limited ticks were never greying) + scatter `x===y` neutral verdict (was mislabeled "underperformed").

## Conscious tradeoffs

- **No live in-browser screenshot** (same as #593): FE auth is an HttpOnly cookie; the isolated chrome-devtools browser has no operator session. Render covered by the render tests + typecheck-validated recharts props (the repo's actual chart-verification path).
- **Radar min-max is outlier-sensitive** on a ~10-point cohort — it's a relative-position radar (where the instrument sits vs peers), not an absolute scale. Documented in the chart caption.
- **6-month candle window** for the scatter; a peer with no eToro candles is dropped (allSettled), median taken over whoever remains.

Closes #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)