### PR TITLE
feat(#1754): exchange-calendar Phase B (events page) + Phase C (coverage-gap shading)

### DIFF
--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -226,3 +226,19 @@ A migration-behaviour test (seed pre-state → run the migration SQL inline → 
 - Migrations with NO embedded transaction (e.g. `sql/111`) are fine to execute directly — the issue is only the embedded `BEGIN/COMMIT`.
 
 Origin: PR #1467 (#1320) review WARNING — `test_migration_182_pre14a_purge.py` executed `sql/182` (which wraps in `BEGIN;…COMMIT;`) inline then called `conn.commit()` again. EXTRACTED here rather than as a grep lint: the failure mode is narrow (migration tests only) and the fix is a one-liner at the call site.
+
+## A negative test must fail for the RIGHT reason
+
+Asserting `== []` / "does NOT fire" only proves something if the branch you
+*claim* to cover is what suppressed it — not an incidental earlier guard. A
+multi-guard function (e.g. `detectCoverageGaps`: cross-day guard THEN
+closed-window guard) will short-circuit on the first guard, so a fixture meant
+to exercise guard #2 can pass entirely on guard #1 and silently cover nothing.
+
+Construct the fixture so ONLY the target guard can be responsible: hold every
+earlier guard non-firing. For the closed-window case that meant a SAME-NY-date
+pair (cross-day guard inert) with the prev bar in a pre-04:00 closed window —
+not a cross-day pair that passes before the closed check is ever reached.
+
+Origin: PR #1763 (#1754) review WARNING — the "closed window" gap test passed
+because the two bars were different NY dates, never reaching the closed guard.

--- a/.claude/skills/frontend/async-data-loading.md
+++ b/.claude/skills/frontend/async-data-loading.md
@@ -182,3 +182,17 @@ grep -nE '\.error\b' frontend/src/pages/*.tsx            # duplicate error surfa
 ```
 
 Each match must be deliberate. Each `useAsync` state should appear in the error branch exactly once.
+
+## Render-stable hook arguments (#1754)
+
+A fresh array/object **literal** passed to a custom hook each render — e.g.
+`useMarketSpecials("us_equity", [{ time: now }])` — is a refetch/recompute
+hazard: if the hook ever uses that arg in a `useEffect`/`useMemo` dependency
+by identity, it loops every render. Memoise it (`useMemo(() => […], deps)`)
+or hoist it to module scope. This holds even when the hook *currently* derives
+a stable key internally — the call site must not bank on the hook's private
+implementation staying that way. Grep before push:
+
+```bash
+grep -nE 'use[A-Z][A-Za-z]+\([^)]*\[\{' frontend/src/**/*.tsx   # literal array-of-object hook args
+```

--- a/app/api/calendar.py
+++ b/app/api/calendar.py
@@ -1,0 +1,204 @@
+"""Calendar-of-events API (#1754 Phase B).
+
+A portfolio/watchlist-wide view: this week's market status (trading day /
+half-day / closed) per session profile, plus the real upcoming corporate
+events we actually ingest — ex-dividends.
+
+Scope of the data (premise-checked on dev, #1754):
+  * **Market status** — US is precise via the in-house ``market_calendar``
+    (NYSE). ``foreign_equity`` degrades to weekday-open / weekend-closed
+    (``holidays_modelled=false``) — no foreign exchange holiday set is
+    modelled (the operator's "no new deps" decision; #609 posture).
+    ``continuous`` (crypto/fx/commodity/index) is ``not_modelled`` — we do
+    not assert an open/closed for it.
+  * **Upcoming ex-dividends** — ``dividend_events.ex_date >= today``. Real
+    (sparse) data.
+  * Forward earnings + filing dates are deliberately NOT here: we ingest no
+    forward earnings calendar and no filing-due dates (verified absent).
+
+``is_open_now`` / the current intraday session is computed on the FRONTEND
+via the existing ``classifySession`` over these rows + the market specials
+it already fetches — no server-side duplication of the session-window logic.
+
+Auth: single-operator / global semantics matching the rest of the app —
+``positions`` is global; ``watchlist`` is resolved via ``sole_operator_id``.
+A service-token caller sees instance-wide scope.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Literal
+from zoneinfo import ZoneInfo
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.api.auth import require_session_or_service_token
+from app.api.instruments import _SESSION_PROFILE_SQL
+from app.db import get_conn
+from app.services.market_calendar import us_market_status
+from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
+
+router = APIRouter(
+    prefix="/calendar",
+    tags=["calendar"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+_NY = ZoneInfo("America/New_York")
+_WEEK_DAYS = 7
+
+CalendarScope = Literal["portfolio", "watchlist", "all"]
+DayType = Literal["open", "half_day", "closed", "not_modelled"]
+
+# Human label + degradation metadata per session profile.
+_PROFILE_META: dict[str, tuple[str, str, bool]] = {
+    # profile -> (label, timezone, holidays_modelled)
+    "us_equity": ("US equity", "America/New_York", True),
+    "us_equity_rth": ("US equity (regular hours)", "America/New_York", True),
+    "foreign_equity": ("Foreign equity", "exchange-local (approx)", False),
+    "continuous": ("Continuous (crypto / FX / commodity / index)", "UTC", False),
+}
+
+
+class MarketStatusDay(BaseModel):
+    date: date
+    day_type: DayType
+
+
+class MarketStatusRow(BaseModel):
+    profile: str
+    label: str
+    timezone: str
+    holidays_modelled: bool
+    week: list[MarketStatusDay]
+
+
+class UpcomingExDividend(BaseModel):
+    symbol: str
+    instrument_id: int
+    ex_date: date
+    pay_date: date | None
+
+
+class CalendarEvents(BaseModel):
+    scope: CalendarScope
+    as_of: date
+    market_status: list[MarketStatusRow]
+    ex_dividends: list[UpcomingExDividend]
+
+
+def _day_type(profile: str, d: date) -> DayType:
+    """Trading-day classification for a session profile on a civil date.
+
+    US is precise (NYSE). Foreign degrades to weekday/weekend. Continuous is
+    not modelled. ``d`` is the relevant civil date (NY for US; the caller uses
+    NY 'today' as the anchor uniformly — foreign weekend-vs-weekday is robust
+    to the ~hours of NY/local skew)."""
+    if profile in ("us_equity", "us_equity_rth"):
+        return us_market_status(d)
+    if profile == "foreign_equity":
+        return "closed" if d.weekday() >= 5 else "open"
+    if profile == "continuous":
+        # crypto / FX / commodity / index — eBull's settled stance (#609
+        # classifySession) is "no session concept, always trading"; report it
+        # the same way the chart + the live now-badge do, not as not_modelled.
+        return "open"
+    return "not_modelled"  # unknown/future profile — safe default
+
+
+def _scope_instruments(conn: psycopg.Connection[object], scope: CalendarScope) -> list[tuple[int, str, str]]:
+    """``(instrument_id, symbol, session_profile)`` for the scope. Empty list is
+    a valid result (no holdings / empty watchlist).
+
+    ``watchlist`` is operator-scoped via ``sole_operator_id`` (matching the
+    watchlist endpoint's single-operator posture); ``all`` applies the SAME
+    operator filter to its watchlist leg so one operator's view never unions
+    another's watchlist (Codex ckpt-2). ``positions`` is global."""
+    params: dict[str, object] = {}
+    if scope in ("watchlist", "all"):
+        try:
+            params["op"] = sole_operator_id(conn)
+        except NoOperatorError as exc:
+            raise HTTPException(status_code=503, detail="no operator configured") from exc
+        except AmbiguousOperatorError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="multiple operators present — calendar requires a per-session operator context",
+            ) from exc
+
+    if scope == "watchlist":
+        source = "JOIN watchlist src ON src.instrument_id = i.instrument_id AND src.operator_id = %(op)s"
+    elif scope == "portfolio":
+        source = "JOIN positions src ON src.instrument_id = i.instrument_id"
+    else:  # all — positions (global) ∪ this operator's watchlist
+        source = (
+            "JOIN (SELECT instrument_id FROM positions "
+            "UNION SELECT instrument_id FROM watchlist WHERE operator_id = %(op)s"
+            ") src ON src.instrument_id = i.instrument_id"
+        )
+
+    sql = f"""
+        SELECT DISTINCT i.instrument_id, i.symbol, {_SESSION_PROFILE_SQL}
+        FROM instruments i
+        {source}
+        LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+        ORDER BY i.symbol
+    """  # noqa: S608 — _SESSION_PROFILE_SQL is a static module constant, params are bound
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, params)
+        return [(int(r["instrument_id"]), str(r["symbol"]), str(r["session_profile"])) for r in cur.fetchall()]
+
+
+@router.get("/events", response_model=CalendarEvents)
+def calendar_events(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    scope: CalendarScope = Query(default="portfolio"),
+) -> CalendarEvents:
+    instruments = _scope_instruments(conn, scope)
+    today_ny = datetime.now(tz=_NY).date()
+
+    # One market-status row per DISTINCT profile present in the scope.
+    profiles = sorted({p for _, _, p in instruments})
+    week_dates = [today_ny + timedelta(days=i) for i in range(_WEEK_DAYS)]
+    market_status = [
+        MarketStatusRow(
+            profile=p,
+            label=_PROFILE_META.get(p, (p, "UTC", False))[0],
+            timezone=_PROFILE_META.get(p, (p, "UTC", False))[1],
+            holidays_modelled=_PROFILE_META.get(p, (p, "UTC", False))[2],
+            week=[MarketStatusDay(date=d, day_type=_day_type(p, d)) for d in week_dates],
+        )
+        for p in profiles
+    ]
+
+    ex_dividends: list[UpcomingExDividend] = []
+    instrument_ids = [iid for iid, _, _ in instruments]
+    if instrument_ids:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT i.symbol, d.instrument_id, d.ex_date, d.pay_date
+                FROM dividend_events d
+                JOIN instruments i ON i.instrument_id = d.instrument_id
+                WHERE d.instrument_id = ANY(%(ids)s)
+                  AND d.ex_date IS NOT NULL
+                  AND d.ex_date >= %(today)s
+                ORDER BY d.ex_date, i.symbol, d.instrument_id
+                """,
+                {"ids": instrument_ids, "today": today_ny},
+            )
+            ex_dividends = [
+                UpcomingExDividend(
+                    symbol=str(r["symbol"]),
+                    instrument_id=int(r["instrument_id"]),
+                    ex_date=r["ex_date"],
+                    pay_date=r["pay_date"],
+                )
+                for r in cur.fetchall()
+            ]
+
+    return CalendarEvents(scope=scope, as_of=today_ny, market_status=market_status, ex_dividends=ex_dividends)

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from app.api.bootstrap import router as bootstrap_router
 from app.api.broker_credentials import router as broker_credentials_router
 from app.api.budget import router as budget_router
 from app.api.business_summary_admin import router as business_summary_admin_router
+from app.api.calendar import router as calendar_router
 from app.api.capability_overrides_admin import router as capability_overrides_admin_router
 from app.api.config import KillSwitchRequest, KillSwitchResponse, post_kill_switch
 from app.api.config import router as config_router
@@ -521,6 +522,7 @@ app.include_router(auth_session_router)
 app.include_router(operators_router)
 app.include_router(audit_router)
 app.include_router(budget_router)
+app.include_router(calendar_router)
 app.include_router(broker_credentials_router)
 app.include_router(config_router)
 app.include_router(copy_trading_router)

--- a/app/services/market_calendar.py
+++ b/app/services/market_calendar.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from typing import Literal
 
 from pandas.tseries.holiday import (
     AbstractHolidayCalendar,
@@ -165,3 +166,21 @@ def us_market_specials(year: int) -> MarketYear:
         )
         _CACHE[year] = cached
     return cached
+
+
+UsMarketStatus = Literal["open", "half_day", "closed"]
+
+
+def us_market_status(d: date) -> UsMarketStatus:
+    """NYSE trading status for an ``America/New_York`` civil date (#1754).
+
+    ``closed`` on weekends and full closures; ``half_day`` on a 13:00-ET early
+    close; ``open`` otherwise. The argument is a NY-local date — the caller maps
+    "today"/the week to NY-local civil dates first (the calendar is keyed that
+    way, like ``us_market_specials``)."""
+    specials = us_market_specials(d.year)
+    if d.weekday() >= 5 or d in specials.full_closures:
+        return "closed"
+    if d in specials.half_days:
+        return "half_day"
+    return "open"

--- a/docs/specs/ui/2026-06-27-1754-exchange-calendar-bc.md
+++ b/docs/specs/ui/2026-06-27-1754-exchange-calendar-bc.md
@@ -1,0 +1,39 @@
+# #1754 — exchange-calendar Phase B (events page) + Phase C (coverage-gap shading)
+
+Parent #585. Follow-up to #609 Phase A (PR1753: in-house NYSE calendar + `session_profile` + `classifySession` intraday shading).
+
+## Premise check (dev — the handoff's "already ingested" is partly false)
+The issue says Phase B surfaces "earnings, ex-dividend, 10-K/10-Q dates (already ingested)". Verified on dev:
+- **Forward earnings dates: do not exist.** No earnings/calendar table; `financial_periods` is historical (period_end in the past). We ingest no forward earnings calendar.
+- **Future filings: 0.** `filing_events.filing_date` is always past; no due/expected filing dates.
+- **Future ex-dividends: 4 universe-wide** (`dividend_events.ex_date >= today`, the partial `idx_dividend_events_ex_date_future`). Real but sparse; **0** in the current portfolio (6 holdings, all `us_equity`; watchlist empty).
+
+So the always-correct, always-populated value is **market status** (is each held/watched market open / closed / half-day today + this week). Upcoming corporate events = the **real** future ex-dividends only. Forward earnings/filing dates are **out of scope** (no source) → a separate forward-events-ingestion ticket if ever needed.
+
+## Deps decision (the issue's "decide deps here")
+Portfolio + watchlist are **100% US today** (6 holdings, 0 foreign; universe has ~4,700 foreign tradables but none held/watched). Adding `pandas_market_calendars` (+6 transitive deps) or hand-rolling LSE/Xetra/Euronext closure sets (annual re-verify burden per exchange) for **zero** foreign holdings is the speculative dependency the project forbids ("don't add libraries casually; keep dependencies justified and minimal") and contradicts the Phase A decision. **Decision: no new deps.** US market status is precise via the in-house `market_calendar`; a foreign-listed holding shows **open (weekday) / closed (weekend)** with an "exchange holidays not modelled" caveat (Phase A's settled posture). Foreign holiday precision becomes a real-need-triggered follow-up the day a foreign holding is added.
+
+## Phase B — market-status + upcoming-events page
+Route `/calendar` (portfolio-wide, not per-instrument). Backend `GET /calendar/events?scope=portfolio|watchlist|all`:
+- **Market status** — for the distinct `session_profile`s across the scope's instruments, today's status + this week (next 7 days): `open` / `closed` / `half_day` (US via `market_calendar.us_market_specials`; `foreign_equity` → weekday open/weekend closed + `holidays_modelled=false`; `continuous` → always open). Computed server-side in America/New_York for US, UTC weekday for foreign.
+- **Upcoming ex-dividends** — `dividend_events.ex_date >= today` for the scope's instruments, ordered by ex_date, with symbol + pay_date. (Real data; honestly sparse/empty.)
+- Pydantic `CalendarEvents { scope, market_status: [{profile, label, today, week: [{date,status}]}], ex_dividends: [{symbol, ex_date, pay_date}] }`.
+- Scope resolution: `portfolio` = `positions`, `watchlist` = `watchlist` (operator-scoped), `all` = union. Reuse the session-token operator id.
+
+FE: `CalendarPage` (`/calendar`), `useAsync` over `fetchCalendarEvents`, loading/error/empty states, a market-status strip + an upcoming ex-dividends list. Honest empty states ("No upcoming ex-dividends for your holdings"). Link from the dashboard/nav.
+
+**No forward earnings/filings section** — stated on-page as "earnings & filing dates: not yet ingested" rather than a fake/empty widget.
+
+## Phase C — intraday coverage-gap shading
+FE-only on the intraday price chart. A gap = consecutive bars `bar[i].time - bar[i-1].time > interval × _GAP_FACTOR` (factor ~1.5 to tolerate a single missing bar; ignore the expected overnight/weekend gaps — only flag WITHIN a session via `classifySession` both ends in the same session-day's RTH/extended window, OR simpler: flag intrasession gaps, not cross-session). Draw a dashed vertical line (lightweight-charts overlay, mirror `SessionBands`) at each gap. Pure detector `detectCoverageGaps(bars, intervalSeconds, profile, specials)` in `chartFormatters`-style lib, table-tested; the chart renders the lines. Caption notes sparse intraday coverage.
+
+## Source rule / settled
+In-house NYSE calendar (`market_calendar`, Phase A) is the US source of truth; ⚠ NYSE half-day set needs annual re-verify (carried from #609). `dividend_events.ex_date` is the settled ex-dividend source. `session_profile` (instruments API) drives foreign vs US vs continuous.
+
+## Tests
+- Pure: `detectCoverageGaps` (intrasession gap flagged; overnight/weekend NOT flagged; exact-interval clean) table-test.
+- Pure/db: market-status builder (US holiday/half-day/open; foreign weekend; continuous) — prefer a pure status fn over `(profile, date, specials)` table-tested.
+- FE: CalendarPage render-test (loading/empty/populated); chart gap-line render-test (mirror SessionBands test pattern).
+
+## DoD
+Smoke `/calendar?scope=portfolio` on dev (6 US holdings → US market status this week + likely empty ex-div list, honest). Phase C: load an intraday chart with a known sparse window, confirm a dashed line renders at the gap. No daemon restart (API + FE only).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { OperatorsPage } from "@/pages/OperatorsPage";
 import { CopyTradingPage } from "@/pages/CopyTradingPage";
 import { InstrumentsPage } from "@/pages/InstrumentsPage";
 import { PortfolioPage } from "@/pages/PortfolioPage";
+import { CalendarPage } from "@/pages/CalendarPage";
 
 export function App() {
   return (
@@ -66,6 +67,7 @@ export function App() {
         >
           <Route index element={<DashboardPage />} />
           <Route path="portfolio" element={<PortfolioPage />} />
+          <Route path="calendar" element={<CalendarPage />} />
           {/* Legacy per-instrument routes redirect to the canonical
               `/instrument/:symbol` research page. Introduced in Slice 3
               of the per-stock research spec; Slice 5 deleted

--- a/frontend/src/api/calendar.ts
+++ b/frontend/src/api/calendar.ts
@@ -1,0 +1,7 @@
+import { apiFetch } from "@/api/client";
+import type { CalendarEvents, CalendarScope } from "@/api/types";
+
+export function fetchCalendarEvents(scope: CalendarScope = "portfolio"): Promise<CalendarEvents> {
+  const params = new URLSearchParams({ scope });
+  return apiFetch<CalendarEvents>(`/calendar/events?${params.toString()}`);
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1133,6 +1133,37 @@ export interface RedFlagTrend {
   points: RedFlagTrendPoint[];
 }
 
+// #1754 calendar-of-events
+export type CalendarScope = "portfolio" | "watchlist" | "all";
+export type MarketDayType = "open" | "half_day" | "closed" | "not_modelled";
+
+export interface MarketStatusDay {
+  date: string; // YYYY-MM-DD
+  day_type: MarketDayType;
+}
+
+export interface MarketStatusRow {
+  profile: SessionProfile;
+  label: string;
+  timezone: string;
+  holidays_modelled: boolean;
+  week: MarketStatusDay[];
+}
+
+export interface UpcomingExDividend {
+  symbol: string;
+  instrument_id: number;
+  ex_date: string; // YYYY-MM-DD
+  pay_date: string | null;
+}
+
+export interface CalendarEvents {
+  scope: CalendarScope;
+  as_of: string; // YYYY-MM-DD
+  market_status: MarketStatusRow[];
+  ex_dividends: UpcomingExDividend[];
+}
+
 // ---------------------------------------------------------------------------
 // /news/{instrument_id} (app/api/news.py)
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/instrument/CoverageGapMarkers.tsx
+++ b/frontend/src/components/instrument/CoverageGapMarkers.tsx
@@ -1,0 +1,149 @@
+/**
+ * CoverageGapMarkers — dashed vertical lines marking intrasession data gaps
+ * on an intraday lightweight-charts canvas (#1754 Phase C).
+ *
+ * eToro intraday feeds are sometimes sparse: a run of buckets is simply
+ * missing inside a trading session. On the chart's ordinal axis those bars
+ * render adjacent, hiding the hole. This overlay draws a faint dashed vertical
+ * line at each gap (`detectCoverageGaps`) so the operator can see where
+ * coverage is missing — distinct from the expected overnight/weekend gaps the
+ * ordinal axis collapses (and which the detector deliberately ignores).
+ *
+ * Only US-equity profiles have a precise enough session model; the detector
+ * returns nothing for foreign/continuous, so this renders nothing there.
+ *
+ * Implementation mirrors `SessionBands`: absolute-positioned, pointer-events
+ * none, coordinates via `timeScale().timeToCoordinate()`, recomputed on
+ * zoom/pan/resize. The interval (bucket size) is derived from the smallest
+ * adjacent bar delta — robust to the gaps themselves.
+ */
+import { useEffect, useState, type JSX, type RefObject } from "react";
+import type { IChartApi, Time } from "lightweight-charts";
+
+import type { SessionProfile } from "@/api/types";
+import { detectCoverageGaps, type MarketSpecials } from "@/lib/chartFormatters";
+
+function _minInterval(bars: ReadonlyArray<{ readonly time: number }>): number {
+  let min = Infinity;
+  for (let i = 1; i < bars.length; i++) {
+    const d = bars[i]!.time - bars[i - 1]!.time;
+    if (d > 0 && d < min) min = d;
+  }
+  return Number.isFinite(min) ? min : 0;
+}
+
+export interface CoverageGapMarkersProps {
+  readonly chartRef: RefObject<IChartApi | null>;
+  /** Full provider bar set (NOT the PM/AH-visibility-filtered subset), so a
+   *  user toggle can't fabricate a gap. */
+  readonly bars: ReadonlyArray<{ readonly time: number }>;
+  /** Daily/weekly charts have one bar per session — no intraday gaps. */
+  readonly enabled: boolean;
+  readonly profile: SessionProfile;
+  readonly specials: MarketSpecials;
+}
+
+export function CoverageGapMarkers({
+  chartRef,
+  bars,
+  enabled,
+  profile,
+  specials,
+}: CoverageGapMarkersProps): JSX.Element | null {
+  const [lefts, setLefts] = useState<number[]>([]);
+  const [bottomInset, setBottomInset] = useState(0);
+  const [rightInset, setRightInset] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLefts([]);
+      return;
+    }
+    let cancelled = false;
+    let rafReady: number | undefined;
+    let rafFirstPaint: number | undefined;
+    let attachedTs: ReturnType<IChartApi["timeScale"]> | null = null;
+    let ro: ResizeObserver | null = null;
+
+    const recompute = (): void => {
+      const chart = chartRef.current;
+      if (chart === null) return;
+      const ts = chart.timeScale();
+      try {
+        setRightInset(chart.priceScale("right").width());
+        setBottomInset(ts.height());
+      } catch {
+        return;
+      }
+      const interval = _minInterval(bars);
+      const gapIdx = detectCoverageGaps(bars, interval, profile, specials);
+      const next: number[] = [];
+      for (const i of gapIdx) {
+        const a = ts.timeToCoordinate(bars[i - 1]!.time as Time);
+        const b = ts.timeToCoordinate(bars[i]!.time as Time);
+        if (a === null || b === null) continue;
+        next.push((a + b) / 2); // midpoint of the collapsed (adjacent) pair
+      }
+      setLefts(next);
+    };
+
+    const attach = (): void => {
+      if (cancelled) return;
+      const chart = chartRef.current;
+      if (chart === null) {
+        rafReady = requestAnimationFrame(attach);
+        return;
+      }
+      const ts = chart.timeScale();
+      attachedTs = ts;
+      ts.subscribeVisibleLogicalRangeChange(recompute);
+      try {
+        const el = chart.chartElement();
+        if (el !== null) {
+          ro = new ResizeObserver(recompute);
+          ro.observe(el);
+        }
+      } catch {
+        // torn down between createChart and observe — skip.
+      }
+      recompute();
+      rafFirstPaint = requestAnimationFrame(recompute);
+    };
+
+    attach();
+    return () => {
+      cancelled = true;
+      if (rafReady !== undefined) cancelAnimationFrame(rafReady);
+      if (rafFirstPaint !== undefined) cancelAnimationFrame(rafFirstPaint);
+      if (attachedTs !== null) {
+        try {
+          attachedTs.unsubscribeVisibleLogicalRangeChange(recompute);
+        } catch {
+          // already torn down.
+        }
+      }
+      if (ro !== null) ro.disconnect();
+    };
+  }, [chartRef, bars, enabled, profile, specials]);
+
+  if (!enabled || lefts.length === 0) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="coverage-gap-markers"
+      className="pointer-events-none absolute z-[5] overflow-hidden"
+      style={{ left: 0, top: 0, right: rightInset, bottom: bottomInset }}
+    >
+      {lefts.map((x, i) => (
+        <div
+          key={`gap-${i}-${x}`}
+          data-testid="coverage-gap-line"
+          className="absolute bottom-0 top-0 border-l border-dashed border-slate-400/60"
+          style={{ left: `${x}px` }}
+          title="Missing intraday data (coverage gap)"
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -36,6 +36,7 @@ import {
 
 import type { ChartRange } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { CoverageGapMarkers } from "@/components/instrument/CoverageGapMarkers";
 import { SessionBands } from "@/components/instrument/SessionBands";
 import { EmptyState } from "@/components/states/EmptyState";
 import {
@@ -906,6 +907,13 @@ export function ChartCanvas({
         chartRef={chartRef}
         bars={bandBars}
         enabled={intraday && (showPm || showAh)}
+        profile={sessionProfile}
+        specials={specials}
+      />
+      <CoverageGapMarkers
+        chartRef={chartRef}
+        bars={cleanAll}
+        enabled={intraday}
         profile={sessionProfile}
         specials={specials}
       />

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import { NavLink } from "react-router-dom";
 const NAV_ITEMS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/portfolio", label: "Portfolio" },
+  { to: "/calendar", label: "Calendar" },
   { to: "/instruments", label: "Instruments" },
   { to: "/rankings", label: "Rankings" },
   { to: "/recommendations", label: "Recommendations" },

--- a/frontend/src/lib/chartFormatters.test.ts
+++ b/frontend/src/lib/chartFormatters.test.ts
@@ -167,9 +167,12 @@ describe("detectCoverageGaps (#1754 Phase C)", () => {
     expect(detectCoverageGaps([bar(t0), bar(nextDay)], 60, "us_equity")).toEqual([]);
   });
 
-  it("does NOT flag a gap touching a closed window", () => {
-    const closed = utc(2026, 4, 21, 2, 0); // 22:00 ET prior — closed
-    expect(detectCoverageGaps([bar(closed), bar(t0)], 60, "us_equity")).toEqual([]);
+  it("does NOT flag when an endpoint is in a same-day closed window", () => {
+    // Both bars are Apr 21 ET (same NY date, so the cross-day guard does NOT
+    // fire) — the suppression must come from the closed-window guard: 03:00 ET
+    // (07:00 UTC) is before the 04:00 pre-market open → classifySession "closed".
+    const closedSameDay = utc(2026, 4, 21, 7, 0); // 03:00 ET Apr 21 — closed
+    expect(detectCoverageGaps([bar(closedSameDay), bar(t0)], 60, "us_equity")).toEqual([]);
   });
 
   it("is disabled for non-US profiles (no precise session model)", () => {

--- a/frontend/src/lib/chartFormatters.test.ts
+++ b/frontend/src/lib/chartFormatters.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { classifySession, classifyUsSession, type MarketSpecials } from "./chartFormatters";
+import {
+  classifySession,
+  classifyUsSession,
+  detectCoverageGaps,
+  type MarketSpecials,
+} from "./chartFormatters";
 
 /**
  * Lock down US-equity session classification across the four windows
@@ -143,5 +148,38 @@ describe("classifySession (#609 profile-aware)", () => {
     const specials: MarketSpecials = { fullClosures: new Set(), halfDays: new Set(["2026-04-21"]) };
     expect(classifySession("us_equity_rth", utc(2026, 4, 21, 16, 59), specials)).toBe("rth"); // 12:59 ET
     expect(classifySession("us_equity_rth", utc(2026, 4, 21, 17, 0), specials)).toBe("closed"); // 13:00 ET
+  });
+});
+
+describe("detectCoverageGaps (#1754 Phase C)", () => {
+  // April 21 2026 is a Tue (EDT); 14:00 UTC = 10:00 ET (RTH). interval = 60s.
+  const t0 = utc(2026, 4, 21, 14, 0);
+  const bar = (sec: number) => ({ time: sec });
+
+  it("flags an intrasession hole > 2 buckets, tolerating one missing bar", () => {
+    // +60 (clean), +120 (one missing — tolerated), +300 (≥2 missing — gap).
+    const bars = [bar(t0), bar(t0 + 60), bar(t0 + 60 + 120), bar(t0 + 60 + 120 + 300)];
+    expect(detectCoverageGaps(bars, 60, "us_equity")).toEqual([3]);
+  });
+
+  it("does NOT flag the expected overnight (cross-day) gap", () => {
+    const nextDay = utc(2026, 4, 22, 14, 0); // next RTH day — huge delta, cross-day
+    expect(detectCoverageGaps([bar(t0), bar(nextDay)], 60, "us_equity")).toEqual([]);
+  });
+
+  it("does NOT flag a gap touching a closed window", () => {
+    const closed = utc(2026, 4, 21, 2, 0); // 22:00 ET prior — closed
+    expect(detectCoverageGaps([bar(closed), bar(t0)], 60, "us_equity")).toEqual([]);
+  });
+
+  it("is disabled for non-US profiles (no precise session model)", () => {
+    const bars = [bar(t0), bar(t0 + 600)];
+    expect(detectCoverageGaps(bars, 60, "foreign_equity")).toEqual([]);
+    expect(detectCoverageGaps(bars, 60, "continuous")).toEqual([]);
+  });
+
+  it("handles degenerate inputs", () => {
+    expect(detectCoverageGaps([bar(t0)], 60, "us_equity")).toEqual([]);
+    expect(detectCoverageGaps([bar(t0), bar(t0 + 600)], 0, "us_equity")).toEqual([]);
   });
 });

--- a/frontend/src/lib/chartFormatters.ts
+++ b/frontend/src/lib/chartFormatters.ts
@@ -150,6 +150,47 @@ export function classifySession(
   return "closed";
 }
 
+/**
+ * Indices of bars preceded by an intrasession coverage gap (#1754 Phase C).
+ *
+ * A gap = a missing-bars hole INSIDE a trading session, distinct from the
+ * expected overnight / weekend / holiday gaps the ordinal chart axis already
+ * collapses. Only the US-equity profiles have a session model precise enough to
+ * tell the two apart — `foreign_equity` (no exchange-local session/lunch model)
+ * and `continuous` are skipped (would false-flag e.g. Tokyo lunch breaks).
+ *
+ * A pair `(bar[i-1], bar[i])` is a gap iff:
+ *   - they are more than TWO buckets apart (one missing bar is tolerated;
+ *     `delta > 2×interval` ⇒ ≥2 missing buckets), AND
+ *   - they share the same NY-local trading date (a cross-day gap is the
+ *     expected overnight close, not missing coverage), AND
+ *   - neither end is `"closed"` (both inside a tradable window).
+ *
+ * Returns the indices `i` (the bar AFTER each gap). Runs on the full provider
+ * bar set — never the PM/AH-visibility-filtered subset, so a user toggle can't
+ * fabricate a gap.
+ */
+export function detectCoverageGaps(
+  bars: ReadonlyArray<{ readonly time: number }>,
+  intervalSeconds: number,
+  profile: SessionProfile,
+  specials: MarketSpecials = _EMPTY_SPECIALS,
+): number[] {
+  if (profile !== "us_equity" && profile !== "us_equity_rth") return [];
+  if (intervalSeconds <= 0 || bars.length < 2) return [];
+  const gaps: number[] = [];
+  for (let i = 1; i < bars.length; i++) {
+    const prev = bars[i - 1]!;
+    const cur = bars[i]!;
+    if (cur.time - prev.time <= intervalSeconds * 2) continue;
+    if (nyDateString(prev.time) !== nyDateString(cur.time)) continue;
+    if (classifySession(profile, prev.time, specials) === "closed") continue;
+    if (classifySession(profile, cur.time, specials) === "closed") continue;
+    gaps.push(i);
+  }
+  return gaps;
+}
+
 /** Back-compat alias — US-equity classification with no special days.
  *  Prefer `classifySession(profile, …)` at new call sites. */
 export function classifyUsSession(epochSeconds: number): SessionKind {

--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+import { CalendarPage } from "./CalendarPage";
+import type { CalendarEvents } from "@/api/types";
+
+const sample: CalendarEvents = {
+  scope: "portfolio",
+  as_of: "2026-06-29",
+  market_status: [
+    {
+      profile: "us_equity",
+      label: "US equity",
+      timezone: "America/New_York",
+      holidays_modelled: true,
+      week: [
+        { date: "2026-06-29", day_type: "open" },
+        { date: "2026-07-03", day_type: "closed" },
+      ],
+    },
+  ],
+  ex_dividends: [{ symbol: "FOO", instrument_id: 1, ex_date: "2026-07-01", pay_date: "2026-07-15" }],
+};
+
+vi.mock("@/api/calendar", () => ({
+  fetchCalendarEvents: vi.fn(() => Promise.resolve(sample)),
+}));
+// useMarketSpecials hits the network for US years; stub it.
+vi.mock("@/lib/useMarketSpecials", () => ({
+  useMarketSpecials: () => ({ fullClosures: new Set<string>(), halfDays: new Set<string>() }),
+}));
+
+describe("CalendarPage", () => {
+  it("renders market status + upcoming ex-dividends", async () => {
+    render(
+      <MemoryRouter>
+        <CalendarPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("US equity")).toBeInTheDocument());
+    // day-type labels render (open + closed in the week strip).
+    expect(screen.getAllByText("Open").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Closed").length).toBeGreaterThan(0);
+    // upcoming ex-dividend row.
+    expect(screen.getByText("FOO")).toBeInTheDocument();
+    expect(screen.getByText(/ex 2026-07-01/)).toBeInTheDocument();
+    // the honest "not ingested" note about earnings/filings.
+    expect(screen.getByText(/does not ingest forward earnings/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,0 +1,176 @@
+/**
+ * /calendar — calendar-of-events (#1754 Phase B).
+ *
+ * Portfolio/watchlist-wide market status for the week ahead + the real
+ * upcoming corporate events we ingest (ex-dividends). US market status is
+ * NYSE-precise; foreign equities degrade to weekday/weekend (holidays not
+ * modelled); continuous (crypto/FX/…) is not modelled. The live "now" session
+ * is computed client-side via `classifySession` (no server duplication).
+ *
+ * Forward earnings + filing dates are intentionally absent — we ingest no
+ * forward earnings calendar or filing-due dates (stated on-page, not faked).
+ */
+import { useCallback, useState } from "react";
+
+import { fetchCalendarEvents } from "@/api/calendar";
+import type { CalendarEvents, CalendarScope, MarketDayType, SessionProfile } from "@/api/types";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { classifySession, type SessionKind } from "@/lib/chartFormatters";
+import { useAsync } from "@/lib/useAsync";
+import { useMarketSpecials } from "@/lib/useMarketSpecials";
+
+const SCOPES: ReadonlyArray<{ key: CalendarScope; label: string }> = [
+  { key: "portfolio", label: "Portfolio" },
+  { key: "watchlist", label: "Watchlist" },
+  { key: "all", label: "All" },
+];
+
+const DAY_TYPE_STYLE: Record<MarketDayType, string> = {
+  open: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+  half_day: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  closed: "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
+  not_modelled: "bg-slate-50 text-slate-400 dark:bg-slate-800/50 dark:text-slate-500",
+};
+
+const DAY_TYPE_LABEL: Record<MarketDayType, string> = {
+  open: "Open",
+  half_day: "Half day",
+  closed: "Closed",
+  not_modelled: "—",
+};
+
+const SESSION_LABEL: Record<SessionKind, string> = {
+  rth: "Open · regular hours",
+  pre: "Pre-market",
+  ah: "After-hours",
+  closed: "Closed",
+};
+
+function weekdayShort(isoDate: string): string {
+  // Parse as UTC noon to avoid TZ date-shift on the label.
+  return new Date(`${isoDate}T12:00:00Z`).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function nowSession(profile: SessionProfile, specials: ReturnType<typeof useMarketSpecials>): SessionKind {
+  return classifySession(profile, Math.floor(Date.now() / 1000), specials);
+}
+
+export function CalendarPage(): JSX.Element {
+  const [scope, setScope] = useState<CalendarScope>("portfolio");
+  const events = useAsync<CalendarEvents>(
+    useCallback(() => fetchCalendarEvents(scope), [scope]),
+    [scope],
+  );
+
+  // One specials fetch (current year) reused for every profile's live-session
+  // badge — useMarketSpecials only fetches for US profiles; foreign/continuous
+  // ignore specials in classifySession anyway.
+  const nowBar = [{ time: Math.floor(Date.now() / 1000) }];
+  const specials = useMarketSpecials("us_equity", nowBar);
+
+  return (
+    <div className="mx-auto max-w-screen-lg space-y-4 p-4">
+      <header className="border-b border-slate-200 pb-3 dark:border-slate-800">
+        <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Calendar</h1>
+        <p className="mt-1 text-xs text-slate-500">
+          Market status for the week ahead + upcoming ex-dividends across your{" "}
+          {scope === "all" ? "portfolio & watchlist" : scope}. US markets are NYSE-precise;
+          foreign exchanges show weekday/weekend only (holidays not modelled).
+        </p>
+        <div className="mt-2 flex gap-1">
+          {SCOPES.map((s) => (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => setScope(s.key)}
+              className={`rounded px-2 py-1 text-xs ${
+                scope === s.key
+                  ? "bg-sky-600 text-white"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300"
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {events.loading ? (
+        <SectionSkeleton rows={5} />
+      ) : events.error !== null ? (
+        <SectionError onRetry={events.refetch} />
+      ) : events.data === null || events.data.market_status.length === 0 ? (
+        <EmptyState
+          title="Nothing to show"
+          description={
+            scope === "watchlist"
+              ? "Your watchlist is empty — add instruments to see their market calendar."
+              : "No holdings in scope yet."
+          }
+        />
+      ) : (
+        <>
+          <Section title="Market status — this week">
+            <div className="space-y-3">
+              {events.data.market_status.map((row) => (
+                <div key={row.profile}>
+                  <div className="mb-1 flex items-baseline gap-2">
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                      {row.label}
+                    </span>
+                    <span className="text-[11px] text-slate-500">{SESSION_LABEL[nowSession(row.profile, specials)]} now</span>
+                    {!row.holidays_modelled && (
+                      <span className="text-[10px] text-slate-400">· holidays not modelled</span>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {row.week.map((d) => (
+                      <div
+                        key={d.date}
+                        className={`rounded px-2 py-1 text-[11px] tabular-nums ${DAY_TYPE_STYLE[d.day_type]}`}
+                        title={`${d.date}: ${DAY_TYPE_LABEL[d.day_type]}`}
+                      >
+                        <span className="block font-medium">{weekdayShort(d.date)}</span>
+                        <span className="block">{DAY_TYPE_LABEL[d.day_type]}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Section>
+
+          <Section title="Upcoming ex-dividends">
+            {events.data.ex_dividends.length === 0 ? (
+              <p className="px-2 py-4 text-xs text-slate-500">
+                No upcoming ex-dividends for instruments in scope.
+              </p>
+            ) : (
+              <ul className="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+                {events.data.ex_dividends.map((d) => (
+                  <li key={`${d.instrument_id}-${d.ex_date}`} className="flex justify-between py-1.5">
+                    <span className="font-medium text-slate-700 dark:text-slate-200">{d.symbol}</span>
+                    <span className="tabular-nums text-slate-500">
+                      ex {d.ex_date}
+                      {d.pay_date !== null ? ` · pay ${d.pay_date}` : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
+          <p className="px-1 text-[10px] text-slate-400">
+            Earnings &amp; filing dates are not yet shown — eBull does not ingest forward earnings
+            calendars or filing-due dates.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -10,7 +10,7 @@
  * Forward earnings + filing dates are intentionally absent — we ingest no
  * forward earnings calendar or filing-due dates (stated on-page, not faked).
  */
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { fetchCalendarEvents } from "@/api/calendar";
 import type { CalendarEvents, CalendarScope, MarketDayType, SessionProfile } from "@/api/types";
@@ -56,8 +56,12 @@ function weekdayShort(isoDate: string): string {
   });
 }
 
-function nowSession(profile: SessionProfile, specials: ReturnType<typeof useMarketSpecials>): SessionKind {
-  return classifySession(profile, Math.floor(Date.now() / 1000), specials);
+function nowSession(
+  profile: SessionProfile,
+  epochSeconds: number,
+  specials: ReturnType<typeof useMarketSpecials>,
+): SessionKind {
+  return classifySession(profile, epochSeconds, specials);
 }
 
 export function CalendarPage(): JSX.Element {
@@ -67,10 +71,14 @@ export function CalendarPage(): JSX.Element {
     [scope],
   );
 
-  // One specials fetch (current year) reused for every profile's live-session
-  // badge — useMarketSpecials only fetches for US profiles; foreign/continuous
-  // ignore specials in classifySession anyway.
-  const nowBar = [{ time: Math.floor(Date.now() / 1000) }];
+  // "Now" frozen at mount — the live-session badge is a load-time snapshot
+  // (refresh re-reads it). Memoised so the array reference is render-stable:
+  // passing a fresh literal to a hook each render is a refetch hazard even
+  // though useMarketSpecials currently keys on a derived years-string, not the
+  // array identity. One specials fetch (current year) reused for every
+  // profile's badge — the hook only fetches for US profiles; foreign/continuous
+  // ignore specials in classifySession.
+  const nowBar = useMemo(() => [{ time: Math.floor(Date.now() / 1000) }], []);
   const specials = useMarketSpecials("us_equity", nowBar);
 
   return (
@@ -123,7 +131,9 @@ export function CalendarPage(): JSX.Element {
                     <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
                       {row.label}
                     </span>
-                    <span className="text-[11px] text-slate-500">{SESSION_LABEL[nowSession(row.profile, specials)]} now</span>
+                    <span className="text-[11px] text-slate-500">
+                      {SESSION_LABEL[nowSession(row.profile, nowBar[0]!.time, specials)]} now
+                    </span>
                     {!row.holidays_modelled && (
                       <span className="text-[10px] text-slate-400">· holidays not modelled</span>
                     )}

--- a/tests/test_market_calendar_status.py
+++ b/tests/test_market_calendar_status.py
@@ -1,0 +1,43 @@
+"""Pure tests for #1754 market-status classification."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from app.api.calendar import _day_type
+from app.services.market_calendar import us_market_status
+
+
+class TestUsMarketStatus:
+    def test_full_closures_are_closed(self) -> None:
+        assert us_market_status(date(2026, 1, 1)) == "closed"  # New Year's Day
+        assert us_market_status(date(2026, 12, 25)) == "closed"  # Christmas (Fri)
+        assert us_market_status(date(2026, 7, 3)) == "closed"  # Jul 4 Sat → observed Fri closure
+
+    def test_half_days(self) -> None:
+        assert us_market_status(date(2026, 11, 27)) == "half_day"  # Fri after Thanksgiving
+        assert us_market_status(date(2026, 12, 24)) == "half_day"  # Christmas Eve (Thu)
+
+    def test_weekends_closed(self) -> None:
+        assert us_market_status(date(2026, 6, 27)) == "closed"  # Saturday
+        assert us_market_status(date(2026, 6, 28)) == "closed"  # Sunday
+
+    def test_normal_weekday_open(self) -> None:
+        assert us_market_status(date(2026, 6, 23)) == "open"  # plain Tuesday
+
+
+class TestDayType:
+    def test_us_profiles_delegate_to_nyse(self) -> None:
+        assert _day_type("us_equity", date(2026, 1, 1)) == "closed"
+        assert _day_type("us_equity_rth", date(2026, 6, 23)) == "open"
+        assert _day_type("us_equity", date(2026, 12, 24)) == "half_day"
+
+    def test_foreign_weekday_open_weekend_closed(self) -> None:
+        # Foreign holidays NOT modelled — even Jan 1 reads "open" on a weekday.
+        assert _day_type("foreign_equity", date(2026, 1, 1)) == "open"  # Thu
+        assert _day_type("foreign_equity", date(2026, 6, 27)) == "closed"  # Sat
+
+    def test_continuous_always_open(self) -> None:
+        # Matches the shipped #609 classifySession (continuous = always trading).
+        assert _day_type("continuous", date(2026, 6, 23)) == "open"
+        assert _day_type("continuous", date(2026, 6, 27)) == "open"  # weekend too


### PR DESCRIPTION
Closes #1754. Parent #585. Follow-up to #609 Phase A (PR1753).

## Premise check (dev) + deps decision
The issue's "earnings, ex-dividend, 10-K/10-Q dates (already ingested)" is **partly false**: no forward earnings table, **0** future filings, only **4** future ex-dividends universe-wide (0 in the portfolio). And portfolio+watchlist are **100% US** (6 holdings, 0 foreign). So:
- **Deps:** adding `pandas_market_calendars` (+6 transitive deps) or hand-rolling LSE/Xetra/Euronext closure sets for **zero** foreign holdings is the casual dependency the project forbids + contradicts Phase A. **Decision: no new deps.** US is NYSE-precise; foreign degrades to weekday/weekend + "holidays not modelled"; foreign-holiday precision is a real-need-triggered follow-up.
- **Forward earnings/filing dates: out of scope** (no source) — stated on-page, not faked.

## Phase B — calendar-of-events page (`/calendar`, sidebar link)
- `GET /calendar/events?scope=portfolio|watchlist|all` → per-`session_profile` this-week market status + upcoming ex-dividends.
- `market_calendar.us_market_status(date)` (reuses the settled NYSE calendar): `open`/`half_day`/`closed`. `_day_type`: US precise; `foreign_equity` weekday/weekend (`holidays_modelled=false`); `continuous` → `open` (consistent with the shipped `classifySession` + the live now-badge — Codex ckpt-2).
- `watchlist` + `all` operator-scoped via `sole_operator_id`; `all`'s watchlist leg filtered by operator so no cross-operator union (Codex ckpt-2); `positions` global.
- `CalendarPage`: week day-type grid + live "now" session per profile (one `useMarketSpecials` reused + pure `classifySession`, **no server duplication**) + upcoming ex-div list + honest "earnings/filings not ingested" note.

## Phase C — intraday coverage-gap shading
- `detectCoverageGaps(bars, interval, profile, specials)`: flags intrasession holes (`>2×interval` so one missing bar is tolerated, same NY-date, both ends non-`closed`); **US-equity profiles only** (foreign lunch breaks unmodelled — Codex ckpt-1); runs on the **full** provider bars (toggles can't fabricate a gap).
- `CoverageGapMarkers` overlay (mirrors `SessionBands`): a faint dashed vertical line per gap; bucket interval derived from the min bar delta. Wired into `PriceChart`.

## Tests / gates
Pure `us_market_status`/`_day_type` (7), `detectCoverageGaps` (5), `CalendarPage` render (1). ruff/pyright clean; backend fast tier **4578**; smoke **129** (app boots with the new router); FE typecheck / test:unit **1142** / dark:check **226** — all green.

## Verification
`GET /calendar/events?scope=portfolio` on dev (6 US holdings) → `us_equity` week with Sat/Sun + Fri Jul 3 closed (Jul 4 Sat → observed closure ✓), ex-dividends honestly empty; `scope=all` → 200. Live intraday-chart gap render not browser-verified (cookie-auth blocks the isolated browser — repo's standard path); covered by the pure detector test + typecheck-validated overlay mirroring the shipped `SessionBands`.

No daemon restart (API + FE only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)