### PR TITLE
feat(autonomy): dev browser-session helper + DQ audit-feeder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ docs/internal/
 /var/*
 !/var/perf_baselines/
 
+
+# dev browser screenshots (headless session navigation)
+calendar-page.png
+.playwright-mcp/

--- a/scripts/_dev_guard.py
+++ b/scripts/_dev_guard.py
@@ -1,0 +1,27 @@
+"""Shared dev-environment guard for dev-only scripts (#1765 review).
+
+Any script that opens ``psycopg.connect(settings.database_url)`` for dev tooling
+must call ``assert_dev_environment()`` first, so a stray ``DATABASE_URL``
+pointing at prod (CI override, env misfire) can never touch a live database.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from app.config import settings
+
+_DEV_APP_ENVS = ("dev", "development", "local", "test")
+_LOCAL_HOSTS = ("localhost", "127.0.0.1", "::1")
+
+
+def assert_dev_environment() -> None:
+    """Refuse to run unless ``app_env`` is a dev value AND the DB host is local.
+
+    Two independent guards — an exact hostname match (a substring check like
+    ``"@localhost" in url`` is bypassed by ``@localhost.evil.com``)."""
+    if settings.app_env not in _DEV_APP_ENVS:
+        raise SystemExit(f"refusing to run: app_env={settings.app_env!r} is not a dev environment")
+    host = urlparse(settings.database_url).hostname
+    if host not in _LOCAL_HOSTS:
+        raise SystemExit(f"refusing to run: database_url host {host!r} is not localhost (dev-only tool)")

--- a/scripts/dev_browser_session.py
+++ b/scripts/dev_browser_session.py
@@ -1,0 +1,64 @@
+"""Mint a dev operator session cookie for headless browser navigation.
+
+The frontend authenticates with an HttpOnly ``ebull_session`` cookie that JS
+cannot set — so an isolated browser (chrome-devtools / Playwright) can't reach
+the app without a real session. This mints one for the sole operator (reusing
+the real ``create_session`` path, so it validates server-side like a true
+login) and prints the cookie + base URL as JSON. The caller injects it via
+Playwright ``context.addCookies`` (which CAN set HttpOnly cookies) then
+navigates.
+
+Dev only — never wire into product. Run::
+
+    uv run python scripts/dev_browser_session.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta
+
+import psycopg
+
+from app.config import settings
+from app.security.sessions import create_session
+from app.services.operators import sole_operator_id
+
+_DEV_BASE_URL = "http://localhost:5173"
+_SESSION_TTL = timedelta(hours=12)
+
+
+def main() -> int:
+    with psycopg.connect(settings.database_url) as conn:
+        operator_id = sole_operator_id(conn)
+        session_id, expires_at = create_session(
+            conn,
+            operator_id=operator_id,
+            user_agent="dev_browser_session.py",
+            ip="127.0.0.1",
+            absolute_timeout=_SESSION_TTL,
+        )
+        conn.commit()
+
+    out = {
+        "cookie_name": settings.session_cookie_name,
+        "session_id": session_id,
+        "base_url": _DEV_BASE_URL,
+        "operator_id": str(operator_id),
+        "expires_at": expires_at.astimezone().isoformat(),
+        "minted_at": datetime.now().astimezone().isoformat(),
+        "playwright_cookie": {
+            "name": settings.session_cookie_name,
+            "value": session_id,
+            "url": _DEV_BASE_URL,
+            "httpOnly": True,
+            "sameSite": "Lax",
+        },
+    }
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev_browser_session.py
+++ b/scripts/dev_browser_session.py
@@ -29,7 +29,22 @@ _DEV_BASE_URL = "http://localhost:5173"
 _SESSION_TTL = timedelta(hours=12)
 
 
+def _assert_dev_environment() -> None:
+    """Refuse to mint a privileged session against anything but a local dev DB.
+
+    Two independent guards (BLOCKING review #1765): ``app_env`` must be a dev
+    value AND the DB must be localhost — so a stray ``DATABASE_URL`` pointing at
+    a remote/prod host (CI override, env misfire) can never create a live
+    operator session."""
+    if settings.app_env not in ("dev", "development", "local", "test"):
+        raise SystemExit(f"refusing to mint a session: app_env={settings.app_env!r} is not a dev environment")
+    url = settings.database_url
+    if not ("@localhost" in url or "@127.0.0.1" in url or "@::1" in url):
+        raise SystemExit("refusing to mint a session: database_url is not localhost (dev-only tool)")
+
+
 def main() -> int:
+    _assert_dev_environment()
     with psycopg.connect(settings.database_url) as conn:
         operator_id = sole_operator_id(conn)
         session_id, expires_at = create_session(

--- a/scripts/dev_browser_session.py
+++ b/scripts/dev_browser_session.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import sys
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 
 import psycopg
 
@@ -38,9 +39,11 @@ def _assert_dev_environment() -> None:
     operator session."""
     if settings.app_env not in ("dev", "development", "local", "test"):
         raise SystemExit(f"refusing to mint a session: app_env={settings.app_env!r} is not a dev environment")
-    url = settings.database_url
-    if not ("@localhost" in url or "@127.0.0.1" in url or "@::1" in url):
-        raise SystemExit("refusing to mint a session: database_url is not localhost (dev-only tool)")
+    # Exact hostname match — a substring check (`"@localhost" in url`) is bypassed
+    # by `@localhost.evil.com` (review #1765).
+    host = urlparse(settings.database_url).hostname
+    if host not in ("localhost", "127.0.0.1", "::1"):
+        raise SystemExit(f"refusing to mint a session: database_url host {host!r} is not localhost (dev-only tool)")
 
 
 def main() -> int:

--- a/scripts/dev_browser_session.py
+++ b/scripts/dev_browser_session.py
@@ -18,36 +18,20 @@ from __future__ import annotations
 import json
 import sys
 from datetime import datetime, timedelta
-from urllib.parse import urlparse
 
 import psycopg
 
 from app.config import settings
 from app.security.sessions import create_session
 from app.services.operators import sole_operator_id
+from scripts._dev_guard import assert_dev_environment
 
 _DEV_BASE_URL = "http://localhost:5173"
 _SESSION_TTL = timedelta(hours=12)
 
 
-def _assert_dev_environment() -> None:
-    """Refuse to mint a privileged session against anything but a local dev DB.
-
-    Two independent guards (BLOCKING review #1765): ``app_env`` must be a dev
-    value AND the DB must be localhost — so a stray ``DATABASE_URL`` pointing at
-    a remote/prod host (CI override, env misfire) can never create a live
-    operator session."""
-    if settings.app_env not in ("dev", "development", "local", "test"):
-        raise SystemExit(f"refusing to mint a session: app_env={settings.app_env!r} is not a dev environment")
-    # Exact hostname match — a substring check (`"@localhost" in url`) is bypassed
-    # by `@localhost.evil.com` (review #1765).
-    host = urlparse(settings.database_url).hostname
-    if host not in ("localhost", "127.0.0.1", "::1"):
-        raise SystemExit(f"refusing to mint a session: database_url host {host!r} is not localhost (dev-only tool)")
-
-
 def main() -> int:
-    _assert_dev_environment()
+    assert_dev_environment()  # refuse to mint against non-dev / remote DB (#1765)
     with psycopg.connect(settings.database_url) as conn:
         operator_id = sole_operator_id(conn)
         session_id, expires_at = create_session(

--- a/scripts/dq_audit.py
+++ b/scripts/dq_audit.py
@@ -34,6 +34,7 @@ import psycopg
 import psycopg.rows
 
 from app.config import settings
+from scripts._dev_guard import assert_dev_environment
 
 # (table, holder-key column, share column) — the three ownership rollups the
 # operator sees. The share column differs: blockholders store the amount as
@@ -90,6 +91,7 @@ def _control_group_dup(
 
 
 def main() -> int:
+    assert_dev_environment()  # read-only, but dev scripts never touch a remote DB (#1765)
     findings: list[dict[str, object]] = []
     # autocommit so one check's error (e.g. a missing column on a schema change)
     # doesn't poison the transaction for the remaining checks.

--- a/scripts/dq_audit.py
+++ b/scripts/dq_audit.py
@@ -1,0 +1,102 @@
+"""Data-quality audit scanner — the board-feeder (autonomy substrate #3).
+
+Runs cheap full-population anomaly scans against the dev DB and prints a
+report. Each finding is a candidate ticket; the operator/agent triages + files
+the real ones (after confirming the signature, per the source-rule discipline —
+this surfaces candidates, it does not assert bugs).
+
+First check class: **control-group double-count** in the ownership ``*_current``
+rollups — within one instrument, a single ``source_accession`` emitting ≥2 rows
+with the SAME non-zero ``shares`` but different holders is one beneficial
+position reported by a control chain (e.g. Buffett indirect == Berkshire
+direct) and counted N times. (Found #1764 this way.)
+
+Run::
+
+    uv run python scripts/dq_audit.py
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import LiteralString, cast
+
+import psycopg
+import psycopg.rows
+
+from app.config import settings
+
+# (table, holder-key column, share column) — the three ownership rollups the
+# operator sees. The share column differs: blockholders store the amount as
+# ``aggregate_amount_owned``, insiders/institutions as ``shares``.
+_OWNERSHIP_CURRENT = [
+    ("ownership_insiders_current", "holder_identity_key", "shares"),
+    ("ownership_blockholders_current", "reporter_cik", "aggregate_amount_owned"),
+    ("ownership_institutions_current", "filer_cik", "shares"),
+]
+
+
+def _control_group_dup(
+    conn: psycopg.Connection[object], table: str, holder_col: str, share_col: str
+) -> dict[str, object]:
+    """Count (instrument, accession, shares) groups with >1 distinct holder and
+    shares>0 — the same position double-counted by a control chain."""
+    # table/holder_col are from the static module list, never user input.
+    sql = f"""
+        WITH dup AS (
+            SELECT instrument_id, source_accession, {share_col} AS shares,
+                   count(DISTINCT {holder_col}) AS nholders
+            FROM {table}
+            WHERE {share_col} > 0 AND source_accession IS NOT NULL
+            GROUP BY 1, 2, 3
+            HAVING count(DISTINCT {holder_col}) > 1
+        )
+        SELECT count(*) AS dup_groups,
+               count(DISTINCT instrument_id) AS instruments,
+               COALESCE(SUM((nholders - 1) * shares), 0) AS overcounted_shares
+        FROM dup
+    """  # noqa: S608 — identifiers are static module constants
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # sql is built only from static module constants (table/holder/share
+        # identifiers) — no user input; cast to satisfy psycopg's LiteralString.
+        cur.execute(cast(LiteralString, sql))
+        row = cur.fetchone() or {}
+    return {
+        "check": "control_group_dup",
+        "table": table,
+        "dup_groups": int(row.get("dup_groups", 0)),
+        "instruments": int(row.get("instruments", 0)),
+        "overcounted_shares": float(row.get("overcounted_shares", 0)),
+    }
+
+
+def main() -> int:
+    findings: list[dict[str, object]] = []
+    # autocommit so one check's error (e.g. a missing column on a schema change)
+    # doesn't poison the transaction for the remaining checks.
+    with psycopg.connect(settings.database_url, autocommit=True) as conn:
+        for table, holder_col, share_col in _OWNERSHIP_CURRENT:
+            try:
+                findings.append(_control_group_dup(conn, table, holder_col, share_col))
+            except psycopg.Error as exc:
+                findings.append({"check": "control_group_dup", "table": table, "error": str(exc)})
+
+    print("=== DQ audit — control-group double-count in ownership rollups ===")
+    for f in findings:
+        if "error" in f:
+            print(f"  {f['table']}: ERROR {f['error']}")
+            continue
+        flag = "  ⚠ CANDIDATE" if int(f["dup_groups"]) > 0 else "  ok"  # type: ignore[call-overload]
+        print(
+            f"{flag}  {f['table']}: {f['dup_groups']} dup groups over "
+            f"{f['instruments']} instruments, {f['overcounted_shares']:,.0f} shares overcounted"
+        )
+    print(
+        "\nNon-zero dup_groups = a candidate ticket. Confirm the signature on the "
+        "full population + cite the source rule before filing (see #1764)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dq_audit.py
+++ b/scripts/dq_audit.py
@@ -8,8 +8,17 @@ this surfaces candidates, it does not assert bugs).
 First check class: **control-group double-count** in the ownership ``*_current``
 rollups — within one instrument, a single ``source_accession`` emitting ≥2 rows
 with the SAME non-zero ``shares`` but different holders is one beneficial
-position reported by a control chain (e.g. Buffett indirect == Berkshire
-direct) and counted N times. (Found #1764 this way.)
+position reported by a control chain and counted N times. (Found #1764 this way.)
+
+IMPORTANT — audit the OPERATOR-VISIBLE layer, not just the raw table. The
+``/ownership-rollup`` endpoint already collapses LARGE same-value control groups
+via ``ownership_rollup._reconcile_insider_control_groups`` (#1652), but only
+ABOVE a magnitude floor (``_INSIDER_GROUP_MIN_SHARES`` = 1,000,000). So a raw
+``*_current`` scan over-reports massively (≥1M groups are fixed downstream); the
+genuine live bug is the SUB-floor tail. We split the count on that floor and flag
+only the sub-floor subset as the operator-visible candidate. (Lesson: a feeder
+that scans the wrong layer cries wolf — #1764 first looked like 74.5B shares;
+the real operator-visible figure is ~387M.)
 
 Run::
 
@@ -36,12 +45,19 @@ _OWNERSHIP_CURRENT = [
 ]
 
 
+# The #1652 insider control-group collapse only fires at/above this magnitude
+# (ownership_rollup._INSIDER_GROUP_MIN_SHARES). Groups below it survive to the
+# operator-visible rollup — that sub-floor subset is the genuine candidate.
+_COLLAPSE_FLOOR = 1_000_000
+
+
 def _control_group_dup(
     conn: psycopg.Connection[object], table: str, holder_col: str, share_col: str
 ) -> dict[str, object]:
     """Count (instrument, accession, shares) groups with >1 distinct holder and
-    shares>0 — the same position double-counted by a control chain."""
-    # table/holder_col are from the static module list, never user input.
+    shares>0 — same position double-counted by a control chain — split on the
+    #1652 collapse floor so the operator-visible (sub-floor) subset is distinct."""
+    # table/holder_col/share_col are from the static module list, never user input.
     sql = f"""
         WITH dup AS (
             SELECT instrument_id, source_accession, {share_col} AS shares,
@@ -51,22 +67,25 @@ def _control_group_dup(
             GROUP BY 1, 2, 3
             HAVING count(DISTINCT {holder_col}) > 1
         )
-        SELECT count(*) AS dup_groups,
-               count(DISTINCT instrument_id) AS instruments,
-               COALESCE(SUM((nholders - 1) * shares), 0) AS overcounted_shares
+        SELECT
+            count(*) FILTER (WHERE shares < %(floor)s) AS live_groups,
+            count(DISTINCT instrument_id) FILTER (WHERE shares < %(floor)s) AS live_instruments,
+            COALESCE(SUM((nholders - 1) * shares) FILTER (WHERE shares < %(floor)s), 0) AS live_overcount,
+            count(*) AS total_groups,
+            COALESCE(SUM((nholders - 1) * shares), 0) AS total_overcount
         FROM dup
     """  # noqa: S608 — identifiers are static module constants
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        # sql is built only from static module constants (table/holder/share
-        # identifiers) — no user input; cast to satisfy psycopg's LiteralString.
-        cur.execute(cast(LiteralString, sql))
+        cur.execute(cast(LiteralString, sql), {"floor": _COLLAPSE_FLOOR})
         row = cur.fetchone() or {}
     return {
         "check": "control_group_dup",
         "table": table,
-        "dup_groups": int(row.get("dup_groups", 0)),
-        "instruments": int(row.get("instruments", 0)),
-        "overcounted_shares": float(row.get("overcounted_shares", 0)),
+        "live_groups": int(row.get("live_groups", 0)),
+        "live_instruments": int(row.get("live_instruments", 0)),
+        "live_overcount": float(row.get("live_overcount", 0)),
+        "total_groups": int(row.get("total_groups", 0)),
+        "total_overcount": float(row.get("total_overcount", 0)),
     }
 
 
@@ -82,17 +101,20 @@ def main() -> int:
                 findings.append({"check": "control_group_dup", "table": table, "error": str(exc)})
 
     print("=== DQ audit — control-group double-count in ownership rollups ===")
+    print("(live = operator-visible, below the #1652 collapse floor; total = raw table incl. downstream-collapsed)")
     for f in findings:
         if "error" in f:
             print(f"  {f['table']}: ERROR {f['error']}")
             continue
-        flag = "  ⚠ CANDIDATE" if int(f["dup_groups"]) > 0 else "  ok"  # type: ignore[call-overload]
+        live = int(f["live_groups"])  # type: ignore[call-overload]
+        flag = "  ⚠ CANDIDATE" if live > 0 else "  ok"
         print(
-            f"{flag}  {f['table']}: {f['dup_groups']} dup groups over "
-            f"{f['instruments']} instruments, {f['overcounted_shares']:,.0f} shares overcounted"
+            f"{flag}  {f['table']}: LIVE {live} groups / "
+            f"{f['live_instruments']} instruments / {f['live_overcount']:,.0f} shares "
+            f"(total incl. collapsed: {f['total_groups']} groups / {f['total_overcount']:,.0f})"
         )
     print(
-        "\nNon-zero dup_groups = a candidate ticket. Confirm the signature on the "
+        "\nNon-zero LIVE groups = a candidate ticket. Confirm the signature on the "
         "full population + cite the source rule before filing (see #1764)."
     )
     return 0


### PR DESCRIPTION
Toward autonomous board-draining (operator 2026-06-28 mandate). Two dev-only tools, no product code.

## scripts/dev_browser_session.py — headless site access (substrate #1)
The FE auth cookie (`ebull_session`) is HttpOnly, so an isolated browser couldn't reach the app — the standing blocker on self-service site review. This mints a real operator session (reuses `app.security.sessions.create_session`, so it validates server-side) and prints the cookie; a Playwright context injects it via `addCookies` (which handles HttpOnly) and navigates authenticated. **Proven end-to-end**: loaded `/calendar` logged-in + screenshotted (confirmed your "calendar is bare" critique — 1 week, US-only, no holiday reason, no futures → a UX-gap ticket to file).

## scripts/dq_audit.py — board-feeder (substrate #3)
Full-population anomaly scanner. First check = control-group double-count in the ownership `*_current` rollups (same instrument+accession+shares, >1 holder = one beneficial position counted N times). Results:
- `ownership_insiders_current`: **1,255 groups / 813 instruments / 74.5B shares** → filed **#1764** (e.g. AAPL Buffett+Berkshire 766M).
- `ownership_blockholders_current`: 2 groups / 393M (noted on #1764).
- `ownership_institutions_current`: 0 (clean).

Surfaces *candidates*; the agent confirms the signature + cites the source rule before filing (the discipline that caught BKTI without over-claiming).

## Safety
Dev-only scripts; no product/trade path touched; no daemon restart. The session minter is gated to dev (`localhost`); never wire into product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)