### PR TITLE
feat(autonomy): limit-aware supervisor (walk-away-for-days draining)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ calendar-page.png
 # autonomy loop runtime artifacts
 var/autonomy-logs/
 var/autonomy-loop.lock/
+var/autonomy-supervisor.lock/

--- a/scripts/autonomy/com.ebull.autonomy.plist
+++ b/scripts/autonomy/com.ebull.autonomy.plist
@@ -14,14 +14,15 @@
   <key>Label</key>
   <string>com.ebull.autonomy</string>
 
+  <!-- __REPO__ substituted with the repo root by the setup.md install step (sed). -->
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
-    <string>/Users/lukebradford/Dev/eBull/scripts/autonomy/run_loop.sh</string>
+    <string>__REPO__/scripts/autonomy/run_loop.sh</string>
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/lukebradford/Dev/eBull</string>
+  <string>__REPO__</string>
 
   <!-- launchd gives a minimal PATH; add Homebrew + system bins so claude/uv/gh/git resolve. -->
   <key>EnvironmentVariables</key>
@@ -37,11 +38,10 @@
   <key>RunAtLoad</key>
   <false/>
 
-  <!-- /tmp always exists — launchd opens these BEFORE run_loop.sh can mkdir its
-       var/ logdir (Codex ckpt-2 MED). Per-run transcripts still go to var/autonomy-logs. -->
+  <!-- Persist across reboots; setup.md mkdirs var/autonomy-logs before load. -->
   <key>StandardOutPath</key>
-  <string>/tmp/ebull-autonomy-launchd.out.log</string>
+  <string>__REPO__/var/autonomy-logs/launchd.out.log</string>
   <key>StandardErrorPath</key>
-  <string>/tmp/ebull-autonomy-launchd.err.log</string>
+  <string>__REPO__/var/autonomy-logs/launchd.err.log</string>
 </dict>
 </plist>

--- a/scripts/autonomy/com.ebull.autonomy.supervisor.plist
+++ b/scripts/autonomy/com.ebull.autonomy.supervisor.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd LaunchAgent for the autonomy SUPERVISOR (walk-away-for-days mode).
+  KeepAlive + RunAtLoad: starts on load and is restarted if it ever exits
+  (crash, reboot, OOM). The supervisor itself loops sessions forever with
+  usage-limit backoff, so launchd's only job is to keep ONE supervisor alive.
+  Its internal lock prevents duplicates if launchd double-starts.
+
+  Use this OR com.ebull.autonomy.plist (the simpler hourly run_loop) — not both.
+  Install: see scripts/autonomy/setup.md
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.ebull.autonomy.supervisor</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/lukebradford/Dev/eBull/scripts/autonomy/supervisor.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/lukebradford/Dev/eBull</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <!-- Resurrect the supervisor if it exits for any reason; throttle restarts. -->
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/ebull-autonomy-supervisor.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/ebull-autonomy-supervisor.err.log</string>
+</dict>
+</plist>

--- a/scripts/autonomy/com.ebull.autonomy.supervisor.plist
+++ b/scripts/autonomy/com.ebull.autonomy.supervisor.plist
@@ -14,14 +14,16 @@
   <key>Label</key>
   <string>com.ebull.autonomy.supervisor</string>
 
+  <!-- __REPO__ is substituted with the repo root by the setup.md install step
+       (sed), so nothing personal/hardcoded is committed. -->
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
-    <string>/Users/lukebradford/Dev/eBull/scripts/autonomy/supervisor.sh</string>
+    <string>__REPO__/scripts/autonomy/supervisor.sh</string>
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/lukebradford/Dev/eBull</string>
+  <string>__REPO__</string>
 
   <key>EnvironmentVariables</key>
   <dict>
@@ -37,9 +39,11 @@
   <key>ThrottleInterval</key>
   <integer>60</integer>
 
+  <!-- Persist across reboots (setup.md mkdirs var/autonomy-logs before load, so
+       launchd can open these). __REPO__ substituted at install. -->
   <key>StandardOutPath</key>
-  <string>/tmp/ebull-autonomy-supervisor.out.log</string>
+  <string>__REPO__/var/autonomy-logs/launchd.supervisor.out.log</string>
   <key>StandardErrorPath</key>
-  <string>/tmp/ebull-autonomy-supervisor.err.log</string>
+  <string>__REPO__/var/autonomy-logs/launchd.supervisor.err.log</string>
 </dict>
 </plist>

--- a/scripts/autonomy/loop_prompt.md
+++ b/scripts/autonomy/loop_prompt.md
@@ -28,10 +28,23 @@ branches, no unpushed WIP).
    scheduler merge (graceful SIGTERM, confirm old PID gone), `sec_rebuild` the
    affected source only if output changed. FE/API/docs/test/script merges need
    no restart.
-4. **Feed the board.** Periodically run `uv run python scripts/dq_audit.py` and
-   review the live site (`scripts/dev_browser_session.py` + Playwright) for new
-   bugs / UX gaps; file verified tickets (confirm the signal full-population +
-   cite the source rule first — do not file unverified candidates).
+4. **Feed the board (data QA + front-end QA).** Periodically:
+   - **Data QA:** `uv run python scripts/dq_audit.py` → confirm any candidate on
+     the full population + cite the source rule before filing.
+   - **Front-end QA:** mint a dev session (`uv run python
+     scripts/dev_browser_session.py`), inject the cookie into a Playwright/chrome
+     context (`addCookies`, it's HttpOnly), and actually USE the app as an
+     operator would. Walk the key routes — `/` dashboard, `/portfolio`,
+     `/calendar`, `/instrument/<symbol>` + its drills (chart, fundamentals,
+     dividends, risk, peers, news, filings, ownership, insider), `/rankings`,
+     `/recommendations`, `/reports`, `/admin`. For each, screenshot + judge:
+     does it look good and intuitive? loading/empty/error states present and
+     honest? dark mode clean? numbers match the API (spot-check one figure
+     against the endpoint)? any broken layout, dead link, confusing affordance,
+     or thin/placeholder content (like the bare calendar #1766)? File verified
+     **bug / ux / tech-debt** tickets with the screenshot + the exact route, one
+     issue per distinct problem. Site review needs vite (`:5173`) + API
+     (`:8000`) up; if down, skip FE-QA this iteration and note it.
 5. Update memory (the index + topic files) as you land work, per the memory rules.
 6. Next ticket.
 

--- a/scripts/autonomy/run_loop.sh
+++ b/scripts/autonomy/run_loop.sh
@@ -52,6 +52,11 @@ echo "=== autonomy loop start $(date -u +%FT%TZ) -> $LOG ==="
 # Clean-state preflight (Codex ckpt-2 MED): each session starts on clean, latest
 # main. If a prior crash left a dirty tree or an un-fast-forwardable main, ABORT
 # and leave it for inspection — never start a session on top of half-done work.
+# Guard dirty tree / in-progress rebase BEFORE checkout (a checkout could discard
+# or abort that work silently — review #1768).
+if [ -n "$(git status --porcelain)" ] || [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ] || [ -f .git/CHERRY_PICK_HEAD ] || [ -f .git/MERGE_HEAD ]; then
+  echo "preflight: tree dirty or rebase/merge in progress — abort (manual inspection, won't checkout over it)" | tee -a "$LOG" >&2; exit 1
+fi
 git fetch origin -q 2>>"$LOG" || { echo "preflight: git fetch failed (network?) — abort, won't run on stale state" | tee -a "$LOG" >&2; exit 1; }
 git checkout main -q 2>>"$LOG" || { echo "preflight: cannot checkout main — abort" | tee -a "$LOG" >&2; exit 1; }
 if ! git pull -q --ff-only 2>>"$LOG"; then

--- a/scripts/autonomy/setup.md
+++ b/scripts/autonomy/setup.md
@@ -22,8 +22,10 @@ backs off to the reset window → retries when capacity returns; board empty →
 idle-polls; kept alive across crashes/reboots by launchd `KeepAlive`. Start it
 once and leave for days.
 ```bash
-mkdir -p var/autonomy-logs
-cp scripts/autonomy/com.ebull.autonomy.supervisor.plist ~/Library/LaunchAgents/
+mkdir -p var/autonomy-logs   # must exist before launchd opens its log paths
+# substitute __REPO__ with this checkout's path (plists ship path-agnostic):
+sed "s#__REPO__#$(pwd)#g" scripts/autonomy/com.ebull.autonomy.supervisor.plist \
+  > ~/Library/LaunchAgents/com.ebull.autonomy.supervisor.plist
 launchctl load ~/Library/LaunchAgents/com.ebull.autonomy.supervisor.plist
 launchctl list | grep ebull          # confirm loaded
 tail -f var/autonomy-logs/supervisor.log
@@ -38,8 +40,10 @@ One fresh session per hour (lock = no overlap). Less tight than the supervisor
 and no smart limit-backoff (a limited hour just retries next hour), but minimal.
 Use this OR the supervisor, **not both**.
 ```bash
-cp scripts/autonomy/com.ebull.autonomy.plist ~/Library/LaunchAgents/
-launchctl load   ~/Library/LaunchAgents/com.ebull.autonomy.plist
+mkdir -p var/autonomy-logs
+sed "s#__REPO__#$(pwd)#g" scripts/autonomy/com.ebull.autonomy.plist \
+  > ~/Library/LaunchAgents/com.ebull.autonomy.plist
+launchctl load ~/Library/LaunchAgents/com.ebull.autonomy.plist
 ```
 
 ### Stop / remove

--- a/scripts/autonomy/setup.md
+++ b/scripts/autonomy/setup.md
@@ -16,19 +16,36 @@ bash scripts/autonomy/run_loop.sh        # blocks for the session; tail the log 
 Watch it pick a ticket, open a PR, wait for the bot, merge. Ctrl-C to stop; the
 lock auto-clears on exit.
 
-## Install the scheduler (refreshing sessions, unattended)
+## Walk-away-for-days mode (RECOMMENDED): the supervisor
+Runs sessions back-to-back forever with **usage-limit backoff** — hits a limit →
+backs off to the reset window → retries when capacity returns; board empty →
+idle-polls; kept alive across crashes/reboots by launchd `KeepAlive`. Start it
+once and leave for days.
+```bash
+mkdir -p var/autonomy-logs
+cp scripts/autonomy/com.ebull.autonomy.supervisor.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.ebull.autonomy.supervisor.plist
+launchctl list | grep ebull          # confirm loaded
+tail -f var/autonomy-logs/supervisor.log
+```
+Stop:
+```bash
+launchctl unload ~/Library/LaunchAgents/com.ebull.autonomy.supervisor.plist
+```
+
+## Simpler alternative: hourly run_loop (no continuous supervisor)
+One fresh session per hour (lock = no overlap). Less tight than the supervisor
+and no smart limit-backoff (a limited hour just retries next hour), but minimal.
+Use this OR the supervisor, **not both**.
 ```bash
 cp scripts/autonomy/com.ebull.autonomy.plist ~/Library/LaunchAgents/
-launchctl load   ~/Library/LaunchAgents/com.ebull.autonomy.plist   # start
-launchctl list | grep ebull                                        # confirm
+launchctl load   ~/Library/LaunchAgents/com.ebull.autonomy.plist
 ```
-It now fires hourly. While a session is mid-drain the next firing no-ops (lock),
-so effectively a new session starts within ~1h of the previous finishing.
 
 ### Stop / remove
 ```bash
-launchctl unload ~/Library/LaunchAgents/com.ebull.autonomy.plist
-rm ~/Library/LaunchAgents/com.ebull.autonomy.plist
+launchctl unload ~/Library/LaunchAgents/com.ebull.autonomy.plist        # or .supervisor.plist
+rm ~/Library/LaunchAgents/com.ebull.autonomy*.plist
 ```
 
 ### Watch it

--- a/scripts/autonomy/supervisor.sh
+++ b/scripts/autonomy/supervisor.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Autonomy SUPERVISOR — run board-drain sessions back-to-back for days,
+# unattended, with usage-limit backoff. This is the "walk away, come back to the
+# board worked through" entry point.
+#
+# Loop: check the board → run ONE fresh headless `claude` session (drains as many
+# tickets as fit in its context) → classify the outcome → wait → repeat, forever:
+#   - usage/rate limit hit  → back off (exponential, capped ~5h ≈ the usage
+#                             window) then retry when capacity returns.
+#   - other error           → exponential backoff (capped 1h).
+#   - clean finish          → short pace, next session.
+#   - board empty           → idle-poll every 30 min.
+#
+# Kept alive across crashes/reboots by launchd KeepAlive (com.ebull.autonomy.
+# supervisor.plist). Single instance via lock. Each session starts on clean
+# latest main (preflight); a dirty tree from a crash aborts that iteration
+# rather than building on half-done work.
+#
+# Run:  bash scripts/autonomy/supervisor.sh   (or via launchd — see setup.md)
+
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+[ -f "$REPO/.claude/CLAUDE.md" ] || { echo "not the eBull repo root: $REPO" >&2; exit 1; }
+
+LOCK="$REPO/var/autonomy-supervisor.lock"
+LOGDIR="$REPO/var/autonomy-logs"
+mkdir -p "$LOGDIR"
+SUPLOG="$LOGDIR/supervisor.log"
+
+# --- timing knobs (seconds) ---
+PACE=120                    # gap between back-to-back clean sessions
+EMPTY_IDLE=1800            # board empty → poll every 30 min
+ERR_BACKOFF_START=300; ERR_BACKOFF_MAX=3600
+LIMIT_BACKOFF_START=1800; LIMIT_BACKOFF_MAX=18000   # 30 min → cap 5 h (usage window)
+
+FALLBACK_MODEL="claude-sonnet-4-6"   # keep working if the primary model is throttled
+SAFETY="Unattended run. HARD RULES: never execute/approve/simulate a trade, never POST order endpoints, never touch the kill-switch, never close a position; merge ONLY via scripts/autonomy/safe_merge.sh; never push --no-verify; never restart the :8000/:5173 tasks. Follow .claude/CLAUDE.md and scripts/autonomy/loop_prompt.md exactly."
+
+log() { echo "$(date -u +%FT%TZ) $*" | tee -a "$SUPLOG"; }
+
+# --- single-instance lock (atomic mkdir; stale = dead pid; supervisor is long-lived) ---
+if ! mkdir "$LOCK" 2>/dev/null; then
+  pid="$(cat "$LOCK/pid" 2>/dev/null || echo)"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    log "supervisor already running (pid $pid); exiting."; exit 0
+  fi
+  rm -rf "$LOCK"; mkdir "$LOCK" || { log "lost lock race; exiting."; exit 0; }
+fi
+echo $$ >"$LOCK/pid"
+trap 'rm -rf "$LOCK"; log "supervisor stopped."; exit 0' EXIT INT TERM
+
+log "=== supervisor start (pid $$) ==="
+err_backoff=$ERR_BACKOFF_START
+limit_backoff=$LIMIT_BACKOFF_START
+
+run_session() {
+  # Preflight: clean, latest main, or skip this iteration.
+  git fetch origin -q 2>>"$SUPLOG" || { log "preflight: fetch failed"; return 2; }
+  git checkout main -q 2>>"$SUPLOG" || { log "preflight: checkout main failed"; return 2; }
+  git pull -q --ff-only 2>>"$SUPLOG" || { log "preflight: main not fast-forward"; return 2; }
+  [ -z "$(git status --porcelain)" ] || { log "preflight: tree dirty on main — skip"; return 2; }
+
+  local log_file; log_file="$LOGDIR/session-$(date +%Y%m%dT%H%M%S).log"
+  log "session start -> $log_file"
+  claude -p "$(cat "$REPO/scripts/autonomy/loop_prompt.md")" \
+    --dangerously-skip-permissions \
+    --fallback-model "$FALLBACK_MODEL" \
+    --append-system-prompt "$SAFETY" \
+    --output-format stream-json --verbose \
+    >>"$log_file" 2>&1
+  local rc=$?
+  # Usage/rate-limit signal anywhere in the session output.
+  if grep -qiE 'usage limit|rate limit|resets at|overloaded_error|too many requests|"?429"?|exceeded your' "$log_file"; then
+    return 3
+  fi
+  return $rc
+}
+
+while true; do
+  open_count="$(gh issue list --state open --json number -q 'length' 2>/dev/null || echo -1)"
+  if [ "$open_count" = "0" ]; then
+    log "board empty — idle ${EMPTY_IDLE}s"; sleep "$EMPTY_IDLE"; continue
+  fi
+
+  run_session; outcome=$?
+  case $outcome in
+    0) log "session clean (open issues ~$open_count). pace ${PACE}s"
+       err_backoff=$ERR_BACKOFF_START; limit_backoff=$LIMIT_BACKOFF_START
+       sleep "$PACE" ;;
+    3) jitter=$((RANDOM % 120))
+       log "USAGE LIMIT — backoff $((limit_backoff + jitter))s then retry"
+       sleep $((limit_backoff + jitter))
+       limit_backoff=$(( limit_backoff*2 < LIMIT_BACKOFF_MAX ? limit_backoff*2 : LIMIT_BACKOFF_MAX )) ;;
+    2) log "preflight skip — wait ${ERR_BACKOFF_START}s"; sleep "$ERR_BACKOFF_START" ;;
+    *) log "session error (rc=$outcome) — backoff ${err_backoff}s"
+       sleep "$err_backoff"
+       err_backoff=$(( err_backoff*2 < ERR_BACKOFF_MAX ? err_backoff*2 : ERR_BACKOFF_MAX )) ;;
+  esac
+done

--- a/scripts/autonomy/supervisor.sh
+++ b/scripts/autonomy/supervisor.sh
@@ -55,7 +55,13 @@ err_backoff=$ERR_BACKOFF_START
 limit_backoff=$LIMIT_BACKOFF_START
 
 run_session() {
-  # Preflight: clean, latest main, or skip this iteration.
+  # Preflight: clean, latest main, or skip this iteration. Guard dirty tree /
+  # in-progress rebase|cherry-pick BEFORE `git checkout` — checkout could discard
+  # or abort that work silently (review #1768).
+  [ -z "$(git status --porcelain)" ] || { log "preflight: tree dirty — skip (won't checkout over uncommitted work)"; return 2; }
+  if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ] || [ -f .git/CHERRY_PICK_HEAD ] || [ -f .git/MERGE_HEAD ]; then
+    log "preflight: rebase/cherry-pick/merge in progress — skip"; return 2
+  fi
   git fetch origin -q 2>>"$SUPLOG" || { log "preflight: fetch failed"; return 2; }
   git checkout main -q 2>>"$SUPLOG" || { log "preflight: checkout main failed"; return 2; }
   git pull -q --ff-only 2>>"$SUPLOG" || { log "preflight: main not fast-forward"; return 2; }


### PR DESCRIPTION
Answers "walk away for days, come back to the board worked through, backing off + retrying when usage limits hit."

## What
- `supervisor.sh` — runs board-drain sessions back-to-back **forever**:
  - **usage/rate limit** in a session's output → exponential backoff (30 min → cap ~5 h, the usage window) + jitter, then retry when capacity returns.
  - **error** → exponential backoff (5 min → cap 1 h).
  - **clean finish** → short pace, next session.
  - **board empty** → idle-poll every 30 min.
  - clean-tree preflight each iteration (never builds on half-done work).
  - `--fallback-model claude-sonnet-4-6` so it keeps working when the primary model is throttled.
- `com.ebull.autonomy.supervisor.plist` — launchd `KeepAlive` + `RunAtLoad`: starts on load, resurrected across crashes/reboots. Internal lock = single instance.
- `setup.md` — supervisor is now the recommended walk-away mode; hourly `run_loop` stays as the simpler alternative (use one, not both).

## Go live
```bash
cp scripts/autonomy/com.ebull.autonomy.supervisor.plist ~/Library/LaunchAgents/
launchctl load ~/Library/LaunchAgents/com.ebull.autonomy.supervisor.plist
tail -f var/autonomy-logs/supervisor.log
```
Start once, walk away. `launchctl unload …` to stop.

## Safety unchanged
Same rails: merges only via `safe_merge.sh` (bot-APPROVE-in-comments + CI-green), never trades / kill-switch / close positions, run with no broker creds, never `--no-verify`.

`bash -n` clean; `plutil -lint` OK. Dev-ops only; no product/trade path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)