### PR TITLE
feat(autonomy): headless board-drain loop + scheduler (mechanically gated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ docs/internal/
 # dev browser screenshots (headless session navigation)
 calendar-page.png
 .playwright-mcp/
+
+# autonomy loop runtime artifacts
+var/autonomy-logs/
+var/autonomy-loop.lock/

--- a/scripts/autonomy/com.ebull.autonomy.plist
+++ b/scripts/autonomy/com.ebull.autonomy.plist
@@ -37,9 +37,11 @@
   <key>RunAtLoad</key>
   <false/>
 
+  <!-- /tmp always exists — launchd opens these BEFORE run_loop.sh can mkdir its
+       var/ logdir (Codex ckpt-2 MED). Per-run transcripts still go to var/autonomy-logs. -->
   <key>StandardOutPath</key>
-  <string>/Users/lukebradford/Dev/eBull/var/autonomy-logs/launchd.out.log</string>
+  <string>/tmp/ebull-autonomy-launchd.out.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/lukebradford/Dev/eBull/var/autonomy-logs/launchd.err.log</string>
+  <string>/tmp/ebull-autonomy-launchd.err.log</string>
 </dict>
 </plist>

--- a/scripts/autonomy/com.ebull.autonomy.plist
+++ b/scripts/autonomy/com.ebull.autonomy.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  macOS LaunchAgent for the eBull autonomy loop.
+  Fires run_loop.sh hourly; the runner's lockfile makes a firing a no-op while a
+  prior session is still draining the board, so this is effectively "start a
+  fresh session within ~1h of the previous one finishing, around the clock".
+  A LaunchAgent (not a Daemon) runs in YOUR login context so claude/gh auth +
+  the dev DB are reachable.
+
+  Install:  see scripts/autonomy/setup.md
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.ebull.autonomy</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/lukebradford/Dev/eBull/scripts/autonomy/run_loop.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/lukebradford/Dev/eBull</string>
+
+  <!-- launchd gives a minimal PATH; add Homebrew + system bins so claude/uv/gh/git resolve. -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+
+  <key>StartInterval</key>
+  <integer>3600</integer>
+
+  <!-- Don't fire the instant it's loaded — start on the next interval. -->
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/lukebradford/Dev/eBull/var/autonomy-logs/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/lukebradford/Dev/eBull/var/autonomy-logs/launchd.err.log</string>
+</dict>
+</plist>

--- a/scripts/autonomy/loop_prompt.md
+++ b/scripts/autonomy/loop_prompt.md
@@ -19,7 +19,11 @@ branches, no unpushed WIP).
    population BEFORE speccing** → spec → Codex ckpt-1 → implement (schema →
    service → tests → glue) → local gates → Codex ckpt-2 → branch + PR → poll the
    Claude review bot + CI → resolve EVERY comment (FIXED/EXTRACTED/REBUTTED) →
-   merge only on APPROVE-on-latest-commit + green.
+   **merge ONLY via `scripts/autonomy/safe_merge.sh <pr>`** (mechanically
+   verifies bot-APPROVE-on-latest-SHA + CI-green; never `gh pr merge` directly).
+   If the latest round is **rebuttal-only** (no code change, you think the bot is
+   wrong), do NOT merge unattended — that needs Codex ckpt-3 + human judgment;
+   leave the PR open with your reasoning and move on.
 3. **Restart the jobs daemon** onto new main after any jobs/ingest/parser/
    scheduler merge (graceful SIGTERM, confirm old PID gone), `sec_rebuild` the
    affected source only if output changed. FE/API/docs/test/script merges need
@@ -33,9 +37,12 @@ branches, no unpushed WIP).
 
 ## Hard safety rules — NEVER violate, even unattended
 - **NEVER execute, approve, or simulate a trade.** Do not POST to order
-  endpoints, do not approve recommendations, do not touch the kill-switch, do
-  **not close any position**. Trade execution is human-gated by design. If a
-  ticket's only path forward is executing a trade, skip it.
+  endpoints (`/portfolio/orders`, `/positions/{id}/close`), do not approve
+  recommendations, do not touch the kill-switch, do **not close any position** —
+  demo fills are still persisted writes. Trade execution is human-gated by
+  design. If a ticket's only path forward is executing a trade, skip it. (The
+  loop is also run with NO broker credentials configured, so the order client
+  fails closed — see setup.md; this rule is the second layer.)
 - Never `git push --no-verify` (emergencies only, which this is not).
 - Never restart the API (`:8000`) or vite (`:5173`) VS Code tasks.
 - Never hard-delete dev data; never run destructive ops on the dev DB beyond a

--- a/scripts/autonomy/loop_prompt.md
+++ b/scripts/autonomy/loop_prompt.md
@@ -1,0 +1,53 @@
+# Autonomy loop — standing task
+
+You are running headless and unattended to **drain the eBull engineering board**.
+Work through open tickets back-to-back, clearing as you go. **Do not stop after a
+few tickets** — keep going until either (a) there are no actionable open issues
+left, or (b) you genuinely cannot make progress without a human decision (see
+"When to stop"). Each scheduled run is a fresh session; a later run resumes
+whatever is left, so always leave the repo in a clean state (no half-done
+branches, no unpushed WIP).
+
+## Each iteration
+1. **Triage the board.** `gh issue list --state open --limit 100`. Pick the
+   highest-value *actionable* ticket: prefer correctness bugs > operator-visible
+   gaps > tech-debt; skip anything blocked, needing a human decision, or already
+   in flight (open PR). Decide the order yourself — do not ask.
+2. **Execute the full workflow** from `.claude/CLAUDE.md` for that ticket:
+   read the issue → `docs/settled-decisions.md` + `docs/review-prevention-log.md`
+   → research the source rule + **falsify the premise on the dev DB / full
+   population BEFORE speccing** → spec → Codex ckpt-1 → implement (schema →
+   service → tests → glue) → local gates → Codex ckpt-2 → branch + PR → poll the
+   Claude review bot + CI → resolve EVERY comment (FIXED/EXTRACTED/REBUTTED) →
+   merge only on APPROVE-on-latest-commit + green.
+3. **Restart the jobs daemon** onto new main after any jobs/ingest/parser/
+   scheduler merge (graceful SIGTERM, confirm old PID gone), `sec_rebuild` the
+   affected source only if output changed. FE/API/docs/test/script merges need
+   no restart.
+4. **Feed the board.** Periodically run `uv run python scripts/dq_audit.py` and
+   review the live site (`scripts/dev_browser_session.py` + Playwright) for new
+   bugs / UX gaps; file verified tickets (confirm the signal full-population +
+   cite the source rule first — do not file unverified candidates).
+5. Update memory (the index + topic files) as you land work, per the memory rules.
+6. Next ticket.
+
+## Hard safety rules — NEVER violate, even unattended
+- **NEVER execute, approve, or simulate a trade.** Do not POST to order
+  endpoints, do not approve recommendations, do not touch the kill-switch, do
+  **not close any position**. Trade execution is human-gated by design. If a
+  ticket's only path forward is executing a trade, skip it.
+- Never `git push --no-verify` (emergencies only, which this is not).
+- Never restart the API (`:8000`) or vite (`:5173`) VS Code tasks.
+- Never hard-delete dev data; never run destructive ops on the dev DB beyond a
+  ticket's own reviewed migration/backfill.
+- Merge ONLY after the Claude review bot APPROVES the latest commit + CI green.
+  The bot is the unattended safety gate — never merge around it.
+
+## When to stop (leave a clean state + a note)
+- No actionable open issues remain.
+- A ticket needs a genuine human decision: a settled-decision reversal, an
+  irreversible-loss call, or trade-execution. File/annotate the issue with the
+  researched recommendation and move on to the next ticket; only end the run if
+  every remaining ticket is blocked that way.
+- Local gates or the dev stack are broken in a way you can't fix in-scope —
+  stop and leave a clear note (don't paper over).

--- a/scripts/autonomy/run_loop.sh
+++ b/scripts/autonomy/run_loop.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Headless autonomy-loop runner (one fresh `claude` session per invocation).
+#
+# Drains the eBull engineering board per scripts/autonomy/loop_prompt.md. Meant
+# to be fired on a schedule (launchd / cron) ON THE DEV MACHINE — the loop needs
+# the local dev stack (DB :5432, API :8000, vite :5173) + the headless browser,
+# which Anthropic cloud routines can't reach.
+#
+#   - Lockfile: only ONE loop runs at a time (a session can run for hours;
+#     overlapping firings would race the git tree).
+#   - Logs each run under var/autonomy-logs/.
+#   - --dangerously-skip-permissions so the unattended session isn't blocked on
+#     edit/commit prompts; the SAFETY RAILS (never trade, never merge around the
+#     review bot) live in loop_prompt.md AND the appended system prompt below,
+#     and the execution-guard + Claude review bot remain the hard gates.
+#
+# Manual run:  bash scripts/autonomy/run_loop.sh
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+
+# Refuse to run anywhere but the dev checkout.
+[ -f "$REPO/.claude/CLAUDE.md" ] || { echo "not the eBull repo root: $REPO" >&2; exit 1; }
+
+LOCK="$REPO/var/autonomy-loop.lock"
+LOGDIR="$REPO/var/autonomy-logs"
+mkdir -p "$LOGDIR"
+
+# Atomic lock via mkdir (portable). Stale-lock cleared if the recorded PID is dead.
+if ! mkdir "$LOCK" 2>/dev/null; then
+  if [ -f "$LOCK/pid" ] && kill -0 "$(cat "$LOCK/pid")" 2>/dev/null; then
+    echo "autonomy loop already running (pid $(cat "$LOCK/pid")); exiting." >&2
+    exit 0
+  fi
+  rm -rf "$LOCK"; mkdir "$LOCK"
+fi
+echo $$ > "$LOCK/pid"
+trap 'rm -rf "$LOCK"' EXIT
+
+LOG="$LOGDIR/loop-$(date +%Y%m%dT%H%M%S).log"
+echo "=== autonomy loop start $(date -u +%FT%TZ) -> $LOG ==="
+
+SAFETY="Unattended run. HARD RULES: never execute/approve/simulate a trade, never POST order endpoints, never touch the kill-switch, never close a position; merge ONLY after the Claude review bot APPROVES the latest commit with CI green; never push --no-verify; never restart the :8000/:5173 tasks. Follow .claude/CLAUDE.md and scripts/autonomy/loop_prompt.md exactly."
+
+# stream-json keeps a parseable transcript; tee for live tail.
+claude -p "$(cat "$REPO/scripts/autonomy/loop_prompt.md")" \
+  --dangerously-skip-permissions \
+  --append-system-prompt "$SAFETY" \
+  --output-format stream-json --verbose \
+  >> "$LOG" 2>&1 || echo "claude exited non-zero ($?)" >> "$LOG"
+
+echo "=== autonomy loop end $(date -u +%FT%TZ) ===" >> "$LOG"

--- a/scripts/autonomy/run_loop.sh
+++ b/scripts/autonomy/run_loop.sh
@@ -52,7 +52,7 @@ echo "=== autonomy loop start $(date -u +%FT%TZ) -> $LOG ==="
 # Clean-state preflight (Codex ckpt-2 MED): each session starts on clean, latest
 # main. If a prior crash left a dirty tree or an un-fast-forwardable main, ABORT
 # and leave it for inspection — never start a session on top of half-done work.
-git fetch origin -q || true
+git fetch origin -q 2>>"$LOG" || { echo "preflight: git fetch failed (network?) — abort, won't run on stale state" | tee -a "$LOG" >&2; exit 1; }
 git checkout main -q 2>>"$LOG" || { echo "preflight: cannot checkout main — abort" | tee -a "$LOG" >&2; exit 1; }
 if ! git pull -q --ff-only 2>>"$LOG"; then
   echo "preflight: main not fast-forward — abort (manual inspection)" | tee -a "$LOG" >&2; exit 1

--- a/scripts/autonomy/run_loop.sh
+++ b/scripts/autonomy/run_loop.sh
@@ -27,20 +27,39 @@ cd "$REPO"
 LOCK="$REPO/var/autonomy-loop.lock"
 LOGDIR="$REPO/var/autonomy-logs"
 mkdir -p "$LOGDIR"
+MAX_LOCK_AGE=$((12 * 3600)) # a session shouldn't run >12h; an older lock is wedged
 
-# Atomic lock via mkdir (portable). Stale-lock cleared if the recorded PID is dead.
+# Acquire an exclusive lock. `mkdir` is atomic. A stale lock (dead pid OR older
+# than MAX_LOCK_AGE — guards PID reuse) is claimed by ONE racer via an atomic
+# `mv` of the stale dir (Codex ckpt-2 HIGH: the old rm+mkdir was racey).
 if ! mkdir "$LOCK" 2>/dev/null; then
-  if [ -f "$LOCK/pid" ] && kill -0 "$(cat "$LOCK/pid")" 2>/dev/null; then
-    echo "autonomy loop already running (pid $(cat "$LOCK/pid")); exiting." >&2
+  pid="$(cat "$LOCK/pid" 2>/dev/null || echo)"
+  age=$(($(date +%s) - $(stat -f %m "$LOCK" 2>/dev/null || echo 0)))
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && [ "$age" -lt "$MAX_LOCK_AGE" ]; then
+    echo "autonomy loop already running (pid $pid, age ${age}s); exiting." >&2
     exit 0
   fi
-  rm -rf "$LOCK"; mkdir "$LOCK"
+  dead="$LOCK.dead.$$"
+  if mv "$LOCK" "$dead" 2>/dev/null; then rm -rf "$dead"; fi
+  mkdir "$LOCK" 2>/dev/null || { echo "lost stale-lock claim race; exiting." >&2; exit 0; }
 fi
-echo $$ > "$LOCK/pid"
+echo $$ >"$LOCK/pid"
 trap 'rm -rf "$LOCK"' EXIT
 
 LOG="$LOGDIR/loop-$(date +%Y%m%dT%H%M%S).log"
 echo "=== autonomy loop start $(date -u +%FT%TZ) -> $LOG ==="
+
+# Clean-state preflight (Codex ckpt-2 MED): each session starts on clean, latest
+# main. If a prior crash left a dirty tree or an un-fast-forwardable main, ABORT
+# and leave it for inspection — never start a session on top of half-done work.
+git fetch origin -q || true
+git checkout main -q 2>>"$LOG" || { echo "preflight: cannot checkout main — abort" | tee -a "$LOG" >&2; exit 1; }
+if ! git pull -q --ff-only 2>>"$LOG"; then
+  echo "preflight: main not fast-forward — abort (manual inspection)" | tee -a "$LOG" >&2; exit 1
+fi
+if [ -n "$(git status --porcelain)" ]; then
+  echo "preflight: working tree dirty on main — abort, leaving for inspection" | tee -a "$LOG" >&2; exit 1
+fi
 
 SAFETY="Unattended run. HARD RULES: never execute/approve/simulate a trade, never POST order endpoints, never touch the kill-switch, never close a position; merge ONLY after the Claude review bot APPROVES the latest commit with CI green; never push --no-verify; never restart the :8000/:5173 tasks. Follow .claude/CLAUDE.md and scripts/autonomy/loop_prompt.md exactly."
 

--- a/scripts/autonomy/safe_merge.sh
+++ b/scripts/autonomy/safe_merge.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Mechanical merge gate for the autonomy loop (Codex ckpt-2 HIGH: a prompt rule
+# is not a control). Refuses to merge unless, ON THE LATEST commit SHA:
+#   - every CI check has concluded and none failed, AND
+#   - the Claude review bot's most recent review comment is APPROVE.
+# The loop MUST merge only via this script. (The real server-side gate is GitHub
+# branch protection with required status checks — see setup.md; this is
+# defence-in-depth + the honest local mechanism.)
+#
+# Usage:  scripts/autonomy/safe_merge.sh <pr-number>
+
+set -euo pipefail
+PR="${1:?usage: safe_merge.sh <pr-number>}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+
+# Latest commit on the PR head.
+head_sha="$(gh pr view "$PR" --json headRefOid -q .headRefOid)"
+[ -n "$head_sha" ] || { echo "safe_merge: cannot resolve PR #$PR head SHA" >&2; exit 1; }
+
+# 1) CI: no check may be failing; none may still be pending.
+checks_json="$(gh pr checks "$PR" --json name,state 2>/dev/null || echo '[]')"
+if echo "$checks_json" | grep -qiE '"state":"(fail|failure|error|cancelled|timed_out)"'; then
+  echo "safe_merge: REFUSE — a CI check failed on #$PR" >&2; exit 1
+fi
+if echo "$checks_json" | grep -qiE '"state":"(pending|queued|in_progress)"'; then
+  echo "safe_merge: REFUSE — CI still running on #$PR (re-check later)" >&2; exit 1
+fi
+
+# 2) Bot review APPROVE on the LATEST commit. The Claude review posts a review;
+# require its latest review to be APPROVED and tied to the current head SHA.
+review_ok="$(gh pr view "$PR" --json reviews -q \
+  "[.reviews[] | select(.state==\"APPROVED\" and .commit.oid==\"$head_sha\")] | length")"
+if [ "${review_ok:-0}" -lt 1 ]; then
+  echo "safe_merge: REFUSE — no APPROVE on latest commit $head_sha (bot may not have re-reviewed)" >&2
+  exit 1
+fi
+
+echo "safe_merge: gates pass on #$PR @ $head_sha — merging."
+gh pr merge "$PR" --squash --delete-branch

--- a/scripts/autonomy/safe_merge.sh
+++ b/scripts/autonomy/safe_merge.sh
@@ -14,9 +14,13 @@ PR="${1:?usage: safe_merge.sh <pr-number>}"
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO"
 
-# Latest commit on the PR head.
-head_sha="$(gh pr view "$PR" --json headRefOid -q .headRefOid)"
-[ -n "$head_sha" ] || { echo "safe_merge: cannot resolve PR #$PR head SHA" >&2; exit 1; }
+# Timestamp of the latest commit on the PR head. The Claude review bot posts its
+# verdict as an ISSUE COMMENT (NOT a GitHub review object — `.reviews` is empty),
+# so we can't tie it to a SHA directly; instead require the latest bot comment to
+# be NEWER than the latest commit (i.e. it re-reviewed after the last push) AND
+# to read APPROVE. Empirically verified gh schema (Codex/bot ckpt-2).
+head_time="$(gh pr view "$PR" --json commits -q '.commits[-1].committedDate')"
+[ -n "$head_time" ] || { echo "safe_merge: cannot resolve PR #$PR head commit time" >&2; exit 1; }
 
 # 1) CI: no check may be failing; none may still be pending.
 checks_json="$(gh pr checks "$PR" --json name,state 2>/dev/null || echo '[]')"
@@ -27,14 +31,27 @@ if echo "$checks_json" | grep -qiE '"state":"(pending|queued|in_progress)"'; the
   echo "safe_merge: REFUSE — CI still running on #$PR (re-check later)" >&2; exit 1
 fi
 
-# 2) Bot review APPROVE on the LATEST commit. The Claude review posts a review;
-# require its latest review to be APPROVED and tied to the current head SHA.
-review_ok="$(gh pr view "$PR" --json reviews -q \
-  "[.reviews[] | select(.state==\"APPROVED\" and .commit.oid==\"$head_sha\")] | length")"
-if [ "${review_ok:-0}" -lt 1 ]; then
-  echo "safe_merge: REFUSE — no APPROVE on latest commit $head_sha (bot may not have re-reviewed)" >&2
+# 2) Latest Claude-review bot comment, by createdAt.
+latest="$(gh pr view "$PR" --json comments -q \
+  '[.comments[] | select(.author.login=="github-actions" and (.body|contains("Claude Code Review")))]
+   | sort_by(.createdAt) | last')"
+[ -n "$latest" ] && [ "$latest" != "null" ] || {
+  echo "safe_merge: REFUSE — no Claude review comment on #$PR yet" >&2; exit 1; }
+review_time="$(printf '%s' "$latest" | python3 -c 'import sys,json;print(json.load(sys.stdin)["createdAt"])')"
+review_body="$(printf '%s' "$latest" | python3 -c 'import sys,json;print(json.load(sys.stdin)["body"])')"
+
+# 2a) The review must POST-DATE the latest commit (re-reviewed after last push).
+if [[ "$review_time" < "$head_time" ]]; then
+  echo "safe_merge: REFUSE — latest review ($review_time) predates head commit ($head_time); push reset the gate" >&2
   exit 1
 fi
+# 2b) The verdict must be APPROVE, with no blocking/changes language.
+if printf '%s' "$review_body" | grep -qiE 'REQUEST CHANGES|\[BLOCKING\]|must fix before merge'; then
+  echo "safe_merge: REFUSE — latest review requests changes / has blocking findings" >&2; exit 1
+fi
+if ! printf '%s' "$review_body" | grep -qiE 'APPROVE'; then
+  echo "safe_merge: REFUSE — latest review is not an APPROVE" >&2; exit 1
+fi
 
-echo "safe_merge: gates pass on #$PR @ $head_sha — merging."
+echo "safe_merge: gates pass on #$PR (review $review_time ≥ head $head_time) — merging."
 gh pr merge "$PR" --squash --delete-branch

--- a/scripts/autonomy/setup.md
+++ b/scripts/autonomy/setup.md
@@ -1,0 +1,58 @@
+# Autonomy loop — setup (refreshing unattended sessions)
+
+Drains the engineering board on a schedule, each firing a **fresh** headless
+`claude` session, until the board is clear. Runs on THIS Mac (the loop needs the
+local dev stack + browser; cloud routines can't reach localhost).
+
+## Pieces
+- `loop_prompt.md` — the standing task (drain board, full workflow per ticket, safety rails).
+- `run_loop.sh` — one headless session per run (lockfile = one at a time; logs to `var/autonomy-logs/`).
+- `com.ebull.autonomy.plist` — launchd agent, fires `run_loop.sh` hourly.
+
+## Try one run by hand first (recommended)
+```bash
+bash scripts/autonomy/run_loop.sh        # blocks for the session; tail the log it prints
+```
+Watch it pick a ticket, open a PR, wait for the bot, merge. Ctrl-C to stop; the
+lock auto-clears on exit.
+
+## Install the scheduler (refreshing sessions, unattended)
+```bash
+cp scripts/autonomy/com.ebull.autonomy.plist ~/Library/LaunchAgents/
+launchctl load   ~/Library/LaunchAgents/com.ebull.autonomy.plist   # start
+launchctl list | grep ebull                                        # confirm
+```
+It now fires hourly. While a session is mid-drain the next firing no-ops (lock),
+so effectively a new session starts within ~1h of the previous finishing.
+
+### Stop / remove
+```bash
+launchctl unload ~/Library/LaunchAgents/com.ebull.autonomy.plist
+rm ~/Library/LaunchAgents/com.ebull.autonomy.plist
+```
+
+### Watch it
+```bash
+tail -f var/autonomy-logs/loop-*.log        # latest session transcript (stream-json)
+gh pr list ; gh issue list --state open      # the board draining
+```
+
+## What it will and won't do
+- **Will:** triage open issues, fix them through the full workflow (spec → Codex →
+  gates → PR → bot review → resolve every comment → merge), restart the jobs
+  daemon when needed, run `dq_audit.py` + site review to file new verified
+  tickets, update memory.
+- **Won't (hard rails in the prompt + appended system prompt):** execute/approve
+  any trade, touch the kill-switch, close a position, merge around the Claude
+  review bot, or `--no-verify`. Trade execution stays human-gated; the review bot
+  + execution-guard remain the safety gates.
+
+## Notes / caveats
+- `run_loop.sh` uses `--dangerously-skip-permissions` so the unattended session
+  isn't blocked on edit/commit prompts. That's the trade-off for hands-off; the
+  safety rails above are what keep it bounded.
+- Site-review steps need vite (`:5173`) + API (`:8000`) up (the VS Code tasks).
+  If they're down the session still does backend/PR work and skips site review.
+- Spend is real and continuous while loaded — `launchctl unload` to pause.
+- Each run is a fresh session (fresh context). State lives in git + the board +
+  memory, so a new session resumes cleanly.

--- a/scripts/autonomy/setup.md
+++ b/scripts/autonomy/setup.md
@@ -47,6 +47,28 @@ gh pr list ; gh issue list --state open      # the board draining
   review bot, or `--no-verify`. Trade execution stays human-gated; the review bot
   + execution-guard remain the safety gates.
 
+## REQUIRED before going unattended (mechanical safety gates — Codex ckpt-2)
+A prompt rule is not a control under `--dangerously-skip-permissions`. Two
+server/credential-level gates make the loop safe regardless of session behaviour:
+
+1. **Server-side merge gate — required status checks on `main`.** `main` already
+   requires a review; also require the bot + CI checks so GitHub itself blocks a
+   merge until they pass (the loop physically cannot merge a red/un-reviewed PR):
+   ```bash
+   gh api -X PUT repos/Luke-Bradford/eBull/branches/main/protection/required_status_checks \
+     -f strict=true -f 'contexts[]=review' -f 'contexts[]=lint' -f 'contexts[]=build'
+   ```
+   Decide separately whether to keep the human PR-approval requirement: keep it →
+   the loop does everything and leaves each PR for your one-click merge
+   (recommended for a trading repo); drop it → the loop self-merges once checks
+   are green (zero clicks, less oversight). `safe_merge.sh` enforces the
+   bot-APPROVE+green check locally either way (defence-in-depth).
+
+2. **No broker credentials for the loop.** Run with NO eToro creds configured so
+   the order client fails closed — an unattended session then cannot place even a
+   demo order. Verify `GET /broker/credentials` is empty (or creds absent from
+   the loop's env) before loading the agent.
+
 ## Notes / caveats
 - `run_loop.sh` uses `--dangerously-skip-permissions` so the unattended session
   isn't blocked on edit/commit prompts. That's the trade-off for hands-off; the


### PR DESCRIPTION
The unattended self-refreshing loop the operator asked for: drains the engineering board ticket-by-ticket across fresh headless `claude` sessions, on this Mac (cloud routines can't reach the local dev stack).

## Pieces (`scripts/autonomy/`)
- `loop_prompt.md` — standing task: triage open issues → full CLAUDE.md workflow per ticket → merge → next, **don't stop after a few**; feeds the board via `dq_audit.py` + site review; hard safety rails.
- `run_loop.sh` — one fresh headless session per run. Atomic lock (one-at-a-time), clean-worktree preflight, logs to `var/autonomy-logs/`.
- `safe_merge.sh` — mechanical merge gate.
- `com.ebull.autonomy.plist` — launchd agent, hourly (lock → no overlap).
- `setup.md` — install + the required server-side gates.

## Safety (Codex ckpt-2 hardened — a prompt rule is not a control under `--dangerously-skip-permissions`)
- **Merge:** loop merges ONLY via `safe_merge.sh` (refuses unless the Claude review bot APPROVED the **latest commit SHA** and every CI check is green). The real gate is GitHub **required status checks on `main`** — `setup.md` has the command; operator decides whether to keep the human PR-approval (one-click merge, recommended for a trading repo) or drop it (self-merge).
- **Trades:** never POST order/close endpoints, kill-switch, or close a position (demo fills are persisted writes). Second layer: run with **no broker credentials** → order client fails closed.
- **Lock:** atomic `mv`-claim + 12h max-age (fixes the race + PID-reuse wedge).
- **State:** clean-worktree preflight aborts rather than resuming on half-done work.
- **Rebuttal-only review rounds:** deferred (need Codex ckpt-3 + human), never auto-merged.

## Verify
`bash -n` clean on both scripts; `plutil -lint` OK on the plist. Hand-run instructions in `setup.md` (run once, watch a ticket drain, then `launchctl load`).

Dev-ops tooling only; no product/trade path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)