### PR TITLE
feat(#1745): per-period dual-class FCF yield + cross-currency FX normalisation

### DIFF
--- a/app/services/fcf_yield.py
+++ b/app/services/fcf_yield.py
@@ -1,18 +1,24 @@
-"""Per-period FCF-yield series for the fundamentals drill page (#671).
+"""Per-period FCF-yield series for the fundamentals drill page (#671, #1745).
 
 FCF yield = TTM free cash flow / period-end market cap, rendered as a trend
 overlay on the absolute-FCF line (`/instrument/:symbol/fundamentals`).
 
 This module owns the fail-closed market-cap policy the frontend cannot
-reproduce (data-eng I20 / prevention-log #1664):
+reproduce (data-eng I20 / prevention-log #1664). #1745 replaced the two
+whole-series *suppressions* with per-period reconstruction:
 
-  * **Multi-class issuers** — `close × combined_shares` is the structurally-wrong
-    figure #1662 retired. v1 does no per-period per-class reconstruction, so any
-    curated multi-class issuer (``resolve_market_cap_basis().basis !=
-    "not_multiclass"``) is SUPPRESSED, not approximated.
+  * **Multi-class issuers** — ``close × combined_shares`` is the structurally-wrong
+    figure #1662 retired. Each period's cap is now the per-period total-company cap
+    (``xbrl_derived_stats.total_company_cap_at_period``: Σ per-class price×shares +
+    residual, fail-closed guards). A period with no clean cap → NULL yield for that
+    point (not a whole-series suppression).
   * **Cross-currency** — FCF is in ``financial_periods.reported_currency``; price
-    is the instrument's eToro trading currency (``instruments.currency``). With no
-    FX normaliser (sql/024 caveat), a proven mismatch is SUPPRESSED.
+    (hence cap) is the eToro trading currency (``instruments.currency``). A mismatch
+    is normalised at the period-end FX rate (``fx_history``) before dividing; a
+    period with no usable rate → NULL yield for that point.
+
+``suppressed_reason`` is retained on the response for forward-compat but is no
+longer set by either path (always ``None`` post-#1745).
 
 Single-class, currency-coherent issuers get the per-period TTM yield:
 ``fcf_ttm = SUM(operating_cf) − ABS(SUM(capex))`` over 4 consecutive normalized
@@ -30,10 +36,16 @@ from typing import Any, Literal
 import psycopg
 import psycopg.rows
 
-from app.services.xbrl_derived_stats import resolve_market_cap_basis
+from app.services.fx_history import fx_cross_rate
+from app.services.xbrl_derived_stats import resolve_market_cap_basis, total_company_cap_at_period
 
 FcfYieldSuppression = Literal["multiclass", "currency_mismatch"]
 FinancialsPeriod = Literal["quarterly", "annual"]
+
+# FX is daily; a period-end rate carried forward more than this from the nearest
+# stored business day is too stale to trust for that period → NULL yield (Codex
+# ckpt-1 MED-2). Generous (covers a long holiday) but bounded.
+_MAX_FX_CARRY_FORWARD_DAYS = 7
 
 
 @dataclass(frozen=True)
@@ -80,7 +92,7 @@ def fcf_yield_pct(fcf_ttm: Decimal | None, market_cap: Decimal | None) -> Decima
 _QUARTERLY_SQL = """
     WITH q AS (
         SELECT
-            period_end_date, period_type, shares_outstanding,
+            period_end_date, period_type, shares_outstanding, reported_currency,
             SUM(operating_cf)    OVER w AS ocf_ttm,
             SUM(capex)           OVER w AS capex_ttm,
             COUNT(*)             OVER w AS n_q,
@@ -93,7 +105,7 @@ _QUARTERLY_SQL = """
         WINDOW w AS (ORDER BY period_end_date ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
     )
     SELECT
-        q.period_end_date, q.period_type, q.shares_outstanding,
+        q.period_end_date, q.period_type, q.shares_outstanding, q.reported_currency,
         CASE
             WHEN q.n_q = 4 AND (q.period_end_date - q.ttm_start) <= 330
             THEN q.ocf_ttm - ABS(COALESCE(q.capex_ttm, 0))
@@ -116,7 +128,7 @@ _QUARTERLY_SQL = """
 # Annual: a FY row is already 12 months, so fcf = that row's own ocf − |capex|.
 _ANNUAL_SQL = """
     SELECT
-        fp.period_end_date, fp.period_type, fp.shares_outstanding,
+        fp.period_end_date, fp.period_type, fp.shares_outstanding, fp.reported_currency,
         fp.operating_cf - ABS(COALESCE(fp.capex, 0)) AS fcf_ttm,
         pd.close AS price, pd.price_date AS price_as_of
     FROM financial_periods fp
@@ -137,34 +149,61 @@ _ANNUAL_SQL = """
 """
 
 
-def _currency_mismatch(conn: psycopg.Connection[Any], instrument_id: int) -> bool:
-    """True only on a PROVEN mismatch — both currencies known and different.
+def _trading_currency(conn: psycopg.Connection[Any], instrument_id: int) -> str | None:
+    """The instrument's eToro trading currency (``None`` on a data gap). Stable per
+    instrument; the per-period *reporting* currency comes from each row instead, so
+    a historical reporting-currency change converts each period correctly (Codex
+    ckpt-2)."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT currency FROM instruments WHERE instrument_id = %s", (instrument_id,))
+        row = cur.fetchone()
+    return row[0] if row is not None else None
 
-    A NULL trading currency (data gap) is NOT treated as a mismatch: over-
-    suppressing US instruments is worse for the operator than a rare undetected
-    foreign mismatch. The full-population verification (spec) reports the
-    mismatch count; reported_currency is NOT NULL (sql/032:121).
-    """
+
+def _instrument_cik(conn: psycopg.Connection[Any], instrument_id: int) -> str | None:
+    """10-digit primary SEC CIK, or ``None``. Same normalization as
+    ``resolve_market_cap_basis`` so the curated FSDS oracle is hit identically."""
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT i.currency AS trading_ccy,
-                   (SELECT reported_currency
-                    FROM financial_periods
-                    WHERE instrument_id = %(iid)s AND superseded_at IS NULL
-                      AND normalization_status = 'normalized'
-                    ORDER BY period_end_date DESC, filed_date DESC NULLS LAST
-                    LIMIT 1) AS reported_ccy
-            FROM instruments i
-            WHERE i.instrument_id = %(iid)s
+            SELECT identifier_value FROM external_identifiers
+            WHERE instrument_id = %s AND provider = 'sec' AND identifier_type = 'cik'
+              AND is_primary = TRUE
+            LIMIT 1
             """,
-            {"iid": instrument_id},
+            (instrument_id,),
         )
         row = cur.fetchone()
-    if row is None:
-        return False
-    trading_ccy, reported_ccy = row
-    return trading_ccy is not None and reported_ccy is not None and trading_ccy != reported_ccy
+    return str(row[0]).zfill(10) if row is not None and row[0] is not None else None
+
+
+def _period_fx_rate(
+    conn: psycopg.Connection[Any], *, period_end: date, reported_ccy: str, trading_ccy: str
+) -> Decimal | None:
+    """Reported→trading cross rate at ``period_end``, or ``None`` (fail-closed) if
+    EITHER currency leg lacks a USD-base rate within ``_MAX_FX_CARRY_FORWARD_DAYS``
+    of the period.
+
+    Freshness is checked on each SPECIFIC leg, NOT the aggregate newest rate_date —
+    a fresh unrelated pair must not let a stale ``reported``/``trading`` leg through
+    (Codex ckpt-2). USD legs are unity (no stored row needed)."""
+    rates: dict[tuple[str, str], Decimal] = {}
+    with conn.cursor() as cur:
+        for ccy in {reported_ccy, trading_ccy} - {"USD"}:
+            cur.execute(
+                """
+                SELECT rate, rate_date FROM fx_rates_daily
+                WHERE base_currency = 'USD' AND quote_currency = %(c)s AND rate_date <= %(d)s::date
+                ORDER BY rate_date DESC
+                LIMIT 1
+                """,
+                {"c": ccy, "d": period_end},
+            )
+            row = cur.fetchone()
+            if row is None or (period_end - row[1]).days > _MAX_FX_CARRY_FORWARD_DAYS:
+                return None
+            rates[("USD", ccy)] = Decimal(row[0])
+    return fx_cross_rate(rates, from_ccy=reported_ccy, to_ccy=trading_ccy)
 
 
 def fcf_yield_series(
@@ -173,11 +212,19 @@ def fcf_yield_series(
     instrument_id: int,
     period: FinancialsPeriod,
 ) -> FcfYieldComputation:
-    """Per-period FCF-yield series, or a suppression reason (empty rows)."""
-    if resolve_market_cap_basis(conn, instrument_id=instrument_id).basis != "not_multiclass":
-        return FcfYieldComputation(suppressed_reason="multiclass", rows=[])
-    if _currency_mismatch(conn, instrument_id):
-        return FcfYieldComputation(suppressed_reason="currency_mismatch", rows=[])
+    """Per-period FCF-yield series. Per-period fail-closed: a period whose market
+    cap or FX rate can't be sourced cleanly gets a NULL yield (its absolute FCF
+    still renders); the series itself is never suppressed (#1745)."""
+    basis = resolve_market_cap_basis(conn, instrument_id=instrument_id).basis
+    is_multiclass = basis != "not_multiclass"
+    cik = _instrument_cik(conn, instrument_id) if is_multiclass else None
+
+    trading_ccy = _trading_currency(conn, instrument_id)
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date")
+        today_row = cur.fetchone()
+    today: date = today_row[0] if today_row is not None else date.max
 
     sql = _QUARTERLY_SQL if period == "quarterly" else _ANNUAL_SQL
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -186,17 +233,41 @@ def fcf_yield_series(
 
     rows: list[FcfYieldRow] = []
     for r in db_rows:
+        period_end: date = r["period_end_date"]
         shares = r["shares_outstanding"]
         price = r["price"]
         fcf_ttm = r["fcf_ttm"]
-        market_cap = shares * price if shares is not None and price is not None else None
+
+        # Market cap: per-period total-company cap for a multi-class issuer (#1745),
+        # else the single-class period_end shares × close.
+        if is_multiclass:
+            cap = (
+                total_company_cap_at_period(conn, cik=cik, target_period_end=period_end, today=today)
+                if cik is not None
+                else None
+            )
+            market_cap = cap.value if cap is not None else None
+        else:
+            market_cap = shares * price if shares is not None and price is not None else None
+
+        # FX-normalise the (reporting-currency) FCF into the trading currency the cap
+        # is denominated in, before taking the ratio. The reporting currency is read
+        # PER ROW (an issuer can change it over time — Codex ckpt-2). No usable rate →
+        # NULL yield for this period. The displayed absolute fcf_ttm stays in its
+        # reporting currency.
+        reported_ccy = r["reported_currency"]
+        fcf_for_yield = fcf_ttm
+        if fcf_ttm is not None and trading_ccy is not None and reported_ccy is not None and reported_ccy != trading_ccy:
+            rate = _period_fx_rate(conn, period_end=period_end, reported_ccy=reported_ccy, trading_ccy=trading_ccy)
+            fcf_for_yield = fcf_ttm * rate if rate is not None else None
+
         rows.append(
             FcfYieldRow(
-                period_end=r["period_end_date"],
+                period_end=period_end,
                 period_type=str(r["period_type"]),
                 fcf_ttm=fcf_ttm,
                 market_cap=market_cap,
-                fcf_yield_pct=fcf_yield_pct(fcf_ttm, market_cap),
+                fcf_yield_pct=fcf_yield_pct(fcf_for_yield, market_cap),
                 price=price,
                 price_as_of=r["price_as_of"],
             )

--- a/app/services/fx_history.py
+++ b/app/services/fx_history.py
@@ -19,6 +19,7 @@ Two responsibilities:
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from datetime import date
 from decimal import Decimal
 from typing import Any
@@ -195,3 +196,30 @@ def load_fx_rates_for_date(
         if used is None or rd > used:
             used = rd
     return rates, used
+
+
+def fx_cross_rate(
+    rates: Mapping[tuple[str, str], Decimal],
+    *,
+    from_ccy: str,
+    to_ccy: str,
+) -> Decimal | None:
+    """USD-base cross rate: ``amount_in_from_ccy × result = amount_in_to_ccy``.
+
+    ``rates`` is the ``load_fx_rates_for_date`` dict, keyed ``(base, quote) -> rate``
+    where base is always ``USD`` (``FX_BASE``) and the value is units of *quote* per
+    1 USD. USD is treated as ``1`` (it is never a stored pair). Cross = (to per USD)
+    / (from per USD). Returns ``None`` (fail-closed) if either currency is neither
+    USD nor a stored USD-quote pair — never call ``convert()`` for a non-USD cross
+    (Codex ckpt-1 MED). Pure — table-tested without a DB."""
+
+    def per_usd(ccy: str) -> Decimal | None:
+        if ccy == "USD":
+            return Decimal(1)
+        return rates.get(("USD", ccy))
+
+    to_rate = per_usd(to_ccy)
+    from_rate = per_usd(from_ccy)
+    if to_rate is None or from_rate is None or from_rate == 0:
+        return None
+    return to_rate / from_rate

--- a/app/services/xbrl_derived_stats.py
+++ b/app/services/xbrl_derived_stats.py
@@ -145,6 +145,12 @@ _RESIDUAL_MAX_FRACTION: Final = Decimal("0.25")
 # (Codex ckpt-1 MED: "nearest" needs a max delta). ~4 quarters.
 _MAX_COMBINED_FSDS_DELTA_DAYS: Final = 400
 
+# #1745 per-period cap: max gap between the FSDS class-shares period actually on
+# file and the TARGET financial period_end being priced. Tight (~one quarter) so a
+# period borrows class shares only from its own (or an immediately adjacent) quarter
+# — not a year-away row the 548-day staleness window would otherwise admit.
+_MAX_CLASS_PERIOD_TARGET_DELTA_DAYS: Final = 100
+
 
 @dataclass(frozen=True)
 class _ClassLeg:
@@ -259,6 +265,28 @@ def _latest_price(conn: psycopg.Connection[Any], instrument_id: int) -> Decimal 
     return price if price > 0 else None
 
 
+def _price_at(conn: psycopg.Connection[Any], instrument_id: int, on_date: date) -> Decimal | None:
+    """Daily close at/just-before ``on_date`` — the period-end price for the
+    historical per-period cap (#1745). ``price_daily`` (EOD), NOT live ``quotes``,
+    because a 2023 cap must use the 2023 price, not today's. ``None`` when no
+    positive close is on file on/before the date."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT close FROM price_daily
+            WHERE instrument_id = %(iid)s AND price_date <= %(d)s::date AND close > 0
+            ORDER BY price_date DESC
+            LIMIT 1
+            """,
+            {"iid": instrument_id, "d": on_date},
+        )
+        row = cur.fetchone()
+    if row is None or row[0] is None:
+        return None
+    price = Decimal(row[0])
+    return price if price > 0 else None
+
+
 def _read_combined_shares_near(
     conn: psycopg.Connection[Any], instrument_id: int, near_period: date
 ) -> tuple[Decimal, date] | None:
@@ -296,14 +324,24 @@ def _assemble_total_company_cap(
     legs_raw: list[tuple[int, Decimal, Decimal | None]],
     combined_shares: Decimal,
     combined_as_of: date,
+    as_of: date | None = None,
 ) -> TotalCompanyMarketCap | None:
     """Pure policy: given the per-class rows (``(instrument_id, shares, price | None)``
     — ``price=None`` = unpriced sibling), the combined all-class count, and the two
     instants, return the total-company cap or ``None`` if any guard fails. No DB —
     every fail-closed branch is table-tested. The freshness + structural per-class
     policy defers to the shared ``ownership_rollup.class_shares_usable`` (single
-    source with the ownership denominator)."""
+    source with the ownership denominator).
+
+    ``as_of`` is the freshness reference for the per-class staleness gate. The LATEST
+    live-cap path leaves it ``None`` → it defaults to ``today`` (is the newest FSDS
+    instant fresh vs now?). The per-period historical path (#1745) passes the TARGET
+    financial period_end → the class row is judged fresh *relative to the period it
+    prices*, not vs 2026-now (which would fail every old point). The future-date
+    guard still uses the real ``today`` (a future instant is corrupt regardless)."""
     from app.services.ownership_rollup import class_shares_usable
+
+    freshness_ref = as_of if as_of is not None else today
 
     # A future period_end is corrupt data, not a fresh figure (the staleness policy
     # deliberately treats future as not-stale; the cap path must not inherit that
@@ -324,7 +362,7 @@ def _assemble_total_company_cap(
             class_shares=shares,
             class_period_end=period_end,
             combined_shares=combined_shares,
-            today=today,
+            today=freshness_ref,
         ):
             return None  # stale or structurally implausible per-class row
         if price is None or price <= 0:
@@ -417,6 +455,80 @@ def _build_total_company_cap(
     return _assemble_total_company_cap(
         period_end=period_end,
         today=today,
+        legs_raw=legs_raw,
+        combined_shares=combined_shares,
+        combined_as_of=combined_as_of,
+    )
+
+
+def total_company_cap_at_period(
+    conn: psycopg.Connection[Any],
+    *,
+    cik: str,
+    target_period_end: date,
+    today: date,
+) -> TotalCompanyMarketCap | None:
+    """Total-company cap AS OF a historical ``target_period_end`` (#1745).
+
+    Like :func:`_build_total_company_cap` but period-anchored, not latest-pinned:
+      * per-class shares = the FSDS row NEAREST ``target_period_end`` for this CIK,
+        rejected if more than ``_MAX_CLASS_PERIOD_TARGET_DELTA_DAYS`` away (Codex
+        ckpt-1 HIGH — "nearest" alone could borrow a year-away quarter);
+      * per-class price = ``price_daily`` close at/just-before the target (NOT the
+        live quote);
+      * freshness judged vs the target (``as_of=target_period_end``), so an old
+        point is not failed merely for being old relative to today.
+    Returns ``None`` (fail-closed) when no clean cap exists for that period — the
+    caller renders absolute FCF with a NULL yield for that point.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT period_end
+            FROM instrument_class_shares_outstanding
+            WHERE source_cik = %(cik)s
+            ORDER BY ABS(period_end - %(t)s::date) ASC, period_end DESC
+            LIMIT 1
+            """,
+            {"cik": cik, "t": target_period_end},
+        )
+        pe_row = cur.fetchone()
+        if pe_row is None or pe_row[0] is None:
+            return None
+        fsds_period: date = pe_row[0]
+        if abs((fsds_period - target_period_end).days) > _MAX_CLASS_PERIOD_TARGET_DELTA_DAYS:
+            return None
+
+        cur.execute(
+            """
+            SELECT instrument_id, shares
+            FROM instrument_class_shares_outstanding
+            WHERE source_cik = %s AND period_end = %s
+            """,
+            (cik, fsds_period),
+        )
+        class_rows = [(int(r[0]), Decimal(r[1])) for r in cur.fetchall()]
+    if not class_rows:
+        return None
+
+    # Combined all-class count nearest the TARGET period, read from any sibling that
+    # carries it (the issuer-level figure is fanned to all siblings, #1102).
+    combined: tuple[Decimal, date] | None = None
+    for iid, _ in class_rows:
+        combined = _read_combined_shares_near(conn, iid, target_period_end)
+        if combined is not None:
+            break
+    if combined is None:
+        return None
+    combined_shares, combined_as_of = combined
+
+    legs_raw: list[tuple[int, Decimal, Decimal | None]] = [
+        (iid, shares, _price_at(conn, iid, target_period_end)) for iid, shares in class_rows
+    ]
+    return _assemble_total_company_cap(
+        period_end=fsds_period,
+        today=today,
+        as_of=target_period_end,
         legs_raw=legs_raw,
         combined_shares=combined_shares,
         combined_as_of=combined_as_of,

--- a/docs/specs/fundamentals/2026-06-27-1745-dual-class-fcf-fx.md
+++ b/docs/specs/fundamentals/2026-06-27-1745-dual-class-fcf-fx.md
@@ -1,0 +1,56 @@
+# #1745 — per-period dual-class FCF yield + cross-currency FX normalisation
+
+Parent #585. Predecessor #671 (FCF yield trend). Operator decision 2026-06-27: build full (A) now + (B).
+
+## Problem
+`fcf_yield_series` (app/services/fcf_yield.py) **fail-closed suppresses** two issuer classes:
+- **`multiclass`** — any curated multi-class issuer (`resolve_market_cap_basis().basis != "not_multiclass"`). `close × combined_shares` is the structurally-wrong cap #1662 retired; v1 did no per-period per-class reconstruction.
+- **`currency_mismatch`** — `financial_periods.reported_currency != instruments.currency`, with no FX normaliser (sql/024 caveat).
+
+Dev: 6 multi-class instruments (GOOG/GOOGL, HEI/HEI.A, METC/METCB); **0** currency-mismatch.
+
+## Source rule
+- **Per-class shares** = SEC DERA FSDS `num.txt`, `tag == "CommonStockSharesOutstanding"` AND `version` starts `us-gaap/`, single `ClassOfStock=<member>` segment, `uom=shares qtrs=0`, current period = `ddate == sub.period` (the settled rules already encoded in `app/services/fsds_class_shares.py`, spec `docs/specs/etl/2026-06-17-per-class-shares-denominator.md`). The companyfacts JSON API strips dimensional facts, so `financial_facts_raw` holds only the COMBINED count.
+- **Total-company cap** = `Σ class_price × class_shares + residual×impute_price`, all fail-closed guards in `xbrl_derived_stats._assemble_total_company_cap` (settled `docs/specs/etl/2026-06-17-per-class-market-cap.md`).
+- **FX** — period-end rate from `fx_rates_daily` (sql/196) via `app/services/fx_history.load_fx_rates_for_date` (USD-base, carry-forward). FCF is reporting-currency; price (hence cap) is trading-currency.
+
+## Full-population verification (dev — premise of the original handoff falsified)
+A per-period cap **trend** needs per-class shares **at each historical period_end**. That data did **not** exist:
+- `instrument_class_shares_outstanding`: **latest snapshot only** — 1 period_end per instrument (6 rows total), because the orchestrator ingests only `last_n_quarters(n_fsds=4)` and only `fsds_2025q1.zip` is cached.
+- `instrument_dimensional_facts`: segment/geo/product **revenue/income/assets** only — no share metric, no ClassOfStock axis.
+- `financial_facts_raw`: **consolidated only** (no dimensional column); GOOG `CommonStockSharesOutstanding` = 12.1B combined.
+
+**Key structural finding:** the fix is *not* a new parser/table. `instrument_class_shares_outstanding` PK is **`(instrument_id, period_end)`** — it already holds history; `ingest_fsds_class_shares_archive` already derives `period_end = ddate` per class. The gap is purely that **only one FSDS quarter was ever ingested**. Ingesting historical quarters fills the per-period rows with the existing, settled parser.
+
+## Design
+
+### (A1) Historical FSDS ingest backfill
+`scripts/backfill_fsds_class_shares_history.py`: build `BulkArchive`s for the last N FSDS quarters (`last_n_quarters(N)` → `files/dera/data/financial-statement-data-sets/{q}.zip`), `download_bulk_archives(archives=…)` into the bulk dir, then run the existing `ingest_fsds_class_shares_archive` per quarter (no-demotion upsert handles overlap/restatement). `--quarters N` (default e.g. 20 ≈ 5y), `--keep`/delete-after. Reuses every settled primitive; output is tiny (per-class rows over the 3 curated issuers × N quarters). Each ZIP ~530 MB streamed.
+
+### (A2) Per-period total-company cap read
+`xbrl_derived_stats.total_company_cap_at_period(conn, *, cik, period_end) -> TotalCompanyMarketCap | None`: refactor `_build_total_company_cap` so the period is a parameter, not `MAX(period_end)`. For a given `period_end`:
+- per-class shares = the `instrument_class_shares_outstanding` row for the CIK at the FSDS period **nearest** `period_end` (exact-or-nearest, same `ABS(period_end − target)` ordering as `_read_combined_shares_near`);
+- per-class **price = `price_daily.close` at ≤ period_end** (NOT `_latest_price`) — new `_price_at(conn, iid, period_end)`;
+- combined = `_read_combined_shares_near(conn, …, period_end)`.
+Defer to the unchanged pure `_assemble_total_company_cap` (its guards: ≥2 siblings, future-date, combined-delta ≤ `_MAX_COMBINED_FSDS_DELTA_DAYS`, `class_shares_usable` staleness, Σ ≤ combined×1.005, residual ≤ 25%). The existing latest-pinned `_build_total_company_cap` becomes a thin `total_company_cap_at_period(…, period_end=MAX)` wrapper so `resolve_market_cap_basis` is unchanged.
+
+### (A3) fcf_yield multiclass path → per-period, drop suppression
+Replace the whole-series `multiclass` suppression: for a multi-class issuer, compute `market_cap` per financial_periods row via `total_company_cap_at_period`; a period whose cap fails its guards → `market_cap=None` → that point shows absolute FCF but **NULL yield** (per-point fail-closed, the FE already gaps NULL `fcf_yield_pct`). Single-class path unchanged. The `multiclass` suppression literal is retired.
+
+### (B) FX normalisation, drop currency_mismatch suppression
+When `reported_currency != trading currency`, convert `fcf_ttm` (reporting ccy) → trading ccy at the **period-end** rate (`load_fx_rates_for_date`; USD-base, so cross rate = `rate[trading]/rate[reported]`) before `fcf_yield_pct`. A period with no FX rate on/near its date → NULL yield (per-point fail-closed). Retire the `currency_mismatch` suppression. 0 dev instruments → covered by unit tests + a synthetic fixture; forward safety net.
+
+## Out of scope / kept
+The fail-closed guards stay for genuinely-uncomputable periods. `resolve_market_cap_basis` / ownership rollup unchanged. Untraded residual imputation unchanged. New curated dual-class issuers still need a `_CLASS_MEMBER_TO_CUSIP` entry (settled).
+
+## Tests
+- Pure: `total_company_cap_at_period` period selection (nearest FSDS period, price-at-period) + FX cross-rate math, table-tested in `_assemble`-style harness.
+- FX cross-rate helper (USD-base → trading/reported) pure test.
+- db-tier: ingest two FSDS quarters → two period rows → per-period cap differs by period.
+- FE: FcfChart already handles NULL yield + multi-point; verify no `suppressed_reason` path break (the literal set shrinks).
+
+## DoD (ETL clauses 8–12)
+- Backfill executed on dev: N historical FSDS quarters ingested → `instrument_class_shares_outstanding` gains per-period rows for the 3 issuers (record counts).
+- Smoke: `/instruments/GOOG/fcf-yield?period=quarterly` now returns **points (not suppressed)** with per-period `market_cap`/`fcf_yield_pct`; same on GOOGL (identical company total). HEI/METC likewise.
+- Cross-source one period's per-class shares vs the issuer's 10-Q cover (e.g. Alphabet Class A vs Class C).
+- Record commit SHA + the GOOG figure.

--- a/scripts/backfill_fsds_class_shares_history.py
+++ b/scripts/backfill_fsds_class_shares_history.py
@@ -1,0 +1,126 @@
+"""Backfill historical per-class shares-outstanding from SEC DERA FSDS (#1745).
+
+`instrument_class_shares_outstanding` (sql/200) is keyed `(instrument_id,
+period_end)` and already holds history — but only `last_n_quarters(4)` are
+ever downloaded by the bootstrap, so dev has just one quarter per issuer.
+The per-period dual-class FCF-yield trend (#1745) needs per-class shares at
+each historical period_end. This script downloads the last N FSDS quarters
+and runs the existing, settled parser
+(`fsds_class_shares.ingest_fsds_class_shares_archive`) over each — no new
+parser, no schema change. The no-demotion upsert handles quarter overlap and
+restatement.
+
+Run from the repo root::
+
+    uv run python scripts/backfill_fsds_class_shares_history.py --quarters 20 --apply
+
+Dry-run by default (lists the quarters + whether each ZIP is already cached).
+`--apply` downloads (each ~530 MB) + ingests. `--keep` retains the ZIPs
+(default: delete each after a successful ingest to bound disk). Resumable —
+a cached ZIP is re-used, and ingest is idempotent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+import psycopg
+
+from app.config import settings
+from app.security.master_key import resolve_data_dir
+from app.services.fsds_class_shares import ingest_fsds_class_shares_archive
+from app.services.sec_bulk_download import (
+    SEC_BASE_URL,
+    BulkArchive,
+    download_bulk_archives,
+    last_n_quarters,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _bulk_dir() -> Path:
+    # Mirrors app.services.sec_bulk_orchestrator_jobs._bulk_dir without importing
+    # that module (it pulls in the insider-ingest import cycle).
+    return resolve_data_dir() / "sec" / "bulk"
+
+
+def _archive_path(name: str) -> Path:
+    return _bulk_dir() / name
+
+
+def _fsds_archives(quarters: list[str]) -> list[BulkArchive]:
+    return [
+        BulkArchive(
+            name=f"fsds_{q}.zip",
+            url=f"{SEC_BASE_URL}/files/dera/data/financial-statement-data-sets/{q}.zip",
+            # The newest quarter is published weeks after it closes — optional so
+            # an expected-404 right after a boundary doesn't fatal the batch.
+            optional=(idx == 0),
+        )
+        for idx, q in enumerate(quarters)
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quarters", type=int, default=20, help="How many recent FSDS quarters (default 20 ≈ 5y).")
+    parser.add_argument("--apply", action="store_true", help="Download + ingest (default: dry-run plan).")
+    parser.add_argument("--keep", action="store_true", help="Keep ZIPs after ingest (default: delete each).")
+    args = parser.parse_args(argv)
+
+    quarters = last_n_quarters(int(args.quarters))
+    logger.info("FSDS history backfill: %d quarters %s..%s", len(quarters), quarters[-1], quarters[0])
+
+    if not args.apply:
+        for q in quarters:
+            cached = _archive_path(f"fsds_{q}.zip").exists()
+            logger.info("  %s — %s", q, "cached" if cached else "would download")
+        logger.info("DRY RUN — pass --apply to download + ingest.")
+        return 0
+
+    archives = _fsds_archives(quarters)
+    # bandwidth_threshold_mbps=0 so a slow dev link still proceeds (no fallback
+    # skip); the orchestrator's probe is for the live bootstrap, not a backfill.
+    result = asyncio.run(
+        download_bulk_archives(
+            target_dir=_bulk_dir(),
+            user_agent=settings.sec_user_agent,
+            archives=archives,
+            bandwidth_threshold_mbps=0,
+        )
+    )
+    logger.info("download: mode=%s", result.mode)
+
+    total_written = 0
+    ingested = 0
+    for q in quarters:
+        path = _archive_path(f"fsds_{q}.zip")
+        if not path.exists():
+            logger.info("  %s — absent after download (expected for the newest optional quarter), skipping", q)
+            continue
+        with psycopg.connect(settings.database_url) as conn:
+            try:
+                res = ingest_fsds_class_shares_archive(conn=conn, archive_path=path, fsds_qtr=q)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                logger.exception("  %s — ingest failed", q)
+                continue
+        ingested += 1
+        total_written += res.rows_written
+        logger.info("  %s — written=%d no_row=%s", q, res.rows_written, res.curated_pairs_without_row)
+        if not args.keep:
+            path.unlink(missing_ok=True)
+
+    logger.info("FSDS history backfill: complete. quarters_ingested=%d rows_written=%d", ingested, total_written)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dual_class_fcf_fx.py
+++ b/tests/test_dual_class_fcf_fx.py
@@ -1,0 +1,85 @@
+"""Pure-logic tests for #1745 — the as-of freshness of the per-period
+total-company cap, and the USD-base FX cross rate. No DB; the DB read path is
+covered end-to-end by the dev-verify recorded in the PR."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.fx_history import fx_cross_rate
+from app.services.xbrl_derived_stats import _assemble_total_company_cap
+
+
+def _legs() -> list[tuple[int, Decimal, Decimal | None]]:
+    # Two priced classes, each a clean subset of the combined count.
+    return [(1, Decimal("60"), Decimal("100")), (2, Decimal("30"), Decimal("90"))]
+
+
+class TestAssembleAsOf:
+    """``as_of`` lets a historical period be judged fresh vs the period it prices,
+    not vs today — the #1745 fix (Codex ckpt-1 HIGH-2)."""
+
+    def test_old_period_fails_without_as_of(self) -> None:
+        # Class data from 3 years before "today" — stale by the 548-day window.
+        old = date(2022, 12, 31)
+        cap = _assemble_total_company_cap(
+            period_end=old,
+            today=date(2026, 6, 27),
+            legs_raw=_legs(),
+            combined_shares=Decimal("100"),
+            combined_as_of=old,
+        )
+        assert cap is None  # stale vs today
+
+    def test_old_period_passes_with_matching_as_of(self) -> None:
+        old = date(2022, 12, 31)
+        cap = _assemble_total_company_cap(
+            period_end=old,
+            today=date(2026, 6, 27),
+            as_of=old,  # judged fresh relative to the period it prices
+            legs_raw=_legs(),
+            combined_shares=Decimal("100"),
+            combined_as_of=old,
+        )
+        assert cap is not None
+        # 60×100 + 30×90 + residual 10 × impute(largest leg price=100) = 6000+2700+1000
+        assert cap.value == Decimal("9700")
+        assert cap.residual_shares == Decimal("10")
+
+    def test_future_period_still_rejected_even_with_as_of(self) -> None:
+        future = date(2099, 1, 1)
+        cap = _assemble_total_company_cap(
+            period_end=future,
+            today=date(2026, 6, 27),
+            as_of=future,
+            legs_raw=_legs(),
+            combined_shares=Decimal("100"),
+            combined_as_of=future,
+        )
+        assert cap is None  # future-date guard uses real today, not as_of
+
+
+class TestFxCrossRate:
+    """USD-base cross: ``rates[(USD, X)]`` = X per 1 USD; USD itself = 1."""
+
+    def test_reported_to_trading_cross(self) -> None:
+        # GBP 0.80/USD, EUR 0.90/USD. reported=GBP → trading=EUR:
+        # (EUR per USD) / (GBP per USD) = 0.90 / 0.80.
+        rates = {("USD", "GBP"): Decimal("0.80"), ("USD", "EUR"): Decimal("0.90")}
+        assert fx_cross_rate(rates, from_ccy="GBP", to_ccy="EUR") == Decimal("0.90") / Decimal("0.80")
+
+    def test_usd_is_unity_either_side(self) -> None:
+        rates = {("USD", "GBP"): Decimal("0.80")}
+        assert fx_cross_rate(rates, from_ccy="GBP", to_ccy="USD") == Decimal(1) / Decimal("0.80")
+        assert fx_cross_rate(rates, from_ccy="USD", to_ccy="GBP") == Decimal("0.80")
+        assert fx_cross_rate(rates, from_ccy="USD", to_ccy="USD") == Decimal(1)
+
+    def test_unsupported_currency_fails_closed(self) -> None:
+        rates = {("USD", "GBP"): Decimal("0.80")}
+        assert fx_cross_rate(rates, from_ccy="GBP", to_ccy="JPY") is None
+        assert fx_cross_rate(rates, from_ccy="ZZZ", to_ccy="GBP") is None
+
+    def test_zero_from_rate_fails_closed(self) -> None:
+        rates = {("USD", "GBP"): Decimal("0"), ("USD", "EUR"): Decimal("0.90")}
+        assert fx_cross_rate(rates, from_ccy="GBP", to_ccy="EUR") is None


### PR DESCRIPTION
Closes #1745. Parent #585. Predecessor #671. Operator decision 2026-06-27: build full (A) + (B).

## Problem
`fcf_yield_series` fail-closed **suppressed** two whole-series classes: multi-class issuers (no per-period per-class cap — `close × combined_shares` is the wrong figure #1662 retired) and currency mismatches (no FX). Both are now reconstructed per-period; suppression retired.

## Premise falsified (handoff was wrong) — fix is NOT a new parser/table
`instrument_class_shares_outstanding` is PK `(instrument_id, period_end)` and `ingest_fsds_class_shares_archive` already derives `period_end` per class — but **only one FSDS quarter was ever ingested** (orchestrator fetches `last_n(4)`; only `fsds_2025q1` cached). `instrument_dimensional_facts` is revenue/geo only; `financial_facts_raw` is consolidated-only. So per-period history just needs **historical FSDS quarters ingested with the existing settled parser**.

## (A) Per-period dual-class cap
- `scripts/backfill_fsds_class_shares_history.py` — downloads the last N FSDS quarters (reuses `download_bulk_archives`) + runs the existing ingester; no-demotion upsert handles overlap. **Dev: 12 quarters → 62 per-class rows** (GOOG 12 periods, etc.).
- `xbrl_derived_stats.total_company_cap_at_period(cik, target_period_end, today)`: per-class shares at the FSDS period **nearest** the target (abs ≤100d guard — Codex ckpt-1), per-class price = `price_daily` close ≤ target (`_price_at`), combined near target; defers to the pure `_assemble_total_company_cap`, now with an **`as_of`** param so freshness is judged vs the period priced, not vs today (Codex ckpt-1 HIGH-2). The **latest path / `resolve_market_cap_basis` is byte-identical** (`as_of` defaults to today) → scoring/ownership untouched.
- `fcf_yield`: a multi-class issuer gets a per-period cap; a period without a clean cap → **NULL yield for that point** (per-point fail-closed), not whole-series suppression.

## (B) FX normalisation
- `fx_history.fx_cross_rate` (USD-base, USD=1, unsupported→None) + `_period_fx_rate` (per-**leg** carry-forward freshness ≤7d — Codex ckpt-2: aggregate newest date masked a stale leg). Reporting currency read **per row** (an issuer can change it — Codex ckpt-2). Reporting→trading conversion before the ratio; no rate → NULL yield. 0 dev mismatch instruments (forward safety net; unit-tested).

## Verification (ETL DoD 8–12, commit on branch)
- Backfill executed on dev: 12 FSDS quarters → per-period rows.
- **GOOG/GOOGL now UNSUPPRESSED** with per-period caps; GOOG==GOOGL (one company, $3.5T); FY2025 yield **1.94%**. Older yields NULL only where `operating_cf`/`capex` are absent (pre-existing `financial_periods` sparsity, unrelated).
- HEI/METC: per-point fail-closed — their companyfacts `CommonStockSharesOutstanding` is a single-class count (HEI combined 55.1M vs Σ classes 139M) → the `Σ ≤ combined×1.005` guard correctly rejects; uncomputable at the latest path too. Now show absolute FCF instead of a blank suppressed chart.
- **Cross-source:** GOOG/C 5,515M + GOOGL/A 5,835M + 861M untraded Class B residual = **12,211M combined ✓** (matches Alphabet's filing + the curated map).

## Tests / gates
Pure: `as_of` freshness + `fx_cross_rate` (7). Existing xbrl/fcf db tier green (16). Fast tier 4571. ruff/pyright clean. FE unchanged (FcfChart already gaps NULL yields; `suppressed_reason` now dormant). **No daemon restart** (read-path/API/script only).

## Operator follow-up after merge
For a fresh prod bootstrap the orchestrator still fetches only `last_n(4)` FSDS quarters (the per-period trend is shallow until deepened); run `scripts/backfill_fsds_class_shares_history.py --quarters N --apply` once for full depth (kept off the per-bootstrap path to avoid 20×530MB on every install). Deepening the bootstrap default is a separate tradeoff ticket if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)