### PR TITLE
fix(#1743): theme recharts default tooltips for dark mode

### DIFF
--- a/frontend/src/components/dividends/dividendsCharts.tsx
+++ b/frontend/src/components/dividends/dividendsCharts.tsx
@@ -27,7 +27,7 @@ import {
 
 import type { DividendPeriod } from "@/api/instruments";
 import type { InstrumentFinancialRow } from "@/api/types";
-import { type ChartTheme, lightTheme } from "@/lib/chartTheme";
+import { type ChartTheme, defaultTooltipStyle, lightTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import {
   buildCumulativeDps,
@@ -135,7 +135,7 @@ export function DpsLineChart({ history }: HistoryProps): JSX.Element {
           <Tooltip
             formatter={(value: number) => formatDps(value, currency)}
             labelFormatter={formatPeriod}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Line
             type="monotone"
@@ -194,7 +194,7 @@ export function CumulativeDpsChart({ history }: HistoryProps): JSX.Element {
           <Tooltip
             formatter={(value: number) => formatDps(value, currency)}
             labelFormatter={formatPeriod}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Area
             type="monotone"
@@ -261,7 +261,7 @@ export function PayoutRatioChart({ cashflowRows }: PayoutRatioProps): JSX.Elemen
           <Tooltip
             formatter={(value: number) => formatPct(value)}
             labelFormatter={formatPeriod}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Line
             type="monotone"
@@ -320,7 +320,7 @@ export function YieldOnCostChart({
                 : [value.toFixed(4), name]
             }
             labelFormatter={(fy: number) => `FY${fy}`}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Bar dataKey="yoc_pct" name="Yield-on-cost" isAnimationActive={false}>
             {series.map((s) => (

--- a/frontend/src/components/fundamentals/fundamentalsCharts.tsx
+++ b/frontend/src/components/fundamentals/fundamentalsCharts.tsx
@@ -32,7 +32,7 @@ import {
 
 import type { FcfYieldSeries } from "@/api/types";
 import { ChartTooltip } from "@/components/charts/ChartTooltip";
-import { type ChartTheme, lightTheme } from "@/lib/chartTheme";
+import { type ChartTheme, defaultTooltipStyle, lightTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import {
   buildCashflowWaterfall,
@@ -151,7 +151,7 @@ export function PnlStackedChart({ periods }: PnlChartProps): JSX.Element {
             cursor={{ fill: theme.gridLine }}
             formatter={(value: number) => formatBigNumber(value)}
             labelFormatter={formatPeriod}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
           <Bar dataKey="cogs" name="COGS" stackId="a" fill={lightTheme.accent[3]} isAnimationActive={false} />
@@ -185,7 +185,7 @@ export function MarginTrendsChart({ periods }: PnlChartProps): JSX.Element {
           <Tooltip
             formatter={(value: number) => formatPct(value)}
             labelFormatter={formatPeriod}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
           <Line type="monotone" dataKey="gross_pct" name="Gross" stroke={lightTheme.accent[1]} strokeWidth={2} dot={false} isAnimationActive={false} />
@@ -226,7 +226,7 @@ export function YoyGrowthChart({
           <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
           <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...sharedAxis(theme)} />
           <ReferenceLine y={0} stroke={theme.borderColor} />
-          <Tooltip formatter={(value: number) => formatPct(value)} labelFormatter={formatPeriod} contentStyle={{ fontSize: "11px" }} />
+          <Tooltip formatter={(value: number) => formatPct(value)} labelFormatter={formatPeriod} contentStyle={defaultTooltipStyle(theme)} />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
           <Bar dataKey="revenue_yoy_pct" name="Revenue" fill={lightTheme.accent[1]} isAnimationActive={false} />
           <Bar dataKey="eps_yoy_pct" name="EPS (diluted)" fill={lightTheme.accent[2]} isAnimationActive={false} />
@@ -300,7 +300,7 @@ export function CashflowWaterfallChart({ period }: WaterfallProps): JSX.Element 
               return [formatBigNumber(payload.value), payload.label];
             }}
             labelFormatter={() => ""}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Bar dataKey="base" stackId="a" fill="transparent" isAnimationActive={false} />
           <Bar dataKey="delta" stackId="a" isAnimationActive={false}>
@@ -361,7 +361,7 @@ export function BalanceStructureChart({
             <YAxis type="category" dataKey="side" width={140} {...sharedAxis(theme)} />
             <Tooltip
               formatter={(value: number, name: string) => [formatBigNumber(value), name]}
-              contentStyle={{ fontSize: "11px" }}
+              contentStyle={defaultTooltipStyle(theme)}
             />
             <Legend wrapperStyle={{ fontSize: "11px" }} />
             <Bar dataKey="assets" name="Assets" stackId="a" fill={lightTheme.accent[1]} isAnimationActive={false} />
@@ -400,7 +400,7 @@ export function DebtStructureChart({ periods }: PnlChartProps): JSX.Element {
                 : [formatBigNumber(value), name]
             }
             labelFormatter={formatPeriod}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
           <Bar yAxisId="left" dataKey="long_term" name="Long-term debt" stackId="d" fill={lightTheme.accent[3]} isAnimationActive={false} />
@@ -455,7 +455,7 @@ export function DupontChart({ periods }: PnlChartProps): JSX.Element {
                 : [formatRatio(value), name]
             }
             labelFormatter={formatPeriod}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Legend wrapperStyle={{ fontSize: "11px" }} />
           <Line yAxisId="pct" type="monotone" dataKey="roe_pct" name="ROE" stroke={lightTheme.accent[0]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
@@ -491,7 +491,7 @@ export function RoicChart({ periods }: PnlChartProps): JSX.Element {
           <XAxis dataKey="period_end" tickFormatter={formatPeriod} interval="preserveStartEnd" minTickGap={20} {...sharedAxis(theme)} />
           <YAxis tickFormatter={(v: number) => `${v.toFixed(0)}%`} width={48} {...sharedAxis(theme)} />
           <ReferenceLine y={0} stroke={theme.borderColor} />
-          <Tooltip formatter={(value: number) => formatPct(value)} labelFormatter={formatPeriod} contentStyle={{ fontSize: "11px" }} />
+          <Tooltip formatter={(value: number) => formatPct(value)} labelFormatter={formatPeriod} contentStyle={defaultTooltipStyle(theme)} />
           <Line type="monotone" dataKey="roic_pct" name="ROIC" stroke={lightTheme.accent[2]} strokeWidth={2.5} dot={false} isAnimationActive={false} />
         </LineChart>
       </ResponsiveContainer>

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -56,7 +56,7 @@ import type { InstrumentFinancialRow, InstrumentSummary } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
 import { formatBigNumber } from "@/lib/format";
-import { lightTheme } from "@/lib/chartTheme";
+import { defaultTooltipStyle, lightTheme } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 import { useChartTheme } from "@/lib/useChartTheme";
 import { useCallback, useId, useMemo } from "react";
@@ -469,11 +469,7 @@ function FundamentalCell({
                   return [formatBigNumber(Number.isFinite(n) ? n : null), label];
                 }}
                 labelFormatter={formatPeriodTick}
-                contentStyle={{
-                  fontSize: "11px",
-                  borderColor: theme.borderColor,
-                  borderRadius: 4,
-                }}
+                contentStyle={defaultTooltipStyle(theme)}
               />
               <Area
                 type="monotone"

--- a/frontend/src/components/risk/riskCharts.tsx
+++ b/frontend/src/components/risk/riskCharts.tsx
@@ -37,7 +37,7 @@ import type {
   HistogramBin,
   RollingVolPoint,
 } from "@/api/types";
-import type { ChartTheme } from "@/lib/chartTheme";
+import { type ChartTheme, defaultTooltipStyle } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 
 // ---------------------------------------------------------------------------
@@ -129,7 +129,7 @@ export function UnderwaterChart({ points }: UnderwaterProps): JSX.Element {
           <Tooltip
             formatter={(value: number) => [pctSigned(value), "Drawdown"]}
             labelFormatter={formatDay}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Area
             type="monotone"
@@ -187,7 +187,7 @@ export function RollingVolChart({ points }: RollingVolProps): JSX.Element {
           <Tooltip
             formatter={(value: number) => [pct(value), "Annualized vol"]}
             labelFormatter={formatDay}
-            contentStyle={{ fontSize: "11px" }}
+            contentStyle={defaultTooltipStyle(theme)}
           />
           <Line
             type="monotone"
@@ -277,7 +277,7 @@ export function ReturnsHistogram({ bins }: ReturnsHistogramProps): JSX.Element {
             <Tooltip
               formatter={(value: number) => [String(value), "Days"]}
               labelFormatter={(v: number) => `~${pctSigned(v, 2)}`}
-              contentStyle={{ fontSize: "11px" }}
+              contentStyle={defaultTooltipStyle(theme)}
             />
             <Bar
               dataKey="count"
@@ -369,7 +369,7 @@ export function BetaScatterChart({
             <Tooltip
               cursor={{ strokeDasharray: "3 3" }}
               formatter={(value: number, name: string) => [pctSigned(value), name]}
-              contentStyle={{ fontSize: "11px" }}
+              contentStyle={defaultTooltipStyle(theme)}
             />
             <Scatter
               data={data}

--- a/frontend/src/lib/chartTheme.test.ts
+++ b/frontend/src/lib/chartTheme.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { darkTheme, defaultTooltipStyle, lightTheme } from "@/lib/chartTheme";
+
+describe("defaultTooltipStyle", () => {
+  it("themes the surface from the dark palette (the white-card fix)", () => {
+    const style = defaultTooltipStyle(darkTheme);
+    expect(style.backgroundColor).toBe(darkTheme.bg);
+    expect(style.color).toBe(darkTheme.textPrimary);
+    expect(style.border).toBe(`1px solid ${darkTheme.borderColor}`);
+  });
+
+  it("themes the surface from the light palette", () => {
+    const style = defaultTooltipStyle(lightTheme);
+    expect(style.backgroundColor).toBe(lightTheme.bg);
+    expect(style.color).toBe(lightTheme.textPrimary);
+    expect(style.border).toBe(`1px solid ${lightTheme.borderColor}`);
+  });
+
+  it("preserves the 11px size and rounded corner across themes", () => {
+    for (const theme of [lightTheme, darkTheme]) {
+      const style = defaultTooltipStyle(theme);
+      expect(style.fontSize).toBe("11px");
+      expect(style.borderRadius).toBe(4);
+    }
+  });
+
+  it("yields distinct surfaces per theme so light and dark never collide", () => {
+    expect(defaultTooltipStyle(lightTheme).backgroundColor).not.toBe(
+      defaultTooltipStyle(darkTheme).backgroundColor,
+    );
+  });
+});

--- a/frontend/src/lib/chartTheme.ts
+++ b/frontend/src/lib/chartTheme.ts
@@ -17,6 +17,8 @@
  * only if no existing slot fits the semantic role. Add the key to BOTH
  * palettes. Do NOT inline hex values in chart components.
  */
+import type { CSSProperties } from "react";
+
 export interface ChartTheme {
   /** Background of the chart surface. Matches the page card chrome. */
   readonly bg: string;
@@ -179,3 +181,26 @@ export const darkTheme: ChartTheme = {
   areaTopAlpha: lightTheme.areaTopAlpha,
   areaBottomAlpha: lightTheme.areaBottomAlpha,
 };
+
+/**
+ * Inline style for recharts' DEFAULT `<Tooltip>` (the ones rendered with
+ * no custom `content`). recharts paints that card with inline styles
+ * (white surface, dark text), and Tailwind's class-based `dark:` cannot
+ * reach an inline style — so on the dark `slate-950` page the card stays
+ * white. Theme the surface from the palette here.
+ *
+ * `color` cascades to the date label (`.recharts-tooltip-label`, which
+ * carries no explicit color); the series rows keep their own legible
+ * series colors, so the value→series color link survives. Custom-content
+ * tooltips use `<ChartTooltip>` (Tailwind classes) instead — keep the two
+ * surfaces visually aligned when editing either.
+ */
+export function defaultTooltipStyle(theme: ChartTheme): CSSProperties {
+  return {
+    fontSize: "11px",
+    backgroundColor: theme.bg,
+    border: `1px solid ${theme.borderColor}`,
+    borderRadius: 4,
+    color: theme.textPrimary,
+  };
+}


### PR DESCRIPTION
Closes #1743.

## Problem
~17 charts render recharts' DEFAULT `<Tooltip>` (no custom content) with only `contentStyle={{ fontSize: "11px" }}`. recharts inline-styles that card (white surface, dark text); Tailwind's class-based `dark:` (`darkMode: "class"`) cannot reach an inline style, so on the dark `slate-950` page the tooltip stays a white card — legible but inconsistent with every other (themed) surface.

Option **A** from the issue (dark-correctness fix, not a redesign).

## Change
- New `defaultTooltipStyle(theme)` in `frontend/src/lib/chartTheme.ts` (the palette SSOT — its header already mandates "no inline hex in chart components"). One helper themes `backgroundColor`/`border`/`color` from the resolved palette. `contentStyle.color` cascades to the date label (`.recharts-tooltip-label`, no explicit color); series rows keep their own legible series colors, so the value→series color link survives.
- Swapped all 17 inline `contentStyle` to the helper: dividends 4, fundamentals 8, risk 4, `FundamentalsPane` 1. The `FundamentalsPane` one was *half*-themed (border/radius only, no bg/color) → still a white card in dark; now fully fixed.
- Pure-fn unit test `chartTheme.test.ts` asserts the light/dark surface tokens + invariants (fontSize, radius, distinct per-theme bg).

## Scope / out of scope
Custom-content tooltips (`peers` / `news` / `filings` / `insider` / `reports` via `<ChartTooltip>`) are already dark-safe — untouched. `FcfTooltip` (fundamentals:589) is custom content — untouched. Verified by grepping every `<Tooltip` in `frontend/src`: only the 17 default ones changed.

## Visual note (conscious tradeoff)
Default tooltips now use `theme.bg` (slate-950 dark / white light) + border, per the issue's Option A spec. `ChartTooltip` (custom-content tooltips) uses slate-900 for slight elevation. Both are dark-safe and bordered; the minor slate-950-vs-900 surface difference is the issue's chosen behaviour, not a regression.

## Verification (no backend / no daemon — FE-only)
- `pnpm typecheck` ✓ (Codex independently re-ran `tsc -p tsconfig.app.json --noEmit` clean)
- `pnpm test:unit` ✓ 1134 pass (incl. new chartTheme tests)
- `node scripts/check-dark-classes.mjs` ✓ 222 files, no violations
- Codex ckpt-2 branch review: no findings.

Live-browser render not exercised (FE auth is HttpOnly session cookie; isolated browser has no operator session) — render coverage is via render-tests + typecheck-validated recharts props, the repo's standard chart-verification path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)