### PR TITLE
feat(#1748): filings risk-scorer — populate red_flag_score + red-flag trend chart

### DIFF
--- a/app/api/filings.py
+++ b/app/api/filings.py
@@ -81,6 +81,18 @@ class FilingQuarterlyCounts(BaseModel):
     counts: list[FilingQuarterCount]
 
 
+class RedFlagTrendPoint(BaseModel):
+    quarter: str  # "YYYY-Qn"
+    avg_score: float  # mean red_flag_score over scored filings that quarter
+    n: int  # number of scored (non-NULL) filings in the quarter
+
+
+class RedFlagTrend(BaseModel):
+    instrument_id: int
+    symbol: str | None
+    points: list[RedFlagTrendPoint]
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -197,8 +209,8 @@ def filing_quarterly_counts(
     form-type heatmap. Aggregated server-side so the client never pulls the raw
     filing rows (an active filer has hundreds of Form 4s alone, past the
     /filings page cap); the small {quarter, filing_type, count} payload is
-    categorised + bucketed on the FE. ``red_flag_score`` is unpopulated across
-    the corpus, so the red-flag trend chart was deferred to #1748.
+    categorised + bucketed on the FE. The red-flag-score trend is served
+    separately by ``/{instrument_id}/red-flag-trend`` (#1748).
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
@@ -234,6 +246,59 @@ def filing_quarterly_counts(
                 quarter=str(r["quarter"]),
                 filing_type=str(r["filing_type"]),
                 count=int(r["count"]),
+            )
+            for r in rows
+        ],
+    )
+
+
+@router.get("/{instrument_id}/red-flag-trend", response_model=RedFlagTrend)
+def filing_red_flag_trend(
+    instrument_id: int,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    years: int = Query(default=5, ge=1, le=20),
+) -> RedFlagTrend:
+    """Per-quarter mean ``red_flag_score`` over the last ``years`` years.
+
+    The #592-deferred third filings-analytics chart (#1748). Only scored
+    filings (``red_flag_score IS NOT NULL`` — critical 8-Ks and Form NT
+    late filings) contribute, so a quarter with no risk-bearing filing is
+    simply absent (the FE renders an empty state / gaps).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT symbol FROM instruments WHERE instrument_id = %(id)s",
+            {"id": instrument_id},
+        )
+        inst_row = cur.fetchone()
+    if inst_row is None:
+        raise HTTPException(status_code=404, detail="Instrument not found")
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT to_char(date_trunc('quarter', filing_date), 'YYYY-"Q"Q') AS quarter,
+                   AVG(red_flag_score) AS avg_score,
+                   COUNT(*) AS n
+            FROM filing_events
+            WHERE instrument_id = %(id)s
+              AND red_flag_score IS NOT NULL
+              AND filing_date >= (CURRENT_DATE - make_interval(years => %(years)s))
+            GROUP BY 1
+            ORDER BY 1
+            """,
+            {"id": instrument_id, "years": years},
+        )
+        rows = cur.fetchall()
+
+    return RedFlagTrend(
+        instrument_id=instrument_id,
+        symbol=inst_row["symbol"],  # type: ignore[index]
+        points=[
+            RedFlagTrendPoint(
+                quarter=str(r["quarter"]),
+                avg_score=float(r["avg_score"]),
+                n=int(r["n"]),
             )
             for r in rows
         ],

--- a/app/services/filings.py
+++ b/app/services/filings.py
@@ -48,6 +48,7 @@ from app.services.bootstrap_state import (
     resolve_progress_context,
     set_stage_processed,
 )
+from app.services.filings_risk import score_filing_red_flag
 
 logger = logging.getLogger(__name__)
 
@@ -648,19 +649,23 @@ def _upsert_filing_event(
         INSERT INTO filing_events (
             instrument_id, filing_date, filing_type,
             provider, provider_filing_id, source_url, primary_document_url,
-            report_date, raw_payload_json
+            report_date, raw_payload_json, red_flag_score
         )
         VALUES (
             %(instrument_id)s, %(filing_date)s, %(filing_type)s,
             %(provider)s, %(provider_filing_id)s, %(source_url)s, %(primary_document_url)s,
-            %(report_date)s, %(raw_payload_json)s
+            %(report_date)s, %(raw_payload_json)s, %(red_flag_score)s
         )
         ON CONFLICT (provider, provider_filing_id, instrument_id) DO UPDATE SET
             filing_date          = EXCLUDED.filing_date,
             filing_type          = EXCLUDED.filing_type,
             source_url           = EXCLUDED.source_url,
             primary_document_url = EXCLUDED.primary_document_url,
-            report_date          = COALESCE(EXCLUDED.report_date, filing_events.report_date)
+            report_date          = COALESCE(EXCLUDED.report_date, filing_events.report_date),
+            -- NT late-filing flag only (EXCLUDED is NT-or-NULL here). NEVER
+            -- clobber an 8-K's score, which apply_8k_items_to_filing_events
+            -- owns and sets after items[] are known (#1748).
+            red_flag_score       = COALESCE(EXCLUDED.red_flag_score, filing_events.red_flag_score)
         """,
         {
             "instrument_id": instrument_id,
@@ -670,6 +675,10 @@ def _upsert_filing_event(
             "provider_filing_id": event.provider_filing_id,
             "source_url": event.primary_document_url,
             "primary_document_url": event.primary_document_url,
+            # items are not known at insert time (set later by the 8-K items
+            # path); only the Form NT late-filing flag (filing_type-driven)
+            # is computable here. #1748.
+            "red_flag_score": score_filing_red_flag(event.filing_type, None, {}),
             # #1343 — promote reportDate to a column (was raw_payload_json-only;
             # a §903 structured-field-in-SQL gap). Feeds the 8-K metadata seed's
             # date_of_report with no body fetch.
@@ -723,19 +732,23 @@ def _upsert_filing(
         INSERT INTO filing_events (
             instrument_id, filing_date, filing_type,
             provider, provider_filing_id, source_url, primary_document_url,
-            report_date, raw_payload_json
+            report_date, raw_payload_json, red_flag_score
         )
         VALUES (
             %(instrument_id)s, %(filing_date)s, %(filing_type)s,
             %(provider)s, %(provider_filing_id)s, %(source_url)s, %(primary_document_url)s,
-            %(report_date)s, %(raw_payload_json)s
+            %(report_date)s, %(raw_payload_json)s, %(red_flag_score)s
         )
         ON CONFLICT (provider, provider_filing_id, instrument_id) DO UPDATE SET
             filing_date          = EXCLUDED.filing_date,
             filing_type          = EXCLUDED.filing_type,
             source_url           = EXCLUDED.source_url,
             primary_document_url = EXCLUDED.primary_document_url,
-            report_date          = COALESCE(EXCLUDED.report_date, filing_events.report_date)
+            report_date          = COALESCE(EXCLUDED.report_date, filing_events.report_date),
+            -- NT late-filing flag only (EXCLUDED is NT-or-NULL here). NEVER
+            -- clobber an 8-K's score, which apply_8k_items_to_filing_events
+            -- owns and sets after items[] are known (#1748).
+            red_flag_score       = COALESCE(EXCLUDED.red_flag_score, filing_events.red_flag_score)
         """,
         {
             "instrument_id": instrument_id,
@@ -745,6 +758,9 @@ def _upsert_filing(
             "provider_filing_id": result.provider_filing_id,
             "source_url": result.primary_document_url,
             "primary_document_url": result.primary_document_url,
+            # items unknown at insert (set later by the 8-K items path); only
+            # the Form NT late-filing flag is computable here. #1748.
+            "red_flag_score": score_filing_red_flag(result.filing_type, None, {}),
             # #1343 — promote reportDate to a column (was raw_payload_json-only;
             # a §903 structured-field-in-SQL gap).
             "report_date": result.period_of_report,

--- a/app/services/filings_risk.py
+++ b/app/services/filings_risk.py
@@ -1,0 +1,78 @@
+"""Filings risk-scorer (#1748) — derive ``filing_events.red_flag_score``.
+
+The score is an eBull metric, but its inputs are fixed by settled
+invariants: 8-K item severity from ``sec_8k_item_codes`` (sql/053) and
+Form NT late-filing (SEC Rule 12b-25). See
+``docs/specs/filings/2026-06-27-1748-filings-risk-scorer.md``.
+
+We write ONLY genuine red flags, and ONLY at a high value:
+
+  * a critical 8-K item  -> 1.0
+  * a Form NT late filing -> 0.7
+  * anything else         -> None (no red flag asserted)
+
+Why never a low score: scoring's turnaround component is
+``1.0 - avg_red_flag_score`` with a 0.5-neutral default when NULL
+(``app/services/scoring.py``). Any non-null score below 0.5 would
+*reward* the instrument relative to having no data. The scoring penalty
+and the portfolio EXIT guard both aggregate over ``WHERE
+red_flag_score IS NOT NULL`` (AVG > 0.60 / MAX >= 0.80), so scoring a
+benign filing at, say, 0.1 would also dilute the average and suppress a
+genuine critical signal. Leaving non-flags NULL keeps a lone critical at
+avg = 1.0.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import psycopg
+
+#: A critical 8-K item (bankruptcy, delisting, non-reliance/Item 4.02,
+#: auditor change, material impairment, cyber incident, change of control,
+#: failed distribution) -> top of scale.
+CRITICAL_8K_SCORE = 1.0
+
+#: Form NT late filing (Rule 12b-25). Above the scoring penalty threshold
+#: (0.60) so a recent NT alone dings the score, but below the portfolio
+#: EXIT threshold (0.80) so a missed deadline is not on its own
+#: auto-exit-grade.
+NT_LATE_FILING_SCORE = 0.7
+
+
+def load_severity_by_code(conn: psycopg.Connection[Any]) -> dict[str, str]:
+    """Load the settled 8-K item-code -> severity map (32 rows)."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT code, severity FROM sec_8k_item_codes")
+        return {str(code): str(sev) for code, sev in cur.fetchall()}
+
+
+def score_filing_red_flag(
+    filing_type: str | None,
+    items: Sequence[str] | None,
+    severity_by_code: Mapping[str, str],
+) -> float | None:
+    """Return the red-flag score for one filing, or ``None`` for no flag.
+
+    Pure: callers supply ``severity_by_code`` (see ``load_severity_by_code``).
+    ``items`` is the ``filing_events.items[]`` array (8-K item codes),
+    ``None``/empty for non-8-K or unparsed 8-K rows.
+    """
+    ft = (filing_type or "").strip().upper()
+
+    # Form NT (late filing). NT 10-K, NT 10-Q, NT 20-F, NT-NCSR,
+    # NT NPORT-P, ... — "NT" followed by a space / hyphen / slash so a
+    # hypothetical "NTxx" form can never match.
+    if len(ft) >= 3 and ft.startswith("NT") and ft[2] in " /-":
+        return NT_LATE_FILING_SCORE
+
+    # 8-K / 8-K/A: flag iff any item is critical per the settled lookup.
+    # Unknown codes contribute nothing (fail-closed: never a false
+    # critical); a new SEC critical code is caught once sec_8k_item_codes
+    # is updated.
+    if ft.startswith("8-K") and items:
+        if any(severity_by_code.get(code) == "critical" for code in items):
+            return CRITICAL_8K_SCORE
+
+    return None

--- a/app/services/fundamentals/__init__.py
+++ b/app/services/fundamentals/__init__.py
@@ -47,6 +47,7 @@ from app.services.filings import (
     FILING_EVENTS_RETENTION_YEARS,
     filing_within_retention,
 )
+from app.services.filings_risk import score_filing_red_flag
 from app.services.ownership_observations import (
     record_treasury_observation,
     refresh_treasury_current,
@@ -2349,18 +2350,21 @@ def _upsert_filing_from_master_index(
         INSERT INTO filing_events (
             instrument_id, filing_date, filing_type,
             provider, provider_filing_id, source_url, primary_document_url,
-            raw_payload_json
+            raw_payload_json, red_flag_score
         )
         VALUES (
             %(instrument_id)s, %(filing_date)s, %(filing_type)s,
             %(provider)s, %(provider_filing_id)s, %(source_url)s, %(primary_document_url)s,
-            %(raw_payload_json)s
+            %(raw_payload_json)s, %(red_flag_score)s
         )
         ON CONFLICT (provider, provider_filing_id, instrument_id) DO UPDATE SET
             filing_date          = EXCLUDED.filing_date,
             filing_type          = EXCLUDED.filing_type,
             source_url           = COALESCE(filing_events.source_url, EXCLUDED.source_url),
-            primary_document_url = COALESCE(filing_events.primary_document_url, EXCLUDED.primary_document_url)
+            primary_document_url = COALESCE(filing_events.primary_document_url, EXCLUDED.primary_document_url),
+            -- NT late-filing flag only (EXCLUDED is NT-or-NULL here); the 8-K
+            -- score is owned by apply_8k_items_to_filing_events. #1748.
+            red_flag_score       = COALESCE(EXCLUDED.red_flag_score, filing_events.red_flag_score)
         """,
         {
             "instrument_id": instrument_id,
@@ -2370,6 +2374,9 @@ def _upsert_filing_from_master_index(
             "provider_filing_id": entry.accession_number,
             "source_url": master_index_url,
             "primary_document_url": master_index_url,
+            # items unknown here (set later by the 8-K items path); only the
+            # Form NT late-filing flag is computable at insert. #1748.
+            "red_flag_score": score_filing_red_flag(entry.form_type, None, {}),
             "raw_payload_json": json.dumps(
                 {
                     "source": "master-index",

--- a/app/services/sec_filing_items.py
+++ b/app/services/sec_filing_items.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import psycopg
 
+from app.services.filings_risk import load_severity_by_code, score_filing_red_flag
+
 
 def parse_8k_items_by_accession(submissions: dict[str, Any]) -> dict[str, list[str]]:
     """Extract accession_number → list[item_code] for every 8-K /
@@ -85,14 +87,22 @@ def apply_8k_items_to_filing_events(
     conn: psycopg.Connection[Any],
     items_by_accession: dict[str, list[str]],
 ) -> int:
-    """UPDATE ``filing_events.items`` for every accession we've parsed.
+    """UPDATE ``filing_events.items`` (and ``red_flag_score``) for every
+    accession we've parsed.
 
     Only touches rows that already exist (no INSERT). Returns the
     count of rows updated. Empty-list updates are still applied so
     operators can tell "parsed, no items" from "never parsed".
+
+    This is the canonical 8-K source-of-truth for ``red_flag_score``
+    (#1748): ``items[]`` is known here, set after the ``filing_events``
+    row exists, so the score is computed alongside it rather than at the
+    earlier INSERT (which doesn't carry items).
     """
     if not items_by_accession:
         return 0
+
+    severity_by_code = load_severity_by_code(conn)
 
     # One UPDATE per accession. At daily-cadence volume (tens of
     # 8-Ks across all covered CIKs) this is fine — a bulk UNNEST
@@ -102,13 +112,15 @@ def apply_8k_items_to_filing_events(
     updated = 0
     with conn.cursor() as cur:
         for accession, codes in items_by_accession.items():
+            # parse_8k_items_by_accession only emits 8-K / 8-K/A rows.
+            red_flag_score = score_filing_red_flag("8-K", codes, severity_by_code)
             cur.execute(
                 """
                 UPDATE filing_events
-                SET items = %s
+                SET items = %s, red_flag_score = %s
                 WHERE provider = 'sec' AND provider_filing_id = %s
                 """,
-                (codes, accession),
+                (codes, red_flag_score, accession),
             )
             updated += cur.rowcount
     return updated

--- a/docs/specs/filings/2026-06-27-1748-filings-risk-scorer.md
+++ b/docs/specs/filings/2026-06-27-1748-filings-risk-scorer.md
@@ -1,0 +1,63 @@
+# #1748 — filings risk-scorer: populate `filing_events.red_flag_score`
+
+Parent #585. Predecessor #592 (deferred the red-flag-trend chart for lack of data).
+
+## Problem
+`filing_events.red_flag_score NUMERIC(10,4)` (sql/001) is **NULL across all 2,717,528 rows** (dev-verified). Three consumers already read it and sit dark:
+1. **Scoring** (`app/services/scoring.py`): `AVG(red_flag_score) … WHERE red_flag_score IS NOT NULL` over 90d → turnaround component (`1.0 − avg`, weight 30%, scoring.py:748) + additive `high_red_flag` penalty 0.10 when avg > 0.60 (scoring.py:824).
+2. **Portfolio manager** (`app/services/portfolio.py`): `MAX(red_flag_score)` over 90d (:480); EXIT **recommendation** when `break_conditions` present AND max ≥ `EXIT_RED_FLAG_THRESHOLD` 0.80 (:611). Advisory only — never auto-closes (safety invariant: positions close only on explicit user action).
+3. **FE**: InstrumentPage red-flag badge; #592 deferred trend chart.
+
+## Source rule
+Score is an eBull metric (no SEC reg defines a 0–1 score); its **inputs are fixed by settled invariants**:
+- **8-K item severity** — `sec_8k_item_codes.severity ∈ {informational, material, critical}` (sql/053, seeded from Form 8-K General Instructions; severity is our settled editorial tier). Per-filing item set = `filing_events.items[]` (same migration), from `submissions.json filings.recent[].items`.
+- **Late filing (Form NT)** — SEC Rule 12b-25: an NT filing = a periodic report missed its deadline. Form in `filing_events.filing_type`.
+- **Restatement / non-reliance** — 8-K **Item 4.02**, already `critical` in the lookup → captured via `items[]`.
+
+## Full-population verification (dev)
+- `red_flag_score`: 0 / 2,717,528 non-null → premise holds.
+- `items[]`: **393,519** non-null (covers the 385,169 `8-K`/`8-K/A`). **Chosen source.**
+- `eight_k_items` (parsed bodies): only 20,343 → **rejected** (20× sparser; would leave most 8-Ks unscored).
+- NT forms: NT 10-Q 2600, NT 10-K 1648, NT 20-F 51, + smaller. Matchable by `filing_type` prefix.
+
+## Model (explicit, auditable — settled §191; only ever writes scores ≥ 0.7)
+Pure fn `score_filing_red_flag(filing_type, items, severity_by_code) -> float | None`:
+
+| Filing | Score |
+|---|---|
+| 8-K / 8-K/A with **≥1 critical** item (per `sec_8k_item_codes`) | **1.0** |
+| 8-K with only material / informational / unknown items | **NULL** |
+| Form NT (`filing_type ~* '^NT[ /-]'`) — late filing | **0.7** |
+| everything else (Form 4, 10-Q, 10-K, 13D/G, material/info 8-K, …) | **NULL** |
+
+**Why only critical + NT, and only high values (resolves Codex ckpt-1 HIGH-1/HIGH-2, LOW-7):**
+- Scoring's turnaround is `1.0 − avg_red_flag`; a NULL defaults to **0.5-neutral**. So *any* non-null score **< 0.5 would REWARD** the instrument (a benign 8-K at 0.1 → 0.9 turnaround component, better than no-data). Therefore we never write a low score — only genuine red flags, and only at ≥ 0.7.
+- Scoring penalty + portfolio guard both read **AVG / MAX over `WHERE NOT NULL`**. Scoring material/informational 8-Ks (even at 0.5) would **dilute the AVG**, suppressing the penalty after a real critical. Leaving them NULL keeps a lone critical at avg = 1.0 → penalty fires.
+- `red_flag_score` is specifically a **risk** signal. `material` 8-K items are genuinely mixed (entering a material agreement is often good); asserting a red flag there would be wrong. Fail-closed: NULL = "no red flag asserted," not "score 0."
+- NT at **0.7**: > 0.60 so a recent NT alone trips the *scoring* penalty; < 0.80 so it does **not** alone trigger a portfolio EXIT recommendation (a missed deadline dings the score but isn't an auto-exit-grade event; a critical 8-K is). Late annual vs quarterly not distinguished in v1 — KISS.
+- Binary critical-present = 1.0 (no MAX-over-severity gradation needed once material/info are NULL). 4.02 is `critical` → 1.0.
+
+**Unknown item codes (Codex MED-6):** an 8-K whose items are all absent from `sec_8k_item_codes` → no critical found → NULL (fail-closed: never a false critical). A genuinely-new SEC *critical* code is a blind spot until `sec_8k_item_codes` is updated — that's the existing taxonomy-maintenance norm (the lookup is the settled source; SEC item-code changes are rare and announced). Noted, not solved in code.
+
+## No model_version bump
+Current default is **`v1.3-balanced`** (scoring.py:42; settled-decisions §220 text says v1.2 but is stale post-#1635). `red_flag_score` was always a scoring input (defaults 0.5-neutral when NULL). Populating it is **data completion under the existing `v1.3-balanced` model** — no formula or threshold changes — matching settled §236 ("bump only when an EXISTING metric's *computation* changes"). Append-only history preserved; rank_delta stays within-version.
+
+**Operator-visible effects (documented, intended — the column's designed purpose going live, demo-first):** instruments with a recent **critical 8-K** (bankruptcy / delisting / non-reliance / auditor change / impairment / cyber / control change / failed distribution) or a recent **NT late filing** will (a) lose turnaround/score weight, (b) may trip the additive `high_red_flag` penalty, (c) for a held position with a thesis carrying `break_conditions`, may surface an EXIT **recommendation** (critical only; advisory, never auto-close). No threshold/formula changed — only the data feeding existing, intended consumers.
+
+## Implementation
+1. **Pure scorer** `app/services/filings_risk.py`: `score_filing_red_flag(filing_type, items, severity_by_code)`. Helper `load_severity_by_code(conn) -> dict[str,str]` from `sec_8k_item_codes`. Table-tested.
+2. **8-K write path** — extend `app/services/sec_filing_items.py::apply_8k_items_to_filing_events` to `SET items = …, red_flag_score = …` in the same UPDATE (items known there; this is the real 8-K source-of-truth, not the `filings.py` INSERTs which don't carry items — Codex HIGH-3). Pass the severity map in.
+3. **NT write path** — at the `filing_events` INSERTs in `app/services/filings.py` (`_insert_filing_event`, `_upsert_filing`), compute `red_flag_score` from `filing_type` (NT → 0.7, else None — items not needed). Add to INSERT columns + `ON CONFLICT … DO UPDATE SET red_flag_score = EXCLUDED.red_flag_score`. (8-K rows get None here, filled by step 2.)
+4. **Backfill job** `filings_red_flag_backfill` (registered, manual-trigger) — batched over `red_flag_score IS NULL AND (filing_type ~* '^NT' OR items IS NOT NULL)`; apply the SAME pure fn; `UPDATE … WHERE filing_event_id = ANY(batch)`. One source of truth (no SQL re-encoding). Run on dev after merge (ETL clause 10).
+5. **Trend endpoint** `GET /filings/{instrument_id}/red-flag-trend` (app/api/filings.py) → per-quarter `AVG(red_flag_score)` + `COUNT` over scored rows (mirror quarterly-counts shape). Pydantic `RedFlagTrend { instrument_id, symbol, points:[{quarter, avg_score, n}] }`.
+6. **FE 3rd chart** — `RedFlagTrendChart` in `filingsAnalyticsCharts.tsx` (`useChartTheme`, `defaultTooltipStyle`, empty guard, `isAnimationActive={false}`); render the deferred 3rd `<Section>` in `FilingsAnalyticsPage.tsx`; drop the #1748 deferral comment. New `fetchRedFlagTrend` + types.
+
+## Tests
+- Pure-fn table test (`tests/test_filings_risk.py`): critical→1.0, material/info only→None, NT variants→0.7, routine→None, empty items→None, unknown-only→None, mixed (critical+info)→1.0.
+- FE: red-flag-trend lib transform + chart render-test (empty + populated).
+
+## Out of scope
+Going-concern / restatement-language NLP (body text); `eight_k_items`-based scoring; dense scoring of routine forms; distinguishing NT 10-K vs NT 10-Q severity.
+
+## DoD (ETL clauses 8–12)
+Smoke panel after backfill: AAPL, GME, MSFT, JPM, HD — record a scored critical 8-K (or note none in window) + the trend endpoint figure. Cross-source one critical 8-K item vs SEC EDGAR. Backfill executed on dev (clause 10); trend endpoint verified live (clause 11).

--- a/frontend/src/api/filings.ts
+++ b/frontend/src/api/filings.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "@/api/client";
-import type { FilingQuarterlyCounts, FilingsListResponse } from "@/api/types";
+import type { FilingQuarterlyCounts, FilingsListResponse, RedFlagTrend } from "@/api/types";
 
 export interface FetchFilingsOpts {
   readonly filing_type?: string;
@@ -30,5 +30,15 @@ export function fetchFilingQuarterlyCounts(
   const params = new URLSearchParams({ years: String(years) });
   return apiFetch<FilingQuarterlyCounts>(
     `/filings/${instrumentId}/quarterly-counts?${params.toString()}`,
+  );
+}
+
+export function fetchRedFlagTrend(
+  instrumentId: number,
+  years = 5,
+): Promise<RedFlagTrend> {
+  const params = new URLSearchParams({ years: String(years) });
+  return apiFetch<RedFlagTrend>(
+    `/filings/${instrumentId}/red-flag-trend?${params.toString()}`,
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1121,6 +1121,18 @@ export interface FilingQuarterlyCounts {
   counts: FilingQuarterCount[];
 }
 
+export interface RedFlagTrendPoint {
+  quarter: string; // "YYYY-Qn"
+  avg_score: number; // mean red_flag_score over scored filings that quarter
+  n: number; // number of scored (non-null) filings in the quarter
+}
+
+export interface RedFlagTrend {
+  instrument_id: number;
+  symbol: string | null;
+  points: RedFlagTrendPoint[];
+}
+
 // ---------------------------------------------------------------------------
 // /news/{instrument_id} (app/api/news.py)
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/filings/filingsAnalyticsCharts.test.tsx
+++ b/frontend/src/components/filings/filingsAnalyticsCharts.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * Render test for the red-flag-trend chart (#1748). jsdom stubs
+ * ResizeObserver (test/setup.ts) so ResponsiveContainer measures 0px and
+ * never draws the inner series — assert the empty-state guard + the
+ * container element, not chart internals (recharts props are typecheck-
+ * validated). Pins the empty branch (no risk-bearing filing) so a future
+ * bug shows as the hint, not a blank frame.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RedFlagTrendChart } from "@/components/filings/filingsAnalyticsCharts";
+import type { RedFlagTrendPoint } from "@/api/types";
+
+describe("RedFlagTrendChart", () => {
+  it("renders the no-red-flag hint on empty points", () => {
+    render(<RedFlagTrendChart points={[]} />);
+    expect(screen.getByText(/No red-flag filings/i)).toBeInTheDocument();
+  });
+
+  it("mounts the chart when scored quarters are present", () => {
+    const points: RedFlagTrendPoint[] = [
+      { quarter: "2025-Q1", avg_score: 1.0, n: 1 },
+      { quarter: "2025-Q3", avg_score: 0.7, n: 2 },
+    ];
+    const { container } = render(<RedFlagTrendChart points={points} />);
+    expect(screen.queryByText(/No red-flag filings/i)).not.toBeInTheDocument();
+    expect(container.querySelector(".recharts-responsive-container")).not.toBeNull();
+  });
+});

--- a/frontend/src/components/filings/filingsAnalyticsCharts.tsx
+++ b/frontend/src/components/filings/filingsAnalyticsCharts.tsx
@@ -10,13 +10,15 @@ import {
   BarChart,
   CartesianGrid,
   Legend,
+  Line,
+  LineChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
 
-import type { FilingQuarterCount } from "@/api/types";
+import type { FilingQuarterCount, RedFlagTrendPoint } from "@/api/types";
 import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import {
   buildDensity,
@@ -181,6 +183,82 @@ export function FilingHeatmapChart({
       </div>
       <p className="mt-2 text-[10px] text-slate-400">
         Cell shade ∝ filing count (peak {h.max}). Routine insider Form 3/4/5 excluded.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Red-flag score trend — mean red_flag_score per quarter (#1748)
+// ---------------------------------------------------------------------------
+
+interface RedFlagTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload?: RedFlagTrendPoint }>;
+}
+
+function RedFlagTooltip({ active, payload }: RedFlagTooltipProps): JSX.Element | null {
+  if (active !== true || !payload || payload.length === 0) return null;
+  const p = payload[0]?.payload;
+  if (!p) return null;
+  return (
+    <ChartTooltip>
+      <div className="font-medium text-slate-700 dark:text-slate-200">{p.quarter}</div>
+      <div className="tabular-nums text-slate-600 dark:text-slate-300">
+        avg red-flag {p.avg_score.toFixed(2)}
+      </div>
+      <div className="tabular-nums text-slate-500 dark:text-slate-400">
+        {p.n} scored filing{p.n === 1 ? "" : "s"}
+      </div>
+    </ChartTooltip>
+  );
+}
+
+export function RedFlagTrendChart({
+  points,
+}: {
+  readonly points: ReadonlyArray<RedFlagTrendPoint>;
+}): JSX.Element {
+  const theme = useChartTheme();
+  if (points.length === 0) {
+    return (
+      <NoFilings message="No red-flag filings (critical 8-K or late NT) in the window." />
+    );
+  }
+  return (
+    <div style={{ height: CHART_HEIGHT }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={[...points]} margin={{ top: 8, right: 8, left: 0, bottom: 4 }}>
+          <CartesianGrid stroke={theme.gridLine} vertical={false} />
+          <XAxis
+            dataKey="quarter"
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            interval="preserveStartEnd"
+            minTickGap={16}
+          />
+          <YAxis
+            domain={[0, 1]}
+            ticks={[0, 0.5, 1]}
+            stroke={theme.textSecondary}
+            tick={{ fill: theme.textMuted, fontSize: 10 }}
+            width={32}
+          />
+          <Tooltip content={<RedFlagTooltip />} cursor={{ stroke: theme.crosshair }} />
+          <Line
+            type="monotone"
+            dataKey="avg_score"
+            name="avg red-flag"
+            stroke={theme.down}
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+      <p className="mt-2 text-[10px] text-slate-400">
+        Mean red-flag score per quarter (1.0 = critical 8-K; 0.7 = late NT filing). Higher
+        = worse; quarters with no risk-bearing filing are absent.
       </p>
     </div>
   );

--- a/frontend/src/pages/FilingsAnalyticsPage.tsx
+++ b/frontend/src/pages/FilingsAnalyticsPage.tsx
@@ -1,40 +1,60 @@
 /**
- * /instrument/:symbol/filings/analytics — filings-analytics drill (#592).
+ * /instrument/:symbol/filings/analytics — filings-analytics drill (#592, #1748).
  *
- * Two charts over the server's per-(quarter, filing_type) counts
- * (`/filings/{id}/quarterly-counts`): a stacked filing-density timeline + a
- * form-type heatmap. The red-flag-score trend the issue also called for is
- * deferred to #1748 — `red_flag_score` is unpopulated across the filings corpus.
+ * Three charts over the server's filings aggregates: a stacked filing-density
+ * timeline + a form-type heatmap (`/filings/{id}/quarterly-counts`), and the
+ * red-flag-score trend (`/filings/{id}/red-flag-trend`, #1748 — now that
+ * `red_flag_score` is populated).
  */
 import { useCallback } from "react";
 import { Link, useParams } from "react-router-dom";
 
-import { fetchFilingQuarterlyCounts } from "@/api/filings";
+import { fetchFilingQuarterlyCounts, fetchRedFlagTrend } from "@/api/filings";
 import { fetchInstrumentSummary } from "@/api/instruments";
-import type { FilingQuarterlyCounts } from "@/api/types";
+import type { FilingQuarterlyCounts, RedFlagTrend } from "@/api/types";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import {
   FilingDensityChart,
   FilingHeatmapChart,
+  RedFlagTrendChart,
 } from "@/components/filings/filingsAnalyticsCharts";
 import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
+
+interface FilingsAnalytics {
+  readonly counts: FilingQuarterlyCounts;
+  readonly trend: RedFlagTrend;
+}
 
 export function FilingsAnalyticsPage(): JSX.Element {
   const { symbol = "" } = useParams<{ symbol: string }>();
   const backHref = `/instrument/${encodeURIComponent(symbol)}`;
 
   // The /filings endpoints are instrument_id-keyed; resolve :symbol → id via the
-  // summary, then pull the aggregated counts — one lifecycle, one error surface.
-  const counts = useAsync<FilingQuarterlyCounts>(
+  // summary, then pull both aggregates together — one lifecycle, one error
+  // surface. The trend can be empty even when counts has filings (no
+  // risk-bearing filing), so its chart carries its own empty guard.
+  const analytics = useAsync<FilingsAnalytics>(
     useCallback(
       () =>
-        fetchInstrumentSummary(symbol).then((s) => fetchFilingQuarterlyCounts(s.instrument_id)),
+        fetchInstrumentSummary(symbol).then(async (s) => {
+          const [counts, trend] = await Promise.all([
+            fetchFilingQuarterlyCounts(s.instrument_id),
+            fetchRedFlagTrend(s.instrument_id),
+          ]);
+          return { counts, trend };
+        }),
       [symbol],
     ),
     [symbol],
   );
 
+  const counts = {
+    loading: analytics.loading,
+    error: analytics.error,
+    data: analytics.data?.counts ?? null,
+    refetch: analytics.refetch,
+  };
   const isEmpty = counts.data !== null && counts.data.counts.length === 0;
 
   return (
@@ -83,6 +103,9 @@ export function FilingsAnalyticsPage(): JSX.Element {
           </Section>
           <Section title="Form-type heatmap">
             <FilingHeatmapChart counts={counts.data.counts} />
+          </Section>
+          <Section title="Red-flag score trend">
+            <RedFlagTrendChart points={analytics.data?.trend.points ?? []} />
           </Section>
         </>
       )}

--- a/scripts/backfill_red_flag_score.py
+++ b/scripts/backfill_red_flag_score.py
@@ -1,0 +1,117 @@
+"""One-shot backfill of ``filing_events.red_flag_score`` (#1748).
+
+The score was added to all three write paths (NT at INSERT, 8-K via
+``apply_8k_items_to_filing_events``), so a *fresh* bootstrap populates it
+natively. This script fills the existing corpus, where every input is
+already in the DB — no SEC fetch needed.
+
+Candidate rows: ``red_flag_score IS NULL`` AND (a Form NT, or an 8-K with
+``items[]`` already applied). The score is computed by the SAME pure fn
+the write paths use (``app.services.filings_risk.score_filing_red_flag``)
+— one source of truth, no SQL re-encoding of the rule. Rows that compute
+to ``None`` (e.g. an 8-K with no critical item) are left NULL.
+
+Run from the repo root::
+
+    uv run python scripts/backfill_red_flag_score.py --apply
+
+Dry-run by default (counts what would change). ``--batch N`` sets the
+keyset page size (default 5000). Idempotent — re-running only touches
+still-NULL candidates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections import defaultdict
+
+import psycopg
+
+from app.config import settings
+from app.services.filings_risk import load_severity_by_code, score_filing_red_flag
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Commit writes (default: dry-run count).")
+    parser.add_argument("--batch", type=int, default=5000, help="Keyset page size (default 5000).")
+    args = parser.parse_args(argv)
+
+    if not args.apply:
+        logger.info("DRY RUN — counts only, no writes. Use --apply to commit.")
+
+    # autocommit so each per-batch ``with conn.transaction()`` is a real
+    # BEGIN/COMMIT pair (durable incrementally; a crash keeps prior
+    # batches) rather than a savepoint under an implicit outer txn.
+    with psycopg.connect(settings.database_url, autocommit=True) as conn:
+        severity_by_code = load_severity_by_code(conn)
+
+        last_id = 0
+        scanned = 0
+        none_total = 0
+        # score value -> rows written, so totals stay correct no matter what
+        # values the pure fn returns (no re-encoding of the constants here).
+        written: defaultdict[float, int] = defaultdict(int)
+        while True:
+            rows = conn.execute(
+                """
+                SELECT filing_event_id, filing_type, items
+                FROM filing_events
+                WHERE red_flag_score IS NULL
+                  AND filing_event_id > %(last_id)s
+                  AND (filing_type ~* '^NT' OR items IS NOT NULL)
+                ORDER BY filing_event_id
+                LIMIT %(batch)s
+                """,
+                {"last_id": last_id, "batch": int(args.batch)},
+            ).fetchall()
+            if not rows:
+                break
+
+            # Group ids by the score the pure fn returns. The SQL only writes
+            # the value the rule produced — never a hardcoded bucket — so the
+            # backfill follows the scorer's constants automatically.
+            ids_by_score: defaultdict[float, list[int]] = defaultdict(list)
+            for fid, filing_type, items in rows:
+                score = score_filing_red_flag(filing_type, items, severity_by_code)
+                if score is None:
+                    none_total += 1
+                else:
+                    ids_by_score[score].append(int(fid))
+            scanned += len(rows)
+            last_id = int(rows[-1][0])
+
+            if args.apply:
+                with conn.transaction():
+                    for score, ids in ids_by_score.items():
+                        conn.execute(
+                            "UPDATE filing_events SET red_flag_score = %s WHERE filing_event_id = ANY(%s)",
+                            (score, ids),
+                        )
+            for score, ids in ids_by_score.items():
+                written[score] += len(ids)
+            logger.info(
+                "backfill: scanned=%d written=%s none=%d (last_id=%d)",
+                scanned,
+                {k: written[k] for k in sorted(written)},
+                none_total,
+                last_id,
+            )
+
+    logger.info(
+        "backfill: complete. scanned=%d written=%s none(left NULL)=%d apply=%s",
+        scanned,
+        {k: written[k] for k in sorted(written)},
+        none_total,
+        args.apply,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_filings_risk.py
+++ b/tests/test_filings_risk.py
@@ -1,0 +1,78 @@
+"""Pure-logic tests for the filings risk-scorer (#1748).
+
+No DB — the severity map is supplied directly (mirrors the settled
+``sec_8k_item_codes`` seed in sql/053).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.filings_risk import (
+    CRITICAL_8K_SCORE,
+    NT_LATE_FILING_SCORE,
+    score_filing_red_flag,
+)
+
+# Subset of the settled sec_8k_item_codes seed (sql/053).
+SEVERITY = {
+    "1.01": "material",  # Material Definitive Agreement
+    "1.03": "critical",  # Bankruptcy
+    "4.02": "critical",  # Non-Reliance / restatement
+    "7.01": "informational",  # Reg FD
+    "9.01": "informational",  # Exhibits
+    "8.01": "informational",  # Other Events
+}
+
+
+@pytest.mark.parametrize(
+    "filing_type,items,expected",
+    [
+        # 8-K critical present -> 1.0 (worst item drives it)
+        ("8-K", ["1.03"], CRITICAL_8K_SCORE),
+        ("8-K", ["4.02"], CRITICAL_8K_SCORE),
+        ("8-K/A", ["1.03"], CRITICAL_8K_SCORE),
+        ("8-K", ["7.01", "1.03", "9.01"], CRITICAL_8K_SCORE),  # critical among benign
+        # 8-K with no critical item -> NULL (not a red flag; avoids reward+dilution)
+        ("8-K", ["1.01"], None),  # material only
+        ("8-K", ["7.01", "9.01"], None),  # informational only
+        ("8-K", [], None),  # parsed, no items
+        ("8-K", None, None),  # items not yet applied
+        ("8-K", ["6.99"], None),  # unknown code only -> fail-closed
+        # Form NT late filings -> 0.7
+        ("NT 10-K", None, NT_LATE_FILING_SCORE),
+        ("NT 10-Q", None, NT_LATE_FILING_SCORE),
+        ("NT 20-F", None, NT_LATE_FILING_SCORE),
+        ("NT-NCSR", None, NT_LATE_FILING_SCORE),
+        ("NT NPORT-P", None, NT_LATE_FILING_SCORE),
+        ("nt 10-k", None, NT_LATE_FILING_SCORE),  # case-insensitive
+        # Routine / non-risk forms -> NULL
+        ("10-K", None, None),
+        ("10-Q", None, None),
+        ("4", None, None),
+        ("DEF 14A", None, None),
+        ("SC 13G", None, None),
+        ("", None, None),
+        (None, None, None),
+        # "NT"-prefixed but not a real NT form must NOT match (guard on the
+        # separator char after NT).
+        ("NTRS", None, None),
+    ],
+)
+def test_score_filing_red_flag(filing_type, items, expected):
+    assert score_filing_red_flag(filing_type, items, SEVERITY) == expected
+
+
+def test_only_ever_writes_high_scores_or_none():
+    """Invariant the whole model rests on: a written score is never below
+    0.5, so it can never *reward* turnaround (1.0 - avg) vs the 0.5-neutral
+    NULL default."""
+    cases = [
+        ("8-K", ["1.03"], SEVERITY),
+        ("NT 10-K", None, SEVERITY),
+        ("8-K", ["1.01"], SEVERITY),
+        ("10-Q", None, SEVERITY),
+    ]
+    for ft, items, sev in cases:
+        score = score_filing_red_flag(ft, items, sev)
+        assert score is None or score >= 0.7


### PR DESCRIPTION
Closes #1748. Parent #585. Predecessor #592.

## Problem
`filing_events.red_flag_score` was **NULL across all 2,717,528 rows** while three consumers sat dark:
1. **Scoring** (`scoring.py`): `AVG(red_flag_score) WHERE NOT NULL` over 90d → turnaround component (`1.0 − avg`, weight 30%) + additive `high_red_flag` penalty 0.10 when avg > 0.60.
2. **Portfolio manager** (`portfolio.py`): `MAX(red_flag_score)` 90d → EXIT **recommendation** (advisory; gated on thesis `break_conditions` + max ≥ 0.80; never auto-closes per safety invariant).
3. **FE**: InstrumentPage red-flag badge + the #592-deferred trend chart.

## Model (spec: `docs/specs/filings/2026-06-27-1748-filings-risk-scorer.md`)
Explicit/auditable (settled §191); **only ever writes scores ≥ 0.7**:

| Filing | Score |
| --- | --- |
| 8-K/8-K/A with ≥1 **critical** item (per settled `sec_8k_item_codes`, sql/053) | 1.0 |
| Form NT late filing (Rule 12b-25) | 0.7 |
| everything else | NULL |

**Why only critical+NT, only high (Codex ckpt-1 caught the original sparse-with-0.1 model):** turnaround is `1.0 − avg` with a 0.5-neutral NULL default, so any score < 0.5 would *reward* the instrument; and AVG/MAX over `WHERE NOT NULL` means scoring benign filings would *dilute* a genuine critical. Leaving non-flags NULL keeps a lone critical at avg 1.0.

**No `model_version` bump:** data completion under the existing `v1.3-balanced` model — no formula/threshold change (settled §236). Documented operator-visible effect: instruments with a recent critical 8-K / NT lose score weight, may trip the penalty, and (held + thesis break_conditions) may surface an advisory EXIT recommendation. The column's designed purpose going live; demo-first.

## Source rule
Inputs fixed by settled invariants: 8-K item severity from `sec_8k_item_codes` (sql/053, SEC Form 8-K General Instructions); Form NT = SEC Rule 12b-25; Item 4.02 already `critical`. Full-population dev check picked `filing_events.items[]` (393,519 populated) over `eight_k_items` (only 20,343 parsed).

## Write paths (one pure fn `app/services/filings_risk.py`, single source)
- **8-K**: `apply_8k_items_to_filing_events` sets `red_flag_score` alongside `items[]` (the real 8-K source-of-truth — INSERTs don't carry items).
- **NT**: computed at the 3 `filing_events` INSERTs (filing_type-driven); `ON CONFLICT … COALESCE(EXCLUDED, existing)` so the NT path never clobbers an 8-K's items-path score, and 8-K item-removal correctly clears via the items path's explicit SET.
- **Backfill** `scripts/backfill_red_flag_score.py` (keyset, idempotent, value-driven — follows the scorer's constants, no SQL re-encoding).
- New endpoint `GET /filings/{id}/red-flag-trend` (per-quarter AVG) + FE `RedFlagTrendChart` (deferred 3rd filings-analytics chart).

## Verification (ETL DoD clauses 8–12, commit `7be47459`)
- **Backfill executed on dev (clause 10):** 10,280 critical (1.0) + 4,317 NT (0.7) = 14,597 scored; 383,239 non-critical 8-Ks left NULL (idempotent re-run writes 0).
- **Smoke panel (clause 8)** AAPL/GME/MSFT/JPM/HD: GME & MSFT 2 criticals each; AAPL/HD/JPM legitimately 0 (no critical/NT filings — blue-chips).
- **Cross-source (clause 9):** GME 8-K `0001326380-24-000168` (2024-12-10) item **4.01 Changes in Certifying Accountant** = critical per SEC Form 8-K General Instructions + sql/053.
- **Live endpoint (clause 11):** `GET /filings/1699/red-flag-trend` → `2024-Q4 avg 1.0 n=1`; AAPL → empty (FE empty-state).

## Tests / gates
Pure-fn table test (24); FE chart render-test + types. ruff, pyright, pytest fast (4564) + affected db tier (`test_sec_filing_items`, `test_api_filings` — 26), FE typecheck / test:unit (1136) / dark:check (223). Codex ckpt-1 (spec) + ckpt-2 (diff) both addressed/clean.

## Operator follow-up after merge
Daemon restart onto new main (ingest/parser touched) + the backfill is already run on dev. New filings score natively via the write paths (fresh bootstrap needs no separate backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)